### PR TITLE
docs(api): annotate compute_split_block offset unit (#216 §16)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -279,8 +279,7 @@ conversion seam and lists follow-ups not blocked on moji.
 
 - [ ] (moji-blocked) Add `move_cursor_left_grapheme` / `_right_grapheme` (and word variants per UAX #29) on `SyncEditor`.
 
-- [ ] Add a one-line docstring to `lang/markdown/edits/compute_markdown_edit.mbt:211 compute_split_block` noting `offset` is a code-unit offset inside the text span.
-  Status: not blocked on moji; cleanup item from the audit's open follow-ups.
+- [x] Add a one-line docstring to `lang/markdown/edits/compute_markdown_edit.mbt:211 compute_split_block` noting `offset` is a code-unit offset inside the text span.
 
 - [ ] Disambiguate `UserIntent.SetCursor.position` — same `number` carries PM-tree positions (PMAdapter) and CM-doc code-unit offsets (CM6Adapter). Naming cleanup, not unit conversion.
   Status: not blocked on moji.

--- a/docs/plans/2026-05-09-216-step4-bridge-audit.md
+++ b/docs/plans/2026-05-09-216-step4-bridge-audit.md
@@ -97,14 +97,22 @@ in reverse at the same seam.
 HTMLTextAreaElement
   → onKeydown('Enter' mid-text)
   → emit StructuralEdit{ op: 'split_block', params: { offset: String(selectionStart) } }
-  → main.ts → crdt.handle_structural_intent(...)
-  → ffi/markdown/markdown_ffi.mbt → apply_markdown_tree_edit_json
-  → lang/markdown/edits/compute_markdown_edit.mbt:211  compute_split_block
+  → examples/web/src/markdown-editor.ts blockInput.onIntent
+  → applyEdit('split_block', nodeId, '', parseInt(params.offset))
+  → crdt.markdown_apply_edit(handle, 'split_block', nodeId, '', offset, ts)
+  → ffi/markdown/markdown_ffi.mbt:62 markdown_apply_edit
+       (param2 is reused as the offset slot; "split_block" → SplitBlock op)
+  → lang/markdown/edits/compute_markdown_edit.mbt:211 compute_split_block
        offset is a code-unit offset *inside the source-mapped text span*:
          split_pos = text_range.start + offset
          delete_len = range.end - split_pos
          FocusHint::MoveCursor(position = split_pos + separator.length())
 ```
+
+The markdown editor uses its own `markdown_apply_edit` FFI (a fixed-arity
+six-argument bridge with a `param1: String` / `param2: Int` reuse pattern),
+*not* the lambda editor's `handle_structural_intent` — the two structural-
+edit FFIs evolved separately.
 
 **Sharp edge.** `selectionStart` and `text_range.start/end` are both
 UTF-16 code units, so the path is internally consistent for ASCII; for

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -208,6 +208,13 @@ fn compute_insert_block_after(
 
 ///|
 /// Split block at cursor offset within the text span.
+///
+/// `offset` is a UTF-16 code-unit offset inside the block's text span
+/// (i.e. relative to `text_range.start`, not the document root). Same
+/// unit caveat as `SyncEditor::move_cursor`: pre-moji this is not
+/// grapheme-aware, so callers should clamp to a grapheme boundary
+/// before passing — see `docs/plans/2026-05-09-216-step4-bridge-audit.md`
+/// Path B.
 fn compute_split_block(
   source : String,
   proj : ProjNode[@markdown.Block],


### PR DESCRIPTION
## Summary

Audit follow-up #2 from #242. Adds an inline docstring on
`compute_split_block` clarifying that `offset` is a UTF-16 code-unit
offset relative to the block's text-span start (not the document root,
not a grapheme offset). Same unit caveat as `SyncEditor::move_cursor`.

Caller-side plumbing is documented in the Path B trace of
`docs/plans/2026-05-09-216-step4-bridge-audit.md`; this puts the unit
annotation at the callee so future readers don't have to chase to the
audit doc to understand what they're passing.

Marks the TODO §16 item done.

## Also fixes (Codex catch)

The original Path B trace named the lambda editor's
`handle_structural_intent` and a nonexistent
`apply_markdown_tree_edit_json`. The markdown editor actually uses
its own `markdown_apply_edit` FFI (a six-arg fixed-arity bridge with
a `param1`/`param2` reuse pattern) — the two structural-edit FFIs
evolved separately. Updates Path B's trace to match the live code.

## Followup observed (not in this PR)

Path D in the same audit doc still describes the older ideal bridge
as using per-char `insert_at`/`delete_at`; that became stale when
#246 migrated it to `handle_text_intent_checked`. Worth tracking as
a separate one-line audit-doc cleanup so this PR stays scoped to the
Codex finding.

## Test plan
- [x] `moon check` clean
- [x] `moon test` 921/921
- [x] `moon fmt && moon info` clean
- [x] Codex review confirmed docstring claims (a)-(d) are factually correct
- [x] Codex flagged Path B FFI naming staleness — addressed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)