### PR TITLE
refactor(lambda): adopt loom LambdaAnalysis attachment

### DIFF
--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -10,33 +10,8 @@
 priv struct LambdaHandle {
   editor : @editor.SyncEditor[@ast.Term]
   companion : @lang_lambda.LambdaCompanion
-  typecheck : TypecheckBundle
   editor_id : @workspace.EditorId
   cells : LambdaProtectedCells
-}
-
-///|
-/// Typecheck pipeline cells. `scope` disposal handles owned per-def cells;
-/// rooting of `output` is the caller's responsibility — under §P0b Phase 1,
-/// `LambdaProtectedCells` constructs the `Watch` via
-/// `ProtectedCell::from_derived` (`protected_cells.mbt` `typecheck_output`).
-priv struct TypecheckBundle {
-  scope : @cells.Scope
-  output : @cells.Derived[@typecheck.ModuleTypeResult]
-}
-
-///|
-fn new_typecheck_bundle(
-  rt : @cells.Runtime,
-  syntax_tree : @cells.Derived[@seam.SyntaxNode],
-) -> TypecheckBundle {
-  let scope = @cells.Scope::new(rt)
-  let typed_term_memo : @cells.Derived[@typecheck.TypedTerm] = scope.derived(
-    fn() { @typecheck.convert_from_cst(syntax_tree.get_or_abort()) },
-    label="lambda-typed-term",
-  )
-  let output = @typecheck.build_typecheck_pipeline(rt, scope, typed_term_memo)
-  { scope, output }
 }
 
 ///|
@@ -52,8 +27,8 @@ let lambda_handles : Map[Int, LambdaHandle] = Map::default()
 let last_created_handle : Ref[Int?] = { val: None }
 
 ///|
-/// Build a Lambda editor + companion + typecheck bundle on the shared
-/// runtime, then atomically register them with the coordinator. Returns
+/// Build a Lambda editor + companion on the shared runtime, then
+/// atomically register them with the coordinator. Returns
 /// the freshly-allocated `EditorId`. Aborting at any step leaves
 /// `lambda_handles` untouched (atomic-boundary observation, spec §8.3).
 fn assemble_lambda_handle(
@@ -65,24 +40,12 @@ fn assemble_lambda_handle(
     capture_timeout_ms~,
     parent_runtime=coordinator.runtime(),
   )
-  let typecheck = new_typecheck_bundle(
-    editor.parser_runtime(),
-    editor.parser_syntax_tree(),
-  )
-  let cells = LambdaProtectedCells::LambdaProtectedCells(
-    editor, companion, typecheck,
-  )
+  let cells = LambdaProtectedCells::LambdaProtectedCells(editor, companion)
   let editor_id = coordinator.register_editor(
     agent_id,
     cells.to_protected_reads(),
   )
-  lambda_handles[editor_id.0] = {
-    editor,
-    companion,
-    typecheck,
-    editor_id,
-    cells,
-  }
+  lambda_handles[editor_id.0] = { editor, companion, editor_id, cells }
   last_created_handle.val = Some(editor_id.0)
   editor_id
 }
@@ -122,8 +85,8 @@ pub fn create_editor(agent_id : String) -> Int {
 ///|
 /// Destroy an editor instance and free its resources. The coordinator
 /// gateway refuses if workspace deps still reference the editor; in that
-/// case the FFI-side bookkeeping (lambda_handles entry, typecheck scope)
-/// is intentionally left intact so reads of cached state remain valid.
+/// case the FFI-side bookkeeping and analysis attachment are intentionally
+/// left intact so reads of cached state remain valid.
 pub fn destroy_editor(handle : Int) -> Unit {
   let h = match lambda_handles.get(handle) {
     Some(v) => v
@@ -138,19 +101,19 @@ pub fn destroy_editor(handle : Int) -> Unit {
       return
     }
   }
-  // Remove FFI-side bookkeeping BEFORE disposing the typecheck scope. If
-  // scope.dispose ever raises (e.g., loom-side cleanup defect), the
-  // externally-visible state still reflects reality: the handle is gone,
-  // subsequent FFI calls on it return the empty/default fallback path. A
-  // leaked scope is observable only via incr-level inspection; a leaked
-  // lambda_handles entry would be observable as a phantom editor.
+  // Remove FFI-side bookkeeping BEFORE disposing the analysis attachment. If
+  // dispose ever raises (e.g., loom-side cleanup defect), the externally-visible
+  // state still reflects reality: the handle is gone, subsequent FFI calls on it
+  // return the empty/default fallback path. A leaked attachment is observable
+  // only via incr-level inspection; a leaked lambda_handles entry would be
+  // observable as a phantom editor.
   lambda_handles.remove(handle)
   view_states.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
   }
-  h.typecheck.scope.dispose()
+  h.companion.dispose_analysis_attachment()
 }
 
 ///|

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -107,12 +107,12 @@ test "spec §12 #2: destroy refused while depended-upon; succeeds after unregist
     Ok(_) => ()
     Err(report) => fail("expected Ok after unregister_dep, got \{report}")
   }
-  // We bypassed the FFI `destroy_editor` wrapper, so the typecheck scope
+  // We bypassed the FFI `destroy_editor` wrapper, so the analysis attachment
   // and FFI bookkeeping are still in place. Drain them so subsequent
   // tests don't trip over the lingering handle. We cannot route through
   // `destroy_editor(handle)` again because the coordinator has already
   // marked the registration alive=false.
-  h.typecheck.scope.dispose()
+  h.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle)
   view_states.remove(handle)
   pretty_view_states.remove(handle)
@@ -212,7 +212,7 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
   }
   // Post-destroy must collapse to "[]" via the Err arm of read_protected.
   assert_eq(get_diagnostics_json(handle), "[]")
-  h.typecheck.scope.dispose()
+  h.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle)
   view_states.remove(handle)
   pretty_view_states.remove(handle)
@@ -243,7 +243,7 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
     Err(report) => fail("coordinator destroy: \{report}")
   }
   assert_eq(get_diagnostics_json(handle), "[]")
-  h.typecheck.scope.dispose()
+  h.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle)
   view_states.remove(handle)
   pretty_view_states.remove(handle)

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -11,7 +11,6 @@ import {
   "dowdiness/lambda/typecheck",
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",
-  "dowdiness/incr/cells",
   "dowdiness/event-graph-walker/text",
   "moonbitlang/async/js_async",
   "moonbitlang/core/buffer",

--- a/ffi/lambda/protected_cells.mbt
+++ b/ffi/lambda/protected_cells.mbt
@@ -3,8 +3,8 @@
 //
 // Each field wraps an editor or companion `Derived[T]` in a long-lived
 // `Watch` (the GC root) via `ProtectedCell::from_derived`. The bundle is
-// constructed from a freshly-built editor + companion + typecheck bundle
-// inside `assemble_lambda_handle` (lifecycle.mbt) and erased to
+// constructed from a freshly-built editor + companion inside
+// `assemble_lambda_handle` (lifecycle.mbt) and erased to
 // `Array[ProtectedRead]` for registration with the coordinator.
 //
 // See docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md §8.1.
@@ -34,7 +34,6 @@ priv struct LambdaProtectedCells {
 fn LambdaProtectedCells::LambdaProtectedCells(
   editor : @editor.SyncEditor[@ast.Term],
   companion : @lang_lambda.LambdaCompanion,
-  typecheck : TypecheckBundle,
 ) -> LambdaProtectedCells {
   {
     parser_syntax_tree: @workspace.ProtectedCell::from_derived(
@@ -75,7 +74,7 @@ fn LambdaProtectedCells::LambdaProtectedCells(
     ),
     typecheck_output: @workspace.ProtectedCell::from_derived(
       "typecheck_pipeline",
-      typecheck.output,
+      companion.typecheck_output(),
     ),
   }
 }

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -10,6 +10,7 @@ pub struct LambdaCompanion {
   // Escalation memo merges Tier 1 (direct) + Tier 2 (egglog) results.
   // Falls back to Tier 1 results when no definitions are Suppressed.
   priv escalation_memo : @incr.Derived[Array[@lambda_eval.EvalResult]]
+  priv analysis : @parser.LambdaAnalysis
 }
 
 ///|
@@ -28,6 +29,23 @@ pub fn LambdaCompanion::escalation_memo(
   self : LambdaCompanion,
 ) -> @incr.Derived[Array[@lambda_eval.EvalResult]] {
   self.escalation_memo
+}
+
+///|
+/// Reactive view of the lambda analysis typecheck result for FFI protected cells.
+pub fn LambdaCompanion::typecheck_output(
+  self : LambdaCompanion,
+) -> @incr.Derived[@typecheck.ModuleTypeResult] {
+  self.analysis.typecheck.result
+}
+
+///|
+/// Dispose only the analysis attachment rooted on the editor parser.
+/// FFI lifecycle calls this after protected watches are disposed.
+pub fn LambdaCompanion::dispose_analysis_attachment(
+  self : LambdaCompanion,
+) -> Unit {
+  self.analysis.dispose()
 }
 
 ///|
@@ -127,6 +145,7 @@ pub fn new_lambda_editor(
   let escalation_memo_ref : Ref[@incr.Derived[Array[@lambda_eval.EvalResult]]?] = Ref(
     None,
   )
+  let analysis_ref : Ref[@parser.LambdaAnalysis?] = Ref(None)
   let cached_proj_node_ref : Ref[@incr.Derived[@core.ProjNode[@ast.Term]?]?] = Ref(
     None,
   )
@@ -139,6 +158,7 @@ pub fn new_lambda_editor(
       )
       proj_memo_ref.val = Some(proj_memo)
       cached_proj_node_ref.val = Some(cached_proj_node)
+      analysis_ref.val = Some(@parser.attach_lambda_analysis(parser))
       let eval_memo = @lambda_eval.build_eval_memo(parser)
       // Escalation memo: merges Tier 1 + Tier 2 for incomplete programs
       let escalation_memo = @lambda_eval.build_escalation_memo(
@@ -156,6 +176,7 @@ pub fn new_lambda_editor(
   let companion : LambdaCompanion = {
     proj_memo: proj_memo_ref.val.unwrap(),
     escalation_memo: escalation_memo_ref.val.unwrap(),
+    analysis: analysis_ref.val.unwrap(),
   }
   (editor, companion)
 }

--- a/lang/lambda/companion/moon.pkg
+++ b/lang/lambda/companion/moon.pkg
@@ -9,6 +9,7 @@ import {
   "dowdiness/incr",
   "dowdiness/lambda" @parser,
   "dowdiness/lambda/ast",
+  "dowdiness/lambda/typecheck",
   "dowdiness/loom",
   "dowdiness/pretty",
   "dowdiness/seam",

--- a/lang/lambda/companion/pkg.generated.mbti
+++ b/lang/lambda/companion/pkg.generated.mbti
@@ -12,6 +12,7 @@ import {
   "dowdiness/incr/cells",
   "dowdiness/lambda",
   "dowdiness/lambda/ast",
+  "dowdiness/lambda/typecheck",
 }
 
 // Values
@@ -35,11 +36,13 @@ pub fn parse_tree_edit_op(Json) -> @edits.TreeEditOp raise @editor.TreeEditError
 pub struct LambdaCompanion {
   // private fields
 }
+pub fn LambdaCompanion::dispose_analysis_attachment(Self) -> Unit
 pub fn LambdaCompanion::escalation_memo(Self) -> @cells.Derived[Array[@eval.EvalResult]]
 pub fn LambdaCompanion::get_eval_annotations(Self, @core.ProjNode[@ast.Term]?) -> Map[@core.NodeId, Array[@protocol.ViewAnnotation]]
 pub fn LambdaCompanion::get_eval_results(Self) -> Array[@eval.EvalResult]
 pub fn LambdaCompanion::get_flat_proj(Self) -> @proj.FlatProj?
 pub fn LambdaCompanion::proj_memo(Self) -> @cells.Derived[@flat.VersionedFlatProj]
+pub fn LambdaCompanion::typecheck_output(Self) -> @cells.Derived[@typecheck.ModuleTypeResult]
 
 // Type aliases
 


### PR DESCRIPTION
## Summary
- bump loom to merged LambdaAnalysis API commit and attach analysis to the existing Lambda parser
- remove the parent FFI-local duplicate typecheck bundle
- keep diagnostics JSON assembly stable while routing typecheck output through the attached analysis

## Validation
- moon check
- moon check --deny-warn
- moon test ffi/lambda
- cd loom/examples/lambda && moon test
- moon test
- moon build --target js
- git diff --check

## Notes
- Uses attach_lambda_analysis(existing_parser); does not construct LambdaAnalysis(source) or a second parser/runtime.