### PR TITLE
feat(lambda): project let definitions as first-class nodes

### DIFF
--- a/editor/sync_editor_test.mbt
+++ b/editor/sync_editor_test.mbt
@@ -479,8 +479,8 @@ test "incremental patch: get_node returns correct node after edit" {
   let editor = @lambda.new_lambda_editor("test").0
   editor.set_text("let x = 1\nlet y = 2\ny")
   let proj = editor.get_proj_node().unwrap()
-  // Get node ID of x's init (Int(1)) — first child of Module
-  let x_init_id = proj.children[0].id()
+  // Get node ID of x's init (Int(1)) — child of the first LetDef
+  let x_init_id = proj.children[0].children[0].id()
   // Edit y's init: 2 → 3
   let text = editor.get_text()
   let pos = text.length() - 3

--- a/editor/sync_editor_tree_edit_wbtest.mbt
+++ b/editor/sync_editor_tree_edit_wbtest.mbt
@@ -172,7 +172,7 @@ test "move_node exchange (Inside) swaps two expressions" {
 }
 
 ///|
-test "move_node exchange swaps two let-definitions" {
+test "move_node exchange moves whole let-definitions" {
   let editor = @lambda.new_lambda_editor("test").0
   editor.set_text("let x = 1\nlet y = 2\nx")
   let root = match editor.get_proj_node() {
@@ -193,8 +193,8 @@ test "move_node exchange swaps two let-definitions" {
   inspect(
     editor.get_text(),
     content=(
-      #|let x = 2
-      #|let y = 1
+      #|let y = 2
+      #|let x = 1
       #|x
     ),
   )

--- a/examples/ideal/main/action_model.mbt
+++ b/examples/ideal/main/action_model.mbt
@@ -5,7 +5,7 @@
 ///|
 /// Detect the action context for a selected node.
 /// Parses the node ID string, looks up the node in the editor's projection,
-/// checks if it's a let-binding init, and finds the enclosing Module node.
+/// checks if it's a let-binding row/init, and finds the enclosing Module node.
 fn detect_action_context(
   editor : @editor.SyncEditor[@ast.Term],
   companion : @lambda.LambdaCompanion,
@@ -23,7 +23,7 @@ fn detect_action_context(
     Some(fp) => fp
     None => return None
   }
-  // Check if this node is a let-binding init expression
+  // Check if this node is a let-binding row or init expression.
   let (is_let_binding, binding_node_id, binding_def_index) = match
     @lambda_edits.find_binding_for_init(nid, flat_proj) {
     Some((bid, idx)) => (true, Some(bid), Some(idx))

--- a/examples/ideal/main/scope_annotation.mbt
+++ b/examples/ideal/main/scope_annotation.mbt
@@ -8,11 +8,10 @@
 //     DeclId, so shadowing is handled by declaration identity rather than
 //     name-only membership.
 //
-//   UI representation decision (scope-binder-node-id plan step 5): keep the
-//     existing NodeId-keyed outline highlight model. Lambda binders use their
-//     real Lam node id; module binders use stable UI-only synthetic keys because
-//     module binder names still have source ranges, not outline rows.
-//     Source/binding resolution still comes from @scope.
+//   UI representation decision (#127): keep the existing NodeId-keyed outline
+//     highlight model. Lambda binders use their Lam node id; module binders use
+//     their real first-class LetDef node id. Source/binding resolution still
+//     comes from @scope.
 //
 //   compute_highlight_set(selected_id, scope_map) → HashSet[NodeId]
 //     Given a clicked/navigated node, returns the set of NodeIds to highlight:
@@ -50,30 +49,12 @@ fn binder_color_index(name : String) -> Int {
 }
 
 ///|
-/// UI-only key for a module binder in the NodeId-keyed outline highlight map.
-/// This is deliberately separate from @scope's source-location contract:
-/// bindings are resolved by DeclId/@scope.references; this key only lets the
-/// existing highlight data structure represent a binder that has no ProjNode.
-fn module_binder_ui_key(
-  module_node_id : @canopy_core.NodeId,
-  def_index : Int,
-) -> @canopy_core.NodeId {
-  let sum = module_node_id.0 + def_index
-  let pair = sum * (sum + 1) / 2 + def_index
-  @canopy_core.NodeId::from_int(-(pair + 1))
-}
-
-///|
 /// Convert a @scope declaration to the NodeId-compatible UI key used by the
-/// outline highlight map.
-fn scope_binder_ui_key(
-  graph : @scope.ScopeGraph,
-  decl : @scope.Decl,
-) -> @canopy_core.NodeId {
+/// outline highlight map. Module declarations now point at real LetDef nodes.
+fn scope_binder_ui_key(decl : @scope.Decl) -> @canopy_core.NodeId {
   match decl.kind {
     @scope.DeclKind::LamParam(lam_id~) => lam_id
-    @scope.DeclKind::ModuleDef(def_index~) =>
-      module_binder_ui_key(graph.module_node_id, def_index)
+    @scope.DeclKind::ModuleDef(_) => decl.node_id
   }
 }
 
@@ -84,7 +65,7 @@ fn add_scope_graph_annotations(
   graph : @scope.ScopeGraph,
 ) -> Unit {
   for decl in graph.decls {
-    let binder_id = scope_binder_ui_key(graph, decl)
+    let binder_id = scope_binder_ui_key(decl)
     let color_index = binder_color_index(decl.name)
     let usage_ids = @scope.references(graph, decl.id)
     scope_map[binder_id] = {

--- a/examples/ideal/main/scope_annotation_wbtest.mbt
+++ b/examples/ideal/main/scope_annotation_wbtest.mbt
@@ -113,7 +113,7 @@ test "nested block: inner module can reference enclosing block binder" {
 }
 
 ///|
-test "scope_map keys module references by canonical @scope declaration" {
+test "scope_map keys module references by real LetDef declaration" {
   let (editor, companion) = @lambda.new_lambda_editor("test")
   editor.set_text("let x = 0\nlet f = \\x. { x }\nx")
   let scope_map = build_scope_map(editor, companion)
@@ -134,7 +134,13 @@ test "scope_map keys module references by canonical @scope declaration" {
     _ => false
   }
   inspect(is_module_decl, content="true")
-  let module_binder_key = scope_binder_ui_key(graph, module_decl)
+  let module_binder_key = scope_binder_ui_key(module_decl)
+  let binder_node = editor.get_registry().get(module_binder_key).unwrap()
+  let is_let_def = match binder_node.kind {
+    @ast.Term::LetDef(_, _) => true
+    _ => false
+  }
+  inspect(is_let_def, content="true")
   let ann = scope_map.get(module_x_id).unwrap()
   inspect(ann.binder_id == Some(module_binder_key), content="true")
   let binder_ann = scope_map.get(module_binder_key).unwrap()

--- a/examples/ideal/web/e2e/drag-drop.spec.ts
+++ b/examples/ideal/web/e2e/drag-drop.spec.ts
@@ -3,6 +3,7 @@
 // no orphaned separators) by checking the resulting editor text.
 
 import { test, expect, type Page } from '@playwright/test';
+import { dispatchExternalCrdtChanged } from './support/dom-events';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -40,6 +41,28 @@ async function getCodeMirrorText(page: Page): Promise<string> {
 
 function normalizeText(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
+}
+
+async function setEditorText(page: Page, text: string) {
+  await page.evaluate((source) => {
+    const g = globalThis as any;
+    g.__canopy_crdt.set_text(g.__canopy_crdt_handle, source);
+  }, text);
+  await dispatchExternalCrdtChanged(page);
+  // Re-enter Structure mode so the structure PM view is rebuilt from the new
+  // CRDT text; external text updates are primarily consumed by Text mode.
+  await page.getByRole('button', { name: 'Text' }).click();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-content') !== null;
+  });
+  await page.getByRole('button', { name: 'Structure' }).click();
+  await page.waitForFunction(() => {
+    const ce = document.querySelector('canopy-editor');
+    const labels = Array.from(
+      ce?.shadowRoot?.querySelectorAll('.structure-let_def > .structure-header .structure-label') ?? [],
+    ).map((el) => el.textContent);
+    return labels[0] === 'x' && labels[1] === 'y';
+  });
 }
 
 /** Count structure blocks of a given type inside the shadow DOM. */
@@ -162,15 +185,13 @@ test.describe('Drag-Drop — Before/After/Inside', () => {
     expect(text.length).toBeGreaterThan(10);
   });
 
-  test('exchange (Inside) swaps two let-definitions', async ({ page }) => {
-    const textBefore = await getEditorText(page);
+  test('exchange (Inside) moves whole let-definitions', async ({ page }) => {
+    await setEditorText(page, 'let x = 1\nlet y = 2\nx');
 
     await dragDrop(page, '.structure-let_def', 0, '.structure-let_def', 1, 'Inside');
 
     const textAfter = await getEditorText(page);
-    expect(textAfter).not.toEqual(textBefore);
-    const letCount = (textAfter.match(/let /g) || []).length;
-    expect(letCount).toBeGreaterThanOrEqual(2);
+    expect(textAfter).toEqual('let y = 2\nlet x = 1\nx');
   });
 
   test('drop syncs CM6 before returning to Text mode', async ({ page }) => {

--- a/examples/ideal/web/package.json
+++ b/examples/ideal/web/package.json
@@ -5,7 +5,7 @@
     "dev": "vite",
     "build": "vite build",
     "server": "tsx server/ws-server.ts",
-    "prebuild:moonbit": "cd .. && MOON_WORK=off moon build --target js",
+    "prebuild:moonbit": "cd .. && MOON_WORK=off moon build --target js --release",
     "test": "playwright test",
     "test:perf": "CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 playwright test e2e/editor-response.perf.spec.ts --reporter=line",
     "test:ui": "playwright test --ui",

--- a/examples/ideal/web/src/convert.ts
+++ b/examples/ideal/web/src/convert.ts
@@ -20,6 +20,7 @@ export function attrsForKind(
     case "App": return { nodeId: proj.node_id };
     case "Bop": return { op: proj.kind[1], nodeId: proj.node_id };
     case "If": return { nodeId: proj.node_id };
+    case "LetDef": return { name: proj.kind[1], nodeId: proj.node_id };
     case "Module": return { nodeId: proj.node_id };
   }
 }
@@ -98,32 +99,27 @@ export function projNodeToPmNode(proj: ProjNodeJson): PmNode {
         [condPm, thenPm, elsePm],
       );
     }
+    case "LetDef": {
+      if (proj.children.length < 1) {
+        return editorSchema.node("error_node", { message: "malformed LetDef: missing init", nodeId: proj.node_id });
+      }
+      const initPm = projNodeToPmNode(proj.children[0]);
+      return editorSchema.node(
+        "let_def",
+        {
+          name: proj.kind[1],
+          nodeId: proj.node_id,
+        },
+        [initPm],
+      );
+    }
     case "Module": {
       if (proj.children.length < 1) {
         return editorSchema.node("error_node", { message: "malformed Module: missing body", nodeId: proj.node_id });
       }
       // Module kind: ["Module", [["name0", term0], ["name1", term1]], body_term]
-      // ProjNode children: [init0, init1, ..., body]
-      const defs: [string, any][] = proj.kind[1];
-      const children: PmNode[] = [];
-      for (let i = 0; i < proj.children.length - 1; i++) {
-        const name = i < defs.length ? defs[i][0] : "_";
-        const initPm = projNodeToPmNode(proj.children[i]);
-        children.push(
-          editorSchema.node(
-            "let_def",
-            {
-              name,
-              nodeId: proj.children[i].node_id,
-            },
-            [initPm],
-          ),
-        );
-      }
-      const bodyPm = projNodeToPmNode(
-        proj.children[proj.children.length - 1],
-      );
-      children.push(bodyPm);
+      // ProjNode children: [LetDef0, LetDef1, ..., body]
+      const children = proj.children.map(projNodeToPmNode);
       return editorSchema.node(
         "module",
         {

--- a/examples/ideal/web/src/reconciler.ts
+++ b/examples/ideal/web/src/reconciler.ts
@@ -17,6 +17,7 @@ const kindToPmType: Record<TermKindTag, string> = {
   App: "application",
   Bop: "binary_op",
   If: "if_expr",
+  LetDef: "let_def",
   Module: "module",
 };
 
@@ -98,23 +99,17 @@ function diffNode(
     return;
   }
 
-  // 2. Handle Module specially (has synthesized let_def wrappers)
-  if (tag === "Module") {
-    diffModule(tr, pmNode, proj, pmPos);
-    return;
-  }
-
-  // 3. Check attributes
+  // 2. Check attributes
   const newAttrs = attrsForKind(proj, tag);
   if (!attrsEqual(pmNode.attrs as Record<string, unknown>, newAttrs)) {
     const mappedPos = tr.mapping.map(pmPos);
     tr.setNodeMarkup(mappedPos, null, newAttrs);
   }
 
-  // 4. For atom nodes (leaves), we're done — attrs carry all the data
+  // 3. For atom nodes (leaves), we're done — attrs carry all the data
   if (pmNode.isAtom) return;
 
-  // 5. For compound nodes, recurse into children
+  // 4. For compound nodes, recurse into children
   diffChildren(tr, pmNode, proj, pmPos);
 }
 
@@ -134,10 +129,10 @@ function replaceSubtree(
 }
 
 /**
- * Diff the children of a non-Module compound node.
+ * Diff the children of a compound node.
  *
- * For lambda, application, binary_op, if_expr: the PM children correspond
- * 1:1 with the ProjNode children.
+ * For module, let_def, lambda, application, binary_op, if_expr: the PM
+ * children correspond 1:1 with the ProjNode children.
  */
 function diffChildren(
   tr: Transaction,
@@ -146,113 +141,22 @@ function diffChildren(
   pmPos: number,
 ): void {
   const projChildren = proj.children;
-  let childIndex = 0;
 
-  // Walk PM children and match to ProjNode children by index
-  pmNode.forEach((child, offset) => {
-    if (childIndex < projChildren.length) {
-      // pmPos + 1 skips the parent's open tag
-      // offset is the offset from the start of the parent's content
-      const childPmPos = pmPos + 1 + offset;
-      diffNode(tr, child, projChildren[childIndex], childPmPos);
-    }
-    childIndex++;
-  });
-
-  // If child count changed (shouldn't happen for non-Module fixed-arity nodes,
-  // but handle defensively), do a full subtree replace
-  if (childIndex !== projChildren.length) {
-    replaceSubtree(tr, pmNode, proj, pmPos);
-  }
-}
-
-/**
- * Diff a Module node, handling the let_def wrapper asymmetry.
- *
- * ProjNode Module: children = [init0, init1, ..., body]
- * PM module:       children = [let_def(init0), let_def(init1), ..., body_term]
- *
- * The let_def nodes are synthesized during conversion. We need to:
- * - Match let_defs by position
- * - Check let_def attrs (name) and recurse into their single child (the init term)
- * - Match the body term (last child in both)
- */
-function diffModule(
-  tr: Transaction,
-  pmNode: PmNode,
-  proj: ProjNodeJson,
-  pmPos: number,
-): void {
-  // Check module-level attributes
-  const newModuleAttrs = attrsForKind(proj, "Module");
-  if (
-    !attrsEqual(pmNode.attrs as Record<string, unknown>, newModuleAttrs)
-  ) {
-    const mappedPos = tr.mapping.map(pmPos);
-    tr.setNodeMarkup(mappedPos, null, newModuleAttrs);
-  }
-
-  const defs: [string, any][] = proj.kind[1];
-  const projChildren = proj.children;
-  const numDefs = projChildren.length - 1; // all except last (body)
-  const bodyProj = projChildren[projChildren.length - 1];
-
-  // Collect PM children in a single pass
-  const pmChildren: { node: PmNode; offset: number }[] = [];
-  pmNode.forEach((child, offset) => {
-    pmChildren.push({ node: child, offset });
-  });
-
-  // If structural mismatch in child count, replace entire module
-  // PM should have numDefs let_defs + 1 body = numDefs + 1 = projChildren.length
-  if (pmChildren.length !== projChildren.length) {
+  // If child count changed, do a full subtree replace before emitting child
+  // edits; mixing child edits with a later parent replace can create needless
+  // mapping churn.
+  if (pmNode.childCount !== projChildren.length) {
     replaceSubtree(tr, pmNode, proj, pmPos);
     return;
   }
 
-  for (let childIndex = 0; childIndex < pmChildren.length; childIndex++) {
-    const { node: pmChild, offset } = pmChildren[childIndex];
+  let childIndex = 0;
+  // Walk PM children and match to ProjNode children by index.
+  pmNode.forEach((child, offset) => {
+    // pmPos + 1 skips the parent's open tag
+    // offset is the offset from the start of the parent's content
     const childPmPos = pmPos + 1 + offset;
-
-    if (childIndex < numDefs) {
-      // This PM child should be a let_def wrapping projChildren[childIndex]
-      if (pmChild.type.name !== "let_def") {
-        // Type mismatch — replace entire module and stop
-        replaceSubtree(tr, pmNode, proj, pmPos);
-        return;
-      }
-
-      // Check let_def attrs
-      const defName = childIndex < defs.length ? defs[childIndex][0] : "_";
-      const expectedLetDefAttrs = {
-        name: defName,
-        nodeId: projChildren[childIndex].node_id,
-      };
-      if (
-        !attrsEqual(
-          pmChild.attrs as Record<string, unknown>,
-          expectedLetDefAttrs,
-        )
-      ) {
-        const mappedPos = tr.mapping.map(childPmPos);
-        tr.setNodeMarkup(mappedPos, null, expectedLetDefAttrs);
-      }
-
-      // Recurse into the let_def's single child (the init term)
-      const initProj = projChildren[childIndex];
-      if (pmChild.childCount === 1) {
-        const initPm = pmChild.firstChild!;
-        const initPmPos = childPmPos + 1;
-        diffNode(tr, initPm, initProj, initPmPos);
-      } else {
-        const newInitPm = projNodeToPmNode(initProj);
-        const from = tr.mapping.map(childPmPos + 1);
-        const to = tr.mapping.map(childPmPos + 1 + pmChild.content.size);
-        tr.replaceWith(from, to, newInitPm);
-      }
-    } else {
-      // Last child: the body term (not wrapped in let_def)
-      diffNode(tr, pmChild, bodyProj, childPmPos);
-    }
-  }
+    diffNode(tr, child, projChildren[childIndex], childPmPos);
+    childIndex++;
+  });
 }

--- a/examples/ideal/web/src/text-nodeview.ts
+++ b/examples/ideal/web/src/text-nodeview.ts
@@ -106,8 +106,8 @@ export class LetDefView implements NodeView {
 
   constructor(
     node: PmNode,
-    private pmView: PmView,
-    private getPos: () => number | undefined,
+    _pmView: PmView,
+    _getPos: () => number | undefined,
     private bridge: CrdtBridge | null,
     private shadowRoot?: ShadowRoot,
   ) {
@@ -130,11 +130,7 @@ export class LetDefView implements NodeView {
       parent: nameWrap,
       root: this.shadowRoot,
       onEdit: this.bridge
-        ? (changes) => {
-            const ctx = this.resolveContext();
-            if (!ctx) return;
-            this.bridge!.handleTokenEdit(ctx.moduleNodeId, "name:" + ctx.defIndex, changes);
-          }
+        ? (changes) => this.bridge!.handleTokenEdit(this.node.attrs.nodeId, "name", changes)
         : undefined,
       isUpdating: () => this.updating,
     });
@@ -150,19 +146,6 @@ export class LetDefView implements NodeView {
     this.contentDOM = document.createElement("span");
     this.contentDOM.className = "pm-let-init";
     this.dom.appendChild(this.contentDOM);
-  }
-
-  /** Resolve this let_def's position to get the parent module nodeId and def index in a single pass */
-  private resolveContext(): { moduleNodeId: number; defIndex: number } | null {
-    const pos = this.getPos();
-    if (pos == null) return null;
-    const resolved = this.pmView.state.doc.resolve(pos);
-    const parent = resolved.parent;
-    if (!parent || parent.type.name !== "module") return null;
-    return {
-      moduleNodeId: parent.attrs.nodeId,
-      defIndex: resolved.index(resolved.depth),
-    };
   }
 
   update(node: PmNode): boolean {

--- a/examples/ideal/web/src/types.ts
+++ b/examples/ideal/web/src/types.ts
@@ -13,12 +13,13 @@ export type TermKindTag =
   | "App"
   | "Bop"
   | "If"
+  | "LetDef"
   | "Module"
   | "Unit"
   | "Unbound"
   | "Error";
 
-const VALID_TAGS = new Set<string>(["Int", "Var", "Lam", "App", "Bop", "If", "Module", "Unit", "Unbound", "Error"]);
+const VALID_TAGS = new Set<string>(["Int", "Var", "Lam", "App", "Bop", "If", "LetDef", "Module", "Unit", "Unbound", "Error"]);
 
 export function getKindTag(kind: any[]): TermKindTag {
   if (!Array.isArray(kind) || kind.length === 0) {

--- a/examples/ideal/web/vite.config.ts
+++ b/examples/ideal/web/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig, type PluginOption } from 'vite';
 import { moonbitPlugin } from '../../web/vite-plugin-moonbit';
 
+// Workspace builds emit namespaced artifacts at the repo root; MOON_WORK=off
+// builds the standalone ideal module under examples/ideal/_build.
+const idealEditorOutput = process.env.MOON_WORK === 'off'
+  ? '_build/js/release/build/main/main.js'
+  : '../../_build/js/release/build/dowdiness/ideal-editor/main/main.js';
+
 export default defineConfig({
   plugins: [
     moonbitPlugin({
@@ -10,7 +16,7 @@ export default defineConfig({
           // No separate @moonbit/canopy needed (saves 7.6MB load).
           name: '@moonbit/ideal-editor',
           path: '..',
-          output: '../../_build/js/release/build/dowdiness/ideal-editor/main/main.js'
+          output: idealEditorOutput
         }
       ]
     }) as PluginOption

--- a/examples/ideal/web/vite.config.ts
+++ b/examples/ideal/web/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
           // No separate @moonbit/canopy needed (saves 7.6MB load).
           name: '@moonbit/ideal-editor',
           path: '..',
-          output: '_build/js/release/build/main/main.js'
+          output: '../../_build/js/release/build/dowdiness/ideal-editor/main/main.js'
         }
       ]
     }) as PluginOption

--- a/lang/lambda/edits/actions.mbt
+++ b/lang/lambda/edits/actions.mbt
@@ -95,6 +95,10 @@ pub fn get_actions_for_node(
   context : NodeContext,
 ) -> Array[Action] {
   let actions : Array[Action] = []
+  let is_let_def_node = match kind {
+    @ast.Term::LetDef(_, _) => true
+    _ => false
+  }
   match kind {
     @ast.Term::Int(_) => {
       actions.push(extract_to_let)
@@ -154,6 +158,14 @@ pub fn get_actions_for_node(
       actions.push(wrap_app)
       actions.push(delete)
     }
+    @ast.Term::LetDef(_, _) => {
+      actions.push(binding_rename)
+      actions.push(binding_duplicate)
+      actions.push(binding_move_up)
+      actions.push(binding_move_down)
+      actions.push(binding_inline_all)
+      actions.push(binding_delete)
+    }
     @ast.Term::Module(_, _) => actions.push(add_binding)
     @ast.Term::Unit => {
       actions.push(wrap_lambda)
@@ -173,8 +185,8 @@ pub fn get_actions_for_node(
       actions.push(wrap_app)
     }
   }
-  // Add binding-level actions when the node is in a let-binding context
-  if context.is_let_binding {
+  // Add binding-level actions when an init child is in a let-binding context.
+  if context.is_let_binding && !is_let_def_node {
     actions.push(binding_rename)
     actions.push(binding_duplicate)
     actions.push(binding_move_up)

--- a/lang/lambda/edits/actions_wbtest.mbt
+++ b/lang/lambda/edits/actions_wbtest.mbt
@@ -115,6 +115,22 @@ test "actions for App node" {
 }
 
 ///|
+test "actions for LetDef node" {
+  let ctx = NodeContext::new()
+  let actions = get_actions_for_node(
+    @ast.Term::LetDef("x", @ast.Term::Int(1)),
+    ctx,
+  )
+  let ids = actions.map(fn(a) { a.id })
+  inspect(ids.contains("binding_rename"), content="true")
+  inspect(ids.contains("binding_duplicate"), content="true")
+  inspect(ids.contains("binding_delete"), content="true")
+  inspect(ids.contains("binding_inline_all"), content="true")
+  inspect(ids.contains("binding_move_up"), content="true")
+  inspect(ids.contains("binding_move_down"), content="true")
+}
+
+///|
 test "actions for Module node" {
   let ctx = NodeContext::new()
   let actions = get_actions_for_node(

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -222,15 +222,15 @@ fn free_name_would_rebind_to(
 }
 
 ///|
-/// Look up the FlatProj binding NodeId for a given init expression NodeId.
-/// The UI selects init expression ProjNodes (children of Module); this function
-/// maps that to the corresponding binding NodeId needed by binding-level operations.
+/// Look up the FlatProj binding NodeId for a given init expression or LetDef NodeId.
+/// Init-expression callers are mapped to the parent LetDef id; direct LetDef
+/// callers return the binding id unchanged.
 pub fn find_binding_for_init(
   init_node_id : NodeId,
   flat_proj : FlatProj,
 ) -> (NodeId, Int)? {
   for i, def in flat_proj.defs {
-    if def.1.id() == init_node_id {
+    if def.3 == init_node_id || def.1.id() == init_node_id {
       return Some((def.3, i))
     }
   }

--- a/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
+++ b/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
@@ -2,12 +2,12 @@
 //
 // WHAT THIS PINS
 // Two pipelines build a `FlatProj` from the same source, then a scope graph
-// resolves each Var reference to a declaration. The pipelines assign a module
-// def's binder id (`defs[i].3`) differently:
-//   - TEST path (`graph_and_sm_of` / `from_proj_node`): reuses the init node's
-//     id (a real node present in the reconstructed tree);
-//   - PRODUCTION path (`production_graph_of` / `to_flat_proj`): allocates a
-//     SYNTHETIC binder id occupying no registry node.
+// resolves each Var reference to a declaration. Both pipelines assign a module
+// def's binder id (`defs[i].3`) to a real LetDef node:
+//   - TEST path (`graph_and_sm_of` / `from_proj_node`): extracts the id from the
+//     parsed LetDef child;
+//   - PRODUCTION path (`production_graph_of` / `to_flat_proj`): stores the id in
+//     FlatProj and reconstructs the LetDef child from it.
 // Resolution never reads `node_id` (`Builder::resolve` matches name + def_index
 // < cutoff), so the hand-verified equivalence proof in
 // `scope_equivalence_wbtest.mbt` SHOULD transfer to production — this PBT pins
@@ -16,14 +16,14 @@
 // It also pins the Option-D binder-location contract (docs/TODO.md §20): each
 // resolved declaration is LOCATABLE via `@scope.binder_span`, and that location
 // is pipeline-INDEPENDENT — both pipelines derive the binder span from the same
-// syntax token offsets, so the accessor agrees even though the internal binder
-// `node_id` values diverge. This SUPERSEDES the former gap pin (which asserted
-// the module binder `node_id` was synthetic / not in the registry); Option D
-// locates binders by source span, not `node_id`, so that syntheticness is now
-// an internal detail rather than a gap awaiting a fix.
+// syntax token offsets, so the accessor agrees even if internal binder node ids
+// are allocated through different paths. This SUPERSEDES the former gap pin
+// (which asserted the module binder `node_id` was synthetic / not in the
+// registry); #127 makes that id a real LetDef node while Option D remains the
+// source-location path.
 //
 // HOW IT STAYS NON-CIRCULAR (see memory: feedback_drift_detector_non_circular)
-// The two pipelines differ exactly in their node-id *values*; node ids are
+// The two pipelines may differ in their node-id *values*; node ids are
 // therefore never compared raw. Each resolution is reduced to a
 // pipeline-INDEPENDENT key built from semantic identity (module: def_index;
 // lambda: the binding Lam node's SOURCE RANGE — identical across pipelines

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -182,10 +182,9 @@ test "declaration() resolves a later def's init to an earlier same-name def" {
 ///|
 /// Build a scope graph through the PRODUCTION FlatProj pipeline — `to_flat_proj`
 /// (the live editor's path) rather than `from_proj_node` (used by `graph_of`
-/// above). The two paths assign module binder ids differently: `from_proj_node`
-/// reuses the init node's id, whereas `to_flat_proj` allocates a synthetic
-/// binder id (`defs[i].3`) that is threaded into NO node of the reconstructed
-/// tree. This fixture exists solely to exercise that production path.
+/// above). Both paths now assign module binder ids to real LetDef nodes; this
+/// fixture exercises the production path that starts from flat entries and then
+/// reconstructs those LetDef nodes.
 fn production_graph_of(
   text : String,
 ) -> (
@@ -197,16 +196,16 @@ fn production_graph_of(
   let (cst, _diags) = @parser.parse_cst(text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
-  // Production FlatProj: module binder ids (defs[i].3) are freshly allocated,
-  // distinct from any init node id.
+  // Production FlatProj: module binder ids (defs[i].3) are real LetDef node ids,
+  // distinct from their init expression ids.
   let fp = @lambda_proj.to_flat_proj(syntax, counter)
   // Reconstruct the Module ProjNode exactly as the live `cached_proj_node` memo
-  // does; the synthetic binder ids are not placed into this tree.
+  // does; binding ids become first-class LetDef nodes in this tree.
   let proj = fp.to_proj_node(counter)
   let sm = SourceMap::from_ast(proj)
-  // Token spans are stored on the reconstructed Module/Lam nodes (by index +
-  // role), so `binder_span` works on the production path too — its locator is
-  // the source span, not the synthetic binder id.
+  // Token spans are stored on the reconstructed LetDef/Module/Lam nodes, so
+  // `binder_span` works on the production path too — its locator is the binder
+  // token span, not the full LetDef node range.
   populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(fp, registry, sm)
@@ -215,14 +214,12 @@ fn production_graph_of(
 
 ///|
 /// Option-D binder-location contract on the PRODUCTION path (docs/TODO.md §20,
-/// resolved). Through `to_flat_proj` a module def's `Decl.node_id` is a
-/// synthetic FlatProj binder id occupying no registry node — but locating the
-/// binder no longer depends on `node_id`: `@scope.binder_span` resolves it via
-/// the module node's `"name:<def_index>"` token span. This SUPERSEDES the former
-/// "known gap" pin (which expected `node_id` to become a real node); Option D
-/// instead sidesteps `node_id` entirely, so its syntheticness is now an internal
-/// detail and is deliberately no longer asserted. The companion assertion that
-/// this location is pipeline-independent lives in the cross-pipeline PBT.
+/// resolved). Through `to_flat_proj` a module def's `Decl.node_id` is now the
+/// real LetDef node id, but locating the binder still goes through
+/// `@scope.binder_span`: it resolves the LetDef node's `"name"` token span
+/// (with the module `"name:<def_index>"` fallback during migration), not the
+/// full node range. The companion assertion that this location is
+/// pipeline-independent lives in the cross-pipeline PBT.
 test "production path: module binder located via binder_span (Option D, supersedes §20 gap)" {
   let (proj, registry, g, sm) = production_graph_of("let x = 0\nx")
   let ref_id = find_var(proj, "x") // body Var x
@@ -232,9 +229,9 @@ test "production path: module binder located via binder_span (Option D, supersed
   let (tag, binder, def_index) = norm_decl(d)
   inspect(tag, content="module")
   inspect(def_index, content="0")
-  // `node_id` is NOT the locator — it remains a synthetic non-registry id …
-  inspect(registry.get(binder) is None, content="true")
-  // … yet the binder is locatable: "let x = 0" → name token "x" at 4..5.
+  // `node_id` is structural identity and now points at the LetDef row.
+  inspect(registry.get(binder) is Some(_), content="true")
+  // The locator remains the binder token: "let x = 0" → name token "x" at 4..5.
   guard @scope.binder_span(g, d, sm) is Some(r)
   inspect(r.start, content="4")
   inspect(r.end, content="5")

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -66,14 +66,21 @@ test "find_binding_for_init: maps init ProjNode to binding NodeId" {
   let text = "let x = 0\nlet y = 1\nx + y"
   let (proj, _) = parse_to_proj_node(text)
   let fp = FlatProj::from_proj_node(proj)
-  // First def's init is proj.children[0]
-  let init_id = proj.children[0].id()
+  // First def's init is the LetDef node's child.
+  let init_id = proj.children[0].children[0].id()
   match find_binding_for_init(init_id, fp) {
     Some((binding_id, def_index)) => {
       inspect(binding_id == fp.defs[0].3, content="true")
       inspect(def_index, content="0")
     }
     None => fail("expected Some")
+  }
+  match find_binding_for_init(proj.children[0].id(), fp) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == fp.defs[0].3, content="true")
+      inspect(def_index, content="0")
+    }
+    None => fail("expected Some for LetDef id")
   }
 }
 

--- a/lang/lambda/edits/text_edit_drop.mbt
+++ b/lang/lambda/edits/text_edit_drop.mbt
@@ -19,22 +19,47 @@ fn compute_drop(
     target_range.end <= source_range.end) else {
     return Err("Cannot drop into own descendant")
   }
-  let source_slice = source_text[source_range.start:source_range.end].to_owned()
-  let insert_pos = match position {
-    Before => target_range.start
-    After => target_range.end
-    Inside => target_range.start
+  let is_let_def_drop = match
+    (ctx.registry.get(source), ctx.registry.get(target)) {
+    (Some(source_node), Some(target_node)) =>
+      source_node.kind is @ast.Term::LetDef(_, _) &&
+      target_node.kind is @ast.Term::LetDef(_, _)
+    _ => false
+  }
+  let (delete_start, delete_len, insert_pos, inserted) = if is_let_def_drop {
+    let source_row = source_text[source_range.start:source_range.end].to_owned()
+    let (delete_start, delete_len) = binding_delete_range(
+      source_text,
+      source_range.start,
+      source_range.end,
+    )
+    let (insert_pos, inserted) = match position {
+      Before => (target_range.start, source_row + "\n")
+      // Dropping “inside” a let row means move the whole row after it; the
+      // initializer is a child, not the row's drop target.
+      After | Inside => (target_range.end, "\n" + source_row)
+    }
+    (delete_start, delete_len, insert_pos, inserted)
+  } else {
+    let source_slice = source_text[source_range.start:source_range.end].to_owned()
+    let insert_pos = match position {
+      Before => target_range.start
+      After => target_range.end
+      Inside => target_range.start
+    }
+    (
+      source_range.start,
+      source_range.end - source_range.start,
+      insert_pos,
+      source_slice,
+    )
   }
   Ok(
     Some(
       (
         [
-          {
-            start: source_range.start,
-            delete_len: source_range.end - source_range.start,
-            inserted: "",
-          },
-          { start: insert_pos, delete_len: 0, inserted: source_slice },
+          { start: delete_start, delete_len, inserted: "" },
+          { start: insert_pos, delete_len: 0, inserted },
         ],
         RestoreCursor,
       ),

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -198,13 +198,23 @@ fn rename_module_binding(
     }
   }
   let edits : Array[SpanEdit] = []
-  // Get the name token span
-  let role = @lambda_proj.module_name_role(def_index)
-  match source_map.get_token_span(module_id, role) {
-    Some(name_range) =>
+  // Get the binder-name token span. Prefer the first-class LetDef node; keep
+  // the module-level `name:<i>` lookup as a migration fallback for older maps.
+  let binding_node_id = flat_proj.defs[def_index].3
+  let name_range = match
+    source_map.get_token_span(binding_node_id, @lambda_proj.LET_DEF_NAME_ROLE) {
+    Some(r) => Some(r)
+    None =>
+      source_map.get_token_span(
+        module_id,
+        @lambda_proj.module_name_role(def_index),
+      )
+  }
+  match name_range {
+    Some(range) =>
       edits.push({
-        start: name_range.start,
-        delete_len: name_range.end - name_range.start,
+        start: range.start,
+        delete_len: range.end - range.start,
         inserted: new_name,
       })
     None =>

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -295,6 +295,58 @@ test "compute_text_edit: Drop produces two edits" {
 }
 
 ///|
+test "compute_text_edit: Drop LetDef Inside moves the whole binding row after target" {
+  let text = "let x = 1\nlet y = 2\nx"
+  let (proj, source_map, registry, fp) = parse_with_token_spans(text)
+  let source = proj.children[0]
+  let target = proj.children[1]
+  let result = compute_text_edit(
+    Drop(source=source.id(), target=target.id(), position=Inside),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(
+        new_text,
+        content=(
+          #|let y = 2
+          #|let x = 1
+          #|x
+        ),
+      )
+    }
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
+test "compute_text_edit: Drop LetDef Before moves the whole binding row before target" {
+  let text = "let x = 1\nlet y = 2\nx"
+  let (proj, source_map, registry, fp) = parse_with_token_spans(text)
+  let source = proj.children[1]
+  let target = proj.children[0]
+  let result = compute_text_edit(
+    Drop(source=source.id(), target=target.id(), position=Before),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(
+        new_text,
+        content=(
+          #|let y = 2
+          #|let x = 1
+          #|x
+        ),
+      )
+    }
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
 test "compute_text_edit: Drop with unknown source returns error" {
   let text = "42"
   let (proj, _) = parse_to_proj_node(text)

--- a/lang/lambda/eval/seed_term.mbt
+++ b/lang/lambda/eval/seed_term.mbt
@@ -21,6 +21,10 @@ pub fn seed_term(db : @egglog.Database, term : @ast.Term) -> @egglog.Value {
     Bop(Minus, a, b) => db.call("Minus", [seed_term(db, a), seed_term(db, b)])
     If(c, t, e) =>
       db.call("If", [seed_term(db, c), seed_term(db, t), seed_term(db, e)])
+    LetDef(name, _) =>
+      db.call("ErrorNode", [
+        @egglog.StrVal("standalone let definition: \{name}"),
+      ])
     Module(defs, body) => {
       // Right-fold into nested Let: last def wraps body, first def is outermost
       let mut result = seed_term(db, body)

--- a/lang/lambda/proj/flat_proj.mbt
+++ b/lang/lambda/proj/flat_proj.mbt
@@ -3,7 +3,7 @@
 
 ///|
 pub struct FlatProj {
-  defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)] // (name, init, start, id)
+  defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)] // (name, init, start, LetDef id)
   final_expr : ProjNode[@ast.Term]?
 } derive(Debug, Eq)
 
@@ -15,19 +15,21 @@ pub fn FlatProj::empty() -> FlatProj {
 ///|
 /// Build a FlatProj from a SourceFile SyntaxNode.
 /// Iterates LetDef children and collects them as flat array entries.
-/// Each init subtree is built via syntax_to_proj_node (unchanged).
+/// Each entry stores the init subtree plus the real LetDef node id.
 pub fn to_flat_proj(root : @seam.SyntaxNode, counter : Ref[Int]) -> FlatProj {
   let defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)] = []
   let mut final_proj : ProjNode[@ast.Term]? = None
   for child in root.children() {
     if @parser.LetDefView::cast(child) is Some(v) {
-      let init = match v.init() {
-        Some(n) => syntax_to_proj_node(n, counter)
-        None =>
-          error_node_for_syntax("missing let binding value", child, counter)
-      }
-      let id = NodeId::from_int(@core.next_proj_node_id(counter))
-      defs.push((v.name(), init, child.start(), id))
+      let projected = project_let_def(v, counter)
+      defs.push(
+        (
+          projected.name,
+          projected.node.children[0],
+          child.start(),
+          projected.node.id(),
+        ),
+      )
     } else if final_proj is None {
       final_proj = Some(syntax_to_proj_node(child, counter))
     }
@@ -92,15 +94,15 @@ pub fn to_flat_proj_incremental(
       if !reused {
         any_changed = true
         changed_indices.val.push(defs.length())
-        let init = match v.init() {
-          Some(n) => syntax_to_proj_node(n, counter)
-          None =>
-            error_node_for_syntax(
-              "missing let binding value", new_child, counter,
-            )
-        }
-        let id = NodeId::from_int(@core.next_proj_node_id(counter))
-        defs.push((v.name(), init, new_child.start(), id))
+        let projected = project_let_def(v, counter)
+        defs.push(
+          (
+            projected.name,
+            projected.node.children[0],
+            new_child.start(),
+            projected.node.id(),
+          ),
+        )
       }
     } else if final_proj is None {
       match old_final_child {
@@ -248,7 +250,12 @@ pub fn FlatProj::to_proj_node_with_prev_module_id(
   if self.defs.is_empty() {
     return body
   }
-  let children : Array[ProjNode[@ast.Term]] = self.defs.map(d => d.1)
+  let children : Array[ProjNode[@ast.Term]] = self.defs.map(d => {
+    let NodeId(binding_id) = d.3
+    ProjNode::new(@ast.Term::LetDef(d.0, d.1.kind), d.2, d.1.end, binding_id, [
+      d.1,
+    ])
+  })
   children.push(body)
   let term_defs : Array[(@ast.VarName, @ast.Term)] = self.defs.map(d => {
     (d.0, d.1.kind)
@@ -269,17 +276,29 @@ pub fn FlatProj::to_proj_node_with_prev_module_id(
 
 ///|
 /// Extract a FlatProj from a Module ProjNode.
-/// Reads def entries from Module children and extracts the body.
+/// Reads LetDef children and extracts their init child. Legacy init-only
+/// children are accepted as a compatibility fallback.
 pub fn FlatProj::from_proj_node(root : ProjNode[@ast.Term]) -> FlatProj {
   match root.kind {
     Module(term_defs, _) => {
       let defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)] = []
       for i = 0; i < term_defs.length(); i = i + 1 {
         if i < root.children.length() - 1 {
-          let init_child = root.children[i]
-          defs.push(
-            (term_defs[i].0, init_child, init_child.start, init_child.id()),
-          )
+          let def_child = root.children[i]
+          match def_child.kind {
+            @ast.Term::LetDef(_, _) if def_child.children.length() > 0 => {
+              let init_child = def_child.children[0]
+              defs.push(
+                (term_defs[i].0, init_child, def_child.start, def_child.id()),
+              )
+            }
+            _ => {
+              let init_child = def_child
+              defs.push(
+                (term_defs[i].0, init_child, init_child.start, init_child.id()),
+              )
+            }
+          }
         }
       }
       let body_child = root.children[root.children.length() - 1]

--- a/lang/lambda/proj/flat_proj_wbtest.mbt
+++ b/lang/lambda/proj/flat_proj_wbtest.mbt
@@ -170,6 +170,10 @@ test "FlatProj::to_proj_node: let defs reconstruct Module" {
       #|Module([("x", Int(1)), ("y", Int(2))], Bop(Plus, Var("x"), Var("y")))
     ),
   )
+  inspect(proj.children.length(), content="3")
+  inspect(proj.children[0].kind, content="LetDef(\"x\", Int(1))")
+  inspect(proj.children[0].id() == fp.defs[0].3, content="true")
+  inspect(proj.children[0].children[0].kind, content="Int(1)")
 }
 
 ///|
@@ -188,6 +192,8 @@ test "FlatProj::from_proj_node: extracts Module defs" {
   inspect(fp.defs.length(), content="2")
   inspect(fp.defs[0].0, content="x")
   inspect(fp.defs[1].0, content="y")
+  inspect(fp.defs[0].1.kind, content="Int(1)")
+  inspect(fp.defs[0].3 == proj.children[0].id(), content="true")
 }
 
 ///|

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -9,6 +9,8 @@ import {
 }
 
 // Values
+pub const LET_DEF_NAME_ROLE : String = "name"
+
 pub const PARAM_ROLE : String = "param"
 
 pub fn module_name_role(Int) -> String

--- a/lang/lambda/proj/populate_token_spans.mbt
+++ b/lang/lambda/proj/populate_token_spans.mbt
@@ -24,7 +24,7 @@ fn collect_token_spans_source_file(
   syntax_root : @seam.SyntaxNode,
   proj_root : ProjNode[@ast.Term],
 ) -> Unit {
-  // For a Module ProjNode, children are: [init_0, init_1, ..., body]
+  // For a Module ProjNode, children are: [LetDef_0, LetDef_1, ..., body]
   // The syntax_root has LetDef children and optionally a final expression child.
   match proj_root.kind {
     Module(defs, _) => {
@@ -34,41 +34,28 @@ fn collect_token_spans_source_file(
       for syn_child in syntax_children {
         if @parser.LetDefView::cast(syn_child) is Some(v) {
           if def_idx < defs.length() && def_idx < proj_root.children.length() {
-            // The ProjNode child at def_idx is the init expression, but
-            // the LetDef's name token belongs to the LetDef itself.
-            // We need a NodeId for the LetDef. In the current FlatProj model,
-            // LetDef nodes don't have their own ProjNode — the Module node
-            // owns the defs array. So we store the name span on the Module
-            // node with a role like "name:0", "name:1", etc.
-            // Use index-based key for stability across renames
-            let role = module_name_role(def_idx)
-            source_map.set_span_from_token(
-              proj_root.id(),
-              role,
-              syn_child,
-              @syntax.IdentToken.to_raw(),
+            collect_token_spans_let_def(
+              source_map,
+              proj_root,
+              def_idx,
+              v,
+              proj_root.children[def_idx],
             )
-            // Recurse into the init expression
-            if v.init() is Some(init_syn) {
-              collect_token_spans_expr(
-                source_map,
-                init_syn,
-                proj_root.children[def_idx],
-              )
-            }
           }
           def_idx = def_idx + 1
         } else if !expr_seen {
           expr_seen = true
-          // This is the final expression — last child of Module ProjNode
-          let body_idx = proj_root.children.length() - 1
-          if body_idx >= 0 {
-            collect_token_spans_expr(
-              source_map,
-              syn_child,
-              proj_root.children[body_idx],
-            )
+          // This is the final expression. If no source-file LetDefs were
+          // consumed, a Module ProjNode here came from the expression itself
+          // (for example a block `{ let x = ... }`), so walk the root Module.
+          // Otherwise the final expression is the last child of the top-level
+          // Module ProjNode.
+          let body_proj = if def_idx == 0 {
+            proj_root
+          } else {
+            proj_root.children[proj_root.children.length() - 1]
           }
+          collect_token_spans_expr(source_map, syn_child, body_proj)
         }
       }
     }
@@ -83,6 +70,35 @@ fn collect_token_spans_source_file(
         }
       }
     }
+  }
+}
+
+///|
+/// Record the binder-name token span for one LetDef row and recurse into its
+/// initializer. The canonical span lives on the LetDef node; the module-level
+/// `name:<i>` span remains as a migration fallback for older callers.
+fn collect_token_spans_let_def(
+  source_map : SourceMap,
+  module_node : ProjNode[@ast.Term],
+  def_index : Int,
+  def_view : @parser.LetDefView,
+  let_def_node : ProjNode[@ast.Term],
+) -> Unit {
+  let def_syn = def_view.syntax_node()
+  source_map.set_span_from_token(
+    let_def_node.id(),
+    LET_DEF_NAME_ROLE,
+    def_syn,
+    @syntax.IdentToken.to_raw(),
+  )
+  source_map.set_span_from_token(
+    module_node.id(),
+    module_name_role(def_index),
+    def_syn,
+    @syntax.IdentToken.to_raw(),
+  )
+  if def_view.init() is Some(init_syn) && let_def_node.children.length() > 0 {
+    collect_token_spans_expr(source_map, init_syn, let_def_node.children[0])
   }
 }
 
@@ -193,6 +209,38 @@ fn collect_token_spans_expr(
     // ParenExpr unwraps: ProjNode reuses inner's node_id and children
     if v.inner() is Some(inner) {
       collect_token_spans_expr(source_map, inner, proj_node)
+    }
+  } else if @parser.BlockExprView::cast(syntax_node) is Some(v) {
+    match proj_node.kind {
+      Module(defs, _) => {
+        let mut def_idx = 0
+        for def_view in v.defs() {
+          if def_idx < defs.length() && def_idx < proj_node.children.length() {
+            collect_token_spans_let_def(
+              source_map,
+              proj_node,
+              def_idx,
+              def_view,
+              proj_node.children[def_idx],
+            )
+          }
+          def_idx = def_idx + 1
+        }
+        if v.body() is Some(body_syn) {
+          let body_idx = proj_node.children.length() - 1
+          if body_idx >= 0 {
+            collect_token_spans_expr(
+              source_map,
+              body_syn,
+              proj_node.children[body_idx],
+            )
+          }
+        }
+      }
+      _ =>
+        if v.body() is Some(body_syn) {
+          collect_token_spans_expr(source_map, body_syn, proj_node)
+        }
     }
   }
   // IntLiteral, VarRef: leaf nodes, no token spans to extract

--- a/lang/lambda/proj/populate_token_spans_wbtest.mbt
+++ b/lang/lambda/proj/populate_token_spans_wbtest.mbt
@@ -26,6 +26,52 @@ fn expect_param_span(
 }
 
 ///|
+test "populate_token_spans: LetDef name span lives on LetDef node" {
+  let text = "let x = 1\nx"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  let let_def = proj.children[0]
+  guard source_map.get_token_span(let_def.id(), LET_DEF_NAME_ROLE) is Some(span) else {
+    fail("missing LetDef name span")
+  }
+  inspect(span.start, content="4")
+  inspect(span.end, content="5")
+  guard source_map.get_token_span(proj.id(), module_name_role(0)) is Some(_) else {
+    fail("missing module-level compatibility name span")
+  }
+}
+
+///|
+test "populate_token_spans: nested block LetDef name span lives on LetDef node" {
+  let text = "let x = { let y = 1\n  y }\nx"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  let block_module = proj.children[0].children[0]
+  let nested_let_def = block_module.children[0]
+  guard source_map.get_token_span(nested_let_def.id(), LET_DEF_NAME_ROLE)
+    is Some(span) else {
+    fail("missing nested LetDef name span")
+  }
+  inspect(span.start, content="14")
+  inspect(span.end, content="15")
+  guard source_map.get_token_span(block_module.id(), module_name_role(0))
+    is Some(_) else {
+    fail("missing nested module-level compatibility name span")
+  }
+}
+
+///|
+test "populate_token_spans: root block LetDef name span lives on LetDef node" {
+  let text = "{ let y = 1\n  y }"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  let nested_let_def = proj.children[0]
+  guard source_map.get_token_span(nested_let_def.id(), LET_DEF_NAME_ROLE)
+    is Some(span) else {
+    fail("missing root block LetDef name span")
+  }
+  inspect(span.start, content="6")
+  inspect(span.end, content="7")
+}
+
+///|
 test "populate_token_spans: application left spine reaches every lambda arg" {
   let text = "(\u{03BB}x. x) (\u{03BB}y. y) (\u{03BB}z. z)"
   let (proj, source_map) = parse_proj_with_token_spans(text)

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -57,7 +57,7 @@ fn bop_node(
 ///|
 priv struct ProjectedLetDef {
   name : @ast.VarName
-  init : ProjNode[@ast.Term]
+  node : ProjNode[@ast.Term]
   start : Int
 }
 
@@ -77,7 +77,14 @@ fn project_let_def(
     None =>
       error_node_for_syntax("missing let binding value", def_node, counter)
   }
-  { name: def.name(), init, start: def_node.start() }
+  let node = ProjNode::branch(
+    @ast.Term::LetDef(def.name(), init.kind),
+    def_node.start(),
+    def_node.end(),
+    [init],
+    counter,
+  )
+  { name: def.name(), node, start: def_node.start() }
 }
 
 ///|
@@ -88,10 +95,13 @@ fn module_node_from_defs(
   end : Int,
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  let children : Array[ProjNode[@ast.Term]] = defs.map(fn(d) { d.init })
+  let children : Array[ProjNode[@ast.Term]] = defs.map(fn(d) { d.node })
   children.push(body)
   let term_defs : Array[(@ast.VarName, @ast.Term)] = defs.map(fn(d) {
-    (d.name, d.init.kind)
+    match d.node.kind {
+      @ast.Term::LetDef(_, init) => (d.name, init)
+      _ => (d.name, Error("malformed LetDef"))
+    }
   })
   ProjNode::branch(Module(term_defs, body.kind), start, end, children, counter)
 }
@@ -237,10 +247,9 @@ pub fn syntax_to_proj_node(
 
 ///|
 /// Convert a SourceFile SyntaxNode (LetDef* Expression?) to a ProjNode tree.
-/// Collects LetDef children into a flat Module(defs, body) ProjNode,
-/// mirroring `syntax_node_to_term` but preserving spans and IDs.
-///
-/// LetDef children are collected into a single Module node with flat children.
+/// Collects LetDef children into a Module(defs, body) ProjNode whose children
+/// are first-class LetDef rows followed by the body expression, mirroring
+/// `syntax_node_to_term` while preserving spans and IDs.
 pub fn to_proj_node(
   root : @seam.SyntaxNode,
   counter : Ref[Int],

--- a/lang/lambda/proj/proj_node_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_wbtest.mbt
@@ -8,6 +8,10 @@ test "syntax_to_proj_node: block expression with def and body" {
       #|Module([("x", Int(1))], Var("x"))
     ),
   )
+  inspect(proj.children.length(), content="2")
+  inspect(proj.children[0].kind, content="LetDef(\"x\", Int(1))")
+  inspect(proj.children[0].children.length(), content="1")
+  inspect(proj.children[0].children[0].kind, content="Int(1)")
 }
 
 ///|

--- a/lang/lambda/proj/term_css_class.mbt
+++ b/lang/lambda/proj/term_css_class.mbt
@@ -5,7 +5,7 @@
 ///|
 /// Map a `Term` to its CSS class fragment for the outline
 /// `.tree-row.kind-<X>` selectors in `examples/ideal/web/styles/editor.css`.
-/// One-to-one with the 11 variants; lower-cased for consistency with the
+/// One-to-one with the 12 variants; lower-cased for consistency with the
 /// existing CSS taxonomy (`kind-lambda`, `kind-binop`, etc.).
 ///
 /// **Drift between this function and the CSS is not test-enforced** —
@@ -20,6 +20,7 @@ pub fn term_css_class(t : @ast.Term) -> String {
     App(_, _) => "app"
     Bop(_, _, _) => "binop"
     If(_, _, _) => "if"
+    @ast.Term::LetDef(_, _) => "let-def"
     Module(_, _) => "module"
     Unit => "unit"
     Unbound(_) => "unbound"

--- a/lang/lambda/proj/term_css_class_wbtest.mbt
+++ b/lang/lambda/proj/term_css_class_wbtest.mbt
@@ -1,4 +1,4 @@
-// Enumerate all 11 Term variants — pins the return strings. CSS-selector
+// Enumerate all 12 Term variants — pins the return strings. CSS-selector
 // coverage in editor.css is a manually maintained contract (not test-enforced).
 // See docs/plans/2026-05-16-show-unification.md (Task 1, PR 2).
 
@@ -49,6 +49,14 @@ test "term_css_class — If" {
 }
 
 ///|
+test "term_css_class — LetDef" {
+  inspect(
+    term_css_class(@ast.Term::LetDef("x", @ast.Term::Int(1))),
+    content="let-def",
+  )
+}
+
+///|
 test "term_css_class — Module" {
   inspect(
     term_css_class(@ast.Term::Module([], @ast.Term::Unit)),
@@ -90,6 +98,10 @@ test "term_kind_tag — forwards Renderable::kind_tag verbatim" {
   inspect(
     term_kind_tag(@ast.Term::App(@ast.Term::Var("f"), @ast.Term::Var("x"))),
     content="App",
+  )
+  inspect(
+    term_kind_tag(@ast.Term::LetDef("x", @ast.Term::Int(1))),
+    content="LetDef",
   )
   inspect(term_kind_tag(@ast.Term::Unit), content="Unit")
 }

--- a/lang/lambda/proj/token_roles.mbt
+++ b/lang/lambda/proj/token_roles.mbt
@@ -9,7 +9,13 @@
 pub const PARAM_ROLE : String = "param"
 
 ///|
+/// Role key for a `LetDef` node's binder name token.
+pub const LET_DEF_NAME_ROLE : String = "name"
+
+///|
 /// Role key for module def `def_index`'s name token (stored on the Module node).
+/// Compatibility fallback while callers migrate to `LET_DEF_NAME_ROLE` on the
+/// first-class LetDef node.
 pub fn module_name_role(def_index : Int) -> String {
   "name:" + def_index.to_string()
 }

--- a/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -35,8 +35,8 @@ test "go_to_definition: module def — body var jumps to the name token" {
 test "go_to_definition: shadowed module def — later def wins (production id path)" {
   // "let x = 1\nlet x = 2\nx" — name:0 "x" at 4..5, name:1 "x" at 14..15.
   // The body var (pos 20) resolves to def_index=1, so the binder span must be
-  // 14..15, NOT 4..5. This exercises the module-def binder whose production
-  // FlatProj id was synthetic — the case Option D fixes.
+  // 14..15, NOT 4..5. This exercises the module-def binder through the
+  // production FlatProj/LetDef id path while Option D supplies the token span.
   let (g, sm) = build_fixture_with_spans("let x = 1\nlet x = 2\nx")
   guard go_to_definition(g, sm, 20) is Some(r)
   inspect(r.start, content="14")

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -30,14 +30,14 @@ pub(all) struct Scope {
 ///|
 /// A declaration (binding site). A binder's LOCATION is its source span,
 /// recovered uniformly via `binder_span` (which reads `SourceMap` token spans),
-/// not via `node_id`:
+/// not by interpreting `node_id` as a source range:
 /// - lambda param: the `"param"` token span on the `Lam` node (`kind`'s `lam_id`).
-/// - module def: the `"name:<def_index>"` token span on the module node
-///   (`ScopeGraph::module_node_id`).
-/// `node_id` is retained only as an internal dedup/identity handle. It is NOT a
-/// reliable tree-node pointer for module defs (on the production `to_flat_proj`
-/// path it is a synthetic id occupying no registry node), so consumers needing
-/// to locate a binder MUST use `binder_span`, never `node_id`.
+/// - module def: the `"name"` token span on the first-class `LetDef` node,
+///   with the module node's `"name:<def_index>"` span retained as a migration
+///   fallback.
+/// `node_id` is the declaration's structural identity; for module definitions it
+/// now points at the real `LetDef` projection node. Consumers needing to locate
+/// a binder should still use `binder_span`, never the full node range.
 pub(all) struct Decl {
   id : DeclId
   node_id : @core.NodeId
@@ -69,10 +69,11 @@ pub(all) struct Resolution {
 
 ///|
 /// The binding index for one lambda module.
-/// `module_node_id` is the root projection node that owns the module-def name
-/// token spans (`"name:<def_index>"` in the `SourceMap`); `binder_span` reads
-/// them through it. For a bare-expression program (no defs) it is the root
-/// expression node and the name-span path is never exercised.
+/// `module_node_id` is the root projection node that owns compatibility
+/// module-def name token spans (`"name:<def_index>"` in the `SourceMap`). The
+/// canonical module-def binder span lives on each `LetDef` node. For a
+/// bare-expression program (no defs), this is the root expression node and the
+/// name-span path is never exercised.
 pub(all) struct ScopeGraph {
   scopes : Array[Scope]
   decls : Array[Decl]

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -15,9 +15,9 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
 /// All reference NodeIds whose resolution points at the declaration `decl`.
 /// Identity-based (keyed on `DeclId`, NOT a name match), so shadowing is
 /// respected. Keying on `DeclId` rather than `Decl.node_id` is deliberate:
-/// a module def's `node_id` is a synthetic, non-tree handle (see `Decl`), so a
-/// `NodeId`-keyed lookup silently preserved that broken contract. `DeclId` is
-/// the stable graph-local identity (`declaration(..).id` yields it).
+/// references resolve to declarations, not to whichever structural node id a
+/// declaration currently uses. `DeclId` is the stable graph-local identity
+/// (`declaration(..).id` yields it).
 pub fn references(g : ScopeGraph, decl : DeclId) -> Array[@core.NodeId] {
   [
     for r in g.refs if r.resolution.decl is Some(rid) && rid == decl => {
@@ -32,7 +32,8 @@ pub fn references(g : ScopeGraph, decl : DeclId) -> Array[@core.NodeId] {
 /// `populate_token_spans`). This is the uniform "where is this binder?" primitive
 /// for go-to-definition, binder highlighting, and rename:
 /// - lambda param: the `"param"` token span on the `Lam` node;
-/// - module def: the `"name:<def_index>"` token span on `module_node_id`.
+/// - module def: the `"name"` token span on the `LetDef` node, with the
+///   module-level `"name:<def_index>"` span as a migration fallback.
 /// Failure is always `None`, never a wrong location.
 pub fn binder_span(
   g : ScopeGraph,
@@ -43,10 +44,15 @@ pub fn binder_span(
     LamParam(lam_id~) =>
       source_map.get_token_span(lam_id, @lambda_proj.PARAM_ROLE)
     ModuleDef(def_index~) =>
-      source_map.get_token_span(
-        g.module_node_id,
-        @lambda_proj.module_name_role(def_index),
-      )
+      match
+        source_map.get_token_span(decl.node_id, @lambda_proj.LET_DEF_NAME_ROLE) {
+        Some(range) => Some(range)
+        None =>
+          source_map.get_token_span(
+            g.module_node_id,
+            @lambda_proj.module_name_role(def_index),
+          )
+      }
   }
 }
 

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -66,6 +66,10 @@ fn analyze_node(
       analyze_lambda(node, source_map, param, env, projection)
     @ast.Term::Var(name) | @ast.Term::Unbound(name) =>
       analyze_var(node, source_map, name, env, projection)
+    @ast.Term::LetDef(_, _) =>
+      for child in node.children {
+        analyze_node(child, source_map, env, projection, None)
+      }
     @ast.Term::App(_, _) | @ast.Term::Bop(_, _, _) =>
       for child in node.children {
         analyze_node(child, source_map, env, projection, None)
@@ -93,14 +97,23 @@ fn analyze_module(
   let scoped = env.copy()
   for i, def in defs {
     let name = def.0
-    let binder_id = module_binding_node_id(flat_proj, i).unwrap_or(node.id())
+    let binder_id = if i < node.children.length() {
+      node.children[i].id()
+    } else {
+      module_binding_node_id(flat_proj, i).unwrap_or(node.id())
+    }
     add_annotation(
       projection,
       binder_id,
       @protocol.ViewAnnotation(kind="semantic-binder", label="let " + name),
     )
-    match
-      source_map.get_token_span(node.id(), @lambda_proj.module_name_role(i)) {
+    let binder_span = match
+      source_map.get_token_span(binder_id, @lambda_proj.LET_DEF_NAME_ROLE) {
+      Some(range) => Some(range)
+      None =>
+        source_map.get_token_span(node.id(), @lambda_proj.module_name_role(i))
+    }
+    match binder_span {
       Some(range) =>
         add_decoration(
           projection,

--- a/projection/proj_node_json_test.mbt
+++ b/projection/proj_node_json_test.mbt
@@ -48,7 +48,7 @@ test "ProjNode JSON export for module" {
   inspect(
     proj.to_json().stringify(),
     content=(
-      #|{"node_id":2,"kind":["Module",[["x",["Int",1]]],["Var","x"]],"children":[{"node_id":0,"kind":["Int",1],"children":[],"start":7,"end":9},{"node_id":1,"kind":["Var","x"],"children":[],"start":10,"end":11}],"start":0,"end":11}
+      #|{"node_id":3,"kind":["Module",[["x",["Int",1]]],["Var","x"]],"children":[{"node_id":1,"kind":["LetDef","x",["Int",1]],"children":[{"node_id":0,"kind":["Int",1],"children":[],"start":7,"end":9}],"start":0,"end":9},{"node_id":2,"kind":["Var","x"],"children":[],"start":10,"end":11}],"start":0,"end":11}
     ),
   )
 }

--- a/projection/source_map_token_spans_wbtest.mbt
+++ b/projection/source_map_token_spans_wbtest.mbt
@@ -69,9 +69,14 @@ test "token span: let def name" {
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   let module_id = proj.id()
-  guard sm.get_token_span(module_id, "name:0") is Some(span)
+  let let_def_id = proj.children[0].id()
+  guard sm.get_token_span(let_def_id, @lambda_proj.LET_DEF_NAME_ROLE)
+    is Some(span)
   inspect(span.start, content="4")
   inspect(span.end, content="5")
+  guard sm.get_token_span(module_id, "name:0") is Some(fallback)
+  inspect(fallback.start, content="4")
+  inspect(fallback.end, content="5")
 }
 
 ///|
@@ -84,13 +89,17 @@ test "token span: multiple let defs" {
   @lambda_proj.populate_token_spans(sm, syntax, proj)
   let module_id = proj.id()
   // First let: "x" at position 4..5
-  guard sm.get_token_span(module_id, "name:0") is Some(x_span)
+  guard sm.get_token_span(proj.children[0].id(), @lambda_proj.LET_DEF_NAME_ROLE)
+    is Some(x_span)
   inspect(x_span.start, content="4")
   inspect(x_span.end, content="5")
   // Second let: "y" at position 14..15
-  guard sm.get_token_span(module_id, "name:1") is Some(y_span)
+  guard sm.get_token_span(proj.children[1].id(), @lambda_proj.LET_DEF_NAME_ROLE)
+    is Some(y_span)
   inspect(y_span.start, content="14")
   inspect(y_span.end, content="15")
+  guard sm.get_token_span(module_id, "name:0") is Some(_)
+  guard sm.get_token_span(module_id, "name:1") is Some(_)
 }
 
 ///|
@@ -106,18 +115,21 @@ test "token span: no token spans for simple expression" {
 
 ///|
 test "token span: lambda inside let def" {
-  // let f = λx.x\nf — both "name:0" and lambda "param" should be recorded
+  // let f = λx.x\nf — both LetDef "name" and lambda "param" should be recorded
   let text = "let f = \u{03BB}x.x\nf"
   let syntax = parse_syntax_for_token_test(text)
   let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
   let sm = SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(sm, syntax, proj)
-  // Module node should have "name:0"
+  // LetDef node should have canonical "name" plus module fallback "name:0".
   let module_id = proj.id()
+  let let_def = proj.children[0]
+  guard sm.get_token_span(let_def.id(), @lambda_proj.LET_DEF_NAME_ROLE)
+    is Some(_)
   guard sm.get_token_span(module_id, "name:0") is Some(_)
-  // The lambda (child 0 of Module = init of first def) should have "param"
-  let lambda_node = proj.children[0]
+  // The lambda (child 0 of LetDef = init of first def) should have "param"
+  let lambda_node = let_def.children[0]
   guard sm.get_token_span(lambda_node.id(), "param") is Some(param_span)
   // λ is at position 8, x is at position 9..10
   inspect(param_span.start, content="9")


### PR DESCRIPTION
## Summary

- Resolves #127 by projecting lambda module bindings as first-class `LetDef` ProjNodes, so `Module` children are `[LetDef..., body]` instead of initializer-only rows.
- Preserves Option D for source locations: binder lookup still goes through `binder_span` / token spans, with `LetDef` role `"name"` canonical and module `name:<i>` fallback retained.
- Updates scope annotations, semantic projection, tree edits, drag/drop, web PM conversion/reconciliation, and tests for whole-binding structural editing.

Depends on dowdiness/loom#209 (submodule commit `29432ae`), which depends on dowdiness/egraph#14.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceMap::set_span_from_token` / `get_token_span` | `core/source_map.mbt` | Yes | Used for canonical `LetDef` binder spans and retained module fallback spans. |
| `@scope.binder_span` / `go_to_definition` | `lang/lambda/scope/query.mbt` | Yes | Kept as the only source-location API; updated to prefer `LetDef` token spans. |
| `FlatProj::from_proj_node` / `to_proj_node_with_prev_module_id` | `lang/lambda/proj/flat_proj.mbt` | Yes | Extended to read/write first-class `LetDef` rows while retaining legacy init-child fallback. |
| `binding_delete_range` | `lang/lambda/edits/text_edit_utils.mbt` | Yes | Reused for whole-row LetDef drag/drop deletion. |
| Generic ProjNode child diff | `examples/ideal/web/src/reconciler.ts` | Yes | Module now has 1:1 children, so the old synthesized Module diff path was removed. |

New helpers added (if any):

- `collect_token_spans_let_def` (`lang/lambda/proj/populate_token_spans.mbt`): private helper limited to recording one LetDef row's canonical/fallback name spans and recursing into its initializer; traversal/index policy remains with callers.
- `setEditorText` (`examples/ideal/web/e2e/drag-drop.spec.ts`): test-only helper for loading a small deterministic let-binding fixture before drag/drop assertions.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`moon build --target js`, `scripts/build-js.sh`, and `cd examples/ideal/web && npm run build`)

## Validation

```bash
moon check
moon test
moon build --target js
scripts/build-js.sh
cd examples/ideal/web && npm ci
cd examples/ideal/web && npm run build
cd examples/ideal/web && npm run test -- e2e/drag-drop.spec.ts
cd loom/examples/lambda && rtk moon check
cd loom/examples/lambda && rtk moon test
cd loom/examples/lambda && rtk moon info
cd loom/egraph && NEW_MOON_MOD=0 moon check
cd loom/egraph && NEW_MOON_MOD=0 moon test
cd loom/egraph && NEW_MOON_MOD=0 moon info
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Let definitions are now treated as first-class entities with improved structural editing support, enabling more reliable drag-drop operations and binding actions.
  * Enhanced binding-level actions (rename, duplicate, move up/down, inline, delete) now properly activate for let definitions.

* **Bug Fixes**
  * Improved scope annotation and binder highlighting for module-level let definitions.
  * Fixed drag-drop behavior to correctly move entire let definitions rather than partial content.

* **Tests**
  * Added comprehensive test coverage for let-definition drag-drop operations and binding actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->