### PR TITLE
docs: §15 Task 1 closure — TODO check + plan post-ship status

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -284,13 +284,19 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 15. Editor Framework Decoupling
 
-- [ ] Route inspector kind-labels through `Show`. *Part of Inspector traceability workstream.*
+- [x] Route inspector kind-labels through `Show`. *Part of Inspector traceability workstream.* Shipped 2026-05-17 (PRs #277, #278).
   Why: `examples/ideal/main/view_outline.mbt::kind_of()` and `view_inspector.mbt` each implement their own kind→label classifier, hardcoding lambda-specific syntax ("λ" prefix, "App", "let", "if") in framework views. Adding a new language requires editing per-view classifiers. Existing `Show` impls on `core/proj_node.mbt::ProjNode[T]`, `core/types.mbt::GenericTreeOp`, and `core/types.mbt::SpanEdit` are stubs delegating to `@debug.to_string` (verbose dump, not a short label) with no consumers.
-  Exit:
+  Exit (as originally drafted):
   - Tree-row labels in `view_outline` use `node.to_string()` — consumes real `Show for ProjNode[T]` producing e.g. `"#9 App [25..47]"`.
   - Kind chips in `view_inspector` use `node.kind.to_string()` — consumes existing `Show for Term`/`JsonValue` (already real, no stubs) producing e.g. `"App"`.
   - `view_outline::kind_of()` and any duplicate per-view classifier deleted.
   - Adding a new language touches only the language's `Show for Kind` impl, not framework views.
+
+  As shipped (see `docs/plans/2026-05-16-show-unification.md` for the trace):
+  - Real `Show` impls landed for `SpanEdit`/`GenericTreeOp`/`ProjNode[T]`/`InteractiveTreeNode[T]` (PR #277), but `view_outline` tree-row body keeps `node.label` — the `"#9 App [25..47]"` form is debug output for inspectors/logs, not the navigation tree.
+  - Inspector chip uses `@loomcore.Renderable::kind_tag(node.kind)` (typed kind tag) rather than `node.kind.to_string()` (PR #278); same end-state for the kind→label classifier collapse, different mechanism.
+  - `view_outline::kind_of()` deleted; CSS class derives from `term_css_class(node.kind)` in `lang/lambda/proj/`.
+  - Adding a new language requires a `Renderable` impl (already required) plus an optional language-specific `term_css_class` for accent colors — framework views unchanged.
 
 - [ ] Extract ephemeral subsystem — move ~9 files / ~1500 lines (EphemeralStore, EphemeralHub, EphemeralValue, presence types, cursor view, encoding) from `editor/` to its own package.
   Why: zero dependency on editor concepts. Self-contained collaboration primitive with own binary protocol, encoding, and timeout logic.

--- a/docs/plans/2026-05-16-show-unification.md
+++ b/docs/plans/2026-05-16-show-unification.md
@@ -7,6 +7,24 @@ Patch + Collab panels (TODO §9) by making `ProjNode`/`GenericTreeOp`/`SpanEdit`
 debug-friendly and routing the inspector chip through the existing
 `Renderable::kind_tag` instead of a label-string parser.
 
+## Status — Task 1 shipped 2026-05-17 (PRs #277, #278)
+
+- PR #277 — `feat(core,projection): real Show on editor-infrastructure
+  types`. Real `Show` impls landed for `SpanEdit`, `GenericTreeOp`,
+  `ProjNode[T : Renderable]`, and `InteractiveTreeNode[T : Renderable]`
+  with the escape helper and inspect-test coverage from Steps 1–5 below.
+- PR #278 — `feat(ideal,lang/lambda/proj): route inspector kind chip
+  through Renderable`. `term_css_class` plus the `view_outline` /
+  `view_inspector` migration and CSS additions from Steps 6–13 below.
+- TODO §15 item 1 is checked. The remaining inspector-workstream
+  deliverables (Intent + Patch panels, SourceMap wiring, Collab panel)
+  are unblocked and tracked in [[project_inspector_traceability_workstream]].
+- Tasks 2 (`pretty_unparse` free function) and 3 (`Canonical` companion
+  trait) are still open; see "Sequencing context" below.
+
+The trace below describes the plan as written before implementation and
+is retained as the design record.
+
 ## Sequencing context
 
 Aligned on the invasiveness ladder:


### PR DESCRIPTION
## Summary

- Checks `docs/TODO.md` §15 first item (\"Route inspector kind-labels through `Show`\") with refs to PRs #277 and #278 (merged 2026-05-16 UTC / 2026-05-17 JST).
- Appends an \"As shipped\" reconciliation note to the same TODO entry — the originally drafted Exit criteria expected `node.to_string()` (tree-row body) and `node.kind.to_string()` (inspector chip). What actually shipped keeps `node.label` for the tree-row body and uses `@loomcore.Renderable::kind_tag(node.kind)` for the inspector chip. Same end state for the kind→label classifier collapse; different mechanism.
- Appends a \"## Status — Task 1 shipped 2026-05-17 (PRs #277, #278)\" block to `docs/plans/2026-05-16-show-unification.md`. The design trace below the new block is retained verbatim (post-ship audit-doc convention: append status, do not rewrite trace).

Tasks 2 (`pretty_unparse` free function) and 3 (`Canonical` companion trait) remain open and unblocked. The remaining inspector-workstream deliverables — Intent + Patch panels, SourceMap wiring, Collab panel — are also unblocked.

## Test plan

- [ ] Docs-only PR; CI green is sufficient.
- [ ] Spot-check the TODO render — checkbox checked, \"As shipped\" sub-list visible.
- [ ] Spot-check the plan doc — new Status block sits between intro and \"## Sequencing context\"; trace below untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project tracking documentation to reflect completion of the Show/Renderable integration work, including related task status updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->