### PR TITLE
refactor(visualizer): rename IncrMemoEvent* tap API to Recompute* (#464)

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -39,7 +39,7 @@ fn init_model() -> Model raise {
   // Attach the memo-event tap before any cell reads so initial-parse recomputes
   // are visible to the IncrGraph panel. `attach` only fails if incr's listener
   // slot is already claimed by an external caller — fatal here, propagate.
-  let incr_tap = @visualizer.IncrMemoEventTap::attach(editor.parser_runtime())
+  let incr_tap = @visualizer.RecomputeTap::attach(editor.parser_runtime())
   let init_text = "let id = \\x. { x }\nlet apply = \\f. \\x. { f x }\napply id 42"
   editor.set_text(init_text)
   let outline_state : @proj.TreeEditorState[@ast.Term] = @proj.TreeEditorState::from_projection(

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -104,5 +104,5 @@ pub struct Model {
   // Model-owned tap on the parser's incr Runtime. Created once at init so it
   // observes memo events across the whole session, not per render. Reads via
   // `snapshot()` for the IncrGraph bottom-panel tab.
-  incr_tap : @visualizer.IncrMemoEventTap
+  incr_tap : @visualizer.RecomputeTap
 }

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -130,7 +130,7 @@ pub struct Model {
   drop_position : @core.DropPosition?
   intent_log : Array[String]
   patch_log : Array[PatchEntry]
-  incr_tap : @visualizer.IncrMemoEventTap
+  incr_tap : @visualizer.RecomputeTap
 }
 
 pub enum Msg {

--- a/lib/visualizer/README.md
+++ b/lib/visualizer/README.md
@@ -8,7 +8,7 @@ renderer-neutral graph model, then render with the local `dowdiness/graphviz`
 layout and SVG renderer. The Graphviz SVG renderer is backed by the local
 `dowdiness/svg-dsl` module.
 
-The first adapter is `IncrMemoEventTap`, which listens to
+The first adapter is `RecomputeTap`, which listens to
 `Runtime::on_memo_event`, records compact memo recompute events, enriches known
 cells through `Runtime::cell_info`, and renders the dependency graph. The tap
 does not publish events back into the same runtime. `detach()` deactivates the

--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -109,10 +109,7 @@ fn event_from_memo_event(evt : @incr.MemoEvent) -> RecomputeRecord {
 }
 
 ///|
-fn RecomputeTap::record(
-  self : RecomputeTap,
-  evt : @incr.MemoEvent,
-) -> Unit {
+fn RecomputeTap::record(self : RecomputeTap, evt : @incr.MemoEvent) -> Unit {
   guard self.active.val else { return }
   let record = event_from_memo_event(evt)
   remember_cell(self.cells, record.cell_id)
@@ -209,7 +206,12 @@ fn record_status(record : RecomputeRecord?) -> VisualNodeStatus {
     Some(event) =>
       match event.phase {
         RecomputePhase::Entering => Active
-        RecomputePhase::Completed => if event.backdated { Neutral } else { Changed }
+        RecomputePhase::Completed =>
+          if event.backdated {
+            Neutral
+          } else {
+            Changed
+          }
         RecomputePhase::Aborted => Failed
       }
     None => Neutral
@@ -221,9 +223,7 @@ fn record_status(record : RecomputeRecord?) -> VisualNodeStatus {
 ///
 /// `incr` allows one memo-event listener per runtime, so attaching replaces
 /// any previous listener owned by the same runtime.
-pub fn RecomputeTap::attach(
-  rt : @incr.Runtime,
-) -> RecomputeTap raise Failure {
+pub fn RecomputeTap::attach(rt : @incr.Runtime) -> RecomputeTap raise Failure {
   let tap = { rt, active: Ref(true), events: @hashmap.HashMap([]), cells: [] }
   rt.on_memo_event(evt => tap.record(evt))
   tap

--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -1,16 +1,16 @@
 ///|
 /// Phase of a public `incr` memo recompute event.
-pub(all) enum IncrMemoEventPhase {
-  IncrEntering
-  IncrCompleted
-  IncrAborted
+pub(all) enum RecomputePhase {
+  Entering
+  Completed
+  Aborted
 }
 
 ///|
-/// Compact memo-event record captured by `IncrMemoEventTap`.
-pub struct IncrMemoEventRecord {
+/// Compact memo-event record captured by `RecomputeTap`.
+pub struct RecomputeRecord {
   cell_id : @incr.CellId
-  phase : IncrMemoEventPhase
+  phase : RecomputePhase
   started_revision : @incr.Revision
   elapsed_ns : Int64?
   verified_at : @incr.Revision?
@@ -39,19 +39,19 @@ pub struct IncrSnapshotEdge {
 pub struct IncrSnapshot {
   nodes : Array[IncrSnapshotNode]
   edges : Array[IncrSnapshotEdge]
-  events : Array[IncrMemoEventRecord]
+  events : Array[RecomputeRecord]
 }
 
 ///|
 /// Driver-owned tap that records public `incr` memo events for visualization.
-pub struct IncrMemoEventTap {
+pub struct RecomputeTap {
   priv rt : @incr.Runtime
   priv active : Ref[Bool]
   // Keep-last-per-cell status buffer: bounded by the number of distinct cells
   // that fired events since the last drain, not by the total event count.
   // Status coloring only needs each cell's most recent event, so retaining
   // the latest per cell loses nothing while bounding memory.
-  priv events : @hashmap.HashMap[@incr.CellId, IncrMemoEventRecord]
+  priv events : @hashmap.HashMap[@incr.CellId, RecomputeRecord]
   priv cells : Array[@incr.CellId]
 }
 
@@ -73,12 +73,12 @@ fn remember_cell(ids : Array[@incr.CellId], id : @incr.CellId) -> Unit {
 }
 
 ///|
-fn event_from_memo_event(evt : @incr.MemoEvent) -> IncrMemoEventRecord {
+fn event_from_memo_event(evt : @incr.MemoEvent) -> RecomputeRecord {
   match evt {
     EnteringCompute(e) =>
       {
         cell_id: e.cell_id,
-        phase: IncrEntering,
+        phase: RecomputePhase::Entering,
         started_revision: e.started_revision,
         elapsed_ns: None,
         verified_at: None,
@@ -88,7 +88,7 @@ fn event_from_memo_event(evt : @incr.MemoEvent) -> IncrMemoEventRecord {
     Completed(e) =>
       {
         cell_id: e.cell_id,
-        phase: IncrCompleted,
+        phase: RecomputePhase::Completed,
         started_revision: e.started_revision,
         elapsed_ns: Some(e.elapsed_ns),
         verified_at: Some(e.verified_at),
@@ -98,7 +98,7 @@ fn event_from_memo_event(evt : @incr.MemoEvent) -> IncrMemoEventRecord {
     Aborted(e) =>
       {
         cell_id: e.cell_id,
-        phase: IncrAborted,
+        phase: RecomputePhase::Aborted,
         started_revision: e.started_revision,
         elapsed_ns: Some(e.elapsed_ns),
         verified_at: None,
@@ -109,8 +109,8 @@ fn event_from_memo_event(evt : @incr.MemoEvent) -> IncrMemoEventRecord {
 }
 
 ///|
-fn IncrMemoEventTap::record(
-  self : IncrMemoEventTap,
+fn RecomputeTap::record(
+  self : RecomputeTap,
   evt : @incr.MemoEvent,
 ) -> Unit {
   guard self.active.val else { return }
@@ -120,7 +120,7 @@ fn IncrMemoEventTap::record(
 }
 
 ///|
-fn snapshot_ids(tap : IncrMemoEventTap) -> Array[@incr.CellId] {
+fn snapshot_ids(tap : RecomputeTap) -> Array[@incr.CellId] {
   let ids : Array[@incr.CellId] = []
   for id in tap.cells {
     remember_cell(ids, id)
@@ -192,9 +192,9 @@ fn snapshot_node_detail(node : IncrSnapshotNode, elapsed_ns : Int64?) -> String 
 /// single scan returns that cell's only record — both its status and its
 /// latest `elapsed_ns` come from the one lookup.
 fn event_for_cell(
-  events : Array[IncrMemoEventRecord],
+  events : Array[RecomputeRecord],
   id : @incr.CellId,
-) -> IncrMemoEventRecord? {
+) -> RecomputeRecord? {
   for event in events {
     if event.cell_id == id {
       return Some(event)
@@ -204,13 +204,13 @@ fn event_for_cell(
 }
 
 ///|
-fn record_status(record : IncrMemoEventRecord?) -> VisualNodeStatus {
+fn record_status(record : RecomputeRecord?) -> VisualNodeStatus {
   match record {
     Some(event) =>
       match event.phase {
-        IncrEntering => Active
-        IncrCompleted => if event.backdated { Neutral } else { Changed }
-        IncrAborted => Failed
+        RecomputePhase::Entering => Active
+        RecomputePhase::Completed => if event.backdated { Neutral } else { Changed }
+        RecomputePhase::Aborted => Failed
       }
     None => Neutral
   }
@@ -221,9 +221,9 @@ fn record_status(record : IncrMemoEventRecord?) -> VisualNodeStatus {
 ///
 /// `incr` allows one memo-event listener per runtime, so attaching replaces
 /// any previous listener owned by the same runtime.
-pub fn IncrMemoEventTap::attach(
+pub fn RecomputeTap::attach(
   rt : @incr.Runtime,
-) -> IncrMemoEventTap raise Failure {
+) -> RecomputeTap raise Failure {
   let tap = { rt, active: Ref(true), events: @hashmap.HashMap([]), cells: [] }
   rt.on_memo_event(evt => tap.record(evt))
   tap
@@ -235,7 +235,7 @@ pub fn IncrMemoEventTap::attach(
 /// `incr` exposes replacement and clearing for the runtime listener, but not
 /// listener identity. Deactivating this tap's closure keeps stale handles from
 /// clearing a newer tap that replaced them.
-pub fn IncrMemoEventTap::detach(self : IncrMemoEventTap) -> Unit {
+pub fn RecomputeTap::detach(self : RecomputeTap) -> Unit {
   self.active.val = false
 }
 
@@ -243,9 +243,9 @@ pub fn IncrMemoEventTap::detach(self : IncrMemoEventTap) -> Unit {
 /// Drain the retained events — the most recent record per cell since the last
 /// drain — and clear the buffer. Order is unspecified (keyed by cell, not
 /// arrival); callers that only need per-cell status are unaffected.
-pub fn IncrMemoEventTap::drain_events(
-  self : IncrMemoEventTap,
-) -> Array[IncrMemoEventRecord] {
+pub fn RecomputeTap::drain_events(
+  self : RecomputeTap,
+) -> Array[RecomputeRecord] {
   let drained = self.events.values().to_array()
   self.events.clear()
   drained
@@ -253,7 +253,7 @@ pub fn IncrMemoEventTap::drain_events(
 
 ///|
 /// Capture the current known dependency graph plus buffered event history.
-pub fn IncrMemoEventTap::snapshot(self : IncrMemoEventTap) -> IncrSnapshot {
+pub fn RecomputeTap::snapshot(self : RecomputeTap) -> IncrSnapshot {
   let ids = snapshot_ids(self)
   let nodes : Array[IncrSnapshotNode] = []
   let edges : Array[IncrSnapshotEdge] = []

--- a/lib/visualizer/incr_tap_wbtest.mbt
+++ b/lib/visualizer/incr_tap_wbtest.mbt
@@ -37,9 +37,9 @@ test "to_visual_graph surfaces latest elapsed_ns on the recomputed cell only" {
     changed_at: rev3,
     verified_at: rev3,
   }
-  let event : IncrMemoEventRecord = {
+  let event : RecomputeRecord = {
     cell_id: timed_cell,
-    phase: IncrCompleted,
+    phase: RecomputePhase::Completed,
     started_revision: rev3,
     elapsed_ns: Some(5000L),
     verified_at: Some(rev4),

--- a/lib/visualizer/pkg.generated.mbti
+++ b/lib/visualizer/pkg.generated.mbti
@@ -12,34 +12,10 @@ import {
 // Errors
 
 // Types and methods
-pub(all) enum IncrMemoEventPhase {
-  IncrEntering
-  IncrCompleted
-  IncrAborted
-}
-
-pub struct IncrMemoEventRecord {
-  cell_id : @types.CellId
-  phase : IncrMemoEventPhase
-  started_revision : @types.Revision
-  elapsed_ns : Int64?
-  verified_at : @types.Revision?
-  changed_at : @types.Revision?
-  backdated : Bool
-}
-
-pub struct IncrMemoEventTap {
-  // private fields
-}
-pub fn IncrMemoEventTap::attach(@cells.Runtime) -> Self raise Failure
-pub fn IncrMemoEventTap::detach(Self) -> Unit
-pub fn IncrMemoEventTap::drain_events(Self) -> Array[IncrMemoEventRecord]
-pub fn IncrMemoEventTap::snapshot(Self) -> IncrSnapshot
-
 pub struct IncrSnapshot {
   nodes : Array[IncrSnapshotNode]
   edges : Array[IncrSnapshotEdge]
-  events : Array[IncrMemoEventRecord]
+  events : Array[RecomputeRecord]
 }
 pub fn IncrSnapshot::to_visual_graph(Self) -> VisualGraph
 
@@ -54,6 +30,30 @@ pub struct IncrSnapshotNode {
   changed_at : @types.Revision
   verified_at : @types.Revision
 }
+
+pub(all) enum RecomputePhase {
+  Entering
+  Completed
+  Aborted
+}
+
+pub struct RecomputeRecord {
+  cell_id : @types.CellId
+  phase : RecomputePhase
+  started_revision : @types.Revision
+  elapsed_ns : Int64?
+  verified_at : @types.Revision?
+  changed_at : @types.Revision?
+  backdated : Bool
+}
+
+pub struct RecomputeTap {
+  // private fields
+}
+pub fn RecomputeTap::attach(@cells.Runtime) -> Self raise Failure
+pub fn RecomputeTap::detach(Self) -> Unit
+pub fn RecomputeTap::drain_events(Self) -> Array[RecomputeRecord]
+pub fn RecomputeTap::snapshot(Self) -> IncrSnapshot
 
 pub struct VisualEdge {
   // private fields

--- a/lib/visualizer/visualizer_test.mbt
+++ b/lib/visualizer/visualizer_test.mbt
@@ -26,7 +26,7 @@ test "incr_memo_event_tap_snapshots_runtime_graph" {
   let rt = @incr.Runtime()
   let sig = @incr.Signal(rt, 1, label="input")
   let memo = @incr.Derived(rt, () => sig.get() + 1, label="sum")
-  let tap = @visualizer.IncrMemoEventTap::attach(rt)
+  let tap = @visualizer.RecomputeTap::attach(rt)
   inspect(memo.read_or_abort(), content="2")
   let snapshot = tap.snapshot()
   // Keep-last-per-cell: the memo's EnteringCompute + Completed collapse to a
@@ -44,8 +44,8 @@ test "incr_memo_event_tap_stale_detach_does_not_clear_newer_tap" {
   let rt = @incr.Runtime()
   let sig = @incr.Signal(rt, 1, label="input")
   let memo = @incr.Derived(rt, () => sig.get() + 1, label="sum")
-  let older = @visualizer.IncrMemoEventTap::attach(rt)
-  let newer = @visualizer.IncrMemoEventTap::attach(rt)
+  let older = @visualizer.RecomputeTap::attach(rt)
+  let newer = @visualizer.RecomputeTap::attach(rt)
   inspect(memo.read_or_abort(), content="2")
   inspect(older.drain_events().length(), content="0")
   // One recomputed cell → one retained record (keep-last-per-cell).
@@ -65,7 +65,7 @@ test "incr_memo_event_tap_buffer_is_bounded_per_cell" {
   let rt = @incr.Runtime()
   let sig = @incr.Signal(rt, 1, label="input")
   let memo = @incr.Derived(rt, () => sig.get() + 1, label="sum")
-  let tap = @visualizer.IncrMemoEventTap::attach(rt)
+  let tap = @visualizer.RecomputeTap::attach(rt)
   // Drive several recomputes of the SAME memo without draining: each recompute
   // emits EnteringCompute + Completed, so the unbounded log would hold 6 events.
   inspect(memo.read_or_abort(), content="2")


### PR DESCRIPTION
## #464 — rename visualizer tap API `IncrMemoEvent*` → `Recompute*`

The visualizer tap observes **recompute** events that fire for both `Memo` and `Derived` cells, so the `MemoEvent` name under-described it. This drops the `Incr` prefix and names the types by the operation they observe.

| Before | After |
| --- | --- |
| `IncrMemoEventPhase` | `RecomputePhase` |
| `IncrMemoEventRecord` | `RecomputeRecord` |
| `IncrMemoEventTap` | `RecomputeTap` |
| variants `IncrEntering` / `IncrCompleted` / `IncrAborted` | `Entering` / `Completed` / `Aborted` |

### Variant-collision handling
Dropping the prefix makes `Completed` / `Aborted` collide with `@incr.MemoEvent::Completed` / `::Aborted` at the `event_from_memo_event` conversion site. Resolved by:
- enum **declaration** uses bare variant names;
- every variant **use** site is qualified (`RecomputePhase::Completed`);
- the `@incr.MemoEvent` match-arm patterns are left as `@incr`'s own variants.

### Out of scope
`IncrSnapshot` / `IncrSnapshotNode` / `IncrSnapshotEdge` are unchanged (no "MemoEvent" in them); `RecomputeTap::snapshot` still returns `IncrSnapshot`. The `Incr`-prefixed snapshot naming is tracked as a separate follow-up.

Both `pkg.generated.mbti` files were regenerated via `moon info` (names-only, no signature / `raise` / trait-bound drift).

### Verification
- `git grep IncrMemoEvent` → 0 matches
- `NEW_MOON_MOD=0 moon check` clean
- `moon test` 1298/1298 pass
- Pure rename: balanced add/delete counts across 8 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
