### PR TITLE
test(scope): trim cross-pipeline PBT to 300 cases

### DIFF
--- a/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
+++ b/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
@@ -346,11 +346,16 @@ test "cross-pipeline: fixed sanity case agrees" {
 }
 
 ///|
-/// Thousands of generated, well-formed sources must resolve identically across
-/// both `FlatProj` construction pipelines (docs/TODO.md §20 exit criterion).
+/// Generated well-formed sources must resolve identically across both
+/// `FlatProj` construction pipelines (docs/TODO.md §20). The cross-pipeline
+/// property is near-tautological (resolution ignores `node_id`; both pipelines
+/// build defs from the same syntax in the same order), so a few hundred cases
+/// give the same confidence as thousands — `max_success` is sized for CI cost,
+/// not coverage. The edge-set fixtures above carry the structurally tricky
+/// cases that random generation is unlikely to hit.
 test "property: resolution agrees across both FlatProj pipelines" {
   @qc.quick_check_fn_error(
     fn(gs : GenSource) -> Unit raise { check_agreement(@ast.print_term(gs.0)) },
-    max_success=2000,
+    max_success=300,
   )
 }


### PR DESCRIPTION
Follow-up to #401. The cross-pipeline resolution-equivalence property is near-tautological (resolution ignores `node_id`; both pipelines build defs from the same syntax tree in the same order), so 300 generated cases give the same confidence as 2000 at ~7× lower per-CI cost. The structurally tricky cases (empty/Unit body, error-recovery, nested blocks, shadowing chains) are pinned by the edge-set fixtures, not by random volume.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized test suite performance by streamlining validation parameters, reducing test execution time while maintaining code coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->