### PR TITLE
ci: type-check examples/{web,prosemirror,demo-react} with tsc --noEmit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,51 @@ jobs:
             graphviz/_build/js/release/build/browser/browser.d.ts
           retention-days: 7
 
+  typecheck-ts-examples:
+    name: Type Check TS Examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: web
+            path: examples/web
+          - name: prosemirror
+            path: examples/prosemirror
+          - name: demo-react
+            path: examples/demo-react
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ${{ matrix.path }}/package-lock.json
+
+      - name: Update MoonBit dependencies
+        run: ./scripts/update-moon-deps.sh
+
+      - name: Build MoonBit JS artifacts
+        run: ./scripts/build-js.sh
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.path }}
+        run: npm ci
+
+      - name: Type check
+        working-directory: ${{ matrix.path }}
+        run: npx tsc --noEmit
+
   web-build:
     name: Build Web Example
     runs-on: ubuntu-latest
@@ -388,6 +433,7 @@ jobs:
       - prove
       - format-check
       - build-js
+      - typecheck-ts-examples
       - web-build
       - web-e2e
       - demo-react-e2e
@@ -403,6 +449,7 @@ jobs:
              [[ "${{ needs.prove.result }}" != "success" ]] || \
              [[ "${{ needs.format-check.result }}" != "success" ]] || \
              [[ "${{ needs.build-js.result }}" != "success" ]] || \
+             [[ "${{ needs.typecheck-ts-examples.result }}" != "success" ]] || \
              [[ "${{ needs.web-build.result }}" != "success" ]] || \
              [[ "${{ needs.web-e2e.result }}" != "success" ]] || \
              [[ "${{ needs.demo-react-e2e.result }}" != "success" ]] || \

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -41,9 +41,8 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: current supported targets are native and JS only.
   Exit: wasm build runs in CI and is documented as supported.
 
-- [ ] Add `npx tsc --noEmit` CI job for `examples/{web,prosemirror,demo-react}`.
-  Why: no CI job currently type-checks the examples, so regressions in the `@canopy/editor-adapter` package or example sources go unnoticed until a human runs tsc locally (cf. the 28 errors that silently accumulated between the Stage 5 adapter move and PR #211).
-  Exit: a CI job runs `tsc --noEmit` per example and blocks merge on failure.
+- [x] Add `npx tsc --noEmit` CI job for `examples/{web,prosemirror,demo-react}`.
+  Shipped: `typecheck-ts-examples` matrix job in `.github/workflows/ci.yml`; builds MoonBit JS artifacts, installs deps, runs `npx tsc --noEmit` per example, gated by `all-checks-passed`. Drift it caught on the way in: `examples/demo-react/tsconfig.json` had a deprecated `"baseUrl": "."` (TS 6.0 TS5101 deprecation; redundant under `moduleResolution: "bundler"` since `paths` already resolves relative to the tsconfig); dropped in the same change.
 
 - [ ] Reduce CRDT JS bundle size for `index.html` / `memo.html` (lambda bundle is 546 kB, 46 kB over 500 kB threshold).
   Why: large bundle impacts initial page load for web editors.

--- a/examples/demo-react/tsconfig.json
+++ b/examples/demo-react/tsconfig.json
@@ -16,8 +16,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
       "@moonbit/crdt": ["../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js"]
     }

--- a/examples/prosemirror/package-lock.json
+++ b/examples/prosemirror/package-lock.json
@@ -19,13 +19,14 @@
         "prosemirror-view": "^1.37.0"
       },
       "devDependencies": {
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "vite": "^6.0.0"
       }
     },
     "../../adapters/editor-adapter": {
       "name": "@canopy/editor-adapter",
-      "version": "0.0.0",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@codemirror/commands": "^6.10.0",
         "@codemirror/language": "^6.10.0",
@@ -1246,9 +1247,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/prosemirror/package.json
+++ b/examples/prosemirror/package.json
@@ -20,7 +20,7 @@
     "prosemirror-view": "^1.37.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Add `typecheck-ts-examples` matrix CI job that runs `npx tsc --noEmit` against `examples/{web,prosemirror,demo-react}` after building MoonBit JS artifacts, gated by `all-checks-passed`. Closes `docs/TODO.md` §1 item.
- Fix deprecated `baseUrl: "."` in `examples/demo-react/tsconfig.json` (TS 6.0 TS5101) — redundant under `moduleResolution: "bundler"`; dropped rather than masked with `ignoreDeprecations`.
- Bump `examples/prosemirror` typescript `^5.7.0` → `^6.0.3` for uniformity with web and demo-react. Zero source changes.

## Why

No CI job currently type-checks the TS examples, so regressions in `@canopy/editor-adapter` or example sources go unnoticed until a human runs tsc locally — see the 28 errors that silently accumulated between the Stage 5 adapter move and PR #211.

## Test plan

- [x] `./node_modules/.bin/tsc --noEmit` exit 0 in `examples/web` (TS 6.0.2)
- [x] `./node_modules/.bin/tsc --noEmit` exit 0 in `examples/prosemirror` (TS 6.0.3 after bump)
- [x] `./node_modules/.bin/tsc --noEmit` exit 0 in `examples/demo-react` (TS 6.0.2 after `baseUrl` removal)
- [x] Codex pre-PR review (caught the `baseUrl` deprecation that an earlier `npx tsc` had silently resolved against a different TS version)
- [ ] CI green on the new `typecheck-ts-examples` matrix and `all-checks-passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated TypeScript type-checking is now enforced in the continuous integration pipeline for example projects
  * Updated TypeScript configuration settings and upgraded the TypeScript dependency version for improved type-safety

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->