### PR TITLE
feat(resizable): add Rabbita headless resizable panel

### DIFF
--- a/examples/resizable/README.md
+++ b/examples/resizable/README.md
@@ -1,0 +1,19 @@
+# Resizable example
+
+Runnable Rabbita demo for `dowdiness/rabbita-resizable`.
+
+## Run
+
+```bash
+moon install moonbit-community/warren
+warren dev
+```
+
+Open the local URL shown by Warren.
+
+## Manual check
+
+- Drag the corner handle on the box; width and height change within bounds.
+- Drag the vertical split-pane separator; the left pane width changes.
+- Release the mouse outside the thin handle; resizing still ends because the package installs a document-level `mouseup` subscription.
+- Focus a handle with Tab and use arrow keys: the corner handle responds on both axes, and the split handle responds to Left/Right.

--- a/examples/resizable/main/client.mbt
+++ b/examples/resizable/main/client.mbt
@@ -1,0 +1,137 @@
+///|
+using @html {code, div, h1, h2, p, span, nothing}
+
+///|
+using @rabbita {type Cmd, type Emit, type Html}
+
+///|
+struct Model {
+  corner : @resizable.Model
+  split : @resizable.Model
+}
+
+///|
+enum Msg {
+  Corner(@resizable.Msg)
+  Split(@resizable.Msg)
+}
+
+///|
+fn corner_constraints() -> @resizable.Constraints {
+  { min_w: 160, max_w: 520, min_h: 110, max_h: 360 }
+}
+
+///|
+fn split_constraints() -> @resizable.Constraints {
+  { min_w: 180, max_w: 560, min_h: 240, max_h: 240 }
+}
+
+///|
+let initial_model : Model = {
+  corner: @resizable.Model::new(w=260, h=160, constraints=corner_constraints()),
+  split: @resizable.Model::new(w=320, h=240, constraints=split_constraints()),
+}
+
+///|
+fn update(_emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
+  match msg {
+    Corner(resize_msg) => {
+      let corner = model.corner.update(resize_msg)
+      (@rabbita.none, { ..model, corner, })
+    }
+    Split(resize_msg) => {
+      let split = model.split.update(resize_msg)
+      (@rabbita.none, { ..model, split, })
+    }
+  }
+}
+
+///|
+fn subscriptions(emit : Emit[Msg], model : Model) -> @sub.Sub {
+  @sub.batch([
+    model.corner.subscriptions(msg => emit(Corner(msg))),
+    model.split.subscriptions(msg => emit(Split(msg))),
+  ])
+}
+
+///|
+fn size_badge(width : Int, height : Int) -> Html {
+  span(class="size-badge", "\{width}px × \{height}px")
+}
+
+///|
+fn corner_box(emit : Emit[Msg], model : @resizable.Model) -> Html {
+  div(class="demo-card", [
+    h2("Corner-resizable box"),
+    p("Drag the corner handle, or focus it and use arrow keys."),
+    div(class="corner-box", attrs=model.container_attrs(), [
+      div(class="box-content", [
+        p(class="eyebrow", "SouthEast handle"),
+        h2("Headless behavior, styled by the consumer"),
+        size_badge(model.width(), model.height()),
+      ]),
+      div(
+        class="corner-handle",
+        attrs=model.handle_attrs(@resizable.Edge::SouthEast, msg => {
+          emit(Corner(msg))
+        }),
+        nothing,
+      ),
+    ]),
+  ])
+}
+
+///|
+fn split_pane(emit : Emit[Msg], model : @resizable.Model) -> Html {
+  div(class="demo-card", [
+    h2("Horizontal split pane"),
+    p("Drag the vertical separator, or focus it and press Left/Right."),
+    div(class="split-shell", [
+      div(class="split-left", attrs=model.container_attrs(), [
+        div(class="pane-copy", [
+          p(class="eyebrow", "Resizable East edge"),
+          h2("Inspector"),
+          p("The handle is just a div with attrs supplied by resizable."),
+          code("width = \{model.width()}px"),
+        ]),
+        div(
+          class="split-handle",
+          attrs=model.handle_attrs(@resizable.Edge::East, msg => {
+            emit(Split(msg))
+          }),
+          nothing,
+        ),
+      ]),
+      div(class="split-right", [
+        p(class="eyebrow", "Flexible peer"),
+        h2("Workspace"),
+        p("The right pane does not know about resize state."),
+      ]),
+    ]),
+  ])
+}
+
+///|
+fn view(emit : Emit[Msg], model : Model) -> Html {
+  div(class="page", [
+    div(class="hero", [
+      p(class="eyebrow", "Rabbita package demo"),
+      h1("Headless resizable"),
+      p(
+        class="subtitle",
+        "State, updates, subscriptions, and ARIA are reusable; markup and styling stay local.",
+      ),
+    ]),
+    div(class="demo-grid", [
+      corner_box(emit, model.corner),
+      split_pane(emit, model.split),
+    ]),
+  ])
+}
+
+///|
+#cfg(target="js")
+fn main {
+  let app = @rabbita.cell(model=initial_model, update~, view~, subscriptions~)
+  @rabbita.new(app).mount("app")
+}

--- a/examples/resizable/main/moon.pkg
+++ b/examples/resizable/main/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
+  "dowdiness/rabbita-resizable/resizable",
+}
+
+supported_targets = "js"
+
+options(
+  "is-main": true,
+)

--- a/examples/resizable/main/pkg.generated.mbti
+++ b/examples/resizable/main/pkg.generated.mbti
@@ -1,0 +1,15 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "example/resizable/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+type Model
+
+type Msg
+
+// Type aliases
+
+// Traits

--- a/examples/resizable/moon.mod.json
+++ b/examples/resizable/moon.mod.json
@@ -1,0 +1,20 @@
+{
+  "name": "example/resizable",
+  "version": "0.1.0",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.2"
+    },
+    "dowdiness/rabbita-resizable": {
+      "path": "../../lib/resizable",
+      "version": "0.1.0"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "description": "Rabbita resizable demo",
+  "preferred-target": "js"
+}

--- a/examples/resizable/public/styles.css
+++ b/examples/resizable/public/styles.css
@@ -1,0 +1,206 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #111827;
+  color: #e5e7eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(130, 80, 223, 0.26), transparent 36rem),
+    linear-gradient(135deg, #101626 0%, #17172c 55%, #10131f 100%);
+}
+
+button,
+[role="separator"] {
+  font: inherit;
+}
+
+.page {
+  width: min(1120px, calc(100vw - 48px));
+  margin: 0 auto;
+  padding: 56px 0 72px;
+}
+
+.hero {
+  max-width: 720px;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #a78bfa;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(40px, 7vw, 72px);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+h2 {
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.subtitle,
+.demo-card > p,
+.pane-copy p,
+.split-right p {
+  color: #a8b0c2;
+  line-height: 1.6;
+}
+
+.subtitle {
+  margin-top: 18px;
+  font-size: 18px;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
+}
+
+.demo-card {
+  min-width: 0;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.76);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(18px);
+}
+
+.demo-card > p {
+  margin: 8px 0 20px;
+}
+
+.corner-box,
+.split-left {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(167, 139, 250, 0.42);
+  border-radius: 22px;
+  background:
+    linear-gradient(135deg, rgba(130, 80, 223, 0.24), transparent 55%),
+    rgba(23, 30, 50, 0.9);
+}
+
+.box-content,
+.pane-copy,
+.split-right {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  padding: 22px;
+}
+
+.size-badge,
+code {
+  align-self: flex-start;
+  padding: 6px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  color: #c4b5fd;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.corner-handle,
+.split-handle {
+  position: absolute;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(196, 181, 253, 0.58);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.16), 0 12px 34px rgba(130, 80, 223, 0.34);
+  outline: none;
+}
+
+.corner-handle:focus-visible,
+.split-handle:focus-visible {
+  box-shadow: 0 0 0 3px rgba(196, 181, 253, 0.3), 0 0 0 6px rgba(130, 80, 223, 0.28);
+}
+
+.corner-handle {
+  right: 10px;
+  bottom: 10px;
+  width: 26px;
+  height: 26px;
+}
+
+.corner-handle::before,
+.corner-handle::after {
+  content: "";
+  position: absolute;
+  right: 7px;
+  bottom: 7px;
+  border-right: 2px solid rgba(15, 23, 42, 0.72);
+  border-bottom: 2px solid rgba(15, 23, 42, 0.72);
+}
+
+.corner-handle::before {
+  width: 10px;
+  height: 10px;
+}
+
+.corner-handle::after {
+  width: 5px;
+  height: 5px;
+}
+
+.split-shell {
+  display: flex;
+  min-height: 240px;
+  overflow: hidden;
+  border-radius: 24px;
+  background: rgba(3, 7, 18, 0.44);
+}
+
+.split-left {
+  flex: 0 0 auto;
+  border-radius: 24px 0 0 24px;
+  border-right: 0;
+}
+
+.split-handle {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 12px;
+  border-radius: 0;
+  background: linear-gradient(90deg, transparent, rgba(196, 181, 253, 0.42), transparent);
+}
+
+.split-right {
+  flex: 1 1 auto;
+  min-width: 180px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0 24px 24px 0;
+  background: rgba(15, 23, 42, 0.56);
+}
+
+@media (min-width: 920px) {
+  .demo-grid {
+    grid-template-columns: 0.9fr 1.1fr;
+    align-items: start;
+  }
+}

--- a/lib/resizable/README.md
+++ b/lib/resizable/README.md
@@ -1,0 +1,55 @@
+# Rabbita Resizable
+
+Headless resize behavior for Rabbita apps. The package owns resize state,
+messages, accessibility attributes, and document-level drag subscriptions; the
+consumer owns all HTML structure and styling.
+
+## Use
+
+```mbt nocheck
+// In your app model:
+struct Model {
+  panel : @resizable.Model
+}
+
+// In view:
+@html.div(
+  class="panel",
+  attrs=model.panel.container_attrs(),
+  [
+    @html.div("content"),
+    @html.div(
+      class="panel-handle",
+      attrs=model.panel.handle_attrs(
+        @resizable.Edge::East,
+        msg => emit(PanelResize(msg)),
+      ),
+      @html.nothing,
+    ),
+  ],
+)
+
+// In subscriptions:
+model.panel.subscriptions(msg => emit(PanelResize(msg)))
+```
+
+`Model::new` requires `1 <= min <= max` on both axes and clamps the initial
+size into the constraint bounds.
+
+## Design question report
+
+- **Q1 Packaging:** keep this as a standalone module (`dowdiness/rabbita-resizable`) for v1. It can move upstream once the API shape has real consumers.
+- **Q2 Custom `mouseup` sub:** keep it isolated in `subscriptions.mbt` now. Recommendation: upstream `@sub.on_mouse_up` later, because `mousemove` already exists and the symmetry belongs in Rabbita.
+- **Q3 Edge granularity:** ship `East`, `South`, and `SouthEast` only. The `Msg` payload already carries an `Edge`, so adding origin-moving edges later is source-compatible for message routing, but consumers will need new layout/repositioning logic.
+- **Q4 Keyboard step:** v1 uses a fixed 8px step and orientation-specific arrows, with no Shift multiplier. Recommendation: add configurable step/large-step options only after consumer feedback.
+- **Q5 Subscriptions surface:** keep `Model::subscriptions` as a helper. It removes boilerplate for one instance; consumers with several active instances must batch helpers and should ensure only one resize is active at a time because Rabbita subscription keys are singleton-style.
+
+## Verified Rabbita APIs
+
+Implementation was checked against the vendored Rabbita source, especially:
+
+- `rabbita/rabbita/tea.mbt`
+- `rabbita/rabbita/html/{attrs.mbt,attrs_event.mbt,html.mbt,children.mbt}`
+- `rabbita/rabbita/dom/{mouse_event.mbt,keyboard_event.mbt,event_target.mbt}`
+- `rabbita/rabbita/sub/{sub.mbt,design.md,README.mbt.md}`
+- `rabbita/rabbita/websocket/listen.mbt`

--- a/lib/resizable/moon.mod.json
+++ b/lib/resizable/moon.mod.json
@@ -1,0 +1,24 @@
+{
+  "name": "dowdiness/rabbita-resizable",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.2"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [
+    "rabbita",
+    "resizable",
+    "component",
+    "moonbit",
+    "tea"
+  ],
+  "description": "Headless resizable component helpers for Rabbita.",
+  "preferred-target": "native",
+  "supported-targets": "js+native"
+}

--- a/lib/resizable/src/resizable/attrs.mbt
+++ b/lib/resizable/src/resizable/attrs.mbt
@@ -1,0 +1,158 @@
+///|
+#cfg(target="js")
+let keyboard_step : Int = 8
+
+///|
+fn px(value : Int) -> String {
+  "\{value}px"
+}
+
+///|
+fn Edge::cursor(self : Edge) -> String {
+  match self {
+    East => "ew-resize"
+    South => "ns-resize"
+    SouthEast => "nwse-resize"
+  }
+}
+
+///|
+fn Edge::aria_label(self : Edge) -> String {
+  match self {
+    East => "Resize width"
+    South => "Resize height"
+    SouthEast => "Resize width and height"
+  }
+}
+
+///|
+fn Edge::value_min(self : Edge, constraints : Constraints) -> Int {
+  match self {
+    South => constraints.min_h
+    East | SouthEast => constraints.min_w
+  }
+}
+
+///|
+fn Edge::value_max(self : Edge, constraints : Constraints) -> Int {
+  match self {
+    South => constraints.max_h
+    East | SouthEast => constraints.max_w
+  }
+}
+
+///|
+fn Edge::value_now(self : Edge, model : Model) -> Int {
+  match self {
+    South => model.h
+    East | SouthEast => model.w
+  }
+}
+
+///|
+fn Edge::value_text(self : Edge, model : Model) -> String {
+  match self {
+    East => "width \{model.w}px"
+    South => "height \{model.h}px"
+    SouthEast => "width \{model.w}px, height \{model.h}px"
+  }
+}
+
+///|
+fn Edge::orientation(self : Edge) -> String? {
+  match self {
+    East => Some("vertical")
+    South => Some("horizontal")
+    SouthEast => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn Edge::keydown_nudge(self : Edge, key : String) -> Msg? {
+  match (self, key) {
+    (East | SouthEast, "ArrowRight") => Some(NudgeBy(dw=keyboard_step, dh=0))
+    (East | SouthEast, "ArrowLeft") => Some(NudgeBy(dw=-keyboard_step, dh=0))
+    (South | SouthEast, "ArrowDown") => Some(NudgeBy(dw=0, dh=keyboard_step))
+    (South | SouthEast, "ArrowUp") => Some(NudgeBy(dw=0, dh=-keyboard_step))
+    _ => None
+  }
+}
+
+///|
+fn with_orientation(attrs : @html.Attrs, edge : Edge) -> @html.Attrs {
+  match edge.orientation() {
+    Some(value) => attrs.aria_orientation(value)
+    None => attrs
+  }
+}
+
+///|
+fn Model::value_attrs(
+  self : Model,
+  attrs : @html.Attrs,
+  edge : Edge,
+) -> @html.Attrs {
+  attrs
+  .aria_valuemin(edge.value_min(self.constraints).to_string())
+  .aria_valuemax(edge.value_max(self.constraints).to_string())
+  .aria_valuenow(edge.value_now(self).to_string())
+  .aria_valuetext(edge.value_text(self))
+}
+
+///|
+fn Model::base_handle_attrs(self : Model, edge : Edge) -> @html.Attrs {
+  let attrs = @html.Attrs::build()
+    .role("separator")
+    .tabindex(0)
+    .aria_label(edge.aria_label())
+    .style("cursor", edge.cursor())
+  self.value_attrs(with_orientation(attrs, edge), edge)
+}
+
+///|
+pub fn Model::container_attrs(self : Model) -> @html.Attrs {
+  let attrs = @html.Attrs::build()
+    .style("width", px(self.w))
+    .style("height", px(self.h))
+  if self.is_resizing() {
+    attrs.style("user-select", "none")
+  } else {
+    attrs
+  }
+}
+
+///|
+#cfg(target="js")
+pub fn Model::handle_attrs(
+  self : Model,
+  edge : Edge,
+  dispatch : (Msg) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  self
+  .base_handle_attrs(edge)
+  .on_mousedown(event => {
+    event.prevent_default()
+    dispatch(StartResize(edge~, x=event.get_client_x(), y=event.get_client_y()))
+  })
+  .on_keydown(event => {
+    match edge.keydown_nudge(event.key()) {
+      Some(msg) => {
+        event.prevent_default()
+        dispatch(msg)
+      }
+      None => @rabbita.none
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::handle_attrs(
+  self : Model,
+  edge : Edge,
+  dispatch : (Msg) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  ignore(dispatch)
+  self.base_handle_attrs(edge)
+}

--- a/lib/resizable/src/resizable/moon.pkg
+++ b/lib/resizable/src/resizable/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/common",
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
+}
+
+import {
+  "moonbitlang/core/quickcheck",
+} for "test"
+
+warnings = "-unused_package"
+
+supported_targets = "js+native"

--- a/lib/resizable/src/resizable/pkg.generated.mbti
+++ b/lib/resizable/src/resizable/pkg.generated.mbti
@@ -1,0 +1,51 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita-resizable/resizable"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct Constraints {
+  min_w : Int
+  max_w : Int
+  min_h : Int
+  max_h : Int
+}
+
+type Drag
+
+pub(all) enum Edge {
+  East
+  South
+  SouthEast
+}
+
+pub struct Model {
+  // private fields
+}
+pub fn Model::container_attrs(Self) -> @html.Attrs
+pub fn Model::handle_attrs(Self, Edge, (Msg) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::height(Self) -> Int
+pub fn Model::is_resizing(Self) -> Bool
+pub fn Model::new(w~ : Int, h~ : Int, constraints~ : Constraints) -> Self
+pub fn Model::subscriptions(Self, (Msg) -> @cmd.Cmd) -> @sub.Sub
+pub fn Model::update(Self, Msg) -> Self
+pub fn Model::width(Self) -> Int
+
+pub(all) enum Msg {
+  StartResize(edge~ : Edge, x~ : Int, y~ : Int)
+  PointerMove(x~ : Int, y~ : Int)
+  EndResize
+  NudgeBy(dw~ : Int, dh~ : Int)
+}
+
+// Type aliases
+
+// Traits

--- a/lib/resizable/src/resizable/resizable_test.mbt
+++ b/lib/resizable/src/resizable/resizable_test.mbt
@@ -1,0 +1,156 @@
+///|
+fn test_constraints() -> Constraints {
+  { min_w: 50, max_w: 300, min_h: 40, max_h: 220 }
+}
+
+///|
+fn test_model() -> Model {
+  Model::new(w=120, h=90, constraints=test_constraints())
+}
+
+///|
+fn apply_messages(model : Model, messages : Array[Msg]) -> Model {
+  for msg in messages; current = model {
+    continue current.update(msg)
+  } nobreak {
+    current
+  }
+}
+
+///|
+fn assert_in_bounds(model : Model, constraints : Constraints) -> Unit raise {
+  assert_true(model.width() >= constraints.min_w)
+  assert_true(model.width() <= constraints.max_w)
+  assert_true(model.height() >= constraints.min_h)
+  assert_true(model.height() <= constraints.max_h)
+}
+
+///|
+fn assert_same_public_state(left : Model, right : Model) -> Unit raise {
+  assert_eq(left.width(), right.width())
+  assert_eq(left.height(), right.height())
+  assert_eq(left.is_resizing(), right.is_resizing())
+}
+
+///|
+fn sample_coord(seed : Int) -> Int {
+  seed % 701 - 350
+}
+
+///|
+fn non_negative(seed : Int) -> Int {
+  if seed < 0 {
+    -(seed + 1)
+  } else {
+    seed
+  }
+}
+
+///|
+fn sample_msg(seed : Int) -> Msg {
+  let value = non_negative(seed)
+  let x = sample_coord(value)
+  let y = sample_coord(value / 701)
+  match value % 8 {
+    0 => StartResize(edge=East, x~, y~)
+    1 => StartResize(edge=South, x~, y~)
+    2 => StartResize(edge=SouthEast, x~, y~)
+    3 => PointerMove(x~, y~)
+    4 => EndResize
+    5 => NudgeBy(dw=x, dh=0)
+    6 => NudgeBy(dw=0, dh=y)
+    _ => NudgeBy(dw=x, dh=y)
+  }
+}
+
+///|
+test "Model::new clamps initial size" {
+  let constraints = test_constraints()
+  let model = Model::new(w=10, h=1000, constraints~)
+  assert_eq(model.width(), constraints.min_w)
+  assert_eq(model.height(), constraints.max_h)
+  assert_in_bounds(model, constraints)
+}
+
+///|
+test "quickcheck sample sequences preserve clamp invariant" {
+  let constraints = test_constraints()
+  let samples : Array[Array[Int]] = @quickcheck.samples(32)
+  for sample in samples {
+    let model = apply_messages(
+      Model::new(w=120, h=90, constraints~),
+      sample.map(sample_msg),
+    )
+    assert_in_bounds(model, constraints)
+  }
+}
+
+///|
+test "clamp invariant after representative message sequences" {
+  let constraints = test_constraints()
+  let sequences : Array[Array[Msg]] = [
+    [],
+    [NudgeBy(dw=1000, dh=1000)],
+    [NudgeBy(dw=-1000, dh=-1000)],
+    [StartResize(edge=East, x=0, y=0), PointerMove(x=1000, y=0)],
+    [StartResize(edge=East, x=0, y=0), PointerMove(x=-1000, y=0)],
+    [StartResize(edge=South, x=0, y=0), PointerMove(x=0, y=1000)],
+    [StartResize(edge=South, x=0, y=0), PointerMove(x=0, y=-1000)],
+    [
+      StartResize(edge=SouthEast, x=10, y=10),
+      PointerMove(x=1000, y=-1000),
+      EndResize,
+      NudgeBy(dw=-1000, dh=1000),
+    ],
+    [
+      PointerMove(x=99, y=99),
+      EndResize,
+      StartResize(edge=SouthEast, x=0, y=0),
+      PointerMove(x=25, y=35),
+      EndResize,
+      EndResize,
+    ],
+  ]
+  for seq in sequences {
+    let model = apply_messages(Model::new(w=120, h=90, constraints~), seq)
+    assert_in_bounds(model, constraints)
+  }
+}
+
+///|
+test "EndResize clears drag and is idempotent" {
+  let dragging = test_model().update(StartResize(edge=East, x=10, y=20))
+  assert_true(dragging.is_resizing())
+  let once = dragging.update(EndResize)
+  let twice = once.update(EndResize)
+  assert_true(!once.is_resizing())
+  assert_same_public_state(once, twice)
+}
+
+///|
+test "StartResize followed by same-point PointerMove leaves size unchanged" {
+  let model = test_model()
+  let moved = model
+    .update(StartResize(edge=SouthEast, x=42, y=71))
+    .update(PointerMove(x=42, y=71))
+  assert_eq(moved.width(), model.width())
+  assert_eq(moved.height(), model.height())
+  assert_true(moved.is_resizing())
+}
+
+///|
+test "PointerMove with no active drag is identity" {
+  let model = test_model()
+  let moved = model.update(PointerMove(x=900, y=900))
+  assert_same_public_state(model, moved)
+}
+
+///|
+test "East drag width change equals delta within bounds" {
+  let model = test_model()
+  let moved = model
+    .update(StartResize(edge=East, x=10, y=5))
+    .update(PointerMove(x=45, y=105))
+  assert_eq(moved.width(), model.width() + 35)
+  assert_eq(moved.height(), model.height())
+}

--- a/lib/resizable/src/resizable/subscriptions.mbt
+++ b/lib/resizable/src/resizable/subscriptions.mbt
@@ -1,0 +1,76 @@
+///|
+#cfg(target="js")
+using @cmd {trait Scheduler}
+
+///|
+#cfg(target="js")
+priv suberror DocumentMouseUpSubscription {
+  DocumentMouseUp(@rabbita.Cmd)
+}
+
+///|
+#cfg(target="js")
+fn document_mouse_up_loader(
+  payload : Error,
+  scheduler : &Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    DocumentMouseUp(cmd) => {
+      let mut tagger = cmd
+      let listener : @dom.Listener = _ => scheduler.add(tagger)
+      @dom.document().as_event_target().add_event_listener("mouseup", listener)
+      Some({
+        unload: _ => {
+          @dom.document()
+          .as_event_target()
+          .remove_event_listener("mouseup", listener)
+        },
+        update_tagger: payload => {
+          guard payload is DocumentMouseUp(cmd) else { return }
+          tagger = cmd
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn on_document_mouse_up(cmd : @rabbita.Cmd) -> @sub.Sub {
+  @sub.custom_sub(
+    "resizable.document_mouse_up",
+    Local,
+    DocumentMouseUp(cmd),
+    document_mouse_up_loader,
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn Model::subscriptions(
+  self : Model,
+  dispatch : (Msg) -> @rabbita.Cmd,
+) -> @sub.Sub {
+  if self.is_resizing() {
+    @sub.batch([
+      @sub.on_mouse_move(mouse => {
+        let pos = mouse.client_pos()
+        dispatch(PointerMove(x=pos.x, y=pos.y))
+      }),
+      on_document_mouse_up(dispatch(EndResize)),
+    ])
+  } else {
+    @sub.none
+  }
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::subscriptions(
+  self : Model,
+  dispatch : (Msg) -> @rabbita.Cmd,
+) -> @sub.Sub {
+  ignore((self, dispatch))
+  @sub.none
+}

--- a/lib/resizable/src/resizable/types.mbt
+++ b/lib/resizable/src/resizable/types.mbt
@@ -1,0 +1,55 @@
+///|
+pub(all) enum Edge {
+  East
+  South
+  SouthEast
+}
+
+///|
+pub(all) struct Constraints {
+  min_w : Int
+  max_w : Int
+  min_h : Int
+  max_h : Int
+}
+
+///|
+struct Drag {
+  edge : Edge
+  origin_x : Int
+  origin_y : Int
+  base_w : Int
+  base_h : Int
+}
+
+///|
+pub struct Model {
+  priv w : Int
+  priv h : Int
+  priv constraints : Constraints
+  priv drag : Drag?
+}
+
+///|
+pub(all) enum Msg {
+  StartResize(edge~ : Edge, x~ : Int, y~ : Int)
+  PointerMove(x~ : Int, y~ : Int)
+  EndResize
+  NudgeBy(dw~ : Int, dh~ : Int)
+}
+
+///|
+fn Edge::resizes_width(self : Edge) -> Bool {
+  match self {
+    East | SouthEast => true
+    South => false
+  }
+}
+
+///|
+fn Edge::resizes_height(self : Edge) -> Bool {
+  match self {
+    South | SouthEast => true
+    East => false
+  }
+}

--- a/lib/resizable/src/resizable/update.mbt
+++ b/lib/resizable/src/resizable/update.mbt
@@ -1,0 +1,97 @@
+///|
+fn Constraints::is_valid(self : Constraints) -> Bool {
+  self.min_w >= 1 &&
+  self.min_w <= self.max_w &&
+  self.min_h >= 1 &&
+  self.min_h <= self.max_h
+}
+
+///|
+fn clamp_size(w : Int, h : Int, constraints : Constraints) -> (Int, Int) {
+  (
+    w.clamp(min=constraints.min_w, max=constraints.max_w),
+    h.clamp(min=constraints.min_h, max=constraints.max_h),
+  )
+}
+
+///|
+fn Model::with_clamped_size(self : Model, w : Int, h : Int) -> Model {
+  let (w, h) = clamp_size(w, h, self.constraints)
+  { ..self, w, h }
+}
+
+///|
+fn Model::apply_drag(self : Model, drag : Drag, x : Int, y : Int) -> Model {
+  let delta_x = x - drag.origin_x
+  let delta_y = y - drag.origin_y
+  let raw_w = if drag.edge.resizes_width() {
+    drag.base_w + delta_x
+  } else {
+    drag.base_w
+  }
+  let raw_h = if drag.edge.resizes_height() {
+    drag.base_h + delta_y
+  } else {
+    drag.base_h
+  }
+  self.with_clamped_size(raw_w, raw_h)
+}
+
+///|
+/// Create a resizable model.
+///
+/// Preconditions: `1 <= min_w <= max_w` and `1 <= min_h <= max_h` for
+/// `constraints`. The initial size is clamped into those bounds.
+pub fn Model::new(w~ : Int, h~ : Int, constraints~ : Constraints) -> Model {
+  guard constraints.is_valid() else {
+    abort("resizable constraints require 1 <= min <= max for width and height")
+  }
+  let (w, h) = clamp_size(w, h, constraints)
+  { w, h, constraints, drag: None }
+}
+
+///|
+pub fn Model::width(self : Model) -> Int {
+  self.w
+}
+
+///|
+pub fn Model::height(self : Model) -> Int {
+  self.h
+}
+
+///|
+pub fn Model::is_resizing(self : Model) -> Bool {
+  self.drag is Some(_)
+}
+
+///|
+/// Apply one resizable message to the model.
+///
+/// The update is pure and total. Mouse drags resize from the captured drag
+/// origin; keyboard nudges apply directly to the current clamped size.
+pub fn Model::update(self : Model, msg : Msg) -> Model {
+  match msg {
+    StartResize(edge~, x~, y~) => {
+      let drag = {
+        edge,
+        origin_x: x,
+        origin_y: y,
+        base_w: self.w,
+        base_h: self.h,
+      }
+      { ..self, drag: Some(drag) }
+    }
+    PointerMove(x~, y~) =>
+      match self.drag {
+        Some(drag) => self.apply_drag(drag, x, y)
+        None => self
+      }
+    EndResize =>
+      match self.drag {
+        Some(_) => { ..self, drag: None }
+        None => self
+      }
+    NudgeBy(dw~, dh~) => self.with_clamped_size(self.w + dw, self.h + dh)
+  }
+}

--- a/moon.work
+++ b/moon.work
@@ -4,6 +4,7 @@ members = [
   "./lib/zipper",
   "./lib/btree",
   "./lib/rabbita_codemirror",
+  "./lib/resizable",
   "./lib/dom-boundary",
   "./lib/visualizer",
   "./lib/semantic",
@@ -12,4 +13,5 @@ members = [
   "./examples/block-editor",
   "./examples/canvas",
   "./examples/codemirror_demo",
+  "./examples/resizable",
 ]


### PR DESCRIPTION
## Summary

- Add `dowdiness/rabbita-resizable`, a headless Rabbita resize-state module with opaque `Model`, pure clamp/update logic, ARIA/event attrs, and document-level mouseup cleanup.
- Add black-box tests for clamp invariants, drag behavior, and idempotent end-resize handling.
- Add `examples/resizable` Warren demo with a corner-resizable box and split-pane separator.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@sub.on_mouse_move` | `rabbita/rabbita/sub/sub.mbt` | Yes | Used for document-level drag movement. |
| `@sub.custom_sub` / `RunningSub.update_tagger` | `rabbita/rabbita/sub/sub.mbt`, `rabbita/rabbita/websocket/listen.mbt` | Yes | Used for the missing document-level `mouseup` subscription, following the suberror + tagger-rebind pattern. |
| `@html.Attrs::build` and event attrs | `rabbita/rabbita/html/README.mbt.md`, `rabbita/rabbita/html/attrs*.mbt` | Yes | Used to expose headless attrs instead of owning markup. |
| `@rabbita.cell` | `rabbita/doc/001_intro/readme.mbt.md`, `rabbita/doc/004_using_command/readme.mbt.md` | Yes | Used in the demo app; the package intentionally does not expose a view/Cell wrapper for v1. |

New helpers added:

- Public resizable API: `Model::new`, `Model::update`, size accessors, `Model::container_attrs`, `Model::handle_attrs`, `Model::subscriptions`, plus `Edge`, `Constraints`, and `Msg`. Responsibility: reusable headless resize state and Rabbita integration; no existing resizable package/API covers this.
- Private helpers: clamp/drag math, edge metadata, keyboard nudges, and the `DocumentMouseUp` custom subscription. Responsibility: keep public API minimal and isolate Rabbita escape hatches inside the binding module.

Rabbita docs/patterns consulted: `rabbita/doc/001_intro/readme.mbt.md`, `rabbita/doc/002_writing_html/readme.mbt.md`, `rabbita/doc/004_using_command/readme.mbt.md`, `rabbita/doc/using_subscriptions/readme.mbt.md`, `rabbita/doc/suberror_as_extensible_enum/readme.mbt.md`, `rabbita/rabbita/sub/design.md`, `rabbita/rabbita/sub/README.mbt.md`, and `rabbita/rabbita/websocket/listen.mbt`.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run for affected MoonBit targets (`NEW_MOON_MOD=0 moon build --target js`, `NEW_MOON_MOD=0 moon -C examples/resizable build --target js`)

## Validation

```bash
NEW_MOON_MOD=0 moon fmt --check lib/resizable/src/resizable examples/resizable/main
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon build --target js
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon test --release
NEW_MOON_MOD=0 moon -C examples/resizable build --target js
NEW_MOON_MOD=0 make check
NEW_MOON_MOD=0 make fmt-check
```

Manual browser check:

- Started Warren from `examples/resizable` (temporarily hiding the parent `moon.work` while Warren ran, to avoid Warren's existing workspace-discovery crash on the unrelated `lib/cognition/moon.mod` member).
- Verified corner-handle dragging changes width and height.
- Verified split-pane separator dragging changes the left pane width.
- Verified releasing outside the thin split handle ends resizing; subsequent mouse movement does not continue resizing.
- Verified Tab focus + Arrow keys: corner handle responds on both axes; split handle responds to Left/Right.
