### PR TITLE
docs(rabbita_codemirror): tighten load_codemirror source doc + close §18

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -384,18 +384,6 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Plan: `docs/plans/2026-04-26-lambda-typecheck-pipeline-evolution.md`
   Exit: 6/6 plan steps shipped — type diagnostics carry ranges, wire is typed (no JSON round-trip), `query_type_at_offset` exposed and consumed by hover, diagnostic updates are subscription-driven, per-def memo isolation verified by test, and `@typecheck.attach` is the single shared attachment abstraction used by both canopy and the loom example.
 
----
-
-## 18. Rabbita CodeMirror Binding: load_codemirror source query handling
-
-Why: The doc comment at `lib/rabbita_codemirror/js/codemirror.mbt:71-78` mentions `?deps=@codemirror/state@6` as the future multi-version mitigation, but the current `endsWith('/') ? source : source + '/'` concatenation can't handle query-bearing `source` values — `https://esm.sh/?deps=...` would produce `https://esm.sh/?deps=.../@codemirror/state@6` (path appended after the query). Codex flagged in PR #300 review as a misleading doc example.
-
-Plan: GitHub issue or inline ~5 LOC fix. Two options: (a) tighten the doc to say "query-free base URL only" and remove the `?deps=` example; (b) switch URL construction to the `URL` API so query params survive package-path append.
-
-Exit: doc comment matches actual behavior; either query-bearing `source` works OR the doc explicitly says it doesn't.
-
----
-
 ## Shipped history
 
 Completed items (with PR references and shipping notes) are preserved in

--- a/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
+++ b/docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md
@@ -616,6 +616,9 @@ across workspace-root and `examples/ideal`.
 
 ## Revision history
 
+**rev 3.10 (2026-05-19)** — Tightened `load_codemirror` source docs to
+match query-free string-concat imports, and closed TODO §18.
+
 **rev 3.9 (2026-05-19)** — Listener compartment persistence fix. The
 update listener now reconfigures a mount-created `CmEntry` slot instead
 of appendConfig-appending fresh compartments on listen toggles.

--- a/lib/rabbita_codemirror/js/codemirror.mbt
+++ b/lib/rabbita_codemirror/js/codemirror.mbt
@@ -72,11 +72,13 @@ pub fn raw_extension(value : @js_value.Value) -> Extension {
 /// are added beyond state/view/commands, each may bring its own
 /// transitive `@codemirror/state`, and the resulting "multiple
 /// instances of @codemirror/state" runtime error is one of CM6's
-/// classic foot-guns. Mitigation when that happens is to pin
-/// resolutions via the CDN's exact-version/deps query (e.g.
-/// `https://esm.sh/?deps=@codemirror/state@6`). Pre-1.0 the bare
-/// base URL is sufficient since the three currently-loaded packages
-/// agree.
+/// classic foot-guns. `source` must be a query-free CDN base URL
+/// (path only): this loader normalizes a trailing slash, then appends
+/// `@codemirror/state@6`, `@codemirror/view@6`, and
+/// `@codemirror/commands@6` by string concatenation, so query strings
+/// would corrupt the import path. A multi-version mitigation should be
+/// designed if the hazard surfaces; pre-1.0 the bare base URL is
+/// sufficient since the three currently-loaded packages agree.
 ///
 /// Module loads are memoized per `source` so concurrent calls during
 /// startup share a single import. Rejected imports are evicted from the


### PR DESCRIPTION
## Summary

- Doc-comment for `load_codemirror` now matches actual URL construction: `source` is a query-free CDN base URL, normalized to trailing slash, then sub-package paths appended by string concat.
- Drops the misleading `?deps=@codemirror/state@6` example (it would have appended the package path *after* the query string).
- Removes `docs/TODO.md §18` (last open P2 followup) and adds plan rev 3.10.

## Why

Codex flagged this in PR #300 review: the doc claimed `?deps=` as the multi-version mitigation, but the FFI body uses `source.endsWith('/') ? source : source + '/'` + raw concat, which corrupts query-bearing URLs. Two options were on the table — tighten doc vs. switch to URL API. Picked option (a) since the multi-version hazard isn't real pre-1.0 and the URL API change is non-trivial (relative URLs against query-bearing bases don't merge cleanly). Future-self can revisit if the hazard surfaces.

## Test plan

- [x] `moon check` clean
- [x] Diff scope verified: only the doc-comment block changed in `codemirror.mbt`; JS body untouched
- [x] §18 fully removed from TODO; no neighboring sections affected
- [x] Plan rev 3.10 added in expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)