### PR TITLE
feat(ideal): Intent panel + History/Graphviz rabbita fix + undo Bool API

### DIFF
--- a/editor/sync_editor_undo.mbt
+++ b/editor/sync_editor_undo.mbt
@@ -107,7 +107,9 @@ pub fn[T : Eq] SyncEditor::backspace_and_record(
 pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
   let old_source = self.doc.text()
   try {
-    self.undo.undo(self.doc)
+    if !self.undo.undo(self.doc) {
+      return false
+    }
     let new_source = self.doc.text()
     self.adjust_cursor()
     self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
@@ -122,7 +124,9 @@ pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
 pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
   let old_source = self.doc.text()
   try {
-    self.undo.redo(self.doc)
+    if !self.undo.redo(self.doc) {
+      return false
+    }
     let new_source = self.doc.text()
     self.adjust_cursor()
     self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
@@ -142,12 +146,15 @@ pub fn[T : Eq] SyncEditor::undo_and_export(
   let ver_before = self.doc.version()
   let old_source = self.doc.text()
   let success = try {
-    self.undo.undo(self.doc)
-    let new_source = self.doc.text()
-    self.adjust_cursor()
-    self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
-    self.mark_dirty()
-    true
+    if !self.undo.undo(self.doc) {
+      false
+    } else {
+      let new_source = self.doc.text()
+      self.adjust_cursor()
+      self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
+      self.mark_dirty()
+      true
+    }
   } catch {
     _ => false
   }
@@ -168,12 +175,15 @@ pub fn[T : Eq] SyncEditor::redo_and_export(
   let ver_before = self.doc.version()
   let old_source = self.doc.text()
   let success = try {
-    self.undo.redo(self.doc)
-    let new_source = self.doc.text()
-    self.adjust_cursor()
-    self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
-    self.mark_dirty()
-    true
+    if !self.undo.redo(self.doc) {
+      false
+    } else {
+      let new_source = self.doc.text()
+      self.adjust_cursor()
+      self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
+      self.mark_dirty()
+      true
+    }
   } catch {
     _ => false
   }

--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -97,14 +97,6 @@ extern "js" fn js_take_sync_status() -> String =
   #| }
 
 ///|
-/// Set innerHTML of an element by ID. Used for Graphviz SVG rendering.
-extern "js" fn js_set_inner_html(element_id : String, html : String) -> Unit =
-  #| function(id, html) {
-  #|   var el = document.getElementById(id);
-  #|   if (el) el.innerHTML = html;
-  #| }
-
-///|
 /// Move keyboard focus to an element by ID. Used by the bottom tab strip
 /// to follow roving tabindex after arrow-key navigation. Silently no-ops
 /// if the element isn't in the DOM.

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -265,7 +265,6 @@ fn apply_structural_edit_request(
     "Delete" => @lambda_edits.Delete(node_id=nid)
     _ => return (none, model)
   }
-  push_intent(model, tree_op)
   match
     @lambda.apply_lambda_tree_edit(
       model.editor,
@@ -274,6 +273,7 @@ fn apply_structural_edit_request(
       model.next_timestamp,
     ) {
     Ok(_) => {
+      push_intent(model, tree_op)
       let new_model = refresh({
         ..model,
         next_timestamp: model.next_timestamp + 1,
@@ -632,7 +632,6 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       )
     }
     OutlineStructuralEdit(tree_op) => {
-      push_intent(model, tree_op)
       match
         @lambda.apply_lambda_tree_edit(
           model.editor,
@@ -641,6 +640,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
           model.next_timestamp,
         ) {
         Ok(_) => {
+          push_intent(model, tree_op)
           let new_model = refresh({
             ..model,
             next_timestamp: model.next_timestamp + 1,

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -68,7 +68,16 @@ const MAX_INTENT_LOG = 50
 
 ///|
 fn push_intent(model : Model, op : @lambda_edits.TreeEditOp) -> Unit {
-  model.intent_log.push(op.to_generic().to_string())
+  push_intent_label(model, op.to_generic().to_string())
+}
+
+///|
+/// Record a structural intent that arrived as `(op_string, node_id)` from
+/// the TS side. The lambda-typed payload has already been consumed by
+/// `handle_structural_intent` FFI by the time we get here, so we record
+/// the raw label rather than rebuilding the op.
+fn push_intent_label(model : Model, label : String) -> Unit {
+  model.intent_log.push(label)
   while model.intent_log.length() > MAX_INTENT_LOG {
     model.intent_log.remove(0) |> ignore
   }
@@ -403,6 +412,7 @@ fn execute_action(
           model.next_timestamp,
         ) {
         Ok(_) => {
+          push_intent(model, op)
           js_set_overlay_open(false)
           let cmd = @rabbita.effect(fn() { js_reconcile_after_tree_edit() })
           let new_model = refresh({
@@ -899,6 +909,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         (none, model)
       } else {
         // The edit was already applied by TS calling handle_structural_intent FFI.
+        push_intent_label(model, "\{resolved_op}(node=\{resolved_node_id})")
         let new_model = refresh({
           ..model,
           next_timestamp: model.next_timestamp + 1,

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -59,6 +59,18 @@ fn init_model() -> Model {
     drag_source: None,
     drop_target_id: None,
     drop_position: None,
+    intent_log: [],
+  }
+}
+
+///|
+const MAX_INTENT_LOG = 50
+
+///|
+fn push_intent(model : Model, op : @lambda_edits.TreeEditOp) -> Unit {
+  model.intent_log.push(op.to_generic().to_string())
+  while model.intent_log.length() > MAX_INTENT_LOG {
+    model.intent_log.remove(0) |> ignore
   }
 }
 
@@ -244,6 +256,7 @@ fn apply_structural_edit_request(
     "Delete" => @lambda_edits.Delete(node_id=nid)
     _ => return (none, model)
   }
+  push_intent(model, tree_op)
   match
     @lambda.apply_lambda_tree_edit(
       model.editor,
@@ -471,19 +484,10 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Bottom => { ..ws, bottom_visible: !ws.bottom_visible }
       }
       let new_model = { ..model, workspace, }
-      // Reopening the bottom panel must refresh the active tab's container,
-      // since per-tab cmds bail out while hidden — without this, edits made
-      // while collapsed leave a stale SVG when the panel comes back.
-      let cmd = match panel {
-        Bottom =>
-          if workspace.bottom_visible {
-            bottom_render_cmd(new_model)
-          } else {
-            none
-          }
-        _ => none
-      }
-      (cmd, new_model)
+      // Bottom-panel HTML is now mounted through rabbita's vdom (see
+      // `view_bottom_content`), so opening/closing the panel re-renders
+      // it from scratch — no separate refresh command needed.
+      (none, new_model)
     }
     DismissPanels => {
       let ws = model.workspace
@@ -492,11 +496,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     }
     SelectBottomTab(tab) => {
       let new_model = { ..model, bottom_tab: tab }
-      let cmd = @rabbita.batch([
-        bottom_render_cmd(new_model),
-        bottom_tab_focus_cmd(tab),
-      ])
-      (cmd, new_model)
+      (bottom_tab_focus_cmd(tab), new_model)
     }
     StructuralEditRequested(op~, node_id~) => {
       let resolved_op = if op == "" { js_take_structural_edit_op() } else { op }
@@ -539,10 +539,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       if did_undo {
         let new_model = refresh(model)
         let text = new_model.editor.get_text()
-        let cmd = @rabbita.batch([
-          @rabbita.effect(fn() { js_sync_and_broadcast(text) }),
-          bottom_render_cmd(new_model),
-        ])
+        let cmd = @rabbita.effect(fn() { js_sync_and_broadcast(text) })
         (cmd, new_model)
       } else {
         (none, model)
@@ -553,10 +550,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       if did_redo {
         let new_model = refresh(model)
         let text = new_model.editor.get_text()
-        let cmd = @rabbita.batch([
-          @rabbita.effect(fn() { js_sync_and_broadcast(text) }),
-          bottom_render_cmd(new_model),
-        ])
+        let cmd = @rabbita.effect(fn() { js_sync_and_broadcast(text) })
         (cmd, new_model)
       } else {
         (none, model)
@@ -566,10 +560,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       model.editor.set_text(example_text)
       let new_model = refresh(model)
       let text = new_model.editor.get_text()
-      let cmd = @rabbita.batch([
-        @rabbita.effect(fn() { js_reconcile_editor_with_text(text) }),
-        bottom_render_cmd(new_model),
-      ])
+      let cmd = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
       (cmd, new_model)
     }
     OutlineNodeClicked(node_id) => {
@@ -630,7 +621,8 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         { ..model, selected_node: new_selected, outline_state, highlight_set },
       )
     }
-    OutlineStructuralEdit(tree_op) =>
+    OutlineStructuralEdit(tree_op) => {
+      push_intent(model, tree_op)
       match
         @lambda.apply_lambda_tree_edit(
           model.editor,
@@ -678,6 +670,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         }
         Err(_) => (none, model)
       }
+    }
     OpenActionOverlayFromOutline => {
       let node_id_str = match model.selected_node {
         Some(s) => s
@@ -843,6 +836,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
             target=target_id,
             position~,
           )
+          push_intent(model, tree_op)
           match
             @lambda.apply_lambda_tree_edit(
               model.editor,
@@ -872,11 +866,8 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       // Just refresh the outline.
       js_perf_begin("editorTextChangedTotal")
       let new_model = refresh(model)
-      js_perf_begin("bottomRenderCmd")
-      let cmd = bottom_render_cmd(new_model)
-      js_perf_end("bottomRenderCmd")
       js_perf_end("editorTextChangedTotal")
-      (cmd, new_model)
+      (none, new_model)
     }
     EditorNodeSelected(node_id) => {
       let resolved_node_id = if node_id == "" {
@@ -912,7 +903,7 @@ fn update(_dispatch : Dispatch[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
           ..model,
           next_timestamp: model.next_timestamp + 1,
         })
-        (bottom_render_cmd(new_model), new_model)
+        (none, new_model)
       }
     }
   }

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -77,4 +77,7 @@ pub struct Model {
   drag_source : @canopy_core.NodeId?
   drop_target_id : @canopy_core.NodeId?
   drop_position : @canopy_core.DropPosition?
+  // Inspector traceability: rolling log of structural intents (most recent last).
+  // Mutated in place; capped to MAX_INTENT_LOG entries to keep render cheap.
+  intent_log : Array[String]
 }

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -55,6 +55,8 @@ pub fn handle_structural_intent(Int, String, String, Int, String) -> String
 
 pub fn handle_text_intent(Int, Int, Int, String, Int) -> Unit
 
+pub fn handle_text_intent_checked(Int, Int, Int, String, Int) -> Bool
+
 pub fn handle_undo(Int) -> Bool
 
 pub fn insert_at(Int, Int, String, Int) -> Unit
@@ -120,6 +122,7 @@ pub struct Model {
   drag_source : @core.NodeId?
   drop_target_id : @core.NodeId?
   drop_position : @core.DropPosition?
+  intent_log : Array[String]
 }
 
 pub enum Msg {

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -319,9 +319,18 @@ fn bottom_panel_attrs(tab : BottomTab) -> @html.Attrs {
 /// aria-label, never user-supplied text.
 #warnings("-alert_xss_vulnerable")
 fn view_history_panel(model : Model) -> Html {
+  // When the bottom panel is collapsed, the entire <section> is CSS-hidden
+  // but `view()` still runs on every model change. Skip the DOT/SVG layout
+  // pipeline (cache key changes on every edit) and emit empty innerHTML;
+  // the cache stays valid for the next open.
+  let html = if model.workspace.bottom_visible {
+    render_history_html(model)
+  } else {
+    ""
+  }
   @html.section(
     class="bottom-content history-content",
-    attrs=bottom_panel_attrs(History).inner_html(render_history_html(model)),
+    attrs=bottom_panel_attrs(History).inner_html(html),
     ([] : Array[Html]),
   )
 }
@@ -329,12 +338,17 @@ fn view_history_panel(model : Model) -> Html {
 ///|
 /// Render the Graphviz panel. See `view_history_panel` for why this is
 /// a `<section>` with `inner_html` rather than a `<div>` with vdom
-/// children.
+/// children, and for the `bottom_visible` gate.
 #warnings("-alert_xss_vulnerable")
 fn view_graphviz_panel(model : Model) -> Html {
+  let html = if model.workspace.bottom_visible {
+    render_graphviz_html(model)
+  } else {
+    ""
+  }
   @html.section(
     class="bottom-content graphviz-content",
-    attrs=bottom_panel_attrs(Graphviz).inner_html(render_graphviz_html(model)),
+    attrs=bottom_panel_attrs(Graphviz).inner_html(html),
     ([] : Array[Html]),
   )
 }
@@ -345,7 +359,9 @@ fn view_op_log(model : Model) -> Html {
   if log.is_empty() {
     @html.div(class="bottom-content", attrs=bottom_panel_attrs(OpLog), [
       @html.span(class="no-problems", [
-        @html.text("No structural edits yet — try the action overlay or drag."),
+        @html.text(
+          "No structural edits yet — try the action overlay or drag.",
+        ),
       ]),
     ])
   } else {

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -1,9 +1,9 @@
 ///|
-/// Render-cache for the bottom-panel SVG tabs. The view-update loop
-/// re-issues `bottom_render_cmd` on every Model change; without a cache,
-/// every keystroke would re-walk the snapshot, re-emit DOT, re-parse,
-/// re-layout, and re-render the SVG — work proportional to N ops and
-/// dominated by Sugiyama layout (O(V·E)).
+/// Render-cache for the bottom-panel SVG tabs. The view function runs
+/// on every Model change; without a cache, every keystroke would
+/// re-walk the snapshot, re-emit DOT, re-parse, re-layout, and re-render
+/// the SVG — work proportional to N ops and dominated by Sugiyama
+/// layout (O(V·E)).
 ///
 /// Cache keys on `(editor_identity, op_count, frontier_hash)`. Identity
 /// distinguishes separately-constructed `SyncEditor`s in the same process
@@ -114,18 +114,18 @@ fn render_dot_to_svg(dot : String) -> String {
 }
 
 ///|
-/// Create a command that renders the Graphviz SVG into the container.
-/// Must run after the DOM element exists (use as AfterRender or after flush).
-fn graphviz_render_cmd(model : Model) -> @rabbita.Cmd {
-  if model.bottom_tab != Graphviz || !model.workspace.bottom_visible {
-    return @rabbita.none
-  }
+/// Render the Graphviz tab's HTML (cached). Consumed by
+/// `view_bottom_content` via `Attrs::inner_html` so the raw SVG lives
+/// inside rabbita's vdom rather than being painted in via a side-effect.
+/// Mounting through vdom is what keeps tab-switching consistent: when
+/// the user moves to another tab, rabbita's diff sees the panel element
+/// transition from `<section>` (SVG panels) to `<div>` (everything
+/// else), removes the old subtree wholesale, and rebuilds — so stale
+/// SVG can't leak past the diff and block sibling click handlers.
+fn render_graphviz_html(model : Model) -> String {
   let snap = model.editor.causal_snapshot()
   let key = render_cache_key(model.editor.identity(), snap)
-  // Cache the wrapped HTML, not the bare SVG — the role="img" wrapper is
-  // a constant cost we want to pay once. Mirrors the History tab so screen
-  // readers see the same shape on either panel.
-  let html = if cache_hit(graphviz_cache, key) {
+  if cache_hit(graphviz_cache, key) {
     graphviz_cache.html
   } else {
     let dot = @lambda.get_lambda_dot_resolved(model.editor)
@@ -136,26 +136,16 @@ fn graphviz_render_cmd(model : Model) -> @rabbita.Cmd {
     cache_store(graphviz_cache, key, wrapped)
     wrapped
   }
-  // AfterRender ensures the container div exists in the DOM before setting innerHTML.
-  // We always write — cache hit only skips the upstream resolve+layout cost.
-  @rabbita_cmd.raw_effect(
-    fn(_) { js_set_inner_html("canopy-graphviz-container", html) },
-    kind=@rabbita_cmd.after_render,
-  )
 }
 
 ///|
-/// Render the causal-graph history view (legend + SVG) into the History
-/// tab's container. Mirrors `graphviz_render_cmd` — guarded on tab and
-/// visibility.
-fn history_render_cmd(model : Model) -> @rabbita.Cmd {
-  if model.bottom_tab != History || !model.workspace.bottom_visible {
-    return @rabbita.none
-  }
+/// Render the causal-graph History tab's HTML (legend + SVG, cached).
+/// See `render_graphviz_html` for the vdom-mount rationale.
+fn render_history_html(model : Model) -> String {
   let snap = model.editor.causal_snapshot()
   let me = model.editor.get_peer_id()
   let key = render_cache_key(model.editor.identity(), snap)
-  let html = if cache_hit(history_cache, key) {
+  if cache_hit(history_cache, key) {
     history_cache.html
   } else {
     let h = match render_history(snap, me) {
@@ -178,17 +168,6 @@ fn history_render_cmd(model : Model) -> @rabbita.Cmd {
     cache_store(history_cache, key, h)
     h
   }
-  @rabbita_cmd.raw_effect(
-    fn(_) { js_set_inner_html("canopy-history-container", html) },
-    kind=@rabbita_cmd.after_render,
-  )
-}
-
-///|
-/// Run the appropriate bottom-panel render command for the active tab.
-/// Each per-tab cmd self-guards on tab + visibility, so this just batches.
-fn bottom_render_cmd(model : Model) -> @rabbita.Cmd {
-  @rabbita.batch([graphviz_render_cmd(model), history_render_cmd(model)])
 }
 
 ///|
@@ -327,6 +306,70 @@ fn bottom_panel_attrs(tab : BottomTab) -> @html.Attrs {
 }
 
 ///|
+/// Render the History panel — wraps the cached HTML via `inner_html`.
+/// `<section>` (instead of `<div>`) is intentional: when the user
+/// switches to a non-SVG tab (Problems/OpLog/CrdtState — all `<div>`),
+/// the tag mismatch makes rabbita's diff issue a full remove + insert
+/// rather than patching in place. In-place patching would leave the
+/// raw SVG sitting under the new tab's children, because rabbita's
+/// `remove_property("innerHTML")` is a `delete element.innerHTML` which
+/// is a no-op for prototype accessors.
+/// The `inner_html` call is XSS-vulnerable in general; the input here
+/// is built from our own SVG renderer + `escape_html_string` for the
+/// aria-label, never user-supplied text.
+#warnings("-alert_xss_vulnerable")
+fn view_history_panel(model : Model) -> Html {
+  @html.section(
+    class="bottom-content history-content",
+    attrs=bottom_panel_attrs(History).inner_html(render_history_html(model)),
+    ([] : Array[Html]),
+  )
+}
+
+///|
+/// Render the Graphviz panel. See `view_history_panel` for why this is
+/// a `<section>` with `inner_html` rather than a `<div>` with vdom
+/// children.
+#warnings("-alert_xss_vulnerable")
+fn view_graphviz_panel(model : Model) -> Html {
+  @html.section(
+    class="bottom-content graphviz-content",
+    attrs=bottom_panel_attrs(Graphviz).inner_html(render_graphviz_html(model)),
+    ([] : Array[Html]),
+  )
+}
+
+///|
+fn view_op_log(model : Model) -> Html {
+  let log = model.intent_log
+  if log.is_empty() {
+    @html.div(class="bottom-content", attrs=bottom_panel_attrs(OpLog), [
+      @html.span(class="no-problems", [
+        @html.text("No structural edits yet — try the action overlay or drag."),
+      ]),
+    ])
+  } else {
+    // Most recent first; index labels reflect ordinal across the visible window.
+    let n = log.length()
+    let items : Array[Html] = Array::new(capacity=n)
+    for i in 0..<n {
+      let label = log[n - 1 - i]
+      items.push(
+        @html.div(class="op-log-row", [
+          @html.span(class="op-log-index", [@html.text("\{n - i}.")]),
+          @html.span(class="op-log-intent", [@html.text(label)]),
+        ]),
+      )
+    }
+    @html.div(
+      class="bottom-content op-log",
+      attrs=bottom_panel_attrs(OpLog),
+      items,
+    )
+  }
+}
+
+///|
 fn view_problems(model : Model) -> Html {
   let errors = model.editor.get_errors()
   if errors.is_empty() {
@@ -351,10 +394,7 @@ fn view_problems(model : Model) -> Html {
 fn view_bottom_content(dispatch : Dispatch[Msg], model : Model) -> Html {
   let content : Html = match model.bottom_tab {
     Problems => view_problems(model)
-    OpLog =>
-      @html.div(class="bottom-content", attrs=bottom_panel_attrs(OpLog), [
-        @html.span(class="no-problems", [@html.text("Op log coming soon")]),
-      ])
+    OpLog => view_op_log(model)
     CrdtState =>
       @html.div(
         class="bottom-content crdt-state",
@@ -380,18 +420,8 @@ fn view_bottom_content(dispatch : Dispatch[Msg], model : Model) -> Html {
           ]),
         ],
       )
-    History =>
-      @html.div(
-        class="bottom-content history-content",
-        attrs=bottom_panel_attrs(History),
-        [@html.text("")],
-      )
-    Graphviz =>
-      @html.div(
-        class="bottom-content graphviz-content",
-        attrs=bottom_panel_attrs(Graphviz),
-        [@html.text("")],
-      )
+    History => view_history_panel(model)
+    Graphviz => view_graphviz_panel(model)
   }
   @html.fragment([view_bottom_tabs(dispatch, model), content])
 }

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -683,6 +683,38 @@ canopy-editor {
   font-variant-numeric: tabular-nums;
 }
 
+/* ── Op log tab (Intent panel — §9.2 inspector traceability) ─ */
+
+.op-log {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.op-log-row {
+  display: flex;
+  gap: var(--space-sm);
+  padding: var(--space-xs) 0;
+  align-items: baseline;
+}
+
+.op-log-index {
+  font-size: var(--text-small);
+  color: var(--canopy-muted);
+  font-family: var(--canopy-font-mono);
+  font-variant-numeric: tabular-nums;
+  min-width: 32px;
+  text-align: right;
+}
+
+.op-log-intent {
+  font-size: var(--text-small);
+  color: var(--canopy-fg);
+  font-family: var(--canopy-font-mono);
+  letter-spacing: -0.01em;
+  word-break: break-all;
+}
+
 /* ── Graphviz tab ───────────────────────────────────────── */
 
 /*


### PR DESCRIPTION
## Summary

- **Intent panel** for `examples/ideal`: new bottom-tab listing `GenericTreeOp` history (capped at 50 entries), populated from all three structural-dispatch sites. Part of §9.2 of the inspector-traceability workstream.
- **Panel-switch freeze fix**: convert History/Graphviz panels from `js_set_inner_html` (which mutated DOM behind rabbita's vdom) to rabbita-native `Attrs::inner_html` + `@html.section` tag. Previously, clicking History then any other tab triggered `Failed to execute 'removeChild' on 'Node'` because vdom diff couldn't reconcile the silently-replaced subtree.
- **Undo API consumption**: switch `editor/sync_editor_undo` callers to event-graph-walker's new `Bool`-returning `undo`/`redo` (egw#42), removing the canopy-side `can_undo()`/`can_redo()` preflight checks that were a workaround for the empty-stack abort.
- **Submodule bump**: `event-graph-walker` → `5575d8e` (PR dowdiness/event-graph-walker#42 landed).

## Test plan

- [x] `moon test` workspace — 979/979 pass
- [x] `cd examples/ideal && moon test` — 23/23 pass
- [x] `moon check` clean (workspace + ideal)
- [x] `moon info` no `.mbti` drift
- [x] Manual smoke via Playwright probe: tab switches History → Graphviz → Intent → History all work; undo/redo on empty stack no longer freezes UI
- [ ] Reviewer: verify Intent panel renders meaningful labels on structural edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)