### PR TITLE
refactor(ephemeral): make to_wire_peer_id private again

### DIFF
--- a/editor/sync_editor_ws_wbtest.mbt
+++ b/editor/sync_editor_ws_wbtest.mbt
@@ -21,18 +21,18 @@ test "ws_send: does nothing when disconnected" {
 ///|
 test "ws_on_message: PeerLeft removes peer from hub" {
   let editor = @lambda.new_lambda_editor("alice").0
-  // Set some presence for "bob" in the hub
-  let bob_wire = @ephemeral.to_wire_peer_id("bob")
-  editor.hub.get_store(Cursor).set(bob_wire, EphemeralValue::I64(42L)) catch {
-    _ => ()
-  }
-  // Verify bob is present
-  inspect(editor.hub.get_store(Cursor).get(bob_wire) is None, content="false")
+  // Inject remote cursor presence for "bob" the way it arrives over the wire:
+  // encode it from bob's own hub and apply to alice's editor hub.
+  let bob_hub = EphemeralHub::new("bob")
+  bob_hub.set_cursor(42)
+  editor.hub.apply(Cursor, bob_hub.encode(Cursor))
+  // Verify bob is present (peer-id-keyed query — no wire-key math needed)
+  inspect(editor.hub.get_cursor("bob") is None, content="false")
   // Simulate PeerLeft message
   let wire = encode_message(PeerLeft("bob"))
   editor.ws_on_message(wire)
   // Bob should be removed
-  inspect(editor.hub.get_store(Cursor).get(bob_wire) is None, content="true")
+  inspect(editor.hub.get_cursor("bob") is None, content="true")
 }
 
 ///|

--- a/ephemeral/ephemeral_encoding.mbt
+++ b/ephemeral/ephemeral_encoding.mbt
@@ -273,7 +273,7 @@ fn wire_peer_id(key : String) -> UInt64 {
 ///|
 /// Presence wire format still encodes peer IDs as uvarints. Preserve existing
 /// numeric IDs and map arbitrary agent IDs into a reserved high-bit range.
-pub fn to_wire_peer_id(key : String) -> String {
+fn to_wire_peer_id(key : String) -> String {
   wire_peer_id(key).to_string()
 }
 

--- a/ephemeral/pkg.generated.mbti
+++ b/ephemeral/pkg.generated.mbti
@@ -17,8 +17,6 @@ pub fn namespace_to_byte(EphemeralNamespace) -> Byte
 
 pub fn read_string(Reader) -> String raise EphemeralError
 
-pub fn to_wire_peer_id(String) -> String
-
 pub fn write_string(@buffer.Buffer, String) -> Unit
 
 // Errors


### PR DESCRIPTION
## What

Follow-up to #387. The ephemeral extraction exposed `to_wire_peer_id` as `pub` only to satisfy one native-gated editor test (`sync_editor_ws_wbtest.mbt`), which used it to compute bob's wire key and seed the `Cursor` store directly.

This rewrites that test to inject bob's presence through the **realistic remote path** — encode from a second hub and `apply` it — and asserts via the peer-id-keyed `get_cursor("bob")` query (which converts the peer-id internally). No wire-key math needed.

With the last external caller gone, `to_wire_peer_id` returns to **private**, shrinking ephemeral's public surface by one wire-encoding internal.

## Why this is better

- The test now exercises the actual remote-presence flow (`set_cursor` → `encode` → `apply`) instead of reaching into the store with a hand-computed wire key.
- ephemeral no longer publicly leaks `to_wire_peer_id` (it was only ever a test-convenience export).

## Reuse check

No new API. Uses existing public hub methods (`EphemeralHub::new`, `set_cursor`, `encode`, `apply`, `get_cursor`). Removes one `pub`.

## Verification

- `NEW_MOON_MOD=0 moon test` (js): **1217/1217**.
- `editor/pkg.generated.mbti` unchanged; `ephemeral/pkg.generated.mbti` drops the `to_wire_peer_id` line.
- Rewritten test compiles on native (`moon check --target native`); it does not *run* on native because of a **pre-existing** `now_ms_ffi` link failure (the `native_stub.c` is not declared via `native-stub` — present on `2d2e8c9` before #387, part of the known-broken native target). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)