### PR TITLE
test(core): add 5 more @qc property tests for reconcile

### DIFF
--- a/core/reconcile_properties_wbtest.mbt
+++ b/core/reconcile_properties_wbtest.mbt
@@ -669,3 +669,105 @@ fn collect_leftmost_path_ids(node : ProjNode[TestExpr]) -> Array[Int] {
   }
   result
 }
+
+///|
+/// Property 14: No new-tree ID leakage.
+/// Result IDs come from {old IDs} ∪ {counter range} only — never
+/// from the new tree's temporary IDs.
+fn prop_no_new_tree_id_leakage(pair : (TestExpr, TestExpr)) -> Bool {
+  let (old_expr, new_expr) = pair
+  let old_node = to_proj_node(old_expr, Ref::new(0))
+  // New tree IDs in range 500-999
+  let new_node = to_proj_node(new_expr, Ref::new(500))
+  let counter_start = 1000
+  let result = reconcile(old_node, new_node, Ref::new(counter_start))
+  // Build sets of old and new IDs
+  let old_id_set : Map[Int, Bool] = {}
+  for id in collect_ids(old_node) {
+    old_id_set[id] = true
+  }
+  let new_id_set : Map[Int, Bool] = {}
+  for id in collect_ids(new_node) {
+    new_id_set[id] = true
+  }
+  // Every result ID must be from old tree OR from counter range (>= 1000).
+  // It must NOT be a new-tree-only ID (in new_id_set but not old_id_set
+  // and not in counter range).
+  for id in collect_ids(result) {
+    if new_id_set.contains(id) && !old_id_set.contains(id) && id < counter_start {
+      return false
+    }
+  }
+  true
+}
+
+///|
+test "property: no new-tree ID leakage" {
+  @qc.quick_check_fn(prop_no_new_tree_id_leakage)
+}
+
+///|
+/// Collect all (start, end) spans from a ProjNode tree (pre-order).
+fn collect_spans(node : ProjNode[TestExpr]) -> Array[(Int, Int)] {
+  let result : Array[(Int, Int)] = []
+  collect_spans_rec(node, result)
+  result
+}
+
+///|
+fn collect_spans_rec(
+  node : ProjNode[TestExpr],
+  acc : Array[(Int, Int)],
+) -> Unit {
+  acc.push((node.start, node.end))
+  for child in node.children {
+    collect_spans_rec(child, acc)
+  }
+}
+
+///|
+/// Convert TestExpr to ProjNode with synthetic spans: each node gets
+/// (start=offset, end=offset+1), incrementing in pre-order.
+fn to_proj_node_with_spans(
+  expr : TestExpr,
+  counter : Ref[Int],
+  span_offset : Ref[Int],
+) -> ProjNode[TestExpr] {
+  let my_span = span_offset.val
+  span_offset.val = span_offset.val + 1
+  let children : Array[ProjNode[TestExpr]] = match expr {
+    Leaf(_) => []
+    Branch(_, cs) =>
+      cs.map(fn(c) { to_proj_node_with_spans(c, counter, span_offset) })
+  }
+  let id = next_proj_node_id(counter)
+  ProjNode::new(expr, my_span, my_span + 1, id, children)
+}
+
+///|
+/// Property 15: Result uses new tree's start/end positions.
+/// Old and new trees from the same expr get different span offsets
+/// (0-based vs 100-based). Result should match new tree's spans.
+fn prop_result_uses_new_spans(expr : TestExpr) -> Bool {
+  // Old tree: spans from 0+
+  let old_node = to_proj_node_with_spans(expr, Ref::new(0), Ref::new(0))
+  // New tree: spans from 100+ (different positions)
+  let new_node = to_proj_node_with_spans(expr, Ref::new(500), Ref::new(100))
+  let result = reconcile(old_node, new_node, Ref::new(1000))
+  let result_spans = collect_spans(result)
+  let new_spans = collect_spans(new_node)
+  if result_spans.length() != new_spans.length() {
+    return false
+  }
+  for i = 0; i < result_spans.length(); i = i + 1 {
+    if result_spans[i] != new_spans[i] {
+      return false
+    }
+  }
+  true
+}
+
+///|
+test "property: result uses new tree spans" {
+  @qc.quick_check_fn(prop_result_uses_new_spans)
+}

--- a/core/reconcile_properties_wbtest.mbt
+++ b/core/reconcile_properties_wbtest.mbt
@@ -419,3 +419,253 @@ fn prop_reconcile_triple_idempotent(pair : (TestExpr, TestExpr)) -> Bool {
 test "property: triple reconcile is stable" {
   @qc.quick_check_fn(prop_reconcile_triple_idempotent)
 }
+
+///|
+/// Count total nodes in a ProjNode tree.
+fn count_nodes(node : ProjNode[TestExpr]) -> Int {
+  let mut count = 1
+  for child in node.children {
+    count = count + count_nodes(child)
+  }
+  count
+}
+
+///|
+/// Collect child counts at each node (pre-order) — captures tree shape.
+fn collect_child_counts(node : ProjNode[TestExpr]) -> Array[Int] {
+  let result : Array[Int] = []
+  collect_child_counts_rec(node, result)
+  result
+}
+
+///|
+fn collect_child_counts_rec(
+  node : ProjNode[TestExpr],
+  acc : Array[Int],
+) -> Unit {
+  acc.push(node.children.length())
+  for child in node.children {
+    collect_child_counts_rec(child, acc)
+  }
+}
+
+///|
+/// Property 9: Result has the same shape as the new tree.
+/// Node count and child counts at every position match.
+fn prop_result_same_shape_as_new(pair : (TestExpr, TestExpr)) -> Bool {
+  let (old_expr, new_expr) = pair
+  let old_node = to_proj_node(old_expr, Ref::new(0))
+  let new_node = to_proj_node(new_expr, Ref::new(500))
+  let result = reconcile(old_node, new_node, Ref::new(1000))
+  // Same total node count
+  if count_nodes(result) != count_nodes(new_node) {
+    return false
+  }
+  // Same child counts at every position (pre-order)
+  let result_shape = collect_child_counts(result)
+  let new_shape = collect_child_counts(new_node)
+  if result_shape.length() != new_shape.length() {
+    return false
+  }
+  for i = 0; i < result_shape.length(); i = i + 1 {
+    if result_shape[i] != new_shape[i] {
+      return false
+    }
+  }
+  true
+}
+
+///|
+test "property: result has same shape as new tree" {
+  @qc.quick_check_fn(prop_result_same_shape_as_new)
+}
+
+///|
+/// Property 10: Different root kind → all fresh IDs from counter range.
+/// When same_kind fails at the root, no old IDs leak into the result.
+fn prop_different_root_kind_all_fresh(expr : TestExpr) -> Bool {
+  // Force old=Leaf, new=Branch (always different kind)
+  let old_expr = Leaf("old")
+  let new_expr = match expr {
+    Leaf(s) => Branch(s, [])
+    Branch(_, _) => expr
+  }
+  let old_node = to_proj_node(old_expr, Ref::new(0))
+  let new_node = to_proj_node(new_expr, Ref::new(500))
+  let counter_start = 1000
+  let result = reconcile(old_node, new_node, Ref::new(counter_start))
+  // All result IDs should be fresh (>= counter_start)
+  let result_ids = collect_ids(result)
+  for id in result_ids {
+    if id < counter_start {
+      return false
+    }
+  }
+  // No old IDs should appear
+  let old_ids = collect_ids(old_node)
+  let old_set : Map[Int, Bool] = {}
+  for id in old_ids {
+    old_set[id] = true
+  }
+  for id in result_ids {
+    if old_set.contains(id) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+test "property: different root kind produces all fresh IDs" {
+  @qc.quick_check_fn(prop_different_root_kind_all_fresh)
+}
+
+///|
+/// Property 11: Fresh IDs come from the counter range.
+/// After reconcile, any ID not reused from old must be >= counter start.
+fn prop_fresh_ids_from_counter_range(pair : (TestExpr, TestExpr)) -> Bool {
+  let (old_expr, new_expr) = pair
+  let old_node = to_proj_node(old_expr, Ref::new(0))
+  let new_node = to_proj_node(new_expr, Ref::new(500))
+  let counter_start = 1000
+  let counter = Ref::new(counter_start)
+  let result = reconcile(old_node, new_node, counter)
+  // Build set of old IDs
+  let old_id_set : Map[Int, Bool] = {}
+  for id in collect_ids(old_node) {
+    old_id_set[id] = true
+  }
+  // Every result ID should be either from old or from counter range
+  let result_ids = collect_ids(result)
+  for id in result_ids {
+    if !old_id_set.contains(id) && id < counter_start {
+      return false
+    }
+  }
+  // Counter should have advanced by exactly the number of fresh IDs
+  let mut fresh_count = 0
+  for id in result_ids {
+    if !old_id_set.contains(id) {
+      fresh_count = fresh_count + 1
+    }
+  }
+  counter.val == counter_start + fresh_count
+}
+
+///|
+test "property: fresh IDs come from counter range" {
+  @qc.quick_check_fn(prop_fresh_ids_from_counter_range)
+}
+
+///|
+/// Property 12: Swapping two adjacent siblings preserves at least n-1 IDs.
+/// LCS of a sequence with one adjacent swap has length n-1.
+fn prop_swap_siblings_preserves_most_ids(expr : TestExpr) -> Bool {
+  // Only meaningful for Branch with >= 2 children
+  let (tag, children) = match expr {
+    Branch(t, cs) => if cs.length() >= 2 { (t, cs) } else { return true }
+    Leaf(_) => return true
+  }
+  let old_counter = Ref::new(0)
+  let old_node = to_proj_node(expr, old_counter)
+  // Swap first two children
+  let swapped : Array[TestExpr] = []
+  swapped.push(children[1])
+  swapped.push(children[0])
+  for i = 2; i < children.length(); i = i + 1 {
+    swapped.push(children[i])
+  }
+  let new_expr = Branch(tag, swapped)
+  let new_counter = Ref::new(500)
+  let new_node = to_proj_node(new_expr, new_counter)
+  let result = reconcile(old_node, new_node, Ref::new(1000))
+  // Collect old child root IDs
+  let old_child_ids : Map[Int, Bool] = {}
+  for child in old_node.children {
+    old_child_ids[child.node_id] = true
+  }
+  // Count reused IDs among result children
+  let mut reused = 0
+  for child in result.children {
+    if old_child_ids.contains(child.node_id) {
+      reused = reused + 1
+    }
+  }
+  // LCS of adjacent swap = n-1, so at least n-1 children keep old IDs
+  reused >= children.length() - 1
+}
+
+///|
+test "property: swap siblings preserves at least n-1 IDs" {
+  @qc.quick_check_fn(prop_swap_siblings_preserves_most_ids)
+}
+
+///|
+/// Property 13: Deep leaf change preserves all ancestor IDs.
+/// Change the leftmost leaf's label (same kind) — every ancestor
+/// on the path should keep its old ID.
+fn prop_deep_change_preserves_ancestor_ids(expr : TestExpr) -> Bool {
+  // Need a tree with at least one Branch to be meaningful
+  match expr {
+    Leaf(_) => return true
+    _ => ()
+  }
+  let old_counter = Ref::new(0)
+  let old_node = to_proj_node(expr, old_counter)
+  // Modify the leftmost leaf's label (Leaf→Leaf stays same_kind)
+  let new_expr = modify_leftmost_leaf(expr)
+  let new_counter = Ref::new(500)
+  let new_node = to_proj_node(new_expr, new_counter)
+  let result = reconcile(old_node, new_node, Ref::new(1000))
+  // Collect ancestor IDs along the leftmost path in old and result
+  let old_path_ids = collect_leftmost_path_ids(old_node)
+  let result_path_ids = collect_leftmost_path_ids(result)
+  if old_path_ids.length() != result_path_ids.length() {
+    return false
+  }
+  // All ancestors (all but the last, which is the leaf) should keep IDs.
+  // The leaf itself also keeps its ID since Leaf→Leaf is same_kind.
+  for i = 0; i < old_path_ids.length(); i = i + 1 {
+    if old_path_ids[i] != result_path_ids[i] {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Modify the leftmost leaf's label to "modified".
+fn modify_leftmost_leaf(expr : TestExpr) -> TestExpr {
+  match expr {
+    Leaf(_) => Leaf("modified")
+    Branch(tag, cs) =>
+      if cs.length() == 0 {
+        Branch(tag, cs)
+      } else {
+        let new_children : Array[TestExpr] = []
+        new_children.push(modify_leftmost_leaf(cs[0]))
+        for i = 1; i < cs.length(); i = i + 1 {
+          new_children.push(cs[i])
+        }
+        Branch(tag, new_children)
+      }
+  }
+}
+
+///|
+test "property: deep leaf change preserves ancestor IDs" {
+  @qc.quick_check_fn(prop_deep_change_preserves_ancestor_ids)
+}
+
+///|
+/// Collect node_ids along the leftmost path (root → leftmost leaf).
+fn collect_leftmost_path_ids(node : ProjNode[TestExpr]) -> Array[Int] {
+  let result : Array[Int] = []
+  let mut current = node
+  result.push(current.node_id)
+  while current.children.length() > 0 {
+    current = current.children[0]
+    result.push(current.node_id)
+  }
+  result
+}


### PR DESCRIPTION
## Summary
- Add Properties 9-13 to reconcile property test suite (now 13 total)
- **P9 — Shape preservation**: result tree has same node count and child counts as new tree at every position
- **P10 — Fresh IDs on kind mismatch**: when root kinds differ, all result IDs come from counter range, none from old tree
- **P11 — Counter range invariant**: fresh IDs are always >= counter start, and counter advances by exactly the fresh count
- **P12 — Sibling swap bound**: swapping two adjacent children preserves at least n-1 old IDs (LCS lower bound)
- **P13 — Ancestor ID preservation**: changing a deep leaf (same kind) preserves all ancestor IDs on the path

## Test plan
- [x] `moon check` — 0 errors, 0 warnings
- [x] `moon test -p core` — 176 tests passing (13 property tests at 100 iterations each)
- [x] No `.mbti` API changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added helper utilities for tree traversal and structure analysis
  * Introduced five new property-based tests validating reconciliation behavior across shape consistency, ID freshness, counter accuracy, sibling preservation, and ancestor path retention scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->