### PR TITLE
refactor: lang/lambda idiom sweep + repo-wide ProjNode::id() cleanup

### DIFF
--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -73,7 +73,7 @@ pub fn[T] SourceMap::remove_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  let node_id = NodeId::from_int(node.node_id)
+  let node_id = node.id()
   self.node_to_range.remove(node_id)
   self.token_spans.remove(node_id)
   for child in node.children {
@@ -91,7 +91,7 @@ pub fn[T] SourceMap::patch_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  let node_id = NodeId::from_int(node.node_id)
+  let node_id = node.id()
   self.node_to_range[node_id] = Range::new(node.start, node.end)
   self.token_spans.remove(node_id)
   for child in node.children {

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -144,6 +144,22 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: `build_tree`, `build_tree_interned`, `build_tree_fully_interned` are ~80 lines each of near-identical stack-based tree construction, differing only in token creation and node wrapping. Discovered during error handling audit (loom PR #75).
   Exit: shared core function parameterized by token/node creation callbacks; three variants are thin wrappers.
 
+- [ ] Hoist ProjNode id-allocation boilerplate into `@core` (`core/proj_node.mbt`). (finding B from PR #383)
+  Why: every `ProjNode::new(...)` call across `lang/lambda/proj` and `lang/json/proj` threads `@core.next_proj_node_id(counter)` into the id argument, and the per-language `lambda_leaf_node` / `json_leaf_node` helpers (PR #382/#383) are identical up to the value type `T`. `@core` already depends on `@seam`, so it can host the shared form.
+  Exit: `@core` exposes `ProjNode::leaf[T](kind, node : @seam.SyntaxNode, counter)` (plus a fresh-id branch ctor); both per-language leaf helpers are deleted and branch builders drop the explicit `next_proj_node_id` arg. Non-node-span sites (Unit fallback, Module span, ParenExpr id-reuse) keep raw `ProjNode::new`. `.mbti` change limited to the new `@core` exports; all tests pass.
+
+- [ ] Add an `EditContext` node-resolution helper (`lang/lambda/edits/text_edit.mbt`). (finding C from PR #383)
+  Why: nearly every `compute_*` handler opens with the same pair of guards keyed on one `node_id` — `registry.get(id)` then `source_map.get_range(id)`, both erroring "Node not found" — made visible by the PR #383 guard sweep. `EditContext` already holds both maps.
+  Exit: `EditContext::resolve(self, node_id) -> Result[(ProjNode[T], Range), String]` (or `require_node` / `require_range`); the ~10 handler prologues collapse to one call; behavior and error messages preserved.
+
+- [ ] Evaluate moving the edit layer from `Result[_, String]` to a `raise EditError` model (`lang/lambda/edits`). (finding D from PR #383)
+  Why: the `match x { Ok(v) => v; Err(e) => return Err(e) }` passthroughs left in PR #383 exist only because MoonBit has no `?`-propagation for plain `Result`. A raising error model would auto-propagate them away and let the Some/None guards sit on raising accessors. Larger design call — touches `EditResult` and error-type design; see the `moonbit-error-handling` skill.
+  Exit: decision recorded (adopt or keep `Result`) with rationale; if adopted, passthroughs removed and `EditResult` retyped.
+
+- [ ] Uniform syntax→projection dispatch + parallel-walk helper (loom `@seam` / `lang/*/proj`). (finding E from PR #383)
+  Why: `syntax_to_proj_node` dispatches via a typed `View::cast(node) is Some(v)` ladder, but two arms (`BlockExpr`, `HoleLiteral`) fall back to raw `SyntaxKind::from_raw(...) == ...` because no typed View exists; separately, `populate_token_spans` hand-rolls fragile `proj_chain` index arithmetic to align flat CST App/Binary spans with the nested ProjNode tree.
+  Exit: typed Views cover all dispatched kinds (uniform `is Some` ladder); a loom-level "zip syntax children with projection children" utility absorbs the manual chain navigation. Tracked upstream in loom.
+
 ---
 
 ## 8. Handler Chain Follow-ups

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -61,7 +61,7 @@ fn find_enclosing_lam_binder(
 ) -> BindingSite? {
   for pid, pnode in registry {
     for child in pnode.children {
-      if NodeId::from_int(child.node_id) == node_id {
+      if child.id() == node_id {
         match pnode.kind {
           @ast.Term::Lam(param, _) =>
             if param == name {
@@ -152,7 +152,7 @@ pub fn collect_lam_env(
   fn walk_up(nid : NodeId) {
     for pid, pnode in registry {
       for child in pnode.children {
-        if NodeId::from_int(child.node_id) == nid {
+        if child.id() == nid {
           if pnode.kind is @ast.Term::Lam(param, _) {
             env = env.add(param)
           }

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -21,20 +21,18 @@ pub fn resolve_binder(
     return lam_binder
   }
   // Check Module defs — find which def/body contains this var
-  let var_pos = match source_map.get_range(var_node_id) {
-    Some(r) => r.start
-    None => return None
+  guard source_map.get_range(var_node_id) is Some(var_range) else {
+    return None
   }
+  let var_pos = var_range.start
   // Find which def index (or body) this var is in
   let mut containing_def_index = flat_proj.defs.length() // body sentinel
   for i, def in flat_proj.defs {
-    match source_map.get_range(def.1.id()) {
-      Some(r) =>
-        if var_pos >= r.start && var_pos < r.end {
-          containing_def_index = i
-          break
-        }
-      None => ()
+    if source_map.get_range(def.1.id()) is Some(r) &&
+      var_pos >= r.start &&
+      var_pos < r.end {
+      containing_def_index = i
+      break
     }
   }
   // Walk backwards from containing_def_index to find matching def
@@ -100,11 +98,8 @@ pub fn find_usages(
     collect_var_usages(def.1, var_name, results)
   }
   // Check body only if not shadowed
-  if !shadowed {
-    match flat_proj.final_expr {
-      Some(body) => collect_var_usages(body, var_name, results)
-      None => ()
-    }
+  if !shadowed && flat_proj.final_expr is Some(body) {
+    collect_var_usages(body, var_name, results)
   }
   results
 }
@@ -158,9 +153,8 @@ pub fn collect_lam_env(
     for pid, pnode in registry {
       for child in pnode.children {
         if NodeId::from_int(child.node_id) == nid {
-          match pnode.kind {
-            @ast.Term::Lam(param, _) => env = env.add(param)
-            _ => ()
+          if pnode.kind is @ast.Term::Lam(param, _) {
+            env = env.add(param)
           }
           walk_up(pid)
           return

--- a/lang/lambda/edits/text_edit_binding.mbt
+++ b/lang/lambda/edits/text_edit_binding.mbt
@@ -198,18 +198,17 @@ fn compute_add_binding(
 ) -> EditResult {
   let { registry, flat_proj, .. } = ctx
   // Validate target is a Module node before delegating
-  match registry.get(module_node_id) {
-    None => Err("Module not found: " + module_node_id.to_string())
-    Some(node) =>
-      match node.kind {
-        @ast.Term::Module(_, _) =>
-          compute_insert_child(
-            ctx,
-            module_node_id,
-            flat_proj.defs.length(),
-            @ast.Term::Int(0),
-          )
-        _ => Err("AddBinding target is not a Module node")
-      }
+  guard registry.get(module_node_id) is Some(node) else {
+    return Err("Module not found: " + module_node_id.to_string())
+  }
+  match node.kind {
+    @ast.Term::Module(_, _) =>
+      compute_insert_child(
+        ctx,
+        module_node_id,
+        flat_proj.defs.length(),
+        @ast.Term::Int(0),
+      )
+    _ => Err("AddBinding target is not a Module node")
   }
 }

--- a/lang/lambda/edits/text_edit_commit.mbt
+++ b/lang/lambda/edits/text_edit_commit.mbt
@@ -4,22 +4,21 @@ fn compute_commit(
   node_id : NodeId,
   new_value : String,
 ) -> EditResult {
-  match ctx.source_map.get_range(node_id) {
-    None => Err("Node not found: " + node_id.to_string())
-    Some(range) =>
-      Ok(
-        Some(
-          (
-            [
-              {
-                start: range.start,
-                delete_len: range.end - range.start,
-                inserted: new_value,
-              },
-            ],
-            RestoreCursor,
-          ),
-        ),
-      )
+  guard ctx.source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
   }
+  Ok(
+    Some(
+      (
+        [
+          {
+            start: range.start,
+            delete_len: range.end - range.start,
+            inserted: new_value,
+          },
+        ],
+        RestoreCursor,
+      ),
+    ),
+  )
 }

--- a/lang/lambda/edits/text_edit_delete.mbt
+++ b/lang/lambda/edits/text_edit_delete.mbt
@@ -1,91 +1,14 @@
 ///|
 fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match source_map.get_range(node_id) {
-    None => Err("Node not found: " + node_id.to_string())
-    Some(range) =>
-      match find_parent(registry, node_id) {
-        Some((parent_id, parent_node, child_index)) =>
-          match parent_node.kind {
-            @ast.Term::Error(_) =>
-              // Error parent: remove child entirely
-              Ok(
-                Some(
-                  (
-                    [
-                      {
-                        start: range.start,
-                        delete_len: range.end - range.start,
-                        inserted: "",
-                      },
-                    ],
-                    RestoreCursor,
-                  ),
-                ),
-              )
-            _ => {
-              // Replace child with placeholder in parent, then re-render parent
-              let target = parent_node.children[child_index]
-              let pk = placeholder_term_for_kind(target.kind)
-              // Build new children array with placeholder at child_index
-              let new_children : Array[ProjNode[@ast.Term]] = []
-              for i, c in parent_node.children {
-                if i == child_index {
-                  new_children.push(
-                    ProjNode::new(pk, c.start, c.end, c.node_id, []),
-                  )
-                } else {
-                  new_children.push(c)
-                }
-              }
-              let new_parent_kind = rebuild_kind(parent_node.kind, new_children)
-              let new_text = @ast.print_term(new_parent_kind)
-              match source_map.get_range(parent_id) {
-                None => {
-                  // No parent range — fall back to simple placeholder
-                  let placeholder = match registry.get(node_id) {
-                    Some(node) => placeholder_text_for_kind(node.kind)
-                    None => "a"
-                  }
-                  Ok(
-                    Some(
-                      (
-                        [
-                          {
-                            start: range.start,
-                            delete_len: range.end - range.start,
-                            inserted: placeholder,
-                          },
-                        ],
-                        RestoreCursor,
-                      ),
-                    ),
-                  )
-                }
-                Some(parent_range) =>
-                  Ok(
-                    Some(
-                      (
-                        [
-                          {
-                            start: parent_range.start,
-                            delete_len: parent_range.end - parent_range.start,
-                            inserted: new_text,
-                          },
-                        ],
-                        RestoreCursor,
-                      ),
-                    ),
-                  )
-              }
-            }
-          }
-        None => {
-          // No parent found — this is the root node. Just use placeholder.
-          let placeholder = match registry.get(node_id) {
-            Some(node) => placeholder_text_for_kind(node.kind)
-            None => "a"
-          }
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  match find_parent(registry, node_id) {
+    Some((parent_id, parent_node, child_index)) =>
+      match parent_node.kind {
+        @ast.Term::Error(_) =>
+          // Error parent: remove child entirely
           Ok(
             Some(
               (
@@ -93,14 +16,90 @@ fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult 
                   {
                     start: range.start,
                     delete_len: range.end - range.start,
-                    inserted: placeholder,
+                    inserted: "",
                   },
                 ],
                 RestoreCursor,
               ),
             ),
           )
+        _ => {
+          // Replace child with placeholder in parent, then re-render parent
+          let target = parent_node.children[child_index]
+          let pk = placeholder_term_for_kind(target.kind)
+          // Build new children array with placeholder at child_index
+          let new_children : Array[ProjNode[@ast.Term]] = []
+          for i, c in parent_node.children {
+            if i == child_index {
+              new_children.push(
+                ProjNode::new(pk, c.start, c.end, c.node_id, []),
+              )
+            } else {
+              new_children.push(c)
+            }
+          }
+          let new_parent_kind = rebuild_kind(parent_node.kind, new_children)
+          let new_text = @ast.print_term(new_parent_kind)
+          match source_map.get_range(parent_id) {
+            None => {
+              // No parent range — fall back to simple placeholder
+              let placeholder = match registry.get(node_id) {
+                Some(node) => placeholder_text_for_kind(node.kind)
+                None => "a"
+              }
+              Ok(
+                Some(
+                  (
+                    [
+                      {
+                        start: range.start,
+                        delete_len: range.end - range.start,
+                        inserted: placeholder,
+                      },
+                    ],
+                    RestoreCursor,
+                  ),
+                ),
+              )
+            }
+            Some(parent_range) =>
+              Ok(
+                Some(
+                  (
+                    [
+                      {
+                        start: parent_range.start,
+                        delete_len: parent_range.end - parent_range.start,
+                        inserted: new_text,
+                      },
+                    ],
+                    RestoreCursor,
+                  ),
+                ),
+              )
+          }
         }
       }
+    None => {
+      // No parent found — this is the root node. Just use placeholder.
+      let placeholder = match registry.get(node_id) {
+        Some(node) => placeholder_text_for_kind(node.kind)
+        None => "a"
+      }
+      Ok(
+        Some(
+          (
+            [
+              {
+                start: range.start,
+                delete_len: range.end - range.start,
+                inserted: placeholder,
+              },
+            ],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
   }
 }

--- a/lang/lambda/edits/text_edit_drop.mbt
+++ b/lang/lambda/edits/text_edit_drop.mbt
@@ -8,13 +8,11 @@ fn compute_drop(
   // Legality: self-drop
   guard source != target else { return Err("Cannot drop onto self") }
   let { source_text, source_map, .. } = ctx
-  let source_range = match source_map.get_range(source) {
-    Some(r) => r
-    None => return Err("Source node not found")
+  guard source_map.get_range(source) is Some(source_range) else {
+    return Err("Source node not found")
   }
-  let target_range = match source_map.get_range(target) {
-    Some(r) => r
-    None => return Err("Target node not found")
+  guard source_map.get_range(target) is Some(target_range) else {
+    return Err("Target node not found")
   }
   // Legality: descendant-drop (target is inside source)
   guard !(target_range.start >= source_range.start &&

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -5,26 +5,22 @@ fn compute_extract_to_let(
   var_name : String,
 ) -> EditResult {
   let { source_text, source_map, registry, flat_proj } = ctx
-  let node = match registry.get(node_id) {
-    Some(n) => n
-    None => return Err("Node not found")
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found")
   }
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("Range not found")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Range not found")
   }
   // Free-var validation: check for lambda-captured variables
   let mut module_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   // Find which def contains this node (or if it's in the body)
   let mut in_def_index : Int = flat_proj.defs.length() // body sentinel
   for i, def in flat_proj.defs {
-    match source_map.get_range(def.1.id()) {
-      Some(r) =>
-        if range.start >= r.start && range.end <= r.end {
-          in_def_index = i
-          break
-        }
-      None => ()
+    if source_map.get_range(def.1.id()) is Some(r) &&
+      range.start >= r.start &&
+      range.end <= r.end {
+      in_def_index = i
+      break
     }
   }
   // Add def names in scope at the extraction site
@@ -134,23 +130,19 @@ fn compute_inline_definition(
   node_id : NodeId,
 ) -> EditResult {
   let { source_text, source_map, registry, flat_proj } = ctx
-  let node = match registry.get(node_id) {
-    Some(n) => n
-    None => return Err("Node not found: " + node_id.to_string())
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
   }
-  let var_name = match node.kind {
-    @ast.Term::Var(name) => name
-    _ => return Err("InlineDefinition requires a Var node")
+  guard node.kind is @ast.Term::Var(var_name) else {
+    return Err("InlineDefinition requires a Var node")
   }
-  let range = match source_map.get_range(node_id) {
-    Some(r) => r
-    None => return Err("Var not in source map")
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Var not in source map")
   }
   // Resolve the binding
-  let binder = match
-    resolve_binder(node_id, var_name, flat_proj, registry, source_map) {
-    Some(b) => b
-    None => return Err("No binding found for variable: " + var_name)
+  guard resolve_binder(node_id, var_name, flat_proj, registry, source_map)
+    is Some(binder) else {
+    return Err("No binding found for variable: " + var_name)
   }
   match binder {
     LamBinder(..) =>
@@ -275,9 +267,8 @@ fn compute_inline_all_usages(
   // Collect usage ranges, sorted by position (descending)
   let usage_ranges : Array[(Int, Int)] = []
   for uid in usage_ids {
-    match source_map.get_range(uid) {
-      Some(r) => usage_ranges.push((r.start, r.end))
-      None => ()
+    if source_map.get_range(uid) is Some(r) {
+      usage_ranges.push((r.start, r.end))
     }
   }
   usage_ranges.sort_by(fn(a, b) { b.0.compare(a.0) })

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -28,19 +28,16 @@ fn rename_lam_param(
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
   let source_map = ctx.source_map
   // Guard: check if new_name is free in the lambda body — renaming would capture it
-  match lam_node.kind {
-    @ast.Term::Lam(_, body) => {
-      let bound : @immut/hashset.HashSet[String] = @immut/hashset.new().add(
-        old_name,
+  if lam_node.kind is @ast.Term::Lam(_, body) {
+    let bound : @immut/hashset.HashSet[String] = @immut/hashset.new().add(
+      old_name,
+    )
+    let body_fv = free_vars(body, bound)
+    if body_fv.contains(new_name) {
+      return Err(
+        "Cannot rename: would capture free variable '" + new_name + "'",
       )
-      let body_fv = free_vars(body, bound)
-      if body_fv.contains(new_name) {
-        return Err(
-          "Cannot rename: would capture free variable '" + new_name + "'",
-        )
-      }
     }
-    _ => ()
   }
   let edits : Array[SpanEdit] = []
   // Get param token span
@@ -83,9 +80,8 @@ fn rename_lam_param(
   // Add edits for each var, collecting ranges first
   let var_ranges : Array[(Int, Int)] = []
   for vid in var_ids {
-    match source_map.get_range(vid) {
-      Some(r) => var_ranges.push((r.start, r.end))
-      None => ()
+    if source_map.get_range(vid) is Some(r) {
+      var_ranges.push((r.start, r.end))
     }
   }
   // Sort descending by position for reverse-order application
@@ -106,16 +102,15 @@ fn rename_from_var(
   old_name : String,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let binder = match
-    resolve_binder(
+  guard resolve_binder(
       var_node_id,
       old_name,
       ctx.flat_proj,
       ctx.registry,
       ctx.source_map,
-    ) {
-    Some(b) => b
-    None => return Err("No binding found for variable: " + old_name)
+    )
+    is Some(binder) else {
+    return Err("No binding found for variable: " + old_name)
   }
   match binder {
     LamBinder(lam_id~) =>
@@ -220,9 +215,8 @@ fn rename_module_binding(
   }
   let usage_ranges : Array[(Int, Int)] = []
   for uid in usage_ids {
-    match source_map.get_range(uid) {
-      Some(r) => usage_ranges.push((r.start, r.end))
-      None => ()
+    if source_map.get_range(uid) is Some(r) {
+      usage_ranges.push((r.start, r.end))
     }
   }
   // Sort descending by position

--- a/lang/lambda/edits/text_edit_structural.mbt
+++ b/lang/lambda/edits/text_edit_structural.mbt
@@ -5,31 +5,33 @@ fn compute_unwrap(
   keep_child_index : Int,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match (source_map.get_range(node_id), registry.get(node_id)) {
-    (Some(range), Some(node)) =>
-      if keep_child_index < 0 || keep_child_index >= node.children.length() {
-        Err("Child index out of range")
-      } else {
-        let kept = node.children[keep_child_index]
-        let kept_text = @ast.print_term(kept.kind)
-        // Cursor at start of the replacement text (the parent's original start),
-        // not the kept child's original position which is invalidated by the edit.
-        Ok(
-          Some(
-            (
-              [
-                {
-                  start: range.start,
-                  delete_len: range.end - range.start,
-                  inserted: kept_text,
-                },
-              ],
-              MoveCursor(position=range.start),
-            ),
-          ),
-        )
-      }
-    _ => Err("Node not found: " + node_id.to_string())
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  if keep_child_index < 0 || keep_child_index >= node.children.length() {
+    Err("Child index out of range")
+  } else {
+    let kept = node.children[keep_child_index]
+    let kept_text = @ast.print_term(kept.kind)
+    // Cursor at start of the replacement text (the parent's original start),
+    // not the kept child's original position which is invalidated by the edit.
+    Ok(
+      Some(
+        (
+          [
+            {
+              start: range.start,
+              delete_len: range.end - range.start,
+              inserted: kept_text,
+            },
+          ],
+          MoveCursor(position=range.start),
+        ),
+      ),
+    )
   }
 }
 
@@ -39,46 +41,48 @@ fn compute_swap_children(
   node_id : NodeId,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match (source_map.get_range(node_id), registry.get(node_id)) {
-    (Some(range), Some(node)) =>
-      match node.kind {
-        @ast.Term::Bop(op, l, r) => {
-          let swapped = @ast.print_term(Bop(op, r, l))
-          Ok(
-            Some(
-              (
-                [
-                  {
-                    start: range.start,
-                    delete_len: range.end - range.start,
-                    inserted: swapped,
-                  },
-                ],
-                RestoreCursor,
-              ),
-            ),
-          )
-        }
-        @ast.Term::If(c, t, e) => {
-          let swapped = @ast.print_term(If(c, e, t))
-          Ok(
-            Some(
-              (
-                [
-                  {
-                    start: range.start,
-                    delete_len: range.end - range.start,
-                    inserted: swapped,
-                  },
-                ],
-                RestoreCursor,
-              ),
-            ),
-          )
-        }
-        _ => Err("SwapChildren requires Bop or If node")
-      }
-    _ => Err("Node not found: " + node_id.to_string())
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  match node.kind {
+    @ast.Term::Bop(op, l, r) => {
+      let swapped = @ast.print_term(Bop(op, r, l))
+      Ok(
+        Some(
+          (
+            [
+              {
+                start: range.start,
+                delete_len: range.end - range.start,
+                inserted: swapped,
+              },
+            ],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
+    @ast.Term::If(c, t, e) => {
+      let swapped = @ast.print_term(If(c, e, t))
+      Ok(
+        Some(
+          (
+            [
+              {
+                start: range.start,
+                delete_len: range.end - range.start,
+                inserted: swapped,
+              },
+            ],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
+    _ => Err("SwapChildren requires Bop or If node")
   }
 }
 
@@ -89,28 +93,30 @@ fn compute_change_operator(
   new_op : @ast.Bop,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match (source_map.get_range(node_id), registry.get(node_id)) {
-    (Some(range), Some(node)) =>
-      match node.kind {
-        @ast.Term::Bop(_, l, r) => {
-          let new_text = @ast.print_term(Bop(new_op, l, r))
-          Ok(
-            Some(
-              (
-                [
-                  {
-                    start: range.start,
-                    delete_len: range.end - range.start,
-                    inserted: new_text,
-                  },
-                ],
-                RestoreCursor,
-              ),
-            ),
-          )
-        }
-        _ => Err("ChangeOperator requires Bop node")
-      }
-    _ => Err("Node not found: " + node_id.to_string())
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  match node.kind {
+    @ast.Term::Bop(_, l, r) => {
+      let new_text = @ast.print_term(Bop(new_op, l, r))
+      Ok(
+        Some(
+          (
+            [
+              {
+                start: range.start,
+                delete_len: range.end - range.start,
+                inserted: new_text,
+              },
+            ],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
+    _ => Err("ChangeOperator requires Bop node")
   }
 }

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -74,7 +74,7 @@ fn find_parent(
 ) -> (NodeId, ProjNode[@ast.Term], Int)? {
   for pid, pnode in registry {
     for i, child in pnode.children {
-      if NodeId::from_int(child.node_id) == node_id {
+      if child.id() == node_id {
         return Some((pid, pnode, i))
       }
     }

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -91,9 +91,8 @@ fn get_binding_text_range(
   def : (String, ProjNode[@ast.Term], Int, NodeId),
 ) -> Result[(Int, Int), String] {
   let init_node = def.1
-  let init_range = match source_map.get_range(init_node.id()) {
-    Some(r) => r
-    None => return Err("Init node not in source map")
+  guard source_map.get_range(init_node.id()) is Some(init_range) else {
+    return Err("Init node not in source map")
   }
   let let_start = find_let_start(source_text, init_range.start)
   Ok((let_start, init_range.end))

--- a/lang/lambda/edits/text_edit_wrap.mbt
+++ b/lang/lambda/edits/text_edit_wrap.mbt
@@ -5,30 +5,28 @@ fn compute_wrap_lambda(
   var_name : String,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match source_map.get_range(node_id) {
-    None => Err("Node not found: " + node_id.to_string())
-    Some(range) => {
-      let existing = match registry.get(node_id) {
-        Some(node) => @ast.print_term(node.kind)
-        None => return Err("Node not found in registry")
-      }
-      let wrapped = "(λ" + var_name + ". " + existing + ")"
-      Ok(
-        Some(
-          (
-            [
-              {
-                start: range.start,
-                delete_len: range.end - range.start,
-                inserted: wrapped,
-              },
-            ],
-            RestoreCursor,
-          ),
-        ),
-      )
-    }
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
   }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found in registry")
+  }
+  let existing = @ast.print_term(node.kind)
+  let wrapped = "(λ" + var_name + ". " + existing + ")"
+  Ok(
+    Some(
+      (
+        [
+          {
+            start: range.start,
+            delete_len: range.end - range.start,
+            inserted: wrapped,
+          },
+        ],
+        RestoreCursor,
+      ),
+    ),
+  )
 }
 
 ///|
@@ -37,30 +35,27 @@ fn compute_wrap_app(
   node_id : NodeId,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match source_map.get_range(node_id) {
-    None => Err("Node not found: " + node_id.to_string())
-    Some(range) => {
-      let existing_kind = match registry.get(node_id) {
-        Some(node) => node.kind
-        None => return Err("Node not found in registry")
-      }
-      let wrapped = @ast.print_term(App(existing_kind, Var("a")))
-      Ok(
-        Some(
-          (
-            [
-              {
-                start: range.start,
-                delete_len: range.end - range.start,
-                inserted: wrapped,
-              },
-            ],
-            RestoreCursor,
-          ),
-        ),
-      )
-    }
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
   }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found in registry")
+  }
+  let wrapped = @ast.print_term(App(node.kind, Var("a")))
+  Ok(
+    Some(
+      (
+        [
+          {
+            start: range.start,
+            delete_len: range.end - range.start,
+            inserted: wrapped,
+          },
+        ],
+        RestoreCursor,
+      ),
+    ),
+  )
 }
 
 ///|
@@ -69,28 +64,29 @@ fn compute_wrap_if(
   node_id : NodeId,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match (source_map.get_range(node_id), registry.get(node_id)) {
-    (Some(range), Some(node)) => {
-      let wrapped = @ast.print_term(If(Int(0), node.kind, Int(0)))
-      // "if 0 then ..." — condition placeholder "0" starts at offset 3
-      let condition_pos = range.start + 3
-      Ok(
-        Some(
-          (
-            [
-              {
-                start: range.start,
-                delete_len: range.end - range.start,
-                inserted: wrapped,
-              },
-            ],
-            MoveCursor(position=condition_pos),
-          ),
-        ),
-      )
-    }
-    _ => Err("Node not found: " + node_id.to_string())
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
   }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  let wrapped = @ast.print_term(If(Int(0), node.kind, Int(0)))
+  // "if 0 then ..." — condition placeholder "0" starts at offset 3
+  let condition_pos = range.start + 3
+  Ok(
+    Some(
+      (
+        [
+          {
+            start: range.start,
+            delete_len: range.end - range.start,
+            inserted: wrapped,
+          },
+        ],
+        MoveCursor(position=condition_pos),
+      ),
+    ),
+  )
 }
 
 ///|
@@ -100,28 +96,29 @@ fn compute_wrap_bop(
   op : @ast.Bop,
 ) -> EditResult {
   let { source_map, registry, .. } = ctx
-  match (source_map.get_range(node_id), registry.get(node_id)) {
-    (Some(range), Some(node)) => {
-      let wrapped = @ast.print_term(Bop(op, node.kind, Int(0)))
-      // "(expr + 0)" — placeholder "0" is at wrapped.length() - 2 from start
-      let placeholder_pos = range.start + wrapped.length() - 2
-      Ok(
-        Some(
-          (
-            [
-              {
-                start: range.start,
-                delete_len: range.end - range.start,
-                inserted: wrapped,
-              },
-            ],
-            MoveCursor(position=placeholder_pos),
-          ),
-        ),
-      )
-    }
-    _ => Err("Node not found: " + node_id.to_string())
+  guard source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
   }
+  guard registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  let wrapped = @ast.print_term(Bop(op, node.kind, Int(0)))
+  // "(expr + 0)" — placeholder "0" is at wrapped.length() - 2 from start
+  let placeholder_pos = range.start + wrapped.length() - 2
+  Ok(
+    Some(
+      (
+        [
+          {
+            start: range.start,
+            delete_len: range.end - range.start,
+            inserted: wrapped,
+          },
+        ],
+        MoveCursor(position=placeholder_pos),
+      ),
+    ),
+  )
 }
 
 ///|
@@ -136,69 +133,60 @@ fn compute_insert_child(
   }
   let { source_map, registry, .. } = ctx
   let placeholder = placeholder_text_for_kind(kind)
-  match registry.get(parent) {
-    None => Err("Parent not found: " + parent.to_string())
-    Some(parent_node) =>
-      match source_map.get_range(parent) {
-        None => Err("Parent not in source map")
-        Some(parent_range) =>
-          match parent_node.kind {
-            @ast.Term::Module(_, _) => {
-              // Insert a def between existing defs, with trailing newline separator
-              let insert_text = "let x = " + placeholder + "\n"
-              let insert_pos = if index >= parent_node.children.length() {
-                // Insert before the body (last child)
-                let body = parent_node.children[parent_node.children.length() -
-                  1]
-                match source_map.get_range(NodeId::from_int(body.node_id)) {
-                  Some(r) => r.start
-                  None => parent_range.end
-                }
-              } else {
-                match
-                  source_map.get_range(
-                    NodeId::from_int(parent_node.children[index].node_id),
-                  ) {
-                  Some(r) => r.start
-                  None => parent_range.start
-                }
-              }
-              Ok(
-                Some(
-                  (
-                    [
-                      {
-                        start: insert_pos,
-                        delete_len: 0,
-                        inserted: insert_text,
-                      },
-                    ],
-                    RestoreCursor,
-                  ),
-                ),
-              )
-            }
-            _ => {
-              // Re-render whole parent with new child inserted
-              let new_child = ProjNode::new(kind, 0, 0, 0, [])
-              let new_parent = insert_child_at(parent_node, index, new_child)
-              let new_text = @ast.print_term(new_parent.kind)
-              Ok(
-                Some(
-                  (
-                    [
-                      {
-                        start: parent_range.start,
-                        delete_len: parent_range.end - parent_range.start,
-                        inserted: new_text,
-                      },
-                    ],
-                    RestoreCursor,
-                  ),
-                ),
-              )
-            }
-          }
+  guard registry.get(parent) is Some(parent_node) else {
+    return Err("Parent not found: " + parent.to_string())
+  }
+  guard source_map.get_range(parent) is Some(parent_range) else {
+    return Err("Parent not in source map")
+  }
+  match parent_node.kind {
+    @ast.Term::Module(_, _) => {
+      // Insert a def between existing defs, with trailing newline separator
+      let insert_text = "let x = " + placeholder + "\n"
+      let insert_pos = if index >= parent_node.children.length() {
+        // Insert before the body (last child)
+        let body = parent_node.children[parent_node.children.length() - 1]
+        match source_map.get_range(NodeId::from_int(body.node_id)) {
+          Some(r) => r.start
+          None => parent_range.end
+        }
+      } else {
+        match
+          source_map.get_range(
+            NodeId::from_int(parent_node.children[index].node_id),
+          ) {
+          Some(r) => r.start
+          None => parent_range.start
+        }
       }
+      Ok(
+        Some(
+          (
+            [{ start: insert_pos, delete_len: 0, inserted: insert_text }],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
+    _ => {
+      // Re-render whole parent with new child inserted
+      let new_child = ProjNode::new(kind, 0, 0, 0, [])
+      let new_parent = insert_child_at(parent_node, index, new_child)
+      let new_text = @ast.print_term(new_parent.kind)
+      Ok(
+        Some(
+          (
+            [
+              {
+                start: parent_range.start,
+                delete_len: parent_range.end - parent_range.start,
+                inserted: new_text,
+              },
+            ],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
   }
 }

--- a/lang/lambda/edits/text_edit_wrap.mbt
+++ b/lang/lambda/edits/text_edit_wrap.mbt
@@ -146,15 +146,12 @@ fn compute_insert_child(
       let insert_pos = if index >= parent_node.children.length() {
         // Insert before the body (last child)
         let body = parent_node.children[parent_node.children.length() - 1]
-        match source_map.get_range(NodeId::from_int(body.node_id)) {
+        match source_map.get_range(body.id()) {
           Some(r) => r.start
           None => parent_range.end
         }
       } else {
-        match
-          source_map.get_range(
-            NodeId::from_int(parent_node.children[index].node_id),
-          ) {
+        match source_map.get_range(parent_node.children[index].id()) {
           Some(r) => r.start
           None => parent_range.start
         }

--- a/lang/lambda/proj/flat_proj.mbt
+++ b/lang/lambda/proj/flat_proj.mbt
@@ -272,12 +272,7 @@ pub fn FlatProj::from_proj_node(root : ProjNode[@ast.Term]) -> FlatProj {
         if i < root.children.length() - 1 {
           let init_child = root.children[i]
           defs.push(
-            (
-              term_defs[i].0,
-              init_child,
-              init_child.start,
-              NodeId::from_int(init_child.node_id),
-            ),
+            (term_defs[i].0, init_child, init_child.start, init_child.id()),
           )
         }
       }

--- a/lang/lambda/proj/populate_token_spans.mbt
+++ b/lang/lambda/proj/populate_token_spans.mbt
@@ -49,14 +49,12 @@ fn collect_token_spans_source_file(
               @syntax.IdentToken.to_raw(),
             )
             // Recurse into the init expression
-            match v.init() {
-              Some(init_syn) =>
-                collect_token_spans_expr(
-                  source_map,
-                  init_syn,
-                  proj_root.children[def_idx],
-                )
-              None => ()
+            if v.init() is Some(init_syn) {
+              collect_token_spans_expr(
+                source_map,
+                init_syn,
+                proj_root.children[def_idx],
+              )
             }
           }
           def_idx = def_idx + 1
@@ -105,12 +103,8 @@ fn collect_token_spans_expr(
       @syntax.IdentToken.to_raw(),
     )
     // Recurse into body
-    match v.body() {
-      Some(body_syn) =>
-        if proj_node.children.length() > 0 {
-          collect_token_spans_expr(source_map, body_syn, proj_node.children[0])
-        }
-      None => ()
+    if v.body() is Some(body_syn) && proj_node.children.length() > 0 {
+      collect_token_spans_expr(source_map, body_syn, proj_node.children[0])
     }
   } else if @parser.AppExprView::cast(syntax_node) is Some(v) {
     // AppExpr is flattened: syntax has [func, arg1, arg2, ...]
@@ -201,32 +195,19 @@ fn collect_token_spans_expr(
       }
     }
   } else if @parser.IfExprView::cast(syntax_node) is Some(v) {
-    match v.condition() {
-      Some(cond) =>
-        if proj_node.children.length() > 0 {
-          collect_token_spans_expr(source_map, cond, proj_node.children[0])
-        }
-      None => ()
+    if v.condition() is Some(cond) && proj_node.children.length() > 0 {
+      collect_token_spans_expr(source_map, cond, proj_node.children[0])
     }
-    match v.then_branch() {
-      Some(then_) =>
-        if proj_node.children.length() > 1 {
-          collect_token_spans_expr(source_map, then_, proj_node.children[1])
-        }
-      None => ()
+    if v.then_branch() is Some(then_) && proj_node.children.length() > 1 {
+      collect_token_spans_expr(source_map, then_, proj_node.children[1])
     }
-    match v.else_branch() {
-      Some(else_) =>
-        if proj_node.children.length() > 2 {
-          collect_token_spans_expr(source_map, else_, proj_node.children[2])
-        }
-      None => ()
+    if v.else_branch() is Some(else_) && proj_node.children.length() > 2 {
+      collect_token_spans_expr(source_map, else_, proj_node.children[2])
     }
   } else if @parser.ParenExprView::cast(syntax_node) is Some(v) {
     // ParenExpr unwraps: ProjNode reuses inner's node_id and children
-    match v.inner() {
-      Some(inner) => collect_token_spans_expr(source_map, inner, proj_node)
-      None => ()
+    if v.inner() is Some(inner) {
+      collect_token_spans_expr(source_map, inner, proj_node)
     }
   }
   // IntLiteral, VarRef: leaf nodes, no token spans to extract

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -5,6 +5,23 @@
 using @core {type ProjNode, type NodeId}
 
 ///|
+/// Construct a childless ProjNode for a lambda leaf term, spanning `node`
+/// and taking a fresh id from `counter`.
+fn lambda_leaf_node(
+  kind : @ast.Term,
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> ProjNode[@ast.Term] {
+  ProjNode::new(
+    kind,
+    node.start(),
+    node.end(),
+    @core.next_proj_node_id(counter),
+    [],
+  )
+}
+
+///|
 fn error_node_with_span(
   message : String,
   start : Int,
@@ -20,7 +37,7 @@ fn error_node_for_syntax(
   node : @seam.SyntaxNode,
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  error_node_with_span(message, node.start(), node.end(), counter)
+  lambda_leaf_node(Error(message), node, counter)
 }
 
 ///|
@@ -64,21 +81,9 @@ pub fn syntax_to_proj_node(
       Some(n) => Int(n)
       None => Error("invalid integer literal")
     }
-    ProjNode::new(
-      kind,
-      node.start(),
-      node.end(),
-      @core.next_proj_node_id(counter),
-      [],
-    )
+    lambda_leaf_node(kind, node, counter)
   } else if @parser.VarRefView::cast(node) is Some(v) {
-    ProjNode::new(
-      Var(v.name()),
-      node.start(),
-      node.end(),
-      @core.next_proj_node_id(counter),
-      [],
-    )
+    lambda_leaf_node(Var(v.name()), node, counter)
   } else if @parser.LambdaExprView::cast(node) is Some(v) {
     let body = match v.body() {
       Some(b) => syntax_to_proj_node(b, counter)
@@ -228,13 +233,7 @@ pub fn syntax_to_proj_node(
       )
     }
   } else if @syntax.SyntaxKind::from_raw(node.kind()) == @syntax.HoleLiteral {
-    ProjNode::new(
-      Hole(0),
-      node.start(),
-      node.end(),
-      @core.next_proj_node_id(counter),
-      [],
-    )
+    lambda_leaf_node(Hole(0), node, counter)
   } else {
     error_node_for_syntax(
       "unknown node kind: " + node.kind().to_string(),

--- a/projection/tree_editor_model.mbt
+++ b/projection/tree_editor_model.mbt
@@ -151,7 +151,7 @@ fn[T : Renderable] from_term_node_impl(
   source_map : SourceMap,
   ui_state : TreeUIState,
 ) -> InteractiveTreeNode[T] {
-  let node_id = NodeId::from_int(node.node_id)
+  let node_id = node.id()
   let text_range = match source_map.get_range(node_id) {
     Some(range) => range
     None => Range::new(node.start, node.end)

--- a/projection/tree_editor_refresh.mbt
+++ b/projection/tree_editor_refresh.mbt
@@ -63,7 +63,7 @@ fn[T : TreeNode + Renderable] can_skip_subtree(
         return false
       }
       for i, child in proj_node.children {
-        if NodeId::from_int(child.node_id) != prev_children[i].id {
+        if child.id() != prev_children[i].id {
           return false
         }
         if !can_skip_subtree(child, prev_children[i], source_map, ui_state) {
@@ -115,7 +115,7 @@ fn[T : TreeNode + Renderable] refresh_node_minimal(
   previous_nodes : Map[NodeId, InteractiveTreeNode[T]],
   new_loaded_nodes : Map[NodeId, InteractiveTreeNode[T]],
 ) -> RefreshedInteractiveNode[T] {
-  let node_id = NodeId::from_int(node.node_id)
+  let node_id = node.id()
   let text_range = match source_map.get_range(node_id) {
     Some(range) => range
     None => Range::new(node.start, node.end)


### PR DESCRIPTION
Behavior-preserving idiom sweep of `lang/lambda` (the direct parallel of the `lang/json` pass in #382), plus a repo-wide cleanup that routes through the existing `ProjNode::id()`. No public API change (empty `.mbti` diff in all touched packages).

## lang/lambda idiom sweep
**`proj/proj_node.mbt`** — extracted private `lambda_leaf_node` helper, collapsing the Int/Var/Hole leaf constructions + `error_node_for_syntax` (mirrors json's `json_leaf_node`).
**`proj/populate_token_spans.mbt`** — six `match { Some(x) => stmt; None => () }` filter blocks → `if … is Some(x)`.
**`edits/` (10 files)** — the headline guard conversions: `let x = match expr { Some(v) => v; None => return Err(…) }` → `guard expr is Some(v) else { … }`; tuple matches → sequential guards (same error message; the lookups are side-effect-free so short-circuiting is observationally identical); range-collection filter loops → `if … is Some(r)`. `Err(e) => return Err(e)` Result passthroughs are left as-is (guard can't bind the error in `else`).

## Finding A — use the existing `ProjNode::id()` (11 sites, repo-wide)
`core/proj_node.mbt:42` already defines `ProjNode::id(self) -> NodeId { NodeId(self.node_id) }`, but 11 sites reached past it with raw `NodeId::from_int(x.node_id)`. Byte-identical; pure call-site idiom. Sites: lang/lambda (6), `core/source_map.mbt` (2), `projection/{tree_editor_refresh,tree_editor_model}` (3).

## Recorded for later (docs/TODO.md §7)
Findings surfaced by the sweep, deferred as tracked TODO items:
- **B** — hoist the `next_proj_node_id(counter)` boilerplate into a shared `@core` `ProjNode::leaf`/branch ctor (deletes both per-language leaf helpers; `@core` already depends on `@seam`).
- **C** — `EditContext::resolve(node_id) -> (node, range)` to collapse the duplicated handler prologue.
- **D** — evaluate a `raise EditError` model so the `Ok/Err` passthroughs auto-propagate.
- **E** — loom: complete typed Views for all dispatched syntax kinds + a "zip syntax/projection children" walk helper.

## Reuse check
Per the Existing API First Rule: searched for an existing childless-ProjNode-from-syntax-node builder (`moon ide doc "*leaf*"`) — found only `projection.is_leaf_node` (unrelated predicate) and `ProjNode::new`, so the new private `lambda_leaf_node` is justified (private → stays out of `.mbti`). Finding A is the inverse: an existing helper (`ProjNode::id`) that was being bypassed.

## Verification
- `moon check` clean; `moon fmt` / `moon info` clean
- core + projection + lang/lambda: **308/308** tests pass; full workspace previously **1217/1217**
- `.mbti` diff **empty** in every touched package (the only working-tree `.mbti` change, `lib/cognition/`, is pre-existing and not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)