### PR TITLE
docs: §7 phase-3 — narrow apply_text_edit_internal + Collab panel TODO

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -175,6 +175,14 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   - Patch panel: scrollable log of recent `SpanEdit`s with back-reference to producing `GenericTreeOp`, each row uses `edit.to_string()` (e.g. `"@25 -3 +«add 3 5»"`).
   - Both panels live in `view_bottom.mbt` (new tab) or a new view file alongside outline/inspector/history.
 
+- [ ] Inspector — Collaboration panel. *Part of Inspector traceability workstream.*
+  Why: in a collaborative projectional editor, the connected-peers list, sync status, ephemeral broadcasts (drag state, presence updates), and sync errors are invisible from the main editor surface. Debugging "peer A and peer B disagree on text," "why didn't my drag preview show," or "sync stalled" requires a panel surfacing the collab-layer state. Stub `Show` impls already exist on the relevant types (`PeerCursor`, `PeerPresence`, `PresenceStatus`, `SyncStatus`, `SyncMessage`, `SyncErrorReason`, `DragState`, `EditModeState`, `EphemeralNamespace`, `EphemeralValue`, `EphemeralEventTrigger`) but currently delegate to `@debug.to_string` (verbose dump, not user-facing labels).
+  Exit:
+  - Connected-peers list: renders `PeerPresence` entries (each row uses `peer.to_string()` for a short label like `"alice (online, editing)"`).
+  - Sync status indicator: renders `SyncStatus` + recent `SyncErrorReason` via their `Show` impls.
+  - Recent ephemeral events stream: renders `EphemeralStoreEvent`s via `event.to_string()`.
+  - Lives in `view_bottom` or new tab alongside outline/inspector/history/intent/patch.
+
 - [ ] Wire `SourceMap` query API into editor click-path + fix ordering contract. *Part of Inspector traceability workstream.*
   Why: `core/source_map.mbt::SourceMap::nodes_at_position` and `SourceMap::nodes_in_range` are property-tested (`core/source_map_properties_wbtest.mbt`) but unconsumed by production code. Click-path in `examples/ideal/main/view_editor.mbt` reimplements similar text-position→node logic inline. Additionally, `nodes_at_position` documents "outermost to innermost" ordering but returns `Map.keys().to_array()` — ordering is not guaranteed, latent contract bug if any consumer ever depends on nesting order.
   Exit:
@@ -263,6 +271,14 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 - [ ] Unify voice across architecture docs.
   Why: README and product-vision speak product language; projectional-bridge and structure-format-research speak academic language. One editing pass to make them consistent.
   Exit: all architecture docs feel like they were written by the same person for the same audience.
+
+- [ ] Canopy library API audit and documentation.
+  Why: canopy is currently used as an internal monorepo, but the aspirational direction is to publish it as a general projectional editor library consumable by external MoonBit modules. The audit framing — what's "unused" vs "library API surface" — depends on which direction is committed. Many `pub` symbols in `editor/`, `core/`, `projection/`, and `protocol/` are canonical library API (constructor methods, structural-edit operations, error accessors, query primitives, wire-protocol encoders) that look "unused" under an internal-tool lens because no in-tree consumer exercises them, but are exactly what external library users would call. Without a documented decision, every audit re-relitigates the framing.
+  Exit:
+  - Document the intended library boundary: which packages are public API for external consumers (`core`, `editor`, `projection`, `protocol`) vs internal implementation (`ffi/*`, `editor/*_internal` symbols, etc.).
+  - Establish convention: methods named `*_internal` (e.g. `apply_text_edit_internal`) are implementation-detail regardless of `pub`; library API gets explicit pub visibility, implementation gets private.
+  - Future `moon ide analyze` audits default to KEEP for canonical library API surface; "unused by in-tree consumers" stops being a deletion trigger for these packages.
+  - Optional: a release plan / milestone for first published canopy library version.
 
 ---
 

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -274,7 +274,6 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/cor
 pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise
 pub fn[T : Eq] SyncEditor::apply_text_edit(Self[T], Int, Int, String, Int) -> Unit
 pub fn[T : Eq] SyncEditor::apply_text_edit_exact(Self[T], Int, Int, String, Int) -> Bool
-pub fn[T : Eq] SyncEditor::apply_text_edit_internal(Self[T], Int, Int, String, Int, Bool, Bool) -> Unit
 pub fn[T : Eq] SyncEditor::apply_text_transform(Self[T], @dowdiness/canopy/core.NodeId, (String, Int, Int) -> Result[String, String], Int) -> Result[Unit, TreeEditError]
 pub fn[T : Eq] SyncEditor::backspace(Self[T]) -> Bool
 pub fn[T : Eq] SyncEditor::backspace_and_record(Self[T], Int) -> Bool

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -328,6 +328,11 @@ pub fn[T] SyncEditor::get_node(
 }
 
 ///|
+/// Editor-level cousin of `core/source_map.mbt::SourceMap::nodes_at_position`.
+/// Returns only the innermost node (not the full outermost→innermost chain).
+/// Natural foundation for click-to-select / hover features; see docs/TODO.md §9
+/// "Wire SourceMap query API into editor click-path" — Inspector traceability
+/// workstream.
 pub fn[T] SyncEditor::node_at_position(
   self : SyncEditor[T],
   position : Int,

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -278,7 +278,13 @@ fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::apply_text_edit_internal(
+/// Implementation-detail funnel for all text-changing paths (insert, delete,
+/// backspace, apply_text_edit_with_policy, structural edits). The `_internal`
+/// suffix marks it as private API per the Canopy library API convention
+/// (docs/TODO.md §14 "Canopy library API audit"); external library consumers
+/// should call the higher-level `apply_text_edit_*` / `insert` / `delete`
+/// methods instead.
+fn[T : Eq] SyncEditor::apply_text_edit_internal(
   self : SyncEditor[T],
   start : Int,
   deleted_len : Int,

--- a/editor/sync_status.mbt
+++ b/editor/sync_status.mbt
@@ -27,6 +27,16 @@ pub enum SyncErrorReason {
 } derive(Debug, Eq)
 
 ///|
+/// Stub Show — currently a Debug dump. Cluster awaiting Collaboration panel
+/// adoption (see docs/TODO.md §9 "Inspector — Collaboration panel"): the
+/// following 11 types share this pattern and all need real short-label Show
+/// impls when the panel is built — SyncStatus, SyncErrorReason, SyncMessage
+/// (this file + sync_protocol.mbt); PeerCursor (cursor_view.mbt);
+/// PeerPresence, PresenceStatus, DragState, EditModeState (presence_types.mbt);
+/// EphemeralValue, EphemeralEventTrigger (ephemeral.mbt); EphemeralNamespace
+/// (ephemeral_hub.mbt). Per the §15 Show-unification workstream pattern, real
+/// impls should produce short structural labels (e.g. SyncStatus →
+/// `"connected"`, PeerPresence → `"alice (editing)"`).
 pub impl Show for SyncStatus with output(self, logger) {
   logger.write_string(@debug.to_string(self))
 }


### PR DESCRIPTION
## Summary

§7 trim-audit phase 3 over `editor/` (~52 `moon ide analyze` flags — the largest scope of the three phases). Under the **aspirational library framing** the audit collapses to almost annotation-only: canopy's `editor/` is intended public API for external MoonBit consumers, so canonical-but-internally-unconsumed methods (`insert_at`, `export_since`, `apply_text_transform`, `commit_edit`, `delete_node`, `is_dirty`, `refresh`, `node_at_position`, wire-protocol encoders, error accessors, suberror visibility) are library API surface — not dead code.

## Changes

**One visibility narrow** (`editor/pkg.generated.mbti` -1 line):
- `SyncEditor::apply_text_edit_internal`: `pub` → private. Name literally says "internal." Same pattern as PR #271's `merge_to_edits` narrow. The `_internal` suffix is established convention for implementation-detail per the new §14 library API audit TODO.

**Annotation comments** (zero behavior change):
- Cluster comment at `SyncStatus` naming the 11 collab/UI-state Show stubs awaiting the new Collaboration panel.
- `SyncEditor::node_at_position` annotated as the editor-level cousin of phase-1's `SourceMap::nodes_at_position` (cross-refs Inspector traceability workstream).

**Two new TODOs in `docs/TODO.md`:**
1. **§9 Inspector — Collaboration panel** (fourth Inspector traceability workstream deliverable): peers list, sync status, ephemeral events. Consumer for the 11 collab Show stubs.
2. **§14 Canopy library API audit and documentation**: records the aspirational-library framing decision so future audits default to KEEP for canonical library API surface in `editor/`, `core/`, `projection/`, `protocol/`. Sets the `*_internal` suffix convention for implementation-detail.

## Net delta (vs internal-tool framing)

| Change | Internal-tool | **Library-framing (this PR)** |
|----|----|----|
| Deletions | 2 (`Editor::insert_at`, `export_since`) | **0** |
| Pub→private narrows | ~7 | **1** (`apply_text_edit_internal`) |
| pub(all)→pub narrows | ~5 | **0** |
| Annotations | ~12 | **3** |
| New TODOs | 1 | **2** |
| .mbti diff | medium | **1 line** |

The audit story: phase 3 is essentially "annotation + framing-decision record" because under the library lens, almost everything flagged is real canonical API surface.

## Test plan

- [ ] CI clean
- [ ] `moon check` + `moon test` workspace-clean (verified locally — 366 editor tests pass)
- [ ] `moon info` produces `.mbti` diff of exactly 1 line (verified — only `apply_text_edit_internal` removed)

## Workstream summary

This completes the §7 trim-audit across `core/` (#272), `protocol/` + `projection/` (#273), and `editor/` (this PR). Net across the three phases: **0 deletions, 1 visibility narrow, ~9 annotation comments, 5 new TODOs** (Show unification, Intent+Patch panels, SourceMap wiring, Collaboration panel, Library API audit). The Inspector traceability workstream now has four deliverables; the library API direction has a tracking TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development backlog with planned Inspector collaboration features and API audit scope.
  * Added implementation documentation for editor components.

* **Chores**
  * Removed internal method declaration from public API surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->