### PR TITLE
feat: Markdown block editor — projection pipeline + textarea spike

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,17 @@ git add event-graph-walker
 git commit -m "chore: update event-graph-walker submodule"
 ```
 
+## Adding a New Language
+
+When integrating a new language (like Markdown, JSON, Lambda):
+
+1. **Check if the grammar has a `fold_node`** — look at `Grammar::new(fold_node=...)` in the language's `grammar.mbt`. If it exists, use `@loomcore.CstFold::new(fold_node).fold(syntax_node)` to get the full AST value. Don't hand-build AST values from tokens.
+2. **Reuse existing AST types** — use the language's own AST type (e.g., `@markdown.Block`) as `T` in `ProjNode[T]`. Don't create a custom projection enum. `TreeNode` and `Renderable` impls should already exist in the language's `proj_traits.mbt`.
+3. **Follow the memo builder pattern** — `build_*_projection_memos` returns 3 memos (proj, registry, source_map). Copy from `lang/json/proj/json_memo.mbt`.
+4. **SyncEditor constructor** — `SyncEditor::new_generic(agent_id, parser_factory, memo_builder)`. See `lang/json/edits/sync_editor_json.mbt`.
+
+Note: The JSON editor predates `CstFold` and hand-builds `JsonValue` from tokens. Don't follow that pattern for new languages — use `CstFold` instead.
+
 ## Package Map
 
 **Main module: `dowdiness/canopy`**

--- a/examples/web/spike-block-input.html
+++ b/examples/web/spike-block-input.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>BlockInput Spike</title>
+<style>
+  body { font-family: 'Inter', system-ui, sans-serif; max-width: 600px; margin: 40px auto; }
+  .block { position: relative; padding: 4px 8px; border-radius: 4px; cursor: text; min-height: 1.5em; }
+  .block:hover { background: #f5f5f5; }
+  .block.active { outline: 2px solid #8250df; }
+  .block[data-kind="heading"] { font-size: 1.5em; font-weight: 700; }
+  .block[data-kind="list_item"]::before { content: "• "; color: #666; }
+  .block-text { white-space: pre-wrap; }
+  .block-textarea {
+    position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+    padding: inherit; margin: 0; border: none; outline: none; resize: none;
+    font: inherit; color: inherit; background: transparent;
+    overflow: hidden; box-sizing: border-box; z-index: 1;
+  }
+  .toolbar { margin-bottom: 16px; display: flex; gap: 8px; }
+  .toolbar button { padding: 4px 12px; cursor: pointer; }
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <button id="btn-heading">Heading</button>
+  <button id="btn-paragraph">Paragraph</button>
+  <button id="btn-list">List Item</button>
+</div>
+
+<div id="editor"></div>
+
+<script>
+const blocks = [
+  { id: "1", kind: "heading", text: "Hello World" },
+  { id: "2", kind: "paragraph", text: "This is a paragraph with some text." },
+  { id: "3", kind: "list_item", text: "First item" },
+  { id: "4", kind: "list_item", text: "Second item" },
+  { id: "5", kind: "paragraph", text: "Another paragraph." },
+];
+
+const editor = document.getElementById("editor");
+let activeBlockId = null;
+let textarea = null;
+let blurBound = false;
+
+function render() {
+  editor.innerHTML = "";
+  for (const block of blocks) {
+    const div = document.createElement("div");
+    div.className = "block" + (block.id === activeBlockId ? " active" : "");
+    div.dataset.kind = block.kind;
+    div.dataset.id = block.id;
+
+    const textSpan = document.createElement("span");
+    textSpan.className = "block-text";
+    textSpan.textContent = block.text;
+    div.appendChild(textSpan);
+
+    div.addEventListener("click", (e) => {
+      e.stopPropagation();
+      activateBlock(block.id);
+    });
+    editor.appendChild(div);
+  }
+  if (activeBlockId) positionTextarea();
+}
+
+function activateBlock(blockId) {
+  activeBlockId = blockId;
+  blurBound = false;
+  render();
+
+  if (!textarea) {
+    textarea = document.createElement("textarea");
+    textarea.className = "block-textarea";
+    textarea.composing = false;
+    textarea.addEventListener("pointerdown", (e) => e.stopPropagation());
+    textarea.addEventListener("input", onInput);
+    textarea.addEventListener("keydown", onKeydown);
+    textarea.addEventListener("compositionstart", () => { textarea.composing = true; });
+    textarea.addEventListener("compositionend", () => {
+      textarea.composing = false;
+      onInput();
+    });
+  }
+  positionTextarea();
+}
+
+function positionTextarea() {
+  const block = blocks.find(b => b.id === activeBlockId);
+  const div = editor.querySelector(`[data-id="${activeBlockId}"]`);
+  if (!block || !div) return;
+
+  div.appendChild(textarea);
+  textarea.value = block.text;
+
+  // Match font from the block div
+  const style = getComputedStyle(div);
+  textarea.style.font = style.font;
+  textarea.style.padding = style.padding;
+  textarea.style.lineHeight = style.lineHeight;
+  // 1.05x height buffer (Excalidraw technique)
+  textarea.style.height = (div.offsetHeight * 1.05) + "px";
+
+  textarea.focus();
+
+  // Deferred blur (Excalidraw pattern)
+  if (!blurBound) {
+    document.addEventListener("pointerup", (e) => {
+      // Don't bind blur if click was on toolbar
+      if (e.target.closest(".toolbar")) return;
+      textarea.onblur = deactivate;
+      blurBound = true;
+    }, { once: true });
+  }
+}
+
+function onInput() {
+  if (textarea.composing) return; // Skip during IME composition
+
+  const block = blocks.find(b => b.id === activeBlockId);
+  if (!block) return;
+
+  // Save caret
+  const selStart = textarea.selectionStart;
+  const selEnd = textarea.selectionEnd;
+
+  // Update backing data
+  block.text = textarea.value;
+
+  // Simulate re-render: replace the text span (DOM mutation under textarea)
+  const div = editor.querySelector(`[data-id="${activeBlockId}"]`);
+  if (div) {
+    const textSpan = div.querySelector(".block-text");
+    if (textSpan) textSpan.textContent = block.text;
+    // Re-match textarea height
+    textarea.style.height = (div.offsetHeight * 1.05) + "px";
+  }
+
+  // Restore caret
+  textarea.selectionStart = selStart;
+  textarea.selectionEnd = selEnd;
+}
+
+function onKeydown(e) {
+  if (e.isComposing || e.keyCode === 229) return;
+  // Block navigation stubs
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    console.log("Enter → InsertBlockAfter / SplitBlock");
+  }
+}
+
+function deactivate() {
+  activeBlockId = null;
+  if (textarea && textarea.parentNode) textarea.parentNode.removeChild(textarea);
+  render();
+}
+
+// Toolbar: test deferred blur
+document.getElementById("btn-heading").addEventListener("click", () => {
+  const block = blocks.find(b => b.id === activeBlockId);
+  if (block) { block.kind = "heading"; render(); textarea?.focus(); }
+});
+document.getElementById("btn-paragraph").addEventListener("click", () => {
+  const block = blocks.find(b => b.id === activeBlockId);
+  if (block) { block.kind = "paragraph"; render(); textarea?.focus(); }
+});
+document.getElementById("btn-list").addEventListener("click", () => {
+  const block = blocks.find(b => b.id === activeBlockId);
+  if (block) { block.kind = "list_item"; render(); textarea?.focus(); }
+});
+
+document.addEventListener("click", (e) => {
+  if (!e.target.closest("#editor") && !e.target.closest(".toolbar")) deactivate();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/examples/web/spike-block-input.html
+++ b/examples/web/spike-block-input.html
@@ -89,6 +89,7 @@ function activateBlock(blockId) {
 }
 
 function positionTextarea() {
+  if (!textarea) return;
   const block = blocks.find(b => b.id === activeBlockId);
   const div = editor.querySelector(`[data-id="${activeBlockId}"]`);
   if (!block || !div) return;

--- a/examples/web/spike-block-input.html
+++ b/examples/web/spike-block-input.html
@@ -154,8 +154,13 @@ function onKeydown(e) {
 }
 
 function deactivate() {
+  if (activeBlockId === null) return; // idempotent guard
   activeBlockId = null;
-  if (textarea && textarea.parentNode) textarea.parentNode.removeChild(textarea);
+  blurBound = false;
+  if (textarea) {
+    textarea.onblur = null; // clear stale blur handler
+    if (textarea.parentNode) textarea.parentNode.removeChild(textarea);
+  }
   render();
 }
 

--- a/lang/markdown/proj/markdown_memo.mbt
+++ b/lang/markdown/proj/markdown_memo.mbt
@@ -1,0 +1,66 @@
+///| Reactive memo wrapper for Markdown projection.
+
+///|
+pub fn build_markdown_projection_memos(
+  rt : @incr.Runtime,
+  _source_text : @incr.Signal[String],
+  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
+  _parser : @loom.ImperativeParser[@markdown.Block],
+) -> (
+  @incr.Memo[@core.ProjNode[@markdown.Block]?],
+  @incr.Memo[Map[@core.NodeId, @core.ProjNode[@markdown.Block]]],
+  @incr.Memo[@core.SourceMap],
+) {
+  let counter : Ref[Int] = Ref::new(0)
+  let prev_proj_ref : Ref[@core.ProjNode[@markdown.Block]?] = Ref::new(None)
+  let proj_memo : @incr.Memo[@core.ProjNode[@markdown.Block]?] = @incr.Memo::new_no_backdate(
+    rt,
+    fn() -> @core.ProjNode[@markdown.Block]? {
+      match syntax_tree.get() {
+        None => {
+          prev_proj_ref.val = None
+          None
+        }
+        Some(syntax_root) => {
+          let new_proj = syntax_to_proj_node(syntax_root, counter)
+          let result = match prev_proj_ref.val {
+            Some(old) => @core.reconcile(old, new_proj, counter)
+            None => new_proj
+          }
+          prev_proj_ref.val = Some(result)
+          Some(result)
+        }
+      }
+    },
+    label="markdown_proj",
+  )
+  let registry_memo : @incr.Memo[
+    Map[@core.NodeId, @core.ProjNode[@markdown.Block]],
+  ] = @incr.Memo::new_no_backdate(
+    rt,
+    fn() -> Map[@core.NodeId, @core.ProjNode[@markdown.Block]] {
+      let reg : Map[@core.NodeId, @core.ProjNode[@markdown.Block]] = {}
+      match proj_memo.get() {
+        Some(root) => @core.collect_registry(root, reg)
+        None => ()
+      }
+      reg
+    },
+    label="markdown_registry",
+  )
+  let source_map_memo : @incr.Memo[@core.SourceMap] = @incr.Memo::new_no_backdate(
+    rt,
+    fn() -> @core.SourceMap {
+      match (proj_memo.get(), syntax_tree.get()) {
+        (Some(proj_root), Some(syntax_root)) => {
+          let sm = @core.SourceMap::from_ast(proj_root)
+          populate_token_spans(sm, syntax_root, proj_root)
+          sm
+        }
+        _ => @core.SourceMap::new()
+      }
+    },
+    label="markdown_source_map",
+  )
+  (proj_memo, registry_memo, source_map_memo)
+}

--- a/lang/markdown/proj/moon.pkg
+++ b/lang/markdown/proj/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "dowdiness/canopy/core" @core,
+  "dowdiness/incr" @incr,
+  "dowdiness/markdown" @markdown,
+  "dowdiness/loom" @loom,
+  "dowdiness/loom/core" @loomcore,
+  "dowdiness/seam" @seam,
+}

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/markdown/proj"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -3,12 +3,16 @@ package "dowdiness/canopy/lang/markdown/proj"
 
 import {
   "dowdiness/canopy/core",
+  "dowdiness/incr/cells",
+  "dowdiness/loom/incremental",
   "dowdiness/markdown",
   "dowdiness/seam",
   "moonbitlang/core/ref",
 }
 
 // Values
+pub fn build_markdown_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@markdown.Block]) -> (@cells.Memo[@core.ProjNode[@markdown.Block]?], @cells.Memo[Map[@core.NodeId, @core.ProjNode[@markdown.Block]]], @cells.Memo[@core.SourceMap])
+
 pub fn parse_to_proj_node(String) -> (@core.ProjNode[@markdown.Block], Array[String])
 
 pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@markdown.Block]) -> Unit

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -1,7 +1,17 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "dowdiness/canopy/lang/markdown/proj"
 
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/markdown",
+  "dowdiness/seam",
+  "moonbitlang/core/ref",
+}
+
 // Values
+pub fn parse_to_proj_node(String) -> (@core.ProjNode[@markdown.Block], Array[String])
+
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@markdown.Block]
 
 // Errors
 

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "dowdiness/canopy/lang/markdown/proj"
 
 import {
-  "dowdiness/canopy/core",
   "dowdiness/incr/cells",
   "dowdiness/loom/incremental",
   "dowdiness/markdown",
@@ -11,13 +10,13 @@ import {
 }
 
 // Values
-pub fn build_markdown_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@markdown.Block]) -> (@cells.Memo[@core.ProjNode[@markdown.Block]?], @cells.Memo[Map[@core.NodeId, @core.ProjNode[@markdown.Block]]], @cells.Memo[@core.SourceMap])
+pub fn build_markdown_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@markdown.Block]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
 
-pub fn parse_to_proj_node(String) -> (@core.ProjNode[@markdown.Block], Array[String])
+pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
 
-pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@markdown.Block]) -> Unit
+pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@markdown.Block]) -> Unit
 
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@markdown.Block]
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@markdown.Block]
 
 // Errors
 

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -11,6 +11,8 @@ import {
 // Values
 pub fn parse_to_proj_node(String) -> (@core.ProjNode[@markdown.Block], Array[String])
 
+pub fn populate_token_spans(@core.SourceMap, @seam.SyntaxNode, @core.ProjNode[@markdown.Block]) -> Unit
+
 pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @core.ProjNode[@markdown.Block]
 
 // Errors

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -1,8 +1,7 @@
 ///| Extract token spans from the Markdown CST into the SourceMap.
 ///
 /// Uses `find_token(raw_kind)` because `children()` returns only child nodes,
-/// not tokens. `find_token` searches for the first token of the given kind
-/// within the node's subtree.
+/// not tokens.
 
 ///|
 pub fn populate_token_spans(
@@ -14,11 +13,31 @@ pub fn populate_token_spans(
 }
 
 ///|
+fn set_span(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  proj_id : @core.NodeId,
+  role : String,
+  kind : @markdown.SyntaxKind,
+) -> Unit {
+  match syntax_node.find_token(kind.to_raw()) {
+    Some(tok) =>
+      source_map.set_token_span(
+        proj_id,
+        role,
+        @loomcore.Range::new(tok.start(), tok.end()),
+      )
+    None => ()
+  }
+}
+
+///|
 fn populate_block(
   source_map : @core.SourceMap,
   syntax_node : @seam.SyntaxNode,
   proj_node : @core.ProjNode[@markdown.Block],
 ) -> Unit {
+  let id = proj_node.id()
   match proj_node.kind {
     Document(_) => {
       let syntax_children = collect_block_children(syntax_node)
@@ -28,38 +47,11 @@ fn populate_block(
       }
     }
     Heading(_, _) => {
-      match
-        syntax_node.find_token(
-          @markdown.SyntaxKind::HeadingMarkerToken.to_raw(),
-        ) {
-        Some(tok) =>
-          source_map.set_token_span(
-            proj_node.id(),
-            "marker",
-            @loomcore.Range::new(tok.start(), tok.end()),
-          )
-        None => ()
-      }
-      match syntax_node.find_token(@markdown.SyntaxKind::TextToken.to_raw()) {
-        Some(tok) =>
-          source_map.set_token_span(
-            proj_node.id(),
-            "text",
-            @loomcore.Range::new(tok.start(), tok.end()),
-          )
-        None => ()
-      }
+      set_span(source_map, syntax_node, id, "marker", HeadingMarkerToken)
+      set_span(source_map, syntax_node, id, "text", TextToken)
     }
     Paragraph(_) | ListItem(_) =>
-      match syntax_node.find_token(@markdown.SyntaxKind::TextToken.to_raw()) {
-        Some(tok) =>
-          source_map.set_token_span(
-            proj_node.id(),
-            "text",
-            @loomcore.Range::new(tok.start(), tok.end()),
-          )
-        None => ()
-      }
+      set_span(source_map, syntax_node, id, "text", TextToken)
     UnorderedList(_) => {
       let syntax_children = collect_syntax_children(
         syntax_node,
@@ -71,40 +63,9 @@ fn populate_block(
       }
     }
     CodeBlock(_, _) => {
-      match
-        syntax_node.find_token(
-          @markdown.SyntaxKind::CodeFenceOpenToken.to_raw(),
-        ) {
-        Some(tok) =>
-          source_map.set_token_span(
-            proj_node.id(),
-            "fence_open",
-            @loomcore.Range::new(tok.start(), tok.end()),
-          )
-        None => ()
-      }
-      match
-        syntax_node.find_token(@markdown.SyntaxKind::CodeTextToken.to_raw()) {
-        Some(tok) =>
-          source_map.set_token_span(
-            proj_node.id(),
-            "code",
-            @loomcore.Range::new(tok.start(), tok.end()),
-          )
-        None => ()
-      }
-      match
-        syntax_node.find_token(
-          @markdown.SyntaxKind::CodeFenceCloseToken.to_raw(),
-        ) {
-        Some(tok) =>
-          source_map.set_token_span(
-            proj_node.id(),
-            "fence_close",
-            @loomcore.Range::new(tok.start(), tok.end()),
-          )
-        None => ()
-      }
+      set_span(source_map, syntax_node, id, "fence_open", CodeFenceOpenToken)
+      set_span(source_map, syntax_node, id, "code", CodeTextToken)
+      set_span(source_map, syntax_node, id, "fence_close", CodeFenceCloseToken)
     }
     Error(_) => ()
   }

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -70,28 +70,3 @@ fn populate_block(
     Error(_) => ()
   }
 }
-
-///|
-fn collect_block_children(node : @seam.SyntaxNode) -> Array[@seam.SyntaxNode] {
-  let result : Array[@seam.SyntaxNode] = []
-  for child in node.children() {
-    if is_block_node(@markdown.SyntaxKind::from_raw(child.kind())) {
-      result.push(child)
-    }
-  }
-  result
-}
-
-///|
-fn collect_syntax_children(
-  node : @seam.SyntaxNode,
-  kind : @markdown.SyntaxKind,
-) -> Array[@seam.SyntaxNode] {
-  let result : Array[@seam.SyntaxNode] = []
-  for child in node.children() {
-    if @markdown.SyntaxKind::from_raw(child.kind()) == kind {
-      result.push(child)
-    }
-  }
-  result
-}

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -1,0 +1,136 @@
+///| Extract token spans from the Markdown CST into the SourceMap.
+///
+/// Uses `find_token(raw_kind)` because `children()` returns only child nodes,
+/// not tokens. `find_token` searches for the first token of the given kind
+/// within the node's subtree.
+
+///|
+pub fn populate_token_spans(
+  source_map : @core.SourceMap,
+  syntax_root : @seam.SyntaxNode,
+  proj_root : @core.ProjNode[@markdown.Block],
+) -> Unit {
+  populate_block(source_map, syntax_root, proj_root)
+}
+
+///|
+fn populate_block(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  proj_node : @core.ProjNode[@markdown.Block],
+) -> Unit {
+  match proj_node.kind {
+    Document(_) => {
+      let syntax_children = collect_block_children(syntax_node)
+      let len = proj_node.children.length().min(syntax_children.length())
+      for i in 0..<len {
+        populate_block(source_map, syntax_children[i], proj_node.children[i])
+      }
+    }
+    Heading(_, _) => {
+      match
+        syntax_node.find_token(
+          @markdown.SyntaxKind::HeadingMarkerToken.to_raw(),
+        ) {
+        Some(tok) =>
+          source_map.set_token_span(
+            proj_node.id(),
+            "marker",
+            @loomcore.Range::new(tok.start(), tok.end()),
+          )
+        None => ()
+      }
+      match syntax_node.find_token(@markdown.SyntaxKind::TextToken.to_raw()) {
+        Some(tok) =>
+          source_map.set_token_span(
+            proj_node.id(),
+            "text",
+            @loomcore.Range::new(tok.start(), tok.end()),
+          )
+        None => ()
+      }
+    }
+    Paragraph(_) | ListItem(_) =>
+      match syntax_node.find_token(@markdown.SyntaxKind::TextToken.to_raw()) {
+        Some(tok) =>
+          source_map.set_token_span(
+            proj_node.id(),
+            "text",
+            @loomcore.Range::new(tok.start(), tok.end()),
+          )
+        None => ()
+      }
+    UnorderedList(_) => {
+      let syntax_children = collect_syntax_children(
+        syntax_node,
+        @markdown.SyntaxKind::ListItemNode,
+      )
+      let len = proj_node.children.length().min(syntax_children.length())
+      for i in 0..<len {
+        populate_block(source_map, syntax_children[i], proj_node.children[i])
+      }
+    }
+    CodeBlock(_, _) => {
+      match
+        syntax_node.find_token(
+          @markdown.SyntaxKind::CodeFenceOpenToken.to_raw(),
+        ) {
+        Some(tok) =>
+          source_map.set_token_span(
+            proj_node.id(),
+            "fence_open",
+            @loomcore.Range::new(tok.start(), tok.end()),
+          )
+        None => ()
+      }
+      match
+        syntax_node.find_token(@markdown.SyntaxKind::CodeTextToken.to_raw()) {
+        Some(tok) =>
+          source_map.set_token_span(
+            proj_node.id(),
+            "code",
+            @loomcore.Range::new(tok.start(), tok.end()),
+          )
+        None => ()
+      }
+      match
+        syntax_node.find_token(
+          @markdown.SyntaxKind::CodeFenceCloseToken.to_raw(),
+        ) {
+        Some(tok) =>
+          source_map.set_token_span(
+            proj_node.id(),
+            "fence_close",
+            @loomcore.Range::new(tok.start(), tok.end()),
+          )
+        None => ()
+      }
+    }
+    Error(_) => ()
+  }
+}
+
+///|
+fn collect_block_children(node : @seam.SyntaxNode) -> Array[@seam.SyntaxNode] {
+  let result : Array[@seam.SyntaxNode] = []
+  for child in node.children() {
+    if is_block_node(@markdown.SyntaxKind::from_raw(child.kind())) {
+      result.push(child)
+    }
+  }
+  result
+}
+
+///|
+fn collect_syntax_children(
+  node : @seam.SyntaxNode,
+  kind : @markdown.SyntaxKind,
+) -> Array[@seam.SyntaxNode] {
+  let result : Array[@seam.SyntaxNode] = []
+  for child in node.children() {
+    if @markdown.SyntaxKind::from_raw(child.kind()) == kind {
+      result.push(child)
+    }
+  }
+  result
+}

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -41,19 +41,26 @@ fn set_content_span(
   proj_id : @core.NodeId,
   role : String,
   prefix_kind : @markdown.SyntaxKind?,
+  suffix_kind? : @markdown.SyntaxKind? = None,
 ) -> Unit {
-  // Content starts after the prefix token (if any), otherwise at node start
   let content_start = match prefix_kind {
     Some(kind) =>
       match syntax_node.find_token(kind.to_raw()) {
-        Some(tok) => tok.end() // content starts right after the prefix token
+        Some(tok) => tok.end()
         None => syntax_node.start()
       }
     None => syntax_node.start()
   }
-  // Content ends at node end, trimmed of trailing newlines
-  let mut content_end = syntax_node.end()
-  // Don't include trailing NewlineToken — check if the node has one
+  let mut content_end = match suffix_kind {
+    Some(kind) =>
+      // End before the suffix token (e.g., closing fence)
+      match syntax_node.find_token(kind.to_raw()) {
+        Some(tok) => tok.start()
+        None => syntax_node.end()
+      }
+    None => syntax_node.end()
+  }
+  // Trim trailing newline if it's at the end
   match syntax_node.find_token(@markdown.SyntaxKind::NewlineToken.to_raw()) {
     Some(tok) => if tok.end() == content_end { content_end = tok.start() }
     None => ()
@@ -123,13 +130,14 @@ fn populate_block(
         "fence_open",
         CodeFenceOpenToken,
       )
-      // Full code content between fences
+      // Code content between open and close fences
       set_content_span(
         source_map,
         syntax_node,
         id,
         "code",
         Some(CodeFenceOpenToken),
+        suffix_kind=Some(CodeFenceCloseToken),
       )
       set_token_span(
         source_map,

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -1,7 +1,4 @@
 ///| Extract token spans from the Markdown CST into the SourceMap.
-///
-/// Uses `find_token(raw_kind)` because `children()` returns only child nodes,
-/// not tokens.
 
 ///|
 pub fn populate_token_spans(
@@ -13,7 +10,8 @@ pub fn populate_token_spans(
 }
 
 ///|
-fn set_span(
+/// Set a token span from a single specific token.
+fn set_token_span(
   source_map : @core.SourceMap,
   syntax_node : @seam.SyntaxNode,
   proj_id : @core.NodeId,
@@ -28,6 +26,44 @@ fn set_span(
         @loomcore.Range::new(tok.start(), tok.end()),
       )
     None => ()
+  }
+}
+
+///|
+/// Set a "text" span covering all inline content after a structural prefix.
+/// For headings: content starts after HeadingMarkerToken, ends at node end.
+/// For paragraphs/list items: content starts after ListMarkerToken (if any),
+/// ends at node end. This captures all inline tokens (text, bold, italic, etc.)
+/// as a single contiguous span.
+fn set_content_span(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  proj_id : @core.NodeId,
+  role : String,
+  prefix_kind : @markdown.SyntaxKind?,
+) -> Unit {
+  // Content starts after the prefix token (if any), otherwise at node start
+  let content_start = match prefix_kind {
+    Some(kind) =>
+      match syntax_node.find_token(kind.to_raw()) {
+        Some(tok) => tok.end() // content starts right after the prefix token
+        None => syntax_node.start()
+      }
+    None => syntax_node.start()
+  }
+  // Content ends at node end, trimmed of trailing newlines
+  let mut content_end = syntax_node.end()
+  // Don't include trailing NewlineToken — check if the node has one
+  match syntax_node.find_token(@markdown.SyntaxKind::NewlineToken.to_raw()) {
+    Some(tok) => if tok.end() == content_end { content_end = tok.start() }
+    None => ()
+  }
+  if content_start < content_end {
+    source_map.set_token_span(
+      proj_id,
+      role,
+      @loomcore.Range::new(content_start, content_end),
+    )
   }
 }
 
@@ -47,11 +83,28 @@ fn populate_block(
       }
     }
     Heading(_, _) => {
-      set_span(source_map, syntax_node, id, "marker", HeadingMarkerToken)
-      set_span(source_map, syntax_node, id, "text", TextToken)
+      set_token_span(source_map, syntax_node, id, "marker", HeadingMarkerToken)
+      // Full inline content after the heading marker
+      set_content_span(
+        source_map,
+        syntax_node,
+        id,
+        "text",
+        Some(HeadingMarkerToken),
+      )
     }
-    Paragraph(_) | ListItem(_) =>
-      set_span(source_map, syntax_node, id, "text", TextToken)
+    Paragraph(_) =>
+      // Full inline content (no prefix to skip)
+      set_content_span(source_map, syntax_node, id, "text", None)
+    ListItem(_) =>
+      // Full inline content after the list marker
+      set_content_span(
+        source_map,
+        syntax_node,
+        id,
+        "text",
+        Some(ListMarkerToken),
+      )
     UnorderedList(_) => {
       let syntax_children = collect_syntax_children(
         syntax_node,
@@ -63,9 +116,28 @@ fn populate_block(
       }
     }
     CodeBlock(_, _) => {
-      set_span(source_map, syntax_node, id, "fence_open", CodeFenceOpenToken)
-      set_span(source_map, syntax_node, id, "code", CodeTextToken)
-      set_span(source_map, syntax_node, id, "fence_close", CodeFenceCloseToken)
+      set_token_span(
+        source_map,
+        syntax_node,
+        id,
+        "fence_open",
+        CodeFenceOpenToken,
+      )
+      // Full code content between fences
+      set_content_span(
+        source_map,
+        syntax_node,
+        id,
+        "code",
+        Some(CodeFenceOpenToken),
+      )
+      set_token_span(
+        source_map,
+        syntax_node,
+        id,
+        "fence_close",
+        CodeFenceCloseToken,
+      )
     }
     Error(_) => ()
   }

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -1,4 +1,8 @@
 ///| CST → ProjNode[@markdown.Block] projection for Markdown.
+///
+/// Uses CstFold to get fully-populated Block values (with inline content,
+/// heading levels, code text). The ProjNode tree structure mirrors the
+/// CST block structure; Block payloads carry the semantic content.
 
 ///|
 /// Convenience: parse source and project in one call (for tests and REPL).
@@ -17,31 +21,64 @@ pub fn syntax_to_proj_node(
   node : @seam.SyntaxNode,
   counter : Ref[Int],
 ) -> @core.ProjNode[@markdown.Block] {
-  match @markdown.SyntaxKind::from_raw(node.kind()) {
-    DocumentNode => build_document(node, counter)
-    HeadingNode => build_heading(node, counter)
-    ParagraphNode => build_leaf(node, counter, @markdown.Block::Paragraph([]))
-    UnorderedListNode => build_list(node, counter)
-    ListItemNode => build_leaf(node, counter, @markdown.Block::ListItem([]))
-    CodeBlockNode => build_code_block(node, counter)
-    ErrorNode => {
-      let err_text = match node.first_token() {
-        Some(tok) => tok.text()
-        None => ""
+  // CstFold produces a fully-populated Block with inline content
+  let fold = @loomcore.CstFold::new(@markdown.markdown_fold_node)
+  let block = fold.fold(node)
+  build_proj_tree(node, block, counter)
+}
+
+///|
+fn build_proj_tree(
+  syntax_node : @seam.SyntaxNode,
+  block : @markdown.Block,
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  match block {
+    Document(_) => {
+      let syntax_children = collect_block_children(syntax_node)
+      let block_children = block.children()
+      let len = syntax_children.length().min(block_children.length())
+      let children : Array[@core.ProjNode[@markdown.Block]] = []
+      for i in 0..<len {
+        children.push(
+          build_proj_tree(syntax_children[i], block_children[i], counter),
+        )
       }
       @core.ProjNode::new(
-        @markdown.Block::Error(err_text),
-        node.start(),
-        node.end(),
+        block,
+        syntax_node.start(),
+        syntax_node.end(),
         @core.next_proj_node_id(counter),
-        [],
+        children,
+      )
+    }
+    UnorderedList(_) => {
+      let syntax_children = collect_syntax_children(
+        syntax_node,
+        @markdown.SyntaxKind::ListItemNode,
+      )
+      let block_children = block.children()
+      let len = syntax_children.length().min(block_children.length())
+      let children : Array[@core.ProjNode[@markdown.Block]] = []
+      for i in 0..<len {
+        children.push(
+          build_proj_tree(syntax_children[i], block_children[i], counter),
+        )
+      }
+      @core.ProjNode::new(
+        block,
+        syntax_node.start(),
+        syntax_node.end(),
+        @core.next_proj_node_id(counter),
+        children,
       )
     }
     _ =>
+      // Leaf blocks: heading, paragraph, list item, code block, error
       @core.ProjNode::new(
-        @markdown.Block::Paragraph([]),
-        node.start(),
-        node.end(),
+        block,
+        syntax_node.start(),
+        syntax_node.end(),
         @core.next_proj_node_id(counter),
         [],
       )
@@ -49,116 +86,28 @@ pub fn syntax_to_proj_node(
 }
 
 ///|
-fn build_document(
-  node : @seam.SyntaxNode,
-  counter : Ref[Int],
-) -> @core.ProjNode[@markdown.Block] {
-  let children : Array[@core.ProjNode[@markdown.Block]] = []
+fn collect_block_children(node : @seam.SyntaxNode) -> Array[@seam.SyntaxNode] {
+  let result : Array[@seam.SyntaxNode] = []
   for child in node.children() {
     if is_block_node(@markdown.SyntaxKind::from_raw(child.kind())) {
-      children.push(syntax_to_proj_node(child, counter))
+      result.push(child)
     }
   }
-  @core.ProjNode::new(
-    @markdown.Block::Document([]),
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    children,
-  )
+  result
 }
 
 ///|
-fn build_heading(
+fn collect_syntax_children(
   node : @seam.SyntaxNode,
-  counter : Ref[Int],
-) -> @core.ProjNode[@markdown.Block] {
-  let level = match
-    node.find_token(@markdown.SyntaxKind::HeadingMarkerToken.to_raw()) {
-    Some(tok) => {
-      let mut n = 0
-      for c in tok.text() {
-        if c == '#' {
-          n = n + 1
-        }
-      }
-      if n > 0 {
-        n
-      } else {
-        1
-      }
-    }
-    None => 1
-  }
-  @core.ProjNode::new(
-    @markdown.Block::Heading(level, []),
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    [],
-  )
-}
-
-///|
-fn build_leaf(
-  node : @seam.SyntaxNode,
-  counter : Ref[Int],
-  kind : @markdown.Block,
-) -> @core.ProjNode[@markdown.Block] {
-  @core.ProjNode::new(
-    kind,
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    [],
-  )
-}
-
-///|
-fn build_list(
-  node : @seam.SyntaxNode,
-  counter : Ref[Int],
-) -> @core.ProjNode[@markdown.Block] {
-  let children : Array[@core.ProjNode[@markdown.Block]] = []
+  kind : @markdown.SyntaxKind,
+) -> Array[@seam.SyntaxNode] {
+  let result : Array[@seam.SyntaxNode] = []
   for child in node.children() {
-    if @markdown.SyntaxKind::from_raw(child.kind()) == ListItemNode {
-      children.push(syntax_to_proj_node(child, counter))
+    if @markdown.SyntaxKind::from_raw(child.kind()) == kind {
+      result.push(child)
     }
   }
-  @core.ProjNode::new(
-    @markdown.Block::UnorderedList([]),
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    children,
-  )
-}
-
-///|
-fn build_code_block(
-  node : @seam.SyntaxNode,
-  counter : Ref[Int],
-) -> @core.ProjNode[@markdown.Block] {
-  let info = match
-    node.find_token(@markdown.SyntaxKind::CodeFenceOpenToken.to_raw()) {
-    Some(tok) =>
-      match tok.text().view() {
-        [.. "```", .. rest] =>
-          rest
-          .trim_end(chars="\n".view())
-          .trim_end(chars=" ".view())
-          .to_string()
-        _ => ""
-      }
-    None => ""
-  }
-  @core.ProjNode::new(
-    @markdown.Block::CodeBlock(info, ""),
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    [],
-  )
+  result
 }
 
 ///|

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -147,9 +147,7 @@ fn build_code_block(
       match tok.text().view() {
         [.. "```", .. rest] =>
           rest
-          .to_string()
           .trim_end(chars="\n".view())
-          .to_string()
           .trim_end(chars=" ".view())
           .to_string()
         _ => ""

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -1,0 +1,179 @@
+///| CST → ProjNode[@markdown.Block] projection for Markdown.
+
+///|
+/// Convenience: parse source and project in one call (for tests and REPL).
+pub fn parse_to_proj_node(
+  text : String,
+) -> (@core.ProjNode[@markdown.Block], Array[String]) {
+  let (cst, diagnostics) = @markdown.parse_cst(text) catch {
+    _ => abort("parse failed")
+  }
+  let syntax_node = @seam.SyntaxNode::from_cst(cst)
+  let errors = diagnostics.map(fn(d) { d.message })
+  let root = syntax_to_proj_node(syntax_node, Ref::new(0))
+  (root, errors)
+}
+
+///|
+pub fn syntax_to_proj_node(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  match @markdown.SyntaxKind::from_raw(node.kind()) {
+    DocumentNode => build_document(node, counter)
+    HeadingNode => build_heading(node, counter)
+    ParagraphNode => build_leaf(node, counter, @markdown.Block::Paragraph([]))
+    UnorderedListNode => build_list(node, counter)
+    ListItemNode => build_leaf(node, counter, @markdown.Block::ListItem([]))
+    CodeBlockNode => build_code_block(node, counter)
+    ErrorNode => {
+      let err_text = match node.first_token() {
+        Some(tok) => tok.text()
+        None => ""
+      }
+      @core.ProjNode::new(
+        @markdown.Block::Error(err_text),
+        node.start(),
+        node.end(),
+        @core.next_proj_node_id(counter),
+        [],
+      )
+    }
+    _ =>
+      @core.ProjNode::new(
+        @markdown.Block::Paragraph([]),
+        node.start(),
+        node.end(),
+        @core.next_proj_node_id(counter),
+        [],
+      )
+  }
+}
+
+///|
+fn build_document(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  let children : Array[@core.ProjNode[@markdown.Block]] = []
+  for child in node.children() {
+    if is_block_node(@markdown.SyntaxKind::from_raw(child.kind())) {
+      children.push(syntax_to_proj_node(child, counter))
+    }
+  }
+  @core.ProjNode::new(
+    @markdown.Block::Document([]),
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    children,
+  )
+}
+
+///|
+fn build_heading(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  let level = match
+    node.find_token(@markdown.SyntaxKind::HeadingMarkerToken.to_raw()) {
+    Some(tok) => {
+      let mut n = 0
+      for c in tok.text() {
+        if c == '#' {
+          n = n + 1
+        }
+      }
+      if n > 0 {
+        n
+      } else {
+        1
+      }
+    }
+    None => 1
+  }
+  @core.ProjNode::new(
+    @markdown.Block::Heading(level, []),
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    [],
+  )
+}
+
+///|
+fn build_leaf(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+  kind : @markdown.Block,
+) -> @core.ProjNode[@markdown.Block] {
+  @core.ProjNode::new(
+    kind,
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    [],
+  )
+}
+
+///|
+fn build_list(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  let children : Array[@core.ProjNode[@markdown.Block]] = []
+  for child in node.children() {
+    if @markdown.SyntaxKind::from_raw(child.kind()) == ListItemNode {
+      children.push(syntax_to_proj_node(child, counter))
+    }
+  }
+  @core.ProjNode::new(
+    @markdown.Block::UnorderedList([]),
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    children,
+  )
+}
+
+///|
+fn build_code_block(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  let info = match
+    node.find_token(@markdown.SyntaxKind::CodeFenceOpenToken.to_raw()) {
+    Some(tok) =>
+      match tok.text().view() {
+        [.. "```", .. rest] =>
+          rest
+          .to_string()
+          .trim_end(chars="\n".view())
+          .to_string()
+          .trim_end(chars=" ".view())
+          .to_string()
+        _ => ""
+      }
+    None => ""
+  }
+  @core.ProjNode::new(
+    @markdown.Block::CodeBlock(info, ""),
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    [],
+  )
+}
+
+///|
+fn is_block_node(kind : @markdown.SyntaxKind) -> Bool {
+  match kind {
+    HeadingNode
+    | ParagraphNode
+    | UnorderedListNode
+    | ListItemNode
+    | CodeBlockNode
+    | ErrorNode => true
+    _ => false
+  }
+}

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -34,47 +34,21 @@ fn build_proj_tree(
   counter : Ref[Int],
 ) -> @core.ProjNode[@markdown.Block] {
   match block {
-    Document(_) => {
-      let syntax_children = collect_block_children(syntax_node)
-      let block_children = block.children()
-      let len = syntax_children.length().min(block_children.length())
-      let children : Array[@core.ProjNode[@markdown.Block]] = []
-      for i in 0..<len {
-        children.push(
-          build_proj_tree(syntax_children[i], block_children[i], counter),
-        )
-      }
-      @core.ProjNode::new(
-        block,
-        syntax_node.start(),
-        syntax_node.end(),
-        @core.next_proj_node_id(counter),
-        children,
-      )
-    }
-    UnorderedList(_) => {
-      let syntax_children = collect_syntax_children(
+    Document(_) =>
+      build_container(
         syntax_node,
-        @markdown.SyntaxKind::ListItemNode,
-      )
-      let block_children = block.children()
-      let len = syntax_children.length().min(block_children.length())
-      let children : Array[@core.ProjNode[@markdown.Block]] = []
-      for i in 0..<len {
-        children.push(
-          build_proj_tree(syntax_children[i], block_children[i], counter),
-        )
-      }
-      @core.ProjNode::new(
         block,
-        syntax_node.start(),
-        syntax_node.end(),
-        @core.next_proj_node_id(counter),
-        children,
+        collect_block_children(syntax_node),
+        counter,
       )
-    }
+    UnorderedList(_) =>
+      build_container(
+        syntax_node,
+        block,
+        collect_syntax_children(syntax_node, @markdown.SyntaxKind::ListItemNode),
+        counter,
+      )
     _ =>
-      // Leaf blocks: heading, paragraph, list item, code block, error
       @core.ProjNode::new(
         block,
         syntax_node.start(),
@@ -83,6 +57,30 @@ fn build_proj_tree(
         [],
       )
   }
+}
+
+///|
+fn build_container(
+  syntax_node : @seam.SyntaxNode,
+  block : @markdown.Block,
+  syntax_children : Array[@seam.SyntaxNode],
+  counter : Ref[Int],
+) -> @core.ProjNode[@markdown.Block] {
+  let block_children = block.children()
+  let len = syntax_children.length().min(block_children.length())
+  let children : Array[@core.ProjNode[@markdown.Block]] = []
+  for i in 0..<len {
+    children.push(
+      build_proj_tree(syntax_children[i], block_children[i], counter),
+    )
+  }
+  @core.ProjNode::new(
+    block,
+    syntax_node.start(),
+    syntax_node.end(),
+    @core.next_proj_node_id(counter),
+    children,
+  )
 }
 
 ///|

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -4,10 +4,8 @@
 /// Convenience: parse source and project in one call (for tests and REPL).
 pub fn parse_to_proj_node(
   text : String,
-) -> (@core.ProjNode[@markdown.Block], Array[String]) {
-  let (cst, diagnostics) = @markdown.parse_cst(text) catch {
-    _ => abort("parse failed")
-  }
+) -> (@core.ProjNode[@markdown.Block], Array[String]) raise @loomcore.LexError {
+  let (cst, diagnostics) = @markdown.parse_cst(text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(fn(d) { d.message })
   let root = syntax_to_proj_node(syntax_node, Ref::new(0))

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -1,0 +1,71 @@
+///| Whitebox tests for Markdown projection.
+
+///|
+test "projection: empty document" {
+  let (proj, errors) = parse_to_proj_node("")
+  inspect(errors.length(), content="0")
+  inspect(proj.children.length(), content="0")
+}
+
+///|
+test "projection: single paragraph" {
+  let (proj, _) = parse_to_proj_node("Hello world")
+  inspect(proj.children.length(), content="1")
+}
+
+///|
+test "projection: heading levels" {
+  let (proj, _) = parse_to_proj_node("# H1\n\n## H2\n\n### H3")
+  inspect(proj.children.length(), content="3")
+}
+
+///|
+test "projection: unordered list" {
+  let (proj, _) = parse_to_proj_node("- first\n- second\n- third")
+  inspect(proj.children.length(), content="1")
+  let list = proj.children[0]
+  inspect(list.children.length(), content="3")
+}
+
+///|
+test "projection: code block" {
+  let (proj, _) = parse_to_proj_node("```js\nconsole.log(42)\n```")
+  inspect(proj.children.length(), content="1")
+}
+
+///|
+test "projection: mixed blocks" {
+  let source = "# Title\n\nSome text.\n\n- item one\n- item two\n\nMore text."
+  let (proj, _) = parse_to_proj_node(source)
+  inspect(proj.children.length(), content="4")
+}
+
+///|
+test "projection: node positions span source text" {
+  let source = "# Hello\n\nWorld"
+  let (proj, _) = parse_to_proj_node(source)
+  inspect(proj.start, content="0")
+  inspect(proj.children[0].start, content="0")
+}
+
+///|
+test "projection: IDs are unique" {
+  let (proj, _) = parse_to_proj_node("# H1\n\n- a\n- b")
+  let ids : Array[Int] = []
+  fn collect(node : @core.ProjNode[@markdown.Block]) {
+    ids.push(node.node_id)
+    for child in node.children {
+      collect(child)
+    }
+  }
+  collect(proj)
+  let unique : Map[Int, Bool] = {}
+  let mut all_unique = true
+  for id in ids {
+    if unique.get(id) == Some(true) {
+      all_unique = false
+    }
+    unique[id] = true
+  }
+  inspect(all_unique, content="true")
+}

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -69,3 +69,29 @@ test "projection: IDs are unique" {
   }
   inspect(all_unique, content="true")
 }
+
+///|
+test "projection: incremental reparse preserves IDs" {
+  let source = "# Hello\n\nWorld"
+  let parser = @loom.new_imperative_parser(source, @markdown.markdown_grammar)
+  let counter : Ref[Int] = Ref::new(0)
+  // Initial parse
+  let _ = parser.parse()
+  // First projection
+  let syntax1 = parser.get_syntax_tree().unwrap()
+  let proj1 = syntax_to_proj_node(syntax1, counter)
+  let heading_id = proj1.children[0].node_id
+  let para_id = proj1.children[1].node_id
+  // Incremental edit: change "World" to "World!"
+  // Edit::new(start, old_len, new_len) — "World" starts at offset 9, 5 chars → 6 chars
+  let edit = @loomcore.Edit::new(9, 5, 6)
+  let _ = parser.edit(edit, "# Hello\n\nWorld!")
+  // Second projection with reconciliation
+  let syntax2 = parser.get_syntax_tree().unwrap()
+  let proj2_raw = syntax_to_proj_node(syntax2, counter)
+  let proj2 = @core.reconcile(proj1, proj2_raw, counter)
+  // IDs should be preserved for unchanged structure
+  inspect(proj2.children[0].node_id == heading_id, content="true")
+  // Paragraph content changed, but structure is same — ID preserved
+  inspect(proj2.children[1].node_id == para_id, content="true")
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -29,6 +29,9 @@
     },
     "dowdiness/pretty": {
       "path": "./loom/pretty"
+    },
+    "dowdiness/markdown": {
+      "path": "./loom/examples/markdown"
     }
   },
   "readme": "README.mbt.md",


### PR DESCRIPTION
## Summary

Sub-projects 0-1 of the Markdown block editor ([design spec](docs/plans/2026-04-04-markdown-block-editor-design.md)):

**Sub-project 0: Textarea overlay spike**
- Standalone HTML page validating the Excalidraw-style textarea overlay technique
- Phase A (static positioning) + Phase B (re-render loop with IME composition guard and caret restoration)

**Sub-project 1: Markdown projection pipeline (`lang/markdown/proj/`)**
- `syntax_to_proj_node` — CST → ProjNode[@markdown.Block] for all block types
- `populate_token_spans` — token span extraction via `find_token()` with extracted `set_span` helper
- `build_markdown_projection_memos` — 3 reactive memos (proj, registry, source_map) with reconciliation
- `parse_to_proj_node` — convenience parse + project for tests/REPL
- 9 tests including incremental reparse round-trip (ID preservation via reconcile)
- Uses `@markdown.Block` directly as projection value type (TreeNode/Renderable impls already in loom)

**New dependency:** `dowdiness/markdown` added to `moon.mod.json` (path: `./loom/examples/markdown`)

## Test plan

- [ ] `moon test -p dowdiness/canopy/lang/markdown/proj` — 9 projection tests
- [ ] `moon test` — 765 total tests, no regression
- [ ] `moon check` passes
- [ ] Spike: `cd examples/web && npx vite` → open `spike-block-input.html`, test typing + IME + toolbar


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone BlockInput demo — block-based editable text UI with live editing, toolbar block-type switching, IME support, and outside-click deactivation.
  * Added Markdown projection and source-mapping tooling for incremental projection and accurate token spans.

* **Tests**
  * Added tests validating projection behavior, node uniqueness, and incremental ID preservation across edits.

* **Documentation**
  * Expanded integration guidance for adding new languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->