### PR TITLE
feat(visualizer): surface per-cell recompute timing in IncrGraph (#454)

### DIFF
--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -158,30 +158,62 @@ fn snapshot_node_label(node : IncrSnapshotNode) -> String {
 }
 
 ///|
-fn snapshot_node_detail(node : IncrSnapshotNode) -> String {
-  "changed " +
-  node.changed_at.value.to_string() +
-  ", verified " +
-  node.verified_at.value.to_string()
+/// Render a captured recompute duration with an ASCII unit chosen by magnitude
+/// (ns / us / ms). Truncating division drops sub-unit digits; the unit switch
+/// is the point — an `ms` node stands out against `us` neighbors as a hotspot.
+fn format_elapsed_ns(ns : Int64) -> String {
+  if ns < 1000L {
+    ns.to_string() + "ns"
+  } else if ns < 1_000_000L {
+    (ns / 1000L).to_string() + "us"
+  } else {
+    (ns / 1_000_000L).to_string() + "ms"
+  }
 }
 
 ///|
-fn status_for_cell(
+fn snapshot_node_detail(node : IncrSnapshotNode, elapsed_ns : Int64?) -> String {
+  let base = "changed " +
+    node.changed_at.value.to_string() +
+    ", verified " +
+    node.verified_at.value.to_string()
+  // Only recomputed cells carry a timing; pure dependency nodes that never
+  // fired an event omit it rather than show a misleading zero.
+  match elapsed_ns {
+    Some(ns) => base + ", " + format_elapsed_ns(ns)
+    None => base
+  }
+}
+
+///|
+/// Most recent event retained for `id`, if any.
+///
+/// The tap retains at most one record per cell (keep-last-per-cell), so this
+/// single scan returns that cell's only record — both its status and its
+/// latest `elapsed_ns` come from the one lookup.
+fn event_for_cell(
   events : Array[IncrMemoEventRecord],
   id : @incr.CellId,
-) -> VisualNodeStatus {
-  // The tap retains at most one record per cell (keep-last-per-cell), so the
-  // first match is the only match — return it directly.
+) -> IncrMemoEventRecord? {
   for event in events {
     if event.cell_id == id {
-      return match event.phase {
+      return Some(event)
+    }
+  }
+  None
+}
+
+///|
+fn record_status(record : IncrMemoEventRecord?) -> VisualNodeStatus {
+  match record {
+    Some(event) =>
+      match event.phase {
         IncrEntering => Active
         IncrCompleted => if event.backdated { Neutral } else { Changed }
         IncrAborted => Failed
       }
-    }
+    None => Neutral
   }
-  Neutral
 }
 
 ///|
@@ -249,12 +281,17 @@ pub fn IncrMemoEventTap::snapshot(self : IncrMemoEventTap) -> IncrSnapshot {
 pub fn IncrSnapshot::to_visual_graph(self : IncrSnapshot) -> VisualGraph {
   let graph = VisualGraph(id="incr")
   for node in self.nodes {
+    let record = event_for_cell(self.events, node.id)
+    let elapsed_ns = match record {
+      Some(event) => event.elapsed_ns
+      None => None
+    }
     graph.add_node(
       VisualNode(
         visual_cell_id(node.id),
         label=snapshot_node_label(node),
-        detail=snapshot_node_detail(node),
-        status=status_for_cell(self.events, node.id),
+        detail=snapshot_node_detail(node, elapsed_ns),
+        status=record_status(record),
       ),
     )
   }

--- a/lib/visualizer/incr_tap_wbtest.mbt
+++ b/lib/visualizer/incr_tap_wbtest.mbt
@@ -1,0 +1,60 @@
+///|
+/// `format_elapsed_ns` selects an ASCII unit (ns/us/ms) by magnitude so the
+/// unit switch itself reads as a hotspot cue. Wall-clock timing is
+/// non-deterministic, so the formatting logic is pinned here with fixed
+/// inputs rather than through a live tap.
+test "format_elapsed_ns_picks_unit_by_magnitude" {
+  inspect(format_elapsed_ns(0L), content="0ns")
+  inspect(format_elapsed_ns(500L), content="500ns")
+  // 1000ns is the ns→us boundary; truncating division drops sub-us digits.
+  inspect(format_elapsed_ns(1000L), content="1us")
+  inspect(format_elapsed_ns(1500L), content="1us")
+  inspect(format_elapsed_ns(999_999L), content="999us")
+  // 1_000_000ns is the us→ms boundary.
+  inspect(format_elapsed_ns(1_000_000L), content="1ms")
+  inspect(format_elapsed_ns(2_500_000L), content="2ms")
+}
+
+///|
+/// End-to-end wiring with a controlled `elapsed_ns`: the recomputed cell's
+/// duration reaches its node detail, while a node with no event record shows
+/// no timing. Constructed directly (not via a live tap) so the formatted value
+/// is deterministic — wall-clock timing can't be asserted from a real run.
+test "to_visual_graph surfaces latest elapsed_ns on the recomputed cell only" {
+  let timed_cell : @incr.CellId = { id: 1, runtime_id: 0 }
+  let untimed_cell : @incr.CellId = { id: 2, runtime_id: 0 }
+  let rev3 : @incr.Revision = { value: 3 }
+  let rev4 : @incr.Revision = { value: 4 }
+  let timed_node : IncrSnapshotNode = {
+    id: timed_cell,
+    label: Some("sum"),
+    changed_at: rev4,
+    verified_at: rev4,
+  }
+  let untimed_node : IncrSnapshotNode = {
+    id: untimed_cell,
+    label: Some("input"),
+    changed_at: rev3,
+    verified_at: rev3,
+  }
+  let event : IncrMemoEventRecord = {
+    cell_id: timed_cell,
+    phase: IncrCompleted,
+    started_revision: rev3,
+    elapsed_ns: Some(5000L),
+    verified_at: Some(rev4),
+    changed_at: Some(rev4),
+    backdated: false,
+  }
+  let snapshot : IncrSnapshot = {
+    nodes: [timed_node, untimed_node],
+    edges: [],
+    events: [event],
+  }
+  let dot = snapshot.to_visual_graph().to_dot()
+  // Timed cell: detail carries the formatted duration (5000ns → "5us").
+  inspect(dot.contains("verified 4, 5us"), content="true")
+  // Untimed cell: bare detail, no appended ", <unit>" timing segment.
+  inspect(dot.contains("changed 3, verified 3"), content="true")
+  inspect(dot.contains("verified 3, "), content="false")
+}


### PR DESCRIPTION
## Summary

Closes #454. Surfaces per-cell recompute timing (`elapsed_ns`) in the IncrGraph bottom-panel tab, turning a topology viewer into a recompute-**hotspot** viewer.

`IncrMemoEventTap` already captured `elapsed_ns` on every `Completed`/`Aborted` memo event, but it was **dead data** — read nowhere downstream. The node detail line showed only `changed N, verified M`. This threads the latest `elapsed_ns` per cell into the detail line.

## What changed

- `to_visual_graph` now does one `event_for_cell` lookup per node (replacing `status_for_cell`) and derives **both** the node status and its latest `elapsed_ns` from that single scan — complexity unchanged.
- `snapshot_node_detail(node, elapsed_ns)` appends an adaptive ASCII duration when present: `<1000`→`Nns`, `<1_000_000`→`Nus`, else `Nms`. The unit switch is the signal — an `ms` node stands out against `us` neighbors as a hotspot.
- Pure dependency nodes that never fired an event **omit** timing rather than show a misleading `0`. (After #456's keep-last-per-cell buffer, a recomputed cell's retained record is its `Completed`/`Aborted` event, which always carries `Some(elapsed_ns)`.)

## Scope / non-goals

- **Not** the deferred #457 perf work: the per-node lookup is still one linear scan, exactly as before — no index map, no `status_for_cell`/`snapshot_ids` optimization.
- No new public `incr`/editor APIs. The visualizer `.mbti` public surface is **unchanged** (all new functions are private).

## Reuse check

- Searched for an existing duration/ns formatter (`moon ide doc "*elapsed*"/"*duration*"`, grep of `lib/` and the `incr` mooncake): only raw-timing helpers (`elapsed_ns_from`) exist — no string formatter. `format_elapsed_ns` fills a visualization-specific gap and is self-contained.
- Reused the existing single-scan lookup pattern (one scan per node) rather than adding a second pass for timing; `record_status` consumes the same `IncrMemoEventRecord?` the detail path uses.
- `@incr.CellId`/`@incr.Revision` are `pub(all)` — reused directly to construct the deterministic wiring test (no new test helpers).

## Tests

- `format_elapsed_ns_picks_unit_by_magnitude` — boundary cases (`0ns`, `500ns`, `1000ns→1us`, `999_999→999us`, `1_000_000→1ms`, `2_500_000→2ms`). Wall-clock timing is non-deterministic, so the formatter is pinned with fixed inputs.
- `to_visual_graph surfaces latest elapsed_ns on the recomputed cell only` — controlled `elapsed_ns`, asserts the timed cell shows `verified 4, 5us` and the untimed cell shows no appended timing.
- Verified: `moon test` (native) **7/7**, `moon test --target js` **7/7** (Int64 division/`to_string` on the browser target), and `examples/ideal/web` `incr-graph.spec.ts` e2e **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
