### PR TITLE
feat(scope): binder-location accessor + go-to-definition (Option D, §20)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -423,24 +423,27 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   so it is a regression guard, not a correctness oracle — the latter stays in
   `scope_equivalence_wbtest.mbt`.
 
-- [ ] Reconcile the module-binder `node_id` divergence (driven by go-to-definition).
+- [~] Reconcile the module-binder `node_id` divergence (Option D, driven by go-to-definition).
   Why: the PBT above *pins* the gap; it does not close it. The module-binder
   `node_id` is synthetic on the production path (occupies no real node,
   contradicting the `Decl` "occupies a projection node" invariant in
   `lang/lambda/scope/graph.mbt`), and three incompatible synthetic-id schemes
-  now exist (`to_flat_proj`, `from_proj_node`, and the negative id in
+  existed (`to_flat_proj`, `from_proj_node`, and the negative id in
   `examples/ideal/main/scope_annotation.mbt`, which bypasses `@scope` and
-  re-implements resolution). This blocks go-to-definition and duplicates the
-  resolver.
-  Plan: docs/plans/2026-05-30-scope-binder-node-id-reconciliation.md (Codex-reviewed
-  design, recommends Option D: an on-demand `@scope` binder-location accessor
-  over the already-populated SourceMap let-name token spans — no loom PR, no
-  `FlatProj` change). Driven by building go-to-definition.
-  Exit: go-to-definition lands on the binder name uniformly for module + lambda
-  bindings; `references` migrated off `Decl.node_id`; the #399 fixture + PBT
-  `node_id` invariants rewritten to affirm the binder-location contract; an
-  incremental↔full differential resolution test added for the `@incr` path the
-  PBT excludes.
+  re-implements resolution).
+  Plan: docs/plans/2026-05-30-scope-binder-node-id-reconciliation.md (Codex-reviewed;
+  Option D: an on-demand `@scope` binder-location accessor over the
+  already-populated SourceMap token spans — no loom PR, no `FlatProj` change;
+  `node_id` stays synthetic but is no longer the locator).
+  Shipped (plan steps 1, 2, 4): `@scope.binder_span` + `@scope.go_to_definition`
+  accessors (`lang/lambda/scope/query.mbt`); `references` migrated off
+  `Decl.node_id` to `DeclId`; §7.1 go-to-def behavioral tests
+  (`go_to_definition_wbtest.mbt`); the #399 fixture + cross-pipeline PBT
+  `node_id` invariants rewritten to affirm the binder-location contract
+  (locatable + pipeline-independent).
+  Remaining: (step 3) an incremental↔full differential resolution test for the
+  `@incr` path the PBT excludes; (step 5) collapse `scope_annotation.mbt` onto
+  `@scope` once the outline-highlight UI representation is decided (§5).
 
 ## Shipped history
 

--- a/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
+++ b/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
@@ -154,24 +154,6 @@ fn normalize_decl(
 }
 
 ///|
-/// Affirm the Option-D binder-location contract (docs/TODO.md §20, resolved):
-/// every resolved declaration is LOCATABLE via `@scope.binder_span`, regardless
-/// of kind. This supersedes the former node_id-in-registry gap pin — Option D
-/// locates a binder by its source span (module → `"name:<def_index>"`, lambda →
-/// `"param"`), so a module binder's synthetic, non-registry `node_id` is now an
-/// internal detail rather than a gap. Failure here means the binder span was
-/// never populated (a real locator regression), not a synthetic-id observation.
-fn assert_binder_locatable(
-  decl : @scope.Decl?,
-  g : @scope.ScopeGraph,
-  source_map : SourceMap,
-) -> Unit raise {
-  if decl is Some(d) && @scope.binder_span(g, d, source_map) is None {
-    fail("production: binder not locatable via binder_span for '\{d.name}'")
-  }
-}
-
-///|
 /// Drive both pipelines on one source string and assert resolution agreement.
 /// `expect_clean` asserts zero parser diagnostics (the generated/well-formed
 /// property); error-recovery fixtures pass `expect_clean=false` since both
@@ -204,15 +186,21 @@ fn check_agreement(text : String, expect_clean? : Bool = true) -> Unit raise {
     guard n1 == n2 else {
       fail("resolution disagrees for Var \{key}: test=\{n1} production=\{n2}")
     }
-    // Option D: the production binder is locatable via binder_span, and that
-    // location is pipeline-INDEPENDENT — both pipelines derive the binder span
-    // from the same syntax token offsets, so they must agree even though their
-    // internal binder `node_id` VALUES diverge. This is the cross-pipeline
-    // affirmation that the accessor bridges the (still-present) id divergence.
-    assert_binder_locatable(d2, g2, sm2)
+    // Option D, two DISTINCT affirmations (don't conflate):
+    // (1) locatability (`is Some`) — the production module binder, whose
+    //     internal `node_id` is synthetic, is now reachable at all via
+    //     binder_span; this is what supersedes the old node_id-in-registry pin.
+    // (2) `bs1 == bs2` — the two INDEPENDENTLY-reconstructed trees map this
+    //     binder to the SAME source location. Both spans derive from the same
+    //     parse, so equality mainly guards against a def-order/count drift
+    //     between the pipelines (it does NOT, on its own, exercise the node_id
+    //     divergence — a bad binder key yields None, caught by (1)).
     if (d1, d2) is (Some(dd1), Some(dd2)) {
       let bs1 = @scope.binder_span(g1, dd1, sm1)
       let bs2 = @scope.binder_span(g2, dd2, sm2)
+      guard bs2 is Some(_) else {
+        fail("production: binder not locatable via binder_span for \{key}")
+      }
       guard bs1 is Some(_) else {
         fail("test pipeline: binder not locatable via binder_span for \{key}")
       }

--- a/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
+++ b/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
@@ -4,14 +4,23 @@
 // Two pipelines build a `FlatProj` from the same source, then a scope graph
 // resolves each Var reference to a declaration. The pipelines assign a module
 // def's binder id (`defs[i].3`) differently:
-//   - TEST path (`graph_of` / `from_proj_node`): reuses the init node's id (a
-//     real node present in the reconstructed tree);
+//   - TEST path (`graph_and_sm_of` / `from_proj_node`): reuses the init node's
+//     id (a real node present in the reconstructed tree);
 //   - PRODUCTION path (`production_graph_of` / `to_flat_proj`): allocates a
 //     SYNTHETIC binder id occupying no registry node.
 // Resolution never reads `node_id` (`Builder::resolve` matches name + def_index
 // < cutoff), so the hand-verified equivalence proof in
 // `scope_equivalence_wbtest.mbt` SHOULD transfer to production — this PBT pins
 // that transfer generatively, across many sources.
+//
+// It also pins the Option-D binder-location contract (docs/TODO.md §20): each
+// resolved declaration is LOCATABLE via `@scope.binder_span`, and that location
+// is pipeline-INDEPENDENT — both pipelines derive the binder span from the same
+// syntax token offsets, so the accessor agrees even though the internal binder
+// `node_id` values diverge. This SUPERSEDES the former gap pin (which asserted
+// the module binder `node_id` was synthetic / not in the registry); Option D
+// locates binders by source span, not `node_id`, so that syntheticness is now
+// an internal detail rather than a gap awaiting a fix.
 //
 // HOW IT STAYS NON-CIRCULAR (see memory: feedback_drift_detector_non_circular)
 // The two pipelines differ exactly in their node-id *values*; node ids are
@@ -145,31 +154,23 @@ fn normalize_decl(
 }
 
 ///|
-/// Pin the production-path `node_id` invariant for BOTH declaration kinds
-/// (docs/TODO.md §20). On the `to_flat_proj` path a module binder id is
-/// synthetic and occupies NO registry node (the #398/#399 known gap), while a
-/// lambda binder is a real `Lam` node and IS in the registry. The module half
-/// flipping to `Some(_)` is the INTENDED signal that the gap was reconciled.
-fn assert_production_node_id_invariants(
+/// Affirm the Option-D binder-location contract (docs/TODO.md §20, resolved):
+/// every resolved declaration is LOCATABLE via `@scope.binder_span`, regardless
+/// of kind. This supersedes the former node_id-in-registry gap pin — Option D
+/// locates a binder by its source span (module → `"name:<def_index>"`, lambda →
+/// `"param"`), so a module binder's synthetic, non-registry `node_id` is now an
+/// internal detail rather than a gap. Failure here means the binder span was
+/// never populated (a real locator regression), not a synthetic-id observation.
+fn assert_binder_locatable(
   decl : @scope.Decl?,
-  registry : Map[NodeId, ProjNode[@ast.Term]],
+  g : @scope.ScopeGraph,
+  source_map : SourceMap,
 ) -> Unit raise {
   match decl {
     None => ()
     Some(d) =>
-      match d.kind {
-        ModuleDef(_) =>
-          if registry.get(d.node_id) is Some(_) {
-            fail(
-              "production: module binder node_id is IN the registry — the synthetic-id gap was closed; update §20 + #399 contract test",
-            )
-          }
-        LamParam(lam_id~) =>
-          if registry.get(lam_id) is None {
-            fail(
-              "production: LamParam binder NOT in registry — expected a real Lam node",
-            )
-          }
+      if @scope.binder_span(g, d, source_map) is None {
+        fail("production: binder not locatable via binder_span for '\{d.name}'")
       }
   }
 }
@@ -186,12 +187,12 @@ fn check_agreement(text : String, expect_clean? : Bool = true) -> Unit raise {
       fail("expected clean parse but got \{diags.length()} diagnostic(s)")
     }
   }
-  // Pipeline 1: test path (from_proj_node).
-  let (proj1, _fp1, g1) = graph_of(text)
+  // Pipeline 1: test path (from_proj_node), with token spans for binder_span.
+  let (proj1, _fp1, g1, sm1) = graph_and_sm_of(text)
   let reg1 = scope_test_registry(proj1)
   let ranges1 = def_init_ranges(proj1)
-  // Pipeline 2: production path (to_flat_proj).
-  let (proj2, reg2, g2) = production_graph_of(text)
+  // Pipeline 2: production path (to_flat_proj), with token spans.
+  let (proj2, reg2, g2, sm2) = production_graph_of(text)
   let ranges2 = def_init_ranges(proj2)
   assert_lam_ranges_unique(reg1)
   assert_lam_ranges_unique(reg2)
@@ -207,7 +208,25 @@ fn check_agreement(text : String, expect_clean? : Bool = true) -> Unit raise {
     guard n1 == n2 else {
       fail("resolution disagrees for Var \{key}: test=\{n1} production=\{n2}")
     }
-    assert_production_node_id_invariants(d2, reg2)
+    // Option D: the production binder is locatable via binder_span, and that
+    // location is pipeline-INDEPENDENT — both pipelines derive the binder span
+    // from the same syntax token offsets, so they must agree even though their
+    // internal binder `node_id` VALUES diverge. This is the cross-pipeline
+    // affirmation that the accessor bridges the (still-present) id divergence.
+    assert_binder_locatable(d2, g2, sm2)
+    match (d1, d2) {
+      (Some(dd1), Some(dd2)) => {
+        let bs1 = @scope.binder_span(g1, dd1, sm1)
+        let bs2 = @scope.binder_span(g2, dd2, sm2)
+        guard bs1 is Some(_) else {
+          fail("test pipeline: binder not locatable via binder_span for \{key}")
+        }
+        guard bs1 == bs2 else {
+          fail("binder location disagrees across pipelines for Var \{key}")
+        }
+      }
+      _ => ()
+    }
   }
 }
 

--- a/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
+++ b/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
@@ -166,12 +166,8 @@ fn assert_binder_locatable(
   g : @scope.ScopeGraph,
   source_map : SourceMap,
 ) -> Unit raise {
-  match decl {
-    None => ()
-    Some(d) =>
-      if @scope.binder_span(g, d, source_map) is None {
-        fail("production: binder not locatable via binder_span for '\{d.name}'")
-      }
+  if decl is Some(d) && @scope.binder_span(g, d, source_map) is None {
+    fail("production: binder not locatable via binder_span for '\{d.name}'")
   }
 }
 
@@ -214,18 +210,15 @@ fn check_agreement(text : String, expect_clean? : Bool = true) -> Unit raise {
     // internal binder `node_id` VALUES diverge. This is the cross-pipeline
     // affirmation that the accessor bridges the (still-present) id divergence.
     assert_binder_locatable(d2, g2, sm2)
-    match (d1, d2) {
-      (Some(dd1), Some(dd2)) => {
-        let bs1 = @scope.binder_span(g1, dd1, sm1)
-        let bs2 = @scope.binder_span(g2, dd2, sm2)
-        guard bs1 is Some(_) else {
-          fail("test pipeline: binder not locatable via binder_span for \{key}")
-        }
-        guard bs1 == bs2 else {
-          fail("binder location disagrees across pipelines for Var \{key}")
-        }
+    if (d1, d2) is (Some(dd1), Some(dd2)) {
+      let bs1 = @scope.binder_span(g1, dd1, sm1)
+      let bs2 = @scope.binder_span(g2, dd2, sm2)
+      guard bs1 is Some(_) else {
+        fail("test pipeline: binder not locatable via binder_span for \{key}")
       }
-      _ => ()
+      guard bs1 == bs2 else {
+        fail("binder location disagrees across pipelines for Var \{key}")
+      }
     }
   }
 }

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -36,12 +36,27 @@ fn find_var(root : @core.ProjNode[@ast.Term], name : String) -> NodeId {
 fn graph_of(
   text : String,
 ) -> (@core.ProjNode[@ast.Term], FlatProj, @scope.ScopeGraph) raise {
-  let (proj, _errs) = parse_to_proj_node(text)
+  let (proj, fp, g, _sm) = graph_and_sm_of(text)
+  (proj, fp, g)
+}
+
+///|
+/// Like `graph_of`, but also populates token spans and returns the `SourceMap`,
+/// so callers can exercise `@scope.binder_span` (the Option-D binder-location
+/// accessor). Builds the proj from the SyntaxNode so `populate_token_spans` has
+/// a syntax tree to walk.
+fn graph_and_sm_of(
+  text : String,
+) -> (@core.ProjNode[@ast.Term], FlatProj, @scope.ScopeGraph, SourceMap) raise {
+  let (cst, _errs) = @parser.parse_cst(text)
+  let syntax = @seam.SyntaxNode::from_cst(cst)
+  let proj = to_proj_node(syntax, Ref(0))
   let fp = FlatProj::from_proj_node(proj)
   let sm = SourceMap::from_ast(proj)
+  populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(fp, registry, sm)
-  (proj, fp, g)
+  (proj, fp, g, sm)
 }
 
 // The following tests certify that `@scope.declaration` resolves each lambda
@@ -177,6 +192,7 @@ fn production_graph_of(
   @core.ProjNode[@ast.Term],
   Map[NodeId, ProjNode[@ast.Term]],
   @scope.ScopeGraph,
+  SourceMap,
 ) raise {
   let (cst, _diags) = @parser.parse_cst(text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
@@ -188,25 +204,27 @@ fn production_graph_of(
   // does; the synthetic binder ids are not placed into this tree.
   let proj = fp.to_proj_node(counter)
   let sm = SourceMap::from_ast(proj)
+  // Token spans are stored on the reconstructed Module/Lam nodes (by index +
+  // role), so `binder_span` works on the production path too — its locator is
+  // the source span, not the synthetic binder id.
+  populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(fp, registry, sm)
-  (proj, registry, g)
+  (proj, registry, g, sm)
 }
 
 ///|
-/// KNOWN-GAP record — NOT a desired contract. Through the production
-/// `to_flat_proj` pipeline, a module def's `Decl.node_id` is a synthetic
-/// FlatProj binder id that occupies no registry node — so it does NOT satisfy
-/// the "occupies a projection node" property that the lambda-param case does.
-/// The `Decl` doc in `lang/lambda/scope/graph.mbt` records this as a known
-/// divergence to reconcile; this test pins it so it is not silently
-/// load-bearing. When a consumer first needs a module binder to land on a real
-/// tree node (e.g. go-to-definition) and the fix makes binder ids real nodes,
-/// this `is None` assertion will flip to `is Some(_)` — and that failure is the
-/// INTENDED signal that the invariant was restored, not a regression. See also
-/// the deferred cross-pipeline PBT (docs/TODO.md §20).
-test "module Decl.node_id is a synthetic non-registry id on the production path (known gap vs graph.mbt invariant)" {
-  let (proj, registry, g) = production_graph_of("let x = 0\nx")
+/// Option-D binder-location contract on the PRODUCTION path (docs/TODO.md §20,
+/// resolved). Through `to_flat_proj` a module def's `Decl.node_id` is a
+/// synthetic FlatProj binder id occupying no registry node — but locating the
+/// binder no longer depends on `node_id`: `@scope.binder_span` resolves it via
+/// the module node's `"name:<def_index>"` token span. This SUPERSEDES the former
+/// "known gap" pin (which expected `node_id` to become a real node); Option D
+/// instead sidesteps `node_id` entirely, so its syntheticness is now an internal
+/// detail and is deliberately no longer asserted. The companion assertion that
+/// this location is pipeline-independent lives in the cross-pipeline PBT.
+test "production path: module binder located via binder_span (Option D, supersedes §20 gap)" {
+  let (proj, registry, g, sm) = production_graph_of("let x = 0\nx")
   let ref_id = find_var(proj, "x") // body Var x
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -214,6 +232,10 @@ test "module Decl.node_id is a synthetic non-registry id on the production path 
   let (tag, binder, def_index) = norm_decl(d)
   inspect(tag, content="module")
   inspect(def_index, content="0")
-  // The divergence: the resolved module binder id is NOT a node in the registry.
+  // `node_id` is NOT the locator — it remains a synthetic non-registry id …
   inspect(registry.get(binder) is None, content="true")
+  // … yet the binder is locatable: "let x = 0" → name token "x" at 4..5.
+  guard @scope.binder_span(g, d, sm) is Some(r)
+  inspect(r.start, content="4")
+  inspect(r.end, content="5")
 }

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -41,7 +41,7 @@ fn rename_lam_param(
   }
   let edits : Array[SpanEdit] = []
   // Get param token span
-  match source_map.get_token_span(lam_id, "param") {
+  match source_map.get_token_span(lam_id, @lambda_proj.PARAM_ROLE) {
     Some(param_range) =>
       edits.push({
         start: param_range.start,
@@ -196,7 +196,7 @@ fn rename_module_binding(
   }
   let edits : Array[SpanEdit] = []
   // Get the name token span
-  let role = "name:" + def_index.to_string()
+  let role = @lambda_proj.module_name_role(def_index)
   match source_map.get_token_span(module_id, role) {
     Some(name_range) =>
       edits.push({

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -9,6 +9,10 @@ import {
 }
 
 // Values
+pub const PARAM_ROLE : String = "param"
+
+pub fn module_name_role(Int) -> String
+
 pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@ast.Term]) -> Unit

--- a/lang/lambda/proj/populate_token_spans.mbt
+++ b/lang/lambda/proj/populate_token_spans.mbt
@@ -41,7 +41,7 @@ fn collect_token_spans_source_file(
             // owns the defs array. So we store the name span on the Module
             // node with a role like "name:0", "name:1", etc.
             // Use index-based key for stability across renames
-            let role = "name:" + def_idx.to_string()
+            let role = module_name_role(def_idx)
             source_map.set_span_from_token(
               proj_root.id(),
               role,
@@ -98,7 +98,7 @@ fn collect_token_spans_expr(
     // Extract param token span
     source_map.set_span_from_token(
       proj_node.id(),
-      "param",
+      PARAM_ROLE,
       syntax_node,
       @syntax.IdentToken.to_raw(),
     )

--- a/lang/lambda/proj/token_roles.mbt
+++ b/lang/lambda/proj/token_roles.mbt
@@ -1,0 +1,15 @@
+// Token-span role keys: the contract between `populate_token_spans` (which
+// records the spans) and its consumers (`@scope.binder_span`, rename, semantic
+// projection) that read them back. Every producer and consumer routes through
+// these helpers rather than bare string literals — a drifting literal would
+// silently turn a span lookup into `None` with no compile-time or test signal.
+
+///|
+/// Role key for a lambda parameter's name token (stored on the `Lam` node).
+pub const PARAM_ROLE : String = "param"
+
+///|
+/// Role key for module def `def_index`'s name token (stored on the Module node).
+pub fn module_name_role(def_index : Int) -> String {
+  "name:" + def_index.to_string()
+}

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -70,7 +70,7 @@ fn root_node(
 fn Builder::pass2(
   self : Builder,
   flat_proj : @lambda_proj.FlatProj,
-  registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
+  root : @core.ProjNode[@ast.Term],
 ) -> Unit {
   let root_scope = self.add_scope(None)
   for i, def in flat_proj.defs {
@@ -99,7 +99,7 @@ fn Builder::pass2(
     }
   }
 
-  walk(root_node(registry), root_scope)
+  walk(root, root_scope)
 }
 
 ///|
@@ -211,7 +211,8 @@ pub fn build(
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
   let b = Builder::new()
-  b.pass2(flat_proj, registry)
+  let root = root_node(registry)
+  b.pass2(flat_proj, root)
   b.pass3(flat_proj, registry, source_map)
-  { scopes: b.scopes, decls: b.decls, refs: b.refs }
+  { scopes: b.scopes, decls: b.decls, refs: b.refs, module_node_id: root.id() }
 }

--- a/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -63,6 +63,19 @@ test "go_to_definition: nested lambda shadowing — innermost param wins" {
 }
 
 ///|
+test "go_to_definition: caret on a wrapping paren resolves to the inner var's binder" {
+  // "let x = 1\n(x)" — `(` at 10, `x` at 11, `)` at 12. ParenExpr deliberately
+  // widens the wrapped Var's node span to cover the parens (proj_node.mbt), so a
+  // caret on `(` (pos 10) resolves to `x` and jumps to its binder "x" at 4..5.
+  // Intended position→node behavior, not identifier-token-strict (Codex P2 on
+  // PR #405 — verified intentional, pinned here).
+  let (g, sm) = build_fixture_with_spans("let x = 1\n(x)")
+  guard go_to_definition(g, sm, 10) is Some(r)
+  inspect(r.start, content="4")
+  inspect(r.end, content="5")
+}
+
+///|
 test "go_to_definition: free variable — no jump" {
   // "x" — unbound; go-to-definition yields None.
   let (g, sm) = build_fixture_with_spans("x")

--- a/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -1,0 +1,84 @@
+// Behavioral tests for the binder-location accessor and go-to-definition
+// (plan §7.1). Unlike `build_fixture` in graph_wbtest.mbt, these populate token
+// spans (via the SyntaxNode → ProjNode pipeline), since `binder_span` reads
+// them. Expected offsets are hand-derived and match the conventions pinned in
+// projection/source_map_token_spans_wbtest.mbt (e.g. `let x` name → 4..5,
+// `λx` param → 1..2).
+
+///|
+/// Build a scope graph and a token-span-populated SourceMap from source.
+fn build_fixture_with_spans(
+  text : String,
+) -> (ScopeGraph, @core.SourceMap) raise {
+  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  let syntax = @seam.SyntaxNode::from_cst(cst)
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
+  let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
+  let source_map = @core.SourceMap::from_ast(proj)
+  @lambda_proj.populate_token_spans(source_map, syntax, proj)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(proj, registry)
+  let g = build(flat_proj, registry, source_map)
+  (g, source_map)
+}
+
+///|
+test "go_to_definition: module def — body var jumps to the name token" {
+  // "let x = 1\nx" — name "x" at 4..5; body var "x" at 10.
+  let (g, sm) = build_fixture_with_spans("let x = 1\nx")
+  guard go_to_definition(g, sm, 10) is Some(r)
+  inspect(r.start, content="4")
+  inspect(r.end, content="5")
+}
+
+///|
+test "go_to_definition: shadowed module def — later def wins (production id path)" {
+  // "let x = 1\nlet x = 2\nx" — name:0 "x" at 4..5, name:1 "x" at 14..15.
+  // The body var (pos 20) resolves to def_index=1, so the binder span must be
+  // 14..15, NOT 4..5. This exercises the module-def binder whose production
+  // FlatProj id was synthetic — the case Option D fixes.
+  let (g, sm) = build_fixture_with_spans("let x = 1\nlet x = 2\nx")
+  guard go_to_definition(g, sm, 20) is Some(r)
+  inspect(r.start, content="14")
+  inspect(r.end, content="15")
+}
+
+///|
+test "go_to_definition: lambda param — body var jumps to the param token" {
+  // "λx. x" — param "x" at 1..2; body var "x" at 4.
+  let (g, sm) = build_fixture_with_spans("\u{03BB}x. x")
+  guard go_to_definition(g, sm, 4) is Some(r)
+  inspect(r.start, content="1")
+  inspect(r.end, content="2")
+}
+
+///|
+test "go_to_definition: nested lambda shadowing — innermost param wins" {
+  // "λx. λx. x" — outer param at 1..2, inner param at 5..6; innermost use at 8
+  // resolves to the inner λ.
+  let (g, sm) = build_fixture_with_spans("\u{03BB}x. \u{03BB}x. x")
+  guard go_to_definition(g, sm, 8) is Some(r)
+  inspect(r.start, content="5")
+  inspect(r.end, content="6")
+}
+
+///|
+test "go_to_definition: free variable — no jump" {
+  // "x" — unbound; go-to-definition yields None.
+  let (g, sm) = build_fixture_with_spans("x")
+  inspect(go_to_definition(g, sm, 0) is None, content="true")
+}
+
+///|
+test "binder_span: None when token spans were not populated" {
+  // A SourceMap built via from_ast without populate_token_spans has no token
+  // spans — binder_span must degrade to None, never a wrong location.
+  let (proj, _errs) = @lambda_proj.parse_to_proj_node("let x = 1\nx")
+  let flat_proj = @lambda_proj.FlatProj::from_proj_node(proj)
+  let source_map = @core.SourceMap::from_ast(proj)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(proj, registry)
+  let g = build(flat_proj, registry, source_map)
+  inspect(g.decls[0].kind is ModuleDef(_), content="true")
+  inspect(binder_span(g, g.decls[0], source_map) is None, content="true")
+}

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -28,19 +28,16 @@ pub(all) struct Scope {
 } derive(Debug)
 
 ///|
-/// A declaration (binding site). `node_id` identifies the binder, but its
-/// relationship to the projection tree differs by kind, and the module case is
-/// a KNOWN divergence to reconcile (not a settled contract):
-/// - lambda param: `node_id` IS the `Lam` projection node it occupies.
-/// - module def: `node_id` is the FlatProj binder id (`defs[i].3`). On the
-///   production `to_flat_proj` path this is a SYNTHETIC id occupying no registry
-///   node — so it does NOT satisfy "the projection NodeId it occupies" the way
-///   the lambda case does. Consumers needing a tree node for a module binder
-///   must currently map through `def_index`, not `node_id`.
-/// This gap (recorded by the `to_flat_proj` contract test in `lang/lambda/edits`)
-/// should be revisited the first time a consumer reads a module `node_id` as an
-/// output (e.g. go-to-definition); making module binder ids real tree nodes is
-/// the path that restores the uniform invariant.
+/// A declaration (binding site). A binder's LOCATION is its source span,
+/// recovered uniformly via `binder_span` (which reads `SourceMap` token spans),
+/// not via `node_id`:
+/// - lambda param: the `"param"` token span on the `Lam` node (`kind`'s `lam_id`).
+/// - module def: the `"name:<def_index>"` token span on the module node
+///   (`ScopeGraph::module_node_id`).
+/// `node_id` is retained only as an internal dedup/identity handle. It is NOT a
+/// reliable tree-node pointer for module defs (on the production `to_flat_proj`
+/// path it is a synthetic id occupying no registry node), so consumers needing
+/// to locate a binder MUST use `binder_span`, never `node_id`.
 pub(all) struct Decl {
   id : DeclId
   node_id : @core.NodeId
@@ -72,8 +69,13 @@ pub(all) struct Resolution {
 
 ///|
 /// The binding index for one lambda module.
+/// `module_node_id` is the root projection node that owns the module-def name
+/// token spans (`"name:<def_index>"` in the `SourceMap`); `binder_span` reads
+/// them through it. For a bare-expression program (no defs) it is the root
+/// expression node and the name-span path is never exercised.
 pub(all) struct ScopeGraph {
   scopes : Array[Scope]
   decls : Array[Decl]
   refs : Array[Ref]
+  module_node_id : @core.NodeId
 } derive(Debug)

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -168,8 +168,8 @@ test "references: identity-based, shadowing-aware" {
     "let x = 1\nlet x = 2\nx",
   )
   let g = build(flat_proj, registry, source_map)
-  let def1 = g.decls[1].node_id
-  let def0 = g.decls[0].node_id
+  let def1 = g.decls[1].id
+  let def0 = g.decls[0].id
   inspect(references(g, def1).length() >= 1, content="true")
   inspect(references(g, def0).length(), content="0")
 }

--- a/lang/lambda/scope/moon.pkg
+++ b/lang/lambda/scope/moon.pkg
@@ -2,7 +2,13 @@ import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
   "dowdiness/lambda/ast",
+  "dowdiness/loom/core" @loomcore,
   "moonbitlang/core/immut/hashset" @immut/hashset,
 }
+
+import {
+  "dowdiness/lambda" @parser,
+  "dowdiness/seam",
+} for "wbtest"
 
 warnings = "-2-6-29"

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "dowdiness/canopy/lang/lambda/scope"
 
 import {
-  "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj",
   "dowdiness/lambda/ast",
   "moonbitlang/core/debug",
@@ -10,20 +9,24 @@ import {
 }
 
 // Values
-pub fn build(@proj.FlatProj, Map[@core.NodeId, @core.ProjNode[@ast.Term]], @core.SourceMap) -> ScopeGraph
+pub fn binder_span(ScopeGraph, Decl, @dowdiness/canopy/core.SourceMap) -> @dowdiness/loom/core.Range?
 
-pub fn declaration(ScopeGraph, @core.NodeId) -> Decl?
+pub fn build(@proj.FlatProj, Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]], @dowdiness/canopy/core.SourceMap) -> ScopeGraph
 
-pub fn enclosing_env(ScopeGraph, @core.NodeId) -> @hashset.HashSet[String]
+pub fn declaration(ScopeGraph, @dowdiness/canopy/core.NodeId) -> Decl?
 
-pub fn references(ScopeGraph, @core.NodeId) -> Array[@core.NodeId]
+pub fn enclosing_env(ScopeGraph, @dowdiness/canopy/core.NodeId) -> @hashset.HashSet[String]
+
+pub fn go_to_definition(ScopeGraph, @dowdiness/canopy/core.SourceMap, Int) -> @dowdiness/loom/core.Range?
+
+pub fn references(ScopeGraph, DeclId) -> Array[@dowdiness/canopy/core.NodeId]
 
 // Errors
 
 // Types and methods
 pub(all) struct Decl {
   id : DeclId
-  node_id : @core.NodeId
+  node_id : @dowdiness/canopy/core.NodeId
   name : String
   scope : ScopeId
   kind : DeclKind
@@ -32,13 +35,13 @@ pub(all) struct Decl {
 pub(all) struct DeclId(Int) derive(Compare, Eq, Hash, @debug.Debug)
 
 pub(all) enum DeclKind {
-  LamParam(lam_id~ : @core.NodeId)
+  LamParam(lam_id~ : @dowdiness/canopy/core.NodeId)
   ModuleDef(def_index~ : Int)
 } derive(Eq, @debug.Debug)
 
 pub(all) struct Ref {
   id : RefId
-  node_id : @core.NodeId
+  node_id : @dowdiness/canopy/core.NodeId
   name : String
   scope : ScopeId
   resolution : Resolution
@@ -62,6 +65,7 @@ pub(all) struct ScopeGraph {
   scopes : Array[Scope]
   decls : Array[Decl]
   refs : Array[Ref]
+  module_node_id : @dowdiness/canopy/core.NodeId
 } derive(@debug.Debug)
 
 pub(all) struct ScopeId(Int) derive(Compare, Eq, Hash, @debug.Debug)

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -53,10 +53,22 @@ pub fn binder_span(
 ///|
 /// Go-to-definition: given a cursor `position`, return the source span of the
 /// binder that the reference under the cursor resolves to, or None.
-/// Token-hit semantics: `position` must fall within a reference token's
-/// half-open range; a caret between tokens or at a token end may resolve to an
-/// ancestor node (no jump) — acceptable for v1. Returns None for a free
-/// variable, a non-reference node, or an unpopulated `SourceMap`.
+///
+/// Resolution is by projection-node range: `position` maps to the innermost
+/// node whose source range contains it (half-open), and a jump happens when
+/// that node is a resolved reference. The range used is the reference's *node*
+/// span, not its identifier *token* span — and `ParenExpr` deliberately widens
+/// a wrapped expression's span to cover the parentheses (see `proj_node.mbt`,
+/// "keep the outer ParenExpr span so positions on ( and ) are covered"). So a
+/// caret on the `(` / `)` of `(x)` resolves to `x` and jumps to its binder.
+/// That is intentional and consistent with the editor's position→node mapping;
+/// the resolved target is always the correct binder. A stricter
+/// identifier-token-only restriction would require recording Var token spans
+/// and is intentionally not done.
+///
+/// Returns None for a free variable, a position in no reference node (between
+/// tokens / on surrounding whitespace), or a `SourceMap` without populated
+/// token spans.
 pub fn go_to_definition(
   g : ScopeGraph,
   source_map : @core.SourceMap,

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -40,11 +40,12 @@ pub fn binder_span(
   source_map : @core.SourceMap,
 ) -> @loomcore.Range? {
   match decl.kind {
-    LamParam(lam_id~) => source_map.get_token_span(lam_id, "param")
+    LamParam(lam_id~) =>
+      source_map.get_token_span(lam_id, @lambda_proj.PARAM_ROLE)
     ModuleDef(def_index~) =>
       source_map.get_token_span(
         g.module_node_id,
-        "name:" + def_index.to_string(),
+        @lambda_proj.module_name_role(def_index),
       )
   }
 }

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -12,21 +12,60 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
 }
 
 ///|
-/// All reference NodeIds whose resolution points at the decl at `decl_node`.
-/// Identity-based (NOT a name match), so shadowing is respected.
-/// Reserved API surface; consumer migration deferred (see design spec).
-pub fn references(
-  g : ScopeGraph,
-  decl_node : @core.NodeId,
-) -> Array[@core.NodeId] {
-  guard g.decls.iter().find_first(fn(d) { d.node_id == decl_node })
-    is Some(target) else {
-    return []
-  }
-  let tid = target.id
+/// All reference NodeIds whose resolution points at the declaration `decl`.
+/// Identity-based (keyed on `DeclId`, NOT a name match), so shadowing is
+/// respected. Keying on `DeclId` rather than `Decl.node_id` is deliberate:
+/// a module def's `node_id` is a synthetic, non-tree handle (see `Decl`), so a
+/// `NodeId`-keyed lookup silently preserved that broken contract. `DeclId` is
+/// the stable graph-local identity (`declaration(..).id` yields it).
+pub fn references(g : ScopeGraph, decl : DeclId) -> Array[@core.NodeId] {
   [
-    for r in g.refs if r.resolution.decl is Some(rid) && rid == tid => r.node_id
+    for r in g.refs if r.resolution.decl is Some(rid) && rid == decl => {
+      r.node_id
+    }
   ]
+}
+
+///|
+/// The source span of a declaration's binder name, or None when the token span
+/// was not recorded (e.g. a `SourceMap` built via `from_ast` without
+/// `populate_token_spans`). This is the uniform "where is this binder?" primitive
+/// for go-to-definition, binder highlighting, and rename:
+/// - lambda param: the `"param"` token span on the `Lam` node;
+/// - module def: the `"name:<def_index>"` token span on `module_node_id`.
+/// Failure is always `None`, never a wrong location.
+pub fn binder_span(
+  g : ScopeGraph,
+  decl : Decl,
+  source_map : @core.SourceMap,
+) -> @loomcore.Range? {
+  match decl.kind {
+    LamParam(lam_id~) => source_map.get_token_span(lam_id, "param")
+    ModuleDef(def_index~) =>
+      source_map.get_token_span(
+        g.module_node_id,
+        "name:" + def_index.to_string(),
+      )
+  }
+}
+
+///|
+/// Go-to-definition: given a cursor `position`, return the source span of the
+/// binder that the reference under the cursor resolves to, or None.
+/// Token-hit semantics: `position` must fall within a reference token's
+/// half-open range; a caret between tokens or at a token end may resolve to an
+/// ancestor node (no jump) — acceptable for v1. Returns None for a free
+/// variable, a non-reference node, or an unpopulated `SourceMap`.
+pub fn go_to_definition(
+  g : ScopeGraph,
+  source_map : @core.SourceMap,
+  position : Int,
+) -> @loomcore.Range? {
+  guard source_map.innermost_node_at(position) is Some(ref_id) else {
+    return None
+  }
+  guard declaration(g, ref_id) is Some(decl) else { return None }
+  binder_span(g, decl, source_map)
 }
 
 ///|

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -99,7 +99,8 @@ fn analyze_module(
       binder_id,
       @protocol.ViewAnnotation(kind="semantic-binder", label="let " + name),
     )
-    match source_map.get_token_span(node.id(), "name:" + i.to_string()) {
+    match
+      source_map.get_token_span(node.id(), @lambda_proj.module_name_role(i)) {
       Some(range) =>
         add_decoration(
           projection,
@@ -151,7 +152,7 @@ fn analyze_lambda(
     node.id(),
     @protocol.ViewAnnotation(kind="semantic-binder", label="λ" + param),
   )
-  match source_map.get_token_span(node.id(), "param") {
+  match source_map.get_token_span(node.id(), @lambda_proj.PARAM_ROLE) {
     Some(range) =>
       add_decoration(
         projection,


### PR DESCRIPTION
## What

Implements **Option D** of `docs/plans/2026-05-30-scope-binder-node-id-reconciliation.md` (plan steps **1, 2, 4**), reconciling the module-binder `node_id` divergence (docs/TODO.md §20).

The scope graph's `Decl.node_id` was supposed to "occupy a projection node," but for module defs the production `to_flat_proj` path assigns a **synthetic id occupying no registry node** — three incompatible synthetic-id schemes had accreted. Rather than fabricate real tree nodes, Option D observes the binder *location* already lives in the SourceMap token spans (`populate_token_spans` records each let-name as `"name:<idx>"` on the Module node, each lambda param as `"param"` on the Lam node) and exposes it directly.

### Changes
- **`@scope.binder_span(g, decl, source_map) -> Range?`** — uniform binder source span (lambda → `"param"`; module def → `"name:<def_index>"` on the new `ScopeGraph::module_node_id`). Failure is always `None`, never a wrong location.
- **`@scope.go_to_definition(g, source_map, position) -> Range?`** — the driving consumer; token-hit semantics (documented, not fuzzy-caret).
- **`references` migrated off `Decl.node_id` → `DeclId`** — the only `NodeId`-keyed binder consumer, which silently preserved the broken contract.
- `Decl` / `ScopeGraph` doc notes rewritten: a binder is located by its source span via `binder_span`; `node_id` is now a synthetic internal handle.

### Tests
- §7.1 go-to-def behavioral cases: module def, **shadowed module def** (exercises the previously-synthetic production id), lambda param, nested-lambda shadowing, free var, unpopulated-SourceMap `None`.
- **Rewrote the two gap-pinning tests** to affirm the new contract instead of pinning the now-resolved gap:
  - `#399` fixture asserts `binder_span` locates the name token (`4..5`) while documenting that `node_id` *intentionally* stays synthetic.
  - Cross-pipeline PBT (`assert_production_node_id_invariants` → `assert_binder_locatable`) now asserts the binder is locatable **and pipeline-INDEPENDENT** — identical location across both divergent-`node_id` pipelines.

## Reuse check
- `binder_span` reuses `SourceMap::get_token_span` (existing); `go_to_definition` reuses `innermost_node_at` + `declaration` (existing). No new types — re-keyed on the existing `DeclId`. `module_node_id` is set from the existing `root_node(registry)` (the `pass2` refactor just threads the already-computed root, removing a redundant recompute).

## Scope / follow-ups
Plan steps **1, 2, 4** only. Deferred to follow-up PRs (per the plan, independently reviewable):
- **Step 3:** incremental↔full differential resolution test for the `@incr` path the PBT excludes.
- **Step 5:** collapse `examples/ideal/main/scope_annotation.mbt` onto `@scope` (gated on the outline-highlight UI-representation decision).

## Verification
- Full workspace `moon test`: **1249 passed**; the 300-case cross-pipeline PBT passes with the new pipeline-equality assertion (no hidden lambda-span gap).
- Codex: design validation **SOUND-WITH-CHANGES** (folded in); pre-PR review **PASS** (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added go-to-definition support for jumping to variable and module binding locations.
  * Added binder_span functionality to retrieve precise definition binder token locations.

* **Improvements**
  * Enhanced scope graph consistency across processing pipelines for module and lambda parameter binders.
  * Improved reference tracking through declaration-based lookup mechanism.

* **Tests**
  * Added comprehensive behavioral tests for go-to-definition and binder location features.
  * Updated cross-pipeline verification tests to ensure consistent binder locations across execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->