### PR TITLE
bench: split editor response phase timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,18 @@ jobs:
         run: moon version --all
 
       - name: Update dependencies
-        run: make update
+        run: ./scripts/update-moon-deps.sh
 
       - name: Check code
-        run: make check
+        run: |
+          bash ./scripts/check-agent-doc-links.sh
+          ./scripts/run-moon-module.sh check .
 
       - name: Run tests
-        run: make test
+        run: ./scripts/run-moon-module.sh test .
 
       - name: Build
-        run: make build
+        run: moon build --release
 
   test-submodules:
     name: Test Submodules
@@ -179,7 +181,7 @@ jobs:
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Update dependencies
-        run: make update
+        run: ./scripts/update-moon-deps.sh
 
       - name: Run main module benchmarks
         run: moon bench --release
@@ -205,7 +207,9 @@ jobs:
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Check formatting
-        run: make fmt-check
+        run: |
+          bash ./scripts/check-agent-doc-links.sh
+          ./scripts/run-moon-module.sh fmt-check .
 
   build-js:
     name: Build JavaScript Target
@@ -222,10 +226,10 @@ jobs:
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Update dependencies
-        run: make update
+        run: ./scripts/update-moon-deps.sh
 
       - name: Build JavaScript artifacts
-        run: make build-js
+        run: ./scripts/build-js.sh
 
       - name: Upload JS artifacts
         uses: actions/upload-artifact@v7
@@ -267,10 +271,10 @@ jobs:
           cache-dependency-path: examples/web/package-lock.json
 
       - name: Update MoonBit dependencies
-        run: make update
+        run: ./scripts/update-moon-deps.sh
 
       - name: Build web
-        run: make build-web
+        run: ./scripts/build-web.sh
 
   web-e2e:
     name: Web E2E
@@ -320,10 +324,10 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Update MoonBit dependencies
-        run: make update
+        run: ./scripts/update-moon-deps.sh
 
       - name: Run web Playwright suite
-        run: make test-web-e2e
+        run: ./scripts/test-web-e2e.sh
 
   demo-react-e2e:
     name: Demo React E2E
@@ -373,10 +377,10 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Update MoonBit dependencies
-        run: make update
+        run: ./scripts/update-moon-deps.sh
 
       - name: Run demo-react Playwright suite
-        run: make test-demo-react-e2e
+        run: ./scripts/test-demo-react-e2e.sh
 
   all-checks-passed:
     name: All Checks Passed

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -96,6 +96,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 4. Rabbita Projection Editor Performance
 
+- [ ] Split and optimize the `handle_text_intent` browser edit path.
+  Why: the 2026-05-14 real browser phase benchmark shows the large edit path is dominated by `handleTextIntent` (`p95` 14.7 ms on a 7,284-char example). Rabbita `refreshTotal` is only `p95` 1.6 ms, `TreeEditorState::refresh` is `p95` 0.4 ms, and `buildScopeMap` is `p95` 0.2 ms, so projection refresh is not the first bottleneck.
+  Exit: browser-level phase timings split `handle_text_intent` into edit translation, sync-editor mutation, and state publication, and the large-edit text-change `p95` is comfortably below the single-frame compute budget.
+
 - [ ] Remove redundant render-time tree scans (e.g. sidebar selection lookup from the full rendered tree).
   Why: low priority — full frame is <1 ms, but the scans are still wasted work.
   Exit: render path does not scan the full tree for already-known state.

--- a/docs/performance/2026-05-13-real-browser-editor-response.md
+++ b/docs/performance/2026-05-13-real-browser-editor-response.md
@@ -66,20 +66,41 @@ The most plausible costs to measure first are:
 4. `bottom_render_cmd(new_model)`, especially when bottom panels are hidden or
    inactive.
 
+## Phase Timing Results
+
+Follow-up browser benchmark on 2026-05-14 split the large text edit result into
+measured phases. The command was still `make benchmark-ideal-editor-response`.
+
+| Large edit phase | p50 | p95 | max | Notes |
+|---|---:|---:|---:|---|
+| `handleTextIntent` | 12.6 ms | 14.7 ms | 14.8 ms | Dominant cost; wraps the Web Component text edit path through `handle_text_intent`. |
+| `dispatchTextChanged` | 1.2 ms | 1.8 ms | 3.0 ms | Includes listener dispatch after the editor state update. |
+| `textChangedToRabbitaTrigger` | 1.1 ms | 1.7 ms | 2.9 ms | Browser event bridge from `text-changed` to the Rabbita trigger. |
+| `editorTextChangedTotal` | 1.0 ms | 1.6 ms | 2.9 ms | Rabbita `EditorTextChanged` handler. |
+| `refreshTotal` | 1.0 ms | 1.6 ms | 2.9 ms | Full ideal model refresh. |
+| `getProjNode` | 0.4 ms | 0.6 ms | 0.7 ms | Projection memo forcing after the edit. |
+| `getSourceMap` | 0.3 ms | 0.4 ms | 2.1 ms | Usually small, with one local max spike. |
+| `treeEditorRefresh` | 0.3 ms | 0.4 ms | 0.4 ms | Tree editor state refresh. |
+| `buildScopeMap` | 0.1 ms | 0.2 ms | 0.3 ms | Not the current bottleneck. |
+| `bottomRenderCmd` | 0.0 ms | 0.1 ms | 0.1 ms | Not material in this benchmark. |
+
+This changes the optimization priority. The measured browser path is dominated
+by `handle_text_intent`, while the Rabbita projection refresh work is around
+1-2 ms at the current large-document scale. The scope-map and tree-refresh
+hypotheses were useful to test, but they are not where this benchmark spends
+most of its time.
+
 ## Next Measurement Work
 
-Add phase timings around the real browser benchmark before optimizing:
+Add deeper phase timings or focused release benchmarks for the
+`handle_text_intent` path before changing projection refresh:
 
-- `handle_text_intent` duration in `canopy-editor.ts`.
-- Time from `text-changed` dispatch to Rabbita `EditorTextChanged`.
-- `refresh(model)` total time.
-- Sub-timings inside `refresh(model)`:
-  - `get_proj_node`
-  - `get_source_map`
-  - `TreeEditorState::refresh`
-  - `build_scope_map`
-  - `compute_highlight_set`
-  - `bottom_render_cmd`
+- Split `handle_text_intent` into CodeMirror update handling, edit translation,
+  CRDT/sync-editor mutation, and post-edit state publication.
+- Add a focused browser benchmark that records per-keystroke p95 for repeated
+  edits in the same large document, not just isolated sampled edits.
+- Keep the existing projection phase timers as regression guards, because they
+  prove refresh/scope work is not currently the dominant browser-level cost.
 
 Then add release MoonBit benchmarks for:
 
@@ -89,15 +110,18 @@ Then add release MoonBit benchmarks for:
 
 ## Optimization Candidates
 
-Do not start by optimizing event-graph-walker. Current browser results point at
-over-refreshing projection/UI state per keystroke.
+Do not start by optimizing event-graph-walker or the projection refresh path.
+Current browser phase timings point first at the text-intent/edit-application
+path.
 
 Likely useful changes:
 
-1. Skip or defer `scope_map` rebuilding unless outline/scope UI needs it.
-2. Batch projection refresh to animation frames so text updates immediately and
-   outline/projection work runs at most once per frame.
-3. Avoid bottom-panel render work when panels are closed, and update only the
-   active tab when open.
-4. Move the ideal editor toward incremental view patches instead of broad model
-   refreshes for every text edit.
+1. Split and optimize `handle_text_intent`, especially edit translation and
+   sync-editor mutation after a single-character CodeMirror input.
+2. Check whether the Web Component publishes or normalizes more editor state
+   than the browser needs synchronously for each keystroke.
+3. Keep scope-map, tree-refresh, and bottom-panel work measured, but treat them
+   as secondary until the text-intent p95 is below the smooth target.
+4. If projection work grows with larger examples, batch projection refresh to
+   animation frames so text updates immediately and outline/projection work runs
+   at most once per frame.

--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -213,4 +213,26 @@ extern "js" fn js_focus_tree_rows() -> Unit =
   #|   if (el) el.focus();
   #| }
 
+///|
+/// Start a named browser perf span for the current benchmark sample.
+extern "js" fn js_perf_begin(name : String) -> Unit =
+  #| function(name) {
+  #|   var perf = globalThis.__canopy_perf_current;
+  #|   if (!perf || !perf.spans) return;
+  #|   if (!perf._starts) perf._starts = {};
+  #|   perf._starts[name] = performance.now();
+  #| }
+
+///|
+/// End a named browser perf span for the current benchmark sample.
+extern "js" fn js_perf_end(name : String) -> Unit =
+  #| function(name) {
+  #|   var perf = globalThis.__canopy_perf_current;
+  #|   if (!perf || !perf.spans || !perf._starts) return;
+  #|   var start = perf._starts[name];
+  #|   if (typeof start !== 'number') return;
+  #|   perf.spans[name] = (perf.spans[name] || 0) + performance.now() - start;
+  #|   delete perf._starts[name];
+  #| }
+
 // Note: editor event wiring is done in main.ts wireEditorEvents() — not here.

--- a/examples/ideal/main/crdt_reexport.mbt
+++ b/examples/ideal/main/crdt_reexport.mbt
@@ -175,7 +175,9 @@ pub fn handle_text_intent_checked(
   insert : String,
   timestamp_ms : Int,
 ) -> Bool {
-  @ffi.handle_text_intent_checked(handle, from, deleted_len, insert, timestamp_ms)
+  @ffi.handle_text_intent_checked(
+    handle, from, deleted_len, insert, timestamp_ms,
+  )
 }
 
 ///|

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -64,13 +64,22 @@ fn init_model() -> Model {
 
 ///|
 fn refresh(model : Model) -> Model {
-  let outline_state = model.outline_state.refresh(
-    model.editor.get_proj_node(),
-    model.editor.get_source_map(),
-  )
+  js_perf_begin("refreshTotal")
+  js_perf_begin("getProjNode")
+  let proj_node = model.editor.get_proj_node()
+  js_perf_end("getProjNode")
+  js_perf_begin("getSourceMap")
+  let source_map = model.editor.get_source_map()
+  js_perf_end("getSourceMap")
+  js_perf_begin("treeEditorRefresh")
+  let outline_state = model.outline_state.refresh(proj_node, source_map)
+  js_perf_end("treeEditorRefresh")
   // Build scope_map from current projection
+  js_perf_begin("buildScopeMap")
   let scope_map = build_scope_map(model.editor)
+  js_perf_end("buildScopeMap")
   // Recompute highlight_set if a node is selected
+  js_perf_begin("computeHighlightSet")
   let highlight_set = match model.selected_node {
     Some(nid_str) =>
       match parse_node_id(nid_str) {
@@ -79,6 +88,8 @@ fn refresh(model : Model) -> Model {
       }
     None => @immut/hashset.new()
   }
+  js_perf_end("computeHighlightSet")
+  js_perf_end("refreshTotal")
   { ..model, outline_state, scope_map, highlight_set }
 }
 
@@ -859,8 +870,13 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     EditorTextChanged => {
       // Text was already applied by TS calling handle_text_intent FFI.
       // Just refresh the outline.
+      js_perf_begin("editorTextChangedTotal")
       let new_model = refresh(model)
-      (bottom_render_cmd(new_model), new_model)
+      js_perf_begin("bottomRenderCmd")
+      let cmd = bottom_render_cmd(new_model)
+      js_perf_end("bottomRenderCmd")
+      js_perf_end("editorTextChangedTotal")
+      (cmd, new_model)
     }
     EditorNodeSelected(node_id) => {
       let resolved_node_id = if node_id == "" {

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -3,6 +3,7 @@ import { test, expect, type Page } from '@playwright/test';
 type ResponseSample = {
   inputToTextChangeMs: number;
   inputToPaintMs: number;
+  phases: Record<string, number>;
 };
 
 type Stats = {
@@ -18,6 +19,7 @@ type ResponseSummary = {
   samples: number;
   textChange: Stats;
   paint: Stats;
+  phases: Record<string, Stats>;
 };
 
 const WARMUP_KEYSTROKES = 5;
@@ -87,6 +89,7 @@ async function measureTextInput(page: Page, text: string): Promise<ResponseSampl
 
     let start = 0;
     const timeout = window.setTimeout(() => {
+      (window as any).__canopy_perf_current = null;
       cleanup();
       reject(new Error('Timed out waiting for text-changed after text input'));
     }, 5000);
@@ -98,16 +101,21 @@ async function measureTextInput(page: Page, text: string): Promise<ResponseSampl
       const textChangedAt = performance.now();
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
+          const perf = (window as any).__canopy_perf_current;
+          const phases = { ...(perf?.spans ?? {}) };
+          (window as any).__canopy_perf_current = null;
           cleanup();
           resolve({
             inputToTextChangeMs: textChangedAt - start,
             inputToPaintMs: performance.now() - start,
+            phases,
           });
         });
       });
     };
 
     el.addEventListener('text-changed', onTextChanged, { once: true });
+    (window as any).__canopy_perf_current = { spans: {} };
     start = performance.now();
     const inserted = document.execCommand('insertText', false, insertText);
     if (!inserted) {
@@ -141,12 +149,23 @@ function roundStats(s: Stats): Stats {
 }
 
 function summarize(scenario: string, sourceChars: number, samples: ResponseSample[]): ResponseSummary {
+  const phaseNames = new Set<string>();
+  for (const sample of samples) {
+    for (const phase of Object.keys(sample.phases)) {
+      phaseNames.add(phase);
+    }
+  }
+  const phases: Record<string, Stats> = {};
+  for (const phase of [...phaseNames].sort()) {
+    phases[phase] = roundStats(stats(samples.map((sample) => sample.phases[phase] ?? 0)));
+  }
   return {
     scenario,
     sourceChars,
     samples: samples.length,
     textChange: roundStats(stats(samples.map((sample) => sample.inputToTextChangeMs))),
     paint: roundStats(stats(samples.map((sample) => sample.inputToPaintMs))),
+    phases,
   };
 }
 
@@ -177,6 +196,12 @@ test.describe('realistic editor response benchmark', () => {
 
     for (const summary of summaries) {
       console.log(`[editor-response] ${JSON.stringify(summary)}`);
+      console.log(`[editor-response-phase] ${JSON.stringify({
+        scenario: summary.scenario,
+        sourceChars: summary.sourceChars,
+        samples: summary.samples,
+        phases: summary.phases,
+      })}`);
       expect(summary.paint.p95, `${summary.scenario} p95 paint latency`).toBeLessThan(P95_PAINT_BUDGET_MS);
       expect(summary.paint.max, `${summary.scenario} max paint latency`).toBeLessThan(MAX_PAINT_BUDGET_MS);
     }

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -21,6 +21,17 @@ const lambdaHighlightStyle = HighlightStyle.define([
   { tag: t.punctuation, color: "#787896" },                    // --canopy-text-dim (.)
 ]);
 
+function recordPerfSpan<T>(name: string, fn: () => T): T {
+  const perf = (globalThis as any).__canopy_perf_current;
+  if (!perf?.spans) return fn();
+  const start = performance.now();
+  try {
+    return fn();
+  } finally {
+    perf.spans[name] = (perf.spans[name] ?? 0) + performance.now() - start;
+  }
+}
+
 type StructureModeSession = {
   applyRemote(syncJson: string): string;
   destroy(): void;
@@ -231,32 +242,36 @@ export class CanopyEditor extends HTMLElement {
             // Count changes to detect multi-change transactions
             let changeCount = 0;
             update.changes.iterChanges(() => { changeCount++; });
-            if (changeCount === 1) {
-              // Single change: use incremental intent (avoids O(n) diff)
-              update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
-                this.crdt!.handle_text_intent(
-                  this.crdtHandle!,
-                  fromA,
-                  toA - fromA,
-                  inserted.toString(),
-                  ts,
-                );
-              });
-            } else {
-              // Multi-change (find-replace, multi-cursor) or fallback:
-              // use set_text_and_record which diffs correctly
-              const newText = update.state.doc.toString();
-              if (this.crdt.set_text_and_record) {
-                this.crdt.set_text_and_record(this.crdtHandle, newText, ts);
+            recordPerfSpan("handleTextIntent", () => {
+              if (changeCount === 1) {
+                // Single change: use incremental intent (avoids O(n) diff)
+                update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+                  this.crdt!.handle_text_intent(
+                    this.crdtHandle!,
+                    fromA,
+                    toA - fromA,
+                    inserted.toString(),
+                    ts,
+                  );
+                });
               } else {
-                this.crdt.set_text(this.crdtHandle, newText);
+                // Multi-change (find-replace, multi-cursor) or fallback:
+                // use set_text_and_record which diffs correctly
+                const newText = update.state.doc.toString();
+                if (this.crdt.set_text_and_record) {
+                  this.crdt.set_text_and_record(this.crdtHandle, newText, ts);
+                } else {
+                  this.crdt.set_text(this.crdtHandle, newText);
+                }
               }
-            }
+            });
             // Notify peers + Rabbita
-            this.notifyLocalChange();
-            this.dispatchEvent(new CustomEvent(CanopyEvents.TEXT_CHANGE, {
-              bubbles: true, composed: true,
-            }));
+            recordPerfSpan("notifyLocalChange", () => this.notifyLocalChange());
+            recordPerfSpan("dispatchTextChanged", () => {
+              this.dispatchEvent(new CustomEvent(CanopyEvents.TEXT_CHANGE, {
+                bubbles: true, composed: true,
+              }));
+            });
           }),
           // Broadcast cursor position on selection changes (debounced)
           CmView.updateListener.of(update => {

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -123,6 +123,17 @@ function clickTrigger(id: string) {
   if (btn) btn.click();
 }
 
+function recordPerfSpan<T>(name: string, fn: () => T): T {
+  const perf = (globalThis as any).__canopy_perf_current;
+  if (!perf?.spans) return fn();
+  const start = performance.now();
+  try {
+    return fn();
+  } finally {
+    perf.spans[name] = (perf.spans[name] ?? 0) + performance.now() - start;
+  }
+}
+
 function wireEditorEvents(el: CanopyEditor) {
   // Abort previous listeners if called again (prevents accumulation)
   if (editorEventsController) editorEventsController.abort();
@@ -132,7 +143,9 @@ function wireEditorEvents(el: CanopyEditor) {
   el.addEventListener(CanopyEvents.TEXT_CHANGE, () => {
     // Text was already applied by canopy-editor.ts via handle_text_intent FFI.
     // Trigger Rabbita outline refresh via the protocol-based trigger.
-    clickTrigger('canopy-editor-text-changed');
+    recordPerfSpan("textChangedToRabbitaTrigger", () => {
+      clickTrigger('canopy-editor-text-changed');
+    });
     // Debounced save to localStorage
     if (canopyGlobal.__canopy_crdt && canopyGlobal.__canopy_crdt_handle != null) {
       const roomId = location.hash.slice(1);

--- a/scripts/update-moon-deps.sh
+++ b/scripts/update-moon-deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+moon update
+cd event-graph-walker && moon update
+cd ../loom/loom && moon update
+cd ../../svg-dsl && moon update
+cd ../graphviz && moon update


### PR DESCRIPTION
## Summary
- add browser benchmark phase timing capture for editor text input, Rabbita bridge, and ideal refresh sub-phases
- record the 2026-05-14 phase split in performance docs and TODOs; measured hotspot is handleTextIntent, not projection refresh
- remove make usage from CI workflow steps and add a direct Moon dependency update script for Actions environments without make

## Validation
- rtk moon fmt (examples/ideal)
- rtk moon check (examples/ideal)
- rtk make benchmark-ideal-editor-response
- rtk git diff --check
- rtk bash -n scripts/update-moon-deps.sh