### PR TITLE
refactor(lambda): use typed views for block and hole projection

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -155,9 +155,8 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: the `match x { Ok(v) => v; Err(e) => return Err(e) }` passthroughs left in PR #383 exist only because MoonBit has no `?`-propagation for plain `Result`. A raising error model would auto-propagate them away and let the Some/None guards sit on raising accessors. Larger design call — touches `EditResult` and error-type design; see the `moonbit-error-handling` skill.
   Exit: decision recorded (adopt or keep `Result`) with rationale; if adopted, passthroughs removed and `EditResult` retyped.
 
-- [ ] Uniform syntax→projection dispatch + parallel-walk helper (loom `@seam` / `lang/*/proj`). (finding E from PR #383)
-  Why: `syntax_to_proj_node` dispatches via a typed `View::cast(node) is Some(v)` ladder, but two arms (`BlockExpr`, `HoleLiteral`) fall back to raw `SyntaxKind::from_raw(...) == ...` because no typed View exists; separately, `populate_token_spans` hand-rolls fragile `proj_chain` index arithmetic to align flat CST App/Binary spans with the nested ProjNode tree.
-  Exit: typed Views cover all dispatched kinds (uniform `is Some` ladder); a loom-level "zip syntax children with projection children" utility absorbs the manual chain navigation. Tracked upstream in loom.
+- [x] Uniform syntax→projection dispatch + projection-walk helper decision (loom `@seam` / `lang/*/proj`). (finding E from PR #383)
+  Shipped: #439 extracted Lambda App/Binary token-span left-spine walking into a private iterative helper; loom PR #207 adds Lambda `BlockExprView` / `HoleLiteralView`, and this branch switches Lambda projection dispatch to the uniform typed `View::cast(node) is Some(v)` ladder. Decision: no new public loom-level projection-walk API for now — existing `@seam.SyntaxNode` direct-child helpers plus the private left-spine helper cover the current duplicated/fragile cases without adding an under-evidenced core abstraction.
 
 ---
 

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -55,6 +55,48 @@ fn bop_node(
 }
 
 ///|
+priv struct ProjectedLetDef {
+  name : @ast.VarName
+  init : ProjNode[@ast.Term]
+  start : Int
+}
+
+///|
+fn unit_node_at(pos : Int, counter : Ref[Int]) -> ProjNode[@ast.Term] {
+  ProjNode::new(Unit, pos, pos, @core.next_proj_node_id(counter), [])
+}
+
+///|
+fn project_let_def(
+  def : @parser.LetDefView,
+  counter : Ref[Int],
+) -> ProjectedLetDef {
+  let def_node = def.syntax_node()
+  let init = match def.init() {
+    Some(n) => syntax_to_proj_node(n, counter)
+    None =>
+      error_node_for_syntax("missing let binding value", def_node, counter)
+  }
+  { name: def.name(), init, start: def_node.start() }
+}
+
+///|
+fn module_node_from_defs(
+  defs : Array[ProjectedLetDef],
+  body : ProjNode[@ast.Term],
+  start : Int,
+  end : Int,
+  counter : Ref[Int],
+) -> ProjNode[@ast.Term] {
+  let children : Array[ProjNode[@ast.Term]] = defs.map(fn(d) { d.init })
+  children.push(body)
+  let term_defs : Array[(@ast.VarName, @ast.Term)] = defs.map(fn(d) {
+    (d.name, d.init.kind)
+  })
+  ProjNode::branch(Module(term_defs, body.kind), start, end, children, counter)
+}
+
+///|
 pub fn syntax_to_proj_node(
   node : @seam.SyntaxNode,
   counter : Ref[Int],
@@ -162,49 +204,16 @@ pub fn syntax_to_proj_node(
       }
       None => error_node_for_syntax("empty parentheses", node, counter)
     }
-  } else if @syntax.SyntaxKind::from_raw(node.kind()) == @syntax.BlockExpr {
+  } else if @parser.BlockExprView::cast(node) is Some(v) {
     // Block expression: { LetDef* Expression? } — same structure as SourceFile.
     // Collect defs + body, produce Module node (or unwrap single expression).
-    let defs : Array[(String, ProjNode[@ast.Term], Int)] = []
-    let mut final_proj : ProjNode[@ast.Term]? = None
-    for child in node.children() {
-      if @parser.LetDefView::cast(child) is Some(v) {
-        let init = match v.init() {
-          Some(n) => syntax_to_proj_node(n, counter)
-          None =>
-            error_node_for_syntax("missing let binding value", child, counter)
-        }
-        defs.push((v.name(), init, child.start()))
-      } else if final_proj is None &&
-        @syntax.SyntaxKind::from_raw(child.kind()) != @syntax.LBraceToken &&
-        @syntax.SyntaxKind::from_raw(child.kind()) != @syntax.RBraceToken {
-        final_proj = Some(syntax_to_proj_node(child, counter))
-      }
-    }
-    let result = match final_proj {
-      Some(p) => p
-      None =>
-        ProjNode::new(
-          Unit,
-          node.end(),
-          node.end(),
-          @core.next_proj_node_id(counter),
-          [],
-        )
+    let defs = v.defs().map(fn(def) { project_let_def(def, counter) })
+    let result = match v.body() {
+      Some(body) => syntax_to_proj_node(body, counter)
+      None => unit_node_at(node.end(), counter)
     }
     if defs.length() > 0 {
-      let children : Array[ProjNode[@ast.Term]] = defs.map(fn(d) { d.1 })
-      children.push(result)
-      let term_defs : Array[(@ast.VarName, @ast.Term)] = defs.map(fn(d) {
-        (d.0, d.1.kind)
-      })
-      ProjNode::branch(
-        Module(term_defs, result.kind),
-        node.start(),
-        node.end(),
-        children,
-        counter,
-      )
+      module_node_from_defs(defs, result, node.start(), node.end(), counter)
     } else {
       // Single expression block: unwrap like ParenExpr
       ProjNode::new(
@@ -215,7 +224,7 @@ pub fn syntax_to_proj_node(
         result.children,
       )
     }
-  } else if @syntax.SyntaxKind::from_raw(node.kind()) == @syntax.HoleLiteral {
+  } else if @parser.HoleLiteralView::cast(node) is Some(_) {
     ProjNode::leaf(Hole(0), node, counter)
   } else {
     error_node_for_syntax(
@@ -236,42 +245,25 @@ pub fn to_proj_node(
   root : @seam.SyntaxNode,
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  let defs : Array[(String, ProjNode[@ast.Term], Int)] = []
+  let defs : Array[ProjectedLetDef] = []
   let mut final_proj : ProjNode[@ast.Term]? = None
   for child in root.children() {
     if @parser.LetDefView::cast(child) is Some(v) {
-      let init = match v.init() {
-        Some(n) => syntax_to_proj_node(n, counter)
-        None =>
-          error_node_for_syntax("missing let binding value", child, counter)
-      }
-      defs.push((v.name(), init, child.start()))
+      defs.push(project_let_def(v, counter))
     } else if final_proj is None {
       final_proj = Some(syntax_to_proj_node(child, counter))
     }
   }
   let mut result = match final_proj {
     Some(p) => p
-    None =>
-      ProjNode::new(
-        Unit,
-        root.end(),
-        root.end(),
-        @core.next_proj_node_id(counter),
-        [],
-      )
+    None => unit_node_at(root.end(), counter)
   }
   if defs.length() > 0 {
-    let children : Array[ProjNode[@ast.Term]] = defs.map(fn(d) { d.1 })
-    children.push(result)
-    let term_defs : Array[(@ast.VarName, @ast.Term)] = defs.map(fn(d) {
-      (d.0, d.1.kind)
-    })
-    result = ProjNode::branch(
-      Module(term_defs, result.kind),
-      defs[0].2,
+    result = module_node_from_defs(
+      defs,
+      result,
+      defs[0].start,
       result.end,
-      children,
       counter,
     )
   }

--- a/lang/lambda/proj/proj_node_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_wbtest.mbt
@@ -1,0 +1,18 @@
+///|
+test "syntax_to_proj_node: block expression with def and body" {
+  let (proj, errors) = parse_to_proj_node("{ let x = 1; x }")
+  inspect(errors.is_empty(), content="true")
+  inspect(
+    proj.kind,
+    content=(
+      #|Module([("x", Int(1))], Var("x"))
+    ),
+  )
+}
+
+///|
+test "syntax_to_proj_node: hole literal" {
+  let (proj, errors) = parse_to_proj_node("_")
+  inspect(errors.is_empty(), content="true")
+  inspect(proj.kind, content="Hole(0)")
+}


### PR DESCRIPTION
## Summary

- update `loom` to the typed-view coverage commit from dowdiness/loom#207
- switch Lambda projection dispatch for `BlockExpr` and `HoleLiteral` from raw `SyntaxKind::from_raw` checks to typed `View::cast` checks
- replace repeated let-definition tuple plumbing with private `ProjectedLetDef` / module-building helpers, and record the #414 projection-walk decision: no new public Loom helper yet; #439's private iterative left-spine helper plus existing `@seam.SyntaxNode` APIs cover current needs

Depends on dowdiness/loom#207.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@parser.BlockExprView::{cast,defs,body}`, `@parser.HoleLiteralView::cast` | `loom/examples/lambda/src/views.mbt` via loom#207 | Yes | Replaces raw syntax-kind dispatch and block child filtering in Lambda projection. |
| `@parser.LetDefView::{init,name,syntax_node}` | `loom/examples/lambda/src/views.mbt` | Yes | Shared private let-definition projection helper is built on the typed view. |
| `@core.ProjNode::{new,branch,leaf}` | `core/proj_node.mbt` | Yes | Fresh projection node construction continues to use existing constructors. |
| `@seam.SyntaxNode::{children, children_from, nodes_and_tokens}` | `loom/seam/syntax_node.mbt` | Yes | Existing direct-child APIs cover current projection walking; no new public Loom projection-walk helper added. |

New helpers added:

- `ProjectedLetDef` (private): names the internal projected let-def tuple shape so code no longer relies on tuple indexes.
- `unit_node_at` (private): centralizes Unit placeholder node allocation.
- `project_let_def` (private): shares LetDefView → projected init conversion between block and source-file projection.
- `module_node_from_defs` (private): shares Module ProjNode construction between block and source-file projection.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/proj` passes
- [x] `NEW_MOON_MOD=0 moon fmt` passes
- [x] `NEW_MOON_MOD=0 moon info` passes (`git diff -- '*.mbti'` reviewed; no intended parent API changes; reverted unrelated trailing blank in `lib/cognition/pkg.generated.mbti`)
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff --check` passes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`) — N/A, no web artifacts changed

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test lang/lambda/proj
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test
git diff --check
```
