### PR TITLE
feat(ffi/json): P0b route remaining read accessors

### DIFF
--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -120,13 +120,17 @@ pub fn json_get_errors(handle : Int) -> String {
 
 ///|
 /// Get the ProjNode tree as JSON string.
-/// Returns "null" if no projection is available.
+/// Returns "null" if no projection is available or the protected read fails.
 pub fn json_get_proj_node_json(handle : Int) -> String {
   match json_handles.get(handle) {
     Some(h) =>
-      match h.editor.get_proj_node() {
-        Some(proj) => proj.to_json().stringify()
-        None => "null"
+      match coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(Some(proj)) => proj.to_json().stringify()
+        Ok(None) => "null"
+        Err(report) => {
+          println("json_get_proj_node_json proj read: \{report}")
+          "null"
+        }
       }
     None => "null"
   }
@@ -134,10 +138,18 @@ pub fn json_get_proj_node_json(handle : Int) -> String {
 
 ///|
 /// Get the SourceMap as JSON string.
-/// Returns an array of {node_id, start, end} entries.
+/// Returns an array of {node_id, start, end} entries, or "[]" if the
+/// protected read fails.
 pub fn json_get_source_map_json(handle : Int) -> String {
   match json_handles.get(handle) {
-    Some(h) => h.editor.get_source_map().to_json().stringify()
+    Some(h) =>
+      match coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(sm) => sm.to_json().stringify()
+        Err(report) => {
+          println("json_get_source_map_json source_map read: \{report}")
+          "[]"
+        }
+      }
     None => "[]"
   }
 }
@@ -146,26 +158,82 @@ pub fn json_get_source_map_json(handle : Int) -> String {
 
 ///|
 /// Get the ViewNode tree as JSON for a JSON editor.
-/// Returns "null" if no projection is available.
+/// Returns "null" if no projection is available or any protected read fails.
 pub fn json_get_view_tree_json(handle : Int) -> String {
   match json_handles.get(handle) {
-    Some(h) =>
+    Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_get_view_tree_json proj read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_get_view_tree_json source_map read: \{report}")
+          return "null"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_source) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_get_view_tree_json source read: \{report}")
+          return "null"
+        }
+      }
       match h.editor.get_view_tree() {
         Some(view_node) => view_node.to_json().stringify()
         None => "null"
       }
+    }
     None => "null"
   }
 }
 
 ///|
 /// Compute incremental view patches for a JSON editor.
-/// Returns a JSON array of ViewPatch objects. NOT migrated to
-/// `coordinator.read_protected` in WS2 — see spec §9 followup table; will
-/// land in WS3+ alongside the rest of the unmigrated JSON accessors.
+/// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
+/// fails.
 pub fn json_compute_view_patches_json(handle : Int) -> String {
   match json_handles.get(handle) {
     Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_compute_view_patches_json proj read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_compute_view_patches_json source_map read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_source) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_compute_view_patches_json source read: \{report}")
+          return "[]"
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
+        Ok(v) => v
+        Err(report) => {
+          println("json_compute_view_patches_json diagnostics read: \{report}")
+          return "[]"
+        }
+      }
       let state = match json_view_states.get(handle) {
         Some(s) => s
         None => {

--- a/ffi/json/lifecycle_phase1_wbtest.mbt
+++ b/ffi/json/lifecycle_phase1_wbtest.mbt
@@ -20,6 +20,12 @@ fn reset_json_coordinator_for_phase1_tests() -> Unit {
 }
 
 ///|
+fn drain_json_handle_after_direct_coordinator_destroy(handle : Int) -> Unit {
+  json_handles.remove(handle)
+  json_view_states.remove(handle)
+}
+
+///|
 test "spec §12 #1 (json): each protected cell reads through read_protected" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_test_agent_one")
@@ -182,4 +188,79 @@ test "workstream 2 (json): json_get_errors collapses to [] after coordinator des
   assert_eq(json_get_errors(handle), "[]")
   json_handles.remove(handle)
   json_view_states.remove(handle)
+}
+
+///|
+/// Phase 1b JSON followup: remaining exported read accessors route their
+/// protected-cell reads through the coordinator before delegating to the
+/// existing editor implementation.
+test "workstream 3 (json): json_get_proj_node_json collapses to null after coordinator destroy" {
+  reset_json_coordinator_for_phase1_tests()
+  let handle = create_json_editor("json_proj_destroy_agent")
+  json_set_text(handle, "{\"a\": 1}")
+  let alive = json_get_proj_node_json(handle)
+  if alive == "null" {
+    fail("expected live projection JSON before coordinator destroy")
+  }
+  let h = json_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(json_get_proj_node_json(handle), "null")
+  drain_json_handle_after_direct_coordinator_destroy(handle)
+}
+
+///|
+test "workstream 3 (json): json_get_source_map_json collapses to [] after coordinator destroy" {
+  reset_json_coordinator_for_phase1_tests()
+  let handle = create_json_editor("json_source_map_destroy_agent")
+  json_set_text(handle, "{\"a\": 1}")
+  let alive = json_get_source_map_json(handle)
+  if alive == "[]" {
+    fail("expected live source map JSON before coordinator destroy")
+  }
+  let h = json_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(json_get_source_map_json(handle), "[]")
+  drain_json_handle_after_direct_coordinator_destroy(handle)
+}
+
+///|
+test "workstream 3 (json): json_get_view_tree_json collapses to null after coordinator destroy" {
+  reset_json_coordinator_for_phase1_tests()
+  let handle = create_json_editor("json_view_tree_destroy_agent")
+  json_set_text(handle, "{\"a\": 1}")
+  let alive = json_get_view_tree_json(handle)
+  if alive == "null" {
+    fail("expected live view tree JSON before coordinator destroy")
+  }
+  let h = json_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(json_get_view_tree_json(handle), "null")
+  drain_json_handle_after_direct_coordinator_destroy(handle)
+}
+
+///|
+test "workstream 3 (json): json_compute_view_patches_json collapses to [] after coordinator destroy" {
+  reset_json_coordinator_for_phase1_tests()
+  let handle = create_json_editor("json_view_patches_destroy_agent")
+  json_set_text(handle, "{\"a\": 1}")
+  let alive = json_compute_view_patches_json(handle)
+  if alive == "[]" {
+    fail("expected live view patch JSON before coordinator destroy")
+  }
+  let h = json_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(json_compute_view_patches_json(handle), "[]")
+  drain_json_handle_after_direct_coordinator_destroy(handle)
 }


### PR DESCRIPTION
## Summary
- route json_get_proj_node_json and json_get_source_map_json through coordinator.read_protected
- add coordinator preflight guards for json_get_view_tree_json and json_compute_view_patches_json
- add destroyed-editor whitebox regressions for all four JSON accessors

## Validation
- rtk moon check ffi/json
- rtk moon test ffi/json
- rtk env NEW_MOON_MOD=0 moon fmt
- rtk env NEW_MOON_MOD=0 moon info; reverted unrelated lib/cognition/pkg.generated.mbti whitespace churn
- rtk env NEW_MOON_MOD=0 moon check
- rtk env NEW_MOON_MOD=0 moon test
- rtk env NEW_MOON_MOD=0 moon check --deny-warn