### PR TITLE
feat(editor-adapter): implement SetDiagnostics in CM6Adapter (P1)

### DIFF
--- a/adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md
+++ b/adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md
@@ -18,7 +18,20 @@ loop. No type changes were needed. **`stable` exports earn the label.**
 
 The items below are gaps in the concrete adapter, not in the protocol.
 
-## P1 — `SetDiagnostics` is a no-op in `CM6Adapter`
+## P1 — `SetDiagnostics` is a no-op in `CM6Adapter` (resolved)
+
+**Resolved:** implemented in canopy after this doc landed. `SetDiagnostics`
+patches now dispatch a `StateEffect` into a `diagnosticField` /
+`diagnosticPlugin` pair (mirrors the existing decoration code), rendering
+each diagnostic as a CM6 `Decoration.mark` with class
+`cm-diagnostic cm-diagnostic-${severity}` and a native-tooltip
+`title`/`data-severity` attribute pair. No new dependency on
+`@codemirror/lint`. The `static extensions()` return now includes the
+new field + plugin so consumers get squigglies automatically.
+
+**Original report below for context.**
+
+
 
 **File:** `cm6-adapter.ts`, `applyPatch`
 
@@ -113,7 +126,7 @@ Without one of these, "two consumers on CI" can't actually be wired up.
 
 ## Concrete asks for `0.1.0-alpha.1`
 
-- [ ] P1 — implement `SetDiagnostics` in `CM6Adapter`
+- [x] P1 — implement `SetDiagnostics` in `CM6Adapter`
 - [ ] P2 — `import type` fix for `DecorationSet` + `ViewUpdate`
 - [ ] P3 — `override` modifier on `PeerCursorWidget` methods
 - [ ] P4 — decide: publish or drop `private: true`

--- a/adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md
+++ b/adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md
@@ -1,0 +1,123 @@
+# Feedback from moondsp integration
+
+Findings from integrating `@canopy/editor-adapter@0.1.0-alpha.0` into
+`dowdiness/moondsp` (live-coding REPL, phase A). The integration shipped
+green — these notes are the punch list for `0.1.0-alpha.1` based on
+real friction, not speculation.
+
+**Source of truth:** `dowdiness/moondsp` commit `e8bdbee`, vendor copy
+at `web/live/src/canopy/`. Diff against this package's `9df029d`
+captures the workarounds applied.
+
+## Headline: the contract held
+
+The `EditorProtocol` shape is right. Bringing up CM6 with the adapter
+on a non-Canopy engine (a wasm AudioWorklet) was straightforward, and
+the patch/intent split mapped cleanly onto a debounced-eval live-coding
+loop. No type changes were needed. **`stable` exports earn the label.**
+
+The items below are gaps in the concrete adapter, not in the protocol.
+
+## P1 — `SetDiagnostics` is a no-op in `CM6Adapter`
+
+**File:** `cm6-adapter.ts`, `applyPatch`
+
+```ts
+case "SelectNode":
+case "SetDiagnostics":
+  break;
+```
+
+`SetDiagnostics` is dropped on the floor. moondsp routes parse errors
+into a footer panel as a workaround; inline squigglies, hover messages,
+and gutter markers — the whole reason a `Diagnostic` type exists — are
+unreachable from any external consumer.
+
+**Suggested fix:** mirror the `setDecorations` pattern. Add a
+`StateField<Diagnostic[]>` plus a `ViewPlugin` that builds CM6
+`Decoration.mark` ranges with severity-namespaced classes
+(`cm-diagnostic-error`, `…-warning`, `…-info`, `…-hint`) and an
+`@codemirror/lint`-compatible source so existing CM6 lint UI lights up.
+
+**Cost to implement:** ~80 lines, mirrors the existing decoration code.
+**Cost of *not* implementing:** every consumer reinvents an error panel
+or a sibling decoration channel and the protocol's `Diagnostic` type
+becomes vestigial.
+
+## P2 — `verbatimModuleSyntax` breaks the build downstream
+
+**File:** `cm6-adapter.ts` lines 3–10
+
+```ts
+import {
+  EditorView,
+  Decoration as CmDecoration,
+  DecorationSet,    // type-only — value import errors with verbatimModuleSyntax
+  ViewPlugin,
+  ViewUpdate,       // type-only — same
+  WidgetType,
+} from "@codemirror/view";
+```
+
+`DecorationSet` and `ViewUpdate` are used only in type positions. Under
+`tsconfig`'s `verbatimModuleSyntax: true` (a recommended modern default,
+shipped by Vite/SvelteKit/etc.) this fails:
+
+> Type-only import of an external module is not allowed when …
+
+**Suggested fix:** split to `import type { DecorationSet, ViewUpdate }`.
+moondsp applied this in the vendor copy.
+
+## P3 — `noImplicitOverride` requires `override` on `WidgetType` subclass
+
+**File:** `cm6-adapter.ts`, `class PeerCursorWidget extends WidgetType`
+
+`eq`, `toDOM`, `ignoreEvent` override base methods but lack the
+`override` modifier. Under `noImplicitOverride: true` (also a common
+modern default) tsc fails:
+
+> This member must have an 'override' modifier because it overrides …
+
+**Suggested fix:** add `override` to all three. moondsp applied this in
+the vendor copy.
+
+## P4 — `private: true` blocks vendoring → install path until publish
+
+**File:** `package.json`
+
+The package is currently `private: true`. Even consumers willing to
+take a `file:../canopy/adapters/editor-adapter` dep run into npm
+refusing to install a private package without `workspaces` or
+`installPrivate` flags. moondsp went the vendor-copy route partly to
+sidestep this. Either:
+
+- **Publish to npm** (the path the README assumes), or
+- **Drop `private: true`** and rely on the `0.1.0-alpha.x` tag to
+  signal pre-stable. Local-path deps then work for sibling-checkout
+  monorepo setups.
+
+Without one of these, "two consumers on CI" can't actually be wired up.
+
+## Notes that aren't items
+
+- **Wire format**: `ViewPatch` and `UserIntent` were used unmodified.
+  No round-trip surprises.
+- **`createUpdateListener` ergonomics**: the "construct adapter, then
+  inject the listener via Compartment" dance worked but is a touch
+  awkward — a future API could let `CM6Adapter` own its compartment
+  and provide a `mount(parent, initialDoc, extras): EditorView`
+  helper. Not a blocker; flagged for the future shape.
+- **Decoration `data: "name|color"` pipe-encoding**: works but feels
+  like a string-typed escape hatch on `Decoration`. If more widget
+  metadata accrues, consider a typed widget-data union.
+
+## Concrete asks for `0.1.0-alpha.1`
+
+- [ ] P1 — implement `SetDiagnostics` in `CM6Adapter`
+- [ ] P2 — `import type` fix for `DecorationSet` + `ViewUpdate`
+- [ ] P3 — `override` modifier on `PeerCursorWidget` methods
+- [ ] P4 — decide: publish or drop `private: true`
+
+P2 + P3 are 1-line fixes each. P1 is the substantive item; P4 is the
+publish decision. moondsp's vendor copy can drop most local deltas the
+moment alpha.1 lands.

--- a/adapters/editor-adapter/cm6-adapter.ts
+++ b/adapters/editor-adapter/cm6-adapter.ts
@@ -10,7 +10,7 @@ import {
 } from "@codemirror/view";
 import { StateField, StateEffect, RangeSetBuilder } from "@codemirror/state";
 import type { EditorAdapter } from './adapter';
-import type { ViewPatch, UserIntent, Decoration } from './types';
+import type { ViewPatch, UserIntent, Decoration, Diagnostic } from './types';
 
 // ── Decoration state ────────────────────────────────────────
 
@@ -148,6 +148,77 @@ const decorationPlugin = ViewPlugin.fromClass(
   },
 );
 
+// ── Diagnostic state ────────────────────────────────────────
+
+const setDiagnostics = StateEffect.define<Diagnostic[]>();
+
+function buildDiagnosticSet(
+  diagnostics: Diagnostic[],
+  docLength: number,
+): DecorationSet {
+  const sorted = diagnostics
+    .map((d) => {
+      const from = Math.min(Math.max(0, d.from), docLength);
+      const to = Math.min(Math.max(from, d.to), docLength);
+      return { ...d, from, to };
+    })
+    .filter((d) => d.from < d.to)
+    .sort((a, b) => a.from - b.from || a.to - b.to);
+
+  const builder = new RangeSetBuilder<CmDecoration>();
+  for (const d of sorted) {
+    builder.add(
+      d.from,
+      d.to,
+      CmDecoration.mark({
+        class: `cm-diagnostic cm-diagnostic-${d.severity}`,
+        // Native browser tooltip — no extra @codemirror/lint dep.
+        // Consumers can override by replacing this StateField.
+        attributes: { title: d.message, "data-severity": d.severity },
+      }),
+    );
+  }
+  return builder.finish();
+}
+
+const diagnosticField = StateField.define<Diagnostic[]>({
+  create() {
+    return [];
+  },
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setDiagnostics)) {
+        return effect.value;
+      }
+    }
+    return value;
+  },
+});
+
+const diagnosticPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      const diags = view.state.field(diagnosticField);
+      this.decorations = buildDiagnosticSet(diags, view.state.doc.length);
+    }
+
+    update(update: ViewUpdate) {
+      const oldDiags = update.startState.field(diagnosticField);
+      const newDiags = update.state.field(diagnosticField);
+      if (oldDiags !== newDiags) {
+        this.decorations = buildDiagnosticSet(newDiags, update.state.doc.length);
+      } else if (update.docChanged) {
+        this.decorations = this.decorations.map(update.changes);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
 // ── CM6Adapter ──────────────────────────────────────────────
 
 export class CM6Adapter implements EditorAdapter {
@@ -162,8 +233,13 @@ export class CM6Adapter implements EditorAdapter {
   /**
    * CM6 extensions required for this adapter. Include in EditorView extensions.
    */
-  static extensions(): [typeof decorationField, typeof decorationPlugin] {
-    return [decorationField, decorationPlugin];
+  static extensions(): [
+    typeof decorationField,
+    typeof decorationPlugin,
+    typeof diagnosticField,
+    typeof diagnosticPlugin,
+  ] {
+    return [decorationField, decorationPlugin, diagnosticField, diagnosticPlugin];
   }
 
   /**
@@ -238,8 +314,14 @@ export class CM6Adapter implements EditorAdapter {
         break;
       }
 
+      case "SetDiagnostics": {
+        this.view.dispatch({
+          effects: setDiagnostics.of(patch.diagnostics),
+        });
+        break;
+      }
+
       case "SelectNode":
-      case "SetDiagnostics":
         break;
 
       case "FullTree":


### PR DESCRIPTION
## Summary

Closes the P1 gap surfaced by the moondsp integration: `SetDiagnostics`
patches were dropped on the floor in `CM6Adapter`, leaving the protocol's
`Diagnostic` type vestigial for any external consumer.

- Mirrors the existing `setDecorations` pattern: `StateField<Diagnostic[]>` + `ViewPlugin` that builds `Decoration.mark` ranges keyed on severity.
- Class names are `cm-diagnostic cm-diagnostic-${severity}` so consumers can style without pulling `@codemirror/lint`.
- `title` + `data-severity` attributes give a native browser tooltip and a CSS hook out of the box.
- `static extensions()` now returns the diagnostic field + plugin alongside the decoration pair.

Includes `FEEDBACK-FROM-MOONDSP-INTEGRATION.md` capturing the full punch list (P1 resolved here; P2/P3/P4 still open).

## Validation

Verified end-to-end against moondsp `feature/web-live-phase-a` (PR dowdiness/moondsp#12): a parse error in the live-coding REPL now renders an inline squiggly with the parser's `position N: …` message in the native tooltip, and clears on recovery. Playwright smoke spec covers the round trip.

## Test plan

- [ ] Type-check: `pnpm -C adapters/editor-adapter typecheck` (or repo equivalent)
- [ ] Build any existing adapter test suite
- [ ] Smoke against a CM6 host: dispatch a `SetDiagnostics` patch, confirm `.cm-diagnostic-error` mark renders with `title` + `data-severity` attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)