### PR TITLE
feat(ffi/lambda): P0b WS3 route remaining accessors

### DIFF
--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -34,6 +34,20 @@ fn reset_coordinator_for_phase1_tests() -> Unit {
 }
 
 ///|
+fn drain_lambda_handle_after_direct_coordinator_destroy(
+  handle : Int,
+  h : LambdaHandle,
+) -> Unit {
+  h.companion.dispose_analysis_attachment()
+  lambda_handles.remove(handle)
+  view_states.remove(handle)
+  pretty_view_states.remove(handle)
+  if last_created_handle.val == Some(handle) {
+    last_created_handle.val = None
+  }
+}
+
+///|
 test "spec §12 #1: each protected cell reads through read_protected" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("test_agent_one")
@@ -119,6 +133,100 @@ test "spec §12 #2: destroy refused while depended-upon; succeeds after unregist
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
   }
+}
+
+///|
+/// Phase 1b workstream 3 suite: the remaining composite Lambda accessors in
+/// this slice now perform coordinator-mediated protected-read guards before
+/// delegating to the existing editor implementation.
+test "workstream 3: get_view_tree_json collapses to null after coordinator destroy" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("view_tree_coord_destroy_agent")
+  set_text(handle, "λx. x")
+  let alive_json = get_view_tree_json(handle)
+  if alive_json == "null" {
+    fail("expected live view tree JSON before coordinator destroy")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(get_view_tree_json(handle), "null")
+  drain_lambda_handle_after_direct_coordinator_destroy(handle, h)
+}
+
+///|
+test "workstream 3: compute_view_patches_json collapses to [] after coordinator destroy" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("view_patches_coord_destroy_agent")
+  set_text(handle, "λx. x")
+  let alive_json = compute_view_patches_json(handle)
+  if alive_json == "[]" {
+    fail("expected live view patch JSON before coordinator destroy")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(compute_view_patches_json(handle), "[]")
+  drain_lambda_handle_after_direct_coordinator_destroy(handle, h)
+}
+
+///|
+test "workstream 3: get_semantic_projection_json collapses to empty after coordinator destroy" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("semantic_projection_coord_destroy_agent")
+  set_text(handle, "let x = 1\nx")
+  let empty = @lambda_semantic.SemanticProjection::empty().to_json().stringify()
+  let alive_json = get_semantic_projection_json(handle)
+  if alive_json == empty {
+    fail("expected live semantic projection JSON before coordinator destroy")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(get_semantic_projection_json(handle), empty)
+  drain_lambda_handle_after_direct_coordinator_destroy(handle, h)
+}
+
+///|
+test "workstream 3: get_pretty_view_json collapses to null after coordinator destroy" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("pretty_view_coord_destroy_agent")
+  set_text(handle, "let x = 1\nx")
+  let alive_json = get_pretty_view_json(handle)
+  if alive_json == "null" {
+    fail("expected live pretty view JSON before coordinator destroy")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(get_pretty_view_json(handle), "null")
+  drain_lambda_handle_after_direct_coordinator_destroy(handle, h)
+}
+
+///|
+test "workstream 3: compute_pretty_patches_json collapses to [] after coordinator destroy" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("pretty_patches_coord_destroy_agent")
+  set_text(handle, "let x = 1\nx")
+  let alive_json = compute_pretty_patches_json(handle)
+  if alive_json == "[]" {
+    fail("expected live pretty patch JSON before coordinator destroy")
+  }
+  let h = lambda_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(compute_pretty_patches_json(handle), "[]")
+  drain_lambda_handle_after_direct_coordinator_destroy(handle, h)
 }
 
 ///|

--- a/ffi/lambda/pretty.mbt
+++ b/ffi/lambda/pretty.mbt
@@ -5,19 +5,55 @@ let pretty_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 
 ///|
 /// Get the pretty-printed ViewNode tree as JSON for a lambda editor.
+/// Returns "null" if any protected read fails.
 pub fn get_pretty_view_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
-    Some(h) => h.editor.get_pretty_view().to_json().stringify()
+    Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_ast) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_pretty_view_json ast read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.escalation_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_pretty_view_json eval read: \{report}")
+          return "null"
+        }
+      }
+      h.editor.get_pretty_view().to_json().stringify()
+    }
     None => "null"
   }
 }
 
 ///|
 /// Compute incremental pretty-view patches for a lambda editor.
-/// Returns a JSON array of ViewPatch objects.
+/// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
+/// fails.
 pub fn compute_pretty_patches_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
     Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_ast) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_pretty_patches_json ast read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.escalation_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_pretty_patches_json eval read: \{report}")
+          return "[]"
+        }
+      }
       let state = match pretty_view_states.get(handle) {
         Some(s) => s
         None => {

--- a/ffi/lambda/semantic.mbt
+++ b/ffi/lambda/semantic.mbt
@@ -18,25 +18,50 @@ fn semantic_node_allows_rename(
 }
 
 ///|
+fn empty_semantic_projection_json() -> String {
+  @lambda_semantic.SemanticProjection::empty().to_json().stringify()
+}
+
+///|
 /// Get the read-only semantic projection as JSON.
 /// Returns `{annotations, decorations, diagnostics}` and never mutates editor
-/// state; semantic edits still lower through text/CRDT edit paths.
+/// state; semantic edits still lower through text/CRDT edit paths. Returns the
+/// empty projection if any protected read fails.
 pub fn get_semantic_projection_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
-    Some(h) =>
-      match h.editor.get_proj_node() {
-        Some(root) =>
-          @lambda_semantic.build_semantic_projection_with_flat_proj(
-            root,
-            h.editor.get_source_map(),
-            h.companion.get_flat_proj(),
-          )
-          .to_json()
-          .stringify()
-        None =>
-          @lambda_semantic.SemanticProjection::empty().to_json().stringify()
+    Some(h) => {
+      let root = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(Some(root)) => root
+        Ok(None) => return empty_semantic_projection_json()
+        Err(report) => {
+          println("get_semantic_projection_json proj read: \{report}")
+          return empty_semantic_projection_json()
+        }
       }
-    None => @lambda_semantic.SemanticProjection::empty().to_json().stringify()
+      let source_map = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(sm) => sm
+        Err(report) => {
+          println("get_semantic_projection_json source_map read: \{report}")
+          return empty_semantic_projection_json()
+        }
+      }
+      let flat_proj = match
+        coordinator.read_protected(h.editor_id, h.cells.proj_memo) {
+        Ok(v) => v.proj
+        Err(report) => {
+          println("get_semantic_projection_json flat-proj read: \{report}")
+          return empty_semantic_projection_json()
+        }
+      }
+      @lambda_semantic.build_semantic_projection_with_flat_proj(
+        root, source_map, flat_proj,
+      )
+      .to_json()
+      .stringify()
+    }
+    None => empty_semantic_projection_json()
   }
 }
 

--- a/ffi/lambda/view.mbt
+++ b/ffi/lambda/view.mbt
@@ -5,24 +5,112 @@ let view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 
 ///|
 /// Get the ViewNode tree as JSON for a lambda editor.
-/// Returns "null" if no projection is available.
+/// Returns "null" if no projection is available or any protected read fails.
 pub fn get_view_tree_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
-    Some(h) =>
+    Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_view_tree_json proj read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_view_tree_json source_map read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_source) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_view_tree_json source read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match coordinator.read_protected(h.editor_id, h.cells.proj_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_view_tree_json flat-proj read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.escalation_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("get_view_tree_json eval read: \{report}")
+          return "null"
+        }
+      }
       match h.editor.get_view_tree() {
         Some(view_node) => view_node.to_json().stringify()
         None => "null"
       }
+    }
     None => "null"
   }
 }
 
 ///|
 /// Compute incremental view patches for a lambda editor.
-/// Returns a JSON array of ViewPatch objects.
+/// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
+/// fails.
 pub fn compute_view_patches_json(handle : Int) -> String {
   match lambda_handles.get(handle) {
     Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_view_patches_json proj read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_view_patches_json source_map read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_source) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_view_patches_json source read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_view_patches_json diagnostics read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match coordinator.read_protected(h.editor_id, h.cells.proj_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_view_patches_json flat-proj read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.escalation_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("compute_view_patches_json eval read: \{report}")
+          return "[]"
+        }
+      }
       let state = match view_states.get(handle) {
         Some(s) => s
         None => {


### PR DESCRIPTION
## Summary
- route get_view_tree_json, compute_view_patches_json, get_semantic_projection_json, get_pretty_view_json, and compute_pretty_patches_json through coordinator.read_protected guards
- collapse destroyed-editor protected-read failures to each accessor fallback
- add Lambda lifecycle whitebox regressions for direct coordinator destroy on all five WS3 accessors

## Validation
- rtk moon check
- rtk moon test -p dowdiness/canopy/ffi/lambda
- rtk moon fmt; cleaned moon.mod migration churn
- rtk moon info; reverted unrelated lib/cognition/pkg.generated.mbti whitespace churn
- rtk moon test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite verifying Lambda accessor functions return expected fallback values after resource cleanup, ensuring system stability.

* **Bug Fixes**
  * Enhanced error handling in JSON accessor functions to gracefully return safe fallback values when protected read operations fail, preventing errors after resource destruction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->