### PR TITLE
fix(core): clamp SourceMap range start in overlap branch

### DIFF
--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -185,8 +185,12 @@ fn shift_range(
   } else if r.start >= old_end {
     Range::new(r.start - delta, r.end - delta)
   } else {
-    let new_end = if r.end <= old_end { r.end } else { r.end - delta }
-    Range::new(r.start, new_end)
+    // Overlap: the deleted region intersects this range. Clamp start/end to
+    // the deletion boundary — the deleted portion is removed, and any surviving
+    // suffix past old_end shifts left by delta.
+    let new_start = if r.start < edit_start { r.start } else { edit_start }
+    let new_end = if r.end <= old_end { edit_start } else { r.end - delta }
+    Range::new(new_start, new_end)
   }
 }
 

--- a/core/source_map_wbtest.mbt
+++ b/core/source_map_wbtest.mbt
@@ -48,3 +48,106 @@ test "patch_subtree clears stale token spans" {
   let spans = sm.get_all_token_spans(nid)
   inspect(spans.length(), content="0")
 }
+
+///|
+test "shift_range: node starts inside deleted region — clamp to edit_start" {
+  // Node: 5..15, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(5, 15), 3, 8, 5)
+  // Start should clamp to 3, end shifts: 15 - 5 = 10
+  inspect(result.start, content="3")
+  inspect(result.end, content="10")
+}
+
+///|
+test "shift_range: node entirely inside deleted region — collapse to point at edit_start" {
+  // Node: 5..7, Delete: 3..10 (delta=7, old_end=10)
+  let result = shift_range(@loomcore.Range::new(5, 7), 3, 10, 7)
+  // Both start and end inside deletion → collapse to (3, 3)
+  inspect(result.start, content="3")
+  inspect(result.end, content="3")
+}
+
+///|
+test "shift_range: node starts before deletion, ends inside — truncate at edit_start" {
+  // Node: 1..6, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(1, 6), 3, 8, 5)
+  // Start unchanged (before deletion), end truncated to edit_start
+  inspect(result.start, content="1")
+  inspect(result.end, content="3")
+}
+
+///|
+test "shift_range: node starts before deletion, ends after — shrink by delta" {
+  // Node: 1..20, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(1, 20), 3, 8, 5)
+  // Start unchanged, end shifts: 20 - 5 = 15
+  inspect(result.start, content="1")
+  inspect(result.end, content="15")
+}
+
+///|
+test "shift_range: range starts at edit_start, ends after deletion" {
+  // Node: 3..10, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(3, 10), 3, 8, 5)
+  // Start at boundary → clamp to edit_start (3), end shifts: 10 - 5 = 5
+  inspect(result.start, content="3")
+  inspect(result.end, content="5")
+}
+
+///|
+test "shift_range: range ends exactly at old_end" {
+  // Node: 1..8, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(1, 8), 3, 8, 5)
+  // Start before deletion → unchanged, end at boundary → truncate to edit_start
+  inspect(result.start, content="1")
+  inspect(result.end, content="3")
+}
+
+///|
+test "shift_range: range equals deletion exactly — collapse to point" {
+  // Node: 3..8, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(3, 8), 3, 8, 5)
+  inspect(result.start, content="3")
+  inspect(result.end, content="3")
+}
+
+///|
+test "shift_range: zero-width range inside deletion — collapse to edit_start" {
+  // Node: 5..5, Delete: 3..8 (delta=5, old_end=8)
+  let result = shift_range(@loomcore.Range::new(5, 5), 3, 8, 5)
+  inspect(result.start, content="3")
+  inspect(result.end, content="3")
+}
+
+///|
+test "apply_edit: fully deleted token span collapses to point" {
+  let sm = SourceMap::new()
+  let nid = NodeId::from_int(1)
+  sm.node_to_range[nid] = @loomcore.Range::new(0, 20)
+  // Token span entirely inside the deletion
+  sm.set_token_span(nid, "name", @loomcore.Range::new(4, 6))
+  // Delete chars 3..10 (delta=7)
+  sm.apply_edit(3, @loomcore.Range::new(3, 10))
+  let spans = sm.get_all_token_spans(nid)
+  inspect(spans.length(), content="1")
+  // 4..6 entirely inside 3..10 → collapse to (3, 3)
+  inspect(spans[0].1.start, content="3")
+  inspect(spans[0].1.end, content="3")
+}
+
+///|
+test "apply_edit: token spans shifted correctly after overlapping deletion" {
+  let sm = SourceMap::new()
+  let nid = NodeId::from_int(1)
+  sm.node_to_range[nid] = @loomcore.Range::new(0, 20)
+  // Token span inside the node, overlapping with deletion
+  sm.set_token_span(nid, "param", @loomcore.Range::new(5, 10))
+  // Delete chars 3..8 (delta=5)
+  sm.apply_edit(3, @loomcore.Range::new(3, 8))
+  // Token span 5..10 overlaps deletion 3..8:
+  // start (5) inside deletion → clamp to 3, end (10) → shift to 5
+  let spans = sm.get_all_token_spans(nid)
+  inspect(spans.length(), content="1")
+  inspect(spans[0].1.start, content="3")
+  inspect(spans[0].1.end, content="5")
+}

--- a/projection/source_map_wbtest.mbt
+++ b/projection/source_map_wbtest.mbt
@@ -91,10 +91,10 @@ test "apply_edit multiple nodes" {
     None => fail("Node A not found")
   }
 
-  // Node B (5-8): overlaps, start unchanged, end shifts backward by 2
+  // Node B (5-8): overlaps deletion 4..6, start inside deletion → clamp to 4
   match source_map.get_range(NodeId::from_int(2)) {
     Some(range) => {
-      inspect(range.start, content="5")
+      inspect(range.start, content="4") // was 5, inside deletion → clamped to edit_start
       inspect(range.end, content="6") // 8 - 2 = 6
     }
     None => fail("Node B not found")


### PR DESCRIPTION
## Summary

- Fix `shift_range` overlap branch to clamp start position when inside deleted region
- Previously, ranges starting inside a deletion kept their original (now-invalid) start position
- Now handles all 4 overlap sub-cases correctly
- Token spans use the same `shift_range`, so both bugs are fixed by one change

## Four overlap sub-cases

| Sub-case | Before | After |
|----------|--------|-------|
| start before, end inside deletion | `1..6` del `3..8` → `1..6` (wrong) | `1..3` |
| start before, end after deletion | `1..20` del `3..8` → `1..15` | `1..15` (was correct) |
| start inside, end after deletion | `5..15` del `3..8` → `5..10` (wrong) | `3..10` |
| entirely inside deletion | `5..7` del `3..10` → `5..7` (wrong) | `3..3` (zero-width) |

Closes #71, closes #70

## Test plan

- [x] 5 new whitebox tests for all `shift_range` overlap sub-cases
- [x] 1 new test for token span shifting after overlapping deletion
- [x] Existing overlapping deletion test updated for correct behavior
- [x] All 669 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted source-map range handling for deletions so overlapping ranges clamp to the edit start and shift ends consistently, preventing incorrect preserved boundaries.

* **Tests**
  * Added tests covering multiple overlap scenarios (clamping, collapsing, truncating, cross-deletion shifts).
  * Updated existing tests to match the corrected overlap semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->