### PR TITLE
ci: route remaining bare `moon update` sites through retry wrapper + add guard (#467)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Running benchmarks on base branch..."
-          if moon update && moon bench --release > base_bench.txt 2>&1; then
+          if "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release > base_bench.txt 2>&1; then
             cat base_bench.txt
           else
             echo "(base branch benchmark failed — may not compile)" > base_bench.txt
@@ -60,7 +60,7 @@ jobs:
         run: |
           if (
             cd event-graph-walker
-            moon update
+            "$GITHUB_WORKSPACE/scripts/moon-update.sh"
             moon bench --release
           ) > base_egw_bench.txt 2>&1; then
             cat base_egw_bench.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run check-deps
         run: ./scripts/check-deps.sh
 
+      - name: Check moon update is retry-wrapped
+        run: ./scripts/check-moon-update-wrapped.sh
+
   test-main:
     name: Test Main Module
     runs-on: ubuntu-latest

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,5 +37,6 @@ jobs:
       - name: Update MoonBit dependencies
         run: |
             moon version --all
-            moon update
+            # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+            "$GITHUB_WORKSPACE/scripts/moon-update.sh"
             

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -20,9 +20,10 @@ jobs:
           - name: web
             project-name: canopy-lambda-editor
             type: pages
+            # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
             moon-update: |
-              moon update
-              cd graphviz && moon update
+              "$GITHUB_WORKSPACE/scripts/moon-update.sh"
+              cd graphviz && "$GITHUB_WORKSPACE/scripts/moon-update.sh"
             moon-build: |
               moon build --target js --release
               cd graphviz && moon build --target js --release
@@ -36,7 +37,7 @@ jobs:
             # mode forces wasm-gc and skips the JS bundle vite expects. Same
             # treatment as scripts/test-canvas-e2e.sh + benchmark.yml. Tracked
             # as #335; remove once moon honors per-member preferred-target.
-            moon-update: cd examples/ideal && MOON_WORK=off moon update
+            moon-update: cd examples/ideal && MOON_WORK=off "$GITHUB_WORKSPACE/scripts/moon-update.sh"
             moon-build: cd examples/ideal && MOON_WORK=off moon build --target js --release
             npm-dir: examples/ideal/web
             deploy-dir: examples/ideal/web/dist
@@ -44,7 +45,7 @@ jobs:
           - name: prosemirror
             project-name: canopy-prosemirror
             type: pages
-            moon-update: moon update
+            moon-update: '"$GITHUB_WORKSPACE/scripts/moon-update.sh"'
             moon-build: moon build --target js --release
             npm-dir: examples/prosemirror
             deploy-dir: examples/prosemirror/dist
@@ -52,7 +53,7 @@ jobs:
           - name: demo-react
             project-name: canopy-demo-react
             type: pages
-            moon-update: moon update
+            moon-update: '"$GITHUB_WORKSPACE/scripts/moon-update.sh"'
             moon-build: moon build --target js --release
             npm-dir: examples/demo-react
             deploy-dir: examples/demo-react/dist
@@ -61,7 +62,7 @@ jobs:
             project-name: canopy-block-editor
             type: pages
             # MOON_WORK=off: see ideal entry above (#335).
-            moon-update: cd examples/block-editor && MOON_WORK=off moon update
+            moon-update: cd examples/block-editor && MOON_WORK=off "$GITHUB_WORKSPACE/scripts/moon-update.sh"
             moon-build: cd examples/block-editor && MOON_WORK=off moon build --target js --release
             npm-dir: examples/block-editor/web
             deploy-dir: examples/block-editor/web/dist
@@ -70,7 +71,7 @@ jobs:
             project-name: canopy-canvas
             type: pages
             # MOON_WORK=off: see ideal entry above (#335).
-            moon-update: cd examples/canvas && MOON_WORK=off moon update
+            moon-update: cd examples/canvas && MOON_WORK=off "$GITHUB_WORKSPACE/scripts/moon-update.sh"
             moon-build: cd examples/canvas && MOON_WORK=off moon build --target js --release
             npm-dir: examples/canvas/web
             deploy-dir: examples/canvas/web/dist
@@ -78,7 +79,7 @@ jobs:
           - name: relay-server
             project-name: canopy-relay
             type: workers
-            moon-update: moon update
+            moon-update: '"$GITHUB_WORKSPACE/scripts/moon-update.sh"'
             moon-build: moon build --target js --release
             npm-dir: examples/relay-server
             deploy-dir: ""

--- a/scripts/check-moon-update-wrapped.sh
+++ b/scripts/check-moon-update-wrapped.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Guard: every `moon update` invocation in CI workflows and shell scripts must
+# go through scripts/moon-update.sh, the bounded-retry wrapper for the transient
+# mooncakes CDN 403 (issue #467). A bare `moon update` silently loses that retry
+# coverage — a CDN flake then fails the job (and, in deploy-cloudflare.yml, a
+# production deploy) instead of auto-recovering. Coverage erodes by default
+# without this enforcement, so fail the build if a bare invocation reappears.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+# Scan executable CI surfaces only: workflows + shell scripts. Markdown/docs may
+# mention `moon update` in prose and are out of scope. The wrapper itself is the
+# one legitimate `moon update` caller, so exclude it.
+mapfile -t files < <(
+  git ls-files '.github' 'scripts' |
+    grep -E '\.(ya?ml|sh)$' |
+    grep -vx 'scripts/moon-update.sh'
+)
+
+# `moon-update.sh` (hyphen) never matches `moon update` (space), so the wrapper's
+# own call is ignored for free. Match only command-position `moon update` so that
+# prose mentions (a step `name:`, an `echo` string, a doc sentence) don't
+# false-positive. A command-position invocation has `moon` at a shell command
+# boundary, optionally behind inline `VAR=val` env prefixes:
+#   - line start (after indentation)            ^   moon update
+#   - after a shell operator                    && | ; ( {  moon update
+#   - as a YAML/shell value right after a colon  run: moon update
+#   - after a conditional/loop head             if/while/until moon update
+#   - any of the above + env prefix             MOON_WORK=off moon update
+# The env prefix is matched ONLY when it itself follows a boundary, so a `VAR=val`
+# token inside a quoted echo/argument string (e.g. `echo "X=y moon update"`) is
+# not mistaken for a command. Comment lines (`#`) are dropped first — a colon in a
+# comment (`# fix: ...`) would otherwise trip the value-after-colon arm.
+#
+# The keyword arm is scoped to `if|while|until` — the command-taking heads with
+# real precedent (benchmark.yml had `if moon update`). Common-word keywords like
+# `time`/`command`/`then` are deliberately excluded: they collide with prose
+# inside string literals (`name: at build time moon update ...`) and a
+# `time`/`command`-prefixed dependency update never occurs in practice.
+boundary='(^[[:space:]]*|[;&|({][[:space:]]*|:[[:space:]]+|\b(if|while|until)[[:space:]]+)'
+env_prefix='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*'
+violations="$(
+  grep -nE "${boundary}${env_prefix}moon update\b" "${files[@]}" |
+    grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' ||
+    true
+)"
+
+if [ -n "$violations" ]; then
+  echo "error: bare 'moon update' found — route it through scripts/moon-update.sh (issue #467)." >&2
+  echo "       Use \"\$GITHUB_WORKSPACE/scripts/moon-update.sh\" in workflows," >&2
+  echo "       or \"\$SCRIPT_DIR/moon-update.sh\" in scripts. Offending lines:" >&2
+  echo "$violations" >&2
+  exit 1
+fi
+
+echo "ok: all 'moon update' invocations route through scripts/moon-update.sh"

--- a/scripts/test-canvas-e2e.sh
+++ b/scripts/test-canvas-e2e.sh
@@ -11,7 +11,8 @@ cd "$PROJECT_ROOT"
 
 (
     cd examples/canvas
-    moon update
+    # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+    "$SCRIPT_DIR/moon-update.sh"
 )
 
 echo "Running canvas Playwright E2E..."


### PR DESCRIPTION
Closes the coverage gap tracked in #467.

## What

PR #468 (`cc0b23c`) shipped `scripts/moon-update.sh` — a bounded-retry wrapper around `moon update` for the transient mooncakes CDN 403 (#467) — and wired it into `ci.yml`, `benchmark.yml`'s editor-response gate, `run-moon-module.sh`, and `update-moon-deps.sh`. But ~10 **bare** `moon update` sites remained unrouted, so a CDN flake there still fails the job (and, in the deploy path, a **production deploy** that PR CI never exercises).

This PR routes the remaining sites and adds a lint so the gap can't silently reopen.

### Routed sites
- **`deploy-cloudflare.yml`** (highest value): all 8 matrix `moon-update:` values. These run via `run: ${{ matrix.moon-update }}` — a plain `run:` step, *not* a custom action — so the same `"$GITHUB_WORKSPACE/scripts/moon-update.sh"` idiom `ci.yml` already uses works directly. `MOON_WORK=off` prefixes propagate into the wrapper's inner `moon update "$@"`.
- **`benchmark.yml`**: both base-branch comparison steps (the `continue-on-error` ones at the old lines ~51/63). Routing them hardens the base comparison against spurious "may not compile" on a flake; the `$GITHUB_WORKSPACE` path resolves correctly after the base-branch checkout.
- **`copilot-setup-steps.yml`** and **`scripts/test-canvas-e2e.sh`** (the latter via the script-local `$SCRIPT_DIR` idiom).

### Guard
`scripts/check-moon-update-wrapped.sh`, run in `ci.yml`'s `dep-check` job, fails if a bare `moon update` reappears in `.github/` or `scripts/` outside the wrapper. The review on #468 flagged that coverage erodes by default without enforcement.

The guard matches **command-position** invocations only — line-start, after `&&`/`;`/`|`/`(`, after a `:` value-start (`run: moon update`), after an env prefix (`MOON_WORK=off moon update`), or after `if`/`while`/`until` — so prose mentions in step `name:`s and `echo` strings don't false-positive. The env-prefix arm requires a preceding command boundary, so a `VAR=val` token inside a quoted string isn't mistaken for a command.

## Scope / non-goals
No wrapper *logic* changes — that work shipped fully in #468. This is pure call-site coverage + the lint. The wrapper still retries **only** the known-transient CDN/network signature and exits immediately on any other failure.

## Reuse check
Reuses the existing `scripts/moon-update.sh` wrapper and its two established path idioms (`$GITHUB_WORKSPACE` in workflows, `$SCRIPT_DIR` in scripts). The new lint mirrors the existing grep-based check scripts (`check-deps.sh`, `check-agent-doc-links.sh`) in style and CI placement.

## Verification
- `actionlint` on all four edited workflows: **zero new findings** (the 4 pre-existing shellcheck warnings are on untouched lines — identical count on `main` vs this branch).
- `shellcheck scripts/check-moon-update-wrapped.sh`: clean.
- Guard regex validated with a known-positive/negative control set: all realistic invocation forms (`run:`, `&&`, env-prefix, multi-env-prefix, `if`/`while`, matrix-key) flag; prose cases (`echo "running moon update"`, `echo "X=y moon update"`, `name: at build time moon update is wrapped`) do not.
- Codex pre-PR review: confirmed YAML validity, shell expansion, `MOON_WORK=off` propagation, and benchmark base-branch path resolution; its one finding (a lint-regex gap) is fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
