### PR TITLE
feat(ideal): bottom-panel render cache, a11y, and keyboard nav

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -105,6 +105,16 @@ extern "js" fn js_set_inner_html(element_id : String, html : String) -> Unit =
   #| }
 
 ///|
+/// Move keyboard focus to an element by ID. Used by the bottom tab strip
+/// to follow roving tabindex after arrow-key navigation. Silently no-ops
+/// if the element isn't in the DOM.
+extern "js" fn js_focus_element(element_id : String) -> Unit =
+  #| function(id) {
+  #|   var el = document.getElementById(id);
+  #|   if (el && typeof el.focus === 'function') el.focus();
+  #| }
+
+///|
 /// Consume the pending action overlay node ID set by JS.
 extern "js" fn js_take_action_overlay_node() -> String =
   #| function() {

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -481,7 +481,11 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     }
     SelectBottomTab(tab) => {
       let new_model = { ..model, bottom_tab: tab }
-      (bottom_render_cmd(new_model), new_model)
+      let cmd = @rabbita.batch([
+        bottom_render_cmd(new_model),
+        bottom_tab_focus_cmd(tab),
+      ])
+      (cmd, new_model)
     }
     StructuralEditRequested(op~, node_id~) => {
       let resolved_op = if op == "" { js_take_structural_edit_op() } else { op }

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -189,6 +189,20 @@ fn bottom_render_cmd(model : Model) -> @rabbita.Cmd {
 }
 
 ///|
+/// Focus the active tab's button after the next render. Roving tabindex
+/// makes inactive tabs unreachable via Tab; without this, arrow-key
+/// navigation would leave focus stranded on the previous (now
+/// `tabindex="-1"`) button. Click-driven switches are no-ops because the
+/// browser already focuses the clicked button.
+fn bottom_tab_focus_cmd(tab : BottomTab) -> @rabbita.Cmd {
+  let id = bottom_tab_button_id(tab)
+  @rabbita_cmd.raw_effect(
+    fn(_) { js_focus_element(id) },
+    kind=@rabbita_cmd.after_render,
+  )
+}
+
+///|
 /// Stable slug per tab — used for both the tab button id and the tabpanel
 /// id, so `aria-controls` ↔ `aria-labelledby` round-trips cleanly.
 fn bottom_tab_slug(tab : BottomTab) -> String {
@@ -227,27 +241,50 @@ fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
     (CrdtState, "CRDT State"),
     (Graphviz, "Graphviz"),
   ]
-  @html.div(
-    class="bottom-tabs",
-    attrs=@html.Attrs::build()
-      .role("tablist")
-      .aria_label("Bottom panel sections"),
-    tabs.map(fn(pair) {
-      let (tab, label) = pair
-      let active = model.bottom_tab == tab
-      let class_name = if active { "tab active" } else { "tab" }
-      let attrs = @html.Attrs::build()
-        .id(bottom_tab_button_id(tab))
-        .role("tab")
-        .aria_selected(if active { "true" } else { "false" })
-        .aria_controls(bottom_tab_panel_id(tab))
+  // Build buttons with WAI-ARIA tabs keyboard support: arrow keys
+  // navigate, Home/End jump to ends, and roving tabindex keeps the focus
+  // budget at one (active tab is tabindex=0; others are -1, so the page
+  // Tab key skips over inactive tabs).
+  let n = tabs.length()
+  let first_tab = tabs[0].0
+  let last_tab = tabs[n - 1].0
+  let buttons : Array[Html] = []
+  for i in 0..<n {
+    let (tab, label) = tabs[i]
+    let prev_tab = tabs[(i + n - 1) % n].0
+    let next_tab = tabs[(i + 1) % n].0
+    let active = model.bottom_tab == tab
+    let class_name = if active { "tab active" } else { "tab" }
+    let attrs = @html.Attrs::build()
+      .id(bottom_tab_button_id(tab))
+      .role("tab")
+      .aria_selected(if active { "true" } else { "false" })
+      .aria_controls(bottom_tab_panel_id(tab))
+      .tabindex(if active { 0 } else { -1 })
+      .on_keydown(fn(ev) {
+        match ev.key() {
+          "ArrowLeft" | "ArrowUp" => dispatch(SelectBottomTab(prev_tab))
+          "ArrowRight" | "ArrowDown" => dispatch(SelectBottomTab(next_tab))
+          "Home" => dispatch(SelectBottomTab(first_tab))
+          "End" => dispatch(SelectBottomTab(last_tab))
+          _ => @rabbita.none
+        }
+      })
+    buttons.push(
       @html.button(
         class=class_name,
         on_click=dispatch(SelectBottomTab(tab)),
         attrs~,
         [@html.text(label)],
-      )
-    }),
+      ),
+    )
+  }
+  @html.div(
+    class="bottom-tabs",
+    attrs=@html.Attrs::build()
+      .role("tablist")
+      .aria_label("Bottom panel sections"),
+    buttons,
   )
 }
 

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -5,37 +5,40 @@
 /// re-layout, and re-render the SVG — work proportional to N ops and
 /// dominated by Sugiyama layout (O(V·E)).
 ///
-/// Cache keys on `(op_count, frontier_hash, agent)`. The snapshot is a
-/// live alias over egw's Document, so cache key extraction is O(|frontier|).
-/// `html` is cached too, so a tab switch that remounts the container still
-/// gets innerHTML written cheaply on the next render — only the heavy
-/// pipeline is skipped.
+/// Cache keys on `(editor_identity, op_count, frontier_hash)`. Identity
+/// distinguishes separately-constructed `SyncEditor`s in the same process
+/// — the existing flow has one editor per page, but keying on identity
+/// closes the stale-hit path if a future flow swaps editors. Snapshot is
+/// a live alias over egw's Document, so key extraction is O(|frontier|).
+/// `html` is cached too, so a tab switch that remounts the container
+/// still gets innerHTML written cheaply on the next render — only the
+/// heavy pipeline is skipped.
 ///
 /// Module-local mutable state is acceptable here: the cmd is the only
 /// writer, the update loop sequences calls, and after_render writes are
 /// synchronous.
 priv struct RenderCache {
+  mut identity : Int
   mut op_count : Int
   mut frontier_hash : Int
-  mut agent : String
   mut html : String
   mut valid : Bool
 }
 
 ///|
 let history_cache : RenderCache = {
+  identity: -1,
   op_count: 0,
   frontier_hash: 0,
-  agent: "",
   html: "",
   valid: false,
 }
 
 ///|
 let graphviz_cache : RenderCache = {
+  identity: -1,
   op_count: 0,
   frontier_hash: 0,
-  agent: "",
   html: "",
   valid: false,
 }
@@ -45,33 +48,33 @@ let graphviz_cache : RenderCache = {
 /// practice); the multiply-by-31 fold collides only on adversarial inputs
 /// that callers don't construct.
 fn render_cache_key(
+  identity : Int,
   snap : @history.CausalSnapshot,
-  agent : String,
-) -> (Int, Int, String) {
+) -> (Int, Int, Int) {
   let mut h = 0
   for lv in snap.frontier() {
     h = h * 31 + lv
   }
-  (snap.op_count(), h, agent)
+  (identity, snap.op_count(), h)
 }
 
 ///|
-fn cache_hit(cache : RenderCache, key : (Int, Int, String)) -> Bool {
+fn cache_hit(cache : RenderCache, key : (Int, Int, Int)) -> Bool {
   cache.valid &&
-  cache.op_count == key.0 &&
-  cache.frontier_hash == key.1 &&
-  cache.agent == key.2
+  cache.identity == key.0 &&
+  cache.op_count == key.1 &&
+  cache.frontier_hash == key.2
 }
 
 ///|
 fn cache_store(
   cache : RenderCache,
-  key : (Int, Int, String),
+  key : (Int, Int, Int),
   html : String,
 ) -> Unit {
-  cache.op_count = key.0
-  cache.frontier_hash = key.1
-  cache.agent = key.2
+  cache.identity = key.0
+  cache.op_count = key.1
+  cache.frontier_hash = key.2
   cache.html = html
   cache.valid = true
 }
@@ -118,7 +121,7 @@ fn graphviz_render_cmd(model : Model) -> @rabbita.Cmd {
     return @rabbita.none
   }
   let snap = model.editor.causal_snapshot()
-  let key = render_cache_key(snap, model.editor.get_peer_id())
+  let key = render_cache_key(model.editor.identity(), snap)
   // Cache the wrapped HTML, not the bare SVG — the role="img" wrapper is
   // a constant cost we want to pay once. Mirrors the History tab so screen
   // readers see the same shape on either panel.
@@ -151,7 +154,7 @@ fn history_render_cmd(model : Model) -> @rabbita.Cmd {
   }
   let snap = model.editor.causal_snapshot()
   let me = model.editor.get_peer_id()
-  let key = render_cache_key(snap, me)
+  let key = render_cache_key(model.editor.identity(), snap)
   let html = if cache_hit(history_cache, key) {
     history_cache.html
   } else {
@@ -255,21 +258,30 @@ fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
     let next_tab = tabs[(i + 1) % n].0
     let active = model.bottom_tab == tab
     let class_name = if active { "tab active" } else { "tab" }
-    let attrs = @html.Attrs::build()
+    // `aria-controls` is set only on the active tab — the other panels
+    // aren't mounted (`view_bottom_content` matches on `bottom_tab` and
+    // returns one), so cross-referencing missing IDs would mislead AT.
+    // The `aria-labelledby` on the active panel still ties it back to
+    // its tab button.
+    let mut attrs = @html.Attrs::build()
       .id(bottom_tab_button_id(tab))
       .role("tab")
       .aria_selected(if active { "true" } else { "false" })
-      .aria_controls(bottom_tab_panel_id(tab))
       .tabindex(if active { 0 } else { -1 })
       .on_keydown(fn(ev) {
+        // Horizontal tablist: APG reserves ArrowUp/Down for normal scroll;
+        // only ArrowLeft/Right + Home/End move between tabs.
         match ev.key() {
-          "ArrowLeft" | "ArrowUp" => dispatch(SelectBottomTab(prev_tab))
-          "ArrowRight" | "ArrowDown" => dispatch(SelectBottomTab(next_tab))
+          "ArrowLeft" => dispatch(SelectBottomTab(prev_tab))
+          "ArrowRight" => dispatch(SelectBottomTab(next_tab))
           "Home" => dispatch(SelectBottomTab(first_tab))
           "End" => dispatch(SelectBottomTab(last_tab))
           _ => @rabbita.none
         }
       })
+    if active {
+      attrs = attrs.aria_controls(bottom_tab_panel_id(tab))
+    }
     buttons.push(
       @html.button(
         class=class_name,
@@ -290,12 +302,17 @@ fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
 
 ///|
 /// Build the standard tabpanel attrs for a bottom-panel container — id,
-/// role, and aria-labelledby pointing back at the tab button.
+/// role, aria-labelledby pointing back at the tab button, and
+/// `tabindex="0"` so Tab from the tablist enters the panel even when no
+/// descendant is focusable (Problems / OpLog / CRDT State / SVG-only
+/// History/Graphviz). APG: a tabpanel with no focusable content must be
+/// in the tab sequence itself.
 fn bottom_panel_attrs(tab : BottomTab) -> @html.Attrs {
   @html.Attrs::build()
   .id(bottom_tab_panel_id(tab))
   .role("tabpanel")
   .aria_labelledby(bottom_tab_button_id(tab))
+  .tabindex(0)
 }
 
 ///|

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -270,13 +270,24 @@ fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
       .tabindex(if active { 0 } else { -1 })
       .on_keydown(fn(ev) {
         // Horizontal tablist: APG reserves ArrowUp/Down for normal scroll;
-        // only ArrowLeft/Right + Home/End move between tabs.
-        match ev.key() {
-          "ArrowLeft" => dispatch(SelectBottomTab(prev_tab))
-          "ArrowRight" => dispatch(SelectBottomTab(next_tab))
-          "Home" => dispatch(SelectBottomTab(first_tab))
-          "End" => dispatch(SelectBottomTab(last_tab))
-          _ => @rabbita.none
+        // only ArrowLeft/Right + Home/End move between tabs. Cancel the
+        // browser default for handled keys — Home/End and arrow keys
+        // otherwise scroll the page or scroll containers, so without
+        // prevent_default the viewport jumps while focus moves between
+        // tabs.
+        let target_tab = match ev.key() {
+          "ArrowLeft" => Some(prev_tab)
+          "ArrowRight" => Some(next_tab)
+          "Home" => Some(first_tab)
+          "End" => Some(last_tab)
+          _ => None
+        }
+        match target_tab {
+          Some(t) => {
+            ev.prevent_default()
+            dispatch(SelectBottomTab(t))
+          }
+          None => @rabbita.none
         }
       })
     if active {

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -1,4 +1,82 @@
 ///|
+/// Render-cache for the bottom-panel SVG tabs. The view-update loop
+/// re-issues `bottom_render_cmd` on every Model change; without a cache,
+/// every keystroke would re-walk the snapshot, re-emit DOT, re-parse,
+/// re-layout, and re-render the SVG — work proportional to N ops and
+/// dominated by Sugiyama layout (O(V·E)).
+///
+/// Cache keys on `(op_count, frontier_hash, agent)`. The snapshot is a
+/// live alias over egw's Document, so cache key extraction is O(|frontier|).
+/// `html` is cached too, so a tab switch that remounts the container still
+/// gets innerHTML written cheaply on the next render — only the heavy
+/// pipeline is skipped.
+///
+/// Module-local mutable state is acceptable here: the cmd is the only
+/// writer, the update loop sequences calls, and after_render writes are
+/// synchronous.
+priv struct RenderCache {
+  mut op_count : Int
+  mut frontier_hash : Int
+  mut agent : String
+  mut html : String
+  mut valid : Bool
+}
+
+///|
+let history_cache : RenderCache = {
+  op_count: 0,
+  frontier_hash: 0,
+  agent: "",
+  html: "",
+  valid: false,
+}
+
+///|
+let graphviz_cache : RenderCache = {
+  op_count: 0,
+  frontier_hash: 0,
+  agent: "",
+  html: "",
+  valid: false,
+}
+
+///|
+/// Snapshot identity hash for cache lookup. Frontier is small (1-3 LVs in
+/// practice); the multiply-by-31 fold collides only on adversarial inputs
+/// that callers don't construct.
+fn render_cache_key(
+  snap : @history.CausalSnapshot,
+  agent : String,
+) -> (Int, Int, String) {
+  let mut h = 0
+  for lv in snap.frontier() {
+    h = h * 31 + lv
+  }
+  (snap.op_count(), h, agent)
+}
+
+///|
+fn cache_hit(cache : RenderCache, key : (Int, Int, String)) -> Bool {
+  cache.valid &&
+  cache.op_count == key.0 &&
+  cache.frontier_hash == key.1 &&
+  cache.agent == key.2
+}
+
+///|
+fn cache_store(
+  cache : RenderCache,
+  key : (Int, Int, String),
+  html : String,
+) -> Unit {
+  cache.op_count = key.0
+  cache.frontier_hash = key.1
+  cache.agent = key.2
+  cache.html = html
+  cache.valid = true
+}
+
+///|
 /// Render a DOT string to SVG using the MoonBit graphviz pipeline.
 ///
 /// `LayoutConfig::compact()` produces 50×28 user-unit nodes; the
@@ -39,11 +117,26 @@ fn graphviz_render_cmd(model : Model) -> @rabbita.Cmd {
   if model.bottom_tab != Graphviz || !model.workspace.bottom_visible {
     return @rabbita.none
   }
-  let dot = @lambda.get_lambda_dot_resolved(model.editor)
-  let svg = render_dot_to_svg(dot)
+  let snap = model.editor.causal_snapshot()
+  let key = render_cache_key(snap, model.editor.get_peer_id())
+  // Cache the wrapped HTML, not the bare SVG — the role="img" wrapper is
+  // a constant cost we want to pay once. Mirrors the History tab so screen
+  // readers see the same shape on either panel.
+  let html = if cache_hit(graphviz_cache, key) {
+    graphviz_cache.html
+  } else {
+    let dot = @lambda.get_lambda_dot_resolved(model.editor)
+    let svg = render_dot_to_svg(dot)
+    let wrapped = "<div role=\"img\" aria-label=\"Resolved lambda expression graph\">" +
+      svg +
+      "</div>"
+    cache_store(graphviz_cache, key, wrapped)
+    wrapped
+  }
   // AfterRender ensures the container div exists in the DOM before setting innerHTML.
+  // We always write — cache hit only skips the upstream resolve+layout cost.
   @rabbita_cmd.raw_effect(
-    fn(_) { js_set_inner_html("canopy-graphviz-container", svg) },
+    fn(_) { js_set_inner_html("canopy-graphviz-container", html) },
     kind=@rabbita_cmd.after_render,
   )
 }
@@ -58,15 +151,29 @@ fn history_render_cmd(model : Model) -> @rabbita.Cmd {
   }
   let snap = model.editor.causal_snapshot()
   let me = model.editor.get_peer_id()
-  let html = match render_history(snap, me) {
-    Empty => "<span class=\"history-empty\">No edits yet.</span>"
-    TooLarge(n) =>
-      "<span class=\"history-empty\">\{n} operations — too many to display.</span>"
-    Dot(dot) =>
-      legend_html(snap, me) +
-      "<div class=\"history-graph\">" +
-      render_dot_to_svg(dot) +
-      "</div>"
+  let key = render_cache_key(snap, me)
+  let html = if cache_hit(history_cache, key) {
+    history_cache.html
+  } else {
+    let h = match render_history(snap, me) {
+      Empty =>
+        "<span class=\"history-empty\">No history yet. Edits will appear here as you type.</span>"
+      TooLarge(n) =>
+        "<span class=\"history-empty\">Too many edits to render (\{n}). This view shows histories up to \{MAX_OPS} ops.</span>"
+      Dot(dot) => {
+        // Screen-reader label for the SVG. Legend stays outside the
+        // role="img" subtree so its agent decoder remains list-readable.
+        let svg_label = "Causal history graph: \{snap.op_count()} edits"
+        legend_html(snap, me) +
+        "<div class=\"history-graph\" role=\"img\" aria-label=\"" +
+        escape_html_string(svg_label) +
+        "\">" +
+        render_dot_to_svg(dot) +
+        "</div>"
+      }
+    }
+    cache_store(history_cache, key, h)
+    h
   }
   @rabbita_cmd.raw_effect(
     fn(_) { js_set_inner_html("canopy-history-container", html) },
@@ -82,6 +189,36 @@ fn bottom_render_cmd(model : Model) -> @rabbita.Cmd {
 }
 
 ///|
+/// Stable slug per tab — used for both the tab button id and the tabpanel
+/// id, so `aria-controls` ↔ `aria-labelledby` round-trips cleanly.
+fn bottom_tab_slug(tab : BottomTab) -> String {
+  match tab {
+    Problems => "problems"
+    OpLog => "oplog"
+    History => "history"
+    CrdtState => "crdt"
+    Graphviz => "graphviz"
+  }
+}
+
+///|
+fn bottom_tab_button_id(tab : BottomTab) -> String {
+  "canopy-bottom-tab-" + bottom_tab_slug(tab)
+}
+
+///|
+/// Panel container id. History and Graphviz keep their existing
+/// `canopy-{name}-container` ids because the render cmds write innerHTML
+/// to those exact element ids; the others get a uniform slug.
+fn bottom_tab_panel_id(tab : BottomTab) -> String {
+  match tab {
+    History => "canopy-history-container"
+    Graphviz => "canopy-graphviz-container"
+    _ => "canopy-bottom-panel-" + bottom_tab_slug(tab)
+  }
+}
+
+///|
 fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
   let tabs : Array[(BottomTab, String)] = [
     (Problems, "Problems"),
@@ -92,25 +229,43 @@ fn view_bottom_tabs(dispatch : Dispatch[Msg], model : Model) -> Html {
   ]
   @html.div(
     class="bottom-tabs",
+    attrs=@html.Attrs::build()
+      .role("tablist")
+      .aria_label("Bottom panel sections"),
     tabs.map(fn(pair) {
       let (tab, label) = pair
-      let class_name = if model.bottom_tab == tab {
-        "tab active"
-      } else {
-        "tab"
-      }
-      @html.button(class=class_name, on_click=dispatch(SelectBottomTab(tab)), [
-        @html.text(label),
-      ])
+      let active = model.bottom_tab == tab
+      let class_name = if active { "tab active" } else { "tab" }
+      let attrs = @html.Attrs::build()
+        .id(bottom_tab_button_id(tab))
+        .role("tab")
+        .aria_selected(if active { "true" } else { "false" })
+        .aria_controls(bottom_tab_panel_id(tab))
+      @html.button(
+        class=class_name,
+        on_click=dispatch(SelectBottomTab(tab)),
+        attrs~,
+        [@html.text(label)],
+      )
     }),
   )
+}
+
+///|
+/// Build the standard tabpanel attrs for a bottom-panel container — id,
+/// role, and aria-labelledby pointing back at the tab button.
+fn bottom_panel_attrs(tab : BottomTab) -> @html.Attrs {
+  @html.Attrs::build()
+  .id(bottom_tab_panel_id(tab))
+  .role("tabpanel")
+  .aria_labelledby(bottom_tab_button_id(tab))
 }
 
 ///|
 fn view_problems(model : Model) -> Html {
   let errors = model.editor.get_errors()
   if errors.is_empty() {
-    @html.div(class="bottom-content", [
+    @html.div(class="bottom-content", attrs=bottom_panel_attrs(Problems), [
       @html.span(class="no-problems", [@html.text("No problems found")]),
     ])
   } else {
@@ -119,7 +274,11 @@ fn view_problems(model : Model) -> Html {
         @html.span(class="problem-text", [@html.text(err)]),
       ])
     })
-    @html.div(class="bottom-content problems-list", items)
+    @html.div(
+      class="bottom-content problems-list",
+      attrs=bottom_panel_attrs(Problems),
+      items,
+    )
   }
 }
 
@@ -128,38 +287,44 @@ fn view_bottom_content(dispatch : Dispatch[Msg], model : Model) -> Html {
   let content : Html = match model.bottom_tab {
     Problems => view_problems(model)
     OpLog =>
-      @html.div(class="bottom-content", [
-        @html.span(class="no-problems", [@html.text("No operations recorded")]),
+      @html.div(class="bottom-content", attrs=bottom_panel_attrs(OpLog), [
+        @html.span(class="no-problems", [@html.text("Op log coming soon")]),
       ])
     CrdtState =>
-      @html.div(class="bottom-content crdt-state", [
-        @html.div(class="state-row", [
-          @html.span(class="state-label", [@html.text("Agent")]),
-          @html.span(class="state-value", [@html.text("local")]),
-        ]),
-        @html.div(class="state-row", [
-          @html.span(class="state-label", [@html.text("Timestamp")]),
-          @html.span(class="state-value", [
-            @html.text(model.next_timestamp.to_string()),
+      @html.div(
+        class="bottom-content crdt-state",
+        attrs=bottom_panel_attrs(CrdtState),
+        [
+          @html.div(class="state-row", [
+            @html.span(class="state-label", [@html.text("Agent")]),
+            @html.span(class="state-value", [
+              @html.text(model.editor.get_peer_id()),
+            ]),
           ]),
-        ]),
-        @html.div(class="state-row", [
-          @html.span(class="state-label", [@html.text("Text length")]),
-          @html.span(class="state-value", [
-            @html.text(model.editor.get_text().length().to_string()),
+          @html.div(class="state-row", [
+            @html.span(class="state-label", [@html.text("Timestamp")]),
+            @html.span(class="state-value", [
+              @html.text(model.next_timestamp.to_string()),
+            ]),
           ]),
-        ]),
-      ])
+          @html.div(class="state-row", [
+            @html.span(class="state-label", [@html.text("Text length")]),
+            @html.span(class="state-value", [
+              @html.text(model.editor.get_text().length().to_string()),
+            ]),
+          ]),
+        ],
+      )
     History =>
       @html.div(
         class="bottom-content history-content",
-        attrs=@html.Attrs::build().id("canopy-history-container"),
+        attrs=bottom_panel_attrs(History),
         [@html.text("")],
       )
     Graphviz =>
       @html.div(
         class="bottom-content graphviz-content",
-        attrs=@html.Attrs::build().id("canopy-graphviz-container"),
+        attrs=bottom_panel_attrs(Graphviz),
         [@html.text("")],
       )
   }

--- a/examples/ideal/main/view_history.mbt
+++ b/examples/ideal/main/view_history.mbt
@@ -255,6 +255,11 @@ fn palette_color(idx : Int) -> String {
 
 ///|
 /// Frontier stroke color — must contrast with every fill.
+///
+/// Used inside DOT, which Graphviz parses as a literal: CSS custom
+/// properties are unreachable from the layout pipeline, so the value
+/// has to live here as a string. Mirrored in `editor.css` as
+/// `--canopy-frontier`; keep the two in sync by hand.
 const FRONTIER_STROKE : String = "#ffcb6b"
 
 ///|
@@ -413,11 +418,11 @@ pub fn legend_html(
     )
   }
   // Frontier swatch — amber border, no fill — mirrors the SVG's stroke.
+  // Border color comes from `--canopy-frontier` in editor.css; the swatch
+  // is purely decorative so the chip stays free of inline style.
   buf.write_string(
-    "<span class=\"history-legend-item\" role=\"listitem\"><span class=\"history-legend-frontier\" style=\"border-color:",
+    "<span class=\"history-legend-item\" role=\"listitem\"><span class=\"history-legend-frontier\" aria-hidden=\"true\"></span>now</span>",
   )
-  buf.write_string(FRONTIER_STROKE)
-  buf.write_string("\"></span>now</span>")
   buf.write_string("</div>")
   buf.to_string()
 }
@@ -428,8 +433,11 @@ fn append_legend_chip(
   fill : String,
   label : String,
 ) -> Unit {
+  // The colored dot is decorative — it duplicates information that's
+  // already in the SVG fill, and color alone never conveys meaning to
+  // assistive tech. The text label beside it carries the agent identity.
   buf.write_string(
-    "<span class=\"history-legend-item\" role=\"listitem\"><span class=\"history-legend-dot\" style=\"background:",
+    "<span class=\"history-legend-item\" role=\"listitem\"><span class=\"history-legend-dot\" aria-hidden=\"true\" style=\"background:",
   )
   buf.write_string(fill)
   buf.write_string("\"></span>")

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -886,6 +886,13 @@ canopy-editor {
     padding: var(--space-md) var(--space-md);
   }
 
+  /* Drop the desktop's fixed 36px height on the bottom tab strip so its
+     children's 44px touch targets aren't clipped by an undersized parent. */
+  .bottom-tabs {
+    height: auto;
+    min-height: 44px;
+  }
+
   /* Hide spacers on mobile — let flex-gap handle spacing */
   .toolbar-spacer { flex: 0 0 var(--space-xs); }
 

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -33,6 +33,10 @@
   --canopy-error-text: #ef4444;
   --canopy-success: #34d058;
   --canopy-peer-blue: #58a6ff;
+  --canopy-frontier: #ffcb6b;        /* Causal-history "now" stroke. Mirrored
+                                        in MoonBit as FRONTIER_STROKE — DOT
+                                        can't read CSS vars, so the literal
+                                        must stay in sync. */
   --canopy-shadow-heavy: rgba(0, 0, 0, 0.5);
 
   /* ── Derived (hover/interaction overlays) ────────────── */
@@ -747,7 +751,7 @@ canopy-editor {
   width: 10px;
   height: 10px;
   border-radius: 2px;
-  border: 2px solid;
+  border: 2px solid var(--canopy-frontier);
   background: transparent;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

Follow-up passes on the Causal History tab after Phase 1 merged (#232 / #234). Two commits:

**`chore(ideal): bottom-panel render cache + tablist a11y + frontier token`**
- Memoize `history_render_cmd` and `graphviz_render_cmd` on `(op_count, frontier_hash, agent)`; cache the wrapped HTML so tab-switch DOM remounts get content without re-running DOT parse + Sugiyama layout + SVG render.
- Tablist semantics on `view_bottom_tabs`: `role="tablist"`/`tab` + `aria-selected` + `aria-controls`; all five panels become `role="tabpanel"` with `aria-labelledby` round-tripping back to the tab id. History and Graphviz SVGs wrapped in `role="img"` with descriptive labels (dynamic `"Causal history graph: N edits"` / static for Graphviz). Decorative legend swatches `aria-hidden`.
- Empty / too-large copy refresh; `MAX_OPS` referenced so copy can't drift.
- New `--canopy-frontier` token; inline `style="border-color"` removed from the legend swatch. `FRONTIER_STROKE` documents the cross-language sync (Graphviz can't read CSS vars).
- CRDT State Agent row reads `model.editor.get_peer_id()` instead of the hardcoded `"local"` literal — wrong any time JS sets a real `agent_id`.

**`feat(ideal): bottom-tab keyboard nav + 44px touch targets`**
- Roving tabindex (active=0, others=-1) + `Attrs::on_keydown` dispatching `SelectBottomTab(prev|next|first|last)` for ArrowLeft/Right/Up/Down/Home/End.
- New `js_focus_element` FFI; `SelectBottomTab` batches `bottom_tab_focus_cmd` with `bottom_render_cmd` so focus follows the active tab (clicks are no-ops because the browser already focused on mousedown; arrow-key switches now stay reachable instead of stranding focus on a `tabindex=-1` button).
- At `(max-width: 768px)`, `.bottom-tabs` drops the desktop `height: 36px` for `height: auto; min-height: 44px` so the existing `.tab` 44px child rule isn't clipped.

## Test plan

- [ ] `moon test` from `examples/ideal/` — 23/23 pass
- [ ] `moon check` clean
- [ ] Open History tab, type — graph updates only on actual op-count changes (cache hits skip the layout pipeline)
- [ ] Click between bottom tabs — focus stays on the clicked tab
- [ ] Tab key into the bottom strip, arrow keys cycle through tabs (wraps), Home/End jump to ends, Tab key skips the strip on next press
- [ ] Mobile viewport (<=768px) — tab buttons render at 44px tall instead of clipped at 36px
- [ ] Screen reader (VoiceOver / NVDA) announces tabs with names + selected state, and the History/Graphviz SVGs as labeled images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Programmatic focus capability for DOM elements and improved tab selection that moves keyboard focus to the active panel.

* **Accessibility**
  * WAI-ARIA tablist semantics with keyboard navigation (ArrowLeft/ArrowRight, Home/End), roving tabindex, role/aria labeling, and decorative elements marked aria-hidden.
  * Graphical panels exposed with appropriate landmark/role and screen-reader labels.

* **Performance**
  * Render caching for bottom-panel History and Graphviz views to speed panel updates.

* **Style**
  * New customizable frontier color and improved mobile bottom-tab touch sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->