### PR TITLE
feat(markdown): three-mode web editor page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ examples/demo-react/playwright-report/
 examples/demo-react/test-results/
 examples/ideal/web/playwright-report/
 examples/ideal/web/test-results/
+examples/web/test-results/
+test-results/
 .grepai/
 .worktrees/
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,16 @@ Note: The JSON editor predates `CstFold` and hand-builds `JsonValue` from tokens
 
 ## Development Workflow
 
+### UI / Visual Feature Rule
+
+**CRITICAL:** Before writing a design spec or implementation plan for any UI or visual feature, build the **smallest working prototype** that touches the real system and test it manually in the browser. If you can't see the change working in 10 minutes, stop and re-evaluate.
+
+1. **Prototype first (10 min):** Add one CSS class to one element, open the browser, verify it renders. Don't write plans.
+2. **Spike unknowns (30 min):** Before building, answer platform questions with small experiments (DOM focus behavior, web component internals, framework re-render semantics). Don't assume — verify.
+3. **Incremental manual testing:** After each integration point (not just `moon check`), open the browser and click. Especially for focus, keyboard events, and visual state.
+4. **Don't batch-build UI features via subagents.** Tightly-coupled UI work (focus management, DOM events, visual feedback) needs human-in-the-loop feedback cycles, not parallel isolated implementation.
+5. **Listen to user signals.** When the user questions the value of what you're building, stop and validate before continuing. User testing feedback > design spec > implementation plan.
+
 ### Performance Optimization Rule
 
 **CRITICAL:** Before designing any performance optimization, write a microbenchmark that **reproduces the claimed bottleneck** in isolation. If the benchmark can't demonstrate the problem, stop and re-evaluate. Stale profiling data (from before prior optimizations) and O(bad) asymptotic complexity are not proof of a real problem. Check if existing mitigations (batch modes, caching, lazy eval) already neutralize the issue.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -397,6 +397,8 @@ From SuperOOP analysis and handler chain refactor (PR #54):
   Why: instead of migrating the property-based block editor to the protocol, build a new Markdown-backed block editor using SyncEditor + loom Markdown parser + projection. Three modes: raw (CM6), block (Canopy-owned thin input layer with Excalidraw-style textarea overlay), preview (semantic HTML). Explicit conversion model (slash commands, not autoformat). 7 edit ops.
   Plan: `docs/plans/2026-04-04-markdown-block-editor-design.md`
   Exit: `examples/web/markdown.html` with 3 modes, `lang/markdown/` projection + edit ops, BlockInput + MarkdownPreview adapters.
+- [ ] **ZWSP cleanup for empty blocks** — `InsertBlockAfter` inserts `\u200B` (zero-width space) as placeholder so the parser produces a ProjNode for empty paragraphs. The ZWSP is stripped on keystroke, but unused empty blocks keep it. If raw Markdown is copy-pasted to another tool, invisible ZWSP characters travel with it. Fix by either: (a) teaching the parser to produce empty paragraph nodes for consecutive blank lines, or (b) stripping all ZWSP on save/export.
+  Exit: No `\u200B` in raw Markdown output after save or copy.
 
 ---
 

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -20,7 +20,8 @@ pub fn[T : @proj.Renderable] SyncEditor::get_view_tree(
   match self.get_proj_node() {
     Some(proj_node) => {
       let source_map = self.get_source_map()
-      Some(@protocol.proj_to_view_node(proj_node, source_map))
+      let source_text = Some(self.get_text())
+      Some(@protocol.proj_to_view_node(proj_node, source_map, source_text~))
     }
     None => None
   }
@@ -123,17 +124,18 @@ fn diff_view_nodes(
   patches : Array[@protocol.ViewPatch],
 ) -> Unit {
   if prev.kind_tag != curr.kind_tag {
-    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=curr.id, node=curr))
+    // Use prev.id so the receiver can find the node to replace in its tree
+    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=prev.id, node=curr))
     return
   }
   // token_spans changes require ReplaceNode because UpdateNode doesn't carry spans
   if prev.token_spans != curr.token_spans {
-    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=curr.id, node=curr))
+    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=prev.id, node=curr))
     return
   }
   // annotation changes require ReplaceNode because UpdateNode doesn't carry annotations
   if prev.annotations != curr.annotations {
-    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=curr.id, node=curr))
+    patches.push(@protocol.ViewPatch::ReplaceNode(node_id=prev.id, node=curr))
     return
   }
   if prev.label != curr.label ||

--- a/examples/web/markdown.html
+++ b/examples/web/markdown.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Canopy Markdown Editor</title>
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: Inter, system-ui, -apple-system, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e8;
+      padding: 24px;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 860px;
+      margin: 0 auto;
+    }
+
+    /* --- Header ----------------------------------------------------------- */
+
+    header {
+      margin-bottom: 24px;
+    }
+
+    header h1 {
+      font-size: 28px;
+      font-weight: 700;
+      color: #f0f0f8;
+      letter-spacing: -0.02em;
+    }
+
+    header h1 span {
+      color: #8250df;
+    }
+
+    .subtitle {
+      color: #8888a0;
+      font-size: 14px;
+      margin-top: 4px;
+    }
+
+    /* --- Examples bar ----------------------------------------------------- */
+
+    .examples-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 16px;
+      align-items: center;
+    }
+
+    .examples-label {
+      color: #8888a0;
+      font-size: 13px;
+      margin-right: 4px;
+    }
+
+    .example-btn {
+      padding: 6px 14px;
+      background: rgba(130, 80, 223, 0.08);
+      color: #c0b8d8;
+      border: 1px solid rgba(130, 80, 223, 0.2);
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 13px;
+      font-family: inherit;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .example-btn:hover {
+      background: rgba(130, 80, 223, 0.16);
+      border-color: rgba(130, 80, 223, 0.4);
+      color: #e0d8f0;
+    }
+
+    /* --- Mode tabs -------------------------------------------------------- */
+
+    .mode-tabs {
+      display: flex;
+      gap: 2px;
+      margin-bottom: 0;
+      background: rgba(130, 80, 223, 0.06);
+      border-radius: 8px 8px 0 0;
+      padding: 4px 4px 0 4px;
+    }
+
+    .mode-tab {
+      padding: 8px 20px;
+      background: transparent;
+      color: #8888a0;
+      border: none;
+      border-radius: 6px 6px 0 0;
+      cursor: pointer;
+      font-size: 13px;
+      font-family: inherit;
+      font-weight: 500;
+      transition: background 0.15s, color 0.15s;
+    }
+
+    .mode-tab:hover {
+      color: #c0b8d8;
+      background: rgba(130, 80, 223, 0.08);
+    }
+
+    .mode-tab.active {
+      background: #22223a;
+      color: #f0f0f8;
+    }
+
+    /* --- Editor panel ----------------------------------------------------- */
+
+    .editor-panel {
+      background: #22223a;
+      border: 1px solid rgba(130, 80, 223, 0.15);
+      border-top: none;
+      border-radius: 0 0 8px 8px;
+      overflow: hidden;
+    }
+
+    /* --- Toolbar ---------------------------------------------------------- */
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding: 8px 12px;
+      border-bottom: 1px solid rgba(130, 80, 223, 0.1);
+      align-items: center;
+    }
+
+    .toolbar-group {
+      display: flex;
+      gap: 2px;
+      align-items: center;
+    }
+
+    .toolbar-divider {
+      width: 1px;
+      height: 20px;
+      background: rgba(130, 80, 223, 0.15);
+      margin: 0 6px;
+    }
+
+    .toolbar-btn {
+      padding: 4px 10px;
+      background: transparent;
+      color: #a0a0b8;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+      font-family: inherit;
+      font-weight: 500;
+      transition: background 0.12s, color 0.12s, border-color 0.12s;
+      line-height: 1.4;
+    }
+
+    .toolbar-btn:hover:not(:disabled) {
+      background: rgba(130, 80, 223, 0.1);
+      color: #e0d8f0;
+      border-color: rgba(130, 80, 223, 0.2);
+    }
+
+    .toolbar-btn:disabled {
+      cursor: not-allowed;
+      opacity: 0.35;
+    }
+
+    .toolbar-btn .shortcut {
+      font-size: 11px;
+      color: #666680;
+      margin-left: 4px;
+    }
+
+    /* --- Editor panes ----------------------------------------------------- */
+
+    .editor-pane {
+      min-height: 400px;
+    }
+
+    /* Raw mode */
+    #raw-editor {
+      width: 100%;
+      min-height: 400px;
+      padding: 16px;
+      background: transparent;
+      color: #e0e0e8;
+      border: none;
+      outline: none;
+      resize: vertical;
+      font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 14px;
+      line-height: 1.6;
+      tab-size: 2;
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
+    }
+
+    #raw-editor::placeholder {
+      color: #555568;
+    }
+
+    /* Block mode container */
+    #block-container {
+      padding: 16px;
+      min-height: 400px;
+    }
+
+    /* Preview mode container */
+    #preview-container {
+      padding: 24px 20px;
+      min-height: 400px;
+    }
+
+    /* --- Preview styles --------------------------------------------------- */
+
+    #preview-container h1,
+    #preview-container h2,
+    #preview-container h3,
+    #preview-container h4,
+    #preview-container h5,
+    #preview-container h6 {
+      color: #f0f0f8;
+      margin-bottom: 0.5em;
+      line-height: 1.3;
+    }
+
+    #preview-container h1 { font-size: 2em; font-weight: 700; }
+    #preview-container h2 { font-size: 1.5em; font-weight: 600; border-bottom: 1px solid rgba(130,80,223,0.15); padding-bottom: 0.3em; }
+    #preview-container h3 { font-size: 1.25em; font-weight: 600; }
+
+    #preview-container p {
+      margin-bottom: 1em;
+      color: #c8c8d8;
+    }
+
+    #preview-container ul {
+      margin-bottom: 1em;
+      padding-left: 1.5em;
+    }
+
+    #preview-container li {
+      color: #c8c8d8;
+      margin-bottom: 0.25em;
+    }
+
+    #preview-container li::marker {
+      color: #8250df;
+    }
+
+    #preview-container pre {
+      background: rgba(130, 80, 223, 0.06);
+      border: 1px solid rgba(130, 80, 223, 0.12);
+      border-radius: 6px;
+      padding: 12px 16px;
+      margin-bottom: 1em;
+      overflow-x: auto;
+    }
+
+    #preview-container code {
+      font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 0.9em;
+      color: #c3e88d;
+    }
+
+    /* --- Responsive ------------------------------------------------------- */
+
+    @media (max-width: 640px) {
+      body {
+        padding: 12px;
+      }
+
+      header h1 {
+        font-size: 22px;
+      }
+
+      .mode-tab {
+        padding: 6px 14px;
+        font-size: 12px;
+      }
+
+      .toolbar-btn .shortcut {
+        display: none;
+      }
+
+      #raw-editor,
+      #block-container,
+      #preview-container {
+        min-height: 300px;
+        padding: 12px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1><span>&#9649;</span> Markdown Editor</h1>
+      <p class="subtitle">Block-based Markdown editing with three view modes</p>
+    </header>
+
+    <div class="examples-bar">
+      <span class="examples-label">Examples:</span>
+      <button class="example-btn" data-example="# Hello World&#10;&#10;Welcome to the Canopy Markdown editor.&#10;&#10;This editor has three modes: raw, block, and preview.">Hello</button>
+      <button class="example-btn" data-example="# Getting Started&#10;&#10;Canopy is an incremental projectional editor.&#10;&#10;## Features&#10;&#10;The editor supports real-time collaboration via CRDT.&#10;&#10;Every keystroke is incrementally parsed and projected into a structured view.">Blog</button>
+      <button class="example-btn" data-example="# Shopping List&#10;&#10;Things to pick up:&#10;&#10;- Apples&#10;- Bread&#10;- Coffee&#10;- Dark chocolate">List</button>
+      <button class="example-btn" data-example="# README&#10;&#10;A minimal example project.&#10;&#10;## Install&#10;&#10;```bash&#10;npm install&#10;```&#10;&#10;## Usage&#10;&#10;- Run the dev server&#10;- Open the browser&#10;- Start editing">Code</button>
+    </div>
+
+    <div class="mode-tabs">
+      <button class="mode-tab active" data-mode="block">Block</button>
+      <button class="mode-tab" data-mode="raw">Raw</button>
+      <button class="mode-tab" data-mode="preview">Preview</button>
+    </div>
+
+    <div class="editor-panel">
+      <div class="toolbar" id="toolbar" data-no-blur>
+        <div class="toolbar-group">
+          <button id="h1-btn" class="toolbar-btn" type="button" title="Heading 1 (Ctrl+1)" disabled>H1</button>
+          <button id="h2-btn" class="toolbar-btn" type="button" title="Heading 2 (Ctrl+2)" disabled>H2</button>
+          <button id="h3-btn" class="toolbar-btn" type="button" title="Heading 3 (Ctrl+3)" disabled>H3</button>
+        </div>
+        <div class="toolbar-divider"></div>
+        <div class="toolbar-group">
+          <button id="list-btn" class="toolbar-btn" type="button" title="Toggle list (Ctrl+Shift+L)" disabled>List</button>
+        </div>
+        <div class="toolbar-divider"></div>
+        <div class="toolbar-group">
+          <button id="delete-btn" class="toolbar-btn" type="button" title="Delete block" disabled>Delete</button>
+        </div>
+      </div>
+
+      <div class="editor-pane" id="raw-pane" hidden>
+        <textarea id="raw-editor" placeholder="Type Markdown here..." spellcheck="false"></textarea>
+      </div>
+
+      <div class="editor-pane" id="block-pane">
+        <div id="block-container"></div>
+      </div>
+
+      <div class="editor-pane" id="preview-pane" hidden>
+        <div id="preview-container"></div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/markdown-editor.ts"></script>
+</body>
+</html>

--- a/examples/web/playwright.config.ts
+++ b/examples/web/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:5190',
+  },
+  webServer: {
+    command: 'npx vite --port 5190',
+    port: 5190,
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/examples/web/src/markdown-editor.ts
+++ b/examples/web/src/markdown-editor.ts
@@ -1,0 +1,324 @@
+// Markdown Block Editor — three-mode page wiring FFI → adapters.
+
+import * as crdt from '@moonbit/crdt';
+import { BlockInput } from '../../../lib/editor-adapter/block-input';
+import { MarkdownPreview } from '../../../lib/editor-adapter/markdown-preview';
+import '../../../lib/editor-adapter/block-input.css';
+import type { ViewPatch, UserIntent } from '../../../lib/editor-adapter/types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TEXT = `# Hello World
+
+Welcome to the Canopy Markdown editor.
+
+This editor has three modes: raw, block, and preview.
+`;
+
+type Mode = 'raw' | 'block' | 'preview';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const agentId = `md-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const handle = crdt.create_markdown_editor(agentId);
+
+let activeMode: Mode = 'block';
+let activeNodeId: number | null = null;
+let rawSyncScheduled = false;
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+function must<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Missing element #${id}`);
+  return el as T;
+}
+
+const rawPane = must<HTMLDivElement>('raw-pane');
+const blockPane = must<HTMLDivElement>('block-pane');
+const previewPane = must<HTMLDivElement>('preview-pane');
+const rawEditor = must<HTMLTextAreaElement>('raw-editor');
+const blockContainer = must<HTMLDivElement>('block-container');
+const previewContainer = must<HTMLDivElement>('preview-container');
+const toolbarEl = must<HTMLDivElement>('toolbar');
+
+const h1Btn = must<HTMLButtonElement>('h1-btn');
+const h2Btn = must<HTMLButtonElement>('h2-btn');
+const h3Btn = must<HTMLButtonElement>('h3-btn');
+const listBtn = must<HTMLButtonElement>('list-btn');
+const deleteBtn = must<HTMLButtonElement>('delete-btn');
+
+const modeTabs = document.querySelectorAll<HTMLButtonElement>('.mode-tab');
+
+// ---------------------------------------------------------------------------
+// Adapters
+// ---------------------------------------------------------------------------
+
+const blockInput = new BlockInput(blockContainer);
+const preview = new MarkdownPreview(previewContainer);
+
+// ---------------------------------------------------------------------------
+// Core functions
+// ---------------------------------------------------------------------------
+
+function refresh(): void {
+  const patchesJson = crdt.markdown_compute_view_patches_json(handle);
+  const patches: ViewPatch[] = JSON.parse(patchesJson);
+  blockInput.applyPatches(patches);
+  preview.applyPatches(patches);
+}
+
+function syncRawFromModel(): void {
+  const text = crdt.markdown_get_text(handle);
+  if (rawEditor.value !== text) rawEditor.value = text;
+}
+
+function applyEdit(op: string, nodeId: number, param1: string, param2: number): boolean {
+  const resultJson: string = crdt.markdown_apply_edit(
+    handle, op, nodeId, param1, param2, Date.now(),
+  );
+  const result = JSON.parse(resultJson);
+  refresh();
+  syncRawFromModel();
+  if (result.status === 'error') {
+    console.error('[canopy] edit error:', result.message);
+    return false;
+  }
+  return true;
+}
+
+/** Read ordered block IDs from the rendered DOM. */
+function getBlockIds(): number[] {
+  return Array.from(blockContainer.querySelectorAll<HTMLElement>('[data-node-id]'))
+    .map(el => parseInt(el.dataset.nodeId!, 10))
+    .filter(id => !isNaN(id));
+}
+
+function selectBlock(id: number): void {
+  blockInput.applyPatches([{ type: 'SelectNode', node_id: id }]);
+  activeNodeId = id;
+  updateToolbar();
+}
+
+/** Read the active block's kind and heading level from the DOM. */
+function getActiveBlockInfo(): { kind: string; level: number } | null {
+  if (activeNodeId === null) return null;
+  const div = blockContainer.querySelector<HTMLElement>(
+    `[data-node-id="${activeNodeId}"]`,
+  );
+  if (!div) return null;
+  const kind = div.dataset.kind ?? '';
+  // kind_tag is "H1"–"H6" for headings
+  const levelMatch = kind.match(/^H(\d)$/);
+  const level = levelMatch ? parseInt(levelMatch[1], 10) : 0;
+  return { kind, level };
+}
+
+// ---------------------------------------------------------------------------
+// Intent handling (BlockInput → FFI)
+// ---------------------------------------------------------------------------
+
+blockInput.onIntent((intent: UserIntent) => {
+  switch (intent.type) {
+    case 'CommitEdit':
+      applyEdit('commit_edit', intent.node_id, intent.value, 0);
+      break;
+
+    case 'StructuralEdit': {
+      const { op, node_id: nodeId, params } = intent;
+      const blocksBefore = getBlockIds();
+      const index = blocksBefore.indexOf(nodeId);
+
+      applyEdit(op, nodeId, '', parseInt(params.offset || '0'));
+
+      // Focus management: move to new/adjacent block after structural edit
+      const blocksAfter = getBlockIds();
+      if (op === 'insert_block_after' || op === 'split_block') {
+        const target = blocksAfter[index + 1];
+        if (target != null) selectBlock(target);
+      } else if (op === 'merge_with_previous' && index > 0) {
+        const target = blocksAfter[index - 1];
+        if (target != null) selectBlock(target);
+      }
+      break;
+    }
+
+    case 'SelectNode':
+      activeNodeId = intent.node_id;
+      updateToolbar();
+      break;
+
+    default:
+      break;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Raw mode input
+// ---------------------------------------------------------------------------
+
+rawEditor.addEventListener('input', () => {
+  if (rawSyncScheduled) return;
+  rawSyncScheduled = true;
+  requestAnimationFrame(() => {
+    rawSyncScheduled = false;
+    crdt.markdown_set_text(handle, rawEditor.value);
+    refresh();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode switching
+// ---------------------------------------------------------------------------
+
+function setMode(mode: Mode): void {
+  if (mode === activeMode) return;
+
+  // Sync from current mode before switching
+  if (activeMode === 'raw') {
+    crdt.markdown_set_text(handle, rawEditor.value);
+    refresh();
+  }
+
+  activeMode = mode;
+
+  // Show/hide panes
+  rawPane.hidden = mode !== 'raw';
+  blockPane.hidden = mode !== 'block';
+  previewPane.hidden = mode !== 'preview';
+  toolbarEl.hidden = mode !== 'block';
+
+  // Sync to new mode
+  if (mode === 'raw') {
+    syncRawFromModel();
+    rawEditor.focus();
+  }
+
+  // Update tab styles
+  modeTabs.forEach(tab => {
+    tab.classList.toggle('active', tab.dataset.mode === mode);
+  });
+
+  updateToolbar();
+}
+
+modeTabs.forEach(tab => {
+  tab.addEventListener('click', () => {
+    setMode(tab.dataset.mode as Mode);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Toolbar
+// ---------------------------------------------------------------------------
+
+function updateToolbar(): void {
+  const hasSelection = activeNodeId !== null && activeMode === 'block';
+  h1Btn.disabled = !hasSelection;
+  h2Btn.disabled = !hasSelection;
+  h3Btn.disabled = !hasSelection;
+  listBtn.disabled = !hasSelection;
+  deleteBtn.disabled = !hasSelection;
+}
+
+/** Toggle heading level: clicking the same level reverts to paragraph (level 0). */
+function toggleHeading(level: number): void {
+  if (activeNodeId == null) return;
+  const info = getActiveBlockInfo();
+  const targetLevel = info && info.level === level ? 0 : level;
+  applyEdit('change_heading_level', activeNodeId, '', targetLevel);
+}
+
+h1Btn.addEventListener('click', () => toggleHeading(1));
+h2Btn.addEventListener('click', () => toggleHeading(2));
+h3Btn.addEventListener('click', () => toggleHeading(3));
+
+listBtn.addEventListener('click', () => {
+  if (activeNodeId != null) applyEdit('toggle_list_item', activeNodeId, '', 0);
+});
+
+deleteBtn.addEventListener('click', () => {
+  if (activeNodeId == null) return;
+  const blocksBefore = getBlockIds();
+  const index = blocksBefore.indexOf(activeNodeId);
+  applyEdit('delete', activeNodeId, '', 0);
+  // Focus the next (or previous) block after deletion
+  const blocksAfter = getBlockIds();
+  if (blocksAfter.length > 0) {
+    const nextIndex = Math.min(index, blocksAfter.length - 1);
+    selectBlock(blocksAfter[nextIndex]);
+  } else {
+    activeNodeId = null;
+    updateToolbar();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard shortcuts (block mode)
+// ---------------------------------------------------------------------------
+
+document.addEventListener('keydown', (e) => {
+  if (activeMode !== 'block' || activeNodeId === null) return;
+  if (e.isComposing) return;
+
+  // Ctrl+1–6: toggle heading level
+  if (e.ctrlKey && !e.shiftKey && e.key >= '1' && e.key <= '6') {
+    e.preventDefault();
+    toggleHeading(parseInt(e.key));
+    return;
+  }
+
+  // Ctrl+0: revert to paragraph
+  if (e.ctrlKey && !e.shiftKey && e.key === '0') {
+    e.preventDefault();
+    applyEdit('change_heading_level', activeNodeId, '', 0);
+    return;
+  }
+
+  // Ctrl+Shift+L: toggle list
+  if (e.ctrlKey && e.shiftKey && (e.key === 'l' || e.key === 'L')) {
+    e.preventDefault();
+    applyEdit('toggle_list_item', activeNodeId, '', 0);
+    return;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Examples
+// ---------------------------------------------------------------------------
+
+document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const text = btn.dataset.example ?? DEFAULT_TEXT;
+    crdt.markdown_set_text(handle, text);
+    syncRawFromModel();
+    activeNodeId = null;
+    refresh();
+    updateToolbar();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+window.addEventListener('beforeunload', () => {
+  blockInput.destroy();
+  preview.destroy();
+  crdt.destroy_markdown_editor(handle);
+});
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+crdt.markdown_set_text(handle, DEFAULT_TEXT);
+syncRawFromModel();
+refresh();
+updateToolbar();

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -1,0 +1,145 @@
+// Markdown block editor — fundamental invariant tests.
+// Tests the editor's contract, not UI surface details.
+// Uses built-in example presets to avoid text-sync timing issues.
+
+import { test, expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Get all visible block texts from the block-mode container. */
+async function blockTexts(page: Page): Promise<string[]> {
+  return page.locator('#block-container .block-text').allTextContents();
+}
+
+/** Switch to a mode tab and wait for the pane to appear. */
+async function switchMode(page: Page, mode: 'Block' | 'Raw' | 'Preview') {
+  await page.locator(`button.mode-tab:has-text("${mode}")`).click();
+  const paneId =
+    mode === 'Block' ? '#block-pane' :
+    mode === 'Raw' ? '#raw-pane' :
+    '#preview-pane';
+  await expect(page.locator(paneId)).toBeVisible();
+}
+
+/** Load an example preset and wait for blocks to render. */
+async function loadExample(page: Page, name: 'Hello' | 'Blog' | 'List' | 'Code') {
+  await page.locator(`button.example-btn:has-text("${name}")`).click();
+  await expect(page.locator('#block-container .block-text').first()).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/markdown.html');
+  await expect(page.locator('#block-container .block-text').first()).toBeVisible();
+});
+
+test.describe('Markdown Block Editor', () => {
+
+  test('blocks render from Markdown source', async ({ page }) => {
+    // Default text loads blocks with content
+    const texts = await blockTexts(page);
+    expect(texts.length).toBeGreaterThanOrEqual(2);
+    // Every block has non-empty text
+    for (const t of texts) {
+      expect(t.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('block edit round-trips through raw', async ({ page }) => {
+    // Load a simple example
+    await loadExample(page, 'Hello');
+    const originalTexts = await blockTexts(page);
+    const originalSecond = originalTexts[1]; // a paragraph
+
+    // Click the second block and edit it
+    await page.locator('#block-container .block').nth(1).click();
+    await expect(page.locator('.block-textarea')).toBeVisible();
+    const textarea = page.locator('.block-textarea');
+    await textarea.fill('Edited paragraph.');
+
+    // Switch to Raw — verify the Markdown source reflects the edit
+    await switchMode(page, 'Raw');
+    const raw = await page.locator('#raw-editor').inputValue();
+    expect(raw).toContain('Edited paragraph.');
+    // Original heading should still be present
+    expect(raw).toContain('# Hello World');
+    // Original paragraph text should NOT be present
+    expect(raw).not.toContain(originalSecond);
+  });
+
+  test('mode switching is lossless', async ({ page }) => {
+    // Load the List example (has heading + paragraph + list items)
+    await loadExample(page, 'List');
+    const originalTexts = await blockTexts(page);
+
+    // Cycle through all modes: Block → Raw → Preview → Block
+    await switchMode(page, 'Raw');
+    const raw = await page.locator('#raw-editor').inputValue();
+    // Raw should contain Markdown syntax
+    expect(raw).toContain('#');
+
+    await switchMode(page, 'Preview');
+    await switchMode(page, 'Block');
+
+    // Same block texts after full cycle
+    const afterCycle = await blockTexts(page);
+    expect(afterCycle).toEqual(originalTexts);
+  });
+
+  test('structural edit produces valid Markdown', async ({ page }) => {
+    // Load Hello example (heading + paragraphs)
+    await loadExample(page, 'Hello');
+
+    // Get raw source before edit
+    await switchMode(page, 'Raw');
+    const rawBefore = await page.locator('#raw-editor').inputValue();
+    await switchMode(page, 'Block');
+
+    // Click a paragraph block and edit: type new text, then press Enter to split
+    await page.locator('#block-container .block').nth(1).click();
+    await expect(page.locator('.block-textarea')).toBeVisible();
+    const textarea = page.locator('.block-textarea');
+    const originalText = await textarea.inputValue();
+
+    // Press Enter at end → inserts new block (raw source grows)
+    await textarea.press('End');
+    await textarea.press('Enter');
+    await page.waitForTimeout(300);
+
+    // Verify the raw source changed and is valid Markdown
+    await switchMode(page, 'Raw');
+    const rawAfter = await page.locator('#raw-editor').inputValue();
+    // Source should have grown (extra blank line for the new block)
+    expect(rawAfter.length).toBeGreaterThan(rawBefore.length);
+    // Original content preserved
+    expect(rawAfter).toContain('# Hello World');
+    expect(rawAfter).toContain(originalText);
+    // No garbled output
+    expect(rawAfter).not.toContain('undefined');
+    expect(rawAfter).not.toContain('null');
+  });
+
+  test('preview produces semantic HTML', async ({ page }) => {
+    // Load Code example — has heading, paragraphs, code block, and list
+    await loadExample(page, 'Code');
+    await switchMode(page, 'Preview');
+    const container = page.locator('#preview-container');
+
+    // Heading renders as <h1> or <h2>
+    const headings = await container.locator('h1, h2').count();
+    expect(headings).toBeGreaterThanOrEqual(1);
+    // Paragraph renders as <p>
+    await expect(container.locator('p').first()).toBeVisible();
+    // List renders as <ul> with <li> children
+    await expect(container.locator('ul')).toBeVisible();
+    await expect(container.locator('li').first()).toBeVisible();
+    // Code block renders as <pre>
+    await expect(container.locator('pre')).toBeVisible();
+  });
+
+});

--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         main: 'index.html',
         json: 'json.html',
         memo: 'memo.html',
+        markdown: 'markdown.html',
       },
     },
   },

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -187,10 +187,14 @@ fn compute_insert_block_after(
     None => return Err("node not found in source map")
   }
   let insert_pos = range.end
+  // Insert "\n\u200B\n" to create a visible empty paragraph.
+  // The zero-width space gives the parser a real token to produce a ProjNode,
+  // so BlockInput can render and focus the new block. CommitEdit strips it
+  // on the first keystroke.
   Ok(
     Some(
       (
-        [SpanEdit::{ start: insert_pos, delete_len: 0, inserted: "\n" }],
+        [SpanEdit::{ start: insert_pos, delete_len: 0, inserted: "\n\u200B\n" }],
         FocusHint::MoveCursor(position=insert_pos + 1),
       ),
     ),

--- a/lib/editor-adapter/block-input.css
+++ b/lib/editor-adapter/block-input.css
@@ -8,6 +8,13 @@
 
 /* --- Block base --------------------------------------------------------- */
 
+/* Reset default margins for semantic elements used as blocks */
+.block-editor h1, .block-editor h2, .block-editor h3,
+.block-editor h4, .block-editor h5, .block-editor h6,
+.block-editor p, .block-editor pre {
+  margin: 0;
+}
+
 .block {
   position: relative;
   padding: 4px 8px;
@@ -28,24 +35,32 @@
 
 /* --- Block kinds -------------------------------------------------------- */
 
-.block[data-kind="heading"] {
-  font-size: 1.5em;
+/* Headings: kind_tag is "H1"–"H6" */
+.block[data-kind^="H"] {
   font-weight: 700;
   line-height: 1.3;
 }
 
-.block[data-kind="list_item"] {
+.block[data-kind="H1"] { font-size: 2em; }
+.block[data-kind="H2"] { font-size: 1.5em; font-weight: 600; }
+.block[data-kind="H3"] { font-size: 1.25em; font-weight: 600; }
+.block[data-kind="H4"] { font-size: 1.1em; font-weight: 600; }
+.block[data-kind="H5"],
+.block[data-kind="H6"] { font-size: 1em; font-weight: 600; }
+
+.block[data-kind="ListItem"] {
   padding-left: 24px;
 }
 
-.block[data-kind="list_item"]::before {
+.block[data-kind="ListItem"]::before {
   content: "\2022 ";
   position: absolute;
   left: 8px;
   color: #666;
 }
 
-.block[data-kind="code_block"] {
+/* Code blocks: kind_tag is "Code" or "Code(lang)" */
+.block[data-kind^="Code"] {
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   font-size: 0.9em;
   background: rgba(130, 80, 223, 0.04);

--- a/lib/editor-adapter/block-input.ts
+++ b/lib/editor-adapter/block-input.ts
@@ -94,36 +94,46 @@ export class BlockInput implements EditorAdapter {
     return result;
   }
 
-  private createBlockDiv(node: ViewNode): HTMLDivElement {
-    const div = document.createElement('div');
-    div.className = 'block' + (node.id === this.activeBlockId ? ' active' : '');
-    if (node.css_class) div.className += ' ' + node.css_class;
-    div.dataset.nodeId = String(node.id);
-    div.dataset.kind = node.kind_tag;
-
-    // Accessibility for headings
-    if (node.kind_tag === 'heading') {
-      div.setAttribute('role', 'heading');
-      const level = this.headingLevel(node.css_class);
-      div.setAttribute('aria-level', String(level));
-    }
+  /** Create a semantic block element based on kind_tag. */
+  private createBlockDiv(node: ViewNode): HTMLElement {
+    const el = this.semanticBlockElement(node.kind_tag);
+    el.className = 'block' + (node.id === this.activeBlockId ? ' active' : '');
+    if (node.css_class) el.className += ' ' + node.css_class;
+    el.dataset.nodeId = String(node.id);
+    el.dataset.kind = node.kind_tag;
 
     const textSpan = document.createElement('span');
     textSpan.className = 'block-text';
-    textSpan.textContent = node.text ?? '';
-    div.appendChild(textSpan);
+    // Strip ZWSP placeholder so empty blocks show as truly empty
+    textSpan.textContent = (node.text ?? '').replace(/\u200B/g, '');
+    el.appendChild(textSpan);
 
-    div.addEventListener('click', (e) => {
+    el.addEventListener('click', (e) => {
       e.stopPropagation();
       this.activateBlock(node.id);
     });
 
-    return div;
+    return el;
   }
 
-  private headingLevel(cssClass: string): number {
-    const m = cssClass.match(/heading-(\d)/);
-    return m ? parseInt(m[1], 10) : 1;
+  /** Map kind_tag to the appropriate semantic HTML element. */
+  private semanticBlockElement(kindTag: string): HTMLElement {
+    const hLevel = this.headingLevelFromTag(kindTag);
+    if (hLevel > 0) return document.createElement(`h${hLevel}`);
+    switch (kindTag) {
+      case 'Paragraph': return document.createElement('p');
+      case 'ListItem': return document.createElement('p');
+      default:
+        if (kindTag.startsWith('Code'))
+          return document.createElement('pre');
+        return document.createElement('div');
+    }
+  }
+
+  /** Extract heading level from kind_tag like "H1" → 1, or 0 if not a heading. */
+  private headingLevelFromTag(kindTag: string): number {
+    const m = kindTag.match(/^H(\d)$/);
+    return m ? parseInt(m[1], 10) : 0;
   }
 
   // --- Patch helpers -------------------------------------------------------
@@ -221,7 +231,8 @@ export class BlockInput implements EditorAdapter {
     if (!node || !div) return;
 
     div.appendChild(ta);
-    ta.value = node.text ?? '';
+    // Strip ZWSP placeholder (inserted by InsertBlockAfter for empty blocks)
+    ta.value = (node.text ?? '').replace(/\u200B/g, '');
 
     // Match font from the block div
     const style = getComputedStyle(div);
@@ -270,7 +281,7 @@ export class BlockInput implements EditorAdapter {
     this.emit({
       type: 'CommitEdit',
       node_id: this.activeBlockId,
-      value: ta.value,
+      value: ta.value.replace(/\u200B/g, ''),
     });
 
     // Re-sync text span under the textarea

--- a/lib/editor-adapter/markdown-preview.ts
+++ b/lib/editor-adapter/markdown-preview.ts
@@ -3,31 +3,34 @@
 import type { EditorAdapter } from './adapter';
 import type { ViewNode, ViewPatch, UserIntent } from './types';
 
-/** Extract heading level from css_class like "heading-2" → 2, default 1 */
-function headingLevel(cssClass: string): number {
-  const m = cssClass.match(/heading-(\d)/);
-  return m ? Math.min(Math.max(Number(m[1]), 1), 6) : 1;
+/** Extract heading level from kind_tag like "H2" → 2, or 0 if not a heading */
+function headingLevel(kindTag: string): number {
+  const m = kindTag.match(/^H(\d)$/);
+  return m ? Math.min(Math.max(Number(m[1]), 1), 6) : 0;
 }
 
 /** Create the appropriate semantic element for a ViewNode based on kind_tag */
 function semanticTag(node: ViewNode): HTMLElement {
+  // Headings: kind_tag is "H1"–"H6"
+  const hLevel = headingLevel(node.kind_tag);
+  if (hLevel > 0) {
+    return document.createElement(`h${hLevel}`);
+  }
   switch (node.kind_tag) {
-    case 'heading':
-      return document.createElement(`h${headingLevel(node.css_class)}`);
-    case 'paragraph':
+    case 'Paragraph':
       return document.createElement('p');
-    case 'unordered_list':
+    case 'List':
       return document.createElement('ul');
-    case 'list_item':
+    case 'ListItem':
       return document.createElement('li');
-    case 'code_block': {
-      const pre = document.createElement('pre');
-      const code = document.createElement('code');
-      pre.appendChild(code);
-      return pre;
-    }
-    case 'document':
     default:
+      // Code blocks: kind_tag is "Code" or "Code(lang)"
+      if (node.kind_tag.startsWith('Code')) {
+        const pre = document.createElement('pre');
+        const code = document.createElement('code');
+        pre.appendChild(code);
+        return pre;
+      }
       return document.createElement('div');
   }
 }
@@ -37,9 +40,9 @@ function renderNode(node: ViewNode): HTMLElement {
   el.setAttribute('data-node-id', String(node.id));
   if (node.css_class) el.className = node.css_class;
 
-  // For code_block, text goes inside the <code> child
-  const textTarget = node.kind_tag === 'code_block'
-    ? el.querySelector('code')!
+  // For code blocks (kind_tag "Code" or "Code(lang)"), text goes inside the <code> child
+  const textTarget = node.kind_tag.startsWith('Code')
+    ? (el.querySelector('code') ?? el)
     : el;
 
   const text = node.text ?? node.label;

--- a/protocol/convert.mbt
+++ b/protocol/convert.mbt
@@ -8,6 +8,7 @@ pub fn[T : @loomcore.Renderable] proj_to_view_node(
   node : @core.ProjNode[T],
   source_map : @core.SourceMap,
   annotations? : Map[@core.NodeId, Array[ViewAnnotation]] = {},
+  source_text? : String? = None,
 ) -> ViewNode {
   let node_id = node.id()
   let kind_tag = @loomcore.Renderable::kind_tag(node.kind)
@@ -24,24 +25,46 @@ pub fn[T : @loomcore.Renderable] proj_to_view_node(
       }
     None => ()
   }
+  // Extract visible text from "text" or "code" token span when source_text is provided
+  let text : String? = match source_text {
+    Some(src) =>
+      match source_map.token_spans.get(node_id) {
+        Some(roles) =>
+          match roles.get("text") {
+            Some(range) => Some(src[range.start:range.end].to_string())
+            None =>
+              match roles.get("code") {
+                Some(range) => Some(src[range.start:range.end].to_string())
+                None => None
+              }
+          }
+        None => None
+      }
+    None => None
+  }
+  let editable = text is Some(_)
   let children : Array[ViewNode] = []
   for child in node.children {
-    children.push(proj_to_view_node(child, source_map, annotations~))
+    children.push(
+      proj_to_view_node(child, source_map, annotations~, source_text~),
+    )
   }
   let node_annotations = match annotations.get(node_id) {
     Some(anns) => anns
     None => []
   }
-  ViewNode(
-    id=node_id,
-    kind_tag~,
-    label~,
-    text_range~,
-    token_spans~,
-    css_class=kind_tag,
-    children~,
-    annotations=node_annotations,
-  )
+  {
+    id: node_id,
+    kind_tag,
+    label,
+    text,
+    text_range,
+    token_spans,
+    editable,
+    css_class: kind_tag,
+    children,
+    annotations: node_annotations,
+  }
 }
 
 ///|

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 // Values
 pub fn layout_to_view_tree(@pretty.Layout[@pretty.SyntaxCategory], width? : Int) -> ViewNode
 
-pub fn[T : @dowdiness/loom/core.Renderable] proj_to_view_node(@dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap, annotations? : Map[@dowdiness/canopy/core.NodeId, Array[ViewAnnotation]]) -> ViewNode
+pub fn[T : @dowdiness/loom/core.Renderable] proj_to_view_node(@dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap, annotations? : Map[@dowdiness/canopy/core.NodeId, Array[ViewAnnotation]], source_text? : String?) -> ViewNode
 
 // Errors
 


### PR DESCRIPTION
## Summary

- **Sub-project 4** of the Markdown block editor: web page with three view modes (Block / Raw / Preview)
- Wires FFI → BlockInput + MarkdownPreview adapters with mode switching, toolbar, keyboard shortcuts
- Fixes integration issues discovered during testing: ViewNode text/editable population, diff patching, semantic HTML, empty block visibility

## What changed

**New files:**
- `examples/web/markdown.html` — three-mode page with Canopy design
- `examples/web/src/markdown-editor.ts` — glue code (FFI → adapters, mode switching, toolbar)
- `examples/web/playwright.config.ts` + `tests/markdown-editor.spec.ts` — 5 e2e invariant tests

**Integration fixes:**
- `protocol/convert.mbt` — `proj_to_view_node` accepts optional `source_text` to populate `text`/`editable` from token spans
- `editor/view_updater.mbt` — passes source text; `diff_view_nodes` uses `prev.id` in ReplaceNode
- `lib/editor-adapter/block-input.ts` — semantic HTML elements (`<h1>`–`<h6>`, `<p>`, `<pre>`); kind_tag matching for MoonBit output
- `lib/editor-adapter/markdown-preview.ts` — kind_tag matching; code block rendering fix
- `lang/markdown/edits/compute_markdown_edit.mbt` — `InsertBlockAfter` inserts ZWSP placeholder for visible empty blocks

## Test plan

- [x] `moon test` — 815 tests pass
- [x] `npx playwright test` — 5 e2e tests pass (blocks render, edit round-trip, lossless mode switching, structural edits, semantic preview)
- [x] Manual testing: Block/Raw/Preview modes, toolbar, keyboard shortcuts, example presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three-mode Markdown editor (Block / Raw / Preview) with live sync, toolbar, shortcuts, presets, and real-time semantic preview
* **Bug Fixes**
  * Improved handling of invisible placeholder characters to prevent leaks into raw Markdown
  * More reliable block rendering and cursor behavior after edits
* **Tests**
  * End-to-end Playwright suite validating editor invariants and mode cycling
* **Style**
  * Updated block editor styling and semantic element rendering
* **Documentation**
  * Added UI/visual workflow guidance and an editor backlog task for ZWSP cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->