### PR TITLE
feat(canvas): add source-backed browser demo

### DIFF
--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -1,10 +1,24 @@
 ///|
+fn default_source_graph_viewport() -> Viewport {
+  { x: 360.0, y: 330.0, scale: 1.0 }
+}
+
+///|
+struct SourceNodePosition {
+  binding : String
+  x : Double
+  y : Double
+}
+
+///|
 struct SourceBackedGraph {
   attachment : @graph_dsl.GraphAttachment
   mut source : String
-  viewport : Viewport
-  interaction : InteractionState
-  action_log : Array[GraphOperation]
+  mut viewport : Viewport
+  mut interaction : InteractionState
+  mut drag_preview : DragPreview
+  mut layout : Array[SourceNodePosition]
+  mut action_log : Array[GraphOperation]
 }
 
 ///|
@@ -12,8 +26,10 @@ fn SourceBackedGraph::SourceBackedGraph(source : String) -> SourceBackedGraph {
   {
     attachment: @graph_dsl.GraphAttachment::GraphAttachment(source),
     source,
-    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    viewport: default_source_graph_viewport(),
     interaction: @graph_model.empty_interaction(),
+    drag_preview: idle_drag_preview(),
+    layout: [],
     action_log: [],
   }
 }
@@ -38,7 +54,7 @@ fn source_graph_by_handle(handle : Int) -> SourceBackedGraph? {
 ///|
 fn empty_source_canvas_state() -> CanvasState {
   {
-    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    viewport: default_source_graph_viewport(),
     nodes: [],
     edges: [],
     next_node_id: 1,
@@ -107,6 +123,42 @@ fn canvas_node_from_graph_node(
 }
 
 ///|
+fn source_layout_for_binding(
+  layout : Array[SourceNodePosition],
+  binding : String,
+) -> SourceNodePosition? {
+  for position in layout {
+    if position.binding == binding {
+      return Some(position)
+    }
+  }
+  None
+}
+
+///|
+fn canvas_node_with_source_layout(
+  node : CanvasNode,
+  layout : Array[SourceNodePosition],
+) -> CanvasNode {
+  match source_layout_for_binding(layout, node.title) {
+    Some(position) => { ..node, x: position.x, y: position.y }
+    None => node
+  }
+}
+
+///|
+fn canvas_state_with_source_layout(
+  state : CanvasState,
+  layout : Array[SourceNodePosition],
+) -> CanvasState {
+  let nodes : Array[CanvasNode] = []
+  for node in state.nodes {
+    nodes.push(canvas_node_with_source_layout(node, layout))
+  }
+  { ..state, nodes, }
+}
+
+///|
 fn canvas_from_graph_doc(doc : @graph_dsl.GraphDoc) -> CanvasState {
   let nodes : Array[CanvasNode] = []
   for i, graph_node in doc.nodes() {
@@ -154,10 +206,13 @@ fn source_graph_doc_for_render(
 }
 
 ///|
-fn source_graph_canvas_state(graph : SourceBackedGraph) -> CanvasState {
+fn source_graph_base_canvas_state(graph : SourceBackedGraph) -> CanvasState {
   match source_graph_doc_for_render(graph) {
     Some(doc) => {
-      let state = canvas_from_graph_doc(doc)
+      let state = canvas_state_with_source_layout(
+        canvas_from_graph_doc(doc),
+        graph.layout,
+      )
       {
         ..state,
         viewport: graph.viewport,
@@ -166,6 +221,16 @@ fn source_graph_canvas_state(graph : SourceBackedGraph) -> CanvasState {
       }
     }
     None => { ..empty_source_canvas_state(), viewport: graph.viewport }
+  }
+}
+
+///|
+fn source_graph_canvas_state(graph : SourceBackedGraph) -> CanvasState {
+  let state = source_graph_base_canvas_state(graph)
+  match graph.interaction.dragging {
+    Some(_) if graph.interaction.did_move =>
+      state_with_preview_nodes(state, graph.drag_preview)
+    _ => state
   }
 }
 
@@ -185,7 +250,18 @@ struct SourceGraphOperationResultJson {
   diagnostics : Array[String]
   action_count : Int
   message : String?
-} derive(ToJson)
+} derive(ToJson, FromJson)
+
+///|
+fn source_graph_operation_result_json(
+  applied : Bool,
+  source : String,
+  diagnostics : Array[String],
+  action_count : Int,
+  message : String?,
+) -> SourceGraphOperationResultJson {
+  { applied, source, diagnostics, action_count, message }
+}
 
 ///|
 fn source_graph_operation_result(
@@ -195,11 +271,26 @@ fn source_graph_operation_result(
   action_count : Int,
   message : String?,
 ) -> String {
-  (
-    { applied, source, diagnostics, action_count, message } :
-    SourceGraphOperationResultJson)
+  source_graph_operation_result_json(
+    applied, source, diagnostics, action_count, message,
+  )
   .to_json()
   .stringify()
+}
+
+///|
+fn source_graph_result_json_for_graph(
+  graph : SourceBackedGraph,
+  applied : Bool,
+  message : String?,
+) -> SourceGraphOperationResultJson {
+  source_graph_operation_result_json(
+    applied,
+    graph.source,
+    graph.attachment.diagnostics(),
+    graph.action_log.length(),
+    message,
+  )
 }
 
 ///|
@@ -208,13 +299,9 @@ fn source_graph_result_for_graph(
   applied : Bool,
   message : String?,
 ) -> String {
-  source_graph_operation_result(
-    applied,
-    graph.source,
-    graph.attachment.diagnostics(),
-    graph.action_log.length(),
-    message,
-  )
+  source_graph_result_json_for_graph(graph, applied, message)
+  .to_json()
+  .stringify()
 }
 
 ///|
@@ -335,6 +422,237 @@ fn SourceBackedGraph::append_operation(
 }
 
 ///|
+fn SourceBackedGraph::sync_layout_from_state(
+  self : SourceBackedGraph,
+  state : CanvasState,
+) -> Unit {
+  let layout : Array[SourceNodePosition] = []
+  for node in state.nodes {
+    layout.push({ binding: node.title, x: node.x, y: node.y })
+  }
+  self.layout = layout
+}
+
+///|
+fn SourceBackedGraph::pointer_down(
+  self : SourceBackedGraph,
+  node_id : Int,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let target : NodeId? = if node_id <= 0 { None } else { Some(NodeId(node_id)) }
+  let state = update_pointer_down(
+    source_graph_base_canvas_state(self),
+    target,
+    sx,
+    sy,
+  )
+  self.drag_preview = idle_drag_preview()
+  self.interaction = state.interaction
+}
+
+///|
+fn SourceBackedGraph::pointer_move(
+  self : SourceBackedGraph,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  let state = source_graph_base_canvas_state(self)
+  match state.interaction.connecting {
+    Some(_) => {
+      let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+      self.interaction = update_connect_move(state, wx, wy).interaction
+    }
+    None =>
+      match state.interaction.dragging {
+        Some(drag) => {
+          let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+          let new_interaction : InteractionState = {
+            ..state.interaction,
+            did_move: true,
+          }
+          self.drag_preview = drag_preview_from_move(drag, wx, wy)
+          self.interaction = new_interaction
+        }
+        None =>
+          match state.interaction.panning {
+            Some(_) => {
+              let next = update_pan_move(state, sx, sy)
+              self.viewport = next.viewport
+              self.interaction = next.interaction
+            }
+            None => ()
+          }
+      }
+  }
+}
+
+///|
+fn SourceBackedGraph::pointer_up(
+  self : SourceBackedGraph,
+  node_id : Int,
+  target_port_id : String,
+  additive : Bool,
+) -> Unit {
+  let state = source_graph_base_canvas_state(self)
+  let commit_state = match state.interaction.dragging {
+    Some(_) if state.interaction.did_move =>
+      state_with_preview_nodes(state, self.drag_preview)
+    _ => state
+  }
+  let next = update_pointer_up(commit_state, node_id, target_port_id, additive)
+  self.sync_layout_from_state(next)
+  self.viewport = next.viewport
+  self.drag_preview = idle_drag_preview()
+  self.interaction = next.interaction
+  self.action_log = next.action_log.copy()
+}
+
+///|
+fn SourceBackedGraph::zoom(
+  self : SourceBackedGraph,
+  delta : Double,
+  cx : Double,
+  cy : Double,
+) -> Unit {
+  let next = update_zoom(source_graph_base_canvas_state(self), delta, cx, cy)
+  self.viewport = next.viewport
+  self.action_log = next.action_log.copy()
+}
+
+///|
+fn source_graph_node_payload(
+  binding : String,
+  constructor_name : String,
+) -> CanvasNode {
+  {
+    id: NodeId(0),
+    x: 0.0,
+    y: 0.0,
+    w: 250.0,
+    h: 138.0,
+    kind: Workflow(Custom(constructor_name)),
+    title: binding,
+    subtitle: constructor_name,
+    inputs: [],
+    outputs: [],
+    configured: true,
+  }
+}
+
+///|
+fn next_source_binding(doc : @graph_dsl.GraphDoc, base : String) -> String {
+  if doc.find_node(base) is None {
+    return base
+  }
+  for suffix = 2 {
+    let candidate = base + suffix.to_string()
+    if doc.find_node(candidate) is None {
+      break candidate
+    }
+    continue suffix + 1
+  }
+}
+
+///|
+fn source_graph_insert_unique_result(
+  handle : Int,
+  binding_base : String,
+  constructor_name : String,
+) -> SourceGraphOperationResultJson {
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None =>
+      return source_graph_operation_result_json(
+        false,
+        "",
+        ["source graph handle not found"],
+        0,
+        Some("source graph handle not found"),
+      )
+  }
+  let doc = match source_graph_current_doc(graph) {
+    Ok(doc) => doc
+    Err(message) =>
+      return source_graph_result_json_for_graph(graph, false, Some(message))
+  }
+  let binding = next_source_binding(doc, binding_base)
+  let operation = GraphOperation(
+    AddNode(source_graph_node_payload(binding, constructor_name)),
+  )
+  let result_json = apply_source_graph_operation(
+    handle,
+    operation.to_json().stringify(),
+  )
+  let json = @json.parse(result_json) catch {
+    _ =>
+      return source_graph_result_json_for_graph(
+        graph,
+        false,
+        Some("source graph operation result JSON parse failed"),
+      )
+  }
+  let result : SourceGraphOperationResultJson = @json.from_json(json) catch {
+    _ =>
+      return source_graph_result_json_for_graph(
+        graph,
+        false,
+        Some("source graph operation result JSON decode failed"),
+      )
+  }
+  result
+}
+
+///|
+fn source_graph_connect_sample_result(
+  handle : Int,
+) -> SourceGraphOperationResultJson {
+  let result_json = apply_source_graph_operation(
+    handle,
+    GraphOperation(ConnectPorts(NodeId(1), "out", NodeId(2), "input"))
+    .to_json()
+    .stringify(),
+  )
+  let json = @json.parse(result_json) catch {
+    _ =>
+      return source_graph_operation_result_json(
+        false,
+        "",
+        ["source graph operation result JSON parse failed"],
+        0,
+        Some("source graph operation result JSON parse failed"),
+      )
+  }
+  let result : SourceGraphOperationResultJson = @json.from_json(json) catch {
+    _ =>
+      return source_graph_operation_result_json(
+        false,
+        "",
+        ["source graph operation result JSON decode failed"],
+        0,
+        Some("source graph operation result JSON decode failed"),
+      )
+  }
+  result
+}
+
+///|
+pub fn source_graph_insert_unique(
+  handle : Int,
+  binding_base : String,
+  constructor_name : String,
+) -> String {
+  source_graph_insert_unique_result(handle, binding_base, constructor_name)
+  .to_json()
+  .stringify()
+}
+
+///|
+pub fn sample_graph_dsl_source() -> String {
+  "osc = sine(freq: 440Hz)\nmeter = scope()"
+}
+
+///|
 pub fn create_source_graph(source : String) -> Int {
   _source_registry.push(Some(SourceBackedGraph(source)))
   _source_registry.length() - 1
@@ -366,6 +684,57 @@ pub fn set_source_graph_source(handle : Int, source : String) -> Unit {
       graph.source = source
       graph.attachment.set_source(source)
     }
+    None => ()
+  }
+}
+
+///|
+pub fn source_graph_pointer_down(
+  handle : Int,
+  node_id : Int,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.pointer_down(node_id, sx, sy)
+    None => ()
+  }
+}
+
+///|
+pub fn source_graph_pointer_move(
+  handle : Int,
+  sx : Double,
+  sy : Double,
+) -> Unit {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.pointer_move(sx, sy)
+    None => ()
+  }
+}
+
+///|
+pub fn source_graph_pointer_up(
+  handle : Int,
+  node_id : Int,
+  target_port_id : String,
+  additive : Bool,
+) -> Unit {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.pointer_up(node_id, target_port_id, additive)
+    None => ()
+  }
+}
+
+///|
+pub fn source_graph_zoom(
+  handle : Int,
+  delta : Double,
+  cx : Double,
+  cy : Double,
+) -> Unit {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.zoom(delta, cx, cy)
     None => ()
   }
 }

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -236,6 +236,34 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
 }
 
 ///|
+test "source-backed unique insert chooses a fresh graph-dsl binding" {
+  let handle = create_source_graph("reverb = plate()")
+  inspect(
+    operation_result_applied(
+      source_graph_insert_unique(handle, "reverb", "plate"),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="reverb = plate()\nreverb2 = plate()",
+  )
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  match operations {
+    [added] =>
+      match added.action() {
+        AddNode(node) => {
+          inspect(node.title, content="reverb2")
+          @debug.assert_eq(node.id, NodeId(2))
+        }
+        _ => abort("expected AddNode action")
+      }
+    _ => abort("expected one source-backed unique insert operation")
+  }
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed handle rejects local graph operations without mutating source" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -4,7 +4,12 @@ import {
   "dowdiness/canopy-canvas/graph_model",
   "dowdiness/incr",
   "dowdiness/graph-dsl" @graph_dsl,
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
 }
+
+supported_targets = "js"
 
 options(
   "is-main": true,
@@ -28,6 +33,13 @@ options(
         "get_source_graph_render_state",
         "get_source_graph_action_log",
         "apply_source_graph_operation",
+        "sample_graph_dsl_source",
+        "mount_source_demo",
+        "source_graph_insert_unique",
+        "source_graph_pointer_down",
+        "source_graph_pointer_move",
+        "source_graph_pointer_up",
+        "source_graph_zoom",
       ],
     },
   },

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "dowdiness/canopy-canvas/main"
 import {
   "dowdiness/canopy-canvas/graph_model",
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
 }
 
 // Values
@@ -29,6 +30,8 @@ pub fn get_source_graph_source(Int) -> String
 
 pub fn hover_node(Int, Int) -> Unit
 
+pub fn mount_source_demo(Int, Bool, () -> Unit) -> Unit
+
 pub fn pointer_down(Int, Int, Double, Double) -> Unit
 
 pub fn pointer_down_handle(Int, Int, String, Double, Double) -> Unit
@@ -37,7 +40,19 @@ pub fn pointer_move(Int, Double, Double) -> Unit
 
 pub fn pointer_up(Int, Int, String, Bool) -> Unit
 
+pub fn sample_graph_dsl_source() -> String
+
 pub fn set_source_graph_source(Int, String) -> Unit
+
+pub fn source_graph_insert_unique(Int, String, String) -> String
+
+pub fn source_graph_pointer_down(Int, Int, Double, Double) -> Unit
+
+pub fn source_graph_pointer_move(Int, Double, Double) -> Unit
+
+pub fn source_graph_pointer_up(Int, Int, String, Bool) -> Unit
+
+pub fn source_graph_zoom(Int, Double, Double, Double) -> Unit
 
 pub fn zoom(Int, Double, Double, Double) -> Unit
 
@@ -73,7 +88,13 @@ type SelectionState derive(Eq, @debug.Debug)
 
 type SourceBackedGraph
 
-type SourceGraphOperationResultJson derive(ToJson)
+type SourceDemoModel
+
+type SourceDemoMsg
+
+type SourceGraphOperationResultJson derive(ToJson, @json.FromJson)
+
+type SourceNodePosition
 
 type ValidatedCanvas derive(Eq)
 

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -1,0 +1,258 @@
+///|
+using @rabbita {type Cmd, type Emit, type Html}
+
+///|
+using @html {a, aside, button, div, h2, nothing, p, span, textarea, text}
+
+///|
+#cfg(target="js")
+extern "js" fn js_source_mode_url(enabled : Bool) -> String =
+  #|((enabled) => {
+  #|  const url = new URL(window.location.href);
+  #|  if (enabled) {
+  #|    url.searchParams.set('source', '1');
+  #|  } else {
+  #|    url.searchParams.delete('source');
+  #|  }
+  #|  return url.toString();
+  #|})
+
+///|
+#cfg(not(target="js"))
+fn js_source_mode_url(enabled : Bool) -> String {
+  if enabled {
+    "?source=1"
+  } else {
+    "/"
+  }
+}
+
+///|
+struct SourceDemoModel {
+  handle : Int
+  editor : String
+  dirty : Bool
+  status : String
+  tone : String
+  on_change : () -> Unit
+}
+
+///|
+enum SourceDemoMsg {
+  EditorChanged(String)
+  ApplySource
+  ConnectSample
+  InsertReverb
+  SyncFromGraph
+}
+
+///|
+fn source_toggle_view(enabled : Bool) -> Html {
+  let next_enabled = !enabled
+  a(
+    id="source-mode-toggle",
+    class="mode-toggle",
+    href=js_source_mode_url(next_enabled),
+    title=if enabled {
+      "Reload the demo with the local canvas runtime adapter"
+    } else {
+      "Reload the demo with graph-dsl source as the backing store"
+    },
+    if enabled {
+      "Return to canvas runtime"
+    } else {
+      "Open source-backed demo"
+    },
+  )
+}
+
+///|
+fn source_demo_notify(model : SourceDemoModel) -> Cmd {
+  @rabbita.effect(fn() { (model.on_change)() })
+}
+
+///|
+fn source_demo_status_from_result(
+  result : SourceGraphOperationResultJson,
+  success_message : String,
+) -> (String, String) {
+  if result.applied {
+    (success_message, "success")
+  } else {
+    let detail = match result.message {
+      Some(message) => message
+      None =>
+        if result.diagnostics.is_empty() {
+          "operation was rejected"
+        } else {
+          result.diagnostics.join("; ")
+        }
+    }
+    ("Source operation rejected: " + detail, "error")
+  }
+}
+
+///|
+fn source_demo_update(
+  _emit : Emit[SourceDemoMsg],
+  msg : SourceDemoMsg,
+  model : SourceDemoModel,
+) -> (Cmd, SourceDemoModel) {
+  match msg {
+    EditorChanged(source) =>
+      (@rabbita.none, { ..model, editor: source, dirty: true })
+    ApplySource => {
+      set_source_graph_source(model.handle, model.editor)
+      (
+        source_demo_notify(model),
+        {
+          ..model,
+          editor: get_source_graph_source(model.handle),
+          dirty: false,
+          status: "Source applied; render state is reparsed from Loom GraphDoc.",
+          tone: "success",
+        },
+      )
+    }
+    ConnectSample => {
+      let result = source_graph_connect_sample_result(model.handle)
+      let (status, tone) = source_demo_status_from_result(
+        result, "Connected meter.input to osc.out through graph-dsl source.",
+      )
+      (
+        source_demo_notify(model),
+        { ..model, editor: result.source, dirty: false, status, tone },
+      )
+    }
+    InsertReverb => {
+      let result = source_graph_insert_unique_result(
+        model.handle,
+        "reverb",
+        "plate",
+      )
+      let (status, tone) = source_demo_status_from_result(
+        result, "Inserted reverb = plate() from canonical source.",
+      )
+      (
+        source_demo_notify(model),
+        { ..model, editor: result.source, dirty: false, status, tone },
+      )
+    }
+    SyncFromGraph => {
+      if model.dirty {
+        return (@rabbita.none, model)
+      }
+      let source = get_source_graph_source(model.handle)
+      if source == model.editor {
+        (@rabbita.none, model)
+      } else {
+        (
+          @rabbita.none,
+          {
+            ..model,
+            editor: source,
+            status: "Source synchronized from graph-dsl backing store.",
+            tone: "success",
+          },
+        )
+      }
+    }
+  }
+}
+
+///|
+fn source_demo_subscriptions(
+  emit : Emit[SourceDemoMsg],
+  _model : SourceDemoModel,
+) -> @sub.Sub {
+  @sub.every(250, emit(SyncFromGraph))
+}
+
+///|
+fn source_status_attrs(tone : String) -> @html.Attrs {
+  @html.Attrs::build().data_set("tone", tone)
+}
+
+///|
+fn source_textarea_attrs() -> @html.Attrs {
+  @html.Attrs::build().spellcheck(false).aria_label("Graph DSL source")
+}
+
+///|
+fn source_demo_view(
+  emit : Emit[SourceDemoMsg],
+  model : SourceDemoModel,
+) -> Html {
+  aside(
+    id="source-panel",
+    class="panel source-panel",
+    attrs=@html.Attrs::build().aria_label("Graph DSL source"),
+    [
+      div(class="panel-title", [h2("Graph source"), span("Canonical DSL")]),
+      textarea(
+        id="source-editor",
+        class="source-editor",
+        value=model.editor,
+        on_input=emit.map(source => EditorChanged(source)),
+        attrs=source_textarea_attrs(),
+        nothing,
+      ),
+      div(class="source-actions", [
+        button(
+          id="source-apply",
+          type_="button",
+          on_click=emit(ApplySource),
+          "Apply source",
+        ),
+        button(
+          id="source-connect",
+          type_="button",
+          on_click=emit(ConnectSample),
+          "Connect osc → meter",
+        ),
+        button(
+          id="source-insert",
+          type_="button",
+          on_click=emit(InsertReverb),
+          "Insert reverb",
+        ),
+      ]),
+      p(
+        id="source-status",
+        class="hint source-status",
+        attrs=source_status_attrs(model.tone),
+        style=["margin-top: 12px"],
+        [text(model.status)],
+      ),
+    ],
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn mount_source_demo(
+  handle : Int,
+  enabled : Bool,
+  on_change : () -> Unit,
+) -> Unit {
+  @rabbita.new(@rabbita.static_cell(source_toggle_view(enabled))).mount(
+    "source-mode-root",
+  )
+  guard enabled else { return }
+  let model = {
+    handle,
+    editor: get_source_graph_source(handle),
+    dirty: false,
+    status: "Source mode active: operations lower into graph-dsl text.",
+    tone: "success",
+    on_change,
+  }
+  @rabbita.new(
+    @rabbita.cell(
+      model~,
+      update=source_demo_update,
+      view=source_demo_view,
+      subscriptions=source_demo_subscriptions,
+    ),
+  ).mount("source-panel-root")
+}

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -6,7 +6,11 @@
       "path": "../../loom/examples/graph-dsl",
       "version": "0.1.0"
     },
-    "dowdiness/incr": "0.7.1"
+    "dowdiness/incr": "0.7.1",
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.2"
+    }
   },
   "source": ".",
   "preferred-target": "js"

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -1,0 +1,129 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+const SAMPLE_SOURCE = 'osc = sine(freq: 440Hz)\nmeter = scope()';
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+function inputHandle(page: Page, nodeId: number): Locator {
+  return page.locator(`.handle.input[data-node-id="${nodeId}"]`);
+}
+
+function outputHandle(page: Page, nodeId: number): Locator {
+  return page.locator(`.handle.output[data-node-id="${nodeId}"]`);
+}
+
+async function center(locator: Locator, label: string): Promise<Point> {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(`${label} is not visible`);
+  }
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  };
+}
+
+async function dragBetween(page: Page, from: Locator, to: Locator): Promise<void> {
+  const start = await center(from, 'source handle');
+  const end = await center(to, 'target handle');
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps: 8 });
+}
+
+async function dragBy(page: Page, locator: Locator, dx: number, dy: number): Promise<void> {
+  const start = await center(locator, 'draggable node');
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + dx, start.y + dy, { steps: 8 });
+  await page.mouse.up();
+}
+
+function collectRuntimeErrors(page: Page): string[] {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+  return runtimeErrors;
+}
+
+test('source-backed node drag updates local layout without mutating source', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+
+  const node = page.locator('.canvas-node[data-node-id="1"]');
+  const before = await center(node, 'source-backed node');
+  await dragBy(page, node.locator('.node-title'), 82, 36);
+  const after = await center(node, 'dragged source-backed node');
+
+  expect(after.x - before.x).toBeGreaterThan(60);
+  expect(after.y - before.y).toBeGreaterThan(20);
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed canvas gestures lower into canonical source', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+
+  await dragBetween(page, outputHandle(page, 1), inputHandle(page, 2));
+  await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
+  await page.mouse.up();
+
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
+  );
+  await expect(page.locator('#edges path.edge')).toHaveCount(1);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed mode mutates canonical source and render state together', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+
+  await expect(page.locator('#source-panel')).toBeVisible();
+  await expect(page.locator('#source-mode-toggle')).toHaveText('Return to canvas runtime');
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+  await expect(page.locator('#edges path.edge')).toHaveCount(0);
+  await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+
+  await page.locator('#source-connect').click();
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
+  );
+  await expect(page.locator('#edges path.edge')).toHaveCount(1);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+
+  await page.locator('#source-insert').click();
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()',
+  );
+  await expect(page.locator('.canvas-node')).toHaveCount(3);
+  await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
+
+  await page.locator('#source-editor').fill(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()\ntap = scope(input: reverb)',
+  );
+  await page.locator('#source-apply').click();
+  await expect(page.locator('.canvas-node')).toHaveCount(4);
+  await expect(page.locator('#edges path.edge')).toHaveCount(2);
+  await expect(page.locator('#source-status')).toHaveText(
+    'Source applied; render state is reparsed from Loom GraphDoc.',
+  );
+
+  expect(runtimeErrors).toEqual([]);
+});

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -101,6 +101,12 @@
       width: 280px;
       padding: var(--space-lg);
     }
+    .source-panel {
+      top: 20px;
+      left: 328px;
+      width: min(520px, calc(100vw - 660px));
+      padding: var(--space-lg);
+    }
     .panel-title {
       display: flex;
       align-items: baseline;
@@ -145,6 +151,71 @@
       overflow: auto;
       padding-right: 2px;
     }
+    .mode-toggle {
+      box-sizing: border-box;
+      display: block;
+      width: 100%;
+      margin-top: var(--space-md);
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: var(--accent-soft);
+      color: var(--text);
+      cursor: pointer;
+      font: inherit;
+      font-size: 12.5px;
+      text-align: left;
+      text-decoration: none;
+      transition: background 120ms ease, border-color 120ms ease;
+    }
+    .mode-toggle:hover,
+    .mode-toggle:focus-visible {
+      background: oklch(63% 0.12 292 / 0.24);
+      border-color: var(--line-strong);
+      outline: none;
+    }
+    .source-editor {
+      width: 100%;
+      min-height: 148px;
+      resize: vertical;
+      padding: 10px 11px;
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: oklch(15% 0.018 276 / 0.94);
+      color: var(--text);
+      outline: none;
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+      font-size: 12px;
+      line-height: 1.55;
+    }
+    .source-editor:focus {
+      border-color: var(--line-strong);
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+    .source-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: var(--space-md);
+    }
+    .source-actions button {
+      padding: 7px 9px;
+      border-radius: 9px;
+      border: 1px solid var(--line);
+      background: oklch(28% 0.022 276 / 0.86);
+      color: var(--text);
+      cursor: pointer;
+      font: inherit;
+      font-size: 12px;
+    }
+    .source-actions button:hover,
+    .source-actions button:focus-visible {
+      background: var(--surface-soft);
+      border-color: var(--line-strong);
+      outline: none;
+    }
+    .source-status[data-tone="success"] { color: var(--success); }
+    .source-status[data-tone="error"] { color: oklch(82% 0.08 18); }
     .library-item,
     .validation-item,
     #context-menu button {
@@ -418,6 +489,11 @@
         width: 248px;
         padding: 14px;
       }
+      .source-panel {
+        left: 272px;
+        width: min(480px, calc(100vw - 590px));
+        padding: 14px;
+      }
       .inspector-panel {
         right: 12px;
         bottom: 12px;
@@ -430,11 +506,13 @@
 
     @media (max-width: 1100px) {
       .library-panel,
+      .source-panel,
       .inspector-panel {
         overflow: hidden;
         transition: transform 180ms cubic-bezier(.2,.8,.2,1), opacity 180ms ease;
       }
       .library-panel > *,
+      .source-panel > *,
       .inspector-panel > * {
         transition: opacity 120ms ease;
       }
@@ -442,6 +520,7 @@
         transform: translateX(calc(-100% + 46px));
       }
       .library-panel::after,
+      .source-panel::after,
       .inspector-panel::before {
         position: absolute;
         top: 50%;
@@ -457,6 +536,14 @@
         content: "Nodes";
         right: 14px;
       }
+      .source-panel {
+        transform: translateY(calc(-100% + 46px));
+      }
+      .source-panel::after {
+        content: "Source";
+        right: 50%;
+        transform: translate(50%, -50%) rotate(90deg);
+      }
       .inspector-panel {
         transform: translateX(calc(100% - 46px));
       }
@@ -465,6 +552,7 @@
         left: 14px;
       }
       .library-panel:not(:hover):not(:focus-within) > *,
+      .source-panel:not(:hover):not(:focus-within) > *,
       .inspector-panel:not(:hover):not(:focus-within) > * {
         opacity: 0;
         pointer-events: none;
@@ -474,6 +562,18 @@
       .inspector-panel:hover,
       .inspector-panel:focus-within {
         transform: translateX(0);
+      }
+      .source-panel:hover,
+      .source-panel:focus-within {
+        transform: translateY(0);
+      }
+    }
+
+    @media (max-width: 760px) {
+      .source-panel {
+        left: 58px;
+        right: 58px;
+        width: auto;
       }
     }
   </style>
@@ -487,8 +587,11 @@
       </div>
       <input id="node-search" type="search" placeholder="Search nodes…" aria-label="Search node library" />
       <div id="node-library"></div>
+      <div id="source-mode-root"></div>
       <p class="hint" style="margin-top: 12px;">Right-click to insert. Shift-click to multi-select.</p>
     </aside>
+
+    <div id="source-panel-root"></div>
 
     <section id="canvas-root" aria-label="Workflow canvas">
       <svg id="edges" xmlns="http://www.w3.org/2000/svg"></svg>

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -27,6 +27,22 @@ export type CanvasModule = {
   get_source_graph_render_state?: (h: number) => string;
   get_source_graph_action_log?: (h: number) => string;
   apply_source_graph_operation?: (h: number, operationJson: string) => string;
+  source_graph_insert_unique?: (
+    h: number,
+    bindingBase: string,
+    constructorName: string,
+  ) => string;
+  source_graph_pointer_down?: (h: number, nodeId: number, sx: number, sy: number) => void;
+  source_graph_pointer_move?: (h: number, sx: number, sy: number) => void;
+  source_graph_pointer_up?: (
+    h: number,
+    nodeId: number,
+    targetPortId: string,
+    additive: boolean,
+  ) => void;
+  source_graph_zoom?: (h: number, delta: number, cx: number, cy: number) => void;
+  sample_graph_dsl_source?: () => string;
+  mount_source_demo?: (h: number, enabled: boolean, onChange: () => void) => void;
 };
 
 type SourceCanvasModule = CanvasModule & {
@@ -37,6 +53,20 @@ type SourceCanvasModule = CanvasModule & {
   get_source_graph_render_state: (h: number) => string;
   get_source_graph_action_log: (h: number) => string;
   apply_source_graph_operation: (h: number, operationJson: string) => string;
+  source_graph_insert_unique: (
+    h: number,
+    bindingBase: string,
+    constructorName: string,
+  ) => string;
+  source_graph_pointer_down: (h: number, nodeId: number, sx: number, sy: number) => void;
+  source_graph_pointer_move: (h: number, sx: number, sy: number) => void;
+  source_graph_pointer_up: (
+    h: number,
+    nodeId: number,
+    targetPortId: string,
+    additive: boolean,
+  ) => void;
+  source_graph_zoom: (h: number, delta: number, cx: number, cy: number) => void;
 };
 
 const SOURCE_METHODS = [
@@ -47,6 +77,11 @@ const SOURCE_METHODS = [
   'get_source_graph_render_state',
   'get_source_graph_action_log',
   'apply_source_graph_operation',
+  'source_graph_insert_unique',
+  'source_graph_pointer_down',
+  'source_graph_pointer_move',
+  'source_graph_pointer_up',
+  'source_graph_zoom',
 ] as const;
 
 export type Tagged = string | [string, ...unknown[]];
@@ -247,6 +282,19 @@ export class GraphAdapter {
     });
   }
 
+  insertUniqueNode(bindingBase: string, constructorName: string): SourceGraphOperationResult {
+    this.assertLive();
+    const result = JSON.parse(
+      this.sourceModule().source_graph_insert_unique(
+        this.handle,
+        bindingBase,
+        constructorName,
+      ),
+    ) as SourceGraphOperationResult;
+    this.emitLatestOperations();
+    return result;
+  }
+
   connectPorts(
     sourceNodeId: number,
     targetNodeId: number,
@@ -263,8 +311,12 @@ export class GraphAdapter {
   }
 
   pointerDown(nodeId: number, sx: number, sy: number): void {
-    this.assertCanvasBacked('pointerDown');
-    this.mb.pointer_down(this.handle, nodeId, sx, sy);
+    this.assertLive();
+    if (this.isSourceBacked) {
+      this.sourceModule().source_graph_pointer_down(this.handle, nodeId, sx, sy);
+    } else {
+      this.mb.pointer_down(this.handle, nodeId, sx, sy);
+    }
   }
 
   pointerDownHandle(
@@ -278,24 +330,41 @@ export class GraphAdapter {
   }
 
   pointerMove(sx: number, sy: number): void {
-    this.assertCanvasBacked('pointerMove');
-    this.mb.pointer_move(this.handle, sx, sy);
+    this.assertLive();
+    if (this.isSourceBacked) {
+      this.sourceModule().source_graph_pointer_move(this.handle, sx, sy);
+    } else {
+      this.mb.pointer_move(this.handle, sx, sy);
+    }
   }
 
   pointerUp(nodeId: number, targetPortId: string, additive: boolean): void {
-    this.assertCanvasBacked('pointerUp');
-    this.mb.pointer_up(this.handle, nodeId, targetPortId, additive);
+    this.assertLive();
+    if (this.isSourceBacked) {
+      this.sourceModule().source_graph_pointer_up(
+        this.handle,
+        nodeId,
+        targetPortId,
+        additive,
+      );
+    } else {
+      this.mb.pointer_up(this.handle, nodeId, targetPortId, additive);
+    }
     this.emitLatestOperations();
   }
 
   hoverNode(nodeId: number): void {
-    this.assertLive();
+    this.assertCanvasBacked('hoverNode');
     this.mb.hover_node(this.handle, nodeId);
   }
 
   zoom(delta: number, cx: number, cy: number): void {
-    this.assertCanvasBacked('zoom');
-    this.mb.zoom(this.handle, delta, cx, cy);
+    this.assertLive();
+    if (this.isSourceBacked) {
+      this.sourceModule().source_graph_zoom(this.handle, delta, cx, cy);
+    } else {
+      this.mb.zoom(this.handle, delta, cx, cy);
+    }
     this.emitLatestOperations();
   }
 

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -1,6 +1,7 @@
 import {
   GraphAdapter,
   type CanvasModule,
+  type Connecting,
   type EdgeData,
   type NodeData,
   type PortDef,
@@ -19,6 +20,11 @@ type LibraryItem = {
   key: string;
   label: string;
   description: string;
+};
+
+type SourceDemoModule = CanvasModule & {
+  sample_graph_dsl_source: () => string;
+  mount_source_demo: (h: number, enabled: boolean, onChange: () => void) => void;
 };
 
 const LIBRARY: LibraryItem[] = [
@@ -52,6 +58,8 @@ const nodeDivs = new Map<number, HTMLDivElement>();
 const edgePaths = new Map<number, SVGPathElement>();
 let pendingPath: SVGPathElement | null = null;
 let contextPoint: [number, number] = [0, 0];
+let sourcePointerId = -1;
+let sourceConnecting: Connecting | null = null;
 
 // ─── Geometry ────────────────────────────────────────────────────────────────
 
@@ -76,6 +84,15 @@ function bezierPath(sx: number, sy: number, tx: number, ty: number): string {
 function localCoords(e: MouseEvent): [number, number] {
   const rect = root.getBoundingClientRect();
   return [e.clientX - rect.left, e.clientY - rect.top];
+}
+
+function screenToWorld(point: [number, number], state: RenderState): [number, number] {
+  const { x, y, scale } = state.viewport;
+  return [(point[0] - x) / scale, (point[1] - y) / scale];
+}
+
+function eventWorldCoords(e: MouseEvent): [number, number] {
+  return screenToWorld(localCoords(e), lastState ?? adapter.renderState());
 }
 
 function portTypeName(portType: Tagged): string {
@@ -176,8 +193,9 @@ function render(): void {
   // Resolve the in-flight connection's source port type once, so each input
   // handle can preview compatibility while the drag is live.
   let connectCtx: ConnectCtx | null = null;
-  if (state.connecting) {
-    const from = state.connecting;
+  const connecting = state.connecting ?? sourceConnecting ?? undefined;
+  if (connecting) {
+    const from = connecting;
     const srcNode = state.nodes.find((n) => n.id === from.from);
     const srcPort = srcNode?.outputs.find((p) => p.id === from.from_port);
     connectCtx = {
@@ -220,7 +238,7 @@ function render(): void {
     div.classList.toggle('selected', selected.has(node.id));
     div.classList.toggle('invalid', invalidNodeIds.has(node.id));
     div.classList.toggle('unconfigured', !node.configured);
-    div.classList.toggle('connecting-source', state.connecting?.from === node.id);
+    div.classList.toggle('connecting-source', connecting?.from === node.id);
     div.title = `${node.title}\n${node.subtitle}`;
 
     const title = div.querySelector('.node-title') as HTMLDivElement;
@@ -268,12 +286,12 @@ function render(): void {
   }
 
   // In-flight connection ─────────────────────────────────────────────────────
-  if (state.connecting) {
-    const src = nodesById.get(state.connecting.from);
+  if (connecting) {
+    const src = nodesById.get(connecting.from);
     if (src) {
-      const [sx, sy] = outputAnchor(src, state.connecting.from_port);
-      const tx = state.connecting.cursor_x;
-      const ty = state.connecting.cursor_y;
+      const [sx, sy] = outputAnchor(src, connecting.from_port);
+      const tx = connecting.cursor_x;
+      const ty = connecting.cursor_y;
       if (!pendingPath) {
         pendingPath = document.createElementNS(SVG_NS, 'path');
         pendingPath.setAttribute('class', 'edge-pending');
@@ -381,6 +399,12 @@ function hitFromTarget(target: EventTarget | null): HitTarget {
 }
 
 function addNodeAt(kindKey: string, point: [number, number]): void {
+  if (adapter.isSourceBacked) {
+    adapter.insertUniqueNode(kindKey, kindKey);
+    hideContextMenu();
+    scheduleRender();
+    return;
+  }
   adapter.addNode(kindKey, point[0], point[1]);
   hideContextMenu();
   scheduleRender();
@@ -391,7 +415,50 @@ function hoverNodeId(hit: HitTarget): number {
 }
 
 function updateHover(hit: HitTarget): void {
+  if (adapter.isSourceBacked) return;
   adapter.hoverNode(hoverNodeId(hit));
+}
+
+function startSourceConnection(e: PointerEvent, hit: HitTarget): void {
+  if (hit.kind !== 'handle' || hit.side !== 'output') return;
+  hideContextMenu();
+  root.setPointerCapture(e.pointerId);
+  sourcePointerId = e.pointerId;
+  const [cursor_x, cursor_y] = eventWorldCoords(e);
+  sourceConnecting = {
+    from: hit.nodeId,
+    from_port: hit.portId,
+    cursor_x,
+    cursor_y,
+  };
+  scheduleRender();
+}
+
+function moveSourceConnection(e: PointerEvent): void {
+  if (e.pointerId !== sourcePointerId || !sourceConnecting) return;
+  const [cursor_x, cursor_y] = eventWorldCoords(e);
+  sourceConnecting = { ...sourceConnecting, cursor_x, cursor_y };
+  scheduleRender();
+}
+
+function finishSourceConnection(e: PointerEvent): void {
+  if (e.pointerId !== sourcePointerId) return;
+  const connecting = sourceConnecting;
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  const hit = hitFromTarget(under);
+  sourcePointerId = -1;
+  sourceConnecting = null;
+  if (connecting && hit.kind === 'handle' && hit.side === 'input') {
+    adapter.connectPorts(connecting.from, hit.nodeId, hit.portId);
+  }
+  scheduleRender();
+}
+
+function cancelSourceConnection(e: PointerEvent): void {
+  if (e.pointerId !== sourcePointerId) return;
+  sourcePointerId = -1;
+  sourceConnecting = null;
+  scheduleRender();
 }
 
 function hideContextMenu(): void {
@@ -432,6 +499,25 @@ let pointerDownNodeId = 0;
 let pointerUpAdditive = false;
 
 root.addEventListener('pointerdown', (e: PointerEvent) => {
+  if (adapter.isSourceBacked) {
+    if (e.button !== 0) return;
+    const hit = hitFromTarget(e.target);
+    if (hit.kind === 'handle') {
+      startSourceConnection(e, hit);
+      return;
+    }
+    if (activePointerId !== -1) return;
+    hideContextMenu();
+    root.setPointerCapture(e.pointerId);
+    activePointerId = e.pointerId;
+    pointerUpAdditive = e.shiftKey || e.metaKey || e.ctrlKey;
+    const [sx, sy] = localCoords(e);
+    pointerDownNodeId = hit.kind === 'node' ? hit.nodeId : 0;
+    adapter.pointerDown(pointerDownNodeId, sx, sy);
+    if (hit.kind === 'background') root.classList.add('panning');
+    scheduleRender();
+    return;
+  }
   // macOS Ctrl+click is a secondary-click gesture but still reports button 0.
   // Let the contextmenu handler own it without breaking Ctrl-additive
   // selection on non-Mac platforms.
@@ -469,6 +555,20 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
 });
 
 root.addEventListener('pointermove', (e: PointerEvent) => {
+  if (adapter.isSourceBacked) {
+    if (e.pointerId === sourcePointerId) {
+      moveSourceConnection(e);
+      return;
+    }
+    if (e.pointerId !== activePointerId) {
+      scheduleRender();
+      return;
+    }
+    const [sx, sy] = localCoords(e);
+    adapter.pointerMove(sx, sy);
+    scheduleRender();
+    return;
+  }
   updateHover(hitFromTarget(e.target));
   if (e.pointerId !== activePointerId) {
     scheduleRender();
@@ -480,11 +580,32 @@ root.addEventListener('pointermove', (e: PointerEvent) => {
 });
 
 root.addEventListener('pointerleave', () => {
+  if (adapter.isSourceBacked) return;
   updateHover({ kind: 'background' });
   scheduleRender();
 });
 
 root.addEventListener('pointerup', (e: PointerEvent) => {
+  if (adapter.isSourceBacked) {
+    if (e.pointerId === sourcePointerId) {
+      finishSourceConnection(e);
+      return;
+    }
+    if (e.pointerId !== activePointerId) return;
+    const under = document.elementFromPoint(e.clientX, e.clientY);
+    const hit = hitFromTarget(under);
+    const upNodeId =
+      hit.kind === 'node'   ? hit.nodeId :
+      hit.kind === 'handle' ? hit.nodeId :
+      pointerDownNodeId;
+    adapter.pointerUp(upNodeId, '', pointerUpAdditive);
+    activePointerId = -1;
+    pointerDownNodeId = 0;
+    pointerUpAdditive = false;
+    root.classList.remove('panning');
+    scheduleRender();
+    return;
+  }
   if (e.pointerId !== activePointerId) return;
   // setPointerCapture redirects later events to the capturer, so e.target is
   // unreliable for hit-testing on release. Use elementFromPoint instead.
@@ -504,6 +625,20 @@ root.addEventListener('pointerup', (e: PointerEvent) => {
 });
 
 root.addEventListener('pointercancel', (e: PointerEvent) => {
+  if (adapter.isSourceBacked) {
+    if (e.pointerId === sourcePointerId) {
+      cancelSourceConnection(e);
+      return;
+    }
+    if (e.pointerId !== activePointerId) return;
+    adapter.pointerUp(0, '', false);
+    activePointerId = -1;
+    pointerDownNodeId = 0;
+    pointerUpAdditive = false;
+    root.classList.remove('panning');
+    scheduleRender();
+    return;
+  }
   if (e.pointerId !== activePointerId) return;
   adapter.pointerUp(0, '', false);
   activePointerId = -1;
@@ -545,9 +680,28 @@ search.addEventListener('input', () => renderLibrary(search.value));
 
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
+function sourceDemoRequested(searchParams = window.location.search): boolean {
+  return new URLSearchParams(searchParams).get('source') === '1';
+}
+
+function requireSourceDemoModule(mb: CanvasModule): SourceDemoModule {
+  if (typeof mb.sample_graph_dsl_source !== 'function') {
+    throw new Error('Canvas module is missing source demo export: sample_graph_dsl_source');
+  }
+  if (typeof mb.mount_source_demo !== 'function') {
+    throw new Error('Canvas module is missing source demo export: mount_source_demo');
+  }
+  return mb as SourceDemoModule;
+}
+
 async function init(): Promise<void> {
   const mod = await import('@moonbit/canopy-canvas') as CanvasModule;
-  adapter = GraphAdapter.create(mod);
+  const sourceDemoModule = requireSourceDemoModule(mod);
+  const sourceMode = sourceDemoRequested();
+  adapter = sourceMode
+    ? GraphAdapter.createSourceBacked(mod, sourceDemoModule.sample_graph_dsl_source())
+    : GraphAdapter.create(mod);
+  sourceDemoModule.mount_source_demo(adapter.handleId, sourceMode, scheduleRender);
   renderLibrary();
   render();
 }


### PR DESCRIPTION
## Summary
- Add a `?source=1` canvas browser demo mode with a Graph DSL source panel rendered by a small MoonBit/Rabbita cell.
- Route source edits and demo operations through the source-backed GraphAttachment / Loom GraphDoc path, keeping render state source-canonical.
- Keep TypeScript focused on canvas event plumbing and bridge calls; move source-demo UI state, commands, and subscriptions into MoonBit.
- Add MoonBit and Playwright coverage for source-backed source/render/action-log synchronization.

## Reuse check
- Reused `GraphDoc::lower_insert_node_binding`, `GraphDoc::lower_add_connection`, and `apply_source_graph_operation` for all source mutations; no parallel browser graph document was introduced.
- Reused Rabbita `@html` wrappers, `@rabbita.cell`, managed `Cmd` effects, and `@sub.every` for the source panel instead of imperative TypeScript DOM listeners.
- Reused the existing canvas render loop, node library insertion path, action stat rendering, and `scheduleRender` flow in `examples/canvas/web/src/main.ts`; source mode only gates canvas-backed pointer/zoom mutations.

## Validation
- `git diff --check`
- `moon check --deny-warn`
- `moon test`
- `cd examples/canvas && MOON_WORK=off moon check && MOON_WORK=off moon test`
- `cd examples/canvas/web && npm run build && npm run test:e2e`

Rabbita docs consulted: `rabbita/doc/001_intro/readme.mbt.md`, `rabbita/doc/002_writing_html/readme.mbt.md`, `rabbita/doc/004_using_command/readme.mbt.md`, `rabbita/doc/using_subscriptions/readme.mbt.md`, `rabbita/rabbita/html/README.mbt.md`, `rabbita/rabbita/sub/README.mbt.md`, `rabbita/rabbita/dom/README.mbt.md`.

Note: local working tree still has an unrelated dirty `loom` submodule; it is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced source-backed canvas mode enabling editing and manipulation of graphs through canonical Graph DSL source text.
  * Node positions are now persisted and automatically applied during interactive canvas operations.
  * Full pointer event support (drag, connect handles, zoom) for intuitive node manipulation.
  * Unique node insertion prevents accidental binding reuse when adding new nodes.

* **Tests**
  * Added end-to-end tests validating source-backed canvas interactions and node positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->