### PR TITLE
feat: skip unchanged defs via CstNode physical_equal

### DIFF
--- a/editor/performance_benchmark.mbt
+++ b/editor/performance_benchmark.mbt
@@ -1,3 +1,40 @@
+// Projection pipeline benchmarks — measures to_flat_proj + reconcile + to_proj_node
+// Uses single-char insert/delete to avoid CRDT set_text overhead.
+
+///|
+fn run_projection_incremental_bench(b : @bench.T, let_count : Int) -> Unit {
+  let source = parser_bench_source(let_count, "0")
+  let editor = SyncEditor::new("bench")
+  editor.set_text(source)
+  ignore(editor.get_proj_node()) // warm up — initial parse + project
+  let edit_pos = source.length() - 2
+  editor.move_cursor(edit_pos)
+  let mut inserted = false
+  b.bench(() => {
+    if inserted {
+      ignore(editor.backspace())
+    } else {
+      editor.insert("1") catch {
+        _ => ()
+      }
+    }
+    b.keep(editor.get_proj_node())
+    inserted = not(inserted)
+  })
+}
+
+///|
+test "projection pipeline - incremental keystroke (20 defs)" (b : @bench.T) {
+  run_projection_incremental_bench(b, 20)
+}
+
+///|
+test "projection pipeline - incremental keystroke (80 defs)" (b : @bench.T) {
+  run_projection_incremental_bench(b, 80)
+}
+
+// Parser-only benchmarks — measures parse layer without projection
+
 ///|
 priv struct ParserBenchScenario {
   source : String

--- a/editor/projection_memo.mbt
+++ b/editor/projection_memo.mbt
@@ -7,6 +7,7 @@ fn build_projection_memos(
   source_text : @incr.Signal[String],
   syntax_tree : @incr.Signal[@seam.SyntaxNode?],
   prev_flat_proj_ref : Ref[@proj.FlatProj?],
+  prev_syntax_root_ref : Ref[@seam.SyntaxNode?],
   next_id_ref : Ref[Int],
 ) -> (
   @incr.Memo[@proj.FlatProj?],
@@ -19,24 +20,36 @@ fn build_projection_memos(
     fn() -> @proj.FlatProj? {
       if source_text.get() == "" {
         prev_flat_proj_ref.val = None
+        prev_syntax_root_ref.val = None
         return None
       }
       let syntax_root = match syntax_tree.get() {
         Some(root) => root
         None => {
           prev_flat_proj_ref.val = None
+          prev_syntax_root_ref.val = None
           return None
         }
       }
       let counter = Ref::new(next_id_ref.val)
-      let new_fp = @proj.to_flat_proj(syntax_root, counter)
-      let reconciled = match prev_flat_proj_ref.val {
-        None => new_fp
-        Some(prev) => @proj.reconcile_flat_proj(prev, new_fp, counter)
+      let result = match (prev_flat_proj_ref.val, prev_syntax_root_ref.val) {
+        (Some(prev_fp), Some(prev_root)) =>
+          // Incremental path: compare CST children via physical_equal
+          @proj.to_flat_proj_incremental(
+            syntax_root, prev_root, prev_fp, counter,
+          )
+        (Some(prev_fp), None) => {
+          // No previous syntax root (e.g., after tree edit) — build fresh
+          // and reconcile to preserve node IDs
+          let new_fp = @proj.to_flat_proj(syntax_root, counter)
+          @proj.reconcile_flat_proj(prev_fp, new_fp, counter)
+        }
+        _ => @proj.to_flat_proj(syntax_root, counter)
       }
       next_id_ref.val = counter.val
-      prev_flat_proj_ref.val = Some(reconciled)
-      Some(reconciled)
+      prev_flat_proj_ref.val = Some(result)
+      prev_syntax_root_ref.val = Some(syntax_root)
+      Some(result)
     },
     label="proj_node",
   )
@@ -116,6 +129,9 @@ pub fn SyncEditor::get_source_map(self : SyncEditor) -> @proj.SourceMap {
 ///|
 fn SyncEditor::seed_flat_proj(self : SyncEditor, fp : @proj.FlatProj?) -> Unit {
   self.prev_flat_proj.val = fp
+  // Clear prev syntax root so next memo evaluation uses non-incremental path.
+  // After tree edits, the syntax root doesn't correspond to the seeded FlatProj.
+  self.prev_syntax_root.val = None
 }
 
 ///|

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -11,6 +11,7 @@ pub struct SyncEditor {
   priv syntax_tree : @incr.Signal[@seam.SyntaxNode?]
   priv mut cursor : Int
   priv prev_flat_proj : Ref[@proj.FlatProj?]
+  priv prev_syntax_root : Ref[@seam.SyntaxNode?]
   priv proj_memo : @incr.Memo[@proj.FlatProj?]
   priv cached_proj_node : @incr.Memo[@proj.ProjNode?]
   priv registry_memo : @incr.Memo[Map[@proj.NodeId, @proj.ProjNode]]
@@ -37,9 +38,10 @@ pub fn SyncEditor::new(
     label="editor_syntax_tree",
   )
   let prev_flat_proj : Ref[@proj.FlatProj?] = Ref::new(None)
+  let prev_syntax_root : Ref[@seam.SyntaxNode?] = Ref::new(None)
   let next_node_id : Ref[Int] = Ref::new(0)
   let (proj_memo, cached_proj_node, registry_memo, source_map_memo) = build_projection_memos(
-    parser_rt, source_text, syntax_tree, prev_flat_proj, next_node_id,
+    parser_rt, source_text, syntax_tree, prev_flat_proj, prev_syntax_root, next_node_id,
   )
   let ephemeral = EphemeralStore::new(ephemeral_timeout_ms)
   let cursor_view = PeerCursorView::new()
@@ -83,6 +85,7 @@ pub fn SyncEditor::new(
     syntax_tree,
     cursor: 0,
     prev_flat_proj,
+    prev_syntax_root,
     proj_memo,
     cached_proj_node,
     registry_memo,

--- a/projection/flat_proj.mbt
+++ b/projection/flat_proj.mbt
@@ -33,6 +33,89 @@ pub fn to_flat_proj(root : @seam.SyntaxNode, counter : Ref[Int]) -> FlatProj {
 }
 
 ///|
+/// Build a FlatProj incrementally by comparing old and new CST children.
+///
+/// For each child pair, compares underlying CstNodes. If unchanged
+/// (physical_equal via NodeInterner), reuses the old FlatProj entry
+/// directly — skipping both syntax_to_proj_node and reconcile_ast.
+/// Only changed children are rebuilt and reconciled.
+///
+/// Cost: O(n) CstNode pointer comparisons + O(changed_subtree) rebuilds.
+pub fn to_flat_proj_incremental(
+  new_root : @seam.SyntaxNode,
+  old_root : @seam.SyntaxNode,
+  old_fp : FlatProj,
+  counter : Ref[Int],
+) -> FlatProj {
+  // Extract LetDef children from old and new roots
+  let new_children = new_root.children()
+  let old_let_children : Array[@seam.SyntaxNode] = []
+  let mut old_final_child : @seam.SyntaxNode? = None
+  for child in old_root.children() {
+    if @parser.LetDefView::cast(child) is Some(_) {
+      old_let_children.push(child)
+    } else if old_final_child is None {
+      old_final_child = Some(child)
+    }
+  }
+  // Parallel scan: compare new LetDefs against old LetDefs by index.
+  // physical_equal checks pointer identity (same interned CstNode object).
+  // When content and position are both unchanged, the parser returns
+  // the exact same object, making physical_equal true.
+  let defs : Array[(String, ProjNode, Int, NodeId)] = []
+  let mut final_proj : ProjNode? = None
+  let mut old_def_idx = 0
+  let mut any_changed = false
+  for new_child in new_children {
+    if @parser.LetDefView::cast(new_child) is Some(v) {
+      let mut reused = false
+      if old_def_idx < old_let_children.length() &&
+        old_def_idx < old_fp.defs.length() {
+        let old_child = old_let_children[old_def_idx]
+        if physical_equal(new_child.cst_node(), old_child.cst_node()) {
+          // Same pointer — safe to reuse old entry with same positions
+          let old_entry = old_fp.defs[old_def_idx]
+          defs.push((old_entry.0, old_entry.1, old_entry.2, old_entry.3))
+          reused = true
+        }
+        old_def_idx = old_def_idx + 1
+      }
+      if not(reused) {
+        any_changed = true
+        let init = match v.init() {
+          Some(n) => syntax_to_proj_node(n, counter)
+          None =>
+            error_node_for_syntax(
+              "missing let binding value", new_child, counter,
+            )
+        }
+        let id = NodeId(next_proj_node_id(counter))
+        defs.push((v.name(), init, new_child.start(), id))
+      }
+    } else if final_proj is None {
+      match old_final_child {
+        Some(old_fc) if physical_equal(new_child.cst_node(), old_fc.cst_node()) =>
+          final_proj = old_fp.final_expr
+        _ => {
+          any_changed = true
+          final_proj = Some(syntax_to_proj_node(new_child, counter))
+        }
+      }
+    }
+  }
+  // If number of defs changed, that's also a change
+  if old_fp.defs.length() != defs.length() {
+    any_changed = true
+  }
+  let new_fp : FlatProj = { defs, final_expr: final_proj }
+  if any_changed {
+    reconcile_flat_proj(old_fp, new_fp, counter)
+  } else {
+    new_fp
+  }
+}
+
+///|
 /// O(n) hash-based key matching. For each new key, finds the corresponding
 /// old index by consuming old entries in order per key.
 /// Handles duplicate keys correctly via per-key cursors.

--- a/projection/pkg.generated.mbti
+++ b/projection/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode
 
 pub fn to_flat_proj(@seam.SyntaxNode, @ref.Ref[Int]) -> FlatProj
 
+pub fn to_flat_proj_incremental(@seam.SyntaxNode, @seam.SyntaxNode, FlatProj, @ref.Ref[Int]) -> FlatProj
+
 pub fn to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode
 
 // Errors


### PR DESCRIPTION
## Summary

Add `to_flat_proj_incremental` that compares old and new CST children via CstNode equality (`physical_equal` fast-path from NodeInterner). Unchanged LetDefs reuse old FlatProj entries directly — skipping both `syntax_to_proj_node` and `reconcile_ast`.

### How it works

Three memo paths:
- **Incremental:** prev FlatProj + prev SyntaxNode available → compare CstNode pointers, reuse unchanged entries
- **Reconcile-only:** prev FlatProj but no prev SyntaxNode (after tree edit) → full rebuild + reconcile for ID preservation
- **Fresh:** no prev FlatProj → fresh build

### Performance impact

Benefits incremental editing (single keystroke changes) where most CST children are unchanged. Full reparse benchmarks are unaffected since every child is new.

## Test plan
- [x] 232/232 tests passing
- [x] Tree edit bridge tests pass (ID preservation after tree edit + reparse)
- [x] `seed_flat_proj` clears prev syntax root to avoid stale comparisons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental projection rebuild that reuses unchanged items and reconciles edits to preserve identities.

* **Performance**
  * Faster, more responsive incremental projection updates.
  * Added benchmarks measuring incremental keystroke performance for medium and large scenarios.

* **Bug Fixes**
  * Improved handling of prior syntax state with a fallback to full rebuild when needed; seeding now forces full rebuild to avoid stale state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->