### PR TITLE
fix(ffi): drop empty rooms when relay_on_connect rejects the first peer

### DIFF
--- a/ffi/canopy_sync.mbt
+++ b/ffi/canopy_sync.mbt
@@ -63,12 +63,21 @@ fn get_or_create_room(room_id : String) -> @relay.RelayRoom {
 /// Register a peer in the given room. Returns `true` on success, `false` if
 /// the peer_id is empty or already connected — the caller (TS glue) should
 /// close the duplicate transport.
+///
+/// If the call creates a new room and the peer is then rejected, the empty
+/// room is removed so that clients cannot leak room entries by sending
+/// repeated invalid connects to unique room IDs.
 pub fn relay_on_connect(
   room_id : String,
   peer_id : String,
   send_fn : (Bytes) -> Unit,
 ) -> Bool {
-  get_or_create_room(room_id).on_connect(peer_id, send_fn)
+  let room = get_or_create_room(room_id)
+  let accepted = room.on_connect(peer_id, send_fn)
+  if !accepted && room.peer_count() == 0 {
+    relay_rooms.remove(room_id)
+  }
+  accepted
 }
 
 ///|

--- a/ffi/relay_room_leak_wbtest.mbt
+++ b/ffi/relay_room_leak_wbtest.mbt
@@ -1,0 +1,60 @@
+// Regression tests for CF Worker memory leak: rejected connects to
+// otherwise-new rooms must not leave empty entries in `relay_rooms`.
+// A malicious or buggy client could otherwise send `?room=<unique>`
+// with an invalid peer_id repeatedly to grow the map unbounded.
+
+///|
+fn noop_send(_ : Bytes) -> Unit {
+  ()
+}
+
+///|
+fn clear_relay_rooms() -> Unit {
+  let keys = relay_rooms.keys().to_array()
+  for k in keys {
+    relay_rooms.remove(k)
+  }
+}
+
+///|
+test "relay_on_connect: rejected empty peer_id does not leak empty room" {
+  clear_relay_rooms()
+  let accepted = relay_on_connect("leak-test-empty", "", noop_send)
+  inspect(accepted, content="false")
+  // The room must not remain in the map — would otherwise grow
+  // unbounded across unique room IDs.
+  inspect(relay_rooms.contains("leak-test-empty"), content="false")
+}
+
+///|
+test "relay_on_connect: duplicate rejection keeps the room alive" {
+  clear_relay_rooms()
+  inspect(relay_on_connect("leak-test-dup", "alice", noop_send), content="true")
+  // Duplicate rejection does NOT drop the room — the original peer
+  // is still a legitimate member.
+  inspect(
+    relay_on_connect("leak-test-dup", "alice", noop_send),
+    content="false",
+  )
+  inspect(relay_rooms.contains("leak-test-dup"), content="true")
+  // Cleanup
+  relay_on_disconnect("leak-test-dup", "alice")
+  inspect(relay_rooms.contains("leak-test-dup"), content="false")
+}
+
+///|
+test "relay_on_connect: rejection in a room with other peers preserves the room" {
+  clear_relay_rooms()
+  inspect(
+    relay_on_connect("leak-test-mixed", "alice", noop_send),
+    content="true",
+  )
+  // Trying to rejoin as alice is rejected, room has 1 peer so stays.
+  inspect(
+    relay_on_connect("leak-test-mixed", "alice", noop_send),
+    content="false",
+  )
+  inspect(relay_rooms.contains("leak-test-mixed"), content="true")
+  relay_on_disconnect("leak-test-mixed", "alice")
+  inspect(relay_rooms.contains("leak-test-mixed"), content="false")
+}


### PR DESCRIPTION
## Summary

Follow-up P1 fix to #188. The peer-ID validation introduced there left a CF Worker memory leak at the FFI boundary: `relay_on_connect` calls `get_or_create_room` before `RelayRoom::on_connect` runs validation, so a first-peer rejection (e.g. empty peer_id) leaves an empty entry in `relay_rooms`. A client hitting `?room=<unique>&peer_id=` across unique room IDs grows the isolate's room map unbounded.

Fix: after a rejected connect, if `room.peer_count() == 0` the room was freshly created by this call — remove it. Mirrors the cleanup pattern already in `relay_on_disconnect`.

**Why rollback over pre-validation:** pre-validating `peer_id == ""` at the FFI boundary would duplicate policy and miss any future rejection reason added to `RelayRoom::on_connect`. Rollback keeps the boundary responsible for cleanup regardless of why validation failed.

**Concurrency:** verified (with Codex) that MoonBit execution inside a Durable Object is cooperatively scheduled and the FFI path around `on_connect` is fully synchronous — `peer_count() == 0` correctly identifies "we just created this empty room."

## Test plan

- [x] `moon test ffi` — 13/13 pass (+3 new regression tests)
- [x] `moon test` — 884/884 pass (workspace)
- [x] `moon check` / `moon fmt` clean
- [x] `.mbti` diff empty — internal-only change
- [x] Codex high-reasoning review applied (removed one redundant test flagged as duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)