### PR TITLE
feat(ideal): unify Op Log label format across direct-apply and FFI paths

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -421,11 +421,14 @@ fn can_hydrate_tree_node(model : Model, node_id : @canopy_core.NodeId) -> Bool {
 }
 
 ///|
-/// Map a standard structural-edit op string (sent from Inspector buttons
-/// and Web Component `STRUCTURAL_EDIT_REQUEST` dispatches) to a typed
-/// `TreeEditOp`. Returns `None` for ops outside the standard set —
-/// notably `"Drop"`, whose `source`/`position` payload is not recoverable
-/// from `(op, node_id)` alone.
+/// Map a standard structural-edit op string to a typed `TreeEditOp`. Used
+/// on both the direct-apply path (`apply_structural_edit_request`, from
+/// Inspector / Web Component `STRUCTURAL_EDIT_REQUEST`) and the FFI-applied
+/// path (`StructureStructuralEdit`, from `STRUCTURAL_EDIT_APPLIED`) so the
+/// Op Log row shape matches in both. Must stay in sync with the dispatch
+/// sites in `view_inspector.mbt` and `web/src/keymap.ts`. Returns `None`
+/// for ops outside the standard set — notably `"Drop"`, whose `source` /
+/// `position` payload is not recoverable from `(op, node_id)` alone.
 fn structural_edit_op_to_tree_edit(
   op : String,
   node_id : @canopy_core.NodeId,
@@ -448,7 +451,7 @@ fn apply_structural_edit_request(
     None => return (none, model)
   }
   let tree_op = match structural_edit_op_to_tree_edit(op, nid) {
-    Some(op) => op
+    Some(tree_op) => tree_op
     None => return (none, model)
   }
   match

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -190,10 +190,11 @@ fn push_intent(model : Model, op : @lambda_edits.TreeEditOp) -> Unit {
 }
 
 ///|
-/// Record a structural intent that arrived as `(op_string, node_id)` from
-/// the TS side. The lambda-typed payload has already been consumed by
-/// `handle_structural_intent` FFI by the time we get here, so we record
-/// the raw label rather than rebuilding the op.
+/// Fallback for structural intents arriving via the FFI path when the op
+/// cannot be rebuilt as a typed `TreeEditOp` from `(op, node_id)` alone —
+/// e.g. `"Drop"`, whose `source`/`position` payload is not recoverable.
+/// Ops in `structural_edit_op_to_tree_edit`'s domain go through
+/// `push_intent` instead so the Op Log row shape matches direct-apply paths.
 fn push_intent_label(model : Model, label : String) -> Unit {
   model.intent_log.push(label)
   while model.intent_log.length() > MAX_INTENT_LOG {
@@ -420,6 +421,23 @@ fn can_hydrate_tree_node(model : Model, node_id : @canopy_core.NodeId) -> Bool {
 }
 
 ///|
+/// Map a standard structural-edit op string (sent from Inspector buttons
+/// and Web Component `STRUCTURAL_EDIT_REQUEST` dispatches) to a typed
+/// `TreeEditOp`. Returns `None` for ops outside the standard set —
+/// notably `"Drop"`, whose `source`/`position` payload is not recoverable
+/// from `(op, node_id)` alone.
+fn structural_edit_op_to_tree_edit(
+  op : String,
+  node_id : @canopy_core.NodeId,
+) -> @lambda_edits.TreeEditOp? {
+  match op {
+    "WrapInLambda" => Some(@lambda_edits.WrapInLambda(node_id~, var_name="x"))
+    "Delete" => Some(@lambda_edits.Delete(node_id~))
+    _ => None
+  }
+}
+
+///|
 fn apply_structural_edit_request(
   model : Model,
   op : String,
@@ -429,10 +447,9 @@ fn apply_structural_edit_request(
     Some(id) => id
     None => return (none, model)
   }
-  let tree_op : @lambda_edits.TreeEditOp = match op {
-    "WrapInLambda" => @lambda_edits.WrapInLambda(node_id=nid, var_name="x")
-    "Delete" => @lambda_edits.Delete(node_id=nid)
-    _ => return (none, model)
+  let tree_op = match structural_edit_op_to_tree_edit(op, nid) {
+    Some(op) => op
+    None => return (none, model)
   }
   match
     @lambda.apply_lambda_tree_edit(
@@ -1026,7 +1043,17 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         (none, model)
       } else {
         // The edit was already applied by TS calling handle_structural_intent FFI.
-        push_intent_label(model, "\{op}(node=\{node_id})")
+        // For ops the helper can rebuild (`WrapInLambda`, `Delete`), route
+        // through `push_intent` so the Op Log row shape matches direct-apply
+        // paths. Fall back to a raw label for ops whose payload can't be
+        // reconstructed from `(op, node_id)` (e.g. `"Drop"`).
+        let rebuilt = parse_node_id(node_id).bind(nid => {
+          structural_edit_op_to_tree_edit(op, nid)
+        })
+        match rebuilt {
+          Some(tree_op) => push_intent(model, tree_op)
+          None => push_intent_label(model, "\{op}(node=\{node_id})")
+        }
         let new_model = refresh({
           ..model,
           next_timestamp: model.next_timestamp + 1,

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -132,3 +132,31 @@ test "dom event subscription error message includes context" {
     content="[canopy] failed to install DOM event subscription target=editor-host event=action-key: document is unavailable",
   )
 }
+
+///|
+/// Locks in the unified Op Log shape contract: the rebuilt-from-(op,
+/// node_id) `TreeEditOp` produced for the FFI arm must stringify the same
+/// way as the direct-apply paths' typed op (both routes go through
+/// `push_intent`, which calls `op.to_generic().to_string()`). If a future
+/// refactor reintroduces a divergent label format, this snapshot fails.
+test "structural_edit_op_to_tree_edit rebuilds known ops with unified label shape" {
+  let nid = @canopy_core.NodeId::from_int(42)
+  let wrap = structural_edit_op_to_tree_edit("WrapInLambda", nid).unwrap()
+  inspect(
+    wrap.to_generic().to_string(),
+    content="StructuralEditKeepSelected(#42)",
+  )
+  let del = structural_edit_op_to_tree_edit("Delete", nid).unwrap()
+  inspect(del.to_generic().to_string(), content="Delete(#42)")
+}
+
+///|
+test "structural_edit_op_to_tree_edit returns None for unrebuildable ops" {
+  let nid = @canopy_core.NodeId::from_int(7)
+  inspect(structural_edit_op_to_tree_edit("Drop", nid) is None, content="true")
+  inspect(structural_edit_op_to_tree_edit("", nid) is None, content="true")
+  inspect(
+    structural_edit_op_to_tree_edit("UnknownOp", nid) is None,
+    content="true",
+  )
+}

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -485,9 +485,7 @@ fn view_patch_log(model : Model) -> Html {
       let entry = log[n - 1 - i]
       let edit_rows : Array[Html] = entry.edits.map(fn(edit) {
         @html.div(class="patch-log-edit", [
-          @html.span(class="patch-log-edit-text", [
-            @html.text(edit.to_string()),
-          ]),
+          @html.span(class="patch-log-edit-text", [@html.text(edit.to_string())]),
         ])
       })
       items.push(


### PR DESCRIPTION
## Summary

- Extract `apply_structural_edit_request`'s op-string→`TreeEditOp` dispatch into a `structural_edit_op_to_tree_edit` helper.
- Reuse it in the `StructureStructuralEdit` (FFI) arm to rebuild a typed `TreeEditOp` and route through `push_intent`, so Op Log rows from the FFI path share the `TreeEditOp.to_generic().to_string()` shape used by direct-apply paths.
- Fallback `push_intent_label` stays for ops whose payload isn't recoverable from `(op, node_id)` alone — currently `"Drop"`, whose `source`/`position` aren't carried by `STRUCTURAL_EDIT_APPLIED`.

Closes the TODO at `docs/TODO.md` §9 ("Inspector — unify Op Log label format across direct-apply and FFI paths").

## Semantic equivalence

For `WrapInLambda` via the FFI path, TS calls `crdt.handle_structural_intent(handle, op, nodeId, ts, "")` (empty `params_json`). `ffi/lambda/intent.mbt:120` injects `type`/`node_id`, and `lang/lambda/companion/tree_edit_json.mbt:94-98` defaults `var_name` to `"x"` when absent — matching the helper's hardcoded `var_name="x"`. Codex pre-PR review confirmed this with file:line citations.

## Notes

- `examples/ideal/main/view_bottom.mbt` change (+1/-3) is an incidental `moon fmt` array collapse, unrelated to this task.
- No `.mbti` changes (helper is non-`pub`).

## Test plan

- [x] `moon check` clean
- [x] `moon test` 35/35 in `examples/ideal`
- [x] Codex pre-PR review (PASS, no findings)
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)