### PR TITLE
perf(projection): BAND 2b evidence gate — isolate hot-path scaling cliffs (#443)

### DIFF
--- a/docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md
+++ b/docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md
@@ -1,0 +1,167 @@
+# BAND 2b — Canopy hot-path scaling cliffs: reproduce-or-reject (2026-06-01)
+
+## Purpose
+
+Evidence gate for canopy #443. The MoonDsp+Canopy vision report §7.6 claimed two
+hot-path scaling cliffs in the per-keystroke projection pipeline:
+
+1. `to_flat_proj_incremental` — an O(N) change-detection scan estimated at
+   ~5 ms / ~60% of an ~8.5 ms 1000-def keystroke.
+2. `core/reconcile.mbt` — LCS child matching, O(m×n) on wide sibling lists.
+
+Per the project's microbenchmark-first rule these were **hypotheses**. This
+document isolates each operation and reports the measured cost. **No
+optimization code was written.** Follow-up fixes (if greenlit) stay separate.
+
+## Method
+
+Two isolated microbenchmark files, both `moon bench --release` (wasm-gc backend):
+
+- `projection/flat_proj_incremental_benchmark_wbtest.mbt` — isolates
+  `@lambda_proj.to_flat_proj_incremental` at 20/80/320/1000 defs across three
+  scenarios.
+- `projection/reconcile_lcs_benchmark_wbtest.mbt` — isolates `@core.reconcile`
+  on wide Module sibling lists (the only realistic path that reaches the LCS DP
+  on a wide list — see Cliff #2 scope note).
+
+Each scenario carries a **positive-control test** that asserts it exercises the
+intended code path (so timings aren't measuring a vacuous no-op). All four
+controls pass: unchanged → 0 reuse-misses; tail → exactly 1; shifted → all 81;
+reconcile → N+1 wide children at every benched size (21/81/321/1001).
+
+Command: `NEW_MOON_MOD=0 moon bench --release --package dowdiness/canopy/projection`
+
+## Staleness correction (read this first)
+
+The 2026-04-06 "~5 ms / ~60%" figure for cliff #1 is **doubly stale** and must
+not be cited as a measurement:
+
+1. It was an **estimate by subtraction** — the analysis table header literally
+   reads "Estimated cost"; the function was never benchmarked in isolation.
+2. It described an O(N) scan checking **`physical_equal()` on CstNode pointers**.
+   That algorithm no longer exists. `flat_proj.mbt:83-84` now compares
+   `new_child.start() == old_child.start()` plus **structural**
+   `cst_node() == cst_node()` equality (switched from `physical_equal` in commit
+   `4875da6` / #396 when source-span CSTs dropped canonical physical identity;
+   `b8b068b` was an earlier package-extraction refactor that still used
+   `physical_equal`). `physical_equal` does
+   not appear anywhere in `flat_proj.mbt` today.
+
+So this gate establishes the **first** isolated measurement of the current
+algorithm, not a re-validation.
+
+## Results — Cliff #1: `to_flat_proj_incremental` (wasm-gc, release)
+
+| Defs | unchanged (pure detection) | tail (1-line keystroke) | shifted (reuse fully blocked) |
+|------|---------------------------:|------------------------:|------------------------------:|
+| 20   |   6.22 µs |  14.70 µs |  17.78 µs |
+| 80   |  38.53 µs |  76.94 µs |  71.47 µs |
+| 320  | 417.61 µs | 604.34 µs | 345.09 µs |
+| 1000 | **3.72 ms** | **4.50 ms** | **1.13 ms** |
+
+- **unchanged** = old/new parsed from identical source: every structural
+  comparison runs to completion and succeeds → pure change-*detection* cost.
+- **tail** = only the last def's value changes (same width, no offset shift):
+  N−1 reused, 1 rebuilt + reconciled — a realistic single-line keystroke.
+- **shifted** = a leading space shifts every offset: the cheap `start()` check
+  fails first (short-circuiting the structural compare), so reuse is fully
+  blocked and every def is rebuilt — the worst case for change *propagation*.
+
+### Findings (cliff #1)
+
+1. **Reproduced — the function is a multi-millisecond cost at 1000 defs.** The
+   realistic tail keystroke is **4.50 ms** and pure detection **3.72 ms**, the
+   same order as the ~5 ms claim and ~44–53% of the 8.47 ms full-pipeline
+   baseline. The qualitative claim "`to_flat_proj_incremental` dominates the
+   1000-def keystroke" holds. (The gate's STOP-and-reprofile branch — for a
+   result in the *microsecond* range — is **not** triggered.)
+
+2. **Scaling is super-linear, not O(N).** unchanged: 80→320 = 4× defs → 10.8×
+   time; 320→1000 = 3.1× defs → 8.9× time (≈O(N^1.7–2)). The stale doc's "O(N)
+   scan" description is wrong for the current code. The detection cost grows
+   faster than the def count — which undermines the whole point of an
+   *incremental* scan at scale.
+
+3. **The expensive path is detection (reuse-success), not rebuild.** The
+   `unchanged`/`tail` cases (structural `cst_node() ==` runs to completion) are
+   3–4× more expensive than `shifted` (1.13 ms), where the `start()` mismatch
+   short-circuits the structural compare. So the cost lives in the structural
+   CstNode equality of *successfully reused* defs.
+
+4. **Below ~320 defs there is no cliff.** Realistic keystroke at 320 defs =
+   604 µs, well within a 16 ms frame. The cliff is a >500-def concern, matching
+   the 2026-04-06 "re-measure when documents exceed 500 definitions" trigger.
+
+**Mechanism is a hypothesis, not yet proven.** The super-linear shape is
+*consistent with* per-call `start()` / `cst_node()` costs that grow with a
+node's position in the document (O(i) for the i-th def → O(N²) total over the
+scan), plausibly tied to the source-span left-spine token walk (cf. #439). This
+is **not** established by these benchmarks and must be confirmed (e.g. by
+micro-timing `start()`/`cst_node()` at varying positions) before any fix is
+designed. Do not edit code on the strength of this hypothesis.
+
+## Results — Cliff #2: `@core.reconcile` LCS on wide siblings (wasm-gc, release)
+
+| Defs (= N+1 wide children) | reconcile |
+|------:|----------:|
+| 20   |   7.20 µs |
+| 80   |  69.80 µs |
+| 320  |   1.00 ms |
+| 1000 | **9.70 ms** |
+
+### Findings (cliff #2)
+
+1. **Reproduced and severe where reached.** Clean O(N²): 80→320 = 4× → 14×;
+   320→1000 = 3.1× → 9.7×. At 1000 wide siblings the single `reconcile` call is
+   **9.70 ms**. The unconditional (m+1)×(n+1) DP-table fill in
+   `reconcile_children` (`core/reconcile.mbt:39-48`) is the cost; it does not
+   short-circuit on identical input.
+
+2. **CRITICAL scope note — the lambda keystroke hot path does NOT reach this.**
+   `reconcile_flat_proj` routes the wide def list through `key_match`
+   (hash-based, O(N), `flat_proj.mbt:134-166`) and only calls `@core.reconcile`
+   per **individual init subtree** (narrow). The wide-sibling LCS is reached
+   only when a parent with many direct children is reconciled *as a whole* —
+   i.e. reconciling a Module node directly, or the JSON/flat-list projection
+   path (arrays/objects with N elements). For the **lambda** editor this cliff
+   is **already mitigated** and is not on the per-keystroke path. The
+   "check existing mitigations" step (skill Step 3) is what surfaced this.
+
+## Gate decision
+
+- **Cliff #1 (`to_flat_proj_incremental`): REPRODUCED.** Multi-ms at 1000 defs
+  (4.50 ms realistic), super-linear, dominated by structural CstNode equality on
+  reused defs. Corrected vs the stale doc: it is **not** the O(N) `physical_equal`
+  scan described — that algorithm is gone. Real cliff above ~500 defs.
+- **Cliff #2 (LCS wide-sibling reconcile): REPRODUCED where reached (9.70 ms @
+  1000), but NOT on the lambda keystroke path** — `key_match` routing already
+  mitigates it there. It is a live concern for whole-node / JSON-array
+  reconciliation only.
+
+**This issue (#443) is an evidence gate and stops here. No optimization code.**
+The two cliffs share only the conceptual "revision-stamp / skip-when-unchanged"
+idea, not an implementation — any follow-up fixes are tracked as separate issues.
+
+## Caveats / required follow-up before any optimization is greenlit
+
+1. **Deployment target not yet measured.** These numbers are wasm-gc (matching
+   the 2026-04-06 baseline for comparability). Canopy ships to the **web (JS)**;
+   per the perf-investigation skill Step 6, a candidate fix's payoff must be
+   measured on the JS backend (`moon build --target js` + Node harness) before
+   it is greenlit. wasm-gc and JS can diverge.
+2. **Cliff #1 mechanism unproven** (see hypothesis above) — confirm the
+   per-position cost source before designing a fix.
+3. These are 1000-def figures; if real-world documents stay under ~320 defs,
+   neither cliff is worth optimizing (320-def keystroke = 604 µs).
+
+## Artifacts
+
+- `projection/flat_proj_incremental_benchmark_wbtest.mbt` (12 benches + 3 controls)
+- `projection/reconcile_lcs_benchmark_wbtest.mbt` (4 benches + 1 control)
+
+## Reproduce
+
+```bash
+NEW_MOON_MOD=0 moon bench --release --package dowdiness/canopy/projection
+NEW_MOON_MOD=0 moon test --package dowdiness/canopy/projection -f "control:*"
+```

--- a/projection/flat_proj_incremental_benchmark_wbtest.mbt
+++ b/projection/flat_proj_incremental_benchmark_wbtest.mbt
@@ -1,0 +1,230 @@
+// Isolated microbenchmark for `@lambda_proj.to_flat_proj_incremental`
+// change-detection scan (BAND 2b evidence gate, canopy #443).
+//
+// Why this exists: the 2026-04-06 pipeline-decomposition doc ESTIMATED this
+// function at ~5 ms / ~60% of an 8.5 ms 1000-def keystroke. That figure is
+// doubly stale:
+//   (a) it was derived by subtraction ("Estimated cost"), never measured in
+//       isolation; and
+//   (b) it described an O(N) scan checking `physical_equal()` on CstNode
+//       pointers — that algorithm no longer exists. flat_proj.mbt:83-84 now
+//       compares `new_child.start() == old_child.start()` plus *structural*
+//       `cst_node() == cst_node()` equality.
+// This file reproduces-or-rejects the cliff by isolating the current scan.
+//
+// Three scenarios, each at 20/80/320/1000 defs:
+//   - unchanged : old and new parsed from identical source. Every comparison
+//                 runs to completion and succeeds → pure change-DETECTION cost
+//                 (no rebuild, no reconcile; `any_changed` stays false).
+//   - tail      : only the last def's value changes (same width, no offset
+//                 shift). N-1 reused, 1 rebuilt + reconciled — realistic
+//                 single-line keystroke at the bottom of the document.
+//   - shifted   : a leading space shifts every def's start offset. The cheap
+//                 start() check fails first (short-circuiting the structural
+//                 compare), so reuse is fully blocked and every def is rebuilt
+//                 + reconciled — the worst case for change propagation.
+
+///|
+fn fp_parse_syntax(text : String) -> @seam.SyntaxNode raise {
+  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  @seam.SyntaxNode::from_cst(cst)
+}
+
+// Source generator: reuses `tree_refresh_bench_source(let_count, tail_literal)`
+// from tree_refresh_benchmark_wbtest.mbt (same projection wbtest module). It
+// emits `let x0 = 0 ... let x{N-1} = {tail}` then the final expr `x{N-1}`, so a
+// caller can flip exactly one same-width literal without shifting any offsets.
+
+///|
+/// Build (new_root, old_root, old_fp) for a scenario. `old_fp` is the FlatProj
+/// of the old tree (the state carried between keystrokes); the bench then runs
+/// only the incremental scan against it.
+fn fp_incr_setup(
+  old_src : String,
+  new_src : String,
+) -> (@seam.SyntaxNode, @seam.SyntaxNode, @lambda_proj.FlatProj) raise {
+  let old_root = fp_parse_syntax(old_src)
+  let old_fp = @lambda_proj.to_flat_proj(old_root, Ref(0))
+  let new_root = fp_parse_syntax(new_src)
+  (new_root, old_root, old_fp)
+}
+
+// --- Positive controls: confirm each scenario exercises the intended path ---
+// (Calibrate the detector before trusting timing — guards against measuring a
+//  vacuous no-op. `changed_indices` records every def that was NOT reused.)
+
+///|
+test "control: unchanged scenario reuses all defs (zero changed)" {
+  let (new_root, old_root, old_fp) = fp_incr_setup(
+    tree_refresh_bench_source(80, "0"),
+    tree_refresh_bench_source(80, "0"),
+  )
+  let changed = Ref(([] : Array[Int]))
+  let _ = @lambda_proj.to_flat_proj_incremental(
+    new_root,
+    old_root,
+    old_fp,
+    Ref(1000),
+    changed_indices=changed,
+  )
+  inspect(changed.val.length(), content="0")
+}
+
+///|
+test "control: tail scenario rebuilds exactly one def" {
+  let (new_root, old_root, old_fp) = fp_incr_setup(
+    tree_refresh_bench_source(80, "0"),
+    tree_refresh_bench_source(80, "1"),
+  )
+  let changed = Ref(([] : Array[Int]))
+  let _ = @lambda_proj.to_flat_proj_incremental(
+    new_root,
+    old_root,
+    old_fp,
+    Ref(1000),
+    changed_indices=changed,
+  )
+  // Only the last def (index 79) differs; the trailing expr keeps its offset.
+  @debug.debug_inspect(changed.val, content="[79]")
+}
+
+///|
+test "control: shifted scenario blocks reuse for every entry" {
+  let base = tree_refresh_bench_source(80, "0")
+  let (new_root, old_root, old_fp) = fp_incr_setup(base, " " + base)
+  let changed = Ref(([] : Array[Int]))
+  let _ = @lambda_proj.to_flat_proj_incremental(
+    new_root,
+    old_root,
+    old_fp,
+    Ref(1000),
+    changed_indices=changed,
+  )
+  // 80 defs + final expr, all offset-shifted → none reused.
+  inspect(changed.val.length(), content="81")
+}
+
+// --- Bench runner: setup ONCE (outside the timed loop), measure only the scan ---
+
+///|
+/// Parse old/new sources and build the carried-over old FlatProj once, then
+/// time only `to_flat_proj_incremental`. Keeping setup out of the `b.bench`
+/// closure is the invariant that makes these numbers a scan measurement.
+fn bench_fp_incr(
+  b : @bench.T,
+  old_src : String,
+  new_src : String,
+) -> Unit raise {
+  let (new_root, old_root, old_fp) = fp_incr_setup(old_src, new_src)
+  b.bench(() => {
+    let r = @lambda_proj.to_flat_proj_incremental(
+      new_root,
+      old_root,
+      old_fp,
+      Ref(1000),
+    )
+    b.keep(r)
+  })
+}
+
+// --- Scenario: unchanged (pure change-detection cost) ---
+
+///|
+test "fp_incr unchanged (20 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(20, "0"),
+    tree_refresh_bench_source(20, "0"),
+  )
+}
+
+///|
+test "fp_incr unchanged (80 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(80, "0"),
+    tree_refresh_bench_source(80, "0"),
+  )
+}
+
+///|
+test "fp_incr unchanged (320 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(320, "0"),
+    tree_refresh_bench_source(320, "0"),
+  )
+}
+
+///|
+test "fp_incr unchanged (1000 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(1000, "0"),
+    tree_refresh_bench_source(1000, "0"),
+  )
+}
+
+// --- Scenario: tail-changed (realistic single-line keystroke) ---
+
+///|
+test "fp_incr tail (20 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(20, "0"),
+    tree_refresh_bench_source(20, "1"),
+  )
+}
+
+///|
+test "fp_incr tail (80 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(80, "0"),
+    tree_refresh_bench_source(80, "1"),
+  )
+}
+
+///|
+test "fp_incr tail (320 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(320, "0"),
+    tree_refresh_bench_source(320, "1"),
+  )
+}
+
+///|
+test "fp_incr tail (1000 defs)" (b : @bench.T) {
+  bench_fp_incr(
+    b,
+    tree_refresh_bench_source(1000, "0"),
+    tree_refresh_bench_source(1000, "1"),
+  )
+}
+
+// --- Scenario: shifted-offset (reuse fully blocked, worst case) ---
+
+///|
+test "fp_incr shifted (20 defs)" (b : @bench.T) {
+  let base = tree_refresh_bench_source(20, "0")
+  bench_fp_incr(b, base, " " + base)
+}
+
+///|
+test "fp_incr shifted (80 defs)" (b : @bench.T) {
+  let base = tree_refresh_bench_source(80, "0")
+  bench_fp_incr(b, base, " " + base)
+}
+
+///|
+test "fp_incr shifted (320 defs)" (b : @bench.T) {
+  let base = tree_refresh_bench_source(320, "0")
+  bench_fp_incr(b, base, " " + base)
+}
+
+///|
+test "fp_incr shifted (1000 defs)" (b : @bench.T) {
+  let base = tree_refresh_bench_source(1000, "0")
+  bench_fp_incr(b, base, " " + base)
+}

--- a/projection/reconcile_lcs_benchmark_wbtest.mbt
+++ b/projection/reconcile_lcs_benchmark_wbtest.mbt
@@ -1,0 +1,78 @@
+// Isolated microbenchmark for `@core.reconcile_children`'s LCS DP on WIDE
+// sibling lists (BAND 2b evidence gate, canopy #443, cliff #2).
+//
+// core/reconcile.mbt fills an (m+1)×(n+1) DP table unconditionally (the double
+// loop never short-circuits), so LCS child matching is O(m×n) by inspection.
+// But "O(n²) is bad" is not a profile — at small N with a trivial loop body it
+// may still be microseconds. This isolates the actual cost.
+//
+// IMPORTANT scope note: the lambda Module path does NOT reach this code on the
+// wide def list. `reconcile_flat_proj` routes the def list through `key_match`
+// (hash-based, O(N)) and only calls `@core.reconcile` per individual init
+// subtree (narrow). The wide-sibling LCS is reached when `@core.reconcile`
+// runs on a parent that itself has many direct children — e.g. a Module node
+// reconciled as a whole (the JSON/flat-list projection path), which is what
+// this bench constructs by reconciling two N-def Modules directly.
+
+// Source generator: reuses `tree_refresh_bench_source` from
+// tree_refresh_benchmark_wbtest.mbt (same projection wbtest module). An N-def
+// program projects to a Module ProjNode with N+1 direct children (one init per
+// def + the trailing body), giving a wide sibling list for the LCS DP.
+
+///|
+fn lcs_setup(n : Int) -> (ProjNode[@ast.Term], ProjNode[@ast.Term]) raise {
+  let (root_a, _) = @lambda_proj.parse_to_proj_node(
+    tree_refresh_bench_source(n, "0"),
+  )
+  let (root_b, _) = @lambda_proj.parse_to_proj_node(
+    tree_refresh_bench_source(n, "1"),
+  )
+  (root_a, root_b)
+}
+
+///|
+test "control: reconcile operates on a wide sibling list" {
+  // Pin the wide-sibling width at every benched size: an N-def program must
+  // project to a Module with N+1 direct children (N inits + trailing body) so
+  // the LCS DP runs on an N+1-wide list. Guards against a future regression in
+  // Module construction silently degrading any bench to a degenerate tree.
+  let (root_20, _) = lcs_setup(20)
+  inspect(root_20.children.length(), content="21")
+  let (root_80, _) = lcs_setup(80)
+  inspect(root_80.children.length(), content="81")
+  let (root_320, _) = lcs_setup(320)
+  inspect(root_320.children.length(), content="321")
+  let (root_1000, _) = lcs_setup(1000)
+  inspect(root_1000.children.length(), content="1001")
+}
+
+///|
+/// Build the two N-def Module trees once, then time only `@core.reconcile`
+/// (which runs the wide-sibling LCS DP over the N+1 direct children).
+fn bench_reconcile(b : @bench.T, n : Int) -> Unit raise {
+  let (root_a, root_b) = lcs_setup(n)
+  b.bench(() => {
+    let r = @core.reconcile(root_a, root_b, Ref(1000))
+    b.keep(r)
+  })
+}
+
+///|
+test "reconcile wide-siblings (20 defs)" (b : @bench.T) {
+  bench_reconcile(b, 20)
+}
+
+///|
+test "reconcile wide-siblings (80 defs)" (b : @bench.T) {
+  bench_reconcile(b, 80)
+}
+
+///|
+test "reconcile wide-siblings (320 defs)" (b : @bench.T) {
+  bench_reconcile(b, 320)
+}
+
+///|
+test "reconcile wide-siblings (1000 defs)" (b : @bench.T) {
+  bench_reconcile(b, 1000)
+}


### PR DESCRIPTION
## What

Evidence gate for #443 (BAND 2b). The MoonDsp+Canopy vision report §7.6 claimed two per-keystroke hot-path scaling cliffs; per the microbenchmark-first rule those were **hypotheses**. This PR isolates each operation and records the measured cost. **No optimization code** — benchmarks + a decision record only.

## Results (wasm-gc, `moon bench --release`)

**Cliff #1 — `to_flat_proj_incremental`:**

| Defs | unchanged (detection) | tail (realistic keystroke) | shifted (reuse blocked) |
|------|----------:|------:|------:|
| 320  | 418 µs | 604 µs | 345 µs |
| 1000 | **3.72 ms** | **4.50 ms** | **1.13 ms** |

**Cliff #2 — LCS wide-sibling `@core.reconcile`:** 320 → 1.00 ms; **1000 → 9.70 ms** (clean O(N²)).

## Findings (the stale doc was materially wrong)

1. The 2026-04-06 "~5 ms / O(N) `physical_equal` scan" figure was an **estimate by subtraction** describing an algorithm **that no longer exists** — `flat_proj.mbt:83` now does structural `cst_node()==` (switched from `physical_equal` in `4875da6` / #396). This is the first isolated measurement.
2. **Cliff #1 reproduced** (4.5 ms @ 1000, ~half the 8.5 ms pipeline) but **super-linear (≈O(N²))**, dominated by structural equality of *successfully reused* defs (the `shifted` reuse-blocked case is *cheaper* because `start()` short-circuits). No cliff below ~320 defs.
3. **Cliff #2 reproduced (9.70 ms) but NOT on the lambda keystroke path** — `reconcile_flat_proj` routes the wide def list through `key_match` (hash, O(N)) and only LCS-reconciles narrow per-init subtrees. The O(m×n) DP is reached only by whole-Module / JSON-array reconciliation.

## Gate decision

Both cliffs are real above ~500 defs; **this issue stops here.** Before any fix is greenlit: (a) measure on the **JS backend** (Canopy ships to web; wasm-gc≠JS), and (b) confirm the cliff-#1 mechanism (currently a hypothesis). Follow-ups stay separate issues.

## Reuse check

- Both benchmark source generators **reuse the existing `tree_refresh_bench_source(let_count, tail_literal)`** helper (`projection/tree_refresh_benchmark_wbtest.mbt`) rather than re-implementing it — the duplicate `fp_source`/`lcs_source` were removed during review.
- The benches call existing public APIs only: `@lambda_proj.to_flat_proj_incremental`, `@lambda_proj.to_flat_proj`, `@lambda_proj.parse_to_proj_node`, `@core.reconcile`, `@parser.parse_cst`, `@seam.SyntaxNode::from_cst`. No new types or helpers introduced beyond test scaffolding.

## Test plan

- Each scenario carries a **positive-control test** (asserts it exercises the intended path, not a vacuous no-op): unchanged → 0 reuse-misses; tail → exactly 1; shifted → all 81; reconcile width → 21/81/321/1001 children across all benched sizes.
- `NEW_MOON_MOD=0 moon check` clean; all 4 controls green.

```bash
NEW_MOON_MOD=0 moon bench --release --package dowdiness/canopy/projection
NEW_MOON_MOD=0 moon test  --package dowdiness/canopy/projection -f "control:*"
```

Closes #443.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance baseline documentation measuring Canopy per-keystroke pipeline scaling behavior.

* **Tests**
  * Added performance benchmarks to measure incremental change detection and reconciliation costs across varying definition counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->