### PR TITLE
feat(block-editor): drag-and-drop block reordering

### DIFF
--- a/examples/block-editor/main/block_doc.mbt
+++ b/examples/block-editor/main/block_doc.mbt
@@ -67,6 +67,15 @@ pub fn BlockDoc::move_block(
   ref_id : @container.TreeNodeId,
   position : @canopy_core.DropPosition,
 ) -> Unit raise @container.DocumentError {
+  // Legality: self-drop and root-move are rejected at the model boundary.
+  if @container.tree_node_id_eq(id, ref_id) {
+    return
+  }
+  if @container.tree_node_id_eq(id, root_block_id) {
+    raise @container.DocumentError::Internal(
+      detail="cannot move root block",
+    )
+  }
   // Before/After assume a flat block list (all blocks are root children).
   // Inside reparents into ref_id for future nesting support.
   match position {

--- a/examples/block-editor/main/block_doc.mbt
+++ b/examples/block-editor/main/block_doc.mbt
@@ -56,13 +56,34 @@ pub fn BlockDoc::delete_block(
 }
 
 ///|
-/// Move a block to a new parent.
+/// Move a block relative to a reference sibling.
+///
+/// - `Before`: insert before `ref_id` under the same parent
+/// - `After`: insert after `ref_id` under the same parent
+/// - `Inside`: move as last child of `ref_id`
 pub fn BlockDoc::move_block(
   self : BlockDoc,
   id : @container.TreeNodeId,
-  new_parent~ : @container.TreeNodeId,
+  ref_id : @container.TreeNodeId,
+  position : @canopy_core.DropPosition,
 ) -> Unit raise @container.DocumentError {
-  self.tree.move_node(target=id, new_parent~)
+  // Before/After assume a flat block list (all blocks are root children).
+  // Inside reparents into ref_id for future nesting support.
+  match position {
+    Before =>
+      self.tree.move_node_before(
+        target=id,
+        parent=root_block_id,
+        before=ref_id,
+      )
+    After =>
+      self.tree.move_node_after(
+        target=id,
+        parent=root_block_id,
+        after=ref_id,
+      )
+    Inside => self.tree.move_node(target=id, new_parent=ref_id)
+  }
 }
 
 ///|

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -540,6 +540,45 @@ test "move_block preserves text after reorder" {
   inspect(@container.tree_node_id_eq(children[1], a), content="true")
 }
 
+// ── Legality tests ───────────────────────────────────────────────────
+
+///|
+test "move_block: self-drop is a silent no-op" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  let b = doc.create_block(Paragraph)
+  // Move A relative to itself — should silently return, order unchanged
+  doc.move_block(a, a, @canopy_core.DropPosition::Before)
+  doc.move_block(a, a, @canopy_core.DropPosition::After)
+  let children = doc.children(root_block_id)
+  inspect(children.length(), content="2")
+  inspect(@container.tree_node_id_eq(children[0], a), content="true")
+  inspect(@container.tree_node_id_eq(children[1], b), content="true")
+}
+
+///|
+test "panic move_block: cannot move root block" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  doc.move_block(root_block_id, a, @canopy_core.DropPosition::After)
+}
+
+///|
+test "move_block: descendant-drop rejected by CRDT cycle detection" {
+  let doc = BlockDoc::new("alice")
+  let parent = doc.create_block(Paragraph)
+  let child = doc.create_block(Paragraph, parent=parent)
+  // Moving parent Inside child would create a cycle — CRDT layer rejects
+  let mut caught_cycle = false
+  try {
+    doc.move_block(parent, child, @canopy_core.DropPosition::Inside)
+  } catch {
+    @container.DocumentError::CycleDetected => caught_cycle = true
+    _ => ()
+  }
+  inspect(caught_cycle, content="true")
+}
+
 // TODO: sync tests require container-level sync API (SyncMessage, VersionVector)
 // that includes text CRDT state. Re-add when export_sync_message / apply_remote_sync_message
 // are implemented in dowdiness/event-graph-walker/container.

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -457,6 +457,89 @@ test "import: star bullet list" {
   inspect(doc.get_text(children[0]), content="star item")
 }
 
+// ── Move block tests ─────────────────────────────────────────────────────
+
+///|
+test "move_block After: move first block after second" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  doc.set_text(a, "A")
+  let b = doc.create_block(Paragraph)
+  doc.set_text(b, "B")
+  let c = doc.create_block(Paragraph)
+  doc.set_text(c, "C")
+  // Move A to after B => order should be B, A, C
+  doc.move_block(a, b, @canopy_core.DropPosition::After)
+  let children = doc.children(root_block_id)
+  inspect(children.length(), content="3")
+  inspect(@container.tree_node_id_eq(children[0], b), content="true")
+  inspect(@container.tree_node_id_eq(children[1], a), content="true")
+  inspect(@container.tree_node_id_eq(children[2], c), content="true")
+}
+
+///|
+test "move_block Before: move last block before first" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  doc.set_text(a, "A")
+  let b = doc.create_block(Paragraph)
+  doc.set_text(b, "B")
+  let c = doc.create_block(Paragraph)
+  doc.set_text(c, "C")
+  // Move C before A => order should be C, A, B
+  doc.move_block(c, a, @canopy_core.DropPosition::Before)
+  let children = doc.children(root_block_id)
+  inspect(children.length(), content="3")
+  inspect(@container.tree_node_id_eq(children[0], c), content="true")
+  inspect(@container.tree_node_id_eq(children[1], a), content="true")
+  inspect(@container.tree_node_id_eq(children[2], b), content="true")
+}
+
+///|
+test "move_block Before: move to before middle" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  let b = doc.create_block(Paragraph)
+  let c = doc.create_block(Paragraph)
+  // Move C before B => order should be A, C, B
+  doc.move_block(c, b, @canopy_core.DropPosition::Before)
+  let children = doc.children(root_block_id)
+  inspect(children.length(), content="3")
+  inspect(@container.tree_node_id_eq(children[0], a), content="true")
+  inspect(@container.tree_node_id_eq(children[1], c), content="true")
+  inspect(@container.tree_node_id_eq(children[2], b), content="true")
+}
+
+///|
+test "move_block After: move to after last" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  let b = doc.create_block(Paragraph)
+  let c = doc.create_block(Paragraph)
+  // Move A to after C => order should be B, C, A
+  doc.move_block(a, c, @canopy_core.DropPosition::After)
+  let children = doc.children(root_block_id)
+  inspect(children.length(), content="3")
+  inspect(@container.tree_node_id_eq(children[0], b), content="true")
+  inspect(@container.tree_node_id_eq(children[1], c), content="true")
+  inspect(@container.tree_node_id_eq(children[2], a), content="true")
+}
+
+///|
+test "move_block preserves text after reorder" {
+  let doc = BlockDoc::new("alice")
+  let a = doc.create_block(Paragraph)
+  doc.set_text(a, "alpha")
+  let b = doc.create_block(Paragraph)
+  doc.set_text(b, "beta")
+  doc.move_block(b, a, @canopy_core.DropPosition::Before)
+  inspect(doc.get_text(a), content="alpha")
+  inspect(doc.get_text(b), content="beta")
+  let children = doc.children(root_block_id)
+  inspect(@container.tree_node_id_eq(children[0], b), content="true")
+  inspect(@container.tree_node_id_eq(children[1], a), content="true")
+}
+
 // TODO: sync tests require container-level sync API (SyncMessage, VersionVector)
 // that includes text CRDT state. Re-add when export_sync_message / apply_remote_sync_message
 // are implemented in dowdiness/event-graph-walker/container.

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -58,8 +58,11 @@ pub fn get_render_state(handle : Int) -> String {
   match docs.get(handle) {
     Some(doc) => {
       let buf = StringBuilder::new()
-      buf.write_string("{\"blocks\":[")
       let children = doc.children(root_block_id)
+      let parent_key = @container.tree_node_id_key(root_block_id)
+      buf.write_string("{\"block_count\":")
+      buf.write_string(children.length().to_string())
+      buf.write_string(",\"blocks\":[")
       for i in 0..<children.length() {
         if i > 0 {
           buf.write_string(",")
@@ -70,7 +73,6 @@ pub fn get_render_state(handle : Int) -> String {
         write_json_escaped(buf, @container.tree_node_id_key(id))
         buf.write_string("\",\"block_type\":\"")
         write_json_escaped(buf, block_type_name(bt))
-        // Extract level/list_style directly from BlockType — no Map allocation
         buf.write_string("\",\"level\":\"")
         match bt {
           Heading(n) => write_json_escaped(buf, n.to_string())
@@ -85,14 +87,18 @@ pub fn get_render_state(handle : Int) -> String {
         }
         buf.write_string("\",\"checked\":")
         buf.write_string(if doc.get_checked(id) { "true" } else { "false" })
-        buf.write_string(",\"text\":\"")
+        buf.write_string(",\"index\":")
+        buf.write_string(i.to_string())
+        buf.write_string(",\"parent_id\":\"")
+        write_json_escaped(buf, parent_key)
+        buf.write_string("\",\"text\":\"")
         write_json_escaped(buf, doc.get_text(id))
         buf.write_string("\"}")
       }
       buf.write_string("]}")
       buf.to_string()
     }
-    None => "{\"blocks\":[]}"
+    None => "{\"block_count\":0,\"blocks\":[]}"
   }
 }
 
@@ -209,6 +215,33 @@ pub fn editor_set_block_type(
       doc.set_type(parse_block_id(id_str), bt)
     }
     None => ()
+  }
+}
+
+///|
+/// Move a block relative to a reference block.
+///
+/// `position_str` is one of "Before", "After", "Inside".
+pub fn editor_move_block(
+  handle : Int,
+  id_str : String,
+  ref_id_str : String,
+  position_str : String,
+) -> Bool {
+  match docs.get(handle) {
+    Some(doc) => {
+      let position : @canopy_core.DropPosition = match position_str {
+        "Before" => Before
+        "After" => After
+        "Inside" => Inside
+        _ => return false
+      }
+      let id = parse_block_id(id_str)
+      let ref_id = parse_block_id(ref_id_str)
+      doc.move_block(id, ref_id, position) catch { _ => return false }
+      true
+    }
+    None => false
   }
 }
 

--- a/examples/block-editor/main/block_init_wbtest.mbt
+++ b/examples/block-editor/main/block_init_wbtest.mbt
@@ -77,7 +77,9 @@ test "write_json_escaped: control characters" {
 test "destroy_editor removes handle" {
   let h = create_editor("alice")
   destroy_editor(h)
-  inspect(get_render_state(h), content="{\"blocks\":[]}")
+  inspect(get_render_state(h), content=(
+    #|{"block_count":0,"blocks":[]}
+  ))
 }
 
 ///|

--- a/examples/block-editor/main/moon.pkg
+++ b/examples/block-editor/main/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "dowdiness/canopy/core" @canopy_core,
   "dowdiness/event-graph-walker/container" @container,
   "moonbitlang/core/debug",
 }
@@ -15,6 +16,7 @@ options(
         "editor_set_block_text",
         "editor_delete_block",
         "editor_set_block_type",
+        "editor_move_block",
         "editor_import_markdown",
         "editor_export_markdown",
       ],

--- a/examples/block-editor/main/pkg.generated.mbti
+++ b/examples/block-editor/main/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy-block-editor/main"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/event-graph-walker/container",
   "dowdiness/event-graph-walker/internal/movable_tree",
   "moonbitlang/core/debug",
@@ -30,6 +31,8 @@ pub fn editor_import_markdown(Int, String) -> Unit
 
 pub fn editor_insert_block_after(Int, String, String) -> String
 
+pub fn editor_move_block(Int, String, String, String) -> Bool
+
 pub fn editor_set_block_text(Int, String, String) -> Unit
 
 pub fn editor_set_block_type(Int, String, String, Int, String) -> Unit
@@ -54,7 +57,7 @@ pub fn BlockDoc::get_text(Self, @movable_tree.TreeNodeId) -> String
 pub fn BlockDoc::get_type(Self, @movable_tree.TreeNodeId) -> BlockType
 pub fn BlockDoc::insert_char(Self, @movable_tree.TreeNodeId, Int, String) -> Unit
 pub fn BlockDoc::is_alive(Self, @movable_tree.TreeNodeId) -> Bool
-pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, new_parent~ : @movable_tree.TreeNodeId) -> Unit raise @container.DocumentError
+pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, @movable_tree.TreeNodeId, @core.DropPosition) -> Unit raise @container.DocumentError
 pub fn BlockDoc::new(String) -> Self raise @container.DocumentError
 pub fn BlockDoc::set_checked(Self, @movable_tree.TreeNodeId, Bool) -> Unit
 pub fn BlockDoc::set_text(Self, @movable_tree.TreeNodeId, String) -> Unit

--- a/examples/block-editor/web/index.html
+++ b/examples/block-editor/web/index.html
@@ -89,6 +89,7 @@
 
     /* ── Block base ───────────────────────────────────────────── */
     #editor-blocks > div {
+      position: relative;
       min-height: 1.4em;
       padding: var(--space-xs) 0;
       outline: none;
@@ -140,7 +141,6 @@
 
     /* ── List items ───────────────────────────────────────────── */
     #editor-blocks > div[data-type="list_item"] {
-      position: relative;
       padding-left: var(--space-xl);
     }
     #editor-blocks > div[data-type="list_item"]::before {
@@ -226,6 +226,45 @@
       margin-left: auto;
       opacity: 0.7;
     }
+    /* ── Drag handle ──────────────────────────────────────────── */
+    .drag-handle {
+      position: absolute;
+      left: -28px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 20px;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: grab;
+      color: var(--text-muted);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 150ms ease-out;
+      user-select: none;
+      border-radius: 3px;
+    }
+    .drag-handle:hover { background: var(--accent-08); }
+    .drag-handle:active { cursor: grabbing; }
+    #editor-blocks > div:hover .drag-handle { opacity: 1; }
+
+    /* ── Drop indicators ──────────────────────────────────────── */
+    /* Combine with focus shadow so neither overrides the other */
+    #editor-blocks > div.drop-before {
+      box-shadow: 0 -3px 0 0 var(--accent);
+    }
+    #editor-blocks > div.drop-after {
+      box-shadow: 0 3px 0 0 var(--accent);
+    }
+    #editor-blocks > div.drop-before:focus-visible {
+      box-shadow: -3px 0 0 0 var(--accent), 0 -3px 0 0 var(--accent);
+    }
+    #editor-blocks > div.drop-after:focus-visible {
+      box-shadow: -3px 0 0 0 var(--accent), 0 3px 0 0 var(--accent);
+    }
+    #editor-blocks > div.dragging { opacity: 0.4; }
+
     /* ── Touch devices: larger targets ─────────────────────────── */
     @media (pointer: coarse) {
       nav[aria-label="Document tools"] button {

--- a/examples/block-editor/web/src/main.ts
+++ b/examples/block-editor/web/src/main.ts
@@ -7,8 +7,17 @@ interface Block {
   level: string;
   list_style: string;
   checked: boolean;
+  index: number;
+  parent_id: string;
   text: string;
 }
+
+interface RenderState {
+  block_count: number;
+  blocks: Block[];
+}
+
+type DropPosition = 'Before' | 'After' | 'Inside';
 
 // ── State ──────────────────────────────────────────────────────────────
 const handle = ed.create_editor('local');
@@ -16,12 +25,17 @@ const container = document.getElementById('editor-blocks')!;
 const blockDivs = new Map<string, HTMLDivElement>();
 let suppressNextInput = false;
 
+// Drag state — tracked outside DOM to avoid stale closures
+let dragSourceId: string | null = null;
+let currentDropTarget: HTMLDivElement | null = null;
+let currentDropPosition: DropPosition | null = null;
+
 // Seed
 ed.editor_import_markdown(handle, '# Welcome\n\nStart typing here.\n');
 
 // ── Render ─────────────────────────────────────────────────────────────
 function render() {
-  const state: { blocks: Block[] } = JSON.parse(ed.get_render_state(handle));
+  const state: RenderState = JSON.parse(ed.get_render_state(handle));
   const liveIds = new Set<string>();
 
   for (const block of state.blocks) {
@@ -30,18 +44,42 @@ function render() {
 
     if (!div) {
       div = document.createElement('div');
+      div.classList.add('block');
       div.contentEditable = 'true';
       div.dataset.blockId = block.id;
+
+      // Drag handle — a non-editable grip that makes the block draggable
+      const grip = document.createElement('span');
+      grip.className = 'drag-handle';
+      grip.contentEditable = 'false';
+      grip.draggable = true;
+      grip.textContent = '\u2847'; // braille dots for grip icon
+      grip.addEventListener('dragstart', (e) => {
+        dragSourceId = block.id;
+        e.dataTransfer!.effectAllowed = 'move';
+        e.dataTransfer!.setData('text/plain', block.id);
+        div!.classList.add('dragging');
+      });
+      grip.addEventListener('dragend', () => {
+        div!.classList.remove('dragging');
+        clearDropIndicators();
+        dragSourceId = null;
+      });
+      div.prepend(grip);
+
+      wireDragTarget(div);
       wireEvents(div);
       container.appendChild(div);
       blockDivs.set(block.id, div);
     }
 
-    // Data attributes drive CSS styling — no inline styles needed
+    // Data attributes drive CSS styling and structural context for drop targeting
     div.dataset.type = block.block_type;
     div.dataset.level = block.level;
     div.dataset.listStyle = block.list_style;
     div.dataset.checked = String(block.checked);
+    div.dataset.index = String(block.index);
+    div.dataset.parentId = block.parent_id;
     div.contentEditable = block.block_type === 'divider' ? 'false' : 'true';
     applyAriaRoles(div, block);
 
@@ -64,7 +102,7 @@ function render() {
   for (const block of state.blocks) {
     const div = blockDivs.get(block.id);
     if (!div) continue;
-    const expected = prev ? prev.nextElementSibling : container.firstElementChild;
+    const expected: Element | null = prev ? prev.nextElementSibling : container.firstElementChild;
     if (div !== expected) {
       if (prev) {
         prev.after(div);
@@ -98,6 +136,59 @@ function applyAriaRoles(div: HTMLDivElement, block: Block) {
       div.setAttribute('role', 'separator');
       break;
   }
+}
+
+// ── Drag targeting ──────────────────────────────────────────────────���─
+function computeDropPosition(e: DragEvent, div: HTMLDivElement): DropPosition {
+  const rect = div.getBoundingClientRect();
+  const y = e.clientY - rect.top;
+  const ratio = y / rect.height;
+  if (ratio < 0.5) return 'Before';
+  return 'After';
+}
+
+function clearDropIndicators() {
+  if (currentDropTarget) {
+    currentDropTarget.classList.remove('drop-before', 'drop-after');
+    currentDropTarget = null;
+  }
+  currentDropPosition = null;
+}
+
+function wireDragTarget(div: HTMLDivElement) {
+  div.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    const id = div.dataset.blockId!;
+    if (id === dragSourceId) return;
+
+    e.dataTransfer!.dropEffect = 'move';
+    const position = computeDropPosition(e, div);
+
+    if (currentDropTarget !== div || currentDropPosition !== position) {
+      clearDropIndicators();
+      currentDropTarget = div;
+      currentDropPosition = position;
+      div.classList.add(position === 'Before' ? 'drop-before' : 'drop-after');
+    }
+  });
+
+  div.addEventListener('dragleave', (e) => {
+    // Only clear if leaving the block entirely (not entering a child)
+    if (!div.contains(e.relatedTarget as Node)) {
+      if (currentDropTarget === div) clearDropIndicators();
+    }
+  });
+
+  div.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const targetId = div.dataset.blockId!;
+    if (dragSourceId && dragSourceId !== targetId && currentDropPosition) {
+      ed.editor_move_block(handle, dragSourceId, targetId, currentDropPosition);
+      render();
+    }
+    clearDropIndicators();
+    dragSourceId = null;
+  });
 }
 
 // ── Events ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add HTML5 drag-and-drop for block reordering with drag handles and drop indicators
- Semantic Before/After/Inside positioning through `move_node_before`/`move_node_after` in the CRDT layer (event-graph-walker@9d175ed)
- Render state now includes `block_count`, `index`, and `parent_id` for structural context
- 5 new tests verify move ordering and text preservation

## Test plan
- [x] `moon test` passes (488 EGW + 60 block editor)
- [ ] Manual: drag blocks via grip handle, verify Before/After indicators and correct reordering
- [ ] Manual: verify self-drop is a no-op (dragging onto own block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)