### PR TITLE
test(projection): thread id source forward in incremental bench setup

### DIFF
--- a/projection/module_projection_incremental_benchmark_wbtest.mbt
+++ b/projection/module_projection_incremental_benchmark_wbtest.mbt
@@ -36,17 +36,32 @@ fn fp_parse_syntax(text : String) -> @seam.SyntaxNode raise {
 // caller can flip exactly one same-width literal without shifting any offsets.
 
 ///|
-/// Build (new_root, old_root, old_fp) for a scenario. `old_fp` is the ModuleProjection
-/// of the old tree (the state carried between keystrokes); the bench then runs
-/// only the incremental scan against it.
+/// Build (new_root, old_root, old_fp, next_id) for a scenario. `old_fp` is the
+/// ModuleProjection of the old tree (the state carried between keystrokes); the
+/// bench then runs only the incremental scan against it. `next_id` is the
+/// id-source high-water mark left after building `old_fp` — production threads
+/// ONE counter forward (projection_memo.mbt:57,109: the prev build's
+/// `counter.val` becomes the next call's start), so the incremental call must
+/// resume from `next_id`, not a fixed constant that may not exceed the ids
+/// already allocated inside `old_fp` for larger fixtures.
+///
+/// Production advances that same counter a second time per edit, during the
+/// downstream proj_node materialization (projection_memo.mbt:139,144), so its
+/// real start id sits a little higher than `next_id` here. This bench isolates
+/// `to_module_projection_incremental` and never runs that materialization, so
+/// the only id invariant that matters is "resume above every id in `old_fp`" —
+/// which `counter.val` satisfies exactly. The absolute start value affects only
+/// which integers rebuilt nodes receive, not the scan cost or change detection
+/// (the positive controls below pin the latter independently of `next_id`).
 fn fp_incr_setup(
   old_src : String,
   new_src : String,
-) -> (@seam.SyntaxNode, @seam.SyntaxNode, @lambda_proj.ModuleProjection) raise {
+) -> (@seam.SyntaxNode, @seam.SyntaxNode, @lambda_proj.ModuleProjection, Int) raise {
   let old_root = fp_parse_syntax(old_src)
-  let old_fp = @lambda_proj.to_module_projection(old_root, Ref(0))
+  let counter = Ref(0)
+  let old_fp = @lambda_proj.to_module_projection(old_root, counter)
   let new_root = fp_parse_syntax(new_src)
-  (new_root, old_root, old_fp)
+  (new_root, old_root, old_fp, counter.val)
 }
 
 // --- Positive controls: confirm each scenario exercises the intended path ---
@@ -55,7 +70,7 @@ fn fp_incr_setup(
 
 ///|
 test "control: unchanged scenario reuses all defs (zero changed)" {
-  let (new_root, old_root, old_fp) = fp_incr_setup(
+  let (new_root, old_root, old_fp, next_id) = fp_incr_setup(
     tree_refresh_bench_source(80, "0"),
     tree_refresh_bench_source(80, "0"),
   )
@@ -64,7 +79,7 @@ test "control: unchanged scenario reuses all defs (zero changed)" {
     new_root,
     old_root,
     old_fp,
-    Ref(1000),
+    Ref(next_id),
     changed_indices=changed,
   )
   inspect(changed.val.length(), content="0")
@@ -72,7 +87,7 @@ test "control: unchanged scenario reuses all defs (zero changed)" {
 
 ///|
 test "control: tail scenario rebuilds exactly one def" {
-  let (new_root, old_root, old_fp) = fp_incr_setup(
+  let (new_root, old_root, old_fp, next_id) = fp_incr_setup(
     tree_refresh_bench_source(80, "0"),
     tree_refresh_bench_source(80, "1"),
   )
@@ -81,7 +96,7 @@ test "control: tail scenario rebuilds exactly one def" {
     new_root,
     old_root,
     old_fp,
-    Ref(1000),
+    Ref(next_id),
     changed_indices=changed,
   )
   // Only the last def (index 79) differs; the trailing expr keeps its offset.
@@ -91,13 +106,13 @@ test "control: tail scenario rebuilds exactly one def" {
 ///|
 test "control: shifted scenario blocks reuse for every entry" {
   let base = tree_refresh_bench_source(80, "0")
-  let (new_root, old_root, old_fp) = fp_incr_setup(base, " " + base)
+  let (new_root, old_root, old_fp, next_id) = fp_incr_setup(base, " " + base)
   let changed = Ref(([] : Array[Int]))
   let _ = @lambda_proj.to_module_projection_incremental(
     new_root,
     old_root,
     old_fp,
-    Ref(1000),
+    Ref(next_id),
     changed_indices=changed,
   )
   // 80 defs + final expr, all offset-shifted → none reused.
@@ -115,13 +130,13 @@ fn bench_fp_incr(
   old_src : String,
   new_src : String,
 ) -> Unit raise {
-  let (new_root, old_root, old_fp) = fp_incr_setup(old_src, new_src)
+  let (new_root, old_root, old_fp, next_id) = fp_incr_setup(old_src, new_src)
   b.bench(() => {
     let r = @lambda_proj.to_module_projection_incremental(
       new_root,
       old_root,
       old_fp,
-      Ref(1000),
+      Ref(next_id),
     )
     b.keep(r)
   })


### PR DESCRIPTION
## Summary

Fixes the CodeRabbit benchmark-fidelity finding from #452 (comment #2): the incremental-projection microbenchmark restarted the id counter at a fixed `Ref(1000)` for every incremental call, instead of threading the id source forward like production.

Production threads **one** counter forward (`lang/lambda/flat/projection_memo.mbt:57,109`): the prev build's `counter.val` becomes the next call's start. For larger fixtures `1000` may not exceed the ids already allocated inside `old_fp`, so the bench could re-allocate colliding ids. This is a **setup-fidelity** gap, not a perf regression — no production behavior changed.

## Change

- `fp_incr_setup` now builds `old_fp` from a `Ref(0)` counter and returns its high-water mark as a 4th tuple element `next_id`.
- The three positive-control tests and `bench_fp_incr` resume the incremental call from `Ref(next_id)` instead of `Ref(1000)`.
- The doc comment records the boundary surfaced in Codex review: production advances the same counter a *second* time during the downstream proj_node materialization (`projection_memo.mbt:139,144`), which this bench omits because it isolates `to_module_projection_incremental`. The only id invariant that matters here is "resume above every id in `old_fp`", which `counter.val` satisfies exactly. The absolute start value affects only which integers rebuilt nodes receive — not scan cost or change detection.

## Reuse check

No new functions/types. Reuses the existing `to_module_projection` / `to_module_projection_incremental` `Ref[Int]` counter API (signatures verified via `moon ide doc`); the fix only changes how the bench seeds that counter, mirroring the existing production threading in `projection_memo.mbt`.

## Verification

- `moon check --deny-warn` clean.
- `moon test -p projection`: **73/73 pass**. The positive controls (`0` / `[79]` / `81` changed) are unchanged, confirming change detection is invariant to the id start value.
- Codex pre-PR review (1 finding on the proj_node double-bump nuance, assessed immaterial and documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
