### PR TITLE
docs: refresh package READMEs + trim unused aggregator re-exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ git submodule update --init --recursive
 
 ### Test & Build
 ```bash
-# Workspace-root commands cover canopy + lib/text-change + lib/zipper + lib/btree (`moon.work` members)
-moon test                           # All workspace members (~1029 tests)
+# Workspace-root commands cover the canopy module + lib/text-change + lib/zipper +
+# lib/btree + lib/moji (the five `moon.work` members).
+moon test                           # All workspace members
 moon check                          # Lint across workspace
 moon info && moon fmt               # Format & update interfaces
 
@@ -25,19 +26,25 @@ cd event-graph-walker && moon test  # CRDT library tests
 cd loom/loom && moon test           # Parser framework tests
 cd loom/seam && moon test           # CST library tests
 cd loom/examples/lambda && moon test # Lambda parser tests
+cd loom/examples/json && moon test
+cd loom/examples/markdown && moon test
 cd lib/semantic && moon test        # Semantic annotation tests (not a workspace member)
 cd examples/ideal && moon test      # Ideal editor example (PR-gated in CI)
 cd examples/block-editor && moon test
 cd examples/canvas && moon test
 ```
 
+The canonical CI fan-out is described in `.github/workflows/ci.yml`. Use that
+file as the source of truth if this list drifts.
+
 JS build artifacts are namespaced under the module path: `_build/js/release/build/dowdiness/canopy/ffi/{lambda,json,markdown}/...`. Vite configs, tsconfigs, `scripts/build-js.sh`, `scripts/package-release.sh`, and CI artifact uploads all reference this namespaced path.
 
 ### Web Development
 ```bash
 cd examples/web && npm run dev      # Dev server (localhost:5173)
-# Lambda editor: http://localhost:5173/
-# JSON editor:   http://localhost:5173/json.html
+# Lambda editor:   http://localhost:5173/
+# JSON editor:     http://localhost:5173/json.html
+# Markdown editor: http://localhost:5173/markdown.html
 moon build --target js              # Build for web
 ```
 

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -53,15 +53,28 @@ Text CRDT → Incremental Parse → Projection → Rendering
 
 ## Quick Start
 
-**Prerequisites:** [MoonBit](https://www.moonbitlang.com/download/) and [Node.js](https://nodejs.org/)
+**Prerequisites:** [MoonBit](https://www.moonbitlang.com/download/) and [Node.js](https://nodejs.org/).
 
 ```sh
 git clone --recursive https://github.com/dowdiness/canopy.git
 cd canopy
-moon test                                    # run the test suite
-moon build --target js
-cd examples/web && npm install && npm run dev  # localhost:5173
+
+# Workspace-root tests (canopy + lib/text-change, lib/zipper, lib/btree, lib/moji).
+# Submodules (event-graph-walker, loom, etc.) and example modules have their own
+# test suites; see docs/development/monorepo.md for the full fan-out.
+moon test
+
+# Build the JS FFI artifacts the web demo expects.
+make build-js
+
+# Run the web demo at http://localhost:5173 (lambda editor by default; JSON at
+# /json.html, Markdown at /markdown.html).
+cd examples/web && npm install && npm run dev
 ```
+
+The targets currently exercised in CI are **JavaScript** (web demo, FFI) and
+**native** (CLI, tests). WebAssembly is not a supported build target — see
+`docs/TODO.md`.
 
 ## The Bigger Picture
 
@@ -83,40 +96,74 @@ Read more: [Product Vision](docs/architecture/product-vision.md) · [The Project
 
 ## Repository Structure
 
-**Core libraries:**
+The canopy MoonBit module is at the repository root. Its package layout, plus
+in-tree libraries and submodules, is summarised below. See
+[docs/architecture.md](docs/architecture.md) for the responsibility map.
+
+**Canopy module — internal packages:**
+
+| Package | Role |
+|---------|------|
+| [core/](core/) | `NodeId`, `ProjNode[T]`, `SourceMap`, tree-edit primitives |
+| [editor/](editor/) | `SyncEditor` — wires CRDT, parser, projection, undo, ephemeral cursors |
+| [protocol/](protocol/) | `ViewPatch`, `ViewNode`, `UserIntent` — wire format for the frontend |
+| [projection/](projection/) | `TreeEditorState`, interactive tree operations |
+| [relay/](relay/) | Byte-buffer relay primitive used by the editor's collaboration path |
+| [ffi/](ffi/) | JS FFI surfaces: `ffi/lambda`, `ffi/json`, `ffi/markdown` |
+| [lang/lambda/](lang/lambda/) | Lambda calculus — `proj`, `edits`, `eval`, `flat`, `companion` |
+| [lang/json/](lang/json/) | JSON projectional editor — `proj`, `edits`, `companion` |
+| [lang/markdown/](lang/markdown/) | Markdown projectional editor — `proj`, `edits`, `companion` |
+| [llm/](llm/) | Optional LLM client (JS target only); consumed by `ffi/lambda` |
+| [cmd/main/](cmd/main/) | Native CLI entry point |
+| [echo/](echo/) | Tokenisation engine used by the echo similarity experiment |
+
+The FFI stability surface is intentionally narrow: JS frontends should consume
+the editor through [`adapters/editor-adapter`](adapters/editor-adapter/) where
+practical.
+
+**Workspace members** (built by `moon test` at the repo root, per `moon.work`):
+
+`./` (canopy), `./lib/text-change`, `./lib/zipper`, `./lib/btree`, `./lib/moji`.
+
+`./lib/semantic` is also in-tree but is not a workspace member; run its tests
+separately.
 
 | Library | Purpose |
 |---------|---------|
-| [event-graph-walker](event-graph-walker/) | CRDT engine — eg-walker with FugueMax, O(log n) ancestor queries |
-| [loom](loom/) | Incremental parser framework, CST library, reactive signals, pretty-printer |
-| [editor](editor/) | SyncEditor — wires CRDT, parser, projection, undo, collaboration |
-| [protocol](protocol/) | ViewPatch, ViewNode, UserIntent — framework-agnostic frontend protocol |
-| [core](core/) | ProjNode[T], NodeId, SourceMap, reconciliation |
-| [projection](projection/) | TreeEditorState, interactive tree operations |
+| [lib/btree/](lib/btree/) | Counted B+ tree with O(log n) position-indexed access |
+| [lib/moji/](lib/moji/) | Unicode UAX #29 grapheme- and word-boundary segmentation |
+| [lib/zipper/](lib/zipper/) | Rose-tree zipper |
+| [lib/text-change/](lib/text-change/) | Text-mutation primitives |
+| [lib/semantic/](lib/semantic/) | `Confidence[T]` lattice for merging multi-source annotations |
 
-**Standalone libraries (published on [mooncakes.io](https://mooncakes.io)):**
+**Git submodules** (separately owned repositories):
 
-| Library | Purpose | Package |
-|---------|---------|---------|
-| [lib/btree](lib/btree/) | Counted B+ tree with O(log n) position-indexed access | [`dowdiness/btree`](https://mooncakes.io/docs/dowdiness/btree) |
-| [rle](rle/) | Run-length encoded sequence with O(log n) lookup | [`dowdiness/rle`](https://mooncakes.io/docs/dowdiness/rle) |
-
-**Language packages:**
-
-| Package | Language |
-|---------|----------|
-| [lang/lambda](lang/lambda/) | Lambda calculus with arithmetic, conditionals, let-bindings |
-| [lang/json](lang/json/) | JSON structural editing |
+| Path | Repository | Role |
+|------|------------|------|
+| [event-graph-walker/](event-graph-walker/) | `dowdiness/event-graph-walker` | CRDT engine (eg-walker + FugueMax) |
+| [loom/](loom/) | `dowdiness/loom` | Incremental parser framework, CST library, reactive signals, pretty-printer |
+| [rle/](rle/) | `dowdiness/rle` | Run-length encoded sequence |
+| [order-tree/](order-tree/) | `dowdiness/order-tree` | Counted/order-statistic tree |
+| [graphviz/](graphviz/) | `dowdiness/graphviz` | Graphviz renderer (used in the inspector) |
+| [svg-dsl/](svg-dsl/) | `dowdiness/svg-dsl` | SVG DSL |
+| [valtio/](valtio/) | `dowdiness/valtio` | JS state management glue |
+| [alga/](alga/) | `dowdiness/alga` | Graph algebra |
 
 **Examples:**
 
-| Example | Description | Live Demo |
+| Example | Description | Live demo |
 |---------|-------------|-----------|
-| [web](examples/web/) | Canonical demo — lambda + JSON editors with syntax-highlighted pretty-print | [canopy-lambda-editor.pages.dev](https://canopy-lambda-editor.pages.dev) |
-| [ideal](examples/ideal/) | Full-featured editor with inspector, benchmarks | [canopy-ideal.pages.dev](https://canopy-ideal.pages.dev) |
-| [prosemirror](examples/prosemirror/) | ProseMirror structural editing integration | [canopy-prosemirror.pages.dev](https://canopy-prosemirror.pages.dev) |
-| [canvas](examples/canvas/) | Infinite canvas (experimental) | [canopy-canvas.pages.dev](https://canopy-canvas.pages.dev) |
-| [block-editor](examples/block-editor/) | Block-based structural editing | [canopy-block-editor.pages.dev](https://canopy-block-editor.pages.dev) |
+| [examples/web/](examples/web/) | Vite frontend hosting the lambda, JSON, and Markdown editors | [canopy-lambda-editor.pages.dev](https://canopy-lambda-editor.pages.dev) |
+| [examples/ideal/](examples/ideal/) | Full-featured editor with inspector and benchmarks | [canopy-ideal.pages.dev](https://canopy-ideal.pages.dev) |
+| [examples/prosemirror/](examples/prosemirror/) | ProseMirror structural-editing integration | [canopy-prosemirror.pages.dev](https://canopy-prosemirror.pages.dev) |
+| [examples/canvas/](examples/canvas/) | Infinite canvas (experimental) | [canopy-canvas.pages.dev](https://canopy-canvas.pages.dev) |
+| [examples/block-editor/](examples/block-editor/) | Block-based structural editing | [canopy-block-editor.pages.dev](https://canopy-block-editor.pages.dev) |
+| [examples/demo-react/](examples/demo-react/) | Minimal React integration | [canopy-demo-react.pages.dev](https://canopy-demo-react.pages.dev) |
+| [examples/relay-server/](examples/relay-server/) | Cloudflare Workers relay (collaboration) | deployed as `canopy-relay` |
+
+A few additional unlisted directories (`examples/rabbita/`, the `memo.html` and
+`spike-block-input.html` pages under `examples/web/`) are work-in-progress
+spikes; treat them as unstable.
 
 ## What to Read Next
 

--- a/cmd/main/README.md
+++ b/cmd/main/README.md
@@ -1,0 +1,28 @@
+# cmd/main
+
+Native CLI demo of the editor. Runs two scenarios on launch: a convergence demo (`run_convergence_demo`) that exercises CRDT merge between simulated peers, and an interactive lambda REPL (`run_repl("alice")`).
+
+This is the only executable in the canopy module (`options.is-main: true`). It is built by the workspace's `moon build --release` and is the simplest way to drive the editor without a frontend.
+
+## Public API
+
+The package compiles to a binary and has no library surface to import. The implementation files (`main.mbt`, `demo.mbt`, `repl.mbt`) are not callable from outside.
+
+## Consumers
+
+None — this is the top of the dependency tree. Run with `moon run cmd/main` from the workspace root.
+
+## Dependencies
+
+- `dowdiness/canopy/editor`
+- `dowdiness/event-graph-walker/text`
+- `dowdiness/lambda` (parser, from the loom submodule)
+- `dowdiness/pretty` (loom submodule)
+
+## Stability
+
+Internal demo. Not part of the release artifacts (`scripts/package-release.sh` packages the FFI / web outputs, not this CLI). Expect breaking changes whenever the editor's MoonBit API moves.
+
+## Notes
+
+The REPL is line-oriented (read → parse → evaluate → print). It is primarily useful for debugging parser / evaluator changes without booting the web demo; for that purpose, prefer the per-package tests over the REPL when iterating.

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,34 @@
+# core
+
+Shared runtime types for the projectional editor — the vocabulary that `editor`, `protocol`, and all `lang/*` packages agree on.
+
+This package owns nothing computational: no parsing, no CRDT, no rendering. It only defines the identifiers and data shapes that cross package boundaries, plus the incremental-memo wiring that connects a parsed `SyntaxNode` to a live `ProjNode` tree.
+
+## Public API
+
+- `NodeId` — stable identifier for an AST node, persists across edits
+- `ProjNode[T]` — generic tree node carrying a language-specific `kind : T`, a `NodeId`, and source-range bounds
+- `SourceMap` — bidirectional index from `NodeId` to text range and back; supports incremental `patch_subtree` / `remove_subtree`
+- `GenericTreeOp` — UI-level tree operations (select, drag-drop, structural edit, collapse) that language packages translate to via `to_generic()`
+- `DropPosition` (`Before` / `After` / `Inside`) — drag-and-drop placement enum used by `GenericTreeOp` and by language-specific edit ops
+- `Direction` (`Up` / `Down` / `Left` / `Right`) — navigation direction used by `navigate_proj`
+- `SpanEdit` / `FocusHint` — low-level text-edit and cursor-placement hints returned by edit handlers
+- `build_projection_memos` — wires `SyntaxNode → ProjNode → SourceMap` as three reactive `Memo` cells
+
+## Consumers
+
+Imported by almost every package in the module: `editor`, `protocol`, `projection`, all `lang/*/proj`, `lang/*/edits`, `lang/*/companion`, `lang/*/flat`, `ffi/json`, `ffi/markdown`, and the root `moon.pkg`.
+
+## Dependencies
+
+- `dowdiness/incr` (reactive cells / `Memo`)
+- `dowdiness/loom/core` (`TreeNode`, `Range`, `SyntaxNode`)
+- `dowdiness/seam` (`SyntaxNode` concrete type)
+
+## Stability
+
+Stable wire format / public surface — all language packages depend on these types. Field changes require coordinated updates across the whole module.
+
+## Notes
+
+`ProjNode` IDs are assigned by `assign_fresh_ids` during projection and preserved across incremental refreshes by `reconcile`. The `SourceMap` stores token-level sub-ranges (e.g. the exact span of a keyword within a node) keyed by role string via `set_token_span`.

--- a/core/README.md
+++ b/core/README.md
@@ -22,7 +22,7 @@ Imported by almost every package in the module: `editor`, `protocol`, `projectio
 ## Dependencies
 
 - `dowdiness/incr` (reactive cells / `Memo`)
-- `dowdiness/loom/core` (`TreeNode`, `Range`, `SyntaxNode`)
+- `dowdiness/loom/core` (`TreeNode`, `Range`)
 - `dowdiness/seam` (`SyntaxNode` concrete type)
 
 ## Stability

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,508 +1,156 @@
-# CI/CD Documentation
+# CI / CD
 
-Comprehensive guide to the continuous integration and deployment setup for Canopy.
-
-## Overview
-
-The project uses GitHub Actions for CI/CD with workflows for:
-
-- **Automated Testing** - Run tests on every push/PR
-- **Code Quality** - Enforce formatting and linting
-- **Benchmark Tracking** - Detect performance regressions
-- **Automated Deployment** - Deploy to GitHub Pages
-- **Release Automation** - Create versioned releases
-
-## Quick Start
-
-### For Developers
-
-```bash
-# Run tests locally (like CI does)
-make test-all
-
-# Run all checks (formatting, linting)
-make check-all
-
-# Run full CI suite locally
-make ci
-
-# Install pre-commit hooks
-make install-hooks
-```
-
-### For Maintainers
-
-```bash
-# Create a new release
-git tag v0.2.0
-git push origin v0.2.0
-
-# Deploy to GitHub Pages (automatic on push to main)
-git push origin main
-```
+How continuous integration and deployment are wired up for Canopy. The
+`.github/workflows/*.yml` files are the source of truth; this document
+summarises them.
 
 ## Workflows
 
-### 1. CI Workflow
+There are five workflow files in `.github/workflows/`:
 
-**File:** `.github/workflows/ci.yml`
+| File | Triggers | Purpose |
+|------|----------|---------|
+| `ci.yml` | push to `main`, pull requests, manual dispatch | All gating checks |
+| `benchmark.yml` | pull requests | Benchmark comparison with the base branch |
+| `deploy-cloudflare.yml` | push to `main`, manual dispatch | Deploy the example apps to Cloudflare |
+| `release.yml` | release tags, manual dispatch | Build versioned release artifacts |
+| `copilot-setup-steps.yml` | (assistant tooling) | Environment setup steps used by remote agents |
 
-Runs on every push and pull request to ensure code quality.
+### `ci.yml`
 
-#### Jobs
+The main gating workflow. Job names match the file:
 
-1. **test-main** - Tests the main Canopy module
-   ```bash
-   make update
-   make check
-   make test
-   make build
-   ```
+| Job | What it runs |
+|-----|--------------|
+| `dep-check` | `./scripts/check-deps.sh` |
+| `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check .`, `./scripts/run-moon-module.sh test .`, `moon build --release` |
+| `test-submodules` | Matrix over `event-graph-walker`, `loom/loom`, `svg-dsl`, `graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
+| `test-examples` | Matrix over `examples/ideal`, `examples/block-editor`, `examples/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |
+| `prove` | `moon prove` in `lib/semantic/proof` after installing Why3 1.7.2 + Z3 via opam (cached) |
+| `benchmark` | PR only: `moon bench --release` at the root and in `event-graph-walker` |
+| `format-check` | `./scripts/check-agent-doc-links.sh` and `./scripts/run-moon-module.sh fmt-check .` |
+| `build-js` | `./scripts/update-moon-deps.sh`, `./scripts/build-js.sh`; uploads the 9 JS/d.ts/mbti artifacts named below |
+| `web-build` | `./scripts/build-web.sh` (runs `build-js.sh` then `vite build` in `examples/web`) |
+| `web-e2e` | Playwright suite for `examples/web` |
+| `demo-react-e2e` | Playwright suite for `examples/demo-react` |
+| `canvas-e2e` | Playwright suite for `examples/canvas/web` |
+| `all-checks-passed` | Aggregation gate; fails unless every listed job above succeeds |
 
-2. **test-submodules** - Tests all submodules in parallel
-   - event-graph-walker
-   - loom (`loom/loom` module root)
-   - svg-dsl
-   - graphviz
+#### Uploaded artifacts (`build-js`)
 
-3. **format-check** - Ensures consistent formatting
-   ```bash
-   make fmt-check
-   ```
-
-4. **build-js** - Builds JavaScript target
-   ```bash
-   make build-js
-   ```
-   Uploads `canopy.js`, `canopy.d.ts`, and Graphviz browser artifacts.
-
-5. **web-build** - Verifies `examples/web` still builds
-   - Installs Node.js dependencies
-   - Runs `make build-web`
-
-6. **web-e2e** - Runs web Playwright E2E suite (28 tests: lambda, JSON, markdown)
-   - Installs `examples/web` dependencies
-   - Installs Playwright Chromium
-   - Runs `make test-web-e2e`
-
-7. **demo-react-e2e** - Runs demo-react Playwright E2E suite (25 tests: single editor, collaborative)
-   - Installs `examples/demo-react` dependencies
-   - Installs Playwright Chromium
-   - Runs `make test-demo-react-e2e`
-
-8. **canvas-e2e** - Runs canvas Playwright E2E suite (handles and edges)
-   - Installs `examples/canvas/web` dependencies
-   - Installs Playwright Chromium
-   - Runs `make test-canvas-e2e`
-
-9. **benchmark** (on PRs only) - Runs performance tests
-   ```bash
-   ./scripts/run-moon-module.sh bench .
-   ```
-
-#### Status Checks
-
-All jobs must pass before merging. The `all-checks-passed` job provides a single status check.
-
-### 2. Benchmark Regression
-
-**File:** `.github/workflows/benchmark.yml`
-
-Compares benchmark results between PR and base branch.
-
-#### Process
-
-1. Run benchmarks on PR branch
-2. Checkout base branch
-3. Run root and `event-graph-walker` benchmarks on the base checkout with self-contained `moon update` / `moon bench --release` commands so the workflow does not depend on new helper scripts already existing there
-4. Compare results
-5. Post comparison as PR comment
-6. Upload raw results as artifacts
-
-#### Reading Results
-
-Look for:
-- **Time differences** - >10% is significant
-- **Consistency** - Verify with local runs
-- **Patterns** - Multiple benchmarks degrading
-
-Example comment:
-```
-## Benchmark Comparison Report
-
-### Main Module Benchmarks
-
-**Base branch:**
-Benchmark: 1000_operations - 45.2ms
-Benchmark: parse_complex - 12.8ms
-
-**PR branch:**
-Benchmark: 1000_operations - 42.1ms  ⬇️ 6.9% faster
-Benchmark: parse_complex - 13.5ms   ⬆️ 5.5% slower
-```
-
-### 3. Deployment
-
-**File:** `.github/workflows/deploy.yml`
-
-Automatically deploys to GitHub Pages on push to `main`.
-
-#### Build Process
-
-1. **MoonBit Build**
-   ```bash
-   make build-js
-   ```
-
-2. **Web Build**
-   ```bash
-   make build-web
-   ```
-
-3. **Deploy**
-   - Uploads `examples/web/dist` to GitHub Pages
-   - Publishes to `https://dowdiness.github.io/crdt/`
-
-#### Setup Requirements
-
-1. Go to **Settings** → **Pages**
-2. Set **Source** to "GitHub Actions"
-3. Save
-
-First deployment may take a few minutes. Subsequent deploys are faster.
-
-### 4. Release Workflow
-
-**File:** `.github/workflows/release.yml`
-
-Creates GitHub releases with build artifacts.
-
-Current supported release targets are native and JavaScript. WebAssembly is not supported yet and is not part of the release workflow.
-
-#### Triggering Releases
-
-**Via Git Tag:**
-```bash
-# Create and push a tag
-git tag v0.2.0
-git push origin v0.2.0
-```
-
-**Via GitHub UI:**
-1. Go to **Actions** → **Release**
-2. Click **Run workflow**
-3. Enter version (e.g., `v0.2.0`)
-
-#### Build Artifacts
-
-The workflow creates:
-
-1. **MoonBit Package** - `canopy-moonbit-{version}.tar.gz`
-   - JavaScript builds
-   - Module configuration
-   - README and LICENSE
-
-2. **Web Package** - `canopy-web-{version}.tar.gz`
-   - Production web build
-   - Ready to deploy
-
-#### Changelog Generation
-
-Automatically generates changelog from commits since last tag:
+`actions/upload-artifact@v7` uploads the following paths under the name
+`moonbit-js-build`:
 
 ```
-## What's Changed
-
-- feat: add undo/redo support (a1b2c3d)
-- fix: resolve sync conflict (d4e5f6g)
-- chore: update dependencies (g7h8i9j)
+_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js
+_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/lambda/moonbit.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/json/json.js
+_build/js/release/build/dowdiness/canopy/ffi/json/json.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/json/moonbit.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.js
+_build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/markdown/moonbit.d.ts
+graphviz/_build/js/release/build/browser/browser.js
+graphviz/_build/js/release/build/browser/browser.d.ts
 ```
 
-## Dependency Management
+Retention: default for the workflow (7 days at time of writing — check
+`ci.yml` for the live value).
 
-### Dependabot
+### `benchmark.yml`
 
-**File:** `.github/dependabot.yml`
+Runs on pull requests. Compares benchmark output against the merge base and
+posts the comparison as a PR comment. Reports are also uploaded as artifacts.
+The comparison covers the root module and `event-graph-walker`.
 
-Automatic dependency updates:
+### `deploy-cloudflare.yml`
 
-- **GitHub Actions** - Weekly updates
-- **NPM packages** - Weekly updates (examples/web, examples/demo-react, valtio)
-- **Grouped updates** - Playwright and Vite updates grouped
+Deploys on every push to `main` (and on manual dispatch). The matrix has
+seven entries — six Cloudflare Pages projects and one Cloudflare Workers
+deployment:
 
-Dependabot creates PRs that are automatically tested by CI.
+| Matrix name | Cloudflare project | Type | Source directory |
+|-------------|--------------------|------|------------------|
+| `web` | `canopy-lambda-editor` | Pages | `examples/web/dist` |
+| `ideal` | `canopy-ideal` | Pages | `examples/ideal/web/dist` |
+| `prosemirror` | `canopy-prosemirror` | Pages | `examples/prosemirror/dist` |
+| `demo-react` | `canopy-demo-react` | Pages | `examples/demo-react/dist` |
+| `block-editor` | `canopy-block-editor` | Pages | `examples/block-editor/web/dist` |
+| `canvas` | `canopy-canvas` | Pages | `examples/canvas/web/dist` |
+| `relay-server` | `canopy-relay` | Workers | `examples/relay-server` |
 
-### MoonBit Dependencies
+Requires the secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
 
-Update manually:
-```bash
-make update
+> Earlier revisions of this doc described deployment via GitHub Pages to
+> `dowdiness.github.io/crdt/`. That path is no longer used.
+
+### `release.yml`
+
+Packages release artifacts using `./scripts/package-release.sh`. Currently
+covers **native** and **JavaScript**; WebAssembly is not part of the release
+workflow (see `docs/TODO.md` §1).
+
+## Running locally
+
+Common entry points (Makefile targets that wrap `scripts/`):
+
+```sh
+make help                  # List all targets
+make test                  # Tests for the workspace
+make test-all              # Fan out into submodules
+make check                 # moon check
+make check-all             # check + fmt-check across modules
+make fmt                   # moon fmt && moon info
+make fmt-check             # CI's format gate
+make build                 # moon build --release
+make build-js              # Build the FFI JS artifacts CI uploads
+make build-web             # build-js + npm-driven Vite build in examples/web
+make test-web-e2e          # Playwright suite for examples/web
+make test-demo-react-e2e   # Playwright suite for examples/demo-react
+make test-canvas-e2e       # Playwright suite for examples/canvas/web
+make bench                 # moon bench --release (root + event-graph-walker)
+make ci                    # check-all + test-all
+make web-dev               # build-js then start examples/web Vite dev server
+make install-hooks         # Install pre-commit hook
+make update                # moon update across root + maintained submodules
 ```
 
-Add to CI if you need to test against latest dependencies.
+The shared module helper is `./scripts/run-moon-module.sh <subcommand> <path>`
+where `<subcommand>` is `check`, `test`, `ci`, `fmt-check`, or `bench`. It
+validates that `<path>` is a real MoonBit module before invoking `moon`.
 
-## Local Development Scripts
+## Pre-commit hook
 
-### Makefile Targets
+`make install-hooks` (or `./scripts/install-hooks.sh`) installs the hook in
+`.githooks/`. The hook runs `moon check` for the changed package. If you need
+to bypass it (e.g. during a rebase you understand), `git commit --no-verify` is
+available, but CI's `format-check` and `test-main` will catch the same issues
+on push.
 
-```bash
-make help          # Show all available targets
+## Adding new gating checks
 
-# Testing
-make test          # Test main module only
-make test-all      # Test all modules + submodules
-
-# Code Quality
-make check         # Check main module
-make check-all     # Check all modules
-make fmt           # Format code
-
-# Building
-make build         # Build main module
-make build-js      # Build JavaScript target
-make build-web     # Build web application
-make test-web-e2e         # Run web Playwright E2E (lambda, JSON, markdown)
-make test-canvas-e2e      # Run canvas Playwright E2E (handles, edges)
-make test-demo-react-e2e  # Run demo-react Playwright E2E (single, collaborative)
-
-# Development
-make web-dev       # Build JS + start dev server
-make clean         # Clean build artifacts
-make ci            # Run MoonBit CI checks locally
-
-# Setup
-make install-hooks # Install git pre-commit hooks
-make update        # Update all dependencies
-```
-
-### Scripts
-
-Located in `scripts/`:
-
-1. **build-web.sh** - Builds shared JS artifacts and then builds `examples/web`
-   ```bash
-   ./scripts/build-web.sh
-   ```
-
-2. **test-all.sh** - Tests all modules with nice output
-   ```bash
-   ./scripts/test-all.sh
-   ```
-
-3. **check-all.sh** - Runs check + format validation for all modules
-   ```bash
-   ./scripts/check-all.sh
-   ```
-
-4. **install-hooks.sh** - Installs pre-commit hooks
-   ```bash
-   ./scripts/install-hooks.sh
-   ```
-
-5. **run-moon-module.sh** - Shared entrypoint for `check`, `test`, `fmt-check`, `ci`, and `bench`
-   ```bash
-   ./scripts/run-moon-module.sh ci .
-   ./scripts/run-moon-module.sh bench event-graph-walker
-   ```
-   The helper validates that the provided path is a real MoonBit module root before running commands, so `loom/loom` is used instead of the umbrella `loom/` directory.
-
-6. **build-js.sh** - Builds the canonical JS artifacts for Canopy + Graphviz
-   ```bash
-   ./scripts/build-js.sh
-   ```
-
-7. **package-release.sh** - Creates release archives from the current build outputs
-   ```bash
-   ./scripts/package-release.sh v0.2.0
-   ```
-
-### Pre-commit Hooks
-
-Install with `make install-hooks` or `./scripts/install-hooks.sh`.
-
-The hook runs:
-```bash
-make check
-make fmt-check
-```
-
-Prevents committing code that would fail CI.
-
-**Bypass (not recommended):**
-```bash
-git commit --no-verify
-```
-
-## Performance Optimization
-
-### Build Times
-
-**Parallel Testing:**
-CI runs submodule tests in parallel using matrix strategy:
-
-```yaml
-strategy:
-  matrix:
-    include:
-      - name: event-graph-walker
-        path: event-graph-walker
-      - name: loom
-        path: loom/loom
-      - name: svg-dsl
-        path: svg-dsl
-      - name: graphviz
-        path: graphviz
-```
-
-**Caching:**
-Currently no caching (MoonBit builds are fast). Could add:
-- Moon binary caching
-- npm dependencies caching
-
-### Artifact Storage
-
-| Artifact | Size | Retention | Cost Impact |
-|----------|------|-----------|-------------|
-| JS builds | ~500KB | 7 days | Low |
-| Benchmarks | ~10KB | 30 days | Very low |
-| Releases | ~2MB | 90 days | Low |
-
-Adjust retention periods in workflow files if needed.
+Add the job to `ci.yml`, then add its name to the `needs:` list under
+`all-checks-passed`. The aggregation gate verifies each named job's
+`.result == "success"`, so a missing entry there silently lets failures
+through.
 
 ## Troubleshooting
 
-### Common Issues
-
-#### Submodule Checkout Fails
-
-**Symptom:** CI fails with "submodule not found"
-
-**Solution:**
-```yaml
-- uses: actions/checkout@v4
-  with:
-    submodules: recursive  # ← Must be set
-```
-
-#### Format Check Fails
-
-**Symptom:** CI fails on format-check job
-
-**Solution:**
-```bash
-make fmt
-git add .
-git commit -m "chore: format code"
-```
-
-#### Web Build Fails
-
-**Symptom:** `canopy.js` or `canopy.d.ts` not found in web build
-
-**Solution:** Run the shared JS entrypoint before building the frontend:
-```bash
-make build-js
-make build-web
-```
-
-#### Benchmark Results Noisy
-
-**Symptom:** Benchmarks vary wildly between runs
-
-**Facts:**
-- GitHub Actions runners have variable performance
-- Benchmarks are for **relative** comparison, not absolute
-- Look for consistent patterns, not single runs
-
-**Mitigation:**
-```bash
-# Run locally for accurate numbers
-make bench
-```
-
-### Debug Workflows
-
-#### View Logs
-
-1. Go to **Actions** tab
-2. Click on failed workflow run
-3. Click on failed job
-4. Expand failed step
-
-#### Run Workflow Manually
-
-Most workflows support `workflow_dispatch`:
-
-1. Go to **Actions** tab
-2. Select workflow
-3. Click **Run workflow**
-
-#### Test Locally with act
-
-Install [act](https://github.com/nektos/act):
-```bash
-brew install act  # macOS
-# or
-curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
-```
-
-Run workflows locally:
-```bash
-act pull_request  # Run PR workflows
-act push          # Run push workflows
-```
-
-Note: Some features (GitHub Pages, releases) won't work locally.
-
-## Security
-
-### Token Permissions
-
-Workflows use minimal permissions:
-
-```yaml
-permissions:
-  contents: read        # Read repository
-  pull-requests: write  # Comment on PRs
-  pages: write          # Deploy to Pages
-```
-
-No custom secrets required. Uses auto-generated `GITHUB_TOKEN`.
-
-### Dependabot PRs
-
-Dependabot PRs have restricted permissions and must pass CI before merging.
-
-## Monitoring
-
-### Status Badges
-
-Add to README:
-
-```markdown
-![CI](https://github.com/dowdiness/canopy/actions/workflows/ci.yml/badge.svg)
-![Deploy](https://github.com/dowdiness/canopy/actions/workflows/deploy.yml/badge.svg)
-```
-
-### Notifications
-
-Configure in **Settings** → **Notifications**:
-
-- Email on workflow failure
-- Slack/Discord webhooks (if desired)
-
-## Future Improvements
-
-Active follow-ups are tracked in `docs/TODO.md`. Current CI/CD-related gaps include:
-
-- [ ] If wasm support is added later, add a dedicated target implementation and CI coverage
-- [x] Run one canonical Playwright browser app in CI (`examples/demo-react`)
-- [ ] Add code coverage reporting
-- [ ] Add Docker builds for reproducible environments
+- **`build-js` fails because artifacts are missing.** `scripts/build-js.sh`
+  verifies the eleven JS/d.ts/mbti paths listed above. The most common cause is
+  running it without `submodules: recursive` checked out, because graphviz is a
+  submodule.
+- **`prove` fails to find Why3 or Z3.** The cache key includes the OS and
+  arch; cache misses re-install via opam. If versions ever change, bump the
+  cache key in `ci.yml`.
+- **`format-check` fails.** Run `make fmt` locally and commit the result.
+- **Submodule checkouts.** Every checkout step uses `submodules: recursive`.
+  If you add a new workflow, copy that setting.
 
 ## References
 
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [MoonBit CLI Reference](https://docs.moonbitlang.com)
-- [Workflow Files](../.github/workflows/)
-- [TODO List](TODO.md)
+- [Workflow files](../.github/workflows/) — authoritative
+- [TODO list](TODO.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,16 +26,22 @@ Read in order to build a mental model of the system.
    to be: write, auto-structure, surface.
 2. **[The Projectional Bridge](architecture/vision-projectional-bridge.md)** —
    why: syntax → semantics → intent → mental model.
-3. **[System Architecture Diagram](architecture/ARCHITECTURE_DIAGRAM.md)** —
+3. **[Architecture Overview](architecture.md)** — single-page summary of the
+   pipeline, package responsibilities, key invariants, and extension points.
+4. **[System Architecture Diagram](architecture/ARCHITECTURE_DIAGRAM.md)** —
    high-level data flow: Text CRDT → Incremental Parse → Projection → Rendering.
-4. **[Module Structure](architecture/modules.md)** — how the monorepo and
+5. **[Module Structure](architecture/modules.md)** — how the monorepo and
    submodules map onto that pipeline.
-5. **[Projectional Editing](architecture/PROJECTIONAL_EDITING.md)** — what
-   projectional editing means in Canopy specifically.
 6. **[Incremental Hylomorphism](architecture/Incremental-Hylomorphism.md)** —
    the compositional engine underneath.
 7. **[Multi-Representation System](architecture/multi-representation-system.md)**
    — the `Printable` trait family (Show, Debug, Source, Pretty).
+
+> The earlier "Projectional Editing" deep-dive has been archived to
+> [`archive/PROJECTIONAL_EDITING.md`](archive/PROJECTIONAL_EDITING.md). It is
+> retained for historical context only and is known to disagree with the
+> current code in several places. Use the architecture overview above
+> instead.
 
 Further architecture notes live in [docs/architecture/](architecture/).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,10 +19,13 @@ Text CRDT ─► Incremental parse ─► Projection ─► View patches ─► 
    (submodule [`event-graph-walker`](../event-graph-walker/)).
 2. The incremental parser
    (submodule [`loom`](../loom/)) reparses only affected regions.
-3. The [`projection/`](../projection/) layer maps the parse tree to projection
-   nodes with stable identity.
-4. The [`protocol/`](../protocol/) layer computes patches the frontend can
-   apply.
+3. Each language's `lang/<lang>/proj/` builders map the parse tree to
+   `ProjNode` trees with stable identity (the shared primitives come from
+   [`core/`](../core/); [`projection/`](../projection/) layers interactive
+   tree-editor state on top).
+4. [`editor/`](../editor/) computes incremental `ViewPatch` sequences from the
+   `ProjNode` tree; [`protocol/`](../protocol/) defines the wire types and
+   converts `ProjNode → ViewNode` before serialization.
 5. Structural edits go back through the CRDT as text edits, closing the loop.
 
 ## Package responsibility map (canopy module)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,142 @@
+# Canopy Architecture
+
+Single-page summary of how Canopy is structured. Each section names the
+packages and types involved so that code remains the source of truth; longer
+prose lives under [docs/architecture/](architecture/).
+
+> If a claim here disagrees with the code, the code wins. Update this file
+> rather than the code.
+
+## Pipeline
+
+```
+Text CRDT ─► Incremental parse ─► Projection ─► View patches ─► Frontend
+   ▲                                                                 │
+   └────────────── structural edits feed back ───────────────────────┘
+```
+
+1. The document is stored in a FugueMax sequence CRDT
+   (submodule [`event-graph-walker`](../event-graph-walker/)).
+2. The incremental parser
+   (submodule [`loom`](../loom/)) reparses only affected regions.
+3. The [`projection/`](../projection/) layer maps the parse tree to projection
+   nodes with stable identity.
+4. The [`protocol/`](../protocol/) layer computes patches the frontend can
+   apply.
+5. Structural edits go back through the CRDT as text edits, closing the loop.
+
+## Package responsibility map (canopy module)
+
+| Package | Owns |
+|---------|------|
+| [`core/`](../core/) | Tree-projection primitives: `NodeId`, `ProjNode[T]`, `SourceMap`, `SpanEdit`, `GenericTreeOp` |
+| [`editor/`](../editor/) | `SyncEditor[T]`, view-patch computation, undo, ephemeral cursors, websocket plumbing |
+| [`protocol/`](../protocol/) | Wire-format types: `ViewPatch`, `ViewNode`, `UserIntent`, `Decoration`, `Diagnostic` |
+| [`projection/`](../projection/) | `TreeEditorState[T]`, `InteractiveTreeNode[T]`, interactive tree edits |
+| [`relay/`](../relay/) | Minimal byte-buffer relay used by `editor/` collaboration |
+| [`ffi/lambda`](../ffi/lambda/), [`ffi/json`](../ffi/json/), [`ffi/markdown`](../ffi/markdown/) | JS export surfaces (JS target only) |
+| [`lang/lambda/*`](../lang/lambda/) | Lambda calculus pipeline (`proj`, `edits`, `eval`, `flat`, `companion`) |
+| [`lang/json/*`](../lang/json/) | JSON projectional editor (`proj`, `edits`, `companion`) |
+| [`lang/markdown/*`](../lang/markdown/) | Markdown projectional editor (`proj`, `edits`, `companion`) |
+| [`llm/`](../llm/) | Optional fetch-based LLM client (JS only); consumed by `ffi/lambda` |
+| [`cmd/main/`](../cmd/main/) | Native CLI entry point |
+| [`echo/`](../echo/), [`echo/tokenizer/`](../echo/tokenizer/) | Tokenisation + similarity engine for the echo experiment |
+
+### Workspace libraries (`moon.work` members)
+
+| Package | Role |
+|---------|------|
+| [`lib/btree/`](../lib/btree/) | Counted B+ tree, O(log n) position lookup |
+| [`lib/moji/`](../lib/moji/) | UAX #29 grapheme- and word-boundary segmentation |
+| [`lib/zipper/`](../lib/zipper/) | Rose-tree zipper |
+| [`lib/text-change/`](../lib/text-change/) | Text-mutation primitives |
+
+[`lib/semantic/`](../lib/semantic/) (with `lib/semantic/proof/`) is in-tree but
+*not* a workspace member; it must be tested and proved separately.
+
+### Submodules
+
+Submodules are independent repositories pulled in via path dependencies. See
+[`development/monorepo.md`](development/monorepo.md) for the daily workflow.
+
+| Path | Role |
+|------|------|
+| `event-graph-walker/` | CRDT engine (eg-walker, FugueMax) |
+| `loom/` | Incremental parser framework, CST library (`loom/seam`), reactive signals (`loom/incr`), pretty-printer (`loom/pretty`), example languages, egglog/egraph |
+| `rle/` | Run-length encoded sequence |
+| `order-tree/` | Counted tree |
+| `graphviz/`, `svg-dsl/` | Visualisation in the inspector |
+| `valtio/` | JS state management glue |
+| `alga/` | Graph algebra |
+
+## Key types and invariants
+
+These are framework-level invariants. Specific field names belong in the code,
+not here.
+
+- **Text is ground truth.** The CRDT's text content is authoritative;
+  everything else is computed. Structural edits are first translated into text
+  edits before they enter the CRDT.
+- **Projection identity is stable across reparses.** `NodeId` survives
+  reparsing, so UI state (selection, scroll, drag) does not flicker when the
+  underlying tree changes. Reconciliation lives in `core/`.
+- **CST nodes are position-independent.** The parser stores relative widths,
+  not absolute positions; unchanged subtrees are reused on reparse.
+- **Protocol types are JSON-serialisable.** Anything that crosses the FFI is
+  declared in [`protocol/`](../protocol/); the TypeScript counterpart lives in
+  [`adapters/editor-adapter/types.ts`](../adapters/editor-adapter/types.ts).
+- **Cross-package struct construction needs `pub(all)` or a named constructor.**
+  Plain `pub struct` is read-only outside the defining package.
+
+## Extension points
+
+- **Adding a language** — implement a parser in a `loom/examples/<lang>/`
+  module and a projection layer in `lang/<lang>/proj/`, then a JS FFI in
+  `ffi/<lang>/`. The reference implementation is Markdown; see
+  [`development/ADDING_A_LANGUAGE.md`](development/ADDING_A_LANGUAGE.md).
+- **Adding an editor frontend** — implement an adapter in
+  [`adapters/editor-adapter/`](../adapters/editor-adapter/) against the
+  `ViewPatch`/`UserIntent` protocol. CM6, ProseMirror, and HTML adapters
+  already exist.
+- **Adding a representation** — the `Printable` family
+  ([`docs/architecture/multi-representation-system.md`](architecture/multi-representation-system.md))
+  describes how new text formats (`Show`, `Source`, `Pretty`) are added per
+  language.
+
+## Known limitations
+
+- **WebAssembly is not a supported build target.** Build and CI only cover
+  JavaScript and native. See `docs/TODO.md` §1.
+- **The JS FFI surface is unstable.** `ffi/{lambda,json,markdown}` together
+  export roughly a hundred functions; the wire-format contract lives in
+  [`protocol/`](../protocol/) and
+  [`adapters/editor-adapter/`](../adapters/editor-adapter/), not in the raw FFI
+  layer. Where possible, frontends should consume the editor through the
+  adapter.
+- **WebSocket recovery is incomplete.** Malformed or incompatible CRDT ops can
+  diverge peers silently; recovery is tracked in
+  `docs/plans/2026-03-29-sync-recovery-followup.md`.
+
+## Non-goals
+
+Inferred from the absence of supporting code and from `docs/TODO.md`:
+
+- The framework is not a general-purpose IDE — there is no language-server
+  protocol, debugger, or workspace concept.
+- The CRDT engine is not optimised for documents with hundreds of thousands of
+  operations without lazy loading (see TODO §5).
+- The projection layer does not implement collaborative cursor *prediction* —
+  ephemeral cursors are broadcast as-is.
+
+## Where to read next
+
+- [`docs/architecture/ARCHITECTURE_DIAGRAM.md`](architecture/ARCHITECTURE_DIAGRAM.md)
+  — pipeline diagram.
+- [`docs/architecture/Incremental-Hylomorphism.md`](architecture/Incremental-Hylomorphism.md)
+  — the compositional engine underneath.
+- [`docs/architecture/multi-representation-system.md`](architecture/multi-representation-system.md)
+  — the `Printable` trait family.
+- [`docs/development/ADDING_A_LANGUAGE.md`](development/ADDING_A_LANGUAGE.md)
+  — step-by-step to integrate a new language.
+- [`docs/development/monorepo.md`](development/monorepo.md) — submodule daily
+  workflow.

--- a/docs/archive/2026-03-21-ci-cd-setup-snapshot.md
+++ b/docs/archive/2026-03-21-ci-cd-setup-snapshot.md
@@ -1,10 +1,12 @@
-# CI/CD Setup Status
+# CI/CD Setup Status (archived 2026-05-15)
 
-> **Historical audit snapshot (2026-03-21).** For the living CI/CD guide, see
-> **[docs/CI_CD.md](docs/CI_CD.md)**. This file is preserved as a record of
-> what the 2026-03-21 automation audit produced and what follow-up cleanup
-> landed immediately afterward; newer infrastructure changes are not tracked
-> here.
+> **Historical audit snapshot (2026-03-21).** Originally lived at
+> `CI_CD_SETUP.md` at the repository root and was moved here to clear the way
+> for the rewritten living guide at [`docs/CI_CD.md`](../CI_CD.md).
+>
+> This file is preserved as a record of what the 2026-03-21 automation audit
+> produced and the follow-up cleanup landed immediately afterward. Newer
+> infrastructure changes are not tracked here.
 
 This document summarizes the CI/CD infrastructure for the Canopy project as of the 2026-03-21 automation audit, and the follow-up cleanup completed immediately afterward.
 

--- a/docs/archive/PROJECTIONAL_EDITING.md
+++ b/docs/archive/PROJECTIONAL_EDITING.md
@@ -1,4 +1,12 @@
-# Projectional Editing Architecture Plan
+# Projectional Editing Architecture Plan (archived)
+
+> **Archived 2026-05-15.** This document was moved from
+> `docs/architecture/PROJECTIONAL_EDITING.md` because parts of its concrete
+> design (the `CanonicalModel` struct, `apply_edit_to_proj` API, and §2.3 CST
+> struct definitions) no longer match the code. The theoretical Part 1
+> remains useful but should be read as background, not as a specification of
+> the live system. For current architecture, see
+> [`docs/architecture.md`](../architecture.md).
 
 ## Executive Summary
 

--- a/docs/design/01-edit-bridge.md
+++ b/docs/design/01-edit-bridge.md
@@ -115,8 +115,8 @@ TextDoc.insert_with_op()
 | File | Package | Content |
 |------|---------|---------|
 | `loom/loom/src/core/delta.mbt` | `dowdiness/loom/core` | Existing `TextDelta`, `to_edits`, `text_to_delta` |
-| `editor/edit_bridge.mbt` | `dowdiness/canopy/editor` | `merge_to_edits()` (implemented) |
-| `editor/edit_bridge_test.mbt` | `dowdiness/canopy/editor` | 13 tests: parity between `merge_to_edits` and `compute_edit` |
+| `editor/sync_editor_parser.mbt` | `dowdiness/canopy/editor` | `merge_to_edits()` (implemented; originally drafted as `editor/edit_bridge.mbt`) |
+| `editor/edit_bridge_test.mbt` | `dowdiness/canopy/editor` | parity tests between `merge_to_edits` and `compute_edit` |
 | `editor/text_diff.mbt` | `dowdiness/canopy/editor` | `compute_edit()` — kept as reference baseline |
 
 ---

--- a/docs/development/monorepo.md
+++ b/docs/development/monorepo.md
@@ -157,6 +157,7 @@ cd graphviz  && moon test
 cd rle       && moon test
 cd order-tree && moon test
 cd alga      && moon test
+cd valtio    && moon test
 ```
 
 Non-workspace in-tree modules:

--- a/docs/development/monorepo.md
+++ b/docs/development/monorepo.md
@@ -1,261 +1,219 @@
 # Monorepo & Git Submodule Guide
 
-This project was restructured from a single `til` repository into a monorepo with git submodules. This guide explains the setup, daily workflows, and common pitfalls.
+Canopy is a monorepo that pulls in eight independent libraries via git
+submodules. The MoonBit module at the repo root (`dowdiness/canopy`) depends on
+several of those submodules through path dependencies in `moon.mod.json`.
 
-## Background
-
-Previously, all code lived in a single `dowdiness/til` repository. The restructuring extracted reusable libraries into independent repositories and links them back via git submodules:
+## Layout
 
 ```
-crdt/                           ← monorepo (dowdiness/canopy)
-├── event-graph-walker/         ← submodule (dowdiness/event-graph-walker)
-├── loom/                       ← submodule (dowdiness/loom)
-├── svg-dsl/                    ← submodule (dowdiness/svg-dsl)
-├── graphviz/                   ← submodule (dowdiness/graphviz)
-├── valtio/                     ← submodule (dowdiness/valtio)
-├── editor/                     ← monorepo package
-├── projection/                 ← monorepo package
-├── cmd/                        ← monorepo package
-├── examples/web/               ← monorepo (web frontend)
-└── examples/demo-react/        ← monorepo (React demo)
+canopy/                          dowdiness/canopy (root MoonBit module)
+├── core/  editor/  protocol/    monorepo packages (see docs/architecture.md)
+├── projection/  relay/  ffi/
+├── lang/{lambda,json,markdown}/
+├── llm/  echo/  cmd/main/       monorepo packages
+├── lib/btree/                   workspace member, in-tree library
+├── lib/moji/                    workspace member, in-tree library
+├── lib/zipper/                  workspace member, in-tree library
+├── lib/text-change/             workspace member, in-tree library
+├── lib/semantic/                in-tree library (NOT a workspace member)
+├── adapters/editor-adapter/     in-tree TypeScript adapter package
+├── examples/                    in-tree example apps (web, ideal, …)
+│
+├── event-graph-walker/          submodule (CRDT engine)
+├── loom/                        submodule (parser framework, seam, incr, …)
+├── rle/                         submodule
+├── order-tree/                  submodule
+├── graphviz/                    submodule
+├── svg-dsl/                     submodule
+├── valtio/                      submodule
+└── alga/                        submodule
 ```
 
-The root MoonBit module (`dowdiness/canopy`) depends on submodules via path dependencies in `moon.mod.json`:
+## Workspace members
 
-```json
-{
-  "deps": {
-    "dowdiness/event-graph-walker": { "path": "./event-graph-walker" },
-    "dowdiness/lambda": { "path": "./loom/examples/lambda" },
-    "dowdiness/loom": { "path": "./loom/loom" }
-  }
-}
+`moon.work` lists the modules that root commands operate on:
+
+```
+.                  (the canopy module)
+./lib/text-change
+./lib/zipper
+./lib/btree
+./lib/moji
 ```
 
-## Initial Setup
+`moon test`, `moon check`, `moon fmt`, etc. at the repo root run against all
+five. Everything else (submodules, `lib/semantic`, `examples/*`) is a separate
+MoonBit module and needs its own `moon` invocation.
 
-Clone with `--recursive` to fetch all submodules:
+## Path dependencies
 
-```bash
+The root `moon.mod.json` references 14 path-based dependencies. The current
+list is in `moon.mod.json`; below is a summary of where each lives:
+
+| Dependency | Path |
+|------------|------|
+| `dowdiness/event-graph-walker` | `./event-graph-walker` (submodule) |
+| `dowdiness/loom` | `./loom/loom` (submodule) |
+| `dowdiness/seam` | `./loom/seam` (submodule) |
+| `dowdiness/incr` | `./loom/incr` (submodule) |
+| `dowdiness/pretty` | `./loom/pretty` (submodule) |
+| `dowdiness/egglog` | `./loom/egglog` (submodule) |
+| `dowdiness/egraph` | `./loom/egraph` (submodule) |
+| `dowdiness/lambda` | `./loom/examples/lambda` (submodule example module) |
+| `dowdiness/json` | `./loom/examples/json` (submodule example module) |
+| `dowdiness/markdown` | `./loom/examples/markdown` (submodule example module) |
+| `dowdiness/order-tree` | `./order-tree` (submodule) |
+| `dowdiness/text_change` | `./lib/text-change` (in-tree workspace member) |
+| `dowdiness/zipper` | `./lib/zipper` (in-tree workspace member) |
+| `dowdiness/moji` | `./lib/moji` (in-tree workspace member) |
+
+`svg-dsl`, `graphviz`, `valtio`, and `alga` submodules are *not* root path
+dependencies — they are consumed by frontends or by other submodules.
+
+## Setup
+
+```sh
 git clone --recursive https://github.com/dowdiness/canopy.git
 ```
 
-If you already cloned without `--recursive`:
+If the clone already exists without submodules:
 
-```bash
+```sh
 git submodule update --init --recursive
 ```
 
-## Daily Cheat Sheet
+## Daily workflow
 
-### Edit a submodule
+### Working on a monorepo package
 
-```bash
-cd event-graph-walker
-git checkout main            # or your feature branch
+No submodule awareness required:
 
-# make changes
+```sh
 moon check
 moon test
+```
 
+### Editing a submodule
+
+Each submodule is its own repository. Changes inside a submodule are committed
+to *that* repo; the parent repo records the new submodule commit hash. You
+always make two commits.
+
+```sh
+cd event-graph-walker
+git checkout main                  # avoid editing on detached HEAD
+# … edit, moon check, moon test …
 git add -A
-git commit -m "feat: ..."
-git push origin main
+git commit -m "feat: …"
+git push origin main               # always via PR if the submodule has one
 
 cd ..
-git add event-graph-walker
+git add event-graph-walker          # records the new commit pointer
 git commit -m "chore: update event-graph-walker submodule"
 ```
 
-### Sync after pulling the monorepo
+Always push the submodule's commit to its remote **before** pushing the parent
+or opening a parent PR. CI clones with `submodules: recursive`, so a parent
+commit referencing a submodule SHA that is not yet on `origin` will fail.
 
-```bash
+### Pulling
+
+```sh
 git pull
 git submodule update --init --recursive
 ```
 
-### Advance a submodule to latest upstream
+To pull the latest submodule tips even when the parent has not advanced its
+pointers:
 
-```bash
-git submodule update --remote event-graph-walker
-
-# then test what depends on it
-cd event-graph-walker && moon test && cd ..
-moon test
-
-git add event-graph-walker
-git commit -m "chore: update event-graph-walker submodule"
-```
-
-### Inspect submodule changes
-
-```bash
-git status                   # monorepo root: pointer changes only
-cd event-graph-walker
-git status                   # submodule: actual file changes
-```
-
-### Daily rule
-
-- Always make two commits: one inside the submodule, one in the root repo.
-- If you change `event-graph-walker`, run its tests and root `moon test`.
-- If you change `loom`, run `cd loom/loom && moon test` and any affected root tests.
-
-## Daily Workflow
-
-### Working on monorepo packages (editor/, projection/, cmd/, examples/web/)
-
-No submodule awareness needed. Work as normal:
-
-```bash
-# edit files in editor/, projection/, etc.
-moon check
-moon test
-```
-
-### Working inside a submodule (e.g. event-graph-walker/)
-
-Each submodule is its own git repository. Changes inside a submodule are committed to that submodule's repo, not to the parent monorepo.
-
-```bash
-cd event-graph-walker
-
-# make changes
-moon check
-moon test
-
-# commit inside the submodule
-git add -A
-git commit -m "feat: add new feature"
-git push origin main
-
-# go back to monorepo root
-cd ..
-
-# the monorepo now sees the submodule pointer has changed
-git status
-# modified:   event-graph-walker (new commits)
-
-# update the monorepo to point to the new submodule commit
-git add event-graph-walker
-git commit -m "chore: update event-graph-walker submodule"
-```
-
-**Key point:** You always make two commits — one inside the submodule, one in the monorepo to update the pointer.
-
-### Pulling latest changes
-
-```bash
-# pull monorepo changes
-git pull
-
-# update submodules to match what the monorepo expects
-git submodule update --init --recursive
-```
-
-To pull the latest from all submodule remotes (even if the monorepo hasn't updated its pointers yet):
-
-```bash
+```sh
 git submodule update --remote
 ```
 
-### Running tests across the monorepo
+### Running tests across the tree
 
-Each MoonBit module has its own test suite. Run them separately:
+Workspace root:
 
-```bash
-# root module (crdt)
+```sh
 moon test
-
-# submodule: event-graph-walker
-cd event-graph-walker && moon test && cd ..
-
-# submodule: loom (parser framework + lambda example)
-cd loom/loom && moon test && cd ../..
-cd loom/examples/lambda && moon test && cd ../..
 ```
 
-## Submodule Reference
+Each submodule:
 
-| Directory | Repository | Role | Has MoonBit module? |
-|---|---|---|---|
-| `event-graph-walker/` | [dowdiness/event-graph-walker](https://github.com/dowdiness/event-graph-walker) | Core CRDT library | Yes |
-| `loom/` | [dowdiness/loom](https://github.com/dowdiness/loom) | Incremental parser framework | Yes |
-| `svg-dsl/` | [dowdiness/svg-dsl](https://github.com/dowdiness/svg-dsl) | SVG DSL | Yes |
-| `graphviz/` | [dowdiness/graphviz](https://github.com/dowdiness/graphviz) | Graphviz renderer | Yes |
-| `valtio/` | [dowdiness/valtio](https://github.com/dowdiness/valtio) | Valtio state management | Yes |
-
-Only `event-graph-walker`, `dowdiness/lambda`, and `dowdiness/loom` are path dependencies of the root MoonBit module. The others (`svg-dsl`, `graphviz`, `valtio`) are independent modules used by the web frontend.
-
-## Common Pitfalls
-
-### Detached HEAD inside a submodule
-
-When you `git submodule update`, the submodule is checked out at a specific commit (detached HEAD). If you want to make changes:
-
-```bash
-cd event-graph-walker
-git checkout main     # switch to a branch first
-# now make changes and commit
+```sh
+cd event-graph-walker && moon test
+cd loom/loom          && moon test
+cd loom/seam          && moon test
+cd loom/incr          && moon test
+cd loom/pretty        && moon test
+cd loom/egglog        && moon test
+cd loom/egraph        && moon test
+cd loom/examples/lambda   && moon test
+cd loom/examples/json     && moon test
+cd loom/examples/markdown && moon test
+cd svg-dsl   && moon test
+cd graphviz  && moon test
+cd rle       && moon test
+cd order-tree && moon test
+cd alga      && moon test
 ```
 
-### Forgetting to update the submodule pointer
+Non-workspace in-tree modules:
 
-If you commit and push changes inside a submodule but forget to update the monorepo pointer, other collaborators will still see the old version. Always remember the second commit:
-
-```bash
-cd ..
-git add event-graph-walker
-git commit -m "chore: update event-graph-walker submodule"
+```sh
+cd lib/semantic       && moon test
+cd lib/semantic/proof && moon prove   # needs Why3 + z3
+cd examples/ideal        && moon test
+cd examples/block-editor && moon test
+cd examples/canvas       && moon test
 ```
 
-### Stale submodule after pulling
+The canonical fan-out (subset of the above) is in `.github/workflows/ci.yml`.
 
-If `moon check` fails with missing package errors after `git pull`, your submodules are likely out of date:
+## Submodule reference
 
-```bash
-git submodule update --init --recursive
-```
+| Path | Repository | Role |
+|------|------------|------|
+| `event-graph-walker/` | [dowdiness/event-graph-walker](https://github.com/dowdiness/event-graph-walker) | CRDT engine |
+| `loom/` | [dowdiness/loom](https://github.com/dowdiness/loom) | Parser framework, CST library, reactive signals, pretty-printer, egglog/egraph, example languages |
+| `rle/` | [dowdiness/rle](https://github.com/dowdiness/rle) | Run-length encoded sequence |
+| `order-tree/` | [dowdiness/order-tree](https://github.com/dowdiness/order-tree) | Counted/order-statistic tree |
+| `graphviz/` | [dowdiness/graphviz](https://github.com/dowdiness/graphviz) | Graphviz renderer for the inspector |
+| `svg-dsl/` | [dowdiness/svg-dsl](https://github.com/dowdiness/svg-dsl) | SVG DSL |
+| `valtio/` | [dowdiness/valtio](https://github.com/dowdiness/valtio) | JS state management glue |
+| `alga/` | [dowdiness/alga](https://github.com/dowdiness/alga) | Graph algebra |
 
-### Editing the wrong copy
+## Why submodules
 
-Each submodule directory is its own git repo. Running `git status` from the monorepo root will show submodule changes as a single line like `modified: event-graph-walker (new commits)`. To see the actual file changes, `cd` into the submodule and run `git status` there.
+1. **Reusability** — `event-graph-walker`, `loom`, and `rle` are usable from
+   other MoonBit projects without pulling in the editor.
+2. **Independent versioning** — each library releases on its own cadence.
+3. **Focused testing** — each library owns its CI and benchmarks.
+4. **Clear ownership boundaries** — debt routing (below) is enforced by the
+   physical repository layout.
 
-## Dependency Graph
+## Common pitfalls
 
-```
-svg-dsl (independent)
-   ↑
-graphviz (depends on svg-dsl)
+- **Detached HEAD inside a submodule.** `git submodule update` checks out a
+  specific commit. Run `git checkout main` (or a feature branch) before
+  editing.
+- **Forgetting the second commit.** Pushing the submodule but not the parent
+  pointer leaves collaborators seeing the old version.
+- **Stale submodule after `git pull`.** If `moon check` fails with missing
+  packages, run `git submodule update --init --recursive`.
+- **`git status` from the root only shows pointer changes.** Use
+  `cd <submodule> && git status` to see file-level changes.
 
-valtio (independent)
+## Debt routing
 
-event-graph-walker (independent)
+When a problem appears in a root package, do not assume the fix belongs there.
 
-loom (independent: loom/seam/incr/lambda)
-
-crdt (root module)
- ├── depends on event-graph-walker (path dep)
- ├── depends on dowdiness/lambda (path dep)
- └── depends on dowdiness/loom (path dep)
-```
-
-## Why Submodules?
-
-1. **Reusability** — `event-graph-walker` and `loom` can be used by other MoonBit projects without pulling the entire editor
-2. **Independent versioning** — Each library is versioned and released on its own schedule
-3. **Focused testing** — Each library has its own test suite and CI
-4. **Clear boundaries** — Dependencies are explicit in `moon.mod.json`
-5. **Separate issue tracking** — Bugs in the CRDT library are tracked in its own repository
-
-## Debt Routing
-
-When a problem appears in the root `crdt` module, do not assume the fix belongs
-there.
-
-- Missing text-edit primitives belong in `event-graph-walker/`
-- Parser/edit semantics belong in `loom/`
-- Root-module helpers should only exist when multiple root packages need them
-- Standalone submodules should not grow dependencies upward on `crdt/`
+- Missing text-edit primitives belong in `event-graph-walker/`.
+- Parser or edit-semantics belong in `loom/`.
+- Pretty-printer changes belong in `loom/pretty/`.
+- Run-length encoding belongs in `rle/`.
+- Root-module helpers exist only when multiple root packages need them.
+- Submodules never grow upward dependencies on the root.
 
 See [Paying Technical Debt](technical-debt.md) for the full strategy.

--- a/echo/README.md
+++ b/echo/README.md
@@ -1,0 +1,32 @@
+# echo
+
+Experimental similarity engine for short prose. `Corpus` builds a TF-IDF (with bigram + segment features) index over a set of posts and answers `query_similar(post_id, top_n?)` / `query_text(text, top_n?)` queries.
+
+This package is an offline experiment, not part of the editor pipeline. It exists to evaluate "related notes" retrieval for the broader vision in `docs/architecture/product-vision.md`. The integration and realdata tests in this directory report `P@5` / `MRR` scores against fixture corpora.
+
+## Public API
+
+- `Corpus::new(tokenize? : (String) -> Array[String]) -> Corpus`
+- `Corpus::add_post(self, text : String) -> Int` — returns the new post ID
+- `Corpus::get_post_text(self, id) -> String?`
+- `Corpus::query_similar(self, id, top_n?)` — most-similar posts excluding `id`
+- `Corpus::query_text(self, text, top_n?)` — ad-hoc query without adding to the corpus
+
+The `Post` type is exported but opaque.
+
+## Consumers
+
+No production package imports `echo`. The included `*_test.mbt` files exercise its evaluation harness; `echo/cmd/` provides a small driver.
+
+## Dependencies
+
+- `dowdiness/canopy/echo/tokenizer` — segmented bigram tokenizer
+- `moonbitlang/core/math`
+
+## Stability
+
+Experimental. Tracked under "Echo Similarity Library" in project memory ([`project_echo_improvement_paths`](../../docs/TODO.md)) as a research direction. The API may change as we evaluate BM25, BPE, MeCab, etc.
+
+## Notes
+
+The corpus uses sparse vectors (`sparse_vec.mbt`) so memory is O(unique tokens), not O(corpus × vocab). The baseline reported on the bundled benchmark fixtures is P@5 = 0.48 / 0.43 blended across two evaluation sets — see project memory for the full table and improvement roadmap.

--- a/editor/README.md
+++ b/editor/README.md
@@ -1,0 +1,40 @@
+# editor
+
+Language-agnostic CRDT editor engine that combines text storage, undo/redo, reactive parsing, ephemeral presence, WebSocket sync, and view-update diffing into a single `SyncEditor[T]` host.
+
+`SyncEditor[T]` is parameterized on the language's AST type `T`. Language packages (`lang/lambda`, `lang/json`, `lang/markdown`) construct one via `SyncEditor::new_generic`, passing a parser factory and memo builder. The FFI packages then wrap the result and export concrete functions to JavaScript.
+
+## Public API
+
+- `SyncEditor[T]` — core struct holding `TextState`, `UndoManager`, reactive `Parser[T]`, ephemeral hub, and WebSocket state
+- `SyncEditor::new_generic` — generic constructor; language packages call this, not FFI
+- `compute_view_patches` / `compute_pretty_patches` — incremental diff of `ProjNode` tree into `ViewPatch` operations for the frontend
+- `EphemeralHub` — multi-peer cursor and presence state (encode/apply/broadcast)
+- `SyncMessage` / `encode_message` / `decode_message` — binary protocol framing for CRDT ops, sync requests, and room control
+- `ViewUpdateState` — snapshot used to compute minimal `ViewPatch` sequences
+- `LanguageCapabilities[T]` — per-language hooks wired at construction time (text-edit handler, tree-edit handler, pretty-print, etc.)
+
+## Consumers
+
+- `ffi/lambda`, `ffi/json`, `ffi/markdown` — each wraps a `SyncEditor` behind an integer handle and exports JS-callable functions
+- `lang/lambda`, `lang/json` — aggregator packages that re-export `new_lambda_editor` / `new_json_editor`, both of which call `SyncEditor::new_generic`
+- `lang/*/companion` — implement the `LanguageCapabilities` hooks
+- `cmd/main` — the native CLI demo uses the lower-level `Editor` type (not `SyncEditor`)
+
+## Dependencies
+
+- `dowdiness/canopy/core` — `ProjNode`, `SourceMap`, `NodeId`, `GenericTreeOp`
+- `dowdiness/canopy/protocol` — `ViewPatch`, `ViewNode`, `UserIntent`
+- `dowdiness/event-graph-walker/text` + `undo` + `history` — CRDT text state and undo stack
+- `dowdiness/incr` — reactive cell runtime for projection memos
+- `dowdiness/loom` — parser pipeline
+- `dowdiness/text_change` + `dowdiness/moji` — grapheme-aware text diffing
+- `dowdiness/pretty` — layout engine for pretty-view rendering
+
+## Stability
+
+Internal but stable — this is the central package of the monorepo. The `SyncEditor` struct shape and `LanguageCapabilities` interface are touched whenever a new editor feature lands.
+
+## Notes
+
+WebSocket wiring is split into two per-target files (`websocket_js.mbt` / `websocket_native.mbt`). Ephemeral state (peer cursors) is encoded in a compact binary varint format, not JSON. The binary sync protocol uses a versioned framing defined in `sync_protocol.mbt`; `encode_message` / `decode_message` are the only crossing points.

--- a/editor/README.md
+++ b/editor/README.md
@@ -2,7 +2,7 @@
 
 Language-agnostic CRDT editor engine that combines text storage, undo/redo, reactive parsing, ephemeral presence, WebSocket sync, and view-update diffing into a single `SyncEditor[T]` host.
 
-`SyncEditor[T]` is parameterized on the language's AST type `T`. Language packages (`lang/lambda`, `lang/json`, `lang/markdown`) construct one via `SyncEditor::new_generic`, passing a parser factory and memo builder. The FFI packages then wrap the result and export concrete functions to JavaScript.
+`SyncEditor[T]` is parameterized on the language's AST type `T`. Each language's `companion` subpackage (`lang/lambda/companion`, `lang/json/companion`, `lang/markdown/companion`) constructs one via `SyncEditor::new_generic`, passing a parser factory and memo builder. The FFI packages then wrap the result and export concrete functions to JavaScript.
 
 ## Public API
 
@@ -17,8 +17,8 @@ Language-agnostic CRDT editor engine that combines text storage, undo/redo, reac
 ## Consumers
 
 - `ffi/lambda`, `ffi/json`, `ffi/markdown` — each wraps a `SyncEditor` behind an integer handle and exports JS-callable functions
-- `lang/lambda`, `lang/json` — aggregator packages that re-export `new_lambda_editor` / `new_json_editor`, both of which call `SyncEditor::new_generic`
-- `lang/*/companion` — implement the `LanguageCapabilities` hooks
+- `lang/*/companion` — construct `SyncEditor` instances via `new_*_editor` and implement the `LanguageCapabilities` hooks
+- `lang/lambda` — facade that re-exports `new_lambda_editor` and other companion entry points (the `json`/`markdown` facades currently re-export nothing; consumers reach into the subpackages directly)
 - `cmd/main` — the native CLI demo uses the lower-level `Editor` type (not `SyncEditor`)
 
 ## Dependencies

--- a/ffi/json/README.md
+++ b/ffi/json/README.md
@@ -1,0 +1,29 @@
+# ffi/json
+
+JavaScript FFI boundary for the JSON editor. Exports a minimal set of functions keyed by integer handle, analogous to `ffi/lambda` but for the `SyncEditor[@djson.JsonValue]` instance.
+
+This package contains no logic — it delegates entirely to `editor`, `lang/json`, and their subpackages.
+
+## Public API
+
+- `create_json_editor(source) -> Int` / `destroy_json_editor(handle)`
+- `json_get_text(handle)` / `json_set_text(handle, text)`
+- `json_apply_edit(handle, op_json, cursor) -> String` — apply a structural edit op and return a diff patch JSON
+- `json_get_view_tree_json(handle)` / `json_compute_view_patches_json(handle)`
+- `json_get_proj_node_json(handle)` / `json_get_source_map_json(handle)` / `json_get_errors(handle)`
+- `parse_json_edit_op(json)` — helper also used in tests
+
+## Consumers
+
+No other MoonBit package imports `ffi/json`. Consumed by `examples/web/json.html` and associated TypeScript.
+
+## Dependencies
+
+- `dowdiness/canopy/editor`
+- `dowdiness/canopy/core`
+- `dowdiness/canopy/lang/json/edits` + `lang/json/companion`
+- `dowdiness/json` — JSON value type
+
+## Stability
+
+Unstable — route through `ffi/json`. Exported function list tracks JSON editor feature development.

--- a/ffi/lambda/README.md
+++ b/ffi/lambda/README.md
@@ -1,0 +1,44 @@
+# ffi/lambda
+
+JavaScript FFI boundary for the lambda editor. Exports every function that the TypeScript frontend calls, each identified by an integer handle representing one `SyncEditor[@ast.Term]` instance.
+
+This package contains no logic of its own — it translates between JS-safe types (integers, strings, `Bytes`) and the typed MoonBit API in `editor`, `lang/lambda`, `relay`, and `llm`.
+
+## Public API
+
+All symbols in this package are flat free functions exported via the link block. Highlights:
+
+- `create_editor(source) -> Int` / `destroy_editor(handle)` — editor lifecycle
+- `get_text(handle)` / `set_text(handle, text)` — raw text access
+- `handle_text_intent(handle, from, to, insert, cursor)` — primary edit entry point
+- `apply_sync_json(handle, json)` — apply remote CRDT ops (JSON-encoded)
+- `relay_on_connect/message/disconnect` — server-side relay forwarding
+- `undo_manager_undo/redo/can_undo/can_redo` — undo stack management
+- `ws_on_open/message/close/broadcast_edit/broadcast_cursor` — WebSocket lifecycle
+- `ephemeral_encode_all/apply/set_presence/get_peer_cursors_json` — presence and cursor sync
+- `canopy_llm_fix_typos/edit` — async Gemini-backed text actions (returns `Promise[String]`)
+
+## Consumers
+
+No other MoonBit package imports `ffi/lambda`. It is the terminal layer consumed by the TypeScript/Vite web bundle at `examples/web/`.
+
+## Dependencies
+
+- `dowdiness/canopy/editor` — `SyncEditor`, `JsWebSocket`, wire protocol
+- `dowdiness/canopy/lang/lambda` — `new_lambda_editor`, `apply_lambda_tree_edit`, etc.
+- `dowdiness/canopy/relay` — `RelayRoom` operations
+- `dowdiness/canopy/llm` — `fix_typos`, `edit_text`
+- `dowdiness/lambda/ast` — `Term` AST type
+- `dowdiness/lambda/typecheck` — diagnostics surfaced through `get_diagnostics_json`
+- `dowdiness/seam` — concrete `SyntaxNode` used by the editor cells
+- `dowdiness/incr/cells` — reactive runtime that drives the projection memos
+- `dowdiness/event-graph-walker/text` — CRDT text substrate
+- `moonbitlang/async/js_async` — JS async runtime for the LLM entry points
+
+## Stability
+
+Unstable — route through `ffi/lambda`. The exported function list changes whenever the editor gains new features. The JS import site (`examples/web/`) must be updated in lockstep.
+
+## Notes
+
+Each editor instance lives in a process-local registry keyed by `Int`. The registry is global and unbounded — `destroy_editor` must be called to prevent leaks. LLM functions return `Promise[String]` and require the JS async runtime (`js_async`).

--- a/ffi/lambda/README.md
+++ b/ffi/lambda/README.md
@@ -20,7 +20,8 @@ All symbols in this package are flat free functions exported via the link block.
 
 ## Consumers
 
-No other MoonBit package imports `ffi/lambda`. It is the terminal layer consumed by the TypeScript/Vite web bundle at `examples/web/`.
+- `examples/web/` — TypeScript/Vite web bundle; the primary consumer, calls every JS export
+- `examples/ideal/main/` — separate MoonBit module that imports this package as `@ffi` to construct and recover the singleton editor handle
 
 ## Dependencies
 

--- a/ffi/markdown/README.md
+++ b/ffi/markdown/README.md
@@ -1,0 +1,28 @@
+# ffi/markdown
+
+JavaScript FFI boundary for the Markdown block editor. Exports a small set of functions keyed by integer handle for a `SyncEditor` instance configured for Markdown.
+
+This package contains no logic — it delegates entirely to `editor`, `lang/markdown/edits`, and `lang/markdown/companion`.
+
+## Public API
+
+- `create_markdown_editor(source) -> Int` / `destroy_markdown_editor(handle)`
+- `markdown_get_text(handle)` / `markdown_set_text(handle, text)`
+- `markdown_export_text(handle) -> String` — export canonical Markdown (may differ from raw source)
+- `markdown_apply_edit(handle, op_json, cursor, ...) -> String` — apply a structural edit and return patch JSON
+- `markdown_compute_view_patches_json(handle) -> String`
+
+## Consumers
+
+No other MoonBit package imports `ffi/markdown`. Consumed by the Markdown block editor frontend in `examples/block-editor/`.
+
+## Dependencies
+
+- `dowdiness/canopy/editor`
+- `dowdiness/canopy/core`
+- `dowdiness/canopy/lang/markdown/edits` + `lang/markdown/companion`
+- `dowdiness/markdown` — Markdown AST type
+
+## Stability
+
+Unstable — route through `ffi/markdown`. The Markdown editor is the most actively developed editor and the exported surface changes frequently.

--- a/lang/json/README.md
+++ b/lang/json/README.md
@@ -1,0 +1,27 @@
+# lang/json
+
+Empty facade. Originally re-exported the public surface of `lang/json/proj`, `lang/json/edits`, and `lang/json/companion`, but no consumer ever imported `dowdiness/canopy/lang/json` — `ffi/json/` reaches into the subpackages directly. The facade was trimmed to nothing in 2026-05.
+
+## Public API
+
+None. The package compiles but exports no symbols.
+
+## Consumers
+
+None.
+
+## Where the real API lives
+
+- `lang/json/proj/` — projection from JSON AST to `ProjNode`
+- `lang/json/edits/` — `JsonEditOp` and edit application
+- `lang/json/companion/` — `new_json_editor` constructor
+
+Import these subpackages directly from any new consumer.
+
+## Stability
+
+Reserved as a future aggregator. If a new consumer wants a single import point for the JSON editor, re-add `pub using @json_proj { … }`, `pub using @json_edits { … }`, etc. blocks to `top.mbt` (and the matching imports to `moon.pkg`). Until then this is a placeholder.
+
+## Notes
+
+`ffi/json` does not import this facade. The decision to import subpackages directly avoids re-export churn whenever the JSON subpackages add or rename functions.

--- a/lang/json/moon.pkg
+++ b/lang/json/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "dowdiness/canopy/lang/json/proj" @json_proj,
-  "dowdiness/canopy/lang/json/edits" @json_edits,
-  "dowdiness/canopy/lang/json/companion" @json_companion,
-}
+

--- a/lang/json/pkg.generated.mbti
+++ b/lang/json/pkg.generated.mbti
@@ -1,38 +1,13 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "dowdiness/canopy/lang/json"
 
-import {
-  "dowdiness/canopy/editor",
-  "dowdiness/canopy/lang/json/edits",
-  "dowdiness/incr/cells",
-  "dowdiness/loom/pipeline",
-  "dowdiness/seam",
-  "moonbitlang/core/ref",
-}
-
 // Values
-pub fn apply_json_edit(@editor.SyncEditor[@dowdiness/json.JsonValue], @edits.JsonEditOp, Int) -> Result[Unit, String]
-
-pub fn build_json_projection_memos(@pipeline.Parser[@dowdiness/json.JsonValue]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
-
-pub fn compute_json_edit(@edits.JsonEditOp, String, @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue], @dowdiness/canopy/core.SourceMap) -> Result[(Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint)?, String]
-
-pub fn new_json_editor(String, capture_timeout_ms? : Int) -> @editor.SyncEditor[@dowdiness/json.JsonValue]
-
-pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue], Array[String]) raise @dowdiness/loom/core.LexError
-
-pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]) -> Unit
-
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@dowdiness/json.JsonValue]
 
 // Errors
 
 // Types and methods
 
 // Type aliases
-pub using @edits {type JsonEditOp}
-
-pub using @edits {type JsonType}
 
 // Traits
 

--- a/lang/json/top.mbt
+++ b/lang/json/top.mbt
@@ -1,15 +1,7 @@
-// JSON language facade — unified entry point for JSON editor types.
-
-///|
-pub using @json_proj {
-  parse_to_proj_node,
-  syntax_to_proj_node,
-  populate_token_spans,
-  build_json_projection_memos,
-}
-
-///|
-pub using @json_edits {type JsonEditOp, type JsonType, compute_json_edit}
-
-///|
-pub using @json_companion {apply_json_edit, new_json_editor}
+// JSON language facade — placeholder.
+//
+// The previous version re-exported the proj/edits/companion subpackages, but
+// nothing in the repository imported `dowdiness/canopy/lang/json` — ffi/json
+// imports the subpackages directly. The facade has been trimmed to nothing.
+// Re-add `pub using @json_proj { … }` (etc.) here if a new consumer wants a
+// unified import path.

--- a/lang/lambda/README.md
+++ b/lang/lambda/README.md
@@ -1,6 +1,6 @@
 # lang/lambda
 
-Thin facade for the lambda-calculus editor language. Re-exports the handful of types and functions that consumers (`editor/` tests and `ffi/lambda/`) actually call through this path, sourced from the five subpackages `proj`, `edits`, `eval`, `flat`, `companion`.
+Thin facade for the lambda-calculus editor language. Re-exports the handful of types and functions that consumers (`editor/` tests and `ffi/lambda/`) actually call through this path, sourced from the three currently-imported subpackages `edits`, `eval`, and `companion`. The other lambda subpackages (`proj`, `flat`) are not re-exported here — consumers that need them import the subpackage directly.
 
 The facade was originally much larger; in 2026-05 it was trimmed to the symbols with live callers. Consumers that need more reach into the subpackages directly (see `examples/ideal/main/moon.pkg`).
 

--- a/lang/lambda/README.md
+++ b/lang/lambda/README.md
@@ -1,0 +1,39 @@
+# lang/lambda
+
+Thin facade for the lambda-calculus editor language. Re-exports the handful of types and functions that consumers (`editor/` tests and `ffi/lambda/`) actually call through this path, sourced from the five subpackages `proj`, `edits`, `eval`, `flat`, `companion`.
+
+The facade was originally much larger; in 2026-05 it was trimmed to the symbols with live callers. Consumers that need more reach into the subpackages directly (see `examples/ideal/main/moon.pkg`).
+
+## Public API
+
+Re-exported from `lang/lambda/edits`:
+- type `TreeEditOp`
+- type `DropPosition` (canonical origin is `@core`; `lang/lambda/edits` re-re-exports it, so consumers see it through either path)
+
+Re-exported from `lang/lambda/companion`:
+- type `LambdaCompanion`
+- `new_lambda_editor(source) -> (SyncEditor[Term], LambdaCompanion)`
+- `apply_lambda_tree_edit(editor, companion, op, cursor)`
+- `get_lambda_ast`, `get_lambda_ast_pretty`, `get_lambda_resolution`, `get_lambda_dot_resolved`
+- `parse_tree_edit_op`
+
+Re-exported from `lang/lambda/eval`:
+- type `EvalResult`
+
+## Consumers
+
+- `ffi/lambda/` — JS FFI surface; calls `new_lambda_editor`, `apply_lambda_tree_edit`, `parse_tree_edit_op`, and the AST/pretty accessors.
+- `editor/` (blackbox tests only) — uses `@lambda.get_lambda_ast` and related accessors to drive integration tests.
+- `examples/ideal/main/` — additionally uses `LambdaCompanion`, `EvalResult`, `DropPosition`, `TreeEditOp`; imports `lang/lambda/edits` directly for the rest.
+
+## Dependencies
+
+`lang/lambda/edits`, `lang/lambda/eval`, `lang/lambda/companion`. The `proj` and `flat` subpackages exist but are not re-exported here; consumers that need them (none today) should import them directly.
+
+## Stability
+
+Experimental — the lambda language is the reference implementation for new editor features. The facade surface evolves as features are wired up; expect re-exports to be added as new consumers appear.
+
+## Notes
+
+There is no top-level logic in this package. Earlier revisions included a `reconcile_ast.mbt` file re-exporting `@core.reconcile`, which had no callers and was removed. The reference for incremental projection over the lambda AST lives in `lang/lambda/flat` (`VersionedFlatProj`, `build_lambda_projection_memos`); import that subpackage directly if needed.

--- a/lang/lambda/moon.pkg
+++ b/lang/lambda/moon.pkg
@@ -1,8 +1,5 @@
 import {
-  "dowdiness/canopy/core" @core,
-  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
   "dowdiness/canopy/lang/lambda/edits" @lambda_edits,
   "dowdiness/canopy/lang/lambda/eval" @lambda_eval,
-  "dowdiness/canopy/lang/lambda/flat" @lambda_flat,
   "dowdiness/canopy/lang/lambda/companion" @lambda_companion,
 }

--- a/lang/lambda/pkg.generated.mbti
+++ b/lang/lambda/pkg.generated.mbti
@@ -2,41 +2,16 @@
 package "dowdiness/canopy/lang/lambda"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/companion",
   "dowdiness/canopy/lang/lambda/edits",
   "dowdiness/canopy/lang/lambda/eval",
-  "dowdiness/canopy/lang/lambda/flat",
-  "dowdiness/canopy/lang/lambda/proj",
-  "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
-  "dowdiness/loom/pipeline",
-  "dowdiness/pretty",
-  "dowdiness/seam",
-  "moonbitlang/core/immut/hashset",
-  "moonbitlang/core/ref",
 }
 
 // Values
 pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Unit, @editor.TreeEditError]
-
-pub fn build_eval_memo(@pipeline.Parser[@ast.Term]) -> @cells.Memo[Array[@eval.EvalResult]]
-
-pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term]) -> (@cells.Memo[@flat.VersionedFlatProj], @cells.Memo[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Memo[@dowdiness/canopy/core.SourceMap])
-
-pub fn collect_lam_env(@dowdiness/canopy/core.NodeId, Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]) -> @hashset.HashSet[String]
-
-pub fn compute_text_edit(@edits.TreeEditOp, @edits.EditContext[@ast.Term]) -> Result[(Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint)?, String]
-
-pub fn eval_term(@ast.Term) -> Array[@eval.EvalResult]
-
-pub fn find_binding_for_init(@dowdiness/canopy/core.NodeId, @proj.FlatProj) -> (@dowdiness/canopy/core.NodeId, Int)?
-
-pub fn find_usages(String, Int, @proj.FlatProj, Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]) -> Array[@dowdiness/canopy/core.NodeId]
-
-pub fn free_vars(@ast.Term, @hashset.HashSet[String]) -> @hashset.HashSet[String]
-
-pub fn get_actions_for_node(@ast.Term, @edits.NodeContext) -> Array[@edits.Action]
 
 pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term
 
@@ -46,64 +21,22 @@ pub fn get_lambda_dot_resolved(@editor.SyncEditor[@ast.Term]) -> String
 
 pub fn get_lambda_resolution(@editor.SyncEditor[@ast.Term]) -> @dowdiness/lambda.Resolution
 
-pub fn inject_eval_annotations(@pretty.Layout[@pretty.SyntaxCategory], Array[@eval.EvalResult]) -> @pretty.Layout[@pretty.SyntaxCategory]
-
 pub fn new_lambda_editor(String, capture_timeout_ms? : Int) -> (@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion)
 
-pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
-
 pub fn parse_tree_edit_op(Json) -> @edits.TreeEditOp raise @editor.TreeEditError
-
-pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@ast.Term]) -> Unit
-
-pub fn print_flat_proj(@proj.FlatProj) -> String
-
-pub fn rebuild_kind(@ast.Term, Array[@dowdiness/canopy/core.ProjNode[@ast.Term]]) -> @ast.Term
-
-pub fn[T : @dowdiness/loom/core.TreeNode] reconcile(@dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.ProjNode[T], @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[T]
-
-pub fn reconcile_flat_proj(@proj.FlatProj, @proj.FlatProj, @ref.Ref[Int]) -> @proj.FlatProj
-
-pub fn resolve_binder(@dowdiness/canopy/core.NodeId, String, @proj.FlatProj, Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]], @dowdiness/canopy/core.SourceMap) -> @edits.BindingSite?
-
-pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
-
-pub fn to_flat_proj(@seam.SyntaxNode, @ref.Ref[Int]) -> @proj.FlatProj
-
-pub fn to_flat_proj_incremental(@seam.SyntaxNode, @seam.SyntaxNode, @proj.FlatProj, @ref.Ref[Int], changed_indices? : @ref.Ref[Array[Int]]) -> @proj.FlatProj
-
-pub fn to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
 
 // Errors
 
 // Types and methods
 
 // Type aliases
-pub using @edits {type Action}
-
-pub using @edits {type ActionGroup}
-
-pub using @edits {type BindingSite}
-
-pub using @dowdiness/canopy/core {type DropPosition}
-
-pub using @edits {type EditContext}
-
-pub type EditResult = Result[(Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint)?, String]
+pub using @core {type DropPosition}
 
 pub using @eval {type EvalResult}
 
-pub using @proj {type FlatProj}
-
-pub using @dowdiness/canopy/core {type FocusHint}
-
 pub using @companion {type LambdaCompanion}
 
-pub using @edits {type NodeContext}
-
 pub using @edits {type TreeEditOp}
-
-pub using @flat {type VersionedFlatProj}
 
 // Traits
 

--- a/lang/lambda/reconcile_ast.mbt
+++ b/lang/lambda/reconcile_ast.mbt
@@ -1,4 +1,0 @@
-// Re-export generic reconcile from core for lambda consumers.
-
-///|
-pub using @core {reconcile}

--- a/lang/lambda/top.mbt
+++ b/lang/lambda/top.mbt
@@ -1,38 +1,15 @@
 // Lambda language facade — unified entry point for lambda editor types.
+//
+// Only re-exports symbols that are actually consumed today (by editor/,
+// ffi/lambda/, and examples/ideal). The previous version re-exported the full
+// surface of the proj/edits/eval/flat/companion subpackages, but most of
+// those re-exports had no callers — they were vestiges of an earlier wiring.
+// Removed re-exports can be re-added when a new consumer needs them.
+// Consumers that already import a subpackage directly do not need an
+// aggregator re-export.
 
 ///|
-pub using @lambda_proj {
-  type FlatProj,
-  syntax_to_proj_node,
-  to_proj_node,
-  parse_to_proj_node,
-  rebuild_kind,
-  to_flat_proj,
-  to_flat_proj_incremental,
-  reconcile_flat_proj,
-  print_flat_proj,
-  populate_token_spans,
-}
-
-///|
-pub using @lambda_edits {
-  type TreeEditOp,
-  type EditContext,
-  type EditResult,
-  type FocusHint,
-  type DropPosition,
-  type ActionGroup,
-  type Action,
-  type NodeContext,
-  type BindingSite,
-  compute_text_edit,
-  get_actions_for_node,
-  resolve_binder,
-  find_usages,
-  find_binding_for_init,
-  collect_lam_env,
-  free_vars,
-}
+pub using @lambda_edits {type TreeEditOp, type DropPosition}
 
 ///|
 pub using @lambda_companion {
@@ -47,12 +24,4 @@ pub using @lambda_companion {
 }
 
 ///|
-pub using @lambda_flat {type VersionedFlatProj, build_lambda_projection_memos}
-
-///|
-pub using @lambda_eval {
-  type EvalResult,
-  eval_term,
-  build_eval_memo,
-  inject_eval_annotations,
-}
+pub using @lambda_eval {type EvalResult}

--- a/lib/text-change/README.md
+++ b/lib/text-change/README.md
@@ -1,0 +1,27 @@
+# text-change
+
+`compute_text_change(old, new) -> TextChange` — diff two strings into a single half-open splice (`start`, `delete_len`, `inserted`). Grapheme-aware: the diff respects extended grapheme clusters via [`lib/moji`](../moji/), so combining marks, emoji ZWJ sequences, and regional indicators are never split.
+
+This package is the canopy-module equivalent of a "minimal text diff". It is intentionally tiny and has no opinion about how the resulting splice is then applied to a CRDT or buffer.
+
+## Public API
+
+- `TextChange { start : Int, delete_len : Int, inserted : String }` — half-open replacement
+- `TextChange::is_noop(self) -> Bool` — true when both sides are empty
+- `compute_text_change(old : String, new : String) -> TextChange` — the single diff entry point
+
+## Consumers
+
+`editor` (computes edits for tree-edit round-trip and FlatProj splice translation). Used indirectly by every editor host.
+
+## Dependencies
+
+`dowdiness/moji` — UAX #29 grapheme boundaries, for cluster-safe splice alignment.
+
+## Stability
+
+Internal but stable — the `TextChange` shape is consumed by the editor's tree-edit path. Field renames would propagate up through `editor/` and into `protocol/`'s `ViewPatch::TextChange`.
+
+## Notes
+
+The diff is single-splice (one contiguous delete + insert), not Myers-style multi-edit. That keeps it cheap and matches how the editor's downstream consumers expect to apply it. Callers expecting multi-edit diffs should chain multiple `compute_text_change` calls instead.

--- a/lib/zipper/README.md
+++ b/lib/zipper/README.md
@@ -1,0 +1,30 @@
+# zipper
+
+Functional rose-tree zipper. A `RoseZipper[T]` lets you focus on one node of an immutable `RoseNode[T]` tree and move up / down / left / right in O(1) per step, with O(focus depth) reconstruction back to the root.
+
+This is a foundational data structure, used wherever code needs to express navigation and structural mutation over a rose tree without rebuilding the tree from scratch on every edit.
+
+## Public API
+
+- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode::new(data~, children?~)`
+- `RoseZipper[T]` — focused navigation state; build with `RoseZipper::from_root(node)`
+- `go_up`, `go_down(index?)`, `go_left`, `go_right` — return `Self?`, `None` when the move is impossible
+- `focus_at(node, path)` — jump to a position by index path; `to_path(self)` is its inverse
+- `replace(self, new)` / `modify(self, fn)` — produce a new zipper with the focus replaced
+- `to_tree(self)` — rebuild the root tree from the current zipper state
+
+## Consumers
+
+`lib/zipper` is in-tree but is not imported by any package in the canopy module today. It is a workspace member (declared in `moon.work`) and a path dependency in the root `moon.mod.json`, kept available for future projection / structural-edit work.
+
+## Dependencies
+
+`moonbitlang/core/list` and `moonbitlang/core/debug` only — no project-internal dependencies.
+
+## Stability
+
+Internal but stable — the API mirrors the textbook zipper presentation (Huet) and the test suite includes QuickCheck property tests covering navigation laws. Field changes would invalidate downstream consumers once they exist.
+
+## Notes
+
+`RoseCtx[T]` is the path-context type — exposed as `pub(all)` so callers can inspect or construct zippers manually. Whitebox tests under `zipper_properties_wbtest.mbt` assert round-trip identities (`go_down → go_up` is a no-op, etc.).

--- a/llm/README.md
+++ b/llm/README.md
@@ -1,0 +1,31 @@
+# llm
+
+Optional, JS-only client for Google's Gemini API. Exposes `fix_typos` and `edit_text` as `async` MoonBit functions that resolve to an `Array[EditAction]`. The editor calls these from the `canopy_llm_*` exports in `ffi/lambda`.
+
+This package is opt-in. The native target builds it as a stub; the actual fetch implementation lives in `fetch_ffi.mbt` and is gated to the `js` target in `moon.pkg`.
+
+## Public API
+
+- `GeminiConfig { api_key, model, temperature, max_output_tokens }` with a `GeminiConfig::GeminiConfig` constructor (defaults for everything except `api_key`)
+- `EditAction` — `Replace(line~, old~, new~)`, `Insert(line~, text~)`, `Delete(line~)`, `FixTypos(original~, fixed~)`
+- `fix_typos(cfg, text) -> Array[EditAction]` (async, raises `LlmError`)
+- `edit_text(cfg, instructions, text) -> Array[EditAction]` (async, raises `LlmError`)
+- `parse_edit_actions(s : String) -> Array[EditAction]` — pure parser used by both async paths
+- `LlmError(String)` — single-variant error type
+
+## Consumers
+
+`ffi/lambda` (`canopy_llm_fix_typos`, `canopy_llm_edit`). No other package imports `llm`.
+
+## Dependencies
+
+- `moonbitlang/async/js_async` — JS Promise integration
+- `moonbitlang/core/json`, `moonbitlang/core/debug`
+
+## Stability
+
+**Unstable — route through `ffi/lambda`.** The prompt shapes and `EditAction` variants are tuned against Gemini's current response format. Swapping providers or model versions may force a breaking change in `EditAction`.
+
+## Notes
+
+`fetch_ffi.mbt` is the only file restricted to the `js` target (`options.targets` in `moon.pkg`); the rest of the package is target-agnostic so MoonBit doc and type-checking still run on native. Whitebox tests in `*_wbtest.mbt` cover the prompt builder and response parser without hitting the network.

--- a/projection/README.md
+++ b/projection/README.md
@@ -1,0 +1,32 @@
+# projection
+
+Interactive tree-editor UI state for projectional editing — selection, inline editing, drag-and-drop, and node collapse — maintained as a pure value (`TreeEditorState[T]`) that is updated by applying `GenericTreeOp` events.
+
+This package bridges the gap between the raw `ProjNode` tree (from `core`) and what the frontend tree-editor widget needs to render. It is language-agnostic: any `T` satisfying `TreeNode + Renderable` can be hosted here.
+
+## Public API
+
+- `TreeEditorState[T]` — full UI state snapshot: current tree, selection set, editing node, drag-over target, collapsed nodes
+- `TreeEditorState::from_projection` — build initial state from a `ProjNode` tree
+- `TreeEditorState::refresh` — incremental update when the underlying `ProjNode` changes
+- `TreeEditorState::apply_edit` — apply a `GenericTreeOp` and return the new state (pure)
+- `InteractiveTreeNode[T]` — view-model node annotated with `selected`, `editing`, `collapsed`, `drop_target`
+- `InteractiveChildren[T]` — either `Loaded(children)` or `Elided(count)` for virtual scrolling
+
+## Consumers
+
+- Root `moon.pkg` (canopy module facade) — the only direct in-module importer found
+- `lang/lambda/companion` (`lang/lambda/companion/moon.pkg`) implicitly uses these types through the `editor` package
+
+## Dependencies
+
+- `dowdiness/canopy/core` — `ProjNode`, `SourceMap`, `NodeId`, `GenericTreeOp`, `DropPosition`
+- `dowdiness/loom/core` — `TreeNode`, `Renderable`, `Range`
+
+## Stability
+
+Internal but stable — the `TreeEditorState` shape is touched when new structural editing features are added (e.g. multi-select, new collapse modes).
+
+## Notes
+
+`TreeEditorState` is a pure value — every operation returns a new state rather than mutating in place. This makes it safe to snapshot and compare across reactive refresh cycles.

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -1,0 +1,35 @@
+# protocol
+
+Data types that cross the MoonBit-to-JavaScript boundary: the view tree, diff patches, user intents, and diagnostics. Everything defined here is serializable to JSON and has no dependency on the CRDT internals.
+
+This package is the stable contract between the MoonBit engine and the TypeScript/React frontend. It also contains the two conversion functions that build a `ViewNode` tree from a `ProjNode` tree or a pretty-printer `Layout`.
+
+## Public API
+
+- `ViewNode` — tree node sent to the frontend; carries `id`, `kind_tag`, `label`, `text`, `text_range`, `token_spans`, and `children`
+- `ViewPatch` — incremental update: `TextChange`, `ReplaceNode`, `InsertChild`, `RemoveChild`, `UpdateNode`, `SetDecorations`, `SetDiagnostics`, `SetSelection`, `SelectNode`, `FullTree`
+- `UserIntent` — frontend-originated action: `TextEdit`, `StructuralEdit`, `SelectNode`, `SetCursor`, `Undo`, `Redo`, `CommitEdit`
+- `Decoration` / `Diagnostic` / `Severity` — CodeMirror decoration and lint annotations
+- `proj_to_view_node` — converts a `ProjNode[T]` + `SourceMap` into a `ViewNode`
+- `layout_to_view_tree` — converts a pretty-printer `Layout` into a `ViewNode` tree
+
+## Consumers
+
+- `editor` — produces `ViewPatch` sequences via `compute_view_patches` and `compute_pretty_patches`
+- `lang/lambda/companion` — passes `ViewAnnotation` arrays into `proj_to_view_node`
+- `ffi/lambda`, `ffi/json`, `ffi/markdown` — serialize `ViewPatch` / `ViewNode` to JSON for JavaScript
+- Root `moon.pkg` (canopy module facade)
+
+## Dependencies
+
+- `dowdiness/canopy/core` — `NodeId`, `ProjNode`, `SourceMap`
+- `dowdiness/pretty` — `Layout`, `SyntaxCategory`
+- `moonbitlang/core/json` — `ToJson` / `FromJson` derivations
+
+## Stability
+
+Stable wire format / public surface — changes here break the TypeScript frontend and require coordinated updates to the JS consumer side.
+
+## Notes
+
+`UserIntent` implements both `ToJson` and `FromJson` — it is the one type that flows both directions across the FFI boundary. All other protocol types are output-only (MoonBit → JS).

--- a/protocol/user_intent.mbt
+++ b/protocol/user_intent.mbt
@@ -1,6 +1,13 @@
 // UserIntent: Actions from the UI layer to the editor.
 
 ///|
+/// One user-originated action delivered from the frontend to the editor.
+///
+/// `UserIntent` is the inbound counterpart to [`ViewPatch`](view_patch.mbt):
+/// the frontend sends intents (typing, selection, undo/redo, structural ops)
+/// and the editor responds with patches. The JSON encoding is consumed by
+/// `adapters/editor-adapter` on the TypeScript side; new variants must be
+/// added in both places.
 pub(all) enum UserIntent {
   TextEdit(from~ : Int, to~ : Int, insert~ : String)
   StructuralEdit(

--- a/protocol/view_node.mbt
+++ b/protocol/view_node.mbt
@@ -3,6 +3,9 @@
 // suitable for JSON transport to the UI layer.
 
 ///|
+/// A coloured / labelled slice of a node's text. `role` is a CSS-class-style
+/// tag (e.g. "keyword", "string", "identifier") and `start`/`end` index into
+/// the document text in the same units as `ViewNode.text_range`.
 pub(all) struct TokenSpan {
   role : String
   start : Int
@@ -44,6 +47,20 @@ pub impl ToJson for ViewAnnotation with to_json(self) {
 }
 
 ///|
+/// Language-agnostic view of one projection node, JSON-serialised for the
+/// frontend.
+///
+/// `ViewNode` flattens a `core.ProjNode[T]` plus its slice of the source map
+/// into a uniform representation:
+///
+/// - `id` is the stable `NodeId` used to address the node in patches and
+///   intents; it survives reparses.
+/// - `kind_tag` is the AST variant name (lowercase, used by the frontend as a
+///   discriminator).
+/// - `label` is the short human-readable name shown in tree views.
+/// - `text` is the rendered source for this subtree, when applicable.
+/// - `text_range` is the half-open `[start, end)` range in the source
+///   document the node occupies; consistent with `TokenSpan` offsets.
 pub(all) struct ViewNode {
   id : @core.NodeId
   kind_tag : String

--- a/protocol/view_patch.mbt
+++ b/protocol/view_patch.mbt
@@ -1,6 +1,14 @@
 // ViewPatch: Incremental patches for the editor protocol.
 
 ///|
+/// Visual decoration applied to a half-open text range `[from, to)` in the
+/// editor's source view.
+///
+/// `css_class` is the CSS class the frontend should attach to the range;
+/// `widget` indicates that the decoration replaces the range with an inline
+/// widget rather than overlaying its character cells. `data` is an opaque
+/// string the frontend may use to discriminate between decorations of the
+/// same class (e.g. a kind tag for a hover popover).
 pub(all) struct Decoration {
   from : Int
   to : Int
@@ -21,6 +29,8 @@ pub fn Decoration::Decoration(
 }
 
 ///|
+/// Severity level for a `Diagnostic`. Serialised as the lowercase strings
+/// `"error" | "warning" | "info" | "hint"` for frontend consumers.
 pub(all) enum Severity {
   SevError
   SevWarning
@@ -39,6 +49,8 @@ pub impl ToJson for Severity with to_json(self) {
 }
 
 ///|
+/// A diagnostic message associated with a half-open text range `[from, to)`.
+/// Used to surface compiler/linter findings to the editor frontend.
 pub(all) struct Diagnostic {
   from : Int
   to : Int
@@ -57,6 +69,13 @@ pub fn Diagnostic::Diagnostic(
 }
 
 ///|
+/// Incremental patches emitted by the editor and applied by the frontend.
+///
+/// A patch describes one change to the editor's view. Patches are JSON
+/// serialisable; the canonical mapping is defined by `ToJson for ViewPatch`
+/// below and consumed by `adapters/editor-adapter` on the TypeScript side.
+/// Frontends must treat unknown variants as no-ops so the protocol can be
+/// extended without a breaking change.
 pub(all) enum ViewPatch {
   TextChange(from~ : Int, to~ : Int, insert~ : String)
   ReplaceNode(node_id~ : @core.NodeId, node~ : ViewNode)

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,0 +1,30 @@
+# relay
+
+In-process WebSocket relay for multi-peer CRDT collaboration. A `RelayRoom` holds a set of connected peers and broadcasts messages between them, enforcing membership validity without touching message content.
+
+This package is the server-side half of the real-time sync protocol. It runs inside a Cloudflare Worker (or any native host) as a pure message forwarder — it never parses or interprets CRDT operations.
+
+## Public API
+
+- `RelayRoom` — peer registry with broadcast routing
+- `RelayRoom::on_connect(peer_id, send_fn)` — register a peer; returns `false` if duplicate or empty ID
+- `RelayRoom::on_message(peer_id, bytes)` — forward `bytes` to all other peers; drops messages from unknown senders
+- `RelayRoom::on_disconnect(peer_id)` — deregister a peer and broadcast a `PeerLeft` notification
+- `encode_peer_joined(peer_id)` / `encode_peer_left(peer_id)` — build the binary join/leave notifications sent to all existing peers
+
+## Consumers
+
+- `ffi/lambda` — exports `relay_on_connect`, `relay_on_message`, `relay_on_disconnect` to JavaScript via the link block
+- Root `moon.pkg` (canopy module facade)
+
+## Dependencies
+
+`moonbitlang/core/buffer` only — this package is intentionally dependency-light so it can compile to any target.
+
+## Stability
+
+Internal but stable — the `RelayRoom` API is the server-side counterpart to the sync protocol in `editor/sync_protocol.mbt`. Changes here require matching changes in the client-side WebSocket wiring.
+
+## Notes
+
+Peer IDs are opaque strings, expected to be UUIDs assigned by the hosting environment (e.g. `crypto.randomUUID()` in a CF Worker). `RelayRoom` enforces uniqueness but does not generate IDs. The `ffi/lambda` package exposes a single global relay room shared across all editor instances on one server process.


### PR DESCRIPTION
## Summary

Phase 2 of a documentation audit started from `project_doc_audit_2026_05_15`. Two commits:

1. **`docs: refresh package READMEs and architecture overview`** — realigns docs with current code after several months of drift. New `docs/architecture.md`, 15 per-package READMEs, rewritten `docs/CI_CD.md` (Cloudflare, not Pages) and `docs/development/monorepo.md` (all 8 submodules + 14 path deps), corrected `AGENTS.md`/`README.mbt.md` package lists, archived two stale docs. Adds `///|` doc comments to `protocol/{view_patch,view_node,user_intent}.mbt`.
2. **`refactor: trim unused aggregator re-exports in lang/{lambda,json}`** — `lang/lambda/top.mbt` previously re-exported the full surface of 5 subpackages; most re-exports had no callers because `ffi/lambda` and `examples/ideal` already reach into the subpackages directly. Kept only the symbols with live callers (verified via `moon ide find-references` across `examples/`, `ffi/`, and the editor blackbox tests). `lang/json/top.mbt` was a placeholder with zero consumers — trimmed to an empty facade. Deletes `lang/lambda/reconcile_ast.mbt` (one unused re-export).

No behavior changes — purely docs + dead-code removal.

## Test plan

- [x] `moon check` clean across the workspace
- [x] `moon test` — 932 tests still pass
- [x] `cd examples/ideal && moon check` clean
- [x] `cd examples/canvas && moon check` clean
- [x] `cd examples/block-editor && moon check` clean
- [x] Reviewer agent line-by-line review of the 15 new READMEs against actual code (3 defects flagged and fixed before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)