### PR TITLE
fix(cognition): clean deleted file dependency edges

### DIFF
--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -39,7 +39,14 @@ after query context has observed repo context, the runtime dirties the
 corresponding file-level summary and repo context so repo context can adopt the
 new dependency on the next recomputation. Removing a file unregisters it,
 removes its file text and summary artifacts, and dirties repo/query context so
-the next recomputation excludes the deleted file.
+the next recomputation excludes the deleted file. Dependency edges that mention
+that deleted path are dropped at removal time even though dirty derived values
+are not refreshed until recomputation. Paths are keyed by the caller's
+exact string for this milestone; for example, `foo.mbt` and `./foo.mbt` are
+distinct workspace identities until a separate workspace-root canonicalization
+policy exists. Model rename and move operations as removing the old path and
+adding the new path with the same contents rather than as identity-preserving
+moves.
 
 When an input changes, the store marks transitive dependents dirty. Recomputing
 dirty artifacts proceeds only when their dependencies are clean, so unrelated

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -75,6 +75,80 @@ test "remove_file unregisters file and recomputes repo without deleted summary" 
 }
 
 ///|
+test "remove_file cleans deleted file dependency graph after recompute" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.set_input(FileText("b.mbt"), Text("two"))
+  let _ = store.compute(QueryContext("what changed?"))
+
+  inspect(store.remove_file("a.mbt"), content="true")
+  inspect(store.known_files().join(","), content="b.mbt")
+  inspect(store.get_value(FileText("a.mbt")) is None, content="true")
+  inspect(store.get_value(FileSummary("a.mbt")) is None, content="true")
+  inspect(store.is_dirty(RepoSummary), content="true")
+  inspect(store.is_dirty(QueryContext("what changed?")), content="true")
+  inspect(
+    dependency_edges_mention_path(store.dependency_edges(), "a.mbt"),
+    content="false",
+  )
+  inspect(store.dependents_of(FileText("a.mbt")).length(), content="0")
+  inspect(store.dependents_of(FileSummary("a.mbt")).length(), content="0")
+
+  let _ = store.recompute_dirty()
+  inspect(
+    dependency_edges_mention_path(store.dependency_edges(), "a.mbt"),
+    content="false",
+  )
+  inspect(store.dependents_of(FileText("a.mbt")).length(), content="0")
+  inspect(store.dependents_of(FileSummary("a.mbt")).length(), content="0")
+  let repo_deps = store.dependencies_of(RepoSummary)
+  inspect(repo_deps.contains(FileSummary("a.mbt")), content="false")
+  inspect(repo_deps.contains(FileSummary("b.mbt")), content="true")
+}
+
+///|
+test "caller path strings are distinct workspace identities" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("foo.mbt"), Text("one"))
+  let _ = store.set_input(FileText("./foo.mbt"), Text("two"))
+
+  inspect(store.known_files().join(","), content="foo.mbt,./foo.mbt")
+
+  let _ = store.compute(RepoSummary)
+  let deps = store.dependencies_of(RepoSummary)
+  inspect(deps.contains(FileSummary("./foo.mbt")), content="true")
+  inspect(deps.contains(FileSummary("foo.mbt")), content="true")
+
+  inspect(store.remove_file("./foo.mbt"), content="true")
+  inspect(store.known_files().join(","), content="foo.mbt")
+  inspect(store.get_value(FileText("foo.mbt")) is Some(_), content="true")
+}
+
+///|
+fn dependency_edges_mention_path(
+  edges : Array[Dependency],
+  path : String,
+) -> Bool {
+  for edge in edges {
+    if cognition_key_mentions_path(edge.from, path) ||
+      cognition_key_mentions_path(edge.input, path) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn cognition_key_mentions_path(key : CognitionKey, path : String) -> Bool {
+  match key {
+    FileText(candidate) => candidate == path
+    FileSummary(candidate) => candidate == path
+    RepoSummary => false
+    QueryContext(_) => false
+  }
+}
+
+///|
 test "changing one FileText marks its FileSummary dirty" {
   let store = CognitionStore::new()
   let _ = store.set_input(FileText("a.mbt"), Text("hello"))

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -254,6 +254,37 @@ fn CognitionStore::remove_artifact_state(
   self.dirty.remove(key)
   self.recompute_counts.remove(key)
   self.remove_dependency_record(key)
+  self.remove_incoming_references(key)
+}
+
+///|
+fn CognitionStore::remove_incoming_references(
+  self : CognitionStore,
+  key : CognitionKey,
+) -> Unit {
+  let affected : Array[CognitionKey] = []
+  for from, inputs in self.dependencies {
+    if inputs.contains(key) {
+      affected.push(from)
+    }
+  }
+  let mut changed = false
+  for from in affected {
+    match self.dependencies.get(from) {
+      Some(inputs) => {
+        self.dependencies[from] = inputs.filter(fn(input) { input != key })
+        changed = true
+      }
+      None => ()
+    }
+  }
+  if self.reverse_dependencies.contains(key) {
+    self.reverse_dependencies.remove(key)
+    changed = true
+  }
+  if changed {
+    self.reactive.bump_dependency_revision()
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- remove incoming dependency references when deleting cognition file artifacts
- add deterministic two-file removal tests covering immediate cleanup and post-recompute invariants
- document exact-string path identity and delete+add rename/move semantics

## Validation
- moon -C lib/cognition check
- moon -C lib/cognition test
- moon check --deny-warn
- moon test

Note: `moon fmt` was run, but its unrelated `moon.mod.json` -> `moon.mod` migration output was reverted.