### PR TITLE
fix(canvas): report invalid source apply status

### DIFF
--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -678,14 +678,38 @@ pub fn get_source_graph_source(handle : Int) -> String {
 }
 
 ///|
-pub fn set_source_graph_source(handle : Int, source : String) -> Unit {
-  match source_graph_by_handle(handle) {
-    Some(graph) => {
-      graph.source = source
-      graph.attachment.set_source(source)
-    }
-    None => ()
+fn set_source_graph_source_checked(
+  handle : Int,
+  source : String,
+) -> SourceGraphOperationResultJson {
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None =>
+      return source_graph_operation_result_json(
+        false,
+        "",
+        ["source graph handle not found"],
+        0,
+        Some("source graph handle not found"),
+      )
   }
+  graph.source = source
+  graph.attachment.set_source(source)
+  match source_graph_current_doc(graph) {
+    Ok(_) => source_graph_result_json_for_graph(graph, true, None)
+    Err(message) =>
+      source_graph_result_json_for_graph(graph, false, Some(message))
+  }
+}
+
+///|
+pub fn set_source_graph_source(handle : Int, source : String) -> Unit {
+  ignore(set_source_graph_source_checked(handle, source))
+}
+
+///|
+pub fn set_source_graph_source_result(handle : Int, source : String) -> String {
+  set_source_graph_source_checked(handle, source).to_json().stringify()
 }
 
 ///|

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -284,6 +284,32 @@ test "source-backed handle rejects local graph operations without mutating sourc
 }
 
 ///|
+test "source-backed handle reports invalid source apply status" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  inspect(
+    operation_result_applied(
+      set_source_graph_source_result(handle, "osc = sine(freq: )"),
+    ),
+    content="false",
+  )
+  inspect(get_source_graph_source(handle), content="osc = sine(freq: )")
+  inspect(
+    operation_result_applied(
+      set_source_graph_source_result(handle, "osc = sine(input: missing)"),
+    ),
+    content="false",
+  )
+  inspect(get_source_graph_source(handle), content="osc = sine(input: missing)")
+  inspect(
+    operation_result_applied(set_source_graph_source_result(handle, source)),
+    content="true",
+  )
+  inspect(get_source_graph_source(handle), content=source)
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed handle rejects graph operations while source is invalid" {
   let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
   set_source_graph_source(handle, "osc = sine(freq: )")

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -30,6 +30,7 @@ options(
         "destroy_source_graph",
         "get_source_graph_source",
         "set_source_graph_source",
+        "set_source_graph_source_result",
         "get_source_graph_render_state",
         "get_source_graph_action_log",
         "apply_source_graph_operation",

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -44,6 +44,8 @@ pub fn sample_graph_dsl_source() -> String
 
 pub fn set_source_graph_source(Int, String) -> Unit
 
+pub fn set_source_graph_source_result(Int, String) -> String
+
 pub fn source_graph_insert_unique(Int, String, String) -> String
 
 pub fn source_graph_pointer_down(Int, Int, Double, Double) -> Unit

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -75,6 +75,7 @@ fn source_demo_notify(model : SourceDemoModel) -> Cmd {
 fn source_demo_status_from_result(
   result : SourceGraphOperationResultJson,
   success_message : String,
+  failure_prefix : String,
 ) -> (String, String) {
   if result.applied {
     (success_message, "success")
@@ -88,7 +89,7 @@ fn source_demo_status_from_result(
           result.diagnostics.join("; ")
         }
     }
-    ("Source operation rejected: " + detail, "error")
+    (failure_prefix + ": " + detail, "error")
   }
 }
 
@@ -102,22 +103,22 @@ fn source_demo_update(
     EditorChanged(source) =>
       (@rabbita.none, { ..model, editor: source, dirty: true })
     ApplySource => {
-      set_source_graph_source(model.handle, model.editor)
+      let result = set_source_graph_source_checked(model.handle, model.editor)
+      let success_message = "Source applied; render state is reparsed from Loom GraphDoc."
+      let failure_prefix = "Current source is invalid; canvas is rendering last-good graph"
+      let (status, tone) = source_demo_status_from_result(
+        result, success_message, failure_prefix,
+      )
       (
         source_demo_notify(model),
-        {
-          ..model,
-          editor: get_source_graph_source(model.handle),
-          dirty: false,
-          status: "Source applied; render state is reparsed from Loom GraphDoc.",
-          tone: "success",
-        },
+        { ..model, editor: result.source, dirty: false, status, tone },
       )
     }
     ConnectSample => {
       let result = source_graph_connect_sample_result(model.handle)
+      let success_message = "Connected meter.input to osc.out through graph-dsl source."
       let (status, tone) = source_demo_status_from_result(
-        result, "Connected meter.input to osc.out through graph-dsl source.",
+        result, success_message, "Source operation rejected",
       )
       (
         source_demo_notify(model),
@@ -130,8 +131,9 @@ fn source_demo_update(
         "reverb",
         "plate",
       )
+      let success_message = "Inserted reverb = plate() from canonical source."
       let (status, tone) = source_demo_status_from_result(
-        result, "Inserted reverb = plate() from canonical source.",
+        result, success_message, "Source operation rejected",
       )
       (
         source_demo_notify(model),

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -2,6 +2,11 @@ import { expect, type Locator, type Page, test } from '@playwright/test';
 
 const SAMPLE_SOURCE = 'osc = sine(freq: 440Hz)\nmeter = scope()';
 
+const INVALID_SOURCE_CASES = [
+  { name: 'parser-blocked', source: 'osc = sine(freq: )' },
+  { name: 'projection-blocked', source: 'osc = sine(input: missing)' },
+] as const;
+
 type Point = {
   x: number;
   y: number;
@@ -88,6 +93,31 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   expect(runtimeErrors).toEqual([]);
 });
+
+for (const invalidSource of INVALID_SOURCE_CASES) {
+  test(`source-backed apply reports ${invalidSource.name} source as invalid`, async ({ page }) => {
+    const runtimeErrors = collectRuntimeErrors(page);
+
+    await page.goto('/?source=1');
+    await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+    await expect(page.locator('.canvas-node')).toHaveCount(2);
+
+    await page.locator('#source-editor').fill(invalidSource.source);
+    await page.locator('#source-apply').click();
+
+    await expect(page.locator('#source-editor')).toHaveValue(invalidSource.source);
+    await expect(page.locator('.canvas-node')).toHaveCount(2);
+    await expect(page.locator('#edges path.edge')).toHaveCount(0);
+    await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
+    await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'error');
+    await expect(page.locator('#source-status')).toContainText(
+      'Current source is invalid; canvas is rendering last-good graph: current source is not graph-valid:',
+    );
+    await expect(page.locator('#validation-list .validation-item.error').first()).toBeVisible();
+
+    expect(runtimeErrors).toEqual([]);
+  });
+}
 
 test('source-backed mode mutates canonical source and render state together', async ({ page }) => {
   const runtimeErrors = collectRuntimeErrors(page);

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -24,6 +24,7 @@ export type CanvasModule = {
   destroy_source_graph?: (h: number) => void;
   get_source_graph_source?: (h: number) => string;
   set_source_graph_source?: (h: number, source: string) => void;
+  set_source_graph_source_result?: (h: number, source: string) => string;
   get_source_graph_render_state?: (h: number) => string;
   get_source_graph_action_log?: (h: number) => string;
   apply_source_graph_operation?: (h: number, operationJson: string) => string;
@@ -50,6 +51,7 @@ type SourceCanvasModule = CanvasModule & {
   destroy_source_graph: (h: number) => void;
   get_source_graph_source: (h: number) => string;
   set_source_graph_source: (h: number, source: string) => void;
+  set_source_graph_source_result: (h: number, source: string) => string;
   get_source_graph_render_state: (h: number) => string;
   get_source_graph_action_log: (h: number) => string;
   apply_source_graph_operation: (h: number, operationJson: string) => string;
@@ -74,6 +76,7 @@ const SOURCE_METHODS = [
   'destroy_source_graph',
   'get_source_graph_source',
   'set_source_graph_source',
+  'set_source_graph_source_result',
   'get_source_graph_render_state',
   'get_source_graph_action_log',
   'apply_source_graph_operation',
@@ -256,10 +259,13 @@ export class GraphAdapter {
     return this.sourceModule().get_source_graph_source(this.handle);
   }
 
-  setSource(source: string): void {
+  setSource(source: string): SourceGraphOperationResult {
     this.assertLive();
-    this.sourceModule().set_source_graph_source(this.handle, source);
+    const result = JSON.parse(
+      this.sourceModule().set_source_graph_source_result(this.handle, source),
+    ) as SourceGraphOperationResult;
     this.lastActionCount = this.readActionLog().length;
+    return result;
   }
 
   applyOperation(operation: GraphOperation): SourceGraphOperationResult {


### PR DESCRIPTION
## Summary

- Add a result-returning source apply API for the source-backed canvas demo while preserving the existing Unit setter.
- Update the Rabbita source panel Apply action to report invalid current source with error tone while keeping last-good canvas rendering available.
- Cover parser-blocked and projection-blocked invalid source apply status in MoonBit and Playwright tests.

Closes #483.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceGraphOperationResultJson` | `examples/canvas/main/graph_dsl_adapter.mbt` | Yes | Reused as the typed result shape for source apply status. |
| `source_graph_result_json_for_graph` | `examples/canvas/main/graph_dsl_adapter.mbt` | Yes | Reused to include source, diagnostics, action count, and message consistently. |
| `source_graph_current_doc` | `examples/canvas/main/graph_dsl_adapter.mbt` | Yes | Reused to distinguish valid current source from last-good rendering. |

New helpers added:

- `set_source_graph_source_checked`: private typed apply path used by the MoonBit source panel and JSON export.
- `set_source_graph_source_result`: public JS export returning the same result JSON shape used by other source graph operations; keeps existing `set_source_graph_source(...)->Unit` API intact.

## Test plan

- [x] `MOON_WORK=off moon check --target js` passes from `examples/canvas`
- [x] `MOON_WORK=off moon test --target js` passes from `examples/canvas`
- [x] `git diff *.mbti` reviewed for intended API addition: `set_source_graph_source_result(Int, String) -> String`
- [x] JS rebuild run because canvas web is affected (`cd examples/canvas/web && npm run build`)
- [x] Canvas E2E run (`cd examples/canvas/web && npm run test:e2e`)

## Validation

```bash
cd examples/canvas
MOON_WORK=off moon check --target js
MOON_WORK=off moon test --target js
cd web
npm run build
npm run test:e2e
```
