### PR TITLE
feat(ideal): causal-graph history view — Phase 1a (DOT generation)

### DIFF
--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -4,6 +4,7 @@ import {
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,
   "dowdiness/canopy/editor" @editor,
+  "dowdiness/event-graph-walker/history" @history,
   "dowdiness/canopy/projection" @proj,
   "dowdiness/canopy/lang/lambda" @lambda,
   "dowdiness/canopy/lang/lambda/edits" @lambda_edits,

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "dowdiness/canopy/lang/lambda/companion",
   "dowdiness/canopy/lang/lambda/edits",
   "dowdiness/canopy/projection",
+  "dowdiness/event-graph-walker/history",
   "dowdiness/lambda/ast",
   "moonbitlang/core/immut/hashset",
 }
@@ -58,6 +59,8 @@ pub fn handle_undo(Int) -> Bool
 
 pub fn insert_at(Int, Int, String, Int) -> Unit
 
+pub fn render_history(@history.CausalSnapshot, String) -> HistoryRender
+
 pub fn set_text(Int, String) -> Unit
 
 pub fn set_text_and_record(Int, String, Int) -> Unit
@@ -80,10 +83,22 @@ pub enum BottomTab {
   Graphviz
 } derive(Eq)
 
+type CompressedData
+
+type CompressedNode
+
 pub enum EditorMode {
   Text
   Structure
 } derive(Eq)
+
+type HistoryData
+
+pub enum HistoryRender {
+  Empty
+  Dot(String)
+  TooLarge(Int)
+}
 
 pub struct Model {
   editor : @editor.SyncEditor[@ast.Term]

--- a/examples/ideal/main/view_history.mbt
+++ b/examples/ideal/main/view_history.mbt
@@ -1,0 +1,370 @@
+// Phase 1a: causal-graph history view — DOT generation only.
+//
+// The pipeline is `CausalSnapshot → HistoryData → CompressedData → DOT`.
+// UI wiring (BottomTab::History, view_history Html, render command) is
+// Phase 1b and lives in view_bottom.mbt; this file is intentionally
+// view-free so the algorithm can be tested in isolation.
+
+///|
+/// Minimum chain length to warrant compression. Below the threshold,
+/// expanding each LV to a singleton node reads more clearly than
+/// abstracting them into a "(N ops)" pill.
+const CHAIN_THRESHOLD : Int = 5
+
+///|
+/// Hard ceiling for Phase 1: above this, refuse to render. A "most recent N"
+/// cut is not ancestry-closed and would silently misrepresent the DAG, so
+/// the only honest options are render-everything or render-nothing.
+const MAX_OPS : Int = 1000
+
+///|
+/// Per-agent palette index (0..7). The local agent is pinned to 0 so the
+/// user's own ops stay visually anchored across sessions.
+struct HistoryData {
+  frontier : Map[Int, Bool]
+  agent_color : Map[String, Int]
+}
+
+///|
+/// One node in the rendered graph. A `Chain` carries the full LV list, not
+/// just `(start, end, count)`, so future selection / time-travel features
+/// can map a click on a compressed node back to its constituents.
+enum CompressedNode {
+  Single(Int)
+  Chain(Array[Int])
+}
+
+///|
+struct CompressedData {
+  nodes : Array[CompressedNode]
+  parents : Array[Array[Int]]
+}
+
+///|
+/// Top-level entry. Three outcomes: empty (no ops), valid DOT, or
+/// graph-too-large placeholder. The ceiling check happens before any
+/// graph walking so layout cost stays bounded.
+pub enum HistoryRender {
+  Empty
+  Dot(String)
+  TooLarge(Int)
+}
+
+///|
+pub fn render_history(
+  snap : @history.CausalSnapshot,
+  local_agent : String,
+) -> HistoryRender {
+  let n = snap.op_count()
+  if n == 0 {
+    return Empty
+  }
+  if n > MAX_OPS {
+    return TooLarge(n)
+  }
+  let data = collect_history_data(snap, local_agent)
+  let comp = chain_compress(data, snap)
+  Dot(emit_dot_string(comp, snap, data))
+}
+
+///|
+/// Walk LVs in order, derive the deterministic palette, and snapshot the
+/// frontier as a lookup map for O(1) "is this a tip?" checks during
+/// compression and emission.
+///
+/// Determinism: `local_agent` → 0; remaining agents → 1..7 in lexicographic
+/// order, wrapping after 8. The palette rule is the only source of agent
+/// identity in this module — no other ordering should leak through.
+fn collect_history_data(
+  snap : @history.CausalSnapshot,
+  local_agent : String,
+) -> HistoryData {
+  let n = snap.op_count()
+  let frontier : Map[Int, Bool] = {}
+  for lv in snap.frontier() {
+    frontier[lv] = true
+  }
+  // Gather unique agents.
+  let seen : Map[String, Bool] = {}
+  let others : Array[String] = []
+  for lv in 0..<n {
+    match snap.entry(lv) {
+      Some(e) => {
+        let a = e.agent()
+        if !seen.contains(a) {
+          seen[a] = true
+          if a != local_agent {
+            others.push(a)
+          }
+        }
+      }
+      None => ()
+    }
+  }
+  others.sort()
+  let agent_color : Map[String, Int] = {}
+  agent_color[local_agent] = 0
+  let mut idx = 1
+  for a in others {
+    agent_color[a] = idx % 8
+    idx += 1
+  }
+  { frontier, agent_color }
+}
+
+///|
+/// Collapse maximal same-agent runs whose interior nodes have indegree
+/// exactly 1 and outdegree exactly 1 — the topological correctness
+/// condition for chain quotient — provided neither endpoint is on the
+/// frontier ("now" is always shown un-collapsed). Below `CHAIN_THRESHOLD`
+/// the chain is left expanded.
+///
+/// Phase 1 policy: same-agent only. Cross-agent indegree=1/outdegree=1
+/// chains are legal but rare, and a multi-agent pill would muddle the
+/// "agent A typed N chars" reading.
+fn chain_compress(
+  data : HistoryData,
+  snap : @history.CausalSnapshot,
+) -> CompressedData {
+  let n = snap.op_count()
+  let frontier = data.frontier
+
+  // chain_succ[p] = c if edge p→c is a chain link.
+  // Functional in p (p has children_count == 1, so the unique child is c).
+  let chain_succ : Map[Int, Int] = {}
+  for c in 0..<n {
+    if frontier.contains(c) {
+      continue
+    }
+    let entry = match snap.entry(c) {
+      Some(e) => e
+      None => continue
+    }
+    let parents_view = entry.parents()
+    if parents_view.length() != 1 {
+      continue
+    }
+    let p = parents_view[0]
+    if frontier.contains(p) {
+      continue
+    }
+    if snap.children_count(p) != 1 {
+      continue
+    }
+    let p_entry = match snap.entry(p) {
+      Some(e) => e
+      None => continue
+    }
+    if p_entry.agent() != entry.agent() {
+      continue
+    }
+    chain_succ[p] = c
+  }
+
+  // A node is a chain interior/tail iff it appears as a chain successor.
+  // Chain heads have no chain predecessor; we walk forward from each.
+  let has_chain_pred : Map[Int, Bool] = {}
+  for _, c in chain_succ {
+    has_chain_pred[c] = true
+  }
+  let lv_to_node : Map[Int, Int] = {}
+  let nodes : Array[CompressedNode] = []
+  for lv in 0..<n {
+    if lv_to_node.contains(lv) {
+      continue
+    }
+    if has_chain_pred.contains(lv) {
+      // Reached as a successor of an earlier head; skip until walk picks it up.
+      // (Heads have lower LVs than their successors — earlier-iteration heads
+      // already absorbed this node into their walk.)
+      continue
+    }
+    let chain : Array[Int] = [lv]
+    let mut cur = lv
+    while chain_succ.get(cur) is Some(next) {
+      chain.push(next)
+      cur = next
+    }
+    if chain.length() >= CHAIN_THRESHOLD {
+      let node_idx = nodes.length()
+      nodes.push(Chain(chain))
+      for x in chain {
+        lv_to_node[x] = node_idx
+      }
+    } else {
+      for x in chain {
+        let node_idx = nodes.length()
+        nodes.push(Single(x))
+        lv_to_node[x] = node_idx
+      }
+    }
+  }
+
+  // Build per-node parent edges. Self-edges (parent and child collapsed
+  // into the same chain) are dropped; duplicate parents (multiple chain
+  // members with the same external ancestor — impossible under the
+  // indegree=1/outdegree=1 rule, but cheap to guard) are deduped.
+  let parents : Array[Array[Int]] = []
+  for _ in 0..<nodes.length() {
+    parents.push([])
+  }
+  for c in 0..<n {
+    let c_node = match lv_to_node.get(c) {
+      Some(i) => i
+      None => continue
+    }
+    let entry = match snap.entry(c) {
+      Some(e) => e
+      None => continue
+    }
+    for p in entry.parents() {
+      let p_node = match lv_to_node.get(p) {
+        Some(i) => i
+        None => continue
+      }
+      if p_node == c_node {
+        continue
+      }
+      let plist = parents[c_node]
+      if !plist.contains(p_node) {
+        plist.push(p_node)
+      }
+    }
+  }
+  { nodes, parents }
+}
+
+///|
+/// 8-color palette tuned for the dark theme (`#1a1a2e` background) and the
+/// project's syntax-color hand. Indices match `HistoryData.agent_color`.
+fn palette_color(idx : Int) -> String {
+  match idx {
+    0 => "#82aaff" // blue — local agent
+    1 => "#c792ea" // purple
+    2 => "#c3e88d" // green
+    3 => "#f78c6c" // orange
+    4 => "#ff5370" // red
+    5 => "#ffcb6b" // yellow
+    6 => "#89ddff" // cyan
+    _ => "#bb80ff" // light purple
+  }
+}
+
+///|
+/// Frontier stroke color — must contrast with every fill.
+const FRONTIER_STROKE : String = "#ffcb6b"
+
+///|
+/// Emit a `digraph` consumable by `@gv_parser.parse_dot`. Layout direction
+/// is top-to-bottom (earliest LVs at the top). Roots are pinned to the
+/// source rank explicitly so multi-root graphs render with a clear baseline.
+///
+/// Agent IDs are user-controlled in the protocol, so DOT escaping (backslash,
+/// quote, newline) is a correctness requirement, not just hygiene.
+fn emit_dot_string(
+  comp : CompressedData,
+  snap : @history.CausalSnapshot,
+  data : HistoryData,
+) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("digraph {\n")
+  buf.write_string("  rankdir=TB;\n")
+  buf.write_string(
+    "  node [style=filled, shape=box, fontname=\"JetBrains Mono\"];\n",
+  )
+
+  // Roots: nodes with no parents in the compressed graph.
+  let roots : Array[Int] = []
+  for i in 0..<comp.nodes.length() {
+    if comp.parents[i].is_empty() {
+      roots.push(i)
+    }
+  }
+  if !roots.is_empty() {
+    buf.write_string("  { rank=source; ")
+    for r in roots {
+      buf.write_string("n")
+      buf.write_string(r.to_string())
+      buf.write_string("; ")
+    }
+    buf.write_string("}\n")
+  }
+
+  // Nodes.
+  for i in 0..<comp.nodes.length() {
+    let (label, agent, is_frontier) = node_attrs(comp.nodes[i], snap, data)
+    let color_idx = data.agent_color.get(agent).unwrap_or(0)
+    let fill = palette_color(color_idx)
+    buf.write_string("  n")
+    buf.write_string(i.to_string())
+    buf.write_string(" [label=\"")
+    buf.write_string(label)
+    buf.write_string("\", fillcolor=\"")
+    buf.write_string(fill)
+    buf.write_string("\"")
+    if is_frontier {
+      buf.write_string(", color=\"")
+      buf.write_string(FRONTIER_STROKE)
+      buf.write_string("\", penwidth=2.5")
+    }
+    buf.write_string("];\n")
+  }
+
+  // Edges.
+  for i in 0..<comp.nodes.length() {
+    for p in comp.parents[i] {
+      buf.write_string("  n")
+      buf.write_string(p.to_string())
+      buf.write_string(" -> n")
+      buf.write_string(i.to_string())
+      buf.write_string(";\n")
+    }
+  }
+  buf.write_string("}\n")
+  buf.to_string()
+}
+
+///|
+/// Resolve label, agent, and frontier flag for a single compressed node.
+/// Chains are never on the frontier (excluded during compression), so this
+/// only checks the singleton case.
+fn node_attrs(
+  node : CompressedNode,
+  snap : @history.CausalSnapshot,
+  data : HistoryData,
+) -> (String, String, Bool) {
+  match node {
+    Single(lv) => {
+      let entry = snap.entry(lv).unwrap()
+      let agent = entry.agent()
+      let label = escape_dot_string(agent) + "#" + entry.seq().to_string()
+      (label, agent, data.frontier.contains(lv))
+    }
+    Chain(lvs) => {
+      let head = snap.entry(lvs[0]).unwrap()
+      let agent = head.agent()
+      let label = escape_dot_string(agent) +
+        " (" +
+        lvs.length().to_string() +
+        " ops)"
+      (label, agent, false)
+    }
+  }
+}
+
+///|
+/// DOT-escape a user-supplied identifier: backslash and double-quote are
+/// escaped; newline / carriage-return are replaced with a single space (a
+/// raw newline inside a `"..."` literal is rejected by the DOT parser).
+fn escape_dot_string(s : String) -> String {
+  let buf = StringBuilder::new()
+  for ch in s {
+    match ch {
+      '\\' => buf.write_string("\\\\")
+      '"' => buf.write_string("\\\"")
+      '\n' | '\r' => buf.write_string(" ")
+      _ => buf.write_char(ch)
+    }
+  }
+  buf.to_string()
+}

--- a/examples/ideal/main/view_history.mbt
+++ b/examples/ideal/main/view_history.mbt
@@ -104,9 +104,12 @@ fn collect_history_data(
   others.sort()
   let agent_color : Map[String, Int] = {}
   agent_color[local_agent] = 0
-  let mut idx = 1
+  // Non-local agents wrap through 1..7 so index 0 stays reserved for the
+  // local agent — a naïve `idx % 8` would silently recycle the local
+  // color at 8+ collaborators and break the primary identity cue.
+  let mut idx = 0
   for a in others {
-    agent_color[a] = idx % 8
+    agent_color[a] = idx % 7 + 1
     idx += 1
   }
   { frontier, agent_color }

--- a/examples/ideal/main/view_history_wbtest.mbt
+++ b/examples/ideal/main/view_history_wbtest.mbt
@@ -273,19 +273,19 @@ test "escape_dot_string normalizes newlines and escapes specials" {
 test "collect_history_data reserves index 0 for local agent past 8 collaborators" {
   // 9 distinct non-local agents (a01..a09) collide with index 0 under a
   // naïve `idx % 8` wrap; the 1..7 wrap rule keeps index 0 reserved.
-  let (local, _) = @lambda.new_lambda_editor("local")
-  local.insert_at(0, "a", 0)
+  let (me, _) = @lambda.new_lambda_editor("me")
+  me.insert_at(0, "a", 0)
   let mut pos = 1
   for i in 1..<=9 {
     let agent = "a0" + i.to_string()
     let (peer, _) = @lambda.new_lambda_editor(agent)
-    peer.apply_sync(local.export_all())
+    peer.apply_sync(me.export_all())
     peer.insert_at(pos, "x", 0)
-    local.apply_sync(peer.export_all())
+    me.apply_sync(peer.export_all())
     pos += 1
   }
-  let data = collect_history_data(local.causal_snapshot(), "local")
-  inspect(data.agent_color.get("local"), content="Some(0)")
+  let data = collect_history_data(me.causal_snapshot(), "me")
+  inspect(data.agent_color.get("me").unwrap(), content="0")
   // Every non-local agent maps into 1..7 — never 0.
   for i in 1..<=9 {
     let agent = "a0" + i.to_string()

--- a/examples/ideal/main/view_history_wbtest.mbt
+++ b/examples/ideal/main/view_history_wbtest.mbt
@@ -1,0 +1,270 @@
+// Whitebox tests for the causal-graph history view (Phase 1a).
+//
+// Scenarios are constructed by driving real `SyncEditor` instances through
+// scripted ops and reading the resulting `CausalSnapshot`. Tests consume
+// only the public snapshot API — they never reach into egw internals.
+
+///|
+/// Helper: build a fresh single-editor scenario with `n` sequential
+/// inserts of "a" by `agent`. LVs run 0..<n in append order.
+fn build_linear(agent : String, n : Int) -> @editor.SyncEditor[@ast.Term] {
+  let (editor, _) = @lambda.new_lambda_editor(agent)
+  for i in 0..<n {
+    editor.insert_at(i, "a", 0)
+  }
+  editor
+}
+
+///|
+test "render_history empty" {
+  let (editor, _) = @lambda.new_lambda_editor("local")
+  match render_history(editor.causal_snapshot(), "local") {
+    Empty => ()
+    _ => fail("expected Empty")
+  }
+}
+
+///|
+test "render_history single op" {
+  let editor = build_linear("local", 1)
+  let dot = match render_history(editor.causal_snapshot(), "local") {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  inspect(
+    dot,
+    content=(
+      #|digraph {
+      #|  rankdir=TB;
+      #|  node [style=filled, shape=box, fontname="JetBrains Mono"];
+      #|  { rank=source; n0; }
+      #|  n0 [label="local#0", fillcolor="#82aaff", color="#ffcb6b", penwidth=2.5];
+      #|}
+      #|
+    ),
+  )
+  // Round-trip: emitted DOT parses cleanly.
+  match @gv_parser.parse_dot(dot) {
+    Ok(_) => ()
+    Err(e) => fail("DOT parse failed: \{e.message}")
+  }
+}
+
+///|
+test "render_history linear 3-op chain not compressed" {
+  let editor = build_linear("local", 3)
+  let dot = match render_history(editor.causal_snapshot(), "local") {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  // Below threshold: three singleton nodes, two edges, tail on frontier.
+  // Count nodes/edges loosely so palette tweaks don't churn the test.
+  let lines = dot.split("\n").collect()
+  let mut node_count = 0
+  let mut edge_count = 0
+  for line in lines {
+    if line.has_prefix("  n") && line.contains("[label=") {
+      node_count += 1
+    } else if line.contains(" -> n") {
+      edge_count += 1
+    }
+  }
+  inspect(node_count, content="3")
+  inspect(edge_count, content="2")
+  // Only the tail (LV2, seq 2) gets the frontier stroke.
+  let frontier_marks = dot.split("penwidth=2.5").collect().length() - 1
+  inspect(frontier_marks, content="1")
+  match @gv_parser.parse_dot(dot) {
+    Ok(_) => ()
+    Err(e) => fail("DOT parse failed: \{e.message}")
+  }
+}
+
+///|
+test "render_history 10-op chain extended by 1 — chain compressed, frontier singleton" {
+  // 11 ops total: LVs 0..9 form an interior chain (no frontier inside),
+  // LV 10 is the sole frontier tip. Chain length 10 ≥ threshold ⇒ compress.
+  let editor = build_linear("local", 11)
+  let dot = match render_history(editor.causal_snapshot(), "local") {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  // Two compressed nodes total: the chain pill + the frontier singleton.
+  let lines = dot.split("\n").collect()
+  let mut node_count = 0
+  for line in lines {
+    if line.has_prefix("  n") && line.contains("[label=") {
+      node_count += 1
+    }
+  }
+  inspect(node_count, content="2")
+  // Chain label includes "(10 ops)".
+  inspect(dot.contains("(10 ops)"), content="true")
+  // Frontier singleton "local#10".
+  inspect(dot.contains("local#10"), content="true")
+  // Exactly one frontier-stroked node (the tip).
+  let frontier_marks = dot.split("penwidth=2.5").collect().length() - 1
+  inspect(frontier_marks, content="1")
+  match @gv_parser.parse_dot(dot) {
+    Ok(_) => ()
+    Err(e) => fail("DOT parse failed: \{e.message}")
+  }
+}
+
+///|
+test "render_history 10-op chain terminating at frontier — 9 compressed + 1 singleton" {
+  // 10 ops. LV 9 is the sole frontier; LVs 0..8 are interior (length 9 ≥ 5).
+  let editor = build_linear("local", 10)
+  let dot = match render_history(editor.causal_snapshot(), "local") {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  let lines = dot.split("\n").collect()
+  let mut node_count = 0
+  for line in lines {
+    if line.has_prefix("  n") && line.contains("[label=") {
+      node_count += 1
+    }
+  }
+  inspect(node_count, content="2")
+  inspect(dot.contains("(9 ops)"), content="true")
+  inspect(dot.contains("local#9"), content="true")
+}
+
+///|
+test "render_history two-agent divergence — 3 nodes, 2 edges, two fills, two frontier tips" {
+  let (alice, _) = @lambda.new_lambda_editor("alice")
+  alice.insert_at(0, "a", 0) // LV0 by alice → shared root
+  let (bob, _) = @lambda.new_lambda_editor("bob")
+  bob.apply_sync(alice.export_all())
+  // Now both have alice's LV0 with op_count 1, frontier {0}.
+  alice.insert_at(1, "x", 0) // LV1_alice on top of root
+  bob.insert_at(1, "y", 0) // LV1_bob on top of root
+  alice.apply_sync(bob.export_all())
+  // alice now has root + alice-tip + bob-tip; both tips on frontier.
+  let dot = match render_history(alice.causal_snapshot(), "alice") {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  let lines = dot.split("\n").collect()
+  let mut node_count = 0
+  let mut edge_count = 0
+  for line in lines {
+    if line.has_prefix("  n") && line.contains("[label=") {
+      node_count += 1
+    } else if line.contains(" -> n") {
+      edge_count += 1
+    }
+  }
+  inspect(node_count, content="3")
+  inspect(edge_count, content="2")
+  // Local agent (alice) gets palette[0] = blue; bob gets a non-zero index.
+  inspect(dot.contains("#82aaff"), content="true") // alice fills
+  // Two frontier tips.
+  let frontier_marks = dot.split("penwidth=2.5").collect().length() - 1
+  inspect(frontier_marks, content="2")
+  match @gv_parser.parse_dot(dot) {
+    Ok(_) => ()
+    Err(e) => fail("DOT parse failed: \{e.message}")
+  }
+}
+
+///|
+test "render_history merge — diamond, single frontier" {
+  // Build divergence then have alice insert a third op AFTER syncing bob.
+  // Result: alice's new op has parents = [alice_tip, bob_tip] ⇒ a merge node.
+  let (alice, _) = @lambda.new_lambda_editor("alice")
+  alice.insert_at(0, "a", 0)
+  let (bob, _) = @lambda.new_lambda_editor("bob")
+  bob.apply_sync(alice.export_all())
+  alice.insert_at(1, "x", 0)
+  bob.insert_at(1, "y", 0)
+  alice.apply_sync(bob.export_all())
+  // Alice's frontier is now {alice_tip, bob_tip}; her next insert merges.
+  alice.insert_at(0, "M", 0)
+  let dot = match render_history(alice.causal_snapshot(), "alice") {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  // 4 nodes total. Single frontier: the merge tip.
+  let lines = dot.split("\n").collect()
+  let mut node_count = 0
+  for line in lines {
+    if line.has_prefix("  n") && line.contains("[label=") {
+      node_count += 1
+    }
+  }
+  inspect(node_count, content="4")
+  let frontier_marks = dot.split("penwidth=2.5").collect().length() - 1
+  inspect(frontier_marks, content="1")
+  match @gv_parser.parse_dot(dot) {
+    Ok(_) => ()
+    Err(e) => fail("DOT parse failed: \{e.message}")
+  }
+}
+
+///|
+test "render_history graph too large refuses to render" {
+  let editor = build_linear("local", MAX_OPS + 1)
+  match render_history(editor.causal_snapshot(), "local") {
+    TooLarge(n) => inspect(n, content="1001")
+    _ => fail("expected TooLarge")
+  }
+}
+
+///|
+test "render_history escapes adversarial agent IDs and round-trips" {
+  // Agent name with backslash, quote, and brace — DOT parser would choke
+  // without escaping.
+  let weird = "agent\"with\\{braces}"
+  let editor = build_linear(weird, 1)
+  let dot = match render_history(editor.causal_snapshot(), weird) {
+    Dot(s) => s
+    _ => {
+      fail("expected Dot")
+      return
+    }
+  }
+  // Backslash and quote escaped in the label.
+  inspect(dot.contains("agent\\\"with\\\\{braces}"), content="true")
+  match @gv_parser.parse_dot(dot) {
+    Ok(_) => ()
+    Err(e) => fail("DOT parse failed: \{e.message}")
+  }
+}
+
+///|
+test "escape_dot_string normalizes newlines and escapes specials" {
+  inspect(escape_dot_string("plain"), content="plain")
+  inspect(
+    escape_dot_string("a\"b"),
+    content=(
+      #|a\"b
+    ),
+  )
+  inspect(
+    escape_dot_string("a\\b"),
+    content=(
+      #|a\\b
+    ),
+  )
+  inspect(escape_dot_string("a\nb\rc"), content="a b c")
+}

--- a/examples/ideal/main/view_history_wbtest.mbt
+++ b/examples/ideal/main/view_history_wbtest.mbt
@@ -268,3 +268,28 @@ test "escape_dot_string normalizes newlines and escapes specials" {
   )
   inspect(escape_dot_string("a\nb\rc"), content="a b c")
 }
+
+///|
+test "collect_history_data reserves index 0 for local agent past 8 collaborators" {
+  // 9 distinct non-local agents (a01..a09) collide with index 0 under a
+  // naïve `idx % 8` wrap; the 1..7 wrap rule keeps index 0 reserved.
+  let (local, _) = @lambda.new_lambda_editor("local")
+  local.insert_at(0, "a", 0)
+  let mut pos = 1
+  for i in 1..<=9 {
+    let agent = "a0" + i.to_string()
+    let (peer, _) = @lambda.new_lambda_editor(agent)
+    peer.apply_sync(local.export_all())
+    peer.insert_at(pos, "x", 0)
+    local.apply_sync(peer.export_all())
+    pos += 1
+  }
+  let data = collect_history_data(local.causal_snapshot(), "local")
+  inspect(data.agent_color.get("local"), content="Some(0)")
+  // Every non-local agent maps into 1..7 — never 0.
+  for i in 1..<=9 {
+    let agent = "a0" + i.to_string()
+    let c = data.agent_color.get(agent).unwrap()
+    inspect(c >= 1 && c <= 7, content="true")
+  }
+}

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -14,6 +14,9 @@
     },
     "dowdiness/lambda": {
       "path": "../../loom/examples/lambda"
+    },
+    "dowdiness/event-graph-walker": {
+      "path": "../../event-graph-walker"
     }
   },
   "source": ".",


### PR DESCRIPTION
## Summary
- Implements `render_history(snap, local_agent) → Empty | Dot(String) | TooLarge(Int)` in `examples/ideal/main/view_history.mbt`, consuming the `CausalSnapshot` + construction `identity` surface from #225.
- Chain-compresses maximal same-agent indegree=1/outdegree=1 runs (≥ 5), never folds the frontier, refuses to render above 1000 ops (recency truncation rejected — not ancestry-closed).
- 10 whitebox tests + DOT round-trip through `@gv_parser.parse_dot`. Spec scenarios 1–7, 10–13 covered; 8 (cross-agent expansion policy) and 9 (seq-gap policy) deferred — they don't gate the algorithm.
- UI wiring (BottomTab::History, render cmd, CSS) is **Phase 1b**, separate PR.

Spec: `docs/plans/2026-05-06-causal-graph-history-view.md` (Codex-validated, on `origin/docs/causal-graph-history-spec`).

## Test plan
- [x] `moon check` clean workspace-wide
- [x] `moon test` — 22/22 in `examples/ideal` (10 new tests pass)
- [x] `moon info` + `moon fmt` ran; mbti diff reviewed (only `render_history` + `HistoryRender` exposed; `HistoryData` / `CompressedNode` / `CompressedData` opaque)
- [ ] CI green before merge
- [ ] Visual verification deferred to Phase 1b (no UI yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)