### PR TITLE
[codex] Log DOM event subscription failures

### DIFF
--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -72,3 +72,15 @@ test "event names are centralized" {
   inspect(ActionKey.event_type(), content="action-key")
   inspect(LongPress.event_type(), content="long-press")
 }
+
+///|
+test "dom event subscription error message includes context" {
+  inspect(
+    dom_event_subscription_error_message(
+      EditorHost,
+      ActionKey,
+      "document is unavailable",
+    ),
+    content="[canopy] failed to install DOM event subscription target=editor-host event=action-key: document is unavailable",
+  )
+}

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -85,15 +85,38 @@ fn dom_event_sub_loader(
               current_tagger = new_tagger
             },
           })
-        // TODO(ideal): Add a small JS console logger FFI and include
-        // target.key(), event_name.key(), and error.message() here so failed
-        // subscription installs are visible during editor startup.
-        Err(_) => None
+        Err(error) => {
+          js_warn_dom_event_subscription_error(
+            dom_event_subscription_error_message(
+              target,
+              event_name,
+              error.message(),
+            ),
+          )
+          None
+        }
       }
     }
     _ => None
   }
 }
+
+///|
+fn dom_event_subscription_error_message(
+  target : EventTarget,
+  event_name : EventName,
+  detail : String,
+) -> String {
+  "[canopy] failed to install DOM event subscription target=\{target.key()} event=\{event_name.key()}: \{detail}"
+}
+
+///|
+extern "js" fn js_warn_dom_event_subscription_error(message : String) -> Unit =
+  #| (message) => {
+  #|   if (typeof console !== "undefined" && typeof console.warn === "function") {
+  #|     console.warn(message);
+  #|   }
+  #| }
 
 ///|
 fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {


### PR DESCRIPTION
## Summary

Implements the Ideal editor diagnosability TODO from the DOM event subscription adapter.

- Logs DOM custom-event subscription install failures through a tiny JS console warning FFI.
- Includes the typed target key, event key, and `DomBoundaryError::message()` detail in the warning.
- Adds white-box coverage for the formatted diagnostic message.

## Validation

- `rtk moon check --deny-warn` in `examples/ideal`
- `rtk moon test` in `examples/ideal`: `29 passed`
- `rtk moon fmt --check` in `examples/ideal`
- `rtk moon info` in `examples/ideal`
- `rtk moon build --target js` in `examples/ideal`
- `git diff --check`

## Notes

This PR only touches the Ideal editor adapter and tests. It does not modify `loom` or any submodule pointer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DOM event subscription error handling now captures and reports failures with formatted error messages including contextual details. Added JavaScript logging support for improved debugging visibility.

* **Tests**
  * Added test to validate DOM event subscription error message formatting, ensuring contextual information is properly included in error output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->