### PR TITLE
ci: gate ideal web e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,35 @@ jobs:
       - name: Run web Playwright suite
         run: ./scripts/test-web-e2e.sh
 
+  ideal-web-e2e:
+    name: Ideal Web E2E
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MoonBit
+        uses: ./.github/actions/setup-moonbit
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: examples/ideal/web/package-lock.json
+
+      - name: Install Ideal editor web dependencies
+        working-directory: examples/ideal/web
+        run: npm ci
+
+      - name: Run Ideal editor Playwright suite
+        run: ./scripts/test-ideal-web-e2e.sh
+
   demo-react-e2e:
     name: Demo React E2E
     runs-on: ubuntu-latest
@@ -417,6 +446,7 @@ jobs:
       - typecheck-ts-examples
       - web-build
       - web-e2e
+      - ideal-web-e2e
       - demo-react-e2e
       - canvas-e2e
     if: always()
@@ -433,6 +463,7 @@ jobs:
              [[ "${{ needs.typecheck-ts-examples.result }}" != "success" ]] || \
              [[ "${{ needs.web-build.result }}" != "success" ]] || \
              [[ "${{ needs.web-e2e.result }}" != "success" ]] || \
+             [[ "${{ needs.ideal-web-e2e.result }}" != "success" ]] || \
              [[ "${{ needs.demo-react-e2e.result }}" != "success" ]] || \
              [[ "${{ needs.canvas-e2e.result }}" != "success" ]]; then
             echo "❌ One or more required checks failed"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ release/
 .env
 _build
 *.db
+*.db-shm
+*.db-wal
 .wrangler/
 .vite/
 

--- a/scripts/test-ideal-web-e2e.sh
+++ b/scripts/test-ideal-web-e2e.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Build the Ideal editor MoonBit JS output and run the non-performance
+# Playwright E2E specs. The editor-response perf spec is gated separately by
+# .github/workflows/benchmark.yml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+(
+    cd examples/ideal
+    # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+    "$SCRIPT_DIR/moon-update.sh"
+)
+
+echo "Running Ideal editor Playwright E2E..."
+cd examples/ideal/web
+
+if [ ! -d node_modules ]; then
+    echo "Installing Ideal editor web dependencies..."
+    npm ci
+fi
+
+# Disable workspace mode for the JS build that vite-plugin-moonbit kicks off.
+# When examples/ideal is a moon.work member, `moon build --target js` only
+# emits wasm-gc artifacts (moon picks the workspace target over ideal's
+# `preferred-target: js`), so vite can't find the JS output it imports.
+# Tracked as #335; remove once moon honors per-member preferred-target.
+export MOON_WORK=off
+
+DEFAULT_SPECS=()
+while IFS= read -r spec; do
+    DEFAULT_SPECS+=("$spec")
+done < <(find e2e -maxdepth 1 -name '*.spec.ts' ! -name 'editor-response.perf.spec.ts' | sort)
+
+if [ "$#" -eq 0 ]; then
+    set -- "${DEFAULT_SPECS[@]}"
+fi
+
+CI="${CI:-1}" npx playwright test "$@"


### PR DESCRIPTION
## Summary

- Add a dedicated `Ideal Web E2E` CI job for `examples/ideal/web` Playwright specs.
- Add `scripts/test-ideal-web-e2e.sh` to run all non-performance Ideal specs while leaving `editor-response.perf.spec.ts` in benchmark CI.
- Ignore SQLite WAL/SHM sidecars emitted by the local Ideal relay server during E2E runs.

Fixes #461.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `scripts/test-web-e2e.sh` | `scripts/test-web-e2e.sh` | Pattern reused | New Ideal-specific script needs `MOON_WORK=off` and excludes the perf spec. |
| `scripts/test-canvas-e2e.sh` | `scripts/test-canvas-e2e.sh` | Pattern reused | Ideal has its own package path and Playwright config. |
| Editor response benchmark setup | `.github/workflows/benchmark.yml` | Reused | Mirrored package-lock cache path, `examples/ideal` moon update location, and `MOON_WORK=off` rationale. |

New helpers added (if any):

- `scripts/test-ideal-web-e2e.sh` — repo script for the new CI job; keeps perf gating separate and makes the Ideal suite runnable locally with the same defaults.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (`moon info` generated blank-line-only `.mbti` drift; reverted)
- [x] JS rebuild run if web is affected (`./scripts/test-ideal-web-e2e.sh` ran the Ideal webServer MoonBit release build)
- [x] `./scripts/test-ideal-web-e2e.sh` passes (73 tests)
- [x] `shellcheck scripts/test-ideal-web-e2e.sh` passes
- [x] `actionlint -ignore 'SC2046' .github/workflows/ci.yml` passes (ignored pre-existing opam `eval $(opam env)` warnings)

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
./scripts/test-ideal-web-e2e.sh
git diff --check
shellcheck scripts/test-ideal-web-e2e.sh
actionlint -ignore 'SC2046' .github/workflows/ci.yml
```
