### PR TITLE
feat(cognition): add minimal incremental runtime

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -32,6 +32,9 @@ the files inside `docs/architecture/`.
 - **[Incremental Evaluation](incremental-evaluation.md)** — framework for
   evaluating the query-based incremental architecture; 15 criteria and when to
   re-evaluate.
+- **[Cognition Runtime](cognition-runtime.md)** — minimal incremental graph for
+  AI coding context artifacts: dependencies, revisions, dirty propagation, and
+  selective recomputation.
 
 ## Vision
 

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -31,9 +31,10 @@ interface is the source of truth for concrete API names.
 The first mock graph has three layers: file text, file-level summaries, and
 repo/query context. File-level summaries read one file input. Repo context reads
 all known file summaries. Query context reads repo context. When a new file
-input appears after repo context already exists, the runtime dirties the
-corresponding file-level summary and repo context so repo context can adopt the
-new dependency on the next recomputation.
+input appears after repo context already exists, or after query context has
+observed repo context, the runtime dirties the corresponding file-level summary
+and repo context so repo context can adopt the new dependency on the next
+recomputation.
 
 When an input changes, the store marks transitive dependents dirty. Recomputing
 dirty artifacts proceeds only when their dependencies are clean, so unrelated

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -1,0 +1,60 @@
+# Cognition Runtime
+
+This is the first minimal runtime layer for AI-native cognition in Canopy. It is
+not an IDE feature yet and does not change the existing editor, CRDT, parser,
+projection, or rendering pipeline.
+
+The runtime models an incremental cognition graph:
+
+```text
+Workspace inputs → derived cognition artifacts → AI context artifacts
+```
+
+The first goal is dependency tracking and selective recomputation for AI coding
+context. Quality of generated summaries is deliberately out of scope; current
+recomputation uses deterministic mock functions.
+
+## Minimal model
+
+The initial package is `lib/cognition`.
+
+- `CognitionKey` names inputs and derived artifacts:
+  - `FileText(path)`
+  - `FileSummary(path)`
+  - `RepoSummary`
+  - `QueryContext(query)`
+- `CognitionValue` stores simple artifact values:
+  - `Text(value)`
+  - `Summary(value)`
+  - `ContextBundle(items)`
+- `Revision` is a store-local monotonic integer.
+- `Dependency` is a directed edge from a derived key to the input key it reads.
+- `CognitionStore` stores values, revisions, dependency edges, reverse edges,
+  dirty keys, and recomputation counts for tests/demo traces.
+
+## Mock recomputation rules
+
+- `FileSummary(path)` depends on `FileText(path)`.
+- `RepoSummary` depends on all known `FileSummary(path)` values.
+- `QueryContext(query)` depends on `RepoSummary`.
+
+When an input changes, the store marks transitive dependents dirty. Calling
+`recompute_dirty()` recomputes dirty artifacts whose dependencies are clean, so
+unrelated summaries are not recomputed when another file changes.
+
+## Non-goals for this milestone
+
+- No real LLM calls.
+- No vector database.
+- No network sync.
+- No CRDT changes.
+- No frontend UI.
+- No VSCode/Cursor integration.
+- No full IDE or agent framework.
+
+## Future artifact shapes
+
+Future cognition keys may include `SymbolSummary`, `DecisionLog`,
+`AgentMemory`, `BranchMemory`, and `StaleMemory`. Those should build on the
+same graph discipline: explicit inputs, explicit dependencies, revisions, and
+selective invalidation before any expensive AI work is introduced.

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -16,31 +16,27 @@ recomputation uses deterministic mock functions.
 
 ## Minimal model
 
-The initial package is `lib/cognition`.
+The runtime is intentionally small and separate from the editor pipeline. It
+stores named workspace inputs and derived cognition artifacts, records the
+revision assigned to each stored artifact, and maintains both dependency and
+reverse-dependency edges. Reverse edges make invalidation cheap: when an input
+changes, all transitive dependents can be marked dirty without scanning every
+artifact.
 
-- `CognitionKey` names inputs and derived artifacts:
-  - `FileText(path)`
-  - `FileSummary(path)`
-  - `RepoSummary`
-  - `QueryContext(query)`
-- `CognitionValue` stores simple artifact values:
-  - `Text(value)`
-  - `Summary(value)`
-  - `ContextBundle(items)`
-- `Revision` is a store-local monotonic integer.
-- `Dependency` is a directed edge from a derived key to the input key it reads.
-- `CognitionStore` stores values, revisions, dependency edges, reverse edges,
-  dirty keys, and recomputation counts for tests/demo traces.
+The current implementation lives in `lib/cognition`; its generated package
+interface is the source of truth for concrete API names.
 
 ## Mock recomputation rules
 
-- `FileSummary(path)` depends on `FileText(path)`.
-- `RepoSummary` depends on all known `FileSummary(path)` values.
-- `QueryContext(query)` depends on `RepoSummary`.
+The first mock graph has three layers: file text, file-level summaries, and
+repo/query context. File-level summaries read one file input. Repo context reads
+all known file summaries. Query context reads repo context. When a new
+file-level summary appears after repo context already exists, repo context is
+invalidated so it can adopt the new dependency on the next recomputation.
 
-When an input changes, the store marks transitive dependents dirty. Calling
-`recompute_dirty()` recomputes dirty artifacts whose dependencies are clean, so
-unrelated summaries are not recomputed when another file changes.
+When an input changes, the store marks transitive dependents dirty. Recomputing
+dirty artifacts proceeds only when their dependencies are clean, so unrelated
+summaries are not recomputed when another file changes.
 
 ## Non-goals for this milestone
 

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -30,9 +30,10 @@ interface is the source of truth for concrete API names.
 
 The first mock graph has three layers: file text, file-level summaries, and
 repo/query context. File-level summaries read one file input. Repo context reads
-all known file summaries. Query context reads repo context. When a new
-file-level summary appears after repo context already exists, repo context is
-invalidated so it can adopt the new dependency on the next recomputation.
+all known file summaries. Query context reads repo context. When a new file
+input appears after repo context already exists, the runtime dirties the
+corresponding file-level summary and repo context so repo context can adopt the
+new dependency on the next recomputation.
 
 When an input changes, the store marks transitive dependents dirty. Recomputing
 dirty artifacts proceeds only when their dependencies are clean, so unrelated

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -64,6 +64,41 @@ test "QueryContext depends on RepoSummary" {
 }
 
 ///|
+test "new FileSummary invalidates existing repo context" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(RepoSummary)
+  let _ = store.compute(QueryContext("what changed?"))
+
+  store.set_input(FileText("b.mbt"), Text("two"))
+  store.mark_dirty(FileSummary("b.mbt"))
+  let recomputed = store.recompute_dirty()
+
+  inspect(recomputed.contains(FileSummary("b.mbt")), content="true")
+  inspect(recomputed.contains(RepoSummary), content="true")
+  inspect(recomputed.contains(QueryContext("what changed?")), content="true")
+}
+
+///|
+test "returned ContextBundle cannot mutate stored value" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("hello"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(RepoSummary)
+  let _ = store.compute(QueryContext("what changed?"))
+  match store.get_value(QueryContext("what changed?")) {
+    Some(ContextBundle(items)) => items.push("external mutation")
+    _ => fail("expected context bundle")
+  }
+  match store.get_value(QueryContext("what changed?")) {
+    Some(ContextBundle(items)) =>
+      inspect(items.contains("external mutation"), content="false")
+    _ => fail("expected context bundle")
+  }
+}
+
+///|
 test "demo trace shows selective recomputation" {
   inspect(
     demo_trace().join("\n"),

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -82,6 +82,37 @@ test "new FileSummary invalidates existing repo context" {
 }
 
 ///|
+test "new FileText invalidates query context before RepoSummary exists" {
+  let store = CognitionStore::new()
+  let _ = store.compute(QueryContext("what changed?"))
+
+  store.set_input(FileText("a.mbt"), Text("one"))
+  let recomputed = store.recompute_dirty()
+
+  inspect(recomputed.contains(FileSummary("a.mbt")), content="true")
+  inspect(recomputed.contains(RepoSummary), content="true")
+  inspect(recomputed.contains(QueryContext("what changed?")), content="true")
+  let deps = store.dependencies_of(RepoSummary)
+  assert_true(deps.contains(FileSummary("a.mbt")))
+}
+
+///|
+test "dirty traversal skips already dirty subtrees" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(RepoSummary)
+  let _ = store.compute(QueryContext("what changed?"))
+
+  store.mark_dirty(RepoSummary)
+  let changed = store.dirty_dependents(FileSummary("a.mbt"))
+
+  inspect(changed.contains(RepoSummary), content="false")
+  inspect(changed.contains(QueryContext("what changed?")), content="false")
+  inspect(store.is_dirty(QueryContext("what changed?")), content="true")
+}
+
+///|
 test "returned ContextBundle cannot mutate stored value" {
   let store = CognitionStore::new()
   store.set_input(FileText("a.mbt"), Text("hello"))

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -1,0 +1,77 @@
+///|
+test "FileSummary depends on FileText" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("hello\nworld"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let deps = store.dependencies_of(FileSummary("a.mbt"))
+  assert_true(deps.contains(FileText("a.mbt")))
+}
+
+///|
+test "changing one FileText marks its FileSummary dirty" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("hello"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  store.set_input(FileText("a.mbt"), Text("hello again"))
+  inspect(store.is_dirty(FileSummary("a.mbt")), content="true")
+}
+
+///|
+test "RepoSummary becomes dirty when a FileSummary changes" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("hello"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(RepoSummary)
+  store.mark_dirty(FileSummary("a.mbt"))
+  inspect(store.is_dirty(RepoSummary), content="true")
+}
+
+///|
+test "unrelated FileSummary is not recomputed when another file changes" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("one"))
+  store.set_input(FileText("b.mbt"), Text("two"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(FileSummary("b.mbt"))
+  let _ = store.compute(RepoSummary)
+  let a_before = store.recompute_count(FileSummary("a.mbt"))
+  let b_before = store.recompute_count(FileSummary("b.mbt"))
+
+  store.set_input(FileText("a.mbt"), Text("one changed"))
+  let recomputed = store.recompute_dirty()
+
+  inspect(recomputed.contains(FileSummary("a.mbt")), content="true")
+  inspect(recomputed.contains(FileSummary("b.mbt")), content="false")
+  inspect(
+    store.recompute_count(FileSummary("a.mbt")) == a_before + 1,
+    content="true",
+  )
+  inspect(
+    store.recompute_count(FileSummary("b.mbt")) == b_before,
+    content="true",
+  )
+}
+
+///|
+test "QueryContext depends on RepoSummary" {
+  let store = CognitionStore::new()
+  store.set_input(FileText("a.mbt"), Text("hello"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(RepoSummary)
+  let _ = store.compute(QueryContext("what changed?"))
+  let deps = store.dependencies_of(QueryContext("what changed?"))
+  assert_true(deps.contains(RepoSummary))
+}
+
+///|
+test "demo trace shows selective recomputation" {
+  inspect(
+    demo_trace().join("\n"),
+    content=(
+      #|dirty after src/a.mbt edit: FileSummary(src/a.mbt), RepoSummary, QueryContext(what changed?)
+      #|recomputed: FileSummary(src/a.mbt), RepoSummary, QueryContext(what changed?)
+      #|FileSummary(src/a.mbt) count: 2
+      #|FileSummary(src/b.mbt) count: 1
+    ),
+  )
+}

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -72,12 +72,13 @@ test "new FileSummary invalidates existing repo context" {
   let _ = store.compute(QueryContext("what changed?"))
 
   store.set_input(FileText("b.mbt"), Text("two"))
-  store.mark_dirty(FileSummary("b.mbt"))
   let recomputed = store.recompute_dirty()
 
   inspect(recomputed.contains(FileSummary("b.mbt")), content="true")
   inspect(recomputed.contains(RepoSummary), content="true")
   inspect(recomputed.contains(QueryContext("what changed?")), content="true")
+  let deps = store.dependencies_of(RepoSummary)
+  assert_true(deps.contains(FileSummary("b.mbt")))
 }
 
 ///|

--- a/lib/cognition/demo.mbt
+++ b/lib/cognition/demo.mbt
@@ -1,0 +1,32 @@
+///|
+/// Deterministic mini-demo for the first cognition runtime milestone.
+pub fn demo_trace() -> Array[String] {
+  let store = CognitionStore::new()
+  store.set_input(FileText("src/a.mbt"), Text("let a = 1\n"))
+  store.set_input(FileText("src/b.mbt"), Text("let b = 2\nlet c = 3\n"))
+  let _ = store.compute(FileSummary("src/a.mbt"))
+  let _ = store.compute(FileSummary("src/b.mbt"))
+  let _ = store.compute(RepoSummary)
+  let _ = store.compute(QueryContext("what changed?"))
+
+  store.set_input(FileText("src/a.mbt"), Text("let a = 10\n"))
+  let dirty_after_change = store.dirty_keys()
+  let recomputed = store.recompute_dirty()
+  let a_count = store.recompute_count(FileSummary("src/a.mbt"))
+  let b_count = store.recompute_count(FileSummary("src/b.mbt"))
+  [
+    "dirty after src/a.mbt edit: \{format_key_list(dirty_after_change)}",
+    "recomputed: \{format_key_list(recomputed)}",
+    "FileSummary(src/a.mbt) count: \{a_count}",
+    "FileSummary(src/b.mbt) count: \{b_count}",
+  ]
+}
+
+///|
+fn format_key_list(keys : Array[CognitionKey]) -> String {
+  let labels : Array[String] = []
+  for key in keys {
+    labels.push(key.label())
+  }
+  labels.join(", ")
+}

--- a/lib/cognition/moon.mod
+++ b/lib/cognition/moon.mod
@@ -1,0 +1,11 @@
+name = "dowdiness/cognition"
+
+version = "0.1.0"
+
+repository = "https://github.com/dowdiness/canopy"
+
+license = "Apache-2.0"
+
+keywords = [ "cognition", "incremental", "dependency-graph", "ai-context" ]
+
+description = "Minimal incremental cognition graph runtime for AI coding context artifacts"

--- a/lib/cognition/moon.pkg
+++ b/lib/cognition/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "moonbitlang/core/debug",
+}

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -1,0 +1,56 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/cognition"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn demo_trace() -> Array[String]
+
+// Errors
+
+// Types and methods
+pub(all) enum CognitionKey {
+  FileText(String)
+  FileSummary(String)
+  RepoSummary
+  QueryContext(String)
+} derive(Compare, Eq, Hash, @debug.Debug)
+pub fn CognitionKey::label(Self) -> String
+
+pub(all) struct CognitionStore {
+  // private fields
+}
+pub fn CognitionStore::compute(Self, CognitionKey) -> CognitionValue?
+pub fn CognitionStore::dependencies_of(Self, CognitionKey) -> Array[CognitionKey]
+pub fn CognitionStore::dependency_edges(Self) -> Array[Dependency]
+pub fn CognitionStore::dependents_of(Self, CognitionKey) -> Array[CognitionKey]
+pub fn CognitionStore::dirty_dependents(Self, CognitionKey) -> Array[CognitionKey]
+pub fn CognitionStore::dirty_keys(Self) -> Array[CognitionKey]
+pub fn CognitionStore::get_revision(Self, CognitionKey) -> Revision?
+pub fn CognitionStore::get_value(Self, CognitionKey) -> CognitionValue?
+pub fn CognitionStore::is_dirty(Self, CognitionKey) -> Bool
+pub fn CognitionStore::mark_dirty(Self, CognitionKey) -> Unit
+pub fn CognitionStore::new() -> Self
+pub fn CognitionStore::recompute_count(Self, CognitionKey) -> Int
+pub fn CognitionStore::recompute_dirty(Self) -> Array[CognitionKey]
+pub fn CognitionStore::set_input(Self, CognitionKey, CognitionValue) -> Unit
+
+pub(all) enum CognitionValue {
+  Text(String)
+  Summary(String)
+  ContextBundle(Array[String])
+} derive(Eq, @debug.Debug)
+
+pub(all) struct Dependency {
+  from : CognitionKey
+  input : CognitionKey
+} derive(Eq, @debug.Debug)
+
+pub struct Revision(Int) derive(Compare, Eq, Hash, @debug.Debug)
+pub fn Revision::to_int(Self) -> Int
+
+// Type aliases
+
+// Traits

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -1,0 +1,366 @@
+///|
+/// Mutable store for cognition values, revisions, dependencies, and dirtiness.
+pub(all) struct CognitionStore {
+  priv values : Map[CognitionKey, CognitionValue]
+  priv revisions : Map[CognitionKey, Revision]
+  priv dependencies : Map[CognitionKey, Array[CognitionKey]]
+  priv reverse_dependencies : Map[CognitionKey, Array[CognitionKey]]
+  priv dirty : Map[CognitionKey, Bool]
+  priv recompute_counts : Map[CognitionKey, Int]
+  priv mut next_revision : Int
+}
+
+///|
+pub fn CognitionStore::new() -> CognitionStore {
+  {
+    values: Map::default(),
+    revisions: Map::default(),
+    dependencies: Map::default(),
+    reverse_dependencies: Map::default(),
+    dirty: Map::default(),
+    recompute_counts: Map::default(),
+    next_revision: 0,
+  }
+}
+
+///|
+/// Set an input value, assign a new revision, and dirty all derived dependents.
+pub fn CognitionStore::set_input(
+  self : CognitionStore,
+  key : CognitionKey,
+  value : CognitionValue,
+) -> Unit {
+  self.values[key] = value
+  self.bump_revision(key)
+  self.dirty.remove(key)
+  let _ = self.dirty_dependents(key)
+}
+
+///|
+pub fn CognitionStore::get_value(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> CognitionValue? {
+  self.values.get(key)
+}
+
+///|
+pub fn CognitionStore::get_revision(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Revision? {
+  self.revisions.get(key)
+}
+
+///|
+pub fn CognitionStore::dependencies_of(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Array[CognitionKey] {
+  self.dependencies.get(key).unwrap_or([]).copy()
+}
+
+///|
+pub fn CognitionStore::dependents_of(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Array[CognitionKey] {
+  self.reverse_dependencies.get(key).unwrap_or([]).copy()
+}
+
+///|
+pub fn CognitionStore::dependency_edges(
+  self : CognitionStore,
+) -> Array[Dependency] {
+  let edges : Array[Dependency] = []
+  for from, inputs in self.dependencies {
+    for input in inputs {
+      edges.push({ from, input })
+    }
+  }
+  edges.sort_by(fn(a, b) {
+    let by_from = a.from.compare(b.from)
+    if by_from != 0 {
+      by_from
+    } else {
+      a.input.compare(b.input)
+    }
+  })
+  edges
+}
+
+///|
+pub fn CognitionStore::is_dirty(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Bool {
+  self.dirty.contains(key)
+}
+
+///|
+pub fn CognitionStore::dirty_keys(self : CognitionStore) -> Array[CognitionKey] {
+  let keys = self.dirty.keys().to_array()
+  keys.sort_by(fn(a, b) { a.compare(b) })
+  keys
+}
+
+///|
+pub fn CognitionStore::recompute_count(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Int {
+  self.recompute_counts.get(key).unwrap_or(0)
+}
+
+///|
+/// Mark one artifact and all of its dependents dirty.
+pub fn CognitionStore::mark_dirty(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Unit {
+  self.dirty[key] = true
+  let _ = self.dirty_dependents(key)
+}
+
+///|
+/// Mark all transitive dependents of `key` dirty and return newly dirtied keys.
+pub fn CognitionStore::dirty_dependents(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Array[CognitionKey] {
+  let changed : Array[CognitionKey] = []
+  self.collect_dirty_dependents(key, changed)
+  changed.sort_by(fn(a, b) { a.compare(b) })
+  changed
+}
+
+///|
+/// Recompute dirty derived artifacts whose dependencies are already clean.
+/// Returns the keys recomputed by this call, in deterministic order.
+pub fn CognitionStore::recompute_dirty(
+  self : CognitionStore,
+) -> Array[CognitionKey] {
+  let recomputed : Array[CognitionKey] = []
+  while true {
+    match self.next_ready_dirty_key() {
+      Some(key) => {
+        self.recompute_one(key)
+        self.dirty.remove(key)
+        recomputed.push(key)
+      }
+      None => break
+    }
+  }
+  recomputed
+}
+
+///|
+/// Convenience helper for examples and tests: mark one key dirty, recompute,
+/// then return its current value.
+pub fn CognitionStore::compute(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> CognitionValue? {
+  self.mark_dirty(key)
+  let _ = self.recompute_dirty()
+  self.get_value(key)
+}
+
+///|
+fn CognitionStore::bump_revision(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Unit {
+  self.next_revision += 1
+  self.revisions[key] = Revision(self.next_revision)
+}
+
+///|
+fn CognitionStore::collect_dirty_dependents(
+  self : CognitionStore,
+  key : CognitionKey,
+  changed : Array[CognitionKey],
+) -> Unit {
+  match self.reverse_dependencies.get(key) {
+    Some(dependents) =>
+      for dependent in dependents {
+        if !self.dirty.contains(dependent) {
+          self.dirty[dependent] = true
+          changed.push(dependent)
+        }
+        self.collect_dirty_dependents(dependent, changed)
+      }
+    None => ()
+  }
+}
+
+///|
+fn CognitionStore::next_ready_dirty_key(self : CognitionStore) -> CognitionKey? {
+  let keys = self.dirty_keys()
+  for key in keys {
+    if self.dependencies_clean(key) {
+      return Some(key)
+    }
+  }
+  None
+}
+
+///|
+fn CognitionStore::dependencies_clean(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Bool {
+  match self.dependencies.get(key) {
+    Some(inputs) => {
+      for input in inputs {
+        if self.dirty.contains(input) {
+          return false
+        }
+      }
+      true
+    }
+    None => true
+  }
+}
+
+///|
+fn CognitionStore::set_dependencies(
+  self : CognitionStore,
+  key : CognitionKey,
+  inputs : Array[CognitionKey],
+) -> Unit {
+  match self.dependencies.get(key) {
+    Some(old_inputs) =>
+      for input in old_inputs {
+        match self.reverse_dependencies.get(input) {
+          Some(dependents) => {
+            let remaining = dependents.filter(fn(k) { k != key })
+            if remaining.length() == 0 {
+              self.reverse_dependencies.remove(input)
+            } else {
+              self.reverse_dependencies[input] = remaining
+            }
+          }
+          None => ()
+        }
+      }
+    None => ()
+  }
+  self.dependencies[key] = inputs.copy()
+  for input in inputs {
+    let dependents = self.reverse_dependencies.get(input).unwrap_or([])
+    if !dependents.contains(key) {
+      dependents.push(key)
+    }
+    self.reverse_dependencies[input] = dependents
+  }
+}
+
+///|
+fn CognitionStore::recompute_one(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Unit {
+  match key {
+    FileText(_) => ()
+    FileSummary(path) => self.recompute_file_summary(path)
+    RepoSummary => self.recompute_repo_summary()
+    QueryContext(query) => self.recompute_query_context(query)
+  }
+}
+
+///|
+fn CognitionStore::store_recomputed(
+  self : CognitionStore,
+  key : CognitionKey,
+  value : CognitionValue,
+  inputs : Array[CognitionKey],
+) -> Unit {
+  self.values[key] = value
+  self.set_dependencies(key, inputs)
+  self.bump_revision(key)
+  self.recompute_counts[key] = self.recompute_count(key) + 1
+}
+
+///|
+fn CognitionStore::recompute_file_summary(
+  self : CognitionStore,
+  path : String,
+) -> Unit {
+  let input = FileText(path)
+  let text = match self.values.get(input) {
+    Some(Text(value)) => value
+    _ => ""
+  }
+  self.store_recomputed(
+    FileSummary(path),
+    Summary(mock_file_summary(path, text)),
+    [input],
+  )
+}
+
+///|
+fn CognitionStore::recompute_repo_summary(self : CognitionStore) -> Unit {
+  let summary_keys = self.known_file_summary_keys()
+  let items : Array[String] = []
+  for key in summary_keys {
+    match self.values.get(key) {
+      Some(Summary(value)) => items.push(value)
+      _ => ()
+    }
+  }
+  let summary = if items.length() == 0 {
+    "repo summary: <empty>"
+  } else {
+    "repo summary:\n" + items.join("\n")
+  }
+  self.store_recomputed(RepoSummary, Summary(summary), summary_keys)
+}
+
+///|
+fn CognitionStore::recompute_query_context(
+  self : CognitionStore,
+  query : String,
+) -> Unit {
+  let repo_summary = match self.values.get(RepoSummary) {
+    Some(Summary(value)) => value
+    _ => "repo summary: <missing>"
+  }
+  self.store_recomputed(
+    QueryContext(query),
+    ContextBundle(["query: \{query}", repo_summary]),
+    [RepoSummary],
+  )
+}
+
+///|
+fn CognitionStore::known_file_summary_keys(
+  self : CognitionStore,
+) -> Array[CognitionKey] {
+  let keys : Array[CognitionKey] = []
+  for key, _ in self.values {
+    match key {
+      FileSummary(_) => keys.push(key)
+      _ => ()
+    }
+  }
+  keys.sort_by(fn(a, b) { a.compare(b) })
+  keys
+}
+
+///|
+fn mock_file_summary(path : String, text : String) -> String {
+  let line_count = if text == "" { 0 } else { count_lines(text) }
+  "\{path}: \{line_count} lines, \{text.length()} chars"
+}
+
+///|
+fn count_lines(text : String) -> Int {
+  let mut lines = 1
+  for ch in text {
+    if ch == '\n' {
+      lines += 1
+    }
+  }
+  lines
+}

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -30,7 +30,7 @@ pub fn CognitionStore::set_input(
   key : CognitionKey,
   value : CognitionValue,
 ) -> Unit {
-  self.values[key] = value
+  self.values[key] = value.copy_value()
   self.bump_revision(key)
   self.dirty.remove(key)
   let _ = self.dirty_dependents(key)
@@ -41,7 +41,10 @@ pub fn CognitionStore::get_value(
   self : CognitionStore,
   key : CognitionKey,
 ) -> CognitionValue? {
-  self.values.get(key)
+  match self.values.get(key) {
+    Some(value) => Some(value.copy_value())
+    None => None
+  }
 }
 
 ///|
@@ -276,10 +279,25 @@ fn CognitionStore::store_recomputed(
   value : CognitionValue,
   inputs : Array[CognitionKey],
 ) -> Unit {
-  self.values[key] = value
+  let was_new = !self.values.contains(key)
+  self.values[key] = value.copy_value()
   self.set_dependencies(key, inputs)
   self.bump_revision(key)
   self.recompute_counts[key] = self.recompute_count(key) + 1
+  self.after_recompute(key, was_new~)
+}
+
+///|
+fn CognitionStore::after_recompute(
+  self : CognitionStore,
+  key : CognitionKey,
+  was_new~ : Bool,
+) -> Unit {
+  match key {
+    FileSummary(_) if was_new && self.values.contains(RepoSummary) =>
+      self.mark_dirty(RepoSummary)
+    _ => ()
+  }
 }
 
 ///|
@@ -346,6 +364,15 @@ fn CognitionStore::known_file_summary_keys(
   }
   keys.sort_by(fn(a, b) { a.compare(b) })
   keys
+}
+
+///|
+fn CognitionValue::copy_value(self : CognitionValue) -> CognitionValue {
+  match self {
+    Text(value) => Text(value)
+    Summary(value) => Summary(value)
+    ContextBundle(items) => ContextBundle(items.copy())
+  }
 }
 
 ///|

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -43,12 +43,18 @@ fn CognitionStore::after_input_set(
   key : CognitionKey,
 ) -> Unit {
   match key {
-    FileText(path) if self.values.contains(RepoSummary) => {
+    FileText(path) if self.repo_context_is_observed() => {
       self.mark_dirty(FileSummary(path))
       self.mark_dirty(RepoSummary)
     }
     _ => ()
   }
+}
+
+///|
+fn CognitionStore::repo_context_is_observed(self : CognitionStore) -> Bool {
+  self.values.contains(RepoSummary) ||
+  self.reverse_dependencies.contains(RepoSummary)
 }
 
 ///|
@@ -205,8 +211,8 @@ fn CognitionStore::collect_dirty_dependents(
         if !self.dirty.contains(dependent) {
           self.dirty[dependent] = true
           changed.push(dependent)
+          self.collect_dirty_dependents(dependent, changed)
         }
-        self.collect_dirty_dependents(dependent, changed)
       }
     None => ()
   }

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -34,6 +34,21 @@ pub fn CognitionStore::set_input(
   self.bump_revision(key)
   self.dirty.remove(key)
   let _ = self.dirty_dependents(key)
+  self.after_input_set(key)
+}
+
+///|
+fn CognitionStore::after_input_set(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Unit {
+  match key {
+    FileText(path) if self.values.contains(RepoSummary) => {
+      self.mark_dirty(FileSummary(path))
+      self.mark_dirty(RepoSummary)
+    }
+    _ => ()
+  }
 }
 
 ///|

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -1,0 +1,43 @@
+///|
+/// Key for an input or derived cognition artifact.
+pub(all) enum CognitionKey {
+  FileText(String)
+  FileSummary(String)
+  RepoSummary
+  QueryContext(String)
+} derive(Debug, Eq, Hash, Compare)
+
+///|
+/// Stored value for a cognition artifact.
+pub(all) enum CognitionValue {
+  Text(String)
+  Summary(String)
+  ContextBundle(Array[String])
+} derive(Debug, Eq)
+
+///|
+/// Monotonic store-local revision. The first stored value receives revision 1.
+pub struct Revision(Int) derive(Debug, Eq, Hash, Compare)
+
+///|
+pub fn Revision::to_int(self : Revision) -> Int {
+  let Revision(n) = self
+  n
+}
+
+///|
+/// Directed edge from a derived artifact to one input artifact it reads.
+pub(all) struct Dependency {
+  from : CognitionKey
+  input : CognitionKey
+} derive(Debug, Eq)
+
+///|
+pub fn CognitionKey::label(self : CognitionKey) -> String {
+  match self {
+    FileText(path) => "FileText(\{path})"
+    FileSummary(path) => "FileSummary(\{path})"
+    RepoSummary => "RepoSummary"
+    QueryContext(query) => "QueryContext(\{query})"
+  }
+}

--- a/moon.work
+++ b/moon.work
@@ -6,6 +6,7 @@ members = [
   "./lib/dom-boundary",
   "./lib/visualizer",
   "./lib/semantic",
+  "./lib/cognition",
   "./examples/ideal",
   "./examples/block-editor",
   "./examples/canvas",


### PR DESCRIPTION
## Summary
- add standalone lib/cognition package with cognition keys, values, revisions, dependencies, and dirty invalidation
- add deterministic mock recomputation for FileSummary, RepoSummary, and QueryContext
- document the cognition runtime architecture direction

## Validation
- moon check lib/cognition
- moon test lib/cognition
- moon fmt
- moon info
- moon test
- moon check