### PR TITLE
ci(benchmark): loosen editor-response p95 paint gate to 175ms on CI (#458)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,4 +193,15 @@ jobs:
           # at _build/js/release/build/main/main.js is never produced. Same
           # treatment as scripts/test-canvas-e2e.sh. Tracked as #335.
           MOON_WORK: off
+          # CI-only p95 paint budget (#458). The 100 ms local default
+          # (editor-response.perf.spec.ts:28) is too tight for shared runners:
+          # PR #453's build-inert diff flaked at 128-136 ms p95 from runner
+          # timing variance alone (attempt-2 re-run of the identical diff passed
+          # < 100 ms). 175 clears the observed flake ceiling (~29% headroom over
+          # 136) while staying below 2x the healthy < 100 ms baseline, so a
+          # genuine ~2x regression still trips the gate (positive-control
+          # verified). The tight local default is preserved. Single-run p95 is
+          # inherently noisy on shared infra; a robust median/trimmed-mean metric
+          # (#458 levers 2-3) is the durable follow-up.
+          EDITOR_RESPONSE_P95_BUDGET_MS: 175
         run: npm run test:perf


### PR DESCRIPTION
## Summary

Fixes the flaky `large text edit` p95 paint-latency gate in the **Editor Response Benchmark** job (#458). Sets a CI-only `EDITOR_RESPONSE_P95_BUDGET_MS=175` via the spec's existing env override; the tight `100 ms` local default (`editor-response.perf.spec.ts:28`) is preserved.

This is a **CI-budget / test-infra** fix. No production or projection code is touched — unrelated to the parked BAND-2b algorithm cliffs (#449/#450).

## Why it flaked

PR #453's only failing check was this job. Its diff was a single MoonBit `_wbtest.mbt` — excluded from `moon build --target js --release`, so build-inert (it can't reach the browser bundle the E2E paints). It flaked at **128–136 ms** p95; an **attempt-2 re-run of the identical diff passed <100 ms**. So the failure was shared-runner timing variance, not a regression.

## Why 175

| Constraint | Value | 175 |
|---|---|---|
| Observed CI flake ceiling (variance alone) | 128–136 ms | ✅ ~29% headroom over 136 |
| Healthy CI baseline (attempt-2 passed) | < 100 ms | — |
| Catch a genuine ~2× regression (2× baseline) | ~180–200 ms | ✅ stays below 2× → still trips |

175 is the value in the issue's 175–200 range that *both* clears the flake ceiling *and* stays under 2× the healthy baseline (200 would let a ~190 ms 2× regression of a ~95 ms baseline slip through).

## Positive control (acceptance criterion)

Ran the real E2E twice locally (release build + Playwright chromium); detector validated before trusting the looser null:

| Run | Injected stall | large p95 paint | Gate @175 | Exit |
|---|---|---|---|---|
| Baseline | none | **80.4 ms** | PASS | 0 |
| Regression | +120 ms real busy-wait in measured region (~2× the CI-target ~100 ms baseline) | **196.9 ms** | **FAIL** (`Expected < 175, Received 196.9`) | 1 |

The medium scenario (~168 ms regressed) still passed, so the firing assertion was specifically the `large text edit` gate — exactly the #458 scenario. The injection knob was a temporary env-gated busy-wait, fully reverted (no spec change in this PR).

## Caveat / follow-up

A fixed absolute budget can't be "2× baseline" across runners of differing speed, and single-run p95 is inherently noisy on shared infra. This is the lowest-risk stopgap (lever 1); the durable fix is a robust median/trimmed-mean metric over more samples (#458 levers 2–3), left as a separate follow-up.

## Reuse check

No new function, type, or helper introduced — reuses the spec's existing `EDITOR_RESPONSE_P95_BUDGET_MS` env hook. Single-line workflow env addition.

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
