### PR TITLE
feat(rabbita_codemirror): P2.2 — public API + sub loader + theme/keymap scaffolds

### DIFF
--- a/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
+++ b/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
@@ -616,6 +616,46 @@ across workspace-root and `examples/ideal`.
 
 ## Revision history
 
+**rev 3.5 (2026-05-19)** — Post-P2.2 ship (PR #297). Codex implemented
+the spec verbatim; three notable deviations + one pre-PR cleanup landed
+versus rev 3.4's handoff doc:
+(a) `lib/rabbita_codemirror/moon.pkg` carries `supported_targets = "js"`
+**in addition to** the `options(targets: { "*": [ "js" ] })` the handoff
+specified — required because `moonbit-community/rabbita/cmd` declares
+`supported_targets`, and MoonBit raises a package-target warning unless
+the consumer matches the form. Per-fn `#cfg(target="js")` annotations
+remain canonical for binding code; `supported_targets` is package-level
+belt-and-suspenders to silence the compatibility warning.
+(b) The MoonBit formatter rewrote `addon/{theme,keymap}` `to_extension`
+from free-function form (`fn to_extension(self : T)`) to qualified
+method form (`fn T::to_extension(self : T)`). Semantically identical
+callable surface (`theme.to_extension()` either way); the `.mbti`
+records the method form. No follow-up needed — Codex's pre-PR review
+confirmed the qualified form is the idiomatic post-deprecation shape.
+(c) `priv suberror CmListen` uses a positional `String` as its first
+field rather than the named `id : String` in the handoff doc — Codex's
+implementer flagged this as a MoonBit constraint on suberror payloads.
+The Codex reviewer pass corrected the framing: the canonical
+`rabbita/rabbita/websocket/listen.mbt` *also* uses a positional first
+field, so the original handoff's `id : String` was the deviation, not
+Codex's implementation. Future bindings should mirror the websocket
+positional-first form. The pattern still matches by position in
+`cm_sub_loader` and `update_tagger`.
+**Cleanup before PR:** removed two stale `#warnings("-deprecated_syntax")`
+annotations Codex left on `addon/{theme,keymap}/*.mbt`'s
+`to_extension` — Codex's review pass diagnosed them as referring to the
+*old* free-function `fn to_extension(self : T)` form that the formatter
+had already replaced, so the suppressions were no-ops. Removed; build
+still clean.
+**Other findings from Codex review (all PASS):** the double-dispose
+path on `update_disposable` after a sub-unload + later `unmount` is
+safe (the JS disposable closures guard with a `disposed` flag in
+`js/codemirror.mbt:283-290`); the listen-before-mount race recovers on
+the next re-render because the loader returns `None` and Rabbita re-fires
+on the next `diff_subs` pass; and the `Local` argument to
+`@sub.custom_sub` is the correct per-instance semantics for a binding
+that owns per-editor state.
+
 **rev 3.4 (2026-05-18)** — Pre-P2.2 dispatch, addon sequencing. The
 prior plan sequenced P2.2 (main API) → P2.3 (all five addon subpackages),
 but P2.2's `mount` and `set_theme`/`set_keymap` signatures already

--- a/lib/rabbita_codemirror/addon/keymap/keymap.mbt
+++ b/lib/rabbita_codemirror/addon/keymap/keymap.mbt
@@ -1,0 +1,16 @@
+///|
+/// Typed wrapper for a CodeMirror keymap extension. Factory
+/// constructors (`default_keymap()`, `vim()`, `from_raw(...)`) land
+/// in P2.3; this scaffold exists so the main package's `mount` /
+/// `set_keymap` signatures can reference `@keymap.Keymap` from the
+/// first public release.
+
+///|
+#warnings("-unused_constructor")
+pub struct Keymap(@js_ffi.Extension)
+
+///|
+#cfg(target="js")
+pub fn Keymap::to_extension(self : Keymap) -> @js_ffi.Extension {
+  self.0
+}

--- a/lib/rabbita_codemirror/addon/keymap/moon.pkg
+++ b/lib/rabbita_codemirror/addon/keymap/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "dowdiness/rabbita_codemirror/js" @js_ffi,
+}
+
+options(
+  targets: { "*": [ "js" ] },
+)

--- a/lib/rabbita_codemirror/addon/keymap/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/addon/keymap/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita_codemirror/addon/keymap"
+
+import {
+  "dowdiness/rabbita_codemirror/js",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct Keymap(@js.Extension)
+pub fn Keymap::to_extension(Self) -> @js.Extension
+
+// Type aliases
+
+// Traits
+

--- a/lib/rabbita_codemirror/addon/theme/moon.pkg
+++ b/lib/rabbita_codemirror/addon/theme/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "dowdiness/rabbita_codemirror/js" @js_ffi,
+}
+
+options(
+  targets: { "*": [ "js" ] },
+)

--- a/lib/rabbita_codemirror/addon/theme/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/addon/theme/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita_codemirror/addon/theme"
+
+import {
+  "dowdiness/rabbita_codemirror/js",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct Theme(@js.Extension)
+pub fn Theme::to_extension(Self) -> @js.Extension
+
+// Type aliases
+
+// Traits
+

--- a/lib/rabbita_codemirror/addon/theme/theme.mbt
+++ b/lib/rabbita_codemirror/addon/theme/theme.mbt
@@ -1,0 +1,16 @@
+///|
+/// Typed wrapper for a CodeMirror theme extension. Factory
+/// constructors (`dark()`, `light()`, `custom(...)`) land in P2.3;
+/// this scaffold exists so the main package's `mount` /
+/// `set_theme` signatures can reference `@theme.Theme` from the
+/// first public release.
+
+///|
+#warnings("-unused_constructor")
+pub struct Theme(@js_ffi.Extension)
+
+///|
+#cfg(target="js")
+pub fn Theme::to_extension(self : Theme) -> @js_ffi.Extension {
+  self.0
+}

--- a/lib/rabbita_codemirror/codemirror.mbt
+++ b/lib/rabbita_codemirror/codemirror.mbt
@@ -5,5 +5,572 @@
 /// lifecycle and mutation ops return `@cmd.Cmd`, subscription helpers return
 /// `@sub.Sub`, and the per-editor handle the consumer's Model holds is a
 /// plain `String` id. All JS handles live in this package's private
-/// `editors` registry; this package owns no `extern "js"` declarations —
-/// those live in the `js/` subpackage.
+/// `editors` registry; raw JavaScript declarations live in the `js/`
+/// subpackage.
+
+///|
+using @cmd {trait Scheduler}
+
+///|
+#cfg(target="js")
+pub struct SelRange {
+  from : Int
+  to : Int
+}
+
+///|
+#cfg(target="js")
+priv struct CmEntry {
+  view : @js_ffi.CmView
+  theme_comp : @js_ffi.Compartment
+  readonly_comp : @js_ffi.Compartment
+  keymap_comp : @js_ffi.Compartment
+  line_numbers_comp : @js_ffi.Compartment
+  line_wrapping_comp : @js_ffi.Compartment
+  update_disposable : @js_ffi.Disposable
+}
+
+///|
+#cfg(target="js")
+let editors : Map[String, CmEntry] = {}
+
+///|
+priv suberror CmSubscription {
+  CmListen(
+    String,
+    doc~ : @cmd.Emit[String]?,
+    selection~ : @cmd.Emit[SelRange]?,
+    focus~ : @cmd.Emit[Bool]?
+  )
+}
+
+///|
+#cfg(target="js")
+fn report_failure(
+  scheduler : &Scheduler,
+  failed : @cmd.Emit[String]?,
+  message : String,
+) -> Unit {
+  match failed {
+    Some(failed) => scheduler.add(failed(message))
+    None => ()
+  }
+}
+
+///|
+#cfg(target="js")
+fn not_found_message(id : String) -> String {
+  "codemirror editor not found: \{id}"
+}
+
+///|
+#cfg(target="js")
+fn empty_extension() -> @js_ffi.Extension {
+  @js_ffi.js_extension_combine([])
+}
+
+///|
+#cfg(target="js")
+fn module_value(cm : @js_ffi.CmModule) -> @js_value.Value {
+  cm.0
+}
+
+///|
+#cfg(target="js")
+fn module_value_of_view(view : @js_ffi.CmView) -> @js_value.Value {
+  let value : @js_value.Value = view.0
+  value.get_with_string("_cmModule")
+}
+
+///|
+#cfg(target="js")
+fn transaction_spec(value : @js_value.Value) -> @js_ffi.TransactionSpec {
+  value.cast()
+}
+
+///|
+#cfg(target="js")
+fn theme_extension(theme : @theme.Theme?) -> @js_ffi.Extension {
+  match theme {
+    Some(theme) => theme.to_extension()
+    None => empty_extension()
+  }
+}
+
+///|
+#cfg(target="js")
+fn keymap_extension(keymap : @keymap.Keymap?) -> @js_ffi.Extension {
+  match keymap {
+    Some(keymap) => keymap.to_extension()
+    None => empty_extension()
+  }
+}
+
+///|
+#cfg(target="js")
+fn readonly_extension(
+  cm_value : @js_value.Value,
+  enabled : Bool,
+) -> @js_ffi.Extension {
+  let editor_state : @js_value.Value = cm_value.get_with_string("EditorState")
+  let read_only : @js_value.Value = editor_state.get_with_string("readOnly")
+  let extension : @js_value.Value = read_only.apply_with_string("of", [enabled])
+  @js_ffi.raw_extension(extension)
+}
+
+///|
+#cfg(target="js")
+fn line_numbers_extension(
+  cm_value : @js_value.Value,
+  enabled : Bool,
+) -> @js_ffi.Extension {
+  if enabled {
+    let extension : @js_value.Value = cm_value.apply_with_string(
+      "lineNumbers",
+      ([] : Array[@js_value.Value]),
+    )
+    @js_ffi.raw_extension(extension)
+  } else {
+    empty_extension()
+  }
+}
+
+///|
+#cfg(target="js")
+fn line_wrapping_extension(
+  cm_value : @js_value.Value,
+  enabled : Bool,
+) -> @js_ffi.Extension {
+  if enabled {
+    let editor_view : @js_value.Value = cm_value.get_with_string("EditorView")
+    @js_ffi.raw_extension(editor_view.get_with_string("lineWrapping"))
+  } else {
+    empty_extension()
+  }
+}
+
+///|
+#cfg(target="js")
+fn no_op_update_listener(view : @js_ffi.CmView) -> @js_ffi.Disposable {
+  @js_ffi.js_add_update_listener(view, _ => (), _ => (), _ => ())
+}
+
+///|
+#cfg(target="js")
+fn dispose_entry(entry : CmEntry) -> Unit {
+  entry.update_disposable.dispose()
+  @js_ffi.js_view_destroy(entry.view)
+}
+
+///|
+#cfg(target="js")
+fn with_entry(
+  id : String,
+  failed : @cmd.Emit[String]?,
+  scheduler : &Scheduler,
+  op : (CmEntry) -> Unit,
+) -> Unit {
+  match editors.get(id) {
+    Some(entry) => op(entry)
+    None => report_failure(scheduler, failed, not_found_message(id))
+  }
+}
+
+///|
+#cfg(target="js")
+fn change_spec(from : Int, to : Int?, text : String) -> @js_ffi.TransactionSpec {
+  let changes = @js_value.Object::new()
+  changes["from"] = from
+  match to {
+    Some(to) => changes["to"] = to
+    None => ()
+  }
+  changes["insert"] = text
+  let spec = @js_value.Object::new()
+  spec["changes"] = changes.to_value()
+  transaction_spec(spec.to_value())
+}
+
+///|
+#cfg(target="js")
+fn selection_spec(range : SelRange) -> @js_ffi.TransactionSpec {
+  let selection = @js_value.Object::new()
+  selection["anchor"] = range.from
+  selection["head"] = range.to
+  let spec = @js_value.Object::new()
+  spec["selection"] = selection.to_value()
+  transaction_spec(spec.to_value())
+}
+
+///|
+#cfg(target="js")
+fn selection_from_value(value : @js_value.Value) -> SelRange {
+  { from: value.get_with_string("from"), to: value.get_with_string("to") }
+}
+
+///|
+#cfg(target="js")
+fn reconfigure(
+  view : @js_ffi.CmView,
+  compartment : @js_ffi.Compartment,
+  extension : @js_ffi.Extension,
+) -> Unit {
+  @js_ffi.js_dispatch(
+    view,
+    @js_ffi.js_compartment_reconfigure(compartment, extension),
+  )
+}
+
+///|
+#cfg(target="js")
+fn build_initial_extension(
+  cm_value : @js_value.Value,
+  theme_comp : @js_ffi.Compartment,
+  readonly_comp : @js_ffi.Compartment,
+  keymap_comp : @js_ffi.Compartment,
+  line_numbers_comp : @js_ffi.Compartment,
+  line_wrapping_comp : @js_ffi.Compartment,
+  initial_theme : @theme.Theme?,
+  initial_readonly : Bool,
+  initial_keymap : @keymap.Keymap?,
+  initial_line_numbers : Bool,
+  initial_line_wrapping : Bool,
+) -> @js_ffi.Extension {
+  @js_ffi.js_extension_combine([
+    @js_ffi.js_compartment_of(theme_comp, theme_extension(initial_theme)),
+    @js_ffi.js_compartment_of(
+      readonly_comp,
+      readonly_extension(cm_value, initial_readonly),
+    ),
+    @js_ffi.js_compartment_of(keymap_comp, keymap_extension(initial_keymap)),
+    @js_ffi.js_compartment_of(
+      line_numbers_comp,
+      line_numbers_extension(cm_value, initial_line_numbers),
+    ),
+    @js_ffi.js_compartment_of(
+      line_wrapping_comp,
+      line_wrapping_extension(cm_value, initial_line_wrapping),
+    ),
+  ])
+}
+
+///|
+#cfg(target="js")
+fn build_listen_key(
+  id : String,
+  has_doc : Bool,
+  has_selection : Bool,
+  has_focus : Bool,
+) -> String {
+  "codemirror.listen(id=\{id},doc=\{has_doc},selection=\{has_selection},focus=\{has_focus})"
+}
+
+///|
+#cfg(target="js")
+fn cm_sub_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    CmListen(id, doc~, selection~, focus~) => {
+      guard editors.get(id) is Some(entry) else { return None }
+
+      let mut doc_tagger = doc
+      let mut selection_tagger = selection
+      let mut focus_tagger = focus
+
+      fn on_doc(value : @js_value.Value) {
+        guard doc_tagger is Some(msg) else { return }
+        scheduler.add(msg(value.cast()))
+      }
+      fn on_selection(value : @js_value.Value) {
+        guard selection_tagger is Some(msg) else { return }
+        scheduler.add(msg(selection_from_value(value)))
+      }
+      fn on_focus(value : @js_value.Value) {
+        guard focus_tagger is Some(msg) else { return }
+        scheduler.add(msg(value.cast()))
+      }
+
+      entry.update_disposable.dispose()
+      let disposable = @js_ffi.js_add_update_listener(
+        entry.view,
+        on_doc,
+        on_selection,
+        on_focus,
+      )
+      editors[id] = { ..entry, update_disposable: disposable }
+
+      Some({
+        unload: fn(_) { disposable.dispose() },
+        update_tagger: fn(payload) {
+          guard payload is CmListen(_, doc~, selection~, focus~) else { return }
+          doc_tagger = doc
+          selection_tagger = selection
+          focus_tagger = focus
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+/// Mount or replace a named CodeMirror editor.
+#cfg(target="js")
+pub fn mount(
+  id : String,
+  host_id : String,
+  init_doc? : String = "",
+  source? : String = "https://esm.sh/codemirror@6",
+  initial_theme? : @theme.Theme? = None,
+  initial_readonly? : Bool = false,
+  initial_keymap? : @keymap.Keymap? = None,
+  initial_line_numbers? : Bool = true,
+  initial_line_wrapping? : Bool = false,
+  on_mounted? : @cmd.Cmd,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    @js_value.async_run(() => {
+      let loaded = Some(@js_ffi.load_codemirror(source~).wait()) catch {
+        e => {
+          report_failure(
+            scheduler,
+            failed,
+            "codemirror module load failed: \{e.to_string()}",
+          )
+          None
+        }
+      }
+      guard loaded is Some(value) else { return }
+      let cm = @js_ffi.cm_module_of(value)
+      let cm_value = module_value(cm)
+
+      if editors.get(id) is Some(old_entry) {
+        dispose_entry(old_entry)
+        editors.remove(id)
+      }
+
+      let theme_comp = @js_ffi.js_compartment_new(cm)
+      let readonly_comp = @js_ffi.js_compartment_new(cm)
+      let keymap_comp = @js_ffi.js_compartment_new(cm)
+      let line_numbers_comp = @js_ffi.js_compartment_new(cm)
+      let line_wrapping_comp = @js_ffi.js_compartment_new(cm)
+      let extension = build_initial_extension(
+        cm_value, theme_comp, readonly_comp, keymap_comp, line_numbers_comp, line_wrapping_comp,
+        initial_theme, initial_readonly, initial_keymap, initial_line_numbers, initial_line_wrapping,
+      )
+      let view = @js_ffi.js_create_view(cm, host_id, init_doc, extension)
+      let update_disposable = no_op_update_listener(view)
+      editors[id] = {
+        view,
+        theme_comp,
+        readonly_comp,
+        keymap_comp,
+        line_numbers_comp,
+        line_wrapping_comp,
+        update_disposable,
+      }
+      match on_mounted {
+        Some(cmd) => scheduler.add(cmd)
+        None => ()
+      }
+    })
+  })
+}
+
+///|
+/// Unmount a named CodeMirror editor.
+#cfg(target="js")
+pub fn unmount(id : String, failed? : @cmd.Emit[String]) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    match editors.get(id) {
+      Some(entry) => {
+        dispose_entry(entry)
+        editors.remove(id)
+      }
+      None => report_failure(scheduler, failed, not_found_message(id))
+    }
+  })
+}
+
+///|
+/// Replace the full document, skipping echo dispatches when the document is
+/// already current.
+#cfg(target="js")
+pub fn set_doc(
+  id : String,
+  doc : String,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      let current = @js_ffi.js_state_doc(entry.view)
+      if doc != current {
+        @js_ffi.js_dispatch(
+          entry.view,
+          change_spec(0, Some(current.length()), doc),
+        )
+      }
+    })
+  })
+}
+
+///|
+/// Insert text at `pos`.
+#cfg(target="js")
+pub fn insert(
+  id : String,
+  pos : Int,
+  text : String,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      @js_ffi.js_dispatch(entry.view, change_spec(pos, None, text))
+    })
+  })
+}
+
+///|
+/// Replace text in `[from, to)` with `text`.
+#cfg(target="js")
+pub fn replace(
+  id : String,
+  from : Int,
+  to : Int,
+  text : String,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      @js_ffi.js_dispatch(entry.view, change_spec(from, Some(to), text))
+    })
+  })
+}
+
+///|
+/// Set the primary selection range.
+#cfg(target="js")
+pub fn set_selection(
+  id : String,
+  range : SelRange,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      @js_ffi.js_dispatch(entry.view, selection_spec(range))
+    })
+  })
+}
+
+///|
+/// Reconfigure the theme compartment.
+#cfg(target="js")
+pub fn set_theme(
+  id : String,
+  theme : @theme.Theme,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      reconfigure(entry.view, entry.theme_comp, theme.to_extension())
+    })
+  })
+}
+
+///|
+/// Reconfigure the readonly compartment.
+#cfg(target="js")
+pub fn set_readonly(
+  id : String,
+  enabled : Bool,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      reconfigure(
+        entry.view,
+        entry.readonly_comp,
+        readonly_extension(module_value_of_view(entry.view), enabled),
+      )
+    })
+  })
+}
+
+///|
+/// Reconfigure the keymap compartment.
+#cfg(target="js")
+pub fn set_keymap(
+  id : String,
+  keymap : @keymap.Keymap,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      reconfigure(entry.view, entry.keymap_comp, keymap.to_extension())
+    })
+  })
+}
+
+///|
+/// Reconfigure the line-number compartment.
+#cfg(target="js")
+pub fn set_line_numbers(
+  id : String,
+  enabled : Bool,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      reconfigure(
+        entry.view,
+        entry.line_numbers_comp,
+        line_numbers_extension(module_value_of_view(entry.view), enabled),
+      )
+    })
+  })
+}
+
+///|
+/// Reconfigure the line-wrapping compartment.
+#cfg(target="js")
+pub fn set_line_wrapping(
+  id : String,
+  enabled : Bool,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      reconfigure(
+        entry.view,
+        entry.line_wrapping_comp,
+        line_wrapping_extension(module_value_of_view(entry.view), enabled),
+      )
+    })
+  })
+}
+
+///|
+/// Subscribe to CodeMirror document, selection, and focus changes.
+#cfg(target="js")
+pub fn listen(
+  id : String,
+  doc? : @cmd.Emit[String],
+  selection? : @cmd.Emit[SelRange],
+  focus? : @cmd.Emit[Bool],
+) -> @sub.Sub {
+  let has_doc = doc is Some(_)
+  let has_selection = selection is Some(_)
+  let has_focus = focus is Some(_)
+
+  guard has_doc || has_selection || has_focus else { @sub.none }
+  let key = build_listen_key(id, has_doc, has_selection, has_focus)
+  @sub.custom_sub(
+    key,
+    Local,
+    CmListen(id, doc~, selection~, focus~),
+    cm_sub_loader,
+  )
+}

--- a/lib/rabbita_codemirror/codemirror_wbtest.mbt
+++ b/lib/rabbita_codemirror/codemirror_wbtest.mbt
@@ -1,0 +1,43 @@
+///|
+test "listen key format" {
+  inspect(
+    build_listen_key("a", true, true, false),
+    content="codemirror.listen(id=a,doc=true,selection=true,focus=false)",
+  )
+}
+
+///|
+test "listen key deterministic" {
+  inspect(
+    build_listen_key("a", true, false, false) ==
+    build_listen_key("a", true, false, false),
+    content="true",
+  )
+}
+
+///|
+test "listen key id matters" {
+  inspect(
+    build_listen_key("a", true, false, false) ==
+    build_listen_key("b", true, false, false),
+    content="false",
+  )
+}
+
+///|
+test "listen key doc flag matters" {
+  inspect(
+    build_listen_key("a", true, false, false) ==
+    build_listen_key("a", false, false, false),
+    content="false",
+  )
+}
+
+///|
+test "listen key selection and focus flags matter" {
+  inspect(
+    build_listen_key("a", false, true, false) ==
+    build_listen_key("a", false, false, true),
+    content="false",
+  )
+}

--- a/lib/rabbita_codemirror/moon.pkg
+++ b/lib/rabbita_codemirror/moon.pkg
@@ -1,1 +1,14 @@
+import {
+  "moonbit-community/rabbita/js" @js_value,
+  "moonbit-community/rabbita/cmd" @cmd,
+  "moonbit-community/rabbita/sub" @sub,
+  "dowdiness/rabbita_codemirror/js" @js_ffi,
+  "dowdiness/rabbita_codemirror/addon/theme" @theme,
+  "dowdiness/rabbita_codemirror/addon/keymap" @keymap,
+}
 
+supported_targets = "js"
+
+options(
+  targets: { "*": [ "js" ] },
+)

--- a/lib/rabbita_codemirror/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/pkg.generated.mbti
@@ -1,11 +1,45 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "dowdiness/rabbita_codemirror"
 
+import {
+  "dowdiness/rabbita_codemirror/addon/keymap",
+  "dowdiness/rabbita_codemirror/addon/theme",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/sub",
+}
+
 // Values
+pub fn insert(String, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool]) -> @sub.Sub
+
+pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn replace(String, Int, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_doc(String, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_keymap(String, @keymap.Keymap, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_line_numbers(String, Bool, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_line_wrapping(String, Bool, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_readonly(String, Bool, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_selection(String, SelRange, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_theme(String, @theme.Theme, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn unmount(String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
 // Errors
 
 // Types and methods
+pub struct SelRange {
+  from : Int
+  to : Int
+}
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

Third PR in the rabbita_codemirror Phase 2 sequence, after P2.0 + P2.1 in #296.
Implements the public function-based API plus the addon type scaffolds.

- `lib/rabbita_codemirror/codemirror.mbt` (576 lines) — `mount` / `unmount` / `set_doc` / `insert` / `replace` / `set_selection` / `set_theme` / `set_readonly` / `set_keymap` / `set_line_numbers` / `set_line_wrapping` / `listen`. Consumer's Model holds only a `String` id; all CodeMirror state lives in a private `editors : Map[String, CmEntry]`.
- `cm_sub_loader` uses the canonical `let mut <tagger>` + `update_tagger` pattern that the P2.0 `diff_subs` patch unlocks — three taggers (doc / selection / focus) rebind across re-renders without re-installing the listener. Sub key encodes id + presence-only, never tagger identity.
- `lib/rabbita_codemirror/addon/theme/` and `addon/keymap/` — type-only newtypes (`Theme(@js_ffi.Extension)` + `to_extension`); factory constructors land in P2.3. Each addon package imports only `js/`.
- `lib/rabbita_codemirror/codemirror_wbtest.mbt` — whitebox tests for `build_listen_key` (format snapshot + determinism + id-mattering + presence-flags-mattering).

Codex-implemented from `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2-p22-codex-handoff.md`; Codex-reviewed before commit (ship-with-caveat; stale `-deprecated_syntax` suppressions on the addon `to_extension` removed before push).

## Spec references

- Plan: `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` §P2.2 (rev 3.4)
- Handoff: `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2-p22-codex-handoff.md`
- Canonical pattern: `rabbita/rabbita/websocket/{listen,websocket}.mbt`

## Verification (independently re-run after Codex returned artifacts)

- `moon check` — clean.
- `moon test --target js` — `Total tests: 1155, passed: 1155, failed: 0.`
- `moon info` — clean; `.mbti` diffs match expected new surface (see below).
- All six grep invariants pass:
  - no `extern "js"` outside `js/`
  - exactly one `priv suberror` in `codemirror.mbt`
  - exactly one `@sub.custom_sub` in `codemirror.mbt`
  - three `let mut <name>_tagger` lines
  - one `update_tagger` rebind inside `cm_sub_loader`
  - no `Compartment` / `@cmd` / `@sub` / `@js_value` imports inside `addon/`

## Test plan

- [x] `moon check` clean (workspace root)
- [x] `moon test --target js` 1155/1155 passing
- [x] `moon info` clean — `.mbti` diff reviewed
- [x] Six grep invariants pass independently of Codex's summary
- [x] Codex second-opinion review on tagger rebind, set_doc echo prevention, mount collision, load_codemirror rejection, sub key composition, plus double-dispose / listen-before-mount / `Local` semantics — verdict: ship-with-caveat (caveat addressed)
- [ ] CI green (workspace tests + JS build + `moon prove` where applicable)
- [ ] Browser smoke test deferred to P2.4

## Out of scope (per plan)

- Addon factory constructors (`dark()` / `light()` / `vim()` / `from_raw(…)`) → P2.3
- `examples/codemirror_demo/` browser smoke → P2.4
- Migrating `examples/ideal/main/canopy-editor.ts` behind the binding → P2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)