### PR TITLE
feat: add rose tree zipper library (lib/zipper)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -513,6 +513,18 @@ Post-consolidation app inventory:
 
 ---
 
+## 20. Generic Zipper Library
+
+**Impact:** Medium | **Effort:** Medium | **Status:** Phase 1 Done
+
+- [x] **Phase 1: Rose tree zipper** — ✅ Done (PR #130). `lib/zipper/` standalone module (`dowdiness/zipper`) with `RoseNode[T]`, `RoseCtx[T]`, `RoseZipper[T]`. 36 tests (33 blackbox + 3 @qc properties), full API in `pkg.generated.mbti`.
+  Plan: `docs/plans/2026-04-07-rose-tree-zipper-impl.md`
+  Design: `docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md`
+- [ ] **Phase 2: Annotation trait** — ScopeProvider, DepthCounter as Self-Closed Algebra traits.
+- [ ] **Phase 3: B-tree zipper** — Refactor OrderTree's `Cursor[T]` to use generic btree zipper.
+
+---
+
 ## Priority Ranking
 
 | # | Proposal | Effort | Impact |

--- a/docs/plans/2026-04-07-rose-tree-zipper-impl.md
+++ b/docs/plans/2026-04-07-rose-tree-zipper-impl.md
@@ -1,0 +1,984 @@
+# Rose Tree Zipper Library Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `dowdiness/zipper` — a standalone, persistent rose tree zipper library in MoonBit.
+
+**Architecture:** Three types (`RoseNode[T]`, `RoseCtx[T]`, `RoseZipper[T]`) with hybrid Array/List representation. `Array` for children in nodes; `@list.List` for siblings in contexts (O(1) lateral movement). Navigation methods return `Option` at boundaries. All operations are persistent — old zippers remain valid.
+
+**Tech Stack:** MoonBit, `moonbitlang/core` (List, quickcheck)
+
+**Design spec:** `docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md`
+
+**Semantic note:** `focus_at` is strict (returns `None` on invalid path), unlike the existing lambda zipper's `focus_at` which does best-effort prefix navigation. Bridge consumers that rely on the old behavior should not switch without a wrapper.
+
+**Acceptance criteria:**
+1. `cd lib/zipper && moon check` passes with 0 errors, 0 warnings (except deprecated core imports if any)
+2. `cd lib/zipper && moon test` passes all tests
+3. `moon check` (canopy root) passes — no regressions
+4. `lib/zipper/pkg.generated.mbti` exports exactly: `RoseNode::new`, `RoseZipper::from_root`, `go_down`, `go_up`, `go_left`, `go_right`, `to_tree`, `replace`, `modify`, `depth`, `child_index`, `is_root`, `is_leaf`, `num_children`, `to_path`, `focus_at`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `lib/zipper/moon.mod.json` | Module declaration: `dowdiness/zipper` |
+| `lib/zipper/moon.pkg` | Package config with `@list` import |
+| `lib/zipper/rose_node.mbt` | `RoseNode[T]`, `RoseCtx[T]`, `RoseZipper[T]` types + constructors |
+| `lib/zipper/navigate.mbt` | Navigation, reconstruction, modification, queries, path operations |
+| `lib/zipper/zipper_test.mbt` | Black-box tests (round-trips, boundaries, persistence) |
+
+---
+
+### Task 1: Create module scaffolding
+
+**Files:**
+- Create: `lib/zipper/moon.mod.json`
+- Create: `lib/zipper/moon.pkg`
+
+- [ ] **Step 1: Create `moon.mod.json`**
+
+```json
+{
+  "name": "dowdiness/zipper",
+  "version": "0.1.0",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": ["zipper", "rose-tree", "data-structure", "moonbit"],
+  "description": "Persistent rose tree zipper — generic, correct, O(1) lateral navigation"
+}
+```
+
+- [ ] **Step 2: Create `moon.pkg`**
+
+```text
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/list" @list,
+}
+```
+
+- [ ] **Step 3: Create a minimal placeholder source file**
+
+Create `lib/zipper/rose_node.mbt` with just a comment so `moon check` has something to compile:
+
+```moonbit
+// Rose tree zipper library — types and constructors.
+```
+
+- [ ] **Step 4: Verify the module compiles**
+
+Run: `cd lib/zipper && moon check`
+Expected: PASS (0 errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/moon.mod.json lib/zipper/moon.pkg lib/zipper/rose_node.mbt
+git commit -m "chore: scaffold dowdiness/zipper module"
+```
+
+---
+
+### Task 2: Define types and constructors
+
+**Files:**
+- Modify: `lib/zipper/rose_node.mbt`
+
+- [ ] **Step 1: Write test for RoseNode construction**
+
+Create `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "RoseNode leaf and internal construction" {
+  let leaf = RoseNode::new(data=1)
+  inspect(leaf.data, content="1")
+  inspect(leaf.children.length(), content="0")
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  inspect(tree.children.length(), content="3")
+  inspect(tree.children[1].data, content="2")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd lib/zipper && moon test`
+Expected: FAIL — `RoseNode` not defined.
+
+- [ ] **Step 3: Implement types and constructors in `rose_node.mbt`**
+
+```moonbit
+// Rose tree zipper library — types and constructors.
+//
+// RoseNode[T]: a node carrying data of type T with ordered children.
+// RoseCtx[T]: one-hole context (derivative of RoseNode).
+// RoseZipper[T]: focused position within a RoseNode tree.
+
+///|
+pub(all) struct RoseNode[T] {
+  data : T
+  children : Array[RoseNode[T]]
+} derive(Debug, Eq)
+
+///|
+pub fn[T] RoseNode::new(
+  data~ : T,
+  children? : Array[RoseNode[T]] = [],
+) -> RoseNode[T] {
+  { data, children }
+}
+
+///|
+pub(all) struct RoseCtx[T] {
+  data : T
+  left : @list.List[RoseNode[T]]
+  right : @list.List[RoseNode[T]]
+  index : Int
+} derive(Debug, Eq)
+
+///|
+pub(all) struct RoseZipper[T] {
+  focus : RoseNode[T]
+  path : @list.List[RoseCtx[T]]
+  depth : Int
+} derive(Debug, Eq)
+
+///|
+pub fn[T] RoseZipper::from_root(tree : RoseNode[T]) -> RoseZipper[T] {
+  { focus: tree, path: @list.List::default(), depth: 0 }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Add from_root test**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "from_root creates zipper at root" {
+  let tree = RoseNode::new(data="hello")
+  let z = RoseZipper::from_root(tree)
+  inspect(z.focus.data, content="hello")
+  inspect(z.depth(), content="0")
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (2 tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/zipper/rose_node.mbt lib/zipper/zipper_test.mbt
+git commit -m "feat(zipper): add RoseNode, RoseCtx, RoseZipper types and constructors"
+```
+
+---
+
+### Task 3: Implement go_down and go_up
+
+**Files:**
+- Create: `lib/zipper/navigate.mbt`
+- Modify: `lib/zipper/zipper_test.mbt`
+
+- [ ] **Step 1: Write tests for go_down and go_up**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "go_down to first child" {
+  let tree = RoseNode::new(data="root", children=[
+    RoseNode::new(data="a"),
+    RoseNode::new(data="b"),
+    RoseNode::new(data="c"),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z1 = z.go_down().unwrap()
+  inspect(z1.focus.data, content="a")
+  inspect(z1.depth(), content="1")
+}
+
+test "go_down with index" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=10),
+    RoseNode::new(data=20),
+    RoseNode::new(data=30),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.go_down(index=2).unwrap()
+  inspect(z2.focus.data, content="30")
+}
+
+test "go_down boundary: leaf returns None" {
+  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  inspect(z.go_down(), content="None")
+}
+
+test "go_down boundary: negative index returns None" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.go_down(index=-1), content="None")
+}
+
+test "go_down boundary: out of bounds returns None" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.go_down(index=5), content="None")
+}
+
+test "go_up from child returns parent" {
+  let tree = RoseNode::new(data="root", children=[
+    RoseNode::new(data="a"),
+    RoseNode::new(data="b"),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  let z2 = z.go_up().unwrap()
+  inspect(z2.focus.data, content="root")
+  inspect(z2.depth(), content="0")
+}
+
+test "go_up at root returns None" {
+  let z = RoseZipper::from_root(RoseNode::new(data=42))
+  inspect(z.go_up(), content="None")
+}
+
+test "go_down then go_up round-trip preserves tree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
+    RoseNode::new(data=3),
+    RoseNode::new(data=4),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.go_down().unwrap().go_up().unwrap()
+  assert_eq(z2.focus, tree)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd lib/zipper && moon test`
+Expected: FAIL — `go_down` and `go_up` not defined.
+
+- [ ] **Step 3: Implement go_down in `navigate.mbt`**
+
+Create `lib/zipper/navigate.mbt`:
+
+```moonbit
+// Navigation, reconstruction, modification, and query operations for RoseZipper.
+
+///|
+pub fn[T] RoseZipper::go_down(
+  self : RoseZipper[T],
+  index? : Int = 0,
+) -> RoseZipper[T]? {
+  if index < 0 || index >= self.focus.children.length() {
+    return None
+  }
+  let children = self.focus.children
+  let mut left : @list.List[RoseNode[T]] = @list.List::default()
+  for i in 0..<index {
+    left = @list.cons(children[i], left)
+  }
+  let mut right : @list.List[RoseNode[T]] = @list.List::default()
+  for i = children.length() - 1; i > index; i = i - 1 {
+    right = @list.cons(children[i], right)
+  }
+  let ctx : RoseCtx[T] = {
+    data: self.focus.data,
+    left,
+    right,
+    index,
+  }
+  Some({
+    focus: children[index],
+    path: @list.cons(ctx, self.path),
+    depth: self.depth + 1,
+  })
+}
+```
+
+- [ ] **Step 4: Implement go_up**
+
+Append to `lib/zipper/navigate.mbt`:
+
+```moonbit
+///|
+pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
+  match self.path {
+    Empty => None
+    More(ctx, tail=rest) => {
+      let children : Array[RoseNode[T]] = ctx.left.rev().to_array()
+      children.push(self.focus)
+      ctx.right.each(fn(n) { children.push(n) })
+      let parent = RoseNode::new(data=ctx.data, children~)
+      Some({ focus: parent, path: rest, depth: self.depth - 1 })
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (all tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/zipper/navigate.mbt lib/zipper/zipper_test.mbt
+git commit -m "feat(zipper): implement go_down and go_up navigation"
+```
+
+---
+
+### Task 4: Implement go_left and go_right
+
+**Files:**
+- Modify: `lib/zipper/navigate.mbt`
+- Modify: `lib/zipper/zipper_test.mbt`
+
+- [ ] **Step 1: Write tests for go_left and go_right**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "go_right traverses siblings" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  inspect(z.focus.data, content="1")
+  let z2 = z.go_right().unwrap()
+  inspect(z2.focus.data, content="2")
+  let z3 = z2.go_right().unwrap()
+  inspect(z3.focus.data, content="3")
+  inspect(z3.go_right(), content="None")
+}
+
+test "go_left traverses siblings backward" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down(index=2).unwrap()
+  inspect(z.focus.data, content="3")
+  let z2 = z.go_left().unwrap()
+  inspect(z2.focus.data, content="2")
+  let z3 = z2.go_left().unwrap()
+  inspect(z3.focus.data, content="1")
+  inspect(z3.go_left(), content="None")
+}
+
+test "go_left at first child returns None" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  inspect(z.go_left(), content="None")
+}
+
+test "go_left and go_right at root return None" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.go_left(), content="None")
+  inspect(z.go_right(), content="None")
+}
+
+test "go_right then go_left round-trip" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  let z2 = z.go_right().unwrap().go_left().unwrap()
+  inspect(z2.focus.data, content="1")
+}
+
+test "lateral then up preserves tree" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree)
+    .go_down().unwrap()
+    .go_right().unwrap()
+    .go_up().unwrap()
+  assert_eq(z.focus, tree)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd lib/zipper && moon test`
+Expected: FAIL — `go_left` and `go_right` not defined.
+
+- [ ] **Step 3: Implement go_left and go_right**
+
+Append to `lib/zipper/navigate.mbt`:
+
+```moonbit
+///|
+pub fn[T] RoseZipper::go_left(self : RoseZipper[T]) -> RoseZipper[T]? {
+  match self.path {
+    More(ctx, tail=rest) =>
+      match ctx.left {
+        More(sibling, tail=left_rest) => {
+          let new_right = @list.cons(self.focus, ctx.right)
+          let new_ctx : RoseCtx[T] = {
+            data: ctx.data,
+            left: left_rest,
+            right: new_right,
+            index: ctx.index - 1,
+          }
+          Some({
+            focus: sibling,
+            path: @list.cons(new_ctx, rest),
+            depth: self.depth,
+          })
+        }
+        Empty => None
+      }
+    Empty => None
+  }
+}
+
+///|
+pub fn[T] RoseZipper::go_right(self : RoseZipper[T]) -> RoseZipper[T]? {
+  match self.path {
+    More(ctx, tail=rest) =>
+      match ctx.right {
+        More(sibling, tail=right_rest) => {
+          let new_left = @list.cons(self.focus, ctx.left)
+          let new_ctx : RoseCtx[T] = {
+            data: ctx.data,
+            left: new_left,
+            right: right_rest,
+            index: ctx.index + 1,
+          }
+          Some({
+            focus: sibling,
+            path: @list.cons(new_ctx, rest),
+            depth: self.depth,
+          })
+        }
+        Empty => None
+      }
+    Empty => None
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/navigate.mbt lib/zipper/zipper_test.mbt
+git commit -m "feat(zipper): implement go_left and go_right lateral navigation"
+```
+
+---
+
+### Task 5: Implement to_tree, replace, modify
+
+**Files:**
+- Modify: `lib/zipper/navigate.mbt`
+- Modify: `lib/zipper/zipper_test.mbt`
+
+- [ ] **Step 1: Write tests**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "to_tree from root is identity" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
+    RoseNode::new(data=3),
+    RoseNode::new(data=4),
+  ])
+  assert_eq(RoseZipper::from_root(tree).to_tree(), tree)
+}
+
+test "to_tree from deep position reconstructs full tree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
+    RoseNode::new(data=3),
+    RoseNode::new(data=4),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap().go_down().unwrap()
+  inspect(z.focus.data, content="5")
+  assert_eq(z.to_tree(), tree)
+}
+
+test "replace changes focused subtree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
+  let z2 = z.replace(RoseNode::new(data=99))
+  inspect(z2.focus.data, content="99")
+  let rebuilt = z2.to_tree()
+  inspect(rebuilt.children[1].data, content="99")
+  // original focus unchanged (persistence)
+  inspect(z.focus.data, content="3")
+}
+
+test "modify transforms focused subtree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
+  let z2 = z.modify(fn(n) {
+    RoseNode::new(data=n.data * 10, children=n.children)
+  })
+  inspect(z2.focus.data, content="30")
+  // verify modify propagates through to_tree
+  let rebuilt = z2.to_tree()
+  inspect(rebuilt.children[1].data, content="30")
+  inspect(rebuilt.children[0].data, content="2")
+}
+
+test "replace at root" {
+  let tree = RoseNode::new(data=1)
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.replace(RoseNode::new(data=99))
+  inspect(z2.focus.data, content="99")
+  assert_eq(z2.to_tree(), RoseNode::new(data=99))
+}
+
+test "modify at root" {
+  let tree = RoseNode::new(data=5, children=[RoseNode::new(data=10)])
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.modify(fn(n) {
+    RoseNode::new(data=n.data * 2, children=n.children)
+  })
+  let rebuilt = z2.to_tree()
+  inspect(rebuilt.data, content="10")
+  inspect(rebuilt.children[0].data, content="10")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd lib/zipper && moon test`
+Expected: FAIL — `to_tree`, `replace`, `modify` not defined.
+
+- [ ] **Step 3: Implement to_tree, replace, modify**
+
+Append to `lib/zipper/navigate.mbt`:
+
+```moonbit
+///|
+pub fn[T] RoseZipper::to_tree(self : RoseZipper[T]) -> RoseNode[T] {
+  let mut z = self
+  while true {
+    match z.go_up() {
+      Some(parent) => z = parent
+      None => break
+    }
+  }
+  z.focus
+}
+
+///|
+pub fn[T] RoseZipper::replace(
+  self : RoseZipper[T],
+  new_focus : RoseNode[T],
+) -> RoseZipper[T] {
+  { ..self, focus: new_focus }
+}
+
+///|
+pub fn[T] RoseZipper::modify(
+  self : RoseZipper[T],
+  f : (RoseNode[T]) -> RoseNode[T],
+) -> RoseZipper[T] {
+  { ..self, focus: f(self.focus) }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/navigate.mbt lib/zipper/zipper_test.mbt
+git commit -m "feat(zipper): implement to_tree, replace, modify"
+```
+
+---
+
+### Task 6: Implement query methods
+
+**Files:**
+- Modify: `lib/zipper/navigate.mbt`
+- Modify: `lib/zipper/zipper_test.mbt`
+
+- [ ] **Step 1: Write tests**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "depth tracks navigation depth" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1, children=[RoseNode::new(data=2)]),
+  ])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.depth(), content="0")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.depth(), content="1")
+  let z2 = z1.go_down().unwrap()
+  inspect(z2.depth(), content="2")
+}
+
+test "child_index tracks position among siblings" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.child_index(), content="None")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.child_index(), content="Some(0)")
+  let z2 = z1.go_right().unwrap()
+  inspect(z2.child_index(), content="Some(1)")
+  let z3 = z2.go_right().unwrap()
+  inspect(z3.child_index(), content="Some(2)")
+}
+
+test "is_root and is_leaf" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.is_root(), content="true")
+  inspect(z.is_leaf(), content="false")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.is_root(), content="false")
+  inspect(z1.is_leaf(), content="true")
+}
+
+test "num_children" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.num_children(), content="2")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.num_children(), content="0")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd lib/zipper && moon test`
+Expected: FAIL — query methods not defined.
+
+- [ ] **Step 3: Implement query methods**
+
+Append to `lib/zipper/navigate.mbt`:
+
+```moonbit
+///|
+pub fn[T] RoseZipper::depth(self : RoseZipper[T]) -> Int {
+  self.depth
+}
+
+///|
+pub fn[T] RoseZipper::child_index(self : RoseZipper[T]) -> Int? {
+  match self.path {
+    More(ctx, ..) => Some(ctx.index)
+    Empty => None
+  }
+}
+
+///|
+pub fn[T] RoseZipper::is_root(self : RoseZipper[T]) -> Bool {
+  self.path is Empty
+}
+
+///|
+pub fn[T] RoseZipper::is_leaf(self : RoseZipper[T]) -> Bool {
+  self.focus.children.is_empty()
+}
+
+///|
+pub fn[T] RoseZipper::num_children(self : RoseZipper[T]) -> Int {
+  self.focus.children.length()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/navigate.mbt lib/zipper/zipper_test.mbt
+git commit -m "feat(zipper): implement depth, child_index, is_root, is_leaf, num_children queries"
+```
+
+---
+
+### Task 7: Implement to_path and focus_at
+
+**Files:**
+- Modify: `lib/zipper/navigate.mbt`
+- Modify: `lib/zipper/zipper_test.mbt`
+
+- [ ] **Step 1: Write tests**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "to_path returns child indices from root" {
+  let tree = RoseNode::new(data="r", children=[
+    RoseNode::new(data="a", children=[
+      RoseNode::new(data="x"),
+      RoseNode::new(data="y"),
+    ]),
+    RoseNode::new(data="b"),
+  ])
+  let z = RoseZipper::from_root(tree)
+    .go_down().unwrap()
+    .go_down(index=1).unwrap()
+  inspect(z.focus.data, content="y")
+  inspect(z.to_path(), content="[0, 1]")
+}
+
+test "to_path at root is empty" {
+  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  inspect(z.to_path(), content="[]")
+}
+
+test "focus_at navigates to position" {
+  let tree = RoseNode::new(data="r", children=[
+    RoseNode::new(data="a", children=[
+      RoseNode::new(data="x"),
+      RoseNode::new(data="y"),
+    ]),
+    RoseNode::new(data="b"),
+  ])
+  let z = RoseZipper::focus_at(tree, [0, 1]).unwrap()
+  inspect(z.focus.data, content="y")
+  inspect(z.depth(), content="2")
+}
+
+test "focus_at with empty path stays at root" {
+  let tree = RoseNode::new(data=1)
+  let z = RoseZipper::focus_at(tree, []).unwrap()
+  inspect(z.focus.data, content="1")
+  inspect(z.is_root(), content="true")
+}
+
+test "focus_at returns None on invalid path" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+  ])
+  inspect(RoseZipper::focus_at(tree, [0, 5]), content="None")
+  inspect(RoseZipper::focus_at(tree, [3]), content="None")
+  inspect(RoseZipper::focus_at(tree, [-1]), content="None")
+}
+
+test "to_path and focus_at round-trip" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1, children=[
+      RoseNode::new(data=3),
+      RoseNode::new(data=4),
+    ]),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree)
+    .go_down().unwrap()
+    .go_down(index=1).unwrap()
+  let path = z.to_path()
+  let z2 = RoseZipper::focus_at(tree, path).unwrap()
+  inspect(z2.focus.data, content="4")
+  assert_eq(z.focus, z2.focus)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd lib/zipper && moon test`
+Expected: FAIL — `to_path` and `focus_at` not defined.
+
+- [ ] **Step 3: Implement to_path and focus_at**
+
+Append to `lib/zipper/navigate.mbt`:
+
+```moonbit
+///|
+pub fn[T] RoseZipper::to_path(self : RoseZipper[T]) -> Array[Int] {
+  let indices : Array[Int] = []
+  let mut p = self.path
+  while true {
+    match p {
+      Empty => break
+      More(ctx, tail=rest) => {
+        indices.push(ctx.index)
+        p = rest
+      }
+    }
+  }
+  indices.rev_in_place()
+  indices
+}
+
+///|
+pub fn[T] RoseZipper::focus_at(
+  tree : RoseNode[T],
+  path : Array[Int],
+) -> RoseZipper[T]? {
+  let mut z = RoseZipper::from_root(tree)
+  for idx in path {
+    match z.go_down(index=idx) {
+      Some(z2) => z = z2
+      None => return None
+    }
+  }
+  Some(z)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/navigate.mbt lib/zipper/zipper_test.mbt
+git commit -m "feat(zipper): implement to_path and focus_at path operations"
+```
+
+---
+
+### Task 8: Persistence test and add module to canopy
+
+**Files:**
+- Modify: `lib/zipper/zipper_test.mbt`
+- Modify: `moon.mod.json` (canopy root)
+
+- [ ] **Step 1: Write persistence test**
+
+Append to `lib/zipper/zipper_test.mbt`:
+
+```moonbit
+test "persistence: old zipper unchanged after navigation" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z1 = z.go_down().unwrap()
+  // z is still at root
+  inspect(z.focus.data, content="0")
+  inspect(z.is_root(), content="true")
+  // z1 at child
+  inspect(z1.focus.data, content="1")
+  // navigate from z1
+  let z2 = z1.go_right().unwrap()
+  // z1 unchanged
+  inspect(z1.focus.data, content="1")
+  inspect(z1.child_index(), content="Some(0)")
+  // z2 at sibling
+  inspect(z2.focus.data, content="2")
+  inspect(z2.child_index(), content="Some(1)")
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd lib/zipper && moon test`
+Expected: PASS (all tests)
+
+- [ ] **Step 3: Add zipper as a dependency in canopy root module**
+
+Add to the `"deps"` object in the root `moon.mod.json`:
+
+```json
+"dowdiness/zipper": {
+  "path": "./lib/zipper"
+}
+```
+
+- [ ] **Step 4: Verify canopy still builds with the new dependency**
+
+Run: `moon check`
+Expected: PASS (0 errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/zipper_test.mbt moon.mod.json
+git commit -m "feat(zipper): add persistence test and register module in canopy"
+```
+
+---
+
+### Task 9: Finalize — format, interfaces, review
+
+**Files:**
+- Various generated files
+
+- [ ] **Step 1: Update interfaces and format**
+
+Run: `cd lib/zipper && moon info && moon fmt`
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd lib/zipper && moon check && moon test`
+Expected: PASS (0 errors, all tests pass)
+
+- [ ] **Step 3: Run canopy-wide check to ensure no regressions**
+
+Run: `moon check && moon test`
+Expected: PASS
+
+- [ ] **Step 4: Review generated `.mbti` file**
+
+Run: `cat lib/zipper/pkg.generated.mbti`
+
+Verify the public API matches the spec:
+- `RoseNode::new`
+- `RoseZipper::from_root`, `go_down`, `go_up`, `go_left`, `go_right`
+- `RoseZipper::to_tree`, `replace`, `modify`
+- `RoseZipper::depth`, `child_index`, `is_root`, `is_leaf`, `num_children`
+- `RoseZipper::to_path`, `focus_at`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/zipper/
+git commit -m "chore(zipper): update interfaces and format"
+```

--- a/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
+++ b/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
@@ -1,0 +1,219 @@
+# Rose Tree Zipper Library — Design Spec
+
+**Date:** 2026-04-07
+**Status:** Phase 1 design
+**Module:** `dowdiness/zipper` at `lib/zipper/`
+
+## Goal
+
+A standalone, reusable rose tree zipper library for MoonBit. Rose trees appear throughout compiler development (ASTs, CSTs, scope trees, DOM-like structures). This library provides a correct, persistent, generic implementation grounded in Huet's zipper and McBride's type derivative theory.
+
+Phase 1 covers the rose tree shape only. Binary tree and B-tree zippers are deferred to future phases.
+
+## Theoretical Foundation
+
+A rose tree is the type `RoseNode[T] = T × List[RoseNode[T]]` — a node carrying data of type `T` with an ordered list of children.
+
+The **derivative** (McBride 2001) of this type gives the one-hole context:
+
+```text
+d(T × List[X]) = T × List[X] × List[X]
+                 ^   ^^^^^^^^^   ^^^^^^^^^
+              parent  left sibs   right sibs
+              data
+```
+
+`T` is in constant position (node data, not part of the branching structure), so its derivative is 0. The context retains `T` as a value (parent data is stored), but the **construction** of the context type is uniform in `T` — the same zipper shape works for any `T`. This is why `RoseNode[LambdaTerm]` has the same zipper structure as `RoseNode[JsonValue]` — no per-language codegen needed.
+
+The zipper is then: `(Focus, List[Context])` — the focused subtree plus a stack of contexts from focus to root.
+
+## Types
+
+```moonbit
+pub(all) struct RoseNode[T] {
+  data : T
+  children : Array[RoseNode[T]]
+
+  fn new(data~ : T, children? : Array[RoseNode[T]] = []) -> RoseNode[T]
+} derive(Debug, Eq)
+
+pub(all) struct RoseCtx[T] {
+  data : T
+  left : @list.List[RoseNode[T]]    // left siblings, nearest first
+  right : @list.List[RoseNode[T]]   // right siblings, nearest first
+  index : Int                        // cached child position (== left.length())
+} derive(Debug, Eq)
+
+pub(all) struct RoseZipper[T] {
+  focus : RoseNode[T]
+  path : @list.List[RoseCtx[T]]
+  depth : Int                        // cached depth from root
+} derive(Debug, Eq)
+```
+
+### Design decisions
+
+**`Array` for children in `RoseNode`, `@list.List` for siblings in `RoseCtx`.** Hybrid representation. `Array` gives random access and cache-friendly traversal for tree operations. `@list.List` gives O(1) lateral movement in the zipper (cons/uncons). The cost is O(n) for `go_down` (split array into lists) and `go_up` (merge lists into array), which is inherent and acceptable.
+
+**Cached `index` in `RoseCtx`.** Avoids O(n) `left.length()` call for `child_index` queries. Maintained trivially during lateral navigation.
+
+**Cached `depth` in `RoseZipper`.** Avoids O(depth) path traversal. Incremented on `go_down`, decremented on `go_up`.
+
+**`pub(all)` structs.** Fields are readable for introspection (e.g., accessing `focus.data` directly). Users should construct zippers only via `from_root` and navigate via methods, but enforcing this with `priv` fields would add accessor boilerplate without meaningful safety gain — the invariants (`index == left.length()`, `depth == path.length()`) are maintained by the navigation methods.
+
+## API
+
+### Construction
+
+```moonbit
+pub fn[T] RoseNode::new(data~ : T, children? : Array[RoseNode[T]] = []) -> RoseNode[T]
+pub fn[T] RoseZipper::from_root(tree : RoseNode[T]) -> RoseZipper[T]
+```
+
+`RoseNode(data=x)` creates a leaf. `RoseNode(data=x, children=kids)` creates an internal node.
+
+### Navigation
+
+```moonbit
+pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]?
+pub fn[T] RoseZipper::go_down(self : RoseZipper[T], index? : Int = 0) -> RoseZipper[T]?
+pub fn[T] RoseZipper::go_left(self : RoseZipper[T]) -> RoseZipper[T]?
+pub fn[T] RoseZipper::go_right(self : RoseZipper[T]) -> RoseZipper[T]?
+```
+
+`go_down()` focuses on the first child. `go_down(index=2)` focuses on the third child. Returns `None` at boundaries (leaf, first/last sibling, root) or if `index` is negative or out of bounds.
+
+### Reconstruction
+
+```moonbit
+pub fn[T] RoseZipper::to_tree(self : RoseZipper[T]) -> RoseNode[T]
+```
+
+Navigate to root and return the reconstructed tree.
+
+### Modification
+
+```moonbit
+pub fn[T] RoseZipper::replace(self : RoseZipper[T], new_focus : RoseNode[T]) -> RoseZipper[T]
+pub fn[T] RoseZipper::modify(self : RoseZipper[T], f : (RoseNode[T]) -> RoseNode[T]) -> RoseZipper[T]
+```
+
+Both O(1) — swap focus, path unchanged. `to_tree` after modification reconstructs the tree with the change applied.
+
+### Queries
+
+```moonbit
+pub fn[T] RoseZipper::depth(self : RoseZipper[T]) -> Int            // O(1), cached
+pub fn[T] RoseZipper::child_index(self : RoseZipper[T]) -> Int?     // O(1), cached; None at root
+pub fn[T] RoseZipper::is_root(self : RoseZipper[T]) -> Bool         // O(1)
+pub fn[T] RoseZipper::is_leaf(self : RoseZipper[T]) -> Bool         // O(1)
+pub fn[T] RoseZipper::num_children(self : RoseZipper[T]) -> Int     // O(1)
+pub fn[T] RoseZipper::to_path(self : RoseZipper[T]) -> Array[Int]   // O(depth)
+```
+
+### Path-based navigation
+
+```moonbit
+pub fn[T] RoseZipper::focus_at(tree : RoseNode[T], path : Array[Int]) -> RoseZipper[T]?
+```
+
+Navigate from root following child indices. Returns `None` if any index is out of bounds or negative. For best-effort prefix navigation (stop at deepest reachable node), callers can implement a wrapper that tries progressively shorter paths.
+
+## Complexity
+
+| Operation | Time | Space | Notes |
+|-----------|------|-------|-------|
+| `from_root` | O(1) | O(1) | |
+| `go_down(i)` | O(n) | O(n) | n = num children; split array into two lists |
+| `go_up` | O(n) | O(n) | n = num siblings; merge lists into array |
+| `go_left` | O(1) | O(1) | list cons/uncons |
+| `go_right` | O(1) | O(1) | list cons/uncons |
+| `replace` / `modify` | O(1) | O(1) | swap focus |
+| `to_tree` | O(depth × avg siblings) | O(Σ siblings along spine) | chain of go_up; unchanged subtrees are shared via persistence |
+| `depth` / `child_index` | O(1) | O(1) | cached |
+| `to_path` | O(depth) | O(depth) | walk path, read cached index |
+| `focus_at` | O(Σ children per level) | O(path length × avg siblings) | chain of go_down |
+
+**Persistence:** All operations return new values. Old zippers remain valid. Structural sharing via `@list.List` cons cells — `go_down` shares parent path, `go_left`/`go_right` share sibling tails.
+
+## Module Structure
+
+```text
+lib/zipper/
+  moon.mod.json         -- name: "dowdiness/zipper", deps: moonbitlang/core
+  moon.pkg              -- is_main: false
+  rose_node.mbt         -- RoseNode[T], RoseCtx[T], RoseZipper[T] (types + constructors)
+  navigate.mbt          -- Navigation, reconstruction, modification, queries
+  zipper_test.mbt       -- Black-box tests
+  pkg.generated.mbti    -- Generated interface
+```
+
+The `Rose` prefix on all types is intentional — future phases will add `BinaryNode`/`BinaryZipper` and `BTreeNode`/`BTreeZipper` to the same package.
+
+Canopy packages that use the library add to `moon.mod.json`:
+
+```json
+"dowdiness/zipper": { "path": "./lib/zipper" }
+```
+
+## Consumer Integration (ProjNode)
+
+ProjNode stays separate. The zipper library does not depend on canopy/core. When a canopy package needs a zipper over ProjNode, it converts at the boundary:
+
+```moonbit
+// In canopy/core or consumer package — NOT in lib/zipper
+fn proj_to_rose[T](p : ProjNode[T]) -> @zipper.RoseNode[ProjData[T]] {
+  @zipper.RoseNode(
+    data=ProjData(node_id=p.node_id, kind=p.kind, start=p.start, end=p.end),
+    children=p.children.map(proj_to_rose),
+  )
+}
+```
+
+The O(n) conversion cost is paid once, duplicating the tree into `RoseNode` form. After that, navigation is O(1) per lateral move. For repeated navigation (keyboard-driven editing, DFS traversals), this is better than the current bridge approach (O(n) DFS per navigation in `lang/lambda/zipper/zipper_bridge.mbt`). For single-shot lookups, the upfront conversion may not be worthwhile — use the bridge directly.
+
+## Testing Strategy
+
+1. **Docstring tests** on every public method — small, focused examples verified by `mbt check`.
+
+2. **Black-box tests** in `zipper_test.mbt`:
+   - Round-trips: `from_root(tree).to_tree() == tree`
+   - Navigation round-trips: `go_down(i) |> go_up == identity`
+   - Lateral round-trips: `go_right |> go_left == identity`
+   - Boundary cases: `go_up` at root, `go_down` on leaf, `go_left` on first child, `go_right` on last child all return `None`
+   - Modification: replace subtree, verify `to_tree` reflects change
+   - Path: `to_path` + `focus_at` round-trip
+   - Persistence: old zipper unchanged after navigation from it
+
+3. **Property-based tests** with `@qc`:
+   - Requires `@qc.Arbitrary` for `RoseNode[Int]` with bounded depth/branching
+   - Properties: round-trip, navigation laws, path serialization
+
+## Implementation Risks (verify during implementation)
+
+1. ~~`derive(Show, Eq)` through `@list.List[RoseNode[T]]` nesting~~ — resolved: use `derive(Debug, Eq)` + manual `Show` impl via `@debug.to_string`.
+2. ~~`@list.List` pattern syntax~~ — resolved: `Empty` and `More(head, tail=rest)` for matching; `@list.cons()` and `@list.List::default()` for construction.
+3. ~~`fn new()` declaration-inside-struct with generic type parameters~~ — resolved: define constructor outside struct as `fn[T] RoseNode::new(...)`.
+4. ~~`go_down(index? : Int = 0)` optional parameter~~ — resolved: use `?` syntax, not `~`.
+
+## What Phase 1 Does NOT Include
+
+- **Annotation layer** (ScopeProvider, DepthCounter, etc.) — deferred to Phase 2. The design (Self-Closed Algebra trait with `push`/`pop`) is sketched but not specified.
+- **Structural edit primitives** (`insert_child`, `remove_child`, `insert_sibling`, `delete_focus` with re-focus rules) — buildable on top of `replace`/`modify`, deferred until a consumer needs them.
+- **Tree utilities** (`fold`, `map`, `iter`, `find` on `RoseNode`) — these don't need a zipper and can be added incrementally.
+- **Binary/B-tree zippers** — deferred to future phases.
+- **`Navigable` trait** abstracting over tree shapes — deferred until multiple zipper types exist.
+- **ProjNode integration in canopy/core** — consumer concern, not library concern.
+
+## Future Phases (not designed, just noted)
+
+- **Phase 2:** Annotation trait + ScopeProvider reference implementation
+- **Phase 3:** B-tree zipper (refactor OrderTree's `Cursor[T]`)
+- **Phase 4:** `Navigable` capability trait across rose/btree/binary
+- **Phase 5:** Binary tree zipper (when a consumer appears)
+
+## References
+
+- Huet (1997) — "Functional Pearl: The Zipper"
+- McBride (2001) — "The Derivative of a Regular Type is its Type of One-Hole Contexts"
+- Hinze & Paterson (2006) — "Finger trees: a simple general-purpose data structure"

--- a/lib/zipper/moon.mod.json
+++ b/lib/zipper/moon.mod.json
@@ -1,0 +1,11 @@
+{
+  "name": "dowdiness/zipper",
+  "version": "0.1.0",
+  "deps": {
+    "moonbitlang/quickcheck": "0.11.2"
+  },
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": ["zipper", "rose-tree", "data-structure", "moonbit"],
+  "description": "Persistent rose tree zipper — generic, correct, O(1) lateral navigation"
+}

--- a/lib/zipper/moon.pkg
+++ b/lib/zipper/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/list" @list,
+}
+
+import {
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/splitmix" @splitmix,
+  "moonbitlang/quickcheck" @qc,
+} for "wbtest"

--- a/lib/zipper/navigate.mbt
+++ b/lib/zipper/navigate.mbt
@@ -1,0 +1,191 @@
+// Navigation, reconstruction, modification, and query operations for RoseZipper.
+//
+// All navigation returns Option — None at boundaries (root, leaf, first/last
+// sibling). Every operation is persistent: the original zipper is unchanged,
+// and old/new zippers share structure via @list.List cons cells.
+//
+// Vertical moves (go_down, go_up) are O(n) where n = number of children
+// at the focused node (go_down) or siblings at the current level (go_up),
+// because they split/merge the children array into sibling lists.
+// Lateral moves (go_left, go_right) are O(1) — just list cons/uncons.
+
+///|
+pub fn[T] RoseZipper::go_down(
+  self : RoseZipper[T],
+  index? : Int = 0,
+) -> RoseZipper[T]? {
+  if index < 0 || index >= self.focus.children.length() {
+    return None
+  }
+  let children = self.focus.children
+  // Build left siblings in reverse order (nearest first) via cons — this
+  // makes go_left O(1) and matches the reversed-list convention in RoseCtx.
+  let mut left : @list.List[RoseNode[T]] = @list.List::default()
+  for i in 0..<index {
+    left = @list.cons(children[i], left)
+  }
+  let mut right : @list.List[RoseNode[T]] = @list.List::default()
+  for i = children.length() - 1; i > index; i = i - 1 {
+    right = @list.cons(children[i], right)
+  }
+  let ctx : RoseCtx[T] = { data: self.focus.data, left, right, index }
+  Some({
+    focus: children[index],
+    path: @list.cons(ctx, self.path),
+    depth: self.depth + 1,
+  })
+}
+
+///|
+pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
+  match self.path {
+    Empty => None
+    More(ctx, tail=rest) => {
+      // Reconstruct children: left (reversed back to original order) + focus + right
+      let children : Array[RoseNode[T]] = ctx.left.to_array()
+      children.rev_in_place() // left was stored nearest-first; restore tree order
+      children.push(self.focus)
+      ctx.right.each(fn(n) { children.push(n) })
+      let parent = RoseNode::new(data=ctx.data, children~)
+      Some({ focus: parent, path: rest, depth: self.depth - 1 })
+    }
+  }
+}
+
+///|
+pub fn[T] RoseZipper::go_left(self : RoseZipper[T]) -> RoseZipper[T]? {
+  match self.path {
+    More(ctx, tail=rest) =>
+      match ctx.left {
+        More(sibling, tail=left_rest) => {
+          let new_right = @list.cons(self.focus, ctx.right)
+          let new_ctx : RoseCtx[T] = {
+            data: ctx.data,
+            left: left_rest,
+            right: new_right,
+            index: ctx.index - 1,
+          }
+          Some({
+            focus: sibling,
+            path: @list.cons(new_ctx, rest),
+            depth: self.depth,
+          })
+        }
+        Empty => None
+      }
+    Empty => None
+  }
+}
+
+///|
+pub fn[T] RoseZipper::go_right(self : RoseZipper[T]) -> RoseZipper[T]? {
+  match self.path {
+    More(ctx, tail=rest) =>
+      match ctx.right {
+        More(sibling, tail=right_rest) => {
+          let new_left = @list.cons(self.focus, ctx.left)
+          let new_ctx : RoseCtx[T] = {
+            data: ctx.data,
+            left: new_left,
+            right: right_rest,
+            index: ctx.index + 1,
+          }
+          Some({
+            focus: sibling,
+            path: @list.cons(new_ctx, rest),
+            depth: self.depth,
+          })
+        }
+        Empty => None
+      }
+    Empty => None
+  }
+}
+
+///|
+pub fn[T] RoseZipper::to_tree(self : RoseZipper[T]) -> RoseNode[T] {
+  let mut z = self
+  while true {
+    match z.go_up() {
+      Some(parent) => z = parent
+      None => break
+    }
+  }
+  z.focus
+}
+
+///|
+pub fn[T] RoseZipper::replace(
+  self : RoseZipper[T],
+  new_focus : RoseNode[T],
+) -> RoseZipper[T] {
+  { ..self, focus: new_focus }
+}
+
+///|
+pub fn[T] RoseZipper::modify(
+  self : RoseZipper[T],
+  f : (RoseNode[T]) -> RoseNode[T],
+) -> RoseZipper[T] {
+  { ..self, focus: f(self.focus) }
+}
+
+///|
+pub fn[T] RoseZipper::depth(self : RoseZipper[T]) -> Int {
+  self.depth
+}
+
+///|
+pub fn[T] RoseZipper::child_index(self : RoseZipper[T]) -> Int? {
+  match self.path {
+    More(ctx, ..) => Some(ctx.index)
+    Empty => None
+  }
+}
+
+///|
+pub fn[T] RoseZipper::is_root(self : RoseZipper[T]) -> Bool {
+  self.path is Empty
+}
+
+///|
+pub fn[T] RoseZipper::is_leaf(self : RoseZipper[T]) -> Bool {
+  self.focus.children.is_empty()
+}
+
+///|
+pub fn[T] RoseZipper::num_children(self : RoseZipper[T]) -> Int {
+  self.focus.children.length()
+}
+
+///|
+pub fn[T] RoseZipper::to_path(self : RoseZipper[T]) -> Array[Int] {
+  let indices : Array[Int] = []
+  let mut p = self.path
+  while true {
+    match p {
+      Empty => break
+      More(ctx, tail=rest) => {
+        indices.push(ctx.index)
+        p = rest
+      }
+    }
+  }
+  indices.rev_in_place()
+  indices
+}
+
+///|
+pub fn[T] RoseZipper::focus_at(
+  tree : RoseNode[T],
+  path : Array[Int],
+) -> RoseZipper[T]? {
+  let mut z = RoseZipper::from_root(tree)
+  for idx in path {
+    match z.go_down(index=idx) {
+      Some(z2) => z = z2
+      None => return None
+    }
+  }
+  Some(z)
+}

--- a/lib/zipper/pkg.generated.mbti
+++ b/lib/zipper/pkg.generated.mbti
@@ -1,0 +1,54 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/zipper"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/list",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct RoseCtx[T] {
+  data : T
+  left : @list.List[RoseNode[T]]
+  right : @list.List[RoseNode[T]]
+  index : Int
+} derive(Eq, @debug.Debug)
+pub impl[T : @debug.Debug] Show for RoseCtx[T]
+
+pub(all) struct RoseNode[T] {
+  data : T
+  children : Array[RoseNode[T]]
+} derive(Eq, @debug.Debug)
+pub fn[T] RoseNode::new(data~ : T, children? : Array[Self[T]]) -> Self[T]
+pub impl[T : @debug.Debug] Show for RoseNode[T]
+
+pub(all) struct RoseZipper[T] {
+  focus : RoseNode[T]
+  path : @list.List[RoseCtx[T]]
+  depth : Int
+} derive(Eq, @debug.Debug)
+pub fn[T] RoseZipper::child_index(Self[T]) -> Int?
+pub fn[T] RoseZipper::depth(Self[T]) -> Int
+pub fn[T] RoseZipper::focus_at(RoseNode[T], Array[Int]) -> Self[T]?
+pub fn[T] RoseZipper::from_root(RoseNode[T]) -> Self[T]
+pub fn[T] RoseZipper::go_down(Self[T], index? : Int) -> Self[T]?
+pub fn[T] RoseZipper::go_left(Self[T]) -> Self[T]?
+pub fn[T] RoseZipper::go_right(Self[T]) -> Self[T]?
+pub fn[T] RoseZipper::go_up(Self[T]) -> Self[T]?
+pub fn[T] RoseZipper::is_leaf(Self[T]) -> Bool
+pub fn[T] RoseZipper::is_root(Self[T]) -> Bool
+pub fn[T] RoseZipper::modify(Self[T], (RoseNode[T]) -> RoseNode[T]) -> Self[T]
+pub fn[T] RoseZipper::num_children(Self[T]) -> Int
+pub fn[T] RoseZipper::replace(Self[T], RoseNode[T]) -> Self[T]
+pub fn[T] RoseZipper::to_path(Self[T]) -> Array[Int]
+pub fn[T] RoseZipper::to_tree(Self[T]) -> RoseNode[T]
+pub impl[T : @debug.Debug] Show for RoseZipper[T]
+
+// Type aliases
+
+// Traits
+

--- a/lib/zipper/rose_node.mbt
+++ b/lib/zipper/rose_node.mbt
@@ -1,0 +1,74 @@
+// Rose tree zipper library — types and constructors.
+//
+// A zipper (Huet 1997) turns an immutable tree inside-out around a focus
+// point, enabling efficient local navigation without mutating the original tree.
+// Lateral moves (go_left, go_right) are O(1); vertical moves (go_down, go_up)
+// are O(n) where n is the number of children at the relevant node.
+//
+//   RoseNode[T]   — the tree itself: data of type T with ordered children.
+//   RoseCtx[T]    — one-hole context: the "derivative" of RoseNode (McBride 2001).
+//                   Stores the parent's data plus left and right sibling lists
+//                   so the parent can be reconstructed when navigating up.
+//   RoseZipper[T] — a position within a tree: the focused subtree plus a
+//                   stack of contexts from focus to root.
+//
+// The context type is uniform in T — the same zipper shape works regardless
+// of what data the nodes carry. No per-language codegen is needed.
+
+///|
+pub(all) struct RoseNode[T] {
+  data : T
+  children : Array[RoseNode[T]]
+} derive(Debug, Eq)
+
+///|
+pub impl[T : Debug] Show for RoseNode[T] with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub fn[T] RoseNode::new(
+  data~ : T,
+  children? : Array[RoseNode[T]] = [],
+) -> RoseNode[T] {
+  { data, children }
+}
+
+///|
+/// One-hole context for a rose tree node. Stores everything needed to
+/// reconstruct the parent: its data, the siblings to the left and right
+/// of the focused child, and the child's index.
+///
+/// `left` is stored in reverse order (nearest sibling first) so that
+/// go_left/go_right are O(1) list cons/uncons operations.
+pub(all) struct RoseCtx[T] {
+  data : T
+  left : @list.List[RoseNode[T]]
+  right : @list.List[RoseNode[T]]
+  index : Int
+} derive(Debug, Eq)
+
+///|
+pub impl[T : Debug] Show for RoseCtx[T] with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// A focused position within a rose tree. `focus` is the current subtree,
+/// `path` is the stack of contexts from focus to root (innermost first).
+/// `depth` is cached (invariant: depth == path.length()) for O(1) queries.
+pub(all) struct RoseZipper[T] {
+  focus : RoseNode[T]
+  path : @list.List[RoseCtx[T]]
+  depth : Int
+} derive(Debug, Eq)
+
+///|
+pub impl[T : Debug] Show for RoseZipper[T] with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub fn[T] RoseZipper::from_root(tree : RoseNode[T]) -> RoseZipper[T] {
+  { focus: tree, path: @list.List::default(), depth: 0 }
+}

--- a/lib/zipper/zipper_properties_wbtest.mbt
+++ b/lib/zipper/zipper_properties_wbtest.mbt
@@ -1,0 +1,88 @@
+// Property-based tests for the rose tree zipper using @qc (quickcheck).
+// These verify structural invariants that hand-written tests cannot exhaustively cover:
+// round-trip laws, path serialization, and persistence guarantees.
+
+///|
+/// Bounded-depth recursive generator for RoseNode[Int] trees.
+fn gen_rose_node(rs : @splitmix.RandomState, depth : Int) -> RoseNode[Int] {
+  if depth <= 0 {
+    RoseNode::new(data=rs.split().next_positive_int() % 100)
+  } else {
+    let coin = rs.split().next_positive_int() % 3
+    if coin == 0 {
+      RoseNode::new(data=rs.split().next_positive_int() % 100)
+    } else {
+      let child_count = rs.split().next_positive_int() % 4
+      let children : Array[RoseNode[Int]] = []
+      for _ in 0..<child_count {
+        children.push(gen_rose_node(rs.split(), depth - 1))
+      }
+      RoseNode::new(data=rs.split().next_positive_int() % 100, children~)
+    }
+  }
+}
+
+///|
+impl @quickcheck.Arbitrary for RoseNode[Int] with arbitrary(size, rs) {
+  gen_rose_node(rs, if size < 1 { 1 } else if size > 4 { 4 } else { size })
+}
+
+///|
+/// No-op shrink impl (required by quick_check_fn).
+impl @qc.Shrink for RoseNode[Int]
+
+///|
+fn prop_from_root_to_tree_identity(tree : RoseNode[Int]) -> Bool {
+  RoseZipper::from_root(tree).to_tree() == tree
+}
+
+///|
+test "property: from_root then to_tree is identity" {
+  @qc.quick_check_fn(prop_from_root_to_tree_identity)
+}
+
+///|
+fn prop_go_down_go_up_round_trip(tree : RoseNode[Int]) -> Bool {
+  let z = RoseZipper::from_root(tree)
+  if z.num_children() > 0 {
+    let z2 = z.go_down().unwrap().go_up().unwrap()
+    z2.focus == tree
+  } else {
+    true
+  }
+}
+
+///|
+test "property: go_down then go_up round-trip preserves focus" {
+  @qc.quick_check_fn(prop_go_down_go_up_round_trip)
+}
+
+///|
+fn prop_to_path_focus_at_inverse(tree : RoseNode[Int]) -> Bool {
+  let z = RoseZipper::from_root(tree)
+  // Root case: empty path round-trips
+  let root_path = z.to_path()
+  if root_path != ([] : Array[Int]) {
+    return false
+  }
+  match RoseZipper::focus_at(tree, root_path) {
+    Some(z_root) => if z_root.focus != tree { return false }
+    None => return false
+  }
+  // Navigate to first child if possible
+  if z.num_children() > 0 {
+    let z2 = z.go_down().unwrap()
+    let path = z2.to_path()
+    match RoseZipper::focus_at(tree, path) {
+      Some(z3) => z2.focus == z3.focus
+      None => false
+    }
+  } else {
+    true
+  }
+}
+
+///|
+test "property: to_path and focus_at are inverse" {
+  @qc.quick_check_fn(prop_to_path_focus_at_inverse)
+}

--- a/lib/zipper/zipper_test.mbt
+++ b/lib/zipper/zipper_test.mbt
@@ -1,0 +1,400 @@
+///|
+test "RoseNode leaf and internal construction" {
+  let leaf = RoseNode::new(data=1)
+  inspect(leaf.data, content="1")
+  inspect(leaf.children.length(), content="0")
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  inspect(tree.children.length(), content="3")
+  inspect(tree.children[1].data, content="2")
+}
+
+///|
+test "from_root creates zipper at root" {
+  let tree = RoseNode::new(data="hello")
+  let z = RoseZipper::from_root(tree)
+  inspect(z.focus.data, content="hello")
+  inspect(z.depth, content="0")
+}
+
+///|
+test "go_down to first child" {
+  let tree = RoseNode::new(data="root", children=[
+    RoseNode::new(data="a"),
+    RoseNode::new(data="b"),
+    RoseNode::new(data="c"),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z1 = z.go_down().unwrap()
+  inspect(z1.focus.data, content="a")
+  inspect(z1.depth, content="1")
+}
+
+///|
+test "go_down with index" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=10),
+    RoseNode::new(data=20),
+    RoseNode::new(data=30),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.go_down(index=2).unwrap()
+  inspect(z2.focus.data, content="30")
+}
+
+///|
+test "go_down boundary: leaf returns None" {
+  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  inspect(z.go_down(), content="None")
+}
+
+///|
+test "go_down boundary: negative index returns None" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.go_down(index=-1), content="None")
+}
+
+///|
+test "go_down boundary: out of bounds returns None" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.go_down(index=5), content="None")
+}
+
+///|
+test "go_up from child returns parent" {
+  let tree = RoseNode::new(data="root", children=[
+    RoseNode::new(data="a"),
+    RoseNode::new(data="b"),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  let z2 = z.go_up().unwrap()
+  inspect(z2.focus.data, content="root")
+  inspect(z2.depth, content="0")
+}
+
+///|
+test "go_up at root returns None" {
+  let z = RoseZipper::from_root(RoseNode::new(data=42))
+  inspect(z.go_up(), content="None")
+}
+
+///|
+test "go_down then go_up round-trip preserves tree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
+    RoseNode::new(data=3),
+    RoseNode::new(data=4),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.go_down().unwrap().go_up().unwrap()
+  assert_eq(z2.focus, tree)
+}
+
+///|
+test "go_right traverses siblings" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  inspect(z.focus.data, content="1")
+  let z2 = z.go_right().unwrap()
+  inspect(z2.focus.data, content="2")
+  let z3 = z2.go_right().unwrap()
+  inspect(z3.focus.data, content="3")
+  inspect(z3.go_right(), content="None")
+}
+
+///|
+test "go_left traverses siblings backward" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down(index=2).unwrap()
+  inspect(z.focus.data, content="3")
+  let z2 = z.go_left().unwrap()
+  inspect(z2.focus.data, content="2")
+  let z3 = z2.go_left().unwrap()
+  inspect(z3.focus.data, content="1")
+  inspect(z3.go_left(), content="None")
+}
+
+///|
+test "go_left at first child returns None" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  inspect(z.go_left(), content="None")
+}
+
+///|
+test "go_left and go_right at root return None" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.go_left(), content="None")
+  inspect(z.go_right(), content="None")
+}
+
+///|
+test "go_right then go_left round-trip" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap()
+  let z2 = z.go_right().unwrap().go_left().unwrap()
+  inspect(z2.focus.data, content="1")
+}
+
+///|
+test "lateral then up preserves tree" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree)
+    .go_down()
+    .unwrap()
+    .go_right()
+    .unwrap()
+    .go_up()
+    .unwrap()
+  assert_eq(z.focus, tree)
+}
+
+///|
+test "to_tree from root is identity" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
+    RoseNode::new(data=3),
+    RoseNode::new(data=4),
+  ])
+  assert_eq(RoseZipper::from_root(tree).to_tree(), tree)
+}
+
+///|
+test "to_tree from deep position reconstructs full tree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
+    RoseNode::new(data=3),
+    RoseNode::new(data=4),
+  ])
+  let z = RoseZipper::from_root(tree).go_down().unwrap().go_down().unwrap()
+  inspect(z.focus.data, content="5")
+  assert_eq(z.to_tree(), tree)
+}
+
+///|
+test "replace changes focused subtree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
+  let z2 = z.replace(RoseNode::new(data=99))
+  inspect(z2.focus.data, content="99")
+  let rebuilt = z2.to_tree()
+  inspect(rebuilt.children[1].data, content="99")
+  // original focus unchanged (persistence)
+  inspect(z.focus.data, content="3")
+}
+
+///|
+test "modify transforms focused subtree" {
+  let tree = RoseNode::new(data=1, children=[
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
+  let z2 = z.modify(fn(n) {
+    RoseNode::new(data=n.data * 10, children=n.children)
+  })
+  inspect(z2.focus.data, content="30")
+  // verify modify propagates through to_tree
+  let rebuilt = z2.to_tree()
+  inspect(rebuilt.children[1].data, content="30")
+  inspect(rebuilt.children[0].data, content="2")
+}
+
+///|
+test "replace at root" {
+  let tree = RoseNode::new(data=1)
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.replace(RoseNode::new(data=99))
+  inspect(z2.focus.data, content="99")
+  assert_eq(z2.to_tree(), RoseNode::new(data=99))
+}
+
+///|
+test "modify at root" {
+  let tree = RoseNode::new(data=5, children=[RoseNode::new(data=10)])
+  let z = RoseZipper::from_root(tree)
+  let z2 = z.modify(fn(n) {
+    RoseNode::new(data=n.data * 2, children=n.children)
+  })
+  let rebuilt = z2.to_tree()
+  inspect(rebuilt.data, content="10")
+  inspect(rebuilt.children[0].data, content="10")
+}
+
+///|
+test "depth tracks navigation depth" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1, children=[RoseNode::new(data=2)]),
+  ])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.depth(), content="0")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.depth(), content="1")
+  let z2 = z1.go_down().unwrap()
+  inspect(z2.depth(), content="2")
+}
+
+///|
+test "child_index tracks position among siblings" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+    RoseNode::new(data=3),
+  ])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.child_index(), content="None")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.child_index(), content="Some(0)")
+  let z2 = z1.go_right().unwrap()
+  inspect(z2.child_index(), content="Some(1)")
+  let z3 = z2.go_right().unwrap()
+  inspect(z3.child_index(), content="Some(2)")
+}
+
+///|
+test "is_root and is_leaf" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.is_root(), content="true")
+  inspect(z.is_leaf(), content="false")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.is_root(), content="false")
+  inspect(z1.is_leaf(), content="true")
+}
+
+///|
+test "num_children" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree)
+  inspect(z.num_children(), content="2")
+  let z1 = z.go_down().unwrap()
+  inspect(z1.num_children(), content="0")
+}
+
+///|
+test "to_path returns child indices from root" {
+  let tree = RoseNode::new(data="r", children=[
+    RoseNode::new(data="a", children=[
+      RoseNode::new(data="x"),
+      RoseNode::new(data="y"),
+    ]),
+    RoseNode::new(data="b"),
+  ])
+  let z = RoseZipper::from_root(tree)
+    .go_down()
+    .unwrap()
+    .go_down(index=1)
+    .unwrap()
+  inspect(z.focus.data, content="y")
+  inspect(z.to_path(), content="[0, 1]")
+}
+
+///|
+test "to_path at root is empty" {
+  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  inspect(z.to_path(), content="[]")
+}
+
+///|
+test "focus_at navigates to position" {
+  let tree = RoseNode::new(data="r", children=[
+    RoseNode::new(data="a", children=[
+      RoseNode::new(data="x"),
+      RoseNode::new(data="y"),
+    ]),
+    RoseNode::new(data="b"),
+  ])
+  let z = RoseZipper::focus_at(tree, [0, 1]).unwrap()
+  inspect(z.focus.data, content="y")
+  inspect(z.depth(), content="2")
+}
+
+///|
+test "focus_at with empty path stays at root" {
+  let tree = RoseNode::new(data=1)
+  let z = RoseZipper::focus_at(tree, []).unwrap()
+  inspect(z.focus.data, content="1")
+  inspect(z.is_root(), content="true")
+}
+
+///|
+test "focus_at returns None on invalid path" {
+  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  inspect(RoseZipper::focus_at(tree, [0, 5]), content="None")
+  inspect(RoseZipper::focus_at(tree, [3]), content="None")
+  inspect(RoseZipper::focus_at(tree, [-1]), content="None")
+}
+
+///|
+test "to_path and focus_at round-trip" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1, children=[
+      RoseNode::new(data=3),
+      RoseNode::new(data=4),
+    ]),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree)
+    .go_down()
+    .unwrap()
+    .go_down(index=1)
+    .unwrap()
+  let path = z.to_path()
+  let z2 = RoseZipper::focus_at(tree, path).unwrap()
+  inspect(z2.focus.data, content="4")
+  assert_eq(z.focus, z2.focus)
+}
+
+///|
+test "persistence: old zipper unchanged after navigation" {
+  let tree = RoseNode::new(data=0, children=[
+    RoseNode::new(data=1),
+    RoseNode::new(data=2),
+  ])
+  let z = RoseZipper::from_root(tree)
+  let z1 = z.go_down().unwrap()
+  // z is still at root
+  inspect(z.focus.data, content="0")
+  inspect(z.is_root(), content="true")
+  // z1 at child
+  inspect(z1.focus.data, content="1")
+  // navigate from z1
+  let z2 = z1.go_right().unwrap()
+  // z1 unchanged
+  inspect(z1.focus.data, content="1")
+  inspect(z1.child_index(), content="Some(0)")
+  // z2 at sibling
+  inspect(z2.focus.data, content="2")
+  inspect(z2.child_index(), content="Some(1)")
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -34,6 +34,9 @@
     },
     "dowdiness/markdown": {
       "path": "./loom/examples/markdown"
+    },
+    "dowdiness/zipper": {
+      "path": "./lib/zipper"
     }
   },
   "readme": "README.mbt.md",


### PR DESCRIPTION
## Summary

- Add `dowdiness/zipper` — a standalone, persistent rose tree zipper library grounded in Huet's zipper and McBride's type derivative theory
- Three types: `RoseNode[T]`, `RoseCtx[T]`, `RoseZipper[T]` with hybrid Array/List representation
- O(1) lateral navigation (go_left/go_right), O(n) vertical navigation (go_down/go_up)
- Full API: navigation, reconstruction, modification, path operations, queries
- 33 blackbox tests covering boundaries, round-trips, persistence guarantees
- Educational comments explaining the zipper theory and key invariants

## Details

**Design spec:** `docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md`
**Implementation plan:** `docs/plans/2026-04-07-rose-tree-zipper-impl.md`

Phase 1 of a multi-phase generic zipper library. Future phases add annotation traits, B-tree zipper (OrderTree refactor), and `Navigable` capability trait.

## Test plan

- [x] `cd lib/zipper && moon check` — 0 errors, 0 warnings
- [x] `cd lib/zipper && moon test` — 33/33 tests pass
- [x] `moon check` (canopy root) — no regressions
- [x] Reviewed by 3 parallel agents (reuse, quality, efficiency) + Codex code review
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added backlog item, implementation plan, and detailed design spec for a new persistent rose-tree zipper library and package metadata.

* **New Features**
  * Introduced a generic persistent rose-tree zipper offering navigation, path-based focus, reconstruction, and immutable subtree updates for tree editing workflows.

* **Tests**
  * Added comprehensive unit and property-based tests covering construction, navigation, persistence, path operations, and behavioral invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->