### PR TITLE
feat(visualizer): bound IncrMemoEventTap event buffer (keep-last-per-cell)

### DIFF
--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -47,7 +47,11 @@ pub struct IncrSnapshot {
 pub struct IncrMemoEventTap {
   priv rt : @incr.Runtime
   priv active : Ref[Bool]
-  priv mut events : Array[IncrMemoEventRecord]
+  // Keep-last-per-cell status buffer: bounded by the number of distinct cells
+  // that fired events since the last drain, not by the total event count.
+  // Status coloring only needs each cell's most recent event, so retaining
+  // the latest per cell loses nothing while bounding memory.
+  priv events : @hashmap.HashMap[@incr.CellId, IncrMemoEventRecord]
   priv cells : Array[@incr.CellId]
 }
 
@@ -66,17 +70,6 @@ fn remember_cell(ids : Array[@incr.CellId], id : @incr.CellId) -> Unit {
   if !contains_cell_id(ids, id) {
     ids.push(id)
   }
-}
-
-///|
-fn copy_events(
-  events : Array[IncrMemoEventRecord],
-) -> Array[IncrMemoEventRecord] {
-  let out : Array[IncrMemoEventRecord] = []
-  for event in events {
-    out.push(event)
-  }
-  out
 }
 
 ///|
@@ -123,7 +116,7 @@ fn IncrMemoEventTap::record(
   guard self.active.val else { return }
   let record = event_from_memo_event(evt)
   remember_cell(self.cells, record.cell_id)
-  self.events.push(record)
+  self.events.set(record.cell_id, record)
 }
 
 ///|
@@ -177,17 +170,18 @@ fn status_for_cell(
   events : Array[IncrMemoEventRecord],
   id : @incr.CellId,
 ) -> VisualNodeStatus {
-  let mut status = Neutral
+  // The tap retains at most one record per cell (keep-last-per-cell), so the
+  // first match is the only match — return it directly.
   for event in events {
     if event.cell_id == id {
-      status = match event.phase {
+      return match event.phase {
         IncrEntering => Active
         IncrCompleted => if event.backdated { Neutral } else { Changed }
         IncrAborted => Failed
       }
     }
   }
-  status
+  Neutral
 }
 
 ///|
@@ -198,7 +192,7 @@ fn status_for_cell(
 pub fn IncrMemoEventTap::attach(
   rt : @incr.Runtime,
 ) -> IncrMemoEventTap raise Failure {
-  let tap = { rt, active: Ref(true), events: [], cells: [] }
+  let tap = { rt, active: Ref(true), events: @hashmap.HashMap([]), cells: [] }
   rt.on_memo_event(evt => tap.record(evt))
   tap
 }
@@ -214,12 +208,14 @@ pub fn IncrMemoEventTap::detach(self : IncrMemoEventTap) -> Unit {
 }
 
 ///|
-/// Drain captured events in arrival order.
+/// Drain the retained events — the most recent record per cell since the last
+/// drain — and clear the buffer. Order is unspecified (keyed by cell, not
+/// arrival); callers that only need per-cell status are unaffected.
 pub fn IncrMemoEventTap::drain_events(
   self : IncrMemoEventTap,
 ) -> Array[IncrMemoEventRecord] {
-  let drained = copy_events(self.events)
-  self.events = []
+  let drained = self.events.values().to_array()
+  self.events.clear()
   drained
 }
 
@@ -245,7 +241,7 @@ pub fn IncrMemoEventTap::snapshot(self : IncrMemoEventTap) -> IncrSnapshot {
       None => ()
     }
   }
-  { nodes, edges, events: copy_events(self.events) }
+  { nodes, edges, events: self.events.values().to_array() }
 }
 
 ///|

--- a/lib/visualizer/moon.pkg
+++ b/lib/visualizer/moon.pkg
@@ -3,4 +3,5 @@ import {
   "dowdiness/graphviz/lib/layout",
   "dowdiness/graphviz/lib/svg" @graph_svg,
   "dowdiness/incr",
+  "moonbitlang/core/hashmap",
 }

--- a/lib/visualizer/visualizer_test.mbt
+++ b/lib/visualizer/visualizer_test.mbt
@@ -29,7 +29,9 @@ test "incr_memo_event_tap_snapshots_runtime_graph" {
   let tap = @visualizer.IncrMemoEventTap::attach(rt)
   inspect(memo.read_or_abort(), content="2")
   let snapshot = tap.snapshot()
-  inspect(snapshot.events.length(), content="2")
+  // Keep-last-per-cell: the memo's EnteringCompute + Completed collapse to a
+  // single retained record for the one recomputed cell.
+  inspect(snapshot.events.length(), content="1")
   inspect(snapshot.nodes.length() >= 2, content="true")
   inspect(snapshot.edges.length() >= 1, content="true")
   let graph = snapshot.to_visual_graph()
@@ -46,13 +48,33 @@ test "incr_memo_event_tap_stale_detach_does_not_clear_newer_tap" {
   let newer = @visualizer.IncrMemoEventTap::attach(rt)
   inspect(memo.read_or_abort(), content="2")
   inspect(older.drain_events().length(), content="0")
-  inspect(newer.drain_events().length(), content="2")
+  // One recomputed cell → one retained record (keep-last-per-cell).
+  inspect(newer.drain_events().length(), content="1")
   older.detach()
   sig.set(2)
   inspect(memo.read_or_abort(), content="3")
-  inspect(newer.drain_events().length(), content="2")
+  inspect(newer.drain_events().length(), content="1")
   newer.detach()
   sig.set(3)
   inspect(memo.read_or_abort(), content="4")
   inspect(newer.drain_events().length(), content="0")
+}
+
+///|
+test "incr_memo_event_tap_buffer_is_bounded_per_cell" {
+  let rt = @incr.Runtime()
+  let sig = @incr.Signal(rt, 1, label="input")
+  let memo = @incr.Derived(rt, () => sig.get() + 1, label="sum")
+  let tap = @visualizer.IncrMemoEventTap::attach(rt)
+  // Drive several recomputes of the SAME memo without draining: each recompute
+  // emits EnteringCompute + Completed, so the unbounded log would hold 6 events.
+  inspect(memo.read_or_abort(), content="2")
+  sig.set(2)
+  inspect(memo.read_or_abort(), content="3")
+  sig.set(3)
+  inspect(memo.read_or_abort(), content="4")
+  // Keep-last-per-cell bounds the buffer to one entry per distinct cell.
+  let snapshot = tap.snapshot()
+  inspect(snapshot.events.length(), content="1")
+  tap.detach()
 }


### PR DESCRIPTION
## Summary

Bounds `IncrMemoEventTap`'s event buffer so it can no longer grow without limit.

The tap's `events` log was append-only (`Array[IncrMemoEventRecord]`), bounded only by the consumer draining after each snapshot — a consumer that snapshots without draining leaked unboundedly. Status coloring only ever uses each cell's **most recent** event (`status_for_cell` keeps the last match per cell), so the full arrival log was never needed.

Replace it with a `@hashmap.HashMap[@incr.CellId, IncrMemoEventRecord]` keyed by cell (keep-last-per-cell) — bounded by the number of distinct cells by construction, regardless of recompute count. The separate `cells` registry (persistent topology accumulator, never cleared) is intentionally left unchanged; only the transient status buffer changes.

Also simplifies `status_for_cell` to return on first match (the keep-last buffer holds ≤1 record per cell, so the old scan-all-and-overwrite fold was dead), and replaces the manual `copy_events` helper with the declarative `.values().to_array()`.

Closes #456.

## Behavior change (public surface)

`IncrSnapshot.events` and `drain_events()`'s returned `Array` now contain **one keep-last record per cell, in unspecified order**, instead of the full arrival-ordered event log. This is the intended effect of the bound, surfaced here explicitly rather than as a silent follow-up:

- **In-repo consumers are unaffected.** The only consumer (`examples/ideal`, #321) reads status per-cell via `to_visual_graph` (order-independent) and discards the `drain_events()` result.
- An external library consumer that read `snapshot.events` for an arrival-ordered timeline or to pair `EnteringCompute`↔`Completed` would now see collapsed, unordered records. No such consumer exists today.
- A deeper fix — making `IncrSnapshot.events` a keyed map so per-cell status is an O(1) lookup instead of flatten-then-rescan — is deferred to the timing work in #454, which reworks the snapshot→status path. The per-node rescan cost is tracked in #457.

## Reuse check

- Reused `moonbitlang/core/hashmap` (`@incr.CellId` already derives `Hash`; `workspace/coordinator` already keys a `HashMap` on `@incr.CellId`) — no new container type invented.
- Reused `Iter::to_array` for the map→array materialization instead of a hand-rolled loop.
- No new public editor or `incr` APIs added (per the issue constraint). Public `.mbti` is byte-stable.

## Verification

- `moon check --deny-warn`: clean
- visualizer package tests: 5/5 (added `incr_memo_event_tap_buffer_is_bounded_per_cell` — 6 events for one cell → 1 retained entry; updated the two existing count assertions to the keep-last semantics)
- workspace `moon test`: 1294/1294
- `examples/ideal/web` `incr-graph.spec.ts` Playwright e2e: passes (release build)
- `.mbti` diff: empty (public API unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
