### PR TITLE
[codex] Add DOM boundary helpers

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -162,9 +162,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 - [ ] Structure mode — test and polish PM block editor, verify lazy-loading works.
   Note: completion state is unclear; decision pending in `docs/decisions-needed.md`.
 
-- [ ] Add safe imperative boundary helpers for Rabbita DOM interop.
+- [x] Add safe imperative boundary helpers for Rabbita DOM interop.
   Why: Rabbita has no React-style ref API; current widget and browser-API escape hatches use ad-hoc `after_render` commands, stable ids, and hidden trigger clicks. A tiny helper layer would keep DOM access lifecycle-safe without storing raw elements in app state.
   Exit: shared helpers cover common id-based `after_render` actions such as focus, click, scroll, and typed custom-event subscriptions; ideal-editor bridges use them where practical.
+  Done: added `lib/dom-boundary` with typed throwing DOM helpers, a local Ideal Rabbita adapter, and migrated focus/scroll call sites off direct JS DOM externs (2026-05-21).
 
 - [ ] Graphviz SVG theming — SVG uses hardcoded `Arial` from submodule; needs `pub(all) struct SvgConfig` to customize.
 

--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -231,16 +231,6 @@ extern "js" fn js_take_sync_status() -> String =
   #| }
 
 ///|
-/// Move keyboard focus to an element by ID. Used by the bottom tab strip
-/// to follow roving tabindex after arrow-key navigation. Silently no-ops
-/// if the element isn't in the DOM.
-extern "js" fn js_focus_element(element_id : String) -> Unit =
-  #| function(id) {
-  #|   var el = document.getElementById(id);
-  #|   if (el && typeof el.focus === 'function') el.focus();
-  #| }
-
-///|
 /// Consume the pending action overlay node ID set by JS.
 extern "js" fn js_take_action_overlay_node() -> String =
   #| function() {
@@ -303,23 +293,6 @@ extern "js" fn js_get_outline_selected_rect() -> String =
   #|   if (!sel) return '{}';
   #|   var r = sel.getBoundingClientRect();
   #|   return JSON.stringify({ top: Math.round(r.top), left: Math.round(r.left), bottom: Math.round(r.bottom), right: Math.round(r.right) });
-  #| }
-
-///|
-/// Scroll the selected outline row into view.
-extern "js" fn js_scroll_outline_to_selected() -> Unit =
-  #| function() {
-  #|   var sel = document.querySelector('.outline-panel .tree-row.selected');
-  #|   if (sel) sel.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-  #| }
-
-///|
-/// Focus the action overlay panel in the page DOM (not shadow DOM).
-/// Used when overlay is opened from outline keyboard context.
-extern "js" fn js_focus_outline_overlay() -> Unit =
-  #| function() {
-  #|   var panel = document.querySelector('.action-overlay-panel');
-  #|   if (panel) panel.focus();
   #| }
 
 ///|

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -688,10 +688,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Some(s) =>
           @rabbita.batch([
             select_editor_node_cmd(model, s),
-            @rabbita_cmd.custom_cmd(
-              fn(_) { js_scroll_outline_to_selected() },
-              kind=@rabbita_cmd.after_render,
-            ),
+            scroll_selector_after_render(".outline-panel .tree-row.selected"),
           ])
         None => none
       }
@@ -765,11 +762,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       let rect_json = js_get_outline_selected_rect()
       let new_model = open_action_overlay(model, node_id_str, rect_json~)
       if new_model.overlay.visible {
-        let focus_cmd = @rabbita_cmd.custom_cmd(
-          fn(_) { js_focus_outline_overlay() },
-          kind=@rabbita_cmd.after_render,
-        )
-        (focus_cmd, new_model)
+        (focus_selector_after_render(".action-overlay-panel"), new_model)
       } else {
         (none, new_model)
       }

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbit-community/rabbita/js" @js_value,
   "dowdiness/rabbita_codemirror" @cm,
   "dowdiness/rabbita_codemirror/js" @cm_js,
+  "dowdiness/dom_boundary" @dom_boundary,
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,
   "dowdiness/canopy/editor" @editor,

--- a/examples/ideal/main/rabbita_dom_cmd.mbt
+++ b/examples/ideal/main/rabbita_dom_cmd.mbt
@@ -1,0 +1,54 @@
+///|
+fn dom_after_render_result(
+  action : () -> Unit raise @dom_boundary.DomBoundaryError,
+  on_error? : (@dom_boundary.DomBoundaryError) -> @rabbita.Cmd = fn(_) {
+    @rabbita.none
+  },
+) -> @rabbita.Cmd {
+  @rabbita_cmd.custom_cmd(
+    fn(scheduler) {
+      try {
+        action()
+      } catch {
+        error => scheduler.add(on_error(error))
+      }
+    },
+    kind=@rabbita_cmd.after_render,
+  )
+}
+
+///|
+fn focus_id_after_render(
+  id : String,
+  on_error? : (@dom_boundary.DomBoundaryError) -> @rabbita.Cmd = fn(_) {
+    @rabbita.none
+  },
+) -> @rabbita.Cmd {
+  dom_after_render_result(() => @dom_boundary.focus_id(id), on_error~)
+}
+
+///|
+fn focus_selector_after_render(
+  selector : String,
+  on_error? : (@dom_boundary.DomBoundaryError) -> @rabbita.Cmd = fn(_) {
+    @rabbita.none
+  },
+) -> @rabbita.Cmd {
+  dom_after_render_result(
+    () => @dom_boundary.focus_selector(selector),
+    on_error~,
+  )
+}
+
+///|
+fn scroll_selector_after_render(
+  selector : String,
+  on_error? : (@dom_boundary.DomBoundaryError) -> @rabbita.Cmd = fn(_) {
+    @rabbita.none
+  },
+) -> @rabbita.Cmd {
+  dom_after_render_result(
+    () => @dom_boundary.scroll_selector(selector),
+    on_error~,
+  )
+}

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -177,11 +177,7 @@ fn render_history_html(model : Model) -> String {
 /// `tabindex="-1"`) button. Click-driven switches are no-ops because the
 /// browser already focuses the clicked button.
 fn bottom_tab_focus_cmd(tab : BottomTab) -> @rabbita.Cmd {
-  let id = bottom_tab_button_id(tab)
-  @rabbita_cmd.custom_cmd(
-    fn(_) { js_focus_element(id) },
-    kind=@rabbita_cmd.after_render,
-  )
+  focus_id_after_render(bottom_tab_button_id(tab))
 }
 
 ///|

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -8,6 +8,9 @@
     "dowdiness/rabbita_codemirror": {
       "path": "../../lib/rabbita_codemirror"
     },
+    "dowdiness/dom_boundary": {
+      "path": "../../lib/dom-boundary"
+    },
     "dowdiness/canopy": {
       "path": "../.."
     },

--- a/lib/dom-boundary/dom_boundary.mbt
+++ b/lib/dom-boundary/dom_boundary.mbt
@@ -1,0 +1,197 @@
+///|
+pub(all) enum DomTarget {
+  Id(String)
+  Selector(String)
+  EventSubscription
+} derive(Debug, Eq)
+
+///|
+pub(all) enum DomAction {
+  Focus
+  Click
+  ScrollIntoView
+  DispatchCustomEvent
+  ListenCustomEvent
+  RemoveCustomEventListener
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ScrollBehavior {
+  Auto
+  Instant
+  Smooth
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ScrollBlock {
+  Start
+  Center
+  End
+  Nearest
+} derive(Debug, Eq)
+
+///|
+pub(all) suberror DomBoundaryError {
+  DocumentUnavailable
+  InvalidSelector(selector~ : String, detail~ : String)
+  ElementNotFound(target~ : DomTarget)
+  UnsupportedAction(action~ : DomAction, target~ : DomTarget)
+  ActionFailed(action~ : DomAction, target~ : DomTarget, detail~ : String)
+  UnknownStatus(
+    status~ : Int,
+    action~ : DomAction,
+    target~ : DomTarget,
+    detail~ : String
+  )
+} derive(Debug, Eq)
+
+///|
+#external
+priv type DomStatus
+
+///|
+#external
+priv type DomEventSubscriptionHandle
+
+///|
+#external
+priv type DomElement
+
+///|
+pub struct CustomEventSubscription {
+  priv handle : DomEventSubscriptionHandle
+}
+
+///|
+pub impl Show for DomBoundaryError with output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub fn DomBoundaryError::message(self : DomBoundaryError) -> String {
+  match self {
+    DocumentUnavailable => "document is unavailable"
+    InvalidSelector(selector~, detail~) =>
+      with_detail("invalid DOM selector: \{selector}", detail)
+    ElementNotFound(target~) => "DOM element not found: \{target.describe()}"
+    UnsupportedAction(action~, target~) =>
+      "DOM element does not support \{action.describe()}: \{target.describe()}"
+    ActionFailed(action~, target~, detail~) =>
+      with_detail(
+        "DOM \{action.describe()} failed: \{target.describe()}",
+        detail,
+      )
+    UnknownStatus(status~, action~, target~, detail~) =>
+      with_detail(
+        "unknown DOM boundary status \{status} for \{action.describe()} on \{target.describe()}",
+        detail,
+      )
+  }
+}
+
+///|
+pub fn focus_id(id : String) -> Unit raise DomBoundaryError {
+  focus_target(LOOKUP_ID, id, Id(id))
+}
+
+///|
+pub fn focus_selector(selector : String) -> Unit raise DomBoundaryError {
+  focus_target(LOOKUP_SELECTOR, selector, Selector(selector))
+}
+
+///|
+pub fn click_id(id : String) -> Unit raise DomBoundaryError {
+  click_target(LOOKUP_ID, id, Id(id))
+}
+
+///|
+pub fn click_selector(selector : String) -> Unit raise DomBoundaryError {
+  click_target(LOOKUP_SELECTOR, selector, Selector(selector))
+}
+
+///|
+pub fn scroll_id(
+  id : String,
+  behavior? : ScrollBehavior = Smooth,
+  block? : ScrollBlock = Nearest,
+) -> Unit raise DomBoundaryError {
+  scroll_target(LOOKUP_ID, id, Id(id), behavior, block)
+}
+
+///|
+pub fn scroll_selector(
+  selector : String,
+  behavior? : ScrollBehavior = Smooth,
+  block? : ScrollBlock = Nearest,
+) -> Unit raise DomBoundaryError {
+  scroll_target(LOOKUP_SELECTOR, selector, Selector(selector), behavior, block)
+}
+
+///|
+pub fn dispatch_custom_event_id(
+  id : String,
+  event_type : String,
+  detail? : String = "",
+  bubbles? : Bool = true,
+  composed? : Bool = true,
+) -> Unit raise DomBoundaryError {
+  dispatch_custom_event_target(
+    LOOKUP_ID,
+    id,
+    Id(id),
+    event_type,
+    detail,
+    bubbles~,
+    composed~,
+  )
+}
+
+///|
+pub fn dispatch_custom_event_selector(
+  selector : String,
+  event_type : String,
+  detail? : String = "",
+  bubbles? : Bool = true,
+  composed? : Bool = true,
+) -> Unit raise DomBoundaryError {
+  dispatch_custom_event_target(
+    LOOKUP_SELECTOR,
+    selector,
+    Selector(selector),
+    event_type,
+    detail,
+    bubbles~,
+    composed~,
+  )
+}
+
+///|
+pub fn listen_custom_event_id(
+  id : String,
+  event_type : String,
+  on_event : (String) -> Unit,
+) -> CustomEventSubscription raise DomBoundaryError {
+  listen_custom_event_target(LOOKUP_ID, id, Id(id), event_type, on_event)
+}
+
+///|
+pub fn listen_custom_event_selector(
+  selector : String,
+  event_type : String,
+  on_event : (String) -> Unit,
+) -> CustomEventSubscription raise DomBoundaryError {
+  listen_custom_event_target(
+    LOOKUP_SELECTOR,
+    selector,
+    Selector(selector),
+    event_type,
+    on_event,
+  )
+}
+
+///|
+pub fn CustomEventSubscription::dispose(
+  self : CustomEventSubscription,
+) -> Unit raise DomBoundaryError {
+  dispose_subscription(self.handle)
+}

--- a/lib/dom-boundary/dom_boundary_runtime.mbt
+++ b/lib/dom-boundary/dom_boundary_runtime.mbt
@@ -1,0 +1,455 @@
+///|
+const STATUS_OK = 0
+
+///|
+const STATUS_DOCUMENT_UNAVAILABLE = 1
+
+///|
+const STATUS_NOT_FOUND = 2
+
+///|
+const STATUS_UNSUPPORTED_ACTION = 3
+
+///|
+const STATUS_INVALID_SELECTOR = 4
+
+///|
+const STATUS_ACTION_FAILED = 5
+
+///|
+const LOOKUP_ID : String = "id"
+
+///|
+const LOOKUP_SELECTOR : String = "selector"
+
+///|
+fn focus_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+) -> Unit raise DomBoundaryError {
+  let element = resolve_target(lookup_kind, raw_target, Focus, target)
+  guard js_has_method(element, "focus") else {
+    raise UnsupportedAction(action=Focus, target~)
+  }
+  raise_action_detail(js_focus(element), Focus, target)
+}
+
+///|
+fn click_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+) -> Unit raise DomBoundaryError {
+  let element = resolve_target(lookup_kind, raw_target, Click, target)
+  guard js_has_method(element, "click") else {
+    raise UnsupportedAction(action=Click, target~)
+  }
+  raise_action_detail(js_click(element), Click, target)
+}
+
+///|
+fn scroll_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+  behavior : ScrollBehavior,
+  block : ScrollBlock,
+) -> Unit raise DomBoundaryError {
+  let element = resolve_target(lookup_kind, raw_target, ScrollIntoView, target)
+  guard js_has_method(element, "scrollIntoView") else {
+    raise UnsupportedAction(action=ScrollIntoView, target~)
+  }
+  raise_action_detail(
+    js_scroll_into_view(
+      element,
+      behavior.to_dom_string(),
+      block.to_dom_string(),
+    ),
+    ScrollIntoView,
+    target,
+  )
+}
+
+///|
+fn dispatch_custom_event_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+  event_type : String,
+  detail : String,
+  bubbles~ : Bool,
+  composed~ : Bool,
+) -> Unit raise DomBoundaryError {
+  let element = resolve_target(
+    lookup_kind,
+    raw_target,
+    DispatchCustomEvent,
+    target,
+  )
+  guard js_has_method(element, "dispatchEvent") && js_custom_event_available() else {
+    raise UnsupportedAction(action=DispatchCustomEvent, target~)
+  }
+  raise_action_detail(
+    js_dispatch_custom_event(element, event_type, detail, bubbles~, composed~),
+    DispatchCustomEvent,
+    target,
+  )
+}
+
+///|
+fn listen_custom_event_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+  event_type : String,
+  on_event : (String) -> Unit,
+) -> CustomEventSubscription raise DomBoundaryError {
+  let element = resolve_target(
+    lookup_kind,
+    raw_target,
+    ListenCustomEvent,
+    target,
+  )
+  guard js_has_method(element, "addEventListener") &&
+    js_has_method(element, "removeEventListener") else {
+    raise UnsupportedAction(action=ListenCustomEvent, target~)
+  }
+  decode_subscription_status(
+    js_listen_custom_event(
+      STATUS_OK,
+      STATUS_ACTION_FAILED,
+      element,
+      event_type,
+      on_event,
+    ),
+    ListenCustomEvent,
+    target,
+  )
+}
+
+///|
+fn dispose_subscription(
+  handle : DomEventSubscriptionHandle,
+) -> Unit raise DomBoundaryError {
+  decode_status(
+    js_dispose_custom_event_subscription(
+      STATUS_OK,
+      STATUS_UNSUPPORTED_ACTION,
+      STATUS_ACTION_FAILED,
+      handle,
+    ),
+    RemoveCustomEventListener,
+    EventSubscription,
+  )
+}
+
+///|
+fn resolve_target(
+  lookup_kind : String,
+  raw_target : String,
+  action : DomAction,
+  target : DomTarget,
+) -> DomElement raise DomBoundaryError {
+  if js_document_unavailable() {
+    raise DocumentUnavailable
+  }
+  let status = match lookup_kind {
+    LOOKUP_ID => js_get_element_by_id(STATUS_OK, STATUS_NOT_FOUND, raw_target)
+    LOOKUP_SELECTOR =>
+      js_query_selector(
+        STATUS_OK,
+        STATUS_NOT_FOUND,
+        STATUS_INVALID_SELECTOR,
+        raw_target,
+      )
+    _ => js_status(STATUS_ACTION_FAILED, "unknown lookup kind: \{lookup_kind}")
+  }
+  decode_status(status, action, target)
+  dom_status_element(status)
+}
+
+///|
+fn raise_action_detail(
+  detail : String,
+  action : DomAction,
+  target : DomTarget,
+) -> Unit raise DomBoundaryError {
+  if detail != "" {
+    raise ActionFailed(action~, target~, detail~)
+  }
+}
+
+///|
+fn decode_status(
+  status : DomStatus,
+  action : DomAction,
+  target : DomTarget,
+) -> Unit raise DomBoundaryError {
+  decode_status_parts(
+    dom_status_code(status),
+    dom_status_detail(status),
+    action,
+    target,
+  )
+}
+
+///|
+fn decode_subscription_status(
+  status : DomStatus,
+  action : DomAction,
+  target : DomTarget,
+) -> CustomEventSubscription raise DomBoundaryError {
+  decode_status(status, action, target)
+  { handle: dom_status_handle(status) }
+}
+
+///|
+fn decode_status_parts(
+  status : Int,
+  detail : String,
+  action : DomAction,
+  target : DomTarget,
+) -> Unit raise DomBoundaryError {
+  match status {
+    STATUS_OK => ()
+    STATUS_DOCUMENT_UNAVAILABLE => raise DocumentUnavailable
+    STATUS_NOT_FOUND => raise ElementNotFound(target~)
+    STATUS_UNSUPPORTED_ACTION => raise UnsupportedAction(action~, target~)
+    STATUS_INVALID_SELECTOR =>
+      match target {
+        Selector(selector) => raise InvalidSelector(selector~, detail~)
+        Id(_) | EventSubscription =>
+          raise UnknownStatus(status~, action~, target~, detail~)
+      }
+    STATUS_ACTION_FAILED => raise ActionFailed(action~, target~, detail~)
+    _ => raise UnknownStatus(status~, action~, target~, detail~)
+  }
+}
+
+///|
+fn DomTarget::describe(self : DomTarget) -> String {
+  match self {
+    Id(id) => "#\{id}"
+    Selector(selector) => selector
+    EventSubscription => "custom-event subscription"
+  }
+}
+
+///|
+fn DomAction::describe(self : DomAction) -> String {
+  match self {
+    Focus => "focus"
+    Click => "click"
+    ScrollIntoView => "scrollIntoView"
+    DispatchCustomEvent => "dispatchCustomEvent"
+    ListenCustomEvent => "listenCustomEvent"
+    RemoveCustomEventListener => "removeCustomEventListener"
+  }
+}
+
+///|
+fn ScrollBehavior::to_dom_string(self : ScrollBehavior) -> String {
+  match self {
+    Auto => "auto"
+    Instant => "instant"
+    Smooth => "smooth"
+  }
+}
+
+///|
+fn ScrollBlock::to_dom_string(self : ScrollBlock) -> String {
+  match self {
+    Start => "start"
+    Center => "center"
+    End => "end"
+    Nearest => "nearest"
+  }
+}
+
+///|
+fn with_detail(message : String, detail : String) -> String {
+  if detail == "" {
+    message
+  } else {
+    message + ": " + detail
+  }
+}
+
+///|
+extern "js" fn js_status(status : Int, detail : String) -> DomStatus =
+  #| (status, detail) => ({ status, detail })
+
+///|
+extern "js" fn dom_status_code(status : DomStatus) -> Int =
+  #| (status) => status.status
+
+///|
+extern "js" fn dom_status_detail(status : DomStatus) -> String =
+  #| (status) => typeof status.detail === "string" ? status.detail : ""
+
+///|
+extern "js" fn dom_status_element(status : DomStatus) -> DomElement =
+  #| (status) => status.element
+
+///|
+extern "js" fn dom_status_handle(
+  status : DomStatus,
+) -> DomEventSubscriptionHandle =
+  #| (status) => status.handle
+
+///|
+extern "js" fn js_document_unavailable() -> Bool =
+  #| () => typeof document === "undefined"
+
+///|
+extern "js" fn js_get_element_by_id(
+  status_ok : Int,
+  status_not_found : Int,
+  id : String,
+) -> DomStatus =
+  #| (statusOk, statusNotFound, id) => {
+  #|   const element = document.getElementById(id);
+  #|   return element
+  #|     ? { status: statusOk, detail: "", element }
+  #|     : { status: statusNotFound, detail: "" };
+  #| }
+
+///|
+extern "js" fn js_query_selector(
+  status_ok : Int,
+  status_not_found : Int,
+  status_invalid_selector : Int,
+  selector : String,
+) -> DomStatus =
+  #| (statusOk, statusNotFound, statusInvalidSelector, selector) => {
+  #|   try {
+  #|     const element = document.querySelector(selector);
+  #|     return element
+  #|       ? { status: statusOk, detail: "", element }
+  #|       : { status: statusNotFound, detail: "" };
+  #|   } catch (error) {
+  #|     const detail = error && typeof error.message === "string" ? error.message : String(error);
+  #|     return { status: statusInvalidSelector, detail };
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_has_method(
+  element : DomElement,
+  method_name : String,
+) -> Bool =
+  #| (element, methodName) => !!element && typeof element[methodName] === "function"
+
+///|
+extern "js" fn js_custom_event_available() -> Bool =
+  #| () => typeof CustomEvent !== "undefined"
+
+///|
+extern "js" fn js_focus(element : DomElement) -> String =
+  #| (element) => {
+  #|   try {
+  #|     element.focus();
+  #|     return "";
+  #|   } catch (error) {
+  #|     return error && typeof error.message === "string" ? error.message : String(error);
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_click(element : DomElement) -> String =
+  #| (element) => {
+  #|   try {
+  #|     element.click();
+  #|     return "";
+  #|   } catch (error) {
+  #|     return error && typeof error.message === "string" ? error.message : String(error);
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_scroll_into_view(
+  element : DomElement,
+  behavior : String,
+  block : String,
+) -> String =
+  #| (element, behavior, block) => {
+  #|   try {
+  #|     element.scrollIntoView({ behavior, block });
+  #|     return "";
+  #|   } catch (error) {
+  #|     return error && typeof error.message === "string" ? error.message : String(error);
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_dispatch_custom_event(
+  element : DomElement,
+  event_type : String,
+  detail : String,
+  bubbles~ : Bool,
+  composed~ : Bool,
+) -> String =
+  #| (element, eventType, detail, bubbles, composed) => {
+  #|   try {
+  #|     element.dispatchEvent(new CustomEvent(eventType, { detail, bubbles, composed }));
+  #|     return "";
+  #|   } catch (error) {
+  #|     return error && typeof error.message === "string" ? error.message : String(error);
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_listen_custom_event(
+  status_ok : Int,
+  status_action_failed : Int,
+  element : DomElement,
+  event_type : String,
+  on_event : (String) -> Unit,
+) -> DomStatus =
+  #| (statusOk, statusActionFailed, element, eventType, onEvent) => {
+  #|   const detailToString = (event) => {
+  #|     const detail = event && "detail" in event ? event.detail : "";
+  #|     if (typeof detail === "string") return detail;
+  #|     if (detail == null) return "";
+  #|     try {
+  #|       return JSON.stringify(detail);
+  #|     } catch (_) {
+  #|       return String(detail);
+  #|     }
+  #|   };
+  #|   try {
+  #|     const listener = (event) => onEvent(detailToString(event));
+  #|     element.addEventListener(eventType, listener);
+  #|     return {
+  #|       status: statusOk,
+  #|       detail: "",
+  #|       handle: { element, eventType, listener, disposed: false },
+  #|     };
+  #|   } catch (error) {
+  #|     const detail = error && typeof error.message === "string" ? error.message : String(error);
+  #|     return { status: statusActionFailed, detail };
+  #|   }
+  #| }
+
+///|
+extern "js" fn js_dispose_custom_event_subscription(
+  status_ok : Int,
+  status_unsupported_action : Int,
+  status_action_failed : Int,
+  handle : DomEventSubscriptionHandle,
+) -> DomStatus =
+  #| (statusOk, statusUnsupportedAction, statusActionFailed, handle) => {
+  #|   if (!handle || handle.disposed) return { status: statusOk, detail: "" };
+  #|   if (!handle.element || typeof handle.element.removeEventListener !== "function") {
+  #|     return { status: statusUnsupportedAction, detail: "" };
+  #|   }
+  #|   try {
+  #|     handle.element.removeEventListener(handle.eventType, handle.listener);
+  #|     handle.disposed = true;
+  #|     return { status: statusOk, detail: "" };
+  #|   } catch (error) {
+  #|     const detail = error && typeof error.message === "string" ? error.message : String(error);
+  #|     return { status: statusActionFailed, detail };
+  #|   }
+  #| }

--- a/lib/dom-boundary/dom_boundary_wbtest.mbt
+++ b/lib/dom-boundary/dom_boundary_wbtest.mbt
@@ -1,0 +1,109 @@
+///|
+extern "js" fn clear_fake_document() -> Unit =
+  #| () => { delete globalThis.document; }
+
+///|
+extern "js" fn install_focus_document(id : String) -> Unit =
+  #| (id) => {
+  #|   globalThis.document = {
+  #|     getElementById: (target) => target === id
+  #|       ? { focus() {} }
+  #|       : null,
+  #|   };
+  #| }
+
+///|
+extern "js" fn install_throwing_query_document(message : String) -> Unit =
+  #| (message) => {
+  #|   globalThis.document = {
+  #|     querySelector() {
+  #|       throw new Error(message);
+  #|     },
+  #|   };
+  #| }
+
+///|
+test "decode_status maps invalid selectors to typed errors" {
+  let result : Result[Unit, DomBoundaryError] = try? decode_status_parts(
+    STATUS_INVALID_SELECTOR,
+    "not a valid selector",
+    Focus,
+    Selector("["),
+  )
+  match result {
+    Err(InvalidSelector(selector~, detail~)) => {
+      inspect(selector, content="[")
+      inspect(detail, content="not a valid selector")
+    }
+    _ => fail("expected InvalidSelector")
+  }
+}
+
+///|
+test "focus_id reports unavailable document through JS boundary" {
+  clear_fake_document()
+  let result : Result[Unit, DomBoundaryError] = try? focus_id("missing")
+  match result {
+    Err(DocumentUnavailable) => ()
+    _ => fail("expected DocumentUnavailable")
+  }
+}
+
+///|
+test "focus_id succeeds through JS boundary" {
+  install_focus_document("target")
+  let result : Result[Unit, DomBoundaryError] = try? focus_id("target")
+  clear_fake_document()
+  match result {
+    Ok(_) => ()
+    Err(error) => fail("expected focus_id to succeed, got \{error}")
+  }
+}
+
+///|
+test "focus_selector reports invalid selector through JS boundary" {
+  install_throwing_query_document("bad selector")
+  let result : Result[Unit, DomBoundaryError] = try? focus_selector("[")
+  clear_fake_document()
+  match result {
+    Err(InvalidSelector(selector~, detail~)) => {
+      inspect(selector, content="[")
+      inspect(detail, content="bad selector")
+    }
+    _ => fail("expected InvalidSelector")
+  }
+}
+
+///|
+test "decode_status maps missing elements with target context" {
+  let result : Result[Unit, DomBoundaryError] = try? decode_status_parts(
+    STATUS_NOT_FOUND,
+    "",
+    ScrollIntoView,
+    Id("missing"),
+  )
+  match result {
+    Err(ElementNotFound(target~)) =>
+      inspect(target.describe(), content="#missing")
+    _ => fail("expected ElementNotFound")
+  }
+}
+
+///|
+test "DomBoundaryError message includes action and target" {
+  let error = UnsupportedAction(action=Click, target=Selector(".item"))
+  inspect(error.message(), content="DOM element does not support click: .item")
+}
+
+///|
+test "DomBoundaryError message includes action failure detail" {
+  let error = ActionFailed(
+    action=DispatchCustomEvent,
+    target=Id("btn"),
+    detail="CustomEvent is not defined",
+  )
+  inspect(
+    error.message(),
+    content="DOM dispatchCustomEvent failed: #btn: CustomEvent is not defined",
+  )
+}

--- a/lib/dom-boundary/moon.mod.json
+++ b/lib/dom-boundary/moon.mod.json
@@ -1,0 +1,9 @@
+{
+  "name": "dowdiness/dom_boundary",
+  "version": "0.1.0",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": ["dom", "interop", "moonbit"],
+  "description": "Small JS-backend helpers for imperative DOM boundaries.",
+  "preferred-target": "js"
+}

--- a/lib/dom-boundary/moon.pkg
+++ b/lib/dom-boundary/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/debug",
+}
+
+supported_targets = "js"

--- a/lib/dom-boundary/pkg.generated.mbti
+++ b/lib/dom-boundary/pkg.generated.mbti
@@ -1,0 +1,78 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/dom_boundary"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn click_id(String) -> Unit raise DomBoundaryError
+
+pub fn click_selector(String) -> Unit raise DomBoundaryError
+
+pub fn dispatch_custom_event_id(String, String, detail? : String, bubbles? : Bool, composed? : Bool) -> Unit raise DomBoundaryError
+
+pub fn dispatch_custom_event_selector(String, String, detail? : String, bubbles? : Bool, composed? : Bool) -> Unit raise DomBoundaryError
+
+pub fn focus_id(String) -> Unit raise DomBoundaryError
+
+pub fn focus_selector(String) -> Unit raise DomBoundaryError
+
+pub fn listen_custom_event_id(String, String, (String) -> Unit) -> CustomEventSubscription raise DomBoundaryError
+
+pub fn listen_custom_event_selector(String, String, (String) -> Unit) -> CustomEventSubscription raise DomBoundaryError
+
+pub fn scroll_id(String, behavior? : ScrollBehavior, block? : ScrollBlock) -> Unit raise DomBoundaryError
+
+pub fn scroll_selector(String, behavior? : ScrollBehavior, block? : ScrollBlock) -> Unit raise DomBoundaryError
+
+// Errors
+pub(all) suberror DomBoundaryError {
+  DocumentUnavailable
+  InvalidSelector(selector~ : String, detail~ : String)
+  ElementNotFound(target~ : DomTarget)
+  UnsupportedAction(action~ : DomAction, target~ : DomTarget)
+  ActionFailed(action~ : DomAction, target~ : DomTarget, detail~ : String)
+  UnknownStatus(status~ : Int, action~ : DomAction, target~ : DomTarget, detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn DomBoundaryError::message(Self) -> String
+pub impl Show for DomBoundaryError
+
+// Types and methods
+pub struct CustomEventSubscription {
+  // private fields
+}
+pub fn CustomEventSubscription::dispose(Self) -> Unit raise DomBoundaryError
+
+pub(all) enum DomAction {
+  Focus
+  Click
+  ScrollIntoView
+  DispatchCustomEvent
+  ListenCustomEvent
+  RemoveCustomEventListener
+} derive(Eq, @debug.Debug)
+
+pub(all) enum DomTarget {
+  Id(String)
+  Selector(String)
+  EventSubscription
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ScrollBehavior {
+  Auto
+  Instant
+  Smooth
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ScrollBlock {
+  Start
+  Center
+  End
+  Nearest
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/moon.work
+++ b/moon.work
@@ -5,5 +5,6 @@ members = [
   "./lib/btree",
   "./lib/moji",
   "./lib/rabbita_codemirror",
+  "./lib/dom-boundary",
   "./lib/visualizer",
 ]


### PR DESCRIPTION
## Summary

Adds `dowdiness/dom_boundary`, a small Rabbita-free DOM interop boundary for imperative browser actions. The library exposes typed throwing helpers for focus, click, scroll, custom-event dispatch, and custom-event subscriptions while keeping raw DOM handles private.

Updates the Ideal editor to use a local Rabbita `after_render` adapter for high-confidence focus and scroll call sites, and removes the replaced ad-hoc JS externs from `bridge_ffi.mbt`.

Marks the TODO item for safe imperative Rabbita DOM interop as complete.

## Validation

- `rtk moon check --deny-warn`
- `rtk moon fmt --check`
- `rtk moon info`
- `rtk moon test`
- `rtk moon test lib/dom-boundary`
- `rtk moon check --deny-warn` in `examples/ideal`
- `rtk moon test` in `examples/ideal`

## Notes

The existing dirty `loom` submodule content was left unstaged and is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced manual DOM operations with typed, validated helpers supporting focus, click, scroll, and custom events with comprehensive error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->