### PR TITLE
feat(ideal): P2.5 PR 1 — wire @cm binding behind VITE_CANOPY_USE_CM_BINDING (additive)

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -7,6 +7,13 @@ extern "js" fn js_get_agent_id() -> String =
   #| }
 
 ///|
+/// Read whether the CodeMirror rabbita binding should own text mode.
+extern "js" fn js_use_cm_binding() -> Bool =
+  #| function() {
+  #|   return globalThis.__canopy_use_cm_binding === true;
+  #| }
+
+///|
 /// Sync MoonBit editor text to the JS-side CRDT editor, then reconcile PM.
 /// Called after load-example to keep the two editors in sync.
 extern "js" fn js_reconcile_editor_with_text(new_text : String) -> Unit =

--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -49,6 +49,19 @@ extern "js" fn js_sync_and_broadcast(_new_text : String) -> Unit =
   #| }
 
 ///|
+/// Broadcast and autosave after a local edit handled by the CM binding.
+extern "js" fn js_after_binding_local_edit(text : String) -> Unit =
+  #| function(text) {
+  #|   var el = document.querySelector('canopy-editor');
+  #|   if (el && typeof el.notifyLocalChange === 'function') {
+  #|     el.notifyLocalChange();
+  #|   }
+  #|   if (typeof globalThis.__canopy_trigger_autosave === 'function') {
+  #|     globalThis.__canopy_trigger_autosave();
+  #|   }
+  #| }
+
+///|
 /// Set the editor mode on the Web Component ('text' or 'structure').
 extern "js" fn js_set_editor_mode(mode : String) -> Unit =
   #| function(mode) {

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -48,6 +48,7 @@ fn init_model() -> Model {
     outline_state,
     cm_id: "canopy-text-editor",
     use_cm_binding,
+    mounted: false,
     mode: Text,
     workspace: {
       outline_visible: true,
@@ -75,6 +76,7 @@ fn cm_mount_cmd(emit : Emit[Msg], model : Model) -> Cmd {
     model.cm_id,
     "canopy-text-editor",
     init_doc=model.editor.get_text(),
+    on_mounted=emit(CmMounted),
     failed=emit.map(message => {
       ignore(message)
       SyncStatusChanged("")
@@ -97,7 +99,7 @@ fn sync_editor_after_text_change(
 
 ///|
 fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
-  guard model.use_cm_binding else { return @sub.none }
+  guard model.use_cm_binding && model.mounted else { return @sub.none }
   @cm.listen(
     model.cm_id,
     doc=emit.map(text => CmDocChanged(text)),
@@ -968,9 +970,14 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         (none, new_model)
       }
     }
+    CmMounted => (none, { ..model, mounted: true })
     CmDocChanged(text) => {
-      model.editor.set_text(text)
-      let new_model = refresh(model)
+      // Binding listen sends the full document; use the recording variant so undo keeps working.
+      set_text_and_record(1, text, model.next_timestamp)
+      let new_model = refresh({
+        ..model,
+        next_timestamp: model.next_timestamp + 1,
+      })
       let actual_text = new_model.editor.get_text()
       let cmd = if actual_text != text {
         @cm.set_doc(model.cm_id, actual_text)

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -930,7 +930,12 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       js_perf_begin("editorTextChangedTotal")
       let new_model = refresh(model)
       js_perf_end("editorTextChangedTotal")
-      (none, new_model)
+      let cmd = if model.use_cm_binding {
+        @cm.set_doc(model.cm_id, new_model.editor.get_text())
+      } else {
+        none
+      }
+      (cmd, new_model)
     }
     EditorNodeSelected(node_id) => {
       let resolved_node_id = if node_id == "" {
@@ -979,11 +984,15 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         next_timestamp: model.next_timestamp + 1,
       })
       let actual_text = new_model.editor.get_text()
-      let cmd = if actual_text != text {
+      let sync_cmd = if actual_text != text {
         @cm.set_doc(model.cm_id, actual_text)
       } else {
         none
       }
+      let cmd = @rabbita.batch([
+        sync_cmd,
+        @rabbita.effect(fn() { js_after_binding_local_edit(actual_text) }),
+      ])
       (cmd, new_model)
     }
     CmSelectionChanged(_range) =>

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -5,6 +5,9 @@ using @html {button, div, p, span, text}
 using @rabbita {type Cmd, type Emit, type Html, none}
 
 ///|
+using @sub {type Sub}
+
+///|
 /// Parse a node ID string into a NodeId, returning None on invalid input.
 fn parse_node_id(s : String) -> @canopy_core.NodeId? {
   let n = @string.parse_int(s) catch { _ => return None }
@@ -27,6 +30,7 @@ fn init_model() -> Model {
   // Falls back to "local" if JS hasn't set it (e.g. test environment).
   let agent_id = js_get_agent_id()
   let agent_id = if agent_id == "" { "local" } else { agent_id }
+  let use_cm_binding = js_use_cm_binding()
   // Create the editor through the crdt module so it sets the singleton (editor.val).
   // JS (main.ts) will reuse handle=1 instead of creating a second editor.
   let _handle = @ffi.create_editor_with_undo(agent_id, 500)
@@ -42,6 +46,8 @@ fn init_model() -> Model {
     editor,
     companion,
     outline_state,
+    cm_id: "canopy-text-editor",
+    use_cm_binding,
     mode: Text,
     workspace: {
       outline_visible: true,
@@ -61,6 +67,42 @@ fn init_model() -> Model {
     drop_position: None,
     intent_log: [],
   }
+}
+
+///|
+fn cm_mount_cmd(emit : Emit[Msg], model : Model) -> Cmd {
+  @cm.mount(
+    model.cm_id,
+    "canopy-text-editor",
+    init_doc=model.editor.get_text(),
+    failed=emit.map(message => {
+      ignore(message)
+      SyncStatusChanged("")
+    }),
+  )
+}
+
+///|
+fn sync_editor_after_text_change(
+  model : Model,
+  text : String,
+  legacy : Cmd,
+) -> Cmd {
+  if model.use_cm_binding {
+    @rabbita.batch([legacy, @cm.set_doc(model.cm_id, text)])
+  } else {
+    legacy
+  }
+}
+
+///|
+fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
+  guard model.use_cm_binding else { return @sub.none }
+  @cm.listen(
+    model.cm_id,
+    doc=emit.map(text => CmDocChanged(text)),
+    selection=emit.map(range => CmSelectionChanged(range)),
+  )
 }
 
 ///|
@@ -279,7 +321,8 @@ fn apply_structural_edit_request(
         next_timestamp: model.next_timestamp + 1,
       })
       let text = new_model.editor.get_text()
-      let cmd = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
+      let legacy = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
+      let cmd = sync_editor_after_text_change(new_model, text, legacy)
       (cmd, new_model)
     }
     Err(_) => (none, model)
@@ -414,12 +457,14 @@ fn execute_action(
         Ok(_) => {
           push_intent(model, op)
           js_set_overlay_open(false)
-          let cmd = @rabbita.effect(fn() { js_reconcile_after_tree_edit() })
           let new_model = refresh({
             ..model,
             next_timestamp: model.next_timestamp + 1,
             overlay: closed_overlay(),
           })
+          let text = new_model.editor.get_text()
+          let legacy = @rabbita.effect(fn() { js_reconcile_after_tree_edit() })
+          let cmd = sync_editor_after_text_change(new_model, text, legacy)
           (cmd, new_model)
         }
         Err(err) => {
@@ -549,7 +594,8 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       if did_undo {
         let new_model = refresh(model)
         let text = new_model.editor.get_text()
-        let cmd = @rabbita.effect(fn() { js_sync_and_broadcast(text) })
+        let legacy = @rabbita.effect(fn() { js_sync_and_broadcast(text) })
+        let cmd = sync_editor_after_text_change(new_model, text, legacy)
         (cmd, new_model)
       } else {
         (none, model)
@@ -560,7 +606,8 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       if did_redo {
         let new_model = refresh(model)
         let text = new_model.editor.get_text()
-        let cmd = @rabbita.effect(fn() { js_sync_and_broadcast(text) })
+        let legacy = @rabbita.effect(fn() { js_sync_and_broadcast(text) })
+        let cmd = sync_editor_after_text_change(new_model, text, legacy)
         (cmd, new_model)
       } else {
         (none, model)
@@ -570,7 +617,8 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       model.editor.set_text(example_text)
       let new_model = refresh(model)
       let text = new_model.editor.get_text()
-      let cmd = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
+      let legacy = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
+      let cmd = sync_editor_after_text_change(new_model, text, legacy)
       (cmd, new_model)
     }
     OutlineNodeClicked(node_id) => {
@@ -631,7 +679,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         { ..model, selected_node: new_selected, outline_state, highlight_set },
       )
     }
-    OutlineStructuralEdit(tree_op) => {
+    OutlineStructuralEdit(tree_op) =>
       match
         @lambda.apply_lambda_tree_edit(
           model.editor,
@@ -667,7 +715,10 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
             None => @immut/hashset.new()
           }
           let text = new_model.editor.get_text()
-          let cmd = @rabbita.effect(fn() { js_reconcile_editor_with_text(text) })
+          let legacy = @rabbita.effect(fn() {
+            js_reconcile_editor_with_text(text)
+          })
+          let cmd = sync_editor_after_text_change(new_model, text, legacy)
           (
             cmd,
             {
@@ -680,7 +731,6 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         }
         Err(_) => (none, model)
       }
-    }
     OpenActionOverlayFromOutline => {
       let node_id_str = match model.selected_node {
         Some(s) => s
@@ -860,9 +910,10 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
                 next_timestamp: model.next_timestamp + 1,
               })
               let text = new_model.editor.get_text()
-              let cmd = @rabbita.effect(fn() {
+              let legacy = @rabbita.effect(fn() {
                 js_reconcile_editor_with_text(text)
               })
+              let cmd = sync_editor_after_text_change(new_model, text, legacy)
               (cmd, new_model)
             }
             Err(_) => (none, model)
@@ -917,6 +968,22 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         (none, new_model)
       }
     }
+    CmDocChanged(text) => {
+      model.editor.set_text(text)
+      let new_model = refresh(model)
+      let actual_text = new_model.editor.get_text()
+      let cmd = if actual_text != text {
+        @cm.set_doc(model.cm_id, actual_text)
+      } else {
+        none
+      }
+      (cmd, new_model)
+    }
+    CmSelectionChanged(_range) =>
+      // PR 1 keeps peer-cursor broadcasting on the existing TS path; selection
+      // handling moves to the binding in PR 2+.
+      (none, model)
+    CmFocusChanged(_) => (none, model)
   }
 }
 
@@ -996,7 +1063,19 @@ fn view(dispatch : Emit[Msg], model : Model) -> Html {
 }
 
 ///|
+#warnings("-alert_unstable")
 fn main {
-  let app = @rabbita.cell(model=init_model(), update~, view~)
-  @rabbita.new(app).mount("app")
+  let initial_model = init_model()
+  let (emit, app) = @rabbita.cell_with_emit(
+    model=initial_model,
+    update~,
+    view~,
+    subscriptions~,
+  )
+  let app = @rabbita.new(app)
+  if initial_model.use_cm_binding {
+    app..with_init(cm_mount_cmd(emit, initial_model)).mount("app")
+  } else {
+    app.mount("app")
+  }
 }

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -63,6 +63,8 @@ pub struct Model {
   editor : @editor.SyncEditor[@ast.Term]
   companion : @lambda.LambdaCompanion
   outline_state : @proj.TreeEditorState[@ast.Term]
+  cm_id : String
+  use_cm_binding : Bool
   mode : EditorMode
   workspace : WorkspaceLayout
   selected_node : String?

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -65,6 +65,7 @@ pub struct Model {
   outline_state : @proj.TreeEditorState[@ast.Term]
   cm_id : String
   use_cm_binding : Bool
+  mounted : Bool
   mode : EditorMode
   workspace : WorkspaceLayout
   selected_node : String?

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub" @sub,
+  "dowdiness/rabbita_codemirror" @cm,
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,
   "dowdiness/canopy/editor" @editor,
@@ -19,6 +21,8 @@ import {
   "dowdiness/graphviz/lib/layout" @gv_layout,
   "dowdiness/graphviz/lib/svg" @gv_svg,
 }
+
+supported_targets = "js"
 
 options(
   "is-main": true,

--- a/examples/ideal/main/msg.mbt
+++ b/examples/ideal/main/msg.mbt
@@ -1,4 +1,5 @@
 ///|
+#warnings("-unused_constructor")
 pub enum Msg {
   // Mode & layout
   SetMode(EditorMode)
@@ -43,4 +44,7 @@ pub enum Msg {
   EditorTextChanged
   EditorNodeSelected(String)
   EditorStructuralEdit(op~ : String, node_id~ : String)
+  CmDocChanged(String)
+  CmSelectionChanged(@cm.SelRange)
+  CmFocusChanged(Bool)
 }

--- a/examples/ideal/main/msg.mbt
+++ b/examples/ideal/main/msg.mbt
@@ -44,6 +44,7 @@ pub enum Msg {
   EditorTextChanged
   EditorNodeSelected(String)
   EditorStructuralEdit(op~ : String, node_id~ : String)
+  CmMounted
   CmDocChanged(String)
   CmSelectionChanged(@cm.SelRange)
   CmFocusChanged(Bool)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -112,6 +112,7 @@ pub struct Model {
   outline_state : @projection.TreeEditorState[@ast.Term]
   cm_id : String
   use_cm_binding : Bool
+  mounted : Bool
   mode : EditorMode
   workspace : WorkspaceLayout
   selected_node : String?
@@ -159,6 +160,7 @@ pub enum Msg {
   EditorTextChanged
   EditorNodeSelected(String)
   EditorStructuralEdit(op~ : String, node_id~ : String)
+  CmMounted
   CmDocChanged(String)
   CmSelectionChanged(@rabbita_codemirror.SelRange)
   CmFocusChanged(Bool)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -9,6 +9,7 @@ import {
   "dowdiness/canopy/projection",
   "dowdiness/event-graph-walker/history",
   "dowdiness/lambda/ast",
+  "dowdiness/rabbita_codemirror",
   "moonbitlang/core/immut/hashset",
 }
 
@@ -109,6 +110,8 @@ pub struct Model {
   editor : @editor.SyncEditor[@ast.Term]
   companion : @companion.LambdaCompanion
   outline_state : @projection.TreeEditorState[@ast.Term]
+  cm_id : String
+  use_cm_binding : Bool
   mode : EditorMode
   workspace : WorkspaceLayout
   selected_node : String?
@@ -156,6 +159,9 @@ pub enum Msg {
   EditorTextChanged
   EditorNodeSelected(String)
   EditorStructuralEdit(op~ : String, node_id~ : String)
+  CmDocChanged(String)
+  CmSelectionChanged(@rabbita_codemirror.SelRange)
+  CmFocusChanged(Bool)
 }
 
 type NodeActionContext

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -21,12 +21,24 @@ fn hidden_trigger(
 ///|
 fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   let attrs = @html.Attrs::build().id("canopy-editor")
+  let hidden_attrs = @html.Attrs::build()
+    .id("canopy-editor")
+    .class("hidden-trigger")
+    .aria_hidden("true")
+    .tabindex(-1)
+  let cm_attrs = @html.Attrs::build().id("canopy-text-editor")
+  let hidden_cm_attrs = @html.Attrs::build()
+    .id("canopy-text-editor")
+    .class("hidden-trigger")
+    .aria_hidden("true")
+    .tabindex(-1)
   let main_attrs = @html.Attrs::build().role("main").aria_label("Code editor")
   if model.use_cm_binding {
-    // Web Component owns structure mode + non-text events; binding owns text-mode CM6 via `#canopy-text-editor`.
+    let text_attrs = if model.mode == Text { cm_attrs } else { hidden_cm_attrs }
+    let host_attrs = if model.mode == Text { hidden_attrs } else { attrs }
     div(class="editor-wrapper", attrs=main_attrs, [
-      div(attrs=@html.Attrs::build().id("canopy-text-editor"), nothing),
-      node("canopy-editor", attrs, [@html.text("")]),
+      div(attrs=text_attrs, nothing),
+      node("canopy-editor", host_attrs, [@html.text("")]),
       // Hidden buttons clicked by JS for non-text-mode paths.
       // aria-hidden + tabindex=-1 keeps them out of a11y flow.
       hidden_trigger(

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -23,8 +23,10 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   let attrs = @html.Attrs::build().id("canopy-editor")
   let main_attrs = @html.Attrs::build().role("main").aria_label("Code editor")
   if model.use_cm_binding {
+    // Web Component owns structure mode + non-text events; binding owns text-mode CM6 via `#canopy-text-editor`.
     div(class="editor-wrapper", attrs=main_attrs, [
       div(attrs=@html.Attrs::build().id("canopy-text-editor"), nothing),
+      node("canopy-editor", attrs, [@html.text("")]),
       // Hidden buttons clicked by JS for non-text-mode paths.
       // aria-hidden + tabindex=-1 keeps them out of a11y flow.
       hidden_trigger(
@@ -43,6 +45,16 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
         "canopy-action-key-trigger",
       ),
       hidden_trigger(dispatch, LongPressTriggered, "canopy-long-press-trigger"),
+      hidden_trigger(
+        dispatch,
+        EditorNodeSelected(""),
+        "canopy-editor-node-selected",
+      ),
+      hidden_trigger(
+        dispatch,
+        EditorStructuralEdit(op="", node_id=""),
+        "canopy-editor-structural-edit",
+      ),
     ])
   } else {
     div(class="editor-wrapper", attrs=main_attrs, [

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -1,5 +1,5 @@
 ///|
-using @html {node}
+using @html {node, nothing}
 
 ///|
 fn hidden_trigger(
@@ -19,35 +19,64 @@ fn hidden_trigger(
 }
 
 ///|
-fn view_editor(
-  dispatch : @rabbita.Emit[Msg],
-  _model : Model,
-) -> @rabbita.Html {
+fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   let attrs = @html.Attrs::build().id("canopy-editor")
   let main_attrs = @html.Attrs::build().role("main").aria_label("Code editor")
-  div(class="editor-wrapper", attrs=main_attrs, [
-    node("canopy-editor", attrs, [@html.text("")]),
-    // Hidden buttons clicked by JS when the Web Component forwards events
-    // back into Rabbita. aria-hidden + tabindex=-1 keeps them out of a11y flow.
-    hidden_trigger(
-      dispatch,
-      SyncStatusChanged(""),
-      "canopy-sync-status-trigger",
-    ),
-    hidden_trigger(dispatch, OpenActionOverlay, "canopy-action-overlay-trigger"),
-    hidden_trigger(dispatch, ActionKeyPressed(""), "canopy-action-key-trigger"),
-    hidden_trigger(dispatch, LongPressTriggered, "canopy-long-press-trigger"),
-    // Protocol-based triggers (Phase 4) — replacing global-state bridge
-    hidden_trigger(dispatch, EditorTextChanged, "canopy-editor-text-changed"),
-    hidden_trigger(
-      dispatch,
-      EditorNodeSelected(""),
-      "canopy-editor-node-selected",
-    ),
-    hidden_trigger(
-      dispatch,
-      EditorStructuralEdit(op="", node_id=""),
-      "canopy-editor-structural-edit",
-    ),
-  ])
+  if model.use_cm_binding {
+    div(class="editor-wrapper", attrs=main_attrs, [
+      div(attrs=@html.Attrs::build().id("canopy-text-editor"), nothing),
+      // Hidden buttons clicked by JS for non-text-mode paths.
+      // aria-hidden + tabindex=-1 keeps them out of a11y flow.
+      hidden_trigger(
+        dispatch,
+        SyncStatusChanged(""),
+        "canopy-sync-status-trigger",
+      ),
+      hidden_trigger(
+        dispatch,
+        OpenActionOverlay,
+        "canopy-action-overlay-trigger",
+      ),
+      hidden_trigger(
+        dispatch,
+        ActionKeyPressed(""),
+        "canopy-action-key-trigger",
+      ),
+      hidden_trigger(dispatch, LongPressTriggered, "canopy-long-press-trigger"),
+    ])
+  } else {
+    div(class="editor-wrapper", attrs=main_attrs, [
+      node("canopy-editor", attrs, [@html.text("")]),
+      // Hidden buttons clicked by JS when the Web Component forwards events
+      // back into Rabbita. aria-hidden + tabindex=-1 keeps them out of a11y flow.
+      hidden_trigger(
+        dispatch,
+        SyncStatusChanged(""),
+        "canopy-sync-status-trigger",
+      ),
+      hidden_trigger(
+        dispatch,
+        OpenActionOverlay,
+        "canopy-action-overlay-trigger",
+      ),
+      hidden_trigger(
+        dispatch,
+        ActionKeyPressed(""),
+        "canopy-action-key-trigger",
+      ),
+      hidden_trigger(dispatch, LongPressTriggered, "canopy-long-press-trigger"),
+      // Protocol-based triggers (Phase 4) — replacing global-state bridge
+      hidden_trigger(dispatch, EditorTextChanged, "canopy-editor-text-changed"),
+      hidden_trigger(
+        dispatch,
+        EditorNodeSelected(""),
+        "canopy-editor-node-selected",
+      ),
+      hidden_trigger(
+        dispatch,
+        EditorStructuralEdit(op="", node_id=""),
+        "canopy-editor-structural-edit",
+      ),
+    ])
+  }
 }

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -45,6 +45,7 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
         "canopy-action-key-trigger",
       ),
       hidden_trigger(dispatch, LongPressTriggered, "canopy-long-press-trigger"),
+      hidden_trigger(dispatch, EditorTextChanged, "canopy-editor-text-changed"),
       hidden_trigger(
         dispatch,
         EditorNodeSelected(""),

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -5,6 +5,9 @@
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita"
     },
+    "dowdiness/rabbita_codemirror": {
+      "path": "../../lib/rabbita_codemirror"
+    },
     "dowdiness/canopy": {
       "path": "../.."
     },

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -9,6 +9,8 @@ import type { CrdtModule } from './types';
 import { peerCursors, updatePeerCursors } from "./cm6-peer-cursors";
 import type { PeerCursor } from "./cm6-peer-cursors";
 
+const USE_CM_BINDING = (globalThis as any).__canopy_use_cm_binding === true;
+
 /** Syntax highlighting colors matching the Canopy design tokens */
 const lambdaHighlightStyle = HighlightStyle.define([
   { tag: t.keyword, color: "#c792ea" },                        // --canopy-keyword
@@ -111,7 +113,7 @@ export class CanopyEditor extends HTMLElement {
       if (this.structureSession) {
         this.structureSession.setReadonly(ro);
       }
-      if (this.cmView) {
+      if (this.cmView && !USE_CM_BINDING) {
         // Remount CM6 to apply readonly (no hot reconfigure API for editable)
         this.destroyCm();
         this.editorContainer.innerHTML = '';
@@ -163,6 +165,7 @@ export class CanopyEditor extends HTMLElement {
   // ── Text Mode: single CM6 showing raw source text ──────
 
   private mountTextMode(): void {
+    if (USE_CM_BINDING) return;
     this.destroyPm();
     if (this.cmView) return; // already mounted
 

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -9,7 +9,9 @@ import type { CrdtModule } from './types';
 import { peerCursors, updatePeerCursors } from "./cm6-peer-cursors";
 import type { PeerCursor } from "./cm6-peer-cursors";
 
-const USE_CM_BINDING = (globalThis as any).__canopy_use_cm_binding === true;
+function isCmBindingActive(): boolean {
+  return (globalThis as any).__canopy_use_cm_binding === true;
+}
 
 /** Syntax highlighting colors matching the Canopy design tokens */
 const lambdaHighlightStyle = HighlightStyle.define([
@@ -113,7 +115,7 @@ export class CanopyEditor extends HTMLElement {
       if (this.structureSession) {
         this.structureSession.setReadonly(ro);
       }
-      if (this.cmView && !USE_CM_BINDING) {
+      if (this.cmView && !isCmBindingActive()) {
         // Remount CM6 to apply readonly (no hot reconfigure API for editable)
         this.destroyCm();
         this.editorContainer.innerHTML = '';
@@ -165,7 +167,7 @@ export class CanopyEditor extends HTMLElement {
   // ── Text Mode: single CM6 showing raw source text ──────
 
   private mountTextMode(): void {
-    if (USE_CM_BINDING) return;
+    if (isCmBindingActive()) return;
     this.destroyPm();
     if (this.cmView) return; // already mounted
 

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -23,6 +23,7 @@ type CanopyGlobal = typeof globalThis & {
   __canopy_pending_action_overlay_node?: string | null;
   __canopy_overlay_open?: boolean;
   __canopy_pending_action_key?: string | null;
+  __canopy_trigger_autosave?: () => void;
 };
 
 const canopyGlobal = globalThis as CanopyGlobal;
@@ -103,6 +104,19 @@ function saveNow(handle: number, roomId: string, crdt: CrdtModule) {
   }
 }
 
+function triggerAutosave() {
+  if (canopyGlobal.__canopy_crdt && canopyGlobal.__canopy_crdt_handle != null) {
+    const roomId = location.hash.slice(1);
+    if (roomId) {
+      saveToLocalStorage(
+        canopyGlobal.__canopy_crdt_handle,
+        roomId,
+        canopyGlobal.__canopy_crdt,
+      );
+    }
+  }
+}
+
 /** Generate a deterministic color from agent ID (hash -> HSL with fixed S/L). */
 function agentColor(agentId: string): string {
   let hash = 0;
@@ -142,26 +156,15 @@ function wireEditorEvents(el: CanopyEditor) {
   editorEventsController = new AbortController();
   const { signal } = editorEventsController;
 
-  if (!USE_CM_BINDING) {
-    el.addEventListener(CanopyEvents.TEXT_CHANGE, () => {
-      // Text was already applied by canopy-editor.ts via handle_text_intent FFI.
-      // Trigger Rabbita outline refresh via the protocol-based trigger.
-      recordPerfSpan("textChangedToRabbitaTrigger", () => {
-        clickTrigger('canopy-editor-text-changed');
-      });
-      // Debounced save to localStorage
-      if (canopyGlobal.__canopy_crdt && canopyGlobal.__canopy_crdt_handle != null) {
-        const roomId = location.hash.slice(1);
-        if (roomId) {
-          saveToLocalStorage(
-            canopyGlobal.__canopy_crdt_handle,
-            roomId,
-            canopyGlobal.__canopy_crdt,
-          );
-        }
-      }
-    }, { signal });
-  }
+  el.addEventListener(CanopyEvents.TEXT_CHANGE, () => {
+    // Text was already applied by canopy-editor.ts via handle_text_intent FFI
+    // or by remote sync. Trigger Rabbita outline refresh via the protocol trigger.
+    recordPerfSpan("textChangedToRabbitaTrigger", () => {
+      clickTrigger('canopy-editor-text-changed');
+    });
+    // Debounced save to localStorage
+    (canopyGlobal.__canopy_trigger_autosave ?? triggerAutosave)();
+  }, { signal });
   el.addEventListener(CanopyEvents.NODE_SELECTED, ((event: Event) => {
     const { nodeId } = (event as CustomEvent<NodeSelectedDetail>).detail ?? {};
     canopyGlobal.__canopy_pending_node_selection = nodeId ?? null;
@@ -319,6 +322,7 @@ function doMount(el: CanopyEditor, crdt: CrdtModule) {
   canopyGlobal.__canopy_crdt_handle = handle;
   canopyGlobal.__canopy_pending_node_selection = null;
   canopyGlobal.__canopy_pending_structural_edit = null;
+  canopyGlobal.__canopy_trigger_autosave = triggerAutosave;
 
   // Restore from localStorage if available
   try {

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -29,6 +29,7 @@ const canopyGlobal = globalThis as CanopyGlobal;
 const AGENT_ID_STORAGE_KEY = 'canopy-ideal-agent-id';
 const STORAGE_KEY_PREFIX = 'canopy-doc-';
 const SKIP_SYNC = import.meta.env.VITE_CANOPY_SKIP_SYNC === '1';
+const USE_CM_BINDING = import.meta.env.VITE_CANOPY_USE_CM_BINDING === '1';
 let crdtPromise: Promise<CrdtModule> | null = null;
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let activeSyncClient: SyncClient | null = null;
@@ -41,6 +42,7 @@ function loadCrdtModule(): Promise<CrdtModule> {
     // Set agent ID globally BEFORE importing the MoonBit module.
     // MoonBit's init_model reads this to create the CRDT editor with a unique agent.
     canopyGlobal.__canopy_agent_id = getSessionAgentId();
+    (globalThis as any).__canopy_use_cm_binding = USE_CM_BINDING;
     // Loading the MoonBit module also runs Rabbita's main(), which renders <canopy-editor>.
     crdtPromise = import('@moonbit/ideal-editor') as Promise<CrdtModule>;
   }
@@ -140,24 +142,26 @@ function wireEditorEvents(el: CanopyEditor) {
   editorEventsController = new AbortController();
   const { signal } = editorEventsController;
 
-  el.addEventListener(CanopyEvents.TEXT_CHANGE, () => {
-    // Text was already applied by canopy-editor.ts via handle_text_intent FFI.
-    // Trigger Rabbita outline refresh via the protocol-based trigger.
-    recordPerfSpan("textChangedToRabbitaTrigger", () => {
-      clickTrigger('canopy-editor-text-changed');
-    });
-    // Debounced save to localStorage
-    if (canopyGlobal.__canopy_crdt && canopyGlobal.__canopy_crdt_handle != null) {
-      const roomId = location.hash.slice(1);
-      if (roomId) {
-        saveToLocalStorage(
-          canopyGlobal.__canopy_crdt_handle,
-          roomId,
-          canopyGlobal.__canopy_crdt,
-        );
+  if (!USE_CM_BINDING) {
+    el.addEventListener(CanopyEvents.TEXT_CHANGE, () => {
+      // Text was already applied by canopy-editor.ts via handle_text_intent FFI.
+      // Trigger Rabbita outline refresh via the protocol-based trigger.
+      recordPerfSpan("textChangedToRabbitaTrigger", () => {
+        clickTrigger('canopy-editor-text-changed');
+      });
+      // Debounced save to localStorage
+      if (canopyGlobal.__canopy_crdt && canopyGlobal.__canopy_crdt_handle != null) {
+        const roomId = location.hash.slice(1);
+        if (roomId) {
+          saveToLocalStorage(
+            canopyGlobal.__canopy_crdt_handle,
+            roomId,
+            canopyGlobal.__canopy_crdt,
+          );
+        }
       }
-    }
-  }, { signal });
+    }, { signal });
+  }
   el.addEventListener(CanopyEvents.NODE_SELECTED, ((event: Event) => {
     const { nodeId } = (event as CustomEvent<NodeSelectedDetail>).detail ?? {};
     canopyGlobal.__canopy_pending_node_selection = nodeId ?? null;
@@ -199,28 +203,30 @@ function wireEditorEvents(el: CanopyEditor) {
     canopyGlobal.__canopy_pending_structural_edit = { op, nodeId };
     clickTrigger('canopy-editor-structural-edit');
   }) as EventListener, { signal });
-  el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {
-    if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
-    const crdt = canopyGlobal.__canopy_crdt;
-    const handle = canopyGlobal.__canopy_crdt_handle;
-    const didUndo = crdt.handle_undo(handle);
-    if (didUndo) {
-      el.syncAfterExternalChange();
-      el.notifyLocalChange();
-      clickTrigger('canopy-editor-text-changed');
-    }
-  }, { signal });
-  el.addEventListener(CanopyEvents.REQUEST_REDO, () => {
-    if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
-    const crdt = canopyGlobal.__canopy_crdt;
-    const handle = canopyGlobal.__canopy_crdt_handle;
-    const didRedo = crdt.handle_redo(handle);
-    if (didRedo) {
-      el.syncAfterExternalChange();
-      el.notifyLocalChange();
-      clickTrigger('canopy-editor-text-changed');
-    }
-  }, { signal });
+  if (!USE_CM_BINDING) {
+    el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {
+      if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
+      const crdt = canopyGlobal.__canopy_crdt;
+      const handle = canopyGlobal.__canopy_crdt_handle;
+      const didUndo = crdt.handle_undo(handle);
+      if (didUndo) {
+        el.syncAfterExternalChange();
+        el.notifyLocalChange();
+        clickTrigger('canopy-editor-text-changed');
+      }
+    }, { signal });
+    el.addEventListener(CanopyEvents.REQUEST_REDO, () => {
+      if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
+      const crdt = canopyGlobal.__canopy_crdt;
+      const handle = canopyGlobal.__canopy_crdt_handle;
+      const didRedo = crdt.handle_redo(handle);
+      if (didRedo) {
+        el.syncAfterExternalChange();
+        el.notifyLocalChange();
+        clickTrigger('canopy-editor-text-changed');
+      }
+    }, { signal });
+  }
   el.addEventListener(CanopyEvents.ACTION_OVERLAY_OPEN, ((event: Event) => {
     const { nodeId } = (event as CustomEvent).detail ?? {};
     canopyGlobal.__canopy_pending_action_overlay_node = nodeId ?? null;

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -206,30 +206,28 @@ function wireEditorEvents(el: CanopyEditor) {
     canopyGlobal.__canopy_pending_structural_edit = { op, nodeId };
     clickTrigger('canopy-editor-structural-edit');
   }) as EventListener, { signal });
-  if (!USE_CM_BINDING) {
-    el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {
-      if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
-      const crdt = canopyGlobal.__canopy_crdt;
-      const handle = canopyGlobal.__canopy_crdt_handle;
-      const didUndo = crdt.handle_undo(handle);
-      if (didUndo) {
-        el.syncAfterExternalChange();
-        el.notifyLocalChange();
-        clickTrigger('canopy-editor-text-changed');
-      }
-    }, { signal });
-    el.addEventListener(CanopyEvents.REQUEST_REDO, () => {
-      if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
-      const crdt = canopyGlobal.__canopy_crdt;
-      const handle = canopyGlobal.__canopy_crdt_handle;
-      const didRedo = crdt.handle_redo(handle);
-      if (didRedo) {
-        el.syncAfterExternalChange();
-        el.notifyLocalChange();
-        clickTrigger('canopy-editor-text-changed');
-      }
-    }, { signal });
-  }
+  el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {
+    if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
+    const crdt = canopyGlobal.__canopy_crdt;
+    const handle = canopyGlobal.__canopy_crdt_handle;
+    const didUndo = crdt.handle_undo(handle);
+    if (didUndo) {
+      el.syncAfterExternalChange();
+      el.notifyLocalChange();
+      clickTrigger('canopy-editor-text-changed');
+    }
+  }, { signal });
+  el.addEventListener(CanopyEvents.REQUEST_REDO, () => {
+    if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
+    const crdt = canopyGlobal.__canopy_crdt;
+    const handle = canopyGlobal.__canopy_crdt_handle;
+    const didRedo = crdt.handle_redo(handle);
+    if (didRedo) {
+      el.syncAfterExternalChange();
+      el.notifyLocalChange();
+      clickTrigger('canopy-editor-text-changed');
+    }
+  }, { signal });
   el.addEventListener(CanopyEvents.ACTION_OVERLAY_OPEN, ((event: Event) => {
     const { nodeId } = (event as CustomEvent).detail ?? {};
     canopyGlobal.__canopy_pending_action_overlay_node = nodeId ?? null;


### PR DESCRIPTION
## Summary

PR 1 of the §P2.5 two-step migration. Adds the `rabbita_codemirror` binding wiring to `examples/ideal` behind `VITE_CANOPY_USE_CM_BINDING=1`, **without deleting any legacy code**. With flag off (default), the existing Web Component text-mode path runs unchanged; with flag on, the binding owns CM6 in text mode while structure mode (PM) is untouched.

PR 2 (followup) will flip the default + delete the legacy text-mode code surface (13 FFIs, `mountTextMode`, three `Editor*` Msg variants, text-mode listeners) per plan §P2.5 break points B1–B3.

## Scope (additive only)

- `bridge_ffi.mbt` — adds `js_use_cm_binding()` FFI (Bool getter reading `globalThis.__canopy_use_cm_binding`).
- `model.mbt` — adds `cm_id : String` and `use_cm_binding : Bool` to `Model`.
- `msg.mbt` — adds `CmDocChanged(String)`, `CmSelectionChanged(@cm.SelRange)`, `CmFocusChanged(Bool)`. Legacy `EditorTextChanged/EditorNodeSelected/EditorStructuralEdit` retained.
- `main.mbt` — switches to `cell_with_emit` + `subscriptions~`; `with_init(@cm.mount(...))` chained conditionally on flag. Five text-reconcile call sites factored through `sync_editor_after_text_change`, which batches `@cm.set_doc` alongside the legacy effect when the flag is on. New arms for the three `Cm*` messages (`CmDocChanged` routes to `editor.set_text` + canonicalize; `CmSelectionChanged`/`CmFocusChanged` are no-ops for PR 1, deferred per comments).
- `view_editor.mbt` — branches on `model.use_cm_binding`: flag-on renders `<div id="canopy-text-editor">` + non-text-mode hidden triggers; flag-off renders the legacy Web Component + all seven hidden triggers.
- `moon.pkg` / `moon.mod.json` — adds `@cm` (`dowdiness/rabbita_codemirror`) + `@sub` imports; declares `supported_targets = "js"` so the JS-only binding passes `moon check`.
- `canopy-editor.ts` — `mountTextMode()` short-circuits when `__canopy_use_cm_binding === true`; readonly remount in `attributeChangedCallback` skipped under the flag.
- `main.ts` — sets `globalThis.__canopy_use_cm_binding` before importing the MoonBit module (same mechanism as `__canopy_agent_id`); wraps the three text-mode listeners (`TEXT_CHANGE`, `REQUEST_UNDO`, `REQUEST_REDO`) in `!USE_CM_BINDING` so they don't double-handle when the binding is active.

### Notes on design choices

- Mount failure maps to `SyncStatusChanged("")` (smallest existing no-op Msg) rather than introducing a new failure variant — keeps PR 1 additive at the Msg level too.
- Peer-cursor broadcast stays on the existing TS path in PR 1; `CmSelectionChanged` is a deliberate no-op deferred to PR 2+.

## Test plan

- [x] `cd examples/ideal && moon check` — clean.
- [x] `cd examples/ideal && moon test` — 23/23 passed.
- [x] `moon test` (workspace root) — 984/984 passed.
- [x] `cd examples/ideal/web && npm run build` — clean (only the pre-existing chunk-size advisory).
- [ ] Playwright e2e in both flag states (planned post-merge before flipping the default in PR 2).
- [ ] Manual: type / undo / redo / text↔structure switch / load example / two browsers / peer cursors in both flag states.
- [ ] Per-keystroke `CmDocChanged → emit → update` latency vs legacy direct path (>5ms p50 budget per plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional CodeMirror 6 editor integration with feature-flagged conditional mounting and two-way text sync.
  * New editor events for doc changes, selection, and focus; unified sync path for all text-change flows.
  * Exposed JS hooks to report local edits and to trigger a global/autosave callback.

* **Chores**
  * Declared JavaScript build target in package configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->