### PR TITLE
fix(ideal): schema-valid fallback doc in Structure mode (#428)

### DIFF
--- a/examples/ideal/web/e2e/structure-mode-switch.spec.ts
+++ b/examples/ideal/web/e2e/structure-mode-switch.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+// Regression for #428.
+//
+// Switching Text -> Structure logged
+//   `RangeError: Invalid content for node module: <>`
+// whenever the projection read returned "null" (a transient protected-read
+// failure) and `buildDoc` fell back to an empty `module` node. The editor
+// schema requires `module` content `let_def* term`, so an empty module is
+// invalid and the throw aborted the whole structure mount.
+
+test.describe('Structure mode switch (#428)', () => {
+  test('Text -> Structure renders without uncaught errors and updates inspector', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+
+    await page.goto('/');
+    await expect(page.getByLabel('Code editor')).toBeVisible();
+
+    // Default mode is Text; switching to Structure mounts the ProseMirror host.
+    await page.getByRole('button', { name: 'Structure' }).click();
+
+    // The structure surface renders.
+    await page.waitForFunction(
+      () => {
+        const ce = document.querySelector('canopy-editor');
+        return ce?.shadowRoot?.querySelector('.structure-block') != null;
+      },
+      { timeout: 10000 },
+    );
+
+    // No RangeError / content error escaped from the structure path.
+    expect(
+      errors.filter((e) => /RangeError|Invalid content for node/.test(e)),
+    ).toEqual([]);
+
+    // Selecting a node still updates the inspector.
+    const inspector = page.getByLabel('Node inspector');
+    await expect(inspector).toBeVisible();
+
+    const varCoords = await page.evaluate(() => {
+      const ce = document.querySelector('canopy-editor');
+      const el = ce?.shadowRoot?.querySelector('.structure-var_ref');
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    });
+    expect(varCoords).not.toBeNull();
+    await page.mouse.click(varCoords!.x, varCoords!.y);
+
+    await expect(inspector.locator('.inspector-value').first()).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('buildStructureDoc falls back to a schema-valid doc when the projection is unavailable', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page.getByLabel('Code editor')).toBeVisible();
+
+    // Directly exercise the fallback path that #428 crashed on: a "null"
+    // projection must yield a schema-valid document instead of throwing.
+    // `editorSchema.node(...)` validates content on construction, so the
+    // pre-fix empty-`module` fallback threw here; `doc.check()` re-validates.
+    const result = await page.evaluate(async () => {
+      const mod = await import('/src/structure-runtime.ts');
+      const doc = mod.buildStructureDoc('null');
+      doc.check();
+      return { type: doc.type.name, childCount: doc.childCount };
+    });
+
+    expect(result.type).toBe('doc');
+    expect(result.childCount).toBe(1);
+  });
+});

--- a/examples/ideal/web/src/structure-runtime.ts
+++ b/examples/ideal/web/src/structure-runtime.ts
@@ -24,8 +24,23 @@ export type StructureModeSession = {
   setSelectedNode(id: string | null): void;
 };
 
-function buildDoc(crdtHandle: number, crdt: CrdtModule): PmNode {
-  const projJsonStr = crdt.get_proj_node_json(crdtHandle);
+/**
+ * Build the initial Structure-mode document from a ProjNode JSON string.
+ *
+ * When the projection is unavailable (`"null"` — e.g. a transient
+ * protected-read failure while switching into Structure mode) or conversion
+ * throws, fall back to a schema-valid placeholder.
+ *
+ * The placeholder MUST satisfy the editor schema: `doc` content is
+ * `module | term` and `module` content is `let_def* term`, so an empty
+ * `module` is invalid — it threw `RangeError: Invalid content for node
+ * module: <>` (#428) and aborted the whole mount. A bare `unit` term is the
+ * minimal valid empty document; the RAF / `set projNode` reconcile loop
+ * replaces it as soon as a real projection arrives.
+ *
+ * Exported for regression testing of the fallback path.
+ */
+export function buildStructureDoc(projJsonStr: string): PmNode {
   if (projJsonStr && projJsonStr !== "null") {
     try {
       return projNodeToDoc(JSON.parse(projJsonStr));
@@ -33,9 +48,11 @@ function buildDoc(crdtHandle: number, crdt: CrdtModule): PmNode {
       console.error("[canopy-editor] Failed to build PM doc:", error);
     }
   }
-  return editorSchema.node("doc", null, [
-    editorSchema.node("module", { nodeId: 0 }),
-  ]);
+  return editorSchema.node("doc", null, [editorSchema.node("unit")]);
+}
+
+function buildDoc(crdtHandle: number, crdt: CrdtModule): PmNode {
+  return buildStructureDoc(crdt.get_proj_node_json(crdtHandle));
 }
 
 function createStructureNodeViews() {


### PR DESCRIPTION
Fixes #428.

## Problem

Switching Text → Structure in `examples/ideal/web` logged:

```
RangeError: Invalid content for node module: <>
```

and aborted the whole structure mount.

## Root cause

`structure-runtime.ts buildDoc()` builds the initial ProseMirror document from `get_proj_node_json(handle)`. When that returns `"null"` — empty source, or a transient protected-read failure while switching modes — it fell back to:

```ts
editorSchema.node("doc", null, [editorSchema.node("module", { nodeId: 0 })]);
```

But the editor schema requires `module` content `let_def* term`, so an **empty** `module` is invalid. `editorSchema.node(...)` validates content on construction and threw `RangeError: Invalid content for node module: <>`. The throw is exactly the `<>` (empty fragment) the error reports.

The mismatch is **not** in the ProseMirror schema, the `ProjNodeJson → doc` conversion, or the reconciler — those handle real projections correctly (verified in isolation). It is purely the fallback path constructing a doc the schema forbids.

## Fix

Extract the builder as `buildStructureDoc(projJsonStr)` and fall back to a bare `unit` term — the minimal schema-valid empty document (`doc` content is `module | term`; `unit` is a `term`). The RAF / `set projNode` reconcile loop replaces it via a full subtree replace as soon as a real projection arrives, so a transient `"null"` degrades gracefully instead of crashing.

## Tests

New `e2e/structure-mode-switch.spec.ts`:
- **switch**: Text → Structure renders `.structure-block`, logs no `RangeError`/content error, and selecting a node populates the inspector (`.inspector-value`).
- **fallback**: `buildStructureDoc('null')` returns a schema-valid `doc` (`doc.check()` passes) instead of throwing — the path that crashed pre-fix.

## Reuse check

No new types/helpers beyond extracting the existing `buildDoc` body into an exported `buildStructureDoc`; the fallback reuses the existing `unit` schema node and the existing reconcile loop for healing.

## Verification

- `moon check` from workspace root: passes (no `.mbt` changes).
- `examples/ideal/web` e2e `structure-mode-switch.spec.ts`: 2/2 pass.
- Existing `structural-editing.spec.ts`: 10/10 pass against a fresh release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structure mode switching to prevent errors when transitioning between editor modes.
  * Enhanced document initialization with more robust fallback handling for edge cases.

* **Tests**
  * Added end-to-end tests for structure mode switching and document initialization verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->