### PR TITLE
fix(ideal): single SyncEditor shared between MoonBit and JS

### DIFF
--- a/crdt.mbt
+++ b/crdt.mbt
@@ -7,6 +7,12 @@
 let editor : Ref[@editor.SyncEditor?] = { val: None }
 
 ///|
+/// Get the current singleton SyncEditor, if one has been created.
+pub fn get_sync_editor() -> @editor.SyncEditor? {
+  editor.val
+}
+
+///|
 /// Create a new SyncEditor instance
 /// Returns handle 1 (MVP: single editor only)
 pub fn create_editor(agent_id : String) -> Int {

--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -1,4 +1,12 @@
 ///|
+/// Read the agent ID set by JS before module import.
+extern "js" fn js_get_agent_id() -> String =
+  #| function() {
+  #|   var id = globalThis.__canopy_agent_id;
+  #|   return typeof id === 'string' ? id : '';
+  #| }
+
+///|
 /// Sync MoonBit editor text to the JS-side CRDT editor, then reconcile PM.
 /// Called after undo/redo/load-example to keep the two editors in sync.
 extern "js" fn js_reconcile_editor_with_text(new_text : String) -> Unit =
@@ -66,17 +74,6 @@ extern "js" fn js_take_structural_edit_node_id() -> String =
   #|   globalThis.__canopy_pending_structural_edit = null;
   #|   if (!pending) return '';
   #|   return typeof pending.nodeId === 'string' ? pending.nodeId : '';
-  #| }
-
-///|
-/// Get the current text from the JS-side CRDT editor.
-/// Used to sync CM6 edits back to MoonBit's SyncEditor.
-extern "js" fn js_get_editor_text() -> String =
-  #| function() {
-  #|   var crdt = globalThis.__canopy_crdt;
-  #|   var handle = globalThis.__canopy_crdt_handle;
-  #|   if (!crdt || handle == null) return '';
-  #|   return crdt.get_text(handle);
   #| }
 
 ///|

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -9,8 +9,15 @@ let deferred_refresh_ms = 150
 
 ///|
 fn init_model() -> Model {
+  // Read agent ID set by JS (main.ts) before module import.
+  // Falls back to "local" if JS hasn't set it (e.g. test environment).
+  let agent_id = js_get_agent_id()
+  let agent_id = if agent_id == "" { "local" } else { agent_id }
+  // Create the editor through the crdt module so it sets the singleton (editor.val).
+  // JS (main.ts) will reuse handle=1 instead of creating a second editor.
+  let _handle = @crdt.create_editor_with_undo(agent_id, 500)
+  let editor = @crdt.get_sync_editor().unwrap()
   let init_text = "let id = \\x.x\nlet apply = \\f.\\x.f x\napply id 42"
-  let editor = @editor.SyncEditor::new("local")
   editor.set_text(init_text)
   let outline_state = @proj.TreeEditorState::from_projection(
     editor.get_proj_node(),
@@ -267,11 +274,8 @@ fn update(dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         _ => (none, model)
       }
     RefreshProjection => {
-      // Sync text from JS-side CRDT editor before refreshing
-      let js_text = js_get_editor_text()
-      if js_text != model.editor.get_text() {
-        model.editor.set_text(js_text)
-      }
+      // model.editor IS the crdt singleton — already has latest text.
+      // Just rebuild the outline from the current projection.
       if model.projection_dirty {
         (none, refresh(model))
       } else {
@@ -299,10 +303,12 @@ fn update(dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       (cmd, { ..model, selected_node: Some(node_id) })
     }
     TextChangedFromEditor => {
-      // Pull text from JS-side CRDT editor into MoonBit's SyncEditor
-      let js_text = js_get_editor_text()
-      if js_text != model.editor.get_text() {
-        model.editor.set_text(js_text)
+      // model.editor IS the crdt singleton — text is already updated by CM6.
+      // Just mark projection dirty and schedule a deferred refresh.
+      if model.projection_dirty && model.refresh_scheduled {
+        // Already scheduled — no-op
+        (none, model)
+      } else {
         let updated = { ..model, projection_dirty: true }
         if model.refresh_scheduled {
           (none, updated)

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -16,6 +16,7 @@ type StructuralEditDetail = {
 type CanopyGlobal = typeof globalThis & {
   __canopy_crdt?: CrdtModule;
   __canopy_crdt_handle?: number;
+  __canopy_agent_id?: string;
   __canopy_pending_node_selection?: string | null;
   __canopy_pending_structural_edit?: StructuralEditDetail | null;
 };
@@ -29,6 +30,9 @@ let beforeUnloadRegistered = false;
 
 function loadCrdtModule(): Promise<CrdtModule> {
   if (!crdtPromise) {
+    // Set agent ID globally BEFORE importing the MoonBit module.
+    // MoonBit's init_model reads this to create the CRDT editor with a unique agent.
+    canopyGlobal.__canopy_agent_id = getSessionAgentId();
     // Loading the MoonBit module also runs Rabbita's main(), which renders <canopy-editor>.
     crdtPromise = import('@moonbit/ideal-editor') as Promise<CrdtModule>;
   }
@@ -124,12 +128,13 @@ function mountWhenReady(crdt: CrdtModule) {
 }
 
 function doMount(el: CanopyEditor, crdt: CrdtModule) {
-  const handle = crdt.create_editor_with_undo(getSessionAgentId(), 500);
-  const text = 'let id = \\x.x\nlet apply = \\f.\\x.f x\napply id 42';
+  // Reuse the editor MoonBit already created in init_model (handle = 1).
+  // Don't call create_editor_with_undo again — that would overwrite the singleton.
+  const handle = 1;
   canopyGlobal.__canopy_crdt_handle = handle;
   canopyGlobal.__canopy_pending_node_selection = null;
   canopyGlobal.__canopy_pending_structural_edit = null;
-  crdt.set_text(handle, text);
+  // Text already set by MoonBit's init_model — don't overwrite.
   el.mount(handle, crdt);
   wireEditorEvents(el);
   startSync(el, handle, crdt);

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -48,6 +48,8 @@ pub fn get_proj_node_json(Int) -> String
 
 pub fn get_source_map_json(Int) -> String
 
+pub fn get_sync_editor() -> @editor.SyncEditor?
+
 pub fn get_text(Int) -> String
 
 pub fn get_version_json(Int) -> String


### PR DESCRIPTION
## Summary

- Added `get_sync_editor()` to `crdt.mbt` — one-line getter for the singleton
- `init_model()` creates editor via `@crdt.create_editor_with_undo` then reads back via `get_sync_editor()`
- `main.ts` reuses handle=1 instead of creating a second editor

Both MoonBit and JS now operate on the exact same SyncEditor instance.

## Test plan

- [ ] `moon check` — 0 errors, 0 warnings
- [ ] Text mode typing updates outline
- [ ] Undo/redo works
- [ ] Example loader works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to obtain the shared editor instance.
  * Host can supply a session agent ID to initialize/reuse the editor.

* **Bug Fixes**
  * Prevents duplicate editor creation and redundant initial text setting during mount.
  * Stops pulling editor text from the host into the app model; updates now mark projections dirty and refresh asynchronously for cleaner sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->