### PR TITLE
[codex] Migrate Ideal sync DOM triggers

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -222,15 +222,6 @@ extern "js" fn js_take_structural_edit_node_id() -> String =
   #| }
 
 ///|
-/// Read and consume the pending sync status set by JS.
-extern "js" fn js_take_sync_status() -> String =
-  #| function() {
-  #|   var s = globalThis.__canopy_pending_sync_status;
-  #|   globalThis.__canopy_pending_sync_status = null;
-  #|   return typeof s === 'string' ? s : '';
-  #| }
-
-///|
 /// Tell JS whether the action overlay is currently open.
 extern "js" fn js_set_overlay_open(open : Bool) -> Unit =
   #| function(open) {

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -79,7 +79,7 @@ fn cm_mount_cmd(emit : Emit[Msg], model : Model) -> Cmd {
     on_mounted=emit(CmMounted),
     failed=emit.map(message => {
       ignore(message)
-      SyncStatusChanged("")
+      SyncStatusChanged("error")
     }),
     initial_extension=Some(js_make_ideal_cm_extension),
   )
@@ -791,8 +791,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       }
     }
     SyncStatusChanged(status) => {
-      let resolved = if status == "" { js_take_sync_status() } else { status }
-      let sync_status : SyncStatus = match resolved {
+      let sync_status : SyncStatus = match status {
         "connected" => Connected
         "connecting" => Connecting
         "disconnected" => Offline

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -62,6 +62,24 @@ test "event_detail_node_id rejects unrelated detail" {
 }
 
 ///|
+test "event_detail_status extracts status from object detail" {
+  inspect(
+    event_detail_status("{\"status\":\"connected\"}"),
+    content="connected",
+  )
+}
+
+///|
+test "event_detail_status accepts string detail fallback" {
+  inspect(event_detail_status("error"), content="error")
+}
+
+///|
+test "event_detail_status rejects unrelated detail" {
+  inspect(event_detail_status("{\"other\":\"connected\"}"), content="")
+}
+
+///|
 test "event target selector is centralized" {
   inspect(EditorHost.selector(), content="#canopy-editor")
 }
@@ -70,7 +88,9 @@ test "event target selector is centralized" {
 test "event names are centralized" {
   inspect(ActionOverlayOpen.event_type(), content="action-overlay-open")
   inspect(ActionKey.event_type(), content="action-key")
+  inspect(ExternalCrdtChange.event_type(), content="external-crdt-changed")
   inspect(LongPress.event_type(), content="long-press")
+  inspect(SyncStatus.event_type(), content="sync-status")
 }
 
 ///|

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -7,7 +7,9 @@ priv enum EventTarget {
 priv enum EventName {
   ActionOverlayOpen
   ActionKey
+  ExternalCrdtChange
   LongPress
+  SyncStatus
 }
 
 ///|
@@ -29,7 +31,9 @@ fn EventName::event_type(self : EventName) -> String {
   match self {
     ActionOverlayOpen => "action-overlay-open"
     ActionKey => "action-key"
+    ExternalCrdtChange => "external-crdt-changed"
     LongPress => "long-press"
+    SyncStatus => "sync-status"
   }
 }
 
@@ -38,7 +42,9 @@ fn EventName::key(self : EventName) -> String {
   match self {
     ActionOverlayOpen => "action-overlay-open"
     ActionKey => "action-key"
+    ExternalCrdtChange => "external-crdt-changed"
     LongPress => "long-press"
+    SyncStatus => "sync-status"
   }
 }
 
@@ -133,8 +139,18 @@ fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
     ),
     custom_event_sub(
       EditorHost,
+      ExternalCrdtChange,
+      emit.map(_ => ExternalCrdtChanged),
+    ),
+    custom_event_sub(
+      EditorHost,
       LongPress,
       emit.map(detail => LongPressTriggeredForNode(event_detail_node_id(detail))),
+    ),
+    custom_event_sub(
+      EditorHost,
+      SyncStatus,
+      emit.map(detail => SyncStatusChanged(event_detail_status(detail))),
     ),
   ])
 }
@@ -152,6 +168,23 @@ fn event_detail_node_id(detail : String) -> String {
         _ => ""
       }
     Json::String(node_id) => node_id
+    _ => detail
+  }
+}
+
+///|
+fn event_detail_status(detail : String) -> String {
+  if detail == "" {
+    return ""
+  }
+  let json = @json.parse(detail) catch { _ => return detail }
+  match json {
+    Json::Object(m) =>
+      match m.get("status") {
+        Some(Json::String(status)) => status
+        _ => ""
+      }
+    Json::String(status) => status
     _ => detail
   }
 }

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -38,21 +38,11 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   div(class="editor-wrapper", attrs=main_attrs, [
     div(attrs=text_attrs, nothing),
     node("canopy-editor", host_attrs, [@html.text("")]),
-    // Hidden buttons clicked by JS for structure/sync paths not yet moved to
-    // DOM custom-event subscriptions.
+    // Hidden buttons clicked by JS for undo/redo and structure paths not yet
+    // moved to DOM custom-event subscriptions.
     // aria-hidden + tabindex=-1 keeps them out of a11y flow.
-    hidden_trigger(
-      dispatch,
-      SyncStatusChanged(""),
-      "canopy-sync-status-trigger",
-    ),
     hidden_trigger(dispatch, Undo, "canopy-editor-undo-trigger"),
     hidden_trigger(dispatch, Redo, "canopy-editor-redo-trigger"),
-    hidden_trigger(
-      dispatch,
-      ExternalCrdtChanged,
-      "canopy-external-crdt-changed-trigger",
-    ),
     hidden_trigger(
       dispatch,
       StructureNodeSelected(""),

--- a/examples/ideal/web/e2e/editor-features.spec.ts
+++ b/examples/ideal/web/e2e/editor-features.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { dispatchExternalCrdtChanged } from './support/dom-events';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -212,8 +213,8 @@ test.describe('External Sync', () => {
       const handle = g.__canopy_crdt_handle;
       const text = g.__canopy_crdt.get_text(handle);
       g.__canopy_crdt.set_text(handle, `let remote = 0\n${text}`);
-      document.getElementById('canopy-external-crdt-changed-trigger')?.click();
     });
+    await dispatchExternalCrdtChanged(page);
     await page.waitForFunction(() => {
       return document.querySelector('#canopy-text-editor .cm-content')?.textContent?.includes('remote') ?? false;
     });

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { dispatchExternalCrdtChanged } from './support/dom-events';
 
 type ResponseSample = {
   inputToTextChangeMs: number;
@@ -58,8 +59,8 @@ async function seedEditor(page: Page, source: string) {
     }
 
     crdt.set_text(handle, text);
-    document.getElementById('canopy-external-crdt-changed-trigger')?.click();
   }, source);
+  await dispatchExternalCrdtChanged(page);
 
   await page.waitForFunction((text) => {
     const content = document.querySelector('#canopy-text-editor .cm-content');

--- a/examples/ideal/web/e2e/outline-navigation.spec.ts
+++ b/examples/ideal/web/e2e/outline-navigation.spec.ts
@@ -1,5 +1,6 @@
 // E2E test: outline tree keyboard navigation using navigate_proj.
 import { test, expect } from '@playwright/test';
+import { dispatchExternalCrdtChanged } from './support/dom-events';
 
 test.describe('Outline keyboard navigation', () => {
   test.beforeEach(async ({ page }) => {
@@ -91,8 +92,8 @@ test.describe('Outline keyboard navigation', () => {
     await page.evaluate((text) => {
       const g = globalThis as any;
       g.__canopy_crdt.set_text(g.__canopy_crdt_handle, text);
-      document.getElementById('canopy-external-crdt-changed-trigger')?.click();
     }, source);
+    await dispatchExternalCrdtChanged(page);
     const targetNode = page.getByLabel('AST outline')
       .locator('.tree-label-text', { hasText: /^119$/ })
       .first();

--- a/examples/ideal/web/e2e/support/dom-events.ts
+++ b/examples/ideal/web/e2e/support/dom-events.ts
@@ -1,0 +1,16 @@
+import type { Page } from '@playwright/test';
+import { CanopyEvents } from '../../src/events';
+
+export async function dispatchExternalCrdtChanged(page: Page) {
+  await page.evaluate((eventName) => {
+    const editor = document.querySelector('#canopy-editor');
+    if (!editor) {
+      throw new Error('Canopy editor host is not mounted');
+    }
+    editor.dispatchEvent(new CustomEvent(eventName, {
+      detail: { autosave: false },
+      bubbles: true,
+      composed: true,
+    }));
+  }, CanopyEvents.EXTERNAL_CRDT_CHANGE);
+}

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -21,6 +21,10 @@ type StructuralEditDetail = {
   nodeId?: string;
 };
 
+type ExternalCrdtChangedDetail = {
+  autosave?: boolean;
+};
+
 type CmExtensionFactory = (cm: Record<string, any>) => any | any[];
 
 type CanopyGlobal = typeof globalThis & {
@@ -29,7 +33,6 @@ type CanopyGlobal = typeof globalThis & {
   __canopy_agent_id?: string;
   __canopy_pending_node_selection?: string | null;
   __canopy_pending_structural_edit?: StructuralEditDetail | null;
-  __canopy_pending_sync_status?: string | null;
   __canopy_overlay_open?: boolean;
   __canopy_trigger_autosave?: () => void;
   __canopy_agent_name?: string;
@@ -177,15 +180,12 @@ function clickTrigger(id: string) {
   if (btn) btn.click();
 }
 
-function recordPerfSpan<T>(name: string, fn: () => T): T {
-  const perf = (globalThis as any).__canopy_perf_current;
-  if (!perf?.spans) return fn();
-  const start = performance.now();
-  try {
-    return fn();
-  } finally {
-    perf.spans[name] = (perf.spans[name] ?? 0) + performance.now() - start;
-  }
+function dispatchExternalCrdtChanged(el: CanopyEditor, detail?: ExternalCrdtChangedDetail) {
+  el.dispatchEvent(new CustomEvent(CanopyEvents.EXTERNAL_CRDT_CHANGE, {
+    detail,
+    bubbles: true,
+    composed: true,
+  }));
 }
 
 function wireEditorEvents(el: CanopyEditor) {
@@ -194,12 +194,12 @@ function wireEditorEvents(el: CanopyEditor) {
   editorEventsController = new AbortController();
   const { signal } = editorEventsController;
 
-  el.addEventListener(CanopyEvents.EXTERNAL_CRDT_CHANGE, () => {
-    recordPerfSpan("externalCrdtChangedToRabbitaTrigger", () => {
-      clickTrigger('canopy-external-crdt-changed-trigger');
-    });
-    triggerAutosave();
-  }, { signal });
+  el.addEventListener(CanopyEvents.EXTERNAL_CRDT_CHANGE, ((event: Event) => {
+    const detail = (event as CustomEvent<ExternalCrdtChangedDetail>).detail;
+    if (detail?.autosave !== false) {
+      triggerAutosave();
+    }
+  }) as EventListener, { signal });
   el.addEventListener(CanopyEvents.NODE_SELECTED, ((event: Event) => {
     const { nodeId } = (event as CustomEvent<NodeSelectedDetail>).detail ?? {};
     canopyGlobal.__canopy_pending_node_selection = nodeId ?? null;
@@ -250,8 +250,7 @@ function wireEditorEvents(el: CanopyEditor) {
     if (didUndo) {
       el.syncAfterExternalChange();
       el.notifyLocalChange();
-      triggerAutosave();
-      clickTrigger('canopy-external-crdt-changed-trigger');
+      dispatchExternalCrdtChanged(el);
     }
   }, { signal });
   el.addEventListener(CanopyEvents.REQUEST_REDO, () => {
@@ -262,17 +261,9 @@ function wireEditorEvents(el: CanopyEditor) {
     if (didRedo) {
       el.syncAfterExternalChange();
       el.notifyLocalChange();
-      triggerAutosave();
-      clickTrigger('canopy-external-crdt-changed-trigger');
+      dispatchExternalCrdtChanged(el);
     }
   }, { signal });
-  el.addEventListener('sync-status', ((event: Event) => {
-    const { status } = (event as CustomEvent<{ status: string }>).detail ?? {};
-    if (status) {
-      canopyGlobal.__canopy_pending_sync_status = status;
-      clickTrigger('canopy-sync-status-trigger');
-    }
-  }) as EventListener, { signal });
 
   // When remote ephemeral data arrives, update text-mode peer cursor decorations.
   el.addEventListener('sync-cursors-updated', () => {
@@ -387,7 +378,7 @@ function doMount(el: CanopyEditor, crdt: CrdtModule) {
   el.mount(handle, crdt);
   wireEditorEvents(el);
   if (restoredState) {
-    clickTrigger('canopy-external-crdt-changed-trigger');
+    dispatchExternalCrdtChanged(el, { autosave: false });
   }
   if (!SKIP_SYNC) {
     startSync(el, handle, crdt, roomId);


### PR DESCRIPTION
## Summary

- Move Ideal `sync-status` and `external-crdt-changed` paths from hidden trigger buttons to the existing Rabbita DOM custom-event subscription adapter.
- Remove the sync-status pending global and its JS FFI reader.
- Dispatch the existing `CanopyEvents.EXTERNAL_CRDT_CHANGE` event for undo/redo and restored-state refreshes, preserving autosave behavior.
- Update E2E helpers/tests that previously clicked the external CRDT hidden trigger.

## Scope

This intentionally leaves the remaining hidden triggers for undo/redo and structure payload paths to later PRs.

## Validation

- `rtk moon update`
- `rtk moon check --deny-warn`
- `rtk moon fmt --check`
- `rtk moon info`
- `rtk moon test` -> 32 passed
- `npm run build`
- `timeout 300s env CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run test -- e2e/editor-features.spec.ts -g "preserves local cursor when CRDT text is refreshed" --reporter=line` -> passed
- `timeout 300s env CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run test -- e2e/outline-navigation.spec.ts -g "click scrolls selected text into view" --reporter=line` -> passed
- `git diff --check`
- `.mbti` diff reviewed: no interface changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync status error reporting to properly display error state on CodeMirror mount failures.

* **Refactor**
  * Transitioned event dispatching from DOM-based triggers to programmatic custom events for external CRDT changes and sync status updates, simplifying the event flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->