### PR TITLE
feat(ffi/markdown): P0b guard export and edit accessors

### DIFF
--- a/ffi/markdown/lifecycle_phase1_wbtest.mbt
+++ b/ffi/markdown/lifecycle_phase1_wbtest.mbt
@@ -28,6 +28,12 @@ fn reset_markdown_coordinator_for_phase1_tests() -> Unit {
 }
 
 ///|
+fn drain_markdown_handle_after_direct_coordinator_destroy(handle : Int) -> Unit {
+  markdown_handles.remove(handle)
+  markdown_view_states.remove(handle)
+}
+
+///|
 test "spec §12 #1 (md): each protected cell reads through read_protected" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_test_agent_one")
@@ -215,4 +221,43 @@ test "workstream 2 (md): compute_view_patches collapses to [] after coordinator 
   assert_eq(markdown_compute_view_patches_json(handle), "[]")
   markdown_handles.remove(handle)
   markdown_view_states.remove(handle)
+}
+
+///|
+/// Phase 1b Markdown followup: exported operations that consult projection /
+/// source-map state guard those protected reads through the coordinator before
+/// delegating to the existing companion implementation.
+test "workstream 3 (md): markdown_export_text collapses to empty after coordinator destroy" {
+  reset_markdown_coordinator_for_phase1_tests()
+  let handle = create_markdown_editor("md_export_destroy_agent")
+  markdown_set_text(handle, "# Pre-destroy\n")
+  let alive = markdown_export_text(handle)
+  if alive == "" {
+    fail("expected exported markdown before coordinator destroy")
+  }
+  let h = markdown_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  assert_eq(markdown_export_text(handle), "")
+  drain_markdown_handle_after_direct_coordinator_destroy(handle)
+}
+
+///|
+test "workstream 3 (md): markdown_apply_edit rejects after coordinator destroy" {
+  reset_markdown_coordinator_for_phase1_tests()
+  let handle = create_markdown_editor("md_apply_destroy_agent")
+  markdown_set_text(handle, "# Pre-destroy\n")
+  let h = markdown_handles.get(handle).unwrap()
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  let out = markdown_apply_edit(handle, "commit_edit", 0, "after", 0, 1)
+  if !out.contains("\"status\":\"error\"") ||
+    !out.contains("\"message\":\"editor unavailable\"") {
+    fail("expected editor-unavailable error after destroy, got \{out}")
+  }
+  drain_markdown_handle_after_direct_coordinator_destroy(handle)
 }

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -88,7 +88,25 @@ pub fn markdown_get_text(handle : Int) -> String {
 /// paragraphs with mixed text) untouched.
 pub fn markdown_export_text(handle : Int) -> String {
   match markdown_handles.get(handle) {
-    Some(h) => @md_companion.export_markdown_text(h.editor)
+    Some(h) => {
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(v) => v
+        Err(report) => {
+          println("markdown_export_text proj read: \{report}")
+          return ""
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("markdown_export_text source_map read: \{report}")
+          return ""
+        }
+      }
+      @md_companion.export_markdown_text(h.editor)
+    }
     None => ""
   }
 }
@@ -147,6 +165,28 @@ pub fn markdown_apply_edit(
             "status": Json::string("error"),
             "message": Json::string("unknown op: " + op_type),
           }).stringify()
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(v) => v
+        Err(report) => {
+          println("markdown_apply_edit proj read: \{report}")
+          return Json::object({
+            "status": Json::string("error"),
+            "message": Json::string("editor unavailable"),
+          }).stringify()
+        }
+      }
+      let _ = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(v) => v
+        Err(report) => {
+          println("markdown_apply_edit source_map read: \{report}")
+          return Json::object({
+            "status": Json::string("error"),
+            "message": Json::string("editor unavailable"),
+          }).stringify()
+        }
       }
       match @md_companion.apply_markdown_edit(h.editor, op, timestamp_ms) {
         Ok(_) => Json::object({ "status": Json::string("ok") }).stringify()

--- a/ffi/markdown/moon.pkg
+++ b/ffi/markdown/moon.pkg
@@ -13,11 +13,11 @@ import {
 }
 
 // `cells` field of MarkdownHandle is read in production by
-// `markdown_compute_view_patches_json` (parser_diagnostics + cached_proj_node
-// + source_map_memo, via Phase 1b workstream 2) and by whitebox tests
-// (`lifecycle_phase1_wbtest.mbt`) for the remaining 4 cells. Until additional
-// Phase 1b workstreams migrate the other production accessors, per-field
-// unused warnings still fire on the rest of `MarkdownProtectedCells`.
+// `markdown_compute_view_patches_json`, `markdown_export_text`, and
+// `markdown_apply_edit` (parser_diagnostics + cached_proj_node +
+// source_map_memo) and by whitebox tests (`lifecycle_phase1_wbtest.mbt`) for
+// the remaining 4 cells. Per-field unused warnings still fire on the rest of
+// `MarkdownProtectedCells`.
 
 warnings = "-7"
 


### PR DESCRIPTION
## Summary
- guard markdown_export_text projection/source-map reads through coordinator.read_protected
- guard markdown_apply_edit projection/source-map reads before delegating to the companion edit bridge
- add destroyed-editor whitebox regressions for export and edit behavior

## Validation
- rtk env NEW_MOON_MOD=0 moon check ffi/markdown
- rtk env NEW_MOON_MOD=0 moon test ffi/markdown
- rtk env NEW_MOON_MOD=0 moon fmt
- rtk env NEW_MOON_MOD=0 moon info; reverted unrelated lib/cognition/pkg.generated.mbti whitespace churn
- rtk env NEW_MOON_MOD=0 moon check
- rtk env NEW_MOON_MOD=0 moon test
- rtk env NEW_MOON_MOD=0 moon check --deny-warn