### PR TITLE
feat(canvas): split graph UI state with incr

### DIFF
--- a/examples/canvas/graph_model/pkg.generated.mbti
+++ b/examples/canvas/graph_model/pkg.generated.mbti
@@ -199,3 +199,4 @@ pub impl Show for WorkflowNodeKind
 // Type aliases
 
 // Traits
+

--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -1,10 +1,10 @@
 ///|
 /// Global handle registry. Index = handle (Int returned by create_canvas).
-let _registry : Array[CanvasState] = []
+let _registry : Array[CanvasRuntime] = []
 
 ///|
 pub fn create_canvas() -> Int {
-  _registry.push(CanvasState::default())
+  _registry.push(CanvasRuntime::CanvasRuntime())
   _registry.length() - 1
 }
 
@@ -18,7 +18,7 @@ pub fn pointer_down(
   sy : Double,
 ) -> Unit {
   let id : NodeId? = if node_id <= 0 { None } else { Some(NodeId(node_id)) }
-  _registry[handle] = update_pointer_down(_registry[handle], id, sx, sy)
+  _registry[handle].pointer_down(id, sx, sy)
 }
 
 ///|
@@ -30,27 +30,19 @@ pub fn pointer_down_handle(
   sx : Double,
   sy : Double,
 ) -> Unit {
-  let state = _registry[handle]
-  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-  _registry[handle] = update_connect_start(
-    state,
-    NodeId(node_id),
-    port_id,
-    wx,
-    wy,
-  )
+  _registry[handle].pointer_down_handle(NodeId(node_id), port_id, sx, sy)
 }
 
 ///|
 /// Handle pointer-move in canvas-local screen coordinates.
 /// Routes to the active gesture (pan, drag, or connect) internally.
 pub fn pointer_move(handle : Int, sx : Double, sy : Double) -> Unit {
-  _registry[handle] = update_pointer_move(_registry[handle], sx, sy)
+  _registry[handle].pointer_move(sx, sy)
 }
 
 ///|
 pub fn zoom(handle : Int, delta : Double, cx : Double, cy : Double) -> Unit {
-  _registry[handle] = update_zoom(_registry[handle], delta, cx, cy)
+  _registry[handle].zoom(delta, cx, cy)
 }
 
 ///|
@@ -60,12 +52,12 @@ pub fn pointer_up(
   target_port_id : String,
   additive : Bool,
 ) -> Unit {
-  _registry[handle] = update_pointer_up(
-    _registry[handle],
-    node_id,
-    target_port_id,
-    additive,
-  )
+  _registry[handle].pointer_up(node_id, target_port_id, additive)
+}
+
+///|
+pub fn hover_node(handle : Int, node_id : Int) -> Unit {
+  _registry[handle].hover_node(node_id)
 }
 
 ///|
@@ -78,9 +70,7 @@ pub fn add_node(
   sx : Double,
   sy : Double,
 ) -> Unit {
-  let state = _registry[handle]
-  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-  _registry[handle] = workflow_add_node(state, kind_key, wx, wy)
+  _registry[handle].add_node(kind_key, sx, sy)
 }
 
 ///|
@@ -98,7 +88,7 @@ struct NodeJson {
   inputs : Array[PortDef]
   outputs : Array[PortDef]
   configured : Bool
-} derive(ToJson)
+} derive(Eq, ToJson)
 
 ///|
 struct EdgeJson {
@@ -107,7 +97,7 @@ struct EdgeJson {
   source_port : String
   target : Int
   target_port : String
-} derive(ToJson)
+} derive(Eq, ToJson)
 
 ///|
 /// Serialized in-flight connection. `from` is the source node id;
@@ -117,19 +107,30 @@ struct ConnectingJson {
   from_port : String
   cursor_x : Double
   cursor_y : Double
-} derive(ToJson)
+} derive(Eq, ToJson)
 
 ///|
 struct ValidationJson {
   severity : String
   message : String
   node_id : Int?
-} derive(ToJson)
+} derive(Eq, ToJson)
+
+///|
+struct InspectorNodeJson {
+  id : Int
+  title : String
+  subtitle : String
+  configured : Bool
+  input_count : Int
+  output_count : Int
+  source : String
+} derive(Eq, ToJson)
 
 ///|
 /// Serializable render snapshot sent to TypeScript each RAF frame.
-/// `selected`/`connecting` are absent (key omitted) when not active — MoonBit derive(ToJson) omits None keys.
-/// TypeScript: use `rs.selected != null` (loose equality) not `rs.selected !== null`.
+/// `selected`/`connecting`/`inspector` are absent (key omitted) when not active
+/// — MoonBit derive(ToJson) omits None keys. TypeScript: use `!= null` checks.
 struct RenderStateJson {
   viewport : Viewport
   nodes : Array[NodeJson]
@@ -139,12 +140,45 @@ struct RenderStateJson {
   connecting : ConnectingJson?
   validation : Array[ValidationJson]
   action_count : Int
-} derive(ToJson)
+  inspector : InspectorNodeJson?
+} derive(Eq, ToJson)
 
 ///|
 fn node_id_to_int(id : NodeId) -> Int {
   let NodeId(n) = id
   n
+}
+
+///|
+fn node_to_json(n : CanvasNode) -> NodeJson {
+  let NodeId(id) = n.id
+  {
+    id,
+    x: n.x,
+    y: n.y,
+    w: n.w,
+    h: n.h,
+    kind: n.kind,
+    title: n.title,
+    subtitle: n.subtitle,
+    inputs: n.inputs,
+    outputs: n.outputs,
+    configured: n.configured,
+  }
+}
+
+///|
+fn edge_to_json(e : Edge) -> EdgeJson {
+  let EdgeId(id) = e.id
+  let NodeId(s) = e.source
+  let NodeId(t) = e.target
+  {
+    id,
+    source: s,
+    source_port: e.source_port,
+    target: t,
+    target_port: e.target_port,
+  }
 }
 
 ///|
@@ -184,87 +218,34 @@ fn append_node_validation(
 }
 
 ///|
-fn validate_workflow(state : CanvasState) -> Array[ValidationJson] {
+fn validate_workflow_document(
+  document : CanvasDocument,
+) -> Array[ValidationJson] {
   let messages : Array[ValidationJson] = []
-  if state.nodes.length() == 0 {
+  if document.nodes.length() == 0 {
     messages.push({
       severity: "error",
       message: "Add at least one workflow node.",
       node_id: None,
     })
   }
-  for node in state.nodes {
-    append_node_validation(messages, node, state.edges)
+  for node in document.nodes {
+    append_node_validation(messages, node, document.edges)
   }
   messages
 }
 
 ///|
+fn validate_workflow(state : CanvasState) -> Array[ValidationJson] {
+  validate_workflow_document(canvas_document_from_state(state))
+}
+
+///|
 pub fn get_render_state(handle : Int) -> String {
-  let state = _registry[handle]
-  let selected : Int? = match state.interaction.selected {
-    None => None
-    Some(id) => Some(node_id_to_int(id))
-  }
-  let selected_nodes = state.interaction.selected_nodes.map(fn(id) {
-    node_id_to_int(id)
-  })
-  let connecting : ConnectingJson? = match state.interaction.connecting {
-    None => None
-    Some(c) => {
-      let NodeId(from) = c.from_node
-      Some({
-        from,
-        from_port: c.from_port,
-        cursor_x: c.cursor_x,
-        cursor_y: c.cursor_y,
-      })
-    }
-  }
-  let nodes = state.nodes.map(fn(n) {
-    let NodeId(id) = n.id
-    (
-      {
-        id,
-        x: n.x,
-        y: n.y,
-        w: n.w,
-        h: n.h,
-        kind: n.kind,
-        title: n.title,
-        subtitle: n.subtitle,
-        inputs: n.inputs,
-        outputs: n.outputs,
-        configured: n.configured,
-      } : NodeJson)
-  })
-  let edges = state.edges.map(fn(e) {
-    let EdgeId(id) = e.id
-    let NodeId(s) = e.source
-    let NodeId(t) = e.target
-    (
-      {
-        id,
-        source: s,
-        source_port: e.source_port,
-        target: t,
-        target_port: e.target_port,
-      } : EdgeJson)
-  })
-  let rs : RenderStateJson = {
-    viewport: state.viewport,
-    nodes,
-    edges,
-    selected,
-    selected_nodes,
-    connecting,
-    validation: validate_workflow(state),
-    action_count: state.action_log.length(),
-  }
-  rs.to_json().stringify()
+  _registry[handle].render_state().to_json().stringify()
 }
 
 ///|
 pub fn get_action_log(handle : Int) -> String {
-  _registry[handle].action_log.to_json().stringify()
+  _registry[handle].action_log_json()
 }

--- a/examples/canvas/main/canvas_runtime.mbt
+++ b/examples/canvas/main/canvas_runtime.mbt
@@ -1,0 +1,496 @@
+///|
+/// Coarse durable validation stage. It owns the document snapshot plus the
+/// validation messages derived from durable nodes/edges only.
+struct ValidatedCanvas {
+  document : CanvasDocument
+  validation : Array[ValidationJson]
+} derive(Eq)
+
+///|
+/// Coarse normalized graph stage. Kept explicit so the canvas runtime mirrors
+/// the graph-editor recompute bench shape: document -> validation ->
+/// normalization -> lowering -> render.
+struct NormalizedCanvas {
+  document : CanvasDocument
+  validation : Array[ValidationJson]
+} derive(Eq)
+
+///|
+struct LoweredCanvas {
+  nodes : Array[NodeJson]
+  edges : Array[EdgeJson]
+  validation : Array[ValidationJson]
+} derive(Eq)
+
+///|
+struct CanvasFullRenderJson {
+  viewport : Viewport
+  nodes : Array[NodeJson]
+  edges : Array[EdgeJson]
+  selected : Int?
+  selected_nodes : Array[Int]
+  connecting : ConnectingJson?
+  validation : Array[ValidationJson]
+  action_count : Int
+} derive(Eq)
+
+///|
+fn validate_canvas_document(document : CanvasDocument) -> ValidatedCanvas {
+  {
+    document: {
+      nodes: document.nodes.copy(),
+      edges: document.edges.copy(),
+      next_node_id: document.next_node_id,
+      next_edge_id: document.next_edge_id,
+    },
+    validation: validate_workflow(
+      canvas_state_from_parts(
+        document,
+        default_viewport(),
+        @graph_model.empty_interaction(),
+        [],
+      ),
+    ),
+  }
+}
+
+///|
+fn normalize_canvas(validated : ValidatedCanvas) -> NormalizedCanvas {
+  {
+    document: {
+      nodes: validated.document.nodes.copy(),
+      edges: validated.document.edges.copy(),
+      next_node_id: validated.document.next_node_id,
+      next_edge_id: validated.document.next_edge_id,
+    },
+    validation: validated.validation.copy(),
+  }
+}
+
+///|
+fn lower_canvas(normalized : NormalizedCanvas) -> LoweredCanvas {
+  {
+    nodes: normalized.document.nodes.map(node_to_json),
+    edges: normalized.document.edges.map(edge_to_json),
+    validation: normalized.validation.copy(),
+  }
+}
+
+///|
+fn preview_position_for(preview : DragPreview, node_id : Int) -> NodePosition? {
+  find_position(preview.positions, NodeId(node_id))
+}
+
+///|
+fn render_node_with_preview(node : NodeJson, preview : DragPreview) -> NodeJson {
+  match preview_position_for(preview, node.id) {
+    None => node
+    Some(pos) => { ..node, x: pos.x, y: pos.y }
+  }
+}
+
+///|
+fn canvas_node_with_preview(
+  node : CanvasNode,
+  preview : DragPreview,
+) -> CanvasNode {
+  match preview_position_for(preview, node_id_to_int(node.id)) {
+    None => node
+    Some(pos) => { ..node, x: pos.x, y: pos.y }
+  }
+}
+
+///|
+fn state_with_preview_nodes(
+  state : CanvasState,
+  preview : DragPreview,
+) -> CanvasState {
+  {
+    ..state,
+    nodes: state.nodes.map(fn(node) { canvas_node_with_preview(node, preview) }),
+  }
+}
+
+///|
+fn connecting_to_json(connecting : ConnectState?) -> ConnectingJson? {
+  match connecting {
+    None => None
+    Some(c) => {
+      let NodeId(from) = c.from_node
+      Some({
+        from,
+        from_port: c.from_port,
+        cursor_x: c.cursor_x,
+        cursor_y: c.cursor_y,
+      })
+    }
+  }
+}
+
+///|
+fn render_full_canvas(
+  lowered : LoweredCanvas,
+  viewport : Viewport,
+  drag_preview : DragPreview,
+  selection : SelectionState,
+  interaction : InteractionState,
+  action_count : Int,
+) -> CanvasFullRenderJson {
+  let selected : Int? = match selection.selected {
+    None => None
+    Some(id) => Some(node_id_to_int(id))
+  }
+  let selected_nodes = selection.selected_nodes.map(node_id_to_int)
+  {
+    viewport,
+    nodes: lowered.nodes.map(fn(node) {
+      render_node_with_preview(node, drag_preview)
+    }),
+    edges: lowered.edges.copy(),
+    selected,
+    selected_nodes,
+    connecting: connecting_to_json(interaction.connecting),
+    validation: lowered.validation.copy(),
+    action_count,
+  }
+}
+
+///|
+fn inspector_node_for_document(
+  document : CanvasDocument,
+  node_id : Int,
+) -> InspectorNodeJson? {
+  match find_node(document.nodes, NodeId(node_id)) {
+    None => None
+    Some(node) =>
+      Some({
+        id: node_id,
+        title: node.title,
+        subtitle: node.subtitle,
+        configured: node.configured,
+        input_count: node.inputs.length(),
+        output_count: node.outputs.length(),
+        source: "",
+      })
+  }
+}
+
+///|
+fn inspector_with_source(
+  inspector : InspectorNodeJson?,
+  source : String,
+) -> InspectorNodeJson? {
+  match inspector {
+    None => None
+    Some(node) => Some({ ..node, source, })
+  }
+}
+
+///|
+fn render_state_from_parts(
+  full : CanvasFullRenderJson,
+  inspector : InspectorNodeJson?,
+) -> RenderStateJson {
+  {
+    viewport: full.viewport,
+    nodes: full.nodes.copy(),
+    edges: full.edges.copy(),
+    selected: full.selected,
+    selected_nodes: full.selected_nodes.copy(),
+    connecting: full.connecting,
+    validation: full.validation.copy(),
+    action_count: full.action_count,
+    inspector,
+  }
+}
+
+///|
+/// Incr-backed canvas model. Durable graph edits flow through `document`;
+/// hover, drag preview, viewport, selection, and pointer gesture state are
+/// independent Inputs so high-frequency UI changes avoid durable recomputation.
+struct CanvasRuntime {
+  document : @incr.Input[CanvasDocument]
+  actions : @incr.Input[Array[GraphOperation]]
+  hover : @incr.Input[NodeId?]
+  drag_preview : @incr.Input[DragPreview]
+  viewport : @incr.Input[Viewport]
+  selection : @incr.Input[SelectionState]
+  interaction : @incr.Input[InteractionState]
+  render_watch : @incr.Watch[CanvasFullRenderJson]
+  inspector_watch : @incr.Watch[InspectorNodeJson?]
+}
+
+///|
+fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
+  let rt = @incr.Runtime()
+  let scope = @incr.Scope::new(rt)
+  let initial = CanvasState::default()
+  let document = scope.input(
+    canvas_document_from_state(initial),
+    label="canvas.document",
+  )
+  let actions = scope.input(
+    initial.action_log.copy(),
+    label="canvas.action_log",
+  )
+  let hover = scope.input(None, label="canvas.hover")
+  let drag_preview = scope.input(
+    idle_drag_preview(),
+    label="canvas.drag_preview",
+  )
+  let viewport = scope.input(initial.viewport, label="canvas.viewport")
+  let selection = scope.input(
+    selection_from_interaction(initial.interaction),
+    label="canvas.selection",
+  )
+  let interaction = scope.input(initial.interaction, label="canvas.gesture")
+
+  let validated = scope.derived(
+    () => validate_canvas_document(document.get()),
+    label="canvas.validation",
+  )
+  let normalized = scope.derived(
+    () => normalize_canvas(validated.get_or_abort()),
+    label="canvas.normalization",
+  )
+  let lowered = scope.derived(
+    () => lower_canvas(normalized.get_or_abort()),
+    label="canvas.lowering",
+  )
+  let render = scope.derived(
+    () => {
+      render_full_canvas(
+        lowered.get_or_abort(),
+        viewport.get(),
+        drag_preview.get(),
+        selection.get(),
+        interaction.get(),
+        actions.get().length(),
+      )
+    },
+    label="canvas.render",
+  )
+
+  let node_inspector = scope.derived_map(
+    (id : Int) => {
+      inspector_node_for_document(normalized.get_or_abort().document, id)
+    },
+    label="canvas.inspector.node_by_id",
+  )
+  let inspector_scope = scope.child()
+  let inspector = inspector_scope.reachable_derived(
+    () => {
+      let current_selection = selection.get()
+      match current_selection.selected {
+        Some(id) =>
+          inspector_with_source(
+            node_inspector.get_or_abort(node_id_to_int(id)),
+            "selected",
+          )
+        None =>
+          match hover.get() {
+            None => None
+            Some(id) =>
+              inspector_with_source(
+                node_inspector.get_or_abort(node_id_to_int(id)),
+                "hovered",
+              )
+          }
+      }
+    },
+    label="canvas.inspector.selected_node",
+  )
+
+  let render_watch = scope.add_watch(render.watch())
+  let inspector_watch = inspector_scope.add_watch(inspector.watch())
+  ignore(render_watch.read_or_abort())
+  ignore(inspector_watch.read_or_abort())
+  rt.gc()
+  {
+    document,
+    actions,
+    hover,
+    drag_preview,
+    viewport,
+    selection,
+    interaction,
+    render_watch,
+    inspector_watch,
+  }
+}
+
+///|
+fn CanvasRuntime::state_peek(self : CanvasRuntime) -> CanvasState {
+  let interaction = interaction_with_selection(
+    self.interaction.peek(),
+    self.selection.peek(),
+  )
+  canvas_state_from_parts(
+    self.document.peek(),
+    self.viewport.peek(),
+    interaction,
+    self.actions.peek(),
+  )
+}
+
+///|
+fn CanvasRuntime::sync_commit_state(
+  self : CanvasRuntime,
+  state : CanvasState,
+) -> Unit {
+  self.document.set(canvas_document_from_state(state))
+  self.viewport.set(state.viewport)
+  self.drag_preview.set(idle_drag_preview())
+  self.selection.set(selection_from_interaction(state.interaction))
+  self.interaction.set(state.interaction)
+  self.actions.set(state.action_log.copy())
+}
+
+///|
+fn CanvasRuntime::sync_viewport_state(
+  self : CanvasRuntime,
+  state : CanvasState,
+) -> Unit {
+  self.viewport.set(state.viewport)
+  self.interaction.set(state.interaction)
+}
+
+///|
+fn CanvasRuntime::sync_action_viewport_state(
+  self : CanvasRuntime,
+  state : CanvasState,
+) -> Unit {
+  self.viewport.set(state.viewport)
+  self.actions.set(state.action_log.copy())
+}
+
+///|
+fn CanvasRuntime::sync_document_action_state(
+  self : CanvasRuntime,
+  state : CanvasState,
+) -> Unit {
+  self.document.set(canvas_document_from_state(state))
+  self.actions.set(state.action_log.copy())
+}
+
+///|
+fn CanvasRuntime::pointer_down(
+  self : CanvasRuntime,
+  node_id : NodeId?,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let state = update_pointer_down(self.state_peek(), node_id, sx, sy)
+  self.drag_preview.set(idle_drag_preview())
+  self.interaction.set(state.interaction)
+}
+
+///|
+fn CanvasRuntime::pointer_down_handle(
+  self : CanvasRuntime,
+  node_id : NodeId,
+  port_id : String,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let state = self.state_peek()
+  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+  self.interaction.set(
+    update_connect_start(state, node_id, port_id, wx, wy).interaction,
+  )
+}
+
+///|
+fn CanvasRuntime::pointer_move(
+  self : CanvasRuntime,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let state = self.state_peek()
+  match state.interaction.connecting {
+    Some(_) => {
+      let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+      self.interaction.set(update_connect_move(state, wx, wy).interaction)
+    }
+    None =>
+      match state.interaction.dragging {
+        Some(drag) => {
+          let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+          let new_interaction : InteractionState = {
+            ..state.interaction,
+            did_move: true,
+          }
+          self.drag_preview.set(drag_preview_from_move(drag, wx, wy))
+          self.interaction.set(new_interaction)
+        }
+        None =>
+          match state.interaction.panning {
+            Some(_) => self.sync_viewport_state(update_pan_move(state, sx, sy))
+            None => ()
+          }
+      }
+  }
+}
+
+///|
+fn CanvasRuntime::pointer_up(
+  self : CanvasRuntime,
+  node_id : Int,
+  target_port_id : String,
+  additive : Bool,
+) -> Unit {
+  let state = self.state_peek()
+  let commit_state = match state.interaction.dragging {
+    Some(_) if state.interaction.did_move =>
+      state_with_preview_nodes(state, self.drag_preview.peek())
+    _ => state
+  }
+  self.sync_commit_state(
+    update_pointer_up(commit_state, node_id, target_port_id, additive),
+  )
+}
+
+///|
+fn CanvasRuntime::zoom(
+  self : CanvasRuntime,
+  delta : Double,
+  cx : Double,
+  cy : Double,
+) -> Unit {
+  self.sync_action_viewport_state(update_zoom(self.state_peek(), delta, cx, cy))
+}
+
+///|
+fn CanvasRuntime::hover_node(self : CanvasRuntime, node_id : Int) -> Unit {
+  let hovered : NodeId? = if node_id <= 0 {
+    None
+  } else {
+    Some(NodeId(node_id))
+  }
+  self.hover.set(hovered)
+}
+
+///|
+fn CanvasRuntime::add_node(
+  self : CanvasRuntime,
+  kind_key : String,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let state = self.state_peek()
+  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+  self.sync_document_action_state(workflow_add_node(state, kind_key, wx, wy))
+}
+
+///|
+fn CanvasRuntime::render_state(self : CanvasRuntime) -> RenderStateJson {
+  render_state_from_parts(
+    self.render_watch.read_or_abort(),
+    self.inspector_watch.read_or_abort(),
+  )
+}
+
+///|
+fn CanvasRuntime::action_log_json(self : CanvasRuntime) -> String {
+  self.actions.peek().to_json().stringify()
+}

--- a/examples/canvas/main/canvas_state.mbt
+++ b/examples/canvas/main/canvas_state.mbt
@@ -23,9 +23,101 @@ pub using @graph_model {
 ///|
 using @graph_model {
   find_node,
+  find_position,
   make_workflow_node,
   node_id_in_array,
   port_type_by_id,
   record_action,
   workflow_node_kind_from_key,
+}
+
+///|
+/// Durable workflow graph document. High-frequency UI affordances such as
+/// hover, live drag preview, and viewport live outside this value.
+struct CanvasDocument {
+  nodes : Array[CanvasNode]
+  edges : Array[Edge]
+  next_node_id : Int
+  next_edge_id : Int
+} derive(Debug, Eq)
+
+///|
+/// Ephemeral live-drag overlay. Empty positions means no active preview;
+/// committed node positions remain in `CanvasDocument` until pointerup.
+pub(all) struct DragPreview {
+  positions : Array[NodePosition]
+} derive(Debug, Eq)
+
+///|
+pub impl Show for DragPreview with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// Selection is its own UI input so sparse inspector surfaces can depend on it
+/// without reading drag/viewport gesture state.
+struct SelectionState {
+  selected : NodeId?
+  selected_nodes : Array[NodeId]
+} derive(Debug, Eq)
+
+///|
+fn selection_from_interaction(interaction : InteractionState) -> SelectionState {
+  {
+    selected: interaction.selected,
+    selected_nodes: interaction.selected_nodes.copy(),
+  }
+}
+
+///|
+fn interaction_with_selection(
+  interaction : InteractionState,
+  selection : SelectionState,
+) -> InteractionState {
+  {
+    ..interaction,
+    selected: selection.selected,
+    selected_nodes: selection.selected_nodes.copy(),
+  }
+}
+
+///|
+fn idle_drag_preview() -> DragPreview {
+  { positions: [] }
+}
+
+///|
+fn default_viewport() -> Viewport {
+  { x: 760.0, y: 330.0, scale: 0.75 }
+}
+
+///|
+fn canvas_document_from_state(state : CanvasState) -> CanvasDocument {
+  {
+    nodes: state.nodes.copy(),
+    edges: state.edges.copy(),
+    next_node_id: state.next_node_id,
+    next_edge_id: state.next_edge_id,
+  }
+}
+
+///|
+fn canvas_state_from_parts(
+  document : CanvasDocument,
+  viewport : Viewport,
+  interaction : InteractionState,
+  action_log : Array[GraphOperation],
+) -> CanvasState {
+  {
+    viewport,
+    nodes: document.nodes.copy(),
+    edges: document.edges.copy(),
+    next_node_id: document.next_node_id,
+    next_edge_id: document.next_edge_id,
+    interaction: interaction_with_selection(
+      interaction,
+      selection_from_interaction(interaction),
+    ),
+    action_log: action_log.copy(),
+  }
 }

--- a/examples/canvas/main/canvas_update.mbt
+++ b/examples/canvas/main/canvas_update.mbt
@@ -208,37 +208,20 @@ fn update_connect_end(
 }
 
 ///|
-/// Dispatch a pointer-move event to the active gesture.
-/// Accepts screen coordinates; converts to world coords internally for dragging.
-fn update_pointer_move(
-  state : CanvasState,
-  sx : Double,
-  sy : Double,
-) -> CanvasState {
-  match state.interaction.connecting {
-    Some(_) => {
-      let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-      update_connect_move(state, wx, wy)
-    }
-    None =>
-      match state.interaction.dragging {
-        Some(_) => {
-          let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-          update_node_drag_move(state, wx, wy)
-        }
-        None => update_pan_move(state, sx, sy)
-      }
+fn drag_preview_from_move(
+  drag : DragState,
+  world_x : Double,
+  world_y : Double,
+) -> DragPreview {
+  let positions : Array[NodePosition] = []
+  for origin in drag.origins {
+    positions.push({
+      node_id: origin.node_id,
+      x: world_x + origin.offset_x,
+      y: world_y + origin.offset_y,
+    })
   }
-}
-
-///|
-fn find_drag_origin(origins : Array[DragOrigin], id : NodeId) -> DragOrigin? {
-  for origin in origins {
-    if origin.node_id == id {
-      return Some(origin)
-    }
-  }
-  None
+  { positions, }
 }
 
 ///|
@@ -281,35 +264,6 @@ fn update_node_drag_start(
         did_move: false,
       }
       { ..state, interaction: new_interaction }
-    }
-  }
-}
-
-///|
-fn update_node_drag_move(
-  state : CanvasState,
-  world_x : Double,
-  world_y : Double,
-) -> CanvasState {
-  match state.interaction.dragging {
-    None => state
-    Some(drag) => {
-      let new_nodes = state.nodes.map(fn(node) {
-        match find_drag_origin(drag.origins, node.id) {
-          None => node
-          Some(origin) =>
-            {
-              ..node,
-              x: world_x + origin.offset_x,
-              y: world_y + origin.offset_y,
-            }
-        }
-      })
-      let new_interaction : InteractionState = {
-        ..state.interaction,
-        did_move: true,
-      }
-      { ..state, nodes: new_nodes, interaction: new_interaction }
     }
   }
 }

--- a/examples/canvas/main/canvas_update_wbtest.mbt
+++ b/examples/canvas/main/canvas_update_wbtest.mbt
@@ -128,22 +128,28 @@ test "node_drag_start is no-op for unknown node id" {
 }
 
 ///|
-test "node_drag_move updates node position" {
-  let state = make_test_state()
-  let s0 = update_node_drag_start(state, NodeId(1), 110.0, 120.0)
-  let s1 = update_node_drag_move(s0, 200.0, 300.0)
-  let node = s1.nodes[0]
-  assert_eq(node.id, NodeId(1))
-  inspect(node.x, content="190")
-  inspect(node.y, content="280")
-  assert_true(s1.interaction.did_move)
-}
-
-///|
 test "pointer_up records a MoveNodes action after drag" {
   let state = make_test_state()
   let s0 = update_node_drag_start(state, NodeId(1), 110.0, 120.0)
-  let s1 = update_node_drag_move(s0, 200.0, 300.0)
+  let preview = drag_preview_from_move(
+    match s0.interaction.dragging {
+      Some(drag) => drag
+      None => fail("expected active drag")
+    },
+    200.0,
+    300.0,
+  )
+  let moved_nodes = s0.nodes.map(fn(node) {
+    match find_position(preview.positions, node.id) {
+      None => node
+      Some(pos) => { ..node, x: pos.x, y: pos.y }
+    }
+  })
+  let s1 = {
+    ..s0,
+    nodes: moved_nodes,
+    interaction: { ..s0.interaction, did_move: true },
+  }
   let s2 = update_pointer_up(s1, 1, "", false)
   assert_eq(s2.action_log.length(), 1)
   match s2.action_log[0].action() {
@@ -334,4 +340,62 @@ test "get_render_state exposes workflow JSON shape" {
   assert_true(json_str.contains("Timer trigger"))
   assert_true(json_str.contains("\"source_port\""))
   assert_true(json_str.contains("\"validation\""))
+}
+
+///|
+test "runtime live drag updates preview before one durable MoveNodes commit" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
+  let before = runtime.document.peek()
+  runtime.pointer_down(Some(NodeId(1)), -510.0, -180.0)
+  runtime.pointer_move(-400.0, -100.0)
+
+  let during = runtime.document.peek()
+  inspect(during.nodes[0].x, content="-520")
+  inspect(during.nodes[0].y, content="-190")
+  assert_eq(runtime.actions.peek().length(), 0)
+
+  let preview = runtime.render_state().nodes[0]
+  inspect(preview.x, content="-410")
+  inspect(preview.y, content="-110")
+  assert_eq(before.nodes[0].x, during.nodes[0].x)
+
+  runtime.pointer_up(1, "", false)
+  let after = runtime.document.peek()
+  inspect(after.nodes[0].x, content="-410")
+  inspect(after.nodes[0].y, content="-110")
+  assert_eq(runtime.actions.peek().length(), 1)
+  match runtime.actions.peek()[0].action() {
+    MoveNodes(positions) => {
+      assert_eq(positions.length(), 1)
+      inspect(positions[0].x, content="-410")
+      inspect(positions[0].y, content="-110")
+    }
+    _ => fail("expected MoveNodes action")
+  }
+}
+
+///|
+test "runtime sparse inspector follows hover until a node is selected" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
+  runtime.hover_node(1)
+  match runtime.render_state().inspector {
+    Some(node) => {
+      inspect(node.source, content="hovered")
+      inspect(node.title, content="Timer trigger")
+    }
+    None => fail("expected hovered inspector")
+  }
+
+  runtime.pointer_down(Some(NodeId(2)), -190.0, -190.0)
+  runtime.pointer_up(2, "", false)
+  runtime.hover_node(1)
+  match runtime.render_state().inspector {
+    Some(node) => {
+      inspect(node.source, content="selected")
+      inspect(node.title, content="HTTP request")
+    }
+    None => fail("expected selected inspector")
+  }
 }

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/core/debug",
   "dowdiness/canopy-canvas/graph_model",
+  "dowdiness/incr",
 }
 
 import {
@@ -18,6 +19,7 @@ options(
         "pointer_down_handle",
         "pointer_move",
         "pointer_up",
+        "hover_node",
         "zoom",
         "add_node",
         "get_render_state",

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "dowdiness/canopy-canvas/main"
 
 import {
   "dowdiness/canopy-canvas/graph_model",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -13,6 +14,8 @@ pub fn create_canvas() -> Int
 pub fn get_action_log(Int) -> String
 
 pub fn get_render_state(Int) -> String
+
+pub fn hover_node(Int, Int) -> Unit
 
 pub fn pointer_down(Int, Int, Double, Double) -> Unit
 
@@ -27,15 +30,36 @@ pub fn zoom(Int, Double, Double, Double) -> Unit
 // Errors
 
 // Types and methods
-type ConnectingJson derive(ToJson)
+type CanvasDocument derive(Eq, @debug.Debug)
 
-type EdgeJson derive(ToJson)
+type CanvasFullRenderJson derive(Eq)
 
-type NodeJson derive(ToJson)
+type CanvasRuntime
 
-type RenderStateJson derive(ToJson)
+type ConnectingJson derive(Eq, ToJson)
 
-type ValidationJson derive(ToJson)
+pub(all) struct DragPreview {
+  positions : Array[@graph_model.NodePosition]
+} derive(Eq, @debug.Debug)
+pub impl Show for DragPreview
+
+type EdgeJson derive(Eq, ToJson)
+
+type InspectorNodeJson derive(Eq, ToJson)
+
+type LoweredCanvas derive(Eq)
+
+type NodeJson derive(Eq, ToJson)
+
+type NormalizedCanvas derive(Eq)
+
+type RenderStateJson derive(Eq, ToJson)
+
+type SelectionState derive(Eq, @debug.Debug)
+
+type ValidatedCanvas derive(Eq)
+
+type ValidationJson derive(Eq, ToJson)
 
 // Type aliases
 pub using @graph_model {type CanvasNode}

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -5,7 +5,8 @@
     "dowdiness/graph-dsl": {
       "path": "../../loom/examples/graph-dsl",
       "version": "0.1.0"
-    }
+    },
+    "dowdiness/incr": "0.7.1"
   },
   "source": ".",
   "preferred-target": "js"

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -179,20 +179,52 @@
       width: 310px;
       padding: var(--space-lg);
     }
-    #validation-list {
+    #validation-list,
+    #inspector-node {
       display: grid;
       gap: 6px;
       max-height: 30vh;
       overflow: auto;
     }
+    #inspector-node {
+      margin-bottom: var(--space-md);
+      padding-bottom: var(--space-md);
+      border-bottom: 1px solid var(--line);
+    }
     .validation-item,
-    .validation-ok {
+    .validation-ok,
+    .inspector-empty {
       border-radius: 10px;
       padding: 9px 10px;
       font-size: 12.5px;
       line-height: 1.38;
       background: oklch(28% 0.024 276 / 0.72);
       border: 1px solid var(--line);
+    }
+    .inspector-empty { color: var(--text-faint); }
+    .inspector-eyebrow {
+      color: var(--accent);
+      font-size: 10.5px;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+    }
+    .inspector-title {
+      font-size: 16px;
+      font-weight: 620;
+      letter-spacing: -0.012em;
+    }
+    .inspector-subtitle {
+      color: var(--text-muted);
+      font-size: 12.5px;
+      line-height: 1.38;
+    }
+    .inspector-meta {
+      display: flex;
+      justify-content: space-between;
+      gap: var(--space-sm);
+      color: var(--text-faint);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+      font-size: 10.5px;
     }
     .validation-item.warning {
       color: oklch(83% 0.07 54);
@@ -465,9 +497,10 @@
 
     <aside class="panel inspector-panel" aria-label="Validation and activity">
       <div class="panel-title">
-        <h2>Validation</h2>
+        <h2>Inspector</h2>
         <span id="action-stat">0 actions logged</span>
       </div>
+      <div id="inspector-node"></div>
       <div id="validation-list"></div>
       <p class="hint" style="margin-top: 12px;">Press ⌘/Ctrl-L to inspect the serialized action log.</p>
     </aside>

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -15,6 +15,7 @@ export type CanvasModule = {
     targetPortId: string,
     additive: boolean,
   ) => void;
+  hover_node: (h: number, nodeId: number) => void;
   zoom: (h: number, delta: number, cx: number, cy: number) => void;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   get_render_state: (h: number) => string;
@@ -56,6 +57,15 @@ export type ValidationMessage = {
   node_id?: number;
 };
 export type ViewportData = { x: number; y: number; scale: number };
+export type InspectorNode = {
+  id: number;
+  title: string;
+  subtitle: string;
+  configured: boolean;
+  input_count: number;
+  output_count: number;
+  source: 'selected' | 'hovered' | string;
+};
 export type RenderState = {
   viewport: ViewportData;
   nodes: NodeData[];
@@ -65,6 +75,7 @@ export type RenderState = {
   connecting?: Connecting;
   validation: ValidationMessage[];
   action_count: number;
+  inspector?: InspectorNode;
 };
 
 export type NodePositionData = { node_id: number; x: number; y: number };
@@ -155,6 +166,11 @@ export class GraphAdapter {
     this.assertLive();
     this.mb.pointer_up(this.handle, nodeId, targetPortId, additive);
     this.emitLatestOperations();
+  }
+
+  hoverNode(nodeId: number): void {
+    this.assertLive();
+    this.mb.hover_node(this.handle, nodeId);
   }
 
   zoom(delta: number, cx: number, cy: number): void {

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -41,6 +41,7 @@ const edgesSvg   = document.getElementById('edges') as unknown as SVGSVGElement;
 const search     = document.getElementById('node-search') as HTMLInputElement;
 const libraryEl  = document.getElementById('node-library') as HTMLDivElement;
 const validation = document.getElementById('validation-list') as HTMLDivElement;
+const inspectorNode = document.getElementById('inspector-node') as HTMLDivElement;
 const actionStat = document.getElementById('action-stat') as HTMLSpanElement;
 const contextMenu = document.getElementById('context-menu') as HTMLDivElement;
 const nodeDivs = new Map<number, HTMLDivElement>();
@@ -282,6 +283,7 @@ function render(): void {
   }
 
   renderValidation(state);
+  renderInspector(state);
 }
 
 function renderValidation(state: RenderState): void {
@@ -304,6 +306,39 @@ function renderValidation(state: RenderState): void {
     }
     validation.appendChild(item);
   }
+}
+
+function renderInspector(state: RenderState): void {
+  inspectorNode.replaceChildren();
+  if (!state.inspector) {
+    const empty = document.createElement('div');
+    empty.className = 'inspector-empty';
+    empty.textContent = 'Select or hover a node to inspect its sparse derived details.';
+    inspectorNode.appendChild(empty);
+    return;
+  }
+
+  const item = state.inspector;
+  const status = item.configured ? 'Configured' : 'Needs config';
+  const source = item.source === 'selected' ? 'Selected node' : 'Hovered node';
+
+  const eyebrow = document.createElement('div');
+  eyebrow.className = 'inspector-eyebrow';
+  eyebrow.textContent = source;
+  const title = document.createElement('div');
+  title.className = 'inspector-title';
+  title.textContent = item.title;
+  const subtitle = document.createElement('div');
+  subtitle.className = 'inspector-subtitle';
+  subtitle.textContent = item.subtitle;
+  const meta = document.createElement('div');
+  meta.className = 'inspector-meta';
+  const statusSpan = document.createElement('span');
+  statusSpan.textContent = status;
+  const portsSpan = document.createElement('span');
+  portsSpan.textContent = `${item.input_count} in · ${item.output_count} out`;
+  meta.replaceChildren(statusSpan, portsSpan);
+  inspectorNode.replaceChildren(eyebrow, title, subtitle, meta);
 }
 
 function focusNode(nodeId: number): void {
@@ -345,6 +380,14 @@ function addNodeAt(kindKey: string, point: [number, number]): void {
   adapter.addNode(kindKey, point[0], point[1]);
   hideContextMenu();
   scheduleRender();
+}
+
+function hoverNodeId(hit: HitTarget): number {
+  return hit.kind === 'background' ? 0 : hit.nodeId;
+}
+
+function updateHover(hit: HitTarget): void {
+  adapter.hoverNode(hoverNodeId(hit));
 }
 
 function hideContextMenu(): void {
@@ -422,9 +465,18 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
 });
 
 root.addEventListener('pointermove', (e: PointerEvent) => {
-  if (e.pointerId !== activePointerId) return;
+  updateHover(hitFromTarget(e.target));
+  if (e.pointerId !== activePointerId) {
+    scheduleRender();
+    return;
+  }
   const [sx, sy] = localCoords(e);
   adapter.pointerMove(sx, sy);
+  scheduleRender();
+});
+
+root.addEventListener('pointerleave', () => {
+  updateHover({ kind: 'background' });
   scheduleRender();
 });
 


### PR DESCRIPTION
## Summary

- Split the canvas graph UI state into an incr-backed durable `CanvasDocument` input plus separate ephemeral hover, drag-preview, viewport, selection, and gesture inputs.
- Added coarse derived stages for full-canvas render (`validation -> normalization -> lowering -> render`) and kept `DerivedMap` scoped to the sparse selected/hover inspector.
- Routed live node drag through ephemeral preview updates only, committing a single durable `MoveNodes` operation on pointerup.

Reference: `loom/incr/docs/performance/2026-06-01-graph-editor-recompute-benches.md`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `CanvasState`, `WorkflowAction`, `GraphOperation`, `find_node`, `record_action` | `examples/canvas/graph_model/model.mbt` | Yes | Reused upstream extracted graph model/action log as durable document source of truth. |
| `GraphAdapter` | `examples/canvas/web/src/graph-adapter.ts` | Yes | Extended existing lifecycle/FFI seam with hover and inspector typing instead of reintroducing globals. |
| `@incr.Input`, `@incr.Derived`, `@incr.Watch`, `@incr.DerivedMap`, `@incr.ReachableDerived` | `dowdiness/incr` | Yes | Used target facade APIs from the graph-editor recompute benchmark pattern; no incr public API changes. |

New helpers added:

- `CanvasRuntime`: owns the incr graph, persistent watches, and FFI-facing event methods for the canvas instance.
- `CanvasDocument`, `DragPreview`, `SelectionState`: local state-boundary types separating durable document from ephemeral UI state.
- Render/inspector helpers in `canvas_runtime.mbt`: coarse render stages plus sparse selected/hover inspector derivation.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` equivalent via `NEW_MOON_MOD=0 make check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for intended canvas API/interface changes
- [x] JS rebuild run for affected canvas web app (`cd examples/canvas/web && npm run build`)
- [x] Canvas Playwright E2E (`cd examples/canvas/web && npx playwright test`) passes
- [x] Browser smoke verified live drag preview, one `MoveNodes` on pointerup, and selected/hover inspector behavior

## Validation

```bash
NEW_MOON_MOD=0 make check
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 make fmt-check
git diff --check
cd examples/canvas/web && npm run build
cd examples/canvas/web && npx playwright test
```

Notes:

- `npm ci` was needed locally for `@playwright/test`; npm reported 3 moderate audit findings unrelated to this change.
- Vite emits its existing CJS Node API deprecation warning during canvas web build/E2E, but builds/tests pass.
