### PR TITLE
docs: §7 phase-1 — annotate core/ stubs + Inspector traceability TODOs

### DIFF
--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -13,6 +13,11 @@ pub struct ProjNode[T] {
 } derive(Debug, Eq)
 
 ///|
+/// Stub Show — currently a Debug dump. To be replaced with a short structural
+/// label like "#<node_id> <kind> [<start>..<end>]" once the inspector consumes it.
+/// See docs/TODO.md §15 "Route inspector kind-labels through Show" (Inspector
+/// traceability workstream) — tree-row rendering in view_outline.mbt will call
+/// node.to_string() through this impl.
 pub impl[T : Debug] Show for ProjNode[T] with output(self, logger) {
   logger.write_string(@debug.to_string(self))
 }

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -123,6 +123,11 @@ fn SourceMap::node_to_range_at_position(
 ///|
 /// Find all nodes that contain a given position
 /// Returns nodes from outermost to innermost (parent to child)
+///
+/// Contract NOT YET ENFORCED — implementation returns `Map.keys().to_array()`
+/// which does not guarantee any particular order. Fix as part of click-path
+/// wiring (docs/TODO.md §9 "Wire SourceMap query API into editor click-path"):
+/// sort by `(range.end - range.start)` descending and add a property test.
 pub fn SourceMap::nodes_at_position(
   self : SourceMap,
   position : Int,
@@ -230,7 +235,12 @@ pub fn SourceMap::apply_edit(
 }
 
 ///|
-/// Clear and rebuild from a new AST.
+/// Recovery / debug API: full SourceMap regeneration from a fresh projection tree.
+/// Property-tested in `source_map_properties_wbtest.mbt`. No production consumer
+/// today; intended for stale-map diagnostics or replay/resync flows if those
+/// surface. Not bundled into the click-path wiring TODO (docs/TODO.md §9) since
+/// no UI consumer is currently committed.
+///
 /// Note: this clears token_spans. Call populate_token_spans() afterward
 /// if token-level spans are needed.
 pub fn[T] SourceMap::rebuild(self : SourceMap, root : ProjNode[T]) -> Unit {

--- a/core/types.mbt
+++ b/core/types.mbt
@@ -30,6 +30,10 @@ pub(all) struct SpanEdit {
 } derive(Debug, Eq)
 
 ///|
+/// Stub Show — currently a Debug dump. To be replaced with a compact patch
+/// label like "@<pos> -<delete_len> +«<inserted>»" for the Patch panel.
+/// See docs/TODO.md §9 "Inspector — Intent + Patch panels" and §15 Show
+/// unification (Inspector traceability workstream).
 pub impl Show for SpanEdit with output(self, logger) {
   logger.write_string(@debug.to_string(self))
 }
@@ -88,6 +92,10 @@ pub(all) enum GenericTreeOp {
 } derive(Debug)
 
 ///|
+/// Stub Show — currently a Debug dump. To be replaced with a verb-first label
+/// like "Drop(#11→#12 After)" for the Intent panel. See docs/TODO.md §9
+/// "Inspector — Intent + Patch panels" and §15 Show unification (Inspector
+/// traceability workstream).
 pub impl Show for GenericTreeOp with output(self, logger) {
   logger.write_string(@debug.to_string(self))
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -168,6 +168,21 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: `Module` AST supports `ModuleItem` in parser already, but `FlatProj` storage change caused 2× regression from MoonBit enum boxing.
   Alternative: add helper methods on existing `FlatProj` for interleaved views. Decision pending in `docs/decisions-needed.md`.
 
+- [ ] Inspector — Intent + Patch panels. *Part of Inspector traceability workstream.*
+  Why: existing inspector shows the State layer (ProjNode tree, via `view_outline` + `view_inspector`) and the CRDT-op layer (Lamport-version causal graph, via `view_history`). The layers between them — user actions (`GenericTreeOp`) and text patches (`SpanEdit`) — are invisible. These are exactly what's needed for debugging "why did this edit produce that text," teaching the projection→patch translation when bringing up a new language, and reproducing collaborative bugs from clean traces. Should consume §15's `Show`-unification work when both are implemented (TODO 2 can ship first with ad-hoc rendering, but that deepens the debt §15 removes).
+  Exit:
+  - Intent panel: scrollable log of recent `GenericTreeOp`s, each row uses `op.to_string()` (verb-first label like `"Drop(#11→#12 After)"`).
+  - Patch panel: scrollable log of recent `SpanEdit`s with back-reference to producing `GenericTreeOp`, each row uses `edit.to_string()` (e.g. `"@25 -3 +«add 3 5»"`).
+  - Both panels live in `view_bottom.mbt` (new tab) or a new view file alongside outline/inspector/history.
+
+- [ ] Wire `SourceMap` query API into editor click-path + fix ordering contract. *Part of Inspector traceability workstream.*
+  Why: `core/source_map.mbt::SourceMap::nodes_at_position` and `SourceMap::nodes_in_range` are property-tested (`core/source_map_properties_wbtest.mbt`) but unconsumed by production code. Click-path in `examples/ideal/main/view_editor.mbt` reimplements similar text-position→node logic inline. Additionally, `nodes_at_position` documents "outermost to innermost" ordering but returns `Map.keys().to_array()` — ordering is not guaranteed, latent contract bug if any consumer ever depends on nesting order.
+  Exit:
+  - `SourceMap::nodes_at_position` returns guaranteed outermost→innermost order (sort by `(end - start)` descending) with a property test pinning the contract.
+  - Click-path in `view_editor.mbt` consumes `nodes_at_position`.
+  - Selection-extend command consumes `nodes_in_range`.
+  - `SourceMap::rebuild` annotated as recovery API (see comment in source); not bundled into this TODO's exit since no UI consumer is currently committed.
+
 ---
 
 ## 10. Editor Drag-and-Drop Follow-ups
@@ -252,6 +267,14 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 ---
 
 ## 15. Editor Framework Decoupling
+
+- [ ] Route inspector kind-labels through `Show`. *Part of Inspector traceability workstream.*
+  Why: `examples/ideal/main/view_outline.mbt::kind_of()` and `view_inspector.mbt` each implement their own kind→label classifier, hardcoding lambda-specific syntax ("λ" prefix, "App", "let", "if") in framework views. Adding a new language requires editing per-view classifiers. Existing `Show` impls on `core/proj_node.mbt::ProjNode[T]`, `core/types.mbt::GenericTreeOp`, and `core/types.mbt::SpanEdit` are stubs delegating to `@debug.to_string` (verbose dump, not a short label) with no consumers.
+  Exit:
+  - Tree-row labels in `view_outline` use `node.to_string()` — consumes real `Show for ProjNode[T]` producing e.g. `"#9 App [25..47]"`.
+  - Kind chips in `view_inspector` use `node.kind.to_string()` — consumes existing `Show for Term`/`JsonValue` (already real, no stubs) producing e.g. `"App"`.
+  - `view_outline::kind_of()` and any duplicate per-view classifier deleted.
+  - Adding a new language touches only the language's `Show for Kind` impl, not framework views.
 
 - [ ] Extract ephemeral subsystem — move ~9 files / ~1500 lines (EphemeralStore, EphemeralHub, EphemeralValue, presence types, cursor view, encoding) from `editor/` to its own package.
   Why: zero dependency on editor concepts. Self-contained collaboration primitive with own binary protocol, encoding, and timeout logic.


### PR DESCRIPTION
## Summary

§7 trim-audit phase 1 over `core/` (14 flagged symbols from `moon ide analyze`).

After cross-grep + git-blame + product-vision check, the conclusion is that **none of the flags are genuine drift**:
- 5 symbols are workspace blind-spots (consumed by `examples/ideal/` which is a separate `moon.mod.json` invisible to workspace `moon ide`)
- 3 `Show` impls are **stubs** (currently delegate to `@debug.to_string`) waiting for the inspector to consume them as short labels
- 3 `SourceMap` query methods are **canonical-but-unconsumed API** — property-tested, well-shaped for click-to-select / selection-extend, but not yet wired into production code

This PR captures the implicit design intent so the next audit can verify against named TODOs rather than re-flag the same symbols.

## Changes

**docs/TODO.md** — three new entries under "Inspector traceability workstream":
- §15: Route inspector kind-labels through `Show` (eliminates duplicated `view_outline::kind_of()` + `view_inspector` ad-hoc rendering that hardcodes lambda syntax in framework views)
- §9: Inspector — Intent + Patch panels (the GenericTreeOp/SpanEdit layers between existing State view and CRDT-op view)
- §9: Wire `SourceMap` query API into click-path + fix `nodes_at_position` outermost→innermost ordering contract (latent bug — currently returns `Map.keys().to_array()`)

**core/{proj_node,types,source_map}.mbt** — 5 comment annotations:
- 3 `Show` stubs marked with target label format ("`#9 App [25..47]`", "`Drop(#11→#12 After)`", "`@25 -3 +«add 3 5»`") + TODO backref
- `nodes_at_position` notes ordering contract not yet enforced + TODO backref
- `rebuild` annotated as recovery/debug API (no UI consumer committed)

## What's NOT in scope

Zero `.mbti` diff. No deletions. No behavior changes. This is purely doc/annotation work that converts implicit reserved-space into trackable design debt.

The actual TODO execution (real Show impls, panels, click-path wiring) is left for separate PRs.

## Framing process

Three rounds of Codex review shaped this:
- First pass proposed deleting Show impls + SourceMap methods → user pushed back on principle 7 (reserving space)
- Second pass proposed keeping with vague "future Printable" comments → Codex (and user) pushed back on threshold (over-reserving)
- Third pass (this PR) names a concrete *product* the symbols serve: an inspector that doesn't require per-language classifier duplication. Each kept symbol has a named consumer.

## Test plan

- [ ] CI clean
- [ ] `moon check` + `moon test` workspace-clean (verified locally — 67 core tests pass)
- [ ] `moon info` produces no `.mbti` diff (verified locally — zero API surface change)
- [ ] Codex pre-PR review came back clean on the final framing

Follow-up: §7 phase 2 (protocol/ + projection/) and phase 3 (editor/) are tracked as tasks but not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for source map query behavior and show implementations to clarify current implementation details and stub behavior.

* **Chores**
  * Added backlog items for inspector UI improvements, source map API integration, and inspector label routing.

**Note:** This release contains internal documentation and planning updates with no visible changes to end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->