### PR TITLE
refactor(core): add projection node construction helpers

### DIFF
--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -75,7 +75,9 @@ pub struct ProjNode[T] {
   start : Int
   end : Int
 } derive(Eq, @debug.Debug)
+pub fn[T] ProjNode::branch(T, Int, Int, Array[Self[T]], @ref.Ref[Int]) -> Self[T]
 pub fn[T] ProjNode::id(Self[T]) -> NodeId
+pub fn[T] ProjNode::leaf(T, @seam.SyntaxNode, @ref.Ref[Int]) -> Self[T]
 pub fn[T] ProjNode::new(T, Int, Int, Int, Array[Self[T]]) -> Self[T]
 pub impl[T : @dowdiness/loom/core.Renderable] Show for ProjNode[T]
 pub impl[T : ToJson] ToJson for ProjNode[T]

--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -40,6 +40,32 @@ pub fn[T] ProjNode::new(
 }
 
 ///|
+/// Construct a childless ProjNode spanning a syntax node, assigning a fresh id.
+/// Projection builders should prefer this for syntax leaves instead of pairing
+/// `next_proj_node_id` with `ProjNode::new` at each call site.
+pub fn[T] ProjNode::leaf(
+  kind : T,
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> ProjNode[T] {
+  ProjNode::new(kind, node.start(), node.end(), next_proj_node_id(counter), [])
+}
+
+///|
+/// Construct a ProjNode with explicit span and children, assigning a fresh id.
+/// Use this for projection branches whose identity is fresh for this build;
+/// keep `ProjNode::new` when preserving or reusing a known node id.
+pub fn[T] ProjNode::branch(
+  kind : T,
+  start : Int,
+  end : Int,
+  children : Array[ProjNode[T]],
+  counter : Ref[Int],
+) -> ProjNode[T] {
+  ProjNode::new(kind, start, end, next_proj_node_id(counter), children)
+}
+
+///|
 pub fn[T] ProjNode::id(self : ProjNode[T]) -> NodeId {
   NodeId(self.node_id)
 }
@@ -94,8 +120,7 @@ pub fn[T] assign_fresh_ids(
   let new_children : Array[ProjNode[T]] = [
     for child in node.children => assign_fresh_ids(child, counter)
   ]
-  let new_id = next_proj_node_id(counter)
-  ProjNode::new(node.kind, node.start, node.end, new_id, new_children)
+  ProjNode::branch(node.kind, node.start, node.end, new_children, counter)
 }
 
 ///|

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -86,6 +86,40 @@ test "ProjNode[TestExpr] — construction and field access" {
 }
 
 ///|
+test "ProjNode::leaf allocates a fresh id from syntax span" {
+  let syntax_node = @seam.SyntaxNode::from_cst(
+    @seam.CstNode::new(@seam.RawKind(1), [
+      @seam.CstElement::Token(
+        @seam.CstToken::CstToken(@seam.RawKind(2), "text"),
+      ),
+    ]),
+  )
+  let counter = Ref(7)
+  let leaf = ProjNode::leaf(Leaf("x"), syntax_node, counter)
+  inspect(leaf.node_id, content="7")
+  inspect(counter.val, content="8")
+  inspect(leaf.start, content="0")
+  inspect(leaf.end, content="4")
+  inspect(leaf.children.length(), content="0")
+}
+
+///|
+test "ProjNode::branch allocates a fresh id" {
+  let counter = Ref(7)
+  let child = ProjNode::new(Leaf("x"), 0, 1, 0, [])
+  let branch = ProjNode::branch(
+    Branch("root", [Leaf("x")]),
+    0,
+    5,
+    [child],
+    counter,
+  )
+  inspect(branch.node_id, content="7")
+  inspect(counter.val, content="8")
+  inspect(branch.children.length(), content="1")
+}
+
+///|
 test "ProjNode Show — depth-1 only, uses Renderable::kind_tag" {
   let leaf = ProjNode::new(Leaf("x"), 0, 1, 0, [])
   inspect(leaf, content="#0 Leaf [0..1]")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -144,9 +144,8 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: `build_tree`, `build_tree_interned`, `build_tree_fully_interned` are ~80 lines each of near-identical stack-based tree construction, differing only in token creation and node wrapping. Discovered during error handling audit (loom PR #75).
   Exit: shared core function parameterized by token/node creation callbacks; three variants are thin wrappers.
 
-- [ ] Hoist ProjNode id-allocation boilerplate into `@core` (`core/proj_node.mbt`). (finding B from PR #383)
-  Why: every `ProjNode::new(...)` call across `lang/lambda/proj` and `lang/json/proj` threads `@core.next_proj_node_id(counter)` into the id argument, and the per-language `lambda_leaf_node` / `json_leaf_node` helpers (PR #382/#383) are identical up to the value type `T`. `@core` already depends on `@seam`, so it can host the shared form.
-  Exit: `@core` exposes `ProjNode::leaf[T](kind, node : @seam.SyntaxNode, counter)` (plus a fresh-id branch ctor); both per-language leaf helpers are deleted and branch builders drop the explicit `next_proj_node_id` arg. Non-node-span sites (Unit fallback, Module span, ParenExpr id-reuse) keep raw `ProjNode::new`. `.mbti` change limited to the new `@core` exports; all tests pass.
+- [x] Hoist ProjNode id-allocation boilerplate into `@core` (`core/proj_node.mbt`). (finding B from PR #383)
+  Shipped (#437): `@core` exposes `ProjNode::leaf[T](kind, node : @seam.SyntaxNode, counter)` and `ProjNode::branch[T](kind, start, end, children, counter)`. Lambda/JSON/Markdown projection builders now use the shared helpers for fresh syntax leaves/branches; ID-preserving sites keep raw `ProjNode::new`. `.mbti` change is limited to the two new `@core` exports.
 
 - [ ] Add an `EditContext` node-resolution helper (`lang/lambda/edits/text_edit.mbt`). (finding C from PR #383)
   Why: nearly every `compute_*` handler opens with the same pair of guards keyed on one `node_id` — `registry.get(id)` then `source_map.get_range(id)`, both erroring "Node not found" — made visible by the PR #383 guard sweep. `EditContext` already holds both maps.

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -15,8 +15,10 @@ Refresh with: `NEW_MOON_MOD=0 moon ide outline <pkg>` or `NEW_MOON_MOD=0 moon id
 |-----|----------|-------|
 | `NodeId` | `core/` | Opaque wrapper over `Int`. Use this, do not invent integers for nodes. |
 | `NodeId::from_int` | `core/` | Construct from raw int (avoid unless crossing FFI boundary). |
-| `next_proj_node_id(counter)` | `core/` | Monotonic counter for fresh `ProjNode` IDs. |
+| `next_proj_node_id(counter)` | `core/` | Monotonic counter for fresh `ProjNode` IDs. Prefer the constructors below in projection builders. |
 | `ProjNode[T]` | `core/` | Generic projection node carrying value `T`. |
+| `ProjNode::leaf(kind, syntax_node, counter)` | `core/` | Fresh childless projection node spanning a `SyntaxNode`. Preferred for CST leaf projections. |
+| `ProjNode::branch(kind, start, end, children, counter)` | `core/` | Fresh projection node with explicit span and children. Use `ProjNode::new` only when preserving/reusing a known ID. |
 
 **Do not:** Create parallel `id: Int` fields or ad-hoc node numbering.
 

--- a/lang/json/proj/proj_node.mbt
+++ b/lang/json/proj/proj_node.mbt
@@ -5,23 +5,6 @@
 using @core {type ProjNode, type NodeId}
 
 ///|
-/// Construct a childless ProjNode for a JSON leaf value, spanning `node`
-/// and taking a fresh id from `counter`.
-fn json_leaf_node(
-  value : @json.JsonValue,
-  node : @seam.SyntaxNode,
-  counter : Ref[Int],
-) -> ProjNode[@json.JsonValue] {
-  ProjNode::new(
-    value,
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    [],
-  )
-}
-
-///|
 /// Convert a SyntaxNode to a ProjNode[JsonValue].
 /// Handles RootNode by unwrapping to the single child value.
 pub fn syntax_to_proj_node(
@@ -32,7 +15,7 @@ pub fn syntax_to_proj_node(
     RootNode =>
       match node.nth_child(0) {
         Some(child) => syntax_to_proj_node(child, counter)
-        None => json_leaf_node(Error("empty document"), node, counter)
+        None => ProjNode::leaf(Error("empty document"), node, counter)
       }
     ObjectNode => build_object_node(node, counter)
     ArrayNode => build_array_node(node, counter)
@@ -43,31 +26,31 @@ pub fn syntax_to_proj_node(
       } else {
         @json.JsonValue::Error("malformed string")
       }
-      json_leaf_node(value, node, counter)
+      ProjNode::leaf(value, node, counter)
     }
     NumberValue => {
       let text = node.token_text(@json.NumberToken.to_raw())
       let n = @string.parse_double(text) catch {
         _ =>
-          return json_leaf_node(
+          return ProjNode::leaf(
             @json.JsonValue::Error("invalid number: " + text),
             node,
             counter,
           )
       }
-      json_leaf_node(@json.JsonValue::Number(n), node, counter)
+      ProjNode::leaf(@json.JsonValue::Number(n), node, counter)
     }
     BoolValue => {
       let value = @json.JsonValue::Bool(
         node.find_token(@json.TrueKeyword.to_raw()) is Some(_),
       )
-      json_leaf_node(value, node, counter)
+      ProjNode::leaf(value, node, counter)
     }
-    NullValue => json_leaf_node(@json.JsonValue::Null, node, counter)
+    NullValue => ProjNode::leaf(@json.JsonValue::Null, node, counter)
     ErrorNode =>
-      json_leaf_node(@json.JsonValue::Error("parse error"), node, counter)
+      ProjNode::leaf(@json.JsonValue::Error("parse error"), node, counter)
     _ =>
-      json_leaf_node(
+      ProjNode::leaf(
         @json.JsonValue::Error(
           "unknown node: " + @json.SyntaxKind::from_raw(node.kind()).to_string(),
         ),
@@ -93,23 +76,23 @@ fn build_object_node(
       // Use value span for the child ProjNode (not member span).
       // The full member span (key + colon + value) is stored separately
       // as a "member:N" token span on the Object for delete operations.
-      let member_proj = ProjNode::new(
+      let member_proj = ProjNode::branch(
         value_proj.kind,
         value_proj.start,
         value_proj.end,
-        @core.next_proj_node_id(counter),
         value_proj.children,
+        counter,
       )
       children.push(member_proj)
       members.push((key, value_proj.kind))
     }
   }
-  ProjNode::new(
+  ProjNode::branch(
     @json.JsonValue::Object(members),
     node.start(),
     node.end(),
-    @core.next_proj_node_id(counter),
     children,
+    counter,
   )
 }
 
@@ -126,12 +109,12 @@ fn build_array_node(
     children.push(child_proj)
     elements.push(child_proj.kind)
   }
-  ProjNode::new(
+  ProjNode::branch(
     @json.JsonValue::Array(elements),
     node.start(),
     node.end(),
-    @core.next_proj_node_id(counter),
     children,
+    counter,
   )
 }
 
@@ -156,7 +139,7 @@ fn extract_member(
   let value_proj = match member_node.nth_child(0) {
     Some(v) => syntax_to_proj_node(v, counter)
     None =>
-      json_leaf_node(
+      ProjNode::leaf(
         @json.JsonValue::Error("missing member value"),
         member_node,
         counter,

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -5,23 +5,6 @@
 using @core {type ProjNode, type NodeId}
 
 ///|
-/// Construct a childless ProjNode for a lambda leaf term, spanning `node`
-/// and taking a fresh id from `counter`.
-fn lambda_leaf_node(
-  kind : @ast.Term,
-  node : @seam.SyntaxNode,
-  counter : Ref[Int],
-) -> ProjNode[@ast.Term] {
-  ProjNode::new(
-    kind,
-    node.start(),
-    node.end(),
-    @core.next_proj_node_id(counter),
-    [],
-  )
-}
-
-///|
 fn error_node_with_span(
   message : String,
   start : Int,
@@ -37,7 +20,7 @@ fn error_node_for_syntax(
   node : @seam.SyntaxNode,
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  lambda_leaf_node(Error(message), node, counter)
+  ProjNode::leaf(Error(message), node, counter)
 }
 
 ///|
@@ -46,12 +29,12 @@ fn app_node(
   right : ProjNode[@ast.Term],
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  ProjNode::new(
+  ProjNode::branch(
     App(left.kind, right.kind),
     @cmp.minimum(left.start, right.start),
     @cmp.maximum(left.end, right.end),
-    @core.next_proj_node_id(counter),
     [left, right],
+    counter,
   )
 }
 
@@ -62,12 +45,12 @@ fn bop_node(
   right : ProjNode[@ast.Term],
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  ProjNode::new(
+  ProjNode::branch(
     Bop(op, left.kind, right.kind),
     @cmp.minimum(left.start, right.start),
     @cmp.maximum(left.end, right.end),
-    @core.next_proj_node_id(counter),
     [left, right],
+    counter,
   )
 }
 
@@ -81,20 +64,20 @@ pub fn syntax_to_proj_node(
       Some(n) => Int(n)
       None => Error("invalid integer literal")
     }
-    lambda_leaf_node(kind, node, counter)
+    ProjNode::leaf(kind, node, counter)
   } else if @parser.VarRefView::cast(node) is Some(v) {
-    lambda_leaf_node(Var(v.name()), node, counter)
+    ProjNode::leaf(Var(v.name()), node, counter)
   } else if @parser.LambdaExprView::cast(node) is Some(v) {
     let body = match v.body() {
       Some(b) => syntax_to_proj_node(b, counter)
       None => error_node_for_syntax("missing lambda body", node, counter)
     }
-    ProjNode::new(
+    ProjNode::branch(
       Lam(v.param(), body.kind),
       node.start(),
       node.end(),
-      @core.next_proj_node_id(counter),
       [body],
+      counter,
     )
   } else if @parser.AppExprView::cast(node) is Some(v) {
     match v.func() {
@@ -156,12 +139,12 @@ pub fn syntax_to_proj_node(
       Some(n) => syntax_to_proj_node(n, counter)
       None => error_node_for_syntax("missing else branch", node, counter)
     }
-    ProjNode::new(
+    ProjNode::branch(
       If(cond.kind, then_.kind, else_.kind),
       node.start(),
       node.end(),
-      @core.next_proj_node_id(counter),
       [cond, then_, else_],
+      counter,
     )
   } else if @parser.ParenExprView::cast(node) is Some(v) {
     match v.inner() {
@@ -215,12 +198,12 @@ pub fn syntax_to_proj_node(
       let term_defs : Array[(@ast.VarName, @ast.Term)] = defs.map(fn(d) {
         (d.0, d.1.kind)
       })
-      ProjNode::new(
+      ProjNode::branch(
         Module(term_defs, result.kind),
         node.start(),
         node.end(),
-        @core.next_proj_node_id(counter),
         children,
+        counter,
       )
     } else {
       // Single expression block: unwrap like ParenExpr
@@ -233,7 +216,7 @@ pub fn syntax_to_proj_node(
       )
     }
   } else if @syntax.SyntaxKind::from_raw(node.kind()) == @syntax.HoleLiteral {
-    lambda_leaf_node(Hole(0), node, counter)
+    ProjNode::leaf(Hole(0), node, counter)
   } else {
     error_node_for_syntax(
       "unknown node kind: " + node.kind().to_string(),
@@ -284,12 +267,12 @@ pub fn to_proj_node(
     let term_defs : Array[(@ast.VarName, @ast.Term)] = defs.map(fn(d) {
       (d.0, d.1.kind)
     })
-    result = ProjNode::new(
+    result = ProjNode::branch(
       Module(term_defs, result.kind),
       defs[0].2,
       result.end,
-      @core.next_proj_node_id(counter),
       children,
+      counter,
     )
   }
   result

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -48,14 +48,7 @@ fn build_proj_tree(
         collect_syntax_children(syntax_node, @markdown.SyntaxKind::ListItemNode),
         counter,
       )
-    _ =>
-      @core.ProjNode::new(
-        block,
-        syntax_node.start(),
-        syntax_node.end(),
-        @core.next_proj_node_id(counter),
-        [],
-      )
+    _ => @core.ProjNode::leaf(block, syntax_node, counter)
   }
 }
 
@@ -74,12 +67,12 @@ fn build_container(
       build_proj_tree(syntax_children[i], block_children[i], counter),
     )
   }
-  @core.ProjNode::new(
+  @core.ProjNode::branch(
     block,
     syntax_node.start(),
     syntax_node.end(),
-    @core.next_proj_node_id(counter),
     children,
+    counter,
   )
 }
 


### PR DESCRIPTION
## Summary

- Add shared `ProjNode::leaf` and `ProjNode::branch` helpers for fresh projection-node construction.
- Replace duplicated Lambda/JSON/Markdown projection construction boilerplate with the shared helpers.
- Update `docs/api-map.md` and generated core interface for the new preferred projection-builder APIs.

Refs #414.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ProjNode::new` | `core/proj_node.mbt` | Yes | Remains the underlying constructor and the escape hatch when preserving/reusing known node IDs. |
| `next_proj_node_id` | `core/proj_node.mbt` | Yes | Reused inside the new helpers to keep fresh-id allocation semantics centralized. |
| Local `lambda_leaf_node` / `json_leaf_node` | `lang/{lambda,json}/proj/proj_node.mbt` | No | Deleted because they duplicated the same fresh childless syntax-node construction pattern now covered by `ProjNode::leaf`. |

New helpers added:

- `ProjNode::leaf(kind, syntax_node, counter)` — centralizes fresh childless projection nodes that span a `SyntaxNode`.
- `ProjNode::branch(kind, start, end, children, counter)` — centralizes fresh branch projection nodes with explicit span and children while leaving ID-preserving construction on `ProjNode::new`.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`) — N/A, no web artifacts changed

## Validation

```bash
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test
```

`core/pkg.generated.mbti` change reviewed: only the intended `ProjNode::leaf` and `ProjNode::branch` exports were added.
