### PR TITLE
ci: retry moon update on transient mooncakes CDN 403 (#467)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -183,7 +183,9 @@ jobs:
 
       - name: Update MoonBit dependencies
         working-directory: examples/ideal
-        run: moon update
+        # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+        run: |
+          "$GITHUB_WORKSPACE/scripts/moon-update.sh"
 
       - name: Run realistic editor response benchmark
         working-directory: examples/ideal/web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,9 @@ jobs:
 
       - name: Update MoonBit dependencies
         working-directory: lib/semantic/proof
-        run: moon update
+        # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+        run: |
+          "$GITHUB_WORKSPACE/scripts/moon-update.sh"
 
       - name: Run moon prove
         working-directory: lib/semantic/proof
@@ -181,7 +183,7 @@ jobs:
       - name: Run event-graph-walker benchmarks
         working-directory: event-graph-walker
         run: |
-          moon update
+          "$GITHUB_WORKSPACE/scripts/moon-update.sh"
           moon bench --release
 
   format-check:

--- a/scripts/moon-update.sh
+++ b/scripts/moon-update.sh
@@ -21,15 +21,18 @@
 set -uo pipefail
 
 MAX_ATTEMPTS="${MOON_UPDATE_MAX_ATTEMPTS:-3}"
+# BASE_DELAY=0 is a deliberate test affordance — the regression suite sets
+# MOON_UPDATE_RETRY_DELAY=0 to exercise the retry path without real sleeps. The
+# 5s default is what production CI uses; don't set 0 in a real workflow.
 BASE_DELAY="${MOON_UPDATE_RETRY_DELAY:-5}"
 
 # Fail fast on a misconfigured tunable rather than letting a nonnumeric value
 # make the bounded-attempt comparison error out and loop until the CI job times
-# out.
-case "$MAX_ATTEMPTS" in '' | *[!0-9]*) MAX_ATTEMPTS=bad ;; esac
-case "$BASE_DELAY" in *[!0-9]*) BASE_DELAY=bad ;; esac
-if [ "$MAX_ATTEMPTS" = bad ] || [ "$MAX_ATTEMPTS" -lt 1 ] || [ "$BASE_DELAY" = bad ]; then
-  echo "moon-update: MOON_UPDATE_MAX_ATTEMPTS (>=1) and MOON_UPDATE_RETRY_DELAY must be non-negative integers." >&2
+# out. MAX_ATTEMPTS must be a positive integer; BASE_DELAY a non-negative one.
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] ||
+  [ "$MAX_ATTEMPTS" -lt 1 ] ||
+  ! [[ "$BASE_DELAY" =~ ^[0-9]+$ ]]; then
+  echo "moon-update: MOON_UPDATE_MAX_ATTEMPTS (>=1) and MOON_UPDATE_RETRY_DELAY (>=0) must be integers." >&2
   exit 2
 fi
 
@@ -41,30 +44,30 @@ fi
 # stdout+stderr.
 TRANSIENT_RE='403 forbidden|429 too many requests|server error|connection (reset|refused|timed out)|could not resolve host|temporary failure in name resolution|network is unreachable|error sending request|operation timed out'
 
+# One tempfile for the whole run; `tee` truncates it each attempt. The trap
+# removes it on every exit path, including a signal kill mid-loop.
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
 attempt=1
 while :; do
-  log="$(mktemp)"
   moon update "$@" 2>&1 | tee "$log"
   status="${PIPESTATUS[0]}"
 
   if [ "$status" -eq 0 ]; then
-    rm -f "$log"
     exit 0
   fi
 
   if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
     echo "moon-update: failed after ${attempt} attempt(s) (exit ${status}); giving up." >&2
-    rm -f "$log"
     exit "$status"
   fi
 
   if ! grep -qiE "$TRANSIENT_RE" "$log"; then
     echo "moon-update: failure (exit ${status}) is not the transient CDN/network signature; not retrying." >&2
-    rm -f "$log"
     exit "$status"
   fi
 
-  rm -f "$log"
   delay=$(( BASE_DELAY * attempt ))
   echo "moon-update: transient CDN/network failure (exit ${status}); attempt ${attempt}/${MAX_ATTEMPTS}, retrying in ${delay}s..." >&2
   sleep "$delay"

--- a/scripts/moon-update.sh
+++ b/scripts/moon-update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Run `moon update` with bounded retries for the transient mooncakes CloudFront
+# CDN flake (issue #467): the CDN intermittently returns HTTP 403 for
+# symbols.zip during registry/symbol resolution. Identical re-runs always clear
+# it, so a small in-job retry auto-recovers without a manual "re-run failed
+# jobs".
+#
+# Discipline: only the known-transient CDN/network signature is retried. Any
+# other failure (a real toolchain or dependency error) exits immediately with
+# the original status, so a genuine break is never masked by retries.
+#
+# Runs `moon update` in the current working directory; callers cd into the
+# target module first (the registry it updates is global). Extra args are
+# forwarded to `moon update`.
+#
+# Tunables (env):
+#   MOON_UPDATE_MAX_ATTEMPTS  total attempts, including the first (default 3)
+#   MOON_UPDATE_RETRY_DELAY   base backoff seconds; delay = base * attempt (default 5)
+
+set -uo pipefail
+
+MAX_ATTEMPTS="${MOON_UPDATE_MAX_ATTEMPTS:-3}"
+BASE_DELAY="${MOON_UPDATE_RETRY_DELAY:-5}"
+
+# Fail fast on a misconfigured tunable rather than letting a nonnumeric value
+# make the bounded-attempt comparison error out and loop until the CI job times
+# out.
+case "$MAX_ATTEMPTS" in '' | *[!0-9]*) MAX_ATTEMPTS=bad ;; esac
+case "$BASE_DELAY" in *[!0-9]*) BASE_DELAY=bad ;; esac
+if [ "$MAX_ATTEMPTS" = bad ] || [ "$MAX_ATTEMPTS" -lt 1 ] || [ "$BASE_DELAY" = bad ]; then
+  echo "moon-update: MOON_UPDATE_MAX_ATTEMPTS (>=1) and MOON_UPDATE_RETRY_DELAY must be non-negative integers." >&2
+  exit 2
+fi
+
+# Signatures that are unambiguously transient infrastructure noise, never a code
+# or dependency-spec error. Keyed on transient HTTP status semantics (the issue
+# #467 403, plus 429 / 5xx) and network-layer failures — deliberately NOT the
+# generic "client error" (which also covers a deterministic 404 missing package
+# or 401) nor a bare "symbols.zip". Matched case-insensitively against combined
+# stdout+stderr.
+TRANSIENT_RE='403 forbidden|429 too many requests|server error|connection (reset|refused|timed out)|could not resolve host|temporary failure in name resolution|network is unreachable|error sending request|operation timed out'
+
+attempt=1
+while :; do
+  log="$(mktemp)"
+  moon update "$@" 2>&1 | tee "$log"
+  status="${PIPESTATUS[0]}"
+
+  if [ "$status" -eq 0 ]; then
+    rm -f "$log"
+    exit 0
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "moon-update: failed after ${attempt} attempt(s) (exit ${status}); giving up." >&2
+    rm -f "$log"
+    exit "$status"
+  fi
+
+  if ! grep -qiE "$TRANSIENT_RE" "$log"; then
+    echo "moon-update: failure (exit ${status}) is not the transient CDN/network signature; not retrying." >&2
+    rm -f "$log"
+    exit "$status"
+  fi
+
+  rm -f "$log"
+  delay=$(( BASE_DELAY * attempt ))
+  echo "moon-update: transient CDN/network failure (exit ${status}); attempt ${attempt}/${MAX_ATTEMPTS}, retrying in ${delay}s..." >&2
+  sleep "$delay"
+  attempt=$(( attempt + 1 ))
+done

--- a/scripts/run-moon-module.sh
+++ b/scripts/run-moon-module.sh
@@ -33,12 +33,13 @@ case "$ACTION" in
         moon fmt --check
         ;;
     ci)
-        moon update
+        # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+        "$SCRIPT_DIR/moon-update.sh"
         moon check "${DENY_WARN_FLAGS[@]}"
         moon test --release
         ;;
     bench)
-        moon update
+        "$SCRIPT_DIR/moon-update.sh"
         moon bench --release
         ;;
     *)

--- a/scripts/update-moon-deps.sh
+++ b/scripts/update-moon-deps.sh
@@ -2,8 +2,14 @@
 
 set -euo pipefail
 
-moon update
-cd event-graph-walker && moon update
-cd ../loom/loom && moon update
-cd ../../svg-dsl && moon update
-cd ../graphviz && moon update
+# Route every `moon update` through the retry wrapper so a transient mooncakes
+# CDN 403 (issue #467) auto-recovers instead of reddening CI. Absolute path so
+# it survives the `cd` into each submodule below.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+moon_update="$SCRIPT_DIR/moon-update.sh"
+
+"$moon_update"
+cd event-graph-walker && "$moon_update"
+cd ../loom/loom && "$moon_update"
+cd ../../svg-dsl && "$moon_update"
+cd ../graphviz && "$moon_update"


### PR DESCRIPTION
## Summary

Fixes #467. The mooncakes CloudFront CDN intermittently returns **HTTP 403** for `symbols.zip` during `moon update`, failing MoonBit CI jobs in the toolchain-setup phase before any test runs. Identical-commit re-runs always pass — transient infra noise, not a code regression — but it currently forces a manual `gh run rerun --failed` and turns clean PRs red.

This adds a bounded retry wrapper around the single chokepoint (`moon update`, which downloads `symbols.zip` into the global `~/.moon` registry) and routes every PR-gating call site through it.

## What changed

- **`scripts/moon-update.sh`** (new) — runs `moon update` with up to 3 attempts and linear backoff. It **only** retries the transient CDN/network signature (`403 Forbidden` / `429` / `5xx server error` / connection / DNS errors). Any other failure exits immediately with the original status.
- Routed through the wrapper: `scripts/update-moon-deps.sh`, `scripts/run-moon-module.sh` (ci/bench), and the inline `moon update` calls in `ci.yml` (prove, event-graph-walker bench) and `benchmark.yml` (editor-response gate).

## Why retries don't mask real failures

The discipline from #467: *a retry that masks a real setup failure is a regression.* The gate keys on transient **HTTP status semantics**, deliberately **not** the generic `client error` substring (which also covers a deterministic 404 missing-package or 401 auth) nor a bare `symbols.zip`. A genuine toolchain/dependency-spec error — including a deterministic 404 — exits on the first attempt. A misconfigured nonnumeric attempt/delay tunable fails fast (exit 2) rather than looping until the job times out.

## Validation

Stubbed-`moon` regression tests (in PR discussion / commit body) confirm:

| Scenario | Behavior |
|---|---|
| transient 403 (always) | retries, exhausts at 3 attempts, propagates exit |
| 5xx server error | retries |
| deterministic 404 missing package | **1 attempt, no retry** |
| parse error (non-transient) | **1 attempt, no retry** |
| fail twice → succeed | recovers, exit 0 |
| nonnumeric `MOON_UPDATE_MAX_ATTEMPTS` | **fail fast, no loop** |

`shellcheck` clean on all three scripts; `actionlint` clean on the changed workflow lines.

## Out of scope (follow-up)

Not routed, to keep this PR to the PR-gating surface: `deploy-cloudflare.yml` (custom matrix `moon-update:` key shape), `copilot-setup-steps.yml`, `test-canvas-e2e.sh`, and `benchmark.yml`'s `continue-on-error` base-benchmark steps (already failure-tolerant, so they don't redden PRs). The wrapper is reusable for these later.

## Reuse check

No new MoonBit symbols. `moon update` is the existing chokepoint; this wraps it rather than introducing a parallel path. The wrapper is a single source of truth — all routed sites delegate to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
