### PR TITLE
feat(proof): formal verification of Confidence lattice laws

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,41 @@ jobs:
       - name: Check and test ${{ matrix.name }}
         run: ./scripts/run-moon-module.sh ci "${{ matrix.path }}"
 
+  prove:
+    name: Formal Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Set up OCaml and opam
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.3'
+
+      - name: Install Why3 and Z3
+        run: |
+          opam install why3.1.7.2 z3 --yes
+          eval $(opam env)
+          why3 config detect
+
+      - name: Update MoonBit dependencies
+        working-directory: lib/semantic/proof
+        run: moon update
+
+      - name: Run moon prove
+        working-directory: lib/semantic/proof
+        run: |
+          eval $(opam env)
+          moon prove
+
   benchmark:
     name: Run Benchmarks
     runs-on: ubuntu-latest
@@ -288,6 +323,7 @@ jobs:
     needs:
       - test-main
       - test-submodules
+      - prove
       - format-check
       - build-js
       - web-build
@@ -299,6 +335,7 @@ jobs:
         run: |
           if [[ "${{ needs.test-main.result }}" != "success" ]] || \
              [[ "${{ needs.test-submodules.result }}" != "success" ]] || \
+             [[ "${{ needs.prove.result }}" != "success" ]] || \
              [[ "${{ needs.format-check.result }}" != "success" ]] || \
              [[ "${{ needs.build-js.result }}" != "success" ]] || \
              [[ "${{ needs.web-build.result }}" != "success" ]] || \

--- a/docs/development/formal-verification.md
+++ b/docs/development/formal-verification.md
@@ -1,0 +1,204 @@
+# Formal Verification
+
+## Overview
+
+MoonBit provides formal verification via `moon prove`, which uses SMT solvers (z3) through Why3 to mathematically prove properties about code. Unlike property-based tests (@qc) that check random samples, `moon prove` guarantees a property holds for **all** inputs.
+
+Canopy uses both: `moon prove` for properties the prover can model, @qc for everything else. The two layers complement each other.
+
+## Toolchain
+
+```
+moon prove  →  moonc (WhyML codegen)  →  Why3  →  z3 (SMT solver)
+```
+
+**Tested versions:**
+- MoonBit moon 0.1.20260409
+- Why3 1.7.2 (install via `opam install why3.1.7.2`)
+- Z3 4.13.x (install via `pip3 install z3-solver==4.13.4.0` or `opam install z3`)
+
+**Why3 1.7.2 specifically:** moonc's built-in Why3 harness expects this version. Stock 1.7.2 recognizes z3 up to 4.13.x — newer z3 versions are not detected.
+
+## How It Works
+
+### File structure
+
+```
+lib/semantic/proof/
+├── moon.mod.json          # Standalone module (no canopy deps)
+├── moon.pkg               # options("proof-enabled": true)
+├── confidence.mbt          # Code + proof_ensure contracts
+├── confidence.mbtp         # Logical predicates (spec-only)
+└── pkg.generated.mbti
+```
+
+### Program side (`.mbt`)
+
+Functions carry contracts via `where` blocks:
+
+```moonbit
+pub fn join(self : T, other : T) -> T where {
+  proof_ensure: result => conflict_is_top(self, other, result),
+  proof_ensure: result => identity_left(self, other, result),
+} {
+  // implementation
+}
+```
+
+- `proof_require`: preconditions (assumed true at call site)
+- `proof_ensure`: postconditions (must hold for every execution path)
+- `proof_assert`: intermediate facts within function body
+- `proof_invariant`: loop invariants
+- `#proof_pure`: marks a function as callable from `.mbtp` predicates
+
+### Logic side (`.mbtp`)
+
+Pure specifications — predicates, lemmas, models:
+
+```
+predicate conflict_is_top(a : T, b : T, result : T) {
+  (a.rank() == 4 → result.rank() == 4) &&
+  (b.rank() == 4 → result.rank() == 4)
+}
+```
+
+### Running
+
+```bash
+cd lib/semantic/proof
+moon prove          # verify all proof_ensure contracts
+```
+
+## Prover Limitations
+
+These constraints determine what `moon prove` can and cannot verify:
+
+| Limitation | Impact | Workaround |
+|---|---|---|
+| Unbounded integers only | No Float, no overflow modeling | Use Int-specialized mirror types |
+| No `==` on custom enums | Can't write `result == expected` for enum types | Project to Int via `#proof_pure` functions |
+| No method calls in predicates | Only `#proof_pure` functions and primitives | Write pure projection functions |
+| No Map/Array[T]/closure reasoning | Can't model stateful data structures | Use @qc for these properties |
+| Wildcard `_` codegen bug | `IRuleBased(_) => 2` emits broken WhyML | Use named bindings: `IRuleBased(_v) => 2` |
+| `proof-enabled` cascades to deps | Enabling on a package proves all transitive deps | Isolate proof packages in standalone modules |
+
+## When to Use What
+
+### Decision flow
+
+```
+Is the property about pure Int/Bool/FixedArray functions?
+├── yes → Can you avoid == on custom enums?
+│   ├── yes → moon prove
+│   └── no → Can you project to Int via #proof_pure?
+│       ├── yes → moon prove (projection pattern)
+│       └── no → @qc
+└── no → @qc
+```
+
+### Three tiers
+
+| Tier | Tool | Guarantee | Best for |
+|---|---|---|---|
+| 1. Formal proof | `moon prove` | All inputs, mathematical | Index arithmetic, lattice laws, loop invariants, sorted-order |
+| 2. Property tests | `@qc` | High confidence, random sampling | CRDT convergence, tree reconciliation, round-trips, stateful interactions |
+| 3. Snapshot tests | `inspect` | Specific examples only | Regression detection, expected output |
+
+### Composition principle
+
+**Prove the algorithm, test the integration.**
+
+For `Confidence::join`: we proved the lattice laws on `IntConfidence` (the algorithm structure), while @qc tests cover `Confidence[Role]` with Float scores (the real type with integration concerns). If someone changes the match arms, `moon prove` catches it. If someone breaks Float validation in `guessed()`, @qc catches it.
+
+## Current Coverage
+
+### Formally verified (lib/semantic/proof/)
+
+`IntConfidence::join` — 5 properties:
+
+| Predicate | What it proves |
+|---|---|
+| `conflict_is_top` | Conflict absorbs: join with Conflict always yields Conflict |
+| `unknown_is_bottom_left` | Left identity: join(Unknown, x) == x (via rank/payload/score) |
+| `unknown_is_bottom_right` | Right identity: join(x, Unknown) == x |
+| `disagreement_yields_conflict` | Different payloads from non-trivial inputs → Conflict |
+| `guessed_max_score` | Guessed+Guessed same payload → Guessed with exact max score, payload preserved |
+
+### Property-tested (@qc)
+
+| Package | File | Properties |
+|---|---|---|
+| core/ | reconcile_properties_wbtest.mbt | ID uniqueness, ID preservation, kind propagation, idempotency, insert/delete stability |
+| core/ | source_map_properties_wbtest.mbt | Node coverage, range sorting, rebuild consistency, parent enclosure, innermost node minimality |
+| lib/semantic/ | confidence_properties_wbtest.mbt | Commutativity, associativity, idempotency, identity, absorbing top (on real `Confidence[Role]`) |
+| lib/zipper/ | zipper_properties_wbtest.mbt | Zipper navigation laws |
+| event-graph-walker/ | Various *_properties_test.mbt | CRDT convergence, version vector properties, FractionalIndex ordering |
+
+## Future Proof Targets
+
+Candidates ordered by value and feasibility:
+
+### High value, good fit for moon prove
+
+| Target | Package | Properties | Why provable |
+|---|---|---|---|
+| BTree node invariants | lib/btree | Key count in [t-1, 2t-1] after insert/delete | Pure Int arithmetic with loop invariants |
+| delete_range boundaries | lib/btree | Index parameters stay valid through descent | Index math — exactly what z3 excels at |
+| SourceMap range sorting | core/ | Ranges array sorted after rebuild | Int comparisons on array indices |
+| FractionalIndex ordering | event-graph-walker/ | midpoint(a, b) is strictly between a and b | Byte-array arithmetic |
+
+### High value, better as @qc
+
+| Target | Package | Properties | Why not provable |
+|---|---|---|---|
+| Reconcile ID uniqueness | core/ | No duplicate NodeIds after reconcile | Involves Map, recursive trees, counters |
+| CRDT convergence | event-graph-walker/ | Two peers converge regardless of op order | Multi-step stateful interactions |
+| Projection idempotence | projection/ | project → reconcile → project is stable | Full pipeline with many moving parts |
+| Projection stability | projection/ | Same input → same output across rebuilds | Depends on mutable SourceMap state |
+
+### Not worth verifying (unit/snapshot tests sufficient)
+
+- FFI serialization (test at the boundary, trust the format)
+- UI rendering (test in browser via Playwright)
+- Config parsing (finite cases, exhaustive unit tests)
+
+## Setup Guide
+
+### Local development
+
+```bash
+# Install opam (OCaml package manager)
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)"
+opam init --yes
+
+# Install Why3 and z3
+opam install why3.1.7.2 --yes
+pip3 install --user z3-solver==4.13.4.0
+
+# Register z3 with Why3
+why3 config detect
+
+# Run proofs
+cd lib/semantic/proof
+moon prove
+```
+
+### CI
+
+The `prove` job in `.github/workflows/ci.yml` uses `ocaml/setup-ocaml@v3` to install OCaml/opam, then installs Why3 1.7.2 and z3. The opam switch is cached across runs.
+
+### Adding a new proof package
+
+1. Create a standalone module with its own `moon.mod.json` (avoids cascading `proof-enabled` to the entire dependency graph)
+2. Add `options("proof-enabled": true)` to `moon.pkg`
+3. Write `#proof_pure` projection functions for any custom types
+4. Write predicates in `.mbtp`
+5. Add `proof_ensure` contracts to the function under verification
+6. Run `moon prove` and iterate
+
+### Common issues
+
+- **z3 not recognized**: Why3 1.7.2 only supports z3 up to 4.13.x
+- **"no configured provers"**: Run `why3 config detect` after installing z3
+- **Wildcard codegen bug**: Use `_v` not `_` in match arms of `#proof_pure` functions
+- **`proof-enabled` cascading**: Keep proof packages in standalone modules with no project dependencies

--- a/lib/semantic/proof/confidence.mbt
+++ b/lib/semantic/proof/confidence.mbt
@@ -67,13 +67,12 @@ pub fn IntConfidence::score(self : IntConfidence) -> Int {
 ///|
 /// Join for IntConfidence — structurally identical to Confidence::join.
 ///
-/// Verified properties (via moon prove):
-///   - Monotonicity: rank(result) >= rank(a) and rank(result) >= rank(b)
-///     (except when both carry matching values — Guessed+RuleBased→Confirmed)
-///   - Unknown is bottom: if a is Unknown, result == b (by rank + payload)
-///   - Conflict is top: if a or b is Conflict, result is Conflict
-///   - Agreement promotion: same payload from different tiers → Confirmed
+/// Verified properties (via moon prove, see proof_ensure below):
+///   - Conflict is top: if either input is Conflict, result is Conflict
+///   - Unknown is left/right identity: join(Unknown, x) == x and vice versa
 ///   - Disagreement absorption: different payloads → Conflict
+///   - Guessed max score: Guessed+Guessed with same payload → Guessed
+///     with exactly max(score_a, score_b) and payload preserved
 pub fn IntConfidence::join(
   self : IntConfidence,
   other : IntConfidence,

--- a/lib/semantic/proof/confidence.mbt
+++ b/lib/semantic/proof/confidence.mbt
@@ -1,0 +1,115 @@
+///|
+/// Int-specialized confidence for formal verification.
+///
+/// Proved with:
+///   - MoonBit moon 0.1.20260409 (a87440e 2026-04-09)
+///   - Why3 1.7.2
+///   - Z3 4.13.4
+///
+/// `moon prove` reasons over unbounded mathematical integers, not IEEE floats.
+/// This mirrors `Confidence[T]` from lib/semantic with Int payloads so the
+/// lattice laws can be formally verified. The generic Float-bearing version
+/// remains tested via @qc (quickcheck).
+pub(all) enum IntConfidence {
+  IUnknown
+  IGuessed(Int, Int)
+  IRuleBased(Int)
+  IConfirmed(Int)
+  IConflict
+} derive(Eq, Debug)
+
+///|
+pub impl Show for IntConfidence with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// Rank in the lattice: Unknown(0) < Guessed(1) < RuleBased(2) < Confirmed(3) < Conflict(4).
+/// Marked #proof_pure so it can be used in .mbtp predicates.
+#proof_pure
+pub fn IntConfidence::rank(self : IntConfidence) -> Int {
+  match self {
+    IUnknown => 0
+    IGuessed(_p, _v) => 1
+    IRuleBased(_v) => 2
+    IConfirmed(_v) => 3
+    IConflict => 4
+  }
+}
+
+///|
+/// Extract payload value (-1 for Unknown/Conflict which carry none).
+/// Used by the prover to reason about value-agreement rules.
+#proof_pure
+pub fn IntConfidence::payload(self : IntConfidence) -> Int {
+  match self {
+    IUnknown => -1
+    IGuessed(_, v) => v
+    IRuleBased(v) => v
+    IConfirmed(v) => v
+    IConflict => -1
+  }
+}
+
+///|
+/// Extract confidence score (only meaningful for IGuessed, 0 otherwise).
+#proof_pure
+pub fn IntConfidence::score(self : IntConfidence) -> Int {
+  match self {
+    IGuessed(p, _v) => p
+    IUnknown => 0
+    IRuleBased(_v) => 0
+    IConfirmed(_v) => 0
+    IConflict => 0
+  }
+}
+
+///|
+/// Join for IntConfidence — structurally identical to Confidence::join.
+///
+/// Verified properties (via moon prove):
+///   - Monotonicity: rank(result) >= rank(a) and rank(result) >= rank(b)
+///     (except when both carry matching values — Guessed+RuleBased→Confirmed)
+///   - Unknown is bottom: if a is Unknown, result == b (by rank + payload)
+///   - Conflict is top: if a or b is Conflict, result is Conflict
+///   - Agreement promotion: same payload from different tiers → Confirmed
+///   - Disagreement absorption: different payloads → Conflict
+pub fn IntConfidence::join(
+  self : IntConfidence,
+  other : IntConfidence,
+) -> IntConfidence where {
+  proof_ensure: result => conflict_is_top(self, other, result),
+  proof_ensure: result => unknown_is_bottom_left(self, other, result),
+  proof_ensure: result => unknown_is_bottom_right(self, other, result),
+  proof_ensure: result => disagreement_yields_conflict(self, other, result),
+  proof_ensure: result => guessed_max_score(self, other, result),
+} {
+  match (self, other) {
+    (IUnknown, x) | (x, IUnknown) => x
+    (IConflict, _) | (_, IConflict) => IConflict
+    (IConfirmed(a), IConfirmed(b))
+    | (IConfirmed(a), IRuleBased(b))
+    | (IRuleBased(b), IConfirmed(a))
+    | (IConfirmed(a), IGuessed(_, b))
+    | (IGuessed(_, b), IConfirmed(a))
+    | (IRuleBased(a), IGuessed(_, b))
+    | (IGuessed(_, b), IRuleBased(a)) =>
+      if a == b {
+        IConfirmed(a)
+      } else {
+        IConflict
+      }
+    (IRuleBased(a), IRuleBased(b)) =>
+      if a == b {
+        IRuleBased(a)
+      } else {
+        IConflict
+      }
+    (IGuessed(p, a), IGuessed(q, b)) =>
+      if a == b {
+        IGuessed(if p >= q { p } else { q }, a)
+      } else {
+        IConflict
+      }
+  }
+}

--- a/lib/semantic/proof/confidence.mbtp
+++ b/lib/semantic/proof/confidence.mbtp
@@ -1,0 +1,68 @@
+// Formal specifications for IntConfidence lattice laws.
+//
+// Proved with:
+//   - MoonBit moon 0.1.20260409 (a87440e 2026-04-09)
+//   - Why3 1.7.2
+//   - Z3 4.13.4
+//
+// The prover can't use == on custom enums, so we express properties
+// via rank/payload/score projections (marked #proof_pure in .mbt)
+// and pattern matching.
+
+// Conflict is the top element (absorbing): if either input is Conflict,
+// result must be Conflict (rank 4).
+predicate conflict_is_top(
+  a : IntConfidence,
+  b : IntConfidence,
+  result : IntConfidence,
+) {
+  (a.rank() == 4 → result.rank() == 4) &&
+  (b.rank() == 4 → result.rank() == 4)
+}
+
+// Unknown is bottom (left identity): if a is Unknown, result has
+// same rank and payload as b.
+predicate unknown_is_bottom_left(
+  a : IntConfidence,
+  b : IntConfidence,
+  result : IntConfidence,
+) {
+  a.rank() == 0 →
+    (result.rank() == b.rank() && result.payload() == b.payload() &&
+      result.score() == b.score())
+}
+
+// Unknown is bottom (right identity): if b is Unknown, result has
+// same rank and payload as a.
+predicate unknown_is_bottom_right(
+  a : IntConfidence,
+  b : IntConfidence,
+  result : IntConfidence,
+) {
+  b.rank() == 0 →
+    (result.rank() == a.rank() && result.payload() == a.payload() &&
+      result.score() == a.score())
+}
+
+// Disagreement yields Conflict: when both inputs carry payloads
+// (rank > 0 and rank < 4) and payloads differ, result is Conflict.
+predicate disagreement_yields_conflict(
+  a : IntConfidence,
+  b : IntConfidence,
+  result : IntConfidence,
+) {
+  (a.rank() > 0 && a.rank() < 4 &&
+   b.rank() > 0 && b.rank() < 4 &&
+   a.payload() != b.payload()) →
+    result.rank() == 4
+}
+
+// Guessed+Guessed with same value: result score is max of input scores.
+predicate guessed_max_score(
+  a : IntConfidence,
+  b : IntConfidence,
+  result : IntConfidence,
+) {
+  (a.rank() == 1 && b.rank() == 1 && a.payload() == b.payload()) →
+    (result.score() >= a.score() && result.score() >= b.score())
+}

--- a/lib/semantic/proof/confidence.mbtp
+++ b/lib/semantic/proof/confidence.mbtp
@@ -57,12 +57,17 @@ predicate disagreement_yields_conflict(
     result.rank() == 4
 }
 
-// Guessed+Guessed with same value: result score is max of input scores.
+// Guessed+Guessed with same value: result is Guessed with same payload
+// and score == max(a.score(), b.score()). Exact equality rejects bugs
+// that inflate the score (e.g. summing both scores).
 predicate guessed_max_score(
   a : IntConfidence,
   b : IntConfidence,
   result : IntConfidence,
 ) {
   (a.rank() == 1 && b.rank() == 1 && a.payload() == b.payload()) →
-    (result.score() >= a.score() && result.score() >= b.score())
+    (result.rank() == 1 &&
+     result.payload() == a.payload() &&
+     ((a.score() >= b.score() && result.score() == a.score()) ||
+      (b.score() > a.score() && result.score() == b.score())))
 }

--- a/lib/semantic/proof/moon.mod.json
+++ b/lib/semantic/proof/moon.mod.json
@@ -1,0 +1,8 @@
+{
+  "name": "dowdiness/semantic-proof",
+  "version": "0.1.0",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": ["verification", "lattice", "proof"],
+  "description": "Formal verification of Confidence lattice laws via moon prove"
+}

--- a/lib/semantic/proof/moon.pkg
+++ b/lib/semantic/proof/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "moonbitlang/core/debug",
+}
+
+options(
+  "proof-enabled": true,
+)

--- a/lib/semantic/proof/pkg.generated.mbti
+++ b/lib/semantic/proof/pkg.generated.mbti
@@ -1,0 +1,29 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/semantic-proof"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum IntConfidence {
+  IUnknown
+  IGuessed(Int, Int)
+  IRuleBased(Int)
+  IConfirmed(Int)
+  IConflict
+} derive(Eq, @debug.Debug)
+pub fn IntConfidence::join(Self, Self) -> Self
+pub fn IntConfidence::payload(Self) -> Int
+pub fn IntConfidence::rank(Self) -> Int
+pub fn IntConfidence::score(Self) -> Int
+pub impl Show for IntConfidence
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

- Adds `lib/semantic/proof/` — standalone MoonBit package with `moon prove` formal verification of lattice laws for `IntConfidence::join`
- 5 properties proved via z3 SMT solver: conflict absorption (top), left/right identity (bottom), disagreement→conflict, and Guessed max-score
- Uses `#proof_pure` projection functions (`rank`, `payload`, `score`) to express enum properties within the prover's Int-only equality constraint
- Complements existing `@qc` property tests in `lib/semantic/` which cover the generic `Confidence[T]` with Float payloads

## Toolchain

- MoonBit moon 0.1.20260409
- Why3 1.7.2
- Z3 4.13.4

## Test plan

- [x] `moon prove` passes (5/5 goals, 0 failures)
- [x] `moon check` clean (parent project unaffected)
- [ ] CI (no `moon prove` in CI yet — requires Why3 + z3 setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new confidence type with operations to compare and combine confidence values.
  * Added helper methods to inspect confidence rank, payload, and score.
  * Implemented formal verification rules ensuring correct composition and conflict handling.

* **Documentation**
  * Added a developer guide detailing the formal verification workflow, limitations, and usage.

* **Chores**
  * Added CI checks to run the formal proof pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->