### PR TITLE
docs(api): annotate position units (#216 step 3)

### DIFF
--- a/docs/development/API_REFERENCE.md
+++ b/docs/development/API_REFERENCE.md
@@ -11,20 +11,38 @@ The `SyncEditor` is the primary facade for the editor application, integrating t
   Creates the lambda-calculus editor facade used by the current apps and tests.
 
 ### Text Operations
+
+> All `Int` positions in this section are **UTF-16 code-unit offsets** at the
+> editor layer. Forwarded into the eg-walker text facade they address
+> *item-space* (visible-character count). The two coincide for ASCII and
+> diverge for non-ASCII inputs in known, bimodal ways. See
+> [Position Units](#position-units) for the full contract and sharp edges.
+
 - `insert(text : String) -> Unit raise`
-  Inserts text at the current cursor position.
+  Inserts text at the current cursor position. The cursor is advanced by
+  `text.length()` (code units), which for non-ASCII input may not be a
+  grapheme boundary.
 - `delete() -> Bool`
   Deletes the character at the current cursor position (forward delete).
+  Operates on a single code-unit slot at the editor layer.
 - `backspace() -> Bool`
-  Deletes the character before the current cursor position.
+  Deletes the character before the current cursor position. Removes a
+  single code-unit slot — see [Position Units](#position-units) for the
+  combining-mark and surrogate-pair edges.
 - `move_cursor(position : Int) -> Unit`
-  Moves the cursor to the specified absolute position.
+  Moves the cursor to the specified absolute position. `position` is a
+  UTF-16 code-unit offset clamped to `[0, doc.len()]`. The future external
+  contract is a grapheme-cluster offset; the unit will be tightened (and
+  may be wrapped in a `GraphemeOffset` opaque type — name reserved) once
+  the **moji** UAX #29 dependency is available.
 - `get_text() -> String`
   Returns the full document text.
 - `get_cursor() -> Int`
-  Returns the current cursor position.
+  Returns the current cursor position as a UTF-16 code-unit offset.
+  Same future direction as `move_cursor`.
 - `set_text(new_text : String) -> Unit`
   Replaces the entire document text (useful for initialization).
+  Routes through `text_diff::compute_edit`; see [Text Diff](#text-diff-editortext_diff).
 
 ### Undo/Redo
 - `insert_and_record(text : String, timestamp_ms : Int) -> Unit raise`
@@ -72,6 +90,67 @@ The `SyncEditor` is the primary facade for the editor application, integrating t
   Applies incoming wire data. Malformed protocol/input frames are intentionally
   dropped as resilience policy; typed decode helpers exist when diagnostics are
   needed outside the hot path.
+
+## Text Diff (`@editor.text_diff`)
+
+- `compute_edit(old_text : String, new_text : String) -> @loom_core.Edit`
+  Computes a parser `Edit` describing the splice that turns `old_text` into
+  `new_text`. The returned `start`, `delete_len`, and inserted-length fields
+  are all in **UTF-16 code units** — `compute_edit` operates on `String`
+  arguments directly and does not pass through eg-walker, so it does not
+  inherit the typed-rejection behavior described in
+  [Position Units](#position-units). Non-ASCII inputs (notably surrogate
+  pairs and BMP combining marks) can produce splices that are not aligned
+  to grapheme boundaries; this is pinned by xfail tests in
+  `editor/text_diff_test.mbt` and resolved as part of issue #216 once
+  **moji** is available.
+
+## Position Units
+
+> **Status (2026-05-09):** this section documents the *current* contract,
+> not the target one. Tracked at canopy [#216][issue-216]. The editor's
+> intended external contract is grapheme-cluster offsets; landing it is
+> blocked on the **moji** UAX #29 library.
+
+[issue-216]: https://github.com/dowdiness/canopy/issues/216
+
+Three position units appear in the text-editing surface:
+
+| Layer | Unit (today) | What it counts |
+|---|---|---|
+| Editor (`SyncEditor::*`, `text_diff::compute_edit`) | UTF-16 code-unit offset | One slot per `String.length()` increment. Non-BMP code points count as 2; combining marks count as 1. |
+| eg-walker text facade (`@text.Pos`, `TextState::len` via `visible_count()`) | Item-space offset | One slot per atomic content `Op`. Post eg-walker [#31][egw31] / canopy [#240][canopy240], inputs are split into per-codepoint atomic Ops, so item-space is closely aligned with code-point count. |
+| Future external contract | Grapheme-cluster offset | One slot per UAX #29 grapheme cluster. Not yet implemented. |
+
+[egw31]: https://github.com/dowdiness/event-graph-walker/issues/31
+[canopy240]: https://github.com/dowdiness/canopy/pull/240
+
+The editor advances its cursor by `text.length()` (code units) and forwards
+the resulting `Int` to the eg-walker facade, whose internal addressing is
+item-space. The two coincide for ASCII; for non-ASCII inputs they diverge
+along the failure modes below.
+
+A future `GraphemeOffset` opaque type may replace `Int` at the editor's
+public boundary once **moji** lands. The name is **reserved** — no such
+type exists today.
+
+### Known sharp edges (non-ASCII inputs)
+
+The non-ASCII failure surface is **bimodal** — two distinct paths, two
+distinct failure modes. Both are pinned by xfail tests added in
+[#239][canopy239]:
+
+| Inputs | Failure mode |
+|---|---|
+| Surrogate-pair (emoji, ZWJ family, regional indicator) | **Typed rejection** at the CRDT boundary. After eg-walker [#31][egw31] / canopy [#240][canopy240], the eg-walker text facade splits inputs into per-codepoint atomic Ops and rejects mid-surrogate positions with `TextError::SyncFailed(MalformedContent { ... })` rather than aborting via `String::sub`. The editor layer does not yet round-trip these inputs cleanly: `cursor + text.length()` advancement after `insert("😀")` can land between the high and low surrogate from the editor's point of view, and `backspace` removes only one code unit. |
+| BMP combining marks (NFD `"e\u{0301}"`) | **Silent corruption.** `backspace` deletes only the trailing combining mark; `text_diff::compute_edit` reports a 1-code-unit delete. No abort, no rejection — the output is wrong. This path is unaffected by eg-walker [#31][egw31] / canopy [#240][canopy240]; only editor-layer grapheme awareness closes it. |
+
+The grapheme-aware fix at the editor layer (Step 2 of [#216][issue-216])
+is what closes both edges; it is blocked on **moji**. Until then, callers
+should treat editor positions as UTF-16 code-unit offsets and avoid
+constructing positions arithmetically across non-ASCII boundaries.
+
+[canopy239]: https://github.com/dowdiness/canopy/pull/239
 
 ## EphemeralStore (`@editor.EphemeralStore`)
 


### PR DESCRIPTION
## Summary

Step 3 of issue #216 — annotate position units in `docs/development/API_REFERENCE.md` to document the *current* contract honestly while pointing at the future grapheme-aware direction.

- Annotate every public position-taking API in `editor/` with its current unit:
  - `SyncEditor::insert`, `delete`, `backspace`, `move_cursor`, `get_cursor`, `set_text`
  - `text_diff::compute_edit` (added — was previously undocumented in this reference)
- New **Position Units** section captures the three layers:
  - editor: UTF-16 code-unit offsets
  - eg-walker text facade: item-space (`visible_count` / per-codepoint atomic Ops post #240)
  - future: grapheme-cluster offsets, blocked on **moji**
- Records the **bimodal** non-ASCII failure surface pinned by xfail tests in #239:
  - **Surrogate-pair** inputs → typed `TextError::SyncFailed(MalformedContent { ... })` rejection at the CRDT boundary, post canopy #240 / eg-walker #31. Editor still doesn't round-trip cleanly.
  - **BMP combining marks** (NFD `e\u{0301}`) → silent corruption; unaffected by #240. Closed only by editor-layer grapheme awareness.
- Reserves the `GraphemeOffset` opaque-type name without introducing it now.

No code changes — docs only. Issue #216 checklist item *"Annotate `position` unit in `docs/development/API_REFERENCE.md`"* is now satisfiable.

## Test plan

- [x] `moon check` — clean
- [x] `moon test` — 921/921 passed (workspace)
- [x] Manually inspected rendered structure (section headers + cross-links)
- [ ] No round-trip examples added that would exercise the broken paths (failure modes are pinned in tests, not docs)

Refs #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation to clarify text-editing coordinate handling and position semantics across different system layers.
  * Added documentation for the `compute_edit` function specifying how it processes text changes.
  * Introduced a Position Units section detailing UTF-16 code unit handling and known behavior with non-ASCII text.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->