### PR TITLE
refactor(ffi/lambda): anchor typecheck output via persistent Observer

### DIFF
--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -48,12 +48,7 @@ pub fn get_diagnostics_json(handle : Int) -> String {
       // the AST is incomplete and type errors would just be noise on top of
       // the parse error.
       if parse_errors.is_empty() {
-        // typecheck.output is built by loom-lambda's `build_typecheck_pipeline`
-        // which still returns @incr.Memo. Use a one-shot Observer until that
-        // function is migrated to publish @incr.Derived.
-        let obs = h.typecheck.output.observe()
-        let result = obs.get()
-        obs.dispose()
+        let result = h.typecheck.observer.get()
         for diag in result.all_diagnostics {
           let m : Map[String, Json] = {}
           m["level"] = "error".to_json()

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -45,7 +45,7 @@ fn new_typecheck_bundle(
   // over empty input; if downstream stages ever become fallible here,
   // create_editor aborts instead of the FFI consumer receiving an empty
   // diagnostics result.
-  let _ = observer.get()
+  let _prime = observer.get()
   { scope, observer }
 }
 

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -10,11 +10,17 @@ priv struct LambdaHandle {
 }
 
 ///|
-/// Typecheck pipeline memos; `scope` disposal only — the underlying
+/// Typecheck pipeline cells; `scope` disposal only — the underlying
 /// `Runtime` is owned by the editor's `Parser`.
+///
+/// `observer` is both the read path and the GC anchor: Scope membership
+/// alone does not register the underlying Derived's cell as a `gc_root`,
+/// so without a persistent Observer the entire typecheck cone would be
+/// eligible for sweep on any future `Runtime::gc()`. Mirrors loom-side
+/// `TypecheckAttachment` in `examples/lambda/src/typed_parser.mbt`.
 priv struct TypecheckBundle {
   scope : @cells.Scope
-  output : @cells.Memo[@typecheck.ModuleTypeResult]
+  observer : @cells.Observer[@typecheck.ModuleTypeResult]
 }
 
 ///|
@@ -28,7 +34,19 @@ fn new_typecheck_bundle(
     label="lambda-typed-term",
   )
   let output = @typecheck.build_typecheck_pipeline(rt, scope, typed_term_memo)
-  { scope, output }
+  let observer = scope.add_observer(output.observe())
+  // Prime the closure so `gc_dependencies` is populated before any gc cycle
+  // could run — Observer alone is insufficient until the Memo has computed
+  // once (see `feedback-incr-gc-anchor-needs-priming`).
+  //
+  // Side effect: this makes `create_editor` the failure boundary for any
+  // typecheck panic, not `get_diagnostics_json`. Currently benign because a
+  // freshly-created editor has an empty document and the pipeline is total
+  // over empty input; if downstream stages ever become fallible here,
+  // create_editor aborts instead of the FFI consumer receiving an empty
+  // diagnostics result.
+  let _ = observer.get()
+  { scope, observer }
 }
 
 ///|


### PR DESCRIPTION
## Summary

Closes the Phase 3a boundary noted in #332: loom-lambda's `build_typecheck_pipeline` now returns `@incr.Derived[ModuleTypeResult]` (loom#140), so the one-shot Observer workaround in `diagnostics.mbt` can go away.

This PR has 2 commits:

1. **`chore: bump loom submodule to 8c55129 (merged main)`** — points canopy/loom at the squash of loom#140 so canopy CI's recursive submodule fetch resolves the typecheck contract change from main refs alone.

2. **`refactor(ffi/lambda): anchor typecheck output via persistent Observer`** — migrates `TypecheckBundle` to the loom-side `TypecheckAttachment` shape (`examples/lambda/src/typed_parser.mbt`): `{ scope, observer }` instead of `{ scope, output : Memo }`. The Observer is both the read path AND the GC anchor.

## Why the persistent Observer

Scope membership alone does not register the underlying cell as a `gc_root`, so without a persistent Observer the entire typecheck cone would be eligible for sweep on any future `Runtime::gc()`. Constructor primes via `let _ = observer.get()` because `gc_dependencies` is empty until the Memo has computed once.

## Trade-off worth surfacing

The eager prime makes `create_editor` the failure boundary for any typecheck panic, not `get_diagnostics_json`. Currently benign — a freshly-created editor has an empty document and the pipeline is total over empty input. If downstream stages ever become fallible on empty/partial CST, `create_editor` will abort instead of the FFI consumer receiving an empty diagnostics result. Documented inline at `ffi/lambda/lifecycle.mbt:42-49`.

## Structural mirror

```
canopy TypecheckBundle { scope, observer }
loom   TypecheckAttachment { scope, observer, index }
```

(canopy lacks `index` because it calls `build_typecheck_pipeline`, not `_with_index`.)

The `output : @cells.Derived` field was dropped from the struct — once Observer is the read path AND the anchor, the Derived handle is dead state and keeping it would advertise a "publishes Derived" contract that nothing reads.

## Test plan

- [x] 18/18 `ffi/lambda` tests pass locally (`NEW_MOON_MOD=0 moon test /home/antisatori/ghq/github.com/dowdiness/canopy/ffi/lambda`)
- [x] 0 errors on `NEW_MOON_MOD=0 moon check /home/antisatori/ghq/github.com/dowdiness/canopy/ffi/lambda` (27 pre-existing buffer-deprecation warnings unchanged — #334 reduced these; remaining are not in `ffi/lambda` scope)
- [x] Local /code-review pass: 1 PLAUSIBLE finding (moved-failure-surface, now documented inline); no CONFIRMED bugs
- [ ] Canopy CI green (this is the de-facto gate; loom has no test CI)

## Dependencies

- Requires loom#140 (merged at 8c55129) — already pulled in via the submodule bump in commit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal type diagnostic collection by streamlining the observer handling process.
  * Enhanced type check pipeline architecture for improved memory management and garbage collection efficiency.
  * Updated dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->