### PR TITLE
fix(ideal): derive scope annotations from scope graph

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -435,15 +435,18 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Option D: an on-demand `@scope` binder-location accessor over the
   already-populated SourceMap token spans — no loom PR, no `FlatProj` change;
   `node_id` stays synthetic but is no longer the locator).
-  Shipped (plan steps 1, 2, 4): `@scope.binder_span` + `@scope.go_to_definition`
+  Shipped (plan steps 1–5): `@scope.binder_span` + `@scope.go_to_definition`
   accessors (`lang/lambda/scope/query.mbt`); `references` migrated off
   `Decl.node_id` to `DeclId`; §7.1 go-to-def behavioral tests
-  (`go_to_definition_wbtest.mbt`); the #399 fixture + cross-pipeline PBT
-  `node_id` invariants rewritten to affirm the binder-location contract
-  (locatable + pipeline-independent).
-  Remaining: (step 3) an incremental↔full differential resolution test for the
-  `@incr` path the PBT excludes; (step 5) collapse `scope_annotation.mbt` onto
-  `@scope` once the outline-highlight UI representation is decided (§5).
+  (`go_to_definition_wbtest.mbt`); incremental/full scope differential tests
+  (`scope_incremental_differential_wbtest.mbt`,
+  `scope_memo_stack_differential_wbtest.mbt`); the #399 fixture +
+  cross-pipeline PBT `node_id` invariants rewritten to affirm the
+  binder-location contract (locatable + pipeline-independent); and Ideal
+  outline scope annotation collapsed onto @scope with the NodeId-keyed UI model
+  retained via stable module-binder UI keys.
+  Remaining: gated query-indexing is the only open scope follow-up here; the
+  binder-location plan itself is complete.
 
 ## Shipped history
 

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -64,7 +64,7 @@ fn init_model() -> Model raise {
     bottom_tab: Problems,
     sync_status: Connecting,
     overlay: closed_overlay(),
-    scope_map: build_scope_map(editor),
+    scope_map: build_scope_map(editor, companion),
     highlight_set: @immut/hashset.new(),
     drag_source: None,
     drop_target_id: None,
@@ -268,7 +268,7 @@ fn refresh(model : Model) -> Model {
   js_perf_end("treeEditorRefresh")
   // Build scope_map from current projection
   js_perf_begin("buildScopeMap")
-  let scope_map = build_scope_map(model.editor)
+  let scope_map = build_scope_map(model.editor, model.companion)
   js_perf_end("buildScopeMap")
   // Recompute highlight_set if a node is selected
   js_perf_begin("computeHighlightSet")

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -14,6 +14,7 @@ import {
   "dowdiness/canopy/lang/lambda",
   "dowdiness/canopy/lang/lambda/edits" @lambda_edits,
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/canopy/lang/lambda/scope",
   "dowdiness/lambda/ast",
   "moonbitlang/core/strconv",
   "moonbitlang/core/string",

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -187,8 +187,6 @@ pub(all) struct PatchEntry {
 
 type ScopeAnnotation
 
-type ScopeEntry
-
 pub enum SyncStatus {
   Offline
   Connecting

--- a/examples/ideal/main/scope_annotation.mbt
+++ b/examples/ideal/main/scope_annotation.mbt
@@ -2,28 +2,31 @@
 // Rabbita-local — does not modify ViewNode (framework genericity contract).
 //
 // Architecture:
-//   build_scope_map(editor) → Map[NodeId, ScopeAnnotation]
-//     Uses walk_scope: a single recursive walk over the ProjNode tree with
-//     a scope stack, following the same scoping rules as free_vars.mbt:
-//       - Module defs: sequential scope (each def visible to subsequent defs + body)
-//       - Lam params: lexical scope (visible in the body)
-//       - Nested blocks: handled naturally by the scope stack
-//     No dependency on FlatProj or the edits-package binder lookup.
+//   build_scope_map(editor, companion) → Map[NodeId, ScopeAnnotation]
+//     Uses the canonical lambda @scope graph as the single source of binding
+//     truth. References and usage lists come from @scope.references keyed by
+//     DeclId, so shadowing is handled by declaration identity rather than
+//     name-only membership.
+//
+//   UI representation decision (scope-binder-node-id plan step 5): keep the
+//     existing NodeId-keyed outline highlight model. Lambda binders use their
+//     real Lam node id; module binders use stable UI-only synthetic keys because
+//     module binder names still have source ranges, not outline rows.
+//     Source/binding resolution still comes from @scope.
 //
 //   compute_highlight_set(selected_id, scope_map) → HashSet[NodeId]
 //     Given a clicked/navigated node, returns the set of NodeIds to highlight:
-//     binder + all its usages. Uniform for both lambda and module bindings.
-//
-//   backfill_usages(scope_map)
-//     Second pass: for each Var → binder link, adds the Var to the binder's
-//     usage_ids list. This enables binder → usages lookup in highlight_set.
+//     binder key + all its usages. Uniform for both lambda and module bindings.
 //
 // Data flow:
-//   ProjNode tree → walk_scope (scope stack) → scope_map → view_outline_node
-//                                                        → compute_highlight_set
+//   FlatProj + registry + SourceMap → @scope.build → @scope.references
+//     → scope_map → view_outline_node → compute_highlight_set
+//   Nested block Modules are overlaid by building @scope graphs for each nested
+//   Module subtree; the overlay still consumes @scope.references by DeclId and
+//   does not perform name-stack resolution locally.
 
 ///|
-/// Annotation for one node: its binder, whether it's a definition site,
+/// Annotation for one node: its binder key, whether it's a definition site,
 /// deterministic color, and (for binders) the list of usage NodeIds.
 struct ScopeAnnotation {
   binder_id : @canopy_core.NodeId?
@@ -47,158 +50,145 @@ fn binder_color_index(name : String) -> Int {
 }
 
 ///|
-/// A scope entry: a name bound to a binder NodeId.
-struct ScopeEntry {
-  name : String
-  binder_node_id : @canopy_core.NodeId
-  binder_name : String
+/// UI-only key for a module binder in the NodeId-keyed outline highlight map.
+/// This is deliberately separate from @scope's source-location contract:
+/// bindings are resolved by DeclId/@scope.references; this key only lets the
+/// existing highlight data structure represent a binder that has no ProjNode.
+fn module_binder_ui_key(
+  module_node_id : @canopy_core.NodeId,
+  def_index : Int,
+) -> @canopy_core.NodeId {
+  let sum = module_node_id.0 + def_index
+  let pair = sum * (sum + 1) / 2 + def_index
+  @canopy_core.NodeId::from_int(-(pair + 1))
 }
 
 ///|
-/// Build scope_map by walking the ProjNode tree with a scope stack.
-/// Follows the same scoping rules as free_vars: sequential scope for Module
-/// defs, lexical scope for Lam params. Handles nested blocks correctly.
-fn build_scope_map(
-  editor : @editor.SyncEditor[@ast.Term],
-) -> Map[@canopy_core.NodeId, ScopeAnnotation] {
-  let scope_map : Map[@canopy_core.NodeId, ScopeAnnotation] = {}
-  let proj_root = match editor.get_proj_node() {
-    Some(r) => r
-    None => return scope_map
+/// Convert a @scope declaration to the NodeId-compatible UI key used by the
+/// outline highlight map.
+fn scope_binder_ui_key(
+  graph : @scope.ScopeGraph,
+  decl : @scope.Decl,
+) -> @canopy_core.NodeId {
+  match decl.kind {
+    @scope.DeclKind::LamParam(lam_id~) => lam_id
+    @scope.DeclKind::ModuleDef(def_index~) =>
+      module_binder_ui_key(graph.module_node_id, def_index)
   }
-  // Walk the ProjNode tree with an empty scope stack
-  let scope : Array[ScopeEntry] = []
-  walk_scope(proj_root, scope, scope_map)
-  // Backfill: for each var that points to a binder, add var to binder's usage_ids
-  backfill_usages(scope_map)
-  scope_map
 }
 
 ///|
-/// Recursive walk over ProjNode tree, maintaining a scope stack.
-/// For each Var, looks up the name in the scope stack (innermost first).
-/// For each Lam, pushes the param onto the scope stack.
-/// For Module, pushes defs in sequential scope order.
-fn walk_scope(
-  node : @canopy_core.ProjNode[@ast.Term],
-  scope : Array[ScopeEntry],
+/// Merge one canonical @scope graph into the UI scope_map.
+fn add_scope_graph_annotations(
   scope_map : Map[@canopy_core.NodeId, ScopeAnnotation],
+  graph : @scope.ScopeGraph,
 ) -> Unit {
-  let node_id = node.id()
-  match node.kind {
-    Var(name) => {
-      // Look up name in scope stack (last = innermost)
-      let mut i = scope.length() - 1
-      while i >= 0 {
-        if scope[i].name == name {
-          let entry = scope[i]
-          scope_map[node_id] = {
-            binder_id: Some(entry.binder_node_id),
-            is_definition: false,
-            color_index: binder_color_index(entry.binder_name),
-            usage_ids: [],
-          }
-          break
-        }
-        i = i - 1
-      }
-      // If not found, it's a free variable — no annotation
+  for decl in graph.decls {
+    let binder_id = scope_binder_ui_key(graph, decl)
+    let color_index = binder_color_index(decl.name)
+    let usage_ids = @scope.references(graph, decl.id)
+    scope_map[binder_id] = {
+      binder_id: Some(binder_id),
+      is_definition: true,
+      color_index,
+      usage_ids: [],
     }
-    Lam(param_name, _) => {
-      // Register the Lam as a definition site
-      let cidx = binder_color_index(param_name)
-      scope_map[node_id] = {
-        binder_id: Some(node_id),
-        is_definition: true,
-        color_index: cidx,
+    for usage_id in usage_ids {
+      scope_map[usage_id] = {
+        binder_id: Some(binder_id),
+        is_definition: false,
+        color_index,
         usage_ids: [],
       }
-      // Push param onto scope and walk children
-      scope.push({
-        name: param_name,
-        binder_node_id: node_id,
-        binder_name: param_name,
-      })
-      for child in node.children {
-        walk_scope(child, scope, scope_map)
-      }
-      let _ = scope.unsafe_pop()
-      return // Already walked children
     }
-    Module(defs, _) => {
-      // Sequential scope: each def is visible to subsequent defs and the body.
-      // Children are [init_0, init_1, ..., body].
-      // defs[i] corresponds to children[i].
-      let initial_scope_len = scope.length()
-      for i, child in node.children {
-        if i < defs.length() {
-          // Walk the init expression BEFORE pushing this def's name
-          // (a def's init can't reference itself — sequential scope)
-          walk_scope(child, scope, scope_map)
-          // Push the def name for subsequent defs and the body.
-          // Use a synthetic NodeId for the module-def binder to avoid
-          // collision with the init expression's own NodeId (which may
-          // be a Lam that has its own lambda-binder annotation).
-          let def_name = defs[i].0
-          let def_binder_id = @canopy_core.NodeId::from_int(
-            -(child.node_id + 1),
-          )
-          scope.push({
-            name: def_name,
-            binder_node_id: def_binder_id,
-            binder_name: def_name,
-          })
-          // Register synthetic binder as a definition site
-          scope_map[def_binder_id] = {
-            binder_id: Some(def_binder_id),
-            is_definition: true,
-            color_index: binder_color_index(def_name),
-            usage_ids: [],
-          }
-        } else {
-          // Body expression — all defs are in scope
-          walk_scope(child, scope, scope_map)
-        }
-      }
-      // Pop all defs we pushed
-      while scope.length() > initial_scope_len {
-        let _ = scope.unsafe_pop()
-      }
-      return // Already walked children
-    }
-    _ => ()
-  }
-  // Default: walk children (for App, Bop, If, etc.)
-  for child in node.children {
-    walk_scope(child, scope, scope_map)
   }
 }
 
 ///|
-/// Second pass: for each Var that points to a binder,
-/// add the Var's NodeId to the binder's usage_ids.
-fn backfill_usages(
+/// Build and merge a canonical @scope graph rooted at one Module node.
+fn add_module_scope_annotations(
+  node : @canopy_core.ProjNode[@ast.Term],
+  source_map : @canopy_core.SourceMap,
+  scope_map : Map[@canopy_core.NodeId, ScopeAnnotation],
+) -> Unit {
+  let registry : Map[@canopy_core.NodeId, @canopy_core.ProjNode[@ast.Term]] = {}
+  @canopy_core.collect_registry(node, registry)
+  if registry.is_empty() {
+    return
+  }
+  let graph = @scope.build(
+    @lambda_proj.FlatProj::from_proj_node(node),
+    registry,
+    source_map,
+  )
+  add_scope_graph_annotations(scope_map, graph)
+}
+
+///|
+/// Overlay @scope annotations for block Module subtrees. The top-level graph
+/// ignores local block definitions; building a graph rooted at each Module lets
+/// @scope own local declaration identity too. Pre-order traversal is important:
+/// inner Module graphs run after outer graphs, so innermost declarations
+/// overwrite outer annotations for references they actually resolve.
+fn add_nested_module_scope_annotations(
+  node : @canopy_core.ProjNode[@ast.Term],
+  source_map : @canopy_core.SourceMap,
+  scope_map : Map[@canopy_core.NodeId, ScopeAnnotation],
+) -> Unit {
+  match node.kind {
+    @ast.Term::Module(_, _) =>
+      add_module_scope_annotations(node, source_map, scope_map)
+    _ => ()
+  }
+  for child in node.children {
+    add_nested_module_scope_annotations(child, source_map, scope_map)
+  }
+}
+
+///|
+/// Rebuild binder usage lists from the final reference annotations. This removes
+/// stale outer-graph references after a nested Module graph overwrites a Var with
+/// a more local declaration.
+fn rebuild_usage_lists(
   scope_map : Map[@canopy_core.NodeId, ScopeAnnotation],
 ) -> Unit {
   let pairs : Array[(@canopy_core.NodeId, @canopy_core.NodeId)] = []
   for node_id, ann in scope_map {
-    if !ann.is_definition {
-      match ann.binder_id {
-        Some(bid) => pairs.push((node_id, bid))
-        None => ()
-      }
+    if ann.is_definition {
+      ann.usage_ids.clear()
+    } else if ann.binder_id is Some(binder_id) {
+      pairs.push((node_id, binder_id))
     }
   }
   for pair in pairs {
-    let (var_id, binder_id) = pair
+    let (usage_id, binder_id) = pair
     match scope_map.get(binder_id) {
-      Some(binder_ann) =>
-        if binder_ann.is_definition {
-          binder_ann.usage_ids.push(var_id)
-        }
-      None => ()
+      Some(binder_ann) if binder_ann.is_definition =>
+        binder_ann.usage_ids.push(usage_id)
+      _ => ()
     }
   }
+}
+
+///|
+/// Build scope_map from canonical lambda @scope graphs.
+fn build_scope_map(
+  editor : @editor.SyncEditor[@ast.Term],
+  companion : @lambda.LambdaCompanion,
+) -> Map[@canopy_core.NodeId, ScopeAnnotation] {
+  let scope_map : Map[@canopy_core.NodeId, ScopeAnnotation] = {}
+  guard editor.get_proj_node() is Some(proj_root) else { return scope_map }
+  guard companion.get_flat_proj() is Some(flat_proj) else { return scope_map }
+  let registry = editor.get_registry()
+  if registry.is_empty() {
+    return scope_map
+  }
+  let source_map = editor.get_source_map()
+  let graph = @scope.build(flat_proj, registry, source_map)
+  add_scope_graph_annotations(scope_map, graph)
+  add_nested_module_scope_annotations(proj_root, source_map, scope_map)
+  rebuild_usage_lists(scope_map)
+  scope_map
 }
 
 ///|
@@ -212,7 +202,7 @@ fn compute_highlight_set(
   match scope_map.get(selected_id) {
     None => hs
     Some(ann) => {
-      // Include the binder and all its usages
+      // Include the binder and all its usages.
       match ann.binder_id {
         Some(bid) => {
           hs = hs.add(bid)
@@ -226,7 +216,7 @@ fn compute_highlight_set(
         }
         None => ()
       }
-      // If this IS a binder, include self + usages
+      // If this IS a binder, include self + usages.
       if ann.is_definition {
         hs = hs.add(selected_id)
         for uid in ann.usage_ids {

--- a/examples/ideal/main/scope_annotation_wbtest.mbt
+++ b/examples/ideal/main/scope_annotation_wbtest.mbt
@@ -45,11 +45,11 @@ test "compute_highlight_set for non-identifier returns empty set" {
 
 ///|
 test "clicking f does not highlight apply var (no module/lambda scope confusion)" {
-  let editor = @lambda.new_lambda_editor("test").0
+  let (editor, companion) = @lambda.new_lambda_editor("test")
   editor.set_text(
     "let id = \\x. { x }\nlet apply = \\f. \\x. { f x }\napply id 42",
   )
-  let scope_map = build_scope_map(editor)
+  let scope_map = build_scope_map(editor, companion)
   let proj_root = editor.get_proj_node().unwrap()
   let f_var_id = find_var_node_id(proj_root, "f")
   let apply_var_id = find_var_node_id(proj_root, "apply")
@@ -71,9 +71,9 @@ test "clicking f does not highlight apply var (no module/lambda scope confusion)
 
 ///|
 test "nested block: inner x does not highlight outer x" {
-  let editor = @lambda.new_lambda_editor("test").0
+  let (editor, companion) = @lambda.new_lambda_editor("test")
   editor.set_text("let x = 0\nlet y = { let x = 1\n  x }\nx")
-  let scope_map = build_scope_map(editor)
+  let scope_map = build_scope_map(editor, companion)
   let proj_root = editor.get_proj_node().unwrap()
   // There are two Var("x") nodes — inner (inside block) and outer (body)
   let x_vars = find_all_var_node_ids(proj_root, "x")
@@ -91,6 +91,59 @@ test "nested block: inner x does not highlight outer x" {
   // Clicking one x should NOT highlight the other
   let hs0 = compute_highlight_set(x_vars[0], scope_map)
   inspect(hs0.contains(x_vars[1]), content="false")
+  let hs1 = compute_highlight_set(x_vars[1], scope_map)
+  inspect(hs1.contains(x_vars[0]), content="false")
+}
+
+///|
+test "nested block: inner module can reference enclosing block binder" {
+  let (editor, companion) = @lambda.new_lambda_editor("test")
+  editor.set_text("let x = 0\nlet y = { let x = 1\n  { let z = x\n    z } }\nx")
+  let scope_map = build_scope_map(editor, companion)
+  let proj_root = editor.get_proj_node().unwrap()
+  let x_vars = find_all_var_node_ids(proj_root, "x")
+  inspect(x_vars.length() >= 2, content="true")
+  let inner_x_ann = scope_map.get(x_vars[0]).unwrap()
+  let outer_x_ann = scope_map.get(x_vars[x_vars.length() - 1]).unwrap()
+  inspect(inner_x_ann.binder_id == outer_x_ann.binder_id, content="false")
+  let hs_inner = compute_highlight_set(x_vars[0], scope_map)
+  inspect(hs_inner.contains(x_vars[x_vars.length() - 1]), content="false")
+  let hs_outer = compute_highlight_set(x_vars[x_vars.length() - 1], scope_map)
+  inspect(hs_outer.contains(x_vars[0]), content="false")
+}
+
+///|
+test "scope_map keys module references by canonical @scope declaration" {
+  let (editor, companion) = @lambda.new_lambda_editor("test")
+  editor.set_text("let x = 0\nlet f = \\x. { x }\nx")
+  let scope_map = build_scope_map(editor, companion)
+  let proj_root = editor.get_proj_node().unwrap()
+  let x_vars = find_all_var_node_ids(proj_root, "x")
+  let inner_x_id = x_vars[0]
+  let module_x_id = x_vars[x_vars.length() - 1]
+  let graph = @scope.build(
+    companion.get_flat_proj().unwrap(),
+    editor.get_registry(),
+    editor.get_source_map(),
+  )
+  let module_decl = @scope.declaration(graph, module_x_id).unwrap()
+  let inner_decl = @scope.declaration(graph, inner_x_id).unwrap()
+  inspect(module_decl.id == inner_decl.id, content="false")
+  let is_module_decl = match module_decl.kind {
+    @scope.DeclKind::ModuleDef(def_index=_) => true
+    _ => false
+  }
+  inspect(is_module_decl, content="true")
+  let module_binder_key = scope_binder_ui_key(graph, module_decl)
+  let ann = scope_map.get(module_x_id).unwrap()
+  inspect(ann.binder_id == Some(module_binder_key), content="true")
+  let binder_ann = scope_map.get(module_binder_key).unwrap()
+  inspect(
+    binder_ann.usage_ids == @scope.references(graph, module_decl.id),
+    content="true",
+  )
+  let hs_inner = compute_highlight_set(inner_x_id, scope_map)
+  inspect(hs_inner.contains(module_x_id), content="false")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Collapse Ideal outline scope annotations onto the canonical lambda `@scope` graph instead of maintaining a separate `walk_scope` resolver.
- Keep the existing `NodeId`-keyed highlight UI model by using stable UI-only keys for module binders, while binding semantics come from `DeclId`/`@scope.references`.
- Update scope follow-up TODO state and add regression coverage for nested block shadowing in both highlight directions.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@scope.build` | `lang/lambda/scope/builder.mbt` | Yes | Canonical lambda scope graph construction for top-level and nested Module subtrees. |
| `@scope.references` | `lang/lambda/scope/query.mbt` | Yes | Identity-based reference enumeration keyed by `DeclId`; avoids name-only binding semantics. |
| `@scope.declaration` | `lang/lambda/scope/query.mbt` | Yes | Used in tests to assert UI annotations align with canonical declarations. |
| `@canopy_core.collect_registry` | `core` | Yes | Builds registry for nested Module subtrees before calling `@scope.build`. |
| `@lambda_proj.FlatProj::from_proj_node` | `lang/lambda/proj/flat_proj.mbt` | Yes | Converts Module subtree projection into the `FlatProj` shape expected by `@scope.build`. |

New helpers added:

- `module_binder_ui_key` / `scope_binder_ui_key`: UI-only bridge from `@scope.Decl` to the existing `NodeId`-keyed outline highlight map; does not define binding semantics.
- `add_scope_graph_annotations` / `add_module_scope_annotations` / `add_nested_module_scope_annotations`: local Ideal adapters that merge canonical scope graph facts into `ScopeAnnotation`.
- `rebuild_usage_lists`: normalizes binder usage lists after nested Module overlays so stale outer-graph references are removed.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`NEW_MOON_MOD=0 moon build --target js`)
- [x] Browser smoke: `examples/ideal/web` Vite app; checked lambda param/use highlighting, module reference highlighting, nested block shadowing both directions, and non-identifier selection clearing highlights.
- [x] `NEW_MOON_MOD=0 moon test` passes

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test examples/ideal/main/scope_annotation_wbtest.mbt
NEW_MOON_MOD=0 moon test examples/ideal/main
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon build --target js
NEW_MOON_MOD=0 moon check --deny-warn
git diff --check
```
