### PR TITLE
fix: strip ZWSP from markdown export boundaries

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -400,8 +400,8 @@ From SuperOOP analysis and handler chain refactor (PR #54):
   Plan: `docs/plans/2026-04-01-editor-protocol-design.md`
 - [x] Markdown block editor (Phase 7) — ✅ Done (PRs #115, #117, #121, #123). Three modes (raw/block/preview), 7 edit ops, BlockInput + MarkdownPreview adapters.
   Plan: `docs/archive/2026-04-04-markdown-block-editor-design.md`
-- [ ] **ZWSP cleanup for empty blocks** — `InsertBlockAfter` inserts `\u200B` (zero-width space) as placeholder so the parser produces a ProjNode for empty paragraphs. The ZWSP is stripped on keystroke, but unused empty blocks keep it. If raw Markdown is copy-pasted to another tool, invisible ZWSP characters travel with it. Fix by either: (a) teaching the parser to produce empty paragraph nodes for consecutive blank lines, or (b) stripping all ZWSP on save/export.
-  Exit: No `\u200B` in raw Markdown output after save or copy.
+- [x] **ZWSP cleanup for empty blocks** — `markdown_export_text()` FFI strips ZWSP at export boundary. `block-input.ts` strips on display/edit/commit. `compute_merge_with_previous` strips on merge. ZWSP remains as internal parser placeholder only. Long-term fix: Container per-block text (§16).
+  Exit: No `\u200B` in exported Markdown text.
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -401,6 +401,7 @@ From SuperOOP analysis and handler chain refactor (PR #54):
 - [x] Markdown block editor (Phase 7) — ✅ Done (PRs #115, #117, #121, #123). Three modes (raw/block/preview), 7 edit ops, BlockInput + MarkdownPreview adapters.
   Plan: `docs/archive/2026-04-04-markdown-block-editor-design.md`
 - [x] **ZWSP cleanup for empty blocks** — `markdown_export_text()` FFI strips ZWSP at export boundary. `block-input.ts` strips on display/edit/commit. `compute_merge_with_previous` strips on merge. ZWSP remains as internal parser placeholder only. Long-term fix: Container per-block text (§16).
+  Known edge: fenced code blocks containing only U+200B on a line would match the strip pattern. Eliminated by Container per-block text migration (§16).
   Exit: No `\u200B` in exported Markdown text.
 
 ---

--- a/docs/plans/2026-04-11-zwsp-cleanup.md
+++ b/docs/plans/2026-04-11-zwsp-cleanup.md
@@ -1,0 +1,388 @@
+# ZWSP Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate ZWSP (U+200B) leakage from Markdown block editor export/display boundaries while keeping it as an internal parser placeholder.
+
+**Architecture:** Add `export_markdown_text()` FFI function that strips ZWSP. Add a ZWSP cleanup pass in `compute_commit_edit` so editing any block also scrubs neighboring ZWSP. Wire the raw-mode sync through the clean export path.
+
+**Tech Stack:** MoonBit (editor/FFI), TypeScript (web adapter)
+
+**Design decision:** ZWSP remains as an internal parser placeholder (the parser needs source text to produce ProjNodes). The fix strips ZWSP at every boundary where text leaves the editor. Long-term fix is Container per-block text migration (tracked separately).
+
+---
+
+### Task 1: Add `export_text` method to SyncEditor
+
+Strip ZWSP from the text returned to consumers. `get_text()` stays unchanged (internal, position-consistent with source map). `export_text()` is the user-facing export path.
+
+**Files:**
+- Modify: `editor/sync_editor_text.mbt:71-73`
+- Test: `editor/sync_editor_test.mbt` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+In `editor/sync_editor_test.mbt`, append:
+
+```moonbit
+///|
+test "export_text strips ZWSP" {
+  let se = @editor.SyncEditor::new(
+    "test",
+    fn(s) { @loom.new_imperative_parser(s, @lambda.lambda_grammar) },
+  )
+  se.set_text("hello\u200Bworld")
+  inspect(se.get_text(), content="hello\u200Bworld")
+  inspect(se.export_text(), content="helloworld")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/editor -f sync_editor_test.mbt`
+Expected: FAIL — `export_text` method does not exist.
+
+- [ ] **Step 3: Implement `export_text`**
+
+In `editor/sync_editor_text.mbt`, after the `get_text` function (line 73), add:
+
+```moonbit
+///|
+/// Return document text with ZWSP placeholders stripped.
+/// Use this for export, clipboard, and display — not for internal position math.
+pub fn[T] SyncEditor::export_text(self : SyncEditor[T]) -> String {
+  self.doc.text().replace_all(old="\u200B", new="")
+}
+```
+
+- [ ] **Step 4: Run `moon check`**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon check`
+Expected: no errors.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/editor -f sync_editor_test.mbt`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add editor/sync_editor_text.mbt editor/sync_editor_test.mbt
+git commit -m "feat(editor): add export_text() that strips ZWSP placeholders"
+```
+
+---
+
+### Task 2: Add `markdown_export_text` FFI function
+
+Wire the clean export path through FFI so TypeScript can call it.
+
+**Files:**
+- Modify: `ffi/canopy_markdown.mbt:28-33`
+
+- [ ] **Step 1: Add `markdown_export_text` to FFI**
+
+In `ffi/canopy_markdown.mbt`, after the `markdown_get_text` function (line 33), add:
+
+```moonbit
+///|
+pub fn markdown_export_text(handle : Int) -> String {
+  match markdown_editors.get(handle) {
+    Some(ed) => ed.export_text()
+    None => ""
+  }
+}
+```
+
+- [ ] **Step 2: Run `moon check`**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add ffi/canopy_markdown.mbt
+git commit -m "feat(ffi): add markdown_export_text() for ZWSP-free text export"
+```
+
+---
+
+### Task 3: Wire raw-mode sync through clean export
+
+The raw editor textarea should show ZWSP-free text. Currently `syncRawFromModel()` calls `markdown_get_text()`.
+
+**Files:**
+- Modify: `examples/web/src/markdown-editor.ts:78`
+
+- [ ] **Step 1: Update `syncRawFromModel` to use `markdown_export_text`**
+
+In `examples/web/src/markdown-editor.ts`, change line 78:
+
+```typescript
+// Before:
+const text = crdt.markdown_get_text(handle);
+
+// After:
+const text = crdt.markdown_export_text(handle);
+```
+
+- [ ] **Step 2: Verify the TS import**
+
+Check that `markdown_export_text` is exported from `@moonbit/crdt`. If not, it needs to be added to the JS build exports. Run:
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon build --target js 2>&1 | tail -5
+```
+
+Then verify `markdown_export_text` appears in the generated JS bundle.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add examples/web/src/markdown-editor.ts
+git commit -m "fix(web): use markdown_export_text for raw-mode sync"
+```
+
+---
+
+### Task 4: ZWSP cleanup pass in `compute_commit_edit`
+
+When a block's text is committed via the block editor, strip any ZWSP from the incoming text. This catches cases where ZWSP might enter via programmatic editing or sync.
+
+**Files:**
+- Modify: `lang/markdown/edits/compute_markdown_edit.mbt:28-56`
+- Test: `lang/markdown/edits/compute_markdown_edit_wbtest.mbt` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+In `lang/markdown/edits/compute_markdown_edit_wbtest.mbt`, append:
+
+```moonbit
+///|
+test "commit_edit: strips ZWSP from new text" {
+  let source = "Hello\n"
+  let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")
+  let para_id = proj.children[0].id()
+  let result = apply_edit(
+    source,
+    CommitEdit(node_id=para_id, new_text="wo\u200Brld"),
+  )
+  inspect(result.contains("\u200B"), content="false")
+  inspect(result.contains("world"), content="true")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/lang/markdown/edits -f compute_markdown_edit_wbtest.mbt`
+Expected: FAIL — result still contains ZWSP.
+
+- [ ] **Step 3: Add ZWSP stripping in `compute_commit_edit`**
+
+In `lang/markdown/edits/compute_markdown_edit.mbt`, modify `compute_commit_edit` to strip ZWSP from `new_text`:
+
+```moonbit
+fn compute_commit_edit(
+  source_map : SourceMap,
+  node_id : NodeId,
+  new_text : String,
+) -> Result[(Array[SpanEdit], FocusHint)?, String] {
+  // Strip ZWSP placeholder — block-input.ts strips on the TS side,
+  // but this catches programmatic or sync-originated text.
+  let clean_text = new_text.replace_all(old="\u200B", new="")
+  // Try "text" role first, fall back to "code" for code blocks
+  let range = match source_map.get_token_span(node_id, "text") {
+    Some(r) => r
+    None =>
+      match source_map.get_token_span(node_id, "code") {
+        Some(r) => r
+        None => return Err("no editable span for node " + node_id.to_string())
+      }
+  }
+  Ok(
+    Some(
+      (
+        [
+          SpanEdit::{
+            start: range.start,
+            delete_len: range.end - range.start,
+            inserted: clean_text,
+          },
+        ],
+        FocusHint::MoveCursor(position=range.start + clean_text.length()),
+      ),
+    ),
+  )
+}
+```
+
+- [ ] **Step 4: Run `moon check`**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon check`
+Expected: no errors.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/lang/markdown/edits -f compute_markdown_edit_wbtest.mbt`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add lang/markdown/edits/compute_markdown_edit.mbt lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+git commit -m "fix(markdown): strip ZWSP in compute_commit_edit"
+```
+
+---
+
+### Task 5: ZWSP cleanup in `InsertBlockAfter` and `SplitBlock` comments
+
+Document that ZWSP is intentional in these functions and will be cleaned at boundaries.
+
+**Files:**
+- Modify: `lang/markdown/edits/compute_markdown_edit.mbt:190-193`
+
+- [ ] **Step 1: Update comments**
+
+In `compute_insert_block_after` (line 190-193), update the comment:
+
+```moonbit
+  // Insert "\n\u200B\n" to create a visible empty paragraph.
+  // The zero-width space gives the parser a real token to produce a ProjNode,
+  // so BlockInput can render and focus the new block. ZWSP is stripped at:
+  //   - export_text() (MoonBit export boundary)
+  //   - block-input.ts (TS display/edit boundary)
+  //   - compute_commit_edit (on first keystroke)
+  //   - compute_merge_with_previous (on block merge)
+  // Long-term fix: migrate to Container per-block text (empty block = empty text).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add lang/markdown/edits/compute_markdown_edit.mbt
+git commit -m "docs(markdown): document ZWSP cleanup boundaries"
+```
+
+---
+
+### Task 6: End-to-end ZWSP round-trip test
+
+Verify the full lifecycle: insert block → ZWSP exists internally → export strips it.
+
+**Files:**
+- Test: `lang/markdown/edits/compute_markdown_edit_wbtest.mbt` (append)
+
+- [ ] **Step 1: Write end-to-end test**
+
+In `lang/markdown/edits/compute_markdown_edit_wbtest.mbt`, append:
+
+```moonbit
+///|
+test "insert_block_after: ZWSP present in raw text, absent in export" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("Hello\n")
+  // Force projection cycle
+  let state = @editor.ViewUpdateState::new()
+  let _ = @editor.compute_view_patches(state, ed)
+  let proj = ed.get_proj_node().unwrap()
+  let para_id = proj.children[0].id()
+  let result = apply_markdown_edit(ed, InsertBlockAfter(node_id=para_id), 0)
+  inspect(result is Ok(_), content="true")
+  // Raw text has ZWSP (parser needs it)
+  inspect(ed.get_text().contains("\u200B"), content="true")
+  // Exported text is clean
+  inspect(ed.export_text().contains("\u200B"), content="false")
+}
+
+///|
+test "merge cleans up ZWSP from empty block" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("Hello\n")
+  let state = @editor.ViewUpdateState::new()
+  let _ = @editor.compute_view_patches(state, ed)
+  // Insert an empty block after "Hello"
+  let proj = ed.get_proj_node().unwrap()
+  let para_id = proj.children[0].id()
+  let _ = apply_markdown_edit(ed, InsertBlockAfter(node_id=para_id), 0)
+  // Force re-projection to get new block's ID
+  let _ = @editor.compute_view_patches(state, ed)
+  let proj2 = ed.get_proj_node().unwrap()
+  // The new empty block should be at index 1
+  guard proj2.children.length() >= 2 else {
+    return // skip if projection didn't produce expected structure
+  }
+  let empty_block_id = proj2.children[1].id()
+  // Merge the empty block back into previous
+  let merge_result = apply_markdown_edit(
+    ed,
+    MergeWithPrevious(node_id=empty_block_id),
+    0,
+  )
+  inspect(merge_result is Ok(_), content="true")
+  // After merge, ZWSP should be gone from raw text too
+  inspect(ed.get_text().contains("\u200B"), content="false")
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/lang/markdown/edits -f compute_markdown_edit_wbtest.mbt`
+Expected: PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test`
+Expected: all 807+ tests pass.
+
+- [ ] **Step 4: Run `moon info && moon fmt`**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon info && moon fmt`
+Then check: `git diff *.mbti` — verify only `export_text` and `markdown_export_text` are added, no trait bound widening.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+git commit -m "test(markdown): add ZWSP round-trip and merge cleanup tests"
+```
+
+---
+
+### Task 7: Update TODO.md
+
+Mark the ZWSP cleanup item as done and add a future item for Container migration.
+
+**Files:**
+- Modify: `docs/TODO.md`
+
+- [ ] **Step 1: Update the ZWSP item in §14**
+
+Change:
+```markdown
+- [ ] **ZWSP cleanup for empty blocks** — ...
+```
+To:
+```markdown
+- [x] **ZWSP cleanup for empty blocks** — `export_text()` strips ZWSP at all export boundaries. `compute_commit_edit` strips on text commit. ZWSP remains as internal parser placeholder only.
+```
+
+- [ ] **Step 2: Verify a future TODO exists for Container migration**
+
+In §16 (Unified Container), the Phase 4 item already exists. No additional item needed — the long-term ZWSP elimination is a natural consequence of per-block text.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
+git add docs/TODO.md
+git commit -m "docs: mark ZWSP cleanup done in TODO.md"
+```

--- a/docs/plans/2026-04-11-zwsp-cleanup.md
+++ b/docs/plans/2026-04-11-zwsp-cleanup.md
@@ -4,83 +4,28 @@
 
 **Goal:** Eliminate ZWSP (U+200B) leakage from Markdown block editor export/display boundaries while keeping it as an internal parser placeholder.
 
-**Architecture:** Add `export_markdown_text()` FFI function that strips ZWSP. Add a ZWSP cleanup pass in `compute_commit_edit` so editing any block also scrubs neighboring ZWSP. Wire the raw-mode sync through the clean export path.
+**Architecture:** Add `markdown_export_text()` FFI function that strips ZWSP at the markdown-specific boundary. Wire the raw-mode sync through the clean export path. ZWSP stripping is markdown-specific — not on the generic `SyncEditor[T]`.
 
-**Tech Stack:** MoonBit (editor/FFI), TypeScript (web adapter)
+**Tech Stack:** MoonBit (FFI), TypeScript (web adapter)
 
-**Design decision:** ZWSP remains as an internal parser placeholder (the parser needs source text to produce ProjNodes). The fix strips ZWSP at every boundary where text leaves the editor. Long-term fix is Container per-block text migration (tracked separately).
+**Design decisions:**
+- ZWSP remains as an internal parser placeholder (the parser needs source text to produce ProjNodes).
+- Stripping lives in the markdown FFI layer, not on generic `SyncEditor[T]` — avoids stripping legitimate ZWSP from other editors or markdown code blocks.
+- `block-input.ts` already strips ZWSP on display/edit/commit (3 sites). `compute_merge_with_previous` already handles ZWSP on merge.
+- `compute_commit_edit` is NOT modified — the TS boundary already strips, and adding a second strip would forbid intentional ZWSP in code blocks.
+- Preview mode: ZWSP is invisible in HTML rendering. Copy-paste from preview is a known minor gap — one-line fix if reported.
+- Long-term fix is Container per-block text migration (tracked separately in TODO §16).
 
----
-
-### Task 1: Add `export_text` method to SyncEditor
-
-Strip ZWSP from the text returned to consumers. `get_text()` stays unchanged (internal, position-consistent with source map). `export_text()` is the user-facing export path.
-
-**Files:**
-- Modify: `editor/sync_editor_text.mbt:71-73`
-- Test: `editor/sync_editor_test.mbt` (append)
-
-- [ ] **Step 1: Write the failing test**
-
-In `editor/sync_editor_test.mbt`, append:
-
-```moonbit
-///|
-test "export_text strips ZWSP" {
-  let se = @editor.SyncEditor::new(
-    "test",
-    fn(s) { @loom.new_imperative_parser(s, @lambda.lambda_grammar) },
-  )
-  se.set_text("hello\u200Bworld")
-  inspect(se.get_text(), content="hello\u200Bworld")
-  inspect(se.export_text(), content="helloworld")
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/editor -f sync_editor_test.mbt`
-Expected: FAIL — `export_text` method does not exist.
-
-- [ ] **Step 3: Implement `export_text`**
-
-In `editor/sync_editor_text.mbt`, after the `get_text` function (line 73), add:
-
-```moonbit
-///|
-/// Return document text with ZWSP placeholders stripped.
-/// Use this for export, clipboard, and display — not for internal position math.
-pub fn[T] SyncEditor::export_text(self : SyncEditor[T]) -> String {
-  self.doc.text().replace_all(old="\u200B", new="")
-}
-```
-
-- [ ] **Step 4: Run `moon check`**
-
-Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon check`
-Expected: no errors.
-
-- [ ] **Step 5: Run test to verify it passes**
-
-Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/editor -f sync_editor_test.mbt`
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
-
-```bash
-cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
-git add editor/sync_editor_text.mbt editor/sync_editor_test.mbt
-git commit -m "feat(editor): add export_text() that strips ZWSP placeholders"
-```
+**Known gap:** `MarkdownPreview` renders `node.text` as-is. ZWSP is invisible in HTML but could leak on copy-paste from preview. Not addressed here — trivial fix if needed.
 
 ---
 
-### Task 2: Add `markdown_export_text` FFI function
+### Task 1: Add `markdown_export_text` FFI function
 
-Wire the clean export path through FFI so TypeScript can call it.
+Strip ZWSP at the markdown-specific FFI boundary. `markdown_get_text()` stays unchanged (internal, position-consistent with source map).
 
 **Files:**
-- Modify: `ffi/canopy_markdown.mbt:28-33`
+- Modify: `ffi/canopy_markdown.mbt` (after line 33)
 
 - [ ] **Step 1: Add `markdown_export_text` to FFI**
 
@@ -88,9 +33,11 @@ In `ffi/canopy_markdown.mbt`, after the `markdown_get_text` function (line 33), 
 
 ```moonbit
 ///|
+/// Return markdown text with ZWSP placeholders stripped.
+/// Use for export, clipboard, raw-mode display — not for internal position math.
 pub fn markdown_export_text(handle : Int) -> String {
   match markdown_editors.get(handle) {
-    Some(ed) => ed.export_text()
+    Some(ed) => ed.get_text().replace_all(old="\u200B", new="")
     None => ""
   }
 }
@@ -111,7 +58,7 @@ git commit -m "feat(ffi): add markdown_export_text() for ZWSP-free text export"
 
 ---
 
-### Task 3: Wire raw-mode sync through clean export
+### Task 2: Wire raw-mode sync through clean export
 
 The raw editor textarea should show ZWSP-free text. Currently `syncRawFromModel()` calls `markdown_get_text()`.
 
@@ -130,15 +77,17 @@ const text = crdt.markdown_get_text(handle);
 const text = crdt.markdown_export_text(handle);
 ```
 
-- [ ] **Step 2: Verify the TS import**
+- [ ] **Step 2: Verify the JS build**
 
-Check that `markdown_export_text` is exported from `@moonbit/crdt`. If not, it needs to be added to the JS build exports. Run:
-
+Run:
 ```bash
 cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon build --target js 2>&1 | tail -5
 ```
 
-Then verify `markdown_export_text` appears in the generated JS bundle.
+Then verify `markdown_export_text` appears in the generated JS. Check:
+```bash
+grep -l 'markdown_export_text' _build/js/release/build/*.js
+```
 
 - [ ] **Step 3: Commit**
 
@@ -150,120 +99,35 @@ git commit -m "fix(web): use markdown_export_text for raw-mode sync"
 
 ---
 
-### Task 4: ZWSP cleanup pass in `compute_commit_edit`
+### Task 3: Document ZWSP cleanup boundaries
 
-When a block's text is committed via the block editor, strip any ZWSP from the incoming text. This catches cases where ZWSP might enter via programmatic editing or sync.
-
-**Files:**
-- Modify: `lang/markdown/edits/compute_markdown_edit.mbt:28-56`
-- Test: `lang/markdown/edits/compute_markdown_edit_wbtest.mbt` (append)
-
-- [ ] **Step 1: Write the failing test**
-
-In `lang/markdown/edits/compute_markdown_edit_wbtest.mbt`, append:
-
-```moonbit
-///|
-test "commit_edit: strips ZWSP from new text" {
-  let source = "Hello\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")
-  let para_id = proj.children[0].id()
-  let result = apply_edit(
-    source,
-    CommitEdit(node_id=para_id, new_text="wo\u200Brld"),
-  )
-  inspect(result.contains("\u200B"), content="false")
-  inspect(result.contains("world"), content="true")
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/lang/markdown/edits -f compute_markdown_edit_wbtest.mbt`
-Expected: FAIL — result still contains ZWSP.
-
-- [ ] **Step 3: Add ZWSP stripping in `compute_commit_edit`**
-
-In `lang/markdown/edits/compute_markdown_edit.mbt`, modify `compute_commit_edit` to strip ZWSP from `new_text`:
-
-```moonbit
-fn compute_commit_edit(
-  source_map : SourceMap,
-  node_id : NodeId,
-  new_text : String,
-) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  // Strip ZWSP placeholder — block-input.ts strips on the TS side,
-  // but this catches programmatic or sync-originated text.
-  let clean_text = new_text.replace_all(old="\u200B", new="")
-  // Try "text" role first, fall back to "code" for code blocks
-  let range = match source_map.get_token_span(node_id, "text") {
-    Some(r) => r
-    None =>
-      match source_map.get_token_span(node_id, "code") {
-        Some(r) => r
-        None => return Err("no editable span for node " + node_id.to_string())
-      }
-  }
-  Ok(
-    Some(
-      (
-        [
-          SpanEdit::{
-            start: range.start,
-            delete_len: range.end - range.start,
-            inserted: clean_text,
-          },
-        ],
-        FocusHint::MoveCursor(position=range.start + clean_text.length()),
-      ),
-    ),
-  )
-}
-```
-
-- [ ] **Step 4: Run `moon check`**
-
-Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon check`
-Expected: no errors.
-
-- [ ] **Step 5: Run test to verify it passes**
-
-Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon test -p dowdiness/canopy/lang/markdown/edits -f compute_markdown_edit_wbtest.mbt`
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
-
-```bash
-cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
-git add lang/markdown/edits/compute_markdown_edit.mbt lang/markdown/edits/compute_markdown_edit_wbtest.mbt
-git commit -m "fix(markdown): strip ZWSP in compute_commit_edit"
-```
-
----
-
-### Task 5: ZWSP cleanup in `InsertBlockAfter` and `SplitBlock` comments
-
-Document that ZWSP is intentional in these functions and will be cleaned at boundaries.
+Update comments in `InsertBlockAfter` to document where ZWSP is stripped and why.
 
 **Files:**
 - Modify: `lang/markdown/edits/compute_markdown_edit.mbt:190-193`
 
 - [ ] **Step 1: Update comments**
 
-In `compute_insert_block_after` (line 190-193), update the comment:
+In `compute_insert_block_after` (line 190-193), replace the existing comment block:
 
 ```moonbit
   // Insert "\n\u200B\n" to create a visible empty paragraph.
   // The zero-width space gives the parser a real token to produce a ProjNode,
   // so BlockInput can render and focus the new block. ZWSP is stripped at:
-  //   - export_text() (MoonBit export boundary)
-  //   - block-input.ts (TS display/edit boundary)
-  //   - compute_commit_edit (on first keystroke)
-  //   - compute_merge_with_previous (on block merge)
+  //   - markdown_export_text() (FFI export boundary — raw mode, clipboard)
+  //   - block-input.ts (TS display/edit/commit — 3 sites)
+  //   - compute_merge_with_previous (on block merge, line 307)
+  // Known minor gap: MarkdownPreview renders node.text as-is (ZWSP invisible
+  // in HTML, but could leak on copy-paste from preview).
   // Long-term fix: migrate to Container per-block text (empty block = empty text).
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 2: Run `moon check`**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
 
 ```bash
 cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup
@@ -273,14 +137,14 @@ git commit -m "docs(markdown): document ZWSP cleanup boundaries"
 
 ---
 
-### Task 6: End-to-end ZWSP round-trip test
+### Task 4: End-to-end ZWSP round-trip tests
 
-Verify the full lifecycle: insert block → ZWSP exists internally → export strips it.
+Verify the full lifecycle: insert block → ZWSP exists internally → FFI export strips it → merge cleans it up.
 
 **Files:**
 - Test: `lang/markdown/edits/compute_markdown_edit_wbtest.mbt` (append)
 
-- [ ] **Step 1: Write end-to-end test**
+- [ ] **Step 1: Write end-to-end tests**
 
 In `lang/markdown/edits/compute_markdown_edit_wbtest.mbt`, append:
 
@@ -298,8 +162,9 @@ test "insert_block_after: ZWSP present in raw text, absent in export" {
   inspect(result is Ok(_), content="true")
   // Raw text has ZWSP (parser needs it)
   inspect(ed.get_text().contains("\u200B"), content="true")
-  // Exported text is clean
-  inspect(ed.export_text().contains("\u200B"), content="false")
+  // Export strips ZWSP
+  let exported = ed.get_text().replace_all(old="\u200B", new="")
+  inspect(exported.contains("\u200B"), content="false")
 }
 
 ///|
@@ -345,7 +210,7 @@ Expected: all 807+ tests pass.
 - [ ] **Step 4: Run `moon info && moon fmt`**
 
 Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup && moon info && moon fmt`
-Then check: `git diff *.mbti` — verify only `export_text` and `markdown_export_text` are added, no trait bound widening.
+Then check: `git diff *.mbti` — verify only `markdown_export_text` is added to `ffi/pkg.generated.mbti`, no trait bound widening.
 
 - [ ] **Step 5: Commit**
 
@@ -357,9 +222,9 @@ git commit -m "test(markdown): add ZWSP round-trip and merge cleanup tests"
 
 ---
 
-### Task 7: Update TODO.md
+### Task 5: Update TODO.md
 
-Mark the ZWSP cleanup item as done and add a future item for Container migration.
+Mark the ZWSP cleanup item as done.
 
 **Files:**
 - Modify: `docs/TODO.md`
@@ -368,18 +233,16 @@ Mark the ZWSP cleanup item as done and add a future item for Container migration
 
 Change:
 ```markdown
-- [ ] **ZWSP cleanup for empty blocks** — ...
+- [ ] **ZWSP cleanup for empty blocks** — `InsertBlockAfter` inserts `\u200B` (zero-width space) as placeholder so the parser produces a ProjNode for empty paragraphs. The ZWSP is stripped on keystroke, but unused empty blocks keep it. If raw Markdown is copy-pasted to another tool, invisible ZWSP characters travel with it. Fix by either: (a) teaching the parser to produce empty paragraph nodes for consecutive blank lines, or (b) stripping all ZWSP on save/export.
+  Exit: No `\u200B` in raw Markdown output after save or copy.
 ```
 To:
 ```markdown
-- [x] **ZWSP cleanup for empty blocks** — `export_text()` strips ZWSP at all export boundaries. `compute_commit_edit` strips on text commit. ZWSP remains as internal parser placeholder only.
+- [x] **ZWSP cleanup for empty blocks** — `markdown_export_text()` FFI strips ZWSP at export boundary. `block-input.ts` strips on display/edit/commit. `compute_merge_with_previous` strips on merge. ZWSP remains as internal parser placeholder only. Long-term fix: Container per-block text (§16).
+  Exit: No `\u200B` in exported Markdown text.
 ```
 
-- [ ] **Step 2: Verify a future TODO exists for Container migration**
-
-In §16 (Unified Container), the Phase 4 item already exists. No additional item needed — the long-term ZWSP elimination is a natural consequence of per-block text.
-
-- [ ] **Step 3: Commit**
+- [ ] **Step 2: Commit**
 
 ```bash
 cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/zwsp-cleanup

--- a/examples/web/src/markdown-editor.ts
+++ b/examples/web/src/markdown-editor.ts
@@ -29,6 +29,7 @@ const handle = crdt.create_markdown_editor(agentId);
 let activeMode: Mode = 'block';
 let activeNodeId: number | null = null;
 let rawSyncScheduled = false;
+let rawDirty = false;
 
 // ---------------------------------------------------------------------------
 // DOM helpers
@@ -164,6 +165,7 @@ blockInput.onIntent((intent: UserIntent) => {
 // ---------------------------------------------------------------------------
 
 rawEditor.addEventListener('input', () => {
+  rawDirty = true;
   if (rawSyncScheduled) return;
   rawSyncScheduled = true;
   requestAnimationFrame(() => {
@@ -180,10 +182,13 @@ rawEditor.addEventListener('input', () => {
 function setMode(mode: Mode): void {
   if (mode === activeMode) return;
 
-  // Sync from current mode before switching
-  if (activeMode === 'raw') {
+  // Sync from current mode before switching — only if user edited in raw mode.
+  // If they just viewed raw mode without editing, don't write back the
+  // ZWSP-stripped display text (which would destroy empty block placeholders).
+  if (activeMode === 'raw' && rawDirty) {
     crdt.markdown_set_text(handle, rawEditor.value);
     refresh();
+    rawDirty = false;
   }
 
   activeMode = mode;
@@ -197,6 +202,7 @@ function setMode(mode: Mode): void {
   // Sync to new mode
   if (mode === 'raw') {
     syncRawFromModel();
+    rawDirty = false;
     rawEditor.focus();
   }
 

--- a/examples/web/src/markdown-editor.ts
+++ b/examples/web/src/markdown-editor.ts
@@ -75,7 +75,7 @@ function refresh(): void {
 }
 
 function syncRawFromModel(): void {
-  const text = crdt.markdown_get_text(handle);
+  const text = crdt.markdown_export_text(handle);
   if (rawEditor.value !== text) rawEditor.value = text;
 }
 

--- a/ffi/canopy_markdown.mbt
+++ b/ffi/canopy_markdown.mbt
@@ -33,6 +33,16 @@ pub fn markdown_get_text(handle : Int) -> String {
 }
 
 ///|
+/// Return markdown text with ZWSP placeholders stripped.
+/// Use for export, clipboard, raw-mode display — not for internal position math.
+pub fn markdown_export_text(handle : Int) -> String {
+  match markdown_editors.get(handle) {
+    Some(ed) => ed.get_text().replace_all(old="\u200B", new="")
+    None => ""
+  }
+}
+
+///|
 pub fn markdown_set_text(handle : Int, text : String) -> Unit {
   match markdown_editors.get(handle) {
     Some(ed) => ed.set_text(text)

--- a/ffi/canopy_markdown.mbt
+++ b/ffi/canopy_markdown.mbt
@@ -33,11 +33,12 @@ pub fn markdown_get_text(handle : Int) -> String {
 }
 
 ///|
-/// Return markdown text with ZWSP placeholders stripped.
-/// Use for export, clipboard, raw-mode display — not for internal position math.
+/// Return markdown text with ZWSP placeholder lines stripped.
+/// Only strips the "\n\u200B\n" pattern (empty-block sentinel from InsertBlockAfter),
+/// preserving legitimate ZWSP in user content (code blocks, pasted text).
 pub fn markdown_export_text(handle : Int) -> String {
   match markdown_editors.get(handle) {
-    Some(ed) => ed.get_text().replace_all(old="\u200B", new="")
+    Some(ed) => ed.get_text().replace_all(old="\n\u200B\n", new="\n\n")
     None => ""
   }
 }

--- a/ffi/moon.pkg
+++ b/ffi/moon.pkg
@@ -86,6 +86,7 @@ options(
         "create_markdown_editor",
         "destroy_markdown_editor",
         "markdown_get_text",
+        "markdown_export_text",
         "markdown_set_text",
         "markdown_compute_view_patches_json",
         "markdown_apply_edit",

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -189,8 +189,13 @@ fn compute_insert_block_after(
   let insert_pos = range.end
   // Insert "\n\u200B\n" to create a visible empty paragraph.
   // The zero-width space gives the parser a real token to produce a ProjNode,
-  // so BlockInput can render and focus the new block. CommitEdit strips it
-  // on the first keystroke.
+  // so BlockInput can render and focus the new block. ZWSP is stripped at:
+  //   - markdown_export_text() (FFI export boundary — raw mode, clipboard)
+  //   - block-input.ts (TS display/edit/commit — 3 sites)
+  //   - compute_merge_with_previous (on block merge, line 307)
+  // Known minor gap: MarkdownPreview renders node.text as-is (ZWSP invisible
+  // in HTML, but could leak on copy-paste from preview).
+  // Long-term fix: migrate to Container per-block text (empty block = empty text).
   Ok(
     Some(
       (

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -190,9 +190,9 @@ fn compute_insert_block_after(
   // Insert "\n\u200B\n" to create a visible empty paragraph.
   // The zero-width space gives the parser a real token to produce a ProjNode,
   // so BlockInput can render and focus the new block. ZWSP is stripped at:
-  //   - markdown_export_text() (FFI export boundary — raw mode, clipboard)
+  //   - markdown_export_text() (FFI export boundary — raw mode)
   //   - block-input.ts (TS display/edit/commit — 3 sites)
-  //   - compute_merge_with_previous (on block merge, line 307)
+  //   - compute_merge_with_previous (on block merge)
   // Known minor gap: MarkdownPreview renders node.text as-is (ZWSP invisible
   // in HTML, but could leak on copy-paste from preview).
   // Long-term fix: migrate to Container per-block text (empty block = empty text).

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -168,3 +168,50 @@ test "split_block: end of block inserts after" {
   inspect(result is Ok(_), content="true")
   inspect(ed.get_text().length() > 6, content="true")
 }
+
+///|
+test "insert_block_after: ZWSP present in raw text, absent in export" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("Hello\n")
+  // Force projection cycle
+  let state = @editor.ViewUpdateState::new()
+  let _ = @editor.compute_view_patches(state, ed)
+  let proj = ed.get_proj_node().unwrap()
+  let para_id = proj.children[0].id()
+  let result = apply_markdown_edit(ed, InsertBlockAfter(node_id=para_id), 0)
+  inspect(result is Ok(_), content="true")
+  // Raw text has ZWSP (parser needs it)
+  inspect(ed.get_text().contains("\u200B"), content="true")
+  // Export strips ZWSP
+  let exported = ed.get_text().replace_all(old="\u200B", new="")
+  inspect(exported.contains("\u200B"), content="false")
+}
+
+///|
+test "merge cleans up ZWSP from empty block" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("Hello\n")
+  let state = @editor.ViewUpdateState::new()
+  let _ = @editor.compute_view_patches(state, ed)
+  // Insert an empty block after "Hello"
+  let proj = ed.get_proj_node().unwrap()
+  let para_id = proj.children[0].id()
+  let _ = apply_markdown_edit(ed, InsertBlockAfter(node_id=para_id), 0)
+  // Force re-projection to get new block's ID
+  let _ = @editor.compute_view_patches(state, ed)
+  let proj2 = ed.get_proj_node().unwrap()
+  // The new empty block should be at index 1
+  guard proj2.children.length() >= 2 else { // skip if projection didn't produce expected structure
+    return
+  }
+  let empty_block_id = proj2.children[1].id()
+  // Merge the empty block back into previous
+  let merge_result = apply_markdown_edit(
+    ed,
+    MergeWithPrevious(node_id=empty_block_id),
+    0,
+  )
+  inspect(merge_result is Ok(_), content="true")
+  // After merge, ZWSP should be gone from raw text too
+  inspect(ed.get_text().contains("\u200B"), content="false")
+}

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -182,9 +182,19 @@ test "insert_block_after: ZWSP present in raw text, absent in export" {
   inspect(result is Ok(_), content="true")
   // Raw text has ZWSP (parser needs it)
   inspect(ed.get_text().contains("\u200B"), content="true")
-  // Export strips ZWSP
-  let exported = ed.get_text().replace_all(old="\u200B", new="")
+  // Export strips placeholder ZWSP (the "\n\u200B\n" pattern)
+  let exported = ed.get_text().replace_all(old="\n\u200B\n", new="\n\n")
   inspect(exported.contains("\u200B"), content="false")
+}
+
+///|
+test "export preserves legitimate ZWSP in user content" {
+  let ed = new_markdown_editor("test")
+  // Simulate user content with ZWSP inside text (e.g., pasted from another tool)
+  ed.set_text("Hello\u200Bworld\n")
+  let exported = ed.get_text().replace_all(old="\n\u200B\n", new="\n\n")
+  // Legitimate ZWSP inside text is preserved
+  inspect(exported.contains("\u200B"), content="true")
 }
 
 ///|

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -201,9 +201,10 @@ test "merge cleans up ZWSP from empty block" {
   let _ = @editor.compute_view_patches(state, ed)
   let proj2 = ed.get_proj_node().unwrap()
   // The new empty block should be at index 1
-  guard proj2.children.length() >= 2 else { // skip if projection didn't produce expected structure
-    return
-  }
+  assert_true(
+    proj2.children.length() >= 2,
+    msg="InsertBlockAfter should produce at least 2 children",
+  )
   let empty_block_id = proj2.children[1].id()
   // Merge the empty block back into previous
   let merge_result = apply_markdown_edit(


### PR DESCRIPTION
## Summary

- Add `markdown_export_text()` FFI function that strips ZWSP (U+200B) placeholders from exported markdown text
- Wire raw-mode sync through the clean export path so the raw textarea never shows ZWSP
- Add ZWSP to JS exports list in `ffi/moon.pkg`
- Document all ZWSP cleanup boundaries in `compute_insert_block_after`
- Add 2 end-to-end tests (insert→export round-trip, merge cleanup)

## Context

The markdown block editor inserts ZWSP as a parser placeholder for empty blocks (`InsertBlockAfter`). The parser needs source text to produce ProjNodes, so ZWSP is architecturally necessary as an internal detail. However, it was leaking to users via raw-mode view and export.

**Approach:** Strip ZWSP at the markdown-specific FFI boundary (`markdown_export_text`), not on generic `SyncEditor[T]`. This avoids stripping legitimate ZWSP from other editors (lambda, JSON) or markdown code blocks.

**Known minor gap:** `MarkdownPreview` renders `node.text` as-is (ZWSP is invisible in HTML, could leak on copy-paste from preview). One-line fix if reported.

**Long-term fix:** Container per-block text migration (§16) — empty blocks become tree nodes with empty text, no sentinel needed.

Design validated by Codex review before implementation.

## Test plan

- [x] 809/809 tests pass
- [x] `markdown_export_text` confirmed in JS build exports
- [x] New test: ZWSP present in raw `get_text()`, absent after export strip
- [x] New test: `MergeWithPrevious` cleans ZWSP from merged empty block
- [ ] Manual: open markdown editor, create empty block (Enter), switch to raw mode — verify no `\u200B` visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strip zero‑width space characters from exported Markdown and from raw-text editor views so exported/copyable text contains no ZWSP.

* **Documentation**
  * Updated docs to mark ZWSP cleanup complete and clarified where ZWSP is retained vs. removed during editing, preview, and merge flows.

* **Tests**
  * Added end-to-end tests for ZWSP appearance in the editor, preservation of intentional ZWSP in content, and removal during empty-block merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->