### PR TITLE
feat: BlockInput + MarkdownPreview adapters (sub-project 3)

### DIFF
--- a/lib/editor-adapter/block-input.css
+++ b/lib/editor-adapter/block-input.css
@@ -65,7 +65,8 @@
   outline: none;
   resize: none;
   font: inherit;
-  color: inherit;
+  color: transparent;
+  caret-color: currentColor;
   background: transparent;
   overflow: hidden;
   box-sizing: border-box;

--- a/lib/editor-adapter/block-input.css
+++ b/lib/editor-adapter/block-input.css
@@ -1,0 +1,82 @@
+/* BlockInput — thin block-mode input layer with textarea overlay */
+
+.block-editor {
+  position: relative;
+  font-family: 'Inter', system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+/* --- Block base --------------------------------------------------------- */
+
+.block {
+  position: relative;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: text;
+  min-height: 1.5em;
+  transition: background 0.1s ease;
+}
+
+.block:hover {
+  background: rgba(130, 80, 223, 0.04);
+}
+
+.block.active {
+  outline: 2px solid #8250df;
+  outline-offset: -1px;
+}
+
+/* --- Block kinds -------------------------------------------------------- */
+
+.block[data-kind="heading"] {
+  font-size: 1.5em;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.block[data-kind="list_item"] {
+  padding-left: 24px;
+}
+
+.block[data-kind="list_item"]::before {
+  content: "\2022 ";
+  position: absolute;
+  left: 8px;
+  color: #666;
+}
+
+.block[data-kind="code_block"] {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.9em;
+  background: rgba(130, 80, 223, 0.04);
+  border-radius: 4px;
+}
+
+/* --- Textarea overlay --------------------------------------------------- */
+
+.block-textarea {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: inherit;
+  margin: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  overflow: hidden;
+  box-sizing: border-box;
+  z-index: 1;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* --- Text span ---------------------------------------------------------- */
+
+.block-text {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/lib/editor-adapter/block-input.css
+++ b/lib/editor-adapter/block-input.css
@@ -66,7 +66,7 @@
   resize: none;
   font: inherit;
   color: transparent;
-  caret-color: currentColor;
+  caret-color: #1a1a2e;
   background: transparent;
   overflow: hidden;
   box-sizing: border-box;

--- a/lib/editor-adapter/block-input.css
+++ b/lib/editor-adapter/block-input.css
@@ -2,7 +2,7 @@
 
 .block-editor {
   position: relative;
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: Inter, system-ui, sans-serif;
   line-height: 1.6;
 }
 
@@ -71,12 +71,12 @@
   box-sizing: border-box;
   z-index: 1;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 /* --- Text span ---------------------------------------------------------- */
 
 .block-text {
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }

--- a/lib/editor-adapter/block-input.ts
+++ b/lib/editor-adapter/block-input.ts
@@ -1,0 +1,346 @@
+// BlockInput — Canopy-owned thin input layer for block-mode editing.
+// Follows the Excalidraw textarea overlay pattern: a single <textarea>
+// is positioned over the active block div, matching its computed font.
+
+import type { EditorAdapter } from './adapter';
+import type { ViewNode, ViewPatch, UserIntent } from './types';
+
+// ---------------------------------------------------------------------------
+// BlockInput
+// ---------------------------------------------------------------------------
+
+export class BlockInput implements EditorAdapter {
+  private container: HTMLElement;
+  private currentTree: ViewNode | null = null;
+  private activeBlockId: number | null = null;
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurBound = false;
+  private composing = false;
+  private intentCb: ((intent: UserIntent) => void) | null = null;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+    this.container.classList.add('block-editor');
+    this.onContainerClick = this.onContainerClick.bind(this);
+    this.container.addEventListener('click', this.onContainerClick);
+  }
+
+  // --- EditorAdapter interface ---------------------------------------------
+
+  applyPatches(patches: ViewPatch[]): void {
+    for (const p of patches) {
+      switch (p.type) {
+        case 'FullTree':
+          this.currentTree = p.root;
+          this.renderAll();
+          break;
+        case 'ReplaceNode':
+          this.replaceNode(p.node_id, p.node);
+          break;
+        case 'InsertChild':
+          this.insertChild(p.parent_id, p.index, p.child);
+          break;
+        case 'RemoveChild':
+          this.removeChild(p.parent_id, p.child_id);
+          break;
+        case 'UpdateNode':
+          this.updateNode(p.node_id, p.label, p.css_class, p.text);
+          break;
+        // TextChange, SetDecorations, etc. are not applicable to block mode
+      }
+    }
+  }
+
+  onIntent(callback: (intent: UserIntent) => void): void {
+    this.intentCb = callback;
+  }
+
+  destroy(): void {
+    this.deactivate();
+    this.container.removeEventListener('click', this.onContainerClick);
+    this.container.innerHTML = '';
+    this.currentTree = null;
+    if (this.textarea) {
+      this.textarea.remove();
+      this.textarea = null;
+    }
+  }
+
+  // --- Rendering -----------------------------------------------------------
+
+  private renderAll(): void {
+    this.container.innerHTML = '';
+    if (!this.currentTree) return;
+    for (const child of this.currentTree.children) {
+      if (!child.editable) continue;
+      this.container.appendChild(this.createBlockDiv(child));
+    }
+    if (this.activeBlockId !== null) this.positionTextarea();
+  }
+
+  private createBlockDiv(node: ViewNode): HTMLDivElement {
+    const div = document.createElement('div');
+    div.className = 'block' + (node.id === this.activeBlockId ? ' active' : '');
+    if (node.css_class) div.className += ' ' + node.css_class;
+    div.dataset.nodeId = String(node.id);
+    div.dataset.kind = node.kind_tag;
+
+    // Accessibility for headings
+    if (node.kind_tag === 'heading') {
+      div.setAttribute('role', 'heading');
+      const level = this.headingLevel(node.css_class);
+      div.setAttribute('aria-level', String(level));
+    }
+
+    const textSpan = document.createElement('span');
+    textSpan.className = 'block-text';
+    textSpan.textContent = node.text ?? '';
+    div.appendChild(textSpan);
+
+    div.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.activateBlock(node.id);
+    });
+
+    return div;
+  }
+
+  private headingLevel(cssClass: string): number {
+    const m = cssClass.match(/h(\d)/);
+    return m ? parseInt(m[1], 10) : 1;
+  }
+
+  // --- Patch helpers -------------------------------------------------------
+
+  private findNode(id: number, node: ViewNode | null = this.currentTree): ViewNode | null {
+    if (!node) return null;
+    if (node.id === id) return node;
+    for (const c of node.children) {
+      const found = this.findNode(id, c);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  private replaceNode(nodeId: number, replacement: ViewNode): void {
+    if (!this.currentTree) return;
+    const parent = this.findParent(nodeId, this.currentTree);
+    if (parent) {
+      const idx = parent.children.findIndex(c => c.id === nodeId);
+      if (idx !== -1) parent.children[idx] = replacement;
+    }
+    this.renderAll();
+  }
+
+  private insertChild(parentId: number, index: number, child: ViewNode): void {
+    const parent = this.findNode(parentId);
+    if (parent) parent.children.splice(index, 0, child);
+    this.renderAll();
+  }
+
+  private removeChild(parentId: number, childId: number): void {
+    const parent = this.findNode(parentId);
+    if (parent) {
+      const idx = parent.children.findIndex(c => c.id === childId);
+      if (idx !== -1) parent.children.splice(idx, 1);
+    }
+    if (this.activeBlockId === childId) this.activeBlockId = null;
+    this.renderAll();
+  }
+
+  private updateNode(nodeId: number, label: string, cssClass: string, text: string | null): void {
+    const node = this.findNode(nodeId);
+    if (node) {
+      node.label = label;
+      node.css_class = cssClass;
+      node.text = text;
+    }
+    // Skip DOM re-render during IME composition to avoid caret disruption
+    if (!this.composing) this.renderAll();
+  }
+
+  private findParent(childId: number, node: ViewNode): ViewNode | null {
+    for (const c of node.children) {
+      if (c.id === childId) return node;
+      const found = this.findParent(childId, c);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  // --- Textarea overlay (Excalidraw pattern) -------------------------------
+
+  private activateBlock(blockId: number): void {
+    this.activeBlockId = blockId;
+    this.blurBound = false;
+    this.renderAll();
+    this.ensureTextarea();
+    this.positionTextarea();
+    this.emit({ type: 'SelectNode', node_id: blockId });
+  }
+
+  private ensureTextarea(): void {
+    if (this.textarea) return;
+    const ta = document.createElement('textarea');
+    ta.className = 'block-textarea';
+    ta.addEventListener('pointerdown', (e) => e.stopPropagation());
+    ta.addEventListener('input', () => this.onInput());
+    ta.addEventListener('keydown', (e) => this.onKeydown(e));
+    ta.addEventListener('compositionstart', () => { this.composing = true; });
+    ta.addEventListener('compositionend', () => {
+      this.composing = false;
+      this.onInput();
+    });
+    this.textarea = ta;
+  }
+
+  private positionTextarea(): void {
+    const ta = this.textarea;
+    if (!ta || this.activeBlockId === null) return;
+
+    const node = this.findNode(this.activeBlockId);
+    const div = this.container.querySelector<HTMLElement>(
+      `[data-node-id="${this.activeBlockId}"]`,
+    );
+    if (!node || !div) return;
+
+    div.appendChild(ta);
+    ta.value = node.text ?? '';
+
+    // Match font from the block div
+    const style = getComputedStyle(div);
+    ta.style.font = style.font;
+    ta.style.padding = style.padding;
+    ta.style.lineHeight = style.lineHeight;
+    // 1.05x height buffer (Excalidraw technique)
+    ta.style.height = div.offsetHeight * 1.05 + 'px';
+
+    ta.focus();
+
+    // Deferred blur: bind onblur only after pointerup (Excalidraw pattern)
+    if (!this.blurBound) {
+      const handler = () => {
+        if (ta) ta.onblur = () => this.deactivate();
+        this.blurBound = true;
+      };
+      document.addEventListener('pointerup', handler, { once: true });
+    }
+  }
+
+  private deactivate(): void {
+    if (this.activeBlockId === null) return;
+    this.activeBlockId = null;
+    this.blurBound = false;
+    const ta = this.textarea;
+    if (ta) {
+      ta.onblur = null;
+      ta.remove();
+    }
+    this.renderAll();
+  }
+
+  // --- Input handling ------------------------------------------------------
+
+  private onInput(): void {
+    const ta = this.textarea;
+    if (!ta || this.composing || this.activeBlockId === null) return;
+
+    // Save caret
+    const selStart = ta.selectionStart;
+    const selEnd = ta.selectionEnd;
+
+    this.emit({
+      type: 'CommitEdit',
+      node_id: this.activeBlockId,
+      value: ta.value,
+    });
+
+    // Re-sync text span under the textarea
+    const div = this.container.querySelector<HTMLElement>(
+      `[data-node-id="${this.activeBlockId}"]`,
+    );
+    if (div) {
+      const textSpan = div.querySelector('.block-text');
+      if (textSpan) textSpan.textContent = ta.value;
+      ta.style.height = div.offsetHeight * 1.05 + 'px';
+    }
+
+    // Restore caret
+    ta.selectionStart = selStart;
+    ta.selectionEnd = selEnd;
+  }
+
+  private onKeydown(e: KeyboardEvent): void {
+    if (e.isComposing || e.keyCode === 229) return;
+    const ta = this.textarea;
+    if (!ta || this.activeBlockId === null) return;
+
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      const pos = ta.selectionStart;
+      const atEnd = pos === ta.value.length;
+      if (atEnd) {
+        this.emit({
+          type: 'StructuralEdit',
+          node_id: this.activeBlockId,
+          op: 'insert_block_after',
+          params: {},
+        });
+      } else {
+        this.emit({
+          type: 'StructuralEdit',
+          node_id: this.activeBlockId,
+          op: 'split_block',
+          params: { offset: String(pos) },
+        });
+      }
+      return;
+    }
+
+    if (e.key === 'Backspace' && ta.selectionStart === 0 && ta.selectionEnd === 0) {
+      e.preventDefault();
+      this.emit({
+        type: 'StructuralEdit',
+        node_id: this.activeBlockId,
+        op: 'merge_with_previous',
+        params: {},
+      });
+      return;
+    }
+
+    if (e.key === 'ArrowUp' && ta.selectionStart === 0) {
+      e.preventDefault();
+      this.moveFocus(-1);
+      return;
+    }
+
+    if (e.key === 'ArrowDown' && ta.selectionStart === ta.value.length) {
+      e.preventDefault();
+      this.moveFocus(1);
+      return;
+    }
+  }
+
+  // --- Block navigation ----------------------------------------------------
+
+  private moveFocus(direction: -1 | 1): void {
+    if (this.activeBlockId === null || !this.currentTree) return;
+    const siblings = this.currentTree.children.filter(c => c.editable);
+    const idx = siblings.findIndex(c => c.id === this.activeBlockId);
+    const next = siblings[idx + direction];
+    if (next) this.activateBlock(next.id);
+  }
+
+  // --- Helpers -------------------------------------------------------------
+
+  private emit(intent: UserIntent): void {
+    if (this.intentCb) this.intentCb(intent);
+  }
+
+  private onContainerClick(e: MouseEvent): void {
+    const target = e.target as HTMLElement;
+    if (!target.closest('.block')) {
+      this.deactivate();
+    }
+  }
+}

--- a/lib/editor-adapter/block-input.ts
+++ b/lib/editor-adapter/block-input.ts
@@ -46,6 +46,9 @@ export class BlockInput implements EditorAdapter {
         case 'UpdateNode':
           this.updateNode(p.node_id, p.label, p.css_class, p.text);
           break;
+        case 'SelectNode':
+          this.activateBlock(p.node_id);
+          break;
         // TextChange, SetDecorations, etc. are not applicable to block mode
       }
     }

--- a/lib/editor-adapter/block-input.ts
+++ b/lib/editor-adapter/block-input.ts
@@ -71,11 +71,24 @@ export class BlockInput implements EditorAdapter {
   private renderAll(): void {
     this.container.innerHTML = '';
     if (!this.currentTree) return;
-    for (const child of this.currentTree.children) {
-      if (!child.editable) continue;
-      this.container.appendChild(this.createBlockDiv(child));
+    for (const block of this.collectEditableBlocks(this.currentTree)) {
+      this.container.appendChild(this.createBlockDiv(block));
     }
     if (this.activeBlockId !== null) this.positionTextarea();
+  }
+
+  /** Recursively collect editable leaf blocks (flattens containers like UnorderedList) */
+  private collectEditableBlocks(node: ViewNode): ViewNode[] {
+    const result: ViewNode[] = [];
+    for (const child of node.children) {
+      if (child.editable) {
+        result.push(child);
+      } else if (child.children.length > 0) {
+        // Container (e.g., UnorderedList) — descend into children
+        result.push(...this.collectEditableBlocks(child));
+      }
+    }
+    return result;
   }
 
   private createBlockDiv(node: ViewNode): HTMLDivElement {
@@ -106,7 +119,7 @@ export class BlockInput implements EditorAdapter {
   }
 
   private headingLevel(cssClass: string): number {
-    const m = cssClass.match(/h(\d)/);
+    const m = cssClass.match(/heading-(\d)/);
     return m ? parseInt(m[1], 10) : 1;
   }
 
@@ -217,13 +230,15 @@ export class BlockInput implements EditorAdapter {
 
     ta.focus();
 
-    // Deferred blur: bind onblur only after pointerup (Excalidraw pattern)
+    // Deferred blur: bind onblur only after pointerup, skip if target is toolbar
     if (!this.blurBound) {
-      const handler = () => {
+      const handler = (e: PointerEvent) => {
+        // Don't bind blur if click was on toolbar/menu — keeps textarea active
+        if ((e.target as Element)?.closest?.('[data-no-blur]')) return;
         if (ta) ta.onblur = () => this.deactivate();
         this.blurBound = true;
       };
-      document.addEventListener('pointerup', handler, { once: true });
+      document.addEventListener('pointerup', handler as EventListener, { once: true });
     }
   }
 
@@ -325,7 +340,7 @@ export class BlockInput implements EditorAdapter {
 
   private moveFocus(direction: -1 | 1): void {
     if (this.activeBlockId === null || !this.currentTree) return;
-    const siblings = this.currentTree.children.filter(c => c.editable);
+    const siblings = this.collectEditableBlocks(this.currentTree);
     const idx = siblings.findIndex(c => c.id === this.activeBlockId);
     const next = siblings[idx + direction];
     if (next) this.activateBlock(next.id);

--- a/lib/editor-adapter/index.ts
+++ b/lib/editor-adapter/index.ts
@@ -13,3 +13,4 @@ export type { EditorAdapter } from './adapter';
 export { HTMLAdapter } from './html-adapter';
 export { CM6Adapter } from './cm6-adapter';
 export { PMAdapter, pmAdapterSchema } from './pm-adapter';
+export { MarkdownPreview } from './markdown-preview';

--- a/lib/editor-adapter/index.ts
+++ b/lib/editor-adapter/index.ts
@@ -14,3 +14,4 @@ export { HTMLAdapter } from './html-adapter';
 export { CM6Adapter } from './cm6-adapter';
 export { PMAdapter, pmAdapterSchema } from './pm-adapter';
 export { MarkdownPreview } from './markdown-preview';
+export { BlockInput } from './block-input';

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -76,9 +76,9 @@ function removeFromTree(tree: ViewNode, parentId: number, childId: number): View
   return { ...tree, children: tree.children.map(c => removeFromTree(c, parentId, childId)) };
 }
 
-function updateInTree(tree: ViewNode, id: number, label: string, cssClass: string, text?: string): ViewNode {
+function updateInTree(tree: ViewNode, id: number, label: string, cssClass: string, text: string | null): ViewNode {
   if (tree.id === id) {
-    return { ...tree, label, css_class: cssClass, ...(text !== undefined ? { text } : {}) };
+    return { ...tree, label, css_class: cssClass, text };
   }
   return { ...tree, children: tree.children.map(c => updateInTree(c, id, label, cssClass, text)) };
 }
@@ -134,7 +134,7 @@ export class MarkdownPreview implements EditorAdapter {
         }
 
         case 'UpdateNode': {
-          if (this.currentTree) this.currentTree = updateInTree(this.currentTree, patch.node_id, patch.label, patch.css_class, patch.text ?? undefined);
+          if (this.currentTree) this.currentTree = updateInTree(this.currentTree, patch.node_id, patch.label, patch.css_class, patch.text);
           const el = this.container.querySelector(`[data-node-id="${patch.node_id}"]`);
           if (el) {
             // Check if the semantic tag needs to change (e.g., h1 → h2 on heading level change)

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -148,9 +148,14 @@ export class MarkdownPreview implements EditorAdapter {
                 break;
               }
             }
-            // Tag unchanged — update in place
-            if (el.children.length === 0) {
-              el.textContent = patch.text ?? patch.label;
+            // Tag unchanged — update text in place
+            const text = patch.text ?? patch.label;
+            if (el.tagName === 'PRE') {
+              // Code block: update the <code> child, not the <pre> wrapper
+              const code = el.querySelector('code');
+              if (code) code.textContent = text;
+            } else if (el.children.length === 0) {
+              el.textContent = text;
             }
             if (patch.css_class) el.className = patch.css_class;
           }

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -35,6 +35,7 @@ function semanticTag(node: ViewNode): HTMLElement {
 function renderNode(node: ViewNode): HTMLElement {
   const el = semanticTag(node);
   el.setAttribute('data-node-id', String(node.id));
+  if (node.css_class) el.className = node.css_class;
 
   // For code_block, text goes inside the <code> child
   const textTarget = node.kind_tag === 'code_block'
@@ -119,8 +120,12 @@ export class MarkdownPreview implements EditorAdapter {
         case 'InsertChild': {
           const parentEl = this.container.querySelector(`[data-node-id="${patch.parent_id}"]`);
           if (parentEl) {
-            const ref = parentEl.children[patch.index] ?? null;
-            parentEl.insertBefore(renderNode(patch.child), ref);
+            // Code blocks: insert into <code> child, not <pre> wrapper
+            const target = parentEl.tagName === 'PRE'
+              ? (parentEl.querySelector('code') ?? parentEl)
+              : parentEl;
+            const ref = target.children[patch.index] ?? null;
+            target.insertBefore(renderNode(patch.child), ref);
           }
           if (this.currentTree) this.currentTree = insertInTree(this.currentTree, patch.parent_id, patch.index, patch.child);
           break;
@@ -157,7 +162,7 @@ export class MarkdownPreview implements EditorAdapter {
             } else if (el.children.length === 0) {
               el.textContent = text;
             }
-            if (patch.css_class) el.className = patch.css_class;
+            el.className = patch.css_class;
           }
           break;
         }

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -1,0 +1,148 @@
+// MarkdownPreview: Read-only semantic HTML renderer for ViewPatch streams.
+
+import type { EditorAdapter } from './adapter';
+import type { ViewNode, ViewPatch, UserIntent } from './types';
+
+/** Extract heading level from css_class like "heading-2" → 2, default 1 */
+function headingLevel(cssClass: string): number {
+  const m = cssClass.match(/heading-(\d)/);
+  return m ? Math.min(Math.max(Number(m[1]), 1), 6) : 1;
+}
+
+/** Create the appropriate semantic element for a ViewNode based on kind_tag */
+function semanticTag(node: ViewNode): HTMLElement {
+  switch (node.kind_tag) {
+    case 'heading':
+      return document.createElement(`h${headingLevel(node.css_class)}`);
+    case 'paragraph':
+      return document.createElement('p');
+    case 'unordered_list':
+      return document.createElement('ul');
+    case 'list_item':
+      return document.createElement('li');
+    case 'code_block': {
+      const pre = document.createElement('pre');
+      const code = document.createElement('code');
+      pre.appendChild(code);
+      return pre;
+    }
+    case 'document':
+    default:
+      return document.createElement('div');
+  }
+}
+
+function renderNode(node: ViewNode): HTMLElement {
+  const el = semanticTag(node);
+  el.setAttribute('data-node-id', String(node.id));
+
+  // For code_block, text goes inside the <code> child
+  const textTarget = node.kind_tag === 'code_block'
+    ? el.querySelector('code')!
+    : el;
+
+  const text = node.text ?? node.label;
+  if (text && node.children.length === 0) {
+    textTarget.textContent = text;
+  }
+
+  for (const child of node.children) {
+    textTarget.appendChild(renderNode(child));
+  }
+
+  return el;
+}
+
+// --- Tree mutation helpers ---
+
+function replaceInTree(tree: ViewNode, id: number, replacement: ViewNode): ViewNode {
+  if (tree.id === id) return replacement;
+  return { ...tree, children: tree.children.map(c => replaceInTree(c, id, replacement)) };
+}
+
+function insertInTree(tree: ViewNode, parentId: number, index: number, child: ViewNode): ViewNode {
+  if (tree.id === parentId) {
+    const ch = [...tree.children];
+    ch.splice(index, 0, child);
+    return { ...tree, children: ch };
+  }
+  return { ...tree, children: tree.children.map(c => insertInTree(c, parentId, index, child)) };
+}
+
+function removeFromTree(tree: ViewNode, parentId: number, childId: number): ViewNode {
+  if (tree.id === parentId) {
+    return { ...tree, children: tree.children.filter(c => c.id !== childId) };
+  }
+  return { ...tree, children: tree.children.map(c => removeFromTree(c, parentId, childId)) };
+}
+
+function updateInTree(tree: ViewNode, id: number, label: string, cssClass: string, text?: string): ViewNode {
+  if (tree.id === id) {
+    return { ...tree, label, css_class: cssClass, ...(text !== undefined ? { text } : {}) };
+  }
+  return { ...tree, children: tree.children.map(c => updateInTree(c, id, label, cssClass, text)) };
+}
+
+export class MarkdownPreview implements EditorAdapter {
+  private container: HTMLElement;
+  private currentTree: ViewNode | null = null;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+  }
+
+  applyPatches(patches: ViewPatch[]): void {
+    for (const patch of patches) {
+      switch (patch.type) {
+        case 'FullTree':
+          this.currentTree = patch.root;
+          this.container.replaceChildren();
+          if (patch.root) this.container.appendChild(renderNode(patch.root));
+          break;
+
+        case 'ReplaceNode': {
+          const el = this.container.querySelector(`[data-node-id="${patch.node_id}"]`);
+          if (el?.parentElement) el.parentElement.replaceChild(renderNode(patch.node), el);
+          if (this.currentTree) this.currentTree = replaceInTree(this.currentTree, patch.node_id, patch.node);
+          break;
+        }
+
+        case 'InsertChild': {
+          const parentEl = this.container.querySelector(`[data-node-id="${patch.parent_id}"]`);
+          if (parentEl) {
+            const ref = parentEl.children[patch.index] ?? null;
+            parentEl.insertBefore(renderNode(patch.child), ref);
+          }
+          if (this.currentTree) this.currentTree = insertInTree(this.currentTree, patch.parent_id, patch.index, patch.child);
+          break;
+        }
+
+        case 'RemoveChild': {
+          const el = this.container.querySelector(`[data-node-id="${patch.child_id}"]`);
+          if (el) el.remove();
+          if (this.currentTree) this.currentTree = removeFromTree(this.currentTree, patch.parent_id, patch.child_id);
+          break;
+        }
+
+        case 'UpdateNode': {
+          const el = this.container.querySelector(`[data-node-id="${patch.node_id}"]`);
+          if (el) el.textContent = patch.text ?? patch.label;
+          if (this.currentTree) this.currentTree = updateInTree(this.currentTree, patch.node_id, patch.label, patch.css_class, patch.text ?? undefined);
+          break;
+        }
+
+        default:
+          break;
+      }
+    }
+  }
+
+  onIntent(_callback: (intent: UserIntent) => void): void {
+    // Read-only — no intents emitted
+  }
+
+  destroy(): void {
+    this.currentTree = null;
+    this.container.replaceChildren();
+  }
+}

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -126,7 +126,13 @@ export class MarkdownPreview implements EditorAdapter {
 
         case 'UpdateNode': {
           const el = this.container.querySelector(`[data-node-id="${patch.node_id}"]`);
-          if (el) el.textContent = patch.text ?? patch.label;
+          if (el) {
+            // Only set textContent on leaf elements — containers have child elements
+            if (el.children.length === 0) {
+              el.textContent = patch.text ?? patch.label;
+            }
+            if (patch.css_class) el.className = patch.css_class;
+          }
           if (this.currentTree) this.currentTree = updateInTree(this.currentTree, patch.node_id, patch.label, patch.css_class, patch.text ?? undefined);
           break;
         }

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -83,6 +83,15 @@ function updateInTree(tree: ViewNode, id: number, label: string, cssClass: strin
   return { ...tree, children: tree.children.map(c => updateInTree(c, id, label, cssClass, text)) };
 }
 
+function findInTree(tree: ViewNode, id: number): ViewNode | null {
+  if (tree.id === id) return tree;
+  for (const child of tree.children) {
+    const found = findInTree(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
 export class MarkdownPreview implements EditorAdapter {
   private container: HTMLElement;
   private currentTree: ViewNode | null = null;
@@ -125,15 +134,26 @@ export class MarkdownPreview implements EditorAdapter {
         }
 
         case 'UpdateNode': {
+          if (this.currentTree) this.currentTree = updateInTree(this.currentTree, patch.node_id, patch.label, patch.css_class, patch.text ?? undefined);
           const el = this.container.querySelector(`[data-node-id="${patch.node_id}"]`);
           if (el) {
-            // Only set textContent on leaf elements — containers have child elements
+            // Check if the semantic tag needs to change (e.g., h1 → h2 on heading level change)
+            const updatedNode = this.currentTree ? findInTree(this.currentTree, patch.node_id) : null;
+            if (updatedNode) {
+              const requiredTag = semanticTag(updatedNode).tagName;
+              if (el.tagName !== requiredTag) {
+                // Tag changed — re-render the full node
+                const newEl = renderNode(updatedNode);
+                el.parentElement?.replaceChild(newEl, el);
+                break;
+              }
+            }
+            // Tag unchanged — update in place
             if (el.children.length === 0) {
               el.textContent = patch.text ?? patch.label;
             }
             if (patch.css_class) el.className = patch.css_class;
           }
-          if (this.currentTree) this.currentTree = updateInTree(this.currentTree, patch.node_id, patch.label, patch.css_class, patch.text ?? undefined);
           break;
         }
 


### PR DESCRIPTION
## Summary

Sub-project 3 of the Markdown block editor ([design spec](docs/plans/2026-04-04-markdown-block-editor-design.md)):

**`lib/editor-adapter/block-input.ts`** (346 lines) — Canopy-owned thin input layer:
- Textarea overlay following Excalidraw pattern (absolute position, font-matched, 1.05x height buffer)
- IME composition guards (compositionstart/end, skip re-render during composition)
- Caret preservation across DOM updates
- Deferred blur (toolbar clicks don't dismiss textarea)
- Keyboard: Enter → insert_block_after / split_block, Backspace@0 → merge_with_previous, ArrowUp/Down → block navigation
- Emits CommitEdit and StructuralEdit UserIntents

**`lib/editor-adapter/block-input.css`** (82 lines) — Block styles, textarea overlay, kind-specific display (heading, list_item, code_block)

**`lib/editor-adapter/markdown-preview.ts`** (148 lines) — Read-only semantic HTML renderer:
- Maps kind_tag → semantic elements: heading → h1-h6, paragraph → p, unordered_list → ul, list_item → li, code_block → pre>code
- Handles FullTree, ReplaceNode, InsertChild, RemoveChild, UpdateNode patches
- data-node-id on every element

Both exported from `lib/editor-adapter/index.ts`.

## Test plan

- [ ] `moon check` passes (no MoonBit changes)
- [ ] TypeScript compiles: `cd examples/web && npx tsc --noEmit`
- [ ] Manual test: import BlockInput/MarkdownPreview in sub-project 4 web editor


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block-mode editor with clickable editable blocks and an overlaid textarea for the active block
  * Block-specific keyboard behavior: arrows to move, Enter to split/insert, Backspace to merge
  * Read‑only markdown preview that renders semantic HTML (headings, lists, code, etc.)
  * Block styling: typography, per-kind visuals, hover/active states, and caret-preserving textarea behavior
  * Click-outside to deactivate blocks and improved input/IME caret handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->