### PR TITLE
feat: pretty-printer ViewNode bridge — syntax-highlighted formatted display

### DIFF
--- a/editor/moon.pkg
+++ b/editor/moon.pkg
@@ -15,7 +15,6 @@ import {
   "moonbitlang/core/bench",
   "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
-  "moonbitlang/quickcheck" @qc,
   "moonbitlang/core/buffer",
   "moonbitlang/core/strconv",
   "moonbitlang/core/string",
@@ -23,6 +22,10 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/json",
 }
+
+import {
+  "moonbitlang/quickcheck" @qc,
+} for "test"
 
 options(
   is_main: false,

--- a/editor/moon.pkg
+++ b/editor/moon.pkg
@@ -15,6 +15,7 @@ import {
   "moonbitlang/core/bench",
   "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/quickcheck" @qc,
   "moonbitlang/core/buffer",
   "moonbitlang/core/strconv",
   "moonbitlang/core/string",

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -18,6 +18,8 @@ pub fn adjust_position(Int, Int, Int, Int) -> Int
 
 pub fn compute_edit(String, String) -> @dowdiness/loom/core.Edit
 
+pub fn compute_pretty_patches(ViewUpdateState, SyncEditor[@ast.Term]) -> Array[@protocol.ViewPatch]
+
 pub fn[T : @dowdiness/loom/core.Renderable] compute_view_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch]
 
 pub fn decode_message(Bytes) -> SyncMessage?
@@ -289,6 +291,7 @@ pub fn[T] SyncEditor::get_node(Self[T], @dowdiness/canopy/core.NodeId) -> @dowdi
 pub fn[T] SyncEditor::get_node_range(Self[T], @dowdiness/canopy/core.NodeId) -> @dowdiness/loom/core.Range?
 pub fn[T] SyncEditor::get_peer_cursors(Self[T]) -> Map[String, PeerCursor]
 pub fn[T] SyncEditor::get_peer_id(Self[T]) -> String
+pub fn SyncEditor::get_pretty_view(Self[@ast.Term]) -> @protocol.ViewNode
 pub fn[T] SyncEditor::get_proj_node(Self[T]) -> @dowdiness/canopy/core.ProjNode[T]?
 pub fn SyncEditor::get_resolution(Self[@ast.Term]) -> @lambda.Resolution
 pub fn[T] SyncEditor::get_source_map(Self[T]) -> @dowdiness/canopy/core.SourceMap

--- a/editor/pretty_view_test.mbt
+++ b/editor/pretty_view_test.mbt
@@ -1,0 +1,46 @@
+///|
+/// Property: concatenating view node line texts with newlines equals render_string.
+fn prop_view_text_matches_render(term : @ast.Term) -> Bool {
+  let layout = @pretty.Pretty::to_layout(term)
+  let view = @protocol.layout_to_view_tree(layout)
+  let buf = StringBuilder::new()
+  for i, child in view.children {
+    if i > 0 {
+      buf.write_char('\n')
+    }
+    match child.text {
+      Some(t) => buf.write_string(t)
+      None => ()
+    }
+  }
+  let view_text = buf.to_string()
+  let expected = @pretty.render_string(layout)
+  view_text == expected
+}
+
+///|
+test "property: view tree text == render_string" {
+  @qc.quick_check_fn(prop_view_text_matches_render)
+}
+
+///|
+/// Property: token spans within each line do not overlap.
+fn prop_token_spans_no_overlap(term : @ast.Term) -> Bool {
+  let layout = @pretty.Pretty::to_layout(term)
+  let view = @protocol.layout_to_view_tree(layout)
+  for child in view.children {
+    let sorted = child.token_spans.copy()
+    sorted.sort_by(fn(a, b) { a.start.compare(b.start) })
+    for i = 1; i < sorted.length(); i = i + 1 {
+      if sorted[i].start < sorted[i - 1].end {
+        return false
+      }
+    }
+  }
+  true
+}
+
+///|
+test "property: token spans do not overlap within a line" {
+  @qc.quick_check_fn(prop_token_spans_no_overlap)
+}

--- a/editor/sync_editor_pretty.mbt
+++ b/editor/sync_editor_pretty.mbt
@@ -1,0 +1,31 @@
+// Pretty-printer integration for SyncEditor.
+// Produces ViewNode trees from the Pretty trait, enabling syntax-highlighted
+// formatted display through the ViewPatch → Adapter pipeline.
+
+///|
+/// Lambda-specific: returns the pretty-printed ViewNode tree.
+/// Each line becomes a child ViewNode with text + token_spans.
+pub fn SyncEditor::get_pretty_view(
+  self : SyncEditor[@ast.Term],
+) -> @protocol.ViewNode {
+  let ast = self.get_ast()
+  let layout = @pretty.Pretty::to_layout(ast)
+  @protocol.layout_to_view_tree(layout, width=80)
+}
+
+///|
+/// Compute incremental pretty-view patches for a lambda editor.
+/// Uses a separate ViewUpdateState from the structural view.
+pub fn compute_pretty_patches(
+  state : ViewUpdateState,
+  editor : SyncEditor[@ast.Term],
+) -> Array[@protocol.ViewPatch] {
+  let patches : Array[@protocol.ViewPatch] = []
+  let current = editor.get_pretty_view()
+  match state.previous {
+    None => patches.push(@protocol.ViewPatch::FullTree(root=Some(current)))
+    Some(prev) => diff_view_nodes(prev, current, patches)
+  }
+  state.previous = Some(current)
+  patches
+}

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -73,6 +73,11 @@ fn diff_view_nodes(
     patches.push(@protocol.ViewPatch::ReplaceNode(node_id=curr.id, node=curr))
     return
   }
+  // token_spans changes require ReplaceNode because UpdateNode doesn't carry spans
+  if prev.token_spans != curr.token_spans {
+    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=curr.id, node=curr))
+    return
+  }
   if prev.label != curr.label ||
     prev.css_class != curr.css_class ||
     prev.text != curr.text {

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -411,6 +411,29 @@
       }
     }
 
+    /* Pretty-printer syntax highlighting */
+    .formatted-text {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      padding: 1rem;
+      margin: 0;
+      overflow-x: auto;
+      background: transparent;
+    }
+    .formatted-text .line {
+      white-space: pre;
+      min-height: 1.5em;
+    }
+    .keyword { color: #c792ea; }
+    .identifier { color: #82aaff; }
+    .number { color: #f78c6c; }
+    .string { color: #c3e88d; }
+    .operator { color: #ff5370; }
+    .punctuation { color: #89ddff; }
+    .comment { color: #546e7a; font-style: italic; }
+    .error { color: #ff5370; text-decoration: underline wavy; }
+
     /* Extra small screens (phones in portrait) */
     @media (max-width: 480px) {
       body {

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -425,14 +425,14 @@
       white-space: pre;
       min-height: 1.5em;
     }
-    .keyword { color: #c792ea; }
-    .identifier { color: #82aaff; }
-    .number { color: #f78c6c; }
-    .string { color: #c3e88d; }
-    .operator { color: #ff5370; }
-    .punctuation { color: #89ddff; }
-    .comment { color: #546e7a; font-style: italic; }
-    .error { color: #ff5370; text-decoration: underline wavy; }
+    .formatted-text .keyword { color: #c792ea; }
+    .formatted-text .identifier { color: #82aaff; }
+    .formatted-text .number { color: #f78c6c; }
+    .formatted-text .string { color: #c3e88d; }
+    .formatted-text .operator { color: #ff5370; }
+    .formatted-text .punctuation { color: #89ddff; }
+    .formatted-text .comment { color: #546e7a; font-style: italic; }
+    .formatted-text .error { color: #ff5370; text-decoration: underline wavy; }
 
     /* Extra small screens (phones in portrait) */
     @media (max-width: 480px) {

--- a/examples/web/src/editor.ts
+++ b/examples/web/src/editor.ts
@@ -2,14 +2,19 @@
 
 import * as crdt from '@moonbit/crdt';
 import * as graphviz from '@moonbit/graphviz';
+import { HTMLAdapter } from '../../../lib/editor-adapter/html-adapter';
+import type { ViewPatch } from '../../../lib/editor-adapter/types';
 
 export function createEditor(agentId: string) {
   const handle = crdt.create_editor(agentId);
 
   const editorEl = document.getElementById('editor') as HTMLDivElement;
   const astGraphEl = document.getElementById('ast-graph') as HTMLDivElement;
-  const astOutputEl = document.getElementById('ast-output') as HTMLPreElement;
+  const astOutputEl = document.getElementById('ast-output') as HTMLElement;
   const errorEl = document.getElementById('error-output') as HTMLUListElement;
+
+  // Protocol-based pretty-print adapter
+  const prettyAdapter = new HTMLAdapter(astOutputEl);
 
   let lastText = '';
   let scheduled = false;
@@ -34,8 +39,15 @@ export function createEditor(agentId: string) {
       astGraphEl.innerHTML = `<p style="color:#f44">Error: ${e}</p>`;
     }
 
-    // AST structure (pure MoonBit string via Debug trait)
-    astOutputEl.textContent = crdt.get_ast_pretty(handle);
+    // Pretty-printed AST with syntax highlighting (via protocol)
+    try {
+      const patches: ViewPatch[] = JSON.parse(
+        crdt.compute_pretty_patches_json(handle),
+      );
+      prettyAdapter.applyPatches(patches);
+    } catch (e) {
+      astOutputEl.textContent = `Pretty-print error: ${e}`;
+    }
 
     // Errors
     const errors: string[] = JSON.parse(crdt.get_errors_json(handle));

--- a/ffi/canopy_lambda.mbt
+++ b/ffi/canopy_lambda.mbt
@@ -36,6 +36,7 @@ pub fn create_editor(agent_id : String) -> Int {
 pub fn destroy_editor(handle : Int) -> Unit {
   editors.remove(handle)
   view_states.remove(handle)
+  pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
   }

--- a/ffi/canopy_pretty.mbt
+++ b/ffi/canopy_pretty.mbt
@@ -1,0 +1,34 @@
+// Pretty-printer FFI — ViewNode tree and ViewPatch streams for formatted display
+
+///|
+let pretty_view_states : Map[Int, @editor.ViewUpdateState] = Map::new()
+
+///|
+/// Get the pretty-printed ViewNode tree as JSON for a lambda editor.
+pub fn get_pretty_view_json(handle : Int) -> String {
+  match editors.get(handle) {
+    Some(ed) => ed.get_pretty_view().to_json().stringify()
+    None => "null"
+  }
+}
+
+///|
+/// Compute incremental pretty-view patches for a lambda editor.
+/// Returns a JSON array of ViewPatch objects.
+pub fn compute_pretty_patches_json(handle : Int) -> String {
+  match editors.get(handle) {
+    Some(ed) => {
+      let state = match pretty_view_states.get(handle) {
+        Some(s) => s
+        None => {
+          let s = @editor.ViewUpdateState::new()
+          pretty_view_states[handle] = s
+          s
+        }
+      }
+      let patches = @editor.compute_pretty_patches(state, ed)
+      Json::array(patches.map(fn(p) { p.to_json() })).stringify()
+    }
+    None => "[]"
+  }
+}

--- a/ffi/moon.pkg
+++ b/ffi/moon.pkg
@@ -75,6 +75,8 @@ options(
         "handle_undo",
         "handle_redo",
         "handle_structural_intent",
+        "get_pretty_view_json",
+        "compute_pretty_patches_json",
       ],
     },
   },

--- a/ffi/pkg.generated.mbti
+++ b/ffi/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn apply_tree_edit_json(Int, String, Int) -> String
 
 pub fn backspace_and_record(Int, Int) -> Bool
 
+pub fn compute_pretty_patches_json(Int) -> String
+
 pub fn compute_view_patches_json(Int) -> String
 
 pub fn create_editor(String) -> Int
@@ -53,6 +55,8 @@ pub fn get_ast_dot_resolved(Int) -> String
 pub fn get_ast_pretty(Int) -> String
 
 pub fn get_errors_json(Int) -> String
+
+pub fn get_pretty_view_json(Int) -> String
 
 pub fn get_proj_node_json(Int) -> String
 

--- a/lib/editor-adapter/html-adapter.ts
+++ b/lib/editor-adapter/html-adapter.ts
@@ -168,6 +168,14 @@ export class HTMLAdapter implements EditorAdapter {
   }
 
   private renderNode(node: ViewNode, edgeLabel: string | null, isRoot: boolean): HTMLElement {
+    // Formatted text display (pretty-printer output)
+    if (node.kind_tag === 'formatted-text') {
+      return this.renderFormattedText(node, isRoot);
+    }
+    if (node.text != null && node.token_spans.length > 0) {
+      return this.renderTextLine(node);
+    }
+
     const hasChildren = node.children.length > 0;
     const kindClass = node.kind_tag.toLowerCase();
 
@@ -256,6 +264,42 @@ export class HTMLAdapter implements EditorAdapter {
     container.appendChild(childrenContainer);
 
     return container;
+  }
+
+  private renderFormattedText(node: ViewNode, isRoot: boolean): HTMLElement {
+    const pre = document.createElement('pre');
+    pre.className = isRoot ? 'formatted-text root' : 'formatted-text';
+    pre.setAttribute('data-node-id', String(node.id));
+    for (let i = 0; i < node.children.length; i++) {
+      pre.appendChild(this.renderNode(node.children[i], null, false));
+    }
+    return pre;
+  }
+
+  private renderTextLine(node: ViewNode): HTMLElement {
+    const div = document.createElement('div');
+    div.className = 'line';
+    div.setAttribute('data-node-id', String(node.id));
+    const text = node.text ?? '';
+    const spans = [...node.token_spans].sort((a, b) => a.start - b.start);
+    let pos = 0;
+    for (const span of spans) {
+      // Gap before this span: unstyled text
+      if (span.start > pos) {
+        div.appendChild(document.createTextNode(text.slice(pos, span.start)));
+      }
+      // Styled span
+      const el = document.createElement('span');
+      el.className = span.role;
+      el.textContent = text.slice(span.start, span.end);
+      div.appendChild(el);
+      pos = span.end;
+    }
+    // Trailing unstyled text
+    if (pos < text.length) {
+      div.appendChild(document.createTextNode(text.slice(pos)));
+    }
+    return div;
   }
 
   private renderDiagnostics(diagnostics: Diagnostic[]): void {

--- a/lib/editor-adapter/html-adapter.ts
+++ b/lib/editor-adapter/html-adapter.ts
@@ -172,7 +172,7 @@ export class HTMLAdapter implements EditorAdapter {
     if (node.kind_tag === 'formatted-text') {
       return this.renderFormattedText(node, isRoot);
     }
-    if (node.text != null && node.token_spans.length > 0) {
+    if (node.text != null) {
       return this.renderTextLine(node);
     }
 

--- a/protocol/formatted_view.mbt
+++ b/protocol/formatted_view.mbt
@@ -1,0 +1,113 @@
+// formatted_view: Converts pretty-printer Layout into ViewNode tree.
+// Each rendered line becomes a child ViewNode with text + token_spans.
+// This is the text-format renderer for the multi-representation system
+// (see docs/architecture/multi-representation-system.md).
+
+///|
+fn category_to_role(cat : @pretty.SyntaxCategory) -> String {
+  match cat {
+    Keyword => "keyword"
+    Identifier => "identifier"
+    Number => "number"
+    StringLit => "string"
+    Operator => "operator"
+    Punctuation => "punctuation"
+    Comment => "comment"
+    Error => "error"
+  }
+}
+
+///|
+/// Convert a pretty-print layout into a ViewNode tree for formatted text display.
+/// Each rendered line becomes a child ViewNode with text and token_spans.
+/// Annotations that span line breaks are split into per-line TokenSpans.
+pub fn layout_to_view_tree(
+  layout : @pretty.Layout[@pretty.SyntaxCategory],
+  width? : Int = 80,
+) -> ViewNode {
+  let cmds = @pretty.resolve(width, layout)
+  let children : Array[ViewNode] = []
+  let line_buf = StringBuilder::new()
+  let line_spans : Array[TokenSpan] = []
+  let ann_stack : Array[(@pretty.SyntaxCategory, Int)] = []
+  let mut offset = 0
+  let mut line_id = 1
+  // flush_line: emit current line as a ViewNode child, handle cross-line spans
+  fn flush_line() {
+    let text = line_buf.to_string()
+    if text.length() > 0 || children.length() > 0 {
+      children.push(
+        ViewNode(
+          id=@core.NodeId::from_int(line_id),
+          kind_tag="line",
+          label="",
+          text~,
+          text_range=(0, 0),
+          token_spans=line_spans.copy(),
+          css_class="line",
+        ),
+      )
+      line_id = line_id + 1
+    }
+    line_buf.reset()
+    line_spans.clear()
+    offset = 0
+    // Re-open any annotations that were split across the line break
+    for i = 0; i < ann_stack.length(); i = i + 1 {
+      ann_stack[i] = (ann_stack[i].0, 0)
+    }
+  }
+
+  for cmd in cmds {
+    match cmd {
+      @pretty.CText(s) => {
+        line_buf.write_string(s)
+        offset = offset + s.length()
+      }
+      @pretty.CNewline(indent) => {
+        // Close any open annotations on the current line
+        for i = ann_stack.length() - 1; i >= 0; i = i - 1 {
+          let (cat, start) = ann_stack[i]
+          if offset > start {
+            line_spans.push(
+              TokenSpan(role=category_to_role(cat), start~, end=offset),
+            )
+          }
+        }
+        flush_line()
+        // Add indentation
+        for j = 0; j < indent; j = j + 1 {
+          line_buf.write_char(' ')
+        }
+        offset = indent
+        // Re-open spans at the indent position
+        for i = 0; i < ann_stack.length(); i = i + 1 {
+          ann_stack[i] = (ann_stack[i].0, offset)
+        }
+      }
+      @pretty.CAnnStart(cat) => ann_stack.push((cat, offset))
+      @pretty.CAnnEnd(_) =>
+        if ann_stack.pop() is Some((cat, start)) && offset > start {
+          line_spans.push(
+            TokenSpan(role=category_to_role(cat), start~, end=offset),
+          )
+        }
+    }
+  }
+  // Flush final line (close any remaining open annotations)
+  for i = ann_stack.length() - 1; i >= 0; i = i - 1 {
+    let (cat, start) = ann_stack[i]
+    if offset > start {
+      line_spans.push(TokenSpan(role=category_to_role(cat), start~, end=offset))
+    }
+  }
+  flush_line()
+  ViewNode(
+    id=@core.NodeId::from_int(0),
+    kind_tag="formatted-text",
+    label="formatted-text",
+    text_range=(0, 0),
+    children~,
+    css_class="formatted-text",
+  )
+}

--- a/protocol/formatted_view_wbtest.mbt
+++ b/protocol/formatted_view_wbtest.mbt
@@ -1,0 +1,142 @@
+///|
+test "layout_to_view_tree: single line, no annotations" {
+  let layout = @pretty.text("hello world")
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.kind_tag, "formatted-text")
+  assert_eq(view.children.length(), 1)
+  assert_eq(view.children[0].text, Some("hello world"))
+  assert_eq(view.children[0].token_spans.length(), 0)
+}
+
+///|
+test "layout_to_view_tree: single line with annotation" {
+  let layout = @pretty.annotate(
+    @pretty.SyntaxCategory::Keyword,
+    @pretty.text("let"),
+  )
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.children.length(), 1)
+  let line = view.children[0]
+  assert_eq(line.text, Some("let"))
+  assert_eq(line.token_spans.length(), 1)
+  assert_eq(line.token_spans[0].role, "keyword")
+  assert_eq(line.token_spans[0].start, 0)
+  assert_eq(line.token_spans[0].end, 3)
+}
+
+///|
+test "layout_to_view_tree: multi-line with nest" {
+  let layout = @pretty.concat(
+    @pretty.annotate(@pretty.SyntaxCategory::Keyword, @pretty.text("let")),
+    @pretty.nest(
+      @pretty.concat(
+        @pretty.hardline(),
+        @pretty.annotate(@pretty.SyntaxCategory::Identifier, @pretty.text("x")),
+      ),
+      indent=2,
+    ),
+  )
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.children.length(), 2)
+  let line0 = view.children[0]
+  assert_eq(line0.text, Some("let"))
+  assert_eq(line0.token_spans.length(), 1)
+  assert_eq(line0.token_spans[0].role, "keyword")
+  let line1 = view.children[1]
+  assert_eq(line1.text, Some("  x"))
+  assert_eq(line1.token_spans.length(), 1)
+  assert_eq(line1.token_spans[0].role, "identifier")
+  assert_eq(line1.token_spans[0].start, 2)
+  assert_eq(line1.token_spans[0].end, 3)
+}
+
+///|
+test "layout_to_view_tree: annotation spanning line break" {
+  let inner = @pretty.concat(
+    @pretty.text("if"),
+    @pretty.concat(@pretty.hardline(), @pretty.text("then")),
+  )
+  let layout = @pretty.annotate(@pretty.SyntaxCategory::Keyword, inner)
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.children.length(), 2)
+  let line0 = view.children[0]
+  assert_eq(line0.text, Some("if"))
+  assert_eq(line0.token_spans.length(), 1)
+  assert_eq(line0.token_spans[0].role, "keyword")
+  assert_eq(line0.token_spans[0].start, 0)
+  assert_eq(line0.token_spans[0].end, 2)
+  let line1 = view.children[1]
+  assert_eq(line1.text, Some("then"))
+  assert_eq(line1.token_spans.length(), 1)
+  assert_eq(line1.token_spans[0].role, "keyword")
+  assert_eq(line1.token_spans[0].start, 0)
+  assert_eq(line1.token_spans[0].end, 4)
+}
+
+///|
+test "layout_to_view_tree: mixed annotated and unannotated text" {
+  let layout = @pretty.concat(
+    @pretty.annotate(@pretty.SyntaxCategory::Keyword, @pretty.text("let")),
+    @pretty.concat(
+      @pretty.text(" "),
+      @pretty.concat(
+        @pretty.annotate(@pretty.SyntaxCategory::Identifier, @pretty.text("x")),
+        @pretty.concat(
+          @pretty.text(" = "),
+          @pretty.annotate(@pretty.SyntaxCategory::Number, @pretty.text("42")),
+        ),
+      ),
+    ),
+  )
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.children.length(), 1)
+  let line = view.children[0]
+  assert_eq(line.text, Some("let x = 42"))
+  assert_eq(line.token_spans.length(), 3)
+  assert_eq(line.token_spans[0].role, "keyword")
+  assert_eq(line.token_spans[0].start, 0)
+  assert_eq(line.token_spans[0].end, 3)
+  assert_eq(line.token_spans[1].role, "identifier")
+  assert_eq(line.token_spans[1].start, 4)
+  assert_eq(line.token_spans[1].end, 5)
+  assert_eq(line.token_spans[2].role, "number")
+  assert_eq(line.token_spans[2].start, 8)
+  assert_eq(line.token_spans[2].end, 10)
+}
+
+///|
+test "layout_to_view_tree: empty layout" {
+  let layout : @pretty.Layout[@pretty.SyntaxCategory] = @pretty.text("")
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.kind_tag, "formatted-text")
+  assert_eq(view.children.length(), 0)
+}
+
+///|
+test "layout_to_view_tree: node IDs are sequential" {
+  let layout = @pretty.concat(
+    @pretty.text("a"),
+    @pretty.concat(@pretty.hardline(), @pretty.text("b")),
+  )
+  let view = layout_to_view_tree(layout)
+  assert_eq(view.id, @core.NodeId::from_int(0))
+  assert_eq(view.children[0].id, @core.NodeId::from_int(1))
+  assert_eq(view.children[1].id, @core.NodeId::from_int(2))
+}
+
+///|
+test "layout_to_view_tree: group flattening (narrow width)" {
+  let layout = @pretty.group(
+    @pretty.concat(
+      @pretty.text("a"),
+      @pretty.concat(@pretty.line(), @pretty.text("b")),
+    ),
+  )
+  let wide = layout_to_view_tree(layout, width=80)
+  assert_eq(wide.children.length(), 1)
+  assert_eq(wide.children[0].text, Some("a b"))
+  let narrow = layout_to_view_tree(layout, width=1)
+  assert_eq(narrow.children.length(), 2)
+  assert_eq(narrow.children[0].text, Some("a"))
+  assert_eq(narrow.children[1].text, Some("b"))
+}

--- a/protocol/moon.pkg
+++ b/protocol/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core" @core,
   "dowdiness/loom/core" @loomcore,
+  "dowdiness/pretty" @pretty,
   "moonbitlang/core/json",
 }

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -2,10 +2,13 @@
 package "dowdiness/canopy/protocol"
 
 import {
+  "dowdiness/pretty",
   "moonbitlang/core/json",
 }
 
 // Values
+pub fn layout_to_view_tree(@pretty.Layout[@pretty.SyntaxCategory], width? : Int) -> ViewNode
+
 pub fn[T : @dowdiness/loom/core.Renderable] proj_to_view_node(@dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap) -> ViewNode
 
 // Errors


### PR DESCRIPTION
## Summary

- Add `layout_to_view_tree` bridge in `protocol/` that converts `Layout[SyntaxCategory]` → per-line ViewNode tree with token_spans, enabling any `T : Pretty` to get syntax-highlighted display through the existing ViewPatch → Adapter pipeline
- Wire into `editor/` (`get_pretty_view`, `compute_pretty_patches`), FFI exports, HTMLAdapter text-display rendering, and `examples/web/` lambda editor
- Fix `diff_view_nodes` to emit `ReplaceNode` when `token_spans` change (was silently losing updates via `UpdateNode` which doesn't carry spans)
- Add `Arbitrary` for `Term` + 3 property-based tests: pretty roundtrip (`parse(pretty_print(x)) == x`), view tree text consistency, span non-overlap

Architecture: `docs/architecture/multi-representation-system.md`
Design: `docs/plans/2026-04-02-pretty-printer-viewnode-bridge-design.md`

## Test plan

- [x] 674 tests pass (10 new: 8 unit + 2 property in canopy, plus roundtrip in loom submodule)
- [x] `moon check` — 0 warnings, 0 errors
- [x] `moon build --target js --release` — builds clean
- [x] Manual: web editor shows syntax-highlighted pretty-print output updating on every keystroke
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting to the formatted text output with distinct styling for keywords, identifiers, numbers, strings, operators, punctuation, and comments.
  * Implemented incremental patch-based rendering for improved performance.
  * Added error handling with fallback messages for pretty-print failures.

* **Bug Fixes**
  * Fixed token span detection in view updates to properly identify changes.

* **Style**
  * Added CSS styling for formatted text display with error indicators and visual token differentiation.

* **Tests**
  * Added property-based tests for pretty-print output validation and token span overlap detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->