### PR TITLE
feat: add reactive provider boundary driver

### DIFF
--- a/lib/cognition/provider_boundary_driver_wbtest.mbt
+++ b/lib/cognition/provider_boundary_driver_wbtest.mbt
@@ -1,0 +1,369 @@
+///|
+priv struct ScriptedProviderResponse {
+  request_id : ProviderRequestId
+  result : ProviderResult
+}
+
+///|
+fn ScriptedProviderResponse::ScriptedProviderResponse(
+  request_id~ : ProviderRequestId,
+  result~ : ProviderResult,
+) -> ScriptedProviderResponse {
+  { request_id, result: result.copy_result() }
+}
+
+///|
+priv struct ScriptedProviderDriver {
+  store : CognitionStore
+  mut responses : Array[ScriptedProviderResponse]
+  started : Array[ProviderRequestId]
+  cancelled : Array[ProviderRequestId]
+  mut now_ms : Int
+  mut shutdown : Bool
+}
+
+///|
+fn ScriptedProviderDriver::ScriptedProviderDriver(
+  store : CognitionStore,
+) -> ScriptedProviderDriver {
+  {
+    store,
+    responses: [],
+    started: [],
+    cancelled: [],
+    now_ms: 0,
+    shutdown: false,
+  }
+}
+
+///|
+fn ScriptedProviderDriver::enqueue(
+  self : ScriptedProviderDriver,
+  request : ProviderRequestDescriptor,
+  result : ProviderResult,
+) -> Unit {
+  self.responses.push(
+    ScriptedProviderResponse::ScriptedProviderResponse(
+      request_id=request.id(),
+      result~,
+    ),
+  )
+}
+
+///|
+fn ScriptedProviderDriver::shutdown(self : ScriptedProviderDriver) -> Unit {
+  self.shutdown = true
+}
+
+///|
+fn ScriptedProviderDriver::set_fake_time_ms(
+  self : ScriptedProviderDriver,
+  now_ms : Int,
+) -> Unit {
+  self.now_ms = now_ms
+}
+
+///|
+fn ScriptedProviderDriver::step(self : ScriptedProviderDriver) -> Bool {
+  if self.shutdown {
+    false
+  } else {
+    match self.store.reactive.provider_next_driver_action_at(self.now_ms) {
+      ProviderDriverAction::StartProviderRequest(request) =>
+        self.complete_next_response(request)
+      ProviderDriverAction::RetryProviderRequest(request) =>
+        self.retry_next_response(request)
+      ProviderDriverAction::CancelProviderRequest(request_id) => {
+        if !self.cancelled.contains(request_id) {
+          self.cancelled.push(request_id)
+        }
+        self.store.reactive.acknowledge_provider_cancellation(request_id)
+        false
+      }
+      ProviderDriverAction::WaitProviderRetry(_, _) => false
+      ProviderDriverAction::NoDriverAction => false
+    }
+  }
+}
+
+///|
+fn ScriptedProviderDriver::retry_next_response(
+  self : ScriptedProviderDriver,
+  request : ProviderRequestDescriptor,
+) -> Bool {
+  let replanned = self.store.plan_provider_request(
+    target=request.target(),
+    options=request.options(),
+  )
+  self.complete_next_response(replanned)
+}
+
+///|
+fn ScriptedProviderDriver::complete_next_response(
+  self : ScriptedProviderDriver,
+  request : ProviderRequestDescriptor,
+) -> Bool {
+  self.started.push(request.id())
+  self.store.reactive.acknowledge_provider_start(request.id())
+  match self.take_response(request.id()) {
+    Some(result) => {
+      let _ = self.store.complete_provider_request(
+        provider_driver_completion_for_test(request, result),
+      )
+      true
+    }
+    None => false
+  }
+}
+
+///|
+fn ScriptedProviderDriver::take_response(
+  self : ScriptedProviderDriver,
+  request_id : ProviderRequestId,
+) -> ProviderResult? {
+  let mut selected : ProviderResult? = None
+  let remaining : Array[ScriptedProviderResponse] = []
+  for response in self.responses {
+    if selected is None && response.request_id == request_id {
+      selected = Some(response.result.copy_result())
+    } else {
+      remaining.push(response)
+    }
+  }
+  self.responses = remaining
+  selected
+}
+
+///|
+fn provider_driver_options_for_test() -> ProviderOptionProvenance {
+  ProviderOptionProvenance::new(
+    task_kind="summarize",
+    provider_id="scripted-provider",
+    model_id="scripted-model",
+    option_identity=RedactedOptionIdentity::new(
+      "temperature=<redacted>;max=128",
+    ),
+  )
+}
+
+///|
+fn provider_driver_completion_for_test(
+  request : ProviderRequestDescriptor,
+  result : ProviderResult,
+) -> ProviderResultDescriptor {
+  ProviderResultDescriptor::new(
+    request_id=request.id(),
+    target=request.target(),
+    options=request.options(),
+    source_revisions=request.source_revisions(),
+    dependency_fingerprint=request.dependency_fingerprint(),
+    result~,
+  )
+}
+
+///|
+fn provider_driver_summary_for_test(
+  store : CognitionStore,
+  key : CognitionKey,
+) -> String raise {
+  match store.get_value(key) {
+    Some(Summary(summary)) => summary
+    _ => fail("expected summary")
+  }
+}
+
+///|
+test "scripted provider driver completes planned success without network" {
+  let store = CognitionStore::new()
+  let driver = ScriptedProviderDriver::ScriptedProviderDriver(store)
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_driver_options_for_test(),
+  )
+  driver.enqueue(request, ProviderResult::Succeeded(Summary("scripted alpha")))
+
+  inspect(driver.step(), content="true")
+
+  inspect(
+    provider_driver_summary_for_test(store, target),
+    content="scripted alpha",
+  )
+  match store.get_provider_status(request.id()) {
+    Some(status) =>
+      inspect(
+        status.status() == ProviderRequestStatus::Succeeded,
+        content="true",
+      )
+    None => fail("expected provider status")
+  }
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::NoDriverAction,
+    content="true",
+  )
+}
+
+///|
+test "scripted provider driver does not duplicate in-flight start without response" {
+  let store = CognitionStore::new()
+  let driver = ScriptedProviderDriver::ScriptedProviderDriver(store)
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_driver_options_for_test(),
+  )
+
+  inspect(driver.step(), content="false")
+  inspect(driver.started.length(), content="1")
+  inspect(driver.started[0] == request.id(), content="true")
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::NoDriverAction,
+    content="true",
+  )
+  inspect(driver.step(), content="false")
+  inspect(driver.started.length(), content="1")
+}
+
+///|
+test "scripted provider driver waits under fake time then retries" {
+  let store = CognitionStore::new()
+  let driver = ScriptedProviderDriver::ScriptedProviderDriver(store)
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_driver_options_for_test(),
+  )
+  driver.set_fake_time_ms(100)
+  driver.enqueue(
+    request,
+    ProviderResult::Failed(ProviderError::RateLimited(retry_after_ms=Some(50))),
+  )
+  driver.enqueue(request, ProviderResult::Succeeded(Summary("retry alpha")))
+
+  inspect(driver.step(), content="true")
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::WaitProviderRetry(request.id(), 150),
+    content="true",
+  )
+  inspect(driver.step(), content="false")
+  driver.set_fake_time_ms(149)
+  inspect(driver.step(), content="false")
+  driver.set_fake_time_ms(150)
+  inspect(
+    store.reactive.provider_next_driver_action_at(150) ==
+    ProviderDriverAction::RetryProviderRequest(request),
+    content="true",
+  )
+  inspect(driver.step(), content="true")
+
+  inspect(
+    provider_driver_summary_for_test(store, target),
+    content="retry alpha",
+  )
+  match store.get_provider_status(request.id()) {
+    Some(status) =>
+      inspect(
+        status.status() == ProviderRequestStatus::Succeeded,
+        content="true",
+      )
+    None => fail("expected provider status")
+  }
+}
+
+///|
+test "scripted provider driver observes cancellation without completing" {
+  let store = CognitionStore::new()
+  let driver = ScriptedProviderDriver::ScriptedProviderDriver(store)
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_driver_options_for_test(),
+  )
+  driver.enqueue(
+    request,
+    ProviderResult::Succeeded(Summary("should not be stored")),
+  )
+
+  let _ = store.cancel_provider_request(request.id())
+  inspect(driver.step(), content="false")
+
+  inspect(driver.cancelled.contains(request.id()), content="true")
+  inspect(store.get_value(target) is None, content="true")
+  match store.get_provider_status(request.id()) {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(ProviderError::Cancelled),
+        content="true",
+      )
+    None => fail("expected provider status")
+  }
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::NoDriverAction,
+    content="true",
+  )
+}
+
+///|
+test "scripted provider driver cancels before starting later request" {
+  let store = CognitionStore::new()
+  let driver = ScriptedProviderDriver::ScriptedProviderDriver(store)
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let target_b = CognitionKey::FileSummary("src/b.mbt")
+  let request_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_driver_options_for_test(),
+  )
+  let request_b = store.plan_provider_request(
+    target=target_b,
+    options=provider_driver_options_for_test(),
+  )
+  driver.enqueue(request_b, ProviderResult::Succeeded(Summary("scripted beta")))
+
+  let _ = store.cancel_provider_request(request_a.id())
+  inspect(driver.step(), content="false")
+
+  inspect(driver.cancelled.contains(request_a.id()), content="true")
+  inspect(store.get_value(target_b) is None, content="true")
+  inspect(driver.step(), content="true")
+  inspect(
+    provider_driver_summary_for_test(store, target_b),
+    content="scripted beta",
+  )
+}
+
+///|
+test "scripted provider driver shutdown leaves queued completion unapplied" {
+  let store = CognitionStore::new()
+  let driver = ScriptedProviderDriver::ScriptedProviderDriver(store)
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_driver_options_for_test(),
+  )
+  driver.enqueue(
+    request,
+    ProviderResult::Succeeded(Summary("should not be stored")),
+  )
+
+  driver.shutdown()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha changed"))
+  inspect(driver.step(), content="false")
+
+  inspect(store.get_value(target) is None, content="true")
+  match store.get_provider_status(request.id()) {
+    Some(status) =>
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+    None => fail("expected provider status")
+  }
+}

--- a/lib/cognition/provider_boundary_reactive.mbt
+++ b/lib/cognition/provider_boundary_reactive.mbt
@@ -1,0 +1,871 @@
+///|
+/// Request intent fed into the internal provider-planning graph.
+priv struct ProviderPlanningIntent {
+  target : CognitionKey
+  options : ProviderOptionProvenance
+  snapshot : ProviderPlanningSnapshot
+} derive(Eq)
+
+///|
+fn ProviderPlanningIntent::ProviderPlanningIntent(
+  target~ : CognitionKey,
+  options~ : ProviderOptionProvenance,
+  snapshot~ : ProviderPlanningSnapshot,
+) -> ProviderPlanningIntent {
+  { target, options, snapshot }
+}
+
+///|
+/// Graph snapshot observed while planning one provider request.
+priv struct ProviderPlanningSnapshot {
+  context : Array[ContextItem]
+  source_revisions : Array[ProviderSourceSnapshot]
+  dependencies : Array[CognitionKey]
+} derive(Eq)
+
+///|
+fn ProviderPlanningSnapshot::ProviderPlanningSnapshot(
+  context~ : Array[ContextItem],
+  source_revisions~ : Array[ProviderSourceSnapshot],
+  dependencies~ : Array[CognitionKey],
+) -> ProviderPlanningSnapshot {
+  {
+    context: context.copy(),
+    source_revisions: source_revisions.copy(),
+    dependencies: dependencies.copy(),
+  }
+}
+
+///|
+/// User cancellation input recorded for one planned request.
+priv struct ProviderCancellationRecord {
+  request_id : ProviderRequestId
+  cancelled_at_ms : Int
+  driver_acknowledged : Bool
+} derive(Eq)
+
+///|
+fn ProviderCancellationRecord::ProviderCancellationRecord(
+  request_id~ : ProviderRequestId,
+  cancelled_at_ms~ : Int,
+) -> ProviderCancellationRecord {
+  { request_id, cancelled_at_ms, driver_acknowledged: false }
+}
+
+///|
+fn ProviderCancellationRecord::acknowledge_driver(
+  self : ProviderCancellationRecord,
+) -> ProviderCancellationRecord {
+  {
+    request_id: self.request_id,
+    cancelled_at_ms: self.cancelled_at_ms,
+    driver_acknowledged: true,
+  }
+}
+
+///|
+/// Driver start input recorded for the current in-flight attempt.
+priv struct ProviderStartRecord {
+  request_id : ProviderRequestId
+  started_at_ms : Int
+} derive(Eq)
+
+///|
+fn ProviderStartRecord::ProviderStartRecord(
+  request_id~ : ProviderRequestId,
+  started_at_ms~ : Int,
+) -> ProviderStartRecord {
+  { request_id, started_at_ms }
+}
+
+///|
+/// Completion/error input recorded for one planned request.
+priv struct ProviderCompletionRecord {
+  completion : ProviderResultDescriptor
+  completed_at_ms : Int
+} derive(Eq)
+
+///|
+fn ProviderCompletionRecord::ProviderCompletionRecord(
+  completion~ : ProviderResultDescriptor,
+  completed_at_ms~ : Int,
+) -> ProviderCompletionRecord {
+  { completion, completed_at_ms }
+}
+
+///|
+/// Internal status state for one planned provider request.
+priv struct ProviderRequestState {
+  request : ProviderRequestDescriptor
+  start : ProviderStartRecord?
+  cancellation : ProviderCancellationRecord?
+  completion : ProviderCompletionRecord?
+} derive(Eq)
+
+///|
+fn ProviderRequestState::ProviderRequestState(
+  request~ : ProviderRequestDescriptor,
+  start~ : ProviderStartRecord?,
+  cancellation~ : ProviderCancellationRecord?,
+  completion~ : ProviderCompletionRecord?,
+) -> ProviderRequestState {
+  { request, start, cancellation, completion }
+}
+
+///|
+fn ProviderRequestState::pending(
+  request : ProviderRequestDescriptor,
+) -> ProviderRequestState {
+  ProviderRequestState::ProviderRequestState(
+    request~,
+    start=None,
+    cancellation=None,
+    completion=None,
+  )
+}
+
+///|
+fn ProviderRequestState::with_start(
+  self : ProviderRequestState,
+  start : ProviderStartRecord,
+) -> ProviderRequestState {
+  ProviderRequestState::ProviderRequestState(
+    request=self.request,
+    start=Some(start),
+    cancellation=self.cancellation,
+    completion=self.completion,
+  )
+}
+
+///|
+fn ProviderRequestState::with_cancellation(
+  self : ProviderRequestState,
+  cancellation : ProviderCancellationRecord,
+) -> ProviderRequestState {
+  ProviderRequestState::ProviderRequestState(
+    request=self.request,
+    start=self.start,
+    cancellation=Some(cancellation),
+    completion=self.completion,
+  )
+}
+
+///|
+fn ProviderRequestState::with_cancellation_acknowledged(
+  self : ProviderRequestState,
+) -> ProviderRequestState {
+  match self.cancellation {
+    Some(cancellation) =>
+      ProviderRequestState::ProviderRequestState(
+        request=self.request,
+        start=self.start,
+        cancellation=Some(cancellation.acknowledge_driver()),
+        completion=self.completion,
+      )
+    None => self
+  }
+}
+
+///|
+fn ProviderRequestState::with_completion(
+  self : ProviderRequestState,
+  completion : ProviderCompletionRecord,
+) -> ProviderRequestState {
+  ProviderRequestState::ProviderRequestState(
+    request=self.request,
+    start=None,
+    cancellation=self.cancellation,
+    completion=Some(completion),
+  )
+}
+
+///|
+fn ProviderRequestState::status(
+  self : ProviderRequestState,
+) -> ProviderRequestStatus {
+  provider_status_for_records(self.request, self.cancellation, self.completion)
+}
+
+///|
+fn ProviderRequestState::driver_action(
+  self : ProviderRequestState,
+  now_ms : Int,
+) -> ProviderDriverAction {
+  provider_next_driver_action_for_records(
+    self.request,
+    self.start,
+    self.cancellation,
+    self.completion,
+    now_ms,
+  )
+}
+
+///|
+/// Deterministic next action for a provider driver to interpret outside `@incr`.
+priv enum ProviderDriverAction {
+  NoDriverAction
+  StartProviderRequest(ProviderRequestDescriptor)
+  CancelProviderRequest(ProviderRequestId)
+  WaitProviderRetry(ProviderRequestId, Int)
+  RetryProviderRequest(ProviderRequestDescriptor)
+} derive(Eq)
+
+///|
+/// Internal `@incr` cells for provider planning/status state.
+priv struct ProviderPlanningGraph {
+  runtime : @incr.Runtime
+  scope : @incr.Scope
+  intent : @incr.Input[ProviderPlanningIntent?]
+  request_states : @incr.Input[Array[ProviderRequestState]]
+  fake_time_ms : @incr.Input[Int]
+  dependency_fingerprint_cell_id : @incr.CellId
+  request_cell_id : @incr.CellId
+  status_cell_id : @incr.CellId
+  retry_classification_cell_id : @incr.CellId
+  next_driver_action_cell_id : @incr.CellId
+  dependency_fingerprint_watch : @incr.Watch[ProviderDependencyFingerprint?]
+  request_watch : @incr.Watch[ProviderRequestDescriptor?]
+  status_watch : @incr.Watch[ProviderStatusDescriptor?]
+  retry_classification_watch : @incr.Watch[ProviderRetryClassification?]
+  next_driver_action_watch : @incr.Watch[ProviderDriverAction]
+}
+
+///|
+fn ProviderPlanningGraph::ProviderPlanningGraph(
+  runtime : @incr.Runtime,
+) -> ProviderPlanningGraph {
+  let scope = @incr.Scope::new(runtime)
+  let intent : @incr.Input[ProviderPlanningIntent?] = scope.input(
+    None,
+    label="cognition_provider_request_intent",
+  )
+  let request_states : @incr.Input[Array[ProviderRequestState]] = scope.input(
+    [],
+    label="cognition_provider_request_states",
+  )
+  let fake_time_ms = scope.input(0, label="cognition_provider_fake_time_ms")
+  let dependency_fingerprint_cell = scope.derived(
+    fn() {
+      match intent.get() {
+        Some(intent) =>
+          Some(
+            provider_dependency_fingerprint_for_snapshots(
+              intent.snapshot.dependencies,
+              intent.snapshot.source_revisions,
+            ),
+          )
+        None => None
+      }
+    },
+    label="cognition_provider_dependency_fingerprint",
+  )
+  let request_cell = scope.derived(
+    fn() {
+      match (intent.get(), dependency_fingerprint_cell.get_or_abort()) {
+        (Some(intent), Some(dependency_fingerprint)) =>
+          Some(
+            ProviderRequestDescriptor::new(
+              id=provider_request_id_for(
+                intent.target,
+                intent.options,
+                dependency_fingerprint,
+              ),
+              target=intent.target,
+              options=intent.options,
+              context=intent.snapshot.context,
+              source_revisions=intent.snapshot.source_revisions,
+              dependencies=intent.snapshot.dependencies,
+              dependency_fingerprint~,
+            ),
+          )
+        _ => None
+      }
+    },
+    label="cognition_provider_request_descriptor",
+  )
+  let status_cell = scope.derived(
+    fn() {
+      match request_cell.get_or_abort() {
+        Some(request) => {
+          let state = provider_state_for_request(request_states.get(), request).unwrap_or(
+            ProviderRequestState::pending(request),
+          )
+          Some(
+            ProviderStatusDescriptor::new(
+              request_id=request.id(),
+              target=request.target(),
+              status=state.status(),
+            ),
+          )
+        }
+        None => None
+      }
+    },
+    label="cognition_provider_status",
+  )
+  let retry_classification_cell = scope.derived(
+    fn() {
+      match status_cell.get_or_abort() {
+        Some(status) =>
+          match status.status() {
+            ProviderRequestStatus::Failed(error) =>
+              Some(error.retry_classification())
+            _ => None
+          }
+        None => None
+      }
+    },
+    label="cognition_provider_retry_classification",
+  )
+  let next_driver_action_cell = scope.derived(
+    fn() {
+      provider_next_driver_action_for_states(
+        request_states.get(),
+        fake_time_ms.get(),
+      )
+    },
+    label="cognition_provider_next_driver_action",
+  )
+  let graph = {
+    runtime,
+    scope,
+    intent,
+    request_states,
+    fake_time_ms,
+    dependency_fingerprint_cell_id: dependency_fingerprint_cell.id(),
+    request_cell_id: request_cell.id(),
+    status_cell_id: status_cell.id(),
+    retry_classification_cell_id: retry_classification_cell.id(),
+    next_driver_action_cell_id: next_driver_action_cell.id(),
+    dependency_fingerprint_watch: scope.add_watch(
+      dependency_fingerprint_cell.watch(),
+    ),
+    request_watch: scope.add_watch(request_cell.watch()),
+    status_watch: scope.add_watch(status_cell.watch()),
+    retry_classification_watch: scope.add_watch(
+      retry_classification_cell.watch(),
+    ),
+    next_driver_action_watch: scope.add_watch(next_driver_action_cell.watch()),
+  }
+  let _ = graph.watched_cells_are_rooted()
+  graph
+}
+
+///|
+fn ProviderPlanningGraph::plan_request(
+  self : ProviderPlanningGraph,
+  target~ : CognitionKey,
+  options~ : ProviderOptionProvenance,
+  context~ : Array[ContextItem],
+  source_revisions~ : Array[ProviderSourceSnapshot],
+  dependencies~ : Array[CognitionKey],
+) -> ProviderRequestDescriptor {
+  self.intent.set(
+    Some(
+      ProviderPlanningIntent::ProviderPlanningIntent(
+        target~,
+        options~,
+        snapshot=ProviderPlanningSnapshot::ProviderPlanningSnapshot(
+          context~,
+          source_revisions~,
+          dependencies~,
+        ),
+      ),
+    ),
+  )
+  let request = self.current_request_or_abort()
+  self.request_states.set(
+    provider_request_states_ensure(self.request_states.peek(), request),
+  )
+  request
+}
+
+///|
+fn ProviderPlanningGraph::clear_events(self : ProviderPlanningGraph) -> Unit {
+  match self.current_request() {
+    Some(request) =>
+      self.request_states.set(
+        provider_request_states_upsert(
+          self.request_states.peek(),
+          ProviderRequestState::pending(request),
+        ),
+      )
+    None => ()
+  }
+}
+
+///|
+fn ProviderPlanningGraph::record_cancellation(
+  self : ProviderPlanningGraph,
+  request : ProviderRequestDescriptor,
+) -> Unit {
+  let cancellation = ProviderCancellationRecord::ProviderCancellationRecord(
+    request_id=request.id(),
+    cancelled_at_ms=self.fake_time_ms.peek(),
+  )
+  self.request_states.set(
+    provider_request_states_record_cancellation(
+      self.request_states.peek(),
+      request,
+      cancellation,
+    ),
+  )
+}
+
+///|
+fn ProviderPlanningGraph::acknowledge_cancellation(
+  self : ProviderPlanningGraph,
+  request_id : ProviderRequestId,
+) -> Unit {
+  self.request_states.set(
+    provider_request_states_acknowledge_cancellation(
+      self.request_states.peek(),
+      request_id,
+    ),
+  )
+}
+
+///|
+fn ProviderPlanningGraph::acknowledge_start(
+  self : ProviderPlanningGraph,
+  request_id : ProviderRequestId,
+) -> Unit {
+  let start = ProviderStartRecord::ProviderStartRecord(
+    request_id~,
+    started_at_ms=self.fake_time_ms.peek(),
+  )
+  self.request_states.set(
+    provider_request_states_acknowledge_start(
+      self.request_states.peek(),
+      request_id,
+      start,
+    ),
+  )
+}
+
+///|
+fn ProviderPlanningGraph::record_completion(
+  self : ProviderPlanningGraph,
+  request : ProviderRequestDescriptor,
+  completion : ProviderResultDescriptor,
+) -> Unit {
+  let completion_record = ProviderCompletionRecord::ProviderCompletionRecord(
+    completion~,
+    completed_at_ms=self.fake_time_ms.peek(),
+  )
+  self.request_states.set(
+    provider_request_states_record_completion(
+      self.request_states.peek(),
+      request,
+      completion_record,
+    ),
+  )
+}
+
+///|
+fn ProviderPlanningGraph::set_fake_time_ms(
+  self : ProviderPlanningGraph,
+  now_ms : Int,
+) -> Unit {
+  self.fake_time_ms.set(now_ms)
+}
+
+///|
+fn ProviderPlanningGraph::next_driver_action_at(
+  self : ProviderPlanningGraph,
+  now_ms : Int,
+) -> ProviderDriverAction {
+  self.fake_time_ms.set(now_ms)
+  self.next_driver_action()
+}
+
+///|
+fn ProviderPlanningGraph::current_request(
+  self : ProviderPlanningGraph,
+) -> ProviderRequestDescriptor? {
+  self.ensure_scope_live()
+  self.request_watch.read_or_abort()
+}
+
+///|
+fn ProviderPlanningGraph::current_request_or_abort(
+  self : ProviderPlanningGraph,
+) -> ProviderRequestDescriptor {
+  match self.current_request() {
+    Some(request) => request
+    None => abort("provider planning graph produced no request")
+  }
+}
+
+///|
+fn ProviderPlanningGraph::dependency_fingerprint(
+  self : ProviderPlanningGraph,
+) -> ProviderDependencyFingerprint? {
+  self.ensure_scope_live()
+  self.dependency_fingerprint_watch.read_or_abort()
+}
+
+///|
+fn ProviderPlanningGraph::status(
+  self : ProviderPlanningGraph,
+) -> ProviderStatusDescriptor? {
+  self.ensure_scope_live()
+  self.status_watch.read_or_abort()
+}
+
+///|
+fn ProviderPlanningGraph::retry_classification(
+  self : ProviderPlanningGraph,
+) -> ProviderRetryClassification? {
+  self.ensure_scope_live()
+  self.retry_classification_watch.read_or_abort()
+}
+
+///|
+fn ProviderPlanningGraph::next_driver_action(
+  self : ProviderPlanningGraph,
+) -> ProviderDriverAction {
+  self.ensure_scope_live()
+  self.next_driver_action_watch.read_or_abort()
+}
+
+///|
+fn ProviderPlanningGraph::watched_cells_are_rooted(
+  self : ProviderPlanningGraph,
+) -> Bool {
+  self.runtime.gc_root_count(self.dependency_fingerprint_cell_id) > 0 &&
+  self.runtime.gc_root_count(self.request_cell_id) > 0 &&
+  self.runtime.gc_root_count(self.status_cell_id) > 0 &&
+  self.runtime.gc_root_count(self.retry_classification_cell_id) > 0 &&
+  self.runtime.gc_root_count(self.next_driver_action_cell_id) > 0
+}
+
+///|
+fn ProviderPlanningGraph::ensure_scope_live(
+  self : ProviderPlanningGraph,
+) -> Unit {
+  guard !self.scope.is_disposed() else {
+    abort("provider planning graph scope is disposed")
+  }
+}
+
+///|
+fn provider_request_states_ensure(
+  states : Array[ProviderRequestState],
+  request : ProviderRequestDescriptor,
+) -> Array[ProviderRequestState] {
+  if provider_state_for_request(states, request) is Some(_) {
+    states.copy()
+  } else {
+    let next = states.copy()
+    next.push(ProviderRequestState::pending(request))
+    next
+  }
+}
+
+///|
+fn provider_request_states_upsert(
+  states : Array[ProviderRequestState],
+  state : ProviderRequestState,
+) -> Array[ProviderRequestState] {
+  let next : Array[ProviderRequestState] = []
+  let mut replaced = false
+  for existing in states {
+    if existing.request.id() == state.request.id() {
+      next.push(state)
+      replaced = true
+    } else {
+      next.push(existing)
+    }
+  }
+  if !replaced {
+    next.push(state)
+  }
+  next
+}
+
+///|
+fn provider_request_states_record_cancellation(
+  states : Array[ProviderRequestState],
+  request : ProviderRequestDescriptor,
+  cancellation : ProviderCancellationRecord,
+) -> Array[ProviderRequestState] {
+  match provider_state_for_request(states, request) {
+    Some(state) =>
+      provider_request_states_upsert(
+        states,
+        state.with_cancellation(cancellation),
+      )
+    None => states.copy()
+  }
+}
+
+///|
+fn provider_request_states_record_completion(
+  states : Array[ProviderRequestState],
+  request : ProviderRequestDescriptor,
+  completion : ProviderCompletionRecord,
+) -> Array[ProviderRequestState] {
+  match provider_state_for_request(states, request) {
+    Some(state) =>
+      provider_request_states_upsert(states, state.with_completion(completion))
+    None => states.copy()
+  }
+}
+
+///|
+fn provider_request_states_acknowledge_cancellation(
+  states : Array[ProviderRequestState],
+  request_id : ProviderRequestId,
+) -> Array[ProviderRequestState] {
+  let next : Array[ProviderRequestState] = []
+  for state in states {
+    if state.request.id() == request_id {
+      next.push(state.with_cancellation_acknowledged())
+    } else {
+      next.push(state)
+    }
+  }
+  next
+}
+
+///|
+fn provider_request_states_acknowledge_start(
+  states : Array[ProviderRequestState],
+  request_id : ProviderRequestId,
+  start : ProviderStartRecord,
+) -> Array[ProviderRequestState] {
+  let next : Array[ProviderRequestState] = []
+  for state in states {
+    if state.request.id() == request_id {
+      next.push(state.with_start(start))
+    } else {
+      next.push(state)
+    }
+  }
+  next
+}
+
+///|
+fn provider_state_for_request(
+  states : Array[ProviderRequestState],
+  request : ProviderRequestDescriptor,
+) -> ProviderRequestState? {
+  for state in states {
+    if state.request.id() == request.id() {
+      return Some(state)
+    }
+  }
+  None
+}
+
+///|
+fn provider_next_driver_action_for_states(
+  states : Array[ProviderRequestState],
+  now_ms : Int,
+) -> ProviderDriverAction {
+  let mut cancellation_action : ProviderDriverAction? = None
+  let mut pending_start_action : ProviderDriverAction? = None
+  let mut retry_action : ProviderDriverAction? = None
+  let mut delayed_action : ProviderDriverAction? = None
+  for state in states {
+    let action = state.driver_action(now_ms)
+    match action {
+      ProviderDriverAction::CancelProviderRequest(request_id) =>
+        if cancellation_action is None {
+          cancellation_action = Some(
+            ProviderDriverAction::CancelProviderRequest(request_id),
+          )
+        }
+      _ =>
+        if !provider_request_is_superseded_by_later_target(
+            states,
+            state.request,
+          ) {
+          match action {
+            ProviderDriverAction::NoDriverAction => ()
+            ProviderDriverAction::WaitProviderRetry(request_id, ready_at_ms) =>
+              match delayed_action {
+                Some(
+                  ProviderDriverAction::WaitProviderRetry(
+                    _,
+                    current_ready_at_ms
+                  )
+                ) =>
+                  if current_ready_at_ms > ready_at_ms {
+                    delayed_action = Some(
+                      ProviderDriverAction::WaitProviderRetry(
+                        request_id, ready_at_ms,
+                      ),
+                    )
+                  }
+                _ =>
+                  delayed_action = Some(
+                    ProviderDriverAction::WaitProviderRetry(
+                      request_id, ready_at_ms,
+                    ),
+                  )
+              }
+            ProviderDriverAction::CancelProviderRequest(_) => ()
+            ProviderDriverAction::StartProviderRequest(request) =>
+              if pending_start_action is None {
+                pending_start_action = Some(
+                  ProviderDriverAction::StartProviderRequest(request),
+                )
+              }
+            ProviderDriverAction::RetryProviderRequest(request) =>
+              if retry_action is None {
+                retry_action = Some(
+                  ProviderDriverAction::RetryProviderRequest(request),
+                )
+              }
+          }
+        }
+    }
+  }
+  match cancellation_action {
+    Some(action) => action
+    None =>
+      match pending_start_action {
+        Some(action) => action
+        None =>
+          match retry_action {
+            Some(action) => action
+            None =>
+              delayed_action.unwrap_or(ProviderDriverAction::NoDriverAction)
+          }
+      }
+  }
+}
+
+///|
+fn provider_request_is_superseded_by_later_target(
+  states : Array[ProviderRequestState],
+  request : ProviderRequestDescriptor,
+) -> Bool {
+  let mut seen_request = false
+  for state in states {
+    if state.request.id() == request.id() {
+      seen_request = true
+    } else if seen_request && state.request.target() == request.target() {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn provider_status_for_records(
+  request : ProviderRequestDescriptor,
+  cancellation : ProviderCancellationRecord?,
+  completion : ProviderCompletionRecord?,
+) -> ProviderRequestStatus {
+  if provider_cancellation_wins(request, cancellation, completion) {
+    ProviderRequestStatus::Failed(ProviderError::Cancelled)
+  } else {
+    match completion {
+      Some(record) if provider_completion_matches_request(request, record) =>
+        record.completion.status()
+      _ => ProviderRequestStatus::Pending
+    }
+  }
+}
+
+///|
+fn provider_next_driver_action_for_records(
+  request : ProviderRequestDescriptor,
+  start : ProviderStartRecord?,
+  cancellation : ProviderCancellationRecord?,
+  completion : ProviderCompletionRecord?,
+  now_ms : Int,
+) -> ProviderDriverAction {
+  if provider_cancellation_wins(request, cancellation, completion) {
+    match cancellation {
+      Some(record) if !record.driver_acknowledged =>
+        ProviderDriverAction::CancelProviderRequest(request.id())
+      _ => ProviderDriverAction::NoDriverAction
+    }
+  } else if provider_start_matches_request(request, start) {
+    ProviderDriverAction::NoDriverAction
+  } else {
+    match completion {
+      Some(record) if provider_completion_matches_request(request, record) =>
+        match record.completion.status() {
+          ProviderRequestStatus::Failed(error) =>
+            provider_retry_driver_action(
+              request,
+              error,
+              record.completed_at_ms,
+              now_ms,
+            )
+          _ => ProviderDriverAction::NoDriverAction
+        }
+      _ => ProviderDriverAction::StartProviderRequest(request)
+    }
+  }
+}
+
+///|
+fn provider_start_matches_request(
+  request : ProviderRequestDescriptor,
+  start : ProviderStartRecord?,
+) -> Bool {
+  match start {
+    Some(record) => record.request_id == request.id()
+    None => false
+  }
+}
+
+///|
+fn provider_retry_driver_action(
+  request : ProviderRequestDescriptor,
+  error : ProviderError,
+  completed_at_ms : Int,
+  now_ms : Int,
+) -> ProviderDriverAction {
+  match error.retry_classification() {
+    ProviderRetryClassification::RetryableLater(retry_after_ms~) => {
+      let ready_at_ms = completed_at_ms + retry_after_ms.unwrap_or(0)
+      if now_ms >= ready_at_ms {
+        ProviderDriverAction::RetryProviderRequest(request)
+      } else {
+        ProviderDriverAction::WaitProviderRetry(request.id(), ready_at_ms)
+      }
+    }
+    _ => ProviderDriverAction::NoDriverAction
+  }
+}
+
+///|
+fn provider_cancellation_wins(
+  request : ProviderRequestDescriptor,
+  cancellation : ProviderCancellationRecord?,
+  completion : ProviderCompletionRecord?,
+) -> Bool {
+  match cancellation {
+    Some(record) if provider_cancellation_matches_request(request, record) =>
+      match completion {
+        Some(completion) if provider_completion_matches_request(
+            request, completion,
+          ) => record.cancelled_at_ms <= completion.completed_at_ms
+        _ => true
+      }
+    _ => false
+  }
+}
+
+///|
+fn provider_cancellation_matches_request(
+  request : ProviderRequestDescriptor,
+  cancellation : ProviderCancellationRecord,
+) -> Bool {
+  cancellation.request_id == request.id()
+}
+
+///|
+fn provider_completion_matches_request(
+  request : ProviderRequestDescriptor,
+  completion : ProviderCompletionRecord,
+) -> Bool {
+  completion.completion.request_id() == request.id()
+}

--- a/lib/cognition/provider_boundary_reactive_wbtest.mbt
+++ b/lib/cognition/provider_boundary_reactive_wbtest.mbt
@@ -1,0 +1,564 @@
+///|
+fn provider_reactive_options_for_test() -> ProviderOptionProvenance {
+  ProviderOptionProvenance::new(
+    task_kind="summarize",
+    provider_id="mock-provider",
+    model_id="mock-model",
+    option_identity=RedactedOptionIdentity::new(
+      "temperature=<redacted>;max=128",
+    ),
+  )
+}
+
+///|
+fn provider_reactive_completion_for_test(
+  request : ProviderRequestDescriptor,
+  result : ProviderResult,
+) -> ProviderResultDescriptor {
+  ProviderResultDescriptor::new(
+    request_id=request.id(),
+    target=request.target(),
+    options=request.options(),
+    source_revisions=request.source_revisions(),
+    dependency_fingerprint=request.dependency_fingerprint(),
+    result~,
+  )
+}
+
+///|
+test "provider planning cells derive descriptor status fingerprint and start action" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+
+  match store.reactive.provider_dependency_fingerprint() {
+    Some(fingerprint) =>
+      inspect(fingerprint == request.dependency_fingerprint(), content="true")
+    None => fail("expected dependency fingerprint")
+  }
+  match store.reactive.provider_status() {
+    Some(status) => {
+      inspect(status.request_id() == request.id(), content="true")
+      inspect(status.target() == target, content="true")
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+    }
+    None => fail("expected provider status")
+  }
+  inspect(
+    store.reactive.provider_retry_classification() is None,
+    content="true",
+  )
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request),
+    content="true",
+  )
+}
+
+///|
+test "provider planning start acknowledgement suppresses duplicate starts" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+
+  store.reactive.acknowledge_provider_start(request.id())
+
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::NoDriverAction,
+    content="true",
+  )
+  match store.reactive.provider_status() {
+    Some(status) =>
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+    None => fail("expected pending status while request is in flight")
+  }
+}
+
+///|
+test "provider planning preserves start acknowledgement on pending replan" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  store.reactive.acknowledge_provider_start(request.id())
+
+  let repeated = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+
+  inspect(repeated.id() == request.id(), content="true")
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::NoDriverAction,
+    content="true",
+  )
+}
+
+///|
+test "provider planning cells derive cancellation status and action" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+
+  match store.cancel_provider_request(request.id()) {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(ProviderError::Cancelled),
+        content="true",
+      )
+    None => fail("expected cancellation status")
+  }
+
+  match store.reactive.provider_status() {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(ProviderError::Cancelled),
+        content="true",
+      )
+    None => fail("expected reactive cancellation status")
+  }
+  inspect(
+    store.reactive.provider_retry_classification() ==
+    Some(ProviderRetryClassification::CallerInitiated),
+    content="true",
+  )
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::CancelProviderRequest(request.id()),
+    content="true",
+  )
+}
+
+///|
+test "provider planning cells use fake time for retry action" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  store.reactive.provider_planning.set_fake_time_ms(100)
+
+  let status = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      request,
+      ProviderResult::Failed(
+        ProviderError::RateLimited(retry_after_ms=Some(250)),
+      ),
+    ),
+  )
+
+  inspect(
+    status.status() ==
+    ProviderRequestStatus::Failed(
+      ProviderError::RateLimited(retry_after_ms=Some(250)),
+    ),
+    content="true",
+  )
+  inspect(
+    store.reactive.provider_retry_classification() ==
+    Some(ProviderRetryClassification::RetryableLater(retry_after_ms=Some(250))),
+    content="true",
+  )
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::WaitProviderRetry(request.id(), 350),
+    content="true",
+  )
+
+  store.reactive.provider_planning.set_fake_time_ms(349)
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::WaitProviderRetry(request.id(), 350),
+    content="true",
+  )
+  store.reactive.provider_planning.set_fake_time_ms(350)
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::RetryProviderRequest(request),
+    content="true",
+  )
+  store.reactive.acknowledge_provider_start(request.id())
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::NoDriverAction,
+    content="true",
+  )
+}
+
+///|
+test "provider planning preserves terminal status when replanning completed request" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let request_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  let _ = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      request_a,
+      ProviderResult::Succeeded(Summary("alpha done")),
+    ),
+  )
+  let request_b = store.plan_provider_request(
+    target=FileSummary("src/b.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request_b),
+    content="true",
+  )
+
+  let repeated_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+
+  inspect(repeated_a.id() == request_a.id(), content="true")
+  match store.reactive.provider_status() {
+    Some(status) => {
+      inspect(status.request_id() == request_a.id(), content="true")
+      inspect(
+        status.status() == ProviderRequestStatus::Succeeded,
+        content="true",
+      )
+    }
+    None => fail("expected terminal provider status")
+  }
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request_b),
+    content="true",
+  )
+}
+
+///|
+test "provider planning selects oldest pending request" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let request_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  let _ = store.plan_provider_request(
+    target=FileSummary("src/b.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request_a),
+    content="true",
+  )
+}
+
+///|
+test "provider planning starts current pending request before stale pending start" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let stale_request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha changed"))
+  let current_request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  inspect(current_request.id() != stale_request.id(), content="true")
+
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(current_request),
+    content="true",
+  )
+}
+
+///|
+test "provider planning starts current pending request before stale ready retry" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let stale_request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  store.reactive.provider_planning.set_fake_time_ms(100)
+  let _ = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      stale_request,
+      ProviderResult::Failed(
+        ProviderError::RateLimited(retry_after_ms=Some(50)),
+      ),
+    ),
+  )
+
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha changed"))
+  let current_request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  inspect(current_request.id() != stale_request.id(), content="true")
+
+  store.reactive.provider_planning.set_fake_time_ms(150)
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(current_request),
+    content="true",
+  )
+}
+
+///|
+test "provider planning waits for earliest retryable request" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let request_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  let request_b = store.plan_provider_request(
+    target=FileSummary("src/b.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  store.reactive.provider_planning.set_fake_time_ms(0)
+  let _ = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      request_a,
+      ProviderResult::Failed(
+        ProviderError::RateLimited(retry_after_ms=Some(1000)),
+      ),
+    ),
+  )
+  let _ = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      request_b,
+      ProviderResult::Failed(
+        ProviderError::RateLimited(retry_after_ms=Some(100)),
+      ),
+    ),
+  )
+
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::WaitProviderRetry(request_b.id(), 100),
+    content="true",
+  )
+}
+
+///|
+test "provider planning ignores late completion for non-current request" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let request_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  let request_b = store.plan_provider_request(
+    target=FileSummary("src/b.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+
+  let _ = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      request_a,
+      ProviderResult::Succeeded(Summary("late alpha")),
+    ),
+  )
+
+  match store.reactive.provider_status() {
+    Some(status) => {
+      inspect(status.request_id() == request_b.id(), content="true")
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+    }
+    None => fail("expected current provider status")
+  }
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request_b),
+    content="true",
+  )
+}
+
+///|
+test "provider planning prioritizes cancellation for non-current request" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let request_a = store.plan_provider_request(
+    target=FileSummary("src/a.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+  let request_b = store.plan_provider_request(
+    target=FileSummary("src/b.mbt"),
+    options=provider_reactive_options_for_test(),
+  )
+
+  let _ = store.cancel_provider_request(request_a.id())
+
+  match store.reactive.provider_status() {
+    Some(status) => {
+      inspect(status.request_id() == request_b.id(), content="true")
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+    }
+    None => fail("expected current provider status")
+  }
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::CancelProviderRequest(request_a.id()),
+    content="true",
+  )
+  store.reactive.acknowledge_provider_cancellation(request_a.id())
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request_b),
+    content="true",
+  )
+}
+
+///|
+test "provider planning watches keep pending request cells alive across gc" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+
+  inspect(
+    store.reactive.provider_planning.watched_cells_are_rooted(),
+    content="true",
+  )
+  store.reactive.provider_planning.runtime.gc()
+
+  match store.reactive.provider_status() {
+    Some(status) => {
+      inspect(status.request_id() == request.id(), content="true")
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+    }
+    None => fail("expected provider status after gc")
+  }
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::StartProviderRequest(request),
+    content="true",
+  )
+  match store.reactive.provider_dependency_fingerprint() {
+    Some(fingerprint) =>
+      inspect(fingerprint == request.dependency_fingerprint(), content="true")
+    None => fail("expected dependency fingerprint after gc")
+  }
+}
+
+///|
+test "provider planning watches keep cancellation cells alive across gc" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  let _ = store.cancel_provider_request(request.id())
+
+  inspect(
+    store.reactive.provider_planning.watched_cells_are_rooted(),
+    content="true",
+  )
+  store.reactive.provider_planning.runtime.gc()
+
+  match store.reactive.provider_status() {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(ProviderError::Cancelled),
+        content="true",
+      )
+    None => fail("expected cancellation status after gc")
+  }
+  inspect(
+    store.reactive.provider_retry_classification() ==
+    Some(ProviderRetryClassification::CallerInitiated),
+    content="true",
+  )
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::CancelProviderRequest(request.id()),
+    content="true",
+  )
+}
+
+///|
+test "provider planning watches keep retry status cells alive across gc" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_reactive_options_for_test(),
+  )
+  store.reactive.provider_planning.set_fake_time_ms(25)
+  let _ = store.complete_provider_request(
+    provider_reactive_completion_for_test(
+      request,
+      ProviderResult::Failed(
+        ProviderError::RateLimited(retry_after_ms=Some(75)),
+      ),
+    ),
+  )
+
+  inspect(
+    store.reactive.provider_planning.watched_cells_are_rooted(),
+    content="true",
+  )
+  store.reactive.provider_planning.runtime.gc()
+
+  match store.reactive.provider_status() {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(
+          ProviderError::RateLimited(retry_after_ms=Some(75)),
+        ),
+        content="true",
+      )
+    None => fail("expected retry status after gc")
+  }
+  inspect(
+    store.reactive.provider_retry_classification() ==
+    Some(ProviderRetryClassification::RetryableLater(retry_after_ms=Some(75))),
+    content="true",
+  )
+  inspect(
+    store.reactive.provider_next_driver_action() ==
+    ProviderDriverAction::WaitProviderRetry(request.id(), 100),
+    content="true",
+  )
+}

--- a/lib/cognition/provider_boundary_store.mbt
+++ b/lib/cognition/provider_boundary_store.mbt
@@ -11,50 +11,51 @@ pub fn CognitionStore::plan_provider_request(
 ) -> ProviderRequestDescriptor {
   let dependencies = self.provider_dependencies_for_target(target)
   let source_revisions = self.provider_source_snapshots_for(dependencies)
-  let dependency_fingerprint = provider_dependency_fingerprint_for_snapshots(
-    dependencies, source_revisions,
+  let request = self.reactive.plan_provider_request(
+    target~,
+    options~,
+    context=self.provider_context_for_target(target, dependencies),
+    source_revisions~,
+    dependencies~,
   )
-  let request_id = provider_request_id_for(
-    target, options, dependency_fingerprint,
-  )
+  let request_id = request.id()
   match self.provider_requests.get(request_id) {
     Some(request) => {
       let current_status = self.provider_statuses
         .get(request_id)
         .unwrap_or(ProviderRequestStatus::Planned)
-      if provider_status_should_replan(current_status) {
-        self.provider_statuses[request_id] = ProviderRequestStatus::Pending
-        self.provider_results.remove(request_id)
+      match current_status {
+        ProviderRequestStatus::Planned | ProviderRequestStatus::Pending =>
+          self.provider_statuses[request_id] = ProviderRequestStatus::Pending
+        ProviderRequestStatus::Failed(error) =>
+          match error.retry_classification() {
+            ProviderRetryClassification::RetryableLater(_) => {
+              self.provider_statuses[request_id] = ProviderRequestStatus::Pending
+              self.provider_results.remove(request_id)
+              self.reactive.clear_provider_events()
+            }
+            _ =>
+              match self.provider_results.get(request_id) {
+                Some(result) =>
+                  self.reactive.record_provider_completion(request, result)
+                None => ()
+              }
+          }
+        ProviderRequestStatus::Succeeded =>
+          match self.provider_results.get(request_id) {
+            Some(result) =>
+              self.reactive.record_provider_completion(request, result)
+            None => ()
+          }
       }
       request
     }
     None => {
-      let request = ProviderRequestDescriptor::new(
-        id=request_id,
-        target~,
-        options~,
-        context=self.provider_context_for_target(target, dependencies),
-        source_revisions~,
-        dependencies~,
-        dependency_fingerprint~,
-      )
+      self.reactive.clear_provider_events()
       self.provider_requests[request_id] = request
       self.provider_statuses[request_id] = ProviderRequestStatus::Pending
       request
     }
-  }
-}
-
-///|
-fn provider_status_should_replan(status : ProviderRequestStatus) -> Bool {
-  match status {
-    ProviderRequestStatus::Planned | ProviderRequestStatus::Pending => true
-    ProviderRequestStatus::Failed(error) =>
-      match error.retry_classification() {
-        ProviderRetryClassification::RetryableLater(_) => true
-        _ => false
-      }
-    ProviderRequestStatus::Succeeded => false
   }
 }
 
@@ -122,6 +123,7 @@ pub fn CognitionStore::cancel_provider_request(
           result=ProviderResult::Failed(ProviderError::Cancelled),
         )
         self.provider_results[request_id] = result
+        self.reactive.record_provider_cancellation(request)
         Some(
           ProviderStatusDescriptor::new(
             request_id~,
@@ -234,6 +236,7 @@ fn CognitionStore::accept_provider_completion(
       self.provider_statuses[request_id] = status
     }
   }
+  self.reactive.record_provider_completion(request, completion)
   ProviderStatusDescriptor::new(request_id~, target=request.target(), status~)
 }
 
@@ -255,6 +258,7 @@ fn CognitionStore::reject_provider_completion(
   )
   self.provider_results[request_id] = result
   self.provider_statuses[request_id] = status
+  self.reactive.record_provider_completion(request, result)
   ProviderStatusDescriptor::new(request_id~, target=request.target(), status~)
 }
 

--- a/lib/cognition/provider_boundary_store_test.mbt
+++ b/lib/cognition/provider_boundary_store_test.mbt
@@ -489,6 +489,101 @@ test "provider cancellation after success leaves terminal result intact" {
 }
 
 ///|
+test "provider cancellation is request scoped and idempotent" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/b.mbt"), Text("beta"))
+  let target_a = CognitionKey::FileSummary("src/a.mbt")
+  let target_b = CognitionKey::FileSummary("src/b.mbt")
+  let request_a = store.plan_provider_request(
+    target=target_a,
+    options=provider_boundary_options_for_test(),
+  )
+  let request_b = store.plan_provider_request(
+    target=target_b,
+    options=provider_boundary_options_for_test(),
+  )
+
+  match store.cancel_provider_request(request_a.id()) {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(ProviderError::Cancelled),
+        content="true",
+      )
+    None => fail("expected first cancellation status")
+  }
+  match store.cancel_provider_request(request_a.id()) {
+    Some(status) =>
+      inspect(
+        status.status() ==
+        ProviderRequestStatus::Failed(ProviderError::Cancelled),
+        content="true",
+      )
+    None => fail("expected idempotent cancellation status")
+  }
+
+  let status_b = store.complete_provider_request(
+    provider_boundary_completion_for_test(
+      request_b,
+      ProviderResult::Succeeded(Summary("provider b summary")),
+    ),
+  )
+  let late_a = store.complete_provider_request(
+    provider_boundary_completion_for_test(
+      request_a,
+      ProviderResult::Succeeded(Summary("late provider a summary")),
+    ),
+  )
+
+  inspect(status_b.status() == ProviderRequestStatus::Succeeded, content="true")
+  inspect(
+    late_a.status() == ProviderRequestStatus::Failed(ProviderError::Cancelled),
+    content="true",
+  )
+  inspect(
+    provider_boundary_summary_for_test(store, target_b),
+    content="provider b summary",
+  )
+  inspect(store.get_value(target_a) is None, content="true")
+}
+
+///|
+test "provider driver shutdown leaves pending request observable" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_boundary_options_for_test(),
+  )
+
+  // Simulate provider-driver shutdown by dropping external work without
+  // recording either a completion or a cancellation.
+  let repeated = store.plan_provider_request(
+    target~,
+    options=provider_boundary_options_for_test(),
+  )
+
+  inspect(repeated.id() == request.id(), content="true")
+  inspect(store.get_provider_result(request.id()) is None, content="true")
+  match store.get_provider_request(request.id()) {
+    Some(stored) => inspect(stored == request, content="true")
+    None => fail("expected pending request to remain observable")
+  }
+  match store.get_provider_status(request.id()) {
+    Some(status) => {
+      inspect(status.status() == ProviderRequestStatus::Pending, content="true")
+      inspect(
+        status.classification() == ProviderStatusClassification::InFlight,
+        content="true",
+      )
+    }
+    None => fail("expected pending request status")
+  }
+}
+
+///|
 test "provider completion rejects stale source revisions after edit" {
   let store = CognitionStore::new()
   let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
@@ -522,6 +617,124 @@ test "provider completion rejects stale source revisions after edit" {
         content="true",
       )
     None => fail("expected stale completion record")
+  }
+}
+
+///|
+test "provider completion rejects stale source revisions after file removal" {
+  let store = CognitionStore::new()
+  let _ = store.set_input(FileText("src/a.mbt"), Text("alpha"))
+  let _ = store.compute(FileSummary("src/a.mbt"))
+  let target = CognitionKey::FileSummary("src/a.mbt")
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_boundary_options_for_test(),
+  )
+  inspect(store.remove_file("src/a.mbt"), content="true")
+
+  let status = store.complete_provider_request(
+    provider_boundary_completion_for_test(
+      request,
+      ProviderResult::Succeeded(Summary("stale provider summary")),
+    ),
+  )
+
+  inspect(
+    status.status() ==
+    ProviderRequestStatus::Failed(ProviderError::StaleCompletion),
+    content="true",
+  )
+  inspect(store.known_files().contains("src/a.mbt"), content="false")
+  inspect(store.get_value(FileText("src/a.mbt")) is None, content="true")
+  inspect(store.get_value(target) is None, content="true")
+  match store.get_provider_result(request.id()) {
+    Some(result) =>
+      inspect(
+        result.status() ==
+        ProviderRequestStatus::Failed(ProviderError::StaleCompletion),
+        content="true",
+      )
+    None => fail("expected stale completion record")
+  }
+}
+
+///|
+test "provider completion rejects stale budgeted context after ranker selection changes" {
+  let ranker : ContextRanker = {
+    score_summary: fn(_query, key) {
+      match key {
+        FileSummary("src/gamma.mbt") => 1000
+        FileSummary(_) => 0
+        _ => 0
+      }
+    },
+    reason_summary: fn(_query, key) {
+      match key {
+        FileSummary("src/gamma.mbt") => "custom preferred gamma"
+        FileSummary(path) => "custom fallback \{path}"
+        _ => "custom artifact"
+      }
+    },
+  }
+  let store = CognitionStore::new_with_provider_and_ranker(
+    CognitionProvider::mock(),
+    ranker,
+  )
+  let _ = store.set_input(FileText("src/alpha.mbt"), Text("alpha"))
+  let _ = store.set_input(FileText("src/beta.mbt"), Text("beta"))
+  let target = CognitionKey::BudgetedContext("focus", 3, 40)
+  let initial_items = store.pack_context_with_budget("focus", 3, 40)
+  let request = store.plan_provider_request(
+    target~,
+    options=provider_boundary_options_for_test(),
+  )
+
+  inspect(initial_items.length(), content="1")
+  inspect(
+    initial_items[0].source != FileSummary("src/gamma.mbt"),
+    content="true",
+  )
+  inspect(request.context().length(), content="1")
+  inspect(
+    request.context()[0].source == initial_items[0].source,
+    content="true",
+  )
+
+  let _ = store.set_input(FileText("src/gamma.mbt"), Text("gamma"))
+  let refreshed_items = store.pack_context_with_budget("focus", 3, 40)
+  inspect(refreshed_items.length(), content="1")
+  inspect(
+    refreshed_items[0].source == FileSummary("src/gamma.mbt"),
+    content="true",
+  )
+
+  let status = store.complete_provider_request(
+    provider_boundary_completion_for_test(
+      request,
+      ProviderResult::Succeeded(ContextItems(request.context())),
+    ),
+  )
+
+  inspect(
+    status.status() ==
+    ProviderRequestStatus::Failed(ProviderError::StaleCompletion),
+    content="true",
+  )
+  match store.get_value(target) {
+    Some(ContextItems(items)) => {
+      inspect(items.length(), content="1")
+      inspect(items[0].source == FileSummary("src/gamma.mbt"), content="true")
+    }
+    _ => fail("expected refreshed budgeted context")
+  }
+  match store.get_provider_result(request.id()) {
+    Some(result) =>
+      inspect(
+        result.status() ==
+        ProviderRequestStatus::Failed(ProviderError::StaleCompletion),
+        content="true",
+      )
+    None => fail("expected stale budgeted-context completion record")
   }
 }
 

--- a/lib/cognition/reactive.mbt
+++ b/lib/cognition/reactive.mbt
@@ -4,6 +4,7 @@ struct CognitionReactive {
   revision : @incr.Input[Revision]
   dependency_tick : @incr.Input[Int]
   dependency_edges_watch : @incr.Watch[Array[Dependency]]
+  provider_planning : ProviderPlanningGraph
 }
 
 ///|
@@ -26,7 +27,9 @@ fn CognitionReactive::CognitionReactive(
     label="cognition_dependency_edges",
   )
   let dependency_edges_watch = dependency_edges_cell.watch()
-  { revision, dependency_tick, dependency_edges_watch }
+  let provider_planning = ProviderPlanningGraph::ProviderPlanningGraph(runtime)
+  provider_planning.set_fake_time_ms(0)
+  { revision, dependency_tick, dependency_edges_watch, provider_planning }
 }
 
 ///|
@@ -53,6 +56,118 @@ fn CognitionReactive::dependency_edges(
   self : CognitionReactive,
 ) -> Array[Dependency] {
   self.dependency_edges_watch.read_or_abort().copy()
+}
+
+///|
+fn CognitionReactive::plan_provider_request(
+  self : CognitionReactive,
+  target~ : CognitionKey,
+  options~ : ProviderOptionProvenance,
+  context~ : Array[ContextItem],
+  source_revisions~ : Array[ProviderSourceSnapshot],
+  dependencies~ : Array[CognitionKey],
+) -> ProviderRequestDescriptor {
+  let request = self.provider_planning.plan_request(
+    target~,
+    options~,
+    context~,
+    source_revisions~,
+    dependencies~,
+  )
+  self.prime_provider_boundary()
+  request
+}
+
+///|
+fn CognitionReactive::clear_provider_events(self : CognitionReactive) -> Unit {
+  self.provider_planning.clear_events()
+  self.prime_provider_boundary()
+}
+
+///|
+fn CognitionReactive::record_provider_cancellation(
+  self : CognitionReactive,
+  request : ProviderRequestDescriptor,
+) -> Unit {
+  self.provider_planning.record_cancellation(request)
+  self.prime_provider_boundary()
+}
+
+///|
+/// Internal provider-driver test hook; keep private until a real driver API exists.
+#warnings("-unused_value")
+fn CognitionReactive::acknowledge_provider_cancellation(
+  self : CognitionReactive,
+  request_id : ProviderRequestId,
+) -> Unit {
+  self.provider_planning.acknowledge_cancellation(request_id)
+  self.prime_provider_boundary()
+}
+
+///|
+/// Internal provider-driver test hook; keep private until a real driver API exists.
+#warnings("-unused_value")
+fn CognitionReactive::acknowledge_provider_start(
+  self : CognitionReactive,
+  request_id : ProviderRequestId,
+) -> Unit {
+  self.provider_planning.acknowledge_start(request_id)
+  self.prime_provider_boundary()
+}
+
+///|
+fn CognitionReactive::record_provider_completion(
+  self : CognitionReactive,
+  request : ProviderRequestDescriptor,
+  completion : ProviderResultDescriptor,
+) -> Unit {
+  self.provider_planning.record_completion(request, completion)
+  self.prime_provider_boundary()
+}
+
+///|
+fn CognitionReactive::provider_dependency_fingerprint(
+  self : CognitionReactive,
+) -> ProviderDependencyFingerprint? {
+  self.provider_planning.dependency_fingerprint()
+}
+
+///|
+fn CognitionReactive::provider_status(
+  self : CognitionReactive,
+) -> ProviderStatusDescriptor? {
+  self.provider_planning.status()
+}
+
+///|
+fn CognitionReactive::provider_retry_classification(
+  self : CognitionReactive,
+) -> ProviderRetryClassification? {
+  self.provider_planning.retry_classification()
+}
+
+///|
+fn CognitionReactive::provider_next_driver_action(
+  self : CognitionReactive,
+) -> ProviderDriverAction {
+  self.provider_planning.next_driver_action()
+}
+
+///|
+#warnings("-unused_value")
+fn CognitionReactive::provider_next_driver_action_at(
+  self : CognitionReactive,
+  now_ms : Int,
+) -> ProviderDriverAction {
+  self.provider_planning.next_driver_action_at(now_ms)
+}
+
+///|
+fn CognitionReactive::prime_provider_boundary(self : CognitionReactive) -> Unit {
+  let _ = self.provider_dependency_fingerprint()
+  let _ = self.provider_status()
+  let _ = self.provider_retry_classification()
+  let _ = self.provider_next_driver_action()
 }
 
 ///|


### PR DESCRIPTION
## Summary

Adds the first reactive provider-boundary implementation for cognition without introducing real provider/network execution.

This keeps `CognitionStore` synchronous and deterministic while giving provider request planning, status, retry timing, cancellation, and driver actions an internal `@incr` representation.

## Changes

- Add `lib/cognition/provider_boundary_reactive.mbt` with an internal `ProviderPlanningGraph`.
- Derive request descriptors, dependency fingerprints, visible status, retry classification, and next driver action from watched `@incr` cells.
- Keep provider execution outside `Derived` closures; the graph only derives domain data for a driver to interpret.
- Wire provider planning, cancellation, and completion through `CognitionReactive`.
- Preserve the public request/completion contract as ordinary cognition domain values, with no public `@incr` handle types.
- Add deterministic wbtests for:
  - planning/status derivation,
  - retry timing under fake time,
  - request-scoped cancellation,
  - in-flight start acknowledgement,
  - idempotent pending replans preserving in-flight starts,
  - driver-supplied retry clocks,
  - cancellation priority before later starts,
  - `Scope`/`Watch` liveness across `Runtime::gc()`,
  - scripted driver success, retry, cancellation, and shutdown behavior,
  - stale completions after file removal and ranker/budget context changes.

## Non-Goals

- No real LLM/provider client.
- No credentials, HTTP transport, timers, background tasks, or async runtime integration.
- No Tier 2 `ReadError` widening.
- No durable dependency-history migration.

## Validation

- `NEW_MOON_MOD=0 moon check lib/cognition`
- `NEW_MOON_MOD=0 moon test lib/cognition` -> 91 passed
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info`
- `NEW_MOON_MOD=0 moon check`
- `NEW_MOON_MOD=0 moon test` -> 1217 JS passed, 237 wasm-gc passed
- `NEW_MOON_MOD=0 moon check --deny-warn`
- `git diff --cached --check`
