### PR TITLE
refactor(relay): migrate wire codec onto shared lib/byte-codec (Option B)

### DIFF
--- a/relay/moon.pkg
+++ b/relay/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/buffer",
+  "dowdiness/byte_codec",
 }
 
 options(

--- a/relay/relay_room_wbtest.mbt
+++ b/relay/relay_room_wbtest.mbt
@@ -186,26 +186,28 @@ test "on_message: SyncRequest routes to target peer" {
   msgs_a.clear()
   msgs_b.clear()
   msgs_c.clear()
-  // Build SyncRequest targeting "bob": [0x02][0x03][0x00][uvarint len]["bob" bytes][payload]
+  // Build SyncRequest targeting "bob": [0x02][0x03][0x00][write_string("bob")][payload]
   let buf = Buffer()
   buf.write_byte(b'\x02')
   buf.write_byte(b'\x03')
   buf.write_byte(b'\x00')
-  let tmp = Buffer()
-  tmp.write_string_utf16le("bob".view())
-  let target_bytes = tmp.to_bytes()
-  write_relay_uvarint(buf, target_bytes.length())
-  buf.write_bytes(target_bytes)
+  write_string(buf, "bob")
   buf.write_byte(b'\xAA') // payload
   room.on_message("alice", buf.to_bytes())
   // Only bob should receive it, not alice or charlie
   inspect(msgs_a.length(), content="0")
   inspect(msgs_b.length(), content="1")
   inspect(msgs_c.length(), content="0")
-  // The forwarded message should have sender="alice" replacing target="bob"
+  // Full forwarded frame: target "bob" is replaced by sender "alice" and the
+  // 0xAA payload after the target survives. Pinning the whole frame exercises
+  // read_relay_string's `after_target` offset end-to-end — an off-by-one there
+  // would keep/drop the target or payload and is caught here.
+  // [0x02][0x03][0x00][write_string("alice")][0xAA]
   let received = msgs_b[0]
-  inspect(received[0] == b'\x02', content="true") // version
-  inspect(received[1] == b'\x03', content="true") // type preserved
+  inspect(
+    received == b"\x02\x03\x00\x0a\x61\x00\x6c\x00\x69\x00\x63\x00\x65\x00\xaa",
+    content="true",
+  )
 }
 
 ///|
@@ -217,24 +219,24 @@ test "on_message: SyncResponse routes to target peer" {
   connect_ok(room, "bob", send_b)
   msgs_a.clear()
   msgs_b.clear()
-  // Build SyncResponse targeting "alice": [0x02][0x04][0x00][uvarint len]["alice" bytes][payload]
+  // Build SyncResponse targeting "alice": [0x02][0x04][0x00][write_string("alice")][payload]
   let buf = Buffer()
   buf.write_byte(b'\x02')
   buf.write_byte(b'\x04')
   buf.write_byte(b'\x00')
-  let tmp = Buffer()
-  tmp.write_string_utf16le("alice".view())
-  let target_bytes = tmp.to_bytes()
-  write_relay_uvarint(buf, target_bytes.length())
-  buf.write_bytes(target_bytes)
+  write_string(buf, "alice")
   buf.write_byte(b'\xBB') // payload
   room.on_message("bob", buf.to_bytes())
   // Only alice should receive it
   inspect(msgs_a.length(), content="1")
   inspect(msgs_b.length(), content="0")
+  // Full forwarded frame: target "alice" replaced by sender "bob", 0xBB payload
+  // preserved. [0x02][0x04][0x00][write_string("bob")][0xBB]
   let received = msgs_a[0]
-  inspect(received[0] == b'\x02', content="true") // version
-  inspect(received[1] == b'\x04', content="true") // type preserved
+  inspect(
+    received == b"\x02\x04\x00\x06\x62\x00\x6f\x00\x62\x00\xbb",
+    content="true",
+  )
 }
 
 ///|
@@ -251,11 +253,7 @@ test "on_message: SyncRequest to unknown target is dropped" {
   buf.write_byte(b'\x02')
   buf.write_byte(b'\x03')
   buf.write_byte(b'\x00')
-  let tmp = Buffer()
-  tmp.write_string_utf16le("nobody".view())
-  let target_bytes = tmp.to_bytes()
-  write_relay_uvarint(buf, target_bytes.length())
-  buf.write_bytes(target_bytes)
+  write_string(buf, "nobody")
   room.on_message("alice", buf.to_bytes())
   // Nobody should receive anything
   inspect(msgs_a.length(), content="0")

--- a/relay/wire.mbt
+++ b/relay/wire.mbt
@@ -19,15 +19,10 @@ let sub_join : Byte = b'\x01'
 let sub_leave : Byte = b'\x02'
 
 ///|
-/// Encode an unsigned variable-length integer into the buffer.
-fn write_relay_uvarint(buf : Buffer, value : Int) -> Unit {
-  let mut v = value
-  while v >= 0x80 {
-    buf.write_byte(((v & 0x7F) | 0x80).to_byte())
-    v = v >> 7
-  }
-  buf.write_byte(v.to_byte())
-}
+/// LEB128 varints + length-prefixed UTF-16LE strings come from the shared
+/// `lib/byte-codec` package. relay keeps only its own framing here; the
+/// generic codec lives in one place (see docs/plans/2026-05-29-byte-codec-package-design.md).
+using @byte_codec {type Reader, read_string, write_string}
 
 ///|
 /// Encode a peer control message with the given sub-type and peer ID.
@@ -40,48 +35,24 @@ fn encode_peer_control(sub_type : Byte, peer_id : String) -> Bytes {
   buf.write_byte(msg_room_control)
   buf.write_byte(flags_none)
   buf.write_byte(sub_type)
-  let tmp = Buffer()
-  tmp.write_string_utf16le(peer_id.view())
-  let peer_bytes = tmp.to_bytes()
-  write_relay_uvarint(buf, peer_bytes.length())
-  buf.write_bytes(peer_bytes)
+  write_string(buf, peer_id)
   buf.to_bytes()
 }
 
 ///|
-/// Read a uvarint from a byte slice starting at offset. Returns (value, new_offset).
-fn read_relay_uvarint(data : Bytes, offset : Int) -> (Int, Int)? {
-  let mut result = 0
-  let mut shift = 0
-  let mut pos = offset
-  for i = 0; i < 10; i = i + 1 {
-    if pos >= data.length() {
-      return None
-    }
-    let b = data[pos].to_int()
-    pos += 1
-    result = result | ((b & 0x7F) << shift)
-    if (b & 0x80) == 0 {
-      return Some((result, pos))
-    }
-    shift += 7
-  }
-  None
-}
-
-///|
-/// Read a length-prefixed string from data at offset. Returns (string, new_offset).
+/// Read a length-prefixed string from `data` starting at `offset`. Returns
+/// `(string, new_offset)`, or `None` if the frame is truncated or malformed.
+///
+/// Adapts `byte-codec`'s raising `Reader` to relay's `Option`-returning
+/// boundary: the byte stream is sliced from `offset` so the cursor starts at
+/// the length prefix, and any `CodecError` (EOF, oversized length) maps to a
+/// dropped frame.
 fn read_relay_string(data : Bytes, offset : Int) -> (String, Int)? {
-  match read_relay_uvarint(data, offset) {
-    None => None
-    Some((len, pos)) => {
-      if pos + len > data.length() {
-        return None
-      }
-      let bytes = data.view(start=pos, end=pos + len).to_owned()
-      Some((bytes.to_unchecked_string(), pos + len))
-    }
-  }
+  let reader = Reader::new(
+    data.view(start=offset, end=data.length()).to_owned(),
+  )
+  let s = read_string(reader) catch { _ => return None }
+  Some((s, offset + reader.pos))
 }
 
 ///|
@@ -97,11 +68,7 @@ fn wrap_with_sender(
   buf.write_byte(version)
   buf.write_byte(new_type)
   buf.write_byte(flags_none)
-  let tmp = Buffer()
-  tmp.write_string_utf16le(sender.view())
-  let sender_bytes = tmp.to_bytes()
-  write_relay_uvarint(buf, sender_bytes.length())
-  buf.write_bytes(sender_bytes)
+  write_string(buf, sender)
   if payload_offset < data.length() {
     buf.write_bytes(
       data.view(start=payload_offset, end=data.length()).to_owned(),

--- a/relay/wire_frozen_wbtest.mbt
+++ b/relay/wire_frozen_wbtest.mbt
@@ -1,0 +1,95 @@
+// Frozen wire-format fixtures for the relay protocol.
+//
+// These pin the EXACT on-the-wire bytes relay produces, asserted against
+// hand-derived byte literals — NOT re-derived by calling the code under test.
+// They are the safety net for migrating relay's hand-rolled varint/string
+// codec onto `lib/byte-codec`: the migration is only byte-safe if every literal
+// below still matches after the rewrite. relay's frames are transmitted between
+// peers, so a silent format change is a correctness break.
+//
+// Layout reference (see wire.mbt):
+//   peer control: [version=0x02][msg=0x05][flags=0x00][sub_type][write_string(peer_id)]
+//   wrapped:      [version=0x02][new_type][flags=0x00][write_string(sender)][payload]
+//   write_string(s) = [uvarint(utf16le_bytes_len)][utf16le bytes]
+// UTF-16LE of ASCII "x" is the byte pair [0xXX, 0x00].
+
+///|
+test "FROZEN encode_peer_joined(alice) full wire bytes" {
+  let actual = encode_peer_joined("alice")
+  // 02 05 00 01 | uvarint(10)=0a | "alice" utf16le (61 00 6c 00 69 00 63 00 65 00)
+  inspect(actual.length(), content="15")
+  inspect(
+    actual == b"\x02\x05\x00\x01\x0a\x61\x00\x6c\x00\x69\x00\x63\x00\x65\x00",
+    content="true",
+  )
+}
+
+///|
+test "FROZEN encode_peer_left(bob) full wire bytes" {
+  let actual = encode_peer_left("bob")
+  // 02 05 00 02 | uvarint(6)=06 | "bob" utf16le (62 00 6f 00 62 00)
+  inspect(actual.length(), content="11")
+  inspect(
+    actual == b"\x02\x05\x00\x02\x06\x62\x00\x6f\x00\x62\x00",
+    content="true",
+  )
+}
+
+///|
+test "FROZEN encode_peer_joined(empty) header-only" {
+  let actual = encode_peer_joined("")
+  // 02 05 00 01 | uvarint(0)=00 | no peer bytes
+  inspect(actual.length(), content="5")
+  inspect(actual == b"\x02\x05\x00\x01\x00", content="true")
+}
+
+///|
+test "FROZEN wrap_with_sender appends payload after sender id" {
+  // data payload begins at offset 3 (aa bb); header bytes 01 00 07 are dropped.
+  let data = b"\x01\x00\x07\xaa\xbb"
+  let actual = wrap_with_sender("alice", b'\x06', data, 3)
+  // 02 06 00 | uvarint(10)=0a | "alice" utf16le | payload (aa bb)
+  inspect(actual.length(), content="16")
+  inspect(
+    actual ==
+    b"\x02\x06\x00\x0a\x61\x00\x6c\x00\x69\x00\x63\x00\x65\x00\xaa\xbb",
+    content="true",
+  )
+}
+
+///|
+test "FROZEN wrap_with_sender with no payload (offset == length)" {
+  // payload_offset == data.length(): nothing is appended after the sender id.
+  let data = b"\x01\x02\x03"
+  let actual = wrap_with_sender("bob", b'\x06', data, 3)
+  // 02 06 00 | uvarint(6)=06 | "bob" utf16le
+  inspect(actual.length(), content="10")
+  inspect(actual == b"\x02\x06\x00\x06\x62\x00\x6f\x00\x62\x00", content="true")
+}
+
+///|
+test "FROZEN read_relay_string decodes frozen frame to (target, offset)" {
+  // 02 03 00 (SyncRequest header) | uvarint(4)=04 | "xy" utf16le (78 00 79 00)
+  let data = b"\x02\x03\x00\x04\x78\x00\x79\x00"
+  match read_relay_string(data, 3) {
+    Some((target, after)) => {
+      inspect(target, content="xy")
+      inspect(after, content="8")
+    }
+    None => fail("expected Some((\"xy\", 8))")
+  }
+}
+
+///|
+test "FROZEN read_relay_string returns None on truncated string body" {
+  // Claims length 4 but only two string bytes (78 00) follow.
+  let data = b"\x02\x03\x00\x04\x78\x00"
+  inspect(read_relay_string(data, 3) is None, content="true")
+}
+
+///|
+test "FROZEN read_relay_string returns None on truncated length varint" {
+  // Offset 3 is past the end of the buffer entirely.
+  let data = b"\x02\x03\x00"
+  inspect(read_relay_string(data, 3) is None, content="true")
+}

--- a/relay/wire_wbtest.mbt
+++ b/relay/wire_wbtest.mbt
@@ -58,24 +58,8 @@ test "encode_peer_joined encodes peer_id bytes" {
 }
 
 ///|
-test "write_relay_uvarint encodes small values in one byte" {
-  let buf = Buffer()
-  write_relay_uvarint(buf, 5)
-  let bytes = buf.to_bytes()
-  inspect(bytes.length(), content="1")
-  inspect(bytes[0], content="b'\\x05'")
-}
-
-///|
-test "write_relay_uvarint encodes 128 in two bytes" {
-  let buf = Buffer()
-  write_relay_uvarint(buf, 128)
-  let bytes = buf.to_bytes()
-  inspect(bytes.length(), content="2")
-  // 128 = 0x80 => first byte: (0x00 | 0x80) = 0x80, second byte: 0x01
-  inspect(bytes[0], content="b'\\x80'")
-  inspect(bytes[1], content="b'\\x01'")
-}
+// Note: uvarint byte-layout tests (small one-byte values, two-byte 128) now
+// live in lib/byte-codec, which owns the varint codec relay delegates to.
 
 ///|
 test "encode_peer_joined with empty peer_id" {


### PR DESCRIPTION
## What

Option B of the byte-codec extraction: migrate `relay/wire.mbt` onto the shared `dowdiness/byte_codec` package, deleting relay's duplicate hand-rolled LEB128 varint + length-prefixed UTF-16LE string codec. Follows Option A (#391, extracted the generic primitives + `CodecError` seam).

Design of record: `docs/plans/2026-05-29-byte-codec-package-design.md`.

## Changes

- **Deleted** `write_relay_uvarint` and `read_relay_uvarint` from `relay/wire.mbt` (the duplicated generic codec).
- `encode_peer_control` / `wrap_with_sender` now call `@byte_codec.write_string` — byte-identical to the prior inline `write_string_utf16le` + uvarint + `write_bytes` sequence.
- `read_relay_string` adapts byte-codec's raising `Reader` to relay's `Option`-returning boundary: it slices the buffer from `offset` so the cursor starts at the length prefix, and maps any `CodecError` (EOF, oversized length) to a dropped frame (`None`). New absolute offset = `offset + reader.pos`.
- relay-specific framing (`encode_peer_joined/left`, `wrap_with_sender`) stays in relay; only the generic primitives moved.
- Uvarint byte-layout tests move to `lib/byte-codec` (which now owns that codec); relay test frame-builders use `write_string`.

## Wire format is unchanged

relay frames are transmitted between peers, so byte-equivalence is non-negotiable. Pinned three ways:

1. **New frozen-bytes fixtures** (`relay/wire_frozen_wbtest.mbt`) assert the exact output of `encode_peer_joined/left` and `wrap_with_sender` against hand-derived byte literals (not re-derived from the code under refactor). They passed **unchanged** before and after the migration — the byte-equivalence proof.
2. **SyncRequest/SyncResponse routing tests** now assert the **full forwarded frame**, exercising `read_relay_string`'s `after_target` offset end-to-end (added in response to the pre-PR review).
3. **Codex** verified `write_relay_uvarint(non-neg Int)` == `write_uvarint(.to_uint64())` and that the slice-`Reader` decode matches the prior offset-threading read.

## Behavior change (hardening, not a regression)

A malformed frame whose length prefix encodes a value ≥ 2³¹ now drops cleanly (`None`) instead of silently overflowing the `Int` accumulator (which could even panic on the subsequent `view(start, end<start)`). Consistent with relay's existing drop-on-malformed contract. No well-formed frame is affected.

## Reuse check

Reuses `@byte_codec.{Reader, read_string, write_string, read_uvarint, safe_uvarint_to_int}` — no new helpers introduced. relay's public `.mbti` is **unchanged**.

## Verification

- `moon test` relay package: 45/45 (js + native).
- `lib/byte-codec` standalone native: 11/11.
- Full workspace `moon test`: 1219/1219.
- `relay/pkg.generated.mbti` diff: empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)