### PR TITLE
refactor(lang/json): idiom sweep — guards, leaf-node dedup, pattern matching

### DIFF
--- a/lang/json/edits/compute_json_edit.mbt
+++ b/lang/json/edits/compute_json_edit.mbt
@@ -102,11 +102,12 @@ fn compute_delete(
   let (range_start, range_end) = match
     find_parent_member_span(proj, source_map, node_id) {
     Some(span) => span
-    None =>
-      match source_map.get_range(node_id) {
-        Some(r) => (r.start, r.end)
-        None => return Err("node not found in source map")
+    None => {
+      guard source_map.get_range(node_id) is Some(r) else {
+        return Err("node not found in source map")
       }
+      (r.start, r.end)
+    }
   }
   // Find parent to handle comma cleanup
   let (delete_start, delete_end) = find_delete_range_with_comma(
@@ -132,18 +133,17 @@ fn find_parent_member_span(
   source_map : SourceMap,
   node_id : NodeId,
 ) -> (Int, Int)? {
-  match find_parent_object(proj, node_id) {
-    Some((parent_id, child_index)) =>
-      match
-        source_map.get_token_span(
-          parent_id,
-          @json_proj.member_role(child_index),
-        ) {
-        Some(r) => Some((r.start, r.end))
-        None => None
-      }
-    None => None
+  guard find_parent_object(proj, node_id) is Some((parent_id, child_index)) else {
+    return None
   }
+  guard source_map.get_token_span(
+      parent_id,
+      @json_proj.member_role(child_index),
+    )
+    is Some(r) else {
+    return None
+  }
+  Some((r.start, r.end))
 }
 
 ///|
@@ -162,9 +162,8 @@ fn find_parent_object(
   }
   // Recurse into all children
   for child in root.children {
-    match find_parent_object(child, target_id) {
-      Some(found) => return Some(found)
-      None => continue
+    if find_parent_object(child, target_id) is Some(found) {
+      return Some(found)
     }
   }
   None
@@ -184,20 +183,20 @@ fn find_delete_range_with_comma(
   // Try consuming trailing comma + whitespace
   let mut trail = end
   while trail < len && is_ws_code(source[trail]) {
-    trail = trail + 1
+    trail += 1
   }
   if trail < len && source[trail] == comma_code {
-    trail = trail + 1
+    trail += 1
     // Also skip whitespace after the comma
     while trail < len && is_ws_code(source[trail]) {
-      trail = trail + 1
+      trail += 1
     }
     return (start, trail)
   }
   // No trailing comma — try consuming leading comma + whitespace
   let mut lead = start - 1
   while lead >= 0 && is_ws_code(source[lead]) {
-    lead = lead - 1
+    lead -= 1
   }
   if lead >= 0 && source[lead] == comma_code {
     // Include the comma and whitespace before the node
@@ -234,9 +233,8 @@ fn compute_add_member(
   object_id : NodeId,
   key : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(object_id) {
-    Some(r) => r
-    None => return Err("object node not found in source map")
+  guard source_map.get_range(object_id) is Some(range) else {
+    return Err("object node not found in source map")
   }
   // Find the closing brace position
   let close_brace = range.end - 1
@@ -265,12 +263,10 @@ fn compute_add_member(
 ///|
 /// Check if there is any non-whitespace content between two positions.
 fn has_content_between(source : String, start : Int, end : Int) -> Bool {
-  let mut i = start
-  while i < end {
+  for i in start..<end {
     if !is_ws_code(source[i]) {
       return true
     }
-    i = i + 1
   }
   false
 }
@@ -284,9 +280,8 @@ fn compute_add_element(
   source_map : SourceMap,
   array_id : NodeId,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(array_id) {
-    Some(r) => r
-    None => return Err("array node not found in source map")
+  guard source_map.get_range(array_id) is Some(range) else {
+    return Err("array node not found in source map")
   }
   let close_bracket = range.end - 1
   if close_bracket < 0 ||
@@ -316,9 +311,8 @@ fn compute_wrap_in_array(
   source_map : SourceMap,
   node_id : NodeId,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("node not found in source map")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("node not found in source map")
   }
   let existing = source[range.start:range.end].to_owned()
   let wrapped = "[" + existing + "]"
@@ -343,9 +337,8 @@ fn compute_wrap_in_object(
   node_id : NodeId,
   key : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("node not found in source map")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("node not found in source map")
   }
   let escaped = json_escape_key(key)
   let existing = source[range.start:range.end].to_owned()
@@ -370,19 +363,12 @@ fn compute_unwrap(
   source_map : SourceMap,
   node_id : NodeId,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("node not found in source map")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("node not found in source map")
   }
   // Find the node in the projection tree to check it has exactly one child
-  let node = match
-    @core.get_node_in_tree(
-      // We need a way to find the node — use source_map to validate
-      // and then work with text directly
-      _proj, node_id,
-    ) {
-    Some(n) => n
-    None => return Err("node not found in projection tree")
+  guard @core.get_node_in_tree(_proj, node_id) is Some(node) else {
+    return Err("node not found in projection tree")
   }
   if node.children.length() != 1 {
     return Err(
@@ -391,9 +377,8 @@ fn compute_unwrap(
     )
   }
   let child = node.children[0]
-  let child_range = match source_map.get_range(child.id()) {
-    Some(r) => r
-    None => return Err("child node not found in source map")
+  guard source_map.get_range(child.id()) is Some(child_range) else {
+    return Err("child node not found in source map")
   }
   // Extract the child's text and replace the whole container
   let child_text = source[child_range.start:child_range.end].to_owned()
@@ -419,9 +404,8 @@ fn compute_change_type(
   node_id : NodeId,
   new_type : JsonType,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("node not found in source map")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("node not found in source map")
   }
   let placeholder = match new_type {
     JNull => "null"
@@ -456,9 +440,8 @@ fn compute_rename_key(
   new_key : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
   let role = @json_proj.key_role(key_index)
-  let key_range = match source_map.get_token_span(object_id, role) {
-    Some(r) => r
-    None => return Err("key span not found for " + role)
+  guard source_map.get_token_span(object_id, role) is Some(key_range) else {
+    return Err("key span not found for " + role)
   }
   let escaped = json_escape_key(new_key)
   let new_text = "\"" + escaped + "\""
@@ -484,9 +467,8 @@ fn compute_commit_edit(
   node_id : NodeId,
   new_value : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("node not found in source map")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("node not found in source map")
   }
   let edit = SpanEdit::{
     start: range.start,

--- a/lang/json/proj/populate_token_spans.mbt
+++ b/lang/json/proj/populate_token_spans.mbt
@@ -7,7 +7,7 @@ using @core {type SourceMap}
 ///|
 /// Token span role for object member keys. Convention: "key:0", "key:1", etc.
 pub fn key_role(index : Int) -> String {
-  "key:" + index.to_string()
+  "key:\{index}"
 }
 
 ///|
@@ -15,7 +15,7 @@ pub fn key_role(index : Int) -> String {
 /// Convention: "member:0", "member:1", etc.
 /// Used by Delete to remove the complete member text.
 pub fn member_role(index : Int) -> String {
-  "member:" + index.to_string()
+  "member:\{index}"
 }
 
 ///|
@@ -66,27 +66,22 @@ fn collect_token_spans(
           )
           // Find the StringToken key and record its span on the Object node
           for elem in member_syn.all_children() {
-            match elem {
-              @seam.SyntaxElement::Token(t) =>
-                if t.kind() == @json.StringToken.to_raw() {
-                  source_map.set_token_span(
-                    proj_node.id(),
-                    key_role(proj_idx),
-                    @loomcore.Range::new(t.start(), t.end()),
-                  )
-                  break
-                }
-              _ => ()
+            if elem is @seam.SyntaxElement::Token(t) &&
+              t.kind() == @json.StringToken.to_raw() {
+              source_map.set_token_span(
+                proj_node.id(),
+                key_role(proj_idx),
+                @loomcore.Range::new(t.start(), t.end()),
+              )
+              break
             }
           }
-          // Recurse into the value (first node child of MemberNode)
-          match member_syn.nth_child(0) {
-            Some(value_syn) =>
-              // The ProjNode child may itself have children (nested object/array)
-              collect_token_spans(source_map, value_syn, child_proj)
-            None => ()
+          // Recurse into the value (first node child of MemberNode).
+          // The ProjNode child may itself have children (nested object/array).
+          if member_syn.nth_child(0) is Some(value_syn) {
+            collect_token_spans(source_map, value_syn, child_proj)
           }
-          proj_idx = proj_idx + 1
+          proj_idx += 1
         }
       }
     }
@@ -101,7 +96,7 @@ fn collect_token_spans(
             elem_syn,
             proj_node.children[proj_idx],
           )
-          proj_idx = proj_idx + 1
+          proj_idx += 1
         }
       }
     }

--- a/lang/json/proj/proj_node.mbt
+++ b/lang/json/proj/proj_node.mbt
@@ -5,6 +5,23 @@
 using @core {type ProjNode, type NodeId}
 
 ///|
+/// Construct a childless ProjNode for a JSON leaf value, spanning `node`
+/// and taking a fresh id from `counter`.
+fn json_leaf_node(
+  value : @json.JsonValue,
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> ProjNode[@json.JsonValue] {
+  ProjNode::new(
+    value,
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    [],
+  )
+}
+
+///|
 /// Convert a SyntaxNode to a ProjNode[JsonValue].
 /// Handles RootNode by unwrapping to the single child value.
 pub fn syntax_to_proj_node(
@@ -15,14 +32,7 @@ pub fn syntax_to_proj_node(
     RootNode =>
       match node.nth_child(0) {
         Some(child) => syntax_to_proj_node(child, counter)
-        None =>
-          ProjNode::new(
-            Error("empty document"),
-            node.start(),
-            node.end(),
-            @core.next_proj_node_id(counter),
-            [],
-          )
+        None => json_leaf_node(Error("empty document"), node, counter)
       }
     ObjectNode => build_object_node(node, counter)
     ArrayNode => build_array_node(node, counter)
@@ -33,74 +43,36 @@ pub fn syntax_to_proj_node(
       } else {
         @json.JsonValue::Error("malformed string")
       }
-      ProjNode::new(
-        value,
-        node.start(),
-        node.end(),
-        @core.next_proj_node_id(counter),
-        [],
-      )
+      json_leaf_node(value, node, counter)
     }
     NumberValue => {
       let text = node.token_text(@json.NumberToken.to_raw())
       let n = @string.parse_double(text) catch {
-        _ => {
-          let value = @json.JsonValue::Error("invalid number: " + text)
-          return ProjNode::new(
-            value,
-            node.start(),
-            node.end(),
-            @core.next_proj_node_id(counter),
-            [],
+        _ =>
+          return json_leaf_node(
+            @json.JsonValue::Error("invalid number: " + text),
+            node,
+            counter,
           )
-        }
       }
-      ProjNode::new(
-        @json.JsonValue::Number(n),
-        node.start(),
-        node.end(),
-        @core.next_proj_node_id(counter),
-        [],
-      )
+      json_leaf_node(@json.JsonValue::Number(n), node, counter)
     }
     BoolValue => {
-      let value = match node.find_token(@json.TrueKeyword.to_raw()) {
-        Some(_) => @json.JsonValue::Bool(true)
-        None => @json.JsonValue::Bool(false)
-      }
-      ProjNode::new(
-        value,
-        node.start(),
-        node.end(),
-        @core.next_proj_node_id(counter),
-        [],
+      let value = @json.JsonValue::Bool(
+        node.find_token(@json.TrueKeyword.to_raw()) is Some(_),
       )
+      json_leaf_node(value, node, counter)
     }
-    NullValue =>
-      ProjNode::new(
-        @json.JsonValue::Null,
-        node.start(),
-        node.end(),
-        @core.next_proj_node_id(counter),
-        [],
-      )
+    NullValue => json_leaf_node(@json.JsonValue::Null, node, counter)
     ErrorNode =>
-      ProjNode::new(
-        @json.JsonValue::Error("parse error"),
-        node.start(),
-        node.end(),
-        @core.next_proj_node_id(counter),
-        [],
-      )
+      json_leaf_node(@json.JsonValue::Error("parse error"), node, counter)
     _ =>
-      ProjNode::new(
+      json_leaf_node(
         @json.JsonValue::Error(
           "unknown node: " + @json.SyntaxKind::from_raw(node.kind()).to_string(),
         ),
-        node.start(),
-        node.end(),
-        @core.next_proj_node_id(counter),
-        [],
+        node,
+        counter,
       )
   }
 }
@@ -116,23 +88,20 @@ fn build_object_node(
   let children : Array[ProjNode[@json.JsonValue]] = []
   let members : Array[(String, @json.JsonValue)] = []
   for child in node.children() {
-    match @json.SyntaxKind::from_raw(child.kind()) {
-      MemberNode => {
-        let (key, value_proj) = extract_member(child, counter)
-        // Use value span for the child ProjNode (not member span).
-        // The full member span (key + colon + value) is stored separately
-        // as a "member:N" token span on the Object for delete operations.
-        let member_proj = ProjNode::new(
-          value_proj.kind,
-          value_proj.start,
-          value_proj.end,
-          @core.next_proj_node_id(counter),
-          value_proj.children,
-        )
-        children.push(member_proj)
-        members.push((key, value_proj.kind))
-      }
-      _ => ()
+    if @json.SyntaxKind::from_raw(child.kind()) is MemberNode {
+      let (key, value_proj) = extract_member(child, counter)
+      // Use value span for the child ProjNode (not member span).
+      // The full member span (key + colon + value) is stored separately
+      // as a "member:N" token span on the Object for delete operations.
+      let member_proj = ProjNode::new(
+        value_proj.kind,
+        value_proj.start,
+        value_proj.end,
+        @core.next_proj_node_id(counter),
+        value_proj.children,
+      )
+      children.push(member_proj)
+      members.push((key, value_proj.kind))
     }
   }
   ProjNode::new(
@@ -177,25 +146,20 @@ fn extract_member(
   // Extract key from the first StringToken (direct child only)
   let mut key_text = ""
   for elem in member_node.all_children() {
-    match elem {
-      @seam.SyntaxElement::Token(t) =>
-        if t.kind() == @json.StringToken.to_raw() {
-          key_text = parse_json_string(t.text())
-          break
-        }
-      _ => ()
+    if elem is @seam.SyntaxElement::Token(t) &&
+      t.kind() == @json.StringToken.to_raw() {
+      key_text = parse_json_string(t.text())
+      break
     }
   }
   // Extract value from first node child
   let value_proj = match member_node.nth_child(0) {
     Some(v) => syntax_to_proj_node(v, counter)
     None =>
-      ProjNode::new(
+      json_leaf_node(
         @json.JsonValue::Error("missing member value"),
-        member_node.start(),
-        member_node.end(),
-        @core.next_proj_node_id(counter),
-        [],
+        member_node,
+        counter,
       )
   }
   (key_text, value_proj)


### PR DESCRIPTION
## Summary

Behavior-preserving idiom sweep of the `lang/json/` module, continuing the stdlib/idiom pass from #381 (which covered `core/` + `projection/`). Two commits, no public API change anywhere (every `pkg.generated.mbti` diff is empty).

### `edits/compute_json_edit.mbt`
- Convert 11 `match source_map.get_range(...) { Some(r) => r; None => return Err(...) }` blocks → `guard ... is Some(range) else { return Err(...) }`, binding the result name directly and keeping the happy path unindented.
- `find_parent_member_span`: nested `Option` matches → two guards.
- `find_parent_object`: recurse loop `match { Some => return; None => continue }` → `if ... is Some(found) { return ... }`.
- `has_content_between`: index `while` → `for i in start..<end`.
- comma-scan loops: `x = x + 1` → `+=` / `-=`.

### `proj/proj_node.mbt`
- Extract a private `json_leaf_node` helper, collapsing **9** copies of the 6-line `ProjNode::new(value, node.start(), node.end(), next_proj_node_id(counter), [])` leaf construction into one-liners.
- `BoolValue`: `match find_token { Some(_) => Bool(true); None => Bool(false) }` → `Bool(find_token(...) is Some(_))`.
- `build_object_node` / `extract_member`: `match { Variant => ...; _ => () }` filter loops → `if ... is Variant`.

### `proj/populate_token_spans.mbt`
- `key_role`/`member_role`: string concat → interpolation `"key:\{index}"`.
- key-token filter loop → `if elem is Token(t) && ...`.
- `match nth_child { Some => ...; None => () }` → `if ... is Some`.
- `proj_idx = proj_idx + 1` → `+= 1`.

Left untouched: `proj/parse_json_string.mbt` (a variable-stride escape-scanner where the `while` loop is the correct idiom), `companion/` (already uses `guard ... is Some`), and `edits/json_edit_op.mbt` / `top.mbt` (plain definitions).

## Reuse check

- `json_leaf_node` is a new **private** helper. Existing-API check: `@core.ProjNode::new` is the 5-arg positional primitive being duplicated (the smell); `@projection.is_leaf_node` is an unrelated `Bool` predicate, not a constructor. No existing helper takes a syntax node to build a childless leaf, so the local helper is justified; its responsibility is scoped to the JSON projection builder.
- All other changes rewrite existing code into language idioms (`guard`/`is`/`for-in`/interpolation) — no new helpers, no signature changes.

## Verification

- `moon check` — clean across workspace.
- `moon test lang/json/proj lang/json/companion` — **38/38 pass** (companion `integration_wbtest.mbt` is the behavior harness for `compute_json_edit`; proj has 17 builder tests). Baselines were 21 and 17.
- `moon info` → `git diff lang/json/**/*.mbti` is **empty** — no contract leak.
- `moon fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)