### PR TITLE
docs(perf): BAND 2b JS-target addendum — cliff #1 reproduces, mechanism corrected

### DIFF
--- a/docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md
+++ b/docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md
@@ -154,14 +154,243 @@ idea, not an implementation — any follow-up fixes are tracked as separate issu
 3. These are 1000-def figures; if real-world documents stay under ~320 defs,
    neither cliff is worth optimizing (320-def keystroke = 604 µs).
 
+## JS-target measurement + mechanism confirmation (2026-06-01 addendum)
+
+Caveat 1 (deployment target) and caveat 2 (cliff #1 mechanism unproven) above are
+now resolved. Canopy ships to the **web (JS)**; the wasm-gc numbers needed a JS
+cross-check before any fix could be greenlit, and the doc's mechanism claim was a
+flagged hypothesis. Both were measured on the JS backend (`moon build --target js`,
+Node v24 `performance.now()` harness — see Reproduce). **Still no optimization code.**
+
+### Cliff #1 REPRODUCES on JS — V8 does not rescue it
+
+JS is within ~10–15% of wasm-gc at every size; the cliff is essentially identical.
+
+| Defs | unchanged JS / wasm | tail JS / wasm | shifted JS / wasm |
+|------|--------------------:|---------------:|------------------:|
+| 20   |    6.11 / 6.22 µs   |  14.1 / 14.7 µs |  15.9 / 17.8 µs   |
+| 80   |   36.8 / 38.5 µs    |  64.7 / 76.9 µs |  66.5 / 71.5 µs   |
+| 320  |    404 / 418 µs     |   515 / 604 µs  |   289 / 345 µs    |
+| 1000 |  **3.61 / 3.72 ms** | **3.97 / 4.50 ms** | **1.03 / 1.13 ms** |
+
+The realistic 1000-def tail keystroke is **3.97 ms on JS**. The gate's
+microsecond STOP-branch is not triggered. Cliff #1 is a real JS-target concern.
+
+### Mechanism CORRECTED — the doc's hypothesis was wrong twice over
+
+The hypothesis above (lines 95–101) — "per-call `start()` / `cst_node()` cost
+that grows with a node's position … tied to the source-span left-spine token
+walk" — is **disproven**:
+
+1. **`start()` and `cst_node()` are O(1) field reads** (`self.offset`,
+   `self.cst` — `loom/seam/syntax_node.mbt:160-164, 525-533`). They cannot be
+   the source of any super-linearity. The shifted case (which short-circuits at
+   the `start()` field read, skipping the structural compare) confirms this: it
+   scales near-**linearly** at the top (320→1000 = 3.1× time for 3.1× defs).
+
+2. **The cost IS the structural `CstNode ==` of reused defs** (the doc's
+   *attribution* was right; its *explanation* was not). Measured with the
+   realistic access pattern — sweep `a[i].cst_node() == b[i].cst_node()` over all
+   N **cold, independently-parsed** pairs once each:
+
+   | N | ns / def-compare |
+   |---|-----------------:|
+   | 80 | 345 |
+   | 320 | 1081 |
+   | 1000 | 3422 |
+
+   The full-sweep total at N=1000 (≈3.42 ms) ≈ the entire `unchanged` scan
+   (3.61 ms): the structural compare is ~95% of the scan. (A naïve probe that
+   compares the *same hot pair* 200 k× reports only ~65 ns — V8 caches it; that
+   number is an artifact, not the in-situ cost.)
+
+3. **The super-linearity is cache-bound, not algorithmic.** Each def's CST
+   subtree is **flat and fixed-size = 9 nodes** at every position (probe 3:
+   def 0/250/500/999 all = 9; root has 1001 flat children). So each deep compare
+   does **O(1) work** (~9 node visits, no short-circuit since `physical_equal`
+   fails across two parses and the hashes match). Yet per-def wall-clock grows
+   ~linearly with N (345→3422 ns). The driver is **memory locality**:
+   `a` and `b` come from two independent parses, so each compare chases pointers
+   into two scattered heap regions whose combined working set outgrows cache as
+   N rises → cache-miss rate per compare grows ~linearly → **O(N²) wall-clock
+   from O(N) work**. Both GC'd backends (V8, wasm-gc) show it for the same
+   pointer-chasing reason. (`children()` materialization is genuinely O(N):
+   4.1 / 16.7 / 54.4 µs at 80/320/1000 — a real but minor ~1.5% slice.)
+
+### Implication for any future fix (design NOT started)
+
+`physical_equal` already collapses this exact compare to O(1) **during the
+initial interned parse** (ADR `2026-03-14-physical-equal-interner.md`); it fails
+on the incremental keystroke path only because new and old trees come from two
+separate full parses that don't share interned identity. Two architecture-aligned
+levers therefore exist, both targeting the confirmed cost (not the disproven one):
+
+- **Extend cross-parse interning / subtree reuse** so unchanged def subtrees keep
+  one identity across keystrokes → `physical_equal` fires → O(1)/def. Aligned
+  with the existing `ReuseCursor` machinery; no correctness trade.
+- **Compare cached `hash` only**, skipping the deep walk. O(1) field read per def,
+  but the `CstNode::Eq` ADR (`cst_node.mbt:309-313`) *deliberately* does NOT
+  trust hash alone (collision-safety). Trusting it trades that guarantee — a
+  judgment call, not a free win.
+
+A "skip-when-unchanged / revision-stamp" optimization is therefore **viable and
+high-payoff** (it removes the cache-miss pointer chase that is ~95% of the cost),
+but the deep-compare-avoidance must be designed against the collision-safety
+invariant. **This remains an evidence gate; any such fix is a separate, greenlit
+issue.**
+
 ## Artifacts
 
 - `projection/flat_proj_incremental_benchmark_wbtest.mbt` (12 benches + 3 controls)
 - `projection/reconcile_lcs_benchmark_wbtest.mbt` (4 benches + 1 control)
+- JS-target harness: a throwaway `cmd/jsbench` main package (deleted after this
+  measurement). Full source in the Reproduce section below — recreate to re-run.
 
 ## Reproduce
+
+wasm-gc baseline + controls:
 
 ```bash
 NEW_MOON_MOD=0 moon bench --release --package dowdiness/canopy/projection
 NEW_MOON_MOD=0 moon test --package dowdiness/canopy/projection -f "control:*"
 ```
+
+JS-target measurement (recreate the throwaway harness, then run on Node):
+
+```bash
+mkdir -p cmd/jsbench
+cat > cmd/jsbench/moon.pkg <<'PKG'
+import {
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/lambda" @parser,
+  "dowdiness/seam",
+}
+
+options(
+  "is-main": true,
+)
+PKG
+# cmd/jsbench/main.mbt — full source below, then:
+NEW_MOON_MOD=0 moon run --target js --release ./cmd/jsbench
+rm -rf cmd/jsbench   # throwaway; do not commit
+```
+
+<details><summary><code>cmd/jsbench/main.mbt</code> (JS evidence harness — full scan + 3 mechanism probes)</summary>
+
+```moonbit
+/// performance.now() — milliseconds, monotonic, sub-µs resolution. Node global.
+extern "js" fn js_now_ms() -> Double =
+  #| function() { return performance.now(); }
+
+/// Verbatim copy of projection/tree_refresh_benchmark_wbtest.mbt's source
+/// generator (a wbtest fn, not public) so the JS scenario is byte-identical.
+fn bench_source(let_count : Int, tail_literal : String) -> String {
+  let segments : Array[String] = []
+  for i = 0; i < let_count - 1; i = i + 1 {
+    segments.push("let x\{i} = \{i}")
+  }
+  segments.push("let x\{let_count - 1} = \{tail_literal}")
+  segments.push("x\{let_count - 1}")
+  segments.join("\n")
+}
+
+fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
+  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  @seam.SyntaxNode::from_cst(cst)
+}
+
+/// Setup OUTSIDE the timed loop, time only to_flat_proj_incremental. Fresh
+/// Ref(1000) per call, matching bench_fp_incr.
+fn run_scenario(
+  name : String, defs : Int, old_src : String, new_src : String, iters : Int,
+) -> Unit raise {
+  let old_root = parse_syntax(old_src)
+  let old_fp = @lambda_proj.to_flat_proj(old_root, Ref(0))
+  let new_root = parse_syntax(new_src)
+  let mut sink = 0
+  for _ in 0..<25 {
+    let r = @lambda_proj.to_flat_proj_incremental(new_root, old_root, old_fp, Ref(1000))
+    sink = sink + r.defs.length()
+  }
+  let t0 = js_now_ms()
+  for _ in 0..<iters {
+    let r = @lambda_proj.to_flat_proj_incremental(new_root, old_root, old_fp, Ref(1000))
+    sink = sink + r.defs.length() // accumulate to defeat dead-code elimination
+  }
+  let us_per = (js_now_ms() - t0) * 1000.0 / iters.to_double()
+  println("\{name} @ \{defs} defs: \{us_per} us/iter (sink=\{sink})")
+}
+
+/// PROBE 1 — structural CstNode== sweep over all N COLD pairs once (realistic).
+/// Per-def cost growing with N ⇒ cache-driven super-linear compare.
+fn probe_compare_cost() -> Unit raise {
+  println("=== probe 1: structural CstNode== SWEEP (all N pairs once) ===")
+  for n in [80, 320, 1000] {
+    let a = parse_syntax(bench_source(n, "0")).children()
+    let b = parse_syntax(bench_source(n, "0")).children()
+    let reps = if n >= 1000 { 400 } else { 2000 }
+    let mut acc = 0
+    for _ in 0..<20 {
+      for i in 0..<a.length() { if a[i].cst_node() == b[i].cst_node() { acc = acc + 1 } }
+    }
+    let t0 = js_now_ms()
+    for _ in 0..<reps {
+      for i in 0..<a.length() { if a[i].cst_node() == b[i].cst_node() { acc = acc + 1 } }
+    }
+    let total_us = (js_now_ms() - t0) * 1000.0 / reps.to_double()
+    println("  N=\{n}: \{total_us} us/sweep (\{total_us * 1000.0 / n.to_double()} ns/def, acc=\{acc})")
+  }
+}
+
+/// PROBE 2 — children() materialization scaling (the scan does it ×2/call).
+fn probe_children_cost() -> Unit raise {
+  println("=== probe 2: children() materialization scaling ===")
+  for n in [80, 320, 1000] {
+    let root = parse_syntax(bench_source(n, "0"))
+    let iters = if n >= 1000 { 2000 } else { 8000 }
+    let mut sink = 0
+    for _ in 0..<50 { sink = sink + root.children().length() }
+    let t0 = js_now_ms()
+    for _ in 0..<iters { sink = sink + root.children().length() }
+    println("  children() @ \{n}: \{(js_now_ms() - t0) * 1000.0 / iters.to_double()} us/call (sink=\{sink})")
+  }
+}
+
+fn subtree_size(n : @seam.CstNode) -> Int {
+  let mut total = 1
+  for child in n.children {
+    match child {
+      @seam.CstElement::Node(c) => total = total + subtree_size(c)
+      @seam.CstElement::Token(_) => total = total + 1
+    }
+  }
+  total
+}
+
+/// PROBE 3 — flat (fixed subtree size ⇒ cache effect) vs nested (⇒ algorithmic O(N²)).
+fn probe_subtree_shape() -> Unit raise {
+  let kids = parse_syntax(bench_source(1000, "0")).children()
+  println("=== probe 3: per-def CST subtree size (N=1000) ===")
+  println("  #children at root = \{kids.length()}")
+  for pos in [0, 250, 500, 999] {
+    println("  def \{pos}: subtree_size = \{subtree_size(kids[pos].cst_node())}")
+  }
+}
+
+fn main {
+  try {
+    probe_subtree_shape()
+    probe_compare_cost()
+    probe_children_cost()
+    println("=== cliff #1 to_flat_proj_incremental — JS backend (Node) ===")
+    let sizes = [(20, 5000), (80, 2000), (320, 500), (1000, 150)]
+    for sz in sizes { let (n, it) = sz; run_scenario("unchanged", n, bench_source(n, "0"), bench_source(n, "0"), it) }
+    for sz in sizes { let (n, it) = sz; run_scenario("tail     ", n, bench_source(n, "0"), bench_source(n, "1"), it) }
+    for sz in sizes { let (n, it) = sz; let base = bench_source(n, "0"); run_scenario("shifted  ", n, base, " " + base, it) }
+  } catch {
+    e => println("ERROR: \{e}")
+  }
+}
+```
+
+</details>

--- a/docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md
+++ b/docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md
@@ -239,6 +239,42 @@ but the deep-compare-avoidance must be designed against the collision-safety
 invariant. **This remains an evidence gate; any such fix is a separate, greenlit
 issue.**
 
+## Document-size gate → #449 PARKED (2026-06-01)
+
+The fix's payoff is **entirely gated on real document size**: the cliff only bites
+above ~500 defs, and the JS-target keystroke is sub-millisecond well below that
+(tail @80 = 64.7 µs, @320 = 515 µs — both inside a 16 ms frame; only @1000 reaches
+3.97 ms). So before designing lever-1, the prerequisite question is: **do real
+Canopy documents ever approach that scale?**
+
+A repo-wide survey of every realistic lambda/JSON document (default editor seeds,
+web example snippets, fixtures, demo source — explicitly excluding the synthetic
+`bench_source`-style 1000-def stress generators) found:
+
+| Kind | Largest real document | Size |
+|------|-----------------------|------|
+| Lambda | web "pipeline" example snippet; default seed (`examples/ideal/main/main.mbt:43`) is 2 | **4** top-level `let` defs |
+| JSON | `rabbita/doc/menu.json`; default seed (`examples/web/src/json-editor.ts:7`) is 1 key | **7** top-level elements |
+
+There are **no** `.lambda`/`.lam` fixture files in the repo; the high `let`-count
+files are `.mbt` test sources (MoonBit's own local bindings, not editor documents).
+**Nothing real approaches even 20 defs, let alone 320/500.** At 4 defs the structural
+compare costs single-digit microseconds — three orders of magnitude under the frame
+budget.
+
+**Decision: PARK #449. Do NOT implement.** The optimization is correct in the
+abstract (the cliff reproduces on JS, mechanism confirmed) but optimizes a regime
+no real document occupies — a 250×+ gap between the largest real doc (4 defs) and
+the cliff onset (~500 defs). Implementing now would add interning/revision-stamp
+complexity to the hot path for zero realized benefit, violating the
+microbenchmark-first / reproduce-the-bottleneck rule at the *document-scale* level.
+
+**Un-park trigger (unchanged from the existing >500-def trigger):** revisit #449
+only if real Canopy documents reach ~320+ defs — e.g. a generated/imported-document
+feature, a large-program demo, or telemetry showing user docs at that scale. The
+evidence (benches + JS harness recipe above) is preserved so the fix can be designed
+immediately if that day comes; only the *scale precondition* is missing today.
+
 ## Artifacts
 
 - `projection/flat_proj_incremental_benchmark_wbtest.mbt` (12 benches + 3 controls)


### PR DESCRIPTION
## What

Docs-only addendum to the BAND 2b decision record (`docs/performance/2026-06-01-band2-canopy-hotpath-baseline.md`), extending the #443 evidence gate onto the **JS deployment target** and recording the document-size gate that parks #449. **No optimization code — evidence gate only.**

## Findings

- **Cliff #1 (`to_flat_proj_incremental`) reproduces on JS**, within ~10–15% of wasm-gc (realistic tail keystroke = **3.97 ms @ 1000 defs**). V8 does not rescue it.
- **Mechanism corrected.** The earlier hypothesis ("per-position `start()`/`cst_node()` walk → O(N²)") is **disproven** — both are O(1) field reads. The cost is the structural `CstNode ==` of *successfully reused* defs (~95% of the scan). The super-linearity is **cache-bound, not algorithmic**.
- **Document-size gate:** real repo documents do not approach the cliff. Largest realistic lambda document found is **4** top-level `let` defs; largest JSON example is **7** top-level elements. #449 is therefore parked until real docs reach ~320+ defs.
- Records both fix levers and the throwaway JS-harness recipe for reproducibility if the scale precondition becomes true later.

## Follow-ups

- #449 — Cliff #1 fix is **parked** pending real document scale (~320+ defs / generated or imported large docs / telemetry).
- #450 — Cliff #2 remains low priority; off the lambda keystroke path and mitigated by `key_match`.

## Reuse check

No new code or types. Adds sections to an existing decision record. wasm-gc numbers were already in the doc; this adds the JS-target table, mechanism probes, and the document-size gate.

## Verification

Measurements via `moon build --target js` + Node v24 `performance.now()` harness (recipe embedded in the doc). Per `/moonbit-perf-investigation` Step 6 (deployment target). No source changed → no `moon check`/`moon test` impact.
