### PR TITLE
test: close PR #186 follow-up gaps 4a+4b

### DIFF
--- a/examples/web/tests/lambda-editor.spec.ts
+++ b/examples/web/tests/lambda-editor.spec.ts
@@ -106,4 +106,18 @@ test.describe('Lambda Editor — Foundation', () => {
     expect(await page.locator('#error-output .diag-item').count()).toBe(0);
   });
 
+  test('parse errors suppress type diagnostics', async ({ page }) => {
+    // A bare backslash is a malformed lambda — the parser expects a variable
+    // name and body after it, so the input fails to parse. Because the AST is
+    // incomplete, get_diagnostics_json only emits parse errors and skips the
+    // type-checker entirely (the suppression guard in canopy_lambda.mbt:170).
+    const editor = page.locator('#editor');
+    await editor.click();
+    await page.keyboard.type('\\');
+
+    await expect(page.locator('#error-output .diag-item.diag-error').first()).toBeVisible();
+    await expect(page.locator('#error-output')).not.toContainText('missing type annotation');
+    await expect(page.locator('#error-output')).not.toContainText('unbound variable');
+  });
+
 });

--- a/ffi/destroy_editor_wbtest.mbt
+++ b/ffi/destroy_editor_wbtest.mbt
@@ -1,0 +1,55 @@
+// Whitebox tests for the destroy_editor lifecycle in the FFI package.
+// Covers: handle removal, last_created_handle reset, unknown-handle no-op,
+// and create → destroy → recreate leaving exactly one entry.
+
+///|
+fn clear_lambda_handles() -> Unit {
+  let keys = lambda_handles.keys().to_array()
+  for k in keys {
+    lambda_handles.remove(k)
+  }
+  let vkeys = view_states.keys().to_array()
+  for k in vkeys {
+    view_states.remove(k)
+  }
+  let pvkeys = pretty_view_states.keys().to_array()
+  for k in pvkeys {
+    pretty_view_states.remove(k)
+  }
+  last_created_handle.val = None
+}
+
+///|
+test "destroy_editor: clears handle state" {
+  clear_lambda_handles()
+  let handle = create_editor("test-destroy-1")
+  destroy_editor(handle)
+  // Whitebox: handle must be removed from the registry
+  inspect(lambda_handles.contains(handle), content="false")
+  // Whitebox: last_created_handle must be reset to None
+  inspect(last_created_handle.val is None, content="true")
+  // Public-API fallback: unknown handle returns empty/default values
+  inspect(get_text(handle), content="")
+  inspect(get_diagnostics_json(handle), content="[]")
+}
+
+///|
+test "destroy_editor: unknown handle is a safe no-op" {
+  clear_lambda_handles()
+  // Must not crash or abort
+  destroy_editor(999999)
+  inspect(lambda_handles.contains(999999), content="false")
+}
+
+///|
+test "destroy_editor: create → destroy → recreate leaves exactly one entry" {
+  clear_lambda_handles()
+  let h1 = create_editor("agent-a")
+  let h2 = create_editor("agent-b")
+  destroy_editor(h1)
+  inspect(lambda_handles.contains(h1), content="false")
+  inspect(lambda_handles.contains(h2), content="true")
+  inspect(lambda_handles.length(), content="1")
+  // Cleanup
+  destroy_editor(h2)
+}

--- a/ffi/destroy_editor_wbtest.mbt
+++ b/ffi/destroy_editor_wbtest.mbt
@@ -45,8 +45,10 @@ test "destroy_editor: unknown handle is a safe no-op" {
 test "destroy_editor: create → destroy → recreate leaves exactly one entry" {
   clear_lambda_handles()
   let h1 = create_editor("agent-a")
-  let h2 = create_editor("agent-b")
   destroy_editor(h1)
+  // Recreate after teardown — this is the isolation case that a bug
+  // in destroy's cleanup (e.g. stale next_handle, leftover scope) could break.
+  let h2 = create_editor("agent-b")
   inspect(lambda_handles.contains(h1), content="false")
   inspect(lambda_handles.contains(h2), content="true")
   inspect(lambda_handles.length(), content="1")


### PR DESCRIPTION
## Summary

Closes two test-coverage gaps from the PR #186 follow-up list (`memory/project_lambda_type_diagnostics_followups.md`, gap 4).

- **Gap 4a** — Playwright test in `examples/web/tests/lambda-editor.spec.ts` verifying the **parse-error suppression** invariant: when input fails to parse, `get_diagnostics_json` skips the type-checker entirely (guard at `ffi/canopy_lambda.mbt:170`). Uses a bare `\` as reliably-parse-failing input and asserts that type-checker signature phrases (`"missing type annotation"`, `"unbound variable"`) never appear in the diagnostics panel.
- **Gap 4b** — Whitebox MoonBit tests in `ffi/destroy_editor_wbtest.mbt` covering the `destroy_editor` lifecycle: handle removal from `lambda_handles`, reset of `last_created_handle`, safe no-op on unknown handle, and isolation across create → destroy → recreate cycles. Follows the `ffi/relay_room_leak_wbtest.mbt` pattern (local `clear_lambda_handles()` helper for per-test clean slate).

## Test plan

- [x] `moon test` — 887/887 pass (includes 3 new whitebox tests)
- [x] `npx playwright test examples/web/tests/lambda-editor.spec.ts` — 11/11 pass (includes 1 new suppression test)
- [x] Each gap committed separately so revert granularity stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)