### PR TITLE
fix(core): enforce SourceMap::nodes_at_position outermost→innermost ordering

### DIFF
--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -121,18 +121,21 @@ fn SourceMap::node_to_range_at_position(
 }
 
 ///|
-/// Find all nodes that contain a given position
-/// Returns nodes from outermost to innermost (parent to child)
-///
-/// Contract NOT YET ENFORCED — implementation returns `Map.keys().to_array()`
-/// which does not guarantee any particular order. Fix as part of click-path
-/// wiring (docs/TODO.md §9 "Wire SourceMap query API into editor click-path"):
-/// sort by `(range.end - range.start)` descending and add a property test.
+/// Find all nodes that contain a given position.
+/// Returns nodes sorted by containing-range length descending — outermost
+/// (largest range) first, innermost (smallest range) last. Agrees with
+/// `innermost_node_at`'s `minimum_by_length` semantics: the last element is
+/// the innermost node.
 pub fn SourceMap::nodes_at_position(
   self : SourceMap,
   position : Int,
 ) -> Array[NodeId] {
-  self.node_to_range_at_position(position).keys().to_array()
+  let pairs : Array[(NodeId, Range)] = []
+  for id, range in self.node_to_range_at_position(position) {
+    pairs.push((id, range))
+  }
+  pairs.sort_by(fn(a, b) { b.1.length().compare(a.1.length()) })
+  pairs.map(fn(p) { p.0 })
 }
 
 ///|

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -126,6 +126,11 @@ fn SourceMap::node_to_range_at_position(
 /// (largest range) first, innermost (smallest range) last. Agrees with
 /// `innermost_node_at`'s `minimum_by_length` semantics: the last element is
 /// the innermost node.
+///
+/// Among nodes of equal range length, relative order is unspecified.
+/// Strict containment of consecutive ranges (parent encloses child) further
+/// relies on the input being a tree of non-overlapping sibling ranges — the
+/// invariant satisfied by `SourceMap::from_ast`.
 pub fn SourceMap::nodes_at_position(
   self : SourceMap,
   position : Int,

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -134,8 +134,8 @@ pub fn SourceMap::nodes_at_position(
   for id, range in self.node_to_range_at_position(position) {
     pairs.push((id, range))
   }
-  pairs.sort_by(fn(a, b) { b.1.length().compare(a.1.length()) })
-  pairs.map(fn(p) { p.0 })
+  pairs.sort_by((a, b) => b.1.length().compare(a.1.length()))
+  pairs.map(p => p.0)
 }
 
 ///|

--- a/core/source_map_properties_wbtest.mbt
+++ b/core/source_map_properties_wbtest.mbt
@@ -225,6 +225,51 @@ test "property: innermost_node_at returns minimal containing node" {
 }
 
 ///|
+/// Property 6b: nodes_at_position returns nodes ordered outermost→innermost.
+/// For any two consecutive nodes in the returned array, the earlier node's
+/// range must contain (or equal) the later node's range — equivalently,
+/// `prev.length() >= curr.length()`. The two formulations agree on properly
+/// nested AST trees, where any two ranges containing the same point are in
+/// a containment relationship.
+fn prop_nodes_at_position_outermost_first(expr : TestExpr) -> Bool {
+  let counter = Ref(0)
+  let offset = Ref(0)
+  let root = to_proj_node_with_ranges(expr, counter, offset)
+  let sm = SourceMap::from_ast(root)
+  let root_range = match sm.get_range(root.id()) {
+    Some(r) => r
+    None => return true
+  }
+  let positions = [
+    root_range.start,
+    (root_range.start + root_range.end) / 2,
+    (root_range.end - 1).max(root_range.start),
+  ]
+  for pos in positions {
+    let ids = sm.nodes_at_position(pos)
+    for i = 1; i < ids.length(); i = i + 1 {
+      let prev = match sm.get_range(ids[i - 1]) {
+        Some(r) => r
+        None => return false
+      }
+      let curr = match sm.get_range(ids[i]) {
+        Some(r) => r
+        None => return false
+      }
+      if prev.start > curr.start || prev.end < curr.end {
+        return false
+      }
+    }
+  }
+  true
+}
+
+///|
+test "property: nodes_at_position returns outermost first" {
+  @qc.quick_check_fn(prop_nodes_at_position_outermost_first)
+}
+
+///|
 /// Property 7: rebuild() clears token spans.
 /// Set token spans on the SourceMap, then rebuild from the same tree.
 /// All token spans should be gone after rebuild (as documented in

--- a/core/source_map_properties_wbtest.mbt
+++ b/core/source_map_properties_wbtest.mbt
@@ -236,10 +236,7 @@ fn prop_nodes_at_position_outermost_first(expr : TestExpr) -> Bool {
   let offset = Ref(0)
   let root = to_proj_node_with_ranges(expr, counter, offset)
   let sm = SourceMap::from_ast(root)
-  let root_range = match sm.get_range(root.id()) {
-    Some(r) => r
-    None => return true
-  }
+  guard let Some(root_range) = sm.get_range(root.id()) else { return true }
   let positions = [
     root_range.start,
     (root_range.start + root_range.end) / 2,
@@ -247,15 +244,9 @@ fn prop_nodes_at_position_outermost_first(expr : TestExpr) -> Bool {
   ]
   for pos in positions {
     let ids = sm.nodes_at_position(pos)
-    for i = 1; i < ids.length(); i = i + 1 {
-      let prev = match sm.get_range(ids[i - 1]) {
-        Some(r) => r
-        None => return false
-      }
-      let curr = match sm.get_range(ids[i]) {
-        Some(r) => r
-        None => return false
-      }
+    for i in 1..<ids.length() {
+      guard let Some(prev) = sm.get_range(ids[i - 1]) else { return false }
+      guard let Some(curr) = sm.get_range(ids[i]) else { return false }
       if prev.start > curr.start || prev.end < curr.end {
         return false
       }

--- a/core/source_map_properties_wbtest.mbt
+++ b/core/source_map_properties_wbtest.mbt
@@ -236,7 +236,7 @@ fn prop_nodes_at_position_outermost_first(expr : TestExpr) -> Bool {
   let offset = Ref(0)
   let root = to_proj_node_with_ranges(expr, counter, offset)
   let sm = SourceMap::from_ast(root)
-  guard let Some(root_range) = sm.get_range(root.id()) else { return true }
+  guard sm.get_range(root.id()) is Some(root_range) else { return true }
   let positions = [
     root_range.start,
     (root_range.start + root_range.end) / 2,
@@ -245,8 +245,8 @@ fn prop_nodes_at_position_outermost_first(expr : TestExpr) -> Bool {
   for pos in positions {
     let ids = sm.nodes_at_position(pos)
     for i in 1..<ids.length() {
-      guard let Some(prev) = sm.get_range(ids[i - 1]) else { return false }
-      guard let Some(curr) = sm.get_range(ids[i]) else { return false }
+      guard sm.get_range(ids[i - 1]) is Some(prev) else { return false }
+      guard sm.get_range(ids[i]) is Some(curr) else { return false }
       if prev.start > curr.start || prev.end < curr.end {
         return false
       }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -194,13 +194,9 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   - Recent ephemeral events stream: renders `EphemeralStoreEvent`s via `event.to_string()`.
   - Lives in `view_bottom` or new tab alongside outline/inspector/history/intent/patch.
 
-- [ ] Wire `SourceMap` query API into editor click-path + fix ordering contract. *Part of Inspector traceability workstream.*
-  Why: `core/source_map.mbt::SourceMap::nodes_at_position` and `SourceMap::nodes_in_range` are property-tested (`core/source_map_properties_wbtest.mbt`) but unconsumed by production code. Click-path in `examples/ideal/main/view_editor.mbt` reimplements similar text-position→node logic inline. Additionally, `nodes_at_position` documents "outermost to innermost" ordering but returns `Map.keys().to_array()` — ordering is not guaranteed, latent contract bug if any consumer ever depends on nesting order.
-  Exit:
-  - `SourceMap::nodes_at_position` returns guaranteed outermost→innermost order (sort by `(end - start)` descending) with a property test pinning the contract.
-  - Click-path in `view_editor.mbt` consumes `nodes_at_position`.
-  - Selection-extend command consumes `nodes_in_range`.
-  - `SourceMap::rebuild` annotated as recovery API (see comment in source); not bundled into this TODO's exit since no UI consumer is currently committed.
+- [x] Enforce `SourceMap::nodes_at_position` ordering contract. *Part of Inspector traceability workstream.*
+  Why: the doc-comment promised "outermost to innermost" but the body returned `Map.keys().to_array()` — no ordering guarantee. Latent contract bug if any consumer ever depended on nesting order. The earlier framing ("wire into editor click-path") was stale: `examples/ideal/main/view_editor.mbt` is 25 lines of DOM mount only; the position→node lookup already routes through `SyncEditor::node_at_position` (which uses `innermost_node_at`). The "selection-extend command consumes `nodes_in_range`" sub-bullet had no committed consumer either.
+  Shipped: `SourceMap::nodes_at_position` now sorts by range length descending (outermost first, innermost last — matches `innermost_node_at`'s `minimum_by_length` semantics). Property test in `core/source_map_properties_wbtest.mbt` pins the contract — for any two consecutive returned nodes, the earlier's range contains (or equals) the later's. `SourceMap::rebuild` remains annotated in source as recovery API; no UI consumer committed, not bundled into this entry.
 
 ---
 


### PR DESCRIPTION
## Summary

- `SourceMap::nodes_at_position` previously returned `Map.keys().to_array()` with no guaranteed order, despite the doc-comment promising "outermost to innermost". Now sorts by containing-range length descending — outermost (largest) first, innermost (smallest) last. Agrees with `innermost_node_at`'s `minimum_by_length` semantics: the last element is the innermost node.
- New property test in `core/source_map_properties_wbtest.mbt` pins the contract: for any two consecutive returned nodes, the earlier's range contains (or equals) the later's. Sound for properly nested AST trees, which is the only thing the test generator produces and the only shape `SourceMap` is built from.
- `docs/TODO.md` §9: marked shipped. Dropped the stale "wire into editor click-path" sub-bullet (`view_editor.mbt` is 25 lines of DOM mount only; the position→node lookup already routes through `SyncEditor::node_at_position`). Dropped the `nodes_in_range` selection-extend sub-bullet — no committed consumer.

## Validation

- `cd core && moon test` — 96/96 pass (was 95; +1 from the new property test).
- `moon info` — `core/pkg.generated.mbti` unchanged, public API preserved.
- Codex design review (pre-PR): PASS-with-caveat. Sort-by-length-desc doesn't imply strict containment for arbitrary inputs (`[0,10)` vs `[5,12)` both contain pos 7), but SourceMap-via-ProjNode trees keep siblings non-overlapping so the containment property holds for both the test generator and real consumers. Ties don't break containment.

## Test plan

- [x] `cd core && moon test` passes
- [x] `moon info` shows no `.mbti` diff
- [x] `git diff --stat` confirms only intended files changed (`core/source_map.mbt`, `core/source_map_properties_wbtest.mbt`, `docs/TODO.md`)
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Consistent node ordering: queries now predictably return nodes from outermost to innermost.
* **Tests**
  * Added property-based test to ensure node ordering consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->