### PR TITLE
feat(ideal): add Inspector Patch panel for SpanEdit traceability

### DIFF
--- a/docs/development/API_REFERENCE.md
+++ b/docs/development/API_REFERENCE.md
@@ -86,8 +86,10 @@ The `SyncEditor` is the primary facade for the editor application, integrating t
   Deletes a node by round-tripping through the text CRDT.
 - `commit_edit(node_id : @core.NodeId, new_text : String, timestamp_ms : Int) -> Result[Unit, TreeEditError]`
   Commits an inline text edit on a node.
-- `move_node(source_id : @core.NodeId, target_id : @core.NodeId, position : @core.DropPosition, timestamp_ms : Int) -> Result[Unit, TreeEditError]`
-  Moves a node via drag-and-drop.
+- `move_node(source_id : @core.NodeId, target_id : @core.NodeId, position : @core.DropPosition, timestamp_ms : Int) -> Result[Array[@core.SpanEdit], TreeEditError]`
+  Moves a node via drag-and-drop. On success, returns the `SpanEdit`s applied
+  to the underlying text CRDT so callers can record a patch-level trace
+  alongside the originating intent.
 
 ### WebSocket / Wire Protocol
 - `decode_message(data : Bytes) -> SyncMessage?`

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -318,7 +318,7 @@ pub fn[T] SyncEditor::move_cursor_left_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_left_word(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_word(Self[T]) -> Unit
-pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Unit, TreeEditError]
+pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], TreeEditError]
 pub fn[T] SyncEditor::new_generic(String, (String) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Memo[@dowdiness/canopy/core.ProjNode[T]?], @cells.Memo[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Memo[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, capabilities? : LanguageCapabilities[T]) -> Self[T]
 pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId?
 pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit

--- a/editor/sync_editor_tree_edit.mbt
+++ b/editor/sync_editor_tree_edit.mbt
@@ -150,7 +150,7 @@ pub fn[T : Eq + @loom_core.Renderable] SyncEditor::move_node(
   target_id : @core.NodeId,
   position : @core.DropPosition,
   timestamp_ms : Int,
-) -> Result[Unit, TreeEditError] {
+) -> Result[Array[@core.SpanEdit], TreeEditError] {
   // Legality: self-drop
   guard source_id != target_id else {
     return Err(TreeEditError::ProjectionEdit(detail="Cannot drop onto self"))
@@ -257,5 +257,5 @@ pub fn[T : Eq + @loom_core.Renderable] SyncEditor::move_node(
     }
   }
   self.apply_span_edits(edits, @core.FocusHint::RestoreCursor, timestamp_ms)
-  Ok(())
+  Ok(edits)
 }

--- a/editor/tree_edit_bridge_test.mbt
+++ b/editor/tree_edit_bridge_test.mbt
@@ -68,6 +68,14 @@ test "apply_tree_edit - WrapInLambda" {
   )
   inspect(result is Ok(_), content="true")
   inspect(editor.get_text(), content="(λx. 42)")
+  // Trace contract: structural edits return the SpanEdits applied to the
+  // CRDT so the Inspector Patch panel can show them. A regression to
+  // `Ok([])` would silently empty the panel while text-outcome tests pass.
+  let edit_count = match result {
+    Ok(edits) => edits.length()
+    Err(_) => -1
+  }
+  inspect(edit_count > 0, content="true")
 }
 
 ///|

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -69,6 +69,7 @@ fn init_model() -> Model raise {
     drop_target_id: None,
     drop_position: None,
     intent_log: [],
+    patch_log: [],
     incr_tap,
   }
 }
@@ -175,6 +176,15 @@ fn open_action_overlay_from_event(
 const MAX_INTENT_LOG = 50
 
 ///|
+const MAX_PATCH_LOG = 50
+
+///|
+/// Per-SpanEdit cap on the retained `inserted` text. The full text is still
+/// applied to the CRDT; only the patch_log copy is truncated to keep
+/// patch_log memory proportional to MAX_PATCH_LOG, not to user paste size.
+const MAX_PATCH_INSERTED_CHARS = 200
+
+///|
 fn push_intent(model : Model, op : @lambda_edits.TreeEditOp) -> Unit {
   push_intent_label(model, op.to_generic().to_string())
 }
@@ -188,6 +198,57 @@ fn push_intent_label(model : Model, label : String) -> Unit {
   model.intent_log.push(label)
   while model.intent_log.length() > MAX_INTENT_LOG {
     model.intent_log.remove(0) |> ignore
+  }
+}
+
+///|
+/// Record an applied (op, SpanEdits) pair for the Patch panel. The op label
+/// mirrors the Op Log entry shape (`TreeEditOp.to_generic().to_string()`),
+/// so a Patch row reads as a back-reference to the producing Op Log entry.
+/// Skipped if `edits` is empty — those rows would be visually noisy and
+/// duplicate the corresponding Op Log entry without adding patch detail.
+///
+/// Each retained `SpanEdit` is decoupled from the editor-owned array:
+/// (a) the outer array is rebuilt, so post-apply mutation upstream can't
+/// corrupt logged rows; (b) `inserted` is capped at
+/// `MAX_PATCH_INSERTED_CHARS` so a 1MB paste doesn't anchor 1MB in the log.
+fn push_patch(
+  model : Model,
+  op : @lambda_edits.TreeEditOp,
+  edits : Array[@canopy_core.SpanEdit],
+) -> Unit {
+  if edits.is_empty() {
+    return
+  }
+  let snapshot : Array[@canopy_core.SpanEdit] = edits.map(fn(e) {
+    // Truncate by iterating codepoints, not UTF-16 code units. Slicing
+    // `e.inserted[:N]` would abort uncatchably if index N landed mid
+    // surrogate pair (e.g. user pastes 199 BMP code units then an emoji).
+    // `String::length` is the cheap upper-bound check; the loop produces a
+    // codepoint-bounded copy when truncation is warranted.
+    let inserted = if e.inserted.length() > MAX_PATCH_INSERTED_CHARS {
+      let buf = StringBuilder::new(size_hint=MAX_PATCH_INSERTED_CHARS)
+      let mut count = 0
+      for ch in e.inserted {
+        if count >= MAX_PATCH_INSERTED_CHARS {
+          break
+        }
+        buf.write_char(ch)
+        count = count + 1
+      }
+      buf.write_char('…')
+      buf.to_string()
+    } else {
+      e.inserted
+    }
+    { start: e.start, delete_len: e.delete_len, inserted }
+  })
+  model.patch_log.push({
+    op_label: op.to_generic().to_string(),
+    edits: snapshot,
+  })
+  while model.patch_log.length() > MAX_PATCH_LOG {
+    model.patch_log.remove(0) |> ignore
   }
 }
 
@@ -380,8 +441,9 @@ fn apply_structural_edit_request(
       tree_op,
       js_now_ms(),
     ) {
-    Ok(_) => {
+    Ok(edits) => {
       push_intent(model, tree_op)
+      push_patch(model, tree_op, edits)
       let new_model = refresh({
         ..model,
         next_timestamp: model.next_timestamp + 1,
@@ -519,8 +581,9 @@ fn execute_action(
           op,
           js_now_ms(),
         ) {
-        Ok(_) => {
+        Ok(edits) => {
           push_intent(model, op)
+          push_patch(model, op, edits)
           js_set_overlay_open(false)
           let new_model = refresh({
             ..model,
@@ -734,8 +797,9 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
           tree_op,
           js_now_ms(),
         ) {
-        Ok(_) => {
+        Ok(edits) => {
           push_intent(model, tree_op)
+          push_patch(model, tree_op, edits)
           let new_model = refresh({
             ..model,
             next_timestamp: model.next_timestamp + 1,
@@ -923,7 +987,6 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
             target=target_id,
             position~,
           )
-          push_intent(model, tree_op)
           match
             @lambda.apply_lambda_tree_edit(
               model.editor,
@@ -931,7 +994,9 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
               tree_op,
               js_now_ms(),
             ) {
-            Ok(_) => {
+            Ok(edits) => {
+              push_intent(model, tree_op)
+              push_patch(model, tree_op, edits)
               let new_model = refresh({
                 ..model,
                 next_timestamp: model.next_timestamp + 1,

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -8,11 +8,22 @@ pub enum EditorMode {
 pub enum BottomTab {
   Problems
   OpLog
+  Patch
   History
   CrdtState
   Graphviz
   IncrGraph
 } derive(Eq)
+
+///|
+/// One row group in the Patch panel: a structural intent (op label, same
+/// shape as the Op Log entry) paired with the `SpanEdit`s that the editor
+/// produced for it. Empty `edits` is legal — pure navigation ops like
+/// `Select` resolve to zero text changes.
+pub(all) struct PatchEntry {
+  op_label : String
+  edits : Array[@canopy_core.SpanEdit]
+}
 
 ///|
 pub enum PanelId {
@@ -83,6 +94,13 @@ pub struct Model {
   // Inspector traceability: rolling log of structural intents (most recent last).
   // Mutated in place; capped to MAX_INTENT_LOG entries to keep render cheap.
   intent_log : Array[String]
+  // Inspector traceability: rolling log of (op, SpanEdits) pairs, most recent
+  // last. Capped to MAX_PATCH_LOG. Populated by the direct-apply dispatch
+  // sites that route through `apply_lambda_tree_edit`; the
+  // `StructureStructuralEdit` FFI path (main.mbt::update) cannot contribute —
+  // the typed payload is consumed by `handle_structural_intent` FFI before
+  // MoonBit sees the message, so no `SpanEdit` array is available to record.
+  patch_log : Array[PatchEntry]
   // Model-owned tap on the parser's incr Runtime. Created once at init so it
   // observes memo events across the whole session, not per render. Reads via
   // `snapshot()` for the IncrGraph bottom-panel tab.

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -85,6 +85,7 @@ pub fn undo_manager_undo(Int) -> Bool
 pub enum BottomTab {
   Problems
   OpLog
+  Patch
   History
   CrdtState
   Graphviz
@@ -128,6 +129,7 @@ pub struct Model {
   drop_target_id : @core.NodeId?
   drop_position : @core.DropPosition?
   intent_log : Array[String]
+  patch_log : Array[PatchEntry]
   incr_tap : @visualizer.IncrMemoEventTap
 }
 
@@ -177,6 +179,11 @@ pub enum PanelId {
   Inspector
   Bottom
 } derive(Eq)
+
+pub(all) struct PatchEntry {
+  op_label : String
+  edits : Array[@core.SpanEdit]
+}
 
 type ScopeAnnotation
 

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -227,6 +227,7 @@ fn bottom_tab_slug(tab : BottomTab) -> String {
   match tab {
     Problems => "problems"
     OpLog => "oplog"
+    Patch => "patch"
     History => "history"
     CrdtState => "crdt"
     Graphviz => "graphviz"
@@ -257,6 +258,7 @@ fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
   let tabs : Array[(BottomTab, String)] = [
     (Problems, "Problems"),
     (OpLog, "Op Log"),
+    (Patch, "Patch"),
     (History, "History"),
     (CrdtState, "CRDT State"),
     (Graphviz, "Graphviz"),
@@ -442,6 +444,52 @@ fn view_op_log(model : Model) -> Html {
 }
 
 ///|
+/// Render the Patch panel — paired (op label, SpanEdits) rows.
+/// Mirrors `view_op_log` shape: most-recent first, capped to MAX_PATCH_LOG.
+/// Each entry surfaces the producing `GenericTreeOp` label as a header row
+/// so the user can cross-reference the matching Op Log entry, then each
+/// `SpanEdit` renders via its `Show` impl (`@<start> -<delete_len> +«…»`).
+fn view_patch_log(model : Model) -> Html {
+  let log = model.patch_log
+  if log.is_empty() {
+    @html.div(class="bottom-content", attrs=bottom_panel_attrs(Patch), [
+      @html.span(class="no-problems", [
+        @html.text(
+          "No patches yet. Structure-mode edits aren't traced here — see the Op Log tab.",
+        ),
+      ]),
+    ])
+  } else {
+    let n = log.length()
+    let items : Array[Html] = Array::new(capacity=n)
+    for i in 0..<n {
+      let entry = log[n - 1 - i]
+      let edit_rows : Array[Html] = entry.edits.map(fn(edit) {
+        @html.div(class="patch-log-edit", [
+          @html.span(class="patch-log-edit-text", [
+            @html.text(edit.to_string()),
+          ]),
+        ])
+      })
+      items.push(
+        @html.div(class="patch-log-row", [
+          @html.div(class="patch-log-header", [
+            @html.span(class="patch-log-index", [@html.text("\{n - i}.")]),
+            @html.span(class="patch-log-op", [@html.text(entry.op_label)]),
+          ]),
+          @html.div(class="patch-log-edits", edit_rows),
+        ]),
+      )
+    }
+    @html.div(
+      class="bottom-content patch-log",
+      attrs=bottom_panel_attrs(Patch),
+      items,
+    )
+  }
+}
+
+///|
 fn view_problems(model : Model) -> Html {
   let errors = model.editor.get_errors()
   if errors.is_empty() {
@@ -467,6 +515,7 @@ fn view_bottom_content(dispatch : Emit[Msg], model : Model) -> Html {
   let content : Html = match model.bottom_tab {
     Problems => view_problems(model)
     OpLog => view_op_log(model)
+    Patch => view_patch_log(model)
     CrdtState =>
       @html.div(
         class="bottom-content crdt-state",

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -722,6 +722,60 @@ canopy-editor {
   word-break: break-all;
 }
 
+/* ── Patch log tab (§9.2 inspector traceability) ────────── */
+
+.patch-log {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.patch-log-row {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-xs) 0;
+  border-left: 2px solid var(--canopy-border);
+  padding-left: var(--space-sm);
+}
+
+.patch-log-header {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: baseline;
+}
+
+.patch-log-index {
+  font-size: var(--text-small);
+  color: var(--canopy-muted);
+  font-family: var(--canopy-font-mono);
+  font-variant-numeric: tabular-nums;
+  min-width: 32px;
+  text-align: right;
+}
+
+.patch-log-op {
+  font-size: var(--text-small);
+  color: var(--canopy-fg);
+  font-family: var(--canopy-font-mono);
+  letter-spacing: -0.01em;
+  word-break: break-all;
+}
+
+.patch-log-edits {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: 40px;
+  padding-top: 2px;
+}
+
+.patch-log-edit {
+  font-size: var(--text-small);
+  color: var(--canopy-muted);
+  font-family: var(--canopy-font-mono);
+  word-break: break-all;
+}
+
 /* ── Graphviz tab ───────────────────────────────────────── */
 
 /*

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -174,12 +174,16 @@ fn build_lambda_capabilities(
 
 ///|
 /// Apply a lambda tree edit through the text CRDT.
+///
+/// Returns the array of `SpanEdit`s that were applied to the underlying
+/// text CRDT, so callers can record a patch-level trace alongside the
+/// originating `TreeEditOp` (see the Inspector Patch panel).
 pub fn apply_lambda_tree_edit(
   editor : @editor.SyncEditor[@ast.Term],
   companion : LambdaCompanion,
   op : @lambda_edits.TreeEditOp,
   timestamp_ms : Int,
-) -> Result[Unit, @editor.TreeEditError] {
+) -> Result[Array[@core.SpanEdit], @editor.TreeEditError] {
   // Drop uses SyncEditor::move_node which handles placeholders and separators
   // correctly, instead of the naive text splice in compute_drop.
   match op {
@@ -202,10 +206,10 @@ pub fn apply_lambda_tree_edit(
   match @lambda_edits.compute_text_edit(op, ctx) {
     Ok(Some((edits, focus_hint))) => {
       if edits.is_empty() {
-        return Ok(())
+        return Ok(edits)
       }
       editor.apply_span_edits(edits, focus_hint, timestamp_ms)
-      Ok(())
+      Ok(edits)
     }
     Ok(None) =>
       Err(@editor.TreeEditError::UnhandledOperation(detail=op.to_string()))

--- a/lang/lambda/companion/pkg.generated.mbti
+++ b/lang/lambda/companion/pkg.generated.mbti
@@ -13,7 +13,7 @@ import {
 }
 
 // Values
-pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Unit, @editor.TreeEditError]
+pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @editor.TreeEditError]
 
 pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term
 

--- a/lang/lambda/pkg.generated.mbti
+++ b/lang/lambda/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 }
 
 // Values
-pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Unit, @editor.TreeEditError]
+pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @editor.TreeEditError]
 
 pub fn get_lambda_ast(@editor.SyncEditor[@ast.Term]) -> @ast.Term
 


### PR DESCRIPTION
## Summary

- New `Patch` tab in the bottom panel (`examples/ideal`) shows the `SpanEdit`s the editor applied for each structural edit, paired with the originating `TreeEditOp` label — second prong of the Inspector traceability workstream alongside the shipped Op Log (#293, TODO.md §9).
- API enrichment: `SyncEditor::move_node` and `apply_lambda_tree_edit` return `Result[Array[@core.SpanEdit], Err]` instead of `Result[Unit, Err]`. The editor still applies the edits internally; the return is the trace so inspectors/telemetry can observe what reached the CRDT without re-computing.
- `push_patch` is defensive against the easy failure modes: outer array rebuilt via `.map` (no aliasing back to editor-owned data), `SpanEdit.inserted` truncated to 200 codepoints by iterating `Char`s (not UTF-16 code units — splitting a surrogate pair would abort uncatchably).

## Known limitation (documented in-code, mentioned in empty-state copy)

Structure-mode dispatch via `StructureStructuralEdit` FFI can't populate the panel — the typed payload is consumed by `handle_structural_intent` FFI before MoonBit sees the message. The empty-state copy says so explicitly so users in that mode aren't misled.

## CI note

Format Check is independently red on main today (rr_moon_mod migration; upstream moon#1716 / moon#1717). Not introduced by this PR; flagging per the `project_rr_moon_mod_migration` note.

## Review trail

- Self-review surfaced and fixed 6 findings before opening (Drop dispatch asymmetry, aliasing risk, memory cap, stale Msg name in docstring, misleading empty-state copy, CSS class reuse).
- Codex pre-PR review caught 3 more I missed: non-BMP slice abort (fixed via codepoint iteration), stale `move_node` signature in `docs/development/API_REFERENCE.md`, untested trace contract (added `edit_count > 0` assertion in the WrapInLambda bridge test).

## Test plan

- [x] `moon check --target js` clean across workspace + `examples/ideal`
- [x] `moon test` — 1028 tests pass (993 workspace + 35 ideal), including the new SpanEdit-count assertion
- [x] JS artifacts rebuilt
- [x] Playwright smoke confirmed the tab renders in the DOM (`<button role="tab" id="canopy-bottom-tab-patch">Patch</button>`)
- [ ] Manual: open ideal editor, perform a structural edit (e.g., WrapInLambda via overlay), switch to Patch tab, see the op-label header + `@start -len +«inserted»` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)