### PR TITLE
test(scope): pin module Decl.node_id production contract; drop tautological asserts

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -411,6 +411,39 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Plan: `docs/plans/2026-05-26-cognition-provider-boundary-design.md`
   Exit: a provider-client plan names the backend, driver clock/scheduling model, credential boundary, retry/redaction policy, and host integration surface. No real network/LLM code lands without that plan.
 
+## 20. Scope-Graph FlatProj Fidelity
+
+- [ ] Cross-pipeline resolution-equivalence property test (`@qc`).
+  Why: every `@scope` unit test and the `scope_equivalence_wbtest` oracle build
+  the `FlatProj` via `from_proj_node`, but the live editor builds it via
+  `to_flat_proj` → `to_proj_node_with_prev_module_id` → `collect_registry` →
+  `from_ast` (`lang/lambda/flat/projection_memo.mbt`). The two paths assign
+  module binder ids differently (init-node id vs synthetic `defs[i].3`), so the
+  hand-verified equivalence proof is certified on the `from_proj_node` path
+  only. Resolution does not read `node_id`, so it *should* transfer — but that
+  transfer is currently untested.
+  Plan: generate valid lambda source strings; for each, build the scope graph
+  through BOTH pipelines (a pure production-path driver reusing
+  `to_flat_proj`/`to_proj_node_with_prev_module_id`, bypassing the `@incr`
+  layer); match references by source range; assert equal normalized resolution
+  (`(tag, def_index)` for module, structural Lam position for lambda). Layer the
+  chosen module-`node_id` invariant on as a one-line property in the same
+  harness. Medium-band (generator + two-pipeline driver + range-matched
+  normalizer); its own PR.
+  Exit: thousands of generated cases agree on resolution across both pipelines;
+  edge set covered (empty/Unit body, error nodes, nested blocks, shadowing
+  chains). NOT a formal-verification target — the invariant spans the parser +
+  mutable Maps + a global id counter, outside any `moon prove` boundary; FV is
+  viable only for pure resolution kernels (e.g. `containing_def_index` bounds,
+  `resolve` cutoff exclusivity), which are a complement, not the answer.
+  Context: surfaced reviewing PR #398. The module-`node_id` divergence (a
+  synthetic id occupying no registry node, contradicting the `Decl` "occupies"
+  invariant) is recorded by the `to_flat_proj` contract test in
+  `lang/lambda/edits/scope_equivalence_wbtest.mbt` and the `Decl` doc note in
+  `lang/lambda/scope/graph.mbt`; reconcile it here, or when a consumer first
+  reads a module `node_id` as output (e.g. go-to-definition) — whichever lands
+  first.
+
 ## Shipped history
 
 Completed items (with PR references and shipping notes) are preserved in

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -429,7 +429,11 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   (`(tag, def_index)` for module, structural Lam position for lambda). Layer the
   chosen module-`node_id` invariant on as a one-line property in the same
   harness. Medium-band (generator + two-pipeline driver + range-matched
-  normalizer); its own PR.
+  normalizer); its own PR. Pin the production-path `node_id` invariant for BOTH
+  kinds in the same harness: module defs (synthetic id, NOT in the registry —
+  the gap recorded by the #398/#399 contract test) AND lambda params (the real
+  `Lam` node, IN the registry — currently unpinned on the production path; the
+  `to_flat_proj` fixture only asserts the module case).
   Exit: thousands of generated cases agree on resolution across both pipelines;
   edge set covered (empty/Unit body, error nodes, nested blocks, shadowing
   chains). NOT a formal-verification target — the invariant spans the parser +

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -44,15 +44,23 @@ fn graph_of(
   (proj, fp, g)
 }
 
-// The following eight tests certify that `@scope.declaration` resolves each
-// lambda binding rule to the FROZEN, hand-derived expected declaration. Each
-// expected value is reasoned out from the source string and the binding rules
+// The following tests certify that `@scope.declaration` resolves each lambda
+// binding rule to the FROZEN, hand-derived expected declaration. Each expected
+// value is reasoned out from the source string and the binding rules
 // (sequential module scope with later-wins shadowing; lambda params shadow
-// module defs; a def's own init cannot see itself). The expected binder is
-// located STRUCTURALLY in the parsed tree (a Lam node, or `fp.defs[i].3`),
-// never by a second `declaration` call — so the test cannot drift in lockstep
-// with the code it checks. `inspect` targets scalars only (tag String,
-// def_index Int, identity Bool), since the repo derives Debug/Eq, not Show.
+// module defs; a def's own init cannot see itself), never by a second
+// `declaration` call. `inspect` targets scalars only (tag String, def_index
+// Int, identity Bool), since the repo derives Debug/Eq, not Show.
+//
+// Binder-identity asymmetry: for LAMBDA cases the resolved `decl.node_id` is
+// checked against the Lam node located STRUCTURALLY in the tree (`proj.id()` /
+// `proj.children[..]`), independent of the FlatProj — a genuine non-circular
+// check (case 6 distinguishes inner vs outer). For MODULE cases identity is
+// carried by `def_index` alone: these fixtures build the FlatProj via
+// `from_proj_node`, where `decl.node_id == fp.defs[def_index].3` holds by
+// construction, so re-asserting it would be tautological. The PRODUCTION-path
+// meaning of a module binder id is pinned separately by the `to_flat_proj`
+// contract test at the bottom of this file.
 
 ///|
 test "declaration() resolves a Var to its enclosing Lam param" {
@@ -71,15 +79,14 @@ test "declaration() resolves a Var to its enclosing Lam param" {
 ///|
 test "declaration() resolves a body Var to its module def" {
   // let x = 0\nx — the body Var binds to def 0.
-  let (proj, fp, g) = graph_of("let x = 0\nx")
+  let (proj, _fp, g) = graph_of("let x = 0\nx")
   let ref_id = find_var(proj, "x") // body Var (init is Int 0, no Var)
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
   }
-  let (tag, binder, def_index) = norm_decl(d)
+  let (tag, _binder, def_index) = norm_decl(d)
   inspect(tag, content="module")
-  inspect(def_index, content="0")
-  inspect(binder == fp.defs[0].3, content="true") // binder is def 0's NodeId
+  inspect(def_index, content="0") // module identity = def_index (see header note)
 }
 
 ///|
@@ -94,15 +101,14 @@ test "declaration() leaves a self-referential def init unbound" {
 ///|
 test "declaration() picks the latest shadowing module def" {
   // let x = 1\nlet x = 2\nx — the body Var binds to the LATER def (index 1).
-  let (proj, fp, g) = graph_of("let x = 1\nlet x = 2\nx")
+  let (proj, _fp, g) = graph_of("let x = 1\nlet x = 2\nx")
   let ref_id = find_var(proj, "x") // body Var (both inits are Ints)
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
   }
-  let (tag, binder, def_index) = norm_decl(d)
+  let (tag, _binder, def_index) = norm_decl(d)
   inspect(tag, content="module")
-  inspect(def_index, content="1")
-  inspect(binder == fp.defs[1].3, content="true")
+  inspect(def_index, content="1") // latest of two same-name defs
 }
 
 ///|
@@ -148,13 +154,66 @@ test "declaration() lets a Lam param shadow a same-name module def" {
 test "declaration() resolves a later def's init to an earlier same-name def" {
   // let x = 1\nlet x = x\nx — the init Var of def 1 binds to def 0 (cutoff = 1
   // excludes def 1 itself), not to itself.
-  let (proj, fp, g) = graph_of("let x = 1\nlet x = x\nx")
+  let (proj, _fp, g) = graph_of("let x = 1\nlet x = x\nx")
   let ref_id = find_var(proj, "x") // first Var = def 1's init `x`
+  guard @scope.declaration(g, ref_id) is Some(d) else {
+    fail("expected resolved declaration")
+  }
+  let (tag, _binder, def_index) = norm_decl(d)
+  inspect(tag, content="module")
+  inspect(def_index, content="0") // def 1's init resolves to earlier def 0
+}
+
+///|
+/// Build a scope graph through the PRODUCTION FlatProj pipeline — `to_flat_proj`
+/// (the live editor's path) rather than `from_proj_node` (used by `graph_of`
+/// above). The two paths assign module binder ids differently: `from_proj_node`
+/// reuses the init node's id, whereas `to_flat_proj` allocates a synthetic
+/// binder id (`defs[i].3`) that is threaded into NO node of the reconstructed
+/// tree. This fixture exists solely to exercise that production path.
+fn production_graph_of(
+  text : String,
+) -> (
+  @core.ProjNode[@ast.Term],
+  Map[NodeId, ProjNode[@ast.Term]],
+  @scope.ScopeGraph,
+) raise {
+  let (cst, _diags) = @parser.parse_cst(text)
+  let syntax = @seam.SyntaxNode::from_cst(cst)
+  let counter = Ref(0)
+  // Production FlatProj: module binder ids (defs[i].3) are freshly allocated,
+  // distinct from any init node id.
+  let fp = @lambda_proj.to_flat_proj(syntax, counter)
+  // Reconstruct the Module ProjNode exactly as the live `cached_proj_node` memo
+  // does; the synthetic binder ids are not placed into this tree.
+  let proj = fp.to_proj_node(counter)
+  let sm = SourceMap::from_ast(proj)
+  let registry = scope_test_registry(proj)
+  let g = @scope.build(fp, registry, sm)
+  (proj, registry, g)
+}
+
+///|
+/// KNOWN-GAP record — NOT a desired contract. Through the production
+/// `to_flat_proj` pipeline, a module def's `Decl.node_id` is a synthetic
+/// FlatProj binder id that occupies no registry node — so it does NOT satisfy
+/// the "occupies a projection node" property that the lambda-param case does.
+/// The `Decl` doc in `lang/lambda/scope/graph.mbt` records this as a known
+/// divergence to reconcile; this test pins it so it is not silently
+/// load-bearing. When a consumer first needs a module binder to land on a real
+/// tree node (e.g. go-to-definition) and the fix makes binder ids real nodes,
+/// this `is None` assertion will flip to `is Some(_)` — and that failure is the
+/// INTENDED signal that the invariant was restored, not a regression. See also
+/// the deferred cross-pipeline PBT (docs/TODO.md §20).
+test "module Decl.node_id is a synthetic non-registry id on the production path (known gap vs graph.mbt invariant)" {
+  let (proj, registry, g) = production_graph_of("let x = 0\nx")
+  let ref_id = find_var(proj, "x") // body Var x
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
   }
   let (tag, binder, def_index) = norm_decl(d)
   inspect(tag, content="module")
   inspect(def_index, content="0")
-  inspect(binder == fp.defs[0].3, content="true")
+  // The divergence: the resolved module binder id is NOT a node in the registry.
+  inspect(registry.get(binder) is None, content="true")
 }

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -28,7 +28,19 @@ pub(all) struct Scope {
 } derive(Debug)
 
 ///|
-/// A declaration (binding site), keyed by the projection NodeId it occupies.
+/// A declaration (binding site). `node_id` identifies the binder, but its
+/// relationship to the projection tree differs by kind, and the module case is
+/// a KNOWN divergence to reconcile (not a settled contract):
+/// - lambda param: `node_id` IS the `Lam` projection node it occupies.
+/// - module def: `node_id` is the FlatProj binder id (`defs[i].3`). On the
+///   production `to_flat_proj` path this is a SYNTHETIC id occupying no registry
+///   node — so it does NOT satisfy "the projection NodeId it occupies" the way
+///   the lambda case does. Consumers needing a tree node for a module binder
+///   must currently map through `def_index`, not `node_id`.
+/// This gap (recorded by the `to_flat_proj` contract test in `lang/lambda/edits`)
+/// should be revisited the first time a consumer reads a module `node_id` as an
+/// output (e.g. go-to-definition); making module binder ids real tree nodes is
+/// the path that restores the uniform invariant.
 pub(all) struct Decl {
   id : DeclId
   node_id : @core.NodeId


### PR DESCRIPTION
## Summary

Follow-up to #398, from a deeper review of the scope-graph equivalence test. No production behavior change — this is test + doc fidelity.

The equivalence test (and every `@scope` unit test) builds its `FlatProj` via `from_proj_node`, but the **live editor** builds it via `to_flat_proj` → `to_proj_node_with_prev_module_id` → `collect_registry` → `from_ast` (`lang/lambda/flat/projection_memo.mbt`). The two paths assign a module def's binder id (`defs[i].3`, stored as `Decl.node_id`) differently:

- `from_proj_node` (tests): `defs[i].3 = init_child.id()` — a real registry node.
- `to_flat_proj` (production): `defs[i].3` is a **synthetic** id (`flat_proj.mbt:29`) that `to_proj_node_with_prev_module_id` never threads into the tree — so a module `Decl.node_id` occupies **no registry node**.

That contradicts the lambda-param case (where `node_id` IS the `Lam` node) and the historical "occupies a projection node" reading of the `Decl` doc.

## Changes
- **Drop three tautological module assertions** (`binder == fp.defs[def_index].3`) in `scope_equivalence_wbtest.mbt`. On the `from_proj_node` path these hold *by construction* — `pass2` writes `decl.node_id` and `def_index` from the same loop entry, compared against the same `fp` — so they can't fail independently of the `def_index` check above them. The **lam-case** structural assertions (`proj.id()` / `proj.children[..]`) stay; those are the genuinely non-circular identity checks (case 6 distinguishes inner vs outer Lam).
- **Add a KNOWN-GAP contract test** (`production_graph_of` + one test) asserting a module `Decl.node_id` is **not** in the registry on the `to_flat_proj` path. Framed explicitly as a recorded gap, not a desired contract: when a consumer reads a module `node_id` as output (e.g. go-to-definition) and the fix makes binder ids real nodes, this `is None` flips to `is Some(_)` — the **intended** signal, not a regression.
- **Rewrite the `Decl` doc** (`graph.mbt`) to describe the divergence honestly as a known gap — same commit, so doc / test / production agree.
- **File the deferred PBT** (`docs/TODO.md §20`): a cross-pipeline resolution-equivalence property test (the rigorous version). Noted as **not** a formal-verification target — the invariant spans the parser + mutable Maps + a global id counter, outside any `moon prove` boundary.

## Reuse check
No new types or public API. `production_graph_of` reuses `@lambda_proj.to_flat_proj` / `FlatProj::to_proj_node` / `scope_test_registry` — no new helpers beyond the test fixture. `.mbti` unchanged (doc-comment-only edit to `graph.mbt` does not surface).

## Verification
- Full `moon test` green (**1237 passed**, +1 contract test); `lang/lambda/{edits,scope}` green (115).
- The contract test's hypothesis (synthetic id ∉ registry) is **confirmed by execution**, not assumed.
- Codex review: **(A) faithful production repro, (B) tautology claim sound, (C) synthetic-id claim traced — PASS**; one doc-staleness nit in a test comment, fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test suite and module documentation to clarify internal behavior and scope resolution patterns.

* **Tests**
  * Added a new backlog item for implementing a cross-pipeline property test.
  * Adjusted test assertions and added new test helper functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->