### PR TITLE
refactor: reuse SourceMap token helper for JSON keys

### DIFF
--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -38,7 +38,9 @@ Refresh with: `NEW_MOON_MOD=0 moon ide outline <pkg>` or `NEW_MOON_MOD=0 moon id
 | `SourceMap::nodes_in_range(range)` | `core/` | All nodes overlapping a range. |
 | `SourceMap::apply_edit(edit)` | `core/` | Update ranges after a text edit. Call this, don't rebuild. |
 | `SourceMap::rebuild_ranges()` | `core/` | Full rebuild (expensive — prefer `apply_edit`). |
-| `SourceMap::set_token_span` / `get_token_span` | `core/` | Token-level spans. |
+| `SourceMap::set_token_span` | `core/` | Use for computed token-level ranges. |
+| `SourceMap::set_span_from_token` | `core/` | Preferred direct-token registration helper: finds a direct visible token on a `SyntaxNode` and records its range. |
+| `SourceMap::get_token_span` | `core/` | Read a recorded token-level span by role. |
 
 **Do not:** Store `(start, end)` integers separately when `SourceMap` already tracks them.
 

--- a/lang/json/proj/populate_token_spans.mbt
+++ b/lang/json/proj/populate_token_spans.mbt
@@ -58,24 +58,20 @@ fn collect_token_spans(
         if @json.SyntaxKind::from_raw(member_syn.kind()) == @json.MemberNode &&
           proj_idx < proj_node.children.length() {
           let child_proj = proj_node.children[proj_idx]
+          let object_id = proj_node.id()
           // Record the full member span on the Object node
           source_map.set_token_span(
-            proj_node.id(),
+            object_id,
             member_role(proj_idx),
             @loomcore.Range::new(member_syn.start(), member_syn.end()),
           )
-          // Find the StringToken key and record its span on the Object node
-          for elem in member_syn.all_children() {
-            if elem is @seam.SyntaxElement::Token(t) &&
-              t.kind() == @json.StringToken.to_raw() {
-              source_map.set_token_span(
-                proj_node.id(),
-                key_role(proj_idx),
-                @loomcore.Range::new(t.start(), t.end()),
-              )
-              break
-            }
-          }
+          // Record the direct StringToken key span on the Object node
+          source_map.set_span_from_token(
+            object_id,
+            key_role(proj_idx),
+            member_syn,
+            @json.StringToken.to_raw(),
+          )
           // Recurse into the value (first node child of MemberNode).
           // The ProjNode child may itself have children (nested object/array).
           if member_syn.nth_child(0) is Some(value_syn) {


### PR DESCRIPTION
## Summary

- Reuse the existing `SourceMap::set_span_from_token` helper for JSON object key token spans.
- Document preferred SourceMap token-span APIs in `docs/api-map.md`.
- Keep the #414 token-span cleanup narrow: no new public API and no projection identity changes.

Part of #414.

## Reuse check

- `SourceMap::set_span_from_token` (`core/source_map.mbt`): reused for direct token registration from a `SyntaxNode`; replaces the hand-rolled JSON key token scan.
- `SourceMap::set_token_span` (`core/source_map.mbt`): retained for computed ranges, such as full JSON member spans.
- `SyntaxNode::find_token` / direct-token helpers (`loom/seam/syntax_node.mbt`): covered by `set_span_from_token`, so no new seam/core helper was added.

## Validation

- `NEW_MOON_MOD=0 moon check`
- `NEW_MOON_MOD=0 moon test lang/json/proj`
- `NEW_MOON_MOD=0 moon test projection/source_map_token_spans_wbtest.mbt`
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon test` — 1279 passed
- `NEW_MOON_MOD=0 moon info`
- `git diff --check`
