### PR TITLE
perf(ci): robust 10% trimmed-mean metric for editor-response paint gate (#460)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,15 +193,18 @@ jobs:
           # at _build/js/release/build/main/main.js is never produced. Same
           # treatment as scripts/test-canvas-e2e.sh. Tracked as #335.
           MOON_WORK: off
-          # CI-only p95 paint budget (#458). The 100 ms local default
-          # (editor-response.perf.spec.ts:28) is too tight for shared runners:
-          # PR #453's build-inert diff flaked at 128-136 ms p95 from runner
-          # timing variance alone (attempt-2 re-run of the identical diff passed
-          # < 100 ms). 175 clears the observed flake ceiling (~29% headroom over
-          # 136) while staying below 2x the healthy < 100 ms baseline, so a
-          # genuine ~2x regression still trips the gate (positive-control
-          # verified). The tight local default is preserved. Single-run p95 is
-          # inherently noisy on shared infra; a robust median/trimmed-mean metric
-          # (#458 levers 2-3) is the durable follow-up.
-          EDITOR_RESPONSE_P95_BUDGET_MS: 175
+          # CI-only paint budget for the 10% trimmed-mean gate (#460, the durable
+          # fix for the single-run-p95 flakiness #458/#459 papered over with a 175
+          # ms p95 budget). The trimmed mean drops the 1-2 transient slow paints
+          # per run that made p95 noisy, so the gate tracks the runner's central
+          # latency. 130 is derived from the observed CI distribution (12 runs):
+          # worst central tendency ~95-97 ms plus ~3.5 sigma of the ~9.6 ms
+          # between-run baseline drift. It is a calibrated empirical ceiling (n=12,
+          # not a strong statistical bound) — meaningfully tighter than the old 175
+          # (catches a ~+37% regression on the ~95 ms CI baseline vs ~+119% before)
+          # while leaving ~35% headroom over the worst clean run. The 100 ms local
+          # default in the spec is preserved. Positive control: re-run with
+          # EDITOR_RESPONSE_INJECT_PAINT_MS set (e.g. 80) to confirm the gate still
+          # FAILS on a uniform ~2x paint regression.
+          EDITOR_RESPONSE_TRIMMED_MEAN_BUDGET_MS: 130
         run: npm run test:perf

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -24,6 +24,23 @@ type ResponseSummary = {
   phases: Record<string, Stats>;
 };
 
+// Read a numeric env override, falling back to `fallback` when unset/empty. A
+// malformed value (non-finite, e.g. "80ms" or a stray space) is a
+// misconfiguration: fail fast with a clear message rather than silently
+// coercing to NaN, which would disable the positive-control injection
+// (NaN > 0 is false) or produce a confusing toBeLessThan(NaN) failure.
+function numericEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number, got ${JSON.stringify(raw)}`);
+  }
+  return value;
+}
+
 const WARMUP_KEYSTROKES = 5;
 // 40 measured keystrokes so a 10% symmetric trim drops 4 samples per end and
 // averages the central 32. The bump from 30 firms up the central estimate; it
@@ -40,21 +57,19 @@ const TRIM_FRACTION = 0.1;
 // noisy tail (#460). Local default 100 ms is unchanged from the old local p95
 // default — the local trimmed mean is ~80 ms with ~1 ms spread, so 100 stays
 // tight without flaking. CI overrides this via benchmark.yml.
-const TRIMMED_MEAN_PAINT_BUDGET_MS = Number(
-  process.env.EDITOR_RESPONSE_TRIMMED_MEAN_BUDGET_MS ?? 100,
-);
+const TRIMMED_MEAN_PAINT_BUDGET_MS = numericEnv('EDITOR_RESPONSE_TRIMMED_MEAN_BUDGET_MS', 100);
 // Coarse catastrophe backstop on the single worst paint. Worst observed CI max
 // is ~133 ms, so 250 never flakes; it only trips on a severe single-paint blowup.
 // Intentionally loose — tightening it would reintroduce the single-sample
 // flakiness the trimmed-mean gate exists to remove.
-const MAX_PAINT_BUDGET_MS = Number(process.env.EDITOR_RESPONSE_MAX_BUDGET_MS ?? 250);
+const MAX_PAINT_BUDGET_MS = numericEnv('EDITOR_RESPONSE_MAX_BUDGET_MS', 250);
 // Positive-control harness (#460 / carried from #459). When set, a synchronous
 // busy-wait of this many ms is injected into the MEASURED paint region of every
 // keystroke (see measureTextInput), simulating a uniform paint regression. A
 // regression shifts all samples equally, so the trim does not remove it and the
 // trimmed mean rises by ~this value. Default 0 = off. Validate the detector with
 // e.g. EDITOR_RESPONSE_INJECT_PAINT_MS=80 (a ~2x local regression) -> gate FAILS.
-const INJECT_PAINT_MS = Number(process.env.EDITOR_RESPONSE_INJECT_PAINT_MS ?? 0);
+const INJECT_PAINT_MS = numericEnv('EDITOR_RESPONSE_INJECT_PAINT_MS', 0);
 
 async function waitForEditor(page: Page) {
   await page.goto(`/#perf-${Date.now()}`);
@@ -251,6 +266,11 @@ async function runScenario(page: Page, scenario: string, definitions: number): P
 
 test.describe('realistic editor response benchmark', () => {
   test('text-mode typing updates CRDT, projection, and browser paint within budget', async ({ page }) => {
+    // ~90 measureTextInput calls (warmup + measured, both scenarios), plus the
+    // optional positive-control busy-wait, can approach Playwright's 30s default
+    // on a slow runner or under an injected regression. Give headroom so a real
+    // slowdown surfaces as a trimmed-mean assertion failure, not a timeout kill.
+    test.setTimeout(60_000);
     await waitForEditor(page);
 
     const summaries = [
@@ -266,6 +286,9 @@ test.describe('realistic editor response benchmark', () => {
         samples: summary.samples,
         phases: summary.phases,
       })}`);
+      // Gated metrics: trimmedMean (primary, noise-robust) and max (catastrophe
+      // backstop). p50/p95/mean are computed and logged for observability only —
+      // do not assert on them without an empirical per-metric baseline.
       expect(
         summary.paint.trimmedMean,
         `${summary.scenario} trimmed-mean paint latency`,

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -118,7 +118,7 @@ async function seedEditor(page: Page, source: string) {
   await page.keyboard.press('Control+End');
 }
 
-async function measureTextInput(page: Page, text: string): Promise<ResponseSample> {
+async function measureTextInput(page: Page, text: string, injectMs: number = INJECT_PAINT_MS): Promise<ResponseSample> {
   return page.evaluate(({ insertText, injectPaintMs }) => new Promise<ResponseSample>((resolve, reject) => {
     const global = window as any;
     const cmContent = document.querySelector('#canopy-text-editor .cm-content') as HTMLElement | null;
@@ -194,7 +194,7 @@ async function measureTextInput(page: Page, text: string): Promise<ResponseSampl
       return;
     }
     requestAnimationFrame(poll);
-  }), { insertText: text, injectPaintMs: INJECT_PAINT_MS });
+  }), { insertText: text, injectPaintMs: injectMs });
 }
 
 function mean(values: number[]): number {
@@ -295,5 +295,61 @@ test.describe('realistic editor response benchmark', () => {
       ).toBeLessThan(TRIMMED_MEAN_PAINT_BUDGET_MS);
       expect(summary.paint.max, `${summary.scenario} max paint latency`).toBeLessThan(MAX_PAINT_BUDGET_MS);
     }
+  });
+
+  // Self-validating positive control. The trimmed-mean gate above is only a
+  // meaningful regression detector if an injected slowdown actually lands in
+  // the measured paint window. This test proves that on every run: it measures
+  // the same scenario clean vs. with CONTROL_INJECT_MS of injected paint work
+  // and asserts (a) the paint trimmed mean rises by ~CONTROL_INJECT_MS AND
+  // (b) text-change latency does NOT — which is only true if the injection sits
+  // in the paint region the gate measures. If a future refactor moves the
+  // injection out of that window or breaks the measurement, the delta collapses
+  // to ~0 and this test fails for the right reason (non-circular: it never
+  // asserts against a value derived from the path it is validating).
+  test('positive control: injected paint work raises measured paint latency, not text-change', async ({ page }) => {
+    test.setTimeout(60_000);
+    await waitForEditor(page);
+
+    const CONTROL_INJECT_MS = 80;
+    const CONTROL_SAMPLES = 12;
+
+    await seedEditor(page, lambdaSource(100));
+    for (let i = 0; i < WARMUP_KEYSTROKES; i += 1) {
+      await measureTextInput(page, 'a', 0);
+    }
+
+    const collect = async (injectMs: number): Promise<ResponseSample[]> => {
+      const out: ResponseSample[] = [];
+      for (let i = 0; i < CONTROL_SAMPLES; i += 1) {
+        out.push(await measureTextInput(page, 'a', injectMs));
+      }
+      return out;
+    };
+
+    const clean = await collect(0);
+    const injected = await collect(CONTROL_INJECT_MS);
+
+    const trimmed = (samples: ResponseSample[], select: (s: ResponseSample) => number) =>
+      stats(samples.map(select)).trimmedMean;
+    const paintDelta = trimmed(injected, (s) => s.inputToPaintMs) - trimmed(clean, (s) => s.inputToPaintMs);
+    const textDelta = trimmed(injected, (s) => s.inputToTextChangeMs) - trimmed(clean, (s) => s.inputToTextChangeMs);
+
+    console.log(`[editor-response-control] ${JSON.stringify({
+      injectMs: CONTROL_INJECT_MS,
+      paintDelta: Number(paintDelta.toFixed(2)),
+      textDelta: Number(textDelta.toFixed(2)),
+    })}`);
+
+    // Injection must show up in the measured paint latency (~CONTROL_INJECT_MS).
+    expect(
+      paintDelta,
+      'injected paint work must raise measured paint latency (detector lands in the measured window)',
+    ).toBeGreaterThan(CONTROL_INJECT_MS * 0.7);
+    // …and must NOT inflate text-change latency, proving it is paint-only.
+    expect(
+      Math.abs(textDelta),
+      'injection must not affect text-change latency (it targets the paint window only)',
+    ).toBeLessThan(CONTROL_INJECT_MS * 0.3);
   });
 });

--- a/examples/ideal/web/e2e/editor-response.perf.spec.ts
+++ b/examples/ideal/web/e2e/editor-response.perf.spec.ts
@@ -12,6 +12,7 @@ type Stats = {
   p95: number;
   max: number;
   mean: number;
+  trimmedMean: number;
 };
 
 type ResponseSummary = {
@@ -24,9 +25,36 @@ type ResponseSummary = {
 };
 
 const WARMUP_KEYSTROKES = 5;
-const MEASURED_KEYSTROKES = 30;
-const P95_PAINT_BUDGET_MS = Number(process.env.EDITOR_RESPONSE_P95_BUDGET_MS ?? 100);
+// 40 measured keystrokes so a 10% symmetric trim drops 4 samples per end and
+// averages the central 32. The bump from 30 firms up the central estimate; it
+// does NOT reduce the dominant between-run baseline drift (see #460 analysis).
+const MEASURED_KEYSTROKES = 40;
+// Drop the top and bottom TRIM_FRACTION of samples before averaging. This makes
+// the gate reject the 1-2 transient slow paints per run (GC / CPU-steal on
+// shared CI runners) that inflated the old single-run p95 metric, while
+// preserving systematic latency shifts — a real regression slows every paint, so
+// it survives the trim. See stats().
+const TRIM_FRACTION = 0.1;
+// Primary gate: 10% trimmed mean of paint latency. Replaces the old single-run
+// p95, which was the 2nd-highest of 30 samples and therefore dominated by the
+// noisy tail (#460). Local default 100 ms is unchanged from the old local p95
+// default — the local trimmed mean is ~80 ms with ~1 ms spread, so 100 stays
+// tight without flaking. CI overrides this via benchmark.yml.
+const TRIMMED_MEAN_PAINT_BUDGET_MS = Number(
+  process.env.EDITOR_RESPONSE_TRIMMED_MEAN_BUDGET_MS ?? 100,
+);
+// Coarse catastrophe backstop on the single worst paint. Worst observed CI max
+// is ~133 ms, so 250 never flakes; it only trips on a severe single-paint blowup.
+// Intentionally loose — tightening it would reintroduce the single-sample
+// flakiness the trimmed-mean gate exists to remove.
 const MAX_PAINT_BUDGET_MS = Number(process.env.EDITOR_RESPONSE_MAX_BUDGET_MS ?? 250);
+// Positive-control harness (#460 / carried from #459). When set, a synchronous
+// busy-wait of this many ms is injected into the MEASURED paint region of every
+// keystroke (see measureTextInput), simulating a uniform paint regression. A
+// regression shifts all samples equally, so the trim does not remove it and the
+// trimmed mean rises by ~this value. Default 0 = off. Validate the detector with
+// e.g. EDITOR_RESPONSE_INJECT_PAINT_MS=80 (a ~2x local regression) -> gate FAILS.
+const INJECT_PAINT_MS = Number(process.env.EDITOR_RESPONSE_INJECT_PAINT_MS ?? 0);
 
 async function waitForEditor(page: Page) {
   await page.goto(`/#perf-${Date.now()}`);
@@ -76,7 +104,7 @@ async function seedEditor(page: Page, source: string) {
 }
 
 async function measureTextInput(page: Page, text: string): Promise<ResponseSample> {
-  return page.evaluate((insertText) => new Promise<ResponseSample>((resolve, reject) => {
+  return page.evaluate(({ insertText, injectPaintMs }) => new Promise<ResponseSample>((resolve, reject) => {
     const global = window as any;
     const cmContent = document.querySelector('#canopy-text-editor .cm-content') as HTMLElement | null;
     const crdt = global.__canopy_crdt;
@@ -110,6 +138,16 @@ async function measureTextInput(page: Page, text: string): Promise<ResponseSampl
       const textChangedAt = performance.now();
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
+          // Positive-control injection: a synchronous busy-wait in the measured
+          // paint window simulates a uniform paint regression. Placed after
+          // textChangedAt so it affects only inputToPaintMs, not the text-change
+          // latency. No-op when injectPaintMs is 0 (the default).
+          if (injectPaintMs > 0) {
+            const spinUntil = performance.now() + injectPaintMs;
+            while (performance.now() < spinUntil) {
+              // busy-wait
+            }
+          }
           const perf = (window as any).__canopy_perf_current;
           const phases = { ...(perf?.spans ?? {}) };
           (window as any).__canopy_perf_current = null;
@@ -141,17 +179,26 @@ async function measureTextInput(page: Page, text: string): Promise<ResponseSampl
       return;
     }
     requestAnimationFrame(poll);
-  }), text);
+  }), { insertText: text, injectPaintMs: INJECT_PAINT_MS });
+}
+
+function mean(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 function stats(values: number[]): Stats {
   const sorted = [...values].sort((a, b) => a - b);
   const at = (q: number) => sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))];
+  // Symmetric trim: drop the lowest and highest `drop` samples, average the
+  // rest. `drop` is clamped so at least one sample always survives.
+  const drop = Math.min(Math.floor(sorted.length * TRIM_FRACTION), Math.floor((sorted.length - 1) / 2));
+  const trimmed = sorted.slice(drop, sorted.length - drop);
   return {
     p50: at(0.50),
     p95: at(0.95),
     max: sorted[sorted.length - 1],
-    mean: values.reduce((sum, value) => sum + value, 0) / values.length,
+    mean: mean(values),
+    trimmedMean: mean(trimmed),
   };
 }
 
@@ -161,6 +208,7 @@ function roundStats(s: Stats): Stats {
     p95: Number(s.p95.toFixed(2)),
     max: Number(s.max.toFixed(2)),
     mean: Number(s.mean.toFixed(2)),
+    trimmedMean: Number(s.trimmedMean.toFixed(2)),
   };
 }
 
@@ -218,7 +266,10 @@ test.describe('realistic editor response benchmark', () => {
         samples: summary.samples,
         phases: summary.phases,
       })}`);
-      expect(summary.paint.p95, `${summary.scenario} p95 paint latency`).toBeLessThan(P95_PAINT_BUDGET_MS);
+      expect(
+        summary.paint.trimmedMean,
+        `${summary.scenario} trimmed-mean paint latency`,
+      ).toBeLessThan(TRIMMED_MEAN_PAINT_BUDGET_MS);
       expect(summary.paint.max, `${summary.scenario} max paint latency`).toBeLessThan(MAX_PAINT_BUDGET_MS);
     }
   });


### PR DESCRIPTION
## What

Replaces the editor-response paint gate's noise-sensitive **single-run p95** with a **10% symmetric trimmed mean** — the durable fix (#460, levers 2-3) for the flakiness that #458/#459 papered over with a CI-only 175 ms p95 budget (lever 1).

`p95` over 30 samples is the 2nd-highest value, so 1-2 transient slow paints per run (GC / CPU-steal on shared CI runners) inflated it and tripped the gate. A trimmed mean drops those transient spikes while preserving systematic shifts — a real regression slows *every* paint, so it survives the trim.

## Evidence (drove the design)

Pulled 12 recent CI runs of the `large text edit` scenario (`benchmark.yml` Editor Response Benchmark job logs):

| metric | min | max | std | CV |
|--------|-----|-----|-----|-----|
| p50 (median) | 62.9 | 96.2 | 9.92 | 11.6% |
| **p95 (old gate)** | 78.7 | 116.7 | **12.38** | 12.7% |
| mean | 64.9 | 96.9 | **9.59** | 11.2% |
| max | 79.4 | 133.2 | 13.98 | 12.1% |

- **Tail spike is the flake driver:** within a single run, `p95 − p50` averages +11.3 ms and reaches +21.4 ms. In 4/12 runs p95 ≥ 113 ms while the same run's median was 82-96 ms.
- p95 is the **highest-variance** central metric; median and mean are ~20% more stable. A trimmed mean gets the mean's low variance *with* the median's outlier-robustness.
- Residual between-run **baseline drift** (median 63→96) is real and no within-run metric removes it — it sets the floor on how tight the budget can go.
- Local dev is near-noiseless (~1 ms spread, ~80 ms baseline), so the local default can stay tight.

## Changes

- **Metric:** gate on a 10% symmetric trimmed mean of paint latency (drop top/bottom 10%, clamped so ≥1 sample survives). `trimmedMean` is added to the logged `Stats` so future CI logs build the lever-3 distribution.
- **Samples:** 30 → 40 (10% trim drops 4/end, averages 32) to firm up the central estimate. (Does *not* reduce between-run drift — acknowledged.)
- **Budgets:** local default stays **100 ms** (don't regress the local signal). CI override drops **175 → 130**, derived from the observed CI distribution (worst central tendency ~95-97 ms + ~3.5σ of the ~9.6 ms baseline drift). Catches a ~+37% CI regression (vs ~+119% before) with ~35% headroom over the worst clean run. `max < 250` kept as a coarse single-paint catastrophe backstop.
- **Positive-control harness:** new env-gated `EDITOR_RESPONSE_INJECT_PAINT_MS` synchronously busy-waits in the *measured* paint window (after the text-change timestamp, before the paint timestamp), simulating a uniform paint regression. Promoted from #459's ad-hoc injection to a permanent, re-validatable detector.

## Validation (release build, chromium, local)

- **Null:** clean run large-text trimmed mean = **79.03 ms** → PASSES (< 100 / < 130).
- **Detector:** `EDITOR_RESPONSE_INJECT_PAINT_MS=80` (a ~2× regression) → trimmed mean **155.13 ms**, text-change latency unchanged → **FAILS** the 130 gate. Non-vacuous.

Reproduce the detector: `EDITOR_RESPONSE_TRIMMED_MEAN_BUDGET_MS=130 EDITOR_RESPONSE_INJECT_PAINT_MS=80 npm run test:perf`.

## Known tradeoff (Codex-flagged, accepted)

A regression affecting only ≤10% of paints gets trimmed away where p95 would catch it. For this workload a genuine projection/paint regression hits every keystroke uniformly (matching the busy-wait control); intermittent tail spikes are exactly the CI noise we mean to reject. The `max < 250` backstop catches catastrophic single paints. The 130 budget is a calibrated empirical ceiling (n=12), not a strong statistical bound.

## Reuse check

- Reused existing `stats()` / `roundStats()` / `summarize()` infrastructure — only added one field (`trimmedMean`) and the trim computation.
- Extracted a small `mean()` helper from the existing inline reduce so `mean` and `trimmedMean` share it (no behavior change to `mean`).
- Reused the existing env-gated-budget pattern (`Number(process.env.X ?? default)`) and the `measureTextInput` RAF measurement loop.
- Positive-control harness follows the #459 busy-wait pattern, promoted to a permanent env-gated form.
- No new MoonBit types/APIs (TS test-infra only). Renamed env var `EDITOR_RESPONSE_P95_BUDGET_MS` → `EDITOR_RESPONSE_TRIMMED_MEAN_BUDGET_MS`; only referenced in the spec + `benchmark.yml` (verified by grep).

Closes #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commits (post code review)

A high-effort `/code-review` pass (7 finder angles + verification) surfaced no new correctness bugs but several hardening/altitude items. Addressed in follow-up commits:

- **`numericEnv` boundary validation** — a malformed numeric env override (e.g. `80ms`, a stray space) previously coerced to `NaN`; for `EDITOR_RESPONSE_INJECT_PAINT_MS` that silently disabled the positive-control injection (`NaN > 0` is false), so a mistyped control run would *pass* when the operator expected failure. Now fails fast with a clear message; applied to all three env budgets.
- **`test.setTimeout(60_000)`** — the 30→40 keystroke bump narrowed the margin to Playwright's 30 s default; under a severe regression the test could be killed by an opaque timeout instead of surfacing a clean trimmed-mean assertion failure.
- **Gating-surface comment** — only `paint.trimmedMean` (primary) and `paint.max` (backstop) are asserted; `p50`/`p95`/`mean` are logged for observability. Prevents a future contributor adding an ungated metric assertion by analogy.
- **Self-validating positive control (review finding #1)** — a second in-spec test, run automatically in CI, that measures clean vs. injected (80 ms) and asserts paint `trimmedMean` rose by ~80 ms **and** text-change latency did not. This proves the injection lands in the measured paint window on every run. Verified non-circular/non-vacuous by mutation: with the busy-wait disabled, `paintDelta` collapses `73.51 → 0.46 ms` and the self-check fails for the right reason.

Not applied: the dead second term of the trim `drop` clamp was left as intentional defensiveness against future `MEASURED_KEYSTROKES`/`TRIM_FRACTION` edits.
