### PR TITLE
fix(lambda): surface parse recovery as Error ProjNodes (#74)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -250,8 +250,7 @@ Known concerns from the `editor/tree_edit_bridge.mbt` roundtrip implementation (
   Exit: `editor/` uses explicit boundary error types and root FFI remains the primary error-flattening edge.
   Note: tree-edit, ephemeral, and websocket/protocol slices are implemented; contributor and API docs now describe the current boundary strategy. A future wrapper-type decision can be tracked separately if needed.
 - [x] Convert `abort()` calls in test files to proper assertions — ✅ Done. Verified 2026-04-02: zero `abort()` in any .mbt file across entire repo. Plan archived.
-- [ ] Parse recovery should produce `Error` nodes, not coerce to `Int(0)`/`Plus` (GitHub #74)
-  Exit: malformed expressions produce `Error(...)` nodes in the AST.
+- [x] Parse recovery should produce `Error` nodes, not coerce to `Int(0)`/`Plus` (GitHub #74) — ✅ Done. `syntax_to_proj_node` in `lang/lambda/proj/proj_node.mbt`: unparseable int literals (e.g. overflow) emit `Error("invalid integer literal")`; operand/operator mismatch in `BinaryExpr` emits `Error("missing binary operator")` instead of fabricating `Plus`.
 - [x] `parse_to_proj_node` should return `Result` instead of aborting (GitHub #75) — ✅ Done. Lambda and JSON now propagate `LexError` via `raise`, matching Markdown. 807 tests pass.
 - [ ] Tighten `ActionRecord` visibility (GitHub #97)
   Exit: `ActionRecord` fields use appropriate visibility modifiers.

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -60,8 +60,12 @@ pub fn syntax_to_proj_node(
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
   if @parser.IntLiteralView::cast(node) is Some(v) {
+    let kind : @ast.Term = match v.value() {
+      Some(n) => Int(n)
+      None => Error("invalid integer literal")
+    }
     ProjNode::new(
-      Int(v.value().unwrap_or(0)),
+      kind,
       node.start(),
       node.end(),
       @core.next_proj_node_id(counter),
@@ -109,13 +113,30 @@ pub fn syntax_to_proj_node(
       syntax_to_proj_node(operands[0], counter)
     } else {
       // Fold n-ary syntax (`a + b + c`) into binary Term shape.
+      // The parser emits operator+operand pairs, so `ops` and trailing
+      // operands stay balanced; the Error branch guards malformed or
+      // hand-built CSTs, not normal parser output. Check before recursing
+      // so we neither re-overwrite Error nor traverse unreachable operands.
       let mut result = syntax_to_proj_node(operands[0], counter)
+      let mut missing_at : Int? = None
       for i = 1; i < operands.length(); i = i + 1 {
-        let op = if i - 1 < ops.length() { ops[i - 1] } else { @ast.Bop::Plus }
+        if i - 1 >= ops.length() {
+          missing_at = Some(operands[i].start())
+          break
+        }
         let rhs = syntax_to_proj_node(operands[i], counter)
-        result = bop_node(op, result, rhs, counter)
+        result = bop_node(ops[i - 1], result, rhs, counter)
       }
-      result
+      match missing_at {
+        Some(end) =>
+          error_node_with_span(
+            "missing binary operator",
+            result.start,
+            end,
+            counter,
+          )
+        None => result
+      }
     }
   } else if @parser.IfExprView::cast(node) is Some(v) {
     let cond = match v.condition() {

--- a/lang/lambda/proj/proj_node_recovery_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_recovery_wbtest.mbt
@@ -1,0 +1,19 @@
+// Tests for parse recovery producing explicit Error ProjNodes
+// instead of silently coercing to Int(0) / Plus.
+
+///|
+test "recovery: int literal overflow yields Error node" {
+  // parse_int overflows on 20+ digit integers, so IntLiteralView::value
+  // returns None. Recovery should emit an Error node, not Int(0).
+  let (proj, _) = parse_to_proj_node("99999999999999999999")
+  match proj.kind {
+    Error(msg) => inspect(msg, content="invalid integer literal")
+    other => fail("expected Error node, got \{other}")
+  }
+}
+
+///|
+test "recovery: valid int literal still produces Int" {
+  let (proj, _) = parse_to_proj_node("42")
+  inspect(proj.kind, content="Int(42)")
+}


### PR DESCRIPTION
Closes #74.

## Summary

- `syntax_to_proj_node` in `lang/lambda/proj/proj_node.mbt` previously hid two parse-recovery failures by coercing to valid-looking projections:
  - Unparseable `IntLiteral` (e.g. 20+ digit overflow) → `Int(0)` via `unwrap_or`
  - `BinaryExpr` with more operand children than operator tokens → fabricated `@ast.Bop::Plus`
- Both sites now emit `Error(msg)` ProjNodes, so downstream consumers (evaluator, renderer, pretty-printer) see that recovery happened instead of receiving a well-formed-but-wrong AST.
- Missing-operator branch is defensive — parser emits operator+operand pairs so `ops` stays balanced. The guard catches malformed/hand-built CSTs, not normal parser output. Comment documents this.

## Paired loom PR

Bumps loom submodule to `3c66df6` (dowdiness/loom#86 merged), which applies the same fix to the parallel `lambda_fold_node` Term fold used by `parse_term` and `get_lambda_ast`.

## Test plan

- [x] `moon test` — 889/889 pass (includes 2 new tests in `proj_node_recovery_wbtest.mbt`)
- [x] `moon check`, `moon fmt`, `moon info` clean
- [x] Overflow input `"99999999999999999999"` yields `Error("invalid integer literal")`; valid `"42"` still yields `Int(42)`

## Reviewer notes

Codex review caught the duplicated fold in loom and prompted the paired submodule PR. CodeRabbit suggested tightening the BinaryExpr loop so it checks the mismatch condition before recursing and breaks — applied on both sides for symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)