### PR TITLE
feat(ffi/lambda): §P0b Phase 1b WS3 — coordinator-route 2 mechanical accessors

### DIFF
--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -171,13 +171,17 @@ pub fn get_version_json(handle : Int) -> String {
 
 ///|
 /// Get the ProjNode tree as JSON string.
-/// Returns "null" if no projection is available.
+/// Returns "null" if no projection is available or the protected read fails.
 pub fn get_proj_node_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
     Some(h) =>
-      match h.editor.get_proj_node() {
-        Some(proj) => proj.to_json().stringify()
-        None => "null"
+      match coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(Some(proj)) => proj.to_json().stringify()
+        Ok(None) => "null"
+        Err(report) => {
+          println("get_proj_node_json: \{report}")
+          "null"
+        }
       }
     None => "null"
   }
@@ -185,10 +189,18 @@ pub fn get_proj_node_json(handle : Int) -> String {
 
 ///|
 /// Get the SourceMap as JSON string.
-/// Returns an array of {node_id, start, end} entries.
+/// Returns an array of {node_id, start, end} entries, or "[]" if the
+/// protected read fails.
 pub fn get_source_map_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
-    Some(h) => h.editor.get_source_map().to_json().stringify()
+    Some(h) =>
+      match coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(sm) => sm.to_json().stringify()
+        Err(report) => {
+          println("get_source_map_json: \{report}")
+          "[]"
+        }
+      }
     None => "[]"
   }
 }


### PR DESCRIPTION
## Summary

Migrates two truly-mechanical FFI accessors in `ffi/lambda/diagnostics.mbt` to route their reads through `coordinator.read_protected`, matching the WS1 (#349) pattern:

- `get_proj_node_json` — reads `h.cells.cached_proj_node` (was `h.editor.get_proj_node()`)
- `get_source_map_json` — reads `h.cells.source_map_memo` (was `h.editor.get_source_map()`)

Diff: `+18 / -6` in **one file**.

## Scope — narrowed from "5 accessors" to 2

The original §P0b Phase 1b WS3 framing was *"5 remaining Lambda FFI accessors."* An audit against the editor surface surfaced that only 2 of the 5 are truly mechanical single-cell reads. The other 3 are deeply composite:

| Accessor | Cells read pre-migration | Why deferred |
|---|---|---|
| `get_proj_node_json` | `cached_proj_node` only | ✅ shipped here |
| `get_source_map_json` | `source_map_memo` only | ✅ shipped here |
| `get_view_tree_json` | `cached_proj_node` + `source_map_memo` + `get_text()` (unprotected) + capabilities callback | 3 reads + callback — deferred |
| `get_pretty_view_json` | `parser_ast` (via `get_tree`) + Pretty layout + capabilities `pretty_post_process` (which transitively reads `cached_proj_node` + `escalation_memo` for eval annotations) | Composite + transitive — deferred |
| `compute_pretty_patches_json` | Inherits `get_pretty_view`'s reads + mutates `state.previous` cross-call | Composite + cross-call state — deferred |

The WS1 retrospective already named this architectural decision unresolved: *"Migrating those requires either (a) FFI-side decomposition (duplicates editor logic) or (b) editor-level Result-returning variants (editor public API change)."* That decision is its own deliverable, not smuggled into a "mechanical sweep" PR.

## Observational equivalence

Both migrations preserve happy-path behavior:
- `cached_proj_node` is itself `Option`-wrapped; `Ok(None) => "null"` covers empty doc / no-projection.
- `source_map_memo` is always defined; `SourceMap::new()` serializes to `"[]"`.

The new `Err` branches log via `println("get_X: \{report}")` and return the same fallback as the no-handle case, matching WS1's collapse-to-empty contract.

## Codex paired review

Per `[[feedback-codex-broad-vs-scoped-review]]`:

- **Scoped** (empty-doc semantics, Err shape, cell selection, race interaction): **PASS, 0 findings.**
- **Broad** (open-ended pre-merge): **PASS, no must-fix.**
  - nice-to-have: `get_source_map_json` doc-comment should mention `[]` fallback on Err. **Fixed inline.**
  - nice-to-have: no direct tests for the Err fallback paths. **Acknowledged limitation** — exercising the Err path requires synthetic poison-cell test infrastructure deferred from PR4 (per `[[feedback-verify-test-for-flagged-risk]]`).
  - FYI: stray `lib/cognition/pkg.generated.mbti` trailing-newline diff from `moon info`. **Reverted** to keep one-file scope.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check --target js` — clean
- [x] `NEW_MOON_MOD=0 moon test --target js` — 1407/1407 passing
- [x] `moon info` — zero `.mbti` drift on `ffi/lambda/pkg.generated.mbti`
- [x] Codex scoped + broad reviews complete

## Reference

- WS1 pattern: `ffi/lambda/diagnostics.mbt:36-118` (`get_diagnostics_json`), shipped as canopy#349 squash `52b13a0`
- Deferred composite-accessor decision tracked in `project_shared_runtime_workspace_contract.md` memory