### PR TITLE
fix(ideal): route binding edits through model editor

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -978,7 +978,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     CmMounted => (none, { ..model, mounted: true })
     CmDocChanged(text) => {
       // Binding listen sends the full document; use the recording variant so undo keeps working.
-      set_text_and_record(1, text, model.next_timestamp)
+      model.editor.set_text_and_record(text, model.next_timestamp)
       let new_model = refresh({
         ..model,
         next_timestamp: model.next_timestamp + 1,


### PR DESCRIPTION
## Summary

- replace the hardcoded CRDT handle in `CmDocChanged` with `model.editor.set_text_and_record(...)`
- preserve the recording path and existing `model.next_timestamp` increment behavior for undo/redo

## Finding Verification

Still valid. `CmDocChanged` was writing through exported handle `1`, while `refresh(...)` immediately reads from `model.editor`. The current `SyncEditor` API already exposes `set_text_and_record(new_text, timestamp_ms)`, so the minimal fix is to use the model-owned editor directly.

Skipped findings: none in this request.

## Validation

- `cd examples/ideal && moon check`
- `cd examples/ideal && moon test` (23/23 passing)
- `cd examples/ideal && moon fmt`
- `cd examples/ideal && moon info`
- `git diff --check`
- `cd examples/ideal/web && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved editor text synchronization when document changes occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->