### PR TITLE
Add source-backed graph adapter

### DIFF
--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -241,6 +241,37 @@ fn validate_workflow(state : CanvasState) -> Array[ValidationJson] {
 }
 
 ///|
+fn render_state_json(
+  state : CanvasState,
+  validation : Array[ValidationJson],
+) -> RenderStateJson {
+  let selected : Int? = match state.interaction.selected {
+    None => None
+    Some(id) => Some(node_id_to_int(id))
+  }
+  let selected_nodes = state.interaction.selected_nodes.map(node_id_to_int)
+  {
+    viewport: state.viewport,
+    nodes: state.nodes.map(node_to_json),
+    edges: state.edges.map(edge_to_json),
+    selected,
+    selected_nodes,
+    connecting: connecting_to_json(state.interaction.connecting),
+    validation,
+    action_count: state.action_log.length(),
+    inspector: None,
+  }
+}
+
+///|
+fn render_state_string(
+  state : CanvasState,
+  validation : Array[ValidationJson],
+) -> String {
+  render_state_json(state, validation).to_json().stringify()
+}
+
+///|
 pub fn get_render_state(handle : Int) -> String {
   _registry[handle].render_state().to_json().stringify()
 }

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -1,0 +1,422 @@
+///|
+struct SourceBackedGraph {
+  attachment : @graph_dsl.GraphAttachment
+  mut source : String
+  viewport : Viewport
+  interaction : InteractionState
+  action_log : Array[GraphOperation]
+}
+
+///|
+fn SourceBackedGraph::SourceBackedGraph(source : String) -> SourceBackedGraph {
+  {
+    attachment: @graph_dsl.GraphAttachment::GraphAttachment(source),
+    source,
+    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    interaction: @graph_model.empty_interaction(),
+    action_log: [],
+  }
+}
+
+///|
+fn SourceBackedGraph::dispose(self : SourceBackedGraph) -> Unit {
+  self.attachment.dispose()
+}
+
+///|
+let _source_registry : Array[SourceBackedGraph?] = []
+
+///|
+fn source_graph_by_handle(handle : Int) -> SourceBackedGraph? {
+  if handle < 0 || handle >= _source_registry.length() {
+    None
+  } else {
+    _source_registry[handle]
+  }
+}
+
+///|
+fn empty_source_canvas_state() -> CanvasState {
+  {
+    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    nodes: [],
+    edges: [],
+    next_node_id: 1,
+    next_edge_id: 1,
+    interaction: @graph_model.empty_interaction(),
+    action_log: [],
+  }
+}
+
+///|
+fn graph_input_reference(param : @graph_dsl.GraphParam) -> String? {
+  for token in param.value_tokens() {
+    if token.role() == @graph_dsl.InputReference {
+      return Some(token.text())
+    }
+  }
+  None
+}
+
+///|
+fn canvas_id_for_binding(
+  doc : @graph_dsl.GraphDoc,
+  binding : String,
+) -> NodeId? {
+  for i, node in doc.nodes() {
+    if node.binding() == binding {
+      return Some(NodeId(i + 1))
+    }
+  }
+  None
+}
+
+///|
+fn graph_node_for_canvas_id(
+  doc : @graph_dsl.GraphDoc,
+  id : NodeId,
+) -> @graph_dsl.GraphNode? {
+  let NodeId(raw_id) = id
+  let index = raw_id - 1
+  let nodes = doc.nodes()
+  if index < 0 || index >= nodes.length() {
+    None
+  } else {
+    Some(nodes[index])
+  }
+}
+
+///|
+fn canvas_node_from_graph_node(
+  index : Int,
+  graph_node : @graph_dsl.GraphNode,
+) -> CanvasNode {
+  {
+    id: NodeId(index + 1),
+    x: index.to_double() * 300.0,
+    y: 0.0,
+    w: 250.0,
+    h: 138.0,
+    kind: Workflow(Custom(graph_node.constructor_name())),
+    title: graph_node.binding(),
+    subtitle: graph_node.constructor_name(),
+    inputs: [@graph_model.port("input", "input", Any)],
+    outputs: [@graph_model.port("out", "out", Any)],
+    configured: true,
+  }
+}
+
+///|
+fn canvas_from_graph_doc(doc : @graph_dsl.GraphDoc) -> CanvasState {
+  let nodes : Array[CanvasNode] = []
+  for i, graph_node in doc.nodes() {
+    nodes.push(canvas_node_from_graph_node(i, graph_node))
+  }
+  let edges : Array[Edge] = []
+  for target_index, graph_node in doc.nodes() {
+    for param in graph_node.params() {
+      match graph_input_reference(param) {
+        None => ()
+        Some(source_binding) =>
+          match canvas_id_for_binding(doc, source_binding) {
+            None => ()
+            Some(source) =>
+              edges.push({
+                id: EdgeId(edges.length() + 1),
+                source,
+                source_port: "out",
+                target: NodeId(target_index + 1),
+                target_port: param.name(),
+              })
+          }
+      }
+    }
+  }
+  {
+    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    nodes,
+    edges,
+    next_node_id: nodes.length() + 1,
+    next_edge_id: edges.length() + 1,
+    interaction: @graph_model.empty_interaction(),
+    action_log: [],
+  }
+}
+
+///|
+fn source_graph_doc_for_render(
+  graph : SourceBackedGraph,
+) -> @graph_dsl.GraphDoc? {
+  match graph.attachment.current_result() {
+    Ok(doc) => Some(doc)
+    Err(_) => graph.attachment.last_good()
+  }
+}
+
+///|
+fn source_graph_canvas_state(graph : SourceBackedGraph) -> CanvasState {
+  match source_graph_doc_for_render(graph) {
+    Some(doc) => {
+      let state = canvas_from_graph_doc(doc)
+      {
+        ..state,
+        viewport: graph.viewport,
+        interaction: graph.interaction,
+        action_log: graph.action_log.copy(),
+      }
+    }
+    None => { ..empty_source_canvas_state(), viewport: graph.viewport }
+  }
+}
+
+///|
+fn source_graph_validation(graph : SourceBackedGraph) -> Array[ValidationJson] {
+  let messages : Array[ValidationJson] = []
+  for message in graph.attachment.diagnostics() {
+    messages.push({ severity: "error", message, node_id: None })
+  }
+  messages
+}
+
+///|
+struct SourceGraphOperationResultJson {
+  applied : Bool
+  source : String
+  diagnostics : Array[String]
+  action_count : Int
+  message : String?
+} derive(ToJson)
+
+///|
+fn source_graph_operation_result(
+  applied : Bool,
+  source : String,
+  diagnostics : Array[String],
+  action_count : Int,
+  message : String?,
+) -> String {
+  (
+    { applied, source, diagnostics, action_count, message } :
+    SourceGraphOperationResultJson)
+  .to_json()
+  .stringify()
+}
+
+///|
+fn source_graph_result_for_graph(
+  graph : SourceBackedGraph,
+  applied : Bool,
+  message : String?,
+) -> String {
+  source_graph_operation_result(
+    applied,
+    graph.source,
+    graph.attachment.diagnostics(),
+    graph.action_log.length(),
+    message,
+  )
+}
+
+///|
+fn decode_graph_operation(json_text : String) -> Result[GraphOperation, String] {
+  let json = @json.parse(json_text) catch {
+    _ => return Err("operation JSON parse failed")
+  }
+  let operation : GraphOperation = @json.from_json(json) catch {
+    _ => return Err("operation JSON decode failed")
+  }
+  Ok(operation)
+}
+
+///|
+fn source_graph_current_doc(
+  graph : SourceBackedGraph,
+) -> Result[@graph_dsl.GraphDoc, String] {
+  match graph.attachment.current_result() {
+    Ok(doc) => Ok(doc)
+    Err(message) => Err("current source is not graph-valid: " + message)
+  }
+}
+
+///|
+fn lower_source_operation(
+  doc : @graph_dsl.GraphDoc,
+  operation : GraphOperation,
+) -> Result[@graph_dsl.LoweredGraphEdit, String] {
+  match operation.action() {
+    AddNode(node) =>
+      match doc.lower_insert_node_binding(node.title, node.subtitle) {
+        Some(edit) => Ok(edit)
+        None =>
+          Err(
+            "cannot lower AddNode for binding '" +
+            node.title +
+            "' and constructor '" +
+            node.subtitle +
+            "'",
+          )
+      }
+    ConnectPorts(source, source_port, target, target_port) => {
+      if source_port != "out" {
+        return Err("graph-dsl source connections must use port 'out'")
+      }
+      if target_port != "input" {
+        return Err("graph-dsl target connections must use port 'input'")
+      }
+      let source_node = match graph_node_for_canvas_id(doc, source) {
+        Some(node) => node
+        None => return Err("cannot lower ConnectPorts: missing source node")
+      }
+      let target_node = match graph_node_for_canvas_id(doc, target) {
+        Some(node) => node
+        None => return Err("cannot lower ConnectPorts: missing target node")
+      }
+      match
+        doc.lower_add_connection(target_node.binding(), source_node.binding()) {
+        Some(edit) => Ok(edit)
+        None => Err("cannot lower ConnectPorts into source")
+      }
+    }
+    MoveNodes(_) =>
+      Err("MoveNodes is local layout state; source lowering is not defined")
+    SelectNodes(_) =>
+      Err(
+        "SelectNodes is local selection state; source lowering is not defined",
+      )
+    SetViewport(_) =>
+      Err("SetViewport is local viewport state; source lowering is not defined")
+  }
+}
+
+///|
+fn SourceBackedGraph::apply_lowered_edit(
+  self : SourceBackedGraph,
+  edit : @graph_dsl.LoweredGraphEdit,
+) -> Result[Unit, String] {
+  let old_source = self.source
+  let new_source = edit.new_source()
+  match edit.incremental_edit() {
+    Some(incremental_edit) =>
+      self.attachment.apply_edit(incremental_edit, new_source)
+    None => self.attachment.set_source(new_source)
+  }
+  self.source = new_source
+  match self.attachment.current_result() {
+    Ok(_) => Ok(())
+    Err(message) => {
+      self.source = old_source
+      self.attachment.set_source(old_source)
+      Err(message)
+    }
+  }
+}
+
+///|
+fn SourceBackedGraph::append_operation(
+  self : SourceBackedGraph,
+  operation : GraphOperation,
+) -> Unit {
+  self.action_log.push(operation)
+}
+
+///|
+pub fn create_source_graph(source : String) -> Int {
+  _source_registry.push(Some(SourceBackedGraph(source)))
+  _source_registry.length() - 1
+}
+
+///|
+pub fn destroy_source_graph(handle : Int) -> Unit {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.dispose()
+    None => ()
+  }
+  if handle >= 0 && handle < _source_registry.length() {
+    _source_registry[handle] = None
+  }
+}
+
+///|
+pub fn get_source_graph_source(handle : Int) -> String {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.source
+    None => ""
+  }
+}
+
+///|
+pub fn set_source_graph_source(handle : Int, source : String) -> Unit {
+  match source_graph_by_handle(handle) {
+    Some(graph) => {
+      graph.source = source
+      graph.attachment.set_source(source)
+    }
+    None => ()
+  }
+}
+
+///|
+pub fn get_source_graph_render_state(handle : Int) -> String {
+  match source_graph_by_handle(handle) {
+    Some(graph) => {
+      let state = source_graph_canvas_state(graph)
+      render_state_string(state, source_graph_validation(graph))
+    }
+    None =>
+      render_state_string(empty_source_canvas_state(), [
+        {
+          severity: "error",
+          message: "source graph handle not found",
+          node_id: None,
+        },
+      ])
+  }
+}
+
+///|
+pub fn get_source_graph_action_log(handle : Int) -> String {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.action_log.to_json().stringify()
+    None => ([] : Array[GraphOperation]).to_json().stringify()
+  }
+}
+
+///|
+pub fn apply_source_graph_operation(
+  handle : Int,
+  operation_json : String,
+) -> String {
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None =>
+      return source_graph_operation_result(
+        false,
+        "",
+        ["source graph handle not found"],
+        0,
+        Some("source graph handle not found"),
+      )
+  }
+  let operation = match decode_graph_operation(operation_json) {
+    Ok(operation) => operation
+    Err(message) =>
+      return source_graph_result_for_graph(graph, false, Some(message))
+  }
+  let doc = match source_graph_current_doc(graph) {
+    Ok(doc) => doc
+    Err(message) =>
+      return source_graph_result_for_graph(graph, false, Some(message))
+  }
+  let lowered = match lower_source_operation(doc, operation) {
+    Ok(edit) => edit
+    Err(message) =>
+      return source_graph_result_for_graph(graph, false, Some(message))
+  }
+  match graph.apply_lowered_edit(lowered) {
+    Ok(_) => {
+      graph.append_operation(operation)
+      source_graph_result_for_graph(graph, true, None)
+    }
+    Err(message) => source_graph_result_for_graph(graph, false, Some(message))
+  }
+}

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -292,7 +292,7 @@ fn lower_source_operation(
 fn SourceBackedGraph::apply_lowered_edit(
   self : SourceBackedGraph,
   edit : @graph_dsl.LoweredGraphEdit,
-) -> Result[Unit, String] {
+) -> Result[@graph_dsl.GraphDoc, String] {
   let old_source = self.source
   let new_source = edit.new_source()
   match edit.incremental_edit() {
@@ -302,12 +302,27 @@ fn SourceBackedGraph::apply_lowered_edit(
   }
   self.source = new_source
   match self.attachment.current_result() {
-    Ok(_) => Ok(())
+    Ok(doc) => Ok(doc)
     Err(message) => {
       self.source = old_source
       self.attachment.set_source(old_source)
       Err(message)
     }
+  }
+}
+
+///|
+fn realized_source_operation(
+  doc : @graph_dsl.GraphDoc,
+  operation : GraphOperation,
+) -> GraphOperation {
+  match operation.action() {
+    AddNode(node) =>
+      match canvas_id_for_binding(doc, node.title) {
+        Some(id) => GraphOperation(AddNode({ ..node, id, }))
+        None => operation
+      }
+    _ => operation
   }
 }
 
@@ -413,8 +428,8 @@ pub fn apply_source_graph_operation(
       return source_graph_result_for_graph(graph, false, Some(message))
   }
   match graph.apply_lowered_edit(lowered) {
-    Ok(_) => {
-      graph.append_operation(operation)
+    Ok(doc) => {
+      graph.append_operation(realized_source_operation(doc, operation))
       source_graph_result_for_graph(graph, true, None)
     }
     Err(message) => source_graph_result_for_graph(graph, false, Some(message))

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -57,6 +57,16 @@ fn operation_result_applied(json_text : String) -> Bool {
 }
 
 ///|
+fn ok_operation_log(json_text : String) -> Array[GraphOperation] {
+  let json = @json.parse(json_text) catch {
+    _ => abort("expected operation log JSON")
+  }
+  @json.from_json(json) catch {
+    _ => abort("expected GraphOperation array")
+  }
+}
+
+///|
 fn graph_node_id(doc : @graph_dsl.GraphDoc, binding : String) -> String {
   match doc.find_node(binding) {
     Some(node) => node.id()
@@ -213,7 +223,15 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
     get_source_graph_source(handle),
     content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()",
   )
-  inspect(get_source_graph_action_log(handle) == "[]", content="false")
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  match operations {
+    [_, added] =>
+      match added.action() {
+        AddNode(node) => @debug.assert_eq(node.id, NodeId(3))
+        _ => abort("expected AddNode action")
+      }
+    _ => abort("expected two source-backed operations")
+  }
   destroy_source_graph(handle)
 }
 

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -1,7 +1,4 @@
 ///|
-using @graph_model {empty_interaction, port}
-
-///|
 const GRAPH_DSL_SAMPLE = "osc = sine(freq: 440Hz, wave: \"saw\") -> audio\nfilter = lowpass(input: osc, cutoff: 1200Hz, mode: warm)"
 
 ///|
@@ -44,6 +41,22 @@ fn ok_lowered(
 }
 
 ///|
+fn operation_result_applied(json_text : String) -> Bool {
+  let json = @json.parse(json_text) catch {
+    _ => abort("expected operation result JSON")
+  }
+  match json {
+    Json::Object(fields) =>
+      match fields.get("applied") {
+        Some(Json::True) => true
+        Some(Json::False) => false
+        _ => abort("expected operation result applied flag")
+      }
+    _ => abort("expected operation result object")
+  }
+}
+
+///|
 fn graph_node_id(doc : @graph_dsl.GraphDoc, binding : String) -> String {
   match doc.find_node(binding) {
     Some(node) => node.id()
@@ -52,75 +65,13 @@ fn graph_node_id(doc : @graph_dsl.GraphDoc, binding : String) -> String {
 }
 
 ///|
-fn canvas_id_for_binding(doc : @graph_dsl.GraphDoc, binding : String) -> NodeId {
-  for i, node in doc.nodes() {
-    if node.binding() == binding {
-      return NodeId(i + 1)
-    }
-  }
-  abort("missing graph binding: " + binding)
-}
-
-///|
-fn graph_input_reference(param : @graph_dsl.GraphParam) -> String? {
-  for token in param.value_tokens() {
-    if token.role() == @graph_dsl.InputReference {
-      return Some(token.text())
-    }
-  }
-  None
-}
-
-///|
-fn canvas_node_from_graph_node(
-  index : Int,
-  graph_node : @graph_dsl.GraphNode,
-) -> CanvasNode {
-  {
-    id: NodeId(index + 1),
-    x: index.to_double() * 300.0,
-    y: 0.0,
-    w: 250.0,
-    h: 138.0,
-    kind: Workflow(Custom(graph_node.constructor_name())),
-    title: graph_node.binding(),
-    subtitle: graph_node.constructor_name(),
-    inputs: [port("input", "input", Any)],
-    outputs: [port("out", "out", Any)],
-    configured: true,
-  }
-}
-
-///|
-fn canvas_from_graph_doc(doc : @graph_dsl.GraphDoc) -> CanvasState {
-  let nodes : Array[CanvasNode] = []
-  for i, graph_node in doc.nodes() {
-    nodes.push(canvas_node_from_graph_node(i, graph_node))
-  }
-  let edges : Array[Edge] = []
-  for target_index, graph_node in doc.nodes() {
-    for param in graph_node.params() {
-      match graph_input_reference(param) {
-        None => ()
-        Some(source_binding) =>
-          edges.push({
-            id: EdgeId(edges.length() + 1),
-            source: canvas_id_for_binding(doc, source_binding),
-            source_port: "out",
-            target: NodeId(target_index + 1),
-            target_port: param.name(),
-          })
-      }
-    }
-  }
-  {
-    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
-    nodes,
-    edges,
-    next_node_id: nodes.length() + 1,
-    next_edge_id: edges.length() + 1,
-    interaction: empty_interaction(),
-    action_log: [],
+fn required_canvas_id_for_binding(
+  doc : @graph_dsl.GraphDoc,
+  binding : String,
+) -> NodeId {
+  match canvas_id_for_binding(doc, binding) {
+    Some(id) => id
+    None => abort("missing graph binding: " + binding)
   }
 }
 
@@ -190,8 +141,14 @@ test "ConnectPorts and AddNode lower through source and reparse to canvas graph"
   let connected_canvas = canvas_from_graph_doc(connected)
   match connected_canvas.edges {
     [edge] => {
-      @debug.assert_eq(edge.source, canvas_id_for_binding(connected, "osc"))
-      @debug.assert_eq(edge.target, canvas_id_for_binding(connected, "meter"))
+      @debug.assert_eq(
+        edge.source,
+        required_canvas_id_for_binding(connected, "osc"),
+      )
+      @debug.assert_eq(
+        edge.target,
+        required_canvas_id_for_binding(connected, "meter"),
+      )
     }
     _ => abort("expected exactly one canvas edge")
   }
@@ -214,6 +171,87 @@ test "ConnectPorts and AddNode lower through source and reparse to canvas graph"
     }
     _ => abort("expected three canvas nodes after AddNode")
   }
+}
+
+///|
+test "source-backed handle lowers GraphOperation through graph-dsl source" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let connect = GraphOperation(
+    ConnectPorts(NodeId(1), "out", NodeId(2), "input"),
+  )
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, connect.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)",
+  )
+  let added : CanvasNode = {
+    id: NodeId(3),
+    x: 0.0,
+    y: 0.0,
+    w: 250.0,
+    h: 138.0,
+    kind: Workflow(Custom("plate")),
+    title: "reverb",
+    subtitle: "plate",
+    inputs: [],
+    outputs: [],
+    configured: true,
+  }
+  let insert = GraphOperation(AddNode(added))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, insert.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()",
+  )
+  inspect(get_source_graph_action_log(handle) == "[]", content="false")
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed handle rejects local graph operations without mutating source" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  let viewport : Viewport = { x: 12.0, y: 24.0, scale: 2.0 }
+  let local_operation = GraphOperation(SetViewport(viewport))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(
+        handle,
+        local_operation.to_json().stringify(),
+      ),
+    ),
+    content="false",
+  )
+  inspect(get_source_graph_source(handle), content=source)
+  inspect(get_source_graph_action_log(handle), content="[]")
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed handle rejects graph operations while source is invalid" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  set_source_graph_source(handle, "osc = sine(freq: )")
+  let connect = GraphOperation(
+    ConnectPorts(NodeId(1), "out", NodeId(2), "input"),
+  )
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, connect.to_json().stringify()),
+    ),
+    content="false",
+  )
+  inspect(get_source_graph_source(handle), content="osc = sine(freq: )")
+  destroy_source_graph(handle)
 }
 
 ///|

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -3,11 +3,8 @@ import {
   "moonbitlang/core/debug",
   "dowdiness/canopy-canvas/graph_model",
   "dowdiness/incr",
-}
-
-import {
   "dowdiness/graph-dsl" @graph_dsl,
-} for "wbtest"
+}
 
 options(
   "is-main": true,
@@ -24,6 +21,13 @@ options(
         "add_node",
         "get_render_state",
         "get_action_log",
+        "create_source_graph",
+        "destroy_source_graph",
+        "get_source_graph_source",
+        "set_source_graph_source",
+        "get_source_graph_render_state",
+        "get_source_graph_action_log",
+        "apply_source_graph_operation",
       ],
     },
   },

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -9,11 +9,23 @@ import {
 // Values
 pub fn add_node(Int, String, Double, Double) -> Unit
 
+pub fn apply_source_graph_operation(Int, String) -> String
+
 pub fn create_canvas() -> Int
+
+pub fn create_source_graph(String) -> Int
+
+pub fn destroy_source_graph(Int) -> Unit
 
 pub fn get_action_log(Int) -> String
 
 pub fn get_render_state(Int) -> String
+
+pub fn get_source_graph_action_log(Int) -> String
+
+pub fn get_source_graph_render_state(Int) -> String
+
+pub fn get_source_graph_source(Int) -> String
 
 pub fn hover_node(Int, Int) -> Unit
 
@@ -24,6 +36,8 @@ pub fn pointer_down_handle(Int, Int, String, Double, Double) -> Unit
 pub fn pointer_move(Int, Double, Double) -> Unit
 
 pub fn pointer_up(Int, Int, String, Bool) -> Unit
+
+pub fn set_source_graph_source(Int, String) -> Unit
 
 pub fn zoom(Int, Double, Double, Double) -> Unit
 
@@ -56,6 +70,10 @@ type NormalizedCanvas derive(Eq)
 type RenderStateJson derive(Eq, ToJson)
 
 type SelectionState derive(Eq, @debug.Debug)
+
+type SourceBackedGraph
+
+type SourceGraphOperationResultJson derive(ToJson)
 
 type ValidatedCanvas derive(Eq)
 

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -20,7 +20,34 @@ export type CanvasModule = {
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   get_render_state: (h: number) => string;
   get_action_log: (h: number) => string;
+  create_source_graph?: (source: string) => number;
+  destroy_source_graph?: (h: number) => void;
+  get_source_graph_source?: (h: number) => string;
+  set_source_graph_source?: (h: number, source: string) => void;
+  get_source_graph_render_state?: (h: number) => string;
+  get_source_graph_action_log?: (h: number) => string;
+  apply_source_graph_operation?: (h: number, operationJson: string) => string;
 };
+
+type SourceCanvasModule = CanvasModule & {
+  create_source_graph: (source: string) => number;
+  destroy_source_graph: (h: number) => void;
+  get_source_graph_source: (h: number) => string;
+  set_source_graph_source: (h: number, source: string) => void;
+  get_source_graph_render_state: (h: number) => string;
+  get_source_graph_action_log: (h: number) => string;
+  apply_source_graph_operation: (h: number, operationJson: string) => string;
+};
+
+const SOURCE_METHODS = [
+  'create_source_graph',
+  'destroy_source_graph',
+  'get_source_graph_source',
+  'set_source_graph_source',
+  'get_source_graph_render_state',
+  'get_source_graph_action_log',
+  'apply_source_graph_operation',
+] as const;
 
 export type Tagged = string | [string, ...unknown[]];
 export type NodeKind = ['Workflow', Tagged];
@@ -96,13 +123,47 @@ export type GraphOperation =
 
 export type GraphOperationCallback = (operation: GraphOperation) => void;
 
+export type SourceGraphOperationResult = {
+  applied: boolean;
+  source: string;
+  diagnostics: string[];
+  action_count: number;
+  message?: string;
+};
+
+type AdapterMode = 'canvas' | 'source';
+
+function requireSourceModule(mb: CanvasModule): SourceCanvasModule {
+  const missing = SOURCE_METHODS.filter((name) => typeof mb[name] !== 'function');
+  if (missing.length > 0) {
+    throw new Error(`Canvas module is missing source graph exports: ${missing.join(', ')}`);
+  }
+  return mb as SourceCanvasModule;
+}
+
+function sourceNodePayload(binding: string, constructorName: string): NodeData {
+  return {
+    id: 0,
+    x: 0,
+    y: 0,
+    w: 250,
+    h: 138,
+    kind: ['Workflow', ['Custom', constructorName]],
+    title: binding,
+    subtitle: constructorName,
+    inputs: [],
+    outputs: [],
+    configured: true,
+  };
+}
+
 /**
  * Lifecycle boundary for the canvas graph surface.
  *
- * The current prototype remains MoonBit-state-backed: DOM rendering still pulls
- * `RenderState` snapshots from the MoonBit canvas model. This adapter is the
- * public TypeScript seam that later source-backed graph panes can reuse for
- * lifecycle, operation notification, and teardown without depending on globals.
+ * `create()` keeps the original MoonBit-canvas state as the backing store.
+ * `createSourceBacked()` keeps graph-dsl source text canonical: operations are
+ * sent to MoonBit as `GraphOperation` JSON, lowered through Loom GraphDoc source
+ * maps, and rendered from the reparsed source/last-good GraphDoc.
  */
 export class GraphAdapter {
   private operationCallback: GraphOperationCallback | null = null;
@@ -112,21 +173,34 @@ export class GraphAdapter {
   private constructor(
     private readonly mb: CanvasModule,
     private readonly handle: number,
+    private readonly mode: AdapterMode,
   ) {
     this.lastActionCount = this.readActionLog().length;
   }
 
   static create(mb: CanvasModule): GraphAdapter {
-    return new GraphAdapter(mb, mb.create_canvas());
+    return new GraphAdapter(mb, mb.create_canvas(), 'canvas');
+  }
+
+  static createSourceBacked(mb: CanvasModule, source: string): GraphAdapter {
+    const sourceMb = requireSourceModule(mb);
+    return new GraphAdapter(mb, sourceMb.create_source_graph(source), 'source');
   }
 
   get handleId(): number {
     return this.handle;
   }
 
+  get isSourceBacked(): boolean {
+    return this.mode === 'source';
+  }
+
   renderState(): RenderState {
     this.assertLive();
-    const state = JSON.parse(this.mb.get_render_state(this.handle)) as RenderState;
+    const json = this.isSourceBacked
+      ? this.sourceModule().get_source_graph_render_state(this.handle)
+      : this.mb.get_render_state(this.handle);
+    const state = JSON.parse(json) as RenderState;
     this.emitOperationsThrough(state.action_count);
     return state;
   }
@@ -142,8 +216,54 @@ export class GraphAdapter {
     this.lastActionCount = this.readActionLog().length;
   }
 
-  pointerDown(nodeId: number, sx: number, sy: number): void {
+  source(): string {
     this.assertLive();
+    return this.sourceModule().get_source_graph_source(this.handle);
+  }
+
+  setSource(source: string): void {
+    this.assertLive();
+    this.sourceModule().set_source_graph_source(this.handle, source);
+    this.lastActionCount = this.readActionLog().length;
+  }
+
+  applyOperation(operation: GraphOperation): SourceGraphOperationResult {
+    this.assertLive();
+    const result = JSON.parse(
+      this.sourceModule().apply_source_graph_operation(
+        this.handle,
+        JSON.stringify(operation),
+      ),
+    ) as SourceGraphOperationResult;
+    this.emitLatestOperations();
+    return result;
+  }
+
+  insertNode(binding: string, constructorName: string): SourceGraphOperationResult {
+    return this.applyOperation({
+      version: 1,
+      type: 'AddNode',
+      node: sourceNodePayload(binding, constructorName),
+    });
+  }
+
+  connectPorts(
+    sourceNodeId: number,
+    targetNodeId: number,
+    targetPortId = 'input',
+  ): SourceGraphOperationResult {
+    return this.applyOperation({
+      version: 1,
+      type: 'ConnectPorts',
+      source: sourceNodeId,
+      source_port: 'out',
+      target: targetNodeId,
+      target_port: targetPortId,
+    });
+  }
+
+  pointerDown(nodeId: number, sx: number, sy: number): void {
+    this.assertCanvasBacked('pointerDown');
     this.mb.pointer_down(this.handle, nodeId, sx, sy);
   }
 
@@ -153,17 +273,17 @@ export class GraphAdapter {
     sx: number,
     sy: number,
   ): void {
-    this.assertLive();
+    this.assertCanvasBacked('pointerDownHandle');
     this.mb.pointer_down_handle(this.handle, nodeId, portId, sx, sy);
   }
 
   pointerMove(sx: number, sy: number): void {
-    this.assertLive();
+    this.assertCanvasBacked('pointerMove');
     this.mb.pointer_move(this.handle, sx, sy);
   }
 
   pointerUp(nodeId: number, targetPortId: string, additive: boolean): void {
-    this.assertLive();
+    this.assertCanvasBacked('pointerUp');
     this.mb.pointer_up(this.handle, nodeId, targetPortId, additive);
     this.emitLatestOperations();
   }
@@ -174,24 +294,37 @@ export class GraphAdapter {
   }
 
   zoom(delta: number, cx: number, cy: number): void {
-    this.assertLive();
+    this.assertCanvasBacked('zoom');
     this.mb.zoom(this.handle, delta, cx, cy);
     this.emitLatestOperations();
   }
 
   addNode(kindKey: string, sx: number, sy: number): void {
-    this.assertLive();
+    this.assertCanvasBacked('addNode');
     this.mb.add_node(this.handle, kindKey, sx, sy);
     this.emitLatestOperations();
   }
 
   destroy(): void {
+    if (!this.destroyed && this.isSourceBacked) {
+      this.sourceModule().destroy_source_graph(this.handle);
+    }
     this.operationCallback = null;
     this.destroyed = true;
   }
 
   private readActionLog(): GraphOperation[] {
-    return JSON.parse(this.mb.get_action_log(this.handle)) as GraphOperation[];
+    const json = this.isSourceBacked
+      ? this.sourceModule().get_source_graph_action_log(this.handle)
+      : this.mb.get_action_log(this.handle);
+    return JSON.parse(json) as GraphOperation[];
+  }
+
+  private sourceModule(): SourceCanvasModule {
+    if (!this.isSourceBacked) {
+      throw new Error('GraphAdapter is not source-backed');
+    }
+    return this.mb as SourceCanvasModule;
   }
 
   private emitLatestOperations(): void {
@@ -215,6 +348,13 @@ export class GraphAdapter {
   private assertLive(): void {
     if (this.destroyed) {
       throw new Error('GraphAdapter has been destroyed');
+    }
+  }
+
+  private assertCanvasBacked(method: string): void {
+    this.assertLive();
+    if (this.isSourceBacked) {
+      throw new Error(`${method} is only available for canvas-backed graphs`);
     }
   }
 }

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -9,7 +9,11 @@ import {
 } from './graph-adapter';
 
 export { GraphAdapter } from './graph-adapter';
-export type { GraphOperation, RenderState } from './graph-adapter';
+export type {
+  GraphOperation,
+  RenderState,
+  SourceGraphOperationResult,
+} from './graph-adapter';
 
 type LibraryItem = {
   key: string;


### PR DESCRIPTION
## Summary

- add a source-backed canvas graph handle backed by `@graph_dsl.GraphAttachment`
- render source-backed graph state from current/last-good Loom `GraphDoc`
- lower `GraphOperation` JSON for `AddNode` and `ConnectPorts` through graph-dsl source edits
- extend the TypeScript `GraphAdapter` with `createSourceBacked`, source access, and operation application APIs

Refs #429.

## Reuse check

- Reused `@graph_dsl.GraphAttachment` for parser lifecycle, shared Loom runtime, diagnostics, and last-good graph state.
- Reused `@graph_dsl.GraphDoc` lowering APIs (`lower_insert_node_binding`, `lower_add_connection`) instead of creating a parallel graph document.
- Reused the existing `@graph_model.GraphOperation` JSON envelope and canvas render-state serialization path.

## Validation

- `moon check --deny-warn`
- `moon test --release`
- `NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info`
- `cd examples/canvas/web && npm run build`
- `git diff --check`

Known local note: `make fmt-check` currently fails on unrelated MoonBit formatter migration diffs from `moon.mod.json` to `moon.mod` across modules.
