### PR TITLE
docs(cognition): archive completed recompute cleanup

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -390,10 +390,9 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 
 ## 19. Cognition Runtime
 
-- [ ] Tighten cognition runtime dependency cleanup before moving artifacts into `@incr`.
-  Why: PR #355/#357 made the minimal runtime useful enough that stale-edge cleanup and graph invariant tests are the next risk; dynamic `@incr` artifact cells would add lifecycle complexity before those invariants are pinned.
-  Plan: `docs/plans/2026-05-26-cognition-runtime-recompute-strategy.md`
-  Exit: explicit file removal and dependency replacement have tests proving no deleted-path dependency edges remain after cleanup/recompute, with existing cognition behavior unchanged.
+- [ ] Draft real provider-boundary design before adding LLM/network calls.
+  Why: PR #359 shipped deterministic synchronous provider/ranker seams and provenance-packed context; real provider integration needs explicit async, cancellation, error, and lifetime semantics before code changes.
+  Exit: a canonical plan/design specifies provider call placement (graph artifact vs external effect), async shape, cancellation behavior, typed errors/retries, deterministic test doubles, and validation boundaries. No real network/LLM code lands in this step.
 
 ## Shipped history
 

--- a/docs/archive/2026-05-26-cognition-runtime-recompute-strategy.md
+++ b/docs/archive/2026-05-26-cognition-runtime-recompute-strategy.md
@@ -1,5 +1,11 @@
 # Cognition Runtime Recompute Strategy Follow-up
 
+> **Archived 2026-05-26.** This dependency-cleanup follow-up shipped in
+> PR #358 (`4c5e0bb`): deleted-file dependency edges are cleaned, graph
+> invariants are tested, caller-string path identity is pinned, and rename/move
+> semantics are documented as delete+add. It is no longer an active
+> `docs/TODO.md` item.
+
 ## Why
 
 PR #355 added the minimal cognition runtime; PR #357 added workspace file


### PR DESCRIPTION
## Summary

- archive the completed cognition recompute cleanup plan shipped by PR #358
- replace the stale cognition TODO with provider-boundary design as the next planning task
- keep real LLM/network integration explicitly out of this cleanup

## Validation

Docs-only change; no MoonBit validation required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap with new design planning task for the Cognition Runtime component.
  * Added archive notice to a previous strategy document, marking it as superseded by current planning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->