### PR TITLE
ci: widen moon-update guard + route Makefile/build-deploy sites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,16 @@ install-hooks: ## Install git pre-commit hooks
 
 ci: check-all test-all ## Run all CI checks locally
 
+# Route `moon update` through the retry wrapper for the transient mooncakes CDN
+# 403 (issue #467). $(CURDIR) is absolute, so it survives the `cd` into submodules.
+MOON_UPDATE := $(CURDIR)/scripts/moon-update.sh
+
 update: ## Update MoonBit dependencies
-	moon update
-	cd event-graph-walker && moon update
-	cd loom/loom && moon update
-	cd svg-dsl && moon update
-	cd graphviz && moon update
+	$(MOON_UPDATE)
+	cd event-graph-walker && $(MOON_UPDATE)
+	cd loom/loom && $(MOON_UPDATE)
+	cd svg-dsl && $(MOON_UPDATE)
+	cd graphviz && $(MOON_UPDATE)
 
 bench: ## Run benchmarks
 	moon bench --release

--- a/examples/ideal/scripts/build-deploy.sh
+++ b/examples/ideal/scripts/build-deploy.sh
@@ -17,7 +17,8 @@ git submodule update --init --recursive
 # bundle vite expects unless MOON_WORK=off is set. See #335.
 echo "→ MoonBit dependencies..."
 cd "$IDEAL_ROOT"
-MOON_WORK=off moon update
+# Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+MOON_WORK=off "$REPO_ROOT/scripts/moon-update.sh"
 
 echo "→ MoonBit build (release JS)..."
 MOON_WORK=off moon build --target js --release

--- a/examples/web/scripts/build-deploy.sh
+++ b/examples/web/scripts/build-deploy.sh
@@ -18,10 +18,11 @@ git submodule update --init --recursive
 echo "==> Submodules initialized"
 
 # Install MoonBit package dependencies
+# Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
 echo "==> Running moon update (root)..."
-moon update
+"$REPO_ROOT/scripts/moon-update.sh"
 echo "==> Running moon update (graphviz)..."
-(cd graphviz && moon update)
+(cd graphviz && "$REPO_ROOT/scripts/moon-update.sh")
 
 # Pre-build MoonBit modules explicitly
 echo "==> Building crdt module..."

--- a/scripts/check-moon-update-wrapped.sh
+++ b/scripts/check-moon-update-wrapped.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root_dir"
 
-# Scan executable CI surfaces only: workflows + shell scripts. Markdown/docs may
-# mention `moon update` in prose and are out of scope. The wrapper itself is the
-# one legitimate `moon update` caller, so exclude it.
+# Scan every command-bearing tracked file, wherever it lives: workflows/actions
+# (*.yml/*.yaml), shell scripts (*.sh/*.bash/*.zsh) anywhere in the tree, and
+# build files (Makefile/*.mk/justfile/Taskfile). Scoping to .github + scripts
+# alone left blind spots — the Makefile `update:` target and examples/*/scripts/
+# build-deploy.sh ran bare `moon update` undetected. Markdown/source/config are
+# excluded by the allowlist (they only mention the command in prose). The wrapper
+# itself is the one legitimate `moon update` caller, so exclude it.
 mapfile -t files < <(
-  git ls-files '.github' 'scripts' |
-    grep -E '\.(ya?ml|sh)$' |
+  git ls-files |
+    grep -E '(\.(ya?ml|sh|bash|zsh|mk)$)|(^|/)(Makefile|justfile|Taskfile[^/]*)$' |
     grep -vx 'scripts/moon-update.sh'
 )
 
@@ -26,22 +30,25 @@ mapfile -t files < <(
 # prose mentions (a step `name:`, an `echo` string, a doc sentence) don't
 # false-positive. A command-position invocation has `moon` at a shell command
 # boundary, optionally behind inline `VAR=val` env prefixes:
-#   - line start (after indentation)            ^   moon update
+#   - line start, optionally as a YAML value    moon update / run: moon update
 #   - after a shell operator                    && | ; ( {  moon update
-#   - as a YAML/shell value right after a colon  run: moon update
 #   - after a conditional/loop head             if/while/until moon update
 #   - any of the above + env prefix             MOON_WORK=off moon update
+# The YAML-value arm is anchored to a line-start `key:` (with an optional `- `
+# list dash), NOT any colon. A bare colon arm flagged prose like
+# `name: "Fix issue: moon update deps"` (the inner `issue:` tripped it); requiring
+# the colon to follow a line-start key avoids that while still matching
+# `run: moon update` and matrix `moon-update: moon update`.
 # The env prefix is matched ONLY when it itself follows a boundary, so a `VAR=val`
 # token inside a quoted echo/argument string (e.g. `echo "X=y moon update"`) is
-# not mistaken for a command. Comment lines (`#`) are dropped first — a colon in a
-# comment (`# fix: ...`) would otherwise trip the value-after-colon arm.
+# not mistaken for a command. Comment lines (`#`) are dropped first.
 #
 # The keyword arm is scoped to `if|while|until` — the command-taking heads with
 # real precedent (benchmark.yml had `if moon update`). Common-word keywords like
 # `time`/`command`/`then` are deliberately excluded: they collide with prose
 # inside string literals (`name: at build time moon update ...`) and a
 # `time`/`command`-prefixed dependency update never occurs in practice.
-boundary='(^[[:space:]]*|[;&|({][[:space:]]*|:[[:space:]]+|\b(if|while|until)[[:space:]]+)'
+boundary='(^[[:space:]]*(- )?([A-Za-z0-9_-]+:[[:space:]]+)?|[;&|({][[:space:]]*|\b(if|while|until)[[:space:]]+)'
 env_prefix='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*'
 violations="$(
   grep -nE "${boundary}${env_prefix}moon update\b" "${files[@]}" |
@@ -52,7 +59,8 @@ violations="$(
 if [ -n "$violations" ]; then
   echo "error: bare 'moon update' found — route it through scripts/moon-update.sh (issue #467)." >&2
   echo "       Use \"\$GITHUB_WORKSPACE/scripts/moon-update.sh\" in workflows," >&2
-  echo "       or \"\$SCRIPT_DIR/moon-update.sh\" in scripts. Offending lines:" >&2
+  echo "       \"\$SCRIPT_DIR/moon-update.sh\" (or \"\$REPO_ROOT/...\") in scripts," >&2
+  echo "       or \$(CURDIR)/scripts/moon-update.sh in the Makefile. Offending lines:" >&2
   echo "$violations" >&2
   exit 1
 fi


### PR DESCRIPTION
Follow-up to #470, fixing 3 findings surfaced by that PR's self-review (`/code-review`).

## What & why

#470 routed the `moon update` sites it knew about and added a guard — but scoped the guard to `.github` + `scripts/*.{yml,sh}`. The review found that scoping was too narrow, and widening it exposed that the coverage gap was bigger than #470 closed.

### 1. Route the remaining bare `moon update` sites
- **`Makefile`** `update:` target — 5 bare calls. Routed via `MOON_UPDATE := $(CURDIR)/scripts/moon-update.sh`; `$(CURDIR)` is absolute so it survives each `cd` into a submodule (`make -n update` confirms).
- **`examples/ideal/scripts/build-deploy.sh`** (1) and **`examples/web/scripts/build-deploy.sh`** (2) — the Cloudflare build/deploy scripts. A 403 here fails a production build invisibly to PR CI, same risk class as `deploy-cloudflare.yml`. Routed via `$REPO_ROOT/scripts/moon-update.sh`.

### 2. Widen the guard scope (the blind spot that let the above slip past #470)
`scripts/check-moon-update-wrapped.sh` now scans **every command-bearing tracked file** anywhere in the tree — `*.yml`/`*.yaml`/`*.sh`/`*.bash`/`*.zsh`/`*.mk` + `Makefile`/`justfile`/`Taskfile*` — instead of just two directories. Docs/source/config are excluded by the allowlist (they only mention the command in prose). The guard now catches its own former blind spot.

### 3. Fix the prose false-positive
The lint's `:[[:space:]]+` boundary matched **any** colon, so a non-comment line like `name: "Fix issue: moon update deps"` (the inner `issue:`) was wrongly flagged and would fail CI. Anchored the YAML-value arm to a line-start `key:` (with optional `- ` list dash): it still flags `run: moon update` and `moon-update: moon update`, but not an inner colon.

## Verification
- `make -n update` expands every recipe line to the absolute wrapper path.
- Lint passes on the routed tree; a control set confirms all invocation forms — including in a `.mk` file (proving the widened scope works) — flag, while `name: "Fix issue: moon update"`, `echo "running moon update"`, and `name: verify the moon update step works` do **not**.
- The lint correctly does not flag its own `grep -nE "...moon update\b"` line.
- `shellcheck` clean on the routed scripts and the lint (pre-existing SC1007 on `CDPATH= cd` lines is untouched and a known false positive).
- Codex review: **PASS, no findings** — confirmed the regex, widened scope, `$(CURDIR)` survival, and `/bin/sh`→bash-wrapper invocation.

## Reuse check
Reuses the existing `scripts/moon-update.sh` wrapper; no new mechanism. Each context uses its established path idiom (`$GITHUB_WORKSPACE` / `$SCRIPT_DIR` / `$REPO_ROOT` / `$(CURDIR)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
