### PR TITLE
fix(lambda): use scope graph env for edit capture checks

### DIFF
--- a/lang/lambda/edits/pkg.generated.mbti
+++ b/lang/lambda/edits/pkg.generated.mbti
@@ -10,8 +10,6 @@ import {
 }
 
 // Values
-pub fn collect_lam_env(@core.NodeId, Map[@core.NodeId, @core.ProjNode[@ast.Term]]) -> @hashset.HashSet[String]
-
 pub fn compute_text_edit(TreeEditOp, EditContext[@ast.Term]) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String]
 
 pub fn find_binding_for_init(@core.NodeId, @proj.FlatProj) -> (@core.NodeId, Int)?

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -41,6 +41,44 @@ fn collect_var_usages(
 }
 
 ///|
+fn name_captured_at_node(
+  g : @scope.ScopeGraph,
+  node_id : NodeId,
+  name : String,
+) -> Bool {
+  @scope.enclosing_env(g, node_id).contains(name)
+}
+
+///|
+fn free_names_captured_at_node(
+  g : @scope.ScopeGraph,
+  node_id : NodeId,
+  free_names : @immut/hashset.HashSet[String],
+) -> Bool {
+  let env = @scope.enclosing_env(g, node_id)
+  let mut captured = false
+  free_names.each(fn(v) { if env.contains(v) { captured = true } })
+  captured
+}
+
+///|
+fn free_names_captured_at_use_sites(
+  g : @scope.ScopeGraph,
+  node : ProjNode[@ast.Term],
+  free_names : @immut/hashset.HashSet[String],
+) -> Bool {
+  let mut captured = false
+  free_names.each(fn(v) {
+    let var_ids : Array[NodeId] = []
+    collect_var_usages(node, v, var_ids)
+    if var_ids.any(fn(vid) { name_captured_at_node(g, vid, v) }) {
+      captured = true
+    }
+  })
+  captured
+}
+
+///|
 /// Look up the FlatProj binding NodeId for a given init expression NodeId.
 /// The UI selects init expression ProjNodes (children of Module); this function
 /// maps that to the corresponding binding NodeId needed by binding-level operations.
@@ -54,28 +92,4 @@ pub fn find_binding_for_init(
     }
   }
   None
-}
-
-///|
-/// Collect Lam parameter names in scope at a node position (walking up the tree).
-pub fn collect_lam_env(
-  node_id : NodeId,
-  registry : Map[NodeId, ProjNode[@ast.Term]],
-) -> @immut/hashset.HashSet[String] {
-  let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
-  fn walk_up(nid : NodeId) {
-    for pid, pnode in registry {
-      for child in pnode.children {
-        if child.id() == nid {
-          if pnode.kind is @ast.Term::Lam(param, _) {
-            env = env.add(param)
-          }
-          walk_up(pid)
-          return
-        }
-      }
-    }
-  }
-  walk_up(node_id)
-  env
 }

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -50,18 +50,6 @@ fn name_captured_at_node(
 }
 
 ///|
-fn free_names_captured_at_node(
-  g : @scope.ScopeGraph,
-  node_id : NodeId,
-  free_names : @immut/hashset.HashSet[String],
-) -> Bool {
-  let env = @scope.enclosing_env(g, node_id)
-  let mut captured = false
-  free_names.each(fn(v) { if env.contains(v) { captured = true } })
-  captured
-}
-
-///|
 fn free_names_captured_at_use_sites(
   g : @scope.ScopeGraph,
   node : ProjNode[@ast.Term],
@@ -76,6 +64,101 @@ fn free_names_captured_at_use_sites(
     }
   })
   captured
+}
+
+///|
+fn def_cutoff_at_node(
+  flat_proj : FlatProj,
+  source_map : SourceMap,
+  node_id : NodeId,
+) -> Int {
+  guard source_map.get_range(node_id) is Some(r) else {
+    return flat_proj.defs.length()
+  }
+  flat_proj.defs
+  .search_by(fn(def) {
+    source_map.get_range(def.1.id()) is Some(dr) &&
+    r.start >= dr.start &&
+    r.start < dr.end
+  })
+  .unwrap_or(flat_proj.defs.length())
+}
+
+///|
+fn scope_id_for_node(
+  g : @scope.ScopeGraph,
+  node_id : NodeId,
+) -> @scope.ScopeId? {
+  match g.refs.iter().find_first(fn(r) { r.node_id == node_id }) {
+    Some(r) => Some(r.scope)
+    None =>
+      g.decls
+      .iter()
+      .find_first(fn(d) { d.node_id == node_id })
+      .map(fn(d) { d.scope })
+  }
+}
+
+///|
+fn declaration_id_for_name_at_node(
+  g : @scope.ScopeGraph,
+  flat_proj : FlatProj,
+  source_map : SourceMap,
+  node_id : NodeId,
+  name : String,
+) -> @scope.DeclId? {
+  guard scope_id_for_node(g, node_id) is Some(start_scope) else { return None }
+  let cutoff = def_cutoff_at_node(flat_proj, source_map, node_id)
+  let mut cur : @scope.ScopeId? = Some(start_scope)
+  while cur is Some(sid) {
+    let @scope.ScopeId(si) = sid
+    let scope = g.scopes[si]
+    let mut hit : @scope.DeclId? = None
+    for did in scope.decl_ids {
+      let @scope.DeclId(di) = did
+      let decl = g.decls[di]
+      if decl.name == name {
+        match decl.kind {
+          @scope.DeclKind::ModuleDef(def_index~) =>
+            if def_index < cutoff {
+              hit = Some(did)
+            }
+          @scope.DeclKind::LamParam(_) => hit = Some(did)
+        }
+      }
+    }
+    if hit is Some(_) {
+      return hit
+    }
+    cur = scope.parent
+  }
+  None
+}
+
+///|
+fn free_names_would_rebind_at_node(
+  g : @scope.ScopeGraph,
+  flat_proj : FlatProj,
+  source_map : SourceMap,
+  source_node : ProjNode[@ast.Term],
+  target_node_id : NodeId,
+  free_names : @immut/hashset.HashSet[String],
+) -> Bool {
+  let mut rebound = false
+  free_names.each(fn(v) {
+    let var_ids : Array[NodeId] = []
+    collect_var_usages(source_node, v, var_ids)
+    let target_decl = declaration_id_for_name_at_node(
+      g, flat_proj, source_map, target_node_id, v,
+    )
+    for vid in var_ids {
+      let source_decl = @scope.declaration(g, vid).map(fn(d) { d.id })
+      if source_decl != target_decl {
+        rebound = true
+      }
+    }
+  })
+  rebound
 }
 
 ///|

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -100,15 +100,17 @@ fn scope_id_for_node(
 }
 
 ///|
-fn declaration_id_for_name_at_node(
+fn root_scope_id(g : @scope.ScopeGraph) -> @scope.ScopeId? {
+  g.scopes.iter().find_first(fn(s) { s.parent is None }).map(fn(s) { s.id })
+}
+
+///|
+fn declaration_id_for_name_from_scope(
   g : @scope.ScopeGraph,
-  flat_proj : FlatProj,
-  source_map : SourceMap,
-  node_id : NodeId,
+  start_scope : @scope.ScopeId,
+  cutoff : Int,
   name : String,
 ) -> @scope.DeclId? {
-  guard scope_id_for_node(g, node_id) is Some(start_scope) else { return None }
-  let cutoff = def_cutoff_at_node(flat_proj, source_map, node_id)
   let mut cur : @scope.ScopeId? = Some(start_scope)
   while cur is Some(sid) {
     let @scope.ScopeId(si) = sid
@@ -136,6 +138,38 @@ fn declaration_id_for_name_at_node(
 }
 
 ///|
+fn declaration_id_for_name_at_node(
+  g : @scope.ScopeGraph,
+  flat_proj : FlatProj,
+  source_map : SourceMap,
+  node_id : NodeId,
+  name : String,
+) -> @scope.DeclId? {
+  guard scope_id_for_node(g, node_id) is Some(start_scope) else { return None }
+  declaration_id_for_name_from_scope(
+    g,
+    start_scope,
+    def_cutoff_at_node(flat_proj, source_map, node_id),
+    name,
+  )
+}
+
+///|
+fn declaration_id_for_name_at_module_end(
+  g : @scope.ScopeGraph,
+  flat_proj : FlatProj,
+  name : String,
+) -> @scope.DeclId? {
+  guard root_scope_id(g) is Some(root_scope) else { return None }
+  declaration_id_for_name_from_scope(
+    g,
+    root_scope,
+    flat_proj.defs.length(),
+    name,
+  )
+}
+
+///|
 fn free_names_would_rebind_at_node(
   g : @scope.ScopeGraph,
   flat_proj : FlatProj,
@@ -146,19 +180,45 @@ fn free_names_would_rebind_at_node(
 ) -> Bool {
   let mut rebound = false
   free_names.each(fn(v) {
-    let var_ids : Array[NodeId] = []
-    collect_var_usages(source_node, v, var_ids)
     let target_decl = declaration_id_for_name_at_node(
       g, flat_proj, source_map, target_node_id, v,
     )
-    for vid in var_ids {
-      let source_decl = @scope.declaration(g, vid).map(fn(d) { d.id })
-      if source_decl != target_decl {
-        rebound = true
-      }
+    if free_name_would_rebind_to(g, source_node, v, target_decl) {
+      rebound = true
     }
   })
   rebound
+}
+
+///|
+fn free_names_would_rebind_at_module_end(
+  g : @scope.ScopeGraph,
+  flat_proj : FlatProj,
+  source_node : ProjNode[@ast.Term],
+  free_names : @immut/hashset.HashSet[String],
+) -> Bool {
+  let mut rebound = false
+  free_names.each(fn(v) {
+    let target_decl = declaration_id_for_name_at_module_end(g, flat_proj, v)
+    if free_name_would_rebind_to(g, source_node, v, target_decl) {
+      rebound = true
+    }
+  })
+  rebound
+}
+
+///|
+fn free_name_would_rebind_to(
+  g : @scope.ScopeGraph,
+  source_node : ProjNode[@ast.Term],
+  name : String,
+  target_decl : @scope.DeclId?,
+) -> Bool {
+  let var_ids : Array[NodeId] = []
+  collect_var_usages(source_node, name, var_ids)
+  var_ids.any(fn(vid) {
+    @scope.declaration(g, vid).map(fn(d) { d.id }) != target_decl
+  })
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -11,7 +11,7 @@ fn compute_extract_to_let(
   guard source_map.get_range(node_id) is Some(range) else {
     return Err("Range not found")
   }
-  // Free-var validation: check for lambda-captured variables
+  // Free-var validation: check for variables captured by enclosing scopes.
   let mut module_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   // Find which def contains this node (or if it's in the body)
   let mut in_def_index : Int = flat_proj.defs.length() // body sentinel
@@ -32,12 +32,10 @@ fn compute_extract_to_let(
   for i = 0; i < scope_limit; i = i + 1 {
     module_env = module_env.add(flat_proj.defs[i].0)
   }
-  // Check for lambda-captured vars
-  let lam_env = collect_lam_env(node_id, registry)
+  // Check for variables captured by enclosing scope at their use sites.
+  let g = @scope.build(flat_proj, registry, source_map)
   let fv = free_vars(node.kind, module_env)
-  let mut captured_var : String? = None
-  fv.each(fn(v) { if lam_env.contains(v) { captured_var = Some(v) } })
-  if captured_var is Some(_) {
+  if free_names_captured_at_use_sites(g, node, fv) {
     return Err("Cannot extract: expression captures lambda-bound variables")
   }
   // Build edits
@@ -150,16 +148,9 @@ fn compute_inline_definition(
     DeclKind::ModuleDef(def_index~) => {
       let def = flat_proj.defs[def_index]
       let init_text = @ast.print_term(def.1.kind)
-      // Check for capture: would any free var in init be captured by a lambda at the usage site?
+      // Check for capture: would any free var in init be captured by an enclosing scope at the usage site?
       let init_fv = free_vars(def.1.kind, @immut/hashset.new())
-      let usage_lam_env = collect_lam_env(node_id, registry)
-      let mut would_capture = false
-      init_fv.each(fn(v) {
-        if usage_lam_env.contains(v) {
-          would_capture = true
-        }
-      })
-      if would_capture {
+      if free_names_captured_at_node(g, node_id, init_fv) {
         return Err(
           "Cannot inline: would capture variables bound by enclosing lambda",
         )
@@ -257,13 +248,10 @@ fn compute_inline_all_usages(
     Ok(ids) => ids
     Err(e) => return Err(e)
   }
-  // Check for capture: would any free var in init be captured by a lambda at any reference site?
+  // Check for capture: would any free var in init be captured by an enclosing scope at any reference site?
   let init_fv = free_vars(def.1.kind, @immut/hashset.new())
   for rid in ref_ids {
-    let ref_lam_env = collect_lam_env(rid, registry)
-    let mut would_capture = false
-    init_fv.each(fn(v) { if ref_lam_env.contains(v) { would_capture = true } })
-    if would_capture {
+    if free_names_captured_at_node(g, rid, init_fv) {
       return Err(
         "Cannot inline: would capture variables bound by enclosing lambda",
       )

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -150,7 +150,14 @@ fn compute_inline_definition(
       let init_text = @ast.print_term(def.1.kind)
       // Check for capture: would any free var in init be captured by an enclosing scope at the usage site?
       let init_fv = free_vars(def.1.kind, @immut/hashset.new())
-      if free_names_captured_at_node(g, node_id, init_fv) {
+      if free_names_would_rebind_at_node(
+          g,
+          flat_proj,
+          source_map,
+          def.1,
+          node_id,
+          init_fv,
+        ) {
         return Err(
           "Cannot inline: would capture variables bound by enclosing lambda",
         )
@@ -251,7 +258,14 @@ fn compute_inline_all_usages(
   // Check for capture: would any free var in init be captured by an enclosing scope at any reference site?
   let init_fv = free_vars(def.1.kind, @immut/hashset.new())
   for rid in ref_ids {
-    if free_names_captured_at_node(g, rid, init_fv) {
+    if free_names_would_rebind_at_node(
+        g,
+        flat_proj,
+        source_map,
+        def.1,
+        rid,
+        init_fv,
+      ) {
       return Err(
         "Cannot inline: would capture variables bound by enclosing lambda",
       )

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -11,31 +11,14 @@ fn compute_extract_to_let(
   guard source_map.get_range(node_id) is Some(range) else {
     return Err("Range not found")
   }
-  // Free-var validation: check for variables captured by enclosing scopes.
-  let mut module_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
-  // Find which def contains this node (or if it's in the body)
-  let mut in_def_index : Int = flat_proj.defs.length() // body sentinel
-  for i, def in flat_proj.defs {
-    if source_map.get_range(def.1.id()) is Some(r) &&
-      range.start >= r.start &&
-      range.end <= r.end {
-      in_def_index = i
-      break
-    }
-  }
-  // Add def names in scope at the extraction site
-  let scope_limit = if in_def_index < flat_proj.defs.length() {
-    in_def_index
-  } else {
-    flat_proj.defs.length()
-  }
-  for i = 0; i < scope_limit; i = i + 1 {
-    module_env = module_env.add(flat_proj.defs[i].0)
-  }
-  // Check for variables captured by enclosing scope at their use sites.
   let g = @scope.build(flat_proj, registry, source_map)
-  let fv = free_vars(node.kind, module_env)
-  if free_names_captured_at_use_sites(g, node, fv) {
+  let fv = free_vars(node.kind, @immut/hashset.new())
+  let would_capture = if flat_proj.defs.is_empty() {
+    free_names_captured_at_use_sites(g, node, fv)
+  } else {
+    free_names_would_rebind_at_module_end(g, flat_proj, node, fv)
+  }
+  if would_capture {
     return Err("Cannot extract: expression captures lambda-bound variables")
   }
   // Build edits

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -187,10 +187,9 @@ fn rename_module_binding(
     Ok(ids) => ids
     Err(e) => return Err(e)
   }
-  // Guard: check if new_name would be captured by an enclosing lambda at any reference site
+  // Guard: check if new_name would be captured by an enclosing scope at any reference site
   for ref_id in ref_ids {
-    let ref_lam_env = collect_lam_env(ref_id, registry)
-    if ref_lam_env.contains(new_name) {
+    if new_name != old_name && name_captured_at_node(g, ref_id, new_name) {
       return Err(
         "Cannot rename: '" +
         new_name +

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -760,6 +760,21 @@ test "compute_text_edit: ExtractToLet rejects lambda-captured var" {
 }
 
 ///|
+test "compute_text_edit: ExtractToLet rejects module-def enclosing env capture" {
+  let text = "let x = y\nlet y = 1\n0"
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let init_y = fp.defs[0].1
+  let result = compute_text_edit(
+    ExtractToLet(node_id=init_y.id(), var_name="z"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot extract: expression captures lambda-bound variables\")",
+  )
+}
+
+///|
 test "compute_text_edit: ExtractToLet bare expression" {
   let text = "42"
   let (proj, _) = parse_to_proj_node(text)
@@ -991,6 +1006,24 @@ test "compute_text_edit: Rename module binding" {
 }
 
 ///|
+test "compute_text_edit: Rename module binding to same name remains valid" {
+  let text = "let x = 42\nx"
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let binding_id = fp.defs[0].3
+  let result = compute_text_edit(
+    Rename(node_id=binding_id, new_name="x"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content=text)
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
 test "compute_text_edit: Rename module binding via Var" {
   let text = "let x = 42\nx"
   let (proj, sm, registry, fp) = parse_with_token_spans(text)
@@ -1137,6 +1170,21 @@ test "compute_text_edit: InlineDefinition rejects capture" {
 }
 
 ///|
+test "compute_text_edit: InlineDefinition rejects module-def enclosing env capture" {
+  let text = "let y = 1\nlet x = y\nx"
+  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot inline: would capture variables bound by enclosing lambda\")",
+  )
+}
+
+///|
 test "compute_text_edit: InlineAllUsages rejects capture" {
   let text = "let y = 1\nlet x = y\n\u{03BB}y. x"
   let (proj, sm, registry, fp) = parse_with_token_spans(text)
@@ -1149,6 +1197,20 @@ test "compute_text_edit: InlineAllUsages rejects capture" {
     make_edit_ctx(text, sm, registry, fp),
   )
   inspect(result is Err(_), content="true")
+}
+
+///|
+test "compute_text_edit: InlineAllUsages rejects module-def enclosing env capture" {
+  let text = "let y = 1\nlet x = y\nx"
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let result = compute_text_edit(
+    InlineAllUsages(binding_node_id=fp.defs[1].3),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot inline: would capture variables bound by enclosing lambda\")",
+  )
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1170,8 +1170,26 @@ test "compute_text_edit: InlineDefinition rejects capture" {
 }
 
 ///|
-test "compute_text_edit: InlineDefinition rejects module-def enclosing env capture" {
+test "compute_text_edit: InlineDefinition allows same module-def reference" {
   let text = "let y = 1\nlet x = y\nx"
+  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="let y = 1\ny")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: InlineDefinition rejects later module-def shadow capture" {
+  let text = "let y = 1\nlet x = y\nlet y = 2\nx"
   let (proj, sm, registry, fp) = parse_with_token_spans(text)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
@@ -1200,8 +1218,25 @@ test "compute_text_edit: InlineAllUsages rejects capture" {
 }
 
 ///|
-test "compute_text_edit: InlineAllUsages rejects module-def enclosing env capture" {
+test "compute_text_edit: InlineAllUsages allows same module-def reference" {
   let text = "let y = 1\nlet x = y\nx"
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let result = compute_text_edit(
+    InlineAllUsages(binding_node_id=fp.defs[1].3),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="let y = 1\ny")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: InlineAllUsages rejects later module-def shadow capture" {
+  let text = "let y = 1\nlet x = y\nlet y = 2\nx"
   let (_, sm, registry, fp) = parse_with_token_spans(text)
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=fp.defs[1].3),

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -775,6 +775,21 @@ test "compute_text_edit: ExtractToLet rejects module-def enclosing env capture" 
 }
 
 ///|
+test "compute_text_edit: ExtractToLet rejects later module-def shadow capture" {
+  let text = "let y = 1\nlet x = y\nlet y = 2\n0"
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let init_y = fp.defs[1].1
+  let result = compute_text_edit(
+    ExtractToLet(node_id=init_y.id(), var_name="z"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot extract: expression captures lambda-bound variables\")",
+  )
+}
+
+///|
 test "compute_text_edit: ExtractToLet bare expression" {
   let text = "42"
   let (proj, _) = parse_to_proj_node(text)

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -84,9 +84,8 @@ pub fn go_to_definition(
 ///|
 /// The set of names bound in scopes enclosing `node` — the FULL lexical
 /// environment (lambda params AND module defs). This is a SUPERSET of the
-/// existing `collect_lam_env` (which returns only lambda params); it is NOT a
-/// drop-in replacement. Set semantics (membership, not order).
-/// Reserved API surface; consumer migration deferred (see design spec).
+/// retired edits-package `collect_lam_env` (which returned only lambda params);
+/// it is NOT a drop-in replacement. Set semantics (membership, not order).
 pub fn enclosing_env(
   g : ScopeGraph,
   node : @core.NodeId,


### PR DESCRIPTION
## Summary

- Migrates lambda edit capture checks from the old `collect_lam_env` helper to canonical `@scope.enclosing_env`.
- Removes the public `collect_lam_env` edits API and updates `enclosing_env` docs now that it has edit consumers.
- Adds behavior tests for module-definition capture: allow same-declaration module refs, reject later module shadowing, preserve lambda-capture rejection, and cover extract/inline separately.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@scope.enclosing_env` | `lang/lambda/scope/query.mbt` | Yes | Canonical lexical environment query; target API for this migration. |
| `@scope.declaration` | `lang/lambda/scope/query.mbt` | Yes | Used to compare original reference declarations against hypothetical edit-site declarations. |
| `free_vars` | `lang/lambda/edits/free_vars.mbt` | Yes | Existing free-name analysis for edit capture checks. |
| `collect_var_usages` | `lang/lambda/edits/scope.mbt` | Yes | Existing shadow-aware Var traversal reused for extract and inline checks. |

New helpers added:

- `name_captured_at_node`: private edits-package predicate for one name against `@scope.enclosing_env` at a node.
- `free_names_captured_at_use_sites`: private edits-package predicate for bare-expression extraction, where composite nodes need per-use-site environments.
- `def_cutoff_at_node`, `scope_id_for_node`, `root_scope_id`, `declaration_id_for_name_from_scope`, `declaration_id_for_name_at_node`, `declaration_id_for_name_at_module_end`: private edits-package helpers for resolving a name at concrete or hypothetical edit sites using the same module cutoff rule.
- `free_names_would_rebind_at_node`, `free_names_would_rebind_at_module_end`, `free_name_would_rebind_to`: private edits-package predicates that reject only when a free occurrence would resolve to a different declaration after the edit.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild not run; web build artifacts are not affected by this MoonBit edit-semantics change

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test lang/lambda/edits
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon check --deny-warn
git diff --check
NEW_MOON_MOD=0 moon test
```

Results:

- `lang/lambda/edits`: 135/135 passed
- workspace: 1275/1275 passed
- `.mbti`: only intended removal is public `collect_lam_env`
