### PR TITLE
refactor(ideal-bridge): migrate per-char loop to handle_text_intent

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -267,11 +267,8 @@ on **moji** (in-progress MoonBit UAX #29 library). The #242 audit
 (`docs/plans/2026-05-09-216-step4-bridge-audit.md`) localises the
 conversion seam and lists follow-ups not blocked on moji.
 
-- [ ] Migrate `examples/ideal/web/src/bridge.ts` per-char `insert_at`/`delete_at` loop onto `handle_text_intent`.
-  Why: the older ideal bridge currently composes positions in JS using `get_source_map_json` + per-char iteration (`bridge.ts:143-164`). Moving it onto `handle_text_intent` puts it on the same bulk-splice seam as CM6Adapter, so a single MoonBit-side grapheme shim covers both.
-  Plan: `docs/plans/2026-05-09-216-step4-bridge-audit.md` (Path D, follow-up #1)
-  Exit: ideal bridge no longer calls `insert_at`/`delete_at` in its hot path; existing CM6 NodeView keystroke flow still passes.
-  Status: not blocked on moji.
+- [x] Migrate `examples/ideal/web/src/bridge.ts` per-char `insert_at`/`delete_at` loop onto `handle_text_intent`.
+  Shipped: bridge now calls `handle_text_intent_checked` (Bool-returning FFI added in `ffi/lambda/intent.mbt`) once per CM6 change with cumulative-delta bookkeeping; partial-batch + drift-detection semantics preserved from the prior `applyCharChanges` loop.
 
 - [ ] (moji-blocked) Switch `SyncEditor::backspace` to a grapheme boundary (`editor/sync_editor_text.mbt:37`).
   Plan: bulk-splice seam at `apply_text_edit_internal`; cursor clamping at the per-char path.

--- a/examples/ideal/main/crdt_reexport.mbt
+++ b/examples/ideal/main/crdt_reexport.mbt
@@ -163,6 +163,22 @@ pub fn handle_text_intent(
 }
 
 ///|
+/// Bounds-checked variant of `handle_text_intent`. Returns false when the
+/// requested splice would have been silently clamped by the editor seam,
+/// leaving the CRDT untouched so the caller can resync without
+/// broadcasting a clamped delta to peers. Used by the structural-mode
+/// bridge in `examples/ideal/web/src/bridge.ts`.
+pub fn handle_text_intent_checked(
+  handle : Int,
+  from : Int,
+  deleted_len : Int,
+  insert : String,
+  timestamp_ms : Int,
+) -> Bool {
+  @ffi.handle_text_intent_checked(handle, from, deleted_len, insert, timestamp_ms)
+}
+
+///|
 /// Undo on the MoonBit editor directly and return whether it succeeded.
 pub fn handle_undo(handle : Int) -> Bool {
   @ffi.handle_undo(handle)

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -50,6 +50,7 @@ options(
         "ephemeral_get_peer_cursors_json",
         "ephemeral_remove_outdated",
         "handle_text_intent",
+        "handle_text_intent_checked",
         "handle_undo",
         "handle_redo",
         "handle_structural_intent",

--- a/examples/ideal/web/src/bridge.ts
+++ b/examples/ideal/web/src/bridge.ts
@@ -6,7 +6,7 @@ import type { CrdtModule, ProjNodeJson } from "./types";
  * CrdtBridge — connects PM NodeViews to the CRDT backend.
  *
  * Handles:
- * - Leaf text edits (CM6 → char-at-a-time CRDT ops via source map)
+ * - Leaf text edits (CM6 → bulk-splice via handle_text_intent + source map)
  * - Token edits (lambda param, let-def name)
  * - Structural edits (delete, wrap via TreeEditOp)
  * - Remote sync (apply ops → reconcile PM)
@@ -72,11 +72,8 @@ export class CrdtBridge {
       this.scheduleReconcile();
       return;
     }
-    const basePos: number = entry.start;
-    const ts = Date.now();
-
-    if (!this.applyCharChanges(basePos, ts, changes)) {
-      // Delete failed — CM6 is out of sync with CRDT. Reconcile to resync.
+    if (!this.applySpliceChanges(entry.start, Date.now(), changes)) {
+      // CM6/CRDT drift — abort the batch to avoid broadcasting a clamped edit.
       this.scheduleReconcile();
       return;
     }
@@ -92,10 +89,7 @@ export class CrdtBridge {
       this.scheduleReconcile();
       return;
     }
-    const basePos: number = entry.token_spans[tokenRole].start;
-    const ts = Date.now();
-
-    if (!this.applyCharChanges(basePos, ts, changes)) {
+    if (!this.applySpliceChanges(entry.token_spans[tokenRole].start, Date.now(), changes)) {
       this.scheduleReconcile();
       return;
     }
@@ -139,8 +133,25 @@ export class CrdtBridge {
     }
   }
 
-  /** Apply char-at-a-time CRDT changes. Returns false if any delete fails. */
-  private applyCharChanges(
+  /**
+   * Apply CM6 changes to the CRDT as bulk splices via `handle_text_intent_checked`.
+   *
+   * `iterChanges` emits non-overlapping ranges in old-doc order, so each
+   * subsequent call must be shifted by the cumulative net delta of prior
+   * splices in the same batch (matches the offset bookkeeping the prior
+   * per-char loop used).
+   *
+   * Returns false on drift: `apply_text_edit_internal` would silently clamp
+   * an out-of-bounds index, and the bridge would then broadcast that clamped
+   * edit to peers before reconcile runs. The checked variant rejects the
+   * splice instead, mirroring the old `delete_at`-returns-false recovery path.
+   *
+   * A multi-change batch where splice K fails leaves splices 0..K-1 applied
+   * to the CRDT but un-broadcast on this edit; the next successful edit's
+   * `export_since_json` broadcast carries them as part of the CRDT delta.
+   * This matches the prior per-char loop's behavior — preserved, not new.
+   */
+  private applySpliceChanges(
     basePos: number,
     ts: number,
     changes: { from: number; to: number; insert: string }[],
@@ -148,18 +159,22 @@ export class CrdtBridge {
     let posOffset = 0;
     for (const change of changes) {
       const deleteLen = change.to - change.from;
-      for (let i = deleteLen - 1; i >= 0; i--) {
-        const ok = this.crdt.delete_at(this.handle, basePos + change.from + i + posOffset, ts);
-        if (!ok) {
-          console.warn("delete_at failed at", basePos + change.from + i + posOffset);
-          return false;
-        }
+      const ok = this.crdt.handle_text_intent_checked(
+        this.handle,
+        basePos + change.from + posOffset,
+        deleteLen,
+        change.insert,
+        ts,
+      );
+      if (!ok) {
+        console.warn(
+          "handle_text_intent_checked drift at",
+          basePos + change.from + posOffset,
+          "deleteLen=", deleteLen,
+        );
+        return false;
       }
-      posOffset -= deleteLen;
-      for (let i = 0; i < change.insert.length; i++) {
-        this.crdt.insert_at(this.handle, basePos + change.from + posOffset + i, change.insert[i], ts);
-      }
-      posOffset += change.insert.length;
+      posOffset += change.insert.length - deleteLen;
     }
     return true;
   }

--- a/examples/ideal/web/src/types.ts
+++ b/examples/ideal/web/src/types.ts
@@ -57,6 +57,7 @@ export interface CrdtModule {
   ephemeral_remove_outdated(handle: number): void;
   // Protocol-based intent handlers (Phase 4)
   handle_text_intent(handle: number, from: number, deletedLen: number, insert: string, timestampMs: number): void;
+  handle_text_intent_checked(handle: number, from: number, deletedLen: number, insert: string, timestampMs: number): boolean;
   handle_undo(handle: number): boolean;
   handle_redo(handle: number): boolean;
   handle_structural_intent(handle: number, op: string, nodeId: string, timestampMs: number, paramsJson: string): string;

--- a/ffi/lambda/intent.mbt
+++ b/ffi/lambda/intent.mbt
@@ -74,6 +74,35 @@ pub fn handle_text_intent(
 }
 
 ///|
+/// Bounds-checked variant of `handle_text_intent`. Returns `false` when the
+/// requested splice would have been silently clamped by
+/// `apply_text_edit_internal` — i.e. when the caller's view of the document
+/// has drifted from the CRDT's. The CRDT is left untouched in that case so
+/// the caller can resync without broadcasting garbage to peers.
+pub fn handle_text_intent_checked(
+  handle : Int,
+  from : Int,
+  deleted_len : Int,
+  insert : String,
+  timestamp_ms : Int,
+) -> Bool {
+  match lambda_handles.get(handle) {
+    Some(h) => {
+      let text_len = h.editor.get_text().length()
+      if from < 0 ||
+        deleted_len < 0 ||
+        from > text_len ||
+        from + deleted_len > text_len {
+        return false
+      }
+      h.editor.apply_text_edit(from, deleted_len, insert, timestamp_ms)
+      true
+    }
+    None => false
+  }
+}
+
+///|
 pub fn handle_undo(handle : Int) -> Bool {
   undo_manager_undo(handle)
 }

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -69,6 +69,7 @@ options(
         "get_view_tree_json",
         "compute_view_patches_json",
         "handle_text_intent",
+        "handle_text_intent_checked",
         "handle_undo",
         "handle_redo",
         "handle_structural_intent",

--- a/ffi/lambda/pkg.generated.mbti
+++ b/ffi/lambda/pkg.generated.mbti
@@ -81,6 +81,8 @@ pub fn handle_structural_intent(Int, String, String, Int, String) -> String
 
 pub fn handle_text_intent(Int, Int, Int, String, Int) -> Unit
 
+pub fn handle_text_intent_checked(Int, Int, Int, String, Int) -> Bool
+
 pub fn handle_undo(Int) -> Bool
 
 pub fn insert_and_record(Int, String, Int) -> Unit


### PR DESCRIPTION
## Summary

Audit follow-up #1 from #216 / #242. The older ideal ProseMirror bridge (`examples/ideal/web/src/bridge.ts`) was the last text-edit path on `insert_at` / `delete_at`. This migrates it onto `handle_text_intent`, the same bulk-splice seam `CM6Adapter` already uses, so a future grapheme/moji shim only has to land at one seam.

- Bridge `handleLeafEdit` / `handleTokenEdit` now delegate to `applySpliceChanges`, which issues one CRDT splice per CM6 `iterChanges` entry with cumulative-delta bookkeeping (CM6 emits ranges in old-doc forward order; each call must shift by the net delta of prior splices in the batch).
- Drops `applyCharChanges` and the per-char N+M `delete_at`/`insert_at` loop.

## Drift detection

`apply_text_edit_internal` silently clamps out-of-bounds `start`/`deleted_len`. To keep the prior `delete_at`-returns-false drift recovery, this PR adds `handle_text_intent_checked` in `ffi/lambda/intent.mbt`. It returns `false` when the splice would have been clamped and leaves the CRDT untouched, so a drifted CM6 frame can't broadcast garbage to peers. The bridge skips `afterLocalEdit()` on `false` and schedules a reconcile, matching the prior recovery path.

## Partial-batch behavior

Preserved exactly. If splice K in a multi-change batch fails, splices 0..K-1 stay applied to the CRDT but skip this broadcast; they ride the next successful edit's `export_since_json` delta. Same as the prior loop — neither introduced nor fixed by this PR.

## Out of scope (per #216 audit)

- Grapheme/moji handling — Step 2 of #216, blocked on moji.
- Removing `insert_at` / `delete_at` from FFI — still used by ideal whitebox tests.
- `compute_split_block` / `UserIntent.SetCursor.position` cleanups — separate audit follow-ups.

## Test plan

- [x] `moon check` workspace — clean
- [x] `moon test` workspace — 921/921
- [x] `cd examples/ideal && moon test` — 23/23
- [x] `cd examples/ideal/web && npx tsc --noEmit` — clean
- [x] Manual smoke (Playwright against live dev server): typed into leaf, did select+replace splice, backspace; CM6 stayed in sync with CRDT, zero console errors / warnings
- [ ] Full Playwright e2e — pre-existing tsx/Node 24 + CJS top-level-await bug in `server/ws-server.ts` blocks Playwright's auto-start of the WS server (unrelated to this change). Verified manually instead.
- [x] Codex review — flagged that option (b) "rely on post-edit reconcile" silently broadcast clamped deltas to peers; addressed by introducing `handle_text_intent_checked`. Re-review confirmed the regression is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)