### PR TITLE
chore(ideal): finish P2.6 verification cleanup

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -24,16 +24,16 @@ extern "js" fn js_now_ms() -> Int =
 extern "js" fn js_make_ideal_cm_extension_raw(
   cm : @js_value.Value,
 ) -> @js_value.Value =
-#| function(cm) {
-#|   const click = (id) => {
-#|     const btn = document.getElementById(id);
-#|     if (btn && typeof btn.click === 'function') btn.click();
-#|   };
-#|   const normalizeExtensions = (factory) => {
-#|     const provided = typeof factory === 'function' ? factory(cm) : [];
-#|     return Array.isArray(provided) ? provided : [provided];
-#|   };
-#|   const theme = cm.EditorView.theme({
+  #| function(cm) {
+  #|   const click = (id) => {
+  #|     const btn = document.getElementById(id);
+  #|     if (btn && typeof btn.click === 'function') btn.click();
+  #|   };
+  #|   const normalizeExtensions = (factory) => {
+  #|     const provided = typeof factory === 'function' ? factory(cm) : [];
+  #|     return Array.isArray(provided) ? provided : [provided];
+  #|   };
+  #|   const theme = cm.EditorView.theme({
   #|     "&": {
   #|       backgroundColor: "transparent",
   #|       color: "var(--canopy-fg, #e4e4f0)",
@@ -119,14 +119,14 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   #|     },
   #|     ...defaultKeymap,
   #|   ]);
-#|   const languageExtensions = normalizeExtensions(
-#|     globalThis.__canopy_create_lambda_cm_extensions,
-#|   );
-#|   const peerExtensions = normalizeExtensions(
-#|     globalThis.__canopy_create_cm_peer_cursor_extension,
-#|   );
-#|   return [theme, ...languageExtensions, keymap, ...peerExtensions];
-#| }
+  #|   const languageExtensions = normalizeExtensions(
+  #|     globalThis.__canopy_create_lambda_cm_extensions,
+  #|   );
+  #|   const peerExtensions = normalizeExtensions(
+  #|     globalThis.__canopy_create_cm_peer_cursor_extension,
+  #|   );
+  #|   return [theme, ...languageExtensions, keymap, ...peerExtensions];
+  #| }
 
 ///|
 #warnings("-unused_error_type")

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -102,20 +102,21 @@ fn sync_after_external_crdt_change(model : Model) -> Cmd {
 fn select_text_node_cmd(model : Model, node_id : String) -> Cmd {
   match parse_node_id(node_id) {
     None => none
-    Some(nid) => match model.editor.get_source_map().get_range(nid) {
-      None => none
-      Some(range) =>
-        @rabbita.batch([
-          @cm.set_selection(
-            model.cm_id,
-            @cm.SelRange::new(range.start, range.end),
-            scroll_into_view=true,
-          ),
-          @rabbita.effect(fn() {
-            js_after_cm_selection_changed(range.start, range.end)
-          }),
-        ])
-    }
+    Some(nid) =>
+      match model.editor.get_source_map().get_range(nid) {
+        None => none
+        Some(range) =>
+          @rabbita.batch([
+            @cm.set_selection(
+              model.cm_id,
+              @cm.SelRange::new(range.start, range.end),
+              scroll_into_view=true,
+            ),
+            @rabbita.effect(fn() {
+              js_after_cm_selection_changed(range.start, range.end)
+            }),
+          ])
+      }
   }
 }
 


### PR DESCRIPTION
## Summary
- Ran P2.6 CodeMirror-Rabbita final verification checklist
- Fixed examples/ideal MoonBit formatter drift surfaced by the checklist
- Confirmed generated .mbti files have no diff

## Verification
- moon check
- moon fmt --check
- moon info
- moon test
- cd examples/ideal && moon check && moon fmt --check && moon info && moon test
- cd examples/ideal && moon check --deny-warn
- cd examples/ideal && moon build --target js
- cd examples/ideal/web && npm run build
- binding grep invariants from the Phase 2 plan
- cd examples/codemirror_demo && moon check --deny-warn
- cd examples/codemirror_demo && moon test --release
- cd examples/codemirror_demo && moon build --target js --release
- cd examples/codemirror_demo && npm run build
- manual browser smoke at http://127.0.0.1:5175/

Notes: examples/codemirror_demo has no MoonBit test entries, so moon test --release reports 0/0. Vite build emits existing deprecation/chunk-size warnings but exits successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and readability in internal examples for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->