### PR TITLE
[codex] Use DOM event subscriptions for overlay triggers

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -231,24 +231,6 @@ extern "js" fn js_take_sync_status() -> String =
   #| }
 
 ///|
-/// Consume the pending action overlay node ID set by JS.
-extern "js" fn js_take_action_overlay_node() -> String =
-  #| function() {
-  #|   var v = globalThis.__canopy_pending_action_overlay_node;
-  #|   globalThis.__canopy_pending_action_overlay_node = null;
-  #|   return v || '';
-  #| }
-
-///|
-/// Consume the pending action key pressed set by JS.
-extern "js" fn js_take_action_key() -> String =
-  #| function() {
-  #|   var v = globalThis.__canopy_pending_action_key;
-  #|   globalThis.__canopy_pending_action_key = null;
-  #|   return v || '';
-  #| }
-
-///|
 /// Tell JS whether the action overlay is currently open.
 extern "js" fn js_set_overlay_open(open : Bool) -> Unit =
   #| function(open) {

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -135,12 +135,35 @@ fn select_editor_node_cmd(model : Model, node_id : String) -> Cmd {
 
 ///|
 fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
-  guard model.mounted else { return @sub.none }
-  @cm.listen(
-    model.cm_id,
-    doc=emit.map(text => CmDocChanged(text)),
-    selection=emit.map(range => CmSelectionChanged(range)),
-  )
+  let editor_events = editor_dom_event_subscriptions(emit)
+  let cm_events = if model.mounted {
+    @cm.listen(
+      model.cm_id,
+      doc=emit.map(text => CmDocChanged(text)),
+      selection=emit.map(range => CmSelectionChanged(range)),
+    )
+  } else {
+    @sub.none
+  }
+  @sub.batch([editor_events, cm_events])
+}
+
+///|
+fn open_action_overlay_from_event(
+  model : Model,
+  node_id_str : String,
+) -> (Cmd, Model) {
+  let new_model = open_action_overlay(model, node_id_str)
+  if new_model.overlay.visible {
+    // Focus the overlay panel after Rabbita renders it
+    let focus_cmd = @rabbita_cmd.custom_cmd(
+      fn(_) { js_focus_overlay_panel() },
+      kind=@rabbita_cmd.after_render,
+    )
+    (focus_cmd, new_model)
+  } else {
+    (none, new_model)
+  }
 }
 
 ///|
@@ -778,26 +801,14 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       }
       (none, { ..model, sync_status, })
     }
-    OpenActionOverlay | LongPressTriggered => {
-      let node_id_str = js_take_action_overlay_node()
-      let new_model = open_action_overlay(model, node_id_str)
-      if new_model.overlay.visible {
-        // Focus the overlay panel after Rabbita renders it
-        let focus_cmd = @rabbita_cmd.custom_cmd(
-          fn(_) { js_focus_overlay_panel() },
-          kind=@rabbita_cmd.after_render,
-        )
-        (focus_cmd, new_model)
-      } else {
-        (none, new_model)
-      }
-    }
+    OpenActionOverlayForNode(node_id_str)
+    | LongPressTriggeredForNode(node_id_str) =>
+      open_action_overlay_from_event(model, node_id_str)
     CloseActionOverlay => {
       js_set_overlay_open(false)
       (none, { ..model, overlay: closed_overlay() })
     }
-    ActionKeyPressed(key_arg) => {
-      let key = if key_arg != "" { key_arg } else { js_take_action_key() }
+    ActionKeyPressed(key) => {
       if key == "" {
         return (none, model)
       }

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -45,3 +45,30 @@ test "parse_node_id invalid returns None" {
   inspect(parse_node_id("abc") is None, content="true")
   inspect(parse_node_id("") is None, content="true")
 }
+
+///|
+test "event_detail_node_id extracts nodeId from object detail" {
+  inspect(event_detail_node_id("{\"nodeId\":\"42\"}"), content="42")
+}
+
+///|
+test "event_detail_node_id accepts string detail fallback" {
+  inspect(event_detail_node_id("42"), content="42")
+}
+
+///|
+test "event_detail_node_id rejects unrelated detail" {
+  inspect(event_detail_node_id("{\"other\":\"42\"}"), content="")
+}
+
+///|
+test "event target selector is centralized" {
+  inspect(EditorHost.selector(), content="#canopy-editor")
+}
+
+///|
+test "event names are centralized" {
+  inspect(ActionOverlayOpen.event_type(), content="action-overlay-open")
+  inspect(ActionKey.event_type(), content="action-key")
+  inspect(LongPress.event_type(), content="long-press")
+}

--- a/examples/ideal/main/msg.mbt
+++ b/examples/ideal/main/msg.mbt
@@ -25,14 +25,14 @@ pub enum Msg {
   // Sync
   SyncStatusChanged(String)
   // Action overlay
-  OpenActionOverlay
+  OpenActionOverlayForNode(String)
   CloseActionOverlay
   ActionKeyPressed(String)
   ActionTapped(String)
   NamePromptInput(String)
   NamePromptSubmit
   NamePromptCancel
-  LongPressTriggered
+  LongPressTriggeredForNode(String)
   // Outline drag-and-drop
   OutlineDragStart(@canopy_core.NodeId)
   OutlineDragOver(@canopy_core.NodeId, @canopy_core.DropPosition)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -143,14 +143,14 @@ pub enum Msg {
   OutlineStructuralEdit(@edits.TreeEditOp)
   OpenActionOverlayFromOutline
   SyncStatusChanged(String)
-  OpenActionOverlay
+  OpenActionOverlayForNode(String)
   CloseActionOverlay
   ActionKeyPressed(String)
   ActionTapped(String)
   NamePromptInput(String)
   NamePromptSubmit
   NamePromptCancel
-  LongPressTriggered
+  LongPressTriggeredForNode(String)
   OutlineDragStart(@core.NodeId)
   OutlineDragOver(@core.NodeId, @core.DropPosition)
   OutlineDragLeave

--- a/examples/ideal/main/rabbita_dom_cmd.mbt
+++ b/examples/ideal/main/rabbita_dom_cmd.mbt
@@ -6,13 +6,7 @@ fn dom_after_render_result(
   },
 ) -> @rabbita.Cmd {
   @rabbita_cmd.custom_cmd(
-    fn(scheduler) {
-      try {
-        action()
-      } catch {
-        error => scheduler.add(on_error(error))
-      }
-    },
+    fn(scheduler) { action() catch { error => scheduler.add(on_error(error)) } },
     kind=@rabbita_cmd.after_render,
   )
 }

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -1,0 +1,134 @@
+///|
+priv enum EventTarget {
+  EditorHost
+}
+
+///|
+priv enum EventName {
+  ActionOverlayOpen
+  ActionKey
+  LongPress
+}
+
+///|
+fn EventTarget::selector(self : EventTarget) -> String {
+  match self {
+    EditorHost => "#canopy-editor"
+  }
+}
+
+///|
+fn EventTarget::key(self : EventTarget) -> String {
+  match self {
+    EditorHost => "editor-host"
+  }
+}
+
+///|
+fn EventName::event_type(self : EventName) -> String {
+  match self {
+    ActionOverlayOpen => "action-overlay-open"
+    ActionKey => "action-key"
+    LongPress => "long-press"
+  }
+}
+
+///|
+fn EventName::key(self : EventName) -> String {
+  match self {
+    ActionOverlayOpen => "action-overlay-open"
+    ActionKey => "action-key"
+    LongPress => "long-press"
+  }
+}
+
+///|
+priv suberror DomEventSub {
+  CustomEvent(EventTarget, EventName, @rabbita.Emit[String])
+}
+
+///|
+fn custom_event_sub(
+  target : EventTarget,
+  event_name : EventName,
+  tagger : @rabbita.Emit[String],
+) -> @sub.Sub {
+  @sub.custom_sub(
+    "dom.custom_event(target=\{target.key()},event=\{event_name.key()})",
+    @sub.Scope::Local,
+    CustomEvent(target, event_name, tagger),
+    @sub.SubLoader(dom_event_sub_loader),
+  )
+}
+
+///|
+fn dom_event_sub_loader(
+  payload : Error,
+  scheduler : &@rabbita_cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    CustomEvent(target, event_name, tagger) => {
+      let mut current_tagger = tagger
+      let subscription = try? @dom_boundary.listen_custom_event_selector(
+        target.selector(),
+        event_name.event_type(),
+        detail => scheduler.add(current_tagger(detail)),
+      )
+      match subscription {
+        Ok(subscription) =>
+          Some({
+            unload: fn(_) {
+              let _ : Result[Unit, @dom_boundary.DomBoundaryError] = try? subscription.dispose()
+            },
+            update_tagger: fn(payload) {
+              guard payload is CustomEvent(_, _, new_tagger) else { return }
+              current_tagger = new_tagger
+            },
+          })
+        // TODO(ideal): Add a small JS console logger FFI and include
+        // target.key(), event_name.key(), and error.message() here so failed
+        // subscription installs are visible during editor startup.
+        Err(_) => None
+      }
+    }
+    _ => None
+  }
+}
+
+///|
+fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
+  @sub.batch([
+    custom_event_sub(
+      EditorHost,
+      ActionOverlayOpen,
+      emit.map(detail => OpenActionOverlayForNode(event_detail_node_id(detail))),
+    ),
+    custom_event_sub(
+      EditorHost,
+      ActionKey,
+      emit.map(key => ActionKeyPressed(key)),
+    ),
+    custom_event_sub(
+      EditorHost,
+      LongPress,
+      emit.map(detail => LongPressTriggeredForNode(event_detail_node_id(detail))),
+    ),
+  ])
+}
+
+///|
+fn event_detail_node_id(detail : String) -> String {
+  if detail == "" {
+    return ""
+  }
+  let json = @json.parse(detail) catch { _ => return detail }
+  match json {
+    Json::Object(m) =>
+      match m.get("nodeId") {
+        Some(Json::String(node_id)) => node_id
+        _ => ""
+      }
+    Json::String(node_id) => node_id
+    _ => detail
+  }
+}

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -38,16 +38,14 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   div(class="editor-wrapper", attrs=main_attrs, [
     div(attrs=text_attrs, nothing),
     node("canopy-editor", host_attrs, [@html.text("")]),
-    // Hidden buttons clicked by JS for structure/sync/overlay paths.
+    // Hidden buttons clicked by JS for structure/sync paths not yet moved to
+    // DOM custom-event subscriptions.
     // aria-hidden + tabindex=-1 keeps them out of a11y flow.
     hidden_trigger(
       dispatch,
       SyncStatusChanged(""),
       "canopy-sync-status-trigger",
     ),
-    hidden_trigger(dispatch, OpenActionOverlay, "canopy-action-overlay-trigger"),
-    hidden_trigger(dispatch, ActionKeyPressed(""), "canopy-action-key-trigger"),
-    hidden_trigger(dispatch, LongPressTriggered, "canopy-long-press-trigger"),
     hidden_trigger(dispatch, Undo, "canopy-editor-undo-trigger"),
     hidden_trigger(dispatch, Redo, "canopy-editor-redo-trigger"),
     hidden_trigger(

--- a/examples/ideal/web/e2e/structural-editing.spec.ts
+++ b/examples/ideal/web/e2e/structural-editing.spec.ts
@@ -149,7 +149,7 @@ test.describe('Structural Editing - Overlay on Var nodes', () => {
     await expect(page.locator('.name-prompt-container')).toBeVisible({
       timeout: 5000,
     });
-    await expect(page.locator('.name-prompt-label')).toContainText('Rename');
+    await expect(page.locator('.name-prompt-label')).toContainText('New name');
   });
 
   test('empty name shows error on Rename', async ({ page }) => {
@@ -165,7 +165,7 @@ test.describe('Structural Editing - Overlay on Var nodes', () => {
     });
     await page.locator('.name-prompt-input').focus();
     await page.keyboard.press('Enter');
-    await expect(page.locator('.name-prompt-error')).toContainText('empty');
+    await expect(page.locator('.name-prompt-error')).toContainText('Enter a name to continue');
   });
 
   test('Escape cancels name prompt', async ({ page }) => {

--- a/examples/ideal/web/src/keymap.ts
+++ b/examples/ideal/web/src/keymap.ts
@@ -82,13 +82,11 @@ export function actionKeyForwardPlugin(host: HTMLElement) {
           event.preventDefault();
           return true;
         }
-        g.__canopy_pending_action_key = event.key;
-        const btn = document.getElementById('canopy-action-key-trigger');
-        if (btn) {
-          btn.click();
-        } else {
-          console.warn('[canopy] action-key trigger button not found for key:', event.key);
-        }
+        host.dispatchEvent(new CustomEvent(CanopyEvents.ACTION_KEY, {
+          detail: event.key,
+          bubbles: true,
+          composed: true,
+        }));
         event.preventDefault();
         return true;
       },

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -30,9 +30,7 @@ type CanopyGlobal = typeof globalThis & {
   __canopy_pending_node_selection?: string | null;
   __canopy_pending_structural_edit?: StructuralEditDetail | null;
   __canopy_pending_sync_status?: string | null;
-  __canopy_pending_action_overlay_node?: string | null;
   __canopy_overlay_open?: boolean;
-  __canopy_pending_action_key?: string | null;
   __canopy_trigger_autosave?: () => void;
   __canopy_agent_name?: string;
   __canopy_agent_color?: string;
@@ -268,18 +266,6 @@ function wireEditorEvents(el: CanopyEditor) {
       clickTrigger('canopy-external-crdt-changed-trigger');
     }
   }, { signal });
-  el.addEventListener(CanopyEvents.ACTION_OVERLAY_OPEN, ((event: Event) => {
-    const { nodeId } = (event as CustomEvent).detail ?? {};
-    canopyGlobal.__canopy_pending_action_overlay_node = nodeId ?? null;
-    clickTrigger('canopy-action-overlay-trigger');
-  }) as EventListener, { signal });
-
-  el.addEventListener(CanopyEvents.LONG_PRESS, ((event: Event) => {
-    const { nodeId } = (event as CustomEvent).detail ?? {};
-    canopyGlobal.__canopy_pending_action_overlay_node = nodeId ?? null;
-    clickTrigger('canopy-long-press-trigger');
-  }) as EventListener, { signal });
-
   el.addEventListener('sync-status', ((event: Event) => {
     const { status } = (event as CustomEvent<{ status: string }>).detail ?? {};
     if (status) {


### PR DESCRIPTION
## Summary

Replaces the Ideal editor overlay/action-key hidden trigger bridge with Rabbita-managed DOM custom-event subscriptions backed by `lib/dom-boundary`.

- Adds a local Rabbita subscription adapter for custom events on the editor host.
- Routes `action-overlay-open`, `long-press`, and `action-key` through typed local event target/name constructors instead of raw trigger button IDs and global pending fields.
- Removes the related hidden trigger buttons and JS pending globals.
- Updates white-box coverage for event detail decoding and centralized event names/selectors.
- Updates stale structural-editing E2E copy expectations so the overlay regression spec validates the current UI.

## Validation

- `rtk moon check --deny-warn` from repo root
- `rtk moon fmt --check` from repo root
- `rtk moon info` from repo root
- `rtk moon test` from repo root: `175 wasm-gc`, `993 js`
- `rtk moon check --deny-warn` in `examples/ideal`
- `rtk moon fmt --check` in `examples/ideal`
- `rtk moon info` in `examples/ideal`
- `rtk moon test` in `examples/ideal`: `28 passed`
- `npm run build` in `examples/ideal/web`
- `CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run test -- e2e/structural-editing.spec.ts`: `10 passed`

## Notes

Remaining hidden-trigger paths are intentionally left for later slices: sync/external/structure refresh plus CodeMirror undo/redo.