### PR TITLE
[codex] Move Ideal undo/redo shortcuts to Rabbita events

### DIFF
--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -25,6 +25,8 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   cm : @js_value.Value,
 ) -> @js_value.Value =
   #| function(cm) {
+  #|   const CANOPY_EVENT_REQUEST_UNDO = "request-undo";
+  #|   const CANOPY_EVENT_REQUEST_REDO = "request-redo";
   #|   const dispatchTextEditorEvent = (eventType) => {
   #|     const target = document.getElementById("canopy-text-editor");
   #|     if (target && typeof target.dispatchEvent === "function") {
@@ -104,21 +106,21 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   #|     {
   #|       key: "Mod-z",
   #|       run: () => {
-  #|         dispatchTextEditorEvent("request-undo");
+  #|         dispatchTextEditorEvent(CANOPY_EVENT_REQUEST_UNDO);
   #|         return true;
   #|       },
   #|     },
   #|     {
   #|       key: "Mod-Shift-z",
   #|       run: () => {
-  #|         dispatchTextEditorEvent("request-redo");
+  #|         dispatchTextEditorEvent(CANOPY_EVENT_REQUEST_REDO);
   #|         return true;
   #|       },
   #|     },
   #|     {
   #|       key: "Mod-y",
   #|       run: () => {
-  #|         dispatchTextEditorEvent("request-redo");
+  #|         dispatchTextEditorEvent(CANOPY_EVENT_REQUEST_REDO);
   #|         return true;
   #|       },
   #|     },

--- a/examples/ideal/main/bridge_ffi.mbt
+++ b/examples/ideal/main/bridge_ffi.mbt
@@ -25,9 +25,14 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   cm : @js_value.Value,
 ) -> @js_value.Value =
   #| function(cm) {
-  #|   const click = (id) => {
-  #|     const btn = document.getElementById(id);
-  #|     if (btn && typeof btn.click === 'function') btn.click();
+  #|   const dispatchTextEditorEvent = (eventType) => {
+  #|     const target = document.getElementById("canopy-text-editor");
+  #|     if (target && typeof target.dispatchEvent === "function") {
+  #|       target.dispatchEvent(new CustomEvent(eventType, {
+  #|         bubbles: true,
+  #|         composed: true,
+  #|       }));
+  #|     }
   #|   };
   #|   const normalizeExtensions = (factory) => {
   #|     const provided = typeof factory === 'function' ? factory(cm) : [];
@@ -99,21 +104,21 @@ extern "js" fn js_make_ideal_cm_extension_raw(
   #|     {
   #|       key: "Mod-z",
   #|       run: () => {
-  #|         click("canopy-editor-undo-trigger");
+  #|         dispatchTextEditorEvent("request-undo");
   #|         return true;
   #|       },
   #|     },
   #|     {
   #|       key: "Mod-Shift-z",
   #|       run: () => {
-  #|         click("canopy-editor-redo-trigger");
+  #|         dispatchTextEditorEvent("request-redo");
   #|         return true;
   #|       },
   #|     },
   #|     {
   #|       key: "Mod-y",
   #|       run: () => {
-  #|         click("canopy-editor-redo-trigger");
+  #|         dispatchTextEditorEvent("request-redo");
   #|         return true;
   #|       },
   #|     },

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -105,6 +105,7 @@ test "event_detail_structural_edit rejects non-object detail" {
 ///|
 test "event target selector is centralized" {
   inspect(EditorHost.selector(), content="#canopy-editor")
+  inspect(TextEditor.selector(), content="#canopy-text-editor")
 }
 
 ///|
@@ -114,6 +115,8 @@ test "event names are centralized" {
   inspect(ExternalCrdtChange.event_type(), content="external-crdt-changed")
   inspect(LongPress.event_type(), content="long-press")
   inspect(NodeSelected.event_type(), content="node-selected")
+  inspect(RequestUndo.event_type(), content="request-undo")
+  inspect(RequestRedo.event_type(), content="request-redo")
   inspect(StructuralEditApplied.event_type(), content="structural-edit-applied")
   inspect(SyncStatus.event_type(), content="sync-status")
 }

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -1,6 +1,7 @@
 ///|
 priv enum EventTarget {
   EditorHost
+  TextEditor
 }
 
 ///|
@@ -10,6 +11,8 @@ priv enum EventName {
   ExternalCrdtChange
   LongPress
   NodeSelected
+  RequestRedo
+  RequestUndo
   StructuralEditApplied
   SyncStatus
 }
@@ -18,6 +21,7 @@ priv enum EventName {
 fn EventTarget::selector(self : EventTarget) -> String {
   match self {
     EditorHost => "#canopy-editor"
+    TextEditor => "#canopy-text-editor"
   }
 }
 
@@ -25,6 +29,7 @@ fn EventTarget::selector(self : EventTarget) -> String {
 fn EventTarget::key(self : EventTarget) -> String {
   match self {
     EditorHost => "editor-host"
+    TextEditor => "text-editor"
   }
 }
 
@@ -36,6 +41,8 @@ fn EventName::event_type(self : EventName) -> String {
     ExternalCrdtChange => "external-crdt-changed"
     LongPress => "long-press"
     NodeSelected => "node-selected"
+    RequestRedo => "request-redo"
+    RequestUndo => "request-undo"
     StructuralEditApplied => "structural-edit-applied"
     SyncStatus => "sync-status"
   }
@@ -49,6 +56,8 @@ fn EventName::key(self : EventName) -> String {
     ExternalCrdtChange => "external-crdt-changed"
     LongPress => "long-press"
     NodeSelected => "node-selected"
+    RequestRedo => "request-redo"
+    RequestUndo => "request-undo"
     StructuralEditApplied => "structural-edit-applied"
     SyncStatus => "sync-status"
   }
@@ -158,6 +167,8 @@ fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
       NodeSelected,
       emit.map(detail => StructureNodeSelected(event_detail_node_id(detail))),
     ),
+    custom_event_sub(TextEditor, RequestUndo, emit.map(_ => Undo)),
+    custom_event_sub(TextEditor, RequestRedo, emit.map(_ => Redo)),
     custom_event_sub(
       EditorHost,
       StructuralEditApplied,

--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -2,24 +2,7 @@
 using @html {node, nothing}
 
 ///|
-fn hidden_trigger(
-  dispatch : @rabbita.Emit[Msg],
-  msg : Msg,
-  id : String,
-) -> @rabbita.Html {
-  @html.button(
-    on_click=dispatch(msg),
-    attrs=@html.Attrs::build()
-      .class("hidden-trigger")
-      .id(id)
-      .aria_hidden("true")
-      .tabindex(-1),
-    [@html.text("")],
-  )
-}
-
-///|
-fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
+fn view_editor(_dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   let attrs = @html.Attrs::build().id("canopy-editor")
   let hidden_attrs = @html.Attrs::build()
     .id("canopy-editor")
@@ -38,10 +21,5 @@ fn view_editor(dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   div(class="editor-wrapper", attrs=main_attrs, [
     div(attrs=text_attrs, nothing),
     node("canopy-editor", host_attrs, [@html.text("")]),
-    // Hidden buttons clicked by JS for undo/redo paths not yet moved to DOM
-    // custom-event subscriptions.
-    // aria-hidden + tabindex=-1 keeps them out of a11y flow.
-    hidden_trigger(dispatch, Undo, "canopy-editor-undo-trigger"),
-    hidden_trigger(dispatch, Redo, "canopy-editor-redo-trigger"),
   ])
 }

--- a/examples/ideal/web/e2e/editor-features.spec.ts
+++ b/examples/ideal/web/e2e/editor-features.spec.ts
@@ -329,11 +329,9 @@ test.describe('Bottom Panel Tabs', () => {
 test.describe('Sync Status', () => {
   test('shows connection status in PEERS section', async ({ page }) => {
     await waitForEditor(page);
-    // Should show Connecting or Offline (no server running)
+    // Full E2E starts the relay server; focused/local runs may skip it.
     const peersText = await page.locator('.peer-item').innerText();
-    expect(
-      peersText.includes('Connecting') || peersText.includes('Offline'),
-    ).toBe(true);
+    expect(peersText).toMatch(/Connecting|Offline|connected/i);
   });
 
   test('peer dot is visible', async ({ page }) => {

--- a/examples/ideal/web/e2e/editor-features.spec.ts
+++ b/examples/ideal/web/e2e/editor-features.spec.ts
@@ -331,7 +331,9 @@ test.describe('Sync Status', () => {
     await waitForEditor(page);
     // Full E2E starts the relay server; focused/local runs may skip it.
     const peersText = await page.locator('.peer-item').innerText();
-    expect(peersText).toMatch(/Connecting|Offline|connected/i);
+    expect(peersText).toMatch(
+      /^(?:You \(connected\)|Connecting\u2026|Offline \u2014 reconnecting\u2026)$/,
+    );
   });
 
   test('peer dot is visible', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add Ideal Rabbita DOM custom-event subscriptions for `request-undo` and `request-redo` on `#canopy-text-editor`.
- Change the CodeMirror keymap to dispatch those custom events instead of clicking hidden undo/redo buttons, with local JS constants for the event names.
- Remove the remaining undo/redo hidden trigger buttons and cover the new event target/name constants in whitebox tests.
- Update the sync-status E2E expectation so the relay-enabled full suite accepts the valid `connected` state as well as local/focused `Connecting` and `Offline` states.

## Notes

The existing TypeScript `request-undo` / `request-redo` listeners on `<canopy-editor>` remain in place for structure-mode paths. CodeMirror dispatches from `#canopy-text-editor`, which is a sibling of `<canopy-editor>`, so the text-mode shortcut is handled by Rabbita without double-applying through the TS host listener.

## Validation

- `moon check --deny-warn` in `examples/ideal`
- `moon test` in `examples/ideal` (`35/35` passed)
- `moon fmt`, `moon fmt --check`, `moon info` with no `.mbti` diff
- root `moon check --deny-warn`
- root `moon test` (`175/175` wasm-gc, `993/993` JS)
- `moon build --target js`
- `npm run build` in `examples/ideal/web`
- focused Playwright: `CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run test -- e2e/editor-features.spec.ts -g "undo reverts typed text" --reporter=line` (`1 passed`)
- focused Playwright after local event constants: `npm run test -- e2e/editor-features.spec.ts -g "undo reverts typed text" --reporter=line` (`1 passed`)
- focused Playwright: `npm run test -- e2e/editor-features.spec.ts -g "shows connection status in PEERS section" --reporter=line` (`1 passed`)
- full Playwright: `npm run test -- --reporter=line` (`70/70` passed)