### PR TITLE
feat(ffi): structured def_name field in diagnostic JSON

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -173,6 +173,17 @@
       border-left: 3px solid #cca700;
     }
 
+    .diag-def-badge {
+      display: inline-block;
+      padding: 1px 6px;
+      margin-right: 4px;
+      background: rgba(130, 170, 255, 0.15);
+      color: #82aaff;
+      border-radius: 3px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85em;
+    }
+
     .status {
       background: #007acc22;
       border-left: 3px solid #007acc;

--- a/examples/web/src/editor.ts
+++ b/examples/web/src/editor.ts
@@ -49,15 +49,22 @@ export function createEditor(agentId: string) {
       astOutputEl.textContent = `Pretty-print error: ${e}`;
     }
 
-    // Diagnostics (parse errors + eval warnings)
-    const diags: { level: string; message: string }[] = JSON.parse(
+    // Diagnostics (parse errors + eval warnings). `def_name` is present
+    // on type errors inside a named binding so we can render a badge
+    // instead of string-prefixing the message.
+    const diags: { level: string; message: string; def_name?: string }[] = JSON.parse(
       crdt.get_diagnostics_json(handle),
     );
     if (diags.length === 0) {
       errorEl.innerHTML = '<li>No errors</li>';
     } else {
       errorEl.innerHTML = diags
-        .map(d => `<li class="diag-item diag-${d.level}">${escapeHTML(d.message)}</li>`)
+        .map(d => {
+          const badge = d.def_name
+            ? `<span class="diag-def-badge">${escapeHTML(d.def_name)}</span> `
+            : '';
+          return `<li class="diag-item diag-${d.level}">${badge}${escapeHTML(d.message)}</li>`;
+        })
         .join('');
     }
   }

--- a/examples/web/tests/lambda-editor.spec.ts
+++ b/examples/web/tests/lambda-editor.spec.ts
@@ -120,6 +120,21 @@ test.describe('Lambda Editor — Foundation', () => {
     expect(await page.locator('#error-output .diag-item').count()).toBe(0);
   });
 
+  test('type error inside a named binding shows def badge', async ({ page }) => {
+    // `let f = y\nf` — `y` is unbound inside def `f`. FFI emits the
+    // diagnostic with `def_name: "f"`, which the UI renders as a
+    // `.diag-def-badge` span instead of a `[f]` string prefix.
+    const editor = page.locator('#editor');
+    await editor.click();
+    await page.keyboard.type('let f = y\nf');
+
+    const badge = page.locator('#error-output .diag-item .diag-def-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText('f');
+    // The old `[f] ` string prefix must not appear in the message.
+    await expect(page.locator('#error-output')).not.toContainText('[f]');
+  });
+
   test('parse errors suppress type diagnostics', async ({ page }) => {
     // A bare backslash is a malformed lambda — the parser expects a variable
     // name and body after it, so the input fails to parse. Because the AST is

--- a/ffi/canopy_lambda.mbt
+++ b/ffi/canopy_lambda.mbt
@@ -157,7 +157,10 @@ pub fn get_errors_json(handle : Int) -> String {
 
 ///|
 /// Get all diagnostics (parse errors + type errors + eval warnings) as JSON array.
-/// Each entry: {"level": "error"|"warning", "message": "..."}
+/// Each entry: `{"level": "error"|"warning", "message": "...", "def_name"?: "..."}`.
+/// `def_name` is present only on type-check diagnostics that originate inside a
+/// named binding (e.g. `let f = y` → `def_name: "f"`); consumers should group,
+/// filter, or badge by this field rather than parsing the message string.
 pub fn get_diagnostics_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
     Some(h) => {
@@ -178,11 +181,11 @@ pub fn get_diagnostics_json(handle : Int) -> String {
         for diag in result.all_diagnostics {
           let m : Map[String, Json] = {}
           m["level"] = "error".to_json()
-          let prefix = match diag.def_name {
-            Some(name) => "[\{name}] "
-            None => ""
+          m["message"] = diag.message.to_json()
+          match diag.def_name {
+            Some(name) => m["def_name"] = name.to_json()
+            None => ()
           }
-          m["message"] = (prefix + diag.message).to_json()
           diags.push(Json::object(m))
         }
       }

--- a/ffi/canopy_test.mbt
+++ b/ffi/canopy_test.mbt
@@ -86,3 +86,29 @@ test "get_diagnostics_json FFI: unbound variable" {
   inspect(json.contains("unbound"), content="true")
   destroy_editor(handle)
 }
+
+///|
+test "get_diagnostics_json FFI: def_name populated for errors inside a named binding" {
+  // `let f = y\nf` — `y` is unbound inside the body of def `f`.
+  // The typecheck diagnostic should carry `def_name: "f"` so the
+  // web UI can render it as a badge.
+  let handle = create_editor("test-def-name")
+  set_text(handle, "let f = y\nf")
+  let json = get_diagnostics_json(handle)
+  inspect(json.contains("\"def_name\":\"f\""), content="true")
+  // And the message itself should no longer carry the `[f] ` prefix.
+  inspect(json.contains("[f]"), content="false")
+  destroy_editor(handle)
+}
+
+///|
+test "get_diagnostics_json FFI: def_name omitted for top-level errors" {
+  // `x + 1` — unbound `x` at the module top level; no named-binding
+  // context, so `def_name` should be absent from the JSON entirely.
+  let handle = create_editor("test-no-def-name")
+  set_text(handle, "x + 1")
+  let json = get_diagnostics_json(handle)
+  inspect(json.contains("unbound"), content="true")
+  inspect(json.contains("def_name"), content="false")
+  destroy_editor(handle)
+}


### PR DESCRIPTION
## Summary

Closes gap 3 of the PR #186 follow-up list. Previously the typecheck pipeline prefixed each diagnostic's message string with `[def_name] ` when the error originated inside a named binding — putting a parseable field inside an opaque string. Consumers had to either regex-split the message or render the prefix inline.

Switch `get_diagnostics_json` to emit `{"level", "message", "def_name"?}` where `def_name` is present only for type errors inside a named binding. The web editor now renders a pill-shaped `.diag-def-badge` using the palette's identifier-blue (`#82aaff`) on a translucent background, instead of the `[f] ` inline string.

## Before / after

Input: `let f = y\nf`

Before:
```json
[{"level":"error","message":"[f] unbound variable: y"}]
```
UI: `[f] unbound variable: y` (raw string)

After:
```json
[{"level":"error","message":"unbound variable: y","def_name":"f"}]
```
UI: <kbd>f</kbd> `unbound variable: y` (badge + clean message)

## Test plan

- [x] 889/889 canopy tests pass (`moon test`)
- [x] 18/18 FFI tests pass, including two new ones:
  - `def_name` populated for `let f = y` (badge path)
  - `def_name` omitted for `x + 1` (top-level path)
- [x] 13/13 Playwright tests pass, including new badge rendering test for `let f = y\nf`
- [x] `moon build --target js` clean
- [x] `moon info && moon fmt` — no `.mbti` diff

Gap 2 (absorb the parallel typecheck runtime) remains open — tied to the dowdiness/loom#83 unified-parser ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)