### PR TITLE
[codex] Add canvas Playwright smoke test

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,6 +16,7 @@ Runs comprehensive checks on every push and PR via shared `make` and `scripts/` 
 - **Build JS** - Builds `canopy.js`/`canopy.d.ts` plus Graphviz browser artifacts
 - **Build Web Example** - Builds `examples/web` through `make build-web`
 - **Demo React E2E** - Runs the canonical Playwright browser suite through `make test-demo-react-e2e`
+- **Canvas E2E** - Runs the canvas Playwright suite through `make test-canvas-e2e`
 - **Benchmark** - Runs benchmarks on PRs (optional)
 
 **Status Badge:**
@@ -111,6 +112,9 @@ make build-web
 
 # Run the canonical browser E2E suite
 make test-demo-react-e2e
+
+# Run the canvas browser E2E suite
+make test-canvas-e2e
 
 # Install pre-commit hooks
 make install-hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
         run: npm ci
 
       - name: Run canvas Playwright suite
-        run: make test-canvas-e2e
+        run: ./scripts/test-canvas-e2e.sh
 
   all-checks-passed:
     name: All Checks Passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,37 @@ jobs:
       - name: Run demo-react Playwright suite
         run: ./scripts/test-demo-react-e2e.sh
 
+  canvas-e2e:
+    name: Canvas E2E
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --ipc=host
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: examples/canvas/web/package-lock.json
+
+      - name: Install canvas web dependencies
+        working-directory: examples/canvas/web
+        run: npm ci
+
+      - name: Run canvas Playwright suite
+        run: make test-canvas-e2e
+
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
@@ -358,6 +389,7 @@ jobs:
       - web-build
       - web-e2e
       - demo-react-e2e
+      - canvas-e2e
     if: always()
     steps:
       - name: Check all job statuses
@@ -371,7 +403,8 @@ jobs:
              [[ "${{ needs.build-js.result }}" != "success" ]] || \
              [[ "${{ needs.web-build.result }}" != "success" ]] || \
              [[ "${{ needs.web-e2e.result }}" != "success" ]] || \
-             [[ "${{ needs.demo-react-e2e.result }}" != "success" ]]; then
+             [[ "${{ needs.demo-react-e2e.result }}" != "success" ]] || \
+             [[ "${{ needs.canvas-e2e.result }}" != "success" ]]; then
             echo "❌ One or more required checks failed"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ _build
 .playwright-mcp/
 examples/demo-react/playwright-report/
 examples/demo-react/test-results/
+examples/canvas/web/playwright-report/
 examples/ideal/web/playwright-report/
 examples/ideal/web/test-results/
 examples/web/test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ _build
 examples/demo-react/playwright-report/
 examples/demo-react/test-results/
 examples/canvas/web/playwright-report/
+examples/canvas/web/test-results/
 examples/ideal/web/playwright-report/
 examples/ideal/web/test-results/
 examples/web/test-results/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-all check check-all fmt fmt-check check-agent-doc-links build build-js build-web test-web-e2e test-demo-react-e2e benchmark-ideal-editor-response clean install-hooks release-artifacts
+.PHONY: help test test-all check check-all fmt fmt-check check-agent-doc-links build build-js build-web test-web-e2e test-canvas-e2e test-demo-react-e2e benchmark-ideal-editor-response clean install-hooks release-artifacts
 
 help: ## Show this help message
 	@echo "Canopy - Development Tasks"
@@ -44,6 +44,9 @@ build-web: ## Build web application (MoonBit + Vite)
 
 test-web-e2e: ## Run web Playwright E2E tests
 	@./scripts/test-web-e2e.sh
+
+test-canvas-e2e: ## Run canvas Playwright E2E tests
+	@./scripts/test-canvas-e2e.sh
 
 test-demo-react-e2e: ## Run demo-react Playwright E2E tests
 	@./scripts/test-demo-react-e2e.sh

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -90,7 +90,12 @@ Runs on every push and pull request to ensure code quality.
    - Installs Playwright Chromium
    - Runs `make test-demo-react-e2e`
 
-8. **benchmark** (on PRs only) - Runs performance tests
+8. **canvas-e2e** - Runs canvas Playwright E2E suite (handles and edges)
+   - Installs `examples/canvas/web` dependencies
+   - Installs Playwright Chromium
+   - Runs `make test-canvas-e2e`
+
+9. **benchmark** (on PRs only) - Runs performance tests
    ```bash
    ./scripts/run-moon-module.sh bench .
    ```
@@ -257,6 +262,7 @@ make build         # Build main module
 make build-js      # Build JavaScript target
 make build-web     # Build web application
 make test-web-e2e         # Run web Playwright E2E (lambda, JSON, markdown)
+make test-canvas-e2e      # Run canvas Playwright E2E (handles, edges)
 make test-demo-react-e2e  # Run demo-react Playwright E2E (single, collaborative)
 
 # Development

--- a/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
+++ b/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
@@ -171,6 +171,15 @@ Whitebox tests cover:
 - duplicate source/target edges are rejected
 - render JSON includes seeded demo edges
 
+Playwright smoke coverage in `examples/canvas/web/e2e/canvas-handles.spec.ts`
+drives the actual browser UI and verifies:
+
+- output-handle drag shows a pending SVG edge
+- background release cancels without adding an edge
+- valid handle-to-handle release creates an edge
+- duplicate and self-edge gestures are rejected
+- input-handle drag is inert and does not pan the viewport
+
 Validation run for the implementation:
 
 ```bash
@@ -188,7 +197,6 @@ moderate npm audit warnings, but produced no tracked changes.
 
 ## Follow-Ups
 
-- Browser interaction smoke test with Playwright or agent-browser.
 - Edge deletion and selection.
 - Node add/delete UI and edge cleanup for removed nodes.
 - Persist canvas graph state.

--- a/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
+++ b/docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
@@ -188,12 +188,15 @@ moon check --deny-warn --warn-list @a
 moon test
 cd examples/canvas/web && npm run build
 cd examples/canvas/web && npm exec tsc -- --noEmit
+make test-canvas-e2e
 git diff --cached --check
 markdownlint-cli2 docs/README.md docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
 ```
 
-All passed on 2026-05-14. `npm install` in `examples/canvas/web` reported three
-moderate npm audit warnings, but produced no tracked changes.
+Initial implementation validation passed on 2026-05-14. The Playwright smoke
+follow-up was added on 2026-05-15 and validated with `make test-canvas-e2e`.
+`npm install` in `examples/canvas/web` reported three moderate npm audit
+warnings, but produced no tracked changes.
 
 ## Follow-Ups
 

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -1,0 +1,102 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+function edgePaths(page: Page): Locator {
+  return page.locator('#edges path.edge');
+}
+
+function pendingEdgePaths(page: Page): Locator {
+  return page.locator('#edges path.edge-pending');
+}
+
+function inputHandle(page: Page, nodeId: number): Locator {
+  return page.locator(`.handle.input[data-node-id="${nodeId}"]`);
+}
+
+function outputHandle(page: Page, nodeId: number): Locator {
+  return page.locator(`.handle.output[data-node-id="${nodeId}"]`);
+}
+
+async function center(locator: Locator, label: string): Promise<Point> {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(`${label} is not visible`);
+  }
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  };
+}
+
+async function dragBetween(page: Page, from: Locator, to: Locator): Promise<void> {
+  const start = await center(from, 'source handle');
+  const end = await center(to, 'target handle');
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps: 8 });
+}
+
+async function commitDrag(page: Page, from: Locator, to: Locator): Promise<void> {
+  await dragBetween(page, from, to);
+  await expect(pendingEdgePaths(page)).toHaveCount(1);
+  await page.mouse.up();
+  await expect(pendingEdgePaths(page)).toHaveCount(0);
+}
+
+async function worldTransform(page: Page): Promise<string> {
+  return page.locator('#world').evaluate((el) => (el as HTMLElement).style.transform);
+}
+
+test('canvas handles create edges and reject invalid gestures', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(edgePaths(page)).toHaveCount(3);
+  await expect(pendingEdgePaths(page)).toHaveCount(0);
+  expect(runtimeErrors).toEqual([]);
+
+  const source = outputHandle(page, 1);
+
+  const cancelStart = await center(source, 'node 1 output handle');
+  await page.mouse.move(cancelStart.x, cancelStart.y);
+  await page.mouse.down();
+  await page.mouse.move(430, 250, { steps: 4 });
+  await expect(pendingEdgePaths(page)).toHaveCount(1);
+  await page.mouse.up();
+  await expect(pendingEdgePaths(page)).toHaveCount(0);
+  await expect(edgePaths(page)).toHaveCount(3);
+
+  await commitDrag(page, source, inputHandle(page, 5));
+  await expect(edgePaths(page)).toHaveCount(4);
+
+  await commitDrag(page, source, inputHandle(page, 5));
+  await expect(edgePaths(page)).toHaveCount(4);
+
+  await commitDrag(page, outputHandle(page, 2), inputHandle(page, 2));
+  await expect(edgePaths(page)).toHaveCount(4);
+
+  const transformBeforeInputDrag = await worldTransform(page);
+  const inputStart = await center(inputHandle(page, 3), 'node 3 input handle');
+  await page.mouse.move(inputStart.x, inputStart.y);
+  await page.mouse.down();
+  await page.mouse.move(inputStart.x - 20, inputStart.y + 50, { steps: 4 });
+  await expect(pendingEdgePaths(page)).toHaveCount(0);
+  await expect(page.locator('#canvas-root')).not.toHaveClass(/panning/);
+  expect(await worldTransform(page)).toBe(transformBeforeInputDrag);
+  await page.mouse.up();
+
+  await expect(edgePaths(page)).toHaveCount(4);
+  await expect(pendingEdgePaths(page)).toHaveCount(0);
+  expect(runtimeErrors).toEqual([]);
+});

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -32,6 +32,17 @@ async function center(locator: Locator, label: string): Promise<Point> {
   };
 }
 
+async function canvasBackgroundPoint(page: Page): Promise<Point> {
+  const box = await page.locator('#canvas-root').boundingBox();
+  if (!box) {
+    throw new Error('canvas root is not visible');
+  }
+  return {
+    x: box.x + 20,
+    y: box.y + 20,
+  };
+}
+
 async function dragBetween(page: Page, from: Locator, to: Locator): Promise<void> {
   const start = await center(from, 'source handle');
   const end = await center(to, 'target handle');
@@ -69,9 +80,10 @@ test('canvas handles create edges and reject invalid gestures', async ({ page })
   const source = outputHandle(page, 1);
 
   const cancelStart = await center(source, 'node 1 output handle');
+  const cancelTarget = await canvasBackgroundPoint(page);
   await page.mouse.move(cancelStart.x, cancelStart.y);
   await page.mouse.down();
-  await page.mouse.move(430, 250, { steps: 4 });
+  await page.mouse.move(cancelTarget.x, cancelTarget.y, { steps: 4 });
   await expect(pendingEdgePaths(page)).toHaveCount(1);
   await page.mouse.up();
   await expect(pendingEdgePaths(page)).toHaveCount(0);

--- a/examples/canvas/web/package-lock.json
+++ b/examples/canvas/web/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "canopy-canvas",
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "typescript": "^5.4.0",
         "vite": "^5.4.0"
       }
@@ -399,6 +400,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -876,6 +893,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.8",

--- a/examples/canvas/web/package.json
+++ b/examples/canvas/web/package.json
@@ -4,10 +4,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "playwright test",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
     "prebuild": "npm run prebuild:moonbit",
     "prebuild:moonbit": "cd .. && moon build --target js --release"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "typescript": "^5.4.0",
     "vite": "^5.4.0"
   }

--- a/examples/canvas/web/playwright.config.ts
+++ b/examples/canvas/web/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'line' : 'html',
+  use: {
+    baseURL: 'http://localhost:5182',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run prebuild:moonbit && npx vite --port 5182 --strictPort',
+    url: 'http://localhost:5182',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/scripts/test-canvas-e2e.sh
+++ b/scripts/test-canvas-e2e.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Build the canvas MoonBit JS output and run canvas Playwright tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+(
+    cd examples/canvas
+    moon update
+)
+
+echo "Running canvas Playwright E2E..."
+cd examples/canvas/web
+
+if [ ! -d node_modules ]; then
+    echo "Installing canvas web dependencies..."
+    npm ci
+fi
+
+CI="${CI:-1}" npx playwright test "$@"


### PR DESCRIPTION
## Summary
- add a canvas-local Playwright suite for handle/edge browser interactions
- cover pending edge, background cancel, valid edge creation, duplicate rejection, self-edge rejection, and inert input-handle drag
- update the completed phase doc to remove the now-covered smoke-test follow-up

## Validation
- rtk npm exec tsc -- --noEmit
- rtk npm --prefix examples/canvas/web run build
- rtk npm run test:e2e -- --reporter=line
- rtk npm exec --package markdownlint-cli2 -- markdownlint-cli2 docs/archive/completed-phases/2026-05-14-canvas-handles-edges.md
- rtk git diff --check

No ADR needed: this automates a demo follow-up and does not change architecture or public APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Playwright end-to-end suite for canvas handle-based edge interactions and new test npm scripts.

* **Documentation**
  * Added a Playwright smoke-coverage checklist and updated CI/Makefile usage docs and README with canvas E2E instructions.

* **CI**
  * Added a canvas E2E job to the CI workflow and made the pipeline require its result.

* **Chores**
  * Added Playwright test config, helper test runner script, updated test dependency, and expanded .gitignore for Playwright outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/264)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->