### PR TITLE
refactor(eval): use Memo::new with automatic backdating

### DIFF
--- a/lang/lambda/eval/eval_memo.mbt
+++ b/lang/lambda/eval/eval_memo.mbt
@@ -206,19 +206,13 @@ pub fn build_eval_memo(
   parser : @loom.ImperativeParser[@ast.Term],
 ) -> @incr.Memo[Array[EvalResult]] {
   let cache : Ref[Array[CachedDef]] = Ref::new([])
-  let prev_results : Ref[Array[EvalResult]] = Ref::new([])
-  @incr.Memo::new_no_backdate(
+  @incr.Memo::new(
     rt,
     fn() -> Array[EvalResult] {
       let _ = syntax_tree.get()
       let ast = parser.get_tree().unwrap_or(@ast.Term::Unit)
       let (results, new_cache) = eval_term_cached(ast, cache.val)
-      // If cache unchanged (same reference), reuse previous results array
-      if physical_equal(new_cache, cache.val) && prev_results.val.length() > 0 {
-        return prev_results.val
-      }
       cache.val = new_cache
-      prev_results.val = results
       results
     },
     label="eval_memo",

--- a/lang/lambda/eval/eval_memo.mbt
+++ b/lang/lambda/eval/eval_memo.mbt
@@ -196,10 +196,13 @@ fn fill_suppressed(
 ///|
 /// Build a reactive eval memo with incremental caching.
 ///
-/// Caches per-definition results. When only definition N changes,
-/// reuses cached results for definitions 0..N-1 and re-evaluates
-/// from N onward. This satisfies the "re-editing one binding only
-/// re-evaluates dependents" requirement.
+/// Two layers of incrementality:
+/// - **Inner (CachedDef):** prefix-reuse cache. When only definition N changes,
+///   reuses results for definitions 0..N-1 and re-evaluates from N onward.
+/// - **Outer (Memo::new backdating):** when the recomputed Array[EvalResult]
+///   is structurally equal to the previous one, the memo's changed_at timestamp
+///   is preserved, preventing downstream memos (escalation, projection) from
+///   recomputing unnecessarily.
 pub fn build_eval_memo(
   rt : @incr.Runtime,
   syntax_tree : @incr.Signal[@seam.SyntaxNode?],


### PR DESCRIPTION
## Summary

- Replace `Memo::new_no_backdate` with `Memo::new` in `build_eval_memo`
- **Introduces real backdating**: the old code never backdated — downstream memos (escalation, projection) always recomputed even when eval results were unchanged. Now the incr runtime compares `Array[EvalResult]` structurally via `Eq` and preserves the `changed_at` timestamp when results match.
- Eliminates manual `physical_equal` check and `prev_results` Ref (-7 lines)
- Updated doc comment explaining the two-layer incrementality: inner CachedDef prefix-reuse + outer Memo backdating

## Context

Investigated the "per-def eval Memos" idea from the backlog. Conclusion: full per-def Memos are more complex than the current `CachedDef` prefix-reuse cache because definitions are sequential (def N depends on defs 0..N-1). This change captures the real win — proper backdating that the old `new_no_backdate` code lacked entirely.

Codex review confirmed: no correctness issues. The structural equality on `Array[EvalResult]` is correct for backdating — no consumer needs notifications when results are structurally unchanged.

## Test plan

- [x] All 851 tests pass
- [x] No API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for evaluation memoization behavior regarding two-layer incrementality and memoization caching.

* **Refactor**
  * Simplified evaluation memoization implementation by removing custom result-reuse logic, delegating to standard memoization system for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->