### PR TITLE
refactor(ideal): rename hidden-trigger CSS class to inactive-pane

### DIFF
--- a/examples/ideal/main/view_editor.mbt
+++ b/examples/ideal/main/view_editor.mbt
@@ -4,20 +4,20 @@ using @html {node, nothing}
 ///|
 fn view_editor(_dispatch : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
   let attrs = @html.Attrs::build().id("canopy-editor")
-  let hidden_attrs = @html.Attrs::build()
+  let inactive_attrs = @html.Attrs::build()
     .id("canopy-editor")
-    .class("hidden-trigger")
+    .class("inactive-pane")
     .aria_hidden("true")
     .tabindex(-1)
   let cm_attrs = @html.Attrs::build().id("canopy-text-editor")
-  let hidden_cm_attrs = @html.Attrs::build()
+  let inactive_cm_attrs = @html.Attrs::build()
     .id("canopy-text-editor")
-    .class("hidden-trigger")
+    .class("inactive-pane")
     .aria_hidden("true")
     .tabindex(-1)
   let main_attrs = @html.Attrs::build().role("main").aria_label("Code editor")
-  let text_attrs = if model.mode == Text { cm_attrs } else { hidden_cm_attrs }
-  let host_attrs = if model.mode == Text { hidden_attrs } else { attrs }
+  let text_attrs = if model.mode == Text { cm_attrs } else { inactive_cm_attrs }
+  let host_attrs = if model.mode == Text { inactive_attrs } else { attrs }
   div(class="editor-wrapper", attrs=main_attrs, [
     div(attrs=text_attrs, nothing),
     node("canopy-editor", host_attrs, [@html.text("")]),

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -442,7 +442,7 @@ button:focus-visible, .action-btn:focus-visible,
 
 /* ── Editor ─────────────────────────────────────────────── */
 
-.hidden-trigger {
+.inactive-pane {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -467,7 +467,7 @@ canopy-editor {
   height: 100%;
 }
 
-#canopy-text-editor:not(.hidden-trigger) {
+#canopy-text-editor:not(.inactive-pane) {
   display: block;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary

- Pre-#318, the CSS class `hidden-trigger` was applied to hidden buttons that received programmatic `.click()` calls for undo/redo. #318 routed those through Rabbita `request-undo`/`request-redo` events, so the buttons are gone.
- The only remaining usage of the class is on whichever editor pane (text vs structure) is currently *inactive* — a visibility toggle, not a click trigger. The name became misleading.
- Renames `.hidden-trigger` → `.inactive-pane` in CSS and MoonBit, plus local vars `hidden_attrs`/`hidden_cm_attrs` → `inactive_attrs`/`inactive_cm_attrs` in `view_editor.mbt`.

Scope intentionally minimal: 2 files, 8 lines. Archive doc references in `docs/archive/completed-phases/2026-03-21-*` left as-is per archive convention.

## Test plan

- [x] `cd examples/ideal && moon check` — clean
- [x] `cd examples/ideal && moon test` — 35/35
- [x] `moon fmt` + `moon info` — no-op
- [x] Repo-wide grep for `hidden-trigger`/`hidden_trigger` — only the 4 intended sites + 3 archive refs
- [x] No TypeScript DOM selectors reference `.hidden-trigger`
- [x] Codex pre-PR review — pass, no findings
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)