### PR TITLE
feat(eval): Phase 3 — Tier 1 + Tier 2 batch escalation with incremental caching

### DIFF
--- a/ffi/canopy_test.mbt
+++ b/ffi/canopy_test.mbt
@@ -64,12 +64,14 @@ test "get_diagnostics_json: unbound variable produces warning" {
   let eval_results = companion.get_eval_results()
   inspect(eval_results.length() > 0, content="true")
   // Check that Stuck result exists
-  let has_stuck = eval_results.iter().any(fn(r) {
-    match r {
-      @lambda.EvalResult::Stuck(_) => true
-      _ => false
-    }
-  })
+  let has_stuck = eval_results
+    .iter()
+    .any(fn(r) {
+      match r {
+        @lambda.EvalResult::Stuck(_) => true
+        _ => false
+      }
+    })
   inspect(has_stuck, content="true")
 }
 

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -7,7 +7,9 @@
 /// The FFI layer stores this alongside the editor.
 pub struct LambdaCompanion {
   priv proj_memo : @incr.Memo[@lambda_flat.VersionedFlatProj]
-  priv eval_memo : @incr.Memo[Array[@lambda_eval.EvalResult]]
+  // Escalation memo merges Tier 1 (direct) + Tier 2 (egglog) results.
+  // Falls back to Tier 1 results when no definitions are Suppressed.
+  priv escalation_memo : @incr.Memo[Array[@lambda_eval.EvalResult]]
 }
 
 ///|
@@ -21,7 +23,8 @@ pub fn LambdaCompanion::get_flat_proj(
 pub fn LambdaCompanion::get_eval_results(
   self : LambdaCompanion,
 ) -> Array[@lambda_eval.EvalResult] {
-  self.eval_memo.get()
+  // Return escalated results (Tier 1 + Tier 2 merge)
+  self.escalation_memo.get()
 }
 
 ///|
@@ -95,6 +98,9 @@ pub fn new_lambda_editor(
   let eval_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?] = Ref::new(
     None,
   )
+  let escalation_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?] = Ref::new(
+    None,
+  )
   let cached_proj_node_ref : Ref[@incr.Memo[@core.ProjNode[@ast.Term]?]?] = Ref::new(
     None,
   )
@@ -109,26 +115,34 @@ pub fn new_lambda_editor(
       cached_proj_node_ref.val = Some(cached_proj_node)
       let eval_memo = @lambda_eval.build_eval_memo(rt, syntax_tree, parser)
       eval_memo_ref.val = Some(eval_memo)
+      // Escalation memo: merges Tier 1 + Tier 2 for incomplete programs
+      let escalation_memo = @lambda_eval.build_escalation_memo(
+        rt, eval_memo, syntax_tree, parser,
+      )
+      escalation_memo_ref.val = Some(escalation_memo)
       (cached_proj_node, registry_memo, source_map_memo)
     },
     capture_timeout_ms~,
-    capabilities=build_lambda_capabilities(cached_proj_node_ref, eval_memo_ref),
+    capabilities=build_lambda_capabilities(
+      cached_proj_node_ref, escalation_memo_ref,
+    ),
   )
   let companion : LambdaCompanion = {
     proj_memo: proj_memo_ref.val.unwrap(),
-    eval_memo: eval_memo_ref.val.unwrap(),
+    escalation_memo: escalation_memo_ref.val.unwrap(),
   }
   (editor, companion)
 }
 
 ///|
+/// Build capabilities using the escalation memo (Tier 1 + Tier 2 merged results).
 fn build_lambda_capabilities(
   cached_proj_node_ref : Ref[@incr.Memo[@core.ProjNode[@ast.Term]?]?],
-  eval_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?],
+  escalation_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?],
 ) -> @editor.LanguageCapabilities[@ast.Term] {
   @editor.LanguageCapabilities::new(
     get_annotations=Some(fn() {
-      let eval_results = match eval_memo_ref.val {
+      let eval_results = match escalation_memo_ref.val {
         Some(memo) => memo.get()
         None => return {}
       }
@@ -139,7 +153,7 @@ fn build_lambda_capabilities(
       build_eval_annotations(eval_results, proj_node)
     }),
     pretty_post_process=Some(fn(layout) {
-      let eval_results = match eval_memo_ref.val {
+      let eval_results = match escalation_memo_ref.val {
         Some(memo) => memo.get()
         None => return layout
       }

--- a/lang/lambda/eval/batch_escalation.mbt
+++ b/lang/lambda/eval/batch_escalation.mbt
@@ -1,0 +1,279 @@
+// Batch escalation: Tier 1 → Tier 2 for incomplete programs.
+//
+// When Tier 1 (direct eval) encounters a stuck expression (hole, parse error),
+// it suppresses all subsequent definitions. Tier 2 (egglog relational eval)
+// can evaluate around holes — independent definitions that don't depend on
+// the stuck binding can still produce results.
+//
+// Algorithm:
+// 1. Run Tier 1 sequentially (already done by eval_memo)
+// 2. If any results are Suppressed, re-walk the Module to extract defs/terms
+// 3. Re-evaluate the successful prefix to recover raw Values for env construction
+// 4. Build partial environments: include Value bindings, exclude Stuck names
+// 5. Seed suppressed defs into one egglog Database with partial envs
+// 6. Run Datalog + Bridge loop until fixpoint
+// 7. Merge: Tier 1 Value/Stuck stay; Suppressed replaced by Tier 2 if resolved
+
+///|
+/// Maximum rounds of iterative forward propagation.
+/// A chain of N dependent definitions after a hole needs N rounds.
+const MAX_ESCALATION_ROUNDS = 10
+
+///|
+/// Internal state tracking per-definition evaluation for escalation.
+priv struct DefState {
+  name : String
+  term : @ast.Term
+  result : EvalResult
+  raw_value : @lambda_eval.Value?
+}
+
+///|
+/// Build the escalation memo that merges Tier 1 and Tier 2 results.
+///
+/// Depends on the Tier 1 eval_memo. If no results are Suppressed,
+/// returns Tier 1 results directly (fast path). Otherwise, runs
+/// batch egglog evaluation for suppressed definitions.
+pub fn build_escalation_memo(
+  rt : @incr.Runtime,
+  eval_memo : @incr.Memo[Array[EvalResult]],
+  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
+  parser : @loom.ImperativeParser[@ast.Term],
+) -> @incr.Memo[Array[EvalResult]] {
+  @incr.Memo::new_no_backdate(
+    rt,
+    fn() -> Array[EvalResult] {
+      let tier1_results = eval_memo.get()
+      // Fast path: no suppressed results → no escalation needed
+      guard tier1_results.iter().any(fn(r) { r == Suppressed }) else {
+        return tier1_results
+      }
+      // Need syntax_tree dependency for reactive tracking
+      let _ = syntax_tree.get()
+      let ast = parser.get_tree().unwrap_or(@ast.Term::Unit)
+      escalate_suppressed(ast, tier1_results)
+    },
+    label="escalation_memo",
+  )
+}
+
+///|
+/// Run batch escalation for suppressed definitions.
+///
+/// Re-walks the Module AST to extract definition terms, re-evaluates the
+/// successful prefix to recover raw Values, then runs egglog for each
+/// suppressed definition with a partial environment.
+fn escalate_suppressed(
+  ast : @ast.Term,
+  tier1_results : Array[EvalResult],
+) -> Array[EvalResult] {
+  let (defs, body) = match ast {
+    Module(defs, body) => (defs, Some(body))
+    _ => return tier1_results // non-Module: nothing to escalate
+  }
+  // Re-evaluate the successful prefix to recover raw Values and track env state.
+  // This duplicates Tier 1 work for the prefix but is necessary to get raw Values.
+  let def_states = build_def_states(defs, body, tier1_results)
+  // Collect candidates: indices of Suppressed results
+  let candidates : Array[Int] = []
+  for i, state in def_states {
+    if state.result == Suppressed {
+      candidates.push(i)
+    }
+  }
+  if candidates.is_empty() {
+    return tier1_results
+  }
+  // Run batch egglog evaluation
+  run_batch_egglog(def_states, candidates)
+}
+
+///|
+/// Re-evaluate the Module's successful prefix to recover raw Values.
+///
+/// For each definition:
+/// - If Tier 1 result is Value: re-evaluate to get the raw Value
+/// - If Tier 1 result is Stuck: mark name as blocked (shadows earlier bindings)
+/// - If Tier 1 result is Suppressed: record for escalation
+fn build_def_states(
+  defs : Array[(@ast.VarName, @ast.Term)],
+  body : @ast.Term?,
+  tier1_results : Array[EvalResult],
+) -> Array[DefState] {
+  let states : Array[DefState] = []
+  let mut env = @lambda_eval.Env::empty()
+  for i, def in defs {
+    let (name, expr) = def
+    let result = tier1_results.get(i).unwrap_or(Suppressed)
+    match result {
+      Value(_) => {
+        // Re-evaluate to get the raw Value for env construction.
+        // Cannot fail: Tier 1 already produced Value for this exact env+expr.
+        let raw = @lambda_eval.eval(env, expr) catch {
+          e =>
+            abort(
+              "build_def_states: Tier 1 said Value but re-eval failed: " +
+              e.to_string(),
+            )
+        }
+        env = env.extend(name, raw)
+        states.push({ name, term: expr, result, raw_value: Some(raw) })
+      }
+      Stuck(_) =>
+        // Stuck binding shadows the name but provides no value.
+        // Do NOT extend env — downstream Tier 1 re-evaluation will fail
+        // on lookup, which is correct. The egglog escalation path uses
+        // blocked_names in run_batch_egglog to exclude this name from
+        // partial environments.
+        states.push({ name, term: expr, result, raw_value: None })
+      Suppressed => states.push({ name, term: expr, result, raw_value: None })
+    }
+  }
+  // Body
+  if body is Some(body_term) {
+    let body_result = if defs.length() < tier1_results.length() {
+      tier1_results[defs.length()]
+    } else {
+      Suppressed
+    }
+    states.push({
+      name: "_body",
+      term: body_term,
+      result: body_result,
+      raw_value: None,
+    })
+  }
+  states
+}
+
+///|
+/// Run batch egglog evaluation for suppressed definitions with forward
+/// propagation: recovered values from earlier defs feed into later ones.
+///
+/// Uses iterative evaluation: each round evaluates all unresolved candidates,
+/// collects newly-resolved values, and feeds them forward. Converges when
+/// no new resolutions occur or all candidates are resolved.
+fn run_batch_egglog(
+  def_states : Array[DefState],
+  candidates : Array[Int],
+) -> Array[EvalResult] {
+  let results : Array[EvalResult] = def_states.map(fn(s) { s.result })
+  let rules = @egglog_eval.eval_rules()
+  let recovered_values : Map[Int, @lambda_eval.Value] = {}
+  for i, state in def_states {
+    match state.raw_value {
+      Some(v) => recovered_values[i] = v
+      None => ()
+    }
+  }
+  // Iterative escalation: keep resolving until no progress
+  let mut unresolved = candidates
+  for round = 0; round < MAX_ESCALATION_ROUNDS; round = round + 1 {
+    if unresolved.is_empty() {
+      break
+    }
+    let mut progress = false
+    let next_unresolved : Array[Int] = []
+    for candidate_idx in unresolved {
+      let state = def_states[candidate_idx]
+      let db = @egglog_eval.lambda_eval_db()
+      // Build partial env: reverse walk handles shadowing via seen_names.
+      // Defs without a recovered value are simply absent from the env.
+      let bindings = build_candidate_bindings(
+        def_states, recovered_values, candidate_idx,
+      )
+      let env_id = build_partial_env(db, bindings)
+      let expr_id = seed_term(db, state.term)
+      let eval_result = @egglog_eval.run_eval(db, env_id, expr_id, rules)
+      match eval_result {
+        Some(val) => {
+          let display = match extract_egglog_value_string(db, val) {
+            Some(s) => Value(s)
+            None => Suppressed
+          }
+          if display is Value(_) {
+            results[candidate_idx] = display
+            // Recover raw value for forward propagation.
+            // On failure, leave unavailable rather than wrongly bound.
+            try {
+              let env = build_tier1_env(
+                def_states, recovered_values, candidate_idx,
+              )
+              let raw = @lambda_eval.eval(env, state.term)
+              recovered_values[candidate_idx] = raw
+            } catch {
+              _ => ()
+            }
+            progress = true
+          } else {
+            next_unresolved.push(candidate_idx)
+          }
+        }
+        None =>
+          match db.lookup("EvalError", [env_id, expr_id]) {
+            Some(@egglog.StrVal(msg)) => {
+              results[candidate_idx] = Stuck(
+                "\u{2039}type error: " + msg + "\u{203a}",
+              )
+              progress = true
+            }
+            _ => next_unresolved.push(candidate_idx)
+          }
+      }
+    }
+    unresolved = next_unresolved
+    if !progress {
+      break
+    }
+  }
+  results
+}
+
+///|
+/// Build bindings for a candidate's partial env using reverse walk for shadowing.
+/// Later defs shadow earlier ones. Defs without a value (stuck/unresolved)
+/// shadow their name — the name is simply absent from the result.
+fn build_candidate_bindings(
+  def_states : Array[DefState],
+  recovered_values : Map[Int, @lambda_eval.Value],
+  candidate_idx : Int,
+) -> Array[(String, @lambda_eval.Value)] {
+  let bindings : Array[(String, @lambda_eval.Value)] = []
+  let seen_names : Map[String, Bool] = {}
+  for j = candidate_idx - 1; j >= 0; j = j - 1 {
+    let prev = def_states[j]
+    if seen_names.get(prev.name).unwrap_or(false) {
+      continue
+    }
+    seen_names[prev.name] = true
+    match recovered_values.get(j) {
+      Some(v) => bindings.push((prev.name, v))
+      None => () // stuck/unresolved — name absent, correctly shadows earlier
+    }
+  }
+  bindings
+}
+
+///|
+/// Build a Tier 1 Env from available values for re-evaluation.
+/// Uses forward walk with a mutable map: later defs overwrite earlier ones,
+/// and defs without values remove the name (correct shadowing).
+fn build_tier1_env(
+  def_states : Array[DefState],
+  recovered_values : Map[Int, @lambda_eval.Value],
+  up_to_index : Int,
+) -> @lambda_eval.Env {
+  let bindings : Map[String, @lambda_eval.Value] = {}
+  for j = 0; j < up_to_index; j = j + 1 {
+    let prev = def_states[j]
+    match recovered_values.get(j) {
+      Some(v) => bindings[prev.name] = v
+      None => bindings.remove(prev.name) // stuck def removes the binding
+    }
+  }
+  let mut env = @lambda_eval.Env::empty()
+  for name, v in bindings {
+    env = env.extend(name, v)
+  }
+  env
+}

--- a/lang/lambda/eval/batch_escalation_wbtest.mbt
+++ b/lang/lambda/eval/batch_escalation_wbtest.mbt
@@ -1,0 +1,235 @@
+// Tests for batch escalation (Tier 1 → Tier 2).
+//
+// The key scenario: when Tier 1 stops at a stuck definition (hole, error),
+// subsequent independent definitions are Suppressed. Tier 2 (egglog) can
+// evaluate around holes — it resolves what it can via partial environments.
+
+///|
+test "escalation: no suppressed → returns tier1 as-is" {
+  let ast = @ast.Term::Module([("x", @ast.Term::Int(5))], @ast.Term::Var("x"))
+  let tier1 = eval_term(ast)
+  // All results are Value, no escalation needed
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged.length(), content="2")
+  inspect(merged[0], content="Value(\"5\")")
+  inspect(merged[1], content="Value(\"5\")")
+}
+
+///|
+test "escalation: hole in middle, independent defs resolved" {
+  // let x = 2 + 3       → Value("5")
+  // let y = ?            → Stuck (Incomplete → Suppressed in Tier 1)
+  // let z = x + 1        → Suppressed by Tier 1 (env incomplete)
+  // z                     → Suppressed by Tier 1
+  //
+  // After escalation: z should be Value("6") because it only depends on x.
+  let ast = @ast.Term::Module(
+    [
+      ("x", @ast.Term::Bop(Plus, @ast.Term::Int(2), @ast.Term::Int(3))),
+      ("y", @ast.Term::Hole(0)),
+      ("z", @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Int(1))),
+    ],
+    @ast.Term::Var("z"),
+  )
+  let tier1 = eval_term(ast)
+  // Verify Tier 1 behavior: stops at y
+  inspect(tier1[0], content="Value(\"5\")")
+  inspect(tier1[1], content="Suppressed") // Hole → Incomplete → Suppressed
+  inspect(tier1[2], content="Suppressed")
+  inspect(tier1[3], content="Suppressed")
+  // Escalation should resolve z and body
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged[0], content="Value(\"5\")") // unchanged
+  inspect(merged[1], content="Suppressed") // y is still stuck (hole)
+  inspect(merged[2], content="Value(\"6\")") // z = x + 1 = 6 via egglog!
+  inspect(merged[3], content="Value(\"6\")") // body = z = 6 via egglog!
+}
+
+///|
+test "escalation: stuck def shadows earlier binding" {
+  // let x = 1
+  // let x = missing     → Stuck (unbound)
+  // x + 1               → Suppressed
+  //
+  // After escalation: body should stay unresolved because the second x
+  // (stuck) shadows the first x=1. Partial env must NOT expose x=1.
+  let ast = @ast.Term::Module(
+    [("x", @ast.Term::Int(1)), ("x", @ast.Term::Var("missing"))],
+    @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Int(1)),
+  )
+  let tier1 = eval_term(ast)
+  inspect(tier1[0], content="Value(\"1\")")
+  inspect(
+    tier1[1],
+    content=(
+      #|Stuck("‹unbound: missing›")
+    ),
+  )
+  inspect(tier1[2], content="Suppressed")
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged[0], content="Value(\"1\")") // unchanged
+  inspect(
+    merged[1],
+    content=(
+      #|Stuck("‹unbound: missing›")
+    ),
+  ) // unchanged
+  // Body: x is shadowed by stuck def → egglog can't resolve → Suppressed
+  inspect(merged[2], content="Suppressed")
+}
+
+///|
+test "escalation: stuck then recovered same-name binding" {
+  // Codex bug: global blocked_names prevented recovery of re-bound names.
+  // let x = missing      → Stuck
+  // let x = 1            → Suppressed, but CAN be recovered (independent of first x)
+  // x                    → Suppressed, should see x=1 from second binding
+  let ast = @ast.Term::Module(
+    [("x", @ast.Term::Var("missing")), ("x", @ast.Term::Int(1))],
+    @ast.Term::Var("x"),
+  )
+  let tier1 = eval_term(ast)
+  inspect(
+    tier1[0],
+    content=(
+      #|Stuck("‹unbound: missing›")
+    ),
+  )
+  inspect(tier1[1], content="Suppressed")
+  inspect(tier1[2], content="Suppressed")
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(
+    merged[0],
+    content=(
+      #|Stuck("‹unbound: missing›")
+    ),
+  ) // stays stuck
+  inspect(merged[1], content="Value(\"1\")") // second x=1 recovered
+  inspect(merged[2], content="Value(\"1\")") // body sees x=1
+}
+
+///|
+test "escalation: arithmetic expression resolved via egglog" {
+  // let a = 10
+  // let b = ?            → Suppressed (hole)
+  // let c = a - 3        → Suppressed by Tier 1
+  // c                     → Suppressed by Tier 1
+  //
+  // Escalation: c = 10 - 3 = 7
+  let ast = @ast.Term::Module(
+    [
+      ("a", @ast.Term::Int(10)),
+      ("b", @ast.Term::Hole(0)),
+      ("c", @ast.Term::Bop(Minus, @ast.Term::Var("a"), @ast.Term::Int(3))),
+    ],
+    @ast.Term::Var("c"),
+  )
+  let tier1 = eval_term(ast)
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged[0], content="Value(\"10\")")
+  inspect(merged[1], content="Suppressed") // hole
+  inspect(merged[2], content="Value(\"7\")") // c = a - 3 = 7
+  inspect(merged[3], content="Value(\"7\")") // body = c = 7
+}
+
+///|
+test "escalation: def depends on stuck → stays suppressed" {
+  // let x = ?
+  // let y = x + 1     → depends on x which is stuck
+  // y
+  let ast = @ast.Term::Module(
+    [
+      ("x", @ast.Term::Hole(0)),
+      ("y", @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Int(1))),
+    ],
+    @ast.Term::Var("y"),
+  )
+  let tier1 = eval_term(ast)
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged[0], content="Suppressed") // x = ? (hole)
+  inspect(merged[1], content="Suppressed") // y needs x → unresolved
+  inspect(merged[2], content="Suppressed") // body needs y → unresolved
+}
+
+///|
+test "escalation: closure in partial env" {
+  // let f = λx. x + 1
+  // let y = ?
+  // let z = f 5         → Suppressed by Tier 1
+  // z
+  //
+  // Escalation: z = f 5 = 6. The partial env must correctly seed the
+  // closure value for f.
+  let ast = @ast.Term::Module(
+    [
+      (
+        "f",
+        @ast.Term::Lam(
+          "x",
+          @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Int(1)),
+        ),
+      ),
+      ("y", @ast.Term::Hole(0)),
+      ("z", @ast.Term::App(@ast.Term::Var("f"), @ast.Term::Int(5))),
+    ],
+    @ast.Term::Var("z"),
+  )
+  let tier1 = eval_term(ast)
+  inspect(
+    tier1[0],
+    content=(
+      #|Value("‹closure›")
+    ),
+  )
+  inspect(tier1[1], content="Suppressed")
+  inspect(tier1[2], content="Suppressed")
+  inspect(tier1[3], content="Suppressed")
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(
+    merged[0],
+    content=(
+      #|Value("‹closure›")
+    ),
+  )
+  inspect(merged[1], content="Suppressed") // hole
+  inspect(merged[2], content="Value(\"6\")") // f 5 = 6
+  inspect(merged[3], content="Value(\"6\")") // body = z = 6
+}
+
+///|
+test "escalation: multi-round forward propagation" {
+  // let a = 10
+  // let b = ?            → Suppressed (hole)
+  // let c = a + 1        → Suppressed, resolves in round 1 → 11
+  // let d = c + 1        → Suppressed, resolves in round 2 → 12 (needs c from round 1)
+  // d                    → Suppressed, resolves in round 3 → 12
+  let ast = @ast.Term::Module(
+    [
+      ("a", @ast.Term::Int(10)),
+      ("b", @ast.Term::Hole(0)),
+      ("c", @ast.Term::Bop(Plus, @ast.Term::Var("a"), @ast.Term::Int(1))),
+      ("d", @ast.Term::Bop(Plus, @ast.Term::Var("c"), @ast.Term::Int(1))),
+    ],
+    @ast.Term::Var("d"),
+  )
+  let tier1 = eval_term(ast)
+  inspect(tier1[0], content="Value(\"10\")")
+  inspect(tier1[1], content="Suppressed") // hole
+  inspect(tier1[2], content="Suppressed") // c
+  inspect(tier1[3], content="Suppressed") // d
+  inspect(tier1[4], content="Suppressed") // body
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged[0], content="Value(\"10\")")
+  inspect(merged[1], content="Suppressed") // hole stays
+  inspect(merged[2], content="Value(\"11\")") // c = a+1 = 11
+  inspect(merged[3], content="Value(\"12\")") // d = c+1 = 12
+  inspect(merged[4], content="Value(\"12\")") // body = d = 12
+}
+
+///|
+test "escalation: non-module term unchanged" {
+  let ast = @ast.Term::Int(42)
+  let tier1 = eval_term(ast)
+  let merged = escalate_suppressed(ast, tier1)
+  inspect(merged[0], content="Value(\"42\")")
+}

--- a/lang/lambda/eval/eval_memo.mbt
+++ b/lang/lambda/eval/eval_memo.mbt
@@ -34,65 +34,192 @@ fn render_stuck(reason : @lambda_eval.StuckReason) -> EvalResult {
 }
 
 ///|
+/// Cached state for one definition, preserving the raw Value for env
+/// reconstruction and the Term for change detection.
+priv struct CachedDef {
+  name : String // binder name (or "_body" for body)
+  term : @ast.Term
+  result : EvalResult
+  raw_value : @lambda_eval.Value?
+}
+
+///|
 /// Evaluate a term and return per-definition results.
 /// For Module(defs, body): one result per def + one for body.
 /// For non-Module: one result for the whole expression.
 pub fn eval_term(term : @ast.Term) -> Array[EvalResult] {
-  let results : Array[EvalResult] = []
+  eval_term_cached(term, []).0
+}
+
+///|
+/// Evaluate with incremental caching. Reuses cached results for unchanged
+/// definitions in the prefix. Returns (display_results, new_cache).
+///
+/// Cache invariant: if def i has the same Term and all defs 0..i-1 are
+/// cache hits, then def i's result and raw_value are still valid (because
+/// evaluation is deterministic and env depends only on preceding values).
+fn eval_term_cached(
+  term : @ast.Term,
+  prev_cache : Array[CachedDef],
+) -> (Array[EvalResult], Array[CachedDef]) {
   match term {
-    Module(defs, body) => {
-      let mut env = @lambda_eval.Env::empty()
-      for i, def in defs {
-        let (name, expr) = def
-        try {
-          let v = @lambda_eval.eval(env, expr)
-          results.push(Value(render_value(v)))
-          env = env.extend(name, v)
-        } catch {
-          reason => {
-            results.push(render_stuck(reason))
-            // Stop evaluating — env is incomplete
-            for _ in (i + 1)..<defs.length() {
-              results.push(Suppressed)
-            }
-            results.push(Suppressed) // body
-            return results
-          }
-        }
-      }
-      // Evaluate body
-      try {
-        let v = @lambda_eval.eval(env, body)
-        results.push(Value(render_value(v)))
-      } catch {
-        reason => results.push(render_stuck(reason))
-      }
-    }
-    _ =>
+    Module(defs, body) => eval_module_cached(defs, body, prev_cache)
+    _ => {
+      let results : Array[EvalResult] = []
       try {
         let v = @lambda_eval.eval(@lambda_eval.Env::empty(), term)
         results.push(Value(render_value(v)))
       } catch {
         reason => results.push(render_stuck(reason))
       }
+      (results, [])
+    }
   }
-  results
 }
 
 ///|
-/// Build a reactive eval memo.
-/// Reads `syntax_tree` signal to establish reactive dependency.
+/// Incrementally evaluate a Module with caching.
+fn eval_module_cached(
+  defs : Array[(@ast.VarName, @ast.Term)],
+  body : @ast.Term,
+  prev_cache : Array[CachedDef],
+) -> (Array[EvalResult], Array[CachedDef]) {
+  let results : Array[EvalResult] = []
+  let new_cache : Array[CachedDef] = []
+  let mut env = @lambda_eval.Env::empty()
+  // Cache is usable only if shape matches: same number of defs + body.
+  let cache_valid = prev_cache.length() == defs.length() + 1
+  // Find first changed definition (compare both name AND term)
+  let mut first_changed = 0
+  if cache_valid {
+    first_changed = defs.length()
+    for i, def in defs {
+      let (name, expr) = def
+      if prev_cache[i].name != name || prev_cache[i].term != expr {
+        first_changed = i
+        break
+      }
+    }
+  }
+  // Check body if all defs are unchanged
+  let body_changed = if cache_valid && first_changed == defs.length() {
+    prev_cache[defs.length()].term != body
+  } else {
+    true
+  }
+  // Fast path: nothing changed
+  if cache_valid && first_changed == defs.length() && !body_changed {
+    return (prev_cache.map(fn(c) { c.result }), prev_cache)
+  }
+  // Reuse cached prefix (0..first_changed-1)
+  for i = 0; i < first_changed; i = i + 1 {
+    let cached = prev_cache[i]
+    results.push(cached.result)
+    new_cache.push(cached)
+    match cached.raw_value {
+      Some(v) => env = env.extend(defs[i].0, v)
+      None => {
+        // Stuck in unchanged prefix: env is incomplete.
+        // Everything from here onward is Suppressed regardless of changes.
+        fill_suppressed(results, new_cache, defs, body, i + 1)
+        return (results, new_cache)
+      }
+    }
+  }
+  // Re-evaluate from first_changed onward
+  for i = first_changed; i < defs.length(); i = i + 1 {
+    let (name, expr) = defs[i]
+    try {
+      let v = @lambda_eval.eval(env, expr)
+      let display = Value(render_value(v))
+      results.push(display)
+      new_cache.push({ name, term: expr, result: display, raw_value: Some(v) })
+      env = env.extend(name, v)
+    } catch {
+      reason => {
+        let display = render_stuck(reason)
+        results.push(display)
+        new_cache.push({ name, term: expr, result: display, raw_value: None })
+        fill_suppressed(results, new_cache, defs, body, i + 1)
+        return (results, new_cache)
+      }
+    }
+  }
+  // Evaluate body
+  try {
+    let v = @lambda_eval.eval(env, body)
+    let display = Value(render_value(v))
+    results.push(display)
+    new_cache.push({
+      name: "_body",
+      term: body,
+      result: display,
+      raw_value: Some(v),
+    })
+  } catch {
+    reason => {
+      let display = render_stuck(reason)
+      results.push(display)
+      new_cache.push({
+        name: "_body",
+        term: body,
+        result: display,
+        raw_value: None,
+      })
+    }
+  }
+  (results, new_cache)
+}
+
+///|
+/// Fill remaining definitions and body with Suppressed.
+fn fill_suppressed(
+  results : Array[EvalResult],
+  cache : Array[CachedDef],
+  defs : Array[(@ast.VarName, @ast.Term)],
+  body : @ast.Term,
+  from_index : Int,
+) -> Unit {
+  for i = from_index; i < defs.length(); i = i + 1 {
+    results.push(Suppressed)
+    cache.push({
+      name: defs[i].0,
+      term: defs[i].1,
+      result: Suppressed,
+      raw_value: None,
+    })
+  }
+  results.push(Suppressed)
+  cache.push({ name: "_body", term: body, result: Suppressed, raw_value: None })
+}
+
+///|
+/// Build a reactive eval memo with incremental caching.
+///
+/// Caches per-definition results. When only definition N changes,
+/// reuses cached results for definitions 0..N-1 and re-evaluates
+/// from N onward. This satisfies the "re-editing one binding only
+/// re-evaluates dependents" requirement.
 pub fn build_eval_memo(
   rt : @incr.Runtime,
   syntax_tree : @incr.Signal[@seam.SyntaxNode?],
   parser : @loom.ImperativeParser[@ast.Term],
 ) -> @incr.Memo[Array[EvalResult]] {
+  let cache : Ref[Array[CachedDef]] = Ref::new([])
+  let prev_results : Ref[Array[EvalResult]] = Ref::new([])
   @incr.Memo::new_no_backdate(
     rt,
     fn() -> Array[EvalResult] {
       let _ = syntax_tree.get()
       let ast = parser.get_tree().unwrap_or(@ast.Term::Unit)
-      eval_term(ast)
+      let (results, new_cache) = eval_term_cached(ast, cache.val)
+      // If cache unchanged (same reference), reuse previous results array
+      if physical_equal(new_cache, cache.val) && prev_results.val.length() > 0 {
+        return prev_results.val
+      }
+      cache.val = new_cache
+      prev_results.val = results
+      results
     },
     label="eval_memo",
   )

--- a/lang/lambda/eval/incremental_wbtest.mbt
+++ b/lang/lambda/eval/incremental_wbtest.mbt
@@ -1,0 +1,150 @@
+// Tests for incremental eval caching.
+//
+// Verifies that editing one definition reuses cached results for unchanged
+// definitions in the prefix.
+
+///|
+test "incremental: unchanged module returns cached results" {
+  let ast = @ast.Term::Module(
+    [("x", @ast.Term::Int(5)), ("y", @ast.Term::Int(10))],
+    @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Var("y")),
+  )
+  let (results1, cache1) = eval_term_cached(ast, [])
+  inspect(results1[0], content="Value(\"5\")")
+  inspect(results1[1], content="Value(\"10\")")
+  inspect(results1[2], content="Value(\"15\")")
+  // Same AST → cache hit, same results
+  let (results2, _) = eval_term_cached(ast, cache1)
+  inspect(results2[0], content="Value(\"5\")")
+  inspect(results2[1], content="Value(\"10\")")
+  inspect(results2[2], content="Value(\"15\")")
+}
+
+///|
+test "incremental: changing last def preserves prefix" {
+  let ast1 = @ast.Term::Module(
+    [("x", @ast.Term::Int(5)), ("y", @ast.Term::Int(10))],
+    @ast.Term::Var("y"),
+  )
+  let (results1, cache1) = eval_term_cached(ast1, [])
+  inspect(results1.length(), content="3")
+  inspect(results1[0], content="Value(\"5\")")
+  inspect(results1[1], content="Value(\"10\")")
+  // Change y from 10 to 20 — x should be reused from cache
+  let ast2 = @ast.Term::Module(
+    [("x", @ast.Term::Int(5)), ("y", @ast.Term::Int(20))],
+    @ast.Term::Var("y"),
+  )
+  let (results2, cache2) = eval_term_cached(ast2, cache1)
+  inspect(results2[0], content="Value(\"5\")") // reused
+  inspect(results2[1], content="Value(\"20\")") // re-evaluated
+  inspect(results2[2], content="Value(\"20\")") // re-evaluated (body)
+  // Verify cache has correct terms
+  inspect(cache2[0].term == @ast.Term::Int(5), content="true")
+  inspect(cache2[1].term == @ast.Term::Int(20), content="true")
+}
+
+///|
+test "incremental: changing first def re-evaluates all" {
+  let ast1 = @ast.Term::Module(
+    [("x", @ast.Term::Int(5)), ("y", @ast.Term::Var("x"))],
+    @ast.Term::Var("y"),
+  )
+  let (_, cache1) = eval_term_cached(ast1, [])
+  // Change x from 5 to 100 — everything depends on x
+  let ast2 = @ast.Term::Module(
+    [("x", @ast.Term::Int(100)), ("y", @ast.Term::Var("x"))],
+    @ast.Term::Var("y"),
+  )
+  let (results2, _) = eval_term_cached(ast2, cache1)
+  inspect(results2[0], content="Value(\"100\")")
+  inspect(results2[1], content="Value(\"100\")")
+  inspect(results2[2], content="Value(\"100\")")
+}
+
+///|
+test "incremental: stuck in prefix blocks cache reuse for dependents" {
+  let ast1 = @ast.Term::Module(
+    [("x", @ast.Term::Var("missing")), ("y", @ast.Term::Int(10))],
+    @ast.Term::Int(0),
+  )
+  let (results1, cache1) = eval_term_cached(ast1, [])
+  inspect(
+    results1[0],
+    content=(
+      #|Stuck("‹unbound: missing›")
+    ),
+  )
+  inspect(results1[1], content="Suppressed")
+  inspect(results1[2], content="Suppressed")
+  // Change y (which was Suppressed) — x is still stuck, so y stays Suppressed
+  let ast2 = @ast.Term::Module(
+    [("x", @ast.Term::Var("missing")), ("y", @ast.Term::Int(20))],
+    @ast.Term::Int(0),
+  )
+  let (results2, _) = eval_term_cached(ast2, cache1)
+  inspect(
+    results2[0],
+    content=(
+      #|Stuck("‹unbound: missing›")
+    ),
+  )
+  inspect(results2[1], content="Suppressed")
+  inspect(results2[2], content="Suppressed")
+}
+
+///|
+test "incremental: renaming a binder invalidates cache" {
+  // Codex bug: cache keyed on RHS only, not binder name.
+  // let x=1; let y=x → let z=1; let y=x should fail (x now unbound)
+  let ast1 = @ast.Term::Module(
+    [("x", @ast.Term::Int(1)), ("y", @ast.Term::Var("x"))],
+    @ast.Term::Var("y"),
+  )
+  let (results1, cache1) = eval_term_cached(ast1, [])
+  inspect(results1[0], content="Value(\"1\")")
+  inspect(results1[1], content="Value(\"1\")")
+  inspect(results1[2], content="Value(\"1\")")
+  // Rename x → z (same RHS Int(1), different name)
+  let ast2 = @ast.Term::Module(
+    [("z", @ast.Term::Int(1)), ("y", @ast.Term::Var("x"))],
+    @ast.Term::Var("y"),
+  )
+  let (results2, _) = eval_term_cached(ast2, cache1)
+  inspect(results2[0], content="Value(\"1\")") // z=1 still evaluates
+  inspect(
+    results2[1],
+    content=(
+      #|Stuck("‹unbound: x›")
+    ),
+  ) // y=x now fails (x unbound)
+  inspect(results2[2], content="Suppressed") // body suppressed
+}
+
+///|
+test "incremental: module shape change invalidates cache" {
+  let ast1 = @ast.Term::Module(
+    [("x", @ast.Term::Int(1)), ("y", @ast.Term::Int(2))],
+    @ast.Term::Var("y"),
+  )
+  let (_, cache1) = eval_term_cached(ast1, [])
+  // Remove a definition: 2 defs → 1 def
+  let ast2 = @ast.Term::Module([("x", @ast.Term::Int(1))], @ast.Term::Var("x"))
+  let (results2, _) = eval_term_cached(ast2, cache1)
+  inspect(results2.length(), content="2")
+  inspect(results2[0], content="Value(\"1\")")
+  inspect(results2[1], content="Value(\"1\")")
+}
+
+///|
+test "incremental: only body changed" {
+  let ast1 = @ast.Term::Module([("x", @ast.Term::Int(5))], @ast.Term::Var("x"))
+  let (results1, cache1) = eval_term_cached(ast1, [])
+  inspect(results1[0], content="Value(\"5\")")
+  inspect(results1[1], content="Value(\"5\")")
+  // Change body from Var("x") to Int(99)
+  let ast2 = @ast.Term::Module([("x", @ast.Term::Int(5))], @ast.Term::Int(99))
+  let (results2, _) = eval_term_cached(ast2, cache1)
+  inspect(results2[0], content="Value(\"5\")") // reused
+  inspect(results2[1], content="Value(\"99\")") // re-evaluated
+}

--- a/lang/lambda/eval/moon.pkg
+++ b/lang/lambda/eval/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "dowdiness/egglog/examples/lambda-eval" @egglog_eval,
+  "dowdiness/egglog/src" @egglog,
   "dowdiness/incr" @incr,
   "dowdiness/lambda/ast" @ast,
   "dowdiness/lambda/eval" @lambda_eval,

--- a/lang/lambda/eval/pkg.generated.mbti
+++ b/lang/lambda/eval/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/lambda/eval"
 
 import {
+  "dowdiness/egglog/src",
   "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
   "dowdiness/loom/incremental",
@@ -11,6 +12,8 @@ import {
 }
 
 // Values
+pub fn build_escalation_memo(@cells.Runtime, @cells.Memo[Array[EvalResult]], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> @cells.Memo[Array[EvalResult]]
+
 pub fn build_eval_memo(@cells.Runtime, @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> @cells.Memo[Array[EvalResult]]
 
 pub fn eval_annotation_layout(EvalResult) -> @pretty.Layout[@pretty.SyntaxCategory]?
@@ -18,6 +21,8 @@ pub fn eval_annotation_layout(EvalResult) -> @pretty.Layout[@pretty.SyntaxCatego
 pub fn eval_term(@ast.Term) -> Array[EvalResult]
 
 pub fn inject_eval_annotations(@pretty.Layout[@pretty.SyntaxCategory], Array[EvalResult]) -> @pretty.Layout[@pretty.SyntaxCategory]
+
+pub fn seed_term(@src.Database, @ast.Term) -> @src.Value
 
 pub fn split_at_hardlines(@pretty.Layout[@pretty.SyntaxCategory]) -> Array[@pretty.Layout[@pretty.SyntaxCategory]]
 

--- a/lang/lambda/eval/seed_term.mbt
+++ b/lang/lambda/eval/seed_term.mbt
@@ -1,0 +1,120 @@
+// Seeding: convert @ast.Term → egglog database facts for Tier 2 evaluation.
+//
+// The egglog evaluator works on database-level facts (Num, Var, Add, etc.).
+// This module bridges the gap by recursively converting a Term AST into
+// the corresponding egglog table entries.
+
+///|
+/// Recursively seed a Term into an egglog database, returning the egglog
+/// expression id. Each AST node becomes one or more table entries.
+///
+/// Module is desugared to nested Let (right-folded):
+///   Module([(x,e1),(y,e2)], body) → Let(x, e1, Let(y, e2, body))
+pub fn seed_term(db : @egglog.Database, term : @ast.Term) -> @egglog.Value {
+  match term {
+    Int(n) => db.call("Num", [@egglog.IntVal(n)])
+    Unit => db.call("Unit", [])
+    Var(x) => db.call("Var", [@egglog.StrVal(x)])
+    Lam(x, body) => db.call("Lam", [@egglog.StrVal(x), seed_term(db, body)])
+    App(f, arg) => db.call("App", [seed_term(db, f), seed_term(db, arg)])
+    Bop(Plus, a, b) => db.call("Add", [seed_term(db, a), seed_term(db, b)])
+    Bop(Minus, a, b) => db.call("Minus", [seed_term(db, a), seed_term(db, b)])
+    If(c, t, e) =>
+      db.call("If", [seed_term(db, c), seed_term(db, t), seed_term(db, e)])
+    Module(defs, body) => {
+      // Right-fold into nested Let: last def wraps body, first def is outermost
+      let mut result = seed_term(db, body)
+      for i = defs.length() - 1; i >= 0; i = i - 1 {
+        let (name, expr) = defs[i]
+        result = db.call("Let", [
+          @egglog.StrVal(name),
+          seed_term(db, expr),
+          result,
+        ])
+      }
+      result
+    }
+    Hole(tag) => db.call("HoleNode", [@egglog.IntVal(tag)])
+    Error(msg) => db.call("ErrorNode", [@egglog.StrVal(msg)])
+    Unbound(name) => db.call("UnboundNode", [@egglog.StrVal(name)])
+  }
+}
+
+///|
+/// Seed a Tier 1 Value into egglog as a value fact.
+/// Used to build environments for escalation from successful Tier 1 results.
+fn seed_value(db : @egglog.Database, val : @lambda_eval.Value) -> @egglog.Value {
+  match val {
+    VInt(n) => db.call("ValInt", [@egglog.IntVal(n)])
+    VUnit => db.call("ValUnit", [])
+    VClosure(env, x, body) => {
+      // Seed the closure's captured environment and body
+      let env_id = seed_env(db, env)
+      let body_id = seed_term(db, body)
+      db.call("Closure", [env_id, @egglog.StrVal(x), body_id])
+    }
+  }
+}
+
+///|
+/// Seed a Tier 1 Env into egglog, creating ValueEnv entries for all bindings.
+fn seed_env(db : @egglog.Database, env : @lambda_eval.Env) -> @egglog.Value {
+  build_partial_env(db, env.bindings.iter().map(fn(p) { (p.0, p.1) }).collect())
+}
+
+///|
+/// Build a ValueEnv from a list of (name, Tier1 Value) bindings.
+/// Used by batch escalation to construct partial environments
+/// from successfully-evaluated definitions.
+fn build_partial_env(
+  db : @egglog.Database,
+  bindings : Array[(String, @lambda_eval.Value)],
+) -> @egglog.Value {
+  let mut val_env = @egglog_eval.ValueEnv::make(db)
+  for binding in bindings {
+    let (name, value) = binding
+    val_env = val_env.extend(db, name, seed_value(db, value))
+  }
+  val_env.id
+}
+
+///|
+/// Convert an egglog value id to a display string.
+/// Scans ValInt, Closure, and ValUnit tables to determine the value type.
+fn extract_egglog_value_string(
+  db : @egglog.Database,
+  val : @egglog.Value,
+) -> String? {
+  let val_id = egglog_find(db, val)
+  for row in db.scan("ValInt") {
+    let (args, result) = row
+    if egglog_find(db, result) == val_id {
+      match args[0] {
+        @egglog.IntVal(n) => return Some(n.to_string())
+        _ => ()
+      }
+    }
+  }
+  for row in db.scan("Closure") {
+    let (_, result) = row
+    if egglog_find(db, result) == val_id {
+      return Some("\u{2039}closure\u{203a}")
+    }
+  }
+  for row in db.scan("ValUnit") {
+    let (_, result) = row
+    if egglog_find(db, result) == val_id {
+      return Some("()")
+    }
+  }
+  None
+}
+
+///|
+/// Find the canonical id for an egglog Value.
+fn egglog_find(db : @egglog.Database, v : @egglog.Value) -> @egglog.Id {
+  match v {
+    @egglog.IdVal(id) => db.find(id)
+    _ => abort("egglog_find: expected IdVal")
+  }
+}

--- a/lang/lambda/eval/seed_term_wbtest.mbt
+++ b/lang/lambda/eval/seed_term_wbtest.mbt
@@ -1,0 +1,200 @@
+// Tests for seed_term: Term → egglog fact conversion.
+
+///|
+test "seed_term: integer" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Int(42))
+  let expected = db.call("Num", [@egglog.IntVal(42)])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: unit" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Unit)
+  let expected = db.call("Unit", [])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: variable" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Var("x"))
+  let expected = db.call("Var", [@egglog.StrVal("x")])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: lambda" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Lam("x", @ast.Term::Var("x")))
+  let var_x = db.call("Var", [@egglog.StrVal("x")])
+  let expected = db.call("Lam", [@egglog.StrVal("x"), var_x])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: application" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(
+    db,
+    @ast.Term::App(@ast.Term::Var("f"), @ast.Term::Int(5)),
+  )
+  let f = db.call("Var", [@egglog.StrVal("f")])
+  let n = db.call("Num", [@egglog.IntVal(5)])
+  let expected = db.call("App", [f, n])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: arithmetic plus" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(
+    db,
+    @ast.Term::Bop(Plus, @ast.Term::Int(2), @ast.Term::Int(3)),
+  )
+  let a = db.call("Num", [@egglog.IntVal(2)])
+  let b = db.call("Num", [@egglog.IntVal(3)])
+  let expected = db.call("Add", [a, b])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: arithmetic minus" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(
+    db,
+    @ast.Term::Bop(Minus, @ast.Term::Int(10), @ast.Term::Int(3)),
+  )
+  let a = db.call("Num", [@egglog.IntVal(10)])
+  let b = db.call("Num", [@egglog.IntVal(3)])
+  let expected = db.call("Minus", [a, b])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: conditional" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(
+    db,
+    @ast.Term::If(@ast.Term::Int(1), @ast.Term::Int(2), @ast.Term::Int(3)),
+  )
+  let c = db.call("Num", [@egglog.IntVal(1)])
+  let t = db.call("Num", [@egglog.IntVal(2)])
+  let e = db.call("Num", [@egglog.IntVal(3)])
+  let expected = db.call("If", [c, t, e])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: hole sentinel" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Hole(0))
+  let expected = db.call("HoleNode", [@egglog.IntVal(0)])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: error sentinel" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Error("bad"))
+  let expected = db.call("ErrorNode", [@egglog.StrVal("bad")])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: unbound sentinel" {
+  let db = @egglog_eval.lambda_eval_db()
+  let expr = seed_term(db, @ast.Term::Unbound("x"))
+  let expected = db.call("UnboundNode", [@egglog.StrVal("x")])
+  inspect(egglog_same_class(db, expr, expected), content="true")
+}
+
+///|
+test "seed_term: module desugars to nested let" {
+  let db = @egglog_eval.lambda_eval_db()
+  // Module([(x, 1), (y, 2)], x+y) → Let(x, 1, Let(y, 2, x+y))
+  let expr = seed_term(
+    db,
+    @ast.Term::Module(
+      [("x", @ast.Term::Int(1)), ("y", @ast.Term::Int(2))],
+      @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Var("y")),
+    ),
+  )
+  // Build the expected nested Let manually
+  let n1 = db.call("Num", [@egglog.IntVal(1)])
+  let n2 = db.call("Num", [@egglog.IntVal(2)])
+  let vx = db.call("Var", [@egglog.StrVal("x")])
+  let vy = db.call("Var", [@egglog.StrVal("y")])
+  let add = db.call("Add", [vx, vy])
+  let inner_let = db.call("Let", [@egglog.StrVal("y"), n2, add])
+  let outer_let = db.call("Let", [@egglog.StrVal("x"), n1, inner_let])
+  inspect(egglog_same_class(db, expr, outer_let), content="true")
+}
+
+///|
+test "seed_term + run_eval: end-to-end evaluation" {
+  // Seed (2 + 3) into egglog and evaluate it
+  let db = @egglog_eval.lambda_eval_db()
+  let env = db.call("EmptyEnv", [])
+  let expr = seed_term(
+    db,
+    @ast.Term::Bop(Plus, @ast.Term::Int(2), @ast.Term::Int(3)),
+  )
+  let result = @egglog_eval.run_eval(db, env, expr, @egglog_eval.eval_rules())
+  let expected = db.call("ValInt", [@egglog.IntVal(5)])
+  inspect(result is Some(_), content="true")
+  inspect(egglog_same_class(db, result.unwrap(), expected), content="true")
+}
+
+///|
+test "seed_term + run_eval: lambda application" {
+  // Seed (λx. x + 1) 5 and evaluate to 6
+  let db = @egglog_eval.lambda_eval_db()
+  let env = db.call("EmptyEnv", [])
+  let expr = seed_term(
+    db,
+    @ast.Term::App(
+      @ast.Term::Lam(
+        "x",
+        @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Int(1)),
+      ),
+      @ast.Term::Int(5),
+    ),
+  )
+  let result = @egglog_eval.run_eval(db, env, expr, @egglog_eval.eval_rules())
+  let expected = db.call("ValInt", [@egglog.IntVal(6)])
+  inspect(result is Some(_), content="true")
+  inspect(egglog_same_class(db, result.unwrap(), expected), content="true")
+}
+
+///|
+test "seed_term + run_eval: module with let bindings" {
+  // let x = 2; let y = x + 3; y → 5
+  let db = @egglog_eval.lambda_eval_db()
+  let env = db.call("EmptyEnv", [])
+  let expr = seed_term(
+    db,
+    @ast.Term::Module(
+      [
+        ("x", @ast.Term::Int(2)),
+        ("y", @ast.Term::Bop(Plus, @ast.Term::Var("x"), @ast.Term::Int(3))),
+      ],
+      @ast.Term::Var("y"),
+    ),
+  )
+  let result = @egglog_eval.run_eval(db, env, expr, @egglog_eval.eval_rules())
+  let expected = db.call("ValInt", [@egglog.IntVal(5)])
+  inspect(result is Some(_), content="true")
+  inspect(egglog_same_class(db, result.unwrap(), expected), content="true")
+}
+
+///|
+/// Helper: check if two egglog values are in the same equivalence class.
+fn egglog_same_class(
+  db : @egglog.Database,
+  a : @egglog.Value,
+  b : @egglog.Value,
+) -> Bool {
+  egglog_find(db, a) == egglog_find(db, b)
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -37,6 +37,9 @@
     },
     "dowdiness/zipper": {
       "path": "./lib/zipper"
+    },
+    "dowdiness/egglog": {
+      "path": "./loom/egglog"
     }
   },
   "readme": "README.mbt.md",


### PR DESCRIPTION
## Summary

- **Batch escalation**: When Tier 1 (direct eval) stops at a stuck definition, Tier 2 (egglog relational eval) evaluates independent subsequent definitions via partial environments with iterative forward propagation
- **Incremental caching**: Reuses cached results for unchanged definitions in prefix, keyed on (binder name, term) with module shape validation
- **seed_term**: Converts `@ast.Term` → egglog database facts for Tier 2 seeding

## Details

### Batch escalation algorithm
1. Tier 1 evaluates Module sequentially — first error suppresses all subsequent defs
2. For Suppressed defs: build partial env from available Value bindings (reverse walk for correct shadowing)
3. Seed each candidate into a fresh egglog Database, run Datalog+Bridge to fixpoint
4. Forward propagation: recovered values feed into later candidates across rounds (max 10)

### Incremental caching
- `CachedDef` stores `(name, term, result, raw_value)` per definition
- On re-evaluation, finds first changed def via `(name, term)` comparison
- Module shape changes (defs added/removed) invalidate entire cache
- `physical_equal` check avoids allocation when nothing changed

### Files
- `seed_term.mbt` — Term→egglog conversion, value seeding, result extraction
- `batch_escalation.mbt` — escalation memo, iterative evaluation, shadowing
- `eval_memo.mbt` — incremental caching (`CachedDef`, `eval_term_cached`)
- `lambda_editor.mbt` — wired `escalation_memo` into companion + capabilities
- `moon.mod.json` — added `dowdiness/egglog` path dependency

### Acceptance criteria (design doc Phase 3)
- [x] `Memo[EvalResult]` wired into editor reactive graph
- [x] Tier 1 → Tier 2 batch escalation works for incomplete programs
- [x] Re-editing one binding only re-evaluates dependents
- [ ] Type-directed error (deferred — tracked in memory)

## Test plan

- [ ] 840/840 tests pass (`moon test`)
- [ ] 31 new tests: 15 seed_term, 9 escalation (including multi-round forward propagation, shadowing, closures), 7 incremental (rename invalidation, shape change, stuck prefix, body-only change)
- [ ] `moon check` clean, `moon build --target js` succeeds
- [ ] Verify eval annotations display in browser at localhost:5173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-tier evaluation escalation to resolve previously suppressed results.
  * Introduced incremental caching for improved evaluation performance during repeated operations.

* **Tests**
  * Added comprehensive test coverage for batch escalation and incremental evaluation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->