### PR TITLE
chore(relay): narrow RelayRoom::send_to pub → private + fix stale doc

### DIFF
--- a/relay/pkg.generated.mbti
+++ b/relay/pkg.generated.mbti
@@ -19,7 +19,6 @@ pub fn RelayRoom::on_connect(Self, String, (Bytes) -> Unit) -> Bool
 pub fn RelayRoom::on_disconnect(Self, String) -> Unit
 pub fn RelayRoom::on_message(Self, String, Bytes) -> Unit
 pub fn RelayRoom::peer_count(Self) -> Int
-pub fn RelayRoom::send_to(Self, String, Bytes) -> Unit
 
 // Type aliases
 

--- a/relay/relay_room.mbt
+++ b/relay/relay_room.mbt
@@ -52,12 +52,10 @@ fn RelayRoom::has_peer(self : RelayRoom, peer_id : String) -> Bool {
 
 ///|
 /// Send data to a specific peer by ID. Silent no-op if peer not found.
-/// Public API — used by on_message routing and crdt_relay.mbt FFI.
-pub fn RelayRoom::send_to(
-  self : RelayRoom,
-  peer_id : String,
-  data : Bytes,
-) -> Unit {
+/// Internal helper for `on_message` routing of point-to-point messages
+/// (SyncRequest/SyncResponse). Not part of the relay's public API
+/// (see relay/README.md for the public surface).
+fn RelayRoom::send_to(self : RelayRoom, peer_id : String, data : Bytes) -> Unit {
   for peer in self.peers {
     if peer.peer_id == peer_id {
       (peer.send_fn)(data)


### PR DESCRIPTION
## Summary

§7 audit applied to \`relay/\`. 3 flagged symbols from \`moon ide analyze\`:

| Symbol | Action |
|---|---|
| \`encode_peer_joined\` | **KEEP** — README-documented public API; cross_compat_wbtest verifies wire format matches editor protocol |
| \`encode_peer_left\` | **KEEP** — same |
| \`RelayRoom::send_to\` | **NARROW pub → private** — not in README's Public API list; only internal caller is \`on_message\` for SyncRequest/Response routing |

Per the §7 audit methodology, \`relay/\` uses **internal-tool framing**, not library framing (relay is server-side, sits outside the core/editor/projection/protocol library set per the §14 Library API audit TODO).

## Bonus fix

The existing doc comment on \`send_to\` claimed "used by on_message routing and **crdt_relay.mbt FFI**" — but \`crdt_relay.mbt\` no longer exists (renamed away in a prior refactor) and the current \`ffi/lambda/relay.mbt\` does not call \`send_to\`. The doc was stale; replaced with accurate "internal helper" description.

## Changes

- \`relay/relay_room.mbt\`: \`pub fn RelayRoom::send_to\` → \`fn RelayRoom::send_to\` + corrected doc comment
- \`relay/pkg.generated.mbti\`: 1 line removed

## Test plan

- [ ] CI clean
- [ ] \`moon check\` + \`moon test\` workspace-clean (verified locally — 39 relay tests pass)
- [ ] \`.mbti\` diff is exactly 1 line (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Direct point-to-point message routing is no longer publicly accessible and is now reserved for internal use only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->