### PR TITLE
feat(workspace): §P0b Phase 1 PR3 — coordinator package (types + 7 methods + tests)

### DIFF
--- a/docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md
@@ -277,19 +277,26 @@ pub fn[T] ProtectedCell::from_derived(label : String, d : @incr.Derived[T]) -> P
   )
 }
 
-pub fn[T : Eq] ProtectedCell::from_reachable_derived(
-  label : String, r : @incr.ReachableDerived[T],
-) -> ProtectedCell[T] {
-  let watch = r.watch()
-  let _ = watch.read()
-  ProtectedCell(
-    cell_id=r.id(),
-    label~,
-    read=fn() { watch.read() },
-    is_disposed=fn() { watch.is_disposed() },
-    dispose=fn() { watch.dispose() },
-  )
-}
+// SPEC GAP — DEFERRED PAST PR3 (2026-05-25):
+//   `ReachableDerived::id()` is not exposed in incr v0.6.x's public surface
+//   (only `Derived::id`). The factory below cannot compile against current
+//   incr. The §P0b Phase 1 Lambda protected surface uses only Derived (10
+//   cells, all `from_derived`), so the factory was dropped from PR3 (commit
+//   `11479b1`). When a Phase 1b ReachableDerived cell needs protection, add
+//   `ReachableDerived::id()` upstream first, then re-introduce this factory.
+// pub fn[T : Eq] ProtectedCell::from_reachable_derived(
+//   label : String, r : @incr.ReachableDerived[T],
+// ) -> ProtectedCell[T] {
+//   let watch = r.watch()
+//   let _ = watch.read()
+//   ProtectedCell(
+//     cell_id=r.id(),
+//     label~,
+//     read=fn() { watch.read() },
+//     is_disposed=fn() { watch.is_disposed() },
+//     dispose=fn() { watch.dispose() },
+//   )
+// }
 
 pub fn[T] ProtectedCell::erase(self : ProtectedCell[T]) -> ProtectedRead {
   let c = self

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -326,6 +326,7 @@ pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T]
 pub fn[T] SyncEditor::parser_diagnostics(Self[T]) -> @cells.Derived[@dowdiness/loom/core.DiagnosticSet]
 pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime
+pub fn[T] SyncEditor::parser_source(Self[T]) -> @cells.Derived[String]
 pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Derived[@seam.SyntaxNode]
 pub fn[T : Eq] SyncEditor::redo(Self[T]) -> Bool
 pub fn[T : Eq] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage?

--- a/lang/lambda/README.md
+++ b/lang/lambda/README.md
@@ -12,7 +12,7 @@ Re-exported from `lang/lambda/edits`:
 
 Re-exported from `lang/lambda/companion`:
 - type `LambdaCompanion`
-- `new_lambda_editor(source) -> (SyncEditor[Term], LambdaCompanion)`
+- `new_lambda_editor(agent_id, capture_timeout_ms?, parent_runtime?) -> (SyncEditor[Term], LambdaCompanion)`
 - `apply_lambda_tree_edit(editor, companion, op, cursor)`
 - `get_lambda_ast`, `get_lambda_ast_pretty`, `get_lambda_resolution`, `get_lambda_dot_resolved`
 - `parse_tree_edit_op`

--- a/lang/lambda/flat/pkg.generated.mbti
+++ b/lang/lambda/flat/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 }
 
 // Values
-pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term]) -> (@cells.Memo[VersionedFlatProj], @cells.Derived[@core.ProjNode[@ast.Term]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[@ast.Term]]], @cells.Derived[@core.SourceMap])
+pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term]) -> (@cells.Derived[VersionedFlatProj], @cells.Derived[@core.ProjNode[@ast.Term]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[@ast.Term]]], @cells.Derived[@core.SourceMap])
 
 // Errors
 

--- a/lang/lambda/pkg.generated.mbti
+++ b/lang/lambda/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "dowdiness/canopy/lang/lambda/companion",
   "dowdiness/canopy/lang/lambda/edits",
   "dowdiness/canopy/lang/lambda/eval",
+  "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
 }
 
@@ -21,7 +22,7 @@ pub fn get_lambda_dot_resolved(@editor.SyncEditor[@ast.Term]) -> String
 
 pub fn get_lambda_resolution(@editor.SyncEditor[@ast.Term]) -> @dowdiness/lambda.Resolution
 
-pub fn new_lambda_editor(String, capture_timeout_ms? : Int) -> (@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion)
+pub fn new_lambda_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@ast.Term], @companion.LambdaCompanion)
 
 pub fn parse_tree_edit_op(Json) -> @edits.TreeEditOp raise @editor.TreeEditError
 

--- a/workspace/coordinator/coordinator_test.mbt
+++ b/workspace/coordinator/coordinator_test.mbt
@@ -8,14 +8,20 @@ test "Coordinator types are constructible" {
 
 ///|
 /// `Runtime::set_on_change` is single-occupancy (spec §6.1, claimed by
-/// `Coordinator::new`). Later tests in this file MUST NOT install their own
-/// on_change listeners or they will overwrite the coordinator's stub.
-test "Coordinator::new claims the on_change slot without aborting" {
+/// `Coordinator::new`). This test pins observable behavior: after
+/// construction, an input mutation fires the slot exactly once (because
+/// the slot is populated, even if with a stub). It also exercises the
+/// overwrite path: a downstream caller can replace the stub and the
+/// new callback fires instead. Phase 2 will multiplex registered
+/// listeners through a coordinator-owned dispatcher.
+test "Coordinator::new populates on_change; downstream can override" {
   let coord = Coordinator::new()
   let rt = coord.runtime()
-  // No assertion: this just verifies the slot is in use and the second
-  // assignment overwrites cleanly. Phase 2 multiplexes registered listeners.
-  rt.set_on_change(fn() {  })
+  let probe = Ref(0)
+  rt.set_on_change(fn() { probe.val = probe.val + 1 })
+  let input = @incr.Input(rt, 0, label="probe_input")
+  input.set(1)
+  assert_eq(probe.val, 1)
 }
 
 ///|
@@ -59,7 +65,11 @@ test "read_protected rejects a cell not in editor's protected set" {
 }
 
 ///|
-test "register_dep + unregister_dep round trip" {
+/// Asserts dep-edge state via the observable destroy gateway: after
+/// `register_dep`, destroy must refuse with `DestroyWhileDependedUpon`;
+/// after `unregister_dep`, destroy must succeed. Also exercises
+/// idempotency of both register_dep and unregister_dep.
+test "register_dep + unregister_dep round trip — observable via destroy gate" {
   let coord = Coordinator::new()
   let rt = coord.runtime()
   let editor_cell = @incr.Derived::Derived(rt, fn() { 1 }, label="ec")
@@ -67,11 +77,19 @@ test "register_dep + unregister_dep round trip" {
   let pe = ProtectedCell::from_derived("ec", editor_cell)
   let id = coord.register_editor("agent", [pe.erase()])
   coord.register_dep(ws_cell.id(), id, editor_cell.id())
-  // Idempotent: a second call with the same edge is a no-op.
+  // Idempotent: a second call with the same edge is a no-op (still 1 edge).
   coord.register_dep(ws_cell.id(), id, editor_cell.id())
+  match coord.destroy_editor(id) {
+    Ok(_) => fail("expected DestroyWhileDependedUpon after register_dep")
+    Err(r) => assert_eq(r.kind, DestroyWhileDependedUpon)
+  }
   coord.unregister_dep(ws_cell.id(), id, editor_cell.id())
-  // Idempotent: a second remove is a no-op.
+  // Idempotent: a second remove on an empty edge set is a no-op.
   coord.unregister_dep(ws_cell.id(), id, editor_cell.id())
+  match coord.destroy_editor(id) {
+    Ok(_) => ()
+    Err(r) => fail("expected Ok after unregister_dep, got \{r}")
+  }
 }
 
 ///|
@@ -92,6 +110,8 @@ test "destroy_editor refuses while a dep edge points at this editor" {
     Ok(_) => ()
     Err(r) => fail("expected Ok after unregister_dep, got \{r}")
   }
+  // Destroy disposed the protected Watch (spec §7 lines 425-427).
+  assert_true((pe.is_disposed)())
 }
 
 ///|
@@ -112,6 +132,8 @@ test "read_protected after destroy returns EditorDestroyed with full context" {
     Err(r) => {
       assert_eq(r.kind, EditorDestroyed)
       assert_eq(r.agent_id, "test_agent")
+      @debug.assert_eq(r.cell_id, Some(d.id()))
+      @debug.assert_eq(r.cell_label, Some("ec"))
     }
   }
 }

--- a/workspace/coordinator/coordinator_test.mbt
+++ b/workspace/coordinator/coordinator_test.mbt
@@ -1,0 +1,117 @@
+// Unit tests for workspace/coordinator. See plan §PR3.3.
+
+///|
+test "Coordinator types are constructible" {
+  let coord = Coordinator::new()
+  let _ : @incr.Runtime = coord.runtime()
+}
+
+///|
+/// `Runtime::set_on_change` is single-occupancy (spec §6.1, claimed by
+/// `Coordinator::new`). Later tests in this file MUST NOT install their own
+/// on_change listeners or they will overwrite the coordinator's stub.
+test "Coordinator::new claims the on_change slot without aborting" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  // No assertion: this just verifies the slot is in use and the second
+  // assignment overwrites cleanly. Phase 2 multiplexes registered listeners.
+  rt.set_on_change(fn() {  })
+}
+
+///|
+test "register_editor returns a fresh EditorId and stores the registration" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 42 }, label="probe")
+  let pcell = ProtectedCell::from_derived("probe_label", d)
+  let id = coord.register_editor("agent_x", [pcell.erase()])
+  assert_eq(id, EditorId(0))
+  let id2 = coord.register_editor("agent_y", [])
+  assert_eq(id2, EditorId(1))
+}
+
+///|
+test "read_protected reads through the typed cell" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 99 }, label="probe")
+  let pcell = ProtectedCell::from_derived("probe", d)
+  let id = coord.register_editor("agent", [pcell.erase()])
+  match coord.read_protected(id, pcell) {
+    Ok(v) => assert_eq(v, 99)
+    Err(report) => fail("expected Ok, got \{report}")
+  }
+}
+
+///|
+test "read_protected rejects a cell not in editor's protected set" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d_a = @incr.Derived::Derived(rt, fn() { 1 }, label="a")
+  let d_b = @incr.Derived::Derived(rt, fn() { 2 }, label="b")
+  let pa = ProtectedCell::from_derived("a", d_a)
+  let pb = ProtectedCell::from_derived("b", d_b)
+  let id_a = coord.register_editor("a", [pa.erase()])
+  match coord.read_protected(id_a, pb) {
+    Ok(_) => fail("expected CellNotInProtectedSurface")
+    Err(r) => assert_eq(r.kind, CellNotInProtectedSurface)
+  }
+}
+
+///|
+test "register_dep + unregister_dep round trip" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let editor_cell = @incr.Derived::Derived(rt, fn() { 1 }, label="ec")
+  let ws_cell = @incr.Derived::Derived(rt, fn() { 2 }, label="ws")
+  let pe = ProtectedCell::from_derived("ec", editor_cell)
+  let id = coord.register_editor("agent", [pe.erase()])
+  coord.register_dep(ws_cell.id(), id, editor_cell.id())
+  // Idempotent: a second call with the same edge is a no-op.
+  coord.register_dep(ws_cell.id(), id, editor_cell.id())
+  coord.unregister_dep(ws_cell.id(), id, editor_cell.id())
+  // Idempotent: a second remove is a no-op.
+  coord.unregister_dep(ws_cell.id(), id, editor_cell.id())
+}
+
+///|
+test "destroy_editor refuses while a dep edge points at this editor" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 1 }, label="ec")
+  let pe = ProtectedCell::from_derived("ec", d)
+  let id = coord.register_editor("agent", [pe.erase()])
+  let ws_cell = @incr.Derived::Derived(rt, fn() { 0 }, label="ws")
+  coord.register_dep(ws_cell.id(), id, d.id())
+  match coord.destroy_editor(id) {
+    Ok(_) => fail("expected DestroyWhileDependedUpon")
+    Err(r) => assert_eq(r.kind, DestroyWhileDependedUpon)
+  }
+  coord.unregister_dep(ws_cell.id(), id, d.id())
+  match coord.destroy_editor(id) {
+    Ok(_) => ()
+    Err(r) => fail("expected Ok after unregister_dep, got \{r}")
+  }
+}
+
+///|
+test "read_protected after destroy returns EditorDestroyed with full context" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 7 }, label="ec")
+  let pe = ProtectedCell::from_derived("ec", d)
+  let id = coord.register_editor("test_agent", [pe.erase()])
+  match coord.destroy_editor(id) {
+    Ok(_) => ()
+    Err(r) => fail("destroy: \{r}")
+  }
+  // After destroy: registration stays (alive=false) so error carries
+  // agent_id + cell_label, not the bare-handle path.
+  match coord.read_protected(id, pe) {
+    Ok(_) => fail("expected EditorDestroyed")
+    Err(r) => {
+      assert_eq(r.kind, EditorDestroyed)
+      assert_eq(r.agent_id, "test_agent")
+    }
+  }
+}

--- a/workspace/coordinator/coordinator_wbtest.mbt
+++ b/workspace/coordinator/coordinator_wbtest.mbt
@@ -1,0 +1,22 @@
+// Whitebox tests for workspace/coordinator. These need package-internal
+// access to construct `ProtectedRead` directly (bypassing the public
+// `ProtectedCell::from_derived` factory), so they live here rather than in
+// `coordinator_test.mbt`.
+
+///|
+/// Mode-1 fail-fast (spec §13 D4): a `ProtectedRead` whose cell was never
+/// rooted via `Derived::watch()` is a factory contract violation. Constructed
+/// via the internal `ProtectedRead::ProtectedRead` constructor to bypass
+/// `ProtectedCell::from_derived`'s priming.
+test "panic register_editor aborts if any protected cell has gc_root_count == 0" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 1 }, label="rogue")
+  let pread = ProtectedRead::ProtectedRead(
+    cell_id=d.id(),
+    label="rogue",
+    is_disposed=fn() { false },
+    dispose=fn() {  },
+  )
+  let _ = coord.register_editor("agent", [pread])
+}

--- a/workspace/coordinator/methods.mbt
+++ b/workspace/coordinator/methods.mbt
@@ -6,8 +6,11 @@
 /// slot (spec §6.1), and constructs an empty registry.
 pub fn Coordinator::new() -> Coordinator {
   let runtime = @incr.Runtime::new(on_change=fn() {
-    // Phase 1 stub. Claims the §6.1 single-occupancy slot so no editor
-    // can install its own. Phase 2 multiplexes registered listeners.
+    // Phase 1 stub. Pre-populates the §6.1 single-occupancy slot at
+    // construction so the runtime always has *some* listener. Callers
+    // can still overwrite via `Runtime::set_on_change` — Phase 2 will
+    // close that hole by routing all listener registration through a
+    // coordinator-owned multiplexer (spec §13 follow-up).
 
   })
   Coordinator(runtime~)

--- a/workspace/coordinator/methods.mbt
+++ b/workspace/coordinator/methods.mbt
@@ -1,0 +1,215 @@
+// Coordinator method bodies — §P0b Phase 1.
+// See docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md §7.
+
+///|
+/// Allocates a fresh runtime, claims the single-occupancy `set_on_change`
+/// slot (spec §6.1), and constructs an empty registry.
+pub fn Coordinator::new() -> Coordinator {
+  let runtime = @incr.Runtime::new(on_change=fn() {
+    // Phase 1 stub. Claims the §6.1 single-occupancy slot so no editor
+    // can install its own. Phase 2 multiplexes registered listeners.
+
+  })
+  Coordinator(runtime~)
+}
+
+///|
+pub fn Coordinator::runtime(self : Coordinator) -> @incr.Runtime {
+  self.runtime
+}
+
+///|
+/// Registers an editor and returns a fresh `EditorId`. Factories must have
+/// already created the `Watch` (the GC root) and primed it once.
+pub fn Coordinator::register_editor(
+  self : Coordinator,
+  agent_id : String,
+  protected_reads : Array[ProtectedRead],
+) -> EditorId {
+  // Mode-1 fail-fast: factories MUST call `Derived::watch()` before erasure,
+  // which adds a GC root. Reaching this guard means a factory bypass or a
+  // `watch.dispose()` ran before registration — a contract violation, not a
+  // runtime condition. Spec §13 D4 = ON.
+  for p in protected_reads {
+    let n = self.runtime.gc_root_count(p.cell_id)
+    guard n > 0 else {
+      abort(
+        "Coordinator::register_editor: protected cell '\{p.label}' has no GC root — factory must call .watch() before erasure",
+      )
+    }
+  }
+  let id = self.next_id.val
+  self.next_id.val = id + 1
+  self.editors.set(id, { agent_id, protected_reads, alive: Ref(true) })
+  EditorId(id)
+}
+
+///|
+/// Idempotently records a `workspace_memo → editor_cell` dep edge owned by
+/// `editor_id`. `destroy_editor` refuses while any such edge points at the
+/// editor. Phase 1 callers: tests for the destroy gateway. Phase 1b+ callers:
+/// workspace memos releasing their own deps on dispose.
+pub fn Coordinator::register_dep(
+  self : Coordinator,
+  workspace_memo : @incr.CellId,
+  editor_id : EditorId,
+  editor_cell : @incr.CellId,
+) -> Unit {
+  let entry = match self.deps.get(workspace_memo) {
+    Some(arr) => arr
+    None => {
+      let arr : Array[(EditorId, @incr.CellId)] = []
+      self.deps.set(workspace_memo, arr)
+      arr
+    }
+  }
+  let edge = (editor_id, editor_cell)
+  if !entry.contains(edge) {
+    entry.push(edge)
+  }
+}
+
+///|
+/// Idempotent. Removes the edge if present; no-op if absent.
+pub fn Coordinator::unregister_dep(
+  self : Coordinator,
+  workspace_memo : @incr.CellId,
+  editor_id : EditorId,
+  editor_cell : @incr.CellId,
+) -> Unit {
+  let entry = match self.deps.get(workspace_memo) {
+    Some(e) => e
+    None => return
+  }
+  let edge = (editor_id, editor_cell)
+  // `Array::remove` is positional, not by-value; rebuild via filter and
+  // write back. Phase 1 dep-counts per workspace memo are small (<10 in
+  // any plausible scenario); profile in Phase 2 if this becomes hot.
+  let new_entry = entry.filter(fn(e) { e != edge })
+  if new_entry.is_empty() {
+    self.deps.remove(workspace_memo)
+  } else {
+    self.deps.set(workspace_memo, new_entry)
+  }
+}
+
+///|
+/// Refuses while workspace deps reference the editor (spec §7, Decision A).
+/// On success: flips `alive=false` BEFORE disposing watches so a re-entrant
+/// read can never see `alive=true` with disposed watches. Keeps the
+/// registration in the map so a stray `read_protected` after destroy still
+/// surfaces a full `AbortReport` with `agent_id`.
+pub fn Coordinator::destroy_editor(
+  self : Coordinator,
+  editor_id : EditorId,
+) -> Result[Unit, AbortReport] {
+  let reg = match self.editors.get(editor_id.0) {
+    Some(r) => r
+    None =>
+      return Err(
+        AbortReport(kind=EditorDestroyed, editor_id~, agent_id="<unknown>"),
+      )
+  }
+  guard reg.alive.val else {
+    return Err(
+      AbortReport(kind=EditorDestroyed, editor_id~, agent_id=reg.agent_id),
+    )
+  }
+  let referring : Array[@incr.CellId] = []
+  for ws_memo, edges in self.deps {
+    for edge in edges {
+      if edge.0 == editor_id {
+        referring.push(ws_memo)
+      }
+    }
+  }
+  if referring.length() > 0 {
+    return Err(
+      AbortReport(
+        kind=DestroyWhileDependedUpon,
+        editor_id~,
+        agent_id=reg.agent_id,
+        cell_id=referring[0],
+      ),
+    )
+  }
+  reg.alive.val = false
+  for p in reg.protected_reads {
+    (p.dispose)()
+  }
+  Ok(())
+}
+
+///|
+/// Validates editor liveness + cell membership + watch liveness, then reads.
+/// Cycles propagate to `AbortKind::CycleDetected` with `domain_tag` carrying
+/// `CycleError::format_path()`.
+pub fn[T] Coordinator::read_protected(
+  self : Coordinator,
+  editor_id : EditorId,
+  cell : ProtectedCell[T],
+) -> Result[T, AbortReport] {
+  let reg = match self.editors.get(editor_id.0) {
+    Some(r) => r
+    None =>
+      return Err(
+        AbortReport(
+          kind=EditorDestroyed,
+          editor_id~,
+          agent_id="<unknown>",
+          cell_id=cell.cell_id,
+          cell_label=cell.label,
+        ),
+      )
+  }
+  guard reg.alive.val else {
+    return Err(
+      AbortReport(
+        kind=EditorDestroyed,
+        editor_id~,
+        agent_id=reg.agent_id,
+        cell_id=cell.cell_id,
+        cell_label=cell.label,
+      ),
+    )
+  }
+  guard reg.protected_reads.any(fn(p) { p.cell_id == cell.cell_id }) else {
+    return Err(
+      AbortReport(
+        kind=CellNotInProtectedSurface,
+        editor_id~,
+        agent_id=reg.agent_id,
+        cell_id=cell.cell_id,
+        cell_label=cell.label,
+      ),
+    )
+  }
+  // Defense-in-depth against out-of-band Watch::dispose. Under normal flow,
+  // alive=true ⟹ no destroy ran ⟹ no watch disposed. Surfaces a typed
+  // AbortReport instead of the underlying Watch::read abort.
+  guard !(cell.is_disposed)() else {
+    return Err(
+      AbortReport(
+        kind=ProtectedCellDisposed,
+        editor_id~,
+        agent_id=reg.agent_id,
+        cell_id=cell.cell_id,
+        cell_label=cell.label,
+      ),
+    )
+  }
+  match (cell.read)() {
+    Ok(value) => Ok(value)
+    Err(cycle) =>
+      Err(
+        AbortReport(
+          kind=CycleDetected,
+          editor_id~,
+          agent_id=reg.agent_id,
+          cell_id=cell.cell_id,
+          cell_label=cell.label,
+          domain_tag=cycle.format_path(),
+        ),
+      )
+  }
+}

--- a/workspace/coordinator/moon.pkg
+++ b/workspace/coordinator/moon.pkg
@@ -1,4 +1,5 @@
 import {
   "dowdiness/incr",
+  "moonbitlang/core/debug",
   "moonbitlang/core/hashmap",
 }

--- a/workspace/coordinator/moon.pkg
+++ b/workspace/coordinator/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "dowdiness/incr",
+  "moonbitlang/core/hashmap",
+}

--- a/workspace/coordinator/pkg.generated.mbti
+++ b/workspace/coordinator/pkg.generated.mbti
@@ -1,0 +1,68 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/workspace/coordinator"
+
+import {
+  "dowdiness/incr/cells",
+  "dowdiness/incr/types",
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum AbortKind {
+  EditorDestroyed
+  DestroyWhileDependedUpon
+  CellNotInProtectedSurface
+  CycleDetected
+  ProtectedCellDisposed
+} derive(Eq, @debug.Debug)
+pub impl Show for AbortKind
+
+pub(all) struct AbortReport {
+  kind : AbortKind
+  editor_id : EditorId
+  agent_id : String
+  cell_id : @types.CellId?
+  cell_label : String?
+  domain_tag : String?
+} derive(@debug.Debug)
+pub impl Show for AbortReport
+
+pub struct Coordinator {
+  // private fields
+}
+pub fn Coordinator::destroy_editor(Self, EditorId) -> Result[Unit, AbortReport]
+pub fn Coordinator::new() -> Self
+pub fn[T] Coordinator::read_protected(Self, EditorId, ProtectedCell[T]) -> Result[T, AbortReport]
+pub fn Coordinator::register_dep(Self, @types.CellId, EditorId, @types.CellId) -> Unit
+pub fn Coordinator::register_editor(Self, String, Array[ProtectedRead]) -> EditorId
+pub fn Coordinator::runtime(Self) -> @cells.Runtime
+pub fn Coordinator::unregister_dep(Self, @types.CellId, EditorId, @types.CellId) -> Unit
+
+pub(all) struct EditorId(Int) derive(Eq, Hash, @debug.Debug)
+pub impl Show for EditorId
+
+pub struct ProtectedCell[T] {
+  cell_id : @types.CellId
+  label : String
+  read : () -> Result[T, @types.CycleError]
+  is_disposed : () -> Bool
+  dispose : () -> Unit
+}
+pub fn[T] ProtectedCell::erase(Self[T]) -> ProtectedRead
+pub fn[T] ProtectedCell::from_derived(String, @cells.Derived[T]) -> Self[T]
+
+pub struct ProtectedRead {
+  cell_id : @types.CellId
+  label : String
+  is_disposed : () -> Bool
+  dispose : () -> Unit
+}
+
+// Type aliases
+
+// Traits
+

--- a/workspace/coordinator/types.mbt
+++ b/workspace/coordinator/types.mbt
@@ -1,0 +1,147 @@
+// Workspace coordinator types — §P0b Phase 1 skeleton.
+// See docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md §6.
+
+///|
+pub(all) struct EditorId(Int) derive(Eq, Hash, @debug.Debug)
+
+///|
+pub impl Show for EditorId with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub(all) enum AbortKind {
+  EditorDestroyed
+  DestroyWhileDependedUpon
+  CellNotInProtectedSurface
+  CycleDetected
+  ProtectedCellDisposed
+} derive(Eq, @debug.Debug)
+
+///|
+pub impl Show for AbortKind with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub(all) struct AbortReport {
+  kind : AbortKind
+  editor_id : EditorId
+  agent_id : String
+  cell_id : @incr.CellId?
+  cell_label : String?
+  domain_tag : String?
+} derive(@debug.Debug)
+
+///|
+pub impl Show for AbortReport with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+fn AbortReport::AbortReport(
+  kind~ : AbortKind,
+  editor_id~ : EditorId,
+  agent_id~ : String,
+  cell_id? : @incr.CellId,
+  cell_label? : String,
+  domain_tag? : String,
+) -> AbortReport {
+  { kind, editor_id, agent_id, cell_id, cell_label, domain_tag }
+}
+
+///|
+pub struct ProtectedRead {
+  cell_id : @incr.CellId
+  label : String
+  is_disposed : () -> Bool
+  dispose : () -> Unit
+}
+
+///|
+fn ProtectedRead::ProtectedRead(
+  cell_id~ : @incr.CellId,
+  label~ : String,
+  is_disposed~ : () -> Bool,
+  dispose~ : () -> Unit,
+) -> ProtectedRead {
+  { cell_id, label, is_disposed, dispose }
+}
+
+///|
+pub struct ProtectedCell[T] {
+  cell_id : @incr.CellId
+  label : String
+  read : () -> Result[T, @incr.CycleError]
+  is_disposed : () -> Bool
+  dispose : () -> Unit
+}
+
+///|
+fn[T] ProtectedCell::ProtectedCell(
+  cell_id~ : @incr.CellId,
+  label~ : String,
+  read~ : () -> Result[T, @incr.CycleError],
+  is_disposed~ : () -> Bool,
+  dispose~ : () -> Unit,
+) -> ProtectedCell[T] {
+  { cell_id, label, read, is_disposed, dispose }
+}
+
+///|
+/// Build a `ProtectedCell` from a `Derived[T]`. Creates a long-lived `Watch`
+/// (the GC root) and primes it once so `gc_dependencies` is populated before
+/// any `Runtime::gc()` can sweep upstream cells. See spec §6.6.
+pub fn[T] ProtectedCell::from_derived(
+  label : String,
+  d : @incr.Derived[T],
+) -> ProtectedCell[T] {
+  let watch = d.watch()
+  let _ = watch.read()
+  ProtectedCell(
+    cell_id=d.id(),
+    label~,
+    read=fn() { watch.read() },
+    is_disposed=fn() { watch.is_disposed() },
+    dispose=fn() { watch.dispose() },
+  )
+}
+
+///|
+/// Erase the typed read closure, producing a registration-ready record.
+pub fn[T] ProtectedCell::erase(self : ProtectedCell[T]) -> ProtectedRead {
+  let c = self
+  ProtectedRead(
+    cell_id=c.cell_id,
+    label=c.label,
+    is_disposed=c.is_disposed,
+    dispose=c.dispose,
+  )
+}
+
+///|
+/// `protected_reads` rather than `protected` — the latter is a reserved
+/// MoonBit keyword and rejected by the parser.
+priv struct EditorRegistration {
+  agent_id : String
+  protected_reads : Array[ProtectedRead]
+  alive : Ref[Bool]
+}
+
+///|
+pub struct Coordinator {
+  priv runtime : @incr.Runtime
+  priv editors : @hashmap.HashMap[Int, EditorRegistration]
+  priv deps : @hashmap.HashMap[@incr.CellId, Array[(EditorId, @incr.CellId)]]
+  priv next_id : Ref[Int]
+}
+
+///|
+fn Coordinator::Coordinator(runtime~ : @incr.Runtime) -> Coordinator {
+  {
+    runtime,
+    editors: @hashmap.HashMap([]),
+    deps: @hashmap.HashMap([]),
+    next_id: Ref(0),
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `workspace/coordinator/` — the workspace-level coordinator that owns a shared `@incr.Runtime` and enforces Decision A (no-silent-stale-data) via a typed checked-read API. This PR ships the API + tests; PR4 wires the Lambda FFI helper.

Builds on PR #345 (PR2 — Lambda Memo→Derived sweep + protected-cell accessors + parent_runtime threading).

## Public surface

`workspace/coordinator/pkg.generated.mbti`:

- **`EditorId`** — `pub(all) struct EditorId(Int) derive(Eq, Hash, @debug.Debug)` + manual `impl Show`
- **`AbortKind`** — closed enum (5 variants): `EditorDestroyed`, `DestroyWhileDependedUpon`, `CellNotInProtectedSurface`, `CycleDetected`, `ProtectedCellDisposed`
- **`AbortReport`** — diagnostic payload: kind + editor_id + agent_id + cell_id? + cell_label? + domain_tag?
- **`ProtectedRead`** — erased registration record (cell_id, label, is_disposed, dispose)
- **`ProtectedCell[T]`** — typed read closure record + `from_derived` factory + `erase` projection
- **`Coordinator`** (opaque, fields private) — 7 methods: `new`, `runtime`, `register_editor`, `register_dep`, `unregister_dep`, `destroy_editor`, `read_protected`

## §13 plan-time decisions adopted

| # | Decision | Adopted |
|---|---|---|
| D2 | `unregister_dep` exposure | `pub` from day one (Phase 1b workspace memos will need it) |
| D3 | `AbortReport.domain_tag` semantic | Free-form prose; `CycleDetected` carries `CycleError::format_path()` |
| D4 | Mode-1 `gc_root_count` check | ON in `register_editor` — abort if any cell's gc_root_count is 0 |
| D5 | Test-helper visibility for `ProtectedCell::dispose` | Whitebox test in `coordinator_wbtest.mbt` (keeps API surface minimal) |

## Spec gaps surfaced and resolved inline

1. **`ReachableDerived::id()` is missing from incr v0.6.x public API** — only `Derived::id` is exposed. The spec's `ProtectedCell::from_reachable_derived` factory cannot compile. §P0b Phase 1 Lambda surface uses only `from_derived` (10 cells, all Derived), so the factory was dropped from PR3. When a Phase 1b ReachableDerived cell needs protection, add `ReachableDerived::id()` upstream first. Spec doc updated with a `SPEC GAP — DEFERRED PAST PR3` note.

2. **`domain_tag? : String?` in spec was double-Option** — the `?` suffix already wraps in Option. Corrected to `domain_tag? : String`. Call sites pass the raw String, not `Some(s)`.

3. **`protected` is a reserved MoonBit keyword** — rejected by the parser. Renamed field + parameter to `protected_reads` throughout. The plan/spec text needs the same rename when PR4 lands.

## Codex review

Two consults, both addressed before push.

- **Stage-4 scoped interaction-effect review (Codex):** PASS. Verified atomicity boundary (`alive=false` before watch dispose), dep-refusal path doesn't mutate `deps`, `read_protected` membership uses CellId value equality, mode-1 guard runs before `next_id` is bumped, `ProtectedCell::erase` preserves captured `Watch` via stored closures.
- **Broad open-ended pre-merge review (Codex):** Found 7 substantive issues (matches the precedent from PR #345). All 7 fixed in commit `09d7a94`: tautological round-trip test → observable destroy-gating; no-assertion on_change test → probe-based observable; missing dispose assertion after destroy success; comment/test mismatch on cell_id+cell_label; overstated `Coordinator::new` comment; spec doc updated re: `from_reachable_derived`; `lang/lambda/README.md` signature drift fixed.

## Side-effect catch-up

Three `.mbti` regen diffs trailed PR #345 and surfaced on a fresh-checkout regen:

- `editor/pkg.generated.mbti` — added `parser_source` accessor (PR2.5 added the source, not the .mbti)
- `lang/lambda/flat/pkg.generated.mbti` — `Memo → Derived` in `build_lambda_projection_memos` return tuple
- `lang/lambda/pkg.generated.mbti` — `parent_runtime?` param + `dowdiness/incr/cells` import

## Test plan

- [x] Package suite — 9 tests pass (8 blackbox + 1 panic wbtest)
- [x] Workspace-wide — 1163/1163 passing (baseline 1154 + 9 new)
- [x] check — zero errors, zero warnings
- [x] info + fmt — clean diff
- [x] `.mbti` boundary clean — Codex stage-4 confirmed no private types leak via public fields
- [ ] CI green on remote

## Follow-ups (out of scope)

- **PR4** — Lambda FFI helper (`assemble_lambda_handle`, `LambdaProtectedCells`, coordinator global, FFI ctor rewrite, tests §12 #1-6).
- Re-introduce `ProtectedCell::from_reachable_derived` once `ReachableDerived::id()` lands upstream in incr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
