### PR TITLE
feat: Container Phase 1 -- Document struct and block editor migration

### DIFF
--- a/examples/block-editor/main/block_doc.mbt
+++ b/examples/block-editor/main/block_doc.mbt
@@ -1,25 +1,27 @@
 ///|
 /// The block identifier type — a tree node ID.
-pub type BlockId = @tree.TreeNodeId
+pub type BlockId = @container.TreeNodeId
 
 ///|
 /// Sentinel for the document root (parent of all top-level blocks).
-pub let root_block_id : @tree.TreeNodeId = @tree.root_id
+pub let root_block_id : @container.TreeNodeId = @container.root_id
 
 ///|
 /// A collaborative block document.
 ///
-/// Wraps a `TreeState` for block hierarchy and a per-block `TextState` map for
+/// Wraps a `Document` for block hierarchy and a per-block `TextState` map for
 /// text content. Block ordering delegates to the tree CRDT's fractional indexing.
 pub struct BlockDoc {
-  priv tree : @tree.TreeState
+  priv tree : @container.Document
   priv texts : Map[String, @text.TextState]
   priv replica_id : String
 }
 
 ///|
-pub fn BlockDoc::new(replica_id : String) -> BlockDoc raise @tree.TreeError {
-  { tree: @tree.TreeState::new(replica_id), texts: {}, replica_id }
+pub fn BlockDoc::new(
+  replica_id : String,
+) -> BlockDoc raise @container.DocumentError {
+  { tree: @container.Document::new(replica_id), texts: {}, replica_id }
 }
 
 ///|
@@ -27,8 +29,8 @@ pub fn BlockDoc::new(replica_id : String) -> BlockDoc raise @tree.TreeError {
 pub fn BlockDoc::create_block(
   self : BlockDoc,
   block_type : BlockType,
-  parent? : @tree.TreeNodeId = root_block_id,
-) -> @tree.TreeNodeId raise @tree.TreeError {
+  parent? : @container.TreeNodeId = root_block_id,
+) -> @container.TreeNodeId raise @container.DocumentError {
   let id = self.tree.create_node(parent~)
   self.texts[id_key(id)] = @text.TextState::new(self.replica_id)
   self.apply_block_type(id, block_type)
@@ -39,9 +41,9 @@ pub fn BlockDoc::create_block(
 /// Create a block immediately after `after_id` in document order.
 pub fn BlockDoc::create_block_after(
   self : BlockDoc,
-  after_id : @tree.TreeNodeId,
+  after_id : @container.TreeNodeId,
   block_type : BlockType,
-) -> @tree.TreeNodeId raise @tree.TreeError {
+) -> @container.TreeNodeId raise @container.DocumentError {
   let id = self.tree.create_node_after(parent=root_block_id, after=after_id)
   self.texts[id_key(id)] = @text.TextState::new(self.replica_id)
   self.apply_block_type(id, block_type)
@@ -52,8 +54,8 @@ pub fn BlockDoc::create_block_after(
 /// Delete a block: move it to the tree trash.
 pub fn BlockDoc::delete_block(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
-) -> Unit raise @tree.TreeError {
+  id : @container.TreeNodeId,
+) -> Unit raise @container.DocumentError {
   self.tree.delete_node(id)
 }
 
@@ -61,9 +63,9 @@ pub fn BlockDoc::delete_block(
 /// Move a block to a new parent.
 pub fn BlockDoc::move_block(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
-  new_parent~ : @tree.TreeNodeId,
-) -> Unit raise @tree.TreeError {
+  id : @container.TreeNodeId,
+  new_parent~ : @container.TreeNodeId,
+) -> Unit raise @container.DocumentError {
   self.tree.move_node(target=id, new_parent~)
 }
 
@@ -71,18 +73,21 @@ pub fn BlockDoc::move_block(
 /// Return children of `parent` in display order.
 pub fn BlockDoc::children(
   self : BlockDoc,
-  parent : @tree.TreeNodeId,
-) -> Array[@tree.TreeNodeId] {
+  parent : @container.TreeNodeId,
+) -> Array[@container.TreeNodeId] {
   self.tree.children(parent)
 }
 
 ///|
-pub fn BlockDoc::is_alive(self : BlockDoc, id : @tree.TreeNodeId) -> Bool {
+pub fn BlockDoc::is_alive(self : BlockDoc, id : @container.TreeNodeId) -> Bool {
   self.tree.is_alive(id)
 }
 
 ///|
-pub fn BlockDoc::get_type(self : BlockDoc, id : @tree.TreeNodeId) -> BlockType {
+pub fn BlockDoc::get_type(
+  self : BlockDoc,
+  id : @container.TreeNodeId,
+) -> BlockType {
   let type_str = self.tree.get_property(id, "block_type").unwrap_or("paragraph")
   block_type_from_props(type_str, fn(k) { self.tree.get_property(id, k) })
 }
@@ -90,14 +95,17 @@ pub fn BlockDoc::get_type(self : BlockDoc, id : @tree.TreeNodeId) -> BlockType {
 ///|
 pub fn BlockDoc::set_type(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
+  id : @container.TreeNodeId,
   t : BlockType,
 ) -> Unit {
   self.apply_block_type(id, t)
 }
 
 ///|
-pub fn BlockDoc::get_text(self : BlockDoc, id : @tree.TreeNodeId) -> String {
+pub fn BlockDoc::get_text(
+  self : BlockDoc,
+  id : @container.TreeNodeId,
+) -> String {
   match self.texts.get(id_key(id)) {
     Some(tdoc) => tdoc.text()
     None => ""
@@ -108,7 +116,7 @@ pub fn BlockDoc::get_text(self : BlockDoc, id : @tree.TreeNodeId) -> String {
 /// Bulk-replace block text (atomic CRDT replace).
 pub fn BlockDoc::set_text(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
+  id : @container.TreeNodeId,
   text : String,
 ) -> Unit {
   match self.texts.get(id_key(id)) {
@@ -132,7 +140,7 @@ pub fn BlockDoc::set_text(
 /// Insert a single character at `pos` (preferred for typing).
 pub fn BlockDoc::insert_char(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
+  id : @container.TreeNodeId,
   pos : Int,
   ch : String,
 ) -> Unit {
@@ -146,7 +154,7 @@ pub fn BlockDoc::insert_char(
 /// Delete the character at `pos`.
 pub fn BlockDoc::delete_char(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
+  id : @container.TreeNodeId,
   pos : Int,
 ) -> Unit {
   match self.texts.get(id_key(id)) {
@@ -156,14 +164,17 @@ pub fn BlockDoc::delete_char(
 }
 
 ///|
-pub fn BlockDoc::get_checked(self : BlockDoc, id : @tree.TreeNodeId) -> Bool {
+pub fn BlockDoc::get_checked(
+  self : BlockDoc,
+  id : @container.TreeNodeId,
+) -> Bool {
   self.tree.get_property(id, "checked") == Some("true")
 }
 
 ///|
 pub fn BlockDoc::set_checked(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
+  id : @container.TreeNodeId,
   v : Bool,
 ) -> Unit {
   self.tree.set_property(id, "checked", if v { "true" } else { "false" })
@@ -172,19 +183,19 @@ pub fn BlockDoc::set_checked(
 // ── Private helpers ────────────────────────────────────────────────────────
 
 ///|
-fn id_key(id : @tree.TreeNodeId) -> String {
-  @tree.tree_node_id_key(id)
+fn id_key(id : @container.TreeNodeId) -> String {
+  @container.tree_node_id_key(id)
 }
 
 ///|
-fn id_eq(a : @tree.TreeNodeId, b : @tree.TreeNodeId) -> Bool {
-  @tree.tree_node_id_eq(a, b)
+fn id_eq(a : @container.TreeNodeId, b : @container.TreeNodeId) -> Bool {
+  @container.tree_node_id_eq(a, b)
 }
 
 ///|
 fn BlockDoc::apply_block_type(
   self : BlockDoc,
-  id : @tree.TreeNodeId,
+  id : @container.TreeNodeId,
   t : BlockType,
 ) -> Unit {
   let (type_str, props) = block_type_to_string(t)

--- a/examples/block-editor/main/block_import.mbt
+++ b/examples/block-editor/main/block_import.mbt
@@ -14,7 +14,7 @@
 pub fn block_doc_from_markdown(
   md : String,
   replica_id : String,
-) -> BlockDoc raise @tree.TreeError {
+) -> BlockDoc raise @container.DocumentError {
   let doc = BlockDoc::new(replica_id)
   let lines = split_lines(md)
   let len = lines.length()
@@ -28,8 +28,8 @@ pub fn block_doc_from_markdown(
       let code_buf = StringBuilder::new()
       i = i + 1
       let mut first = true
-      while i < len && !(starts_with(lines[i], "```")) {
-        if !(first) {
+      while i < len && !starts_with(lines[i], "```") {
+        if !first {
           code_buf.write_string("\n")
         }
         code_buf.write_string(lines[i])
@@ -68,7 +68,7 @@ pub fn block_doc_from_markdown(
       starts_with(line, "- [x] ") ||
       starts_with(line, "- [X] ") {
       flush_paragraph(doc, para_buf)
-      let checked = !(starts_with(line, "- [ ] "))
+      let checked = !starts_with(line, "- [ ] ")
       let text = line[6:].to_string()
       let id = doc.create_block(ListItem(Todo))
       doc.set_text(id, text)
@@ -116,7 +116,7 @@ pub fn block_doc_from_markdown(
 fn flush_paragraph(
   doc : BlockDoc,
   buf : Array[String],
-) -> Unit raise @tree.TreeError {
+) -> Unit raise @container.DocumentError {
   if buf.length() > 0 {
     let text = buf.join(" ")
     let id = doc.create_block(Paragraph)

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -33,7 +33,7 @@ fn get_replica_id(handle : Int) -> String {
 ///|
 /// Parse "agent:counter" string into a TreeNodeId.
 /// Splits on last ':' so agent IDs without ':' are safe.
-fn parse_block_id(s : String) -> @tree.TreeNodeId {
+fn parse_block_id(s : String) -> @container.TreeNodeId {
   let mut last_colon = -1
   for i = 0; i < s.length(); i = i + 1 {
     if s[i] == ':' {
@@ -41,7 +41,7 @@ fn parse_block_id(s : String) -> @tree.TreeNodeId {
     }
   }
   if last_colon < 0 {
-    return @tree.root_id
+    return @container.root_id
   }
   let agent = s[0:last_colon].to_string()
   let counter_str = s[last_colon + 1:].to_string()
@@ -59,7 +59,7 @@ fn parse_block_id(s : String) -> @tree.TreeNodeId {
   if neg {
     counter = -counter
   }
-  @tree.tree_node_id_new(agent, counter)
+  @container.tree_node_id_new(agent, counter)
 }
 
 ///|

--- a/examples/block-editor/main/block_init_wbtest.mbt
+++ b/examples/block-editor/main/block_init_wbtest.mbt
@@ -31,9 +31,10 @@ test "parse_block_id round-trips with id_key" {
   let id = doc.create_block(Paragraph)
   let key = id_key(id)
   let parsed = parse_block_id(key)
-  inspect(@tree.tree_node_id_agent(parsed), content="alice")
+  inspect(@container.tree_node_id_agent(parsed), content="alice")
   inspect(
-    @tree.tree_node_id_counter(parsed) == @tree.tree_node_id_counter(id),
+    @container.tree_node_id_counter(parsed) ==
+    @container.tree_node_id_counter(id),
     content="true",
   )
 }

--- a/examples/block-editor/main/moon.pkg
+++ b/examples/block-editor/main/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "dowdiness/event-graph-walker/tree" @tree,
+  "dowdiness/event-graph-walker/container" @container,
   "dowdiness/event-graph-walker/text" @text,
 }
 

--- a/examples/block-editor/main/pkg.generated.mbti
+++ b/examples/block-editor/main/pkg.generated.mbti
@@ -2,12 +2,12 @@
 package "dowdiness/canopy-block-editor/main"
 
 import {
+  "dowdiness/event-graph-walker/container",
   "dowdiness/event-graph-walker/internal/movable_tree",
-  "dowdiness/event-graph-walker/tree",
 }
 
 // Values
-pub fn block_doc_from_markdown(String, String) -> BlockDoc raise @tree.TreeError
+pub fn block_doc_from_markdown(String, String) -> BlockDoc raise @container.DocumentError
 
 pub fn block_doc_to_markdown(BlockDoc) -> String
 
@@ -42,17 +42,17 @@ pub struct BlockDoc {
   // private fields
 }
 pub fn BlockDoc::children(Self, @movable_tree.TreeNodeId) -> Array[@movable_tree.TreeNodeId]
-pub fn BlockDoc::create_block(Self, BlockType, parent? : @movable_tree.TreeNodeId) -> @movable_tree.TreeNodeId raise @tree.TreeError
-pub fn BlockDoc::create_block_after(Self, @movable_tree.TreeNodeId, BlockType) -> @movable_tree.TreeNodeId raise @tree.TreeError
-pub fn BlockDoc::delete_block(Self, @movable_tree.TreeNodeId) -> Unit raise @tree.TreeError
+pub fn BlockDoc::create_block(Self, BlockType, parent? : @movable_tree.TreeNodeId) -> @movable_tree.TreeNodeId raise @container.DocumentError
+pub fn BlockDoc::create_block_after(Self, @movable_tree.TreeNodeId, BlockType) -> @movable_tree.TreeNodeId raise @container.DocumentError
+pub fn BlockDoc::delete_block(Self, @movable_tree.TreeNodeId) -> Unit raise @container.DocumentError
 pub fn BlockDoc::delete_char(Self, @movable_tree.TreeNodeId, Int) -> Unit
 pub fn BlockDoc::get_checked(Self, @movable_tree.TreeNodeId) -> Bool
 pub fn BlockDoc::get_text(Self, @movable_tree.TreeNodeId) -> String
 pub fn BlockDoc::get_type(Self, @movable_tree.TreeNodeId) -> BlockType
 pub fn BlockDoc::insert_char(Self, @movable_tree.TreeNodeId, Int, String) -> Unit
 pub fn BlockDoc::is_alive(Self, @movable_tree.TreeNodeId) -> Bool
-pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, new_parent~ : @movable_tree.TreeNodeId) -> Unit raise @tree.TreeError
-pub fn BlockDoc::new(String) -> Self raise @tree.TreeError
+pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, new_parent~ : @movable_tree.TreeNodeId) -> Unit raise @container.DocumentError
+pub fn BlockDoc::new(String) -> Self raise @container.DocumentError
 pub fn BlockDoc::set_checked(Self, @movable_tree.TreeNodeId, Bool) -> Unit
 pub fn BlockDoc::set_text(Self, @movable_tree.TreeNodeId, String) -> Unit
 pub fn BlockDoc::set_type(Self, @movable_tree.TreeNodeId, BlockType) -> Unit
@@ -65,17 +65,13 @@ pub enum BlockType {
   Code(String)
   Divider
   Raw
-}
-pub impl Eq for BlockType
-pub impl Show for BlockType
+} derive(Eq, Show)
 
 pub enum ListStyle {
   Bullet
   Numbered
   Todo
-}
-pub impl Eq for ListStyle
-pub impl Show for ListStyle
+} derive(Eq, Show)
 
 // Type aliases
 pub using @movable_tree {type TreeNodeId as BlockId}


### PR DESCRIPTION
## Summary

- Add `container/` package to `event-graph-walker` submodule with `Document` struct (renamed from `TreeState`) and `DocumentError` (renamed from `TreeError`)
- Switch the block editor from `@tree` to `@container` import throughout all source files
- 25 container tests + 44 block-editor tests all passing, zero stale `@tree` references

## Test plan

- [x] `cd event-graph-walker && moon test` -- 446 tests pass (including 25 new container tests)
- [x] `cd examples/block-editor && moon test` -- 44 tests pass
- [x] `grep -rn "@tree" examples/block-editor/` -- zero matches
- [x] `moon check` -- 0 errors in both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated block editor example to use an improved data structure backend for enhanced reliability.
  * Migrated error handling types consistently across block editor components.
  * Updated event-graph-walker submodule reference to the latest revision.
  * Simplified code syntax for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->