### PR TITLE
feat(editor): migrate to unified @loom.Parser[T] (Stage 4)

### DIFF
--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub fn[T] assign_fresh_ids(ProjNode[T], @ref.Ref[Int]) -> ProjNode[T]
 
-pub fn[T : @dowdiness/loom/core.TreeNode] build_projection_memos(@cells.Runtime, @cells.Signal[@seam.SyntaxNode?], (@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode[T], (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit, label? : String) -> (@cells.Memo[ProjNode[T]?], @cells.Memo[Map[NodeId, ProjNode[T]]], @cells.Memo[SourceMap])
+pub fn[T : @dowdiness/loom/core.TreeNode] build_projection_memos(@cells.Runtime, @cells.Memo[@seam.SyntaxNode?], (@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode[T], (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit, label? : String) -> (@cells.Memo[ProjNode[T]?], @cells.Memo[Map[NodeId, ProjNode[T]]], @cells.Memo[SourceMap])
 
 pub fn[T] collect_registry(ProjNode[T], Map[NodeId, ProjNode[T]]) -> Unit
 

--- a/core/projection_memo.mbt
+++ b/core/projection_memo.mbt
@@ -4,7 +4,7 @@ using @loomcore {trait TreeNode}
 ///|
 pub fn[T : TreeNode] build_projection_memos(
   rt : @incr.Runtime,
-  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
+  syntax_tree : @incr.Memo[@seam.SyntaxNode?],
   syntax_to_proj : (@seam.SyntaxNode, Ref[Int]) -> ProjNode[T],
   populate_spans : (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit,
   label? : String = "generic",

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -5,7 +5,7 @@ import {
   "dowdiness/canopy/protocol",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
-  "dowdiness/loom/incremental",
+  "dowdiness/loom/pipeline",
   "dowdiness/pretty",
   "dowdiness/seam",
   "moonbitlang/core/debug",
@@ -271,22 +271,22 @@ pub struct SyncEditor[T] {
   // private fields
 }
 pub fn[T] SyncEditor::apply_ephemeral(Self[T], Bytes) -> Unit
-pub fn[T] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int) -> Unit
-pub fn[T] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise
-pub fn[T] SyncEditor::apply_text_edit(Self[T], Int, Int, String, Int) -> Unit
-pub fn[T] SyncEditor::apply_text_edit_internal(Self[T], Int, Int, String, Int, Bool, Bool) -> Unit
-pub fn[T] SyncEditor::apply_text_transform(Self[T], @dowdiness/canopy/core.NodeId, (String, Int, Int) -> Result[String, String], Int) -> Result[Unit, TreeEditError]
-pub fn[T] SyncEditor::backspace(Self[T]) -> Bool
-pub fn[T] SyncEditor::backspace_and_record(Self[T], Int) -> Bool
+pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int) -> Unit
+pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise
+pub fn[T : Eq] SyncEditor::apply_text_edit(Self[T], Int, Int, String, Int) -> Unit
+pub fn[T : Eq] SyncEditor::apply_text_edit_internal(Self[T], Int, Int, String, Int, Bool, Bool) -> Unit
+pub fn[T : Eq] SyncEditor::apply_text_transform(Self[T], @dowdiness/canopy/core.NodeId, (String, Int, Int) -> Result[String, String], Int) -> Result[Unit, TreeEditError]
+pub fn[T : Eq] SyncEditor::backspace(Self[T]) -> Bool
+pub fn[T : Eq] SyncEditor::backspace_and_record(Self[T], Int) -> Bool
 pub fn[T] SyncEditor::can_redo(Self[T]) -> Bool
 pub fn[T] SyncEditor::can_undo(Self[T]) -> Bool
 pub fn[T] SyncEditor::clear_undo(Self[T]) -> Unit
-pub fn[T] SyncEditor::commit_edit(Self[T], @dowdiness/canopy/core.NodeId, String, Int) -> Result[Unit, TreeEditError]
-pub fn[T] SyncEditor::delete(Self[T]) -> Bool
-pub fn[T] SyncEditor::delete_and_record(Self[T], Int) -> Bool
-pub fn[T] SyncEditor::delete_at(Self[T], Int, Int) -> Bool
+pub fn[T : Eq] SyncEditor::commit_edit(Self[T], @dowdiness/canopy/core.NodeId, String, Int) -> Result[Unit, TreeEditError]
+pub fn[T : Eq] SyncEditor::delete(Self[T]) -> Bool
+pub fn[T : Eq] SyncEditor::delete_and_record(Self[T], Int) -> Bool
+pub fn[T : Eq] SyncEditor::delete_at(Self[T], Int, Int) -> Bool
 pub fn[T] SyncEditor::delete_local_presence(Self[T]) -> Unit
-pub fn[T : @dowdiness/loom/core.Renderable] SyncEditor::delete_node(Self[T], @dowdiness/canopy/core.NodeId, Int) -> Result[Unit, TreeEditError]
+pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::delete_node(Self[T], @dowdiness/canopy/core.NodeId, Int) -> Result[Unit, TreeEditError]
 pub fn[T] SyncEditor::encode_ephemeral_all(Self[T]) -> Bytes
 pub fn[T] SyncEditor::export_all(Self[T]) -> @text.SyncMessage raise
 pub fn[T] SyncEditor::export_since(Self[T], @text.Version) -> @text.SyncMessage raise
@@ -306,35 +306,37 @@ pub fn[T] SyncEditor::get_text(Self[T]) -> String
 pub fn[T] SyncEditor::get_tree(Self[T]) -> T?
 pub fn[T] SyncEditor::get_version(Self[T]) -> @text.Version
 pub fn[T : @dowdiness/loom/core.Renderable] SyncEditor::get_view_tree(Self[T]) -> @protocol.ViewNode?
-pub fn[T] SyncEditor::insert(Self[T], String) -> Unit raise
-pub fn[T] SyncEditor::insert_and_record(Self[T], String, Int) -> Unit raise
-pub fn[T] SyncEditor::insert_at(Self[T], Int, String, Int) -> Unit
+pub fn[T : Eq] SyncEditor::insert(Self[T], String) -> Unit raise
+pub fn[T : Eq] SyncEditor::insert_and_record(Self[T], String, Int) -> Unit raise
+pub fn[T : Eq] SyncEditor::insert_at(Self[T], Int, String, Int) -> Unit
 pub fn[T] SyncEditor::is_dirty(Self[T]) -> Bool
 pub fn[T] SyncEditor::is_parse_valid(Self[T]) -> Bool
-pub fn[T] SyncEditor::mark_dirty(Self[T]) -> Unit
+pub fn[T : Eq] SyncEditor::mark_dirty(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor(Self[T], Int) -> Unit
-pub fn[T : @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Unit, TreeEditError]
-pub fn[T] SyncEditor::new_generic(String, (String) -> @incremental.ImperativeParser[T], (@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[T]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[T]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Memo[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, capabilities? : LanguageCapabilities[T]) -> Self[T]
+pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Unit, TreeEditError]
+pub fn[T] SyncEditor::new_generic(String, (String) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[T]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Memo[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, capabilities? : LanguageCapabilities[T]) -> Self[T]
 pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId?
 pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
-pub fn[T] SyncEditor::redo(Self[T]) -> Bool
-pub fn[T] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage?
+pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime
+pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Memo[@seam.SyntaxNode?]
+pub fn[T : Eq] SyncEditor::redo(Self[T]) -> Bool
+pub fn[T : Eq] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage?
 pub fn[T] SyncEditor::refresh(Self[T]) -> Unit
 pub fn[T] SyncEditor::remove_ephemeral_outdated(Self[T]) -> Unit
 pub fn[T] SyncEditor::set_local_presence(Self[T], String, String, selection? : (Int, Int)?) -> Unit
 pub fn[T] SyncEditor::set_on_status_change(Self[T], ((SyncStatus) -> Unit)?) -> Unit
-pub fn[T] SyncEditor::set_text(Self[T], String) -> Unit
-pub fn[T] SyncEditor::set_text_and_record(Self[T], String, Int) -> Unit
+pub fn[T : Eq] SyncEditor::set_text(Self[T], String) -> Unit
+pub fn[T : Eq] SyncEditor::set_text_and_record(Self[T], String, Int) -> Unit
 pub fn[T] SyncEditor::set_tracking(Self[T], Bool) -> Unit
 pub fn[T] SyncEditor::set_watchdog_scheduler(Self[T], ((Int, Int) -> Unit)?) -> Unit
 pub fn[T] SyncEditor::set_watchdog_timeout(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::subscribe_ephemeral_local(Self[T], (Bytes) -> Bool) -> EphemeralSubscription
-pub fn[T] SyncEditor::undo(Self[T]) -> Bool
-pub fn[T] SyncEditor::undo_and_export(Self[T]) -> @text.SyncMessage?
+pub fn[T : Eq] SyncEditor::undo(Self[T]) -> Bool
+pub fn[T : Eq] SyncEditor::undo_and_export(Self[T]) -> @text.SyncMessage?
 pub fn[T] SyncEditor::ws_broadcast_cursor(Self[T]) -> Unit
 pub fn[T] SyncEditor::ws_broadcast_edit(Self[T]) -> Unit
 pub fn[T] SyncEditor::ws_on_close(Self[T]) -> Unit
-pub fn[T] SyncEditor::ws_on_message(Self[T], Bytes) -> Unit
+pub fn[T : Eq] SyncEditor::ws_on_message(Self[T], Bytes) -> Unit
 pub fn[T] SyncEditor::ws_on_open(Self[T], JsWebSocket) -> Unit
 pub fn[T] SyncEditor::ws_send(Self[T], Bytes) -> Unit
 

--- a/editor/projection_memo.mbt
+++ b/editor/projection_memo.mbt
@@ -4,13 +4,13 @@
 /// Returns the cached ProjNode (converted from FlatProj once per invalidation).
 /// Safe to call both inside and outside tracked context.
 pub fn[T] SyncEditor::get_proj_node(self : SyncEditor[T]) -> @core.ProjNode[T]? {
-  self.parser_rt.read(self.cached_proj_node)
+  self.parser.runtime().read(self.cached_proj_node)
 }
 
 ///|
 /// Safe to call both inside and outside tracked context.
 pub fn[T] SyncEditor::get_source_map(self : SyncEditor[T]) -> @core.SourceMap {
-  self.parser_rt.read(self.source_map_memo)
+  self.parser.runtime().read(self.source_map_memo)
 }
 
 ///|
@@ -19,13 +19,16 @@ pub fn[T] SyncEditor::get_source_map(self : SyncEditor[T]) -> @core.SourceMap {
 pub fn[T] SyncEditor::get_registry(
   self : SyncEditor[T],
 ) -> Map[@core.NodeId, @core.ProjNode[T]] {
-  self.parser_rt.read(self.registry_memo)
+  self.parser.runtime().read(self.registry_memo)
 }
 
 ///|
 /// Returns the parsed AST tree (language-specific type T).
+/// Always `Some(_)` — the Parser primes its AST cell in the constructor.
+/// The `?` is kept to leave room for future lex-failure propagation
+/// without churning every caller.
 pub fn[T] SyncEditor::get_tree(self : SyncEditor[T]) -> T? {
-  self.parser.get_tree()
+  Some(self.parser.runtime().read(self.parser.ast()))
 }
 
 ///|
@@ -33,7 +36,7 @@ pub fn[T] SyncEditor::get_node(
   self : SyncEditor[T],
   id : @core.NodeId,
 ) -> @core.ProjNode[T]? {
-  self.parser_rt.read(self.registry_memo).get(id)
+  self.parser.runtime().read(self.registry_memo).get(id)
 }
 
 ///|
@@ -41,7 +44,7 @@ pub fn[T] SyncEditor::node_at_position(
   self : SyncEditor[T],
   position : Int,
 ) -> @core.NodeId? {
-  self.parser_rt.read(self.source_map_memo).innermost_node_at(position)
+  self.parser.runtime().read(self.source_map_memo).innermost_node_at(position)
 }
 
 ///|
@@ -49,5 +52,5 @@ pub fn[T] SyncEditor::get_node_range(
   self : SyncEditor[T],
   id : @core.NodeId,
 ) -> @loom_core.Range? {
-  self.parser_rt.read(self.source_map_memo).get_range(id)
+  self.parser.runtime().read(self.source_map_memo).get_range(id)
 }

--- a/editor/projection_memo.mbt
+++ b/editor/projection_memo.mbt
@@ -24,9 +24,11 @@ pub fn[T] SyncEditor::get_registry(
 
 ///|
 /// Returns the parsed AST tree (language-specific type T).
-/// Always `Some(_)` — the Parser primes its AST cell in the constructor.
-/// The `?` is kept to leave room for future lex-failure propagation
-/// without churning every caller.
+/// Always `Some(_)` — the Parser primes its AST cell in the constructor
+/// and lex failures propagate as a language-specific sentinel (e.g.
+/// `Term::Error("lex error: …")` for lambda via `on_lex_error`), not as
+/// `None`. The `?` is kept so this API doesn't need to churn if we
+/// later separate "never parsed" from "parse failed".
 pub fn[T] SyncEditor::get_tree(self : SyncEditor[T]) -> T? {
   Some(self.parser.runtime().read(self.parser.ast()))
 }

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -1,5 +1,5 @@
-// SyncEditor: Unified facade composing TextState + UndoManager + incremental parser.
-// Parsing stays edit-aware via ImperativeParser; projection views are memo-derived.
+// SyncEditor: TextState + UndoManager + reactive Parser.
+// Projection views subscribe to the parser's reactive memos.
 
 ///|
 /// Default watchdog timeout in milliseconds.
@@ -9,10 +9,7 @@ const DEFAULT_WATCHDOG_MS : Int = 5000
 pub struct SyncEditor[T] {
   priv doc : @text.TextState
   priv undo : @undo.UndoManager
-  priv parser : @loom.ImperativeParser[T]
-  priv parser_rt : @incr.Runtime
-  priv source_text : @incr.Signal[String]
-  priv syntax_tree : @incr.Signal[@seam.SyntaxNode?]
+  priv parser : @loom.Parser[T]
   priv mut cursor : Int
   priv cached_proj_node : @incr.Memo[@core.ProjNode[T]?]
   priv registry_memo : @incr.Memo[Map[@core.NodeId, @core.ProjNode[T]]]
@@ -33,16 +30,13 @@ pub struct SyncEditor[T] {
 
 ///|
 /// Generic constructor for all languages.
-/// The build_memos callback returns 3 memos (ProjNode, registry, SourceMap).
+/// `make_parser` builds a `@loom.Parser[T]` from an initial source string.
+/// `build_memos` receives the parser handle and returns the 3 projection memos
+/// (ProjNode, registry, SourceMap) it wants SyncEditor to own.
 pub fn[T] SyncEditor::new_generic(
   agent_id : String,
-  make_parser : (String) -> @loom.ImperativeParser[T],
-  build_memos : (
-    @incr.Runtime,
-    @incr.Signal[String],
-    @incr.Signal[@seam.SyntaxNode?],
-    @loom.ImperativeParser[T],
-  ) -> (
+  make_parser : (String) -> @loom.Parser[T],
+  build_memos : (@loom.Parser[T]) -> (
     @incr.Memo[@core.ProjNode[T]?],
     @incr.Memo[Map[@core.NodeId, @core.ProjNode[T]]],
     @incr.Memo[@core.SourceMap],
@@ -51,24 +45,12 @@ pub fn[T] SyncEditor::new_generic(
   capabilities? : LanguageCapabilities[T] = LanguageCapabilities::default(),
 ) -> SyncEditor[T] {
   let parser = make_parser("")
-  let parser_rt = @incr.Runtime::new()
-  let source_text = @incr.Signal::new(parser_rt, "", label="editor_source_text")
-  let syntax_tree = @incr.Signal::new(
-    parser_rt,
-    None,
-    label="editor_syntax_tree",
-  )
-  let (cached_proj_node, registry_memo, source_map_memo) = build_memos(
-    parser_rt, source_text, syntax_tree, parser,
-  )
+  let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
   {
     doc: @text.TextState::new(agent_id),
     undo: @undo.UndoManager::new(agent_id, capture_timeout_ms~),
     parser,
-    parser_rt,
-    source_text,
-    syntax_tree,
     cursor: 0,
     cached_proj_node,
     registry_memo,

--- a/editor/sync_editor_parser.mbt
+++ b/editor/sync_editor_parser.mbt
@@ -98,18 +98,9 @@ fn[T : Eq] SyncEditor::apply_local_text_change(
 }
 
 ///|
-fn[T : Eq] SyncEditor::force_parser_reset(
-  self : SyncEditor[T],
-) -> @seam.SyntaxNode? {
-  let source = self.doc.text()
-  self.parser.set_source(source)
-  self.mark_projection_dirty()
-  self.parser.runtime().read(self.parser.syntax_tree())
-}
-
-///|
 pub fn[T : Eq] SyncEditor::mark_dirty(self : SyncEditor[T]) -> Unit {
-  let _ = self.force_parser_reset()
+  self.parser.set_source(self.doc.text())
+  self.mark_projection_dirty()
 }
 
 ///|

--- a/editor/sync_editor_parser.mbt
+++ b/editor/sync_editor_parser.mbt
@@ -1,41 +1,34 @@
 // Parser-facing SyncEditor methods.
 
 ///|
-fn[T] SyncEditor::set_parser_signals(
-  self : SyncEditor[T],
-  source : String,
-  syntax? : @seam.SyntaxNode? = None,
-) -> Unit {
-  self.parser_rt.batch(fn() {
-    self.source_text.set(source)
-    self.syntax_tree.set(syntax)
-  })
-  // All text-changing paths (insert, backspace, apply_text_edit_internal,
-  // undo/redo via mark_dirty, remote sync) converge here.
+/// Flag that the projection registry / source map / proj node may be stale.
+/// All text-changing paths (insert, backspace, apply_text_edit_internal,
+/// undo/redo via mark_dirty, remote sync) converge here after the parser
+/// has been updated — the Parser itself batches its own signal updates
+/// internally via Runtime::batch.
+fn[T] SyncEditor::mark_projection_dirty(self : SyncEditor[T]) -> Unit {
   self.projection_dirty = true
 }
 
 ///|
-fn[T] SyncEditor::sync_parser_after_text_change(
+fn[T : Eq] SyncEditor::sync_parser_after_text_change(
   self : SyncEditor[T],
   old_source : String,
   new_source : String,
   known_edit : @loom_core.Edit?,
 ) -> Unit {
-  if old_source == new_source {
-    return
-  }
+  // Short-circuits mark_projection_dirty; Parser does its own identity check.
+  guard old_source != new_source else { return }
   if new_source == "" {
-    let _ = self.parser.reset(new_source)
-    self.set_parser_signals(new_source)
-    return
+    self.parser.set_source(new_source)
+  } else {
+    let edit = match known_edit {
+      Some(edit) => edit
+      None => compute_edit(old_source, new_source)
+    }
+    self.parser.apply_edit(edit, new_source)
   }
-  let edit = match known_edit {
-    Some(edit) => edit
-    None => compute_edit(old_source, new_source)
-  }
-  let _ = self.parser.edit(edit, new_source)
-  self.set_parser_signals(new_source, syntax=self.parser.get_syntax_tree())
+  self.mark_projection_dirty()
 }
 
 ///|
@@ -91,7 +84,7 @@ fn resolve_applied_edit(
 }
 
 ///|
-fn[T] SyncEditor::apply_local_text_change(
+fn[T : Eq] SyncEditor::apply_local_text_change(
   self : SyncEditor[T],
   old_source : String,
   new_source : String,
@@ -105,16 +98,17 @@ fn[T] SyncEditor::apply_local_text_change(
 }
 
 ///|
-fn[T] SyncEditor::force_parser_reset(self : SyncEditor[T]) -> @seam.SyntaxNode? {
+fn[T : Eq] SyncEditor::force_parser_reset(
+  self : SyncEditor[T],
+) -> @seam.SyntaxNode? {
   let source = self.doc.text()
-  let _ = self.parser.reset(source)
-  let syntax = self.parser.get_syntax_tree()
-  self.set_parser_signals(source, syntax~)
-  syntax
+  self.parser.set_source(source)
+  self.mark_projection_dirty()
+  self.parser.runtime().read(self.parser.syntax_tree())
 }
 
 ///|
-pub fn[T] SyncEditor::mark_dirty(self : SyncEditor[T]) -> Unit {
+pub fn[T : Eq] SyncEditor::mark_dirty(self : SyncEditor[T]) -> Unit {
   let _ = self.force_parser_reset()
 }
 
@@ -123,10 +117,27 @@ pub fn[T] SyncEditor::get_errors(self : SyncEditor[T]) -> Array[String] {
   if self.doc.text() == "" {
     return []
   }
-  self.parser.diagnostics()
+  self.parser.runtime().read(self.parser.diagnostics())
 }
 
 ///|
 pub fn[T] SyncEditor::is_parse_valid(self : SyncEditor[T]) -> Bool {
   self.get_errors().is_empty()
+}
+
+///|
+/// The reactive runtime owned by the parser. Exposed so downstream
+/// consumers (e.g. the FFI typecheck bundle) can join the same graph
+/// and react to edits without a second parse of the editor's text.
+pub fn[T] SyncEditor::parser_runtime(self : SyncEditor[T]) -> @incr.Runtime {
+  self.parser.runtime()
+}
+
+///|
+/// Reactive view of the parser's CST. `None` after a lex error;
+/// `Some(tree)` otherwise. Tracked when `.get()` inside a memo closure.
+pub fn[T] SyncEditor::parser_syntax_tree(
+  self : SyncEditor[T],
+) -> @incr.Memo[@seam.SyntaxNode?] {
+  self.parser.syntax_tree()
 }

--- a/editor/sync_editor_span_edit.mbt
+++ b/editor/sync_editor_span_edit.mbt
@@ -6,7 +6,7 @@
 /// Apply a list of SpanEdits through the text CRDT, then adjust the cursor
 /// per the FocusHint. Edits are applied in reverse document order to avoid
 /// position shifts. All edits are recorded for undo.
-pub fn[T] SyncEditor::apply_span_edits(
+pub fn[T : Eq] SyncEditor::apply_span_edits(
   self : SyncEditor[T],
   edits : Array[@core.SpanEdit],
   focus_hint : @core.FocusHint,

--- a/editor/sync_editor_sync.mbt
+++ b/editor/sync_editor_sync.mbt
@@ -9,7 +9,7 @@ fn[T] SyncEditor::adjust_cursor(self : SyncEditor[T]) -> Unit {
 }
 
 ///|
-pub fn[T] SyncEditor::apply_sync(
+pub fn[T : Eq] SyncEditor::apply_sync(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
 ) -> Unit raise {

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -1,7 +1,10 @@
 // Text and cursor operations for SyncEditor.
 
 ///|
-pub fn[T] SyncEditor::insert(self : SyncEditor[T], text : String) -> Unit raise {
+pub fn[T : Eq] SyncEditor::insert(
+  self : SyncEditor[T],
+  text : String,
+) -> Unit raise {
   let old_source = self.doc.text()
   let insert_start = self.cursor
   self.doc.insert(@text.Pos::at(self.cursor), text)
@@ -14,7 +17,7 @@ pub fn[T] SyncEditor::insert(self : SyncEditor[T], text : String) -> Unit raise 
 }
 
 ///|
-pub fn[T] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
   let old_source = self.doc.text()
   try self.doc.delete(@text.Pos::at(self.cursor)) catch {
     _ => false
@@ -31,7 +34,7 @@ pub fn[T] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
 }
 
 ///|
-pub fn[T] SyncEditor::backspace(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::backspace(self : SyncEditor[T]) -> Bool {
   if self.cursor > 0 {
     let old_source = self.doc.text()
     self.cursor = self.cursor - 1
@@ -99,7 +102,7 @@ fn[T] SyncEditor::apply_replace_span(
 }
 
 ///|
-pub fn[T] SyncEditor::apply_text_edit_internal(
+pub fn[T : Eq] SyncEditor::apply_text_edit_internal(
   self : SyncEditor[T],
   start : Int,
   deleted_len : Int,
@@ -143,7 +146,7 @@ pub fn[T] SyncEditor::apply_text_edit_internal(
 }
 
 ///|
-pub fn[T] SyncEditor::apply_text_edit(
+pub fn[T : Eq] SyncEditor::apply_text_edit(
   self : SyncEditor[T],
   start : Int,
   deleted_len : Int,
@@ -168,7 +171,10 @@ pub fn[T] SyncEditor::apply_text_edit(
 /// `insert` / `insert_and_record` methods which create proper interleaving
 /// points. See `resolve_applied_edit` in `sync_editor_parser.mbt` for how
 /// the cursor adjustment layer compensates for this divergence.
-pub fn[T] SyncEditor::set_text(self : SyncEditor[T], new_text : String) -> Unit {
+pub fn[T : Eq] SyncEditor::set_text(
+  self : SyncEditor[T],
+  new_text : String,
+) -> Unit {
   let old_text = self.doc.text()
   if old_text == new_text {
     return
@@ -187,7 +193,7 @@ pub fn[T] SyncEditor::set_text(self : SyncEditor[T], new_text : String) -> Unit 
 ///|
 /// Insert text at a specific position without moving the cursor.
 /// Records the operation for undo. Used by ProseMirror bridge.
-pub fn[T] SyncEditor::insert_at(
+pub fn[T : Eq] SyncEditor::insert_at(
   self : SyncEditor[T],
   position : Int,
   text : String,
@@ -204,7 +210,7 @@ pub fn[T] SyncEditor::insert_at(
 /// Delete the character at a specific position without moving the cursor.
 /// Records the operation for undo. Returns false if position is out of bounds.
 /// Used by ProseMirror bridge.
-pub fn[T] SyncEditor::delete_at(
+pub fn[T : Eq] SyncEditor::delete_at(
   self : SyncEditor[T],
   position : Int,
   timestamp_ms : Int,
@@ -218,7 +224,7 @@ pub fn[T] SyncEditor::delete_at(
 }
 
 ///|
-pub fn[T] SyncEditor::set_text_and_record(
+pub fn[T : Eq] SyncEditor::set_text_and_record(
   self : SyncEditor[T],
   new_text : String,
   timestamp_ms : Int,

--- a/editor/sync_editor_tree_edit.mbt
+++ b/editor/sync_editor_tree_edit.mbt
@@ -18,7 +18,7 @@ pub fn[T] SyncEditor::is_dirty(self : SyncEditor[T]) -> Bool {
 /// inside a getter.
 pub fn[T] SyncEditor::refresh(self : SyncEditor[T]) -> Unit {
   self.projection_dirty = false
-  let _ = self.parser_rt.read(self.cached_proj_node)
+  let _ = self.parser.runtime().read(self.cached_proj_node)
 }
 
 ///|
@@ -26,7 +26,7 @@ pub fn[T] SyncEditor::refresh(self : SyncEditor[T]) -> Unit {
 /// Uses T::placeholder(node.kind) so deletion leaves a parseable hole.
 ///
 /// Example: deleting `(f x)` in lambda → leaves `?`
-pub fn[T : @loom_core.Renderable] SyncEditor::delete_node(
+pub fn[T : Eq + @loom_core.Renderable] SyncEditor::delete_node(
   self : SyncEditor[T],
   node_id : @core.NodeId,
   timestamp_ms : Int,
@@ -64,7 +64,7 @@ pub fn[T : @loom_core.Renderable] SyncEditor::delete_node(
 /// providing syntactically valid replacement text.
 ///
 /// Example: committing an inline rename edit.
-pub fn[T] SyncEditor::commit_edit(
+pub fn[T : Eq] SyncEditor::commit_edit(
   self : SyncEditor[T],
   node_id : @core.NodeId,
   new_text : String,
@@ -98,7 +98,7 @@ pub fn[T] SyncEditor::commit_edit(
 ///   editor.apply_text_transform(node_id, fn(src, s, e) {
 ///     Ok("(λx. " + src[s:e].to_string() + ")")
 ///   }, timestamp)
-pub fn[T] SyncEditor::apply_text_transform(
+pub fn[T : Eq] SyncEditor::apply_text_transform(
   self : SyncEditor[T],
   node_id : @core.NodeId,
   compute_replacement : (String, Int, Int) -> Result[String, String],
@@ -144,7 +144,7 @@ pub fn[T] SyncEditor::apply_text_transform(
 /// in the document (deletion shifts subsequent offsets backward by
 /// `source_len - placeholder_len`). apply_span_edits handles this via
 /// reverse-order application.
-pub fn[T : @loom_core.Renderable] SyncEditor::move_node(
+pub fn[T : Eq + @loom_core.Renderable] SyncEditor::move_node(
   self : SyncEditor[T],
   source_id : @core.NodeId,
   target_id : @core.NodeId,

--- a/editor/sync_editor_undo.mbt
+++ b/editor/sync_editor_undo.mbt
@@ -1,7 +1,7 @@
 // Undo integration for SyncEditor.
 
 ///|
-pub fn[T] SyncEditor::insert_and_record(
+pub fn[T : Eq] SyncEditor::insert_and_record(
   self : SyncEditor[T],
   text : String,
   timestamp_ms : Int,
@@ -23,7 +23,7 @@ pub fn[T] SyncEditor::insert_and_record(
 }
 
 ///|
-pub fn[T] SyncEditor::delete_and_record(
+pub fn[T : Eq] SyncEditor::delete_and_record(
   self : SyncEditor[T],
   timestamp_ms : Int,
 ) -> Bool {
@@ -46,7 +46,7 @@ pub fn[T] SyncEditor::delete_and_record(
 }
 
 ///|
-pub fn[T] SyncEditor::backspace_and_record(
+pub fn[T : Eq] SyncEditor::backspace_and_record(
   self : SyncEditor[T],
   timestamp_ms : Int,
 ) -> Bool {
@@ -75,7 +75,7 @@ pub fn[T] SyncEditor::backspace_and_record(
 }
 
 ///|
-pub fn[T] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
   let old_source = self.doc.text()
   try {
     self.undo.undo(self.doc)
@@ -90,7 +90,7 @@ pub fn[T] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
 }
 
 ///|
-pub fn[T] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
+pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
   let old_source = self.doc.text()
   try {
     self.undo.redo(self.doc)
@@ -107,7 +107,7 @@ pub fn[T] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
 ///|
 /// Undo and return a SyncMessage containing the inverse ops for peer broadcast.
 /// Returns None if undo stack is empty or undo fails.
-pub fn[T] SyncEditor::undo_and_export(
+pub fn[T : Eq] SyncEditor::undo_and_export(
   self : SyncEditor[T],
 ) -> @text.SyncMessage? {
   let ver_before = self.doc.version()
@@ -133,7 +133,7 @@ pub fn[T] SyncEditor::undo_and_export(
 ///|
 /// Redo and return a SyncMessage containing the ops for peer broadcast.
 /// Returns None if redo stack is empty or redo fails.
-pub fn[T] SyncEditor::redo_and_export(
+pub fn[T : Eq] SyncEditor::redo_and_export(
   self : SyncEditor[T],
 ) -> @text.SyncMessage? {
   let ver_before = self.doc.version()

--- a/editor/sync_editor_ws.mbt
+++ b/editor/sync_editor_ws.mbt
@@ -74,7 +74,10 @@ pub fn[T] SyncEditor::ws_on_open(
 }
 
 ///|
-pub fn[T] SyncEditor::ws_on_message(self : SyncEditor[T], data : Bytes) -> Unit {
+pub fn[T : Eq] SyncEditor::ws_on_message(
+  self : SyncEditor[T],
+  data : Bytes,
+) -> Unit {
   let msg = match decode_message_result(data) {
     Ok(m) => m
     Err(_) => return

--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -48,8 +48,7 @@ pub fn get_diagnostics_json(handle : Int) -> String {
       // the AST is incomplete and type errors would just be noise on top of
       // the parse error.
       if parse_errors.is_empty() {
-        h.typecheck.text_signal.set(h.editor.get_text())
-        let result = h.typecheck.rt.read(h.typecheck.output)
+        let result = h.editor.parser_runtime().read(h.typecheck.output)
         for diag in result.all_diagnostics {
           let m : Map[String, Json] = {}
           m["level"] = "error".to_json()

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -10,38 +10,31 @@ priv struct LambdaHandle {
 }
 
 ///|
-/// Standalone runtime that drives the typecheck pipeline incrementally
-/// off the editor's text. Kept separate from the editor's runtime because
-/// LambdaCompanion does not expose its runtime to FFI.
+/// Typecheck pipeline memos; `scope` disposal only — the underlying
+/// `Runtime` is owned by the editor's `Parser`.
 priv struct TypecheckBundle {
-  rt : @cells.Runtime
   scope : @cells.Scope
-  text_signal : @cells.Signal[String]
   output : @cells.Memo[@typecheck.ModuleTypeResult]
 }
 
 ///|
-fn new_typecheck_bundle() -> TypecheckBundle {
-  let rt = @cells.Runtime::new()
+fn new_typecheck_bundle(
+  rt : @cells.Runtime,
+  syntax_tree : @cells.Memo[@seam.SyntaxNode?],
+) -> TypecheckBundle {
   let scope = @cells.Scope::new(rt)
-  let text_signal = scope.signal("", label="lambda-typecheck-text")
   let typed_term_memo : @cells.Memo[@typecheck.TypedTerm] = scope.memo(
     fn() {
-      let text = text_signal.get()
-      // parse_cst preserves `: Type` annotations on the CST. Parse
-      // diagnostics (lex errors, recoverable syntax errors) are surfaced
-      // separately via editor.get_errors() — get_diagnostics_json() only
-      // reads this memo when parse errors are empty, so we drop the
-      // diagnostics array here.
-      let (cst, _) = @lambda_lang.parse_cst(text) catch {
-        _ => return @typecheck.TypedTerm::Error("parse")
+      // `None` = lex error; must stay non-aborting so later edits recover.
+      match syntax_tree.get() {
+        Some(syntax) => @typecheck.convert_from_cst(syntax)
+        None => @typecheck.TypedTerm::Error("parse")
       }
-      @typecheck.convert_from_cst(@seam.SyntaxNode::from_cst(cst))
     },
     label="lambda-typed-term",
   )
   let output = @typecheck.build_typecheck_pipeline(rt, scope, typed_term_memo)
-  { rt, scope, text_signal, output }
+  { scope, output }
 }
 
 ///|
@@ -89,7 +82,10 @@ pub fn create_editor(agent_id : String) -> Int {
   lambda_handles[handle] = {
     editor,
     companion,
-    typecheck: new_typecheck_bundle(),
+    typecheck: new_typecheck_bundle(
+      editor.parser_runtime(),
+      editor.parser_syntax_tree(),
+    ),
   }
   last_created_handle.val = Some(handle)
   handle

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -4,7 +4,6 @@ import {
   "dowdiness/canopy/llm" @llm,
   "dowdiness/canopy/relay",
   "dowdiness/lambda/ast" @ast,
-  "dowdiness/lambda" @lambda_lang,
   "dowdiness/lambda/typecheck" @typecheck,
   "dowdiness/seam" @seam,
   "dowdiness/incr/cells" @cells,

--- a/ffi/lambda/undo.mbt
+++ b/ffi/lambda/undo.mbt
@@ -17,7 +17,10 @@ pub fn create_editor_with_undo(
   lambda_handles[handle] = {
     editor,
     companion,
-    typecheck: new_typecheck_bundle(),
+    typecheck: new_typecheck_bundle(
+      editor.parser_runtime(),
+      editor.parser_syntax_tree(),
+    ),
   }
   last_created_handle.val = Some(handle)
   handle

--- a/lang/json/companion/json_editor.mbt
+++ b/lang/json/companion/json_editor.mbt
@@ -9,7 +9,7 @@ pub fn new_json_editor(
 ) -> @editor.SyncEditor[@json.JsonValue] {
   @editor.SyncEditor::new_generic(
     agent_id,
-    fn(s) { @loom.new_imperative_parser(s, @json.json_grammar) },
+    fn(s) { @loom.new_parser(s, @json.json_grammar) },
     @json_proj.build_json_projection_memos,
     capture_timeout_ms~,
   )

--- a/lang/json/pkg.generated.mbti
+++ b/lang/json/pkg.generated.mbti
@@ -5,7 +5,7 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/json/edits",
   "dowdiness/incr/cells",
-  "dowdiness/loom/incremental",
+  "dowdiness/loom/pipeline",
   "dowdiness/seam",
   "moonbitlang/core/ref",
 }
@@ -13,7 +13,7 @@ import {
 // Values
 pub fn apply_json_edit(@editor.SyncEditor[@dowdiness/json.JsonValue], @edits.JsonEditOp, Int) -> Result[Unit, String]
 
-pub fn build_json_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@dowdiness/json.JsonValue]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
+pub fn build_json_projection_memos(@pipeline.Parser[@dowdiness/json.JsonValue]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
 
 pub fn compute_json_edit(@edits.JsonEditOp, String, @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue], @dowdiness/canopy/core.SourceMap) -> Result[(Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint)?, String]
 

--- a/lang/json/proj/json_memo.mbt
+++ b/lang/json/proj/json_memo.mbt
@@ -3,18 +3,15 @@
 
 ///|
 pub fn build_json_projection_memos(
-  rt : @incr.Runtime,
-  _source_text : @incr.Signal[String],
-  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
-  _parser : @loom.ImperativeParser[@json.JsonValue],
+  parser : @loom.Parser[@json.JsonValue],
 ) -> (
   @incr.Memo[ProjNode[@json.JsonValue]?],
   @incr.Memo[Map[NodeId, ProjNode[@json.JsonValue]]],
   @incr.Memo[SourceMap],
 ) {
   @core.build_projection_memos(
-    rt,
-    syntax_tree,
+    parser.runtime(),
+    parser.syntax_tree(),
     syntax_to_proj_node,
     populate_token_spans,
     label="json",

--- a/lang/json/proj/pkg.generated.mbti
+++ b/lang/json/proj/pkg.generated.mbti
@@ -4,13 +4,13 @@ package "dowdiness/canopy/lang/json/proj"
 import {
   "dowdiness/incr/cells",
   "dowdiness/json",
-  "dowdiness/loom/incremental",
+  "dowdiness/loom/pipeline",
   "dowdiness/seam",
   "moonbitlang/core/ref",
 }
 
 // Values
-pub fn build_json_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@json.JsonValue]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@json.JsonValue]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@json.JsonValue]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
+pub fn build_json_projection_memos(@pipeline.Parser[@json.JsonValue]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@json.JsonValue]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@json.JsonValue]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
 
 pub fn key_role(Int) -> String
 

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -91,13 +91,11 @@ pub fn new_lambda_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
 ) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
-  // Ref side-channels to capture memos and runtime from build_memos callback.
-  // Safe: new_generic calls build_memos during construction, before returning.
+  // Ref side-channels let the build_memos callback publish extra memos
+  // (beyond the 3-tuple SyncEditor expects) and the runtime back out to
+  // the enclosing scope for companion construction + capabilities wiring.
   let rt_ref : Ref[@incr.Runtime?] = Ref::new(None)
   let proj_memo_ref : Ref[@incr.Memo[@lambda_flat.VersionedFlatProj]?] = Ref::new(
-    None,
-  )
-  let eval_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?] = Ref::new(
     None,
   )
   let escalation_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?] = Ref::new(
@@ -108,19 +106,18 @@ pub fn new_lambda_editor(
   )
   let editor = @editor.SyncEditor::new_generic(
     agent_id,
-    fn(s) { @loom.new_imperative_parser(s, @parser.lambda_grammar) },
-    fn(rt, source_text, syntax_tree, parser) {
-      rt_ref.val = Some(rt)
+    fn(s) { @loom.new_parser(s, @parser.lambda_grammar) },
+    fn(parser) {
+      rt_ref.val = Some(parser.runtime())
       let (proj_memo, cached_proj_node, registry_memo, source_map_memo) = @lambda_flat.build_lambda_projection_memos(
-        rt, source_text, syntax_tree, parser,
+        parser,
       )
       proj_memo_ref.val = Some(proj_memo)
       cached_proj_node_ref.val = Some(cached_proj_node)
-      let eval_memo = @lambda_eval.build_eval_memo(rt, syntax_tree, parser)
-      eval_memo_ref.val = Some(eval_memo)
+      let eval_memo = @lambda_eval.build_eval_memo(parser)
       // Escalation memo: merges Tier 1 + Tier 2 for incomplete programs
       let escalation_memo = @lambda_eval.build_escalation_memo(
-        rt, eval_memo, syntax_tree, parser,
+        parser, eval_memo,
       )
       escalation_memo_ref.val = Some(escalation_memo)
       (cached_proj_node, registry_memo, source_map_memo)

--- a/lang/lambda/eval/batch_escalation.mbt
+++ b/lang/lambda/eval/batch_escalation.mbt
@@ -30,22 +30,18 @@ priv struct DefState {
 /// returns Tier 1 results directly (fast path). Otherwise, runs
 /// batch egglog evaluation for suppressed definitions.
 pub fn build_escalation_memo(
-  rt : @incr.Runtime,
+  parser : @loom.Parser[@ast.Term],
   eval_memo : @incr.Memo[Array[EvalResult]],
-  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
-  parser : @loom.ImperativeParser[@ast.Term],
 ) -> @incr.Memo[Array[EvalResult]] {
   @incr.Memo::new_no_backdate(
-    rt,
+    parser.runtime(),
     fn() -> Array[EvalResult] {
       let tier1_results = eval_memo.get()
       // Fast path: no suppressed results → no escalation needed
       guard tier1_results.iter().any(fn(r) { r == Suppressed }) else {
         return tier1_results
       }
-      // Need syntax_tree dependency for reactive tracking
-      let _ = syntax_tree.get()
-      let ast = parser.get_tree().unwrap_or(@ast.Term::Unit)
+      let ast = parser.ast().get()
       escalate_suppressed(ast, tier1_results)
     },
     label="escalation_memo",

--- a/lang/lambda/eval/eval_memo.mbt
+++ b/lang/lambda/eval/eval_memo.mbt
@@ -204,16 +204,13 @@ fn fill_suppressed(
 ///   is preserved, preventing downstream memos (escalation, projection) from
 ///   recomputing unnecessarily.
 pub fn build_eval_memo(
-  rt : @incr.Runtime,
-  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
-  parser : @loom.ImperativeParser[@ast.Term],
+  parser : @loom.Parser[@ast.Term],
 ) -> @incr.Memo[Array[EvalResult]] {
   let cache : Ref[Array[CachedDef]] = Ref::new([])
   @incr.Memo::new(
-    rt,
+    parser.runtime(),
     fn() -> Array[EvalResult] {
-      let _ = syntax_tree.get()
-      let ast = parser.get_tree().unwrap_or(@ast.Term::Unit)
+      let ast = parser.ast().get()
       let (results, new_cache) = eval_term_cached(ast, cache.val)
       cache.val = new_cache
       results

--- a/lang/lambda/eval/moon.pkg
+++ b/lang/lambda/eval/moon.pkg
@@ -7,6 +7,5 @@ import {
   "dowdiness/lambda/eval" @lambda_eval,
   "dowdiness/loom" @loom,
   "dowdiness/pretty" @pretty,
-  "dowdiness/seam" @seam,
   "moonbitlang/core/debug",
 }

--- a/lang/lambda/eval/pkg.generated.mbti
+++ b/lang/lambda/eval/pkg.generated.mbti
@@ -5,16 +5,15 @@ import {
   "dowdiness/egglog/src",
   "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
-  "dowdiness/loom/incremental",
+  "dowdiness/loom/pipeline",
   "dowdiness/pretty",
-  "dowdiness/seam",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn build_escalation_memo(@cells.Runtime, @cells.Memo[Array[EvalResult]], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> @cells.Memo[Array[EvalResult]]
+pub fn build_escalation_memo(@pipeline.Parser[@ast.Term], @cells.Memo[Array[EvalResult]]) -> @cells.Memo[Array[EvalResult]]
 
-pub fn build_eval_memo(@cells.Runtime, @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> @cells.Memo[Array[EvalResult]]
+pub fn build_eval_memo(@pipeline.Parser[@ast.Term]) -> @cells.Memo[Array[EvalResult]]
 
 pub fn eval_annotation_layout(EvalResult) -> @pretty.Layout[@pretty.SyntaxCategory]?
 

--- a/lang/lambda/flat/pkg.generated.mbti
+++ b/lang/lambda/flat/pkg.generated.mbti
@@ -7,12 +7,11 @@ import {
   "dowdiness/incr/cells",
   "dowdiness/incr/types",
   "dowdiness/lambda/ast",
-  "dowdiness/loom/incremental",
-  "dowdiness/seam",
+  "dowdiness/loom/pipeline",
 }
 
 // Values
-pub fn build_lambda_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> (@cells.Memo[VersionedFlatProj], @cells.Memo[@core.ProjNode[@ast.Term]?], @cells.Memo[Map[@core.NodeId, @core.ProjNode[@ast.Term]]], @cells.Memo[@core.SourceMap])
+pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term]) -> (@cells.Memo[VersionedFlatProj], @cells.Memo[@core.ProjNode[@ast.Term]?], @cells.Memo[Map[@core.NodeId, @core.ProjNode[@ast.Term]]], @cells.Memo[@core.SourceMap])
 
 // Errors
 

--- a/lang/lambda/flat/projection_memo.mbt
+++ b/lang/lambda/flat/projection_memo.mbt
@@ -7,16 +7,16 @@
 /// Lambda-specific memo builder — wraps the lambda-specific FlatProj pipeline
 /// and produces ProjNode[@ast.Term] memos for the SyncEditor constructor.
 pub fn build_lambda_projection_memos(
-  rt : @incr.Runtime,
-  source_text : @incr.Signal[String],
-  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
-  _parser : @loom.ImperativeParser[@ast.Term],
+  parser : @loom.Parser[@ast.Term],
 ) -> (
   @incr.Memo[VersionedFlatProj],
   @incr.Memo[@core.ProjNode[@ast.Term]?],
   @incr.Memo[Map[@core.NodeId, @core.ProjNode[@ast.Term]]],
   @incr.Memo[@core.SourceMap],
 ) {
+  let rt = parser.runtime()
+  let source_text = parser.source()
+  let syntax_tree = parser.syntax_tree()
   let prev_flat_proj_ref : Ref[@lambda_proj.FlatProj?] = Ref::new(None)
   let prev_syntax_root_ref : Ref[@seam.SyntaxNode?] = Ref::new(None)
   let next_id_ref : Ref[Int] = Ref::new(0)

--- a/lang/lambda/pkg.generated.mbti
+++ b/lang/lambda/pkg.generated.mbti
@@ -10,7 +10,7 @@ import {
   "dowdiness/canopy/lang/lambda/proj",
   "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
-  "dowdiness/loom/incremental",
+  "dowdiness/loom/pipeline",
   "dowdiness/pretty",
   "dowdiness/seam",
   "moonbitlang/core/immut/hashset",
@@ -20,9 +20,9 @@ import {
 // Values
 pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Unit, @editor.TreeEditError]
 
-pub fn build_eval_memo(@cells.Runtime, @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> @cells.Memo[Array[@eval.EvalResult]]
+pub fn build_eval_memo(@pipeline.Parser[@ast.Term]) -> @cells.Memo[Array[@eval.EvalResult]]
 
-pub fn build_lambda_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@ast.Term]) -> (@cells.Memo[@flat.VersionedFlatProj], @cells.Memo[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
+pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term]) -> (@cells.Memo[@flat.VersionedFlatProj], @cells.Memo[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
 
 pub fn collect_lam_env(@dowdiness/canopy/core.NodeId, Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]) -> @hashset.HashSet[String]
 

--- a/lang/markdown/companion/markdown_editor.mbt
+++ b/lang/markdown/companion/markdown_editor.mbt
@@ -7,7 +7,7 @@ pub fn new_markdown_editor(
 ) -> @editor.SyncEditor[@markdown.Block] {
   @editor.SyncEditor::new_generic(
     agent_id,
-    fn(s) { @loom.new_imperative_parser(s, @markdown.markdown_grammar) },
+    fn(s) { @loom.new_parser(s, @markdown.markdown_grammar) },
     @md_proj.build_markdown_projection_memos,
     capture_timeout_ms~,
   )

--- a/lang/markdown/proj/markdown_memo.mbt
+++ b/lang/markdown/proj/markdown_memo.mbt
@@ -2,18 +2,15 @@
 
 ///|
 pub fn build_markdown_projection_memos(
-  rt : @incr.Runtime,
-  _source_text : @incr.Signal[String],
-  syntax_tree : @incr.Signal[@seam.SyntaxNode?],
-  _parser : @loom.ImperativeParser[@markdown.Block],
+  parser : @loom.Parser[@markdown.Block],
 ) -> (
   @incr.Memo[@core.ProjNode[@markdown.Block]?],
   @incr.Memo[Map[@core.NodeId, @core.ProjNode[@markdown.Block]]],
   @incr.Memo[@core.SourceMap],
 ) {
   @core.build_projection_memos(
-    rt,
-    syntax_tree,
+    parser.runtime(),
+    parser.syntax_tree(),
     syntax_to_proj_node,
     populate_token_spans,
     label="markdown",

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -3,14 +3,14 @@ package "dowdiness/canopy/lang/markdown/proj"
 
 import {
   "dowdiness/incr/cells",
-  "dowdiness/loom/incremental",
+  "dowdiness/loom/pipeline",
   "dowdiness/markdown",
   "dowdiness/seam",
   "moonbitlang/core/ref",
 }
 
 // Values
-pub fn build_markdown_projection_memos(@cells.Runtime, @cells.Signal[String], @cells.Signal[@seam.SyntaxNode?], @incremental.ImperativeParser[@markdown.Block]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
+pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
 
 pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
 


### PR DESCRIPTION
## Summary

Stage 4 of the [unified parser plan](https://github.com/dowdiness/loom/blob/main/docs/plans/2026-04-17-unified-parser.md). Replaces \`SyncEditor\`'s \`@loom.ImperativeParser[T]\` + two manually-driven \`Signal\` fields + separate \`Runtime\` with a single \`@loom.Parser[T]\` handle.

- **Editor core**: \`SyncEditor\` now owns one \`Parser[T]\`. \`new_generic\` takes \`make_parser: (String) -> Parser[T]\` and a simpler \`build_memos: (Parser[T]) -> (…)\` callback. Two narrow accessors (\`parser_runtime\`, \`parser_syntax_tree\`) let downstream consumers join the shared reactive graph without exposing the mutation surface.
- **Lang companions** (json, markdown, lambda) construct via \`@loom.new_parser\`. Lambda's eval/escalation memos read \`parser.ast().get()\` directly instead of the previous \`syntax_tree.get()\` (track) + \`parser.get_tree()\` (value) split.
- **FFI TypecheckBundle**: drops its private \`Runtime\` + \`Scope\` + \`text_signal\` and subscribes to \`editor.parser_syntax_tree()\` on the shared runtime — **removes the double parse** that motivated ADR 2026-04-17.
- Loom submodule bumped to Stage 3 tip (\`6a6c8f3\`) to pick up \`Parser[Ast]\`.

\`T : Eq\` is added only to methods that transitively call \`Parser::set_source\` / \`Parser::apply_edit\` (text mutation, apply_sync, undo/redo, tree edits). Pure accessors stay unconstrained.

## Test plan

- [x] \`moon check\` clean across all packages (0 warnings, 0 errors)
- [x] \`moon test\` — 908/908 passing (same count as baseline)
- [x] \`moon info && moon fmt\` — \`.mbti\` regenerated; changes match the intended API surface (\`new_generic\` signature, Eq bounds on mutation methods, two new accessors)
- [x] \`moon build --target js\` succeeds
- [ ] Manual smoke test of web demo (lambda editor: type, typecheck diagnostics, eval annotations, undo/redo) — please verify on review
- [ ] Stages 5–6 of the unified parser plan (deprecate + remove \`ReactiveParser\`) are follow-ups, not in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parser architecture and reactive dependency handling for improved performance and maintainability
  * Enhanced caching mechanisms across the editor and supported languages (JSON, Lambda, Markdown)
  * Streamlined internal infrastructure for better code organization and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->