### PR TITLE
[codex] Add canvas handles and edges

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,7 @@ behavior** — check the code before relying on any specific detail.
 
 Recently completed (for quick reference):
 
+- [Canvas Handles And Edges](archive/completed-phases/2026-05-14-canvas-handles-edges.md)
 - [Lambda Annotation Plumbing — Design](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-design.md)
 - [Lambda Annotation Plumbing — Impl](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-impl.md)
 - [Framework Extraction — Design](archive/2026-03-18-framework-extraction-design.md)

--- a/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
+++ b/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
@@ -1,0 +1,195 @@
+# Canvas Handles And Edges
+
+**Status:** Complete in branch `codex/canvas-handles-edges`.
+**Implementation:** `d18a14f feat(canvas): add node handles and edges`
+**Scope:** `examples/canvas/`
+
+No ADR needed: this is a demo-only extension of the existing infinite canvas
+example. It does not change the framework architecture, public editor API, CRDT
+model, parser pipeline, or cross-package contracts.
+
+## Goal
+
+Extend the infinite canvas demo from pan/zoom/drag/select into a minimal
+node-graph prototype:
+
+- show input and output handles on each node
+- render persistent edges between demo nodes
+- allow dragging from an output handle to create a new edge
+- show an in-flight edge preview while connecting
+- reject self-loops and duplicate edges
+
+The feature remains deliberately local to the canvas example. There is no
+persistence, CRDT sync, node add/delete UI, edge delete UI, or editor embedding
+yet.
+
+## Design
+
+MoonBit remains the owner of canvas state and interaction rules. TypeScript
+remains a thin browser shell that forwards pointer events into MoonBit, reads
+`get_render_state(handle)`, and patches DOM/SVG during the RAF render loop.
+
+The old future `#overlay` canvas stub is replaced by an SVG edge layer:
+
+```html
+<svg id="edges"></svg>
+<div id="world"></div>
+```
+
+Both `#edges` and `#world` receive the same viewport transform:
+
+```text
+translate(viewport.x px, viewport.y px) scale(viewport.scale)
+```
+
+This keeps node positions, handle anchors, and edge paths in the same world
+coordinate space.
+
+## State Model
+
+New MoonBit state:
+
+```moonbit
+struct EdgeId(Int)
+
+struct Edge {
+  id : EdgeId
+  source : NodeId
+  target : NodeId
+}
+
+struct ConnectState {
+  from_node : NodeId
+  cursor_x : Double
+  cursor_y : Double
+}
+```
+
+`CanvasState` now carries:
+
+```moonbit
+edges : Array[Edge]
+next_edge_id : Int
+```
+
+`InteractionState` now carries:
+
+```moonbit
+connecting : ConnectState?
+```
+
+Each node has one implicit output handle at right-center and one implicit input
+handle at left-center. Handles are not stored in MoonBit state; they are derived
+from node bounds in TypeScript.
+
+## Interaction Rules
+
+Pointer-down on an output handle starts a connection gesture:
+
+```moonbit
+pointer_down_handle(handle, node_id, sx, sy)
+```
+
+The bridge converts screen coordinates to world coordinates and stores:
+
+```moonbit
+ConnectState {
+  from_node: node_id,
+  cursor_x: world_x,
+  cursor_y: world_y,
+}
+```
+
+Pointer-move while `connecting` is active updates only the cursor world
+position. It does not drag a node or pan the viewport.
+
+Pointer-up ends the gesture:
+
+- released over another node: add `Edge(source, target)`
+- released over the source node: cancel, no self-loop
+- released over the background: cancel
+- released over an already-connected target: cancel duplicate
+
+Pointer capture means `pointerup` event targets are unreliable. The TypeScript
+bridge uses `document.elementFromPoint(clientX, clientY)` on release to identify
+the actual node or handle under the pointer.
+
+## Render State JSON
+
+`get_render_state(handle)` now includes `edges` and optional `connecting`:
+
+```json
+{
+  "viewport": { "x": 520, "y": 300, "scale": 1 },
+  "nodes": [],
+  "edges": [
+    { "id": 1, "source": 1, "target": 4 }
+  ],
+  "selected": 1,
+  "connecting": {
+    "from": 1,
+    "cursor_x": 120,
+    "cursor_y": 80
+  }
+}
+```
+
+`selected` and `connecting` are omitted when inactive, following MoonBit
+`derive(ToJson)` optional-field behavior.
+
+## Rendering
+
+TypeScript derives anchors from node bounds:
+
+```typescript
+outputAnchor(node) = [node.x + node.w, node.y + node.h / 2]
+inputAnchor(node)  = [node.x, node.y + node.h / 2]
+```
+
+Edges are rendered as SVG cubic Bezier paths with horizontal handles. Existing
+edge paths are reused by `EdgeId`; missing paths are added; stale paths are
+removed. The in-flight edge uses a single `edge-pending` path.
+
+Nodes now contain:
+
+- `.handle.input`
+- `.handle.output`
+- `.node-label`
+
+Keeping label text inside `.node-label` avoids replacing handle elements when
+the node label changes.
+
+## Tests
+
+Whitebox tests cover:
+
+- connection start stores source node and cursor world position
+- connection move updates cursor position
+- connection end commits a source-to-target edge
+- self-loops are rejected
+- background release cancels the gesture
+- duplicate source/target edges are rejected
+- render JSON includes seeded demo edges
+
+Validation run for the implementation:
+
+```bash
+moon check
+moon check --deny-warn --warn-list @a
+moon test
+cd examples/canvas/web && npm run build
+cd examples/canvas/web && npm exec tsc -- --noEmit
+git diff --cached --check
+```
+
+All passed on 2026-05-14. `npm install` in `examples/canvas/web` reported three
+moderate npm audit warnings, but produced no tracked changes.
+
+## Follow-Ups
+
+- Browser interaction smoke test with Playwright or agent-browser.
+- Edge deletion and selection.
+- Node add/delete UI and edge cleanup for removed nodes.
+- Persist canvas graph state.
+- Decide whether canvas graph state should eventually share the editor CRDT
+  model or remain a separate example-specific data model.

--- a/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
+++ b/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
@@ -180,6 +180,7 @@ moon test
 cd examples/canvas/web && npm run build
 cd examples/canvas/web && npm exec tsc -- --noEmit
 git diff --cached --check
+markdownlint-cli2 docs/README.md docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
 ```
 
 All passed on 2026-05-14. `npm install` in `examples/canvas/web` reported three

--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -22,6 +22,19 @@ pub fn pointer_down(
 }
 
 ///|
+/// Pointer-down on an output handle: start an edge-creation gesture.
+pub fn pointer_down_handle(
+  handle : Int,
+  node_id : Int,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let state = _registry[handle]
+  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+  _registry[handle] = update_connect_start(state, NodeId(node_id), wx, wy)
+}
+
+///|
 /// Handle pointer-move in canvas-local screen coordinates.
 /// Routes to the active gesture (pan or drag) internally.
 pub fn pointer_move(handle : Int, sx : Double, sy : Double) -> Unit {
@@ -51,13 +64,31 @@ struct NodeJson {
 } derive(ToJson)
 
 ///|
+struct EdgeJson {
+  id : Int
+  source : Int
+  target : Int
+} derive(ToJson)
+
+///|
+/// Serialized in-flight connection. `from` is the source node id;
+/// `cursor_x`/`cursor_y` are world coordinates of the pointer.
+struct ConnectingJson {
+  from : Int
+  cursor_x : Double
+  cursor_y : Double
+} derive(ToJson)
+
+///|
 /// Serializable render snapshot sent to TypeScript each RAF frame.
-/// `selected` is absent (key omitted) when no node is selected — MoonBit derive(ToJson) omits None keys.
+/// `selected`/`connecting` are absent (key omitted) when not active — MoonBit derive(ToJson) omits None keys.
 /// TypeScript: use `rs.selected != null` (loose equality) not `rs.selected !== null`.
 struct RenderStateJson {
   viewport : Viewport
   nodes : Array[NodeJson]
+  edges : Array[EdgeJson]
   selected : Int?
+  connecting : ConnectingJson?
 } derive(ToJson)
 
 ///|
@@ -67,10 +98,29 @@ pub fn get_render_state(handle : Int) -> String {
     None => None
     Some(NodeId(id)) => Some(id)
   }
+  let connecting : ConnectingJson? = match state.interaction.connecting {
+    None => None
+    Some(c) => {
+      let NodeId(from) = c.from_node
+      Some({ from, cursor_x: c.cursor_x, cursor_y: c.cursor_y })
+    }
+  }
   let nodes = state.nodes.map(fn(n) {
     let NodeId(id) = n.id
     ({ id, x: n.x, y: n.y, w: n.w, h: n.h, kind: n.kind } : NodeJson)
   })
-  let rs : RenderStateJson = { viewport: state.viewport, nodes, selected }
+  let edges = state.edges.map(fn(e) {
+    let EdgeId(id) = e.id
+    let NodeId(s) = e.source
+    let NodeId(t) = e.target
+    ({ id, source: s, target: t } : EdgeJson)
+  })
+  let rs : RenderStateJson = {
+    viewport: state.viewport,
+    nodes,
+    edges,
+    selected,
+    connecting,
+  }
   rs.to_json().stringify()
 }

--- a/examples/canvas/main/canvas_state.mbt
+++ b/examples/canvas/main/canvas_state.mbt
@@ -81,9 +81,47 @@ pub impl Show for PanState with output(self, logger) {
 }
 
 ///|
+pub struct EdgeId(Int) derive(Debug, Eq, ToJson)
+
+///|
+pub impl Show for EdgeId with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// A connection between two nodes. Each node has an implicit single output
+/// handle (right-center) and input handle (left-center), so handles are not
+/// stored explicitly in the prototype.
+pub(all) struct Edge {
+  id : EdgeId
+  source : NodeId
+  target : NodeId
+} derive(Debug, Eq, ToJson)
+
+///|
+pub impl Show for Edge with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// In-flight connection started from a node's output handle.
+/// `cursor_x`/`cursor_y` are world coordinates of the pointer.
+pub(all) struct ConnectState {
+  from_node : NodeId
+  cursor_x : Double
+  cursor_y : Double
+} derive(Debug, Eq)
+
+///|
+pub impl Show for ConnectState with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
 pub(all) struct InteractionState {
   dragging : DragState?
   panning : PanState?
+  connecting : ConnectState?
   selected : NodeId?
   /// True from pointerdown until pointerup.
   pointer_down : Bool
@@ -100,6 +138,9 @@ pub impl Show for InteractionState with output(self, logger) {
 pub(all) struct CanvasState {
   viewport : Viewport
   nodes : Array[CanvasNode]
+  edges : Array[Edge]
+  /// Monotonic counter used to mint EdgeIds for newly-created connections.
+  next_edge_id : Int
   interaction : InteractionState
 } derive(Debug)
 
@@ -164,9 +205,16 @@ pub impl Default for CanvasState with default() -> CanvasState {
         kind: NodeKind::Text("∞"),
       },
     ],
+    edges: [
+      { id: EdgeId(1), source: NodeId(1), target: NodeId(4) },
+      { id: EdgeId(2), source: NodeId(2), target: NodeId(5) },
+      { id: EdgeId(3), source: NodeId(3), target: NodeId(6) },
+    ],
+    next_edge_id: 4,
     interaction: {
       dragging: None,
       panning: None,
+      connecting: None,
       selected: None,
       pointer_down: false,
       did_move: false,

--- a/examples/canvas/main/canvas_update.mbt
+++ b/examples/canvas/main/canvas_update.mbt
@@ -152,22 +152,27 @@ fn update_connect_end(state : CanvasState, target : NodeId?) -> CanvasState {
       let mut new_state = state
       match target {
         Some(t) if t != conn.from_node => {
-          let already = state.edges
-            .iter()
-            .any(fn(e) { e.source == conn.from_node && e.target == t })
-          if !already {
-            let edge : Edge = {
-              id: EdgeId(state.next_edge_id),
-              source: conn.from_node,
-              target: t,
+          match (find_node(state.nodes, conn.from_node), find_node(state.nodes, t)) {
+            (Some(_), Some(_)) => {
+              let already = state.edges
+                .iter()
+                .any(fn(e) { e.source == conn.from_node && e.target == t })
+              if !already {
+                let edge : Edge = {
+                  id: EdgeId(state.next_edge_id),
+                  source: conn.from_node,
+                  target: t,
+                }
+                let new_edges = state.edges.copy()
+                new_edges.push(edge)
+                new_state = {
+                  ..state,
+                  edges: new_edges,
+                  next_edge_id: state.next_edge_id + 1,
+                }
+              }
             }
-            let new_edges = state.edges.copy()
-            new_edges.push(edge)
-            new_state = {
-              ..state,
-              edges: new_edges,
-              next_edge_id: state.next_edge_id + 1,
-            }
+            _ => ()
           }
         }
         _ => ()

--- a/examples/canvas/main/canvas_update.mbt
+++ b/examples/canvas/main/canvas_update.mbt
@@ -97,6 +97,93 @@ fn update_pointer_down(
 }
 
 ///|
+/// Start an edge-creation gesture from the output handle of `node_id`.
+fn update_connect_start(
+  state : CanvasState,
+  node_id : NodeId,
+  world_x : Double,
+  world_y : Double,
+) -> CanvasState {
+  let conn : ConnectState = {
+    from_node: node_id,
+    cursor_x: world_x,
+    cursor_y: world_y,
+  }
+  let new_interaction : InteractionState = {
+    ..state.interaction,
+    connecting: Some(conn),
+    pointer_down: true,
+    did_move: false,
+  }
+  { ..state, interaction: new_interaction }
+}
+
+///|
+fn update_connect_move(
+  state : CanvasState,
+  world_x : Double,
+  world_y : Double,
+) -> CanvasState {
+  match state.interaction.connecting {
+    None => state
+    Some(conn) => {
+      let new_conn : ConnectState = {
+        ..conn,
+        cursor_x: world_x,
+        cursor_y: world_y,
+      }
+      let new_interaction : InteractionState = {
+        ..state.interaction,
+        connecting: Some(new_conn),
+        did_move: true,
+      }
+      { ..state, interaction: new_interaction }
+    }
+  }
+}
+
+///|
+/// Commit an in-flight connection if released over a different node, otherwise drop it.
+/// Duplicate edges (same source and target) are not added.
+fn update_connect_end(state : CanvasState, target : NodeId?) -> CanvasState {
+  match state.interaction.connecting {
+    None => state
+    Some(conn) => {
+      let mut new_state = state
+      match target {
+        Some(t) if t != conn.from_node => {
+          let already = state.edges
+            .iter()
+            .any(fn(e) { e.source == conn.from_node && e.target == t })
+          if !already {
+            let edge : Edge = {
+              id: EdgeId(state.next_edge_id),
+              source: conn.from_node,
+              target: t,
+            }
+            let new_edges = state.edges.copy()
+            new_edges.push(edge)
+            new_state = {
+              ..state,
+              edges: new_edges,
+              next_edge_id: state.next_edge_id + 1,
+            }
+          }
+        }
+        _ => ()
+      }
+      let new_interaction : InteractionState = {
+        ..new_state.interaction,
+        connecting: None,
+        pointer_down: false,
+        did_move: false,
+      }
+      { ..new_state, interaction: new_interaction }
+    }
+  }
+}
+
+///|
 /// Dispatch a pointer-move event to the active gesture.
 /// Accepts screen coordinates; converts to world coords internally for dragging.
 fn update_pointer_move(
@@ -104,12 +191,19 @@ fn update_pointer_move(
   sx : Double,
   sy : Double,
 ) -> CanvasState {
-  match state.interaction.dragging {
+  match state.interaction.connecting {
     Some(_) => {
       let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-      update_node_drag_move(state, wx, wy)
+      update_connect_move(state, wx, wy)
     }
-    None => update_pan_move(state, sx, sy)
+    None =>
+      match state.interaction.dragging {
+        Some(_) => {
+          let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+          update_node_drag_move(state, wx, wy)
+        }
+        None => update_pan_move(state, sx, sy)
+      }
   }
 }
 
@@ -184,6 +278,11 @@ fn update_pointer_up(state : CanvasState, node_id_int : Int) -> CanvasState {
   } else {
     Some(NodeId(node_id_int))
   }
+  // If a connection gesture is in flight, commit/cancel it and exit.
+  match state.interaction.connecting {
+    Some(_) => return update_connect_end(state, hovered)
+    None => ()
+  }
   let new_selected : NodeId? = if state.interaction.pointer_down &&
     !state.interaction.did_move {
     hovered
@@ -193,6 +292,7 @@ fn update_pointer_up(state : CanvasState, node_id_int : Int) -> CanvasState {
   let new_interaction : InteractionState = {
     dragging: None,
     panning: None,
+    connecting: None,
     pointer_down: false,
     did_move: false,
     selected: new_selected,

--- a/examples/canvas/main/canvas_update.mbt
+++ b/examples/canvas/main/canvas_update.mbt
@@ -143,39 +143,45 @@ fn update_connect_move(
 }
 
 ///|
+fn edge_exists(edges : Array[Edge], source : NodeId, target : NodeId) -> Bool {
+  edges.iter().any(fn(e) { e.source == source && e.target == target })
+}
+
+///|
+fn can_commit_edge(state : CanvasState, source : NodeId, target : NodeId) -> Bool {
+  source != target &&
+  find_node(state.nodes, source) is Some(_) &&
+  find_node(state.nodes, target) is Some(_) &&
+  !edge_exists(state.edges, source, target)
+}
+
+///|
+fn append_edge(state : CanvasState, source : NodeId, target : NodeId) -> CanvasState {
+  let edge : Edge = {
+    id: EdgeId(state.next_edge_id),
+    source,
+    target,
+  }
+  let edges = state.edges.copy()
+  edges.push(edge)
+  {
+    ..state,
+    edges,
+    next_edge_id: state.next_edge_id + 1,
+  }
+}
+
+///|
 /// Commit an in-flight connection if released over a different node, otherwise drop it.
 /// Duplicate edges (same source and target) are not added.
 fn update_connect_end(state : CanvasState, target : NodeId?) -> CanvasState {
   match state.interaction.connecting {
     None => state
     Some(conn) => {
-      let mut new_state = state
-      match target {
-        Some(t) if t != conn.from_node => {
-          match (find_node(state.nodes, conn.from_node), find_node(state.nodes, t)) {
-            (Some(_), Some(_)) => {
-              let already = state.edges
-                .iter()
-                .any(fn(e) { e.source == conn.from_node && e.target == t })
-              if !already {
-                let edge : Edge = {
-                  id: EdgeId(state.next_edge_id),
-                  source: conn.from_node,
-                  target: t,
-                }
-                let new_edges = state.edges.copy()
-                new_edges.push(edge)
-                new_state = {
-                  ..state,
-                  edges: new_edges,
-                  next_edge_id: state.next_edge_id + 1,
-                }
-              }
-            }
-            _ => ()
-          }
-        }
-        _ => ()
+      let new_state = match target {
+        Some(t) if can_commit_edge(state, conn.from_node, t) =>
+          append_edge(state, conn.from_node, t)
+        _ => state
       }
       let new_interaction : InteractionState = {
         ..new_state.interaction,

--- a/examples/canvas/main/canvas_update_wbtest.mbt
+++ b/examples/canvas/main/canvas_update_wbtest.mbt
@@ -300,6 +300,23 @@ test "connect_end deduplicates existing edges" {
 }
 
 ///|
+test "connect_end ignores unknown endpoints" {
+  let state = make_test_state()
+  let missing_target = update_connect_end(
+    update_connect_start(state, NodeId(1), 0.0, 0.0),
+    Some(NodeId(99)),
+  )
+  assert_eq(missing_target.edges.length(), 0)
+  assert_eq(missing_target.next_edge_id, 1)
+  let missing_source = update_connect_end(
+    update_connect_start(state, NodeId(99), 0.0, 0.0),
+    Some(NodeId(2)),
+  )
+  assert_eq(missing_source.edges.length(), 0)
+  assert_eq(missing_source.next_edge_id, 1)
+}
+
+///|
 test "get_render_state returns correct JSON shape" {
   // create_canvas returns handle 0 on first call in test process
   let handle = create_canvas()

--- a/examples/canvas/main/canvas_update_wbtest.mbt
+++ b/examples/canvas/main/canvas_update_wbtest.mbt
@@ -20,9 +20,12 @@ fn make_test_state() -> CanvasState {
         kind: NodeKind::Text("hello"),
       },
     ],
+    edges: [],
+    next_edge_id: 1,
     interaction: {
       dragging: None,
       panning: None,
+      connecting: None,
       selected: None,
       pointer_down: false,
       did_move: false,
@@ -234,6 +237,69 @@ test "pointer_up after pan movement preserves selection" {
 }
 
 ///|
+test "connect_start records source node and cursor world position" {
+  let state = make_test_state()
+  let s = update_connect_start(state, NodeId(1), 250.0, 80.0)
+  guard s.interaction.connecting is Some(c)
+  assert_eq(c.from_node, NodeId(1))
+  inspect(c.cursor_x, content="250")
+  inspect(c.cursor_y, content="80")
+  assert_true(s.interaction.pointer_down)
+}
+
+///|
+test "connect_move updates cursor world position" {
+  let state = make_test_state()
+  let s0 = update_connect_start(state, NodeId(1), 0.0, 0.0)
+  let s1 = update_connect_move(s0, 333.0, 444.0)
+  guard s1.interaction.connecting is Some(c)
+  inspect(c.cursor_x, content="333")
+  inspect(c.cursor_y, content="444")
+  assert_true(s1.interaction.did_move)
+}
+
+///|
+test "connect_end commits an edge when target differs from source" {
+  let state = make_test_state()
+  let s0 = update_connect_start(state, NodeId(1), 0.0, 0.0)
+  let s1 = update_connect_end(s0, Some(NodeId(2)))
+  assert_eq(s1.edges.length(), 1)
+  assert_eq(s1.edges[0].source, NodeId(1))
+  assert_eq(s1.edges[0].target, NodeId(2))
+  assert_true(s1.interaction.connecting is None)
+}
+
+///|
+test "connect_end does not create a self-loop" {
+  let state = make_test_state()
+  let s0 = update_connect_start(state, NodeId(1), 0.0, 0.0)
+  let s1 = update_connect_end(s0, Some(NodeId(1)))
+  assert_eq(s1.edges.length(), 0)
+  assert_true(s1.interaction.connecting is None)
+}
+
+///|
+test "connect_end on background cancels the gesture" {
+  let state = make_test_state()
+  let s0 = update_connect_start(state, NodeId(1), 0.0, 0.0)
+  let s1 = update_connect_end(s0, None)
+  assert_eq(s1.edges.length(), 0)
+  assert_true(s1.interaction.connecting is None)
+}
+
+///|
+test "connect_end deduplicates existing edges" {
+  let state : CanvasState = {
+    ..make_test_state(),
+    edges: [{ id: EdgeId(1), source: NodeId(1), target: NodeId(2) }],
+    next_edge_id: 2,
+  }
+  let s0 = update_connect_start(state, NodeId(1), 0.0, 0.0)
+  let s1 = update_connect_end(s0, Some(NodeId(2)))
+  assert_eq(s1.edges.length(), 1)
+}
+
+///|
 test "get_render_state returns correct JSON shape" {
   // create_canvas returns handle 0 on first call in test process
   let handle = create_canvas()
@@ -242,7 +308,7 @@ test "get_render_state returns correct JSON shape" {
   inspect(
     json_str,
     content=(
-      #|{"viewport":{"x":520,"y":300,"scale":1},"nodes":[{"id":1,"x":-320,"y":-160,"w":200,"h":120,"kind":["Shape","#8250df"]},{"id":2,"x":-60,"y":-160,"w":200,"h":120,"kind":["Shape","#c792ea"]},{"id":3,"x":200,"y":-160,"w":200,"h":120,"kind":["Shape","#82aaff"]},{"id":4,"x":-320,"y":20,"w":200,"h":60,"kind":["Text","Canopy Canvas"]},{"id":5,"x":-60,"y":20,"w":200,"h":60,"kind":["Text","Pan · Zoom · Drag"]},{"id":6,"x":200,"y":20,"w":200,"h":60,"kind":["Text","∞"]}]}
+      #|{"viewport":{"x":520,"y":300,"scale":1},"nodes":[{"id":1,"x":-320,"y":-160,"w":200,"h":120,"kind":["Shape","#8250df"]},{"id":2,"x":-60,"y":-160,"w":200,"h":120,"kind":["Shape","#c792ea"]},{"id":3,"x":200,"y":-160,"w":200,"h":120,"kind":["Shape","#82aaff"]},{"id":4,"x":-320,"y":20,"w":200,"h":60,"kind":["Text","Canopy Canvas"]},{"id":5,"x":-60,"y":20,"w":200,"h":60,"kind":["Text","Pan · Zoom · Drag"]},{"id":6,"x":200,"y":20,"w":200,"h":60,"kind":["Text","∞"]}],"edges":[{"id":1,"source":1,"target":4},{"id":2,"source":2,"target":5},{"id":3,"source":3,"target":6}]}
     ),
   )
 }

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -10,6 +10,7 @@ options(
       "exports": [
         "create_canvas",
         "pointer_down",
+        "pointer_down_handle",
         "pointer_move",
         "pointer_up",
         "zoom",

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -1,12 +1,18 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "dowdiness/canopy-canvas/main"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn create_canvas() -> Int
 
 pub fn get_render_state(Int) -> String
 
 pub fn pointer_down(Int, Int, Double, Double) -> Unit
+
+pub fn pointer_down_handle(Int, Int, Double, Double) -> Unit
 
 pub fn pointer_move(Int, Double, Double) -> Unit
 
@@ -24,74 +30,88 @@ pub(all) struct CanvasNode {
   w : Double
   h : Double
   kind : NodeKind
-}
-pub impl Eq for CanvasNode
+} derive(Eq, @debug.Debug)
 pub impl Show for CanvasNode
 
 pub(all) struct CanvasState {
   viewport : Viewport
   nodes : Array[CanvasNode]
+  edges : Array[Edge]
+  next_edge_id : Int
   interaction : InteractionState
-}
+} derive(@debug.Debug)
 pub impl Default for CanvasState
 pub impl Show for CanvasState
+
+pub(all) struct ConnectState {
+  from_node : NodeId
+  cursor_x : Double
+  cursor_y : Double
+} derive(Eq, @debug.Debug)
+pub impl Show for ConnectState
+
+type ConnectingJson derive(ToJson)
 
 pub(all) struct DragState {
   node_id : NodeId
   offset_x : Double
   offset_y : Double
-}
-pub impl Eq for DragState
+} derive(Eq, @debug.Debug)
 pub impl Show for DragState
+
+pub(all) struct Edge {
+  id : EdgeId
+  source : NodeId
+  target : NodeId
+} derive(Eq, ToJson, @debug.Debug)
+pub impl Show for Edge
+
+pub struct EdgeId(Int) derive(Eq, ToJson, @debug.Debug)
+#deprecated
+pub fn EdgeId::inner(Self) -> Int
+pub impl Show for EdgeId
+
+type EdgeJson derive(ToJson)
 
 pub(all) struct InteractionState {
   dragging : DragState?
   panning : PanState?
+  connecting : ConnectState?
   selected : NodeId?
   pointer_down : Bool
   did_move : Bool
-}
-pub impl Eq for InteractionState
+} derive(Eq, @debug.Debug)
 pub impl Show for InteractionState
 
-pub struct NodeId(Int)
+pub struct NodeId(Int) derive(Eq, ToJson, @debug.Debug)
 #deprecated
 pub fn NodeId::inner(Self) -> Int
-pub impl Eq for NodeId
 pub impl Show for NodeId
-pub impl ToJson for NodeId
 
-type NodeJson
-pub impl ToJson for NodeJson
+type NodeJson derive(ToJson)
 
 pub enum NodeKind {
   Shape(String)
   Text(String)
-}
-pub impl Eq for NodeKind
+} derive(Eq, ToJson, @debug.Debug)
 pub impl Show for NodeKind
-pub impl ToJson for NodeKind
 
 pub(all) struct PanState {
   start_screen_x : Double
   start_screen_y : Double
   start_pan_x : Double
   start_pan_y : Double
-}
-pub impl Eq for PanState
+} derive(Eq, @debug.Debug)
 pub impl Show for PanState
 
-type RenderStateJson
-pub impl ToJson for RenderStateJson
+type RenderStateJson derive(ToJson)
 
 pub(all) struct Viewport {
   x : Double
   y : Double
   scale : Double
-}
-pub impl Eq for Viewport
+} derive(Eq, ToJson, @debug.Debug)
 pub impl Show for Viewport
-pub impl ToJson for Viewport
 
 // Type aliases
 

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -24,14 +24,26 @@
       /* transform set by JS */
     }
 
-    /* Future hybrid: Canvas 2D overlay for selection handles, arrows */
-    #overlay {
+    /* SVG edge layer — sits beneath nodes, transformed alongside #world. */
+    #edges {
       position: absolute;
       top: 0; left: 0;
-      width: 100%;
-      height: 100%;
+      overflow: visible;
       pointer-events: none;
-      display: none; /* enable when drawOverlay is implemented */
+      transform-origin: 0 0;
+    }
+    #edges path.edge {
+      fill: none;
+      stroke: #8250df;
+      stroke-width: 2;
+      opacity: 0.85;
+    }
+    #edges path.edge-pending {
+      fill: none;
+      stroke: #c792ea;
+      stroke-width: 2;
+      stroke-dasharray: 6 4;
+      opacity: 0.9;
     }
 
     .canvas-node {
@@ -54,12 +66,28 @@
       background: rgba(130, 160, 255, 0.08);
       border: 1px solid rgba(130, 160, 255, 0.2);
     }
+
+    .handle {
+      position: absolute;
+      top: 50%;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: #1a1a2e;
+      border: 2px solid #8250df;
+      transform: translate(-50%, -50%);
+      cursor: crosshair;
+      pointer-events: auto;
+    }
+    .handle.input  { left: 0; }
+    .handle.output { left: 100%; }
+    .handle:hover  { background: #8250df; }
   </style>
 </head>
 <body>
   <div id="canvas-root">
+    <svg id="edges" xmlns="http://www.w3.org/2000/svg"></svg>
     <div id="world"></div>
-    <canvas id="overlay"></canvas>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -208,8 +208,8 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
         mb.pointer_down_handle(handle, hit.nodeId, sx, sy);
         pointerDownNodeId = 0; // pointerup uses hover target, not down target
       } else {
-        // Input handle clicks are inert for now.
-        mb.pointer_down(handle, 0, sx, sy);
+        // Input handle clicks are inert for now; do not start background pan.
+        pointerDownNodeId = 0;
       }
       break;
     case 'node':

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -1,15 +1,26 @@
 type CanvasModule = {
   create_canvas: () => number;
-  pointer_down:  (h: number, nodeId: number, sx: number, sy: number) => void;
-  pointer_move:  (h: number, sx: number, sy: number) => void;
-  pointer_up:    (h: number, nodeId: number) => void;
-  zoom:          (h: number, delta: number, cx: number, cy: number) => void;
-  get_render_state: (h: number) => string;
+  pointer_down:        (h: number, nodeId: number, sx: number, sy: number) => void;
+  pointer_down_handle: (h: number, nodeId: number, sx: number, sy: number) => void;
+  pointer_move:        (h: number, sx: number, sy: number) => void;
+  pointer_up:          (h: number, nodeId: number) => void;
+  zoom:                (h: number, delta: number, cx: number, cy: number) => void;
+  get_render_state:    (h: number) => string;
 };
 
-type NodeKind   = ['Shape', string] | ['Text', string];
-type NodeData   = { id: number; x: number; y: number; w: number; h: number; kind: NodeKind };
-type RenderState = { viewport: { x: number; y: number; scale: number }; nodes: NodeData[]; selected?: number };
+type NodeKind = ['Shape', string] | ['Text', string];
+type NodeData = { id: number; x: number; y: number; w: number; h: number; kind: NodeKind };
+type EdgeData = { id: number; source: number; target: number };
+type Connecting = { from: number; cursor_x: number; cursor_y: number };
+type RenderState = {
+  viewport: { x: number; y: number; scale: number };
+  nodes: NodeData[];
+  edges: EdgeData[];
+  selected?: number;
+  connecting?: Connecting;
+};
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
 let mb: CanvasModule;
 let handle = -1;
@@ -17,7 +28,23 @@ let rafPending = false;
 
 const root     = document.getElementById('canvas-root') as HTMLDivElement;
 const world    = document.getElementById('world') as HTMLDivElement;
+const edgesSvg = document.getElementById('edges') as unknown as SVGSVGElement;
 const nodeDivs = new Map<number, HTMLDivElement>();
+const edgePaths = new Map<number, SVGPathElement>();
+let pendingPath: SVGPathElement | null = null;
+
+// ─── Geometry ────────────────────────────────────────────────────────────────
+
+/** Output handle = right-center of node (world coords). */
+function outputAnchor(n: NodeData): [number, number] { return [n.x + n.w, n.y + n.h / 2]; }
+/** Input handle = left-center of node (world coords). */
+function inputAnchor(n: NodeData): [number, number]  { return [n.x,       n.y + n.h / 2]; }
+
+/** Cubic bezier from src to dst with horizontal handles, react-flow style. */
+function bezierPath(sx: number, sy: number, tx: number, ty: number): string {
+  const dx = Math.max(40, Math.abs(tx - sx) * 0.5);
+  return `M ${sx} ${sy} C ${sx + dx} ${sy}, ${tx - dx} ${ty}, ${tx} ${ty}`;
+}
 
 // ─── RAF render loop ─────────────────────────────────────────────────────────
 
@@ -32,16 +59,39 @@ function render(): void {
   const state: RenderState = JSON.parse(mb.get_render_state(handle));
 
   const { x, y, scale } = state.viewport;
-  world.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
+  const transform = `translate(${x}px, ${y}px) scale(${scale})`;
+  world.style.transform    = transform;
+  edgesSvg.style.transform = transform;
 
-  const seen = new Set<number>();
+  // Nodes ────────────────────────────────────────────────────────────────────
+  const nodesById = new Map<number, NodeData>();
+  const seenNodes = new Set<number>();
   for (const node of state.nodes) {
-    seen.add(node.id);
+    seenNodes.add(node.id);
+    nodesById.set(node.id, node);
+
     let div = nodeDivs.get(node.id);
     if (!div) {
       div = document.createElement('div');
       div.className = 'canvas-node';
       div.dataset.nodeId = String(node.id);
+
+      const inH = document.createElement('div');
+      inH.className = 'handle input';
+      inH.dataset.handle = 'input';
+      inH.dataset.nodeId = String(node.id);
+      div.appendChild(inH);
+
+      const outH = document.createElement('div');
+      outH.className = 'handle output';
+      outH.dataset.handle = 'output';
+      outH.dataset.nodeId = String(node.id);
+      div.appendChild(outH);
+
+      const label = document.createElement('span');
+      label.className = 'node-label';
+      div.appendChild(label);
+
       world.appendChild(div);
       nodeDivs.set(node.id, div);
     }
@@ -51,40 +101,92 @@ function render(): void {
     div.style.height = `${node.h}px`;
 
     const [kind, value] = node.kind;
+    const label = div.querySelector('.node-label') as HTMLSpanElement;
     if (kind === 'Shape') {
       div.style.backgroundColor = value;
       div.dataset.kind = 'Shape';
-      div.textContent = '';
+      label.textContent = '';
     } else {
       div.style.backgroundColor = '';
       div.dataset.kind = 'Text';
-      div.textContent = value;
+      label.textContent = value;
     }
-    // selected is absent (not null) when nothing is selected — use loose equality
     div.classList.toggle('selected', state.selected != null && state.selected === node.id);
   }
-
   for (const [id, div] of nodeDivs) {
-    if (!seen.has(id)) { div.remove(); nodeDivs.delete(id); }
+    if (!seenNodes.has(id)) { div.remove(); nodeDivs.delete(id); }
+  }
+
+  // Edges ────────────────────────────────────────────────────────────────────
+  const seenEdges = new Set<number>();
+  for (const edge of state.edges) {
+    const src = nodesById.get(edge.source);
+    const dst = nodesById.get(edge.target);
+    if (!src || !dst) continue;
+    seenEdges.add(edge.id);
+    const [sx, sy] = outputAnchor(src);
+    const [tx, ty] = inputAnchor(dst);
+    let path = edgePaths.get(edge.id);
+    if (!path) {
+      path = document.createElementNS(SVG_NS, 'path');
+      path.setAttribute('class', 'edge');
+      edgesSvg.appendChild(path);
+      edgePaths.set(edge.id, path);
+    }
+    path.setAttribute('d', bezierPath(sx, sy, tx, ty));
+  }
+  for (const [id, path] of edgePaths) {
+    if (!seenEdges.has(id)) { path.remove(); edgePaths.delete(id); }
+  }
+
+  // In-flight connection ─────────────────────────────────────────────────────
+  if (state.connecting) {
+    const src = nodesById.get(state.connecting.from);
+    if (src) {
+      const [sx, sy] = outputAnchor(src);
+      const tx = state.connecting.cursor_x;
+      const ty = state.connecting.cursor_y;
+      if (!pendingPath) {
+        pendingPath = document.createElementNS(SVG_NS, 'path');
+        pendingPath.setAttribute('class', 'edge-pending');
+        edgesSvg.appendChild(pendingPath);
+      }
+      pendingPath.setAttribute('d', bezierPath(sx, sy, tx, ty));
+    }
+  } else if (pendingPath) {
+    pendingPath.remove();
+    pendingPath = null;
   }
 }
 
 // ─── DOM helpers ─────────────────────────────────────────────────────────────
 
-/** Pointer/wheel position in canvas-local screen space. */
 function localCoords(e: MouseEvent): [number, number] {
   const rect = root.getBoundingClientRect();
   return [e.clientX - rect.left, e.clientY - rect.top];
 }
 
-/** Walk up from event target to find data-node-id. Returns 0 for background. */
-function nodeIdFromTarget(target: EventTarget | null): number {
+type HitTarget =
+  | { kind: 'background' }
+  | { kind: 'node'; nodeId: number }
+  | { kind: 'handle'; nodeId: number; side: 'input' | 'output' };
+
+function hitFromTarget(target: EventTarget | null): HitTarget {
   let el = target as HTMLElement | null;
-  while (el && el !== world) {
-    if (el.dataset?.nodeId) return parseInt(el.dataset.nodeId);
+  while (el && el !== root) {
+    if (el.dataset?.handle && el.dataset?.nodeId) {
+      return {
+        kind: 'handle',
+        nodeId: parseInt(el.dataset.nodeId),
+        side: el.dataset.handle as 'input' | 'output',
+      };
+    }
+    if (el.dataset?.nodeId && el.classList.contains('canvas-node')) {
+      return { kind: 'node', nodeId: parseInt(el.dataset.nodeId) };
+    }
     el = el.parentElement;
   }
-  return 0;
+  return { kind: 'background' };
 }
 
 // ─── Event wiring ─────────────────────────────────────────────────────────────
@@ -93,14 +195,33 @@ let activePointerId = -1;
 let pointerDownNodeId = 0;
 
 root.addEventListener('pointerdown', (e: PointerEvent) => {
-  if (activePointerId !== -1) return; // ignore secondary pointers
+  if (activePointerId !== -1) return;
   root.setPointerCapture(e.pointerId);
   activePointerId = e.pointerId;
   const [sx, sy] = localCoords(e);
-  const nodeId = nodeIdFromTarget(e.target);
-  pointerDownNodeId = nodeId;
-  mb.pointer_down(handle, nodeId, sx, sy);
-  if (nodeId === 0) root.classList.add('panning');
+  const hit = hitFromTarget(e.target);
+
+  switch (hit.kind) {
+    case 'handle':
+      // Only output handles initiate a connection in the prototype.
+      if (hit.side === 'output') {
+        mb.pointer_down_handle(handle, hit.nodeId, sx, sy);
+        pointerDownNodeId = 0; // pointerup uses hover target, not down target
+      } else {
+        // Input handle clicks are inert for now.
+        mb.pointer_down(handle, 0, sx, sy);
+      }
+      break;
+    case 'node':
+      pointerDownNodeId = hit.nodeId;
+      mb.pointer_down(handle, hit.nodeId, sx, sy);
+      break;
+    case 'background':
+      pointerDownNodeId = 0;
+      mb.pointer_down(handle, 0, sx, sy);
+      root.classList.add('panning');
+      break;
+  }
   scheduleRender();
 });
 
@@ -113,7 +234,15 @@ root.addEventListener('pointermove', (e: PointerEvent) => {
 
 root.addEventListener('pointerup', (e: PointerEvent) => {
   if (e.pointerId !== activePointerId) return;
-  mb.pointer_up(handle, pointerDownNodeId);
+  // setPointerCapture redirects later events to the capturer, so e.target is
+  // unreliable for hit-testing on release. Use elementFromPoint instead.
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  const hit = hitFromTarget(under);
+  const upNodeId =
+    hit.kind === 'node'   ? hit.nodeId :
+    hit.kind === 'handle' ? hit.nodeId :
+    pointerDownNodeId;
+  mb.pointer_up(handle, upNodeId);
   activePointerId = -1;
   pointerDownNodeId = 0;
   root.classList.remove('panning');


### PR DESCRIPTION
## Summary

- add input/output handles to the canvas example nodes
- add persistent SVG edge rendering and in-flight connection previews
- add MoonBit state/update logic for creating edges, rejecting self-loops, and deduplicating source/target pairs
- document the completed demo extension in the archive docs

## Validation

- `moon check`
- `moon check --deny-warn --warn-list @a`
- `moon test`
- `cd examples/canvas/web && npm run build`
- `cd examples/canvas/web && npm exec tsc -- --noEmit`
- `git diff --cached --check`
- `markdownlint-cli2 docs/README.md docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md`

## Notes

`npm install` was needed in `examples/canvas/web` before the web checks. It reported three moderate npm audit warnings but produced no tracked changes.

No ADR needed: this is a demo-only `examples/canvas/` extension and does not change framework architecture, public editor API, CRDT model, parser pipeline, or cross-package contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas now supports edge creation: drag output handles to connect nodes together
  * Node input/output handles are visually displayed
  * Curved edges render between connected nodes
  * In-flight connection preview displayed while dragging
  * Connection validation prevents self-loops and duplicate connections

* **Documentation**
  * Added "Canvas Handles And Edges" feature documentation

* **Tests**
  * Added connection gesture and validation tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/262)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->