### PR TITLE
[codex] Migrate Ideal structure DOM triggers

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -193,35 +193,6 @@ extern "js" fn js_set_editor_selected_node(node_id : String) -> Unit =
   #| }
 
 ///|
-/// Consume the last node selected from the Web Component.
-extern "js" fn js_take_selected_node_id() -> String =
-  #| function() {
-  #|   var nodeId = globalThis.__canopy_pending_node_selection;
-  #|   globalThis.__canopy_pending_node_selection = null;
-  #|   return typeof nodeId === 'string' ? nodeId : '';
-  #| }
-
-///|
-/// Consume the pending structural edit op forwarded from the Web Component.
-/// Clears the global to prevent stale reads.
-extern "js" fn js_take_structural_edit_op() -> String =
-  #| function() {
-  #|   var pending = globalThis.__canopy_pending_structural_edit;
-  #|   if (!pending) return '';
-  #|   return typeof pending.op === 'string' ? pending.op : '';
-  #| }
-
-///|
-/// Consume the pending structural edit node ID and clear the global.
-extern "js" fn js_take_structural_edit_node_id() -> String =
-  #| function() {
-  #|   var pending = globalThis.__canopy_pending_structural_edit;
-  #|   globalThis.__canopy_pending_structural_edit = null;
-  #|   if (!pending) return '';
-  #|   return typeof pending.nodeId === 'string' ? pending.nodeId : '';
-  #| }
-
-///|
 /// Tell JS whether the action overlay is currently open.
 extern "js" fn js_set_overlay_open(open : Bool) -> Unit =
   #| function(open) {

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -612,19 +612,12 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       let new_model = { ..model, bottom_tab: tab }
       (bottom_tab_focus_cmd(tab), new_model)
     }
-    StructuralEditRequested(op~, node_id~) => {
-      let resolved_op = if op == "" { js_take_structural_edit_op() } else { op }
-      let resolved_node_id = if node_id == "" {
-        js_take_structural_edit_node_id()
-      } else {
-        node_id
-      }
-      if resolved_op == "" || resolved_node_id == "" {
+    StructuralEditRequested(op~, node_id~) =>
+      if op == "" || node_id == "" {
         (none, model)
       } else {
-        apply_structural_edit_request(model, resolved_op, resolved_node_id)
+        apply_structural_edit_request(model, op, node_id)
       }
-    }
     TreeEdited(op) =>
       match op {
         @lambda_edits.Expand(node_id~) => {
@@ -948,44 +941,28 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       }
     }
     // ── Structure-mode Web Component communication ──────
-    StructureNodeSelected(node_id) => {
-      let resolved_node_id = if node_id == "" {
-        js_take_selected_node_id()
-      } else {
-        node_id
-      }
-      if resolved_node_id == "" {
+    StructureNodeSelected(node_id) =>
+      if node_id == "" {
         (none, model)
       } else {
-        let highlight_set = match parse_node_id(resolved_node_id) {
+        let highlight_set = match parse_node_id(node_id) {
           Some(nid) => compute_highlight_set(nid, model.scope_map)
           None => @immut/hashset.new()
         }
-        (
-          none,
-          { ..model, selected_node: Some(resolved_node_id), highlight_set },
-        )
+        (none, { ..model, selected_node: Some(node_id), highlight_set })
       }
-    }
-    StructureStructuralEdit(op~, node_id~) => {
-      let resolved_op = if op == "" { js_take_structural_edit_op() } else { op }
-      let resolved_node_id = if node_id == "" {
-        js_take_structural_edit_node_id()
-      } else {
-        node_id
-      }
-      if resolved_op == "" || resolved_node_id == "" {
+    StructureStructuralEdit(op~, node_id~) =>
+      if op == "" || node_id == "" {
         (none, model)
       } else {
         // The edit was already applied by TS calling handle_structural_intent FFI.
-        push_intent_label(model, "\{resolved_op}(node=\{resolved_node_id})")
+        push_intent_label(model, "\{op}(node=\{node_id})")
         let new_model = refresh({
           ..model,
           next_timestamp: model.next_timestamp + 1,
         })
         (sync_after_external_crdt_change(new_model), new_model)
       }
-    }
     ExternalCrdtChanged => {
       let new_model = refresh(model)
       (sync_after_external_crdt_change(new_model), new_model)

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -80,6 +80,29 @@ test "event_detail_status rejects unrelated detail" {
 }
 
 ///|
+test "event_detail_structural_edit extracts op and nodeId" {
+  let (op, node_id) = event_detail_structural_edit(
+    "{\"op\":\"Drop\",\"nodeId\":\"7\"}",
+  )
+  inspect(op, content="Drop")
+  inspect(node_id, content="7")
+}
+
+///|
+test "event_detail_structural_edit rejects incomplete detail" {
+  let (op, node_id) = event_detail_structural_edit("{\"op\":\"Drop\"}")
+  inspect(op, content="Drop")
+  inspect(node_id, content="")
+}
+
+///|
+test "event_detail_structural_edit rejects non-object detail" {
+  let (op, node_id) = event_detail_structural_edit("Drop")
+  inspect(op, content="")
+  inspect(node_id, content="")
+}
+
+///|
 test "event target selector is centralized" {
   inspect(EditorHost.selector(), content="#canopy-editor")
 }
@@ -90,6 +113,8 @@ test "event names are centralized" {
   inspect(ActionKey.event_type(), content="action-key")
   inspect(ExternalCrdtChange.event_type(), content="external-crdt-changed")
   inspect(LongPress.event_type(), content="long-press")
+  inspect(NodeSelected.event_type(), content="node-selected")
+  inspect(StructuralEditApplied.event_type(), content="structural-edit-applied")
   inspect(SyncStatus.event_type(), content="sync-status")
 }
 

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -9,6 +9,8 @@ priv enum EventName {
   ActionKey
   ExternalCrdtChange
   LongPress
+  NodeSelected
+  StructuralEditApplied
   SyncStatus
 }
 
@@ -33,6 +35,8 @@ fn EventName::event_type(self : EventName) -> String {
     ActionKey => "action-key"
     ExternalCrdtChange => "external-crdt-changed"
     LongPress => "long-press"
+    NodeSelected => "node-selected"
+    StructuralEditApplied => "structural-edit-applied"
     SyncStatus => "sync-status"
   }
 }
@@ -44,6 +48,8 @@ fn EventName::key(self : EventName) -> String {
     ActionKey => "action-key"
     ExternalCrdtChange => "external-crdt-changed"
     LongPress => "long-press"
+    NodeSelected => "node-selected"
+    StructuralEditApplied => "structural-edit-applied"
     SyncStatus => "sync-status"
   }
 }
@@ -149,6 +155,19 @@ fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
     ),
     custom_event_sub(
       EditorHost,
+      NodeSelected,
+      emit.map(detail => StructureNodeSelected(event_detail_node_id(detail))),
+    ),
+    custom_event_sub(
+      EditorHost,
+      StructuralEditApplied,
+      emit.map(detail => {
+        let (op, node_id) = event_detail_structural_edit(detail)
+        StructureStructuralEdit(op~, node_id~)
+      }),
+    ),
+    custom_event_sub(
+      EditorHost,
       SyncStatus,
       emit.map(detail => SyncStatusChanged(event_detail_status(detail))),
     ),
@@ -186,5 +205,27 @@ fn event_detail_status(detail : String) -> String {
       }
     Json::String(status) => status
     _ => detail
+  }
+}
+
+///|
+fn event_detail_structural_edit(detail : String) -> (String, String) {
+  if detail == "" {
+    return ("", "")
+  }
+  let json = @json.parse(detail) catch { _ => return ("", "") }
+  match json {
+    Json::Object(m) => {
+      let op = match m.get("op") {
+        Some(Json::String(value)) => value
+        _ => ""
+      }
+      let node_id = match m.get("nodeId") {
+        Some(Json::String(value)) => value
+        _ => ""
+      }
+      (op, node_id)
+    }
+    _ => ("", "")
   }
 }

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -38,20 +38,10 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   div(class="editor-wrapper", attrs=main_attrs, [
     div(attrs=text_attrs, nothing),
     node("canopy-editor", host_attrs, [@html.text("")]),
-    // Hidden buttons clicked by JS for undo/redo and structure paths not yet
-    // moved to DOM custom-event subscriptions.
+    // Hidden buttons clicked by JS for undo/redo paths not yet moved to DOM
+    // custom-event subscriptions.
     // aria-hidden + tabindex=-1 keeps them out of a11y flow.
     hidden_trigger(dispatch, Undo, "canopy-editor-undo-trigger"),
     hidden_trigger(dispatch, Redo, "canopy-editor-redo-trigger"),
-    hidden_trigger(
-      dispatch,
-      StructureNodeSelected(""),
-      "canopy-structure-node-selected-trigger",
-    ),
-    hidden_trigger(
-      dispatch,
-      StructureStructuralEdit(op="", node_id=""),
-      "canopy-structure-structural-edit-trigger",
-    ),
   ])
 }

--- a/examples/ideal/web/src/events.ts
+++ b/examples/ideal/web/src/events.ts
@@ -3,6 +3,7 @@ export const CanopyEvents = {
   EXTERNAL_CRDT_CHANGE: 'external-crdt-changed',
   NODE_SELECTED: 'node-selected',
   STRUCTURAL_EDIT_REQUEST: 'structural-edit-request',
+  STRUCTURAL_EDIT_APPLIED: 'structural-edit-applied',
   CURSOR_MOVE: 'cursor-move',
   REQUEST_UNDO: 'request-undo',
   REQUEST_REDO: 'request-redo',

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -12,13 +12,13 @@ import { lambda } from './lang/lambda-language';
 import { SyncClient } from './sync';
 import type { CrdtModule } from './types';
 
-type NodeSelectedDetail = {
-  nodeId?: string;
-};
-
 type StructuralEditDetail = {
   op?: string;
   nodeId?: string;
+  position?: string;
+  source?: string | number;
+  target?: string | number;
+  type?: string;
 };
 
 type ExternalCrdtChangedDetail = {
@@ -31,8 +31,6 @@ type CanopyGlobal = typeof globalThis & {
   __canopy_crdt?: CrdtModule;
   __canopy_crdt_handle?: number;
   __canopy_agent_id?: string;
-  __canopy_pending_node_selection?: string | null;
-  __canopy_pending_structural_edit?: StructuralEditDetail | null;
   __canopy_overlay_open?: boolean;
   __canopy_trigger_autosave?: () => void;
   __canopy_agent_name?: string;
@@ -175,14 +173,19 @@ function agentDisplayName(agentId: string): string {
   return `Peer-${suffix}`;
 }
 
-function clickTrigger(id: string) {
-  const btn = document.getElementById(id) as HTMLButtonElement | null;
-  if (btn) btn.click();
-}
-
 function dispatchExternalCrdtChanged(el: CanopyEditor, detail?: ExternalCrdtChangedDetail) {
   el.dispatchEvent(new CustomEvent(CanopyEvents.EXTERNAL_CRDT_CHANGE, {
     detail,
+    bubbles: true,
+    composed: true,
+  }));
+}
+
+function dispatchStructuralEditApplied(el: CanopyEditor, detail: StructuralEditDetail) {
+  const op = detail.op ?? detail.type ?? "";
+  const nodeId = detail.nodeId ?? String(detail.target ?? "");
+  el.dispatchEvent(new CustomEvent(CanopyEvents.STRUCTURAL_EDIT_APPLIED, {
+    detail: { op, nodeId },
     bubbles: true,
     composed: true,
   }));
@@ -200,13 +203,8 @@ function wireEditorEvents(el: CanopyEditor) {
       triggerAutosave();
     }
   }) as EventListener, { signal });
-  el.addEventListener(CanopyEvents.NODE_SELECTED, ((event: Event) => {
-    const { nodeId } = (event as CustomEvent<NodeSelectedDetail>).detail ?? {};
-    canopyGlobal.__canopy_pending_node_selection = nodeId ?? null;
-    clickTrigger('canopy-structure-node-selected-trigger');
-  }) as EventListener, { signal });
   el.addEventListener(CanopyEvents.STRUCTURAL_EDIT_REQUEST, ((event: Event) => {
-    const detail = (event as CustomEvent).detail ?? {};
+    const detail = (event as CustomEvent<StructuralEditDetail>).detail ?? {};
     if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
     const crdt = canopyGlobal.__canopy_crdt;
     const handle = canopyGlobal.__canopy_crdt_handle;
@@ -236,11 +234,8 @@ function wireEditorEvents(el: CanopyEditor) {
     el.syncAfterExternalChange();
     el.notifyLocalChange();
     // Trigger Rabbita refresh
-    const op = detail.op ?? detail.type;
-    const nodeId = detail.nodeId ?? String(detail.target ?? "");
-    canopyGlobal.__canopy_pending_structural_edit = { op, nodeId };
     triggerAutosave();
-    clickTrigger('canopy-structure-structural-edit-trigger');
+    dispatchStructuralEditApplied(el, detail);
   }) as EventListener, { signal });
   el.addEventListener(CanopyEvents.REQUEST_UNDO, () => {
     if (!canopyGlobal.__canopy_crdt || canopyGlobal.__canopy_crdt_handle == null) return;
@@ -335,8 +330,6 @@ function doMount(el: CanopyEditor, crdt: CrdtModule) {
   const handle = 1;
   const roomId = getRoomId();
   canopyGlobal.__canopy_crdt_handle = handle;
-  canopyGlobal.__canopy_pending_node_selection = null;
-  canopyGlobal.__canopy_pending_structural_edit = null;
   canopyGlobal.__canopy_trigger_autosave = triggerAutosave;
   let restoredState = false;
 

--- a/examples/ideal/web/src/structure-nodeview.ts
+++ b/examples/ideal/web/src/structure-nodeview.ts
@@ -1,5 +1,6 @@
 import { EditorView as PmView, NodeView } from "prosemirror-view";
 import { Node as PmNode } from "prosemirror-model";
+import { CanopyEvents } from "./events";
 
 // Kind tag to display badge
 const kindBadges: Record<string, string> = {
@@ -173,7 +174,7 @@ export class StructureCompoundView implements NodeView {
       const sourceId = e.dataTransfer!.getData("application/x-canopy-node");
       if (!sourceId || sourceId === String(nid)) return;
 
-      this.dom.dispatchEvent(new CustomEvent("structural-edit-request", {
+      this.dom.dispatchEvent(new CustomEvent(CanopyEvents.STRUCTURAL_EDIT_REQUEST, {
         bubbles: true,
         composed: true, // cross shadow DOM boundary
         detail: {
@@ -257,7 +258,7 @@ export class StructureLeafView implements NodeView {
       const sourceId = e.dataTransfer!.getData("application/x-canopy-node");
       if (!sourceId || sourceId === String(nid)) return;
 
-      this.dom.dispatchEvent(new CustomEvent("structural-edit-request", {
+      this.dom.dispatchEvent(new CustomEvent(CanopyEvents.STRUCTURAL_EDIT_REQUEST, {
         bubbles: true,
         composed: true,
         detail: {


### PR DESCRIPTION
## Summary

- Move Ideal structure-mode `node-selected` and structural-edit refresh paths from hidden trigger buttons to Rabbita DOM custom-event subscriptions.
- Add a post-apply `structural-edit-applied` event so MoonBit refreshes only after TypeScript has applied the structure edit to CRDT state.
- Remove the structure pending globals and their MoonBit JS FFI readers.
- Centralize remaining raw `structural-edit-request` dispatches behind `CanopyEvents.STRUCTURAL_EDIT_REQUEST`.
- Add whitebox tests for structure event payload parsing.

## Scope

This intentionally leaves the remaining CodeMirror undo/redo hidden triggers for a separate PR.

## Validation

- `rtk moon update`
- `rtk moon check --deny-warn`
- `rtk moon fmt --check`
- `rtk moon info`
- `rtk moon test` -> 35 passed
- `npm run build`
- `timeout 300s env CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run test -- e2e/structural-editing.spec.ts -g "Space opens overlay on selected Var node" --reporter=line` -> passed
- `timeout 300s env CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run test -- e2e/drag-drop.spec.ts -g "drop syncs CM6 before returning to Text mode" --reporter=line` -> passed
- `git diff --check`
- `.mbti` diff reviewed: no interface changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structural edit event handling by requiring complete payload data, eliminating fallback resolution mechanisms that could cause missing values.

* **Tests**
  * Added test coverage for structural edit event extraction and validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->