### PR TITLE
fix(markdown): structural ZWSP-sentinel strip in markdown_export_text

### DIFF
--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -36,12 +36,14 @@ pub fn markdown_get_text(handle : Int) -> String {
 }
 
 ///|
-/// Return markdown text with ZWSP placeholder lines stripped.
-/// Only strips the "\n\u200B\n" pattern (empty-block sentinel from InsertBlockAfter),
-/// preserving legitimate ZWSP in user content (code blocks, pasted text).
+/// Return markdown text with ZWSP placeholder paragraphs stripped structurally.
+/// Delegates to the companion helper which walks the projection tree, identifies
+/// sentinel paragraphs (AST `Paragraph([Text("\u200B")])`), and removes only the
+/// ZWSP character itself \u2014 leaving ZWSP inside other content (code blocks,
+/// paragraphs with mixed text) untouched.
 pub fn markdown_export_text(handle : Int) -> String {
   match markdown_editors.get(handle) {
-    Some(ed) => ed.get_text().replace_all(old="\n\u200B\n", new="\n\n")
+    Some(ed) => @md_companion.export_markdown_text(ed)
     None => ""
   }
 }

--- a/lang/markdown/companion/integration_wbtest.mbt
+++ b/lang/markdown/companion/integration_wbtest.mbt
@@ -94,8 +94,9 @@ test "insert_block_after: ZWSP present in raw text, absent in export" {
   inspect(result is Ok(_), content="true")
   // Raw text has ZWSP (parser needs it)
   inspect(ed.get_text().contains("\u200B"), content="true")
-  // Export strips placeholder ZWSP (the "\n\u200B\n" pattern)
-  let exported = ed.get_text().replace_all(old="\n\u200B\n", new="\n\n")
+  // Force re-projection so export_markdown_text sees the new sentinel paragraph.
+  let _ = @editor.compute_view_patches(state, ed)
+  let exported = export_markdown_text(ed)
   inspect(exported.contains("\u200B"), content="false")
 }
 
@@ -104,9 +105,27 @@ test "export preserves legitimate ZWSP in user content" {
   let ed = new_markdown_editor("test")
   // Simulate user content with ZWSP inside text (e.g., pasted from another tool)
   ed.set_text("Hello\u200Bworld\n")
-  let exported = ed.get_text().replace_all(old="\n\u200B\n", new="\n\n")
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(state, ed)
+  let exported = export_markdown_text(ed)
   // Legitimate ZWSP inside text is preserved
   inspect(exported.contains("\u200B"), content="true")
+}
+
+///|
+/// Regression: a code block containing a line whose only content is U+200B
+/// must round-trip unchanged. The previous blind `replace_all("\n\u200B\n",
+/// "\n\n")` mangled this case.
+test "export preserves ZWSP-only line inside a code block" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("```\nfoo\n\u200B\nbar\n```\n")
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(state, ed)
+  let exported = export_markdown_text(ed)
+  // ZWSP-only line inside the fenced code block is preserved.
+  inspect(exported.contains("\n\u200B\n"), content="true")
+  // No structural mangling \u2014 original source survives untouched.
+  inspect(exported, content="```\nfoo\n\u200B\nbar\n```\n")
 }
 
 ///|

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -17,6 +17,75 @@ pub fn new_markdown_editor(
 }
 
 ///|
+/// Return markdown text with ZWSP placeholder lines stripped structurally.
+///
+/// Identifies sentinel paragraphs (those whose AST is exactly
+/// `Paragraph([Text("\u200B")])`) and removes only the ZWSP character itself,
+/// collapsing `prev\n\u200B\nnext` to `prev\n\nnext` (preserving the block
+/// separator). Leaves ZWSP inside other content (code blocks, paragraphs with
+/// other text) untouched.
+pub fn export_markdown_text(
+  editor : @editor.SyncEditor[@markdown.Block],
+) -> String {
+  let src = editor.get_text()
+  guard editor.get_proj_node() is Some(root) else { return src }
+  let source_map = editor.get_source_map()
+  let ranges : Array[(Int, Int)] = []
+  collect_zwsp_ranges(root, source_map, ranges)
+  if ranges.is_empty() {
+    return src
+  }
+  ranges.sort_by(fn(a, b) { a.0.compare(b.0) })
+  let buf = StringBuilder::new()
+  let mut pos = 0
+  for r in ranges {
+    let (s, e) = r
+    if s > pos {
+      buf.write_string(src[pos:s].to_owned())
+    }
+    pos = e
+  }
+  if pos < src.length() {
+    buf.write_string(src[pos:].to_owned())
+  }
+  buf.to_string()
+}
+
+///|
+/// Walk the projection tree and append the source range of every ZWSP-sentinel
+/// Paragraph to `out`. The range covers exactly the ZWSP character (the "text"
+/// token span), so removing it from source converts `\n\u200B\n` into `\n\n`.
+fn collect_zwsp_ranges(
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+  out : Array[(Int, Int)],
+) -> Unit {
+  if is_zwsp_sentinel(node.kind) {
+    match source_map.get_token_span(node.id(), "text") {
+      Some(r) => out.push((r.start, r.end))
+      None => ()
+    }
+    return
+  }
+  for child in node.children {
+    collect_zwsp_ranges(child, source_map, out)
+  }
+}
+
+///|
+fn is_zwsp_sentinel(block : @markdown.Block) -> Bool {
+  match block {
+    Paragraph(inlines) =>
+      inlines.length() == 1 &&
+      (match inlines[0] {
+        Text(s) => s == "\u200B"
+        _ => false
+      })
+    _ => false
+  }
+}
+
+///|
 /// Bridge a structural MarkdownEditOp into the text CRDT by computing
 /// span-level text edits and applying them via SyncEditor.
 pub fn apply_markdown_edit(

--- a/lang/markdown/companion/moon.pkg
+++ b/lang/markdown/companion/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "dowdiness/canopy/core" @core,
   "dowdiness/canopy/editor" @editor,
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/proj" @md_proj,

--- a/lang/markdown/companion/pkg.generated.mbti
+++ b/lang/markdown/companion/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub fn apply_markdown_edit(@editor.SyncEditor[@markdown.Block], @edits.MarkdownEditOp, Int) -> Result[Unit, String]
 
+pub fn export_markdown_text(@editor.SyncEditor[@markdown.Block]) -> String
+
 pub fn new_markdown_editor(String, capture_timeout_ms? : Int) -> @editor.SyncEditor[@markdown.Block]
 
 // Errors


### PR DESCRIPTION
## Summary

- Replaces the blind `text.replace_all(\"\n​\n\", \"\n\n\")` in `markdown_export_text` with a structural walk that identifies sentinel paragraphs (AST `Paragraph([Text(\"​\")])`, inserted by `InsertBlockAfter`) and removes only the ZWSP byte range reported by the SourceMap.
- A code block containing a legitimately-ZWSP-only line now round-trips byte-identically; ZWSP inside any other content (mixed-text paragraphs, code blocks, inline spans) is left untouched.
- New `pub fn export_markdown_text(editor) -> String` lives in `lang/markdown/companion`; the FFI `markdown_export_text` becomes a thin wrapper.

Closes follow-up F2 from the 2026-05-09 cohesion audit (#236); flagged by CodeRabbit there and deferred as out-of-scope at the time.

## Why structural beats blind replace

| Source | Blind `replace_all` | Structural strip |
|---|---|---|
| `prev\n​\nnext` (sentinel) | `prev\n\nnext` ✓ | `prev\n\nnext` ✓ |
| `\`\`\`\nfoo\n​\nbar\n\`\`\`` (code block w/ ZWSP-only line) | `\`\`\`\nfoo\n\nbar\n\`\`\`` ✗ corrupts user content | unchanged ✓ |
| `Hello​world` (inline ZWSP) | unchanged ✓ | unchanged ✓ |

## Mechanics

The \"text\" token span set by `populate_token_spans.set_content_span` for a `Paragraph` covers the inline content with the trailing `NewlineToken` trimmed. For a sentinel paragraph whose source is exactly `​\n`, that span is the single ZWSP code unit. Stripping just that range turns `prev\n​\nnext` into `prev\n\nnext` — i.e., the block separator survives.

## Test plan

- [x] `moon test -p dowdiness/canopy/lang/markdown/companion` — 8/8 (7 prior + 1 new regression test).
- [x] `moon test` — full workspace 911/911 pass.
- [x] `moon check` clean.
- [x] `moon info` — `.mbti` diff is exactly `+pub fn export_markdown_text(@editor.SyncEditor[@markdown.Block]) -> String` in companion; FFI signature unchanged.
- [x] Codex review (read-only, high reasoning) — no correctness blockers; one note: a user-authored paragraph that is *exactly* `​` is also stripped, which matches prior `replace_all` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)