### PR TITLE
feat(ffi/lambda): §P0b Phase 1b WS1 — route get_diagnostics_json reads through coordinator

### DIFF
--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -41,15 +41,25 @@ pub fn get_diagnostics_json(handle : Int) -> String {
       // coordinator-destroyed editor would be worse than empty, and
       // CellNotInProtectedSurface / CycleDetected are structural defects we
       // do not want to render as authoritative output.
-      let parse_diag_set = match
-        coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
-        Ok(d) => d
-        Err(report) => {
-          println("get_diagnostics_json parser read: \{report}")
-          return "[]"
+      //
+      // Empty-source guard: mirrors the suppression that lived in
+      // `SyncEditor::get_errors` (editor/sync_editor_parser.mbt:108-110)
+      // before this migration replaced that call. Reading
+      // `parser_diagnostics.format()` directly on an empty doc could
+      // surface spurious parser output that consumers (JS panel rendering)
+      // were never previously exposed to.
+      let parse_errors : Array[String] = if h.editor.get_text() == "" {
+        []
+      } else {
+        match
+          coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
+          Ok(d) => d.format()
+          Err(report) => {
+            println("get_diagnostics_json parser read: \{report}")
+            return "[]"
+          }
         }
       }
-      let parse_errors = parse_diag_set.format()
       // Typecheck only meaningful if parsing succeeded; otherwise the AST
       // is incomplete and type errors would just be noise on top of the
       // parse error.

--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -36,31 +36,61 @@ pub fn get_errors_json(handle : Int) -> String {
 pub fn get_diagnostics_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
     Some(h) => {
+      // Read every protected cell this accessor depends on up front; any
+      // Err collapses the whole accessor to "[]". Partial diagnostics from a
+      // coordinator-destroyed editor would be worse than empty, and
+      // CellNotInProtectedSurface / CycleDetected are structural defects we
+      // do not want to render as authoritative output.
+      let parse_diag_set = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
+        Ok(d) => d
+        Err(report) => {
+          println("get_diagnostics_json parser read: \{report}")
+          return "[]"
+        }
+      }
+      let parse_errors = parse_diag_set.format()
+      // Typecheck only meaningful if parsing succeeded; otherwise the AST
+      // is incomplete and type errors would just be noise on top of the
+      // parse error.
+      let typecheck_diags = if parse_errors.is_empty() {
+        match
+          coordinator.read_protected(h.editor_id, h.cells.typecheck_output) {
+          Ok(result) => result.all_diagnostics
+          Err(report) => {
+            println("get_diagnostics_json typecheck read: \{report}")
+            return "[]"
+          }
+        }
+      } else {
+        []
+      }
+      let eval_results = match
+        coordinator.read_protected(h.editor_id, h.cells.escalation_memo) {
+        Ok(r) => r
+        Err(report) => {
+          println("get_diagnostics_json eval read: \{report}")
+          return "[]"
+        }
+      }
       let diags : Array[Json] = []
-      let parse_errors = h.editor.get_errors()
       for msg in parse_errors {
         let m : Map[String, Json] = {}
         m["level"] = "error".to_json()
         m["message"] = msg.to_json()
         diags.push(Json::object(m))
       }
-      // Type diagnostics — only meaningful if parsing succeeded; otherwise
-      // the AST is incomplete and type errors would just be noise on top of
-      // the parse error.
-      if parse_errors.is_empty() {
-        let result = h.typecheck.output.read_or_abort()
-        for diag in result.all_diagnostics {
-          let m : Map[String, Json] = {}
-          m["level"] = "error".to_json()
-          m["message"] = diag.message.to_json()
-          match diag.def_name {
-            Some(name) => m["def_name"] = name.to_json()
-            None => ()
-          }
-          diags.push(Json::object(m))
+      for diag in typecheck_diags {
+        let m : Map[String, Json] = {}
+        m["level"] = "error".to_json()
+        m["message"] = diag.message.to_json()
+        match diag.def_name {
+          Some(name) => m["def_name"] = name.to_json()
+          None => ()
         }
+        diags.push(Json::object(m))
       }
-      for result in h.companion.get_eval_results() {
+      for result in eval_results {
         match result {
           @lang_lambda.EvalResult::Stuck(s) => {
             let m : Map[String, Json] = {}

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -172,12 +172,12 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
   // def_name routing is intact. Either substring missing means the
   // migrated typecheck read is producing something different from the
   // pre-migration baseline.
-  if not(alive_json.contains("unbound variable: y")) {
+  if !alive_json.contains("unbound variable: y") {
     fail(
       "expected typecheck diagnostic for unbound `y` on alive editor, got \{alive_json}",
     )
   }
-  if not(alive_json.contains("\"def_name\":\"x\"")) {
+  if !alive_json.contains("\"def_name\":\"x\"") {
     fail("expected def_name=\"x\" on alive editor, got \{alive_json}")
   }
   let h = lambda_handles.get(handle).unwrap()
@@ -216,7 +216,7 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
   // Trailing operator with no RHS — guaranteed parse error.
   set_text(handle, "let x = 1 +\n")
   let alive_json = get_diagnostics_json(handle)
-  if not(alive_json.contains("\"level\":\"error\"")) {
+  if !alive_json.contains("\"level\":\"error\"") {
     fail("expected parse-error diagnostic on alive editor, got \{alive_json}")
   }
   let h = lambda_handles.get(handle).unwrap()

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -154,3 +154,83 @@ test "spec §12 #4: read_protected rejects cells from a different editor" {
   destroy_editor(handle_a)
   destroy_editor(handle_b)
 }
+
+///|
+/// Phase 1b workstream 1: `get_diagnostics_json` routes every protected-cell
+/// read (parser_diagnostics, typecheck_output, escalation_memo) through the
+/// coordinator. Each test below exercises one entry point — typecheck path
+/// and parse-error path — and asserts the post-destroy collapse to `"[]"`.
+test "workstream 1: get_diagnostics_json collapses to [] after coordinator destroy (typecheck path)" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("diag_coord_typecheck_agent")
+  // `let x = y` parses cleanly but binds an unbound name, exercising the
+  // typecheck branch (parse_errors.is_empty() == true).
+  set_text(handle, "let x = y\n")
+  let alive_json = get_diagnostics_json(handle)
+  // Structural assertion — not just "non-empty". Proves the typecheck path
+  // produced a diagnostic with the expected unbound-name message AND that
+  // def_name routing is intact. Either substring missing means the
+  // migrated typecheck read is producing something different from the
+  // pre-migration baseline.
+  if not(alive_json.contains("unbound variable: y")) {
+    fail(
+      "expected typecheck diagnostic for unbound `y` on alive editor, got \{alive_json}",
+    )
+  }
+  if not(alive_json.contains("\"def_name\":\"x\"")) {
+    fail("expected def_name=\"x\" on alive editor, got \{alive_json}")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  let id = h.editor_id
+  match coordinator.destroy_editor(id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  match lambda_handles.get(handle) {
+    Some(_) => ()
+    None =>
+      fail(
+        "expected lambda_handles to retain handle after direct coordinator destroy",
+      )
+  }
+  // Post-destroy must collapse to "[]" via the Err arm of read_protected.
+  assert_eq(get_diagnostics_json(handle), "[]")
+  h.typecheck.scope.dispose()
+  lambda_handles.remove(handle)
+  view_states.remove(handle)
+  pretty_view_states.remove(handle)
+  if last_created_handle.val == Some(handle) {
+    last_created_handle.val = None
+  }
+}
+
+///|
+/// Companion to the typecheck-path test: parse-error sources go through
+/// `parser_diagnostics`, the first protected cell read. Without that cell
+/// also routing through the coordinator, a destroyed editor with stale
+/// parse errors would leak them to the accessor before the typecheck/eval
+/// guards fire.
+test "workstream 1: get_diagnostics_json collapses to [] after coordinator destroy (parse-error path)" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("diag_coord_parse_agent")
+  // Trailing operator with no RHS — guaranteed parse error.
+  set_text(handle, "let x = 1 +\n")
+  let alive_json = get_diagnostics_json(handle)
+  if not(alive_json.contains("\"level\":\"error\"")) {
+    fail("expected parse-error diagnostic on alive editor, got \{alive_json}")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  let id = h.editor_id
+  match coordinator.destroy_editor(id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(get_diagnostics_json(handle), "[]")
+  h.typecheck.scope.dispose()
+  lambda_handles.remove(handle)
+  view_states.remove(handle)
+  pretty_view_states.remove(handle)
+  if last_created_handle.val == Some(handle) {
+    last_created_handle.val = None
+  }
+}

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -156,16 +156,17 @@ test "spec §12 #4: read_protected rejects cells from a different editor" {
 }
 
 ///|
-/// Phase 1b workstream 1: `get_diagnostics_json` routes every protected-cell
-/// read (parser_diagnostics, typecheck_output, escalation_memo) through the
-/// coordinator. Each test below exercises one entry point — typecheck path
-/// and parse-error path — and asserts the post-destroy collapse to `"[]"`.
-/// Empty-source guard regression check. Pre-migration,
+/// Phase 1b workstream 1 suite: `get_diagnostics_json` routes every
+/// protected-cell read (parser_diagnostics, typecheck_output,
+/// escalation_memo) through the coordinator. The three tests below cover
+/// empty-source, typecheck-path, and parse-error-path entry points.
+///
+/// Empty-source guard regression check: pre-migration,
 /// `h.editor.get_errors()` short-circuited to `[]` on empty doc text
 /// (editor/sync_editor_parser.mbt:108) before reading the parser
-/// diagnostics — empirically the parser produces spurious diagnostics
-/// on `""` source that must be suppressed. The migration must preserve
-/// that semantic at the FFI boundary; calling `parser_diagnostics.format()`
+/// diagnostics — empirically the parser produces spurious diagnostics on
+/// `""` source that must be suppressed. The migration preserves that
+/// semantic at the FFI boundary; calling `parser_diagnostics.format()`
 /// unconditionally would surface those spurious errors.
 test "workstream 1: get_diagnostics_json returns [] for empty source" {
   reset_coordinator_for_phase1_tests()

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -160,6 +160,22 @@ test "spec §12 #4: read_protected rejects cells from a different editor" {
 /// read (parser_diagnostics, typecheck_output, escalation_memo) through the
 /// coordinator. Each test below exercises one entry point — typecheck path
 /// and parse-error path — and asserts the post-destroy collapse to `"[]"`.
+/// Empty-source guard regression check. Pre-migration,
+/// `h.editor.get_errors()` short-circuited to `[]` on empty doc text
+/// (editor/sync_editor_parser.mbt:108) before reading the parser
+/// diagnostics — empirically the parser produces spurious diagnostics
+/// on `""` source that must be suppressed. The migration must preserve
+/// that semantic at the FFI boundary; calling `parser_diagnostics.format()`
+/// unconditionally would surface those spurious errors.
+test "workstream 1: get_diagnostics_json returns [] for empty source" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("diag_empty_agent")
+  // `create_editor` produces an editor with empty source — no `set_text`.
+  assert_eq(get_diagnostics_json(handle), "[]")
+  destroy_editor(handle)
+}
+
+///|
 test "workstream 1: get_diagnostics_json collapses to [] after coordinator destroy (typecheck path)" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("diag_coord_typecheck_agent")

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -19,10 +19,11 @@ import {
   "moonbitlang/core/string",
 }
 
-// `cells` field of LambdaHandle is read only by whitebox tests
-// (`lifecycle_phase1_wbtest.mbt` exercises `coordinator.read_protected(id,
-// h.cells.<cell>)`). Phase 1b will surface those reads in production FFI
-// accessors; until then suppress the source-only unused-field check.
+// `cells` field of LambdaHandle is read in production by `get_diagnostics_json`
+// (typecheck_output + escalation_memo, via Phase 1b workstream 1) and by
+// whitebox tests (`lifecycle_phase1_wbtest.mbt`) for the remaining 8 cells.
+// Until additional Phase 1b workstreams migrate the other production accessors,
+// per-field unused warnings still fire on the rest of `LambdaProtectedCells`.
 
 warnings = "-7"
 

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -20,10 +20,11 @@ import {
 }
 
 // `cells` field of LambdaHandle is read in production by `get_diagnostics_json`
-// (typecheck_output + escalation_memo, via Phase 1b workstream 1) and by
-// whitebox tests (`lifecycle_phase1_wbtest.mbt`) for the remaining 8 cells.
-// Until additional Phase 1b workstreams migrate the other production accessors,
-// per-field unused warnings still fire on the rest of `LambdaProtectedCells`.
+// (parser_diagnostics + typecheck_output + escalation_memo, via Phase 1b
+// workstream 1) and by whitebox tests (`lifecycle_phase1_wbtest.mbt`) for the
+// remaining 7 cells. Until additional Phase 1b workstreams migrate the other
+// production accessors, per-field unused warnings still fire on the rest of
+// `LambdaProtectedCells`.
 
 warnings = "-7"
 


### PR DESCRIPTION
## Summary

First production accessor migration on top of the `LambdaProtectedCells` bundle from PR4 (#348). The three protected-cell reads inside `get_diagnostics_json` — `parser_diagnostics` (formerly via `h.editor.get_errors()`), `typecheck_output`, and `escalation_memo` — now go through `coordinator.read_protected`. Any `Err` collapses the accessor to `"[]"` with a `println`-logged report, rather than returning stale data read off a not-yet-disposed `Derived` or surfacing a structural defect (`CellNotInProtectedSurface` / `CycleDetected`) as authoritative output.

- **Decision A realized** for this accessor: reads of a coordinator-destroyed editor surface as a typed `AbortReport`, mapped to `"[]"` + log.
- **Scope explicitly narrow**: the other 5 FFI accessors (`get_proj_node_json`, `get_source_map_json`, `get_view_tree_json`, `get_pretty_view_json`, `compute_view_patches_json`, `compute_pretty_patches_json`) still call `h.editor.X()` editor methods. Migrating those requires a separate decision (FFI-side decomposition vs editor-API expansion).

## Notable Codex findings caught pre-merge

Codex scoped + broad pre-merge reviews converged on a critical gap in the first-pass migration:

- `h.editor.get_errors()` at the top of the accessor was internally reading `parser_diagnostics` via `.read_or_abort()` — itself a protected cell. The first-pass migration only covered the two reads I could see at the FFI level; parse errors were still leaking from a destroyed editor before the typecheck/eval guards fired. The first-pass test (`let x = y\n`) didn't catch this because the source parsed cleanly.
- Per-block `Err` skipping was also flagged: partial diagnostics from a destroyed editor are worse than empty, and `CellNotInProtectedSurface` / `CycleDetected` are structural defects we don't want to render as authoritative diagnostics. The restructured accessor reads all three cells up front and short-circuits to `"[]"` on any `Err`.

Both fixes are in this PR. See close-detail entries in `~/.claude/memory/delegation-log.md` for the full review trail.

## Tests

Two new tests in `ffi/lambda/lifecycle_phase1_wbtest.mbt`:

- `workstream 1: get_diagnostics_json collapses to [] after coordinator destroy (typecheck path)` — uses `let x = y\n` to exercise the typecheck branch; structural contains-checks on `"unbound variable: y"` and `"def_name":"x"` rather than a weak `!= "[]"`.
- `workstream 1: get_diagnostics_json collapses to [] after coordinator destroy (parse-error path)` — uses `let x = 1 +\n` to exercise the `parser_diagnostics` read specifically; would have failed against the pre-migration code which leaked stale parse errors past the typecheck guard.

Workspace test count: 1169 → 1171.

## Test plan

- [ ] CI green workspace-wide
- [ ] `moon check` clean
- [ ] No `.mbti` drift (no public API change)
- [ ] Both new workstream-1 tests pass; existing §12 #1–#4 still pass

## Followups (not in this PR)

- `warnings = \"-7\"` in `ffi/lambda/moon.pkg` stays in place; can't be removed until additional Phase 1b workstreams migrate the other 8 cells. Comment updated to reflect partial-migration state.
- The remaining FFI accessors listed above. A separate workstream will need to weigh in on FFI-side decomposition vs editor-API expansion before migrating.
- Symmetric helpers for the Markdown + JSON FFI surfaces (`assemble_markdown_handle` / `assemble_json_handle`).
- Coordinator `destroy_editor` hardening (the two PR4-deferred items in `workspace/coordinator/methods.mbt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)