### PR TITLE
feat(ideal): causal-graph history view — Phase 1b (UI wiring)

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -459,7 +459,20 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Inspector => { ..ws, inspector_visible: !ws.inspector_visible }
         Bottom => { ..ws, bottom_visible: !ws.bottom_visible }
       }
-      (none, { ..model, workspace, })
+      let new_model = { ..model, workspace, }
+      // Reopening the bottom panel must refresh the active tab's container,
+      // since per-tab cmds bail out while hidden — without this, edits made
+      // while collapsed leave a stale SVG when the panel comes back.
+      let cmd = match panel {
+        Bottom =>
+          if workspace.bottom_visible {
+            bottom_render_cmd(new_model)
+          } else {
+            none
+          }
+        _ => none
+      }
+      (cmd, new_model)
     }
     DismissPanels => {
       let ws = model.workspace

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -468,7 +468,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     }
     SelectBottomTab(tab) => {
       let new_model = { ..model, bottom_tab: tab }
-      (graphviz_render_cmd(new_model), new_model)
+      (bottom_render_cmd(new_model), new_model)
     }
     StructuralEditRequested(op~, node_id~) => {
       let resolved_op = if op == "" { js_take_structural_edit_op() } else { op }
@@ -513,7 +513,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         let text = new_model.editor.get_text()
         let cmd = @rabbita.batch([
           @rabbita.effect(fn() { js_sync_and_broadcast(text) }),
-          graphviz_render_cmd(new_model),
+          bottom_render_cmd(new_model),
         ])
         (cmd, new_model)
       } else {
@@ -527,7 +527,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         let text = new_model.editor.get_text()
         let cmd = @rabbita.batch([
           @rabbita.effect(fn() { js_sync_and_broadcast(text) }),
-          graphviz_render_cmd(new_model),
+          bottom_render_cmd(new_model),
         ])
         (cmd, new_model)
       } else {
@@ -540,7 +540,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       let text = new_model.editor.get_text()
       let cmd = @rabbita.batch([
         @rabbita.effect(fn() { js_reconcile_editor_with_text(text) }),
-        graphviz_render_cmd(new_model),
+        bottom_render_cmd(new_model),
       ])
       (cmd, new_model)
     }
@@ -843,7 +843,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       // Text was already applied by TS calling handle_text_intent FFI.
       // Just refresh the outline.
       let new_model = refresh(model)
-      (graphviz_render_cmd(new_model), new_model)
+      (bottom_render_cmd(new_model), new_model)
     }
     EditorNodeSelected(node_id) => {
       let resolved_node_id = if node_id == "" {
@@ -879,7 +879,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
           ..model,
           next_timestamp: model.next_timestamp + 1,
         })
-        (graphviz_render_cmd(new_model), new_model)
+        (bottom_render_cmd(new_model), new_model)
       }
     }
   }

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -8,6 +8,7 @@ pub enum EditorMode {
 pub enum BottomTab {
   Problems
   OpLog
+  History
   CrdtState
   Graphviz
 } derive(Eq)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -79,6 +79,7 @@ pub fn undo_manager_undo(Int) -> Bool
 pub enum BottomTab {
   Problems
   OpLog
+  History
   CrdtState
   Graphviz
 } derive(Eq)

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -34,10 +34,38 @@ fn graphviz_render_cmd(model : Model) -> @rabbita.Cmd {
 }
 
 ///|
+/// Render the causal-graph history view as SVG into the History tab's
+/// container. Mirrors `graphviz_render_cmd` — guarded on tab + visibility.
+fn history_render_cmd(model : Model) -> @rabbita.Cmd {
+  if model.bottom_tab != History || !model.workspace.bottom_visible {
+    return @rabbita.none
+  }
+  let snap = model.editor.causal_snapshot()
+  let svg = match render_history(snap, model.editor.get_peer_id()) {
+    Empty => "<span class=\"no-problems\">No operations recorded yet</span>"
+    TooLarge(n) =>
+      "<span class=\"no-problems\">Graph too large — \{n} ops; collapsing UI deferred to Phase 2</span>"
+    Dot(dot) => render_dot_to_svg(dot)
+  }
+  @rabbita_cmd.raw_effect(
+    fn(_) { js_set_inner_html("canopy-history-container", svg) },
+    kind=@rabbita_cmd.after_render,
+  )
+}
+
+///|
+/// Run the appropriate bottom-panel render command for the active tab.
+/// Each per-tab cmd self-guards on tab + visibility, so this just batches.
+fn bottom_render_cmd(model : Model) -> @rabbita.Cmd {
+  @rabbita.batch([graphviz_render_cmd(model), history_render_cmd(model)])
+}
+
+///|
 fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
   let tabs : Array[(BottomTab, String)] = [
     (Problems, "Problems"),
     (OpLog, "Op Log"),
+    (History, "History"),
     (CrdtState, "CRDT State"),
     (Graphviz, "Graphviz"),
   ]
@@ -101,6 +129,12 @@ fn view_bottom_content(dispatch : Dispatch[Msg], model : Model) -> Html {
           ]),
         ]),
       ])
+    History =>
+      @html.div(
+        class="bottom-content history-content",
+        attrs=@html.Attrs::build().id("canopy-history-container"),
+        [@html.text("")],
+      )
     Graphviz =>
       @html.div(
         class="bottom-content graphviz-content",

--- a/examples/ideal/web/e2e/history.spec.ts
+++ b/examples/ideal/web/e2e/history.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForEditor(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await expect(page).toHaveTitle('Canopy Editor');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(
+    () => {
+      const ce = document.querySelector('canopy-editor');
+      return ce?.shadowRoot?.querySelector('.cm-editor') !== null;
+    },
+    { timeout: 10000 },
+  );
+}
+
+async function openBottomPanel(page: import('@playwright/test').Page) {
+  // The Panels button toggles the bottom panel; History tab lives inside it.
+  await page.getByRole('button', { name: 'Panels' }).click();
+}
+
+test.describe('Causal History tab', () => {
+  test('renders SVG for the seeded document', async ({ page }) => {
+    await waitForEditor(page);
+    await openBottomPanel(page);
+    await page.getByRole('button', { name: 'History' }).click();
+    // Container must exist and end up containing an SVG (Phase 1a output
+    // routed through @gv_layout / @gv_svg by history_render_cmd).
+    const container = page.locator('#canopy-history-container');
+    await expect(container).toBeVisible();
+    await expect(container.locator('svg')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/examples/ideal/web/e2e/history.spec.ts
+++ b/examples/ideal/web/e2e/history.spec.ts
@@ -18,6 +18,18 @@ async function openBottomPanel(page: import('@playwright/test').Page) {
   await page.getByRole('button', { name: 'Panels' }).click();
 }
 
+async function typeInEditor(
+  page: import('@playwright/test').Page,
+  text: string,
+) {
+  await page.evaluate(() => {
+    const ce = document.querySelector('canopy-editor');
+    const cm = ce?.shadowRoot?.querySelector('.cm-content') as HTMLElement;
+    cm?.focus();
+  });
+  await page.keyboard.type(text, { delay: 20 });
+}
+
 test.describe('Causal History tab', () => {
   test('renders SVG for the seeded document', async ({ page }) => {
     await waitForEditor(page);
@@ -28,5 +40,26 @@ test.describe('Causal History tab', () => {
     const container = page.locator('#canopy-history-container');
     await expect(container).toBeVisible();
     await expect(container.locator('svg')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('refreshes after reopening the bottom panel post-edit', async ({
+    page,
+  }) => {
+    await waitForEditor(page);
+    await openBottomPanel(page);
+    await page.getByRole('button', { name: 'History' }).click();
+    const container = page.locator('#canopy-history-container');
+    await expect(container.locator('svg')).toBeVisible({ timeout: 10000 });
+    const initialMarkup = await container.innerHTML();
+
+    // Close the panel, edit while hidden, reopen.
+    await openBottomPanel(page);
+    await typeInEditor(page, 'x');
+    await openBottomPanel(page);
+    // Without the TogglePanel(Bottom) refresh hook, the container would
+    // still hold the pre-edit SVG. Expect the markup to have changed.
+    await expect
+      .poll(() => container.innerHTML(), { timeout: 10000 })
+      .not.toBe(initialMarkup);
   });
 });

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -689,6 +689,21 @@ canopy-editor {
   height: auto;
 }
 
+/* ── Causal History ─────────────────────────────────────── */
+
+.history-content {
+  overflow: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--space-md);
+}
+
+.history-content svg {
+  max-width: 100%;
+  height: auto;
+}
+
 /* ── Panel scrim (mobile only — hidden on desktop) ─────── */
 
 .panel-scrim {


### PR DESCRIPTION
## Summary

- New `BottomTab::History` rendering the Phase 1a DOT through the existing graphviz pipeline (`@gv_parser` → `@gv_layout` → `@gv_svg`).
- `bottom_render_cmd` batches `graphviz_render_cmd` + `history_render_cmd`; every existing trigger (text edits, undo/redo, structural edits, examples) refreshes both tabs when active.
- `history_render_cmd` covers `Empty` (no ops yet), `TooLarge(N)` (over 1000-op ceiling), and `Dot` → SVG.
- CSS reuses the `.graphviz-content` layout for the new container.
- Playwright e2e (`history.spec.ts`) asserts the SVG renders for the seeded document.

Builds on #229 (Phase 1a, DOT generation only). Phase 1c (`/critique` polish) lands in a follow-up PR.

## Test plan
- [x] `moon test` (canopy + ideal)
- [x] `moon check` clean
- [x] `playwright test e2e/history.spec.ts` — passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)