### PR TITLE
fix(coordinator): propagate incr ReadError + bump loom submodule

### DIFF
--- a/workspace/coordinator/coordinator_wbtest.mbt
+++ b/workspace/coordinator/coordinator_wbtest.mbt
@@ -52,7 +52,7 @@ test "spec §12 #5: read_protected catches out-of-band Watch dispose" {
 /// handler, so the outer `Watch::read` receives a hard abort rather than
 /// `Err(CycleError)`. To isolate the mapping concern, hand-build a
 /// `ProtectedCell` whose `read` closure directly returns
-/// `Err(CycleError::new(...))`. The cell_id points at a real,
+/// `Err(ReadError::cycle(CycleError::new(...)))`. The cell_id points at a real,
 /// watch-rooted Derived so the mode-1 fail-fast passes.
 test "spec §12 #6: read_protected maps Err(CycleError) to CycleDetected" {
   let coord = Coordinator::new()
@@ -69,7 +69,7 @@ test "spec §12 #6: read_protected maps Err(CycleError) to CycleDetected" {
   let pcell : ProtectedCell[Int] = ProtectedCell::ProtectedCell(
     cell_id~,
     label="synthetic_cycle",
-    read=fn() { Err(synthetic_cycle) },
+    read=fn() { Err(@incr.ReadError::cycle(synthetic_cycle)) },
     is_disposed=fn() { false },
     dispose=fn() {  },
   )
@@ -78,6 +78,37 @@ test "spec §12 #6: read_protected maps Err(CycleError) to CycleDetected" {
     Ok(_) => fail("expected CycleDetected")
     Err(report) => {
       assert_eq(report.kind, CycleDetected)
+      assert_true(report.domain_tag is Some(_))
+    }
+  }
+}
+
+///|
+/// Spec §12 #6 (Disposed variant): a `ReadError::Disposed` surfacing from the
+/// read closure maps to `AbortKind::ProtectedCellDisposed`, distinct from the
+/// cycle case. Mirrors the cycle test — hand-build a `ProtectedCell` whose
+/// `read` closure returns `Err(ReadError::disposed(...))` with
+/// `is_disposed=fn() { false }` so the earlier defense-in-depth guard does not
+/// short-circuit the read and the mapping in `read_protected` is exercised.
+test "spec §12 #6: read_protected maps Err(Disposed) to ProtectedCellDisposed" {
+  let coord = Coordinator::new()
+  let rt = coord.runtime()
+  let anchor = @incr.Derived::Derived(rt, fn() { 0 }, label="anchor")
+  let watch = anchor.watch()
+  let _ = watch.read()
+  let cell_id = anchor.id()
+  let pcell : ProtectedCell[Int] = ProtectedCell::ProtectedCell(
+    cell_id~,
+    label="synthetic_disposed",
+    read=fn() { Err(@incr.ReadError::disposed(cell_id)) },
+    is_disposed=fn() { false },
+    dispose=fn() {  },
+  )
+  let id = coord.register_editor("agent", [pcell.erase()])
+  match coord.read_protected(id, pcell) {
+    Ok(_) => fail("expected ProtectedCellDisposed")
+    Err(report) => {
+      assert_eq(report.kind, ProtectedCellDisposed)
       assert_true(report.domain_tag is Some(_))
     }
   }

--- a/workspace/coordinator/methods.mbt
+++ b/workspace/coordinator/methods.mbt
@@ -151,8 +151,9 @@ pub fn Coordinator::destroy_editor(
 /// internals; boundary code should use this method and collapse `Err` into that
 /// API's existing fail-closed response.
 ///
-/// Cycles propagate to `AbortKind::CycleDetected` with `domain_tag` carrying
-/// `CycleError::format_path()`.
+/// A cycle propagates to `AbortKind::CycleDetected`; a read on a disposed cell
+/// propagates to `AbortKind::ProtectedCellDisposed`. Either way `domain_tag`
+/// carries `ReadError::format_path()`.
 pub fn[T] Coordinator::read_protected(
   self : Coordinator,
   editor_id : EditorId,
@@ -209,15 +210,19 @@ pub fn[T] Coordinator::read_protected(
   }
   match (cell.read)() {
     Ok(value) => Ok(value)
-    Err(cycle) =>
+    Err(e) =>
       Err(
         AbortReport(
-          kind=CycleDetected,
+          kind=if e.is_disposed() {
+            ProtectedCellDisposed
+          } else {
+            CycleDetected
+          },
           editor_id~,
           agent_id=reg.agent_id,
           cell_id=cell.cell_id,
           cell_label=cell.label,
-          domain_tag=cycle.format_path(),
+          domain_tag=e.format_path(),
         ),
       )
   }

--- a/workspace/coordinator/pkg.generated.mbti
+++ b/workspace/coordinator/pkg.generated.mbti
@@ -49,7 +49,7 @@ pub impl Show for EditorId
 pub struct ProtectedCell[T] {
   cell_id : @types.CellId
   label : String
-  read : () -> Result[T, @types.CycleError]
+  read : () -> Result[T, @types.ReadError]
   is_disposed : () -> Bool
   dispose : () -> Unit
 }
@@ -69,7 +69,7 @@ pub struct WorkspaceMemoHandle[T] {
 }
 pub fn[T] WorkspaceMemoHandle::dispose(Self[T]) -> Unit
 pub fn[T] WorkspaceMemoHandle::id(Self[T]) -> @types.CellId
-pub fn[T] WorkspaceMemoHandle::read(Self[T]) -> Result[T, @types.CycleError]
+pub fn[T] WorkspaceMemoHandle::read(Self[T]) -> Result[T, @types.ReadError]
 
 // Type aliases
 

--- a/workspace/coordinator/types.mbt
+++ b/workspace/coordinator/types.mbt
@@ -72,7 +72,7 @@ fn ProtectedRead::ProtectedRead(
 pub struct ProtectedCell[T] {
   cell_id : @incr.CellId
   label : String
-  read : () -> Result[T, @incr.CycleError]
+  read : () -> Result[T, @incr.ReadError]
   is_disposed : () -> Bool
   dispose : () -> Unit
 }
@@ -81,7 +81,7 @@ pub struct ProtectedCell[T] {
 fn[T] ProtectedCell::ProtectedCell(
   cell_id~ : @incr.CellId,
   label~ : String,
-  read~ : () -> Result[T, @incr.CycleError],
+  read~ : () -> Result[T, @incr.ReadError],
   is_disposed~ : () -> Bool,
   dispose~ : () -> Unit,
 ) -> ProtectedCell[T] {

--- a/workspace/coordinator/workspace_memo.mbt
+++ b/workspace/coordinator/workspace_memo.mbt
@@ -100,10 +100,11 @@ pub fn[T] Coordinator::register_workspace_memo(
 }
 
 ///|
-/// Delegates to the underlying watch. A cycle surfaces as `Err(CycleError)`.
+/// Delegates to the underlying watch. Returns `Err(ReadError)` — a cycle as
+/// `Cycle(CycleError)`, a read on a disposed cell as `Disposed(CellId)`.
 pub fn[T] WorkspaceMemoHandle::read(
   self : WorkspaceMemoHandle[T],
-) -> Result[T, @incr.CycleError] {
+) -> Result[T, @incr.ReadError] {
   self.watch.read()
 }
 


### PR DESCRIPTION
Propagates incr's honest-read-error **Tier 2** (`ReadError`) into canopy.

## Chain
- incr #127 (`78de61f`) widened the target-facade read channel — `Derived`/`ReachableDerived`/`DerivedMap` `get`/`read`/`read_or_else` + `Watch::read` — from `Result[T, CycleError]` to `Result[T, ReadError]` (`ReadError = Cycle(CycleError) | Disposed(CellId)`). Compat `get_result` family unchanged.
- loom #200 (`bcfc618`) bumped its incr submodule to `d825537`.
- This PR bumps canopy's loom submodule `8a2c7c2 → bcfc618` and fixes the one canopy package that consumes the widened read channel.

## Coordinator fix (`workspace/coordinator`)
`Watch::read` now yields `ReadError`, which broke `ProtectedCell.read` and `WorkspaceMemoHandle::read` (both typed to `CycleError`).

- **Thin-facade wrappers** (`ProtectedCell.read`, `WorkspaceMemoHandle::read`) widened to `Result[T, @incr.ReadError]` — direct propagation; they expose incr's read channel verbatim.
- **`read_protected`** (the quarantine boundary translating into the domain `AbortReport`) now maps `Disposed → ProtectedCellDisposed` (an existing `AbortKind`) and `Cycle → CycleDetected`, via incr's public `is_disposed()` accessor — instead of mislabeling every read error as `CycleDetected`. This is the honest mapping Tier 2 enables.
- wbtest: fixed the synthetic-cycle test to wrap in `ReadError::cycle`, and added a `Disposed → ProtectedCellDisposed` mapping test for the new branch.

No other canopy package consumes the read Result's error type (ffi `.read().unwrap()` is error-type-agnostic; cognition does not surface it).

## Reuse check
Reuses the existing `AbortKind::ProtectedCellDisposed` variant and incr's public `ReadError::is_disposed()`/`format_path()` accessors — no new types. Wrapper signatures widen to the already-public `@incr.ReadError`.

## Validation
`moon check` clean workspace-wide; `workspace/coordinator` 12/12, `ffi/lambda` 48/48; full loom workspace 1266/1266 against the bumped incr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)