### PR TITLE
chore(editor-adapter): publish as 0.1.0-alpha.0

### DIFF
--- a/adapters/editor-adapter/CHANGELOG.md
+++ b/adapters/editor-adapter/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `README.md` documenting the package boundary, public API stability tiers, wire-format invariants, and extension points.
-- `CHANGELOG.md` (this file).
 - `CM6Adapter` now applies `SetDiagnostics` patches as inline `cm-diagnostic cm-diagnostic-${severity}` marks with native-tooltip `title` and `data-severity` attributes. `static extensions()` returns the new diagnostic field + plugin alongside the decoration pair. (#227)
 
 ### Changed
 - `cm6-adapter.ts`: `DecorationSet` and `ViewUpdate` are now imported with `import type`, fixing the build for downstream TypeScript projects with `verbatimModuleSyntax: true` (a Vite/SvelteKit default).
 - `cm6-adapter.ts`: `PeerCursorWidget.{eq, toDOM, ignoreEvent}` now carry the `override` modifier, fixing the build for downstream projects with `noImplicitOverride: true`.
+
+## [0.1.0-alpha.0] - 2026-05-13
+
+### Added
+- `README.md` documenting the package boundary, public API stability tiers, wire-format invariants, and extension points.
+- `CHANGELOG.md` (this file).
 
 ## [0.0.0] - Initial
 


### PR DESCRIPTION
## Summary
- Drop `private: true` and bump editor-adapter to `0.1.0-alpha.0` so the package can be consumed by external projects.
- Add npm metadata (license, repository, homepage, bugs, keywords, files allowlist).
- Add README documenting the boundary, public API stability tiers, wire-format invariants, and extension points.
- Add CHANGELOG.

## Test plan
- [ ] `npm pack --dry-run` from `adapters/editor-adapter/` shows only the intended files.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline diagnostic marks with customizable severity levels and tooltips for enhanced error feedback.
  * Expanded editor extensions to support diagnostic functionality.

* **Bug Fixes**
  * Resolved TypeScript build configuration issues.

* **Documentation**
  * Introduced [Unreleased] changelog section documenting v0.1.0-alpha.0 features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/223)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->