### PR TITLE
chore: pin incr to registry 0.5.2 + bump loom to dep-switch landing

### DIFF
--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Install MoonBit (pinned)
-      uses: hustcer/setup-moonbit@v1.21
+      uses: hustcer/setup-moonbit@v1.22
       with:
         version: "0.9.2+bbe2b338f"
         core-version: "0.9.2+bbe2b338f"

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -17,10 +17,7 @@
       "path": "./lib/moji",
       "version": "0.1.0"
     },
-    "dowdiness/incr": {
-      "path": "./loom/incr",
-      "version": "0.5.1"
-    },
+    "dowdiness/incr": "0.5.2",
     "dowdiness/lambda": {
       "path": "./loom/examples/lambda",
       "version": "0.1.0"


### PR DESCRIPTION
## Summary
Restores green CI by switching canopy and loom to depend on registry incr@0.5.2 instead of the path-dep to the submodule, and bumping the loom submodule to loom#138 which makes the equivalent change inside the loom monorepo.

## Background
[loom#137](https://github.com/dowdiness/loom/pull/137) bumped the incr submodule from 9dfe38c to 0d74b47, which crossed [incr#70](https://github.com/dowdiness/incr/pull/70) deprecating Runtime::read. Loom has no test CI, so the bump landed green; this canopy bump-attempt (the closed #330) then tripped canopy's `moon check --deny-warn` on 108 Runtime::read call sites.

Instead of reverting, [loom#138](https://github.com/dowdiness/loom/pull/138) pinned loom's incr deps to registry 0.5.2 and reset the incr submodule pointer to the v0.5.2 release tag (c885d19), so the local source matches the published mooncake byte-for-byte. This PR mirrors that change at the canopy level.

## Changes
- `loom` submodule: e3f3a30 → **9cc25c7** (loom#138)
- `moon.mod.json`: `"dowdiness/incr": { "path": "./loom/incr", "version": "0.5.1" }` → `"0.5.2"`

## Why a registry string instead of `{ "path": ... }`?
Moon's resolver prefers a discoverable local path-dep over a registry pin (egglog's `"0.4.1"` declaration today resolves to local 0.5.2). The registry string is advisory while loom/incr/ contains source code, but pinning the submodule to the v0.5.2 release commit means the local source IS the registry source — the build is identical regardless of which path moon picks, and consumers reading moon.mod.json see the intended source-of-truth.

## Local verification
| Check | Result |
| --- | --- |
| canopy root `ci` (`moon check --deny-warn` + `moon test --release`) | 1022/1022 pass |
| canopy root `bench` (`moon bench --release`) | 20/20 pass |
| `loom/loom` `ci` | 270/270 pass |
| `loom/examples/lambda` `moon test` | 681/681 pass |
| `loom/examples/ideal` `ci` | 37/37 pass |

## Follow-up (NOT this PR)
Phase 3a caller migration — replace 108 Runtime::read sites in canopy with `.read_or_abort()` / `.watch()`. Once landed, canopy can pick up the incr ≥ #61 changes (ideal API rename slice).

## Test plan
- [ ] Canopy CI green on chore/switch-incr-to-registry-0.5.2
- [ ] `git submodule status` after merge shows loom at 9cc25c7
- [ ] Phase 3a migration unblocked for the next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)