### PR TITLE
[codex] add visualizer package

### DIFF
--- a/lib/visualizer/README.md
+++ b/lib/visualizer/README.md
@@ -1,0 +1,20 @@
+# Visualizer
+
+Shared graph visualization adapters for Canopy consumers.
+
+This module keeps visualization outside `dowdiness/incr`. Consumers attach
+driver-owned taps to public `incr` APIs, convert runtime snapshots into a small
+renderer-neutral graph model, then render with the local `dowdiness/graphviz`
+layout and SVG renderer. The Graphviz SVG renderer is backed by the local
+`dowdiness/svg-dsl` module.
+
+The first adapter is `IncrMemoEventTap`, which listens to
+`Runtime::on_memo_event`, records compact memo recompute events, enriches known
+cells through `Runtime::cell_info`, and renders the dependency graph. The tap
+does not publish events back into the same runtime. `detach()` deactivates the
+tap's own listener closure; a stale tap handle will not clear a newer tap that
+replaced it on the same runtime.
+
+Build custom graphs with `VisualGraph(id=...)`, `VisualNode(...)`,
+`VisualEdge(...)`, `graph.add_node(...)`, and `graph.add_edge(...)`; render with
+`graph.to_dot()` or `graph.to_svg()`.

--- a/lib/visualizer/graphviz_render.mbt
+++ b/lib/visualizer/graphviz_render.mbt
@@ -1,0 +1,116 @@
+///|
+fn attr(key : String, value : String) -> @dot.Attribute {
+  { key, value }
+}
+
+///|
+fn attrs(attributes : Array[@dot.Attribute]) -> @dot.AttributeList {
+  { attributes, }
+}
+
+///|
+fn node_id(id : String) -> @dot.NodeId {
+  { id, port: None }
+}
+
+///|
+fn node_color(status : VisualNodeStatus) -> String {
+  match status {
+    Neutral => "#3b4252"
+    Active => "#5e81ac"
+    Changed => "#a3be8c"
+    Failed => "#bf616a"
+  }
+}
+
+///|
+fn node_fill(status : VisualNodeStatus) -> String {
+  match status {
+    Neutral => "#eceff4"
+    Active => "#d8dee9"
+    Changed => "#e5f1dc"
+    Failed => "#f3d6d8"
+  }
+}
+
+///|
+fn node_label(node : VisualNode) -> String {
+  let base = node.label.unwrap_or(node.id)
+  match node.detail {
+    Some(detail) => base + "\n" + detail
+    None => base
+  }
+}
+
+///|
+fn node_statement(node : VisualNode) -> @dot.Statement {
+  NodeStmt(
+    node_id(node.id),
+    Some(
+      attrs([
+        attr("label", node_label(node)),
+        attr("color", node_color(node.status)),
+        attr("fontcolor", "#1f2933"),
+        attr("fillcolor", node_fill(node.status)),
+      ]),
+    ),
+  )
+}
+
+///|
+fn edge_statement(edge : VisualEdge) -> @dot.Statement {
+  let edge_attrs = match edge.label {
+    Some(label) => Some(attrs([attr("label", label)]))
+    None => None
+  }
+  EdgeStmt(node_id(edge.from), [(Directed, node_id(edge.to))], edge_attrs)
+}
+
+///|
+fn VisualGraph::to_dot_graph(self : VisualGraph) -> @dot.Graph {
+  let statements : Array[@dot.Statement] = [
+    AttrStmt(
+      GraphAttr,
+      attrs([attr("rankdir", "LR"), attr("bgcolor", "transparent")]),
+    ),
+    AttrStmt(
+      NodeAttr,
+      attrs([
+        attr("shape", "box"),
+        attr("style", "rounded,filled"),
+        attr("fontname", "Inter"),
+      ]),
+    ),
+    AttrStmt(EdgeAttr, attrs([attr("color", "#6b7280")])),
+  ]
+  for node in self.nodes {
+    statements.push(node_statement(node))
+  }
+  for edge in self.edges {
+    statements.push(edge_statement(edge))
+  }
+  { strict: false, directed: true, id: self.id, statements }
+}
+
+///|
+/// Render this visualization graph as DOT text using the local Graphviz formatter.
+pub fn VisualGraph::to_dot(self : VisualGraph) -> String {
+  @dot.format_graph(self.to_dot_graph())
+}
+
+///|
+/// Render this visualization graph as SVG using the local Graphviz layout and SVG renderer.
+pub fn VisualGraph::to_svg(self : VisualGraph) -> String {
+  let layout = @layout.compute_layout(self.to_dot_graph())
+  @graph_svg.render_svg(layout)
+}
+
+///|
+/// Render this visualization graph as SVG with an explicit Graphviz SVG config.
+pub fn VisualGraph::to_svg_with_config(
+  self : VisualGraph,
+  config : @graph_svg.SvgConfig,
+) -> String {
+  let layout = @layout.compute_layout(self.to_dot_graph())
+  @graph_svg.render_svg_with_config(layout, config)
+}

--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -1,0 +1,271 @@
+///|
+/// Phase of a public `incr` memo recompute event.
+pub(all) enum IncrMemoEventPhase {
+  IncrEntering
+  IncrCompleted
+  IncrAborted
+}
+
+///|
+/// Compact memo-event record captured by `IncrMemoEventTap`.
+pub struct IncrMemoEventRecord {
+  cell_id : @incr.CellId
+  phase : IncrMemoEventPhase
+  started_revision : @incr.Revision
+  elapsed_ns : Int64?
+  verified_at : @incr.Revision?
+  changed_at : @incr.Revision?
+  backdated : Bool
+}
+
+///|
+/// Snapshot node enriched from `Runtime::cell_info`.
+pub struct IncrSnapshotNode {
+  id : @incr.CellId
+  label : String?
+  changed_at : @incr.Revision
+  verified_at : @incr.Revision
+}
+
+///|
+/// Snapshot edge from dependency to dependent cell.
+pub struct IncrSnapshotEdge {
+  from : @incr.CellId
+  to : @incr.CellId
+}
+
+///|
+/// Point-in-time graph and event snapshot for an `incr` runtime.
+pub struct IncrSnapshot {
+  nodes : Array[IncrSnapshotNode]
+  edges : Array[IncrSnapshotEdge]
+  events : Array[IncrMemoEventRecord]
+}
+
+///|
+/// Driver-owned tap that records public `incr` memo events for visualization.
+pub struct IncrMemoEventTap {
+  priv rt : @incr.Runtime
+  priv active : Ref[Bool]
+  priv mut events : Array[IncrMemoEventRecord]
+  priv cells : Array[@incr.CellId]
+}
+
+///|
+fn contains_cell_id(ids : Array[@incr.CellId], id : @incr.CellId) -> Bool {
+  for cell_id in ids {
+    if cell_id == id {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn remember_cell(ids : Array[@incr.CellId], id : @incr.CellId) -> Unit {
+  if !contains_cell_id(ids, id) {
+    ids.push(id)
+  }
+}
+
+///|
+fn copy_events(
+  events : Array[IncrMemoEventRecord],
+) -> Array[IncrMemoEventRecord] {
+  let out : Array[IncrMemoEventRecord] = []
+  for event in events {
+    out.push(event)
+  }
+  out
+}
+
+///|
+fn event_from_memo_event(evt : @incr.MemoEvent) -> IncrMemoEventRecord {
+  match evt {
+    EnteringCompute(e) =>
+      {
+        cell_id: e.cell_id,
+        phase: IncrEntering,
+        started_revision: e.started_revision,
+        elapsed_ns: None,
+        verified_at: None,
+        changed_at: None,
+        backdated: false,
+      }
+    Completed(e) =>
+      {
+        cell_id: e.cell_id,
+        phase: IncrCompleted,
+        started_revision: e.started_revision,
+        elapsed_ns: Some(e.elapsed_ns),
+        verified_at: Some(e.verified_at),
+        changed_at: Some(e.changed_at),
+        backdated: e.backdated,
+      }
+    Aborted(e) =>
+      {
+        cell_id: e.cell_id,
+        phase: IncrAborted,
+        started_revision: e.started_revision,
+        elapsed_ns: Some(e.elapsed_ns),
+        verified_at: None,
+        changed_at: None,
+        backdated: false,
+      }
+  }
+}
+
+///|
+fn IncrMemoEventTap::record(
+  self : IncrMemoEventTap,
+  evt : @incr.MemoEvent,
+) -> Unit {
+  guard self.active.val else { return }
+  let record = event_from_memo_event(evt)
+  remember_cell(self.cells, record.cell_id)
+  self.events.push(record)
+}
+
+///|
+fn snapshot_ids(tap : IncrMemoEventTap) -> Array[@incr.CellId] {
+  let ids : Array[@incr.CellId] = []
+  for id in tap.cells {
+    remember_cell(ids, id)
+  }
+  let mut i = 0
+  while i < ids.length() {
+    let id = ids[i]
+    match tap.rt.cell_info(id) {
+      Some(info) => {
+        for dep in info.dependencies {
+          remember_cell(ids, dep)
+        }
+        for sub in info.subscribers {
+          remember_cell(ids, sub)
+        }
+      }
+      None => ()
+    }
+    i = i + 1
+  }
+  ids
+}
+
+///|
+fn visual_cell_id(id : @incr.CellId) -> String {
+  "cell_" + id.runtime_id.to_string() + "_" + id.id.to_string()
+}
+
+///|
+fn snapshot_node_label(node : IncrSnapshotNode) -> String {
+  match node.label {
+    Some(label) => label
+    None => "cell " + node.id.id.to_string()
+  }
+}
+
+///|
+fn snapshot_node_detail(node : IncrSnapshotNode) -> String {
+  "changed " +
+  node.changed_at.value.to_string() +
+  ", verified " +
+  node.verified_at.value.to_string()
+}
+
+///|
+fn status_for_cell(
+  events : Array[IncrMemoEventRecord],
+  id : @incr.CellId,
+) -> VisualNodeStatus {
+  let mut status = Neutral
+  for event in events {
+    if event.cell_id == id {
+      status = match event.phase {
+        IncrEntering => Active
+        IncrCompleted => if event.backdated { Neutral } else { Changed }
+        IncrAborted => Failed
+      }
+    }
+  }
+  status
+}
+
+///|
+/// Attach an event tap to `rt`.
+///
+/// `incr` allows one memo-event listener per runtime, so attaching replaces
+/// any previous listener owned by the same runtime.
+pub fn IncrMemoEventTap::attach(
+  rt : @incr.Runtime,
+) -> IncrMemoEventTap raise Failure {
+  let tap = { rt, active: Ref(true), events: [], cells: [] }
+  rt.on_memo_event(evt => tap.record(evt))
+  tap
+}
+
+///|
+/// Stop this tap from recording future events.
+///
+/// `incr` exposes replacement and clearing for the runtime listener, but not
+/// listener identity. Deactivating this tap's closure keeps stale handles from
+/// clearing a newer tap that replaced them.
+pub fn IncrMemoEventTap::detach(self : IncrMemoEventTap) -> Unit {
+  self.active.val = false
+}
+
+///|
+/// Drain captured events in arrival order.
+pub fn IncrMemoEventTap::drain_events(
+  self : IncrMemoEventTap,
+) -> Array[IncrMemoEventRecord] {
+  let drained = copy_events(self.events)
+  self.events = []
+  drained
+}
+
+///|
+/// Capture the current known dependency graph plus buffered event history.
+pub fn IncrMemoEventTap::snapshot(self : IncrMemoEventTap) -> IncrSnapshot {
+  let ids = snapshot_ids(self)
+  let nodes : Array[IncrSnapshotNode] = []
+  let edges : Array[IncrSnapshotEdge] = []
+  for id in ids {
+    match self.rt.cell_info(id) {
+      Some(info) => {
+        nodes.push({
+          id,
+          label: info.label,
+          changed_at: info.changed_at,
+          verified_at: info.verified_at,
+        })
+        for dep in info.dependencies {
+          edges.push({ from: dep, to: id })
+        }
+      }
+      None => ()
+    }
+  }
+  { nodes, edges, events: copy_events(self.events) }
+}
+
+///|
+/// Convert an `incr` runtime snapshot to the renderer-neutral visual graph.
+pub fn IncrSnapshot::to_visual_graph(self : IncrSnapshot) -> VisualGraph {
+  let graph = VisualGraph(id="incr")
+  for node in self.nodes {
+    graph.add_node(
+      VisualNode(
+        visual_cell_id(node.id),
+        label=snapshot_node_label(node),
+        detail=snapshot_node_detail(node),
+        status=status_for_cell(self.events, node.id),
+      ),
+    )
+  }
+  for edge in self.edges {
+    graph.add_edge(
+      VisualEdge(visual_cell_id(edge.from), visual_cell_id(edge.to)),
+    )
+  }
+  graph
+}

--- a/lib/visualizer/model.mbt
+++ b/lib/visualizer/model.mbt
@@ -1,0 +1,72 @@
+///|
+/// Rendering state used to style a graph node.
+pub(all) enum VisualNodeStatus {
+  Neutral
+  Active
+  Changed
+  Failed
+}
+
+///|
+/// A node in a renderer-neutral visualization graph.
+pub struct VisualNode {
+  priv id : String
+  priv label : String?
+  priv detail : String?
+  priv status : VisualNodeStatus
+}
+
+///|
+/// A directed edge in a renderer-neutral visualization graph.
+pub struct VisualEdge {
+  priv from : String
+  priv to : String
+  priv label : String?
+}
+
+///|
+/// Renderer-neutral graph model consumed by the Graphviz and SVG renderers.
+pub struct VisualGraph {
+  priv id : String?
+  priv nodes : Array[VisualNode]
+  priv edges : Array[VisualEdge]
+}
+
+///|
+/// Create a neutral graph node.
+pub fn VisualNode::VisualNode(
+  id : String,
+  label? : String,
+  detail? : String,
+  status? : VisualNodeStatus = Neutral,
+) -> VisualNode {
+  { id, label, detail, status }
+}
+
+///|
+/// Create a directed graph edge.
+pub fn VisualEdge::VisualEdge(
+  from : String,
+  to : String,
+  label? : String,
+) -> VisualEdge {
+  { from, to, label }
+}
+
+///|
+/// Create an empty visualization graph.
+pub fn VisualGraph::VisualGraph(id? : String) -> VisualGraph {
+  { id, nodes: [], edges: [] }
+}
+
+///|
+/// Add a node to this graph.
+pub fn VisualGraph::add_node(self : VisualGraph, node : VisualNode) -> Unit {
+  self.nodes.push(node)
+}
+
+///|
+/// Add a directed edge to this graph.
+pub fn VisualGraph::add_edge(self : VisualGraph, edge : VisualEdge) -> Unit {
+  self.edges.push(edge)
+}

--- a/lib/visualizer/moon.mod.json
+++ b/lib/visualizer/moon.mod.json
@@ -1,0 +1,28 @@
+{
+  "name": "dowdiness/visualizer",
+  "version": "0.1.0",
+  "deps": {
+    "dowdiness/incr": {
+      "path": "../../loom/incr"
+    },
+    "dowdiness/graphviz": {
+      "path": "../../graphviz"
+    },
+    "dowdiness/svg-dsl": {
+      "path": "../../svg-dsl"
+    },
+    "dowdiness/alga": {
+      "path": "../../alga"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [
+    "visualization",
+    "incremental",
+    "graphviz",
+    "svg"
+  ],
+  "description": "Shared graph visualization adapters for Canopy consumers."
+}

--- a/lib/visualizer/moon.pkg
+++ b/lib/visualizer/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "dowdiness/graphviz/lib/parser" @dot,
+  "dowdiness/graphviz/lib/layout" @layout,
+  "dowdiness/graphviz/lib/svg" @graph_svg,
+  "dowdiness/incr" @incr,
+}

--- a/lib/visualizer/pkg.generated.mbti
+++ b/lib/visualizer/pkg.generated.mbti
@@ -1,0 +1,88 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/visualizer"
+
+import {
+  "dowdiness/graphviz/lib/svg",
+  "dowdiness/incr/cells",
+  "dowdiness/incr/types",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum IncrMemoEventPhase {
+  IncrEntering
+  IncrCompleted
+  IncrAborted
+}
+
+pub struct IncrMemoEventRecord {
+  cell_id : @types.CellId
+  phase : IncrMemoEventPhase
+  started_revision : @types.Revision
+  elapsed_ns : Int64?
+  verified_at : @types.Revision?
+  changed_at : @types.Revision?
+  backdated : Bool
+}
+
+pub struct IncrMemoEventTap {
+  // private fields
+}
+pub fn IncrMemoEventTap::attach(@cells.Runtime) -> Self raise Failure
+pub fn IncrMemoEventTap::detach(Self) -> Unit
+pub fn IncrMemoEventTap::drain_events(Self) -> Array[IncrMemoEventRecord]
+pub fn IncrMemoEventTap::snapshot(Self) -> IncrSnapshot
+
+pub struct IncrSnapshot {
+  nodes : Array[IncrSnapshotNode]
+  edges : Array[IncrSnapshotEdge]
+  events : Array[IncrMemoEventRecord]
+}
+pub fn IncrSnapshot::to_visual_graph(Self) -> VisualGraph
+
+pub struct IncrSnapshotEdge {
+  from : @types.CellId
+  to : @types.CellId
+}
+
+pub struct IncrSnapshotNode {
+  id : @types.CellId
+  label : String?
+  changed_at : @types.Revision
+  verified_at : @types.Revision
+}
+
+pub struct VisualEdge {
+  // private fields
+}
+pub fn VisualEdge::VisualEdge(String, String, label? : String) -> Self
+
+pub struct VisualGraph {
+  // private fields
+}
+pub fn VisualGraph::VisualGraph(id? : String) -> Self
+pub fn VisualGraph::add_edge(Self, VisualEdge) -> Unit
+pub fn VisualGraph::add_node(Self, VisualNode) -> Unit
+pub fn VisualGraph::to_dot(Self) -> String
+pub fn VisualGraph::to_svg(Self) -> String
+pub fn VisualGraph::to_svg_with_config(Self, @svg.SvgConfig) -> String
+
+pub struct VisualNode {
+  // private fields
+}
+pub fn VisualNode::VisualNode(String, label? : String, detail? : String, status? : VisualNodeStatus) -> Self
+
+pub(all) enum VisualNodeStatus {
+  Neutral
+  Active
+  Changed
+  Failed
+}
+
+// Type aliases
+
+// Traits
+

--- a/lib/visualizer/visualizer_test.mbt
+++ b/lib/visualizer/visualizer_test.mbt
@@ -1,0 +1,58 @@
+///|
+test "visual_graph_to_dot_formats_nodes_and_edges" {
+  let graph = @visualizer.VisualGraph(id="sample")
+  graph.add_node(@visualizer.VisualNode("a", label="A"))
+  graph.add_node(
+    @visualizer.VisualNode("b", label="B", status=@visualizer.Changed),
+  )
+  graph.add_edge(@visualizer.VisualEdge("a", "b", label="dep"))
+  let dot = graph.to_dot()
+  inspect(dot.contains("digraph sample"), content="true")
+  inspect(dot.contains("a -> b"), content="true")
+}
+
+///|
+test "visual_graph_to_svg_renders_svg" {
+  let graph = @visualizer.VisualGraph(id="sample")
+  graph.add_node(@visualizer.VisualNode("a", label="A"))
+  graph.add_node(@visualizer.VisualNode("b", label="B"))
+  graph.add_edge(@visualizer.VisualEdge("a", "b"))
+  let svg = graph.to_svg()
+  inspect(svg.contains("<svg"), content="true")
+}
+
+///|
+test "incr_memo_event_tap_snapshots_runtime_graph" {
+  let rt = @incr.Runtime()
+  let sig = @incr.Signal(rt, 1, label="input")
+  let memo = @incr.Memo(rt, () => sig.get() + 1, label="sum")
+  let tap = @visualizer.IncrMemoEventTap::attach(rt)
+  inspect(rt.read(memo), content="2")
+  let snapshot = tap.snapshot()
+  inspect(snapshot.events.length(), content="2")
+  inspect(snapshot.nodes.length() >= 2, content="true")
+  inspect(snapshot.edges.length() >= 1, content="true")
+  let graph = snapshot.to_visual_graph()
+  inspect(graph.to_svg().contains("<svg"), content="true")
+  tap.detach()
+}
+
+///|
+test "incr_memo_event_tap_stale_detach_does_not_clear_newer_tap" {
+  let rt = @incr.Runtime()
+  let sig = @incr.Signal(rt, 1, label="input")
+  let memo = @incr.Memo(rt, () => sig.get() + 1, label="sum")
+  let older = @visualizer.IncrMemoEventTap::attach(rt)
+  let newer = @visualizer.IncrMemoEventTap::attach(rt)
+  inspect(rt.read(memo), content="2")
+  inspect(older.drain_events().length(), content="0")
+  inspect(newer.drain_events().length(), content="2")
+  older.detach()
+  sig.set(2)
+  inspect(rt.read(memo), content="3")
+  inspect(newer.drain_events().length(), content="2")
+  newer.detach()
+  sig.set(3)
+  inspect(rt.read(memo), content="4")
+  inspect(newer.drain_events().length(), content="0")
+}

--- a/moon.work
+++ b/moon.work
@@ -5,4 +5,5 @@ members = [
   "./lib/btree",
   "./lib/moji",
   "./lib/rabbita_codemirror",
+  "./lib/visualizer",
 ]


### PR DESCRIPTION
## Summary

- Add `dowdiness/visualizer` as a new standalone workspace module under `lib/visualizer`.
- Add a renderer-neutral graph model plus Graphviz DOT/SVG rendering backed by the local `dowdiness/graphviz` and `dowdiness/svg-dsl` modules.
- Add `IncrMemoEventTap`, a driver-owned consumer of `Runtime::on_memo_event` that records compact memo events, enriches known cells through `Runtime::cell_info`, and converts snapshots to visual graphs.
- Add `./lib/visualizer` to `moon.work`.
- Bump the `loom` submodule to `e3f3a30`, which includes the merged Loom PR #132 pointing nested `incr` at memo-event API commit `2d4dcde`.

## Notes

The visualizer stays outside `dowdiness/incr`; it consumes the public memo-event API and does not publish events back into the same runtime.

## Validation

- `rtk moon fmt`
- `rtk moon info`
- `rtk moon check --deny-warn`
- `rtk moon test -p dowdiness/visualizer --release`