### PR TITLE
fix(ffi/json): guard apply edit accessor

### DIFF
--- a/ffi/json/edit.mbt
+++ b/ffi/json/edit.mbt
@@ -14,11 +14,28 @@ pub fn json_apply_edit(
         _ => return "error: invalid JSON"
       }
       match parse_json_edit_op(json) {
-        Ok(op) =>
+        Ok(op) => {
+          let _ = match
+            coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
+            Ok(v) => v
+            Err(report) => {
+              println("json_apply_edit proj read: \{report}")
+              return "error: editor unavailable"
+            }
+          }
+          let _ = match
+            coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
+            Ok(v) => v
+            Err(report) => {
+              println("json_apply_edit source_map read: \{report}")
+              return "error: editor unavailable"
+            }
+          }
           match @json_companion.apply_json_edit(h.editor, op, timestamp_ms) {
             Ok(_) => "ok"
             Err(err) => "error: " + err
           }
+        }
         Err(err) => "error: " + err
       }
     }

--- a/ffi/json/lifecycle_phase1_wbtest.mbt
+++ b/ffi/json/lifecycle_phase1_wbtest.mbt
@@ -191,9 +191,9 @@ test "workstream 2 (json): json_get_errors collapses to [] after coordinator des
 }
 
 ///|
-/// Phase 1b JSON followup: remaining exported read accessors route their
-/// protected-cell reads through the coordinator before delegating to the
-/// existing editor implementation.
+/// Phase 1b JSON followup: remaining exported accessors route their
+/// projection/source-map protected-cell reads through the coordinator before
+/// delegating to the existing editor implementation.
 test "workstream 3 (json): json_get_proj_node_json collapses to null after coordinator destroy" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_proj_destroy_agent")
@@ -262,5 +262,30 @@ test "workstream 3 (json): json_compute_view_patches_json collapses to [] after 
     Err(report) => fail("coordinator destroy: \{report}")
   }
   assert_eq(json_compute_view_patches_json(handle), "[]")
+  drain_json_handle_after_direct_coordinator_destroy(handle)
+}
+
+///|
+test "workstream 3 (json): json_apply_edit rejects after coordinator destroy" {
+  reset_json_coordinator_for_phase1_tests()
+  let handle = create_json_editor("json_apply_destroy_agent")
+  json_set_text(handle, "{\"a\": 1}")
+  let h = json_handles.get(handle).unwrap()
+  let node_id = match h.editor.get_proj_node() {
+    Some(root) =>
+      match root.id().to_json() {
+        Json::Number(n, ..) => n.to_int()
+        _ => fail("expected numeric node id")
+      }
+    None => fail("expected projection")
+  }
+  match coordinator.destroy_editor(h.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("coordinator destroy: \{report}")
+  }
+  let op_json = "{\"op\":\"CommitEdit\",\"node_id\":" +
+    node_id.to_string() +
+    ",\"new_value\":\"2\"}"
+  assert_eq(json_apply_edit(handle, op_json, 0), "error: editor unavailable")
   drain_json_handle_after_direct_coordinator_destroy(handle)
 }

--- a/ffi/json/moon.pkg
+++ b/ffi/json/moon.pkg
@@ -10,11 +10,10 @@ import {
   "moonbitlang/core/json" @core_json,
 }
 
-// `cells` field of JsonHandle is read in production by `json_get_errors`
-// (parser_diagnostics, via Phase 1b workstream 2) and by whitebox tests
-// (`lifecycle_phase1_wbtest.mbt`) for the remaining 6 cells. Until additional
-// Phase 1b workstreams migrate the other production accessors, per-field
-// unused warnings still fire on the rest of `JsonProtectedCells`.
+// `cells` field of JsonHandle is read in production by Phase 1b accessors
+// (`json_get_errors`, read/view accessors, and `json_apply_edit`) and by
+// whitebox tests (`lifecycle_phase1_wbtest.mbt`) for direct protected-cell
+// coverage.
 
 warnings = "-7"
 


### PR DESCRIPTION
## Summary
- Route `json_apply_edit` projection and source-map reads through `coordinator.read_protected` before delegating to the JSON companion edit implementation.
- Preserve existing JSON/op parse error precedence before protected-cell guards.
- Add a destroyed-editor regression and refresh the JSON package warning comment for Phase 1b accessors.

## Validation
- `NEW_MOON_MOD=0 moon check ffi/json`
- `NEW_MOON_MOD=0 moon test ffi/json --filter 'workstream 3 (json): json_apply_edit rejects after coordinator destroy'`
- `NEW_MOON_MOD=0 moon test ffi/json`
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info` (reverted unrelated `lib/cognition/pkg.generated.mbti` churn)
- `NEW_MOON_MOD=0 moon check --deny-warn`
- `NEW_MOON_MOD=0 moon test`
