### PR TITLE
bench: add realistic editor response benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -155,3 +155,40 @@ jobs:
             benchmark-results/pr_egw_bench.txt
             comparison.md
           retention-days: 30
+
+  editor-response-benchmark:
+    name: Editor Response Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: examples/ideal/web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: examples/ideal/web
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: examples/ideal/web
+        run: npx playwright install --with-deps chromium
+
+      - name: Update MoonBit dependencies
+        working-directory: examples/ideal
+        run: moon update
+
+      - name: Run realistic editor response benchmark
+        working-directory: examples/ideal/web
+        run: npm run test:perf

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-all check check-all fmt fmt-check check-agent-doc-links build build-js build-web test-web-e2e test-demo-react-e2e clean install-hooks release-artifacts
+.PHONY: help test test-all check check-all fmt fmt-check check-agent-doc-links build build-js build-web test-web-e2e test-demo-react-e2e benchmark-ideal-editor-response clean install-hooks release-artifacts
 
 help: ## Show this help message
 	@echo "Canopy - Development Tasks"
@@ -47,6 +47,9 @@ test-web-e2e: ## Run web Playwright E2E tests
 
 test-demo-react-e2e: ## Run demo-react Playwright E2E tests
 	@./scripts/test-demo-react-e2e.sh
+
+benchmark-ideal-editor-response: ## Run realistic ideal editor response benchmarks
+	@cd examples/ideal/web && npm run test:perf
 
 web-dev: build-js ## Build JS artifacts and start the web dev server
 	@cd examples/web && npm run dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ Only needed if you are modifying Canopy itself.
 
 **Performance:**
 
+- [Real Browser Editor Response Baseline](performance/2026-05-13-real-browser-editor-response.md)
 - [Benchmark Redesign](performance/BENCHMARK_REDESIGN.md)
 - [Performance Analysis](performance/PERFORMANCE_ANALYSIS.md)
 - [Performance Results](performance/PERFORMANCE_RESULTS.md)

--- a/docs/performance/2026-05-13-real-browser-editor-response.md
+++ b/docs/performance/2026-05-13-real-browser-editor-response.md
@@ -1,0 +1,100 @@
+# Real Browser Editor Response Baseline
+
+**Date:** 2026-05-13
+**Command:** `make benchmark-ideal-editor-response`
+**Benchmark:** `examples/ideal/web/e2e/editor-response.perf.spec.ts`
+
+This note records the first browser-level editor response benchmark for the
+ideal editor. Unlike MoonBit microbenchmarks, this runs Chromium against the
+real `examples/ideal/web` app and measures the local text-mode input path:
+
+1. CodeMirror receives text input.
+2. `canopy-editor.ts` applies the edit through `handle_text_intent`.
+3. The Web Component dispatches `text-changed`.
+4. Rabbita handles `EditorTextChanged`.
+5. The ideal model refreshes projection/outline state.
+6. The benchmark waits two animation frames to include browser paint scheduling.
+
+## Results
+
+| Scenario | Source size | Samples | Text-change p50 | Text-change p95 | Paint p50 | Paint p95 | Paint max |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| medium text edit | 1,283 chars | 30 | 5.9 ms | 9.5 ms | 30.6 ms | 31.4 ms | 38.6 ms |
+| large text edit | 7,284 chars | 30 | 20.2 ms | 21.3 ms | 37.2 ms | 39.0 ms | 67.8 ms |
+
+## Interpretation
+
+The editor is interactive, but the large case is not yet comfortably under a
+single-frame compute budget. For a "really smooth" typing experience, target:
+
+| Metric | Current large case | Good | Smooth target | Stretch |
+|---|---:|---:|---:|---:|
+| Text-change p95 | 21.3 ms | <16 ms | <8-10 ms | <4 ms |
+| Paint p95 | 39.0 ms | <50 ms | <32 ms | <16-20 ms |
+| Paint max | 67.8 ms | <100 ms | <50 ms | <32 ms |
+
+This implies roughly a 2x improvement in the editor/projection update path,
+not another large CRDT-engine win. The event-graph-walker regression that
+triggered this discussion is fixed; the remaining smoothness work is likely in
+Canopy's projection/editor refresh path.
+
+## Suspected Hot Path
+
+The text edit path currently runs:
+
+- `examples/ideal/web/src/canopy-editor.ts`
+  - CM6 update listener calls `handle_text_intent`.
+  - Dispatches `text-changed`.
+- `examples/ideal/web/src/main.ts`
+  - `text-changed` clicks the hidden Rabbita trigger.
+- `examples/ideal/main/main.mbt`
+  - `EditorTextChanged` calls `refresh(model)`.
+  - `refresh(model)` reads `get_proj_node()` and `get_source_map()`, refreshes
+    `TreeEditorState`, rebuilds `scope_map`, and recomputes highlights.
+
+The most plausible costs to measure first are:
+
+1. `TreeEditorState::refresh` on real lambda projection trees.
+2. `build_scope_map(editor)`, which currently walks the whole projected tree
+   and backfills usages on every refresh.
+3. `get_proj_node()` / `get_source_map()` memo forcing after single-character
+   edits.
+4. `bottom_render_cmd(new_model)`, especially when bottom panels are hidden or
+   inactive.
+
+## Next Measurement Work
+
+Add phase timings around the real browser benchmark before optimizing:
+
+- `handle_text_intent` duration in `canopy-editor.ts`.
+- Time from `text-changed` dispatch to Rabbita `EditorTextChanged`.
+- `refresh(model)` total time.
+- Sub-timings inside `refresh(model)`:
+  - `get_proj_node`
+  - `get_source_map`
+  - `TreeEditorState::refresh`
+  - `build_scope_map`
+  - `compute_highlight_set`
+  - `bottom_render_cmd`
+
+Then add release MoonBit benchmarks for:
+
+- `ideal refresh(100 defs)` and `ideal refresh(500 defs)`.
+- `build_scope_map(100 defs)` and `build_scope_map(500 defs)`.
+- `TreeEditorState::refresh` with real lambda projection trees.
+
+## Optimization Candidates
+
+Do not start by optimizing event-graph-walker. Current browser results point at
+over-refreshing projection/UI state per keystroke.
+
+Likely useful changes:
+
+1. Skip or defer `scope_map` rebuilding unless outline/scope UI needs it.
+2. Batch projection refresh to animation frames so text updates immediately and
+   outline/projection work runs at most once per frame.
+3. Avoid bottom-panel render work when panels are closed, and update only the
+   active tab when open.
+4. Move the ideal editor toward incremental view patches instead of broad model
+   refreshes for every text edit.
+

--- a/docs/performance/2026-05-13-real-browser-editor-response.md
+++ b/docs/performance/2026-05-13-real-browser-editor-response.md
@@ -15,6 +15,10 @@ real `examples/ideal/web` app and measures the local text-mode input path:
 5. The ideal model refreshes projection/outline state.
 6. The benchmark waits two animation frames to include browser paint scheduling.
 
+The perf run disables WebSocket sync startup with `VITE_CANOPY_SKIP_SYNC=1`.
+This keeps the measurement focused on local editor/projection response rather
+than offline collaboration reconnect work.
+
 ## Results
 
 | Scenario | Source size | Samples | Text-change p50 | Text-change p95 | Paint p50 | Paint p95 | Paint max |
@@ -97,4 +101,3 @@ Likely useful changes:
    active tab when open.
 4. Move the ideal editor toward incremental view patches instead of broad model
    refreshes for every text edit.
-

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect, type Page } from '@playwright/test';
+
+type ResponseSample = {
+  inputToTextChangeMs: number;
+  inputToPaintMs: number;
+};
+
+type Stats = {
+  p50: number;
+  p95: number;
+  max: number;
+  mean: number;
+};
+
+type ResponseSummary = {
+  scenario: string;
+  sourceChars: number;
+  samples: number;
+  textChange: Stats;
+  paint: Stats;
+};
+
+const WARMUP_KEYSTROKES = 5;
+const MEASURED_KEYSTROKES = 30;
+const P95_PAINT_BUDGET_MS = Number(process.env.EDITOR_RESPONSE_P95_BUDGET_MS ?? 100);
+const MAX_PAINT_BUDGET_MS = Number(process.env.EDITOR_RESPONSE_MAX_BUDGET_MS ?? 250);
+
+async function waitForEditor(page: Page) {
+  await page.goto(`/#perf-${Date.now()}`);
+  await expect(page).toHaveTitle('Canopy Editor');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    const el = document.querySelector('canopy-editor') as any;
+    return Boolean(el?.shadowRoot?.querySelector('.cm-editor') && (window as any).__canopy_crdt);
+  }, { timeout: 10000 });
+}
+
+function lambdaSource(definitions: number): string {
+  const lines: string[] = [];
+  for (let i = 0; i < definitions; i += 1) {
+    lines.push(`let v${i} = ${i}`);
+  }
+  lines.push(`v${definitions - 1}`);
+  return lines.join('\n');
+}
+
+async function seedEditor(page: Page, source: string) {
+  await page.evaluate((text) => {
+    const global = window as any;
+    const el = document.querySelector('canopy-editor') as any;
+    const crdt = global.__canopy_crdt;
+    const handle = global.__canopy_crdt_handle;
+    if (!el || !crdt || handle == null) {
+      throw new Error('Canopy editor is not mounted');
+    }
+
+    crdt.set_text(handle, text);
+    el.syncAfterExternalChange();
+    document.getElementById('canopy-editor-text-changed')?.click();
+
+    const view = el.cmView;
+    view.dispatch({
+      selection: { anchor: view.state.doc.length },
+      scrollIntoView: true,
+    });
+    view.focus();
+  }, source);
+
+  await page.waitForFunction((text) => {
+    const el = document.querySelector('canopy-editor') as any;
+    const view = el?.cmView;
+    return view?.state.doc.toString() === text;
+  }, source);
+}
+
+async function measureTextInput(page: Page, text: string): Promise<ResponseSample> {
+  return page.evaluate((insertText) => new Promise<ResponseSample>((resolve, reject) => {
+    const el = document.querySelector('canopy-editor') as any;
+    const cmContent = el?.shadowRoot?.querySelector('.cm-content') as HTMLElement | null;
+    const view = el?.cmView;
+    if (!el || !cmContent || !view) {
+      reject(new Error('CodeMirror content is not mounted'));
+      return;
+    }
+    cmContent.focus();
+    view.focus();
+
+    let start = 0;
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for text-changed after text input'));
+    }, 5000);
+    const cleanup = () => {
+      window.clearTimeout(timeout);
+      el.removeEventListener('text-changed', onTextChanged);
+    };
+    const onTextChanged = () => {
+      const textChangedAt = performance.now();
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          cleanup();
+          resolve({
+            inputToTextChangeMs: textChangedAt - start,
+            inputToPaintMs: performance.now() - start,
+          });
+        });
+      });
+    };
+
+    el.addEventListener('text-changed', onTextChanged, { once: true });
+    start = performance.now();
+    const inserted = document.execCommand('insertText', false, insertText);
+    if (!inserted) {
+      const pos = view.state.selection.main.head;
+      view.dispatch({
+        changes: { from: pos, to: pos, insert: insertText },
+        selection: { anchor: pos + insertText.length },
+      });
+    }
+  }), text);
+}
+
+function stats(values: number[]): Stats {
+  const sorted = [...values].sort((a, b) => a - b);
+  const at = (q: number) => sorted[Math.min(sorted.length - 1, Math.floor(q * (sorted.length - 1)))];
+  return {
+    p50: at(0.50),
+    p95: at(0.95),
+    max: sorted[sorted.length - 1],
+    mean: values.reduce((sum, value) => sum + value, 0) / values.length,
+  };
+}
+
+function roundStats(s: Stats): Stats {
+  return {
+    p50: Number(s.p50.toFixed(2)),
+    p95: Number(s.p95.toFixed(2)),
+    max: Number(s.max.toFixed(2)),
+    mean: Number(s.mean.toFixed(2)),
+  };
+}
+
+function summarize(scenario: string, sourceChars: number, samples: ResponseSample[]): ResponseSummary {
+  return {
+    scenario,
+    sourceChars,
+    samples: samples.length,
+    textChange: roundStats(stats(samples.map((sample) => sample.inputToTextChangeMs))),
+    paint: roundStats(stats(samples.map((sample) => sample.inputToPaintMs))),
+  };
+}
+
+async function runScenario(page: Page, scenario: string, definitions: number): Promise<ResponseSummary> {
+  const source = lambdaSource(definitions);
+  await seedEditor(page, source);
+
+  for (let i = 0; i < WARMUP_KEYSTROKES; i += 1) {
+    await measureTextInput(page, 'a');
+  }
+
+  const samples: ResponseSample[] = [];
+  for (let i = 0; i < MEASURED_KEYSTROKES; i += 1) {
+    samples.push(await measureTextInput(page, 'a'));
+  }
+
+  return summarize(scenario, source.length, samples);
+}
+
+test.describe('realistic editor response benchmark', () => {
+  test('text-mode typing updates CRDT, projection, and browser paint within budget', async ({ page }) => {
+    await waitForEditor(page);
+
+    const summaries = [
+      await runScenario(page, 'medium text edit', 100),
+      await runScenario(page, 'large text edit', 500),
+    ];
+
+    for (const summary of summaries) {
+      console.log(`[editor-response] ${JSON.stringify(summary)}`);
+      expect(summary.paint.p95, `${summary.scenario} p95 paint latency`).toBeLessThan(P95_PAINT_BUDGET_MS);
+      expect(summary.paint.max, `${summary.scenario} max paint latency`).toBeLessThan(MAX_PAINT_BUDGET_MS);
+    }
+  });
+});

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -122,7 +122,7 @@ async function measureTextInput(page: Page, text: string): Promise<ResponseSampl
 
 function stats(values: number[]): Stats {
   const sorted = [...values].sort((a, b) => a - b);
-  const at = (q: number) => sorted[Math.min(sorted.length - 1, Math.floor(q * (sorted.length - 1)))];
+  const at = (q: number) => sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))];
   return {
     p50: at(0.50),
     p95: at(0.95),

--- a/examples/ideal/web/package.json
+++ b/examples/ideal/web/package.json
@@ -7,6 +7,7 @@
     "server": "tsx server/ws-server.ts",
     "prebuild:moonbit": "cd .. && moon build --target js",
     "test": "playwright test",
+    "test:perf": "CANOPY_SKIP_RELAY_SERVER=1 playwright test e2e/editor-response.perf.spec.ts --reporter=line",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed"
   },

--- a/examples/ideal/web/package.json
+++ b/examples/ideal/web/package.json
@@ -7,7 +7,7 @@
     "server": "tsx server/ws-server.ts",
     "prebuild:moonbit": "cd .. && moon build --target js",
     "test": "playwright test",
-    "test:perf": "CANOPY_SKIP_RELAY_SERVER=1 playwright test e2e/editor-response.perf.spec.ts --reporter=line",
+    "test:perf": "CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 playwright test e2e/editor-response.perf.spec.ts --reporter=line",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed"
   },

--- a/examples/ideal/web/playwright.config.ts
+++ b/examples/ideal/web/playwright.config.ts
@@ -1,5 +1,24 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const webServer = [
+  {
+    command: 'npm run prebuild:moonbit && npx vite --port 5190 --strictPort',
+    url: 'http://localhost:5190',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  ...(
+    process.env.CANOPY_SKIP_RELAY_SERVER
+      ? []
+      : [{
+          command: 'npm run server',
+          port: 8787,
+          reuseExistingServer: !process.env.CI,
+          timeout: 15000,
+        }]
+  ),
+];
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -17,18 +36,5 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: [
-    {
-      command: 'npm run prebuild:moonbit && npx vite --port 5190 --strictPort',
-      url: 'http://localhost:5190',
-      reuseExistingServer: !process.env.CI,
-      timeout: 120000,
-    },
-    {
-      command: 'npm run server',
-      port: 8787,
-      reuseExistingServer: !process.env.CI,
-      timeout: 15000,
-    },
-  ],
+  webServer,
 });

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -28,6 +28,7 @@ type CanopyGlobal = typeof globalThis & {
 const canopyGlobal = globalThis as CanopyGlobal;
 const AGENT_ID_STORAGE_KEY = 'canopy-ideal-agent-id';
 const STORAGE_KEY_PREFIX = 'canopy-doc-';
+const SKIP_SYNC = import.meta.env.VITE_CANOPY_SKIP_SYNC === '1';
 let crdtPromise: Promise<CrdtModule> | null = null;
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let activeSyncClient: SyncClient | null = null;
@@ -327,7 +328,9 @@ function doMount(el: CanopyEditor, crdt: CrdtModule) {
   // Text already set by MoonBit's init_model — don't overwrite.
   el.mount(handle, crdt);
   wireEditorEvents(el);
-  startSync(el, handle, crdt, roomId);
+  if (!SKIP_SYNC) {
+    startSync(el, handle, crdt, roomId);
+  }
 
   // Periodically remove outdated ephemeral entries (every 10s)
   if (ephemeralCleanupTimer !== null) {


### PR DESCRIPTION
## Summary
- add a Playwright benchmark for real browser-level ideal editor text response
- wire the benchmark into Makefile/npm and the benchmark workflow
- document the 2026-05-13 baseline, smoothness targets, and follow-up measurement plan

## Verification
- rtk make benchmark-ideal-editor-response
- rtk git diff --check