### PR TITLE
[codex] Update event-graph-walker for cheaper lv_to_position

### DIFF
--- a/core/projection_memo.mbt
+++ b/core/projection_memo.mbt
@@ -13,8 +13,8 @@ pub fn[T : TreeNode] build_projection_memos(
   @incr.Memo[Map[NodeId, ProjNode[T]]],
   @incr.Memo[SourceMap],
 ) {
-  let prev_proj_ref : Ref[ProjNode[T]?] = Ref::new(None)
-  let counter : Ref[Int] = Ref::new(0)
+  let prev_proj_ref : Ref[ProjNode[T]?] = Ref(None)
+  let counter : Ref[Int] = Ref(0)
 
   let proj_memo : @incr.Memo[ProjNode[T]?] = @incr.Memo::new_no_backdate(
     rt,

--- a/core/reconcile_properties_wbtest.mbt
+++ b/core/reconcile_properties_wbtest.mbt
@@ -14,6 +14,29 @@ impl @quickcheck.Arbitrary for TestExpr with arbitrary(size, rs) {
 impl @qc.Shrink for TestExpr
 
 ///|
+struct TestExprPair {
+  old : TestExpr
+  new : TestExpr
+} derive(Debug)
+
+///|
+impl Show for TestExprPair with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+impl @quickcheck.Arbitrary for TestExprPair with arbitrary(size, rs) {
+  let depth = if size < 1 { 1 } else if size > 4 { 4 } else { size }
+  {
+    old: gen_test_expr(rs.split(), depth),
+    new: gen_test_expr(rs.split(), depth),
+  }
+}
+
+///|
+impl @qc.Shrink for TestExprPair
+
+///|
 /// Bounded-depth recursive generator for TestExpr trees.
 fn gen_test_expr(rs : @splitmix.RandomState, depth : Int) -> TestExpr {
   if depth <= 0 {
@@ -124,13 +147,14 @@ fn all_unique(arr : Array[Int]) -> Bool {
 ///|
 /// Property 1: All NodeIds are unique after reconcile.
 /// After reconcile(old, new, counter), the result tree has no duplicate IDs.
-fn prop_unique_ids_after_reconcile(pair : (TestExpr, TestExpr)) -> Bool {
-  let (old_expr, new_expr) = pair
-  let old_counter = Ref::new(0)
+fn prop_unique_ids_after_reconcile(pair : TestExprPair) -> Bool {
+  let old_expr = pair.old
+  let new_expr = pair.new
+  let old_counter = Ref(0)
   let old_node = to_proj_node(old_expr, old_counter)
-  let new_counter = Ref::new(0)
+  let new_counter = Ref(0)
   let new_node = to_proj_node(new_expr, new_counter)
-  let counter = Ref::new(1000)
+  let counter = Ref(1000)
   let result = reconcile(old_node, new_node, counter)
   let ids = collect_ids(result)
   all_unique(ids)
@@ -146,11 +170,11 @@ test "property: unique IDs after reconcile" {
 /// Building two ProjNodes from the same TestExpr (with different ID ranges)
 /// and reconciling should yield the old tree's IDs positionally.
 fn prop_preserves_ids_for_identical_trees(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old_node = to_proj_node(expr, counter)
-  let new_counter = Ref::new(500)
+  let new_counter = Ref(500)
   let new_node = to_proj_node(expr, new_counter)
-  let reconcile_counter = Ref::new(1000)
+  let reconcile_counter = Ref(1000)
   let result = reconcile(old_node, new_node, reconcile_counter)
   let old_ids = collect_ids(old_node)
   let result_ids = collect_ids(result)
@@ -177,11 +201,11 @@ test "property: preserves IDs for identical trees" {
 /// We test this by building two trees with the same shape but different labels.
 fn prop_uses_new_kind_values(expr : TestExpr) -> Bool {
   let relabeled = relabel_expr(expr, "old_")
-  let counter_old = Ref::new(0)
+  let counter_old = Ref(0)
   let old_node = to_proj_node(relabeled, counter_old)
-  let counter_new = Ref::new(500)
+  let counter_new = Ref(500)
   let new_node = to_proj_node(expr, counter_new)
-  let reconcile_counter = Ref::new(1000)
+  let reconcile_counter = Ref(1000)
   let result = reconcile(old_node, new_node, reconcile_counter)
   let result_kinds = collect_kinds(result)
   let new_kinds = collect_kinds(new_node)
@@ -216,17 +240,17 @@ test "property: uses new kind values after reconcile" {
 /// reconcile(tree, tree) then reconcile(result, tree) should produce
 /// the same IDs as the first reconcile.
 fn prop_idempotent_on_stable(expr : TestExpr) -> Bool {
-  let counter1 = Ref::new(0)
+  let counter1 = Ref(0)
   let tree1 = to_proj_node(expr, counter1)
-  let counter2 = Ref::new(500)
+  let counter2 = Ref(500)
   let tree2 = to_proj_node(expr, counter2)
-  let counter3 = Ref::new(800)
+  let counter3 = Ref(800)
   let tree3 = to_proj_node(expr, counter3)
   // First reconcile
-  let rc1 = Ref::new(1000)
+  let rc1 = Ref(1000)
   let result1 = reconcile(tree1, tree2, rc1)
   // Second reconcile: reconcile(result1, tree3)
-  let rc2 = Ref::new(2000)
+  let rc2 = Ref(2000)
   let result2 = reconcile(result1, tree3, rc2)
   // IDs from result1 and result2 should be the same
   let ids1 = collect_ids(result1)
@@ -262,15 +286,15 @@ fn prop_retained_siblings_keep_ids_after_insert(expr : TestExpr) -> Bool {
     Branch(t, _) => t
     _ => ""
   }
-  let old_counter = Ref::new(0)
+  let old_counter = Ref(0)
   let old_node = to_proj_node(expr, old_counter)
   // Build new tree with an extra Leaf inserted in the middle
   let insert_idx = children.length() / 2
   let new_children = insert_at(children, insert_idx, Leaf("inserted"))
   let new_expr = Branch(tag, new_children)
-  let new_counter = Ref::new(500)
+  let new_counter = Ref(500)
   let new_node = to_proj_node(new_expr, new_counter)
-  let reconcile_counter = Ref::new(1000)
+  let reconcile_counter = Ref(1000)
   let result = reconcile(old_node, new_node, reconcile_counter)
   // The old IDs for retained children should appear in the result.
   // Build a set of old child IDs
@@ -311,15 +335,15 @@ fn prop_reused_id_count_after_delete(expr : TestExpr) -> Bool {
     Branch(t, _) => t
     _ => ""
   }
-  let old_counter = Ref::new(0)
+  let old_counter = Ref(0)
   let old_node = to_proj_node(expr, old_counter)
   // Build new tree with one child removed from the middle
   let remove_idx = children.length() / 2
   let new_children = remove_at(children, remove_idx)
   let new_expr = Branch(tag, new_children)
-  let new_counter = Ref::new(500)
+  let new_counter = Ref(500)
   let new_node = to_proj_node(new_expr, new_counter)
-  let reconcile_counter = Ref::new(1000)
+  let reconcile_counter = Ref(1000)
   let result = reconcile(old_node, new_node, reconcile_counter)
   // Result should have one fewer child
   if result.children.length() != old_node.children.length() - 1 {
@@ -353,18 +377,19 @@ test "property: reused ID count correct after child deletion" {
 /// Given different old and new trees, reconcile(old, new) then
 /// reconcile(result1, new_copy) should produce the same IDs —
 /// a second pass on the same new tree shouldn't change anything.
-fn prop_reconcile_idempotent_on_diff_trees(pair : (TestExpr, TestExpr)) -> Bool {
-  let (old_expr, new_expr) = pair
+fn prop_reconcile_idempotent_on_diff_trees(pair : TestExprPair) -> Bool {
+  let old_expr = pair.old
+  let new_expr = pair.new
   // Build old tree with counter range 0+
-  let old_node = to_proj_node(old_expr, Ref::new(0))
+  let old_node = to_proj_node(old_expr, Ref(0))
   // Build first new tree with counter range 500+
-  let new_node1 = to_proj_node(new_expr, Ref::new(500))
+  let new_node1 = to_proj_node(new_expr, Ref(500))
   // First reconcile with fresh IDs from 1000+
-  let result1 = reconcile(old_node, new_node1, Ref::new(1000))
+  let result1 = reconcile(old_node, new_node1, Ref(1000))
   // Build second copy of new tree with counter range 600+
-  let new_node2 = to_proj_node(new_expr, Ref::new(600))
+  let new_node2 = to_proj_node(new_expr, Ref(600))
   // Second reconcile with fresh IDs from 2000+
-  let result2 = reconcile(result1, new_node2, Ref::new(2000))
+  let result2 = reconcile(result1, new_node2, Ref(2000))
   // IDs should match positionally
   let ids1 = collect_ids(result1)
   let ids2 = collect_ids(result2)
@@ -389,18 +414,19 @@ test "property: reconcile idempotent on different trees" {
 /// Runs reconcile three times: old→new, result1→new, result2→new.
 /// result2 and result3 should have identical IDs, catching any drift
 /// that only manifests after multiple passes.
-fn prop_reconcile_triple_idempotent(pair : (TestExpr, TestExpr)) -> Bool {
-  let (old_expr, new_expr) = pair
+fn prop_reconcile_triple_idempotent(pair : TestExprPair) -> Bool {
+  let old_expr = pair.old
+  let new_expr = pair.new
   // Build old tree with counter range 0+
-  let old_node = to_proj_node(old_expr, Ref::new(0))
+  let old_node = to_proj_node(old_expr, Ref(0))
   // Build three copies of new tree with different counter ranges
-  let new_node1 = to_proj_node(new_expr, Ref::new(500))
-  let new_node2 = to_proj_node(new_expr, Ref::new(600))
-  let new_node3 = to_proj_node(new_expr, Ref::new(700))
+  let new_node1 = to_proj_node(new_expr, Ref(500))
+  let new_node2 = to_proj_node(new_expr, Ref(600))
+  let new_node3 = to_proj_node(new_expr, Ref(700))
   // Three rounds of reconcile with well-separated counter ranges
-  let result1 = reconcile(old_node, new_node1, Ref::new(1000))
-  let result2 = reconcile(result1, new_node2, Ref::new(2000))
-  let result3 = reconcile(result2, new_node3, Ref::new(3000))
+  let result1 = reconcile(old_node, new_node1, Ref(1000))
+  let result2 = reconcile(result1, new_node2, Ref(2000))
+  let result3 = reconcile(result2, new_node3, Ref(3000))
   // result2 and result3 should have identical IDs
   let ids2 = collect_ids(result2)
   let ids3 = collect_ids(result3)
@@ -452,11 +478,12 @@ fn collect_child_counts_rec(
 ///|
 /// Property 9: Result has the same shape as the new tree.
 /// Node count and child counts at every position match.
-fn prop_result_same_shape_as_new(pair : (TestExpr, TestExpr)) -> Bool {
-  let (old_expr, new_expr) = pair
-  let old_node = to_proj_node(old_expr, Ref::new(0))
-  let new_node = to_proj_node(new_expr, Ref::new(500))
-  let result = reconcile(old_node, new_node, Ref::new(1000))
+fn prop_result_same_shape_as_new(pair : TestExprPair) -> Bool {
+  let old_expr = pair.old
+  let new_expr = pair.new
+  let old_node = to_proj_node(old_expr, Ref(0))
+  let new_node = to_proj_node(new_expr, Ref(500))
+  let result = reconcile(old_node, new_node, Ref(1000))
   // Same total node count
   if count_nodes(result) != count_nodes(new_node) {
     return false
@@ -490,10 +517,10 @@ fn prop_different_root_kind_all_fresh(expr : TestExpr) -> Bool {
     Leaf(s) => Branch(s, [])
     Branch(_, _) => expr
   }
-  let old_node = to_proj_node(old_expr, Ref::new(0))
-  let new_node = to_proj_node(new_expr, Ref::new(500))
+  let old_node = to_proj_node(old_expr, Ref(0))
+  let new_node = to_proj_node(new_expr, Ref(500))
   let counter_start = 1000
-  let result = reconcile(old_node, new_node, Ref::new(counter_start))
+  let result = reconcile(old_node, new_node, Ref(counter_start))
   // All result IDs should be fresh (>= counter_start)
   let result_ids = collect_ids(result)
   for id in result_ids {
@@ -523,12 +550,13 @@ test "property: different root kind produces all fresh IDs" {
 ///|
 /// Property 11: Fresh IDs come from the counter range.
 /// After reconcile, any ID not reused from old must be >= counter start.
-fn prop_fresh_ids_from_counter_range(pair : (TestExpr, TestExpr)) -> Bool {
-  let (old_expr, new_expr) = pair
-  let old_node = to_proj_node(old_expr, Ref::new(0))
-  let new_node = to_proj_node(new_expr, Ref::new(500))
+fn prop_fresh_ids_from_counter_range(pair : TestExprPair) -> Bool {
+  let old_expr = pair.old
+  let new_expr = pair.new
+  let old_node = to_proj_node(old_expr, Ref(0))
+  let new_node = to_proj_node(new_expr, Ref(500))
   let counter_start = 1000
-  let counter = Ref::new(counter_start)
+  let counter = Ref(counter_start)
   let result = reconcile(old_node, new_node, counter)
   // Build set of old IDs
   let old_id_set : Map[Int, Bool] = {}
@@ -566,7 +594,7 @@ fn prop_swap_siblings_preserves_most_ids(expr : TestExpr) -> Bool {
     Branch(t, cs) => if cs.length() >= 2 { (t, cs) } else { return true }
     Leaf(_) => return true
   }
-  let old_counter = Ref::new(0)
+  let old_counter = Ref(0)
   let old_node = to_proj_node(expr, old_counter)
   // Swap first two children
   let swapped : Array[TestExpr] = []
@@ -576,9 +604,9 @@ fn prop_swap_siblings_preserves_most_ids(expr : TestExpr) -> Bool {
     swapped.push(children[i])
   }
   let new_expr = Branch(tag, swapped)
-  let new_counter = Ref::new(500)
+  let new_counter = Ref(500)
   let new_node = to_proj_node(new_expr, new_counter)
-  let result = reconcile(old_node, new_node, Ref::new(1000))
+  let result = reconcile(old_node, new_node, Ref(1000))
   // Collect old child root IDs
   let old_child_ids : Map[Int, Bool] = {}
   for child in old_node.children {
@@ -610,13 +638,13 @@ fn prop_deep_change_preserves_ancestor_ids(expr : TestExpr) -> Bool {
     Leaf(_) => return true
     _ => ()
   }
-  let old_counter = Ref::new(0)
+  let old_counter = Ref(0)
   let old_node = to_proj_node(expr, old_counter)
   // Modify the leftmost leaf's label (Leaf→Leaf stays same_kind)
   let new_expr = modify_leftmost_leaf(expr)
-  let new_counter = Ref::new(500)
+  let new_counter = Ref(500)
   let new_node = to_proj_node(new_expr, new_counter)
-  let result = reconcile(old_node, new_node, Ref::new(1000))
+  let result = reconcile(old_node, new_node, Ref(1000))
   // Collect ancestor IDs along the leftmost path in old and result
   let old_path_ids = collect_leftmost_path_ids(old_node)
   let result_path_ids = collect_leftmost_path_ids(result)
@@ -674,13 +702,14 @@ fn collect_leftmost_path_ids(node : ProjNode[TestExpr]) -> Array[Int] {
 /// Property 14: No new-tree ID leakage.
 /// Result IDs come from {old IDs} ∪ {counter range} only — never
 /// from the new tree's temporary IDs.
-fn prop_no_new_tree_id_leakage(pair : (TestExpr, TestExpr)) -> Bool {
-  let (old_expr, new_expr) = pair
-  let old_node = to_proj_node(old_expr, Ref::new(0))
+fn prop_no_new_tree_id_leakage(pair : TestExprPair) -> Bool {
+  let old_expr = pair.old
+  let new_expr = pair.new
+  let old_node = to_proj_node(old_expr, Ref(0))
   // New tree IDs in range 500-999
-  let new_node = to_proj_node(new_expr, Ref::new(500))
+  let new_node = to_proj_node(new_expr, Ref(500))
   let counter_start = 1000
-  let result = reconcile(old_node, new_node, Ref::new(counter_start))
+  let result = reconcile(old_node, new_node, Ref(counter_start))
   // Build sets of old and new IDs
   let old_id_set : Map[Int, Bool] = {}
   for id in collect_ids(old_node) {
@@ -750,10 +779,10 @@ fn to_proj_node_with_spans(
 /// (0-based vs 100-based). Result should match new tree's spans.
 fn prop_result_uses_new_spans(expr : TestExpr) -> Bool {
   // Old tree: spans from 0+
-  let old_node = to_proj_node_with_spans(expr, Ref::new(0), Ref::new(0))
+  let old_node = to_proj_node_with_spans(expr, Ref(0), Ref(0))
   // New tree: spans from 100+ (different positions)
-  let new_node = to_proj_node_with_spans(expr, Ref::new(500), Ref::new(100))
-  let result = reconcile(old_node, new_node, Ref::new(1000))
+  let new_node = to_proj_node_with_spans(expr, Ref(500), Ref(100))
+  let result = reconcile(old_node, new_node, Ref(1000))
   let result_spans = collect_spans(result)
   let new_spans = collect_spans(new_node)
   if result_spans.length() != new_spans.length() {

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -112,7 +112,7 @@ fn SourceMap::node_to_range_at_position(
 ) -> Map[NodeId, Range] {
   self.ranges
   .iter()
-  .fold(init=Map::new(), fn(acc, item) {
+  .fold(init=Map::default(), fn(acc, item) {
     if item.0.contains(position) {
       acc.set(item.1, item.0)
     }

--- a/core/source_map_properties_wbtest.mbt
+++ b/core/source_map_properties_wbtest.mbt
@@ -6,7 +6,7 @@
 /// Property 1: Every node in a ProjNode tree has a range in the SourceMap.
 /// SourceMap::from_ast should produce an entry for every node in the tree.
 fn prop_from_ast_covers_all_nodes(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let root = to_proj_node(expr, counter)
   let sm = SourceMap::from_ast(root)
   let ids = collect_ids(root)
@@ -30,7 +30,7 @@ test "property: from_ast covers all nodes" {
 /// Property 2: The sorted ranges array has the same length as node_to_range.
 /// After from_ast, ranges should contain exactly one entry per node.
 fn prop_ranges_length_matches_node_count(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let root = to_proj_node(expr, counter)
   let sm = SourceMap::from_ast(root)
   sm.ranges.length() == sm.node_count()
@@ -46,8 +46,8 @@ test "property: ranges array length matches node count" {
 /// with ties broken by end position (descending — larger ranges first).
 /// Uses realistic nested ranges so sorting is non-trivially exercised.
 fn prop_ranges_sorted(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
-  let offset = Ref::new(0)
+  let counter = Ref(0)
+  let offset = Ref(0)
   let root = to_proj_node_with_ranges(expr, counter, offset)
   let sm = SourceMap::from_ast(root)
   for i = 1; i < sm.ranges.length(); i = i + 1 {
@@ -72,7 +72,7 @@ test "property: ranges array is correctly sorted" {
 /// Property 4: rebuild() then from_ast() produce the same SourceMap content.
 /// Rebuilding from the same tree should yield identical node_to_range entries.
 fn prop_rebuild_matches_from_ast(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let root = to_proj_node(expr, counter)
   let sm1 = SourceMap::from_ast(root)
   let sm2 = SourceMap::new()
@@ -133,8 +133,8 @@ fn to_proj_node_with_ranges(
 /// For every node with children, the parent's range should contain
 /// each child's range.
 fn prop_parent_encloses_children(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
-  let offset = Ref::new(0)
+  let counter = Ref(0)
+  let offset = Ref(0)
   let root = to_proj_node_with_ranges(expr, counter, offset)
   let sm = SourceMap::from_ast(root)
   check_enclosure(root, sm)
@@ -172,8 +172,8 @@ test "property: parent ranges enclose child ranges" {
 /// containing range among all nodes that contain the query position.
 /// Probes multiple positions across the root range for better coverage.
 fn prop_innermost_node_has_minimal_range(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
-  let offset = Ref::new(0)
+  let counter = Ref(0)
+  let offset = Ref(0)
   let root = to_proj_node_with_ranges(expr, counter, offset)
   let sm = SourceMap::from_ast(root)
   let root_range = match sm.get_range(root.id()) {
@@ -230,8 +230,8 @@ test "property: innermost_node_at returns minimal containing node" {
 /// All token spans should be gone after rebuild (as documented in
 /// source_map.mbt — "clears token_spans").
 fn prop_rebuild_clears_token_spans(expr : TestExpr) -> Bool {
-  let counter = Ref::new(0)
-  let offset = Ref::new(0)
+  let counter = Ref(0)
+  let offset = Ref(0)
   let root = to_proj_node_with_ranges(expr, counter, offset)
   let sm = SourceMap::from_ast(root)
   // Set a token span on the root node

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -99,7 +99,7 @@ test "SourceMap::from_ast works with TestExpr" {
 test "reconcile preserves IDs when kinds match" {
   let old = ProjNode::new(Leaf("x"), 0, 1, 42, [])
   let new_ = ProjNode::new(Leaf("y"), 0, 1, 99, [])
-  let counter = Ref::new(100)
+  let counter = Ref(100)
   let result = reconcile(old, new_, counter)
   // same_kind(Leaf, Leaf) is true → old ID preserved
   inspect(result.node_id, content="42")
@@ -110,7 +110,7 @@ test "reconcile preserves IDs when kinds match" {
 test "reconcile assigns fresh IDs when kinds differ" {
   let old = ProjNode::new(Leaf("x"), 0, 1, 42, [])
   let new_ = ProjNode::new(Branch("b", []), 0, 3, 99, [])
-  let counter = Ref::new(100)
+  let counter = Ref(100)
   let result = reconcile(old, new_, counter)
   // same_kind(Leaf, Branch) is false → fresh ID
   inspect(result.node_id, content="100")
@@ -120,7 +120,7 @@ test "reconcile assigns fresh IDs when kinds differ" {
 test "assign_fresh_ids renumbers entire subtree" {
   let child = ProjNode::new(Leaf("a"), 0, 1, 0, [])
   let root = ProjNode::new(Branch("r", [Leaf("a")]), 0, 5, 1, [child])
-  let counter = Ref::new(50)
+  let counter = Ref(50)
   let result = assign_fresh_ids(root, counter)
   // post-order: child gets 50, parent gets 51
   inspect(result.children[0].node_id, content="50")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -106,10 +106,17 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 - [ ] Implement lazy loading for 100 k+ operation documents (load causal graph skeleton, hydrate on demand).
 
-- [ ] Add B-tree indexing for FugueTree (O(n) → O(log n) random-access character lookup).
+- [ ] Benchmark `FugueTree` whole-list traversal after the early-exit `lv_to_position` change.
+  Why: event-graph-walker#38 removes `lv_to_position`'s full `get_visible_items()` allocation by sharing an early-exit traversal helper, but full-list callers such as `get_visible_items()` / `to_text()` may have different constant-factor tradeoffs.
+  Exit: release benchmarks cover `get_visible_items()` and `to_text()` on representative trees; keep the shared traversal helper only if whole-list callers do not regress materially, otherwise restore a direct collection path while preserving early exit for point lookup.
 
-- [ ] Cheaper `FugueTree::lv_to_position`.
-  Why: current impl allocates the full visible-items array then linearly scans. Replace with a tree walk that counts visible items and exits early when target LV is found. No allocation, O(n/2) average. ~20 lines in `event-graph-walker/internal/fugue/tree.mbt`. Bottleneck for incremental remote cache updates.
+- [ ] Consider a public allocation-free `FugueTree` visible traversal API.
+  Why: `get_visible_items()` must materialize the full visible sequence by contract. A visitor/iterator-style API would let callers that only need a point query, fold, or early-exit search reuse canonical tree order without allocating an array.
+  Exit: either expose a documented `visit_visible` / `find_visible` style API and migrate suitable internal callers, or document why the private traversal helper is sufficient for now.
+
+- [ ] Add visible-order indexing for FugueTree / Document LV-position queries.
+  Why: early-exit traversal avoids allocation but remains O(n) worst-case. A maintained visible-order index, B-tree, or reverse LV→position map could make `position_to_lv` and `lv_to_position` near O(log n), but must stay coherent across insert/delete/undelete, merge, and retreat paths.
+  Exit: benchmarked design/prototype with clear mutation invariants, or a written decision that the complexity is not justified by measured workloads.
 
 ---
 

--- a/echo/cmd/store_wbtest.mbt
+++ b/echo/cmd/store_wbtest.mbt
@@ -1,9 +1,4 @@
 ///|
-impl Show for StoredPost with output(self, logger) {
-  logger.write_string(@debug.to_string(self))
-}
-
-///|
 test "StoredPost JSON round-trip" {
   let posts : Array[StoredPost] = [
     { text: "CRDTのmerge操作でバグ", ts: "2026-04-04T10:00:00Z" },
@@ -21,14 +16,14 @@ test "StoredPost JSON round-trip" {
 ///|
 test "posts_from_json - empty string returns empty, no error" {
   let (posts, err) = posts_from_json("")
-  inspect(posts, content="[]")
+  debug_inspect(posts, content="[]")
   inspect(err is None, content="true")
 }
 
 ///|
 test "posts_from_json - invalid JSON returns error" {
   let (posts, err) = posts_from_json("not json")
-  inspect(posts, content="[]")
+  debug_inspect(posts, content="[]")
   // Error should be Some(...) for corrupt data
   inspect(err is None, content="false")
 }
@@ -36,6 +31,6 @@ test "posts_from_json - invalid JSON returns error" {
 ///|
 test "posts_from_json - empty array" {
   let (posts, err) = posts_from_json("[]")
-  inspect(posts, content="[]")
+  debug_inspect(posts, content="[]")
   inspect(err is None, content="true")
 }

--- a/echo/corpus.mbt
+++ b/echo/corpus.mbt
@@ -18,7 +18,7 @@ pub(all) struct Corpus {
 pub fn Corpus::new(
   tokenize? : (String) -> Array[String] = @tokenizer.bigram,
 ) -> Corpus {
-  { tokenize, next_id: 0, doc_freq: Map::new(), posts: [] }
+  { tokenize, next_id: 0, doc_freq: Map::default(), posts: [] }
 }
 
 ///|

--- a/echo/corpus_wbtest.mbt
+++ b/echo/corpus_wbtest.mbt
@@ -55,14 +55,14 @@ test "query_text - finds similar posts" {
 test "query_text - empty query returns empty" {
   let corpus = Corpus::new()
   let _ = corpus.add_post("hello")
-  inspect(corpus.query_text(""), content="[]")
+  debug_inspect(corpus.query_text(""), content="[]")
 }
 
 ///|
 test "query_text - single char query returns empty" {
   let corpus = Corpus::new()
   let _ = corpus.add_post("hello world")
-  inspect(corpus.query_text("h"), content="[]")
+  debug_inspect(corpus.query_text("h"), content="[]")
 }
 
 ///|
@@ -81,7 +81,7 @@ test "query_text - top_n limits results" {
 test "query_text - top_n zero returns empty" {
   let corpus = Corpus::new()
   let _ = corpus.add_post("hello")
-  inspect(corpus.query_text("hello", top_n=0), content="[]")
+  debug_inspect(corpus.query_text("hello", top_n=0), content="[]")
 }
 
 ///|
@@ -99,7 +99,7 @@ test "query_similar - basic" {
 ///|
 test "query_similar - invalid id returns empty" {
   let corpus = Corpus::new()
-  inspect(corpus.query_similar(999), content="[]")
+  debug_inspect(corpus.query_similar(999), content="[]")
 }
 
 ///|

--- a/echo/echo_wbtest.mbt
+++ b/echo/echo_wbtest.mbt
@@ -36,8 +36,8 @@ test "to_sparse_vec - basic" {
 
 ///|
 test "to_sparse_vec - zero total returns zero vector" {
-  let tf : TermFreq = { counts: Map::new(), total: 0 }
-  let vec = to_sparse_vec(tf, 1, Map::new())
+  let tf : TermFreq = { counts: Map::default(), total: 0 }
+  let vec = to_sparse_vec(tf, 1, Map::default())
   inspect(vec.entries.length(), content="0")
   inspect(vec.norm, content="0")
 }
@@ -61,7 +61,7 @@ test "cosine_similarity - orthogonal vectors" {
 
 ///|
 test "cosine_similarity - zero norm" {
-  let zero : SparseVec = { entries: Map::new(), norm: 0.0 }
+  let zero : SparseVec = { entries: Map::default(), norm: 0.0 }
   let nonzero : SparseVec = { entries: { "a": 1.0 }, norm: 1.0 }
   inspect(cosine_similarity(zero, nonzero), content="0")
   inspect(cosine_similarity(nonzero, zero), content="0")

--- a/echo/integration_test.mbt
+++ b/echo/integration_test.mbt
@@ -168,7 +168,7 @@ test "integration - duplicate posts produce zero IDF vectors" {
   let _ = corpus.add_post("全く同じ文章を二回投稿する")
   // Standard TF-IDF: IDF = ln(N/df) = ln(1) = 0 for terms in all docs
   let results = corpus.query_similar(id0, top_n=1)
-  inspect(results, content="[]")
+  debug_inspect(results, content="[]")
 }
 
 ///|
@@ -177,7 +177,7 @@ test "integration - single char post has no similarity" {
   let id0 = corpus.add_post("あ")
   let _ = corpus.add_post("カレーを作った")
   let results = corpus.query_similar(id0)
-  inspect(results, content="[]")
+  debug_inspect(results, content="[]")
 }
 
 ///|
@@ -200,28 +200,28 @@ test "integration - snapshot all cluster scores" {
   // Snapshot full rankings for representative posts from each cluster
   // This captures the actual behavior for regression detection
   let curry = corpus.query_similar(0, top_n=5)
-  inspect(
+  debug_inspect(
     curry.map(fn(p) { p.0 }),
     content=(
       #|[3, 4, 28, 1, 27]
     ),
   )
   let crdt = corpus.query_similar(5, top_n=5)
-  inspect(
+  debug_inspect(
     crdt.map(fn(p) { p.0 }),
     content=(
       #|[9, 7, 6, 17, 8]
     ),
   )
   let moonbit = corpus.query_similar(16, top_n=5)
-  inspect(
+  debug_inspect(
     moonbit.map(fn(p) { p.0 }),
     content=(
       #|[18, 17, 19, 10, 15]
     ),
   )
   let daily = corpus.query_similar(27, top_n=5)
-  inspect(
+  debug_inspect(
     daily.map(fn(p) { p.0 }),
     content=(
       #|[25, 23, 26, 0, 24]

--- a/echo/moon.pkg
+++ b/echo/moon.pkg
@@ -7,6 +7,10 @@ import {
   "moonbitlang/core/debug",
 } for "wbtest"
 
+import {
+  "moonbitlang/core/debug",
+} for "test"
+
 options(
   is_main: false,
 )

--- a/echo/sparse_vec.mbt
+++ b/echo/sparse_vec.mbt
@@ -6,7 +6,7 @@ priv struct TermFreq {
 
 ///|
 fn term_freq(tokens : Array[String]) -> TermFreq {
-  let counts : Map[String, Int] = Map::new()
+  let counts : Map[String, Int] = Map::default()
   for token in tokens {
     counts[token] = counts.get(token).unwrap_or(0) + 1
   }
@@ -21,7 +21,7 @@ priv struct SparseVec {
 
 ///|
 fn SparseVec::zero() -> SparseVec {
-  { entries: Map::new(), norm: 0.0 }
+  { entries: Map::default(), norm: 0.0 }
 }
 
 ///|
@@ -37,7 +37,7 @@ fn to_sparse_vec(
   if tf.total == 0 {
     return SparseVec::zero()
   }
-  let entries : Map[String, Double] = Map::new()
+  let entries : Map[String, Double] = Map::default()
   let mut sum_sq = 0.0
   for term, count in tf.counts {
     let tf_val = count.to_double() / tf.total.to_double()

--- a/echo/tokenizer/bigram_wbtest.mbt
+++ b/echo/tokenizer/bigram_wbtest.mbt
@@ -1,6 +1,6 @@
 ///|
 test "bigram - basic Japanese" {
-  inspect(
+  debug_inspect(
     bigram("カレー"),
     content=(
       #|["カレ", "レー"]
@@ -10,7 +10,7 @@ test "bigram - basic Japanese" {
 
 ///|
 test "bigram - mixed ASCII and Japanese" {
-  inspect(
+  debug_inspect(
     bigram("CRDTの実装"),
     content=(
       #|["CR", "RD", "DT", "Tの", "の実", "実装"]
@@ -20,17 +20,17 @@ test "bigram - mixed ASCII and Japanese" {
 
 ///|
 test "bigram - empty string" {
-  inspect(bigram(""), content="[]")
+  debug_inspect(bigram(""), content="[]")
 }
 
 ///|
 test "bigram - single char" {
-  inspect(bigram("あ"), content="[]")
+  debug_inspect(bigram("あ"), content="[]")
 }
 
 ///|
 test "bigram - with spaces" {
-  inspect(
+  debug_inspect(
     bigram("a b"),
     content=(
       #|["a ", " b"]

--- a/echo/tokenizer/moon.pkg
+++ b/echo/tokenizer/moon.pkg
@@ -1,3 +1,7 @@
 options(
   is_main: false,
 )
+
+import {
+  "moonbitlang/core/debug",
+} for "wbtest"

--- a/echo/tokenizer/moon.pkg
+++ b/echo/tokenizer/moon.pkg
@@ -1,7 +1,7 @@
-options(
-  is_main: false,
-)
-
 import {
   "moonbitlang/core/debug",
 } for "wbtest"
+
+options(
+  is_main: false,
+)

--- a/echo/tokenizer/segment_wbtest.mbt
+++ b/echo/tokenizer/segment_wbtest.mbt
@@ -62,7 +62,7 @@ test "char_type - M before H priority" {
 ///|
 test "segment - basic Japanese sentence" {
   let result = segment("今日はいい天気です")
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|["今日", "は", "いい", "天気", "です"]
@@ -73,7 +73,7 @@ test "segment - basic Japanese sentence" {
 ///|
 test "segment - name sentence" {
   let result = segment("私の名前は田中です")
-  inspect(
+  debug_inspect(
     result,
     content=(
       #|["私", "の", "名前", "は", "田中", "です"]
@@ -83,12 +83,12 @@ test "segment - name sentence" {
 
 ///|
 test "segment - empty string" {
-  inspect(segment(""), content="[]")
+  debug_inspect(segment(""), content="[]")
 }
 
 ///|
 test "segment - single character" {
-  inspect(
+  debug_inspect(
     segment("あ"),
     content=(
       #|["あ"]
@@ -98,7 +98,7 @@ test "segment - single character" {
 
 ///|
 test "segment - katakana" {
-  inspect(
+  debug_inspect(
     segment("カレーライス"),
     content=(
       #|["カレーライス"]
@@ -108,7 +108,7 @@ test "segment - katakana" {
 
 ///|
 test "segment - mixed Japanese and ASCII" {
-  inspect(
+  debug_inspect(
     segment("MoonBitで開発する"),
     content=(
       #|["MoonBit", "で", "開発", "する"]
@@ -118,7 +118,7 @@ test "segment - mixed Japanese and ASCII" {
 
 ///|
 test "segment - longer sentence" {
-  inspect(
+  debug_inspect(
     segment("共同編集にはCRDTかOTが必要"),
     content=(
       #|["共同", "編集", "に", "は", "CRDT", "か", "OT", "が", "必要"]

--- a/editor/cursor_view.mbt
+++ b/editor/cursor_view.mbt
@@ -20,7 +20,7 @@ pub struct PeerCursorView {
 
 ///|
 pub fn PeerCursorView::new() -> PeerCursorView {
-  { cursors: Map::new(), wire_keys: Map::new() }
+  { cursors: Map::default(), wire_keys: Map::default() }
 }
 
 ///|

--- a/editor/ephemeral.mbt
+++ b/editor/ephemeral.mbt
@@ -97,7 +97,7 @@ pub struct EphemeralStore {
 
 ///|
 pub fn EphemeralStore::new(timeout_ms : UInt64) -> EphemeralStore {
-  { timeout_ms, next_sub_id: 1, states: Map::new(), local_subs: [], subs: [] }
+  { timeout_ms, next_sub_id: 1, states: Map::default(), local_subs: [], subs: [] }
 }
 
 ///|

--- a/editor/ephemeral.mbt
+++ b/editor/ephemeral.mbt
@@ -97,7 +97,13 @@ pub struct EphemeralStore {
 
 ///|
 pub fn EphemeralStore::new(timeout_ms : UInt64) -> EphemeralStore {
-  { timeout_ms, next_sub_id: 1, states: Map::default(), local_subs: [], subs: [] }
+  {
+    timeout_ms,
+    next_sub_id: 1,
+    states: Map::default(),
+    local_subs: [],
+    subs: [],
+  }
 }
 
 ///|

--- a/editor/ephemeral_test.mbt
+++ b/editor/ephemeral_test.mbt
@@ -31,7 +31,7 @@ test "keys returns only non-deleted" {
   store.set("1", @editor.EphemeralValue::I64(1L))
   store.set("2", @editor.EphemeralValue::I64(2L))
   store.delete("1")
-  inspect(store.keys(), content="[\"2\"]")
+  @debug.debug_inspect(store.keys(), content="[\"2\"]")
 }
 
 ///|
@@ -53,13 +53,13 @@ test "subscribe receives Local events" {
   store.set("1", @editor.EphemeralValue::I64(42L))
   inspect(events.length(), content="1")
   inspect(events[0].by(), content="Local")
-  inspect(events[0].added(), content="[\"1\"]")
+  @debug.debug_inspect(events[0].added(), content="[\"1\"]")
 }
 
 ///|
 test "subscribe auto-unsubscribe on false" {
   let store = @editor.EphemeralStore::new(60000UL)
-  let call_count : Ref[Int] = Ref::new(0)
+  let call_count : Ref[Int] = Ref(0)
   let _sub = store.subscribe(fn(_event) {
     call_count.val = call_count.val + 1
     false
@@ -72,7 +72,7 @@ test "subscribe auto-unsubscribe on false" {
 ///|
 test "unsubscribe stops events" {
   let store = @editor.EphemeralStore::new(60000UL)
-  let call_count : Ref[Int] = Ref::new(0)
+  let call_count : Ref[Int] = Ref(0)
   let sub = store.subscribe(fn(_event) {
     call_count.val = call_count.val + 1
     true
@@ -145,7 +145,7 @@ test "apply triggers Import event" {
   store.apply(bytes)
   inspect(events.length(), content="1")
   inspect(events[0].by(), content="Import")
-  inspect(events[0].added(), content="[\"1\"]")
+  @debug.debug_inspect(events[0].added(), content="[\"1\"]")
 }
 
 ///|
@@ -180,14 +180,14 @@ test "peer IDs must be canonical decimal strings" {
     rejected.push(caught)
   }
   store.set("0", @editor.EphemeralValue::I64(7L))
-  inspect(rejected, content="[true, true, true]")
+  @debug.debug_inspect(rejected, content="[true, true, true]")
   @debug.debug_inspect(store.get("0"), content="Some(I64(7))")
 }
 
 ///|
 test "subscribe_local_updates receives bytes and can apply to another store" {
   let store = @editor.EphemeralStore::new(60000UL)
-  let received_bytes : Ref[Bytes] = Ref::new(Bytes::new(0))
+  let received_bytes : Ref[Bytes] = Ref(Bytes::new(0))
   let _sub = store.subscribe_local_updates(fn(bytes) {
     received_bytes.val = bytes
     true
@@ -213,11 +213,11 @@ test "set triggers updated event on existing key" {
   store.set("1", @editor.EphemeralValue::I64(20L))
   inspect(events.length(), content="2")
   // First set should be "added"
-  inspect(events[0].added(), content="[\"1\"]")
-  inspect(events[0].updated(), content="[]")
+  @debug.debug_inspect(events[0].added(), content="[\"1\"]")
+  @debug.debug_inspect(events[0].updated(), content="[]")
   // Second set should be "updated"
-  inspect(events[1].added(), content="[]")
-  inspect(events[1].updated(), content="[\"1\"]")
+  @debug.debug_inspect(events[1].added(), content="[]")
+  @debug.debug_inspect(events[1].updated(), content="[\"1\"]")
 }
 
 ///|
@@ -238,8 +238,8 @@ test "apply triggers updated event on existing key" {
   store.apply(bytes)
   inspect(events.length(), content="1")
   inspect(events[0].by(), content="Import")
-  inspect(events[0].updated(), content="[\"1\"]")
-  inspect(events[0].added(), content="[]")
+  @debug.debug_inspect(events[0].updated(), content="[\"1\"]")
+  @debug.debug_inspect(events[0].added(), content="[]")
 }
 
 ///|

--- a/editor/ephemeral_wbtest.mbt
+++ b/editor/ephemeral_wbtest.mbt
@@ -116,7 +116,7 @@ test "remove_outdated_at triggers Timeout event" {
   store.remove_outdated_at(5000UL)
   inspect(events.length(), content="1")
   inspect(events[0].by, content="Timeout")
-  inspect(events[0].removed, content="[\"1\"]")
+  @debug.debug_inspect(events[0].removed, content="[\"1\"]")
   inspect(events[0].added.length(), content="0")
   inspect(events[0].updated.length(), content="0")
 }

--- a/editor/in_memory_transport.mbt
+++ b/editor/in_memory_transport.mbt
@@ -5,7 +5,7 @@ pub struct InMemoryRoom {
 
 ///|
 pub fn InMemoryRoom::new() -> InMemoryRoom {
-  { peers: Map::new() }
+  { peers: Map::default() }
 }
 
 ///|

--- a/editor/sync_editor_history_test.mbt
+++ b/editor/sync_editor_history_test.mbt
@@ -5,7 +5,7 @@ test "fresh SyncEditor produces empty causal snapshot" {
   let se = @lambda.new_lambda_editor("alice").0
   let snap = se.causal_snapshot()
   inspect(snap.op_count(), content="0")
-  inspect(snap.frontier(), content="[]")
+  @debug.debug_inspect(snap.frontier(), content="[]")
 }
 
 ///|

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -1,8 +1,8 @@
 ///|
-let docs : Map[Int, BlockDoc] = Map::new()
+let docs : Map[Int, BlockDoc] = Map::default()
 
 ///|
-let replica_ids : Map[Int, String] = Map::new()
+let replica_ids : Map[Int, String] = Map::default()
 
 ///|
 let next_handle : Ref[Int] = { val: 1 }

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -55,7 +55,7 @@ fn init_model() -> Model {
     sync_status: Connecting,
     overlay: closed_overlay(),
     scope_map: build_scope_map(editor),
-    highlight_set: @immut/hashset.HashSet::new(),
+    highlight_set: @immut/hashset.HashSet::default(),
     drag_source: None,
     drop_target_id: None,
     drop_position: None,
@@ -75,9 +75,9 @@ fn refresh(model : Model) -> Model {
     Some(nid_str) =>
       match parse_node_id(nid_str) {
         Some(nid) => compute_highlight_set(nid, scope_map)
-        None => @immut/hashset.HashSet::new()
+        None => @immut/hashset.HashSet::default()
       }
-    None => @immut/hashset.HashSet::new()
+    None => @immut/hashset.HashSet::default()
   }
   { ..model, outline_state, scope_map, highlight_set }
 }
@@ -569,7 +569,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       })
       let highlight_set = match parse_node_id(node_id) {
         Some(nid) => compute_highlight_set(nid, model.scope_map)
-        None => @immut/hashset.HashSet::new()
+        None => @immut/hashset.HashSet::default()
       }
       (cmd, { ..model, selected_node: Some(node_id), highlight_set })
     }
@@ -610,9 +610,9 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Some(s) =>
           match parse_node_id(s) {
             Some(nid) => compute_highlight_set(nid, model.scope_map)
-            None => @immut/hashset.HashSet::new()
+            None => @immut/hashset.HashSet::default()
           }
-        None => @immut/hashset.HashSet::new()
+        None => @immut/hashset.HashSet::default()
       }
       (
         cmd,
@@ -649,9 +649,9 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
             Some(s) =>
               match parse_node_id(s) {
                 Some(nid) => compute_highlight_set(nid, new_model.scope_map)
-                None => @immut/hashset.HashSet::new()
+                None => @immut/hashset.HashSet::default()
               }
-            None => @immut/hashset.HashSet::new()
+            None => @immut/hashset.HashSet::default()
           }
           let text = new_model.editor.get_text()
           let cmd = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
@@ -873,7 +873,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       } else {
         let highlight_set = match parse_node_id(resolved_node_id) {
           Some(nid) => compute_highlight_set(nid, model.scope_map)
-          None => @immut/hashset.HashSet::new()
+          None => @immut/hashset.HashSet::default()
         }
         (
           none,

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -55,7 +55,7 @@ fn init_model() -> Model {
     sync_status: Connecting,
     overlay: closed_overlay(),
     scope_map: build_scope_map(editor),
-    highlight_set: @immut/hashset.HashSet::default(),
+    highlight_set: @immut/hashset.new(),
     drag_source: None,
     drop_target_id: None,
     drop_position: None,
@@ -75,9 +75,9 @@ fn refresh(model : Model) -> Model {
     Some(nid_str) =>
       match parse_node_id(nid_str) {
         Some(nid) => compute_highlight_set(nid, scope_map)
-        None => @immut/hashset.HashSet::default()
+        None => @immut/hashset.new()
       }
-    None => @immut/hashset.HashSet::default()
+    None => @immut/hashset.new()
   }
   { ..model, outline_state, scope_map, highlight_set }
 }
@@ -569,7 +569,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       })
       let highlight_set = match parse_node_id(node_id) {
         Some(nid) => compute_highlight_set(nid, model.scope_map)
-        None => @immut/hashset.HashSet::default()
+        None => @immut/hashset.new()
       }
       (cmd, { ..model, selected_node: Some(node_id), highlight_set })
     }
@@ -610,9 +610,9 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Some(s) =>
           match parse_node_id(s) {
             Some(nid) => compute_highlight_set(nid, model.scope_map)
-            None => @immut/hashset.HashSet::default()
+            None => @immut/hashset.new()
           }
-        None => @immut/hashset.HashSet::default()
+        None => @immut/hashset.new()
       }
       (
         cmd,
@@ -649,9 +649,9 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
             Some(s) =>
               match parse_node_id(s) {
                 Some(nid) => compute_highlight_set(nid, new_model.scope_map)
-                None => @immut/hashset.HashSet::default()
+                None => @immut/hashset.new()
               }
-            None => @immut/hashset.HashSet::default()
+            None => @immut/hashset.new()
           }
           let text = new_model.editor.get_text()
           let cmd = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
@@ -873,7 +873,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       } else {
         let highlight_set = match parse_node_id(resolved_node_id) {
           Some(nid) => compute_highlight_set(nid, model.scope_map)
-          None => @immut/hashset.HashSet::default()
+          None => @immut/hashset.new()
         }
         (
           none,

--- a/examples/ideal/main/scope_annotation.mbt
+++ b/examples/ideal/main/scope_annotation.mbt
@@ -208,7 +208,7 @@ fn compute_highlight_set(
   selected_id : @canopy_core.NodeId,
   scope_map : Map[@canopy_core.NodeId, ScopeAnnotation],
 ) -> @immut/hashset.HashSet[@canopy_core.NodeId] {
-  let mut hs = @immut/hashset.HashSet::new()
+  let mut hs = @immut/hashset.HashSet::default()
   match scope_map.get(selected_id) {
     None => hs
     Some(ann) => {

--- a/examples/ideal/main/scope_annotation.mbt
+++ b/examples/ideal/main/scope_annotation.mbt
@@ -208,7 +208,7 @@ fn compute_highlight_set(
   selected_id : @canopy_core.NodeId,
   scope_map : Map[@canopy_core.NodeId, ScopeAnnotation],
 ) -> @immut/hashset.HashSet[@canopy_core.NodeId] {
-  let mut hs = @immut/hashset.HashSet::default()
+  let mut hs = @immut/hashset.new()
   match scope_map.get(selected_id) {
     None => hs
     Some(ann) => {

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -3,13 +3,13 @@
 // lambda registry (1..9999). Structural edits live in edit.mbt.
 
 ///|
-let json_editors : Map[Int, @editor.SyncEditor[@djson.JsonValue]] = Map::new()
+let json_editors : Map[Int, @editor.SyncEditor[@djson.JsonValue]] = Map::default()
 
 ///|
 let json_next_handle : Ref[Int] = { val: 10000 }
 
 ///|
-let json_view_states : Map[Int, @editor.ViewUpdateState] = Map::new()
+let json_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 
 // ── Lifecycle ────────────────────────────────────────────────────────────
 

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -38,7 +38,7 @@ fn new_typecheck_bundle(
 }
 
 ///|
-let lambda_handles : Map[Int, LambdaHandle] = Map::new()
+let lambda_handles : Map[Int, LambdaHandle] = Map::default()
 
 ///|
 let next_handle : Ref[Int] = { val: 1 }

--- a/ffi/lambda/pretty.mbt
+++ b/ffi/lambda/pretty.mbt
@@ -1,7 +1,7 @@
 // Pretty-printer FFI — ViewNode tree and ViewPatch streams for formatted display
 
 ///|
-let pretty_view_states : Map[Int, @editor.ViewUpdateState] = Map::new()
+let pretty_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 
 ///|
 /// Get the pretty-printed ViewNode tree as JSON for a lambda editor.

--- a/ffi/lambda/relay.mbt
+++ b/ffi/lambda/relay.mbt
@@ -1,7 +1,7 @@
 // Relay room FFI — multi-peer relay room management
 
 ///|
-let relay_rooms : Map[String, @relay.RelayRoom] = Map::new()
+let relay_rooms : Map[String, @relay.RelayRoom] = Map::default()
 
 ///|
 fn get_or_create_room(room_id : String) -> @relay.RelayRoom {

--- a/ffi/lambda/view.mbt
+++ b/ffi/lambda/view.mbt
@@ -1,7 +1,7 @@
 // View FFI — ViewNode tree and ViewPatch streams for lambda editors
 
 ///|
-let view_states : Map[Int, @editor.ViewUpdateState] = Map::new()
+let view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 
 ///|
 /// Get the ViewNode tree as JSON for a lambda editor.

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -3,13 +3,13 @@
 /// with lambda (0+) and JSON (10000+).
 
 ///|
-let markdown_editors : Map[Int, @editor.SyncEditor[@md.Block]] = Map::new()
+let markdown_editors : Map[Int, @editor.SyncEditor[@md.Block]] = Map::default()
 
 ///|
 let markdown_next_handle : Ref[Int] = { val: 20000 }
 
 ///|
-let markdown_view_states : Map[Int, @editor.ViewUpdateState] = Map::new()
+let markdown_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 
 // ── Lifecycle ────────────────────────────────────────────────────────────
 

--- a/lang/json/proj/proj_node.mbt
+++ b/lang/json/proj/proj_node.mbt
@@ -209,7 +209,7 @@ pub fn parse_to_proj_node(
   let (cst, diagnostics) = @json.parse_cst(text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(fn(d) { d.message })
-  let root = syntax_to_proj_node(syntax_node, Ref::new(0))
+  let root = syntax_to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }
 

--- a/lang/json/proj/proj_node_wbtest.mbt
+++ b/lang/json/proj/proj_node_wbtest.mbt
@@ -138,7 +138,7 @@ test "token spans for object keys stored on Object node" {
   let text = "{\"a\": 1, \"b\": 2}"
   let (cst, _) = @json.parse_cst(text) catch { _ => abort("parse failed") }
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = syntax_to_proj_node(syntax_node, counter)
   let sm = @core.SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax_node, proj)
@@ -158,7 +158,7 @@ test "token spans for object keys stored on Object node" {
 test "reconcile preserves IDs on value edit" {
   let (old_proj, _) = parse_to_proj_node("{\"a\": 1, \"b\": 2}")
   let (new_proj, _) = parse_to_proj_node("{\"a\": 99, \"b\": 2}")
-  let counter = Ref::new(100)
+  let counter = Ref(100)
   let reconciled = @core.reconcile(old_proj, new_proj, counter)
   // Object kind matches → old root ID preserved
   inspect(reconciled.node_id, content=old_proj.node_id.to_string())

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -94,14 +94,14 @@ pub fn new_lambda_editor(
   // Ref side-channels let the build_memos callback publish extra memos
   // (beyond the 3-tuple SyncEditor expects) and the runtime back out to
   // the enclosing scope for companion construction + capabilities wiring.
-  let rt_ref : Ref[@incr.Runtime?] = Ref::new(None)
-  let proj_memo_ref : Ref[@incr.Memo[@lambda_flat.VersionedFlatProj]?] = Ref::new(
+  let rt_ref : Ref[@incr.Runtime?] = Ref(None)
+  let proj_memo_ref : Ref[@incr.Memo[@lambda_flat.VersionedFlatProj]?] = Ref(
     None,
   )
-  let escalation_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?] = Ref::new(
+  let escalation_memo_ref : Ref[@incr.Memo[Array[@lambda_eval.EvalResult]]?] = Ref(
     None,
   )
-  let cached_proj_node_ref : Ref[@incr.Memo[@core.ProjNode[@ast.Term]?]?] = Ref::new(
+  let cached_proj_node_ref : Ref[@incr.Memo[@core.ProjNode[@ast.Term]?]?] = Ref(
     None,
   )
   let editor = @editor.SyncEditor::new_generic(

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -13,7 +13,7 @@ fn parse_with_token_spans(
 ) raise {
   let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
   let syntax = @seam.SyntaxNode::from_cst(cst)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax, proj)

--- a/lang/lambda/edits/text_lens_regression_wbtest.mbt
+++ b/lang/lambda/edits/text_lens_regression_wbtest.mbt
@@ -4,6 +4,6 @@
 test "reconcile_ast rebuilds rendered text after same-shape edit" {
   let (old_root, _) = parse_to_proj_node("x + 1")
   let (new_root, _) = parse_to_proj_node("x + 2")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(100))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(@ast.print_term(reconciled.kind), content="(x + 2)")
 }

--- a/lang/lambda/eval/eval_memo.mbt
+++ b/lang/lambda/eval/eval_memo.mbt
@@ -206,7 +206,7 @@ fn fill_suppressed(
 pub fn build_eval_memo(
   parser : @loom.Parser[@ast.Term],
 ) -> @incr.Memo[Array[EvalResult]] {
-  let cache : Ref[Array[CachedDef]] = Ref::new([])
+  let cache : Ref[Array[CachedDef]] = Ref([])
   @incr.Memo::new(
     parser.runtime(),
     fn() -> Array[EvalResult] {

--- a/lang/lambda/flat/projection_memo.mbt
+++ b/lang/lambda/flat/projection_memo.mbt
@@ -17,19 +17,19 @@ pub fn build_lambda_projection_memos(
   let rt = parser.runtime()
   let source_text = parser.source()
   let syntax_tree = parser.syntax_tree()
-  let prev_flat_proj_ref : Ref[@lambda_proj.FlatProj?] = Ref::new(None)
-  let prev_syntax_root_ref : Ref[@seam.SyntaxNode?] = Ref::new(None)
-  let next_id_ref : Ref[Int] = Ref::new(0)
+  let prev_flat_proj_ref : Ref[@lambda_proj.FlatProj?] = Ref(None)
+  let prev_syntax_root_ref : Ref[@seam.SyntaxNode?] = Ref(None)
+  let next_id_ref : Ref[Int] = Ref(0)
   // Change tracking side-channel: set by proj_memo, read by registry and source_map.
   // None = full rebuild needed (first parse, def count change, no prev root).
   // Some([]) = nothing changed. Some([2, 5]) = defs 2 and 5 changed. -1 = final_expr.
-  let changed_def_indices_ref : Ref[Array[Int]?] = Ref::new(None)
+  let changed_def_indices_ref : Ref[Array[Int]?] = Ref(None)
   // Revision counter: bumped each time proj_memo recomputes. Downstream memos
   // track the last revision they processed. If they skipped revisions (lazy
   // access pattern), the delta in changed_def_indices_ref doesn't match their
   // prev state, so they must fall back to full rebuild.
-  let proj_revision_ref : Ref[Int] = Ref::new(0)
-  let proj_changed_at_ref : Ref[@incr.Revision] = Ref::new(
+  let proj_revision_ref : Ref[Int] = Ref(0)
+  let proj_changed_at_ref : Ref[@incr.Revision] = Ref(
     @incr.Revision::initial(),
   )
 
@@ -59,10 +59,10 @@ pub fn build_lambda_projection_memos(
           }
         }
       }
-      let counter = Ref::new(next_id_ref.val)
+      let counter = Ref(next_id_ref.val)
       let result = match (prev_flat_proj_ref.val, prev_syntax_root_ref.val) {
         (Some(prev_fp), Some(prev_root)) => {
-          let changed = Ref::new(([] : Array[Int]))
+          let changed = Ref(([] : Array[Int]))
           let result = @lambda_proj.to_flat_proj_incremental(
             syntax_root,
             prev_root,
@@ -136,13 +136,13 @@ pub fn build_lambda_projection_memos(
   // Counter write-back ensures Unit fallback IDs don't collide with future IDs.
   // prev_module_id_ref holds the Module node_id from the most recent successful
   // conversion, so stable Module IDs survive incremental rebuilds.
-  let prev_module_id_ref : Ref[Int?] = Ref::new(None)
+  let prev_module_id_ref : Ref[Int?] = Ref(None)
   let cached_proj_node : @incr.Memo[@core.ProjNode[@ast.Term]?] = @incr.Memo::new_no_backdate(
     rt,
     fn() -> @core.ProjNode[@ast.Term]? {
       match proj_memo.get().proj {
         Some(fp) => {
-          let counter = Ref::new(next_id_ref.val)
+          let counter = Ref(next_id_ref.val)
           let proj = fp.to_proj_node_with_prev_module_id(
             counter,
             prev_module_id_ref.val,
@@ -162,13 +162,13 @@ pub fn build_lambda_projection_memos(
     label="cached_proj_node",
   )
 
-  let prev_registry_ref : Ref[Map[@core.NodeId, @core.ProjNode[@ast.Term]]?] = Ref::new(
+  let prev_registry_ref : Ref[Map[@core.NodeId, @core.ProjNode[@ast.Term]]?] = Ref(
     None,
   )
-  let registry_prev_children_ref : Ref[Array[@core.ProjNode[@ast.Term]]?] = Ref::new(
+  let registry_prev_children_ref : Ref[Array[@core.ProjNode[@ast.Term]]?] = Ref(
     None,
   )
-  let registry_last_revision_ref : Ref[Int] = Ref::new(0)
+  let registry_last_revision_ref : Ref[Int] = Ref(0)
 
   let registry_memo : @incr.Memo[Map[@core.NodeId, @core.ProjNode[@ast.Term]]] = @incr.Memo::new_no_backdate(
     rt,
@@ -241,11 +241,11 @@ pub fn build_lambda_projection_memos(
     label="proj_registry",
   )
 
-  let prev_source_map_ref : Ref[@core.SourceMap?] = Ref::new(None)
-  let source_map_prev_children_ref : Ref[Array[@core.ProjNode[@ast.Term]]?] = Ref::new(
+  let prev_source_map_ref : Ref[@core.SourceMap?] = Ref(None)
+  let source_map_prev_children_ref : Ref[Array[@core.ProjNode[@ast.Term]]?] = Ref(
     None,
   )
-  let source_map_last_revision_ref : Ref[Int] = Ref::new(0)
+  let source_map_last_revision_ref : Ref[Int] = Ref(0)
 
   let source_map_memo : @incr.Memo[@core.SourceMap] = @incr.Memo::new_no_backdate(
     rt,

--- a/lang/lambda/flat/projection_memo.mbt
+++ b/lang/lambda/flat/projection_memo.mbt
@@ -29,9 +29,7 @@ pub fn build_lambda_projection_memos(
   // access pattern), the delta in changed_def_indices_ref doesn't match their
   // prev state, so they must fall back to full rebuild.
   let proj_revision_ref : Ref[Int] = Ref(0)
-  let proj_changed_at_ref : Ref[@incr.Revision] = Ref(
-    @incr.Revision::initial(),
-  )
+  let proj_changed_at_ref : Ref[@incr.Revision] = Ref(@incr.Revision::initial())
 
   let proj_memo : @incr.Memo[VersionedFlatProj] = @incr.Memo::new_memo(
     rt,

--- a/lang/lambda/proj/flat_proj.mbt
+++ b/lang/lambda/proj/flat_proj.mbt
@@ -49,7 +49,7 @@ pub fn to_flat_proj_incremental(
   old_root : @seam.SyntaxNode,
   old_fp : FlatProj,
   counter : Ref[Int],
-  changed_indices? : Ref[Array[Int]] = Ref::new([]),
+  changed_indices? : Ref[Array[Int]] = Ref([]),
 ) -> FlatProj {
   // Extract LetDef children from old and new roots
   let new_children = new_root.children()

--- a/lang/lambda/proj/flat_proj_wbtest.mbt
+++ b/lang/lambda/proj/flat_proj_wbtest.mbt
@@ -7,7 +7,7 @@ fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
 ///|
 test "to_flat_proj: single expression" {
   let syntax = parse_syntax("42")
-  let fp = to_flat_proj(syntax, Ref::new(0))
+  let fp = to_flat_proj(syntax, Ref(0))
   inspect(fp.defs.length(), content="0")
   @debug.debug_inspect(
     fp.final_expr.map(fn(n) { n.kind.to_string() }),
@@ -18,7 +18,7 @@ test "to_flat_proj: single expression" {
 ///|
 test "to_flat_proj: single let def + expression" {
   let syntax = parse_syntax("let x = 1\nx")
-  let fp = to_flat_proj(syntax, Ref::new(0))
+  let fp = to_flat_proj(syntax, Ref(0))
   inspect(fp.defs.length(), content="1")
   inspect(fp.defs[0].0, content="x")
   inspect(fp.defs[0].1.kind, content="Int(1)")
@@ -31,7 +31,7 @@ test "to_flat_proj: single let def + expression" {
 ///|
 test "to_flat_proj: multiple let defs" {
   let syntax = parse_syntax("let x = 1\nlet y = 2\nx + y")
-  let fp = to_flat_proj(syntax, Ref::new(0))
+  let fp = to_flat_proj(syntax, Ref(0))
   inspect(fp.defs.length(), content="2")
   inspect(fp.defs[0].0, content="x")
   inspect(fp.defs[1].0, content="y")
@@ -40,7 +40,7 @@ test "to_flat_proj: multiple let defs" {
 ///|
 test "to_flat_proj: no final expression defaults to None" {
   let syntax = parse_syntax("let x = 1\n")
-  let fp = to_flat_proj(syntax, Ref::new(0))
+  let fp = to_flat_proj(syntax, Ref(0))
   inspect(fp.defs.length(), content="1")
   inspect(fp.final_expr is None, content="true")
 }
@@ -48,7 +48,7 @@ test "to_flat_proj: no final expression defaults to None" {
 ///|
 test "to_flat_proj: empty document" {
   let syntax = parse_syntax("")
-  let fp = to_flat_proj(syntax, Ref::new(0))
+  let fp = to_flat_proj(syntax, Ref(0))
   inspect(fp.defs.length(), content="0")
   inspect(fp.final_expr is None, content="true")
 }
@@ -56,7 +56,7 @@ test "to_flat_proj: empty document" {
 ///|
 test "reconcile_flat_proj: unchanged defs preserve IDs" {
   let syntax = parse_syntax("let x = 1\nlet y = 2\nx")
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(syntax, counter)
   let old_ids = old.defs.map(fn(d) { d.3 })
 
@@ -71,7 +71,7 @@ test "reconcile_flat_proj: unchanged defs preserve IDs" {
 
 ///|
 test "reconcile_flat_proj: changed init gets reconciled children" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("let x = 1\nx"), counter)
   let old_id = old.defs[0].3
 
@@ -86,7 +86,7 @@ test "reconcile_flat_proj: changed init gets reconciled children" {
 
 ///|
 test "reconcile_flat_proj: insertion gets fresh ID" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("let x = 1\nx"), counter)
   let old_x_id = old.defs[0].3
 
@@ -102,7 +102,7 @@ test "reconcile_flat_proj: insertion gets fresh ID" {
 
 ///|
 test "reconcile_flat_proj: final_expr reconciled" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("42"), counter)
   let old_final_id = old.final_expr.unwrap().node_id
 
@@ -120,13 +120,13 @@ test "reconcile_flat_proj: final_expr reconciled" {
 
 ///|
 test "print_flat_proj: single expression" {
-  let fp = to_flat_proj(parse_syntax("42"), Ref::new(0))
+  let fp = to_flat_proj(parse_syntax("42"), Ref(0))
   inspect(print_flat_proj(fp), content="42")
 }
 
 ///|
 test "print_flat_proj: single let + expression" {
-  let fp = to_flat_proj(parse_syntax("let x = 1\nx"), Ref::new(0))
+  let fp = to_flat_proj(parse_syntax("let x = 1\nx"), Ref(0))
   inspect(print_flat_proj(fp), content="let x = 1\nx")
 }
 
@@ -134,14 +134,14 @@ test "print_flat_proj: single let + expression" {
 test "print_flat_proj: multiple lets" {
   let fp = to_flat_proj(
     parse_syntax("let x = 1\nlet y = 2\nx + y"),
-    Ref::new(0),
+    Ref(0),
   )
   inspect(print_flat_proj(fp), content="let x = 1\nlet y = 2\n(x + y)")
 }
 
 ///|
 test "print_flat_proj: defs only (no final expression)" {
-  let fp = to_flat_proj(parse_syntax("let x = 1\n"), Ref::new(0))
+  let fp = to_flat_proj(parse_syntax("let x = 1\n"), Ref(0))
   inspect(print_flat_proj(fp), content="let x = 1\n()")
 }
 
@@ -149,17 +149,17 @@ test "print_flat_proj: defs only (no final expression)" {
 test "print_flat_proj: equivalence with print_term on nested spine" {
   let text = "let x = 1\nlet y = 2\nx + y"
   let syntax = parse_syntax(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let nested = to_proj_node(syntax, counter)
-  let counter2 = Ref::new(0)
+  let counter2 = Ref(0)
   let flat = to_flat_proj(parse_syntax(text), counter2)
   inspect(print_flat_proj(flat) == @ast.print_term(nested.kind), content="true")
 }
 
 ///|
 test "FlatProj::to_proj_node: single expression" {
-  let fp = to_flat_proj(parse_syntax("42"), Ref::new(0))
-  let proj = fp.to_proj_node(Ref::new(100))
+  let fp = to_flat_proj(parse_syntax("42"), Ref(0))
+  let proj = fp.to_proj_node(Ref(100))
   inspect(proj.kind, content="Int(42)")
 }
 
@@ -167,9 +167,9 @@ test "FlatProj::to_proj_node: single expression" {
 test "FlatProj::to_proj_node: let defs reconstruct Module" {
   let fp = to_flat_proj(
     parse_syntax("let x = 1\nlet y = 2\nx + y"),
-    Ref::new(0),
+    Ref(0),
   )
-  let proj = fp.to_proj_node(Ref::new(100))
+  let proj = fp.to_proj_node(Ref(100))
   inspect(
     proj.kind,
     content=(
@@ -180,9 +180,9 @@ test "FlatProj::to_proj_node: let defs reconstruct Module" {
 
 ///|
 test "FlatProj::to_proj_node: Module node gets fresh ID (not def ID)" {
-  let fp = to_flat_proj(parse_syntax("let x = 1\nx"), Ref::new(0))
+  let fp = to_flat_proj(parse_syntax("let x = 1\nx"), Ref(0))
   let def_id = fp.defs[0].3
-  let proj = fp.to_proj_node(Ref::new(100))
+  let proj = fp.to_proj_node(Ref(100))
   // Module node gets a fresh counter ID, not the first def's stored ID
   inspect(proj.node_id == def_id.0, content="false")
 }
@@ -206,12 +206,12 @@ test "FlatProj::from_proj_node: single expression (no Module)" {
 ///|
 test "FlatProj roundtrip: to_flat_proj -> to_proj_node matches to_proj_node" {
   let text = "let x = 1\nlet y = 2\nx + y"
-  let counter1 = Ref::new(0)
+  let counter1 = Ref(0)
   let nested = to_proj_node(parse_syntax(text), counter1)
 
-  let counter2 = Ref::new(0)
+  let counter2 = Ref(0)
   let flat = to_flat_proj(parse_syntax(text), counter2)
-  let roundtripped = flat.to_proj_node(Ref::new(100))
+  let roundtripped = flat.to_proj_node(Ref(100))
 
   // Same structure (kind matches)
   inspect(
@@ -225,7 +225,7 @@ test "FlatProj roundtrip: from_proj_node -> to_proj_node preserves text" {
   let text = "let x = 1\nlet y = 2\nx + y"
   let (proj, _) = parse_to_proj_node(text)
   let fp = FlatProj::from_proj_node(proj)
-  let roundtripped = fp.to_proj_node(Ref::new(100))
+  let roundtripped = fp.to_proj_node(Ref(100))
   inspect(
     @ast.print_term(roundtripped.kind) == @ast.print_term(proj.kind),
     content="true",
@@ -235,7 +235,7 @@ test "FlatProj roundtrip: from_proj_node -> to_proj_node preserves text" {
 ///|
 test "reconcile_flat_proj: duplicate/shadowed names preserve correct IDs" {
   // old: let x = 1, let x = 2, x  →  new: let x = 1, let x = 2, x
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("let x = 1\nlet x = 2\nx"), counter)
   let old_id_0 = old.defs[0].3 // first x
   let old_id_1 = old.defs[1].3 // second x
@@ -251,7 +251,7 @@ test "reconcile_flat_proj: duplicate/shadowed names preserve correct IDs" {
 ///|
 test "reconcile_flat_proj: shadow with insertion preserves first x ID" {
   // old: [x=1], x  →  new: [x=1, x=2], x
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("let x = 1\nx"), counter)
   let old_x_id = old.defs[0].3
 
@@ -267,7 +267,7 @@ test "reconcile_flat_proj: shadow with insertion preserves first x ID" {
 
 ///|
 test "reconcile_flat_proj: empty old defs" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("42"), counter)
 
   let new_fp = to_flat_proj(parse_syntax("let x = 1\n42"), counter)
@@ -279,7 +279,7 @@ test "reconcile_flat_proj: empty old defs" {
 
 ///|
 test "reconcile_flat_proj: empty new defs" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old = to_flat_proj(parse_syntax("let x = 1\n42"), counter)
 
   let new_fp = to_flat_proj(parse_syntax("42"), counter)
@@ -291,23 +291,23 @@ test "reconcile_flat_proj: empty new defs" {
 ///|
 test "print_flat_proj: defs-only roundtrips through tree edit" {
   let text = "let x = 1\nlet y = 2\n"
-  let fp = to_flat_proj(parse_syntax(text), Ref::new(0))
+  let fp = to_flat_proj(parse_syntax(text), Ref(0))
   let printed = print_flat_proj(fp)
   // Reconstruct via nested spine and verify equivalence
-  let proj = fp.to_proj_node(Ref::new(100))
+  let proj = fp.to_proj_node(Ref(100))
   inspect(printed == @ast.print_term(proj.kind), content="true")
 }
 
 ///|
 test "FlatProj::to_proj_node: Module node_id is stable across rebuilds" {
   let text = "let x = 1\nlet y = 2\nx + y"
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let fp1 = to_flat_proj(parse_syntax(text), counter)
   let proj1 = fp1.to_proj_node(counter)
   let module_id_1 = proj1.node_id
 
   // Rebuild with same text — should preserve Module node_id when seeded
-  let counter2 = Ref::new(counter.val)
+  let counter2 = Ref(counter.val)
   let fp2 = to_flat_proj(parse_syntax(text), counter2)
   let proj2 = fp2.to_proj_node_with_prev_module_id(counter2, Some(module_id_1))
   let module_id_2 = proj2.node_id
@@ -318,7 +318,7 @@ test "FlatProj::to_proj_node: Module node_id is stable across rebuilds" {
 ///|
 test "FlatProj::to_proj_node: Module node_id seeded None still allocates fresh" {
   let text = "let x = 1\nx"
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let fp = to_flat_proj(parse_syntax(text), counter)
   let proj = fp.to_proj_node_with_prev_module_id(counter, None)
   // Without seed: fresh ID allocated from counter (>=0, valid)
@@ -330,11 +330,11 @@ test "to_flat_proj_incremental: changed_indices records non-reused defs" {
   // NodeInterner deduplicates by structure: unchanged def x=1 gets the same
   // interned CstNode even across independent parses, so physical_equal = true.
   // Only the changed def (y=3 vs y=2) fails physical_equal → index 1 recorded.
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old_root = parse_syntax("let x = 1\nlet y = 2\nx")
   let old_fp = to_flat_proj(old_root, counter)
   let new_root = parse_syntax("let x = 1\nlet y = 3\nx")
-  let changed = Ref::new(([] : Array[Int]))
+  let changed = Ref(([] : Array[Int]))
   let result = to_flat_proj_incremental(
     new_root,
     old_root,
@@ -345,16 +345,16 @@ test "to_flat_proj_incremental: changed_indices records non-reused defs" {
   ignore(result)
   // x=1 is structurally identical → reused (not recorded)
   // y=3 differs from y=2 → not reused → index 1 recorded
-  inspect(changed.val, content="[1]")
+  debug_inspect(changed.val, content="[1]")
 }
 
 ///|
 test "to_flat_proj_incremental: same root means zero changed" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let root = parse_syntax("let x = 1\nlet y = 2\nx")
   let fp = to_flat_proj(root, counter)
   // Same SyntaxNode — physical_equal succeeds for all children
-  let changed = Ref::new(([] : Array[Int]))
+  let changed = Ref(([] : Array[Int]))
   let result = to_flat_proj_incremental(
     root,
     root,
@@ -368,11 +368,11 @@ test "to_flat_proj_incremental: same root means zero changed" {
 
 ///|
 test "to_flat_proj_incremental: final_expr change recorded as -1" {
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let old_root = parse_syntax("let x = 1\n42")
   let old_fp = to_flat_proj(old_root, counter)
   let new_root = parse_syntax("let x = 1\n99")
-  let changed = Ref::new(([] : Array[Int]))
+  let changed = Ref(([] : Array[Int]))
   let result = to_flat_proj_incremental(
     new_root,
     old_root,
@@ -383,5 +383,5 @@ test "to_flat_proj_incremental: final_expr change recorded as -1" {
   ignore(result)
   // x=1 is structurally identical → reused (not recorded)
   // final_expr 99 differs from 42 → recorded as -1
-  inspect(changed.val, content="[-1]")
+  debug_inspect(changed.val, content="[-1]")
 }

--- a/lang/lambda/proj/flat_proj_wbtest.mbt
+++ b/lang/lambda/proj/flat_proj_wbtest.mbt
@@ -132,10 +132,7 @@ test "print_flat_proj: single let + expression" {
 
 ///|
 test "print_flat_proj: multiple lets" {
-  let fp = to_flat_proj(
-    parse_syntax("let x = 1\nlet y = 2\nx + y"),
-    Ref(0),
-  )
+  let fp = to_flat_proj(parse_syntax("let x = 1\nlet y = 2\nx + y"), Ref(0))
   inspect(print_flat_proj(fp), content="let x = 1\nlet y = 2\n(x + y)")
 }
 
@@ -165,10 +162,7 @@ test "FlatProj::to_proj_node: single expression" {
 
 ///|
 test "FlatProj::to_proj_node: let defs reconstruct Module" {
-  let fp = to_flat_proj(
-    parse_syntax("let x = 1\nlet y = 2\nx + y"),
-    Ref(0),
-  )
+  let fp = to_flat_proj(parse_syntax("let x = 1\nlet y = 2\nx + y"), Ref(0))
   let proj = fp.to_proj_node(Ref(100))
   inspect(
     proj.kind,

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -319,6 +319,6 @@ pub fn parse_to_proj_node(
   let (cst, diagnostics) = @parser.parse_cst(text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(fn(d) { d.message })
-  let root = to_proj_node(syntax_node, Ref::new(0))
+  let root = to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -12,7 +12,7 @@ pub fn parse_to_proj_node(
   let (cst, diagnostics) = @markdown.parse_cst(text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let errors = diagnostics.map(fn(d) { d.message })
-  let root = syntax_to_proj_node(syntax_node, Ref::new(0))
+  let root = syntax_to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }
 

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -74,7 +74,7 @@ test "projection: IDs are unique" {
 test "projection: incremental reparse preserves IDs" {
   let source = "# Hello\n\nWorld"
   let parser = @loom.new_imperative_parser(source, @markdown.markdown_grammar)
-  let counter : Ref[Int] = Ref::new(0)
+  let counter : Ref[Int] = Ref(0)
   // Initial parse
   let _ = parser.parse()
   // First projection

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -222,7 +222,7 @@ test "each visits all elements in order" {
   let t = build_tree([(1, 2), (2, 3), (3, 1)])
   let ids : Array[Int] = []
   t.each(fn(item) { ids.push(item.id) })
-  inspect(
+  @debug.debug_inspect(
     ids,
     content=(
       #|[1, 2, 3]

--- a/lib/zipper/zipper_test.mbt
+++ b/lib/zipper/zipper_test.mbt
@@ -317,13 +317,13 @@ test "to_path returns child indices from root" {
     .go_down(index=1)
     .unwrap()
   inspect(z.focus.data, content="y")
-  inspect(z.to_path(), content="[0, 1]")
+  @debug.debug_inspect(z.to_path(), content="[0, 1]")
 }
 
 ///|
 test "to_path at root is empty" {
   let z = RoseZipper::from_root(RoseNode::new(data=1))
-  inspect(z.to_path(), content="[]")
+  @debug.debug_inspect(z.to_path(), content="[]")
 }
 
 ///|

--- a/llm/gemini_wbtest.mbt
+++ b/llm/gemini_wbtest.mbt
@@ -106,7 +106,7 @@ test "extract_gemini_text surfaces Gemini API error" {
   let result : Result[String, LlmError] = Ok(extract_gemini_text(response)) catch {
     err => Err(err)
   }
-  inspect(
+  debug_inspect(
     result,
     content="Err(LlmError(\"Gemini API error: API key not valid\"))",
   )

--- a/llm/prompt_wbtest.mbt
+++ b/llm/prompt_wbtest.mbt
@@ -46,15 +46,15 @@ test "format_edit_user_message" {
 ///|
 test "split_lines preserves trailing empty segment" {
   // "a\n" should produce ["a", ""], not ["a"]
-  inspect(split_lines("a\n"), content="[\"a\", \"\"]")
+  debug_inspect(split_lines("a\n"), content="[\"a\", \"\"]")
 }
 
 ///|
 test "split_lines empty input" {
-  inspect(split_lines(""), content="[\"\"]")
+  debug_inspect(split_lines(""), content="[\"\"]")
 }
 
 ///|
 test "split_lines no trailing newline" {
-  inspect(split_lines("a\nb"), content="[\"a\", \"b\"]")
+  debug_inspect(split_lines("a\nb"), content="[\"a\", \"b\"]")
 }

--- a/projection/lens_test.mbt
+++ b/projection/lens_test.mbt
@@ -59,7 +59,7 @@ test "InteractiveTreeNode from AstNode" {
 test "reconcile_ast preserves IDs for matching nodes" {
   let (old_root, _) = @lambda_proj.parse_to_proj_node("x + 1")
   let (new_root, _) = @lambda_proj.parse_to_proj_node("x + 2")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(100))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(reconciled.node_id, content=old_root.node_id.to_string())
   inspect(
     reconciled.children[0].node_id,
@@ -72,7 +72,7 @@ test "reconcile_ast preserves IDs for matching nodes" {
 test "reconcile_ast preserves IDs across operator-only edits" {
   let (old_root, _) = @lambda_proj.parse_to_proj_node("x + 1")
   let (new_root, _) = @lambda_proj.parse_to_proj_node("x - 1")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(100))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(reconciled.node_id, content=old_root.node_id.to_string())
   inspect(
     reconciled.children[0].node_id,
@@ -89,7 +89,7 @@ test "reconcile_ast preserves IDs across operator-only edits" {
 test "reconcile_ast shrinks rebuilt source map when children disappear" {
   let (old_root, _) = @lambda_proj.parse_to_proj_node("1 + 2 + 3")
   let (new_root, _) = @lambda_proj.parse_to_proj_node("1 + 2")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(100))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(
     @core.SourceMap::from_ast(reconciled).node_count() <
     @core.SourceMap::from_ast(old_root).node_count(),

--- a/projection/proj_node_test.mbt
+++ b/projection/proj_node_test.mbt
@@ -7,14 +7,14 @@ fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
 ///|
 test "to_proj_node: single expression" {
   let syntax = parse_syntax("42")
-  let proj = @lambda_proj.to_proj_node(syntax, Ref::new(0))
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   inspect(proj.kind, content="Int(42)")
 }
 
 ///|
 test "to_proj_node: single let def + expression" {
   let syntax = parse_syntax("let x = 1\nx")
-  let proj = @lambda_proj.to_proj_node(syntax, Ref::new(0))
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   inspect(
     proj.kind,
     content=(
@@ -27,7 +27,7 @@ test "to_proj_node: single let def + expression" {
 ///|
 test "to_proj_node: multiple let defs" {
   let syntax = parse_syntax("let x = 1\nlet y = 2\nx + y")
-  let proj = @lambda_proj.to_proj_node(syntax, Ref::new(0))
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   inspect(
     proj.kind,
     content=(
@@ -41,7 +41,7 @@ test "to_proj_node: multiple let defs" {
 ///|
 test "to_proj_node: no final expression defaults to Unit" {
   let syntax = parse_syntax("let x = 1\n")
-  let proj = @lambda_proj.to_proj_node(syntax, Ref::new(0))
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   inspect(
     proj.kind,
     content=(
@@ -53,14 +53,14 @@ test "to_proj_node: no final expression defaults to Unit" {
 ///|
 test "to_proj_node: empty document" {
   let syntax = parse_syntax("")
-  let proj = @lambda_proj.to_proj_node(syntax, Ref::new(0))
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   inspect(proj.kind, content="Unit")
 }
 
 ///|
 test "to_proj_node: single let def with expression" {
   let syntax = parse_syntax("let x = 1\nx")
-  let proj = @lambda_proj.to_proj_node(syntax, Ref::new(0))
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   inspect(
     proj.kind,
     content=(

--- a/projection/source_map_token_spans_wbtest.mbt
+++ b/projection/source_map_token_spans_wbtest.mbt
@@ -10,7 +10,7 @@ fn parse_syntax_for_token_test(text : String) -> @seam.SyntaxNode raise {
 test "token span: lambda param" {
   let text = "\u{03BB}x.x"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -26,7 +26,7 @@ test "token span: lambda param" {
 test "token span: lambda param multi-char" {
   let text = "\u{03BB}foo.foo"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -42,7 +42,7 @@ test "token span: nested lambda params" {
   // λx.λy.x — outer lambda param "x" at 1..2, inner lambda param "y" at 4..5
   let text = "\u{03BB}x.\u{03BB}y.x"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -64,7 +64,7 @@ test "token span: let def name" {
   // let x = 1\nx — name "x" at position 4..5
   let text = "let x = 1\nx"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -78,7 +78,7 @@ test "token span: let def name" {
 test "token span: multiple let defs" {
   let text = "let x = 1\nlet y = 2\nx + y"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -97,7 +97,7 @@ test "token span: multiple let defs" {
 test "token span: no token spans for simple expression" {
   let text = "42"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -109,7 +109,7 @@ test "token span: lambda inside let def" {
   // let f = λx.x\nf — both "name:0" and lambda "param" should be recorded
   let text = "let f = \u{03BB}x.x\nf"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -128,7 +128,7 @@ test "token span: lambda inside let def" {
 test "token span: get_token_span returns None for missing role" {
   let text = "\u{03BB}x.x"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
@@ -155,7 +155,7 @@ test "token span: set_token_span manual" {
 test "token span: JSON includes token spans" {
   let text = "\u{03BB}x.x"
   let syntax = parse_syntax_for_token_test(text)
-  let counter = Ref::new(0)
+  let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)

--- a/projection/tree_editor_wbtest.mbt
+++ b/projection/tree_editor_wbtest.mbt
@@ -75,7 +75,7 @@ test "refresh_node_minimal skips unchanged subtrees" {
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
   let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(1000))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let ui_state : TreeUIState = {
     collapsed_nodes: @immut/hashset.new(),
@@ -497,7 +497,7 @@ test "refresh rebuilds structural indexes for updated projection" {
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
   let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(1000))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let refreshed = state.refresh(Some(reconciled), source_map)
   let ids = tree_editor_test_ids(refreshed.tree)
@@ -527,7 +527,7 @@ test "refresh builder reuses unchanged sibling subtree after unrelated leaf chan
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
   let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(1000))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let ui_state : TreeUIState = {
     collapsed_nodes: @immut/hashset.new(),
@@ -679,7 +679,7 @@ test "TreeEditorState::refresh preserves unchanged sibling subtree through publi
   let old_right = old_root_children[1]
 
   let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
-  let reconciled = @core.reconcile(old_root, new_root, Ref::new(1000))
+  let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let refreshed = state.refresh(Some(reconciled), source_map)
   let refreshed_tree = match refreshed.tree {

--- a/projection/tree_refresh_benchmark_wbtest.mbt
+++ b/projection/tree_refresh_benchmark_wbtest.mbt
@@ -27,7 +27,7 @@ fn tree_refresh_bench_setup(
   let sm_a = SourceMap::from_ast(root_a)
   let state = TreeEditorState::from_projection(Some(root_a), sm_a)
   let (root_b, _) = @lambda_proj.parse_to_proj_node(source_b)
-  let reconciled = @core.reconcile(root_a, root_b, Ref::new(1000))
+  let reconciled = @core.reconcile(root_a, root_b, Ref(1000))
   let sm_b = SourceMap::from_ast(reconciled)
   (state, root_a, sm_a, reconciled, sm_b)
 }


### PR DESCRIPTION
## Summary

- Update the `event-graph-walker` submodule from `ebd96d1` to `806044c`.
- Pulls in dowdiness/event-graph-walker#38, which avoids the `FugueTree::lv_to_position` visible-items allocation and factors the shared traversal path.
- Track follow-up algorithm work in `docs/TODO.md`: whole-list traversal benchmarks, a possible allocation-free visible traversal API, and visible-order/LV-position indexing.

## Why

The submodule change makes incremental remote cache updates cheaper by replacing a full visible-items allocation plus scan with an in-order traversal that exits when the target LV is found. The TODO updates preserve the remaining design questions: whether whole-list callers regress, whether traversal should become public API, and whether a maintained index is justified.

## Validation

In `event-graph-walker`:
- `rtk moon check`
- `rtk moon test --package internal/fugue` -> 58 passed
- `rtk moon test` -> 545 passed
- `rtk moon bench --release --package internal/fugue`

In `canopy`:
- `rtk moon check`
- `rtk moon test` -> 930 JS tests passed; 167 wasm-gc tests passed