### PR TITLE
refactor(visualizer): rename IncrSnapshot* snapshot types to RecomputeSnapshot* (#472)

### DIFF
--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -20,7 +20,7 @@ pub struct RecomputeRecord {
 
 ///|
 /// Snapshot node enriched from `Runtime::cell_info`.
-pub struct IncrSnapshotNode {
+pub struct RecomputeSnapshotNode {
   id : @incr.CellId
   label : String?
   changed_at : @incr.Revision
@@ -29,16 +29,16 @@ pub struct IncrSnapshotNode {
 
 ///|
 /// Snapshot edge from dependency to dependent cell.
-pub struct IncrSnapshotEdge {
+pub struct RecomputeSnapshotEdge {
   from : @incr.CellId
   to : @incr.CellId
 }
 
 ///|
 /// Point-in-time graph and event snapshot for an `incr` runtime.
-pub struct IncrSnapshot {
-  nodes : Array[IncrSnapshotNode]
-  edges : Array[IncrSnapshotEdge]
+pub struct RecomputeSnapshot {
+  nodes : Array[RecomputeSnapshotNode]
+  edges : Array[RecomputeSnapshotEdge]
   events : Array[RecomputeRecord]
 }
 
@@ -147,7 +147,7 @@ fn visual_cell_id(id : @incr.CellId) -> String {
 }
 
 ///|
-fn snapshot_node_label(node : IncrSnapshotNode) -> String {
+fn snapshot_node_label(node : RecomputeSnapshotNode) -> String {
   match node.label {
     Some(label) => label
     None => "cell " + node.id.id.to_string()
@@ -169,7 +169,10 @@ fn format_elapsed_ns(ns : Int64) -> String {
 }
 
 ///|
-fn snapshot_node_detail(node : IncrSnapshotNode, elapsed_ns : Int64?) -> String {
+fn snapshot_node_detail(
+  node : RecomputeSnapshotNode,
+  elapsed_ns : Int64?,
+) -> String {
   let base = "changed " +
     node.changed_at.value.to_string() +
     ", verified " +
@@ -253,10 +256,10 @@ pub fn RecomputeTap::drain_events(
 
 ///|
 /// Capture the current known dependency graph plus buffered event history.
-pub fn RecomputeTap::snapshot(self : RecomputeTap) -> IncrSnapshot {
+pub fn RecomputeTap::snapshot(self : RecomputeTap) -> RecomputeSnapshot {
   let ids = snapshot_ids(self)
-  let nodes : Array[IncrSnapshotNode] = []
-  let edges : Array[IncrSnapshotEdge] = []
+  let nodes : Array[RecomputeSnapshotNode] = []
+  let edges : Array[RecomputeSnapshotEdge] = []
   for id in ids {
     match self.rt.cell_info(id) {
       Some(info) => {
@@ -278,7 +281,9 @@ pub fn RecomputeTap::snapshot(self : RecomputeTap) -> IncrSnapshot {
 
 ///|
 /// Convert an `incr` runtime snapshot to the renderer-neutral visual graph.
-pub fn IncrSnapshot::to_visual_graph(self : IncrSnapshot) -> VisualGraph {
+pub fn RecomputeSnapshot::to_visual_graph(
+  self : RecomputeSnapshot,
+) -> VisualGraph {
   let graph = VisualGraph(id="incr")
   for node in self.nodes {
     let record = event_for_cell(self.events, node.id)

--- a/lib/visualizer/incr_tap_wbtest.mbt
+++ b/lib/visualizer/incr_tap_wbtest.mbt
@@ -25,13 +25,13 @@ test "to_visual_graph surfaces latest elapsed_ns on the recomputed cell only" {
   let untimed_cell : @incr.CellId = { id: 2, runtime_id: 0 }
   let rev3 : @incr.Revision = { value: 3 }
   let rev4 : @incr.Revision = { value: 4 }
-  let timed_node : IncrSnapshotNode = {
+  let timed_node : RecomputeSnapshotNode = {
     id: timed_cell,
     label: Some("sum"),
     changed_at: rev4,
     verified_at: rev4,
   }
-  let untimed_node : IncrSnapshotNode = {
+  let untimed_node : RecomputeSnapshotNode = {
     id: untimed_cell,
     label: Some("input"),
     changed_at: rev3,
@@ -46,7 +46,7 @@ test "to_visual_graph surfaces latest elapsed_ns on the recomputed cell only" {
     changed_at: Some(rev4),
     backdated: false,
   }
-  let snapshot : IncrSnapshot = {
+  let snapshot : RecomputeSnapshot = {
     nodes: [timed_node, untimed_node],
     edges: [],
     events: [event],

--- a/lib/visualizer/pkg.generated.mbti
+++ b/lib/visualizer/pkg.generated.mbti
@@ -12,25 +12,6 @@ import {
 // Errors
 
 // Types and methods
-pub struct IncrSnapshot {
-  nodes : Array[IncrSnapshotNode]
-  edges : Array[IncrSnapshotEdge]
-  events : Array[RecomputeRecord]
-}
-pub fn IncrSnapshot::to_visual_graph(Self) -> VisualGraph
-
-pub struct IncrSnapshotEdge {
-  from : @types.CellId
-  to : @types.CellId
-}
-
-pub struct IncrSnapshotNode {
-  id : @types.CellId
-  label : String?
-  changed_at : @types.Revision
-  verified_at : @types.Revision
-}
-
 pub(all) enum RecomputePhase {
   Entering
   Completed
@@ -47,13 +28,32 @@ pub struct RecomputeRecord {
   backdated : Bool
 }
 
+pub struct RecomputeSnapshot {
+  nodes : Array[RecomputeSnapshotNode]
+  edges : Array[RecomputeSnapshotEdge]
+  events : Array[RecomputeRecord]
+}
+pub fn RecomputeSnapshot::to_visual_graph(Self) -> VisualGraph
+
+pub struct RecomputeSnapshotEdge {
+  from : @types.CellId
+  to : @types.CellId
+}
+
+pub struct RecomputeSnapshotNode {
+  id : @types.CellId
+  label : String?
+  changed_at : @types.Revision
+  verified_at : @types.Revision
+}
+
 pub struct RecomputeTap {
   // private fields
 }
 pub fn RecomputeTap::attach(@cells.Runtime) -> Self raise Failure
 pub fn RecomputeTap::detach(Self) -> Unit
 pub fn RecomputeTap::drain_events(Self) -> Array[RecomputeRecord]
-pub fn RecomputeTap::snapshot(Self) -> IncrSnapshot
+pub fn RecomputeTap::snapshot(Self) -> RecomputeSnapshot
 
 pub struct VisualEdge {
   // private fields


### PR DESCRIPTION
Closes #472. Follow-up to #464 (PR #471), which renamed the tap/event types `IncrMemoEvent*` → `Recompute*`. This renames the **snapshot** types in the same file for family parity:

| Before | After |
|---|---|
| `IncrSnapshot` | `RecomputeSnapshot` |
| `IncrSnapshotNode` | `RecomputeSnapshotNode` |
| `IncrSnapshotEdge` | `RecomputeSnapshotEdge` |

`RecomputeTap::snapshot` now returns `RecomputeSnapshot`, resolving the naming inconsistency #472 calls out.

### Naming choice
Chose `RecomputeSnapshot` over bare `Snapshot` (the issue says "`Snapshot` (or a clearer name)") because the type is produced by `RecomputeTap`, embeds `RecomputeRecord` events, and gives parity with the `RecomputeTap`/`RecomputeRecord`/`RecomputePhase` family. Bare `Snapshot` would be the lone un-prefixed type in the package. Grep confirmed no `Snapshot`/`RecomputeSnapshot` token collision.

### Scope
- Surface is entirely `lib/visualizer`-local: `incr_tap.mbt`, `incr_tap_wbtest.mbt`, and `pkg.generated.mbti` (regenerated via `moon info`, not hand-edited).
- No consumer names the type — `examples/ideal` calls `RecomputeTap::snapshot()`/`to_visual_graph()` inline.
- No variant-collision / qualification dance (unlike #464): these are visualizer-local names with no `@incr.*` counterpart.

### Verification
- `moon check` (visualizer module) ✅
- 1298/1298 tests pass `[js]` ✅
- `moon fmt --check` clean ✅ (the two re-wrapped signatures are the `fmt` consequence of the longer identifier)
- `examples/ideal` consumer **clean rebuild** (199 tasks) ✅ — confirms no call-site breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
