### PR TITLE
fix(btree): defensive abort + unused field warning

### DIFF
--- a/ffi/canopy_test.mbt
+++ b/ffi/canopy_test.mbt
@@ -64,12 +64,14 @@ test "get_diagnostics_json: unbound variable produces warning" {
   let eval_results = companion.get_eval_results()
   inspect(eval_results.length() > 0, content="true")
   // Check that Stuck result exists
-  let has_stuck = eval_results.iter().any(fn(r) {
-    match r {
-      @lambda.EvalResult::Stuck(_) => true
-      _ => false
-    }
-  })
+  let has_stuck = eval_results
+    .iter()
+    .any(fn(r) {
+      match r {
+        @lambda.EvalResult::Stuck(_) => true
+        _ => false
+      }
+    })
   inspect(has_stuck, content="true")
 }
 

--- a/lib/btree/btree_benchmark.mbt
+++ b/lib/btree/btree_benchmark.mbt
@@ -1,6 +1,6 @@
 ///|
 priv struct BItem {
-  value_ : Int
+  value : Int
 }
 
 ///|
@@ -29,7 +29,7 @@ impl @rle.Sliceable for BItem with slice(self, start~ : Int, end~ : Int) -> Resu
   @rle.RleError,
 ] {
   if start == 0 && end == 1 {
-    Ok(self)
+    Ok({ value: self.value })
   } else {
     Err(@rle.RleError::InvalidSlice(reason=@rle.SliceError::InvalidIndex))
   }
@@ -40,7 +40,7 @@ impl BTreeElem for BItem
 
 ///|
 fn bi(v : Int) -> BItem {
-  { value_: v }
+  { value: v }
 }
 
 ///|

--- a/lib/btree/walker_repair.mbt
+++ b/lib/btree/walker_repair.mbt
@@ -55,7 +55,7 @@ fn[T] repair_at_boundary(
         Right => 0
         Explicit(indices) => {
           let idx = indices[depth]
-          guard idx < children.length() else {
+          guard idx >= 0 && idx < children.length() else {
             abort(
               "repair_at_boundary: boundary index out of range (\{idx} >= \{children.length()})",
             )

--- a/lib/btree/walker_repair.mbt
+++ b/lib/btree/walker_repair.mbt
@@ -57,7 +57,7 @@ fn[T] repair_at_boundary(
           let idx = indices[depth]
           guard idx >= 0 && idx < children.length() else {
             abort(
-              "repair_at_boundary: boundary index out of range (\{idx} >= \{children.length()})",
+              "repair_at_boundary: boundary index out of range (idx=\{idx}, expected 0 <= idx < \{children.length()})",
             )
           }
           idx

--- a/lib/btree/walker_repair.mbt
+++ b/lib/btree/walker_repair.mbt
@@ -55,9 +55,12 @@ fn[T] repair_at_boundary(
         Right => 0
         Explicit(indices) => {
           let idx = indices[depth]
-          // Defensive clamp — shouldn't trigger since merges happen inside
-          // the boundary child, not at its parent's level.
-          if idx >= children.length() { children.length() - 1 } else { idx }
+          guard idx < children.length() else {
+            abort(
+              "repair_at_boundary: boundary index out of range (\{idx} >= \{children.length()})",
+            )
+          }
+          idx
         }
       }
       // Shallow-copy only the adjacent siblings that borrow/merge might touch.


### PR DESCRIPTION
## Summary
- Replace silent defensive clamp in `repair_at_boundary` with `guard`+`abort` to surface bugs during development instead of silently correcting
- Fix `--deny-warn` unused_field error in `btree_benchmark.mbt` by renaming `value_` → `value` and reading it in `slice()`
- `moon fmt` formatting fix in `ffi/canopy_test.mbt`

## Context
Found during idiomatic MoonBit review of `walker_repair.mbt`. The clamp at line 60 silently corrects an out-of-range boundary index that should never occur in practice (merges happen inside the boundary child, not at the parent level). An `abort` with diagnostic message is more appropriate for catching bugs.

The `BItem.value_` warning was already present on `main` and blocks `moon check --deny-warn`.

## Note
lib/btree has 4 pre-existing property test failures in `delete_range` (boundary subtrees with underfull nodes). These exist on `main` and are not affected by this PR. They are not caught by CI because lib/btree is a separate module not included in `test-all.sh`. Tracked separately.

## Test plan
- [x] `moon check --deny-warn` passes (was failing on `main`)
- [x] `moon test` — same 4 pre-existing failures as `main`, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid index operations with more explicit failure messages rather than silent correction.

* **Tests**
  * Refactored test code formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->