### PR TITLE
feat(ideal): guard view_op_log / view_patch_log allocation when bottom panel collapsed

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -184,7 +184,7 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: PR #293 left two row shapes in `Model.intent_log` (`TreeEditOp.to_generic().to_string()` vs `"{op}(node={id})"`). Minor UX inconsistency; distinguishable but not ideal once the panel becomes a debugging surface.
   Exit: rebuild a `TreeEditOp` in the `EditorStructuralEdit` arm using `apply_structural_edit_request`'s op-string dispatch (extract the `"WrapInLambda" | "Delete" | ...` match into a helper), then route through `push_intent`. `push_intent_label` can stay for cases where rebuilding is genuinely impossible.
 
-- [x] Inspector — guard `view_op_log` / `view_patch_log` allocation when bottom panel collapsed. Shipped in PR #TBD (2026-05-23).
+- [x] Inspector — guard `view_op_log` / `view_patch_log` allocation when bottom panel collapsed. Shipped in PR #324 (2026-05-23).
   PR #293 gated the heavy DOT/SVG pipeline (`render_history_html` / `render_graphviz_html`) on `model.workspace.bottom_visible`, but `view_op_log` (up to 50 row nodes) and the new `view_patch_log` from PR #323 (header + N `SpanEdit` rows per entry, capped at MAX_PATCH_LOG=50) still allocated on every render while the panel was hidden via CSS. Both now early-return an empty `<div>` with the appropriate `bottom_panel_attrs(tab)` when the panel is collapsed.
 
 - [ ] Inspector — Collaboration panel. *Part of Inspector traceability workstream.*

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -177,18 +177,15 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   - `TreeEditOp.to_generic().to_string()` for direct-apply paths (`apply_structural_edit_request`, `execute_action`, `OutlineStructuralEdit`)
   - `"{op}(node={id})"` ad-hoc label for the TS-applied `EditorStructuralEdit` path (the typed `TreeEditOp` is already consumed by `handle_structural_intent` FFI before MoonBit sees the message; reconstruction would duplicate the op-string→TreeEditOp dispatch from `apply_structural_edit_request`).
 
-- [ ] Inspector — Patch panel. *Part of Inspector traceability workstream.*
-  Why: same motivation as the Intent panel — the layer between user action and CRDT op is currently invisible. The Patch panel surfaces `SpanEdit`s with back-reference to the producing `GenericTreeOp`.
-  Exit:
-  - Scrollable log of recent `SpanEdit`s with back-reference to producing `GenericTreeOp`, each row uses `edit.to_string()` (e.g. `"@25 -3 +«add 3 5»"`).
-  - Lives in `view_bottom.mbt` as a new tab (sits alongside the shipped Op Log / Intent panel).
+- [x] Inspector — Patch panel. *Part of Inspector traceability workstream.* Shipped in PR #323 (2026-05-22, commit `0c093ac`).
+  Scrollable log of recent `SpanEdit`s with back-reference to producing `GenericTreeOp` (each row uses `edit.to_string()`), rendered by `view_patch_log` in `view_bottom.mbt`.
 
 - [ ] Inspector — unify Op Log label format across direct-apply and FFI paths.
   Why: PR #293 left two row shapes in `Model.intent_log` (`TreeEditOp.to_generic().to_string()` vs `"{op}(node={id})"`). Minor UX inconsistency; distinguishable but not ideal once the panel becomes a debugging surface.
   Exit: rebuild a `TreeEditOp` in the `EditorStructuralEdit` arm using `apply_structural_edit_request`'s op-string dispatch (extract the `"WrapInLambda" | "Delete" | ...` match into a helper), then route through `push_intent`. `push_intent_label` can stay for cases where rebuilding is genuinely impossible.
 
-- [ ] Inspector — guard `view_op_log` allocation when bottom panel collapsed.
-  Why: PR #293 gated the heavy DOT/SVG pipeline (`render_history_html` / `render_graphviz_html`) on `model.workspace.bottom_visible`, but `view_op_log` still allocates up to 50 Html nodes per render even while the panel is hidden via CSS. Sub-millisecond today; revisit if MAX_INTENT_LOG grows past ~500 or if profiling shows hot.
+- [x] Inspector — guard `view_op_log` / `view_patch_log` allocation when bottom panel collapsed. Shipped in PR #TBD (2026-05-23).
+  PR #293 gated the heavy DOT/SVG pipeline (`render_history_html` / `render_graphviz_html`) on `model.workspace.bottom_visible`, but `view_op_log` (up to 50 row nodes) and the new `view_patch_log` from PR #323 (header + N `SpanEdit` rows per entry, capped at MAX_PATCH_LOG=50) still allocated on every render while the panel was hidden via CSS. Both now early-return an empty `<div>` with the appropriate `bottom_panel_attrs(tab)` when the panel is collapsed.
 
 - [ ] Inspector — Collaboration panel. *Part of Inspector traceability workstream.*
   Why: in a collaborative projectional editor, the connected-peers list, sync status, ephemeral broadcasts (drag state, presence updates), and sync errors are invisible from the main editor surface. Debugging "peer A and peer B disagree on text," "why didn't my drag preview show," or "sync stalled" requires a panel surfacing the collab-layer state. Stub `Show` impls already exist on the relevant types (`PeerCursor`, `PeerPresence`, `PresenceStatus`, `SyncStatus`, `SyncMessage`, `SyncErrorReason`, `DragState`, `EditModeState`, `EphemeralNamespace`, `EphemeralValue`, `EphemeralEventTrigger`) but currently delegate to `@debug.to_string` (verbose dump, not user-facing labels).

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -413,6 +413,16 @@ fn view_incr_graph_panel(model : Model) -> Html {
 
 ///|
 fn view_op_log(model : Model) -> Html {
+  // When the bottom panel is collapsed, the whole <section> is CSS-hidden but
+  // `view()` still re-runs on every model change. Skip the log iteration and
+  // emit an empty container; vdom diff repopulates it when the panel reopens.
+  if !model.workspace.bottom_visible {
+    return @html.div(
+      class="bottom-content",
+      attrs=bottom_panel_attrs(OpLog),
+      ([] : Array[Html]),
+    )
+  }
   let log = model.intent_log
   if log.is_empty() {
     @html.div(class="bottom-content", attrs=bottom_panel_attrs(OpLog), [
@@ -450,6 +460,15 @@ fn view_op_log(model : Model) -> Html {
 /// so the user can cross-reference the matching Op Log entry, then each
 /// `SpanEdit` renders via its `Show` impl (`@<start> -<delete_len> +«…»`).
 fn view_patch_log(model : Model) -> Html {
+  // See `view_op_log` for the rationale; Patch panel rows are heavier
+  // (header + N `SpanEdit` rows per entry), so guarding here matters more.
+  if !model.workspace.bottom_visible {
+    return @html.div(
+      class="bottom-content",
+      attrs=bottom_panel_attrs(Patch),
+      ([] : Array[Html]),
+    )
+  }
   let log = model.patch_log
   if log.is_empty() {
     @html.div(class="bottom-content", attrs=bottom_panel_attrs(Patch), [


### PR DESCRIPTION
## Summary

- Mirror the `model.workspace.bottom_visible` gate already used by the three SVG-rendered bottom panels (`view_history_panel`, `view_graphviz_panel`, `view_incr_graph_panel` in the same file) onto the two vdom-rendered log panels (`view_op_log`, `view_patch_log`).
- Both functions previously allocated up to `MAX_INTENT_LOG=50` row nodes / `MAX_PATCH_LOG=50` entry-row × (header + N `SpanEdit` rows) on **every** model change, even while the bottom `<section>` was CSS-hidden. They now early-return an empty `<div>` with `bottom_panel_attrs(<Tab>)` so the tabpanel keeps its `id` / `role` / `aria-labelledby` / `tabindex=0` identity and rabbita's vdom diff repopulates it cleanly on reopen.
- Patch panel rows are the heavier of the two (header row + per-`SpanEdit` rows per entry), so bundling beats two separate PRs — the cost of "worth doing" dropped when #323 landed without `MAX_*` caps changing.

## Why a different shape than the SVG-panel guards

The three sibling guards (`view_history_panel`, `view_graphviz_panel`, `view_incr_graph_panel`) emit `<section>` + `inner_html=""` because their content is generated SVG/DOT. The two log panels emit vdom children on a `<div>`, so the guard returns an empty `Array[Html]` instead.

## Housekeeping bundled

- `docs/TODO.md`: Patch panel entry (line 180) marked `[x]` with PR #323 reference — matches the in-place pattern used by the sibling Intent panel entry (line 175). (Did not move to `docs/archive/`: would orphan the Intent panel sibling, which is also kept inline post-ship — a wider TODO cleanup pass is a better moment to apply the archive convention to both.)
- `docs/TODO.md`: allocation-guard entry (line 190) updated to cover both panels and marked shipped.

## Test plan

- [x] `cd examples/ideal && moon check` — clean
- [x] `cd examples/ideal && moon test` — 35/35 pass
- [x] `moon check` (workspace root) — clean (warnings pre-existing)
- [x] `moon test` (workspace root) — 993/993 pass
- [x] `cd examples/ideal && moon build --target js` — clean
- [x] Codex review — PASS (no findings on vdom/ARIA correctness)
- [ ] Manual: toggle the bottom panel open/closed while Op Log / Patch tabs are active, verify row contents reappear correctly on reopen (cannot automate in WSL2 environment per CLAUDE.md).

Note: `Format Check` CI job will stay red on `main` until the upstream `rr_moon_mod` migration lands per `project_rr_moon_mod_migration` memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized rendering: Operation Log and Patch Log panels no longer allocate resources when the bottom panel is collapsed, improving performance.

* **Documentation**
  * Updated backlog entries to reflect completion of Inspector Patch panel feature and performance optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->