### PR TITLE
refactor(projection): decouple from lang/lambda/edits via GenericTreeOp

### DIFF
--- a/core/generic_tree_op.mbt
+++ b/core/generic_tree_op.mbt
@@ -1,0 +1,36 @@
+// Generic tree operations for the interactive tree editor.
+// Language-agnostic: projection/ uses this instead of language-specific op types.
+
+///|
+/// UI-level tree operations that projection/TreeEditorState understands.
+/// Language packages map their domain-specific ops to this type via to_generic().
+pub(all) enum GenericTreeOp {
+  // Selection
+  Select(node_id~ : NodeId)
+  SelectRange(start~ : NodeId, end~ : NodeId)
+
+  // Inline editing
+  StartEdit(node_id~ : NodeId)
+  CommitEdit(node_id~ : NodeId, new_value~ : String)
+  CancelEdit
+
+  // Structural (generic)
+  Delete(node_id~ : NodeId)
+  StructuralEdit(node_id~ : NodeId)
+  StructuralEditKeepSelected(node_id~ : NodeId)
+  InsertChild(parent~ : NodeId, index~ : Int)
+
+  // Drag and drop
+  StartDrag(node_id~ : NodeId)
+  DragOver(target~ : NodeId, position~ : DropPosition)
+  Drop(source~ : NodeId, target~ : NodeId, position~ : DropPosition)
+
+  // Navigation
+  Collapse(node_id~ : NodeId)
+  Expand(node_id~ : NodeId)
+} derive(Debug)
+
+///|
+pub impl Show for GenericTreeOp with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -45,6 +45,24 @@ pub(all) enum FocusHint {
 } derive(Eq, @debug.Debug)
 pub impl Show for FocusHint
 
+pub(all) enum GenericTreeOp {
+  Select(node_id~ : NodeId)
+  SelectRange(start~ : NodeId, end~ : NodeId)
+  StartEdit(node_id~ : NodeId)
+  CommitEdit(node_id~ : NodeId, new_value~ : String)
+  CancelEdit
+  Delete(node_id~ : NodeId)
+  StructuralEdit(node_id~ : NodeId)
+  StructuralEditKeepSelected(node_id~ : NodeId)
+  InsertChild(parent~ : NodeId, index~ : Int)
+  StartDrag(node_id~ : NodeId)
+  DragOver(target~ : NodeId, position~ : DropPosition)
+  Drop(source~ : NodeId, target~ : NodeId, position~ : DropPosition)
+  Collapse(node_id~ : NodeId)
+  Expand(node_id~ : NodeId)
+} derive(@debug.Debug)
+pub impl Show for GenericTreeOp
+
 pub struct NodeId(Int) derive(Compare, Eq, Hash, @debug.Debug)
 pub fn NodeId::from_int(Int) -> Self
 #deprecated

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -200,6 +200,7 @@ Tracked by:
 - [x] Add E2E browser tests with Playwright — `examples/demo-react` now has Playwright coverage
 - [x] Run existing Playwright E2E in CI and pick a canonical browser app under test (`examples/demo-react`)
 - [x] Add error path tests — malformed sync messages, corrupted operation logs, network interruptions — ✅ Done. `editor/error_path_wbtest.mbt` (20 tests: wire protocol, ws_on_message, apply_sync, export), `relay/error_path_wbtest.mbt` (9 tests: duplicate peers, non-existent peers, empty rooms)
+- [ ] **E2E tests for outline tree panel** — `examples/ideal` outline tree operations (select, collapse, expand, drag-and-drop) have no E2E coverage. Unit tests in `projection/tree_editor_wbtest.mbt` (67 tests) cover the logic, but no browser-level verification exists for the Rabbita-based outline UI.
 
 ---
 

--- a/docs/plans/2026-04-11-generic-tree-op.md
+++ b/docs/plans/2026-04-11-generic-tree-op.md
@@ -1,0 +1,202 @@
+# Generic Tree Op: Decouple projection/ from lang/lambda/edits
+
+## Problem
+
+`projection/tree_editor.mbt` imports `TreeEditOp` from `lang/lambda/edits`. This is a dependency inversion: a language-agnostic package (projection) depends on a language-specific package (lambda). Adding tree editing for a new language would require either routing through lambda's type or modifying projection.
+
+Of TreeEditOp's 27 variants, projection meaningfully handles only 11 generic ones. The remaining 16 lambda-specific variants (WrapInLambda, WrapInBop, ExtractToLet, InlineDefinition, Rename, DeleteBinding, etc.) share a single catch-all behavior: clear editing state.
+
+## Goal
+
+- Remove `projection/moon.pkg` dependency on `lang/lambda/edits`
+- Define a language-agnostic op type in `core/` that projection uses
+- Lambda (and future languages) map their domain-specific ops to the generic type
+- Near-zero behavior change (one minor tightening — see Design Notes)
+
+## Design
+
+### New type in core/
+
+```
+pub enum GenericTreeOp {
+  // Selection
+  Select(node_id~ : NodeId)
+  SelectRange(start~ : NodeId, end~ : NodeId)
+
+  // Inline editing
+  StartEdit(node_id~ : NodeId)
+  CommitEdit(node_id~ : NodeId, new_value~ : String)
+  CancelEdit
+
+  // Structural (generic)
+  Delete(node_id~ : NodeId)
+  StructuralEdit(node_id~ : NodeId)
+  InsertChild(parent~ : NodeId, index~ : Int)
+
+  // Drag and drop
+  StartDrag(node_id~ : NodeId)
+  DragOver(target~ : NodeId, position~ : DropPosition)
+  Drop(source~ : NodeId, target~ : NodeId, position~ : DropPosition)
+
+  // Navigation
+  Collapse(node_id~ : NodeId)
+  Expand(node_id~ : NodeId)
+}
+```
+
+Design notes:
+
+- **StructuralEdit(node_id~)** replaces all lambda-specific variants (WrapInLambda, Unwrap, SwapChildren, WrapInIf, WrapInBop, ChangeOperator, ExtractToLet, InlineDefinition, Rename) plus all binding-level ops (DeleteBinding, DuplicateBinding, MoveBindingUp, MoveBindingDown, AddBinding, InlineAllUsages). Projection's only behavior for all of these is `{ ..self, editing_node: None, edit_value: "" }` — clear editing state.
+- **InsertChild** drops the `kind~ : @ast.Term` field. Projection ignores it today (line 106: `let _ = (index, kind)`). If a future language needs kind-aware insertion in projection state, add a `data~ : String?` field then.
+- **WrapInLambda and WrapInApp** currently do `{ ..self, selection: [node_id] }` — keep the wrapped node selected, but do NOT clear editing state. `StructuralEditKeepSelected` will both select the node AND clear editing state (`editing_node: None, edit_value: ""`). This is a minor behavior tightening: wrapping while editing is not a supported workflow, and the extra clear is strictly safer (prevents stale editing state from leaking through structural operations).
+
+Revised:
+
+```
+pub enum GenericTreeOp {
+  Select(node_id~ : NodeId)
+  SelectRange(start~ : NodeId, end~ : NodeId)
+  StartEdit(node_id~ : NodeId)
+  CommitEdit(node_id~ : NodeId, new_value~ : String)
+  CancelEdit
+  Delete(node_id~ : NodeId)
+  StructuralEdit(node_id~ : NodeId)          // clears editing state
+  StructuralEditKeepSelected(node_id~ : NodeId) // clears editing + selects node_id
+  InsertChild(parent~ : NodeId, index~ : Int)   // selects parent
+  StartDrag(node_id~ : NodeId)
+  DragOver(target~ : NodeId, position~ : DropPosition)
+  Drop(source~ : NodeId, target~ : NodeId, position~ : DropPosition)
+  Collapse(node_id~ : NodeId)
+  Expand(node_id~ : NodeId)
+}
+```
+
+### Mapping in lang/lambda/edits
+
+Add a function that maps TreeEditOp → GenericTreeOp:
+
+```
+pub fn TreeEditOp::to_generic(self : TreeEditOp) -> GenericTreeOp
+```
+
+This is a pure match that:
+- Select → Select, SelectRange → SelectRange, etc. (11 pass-through)
+- WrapInLambda, WrapInApp → StructuralEditKeepSelected(node_id~)
+- InsertChild → InsertChild(parent~, index~) (drops `kind`)
+- All remaining structural/binding ops → StructuralEdit(node_id~)
+
+### Changes to projection/tree_editor.mbt
+
+`TreeEditorState::apply_edit` changes signature from `TreeEditOp` to `GenericTreeOp`. The match body is simplified — no more catch-all for 16+ lambda variants.
+
+### Callsite migration
+
+There are 4 callsite categories:
+
+1. **projection/tree_editor_refresh.mbt** (lines 747, 749): Internal calls using `Expand(node_id~)`. These construct `TreeEditOp::Expand` today. Will construct `GenericTreeOp::Expand` directly — same syntax.
+
+2. **projection/tree_editor_wbtest.mbt** (~40 calls): Tests construct TreeEditOp variants directly (Select, Collapse, Expand, Delete, StartDrag, DragOver, WrapInLambda, StartEdit, SelectRange). After migration, these construct GenericTreeOp variants. For `WrapInLambda`, tests use `StructuralEditKeepSelected`.
+
+3. **examples/ideal/main/main.mbt** (lines 472-601): App code constructs `@lambda_edits.Select`, `@lambda_edits.Expand`, `@lambda_edits.Collapse`, `@lambda_edits.Select`. After migration, these construct `@core.GenericTreeOp::Select`, etc. directly.
+
+4. **ffi/ and lang/lambda/companion/**: These construct `TreeEditOp` for lambda's text-edit pipeline, not for projection's apply_edit. **No change needed** — they continue using `TreeEditOp` for `compute_text_edit`. The `apply_edit` call in examples is separate from the text-edit pipeline.
+
+## Steps
+
+### Step 1: Add GenericTreeOp to core/
+
+- Create `core/generic_tree_op.mbt`
+- Define `pub enum GenericTreeOp` with 14 variants
+- Add `derive(Debug)` and `Show` impl
+- **Compile break**: None — additive change
+
+**Verify**: `moon check` in root
+
+### Step 2: Add TreeEditOp::to_generic in lang/lambda/edits
+
+- Add `core/generic_tree_op.mbt` mapping function in `lang/lambda/edits/tree_lens.mbt`
+- Pure mapping, no logic change
+
+**Compile break**: None — additive change
+
+**Verify**: `moon check` in root
+
+### Step 3: Migrate projection/tree_editor.mbt
+
+- Remove `using @lambda_edits {type TreeEditOp}` import
+- Change `apply_edit` signature: `TreeEditOp` → `GenericTreeOp`
+- Rewrite match body using GenericTreeOp variants
+- Remove `@lambda_edits` from `projection/moon.pkg`
+
+**Compile break**: Yes — all callers of `TreeEditorState::apply_edit` break because the parameter type changed. This includes:
+  - `projection/tree_editor_refresh.mbt` (2 calls)
+  - `projection/tree_editor_wbtest.mbt` (~40 calls)
+  - `examples/ideal/main/main.mbt` (5 calls)
+
+**Fix**: Steps 4-6 fix these.
+
+**Verify**: `moon check` will fail until Steps 4-6 complete.
+
+### Step 4: Fix projection internal callsites
+
+- `projection/tree_editor_refresh.mbt` lines 747, 749: Change `Expand(node_id~)` — no prefix change needed since GenericTreeOp is now in scope via core.
+- Import `using @core {type GenericTreeOp}` at top of file if bare constructors don't resolve.
+
+**Verify**: `moon check` — projection should compile (wbtest may still fail)
+
+### Step 5: Fix projection tests
+
+- `projection/tree_editor_wbtest.mbt`: Replace all `TreeEditOp::*` / bare `Select(...)` etc. with `GenericTreeOp::*` variants.
+- `WrapInLambda(node_id=root_id, var_name="y")` → `StructuralEditKeepSelected(node_id=root_id)` (test on line 431 checks that selection is preserved — behavior unchanged)
+
+**Verify**: `moon check && moon test` in projection/
+
+### Step 6: Fix examples/ideal callsite
+
+- `examples/ideal/main/main.mbt`: Replace `@lambda_edits.Select(...)`, `@lambda_edits.Expand(...)`, `@lambda_edits.Collapse(...)` with `@core.GenericTreeOp::Select(...)`, etc.
+- `examples/ideal/main/view_outline.mbt`: Constructs `@lambda_edits.Expand`/`Collapse` at lines 58, 60, and 219-221. Under option (b) these stay as-is since the message still carries `TreeEditOp`. No code change needed, but audit to confirm.
+- Remove `@lambda_edits` import if it's no longer used for TreeEdited messages. (Check: the `TreeEdited(op)` message type carries `TreeEditOp` — this may still need `@lambda_edits` for the message enum definition. If so, the callsite calls `.to_generic()` before passing to `apply_edit`.)
+
+**Compile break**: The `TreeEdited(op)` message likely carries `TreeEditOp` from the outline view. Two options:
+  a. Change the message to carry `GenericTreeOp` (cleanest — outline only sends generic ops)
+  b. Keep `TreeEditOp` in message, call `op.to_generic()` before `apply_edit` (minimal change)
+
+Option (b) is safer for this PR. Option (a) can follow if the message type is revisited.
+
+**Verify**: `moon check && moon test` in root
+
+### Step 7: Clean up projection/moon.pkg
+
+- Verify `dowdiness/canopy/lang/lambda/edits` is no longer in import list
+- Verify wbtest imports for lambda are still present (tests use lambda AST for test data)
+
+**Verify**: `grep 'lambda/edits' projection/moon.pkg` returns only test imports
+
+### Step 8: Run full verification
+
+- `moon check` — full project
+- `moon test` — all tests pass
+- `moon info && moon fmt` — interfaces updated
+- `git diff *.mbti` — verify only expected API changes:
+  - `core/pkg.generated.mbti` gains `GenericTreeOp`
+  - `projection/pkg.generated.mbti` changes `apply_edit(TreeEditOp)` → `apply_edit(GenericTreeOp)`
+  - `lang/lambda/edits/pkg.generated.mbti` gains `TreeEditOp::to_generic`
+- No other `.mbti` files change
+
+## Invariants
+
+- `TreeEditorState::apply_edit` behavior is identical for all generic variants except one minor tightening: `StructuralEditKeepSelected` now also clears editing state, where `WrapInLambda`/`WrapInApp` previously did not
+- Lambda's text-edit pipeline (`compute_text_edit`) is completely untouched — it still uses `TreeEditOp`
+- No FFI surface changes (ffi/ doesn't call `apply_edit` directly)
+- projection/moon.pkg has zero lang/* dependencies in production imports
+
+## Test Plan
+
+- Existing projection tests (tree_editor_wbtest.mbt) migrated to GenericTreeOp — same assertions
+- Add one new test: `StructuralEdit` clears editing state (replaces implicit coverage from lambda-specific variant tests)
+- `moon test` across root + submodules
+- Manual: web dev server, lambda editor — outline tree operations (select, collapse, expand, drag) still work
+
+## Risk
+
+**Low.** Type-system-guided migration — the compiler catches every broken callsite. One minor behavior tightening (StructuralEditKeepSelected clears editing state — benign, prevents stale state). No FFI surface change. Reversible with a single revert.

--- a/docs/plans/2026-04-11-generic-tree-op.md
+++ b/docs/plans/2026-04-11-generic-tree-op.md
@@ -17,7 +17,7 @@ Of TreeEditOp's 27 variants, projection meaningfully handles only 11 generic one
 
 ### New type in core/
 
-```
+```moonbit
 pub enum GenericTreeOp {
   // Selection
   Select(node_id~ : NodeId)
@@ -52,7 +52,7 @@ Design notes:
 
 Revised:
 
-```
+```moonbit
 pub enum GenericTreeOp {
   Select(node_id~ : NodeId)
   SelectRange(start~ : NodeId, end~ : NodeId)
@@ -75,7 +75,7 @@ pub enum GenericTreeOp {
 
 Add a function that maps TreeEditOp → GenericTreeOp:
 
-```
+```moonbit
 pub fn TreeEditOp::to_generic(self : TreeEditOp) -> GenericTreeOp
 ```
 

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -478,14 +478,14 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
               model.editor.get_source_map(),
             )
           } else {
-            model.outline_state.apply_edit(op)
+            model.outline_state.apply_edit(op.to_generic())
           }
           return (none, { ..model, outline_state, })
         }
         @lambda_edits.Collapse(..)
         | @lambda_edits.Select(..)
         | @lambda_edits.SelectRange(..) => {
-          let outline_state = model.outline_state.apply_edit(op)
+          let outline_state = model.outline_state.apply_edit(op.to_generic())
           return (none, { ..model, outline_state, })
         }
         _ => (none, model)
@@ -551,7 +551,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Some(s) =>
           match parse_node_id(s) {
             Some(nid) =>
-              model.outline_state.apply_edit(@lambda_edits.Select(node_id=nid))
+              model.outline_state.apply_edit(@core.GenericTreeOp::Select(node_id=nid))
             None => return (none, model)
           }
         None => model.outline_state
@@ -598,7 +598,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
             .innermost_node_at(new_model.editor.get_cursor()) {
             Some(nid) => {
               let os = new_model.outline_state.apply_edit(
-                @lambda_edits.Select(node_id=nid),
+                @core.GenericTreeOp::Select(node_id=nid),
               )
               (Some(node_id_to_string(nid)), os)
             }

--- a/lang/lambda/edits/pkg.generated.mbti
+++ b/lang/lambda/edits/pkg.generated.mbti
@@ -93,6 +93,7 @@ pub(all) enum TreeEditOp {
   InlineAllUsages(binding_node_id~ : @core.NodeId)
   Rename(node_id~ : @core.NodeId, new_name~ : String)
 } derive(@debug.Debug)
+pub fn TreeEditOp::to_generic(Self) -> @core.GenericTreeOp
 pub impl Show for TreeEditOp
 
 // Type aliases

--- a/lang/lambda/edits/tree_lens.mbt
+++ b/lang/lambda/edits/tree_lens.mbt
@@ -58,6 +58,43 @@ pub impl Show for TreeEditOp with output(self, logger) {
 }
 
 ///|
+/// Map a language-specific TreeEditOp to the generic op type
+/// that projection/TreeEditorState understands.
+pub fn TreeEditOp::to_generic(self : TreeEditOp) -> @core.GenericTreeOp {
+  match self {
+    Select(node_id~) => Select(node_id~)
+    SelectRange(start~, end~) => SelectRange(start~, end~)
+    StartEdit(node_id~) => StartEdit(node_id~)
+    CommitEdit(node_id~, new_value~) => CommitEdit(node_id~, new_value~)
+    CancelEdit => CancelEdit
+    Delete(node_id~) => Delete(node_id~)
+    WrapInLambda(node_id~, ..) => StructuralEditKeepSelected(node_id~)
+    WrapInApp(node_id~) => StructuralEditKeepSelected(node_id~)
+    InsertChild(parent~, index~, ..) => InsertChild(parent~, index~)
+    StartDrag(node_id~) => StartDrag(node_id~)
+    DragOver(target~, position~) => DragOver(target~, position~)
+    Drop(source~, target~, position~) => Drop(source~, target~, position~)
+    Collapse(node_id~) => Collapse(node_id~)
+    Expand(node_id~) => Expand(node_id~)
+    Unwrap(node_id~, ..)
+    | SwapChildren(node_id~)
+    | WrapInIf(node_id~)
+    | WrapInBop(node_id~, ..)
+    | ChangeOperator(node_id~, ..)
+    | ExtractToLet(node_id~, ..)
+    | InlineDefinition(node_id~)
+    | Rename(node_id~, ..) => StructuralEdit(node_id~)
+    DeleteBinding(binding_node_id~) => StructuralEdit(node_id=binding_node_id)
+    InlineAllUsages(binding_node_id~) => StructuralEdit(node_id=binding_node_id)
+    DuplicateBinding(binding_node_id~) =>
+      StructuralEdit(node_id=binding_node_id)
+    MoveBindingUp(binding_node_id~) => StructuralEdit(node_id=binding_node_id)
+    MoveBindingDown(binding_node_id~) => StructuralEdit(node_id=binding_node_id)
+    AddBinding(module_node_id~) => StructuralEdit(node_id=module_node_id)
+  }
+}
+
+///|
 fn[T : Renderable] placeholder_text_for_kind(kind : T) -> String {
   T::placeholder(kind)
 }

--- a/lang/lambda/edits/tree_lens_wbtest.mbt
+++ b/lang/lambda/edits/tree_lens_wbtest.mbt
@@ -1,2 +1,44 @@
 // Tree lens whitebox tests removed — old apply_edit_to_proj path is dead code.
 // compute_text_edit tests in text_edit_wbtest.mbt cover all TreeEditOp variants.
+
+///|
+test "to_generic: WrapInLambda maps to StructuralEditKeepSelected" {
+  let nid = NodeId::from_int(1)
+  let op = TreeEditOp::WrapInLambda(node_id=nid, var_name="x")
+  let g = op.to_generic()
+  inspect(g, content="StructuralEditKeepSelected(node_id=NodeId(1))")
+}
+
+///|
+test "to_generic: WrapInApp maps to StructuralEditKeepSelected" {
+  let nid = NodeId::from_int(2)
+  let op = TreeEditOp::WrapInApp(node_id=nid)
+  let g = op.to_generic()
+  inspect(g, content="StructuralEditKeepSelected(node_id=NodeId(2))")
+}
+
+///|
+test "to_generic: InsertChild drops kind field" {
+  let parent = NodeId::from_int(3)
+  let op = TreeEditOp::InsertChild(parent~, index=1, kind=@ast.Term::Int(42))
+  let g = op.to_generic()
+  inspect(g, content="InsertChild(parent=NodeId(3), index=1)")
+}
+
+///|
+test "to_generic: structural ops map to StructuralEdit" {
+  let nid = NodeId::from_int(4)
+  let unwrap = TreeEditOp::Unwrap(node_id=nid, keep_child_index=0).to_generic()
+  inspect(unwrap, content="StructuralEdit(node_id=NodeId(4))")
+  let rename = TreeEditOp::Rename(node_id=nid, new_name="y").to_generic()
+  inspect(rename, content="StructuralEdit(node_id=NodeId(4))")
+}
+
+///|
+test "to_generic: binding ops map to StructuralEdit with binding_node_id" {
+  let nid = NodeId::from_int(5)
+  let del = TreeEditOp::DeleteBinding(binding_node_id=nid).to_generic()
+  inspect(del, content="StructuralEdit(node_id=NodeId(5))")
+  let dup = TreeEditOp::DuplicateBinding(binding_node_id=nid).to_generic()
+  inspect(dup, content="StructuralEdit(node_id=NodeId(5))")
+}

--- a/projection/moon.pkg
+++ b/projection/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "dowdiness/canopy/core" @core,
-  "dowdiness/canopy/lang/lambda/edits" @lambda_edits,
   "dowdiness/loom/core" @loomcore,
   "moonbitlang/core/bench" @bench,
   "moonbitlang/core/cmp",

--- a/projection/pkg.generated.mbti
+++ b/projection/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "dowdiness/canopy/projection"
 
 import {
-  "dowdiness/canopy/lang/lambda/edits",
   "moonbitlang/core/debug",
   "moonbitlang/core/immut/hashset",
 }
@@ -44,7 +43,7 @@ pub struct TreeEditorState[T] {
   collapsed_nodes : @hashset.HashSet[@dowdiness/canopy/core.NodeId]
   // private fields
 }
-pub fn[T] TreeEditorState::apply_edit(Self[T], @edits.TreeEditOp) -> Self[T]
+pub fn[T] TreeEditorState::apply_edit(Self[T], @dowdiness/canopy/core.GenericTreeOp) -> Self[T]
 pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] TreeEditorState::expand_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]?, @dowdiness/canopy/core.SourceMap) -> Self[T]
 pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] TreeEditorState::from_projection(@dowdiness/canopy/core.ProjNode[T]?, @dowdiness/canopy/core.SourceMap) -> Self[T]
 pub fn[T] TreeEditorState::get_loaded_node(Self[T], @dowdiness/canopy/core.NodeId) -> InteractiveTreeNode[T]?

--- a/projection/tree_editor.mbt
+++ b/projection/tree_editor.mbt
@@ -1,13 +1,12 @@
 // Interactive Tree Editor: Edit operations
 
 ///|
-using @lambda_edits {type TreeEditOp}
-
-///|
-/// Apply a tree edit operation to the editor state
+/// Apply a generic tree edit operation to the editor state.
+/// Language packages map their domain-specific ops via to_generic()
+/// before calling this method.
 pub fn[T] TreeEditorState::apply_edit(
   self : TreeEditorState[T],
-  edit : TreeEditOp,
+  edit : @core.GenericTreeOp,
 ) -> TreeEditorState[T] {
   match edit {
     Select(node_id~) => apply_selection_edit(self, [node_id])
@@ -90,22 +89,13 @@ pub fn[T] TreeEditorState::apply_edit(
         collapsed_nodes,
       }
     }
-    WrapInLambda(node_id~, var_name~) => {
-      // UI state: keep the wrapped node selected
+    StructuralEditKeepSelected(node_id~) =>
+      // Keep the target node selected, clear editing state.
+      // Used for wrap-style ops where the wrapped node stays focused.
+      { ..self, selection: [node_id], editing_node: None, edit_value: "" }
+    InsertChild(parent~, ..) =>
       // Structural change is handled by SyncEditor::apply_tree_edit + refresh
-      let _ = var_name
-      { ..self, selection: [node_id] }
-    }
-    WrapInApp(node_id~) =>
-      // UI state: keep the wrapped node selected
-      // Structural change is handled by SyncEditor::apply_tree_edit + refresh
-      { ..self, selection: [node_id] }
-    InsertChild(parent~, index~, kind~) => {
-      // UI state: select the parent node
-      // Structural change is handled by SyncEditor::apply_tree_edit + refresh
-      let _ = (index, kind)
       { ..self, selection: [parent] }
-    }
     StartDrag(node_id~) =>
       // Clear any stale drop state when starting a new drag
       {
@@ -195,24 +185,9 @@ pub fn[T] TreeEditorState::apply_edit(
           }
         None => self
       }
-    // Structural ops that use node_id — clear editing state
-    Unwrap(node_id~, ..)
-    | SwapChildren(node_id~)
-    | WrapInIf(node_id~)
-    | WrapInBop(node_id~, ..)
-    | ChangeOperator(node_id~, ..)
-    | ExtractToLet(node_id~, ..)
-    | InlineDefinition(node_id~)
-    | Rename(node_id~, ..) => {
-      let _ = node_id
+    StructuralEdit(..) =>
+      // Generic structural op: clear editing state.
+      // The actual text-level change is handled by the language's edit bridge.
       { ..self, editing_node: None, edit_value: "" }
-    }
-    // Binding-level ops — clear editing state
-    DeleteBinding(..)
-    | InlineAllUsages(..)
-    | DuplicateBinding(..)
-    | MoveBindingUp(..)
-    | MoveBindingDown(..)
-    | AddBinding(..) => { ..self, editing_node: None, edit_value: "" }
   }
 }

--- a/projection/tree_editor_wbtest.mbt
+++ b/projection/tree_editor_wbtest.mbt
@@ -425,12 +425,13 @@ test "DragOver allows elided descendant as drop target (lazy parent map)" {
 }
 
 ///|
-test "WrapInLambda keeps wrapped node selected" {
+test "StructuralEditKeepSelected keeps node selected and clears editing" {
   let (_, _, state) = tree_editor_test_state("x")
   let root_id = tree_editor_test_ids(state.tree)[0]
-  let updated = state.apply_edit(WrapInLambda(node_id=root_id, var_name="y"))
+  let updated = state.apply_edit(StructuralEditKeepSelected(node_id=root_id))
   inspect(updated.selection.length(), content="1")
   inspect(updated.selection[0] == root_id, content="true")
+  inspect(updated.editing_node, content="None")
 }
 
 ///|

--- a/projection/tree_editor_wbtest.mbt
+++ b/projection/tree_editor_wbtest.mbt
@@ -432,6 +432,7 @@ test "StructuralEditKeepSelected keeps node selected and clears editing" {
   inspect(updated.selection.length(), content="1")
   inspect(updated.selection[0] == root_id, content="true")
   inspect(updated.editing_node, content="None")
+  inspect(updated.edit_value, content="")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Introduce `GenericTreeOp` enum in `core/` (14 variants) to replace projection's dependency on lambda-specific `TreeEditOp` (27 variants)
- Add `TreeEditOp::to_generic()` mapping in `lang/lambda/edits`
- Remove `dowdiness/canopy/lang/lambda/edits` production dependency from `projection/moon.pkg`
- One minor behavior tightening: `StructuralEditKeepSelected` clears editing state (previously `WrapInLambda`/`WrapInApp` did not)

## Motivation

`projection/` is language-agnostic but depended on `lang/lambda/edits` for `TreeEditOp`. This blocked adding tree editing for new languages without modifying projection. Of the 27 `TreeEditOp` variants, projection only handled 11 meaningfully — the other 16 shared a single catch-all behavior (clear editing state).

## Test plan

- [x] `moon check` — 0 errors
- [x] `moon test` — 842 tests, all passing
- [x] `git diff *.mbti` — only 3 expected files changed (core, projection, lambda/edits)
- [x] projection/moon.pkg has zero `canopy/lang/*` production dependencies
- [ ] Manual: web dev server, lambda editor — outline tree operations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified tree operation interface supporting selection, editing, structural changes, drag-and-drop, and navigation operations.

* **Refactor**
  * Streamlined tree editing state management with language-agnostic operation handling.
  * Removed language-specific operation dependencies from tree editor for improved cross-language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->