### PR TITLE
feat(cognition): add context packing API

### DIFF
--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -52,13 +52,14 @@ When an input changes, the store marks transitive dependents dirty. Recomputing
 dirty artifacts proceeds only when their dependencies are clean, so unrelated
 summaries are not recomputed when another file changes.
 
-Budgeted packed context is modeled as another derived artifact. It depends on
-repo context plus the selected file-summary candidates, stores
-provenance-bearing `ContextItem` values, and keeps each item's source key,
-source revision, payload, and inclusion reason. Candidate summaries are selected
-by deterministic query/path matching before falling back to path order, so tests
-can explain why a context item was included without invoking a model. This keeps
-AI-facing context inspectable before any real model provider is introduced.
+Packed context is modeled as another derived artifact. It depends on repo
+context plus the selected file-summary candidates, stores provenance-bearing
+`ContextItem` values, and keeps each item's source key, source revision,
+payload, and inclusion reason. Candidate summaries are selected by deterministic
+query/path matching before falling back to path order, then can be constrained by
+item count or cumulative payload character budget. Tests can explain why a
+context item was included without invoking a model, keeping AI-facing context
+inspectable before any real model provider is introduced.
 
 ## Non-goals for this milestone
 

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -55,8 +55,10 @@ summaries are not recomputed when another file changes.
 Budgeted packed context is modeled as another derived artifact. It depends on
 repo context plus the selected file-summary candidates, stores
 provenance-bearing `ContextItem` values, and keeps each item's source key,
-source revision, payload, and inclusion reason. This keeps AI-facing context
-inspectable before any real model provider is introduced.
+source revision, payload, and inclusion reason. Candidate summaries are selected
+by deterministic query/path matching before falling back to path order, so tests
+can explain why a context item was included without invoking a model. This keeps
+AI-facing context inspectable before any real model provider is introduced.
 
 ## Non-goals for this milestone
 

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -52,6 +52,12 @@ When an input changes, the store marks transitive dependents dirty. Recomputing
 dirty artifacts proceeds only when their dependencies are clean, so unrelated
 summaries are not recomputed when another file changes.
 
+Budgeted packed context is modeled as another derived artifact. It depends on
+repo context plus the selected file-summary candidates, stores
+provenance-bearing `ContextItem` values, and keeps each item's source key,
+source revision, payload, and inclusion reason. This keeps AI-facing context
+inspectable before any real model provider is introduced.
+
 ## Non-goals for this milestone
 
 - No real LLM calls.

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -61,6 +61,12 @@ item count or cumulative payload character budget. Tests can explain why a
 context item was included without invoking a model, keeping AI-facing context
 inspectable before any real model provider is introduced.
 
+Summary generation is routed through a deterministic provider seam. The default
+provider preserves the mock summary strings, while tests and future integrations
+can inject alternate synchronous providers without changing graph ownership or
+dependency tracking. Providers produce values only; `CognitionStore` remains the
+source of truth for revisions, dirty state, dependencies, and artifact lifetime.
+
 ## Non-goals for this milestone
 
 - No real LLM calls.

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -25,7 +25,8 @@ engine. Reverse edges make invalidation cheap: when an input changes, all
 transitive dependents can be marked dirty without scanning every artifact.
 
 The current implementation lives in `lib/cognition`; its generated package
-interface is the source of truth for concrete API names.
+interface is the source of truth for concrete API names. Package-level examples
+live in `lib/cognition/README.mbt.md` and are checked by `moon test`.
 
 ## Mock recomputation rules
 

--- a/docs/architecture/cognition-runtime.md
+++ b/docs/architecture/cognition-runtime.md
@@ -61,11 +61,13 @@ item count or cumulative payload character budget. Tests can explain why a
 context item was included without invoking a model, keeping AI-facing context
 inspectable before any real model provider is introduced.
 
-Summary generation is routed through a deterministic provider seam. The default
-provider preserves the mock summary strings, while tests and future integrations
-can inject alternate synchronous providers without changing graph ownership or
-dependency tracking. Providers produce values only; `CognitionStore` remains the
-source of truth for revisions, dirty state, dependencies, and artifact lifetime.
+Summary generation and context ranking are routed through deterministic policy
+seams. The default provider preserves the mock summary strings, and the default
+ranker preserves query/path matching. Tests and future integrations can inject
+alternate synchronous providers or rankers without changing graph ownership or
+dependency tracking. Policies produce values and scores only; `CognitionStore`
+remains the source of truth for revisions, dirty state, dependencies, and
+artifact lifetime.
 
 ## Non-goals for this milestone
 

--- a/lib/cognition/README.mbt.md
+++ b/lib/cognition/README.mbt.md
@@ -1,0 +1,127 @@
+# Cognition Runtime API
+
+`dowdiness/cognition` is a deterministic, incremental graph for AI-facing
+workspace context. It tracks file inputs, derived summaries, packed context,
+provenance, dependency edges, dirty state, and recompute counts. It does not call
+LLMs or the network.
+
+The usual flow is:
+
+1. create a `CognitionStore`,
+2. register workspace files with `set_input(FileText(path), Text(contents))`,
+3. call a context packing method,
+4. inspect returned `ContextItem` provenance and optional `ContextPackStats`.
+
+## Basic context packing
+
+```mbt check
+///|
+test "README basic context packing" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("let alpha = 1\n"))
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("let beta = 2\n"))
+
+  let items = store.pack_context_with_options(
+    "explain beta",
+    ContextPackOptions::new(max_items=2),
+  )
+
+  inspect(items.length(), content="2")
+  inspect(items[0].source == RepoSummary, content="true")
+  inspect(items[1].source == FileSummary("src/beta.mbt"), content="true")
+  inspect(items[1].reason, content="name matched query: beta")
+}
+```
+
+Each `ContextItem` carries:
+
+- `source` — the cognition artifact selected for context,
+- `source_revision` — the revision observed when the item was built,
+- `payload` — the text sent to the caller,
+- `reason` — deterministic explanation of why it was selected.
+
+## Budgets, truncation, and telemetry
+
+Use `ContextPackOptions` when callers need a stable surface for context limits.
+`max_chars` counts cumulative payload characters. By default, oversized items are
+skipped; set `truncate_items=true` to include one truncated item when it would
+otherwise exceed the remaining budget.
+
+```mbt check
+///|
+test "README budgeted context packing" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("let beta = 2\n"))
+
+  let (items, stats) = store.pack_context_with_stats(
+    "explain beta",
+    ContextPackOptions::new(max_items=3, max_chars=10, truncate_items=true),
+  )
+
+  inspect(items.length(), content="1")
+  inspect(items[0].payload.length(), content="10")
+  inspect(items[0].reason.contains("; truncated"), content="true")
+  inspect(stats.selected_items, content="1")
+  inspect(stats.truncated_items, content="1")
+  inspect(stats.payload_chars, content="10")
+}
+```
+
+Telemetry is deterministic and derived from the same candidate list as the
+returned items:
+
+- `selected_items` — number of returned items,
+- `skipped_items` — candidates not returned,
+- `truncated_items` — returned items whose reason includes `; truncated`,
+- `payload_chars` — total returned payload length.
+
+## Custom deterministic policies
+
+`CognitionProvider` controls summary text. `ContextRanker` controls candidate
+ordering and reasons. Both are synchronous deterministic policy seams; the store
+still owns graph state, revisions, dirty propagation, dependency edges, and
+artifact lifetime.
+
+```mbt check
+///|
+test "README custom provider and ranker" {
+  let provider : CognitionProvider = {
+    file_summary: fn(path, text) { "summary \{path}: \{text.length()}" },
+    repo_summary: fn(items) { "repo => " + items.join(" | ") },
+  }
+  let ranker : ContextRanker = {
+    score_summary: fn(_query, key) {
+      match key {
+        FileSummary("src/gamma.mbt") => 10
+        FileSummary(_) => 0
+        _ => 0
+      }
+    },
+    reason_summary: fn(_query, key) {
+      match key {
+        FileSummary("src/gamma.mbt") => "custom preferred gamma"
+        FileSummary(path) => "custom fallback \{path}"
+        _ => "custom artifact"
+      }
+    },
+  }
+  let store = CognitionStore::new_with_provider_and_ranker(provider, ranker)
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+  let _ = store.set_input(FileText("src/gamma.mbt"), Text("gamma"))
+
+  let items = store.pack_context("explain beta", 3)
+
+  inspect(items[1].source == FileSummary("src/gamma.mbt"), content="true")
+  inspect(items[1].reason, content="custom preferred gamma")
+}
+```
+
+## Compatibility helpers
+
+For simple callers, these wrappers remain available:
+
+- `pack_context(query, max_items)` — item-count budget only,
+- `pack_context_with_budget(query, max_items, max_chars)` — item-count plus
+  character budget,
+- `pack_context_with_options(query, options)` — explicit options,
+- `pack_context_with_stats(query, options)` — explicit options plus telemetry.

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -386,6 +386,27 @@ test "pack_context truncates without splitting unicode characters" {
 }
 
 ///|
+test "pack_context does not emit empty truncated items" {
+  let provider : CognitionProvider = {
+    file_summary: fn(path, _text) { "\{path}: data" },
+    repo_summary: fn(_items) { "12345" },
+  }
+  let store = CognitionStore::new_with_provider(provider)
+  let _ = store.set_input(FileText("a.mbt"), Text("ignored"))
+
+  let (items, stats) = store.pack_context_with_stats(
+    "what changed?",
+    ContextPackOptions::new(max_items=2, max_chars=5, truncate_items=true),
+  )
+
+  inspect(items.length(), content="1")
+  inspect(items[0].payload, content="12345")
+  inspect(stats.selected_items, content="1")
+  inspect(stats.truncated_items, content="0")
+  inspect(stats.payload_chars, content="5")
+}
+
+///|
 test "pack_context stats do not infer truncation from ranker reason text" {
   let ranker : ContextRanker = {
     score_summary: fn(_query, _key) { 0 },

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -282,6 +282,27 @@ test "pack_context_with_budget includes more items when budget allows" {
 }
 
 ///|
+test "pack_context_with_options preserves wrapper behavior" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+
+  let by_items = store.pack_context_with_options(
+    "explain beta",
+    ContextPackOptions::new(max_items=2),
+  )
+  let by_chars = store.pack_context_with_options(
+    "explain beta",
+    ContextPackOptions::new(max_items=3, max_chars=40),
+  )
+
+  inspect(by_items.length(), content="2")
+  inspect(by_items[1].source == FileSummary("src/beta.mbt"), content="true")
+  inspect(by_chars.length(), content="1")
+  inspect(by_chars[0].source == FileSummary("src/beta.mbt"), content="true")
+}
+
+///|
 test "pack_context_with_budget with non-positive char budget returns no items but stays live" {
   let store = CognitionStore::new()
   let _ = store.set_input(FileText("a.mbt"), Text("one"))

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -147,6 +147,7 @@ fn cognition_key_mentions_path(key : CognitionKey, path : String) -> Bool {
     QueryContext(_) => false
     PackedContext(_, _) => false
     BudgetedContext(_, _, _) => false
+    TruncatedContext(_, _, _) => false
   }
 }
 
@@ -300,6 +301,30 @@ test "pack_context_with_options preserves wrapper behavior" {
   inspect(by_items[1].source == FileSummary("src/beta.mbt"), content="true")
   inspect(by_chars.length(), content="1")
   inspect(by_chars[0].source == FileSummary("src/beta.mbt"), content="true")
+}
+
+///|
+test "pack_context_with_options truncates oversized selected items when enabled" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+
+  let skipped = store.pack_context_with_options(
+    "explain beta",
+    ContextPackOptions::new(max_items=3, max_chars=10),
+  )
+  let truncated = store.pack_context_with_options(
+    "explain beta",
+    ContextPackOptions::new(max_items=3, max_chars=10, truncate_items=true),
+  )
+
+  inspect(skipped.length(), content="0")
+  inspect(truncated.length(), content="1")
+  inspect(truncated[0].source == RepoSummary, content="true")
+  inspect(truncated[0].payload.length(), content="10")
+  inspect(
+    truncated[0].reason,
+    content="workspace overview for query: explain beta; truncated",
+  )
 }
 
 ///|

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -167,10 +167,38 @@ test "pack_context returns provenance-bearing budgeted items" {
   )
   inspect(items[1].source == FileSummary("a.mbt"), content="true")
   inspect(items[1].payload.contains("a.mbt"), content="true")
-  inspect(
-    items[1].reason,
-    content="file summary selected for query: what changed?",
-  )
+  inspect(items[1].reason, content="workspace file summary")
+}
+
+///|
+test "pack_context prefers file summaries that match the query" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/gamma.mbt"), Text("gamma"))
+
+  let items = store.pack_context("explain beta", 3)
+
+  inspect(items.length(), content="3")
+  inspect(items[0].source == RepoSummary, content="true")
+  inspect(items[1].source == FileSummary("src/beta.mbt"), content="true")
+  inspect(items[1].reason, content="name matched query: beta")
+  inspect(items[2].source == FileSummary("src/alpha.mbt"), content="true")
+  inspect(items[2].reason, content="workspace file summary")
+}
+
+///|
+test "pack_context ranks full path matches before filename matches" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("src a"))
+  let _ = store.set_input(FileText("test/a.mbt"), Text("test a"))
+
+  let items = store.pack_context("debug test/a.mbt and a.mbt", 3)
+
+  inspect(items[1].source == FileSummary("test/a.mbt"), content="true")
+  inspect(items[1].reason, content="path matched query: test/a.mbt")
+  inspect(items[2].source == FileSummary("src/a.mbt"), content="true")
+  inspect(items[2].reason, content="filename matched query: a.mbt")
 }
 
 ///|

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -146,6 +146,7 @@ fn cognition_key_mentions_path(key : CognitionKey, path : String) -> Bool {
     RepoSummary => false
     QueryContext(_) => false
     PackedContext(_, _) => false
+    BudgetedContext(_, _, _) => false
   }
 }
 
@@ -247,6 +248,51 @@ test "pack_context with non-positive budget returns no items but stays live" {
   inspect(
     store
     .dependencies_of(CognitionKey::PackedContext("what changed?", 0))
+    .contains(RepoSummary),
+    content="true",
+  )
+}
+
+///|
+test "pack_context_with_budget skips oversized items and preserves query ranking" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+  let _ = store.set_input(FileText("src/gamma.mbt"), Text("gamma"))
+
+  let items = store.pack_context_with_budget("explain beta", 3, 40)
+
+  inspect(items.length(), content="1")
+  inspect(items[0].source == FileSummary("src/beta.mbt"), content="true")
+  inspect(items[0].reason, content="name matched query: beta")
+}
+
+///|
+test "pack_context_with_budget includes more items when budget allows" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+
+  let items = store.pack_context_with_budget("explain beta", 3, 1000)
+
+  inspect(items.length(), content="3")
+  inspect(items[0].source == RepoSummary, content="true")
+  inspect(items[1].source == FileSummary("src/beta.mbt"), content="true")
+  inspect(items[2].source == FileSummary("src/alpha.mbt"), content="true")
+}
+
+///|
+test "pack_context_with_budget with non-positive char budget returns no items but stays live" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+
+  inspect(
+    store.pack_context_with_budget("what changed?", 3, 0).length(),
+    content="0",
+  )
+  inspect(
+    store
+    .dependencies_of(CognitionKey::BudgetedContext("what changed?", 3, 0))
     .contains(RepoSummary),
     content="true",
   )

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -145,7 +145,83 @@ fn cognition_key_mentions_path(key : CognitionKey, path : String) -> Bool {
     FileSummary(candidate) => candidate == path
     RepoSummary => false
     QueryContext(_) => false
+    PackedContext(_, _) => false
   }
+}
+
+///|
+test "pack_context returns provenance-bearing budgeted items" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("b.mbt"), Text("two"))
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+
+  let items = store.pack_context("what changed?", 2)
+
+  inspect(items.length(), content="2")
+  inspect(items[0].source == RepoSummary, content="true")
+  inspect(items[0].source_revision.to_int() > 0, content="true")
+  inspect(items[0].payload.contains("repo summary"), content="true")
+  inspect(
+    items[0].reason,
+    content="workspace overview for query: what changed?",
+  )
+  inspect(items[1].source == FileSummary("a.mbt"), content="true")
+  inspect(items[1].payload.contains("a.mbt"), content="true")
+  inspect(
+    items[1].reason,
+    content="file summary selected for query: what changed?",
+  )
+}
+
+///|
+test "pack_context records graph dependencies and invalidates on edits" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.set_input(FileText("b.mbt"), Text("two"))
+  let _ = store.pack_context("what changed?", 2)
+  let key = CognitionKey::PackedContext("what changed?", 2)
+  let deps = store.dependencies_of(key)
+
+  inspect(deps.contains(RepoSummary), content="true")
+  inspect(deps.contains(FileSummary("a.mbt")), content="true")
+  inspect(deps.contains(FileSummary("b.mbt")), content="true")
+
+  let _ = store.set_input(FileText("a.mbt"), Text("one changed"))
+  inspect(store.is_dirty(key), content="true")
+  let recomputed = store.recompute_dirty()
+  inspect(recomputed.contains(key), content="true")
+}
+
+///|
+test "pack_context returns immutable item arrays" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+
+  let items = store.pack_context("what changed?", 1)
+  items.push({
+    source: FileText("external.mbt"),
+    source_revision: items[0].source_revision,
+    payload: "external mutation",
+    reason: "external",
+  })
+
+  let fresh = store.pack_context("what changed?", 1)
+  inspect(fresh.length(), content="1")
+  inspect(fresh[0].payload.contains("external mutation"), content="false")
+}
+
+///|
+test "pack_context with non-positive budget returns no items but stays live" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+
+  inspect(store.pack_context("what changed?", 0).length(), content="0")
+  inspect(
+    store
+    .dependencies_of(CognitionKey::PackedContext("what changed?", 0))
+    .contains(RepoSummary),
+    content="true",
+  )
 }
 
 ///|

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -366,6 +366,46 @@ test "pack_context_with_stats reports truncation" {
 }
 
 ///|
+test "pack_context truncates without splitting unicode characters" {
+  let provider : CognitionProvider = {
+    file_summary: fn(path, _text) { "\{path}: 😀" },
+    repo_summary: fn(items) { items.join("\n") },
+  }
+  let store = CognitionStore::new_with_provider(provider)
+  let _ = store.set_input(FileText("emoji.mbt"), Text("ignored"))
+
+  let (items, stats) = store.pack_context_with_stats(
+    "emoji",
+    ContextPackOptions::new(max_items=2, max_chars=12, truncate_items=true),
+  )
+
+  inspect(items.length(), content="1")
+  inspect(items[0].payload, content="emoji.mbt: ")
+  inspect(stats.truncated_items, content="1")
+  inspect(stats.payload_chars, content="11")
+}
+
+///|
+test "pack_context stats do not infer truncation from ranker reason text" {
+  let ranker : ContextRanker = {
+    score_summary: fn(_query, _key) { 0 },
+    reason_summary: fn(_query, _key) { "contains ; truncated marker" },
+  }
+  let store = CognitionStore::new_with_provider_and_ranker(
+    CognitionProvider::mock(),
+    ranker,
+  )
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+
+  let (_items, stats) = store.pack_context_with_stats(
+    "what changed?",
+    ContextPackOptions::new(max_items=2),
+  )
+
+  inspect(stats.truncated_items, content="0")
+}
+
+///|
 test "pack_context_with_budget with non-positive char budget returns no items but stays live" {
   let store = CognitionStore::new()
   let _ = store.set_input(FileText("a.mbt"), Text("one"))

--- a/lib/cognition/cognition_test.mbt
+++ b/lib/cognition/cognition_test.mbt
@@ -328,6 +328,44 @@ test "pack_context_with_options truncates oversized selected items when enabled"
 }
 
 ///|
+test "pack_context_with_stats reports selected skipped and payload counts" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+
+  let (items, stats) = store.pack_context_with_stats(
+    "explain beta",
+    ContextPackOptions::new(max_items=2),
+  )
+
+  inspect(items.length(), content="2")
+  inspect(stats.selected_items, content="2")
+  inspect(stats.skipped_items, content="1")
+  inspect(stats.truncated_items, content="0")
+  inspect(
+    stats.payload_chars == items[0].payload.length() + items[1].payload.length(),
+    content="true",
+  )
+}
+
+///|
+test "pack_context_with_stats reports truncation" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+
+  let (items, stats) = store.pack_context_with_stats(
+    "explain beta",
+    ContextPackOptions::new(max_items=3, max_chars=10, truncate_items=true),
+  )
+
+  inspect(items.length(), content="1")
+  inspect(stats.selected_items, content="1")
+  inspect(stats.skipped_items, content="1")
+  inspect(stats.truncated_items, content="1")
+  inspect(stats.payload_chars, content="10")
+}
+
+///|
 test "pack_context_with_budget with non-positive char budget returns no items but stays live" {
   let store = CognitionStore::new()
   let _ = store.set_input(FileText("a.mbt"), Text("one"))

--- a/lib/cognition/graph_invariant_test.mbt
+++ b/lib/cognition/graph_invariant_test.mbt
@@ -212,6 +212,8 @@ fn graph_key_is_live(store : CognitionStore, key : CognitionKey) -> Bool {
       store.get_value(key) is Some(ContextItems(_)) || store.is_dirty(key)
     BudgetedContext(_, _, _) =>
       store.get_value(key) is Some(ContextItems(_)) || store.is_dirty(key)
+    TruncatedContext(_, _, _) =>
+      store.get_value(key) is Some(ContextItems(_)) || store.is_dirty(key)
   }
 }
 
@@ -224,6 +226,7 @@ fn graph_key_mentions_path(key : CognitionKey, path : String) -> Bool {
     QueryContext(_) => false
     PackedContext(_, _) => false
     BudgetedContext(_, _, _) => false
+    TruncatedContext(_, _, _) => false
   }
 }
 
@@ -239,6 +242,7 @@ fn graph_candidate_keys() -> Array[CognitionKey] {
     CognitionKey::PackedContext("what changed?", 1),
     CognitionKey::PackedContext("what changed?", 3),
     CognitionKey::BudgetedContext("what changed?", 3, 80),
+    CognitionKey::TruncatedContext("what changed?", 3, 80),
   ]
 }
 

--- a/lib/cognition/graph_invariant_test.mbt
+++ b/lib/cognition/graph_invariant_test.mbt
@@ -7,6 +7,7 @@ priv enum GraphOp {
   ComputeQuery
   PackOne
   PackThree
+  PackBudget
   RecomputeDirty
 }
 
@@ -99,6 +100,10 @@ fn apply_graph_op(store : CognitionStore, op : GraphOp) -> Unit {
     }
     PackThree => {
       let _ = store.pack_context("what changed?", 3)
+      ()
+    }
+    PackBudget => {
+      let _ = store.pack_context_with_budget("what changed?", 3, 80)
       ()
     }
     RecomputeDirty => {
@@ -205,6 +210,8 @@ fn graph_key_is_live(store : CognitionStore, key : CognitionKey) -> Bool {
       store.get_value(key) is Some(ContextBundle(_)) || store.is_dirty(key)
     PackedContext(_, _) =>
       store.get_value(key) is Some(ContextItems(_)) || store.is_dirty(key)
+    BudgetedContext(_, _, _) =>
+      store.get_value(key) is Some(ContextItems(_)) || store.is_dirty(key)
   }
 }
 
@@ -216,6 +223,7 @@ fn graph_key_mentions_path(key : CognitionKey, path : String) -> Bool {
     RepoSummary => false
     QueryContext(_) => false
     PackedContext(_, _) => false
+    BudgetedContext(_, _, _) => false
   }
 }
 
@@ -230,6 +238,7 @@ fn graph_candidate_keys() -> Array[CognitionKey] {
     QueryContext("what changed?"),
     CognitionKey::PackedContext("what changed?", 1),
     CognitionKey::PackedContext("what changed?", 3),
+    CognitionKey::BudgetedContext("what changed?", 3, 80),
   ]
 }
 
@@ -255,7 +264,7 @@ fn graph_sequence_count(length : Int) -> Int {
 
 ///|
 fn graph_op_count() -> Int {
-  8
+  9
 }
 
 ///|
@@ -268,6 +277,7 @@ fn graph_op_from_code(code : Int) -> GraphOp {
     4 => ComputeQuery
     5 => PackOne
     6 => PackThree
+    7 => PackBudget
     _ => RecomputeDirty
   }
 }
@@ -282,6 +292,7 @@ fn graph_op_label(op : GraphOp) -> String {
     ComputeQuery => "ComputeQuery"
     PackOne => "PackOne"
     PackThree => "PackThree"
+    PackBudget => "PackBudget"
     RecomputeDirty => "RecomputeDirty"
   }
 }

--- a/lib/cognition/graph_invariant_test.mbt
+++ b/lib/cognition/graph_invariant_test.mbt
@@ -1,0 +1,287 @@
+///|
+priv enum GraphOp {
+  PutA
+  PutB
+  RemoveA
+  RemoveB
+  ComputeQuery
+  PackOne
+  PackThree
+  RecomputeDirty
+}
+
+///|
+test "graph invariants hold across edit remove and context packing scenario" {
+  let store = CognitionStore::new()
+  assert_graph_invariants(store, "initial")
+
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+  assert_graph_invariants(store, "after add a")
+
+  let _ = store.set_input(FileText("b.mbt"), Text("two"))
+  assert_graph_invariants(store, "after add b")
+
+  let _ = store.compute(QueryContext("what changed?"))
+  assert_graph_invariants(store, "after query context")
+
+  let _ = store.pack_context("what changed?", 3)
+  assert_graph_invariants(store, "after packed context")
+
+  let _ = store.set_input(FileText("a.mbt"), Text("one changed"))
+  inspect(
+    store.is_dirty(CognitionKey::PackedContext("what changed?", 3)),
+    content="true",
+  )
+  assert_graph_invariants(store, "after edit a")
+
+  let _ = store.recompute_dirty()
+  assert_graph_invariants(store, "after recompute edit a")
+
+  inspect(store.remove_file("b.mbt"), content="true")
+  assert_graph_invariants(store, "after remove b before recompute")
+
+  let _ = store.recompute_dirty()
+  assert_graph_invariants(store, "after remove b recompute")
+}
+
+///|
+test "generated graph operation sequences preserve invariants" {
+  let sequence_length = 4
+  for index in 0..<graph_sequence_count(sequence_length) {
+    let store = CognitionStore::new()
+    let sequence = graph_sequence_from_index(index, sequence_length)
+    apply_graph_sequence(store, sequence, "sequence #\{index}")
+  }
+}
+
+///|
+fn apply_graph_sequence(
+  store : CognitionStore,
+  sequence : Array[GraphOp],
+  label : String,
+) -> Unit raise {
+  assert_graph_invariants(store, "\{label} start")
+  for step, op in sequence {
+    apply_graph_op(store, op)
+    assert_graph_invariants(
+      store,
+      "\{label} step \{step} \{graph_op_label(op)}",
+    )
+  }
+}
+
+///|
+fn apply_graph_op(store : CognitionStore, op : GraphOp) -> Unit {
+  match op {
+    PutA => {
+      let _ = store.set_input(FileText("a.mbt"), Text("content for a"))
+      ()
+    }
+    PutB => {
+      let _ = store.set_input(FileText("b.mbt"), Text("content for b"))
+      ()
+    }
+    RemoveA => {
+      let _ = store.remove_file("a.mbt")
+      ()
+    }
+    RemoveB => {
+      let _ = store.remove_file("b.mbt")
+      ()
+    }
+    ComputeQuery => {
+      let _ = store.compute(QueryContext("what changed?"))
+      ()
+    }
+    PackOne => {
+      let _ = store.pack_context("what changed?", 1)
+      ()
+    }
+    PackThree => {
+      let _ = store.pack_context("what changed?", 3)
+      ()
+    }
+    RecomputeDirty => {
+      let _ = store.recompute_dirty()
+      ()
+    }
+  }
+}
+
+///|
+fn assert_graph_invariants(
+  store : CognitionStore,
+  label : String,
+) -> Unit raise {
+  let edges = store.dependency_edges()
+  for edge in edges {
+    if !graph_key_is_live(store, edge.from) {
+      fail(
+        "dead dependency source after \{label}: \{edge.from.label()} -> \{edge.input.label()}",
+      )
+    }
+    if !graph_key_is_live(store, edge.input) {
+      fail(
+        "dead dependency input after \{label}: \{edge.from.label()} -> \{edge.input.label()}",
+      )
+    }
+    if !store.dependencies_of(edge.from).contains(edge.input) {
+      fail(
+        "edge snapshot missing dependency map entry after \{label}: \{edge.from.label()} -> \{edge.input.label()}",
+      )
+    }
+    if !store.dependents_of(edge.input).contains(edge.from) {
+      fail(
+        "edge snapshot missing reverse map entry after \{label}: \{edge.from.label()} -> \{edge.input.label()}",
+      )
+    }
+  }
+  for key in graph_candidate_keys() {
+    for dependent in store.dependents_of(key) {
+      if !store.dependencies_of(dependent).contains(key) {
+        fail(
+          "stale reverse dependency after \{label}: \{key.label()} <- \{dependent.label()}",
+        )
+      }
+    }
+  }
+  for path in ["a.mbt", "b.mbt"] {
+    if !store.known_files().contains(path) {
+      assert_path_absent_from_graph(store, path, label)
+    }
+  }
+}
+
+///|
+fn assert_path_absent_from_graph(
+  store : CognitionStore,
+  path : String,
+  label : String,
+) -> Unit raise {
+  for edge in store.dependency_edges() {
+    if graph_key_mentions_path(edge.from, path) ||
+      graph_key_mentions_path(edge.input, path) {
+      fail(
+        "deleted path \{path} remains in edge after \{label}: \{edge.from.label()} -> \{edge.input.label()}",
+      )
+    }
+  }
+  let text_key = CognitionKey::FileText(path)
+  let summary_key = CognitionKey::FileSummary(path)
+  if store.get_value(text_key) is Some(_) {
+    fail("deleted path \{path} still has FileText value after \{label}")
+  }
+  if store.get_value(summary_key) is Some(_) {
+    fail("deleted path \{path} still has FileSummary value after \{label}")
+  }
+  if store.dependencies_of(text_key).length() != 0 {
+    fail("deleted path \{path} still has FileText dependencies after \{label}")
+  }
+  if store.dependencies_of(summary_key).length() != 0 {
+    fail(
+      "deleted path \{path} still has FileSummary dependencies after \{label}",
+    )
+  }
+  if store.dependents_of(text_key).length() != 0 {
+    fail("deleted path \{path} still has FileText dependents after \{label}")
+  }
+  if store.dependents_of(summary_key).length() != 0 {
+    fail("deleted path \{path} still has FileSummary dependents after \{label}")
+  }
+}
+
+///|
+fn graph_key_is_live(store : CognitionStore, key : CognitionKey) -> Bool {
+  match key {
+    FileText(path) =>
+      store.known_files().contains(path) &&
+      store.get_value(key) is Some(Text(_))
+    FileSummary(path) =>
+      store.known_files().contains(path) &&
+      (store.get_value(key) is Some(Summary(_)) || store.is_dirty(key))
+    RepoSummary =>
+      store.get_value(key) is Some(Summary(_)) || store.is_dirty(key)
+    QueryContext(_) =>
+      store.get_value(key) is Some(ContextBundle(_)) || store.is_dirty(key)
+    PackedContext(_, _) =>
+      store.get_value(key) is Some(ContextItems(_)) || store.is_dirty(key)
+  }
+}
+
+///|
+fn graph_key_mentions_path(key : CognitionKey, path : String) -> Bool {
+  match key {
+    FileText(candidate) => candidate == path
+    FileSummary(candidate) => candidate == path
+    RepoSummary => false
+    QueryContext(_) => false
+    PackedContext(_, _) => false
+  }
+}
+
+///|
+fn graph_candidate_keys() -> Array[CognitionKey] {
+  [
+    FileText("a.mbt"),
+    FileSummary("a.mbt"),
+    FileText("b.mbt"),
+    FileSummary("b.mbt"),
+    RepoSummary,
+    QueryContext("what changed?"),
+    CognitionKey::PackedContext("what changed?", 1),
+    CognitionKey::PackedContext("what changed?", 3),
+  ]
+}
+
+///|
+fn graph_sequence_from_index(index : Int, length : Int) -> Array[GraphOp] {
+  let sequence : Array[GraphOp] = []
+  let mut remaining = index
+  for _ in 0..<length {
+    sequence.push(graph_op_from_code(remaining % graph_op_count()))
+    remaining = remaining / graph_op_count()
+  }
+  sequence
+}
+
+///|
+fn graph_sequence_count(length : Int) -> Int {
+  let mut count = 1
+  for _ in 0..<length {
+    count = count * graph_op_count()
+  }
+  count
+}
+
+///|
+fn graph_op_count() -> Int {
+  8
+}
+
+///|
+fn graph_op_from_code(code : Int) -> GraphOp {
+  match code {
+    0 => PutA
+    1 => PutB
+    2 => RemoveA
+    3 => RemoveB
+    4 => ComputeQuery
+    5 => PackOne
+    6 => PackThree
+    _ => RecomputeDirty
+  }
+}
+
+///|
+fn graph_op_label(op : GraphOp) -> String {
+  match op {
+    PutA => "PutA"
+    PutB => "PutB"
+    RemoveA => "RemoveA"
+    RemoveB => "RemoveB"
+    ComputeQuery => "ComputeQuery"
+    PackOne => "PackOne"
+    PackThree => "PackThree"
+    RecomputeDirty => "RecomputeDirty"
+  }
+}

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub(all) enum CognitionKey {
   QueryContext(String)
   PackedContext(String, Int)
   BudgetedContext(String, Int, Int)
+  TruncatedContext(String, Int, Int)
 } derive(Compare, Eq, Hash, @debug.Debug)
 pub fn CognitionKey::label(Self) -> String
 
@@ -71,8 +72,9 @@ pub(all) struct ContextItem {
 pub(all) struct ContextPackOptions {
   max_items : Int
   max_chars : Int?
+  truncate_items : Bool
 } derive(Eq, @debug.Debug)
-pub fn ContextPackOptions::new(max_items~ : Int, max_chars? : Int) -> Self
+pub fn ContextPackOptions::new(max_items~ : Int, max_chars? : Int, truncate_items? : Bool) -> Self
 
 pub(all) struct Dependency {
   from : CognitionKey

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -48,6 +48,7 @@ pub fn CognitionStore::new() -> Self
 pub fn CognitionStore::new_with_provider(CognitionProvider) -> Self
 pub fn CognitionStore::pack_context(Self, String, Int) -> Array[ContextItem]
 pub fn CognitionStore::pack_context_with_budget(Self, String, Int, Int) -> Array[ContextItem]
+pub fn CognitionStore::pack_context_with_options(Self, String, ContextPackOptions) -> Array[ContextItem]
 pub fn CognitionStore::recompute_count(Self, CognitionKey) -> Int
 pub fn CognitionStore::recompute_dirty(Self) -> Array[CognitionKey]
 pub fn CognitionStore::remove_file(Self, String) -> Bool
@@ -66,6 +67,12 @@ pub(all) struct ContextItem {
   payload : String
   reason : String
 } derive(Eq, @debug.Debug)
+
+pub(all) struct ContextPackOptions {
+  max_items : Int
+  max_chars : Int?
+} derive(Eq, @debug.Debug)
+pub fn ContextPackOptions::new(max_items~ : Int, max_chars? : Int) -> Self
 
 pub(all) struct Dependency {
   from : CognitionKey

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub(all) enum CognitionKey {
   RepoSummary
   QueryContext(String)
   PackedContext(String, Int)
+  BudgetedContext(String, Int, Int)
 } derive(Compare, Eq, Hash, @debug.Debug)
 pub fn CognitionKey::label(Self) -> String
 
@@ -39,6 +40,7 @@ pub fn CognitionStore::known_files(Self) -> Array[String]
 pub fn CognitionStore::mark_dirty(Self, CognitionKey) -> Unit
 pub fn CognitionStore::new() -> Self
 pub fn CognitionStore::pack_context(Self, String, Int) -> Array[ContextItem]
+pub fn CognitionStore::pack_context_with_budget(Self, String, Int, Int) -> Array[ContextItem]
 pub fn CognitionStore::recompute_count(Self, CognitionKey) -> Int
 pub fn CognitionStore::recompute_dirty(Self) -> Array[CognitionKey]
 pub fn CognitionStore::remove_file(Self, String) -> Bool

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub(all) enum CognitionKey {
   FileSummary(String)
   RepoSummary
   QueryContext(String)
+  PackedContext(String, Int)
 } derive(Compare, Eq, Hash, @debug.Debug)
 pub fn CognitionKey::label(Self) -> String
 
@@ -37,6 +38,7 @@ pub fn CognitionStore::is_dirty(Self, CognitionKey) -> Bool
 pub fn CognitionStore::known_files(Self) -> Array[String]
 pub fn CognitionStore::mark_dirty(Self, CognitionKey) -> Unit
 pub fn CognitionStore::new() -> Self
+pub fn CognitionStore::pack_context(Self, String, Int) -> Array[ContextItem]
 pub fn CognitionStore::recompute_count(Self, CognitionKey) -> Int
 pub fn CognitionStore::recompute_dirty(Self) -> Array[CognitionKey]
 pub fn CognitionStore::remove_file(Self, String) -> Bool
@@ -46,6 +48,14 @@ pub(all) enum CognitionValue {
   Text(String)
   Summary(String)
   ContextBundle(Array[String])
+  ContextItems(Array[ContextItem])
+} derive(Eq, @debug.Debug)
+
+pub(all) struct ContextItem {
+  source : CognitionKey
+  source_revision : Revision
+  payload : String
+  reason : String
 } derive(Eq, @debug.Debug)
 
 pub(all) struct Dependency {

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -47,6 +47,7 @@ pub fn CognitionStore::known_files(Self) -> Array[String]
 pub fn CognitionStore::mark_dirty(Self, CognitionKey) -> Unit
 pub fn CognitionStore::new() -> Self
 pub fn CognitionStore::new_with_provider(CognitionProvider) -> Self
+pub fn CognitionStore::new_with_provider_and_ranker(CognitionProvider, ContextRanker) -> Self
 pub fn CognitionStore::pack_context(Self, String, Int) -> Array[ContextItem]
 pub fn CognitionStore::pack_context_with_budget(Self, String, Int, Int) -> Array[ContextItem]
 pub fn CognitionStore::pack_context_with_options(Self, String, ContextPackOptions) -> Array[ContextItem]
@@ -75,6 +76,12 @@ pub(all) struct ContextPackOptions {
   truncate_items : Bool
 } derive(Eq, @debug.Debug)
 pub fn ContextPackOptions::new(max_items~ : Int, max_chars? : Int, truncate_items? : Bool) -> Self
+
+pub(all) struct ContextRanker {
+  score_summary : (String, CognitionKey) -> Int
+  reason_summary : (String, CognitionKey) -> String
+}
+pub fn ContextRanker::path_match() -> Self
 
 pub(all) struct Dependency {
   from : CognitionKey

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -51,6 +51,7 @@ pub fn CognitionStore::new_with_provider_and_ranker(CognitionProvider, ContextRa
 pub fn CognitionStore::pack_context(Self, String, Int) -> Array[ContextItem]
 pub fn CognitionStore::pack_context_with_budget(Self, String, Int, Int) -> Array[ContextItem]
 pub fn CognitionStore::pack_context_with_options(Self, String, ContextPackOptions) -> Array[ContextItem]
+pub fn CognitionStore::pack_context_with_stats(Self, String, ContextPackOptions) -> (Array[ContextItem], ContextPackStats)
 pub fn CognitionStore::recompute_count(Self, CognitionKey) -> Int
 pub fn CognitionStore::recompute_dirty(Self) -> Array[CognitionKey]
 pub fn CognitionStore::remove_file(Self, String) -> Bool
@@ -76,6 +77,13 @@ pub(all) struct ContextPackOptions {
   truncate_items : Bool
 } derive(Eq, @debug.Debug)
 pub fn ContextPackOptions::new(max_items~ : Int, max_chars? : Int, truncate_items? : Bool) -> Self
+
+pub(all) struct ContextPackStats {
+  selected_items : Int
+  skipped_items : Int
+  truncated_items : Int
+  payload_chars : Int
+} derive(Eq, @debug.Debug)
 
 pub(all) struct ContextRanker {
   score_summary : (String, CognitionKey) -> Int

--- a/lib/cognition/pkg.generated.mbti
+++ b/lib/cognition/pkg.generated.mbti
@@ -21,6 +21,12 @@ pub(all) enum CognitionKey {
 } derive(Compare, Eq, Hash, @debug.Debug)
 pub fn CognitionKey::label(Self) -> String
 
+pub(all) struct CognitionProvider {
+  file_summary : (String, String) -> String
+  repo_summary : (Array[String]) -> String
+}
+pub fn CognitionProvider::mock() -> Self
+
 type CognitionReactive
 
 pub(all) struct CognitionStore {
@@ -39,6 +45,7 @@ pub fn CognitionStore::is_dirty(Self, CognitionKey) -> Bool
 pub fn CognitionStore::known_files(Self) -> Array[String]
 pub fn CognitionStore::mark_dirty(Self, CognitionKey) -> Unit
 pub fn CognitionStore::new() -> Self
+pub fn CognitionStore::new_with_provider(CognitionProvider) -> Self
 pub fn CognitionStore::pack_context(Self, String, Int) -> Array[ContextItem]
 pub fn CognitionStore::pack_context_with_budget(Self, String, Int, Int) -> Array[ContextItem]
 pub fn CognitionStore::recompute_count(Self, CognitionKey) -> Int

--- a/lib/cognition/provider.mbt
+++ b/lib/cognition/provider.mbt
@@ -1,0 +1,34 @@
+///|
+/// Default deterministic provider used by `CognitionStore::new`.
+pub fn CognitionProvider::mock() -> CognitionProvider {
+  {
+    file_summary: fn(path, text) { mock_file_summary(path, text) },
+    repo_summary: fn(items) { mock_repo_summary(items) },
+  }
+}
+
+///|
+fn mock_file_summary(path : String, text : String) -> String {
+  let line_count = if text == "" { 0 } else { count_lines(text) }
+  "\{path}: \{line_count} lines, \{text.length()} chars"
+}
+
+///|
+fn mock_repo_summary(items : Array[String]) -> String {
+  if items.length() == 0 {
+    "repo summary: <empty>"
+  } else {
+    "repo summary:\n" + items.join("\n")
+  }
+}
+
+///|
+fn count_lines(text : String) -> Int {
+  let mut lines = 1
+  for ch in text {
+    if ch == '\n' {
+      lines += 1
+    }
+  }
+  lines
+}

--- a/lib/cognition/provider_test.mbt
+++ b/lib/cognition/provider_test.mbt
@@ -1,0 +1,54 @@
+///|
+test "custom provider controls file and repo summaries" {
+  let provider : CognitionProvider = {
+    file_summary: fn(path, text) { "custom file \{path}: \{text.length()}" },
+    repo_summary: fn(items) { "custom repo: " + items.join(" | ") },
+  }
+  let store = CognitionStore::new_with_provider(provider)
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+
+  let _ = store.compute(FileSummary("a.mbt"))
+  match store.get_value(FileSummary("a.mbt")) {
+    Some(Summary(summary)) => inspect(summary, content="custom file a.mbt: 3")
+    _ => fail("expected custom file summary")
+  }
+
+  let _ = store.compute(RepoSummary)
+  match store.get_value(RepoSummary) {
+    Some(Summary(summary)) =>
+      inspect(summary, content="custom repo: custom file a.mbt: 3")
+    _ => fail("expected custom repo summary")
+  }
+}
+
+///|
+test "provider is called only for recomputed artifacts" {
+  let file_calls = Ref(0)
+  let repo_calls = Ref(0)
+  let provider : CognitionProvider = {
+    file_summary: fn(path, text) {
+      file_calls.val += 1
+      "\{path}: \{text.length()}"
+    },
+    repo_summary: fn(items) {
+      repo_calls.val += 1
+      "repo: " + items.join(",")
+    },
+  }
+  let store = CognitionStore::new_with_provider(provider)
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.set_input(FileText("b.mbt"), Text("two"))
+  let _ = store.compute(FileSummary("a.mbt"))
+  let _ = store.compute(FileSummary("b.mbt"))
+  let _ = store.compute(RepoSummary)
+
+  inspect(file_calls.val, content="2")
+  inspect(repo_calls.val, content="1")
+
+  let _ = store.set_input(FileText("a.mbt"), Text("one changed"))
+  let _ = store.recompute_dirty()
+
+  inspect(file_calls.val, content="3")
+  inspect(repo_calls.val, content="2")
+  inspect(store.recompute_count(FileSummary("b.mbt")), content="1")
+}

--- a/lib/cognition/provider_test.mbt
+++ b/lib/cognition/provider_test.mbt
@@ -52,3 +52,46 @@ test "provider is called only for recomputed artifacts" {
   inspect(repo_calls.val, content="2")
   inspect(store.recompute_count(FileSummary("b.mbt")), content="1")
 }
+
+///|
+test "repo provider receives copied summary arrays" {
+  let captured : Array[Array[String]] = []
+  let provider : CognitionProvider = {
+    file_summary: fn(path, text) { "\{path}: \{text.length()}" },
+    repo_summary: fn(items) {
+      captured.push(items)
+      "repo: " + items.join(",")
+    },
+  }
+  let store = CognitionStore::new_with_provider(provider)
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.compute(RepoSummary)
+
+  captured[0].push("external mutation")
+
+  match store.get_value(RepoSummary) {
+    Some(Summary(summary)) =>
+      inspect(summary.contains("external mutation"), content="false")
+    _ => fail("expected repo summary")
+  }
+}
+
+///|
+test "provider output is copied before storage" {
+  let provider_payload : Array[String] = ["first"]
+  let provider : CognitionProvider = {
+    file_summary: fn(path, _text) { "\{path}: " + provider_payload.join(",") },
+    repo_summary: fn(items) { "repo: " + items.join(",") },
+  }
+  let store = CognitionStore::new_with_provider(provider)
+  let _ = store.set_input(FileText("a.mbt"), Text("one"))
+  let _ = store.compute(FileSummary("a.mbt"))
+
+  provider_payload.push("external mutation")
+
+  match store.get_value(FileSummary("a.mbt")) {
+    Some(Summary(summary)) =>
+      inspect(summary.contains("external mutation"), content="false")
+    _ => fail("expected file summary")
+  }
+}

--- a/lib/cognition/ranker.mbt
+++ b/lib/cognition/ranker.mbt
@@ -1,0 +1,80 @@
+///|
+/// Default deterministic ranker based on query/path matching.
+pub fn ContextRanker::path_match() -> ContextRanker {
+  {
+    score_summary: fn(query, key) { context_score_for_summary(query, key) },
+    reason_summary: fn(query, key) { context_reason_for_summary(query, key) },
+  }
+}
+
+///|
+fn context_score_for_summary(query : String, key : CognitionKey) -> Int {
+  match key {
+    FileSummary(path) => context_score_for_path(query, path)
+    _ => 0
+  }
+}
+
+///|
+fn context_reason_for_summary(query : String, key : CognitionKey) -> String {
+  match key {
+    FileSummary(path) => context_reason_for_path(query, path)
+    _ => "workspace artifact"
+  }
+}
+
+///|
+fn context_score_for_path(query : String, path : String) -> Int {
+  let filename = file_name_from_path(path)
+  let stem = file_stem_from_name(filename)
+  if query_contains_non_empty(query, path) {
+    100
+  } else if query_contains_non_empty(query, filename) {
+    80
+  } else if query_contains_name(query, stem) {
+    60
+  } else {
+    0
+  }
+}
+
+///|
+fn context_reason_for_path(query : String, path : String) -> String {
+  let filename = file_name_from_path(path)
+  let stem = file_stem_from_name(filename)
+  if query_contains_non_empty(query, path) {
+    "path matched query: \{path}"
+  } else if query_contains_non_empty(query, filename) {
+    "filename matched query: \{filename}"
+  } else if query_contains_name(query, stem) {
+    "name matched query: \{stem}"
+  } else {
+    "workspace file summary"
+  }
+}
+
+///|
+fn query_contains_non_empty(query : String, needle : String) -> Bool {
+  needle.length() > 0 && query.contains(needle)
+}
+
+///|
+fn query_contains_name(query : String, name : String) -> Bool {
+  name.length() > 1 && query.contains(name)
+}
+
+///|
+fn file_name_from_path(path : String) -> String {
+  match path.rev_split_once("/") {
+    Some((_, name)) => name.to_owned()
+    None => path
+  }
+}
+
+///|
+fn file_stem_from_name(filename : String) -> String {
+  match filename.rev_split_once(".") {
+    Some((stem, _)) => stem.to_owned()
+    None => filename
+  }
+}

--- a/lib/cognition/ranker_test.mbt
+++ b/lib/cognition/ranker_test.mbt
@@ -1,0 +1,32 @@
+///|
+test "custom ranker controls packed context order and reasons" {
+  let ranker : ContextRanker = {
+    score_summary: fn(_query, key) {
+      match key {
+        FileSummary("src/gamma.mbt") => 1000
+        FileSummary(_) => 0
+        _ => 0
+      }
+    },
+    reason_summary: fn(_query, key) {
+      match key {
+        FileSummary("src/gamma.mbt") => "custom preferred gamma"
+        FileSummary(path) => "custom fallback \{path}"
+        _ => "custom artifact"
+      }
+    },
+  }
+  let store = CognitionStore::new_with_provider_and_ranker(
+    CognitionProvider::mock(),
+    ranker,
+  )
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+  let _ = store.set_input(FileText("src/gamma.mbt"), Text("gamma"))
+
+  let items = store.pack_context("explain beta", 3)
+
+  inspect(items[1].source == FileSummary("src/gamma.mbt"), content="true")
+  inspect(items[1].reason, content="custom preferred gamma")
+  inspect(items[2].source == FileSummary("src/beta.mbt"), content="true")
+  inspect(items[2].reason, content="custom fallback src/beta.mbt")
+}

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -237,6 +237,8 @@ fn context_key_for_options(
   options : ContextPackOptions,
 ) -> CognitionKey {
   match options.max_chars {
+    Some(max_chars) if options.truncate_items =>
+      TruncatedContext(query, options.max_items, max_chars)
     Some(max_chars) => BudgetedContext(query, options.max_items, max_chars)
     None => PackedContext(query, options.max_items)
   }
@@ -471,6 +473,8 @@ fn CognitionStore::recompute_one(
       self.recompute_packed_context(query, max_items)
     BudgetedContext(query, max_items, max_chars) =>
       self.recompute_budgeted_context(query, max_items, max_chars)
+    TruncatedContext(query, max_items, max_chars) =>
+      self.recompute_truncated_context(query, max_items, max_chars)
   }
 }
 
@@ -586,7 +590,32 @@ fn CognitionStore::recompute_budgeted_context(
   self.store_recomputed(
     BudgetedContext(query, max_items, max_chars),
     ContextItems(
-      take_context_items_with_char_budget(items, max_items, max_chars),
+      take_context_items_with_options(
+        items,
+        ContextPackOptions::new(max_items~, max_chars~),
+      ),
+    ),
+    inputs,
+  )
+}
+
+///|
+fn CognitionStore::recompute_truncated_context(
+  self : CognitionStore,
+  query : String,
+  max_items : Int,
+  max_chars : Int,
+) -> Unit {
+  let items : Array[ContextItem] = []
+  let inputs : Array[CognitionKey] = [RepoSummary]
+  self.build_context_candidates(query, items, inputs)
+  self.store_recomputed(
+    TruncatedContext(query, max_items, max_chars),
+    ContextItems(
+      take_context_items_with_options(
+        items,
+        ContextPackOptions::new(max_items~, max_chars~, truncate_items=true),
+      ),
     ),
     inputs,
   )
@@ -677,27 +706,53 @@ fn take_context_items(
 }
 
 ///|
-fn take_context_items_with_char_budget(
+fn take_context_items_with_options(
   items : Array[ContextItem],
-  max_items : Int,
+  options : ContextPackOptions,
+) -> Array[ContextItem] {
+  match options.max_chars {
+    Some(max_chars) =>
+      take_context_items_with_budget_options(items, options, max_chars)
+    None => take_context_items(items, options.max_items)
+  }
+}
+
+///|
+fn take_context_items_with_budget_options(
+  items : Array[ContextItem],
+  options : ContextPackOptions,
   max_chars : Int,
 ) -> Array[ContextItem] {
-  if max_items <= 0 || max_chars <= 0 {
+  if options.max_items <= 0 || max_chars <= 0 {
     []
   } else {
     let selected : Array[ContextItem] = []
     let mut used_chars = 0
     for item in items {
-      if selected.length() >= max_items {
+      if selected.length() >= options.max_items {
         break
       }
-      let next_chars = used_chars + item.payload.length()
-      if next_chars <= max_chars {
+      let remaining_chars = max_chars - used_chars
+      let item_chars = item.payload.length()
+      if item_chars <= remaining_chars {
         selected.push(item)
-        used_chars = next_chars
+        used_chars += item_chars
+      } else if options.truncate_items {
+        selected.push(truncate_context_item(item, remaining_chars))
+        break
       }
     }
     selected
+  }
+}
+
+///|
+fn truncate_context_item(item : ContextItem, max_chars : Int) -> ContextItem {
+  {
+    source: item.source,
+    source_revision: item.source_revision,
+    payload: item.payload[:max_chars].to_owned(),
+    reason: item.reason + "; truncated",
   }
 }
 

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -198,12 +198,7 @@ pub fn CognitionStore::pack_context(
   query : String,
   max_items : Int,
 ) -> Array[ContextItem] {
-  let key = PackedContext(query, max_items)
-  let _ = self.compute(key)
-  match self.get_value(key) {
-    Some(ContextItems(items)) => items
-    _ => []
-  }
+  self.pack_context_with_options(query, ContextPackOptions::new(max_items~))
 }
 
 ///|
@@ -215,11 +210,35 @@ pub fn CognitionStore::pack_context_with_budget(
   max_items : Int,
   max_chars : Int,
 ) -> Array[ContextItem] {
-  let key = BudgetedContext(query, max_items, max_chars)
+  self.pack_context_with_options(
+    query,
+    ContextPackOptions::new(max_items~, max_chars~),
+  )
+}
+
+///|
+/// Build a provenance-bearing context bundle using explicit packing options.
+pub fn CognitionStore::pack_context_with_options(
+  self : CognitionStore,
+  query : String,
+  options : ContextPackOptions,
+) -> Array[ContextItem] {
+  let key = context_key_for_options(query, options)
   let _ = self.compute(key)
   match self.get_value(key) {
     Some(ContextItems(items)) => items
     _ => []
+  }
+}
+
+///|
+fn context_key_for_options(
+  query : String,
+  options : ContextPackOptions,
+) -> CognitionKey {
+  match options.max_chars {
+    Some(max_chars) => BudgetedContext(query, options.max_items, max_chars)
+    None => PackedContext(query, options.max_items)
   }
 }
 

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -182,13 +182,30 @@ pub fn CognitionStore::recompute_count(
 }
 
 ///|
-/// Build a provenance-bearing, budgeted context bundle for `query`.
+/// Build a provenance-bearing, item-budgeted context bundle for `query`.
 pub fn CognitionStore::pack_context(
   self : CognitionStore,
   query : String,
   max_items : Int,
 ) -> Array[ContextItem] {
   let key = PackedContext(query, max_items)
+  let _ = self.compute(key)
+  match self.get_value(key) {
+    Some(ContextItems(items)) => items
+    _ => []
+  }
+}
+
+///|
+/// Build a provenance-bearing context bundle constrained by item count and
+/// cumulative payload character count.
+pub fn CognitionStore::pack_context_with_budget(
+  self : CognitionStore,
+  query : String,
+  max_items : Int,
+  max_chars : Int,
+) -> Array[ContextItem] {
+  let key = BudgetedContext(query, max_items, max_chars)
   let _ = self.compute(key)
   match self.get_value(key) {
     Some(ContextItems(items)) => items
@@ -423,6 +440,8 @@ fn CognitionStore::recompute_one(
     QueryContext(query) => self.recompute_query_context(query)
     PackedContext(query, max_items) =>
       self.recompute_packed_context(query, max_items)
+    BudgetedContext(query, max_items, max_chars) =>
+      self.recompute_budgeted_context(query, max_items, max_chars)
   }
 }
 
@@ -516,12 +535,46 @@ fn CognitionStore::recompute_packed_context(
   query : String,
   max_items : Int,
 ) -> Unit {
+  let items : Array[ContextItem] = []
+  let inputs : Array[CognitionKey] = [RepoSummary]
+  self.build_context_candidates(query, items, inputs)
+  self.store_recomputed(
+    PackedContext(query, max_items),
+    ContextItems(take_context_items(items, max_items)),
+    inputs,
+  )
+}
+
+///|
+fn CognitionStore::recompute_budgeted_context(
+  self : CognitionStore,
+  query : String,
+  max_items : Int,
+  max_chars : Int,
+) -> Unit {
+  let items : Array[ContextItem] = []
+  let inputs : Array[CognitionKey] = [RepoSummary]
+  self.build_context_candidates(query, items, inputs)
+  self.store_recomputed(
+    BudgetedContext(query, max_items, max_chars),
+    ContextItems(
+      take_context_items_with_char_budget(items, max_items, max_chars),
+    ),
+    inputs,
+  )
+}
+
+///|
+fn CognitionStore::build_context_candidates(
+  self : CognitionStore,
+  query : String,
+  items : Array[ContextItem],
+  inputs : Array[CognitionKey],
+) -> Unit {
   if !self.values.contains(RepoSummary) || self.dirty.contains(RepoSummary) {
     self.recompute_repo_summary()
     self.dirty.remove(RepoSummary)
   }
-  let items : Array[ContextItem] = []
-  let inputs : Array[CognitionKey] = [RepoSummary]
   self.push_context_item(
     items,
     RepoSummary,
@@ -535,11 +588,6 @@ fn CognitionStore::recompute_packed_context(
       reason=context_reason_for_summary(query, summary_key),
     )
   }
-  self.store_recomputed(
-    PackedContext(query, max_items),
-    ContextItems(take_context_items(items, max_items)),
-    inputs,
-  )
 }
 
 ///|
@@ -595,6 +643,31 @@ fn take_context_items(
     let selected : Array[ContextItem] = []
     for i in 0..<max_items {
       selected.push(items[i])
+    }
+    selected
+  }
+}
+
+///|
+fn take_context_items_with_char_budget(
+  items : Array[ContextItem],
+  max_items : Int,
+  max_chars : Int,
+) -> Array[ContextItem] {
+  if max_items <= 0 || max_chars <= 0 {
+    []
+  } else {
+    let selected : Array[ContextItem] = []
+    let mut used_chars = 0
+    for item in items {
+      if selected.length() >= max_items {
+        break
+      }
+      let next_chars = used_chars + item.payload.length()
+      if next_chars <= max_chars {
+        selected.push(item)
+        used_chars = next_chars
+      }
     }
     selected
   }

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -527,12 +527,12 @@ fn CognitionStore::recompute_packed_context(
     RepoSummary,
     reason="workspace overview for query: \{query}",
   )
-  for summary_key in self.known_file_summary_keys() {
+  for summary_key in self.selected_file_summary_keys(query) {
     inputs.push(summary_key)
     self.push_context_item(
       items,
       summary_key,
-      reason="file summary selected for query: \{query}",
+      reason=context_reason_for_summary(query, summary_key),
     )
   }
   self.store_recomputed(
@@ -614,6 +614,24 @@ fn CognitionStore::ensure_file_summaries_for_known_texts(
 }
 
 ///|
+fn CognitionStore::selected_file_summary_keys(
+  self : CognitionStore,
+  query : String,
+) -> Array[CognitionKey] {
+  let keys = self.known_file_summary_keys()
+  keys.sort_by(fn(a, b) {
+    let score_a = context_score_for_summary(query, a)
+    let score_b = context_score_for_summary(query, b)
+    if score_a != score_b {
+      score_b.compare(score_a)
+    } else {
+      a.compare(b)
+    }
+  })
+  keys
+}
+
+///|
 fn CognitionStore::known_file_summary_keys(
   self : CognitionStore,
 ) -> Array[CognitionKey] {
@@ -625,6 +643,78 @@ fn CognitionStore::known_file_summary_keys(
     }
   }
   keys
+}
+
+///|
+fn context_score_for_summary(query : String, key : CognitionKey) -> Int {
+  match key {
+    FileSummary(path) => context_score_for_path(query, path)
+    _ => 0
+  }
+}
+
+///|
+fn context_reason_for_summary(query : String, key : CognitionKey) -> String {
+  match key {
+    FileSummary(path) => context_reason_for_path(query, path)
+    _ => "workspace artifact"
+  }
+}
+
+///|
+fn context_score_for_path(query : String, path : String) -> Int {
+  let filename = file_name_from_path(path)
+  let stem = file_stem_from_name(filename)
+  if query_contains_non_empty(query, path) {
+    100
+  } else if query_contains_non_empty(query, filename) {
+    80
+  } else if query_contains_name(query, stem) {
+    60
+  } else {
+    0
+  }
+}
+
+///|
+fn context_reason_for_path(query : String, path : String) -> String {
+  let filename = file_name_from_path(path)
+  let stem = file_stem_from_name(filename)
+  if query_contains_non_empty(query, path) {
+    "path matched query: \{path}"
+  } else if query_contains_non_empty(query, filename) {
+    "filename matched query: \{filename}"
+  } else if query_contains_name(query, stem) {
+    "name matched query: \{stem}"
+  } else {
+    "workspace file summary"
+  }
+}
+
+///|
+fn query_contains_non_empty(query : String, needle : String) -> Bool {
+  needle.length() > 0 && query.contains(needle)
+}
+
+///|
+fn query_contains_name(query : String, name : String) -> Bool {
+  name.length() > 1 && query.contains(name)
+}
+
+///|
+fn file_name_from_path(path : String) -> String {
+  match path.rev_split_once("/") {
+    Some((_, name)) => name.to_owned()
+    None => path
+  }
+}
+
+///|
+fn file_stem_from_name(filename : String) -> String {
+  match filename.rev_split_once(".") {
+    Some((stem, _)) => stem.to_owned()
+    None => filename
+  }
 }
 
 ///|

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -9,6 +9,7 @@ pub(all) struct CognitionStore {
   priv dirty : Map[CognitionKey, Bool]
   priv recompute_counts : Map[CognitionKey, Int]
   priv provider : CognitionProvider
+  priv ranker : ContextRanker
   priv reactive : CognitionReactive
 }
 
@@ -22,6 +23,18 @@ pub fn CognitionStore::new() -> CognitionStore {
 pub fn CognitionStore::new_with_provider(
   provider : CognitionProvider,
 ) -> CognitionStore {
+  CognitionStore::new_with_provider_and_ranker(
+    provider,
+    ContextRanker::path_match(),
+  )
+}
+
+///|
+/// Create a cognition store with deterministic summary and ranking policies.
+pub fn CognitionStore::new_with_provider_and_ranker(
+  provider : CognitionProvider,
+  ranker : ContextRanker,
+) -> CognitionStore {
   let dependencies : Map[CognitionKey, Array[CognitionKey]] = Map::default()
   {
     values: Map::default(),
@@ -32,6 +45,7 @@ pub fn CognitionStore::new_with_provider(
     dirty: Map::default(),
     recompute_counts: Map::default(),
     provider,
+    ranker,
     reactive: CognitionReactive::CognitionReactive(dependencies),
   }
 }
@@ -642,7 +656,7 @@ fn CognitionStore::build_context_candidates(
     self.push_context_item(
       items,
       summary_key,
-      reason=context_reason_for_summary(query, summary_key),
+      reason=(self.ranker.reason_summary)(query, summary_key),
     )
   }
 }
@@ -776,8 +790,8 @@ fn CognitionStore::selected_file_summary_keys(
 ) -> Array[CognitionKey] {
   let keys = self.known_file_summary_keys()
   keys.sort_by(fn(a, b) {
-    let score_a = context_score_for_summary(query, a)
-    let score_b = context_score_for_summary(query, b)
+    let score_a = (self.ranker.score_summary)(query, a)
+    let score_b = (self.ranker.score_summary)(query, b)
     if score_a != score_b {
       score_b.compare(score_a)
     } else {
@@ -799,78 +813,6 @@ fn CognitionStore::known_file_summary_keys(
     }
   }
   keys
-}
-
-///|
-fn context_score_for_summary(query : String, key : CognitionKey) -> Int {
-  match key {
-    FileSummary(path) => context_score_for_path(query, path)
-    _ => 0
-  }
-}
-
-///|
-fn context_reason_for_summary(query : String, key : CognitionKey) -> String {
-  match key {
-    FileSummary(path) => context_reason_for_path(query, path)
-    _ => "workspace artifact"
-  }
-}
-
-///|
-fn context_score_for_path(query : String, path : String) -> Int {
-  let filename = file_name_from_path(path)
-  let stem = file_stem_from_name(filename)
-  if query_contains_non_empty(query, path) {
-    100
-  } else if query_contains_non_empty(query, filename) {
-    80
-  } else if query_contains_name(query, stem) {
-    60
-  } else {
-    0
-  }
-}
-
-///|
-fn context_reason_for_path(query : String, path : String) -> String {
-  let filename = file_name_from_path(path)
-  let stem = file_stem_from_name(filename)
-  if query_contains_non_empty(query, path) {
-    "path matched query: \{path}"
-  } else if query_contains_non_empty(query, filename) {
-    "filename matched query: \{filename}"
-  } else if query_contains_name(query, stem) {
-    "name matched query: \{stem}"
-  } else {
-    "workspace file summary"
-  }
-}
-
-///|
-fn query_contains_non_empty(query : String, needle : String) -> Bool {
-  needle.length() > 0 && query.contains(needle)
-}
-
-///|
-fn query_contains_name(query : String, name : String) -> Bool {
-  name.length() > 1 && query.contains(name)
-}
-
-///|
-fn file_name_from_path(path : String) -> String {
-  match path.rev_split_once("/") {
-    Some((_, name)) => name.to_owned()
-    None => path
-  }
-}
-
-///|
-fn file_stem_from_name(filename : String) -> String {
-  match filename.rev_split_once(".") {
-    Some((stem, _)) => stem.to_owned()
-    None => filename
-  }
 }
 
 ///|

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -1,4 +1,10 @@
 ///|
+priv struct ContextPackSelection {
+  items : Array[ContextItem]
+  stats : ContextPackStats
+}
+
+///|
 /// Mutable store for cognition values, revisions, dependencies, and dirtiness.
 pub(all) struct CognitionStore {
   priv values : Map[CognitionKey, CognitionValue]
@@ -252,11 +258,12 @@ pub fn CognitionStore::pack_context_with_stats(
   query : String,
   options : ContextPackOptions,
 ) -> (Array[ContextItem], ContextPackStats) {
-  let items = self.pack_context_with_options(query, options)
+  let _ = self.compute(context_key_for_options(query, options))
   let candidates : Array[ContextItem] = []
   let inputs : Array[CognitionKey] = [RepoSummary]
   self.build_context_candidates(query, candidates, inputs)
-  (items, context_pack_stats(candidates.length(), items))
+  let selection = select_context_items(candidates, options)
+  (selection.items, selection.stats)
 }
 
 ///|
@@ -600,7 +607,9 @@ fn CognitionStore::recompute_packed_context(
   self.build_context_candidates(query, items, inputs)
   self.store_recomputed(
     PackedContext(query, max_items),
-    ContextItems(take_context_items(items, max_items)),
+    ContextItems(
+      select_context_items(items, ContextPackOptions::new(max_items~)).items,
+    ),
     inputs,
   )
 }
@@ -618,10 +627,10 @@ fn CognitionStore::recompute_budgeted_context(
   self.store_recomputed(
     BudgetedContext(query, max_items, max_chars),
     ContextItems(
-      take_context_items_with_options(
+      select_context_items(
         items,
         ContextPackOptions::new(max_items~, max_chars~),
-      ),
+      ).items,
     ),
     inputs,
   )
@@ -640,10 +649,10 @@ fn CognitionStore::recompute_truncated_context(
   self.store_recomputed(
     TruncatedContext(query, max_items, max_chars),
     ContextItems(
-      take_context_items_with_options(
+      select_context_items(
         items,
         ContextPackOptions::new(max_items~, max_chars~, truncate_items=true),
-      ),
+      ).items,
     ),
     inputs,
   )
@@ -716,7 +725,22 @@ fn CognitionStore::push_context_item(
 }
 
 ///|
-fn take_context_items(
+fn select_context_items(
+  candidates : Array[ContextItem],
+  options : ContextPackOptions,
+) -> ContextPackSelection {
+  match options.max_chars {
+    Some(max_chars) =>
+      select_context_items_with_char_budget(candidates, options, max_chars)
+    None => {
+      let items = select_context_items_by_count(candidates, options.max_items)
+      { items, stats: context_pack_stats(candidates.length(), items, 0) }
+    }
+  }
+}
+
+///|
+fn select_context_items_by_count(
   items : Array[ContextItem],
   max_items : Int,
 ) -> Array[ContextItem] {
@@ -734,28 +758,17 @@ fn take_context_items(
 }
 
 ///|
-fn take_context_items_with_options(
-  items : Array[ContextItem],
-  options : ContextPackOptions,
-) -> Array[ContextItem] {
-  match options.max_chars {
-    Some(max_chars) =>
-      take_context_items_with_budget_options(items, options, max_chars)
-    None => take_context_items(items, options.max_items)
-  }
-}
-
-///|
-fn take_context_items_with_budget_options(
+fn select_context_items_with_char_budget(
   items : Array[ContextItem],
   options : ContextPackOptions,
   max_chars : Int,
-) -> Array[ContextItem] {
+) -> ContextPackSelection {
   if options.max_items <= 0 || max_chars <= 0 {
-    []
+    { items: [], stats: context_pack_stats(items.length(), [], 0) }
   } else {
     let selected : Array[ContextItem] = []
     let mut used_chars = 0
+    let mut truncated_items = 0
     for item in items {
       if selected.length() >= options.max_items {
         break
@@ -765,12 +778,16 @@ fn take_context_items_with_budget_options(
       if item_chars <= remaining_chars {
         selected.push(item)
         used_chars += item_chars
-      } else if options.truncate_items {
+      } else if options.truncate_items && remaining_chars > 0 {
         selected.push(truncate_context_item(item, remaining_chars))
+        truncated_items += 1
         break
       }
     }
-    selected
+    {
+      items: selected,
+      stats: context_pack_stats(items.length(), selected, truncated_items),
+    }
   }
 }
 
@@ -779,23 +796,36 @@ fn truncate_context_item(item : ContextItem, max_chars : Int) -> ContextItem {
   {
     source: item.source,
     source_revision: item.source_revision,
-    payload: item.payload[:max_chars].to_owned(),
+    payload: safe_prefix_by_code_units(item.payload, max_chars),
     reason: item.reason + "; truncated",
   }
+}
+
+///|
+fn safe_prefix_by_code_units(text : String, max_units : Int) -> String {
+  let chunks : Array[String] = []
+  let mut used_units = 0
+  for ch in text {
+    let chunk = "\{ch}"
+    let next_units = used_units + chunk.length()
+    if next_units > max_units {
+      break
+    }
+    chunks.push(chunk)
+    used_units = next_units
+  }
+  chunks.join("")
 }
 
 ///|
 fn context_pack_stats(
   candidate_count : Int,
   items : Array[ContextItem],
+  truncated_items : Int,
 ) -> ContextPackStats {
   let mut payload_chars = 0
-  let mut truncated_items = 0
   for item in items {
     payload_chars += item.payload.length()
-    if item.reason.contains("; truncated") {
-      truncated_items += 1
-    }
   }
   {
     selected_items: items.length(),

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -8,11 +8,20 @@ pub(all) struct CognitionStore {
   priv reverse_dependencies : Map[CognitionKey, Array[CognitionKey]]
   priv dirty : Map[CognitionKey, Bool]
   priv recompute_counts : Map[CognitionKey, Int]
+  priv provider : CognitionProvider
   priv reactive : CognitionReactive
 }
 
 ///|
 pub fn CognitionStore::new() -> CognitionStore {
+  CognitionStore::new_with_provider(CognitionProvider::mock())
+}
+
+///|
+/// Create a cognition store with a deterministic summary provider.
+pub fn CognitionStore::new_with_provider(
+  provider : CognitionProvider,
+) -> CognitionStore {
   let dependencies : Map[CognitionKey, Array[CognitionKey]] = Map::default()
   {
     values: Map::default(),
@@ -22,6 +31,7 @@ pub fn CognitionStore::new() -> CognitionStore {
     reverse_dependencies: Map::default(),
     dirty: Map::default(),
     recompute_counts: Map::default(),
+    provider,
     reactive: CognitionReactive::CognitionReactive(dependencies),
   }
 }
@@ -485,7 +495,7 @@ fn CognitionStore::recompute_file_summary(
   }
   self.store_recomputed(
     FileSummary(path),
-    Summary(mock_file_summary(path, text)),
+    Summary((self.provider.file_summary)(path, text)),
     [input],
   )
 }
@@ -501,12 +511,11 @@ fn CognitionStore::recompute_repo_summary(self : CognitionStore) -> Unit {
       _ => ()
     }
   }
-  let summary = if items.length() == 0 {
-    "repo summary: <empty>"
-  } else {
-    "repo summary:\n" + items.join("\n")
-  }
-  self.store_recomputed(RepoSummary, Summary(summary), summary_keys)
+  self.store_recomputed(
+    RepoSummary,
+    Summary((self.provider.repo_summary)(items.copy())),
+    summary_keys,
+  )
 }
 
 ///|
@@ -798,21 +807,4 @@ fn CognitionValue::copy_value(self : CognitionValue) -> CognitionValue {
     ContextBundle(items) => ContextBundle(items.copy())
     ContextItems(items) => ContextItems(items.copy())
   }
-}
-
-///|
-fn mock_file_summary(path : String, text : String) -> String {
-  let line_count = if text == "" { 0 } else { count_lines(text) }
-  "\{path}: \{line_count} lines, \{text.length()} chars"
-}
-
-///|
-fn count_lines(text : String) -> Int {
-  let mut lines = 1
-  for ch in text {
-    if ch == '\n' {
-      lines += 1
-    }
-  }
-  lines
 }

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -246,6 +246,20 @@ pub fn CognitionStore::pack_context_with_options(
 }
 
 ///|
+/// Build context and return deterministic selection telemetry.
+pub fn CognitionStore::pack_context_with_stats(
+  self : CognitionStore,
+  query : String,
+  options : ContextPackOptions,
+) -> (Array[ContextItem], ContextPackStats) {
+  let items = self.pack_context_with_options(query, options)
+  let candidates : Array[ContextItem] = []
+  let inputs : Array[CognitionKey] = [RepoSummary]
+  self.build_context_candidates(query, candidates, inputs)
+  (items, context_pack_stats(candidates.length(), items))
+}
+
+///|
 fn context_key_for_options(
   query : String,
   options : ContextPackOptions,
@@ -767,6 +781,27 @@ fn truncate_context_item(item : ContextItem, max_chars : Int) -> ContextItem {
     source_revision: item.source_revision,
     payload: item.payload[:max_chars].to_owned(),
     reason: item.reason + "; truncated",
+  }
+}
+
+///|
+fn context_pack_stats(
+  candidate_count : Int,
+  items : Array[ContextItem],
+) -> ContextPackStats {
+  let mut payload_chars = 0
+  let mut truncated_items = 0
+  for item in items {
+    payload_chars += item.payload.length()
+    if item.reason.contains("; truncated") {
+      truncated_items += 1
+    }
+  }
+  {
+    selected_items: items.length(),
+    skipped_items: candidate_count - items.length(),
+    truncated_items,
+    payload_chars,
   }
 }
 

--- a/lib/cognition/store.mbt
+++ b/lib/cognition/store.mbt
@@ -182,6 +182,21 @@ pub fn CognitionStore::recompute_count(
 }
 
 ///|
+/// Build a provenance-bearing, budgeted context bundle for `query`.
+pub fn CognitionStore::pack_context(
+  self : CognitionStore,
+  query : String,
+  max_items : Int,
+) -> Array[ContextItem] {
+  let key = PackedContext(query, max_items)
+  let _ = self.compute(key)
+  match self.get_value(key) {
+    Some(ContextItems(items)) => items
+    _ => []
+  }
+}
+
+///|
 /// Mark one artifact and all of its dependents dirty.
 pub fn CognitionStore::mark_dirty(
   self : CognitionStore,
@@ -406,6 +421,8 @@ fn CognitionStore::recompute_one(
     FileSummary(path) => self.recompute_file_summary(path)
     RepoSummary => self.recompute_repo_summary()
     QueryContext(query) => self.recompute_query_context(query)
+    PackedContext(query, max_items) =>
+      self.recompute_packed_context(query, max_items)
   }
 }
 
@@ -494,6 +511,96 @@ fn CognitionStore::recompute_query_context(
 }
 
 ///|
+fn CognitionStore::recompute_packed_context(
+  self : CognitionStore,
+  query : String,
+  max_items : Int,
+) -> Unit {
+  if !self.values.contains(RepoSummary) || self.dirty.contains(RepoSummary) {
+    self.recompute_repo_summary()
+    self.dirty.remove(RepoSummary)
+  }
+  let items : Array[ContextItem] = []
+  let inputs : Array[CognitionKey] = [RepoSummary]
+  self.push_context_item(
+    items,
+    RepoSummary,
+    reason="workspace overview for query: \{query}",
+  )
+  for summary_key in self.known_file_summary_keys() {
+    inputs.push(summary_key)
+    self.push_context_item(
+      items,
+      summary_key,
+      reason="file summary selected for query: \{query}",
+    )
+  }
+  self.store_recomputed(
+    PackedContext(query, max_items),
+    ContextItems(take_context_items(items, max_items)),
+    inputs,
+  )
+}
+
+///|
+fn CognitionStore::push_context_item(
+  self : CognitionStore,
+  items : Array[ContextItem],
+  source : CognitionKey,
+  reason~ : String,
+) -> Unit {
+  match self.values.get(source) {
+    Some(Summary(payload)) =>
+      items.push({
+        source,
+        source_revision: self.revisions.get(source).unwrap_or(Revision(0)),
+        payload,
+        reason,
+      })
+    Some(Text(payload)) =>
+      items.push({
+        source,
+        source_revision: self.revisions.get(source).unwrap_or(Revision(0)),
+        payload,
+        reason,
+      })
+    Some(ContextBundle(lines)) =>
+      items.push({
+        source,
+        source_revision: self.revisions.get(source).unwrap_or(Revision(0)),
+        payload: lines.join("\n"),
+        reason,
+      })
+    Some(ContextItems(context_items)) =>
+      items.push({
+        source,
+        source_revision: self.revisions.get(source).unwrap_or(Revision(0)),
+        payload: context_items.map(fn(item) { item.payload }).join("\n"),
+        reason,
+      })
+    None => ()
+  }
+}
+
+///|
+fn take_context_items(
+  items : Array[ContextItem],
+  max_items : Int,
+) -> Array[ContextItem] {
+  if max_items <= 0 {
+    []
+  } else if items.length() <= max_items {
+    items.copy()
+  } else {
+    let selected : Array[ContextItem] = []
+    for i in 0..<max_items {
+      selected.push(items[i])
+    }
+    selected
+  }
+}
+
+///|
 fn CognitionStore::ensure_file_summaries_for_known_texts(
   self : CognitionStore,
 ) -> Unit {
@@ -526,6 +633,7 @@ fn CognitionValue::copy_value(self : CognitionValue) -> CognitionValue {
     Text(value) => Text(value)
     Summary(value) => Summary(value)
     ContextBundle(items) => ContextBundle(items.copy())
+    ContextItems(items) => ContextItems(items.copy())
   }
 }
 

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -39,6 +39,22 @@ pub(all) struct ContextItem {
 } derive(Debug, Eq)
 
 ///|
+/// Options for deterministic context packing.
+pub(all) struct ContextPackOptions {
+  max_items : Int
+  max_chars : Int?
+} derive(Debug, Eq)
+
+///|
+/// Create context packing options.
+pub fn ContextPackOptions::new(
+  max_items~ : Int,
+  max_chars? : Int,
+) -> ContextPackOptions {
+  { max_items, max_chars }
+}
+
+///|
 /// Monotonic store-local revision. The first stored value receives revision 1.
 pub struct Revision(Int) derive(Debug, Eq, Hash, Compare)
 

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -6,6 +6,7 @@ pub(all) enum CognitionKey {
   RepoSummary
   QueryContext(String)
   PackedContext(String, Int)
+  BudgetedContext(String, Int, Int)
 } derive(Debug, Eq, Hash, Compare)
 
 ///|
@@ -51,5 +52,7 @@ pub fn CognitionKey::label(self : CognitionKey) -> String {
     RepoSummary => "RepoSummary"
     QueryContext(query) => "QueryContext(\{query})"
     PackedContext(query, max_items) => "PackedContext(\{query}, \{max_items})"
+    BudgetedContext(query, max_items, max_chars) =>
+      "BudgetedContext(\{query}, \{max_items}, \{max_chars})"
   }
 }

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -7,6 +7,7 @@ pub(all) enum CognitionKey {
   QueryContext(String)
   PackedContext(String, Int)
   BudgetedContext(String, Int, Int)
+  TruncatedContext(String, Int, Int)
 } derive(Debug, Eq, Hash, Compare)
 
 ///|
@@ -43,6 +44,7 @@ pub(all) struct ContextItem {
 pub(all) struct ContextPackOptions {
   max_items : Int
   max_chars : Int?
+  truncate_items : Bool
 } derive(Debug, Eq)
 
 ///|
@@ -50,8 +52,9 @@ pub(all) struct ContextPackOptions {
 pub fn ContextPackOptions::new(
   max_items~ : Int,
   max_chars? : Int,
+  truncate_items? : Bool = false,
 ) -> ContextPackOptions {
-  { max_items, max_chars }
+  { max_items, max_chars, truncate_items }
 }
 
 ///|
@@ -81,5 +84,7 @@ pub fn CognitionKey::label(self : CognitionKey) -> String {
     PackedContext(query, max_items) => "PackedContext(\{query}, \{max_items})"
     BudgetedContext(query, max_items, max_chars) =>
       "BudgetedContext(\{query}, \{max_items}, \{max_chars})"
+    TruncatedContext(query, max_items, max_chars) =>
+      "TruncatedContext(\{query}, \{max_items}, \{max_chars})"
   }
 }

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -5,6 +5,7 @@ pub(all) enum CognitionKey {
   FileSummary(String)
   RepoSummary
   QueryContext(String)
+  PackedContext(String, Int)
 } derive(Debug, Eq, Hash, Compare)
 
 ///|
@@ -13,6 +14,16 @@ pub(all) enum CognitionValue {
   Text(String)
   Summary(String)
   ContextBundle(Array[String])
+  ContextItems(Array[ContextItem])
+} derive(Debug, Eq)
+
+///|
+/// One provenance-bearing item selected for an AI context bundle.
+pub(all) struct ContextItem {
+  source : CognitionKey
+  source_revision : Revision
+  payload : String
+  reason : String
 } derive(Debug, Eq)
 
 ///|
@@ -39,5 +50,6 @@ pub fn CognitionKey::label(self : CognitionKey) -> String {
     FileSummary(path) => "FileSummary(\{path})"
     RepoSummary => "RepoSummary"
     QueryContext(query) => "QueryContext(\{query})"
+    PackedContext(query, max_items) => "PackedContext(\{query}, \{max_items})"
   }
 }

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -55,6 +55,15 @@ pub(all) struct ContextPackOptions {
 } derive(Debug, Eq)
 
 ///|
+/// Deterministic telemetry for one context packing operation.
+pub(all) struct ContextPackStats {
+  selected_items : Int
+  skipped_items : Int
+  truncated_items : Int
+  payload_chars : Int
+} derive(Debug, Eq)
+
+///|
 /// Create context packing options.
 pub fn ContextPackOptions::new(
   max_items~ : Int,

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -10,7 +10,11 @@ pub(all) enum CognitionKey {
 } derive(Debug, Eq, Hash, Compare)
 
 ///|
-/// Deterministic provider for deriving cognition summaries.
+/// Deterministic, synchronous provider for deriving cognition summaries.
+///
+/// Providers produce values only. They must not own or mutate graph state; the
+/// store remains responsible for copying values, revisions, dependencies, dirty
+/// state, and artifact lifetime.
 pub(all) struct CognitionProvider {
   file_summary : (String, String) -> String
   repo_summary : (Array[String]) -> String

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -40,6 +40,13 @@ pub(all) struct ContextItem {
 } derive(Debug, Eq)
 
 ///|
+/// Deterministic policy for ranking and explaining context candidates.
+pub(all) struct ContextRanker {
+  score_summary : (String, CognitionKey) -> Int
+  reason_summary : (String, CognitionKey) -> String
+}
+
+///|
 /// Options for deterministic context packing.
 pub(all) struct ContextPackOptions {
   max_items : Int

--- a/lib/cognition/types.mbt
+++ b/lib/cognition/types.mbt
@@ -10,6 +10,13 @@ pub(all) enum CognitionKey {
 } derive(Debug, Eq, Hash, Compare)
 
 ///|
+/// Deterministic provider for deriving cognition summaries.
+pub(all) struct CognitionProvider {
+  file_summary : (String, String) -> String
+  repo_summary : (Array[String]) -> String
+}
+
+///|
 /// Stored value for a cognition artifact.
 pub(all) enum CognitionValue {
   Text(String)


### PR DESCRIPTION
## Summary
- add provenance-bearing packed context artifacts with deterministic query/path ranking
- add item/character budgets, optional truncation, and pack telemetry
- add deterministic provider and ranker seams plus checked package examples
- add graph invariant coverage for context artifacts

## Validation
- moon -C lib/cognition check
- moon -C lib/cognition test
- moon -C lib/cognition check --deny-warn
- moon check
- moon test
