### PR TITLE
docs(cognition): retarget provider boundary follow-up

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -390,10 +390,10 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 
 ## 19. Cognition Runtime
 
-- [ ] Draft real provider-boundary design before adding LLM/network calls.
-  Why: PR #359 shipped deterministic synchronous provider/ranker seams and provenance-packed context; real provider integration needs explicit async, cancellation, error, and lifetime semantics before code changes.
+- [ ] Implement the provider-boundary contract before adding real LLM/network calls.
+  Why: PR #363 pinned the async/error/cancellation design; the next risk is landing request planning, explicit completion, typed status/errors, and deterministic driver tests without repurposing the synchronous provider/ranker policy seams for transport.
   Plan: `docs/plans/2026-05-26-cognition-provider-boundary-design.md`
-  Exit: the plan specifies provider call placement (graph artifact vs external effect), async shape, cancellation behavior, typed errors/retries, deterministic test doubles, and validation boundaries. No real network/LLM code lands in this step.
+  Exit: `lib/cognition` exposes an engine-agnostic request/completion contract with cancellation, stale-completion checks, typed provider errors/status, deterministic scripted driver coverage, and optional internal `@incr` planning/status cells. No real network/LLM code lands in this step.
 
 ## Shipped history
 

--- a/docs/plans/2026-05-26-cognition-provider-boundary-design.md
+++ b/docs/plans/2026-05-26-cognition-provider-boundary-design.md
@@ -13,10 +13,14 @@ Design the provider boundary before implementation so future work does not
 smuggle network effects into `CognitionStore` recomputation or into the current
 plain callback seams.
 
-## Scope
+## Status
 
-This PR is design-only: it adds this canonical plan and the `docs/TODO.md`
-pointer. The implementation plan below is the intended follow-up surface.
+Design shipped in PR #363 (`07d4039`). This file remains the active
+implementation plan for the provider-boundary contract. Keep real provider
+clients, credentials, and network transport out of scope until the boundary
+implementation and deterministic driver tests land.
+
+## Scope
 
 In:
 - `docs/architecture/cognition-runtime.md`
@@ -356,22 +360,29 @@ and typed failures before transport code exists.
 
 ## Implementation Steps
 
-1. Write the concrete API design for request descriptors, result descriptors,
-   cancellation handles, option provenance, and typed provider errors.
-2. Add deterministic data types plus an internal `@incr` planning/status graph:
+Recommended PR slicing:
+
+1. Retarget the active TODO from design drafting to boundary implementation.
+2. Add pure domain types for request descriptors, result descriptors,
+   cancellation handles, option provenance, dependency fingerprints, typed
+   provider errors, and retry/status classification. Keep this PR free of driver
+   scheduling and network code.
+3. Add request planning, cancellation, and explicit completion APIs. Completion
+   must validate request id, option fingerprint, source revisions, and
+   dependency-set fingerprint.
+4. Add stale-completion tests for file edits, file removal, context budget/ranker
+   selection changes, user cancellation, and driver shutdown semantics.
+5. Add deterministic data types plus an internal `@incr` planning/status graph:
    inputs for request intent, cancellation, completion/error records, and fake
    time; derived cells for request descriptors, dependency fingerprints, status,
    retry classification, and next driver action.
-3. Add `Scope`/`Watch` lifecycle tests for long-lived keyed request-planning
+6. Add `Scope`/`Watch` lifecycle tests for long-lived keyed request-planning
    cells before exposing any driver surface.
-4. Add request planning, cancellation, and explicit completion APIs. Completion
-   must validate request id, option fingerprint, source revisions, and
-   dependency-set fingerprint.
-5. Add a scripted provider driver test harness with no HTTP client.
-6. Update architecture and README examples to show the boundary and reiterate
+7. Add a scripted provider driver test harness with no HTTP client.
+8. Update architecture and README examples to show the boundary and reiterate
    that current synchronous provider/ranker callbacks remain deterministic
    policy seams.
-7. Only after the boundary tests pass, open a separate provider-client plan for a
+9. Only after the boundary tests pass, open a separate provider-client plan for a
    specific backend/provider.
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

- Retarget the active cognition TODO from design drafting to provider-boundary implementation.
- Mark the provider-boundary plan as design-shipped in PR #363 while keeping it active for implementation.
- Split the implementation steps into reviewable PR slices before any real LLM/network client work.

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal implementation planning documentation for upcoming runtime work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->