### PR TITLE
fix(editor-adapter): import type + override for strict TS consumers (P2/P3)

### DIFF
--- a/adapters/editor-adapter/CHANGELOG.md
+++ b/adapters/editor-adapter/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `README.md` documenting the package boundary, public API stability tiers, wire-format invariants, and extension points.
 - `CHANGELOG.md` (this file).
+- `CM6Adapter` now applies `SetDiagnostics` patches as inline `cm-diagnostic cm-diagnostic-${severity}` marks with native-tooltip `title` and `data-severity` attributes. `static extensions()` returns the new diagnostic field + plugin alongside the decoration pair. (#227)
+
+### Changed
+- `cm6-adapter.ts`: `DecorationSet` and `ViewUpdate` are now imported with `import type`, fixing the build for downstream TypeScript projects with `verbatimModuleSyntax: true` (a Vite/SvelteKit default).
+- `cm6-adapter.ts`: `PeerCursorWidget.{eq, toDOM, ignoreEvent}` now carry the `override` modifier, fixing the build for downstream projects with `noImplicitOverride: true`.
 
 ## [0.0.0] - Initial
 

--- a/adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md
+++ b/adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md
@@ -127,10 +127,9 @@ Without one of these, "two consumers on CI" can't actually be wired up.
 ## Concrete asks for `0.1.0-alpha.1`
 
 - [x] P1 — implement `SetDiagnostics` in `CM6Adapter`
-- [ ] P2 — `import type` fix for `DecorationSet` + `ViewUpdate`
-- [ ] P3 — `override` modifier on `PeerCursorWidget` methods
+- [x] P2 — `import type` fix for `DecorationSet` + `ViewUpdate`
+- [x] P3 — `override` modifier on `PeerCursorWidget` methods
 - [ ] P4 — decide: publish or drop `private: true`
 
-P2 + P3 are 1-line fixes each. P1 is the substantive item; P4 is the
-publish decision. moondsp's vendor copy can drop most local deltas the
-moment alpha.1 lands.
+Only P4 (the publish decision) remains. moondsp's vendor copy can drop
+its local TypeScript deltas the moment alpha.1 lands.

--- a/adapters/editor-adapter/cm6-adapter.ts
+++ b/adapters/editor-adapter/cm6-adapter.ts
@@ -3,11 +3,10 @@
 import {
   EditorView,
   Decoration as CmDecoration,
-  DecorationSet,
   ViewPlugin,
-  ViewUpdate,
   WidgetType,
 } from "@codemirror/view";
+import type { DecorationSet, ViewUpdate } from "@codemirror/view";
 import { StateField, StateEffect, RangeSetBuilder } from "@codemirror/state";
 import type { EditorAdapter } from './adapter';
 import type { ViewPatch, UserIntent, Decoration, Diagnostic } from './types';
@@ -25,11 +24,11 @@ class PeerCursorWidget extends WidgetType {
     super();
   }
 
-  eq(other: PeerCursorWidget): boolean {
+  override eq(other: PeerCursorWidget): boolean {
     return this.label === other.label && this.cssClass === other.cssClass && this.color === other.color;
   }
 
-  toDOM(): HTMLElement {
+  override toDOM(): HTMLElement {
     const wrapper = document.createElement("span");
     wrapper.className = this.cssClass;
     if (this.color) wrapper.style.setProperty("--color", this.color);
@@ -42,7 +41,7 @@ class PeerCursorWidget extends WidgetType {
     return wrapper;
   }
 
-  ignoreEvent(): boolean {
+  override ignoreEvent(): boolean {
     return true;
   }
 }

--- a/adapters/editor-adapter/pm-adapter.ts
+++ b/adapters/editor-adapter/pm-adapter.ts
@@ -5,8 +5,10 @@
 // The PM view is non-editable — all mutations come through applyPatches.
 
 import { EditorView as PmView } from "prosemirror-view";
-import { EditorState as PmState, Transaction, Selection, NodeSelection } from "prosemirror-state";
-import { Schema, Node as PmNode, NodeSpec } from "prosemirror-model";
+import { EditorState as PmState, Selection, NodeSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+import { Schema } from "prosemirror-model";
+import type { Node as PmNode, NodeSpec } from "prosemirror-model";
 import type { EditorAdapter } from './adapter';
 import type { ViewPatch, ViewNode, UserIntent } from './types';
 


### PR DESCRIPTION
## Summary

Closes P2 and P3 from the moondsp integration feedback (see
\`adapters/editor-adapter/FEEDBACK-FROM-MOONDSP-INTEGRATION.md\`).
Both are 1-line fixes that unblock builds in downstream projects with
modern strict TypeScript defaults.

- **P2** — \`DecorationSet\` and \`ViewUpdate\` are used only in type
  positions; importing them as values fails under
  \`verbatimModuleSyntax: true\` (a Vite/SvelteKit default). Split to
  \`import type { ... }\`.
- **P3** — \`PeerCursorWidget.{eq, toDOM, ignoreEvent}\` lack the
  \`override\` modifier; under \`noImplicitOverride: true\` (a common
  modern default) tsc fails. Add \`override\` to all three.

The moondsp vendor copy already carries both deltas locally — this
lands them upstream so the vendor copy can be dropped on the next
publish.

After this lands, only **P4** (publish to npm or drop \`private: true\`)
remains before consumers can install \`@canopy/editor-adapter\` directly.

## Test plan

- [ ] Existing CI green
- [ ] Smoke a downstream consumer with \`verbatimModuleSyntax: true\` and \`noImplicitOverride: true\` (moondsp \`web/live/\` is the live example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive package documentation detailing boundaries and API stability information.

* **Bug Fixes**
  * Enhanced diagnostic rendering with inline display, severity indicators, and improved tooltip attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->