### PR TITLE
refactor(editor): package-wide idiom sweep — match→guard/if + loop idioms

### DIFF
--- a/editor/cursor_view.mbt
+++ b/editor/cursor_view.mbt
@@ -74,15 +74,13 @@ pub fn PeerCursorView::adjust_for_edit(
       old_len,
       new_len,
     )
-    match cursor.selection {
-      Some((sel_start, sel_end)) =>
-        cursor.selection = Some(
-          (
-            adjust_position(sel_start, edit_start, old_len, new_len),
-            adjust_position(sel_end, edit_start, old_len, new_len),
-          ),
-        )
-      None => ()
+    if cursor.selection is Some((sel_start, sel_end)) {
+      cursor.selection = Some(
+        (
+          adjust_position(sel_start, edit_start, old_len, new_len),
+          adjust_position(sel_end, edit_start, old_len, new_len),
+        ),
+      )
     }
   }
 }
@@ -131,12 +129,9 @@ pub fn PeerCursorView::apply_raw_update(
           }
         _ => None
       }
-      match self.wire_keys.get(peer_id) {
-        Some(old_peer_id) =>
-          if old_peer_id != logical_peer_id {
-            self.cursors.remove(old_peer_id)
-          }
-        None => ()
+      if self.wire_keys.get(peer_id) is Some(old_peer_id) &&
+        old_peer_id != logical_peer_id {
+        self.cursors.remove(old_peer_id)
       }
       self.wire_keys[peer_id] = logical_peer_id
       self.set_cursor(logical_peer_id, cursor, name, color, selection~)

--- a/editor/editor.mbt
+++ b/editor/editor.mbt
@@ -48,7 +48,7 @@ pub fn Editor::move_cursor(self : Editor, position : Int) -> Unit {
 /// After insertion, cursor moves to after the inserted text
 pub fn Editor::insert(self : Editor, text : String) -> Unit raise {
   self.doc.insert(@text.Pos::at(self.cursor), text)
-  self.cursor = self.cursor + text.length()
+  self.cursor += text.length()
 }
 
 ///| Insert text at a specific position
@@ -88,15 +88,15 @@ pub fn Editor::delete(self : Editor) -> Bool {
 /// Returns true if successful, false if at start
 pub fn Editor::backspace(self : Editor) -> Bool {
   if self.cursor > 0 {
-    self.cursor = self.cursor - 1
+    self.cursor -= 1
     try self.doc.delete(@text.Pos::at(self.cursor)) catch {
       @text.TextError::InvalidPosition(..) => {
         // Restore cursor if delete failed
-        self.cursor = self.cursor + 1
+        self.cursor += 1
         false
       }
       _ => {
-        self.cursor = self.cursor + 1
+        self.cursor += 1
         false
       }
     } noraise {

--- a/editor/ephemeral.mbt
+++ b/editor/ephemeral.mbt
@@ -123,9 +123,8 @@ pub fn EphemeralStore::get_all_states(
 ) -> Map[String, EphemeralValue] {
   let out : Map[String, EphemeralValue] = {}
   for key, record in self.states {
-    match record.value {
-      Some(value) => out[key] = value
-      None => ()
+    if record.value is Some(value) {
+      out[key] = value
     }
   }
   out
@@ -135,9 +134,8 @@ pub fn EphemeralStore::get_all_states(
 pub fn EphemeralStore::keys(self : EphemeralStore) -> Array[String] {
   let out : Array[String] = []
   for key, record in self.states {
-    match record.value {
-      Some(_) => out.push(key)
-      None => ()
+    if record.value is Some(_) {
+      out.push(key)
     }
   }
   out
@@ -199,9 +197,8 @@ fn EphemeralStore::set_state(
       }
     (None, Some(_)) => added.push(key)
     (Some(old_record), None) =>
-      match old_record.value {
-        Some(_) => removed.push(key)
-        None => ()
+      if old_record.value is Some(_) {
+        removed.push(key)
       }
     (None, None) => ()
   }
@@ -347,9 +344,8 @@ pub fn EphemeralStore::apply(
           updated_at: now,
         }
         self.states[key] = incoming
-        match record.value {
-          Some(_) => added.push(key)
-          None => ()
+        if record.value is Some(_) {
+          added.push(key)
         }
       }
     }
@@ -379,9 +375,8 @@ fn EphemeralStore::remove_outdated_at(
   let next : Map[String, EphemeralRecord] = {}
   for key, record in self.states {
     if is_expired(record.updated_at, now, self.timeout_ms) {
-      match record.value {
-        Some(_) => removed.push(key)
-        None => ()
+      if record.value is Some(_) {
+        removed.push(key)
       }
     } else {
       next[key] = record

--- a/editor/ephemeral_encoding.mbt
+++ b/editor/ephemeral_encoding.mbt
@@ -43,7 +43,7 @@ fn write_uvarint(buf : Buffer, value : UInt64) -> Unit {
 fn read_uvarint(reader : Reader) -> UInt64 raise EphemeralError {
   let mut result : UInt64 = 0UL
   let mut shift = 0
-  for i = 0; i < 10; i = i + 1 {
+  for _ in 0..<10 {
     let b = reader.read_byte()
     result = result | ((b.to_int() & 0x7F).to_uint64() << shift)
     if (b.to_int() & 0x80) == 0 {
@@ -201,14 +201,14 @@ fn read_ephemeral_value(reader : Reader) -> EphemeralValue raise EphemeralError 
   } else if tag == tag_list {
     let count = safe_uvarint_to_int(read_uvarint(reader))
     let items : Array[EphemeralValue] = []
-    for i = 0; i < count; i = i + 1 {
+    for _ in 0..<count {
       items.push(read_ephemeral_value(reader))
     }
     EphemeralValue::List(items)
   } else if tag == tag_map {
     let count = safe_uvarint_to_int(read_uvarint(reader))
     let map : Map[String, EphemeralValue] = {}
-    for i = 0; i < count; i = i + 1 {
+    for _ in 0..<count {
       let key = read_string(reader)
       let item = read_ephemeral_value(reader)
       map[key] = item
@@ -222,7 +222,7 @@ fn read_ephemeral_value(reader : Reader) -> EphemeralValue raise EphemeralError 
 ///|
 fn write_f64_le(buf : Buffer, value : Double) -> Unit {
   let bits = value.reinterpret_as_uint64()
-  for i = 0; i < 8; i = i + 1 {
+  for i in 0..<8 {
     buf.write_byte(((bits >> (i * 8)) & 0xFFUL).to_byte())
   }
 }
@@ -231,7 +231,7 @@ fn write_f64_le(buf : Buffer, value : Double) -> Unit {
 fn read_f64_le(reader : Reader) -> Double raise EphemeralError {
   let bytes = reader.read_bytes(8)
   let mut bits : UInt64 = 0UL
-  for i = 0; i < 8; i = i + 1 {
+  for i in 0..<8 {
     bits = bits | (bytes[i].to_uint64() << (i * 8))
   }
   bits.reinterpret_as_double()
@@ -283,8 +283,8 @@ fn stable_peer_hash(key : String) -> UInt64 {
   buf.write_string_utf16le(key.view())
   let bytes = buf.to_bytes()
   let mut hash = 14695981039346656037UL
-  for i = 0; i < bytes.length(); i = i + 1 {
-    hash = hash ^ bytes[i].to_uint64()
+  for b in bytes {
+    hash = hash ^ b.to_uint64()
     hash = hash * 1099511628211UL
   }
   hash
@@ -326,7 +326,7 @@ fn decode_entries(
   let reader = Reader::new(data)
   let count = safe_uvarint_to_int(read_uvarint(reader))
   let out : Array[(String, EphemeralRecord)] = []
-  for i = 0; i < count; i = i + 1 {
+  for _ in 0..<count {
     let peer = read_uvarint(reader)
     let clock = read_ivarint(reader)
     let value = read_ephemeral_value(reader)

--- a/editor/ephemeral_hub.mbt
+++ b/editor/ephemeral_hub.mbt
@@ -122,14 +122,11 @@ pub fn EphemeralHub::apply_all(self : EphemeralHub, data : Bytes) -> Unit {
   }
   let reader = Reader::new(data)
   let count = safe_uvarint_to_int(read_uvarint(reader)) catch { _ => return }
-  for _i = 0; _i < count; _i = _i + 1 {
+  for _ in 0..<count {
     let ns_byte = reader.read_byte() catch { _ => break }
     let ns_data = read_len_bytes(reader) catch { _ => break }
     // Unknown namespace: skip entry data (reader already advanced past it)
-    let ns = match namespace_from_byte(ns_byte) {
-      Some(ns) => ns
-      None => continue
-    }
+    guard namespace_from_byte(ns_byte) is Some(ns) else { continue }
     self.apply(ns, ns_data)
   }
 }

--- a/editor/ephemeral_hub_readers.mbt
+++ b/editor/ephemeral_hub_readers.mbt
@@ -8,10 +8,10 @@ pub fn EphemeralHub::get_cursor(
   let wire_id = to_wire_peer_id(peer_id)
   match self.stores[Cursor].get(wire_id) {
     Some(EphemeralValue::Map(map)) => {
-      let position = match map.get("position") {
-        Some(EphemeralValue::I64(n)) => n.to_int()
-        _ => return None
+      guard map.get("position") is Some(EphemeralValue::I64(n)) else {
+        return None
       }
+      let position = n.to_int()
       let selection = match map.get("selection") {
         Some(EphemeralValue::List(arr)) =>
           if arr.length() == 2 {
@@ -52,9 +52,8 @@ pub fn EphemeralHub::get_all_editing(
 ) -> Map[String, EditModeState] {
   let result : Map[String, EditModeState] = {}
   for key, value in self.stores[EditMode].get_all_states() {
-    match EditModeState::from_ephemeral(value) {
-      Some(state) => result[key] = state
-      None => ()
+    if EditModeState::from_ephemeral(value) is Some(state) {
+      result[key] = state
     }
   }
   result
@@ -78,9 +77,8 @@ pub fn EphemeralHub::get_online_peers(
 ) -> Array[PeerPresence] {
   let result : Array[PeerPresence] = []
   for _key, value in self.stores[Presence].get_all_states() {
-    match PeerPresence::from_ephemeral(value) {
-      Some(presence) => result.push(presence)
-      None => ()
+    if PeerPresence::from_ephemeral(value) is Some(presence) {
+      result.push(presence)
     }
   }
   result

--- a/editor/ephemeral_hub_state.mbt
+++ b/editor/ephemeral_hub_state.mbt
@@ -8,13 +8,11 @@ pub fn EphemeralHub::set_cursor(
 ) -> Unit {
   let map : Map[String, EphemeralValue] = {}
   map["position"] = EphemeralValue::I64(position.to_int64())
-  match selection {
-    Some((start, end)) =>
-      map["selection"] = EphemeralValue::List([
-        EphemeralValue::I64(start.to_int64()),
-        EphemeralValue::I64(end.to_int64()),
-      ])
-    None => ()
+  if selection is Some((start, end)) {
+    map["selection"] = EphemeralValue::List([
+      EphemeralValue::I64(start.to_int64()),
+      EphemeralValue::I64(end.to_int64()),
+    ])
   }
   self.stores[Cursor].set(self.wire_peer_id, EphemeralValue::Map(map)) catch {
     _ => ()

--- a/editor/in_memory_transport.mbt
+++ b/editor/in_memory_transport.mbt
@@ -58,9 +58,8 @@ pub impl SyncTransport for InMemoryTransport with fn send(self, data) {
 
 ///|
 pub impl SyncTransport for InMemoryTransport with fn on_receive(self, handler) {
-  match self.room.peers.get(self.peer_id) {
-    Some(handlers) => handlers.push(handler)
-    None => ()
+  if self.room.peers.get(self.peer_id) is Some(handlers) {
+    handlers.push(handler)
   }
 }
 

--- a/editor/presence_types.mbt
+++ b/editor/presence_types.mbt
@@ -92,14 +92,9 @@ fn drag_position_from_string(s : String) -> DragPosition? {
 pub fn DragState::to_ephemeral(self : DragState) -> EphemeralValue {
   let map : Map[String, EphemeralValue] = {}
   map["source_id"] = EphemeralValue::String(self.source_id)
-  match self.target {
-    Some((target_id, position)) => {
-      map["target_id"] = EphemeralValue::String(target_id)
-      map["position"] = EphemeralValue::String(
-        drag_position_to_string(position),
-      )
-    }
-    None => ()
+  if self.target is Some((target_id, position)) {
+    map["target_id"] = EphemeralValue::String(target_id)
+    map["position"] = EphemeralValue::String(drag_position_to_string(position))
   }
   EphemeralValue::Map(map)
 }

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -93,18 +93,16 @@ fn setup_hub_and_cursor(agent_id : String) -> (EphemeralHub, PeerCursorView) {
         if key == wire_peer_id {
           continue
         }
-        match cursor_store.get(key) {
-          Some(value) => cursor_view.apply_raw_update(key, value)
-          None => ()
+        if cursor_store.get(key) is Some(value) {
+          cursor_view.apply_raw_update(key, value)
         }
       }
       for key in event.updated() {
         if key == wire_peer_id {
           continue
         }
-        match cursor_store.get(key) {
-          Some(value) => cursor_view.apply_raw_update(key, value)
-          None => ()
+        if cursor_store.get(key) is Some(value) {
+          cursor_view.apply_raw_update(key, value)
         }
       }
       for key in event.removed() {
@@ -140,13 +138,11 @@ pub fn[T] SyncEditor::set_local_presence(
   map["cursor"] = EphemeralValue::I64(cursor_pos.to_int64())
   map["name"] = EphemeralValue::String(name)
   map["color"] = EphemeralValue::String(color)
-  match selection {
-    Some((start, end)) =>
-      map["selection"] = EphemeralValue::List([
-        EphemeralValue::I64(start.to_int64()),
-        EphemeralValue::I64(end.to_int64()),
-      ])
-    None => ()
+  if selection is Some((start, end)) {
+    map["selection"] = EphemeralValue::List([
+      EphemeralValue::I64(start.to_int64()),
+      EphemeralValue::I64(end.to_int64()),
+    ])
   }
   self.hub
   .get_store(Cursor)
@@ -201,9 +197,8 @@ pub fn[T] SyncEditor::get_hub(self : SyncEditor[T]) -> EphemeralHub {
 
 ///|
 pub fn[T] SyncEditor::ws_send(self : SyncEditor[T], data : Bytes) -> Unit {
-  match self.ws {
-    Some(ws) => ws.send_bytes(data)
-    None => ()
+  if self.ws is Some(ws) {
+    ws.send_bytes(data)
   }
 }
 
@@ -280,9 +275,8 @@ fn[T] SyncEditor::set_status(
     return
   }
   self.status = new_status
-  match self.on_status_change {
-    Some(cb) => cb(new_status)
-    None => ()
+  if self.on_status_change is Some(cb) {
+    cb(new_status)
   }
 }
 
@@ -444,9 +438,8 @@ pub fn[T : Eq] SyncEditor::apply_sync(
   self.sync_parser_after_text_change(old_source, new_source, None)
   // Clear a prior Error status once any sync applies — another peer
   // (via RelayedCrdtOps) having filled the causal gap counts as recovery.
-  match self.status {
-    Error(_) => self.set_status(Idle)
-    _ => ()
+  if self.status is Error(_) {
+    self.set_status(Idle)
   }
 }
 
@@ -479,9 +472,8 @@ pub fn[T] SyncEditor::export_since(
 pub fn[T : @pretty.Pretty] SyncEditor::get_pretty_view(
   self : SyncEditor[T],
 ) -> @protocol.ViewNode {
-  let tree = match self.get_tree() {
-    Some(t) => t
-    None => return @protocol.layout_to_view_tree(@pretty.text(""), width=80)
+  guard self.get_tree() is Some(tree) else {
+    return @protocol.layout_to_view_tree(@pretty.text(""), width=80)
   }
   let layout = @pretty.Pretty::to_layout(tree)
   let final_layout = match self.capabilities.pretty_post_process {

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -27,7 +27,7 @@ fn utf16_offset_to_item_pos(text : String, offset : Int) -> Int {
     if next_utf16_pos > target {
       return item_pos
     }
-    item_pos = item_pos + 1
+    item_pos += 1
     if next_utf16_pos == target {
       return item_pos
     }

--- a/editor/sync_editor_ws.mbt
+++ b/editor/sync_editor_ws.mbt
@@ -78,19 +78,13 @@ pub fn[T : Eq] SyncEditor::ws_on_message(
   self : SyncEditor[T],
   data : Bytes,
 ) -> Unit {
-  let msg = match decode_message_result(data) {
-    Ok(m) => m
-    Err(_) => return
-  }
+  guard decode_message_result(data) is Ok(msg) else { return }
   match msg {
     CrdtOps(payload) => {
       // CrdtOps is used for backwards-compatible full-state exchange (PeerJoined).
       // Recovery is not possible here because there is no sender ID.
       // Once all peers use RelayedCrdtOps, this path only handles PeerJoined sync.
-      let crdt_msg = match parse_sync_message_json(payload) {
-        Ok(crdt_msg) => crdt_msg
-        Err(_) => return
-      }
+      guard parse_sync_message_json(payload) is Ok(crdt_msg) else { return }
       self.apply_sync(crdt_msg) catch {
         _ => ()
       }
@@ -114,21 +108,16 @@ pub fn[T : Eq] SyncEditor::ws_on_message(
     PeerLeft(peer_id) => {
       self.hub.on_peer_leave(peer_id)
       // Abort recovery if the leaving peer is the one we're recovering from
-      match self.recovery {
-        Some(ctx) =>
-          if ctx.peer_id == peer_id {
-            let target = ctx.peer_id
-            self.recovery = None
-            self.set_status(Error(reason=TargetLeft(peer_id=target)))
-          }
-        None => ()
+      if self.recovery is Some(ctx) && ctx.peer_id == peer_id {
+        let target = ctx.peer_id
+        self.recovery = None
+        self.set_status(Error(reason=TargetLeft(peer_id=target)))
       }
     }
     SyncRequest(payload) => {
-      let (sender, request_id, version_json) = match
-        parse_sync_request_payload(payload) {
-        Ok(parts) => parts
-        Err(_) => return
+      guard parse_sync_request_payload(payload)
+        is Ok((sender, request_id, version_json)) else {
+        return
       }
       // Parse requester's version and export delta
       let peer_version = @text.Version::from_json_string(version_json) catch {
@@ -153,14 +142,12 @@ pub fn[T : Eq] SyncEditor::ws_on_message(
       self.ws_send(wire)
     }
     SyncResponse(payload) => {
-      let (_sender, request_id, sync_json) = match
-        parse_sync_response_payload(payload) {
-        Ok(parts) => parts
-        Err(_) => return
+      guard parse_sync_response_payload(payload)
+        is Ok((_sender, request_id, sync_json)) else {
+        return
       }
-      let ctx = match self.recovery {
-        Some(ctx) => ctx
-        None => return // Not recovering, ignore
+      guard self.recovery is Some(ctx) else { // Not recovering, ignore
+        return
       }
       // Stale response check
       if !ctx.matches_request_id(request_id) {
@@ -209,7 +196,7 @@ pub fn[T : Eq] SyncEditor::ws_on_message(
                 self.recovery_epoch,
               )
               // Buffer remaining deferred messages
-              for j = i + 1; j < deferred.length(); j = j + 1 {
+              for j in (i + 1)..<deferred.length() {
                 new_ctx.buffer_message(deferred[j])
               }
               self.recovery = Some(new_ctx)
@@ -233,18 +220,11 @@ pub fn[T : Eq] SyncEditor::ws_on_message(
       }
     }
     RelayedCrdtOps(sender~, payload~) => {
-      let crdt_msg = match parse_sync_message_json(payload) {
-        Ok(crdt_msg) => crdt_msg
-        Err(_) => return
-      }
+      guard parse_sync_message_json(payload) is Ok(crdt_msg) else { return }
       // If recovering from this sender, buffer instead of applying
-      match self.recovery {
-        Some(ctx) =>
-          if ctx.peer_id == sender {
-            ctx.buffer_message(crdt_msg)
-            return
-          }
-        None => ()
+      if self.recovery is Some(ctx) && ctx.peer_id == sender {
+        ctx.buffer_message(crdt_msg)
+        return
       }
       self.apply_sync(crdt_msg) catch {
         err =>
@@ -265,10 +245,7 @@ pub fn[T] SyncEditor::ws_on_close(self : SyncEditor[T]) -> Unit {
 
 ///|
 pub fn[T] SyncEditor::ws_broadcast_edit(self : SyncEditor[T]) -> Unit {
-  match self.ws {
-    None => return
-    Some(_) => ()
-  }
+  guard self.ws is Some(_) else { return }
   let crdt_msg = self.export_all() catch { _ => return }
   let json_str = crdt_msg.to_json_string()
   let buf = Buffer()
@@ -278,10 +255,7 @@ pub fn[T] SyncEditor::ws_broadcast_edit(self : SyncEditor[T]) -> Unit {
 
 ///|
 pub fn[T] SyncEditor::ws_broadcast_cursor(self : SyncEditor[T]) -> Unit {
-  match self.ws {
-    None => return
-    Some(_) => ()
-  }
+  guard self.ws is Some(_) else { return }
   let cursor_data = self.hub.encode(Cursor)
   if cursor_data.length() > 0 {
     self.ws_send(encode_message(EphemeralUpdate(Cursor, cursor_data)))
@@ -336,9 +310,8 @@ fn[T] SyncEditor::send_sync_request(
   self.ws_send(wire)
   // Arm the watchdog for this request; timeout is read fresh so
   // set_watchdog_timeout takes effect on subsequent sends.
-  match self.watchdog_scheduler {
-    Some(scheduler) => scheduler(request_id, self.watchdog_timeout_ms)
-    None => ()
+  if self.watchdog_scheduler is Some(scheduler) {
+    scheduler(request_id, self.watchdog_timeout_ms)
   }
 }
 
@@ -347,10 +320,7 @@ fn[T] SyncEditor::send_sync_request(
 /// Check exhaustion BEFORE advancing so retries=0,1,2 each send a request
 /// and retries=3 gives up (3 retries total).
 fn[T] SyncEditor::handle_recovery_retry(self : SyncEditor[T]) -> Unit {
-  let ctx = match self.recovery {
-    Some(ctx) => ctx
-    None => return
-  }
+  guard self.recovery is Some(ctx) else { return }
   if ctx.is_exhausted() {
     // Give up — clear recovery and surface the error
     let peer_id = ctx.peer_id

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -146,11 +146,11 @@ fn diff_view_nodes(
   let prev_len = prev.children.length()
   let curr_len = curr.children.length()
   let min_len = if prev_len < curr_len { prev_len } else { curr_len }
-  for i = 0; i < min_len; i = i + 1 {
+  for i in 0..<min_len {
     diff_view_nodes(prev.children[i], curr.children[i], patches)
   }
   if curr_len > prev_len {
-    for i = prev_len; i < curr_len; i = i + 1 {
+    for i in prev_len..<curr_len {
       patches.push(
         @protocol.ViewPatch::InsertChild(
           parent_id=curr.id,


### PR DESCRIPTION
Behavior-preserving idiom sweep of the **entire `editor/` package**, continuing the series: core/projection (#381) → lang/json (#382) → lang/lambda (#383) → editor.

## Changes (13 source files)

**`match` → `guard`/`if`:**
- Filter blocks `match X { Some(v) => stmt; None => () }` / `{ Variant => …; _ => () }` → `if X is Some(v) { stmt }` (sync_editor, cursor_view, ephemeral, ephemeral_hub_readers, ephemeral_hub_state, in_memory_transport, presence_types, sync_editor_ws).
- Bind-or-bail `match X { Some(v) => v; None/Err(_) => return/continue }` → `guard X is Some(v) else { … }` (get_pretty_view, ephemeral_hub_readers, ephemeral_hub, sync_editor_ws message/payload parsing + recovery lookups).
- Two `match self.recovery { Some(ctx) => if cond {…}; None => () }` folded to `if self.recovery is Some(ctx) && cond { … }`.

**Loop idioms:**
- C-style `for i = 0; i < N; i = i + 1` simple counters → `for _/i in 0..<N` (ephemeral_encoding, ephemeral_hub, view_updater forward loops); `stable_peer_hash` byte loop → `for b in bytes`.
- Compound assignment in `editor.mbt` cursor moves and `sync_editor_text` `item_pos`.

## Deliberately left as-is (not idiom-shaped)
- `catch { _ => () }` error-swallow arms
- `Result` `Ok/Err` re-propagation matches with a bound `err`
- Genuine multi-arm / value-producing matches (`cursor_pos`, `final_layout`, `should_retry_sync_error`, `focus_hint`, etc.)
- The varint `while` loop (mutates accumulator)
- `text_diff.mbt` order-sensitive LCS/backtracking loops, and descending index loops

## Reuse check
No new functions, types, or helpers — purely in-place control-flow idiom conversions. Public surface unchanged.

## Verification
- `moon check` clean
- editor **370/370** tests pass
- `editor/pkg.generated.mbti` diff **empty** (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)