### PR TITLE
docs: §15 Task 2 optional Term::unparse swap — declined

### DIFF
--- a/docs/plans/2026-05-16-show-unification.md
+++ b/docs/plans/2026-05-16-show-unification.md
@@ -22,6 +22,60 @@ debug-friendly and routing the inspector chip through the existing
 - Tasks 2 (`pretty_unparse` free function) and 3 (`Canonical` companion
   trait) are still open; see "Sequencing context" below.
 
+### Task 2 optional `Term::unparse` swap — declined 2026-05-17
+
+Task 2 (loom#121) shipped the `pretty_unparse` free function and swapped
+JSON's `Source::to_source` to it. The optional follow-on — swapping
+lambda's `Renderable::unparse for Term` from `print_term(self)` to
+`@pretty.pretty_unparse(self)` — is **declined**. `print_term` stays
+canonical. Reasons:
+
+1. **Outputs diverge on Lam/App/Bop.** `print_term` uses the local
+   `Pretty` struct interpretation (`sym.mbt`), which always wraps
+   `Lam`/`App`/`Bop` in parens (`(λx. x)`, `(f x)`, `(1 + 2)`).
+   `pretty_unparse` uses the `PrettyLayout` interpretation
+   (`pretty_traits.mbt`), which is precedence-aware via
+   `wrap_if_needed` and emits parens only when the parent context
+   demands them (`λx. x`, `f x`, `1 + 2`). Both parse-roundtrip; the
+   other nine Term variants render identically.
+2. **The two seams are intentionally aligned today.** Both
+   `@pretty.Source for Term with to_source(self)` and
+   `@loomcore.Renderable for Term with unparse(self)` delegate to
+   `print_term`. The "Out" section of this plan codified that
+   alignment: *"The compact source form is `print_term` /
+   `Renderable::unparse`."* Swapping only `Renderable::unparse` would
+   split the two seams — `Source::to_source(t) ≠ Renderable::unparse(t)`
+   for `Lam`/`App`/`Bop` — without aligning the broader strategy.
+3. **JSON's parallel case is misleading.** JSON's pre-swap
+   `json_unparse(value, 0)` was already a flat compact serializer; for
+   JSON, `print_term`-equivalent and `pretty_unparse` produce the same
+   output (no precedence layer, no group/nest decisions). Lambda has
+   two deliberately different serializers — `print_term` for
+   deterministic compact serialization (debug snapshots, diff
+   inspection), `PrettyLayout` for precedence-aware
+   syntax-annotated layout. The one-line swap is not equivalence-
+   preserving for lambda the way it was for JSON.
+4. **No caller exercises the seam today.** A canopy-wide search shows
+   zero call sites of `Renderable::unparse(term)`. The swap would
+   change a theoretical seam, not observed behavior, while introducing
+   the seam-divergence in point 2.
+5. **The correct canonicalization is bigger than this optional swap.**
+   If we want a single Term-text serializer, the right refactor is to
+   delete the local `Pretty` struct interpretation in `sym.mbt`,
+   redefine `print_term(t) = @pretty.pretty_unparse(t)`, and accept
+   the snapshot churn across `resolve_wbtest`, `parse_tree_test`,
+   `phase4_correctness_test`, `lens_test`, and the inline `print_term`
+   tests in `ast.mbt`. That's plan-worthy scope (precedence-aware
+   parens flip in ~30+ inspect snapshots), not a one-line optional
+   swap, and it's not currently motivated by a consumer.
+
+`print_term` stays the canonical compact source form for Term;
+`PrettyLayout` / `pretty_print(term)` remain available for any caller
+that wants precedence-aware width-formatted output. The decision is not
+provisional — if a future consumer needs the smaller-output behavior
+from `Renderable::unparse`, the right move is the full canonicalization
+in point 5, not the partial swap.
+
 The trace below describes the plan as written before implementation and
 is retained as the design record.
 


### PR DESCRIPTION
## Summary

- Append a post-ship status subsection to `docs/plans/2026-05-16-show-unification.md` documenting the decision to **decline** the optional Task 2 follow-on swap of lambda's `Renderable::unparse for Term` from `print_term(self)` to `@pretty.pretty_unparse(self)`. `print_term` stays canonical.
- Update the inspector traceability workstream memory to reflect "declined with rationale" instead of "follow-up".

## Rationale (verbatim from the plan)

1. **Outputs diverge on Lam/App/Bop.** `print_term` always wraps these in parens (`(λx. x)`, `(f x)`, `(1 + 2)`); `pretty_unparse` is precedence-aware via `wrap_if_needed` and emits parens only when needed. Both parse-roundtrip; the other nine Term variants render identically.
2. **The two seams are intentionally aligned today.** Both `@pretty.Source::to_source for Term` and `@loomcore.Renderable::unparse for Term` delegate to `print_term`. The plan's "Out" section codified that alignment. Swapping only `Renderable::unparse` would split the two seams on Lam/App/Bop without aligning the broader strategy.
3. **JSON's parallel case is misleading.** JSON's pre-swap `json_unparse` was already a flat compact serializer, so `pretty_unparse` was equivalence-preserving for JSON. Lambda has two deliberately different serializers (local `Pretty` struct in `sym.mbt` vs `PrettyLayout` in `pretty_traits.mbt`); the parallel doesn't transfer.
4. **No caller exercises the seam today.** Canopy-wide search shows zero call sites of `Renderable::unparse(term)`.
5. **The correct canonicalization is bigger than this optional swap.** Delete the local `Pretty` struct interp, redefine `print_term = pretty_unparse`, accept ~30+ snapshot flips across `resolve_wbtest`/`parse_tree_test`/`phase4_correctness_test`/`lens_test`. Plan-worthy scope, not motivated today.

## Methodology note

Per `feedback_audit_doc_post_ship_update`: the new subsection is **appended inside** the existing "## Status — Task 1 shipped 2026-05-17" block. The original trace below ("The trace below describes the plan as written before implementation and is retained as the design record.") is unmodified.

## Test plan

- [x] Docs-only change; no code touched.
- [x] `git diff --stat` shows only `docs/plans/2026-05-16-show-unification.md` modified (+54 lines).
- [x] Status subsection renders cleanly when reading the plan top-to-bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)