### PR TITLE
fix(ffi/lambda): guard semantic rename accessor

### DIFF
--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -194,6 +194,31 @@ test "workstream 3: get_semantic_projection_json collapses to empty after coordi
 }
 
 ///|
+test "workstream 3: rename_semantic_node rejects after coordinator destroy" {
+  reset_coordinator_for_phase1_tests()
+  let handle = create_editor("semantic_rename_coord_destroy_agent")
+  set_text(handle, "λx. x")
+  let h = lambda_handles.get(handle).unwrap()
+  let body_id = match h.editor.get_proj_node() {
+    Some(root) =>
+      match root.children[0].id().to_json() {
+        Json::Number(n, ..) => n.to_int()
+        _ => fail("expected numeric node id")
+      }
+    None => fail("expected projection")
+  }
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  inspect(
+    rename_semantic_node(handle, body_id, "y", 0),
+    content="error: editor unavailable",
+  )
+  drain_lambda_handle_after_direct_coordinator_destroy(handle, h)
+}
+
+///|
 test "workstream 3: get_pretty_view_json collapses to null after coordinator destroy" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("pretty_view_coord_destroy_agent")

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -24,12 +24,10 @@ import {
   "moonbitlang/core/debug",
 } for "wbtest"
 
-// `cells` field of LambdaHandle is read in production by `get_diagnostics_json`
-// (parser_diagnostics + typecheck_output + escalation_memo, via Phase 1b
-// workstream 1) and by whitebox tests (`lifecycle_phase1_wbtest.mbt`) for the
-// remaining 7 cells. Until additional Phase 1b workstreams migrate the other
-// production accessors, per-field unused warnings still fire on the rest of
-// `LambdaProtectedCells`.
+// `cells` field of LambdaHandle is read in production by Phase 1b accessors
+// (`get_diagnostics_json`, view/pretty/semantic projection accessors, and
+// `rename_semantic_node`) and by whitebox tests
+// (`lifecycle_phase1_wbtest.mbt`) for direct protected-cell coverage.
 
 warnings = "-7"
 

--- a/ffi/lambda/semantic.mbt
+++ b/ffi/lambda/semantic.mbt
@@ -78,14 +78,33 @@ pub fn rename_semantic_node(
   match lambda_handles.get(handle) {
     Some(h) => {
       let id = @core.NodeId::from_int(node_id)
-      let root = match h.editor.get_proj_node() {
-        Some(root) => root
-        None => return "error: no projection"
+      let root = match
+        coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+        Ok(Some(root)) => root
+        Ok(None) => return "error: no projection"
+        Err(report) => {
+          println("rename_semantic_node proj read: \{report}")
+          return "error: editor unavailable"
+        }
+      }
+      let source_map = match
+        coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+        Ok(sm) => sm
+        Err(report) => {
+          println("rename_semantic_node source_map read: \{report}")
+          return "error: editor unavailable"
+        }
+      }
+      let flat_proj = match
+        coordinator.read_protected(h.editor_id, h.cells.proj_memo) {
+        Ok(v) => v.proj
+        Err(report) => {
+          println("rename_semantic_node flat-proj read: \{report}")
+          return "error: editor unavailable"
+        }
       }
       let projection = @lambda_semantic.build_semantic_projection_with_flat_proj(
-        root,
-        h.editor.get_source_map(),
-        h.companion.get_flat_proj(),
+        root, source_map, flat_proj,
       )
       if !semantic_node_allows_rename(projection, id) {
         return "error: node is not a semantic binder or reference"


### PR DESCRIPTION
## Summary
- Route `rename_semantic_node` projection, source-map, and flat-proj reads through `coordinator.read_protected`.
- Add a destroyed-editor regression for the semantic rename action.
- Refresh the Lambda package warning comment for the migrated Phase 1b accessors.

## Validation
- `NEW_MOON_MOD=0 moon check ffi/lambda`
- `NEW_MOON_MOD=0 moon test ffi/lambda --filter 'workstream 3: rename_semantic_node rejects after coordinator destroy'`
- `NEW_MOON_MOD=0 moon test ffi/lambda`
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info` (reverted unrelated `lib/cognition/pkg.generated.mbti` churn)
- `NEW_MOON_MOD=0 moon check --deny-warn`
- `NEW_MOON_MOD=0 moon test`
