### PR TITLE
fix(canvas): ignore ctrl-click before pointer gestures

### DIFF
--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -71,6 +71,12 @@ test('canvas handles create edges and reject invalid gestures', async ({ page })
     }
   });
 
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+  });
   await page.goto('/');
   await expect(page.locator('.canvas-node')).toHaveCount(6);
   await expect(edgePaths(page)).toHaveCount(3);
@@ -78,6 +84,16 @@ test('canvas handles create edges and reject invalid gestures', async ({ page })
   expect(runtimeErrors).toEqual([]);
 
   const source = outputHandle(page, 1);
+
+  const ctrlClickStart = await center(source, 'node 1 output handle');
+  await page.keyboard.down('Control');
+  await page.mouse.move(ctrlClickStart.x, ctrlClickStart.y);
+  await page.mouse.down();
+  await page.mouse.up();
+  await page.keyboard.up('Control');
+  await expect(pendingEdgePaths(page)).toHaveCount(0);
+  await expect(edgePaths(page)).toHaveCount(3);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
 
   const cancelStart = await center(source, 'node 1 output handle');
   const cancelTarget = await canvasBackgroundPoint(page);

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -63,6 +63,8 @@ let handle = -1;
 let rafPending = false;
 let lastState: RenderState | null = null;
 
+const isMacLike = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
 const root       = document.getElementById('canvas-root') as HTMLDivElement;
 const world      = document.getElementById('world') as HTMLDivElement;
 const edgesSvg   = document.getElementById('edges') as unknown as SVGSVGElement;
@@ -357,7 +359,10 @@ let pointerDownNodeId = 0;
 let pointerUpAdditive = false;
 
 root.addEventListener('pointerdown', (e: PointerEvent) => {
-  if (e.button !== 0) return;
+  // macOS Ctrl+click is a secondary-click gesture but still reports button 0.
+  // Let the contextmenu handler own it without breaking Ctrl-additive
+  // selection on non-Mac platforms.
+  if (e.button !== 0 || (isMacLike && e.ctrlKey)) return;
   if (activePointerId !== -1) return;
   hideContextMenu();
   root.setPointerCapture(e.pointerId);


### PR DESCRIPTION
## Summary

- ignore macOS Ctrl+click before starting canvas pointer gestures
- add a Canvas E2E regression to ensure Ctrl+click on a handle does not start a pending edge or log actions

## Validation

- `MOON_WORK=off moon check --target js`
- `MOON_WORK=off moon test --target js`
- `npm run build`
- `npm run test:e2e`

Notes: Vite emits its existing CJS Node API deprecation warning during build/e2e, but commands pass.
