### PR TITLE
feat(canvas): preview port compatibility during connection drag

### DIFF
--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -128,3 +128,39 @@ test('canvas handles create edges and reject invalid gestures', async ({ page })
   await expect(pendingEdgePaths(page)).toHaveCount(0);
   expect(runtimeErrors).toEqual([]);
 });
+
+test('input handles preview compatibility during a connection drag', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+
+  // Node 2 (HTTP request) emits a single JSON output. Start a drag from it and
+  // hold it open so input handles render their compatibility preview.
+  const source = outputHandle(page, 2);
+  const start = await center(source, 'node 2 output handle');
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + 40, start.y + 40, { steps: 6 });
+  await expect(pendingEdgePaths(page)).toHaveCount(1);
+
+  // JSON output → JSON input (Loop "items") is compatible.
+  await expect(inputHandle(page, 5)).toHaveClass(/(?:^|\s)compatible-target(?:\s|$)/);
+  // JSON output → Flow input (Parallel "in") is incompatible.
+  await expect(inputHandle(page, 6)).toHaveClass(/(?:^|\s)incompatible-target(?:\s|$)/);
+  // The source node's own input is a self-loop and must read incompatible.
+  await expect(inputHandle(page, 2)).toHaveClass(/(?:^|\s)incompatible-target(?:\s|$)/);
+
+  await page.mouse.up();
+
+  // Once the drag ends, the preview classes are cleared.
+  await expect(inputHandle(page, 5)).not.toHaveClass(/compatible-target/);
+  await expect(inputHandle(page, 6)).not.toHaveClass(/incompatible-target/);
+  expect(runtimeErrors).toEqual([]);
+});

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -345,6 +345,18 @@
     }
     .handle.disabled { opacity: 0.24; cursor: not-allowed; }
 
+    /* Connection-drag compatibility preview (display only; MoonBit
+       can_commit_edge stays authoritative). */
+    .handle.compatible-target {
+      background: var(--success);
+      border-color: oklch(86% 0.07 130);
+      box-shadow: 0 0 0 6px oklch(75% 0.09 130 / 0.2);
+    }
+    .handle.incompatible-target {
+      opacity: 0.22;
+      cursor: not-allowed;
+    }
+
     #context-menu {
       position: fixed;
       z-index: 10;

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -111,7 +111,43 @@ function portTitle(port: PortDef): string {
   return `${port.label}: ${portTypeName(port.port_type)}`;
 }
 
-function renderPortHandles(div: HTMLDivElement, node: NodeData): void {
+// ─── Connection compatibility (display only) ───────────────────────────────────
+// Mirrors MoonBit `can_commit_edge` so input handles can preview which targets a
+// drag could land on. This is purely cosmetic — MoonBit validation stays the
+// authoritative commit/reject check on pointerup.
+
+/** Context for the in-flight connection, resolved once per render. */
+type ConnectCtx = {
+  fromNode: number;
+  fromPort: string;
+  sourceType: string | null;
+  edges: EdgeData[];
+};
+
+/** Mirror of MoonBit `port_type_compatible`. */
+function portTypesCompatible(source: string, target: string): boolean {
+  return source === target || source === 'Any' || target === 'Any';
+}
+
+/**
+ * Whether dragging from the active source onto this input handle would be
+ * accepted, mirroring `can_commit_edge` (self-loop, duplicate edge, type check).
+ */
+function inputHandleCompatible(ctx: ConnectCtx, targetNode: number, targetPort: PortDef): boolean {
+  if (ctx.sourceType == null) return false;
+  if (ctx.fromNode === targetNode) return false; // self-loop
+  const duplicate = ctx.edges.some(
+    (e) =>
+      e.source === ctx.fromNode &&
+      e.source_port === ctx.fromPort &&
+      e.target === targetNode &&
+      e.target_port === targetPort.id,
+  );
+  if (duplicate) return false;
+  return portTypesCompatible(ctx.sourceType, portTypeName(targetPort.port_type));
+}
+
+function renderPortHandles(div: HTMLDivElement, node: NodeData, connectCtx: ConnectCtx | null): void {
   div.querySelectorAll(':scope > .handle').forEach((handle) => handle.remove());
   const addHandles = (side: 'input' | 'output', ports: PortDef[]) => {
     ports.forEach((port, index) => {
@@ -124,6 +160,11 @@ function renderPortHandles(div: HTMLDivElement, node: NodeData): void {
       handle.style.top = `${((index + 1) * 100) / (ports.length + 1)}%`;
       handle.title = `${side === 'input' ? 'Input' : 'Output'} ${portTitle(port)}`;
       handle.setAttribute('aria-label', `${node.title} ${side} ${portTitle(port)}`);
+      if (connectCtx && side === 'input') {
+        handle.classList.add(
+          inputHandleCompatible(connectCtx, node.id, port) ? 'compatible-target' : 'incompatible-target',
+        );
+      }
       div.appendChild(handle);
     });
   };
@@ -156,6 +197,21 @@ function render(): void {
   const invalidNodeIds = new Set(
     state.validation.filter((msg) => msg.node_id != null).map((msg) => msg.node_id as number),
   );
+
+  // Resolve the in-flight connection's source port type once, so each input
+  // handle can preview compatibility while the drag is live.
+  let connectCtx: ConnectCtx | null = null;
+  if (state.connecting) {
+    const from = state.connecting;
+    const srcNode = state.nodes.find((n) => n.id === from.from);
+    const srcPort = srcNode?.outputs.find((p) => p.id === from.from_port);
+    connectCtx = {
+      fromNode: from.from,
+      fromPort: from.from_port,
+      sourceType: srcPort ? portTypeName(srcPort.port_type) : null,
+      edges: state.edges,
+    };
+  }
 
   for (const node of state.nodes) {
     seenNodes.add(node.id);
@@ -197,7 +253,7 @@ function render(): void {
     const ports = div.querySelector('.ports') as HTMLDivElement;
     title.textContent = node.title;
     subtitle.textContent = node.subtitle;
-    renderPortHandles(div, node);
+    renderPortHandles(div, node, connectCtx);
     ports.replaceChildren(
       ...[...node.inputs.map((p) => ['in', p] as const), ...node.outputs.map((p) => ['out', p] as const)]
         .map(([direction, port]) => {


### PR DESCRIPTION
## What

While dragging a connection from an output handle, input handles now preview whether the connection would be accepted:

- **Compatible** targets glow green (`--success`).
- **Incompatible** targets dim.

This is **display-only**. MoonBit `can_commit_edge` remains the authoritative commit/reject check on `pointerup`; the TS classifier never decides whether an edge is created.

## How

- `examples/canvas/web/src/main.ts`: a `ConnectCtx` resolved once per render captures the in-flight source port type. `inputHandleCompatible()` mirrors `can_commit_edge` — rejects self-loop, exact-duplicate edge, then applies `port_type_compatible` (`s == t || s == Any || t == Any`). Input handles receive `.compatible-target` / `.incompatible-target` during a drag. Handles are rebuilt every frame, so the preview tracks the live drag with no separate update pass.
- `examples/canvas/web/index.html`: styles for the two classes (green glow / dim).
- `examples/canvas/web/e2e/canvas-handles.spec.ts`: a test that drags from node 2's JSON output and asserts node 5 (JSON input) is compatible, node 6 (Flow input) and node 2 (self-loop) are incompatible, and all classes clear once the drag ends.

## Scope guards

- No first-port fallback reintroduced — source/target port IDs stay explicit through the FFI.
- TS compatibility is **not** authoritative for commits; MoonBit validation decides.
- Did **not** bundle the unmerged "reject multiple sources into the same target port" review idea.

## Reuse check

- **`portTypeName` (existing, main.ts)** — reused to normalize the `Tagged` JSON port type to its variant name; no new parser added.
- **`renderPortHandles` (existing, main.ts)** — extended with a `ConnectCtx | null` parameter rather than adding a separate handle-decoration pass, since handles are already recreated each render.
- New helpers (`portTypesCompatible`, `inputHandleCompatible`, `ConnectCtx`) intentionally mirror MoonBit `port_type_compatible` / `can_commit_edge`; they are display-only TS counterparts and deliberately do not duplicate authority. No existing TS API covered "is this drag target compatible."

## Validation

- `MOON_WORK=off moon check --target js` — clean (MoonBit untouched)
- `MOON_WORK=off moon test --target js` — 24/24
- `npm run build` — success
- `npm run test:e2e` — 2 passed (incl. new compatibility test)
- Codex pre-PR review — PASS, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Input handles now display visual compatibility preview during connection drag operations. Compatible targets show a green highlight with glow effect, while incompatible targets appear dimmed with a "not-allowed" cursor.

* **Tests**
  * Added end-to-end test for connection drag compatibility preview behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->