### PR TITLE
feat(scope): NodeId-keyed binding index for lambda (v1, rename migrated)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
+++ b/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
@@ -6,7 +6,7 @@
 
 **Architecture:** A single batch-built `ScopeGraph` (Scope/Decl/Ref keyed by `@core.NodeId`) constructed in three passes from `FlatProj` + registry + `SourceMap`. v1 is non-incremental but correct. The `Resolution` record reserves negative-observation fields (`decl: DeclId?`, `visited_scopes`) for a future incremental layer. Only `declaration()` is wired to a consumer (`rename`) in v1; `references()` / `enclosing_env()` are reserved API surface.
 
-**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap, collect_registry), `dowdiness/canopy/lang/lambda/proj` (FlatProj, parse_to_proj_node — default alias `@proj`), `dowdiness/lambda/ast` (Term, alias `@ast`). Tests: `inspect` on **scalar projections** + whitebox `*_wbtest.mbt`.
+**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap, collect_registry — alias `@core`), `dowdiness/canopy/lang/lambda/proj` (FlatProj, parse_to_proj_node — alias `@lambda_proj`, matching the sibling `edits` package), `dowdiness/lambda/ast` (Term, alias `@ast`). Tests: `inspect` on **scalar projections** + whitebox `*_wbtest.mbt`.
 
 **Design spec:** `docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md` — read it before starting; this plan implements it.
 
@@ -38,13 +38,13 @@ trust the *old* assumptions some of these correct:
   `@core.SourceMap::get_range(node_id) -> @core.Range?` with `.start` / `.end`
   fields (`core/source_map.mbt:104`). Construct in tests via
   `@core.SourceMap::from_ast(proj)` — `from_ast` is a `SourceMap` method, so it
-  is `@core.`, NOT `@proj.` (it appears *unqualified* in
+  is `@core.`, NOT `@lambda_proj.` (it appears *unqualified* in
   `lang/lambda/edits/scope_wbtest.mbt:21` only because that package pulls it in
   via `using`).
 - **FlatProj:** `pub struct FlatProj { defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)]; final_expr : ProjNode[@ast.Term]? }`
-  — the def tuple is `(name, init, start, binding_id)`. In `@proj`. Source:
+  — the def tuple is `(name, init, start, binding_id)`. In `@lambda_proj`. Source:
   `lang/lambda/proj/flat_proj.mbt:5`. Construct via
-  `@proj.FlatProj::from_proj_node(proj)`. **Important id-shape note:**
+  `@lambda_proj.FlatProj::from_proj_node(proj)`. **Important id-shape note:**
   `from_proj_node` sets a def's binding id (`.3`) to the **init child's** id
   (`flat_proj.mbt:281`), whereas the live editor path (`to_flat_proj`) allocates
   a *separate* binding id (`flat_proj.mbt:29`). Both the scope graph and
@@ -58,7 +58,7 @@ trust the *old* assumptions some of these correct:
   `scope_wbtest.mbt:38` reads the body as
   `proj.children[proj.children.length() - 1]`). A pure expression (no defs)
   produces NO Module wrapper — `from_proj_node` returns the bare expr.
-- **parse_to_proj_node:** `@proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Ref[Int])`.
+- **parse_to_proj_node:** `@lambda_proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Ref[Int])`.
   Source: `lang/lambda/proj/proj_node.mbt:315`. The lambda surface syntax uses
   the **`λ`** character (U+03BB), as in `scope_wbtest.mbt:18` (`"λx. x"`).
 - **Existing binder API (the v1 migration target):**
@@ -89,10 +89,12 @@ trust the *old* assumptions some of these correct:
   `lam_id == proj.id()` and `def_index`, never the `BindingSite` value).
 - **Workspace:** `moon.work` members do NOT list `lang/*`; the root member `.`
   already covers `lang/lambda/scope`. **Do NOT edit `moon.work`.**
-- **moon.pkg format:** moon.pkg files are **JSON** (`{"import": [...],
-  "warning-list": "..."}`); see `lang/lambda/edits/moon.pkg`. Plain-string
-  imports use the default alias (last path segment, or enough segments to
-  disambiguate — e.g. `moonbitlang/core/immut/hashset` → `@immut/hashset`).
+- **moon.pkg format:** this repo's moon.pkg files use the
+  `import { "path" @alias, ... }` block + `warnings = "..."` form (NOT
+  `moon.pkg.json`); see `lang/lambda/edits/moon.pkg`. A bare path takes its
+  default alias (last segment, or enough segments to disambiguate — e.g.
+  `moonbitlang/core/immut/hashset` → `@immut/hashset`); an explicit `@alias`
+  overrides it. The `edits` package aliases proj as `@lambda_proj` — match that.
 - **New package module path:** `dowdiness/canopy/lang/lambda/scope`; consumers
   alias it `@scope`.
 
@@ -100,7 +102,7 @@ trust the *old* assumptions some of these correct:
 
 ## File structure
 
-- `lang/lambda/scope/moon.pkg` — JSON package config (imports core, proj, ast, immut/hashset).
+- `lang/lambda/scope/moon.pkg` — `import { }` package config (imports core, proj, ast, immut/hashset).
 - `lang/lambda/scope/graph.mbt` — data model: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId`. Language-agnostic except `DeclKind`.
 - `lang/lambda/scope/builder.mbt` — `build(...)`: Pass 1 (parent map), Pass 2 (scopes + decls), Pass 3 (resolve refs).
 - `lang/lambda/scope/query.mbt` — `declaration()`, `references()`, `enclosing_env()`.
@@ -119,20 +121,22 @@ trust the *old* assumptions some of these correct:
 
 - [ ] **Step 1: Create the package config**
 
-Create `lang/lambda/scope/moon.pkg` (JSON; default aliases give `@core`,
-`@proj`, `@ast`, `@immut/hashset`):
+Create `lang/lambda/scope/moon.pkg` (this repo uses the `import { ... }` /
+`warnings = "..."` moon.pkg format, NOT `moon.pkg.json` — copy the shape from
+`lang/lambda/edits/moon.pkg`):
 
-```json
-{
-  "import": [
-    "dowdiness/canopy/core",
-    "dowdiness/canopy/lang/lambda/proj",
-    "dowdiness/lambda/ast",
-    "moonbitlang/core/immut/hashset"
-  ],
-  "warning-list": "-2-6-29"
-}
 ```
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/immut/hashset" @immut/hashset,
+}
+warnings = "-2-6-29"
+```
+
+Bare paths take the default alias (`@core`, `@ast`); the explicit `@lambda_proj`
+and `@immut/hashset` aliases match the sibling `edits` package.
 
 - [ ] **Step 2: (No moon.work change.)**
 
@@ -254,12 +258,12 @@ fn build_fixture(
   text : String,
 ) -> (
   @core.ProjNode[@ast.Term],
-  @proj.FlatProj,
+  @lambda_proj.FlatProj,
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @core.SourceMap,
 ) {
-  let (proj, _counter) = @proj.parse_to_proj_node(text)
-  let flat_proj = @proj.FlatProj::from_proj_node(proj)
+  let (proj, _counter) = @lambda_proj.parse_to_proj_node(text)
+  let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
   let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(proj, registry)
@@ -450,7 +454,7 @@ fn root_node(
 /// LamParam scope per Lam node. Records node→scope membership.
 fn Builder::pass2(
   self : Builder,
-  flat_proj : @proj.FlatProj,
+  flat_proj : @lambda_proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
 ) -> Unit {
   let root_scope = self.add_scope(None)
@@ -483,7 +487,7 @@ fn Builder::pass2(
 ///|
 /// Build the scope graph (Pass 2 only for now; Pass 3 added next task).
 pub fn build(
-  flat_proj : @proj.FlatProj,
+  flat_proj : @lambda_proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
@@ -613,7 +617,7 @@ fn Builder::add_ref(
 /// def count (body sentinel) when the node is in the module body. Mirrors
 /// resolve_binder's def-range containment (scope.mbt:30-39).
 fn containing_def_index(
-  flat_proj : @proj.FlatProj,
+  flat_proj : @lambda_proj.FlatProj,
   source_map : @core.SourceMap,
   node_id : @core.NodeId,
 ) -> Int {
@@ -672,7 +676,7 @@ fn Builder::resolve(
 /// Pass 3: emit a Ref for each Var/Unbound node and resolve it.
 fn Builder::pass3(
   self : Builder,
-  flat_proj : @proj.FlatProj,
+  flat_proj : @lambda_proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> Unit {
@@ -695,7 +699,7 @@ Replace the body of `build`:
 
 ```moonbit
 pub fn build(
-  flat_proj : @proj.FlatProj,
+  flat_proj : @lambda_proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
@@ -970,9 +974,8 @@ provides the `scope_test_registry` helper (`scope_wbtest.mbt:2`). Reuse those.
 
 - [ ] **Step 1: Add the scope import to edits**
 
-In `lang/lambda/edits/moon.pkg` (JSON), add
-`"dowdiness/canopy/lang/lambda/scope"` to the `"import"` array. (Default alias
-`@scope`.)
+In `lang/lambda/edits/moon.pkg`, add `"dowdiness/canopy/lang/lambda/scope"` as
+a new line inside the existing `import { ... }` block (default alias `@scope`).
 
 Run: `moon check -p dowdiness/canopy/lang/lambda/edits`
 Expected: no errors (import resolves; nothing uses it yet — `-2-6-29`
@@ -1270,7 +1273,7 @@ exists (`grep -n 'pub fn resolve_binder' lang/lambda/edits/scope.mbt`).
 
 In the PR description, state: `declaration()` reproduces the existing
 `BindingSite` contract; reused `@core.NodeId`, `@core.ProjNode`,
-`@core.SourceMap`, `@proj.FlatProj` (no duplicate types introduced).
+`@core.SourceMap`, `@lambda_proj.FlatProj` (no duplicate types introduced).
 
 - [ ] **Step 4: Open the PR**
 
@@ -1287,7 +1290,7 @@ Layer 2 caimeox oracle per Task 9 status.
 
 ## Reuse check
 declaration() reproduces the existing BindingSite contract; reused @core.NodeId,
-@core.ProjNode, @core.SourceMap, @proj.FlatProj — no duplicate types.
+@core.ProjNode, @core.SourceMap, @lambda_proj.FlatProj — no duplicate types.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 BODY
@@ -1306,4 +1309,4 @@ BODY
 - **Spec §Testing Layer 1/2/3:** Tasks 5 / 9 / 8 (Layer 3 now table-driven over all rules). ✓
 - **Spec §Non-goals (only rename, only declaration):** Task 8 migrates one call; references/enclosing_env reserved (Task 6), enclosing_env documented as superset of collect_lam_env (not replacement). ✓
 - **Spec §"acyclic by construction":** relied on in Task 2 `build_parent_map` doc; no runtime cycle guard in v1 because the tree-derived parent map cannot cycle.
-- **Codex review (2026-05-30) findings folded:** from_ast→`@core` (C1); `derive(Debug,Eq)`+scalar-inspect idiom (C2); table-driven equivalence (C3); enclosing_env superset comment (C4); id-shape note (C5); plus moon.pkg JSON format + `@proj` default alias.
+- **Codex review (2026-05-30) findings folded:** from_ast→`@core` (C1); `derive(Debug,Eq)`+scalar-inspect idiom (C2); table-driven equivalence (C3); enclosing_env superset comment (C4); id-shape note (C5); plus moon.pkg `import { }` format + `@lambda_proj` alias (matching `edits`).

--- a/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
+++ b/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
@@ -6,24 +6,69 @@
 
 **Architecture:** A single batch-built `ScopeGraph` (Scope/Decl/Ref keyed by `core.NodeId`) constructed in three passes from `FlatProj` + registry + `SourceMap`. v1 is non-incremental but correct. The `Resolution` record reserves negative-observation fields (`decl: DeclId?`, `visited_scopes`) for a future incremental layer. Only `declaration()` is wired to a consumer (`rename`) in v1; `references()` / `enclosing_env()` are reserved API surface.
 
-**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap), `dowdiness/canopy/lang/lambda/proj` (FlatProj), `dowdiness/loomlambda/ast` (Term). Tests: `inspect` snapshots + whitebox `*_wbtest.mbt`.
+**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap, collect_registry), `dowdiness/canopy/lang/lambda/proj` (FlatProj, parse_to_proj_node), `dowdiness/lambda/ast` (Term). Tests: `inspect` snapshots + whitebox `*_wbtest.mbt`.
 
 **Design spec:** `docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md` — read it before starting; this plan implements it.
+
+---
+
+## Verified facts (read these before starting — they fix common wrong guesses)
+
+These were confirmed by reading the code. Do NOT substitute your own guesses:
+
+- **AST type:** `@ast.Term` from package `dowdiness/lambda/ast`. Variants:
+  `Int(Int)`, `Var(VarName)`, `Lam(VarName, Term)`, `App(Term, Term)`,
+  `Bop(Bop, Term, Term)`, `If(Term, Term, Term)`,
+  `Module(Array[(VarName, Term)], Term)`, `Unit`, `Unbound(VarName)`,
+  `Error(String)`, `Hole(Int)`. (`VarName = String`.) Source:
+  `loom/examples/lambda/src/ast/ast.mbt:18`.
+- **NodeId:** `pub struct NodeId(Int)` in `dowdiness/canopy/core`; construct via
+  `@core.NodeId::from_int(n)` or pattern `NodeId(n)`. Source: `core/types.mbt:6`.
+- **ProjNode:** `@core.ProjNode[T]` with `.id() -> NodeId`, `.children`,
+  `.kind`, `.start`, `.end`; construct via
+  `@core.ProjNode::new(kind, start, end, node_id, children)`. Source:
+  `core/proj_node.mbt:7,32`.
+- **Registry walk:** `@core.collect_registry(node, reg)` fills
+  `reg : Map[NodeId, ProjNode[T]]` by walking the tree. Source:
+  `core/proj_node.mbt:58`.
+- **FlatProj:** `pub struct FlatProj { defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)]; final_expr : ProjNode[@ast.Term]? }`
+  — the def tuple is `(name, init, start, binding_id)`. Source:
+  `lang/lambda/proj/flat_proj.mbt:5`.
+- **Construction in tests:**
+  `@lambda_proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Ref[Int])`,
+  `@lambda_proj.FlatProj::from_proj_node(proj)`,
+  `@lambda_proj.SourceMap::from_ast(proj)`. Source: `lang/lambda/proj/proj_node.mbt:175,180,251`.
+  Copy the exact call forms + import aliases from
+  `lang/lambda/edits/scope_wbtest.mbt:1-44`.
+- **Existing binder API (the v1 migration target):**
+  `pub fn resolve_binder(var_node_id, var_name, flat_proj, registry, source_map) -> BindingSite?`
+  where `pub(all) enum BindingSite { LamBinder(lam_id~ : NodeId); ModuleBinder(binding_node_id~ : NodeId, def_index~ : Int) }`.
+  Source: `lang/lambda/edits/scope.mbt:3,11`.
+- **The one consumer to migrate:** `rename_from_var` in
+  `lang/lambda/edits/text_edit_rename.mbt:99`, which calls `resolve_binder` at
+  line 105 through an `EditContext[T]` bundle:
+  `pub(all) struct EditContext[T] { registry; flat_proj; source_map; language; on_structural_edit }`
+  (source `lang/lambda/edits/text_edit.mbt:32`). It dispatches:
+  `LamBinder(lam_id~) -> rename_lam_param(ctx, lam_id, lam_node, old, new)`,
+  `ModuleBinder(binding_node_id~, def_index~) -> rename_module_binding(ctx, module_id, def_index, old, new)`.
+- **Workspace:** `moon.work` members do NOT list `lang/*`; the root member `.`
+  already covers `lang/lambda/scope`. **Do NOT edit `moon.work`.** Source:
+  `moon.work`.
+- **New package module path:** `dowdiness/canopy/lang/lambda/scope`; consumers
+  alias it `@scope`.
 
 ---
 
 ## File structure
 
 - `lang/lambda/scope/moon.pkg` — package config (imports core, proj, ast).
-- `lang/lambda/scope/graph.mbt` — data model: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId` + constructors. Language-agnostic except `DeclKind`.
-- `lang/lambda/scope/builder.mbt` — `build(flat_proj, registry, source_map) -> ScopeGraph`: Pass 1 (parent map), Pass 2 (scopes + decls), Pass 3 (resolve refs).
+- `lang/lambda/scope/graph.mbt` — data model: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId`. Language-agnostic except `DeclKind`.
+- `lang/lambda/scope/builder.mbt` — `build(...)`: Pass 1 (parent map), Pass 2 (scopes + decls), Pass 3 (resolve refs).
 - `lang/lambda/scope/query.mbt` — `declaration()`, `references()`, `enclosing_env()`.
-- `lang/lambda/scope/graph_wbtest.mbt` — Layer 1 hand-written edge-case tests + Layer 3 equivalence test.
-- `lang/lambda/scope/oracle_wbtest.mbt` — Layer 2 caimeox differential oracle (last task; non-blocking for the PoC gate).
-- `moon.work` — add `lang/lambda/scope` to members.
-- `lang/lambda/edits/text_edit_rename.mbt:27` — migrate the `resolve_binder` call in `rename_from_var` to `@scope.declaration()`.
-
-**Naming note:** the new package's MoonBit module path is `dowdiness/canopy/lang/lambda/scope`; consumers alias it `@scope`. Inside the package, imports are aliased `@core`, `@lambda_proj` (for `dowdiness/canopy/lang/lambda/proj`), `@ast` (for `dowdiness/loomlambda/ast`).
+- `lang/lambda/scope/graph_wbtest.mbt` — Layer 1 hand tests + test helpers.
+- `lang/lambda/scope/oracle_wbtest.mbt` — Layer 2 caimeox differential oracle (last task; non-blocking).
+- `lang/lambda/edits/scope_equivalence_wbtest.mbt` — Layer 3 equivalence test (lives in `edits` because the production import goes edits→scope; see Task 8).
+- `lang/lambda/edits/text_edit_rename.mbt:105` + `lang/lambda/edits/moon.pkg` — migrate the `rename_from_var` binder lookup to `@scope`.
 
 ---
 
@@ -32,25 +77,28 @@
 **Files:**
 - Create: `lang/lambda/scope/moon.pkg`
 - Create: `lang/lambda/scope/graph.mbt`
-- Modify: `moon.work` (add member)
 
 - [ ] **Step 1: Create the package config**
 
 Create `lang/lambda/scope/moon.pkg`:
 
-```json
-{
-  "import": [
-    "dowdiness/canopy/core",
-    "dowdiness/canopy/lang/lambda/proj",
-    "dowdiness/loomlambda/ast"
-  ]
+```
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/immut/hashset" @immut/hashset,
 }
 ```
 
-- [ ] **Step 2: Register the package in the workspace**
+Note: `dowdiness/lambda/ast` with no explicit alias binds to `@ast` (default
+alias = last path segment), matching how `lang/lambda/edits` uses it.
 
-In `moon.work`, add `"lang/lambda/scope"` to the `members` array (place it next to the other `lang/lambda/*` entries). Add it exactly once.
+- [ ] **Step 2: (No moon.work change.)**
+
+Confirm `moon.work` already covers the new package via the root `.` member — do
+NOT add an entry. Verify with: `grep -n 'lang/lambda' moon.work` → expect no
+output (none listed; root covers them).
 
 - [ ] **Step 3: Write the data model**
 
@@ -58,7 +106,7 @@ Create `lang/lambda/scope/graph.mbt`:
 
 ```moonbit
 ///|
-/// Graph-local compact indices. NOT persistent identity — `core.NodeId`
+/// Graph-local compact indices. NOT persistent identity — `@core.NodeId`
 /// carries persistent identity; these index into the graph's own arrays.
 pub(all) struct ScopeId(Int) derive(Eq, Hash, Compare, Show)
 
@@ -129,32 +177,78 @@ pub(all) struct ScopeGraph {
 - [ ] **Step 4: Verify it compiles**
 
 Run: `moon check -p dowdiness/canopy/lang/lambda/scope`
-Expected: no errors (an empty package with only type defs compiles clean).
+Expected: no errors. If `@immut/hashset` is reported unused, that is fine for now
+(it is used in Task 6); suppress with `warnings = "-2-6-29"` in `moon.pkg` matching
+the `edits` package, OR leave the import out until Task 6 and add it there.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add lang/lambda/scope/moon.pkg lang/lambda/scope/graph.mbt moon.work
+git add lang/lambda/scope/moon.pkg lang/lambda/scope/graph.mbt
 git commit -m "feat(scope): scaffold lang/lambda/scope package + data model"
 ```
 
 ---
 
-## Task 2: Builder Pass 1 — NodeId → parent map
+## Task 2: Test helpers + Builder Pass 1 (NodeId → parent map)
 
 **Files:**
 - Create: `lang/lambda/scope/builder.mbt`
-- Test: `lang/lambda/scope/graph_wbtest.mbt`
+- Create: `lang/lambda/scope/graph_wbtest.mbt`
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the test helpers + first failing test**
 
-Create `lang/lambda/scope/graph_wbtest.mbt`:
+Create `lang/lambda/scope/graph_wbtest.mbt`. The construction trio mirrors
+`lang/lambda/edits/scope_wbtest.mbt` exactly — read that file (lines 1-44) and
+copy the call forms.
 
 ```moonbit
 ///|
-/// Pass 1: the parent map links each node to its registry parent.
+/// Build (proj, flat_proj, registry, source_map) from source — mirrors the
+/// construction in lang/lambda/edits/scope_wbtest.mbt.
+fn build_fixture(
+  text : String,
+) -> (
+  @core.ProjNode[@ast.Term],
+  @lambda_proj.FlatProj,
+  Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  @core.SourceMap,
+) {
+  let (proj, _counter) = @lambda_proj.parse_to_proj_node(text)
+  let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
+  let source_map = @lambda_proj.SourceMap::from_ast(proj)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(proj, registry)
+  (proj, flat_proj, registry, source_map)
+}
+
+///|
+/// Find the first Var node with the given name anywhere in the tree.
+fn find_var_node(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId {
+  let mut found : @core.NodeId? = None
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if found is Some(_) {
+      return
+    }
+    if n.kind is @ast.Term::Var(x) && x == name {
+      found = Some(n.id())
+      return
+    }
+    for c in n.children {
+      walk(c)
+    }
+  }
+
+  walk(root)
+  found.unwrap()
+}
+
+///|
 test "build_parent_map: child maps to parent" {
-  // Build a tiny ProjNode tree by hand: root(id=0) with one child(id=1).
+  // Hand-built tree: root(id=0) Lam with one child Var(id=1).
   let child = @core.ProjNode::new(@ast.Term::Var("x"), 0, 1, 1, [])
   let root = @core.ProjNode::new(
     @ast.Term::Lam("x", @ast.Term::Var("x")),
@@ -166,17 +260,15 @@ test "build_parent_map: child maps to parent" {
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(root, registry)
   let parents = build_parent_map(registry)
-  inspect(parents.get(@core.NodeId(1)), content="Some(NodeId(0))")
-  inspect(parents.get(@core.NodeId(0)), content="None")
+  inspect(parents.get(@core.NodeId::from_int(1)), content="Some(NodeId(0))")
+  inspect(parents.get(@core.NodeId::from_int(0)), content="None")
 }
 ```
-
-Note: if `@core.next_proj_node_id` is not needed, delete the two `counter` lines — they are only a guard against an unused-import warning and the test does not require them.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: FAIL — `build_parent_map` is not defined.
+Expected: FAIL — `build_parent_map` not defined.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -203,13 +295,15 @@ pub fn build_parent_map(
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: PASS.
+Expected: PASS. If the `Show` of `Option[NodeId]` differs from
+`Some(NodeId(0))`, run with `--update` and confirm the captured value is the
+NodeId(0)/None shape before accepting.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add lang/lambda/scope/builder.mbt lang/lambda/scope/graph_wbtest.mbt
-git commit -m "feat(scope): Pass 1 NodeId->parent map (acyclic by construction)"
+git commit -m "feat(scope): test helpers + Pass 1 NodeId->parent map"
 ```
 
 ---
@@ -220,7 +314,10 @@ git commit -m "feat(scope): Pass 1 NodeId->parent map (acyclic by construction)"
 - Modify: `lang/lambda/scope/builder.mbt`
 - Test: `lang/lambda/scope/graph_wbtest.mbt`
 
-This pass creates: one root module scope; one `ModuleDef` decl per `FlatProj.defs` entry (in that scope); and one child scope + `LamParam` decl per `Lam` node (walking the projection tree). Refs are added empty here (Pass 3 fills resolution). We also record, per node, which scope it belongs to, so Pass 3 can find a ref's starting scope.
+Pass 2 creates: one root module scope; one `ModuleDef` decl per `FlatProj.defs`
+entry (in the root scope); one child scope + `LamParam` decl per `Lam` node
+(walking the projection tree from the root). It records, per node, which scope it
+lexically sits in, so Pass 3 can find a ref's starting scope.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -228,15 +325,11 @@ Add to `lang/lambda/scope/graph_wbtest.mbt`:
 
 ```moonbit
 ///|
-/// Pass 2: a module with two defs yields one root scope + two ModuleDef decls.
 test "build: module defs become ModuleDef decls in root scope" {
-  let src = "let a = 1\nlet b = 2\nb"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (_proj, flat_proj, registry, source_map) = build_fixture(
+    "let a = 1\nlet b = 2\nb",
+  )
   let g = build(flat_proj, registry, source_map)
-  // two module defs → two decls, both ModuleDef, in the root scope (id 0)
   inspect(g.decls.length(), content="2")
   inspect(g.decls[0].kind, content="ModuleDef(def_index=0)")
   inspect(g.decls[1].kind, content="ModuleDef(def_index=1)")
@@ -244,12 +337,10 @@ test "build: module defs become ModuleDef decls in root scope" {
 }
 ```
 
-`build_test_projection` is the shared test helper used by `lang/lambda/edits/scope_wbtest.mbt`; copy its definition into this test file (see "Test helpers" section at the end of this plan for the exact code).
-
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: FAIL — `build` is not defined.
+Expected: FAIL — `build` not defined.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -262,7 +353,6 @@ priv struct Builder {
   scopes : Array[Scope]
   decls : Array[Decl]
   refs : Array[Ref]
-  // node_id -> the scope a node lexically sits in (filled in Pass 2).
   node_scope : Map[@core.NodeId, ScopeId]
 }
 
@@ -286,35 +376,49 @@ fn Builder::add_decl(
   name : String,
   kind : DeclKind,
 ) -> DeclId {
+  let ScopeId(si) = scope
   let id = DeclId(self.decls.length())
   self.decls.push({ id, node_id, name, scope, kind })
-  self.scopes[scope.0].decl_ids.push(id)
+  self.scopes[si].decl_ids.push(id)
   id
 }
 
 ///|
-/// Pass 2: create the root module scope, ModuleDef decls (one per flat def),
-/// and a child LamParam scope per Lam node. Records node→scope membership.
+/// The registry's root is the node that is no other node's child.
+fn root_node(
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> @core.ProjNode[@ast.Term] {
+  let parents = build_parent_map(registry)
+  let mut root : @core.ProjNode[@ast.Term]? = None
+  for id, node in registry {
+    if parents.get(id) is None {
+      root = Some(node)
+    }
+  }
+  root.unwrap()
+}
+
+///|
+/// Pass 2: root module scope, ModuleDef decls (one per flat def), and a child
+/// LamParam scope per Lam node. Records node→scope membership.
 fn Builder::pass2(
   self : Builder,
   flat_proj : @lambda_proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
-) -> ScopeId {
+) -> Unit {
   let root_scope = self.add_scope(None)
-  // Module defs: one ModuleDef decl per flat def, in the root scope.
   for i, def in flat_proj.defs {
     let (name, _init, _start, binder_id) = def
-    self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
+    let _ = self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
   }
-  // Lambda scopes: walk every node; each Lam opens a child scope binding param.
   fn walk(node : @core.ProjNode[@ast.Term], current : ScopeId) -> Unit {
     self.node_scope[node.id()] = current
     match node.kind {
       @ast.Term::Lam(param, _) => {
-        // The Lam node itself sits in `current` (already recorded above);
-        // its param decl and body live in the new child scope.
         let lam_scope = self.add_scope(Some(current))
-        let _ = self.add_decl(lam_scope, node.id(), param, LamParam(lam_id=node.id()))
+        let _ = self.add_decl(
+          lam_scope, node.id(), param, LamParam(lam_id=node.id()),
+        )
         for child in node.children {
           walk(child, lam_scope)
         }
@@ -326,28 +430,7 @@ fn Builder::pass2(
     }
   }
 
-  for _id, node in registry {
-    // Only walk from the root to keep scope nesting correct; find the root.
-    if node.id() == @core.NodeId(root_node_id(registry)) {
-      walk(node, root_scope)
-    }
-  }
-  root_scope
-}
-
-///|
-/// The registry's root is the node that is no other node's child.
-fn root_node_id(
-  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
-) -> Int {
-  let parents = build_parent_map(registry)
-  let mut found = 0
-  for id, _node in registry {
-    if parents.get(id) is None {
-      found = id.raw()
-    }
-  }
-  found
+  walk(root_node(registry), root_scope)
 }
 
 ///|
@@ -359,7 +442,7 @@ pub fn build(
 ) -> ScopeGraph {
   let _ = source_map // used in Pass 3
   let b = Builder::new()
-  let _root = b.pass2(flat_proj, registry)
+  b.pass2(flat_proj, registry)
   { scopes: b.scopes, decls: b.decls, refs: b.refs }
 }
 ```
@@ -367,7 +450,9 @@ pub fn build(
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: PASS. If the `Show` output for `DeclKind` differs (e.g. spacing), run `moon test -p dowdiness/canopy/lang/lambda/scope --update` to capture the actual snapshot, then read the diff to confirm it matches the intended `ModuleDef(def_index=0)` shape before accepting.
+Expected: PASS. If `Show` of `DeclKind`/`ScopeId` differs in spacing, `--update`
+and confirm the diff matches the intended `ModuleDef(def_index=0)` /
+`ScopeId(0)` shapes before accepting.
 
 - [ ] **Step 5: Commit**
 
@@ -378,76 +463,105 @@ git commit -m "feat(scope): Pass 2 build scopes + decls (module + lambda)"
 
 ---
 
-## Task 4: Builder Pass 3 — resolve refs (with negative observations)
+## Task 4: Builder Pass 3 + declaration() — resolve refs
 
 **Files:**
 - Modify: `lang/lambda/scope/builder.mbt`
+- Create: `lang/lambda/scope/query.mbt`
 - Test: `lang/lambda/scope/graph_wbtest.mbt`
 
-Pass 3 walks every `Var`/`Unbound` node, emits a `Ref`, and resolves it: walk the scope chain from the node's scope upward; at each scope, look for a `Decl` with the matching name **subject to the sequential-module cutoff** (a `ModuleDef` decl is visible to a ref only if the decl's `def_index` is strictly less than the def index the ref sits in, or the ref is in the module body). Record visited scopes that did not contain the name.
+Pass 3 walks every `Var`/`Unbound` node, emits a `Ref`, and resolves it: from the
+node's scope, walk parents upward; in each scope, match a `Decl` by name, with a
+**sequential-module cutoff** — a `ModuleDef` decl is visible to a ref only if its
+`def_index` is strictly less than the def index the ref sits in (body refs see
+all defs). Visited scopes lacking the name are recorded (negative observation).
 
-- [ ] **Step 1: Write the failing tests (the core binding rules)**
+**Before writing the test, verify the Module child layout.** Read
+`lang/lambda/proj/proj_node.mbt:175-260` (the `parse_to_proj_node` /
+`from_proj_node` / Module construction) to confirm: (a) whether a def's init is a
+direct child of the Module ProjNode and at what index, and (b) whether the body
+is the last child. The existing `scope_wbtest.mbt:38` uses
+`proj.children[proj.children.length() - 1]` for the body, so the body-is-last-
+child assumption is already established in the codebase. Use the same access
+pattern; if a def-init finder is needed, derive its position the same way the
+existing tests do.
 
-Add to `lang/lambda/scope/graph_wbtest.mbt`:
+- [ ] **Step 1: Write the failing tests (core binding rules)**
+
+Add to `lang/lambda/scope/graph_wbtest.mbt`. (`find_var_in_body` and
+`find_var_in_def_init` use the verified child layout; if Step's verification
+shows a different layout, adjust these two helpers accordingly.)
 
 ```moonbit
 ///|
-/// Lambda param resolves to its LamParam decl.
+/// Find the Var with `name` in the module body (the final/last child).
+fn find_var_in_body(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId {
+  match root.kind {
+    @ast.Term::Module(_, _) =>
+      find_var_node(root.children[root.children.length() - 1], name)
+    _ => find_var_node(root, name)
+  }
+}
+
+///|
+/// Find the Var with `name` inside the init expression of flat def `idx`.
+/// def inits are the Module's leading children (before the body).
+fn find_var_in_def_init(
+  root : @core.ProjNode[@ast.Term],
+  idx : Int,
+  name : String,
+) -> @core.NodeId {
+  match root.kind {
+    @ast.Term::Module(_, _) => find_var_node(root.children[idx], name)
+    _ => find_var_node(root, name)
+  }
+}
+
+///|
 test "resolve: lambda param" {
-  let src = "\\x. x"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture("\\x. x")
   let g = build(flat_proj, registry, source_map)
-  let var_node = find_var_node(root, "x")
-  let d = declaration(g, var_node)
-  inspect(d is Some(_), content="true")
-  guard d is Some(decl)
+  let var_node = find_var_node(proj, "x")
+  guard declaration(g, var_node) is Some(decl)
   inspect(decl.kind, content="LamParam(lam_id=NodeId(0))")
 }
 
 ///|
-/// Self-reference is unbound: `let x = x` — the inner x sees no preceding x.
 test "resolve: self-reference is unbound" {
-  let src = "let x = x\nx"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture("let x = x\nx")
   let g = build(flat_proj, registry, source_map)
-  // the x in the INIT of def 0 must not resolve to def 0 itself
-  let init_var = find_var_in_def_init(g, root, 0, "x")
-  let d = declaration(g, init_var)
-  inspect(d, content="None")
+  let init_var = find_var_in_def_init(proj, 0, "x")
+  inspect(declaration(g, init_var), content="None")
 }
 
 ///|
-/// Sequential shadowing: `let x = 1; let x = x` — second init binds to first x.
 test "resolve: second def init binds to first def" {
-  let src = "let x = 1\nlet x = x\nx"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = x\nx",
+  )
   let g = build(flat_proj, registry, source_map)
-  let init_var = find_var_in_def_init(g, root, 1, "x")
-  let d = declaration(g, init_var)
-  guard d is Some(decl)
+  let init_var = find_var_in_def_init(proj, 1, "x")
+  guard declaration(g, init_var) is Some(decl)
   inspect(decl.kind, content="ModuleDef(def_index=0)")
 }
 ```
 
-`find_var_node` and `find_var_in_def_init` are test helpers — see "Test helpers" at the end of this plan for exact code.
+Note: `LamParam(lam_id=NodeId(0))` assumes the root Lam has node_id 0. If the
+real parser assigns a different id, `--update` and confirm the captured id is the
+Lam node's id (cross-check via `find` on the projection); the equivalence test in
+Task 8 is the authoritative identity check.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: FAIL — `declaration` not defined, and refs not yet resolved.
+Expected: FAIL — `declaration` not defined; refs unresolved.
 
-- [ ] **Step 3: Write the Pass 3 implementation**
+- [ ] **Step 3: Write Pass 3 in builder.mbt**
 
-Add to `lang/lambda/scope/builder.mbt`, and extend `build` to call it:
+Add to `lang/lambda/scope/builder.mbt` and extend `build`:
 
 ```moonbit
 ///|
@@ -458,14 +572,15 @@ fn Builder::add_ref(
   name : String,
   resolution : Resolution,
 ) -> Unit {
+  let ScopeId(si) = scope
   let id = RefId(self.refs.length())
   self.refs.push({ id, node_id, name, scope, resolution })
-  self.scopes[scope.0].ref_ids.push(id)
+  self.scopes[si].ref_ids.push(id)
 }
 
 ///|
 /// Which flat-def index a node sits within, by source position; returns the
-/// number of defs (a body sentinel) when the node is in the module body.
+/// def count (body sentinel) when the node is in the module body.
 fn containing_def_index(
   flat_proj : @lambda_proj.FlatProj,
   source_map : @core.SourceMap,
@@ -487,9 +602,9 @@ fn containing_def_index(
 }
 
 ///|
-/// Resolve a single ref name from `start_scope` upward. A ModuleDef decl is
-/// visible only if its def_index < cutoff (sequential-module rule). Records
-/// every scope visited that did not contain the name (negative observation).
+/// Resolve `name` from `start_scope` upward. ModuleDef decls are visible only
+/// if def_index < cutoff (sequential rule). Records scopes visited that did
+/// not contain the name (negative observation).
 fn Builder::resolve(
   self : Builder,
   name : String,
@@ -499,16 +614,17 @@ fn Builder::resolve(
   let visited : Array[ScopeId] = []
   let mut cur : ScopeId? = Some(start_scope)
   while cur is Some(sid) {
-    let scope = self.scopes[sid.0]
+    let ScopeId(si) = sid
+    let scope = self.scopes[si]
     let mut hit : DeclId? = None
-    // innermost-match within a scope: later decls win (shadowing); for the
-    // module scope, respect the cutoff.
+    // later decls win within a scope (shadowing); module scope respects cutoff.
     for did in scope.decl_ids {
-      let decl = self.decls[did.0]
+      let DeclId(di) = did
+      let decl = self.decls[di]
       if decl.name == name {
         match decl.kind {
           ModuleDef(def_index~) => if def_index < cutoff { hit = Some(did) }
-          LamParam(..) => hit = Some(did)
+          LamParam(_) => hit = Some(did)
         }
       }
     }
@@ -544,7 +660,7 @@ fn Builder::pass3(
 }
 ```
 
-Replace the body of `build` with:
+Replace the body of `build`:
 
 ```moonbit
 pub fn build(
@@ -553,13 +669,13 @@ pub fn build(
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
   let b = Builder::new()
-  let _root = b.pass2(flat_proj, registry)
+  b.pass2(flat_proj, registry)
   b.pass3(flat_proj, registry, source_map)
   { scopes: b.scopes, decls: b.decls, refs: b.refs }
 }
 ```
 
-- [ ] **Step 4: Write a minimal `declaration` so the tests can run**
+- [ ] **Step 4: Write declaration() in query.mbt**
 
 Create `lang/lambda/scope/query.mbt`:
 
@@ -570,7 +686,10 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
   for r in g.refs {
     if r.node_id == ref_node {
       return match r.resolution.decl {
-        Some(did) => Some(g.decls[did.0])
+        Some(did) => {
+          let DeclId(di) = did
+          Some(g.decls[di])
+        }
         None => None
       }
     }
@@ -582,13 +701,17 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: PASS for all three resolution tests. If `Show` snapshots differ in spacing, `--update` and verify the diff matches the intended values (`LamParam(lam_id=NodeId(0))`, `None`, `ModuleDef(def_index=0)`) before accepting.
+Expected: PASS for all three. If a `Show` snapshot differs, `--update` and verify
+the captured value matches the intended `None` / `ModuleDef(def_index=0)` shape
+(the lambda id is checked authoritatively in Task 8) before accepting. If the
+`self-reference is unbound` test FAILS (the init x resolves to def 0), the cutoff
+logic is wrong — fix `containing_def_index` / `resolve`, do NOT weaken the test.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add lang/lambda/scope/builder.mbt lang/lambda/scope/query.mbt lang/lambda/scope/graph_wbtest.mbt
-git commit -m "feat(scope): Pass 3 resolve refs with sequential cutoff + negative observations"
+git commit -m "feat(scope): Pass 3 resolve refs (sequential cutoff + negative obs) + declaration()"
 ```
 
 ---
@@ -598,30 +721,20 @@ git commit -m "feat(scope): Pass 3 resolve refs with sequential cutoff + negativ
 **Files:**
 - Modify: `lang/lambda/scope/graph_wbtest.mbt`
 
-Pin the remaining binding rules from the spec's Layer 1 list: innermost lambda shadowing, module-def shadowing of body usages, and "later def is not visible to an earlier def".
-
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Write the tests**
 
 Add to `lang/lambda/scope/graph_wbtest.mbt`:
 
 ```moonbit
 ///|
-/// Innermost lambda shadows outer: `\x. \x. x` — inner x binds to inner lam.
 test "resolve: innermost lambda shadowing" {
-  let src = "\\x. \\x. x"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture("\\x. \\x. x")
   let g = build(flat_proj, registry, source_map)
-  let var_node = find_var_node(root, "x")
-  let d = declaration(g, var_node)
-  guard d is Some(decl)
-  // the binder is the INNER lambda — assert it is a LamParam (identity check
-  // is exercised by the equivalence test in Task 8).
+  let var_node = find_var_node(proj, "x")
+  guard declaration(g, var_node) is Some(decl)
   inspect(
     (match decl.kind {
-      LamParam(..) => true
+      LamParam(_) => true
       _ => false
     }),
     content="true",
@@ -629,38 +742,33 @@ test "resolve: innermost lambda shadowing" {
 }
 
 ///|
-/// Body usage resolves to the LATEST preceding def (module shadowing).
 test "resolve: body binds to latest def" {
-  let src = "let x = 1\nlet x = 2\nx"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = 2\nx",
+  )
   let g = build(flat_proj, registry, source_map)
-  let body_var = find_var_in_body(g, root, "x")
-  let d = declaration(g, body_var)
-  guard d is Some(decl)
+  let body_var = find_var_in_body(proj, "x")
+  guard declaration(g, body_var) is Some(decl)
   inspect(decl.kind, content="ModuleDef(def_index=1)")
 }
 
 ///|
-/// A def's init cannot see a LATER def: `let a = b\nlet b = 1` — a's b unbound.
 test "resolve: earlier def cannot see later def" {
-  let src = "let a = b\nlet b = 1\na"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let a = b\nlet b = 1\na",
+  )
   let g = build(flat_proj, registry, source_map)
-  let init_var = find_var_in_def_init(g, root, 0, "b")
+  let init_var = find_var_in_def_init(proj, 0, "b")
   inspect(declaration(g, init_var), content="None")
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail or pass**
+- [ ] **Step 2: Run tests**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: these may already PASS (the Pass 3 logic should handle them). If any FAIL, the resolution logic has a gap — fix `Builder::resolve` / `containing_def_index` until they pass. Do NOT weaken a test to match buggy output; the values above are hand-derived and authoritative (design spec Layer 1).
+Expected: PASS (Pass 3 should already handle them). If any FAIL, fix
+`Builder::resolve` / `containing_def_index` — do NOT weaken a test; the values
+are hand-derived and authoritative (design spec Layer 1).
 
 - [ ] **Step 3: Commit**
 
@@ -675,9 +783,8 @@ git commit -m "test(scope): Layer 1 hand-derived binding edge cases"
 
 **Files:**
 - Modify: `lang/lambda/scope/query.mbt`
+- Modify: `lang/lambda/scope/moon.pkg` (ensure `@immut/hashset` imported)
 - Test: `lang/lambda/scope/graph_wbtest.mbt`
-
-These are reserved API surface (no v1 consumer) but must be correct and tested so later consumer migrations are safe. `references()` is identity-based; `enclosing_env()` returns a set.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -685,16 +792,11 @@ Add to `lang/lambda/scope/graph_wbtest.mbt`:
 
 ```moonbit
 ///|
-/// references() is identity-based: shadowed uses do NOT all collapse to one decl.
 test "references: identity-based, shadowing-aware" {
-  let src = "let x = 1\nlet x = 2\nx"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (_proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = 2\nx",
+  )
   let g = build(flat_proj, registry, source_map)
-  // the body `x` resolves to def 1; references(def1) includes the body x,
-  // references(def0) does NOT (def0 is shadowed for the body).
   let def1 = g.decls[1].node_id
   let def0 = g.decls[0].node_id
   inspect(references(g, def1).length() >= 1, content="true")
@@ -702,15 +804,10 @@ test "references: identity-based, shadowing-aware" {
 }
 
 ///|
-/// enclosing_env() returns lambda-bound names in scope at a node.
 test "enclosing_env: lambda params in scope" {
-  let src = "\\x. \\y. x"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture("\\x. \\y. x")
   let g = build(flat_proj, registry, source_map)
-  let var_node = find_var_node(root, "x")
+  let var_node = find_var_node(proj, "x")
   let env = enclosing_env(g, var_node)
   inspect(env.contains("x"), content="true")
   inspect(env.contains("y"), content="true")
@@ -731,7 +828,10 @@ Add to `lang/lambda/scope/query.mbt`:
 /// All reference NodeIds whose resolution points at the decl at `decl_node`.
 /// Identity-based (NOT a name match), so shadowing is respected.
 /// Reserved API surface; consumer migration deferred (see design spec).
-pub fn references(g : ScopeGraph, decl_node : @core.NodeId) -> Array[@core.NodeId] {
+pub fn references(
+  g : ScopeGraph,
+  decl_node : @core.NodeId,
+) -> Array[@core.NodeId] {
   let mut target : DeclId? = None
   for d in g.decls {
     if d.node_id == decl_node {
@@ -750,15 +850,13 @@ pub fn references(g : ScopeGraph, decl_node : @core.NodeId) -> Array[@core.NodeI
 }
 
 ///|
-/// The set of names bound in scopes enclosing `node` (lambda params + module
-/// defs). Set semantics (membership, not order). Replaces collect_lam_env.
+/// The set of names bound in scopes enclosing `node`. Set semantics
+/// (membership, not order). Replaces collect_lam_env.
 /// Reserved API surface; consumer migration deferred (see design spec).
 pub fn enclosing_env(
   g : ScopeGraph,
   node : @core.NodeId,
 ) -> @immut/hashset.HashSet[String] {
-  let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
-  // find the scope the node sits in via the ref/decl tables
   let mut start : ScopeId? = None
   for r in g.refs {
     if r.node_id == node {
@@ -774,11 +872,14 @@ pub fn enclosing_env(
       }
     }
   }
+  let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let mut cur = start
   while cur is Some(sid) {
-    let scope = g.scopes[sid.0]
+    let ScopeId(si) = sid
+    let scope = g.scopes[si]
     for did in scope.decl_ids {
-      env = env.add(g.decls[did.0].name)
+      let DeclId(di) = did
+      env = env.add(g.decls[di].name)
     }
     cur = scope.parent
   }
@@ -786,7 +887,8 @@ pub fn enclosing_env(
 }
 ```
 
-Add `"moonbitlang/core/immut/hashset"` to the `import` array in `lang/lambda/scope/moon.pkg` if `moon check` reports the `@immut/hashset` path is unresolved.
+Ensure `"moonbitlang/core/immut/hashset" @immut/hashset` is in
+`lang/lambda/scope/moon.pkg` (added in Task 1).
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -802,22 +904,23 @@ git commit -m "feat(scope): reserved query API references() + enclosing_env()"
 
 ---
 
-## Task 7: Generate interfaces + full package check
-
-**Files:**
-- Generated: `lang/lambda/scope/scope.mbti` (or `pkg.generated.mbti`)
+## Task 7: Generate interface + full package check
 
 - [ ] **Step 1: Generate interface + format**
 
-Run: `moon info -p dowdiness/canopy/lang/lambda/scope && moon fmt`
-Expected: a `.mbti` file is generated/updated; formatting applied.
+Run: `moon info && moon fmt`
+Expected: `lang/lambda/scope/scope.mbti` (or `pkg.generated.mbti`) generated;
+formatting applied.
 
 - [ ] **Step 2: Review the generated interface**
 
-Run: `git diff --stat lang/lambda/scope/`
-Read the generated `.mbti`. Confirm the public surface is exactly: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId`, `build`, `declaration`, `references`, `enclosing_env` (plus `build_parent_map`). No accidental internal exposure.
+Run: `git diff --stat lang/lambda/scope/` and read the generated `.mbti`. Confirm
+the public surface is exactly: `ScopeGraph`, `Scope`, `Decl`, `Ref`,
+`Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId`, `build`, `build_parent_map`,
+`declaration`, `references`, `enclosing_env`. No accidental internal exposure
+(`Builder` must stay `priv`).
 
-- [ ] **Step 3: Full workspace check + test**
+- [ ] **Step 3: Full check + test**
 
 Run: `moon check && moon test -p dowdiness/canopy/lang/lambda/scope`
 Expected: no errors; all scope tests pass.
@@ -834,106 +937,167 @@ git commit -m "chore(scope): generate .mbti + format"
 ## Task 8: Layer 3 — migrate rename + equivalence test
 
 **Files:**
-- Modify: `lang/lambda/edits/text_edit_rename.mbt:27` (the `resolve_binder` call in `rename_from_var`)
+- Create: `lang/lambda/edits/scope_equivalence_wbtest.mbt`
 - Modify: `lang/lambda/edits/moon.pkg` (add scope import)
-- Test: `lang/lambda/scope/graph_wbtest.mbt` (equivalence test)
+- Modify: `lang/lambda/edits/text_edit_rename.mbt:105-139` (`rename_from_var`)
 
-The migration swaps `resolve_binder` → `@scope.declaration()` mapped to `BindingSite`. The equivalence test pins that the new path returns the SAME `BindingSite` as the old `resolve_binder` across fixtures (behavior-preserving, bugs included — correctness is Layer 1's job).
+The equivalence test lives in the `edits` package because the production import
+will be edits→scope; putting the test here lets it call both `@scope` and the
+local `resolve_binder` without a cycle.
 
-- [ ] **Step 1: Write the equivalence test FIRST (old still live)**
+- [ ] **Step 1: Add the scope import to edits**
 
-Add to `lang/lambda/scope/graph_wbtest.mbt`:
+In `lang/lambda/edits/moon.pkg`, add `"dowdiness/canopy/lang/lambda/scope" @scope`
+to the `import` block.
+
+Run: `moon check -p dowdiness/canopy/lang/lambda/edits`
+Expected: no errors (import resolves; nothing uses it yet).
+
+- [ ] **Step 2: Write the equivalence test FIRST (old resolve_binder still live)**
+
+Create `lang/lambda/edits/scope_equivalence_wbtest.mbt`. It mirrors the
+construction in `scope_wbtest.mbt` (same package, so `resolve_binder`,
+`FlatProj`, `SourceMap`, `parse_to_proj_node` are in scope without `@scope`).
 
 ```moonbit
 ///|
-/// Map a scope-graph Decl back to the edits-layer BindingSite shape.
-fn decl_to_binding_site(decl : Decl) -> (String, @core.NodeId, Int) {
-  // returns (tag, node_id, def_index) — def_index is -1 for lambda params.
+/// Normalize a scope-graph Decl and an edits BindingSite to a comparable shape.
+/// (tag, node_id, def_index) — def_index is -1 for lambda params.
+fn norm_decl(decl : @scope.Decl) -> (String, NodeId, Int) {
   match decl.kind {
-    LamParam(lam_id~) => ("lam", lam_id, -1)
-    ModuleDef(def_index~) => ("module", decl.node_id, def_index)
+    @scope.LamParam(lam_id~) => ("lam", lam_id, -1)
+    @scope.ModuleDef(def_index~) => ("module", decl.node_id, def_index)
   }
 }
 
 ///|
-/// Equivalence: declaration() agrees with the old resolve_binder on a fixture.
-/// (resolve_binder lives in lang/lambda/edits; this test imports it.)
+fn norm_binder(b : BindingSite) -> (String, NodeId, Int) {
+  match b {
+    LamBinder(lam_id~) => ("lam", lam_id, -1)
+    ModuleBinder(binding_node_id~, def_index~) =>
+      ("module", binding_node_id, def_index)
+  }
+}
+
+///|
+fn eq_fixture(text : String) -> (
+  @core.ProjNode[@ast.Term],
+  FlatProj,
+  Map[NodeId, ProjNode[@ast.Term]],
+  SourceMap,
+) {
+  let (proj, _c) = parse_to_proj_node(text)
+  let fp = FlatProj::from_proj_node(proj)
+  let sm = SourceMap::from_ast(proj)
+  let registry : Map[NodeId, ProjNode[@ast.Term]] = {}
+  @core.collect_registry(proj, registry)
+  (proj, fp, registry, sm)
+}
+
+///|
 test "equivalence: declaration matches resolve_binder (lambda param)" {
-  let src = "\\x. x"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
-  let g = build(flat_proj, registry, source_map)
-  let var_node = find_var_node(root, "x")
-  // new path
-  let new_site = match declaration(g, var_node) {
-    Some(d) => Some(decl_to_binding_site(d))
+  let (proj, fp, registry, sm) = eq_fixture("\\x. x")
+  let g = @scope.build(fp, registry, sm)
+  // the Var "x" is the body of the Lam
+  let var_node = proj.children[0]
+  let new_site = match @scope.declaration(g, var_node.id()) {
+    Some(d) => Some(norm_decl(d))
     None => None
   }
-  // old path
-  let old_site = match @edits.resolve_binder(
-      var_node, "x", flat_proj, registry, source_map,
-    ) {
-    Some(@edits.LamBinder(lam_id~)) => Some(("lam", lam_id, -1))
-    Some(@edits.ModuleBinder(binding_node_id~, def_index~)) =>
-      Some(("module", binding_node_id, def_index))
+  let old_site = match resolve_binder(var_node.id(), "x", fp, registry, sm) {
+    Some(b) => Some(norm_binder(b))
+    None => None
+  }
+  inspect(new_site == old_site, content="true")
+}
+
+///|
+test "equivalence: declaration matches resolve_binder (module def)" {
+  let (proj, fp, registry, sm) = eq_fixture("let x = 0\nx")
+  let g = @scope.build(fp, registry, sm)
+  let body = proj.children[proj.children.length() - 1]
+  let new_site = match @scope.declaration(g, body.id()) {
+    Some(d) => Some(norm_decl(d))
+    None => None
+  }
+  let old_site = match resolve_binder(body.id(), "x", fp, registry, sm) {
+    Some(b) => Some(norm_binder(b))
     None => None
   }
   inspect(new_site == old_site, content="true")
 }
 ```
 
-Note: this test requires the scope test build to import `dowdiness/canopy/lang/lambda/edits`. Add `"dowdiness/canopy/lang/lambda/edits"` to a `test-import` (not `import`, to avoid a production cycle) in `lang/lambda/scope/moon.pkg`. If MoonBit reports a dependency cycle (edits will soon import scope), keep this equivalence test in the `edits` package instead — create `lang/lambda/edits/scope_equivalence_wbtest.mbt` with the same body, importing `@scope`. Decide based on which direction the production import goes (Step 3 makes edits→scope), so the equivalence test belongs in `edits` (test-only use of both is fine there).
+Note: `norm_binder`/`norm_decl` map both shapes to `(tag, NodeId, Int)`. For a
+module def the old `ModuleBinder.binding_node_id` and the new `Decl.node_id`
+should be the SAME FlatProj binding NodeId (both come from `flat_proj.defs[i].3`).
+If the equivalence test fails on the module case because the two NodeIds differ,
+that is a real finding — STOP and report which NodeId each side uses before
+changing either (design spec: where Layer 1 and resolve_binder disagree, file the
+bug; do not paper over).
 
-- [ ] **Step 2: Run the equivalence test (old behavior, new graph)**
+- [ ] **Step 3: Run the equivalence test (old behavior, new graph)**
 
-Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt` (or the edits package if relocated).
-Expected: PASS — both paths return the lambda binder. If FAIL, the graph disagrees with `resolve_binder`; investigate which is right against Layer 1 before changing either.
+Run: `moon test -p dowdiness/canopy/lang/lambda/edits -f scope_equivalence_wbtest.mbt`
+Expected: PASS for both. If FAIL, investigate against Layer 1 before changing
+code.
 
-- [ ] **Step 3: Migrate the consumer**
+- [ ] **Step 4: Migrate the consumer**
 
-In `lang/lambda/edits/moon.pkg`, add `"dowdiness/canopy/lang/lambda/scope"` to `import`.
-
-In `lang/lambda/edits/text_edit_rename.mbt`, replace the `resolve_binder` call in `rename_from_var` (around line 27) with a call through the graph. Build the graph from the same inputs and map `Decl -> BindingSite`:
+Replace `rename_from_var`'s body in `lang/lambda/edits/text_edit_rename.mbt`
+(lines 99-139) so the binder lookup goes through `@scope`. Keep the SAME dispatch
+into `rename_lam_param` / `rename_module_binding` and the SAME error messages:
 
 ```moonbit
-pub fn rename_from_var(
+fn rename_from_var(
+  ctx : EditContext[@ast.Term],
   var_node_id : NodeId,
-  var_name : String,
-  flat_proj : FlatProj,
-  registry : Map[NodeId, ProjNode[@ast.Term]],
-  source_map : SourceMap,
-) -> RenameResult? {
-  let g = @scope.build(flat_proj, registry, source_map)
-  guard @scope.declaration(g, var_node_id) is Some(decl) else { return None }
+  old_name : String,
+  new_name : String,
+) -> Result[(Array[SpanEdit], FocusHint)?, String] {
+  let g = @scope.build(ctx.flat_proj, ctx.registry, ctx.source_map)
+  guard @scope.declaration(g, var_node_id) is Some(decl) else {
+    return Err("No binding found for variable: " + old_name)
+  }
   match decl.kind {
     @scope.LamParam(lam_id~) =>
-      rename_lam_param(lam_id, var_name, registry, source_map)
-    @scope.ModuleDef(def_index~) =>
-      rename_module_binding(
-        decl.node_id,
-        def_index,
-        var_name,
-        flat_proj,
-        registry,
-        source_map,
-      )
+      match ctx.registry.get(lam_id) {
+        Some(lam_node) =>
+          rename_lam_param(ctx, lam_id, lam_node, old_name, new_name)
+        None => Err("Lambda node not found in registry")
+      }
+    @scope.ModuleDef(def_index~) => {
+      let mut module_id : NodeId? = None
+      for pid, pnode in ctx.registry {
+        if pnode.kind is @ast.Term::Module(_, _) {
+          module_id = Some(pid)
+          break
+        }
+      }
+      match module_id {
+        Some(mid) =>
+          rename_module_binding(ctx, mid, def_index, old_name, new_name)
+        None => Err("Module node not found in registry")
+      }
+    }
   }
 }
 ```
 
-Leave `resolve_binder` and the other `resolve_binder` caller (`rename_lam_param`'s internal use, if any) in place — only `rename_from_var`'s binder lookup is migrated in v1 (design spec Non-goals). Do NOT delete `resolve_binder` yet; the equivalence test depends on it.
+Do NOT delete `resolve_binder` — `text_edit_refactor.mbt:143` and
+`scope_wbtest.mbt` still use it, and the equivalence test depends on it (design
+spec Non-goals: only `rename_from_var`'s binder lookup migrates in v1).
 
-- [ ] **Step 4: Run the full rename + scope test suites**
+- [ ] **Step 5: Run the full edits + scope suites**
 
 Run: `moon check && moon test -p dowdiness/canopy/lang/lambda/edits && moon test -p dowdiness/canopy/lang/lambda/scope`
-Expected: all existing `text_edit_rename_test.mbt` tests still PASS (behavior preserved), plus the equivalence test passes.
+Expected: all existing `text_edit*` / `scope_wbtest` tests still PASS (behavior
+preserved), plus the equivalence tests pass.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add lang/lambda/edits/text_edit_rename.mbt lang/lambda/edits/moon.pkg lang/lambda/scope/
+git add lang/lambda/edits/scope_equivalence_wbtest.mbt lang/lambda/edits/moon.pkg lang/lambda/edits/text_edit_rename.mbt
 git commit -m "feat(scope): migrate rename_from_var binder lookup to scope graph (equivalent)"
 ```
 
@@ -943,64 +1107,80 @@ git commit -m "feat(scope): migrate rename_from_var binder lookup to scope graph
 
 **Files:**
 - Create: `lang/lambda/scope/oracle_wbtest.mbt`
-- Modify: `moon.mod.json` (add caimeox dependency) — only if integration is feasible
+- Modify: `moon.mod.json` (add caimeox dependency) — only if integration is clean
 
-This task adds the caimeox scope_graph implementation as a batch oracle. It is sequenced LAST because Layer 1 (correctness) and Layer 3 (migration) are the actual gates; if vendoring caimeox proves heavy, the PoC still ships and this lands as a follow-up. Do NOT block the PoC on it.
+Sequenced LAST: Layer 1 (correctness) + Layer 3 (migration) are the shipping
+gates. If vendoring caimeox is heavy, ship the PoC and land this as follow-up.
 
 - [ ] **Step 1: Assess dependency integration**
 
-Run: `cat moon.mod.json` and check how external MoonBit deps are declared. caimeox/scope_graph is at `https://github.com/caimeox/scope_graph` (Apache-2.0). Determine whether it is mooncakes-published or must be vendored. If neither path is clean in under ~30 min, STOP and report: "Layer 2 oracle deferred to follow-up; Layer 1 + Layer 3 are the shipping gates per design spec." Do not force a fragile dependency.
+Run: `cat moon.mod.json` and inspect the `deps` block. caimeox/scope_graph is at
+`https://github.com/caimeox/scope_graph` (Apache-2.0; module name
+`CAIMEOX/scope_graph`). Determine whether it is mooncakes-published or must be
+vendored. If neither path is clean within ~30 min, STOP and do Step 4's deferred
+path. Do not force a fragile dependency.
 
-- [ ] **Step 2: Write the adapter + one differential test (if dep integrated)**
+- [ ] **Step 2: Write an INDEPENDENT adapter + one differential test (if integrated)**
 
-Create `lang/lambda/scope/oracle_wbtest.mbt`. Write an INDEPENDENT `Term -> @lm.LmProgram` adapter (does NOT route through `builder.mbt`/`query.mbt`), restricted to the shared subset (Var / Lam / App / Module / let-equivalent). For a fixture, build both the canopy graph and the caimeox graph, resolve a chosen reference in each, and assert they agree via a NodeId↔caimeox-index side table:
+Create `lang/lambda/scope/oracle_wbtest.mbt`. Write a `@ast.Term -> @lm.LmProgram`
+adapter that does NOT route through `builder.mbt`/`query.mbt`, restricted to the
+shared subset (Var / Lam / App / Module / let-equivalent). caimeox's API (read
+`/tmp/scope_graph_probe/scope_graph/`): `build_scope_graph(program) -> ScopeGraph`,
+then `ScopeGraph::resolve_ref(ref_id) -> @hashset.HashSet[Int]`. For a fixture,
+resolve a chosen reference in BOTH graphs and compare the resolved def index via a
+side table.
 
 ```moonbit
 ///|
 test "oracle: caimeox agrees on let shadowing (shared subset)" {
-  // build canopy graph
-  let src = "let x = 1\nlet x = 2\nx"
-  let (root, source_map) = build_test_projection(src)
-  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
-  @core.collect_registry(root, registry)
-  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = 2\nx",
+  )
   let g = build(flat_proj, registry, source_map)
-  let body_var = find_var_in_body(g, root, "x")
-  let canopy_def_index = match declaration(g, body_var) {
-    Some(d) => match d.kind { ModuleDef(def_index~) => def_index; _ => -1 }
+  let body_var = find_var_in_body(proj, "x")
+  let canopy_idx = match declaration(g, body_var) {
+    Some(d) =>
+      match d.kind {
+        ModuleDef(def_index~) => def_index
+        _ => -1
+      }
     None => -2
   }
-  // caimeox path: adapt to LmProgram, resolve the corresponding ref,
-  // map its resolved decl back to a def index.
-  // (adapter + resolution omitted here; implement per caimeox API:
-  //  build_scope_graph(program) then resolve_ref(ref_id).)
-  let caimeox_def_index = oracle_resolve_body_x(src)
-  inspect(canopy_def_index == caimeox_def_index, content="true")
+  let caimeox_idx = oracle_resolve_body_x("let x = 1\nlet x = 2\nx")
+  inspect(canopy_idx == caimeox_idx, content="true")
 }
 ```
 
-Implement `oracle_resolve_body_x` using caimeox's `build_scope_graph` + `resolve_ref` (see `/tmp/scope_graph_probe/scope_graph/` for the API: `ScopeGraph::resolve_ref(ref_id) -> HashSet[Int]`). Keep the adapter in this test file only.
+Implement `oracle_resolve_body_x` (adapter + caimeox build/resolve) in this file
+only.
 
 - [ ] **Step 3: Apply the adjudication rule on disagreement**
 
-If caimeox and canopy disagree on a fixture, per the design spec: Layer 1 + Layer 3 win, and the caimeox fixture is REMOVED from the differential set with a one-line comment recording why (documented, not silently dropped).
+If caimeox and canopy disagree on a fixture: per the design spec, Layer 1 + Layer
+3 win; REMOVE the caimeox fixture from the differential set with a one-line
+comment recording why (documented, not silently dropped).
 
-- [ ] **Step 4: Run + commit (if integrated)**
+- [ ] **Step 4: Run + commit (integrated) OR commit deferral note**
 
-Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f oracle_wbtest.mbt`
-Expected: PASS on the shared subset.
+Integrated:
 
 ```bash
+moon test -p dowdiness/canopy/lang/lambda/scope -f oracle_wbtest.mbt
 git add lang/lambda/scope/oracle_wbtest.mbt moon.mod.json
 git commit -m "test(scope): caimeox differential oracle on shared subset"
 ```
 
-If deferred at Step 1, instead commit a stub note:
+Deferred — create `lang/lambda/scope/oracle_wbtest.mbt` containing only a
+top-of-file comment:
+
+```
+// Layer 2 caimeox differential oracle deferred to follow-up — see
+// docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md.
+// Layer 1 (graph_wbtest) + Layer 3 (scope_equivalence_wbtest) are the
+// shipping gates.
+```
 
 ```bash
-# create lang/lambda/scope/oracle_wbtest.mbt with a top comment:
-#   // Layer 2 caimeox oracle deferred to follow-up — see design spec.
-#   // Layer 1 (graph_wbtest) + Layer 3 (equivalence) are the shipping gates.
 git add lang/lambda/scope/oracle_wbtest.mbt
 git commit -m "docs(scope): note Layer 2 oracle deferred to follow-up"
 ```
@@ -1012,91 +1192,54 @@ git commit -m "docs(scope): note Layer 2 oracle deferred to follow-up"
 - [ ] **Step 1: Full workspace gate**
 
 Run: `moon check && moon test && moon fmt && moon info`
-Expected: clean across the workspace; all tests pass.
+Expected: clean across the workspace; all tests pass. (If `moon info` changes any
+`.mbti`, review `git diff *.mbti` for unintended trait-bound widening per
+CLAUDE.md, then commit.)
 
 - [ ] **Step 2: Confirm the migration is real and scoped**
 
 Run: `git diff main --stat`
-Expected: only `lang/lambda/scope/*`, `moon.work`, `lang/lambda/edits/text_edit_rename.mbt`, `lang/lambda/edits/moon.pkg`, and the design spec. No unintended files. Confirm `resolve_binder` still exists (not deleted in v1).
+Expected: only `lang/lambda/scope/*`, `lang/lambda/edits/text_edit_rename.mbt`,
+`lang/lambda/edits/moon.pkg`, `lang/lambda/edits/scope_equivalence_wbtest.mbt`,
+and the design/plan docs. No `moon.work` change. Confirm `resolve_binder` still
+exists (`grep -n 'pub fn resolve_binder' lang/lambda/edits/scope.mbt`).
 
 - [ ] **Step 3: Reuse-check note for the PR**
 
-Confirm in the PR description: `declaration()` reuses the existing `BindingSite` consumer contract; no duplicate types were introduced (checked `@core.NodeId`, `@lambda_proj.FlatProj` reused, not re-defined).
+In the PR description, state: `declaration()` reproduces the existing
+`BindingSite` contract; reused `@core.NodeId`, `@core.ProjNode`,
+`@core.SourceMap`, `@lambda_proj.FlatProj` (no duplicate types introduced).
 
 - [ ] **Step 4: Open the PR**
 
 ```bash
 git push -u origin design/lambda-scope-graph
-gh pr create --title "feat(scope): NodeId-keyed binding index for lambda (v1, rename migrated)" --body "Implements docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md. v1: non-incremental binding index; rename_from_var binder lookup migrated with equivalence test. references()/enclosing_env() reserved. Layer 2 oracle per Task 9 status."
+gh pr create --title "feat(scope): NodeId-keyed binding index for lambda (v1, rename migrated)" --body "$(cat <<'BODY'
+Implements docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md.
+
+v1: non-incremental NodeId-keyed binding index (scope/graph.mbt + builder + query).
+rename_from_var binder lookup migrated to @scope.declaration() with equivalence
+tests proving behavior preservation. references()/enclosing_env() are reserved
+API surface (no v1 consumer). Layer 2 caimeox oracle per Task 9 status.
+
+## Reuse check
+declaration() reproduces the existing BindingSite contract; reused @core.NodeId,
+@core.ProjNode, @core.SourceMap, @lambda_proj.FlatProj — no duplicate types.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
 ```
 
 ---
 
-## Test helpers (copy into the test file that needs them)
+## Self-review notes (carried from spec coverage check)
 
-These mirror the helpers in `lang/lambda/edits/scope_wbtest.mbt`. The scope package's test files need their own copies (test helpers are not exported across packages). Read `lang/lambda/edits/scope_wbtest.mbt:13-` for the canonical `build_test_projection` body and copy it verbatim, adjusting the `@`-aliases to the scope package's imports. The additional finders:
-
-```moonbit
-///|
-/// Find the first Var node with the given name anywhere in the tree.
-fn find_var_node(
-  root : @core.ProjNode[@ast.Term],
-  name : String,
-) -> @core.NodeId {
-  let mut found : @core.NodeId? = None
-  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
-    if found is Some(_) {
-      return
-    }
-    if n.kind is @ast.Term::Var(x) && x == name {
-      found = Some(n.id())
-      return
-    }
-    for c in n.children {
-      walk(c)
-    }
-  }
-  walk(root)
-  found.unwrap()
-}
-
-///|
-/// Find the Var with `name` inside the init expression of flat def `idx`.
-fn find_var_in_def_init(
-  g : ScopeGraph,
-  root : @core.ProjNode[@ast.Term],
-  idx : Int,
-  name : String,
-) -> @core.NodeId {
-  let _ = g
-  // The init of def idx is the Module's child at position idx. Walk into it.
-  match root.kind {
-    @ast.Term::Module(_, _) => {
-      let init = root.children[idx]
-      find_var_node(init, name)
-    }
-    _ => find_var_node(root, name)
-  }
-}
-
-///|
-/// Find the Var with `name` in the module body (the final expression).
-fn find_var_in_body(
-  g : ScopeGraph,
-  root : @core.ProjNode[@ast.Term],
-  name : String,
-) -> @core.NodeId {
-  let _ = g
-  match root.kind {
-    @ast.Term::Module(defs, _) => {
-      // body is the last child (after the def inits)
-      let body = root.children[root.children.length() - 1]
-      let _ = defs
-      find_var_node(body, name)
-    }
-    _ => find_var_node(root, name)
-  }
-}
-```
-
-**Important on `find_var_in_def_init` / `find_var_in_body`:** the exact mapping from `FlatProj.defs[i]` / body to `ProjNode` children depends on how `build_flat_proj` lays out the Module projection. Before relying on `root.children[idx]`, verify the child layout by reading `lang/lambda/proj/flat_proj.mbt:18-` (the `build_flat_proj` body) and `lang/lambda/proj/proj_node.mbt` Module construction. If the body is not the last child, adjust `find_var_in_body` accordingly. This verification is part of Task 4 Step 1 (writing the test) — do it before asserting positions.
+- **Spec §Architecture (3 files):** Tasks 1/3/4/6 (graph, builder, query). ✓
+- **Spec §"Sequential-scope encoding" (cutoff):** Task 4 + Task 5. ✓
+- **Spec §"DeclKind" (BindingSite reconstruction):** Task 1 data model + Task 8 `norm_decl`. ✓
+- **Spec §"Var vs Unbound":** Task 4 Pass 3 emits Ref for both. ✓
+- **Spec §"visited_scopes by-product":** Task 4 `Builder::resolve` records visited. ✓
+- **Spec §Testing Layer 1/2/3:** Tasks 5 / 9 / 8. ✓
+- **Spec §Non-goals (only rename, only declaration):** Task 8 migrates one call; references/enclosing_env reserved (Task 6). ✓
+- **Spec §"acyclic by construction":** relied on in Task 2 `build_parent_map` doc; no runtime cycle guard is implemented in v1 because the tree-derived parent map cannot cycle — if a defensive `fail()` guard is wanted, add it in `root_node`/Pass 2, but it is optional for v1 correctness.

--- a/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
+++ b/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
@@ -58,9 +58,17 @@ trust the *old* assumptions some of these correct:
   `scope_wbtest.mbt:38` reads the body as
   `proj.children[proj.children.length() - 1]`). A pure expression (no defs)
   produces NO Module wrapper — `from_proj_node` returns the bare expr.
-- **parse_to_proj_node:** `@lambda_proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Ref[Int])`.
-  Source: `lang/lambda/proj/proj_node.mbt:315`. The lambda surface syntax uses
-  the **`λ`** character (U+03BB), as in `scope_wbtest.mbt:18` (`"λx. x"`).
+- **parse_to_proj_node:** `@lambda_proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Array[String]) raise @loom/core.LexError`.
+  Source: `lang/lambda/proj/proj_node.mbt:315`. **It is FALLIBLE** (`raise`) and the
+  second tuple element is an `Array[String]` of parse errors, NOT a `Ref[Int]`
+  counter. Verified 2026-05-30 via `moon ide doc parse_to_proj_node`. Inside a
+  `test` block the `raise` auto-propagates (no annotation needed — see
+  `scope_wbtest.mbt:19`), but any standalone `fn` that calls it must declare
+  `raise` in its signature (bare `) raise {`, the repo idiom — see
+  `lang/lambda/semantic/semantic_projection_test.mbt:4,16`). Otherwise MoonBit
+  errors [4122] "Function with error can only be used inside a function with
+  error types in its signature." The lambda surface syntax uses the **`λ`**
+  character (U+03BB), as in `scope_wbtest.mbt:18` (`"λx. x"`).
 - **Existing binder API (the v1 migration target):**
   `pub fn resolve_binder(var_node_id, var_name, flat_proj, registry, source_map) -> BindingSite?`
   where `pub(all) enum BindingSite { LamBinder(lam_id~ : NodeId); ModuleBinder(binding_node_id~ : NodeId, def_index~ : Int) } derive(Debug, Eq)`.
@@ -261,8 +269,8 @@ fn build_fixture(
   @lambda_proj.FlatProj,
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @core.SourceMap,
-) {
-  let (proj, _counter) = @lambda_proj.parse_to_proj_node(text)
+) raise {
+  let (proj, _errs) = @lambda_proj.parse_to_proj_node(text)
   let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
   let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
@@ -674,6 +682,12 @@ fn Builder::resolve(
 
 ///|
 /// Pass 3: emit a Ref for each Var/Unbound node and resolve it.
+/// Invariant: pass2 walks the registry's root tree and records `node_scope`
+/// for every node, and the registry itself is that same tree — so every
+/// Var/Unbound node here has a recorded scope. `node_scope.get(..).unwrap()`
+/// therefore asserts that invariant: a missing scope means the registry held a
+/// node not reachable from root (a structural defect), and a loud abort is
+/// correct — silently defaulting to the root scope would mis-resolve it.
 fn Builder::pass3(
   self : Builder,
   flat_proj : @lambda_proj.FlatProj,
@@ -687,7 +701,7 @@ fn Builder::pass3(
       _ => None
     }
     guard name is Some(n) else { continue }
-    let scope = self.node_scope.get(node.id()).unwrap_or(ScopeId(0))
+    let scope = self.node_scope.get(node.id()).unwrap()
     let cutoff = containing_def_index(flat_proj, source_map, node.id())
     let resolution = self.resolve(n, scope, cutoff)
     self.add_ref(scope, node.id(), n, resolution)
@@ -1015,8 +1029,8 @@ fn norm_binder(b : BindingSite) -> (String, NodeId, Int) {
 /// One equivalence check: declaration() must agree with resolve_binder on the
 /// chosen Var node. Returns true if both sides normalize to the same value
 /// (including both-None).
-fn agree(text : String, locate : (@core.ProjNode[@ast.Term]) -> NodeId) -> Bool {
-  let (proj, _c) = parse_to_proj_node(text)
+fn agree(text : String, locate : (@core.ProjNode[@ast.Term]) -> NodeId) -> Bool raise {
+  let (proj, _errs) = parse_to_proj_node(text)
   let fp = FlatProj::from_proj_node(proj)
   let sm = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
@@ -1077,7 +1091,7 @@ fn find_var(root : @core.ProjNode[@ast.Term], name : String) -> NodeId {
 ///|
 test "equivalence: declaration() matches resolve_binder across all binding rules" {
   // (description, source, locator)
-  inspect(agree("λx. x", root => root.children[0]), content="true") // lam param
+  inspect(agree("λx. x", root => root.children[0].id()), content="true") // lam param (locate returns NodeId, so .id())
   inspect(agree("let x = 0\nx", root => find_var(root, "x")), content="true") // module body
   inspect(agree("let x = x\nx", root => find_var(root, "x")), content="true") // self-ref (first x is init → unbound)
   inspect(agree("let x = 1\nlet x = 2\nx", root => find_var(root, "x")), content="true") // shadowing / latest

--- a/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
+++ b/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
@@ -1,0 +1,1102 @@
+# Lambda Scope Graph (Binding Index) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a NodeId-keyed binding index for the lambda language in a new `lang/lambda/scope/` package, consolidating duplicated name-resolution logic, and migrate `rename`'s binder-resolution onto it with proven equivalence.
+
+**Architecture:** A single batch-built `ScopeGraph` (Scope/Decl/Ref keyed by `core.NodeId`) constructed in three passes from `FlatProj` + registry + `SourceMap`. v1 is non-incremental but correct. The `Resolution` record reserves negative-observation fields (`decl: DeclId?`, `visited_scopes`) for a future incremental layer. Only `declaration()` is wired to a consumer (`rename`) in v1; `references()` / `enclosing_env()` are reserved API surface.
+
+**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap), `dowdiness/canopy/lang/lambda/proj` (FlatProj), `dowdiness/loomlambda/ast` (Term). Tests: `inspect` snapshots + whitebox `*_wbtest.mbt`.
+
+**Design spec:** `docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md` — read it before starting; this plan implements it.
+
+---
+
+## File structure
+
+- `lang/lambda/scope/moon.pkg` — package config (imports core, proj, ast).
+- `lang/lambda/scope/graph.mbt` — data model: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId` + constructors. Language-agnostic except `DeclKind`.
+- `lang/lambda/scope/builder.mbt` — `build(flat_proj, registry, source_map) -> ScopeGraph`: Pass 1 (parent map), Pass 2 (scopes + decls), Pass 3 (resolve refs).
+- `lang/lambda/scope/query.mbt` — `declaration()`, `references()`, `enclosing_env()`.
+- `lang/lambda/scope/graph_wbtest.mbt` — Layer 1 hand-written edge-case tests + Layer 3 equivalence test.
+- `lang/lambda/scope/oracle_wbtest.mbt` — Layer 2 caimeox differential oracle (last task; non-blocking for the PoC gate).
+- `moon.work` — add `lang/lambda/scope` to members.
+- `lang/lambda/edits/text_edit_rename.mbt:27` — migrate the `resolve_binder` call in `rename_from_var` to `@scope.declaration()`.
+
+**Naming note:** the new package's MoonBit module path is `dowdiness/canopy/lang/lambda/scope`; consumers alias it `@scope`. Inside the package, imports are aliased `@core`, `@lambda_proj` (for `dowdiness/canopy/lang/lambda/proj`), `@ast` (for `dowdiness/loomlambda/ast`).
+
+---
+
+## Task 1: Package scaffold + data model
+
+**Files:**
+- Create: `lang/lambda/scope/moon.pkg`
+- Create: `lang/lambda/scope/graph.mbt`
+- Modify: `moon.work` (add member)
+
+- [ ] **Step 1: Create the package config**
+
+Create `lang/lambda/scope/moon.pkg`:
+
+```json
+{
+  "import": [
+    "dowdiness/canopy/core",
+    "dowdiness/canopy/lang/lambda/proj",
+    "dowdiness/loomlambda/ast"
+  ]
+}
+```
+
+- [ ] **Step 2: Register the package in the workspace**
+
+In `moon.work`, add `"lang/lambda/scope"` to the `members` array (place it next to the other `lang/lambda/*` entries). Add it exactly once.
+
+- [ ] **Step 3: Write the data model**
+
+Create `lang/lambda/scope/graph.mbt`:
+
+```moonbit
+///|
+/// Graph-local compact indices. NOT persistent identity — `core.NodeId`
+/// carries persistent identity; these index into the graph's own arrays.
+pub(all) struct ScopeId(Int) derive(Eq, Hash, Compare, Show)
+
+///|
+pub(all) struct DeclId(Int) derive(Eq, Hash, Compare, Show)
+
+///|
+pub(all) struct RefId(Int) derive(Eq, Hash, Compare, Show)
+
+///|
+/// The kind of binding site a declaration represents. This is the one
+/// lambda-specific type in graph.mbt (see design spec). A future loom
+/// lift makes `Decl` generic over this (`Decl[K]`).
+pub(all) enum DeclKind {
+  LamParam(lam_id~ : @core.NodeId)
+  ModuleDef(def_index~ : Int)
+} derive(Eq, Show)
+
+///|
+/// A lexical scope. `parent` is the enclosing scope (None for the root).
+pub(all) struct Scope {
+  id : ScopeId
+  parent : ScopeId?
+  decl_ids : Array[DeclId]
+  ref_ids : Array[RefId]
+} derive(Show)
+
+///|
+/// A declaration (binding site), keyed by the projection NodeId it occupies.
+pub(all) struct Decl {
+  id : DeclId
+  node_id : @core.NodeId
+  name : String
+  scope : ScopeId
+  kind : DeclKind
+} derive(Show)
+
+///|
+/// A reference (use site), keyed by NodeId, with its resolution result.
+pub(all) struct Ref {
+  id : RefId
+  node_id : @core.NodeId
+  name : String
+  scope : ScopeId
+  resolution : Resolution
+} derive(Show)
+
+///|
+/// Resolution outcome for a reference.
+/// `decl: None` is a NEGATIVE OBSERVATION (unresolved / free).
+/// `visited_scopes` records scopes checked and found NOT to contain the
+/// name — populated in v1 as a by-product of the resolution walk, read
+/// only by a future incremental layer (see design spec).
+pub(all) struct Resolution {
+  decl : DeclId?
+  visited_scopes : Array[ScopeId]
+} derive(Show)
+
+///|
+/// The binding index for one lambda module.
+pub(all) struct ScopeGraph {
+  scopes : Array[Scope]
+  decls : Array[Decl]
+  refs : Array[Ref]
+} derive(Show)
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `moon check -p dowdiness/canopy/lang/lambda/scope`
+Expected: no errors (an empty package with only type defs compiles clean).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lang/lambda/scope/moon.pkg lang/lambda/scope/graph.mbt moon.work
+git commit -m "feat(scope): scaffold lang/lambda/scope package + data model"
+```
+
+---
+
+## Task 2: Builder Pass 1 — NodeId → parent map
+
+**Files:**
+- Create: `lang/lambda/scope/builder.mbt`
+- Test: `lang/lambda/scope/graph_wbtest.mbt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lang/lambda/scope/graph_wbtest.mbt`:
+
+```moonbit
+///|
+/// Pass 1: the parent map links each node to its registry parent.
+test "build_parent_map: child maps to parent" {
+  // Build a tiny ProjNode tree by hand: root(id=0) with one child(id=1).
+  let child = @core.ProjNode::new(@ast.Term::Var("x"), 0, 1, 1, [])
+  let root = @core.ProjNode::new(
+    @ast.Term::Lam("x", @ast.Term::Var("x")),
+    0,
+    5,
+    0,
+    [child],
+  )
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let parents = build_parent_map(registry)
+  inspect(parents.get(@core.NodeId(1)), content="Some(NodeId(0))")
+  inspect(parents.get(@core.NodeId(0)), content="None")
+}
+```
+
+Note: if `@core.next_proj_node_id` is not needed, delete the two `counter` lines — they are only a guard against an unused-import warning and the test does not require them.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: FAIL — `build_parent_map` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lang/lambda/scope/builder.mbt`:
+
+```moonbit
+///|
+/// Pass 1: build a `NodeId -> parent NodeId` map by walking the registry's
+/// ProjNode tree. Each node appears in exactly one parent's `children`
+/// array, so the map is acyclic by construction. O(N).
+pub fn build_parent_map(
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> Map[@core.NodeId, @core.NodeId] {
+  let parents : Map[@core.NodeId, @core.NodeId] = {}
+  for _id, node in registry {
+    for child in node.children {
+      parents[child.id()] = node.id()
+    }
+  }
+  parents
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lang/lambda/scope/builder.mbt lang/lambda/scope/graph_wbtest.mbt
+git commit -m "feat(scope): Pass 1 NodeId->parent map (acyclic by construction)"
+```
+
+---
+
+## Task 3: Builder Pass 2 — scopes + decls
+
+**Files:**
+- Modify: `lang/lambda/scope/builder.mbt`
+- Test: `lang/lambda/scope/graph_wbtest.mbt`
+
+This pass creates: one root module scope; one `ModuleDef` decl per `FlatProj.defs` entry (in that scope); and one child scope + `LamParam` decl per `Lam` node (walking the projection tree). Refs are added empty here (Pass 3 fills resolution). We also record, per node, which scope it belongs to, so Pass 3 can find a ref's starting scope.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `lang/lambda/scope/graph_wbtest.mbt`:
+
+```moonbit
+///|
+/// Pass 2: a module with two defs yields one root scope + two ModuleDef decls.
+test "build: module defs become ModuleDef decls in root scope" {
+  let src = "let a = 1\nlet b = 2\nb"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  // two module defs → two decls, both ModuleDef, in the root scope (id 0)
+  inspect(g.decls.length(), content="2")
+  inspect(g.decls[0].kind, content="ModuleDef(def_index=0)")
+  inspect(g.decls[1].kind, content="ModuleDef(def_index=1)")
+  inspect(g.decls[0].scope, content="ScopeId(0)")
+}
+```
+
+`build_test_projection` is the shared test helper used by `lang/lambda/edits/scope_wbtest.mbt`; copy its definition into this test file (see "Test helpers" section at the end of this plan for the exact code).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: FAIL — `build` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `lang/lambda/scope/builder.mbt`:
+
+```moonbit
+///|
+/// Mutable builder state accumulated across passes.
+priv struct Builder {
+  scopes : Array[Scope]
+  decls : Array[Decl]
+  refs : Array[Ref]
+  // node_id -> the scope a node lexically sits in (filled in Pass 2).
+  node_scope : Map[@core.NodeId, ScopeId]
+}
+
+///|
+fn Builder::new() -> Builder {
+  { scopes: [], decls: [], refs: [], node_scope: {} }
+}
+
+///|
+fn Builder::add_scope(self : Builder, parent : ScopeId?) -> ScopeId {
+  let id = ScopeId(self.scopes.length())
+  self.scopes.push({ id, parent, decl_ids: [], ref_ids: [] })
+  id
+}
+
+///|
+fn Builder::add_decl(
+  self : Builder,
+  scope : ScopeId,
+  node_id : @core.NodeId,
+  name : String,
+  kind : DeclKind,
+) -> DeclId {
+  let id = DeclId(self.decls.length())
+  self.decls.push({ id, node_id, name, scope, kind })
+  self.scopes[scope.0].decl_ids.push(id)
+  id
+}
+
+///|
+/// Pass 2: create the root module scope, ModuleDef decls (one per flat def),
+/// and a child LamParam scope per Lam node. Records node→scope membership.
+fn Builder::pass2(
+  self : Builder,
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> ScopeId {
+  let root_scope = self.add_scope(None)
+  // Module defs: one ModuleDef decl per flat def, in the root scope.
+  for i, def in flat_proj.defs {
+    let (name, _init, _start, binder_id) = def
+    self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
+  }
+  // Lambda scopes: walk every node; each Lam opens a child scope binding param.
+  fn walk(node : @core.ProjNode[@ast.Term], current : ScopeId) -> Unit {
+    self.node_scope[node.id()] = current
+    match node.kind {
+      @ast.Term::Lam(param, _) => {
+        // The Lam node itself sits in `current` (already recorded above);
+        // its param decl and body live in the new child scope.
+        let lam_scope = self.add_scope(Some(current))
+        let _ = self.add_decl(lam_scope, node.id(), param, LamParam(lam_id=node.id()))
+        for child in node.children {
+          walk(child, lam_scope)
+        }
+      }
+      _ =>
+        for child in node.children {
+          walk(child, current)
+        }
+    }
+  }
+
+  for _id, node in registry {
+    // Only walk from the root to keep scope nesting correct; find the root.
+    if node.id() == @core.NodeId(root_node_id(registry)) {
+      walk(node, root_scope)
+    }
+  }
+  root_scope
+}
+
+///|
+/// The registry's root is the node that is no other node's child.
+fn root_node_id(
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> Int {
+  let parents = build_parent_map(registry)
+  let mut found = 0
+  for id, _node in registry {
+    if parents.get(id) is None {
+      found = id.raw()
+    }
+  }
+  found
+}
+
+///|
+/// Build the scope graph (Pass 2 only for now; Pass 3 added next task).
+pub fn build(
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  source_map : @core.SourceMap,
+) -> ScopeGraph {
+  let _ = source_map // used in Pass 3
+  let b = Builder::new()
+  let _root = b.pass2(flat_proj, registry)
+  { scopes: b.scopes, decls: b.decls, refs: b.refs }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: PASS. If the `Show` output for `DeclKind` differs (e.g. spacing), run `moon test -p dowdiness/canopy/lang/lambda/scope --update` to capture the actual snapshot, then read the diff to confirm it matches the intended `ModuleDef(def_index=0)` shape before accepting.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lang/lambda/scope/builder.mbt lang/lambda/scope/graph_wbtest.mbt
+git commit -m "feat(scope): Pass 2 build scopes + decls (module + lambda)"
+```
+
+---
+
+## Task 4: Builder Pass 3 — resolve refs (with negative observations)
+
+**Files:**
+- Modify: `lang/lambda/scope/builder.mbt`
+- Test: `lang/lambda/scope/graph_wbtest.mbt`
+
+Pass 3 walks every `Var`/`Unbound` node, emits a `Ref`, and resolves it: walk the scope chain from the node's scope upward; at each scope, look for a `Decl` with the matching name **subject to the sequential-module cutoff** (a `ModuleDef` decl is visible to a ref only if the decl's `def_index` is strictly less than the def index the ref sits in, or the ref is in the module body). Record visited scopes that did not contain the name.
+
+- [ ] **Step 1: Write the failing tests (the core binding rules)**
+
+Add to `lang/lambda/scope/graph_wbtest.mbt`:
+
+```moonbit
+///|
+/// Lambda param resolves to its LamParam decl.
+test "resolve: lambda param" {
+  let src = "\\x. x"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(root, "x")
+  let d = declaration(g, var_node)
+  inspect(d is Some(_), content="true")
+  guard d is Some(decl)
+  inspect(decl.kind, content="LamParam(lam_id=NodeId(0))")
+}
+
+///|
+/// Self-reference is unbound: `let x = x` — the inner x sees no preceding x.
+test "resolve: self-reference is unbound" {
+  let src = "let x = x\nx"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  // the x in the INIT of def 0 must not resolve to def 0 itself
+  let init_var = find_var_in_def_init(g, root, 0, "x")
+  let d = declaration(g, init_var)
+  inspect(d, content="None")
+}
+
+///|
+/// Sequential shadowing: `let x = 1; let x = x` — second init binds to first x.
+test "resolve: second def init binds to first def" {
+  let src = "let x = 1\nlet x = x\nx"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let init_var = find_var_in_def_init(g, root, 1, "x")
+  let d = declaration(g, init_var)
+  guard d is Some(decl)
+  inspect(decl.kind, content="ModuleDef(def_index=0)")
+}
+```
+
+`find_var_node` and `find_var_in_def_init` are test helpers — see "Test helpers" at the end of this plan for exact code.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: FAIL — `declaration` not defined, and refs not yet resolved.
+
+- [ ] **Step 3: Write the Pass 3 implementation**
+
+Add to `lang/lambda/scope/builder.mbt`, and extend `build` to call it:
+
+```moonbit
+///|
+fn Builder::add_ref(
+  self : Builder,
+  scope : ScopeId,
+  node_id : @core.NodeId,
+  name : String,
+  resolution : Resolution,
+) -> Unit {
+  let id = RefId(self.refs.length())
+  self.refs.push({ id, node_id, name, scope, resolution })
+  self.scopes[scope.0].ref_ids.push(id)
+}
+
+///|
+/// Which flat-def index a node sits within, by source position; returns the
+/// number of defs (a body sentinel) when the node is in the module body.
+fn containing_def_index(
+  flat_proj : @lambda_proj.FlatProj,
+  source_map : @core.SourceMap,
+  node_id : @core.NodeId,
+) -> Int {
+  guard source_map.get_range(node_id) is Some(r) else {
+    return flat_proj.defs.length()
+  }
+  let pos = r.start
+  for i, def in flat_proj.defs {
+    let (_n, init, _s, _id) = def
+    if source_map.get_range(init.id()) is Some(dr) &&
+      pos >= dr.start &&
+      pos < dr.end {
+      return i
+    }
+  }
+  flat_proj.defs.length()
+}
+
+///|
+/// Resolve a single ref name from `start_scope` upward. A ModuleDef decl is
+/// visible only if its def_index < cutoff (sequential-module rule). Records
+/// every scope visited that did not contain the name (negative observation).
+fn Builder::resolve(
+  self : Builder,
+  name : String,
+  start_scope : ScopeId,
+  cutoff : Int,
+) -> Resolution {
+  let visited : Array[ScopeId] = []
+  let mut cur : ScopeId? = Some(start_scope)
+  while cur is Some(sid) {
+    let scope = self.scopes[sid.0]
+    let mut hit : DeclId? = None
+    // innermost-match within a scope: later decls win (shadowing); for the
+    // module scope, respect the cutoff.
+    for did in scope.decl_ids {
+      let decl = self.decls[did.0]
+      if decl.name == name {
+        match decl.kind {
+          ModuleDef(def_index~) => if def_index < cutoff { hit = Some(did) }
+          LamParam(..) => hit = Some(did)
+        }
+      }
+    }
+    if hit is Some(_) {
+      return { decl: hit, visited_scopes: visited }
+    }
+    visited.push(sid)
+    cur = scope.parent
+  }
+  { decl: None, visited_scopes: visited }
+}
+
+///|
+/// Pass 3: emit a Ref for each Var/Unbound node and resolve it.
+fn Builder::pass3(
+  self : Builder,
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  source_map : @core.SourceMap,
+) -> Unit {
+  for _id, node in registry {
+    let name = match node.kind {
+      @ast.Term::Var(x) => Some(x)
+      @ast.Term::Unbound(x) => Some(x)
+      _ => None
+    }
+    guard name is Some(n) else { continue }
+    let scope = self.node_scope.get(node.id()).unwrap_or(ScopeId(0))
+    let cutoff = containing_def_index(flat_proj, source_map, node.id())
+    let resolution = self.resolve(n, scope, cutoff)
+    self.add_ref(scope, node.id(), n, resolution)
+  }
+}
+```
+
+Replace the body of `build` with:
+
+```moonbit
+pub fn build(
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  source_map : @core.SourceMap,
+) -> ScopeGraph {
+  let b = Builder::new()
+  let _root = b.pass2(flat_proj, registry)
+  b.pass3(flat_proj, registry, source_map)
+  { scopes: b.scopes, decls: b.decls, refs: b.refs }
+}
+```
+
+- [ ] **Step 4: Write a minimal `declaration` so the tests can run**
+
+Create `lang/lambda/scope/query.mbt`:
+
+```moonbit
+///|
+/// The declaration a reference resolves to, or None if unresolved (free).
+pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
+  for r in g.refs {
+    if r.node_id == ref_node {
+      return match r.resolution.decl {
+        Some(did) => Some(g.decls[did.0])
+        None => None
+      }
+    }
+  }
+  None
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: PASS for all three resolution tests. If `Show` snapshots differ in spacing, `--update` and verify the diff matches the intended values (`LamParam(lam_id=NodeId(0))`, `None`, `ModuleDef(def_index=0)`) before accepting.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lang/lambda/scope/builder.mbt lang/lambda/scope/query.mbt lang/lambda/scope/graph_wbtest.mbt
+git commit -m "feat(scope): Pass 3 resolve refs with sequential cutoff + negative observations"
+```
+
+---
+
+## Task 5: Layer 1 — remaining hand-derived edge cases
+
+**Files:**
+- Modify: `lang/lambda/scope/graph_wbtest.mbt`
+
+Pin the remaining binding rules from the spec's Layer 1 list: innermost lambda shadowing, module-def shadowing of body usages, and "later def is not visible to an earlier def".
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `lang/lambda/scope/graph_wbtest.mbt`:
+
+```moonbit
+///|
+/// Innermost lambda shadows outer: `\x. \x. x` — inner x binds to inner lam.
+test "resolve: innermost lambda shadowing" {
+  let src = "\\x. \\x. x"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(root, "x")
+  let d = declaration(g, var_node)
+  guard d is Some(decl)
+  // the binder is the INNER lambda — assert it is a LamParam (identity check
+  // is exercised by the equivalence test in Task 8).
+  inspect(
+    (match decl.kind {
+      LamParam(..) => true
+      _ => false
+    }),
+    content="true",
+  )
+}
+
+///|
+/// Body usage resolves to the LATEST preceding def (module shadowing).
+test "resolve: body binds to latest def" {
+  let src = "let x = 1\nlet x = 2\nx"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let body_var = find_var_in_body(g, root, "x")
+  let d = declaration(g, body_var)
+  guard d is Some(decl)
+  inspect(decl.kind, content="ModuleDef(def_index=1)")
+}
+
+///|
+/// A def's init cannot see a LATER def: `let a = b\nlet b = 1` — a's b unbound.
+test "resolve: earlier def cannot see later def" {
+  let src = "let a = b\nlet b = 1\na"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let init_var = find_var_in_def_init(g, root, 0, "b")
+  inspect(declaration(g, init_var), content="None")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail or pass**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: these may already PASS (the Pass 3 logic should handle them). If any FAIL, the resolution logic has a gap — fix `Builder::resolve` / `containing_def_index` until they pass. Do NOT weaken a test to match buggy output; the values above are hand-derived and authoritative (design spec Layer 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lang/lambda/scope/graph_wbtest.mbt
+git commit -m "test(scope): Layer 1 hand-derived binding edge cases"
+```
+
+---
+
+## Task 6: Reserved query API — references() + enclosing_env()
+
+**Files:**
+- Modify: `lang/lambda/scope/query.mbt`
+- Test: `lang/lambda/scope/graph_wbtest.mbt`
+
+These are reserved API surface (no v1 consumer) but must be correct and tested so later consumer migrations are safe. `references()` is identity-based; `enclosing_env()` returns a set.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `lang/lambda/scope/graph_wbtest.mbt`:
+
+```moonbit
+///|
+/// references() is identity-based: shadowed uses do NOT all collapse to one decl.
+test "references: identity-based, shadowing-aware" {
+  let src = "let x = 1\nlet x = 2\nx"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  // the body `x` resolves to def 1; references(def1) includes the body x,
+  // references(def0) does NOT (def0 is shadowed for the body).
+  let def1 = g.decls[1].node_id
+  let def0 = g.decls[0].node_id
+  inspect(references(g, def1).length() >= 1, content="true")
+  inspect(references(g, def0).length(), content="0")
+}
+
+///|
+/// enclosing_env() returns lambda-bound names in scope at a node.
+test "enclosing_env: lambda params in scope" {
+  let src = "\\x. \\y. x"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(root, "x")
+  let env = enclosing_env(g, var_node)
+  inspect(env.contains("x"), content="true")
+  inspect(env.contains("y"), content="true")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: FAIL — `references` / `enclosing_env` not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `lang/lambda/scope/query.mbt`:
+
+```moonbit
+///|
+/// All reference NodeIds whose resolution points at the decl at `decl_node`.
+/// Identity-based (NOT a name match), so shadowing is respected.
+/// Reserved API surface; consumer migration deferred (see design spec).
+pub fn references(g : ScopeGraph, decl_node : @core.NodeId) -> Array[@core.NodeId] {
+  let mut target : DeclId? = None
+  for d in g.decls {
+    if d.node_id == decl_node {
+      target = Some(d.id)
+      break
+    }
+  }
+  guard target is Some(tid) else { return [] }
+  let out : Array[@core.NodeId] = []
+  for r in g.refs {
+    if r.resolution.decl is Some(rid) && rid == tid {
+      out.push(r.node_id)
+    }
+  }
+  out
+}
+
+///|
+/// The set of names bound in scopes enclosing `node` (lambda params + module
+/// defs). Set semantics (membership, not order). Replaces collect_lam_env.
+/// Reserved API surface; consumer migration deferred (see design spec).
+pub fn enclosing_env(
+  g : ScopeGraph,
+  node : @core.NodeId,
+) -> @immut/hashset.HashSet[String] {
+  let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
+  // find the scope the node sits in via the ref/decl tables
+  let mut start : ScopeId? = None
+  for r in g.refs {
+    if r.node_id == node {
+      start = Some(r.scope)
+      break
+    }
+  }
+  if start is None {
+    for d in g.decls {
+      if d.node_id == node {
+        start = Some(d.scope)
+        break
+      }
+    }
+  }
+  let mut cur = start
+  while cur is Some(sid) {
+    let scope = g.scopes[sid.0]
+    for did in scope.decl_ids {
+      env = env.add(g.decls[did.0].name)
+    }
+    cur = scope.parent
+  }
+  env
+}
+```
+
+Add `"moonbitlang/core/immut/hashset"` to the `import` array in `lang/lambda/scope/moon.pkg` if `moon check` reports the `@immut/hashset` path is unresolved.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lang/lambda/scope/query.mbt lang/lambda/scope/moon.pkg lang/lambda/scope/graph_wbtest.mbt
+git commit -m "feat(scope): reserved query API references() + enclosing_env()"
+```
+
+---
+
+## Task 7: Generate interfaces + full package check
+
+**Files:**
+- Generated: `lang/lambda/scope/scope.mbti` (or `pkg.generated.mbti`)
+
+- [ ] **Step 1: Generate interface + format**
+
+Run: `moon info -p dowdiness/canopy/lang/lambda/scope && moon fmt`
+Expected: a `.mbti` file is generated/updated; formatting applied.
+
+- [ ] **Step 2: Review the generated interface**
+
+Run: `git diff --stat lang/lambda/scope/`
+Read the generated `.mbti`. Confirm the public surface is exactly: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId`, `build`, `declaration`, `references`, `enclosing_env` (plus `build_parent_map`). No accidental internal exposure.
+
+- [ ] **Step 3: Full workspace check + test**
+
+Run: `moon check && moon test -p dowdiness/canopy/lang/lambda/scope`
+Expected: no errors; all scope tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lang/lambda/scope/
+git commit -m "chore(scope): generate .mbti + format"
+```
+
+---
+
+## Task 8: Layer 3 — migrate rename + equivalence test
+
+**Files:**
+- Modify: `lang/lambda/edits/text_edit_rename.mbt:27` (the `resolve_binder` call in `rename_from_var`)
+- Modify: `lang/lambda/edits/moon.pkg` (add scope import)
+- Test: `lang/lambda/scope/graph_wbtest.mbt` (equivalence test)
+
+The migration swaps `resolve_binder` → `@scope.declaration()` mapped to `BindingSite`. The equivalence test pins that the new path returns the SAME `BindingSite` as the old `resolve_binder` across fixtures (behavior-preserving, bugs included — correctness is Layer 1's job).
+
+- [ ] **Step 1: Write the equivalence test FIRST (old still live)**
+
+Add to `lang/lambda/scope/graph_wbtest.mbt`:
+
+```moonbit
+///|
+/// Map a scope-graph Decl back to the edits-layer BindingSite shape.
+fn decl_to_binding_site(decl : Decl) -> (String, @core.NodeId, Int) {
+  // returns (tag, node_id, def_index) — def_index is -1 for lambda params.
+  match decl.kind {
+    LamParam(lam_id~) => ("lam", lam_id, -1)
+    ModuleDef(def_index~) => ("module", decl.node_id, def_index)
+  }
+}
+
+///|
+/// Equivalence: declaration() agrees with the old resolve_binder on a fixture.
+/// (resolve_binder lives in lang/lambda/edits; this test imports it.)
+test "equivalence: declaration matches resolve_binder (lambda param)" {
+  let src = "\\x. x"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(root, "x")
+  // new path
+  let new_site = match declaration(g, var_node) {
+    Some(d) => Some(decl_to_binding_site(d))
+    None => None
+  }
+  // old path
+  let old_site = match @edits.resolve_binder(
+      var_node, "x", flat_proj, registry, source_map,
+    ) {
+    Some(@edits.LamBinder(lam_id~)) => Some(("lam", lam_id, -1))
+    Some(@edits.ModuleBinder(binding_node_id~, def_index~)) =>
+      Some(("module", binding_node_id, def_index))
+    None => None
+  }
+  inspect(new_site == old_site, content="true")
+}
+```
+
+Note: this test requires the scope test build to import `dowdiness/canopy/lang/lambda/edits`. Add `"dowdiness/canopy/lang/lambda/edits"` to a `test-import` (not `import`, to avoid a production cycle) in `lang/lambda/scope/moon.pkg`. If MoonBit reports a dependency cycle (edits will soon import scope), keep this equivalence test in the `edits` package instead — create `lang/lambda/edits/scope_equivalence_wbtest.mbt` with the same body, importing `@scope`. Decide based on which direction the production import goes (Step 3 makes edits→scope), so the equivalence test belongs in `edits` (test-only use of both is fine there).
+
+- [ ] **Step 2: Run the equivalence test (old behavior, new graph)**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt` (or the edits package if relocated).
+Expected: PASS — both paths return the lambda binder. If FAIL, the graph disagrees with `resolve_binder`; investigate which is right against Layer 1 before changing either.
+
+- [ ] **Step 3: Migrate the consumer**
+
+In `lang/lambda/edits/moon.pkg`, add `"dowdiness/canopy/lang/lambda/scope"` to `import`.
+
+In `lang/lambda/edits/text_edit_rename.mbt`, replace the `resolve_binder` call in `rename_from_var` (around line 27) with a call through the graph. Build the graph from the same inputs and map `Decl -> BindingSite`:
+
+```moonbit
+pub fn rename_from_var(
+  var_node_id : NodeId,
+  var_name : String,
+  flat_proj : FlatProj,
+  registry : Map[NodeId, ProjNode[@ast.Term]],
+  source_map : SourceMap,
+) -> RenameResult? {
+  let g = @scope.build(flat_proj, registry, source_map)
+  guard @scope.declaration(g, var_node_id) is Some(decl) else { return None }
+  match decl.kind {
+    @scope.LamParam(lam_id~) =>
+      rename_lam_param(lam_id, var_name, registry, source_map)
+    @scope.ModuleDef(def_index~) =>
+      rename_module_binding(
+        decl.node_id,
+        def_index,
+        var_name,
+        flat_proj,
+        registry,
+        source_map,
+      )
+  }
+}
+```
+
+Leave `resolve_binder` and the other `resolve_binder` caller (`rename_lam_param`'s internal use, if any) in place — only `rename_from_var`'s binder lookup is migrated in v1 (design spec Non-goals). Do NOT delete `resolve_binder` yet; the equivalence test depends on it.
+
+- [ ] **Step 4: Run the full rename + scope test suites**
+
+Run: `moon check && moon test -p dowdiness/canopy/lang/lambda/edits && moon test -p dowdiness/canopy/lang/lambda/scope`
+Expected: all existing `text_edit_rename_test.mbt` tests still PASS (behavior preserved), plus the equivalence test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lang/lambda/edits/text_edit_rename.mbt lang/lambda/edits/moon.pkg lang/lambda/scope/
+git commit -m "feat(scope): migrate rename_from_var binder lookup to scope graph (equivalent)"
+```
+
+---
+
+## Task 9: Layer 2 — caimeox differential oracle (last; non-blocking)
+
+**Files:**
+- Create: `lang/lambda/scope/oracle_wbtest.mbt`
+- Modify: `moon.mod.json` (add caimeox dependency) — only if integration is feasible
+
+This task adds the caimeox scope_graph implementation as a batch oracle. It is sequenced LAST because Layer 1 (correctness) and Layer 3 (migration) are the actual gates; if vendoring caimeox proves heavy, the PoC still ships and this lands as a follow-up. Do NOT block the PoC on it.
+
+- [ ] **Step 1: Assess dependency integration**
+
+Run: `cat moon.mod.json` and check how external MoonBit deps are declared. caimeox/scope_graph is at `https://github.com/caimeox/scope_graph` (Apache-2.0). Determine whether it is mooncakes-published or must be vendored. If neither path is clean in under ~30 min, STOP and report: "Layer 2 oracle deferred to follow-up; Layer 1 + Layer 3 are the shipping gates per design spec." Do not force a fragile dependency.
+
+- [ ] **Step 2: Write the adapter + one differential test (if dep integrated)**
+
+Create `lang/lambda/scope/oracle_wbtest.mbt`. Write an INDEPENDENT `Term -> @lm.LmProgram` adapter (does NOT route through `builder.mbt`/`query.mbt`), restricted to the shared subset (Var / Lam / App / Module / let-equivalent). For a fixture, build both the canopy graph and the caimeox graph, resolve a chosen reference in each, and assert they agree via a NodeId↔caimeox-index side table:
+
+```moonbit
+///|
+test "oracle: caimeox agrees on let shadowing (shared subset)" {
+  // build canopy graph
+  let src = "let x = 1\nlet x = 2\nx"
+  let (root, source_map) = build_test_projection(src)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let flat_proj = @lambda_proj.build_flat_proj(root, source_map)
+  let g = build(flat_proj, registry, source_map)
+  let body_var = find_var_in_body(g, root, "x")
+  let canopy_def_index = match declaration(g, body_var) {
+    Some(d) => match d.kind { ModuleDef(def_index~) => def_index; _ => -1 }
+    None => -2
+  }
+  // caimeox path: adapt to LmProgram, resolve the corresponding ref,
+  // map its resolved decl back to a def index.
+  // (adapter + resolution omitted here; implement per caimeox API:
+  //  build_scope_graph(program) then resolve_ref(ref_id).)
+  let caimeox_def_index = oracle_resolve_body_x(src)
+  inspect(canopy_def_index == caimeox_def_index, content="true")
+}
+```
+
+Implement `oracle_resolve_body_x` using caimeox's `build_scope_graph` + `resolve_ref` (see `/tmp/scope_graph_probe/scope_graph/` for the API: `ScopeGraph::resolve_ref(ref_id) -> HashSet[Int]`). Keep the adapter in this test file only.
+
+- [ ] **Step 3: Apply the adjudication rule on disagreement**
+
+If caimeox and canopy disagree on a fixture, per the design spec: Layer 1 + Layer 3 win, and the caimeox fixture is REMOVED from the differential set with a one-line comment recording why (documented, not silently dropped).
+
+- [ ] **Step 4: Run + commit (if integrated)**
+
+Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f oracle_wbtest.mbt`
+Expected: PASS on the shared subset.
+
+```bash
+git add lang/lambda/scope/oracle_wbtest.mbt moon.mod.json
+git commit -m "test(scope): caimeox differential oracle on shared subset"
+```
+
+If deferred at Step 1, instead commit a stub note:
+
+```bash
+# create lang/lambda/scope/oracle_wbtest.mbt with a top comment:
+#   // Layer 2 caimeox oracle deferred to follow-up — see design spec.
+#   // Layer 1 (graph_wbtest) + Layer 3 (equivalence) are the shipping gates.
+git add lang/lambda/scope/oracle_wbtest.mbt
+git commit -m "docs(scope): note Layer 2 oracle deferred to follow-up"
+```
+
+---
+
+## Task 10: Final verification + PR prep
+
+- [ ] **Step 1: Full workspace gate**
+
+Run: `moon check && moon test && moon fmt && moon info`
+Expected: clean across the workspace; all tests pass.
+
+- [ ] **Step 2: Confirm the migration is real and scoped**
+
+Run: `git diff main --stat`
+Expected: only `lang/lambda/scope/*`, `moon.work`, `lang/lambda/edits/text_edit_rename.mbt`, `lang/lambda/edits/moon.pkg`, and the design spec. No unintended files. Confirm `resolve_binder` still exists (not deleted in v1).
+
+- [ ] **Step 3: Reuse-check note for the PR**
+
+Confirm in the PR description: `declaration()` reuses the existing `BindingSite` consumer contract; no duplicate types were introduced (checked `@core.NodeId`, `@lambda_proj.FlatProj` reused, not re-defined).
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin design/lambda-scope-graph
+gh pr create --title "feat(scope): NodeId-keyed binding index for lambda (v1, rename migrated)" --body "Implements docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md. v1: non-incremental binding index; rename_from_var binder lookup migrated with equivalence test. references()/enclosing_env() reserved. Layer 2 oracle per Task 9 status."
+```
+
+---
+
+## Test helpers (copy into the test file that needs them)
+
+These mirror the helpers in `lang/lambda/edits/scope_wbtest.mbt`. The scope package's test files need their own copies (test helpers are not exported across packages). Read `lang/lambda/edits/scope_wbtest.mbt:13-` for the canonical `build_test_projection` body and copy it verbatim, adjusting the `@`-aliases to the scope package's imports. The additional finders:
+
+```moonbit
+///|
+/// Find the first Var node with the given name anywhere in the tree.
+fn find_var_node(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId {
+  let mut found : @core.NodeId? = None
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if found is Some(_) {
+      return
+    }
+    if n.kind is @ast.Term::Var(x) && x == name {
+      found = Some(n.id())
+      return
+    }
+    for c in n.children {
+      walk(c)
+    }
+  }
+  walk(root)
+  found.unwrap()
+}
+
+///|
+/// Find the Var with `name` inside the init expression of flat def `idx`.
+fn find_var_in_def_init(
+  g : ScopeGraph,
+  root : @core.ProjNode[@ast.Term],
+  idx : Int,
+  name : String,
+) -> @core.NodeId {
+  let _ = g
+  // The init of def idx is the Module's child at position idx. Walk into it.
+  match root.kind {
+    @ast.Term::Module(_, _) => {
+      let init = root.children[idx]
+      find_var_node(init, name)
+    }
+    _ => find_var_node(root, name)
+  }
+}
+
+///|
+/// Find the Var with `name` in the module body (the final expression).
+fn find_var_in_body(
+  g : ScopeGraph,
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId {
+  let _ = g
+  match root.kind {
+    @ast.Term::Module(defs, _) => {
+      // body is the last child (after the def inits)
+      let body = root.children[root.children.length() - 1]
+      let _ = defs
+      find_var_node(body, name)
+    }
+    _ => find_var_node(root, name)
+  }
+}
+```
+
+**Important on `find_var_in_def_init` / `find_var_in_body`:** the exact mapping from `FlatProj.defs[i]` / body to `ProjNode` children depends on how `build_flat_proj` lays out the Module projection. Before relying on `root.children[idx]`, verify the child layout by reading `lang/lambda/proj/flat_proj.mbt:18-` (the `build_flat_proj` body) and `lang/lambda/proj/proj_node.mbt` Module construction. If the body is not the last child, adjust `find_var_in_body` accordingly. This verification is part of Task 4 Step 1 (writing the test) — do it before asserting positions.

--- a/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
+++ b/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
@@ -4,9 +4,9 @@
 
 **Goal:** Build a NodeId-keyed binding index for the lambda language in a new `lang/lambda/scope/` package, consolidating duplicated name-resolution logic, and migrate `rename`'s binder-resolution onto it with proven equivalence.
 
-**Architecture:** A single batch-built `ScopeGraph` (Scope/Decl/Ref keyed by `core.NodeId`) constructed in three passes from `FlatProj` + registry + `SourceMap`. v1 is non-incremental but correct. The `Resolution` record reserves negative-observation fields (`decl: DeclId?`, `visited_scopes`) for a future incremental layer. Only `declaration()` is wired to a consumer (`rename`) in v1; `references()` / `enclosing_env()` are reserved API surface.
+**Architecture:** A single batch-built `ScopeGraph` (Scope/Decl/Ref keyed by `@core.NodeId`) constructed in three passes from `FlatProj` + registry + `SourceMap`. v1 is non-incremental but correct. The `Resolution` record reserves negative-observation fields (`decl: DeclId?`, `visited_scopes`) for a future incremental layer. Only `declaration()` is wired to a consumer (`rename`) in v1; `references()` / `enclosing_env()` are reserved API surface.
 
-**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap, collect_registry), `dowdiness/canopy/lang/lambda/proj` (FlatProj, parse_to_proj_node), `dowdiness/lambda/ast` (Term). Tests: `inspect` snapshots + whitebox `*_wbtest.mbt`.
+**Tech Stack:** MoonBit; `dowdiness/canopy/core` (NodeId, ProjNode, SourceMap, collect_registry), `dowdiness/canopy/lang/lambda/proj` (FlatProj, parse_to_proj_node — default alias `@proj`), `dowdiness/lambda/ast` (Term, alias `@ast`). Tests: `inspect` on **scalar projections** + whitebox `*_wbtest.mbt`.
 
 **Design spec:** `docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md` — read it before starting; this plan implements it.
 
@@ -14,46 +14,85 @@
 
 ## Verified facts (read these before starting — they fix common wrong guesses)
 
-These were confirmed by reading the code. Do NOT substitute your own guesses:
+Confirmed by reading the code. Do NOT substitute your own guesses, and do NOT
+trust the *old* assumptions some of these correct:
 
-- **AST type:** `@ast.Term` from package `dowdiness/lambda/ast`. Variants:
-  `Int(Int)`, `Var(VarName)`, `Lam(VarName, Term)`, `App(Term, Term)`,
-  `Bop(Bop, Term, Term)`, `If(Term, Term, Term)`,
+- **AST type:** `@ast.Term` from package `dowdiness/lambda/ast` (default alias
+  `@ast`). Variants: `Int(Int)`, `Var(VarName)`, `Lam(VarName, Term)`,
+  `App(Term, Term)`, `Bop(Bop, Term, Term)`, `If(Term, Term, Term)`,
   `Module(Array[(VarName, Term)], Term)`, `Unit`, `Unbound(VarName)`,
-  `Error(String)`, `Hole(Int)`. (`VarName = String`.) Source:
+  `Error(String)`, `Hole(Int)`. (`VarName = String`.) Always match with the
+  type-qualified form `@ast.Term::Var(x)`. Source:
   `loom/examples/lambda/src/ast/ast.mbt:18`.
-- **NodeId:** `pub struct NodeId(Int)` in `dowdiness/canopy/core`; construct via
-  `@core.NodeId::from_int(n)` or pattern `NodeId(n)`. Source: `core/types.mbt:6`.
+- **NodeId:** `pub struct NodeId(Int)` in `@core` (`derive(Debug, Eq, Hash,
+  Compare)`); construct via `@core.NodeId::from_int(n)` or pattern
+  `@core.NodeId(n)`. Source: `core/types.mbt:6`.
 - **ProjNode:** `@core.ProjNode[T]` with `.id() -> NodeId`, `.children`,
   `.kind`, `.start`, `.end`; construct via
   `@core.ProjNode::new(kind, start, end, node_id, children)`. Source:
   `core/proj_node.mbt:7,32`.
 - **Registry walk:** `@core.collect_registry(node, reg)` fills
-  `reg : Map[NodeId, ProjNode[T]]` by walking the tree. Source:
+  `reg : Map[@core.NodeId, @core.ProjNode[T]]` by walking the tree. Source:
   `core/proj_node.mbt:58`.
+- **SourceMap:** lives in `@core`. The accessor is
+  `@core.SourceMap::get_range(node_id) -> @core.Range?` with `.start` / `.end`
+  fields (`core/source_map.mbt:104`). Construct in tests via
+  `@core.SourceMap::from_ast(proj)` — `from_ast` is a `SourceMap` method, so it
+  is `@core.`, NOT `@proj.` (it appears *unqualified* in
+  `lang/lambda/edits/scope_wbtest.mbt:21` only because that package pulls it in
+  via `using`).
 - **FlatProj:** `pub struct FlatProj { defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)]; final_expr : ProjNode[@ast.Term]? }`
-  — the def tuple is `(name, init, start, binding_id)`. Source:
-  `lang/lambda/proj/flat_proj.mbt:5`.
-- **Construction in tests:**
-  `@lambda_proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Ref[Int])`,
-  `@lambda_proj.FlatProj::from_proj_node(proj)`,
-  `@lambda_proj.SourceMap::from_ast(proj)`. Source: `lang/lambda/proj/proj_node.mbt:175,180,251`.
-  Copy the exact call forms + import aliases from
-  `lang/lambda/edits/scope_wbtest.mbt:1-44`.
+  — the def tuple is `(name, init, start, binding_id)`. In `@proj`. Source:
+  `lang/lambda/proj/flat_proj.mbt:5`. Construct via
+  `@proj.FlatProj::from_proj_node(proj)`. **Important id-shape note:**
+  `from_proj_node` sets a def's binding id (`.3`) to the **init child's** id
+  (`flat_proj.mbt:281`), whereas the live editor path (`to_flat_proj`) allocates
+  a *separate* binding id (`flat_proj.mbt:29`). Both the scope graph and
+  `resolve_binder` read `flat_proj.defs[i].3`, so they stay consistent on
+  whatever FlatProj is passed — but tests built with `from_proj_node` exercise
+  the init-child id-shape, while the live path is exercised by Task 8 Step 5's
+  integration tests.
+- **Module ProjNode child layout:** def inits are the Module node's leading
+  children `[0 .. n-1]`; the body is the **last** child
+  (`flat_proj.mbt:251-252,278-285`; the working test
+  `scope_wbtest.mbt:38` reads the body as
+  `proj.children[proj.children.length() - 1]`). A pure expression (no defs)
+  produces NO Module wrapper — `from_proj_node` returns the bare expr.
+- **parse_to_proj_node:** `@proj.parse_to_proj_node(text) -> (ProjNode[@ast.Term], Ref[Int])`.
+  Source: `lang/lambda/proj/proj_node.mbt:315`. The lambda surface syntax uses
+  the **`λ`** character (U+03BB), as in `scope_wbtest.mbt:18` (`"λx. x"`).
 - **Existing binder API (the v1 migration target):**
   `pub fn resolve_binder(var_node_id, var_name, flat_proj, registry, source_map) -> BindingSite?`
-  where `pub(all) enum BindingSite { LamBinder(lam_id~ : NodeId); ModuleBinder(binding_node_id~ : NodeId, def_index~ : Int) }`.
-  Source: `lang/lambda/edits/scope.mbt:3,11`.
+  where `pub(all) enum BindingSite { LamBinder(lam_id~ : NodeId); ModuleBinder(binding_node_id~ : NodeId, def_index~ : Int) } derive(Debug, Eq)`.
+  Its algorithm (mirror it exactly): (1) walk up the registry tree for an
+  enclosing `Lam` binding the name → `LamBinder(lam_id = enclosing-Lam-NodeId)`;
+  (2) else find which def-init range (or body) the var sits in via
+  `source_map.get_range`, then walk def indices **backward** from there, first
+  name match → `ModuleBinder(binding_node_id = flat_proj.defs[i].3, def_index = i)`;
+  (3) else `None`. Source: `lang/lambda/edits/scope.mbt:11-62`.
 - **The one consumer to migrate:** `rename_from_var` in
-  `lang/lambda/edits/text_edit_rename.mbt:99`, which calls `resolve_binder` at
-  line 105 through an `EditContext[T]` bundle:
+  `lang/lambda/edits/text_edit_rename.mbt:99`, calling `resolve_binder` at line
+  105 through an `EditContext[T]` bundle:
   `pub(all) struct EditContext[T] { registry; flat_proj; source_map; language; on_structural_edit }`
-  (source `lang/lambda/edits/text_edit.mbt:32`). It dispatches:
-  `LamBinder(lam_id~) -> rename_lam_param(ctx, lam_id, lam_node, old, new)`,
-  `ModuleBinder(binding_node_id~, def_index~) -> rename_module_binding(ctx, module_id, def_index, old, new)`.
+  (`lang/lambda/edits/text_edit.mbt:7`). It dispatches `LamBinder(lam_id~) ->
+  rename_lam_param(...)`, `ModuleBinder(binding_node_id~, def_index~) ->
+  rename_module_binding(...)`.
+- **`collect_lam_env` semantics:** `lang/lambda/edits/scope.mbt:147` collects
+  **only enclosing Lam parameter names** — it does NOT include module defs. The
+  reserved `enclosing_env` query (Task 6) returns the *full* lexical environment
+  (lam params AND module defs), so it is a **superset**, not a drop-in
+  replacement. Do not claim equivalence.
+- **derive / inspect convention:** this repo uses `derive(Debug, Eq)` (see
+  `BindingSite`), NOT `derive(Show)` (deprecated on container-bearing types).
+  Tests therefore `inspect` only **scalar projections** — bools, ints, strings
+  — never whole structs/enums/Options. Mirror `scope_wbtest.mbt` (it inspects
+  `lam_id == proj.id()` and `def_index`, never the `BindingSite` value).
 - **Workspace:** `moon.work` members do NOT list `lang/*`; the root member `.`
-  already covers `lang/lambda/scope`. **Do NOT edit `moon.work`.** Source:
-  `moon.work`.
+  already covers `lang/lambda/scope`. **Do NOT edit `moon.work`.**
+- **moon.pkg format:** moon.pkg files are **JSON** (`{"import": [...],
+  "warning-list": "..."}`); see `lang/lambda/edits/moon.pkg`. Plain-string
+  imports use the default alias (last path segment, or enough segments to
+  disambiguate — e.g. `moonbitlang/core/immut/hashset` → `@immut/hashset`).
 - **New package module path:** `dowdiness/canopy/lang/lambda/scope`; consumers
   alias it `@scope`.
 
@@ -61,14 +100,14 @@ These were confirmed by reading the code. Do NOT substitute your own guesses:
 
 ## File structure
 
-- `lang/lambda/scope/moon.pkg` — package config (imports core, proj, ast).
+- `lang/lambda/scope/moon.pkg` — JSON package config (imports core, proj, ast, immut/hashset).
 - `lang/lambda/scope/graph.mbt` — data model: `ScopeGraph`, `Scope`, `Decl`, `Ref`, `Resolution`, `DeclKind`, `ScopeId`/`DeclId`/`RefId`. Language-agnostic except `DeclKind`.
 - `lang/lambda/scope/builder.mbt` — `build(...)`: Pass 1 (parent map), Pass 2 (scopes + decls), Pass 3 (resolve refs).
 - `lang/lambda/scope/query.mbt` — `declaration()`, `references()`, `enclosing_env()`.
 - `lang/lambda/scope/graph_wbtest.mbt` — Layer 1 hand tests + test helpers.
 - `lang/lambda/scope/oracle_wbtest.mbt` — Layer 2 caimeox differential oracle (last task; non-blocking).
-- `lang/lambda/edits/scope_equivalence_wbtest.mbt` — Layer 3 equivalence test (lives in `edits` because the production import goes edits→scope; see Task 8).
-- `lang/lambda/edits/text_edit_rename.mbt:105` + `lang/lambda/edits/moon.pkg` — migrate the `rename_from_var` binder lookup to `@scope`.
+- `lang/lambda/edits/scope_equivalence_wbtest.mbt` — Layer 3 equivalence test (lives in `edits` because the production import goes edits→scope).
+- `lang/lambda/edits/text_edit_rename.mbt:99-139` + `lang/lambda/edits/moon.pkg` — migrate the `rename_from_var` binder lookup to `@scope`.
 
 ---
 
@@ -80,50 +119,53 @@ These were confirmed by reading the code. Do NOT substitute your own guesses:
 
 - [ ] **Step 1: Create the package config**
 
-Create `lang/lambda/scope/moon.pkg`:
+Create `lang/lambda/scope/moon.pkg` (JSON; default aliases give `@core`,
+`@proj`, `@ast`, `@immut/hashset`):
 
-```
-import {
-  "dowdiness/canopy/core",
-  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
-  "dowdiness/lambda/ast",
-  "moonbitlang/core/immut/hashset" @immut/hashset,
+```json
+{
+  "import": [
+    "dowdiness/canopy/core",
+    "dowdiness/canopy/lang/lambda/proj",
+    "dowdiness/lambda/ast",
+    "moonbitlang/core/immut/hashset"
+  ],
+  "warning-list": "-2-6-29"
 }
 ```
-
-Note: `dowdiness/lambda/ast` with no explicit alias binds to `@ast` (default
-alias = last path segment), matching how `lang/lambda/edits` uses it.
 
 - [ ] **Step 2: (No moon.work change.)**
 
 Confirm `moon.work` already covers the new package via the root `.` member — do
 NOT add an entry. Verify with: `grep -n 'lang/lambda' moon.work` → expect no
-output (none listed; root covers them).
+output.
 
 - [ ] **Step 3: Write the data model**
 
-Create `lang/lambda/scope/graph.mbt`:
+Create `lang/lambda/scope/graph.mbt`. Newtypes are `Int`-based so `derive` is
+unproblematic; the larger records use `derive(Debug, Eq)` per repo convention
+(no `Show`).
 
 ```moonbit
 ///|
 /// Graph-local compact indices. NOT persistent identity — `@core.NodeId`
 /// carries persistent identity; these index into the graph's own arrays.
-pub(all) struct ScopeId(Int) derive(Eq, Hash, Compare, Show)
+pub(all) struct ScopeId(Int) derive(Debug, Eq, Hash, Compare)
 
 ///|
-pub(all) struct DeclId(Int) derive(Eq, Hash, Compare, Show)
+pub(all) struct DeclId(Int) derive(Debug, Eq, Hash, Compare)
 
 ///|
-pub(all) struct RefId(Int) derive(Eq, Hash, Compare, Show)
+pub(all) struct RefId(Int) derive(Debug, Eq, Hash, Compare)
 
 ///|
-/// The kind of binding site a declaration represents. This is the one
-/// lambda-specific type in graph.mbt (see design spec). A future loom
-/// lift makes `Decl` generic over this (`Decl[K]`).
+/// The kind of binding site a declaration represents. The one lambda-specific
+/// type here (see design spec). A future loom lift makes `Decl` generic over
+/// this (`Decl[K]`).
 pub(all) enum DeclKind {
   LamParam(lam_id~ : @core.NodeId)
   ModuleDef(def_index~ : Int)
-} derive(Eq, Show)
+} derive(Debug, Eq)
 
 ///|
 /// A lexical scope. `parent` is the enclosing scope (None for the root).
@@ -132,7 +174,7 @@ pub(all) struct Scope {
   parent : ScopeId?
   decl_ids : Array[DeclId]
   ref_ids : Array[RefId]
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// A declaration (binding site), keyed by the projection NodeId it occupies.
@@ -142,7 +184,7 @@ pub(all) struct Decl {
   name : String
   scope : ScopeId
   kind : DeclKind
-} derive(Show)
+} derive(Debug, Eq)
 
 ///|
 /// A reference (use site), keyed by NodeId, with its resolution result.
@@ -152,18 +194,18 @@ pub(all) struct Ref {
   name : String
   scope : ScopeId
   resolution : Resolution
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Resolution outcome for a reference.
 /// `decl: None` is a NEGATIVE OBSERVATION (unresolved / free).
 /// `visited_scopes` records scopes checked and found NOT to contain the
-/// name — populated in v1 as a by-product of the resolution walk, read
-/// only by a future incremental layer (see design spec).
+/// name — populated in v1 as a by-product of the resolution walk, read only
+/// by a future incremental layer (see design spec).
 pub(all) struct Resolution {
   decl : DeclId?
   visited_scopes : Array[ScopeId]
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// The binding index for one lambda module.
@@ -171,15 +213,14 @@ pub(all) struct ScopeGraph {
   scopes : Array[Scope]
   decls : Array[Decl]
   refs : Array[Ref]
-} derive(Show)
+} derive(Debug)
 ```
 
 - [ ] **Step 4: Verify it compiles**
 
 Run: `moon check -p dowdiness/canopy/lang/lambda/scope`
-Expected: no errors. If `@immut/hashset` is reported unused, that is fine for now
-(it is used in Task 6); suppress with `warnings = "-2-6-29"` in `moon.pkg` matching
-the `edits` package, OR leave the import out until Task 6 and add it there.
+Expected: no errors. `@immut/hashset` is used in Task 6; the `-2-6-29`
+warning-list suppresses the interim unused-import warning.
 
 - [ ] **Step 5: Commit**
 
@@ -196,27 +237,30 @@ git commit -m "feat(scope): scaffold lang/lambda/scope package + data model"
 - Create: `lang/lambda/scope/builder.mbt`
 - Create: `lang/lambda/scope/graph_wbtest.mbt`
 
+> **Test-assertion rule (applies to every test in this plan):** `inspect` only
+> scalar projections (bool / int / string). Never `inspect` a struct, enum, or
+> Option whole — the types derive `Debug`, not `Show`. To check an enum variant,
+> use `x is Variant(_)` (a bool) or destructure with `guard ... is Variant(f~)`
+> then inspect `f`. To check a newtype, destructure: `let ScopeId(n) = s`.
+
 - [ ] **Step 1: Write the test helpers + first failing test**
 
-Create `lang/lambda/scope/graph_wbtest.mbt`. The construction trio mirrors
-`lang/lambda/edits/scope_wbtest.mbt` exactly — read that file (lines 1-44) and
-copy the call forms.
+Create `lang/lambda/scope/graph_wbtest.mbt`:
 
 ```moonbit
 ///|
-/// Build (proj, flat_proj, registry, source_map) from source — mirrors the
-/// construction in lang/lambda/edits/scope_wbtest.mbt.
+/// Build (proj, flat_proj, registry, source_map) from source.
 fn build_fixture(
   text : String,
 ) -> (
   @core.ProjNode[@ast.Term],
-  @lambda_proj.FlatProj,
+  @proj.FlatProj,
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @core.SourceMap,
 ) {
-  let (proj, _counter) = @lambda_proj.parse_to_proj_node(text)
-  let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
-  let source_map = @lambda_proj.SourceMap::from_ast(proj)
+  let (proj, _counter) = @proj.parse_to_proj_node(text)
+  let flat_proj = @proj.FlatProj::from_proj_node(proj)
+  let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(proj, registry)
   (proj, flat_proj, registry, source_map)
@@ -260,8 +304,10 @@ test "build_parent_map: child maps to parent" {
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(root, registry)
   let parents = build_parent_map(registry)
-  inspect(parents.get(@core.NodeId::from_int(1)), content="Some(NodeId(0))")
-  inspect(parents.get(@core.NodeId::from_int(0)), content="None")
+  inspect(parents.get(@core.NodeId::from_int(1)) is Some(_), content="true")
+  guard parents.get(@core.NodeId::from_int(1)) is Some(p)
+  inspect(p == @core.NodeId::from_int(0), content="true")
+  inspect(parents.get(@core.NodeId::from_int(0)) is None, content="true")
 }
 ```
 
@@ -295,9 +341,7 @@ pub fn build_parent_map(
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: PASS. If the `Show` of `Option[NodeId]` differs from
-`Some(NodeId(0))`, run with `--update` and confirm the captured value is the
-NodeId(0)/None shape before accepting.
+Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -316,8 +360,8 @@ git commit -m "feat(scope): test helpers + Pass 1 NodeId->parent map"
 
 Pass 2 creates: one root module scope; one `ModuleDef` decl per `FlatProj.defs`
 entry (in the root scope); one child scope + `LamParam` decl per `Lam` node
-(walking the projection tree from the root). It records, per node, which scope it
-lexically sits in, so Pass 3 can find a ref's starting scope.
+(walking the projection tree). It records, per node, which scope it lexically
+sits in, so Pass 3 can find a ref's starting scope.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -331,9 +375,12 @@ test "build: module defs become ModuleDef decls in root scope" {
   )
   let g = build(flat_proj, registry, source_map)
   inspect(g.decls.length(), content="2")
-  inspect(g.decls[0].kind, content="ModuleDef(def_index=0)")
-  inspect(g.decls[1].kind, content="ModuleDef(def_index=1)")
-  inspect(g.decls[0].scope, content="ScopeId(0)")
+  guard g.decls[0].kind is ModuleDef(def_index=d0)
+  inspect(d0, content="0")
+  guard g.decls[1].kind is ModuleDef(def_index=d1)
+  inspect(d1, content="1")
+  let ScopeId(s0) = g.decls[0].scope
+  inspect(s0, content="0")
 }
 ```
 
@@ -403,7 +450,7 @@ fn root_node(
 /// LamParam scope per Lam node. Records node→scope membership.
 fn Builder::pass2(
   self : Builder,
-  flat_proj : @lambda_proj.FlatProj,
+  flat_proj : @proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
 ) -> Unit {
   let root_scope = self.add_scope(None)
@@ -436,7 +483,7 @@ fn Builder::pass2(
 ///|
 /// Build the scope graph (Pass 2 only for now; Pass 3 added next task).
 pub fn build(
-  flat_proj : @lambda_proj.FlatProj,
+  flat_proj : @proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
@@ -450,9 +497,7 @@ pub fn build(
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: PASS. If `Show` of `DeclKind`/`ScopeId` differs in spacing, `--update`
-and confirm the diff matches the intended `ModuleDef(def_index=0)` /
-`ScopeId(0)` shapes before accepting.
+Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -474,23 +519,12 @@ Pass 3 walks every `Var`/`Unbound` node, emits a `Ref`, and resolves it: from th
 node's scope, walk parents upward; in each scope, match a `Decl` by name, with a
 **sequential-module cutoff** — a `ModuleDef` decl is visible to a ref only if its
 `def_index` is strictly less than the def index the ref sits in (body refs see
-all defs). Visited scopes lacking the name are recorded (negative observation).
-
-**Before writing the test, verify the Module child layout.** Read
-`lang/lambda/proj/proj_node.mbt:175-260` (the `parse_to_proj_node` /
-`from_proj_node` / Module construction) to confirm: (a) whether a def's init is a
-direct child of the Module ProjNode and at what index, and (b) whether the body
-is the last child. The existing `scope_wbtest.mbt:38` uses
-`proj.children[proj.children.length() - 1]` for the body, so the body-is-last-
-child assumption is already established in the codebase. Use the same access
-pattern; if a def-init finder is needed, derive its position the same way the
-existing tests do.
+all defs). This mirrors `resolve_binder`'s backward walk exactly (Verified facts).
+Visited scopes lacking the name are recorded (negative observation).
 
 - [ ] **Step 1: Write the failing tests (core binding rules)**
 
-Add to `lang/lambda/scope/graph_wbtest.mbt`. (`find_var_in_body` and
-`find_var_in_def_init` use the verified child layout; if Step's verification
-shows a different layout, adjust these two helpers accordingly.)
+Add to `lang/lambda/scope/graph_wbtest.mbt`:
 
 ```moonbit
 ///|
@@ -522,11 +556,11 @@ fn find_var_in_def_init(
 
 ///|
 test "resolve: lambda param" {
-  let (proj, flat_proj, registry, source_map) = build_fixture("\\x. x")
+  let (proj, flat_proj, registry, source_map) = build_fixture("λx. x")
   let g = build(flat_proj, registry, source_map)
   let var_node = find_var_node(proj, "x")
   guard declaration(g, var_node) is Some(decl)
-  inspect(decl.kind, content="LamParam(lam_id=NodeId(0))")
+  inspect(decl.kind is LamParam(_), content="true")
 }
 
 ///|
@@ -534,7 +568,7 @@ test "resolve: self-reference is unbound" {
   let (proj, flat_proj, registry, source_map) = build_fixture("let x = x\nx")
   let g = build(flat_proj, registry, source_map)
   let init_var = find_var_in_def_init(proj, 0, "x")
-  inspect(declaration(g, init_var), content="None")
+  inspect(declaration(g, init_var) is None, content="true")
 }
 
 ///|
@@ -545,14 +579,10 @@ test "resolve: second def init binds to first def" {
   let g = build(flat_proj, registry, source_map)
   let init_var = find_var_in_def_init(proj, 1, "x")
   guard declaration(g, init_var) is Some(decl)
-  inspect(decl.kind, content="ModuleDef(def_index=0)")
+  guard decl.kind is ModuleDef(def_index~)
+  inspect(def_index, content="0")
 }
 ```
-
-Note: `LamParam(lam_id=NodeId(0))` assumes the root Lam has node_id 0. If the
-real parser assigns a different id, `--update` and confirm the captured id is the
-Lam node's id (cross-check via `find` on the projection); the equivalence test in
-Task 8 is the authoritative identity check.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -580,9 +610,10 @@ fn Builder::add_ref(
 
 ///|
 /// Which flat-def index a node sits within, by source position; returns the
-/// def count (body sentinel) when the node is in the module body.
+/// def count (body sentinel) when the node is in the module body. Mirrors
+/// resolve_binder's def-range containment (scope.mbt:30-39).
 fn containing_def_index(
-  flat_proj : @lambda_proj.FlatProj,
+  flat_proj : @proj.FlatProj,
   source_map : @core.SourceMap,
   node_id : @core.NodeId,
 ) -> Int {
@@ -641,7 +672,7 @@ fn Builder::resolve(
 /// Pass 3: emit a Ref for each Var/Unbound node and resolve it.
 fn Builder::pass3(
   self : Builder,
-  flat_proj : @lambda_proj.FlatProj,
+  flat_proj : @proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> Unit {
@@ -664,7 +695,7 @@ Replace the body of `build`:
 
 ```moonbit
 pub fn build(
-  flat_proj : @lambda_proj.FlatProj,
+  flat_proj : @proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
@@ -701,11 +732,10 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
-Expected: PASS for all three. If a `Show` snapshot differs, `--update` and verify
-the captured value matches the intended `None` / `ModuleDef(def_index=0)` shape
-(the lambda id is checked authoritatively in Task 8) before accepting. If the
-`self-reference is unbound` test FAILS (the init x resolves to def 0), the cutoff
-logic is wrong — fix `containing_def_index` / `resolve`, do NOT weaken the test.
+Expected: PASS for all three. If `resolve: self-reference is unbound` FAILS (the
+init x resolves to def 0), the cutoff logic is wrong — fix
+`containing_def_index` / `resolve`, do NOT weaken the test (the values are
+hand-derived per the design spec Layer 1).
 
 - [ ] **Step 6: Commit**
 
@@ -728,17 +758,11 @@ Add to `lang/lambda/scope/graph_wbtest.mbt`:
 ```moonbit
 ///|
 test "resolve: innermost lambda shadowing" {
-  let (proj, flat_proj, registry, source_map) = build_fixture("\\x. \\x. x")
+  let (proj, flat_proj, registry, source_map) = build_fixture("λx. λx. x")
   let g = build(flat_proj, registry, source_map)
   let var_node = find_var_node(proj, "x")
   guard declaration(g, var_node) is Some(decl)
-  inspect(
-    (match decl.kind {
-      LamParam(_) => true
-      _ => false
-    }),
-    content="true",
-  )
+  inspect(decl.kind is LamParam(_), content="true")
 }
 
 ///|
@@ -749,7 +773,8 @@ test "resolve: body binds to latest def" {
   let g = build(flat_proj, registry, source_map)
   let body_var = find_var_in_body(proj, "x")
   guard declaration(g, body_var) is Some(decl)
-  inspect(decl.kind, content="ModuleDef(def_index=1)")
+  guard decl.kind is ModuleDef(def_index~)
+  inspect(def_index, content="1")
 }
 
 ///|
@@ -759,7 +784,7 @@ test "resolve: earlier def cannot see later def" {
   )
   let g = build(flat_proj, registry, source_map)
   let init_var = find_var_in_def_init(proj, 0, "b")
-  inspect(declaration(g, init_var), content="None")
+  inspect(declaration(g, init_var) is None, content="true")
 }
 ```
 
@@ -767,8 +792,7 @@ test "resolve: earlier def cannot see later def" {
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
 Expected: PASS (Pass 3 should already handle them). If any FAIL, fix
-`Builder::resolve` / `containing_def_index` — do NOT weaken a test; the values
-are hand-derived and authoritative (design spec Layer 1).
+`Builder::resolve` / `containing_def_index` — do NOT weaken a test.
 
 - [ ] **Step 3: Commit**
 
@@ -783,7 +807,6 @@ git commit -m "test(scope): Layer 1 hand-derived binding edge cases"
 
 **Files:**
 - Modify: `lang/lambda/scope/query.mbt`
-- Modify: `lang/lambda/scope/moon.pkg` (ensure `@immut/hashset` imported)
 - Test: `lang/lambda/scope/graph_wbtest.mbt`
 
 - [ ] **Step 1: Write the failing tests**
@@ -805,7 +828,7 @@ test "references: identity-based, shadowing-aware" {
 
 ///|
 test "enclosing_env: lambda params in scope" {
-  let (proj, flat_proj, registry, source_map) = build_fixture("\\x. \\y. x")
+  let (proj, flat_proj, registry, source_map) = build_fixture("λx. λy. x")
   let g = build(flat_proj, registry, source_map)
   let var_node = find_var_node(proj, "x")
   let env = enclosing_env(g, var_node)
@@ -850,8 +873,10 @@ pub fn references(
 }
 
 ///|
-/// The set of names bound in scopes enclosing `node`. Set semantics
-/// (membership, not order). Replaces collect_lam_env.
+/// The set of names bound in scopes enclosing `node` — the FULL lexical
+/// environment (lambda params AND module defs). This is a SUPERSET of the
+/// existing `collect_lam_env` (which returns only lambda params); it is NOT a
+/// drop-in replacement. Set semantics (membership, not order).
 /// Reserved API surface; consumer migration deferred (see design spec).
 pub fn enclosing_env(
   g : ScopeGraph,
@@ -887,9 +912,6 @@ pub fn enclosing_env(
 }
 ```
 
-Ensure `"moonbitlang/core/immut/hashset" @immut/hashset` is in
-`lang/lambda/scope/moon.pkg` (added in Task 1).
-
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/scope -f graph_wbtest.mbt`
@@ -898,7 +920,7 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add lang/lambda/scope/query.mbt lang/lambda/scope/moon.pkg lang/lambda/scope/graph_wbtest.mbt
+git add lang/lambda/scope/query.mbt lang/lambda/scope/graph_wbtest.mbt
 git commit -m "feat(scope): reserved query API references() + enclosing_env()"
 ```
 
@@ -939,30 +961,36 @@ git commit -m "chore(scope): generate .mbti + format"
 **Files:**
 - Create: `lang/lambda/edits/scope_equivalence_wbtest.mbt`
 - Modify: `lang/lambda/edits/moon.pkg` (add scope import)
-- Modify: `lang/lambda/edits/text_edit_rename.mbt:105-139` (`rename_from_var`)
+- Modify: `lang/lambda/edits/text_edit_rename.mbt:99-139` (`rename_from_var`)
 
-The equivalence test lives in the `edits` package because the production import
-will be edits→scope; putting the test here lets it call both `@scope` and the
-local `resolve_binder` without a cycle.
+The equivalence test lives in the `edits` package: the production import will be
+edits→scope, and `edits` already brings `resolve_binder`, `FlatProj`,
+`SourceMap`, `parse_to_proj_node`, `NodeId` into bare scope (via `using`) and
+provides the `scope_test_registry` helper (`scope_wbtest.mbt:2`). Reuse those.
 
 - [ ] **Step 1: Add the scope import to edits**
 
-In `lang/lambda/edits/moon.pkg`, add `"dowdiness/canopy/lang/lambda/scope" @scope`
-to the `import` block.
+In `lang/lambda/edits/moon.pkg` (JSON), add
+`"dowdiness/canopy/lang/lambda/scope"` to the `"import"` array. (Default alias
+`@scope`.)
 
 Run: `moon check -p dowdiness/canopy/lang/lambda/edits`
-Expected: no errors (import resolves; nothing uses it yet).
+Expected: no errors (import resolves; nothing uses it yet — `-2-6-29`
+suppresses the unused-import warning).
 
-- [ ] **Step 2: Write the equivalence test FIRST (old resolve_binder still live)**
+- [ ] **Step 2: Write the table-driven equivalence test FIRST (old resolve_binder still live)**
 
-Create `lang/lambda/edits/scope_equivalence_wbtest.mbt`. It mirrors the
-construction in `scope_wbtest.mbt` (same package, so `resolve_binder`,
-`FlatProj`, `SourceMap`, `parse_to_proj_node` are in scope without `@scope`).
+Create `lang/lambda/edits/scope_equivalence_wbtest.mbt`. It covers EVERY Layer-1
+binding rule, so the migration in Step 4 is proven safe across self-refs, later
+defs, shadowing, and free refs (not just the two happy paths). Bare names
+(`parse_to_proj_node`, `FlatProj`, `SourceMap`, `NodeId`, `scope_test_registry`,
+`BindingSite`, `resolve_binder`) resolve in the `edits` package; only the new
+package is qualified `@scope`.
 
 ```moonbit
 ///|
-/// Normalize a scope-graph Decl and an edits BindingSite to a comparable shape.
-/// (tag, node_id, def_index) — def_index is -1 for lambda params.
+/// Normalize a scope-graph Decl to (tag, node_id, def_index); def_index = -1
+/// for lambda params.
 fn norm_decl(decl : @scope.Decl) -> (String, NodeId, Int) {
   match decl.kind {
     @scope.LamParam(lam_id~) => ("lam", lam_id, -1)
@@ -971,6 +999,7 @@ fn norm_decl(decl : @scope.Decl) -> (String, NodeId, Int) {
 }
 
 ///|
+/// Normalize an edits BindingSite to the same shape.
 fn norm_binder(b : BindingSite) -> (String, NodeId, Int) {
   match b {
     LamBinder(lam_id~) => ("lam", lam_id, -1)
@@ -980,67 +1009,93 @@ fn norm_binder(b : BindingSite) -> (String, NodeId, Int) {
 }
 
 ///|
-fn eq_fixture(text : String) -> (
-  @core.ProjNode[@ast.Term],
-  FlatProj,
-  Map[NodeId, ProjNode[@ast.Term]],
-  SourceMap,
-) {
+/// One equivalence check: declaration() must agree with resolve_binder on the
+/// chosen Var node. Returns true if both sides normalize to the same value
+/// (including both-None).
+fn agree(text : String, locate : (@core.ProjNode[@ast.Term]) -> NodeId) -> Bool {
   let (proj, _c) = parse_to_proj_node(text)
   let fp = FlatProj::from_proj_node(proj)
   let sm = SourceMap::from_ast(proj)
-  let registry : Map[NodeId, ProjNode[@ast.Term]] = {}
-  @core.collect_registry(proj, registry)
-  (proj, fp, registry, sm)
-}
-
-///|
-test "equivalence: declaration matches resolve_binder (lambda param)" {
-  let (proj, fp, registry, sm) = eq_fixture("\\x. x")
+  let registry = scope_test_registry(proj)
   let g = @scope.build(fp, registry, sm)
-  // the Var "x" is the body of the Lam
-  let var_node = proj.children[0]
-  let new_site = match @scope.declaration(g, var_node.id()) {
+  let var_id = locate(proj)
+  let new_site = match @scope.declaration(g, var_id) {
     Some(d) => Some(norm_decl(d))
     None => None
   }
-  let old_site = match resolve_binder(var_node.id(), "x", fp, registry, sm) {
+  let old_site = match resolve_binder(var_id, var_name_of(proj, var_id), fp, registry, sm) {
     Some(b) => Some(norm_binder(b))
     None => None
   }
-  inspect(new_site == old_site, content="true")
+  new_site == old_site
 }
 
 ///|
-test "equivalence: declaration matches resolve_binder (module def)" {
-  let (proj, fp, registry, sm) = eq_fixture("let x = 0\nx")
-  let g = @scope.build(fp, registry, sm)
-  let body = proj.children[proj.children.length() - 1]
-  let new_site = match @scope.declaration(g, body.id()) {
-    Some(d) => Some(norm_decl(d))
-    None => None
+/// Look up the Var name at a NodeId (resolve_binder needs the name string).
+fn var_name_of(root : @core.ProjNode[@ast.Term], id : NodeId) -> String {
+  let mut out = ""
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if n.id() == id {
+      match n.kind {
+        @ast.Term::Var(x) => out = x
+        @ast.Term::Unbound(x) => out = x
+        _ => ()
+      }
+    }
+    for c in n.children {
+      walk(c)
+    }
   }
-  let old_site = match resolve_binder(body.id(), "x", fp, registry, sm) {
-    Some(b) => Some(norm_binder(b))
-    None => None
+
+  walk(root)
+  out
+}
+
+///|
+/// Find first Var named `name` (helper for locators).
+fn find_var(root : @core.ProjNode[@ast.Term], name : String) -> NodeId {
+  let mut found : NodeId? = None
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if found is Some(_) {
+      return
+    }
+    if n.kind is @ast.Term::Var(x) && x == name {
+      found = Some(n.id())
+    }
+    for c in n.children {
+      walk(c)
+    }
   }
-  inspect(new_site == old_site, content="true")
+
+  walk(root)
+  found.unwrap()
+}
+
+///|
+test "equivalence: declaration() matches resolve_binder across all binding rules" {
+  // (description, source, locator)
+  inspect(agree("λx. x", root => root.children[0]), content="true") // lam param
+  inspect(agree("let x = 0\nx", root => find_var(root, "x")), content="true") // module body
+  inspect(agree("let x = x\nx", root => find_var(root, "x")), content="true") // self-ref (first x is init → unbound)
+  inspect(agree("let x = 1\nlet x = 2\nx", root => find_var(root, "x")), content="true") // shadowing / latest
+  inspect(agree("let a = b\nlet b = 1\na", root => find_var(root, "b")), content="true") // earlier can't see later (free)
+  inspect(agree("λx. λx. x", root => find_var(root, "x")), content="true") // nested lam shadow
 }
 ```
 
-Note: `norm_binder`/`norm_decl` map both shapes to `(tag, NodeId, Int)`. For a
-module def the old `ModuleBinder.binding_node_id` and the new `Decl.node_id`
-should be the SAME FlatProj binding NodeId (both come from `flat_proj.defs[i].3`).
-If the equivalence test fails on the module case because the two NodeIds differ,
-that is a real finding — STOP and report which NodeId each side uses before
-changing either (design spec: where Layer 1 and resolve_binder disagree, file the
-bug; do not paper over).
+Note: `agree` builds FlatProj via `from_proj_node` (init-child id-shape).
+Production uses the live `to_flat_proj` id-shape, but both `@scope.build` and
+`resolve_binder` read `flat_proj.defs[i].3`, so equivalence holds on either; the
+live path is additionally exercised by Step 5's `text_edit_rename` integration
+tests. If the module case ever disagrees because the two NodeIds differ, that is
+a real finding — STOP and report which NodeId each side uses (design spec: file
+the bug; do not paper over).
 
 - [ ] **Step 3: Run the equivalence test (old behavior, new graph)**
 
 Run: `moon test -p dowdiness/canopy/lang/lambda/edits -f scope_equivalence_wbtest.mbt`
-Expected: PASS for both. If FAIL, investigate against Layer 1 before changing
-code.
+Expected: PASS. If any case FAILS, investigate against Layer 1 before changing
+production code.
 
 - [ ] **Step 4: Migrate the consumer**
 
@@ -1084,15 +1139,22 @@ fn rename_from_var(
 }
 ```
 
-Do NOT delete `resolve_binder` — `text_edit_refactor.mbt:143` and
-`scope_wbtest.mbt` still use it, and the equivalence test depends on it (design
-spec Non-goals: only `rename_from_var`'s binder lookup migrates in v1).
+If the bare `@scope.LamParam(..)` / `@scope.ModuleDef(..)` patterns fail to
+compile (MoonBit cross-package enum-constructor matching), add
+`"dowdiness/canopy/lang/lambda/scope"` already imported, then `using @scope {
+type DeclKind }` to `edits/moon.pkg` and match `DeclKind::LamParam(..)` /
+`DeclKind::ModuleDef(..)`. Verify the original line range — read
+`text_edit_rename.mbt:99-139` before replacing.
+
+Do NOT delete `resolve_binder` — `text_edit_refactor.mbt` and `scope_wbtest.mbt`
+still use it, and the equivalence test depends on it (design spec Non-goals: only
+`rename_from_var`'s binder lookup migrates in v1).
 
 - [ ] **Step 5: Run the full edits + scope suites**
 
 Run: `moon check && moon test -p dowdiness/canopy/lang/lambda/edits && moon test -p dowdiness/canopy/lang/lambda/scope`
 Expected: all existing `text_edit*` / `scope_wbtest` tests still PASS (behavior
-preserved), plus the equivalence tests pass.
+preserved — these exercise the live `ctx` path), plus the equivalence tests pass.
 
 - [ ] **Step 6: Commit**
 
@@ -1208,7 +1270,7 @@ exists (`grep -n 'pub fn resolve_binder' lang/lambda/edits/scope.mbt`).
 
 In the PR description, state: `declaration()` reproduces the existing
 `BindingSite` contract; reused `@core.NodeId`, `@core.ProjNode`,
-`@core.SourceMap`, `@lambda_proj.FlatProj` (no duplicate types introduced).
+`@core.SourceMap`, `@proj.FlatProj` (no duplicate types introduced).
 
 - [ ] **Step 4: Open the PR**
 
@@ -1218,13 +1280,14 @@ gh pr create --title "feat(scope): NodeId-keyed binding index for lambda (v1, re
 Implements docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md.
 
 v1: non-incremental NodeId-keyed binding index (scope/graph.mbt + builder + query).
-rename_from_var binder lookup migrated to @scope.declaration() with equivalence
-tests proving behavior preservation. references()/enclosing_env() are reserved
-API surface (no v1 consumer). Layer 2 caimeox oracle per Task 9 status.
+rename_from_var binder lookup migrated to @scope.declaration() with table-driven
+equivalence tests proving behavior preservation across all binding rules.
+references()/enclosing_env() are reserved API surface (no v1 consumer).
+Layer 2 caimeox oracle per Task 9 status.
 
 ## Reuse check
 declaration() reproduces the existing BindingSite contract; reused @core.NodeId,
-@core.ProjNode, @core.SourceMap, @lambda_proj.FlatProj — no duplicate types.
+@core.ProjNode, @core.SourceMap, @proj.FlatProj — no duplicate types.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 BODY
@@ -1233,13 +1296,14 @@ BODY
 
 ---
 
-## Self-review notes (carried from spec coverage check)
+## Self-review notes (spec coverage)
 
 - **Spec §Architecture (3 files):** Tasks 1/3/4/6 (graph, builder, query). ✓
-- **Spec §"Sequential-scope encoding" (cutoff):** Task 4 + Task 5. ✓
+- **Spec §"Sequential-scope encoding" (cutoff):** Task 4 + Task 5; mirrors `resolve_binder` (Verified facts). ✓
 - **Spec §"DeclKind" (BindingSite reconstruction):** Task 1 data model + Task 8 `norm_decl`. ✓
 - **Spec §"Var vs Unbound":** Task 4 Pass 3 emits Ref for both. ✓
 - **Spec §"visited_scopes by-product":** Task 4 `Builder::resolve` records visited. ✓
-- **Spec §Testing Layer 1/2/3:** Tasks 5 / 9 / 8. ✓
-- **Spec §Non-goals (only rename, only declaration):** Task 8 migrates one call; references/enclosing_env reserved (Task 6). ✓
-- **Spec §"acyclic by construction":** relied on in Task 2 `build_parent_map` doc; no runtime cycle guard is implemented in v1 because the tree-derived parent map cannot cycle — if a defensive `fail()` guard is wanted, add it in `root_node`/Pass 2, but it is optional for v1 correctness.
+- **Spec §Testing Layer 1/2/3:** Tasks 5 / 9 / 8 (Layer 3 now table-driven over all rules). ✓
+- **Spec §Non-goals (only rename, only declaration):** Task 8 migrates one call; references/enclosing_env reserved (Task 6), enclosing_env documented as superset of collect_lam_env (not replacement). ✓
+- **Spec §"acyclic by construction":** relied on in Task 2 `build_parent_map` doc; no runtime cycle guard in v1 because the tree-derived parent map cannot cycle.
+- **Codex review (2026-05-30) findings folded:** from_ast→`@core` (C1); `derive(Debug,Eq)`+scalar-inspect idiom (C2); table-driven equivalence (C3); enclosing_env superset comment (C4); id-shape note (C5); plus moon.pkg JSON format + `@proj` default alias.

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -1,0 +1,223 @@
+# Lambda Scope Graph — Binding-Logic Consolidation (Design)
+
+**Date:** 2026-05-30
+**Status:** Design approved, pending spec review
+**Scope:** canopy-side only (`lang/lambda/`); the `loom` submodule is not touched.
+
+## Motivation
+
+Name-resolution / binding logic for the lambda language is duplicated and ad-hoc
+across ~5 sites:
+
+- `lang/lambda/edits/scope.mbt` (167 lines) — `resolve_binder`,
+  `find_enclosing_lam_binder`, `find_usages`, `collect_lam_env`,
+  `find_binding_for_init`.
+- `lang/lambda/edits/free_vars.mbt` (31 lines) — capture analysis `FV(term, env)`.
+- `lang/lambda/semantic/semantic_projection.mbt` (265 lines) — walks the AST
+  threading an environment array, classifies each `Var` as bound/free.
+
+Two concrete problems:
+
+1. **O(N²) parent search.** `find_enclosing_lam_binder` and `collect_lam_env`
+   full-scan `registry: Map[NodeId, ProjNode[Term]]` to find a node's parent —
+   O(N) per step, O(N²) overall.
+2. **No single source of truth.** Each site re-derives scoping, so a fix in one
+   place (e.g. a shadowing edge case) does not propagate. There is no queryable
+   "where is this name declared / referenced" facility, which blocks
+   go-to-definition / find-references / capture-safe rename from sharing one
+   correct implementation.
+
+This design introduces a single **NodeId-keyed scope graph** that the binding
+sites migrate onto, drawing on:
+
+- *A Theory of Name Resolution* (Néron, Tolmach, Visser, Wachsmuth, 2015) — the
+  Scope / Declaration / Reference graph model and resolution-by-path-search.
+- *Incremental Type-Checking for Free* (Zwaan, van Antwerpen, Visser, OOPSLA
+  2022) — query-confirmation + environment-diffing for incrementality. **Not
+  built in v1**; its data shape is *reserved* (see §"Reserved extension points").
+
+A small MoonBit reference implementation of the 2015 theory exists
+(`caimeox/scope_graph`). We do **not** depend on it. It is BATCH
+(non-incremental), uses position-dependent `Int` indices, and is hardcoded to
+its own AST `LmProgram`. We use it only as a **correctness oracle** in
+differential tests.
+
+## Non-goals (v1)
+
+- **Incremental rebuild.** v1 rebuilds the whole graph each time, but correctly.
+  Incrementality is a reserved extension point, not v1 work.
+- **Migrating all consumers.** v1 rewires exactly ONE consumer (`rename`'s
+  `resolve_binder`) and proves equivalence. `free_vars`,
+  `semantic_projection`, and `actions` migrate in later PRs.
+- **loom generalization.** The language-agnostic core lives in its own file so a
+  future loom sibling package can lift it, but v1 does not extract it.
+- **Touching the loom submodule.** canopy `lang/lambda` already shares loom's
+  AST type `@ast.Term`; the graph consumes it. No submodule PR.
+
+## Architecture
+
+New package `lang/lambda/scope/`, split into three files by responsibility:
+
+### `graph.mbt` — data model (language-agnostic core)
+
+```
+ScopeGraph { scopes: Array[Scope], decls: Array[Decl], refs: Array[Ref] }
+Scope { id: ScopeId, parent: ScopeId?, decl_ids: Array[DeclId], ref_ids: Array[RefId] }
+Decl  { node_id: NodeId, name: String, scope: ScopeId }
+Ref   { node_id: NodeId, name: String, scope: ScopeId, resolution: Resolution }
+Resolution { decl: DeclId?, visited_scopes: Array[ScopeId] }
+```
+
+Everything is keyed by `core.NodeId` (stable across edits) rather than the
+position-dependent `Int` indices that caimeox uses. `ScopeId`/`DeclId`/`RefId`
+are internal compact indices into the graph's own arrays (graph-local, not
+persistent identity — `NodeId` carries persistent identity).
+
+`Resolution.decl: None` is a **negative observation** (an unresolved /
+free reference). `visited_scopes` records the scopes that were checked and found
+NOT to contain the name during resolution. Both are populated in v1 (the
+resolution walk produces them as a by-product) but only `decl` is read by v1
+queries. They exist so that incrementality (which depends on negative
+observations) can later be layered on without a breaking change to `Resolution`.
+
+### `builder.mbt` — lambda-specific construction
+
+`build(flat_proj, registry, source_map) -> ScopeGraph`, run once per rebuild:
+
+- **Pass 1:** build a `NodeId -> parent NodeId` map from `registry` in a single
+  scan. This removes the O(N²) full-scan that `find_enclosing_lam_binder` /
+  `collect_lam_env` perform today.
+- **Pass 2:** create scopes and decls encoding the binding rules below.
+- **Pass 3:** resolve each ref, storing its `Resolution` (decl + visited_scopes).
+
+Binding rules of the lambda language (must be faithfully encoded):
+
+1. `Lam(param, body)` opens a new lexical scope binding `param`; an inner `Lam`
+   shadows an outer one.
+2. `Module` defs are **sequential**: def `i` is in scope for defs `i+1..n` AND
+   the body. A later def with the same name shadows an earlier one.
+3. A `Var` resolves to the innermost enclosing `Lam` param matching the name,
+   else the latest *preceding* `Module` def, else free/unbound.
+
+**Sequential-scope encoding (Codex Q1).** A single module scope is used, but each
+ref carries a **cutoff** (the def index it appears within, or a body sentinel),
+and resolution only considers decls whose def-index is *strictly before* the
+cutoff. Consequences that MUST hold:
+
+- `def x = x` alone → the inner `x` is **unbound** (a def is not visible in its
+  own init).
+- `def x = 1; def x = x` → the second init's `x` binds to the **first** `x`.
+- A def referencing a *later* def → unbound.
+
+Per-def child-scope chaining (caimeox's `seqb` approach) is an equivalent
+alternative but unnecessary; the cutoff index achieves the same visibility with
+one module scope.
+
+### `query.mbt` — query API
+
+- `declaration(ref_node: NodeId) -> Decl?` — the binding site a reference
+  resolves to (replaces `resolve_binder`).
+- `references(decl_node: NodeId) -> Array[NodeId]` — **identity-based**: returns
+  refs whose `resolution.decl` points at this decl, NOT a name match. (Codex Q2:
+  a name-based `find_usages` over-renames when shadowing is present.)
+- `enclosing_env(node: NodeId) -> Array[String]` — bound names in scope at a
+  node (replaces `collect_lam_env`).
+
+Dependency direction: `scope` depends on `core` (NodeId/SourceMap/ProjNode) and
+`lang/lambda/proj` (FlatProj/Term). `edits` / `semantic` / `rename` will depend
+on `scope` (no back-edge).
+
+## Data flow (v1, non-incremental)
+
+```
+edit → projection rebuild (existing) → FlatProj + registry + SourceMap (existing)
+     → ScopeGraph::build(...)              [new, once]
+        ├─ pass 1: NodeId → parent map     (single registry scan)
+        ├─ pass 2: scopes + decls          (Lam param scopes + sequential module scope)
+        └─ pass 3: resolve refs            (store Resolution per ref)
+     → query (declaration / references / enclosing_env) ← consumers
+```
+
+## Error handling
+
+- The builder ALWAYS returns a graph, even on partial / broken ASTs
+  (`Error` / `Hole` / `Unbound` nodes). A projectional editor is mid-edit
+  constantly, so resolution never `raise`s on unresolved names — they become
+  `Resolution{ decl: None, .. }` (a normal negative observation).
+- The only invariant violation is a **parent-chain cycle**. The builder asserts
+  the parent DAG is acyclic at construction (Codex Q5). This is structurally
+  impossible for tree-nested Lam/Module, so it is a defect guard via `fail()`
+  (not caught — catching would risk silently-wrong results; cf. memory
+  `feedback_no_safe_recovery_abort_ok`).
+
+## Testing strategy (three layers)
+
+### Layer 1 — hand-written expected-value tests (primary safety net)
+
+Pin the Codex Q1/Q2 edge cases by name, with values **derived by hand** (not by
+re-running a formula; cf. memory `feedback_algorithm_process`):
+
+- `def x = x` → unbound.
+- `def x = 1; def x = x` → second init binds to first `x`.
+- innermost `Lam` shadowing; `Module` def shadowing.
+- body sentinel; "not visible in own init / preceding defs".
+
+### Layer 2 — differential tests (caimeox oracle)
+
+`source fixture → independent Term→LmProgram adapter → caimeox resolution →
+compare via a NodeId side-table`.
+
+- **Non-circularity (Codex Q3):** the adapter is an INDEPENDENT transform that
+  does NOT route through the new builder/query code.
+- **Fidelity (Codex Q3):** caimeox's AST lacks Canopy's `If` / `Unit` / `Hole` /
+  `Error` / `Unbound` and has extra `Fix` / imports. Compare only the shared
+  subset (Var / Lam / App / Module / let-equivalent); excluded constructs are
+  covered by Layer 1.
+- This is the operational form of design principle §6 ("make the discovered
+  structure predict").
+
+### Layer 3 — equivalence tests (migration safety net)
+
+For the migrated `rename` consumer, pin that the new `declaration()` and the
+current `resolve_binder()` return the SAME `BindingSite` across all fixtures.
+
+- **Non-circularity (memory `feedback_drift_detector_non_circular`):** keep the
+  old `resolve_binder` live and run BOTH during the test, comparing outputs.
+  Delete the old implementation only after migration is proven, in the same PR.
+
+This is the pass condition for the "structure + 1 consumer" PoC.
+
+## Reserved extension points (NOT built in v1)
+
+Per design principle §7 (reserving an extension point costs far less than a later
+breaking change):
+
+1. **Incremental rebuild** via query-confirmation + environment-diffing
+   (OOPSLA 2022). The paper's hardest machinery is UNNEEDED here:
+   - §7 scope-graph diffing (for non-deterministic scope identity) — unneeded
+     because canopy has STABLE `NodeId`.
+   - §6 multi-unit actor / deadlock detection — unneeded because canopy is
+     currently a SINGLE compilation unit.
+   What remains is query-confirmation over negative observations, which is why
+   `Resolution` already carries `decl: DeclId?` + `visited_scopes` in v1.
+   - **Cycle trap (Codex Q5):** if later layered on canopy's `loom/incr` Datalog
+     substrate (`Relation` + `MemoMap`), a transitive-closure `MemoMap` compute
+     fn MUST walk the base parent/def edges directly (iterative BFS or Datalog
+     fixpoint), NOT recurse through the closure `MemoMap` itself — that creates a
+     memo cycle the runtime aborts (cf. memory `project_incr_impact_bfs_cycle_trap`).
+2. **loom generalization:** the language-agnostic `graph.mbt` core can be lifted
+   into a loom sibling package; per-language builders supply rules. v1 keeps the
+   core in its own file to make this a move, not a rewrite.
+
+## Open questions
+
+None blocking. Migration order for the remaining consumers
+(`free_vars` / `semantic_projection` / `actions`) is decided per follow-up PR.
+
+## References
+
+- Néron, Tolmach, Visser, Wachsmuth. *A Theory of Name Resolution.* ESOP 2015.
+- Zwaan, van Antwerpen, Visser. *Incremental Type-Checking for Free: Using Scope
+  Graphs to Derive Incremental Type-Checkers.* OOPSLA 2022.
+  <https://aronzwaan.github.io/assets/oopsla22.pdf>
+- `caimeox/scope_graph` (MoonBit reference impl of the 2015 theory) — oracle only.

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -27,7 +27,7 @@ Two concrete problems:
    go-to-definition / find-references / capture-safe rename from sharing one
    correct implementation.
 
-This design introduces a single **NodeId-keyed scope graph** that the binding
+This design introduces a single **NodeId-keyed binding index** that the binding
 sites migrate onto, drawing on:
 
 - *A Theory of Name Resolution* (Néron, Tolmach, Visser, Wachsmuth, 2015) — the

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -46,9 +46,15 @@ differential tests.
 
 - **Incremental rebuild.** v1 rebuilds the whole graph each time, but correctly.
   Incrementality is a reserved extension point, not v1 work.
-- **Migrating all consumers.** v1 rewires exactly ONE consumer (`rename`'s
-  `resolve_binder`) and proves equivalence. `free_vars`,
-  `semantic_projection`, and `actions` migrate in later PRs.
+- **Migrating all consumers.** v1 rewires exactly ONE call: `rename`'s use of
+  `resolve_binder` → `declaration()`, proven equivalent. **rename's OTHER
+  dependencies stay on the old logic in v1** (Codex finding 3): its capture
+  checks via `free_vars`, its usage-edit enumeration via `find_usages`, and its
+  in-scope-name collection via `collect_lam_env` are NOT migrated in v1. Only
+  the binder-resolution step is swapped. `free_vars` / `find_usages` /
+  `collect_lam_env` / `semantic_projection` / `actions` migrate in later PRs.
+  This keeps the v1 equivalence test (Layer 3) scoped to a single, checkable
+  behavioral substitution.
 - **loom generalization.** The language-agnostic core lives in its own file so a
   future loom sibling package can lift it, but v1 does not extract it.
 - **Touching the loom submodule.** canopy `lang/lambda` already shares loom's
@@ -63,10 +69,19 @@ New package `lang/lambda/scope/`, split into three files by responsibility:
 ```
 ScopeGraph { scopes: Array[Scope], decls: Array[Decl], refs: Array[Ref] }
 Scope { id: ScopeId, parent: ScopeId?, decl_ids: Array[DeclId], ref_ids: Array[RefId] }
-Decl  { node_id: NodeId, name: String, scope: ScopeId }
+Decl  { node_id: NodeId, name: String, scope: ScopeId, kind: DeclKind }
 Ref   { node_id: NodeId, name: String, scope: ScopeId, resolution: Resolution }
 Resolution { decl: DeclId?, visited_scopes: Array[ScopeId] }
+DeclKind { LamParam(lam_id: NodeId) | ModuleDef(def_index: Int) }
 ```
+
+**`DeclKind` (Codex finding 1).** `Decl` must carry enough to reconstruct the
+current `BindingSite` returned by `resolve_binder`
+(`lang/lambda/edits/scope.mbt:3`): `LamBinder(lam_id)` and
+`ModuleBinder(binding_node_id, def_index)`. A bare `{ node_id, name, scope }`
+cannot reproduce `ModuleBinder.def_index` or distinguish the two binder kinds, so
+`DeclKind` records `LamParam(lam_id)` / `ModuleDef(def_index)`. The migrated
+`declaration()` maps `Decl{kind, node_id} -> BindingSite` losslessly.
 
 Everything is keyed by `core.NodeId` (stable across edits) rather than the
 position-dependent `Int` indices that caimeox uses. `ScopeId`/`DeclId`/`RefId`
@@ -120,8 +135,21 @@ one module scope.
 - `references(decl_node: NodeId) -> Array[NodeId]` — **identity-based**: returns
   refs whose `resolution.decl` points at this decl, NOT a name match. (Codex Q2:
   a name-based `find_usages` over-renames when shadowing is present.)
-- `enclosing_env(node: NodeId) -> Array[String]` — bound names in scope at a
-  node (replaces `collect_lam_env`).
+- `enclosing_env(node: NodeId) -> @immut/hashset.HashSet[String]` — bound names
+  in scope at a node (replaces `collect_lam_env`). **Set semantics** (Codex
+  finding 6): the current `collect_lam_env` returns a `HashSet[String]` and its
+  consumer (`text_edit_refactor.mbt` capture check) needs membership, not order;
+  the query mirrors that to avoid an impedance mismatch.
+
+**Token-span lookup is via the Module node, not the binding NodeId (Codex
+finding 2).** Module binding name spans are stored on the *Module* ProjNode under
+the role `"name:<def_index>"` (`lang/lambda/proj/populate_token_spans.mbt`,
+consumed by `lang/lambda/edits/text_edit_rename.mbt`), NOT on the FlatProj
+binding `NodeId` that `Decl.node_id` holds. Any go-to-definition / rename built
+on `declaration()` must therefore resolve a `ModuleDef` decl's edit span as
+`source_map.get_token_span(module_node_id, "name:" + def_index)`, using
+`DeclKind::ModuleDef(def_index)`. The graph stores `def_index` precisely so this
+lookup remains possible; the spec does NOT change where spans live.
 
 Dependency direction: `scope` depends on `core` (NodeId/SourceMap/ProjNode) and
 `lang/lambda/proj` (FlatProj/Term). `edits` / `semantic` / `rename` will depend
@@ -140,10 +168,19 @@ edit → projection rebuild (existing) → FlatProj + registry + SourceMap (exis
 
 ## Error handling
 
-- The builder ALWAYS returns a graph, even on partial / broken ASTs
-  (`Error` / `Hole` / `Unbound` nodes). A projectional editor is mid-edit
-  constantly, so resolution never `raise`s on unresolved names — they become
-  `Resolution{ decl: None, .. }` (a normal negative observation).
+- The builder ALWAYS returns a graph, even on partial / broken ASTs. A
+  projectional editor is mid-edit constantly, so resolution never `raise`s on
+  unresolved names.
+- **`Var` vs `Unbound` (Codex finding 4).** `Var(name)` and `Unbound(name)` are
+  BOTH emitted as a `Ref`, and an unresolvable one gets
+  `Resolution{ decl: None, .. }` (a normal negative observation). This is
+  deliberate: `semantic_projection` already treats `Unbound` as reference-like
+  for its free-variable diagnostics (`semantic_projection.mbt:67`), so excluding
+  it would drop a diagnostic the migrated consumer must keep. (`free_vars`
+  ignores `Unbound`; that asymmetry is a free_vars concern, not a graph concern —
+  the graph models both uniformly and each consumer filters as it needs.)
+- **`Error` / `Hole` nodes** carry no name and produce neither a `Decl` nor a
+  `Ref`; they are inert in the graph.
 - The only invariant violation is a **parent-chain cycle**. The builder asserts
   the parent DAG is acyclic at construction (Codex Q5). This is structurally
   impossible for tree-nested Lam/Module, so it is a defect guard via `fail()`
@@ -173,6 +210,14 @@ compare via a NodeId side-table`.
   `Error` / `Unbound` and has extra `Fix` / imports. Compare only the shared
   subset (Var / Lam / App / Module / let-equivalent); excluded constructs are
   covered by Layer 1.
+- **Adjudication rule (Codex finding 5):** caimeox is an oracle, NOT the spec of
+  record. The sequential-module semantics are defined by Canopy's cutoff-index
+  rule (§"Sequential-scope encoding") and by Layer 1's hand-derived expectations.
+  caimeox encodes `let` via `seqb` child-scope chaining; if that disagrees with
+  the cutoff encoding on some edge case, **Layer 1 + current-Canopy equivalence
+  (Layer 3) win, and the caimeox fixture is removed from the differential set**
+  (documented, not silently dropped — cf. "no silent caps"). caimeox earns trust
+  on the agreed subset; it does not override Canopy's own binding contract.
 - This is the operational form of design principle §6 ("make the discovered
   structure predict").
 

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -287,7 +287,10 @@ Checkers*, OOPSLA 2020, which compiles type rules to Datalog; and rust-analyzer'
 Salsa + `DefMap` as the non-scope-graph incremental baseline).
 
 - **Pro:** incrementality comes from the substrate; directly reuses an asset
-  canopy already has; strong precedent for incremental name resolution.
+  canopy already has (`loom/incr` ships `Relation` + `Runtime::new_rule` +
+  `fixpoint` + `MemoMap` — both the demand-driven memo layer AND a Datalog layer
+  coexist by design; cf. memory `project_incr_datalog_substrate`); strong
+  precedent for incremental name resolution.
 - **Con:** wrong altitude for v1. v1 is explicitly *non-incremental* (the user
   chose "verify-first: lock correctness before incrementality"). Introducing the
   Datalog substrate now couples the correctness milestone to the fixpoint
@@ -295,6 +298,17 @@ Salsa + `DefMap` as the non-scope-graph incremental baseline).
   correctness baseline to protect. Datalog is the natural **substrate for the
   reserved incremental future**, not for the v1 correctness layer. Deferring it
   keeps v1 debuggable as a plain batch computation.
+- **Subtlety to remember when this future is pursued:** a fixpoint engine is not
+  the same as incremental maintenance. Semi-naive evaluation speeds up computing
+  a fixpoint *from scratch*; incremental view maintenance (DRed / DRedL) updates
+  a result *when inputs change*. Having `fixpoint` does NOT by itself give
+  edit-incremental resolution. There is also an impedance question between the
+  two incremental models — the memo layer is demand-driven / pull / top-down
+  (Salsa-style verifying traces), while the Datalog layer is bottom-up / push.
+  These do not conflict in v1 (it uses neither incrementally), and `incr` already
+  reconciles them; the intended shape when we do go incremental is the
+  coarse-grained one in §Reserved (memo outside, fixpoint inside, unit
+  granularity), NOT a hand-rolled fusion of both.
 
 ### Alt 3 — NodeId-keyed binding index with scope-graph vocabulary (chosen)
 
@@ -333,6 +347,17 @@ breaking change):
      currently a SINGLE compilation unit.
    What remains is query-confirmation over negative observations, which is why
    `Resolution` already carries `decl: DeclId?` + `visited_scopes` in v1.
+   - **Start at unit granularity, not fine-grained.** When incrementality is
+     built, begin with the coarse shape: the `incr` memo decides whether a
+     file/module unit must be recomputed, and the resolution runs as a batch
+     fixpoint *inside* that unit. Avoid jumping straight to within-unit
+     fine-grained incremental (e.g. function-body-level DRedL). Reason: Zwaan
+     et al.'s query-confirmation stayed at compilation-unit granularity because
+     that was already sound and practical, whereas fine-grained DRedL is a
+     higher-cost solution that depends on the special structure of incremental
+     replacement of lattice values. Coarse-grained is enough; fine-grained is a
+     structure-dependent optimization to reach for only if measurement demands
+     it. This shape also keeps the cycle trap below easy to avoid.
    - **Cycle trap (Codex Q5):** if later layered on canopy's `loom/incr` Datalog
      substrate (`Relation` + `MemoMap`), a transitive-closure `MemoMap` compute
      fn MUST walk the base parent/def edges directly (iterative BFS or Datalog

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -42,6 +42,29 @@ A small MoonBit reference implementation of the 2015 theory exists
 its own AST `LmProgram`. We use it only as a **correctness oracle** in
 differential tests.
 
+### Framing: what v1 actually is, and what it is not
+
+**v1 is a NodeId-keyed binding index, not a scope-graph engine.** The lambda
+language has no imports, no type-dependent resolution, and is a single
+compilation unit. Under those conditions almost all of scope-graph theory's
+machinery degenerates: there are no `I` (import) edges, no `critical edges` /
+Statix scheduling, no file-incremental boundary, and the only path regex that
+ever applies is `P*` (walk the parent chain). What remains — a parent chain plus
+a sequential-module cutoff — is **structurally a symbol table**.
+
+The concrete v1 wins (kill the O(N²) parent scan, identity-based `references()`,
+reserved negative-observation fields) come from making the binding facts an
+**explicit, NodeId-keyed, queryable index**, NOT from scope-graph theory per se.
+We adopt the Scope/Decl/Ref *vocabulary and data shape* deliberately, as the
+minimum-cost stepping stone toward two reserved futures (incremental rebuild;
+loom generalization). That bet on future value is **explicitly provisional**:
+its payoff is re-evaluated after v1 ships and the migrated consumers are
+measured (see §Alternatives and §"Reserved extension points"). If the futures do
+not materialize, what we are left with is a clean symbol table that cost the same
+to build — so the downside is bounded. This framing is a direct response to an
+independent design review that (correctly) flagged the original "scope graph"
+framing as larger than the problem warrants.
+
 ## Non-goals (v1)
 
 - **Incremental rebuild.** v1 rebuilds the whole graph each time, but correctly.

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -232,6 +232,71 @@ current `resolve_binder()` return the SAME `BindingSite` across all fixtures.
 
 This is the pass condition for the "structure + 1 consumer" PoC.
 
+## Alternatives considered
+
+An independent design review pressed the question: *the lambda language is single,
+lexical-scope-centric, with no imports or type-dependent resolution — does it
+warrant scope-graph vocabulary at all, or would a plain symbol table / Datalog
+encoding be a better fit?* The three candidates, and why this design picks the
+binding-index shape:
+
+### Alt 1 — Classic symbol table + visitor resolution
+
+Fold the CST with a catamorphism, threading an environment; resolve names against
+the live environment. This is the lowest-ceremony option and is what
+`semantic_projection.mbt` already does ad-hoc today.
+
+- **Pro:** smallest code; no new data model; familiar.
+- **Con:** does not by itself give an *identity-keyed, queryable* index. The two
+  v1 wins — O(1) parent lookup (kills the O(N²) scan) and identity-based
+  `references()` — require materializing decl/ref facts keyed by `NodeId`
+  anyway. A symbol table that materializes those facts *is* the proposed index
+  under a different name; one that does not, leaves problem #2 (no single source
+  of truth) unsolved. So "plain symbol table" either converges on this design or
+  fails the requirements.
+
+### Alt 2 — Datalog encoding on loom's fixpoint substrate
+
+Express binding as Datalog rules (`decl(scope, name, node)`, `parent(s, s')`,
+`resolves(ref, decl)`) and run them on `loom/incr`'s `Relation` + fixpoint
+(cf. Pacak, Erdweg, Szabó, *A Systematic Approach to Deriving Incremental Type
+Checkers*, OOPSLA 2020, which compiles type rules to Datalog; and rust-analyzer's
+Salsa + `DefMap` as the non-scope-graph incremental baseline).
+
+- **Pro:** incrementality comes from the substrate; directly reuses an asset
+  canopy already has; strong precedent for incremental name resolution.
+- **Con:** wrong altitude for v1. v1 is explicitly *non-incremental* (the user
+  chose "verify-first: lock correctness before incrementality"). Introducing the
+  Datalog substrate now couples the correctness milestone to the fixpoint
+  engine and the memo-cycle hazard (Codex Q5) before there is a passing
+  correctness baseline to protect. Datalog is the natural **substrate for the
+  reserved incremental future**, not for the v1 correctness layer. Deferring it
+  keeps v1 debuggable as a plain batch computation.
+
+### Alt 3 — NodeId-keyed binding index with scope-graph vocabulary (chosen)
+
+The materialized Scope/Decl/Ref index described above.
+
+- **Pro:** delivers both v1 wins; the Scope/Decl/Ref *shape* is the minimum-cost
+  stepping stone to the two reserved futures (incremental via query-confirmation;
+  loom generalization), because the negative-observation fields and the
+  language-agnostic core file are already in place; admits a batch correctness
+  oracle (caimeox) sharing the same conceptual model.
+- **Con:** carries vocabulary (`Scope`, `ScopeId`, regex-able resolution) whose
+  full power lambda never exercises in v1 — accepted deliberately as the reserved
+  bet, with the §Framing escape hatch that the worst case is "a clean symbol
+  table that cost the same."
+
+**Decision.** Alt 3. The implementation cost over Alt 1 is marginal (parent chain
++ cutoff is the same code volume whether or not it is framed as a graph), and the
+reserved affordances (negative observations, agnostic core) are nearly free when
+built in now versus a breaking change later (design principle §7). Alt 2 is
+adopted *later*, as the incremental substrate, not as the v1 correctness layer.
+The provisional nature of the future bet is recorded in §Framing: re-evaluate
+after v1 ships and consumers are measured; name resolution is reported at 35–40%
+of type-checker runtime (Zwaan, *Specializing Scope Graph Resolution Queries*,
+SLE 2022), so the incremental payoff — if pursued — is material.
+
 ## Reserved extension points (NOT built in v1)
 
 Per design principle §7 (reserving an extension point costs far less than a later
@@ -266,3 +331,9 @@ None blocking. Migration order for the remaining consumers
   Graphs to Derive Incremental Type-Checkers.* OOPSLA 2022.
   <https://aronzwaan.github.io/assets/oopsla22.pdf>
 - `caimeox/scope_graph` (MoonBit reference impl of the 2015 theory) — oracle only.
+- Pacak, Erdweg, Szabó. *A Systematic Approach to Deriving Incremental Type
+  Checkers.* OOPSLA 2020. (Datalog encoding — Alt 2 lineage.)
+- Zwaan. *Specializing Scope Graph Resolution Queries.* SLE 2022. (Name
+  resolution = 35–40% of type-checker runtime.)
+- rust-analyzer (Salsa + `DefMap` + `ItemTree`) — non-scope-graph incremental
+  baseline cited in §Alternatives.

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -183,12 +183,16 @@ one module scope.
   resolves to (replaces `resolve_binder`).
 - `references(decl_node: NodeId) -> Array[NodeId]` — **identity-based**: returns
   refs whose `resolution.decl` points at this decl, NOT a name match. (Codex Q2:
-  a name-based `find_usages` over-renames when shadowing is present.)
+  a name-based `find_usages` over-renames when shadowing is present.) *(Reserved
+  API surface; consumer migration — `find_usages` callers — deferred per
+  §Non-goals.)*
 - `enclosing_env(node: NodeId) -> @immut/hashset.HashSet[String]` — bound names
   in scope at a node (replaces `collect_lam_env`). **Set semantics** (Codex
   finding 6): the current `collect_lam_env` returns a `HashSet[String]` and its
   consumer (`text_edit_refactor.mbt` capture check) needs membership, not order;
-  the query mirrors that to avoid an impedance mismatch.
+  the query mirrors that to avoid an impedance mismatch. *(Reserved API surface;
+  consumer migration deferred per §Non-goals. Of the three query methods, only
+  `declaration()` is wired to a consumer in v1.)*
 
 **Token-span lookup is via the Module node, not the binding NodeId (Codex
 finding 2).** Module binding name spans are stored on the *Module* ProjNode under
@@ -215,19 +219,46 @@ edit → projection rebuild (existing) → FlatProj + registry + SourceMap (exis
      → query (declaration / references / enclosing_env) ← consumers
 ```
 
-**v1 full-rebuild cost (review point).** `build()` runs three full passes over
-the projection on *every* rebuild, and a projectional editor rebuilds on every
-edit. This is the accepted non-incremental cost. The §Framing "downside is
-bounded" argument is about *code* (worst case = a symbol table), and that bound
-does NOT extend to *runtime* — so it must be stated separately here: v1's runtime
-cost is O(N) per edit in the projection size N (three linear passes; the Pass-1
-parent map makes per-node parent lookup O(1), removing today's O(N²)). For the
-program sizes a single lambda module reaches today this is expected to be
-negligible, but **it is not yet measured**. The metric that would flip the
-non-incremental decision is therefore made explicit in §Reserved: rebuild
-latency at the p95 edit. Until that metric is measured and shown to exceed an
-interactive budget, incrementality stays reserved (cf. the project rule: measure
-the bottleneck before optimizing).
+**v1 full-rebuild cost (review point).** `build()` runs over the projection on
+*every* rebuild, and a projectional editor rebuilds on every edit. This is the
+accepted non-incremental cost. The §Framing "downside is bounded" argument is
+about *code* (worst case = a symbol table), and that bound does NOT extend to
+*runtime* — so it must be stated separately here.
+
+Per-pass cost (be precise, since a decision is gated on it):
+
+- **Pass 1** (build `NodeId -> parent` map): O(N), one walk of the projection of
+  size N.
+- **Pass 2** (scopes + decls): O(N), one walk emitting a scope/decl per relevant
+  node.
+- **Pass 3** (resolve refs): **O(R · d)**, NOT O(N) — each of R refs walks the
+  parent chain upward; the parent *lookup* is O(1) (Pass-1 map) but the *walk
+  length* is the nesting depth d. This still strictly improves on today's
+  `find_enclosing_lam_binder`, which is O(N · d) per ref because it re-scans the
+  whole registry at each step (`scope.mbt:62`); the Pass-1 map turns the
+  per-step O(N) into O(1). The v1 win is "kill the per-step O(N) rescan," NOT
+  "make resolution linear."
+- **Worst case and why it is not reachable.** Pathologically left-nested lambdas
+  (`\a.\b.\c. ...`) make d ≈ N, so Pass 3 degenerates to O(N²) — the very shape
+  v1 set out to kill. The original O(N²) sin was also "only pathological," so
+  this must be argued, not waved: realistic lambda programs keep d (lexical
+  lambda-nesting plus the single module level) small and roughly constant
+  relative to N — N grows by adding *defs and terms* (breadth), not by deepening
+  nesting hundreds deep. So in practice Pass 3 is ≈ O(R) ≈ O(N). If a real
+  program ever drives d large, that surfaces as rebuild latency, which is exactly
+  the trigger-metric condition below — and the response is the reserved
+  incremental path, not a v1 change.
+
+**Not yet measured for this layer, but the budget is known.** The project's
+established interactive budget is the **16 ms frame (60 fps)**; the existing
+keystroke pipeline sits at ~2.3 ms / 15% of budget at 80 defs
+(`docs/performance/2026-03-21-full-pipeline-benchmarks.md`). The scope build must
+fit *within* that same 16 ms keystroke budget alongside parse + projection + tree
+refresh. The metric that flips the non-incremental decision is made explicit in
+§Reserved: **scope-build's contribution to p95 keystroke latency against the
+16 ms frame budget**. Until measured and shown to threaten that budget,
+incrementality stays reserved (cf. the project rule: measure the bottleneck
+before optimizing).
 
 ## Error handling
 
@@ -424,11 +455,16 @@ breaking change):
      replacement of lattice values. Coarse-grained is enough; fine-grained is a
      structure-dependent optimization to reach for only if measurement demands
      it. This shape also keeps the cycle trap below easy to avoid.
-   - **Trigger metric:** pursue incrementality when measured rebuild latency at
-     the p95 edit exceeds the interactive budget on a realistic program (see
-     §"v1 full-rebuild cost"). Until then the O(N)-per-edit full rebuild is
-     accepted; the field reservations (`visited_scopes`, agnostic core) keep the
-     pivot cheap when the metric demands it.
+   - **Trigger metric:** pursue incrementality when the scope-build's
+     contribution to **p95 keystroke latency threatens the project's 16 ms frame
+     (60 fps) budget** on a realistic program — the same budget the existing
+     pipeline is measured against
+     (`docs/performance/2026-03-21-full-pipeline-benchmarks.md`; today ~2.3 ms /
+     15% at 80 defs). Two things can drive it there: program size N (Pass 1/2 are
+     O(N)) or pathological lambda-nesting depth d (Pass 3 is O(R·d); see §"v1
+     full-rebuild cost"). Until the measurement shows the budget threatened, the
+     full rebuild is accepted; the field reservations (`visited_scopes`, agnostic
+     core) keep the pivot cheap when the metric demands it.
    - **Cycle trap (Codex Q5):** if later layered on canopy's `loom/incr` Datalog
      substrate (`Relation` + `MemoMap`), a transitive-closure `MemoMap` compute
      fn MUST walk the base parent/def edges directly (iterative BFS or Datalog

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -87,7 +87,7 @@ framing as larger than the problem warrants.
 
 New package `lang/lambda/scope/`, split into three files by responsibility:
 
-### `graph.mbt` — data model (language-agnostic core)
+### `graph.mbt` — data model (language-agnostic core, one lambda-specific seam)
 
 ```
 ScopeGraph { scopes: Array[Scope], decls: Array[Decl], refs: Array[Ref] }
@@ -106,6 +106,18 @@ cannot reproduce `ModuleBinder.def_index` or distinguish the two binder kinds, s
 `DeclKind` records `LamParam(lam_id)` / `ModuleDef(def_index)`. The migrated
 `declaration()` maps `Decl{kind, node_id} -> BindingSite` losslessly.
 
+**`DeclKind` is the one lambda-specific type in `graph.mbt` (review point).**
+`Scope` / `Decl` / `Ref` / `Resolution` are language-agnostic, but `DeclKind`'s
+variants (`LamParam` / `ModuleDef`) are lambda-specific, so strictly the file is
+*almost* agnostic. This is a deliberate v1 simplification (single language → a
+concrete enum is simpler than premature generics). It has one consequence for the
+loom-generalization reserve (§Reserved 2): lifting `graph.mbt` into loom is NOT a
+pure move — `Decl` must be made generic over its kind (`Decl[K]`, with `K`
+supplied per language) at that point. v1 keeps `K` concrete as `DeclKind`. The
+cost of that later generalization is small (one type parameter threaded through
+`graph.mbt`), and noting it now keeps the reserve honest rather than implying a
+clean cut-and-paste.
+
 Everything is keyed by `core.NodeId` (stable across edits) rather than the
 position-dependent `Int` indices that caimeox uses. `ScopeId`/`DeclId`/`RefId`
 are internal compact indices into the graph's own arrays (graph-local, not
@@ -113,10 +125,24 @@ persistent identity — `NodeId` carries persistent identity).
 
 `Resolution.decl: None` is a **negative observation** (an unresolved /
 free reference). `visited_scopes` records the scopes that were checked and found
-NOT to contain the name during resolution. Both are populated in v1 (the
-resolution walk produces them as a by-product) but only `decl` is read by v1
-queries. They exist so that incrementality (which depends on negative
-observations) can later be layered on without a breaking change to `Resolution`.
+NOT to contain the name during resolution. Both are populated in v1 but only
+`decl` is read by v1 queries. They exist so that incrementality (which depends on
+negative observations) can later be layered on without a breaking change to
+`Resolution`.
+
+**Is populating `visited_scopes` in v1 actually free? (review point)** §7 says
+reserve the *place* (the field), not necessarily do the *work* of filling it. We
+populate it in v1 anyway, justified as a genuine by-product: resolution already
+walks the scope chain upward (via the Pass-1 parent map) to find a binding, so
+`visited_scopes` is just an `Array[ScopeId]` (`ScopeId` = `Int`) that records the
+scopes that walk *already visits* — **zero extra traversal, only the allocation**.
+The cost is one small array per ref per full rebuild. If profiling later shows
+this allocation is hot on large programs, the reserved fallback is to leave
+`visited_scopes` empty in v1 and populate it lazily when the incremental layer
+first needs it — the field stays, only the fill moves. (v1 chooses eager fill so
+the differential/equivalence tests can assert the negative observations are
+correct from day one, rather than discovering fill bugs when incrementality is
+built.)
 
 ### `builder.mbt` — lambda-specific construction
 
@@ -189,6 +215,20 @@ edit → projection rebuild (existing) → FlatProj + registry + SourceMap (exis
      → query (declaration / references / enclosing_env) ← consumers
 ```
 
+**v1 full-rebuild cost (review point).** `build()` runs three full passes over
+the projection on *every* rebuild, and a projectional editor rebuilds on every
+edit. This is the accepted non-incremental cost. The §Framing "downside is
+bounded" argument is about *code* (worst case = a symbol table), and that bound
+does NOT extend to *runtime* — so it must be stated separately here: v1's runtime
+cost is O(N) per edit in the projection size N (three linear passes; the Pass-1
+parent map makes per-node parent lookup O(1), removing today's O(N²)). For the
+program sizes a single lambda module reaches today this is expected to be
+negligible, but **it is not yet measured**. The metric that would flip the
+non-incremental decision is therefore made explicit in §Reserved: rebuild
+latency at the p95 edit. Until that metric is measured and shown to exceed an
+interactive budget, incrementality stays reserved (cf. the project rule: measure
+the bottleneck before optimizing).
+
 ## Error handling
 
 - The builder ALWAYS returns a graph, even on partial / broken ASTs. A
@@ -204,11 +244,19 @@ edit → projection rebuild (existing) → FlatProj + registry + SourceMap (exis
   the graph models both uniformly and each consumer filters as it needs.)
 - **`Error` / `Hole` nodes** carry no name and produce neither a `Decl` nor a
   `Ref`; they are inert in the graph.
-- The only invariant violation is a **parent-chain cycle**. The builder asserts
-  the parent DAG is acyclic at construction (Codex Q5). This is structurally
-  impossible for tree-nested Lam/Module, so it is a defect guard via `fail()`
-  (not caught — catching would risk silently-wrong results; cf. memory
-  `feedback_no_safe_recovery_abort_ok`).
+- The only invariant violation is a **parent-chain cycle**. This cannot arise
+  from a mid-edit / broken AST, because the `NodeId -> parent` map (Pass 1) is
+  derived by `core.collect_registry` walking the `ProjNode` tree
+  (`core/proj_node.mbt:58`): each node appears in exactly one parent's `children`
+  array, so the parent map is **acyclic by construction**, independent of edit
+  state — a broken AST yields a broken *tree*, never a cyclic graph. The builder
+  still asserts acyclicity via `fail()` (Codex Q5), but this is a genuine
+  **defect guard** (a violation means `collect_registry` or the tree itself is
+  bugged), NOT a runtime error path — so it does not contradict the never-raise
+  contract above, which governs *unresolved names* (those become
+  `Resolution{decl: None}`, not failures). `fail()` rather than catch because a
+  cyclic parent map signals a corrupted invariant where catching would risk
+  silently-wrong results (cf. memory `feedback_no_safe_recovery_abort_ok`).
 
 ## Testing strategy (three layers)
 
@@ -241,6 +289,12 @@ compare via a NodeId side-table`.
   (Layer 3) win, and the caimeox fixture is removed from the differential set**
   (documented, not silently dropped — cf. "no silent caps"). caimeox earns trust
   on the agreed subset; it does not override Canopy's own binding contract.
+- **Agreement is necessary, not sufficient (review point).** Layer 2 catches the
+  case where the new builder disagrees with an independent oracle. It does NOT
+  catch the case where caimeox and the new builder *agree* but both diverge from
+  the intended semantics — there, Layer 1's hand-derived expectations are the
+  backstop, by design. So Layer 2 passing is evidence, not proof; Layer 1 is the
+  authority on what "correct" means.
 - This is the operational form of design principle §6 ("make the discovered
   structure predict").
 
@@ -252,6 +306,18 @@ current `resolve_binder()` return the SAME `BindingSite` across all fixtures.
 - **Non-circularity (memory `feedback_drift_detector_non_circular`):** keep the
   old `resolve_binder` live and run BOTH during the test, comparing outputs.
   Delete the old implementation only after migration is proven, in the same PR.
+- **Layer 3 preserves current behavior, bugs included — correctness is Layer 1's
+  job (review point).** Problem #2 in §Motivation notes the ~5 binding sites can
+  currently disagree, which means `resolve_binder` may carry latent bugs. Layer 3
+  deliberately pins *equivalence to current `resolve_binder`*, so it proves the
+  migration is **behavior-preserving** — including reproducing any existing bug.
+  This is intentional sequencing: a behavior-preserving migration is verifiable
+  on its own, and fixing a binding bug is a *separate, later* step (where Layer 1
+  is extended with the corrected expectation and the fix lands as its own change,
+  not smuggled into the migration). Layer 1 (hand-derived) is the authority on
+  correctness; Layer 3 is only the migration-safety net. Where Layer 1 and
+  current `resolve_binder` disagree, that disagreement is a *found bug* to file,
+  not a Layer 3 failure to paper over.
 
 This is the pass condition for the "structure + 1 consumer" PoC.
 
@@ -358,6 +424,11 @@ breaking change):
      replacement of lattice values. Coarse-grained is enough; fine-grained is a
      structure-dependent optimization to reach for only if measurement demands
      it. This shape also keeps the cycle trap below easy to avoid.
+   - **Trigger metric:** pursue incrementality when measured rebuild latency at
+     the p95 edit exceeds the interactive budget on a realistic program (see
+     §"v1 full-rebuild cost"). Until then the O(N)-per-edit full rebuild is
+     accepted; the field reservations (`visited_scopes`, agnostic core) keep the
+     pivot cheap when the metric demands it.
    - **Cycle trap (Codex Q5):** if later layered on canopy's `loom/incr` Datalog
      substrate (`Relation` + `MemoMap`), a transitive-closure `MemoMap` compute
      fn MUST walk the base parent/def edges directly (iterative BFS or Datalog
@@ -365,7 +436,11 @@ breaking change):
      memo cycle the runtime aborts (cf. memory `project_incr_impact_bfs_cycle_trap`).
 2. **loom generalization:** the language-agnostic `graph.mbt` core can be lifted
    into a loom sibling package; per-language builders supply rules. v1 keeps the
-   core in its own file to make this a move, not a rewrite.
+   core in its own file to make this *mostly* a move. The one non-move is
+   `DeclKind`: it is lambda-specific, so the lift makes `Decl` generic over its
+   kind (`Decl[K]`) and each language supplies its own kind enum (see the
+   `graph.mbt` §"DeclKind is the one lambda-specific type" note). A small,
+   bounded generalization — not a rewrite.
 
 ## Open questions
 

--- a/lang/lambda/edits/moon.pkg
+++ b/lang/lambda/edits/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/canopy/lang/lambda/scope" @scope,
   "dowdiness/lambda" @parser,
   "dowdiness/lambda/ast",
   "dowdiness/loom/core" @loomcore,

--- a/lang/lambda/edits/moon.pkg
+++ b/lang/lambda/edits/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
-  "dowdiness/canopy/lang/lambda/scope" @scope,
+  "dowdiness/canopy/lang/lambda/scope",
   "dowdiness/lambda" @parser,
   "dowdiness/lambda/ast",
   "dowdiness/loom/core" @loomcore,

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -22,7 +22,10 @@ fn norm_binder(b : BindingSite) -> (String, NodeId, Int) {
 /// One equivalence check: declaration() must agree with resolve_binder on the
 /// chosen Var node. Returns true if both sides normalize to the same value
 /// (including both-None).
-fn agree(text : String, locate : (@core.ProjNode[@ast.Term]) -> NodeId) -> Bool raise {
+fn agree(
+  text : String,
+  locate : (@core.ProjNode[@ast.Term]) -> NodeId,
+) -> Bool raise {
   let (proj, _errs) = parse_to_proj_node(text)
   let fp = FlatProj::from_proj_node(proj)
   let sm = SourceMap::from_ast(proj)
@@ -33,7 +36,8 @@ fn agree(text : String, locate : (@core.ProjNode[@ast.Term]) -> NodeId) -> Bool 
     Some(d) => Some(norm_decl(d))
     None => None
   }
-  let old_site = match resolve_binder(var_id, var_name_of(proj, var_id), fp, registry, sm) {
+  let old_site = match
+    resolve_binder(var_id, var_name_of(proj, var_id), fp, registry, sm) {
     Some(b) => Some(norm_binder(b))
     None => None
   }
@@ -87,7 +91,13 @@ test "equivalence: declaration() matches resolve_binder across all binding rules
   inspect(agree("λx. x", root => root.children[0].id()), content="true") // lam param
   inspect(agree("let x = 0\nx", root => find_var(root, "x")), content="true") // module body
   inspect(agree("let x = x\nx", root => find_var(root, "x")), content="true") // self-ref (first x is init → unbound)
-  inspect(agree("let x = 1\nlet x = 2\nx", root => find_var(root, "x")), content="true") // shadowing / latest
-  inspect(agree("let a = b\nlet b = 1\na", root => find_var(root, "b")), content="true") // earlier can't see later (free)
+  inspect(
+    agree("let x = 1\nlet x = 2\nx", root => find_var(root, "x")),
+    content="true",
+  ) // shadowing / latest
+  inspect(
+    agree("let a = b\nlet b = 1\na", root => find_var(root, "b")),
+    content="true",
+  ) // earlier can't see later (free)
   inspect(agree("λx. λx. x", root => find_var(root, "x")), content="true") // nested lam shadow
 }

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -100,7 +100,10 @@ test "equivalence: declaration() matches resolve_binder across all binding rules
     content="true",
   ) // earlier can't see later (free)
   inspect(agree("λx. λx. x", root => find_var(root, "x")), content="true") // nested lam shadow
-  inspect(agree("let x = 0\nλx. x", root => find_var(root, "x")), content="true") // lam param shadows same-name module def
+  inspect(
+    agree("let x = 0\nλx. x", root => find_var(root, "x")),
+    content="true",
+  ) // lam param shadows same-name module def
   inspect(
     agree("let x = 1\nlet x = x\nx", root => find_var(root, "x")),
     content="true",

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -100,4 +100,9 @@ test "equivalence: declaration() matches resolve_binder across all binding rules
     content="true",
   ) // earlier can't see later (free)
   inspect(agree("λx. λx. x", root => find_var(root, "x")), content="true") // nested lam shadow
+  inspect(agree("let x = 0\nλx. x", root => find_var(root, "x")), content="true") // lam param shadows same-name module def
+  inspect(
+    agree("let x = 1\nlet x = x\nx", root => find_var(root, "x")),
+    content="true",
+  ) // later def init resolves to earlier same-name def (not itself)
 }

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -1,0 +1,93 @@
+///|
+/// Normalize a scope-graph Decl to (tag, node_id, def_index); def_index = -1
+/// for lambda params.
+fn norm_decl(decl : @scope.Decl) -> (String, NodeId, Int) {
+  match decl.kind {
+    DeclKind::LamParam(lam_id~) => ("lam", lam_id, -1)
+    DeclKind::ModuleDef(def_index~) => ("module", decl.node_id, def_index)
+  }
+}
+
+///|
+/// Normalize an edits BindingSite to the same shape.
+fn norm_binder(b : BindingSite) -> (String, NodeId, Int) {
+  match b {
+    LamBinder(lam_id~) => ("lam", lam_id, -1)
+    ModuleBinder(binding_node_id~, def_index~) =>
+      ("module", binding_node_id, def_index)
+  }
+}
+
+///|
+/// One equivalence check: declaration() must agree with resolve_binder on the
+/// chosen Var node. Returns true if both sides normalize to the same value
+/// (including both-None).
+fn agree(text : String, locate : (@core.ProjNode[@ast.Term]) -> NodeId) -> Bool raise {
+  let (proj, _errs) = parse_to_proj_node(text)
+  let fp = FlatProj::from_proj_node(proj)
+  let sm = SourceMap::from_ast(proj)
+  let registry = scope_test_registry(proj)
+  let g = @scope.build(fp, registry, sm)
+  let var_id = locate(proj)
+  let new_site = match @scope.declaration(g, var_id) {
+    Some(d) => Some(norm_decl(d))
+    None => None
+  }
+  let old_site = match resolve_binder(var_id, var_name_of(proj, var_id), fp, registry, sm) {
+    Some(b) => Some(norm_binder(b))
+    None => None
+  }
+  new_site == old_site
+}
+
+///|
+/// Look up the Var name at a NodeId (resolve_binder needs the name string).
+fn var_name_of(root : @core.ProjNode[@ast.Term], id : NodeId) -> String {
+  let mut out = ""
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if n.id() == id {
+      match n.kind {
+        @ast.Term::Var(x) => out = x
+        @ast.Term::Unbound(x) => out = x
+        _ => ()
+      }
+    }
+    for c in n.children {
+      walk(c)
+    }
+  }
+
+  walk(root)
+  out
+}
+
+///|
+/// Find first Var named `name` (helper for locators).
+fn find_var(root : @core.ProjNode[@ast.Term], name : String) -> NodeId {
+  let mut found : NodeId? = None
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if found is Some(_) {
+      return
+    }
+    if n.kind is @ast.Term::Var(x) && x == name {
+      found = Some(n.id())
+    }
+    for c in n.children {
+      walk(c)
+    }
+  }
+
+  walk(root)
+  found.unwrap()
+}
+
+///|
+test "equivalence: declaration() matches resolve_binder across all binding rules" {
+  // (description, source, locator)
+  inspect(agree("λx. x", root => root.children[0].id()), content="true") // lam param
+  inspect(agree("let x = 0\nx", root => find_var(root, "x")), content="true") // module body
+  inspect(agree("let x = x\nx", root => find_var(root, "x")), content="true") // self-ref (first x is init → unbound)
+  inspect(agree("let x = 1\nlet x = 2\nx", root => find_var(root, "x")), content="true") // shadowing / latest
+  inspect(agree("let a = b\nlet b = 1\na", root => find_var(root, "b")), content="true") // earlier can't see later (free)
+  inspect(agree("λx. λx. x", root => find_var(root, "x")), content="true") // nested lam shadow
+}

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -95,6 +95,9 @@ fn rename_lam_param(
 }
 
 ///|
+using @scope { type DeclKind }
+
+///|
 /// Rename a variable by resolving its binder and renaming at the definition site + all usages.
 fn rename_from_var(
   ctx : EditContext[@ast.Term],
@@ -102,25 +105,18 @@ fn rename_from_var(
   old_name : String,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  guard resolve_binder(
-      var_node_id,
-      old_name,
-      ctx.flat_proj,
-      ctx.registry,
-      ctx.source_map,
-    )
-    is Some(binder) else {
+  let g = @scope.build(ctx.flat_proj, ctx.registry, ctx.source_map)
+  guard @scope.declaration(g, var_node_id) is Some(decl) else {
     return Err("No binding found for variable: " + old_name)
   }
-  match binder {
-    LamBinder(lam_id~) =>
+  match decl.kind {
+    DeclKind::LamParam(lam_id~) =>
       match ctx.registry.get(lam_id) {
         Some(lam_node) =>
           rename_lam_param(ctx, lam_id, lam_node, old_name, new_name)
         None => Err("Lambda node not found in registry")
       }
-    ModuleBinder(binding_node_id~, def_index~) => {
-      let _ = binding_node_id
+    DeclKind::ModuleDef(def_index~) => {
       // Find the Module node in the registry
       let mut module_id : NodeId? = None
       for pid, pnode in ctx.registry {

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -95,7 +95,7 @@ fn rename_lam_param(
 }
 
 ///|
-using @scope { type DeclKind }
+using @scope {type DeclKind}
 
 ///|
 /// Rename a variable by resolving its binder and renaming at the definition site + all usages.

--- a/lang/lambda/proj/flat_proj.mbt
+++ b/lang/lambda/proj/flat_proj.mbt
@@ -38,12 +38,15 @@ pub fn to_flat_proj(root : @seam.SyntaxNode, counter : Ref[Int]) -> FlatProj {
 ///|
 /// Build a FlatProj incrementally by comparing old and new CST children.
 ///
-/// For each child pair, compares underlying CstNodes. If unchanged
-/// (physical_equal via NodeInterner), reuses the old FlatProj entry
-/// directly — skipping both syntax_to_proj_node and reconcile.
-/// Only changed children are rebuilt and reconciled.
+/// For each child pair, compares start offset plus underlying CstNodes
+/// structurally. If unchanged, reuses the old FlatProj entry directly —
+/// skipping both syntax_to_proj_node and reconcile. Only changed children are
+/// rebuilt and reconciled.
 ///
-/// Cost: O(n) CstNode pointer comparisons + O(changed_subtree) rebuilds.
+/// Source-span CSTs no longer guarantee canonical physical identity across
+/// parses, so equality must use the stable structural CstNode contract.
+///
+/// Cost: O(n) CstNode equality checks + O(changed_subtree) rebuilds.
 pub fn to_flat_proj_incremental(
   new_root : @seam.SyntaxNode,
   old_root : @seam.SyntaxNode,
@@ -63,9 +66,10 @@ pub fn to_flat_proj_incremental(
     }
   }
   // Parallel scan: compare new LetDefs against old LetDefs by index.
-  // physical_equal checks pointer identity (same interned CstNode object).
-  // When content and position are both unchanged, the parser returns
-  // the exact same object, making physical_equal true.
+  // CstNode equality is structural and source-span independent, so unchanged
+  // definitions are recognized even when the parser rebuilt current-source
+  // token spans instead of returning the exact same heap object. The start
+  // check keeps reused ProjNode/source-map positions valid after shifts.
   let defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)] = []
   let mut final_proj : ProjNode[@ast.Term]? = None
   let mut old_def_idx = 0
@@ -76,8 +80,9 @@ pub fn to_flat_proj_incremental(
       if old_def_idx < old_let_children.length() &&
         old_def_idx < old_fp.defs.length() {
         let old_child = old_let_children[old_def_idx]
-        if physical_equal(new_child.cst_node(), old_child.cst_node()) {
-          // Same pointer — safe to reuse old entry with same positions
+        if new_child.start() == old_child.start() &&
+          new_child.cst_node() == old_child.cst_node() {
+          // Same start and structure — safe to reuse old entry with same positions
           let old_entry = old_fp.defs[old_def_idx]
           defs.push((old_entry.0, old_entry.1, old_entry.2, old_entry.3))
           reused = true
@@ -99,7 +104,8 @@ pub fn to_flat_proj_incremental(
       }
     } else if final_proj is None {
       match old_final_child {
-        Some(old_fc) if physical_equal(new_child.cst_node(), old_fc.cst_node()) =>
+        Some(old_fc) if new_child.start() == old_fc.start() &&
+          new_child.cst_node() == old_fc.cst_node() =>
           final_proj = old_fp.final_expr
         _ => {
           any_changed = true

--- a/lang/lambda/proj/flat_proj_wbtest.mbt
+++ b/lang/lambda/proj/flat_proj_wbtest.mbt
@@ -321,9 +321,9 @@ test "FlatProj::to_proj_node: Module node_id seeded None still allocates fresh" 
 
 ///|
 test "to_flat_proj_incremental: changed_indices records non-reused defs" {
-  // NodeInterner deduplicates by structure: unchanged def x=1 gets the same
-  // interned CstNode even across independent parses, so physical_equal = true.
-  // Only the changed def (y=3 vs y=2) fails physical_equal → index 1 recorded.
+  // CstNode equality is structural: unchanged def x=1 at the same start offset
+  // compares equal even when source-span token rebasing rebuilds CST nodes.
+  // Only the changed def (y=3 vs y=2) fails equality → index 1 recorded.
   let counter = Ref(0)
   let old_root = parse_syntax("let x = 1\nlet y = 2\nx")
   let old_fp = to_flat_proj(old_root, counter)
@@ -343,11 +343,32 @@ test "to_flat_proj_incremental: changed_indices records non-reused defs" {
 }
 
 ///|
+test "to_flat_proj_incremental: shifted unchanged children are rebuilt" {
+  let counter = Ref(0)
+  let old_root = parse_syntax("let a = 0\nlet x = 1\nx")
+  let old_fp = to_flat_proj(old_root, counter)
+  let new_root = parse_syntax("let aa = 0\nlet x = 1\nx")
+  let changed = Ref(([] : Array[Int]))
+  let result = to_flat_proj_incremental(
+    new_root,
+    old_root,
+    old_fp,
+    counter,
+    changed_indices=changed,
+  )
+  ignore(result)
+  // The second def and final expression are structurally unchanged, but their
+  // source offsets shifted after the first def grew; reusing old ProjNodes would
+  // preserve stale source-map positions.
+  debug_inspect(changed.val, content="[0, 1, -1]")
+}
+
+///|
 test "to_flat_proj_incremental: same root means zero changed" {
   let counter = Ref(0)
   let root = parse_syntax("let x = 1\nlet y = 2\nx")
   let fp = to_flat_proj(root, counter)
-  // Same SyntaxNode — physical_equal succeeds for all children
+  // Same SyntaxNode — structural equality succeeds for all children
   let changed = Ref(([] : Array[Int]))
   let result = to_flat_proj_incremental(
     root,

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -13,3 +13,102 @@ pub fn build_parent_map(
   }
   parents
 }
+
+///|
+/// Mutable builder state accumulated across passes.
+priv struct Builder {
+  scopes : Array[Scope]
+  decls : Array[Decl]
+  refs : Array[Ref]
+  node_scope : Map[@core.NodeId, ScopeId]
+}
+
+///|
+fn Builder::new() -> Builder {
+  { scopes: [], decls: [], refs: [], node_scope: {} }
+}
+
+///|
+fn Builder::add_scope(self : Builder, parent : ScopeId?) -> ScopeId {
+  let id = ScopeId(self.scopes.length())
+  self.scopes.push({ id, parent, decl_ids: [], ref_ids: [] })
+  id
+}
+
+///|
+fn Builder::add_decl(
+  self : Builder,
+  scope : ScopeId,
+  node_id : @core.NodeId,
+  name : String,
+  kind : DeclKind,
+) -> DeclId {
+  let ScopeId(si) = scope
+  let id = DeclId(self.decls.length())
+  self.decls.push({ id, node_id, name, scope, kind })
+  self.scopes[si].decl_ids.push(id)
+  id
+}
+
+///|
+/// The registry's root is the node that is no other node's child.
+fn root_node(
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> @core.ProjNode[@ast.Term] {
+  let parents = build_parent_map(registry)
+  let mut root : @core.ProjNode[@ast.Term]? = None
+  for id, node in registry {
+    if parents.get(id) is None {
+      root = Some(node)
+    }
+  }
+  root.unwrap()
+}
+
+///|
+/// Pass 2: root module scope, ModuleDef decls (one per flat def), and a child
+/// LamParam scope per Lam node. Records node→scope membership.
+fn Builder::pass2(
+  self : Builder,
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> Unit {
+  let root_scope = self.add_scope(None)
+  for i, def in flat_proj.defs {
+    let (name, _init, _start, binder_id) = def
+    let _ = self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
+  }
+  fn walk(node : @core.ProjNode[@ast.Term], current : ScopeId) -> Unit {
+    self.node_scope[node.id()] = current
+    match node.kind {
+      @ast.Term::Lam(param, _) => {
+        let lam_scope = self.add_scope(Some(current))
+        let _ = self.add_decl(
+          lam_scope, node.id(), param, LamParam(lam_id=node.id()),
+        )
+        for child in node.children {
+          walk(child, lam_scope)
+        }
+      }
+      _ =>
+        for child in node.children {
+          walk(child, current)
+        }
+    }
+  }
+
+  walk(root_node(registry), root_scope)
+}
+
+///|
+/// Build the scope graph (Pass 2 only for now; Pass 3 added next task).
+pub fn build(
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  source_map : @core.SourceMap,
+) -> ScopeGraph {
+  let _ = source_map // used in Pass 3
+  let b = Builder::new()
+  b.pass2(flat_proj, registry)
+  { scopes: b.scopes, decls: b.decls, refs: b.refs }
+}

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -84,7 +84,10 @@ fn Builder::pass2(
       @ast.Term::Lam(param, _) => {
         let lam_scope = self.add_scope(Some(current))
         let _ = self.add_decl(
-          lam_scope, node.id(), param, LamParam(lam_id=node.id()),
+          lam_scope,
+          node.id(),
+          param,
+          LamParam(lam_id=node.id()),
         )
         for child in node.children {
           walk(child, lam_scope)

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -1,0 +1,15 @@
+///|
+/// Pass 1: build a `NodeId -> parent NodeId` map by walking the registry's
+/// ProjNode tree. Each node appears in exactly one parent's `children`
+/// array, so the map is acyclic by construction. O(N).
+pub fn build_parent_map(
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+) -> Map[@core.NodeId, @core.NodeId] {
+  let parents : Map[@core.NodeId, @core.NodeId] = {}
+  for _id, node in registry {
+    for child in node.children {
+      parents[child.id()] = node.id()
+    }
+  }
+  parents
+}

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -101,14 +101,116 @@ fn Builder::pass2(
 }
 
 ///|
-/// Build the scope graph (Pass 2 only for now; Pass 3 added next task).
+fn Builder::add_ref(
+  self : Builder,
+  scope : ScopeId,
+  node_id : @core.NodeId,
+  name : String,
+  resolution : Resolution,
+) -> Unit {
+  let ScopeId(si) = scope
+  let id = RefId(self.refs.length())
+  self.refs.push({ id, node_id, name, scope, resolution })
+  self.scopes[si].ref_ids.push(id)
+}
+
+///|
+/// Which flat-def index a node sits within, by source position; returns the
+/// def count (body sentinel) when the node is in the module body. Mirrors
+/// resolve_binder's def-range containment (scope.mbt:30-39).
+fn containing_def_index(
+  flat_proj : @lambda_proj.FlatProj,
+  source_map : @core.SourceMap,
+  node_id : @core.NodeId,
+) -> Int {
+  guard source_map.get_range(node_id) is Some(r) else {
+    return flat_proj.defs.length()
+  }
+  let pos = r.start
+  for i, def in flat_proj.defs {
+    let (_n, init, _s, _id) = def
+    if source_map.get_range(init.id()) is Some(dr) &&
+      pos >= dr.start &&
+      pos < dr.end {
+      return i
+    }
+  }
+  flat_proj.defs.length()
+}
+
+///|
+/// Resolve `name` from `start_scope` upward. ModuleDef decls are visible only
+/// if def_index < cutoff (sequential rule). Records scopes visited that did
+/// not contain the name (negative observation).
+fn Builder::resolve(
+  self : Builder,
+  name : String,
+  start_scope : ScopeId,
+  cutoff : Int,
+) -> Resolution {
+  let visited : Array[ScopeId] = []
+  let mut cur : ScopeId? = Some(start_scope)
+  while cur is Some(sid) {
+    let ScopeId(si) = sid
+    let scope = self.scopes[si]
+    let mut hit : DeclId? = None
+    // later decls win within a scope (shadowing); module scope respects cutoff.
+    for did in scope.decl_ids {
+      let DeclId(di) = did
+      let decl = self.decls[di]
+      if decl.name == name {
+        match decl.kind {
+          ModuleDef(def_index~) => if def_index < cutoff { hit = Some(did) }
+          LamParam(_) => hit = Some(did)
+        }
+      }
+    }
+    if hit is Some(_) {
+      return { decl: hit, visited_scopes: visited }
+    }
+    visited.push(sid)
+    cur = scope.parent
+  }
+  { decl: None, visited_scopes: visited }
+}
+
+///|
+/// Pass 3: emit a Ref for each Var/Unbound node and resolve it.
+/// Invariant: pass2 walks the registry's root tree and records `node_scope`
+/// for every node, and the registry itself is that same tree — so every
+/// Var/Unbound node here has a recorded scope. `node_scope.get(..).unwrap()`
+/// therefore asserts that invariant: a missing scope means the registry held a
+/// node not reachable from root (a structural defect), and a loud abort is
+/// correct — silently defaulting to the root scope would mis-resolve it.
+fn Builder::pass3(
+  self : Builder,
+  flat_proj : @lambda_proj.FlatProj,
+  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  source_map : @core.SourceMap,
+) -> Unit {
+  for _id, node in registry {
+    let name = match node.kind {
+      @ast.Term::Var(x) => Some(x)
+      @ast.Term::Unbound(x) => Some(x)
+      _ => None
+    }
+    guard name is Some(n) else { continue }
+    let scope = self.node_scope.get(node.id()).unwrap()
+    let cutoff = containing_def_index(flat_proj, source_map, node.id())
+    let resolution = self.resolve(n, scope, cutoff)
+    self.add_ref(scope, node.id(), n, resolution)
+  }
+}
+
+///|
+/// Build the scope graph (Pass 2 then Pass 3).
 pub fn build(
   flat_proj : @lambda_proj.FlatProj,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
-  let _ = source_map // used in Pass 3
   let b = Builder::new()
   b.pass2(flat_proj, registry)
+  b.pass3(flat_proj, registry, source_map)
   { scopes: b.scopes, decls: b.decls, refs: b.refs }
 }

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -2,7 +2,9 @@
 /// Pass 1: build a `NodeId -> parent NodeId` map by walking the registry's
 /// ProjNode tree. Each node appears in exactly one parent's `children`
 /// array, so the map is acyclic by construction. O(N).
-pub fn build_parent_map(
+/// Internal Pass-1 helper (used by `root_node` + whitebox tests) — not part of
+/// the package's public surface.
+fn build_parent_map(
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
 ) -> Map[@core.NodeId, @core.NodeId] {
   let parents : Map[@core.NodeId, @core.NodeId] = {}

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -58,13 +58,10 @@ fn root_node(
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
 ) -> @core.ProjNode[@ast.Term] {
   let parents = build_parent_map(registry)
-  let mut root : @core.ProjNode[@ast.Term]? = None
-  for id, node in registry {
-    if parents.get(id) is None {
-      root = Some(node)
-    }
-  }
-  root.unwrap()
+  registry
+  .values()
+  .find_first(fn(node) { parents.get(node.id()) is None })
+  .unwrap()
 }
 
 ///|
@@ -132,15 +129,14 @@ fn containing_def_index(
     return flat_proj.defs.length()
   }
   let pos = r.start
-  for i, def in flat_proj.defs {
+  flat_proj.defs
+  .search_by(fn(def) {
     let (_n, init, _s, _id) = def
-    if source_map.get_range(init.id()) is Some(dr) &&
-      pos >= dr.start &&
-      pos < dr.end {
-      return i
-    }
-  }
-  flat_proj.defs.length()
+    source_map.get_range(init.id()) is Some(dr) &&
+    pos >= dr.start &&
+    pos < dr.end
+  })
+  .unwrap_or(flat_proj.defs.length())
 }
 
 ///|

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -1,0 +1,67 @@
+///|
+/// Graph-local compact indices. NOT persistent identity — `@core.NodeId`
+/// carries persistent identity; these index into the graph's own arrays.
+pub(all) struct ScopeId(Int) derive(Debug, Eq, Hash, Compare)
+
+///|
+pub(all) struct DeclId(Int) derive(Debug, Eq, Hash, Compare)
+
+///|
+pub(all) struct RefId(Int) derive(Debug, Eq, Hash, Compare)
+
+///|
+/// The kind of binding site a declaration represents. The one lambda-specific
+/// type here (see design spec). A future loom lift makes `Decl` generic over
+/// this (`Decl[K]`).
+pub(all) enum DeclKind {
+  LamParam(lam_id~ : @core.NodeId)
+  ModuleDef(def_index~ : Int)
+} derive(Debug, Eq)
+
+///|
+/// A lexical scope. `parent` is the enclosing scope (None for the root).
+pub(all) struct Scope {
+  id : ScopeId
+  parent : ScopeId?
+  decl_ids : Array[DeclId]
+  ref_ids : Array[RefId]
+} derive(Debug)
+
+///|
+/// A declaration (binding site), keyed by the projection NodeId it occupies.
+pub(all) struct Decl {
+  id : DeclId
+  node_id : @core.NodeId
+  name : String
+  scope : ScopeId
+  kind : DeclKind
+} derive(Debug, Eq)
+
+///|
+/// A reference (use site), keyed by NodeId, with its resolution result.
+pub(all) struct Ref {
+  id : RefId
+  node_id : @core.NodeId
+  name : String
+  scope : ScopeId
+  resolution : Resolution
+} derive(Debug)
+
+///|
+/// Resolution outcome for a reference.
+/// `decl: None` is a NEGATIVE OBSERVATION (unresolved / free).
+/// `visited_scopes` records scopes checked and found NOT to contain the
+/// name — populated in v1 as a by-product of the resolution walk, read only
+/// by a future incremental layer (see design spec).
+pub(all) struct Resolution {
+  decl : DeclId?
+  visited_scopes : Array[ScopeId]
+} derive(Debug)
+
+///|
+/// The binding index for one lambda module.
+pub(all) struct ScopeGraph {
+  scopes : Array[Scope]
+  decls : Array[Decl]
+  refs : Array[Ref]
+} derive(Debug)

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -41,6 +41,21 @@ fn find_var_node(
 }
 
 ///|
+test "build: module defs become ModuleDef decls in root scope" {
+  let (_proj, flat_proj, registry, source_map) = build_fixture(
+    "let a = 1\nlet b = 2\nb",
+  )
+  let g = build(flat_proj, registry, source_map)
+  inspect(g.decls.length(), content="2")
+  guard g.decls[0].kind is ModuleDef(def_index=d0)
+  inspect(d0, content="0")
+  guard g.decls[1].kind is ModuleDef(def_index=d1)
+  inspect(d1, content="1")
+  let ScopeId(s0) = g.decls[0].scope
+  inspect(s0, content="0")
+}
+
+///|
 test "build_parent_map: child maps to parent" {
   // Hand-built tree: root(id=0) Lam with one child Var(id=1).
   let child = @core.ProjNode::new(@ast.Term::Var("x"), 0, 1, 1, [])

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -161,3 +161,25 @@ test "resolve: earlier def cannot see later def" {
   let init_var = find_var_in_def_init(proj, 0, "b")
   inspect(declaration(g, init_var) is None, content="true")
 }
+
+///|
+test "references: identity-based, shadowing-aware" {
+  let (_proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = 2\nx",
+  )
+  let g = build(flat_proj, registry, source_map)
+  let def1 = g.decls[1].node_id
+  let def0 = g.decls[0].node_id
+  inspect(references(g, def1).length() >= 1, content="true")
+  inspect(references(g, def0).length(), content="0")
+}
+
+///|
+test "enclosing_env: lambda params in scope" {
+  let (proj, flat_proj, registry, source_map) = build_fixture("λx. λy. x")
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(proj, "x")
+  let env = enclosing_env(g, var_node)
+  inspect(env.contains("x"), content="true")
+  inspect(env.contains("y"), content="true")
+}

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -1,0 +1,61 @@
+///|
+/// Build (proj, flat_proj, registry, source_map) from source.
+fn build_fixture(
+  text : String,
+) -> (
+  @core.ProjNode[@ast.Term],
+  @lambda_proj.FlatProj,
+  Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  @core.SourceMap,
+) raise {
+  let (proj, _errs) = @lambda_proj.parse_to_proj_node(text)
+  let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
+  let source_map = @core.SourceMap::from_ast(proj)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(proj, registry)
+  (proj, flat_proj, registry, source_map)
+}
+
+///|
+/// Find the first Var node with the given name anywhere in the tree.
+fn find_var_node(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId {
+  let mut found : @core.NodeId? = None
+  fn walk(n : @core.ProjNode[@ast.Term]) -> Unit {
+    if found is Some(_) {
+      return
+    }
+    if n.kind is @ast.Term::Var(x) && x == name {
+      found = Some(n.id())
+      return
+    }
+    for c in n.children {
+      walk(c)
+    }
+  }
+
+  walk(root)
+  found.unwrap()
+}
+
+///|
+test "build_parent_map: child maps to parent" {
+  // Hand-built tree: root(id=0) Lam with one child Var(id=1).
+  let child = @core.ProjNode::new(@ast.Term::Var("x"), 0, 1, 1, [])
+  let root = @core.ProjNode::new(
+    @ast.Term::Lam("x", @ast.Term::Var("x")),
+    0,
+    5,
+    0,
+    [child],
+  )
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let parents = build_parent_map(registry)
+  inspect(parents.get(@core.NodeId::from_int(1)) is Some(_), content="true")
+  guard parents.get(@core.NodeId::from_int(1)) is Some(p)
+  inspect(p == @core.NodeId::from_int(0), content="true")
+  inspect(parents.get(@core.NodeId::from_int(0)) is None, content="true")
+}

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -130,3 +130,34 @@ test "resolve: second def init binds to first def" {
   guard decl.kind is ModuleDef(def_index~)
   inspect(def_index, content="0")
 }
+
+///|
+test "resolve: innermost lambda shadowing" {
+  let (proj, flat_proj, registry, source_map) = build_fixture("λx. λx. x")
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(proj, "x")
+  guard declaration(g, var_node) is Some(decl)
+  inspect(decl.kind is LamParam(_), content="true")
+}
+
+///|
+test "resolve: body binds to latest def" {
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = 2\nx",
+  )
+  let g = build(flat_proj, registry, source_map)
+  let body_var = find_var_in_body(proj, "x")
+  guard declaration(g, body_var) is Some(decl)
+  guard decl.kind is ModuleDef(def_index~)
+  inspect(def_index, content="1")
+}
+
+///|
+test "resolve: earlier def cannot see later def" {
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let a = b\nlet b = 1\na",
+  )
+  let g = build(flat_proj, registry, source_map)
+  let init_var = find_var_in_def_init(proj, 0, "b")
+  inspect(declaration(g, init_var) is None, content="true")
+}

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -74,3 +74,59 @@ test "build_parent_map: child maps to parent" {
   inspect(p == @core.NodeId::from_int(0), content="true")
   inspect(parents.get(@core.NodeId::from_int(0)) is None, content="true")
 }
+
+///|
+/// Find the Var with `name` in the module body (the final/last child).
+fn find_var_in_body(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId {
+  match root.kind {
+    @ast.Term::Module(_, _) =>
+      find_var_node(root.children[root.children.length() - 1], name)
+    _ => find_var_node(root, name)
+  }
+}
+
+///|
+/// Find the Var with `name` inside the init expression of flat def `idx`.
+/// def inits are the Module's leading children (before the body).
+fn find_var_in_def_init(
+  root : @core.ProjNode[@ast.Term],
+  idx : Int,
+  name : String,
+) -> @core.NodeId {
+  match root.kind {
+    @ast.Term::Module(_, _) => find_var_node(root.children[idx], name)
+    _ => find_var_node(root, name)
+  }
+}
+
+///|
+test "resolve: lambda param" {
+  let (proj, flat_proj, registry, source_map) = build_fixture("λx. x")
+  let g = build(flat_proj, registry, source_map)
+  let var_node = find_var_node(proj, "x")
+  guard declaration(g, var_node) is Some(decl)
+  inspect(decl.kind is LamParam(_), content="true")
+}
+
+///|
+test "resolve: self-reference is unbound" {
+  let (proj, flat_proj, registry, source_map) = build_fixture("let x = x\nx")
+  let g = build(flat_proj, registry, source_map)
+  let init_var = find_var_in_def_init(proj, 0, "x")
+  inspect(declaration(g, init_var) is None, content="true")
+}
+
+///|
+test "resolve: second def init binds to first def" {
+  let (proj, flat_proj, registry, source_map) = build_fixture(
+    "let x = 1\nlet x = x\nx",
+  )
+  let g = build(flat_proj, registry, source_map)
+  let init_var = find_var_in_def_init(proj, 1, "x")
+  guard declaration(g, init_var) is Some(decl)
+  guard decl.kind is ModuleDef(def_index~)
+  inspect(def_index, content="0")
+}

--- a/lang/lambda/scope/moon.pkg
+++ b/lang/lambda/scope/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/immut/hashset" @immut/hashset,
+}
+
+warnings = "-2-6-29"

--- a/lang/lambda/scope/oracle_wbtest.mbt
+++ b/lang/lambda/scope/oracle_wbtest.mbt
@@ -1,0 +1,10 @@
+// Layer 2 caimeox differential oracle deferred to follow-up — see
+// docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md.
+//
+// Deferred because integrating CAIMEOX/scope_graph would add a third-party
+// dependency to moon.mod.json (it is not a current dep — see moon.mod.json)
+// mid-PR, and this repo treats new external deps as a CI/build-fragility risk.
+// Layer 2 is explicitly non-blocking: Layer 1 (graph_wbtest) + Layer 3
+// (scope_equivalence_wbtest) are the shipping gates, and both pass. The
+// differential oracle lands as a separate follow-up PR if/when the dependency
+// is vetted.

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -1,0 +1,74 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/lambda/scope"
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/proj",
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/immut/hashset",
+}
+
+// Values
+pub fn build(@proj.FlatProj, Map[@core.NodeId, @core.ProjNode[@ast.Term]], @core.SourceMap) -> ScopeGraph
+
+pub fn build_parent_map(Map[@core.NodeId, @core.ProjNode[@ast.Term]]) -> Map[@core.NodeId, @core.NodeId]
+
+pub fn declaration(ScopeGraph, @core.NodeId) -> Decl?
+
+pub fn enclosing_env(ScopeGraph, @core.NodeId) -> @hashset.HashSet[String]
+
+pub fn references(ScopeGraph, @core.NodeId) -> Array[@core.NodeId]
+
+// Errors
+
+// Types and methods
+pub(all) struct Decl {
+  id : DeclId
+  node_id : @core.NodeId
+  name : String
+  scope : ScopeId
+  kind : DeclKind
+} derive(Eq, @debug.Debug)
+
+pub(all) struct DeclId(Int) derive(Compare, Eq, Hash, @debug.Debug)
+
+pub(all) enum DeclKind {
+  LamParam(lam_id~ : @core.NodeId)
+  ModuleDef(def_index~ : Int)
+} derive(Eq, @debug.Debug)
+
+pub(all) struct Ref {
+  id : RefId
+  node_id : @core.NodeId
+  name : String
+  scope : ScopeId
+  resolution : Resolution
+} derive(@debug.Debug)
+
+pub(all) struct RefId(Int) derive(Compare, Eq, Hash, @debug.Debug)
+
+pub(all) struct Resolution {
+  decl : DeclId?
+  visited_scopes : Array[ScopeId]
+} derive(@debug.Debug)
+
+pub(all) struct Scope {
+  id : ScopeId
+  parent : ScopeId?
+  decl_ids : Array[DeclId]
+  ref_ids : Array[RefId]
+} derive(@debug.Debug)
+
+pub(all) struct ScopeGraph {
+  scopes : Array[Scope]
+  decls : Array[Decl]
+  refs : Array[Ref]
+} derive(@debug.Debug)
+
+pub(all) struct ScopeId(Int) derive(Compare, Eq, Hash, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -12,8 +12,6 @@ import {
 // Values
 pub fn build(@proj.FlatProj, Map[@core.NodeId, @core.ProjNode[@ast.Term]], @core.SourceMap) -> ScopeGraph
 
-pub fn build_parent_map(Map[@core.NodeId, @core.ProjNode[@ast.Term]]) -> Map[@core.NodeId, @core.NodeId]
-
 pub fn declaration(ScopeGraph, @core.NodeId) -> Decl?
 
 pub fn enclosing_env(ScopeGraph, @core.NodeId) -> @hashset.HashSet[String]

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -14,3 +14,67 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
   }
   None
 }
+
+///|
+/// All reference NodeIds whose resolution points at the decl at `decl_node`.
+/// Identity-based (NOT a name match), so shadowing is respected.
+/// Reserved API surface; consumer migration deferred (see design spec).
+pub fn references(
+  g : ScopeGraph,
+  decl_node : @core.NodeId,
+) -> Array[@core.NodeId] {
+  let mut target : DeclId? = None
+  for d in g.decls {
+    if d.node_id == decl_node {
+      target = Some(d.id)
+      break
+    }
+  }
+  guard target is Some(tid) else { return [] }
+  let out : Array[@core.NodeId] = []
+  for r in g.refs {
+    if r.resolution.decl is Some(rid) && rid == tid {
+      out.push(r.node_id)
+    }
+  }
+  out
+}
+
+///|
+/// The set of names bound in scopes enclosing `node` — the FULL lexical
+/// environment (lambda params AND module defs). This is a SUPERSET of the
+/// existing `collect_lam_env` (which returns only lambda params); it is NOT a
+/// drop-in replacement. Set semantics (membership, not order).
+/// Reserved API surface; consumer migration deferred (see design spec).
+pub fn enclosing_env(
+  g : ScopeGraph,
+  node : @core.NodeId,
+) -> @immut/hashset.HashSet[String] {
+  let mut start : ScopeId? = None
+  for r in g.refs {
+    if r.node_id == node {
+      start = Some(r.scope)
+      break
+    }
+  }
+  if start is None {
+    for d in g.decls {
+      if d.node_id == node {
+        start = Some(d.scope)
+        break
+      }
+    }
+  }
+  let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
+  let mut cur = start
+  while cur is Some(sid) {
+    let ScopeId(si) = sid
+    let scope = g.scopes[si]
+    for did in scope.decl_ids {
+      let DeclId(di) = did
+      env = env.add(g.decls[di].name)
+    }
+    cur = scope.parent
+  }
+  env
+}

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -31,13 +31,9 @@ pub fn references(
     }
   }
   guard target is Some(tid) else { return [] }
-  let out : Array[@core.NodeId] = []
-  for r in g.refs {
-    if r.resolution.decl is Some(rid) && rid == tid {
-      out.push(r.node_id)
-    }
-  }
-  out
+  [
+    for r in g.refs if r.resolution.decl is Some(rid) && rid == tid => r.node_id
+  ]
 }
 
 ///|

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -1,18 +1,14 @@
 ///|
 /// The declaration a reference resolves to, or None if unresolved (free).
 pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
-  for r in g.refs {
-    if r.node_id == ref_node {
-      return match r.resolution.decl {
-        Some(did) => {
-          let DeclId(di) = did
-          Some(g.decls[di])
-        }
-        None => None
-      }
-    }
-  }
-  None
+  g.refs
+  .iter()
+  .find_first(fn(r) { r.node_id == ref_node })
+  .bind(fn(r) { r.resolution.decl })
+  .map(fn(did) {
+    let DeclId(di) = did
+    g.decls[di]
+  })
 }
 
 ///|
@@ -23,14 +19,11 @@ pub fn references(
   g : ScopeGraph,
   decl_node : @core.NodeId,
 ) -> Array[@core.NodeId] {
-  let mut target : DeclId? = None
-  for d in g.decls {
-    if d.node_id == decl_node {
-      target = Some(d.id)
-      break
-    }
+  guard g.decls.iter().find_first(fn(d) { d.node_id == decl_node })
+    is Some(target) else {
+    return []
   }
-  guard target is Some(tid) else { return [] }
+  let tid = target.id
   [
     for r in g.refs if r.resolution.decl is Some(rid) && rid == tid => r.node_id
   ]
@@ -46,20 +39,13 @@ pub fn enclosing_env(
   g : ScopeGraph,
   node : @core.NodeId,
 ) -> @immut/hashset.HashSet[String] {
-  let mut start : ScopeId? = None
-  for r in g.refs {
-    if r.node_id == node {
-      start = Some(r.scope)
-      break
-    }
-  }
-  if start is None {
-    for d in g.decls {
-      if d.node_id == node {
-        start = Some(d.scope)
-        break
-      }
-    }
+  let start = match g.refs.iter().find_first(fn(r) { r.node_id == node }) {
+    Some(r) => Some(r.scope)
+    None =>
+      g.decls
+      .iter()
+      .find_first(fn(d) { d.node_id == node })
+      .map(fn(d) { d.scope })
   }
   let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let mut cur = start

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -1,0 +1,16 @@
+///|
+/// The declaration a reference resolves to, or None if unresolved (free).
+pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
+  for r in g.refs {
+    if r.node_id == ref_node {
+      return match r.resolution.decl {
+        Some(did) => {
+          let DeclId(di) = did
+          Some(g.decls[di])
+        }
+        None => None
+      }
+    }
+  }
+  None
+}


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md`.

## What
v1 non-incremental, **correct** NodeId-keyed binding index for the lambda language in a new `lang/lambda/scope/` package (`graph.mbt` data model + 3-pass `builder.mbt` + `query.mbt`). `rename_from_var`'s binder lookup is migrated from `resolve_binder` to `@scope.declaration()`, with a **table-driven equivalence test** proving behavior preservation across all binding rules (lam param, module body, self-ref, shadowing/latest, earlier-can't-see-later, nested-lam shadow, lam-shadows-module-def, later-def-init). `references()` / `enclosing_env()` are reserved API surface (no v1 consumer). `resolve_binder` is intentionally retained (other callers + the equivalence test depend on it).

The `Resolution` record reserves negative-observation fields (`decl: DeclId?`, `visited_scopes`) for a future incremental layer. Layer 2 (caimeox differential oracle) is deferred to a follow-up (non-blocking — see `lang/lambda/scope/oracle_wbtest.mbt`); Layer 1 (`graph_wbtest`) + Layer 3 (`scope_equivalence_wbtest`) are the shipping gates and both pass.

## Verification
- Full workspace: **1231/1231 tests pass**; `moon check` clean.
- Per-task TDD (red→green) + two-stage review; Codex pre-PR review: **PASS** (no Critical/Important findings).
- Migration is behavior-preserving: the equivalence test was written and passing against the live `resolve_binder` *before* the production swap.

## Reuse check
`declaration()` reproduces the existing `BindingSite` contract; reused `@core.NodeId`, `@core.ProjNode`, `@core.SourceMap`, `@lambda_proj.FlatProj` — no duplicate types introduced. No `moon.work` change (root `.` member already covers the new package).

## Note on branch contents
This branch also carries two pre-existing non-scope-graph commits that were already on it: the `flat_proj` reuse-identity fix (`71acf92`) and a `loom` submodule pointer bump (`eba2fc0`→`c52e177`, already on loom's `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced scope graph infrastructure for improved variable binding and resolution in lambda expressions.

* **Bug Fixes**
  * Fixed incremental projection logic to correctly handle structural equality when determining reusable entries.

* **Refactor**
  * Consolidated variable binding logic and updated rename functionality to use unified scope resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->