### PR TITLE
refactor(editor-adapter): convert to @canopy/editor-adapter npm package

### DIFF
--- a/adapters/editor-adapter/package.json
+++ b/adapters/editor-adapter/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@canopy/editor-adapter",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "UI adapters bridging Canopy's ViewPatch protocol to DOM/CodeMirror/ProseMirror renderers.",
+  "exports": {
+    ".": "./index.ts",
+    "./adapter": "./adapter.ts",
+    "./types": "./types.ts",
+    "./html-adapter": "./html-adapter.ts",
+    "./cm6-adapter": "./cm6-adapter.ts",
+    "./pm-adapter": "./pm-adapter.ts",
+    "./markdown-preview": "./markdown-preview.ts",
+    "./block-input": "./block-input.ts",
+    "./block-input.css": "./block-input.css",
+    "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "@codemirror/commands": "^6.10.0",
+    "@codemirror/language": "^6.10.0",
+    "@codemirror/state": "^6.5.0",
+    "@codemirror/view": "^6.35.0",
+    "prosemirror-commands": "^1.6.0",
+    "prosemirror-keymap": "^1.2.0",
+    "prosemirror-model": "^1.24.0",
+    "prosemirror-state": "^1.4.0",
+    "prosemirror-transform": "^1.10.0",
+    "prosemirror-view": "^1.37.0"
+  },
+  "peerDependenciesMeta": {
+    "@codemirror/commands": { "optional": true },
+    "@codemirror/language": { "optional": true },
+    "@codemirror/state": { "optional": true },
+    "@codemirror/view": { "optional": true },
+    "prosemirror-commands": { "optional": true },
+    "prosemirror-keymap": { "optional": true },
+    "prosemirror-model": { "optional": true },
+    "prosemirror-state": { "optional": true },
+    "prosemirror-transform": { "optional": true },
+    "prosemirror-view": { "optional": true }
+  }
+}

--- a/examples/prosemirror/package-lock.json
+++ b/examples/prosemirror/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "crdt-prosemirror",
       "dependencies": {
+        "@canopy/editor-adapter": "file:../../adapters/editor-adapter",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.10.0",
         "@codemirror/state": "^6.5.0",
@@ -21,6 +22,58 @@
         "typescript": "^5.7.0",
         "vite": "^6.0.0"
       }
+    },
+    "../../adapters/editor-adapter": {
+      "name": "@canopy/editor-adapter",
+      "version": "0.0.0",
+      "peerDependencies": {
+        "@codemirror/commands": "^6.10.0",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "prosemirror-commands": "^1.6.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.24.0",
+        "prosemirror-state": "^1.4.0",
+        "prosemirror-transform": "^1.10.0",
+        "prosemirror-view": "^1.37.0"
+      },
+      "peerDependenciesMeta": {
+        "@codemirror/commands": {
+          "optional": true
+        },
+        "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/state": {
+          "optional": true
+        },
+        "@codemirror/view": {
+          "optional": true
+        },
+        "prosemirror-commands": {
+          "optional": true
+        },
+        "prosemirror-keymap": {
+          "optional": true
+        },
+        "prosemirror-model": {
+          "optional": true
+        },
+        "prosemirror-state": {
+          "optional": true
+        },
+        "prosemirror-transform": {
+          "optional": true
+        },
+        "prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@canopy/editor-adapter": {
+      "resolved": "../../adapters/editor-adapter",
+      "link": true
     },
     "node_modules/@codemirror/commands": {
       "version": "6.10.3",

--- a/examples/prosemirror/package.json
+++ b/examples/prosemirror/package.json
@@ -7,6 +7,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@canopy/editor-adapter": "file:../../adapters/editor-adapter",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.10.0",
     "@codemirror/state": "^6.5.0",

--- a/examples/prosemirror/src/keymap.ts
+++ b/examples/prosemirror/src/keymap.ts
@@ -1,6 +1,6 @@
 import { keymap } from "prosemirror-keymap";
 import { NodeSelection } from "prosemirror-state";
-import type { UserIntent } from "../../../adapters/editor-adapter";
+import type { UserIntent } from "@canopy/editor-adapter";
 
 /**
  * ProseMirror keymap plugin for structural operations on AST nodes.

--- a/examples/prosemirror/src/main.ts
+++ b/examples/prosemirror/src/main.ts
@@ -2,8 +2,8 @@
 
 import * as crdt from "@moonbit/canopy";
 import { EditorState as PmState } from "prosemirror-state";
-import { PMAdapter } from "../../../adapters/editor-adapter";
-import type { ViewPatch, ViewNode, UserIntent } from "../../../adapters/editor-adapter";
+import { PMAdapter } from "@canopy/editor-adapter";
+import type { ViewPatch, ViewNode, UserIntent } from "@canopy/editor-adapter";
 import { connectWebSocket } from "./ws-glue";
 import { structuralKeymap } from "./keymap";
 

--- a/examples/prosemirror/tsconfig.json
+++ b/examples/prosemirror/tsconfig.json
@@ -7,21 +7,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "baseUrl": ".",
+    "preserveSymlinks": true,
     "paths": {
-      "@moonbit/canopy": ["../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.d.ts"],
-      "prosemirror-view": ["node_modules/prosemirror-view"],
-      "prosemirror-state": ["node_modules/prosemirror-state"],
-      "prosemirror-model": ["node_modules/prosemirror-model"],
-      "prosemirror-transform": ["node_modules/prosemirror-transform"],
-      "prosemirror-keymap": ["node_modules/prosemirror-keymap"],
-      "prosemirror-commands": ["node_modules/prosemirror-commands"],
-      "@codemirror/state": ["node_modules/@codemirror/state"],
-      "@codemirror/view": ["node_modules/@codemirror/view"],
-      "@codemirror/language": ["node_modules/@codemirror/language"],
-      "@codemirror/commands": ["node_modules/@codemirror/commands"]
+      "@moonbit/canopy": ["../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.d.ts"]
     }
   },
-  "include": ["src", "../../adapters/editor-adapter"],
+  "include": ["src"],
   "exclude": ["node_modules", "../../_build"]
 }

--- a/examples/prosemirror/vite.config.ts
+++ b/examples/prosemirror/vite.config.ts
@@ -14,8 +14,10 @@ export default defineConfig({
     }) as PluginOption
   ],
   resolve: {
-    // Ensure packages imported by adapters/editor-adapter/ (which lives
-    // outside this project's node_modules tree) resolve from here.
+    // @canopy/editor-adapter is symlinked into node_modules; vite realpaths
+    // through the symlink, so dedupe is still needed to pin prosemirror/*
+    // and @codemirror/* to this project's copies rather than the adapter's
+    // (nonexistent) node_modules.
     dedupe: [
       'prosemirror-commands',
       'prosemirror-keymap',

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lambda-crdt-editor",
       "version": "0.1.0",
       "dependencies": {
+        "@canopy/editor-adapter": "file:../../adapters/editor-adapter",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -18,6 +19,58 @@
         "typescript": "^6.0.2",
         "vite": "^8.0.3"
       }
+    },
+    "../../adapters/editor-adapter": {
+      "name": "@canopy/editor-adapter",
+      "version": "0.0.0",
+      "peerDependencies": {
+        "@codemirror/commands": "^6.10.0",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "prosemirror-commands": "^1.6.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.24.0",
+        "prosemirror-state": "^1.4.0",
+        "prosemirror-transform": "^1.10.0",
+        "prosemirror-view": "^1.37.0"
+      },
+      "peerDependenciesMeta": {
+        "@codemirror/commands": {
+          "optional": true
+        },
+        "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/state": {
+          "optional": true
+        },
+        "@codemirror/view": {
+          "optional": true
+        },
+        "prosemirror-commands": {
+          "optional": true
+        },
+        "prosemirror-keymap": {
+          "optional": true
+        },
+        "prosemirror-model": {
+          "optional": true
+        },
+        "prosemirror-state": {
+          "optional": true
+        },
+        "prosemirror-transform": {
+          "optional": true
+        },
+        "prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@canopy/editor-adapter": {
+      "resolved": "../../adapters/editor-adapter",
+      "link": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -10,6 +10,7 @@
     "signaling": "node signaling-server.js"
   },
   "dependencies": {
+    "@canopy/editor-adapter": "file:../../adapters/editor-adapter",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/examples/web/src/editor.ts
+++ b/examples/web/src/editor.ts
@@ -2,8 +2,8 @@
 
 import * as crdt from '@moonbit/crdt-lambda';
 import * as graphviz from '@moonbit/graphviz';
-import { HTMLAdapter } from '../../../adapters/editor-adapter/html-adapter';
-import type { ViewPatch } from '../../../adapters/editor-adapter/types';
+import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
+import type { ViewPatch } from '@canopy/editor-adapter/types';
 
 export function createEditor(agentId: string) {
   const handle = crdt.create_editor(agentId);

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -1,6 +1,6 @@
 import * as crdt from '@moonbit/crdt-json';
-import { HTMLAdapter } from '../../../adapters/editor-adapter/html-adapter';
-import type { ViewPatch, ViewNode } from '../../../adapters/editor-adapter/types';
+import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
+import type { ViewPatch, ViewNode } from '@canopy/editor-adapter/types';
 
 type InlineMode = 'add-member' | 'wrap-object' | 'change-type' | null;
 

--- a/examples/web/src/markdown-editor.ts
+++ b/examples/web/src/markdown-editor.ts
@@ -1,10 +1,10 @@
 // Markdown Block Editor — three-mode page wiring FFI → adapters.
 
 import * as crdt from '@moonbit/crdt-markdown';
-import { BlockInput } from '../../../adapters/editor-adapter/block-input';
-import { MarkdownPreview } from '../../../adapters/editor-adapter/markdown-preview';
-import '../../../adapters/editor-adapter/block-input.css';
-import type { ViewPatch, UserIntent } from '../../../adapters/editor-adapter/types';
+import { BlockInput } from '@canopy/editor-adapter/block-input';
+import { MarkdownPreview } from '@canopy/editor-adapter/markdown-preview';
+import '@canopy/editor-adapter/block-input.css';
+import type { ViewPatch, UserIntent } from '@canopy/editor-adapter/types';
 
 // ---------------------------------------------------------------------------
 // Constants


### PR DESCRIPTION
## Summary

Root-causes the tsc resolution workaround landed in #211. Makes `adapters/editor-adapter/` a proper npm package (`@canopy/editor-adapter`) so module resolution works naturally from consumers and no consumer tsconfig has to duplicate `paths` mappings.

## What changed

**`adapters/editor-adapter/package.json`** (new)
- `name: "@canopy/editor-adapter"`, `type: "module"`.
- `exports` map: barrel (`.`), per-file (`./adapter`, `./types`, `./html-adapter`, `./cm6-adapter`, `./pm-adapter`, `./markdown-preview`, `./block-input`), plus `./block-input.css`.
- `peerDependencies` for `prosemirror-*` and `@codemirror/*`, all marked optional via `peerDependenciesMeta` — each consumer uses only a subset of the adapter's surface and we don't want npm-install warnings for unused slices.

**Consumer wiring**
- `examples/web/package.json`, `examples/prosemirror/package.json`: add `"@canopy/editor-adapter": "file:../../adapters/editor-adapter"`. `npm install` creates `node_modules/@canopy/editor-adapter` as a symlink.
- `examples/prosemirror/tsconfig.json`: add `preserveSymlinks: true` so tsc keeps the symlinked path when resolving transitive imports (this is the key — without it, tsc follows realpath and fails to find peer deps). Drop the 10 `paths` entries and the `include` of `../../adapters/editor-adapter` that #211 needed as a workaround.
- `examples/prosemirror/vite.config.ts`: refresh the `resolve.dedupe` comment (vite follows realpath, so dedupe is still what pins prosemirror/* and @codemirror/* to this project's copies).

**Source rewrites**
- 5 source files + 1 CSS import: `'../../../adapters/editor-adapter/...'` → `'@canopy/editor-adapter/...'`.

## Verification

- [x] `npx tsc --noEmit` in `examples/prosemirror` — 0 errors (previously needed workaround to reach 0)
- [x] `npx tsc --noEmit` in `examples/web` — 0 errors
- [x] `npm run build` (vite) in `examples/prosemirror` — succeeds
- [x] `npm run build` (vite) in `examples/web` — succeeds, all 4 pages produced
- [ ] CI: Build Web Example, Demo React E2E, Web E2E, and all existing jobs

## Tradeoffs

- `preserveSymlinks: true` is a non-obvious knob but matches how the adapter is actually wired (no own `node_modules`; all peer deps come from the consumer's). Documented inline by the renamed vite-config comment.
- `file:` deps create lockfile noise (+53 lines per consumer) but establish a real package boundary without requiring repo-wide npm workspaces. Workspaces would hoist peer deps to a root `node_modules` and let us drop `preserveSymlinks`, but that's a larger change we can pursue separately if/when a root `package.json` is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `@canopy/editor-adapter` is now available as a standalone package with exports for multiple editor adapters, including HTML, CodeMirror 6, ProseMirror, and markdown editors.

* **Chores**
  * Updated example projects to reference the new editor adapter package structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->