### PR TITLE
feat(codemirror): expose selection and extension hooks

### DIFF
--- a/lib/rabbita_codemirror/codemirror.mbt
+++ b/lib/rabbita_codemirror/codemirror.mbt
@@ -19,6 +19,13 @@ pub struct SelRange {
 }
 
 ///|
+/// Create a primary CodeMirror selection range from document offsets.
+#cfg(target="js")
+pub fn SelRange::new(from : Int, to : Int) -> SelRange {
+  { from, to }
+}
+
+///|
 #cfg(target="js")
 priv struct CmEntry {
   view : @js_ffi.CmView
@@ -27,6 +34,7 @@ priv struct CmEntry {
   keymap_comp : @js_ffi.Compartment
   line_numbers_comp : @js_ffi.Compartment
   line_wrapping_comp : @js_ffi.Compartment
+  extension_comp : @js_ffi.Compartment
   listener_comp : @js_ffi.Compartment
   update_disposable : @js_ffi.Disposable
 }
@@ -234,12 +242,14 @@ fn build_initial_extension(
   keymap_comp : @js_ffi.Compartment,
   line_numbers_comp : @js_ffi.Compartment,
   line_wrapping_comp : @js_ffi.Compartment,
+  extension_comp : @js_ffi.Compartment,
   listener_comp : @js_ffi.Compartment,
   initial_theme : @theme.Theme?,
   initial_readonly : Bool,
   initial_keymap : @keymap.Keymap?,
   initial_line_numbers : Bool,
   initial_line_wrapping : Bool,
+  initial_extension : @js_ffi.Extension,
 ) -> @js_ffi.Extension {
   @js_ffi.js_extension_combine([
     @js_ffi.js_compartment_of(theme_comp, theme_extension(initial_theme)),
@@ -256,6 +266,7 @@ fn build_initial_extension(
       line_wrapping_comp,
       line_wrapping_extension(cm_value, initial_line_wrapping),
     ),
+    @js_ffi.js_compartment_of(extension_comp, initial_extension),
     @js_ffi.js_compartment_of(listener_comp, empty_extension()),
   ])
 }
@@ -324,6 +335,10 @@ fn cm_sub_loader(
 
 ///|
 /// Mount or replace a named CodeMirror editor.
+///
+/// `initial_extension` is called with the same loaded CodeMirror module used
+/// to create the view, so consumers can build custom extensions without mixing
+/// incompatible `@codemirror/state` instances.
 #cfg(target="js")
 pub fn mount(
   id : String,
@@ -337,6 +352,7 @@ pub fn mount(
   initial_line_wrapping? : Bool = false,
   on_mounted? : @cmd.Cmd,
   failed? : @cmd.Emit[String],
+  initial_extension? : ((@js_value.Value) -> @js_ffi.Extension raise)? = None,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(kind=Immediately, scheduler => {
     @js_value.async_run(() => {
@@ -353,6 +369,21 @@ pub fn mount(
       guard loaded is Some(value) else { return }
       let cm = @js_ffi.cm_module_of(value)
       let cm_value = module_value(cm)
+      let custom_extension = match initial_extension {
+        Some(make_extension) =>
+          Some(make_extension(cm_value)) catch {
+            e => {
+              report_failure(
+                scheduler,
+                failed,
+                "codemirror extension factory failed: \{e.to_string()}",
+              )
+              None
+            }
+          }
+        None => Some(empty_extension())
+      }
+      guard custom_extension is Some(custom_extension) else { return }
 
       if editors.get(id) is Some(old_entry) {
         dispose_entry(old_entry)
@@ -364,11 +395,12 @@ pub fn mount(
       let keymap_comp = @js_ffi.js_compartment_new(cm)
       let line_numbers_comp = @js_ffi.js_compartment_new(cm)
       let line_wrapping_comp = @js_ffi.js_compartment_new(cm)
+      let extension_comp = @js_ffi.js_compartment_new(cm)
       let listener_comp = @js_ffi.js_compartment_new(cm)
       let extension = build_initial_extension(
         cm_value, theme_comp, readonly_comp, keymap_comp, line_numbers_comp, line_wrapping_comp,
-        listener_comp, initial_theme, initial_readonly, initial_keymap, initial_line_numbers,
-        initial_line_wrapping,
+        extension_comp, listener_comp, initial_theme, initial_readonly, initial_keymap,
+        initial_line_numbers, initial_line_wrapping, custom_extension,
       )
       let view = @js_ffi.js_create_view(cm, host_id, init_doc, extension)
       let update_disposable = no_op_update_listener(view, listener_comp)
@@ -379,6 +411,7 @@ pub fn mount(
         keymap_comp,
         line_numbers_comp,
         line_wrapping_comp,
+        extension_comp,
         listener_comp,
         update_disposable,
       }
@@ -471,6 +504,35 @@ pub fn set_selection(
   @cmd.custom_cmd(kind=Immediately, scheduler => {
     with_entry(id, failed, scheduler, entry => {
       @js_ffi.js_dispatch(entry.view, selection_spec(range))
+    })
+  })
+}
+
+///|
+/// Reconfigure the generic extension compartment.
+///
+/// The factory receives the editor's CodeMirror module and should return an
+/// extension built from that module.
+#cfg(target="js")
+pub fn set_extension(
+  id : String,
+  make_extension : (@js_value.Value) -> @js_ffi.Extension raise,
+  failed? : @cmd.Emit[String],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=Immediately, scheduler => {
+    with_entry(id, failed, scheduler, entry => {
+      let extension = Some(make_extension(module_value_of_view(entry.view))) catch {
+        e => {
+          report_failure(
+            scheduler,
+            failed,
+            "codemirror extension factory failed: \{e.to_string()}",
+          )
+          None
+        }
+      }
+      guard extension is Some(extension) else { return }
+      reconfigure(entry.view, entry.extension_comp, extension)
     })
   })
 }

--- a/lib/rabbita_codemirror/codemirror_test.mbt
+++ b/lib/rabbita_codemirror/codemirror_test.mbt
@@ -1,0 +1,14 @@
+///|
+test "SelRange constructor exposes selection offsets to consumers" {
+  let range = SelRange::new(2, 5)
+  inspect(range.from, content="2")
+  inspect(range.to, content="5")
+}
+
+///|
+test "mount accepts extension factory" {
+  let factory : (@js_value.Value) -> @js_ffi.Extension raise = fn(_cm) {
+    @js_ffi.js_extension_combine([])
+  }
+  ignore(mount("test-editor", "test-host", initial_extension=Some(factory)))
+}

--- a/lib/rabbita_codemirror/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/pkg.generated.mbti
@@ -13,11 +13,13 @@ pub fn insert(String, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
 pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool]) -> @sub.Sub
 
-pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String], initial_extension? : ((@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise)?) -> @cmd.Cmd
 
 pub fn replace(String, Int, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
 pub fn set_doc(String, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
+
+pub fn set_extension(String, (@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
 pub fn set_keymap(String, @keymap.Keymap, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
@@ -40,6 +42,7 @@ pub struct SelRange {
   from : Int
   to : Int
 }
+pub fn SelRange::new(Int, Int) -> Self
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

- add `SelRange::new(from, to)` so consumers can construct CodeMirror selection ranges without reaching into read-only struct construction
- add a generic `initial_extension` mount factory and `set_extension` command backed by a private extension compartment
- pass the binding-loaded CodeMirror module into extension factories to avoid mixing incompatible `@codemirror/state` instances
- cover the new public constructor and extension-factory signature with binding tests

## Context

This is a small precursor for the P2.5 PR2 `examples/ideal` flag flip + legacy deletion. PR2 needs to preserve text-mode outline selection and peer-cursor rendering after deleting the old `canopy-editor.ts` CodeMirror owner. This PR keeps the library API generic to CodeMirror and does not add Canopy-specific peer-cursor code.

## Validation

- `moon check`
- `cd lib/rabbita_codemirror && moon test` (986 JS tests passing, 171 wasm-gc tests passing)
- `moon fmt`
- `moon info`
- `git diff --check`
- `cd examples/ideal/web && npm run build`

Design review result before implementation: CLEAR.