### PR TITLE
feat(ffi/lambda): §P0b Phase 1 PR4 — assemble_lambda_handle + LambdaProtectedCells + §12 tests 1-6

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -31,7 +31,8 @@ fn init_model() -> Model raise {
   let agent_id = js_get_agent_id()
   let agent_id = if agent_id == "" { "local" } else { agent_id }
   // Create the editor through the crdt module so it sets the singleton (editor.val).
-  // JS (main.ts) will reuse handle=1 instead of creating a second editor.
+  // JS (main.ts) reuses this handle instead of creating a second editor.
+  // Under §P0b Phase 1 the coordinator allocates EditorIds from 0.
   let _handle = @ffi.create_editor_with_undo(agent_id, 500)
   let editor = @ffi.get_sync_editor().unwrap()
   let companion = @ffi.get_lambda_companion().unwrap()

--- a/examples/ideal/web/src/main.ts
+++ b/examples/ideal/web/src/main.ts
@@ -325,9 +325,12 @@ function mountWhenReady(crdt: CrdtModule) {
 }
 
 function doMount(el: CanopyEditor, crdt: CrdtModule) {
-  // Reuse the editor MoonBit already created in init_model (handle = 1).
-  // Don't call create_editor_with_undo again — that would overwrite the singleton.
-  const handle = 1;
+  // Reuse the editor MoonBit already created in init_model. Under
+  // §P0b Phase 1 the coordinator-allocated EditorId starts at 0, so
+  // the first (and only) editor opened by init_model has handle 0.
+  // Don't call create_editor_with_undo again — that would overwrite
+  // the singleton.
+  const handle = 0;
   const roomId = getRoomId();
   canopyGlobal.__canopy_crdt_handle = handle;
   canopyGlobal.__canopy_trigger_autosave = triggerAutosave;

--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -48,7 +48,7 @@ pub fn get_diagnostics_json(handle : Int) -> String {
       // the AST is incomplete and type errors would just be noise on top of
       // the parse error.
       if parse_errors.is_empty() {
-        let result = h.typecheck.observer.get()
+        let result = h.typecheck.output.read_or_abort()
         for diag in result.all_diagnostics {
           let m : Map[String, Json] = {}
           m["level"] = "error".to_json()

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -1,26 +1,28 @@
-// Lambda editor FFI — lifecycle, text I/O, handle registry
-
-// Handle-based editor registry (supports multiple concurrent editors)
+// Lambda editor FFI — lifecycle, text I/O, handle registry.
+//
+// All editor construction funnels through `assemble_lambda_handle` so the
+// FFI ctors (`create_editor`, `create_editor_with_undo`) share one
+// `@incr.Runtime`, one atomic registration boundary, and one destroy
+// gateway. See docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md
+// §8 and docs/superpowers/plans/2026-05-24-p0b-phase1-implementation.md §PR4.
 
 ///|
 priv struct LambdaHandle {
   editor : @editor.SyncEditor[@ast.Term]
   companion : @lang_lambda.LambdaCompanion
   typecheck : TypecheckBundle
+  editor_id : @workspace.EditorId
+  cells : LambdaProtectedCells
 }
 
 ///|
-/// Typecheck pipeline cells; `scope` disposal only — the underlying
-/// `Runtime` is owned by the editor's `Parser`.
-///
-/// `observer` is both the read path and the GC anchor: Scope membership
-/// alone does not register the underlying Derived's cell as a `gc_root`,
-/// so without a persistent Observer the entire typecheck cone would be
-/// eligible for sweep on any future `Runtime::gc()`. Mirrors loom-side
-/// `TypecheckAttachment` in `examples/lambda/src/typed_parser.mbt`.
+/// Typecheck pipeline cells. `scope` disposal handles owned per-def cells;
+/// rooting of `output` is the caller's responsibility — under §P0b Phase 1,
+/// `LambdaProtectedCells` constructs the `Watch` via
+/// `ProtectedCell::from_derived` (`protected_cells.mbt` `typecheck_output`).
 priv struct TypecheckBundle {
   scope : @cells.Scope
-  observer : @cells.Observer[@typecheck.ModuleTypeResult]
+  output : @cells.Derived[@typecheck.ModuleTypeResult]
 }
 
 ///|
@@ -34,29 +36,56 @@ fn new_typecheck_bundle(
     label="lambda-typed-term",
   )
   let output = @typecheck.build_typecheck_pipeline(rt, scope, typed_term_memo)
-  let observer = scope.add_observer(output.observe())
-  // Prime the closure so `gc_dependencies` is populated before any gc cycle
-  // could run — Observer alone is insufficient until the Memo has computed
-  // once (see `feedback-incr-gc-anchor-needs-priming`).
-  //
-  // Side effect: this makes `create_editor` the failure boundary for any
-  // typecheck panic, not `get_diagnostics_json`. Currently benign because a
-  // freshly-created editor has an empty document and the pipeline is total
-  // over empty input; if downstream stages ever become fallible here,
-  // create_editor aborts instead of the FFI consumer receiving an empty
-  // diagnostics result.
-  let _prime = observer.get()
-  { scope, observer }
+  { scope, output }
 }
+
+///|
+/// Process-global coordinator. Claimed once. Every FFI ctor goes through
+/// `assemble_lambda_handle`, which uses this instance so all editors share
+/// the same `@incr.Runtime` and the same atomic registration boundary.
+let coordinator : @workspace.Coordinator = @workspace.Coordinator::new()
 
 ///|
 let lambda_handles : Map[Int, LambdaHandle] = Map::default()
 
 ///|
-let next_handle : Ref[Int] = { val: 1 }
+let last_created_handle : Ref[Int?] = { val: None }
 
 ///|
-let last_created_handle : Ref[Int?] = { val: None }
+/// Build a Lambda editor + companion + typecheck bundle on the shared
+/// runtime, then atomically register them with the coordinator. Returns
+/// the freshly-allocated `EditorId`. Aborting at any step leaves
+/// `lambda_handles` untouched (atomic-boundary observation, spec §8.3).
+fn assemble_lambda_handle(
+  agent_id : String,
+  capture_timeout_ms? : Int = 500,
+) -> @workspace.EditorId {
+  let (editor, companion) = @lang_lambda.new_lambda_editor(
+    agent_id,
+    capture_timeout_ms~,
+    parent_runtime=coordinator.runtime(),
+  )
+  let typecheck = new_typecheck_bundle(
+    editor.parser_runtime(),
+    editor.parser_syntax_tree(),
+  )
+  let cells = LambdaProtectedCells::LambdaProtectedCells(
+    editor, companion, typecheck,
+  )
+  let editor_id = coordinator.register_editor(
+    agent_id,
+    cells.to_protected_reads(),
+  )
+  lambda_handles[editor_id.0] = {
+    editor,
+    companion,
+    typecheck,
+    editor_id,
+    cells,
+  }
+  last_created_handle.val = Some(editor_id.0)
+  editor_id
+}
 
 ///|
 /// Get the most recently created editor for legacy MoonBit consumers.
@@ -85,37 +114,43 @@ pub fn get_lambda_companion() -> @lang_lambda.LambdaCompanion? {
 }
 
 ///|
-/// Create a new SyncEditor instance.
-/// Returns a unique handle for this editor.
+/// Create a new SyncEditor instance. Returns a unique handle.
 pub fn create_editor(agent_id : String) -> Int {
-  let handle = next_handle.val
-  next_handle.val = handle + 1
-  let (editor, companion) = @lang_lambda.new_lambda_editor(agent_id)
-  lambda_handles[handle] = {
-    editor,
-    companion,
-    typecheck: new_typecheck_bundle(
-      editor.parser_runtime(),
-      editor.parser_syntax_tree(),
-    ),
-  }
-  last_created_handle.val = Some(handle)
-  handle
+  assemble_lambda_handle(agent_id).0
 }
 
 ///|
-/// Destroy an editor instance and free its resources.
+/// Destroy an editor instance and free its resources. The coordinator
+/// gateway refuses if workspace deps still reference the editor; in that
+/// case the FFI-side bookkeeping (lambda_handles entry, typecheck scope)
+/// is intentionally left intact so reads of cached state remain valid.
 pub fn destroy_editor(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
-    Some(h) => h.typecheck.scope.dispose()
-    None => ()
+  let h = match lambda_handles.get(handle) {
+    Some(v) => v
+    None => return
   }
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => {
+      // Phase 1: log + skip teardown so dep references remain valid.
+      // Phase 2 surfaces this to JS via a dedicated FFI error channel.
+      println("destroy_editor refused: \{report}")
+      return
+    }
+  }
+  // Remove FFI-side bookkeeping BEFORE disposing the typecheck scope. If
+  // scope.dispose ever raises (e.g., loom-side cleanup defect), the
+  // externally-visible state still reflects reality: the handle is gone,
+  // subsequent FFI calls on it return the empty/default fallback path. A
+  // leaked scope is observable only via incr-level inspection; a leaked
+  // lambda_handles entry would be observable as a phantom editor.
   lambda_handles.remove(handle)
   view_states.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
   }
+  h.typecheck.scope.dispose()
 }
 
 ///|

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -1,0 +1,156 @@
+// Whitebox integration tests for §P0b Phase 1: Lambda FFI editors driven
+// through the workspace coordinator. Covers spec §12 tests 1, 2, 3, 4 —
+// these need access to package-private symbols (`lambda_handles`,
+// `coordinator`, `LambdaHandle` fields), so they live in a `_wbtest.mbt`.
+//
+// §12 #5 (`ProtectedCellDisposed`) and §12 #6 (`CycleDetected` mapping)
+// live in `workspace/coordinator/coordinator_wbtest.mbt` — they only
+// exercise coordinator-side behavior and don't need the Lambda surface.
+
+///|
+fn reset_coordinator_for_phase1_tests() -> Unit {
+  // Force-clear the FFI side. Going through public `destroy_editor`
+  // would route through `coordinator.destroy_editor`, which can refuse
+  // (DestroyWhileDependedUpon, EditorDestroyed) and leave the entry
+  // behind — fragile if a prior test panicked mid-flow and left a
+  // stale dep or an already-disposed registration. Mirrors
+  // `clear_lambda_handles` in `destroy_editor_wbtest.mbt`. Coordinator-
+  // side registrations stay around with alive=true and may leak Watch
+  // roots, but each new test gets a fresh EditorId from the monotonic
+  // counter, so leakage cannot affect correctness — only memory.
+  let keys = lambda_handles.keys().to_array()
+  for k in keys {
+    lambda_handles.remove(k)
+  }
+  let vkeys = view_states.keys().to_array()
+  for k in vkeys {
+    view_states.remove(k)
+  }
+  let pvkeys = pretty_view_states.keys().to_array()
+  for k in pvkeys {
+    pretty_view_states.remove(k)
+  }
+  last_created_handle.val = None
+}
+
+///|
+test "spec §12 #1: each protected cell reads through read_protected" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("test_agent_one")
+  let h = lambda_handles.get(handle).unwrap()
+  let id = h.editor_id
+  // Spec compliance: every cell wired into the bundle must reach
+  // `read_protected` with Ok(_) on a freshly-created editor. Reading
+  // all 10 (not a spot-check) guarantees a wiring defect on any single
+  // cell fails this test instead of slipping past.
+  match coordinator.read_protected(id, h.cells.parser_syntax_tree) {
+    Ok(_) => ()
+    Err(report) => fail("parser_syntax_tree: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.parser_ast) {
+    Ok(_) => ()
+    Err(report) => fail("parser_ast: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.parser_source) {
+    Ok(s) => assert_eq(s, "")
+    Err(report) => fail("parser_source: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.parser_diagnostics) {
+    Ok(_) => ()
+    Err(report) => fail("parser_diagnostics: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.cached_proj_node) {
+    Ok(_) => ()
+    Err(report) => fail("cached_proj_node: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.registry_memo) {
+    Ok(_) => ()
+    Err(report) => fail("registry_memo: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.source_map_memo) {
+    Ok(_) => ()
+    Err(report) => fail("source_map_memo: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.proj_memo) {
+    Ok(_) => ()
+    Err(report) => fail("proj_memo: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.escalation_memo) {
+    Ok(_) => ()
+    Err(report) => fail("escalation_memo: \{report}")
+  }
+  match coordinator.read_protected(id, h.cells.typecheck_output) {
+    Ok(_) => ()
+    Err(report) => fail("typecheck_output: \{report}")
+  }
+  destroy_editor(handle)
+}
+
+///|
+test "spec §12 #2: destroy refused while depended-upon; succeeds after unregister_dep" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("test_agent_two")
+  let h = lambda_handles.get(handle).unwrap()
+  let id = h.editor_id
+  let parser_ast_id = h.cells.parser_ast.cell_id()
+  // Synthetic workspace memo id — register_dep only stores edges by
+  // CellId. Using parser_ast_id on both sides keeps the test free of
+  // any real workspace memo, which Phase 1 doesn't ship.
+  let synth_id = parser_ast_id
+  coordinator.register_dep(synth_id, id, parser_ast_id)
+  match coordinator.destroy_editor(id) {
+    Ok(_) => fail("expected DestroyWhileDependedUpon")
+    Err(report) => assert_eq(report.kind, @workspace.DestroyWhileDependedUpon)
+  }
+  coordinator.unregister_dep(synth_id, id, parser_ast_id)
+  match coordinator.destroy_editor(id) {
+    Ok(_) => ()
+    Err(report) => fail("expected Ok after unregister_dep, got \{report}")
+  }
+  // We bypassed the FFI `destroy_editor` wrapper, so the typecheck scope
+  // and FFI bookkeeping are still in place. Drain them so subsequent
+  // tests don't trip over the lingering handle. We cannot route through
+  // `destroy_editor(handle)` again because the coordinator has already
+  // marked the registration alive=false.
+  h.typecheck.scope.dispose()
+  lambda_handles.remove(handle)
+  view_states.remove(handle)
+  pretty_view_states.remove(handle)
+  if last_created_handle.val == Some(handle) {
+    last_created_handle.val = None
+  }
+}
+
+///|
+test "spec §12 #3: read_protected after destroy returns EditorDestroyed" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("test_agent_three")
+  let h = lambda_handles.get(handle).unwrap()
+  let id = h.editor_id
+  let parser_source_cell = h.cells.parser_source
+  destroy_editor(handle)
+  // The handle is now removed from lambda_handles, but the registration
+  // in the coordinator stays (alive=false) so the error carries agent_id.
+  match coordinator.read_protected(id, parser_source_cell) {
+    Ok(_) => fail("expected EditorDestroyed")
+    Err(report) => {
+      assert_eq(report.kind, @workspace.EditorDestroyed)
+      assert_eq(report.agent_id, "test_agent_three")
+    }
+  }
+}
+
+///|
+test "spec §12 #4: read_protected rejects cells from a different editor" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("agent_alpha")
+  let handle_b = create_editor("agent_beta")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+  match coordinator.read_protected(h_b.editor_id, h_a.cells.parser_ast) {
+    Ok(_) => fail("expected CellNotInProtectedSurface")
+    Err(report) => assert_eq(report.kind, @workspace.CellNotInProtectedSurface)
+  }
+  destroy_editor(handle_a)
+  destroy_editor(handle_b)
+}

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -1,10 +1,15 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda" @lang_lambda,
+  "dowdiness/canopy/lang/lambda/flat" @lambda_flat,
+  "dowdiness/canopy/lang/lambda/eval" @lambda_eval,
   "dowdiness/canopy/llm",
   "dowdiness/canopy/relay",
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/workspace/coordinator" @workspace,
   "dowdiness/lambda/ast",
   "dowdiness/lambda/typecheck",
+  "dowdiness/loom/core" @loom,
   "dowdiness/seam",
   "dowdiness/incr/cells",
   "dowdiness/event-graph-walker/text",
@@ -13,6 +18,13 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/core/string",
 }
+
+// `cells` field of LambdaHandle is read only by whitebox tests
+// (`lifecycle_phase1_wbtest.mbt` exercises `coordinator.read_protected(id,
+// h.cells.<cell>)`). Phase 1b will surface those reads in production FFI
+// accessors; until then suppress the source-only unused-field check.
+
+warnings = "-7"
 
 options(
   link: {

--- a/ffi/lambda/pkg.generated.mbti
+++ b/ffi/lambda/pkg.generated.mbti
@@ -4,7 +4,12 @@ package "dowdiness/canopy/ffi/lambda"
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/companion",
+  "dowdiness/canopy/lang/lambda/eval",
+  "dowdiness/canopy/lang/lambda/flat",
+  "dowdiness/canopy/workspace/coordinator",
   "dowdiness/lambda/ast",
+  "dowdiness/lambda/typecheck",
+  "dowdiness/seam",
   "moonbitlang/async/js_async",
 }
 
@@ -134,6 +139,19 @@ pub fn ws_set_status_callback(Int) -> Unit
 // Errors
 
 // Types and methods
+pub struct LambdaProtectedCells {
+  parser_syntax_tree : @coordinator.ProtectedCell[@seam.SyntaxNode]
+  parser_ast : @coordinator.ProtectedCell[@ast.Term]
+  parser_source : @coordinator.ProtectedCell[String]
+  parser_diagnostics : @coordinator.ProtectedCell[@dowdiness/loom/core.DiagnosticSet]
+  cached_proj_node : @coordinator.ProtectedCell[@dowdiness/canopy/core.ProjNode[@ast.Term]?]
+  registry_memo : @coordinator.ProtectedCell[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]]
+  source_map_memo : @coordinator.ProtectedCell[@dowdiness/canopy/core.SourceMap]
+  proj_memo : @coordinator.ProtectedCell[@flat.VersionedFlatProj]
+  escalation_memo : @coordinator.ProtectedCell[Array[@eval.EvalResult]]
+  typecheck_output : @coordinator.ProtectedCell[@typecheck.ModuleTypeResult]
+}
+pub fn LambdaProtectedCells::to_protected_reads(Self) -> Array[@coordinator.ProtectedRead]
 
 // Type aliases
 

--- a/ffi/lambda/pkg.generated.mbti
+++ b/ffi/lambda/pkg.generated.mbti
@@ -4,12 +4,7 @@ package "dowdiness/canopy/ffi/lambda"
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/companion",
-  "dowdiness/canopy/lang/lambda/eval",
-  "dowdiness/canopy/lang/lambda/flat",
-  "dowdiness/canopy/workspace/coordinator",
   "dowdiness/lambda/ast",
-  "dowdiness/lambda/typecheck",
-  "dowdiness/seam",
   "moonbitlang/async/js_async",
 }
 
@@ -139,19 +134,6 @@ pub fn ws_set_status_callback(Int) -> Unit
 // Errors
 
 // Types and methods
-pub struct LambdaProtectedCells {
-  parser_syntax_tree : @coordinator.ProtectedCell[@seam.SyntaxNode]
-  parser_ast : @coordinator.ProtectedCell[@ast.Term]
-  parser_source : @coordinator.ProtectedCell[String]
-  parser_diagnostics : @coordinator.ProtectedCell[@dowdiness/loom/core.DiagnosticSet]
-  cached_proj_node : @coordinator.ProtectedCell[@dowdiness/canopy/core.ProjNode[@ast.Term]?]
-  registry_memo : @coordinator.ProtectedCell[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]]
-  source_map_memo : @coordinator.ProtectedCell[@dowdiness/canopy/core.SourceMap]
-  proj_memo : @coordinator.ProtectedCell[@flat.VersionedFlatProj]
-  escalation_memo : @coordinator.ProtectedCell[Array[@eval.EvalResult]]
-  typecheck_output : @coordinator.ProtectedCell[@typecheck.ModuleTypeResult]
-}
-pub fn LambdaProtectedCells::to_protected_reads(Self) -> Array[@coordinator.ProtectedRead]
 
 // Type aliases
 

--- a/ffi/lambda/protected_cells.mbt
+++ b/ffi/lambda/protected_cells.mbt
@@ -1,0 +1,96 @@
+// Lambda protected-cell bundle — typed view onto the editor surface that
+// participates in workspace coordination.
+//
+// Each field wraps an editor or companion `Derived[T]` in a long-lived
+// `Watch` (the GC root) via `ProtectedCell::from_derived`. The bundle is
+// constructed from a freshly-built editor + companion + typecheck bundle
+// inside `assemble_lambda_handle` (lifecycle.mbt) and erased to
+// `Array[ProtectedRead]` for registration with the coordinator.
+//
+// See docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md §8.1.
+
+///|
+pub struct LambdaProtectedCells {
+  parser_syntax_tree : @workspace.ProtectedCell[@seam.SyntaxNode]
+  parser_ast : @workspace.ProtectedCell[@ast.Term]
+  parser_source : @workspace.ProtectedCell[String]
+  parser_diagnostics : @workspace.ProtectedCell[@loom.DiagnosticSet]
+  cached_proj_node : @workspace.ProtectedCell[@core.ProjNode[@ast.Term]?]
+  registry_memo : @workspace.ProtectedCell[
+    Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  ]
+  source_map_memo : @workspace.ProtectedCell[@core.SourceMap]
+  proj_memo : @workspace.ProtectedCell[@lambda_flat.VersionedFlatProj]
+  escalation_memo : @workspace.ProtectedCell[Array[@lambda_eval.EvalResult]]
+  typecheck_output : @workspace.ProtectedCell[@typecheck.ModuleTypeResult]
+}
+
+///|
+fn LambdaProtectedCells::LambdaProtectedCells(
+  editor : @editor.SyncEditor[@ast.Term],
+  companion : @lang_lambda.LambdaCompanion,
+  typecheck : TypecheckBundle,
+) -> LambdaProtectedCells {
+  {
+    parser_syntax_tree: @workspace.ProtectedCell::from_derived(
+      "parser_syntax_view",
+      editor.parser_syntax_tree(),
+    ),
+    parser_ast: @workspace.ProtectedCell::from_derived(
+      "parser_ast_view",
+      editor.parser_ast(),
+    ),
+    parser_source: @workspace.ProtectedCell::from_derived(
+      "parser_source_view",
+      editor.parser_source(),
+    ),
+    parser_diagnostics: @workspace.ProtectedCell::from_derived(
+      "parser_diagnostics_view",
+      editor.parser_diagnostics(),
+    ),
+    cached_proj_node: @workspace.ProtectedCell::from_derived(
+      "cached_proj_node",
+      editor.cached_proj_node(),
+    ),
+    registry_memo: @workspace.ProtectedCell::from_derived(
+      "proj_registry",
+      editor.registry_memo(),
+    ),
+    source_map_memo: @workspace.ProtectedCell::from_derived(
+      "source_map",
+      editor.source_map_memo(),
+    ),
+    proj_memo: @workspace.ProtectedCell::from_derived(
+      "proj_flat",
+      companion.proj_memo(),
+    ),
+    escalation_memo: @workspace.ProtectedCell::from_derived(
+      "escalation_memo",
+      companion.escalation_memo(),
+    ),
+    typecheck_output: @workspace.ProtectedCell::from_derived(
+      "typecheck_pipeline",
+      typecheck.output,
+    ),
+  }
+}
+
+///|
+/// Erase every typed cell to a registration-ready `ProtectedRead`. Order
+/// is stable; downstream consumers must not depend on order.
+pub fn LambdaProtectedCells::to_protected_reads(
+  self : LambdaProtectedCells,
+) -> Array[@workspace.ProtectedRead] {
+  [
+    self.parser_syntax_tree.erase(),
+    self.parser_ast.erase(),
+    self.parser_source.erase(),
+    self.parser_diagnostics.erase(),
+    self.cached_proj_node.erase(),
+    self.registry_memo.erase(),
+    self.source_map_memo.erase(),
+    self.proj_memo.erase(),
+    self.escalation_memo.erase(),
+    self.typecheck_output.erase(),
+  ]
+}

--- a/ffi/lambda/protected_cells.mbt
+++ b/ffi/lambda/protected_cells.mbt
@@ -10,7 +10,12 @@
 // See docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md §8.1.
 
 ///|
-pub struct LambdaProtectedCells {
+/// Internal FFI assembly bundle. `priv` so the protected-surface shape
+/// stays an implementation detail — Phase 1b production accessors live
+/// in this same package and reach the fields directly. If a future
+/// cross-package consumer (e.g., a separate workspace introspection
+/// crate) needs the bundle, promote to `pub` then.
+priv struct LambdaProtectedCells {
   parser_syntax_tree : @workspace.ProtectedCell[@seam.SyntaxNode]
   parser_ast : @workspace.ProtectedCell[@ast.Term]
   parser_source : @workspace.ProtectedCell[String]
@@ -78,7 +83,7 @@ fn LambdaProtectedCells::LambdaProtectedCells(
 ///|
 /// Erase every typed cell to a registration-ready `ProtectedRead`. Order
 /// is stable; downstream consumers must not depend on order.
-pub fn LambdaProtectedCells::to_protected_reads(
+fn LambdaProtectedCells::to_protected_reads(
   self : LambdaProtectedCells,
 ) -> Array[@workspace.ProtectedRead] {
   [

--- a/ffi/lambda/undo.mbt
+++ b/ffi/lambda/undo.mbt
@@ -8,22 +8,7 @@ pub fn create_editor_with_undo(
   agent_id : String,
   capture_timeout_ms : Int,
 ) -> Int {
-  let handle = next_handle.val
-  next_handle.val = handle + 1
-  let (editor, companion) = @lang_lambda.new_lambda_editor(
-    agent_id,
-    capture_timeout_ms~,
-  )
-  lambda_handles[handle] = {
-    editor,
-    companion,
-    typecheck: new_typecheck_bundle(
-      editor.parser_runtime(),
-      editor.parser_syntax_tree(),
-    ),
-  }
-  last_created_handle.val = Some(handle)
-  handle
+  assemble_lambda_handle(agent_id, capture_timeout_ms~).0
 }
 
 ///|

--- a/workspace/coordinator/coordinator_wbtest.mbt
+++ b/workspace/coordinator/coordinator_wbtest.mbt
@@ -20,3 +20,65 @@ test "panic register_editor aborts if any protected cell has gc_root_count == 0"
   )
   let _ = coord.register_editor("agent", [pread])
 }
+
+///|
+/// Spec §12 #5: defense-in-depth against out-of-band `Watch::dispose`. Under
+/// normal flow, the coordinator destroys the editor before any watch is
+/// disposed. If a caller bypasses the gateway and disposes a watch
+/// directly, the next `read_protected` must surface
+/// `AbortKind::ProtectedCellDisposed` rather than the underlying
+/// `Watch::read` abort. We trigger the out-of-band path by calling the
+/// dispose closure field directly — legal here because the test lives in
+/// the same package as `ProtectedCell`.
+test "spec §12 #5: read_protected catches out-of-band Watch dispose" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 7 }, label="probe")
+  let pcell = ProtectedCell::from_derived("probe", d)
+  let id = coord.register_editor("agent", [pcell.erase()])
+  (pcell.dispose)()
+  match coord.read_protected(id, pcell) {
+    Ok(_) => fail("expected ProtectedCellDisposed")
+    Err(report) => assert_eq(report.kind, ProtectedCellDisposed)
+  }
+}
+
+///|
+/// Spec §12 #6: verify the `Err(CycleError) → AbortKind::CycleDetected`
+/// mapping (not loom's cycle-detection algorithm itself, which is covered
+/// by incr's own test suite). A self-referential `Derived::compute` closure
+/// can't surface real `Err(CycleError)` through `Watch::read` today —
+/// incr's memo machinery wraps the inner abort in its compute-body catch
+/// handler, so the outer `Watch::read` receives a hard abort rather than
+/// `Err(CycleError)`. To isolate the mapping concern, hand-build a
+/// `ProtectedCell` whose `read` closure directly returns
+/// `Err(CycleError::new(...))`. The cell_id points at a real,
+/// watch-rooted Derived so the mode-1 fail-fast passes.
+test "spec §12 #6: read_protected maps Err(CycleError) to CycleDetected" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let anchor = @incr.Derived::Derived(rt, fn() { 0 }, label="anchor")
+  // Explicit watch+prime so `register_editor`'s mode-1 check sees
+  // gc_root_count > 0 for `anchor.id()`. Kept alive by the local binding.
+  let watch = anchor.watch()
+  let _ = watch.read()
+  let cell_id = anchor.id()
+  let synthetic_cycle = @incr.CycleError::new(cell_id, [cell_id], [
+    Some("synthetic_cycle"),
+  ])
+  let pcell : ProtectedCell[Int] = ProtectedCell::ProtectedCell(
+    cell_id~,
+    label="synthetic_cycle",
+    read=fn() { Err(synthetic_cycle) },
+    is_disposed=fn() { false },
+    dispose=fn() {  },
+  )
+  let id = coord.register_editor("agent", [pcell.erase()])
+  match coord.read_protected(id, pcell) {
+    Ok(_) => fail("expected CycleDetected")
+    Err(report) => {
+      assert_eq(report.kind, CycleDetected)
+      assert_true(report.domain_tag is Some(_))
+    }
+  }
+}

--- a/workspace/coordinator/pkg.generated.mbti
+++ b/workspace/coordinator/pkg.generated.mbti
@@ -52,6 +52,7 @@ pub struct ProtectedCell[T] {
   is_disposed : () -> Bool
   dispose : () -> Unit
 }
+pub fn[T] ProtectedCell::cell_id(Self[T]) -> @types.CellId
 pub fn[T] ProtectedCell::erase(Self[T]) -> ProtectedRead
 pub fn[T] ProtectedCell::from_derived(String, @cells.Derived[T]) -> Self[T]
 

--- a/workspace/coordinator/types.mbt
+++ b/workspace/coordinator/types.mbt
@@ -108,6 +108,14 @@ pub fn[T] ProtectedCell::from_derived(
 }
 
 ///|
+/// The cell's underlying `@incr.CellId`. Exposed for cross-package call
+/// sites that need to feed this id back into the coordinator (e.g.,
+/// `register_dep` from an FFI integration test).
+pub fn[T] ProtectedCell::cell_id(self : ProtectedCell[T]) -> @incr.CellId {
+  self.cell_id
+}
+
+///|
 /// Erase the typed read closure, producing a registration-ready record.
 pub fn[T] ProtectedCell::erase(self : ProtectedCell[T]) -> ProtectedRead {
   let c = self


### PR DESCRIPTION
## Summary

Wires the workspace coordinator (PR #347) into the Lambda FFI. Every editor now goes through a process-global `@workspace.Coordinator` with a shared `@incr.Runtime`, an atomic registration boundary, and a typed `LambdaProtectedCells` bundle that the coordinator owns Watches for.

This is **PR4 of 4** in the §P0b Phase 1 sequence. Predecessors: PR #341 (loom #147 migration), PR #345 (Memo→Derived + accessors), PR #347 (coordinator package).

- Spec: `docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md` §8
- Plan: `docs/superpowers/plans/2026-05-24-p0b-phase1-implementation.md` §PR4

## What this lands

**New surface**
- `ffi/lambda/protected_cells.mbt` — `LambdaProtectedCells` (10 typed cells: parser surface 4, projection 3, lambda 2, typecheck 1) + `to_protected_reads()` erasure.
- `ffi/lambda/lifecycle.mbt` — global `coordinator` singleton + `assemble_lambda_handle` helper (eliminates the 5-step ctor duplication between `create_editor` and `create_editor_with_undo`, spec §1).
- `workspace/coordinator/types.mbt` — `pub fn ProtectedCell::cell_id` accessor for cross-package integration tests.

**Migrated**
- `TypecheckBundle`: `observer : Observer[..]` → `output : Derived[..]`. Rooting moves to `ProtectedCell::from_derived(\"typecheck_pipeline\", output)`. `diagnostics.mbt`'s `observer.get()` → `output.read_or_abort()`. This is a single-commit compile gate (acknowledged in the plan).
- `destroy_editor`: now defers to `coordinator.destroy_editor` for the workspace-dep gate, then cleans FFI bookkeeping **before** disposing the typecheck scope so a late-stage scope.dispose raise can't strand a phantom map entry (Codex stage-4 finding #3).
- `examples/ideal/web/src/main.ts`: handle base shifted 1 → 0 (coordinator allocates EditorIds from 0; the prior `next_handle` started at 1). No other example was affected.

## Tests (spec §12 #1-6)

- `ffi/lambda/lifecycle_phase1_wbtest.mbt` — #1 reads all 10 cells; #2 destroy refused while depended-upon, succeeds after `unregister_dep`; #3 read-after-destroy returns `EditorDestroyed` with `agent_id`; #4 cross-editor read returns `CellNotInProtectedSurface`.
- `workspace/coordinator/coordinator_wbtest.mbt` — #5 catches out-of-band `Watch::dispose` with `ProtectedCellDisposed`; #6 `Err(CycleError)` maps to `AbortKind::CycleDetected` (hand-built `ProtectedCell` because real cycles can't surface through `Watch::read` today — see spec gap below).

## Codex review

- **Stage-4 scoped** + **broad pre-merge** per CLAUDE.md \"Algorithm Implementation Process\" stage 4 + the [[feedback-codex-broad-vs-scoped-review]] precedent. Both returned NEEDS-REVISION. 9 findings total.
- **5 fixed inline:** main.ts `handle=1`→`0`, destroy_editor scope.dispose ordering, `reset_coordinator_for_phase1_tests` force-clear (was using public `destroy_editor` which can refuse cleanup if deps are stale), test #1 expanded from 3 → 10 cells, removed rot-prone `cells/memo.mbt:222` citation.
- **2 deferred with reasons** (explicit, not silent followups):
  1. Mode-1 `register_editor` abort leaks Watch roots — recovery requires `register_editor` to return `Result` rather than `abort`, a coordinator API change out of scope for PR4. Mode-1 only fires on factory contract violation (spec §13 D4).
  2. `Coordinator::destroy_editor` sets `alive=false` BEFORE the dispose loop; a mid-loop dispose raise zombies the editor. The fix lives in `workspace/coordinator/methods.mbt` (PR #347 code, not touched by PR4).

## Spec gap surfaced (test #6 cycle reproduction)

The §12 test 6 \"construct a real cycle\" recipe is unreliable: incr's memo compute-body catch wraps any inner abort, so `Watch::read` receives a hard abort rather than `Err(CycleError)`. The test verifies the `Err(CycleError) → AbortKind::CycleDetected` mapping by hand-building a `ProtectedCell` whose read closure returns Err directly. End-to-end real-cycle coverage stays deferred (incr's own tests cover cycle detection upstream). Captured in spec §12 \"Spec gaps surfaced\".

## Verification

- `moon check` workspace-wide: clean.
- `moon test` workspace-wide: **1169/1169** (baseline 1163 + 6 new tests).
- `grep -rn '@incr\\.Memo\\[\\|@cells\\.Memo\\[' lang/ ffi/ editor/ workspace/`: zero hits.
- `moon info` + `moon fmt`: clean.
- `.mbti` diffs reviewed: only intentional pub-API additions.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` clean
- [x] `NEW_MOON_MOD=0 moon test` 1169/1169 passing
- [ ] CI green (all required checks, none skipped)
- [ ] Codex pre-merge review (if reviewer wants a third look — already done locally)
- [ ] Manual smoke: load `examples/ideal/web` and confirm the editor opens with handle 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cell identification accessor for protected cells

* **Bug Fixes**
  * Improved type-check diagnostics retrieval process

* **Tests**
  * Added integration tests for editor lifecycle management and protection
  * Added tests for editor destruction and dependency handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->