### PR TITLE
docs: reconcile modules.md with .gitmodules and moon.mod.json (#425)

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -4,13 +4,19 @@ The codebase is organized as a **monorepo with git submodules**:
 
 ## Git Submodules (Standalone Libraries)
 
+`.gitmodules` is authoritative for which submodules exist; this table adds the
+GitHub repo and MoonBit-module mapping on top of that list.
+
 | Submodule | GitHub Repo | MoonBit Module |
 |---|---|---|
 | `event-graph-walker/` | [dowdiness/event-graph-walker](https://github.com/dowdiness/event-graph-walker) | `dowdiness/event-graph-walker` |
-| `loom/` | [dowdiness/loom](https://github.com/dowdiness/loom) | `dowdiness/loom`, `dowdiness/seam`, `dowdiness/incr`, `dowdiness/text_change`, `dowdiness/moji`, `dowdiness/lambda` |
-| `svg-dsl/` | [dowdiness/svg-dsl](https://github.com/dowdiness/svg-dsl) | `antisatori/svg-dsl` |
-| `graphviz/` | [dowdiness/graphviz](https://github.com/dowdiness/graphviz) | `antisatori/graphviz` |
+| `loom/` | [dowdiness/loom](https://github.com/dowdiness/loom) | `dowdiness/loom`, `dowdiness/seam`, `dowdiness/incr`, `dowdiness/text_change`, `dowdiness/moji`, `dowdiness/pretty`, `dowdiness/lambda` (loom is itself a nested monorepo — see the `loom/` section below) |
+| `svg-dsl/` | [dowdiness/svg-dsl](https://github.com/dowdiness/svg-dsl) | `dowdiness/svg-dsl` |
+| `graphviz/` | [dowdiness/graphviz](https://github.com/dowdiness/graphviz) | `dowdiness/graphviz` |
 | `rle/` | [dowdiness/rle](https://github.com/dowdiness/rle) | `dowdiness/rle` |
+| `order-tree/` | [dowdiness/order-tree](https://github.com/dowdiness/order-tree) | `dowdiness/order-tree` (backs event-graph-walker) |
+| `alga/` | [dowdiness/alga](https://github.com/dowdiness/alga) | `dowdiness/alga` (backs event-graph-walker) |
+| `rabbita/` | [dowdiness/rabbita](https://github.com/dowdiness/rabbita) | vendored community UI library — not a root `moon.mod.json` dependency |
 
 ## `event-graph-walker/` Module (Core CRDT Library)
 
@@ -48,7 +54,17 @@ The `crdt` module depends on `dowdiness/lambda` (`loom/examples/lambda/`) and `d
 - `loom/incr/` — `dowdiness/incr`: reactive signals (`Signal`, `Memo`)
 - `loom/text-change/` — `dowdiness/text_change`: pure contiguous text-change utilities
 - `loom/moji/` — `dowdiness/moji`: UAX #29 grapheme and word-boundary segmentation
+- `loom/pretty/` — `dowdiness/pretty`: Wadler-Lindig pretty-printer
 - `loom/examples/lambda/` — `dowdiness/lambda`: lambda calculus tokenizer, grammar, AST, benchmarks
+
+This covers the loom packages most central to the editor; it is **not** exhaustive
+— the root also consumes `dowdiness/json`, `dowdiness/markdown`, `dowdiness/egglog`,
+and `dowdiness/egraph` from loom. `loom` is itself a nested monorepo:
+`loom/.gitmodules` declares `incr`/`egraph`/`egglog`/`event-graph-walker` as
+submodules and `loom/examples/` adds `json`/`markdown`. loom has no top-level
+module file — each package owns its own `moon.mod.json`; `loom/.gitmodules` plus
+the root `moon.mod.json` are authoritative for loom's package set and what the
+root consumes.
 
 **See:** [loom/README.md](../../loom/README.md) for detailed documentation.
 
@@ -136,19 +152,26 @@ crdt (depends on event-graph-walker + dowdiness/lambda + dowdiness/json + dowdin
 
 ## MoonBit Module Configuration
 
-The root `moon.mod.json` declares path dependencies on the submodules:
+The root [`moon.mod.json`](../../moon.mod.json) is the **authoritative** list of
+`dowdiness/*` dependencies — do not re-curate the full set here, or it re-drifts
+(this section previously listed 5 of 15 deps and went stale).
+
+Two declaration shapes appear there:
 
 ```json
 {
   "deps": {
-    "dowdiness/event-graph-walker": { "path": "./event-graph-walker" },
-    "dowdiness/text_change": { "path": "./loom/text-change" },
-    "dowdiness/moji": { "path": "./loom/moji" },
-    "dowdiness/lambda": { "path": "./loom/examples/lambda" },
-    "dowdiness/loom": { "path": "./loom/loom" }
+    // path dep — resolves to an in-repo submodule directory
+    "dowdiness/loom": { "path": "./loom/loom" },
+    // registry dep — pinned to a published mooncakes version
+    "dowdiness/incr": "0.5.2"
   }
 }
 ```
+
+Most `dowdiness/*` deps are path deps into the submodules above; `incr` is the
+notable exception, consumed as a registry version. For the complete, current
+list, read `moon.mod.json` directly.
 
 ## Run Tests
 


### PR DESCRIPTION
## Summary

Resolves #425. Brings `docs/architecture/modules.md` back in line with the authoritative `.gitmodules` and root `moon.mod.json`, following responsibility-map's "Source of Truth on Drift" (code and generated `.mbti` are authoritative; docs are a reuse index, not a parallel list that re-drifts).

All facts re-verified against the current `main` HEAD's `.gitmodules`, root `moon.mod.json`, and each submodule's own `moon.mod.json`.

## Changes (docs-only, single file)

- **Submodule table**: add the 3 missing submodules (`order-tree`, `alga`, `rabbita` → 8 total); note `.gitmodules` as authoritative; fix `svg-dsl`/`graphviz` module names `antisatori/*` → `dowdiness/*` (verified against their `moon.mod.json`). `order-tree`/`alga` back event-graph-walker; `rabbita` is a vendored UI lib, not a root dep.
- **loom section**: add `loom/pretty`; note loom is a nested monorepo (its own `loom/.gitmodules` declares `incr`/`egraph`/`egglog`/`event-graph-walker`; `examples/` adds `json`/`markdown`), with no top-level module file — each package owns its `moon.mod.json`. The bullet list is explicitly marked non-exhaustive.
- **MoonBit Module Configuration**: replace the stale 5-of-15 partial JSON copy with a pointer to `moon.mod.json` as authority plus a two-shape example (path dep vs registry dep; `incr` is the registry exception).

## Verification

- Cross-checked against `.gitmodules` (8 submodules), root `moon.mod.json` (15 `dowdiness/*` deps), and submodule `moon.mod.json` names.
- Codex pre-PR review caught two factual errors (over-claimed loom completeness; a non-existent `loom/moon.mod.json` reference) — both fixed before this PR.

Closes #425. Related: #413, #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)