### PR TITLE
feat(visualizer): add status-color legend to IncrGraph panel (#455)

### DIFF
--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -148,6 +148,51 @@ fn render_graphviz_html(model : Model) -> String {
 }
 
 ///|
+/// Static color key for the IncrGraph tab. Unlike the History legend
+/// (whose chips are per-agent and data-driven), the incr status palette is
+/// fixed: the four `VisualNodeStatus` values map to fixed colors. Each
+/// swatch sources its colors from `@visualizer.VisualNodeStatus::fill` /
+/// `::stroke` — the same accessors the SVG renderer uses — so the key can't
+/// drift from the rendered nodes.
+///
+/// Labels follow the status semantics in the visualizer event adapter
+/// (`incr_tap.mbt` `record_status`): `Active` = a cell currently
+/// recomputing, `Changed` = recompute produced a new value, `Failed` = the
+/// recompute aborted, `Neutral` = resting (no recent event, or a recompute
+/// that re-derived the prior value).
+///
+/// Emitted as a sibling of the `role="img"` SVG div (not inside it) so the
+/// decoder stays list-readable for assistive tech, mirroring `legend_html`.
+fn incr_legend_html() -> String {
+  let entries : Array[(@visualizer.VisualNodeStatus, String)] = [
+    (Neutral, "Idle"),
+    (Active, "Recomputing"),
+    (Changed, "Changed"),
+    (Failed, "Failed"),
+  ]
+  let buf = StringBuilder::new()
+  buf.write_string(
+    "<div class=\"incr-legend\" role=\"list\" aria-label=\"Incr graph status color legend\">",
+  )
+  for entry in entries {
+    let (status, label) = entry
+    // Swatch is decorative (aria-hidden) — it duplicates the SVG fill; the
+    // text label carries the meaning for assistive tech.
+    buf.write_string(
+      "<span class=\"incr-legend-item\" role=\"listitem\"><span class=\"incr-legend-swatch\" aria-hidden=\"true\" style=\"background:",
+    )
+    buf.write_string(status.fill())
+    buf.write_string(";border-color:")
+    buf.write_string(status.stroke())
+    buf.write_string("\"></span>")
+    buf.write_string(label)
+    buf.write_string("</span>")
+  }
+  buf.write_string("</div>")
+  buf.to_string()
+}
+
+///|
 /// Render the IncrGraph tab's HTML (cached). Keyed on the same triple as
 /// the Graphviz tab: the incr dependency graph only changes when text
 /// edits advance `op_count`, so cache hits skip the snapshot copy + DOT
@@ -169,7 +214,8 @@ fn render_incr_graph_html(model : Model) -> String {
       let svg = snapshot
         .to_visual_graph()
         .to_svg_with_config(bottom_tab_svg_config)
-      "<div role=\"img\" aria-label=\"Incr runtime dependency graph\">" +
+      incr_legend_html() +
+      "<div class=\"incr-graph\" role=\"img\" aria-label=\"Incr runtime dependency graph\">" +
       svg +
       "</div>"
     }

--- a/examples/ideal/web/e2e/incr-graph.spec.ts
+++ b/examples/ideal/web/e2e/incr-graph.spec.ts
@@ -26,4 +26,35 @@ test.describe('Bottom panel — Incr Graph', () => {
     await expect(panel).toBeVisible();
     await expect(panel.locator('svg')).toHaveCount(1, { timeout: 5000 });
   });
+
+  test('IncrGraph tab renders a status-color legend beside the SVG', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await page.getByRole('button', { name: 'Panels' }).click();
+    await page.getByRole('tab', { name: 'Incr Graph' }).click();
+
+    const panel = page.locator('#canopy-incr-container');
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('svg')).toHaveCount(1, { timeout: 5000 });
+
+    // The legend is a sibling of the role="img" SVG region — a fixed key
+    // for the four VisualNodeStatus colors.
+    const legend = panel.locator('.incr-legend');
+    await expect(legend).toBeVisible();
+    await expect(legend.locator('.incr-legend-item')).toHaveCount(4);
+    for (const label of ['Idle', 'Recomputing', 'Changed', 'Failed']) {
+      await expect(legend.getByText(label, { exact: true })).toBeVisible();
+    }
+
+    // Swatch colors come from the visualizer lib's status palette
+    // (VisualNodeStatus::fill / ::stroke). Assert the "Failed" swatch carries
+    // that fill so the legend can't silently render colorless chips.
+    const failedSwatch = legend
+      .locator('.incr-legend-item', { hasText: 'Failed' })
+      .locator('.incr-legend-swatch');
+    await expect(failedSwatch).toHaveAttribute('style', /#f3d6d8/);
+
+    await page.screenshot({ path: 'test-results/incr-graph-legend.png' });
+  });
 });

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -875,6 +875,79 @@ canopy-editor {
   color: var(--canopy-muted);
 }
 
+/* ── Incr Graph tab ─────────────────────────────────────── */
+
+/*
+ * Same vertical layout as the History tab: a fixed status-color legend
+ * strip on top (decoder for the VisualNodeStatus palette), the dependency
+ * SVG below in a centered, overflow-aware region.
+ */
+.incr-graph-content {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* Empty-state message ("No incr cells observed yet") — the container drops
+ * its padding for the legend layout, so restore it for the bare span. The
+ * shared `.no-problems` color is success-green (right for the Problems tab,
+ * wrong for this neutral-info message); override to muted for parity with
+ * the History tab's `.history-empty`. */
+.incr-graph-content .no-problems {
+  padding: var(--space-md);
+  color: var(--canopy-muted);
+}
+
+.incr-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--text-label);
+  color: var(--canopy-muted);
+  border-bottom: 1px solid var(--canopy-border);
+  flex-shrink: 0;
+}
+
+.incr-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  white-space: nowrap;
+}
+
+/*
+ * Swatch mirrors an actual graph node: a rounded rect filled with the
+ * status fill color and bordered with its stroke color. Both colors arrive
+ * via inline style, sourced from @visualizer.VisualNodeStatus::fill/::stroke.
+ */
+.incr-legend-swatch {
+  width: 12px;
+  height: 9px;
+  border-radius: 2px;
+  border: 1.5px solid;
+  flex-shrink: 0;
+}
+
+.incr-graph {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: var(--space-md);
+}
+
+.incr-graph svg {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+}
+
 /* ── Panel scrim (mobile only — hidden on desktop) ─────── */
 
 .panel-scrim {

--- a/lib/visualizer/graphviz_render.mbt
+++ b/lib/visualizer/graphviz_render.mbt
@@ -14,8 +14,12 @@ fn node_id(id : String) -> @dot.NodeId {
 }
 
 ///|
-fn node_color(status : VisualNodeStatus) -> String {
-  match status {
+/// Stroke (border) color for a node in this status. This is the canonical
+/// status→color mapping; consumers that draw their own status key (e.g. the
+/// Ideal IncrGraph legend) call this so the swatches can't drift from the
+/// rendered nodes.
+pub fn VisualNodeStatus::stroke(self : VisualNodeStatus) -> String {
+  match self {
     Neutral => "#3b4252"
     Active => "#5e81ac"
     Changed => "#a3be8c"
@@ -24,8 +28,10 @@ fn node_color(status : VisualNodeStatus) -> String {
 }
 
 ///|
-fn node_fill(status : VisualNodeStatus) -> String {
-  match status {
+/// Fill color for a node in this status. Paired with `stroke`; see that
+/// method for the source-of-truth rationale.
+pub fn VisualNodeStatus::fill(self : VisualNodeStatus) -> String {
+  match self {
     Neutral => "#eceff4"
     Active => "#d8dee9"
     Changed => "#e5f1dc"
@@ -49,9 +55,9 @@ fn node_statement(node : VisualNode) -> @dot.Statement {
     Some(
       attrs([
         attr("label", node_label(node)),
-        attr("color", node_color(node.status)),
+        attr("color", node.status.stroke()),
         attr("fontcolor", "#1f2933"),
-        attr("fillcolor", node_fill(node.status)),
+        attr("fillcolor", node.status.fill()),
       ]),
     ),
   )

--- a/lib/visualizer/pkg.generated.mbti
+++ b/lib/visualizer/pkg.generated.mbti
@@ -81,6 +81,8 @@ pub(all) enum VisualNodeStatus {
   Changed
   Failed
 }
+pub fn VisualNodeStatus::fill(Self) -> String
+pub fn VisualNodeStatus::stroke(Self) -> String
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

Closes #455.

The **Incr Graph** bottom-panel tab colored nodes by `VisualNodeStatus`
(`Neutral`/`Active`/`Changed`/`Failed`) but rendered no key — users saw
green/blue/red nodes with no decoder. This was asymmetric with the **History**
tab, which renders a legend strip beside its SVG.

This adds a fixed 4-chip legend (**Idle / Recomputing / Changed / Failed**)
above the dependency SVG, mirroring the History tab's layout and a11y pattern
(`role="list"` + `aria-hidden` swatch + text label carries meaning).

To keep a single source of truth for the palette, the previously-private
status→color mapping (`node_color`/`node_fill` in `graphviz_render.mbt`) is now
exposed as public methods `VisualNodeStatus::stroke` / `::fill`. The legend
swatches source their colors from those same accessors the SVG renderer uses,
so the key **can't drift** from the rendered nodes (no hardcoded palette copy
in the consumer).

Labels follow the event adapter semantics (`incr_tap.mbt` `record_status`):
`Active` → recomputing, `Changed` → recompute produced a new value, `Failed` →
recompute aborted, `Neutral` → resting (no recent event, or a backdated
recompute that re-derived the prior value → shown as "Idle").

## Changes

- `lib/visualizer/graphviz_render.mbt` — `node_color`/`node_fill` → `pub fn VisualNodeStatus::stroke` / `::fill`; updated the two internal call sites. `.mbti` delta is exactly the two new methods.
- `examples/ideal/main/view_bottom.mbt` — new `incr_legend_html()`; prepended to the panel HTML (sibling of the `role="img"` SVG div, non-empty path only).
- `examples/ideal/web/styles/editor.css` — `.incr-graph-content` / `.incr-legend*` / `.incr-graph` rules mirroring the History tab.
- `examples/ideal/web/e2e/incr-graph.spec.ts` — asserts the 4 chips, their labels, and that the `Failed` swatch carries the lib's fill color (`#f3d6d8`).

## Scope notes

- Static **color** key only. The per-cell recompute **timing** readout (#454 / #465) is a different surface (node detail text, self-describing) and is intentionally not mentioned in the color legend.
- Does not touch #464 (Recompute* rename) or #457 (snapshot perf).

## Reuse check

- **Color source:** reuses the lib's status→color mapping via the new
  `VisualNodeStatus::stroke`/`::fill` accessors rather than hardcoding hex —
  searched `node_color`/`node_fill` callers (only `node_statement`, updated)
  and confirmed no divergent palette is introduced.
- **Legend pattern:** mirrors the existing History `legend_html` +
  `.history-legend*` structure (list semantics, decorative `aria-hidden`
  swatch). Kept as a parallel `incr_legend_html` because the incr legend is a
  fixed 4-status key, while History's is per-agent and data-driven — no shared
  helper would fit both without parameterizing away the difference.

## Verification

- `moon check` / `moon fmt` / `moon info` clean; `moon test` — visualizer 7/7, ideal main 39/39.
- Playwright e2e `incr-graph.spec.ts` passes (2/2); legend eyeballed in-browser (screenshot).
- Codex pre-PR review: PASS, no findings. `/code-review` (high): PASS, no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
