### PR TITLE
feat(markdown): consolidate ZWSP sentinel into three-layer split

### DIFF
--- a/adapters/editor-adapter/block-input.ts
+++ b/adapters/editor-adapter/block-input.ts
@@ -6,6 +6,24 @@ import type { EditorAdapter } from './adapter';
 import type { ViewNode, ViewPatch, UserIntent } from './types';
 
 // ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface BlockInputOptions {
+  /**
+   * Strip empty-paragraph sentinel codepoints from display/commit text.
+   *
+   * Consumers should pass a function sourced from the MoonBit FFI (e.g.,
+   * `markdown_empty_paragraph_sentinel`) so the sentinel definition lives
+   * in one place across the build graph. If omitted, falls back to a
+   * permissive U+200B strip for backwards compatibility — keep this in
+   * sync with `@moji.ZERO_WIDTH_SPACE` if the sentinel codepoint ever
+   * changes.
+   */
+  stripParagraphSentinels?: (s: string) => string;
+}
+
+// ---------------------------------------------------------------------------
 // BlockInput
 // ---------------------------------------------------------------------------
 
@@ -17,9 +35,16 @@ export class BlockInput implements EditorAdapter {
   private blurBound = false;
   private composing = false;
   private intentCb: ((intent: UserIntent) => void) | null = null;
+  private stripParagraphSentinels: (s: string) => string;
 
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, opts: BlockInputOptions = {}) {
     this.container = container;
+    // Literal U+200B fallback when no FFI-sourced strip function is wired.
+    // Do NOT refactor to a shared constant — keeping this codepoint inline
+    // is the documented backwards-compat path; the canonical source is
+    // `markdown_empty_paragraph_sentinel()` exported by `ffi/markdown/`.
+    this.stripParagraphSentinels =
+      opts.stripParagraphSentinels ?? ((s) => s.replace(/​/g, ''));
     this.container.classList.add('block-editor');
     this.onContainerClick = this.onContainerClick.bind(this);
     this.container.addEventListener('click', this.onContainerClick);
@@ -104,8 +129,8 @@ export class BlockInput implements EditorAdapter {
 
     const textSpan = document.createElement('span');
     textSpan.className = 'block-text';
-    // Strip ZWSP placeholder so empty blocks show as truly empty
-    textSpan.textContent = (node.text ?? '').replace(/\u200B/g, '');
+    // Strip empty-paragraph sentinel so empty blocks show as truly empty
+    textSpan.textContent = this.stripParagraphSentinels(node.text ?? '');
     el.appendChild(textSpan);
 
     el.addEventListener('click', (e) => {
@@ -235,8 +260,8 @@ export class BlockInput implements EditorAdapter {
     if (!node || !div) return;
 
     div.appendChild(ta);
-    // Strip ZWSP placeholder (inserted by InsertBlockAfter for empty blocks)
-    ta.value = (node.text ?? '').replace(/\u200B/g, '');
+    // Strip empty-paragraph sentinel (inserted by InsertBlockAfter for empty blocks)
+    ta.value = this.stripParagraphSentinels(node.text ?? '');
 
     // Match font from the block div
     const style = getComputedStyle(div);
@@ -285,7 +310,7 @@ export class BlockInput implements EditorAdapter {
     this.emit({
       type: 'CommitEdit',
       node_id: this.activeBlockId,
-      value: ta.value.replace(/\u200B/g, ''),
+      value: this.stripParagraphSentinels(ta.value),
     });
 
     // Re-sync text span under the textarea

--- a/examples/web/src/markdown-editor.ts
+++ b/examples/web/src/markdown-editor.ts
@@ -5,6 +5,7 @@ import { BlockInput } from '@canopy/editor-adapter/block-input';
 import { MarkdownPreview } from '@canopy/editor-adapter/markdown-preview';
 import '@canopy/editor-adapter/block-input.css';
 import type { ViewPatch, UserIntent } from '@canopy/editor-adapter/types';
+import { stripParagraphSentinels } from './markdown-sentinels';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -61,7 +62,7 @@ const modeTabs = document.querySelectorAll<HTMLButtonElement>('.mode-tab');
 // Adapters
 // ---------------------------------------------------------------------------
 
-const blockInput = new BlockInput(blockContainer);
+const blockInput = new BlockInput(blockContainer, { stripParagraphSentinels });
 const preview = new MarkdownPreview(previewContainer);
 
 // ---------------------------------------------------------------------------

--- a/examples/web/src/markdown-sentinels.ts
+++ b/examples/web/src/markdown-sentinels.ts
@@ -1,0 +1,21 @@
+// Empty-paragraph sentinel wiring for the markdown editor.
+//
+// Sources the sentinel codepoint from the MoonBit FFI bundle so this file
+// and `lang/markdown/sentinel/` + `lib/moji/codepoints.mbt` agree by
+// construction. The build graph routes:
+//
+//   lib/moji/codepoints.mbt           (canonical const: ZERO_WIDTH_SPACE)
+//     → lang/markdown/sentinel/       (role-name layer: EMPTY_PARAGRAPH_SENTINEL)
+//       → ffi/markdown/markdown_ffi   (JS export: markdown_empty_paragraph_sentinel)
+//         → @moonbit/crdt-markdown    (Vite virtual module)
+//           → this file               (captures the value once)
+//             → BlockInput option     (per-instance strip behavior)
+
+import { markdown_empty_paragraph_sentinel } from '@moonbit/crdt-markdown';
+
+const SENTINEL = markdown_empty_paragraph_sentinel();
+
+/** Strip every occurrence of the empty-paragraph sentinel from a display string. */
+export function stripParagraphSentinels(s: string): string {
+  return s.split(SENTINEL).join('');
+}

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -56,6 +56,16 @@ pub fn markdown_set_text(handle : Int, text : String) -> Unit {
   }
 }
 
+///|
+/// JS-side accessor for the empty-paragraph sentinel codepoint. Returns the
+/// same value as `@md_sentinel.EMPTY_PARAGRAPH_SENTINEL` (which itself
+/// aliases `@moji.ZERO_WIDTH_SPACE`). Exposed as a function so TS consumers
+/// import a single source of truth from the build artifact rather than
+/// hardcoding the literal.
+pub fn markdown_empty_paragraph_sentinel() -> String {
+  @md_sentinel.EMPTY_PARAGRAPH_SENTINEL
+}
+
 // ── Structural edits ─────────────────────────────────────────────────────
 
 ///|

--- a/ffi/markdown/moon.pkg
+++ b/ffi/markdown/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/canopy/core" @core,
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/companion" @md_companion,
+  "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/markdown" @md,
 }
 
@@ -17,6 +18,7 @@ options(
         "markdown_set_text",
         "markdown_compute_view_patches_json",
         "markdown_apply_edit",
+        "markdown_empty_paragraph_sentinel",
       ],
     },
   },

--- a/ffi/markdown/pkg.generated.mbti
+++ b/ffi/markdown/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub fn markdown_apply_edit(Int, String, Int, String, Int, Int) -> String
 
 pub fn markdown_compute_view_patches_json(Int) -> String
 
+pub fn markdown_empty_paragraph_sentinel() -> String
+
 pub fn markdown_export_text(Int) -> String
 
 pub fn markdown_get_text(Int) -> String

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -78,7 +78,7 @@ fn is_zwsp_sentinel(block : @markdown.Block) -> Bool {
     Paragraph(inlines) =>
       inlines.length() == 1 &&
       (match inlines[0] {
-        Text(s) => s == "\u200B"
+        Text(s) => @md_sentinel.is_empty_paragraph_text(s)
         _ => false
       })
     _ => false

--- a/lang/markdown/companion/moon.pkg
+++ b/lang/markdown/companion/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/canopy/editor" @editor,
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/proj" @md_proj,
+  "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/markdown" @markdown,
   "dowdiness/loom" @loom,
 }

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -187,19 +187,26 @@ fn compute_insert_block_after(
     None => return Err("node not found in source map")
   }
   let insert_pos = range.end
-  // Insert "\n\u200B\n" to create a visible empty paragraph.
+  // Insert "\n<sentinel>\n" to create a visible empty paragraph.
   // The zero-width space gives the parser a real token to produce a ProjNode,
-  // so BlockInput can render and focus the new block. ZWSP is stripped at:
+  // so BlockInput can render and focus the new block. The sentinel is stripped at:
   //   - markdown_export_text() (FFI export boundary — raw mode)
-  //   - block-input.ts (TS display/edit/commit — 3 sites)
+  //   - BlockInput.stripParagraphSentinels (TS display/edit/commit, sourced
+  //     from this FFI's markdown_empty_paragraph_sentinel accessor)
   //   - compute_merge_with_previous (on block merge)
-  // Known minor gap: MarkdownPreview renders node.text as-is (ZWSP invisible
+  // Known minor gap: MarkdownPreview renders node.text as-is (sentinel invisible
   // in HTML, but could leak on copy-paste from preview).
   // Long-term fix: migrate to Container per-block text (empty block = empty text).
   Ok(
     Some(
       (
-        [SpanEdit::{ start: insert_pos, delete_len: 0, inserted: "\n\u200B\n" }],
+        [
+          SpanEdit::{
+            start: insert_pos,
+            delete_len: 0,
+            inserted: "\n" + @md_sentinel.EMPTY_PARAGRAPH_SENTINEL + "\n",
+          },
+        ],
         FocusHint::MoveCursor(position=insert_pos + 1),
       ),
     ),
@@ -315,8 +322,12 @@ fn compute_merge_with_previous(
         None => return Err("previous node not in source map")
       }
   }
-  // Strip ZWSP placeholder (from InsertBlockAfter empty blocks)
-  let clean_text = if curr_text == "\u200B" { "" } else { curr_text }
+  // Strip empty-paragraph sentinel placeholder (from InsertBlockAfter)
+  let clean_text = if @md_sentinel.is_empty_paragraph_text(curr_text) {
+    ""
+  } else {
+    curr_text
+  }
   // The delete span covers: previous block's trailing newline, blank-line
   // separator, current block's prefix + text + trailing newline. Always
   // append \n to restore the proper \n\n block separator with the next block.

--- a/lang/markdown/edits/moon.pkg
+++ b/lang/markdown/edits/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core" @core,
+  "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/markdown" @markdown,
   "dowdiness/moji" @moji,
 }

--- a/lang/markdown/sentinel/moon.pkg
+++ b/lang/markdown/sentinel/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "dowdiness/moji" @moji,
+}

--- a/lang/markdown/sentinel/pkg.generated.mbti
+++ b/lang/markdown/sentinel/pkg.generated.mbti
@@ -1,0 +1,16 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/markdown/sentinel"
+
+// Values
+pub const EMPTY_PARAGRAPH_SENTINEL : String = "​"
+
+pub fn is_empty_paragraph_text(String) -> Bool
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/lang/markdown/sentinel/sentinel.mbt
+++ b/lang/markdown/sentinel/sentinel.mbt
@@ -1,0 +1,24 @@
+// Role-name layer for canopy's markdown empty-paragraph sentinel.
+//
+// The literal codepoint identity (U+200B) lives in `@moji.ZERO_WIDTH_SPACE`.
+// This package names the editor-policy role: "the codepoint we insert to
+// keep an empty paragraph visible and editable inside a markdown buffer."
+// Feature packages should consume `EMPTY_PARAGRAPH_SENTINEL` /
+// `is_empty_paragraph_text` rather than the raw literal.
+
+///|
+/// Codepoint inserted into the markdown buffer to make an otherwise-empty
+/// paragraph visible and editable. Aliases `@moji.ZERO_WIDTH_SPACE`.
+pub const EMPTY_PARAGRAPH_SENTINEL : String = @moji.ZERO_WIDTH_SPACE
+
+///|
+/// True when `s` is exactly the sentinel codepoint and nothing else.
+///
+/// Intentionally narrow today: legitimate user text containing the sentinel
+/// character alongside other content returns `false`. To broaden the rule
+/// to "any default-ignorable-only paragraph" (catching paste of ZWNJ, BOM,
+/// etc.), iterate codepoints and consult
+/// `@moji.is_default_ignorable_code_point`.
+pub fn is_empty_paragraph_text(s : String) -> Bool {
+  s == EMPTY_PARAGRAPH_SENTINEL
+}

--- a/lang/markdown/sentinel/sentinel_wbtest.mbt
+++ b/lang/markdown/sentinel/sentinel_wbtest.mbt
@@ -1,0 +1,34 @@
+// Tests for the markdown empty-paragraph sentinel role.
+//
+// The sentinel rule is intentionally narrow: exact equality with U+200B
+// and nothing else. Mixed content containing the sentinel must NOT be
+// classified as an empty paragraph.
+
+///|
+test "is_empty_paragraph_text: exact sentinel matches" {
+  assert_eq(is_empty_paragraph_text(EMPTY_PARAGRAPH_SENTINEL), true)
+}
+
+///|
+test "is_empty_paragraph_text: empty string is not the sentinel" {
+  assert_eq(is_empty_paragraph_text(""), false)
+}
+
+///|
+test "is_empty_paragraph_text: two sentinels do not match" {
+  let s = EMPTY_PARAGRAPH_SENTINEL + EMPTY_PARAGRAPH_SENTINEL
+  assert_eq(is_empty_paragraph_text(s), false)
+}
+
+///|
+test "is_empty_paragraph_text: sentinel mixed with other text does not match" {
+  let s = EMPTY_PARAGRAPH_SENTINEL + "a"
+  assert_eq(is_empty_paragraph_text(s), false)
+  let s2 = "a" + EMPTY_PARAGRAPH_SENTINEL
+  assert_eq(is_empty_paragraph_text(s2), false)
+}
+
+///|
+test "EMPTY_PARAGRAPH_SENTINEL aliases @moji.ZERO_WIDTH_SPACE" {
+  assert_eq(EMPTY_PARAGRAPH_SENTINEL, @moji.ZERO_WIDTH_SPACE)
+}


### PR DESCRIPTION
## Summary

Steps 2-6 of the moji ZWSP sentinel consolidation plan ([docs/plans/2026-05-16-moji-zwsp-consolidation.md](docs/plans/2026-05-16-moji-zwsp-consolidation.md), tracked under TODO §7). Builds on #269 which shipped the moji-side \`ZERO_WIDTH_SPACE\` constant + \`is_default_ignorable_code_point\` predicate.

## Layer split

| Layer | Owns | Files |
|---|---|---|
| moji (shipped in #269) | Unicode-general facts | \`lib/moji/codepoints.mbt\`, \`lib/moji/property.mbt\` |
| canopy \`lang/markdown/sentinel/\` (new) | Editor-policy role-name | \`@md_sentinel.EMPTY_PARAGRAPH_SENTINEL\` aliases \`@moji.ZERO_WIDTH_SPACE\`; \`is_empty_paragraph_text\` exact-match predicate |
| FFI + TS | Single-source routing across the build graph | \`ffi/markdown/markdown_ffi.mbt\` exports \`markdown_empty_paragraph_sentinel\`; \`examples/web/src/markdown-sentinels.ts\` captures it; \`BlockInput\` takes a \`stripParagraphSentinels\` option |

The canonical ZWSP literal lives in exactly one place — \`lib/moji/codepoints.mbt\` (already merged in #269). Everything else aliases or imports.

## MoonBit call-site migrations

Three sites moved from inline literals to \`@md_sentinel\`:

- \`lang/markdown/companion/markdown_companion.mbt:81\` — \`s == "​"\` → \`@md_sentinel.is_empty_paragraph_text(s)\`
- \`lang/markdown/edits/compute_markdown_edit.mbt:202\` — \`"\\n​\\n"\` → \`"\\n" + @md_sentinel.EMPTY_PARAGRAPH_SENTINEL + "\\n"\`
- \`lang/markdown/edits/compute_markdown_edit.mbt:319\` — \`curr_text == "​"\` → \`@md_sentinel.is_empty_paragraph_text(curr_text)\`

## TypeScript wiring

- \`adapters/editor-adapter/block-input.ts\`: new \`BlockInputOptions { stripParagraphSentinels?: (s: string) => string }\`; constructor extended to \`(container, opts?)\` (defaulted second arg — backwards compatible with existing \`new BlockInput(container)\` callers); private \`this.stripParagraphSentinels\` field; three inline \`.replace(/​/g, '')\` sites funnel through the option. Fallback regex annotated with a \`do-not-refactor-to-a-shared-constant\` comment.
- \`examples/web/src/markdown-sentinels.ts\` (new): imports \`markdown_empty_paragraph_sentinel\` from \`@moonbit/crdt-markdown\`, captures the string once at module init, exports \`stripParagraphSentinels\`.
- \`examples/web/src/markdown-editor.ts\`: passes \`stripParagraphSentinels\` into \`new BlockInput(blockContainer, { stripParagraphSentinels })\`.

## Validation

- \`moon test\` workspace: **171 wasm-gc + 937 js tests pass** (+5 new tests in the sentinel package; existing tests unchanged).
- \`cd examples/web && npx tsc --noEmit\`: clean. (Other examples: prosemirror clean; demo-react has a pre-existing \`tsconfig.json\` issue unrelated to this PR — verified by stash test.)
- \`moon build --target js --release\` builds; \`_build/.../ffi/markdown/markdown.d.ts\` declares \`markdown_empty_paragraph_sentinel(): MoonBit.String\` and \`markdown.js\` exports it.
- \`ffi/markdown/pkg.generated.mbti\` delta: exactly \`+1 pub fn\`. No surface drift.
- All three ZWSP audit greps (\`​\`, \`\\u{200B}\`, literal U+200B) return only canonical/annotated/test-fixture/docstring hits.
- Pre-PR Codex review (high reasoning): no blockers; caught a missing \`pkg.generated.mbti\` staging for the new sentinel package, now included.

## Test plan

- [x] All MoonBit packages build (\`moon check\` workspace-clean)
- [x] All MoonBit tests pass (171 wasm-gc + 937 js)
- [x] TypeScript \`tsc --noEmit\` clean for \`examples/web\`
- [x] FFI accessor verified in built bundle (\`markdown.{js,d.ts}\`)
- [x] mbti diff reviewed: only the intended new \`pub fn\`
- [x] Three-spelling audit grep clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized empty paragraph marker handling throughout the markdown editor for consistent processing behavior.
  * Updated block input component with customizable paragraph marker processing capabilities.

* **Tests**
  * Added comprehensive tests validating empty paragraph detection and edge case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->