### PR TITLE
fix(rabbita_codemirror): P2.1.5 namespace synthesis + P2.4 demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
             path: examples/block-editor
           - name: canvas
             path: examples/canvas
+          - name: codemirror_demo
+            path: examples/codemirror_demo
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
+++ b/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
@@ -616,6 +616,105 @@ across workspace-root and `examples/ideal`.
 
 ## Revision history
 
+**rev 3.8 (2026-05-19)** — Post-P2.4 demo + P2.1.5 FFI fix. Codex
+implemented `examples/codemirror_demo/` per the handoff
+(`2026-05-19-codemirror-rabbita-binding-phase2-p24-codex-handoff.md`),
+all six §P2.4 behaviors verified end-to-end including the
+load-bearing swap-tagger step. Three Codex implementation
+deviations + one Codex-review nit + one **P2.1.5 FFI bug**
+surfaced by the live smoke (the whole purpose of P2.4 as the
+binding's first end-to-end consumer).
+
+**Codex implementation deviations (all justified):**
+(a) `Model.read_only` instead of `readonly` — `readonly` is a
+MoonBit reserved token and won't parse as a field name.
+(b) `@cm.mount(model.cm_id, "cm-demo-host", ...)` with positional
+`host_id` — the frozen `pkg.generated.mbti` declares
+`pub fn mount(String, String, ...)` (two positional `String`
+args, no `host_id~` label). The handoff doc's labelled-call
+example was wrong; Codex's positional form matches the actual
+binding signature.
+(c) `cell_with_emit(...)..with_init(mount_cmd(emit, initial_model)).mount("app")`
+with `#warnings("-alert_unstable")` instead of websocket's
+`cell(...).mount("app")`. Reason: the demo auto-mounts the
+editor at boot (§P2.4 behavior #1), which needs a `Cmd`
+referencing `emit`, which only `cell_with_emit` exposes
+ergonomically. Matches the `with_init` pattern in
+`rabbita/examples/shiki_editor/main/client.mbt` (the canonical
+editor-binding analog per the rabbita-skill table).
+
+**Codex-review nit (fixed before browser smoke):**
+The original `mount_cmd` did not pass `initial_readonly`, so
+after toggling readonly → unmount → remount, the editor came
+back editable while `model.read_only` was still `true`. Added
+`initial_readonly=model.read_only,` to the `@cm.mount` call site
+in `mount_cmd` so remount preserves readonly state.
+
+**P2.1.5 FFI namespace-synthesis fix (bundled in this PR).**
+Browser smoke's behavior #1 failed with `pageerror:
+cm.Compartment is not a constructor`. Root cause:
+`https://esm.sh/codemirror@6` (the binding's previous default
+`source~`) is the CM6 *metapackage*, which re-exports only
+`default` (the `basicSetup` bundle); it does NOT re-export
+`Compartment`, `EditorView`, `EditorState`, `StateEffect`. The
+FFI bodies in `lib/rabbita_codemirror/js/codemirror.mbt`
+reference `cm.Compartment` (line 194), `cm.EditorView`,
+`cm.EditorState` (lines 97, 99, 280), `cm.StateEffect` (line
+280). The bug had never surfaced because the binding's first
+end-to-end consumer is P2.4 (`examples/ideal` still owns CM6
+directly via `canopy-editor.ts`; that migration is P2.5).
+**Fix:** `load_codemirror` now `Promise.all`-loads
+`@codemirror/state@6`, `@codemirror/view@6`,
+`@codemirror/commands@6` from the `source~` base URL and merges
+their namespaces with `{ ...state, ...view, ...commands }`. The
+`source~` semantics change from "CM6 metapackage URL" to "CDN
+base URL"; default flips from `"https://esm.sh/codemirror@6"`
+to `"https://esm.sh"` on both `mount`'s default and
+`load_codemirror`'s default. `CmModule`'s public API stays
+identical — consumers see the same merged-namespace shape via
+`cm.X` access in any future binding extensions (e.g. when the
+deferred ecosystem factories `dark`/`vim`/`default_keymap` get
+implemented, they can now reach `cm.EditorView.theme(...)` and
+`cm.keymap.of(cm.defaultKeymap)` synchronously — though those
+factories remain deferred until a forcing function demands
+them; `Theme::custom(empty)` carried this demo end-to-end as
+the rev-3.7 default position predicted).
+
+**§P2.1 update.** Plan §P2.1's `load_codemirror` signature line
+(default `"https://esm.sh/codemirror@6"`) is historical — the
+actual shipped (post-P2.1.5) default is `"https://esm.sh"` and
+the body is multi-load + merge. Future P2-doc readers should
+treat §P2.1 as the original spec and this rev 3.8 entry as the
+authoritative current state.
+
+**Swap-tagger smoke result.** PASS. Pre-swap typing → readout
+`"A: ... beforeswap"`. After clicking "Swap tagger" and typing
+` afterswap`, readout flipped to `"B: ... beforeswap afterswap"`.
+End-to-end confirms (a) P2.0's `diff_subs` patch correctly
+preserves same-keyed subs across renders, (b) the binding's
+`cm_sub_loader` `update_tagger` closure (codemirror.mbt:306–311)
+correctly rebinds the doc tagger. The triage branches the
+handoff anticipated (P2.0 regression vs binding closure bug)
+were both ruled out by the green smoke.
+
+**Demo footprint.** 12 files added under
+`examples/codemirror_demo/` (10 source + `dist/` and
+`node_modules/` gitignored). One CI matrix entry added to
+`.github/workflows/ci.yml`. Workspace tests stay at 1155
+passed / 0 failed; demo `moon test` is 0/0 by design (no tests
+defined — runtime smoke is the only validation).
+
+**Deferred work for P2.5.** Migrate `examples/ideal` behind
+`VITE_CANOPY_USE_CM_BINDING=1` per plan §P2.5. The
+multi-load-now-works property may unblock the deferred
+ecosystem factories (`dark`/`vim`/`default_keymap`) at low
+cost since `cm.EditorView` and `cm.keymap.of` are now reachable
+from within `addon/` packages via `@js_ffi.raw_extension` — but
+the actual forcing function (whether the ideal editor needs
+them post-migration) doesn't yet exist. Default position from
+rev 3.7 stands: stay deferred until P2.5 surfaces concrete
+need.
+
 **rev 3.7 (2026-05-19)** — Post-P2.3 ship (PR #299, squash SHA
 `2b0dd11`). Codex implemented the rev-3.6 narrowed scope verbatim:
 `Theme::custom(extension : @js_ffi.Extension) -> Theme` and

--- a/examples/codemirror_demo/.gitignore
+++ b/examples/codemirror_demo/.gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+_build/
+target/
+.mooncakes/

--- a/examples/codemirror_demo/README.md
+++ b/examples/codemirror_demo/README.md
@@ -1,0 +1,26 @@
+# CodeMirror Rabbita Demo
+
+Minimal standalone Rabbita app for the `dowdiness/rabbita_codemirror`
+binding. It exercises the P2.4 public API surface without depending on the
+existing Canopy examples.
+
+## Run
+
+```bash
+moon build --target js --release
+npm install
+npm run build
+npm run dev
+```
+
+Open the Vite URL and use the controls on the page.
+
+## Manual Smoke Checklist
+
+1. The editor mounts when the app starts.
+2. Typing in the editor fires `DocChanged`; the readout updates.
+3. The "Set doc" button calls `set_doc` and resets the editor contents.
+4. The "Toggle readonly" button flips readonly mode in place.
+5. The "Unmount" button removes the editor contents; "Mount" recreates it.
+6. The "Swap tagger" button changes the doc-change variant. Type before the
+   swap and the readout shows `A:`; type after the swap and it shows `B:`.

--- a/examples/codemirror_demo/index.html
+++ b/examples/codemirror_demo/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodeMirror Rabbita Demo</title>
+    <link rel="stylesheet" type="text/css" href="/styles.css" />
+    <script src="/main.js" type="module"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/codemirror_demo/main/client.mbt
+++ b/examples/codemirror_demo/main/client.mbt
@@ -1,0 +1,296 @@
+///|
+using @cmd {type Cmd}
+
+///|
+using @html {button, code, div, h1, h2, nothing, p, span}
+
+///|
+using @rabbita {type Emit, type Html}
+
+///|
+using @sub {type Sub}
+
+///|
+let initial_text =
+  #|Canopy CodeMirror binding demo
+  #|
+  #|Type here to exercise listen(doc=...).
+
+///|
+enum Msg {
+  Mounted
+  MountFailed(String)
+  DocChangedA(String)
+  DocChangedB(String)
+  SetDocClicked
+  ToggleReadonly
+  UnmountClicked
+  MountClicked
+  SwapTagger
+}
+
+///|
+struct Model {
+  cm_id : String
+  mounted : Bool
+  read_only : Bool
+  last_doc : String
+  last_variant : String
+  use_variant_b : Bool
+  status_log : Array[String]
+}
+
+///|
+fn capped_prepend(
+  xs : Array[String],
+  value : String,
+  limit : Int,
+) -> Array[String] {
+  let next = xs.copy()
+  next.insert(0, value)
+  if next.length() > limit {
+    ignore(next.remove(next.length() - 1))
+  }
+  next
+}
+
+///|
+fn with_status(model : Model, line : String) -> Model {
+  { ..model, status_log: capped_prepend(model.status_log, line, 8) }
+}
+
+///|
+fn readonly_label(value : Bool) -> String {
+  if value {
+    "readonly"
+  } else {
+    "editable"
+  }
+}
+
+///|
+fn mounted_label(value : Bool) -> String {
+  if value {
+    "mounted"
+  } else {
+    "unmounted"
+  }
+}
+
+///|
+fn active_variant(model : Model) -> String {
+  if model.use_variant_b {
+    "B"
+  } else {
+    "A"
+  }
+}
+
+///|
+fn mount_cmd(emit : Emit[Msg], model : Model) -> Cmd {
+  @cm.mount(
+    model.cm_id,
+    "cm-demo-host",
+    init_doc=initial_text,
+    initial_theme=Some(@theme.Theme::custom(@js_ffi.js_extension_combine([]))),
+    initial_readonly=model.read_only,
+    on_mounted=emit(Mounted),
+    failed=emit.map(message => MountFailed(message)),
+  )
+}
+
+///|
+fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
+  match msg {
+    Mounted =>
+      (@rabbita.none, with_status({ ..model, mounted: true }, "mounted editor"))
+    MountFailed(message) =>
+      (
+        @rabbita.none,
+        with_status({ ..model, mounted: false }, "failed: \{message}"),
+      )
+    DocChangedA(text) =>
+      (
+        @rabbita.none,
+        with_status(
+          { ..model, last_doc: text, last_variant: "A" },
+          "doc changed through A",
+        ),
+      )
+    DocChangedB(text) =>
+      (
+        @rabbita.none,
+        with_status(
+          { ..model, last_doc: text, last_variant: "B" },
+          "doc changed through B",
+        ),
+      )
+    SetDocClicked =>
+      (
+        @cm.set_doc(model.cm_id, "fresh text from the demo"),
+        with_status(
+          { ..model, last_doc: "fresh text from the demo" },
+          "set_doc requested",
+        ),
+      )
+    ToggleReadonly => {
+      let next_readonly = !model.read_only
+      (
+        @cm.set_readonly(model.cm_id, next_readonly),
+        with_status(
+          { ..model, read_only: next_readonly },
+          "readonly -> \{readonly_label(next_readonly)}",
+        ),
+      )
+    }
+    UnmountClicked =>
+      (
+        @cm.unmount(model.cm_id),
+        with_status({ ..model, mounted: false }, "unmount requested"),
+      )
+    MountClicked =>
+      (
+        mount_cmd(emit, model),
+        with_status({ ..model, mounted: false }, "mount requested"),
+      )
+    SwapTagger => {
+      let next_use_variant_b = !model.use_variant_b
+      let next_variant = if next_use_variant_b { "B" } else { "A" }
+      (
+        @rabbita.none,
+        with_status(
+          { ..model, use_variant_b: next_use_variant_b },
+          "listen tagger -> \{next_variant}",
+        ),
+      )
+    }
+  }
+}
+
+///|
+fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
+  guard model.mounted else { return @sub.none }
+  let doc_tagger : Emit[String] = if model.use_variant_b {
+    emit.map(text => DocChangedB(text))
+  } else {
+    emit.map(text => DocChangedA(text))
+  }
+  @cm.listen(model.cm_id, doc=doc_tagger)
+}
+
+///|
+fn metric(label : String, value : String) -> Html {
+  div(class="metric") <| [
+    p(class="metric-label", label),
+    code(class="metric-value", value),
+  ]
+}
+
+///|
+fn status_class(model : Model) -> String {
+  if model.mounted {
+    "status is-mounted"
+  } else {
+    "status is-unmounted"
+  }
+}
+
+///|
+fn view(emit : Emit[Msg], model : Model) -> Html {
+  div(class="page") <| [
+    div(class="topbar") <| [
+      div(class="title-block") <| [
+        h1(class="title", "CodeMirror Rabbita demo"),
+        p(class="subtitle", "P2.4 public API smoke"),
+      ],
+      div(class=status_class(model), mounted_label(model.mounted)),
+    ],
+    div(class="workbench") <| [
+      div(class="editor-column") <| [
+        div(id="cm-demo-host", class="editor-host", nothing),
+      ],
+      div(class="control-column") <| [
+        div(class="panel") <| [
+          h2(class="panel-title", "Controls"),
+          div(class="actions") <| [
+            button(
+              class="primary",
+              disabled=model.mounted,
+              on_click=emit(MountClicked),
+              "Mount",
+            ),
+            button(
+              class="secondary",
+              disabled=!model.mounted,
+              on_click=emit(UnmountClicked),
+              "Unmount",
+            ),
+            button(
+              class="secondary",
+              disabled=!model.mounted,
+              on_click=emit(SetDocClicked),
+              "Set doc",
+            ),
+            button(
+              class="secondary",
+              disabled=!model.mounted,
+              on_click=emit(ToggleReadonly),
+              "Toggle readonly",
+            ),
+            button(
+              class="secondary",
+              disabled=!model.mounted,
+              on_click=emit(SwapTagger),
+              "Swap tagger",
+            ),
+          ],
+        ],
+        div(class="panel") <| [
+          h2(class="panel-title", "Readout"),
+          div(class="metrics") <| [
+            metric("mode", readonly_label(model.read_only)),
+            metric("next tagger", active_variant(model)),
+            metric("last doc", "\{model.last_variant}: \{model.last_doc}"),
+          ],
+        ],
+        div(class="panel") <| [
+          h2(class="panel-title", "Log"),
+          if model.status_log.is_empty() {
+            p(class="empty", "-")
+          } else {
+            div(class="log-list") <| model.status_log.map(line => {
+              div(class="log-line") <| [
+                span(class="log-dot", ""),
+                code(line),
+              ]
+            })
+          },
+        ],
+      ],
+    ],
+  ]
+}
+
+///|
+let initial_model : Model = {
+  cm_id: "codemirror-demo",
+  mounted: false,
+  read_only: false,
+  last_doc: initial_text,
+  last_variant: "A",
+  use_variant_b: false,
+  status_log: [],
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn main {
+  let (emit, app) = @rabbita.cell_with_emit(
+    model=initial_model,
+    update~,
+    view~,
+    subscriptions~,
+  )
+  @rabbita.new(app)..with_init(mount_cmd(emit, initial_model)).mount("app")
+}

--- a/examples/codemirror_demo/main/moon.pkg
+++ b/examples/codemirror_demo/main/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd" @cmd,
+  "moonbit-community/rabbita/sub" @sub,
+  "moonbit-community/rabbita/html" @html,
+  "dowdiness/rabbita_codemirror" @cm,
+  "dowdiness/rabbita_codemirror/addon/theme" @theme,
+  "dowdiness/rabbita_codemirror/js" @js_ffi,
+}
+
+supported_targets = "js"
+
+options(
+  "is-main": true,
+)

--- a/examples/codemirror_demo/main/pkg.generated.mbti
+++ b/examples/codemirror_demo/main/pkg.generated.mbti
@@ -1,0 +1,16 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "example/codemirror_demo/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+type Model
+
+type Msg
+
+// Type aliases
+
+// Traits
+

--- a/examples/codemirror_demo/moon.mod.json
+++ b/examples/codemirror_demo/moon.mod.json
@@ -1,0 +1,18 @@
+{
+  "name": "example/codemirror_demo",
+  "version": "0.1.0",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita"
+    },
+    "dowdiness/rabbita_codemirror": {
+      "path": "../../lib/rabbita_codemirror"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "description": "Minimal Rabbita \u2194 CodeMirror 6 binding demo",
+  "preferred-target": "js"
+}

--- a/examples/codemirror_demo/package-lock.json
+++ b/examples/codemirror_demo/package-lock.json
@@ -1,0 +1,1120 @@
+{
+  "name": "codemirror_demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@rabbita/vite": "^0.1.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rabbita/vite": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@rabbita/vite/-/vite-0.1.3.tgz",
+      "integrity": "sha512-tWQQ4V1gUKgNmm1v2kBt2ZYLRD3b/eMhckNc8ZFxfoTHnw4JAZ3fiYnbcm4LmImR/I6PJxAUlXpV/r2wxReL9Q==",
+      "peerDependencies": {
+        "vite": "^7.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/codemirror_demo/package.json
+++ b/examples/codemirror_demo/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "type": "module",
+  "dependencies": {
+    "@rabbita/vite": "^0.1.3"
+  }
+}

--- a/examples/codemirror_demo/public/styles.css
+++ b/examples/codemirror_demo/public/styles.css
@@ -1,0 +1,222 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: #f4f0ea;
+  color: #16161d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(130, 80, 223, 0.08), rgba(130, 80, 223, 0) 36%),
+    #f4f0ea;
+}
+
+button {
+  border: 1px solid #b9b2aa;
+  border-radius: 6px;
+  padding: 0.65rem 0.85rem;
+  font: inherit;
+  font-weight: 650;
+  color: #1f1d27;
+  background: #fffdf8;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+button.primary {
+  border-color: #8250df;
+  color: #ffffff;
+  background: #8250df;
+}
+
+button.secondary {
+  background: #ffffff;
+}
+
+code,
+.editor-host {
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.page {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.subtitle {
+  margin: 10px 0 0;
+  color: #68616c;
+}
+
+.status {
+  min-width: 116px;
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.status.is-mounted {
+  color: #123c2b;
+  background: #c8ead5;
+}
+
+.status.is-unmounted {
+  color: #5c2c20;
+  background: #ffd6c9;
+}
+
+.workbench {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 20px;
+  align-items: start;
+}
+
+.editor-column,
+.control-column {
+  min-width: 0;
+}
+
+.editor-host {
+  min-height: 520px;
+  border: 1px solid #d1cbc4;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #ffffff;
+  box-shadow: 0 12px 40px rgba(26, 26, 46, 0.12);
+}
+
+.editor-host .cm-editor {
+  min-height: 520px;
+}
+
+.panel {
+  border: 1px solid #d8d0c8;
+  border-radius: 8px;
+  padding: 16px;
+  background: rgba(255, 253, 248, 0.86);
+}
+
+.panel + .panel {
+  margin-top: 14px;
+}
+
+.panel-title {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  color: #5a5360;
+  text-transform: uppercase;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.metrics {
+  display: grid;
+  gap: 10px;
+}
+
+.metric {
+  display: grid;
+  gap: 4px;
+}
+
+.metric-label {
+  margin: 0;
+  color: #746c78;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.metric-value {
+  display: block;
+  max-height: 7rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #1a1a2e;
+}
+
+.empty {
+  margin: 0;
+  color: #746c78;
+}
+
+.log-list {
+  display: grid;
+  gap: 8px;
+}
+
+.log-line {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+}
+
+.log-line code {
+  overflow-wrap: anywhere;
+}
+
+.log-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #8250df;
+}
+
+@media (max-width: 860px) {
+  .topbar {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .workbench {
+    grid-template-columns: 1fr;
+  }
+
+  .control-column {
+    order: -1;
+  }
+
+  .editor-host,
+  .editor-host .cm-editor {
+    min-height: 380px;
+  }
+}

--- a/examples/codemirror_demo/tsconfig.json
+++ b/examples/codemirror_demo/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/codemirror_demo/vite.config.ts
+++ b/examples/codemirror_demo/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite'
+import rabbita from '@rabbita/vite'
+
+export default defineConfig({
+  plugins: [rabbita()],
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/main.js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith('.css')) {
+            return 'assets/styles.css'
+          }
+          return 'assets/[name][extname]'
+        },
+      },
+    },
+  },
+})

--- a/lib/rabbita_codemirror/codemirror.mbt
+++ b/lib/rabbita_codemirror/codemirror.mbt
@@ -322,7 +322,7 @@ pub fn mount(
   id : String,
   host_id : String,
   init_doc? : String = "",
-  source? : String = "https://esm.sh/codemirror@6",
+  source? : String = "https://esm.sh",
   initial_theme? : @theme.Theme? = None,
   initial_readonly? : Bool = false,
   initial_keymap? : @keymap.Keymap? = None,

--- a/lib/rabbita_codemirror/js/codemirror.mbt
+++ b/lib/rabbita_codemirror/js/codemirror.mbt
@@ -54,16 +54,25 @@ pub fn raw_extension(value : @js_value.Value) -> Extension {
 }
 
 ///|
-/// Dynamically import the CodeMirror 6 ES module from `source`. The
-/// returned Promise resolves to the CM6 namespace object; wrap it with
-/// `cm_module_of` to get a `CmModule` handle and thread that to view /
-/// compartment ops.
+/// Dynamically load the CodeMirror 6 sub-packages from `source` (a CDN
+/// base URL) and merge them into a single namespace. The returned
+/// Promise resolves to that merged namespace object; wrap it with
+/// `cm_module_of` to get a `CmModule` handle.
+///
+/// `source` is a base URL — the loader appends `@codemirror/state@6`,
+/// `@codemirror/view@6`, and `@codemirror/commands@6` to it. The
+/// `https://esm.sh/codemirror@6` metapackage exports only a `default`
+/// (the `basicSetup` bundle); it does NOT re-export `Compartment`,
+/// `EditorView`, `EditorState`, or `StateEffect`, which the binding's
+/// FFI needs. Loading the granular sub-packages and merging keeps the
+/// `CmModule` API a single `cm.X`-shaped object the FFI bodies can
+/// access uniformly.
 ///
 /// Module loads are memoized per `source` so concurrent calls during
 /// startup share a single import. Rejected imports are evicted from the
 /// cache so a transient CDN failure does not poison every later call.
 pub extern "js" fn load_codemirror(
-  source? : String = "https://esm.sh/codemirror@6",
+  source? : String = "https://esm.sh",
 ) -> @js_value.Promise =
   #| async (source) => {
   #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
@@ -72,10 +81,17 @@ pub extern "js" fn load_codemirror(
   #|     applying: new WeakMap(),
   #|   });
   #|   if (!slot.modules.has(source)) {
-  #|     const p = import(/* @vite-ignore */ source).catch(err => {
-  #|       slot.modules.delete(source);
-  #|       throw err;
-  #|     });
+  #|     const base = source.endsWith('/') ? source : source + '/';
+  #|     const p = Promise.all([
+  #|       import(/* @vite-ignore */ base + '@codemirror/state@6'),
+  #|       import(/* @vite-ignore */ base + '@codemirror/view@6'),
+  #|       import(/* @vite-ignore */ base + '@codemirror/commands@6'),
+  #|     ])
+  #|       .then(([state, view, commands]) => ({ ...state, ...view, ...commands }))
+  #|       .catch(err => {
+  #|         slot.modules.delete(source);
+  #|         throw err;
+  #|       });
   #|     slot.modules.set(source, p);
   #|   }
   #|   return await slot.modules.get(source);

--- a/lib/rabbita_codemirror/js/codemirror.mbt
+++ b/lib/rabbita_codemirror/js/codemirror.mbt
@@ -68,6 +68,16 @@ pub fn raw_extension(value : @js_value.Value) -> Extension {
 /// `CmModule` API a single `cm.X`-shaped object the FFI bodies can
 /// access uniformly.
 ///
+/// **Multi-version hazard (future):** When language or theme packages
+/// are added beyond state/view/commands, each may bring its own
+/// transitive `@codemirror/state`, and the resulting "multiple
+/// instances of @codemirror/state" runtime error is one of CM6's
+/// classic foot-guns. Mitigation when that happens is to pin
+/// resolutions via the CDN's exact-version/deps query (e.g.
+/// `https://esm.sh/?deps=@codemirror/state@6`). Pre-1.0 the bare
+/// base URL is sufficient since the three currently-loaded packages
+/// agree.
+///
 /// Module loads are memoized per `source` so concurrent calls during
 /// startup share a single import. Rejected imports are evicted from the
 /// cache so a transient CDN failure does not poison every later call.


### PR DESCRIPTION
## Summary

- **P2.1.5 FFI fix**: `load_codemirror` now multi-loads `@codemirror/state@6` + `@codemirror/view@6` + `@codemirror/commands@6` from a CDN base URL and merges namespaces. Fixes runtime `cm.Compartment is not a constructor` that every consumer hit — the pre-fix default `https://esm.sh/codemirror@6` is the metapackage and exports only `default` (the `basicSetup` bundle), not the classes the FFI bodies reference.
- **P2.4 demo** (`examples/codemirror_demo/`): standalone Rabbita app exercising mount/unmount/set_doc/set_readonly/listen + the P2.3 `Theme::custom` factory. First end-to-end consumer of the binding (examples/ideal still owns CM6 directly via canopy-editor.ts until P2.5). Manual browser smoke confirms all six §P2.4 behaviors, including the load-bearing swap-tagger step that validates P2.0's `diff_subs` patch end-to-end.
- **Plan rev 3.8** captures the discovery, Codex implementation deviations, Codex-review nit fixed before smoke, and the swap-tagger pass.

The bug had passed every prior P2.x check (P2.0/P2.1/P2.2/P2.3 all merged green) because the binding had no runtime consumer until this PR. The new CI matrix entry for `examples/codemirror_demo` ensures future binding regressions surface here before reaching `examples/ideal`.

## Test plan

- [x] `moon check` (workspace + demo) — clean
- [x] `moon test --target js` (workspace) — 1155 / 1155
- [x] `moon test` (demo) — 0/0 (no tests by design; runtime smoke is the validation)
- [x] `moon build --target js --release` (demo) — clean
- [x] `npm install && npm run build` (demo) — vite built in 443ms
- [x] Browser smoke (Playwright CLI, headless chromium) — all 6 §P2.4 behaviors PASS:
  - #1 editor mounts
  - #2 typing fires DocChanged (variant A)
  - #3 set_doc resets editor
  - #4 toggle readonly suppresses typing
  - #5 unmount → re-mount cycle preserves model state
  - #6 **swap-tagger rebind**: pre-swap "A: ... beforeswap" → post-swap "B: ... beforeswap afterswap"
- [x] All six handoff grep gates clean
- [x] Codex design review of demo (4 PASS + 1 WARN → fixed)
- [x] Codex design review of FFI fix (5 PASS + 1 WARN → documented inline)
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)