### PR TITLE
feat(eval): wire Tier 3 egraph optimizer into canopy

### DIFF
--- a/lang/lambda/eval/moon.pkg
+++ b/lang/lambda/eval/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/egglog/examples/lambda-eval" @egglog_eval,
   "dowdiness/egglog/src" @egglog,
+  "dowdiness/egraph/examples/lambda-opt" @lambda_opt,
   "dowdiness/incr" @incr,
   "dowdiness/lambda/ast" @ast,
   "dowdiness/lambda/eval" @lambda_eval,

--- a/lang/lambda/eval/optimize.mbt
+++ b/lang/lambda/eval/optimize.mbt
@@ -1,0 +1,15 @@
+// Tier 3: EGraph-based algebraic optimization.
+// Wraps @lambda_opt.optimize for use in the eval annotation pipeline.
+
+///|
+/// Optimize a term via equality saturation.
+/// Returns the simplified form if it differs from the input,
+/// or None if the optimizer produces the same expression.
+pub fn optimize_term(term : @ast.Term) -> @ast.Term? {
+  let result = @lambda_opt.optimize(term)
+  if result == term {
+    None
+  } else {
+    Some(result)
+  }
+}

--- a/lang/lambda/eval/pkg.generated.mbti
+++ b/lang/lambda/eval/pkg.generated.mbti
@@ -22,6 +22,8 @@ pub fn eval_term(@ast.Term) -> Array[EvalResult]
 
 pub fn inject_eval_annotations(@pretty.Layout[@pretty.SyntaxCategory], Array[EvalResult]) -> @pretty.Layout[@pretty.SyntaxCategory]
 
+pub fn optimize_term(@ast.Term) -> @ast.Term?
+
 pub fn seed_term(@src.Database, @ast.Term) -> @src.Value
 
 pub fn split_at_hardlines(@pretty.Layout[@pretty.SyntaxCategory]) -> Array[@pretty.Layout[@pretty.SyntaxCategory]]

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -40,6 +40,9 @@
     },
     "dowdiness/egglog": {
       "path": "./loom/egglog"
+    },
+    "dowdiness/egraph": {
+      "path": "./loom/egraph"
     }
   },
   "readme": "README.mbt.md",


### PR DESCRIPTION
## Summary

- Add `dowdiness/egraph` dependency to canopy
- Wire `@lambda_opt.optimize` into `lang/lambda/eval/` as `optimize_term(Term) -> Term?`
- Update loom submodule to include egraph API exposure (egraph#10) and lambda-opt package

## Context

Completes Phase 2 of the Tier 3 egraph optimizer plan. Phase 1 (egraph#10, loom#78) exposed the core egraph APIs and created the `lambda-opt` package with:
- `LambdaLang` e-node type
- Arithmetic identity rewrite rules
- Free-variable tracking + constant folding + beta reduction analysis
- `optimize(Term) -> Term` via equality saturation

The canopy-side wrapper `optimize_term` returns `None` when optimization produces no change, making it easy for the editor to skip annotation.

## Test plan

- [x] `moon check` passes
- [x] All 851 canopy tests pass
- [x] `moon info` — only `optimize_term` added to public API
- [x] `moon fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)