### PR TITLE
feat(editor): wire drag-and-drop foundation for ideal editor

### DIFF
--- a/examples/ideal/web/src/bridge.ts
+++ b/examples/ideal/web/src/bridge.ts
@@ -114,6 +114,18 @@ export class CrdtBridge {
     this.afterLocalEdit();
   }
 
+  /** Apply a drag-and-drop edit via the CRDT TreeEditOp bridge */
+  handleDropEdit(source: number, target: number, position: string): void {
+    const opJson = JSON.stringify({ type: "Drop", source, target, position });
+    const ts = Date.now();
+    const result = this.crdt.apply_tree_edit_json(this.handle, opJson, ts);
+    if (result !== "ok") {
+      console.error("Drop edit failed:", result);
+      return;
+    }
+    this.afterLocalEdit();
+  }
+
   /** Apply remote CRDT ops and reconcile PM state */
   applyRemote(syncJson: string): string {
     const result = this.crdt.apply_sync_json(this.handle, syncJson);

--- a/examples/ideal/web/src/bridge.ts
+++ b/examples/ideal/web/src/bridge.ts
@@ -114,18 +114,6 @@ export class CrdtBridge {
     this.afterLocalEdit();
   }
 
-  /** Apply a drag-and-drop edit via the CRDT TreeEditOp bridge */
-  handleDropEdit(source: number, target: number, position: string): void {
-    const opJson = JSON.stringify({ type: "Drop", source, target, position });
-    const ts = Date.now();
-    const result = this.crdt.apply_tree_edit_json(this.handle, opJson, ts);
-    if (result !== "ok") {
-      console.error("Drop edit failed:", result);
-      return;
-    }
-    this.afterLocalEdit();
-  }
-
   /** Apply remote CRDT ops and reconcile PM state */
   applyRemote(syncJson: string): string {
     const result = this.crdt.apply_sync_json(this.handle, syncJson);

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -586,6 +586,13 @@ const SHADOW_STYLES = `
     font-size: 13px;
     color: var(--canopy-fg, #e4e4f0);
   }
+  .structure-block.drop-target {
+    outline: 2px solid var(--canopy-accent, #8250df);
+    outline-offset: -2px;
+  }
+  .structure-block.dragging {
+    opacity: 0.4;
+  }
 
   /* Peer cursor decorations (CM6 text mode) */
   .peer-cursor-widget {

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -150,12 +150,28 @@ function wireEditorEvents(el: CanopyEditor) {
     clickTrigger('canopy-editor-node-selected');
   }) as EventListener, { signal });
   el.addEventListener(CanopyEvents.STRUCTURAL_EDIT_REQUEST, ((event: Event) => {
-    const { op, nodeId } = (event as CustomEvent<StructuralEditDetail>).detail ?? {};
-    if (!op || !nodeId || !canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
+    const detail = (event as CustomEvent).detail ?? {};
+    if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
     const crdt = canopyGlobal.__canopy_crdt;
     const handle = canopyGlobal.__canopy_crdt_handle;
-    // Apply structural edit via protocol FFI
-    const result = crdt.handle_structural_intent(handle, op, nodeId, Date.now(), "");
+
+    let result: string;
+    if (detail.type === "Drop") {
+      // Drag-and-drop: source/target/position payload → apply_tree_edit_json
+      const opJson = JSON.stringify({
+        type: "Drop",
+        source: detail.source,
+        target: detail.target,
+        position: detail.position,
+      });
+      result = crdt.apply_tree_edit_json(handle, opJson, Date.now());
+    } else {
+      // Standard structural edit: op/nodeId → handle_structural_intent
+      const { op, nodeId } = detail as StructuralEditDetail;
+      if (!op || !nodeId) return;
+      result = crdt.handle_structural_intent(handle, op, nodeId, Date.now(), "");
+    }
+
     if (result !== "ok") {
       console.error("[protocol] structural edit failed:", result);
       return;
@@ -164,7 +180,8 @@ function wireEditorEvents(el: CanopyEditor) {
     el.syncAfterExternalChange();
     el.notifyLocalChange();
     // Trigger Rabbita refresh
-    canopyGlobal.__canopy_pending_structural_edit = { op, nodeId };
+    const { op, nodeId } = detail as StructuralEditDetail;
+    canopyGlobal.__canopy_pending_structural_edit = { op: op ?? detail.type, nodeId };
     clickTrigger('canopy-editor-structural-edit');
   }) as EventListener, { signal });
   el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -180,8 +180,9 @@ function wireEditorEvents(el: CanopyEditor) {
     el.syncAfterExternalChange();
     el.notifyLocalChange();
     // Trigger Rabbita refresh
-    const { op, nodeId } = detail as StructuralEditDetail;
-    canopyGlobal.__canopy_pending_structural_edit = { op: op ?? detail.type, nodeId };
+    const op = detail.op ?? detail.type;
+    const nodeId = detail.nodeId ?? String(detail.target ?? "");
+    canopyGlobal.__canopy_pending_structural_edit = { op, nodeId };
     clickTrigger('canopy-editor-structural-edit');
   }) as EventListener, { signal });
   el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {

--- a/examples/ideal/web/src/structure-nodeview.ts
+++ b/examples/ideal/web/src/structure-nodeview.ts
@@ -97,6 +97,47 @@ export class StructureCompoundView implements NodeView {
     this.contentDOM = document.createElement("div");
     this.contentDOM.className = "structure-children";
     this.dom.appendChild(this.contentDOM);
+
+    // Drag-and-drop handlers
+    const nodeId = node.attrs.node_id as number;
+
+    this.dom.addEventListener("dragstart", (e) => {
+      e.dataTransfer!.setData("application/x-canopy-node", String(nodeId));
+      e.dataTransfer!.effectAllowed = "move";
+      this.dom.classList.add("dragging");
+    });
+
+    this.dom.addEventListener("dragend", () => {
+      this.dom.classList.remove("dragging");
+    });
+
+    this.dom.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      e.dataTransfer!.dropEffect = "move";
+      this.dom.classList.add("drop-target");
+    });
+
+    this.dom.addEventListener("dragleave", () => {
+      this.dom.classList.remove("drop-target");
+    });
+
+    this.dom.addEventListener("drop", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.dom.classList.remove("drop-target");
+      const sourceId = e.dataTransfer!.getData("application/x-canopy-node");
+      if (!sourceId || sourceId === String(nodeId)) return;
+
+      this.dom.dispatchEvent(new CustomEvent("structural-edit-request", {
+        bubbles: true,
+        detail: {
+          type: "Drop",
+          source: Number(sourceId),
+          target: nodeId,
+          position: "After",
+        },
+      }));
+    });
   }
 
   update(node: PmNode): boolean {

--- a/examples/ideal/web/src/structure-nodeview.ts
+++ b/examples/ideal/web/src/structure-nodeview.ts
@@ -98,12 +98,12 @@ export class StructureCompoundView implements NodeView {
     this.contentDOM.className = "structure-children";
     this.dom.appendChild(this.contentDOM);
 
-    // Drag-and-drop handlers
-    const nid = node.attrs.nodeId as number;
+    // Drag-and-drop handlers — read this.node.attrs.nodeId at event time
+    // so the ID stays current after update() swaps in a new PM node.
 
     this.dom.addEventListener("dragstart", (e) => {
       e.stopPropagation(); // prevent ancestor compound views from overwriting
-      e.dataTransfer!.setData("application/x-canopy-node", String(nid));
+      e.dataTransfer!.setData("application/x-canopy-node", String(this.node.attrs.nodeId));
       e.dataTransfer!.effectAllowed = "move";
       this.dom.classList.add("dragging");
     });
@@ -127,6 +127,7 @@ export class StructureCompoundView implements NodeView {
       e.preventDefault();
       e.stopPropagation();
       this.dom.classList.remove("drop-target");
+      const nid = this.node.attrs.nodeId as number;
       const sourceId = e.dataTransfer!.getData("application/x-canopy-node");
       if (!sourceId || sourceId === String(nid)) return;
 

--- a/examples/ideal/web/src/structure-nodeview.ts
+++ b/examples/ideal/web/src/structure-nodeview.ts
@@ -59,7 +59,10 @@ export class StructureCompoundView implements NodeView {
   contentDOM: HTMLElement;
   private node: PmNode;
 
+  private view: PmView;
+
   constructor(node: PmNode, _view: PmView, _getPos: () => number | undefined) {
+    this.view = _view;
     this.node = node;
     const typeName = node.type.name;
     this.dom = document.createElement("div");
@@ -102,6 +105,7 @@ export class StructureCompoundView implements NodeView {
     // so the ID stays current after update() swaps in a new PM node.
 
     this.dom.addEventListener("dragstart", (e) => {
+      if (!this.view.editable) { e.preventDefault(); return; }
       e.stopPropagation(); // prevent ancestor compound views from overwriting
       e.dataTransfer!.setData("application/x-canopy-node", String(this.node.attrs.nodeId));
       e.dataTransfer!.effectAllowed = "move";
@@ -127,6 +131,7 @@ export class StructureCompoundView implements NodeView {
       e.preventDefault();
       e.stopPropagation();
       this.dom.classList.remove("drop-target");
+      if (!this.view.editable) return;
       const nid = this.node.attrs.nodeId as number;
       const sourceId = e.dataTransfer!.getData("application/x-canopy-node");
       if (!sourceId || sourceId === String(nid)) return;

--- a/examples/ideal/web/src/structure-nodeview.ts
+++ b/examples/ideal/web/src/structure-nodeview.ts
@@ -99,10 +99,11 @@ export class StructureCompoundView implements NodeView {
     this.dom.appendChild(this.contentDOM);
 
     // Drag-and-drop handlers
-    const nodeId = node.attrs.node_id as number;
+    const nid = node.attrs.nodeId as number;
 
     this.dom.addEventListener("dragstart", (e) => {
-      e.dataTransfer!.setData("application/x-canopy-node", String(nodeId));
+      e.stopPropagation(); // prevent ancestor compound views from overwriting
+      e.dataTransfer!.setData("application/x-canopy-node", String(nid));
       e.dataTransfer!.effectAllowed = "move";
       this.dom.classList.add("dragging");
     });
@@ -113,6 +114,7 @@ export class StructureCompoundView implements NodeView {
 
     this.dom.addEventListener("dragover", (e) => {
       e.preventDefault();
+      e.stopPropagation(); // prevent ancestor drop-target highlights
       e.dataTransfer!.dropEffect = "move";
       this.dom.classList.add("drop-target");
     });
@@ -126,14 +128,15 @@ export class StructureCompoundView implements NodeView {
       e.stopPropagation();
       this.dom.classList.remove("drop-target");
       const sourceId = e.dataTransfer!.getData("application/x-canopy-node");
-      if (!sourceId || sourceId === String(nodeId)) return;
+      if (!sourceId || sourceId === String(nid)) return;
 
       this.dom.dispatchEvent(new CustomEvent("structural-edit-request", {
         bubbles: true,
+        composed: true, // cross shadow DOM boundary
         detail: {
           type: "Drop",
           source: Number(sourceId),
-          target: nodeId,
+          target: nid,
           position: "After",
         },
       }));

--- a/lang/lambda/companion/tree_edit_json.mbt
+++ b/lang/lambda/companion/tree_edit_json.mbt
@@ -47,6 +47,23 @@ fn require_bop(
 }
 
 ///|
+/// Extract a DropPosition from a JSON map at the given key.
+fn require_drop_position(
+  m : Map[String, Json],
+  key : String,
+) -> @core.DropPosition raise @editor.TreeEditError {
+  match m.get(key) {
+    Some(Json::String("Before")) => @core.DropPosition::Before
+    Some(Json::String("After")) => @core.DropPosition::After
+    Some(Json::String("Inside")) => @core.DropPosition::Inside
+    Some(Json::String(s)) =>
+      raise @editor.TreeEditError::UnknownOpType(op_type=s)
+    None => raise @editor.TreeEditError::MissingField(field=key)
+    Some(_) => raise @editor.TreeEditError::FieldMustBeString(field=key)
+  }
+}
+
+///|
 /// Extract a required string from a JSON map at the given key.
 fn require_string(
   m : Map[String, Json],
@@ -185,6 +202,21 @@ pub fn parse_tree_edit_op(
       let node_id = require_node_id(m, "node_id")
       let new_value = require_string(m, "new_value")
       TreeEditOp::CommitEdit(node_id~, new_value~)
+    }
+    "StartDrag" => {
+      let node_id = require_node_id(m, "node_id")
+      TreeEditOp::StartDrag(node_id~)
+    }
+    "DragOver" => {
+      let target = require_node_id(m, "target")
+      let position = require_drop_position(m, "position")
+      TreeEditOp::DragOver(target~, position~)
+    }
+    "Drop" => {
+      let source = require_node_id(m, "source")
+      let target = require_node_id(m, "target")
+      let position = require_drop_position(m, "position")
+      TreeEditOp::Drop(source~, target~, position~)
     }
     _ => raise @editor.TreeEditError::UnknownOpType(op_type~)
   }

--- a/lang/lambda/companion/tree_edit_json.mbt
+++ b/lang/lambda/companion/tree_edit_json.mbt
@@ -56,8 +56,8 @@ fn require_drop_position(
     Some(Json::String("Before")) => @core.DropPosition::Before
     Some(Json::String("After")) => @core.DropPosition::After
     Some(Json::String("Inside")) => @core.DropPosition::Inside
-    Some(Json::String(s)) =>
-      raise @editor.TreeEditError::UnknownOpType(op_type=s)
+    Some(Json::String(_)) =>
+      raise @editor.TreeEditError::FieldMustBeString(field=key)
     None => raise @editor.TreeEditError::MissingField(field=key)
     Some(_) => raise @editor.TreeEditError::FieldMustBeString(field=key)
   }

--- a/lang/lambda/edits/text_edit_drop.mbt
+++ b/lang/lambda/edits/text_edit_drop.mbt
@@ -5,6 +5,8 @@ fn compute_drop(
   target : NodeId,
   position : DropPosition,
 ) -> EditResult {
+  // Legality: self-drop
+  guard source != target else { return Err("Cannot drop onto self") }
   let { source_text, source_map, .. } = ctx
   let source_range = match source_map.get_range(source) {
     Some(r) => r
@@ -13,6 +15,11 @@ fn compute_drop(
   let target_range = match source_map.get_range(target) {
     Some(r) => r
     None => return Err("Target node not found")
+  }
+  // Legality: descendant-drop (target is inside source)
+  guard !(target_range.start >= source_range.start &&
+    target_range.end <= source_range.end) else {
+    return Err("Cannot drop into own descendant")
   }
   let source_slice = source_text[source_range.start:source_range.end].to_string()
   let insert_pos = match position {


### PR DESCRIPTION
## Summary

- Parse `Drop`/`StartDrag`/`DragOver` in the JSON tree-edit bridge (`tree_edit_json.mbt`)
- Add self-drop and descendant-drop legality checks in `compute_drop`
- Wire `dragstart`/`dragover`/`drop` browser events on structure-view compound nodes
- Route Drop events through `apply_tree_edit_json` in the ideal editor event layer

Implements the thinnest vertical slice of `docs/plans/2026-03-30-editor-drag-drop-foundation.md` — steps 1, 2, 4, and 5 scoped to `examples/ideal` only. V1 hardcodes `position: "After"`; position detection (Before/After/Inside) is a follow-up.

## Test plan

- [x] `moon check` — no errors or warnings
- [x] `moon test` — 860 tests pass
- [x] `npx vite build` — JS bundle builds clean
- [x] Playwright: Drop edit via CRDT API returns `"ok"`, text relocates correctly
- [x] Playwright: Self-drop returns `"error: Cannot drop onto self"`
- [x] Playwright: Descendant-drop returns `"error: Cannot drop into own descendant"`
- [x] Playwright: CustomEvent dispatch path triggers CRDT edit and UI reconciliation
- [ ] Manual: drag a structure block by its grip handle, verify drop-target highlight and AST update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop support for structure blocks with visual feedback, including highlighted drop targets and opacity changes during dragging.
  * Added validation to prevent invalid drop operations (e.g., moving a node onto itself or its descendants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->