### PR TITLE
test(ffi/lambda): §P0b first real workspace memo smoke wbtest

### DIFF
--- a/docs/superpowers/plans/2026-05-28-p0b-first-workspace-memo-implementation.md
+++ b/docs/superpowers/plans/2026-05-28-p0b-first-workspace-memo-implementation.md
@@ -1,0 +1,548 @@
+# §P0b First Real Workspace Memo (Smoke Wiring Proof) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a wbtest in `ffi/lambda/workspace_memo_smoke_wbtest.mbt` that drives `@workspace.Coordinator::register_dep` / `unregister_dep` / `destroy_editor` gateway / `read_protected` against the first **real-cell** workspace memo (an `@incr.Derived[Int]` summing two Lambda editors' `parser_source` lengths through the global `coordinator` singleton).
+
+**Architecture:** One new wbtest file in `ffi/lambda/`, four `test "..."` blocks (sanity / reactivity / destroy refusal / clean teardown assertions). No new production code, no new public API, no `.mbti` changes. Each test fully sets up and tears down its own coordinator state per spec §3.7 (helper at `ffi/lambda/lifecycle_phase1_wbtest.mbt:11` only clears FFI handle maps; coordinator state leaks across tests, but freshly-allocated monotonic `EditorId`s prevent cross-test correctness coupling).
+
+**Tech Stack:** MoonBit (whitebox tests), `@workspace.Coordinator` (`workspace/coordinator/methods.mbt`), `@incr.Runtime`/`Derived`/`Watch` (loom/incr), `@editor.SyncEditor`, `assemble_lambda_handle` factory (`ffi/lambda/lifecycle.mbt:34`).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md` (v1 + Codex round-1 + round-2 fixes inline).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `ffi/lambda/workspace_memo_smoke_wbtest.mbt` | Create | The 4-test wbtest. ~120 LOC including required per-test bypass-destroy cleanup. |
+| `ffi/lambda/moon.pkg.json` | None | No changes — wbtests live in the same package; no new deps. |
+| `ffi/lambda/pkg.generated.mbti` | None expected | No public API change. Verification step confirms. |
+
+---
+
+## Cross-task reference: bypass-destroy cleanup pattern
+
+All four tests use this teardown idiom (mirroring `lifecycle_phase1_wbtest.mbt:110-121`). It is duplicated in each test body (NOT factored into a helper) per spec §4's "duplicated rather than helperized at this scale, to keep the proven-end-to-end-path visible in each test body":
+
+```moonbit
+// After unregister_dep × 2 and w.dispose():
+let _ = coordinator.destroy_editor(h_a.editor_id)
+h_a.companion.dispose_analysis_attachment()
+lambda_handles.remove(handle_a)
+view_states.remove(handle_a)
+pretty_view_states.remove(handle_a)
+let _ = coordinator.destroy_editor(h_b.editor_id)
+h_b.companion.dispose_analysis_attachment()
+lambda_handles.remove(handle_b)
+view_states.remove(handle_b)
+pretty_view_states.remove(handle_b)
+if last_created_handle.val == Some(handle_b) {
+  last_created_handle.val = None
+}
+```
+
+**Why bypass the FFI `destroy_editor(handle: Int)` wrapper** (`ffi/lambda/lifecycle.mbt:90-117`): it returns `Unit` and swallows the coordinator's `Err` into a `println`. Tests need to assert on the `Result`, so they call `coordinator.destroy_editor(h.editor_id)` directly and manually drain FFI bookkeeping. Same reasoning the existing PR4 wbtest uses.
+
+**Why `let _ = ...` rather than `match`** at the cleanup site for tests 5.1/5.2/5.3 (NOT 5.4): teardown's job is to leave coordinator state clean; the return value isn't being asserted on (that's §5.4's job, where every step IS asserted).
+
+---
+
+### Task 1: Scaffold file + Test 5.1 (sanity sum)
+
+**Files:**
+- Create: `ffi/lambda/workspace_memo_smoke_wbtest.mbt`
+
+- [ ] **Step 1: Verify baseline test count**
+
+Run: `cd /home/antisatori/ghq/github.com/dowdiness/canopy/.worktrees/scratch && NEW_MOON_MOD=0 moon test 2>&1 | tail -3`
+
+Expected: `Total tests: 1182, passed: 1182, failed: 0. [js]` (or close to 1182 — record the actual baseline). Each new `test "..."` block adds +1.
+
+- [ ] **Step 2: Create the file with header + sanity sum test**
+
+Write the following exactly (note: no `pub` on tests; `///|` block separator is required between top-level items):
+
+```moonbit
+// Whitebox integration test for the §P0b first real workspace memo.
+// Proves end-to-end that Coordinator::register_dep / unregister_dep /
+// destroy_editor gateway / read_protected hold against real Lambda
+// editor cells built by the production `assemble_lambda_handle`
+// factory + global `coordinator` singleton.
+//
+// Per spec §3.7, each test manually drives full teardown (unregister
+// every registered dep, dispose the watch, bypass-destroy each editor,
+// drain FFI bookkeeping) so correctness does not depend on coordinator
+// state being empty at test start.
+//
+// Spec: docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md
+
+///|
+test "smoke 5.1: sanity sum equals known value across two editors" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_1_a")
+  let handle_b = create_editor("smoke_5_1_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  // Build the workspace memo on the coordinator's runtime.
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match coordinator.read_protected(
+      h_a.editor_id, h_a.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.1 read h_a: \{r}")
+    }
+    let sb = match coordinator.read_protected(
+      h_b.editor_id, h_b.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.1 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+
+  // Drive the editors to known sources.
+  h_a.editor.set_text("abc")
+  h_b.editor.set_text("defgh")
+  assert_eq(w.read().unwrap(), 3 + 5)
+
+  // Teardown per spec §3.7 (bypass-destroy + FFI drain).
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+  let _ = coordinator.destroy_editor(h_a.editor_id)
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  let _ = coordinator.destroy_editor(h_b.editor_id)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+```
+
+- [ ] **Step 3: Run only this new test**
+
+Run: `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/lambda -f workspace_memo_smoke_wbtest.mbt 2>&1 | tail -10`
+
+Expected: 1 test passes. If it fails:
+- **`@incr.Derived(rt, fn)` constructor not found** — verified at `loom/incr/cells/pkg.generated.mbti:38` as `Derived::Derived(Runtime, () -> T raise Failure, label? : String) -> Self[T]`. The bare-name `Derived(rt, fn)` form works because of MoonBit's named-constructor convention (see `~/.claude/moonbit-base.md` "Custom constructors for structs"). If it doesn't resolve, use `@incr.Derived::Derived(coordinator.runtime(), fn() { ... })` explicitly.
+- **`compute fn must `raise Failure`** — the closure type is `() -> T raise Failure` (`loom/incr/cells/pkg.generated.mbti:38`). `abort(...)` returns `noreturn` and satisfies any return type without affecting the raise clause, so no `raise` annotation needed in the closure. If the type-checker complains, swap `abort(...)` for `fail(...)` which raises Failure directly.
+- **`sum_d.id()` not found** — verified at `loom/incr/cells/pkg.generated.mbti:44` as `Derived::id(Self[T]) -> @types.CellId`. This exists.
+- **`@incr` import error** — `ffi/lambda/moon.pkg.json` must list `dowdiness/incr` (or alias) under imports. The existing PR4 code in `ffi/lambda/lifecycle.mbt` uses `@incr.Runtime` and `@incr.Derived[T]`, so this should already be present.
+
+- [ ] **Step 4: Verify full workspace tests still pass**
+
+Run: `NEW_MOON_MOD=0 moon test 2>&1 | tail -3`
+
+Expected: baseline + 1 (1183/1183 if baseline was 1182).
+
+---
+
+### Task 2: Test 5.2 (reactivity on editor mutation)
+
+**Files:**
+- Modify: `ffi/lambda/workspace_memo_smoke_wbtest.mbt` (append new test)
+
+- [ ] **Step 1: Append the reactivity test**
+
+Add to the end of the file (after the §5.1 test's closing `}`):
+
+```moonbit
+
+///|
+test "smoke 5.2: mutation in editor A invalidates workspace memo and recomputes" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_2_a")
+  let handle_b = create_editor("smoke_5_2_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match coordinator.read_protected(
+      h_a.editor_id, h_a.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.2 read h_a: \{r}")
+    }
+    let sb = match coordinator.read_protected(
+      h_b.editor_id, h_b.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.2 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+
+  // Prime with initial values.
+  h_a.editor.set_text("ab")
+  h_b.editor.set_text("cd")
+  assert_eq(w.read().unwrap(), 2 + 2)
+
+  // Mutate editor A's source; the workspace memo must recompute on next read.
+  h_a.editor.set_text("abcdef")
+  assert_eq(w.read().unwrap(), 6 + 2)
+
+  // Teardown per spec §3.7.
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+  let _ = coordinator.destroy_editor(h_a.editor_id)
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  let _ = coordinator.destroy_editor(h_b.editor_id)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+```
+
+- [ ] **Step 2: Run only this new test**
+
+Run: `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/lambda -f workspace_memo_smoke_wbtest.mbt 2>&1 | tail -10`
+
+Expected: 2 tests pass. If the second assertion (`8` after mutation) fails with `4` (the stale value):
+- The workspace memo's compute closure did register `parser_source` as a dependency on first read, but `set_text` is not invalidating it — investigate `SyncEditor::set_text` propagation. Confirm by adding `println(w.read().unwrap())` between the two `set_text` calls and the assertion. This is a real bug if it fires; surface it before continuing.
+
+- [ ] **Step 3: Verify full workspace tests still pass**
+
+Run: `NEW_MOON_MOD=0 moon test 2>&1 | tail -3`
+
+Expected: baseline + 2.
+
+---
+
+### Task 3: Test 5.3 (destroy gateway refusal under live dep)
+
+**Files:**
+- Modify: `ffi/lambda/workspace_memo_smoke_wbtest.mbt` (append new test)
+
+- [ ] **Step 1: Append the destroy-refusal test**
+
+Add to the end of the file:
+
+```moonbit
+
+///|
+test "smoke 5.3: destroy_editor refused while workspace memo dep is live" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_3_a")
+  let handle_b = create_editor("smoke_5_3_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match coordinator.read_protected(
+      h_a.editor_id, h_a.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.3 read h_a: \{r}")
+    }
+    let sb = match coordinator.read_protected(
+      h_b.editor_id, h_b.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.3 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+
+  h_a.editor.set_text("hi")
+  h_b.editor.set_text("world")
+  let pre_sum = w.read().unwrap()
+
+  // Destroy must refuse with the precise AbortReport shape spec §5.3 asserts.
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => fail("expected DestroyWhileDependedUpon, got Ok")
+    Err(report) => {
+      assert_eq(report.kind, @workspace.DestroyWhileDependedUpon)
+      assert_eq(report.editor_id, h_a.editor_id)
+      assert_eq(report.cell_id, Some(sum_d.id()))
+    }
+  }
+
+  // Editor A must still be alive — re-read the memo and assert the sum is unchanged.
+  assert_eq(w.read().unwrap(), pre_sum)
+
+  // Teardown per spec §3.7.
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+  let _ = coordinator.destroy_editor(h_a.editor_id)
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  let _ = coordinator.destroy_editor(h_b.editor_id)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+```
+
+- [ ] **Step 2: Run only this new test**
+
+Run: `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/lambda -f workspace_memo_smoke_wbtest.mbt 2>&1 | tail -10`
+
+Expected: 3 tests pass. If `report.cell_id` assertion fails with a different `CellId` than `sum_d.id()`:
+- This is the Codex round-1 finding #2 fragility actually firing. Check whether any prior coordinator dep registrations leaked into this test (run alone, see if it passes). If running alone fixes it, it means the §3.7 isolation contract is being violated by an earlier test in the file.
+
+- [ ] **Step 3: Verify full workspace tests still pass**
+
+Run: `NEW_MOON_MOD=0 moon test 2>&1 | tail -3`
+
+Expected: baseline + 3.
+
+---
+
+### Task 4: Test 5.4 (clean teardown with assertions on each step)
+
+**Files:**
+- Modify: `ffi/lambda/workspace_memo_smoke_wbtest.mbt` (append new test)
+
+- [ ] **Step 1: Append the clean-teardown-assertions test**
+
+Add to the end of the file:
+
+```moonbit
+
+///|
+test "smoke 5.4: clean teardown sequence — each step returns Ok" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_4_a")
+  let handle_b = create_editor("smoke_5_4_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match coordinator.read_protected(
+      h_a.editor_id, h_a.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.4 read h_a: \{r}")
+    }
+    let sb = match coordinator.read_protected(
+      h_b.editor_id, h_b.cells.parser_source,
+    ) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.4 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  h_a.editor.set_text("x")
+  h_b.editor.set_text("yz")
+  let _ = w.read().unwrap() // prime
+
+  // Teardown — every step's outcome asserted.
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+
+  // After unregister + dispose, destroy must succeed.
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("expected Ok destroying h_a after unregister, got \{report}")
+  }
+  match coordinator.destroy_editor(h_b.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("expected Ok destroying h_b after unregister, got \{report}")
+  }
+
+  // Drain FFI bookkeeping so leaks don't pollute later tests.
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+```
+
+- [ ] **Step 2: Run only this new test**
+
+Run: `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/lambda -f workspace_memo_smoke_wbtest.mbt 2>&1 | tail -10`
+
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Verify full workspace tests still pass**
+
+Run: `NEW_MOON_MOD=0 moon test 2>&1 | tail -3`
+
+Expected: baseline + 4.
+
+---
+
+### Task 5: Verification gate + commit
+
+**Files:**
+- Touched only: `ffi/lambda/workspace_memo_smoke_wbtest.mbt`
+
+- [ ] **Step 1: Format the new file**
+
+Run: `NEW_MOON_MOD=0 moon fmt`
+
+Expected: no changes, or whitespace-only reformatting. If a structural reformat happens, re-run the per-file test (Task 4 Step 2) to confirm semantics intact.
+
+- [ ] **Step 2: Regenerate `.mbti` interfaces and confirm zero public-API drift**
+
+Run: `NEW_MOON_MOD=0 moon info && git diff --stat -- '*.mbti'`
+
+Expected: empty output (no `.mbti` files modified). The wbtest adds tests only — no `pub` symbols — so `pkg.generated.mbti` must not change. If it does, revert and investigate (most likely a stray `pub` snuck into the test file or a helper file).
+
+- [ ] **Step 3: Final workspace-wide check + test**
+
+Run: `NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test 2>&1 | tail -3`
+
+Expected: `moon check` clean; `moon test` reports baseline + 4 passing.
+
+- [ ] **Step 4: Stage the file and inspect the diff**
+
+Run: `git add ffi/lambda/workspace_memo_smoke_wbtest.mbt && git diff --cached --stat`
+
+Expected: exactly one new file, ~250 lines (4 tests × ~60 lines each including teardown duplication).
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+test(ffi/lambda): §P0b first real workspace memo smoke wbtest
+
+Drives Coordinator::register_dep / unregister_dep / destroy_editor
+gateway / read_protected end-to-end against the first **real-cell**
+workspace memo — an @incr.Derived[Int] summing two Lambda editors'
+parser_source lengths through the global `coordinator` singleton.
+
+Four scenarios per spec §5: sanity sum, reactivity on editor mutation,
+destroy gateway refusal under live dep, clean teardown with assertions
+on each step.
+
+Per spec §3.7, each test manually drives full teardown (unregister
+every registered dep, dispose the watch, bypass-destroy each editor,
+drain FFI bookkeeping). reset_coordinator_for_phase1_tests only clears
+FFI handle maps; coordinator state leaks across tests, but freshly-
+allocated monotonic EditorIds prevent cross-test correctness coupling.
+
+Spec: docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md
+Plan: docs/superpowers/plans/2026-05-28-p0b-first-workspace-memo-implementation.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Confirm commit landed**
+
+Run: `git log --oneline -1 && git status`
+
+Expected: top commit is the test commit; working tree clean (or only the spec + plan untracked if those weren't committed earlier).
+
+---
+
+## Notes for the implementer
+
+- **Do NOT route through the FFI `destroy_editor(handle: Int)` wrapper** (`ffi/lambda/lifecycle.mbt:90`). It returns `Unit` and `println`s on `Err`. Every test asserts on the `Coordinator::destroy_editor` `Result` directly and manually drains FFI state, mirroring `lifecycle_phase1_wbtest.mbt:110-121`.
+- **Test names matter for `moon test -f`**. Keep them as `"smoke 5.X: ..."` so they sort and grep cleanly.
+- **If any test hangs** during `w.read()`: the on_change callback may be in a loop. Check that the coordinator's stub `on_change` (in `Coordinator::new` at `workspace/coordinator/methods.mbt:7-15`) is still a no-op. If somebody wired a non-trivial on_change, that's an out-of-band substrate change and the test setup needs to adapt — surface to the user.
+- **If `moon fmt` reshapes the multi-line `coordinator.runtime().derived(fn() { ... })` block**: that's expected; trust the formatter's output (the spec/plan code is illustrative, not byte-exact-mandated).
+- **If `set_text` doesn't propagate invalidation** (Task 2 Step 2 fails with stale sum): that's a real bug in the substrate or a misunderstanding of `SyncEditor`'s mutation contract. Do NOT try to "fix" it with a manual `runtime.fire_on_change()` or similar workaround — surface to the user. The spec assumed reads from a Derived inside another Derived auto-track deps and re-fire on input change; if that assumption is wrong, the smoke milestone needs a deeper rethink.
+- **`.mbti` drift in Step 2 of Task 5**: a wbtest file should not touch `.mbti` because it adds no `pub` symbols. If `moon info` modifies `pkg.generated.mbti`, you accidentally added a `pub` keyword somewhere — search for it and remove.

--- a/docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md
+++ b/docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md
@@ -1,0 +1,174 @@
+# §P0b — First Real Workspace Memo (Smoke Wiring Proof) Design
+
+**Date:** 2026-05-28
+**Belongs to slice:** §P0b Phase 1b — backlog item "first real workspace memo registered with `register_dep`" (carried in `project_shared_runtime_workspace_contract` memory under the "Phase 1b queue items" list since PR4 retro 2026-05-25).
+**Pairs with:** `docs/superpowers/specs/2026-05-24-p0b-phase1-skeleton-design.md` (PR3/PR4 coordinator + atomic-construction substrate).
+**Status:** Brainstorm-approved by user 2026-05-28; pending Codex stage-2 design validation, then `superpowers:writing-plans` handoff.
+
+## 0. Background
+
+The coordinator infrastructure that owns `register_dep` / `unregister_dep` / `destroy_editor`-gateway / `read_protected` has shipped through canopy PRs #345 (atomic ctor), #347 (coordinator package), #348 (Lambda FFI atomic boundary), #349 (WS1 production accessor), #351 + #352 (Markdown + JSON parity). Across all six PRs, no production caller has invoked `Coordinator::register_dep` — the only exerciser is `workspace/coordinator/coordinator_wbtest.mbt`, which uses **synthetic** `ProtectedCell` values constructed inside the test itself.
+
+This milestone closes that gap: the smallest caller that drives `register_dep` against **real protected cells** of **real editors** built by the production `assemble_lambda_handle` factory and registered with the global `coordinator` singleton. The deliverable is a wbtest, not a production memo — by explicit user choice, the success criterion is "prove the wiring works end-to-end," not "ship a user-visible aggregator."
+
+## 1. Scope
+
+**In scope:**
+
+- One new file: `ffi/lambda/workspace_memo_smoke_wbtest.mbt`.
+- Four test scenarios (§5) exercising: sanity read, reactivity on editor mutation, destroy-gateway refusal under live dep, clean teardown.
+- One `@incr.Derived[Int]` workspace memo, GC-rooted by a test-owned `Watch`, depending on two real `parser_source` protected cells from two Lambda editors built by `assemble_lambda_handle`.
+
+**Out of scope:**
+
+- New coordinator API. Notably **no** `Coordinator::register_workspace_memo` — test owns the `Watch` directly and calls `register_dep` / `unregister_dep` manually. Spec §6 ownership convergence is deferred to a follow-up; the §10 "Spec gaps" section records this explicitly.
+- Production accessor migration. No FFI surface change. No `.mbti` drift.
+- `Coordinator::destroy_editor` mid-dispose-raise ordering hardening (the deferred-from-PR4 concern). This smoke test cannot surface it — see §6.1.
+- Cross-language coordinators. Per WS2 spec §4, JS-bundle isolation makes shared-runtime cross-language a Phase 2 concern. This memo is Lambda-only.
+- Markdown / JSON parity workspace memos. Symmetric follow-ups; out of scope for this milestone by the "smallest deliverable" criterion.
+- Variety in cell types or editor count beyond N=2 with one cell each (brainstorm Approaches B/C rejected as adding diff with little epistemic gain).
+
+## 2. The contract in one paragraph
+
+A workspace memo is an `@incr.Derived[T]` whose compute closure reads protected cells from one or more editors via `coordinator.read_protected(editor_id, cell)`. It is GC-rooted by a `Watch` (held by the memo's owner — test or coordinator). For each `(editor_id, cell)` it reads, its owner calls `coordinator.register_dep(memo_id, editor_id, cell_id)` after construction. While any such dep edge is live, `coordinator.destroy_editor(editor_id)` returns `Err(AbortReport { kind: DestroyWhileDependedUpon, ... })`; the editor stays alive and the memo's reads continue to succeed. On owner-driven teardown, the owner calls `coordinator.unregister_dep` for each edge it registered, disposes the `Watch`, then `destroy_editor` for each editor succeeds. Spec §6 says the coordinator eventually owns this lifecycle; in this milestone the test owns it as a deliberate Phase-1 shape.
+
+## 3. Hard constraints
+
+| § | Constraint | Where addressed |
+|---|------------|-----------------|
+| 3.1 | Real editor cells only — no synthetic `ProtectedCell` construction. The PR3 wbtest already covers synthetic-cell variants of all 5 `AbortKind` paths; this test's marginal value is in driving the live substrate. | §4 components — `h_a.cells.parser_source` etc., never `ProtectedCell::from_derived` directly. |
+| 3.2 | Global coordinator singleton — uses `coordinator` from `ffi/lambda/lifecycle.mbt`, not a freshly-allocated test-local `Coordinator::new()`. Reason: the milestone is "first production caller registers a real dep on real cells in the real coordinator." | §4 components. Test top calls `reset_coordinator_for_phase1_tests()` (defined `ffi/lambda/lifecycle_phase1_wbtest.mbt:11`, package-scope accessible from the new sibling wbtest) **only to clear FFI handle maps** — see §3.7 for the actual coordinator-state contract. |
+| 3.3 | Test owns the `Watch` and the `register_dep`/`unregister_dep` calls — no new coordinator API. | §6.2 explicitly records this as deviating from spec §6 ownership; §10 lists the follow-up. |
+| 3.4 | `abort` on `read_protected` `Err` inside the compute fn. Phase 1 invariant: live `register_dep` ⇒ destroy refused ⇒ `read_protected` returns `Ok`. Any Err implies a contract violation, not a recoverable runtime condition. Per `[[feedback-no-safe-recovery-abort-ok]]`. | §4 compute fn. |
+| 3.5 | The four scenarios stay in independent `test "..."` blocks (not chained into one large test). Per `[[feedback-codex-broad-vs-scoped-review]]` — independence makes the "what does this scenario prove" review-able per test name. | §5. |
+| 3.6 | Cannot exercise `Coordinator::destroy_editor` mid-dispose-raise. None of Lambda's 10 ProtectedCells has a `dispose` closure that raises in normal flow. | §6.1, §10. |
+| 3.7 | **Coordinator state leaks across tests by design.** `reset_coordinator_for_phase1_tests` only force-clears the FFI-side `lambda_handles` / `view_states` / `pretty_view_states` / `last_created_handle` maps. The coordinator's `editors` registry, `deps` registry, and `next_id` counter all persist across tests (helper docstring at `ffi/lambda/lifecycle_phase1_wbtest.mbt:14-20` is explicit about this; PR4 deliberately avoided routing through `coordinator.destroy_editor` because the gateway can refuse). Each test therefore MUST execute full manual cleanup at its end (unregister all registered deps, dispose the watch, destroy the editors). Test correctness must not depend on coordinator state being empty at test start; instead, each test ends with the coordinator-state delta it introduced fully reversed. | §5 — every scenario has an explicit "Teardown" sentence; §10 records the eventual coordinator-side `reset_for_tests` helper as deferred. |
+
+## 4. Components
+
+**File:** `ffi/lambda/workspace_memo_smoke_wbtest.mbt`. New file; not appended to `lifecycle_phase1_wbtest.mbt`. Reason: the workspace-memo concern is a distinct domain from PR4's atomic-construction tests; a sibling file keeps blame, naming, and test discovery clean.
+
+**Imports:** `@workspace` for `read_protected`/`register_dep`/`unregister_dep`/`destroy_editor`/`AbortReport`/`AbortKind` constructors; `@incr` for `Runtime::derived` and `Watch`.
+
+**Per-test setup** (each of the four `test "..."` blocks performs the same prelude — duplicated rather than helperized at this scale, to keep the proven-end-to-end-path visible in each test body):
+
+1. `reset_coordinator_for_phase1_tests()` — clears the FFI-side handle maps only. Coordinator state (editors / deps / next_id) persists across tests per §3.7; correctness comes from each test's own mandatory teardown (§5) and from monotonic `next_id` (`workspace/coordinator/methods.mbt:44-45`) ensuring this test's freshly-allocated `EditorId`s do not intersect leaked edges.
+2. `let h_a = assemble_lambda_handle("editor_a_<scenario>")` — full atomic construction via the production factory.
+3. `let h_b = assemble_lambda_handle("editor_b_<scenario>")` — second editor in the same coordinator.
+4. Construct the workspace memo:
+
+   ```text
+   let sum_d : @incr.Derived[Int] = coordinator.runtime().derived(fn() {
+     let sa = coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source)
+       .unwrap_or_else(fn(r) { abort("workspace memo smoke: \{r}") })
+     let sb = coordinator.read_protected(h_b.editor_id, h_b.cells.parser_source)
+       .unwrap_or_else(fn(r) { abort("workspace memo smoke: \{r}") })
+     sa.length() + sb.length()
+   })
+   ```
+
+5. `let w = sum_d.watch()` — primes the cell on first read + GC-roots it for the test's duration.
+6. Two `coordinator.register_dep` calls:
+
+   ```text
+   coordinator.register_dep(sum_d.id(), h_a.editor_id, h_a.cells.parser_source.cell_id())
+   coordinator.register_dep(sum_d.id(), h_b.editor_id, h_b.cells.parser_source.cell_id())
+   ```
+
+The exact mutation API used in scenario 2 (`set_text` / `apply_edit` / equivalent) is to be confirmed during implementation by reading the live `SyncEditor` surface — if no public mutation method exists at the cell layer, implementation may need to introduce one (in which case it's a real spec gap; surface it then, do not silently improvise). The protected-cell *read* path is fully proven by PR3/PR4; the protected-cell *invalidation-on-input-mutation* path is the smoke test's primary new claim, so the chosen mutation API matters.
+
+## 5. Test scenarios
+
+Each is its own `test "..."` block.
+
+**5.1 Sanity sum.** After setup, set both editors' sources to known strings (`"abc"`, `"defgh"`). Assert `w.read().unwrap() == 3 + 5`. **Teardown** (required per §3.7): `unregister_dep` both edges, `w.dispose()`, `destroy_editor(h_a.editor_id)`, `destroy_editor(h_b.editor_id)`. Return values not asserted here (that's §5.4's job); the goal is to leave coordinator state unchanged from test start.
+
+**5.2 Reactivity on editor mutation.** After setup with both sources at known values, prime read. Mutate `h_a`'s source to a new string. Read again. Assert the new sum reflects the mutated length. This is the smoke test's primary new claim: invalidation propagates from a real `parser_source` input through `read_protected` into the workspace memo. **Teardown:** same as §5.1.
+
+**5.3 Destroy gateway refusal under live dep.** After setup, assert `coordinator.destroy_editor(h_a.editor_id)` returns an `Err(AbortReport { ... })` whose `kind == DestroyWhileDependedUpon`, `editor_id == h_a.editor_id`, and `cell_id == Some(sum_d.id())` — matching the implementation at `workspace/coordinator/methods.mbt:130-137` which puts the *workspace memo's* `CellId` (the first found `referring[0]`) in the report. Other `AbortReport` fields (`agent_id`, `cell_label`, `domain_tag`) are not asserted by this scenario. The `referring[0] == sum_d.id()` determinism rests on this test's own state, not on coordinator-wide cleanliness: within scenario 5.3, the only workspace memo whose dep-edges reference `h_a.editor_id` is `sum_d` (because `h_a.editor_id` is freshly allocated by this test's `assemble_lambda_handle` call, and `register_dep` was only called for `sum_d`), so the `referring` array contains exactly one entry. **Then** assert that `h_a` is still alive: re-reading the workspace memo succeeds and the sum is unchanged from before the failed destroy. **Teardown:** same as §5.1.
+
+**5.4 Clean teardown — assertions on each step.** This scenario's distinct value over §5.1/§5.2/§5.3's implicit teardown is that each cleanup step's return value is explicitly asserted. After setup, call:
+
+```text
+coordinator.unregister_dep(sum_d.id(), h_a.editor_id, h_a.cells.parser_source.cell_id())
+coordinator.unregister_dep(sum_d.id(), h_b.editor_id, h_b.cells.parser_source.cell_id())
+w.dispose()
+```
+
+Then assert:
+
+```text
+coordinator.destroy_editor(h_a.editor_id) == Ok(())
+coordinator.destroy_editor(h_b.editor_id) == Ok(())
+```
+
+No additional teardown — the asserted steps ARE the teardown.
+
+## 6. What this design deliberately defers
+
+### 6.1 `Coordinator::destroy_editor` mid-dispose-raise
+
+The PR3 implementation flips `alive = false` BEFORE the dispose loop (`workspace/coordinator/methods.mbt:139-142`). The intent is: a re-entrant `read_protected` during dispose cannot observe `alive=true` paired with disposed watches. The deferred-from-PR4 concern is: if any `(p.dispose)()` in the loop raises, the editor is left in a zombie state (`alive=false`, partially-disposed protected cells, still present in `self.editors`).
+
+This smoke test cannot surface that concern because none of the 10 Lambda `ProtectedCell.dispose` closures raises in normal flow. Surfacing it requires a synthetic poison `ProtectedCell` whose `dispose` raises — that's a separate "destroy ordering hardening" follow-up PR, which will exercise the synthetic-cell path that PR3 wbtest already uses, just with an injected raise. Not bundled here because (a) it's orthogonal to the "real cells / register_dep" claim of this milestone, (b) it would re-open coordinator API design, and (c) the smoke test's value is exactly in *not* mixing concerns.
+
+### 6.2 Spec §6 coordinator-owned lifecycle
+
+The spec's §6 statement that "coordinator owns workspace-memo lifecycle" implies a `Coordinator::register_workspace_memo(memo, deps) -> WatchHandle` API that:
+
+- accepts the `Derived[T]` and a list of `(EditorId, ProtectedCell[_])` deps,
+- internally calls `register_dep` for each,
+- owns the `Watch`,
+- on `dispose_workspace_memo(handle)` (or via `WatchHandle::dispose`), calls `unregister_dep` for each registered edge before disposing the watch.
+
+This milestone deliberately does **not** introduce that API. The test drives the substrate by hand. Two reasons: (a) the user's stated goal is "prove the wiring works" — not "ship the ownership API," (b) the ownership API's shape is a meaningful design question on its own (handle vs raw `Watch`, dep-list at construction vs incremental, what happens if a registered dep's editor was already destroyed). Conflating it with the smoke milestone risks repeating the §P0b PR-shape brainstorm trajectory (5 non-convergent Codex rounds 2026-05-24). The follow-up gets its own spec.
+
+### 6.3 Cross-language coordinators
+
+Per WS2 spec §4, the three FFI bundles each compile to their own JS module with their own `coordinator` singleton. Cross-language workspace memos require either a single shared JS bundle, a `globalThis`-coalesced coordinator via `extern "js"`, or a backend-FFI redesign. All Phase 2. Not touched here.
+
+## 7. Why a wbtest rather than production code
+
+The deliverable could in principle live as production code in `ffi/lambda/` (e.g., a `lambda_workspace_summary.mbt` module exposing some derived value to JS). That would force the design surface to grow: where in the FFI API surface does it sit, what JSON shape does it return, what's its consumer's lifecycle obligation. The user's chosen criterion — "prove the wiring works" — is exactly the criterion that says "stop short of those questions." A wbtest gives full coverage of the substrate claim with zero FFI-API design surface, and leaves the "what's the first user-visible workspace aggregator" question fully open for a separate brainstorm.
+
+## 8. Why ABORT inside the compute fn
+
+The compute fn calls `unwrap_or_else(fn(r) { abort(...) })` rather than constructing a fallback `Int`. Three reasons:
+
+1. **Contract invariant.** A live `register_dep(memo_id, editor_id, cell_id)` edge means `destroy_editor(editor_id)` refuses → editor stays alive → its protected cell stays alive → `read_protected` returns `Ok`. The only way to reach `Err` is for a caller to have violated the contract (e.g. forgot to register the dep, or registered then read a different cell, or disposed the cell out-of-band). Abort surfaces the violation loudly; a silent fallback hides it.
+2. **Memory precedent.** `[[feedback-no-safe-recovery-abort-ok]]` records the project rule: keep `abort` when catching would produce silently wrong results. A summary memo returning `0` on `Err` would silently produce a wrong sum.
+3. **Test discipline.** The smoke test stays on the happy path. The unhappy paths are PR3's domain. Mixing them would dilute the milestone's narrative.
+
+The abort report string interpolates the `AbortReport`'s `Show` impl so test failures carry full diagnostic context.
+
+## 9. Verification gate
+
+Before opening the PR, all four must pass:
+
+- `NEW_MOON_MOD=0 moon check` workspace-wide: clean.
+- `NEW_MOON_MOD=0 moon test` workspace-wide: 1182 baseline → 1186 (+4 new tests; one per §5 scenario). Exact baseline to confirm at implementation time.
+- `git diff *.mbti` → zero hits. No public API change.
+- Codex stage-4 scoped review (interaction effects: register/unregister symmetry, destroy-refusal report fidelity, teardown sequence) + broad open-ended review. Pair confirmed load-bearing for this workstream per `[[feedback-codex-broad-vs-scoped-review]]`.
+
+## 10. Spec gaps surfaced
+
+- **§6.2** — Coordinator-owned workspace-memo lifecycle API not delivered; follow-up spec/PR required.
+- **§6.1** — Mid-dispose-raise hardening; separate follow-up PR with synthetic poison cell.
+- **§4 mutation API** — exact `SyncEditor` text-mutation method to use in scenario 5.2 is not pinned in this spec. If no suitable public mutation method exists, implementer must surface this as a real spec gap rather than improvising (e.g. add a `set_source_for_tests` and document it, or surface the design question).
+- **Coordinator-side reset helper** — this spec works around the leak documented in §3.7 by requiring per-test manual cleanup. A real fix is a `Coordinator::reset_for_tests()` (or test-mode flag) that clears `editors`, `deps`, and resets `next_id`. Cleaner long-term, but a workspace/coordinator/ API addition and out of scope here per "smallest design surface." If a future test cannot reliably cleanup (e.g. a deliberate panic test that bypasses teardown), revisit then.
+- **Panic-safety of test-owned lifecycle** — per §3.7, if a test panics between `register_dep` and the corresponding `unregister_dep`, the coordinator retains the leaked dep. Monotonic `next_id` ensures the leaked dep cannot cause a *correctness* failure in subsequent tests (their freshly-allocated EditorIds don't intersect with the leaked edges), but it does cause memory growth and could be confusing in introspection. Documented as known behavior; the coordinator-side reset helper above would close it.
+
+## 11. Decision summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Realness | Real editors via `assemble_lambda_handle` | User-chosen; PR3 wbtest already covers synthetic-cell variants. |
+| Coordinator scope | Per-language (Lambda only) | WS2 §4 — JS-bundle isolation makes cross-language Phase 2. |
+| Editor count | 2 | Smallest N that proves "cross-editor" rather than "self-edge." |
+| Cell type variety | 1 (`parser_source` on both editors) | Heterogeneity adds little epistemic gain (Approach B rejected). |
+| Memo ownership | Test owns `Watch`; manual `register_dep`/`unregister_dep` | Smallest design surface (Option A in user's §6 question). |
+| Test location | `ffi/lambda/workspace_memo_smoke_wbtest.mbt` (new file) | Distinct domain from PR4 atomic-construction tests. |
+| Compute fn Err policy | `abort` | Phase 1 invariant + `[[feedback-no-safe-recovery-abort-ok]]`. |
+| Test scenarios | 4 (sanity / reactivity / destroy refusal / clean teardown) | Cover each load-bearing edge once; no scenario-bundling. |
+| Destroy mid-dispose-raise | Out of scope | Synthetic poison cell required; orthogonal milestone. |
+| §6 ownership API | Deferred | Avoids conflating substrate proof with API design. |

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -19,6 +19,11 @@ import {
   "moonbitlang/core/string",
 }
 
+import {
+  "dowdiness/incr",
+  "moonbitlang/core/debug",
+} for "wbtest"
+
 // `cells` field of LambdaHandle is read in production by `get_diagnostics_json`
 // (parser_diagnostics + typecheck_output + escalation_memo, via Phase 1b
 // workstream 1) and by whitebox tests (`lifecycle_phase1_wbtest.mbt`) for the

--- a/ffi/lambda/workspace_memo_smoke_wbtest.mbt
+++ b/ffi/lambda/workspace_memo_smoke_wbtest.mbt
@@ -62,12 +62,18 @@ test "smoke 5.1: sanity sum equals known value across two editors" {
     h_b.cells.parser_source.cell_id(),
   )
   w.dispose()
-  let _ = coordinator.destroy_editor(h_a.editor_id)
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => ()
+    Err(r) => fail("teardown destroy h_a: \{r}")
+  }
   h_a.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle_a)
   view_states.remove(handle_a)
   pretty_view_states.remove(handle_a)
-  let _ = coordinator.destroy_editor(h_b.editor_id)
+  match coordinator.destroy_editor(h_b.editor_id) {
+    Ok(_) => ()
+    Err(r) => fail("teardown destroy h_b: \{r}")
+  }
   h_b.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle_b)
   view_states.remove(handle_b)
@@ -131,12 +137,18 @@ test "smoke 5.2: mutation in editor A invalidates workspace memo and recomputes"
     h_b.cells.parser_source.cell_id(),
   )
   w.dispose()
-  let _ = coordinator.destroy_editor(h_a.editor_id)
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => ()
+    Err(r) => fail("teardown destroy h_a: \{r}")
+  }
   h_a.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle_a)
   view_states.remove(handle_a)
   pretty_view_states.remove(handle_a)
-  let _ = coordinator.destroy_editor(h_b.editor_id)
+  match coordinator.destroy_editor(h_b.editor_id) {
+    Ok(_) => ()
+    Err(r) => fail("teardown destroy h_b: \{r}")
+  }
   h_b.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle_b)
   view_states.remove(handle_b)
@@ -196,6 +208,14 @@ test "smoke 5.3: destroy_editor refused while workspace memo dep is live" {
   // Editor A must still be alive — re-read the memo and assert the sum is unchanged.
   assert_eq(w.read().unwrap(), pre_sum)
 
+  // Stronger aliveness: mutate editor A AFTER the refused destroy and assert
+  // the memo recomputes from the new source. This is what "still alive" must
+  // mean operationally — accepting writes and propagating invalidation. A
+  // bare value-equality reread alone would also pass if the editor were
+  // half-dead (e.g., reads served from a frozen cache).
+  h_a.editor.set_text("hello-after-refused-destroy")
+  assert_eq(w.read().unwrap(), 27 + 5)
+
   // Teardown per spec §3.7.
   coordinator.unregister_dep(
     sum_d.id(),
@@ -208,12 +228,18 @@ test "smoke 5.3: destroy_editor refused while workspace memo dep is live" {
     h_b.cells.parser_source.cell_id(),
   )
   w.dispose()
-  let _ = coordinator.destroy_editor(h_a.editor_id)
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => ()
+    Err(r) => fail("teardown destroy h_a: \{r}")
+  }
   h_a.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle_a)
   view_states.remove(handle_a)
   pretty_view_states.remove(handle_a)
-  let _ = coordinator.destroy_editor(h_b.editor_id)
+  match coordinator.destroy_editor(h_b.editor_id) {
+    Ok(_) => ()
+    Err(r) => fail("teardown destroy h_b: \{r}")
+  }
   h_b.companion.dispose_analysis_attachment()
   lambda_handles.remove(handle_b)
   view_states.remove(handle_b)

--- a/ffi/lambda/workspace_memo_smoke_wbtest.mbt
+++ b/ffi/lambda/workspace_memo_smoke_wbtest.mbt
@@ -1,0 +1,299 @@
+// Whitebox integration test for the §P0b first real workspace memo.
+// Proves end-to-end that Coordinator::register_dep / unregister_dep /
+// destroy_editor gateway / read_protected hold against real Lambda
+// editor cells built by the production `assemble_lambda_handle`
+// factory + global `coordinator` singleton.
+//
+// Per spec §3.7, each test manually drives full teardown (unregister
+// every registered dep, dispose the watch, bypass-destroy each editor,
+// drain FFI bookkeeping) so correctness does not depend on coordinator
+// state being empty at test start.
+//
+// Spec: docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md
+
+///|
+test "smoke 5.1: sanity sum equals known value across two editors" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_1_a")
+  let handle_b = create_editor("smoke_5_1_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  // Build the workspace memo on the coordinator's runtime.
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match
+      coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.1 read h_a: \{r}")
+    }
+    let sb = match
+      coordinator.read_protected(h_b.editor_id, h_b.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.1 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+
+  // Drive the editors to known sources.
+  h_a.editor.set_text("abc")
+  h_b.editor.set_text("defgh")
+  assert_eq(w.read().unwrap(), 3 + 5)
+
+  // Teardown per spec §3.7 (bypass-destroy + FFI drain).
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+  let _ = coordinator.destroy_editor(h_a.editor_id)
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  let _ = coordinator.destroy_editor(h_b.editor_id)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+
+///|
+test "smoke 5.2: mutation in editor A invalidates workspace memo and recomputes" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_2_a")
+  let handle_b = create_editor("smoke_5_2_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match
+      coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.2 read h_a: \{r}")
+    }
+    let sb = match
+      coordinator.read_protected(h_b.editor_id, h_b.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.2 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+
+  // Prime with initial values.
+  h_a.editor.set_text("ab")
+  h_b.editor.set_text("cd")
+  assert_eq(w.read().unwrap(), 2 + 2)
+
+  // Mutate editor A's source; the workspace memo must recompute on next read.
+  h_a.editor.set_text("abcdef")
+  assert_eq(w.read().unwrap(), 6 + 2)
+
+  // Teardown per spec §3.7.
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+  let _ = coordinator.destroy_editor(h_a.editor_id)
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  let _ = coordinator.destroy_editor(h_b.editor_id)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+
+///|
+test "smoke 5.3: destroy_editor refused while workspace memo dep is live" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_3_a")
+  let handle_b = create_editor("smoke_5_3_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match
+      coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.3 read h_a: \{r}")
+    }
+    let sb = match
+      coordinator.read_protected(h_b.editor_id, h_b.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.3 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+
+  h_a.editor.set_text("hi")
+  h_b.editor.set_text("world")
+  let pre_sum = w.read().unwrap()
+
+  // Destroy must refuse with the precise AbortReport shape spec §5.3 asserts.
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => fail("expected DestroyWhileDependedUpon, got Ok")
+    Err(report) => {
+      assert_eq(report.kind, @workspace.DestroyWhileDependedUpon)
+      assert_eq(report.editor_id, h_a.editor_id)
+      @debug.assert_eq(report.cell_id, Some(sum_d.id()))
+    }
+  }
+
+  // Editor A must still be alive — re-read the memo and assert the sum is unchanged.
+  assert_eq(w.read().unwrap(), pre_sum)
+
+  // Teardown per spec §3.7.
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+  let _ = coordinator.destroy_editor(h_a.editor_id)
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  let _ = coordinator.destroy_editor(h_b.editor_id)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}
+
+///|
+test "smoke 5.4: clean teardown sequence — each step returns Ok" {
+  reset_coordinator_for_phase1_tests()
+  let handle_a = create_editor("smoke_5_4_a")
+  let handle_b = create_editor("smoke_5_4_b")
+  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_b = lambda_handles.get(handle_b).unwrap()
+
+  let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
+    let sa = match
+      coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.4 read h_a: \{r}")
+    }
+    let sb = match
+      coordinator.read_protected(h_b.editor_id, h_b.cells.parser_source) {
+      Ok(s) => s
+      Err(r) => abort("workspace memo smoke 5.4 read h_b: \{r}")
+    }
+    sa.length() + sb.length()
+  })
+  let w = sum_d.watch()
+  coordinator.register_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.register_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  h_a.editor.set_text("x")
+  h_b.editor.set_text("yz")
+  let _ = w.read().unwrap() // prime
+
+  // Teardown — every step's outcome asserted.
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_a.editor_id,
+    h_a.cells.parser_source.cell_id(),
+  )
+  coordinator.unregister_dep(
+    sum_d.id(),
+    h_b.editor_id,
+    h_b.cells.parser_source.cell_id(),
+  )
+  w.dispose()
+
+  // After unregister + dispose, destroy must succeed.
+  match coordinator.destroy_editor(h_a.editor_id) {
+    Ok(_) => ()
+    Err(report) =>
+      fail("expected Ok destroying h_a after unregister, got \{report}")
+  }
+  match coordinator.destroy_editor(h_b.editor_id) {
+    Ok(_) => ()
+    Err(report) =>
+      fail("expected Ok destroying h_b after unregister, got \{report}")
+  }
+
+  // Drain FFI bookkeeping so leaks don't pollute later tests.
+  h_a.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_a)
+  view_states.remove(handle_a)
+  pretty_view_states.remove(handle_a)
+  h_b.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle_b)
+  view_states.remove(handle_b)
+  pretty_view_states.remove(handle_b)
+  if last_created_handle.val == Some(handle_b) {
+    last_created_handle.val = None
+  }
+}


### PR DESCRIPTION
## Summary

Adds an `ffi/lambda/workspace_memo_smoke_wbtest.mbt` wbtest that drives `@workspace.Coordinator::register_dep` / `unregister_dep` / `destroy_editor` gateway / `read_protected` end-to-end against the **first real-cell workspace memo** — an `@incr.Derived[Int]` summing two Lambda editors' `parser_source` lengths through the global `coordinator` singleton.

Four scenarios per spec §5:
- **5.1 sanity sum** — Derived equals known character-count total across two editors
- **5.2 reactivity** — mutation in editor A invalidates the workspace memo and recomputes
- **5.3 destroy refusal** — `destroy_editor` refused with `AbortReport(kind=DestroyWhileDependedUpon, cell_id=Some(sum_d.id()))` while a workspace dep is live, and editor A stays operationally alive (mutation-after-refused-destroy verified)
- **5.4 clean teardown** — every step in the unregister → dispose → destroy sequence asserted `Ok`

Workspace test count: **1182 → 1186** (rebased on top of #367, current baseline 1199).

## Files changed

| File | Action | Lines |
|------|--------|-------|
| `ffi/lambda/workspace_memo_smoke_wbtest.mbt` | new | +319 |
| `ffi/lambda/moon.pkg` | wbtest-import block | +5 |

No production code, no `.mbti` drift, no new public API. `dowdiness/incr` + `moonbitlang/core/debug` added under `for "wbtest"` because production code only references `@incr.Runtime` via inference (no explicit `@incr` mention).

## Codex pre-merge review

Paired stage-4 review per `[[feedback-codex-broad-vs-scoped-review]]`:

- **Scoped** (spec-conformance, API correctness, teardown contract): **PASS, 0 findings**.
- **Broad** (test rigor, brittle refs, cross-file footguns): **NEEDS-REVISION → addressed in commit `512d594`**.
  - F#1 (must-fix): `let _ = coordinator.destroy_editor(...)` in 5.1/5.2/5.3 swallowed `Err`. Upgraded all 6 sites to `match Ok(_) => () / Err(r) => fail(...)` so teardown failures surface immediately in the test that caused them.
  - F#2 (nice-to-have): 5.3's pre_sum/post_sum equality after refused destroy proved consistency, not aliveness. Strengthened by mutating editor A AFTER refused destroy and asserting the memo recomputes (`27 + 5 == 32`).
  - F#3 (singleton coordinator leakage meta-concern): not addressed — spec §3.7 + Codex round-1/round-2 spec reviews already adjudicated the leakage tradeoff with monotonic `EditorId`s as the mitigation.

## Test plan

- [x] `NEW_MOON_MOD=0 moon test` — 1195/1195 passing post-rebase
- [x] `NEW_MOON_MOD=0 moon check` — clean (no warnings)
- [x] `moon info` — zero `.mbti` drift on `ffi/lambda/pkg.generated.mbti`
- [x] Codex scoped + broad reviews complete

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-28-p0b-first-workspace-memo-design.md`
- Plan: `docs/superpowers/plans/2026-05-28-p0b-first-workspace-memo-implementation.md`

(Both spec and plan are committed in `aaa40b2` as part of this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)