### PR TITLE
fix(rabbita_codemirror): persistent listener compartment (P2 followup)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -386,6 +386,16 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 
 ---
 
+## 18. Rabbita CodeMirror Binding: load_codemirror source query handling
+
+Why: The doc comment at `lib/rabbita_codemirror/js/codemirror.mbt:71-78` mentions `?deps=@codemirror/state@6` as the future multi-version mitigation, but the current `endsWith('/') ? source : source + '/'` concatenation can't handle query-bearing `source` values — `https://esm.sh/?deps=...` would produce `https://esm.sh/?deps=.../@codemirror/state@6` (path appended after the query). Codex flagged in PR #300 review as a misleading doc example.
+
+Plan: GitHub issue or inline ~5 LOC fix. Two options: (a) tighten the doc to say "query-free base URL only" and remove the `?deps=` example; (b) switch URL construction to the `URL` API so query params survive package-path append.
+
+Exit: doc comment matches actual behavior; either query-bearing `source` works OR the doc explicitly says it doesn't.
+
+---
+
 ## Shipped history
 
 Completed items (with PR references and shipping notes) are preserved in

--- a/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
+++ b/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
@@ -616,6 +616,10 @@ across workspace-root and `examples/ideal`.
 
 ## Revision history
 
+**rev 3.9 (2026-05-19)** — Listener compartment persistence fix. The
+update listener now reconfigures a mount-created `CmEntry` slot instead
+of appendConfig-appending fresh compartments on listen toggles.
+
 **rev 3.8 (2026-05-19)** — Post-P2.4 demo + P2.1.5 FFI fix. Codex
 implemented `examples/codemirror_demo/` per the handoff
 (`2026-05-19-codemirror-rabbita-binding-phase2-p24-codex-handoff.md`),

--- a/lib/rabbita_codemirror/codemirror.mbt
+++ b/lib/rabbita_codemirror/codemirror.mbt
@@ -27,6 +27,7 @@ priv struct CmEntry {
   keymap_comp : @js_ffi.Compartment
   line_numbers_comp : @js_ffi.Compartment
   line_wrapping_comp : @js_ffi.Compartment
+  listener_comp : @js_ffi.Compartment
   update_disposable : @js_ffi.Disposable
 }
 
@@ -151,8 +152,11 @@ fn line_wrapping_extension(
 
 ///|
 #cfg(target="js")
-fn no_op_update_listener(view : @js_ffi.CmView) -> @js_ffi.Disposable {
-  @js_ffi.js_add_update_listener(view, _ => (), _ => (), _ => ())
+fn no_op_update_listener(
+  view : @js_ffi.CmView,
+  compartment : @js_ffi.Compartment,
+) -> @js_ffi.Disposable {
+  @js_ffi.js_add_update_listener(view, compartment, _ => (), _ => (), _ => ())
 }
 
 ///|
@@ -230,6 +234,7 @@ fn build_initial_extension(
   keymap_comp : @js_ffi.Compartment,
   line_numbers_comp : @js_ffi.Compartment,
   line_wrapping_comp : @js_ffi.Compartment,
+  listener_comp : @js_ffi.Compartment,
   initial_theme : @theme.Theme?,
   initial_readonly : Bool,
   initial_keymap : @keymap.Keymap?,
@@ -251,6 +256,7 @@ fn build_initial_extension(
       line_wrapping_comp,
       line_wrapping_extension(cm_value, initial_line_wrapping),
     ),
+    @js_ffi.js_compartment_of(listener_comp, empty_extension()),
   ])
 }
 
@@ -295,6 +301,7 @@ fn cm_sub_loader(
       entry.update_disposable.dispose()
       let disposable = @js_ffi.js_add_update_listener(
         entry.view,
+        entry.listener_comp,
         on_doc,
         on_selection,
         on_focus,
@@ -357,12 +364,14 @@ pub fn mount(
       let keymap_comp = @js_ffi.js_compartment_new(cm)
       let line_numbers_comp = @js_ffi.js_compartment_new(cm)
       let line_wrapping_comp = @js_ffi.js_compartment_new(cm)
+      let listener_comp = @js_ffi.js_compartment_new(cm)
       let extension = build_initial_extension(
         cm_value, theme_comp, readonly_comp, keymap_comp, line_numbers_comp, line_wrapping_comp,
-        initial_theme, initial_readonly, initial_keymap, initial_line_numbers, initial_line_wrapping,
+        listener_comp, initial_theme, initial_readonly, initial_keymap, initial_line_numbers,
+        initial_line_wrapping,
       )
       let view = @js_ffi.js_create_view(cm, host_id, init_doc, extension)
-      let update_disposable = no_op_update_listener(view)
+      let update_disposable = no_op_update_listener(view, listener_comp)
       editors[id] = {
         view,
         theme_comp,
@@ -370,6 +379,7 @@ pub fn mount(
         keymap_comp,
         line_numbers_comp,
         line_wrapping_comp,
+        listener_comp,
         update_disposable,
       }
       match on_mounted {

--- a/lib/rabbita_codemirror/js/codemirror.mbt
+++ b/lib/rabbita_codemirror/js/codemirror.mbt
@@ -271,11 +271,12 @@ pub fn js_extension_combine(extensions : Array[Extension]) -> Extension {
 ///|
 extern "js" fn js_add_update_listener_raw(
   view : @js_value.Value,
+  compartment : @js_value.Value,
   on_doc : (@js_value.Value) -> Unit,
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
 ) -> () -> Unit =
-  #| (view, onDoc, onSelection, onFocusChange) => {
+  #| (view, compartment, onDoc, onSelection, onFocusChange) => {
   #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
   #|   const slot = globalThis[key];
   #|   const cm = view._cmModule;
@@ -283,7 +284,6 @@ extern "js" fn js_add_update_listener_raw(
   #|     throw new Error("Listener attach requires a view created via js_create_view");
   #|   }
   #|   const isApplying = () => !!slot.applying.get(view)?.value;
-  #|   const compartment = new cm.Compartment();
   #|   const listener = cm.EditorView.updateListener.of(update => {
   #|     if (update.docChanged && !isApplying()) {
   #|       onDoc(update.state.doc.toString());
@@ -303,7 +303,7 @@ extern "js" fn js_add_update_listener_raw(
   #|   });
   #|   js_apply_guarded(view, () => {
   #|     view.dispatch({
-  #|       effects: cm.StateEffect.appendConfig.of([compartment.of(listener)]),
+  #|       effects: compartment.reconfigure(listener),
   #|     });
   #|   });
   #|   let disposed = false;
@@ -333,11 +333,18 @@ extern "js" fn js_add_update_listener_raw(
 ///|
 pub fn js_add_update_listener(
   view : CmView,
+  compartment : Compartment,
   on_doc : (@js_value.Value) -> Unit,
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
 ) -> Disposable {
   Disposable(
-    js_add_update_listener_raw(view.0, on_doc, on_selection, on_focus_change),
+    js_add_update_listener_raw(
+      view.0,
+      compartment.0,
+      on_doc,
+      on_selection,
+      on_focus_change,
+    ),
   )
 }

--- a/lib/rabbita_codemirror/js/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/js/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "dowdiness/rabbita_codemirror/js"
 // Values
 pub fn cm_module_of(@moonbit-community/rabbita/js.Value) -> CmModule
 
-pub fn js_add_update_listener(CmView, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit) -> Disposable
+pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit) -> Disposable
 
 pub fn js_compartment_new(CmModule) -> Compartment
 


### PR DESCRIPTION
## Summary

- Listener compartment is now a persistent `CmEntry` field created at mount, instead of a fresh `cm.Compartment()` per `js_add_update_listener` install.
- The FFI takes the compartment as a parameter and `reconfigure`s it in place: install → wrap listener, dispose → empty. Same slot every time.
- Mount→listen→dispose→listen cycles no longer accumulate empty appended compartments in the view's extension graph.

## Why

`js_add_update_listener_raw` constructed `new cm.Compartment()` per call and `cm.StateEffect.appendConfig.of([compartment.of(listener)])`-appended it. The disposer only ran `compartment.reconfigure([])` — emptying but never removing the appended compartment (CodeMirror's `appendConfig` is sticky until full reconfiguration).

Mount→unmount was fine because the view is destroyed. Mount→listen-toggle→listen wasn't fine on the same view. The P2.4 demo doesn't exercise the leaky path (it always returns the same `listen` sub while mounted), but `examples/ideal` (P2.5 target) will rebuild subs on focus changes.

Codex flagged this on PR #300 review.

## Approach

Mirror the existing 5-compartment pattern (theme / readonly / keymap / line_numbers / line_wrapping):
- `CmEntry` gains a 6th `listener_comp` field.
- `mount()` creates `listener_comp = js_compartment_new(cm)` alongside the others.
- `build_initial_extension` includes a 6th slot wrapping `empty_extension()` — no listener until the sub loader fires.
- `js_add_update_listener(_raw)` takes `compartment` as second arg, reconfigures in place.
- `cm_sub_loader` passes `entry.listener_comp` through. The dispose-then-install sequence already in place keeps working — both ops are now reconfigures of the same compartment, last-write-wins (idempotent under any rabbita unload/load ordering).

## Bundled docs

- `docs/TODO.md` §18 — removed the shipped listener item, kept the `load_codemirror` doc-comment followup as the §18 body.
- `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` — added rev 3.9 entry.

## Test plan

- [x] `moon check` clean
- [x] `moon test` — 984/984 pass workspace-wide
- [x] `moon fmt` clean
- [x] `moon info` regenerated `lib/rabbita_codemirror/js/pkg.generated.mbti` — only the `js_add_update_listener` signature changed (added `Compartment` param); root `pkg.generated.mbti` unchanged
- [x] `moon build --target js --release` + `examples/codemirror_demo` `npm run build` — both succeed
- [ ] **Manual smoke deferred**: the codemirror_demo doesn't exercise the leaky path (always returns the same `listen` sub while mounted), so an in-session Playwright smoke is purely a regression check on the unchanged 6 demo behaviors. Demo build succeeds; the 6-step manual smoke checklist in `examples/codemirror_demo/README.md` should still pass unchanged. Will validate as part of P2.5 (examples/ideal migration), which actually exercises listen-toggle cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)