### PR TITLE
docs: archive completed lambda annotation plumbing plans

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,12 +79,15 @@ Detailed documentation for each module:
 - [AST Zipper Design](plans/2026-03-28-ast-zipper-design.md) — Structural cursor + typed holes
 - [BFT Adapter](plans/2026-03-19-bft-adapter-design.md) — Byzantine Fault Tolerance (deferred)
 - [Ideal Editor](plans/2026-03-19-ideal-editor-impl.md) — Full-featured editor with inspector, benchmarks
-- [Lambda Annotation Plumbing — Design](plans/2026-04-18-lambda-annotation-plumbing-design.md) — Thread `: Type` annotations from CST to TypedTerm; fix unannotated-lambda noise
-- [Lambda Annotation Plumbing — Impl](plans/2026-04-18-lambda-annotation-plumbing-impl.md) — Two-phase task list (Loom L0–L11, Canopy C1–C7)
 
 ## Archive
 
 Historical documentation, completed plans, and investigations.
+
+### Completed Plans (2026-04)
+
+- [Lambda Annotation Plumbing — Design](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-design.md) — Thread `: Type` annotations from CST to TypedTerm via `convert_from_cst`
+- [Lambda Annotation Plumbing — Impl](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-impl.md) — Shipped via loom#84, loom#85, canopy#191
 
 ### Completed Plans (2026-03)
 

--- a/docs/archive/completed-phases/2026-04-18-lambda-annotation-plumbing-design.md
+++ b/docs/archive/completed-phases/2026-04-18-lambda-annotation-plumbing-design.md
@@ -1,7 +1,6 @@
 # Lambda Type-Annotation Plumbing (CST → TypedTerm)
 
-**Status:** Design — ready for implementation plan
-**Related TODO:** `docs/TODO.md` §23
+**Status:** Complete — shipped via loom#84, loom#85, canopy#191 (2026-04-18)
 **Predecessor PR:** #186 (shipped inline type diagnostics with empty annotation pipeline)
 
 ## Why

--- a/docs/archive/completed-phases/2026-04-18-lambda-annotation-plumbing-impl.md
+++ b/docs/archive/completed-phases/2026-04-18-lambda-annotation-plumbing-impl.md
@@ -1,5 +1,7 @@
 # Lambda Type-Annotation Plumbing — Implementation Plan
 
+**Status:** Complete — shipped via loom#84, loom#85, canopy#191 (2026-04-18). Codex review caught two additional correctness holes (empty blocks, missing LetDef names) that were folded into loom#85.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Thread `: Type` annotations from the lambda CST through to `TypedTerm`, so `\x : Int. x` and the five web presets typecheck clean.


### PR DESCRIPTION
## Summary

Both plan documents were executed to completion via dowdiness/loom#84, dowdiness/loom#85, and #191 on 2026-04-18. This PR moves them from `docs/plans/` to `docs/archive/completed-phases/`, updates `docs/README.md` to list them under a new "Completed Plans (2026-04)" section, and stamps each archived plan with `Status: Complete` + links to the shipping PRs.

The impl plan also picks up a one-line note that Codex review caught two correctness holes during execution (empty blocks, missing LetDef names) which were folded into loom#85 before the canopy FFI swap — future readers of the archive will want that context.

## Test plan

- [x] `docs/README.md` has no dangling `plans/2026-04-18-lambda-annotation-plumbing-*` links
- [x] Moved files are listed under Archive
- [x] No code changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)