### PR TITLE
fix(canvas): delete selected nodes from keyboard

### DIFF
--- a/examples/canvas/graph_model/graph_operation_test.mbt
+++ b/examples/canvas/graph_model/graph_operation_test.mbt
@@ -59,6 +59,21 @@ test "GraphOperation round-trips through JSON" {
 }
 
 ///|
+test "DeleteNodes serializes node ids" {
+  let operation = @graph_model.GraphOperation::GraphOperation(
+    @graph_model.WorkflowAction::DeleteNodes([node_id(1), node_id(2)]),
+  )
+  inspect(
+    operation.to_json().stringify(),
+    content="{\"version\":1,\"type\":\"DeleteNodes\",\"nodes\":[1,2]}",
+  )
+  let decoded : @graph_model.GraphOperation = @json.from_json(
+    operation.to_json(),
+  )
+  @debug.assert_eq(decoded, operation)
+}
+
+///|
 test "operation log round-trips and replays into canvas graph state" {
   let added = @graph_model.make_workflow_node(
     node_id(3),
@@ -83,17 +98,44 @@ test "operation log round-trips and replays into canvas graph state" {
         "in",
       ),
     ),
+    @graph_model.GraphOperation::GraphOperation(
+      @graph_model.WorkflowAction::DeleteNodes([node_id(2)]),
+    ),
   ]
   let decoded : Array[@graph_model.GraphOperation] = @json.from_json(
     operations.to_json(),
   )
   @debug.assert_eq(decoded, operations)
   let replayed = @graph_model.replay_operations(replay_base_state(), decoded)
-  assert_eq(replayed.nodes.length(), 3)
-  assert_eq(replayed.edges.length(), 1)
-  assert_eq(replayed.edges[0].source, node_id(1))
-  assert_eq(replayed.edges[0].target, node_id(2))
-  assert_eq(replayed.nodes[2].x, 800.0)
-  assert_eq(replayed.nodes[2].y, 140.0)
-  assert_eq(replayed.action_log.length(), 3)
+  assert_eq(replayed.nodes.length(), 2)
+  assert_eq(replayed.edges.length(), 0)
+  assert_eq(replayed.nodes[1].id, node_id(3))
+  assert_eq(replayed.nodes[1].x, 800.0)
+  assert_eq(replayed.nodes[1].y, 140.0)
+  assert_eq(replayed.action_log.length(), 4)
+}
+
+///|
+test "DeleteNodes removes incident edges and deleted selection" {
+  let selected = @graph_model.set_selection(replay_base_state(), [
+    node_id(1),
+    node_id(2),
+  ])
+  let connected = @graph_model.record_action(
+    selected,
+    @graph_model.WorkflowAction::ConnectPorts(
+      node_id(1),
+      "tick",
+      node_id(2),
+      "in",
+    ),
+  )
+  let deleted = @graph_model.record_action(
+    connected,
+    @graph_model.WorkflowAction::DeleteNodes([node_id(1)]),
+  )
+  assert_eq(deleted.nodes.length(), 1)
+  assert_eq(deleted.edges.length(), 0)
+  @debug.assert_eq(deleted.interaction.selected_nodes, [node_id(2)])
+  @debug.debug_inspect(deleted.interaction.selected, content="Some(NodeId(2))")
 }

--- a/examples/canvas/graph_model/model.mbt
+++ b/examples/canvas/graph_model/model.mbt
@@ -182,6 +182,7 @@ pub(all) enum WorkflowAction {
   AddNode(CanvasNode)
   MoveNodes(Array[NodePosition])
   ConnectPorts(NodeId, String, NodeId, String)
+  DeleteNodes(Array[NodeId])
   SelectNodes(Array[NodeId])
   SetViewport(Viewport)
 } derive(Debug, Eq, ToJson)
@@ -290,6 +291,10 @@ pub impl ToJson for GraphOperation with fn to_json(self) {
       fields["target"] = target.to_json()
       fields["target_port"] = target_port.to_json()
     }
+    DeleteNodes(nodes) => {
+      fields["type"] = "DeleteNodes".to_json()
+      fields["nodes"] = nodes.to_json()
+    }
     SelectNodes(nodes) => {
       fields["type"] = "SelectNodes".to_json()
       fields["nodes"] = nodes.to_json()
@@ -348,6 +353,12 @@ pub impl @json.FromJson for GraphOperation with fn from_json(json, path) {
         fields, path, "target_port", "ConnectPorts",
       )
       WorkflowAction::ConnectPorts(source, source_port, target, target_port)
+    }
+    "DeleteNodes" => {
+      let nodes : Array[NodeId] = @json.from_json(
+        require_json_field(fields, path, "nodes", "DeleteNodes"),
+      )
+      WorkflowAction::DeleteNodes(nodes)
     }
     "SelectNodes" => {
       let nodes : Array[NodeId] = @json.from_json(
@@ -728,6 +739,45 @@ fn append_edge(
 }
 
 ///|
+fn edge_incident_to_nodes(edge : Edge, nodes : Array[NodeId]) -> Bool {
+  node_id_in_array(nodes, edge.source) || node_id_in_array(nodes, edge.target)
+}
+
+///|
+fn delete_nodes_from_state(
+  state : CanvasState,
+  deleted : Array[NodeId],
+) -> CanvasState {
+  if deleted.length() == 0 {
+    return state
+  }
+  let nodes = state.nodes.filter(fn(node) {
+    !node_id_in_array(deleted, node.id)
+  })
+  let edges = state.edges.filter(fn(edge) {
+    !edge_incident_to_nodes(edge, deleted)
+  })
+  let selected_nodes = state.interaction.selected_nodes.filter(fn(node) {
+    !node_id_in_array(deleted, node)
+  })
+  let selected = if selected_nodes.length() == 0 {
+    None
+  } else {
+    Some(selected_nodes[0])
+  }
+  let interaction : InteractionState = {
+    dragging: None,
+    panning: None,
+    connecting: None,
+    selected,
+    selected_nodes,
+    pointer_down: false,
+    did_move: false,
+  }
+  { ..state, nodes, edges, interaction }
+}
+
+///|
 pub fn set_selection(state : CanvasState, nodes : Array[NodeId]) -> CanvasState {
   let selected = if nodes.length() == 0 { None } else { Some(nodes[0]) }
   let new_interaction : InteractionState = {
@@ -764,6 +814,7 @@ pub fn apply_action(
       } else {
         state
       }
+    DeleteNodes(nodes) => delete_nodes_from_state(state, nodes)
     SelectNodes(nodes) => set_selection(state, nodes)
     SetViewport(viewport) => { ..state, viewport, }
   }

--- a/examples/canvas/graph_model/pkg.generated.mbti
+++ b/examples/canvas/graph_model/pkg.generated.mbti
@@ -180,6 +180,7 @@ pub(all) enum WorkflowAction {
   AddNode(CanvasNode)
   MoveNodes(Array[NodePosition])
   ConnectPorts(NodeId, String, NodeId, String)
+  DeleteNodes(Array[NodeId])
   SelectNodes(Array[NodeId])
   SetViewport(Viewport)
 } derive(Eq, ToJson, @debug.Debug)

--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -74,6 +74,23 @@ pub fn add_node(
 }
 
 ///|
+fn decode_node_ids(json_text : String) -> Array[NodeId] {
+  let json = @json.parse(json_text) catch { _ => return [] }
+  @json.from_json(json) catch {
+    _ => []
+  }
+}
+
+///|
+pub fn delete_nodes(handle : Int, node_ids_json : String) -> Unit {
+  let node_ids = decode_node_ids(node_ids_json)
+  if node_ids.length() == 0 {
+    return
+  }
+  _registry[handle].delete_nodes(node_ids)
+}
+
+///|
 /// Serializable node snapshot. Uses plain Int for `id` to avoid
 /// the NodeId newtype wrapper appearing in JSON output.
 struct NodeJson {

--- a/examples/canvas/main/canvas_runtime.mbt
+++ b/examples/canvas/main/canvas_runtime.mbt
@@ -483,6 +483,14 @@ fn CanvasRuntime::add_node(
 }
 
 ///|
+fn CanvasRuntime::delete_nodes(
+  self : CanvasRuntime,
+  nodes : Array[NodeId],
+) -> Unit {
+  self.sync_commit_state(record_action(self.state_peek(), DeleteNodes(nodes)))
+}
+
+///|
 fn CanvasRuntime::render_state(self : CanvasRuntime) -> RenderStateJson {
   render_state_from_parts(
     self.render_watch.read_or_abort(),

--- a/examples/canvas/main/canvas_update_wbtest.mbt
+++ b/examples/canvas/main/canvas_update_wbtest.mbt
@@ -376,6 +376,20 @@ test "runtime live drag updates preview before one durable MoveNodes commit" {
 }
 
 ///|
+test "runtime delete_nodes removes selected nodes and incident edges" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.delete_nodes([NodeId(2)])
+  let state = runtime.render_state()
+  assert_eq(state.nodes.length(), 5)
+  assert_eq(state.edges.length(), 1)
+  assert_eq(runtime.actions.peek().length(), 1)
+  match runtime.actions.peek()[0].action() {
+    DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId(2)])
+    _ => fail("expected DeleteNodes action")
+  }
+}
+
+///|
 test "runtime sparse inspector follows hover until a node is selected" {
   let runtime = CanvasRuntime::CanvasRuntime()
   runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -329,11 +329,11 @@ fn source_graph_current_doc(
 fn lower_source_operation(
   doc : @graph_dsl.GraphDoc,
   operation : GraphOperation,
-) -> Result[@graph_dsl.LoweredGraphEdit, String] {
+) -> Result[SourceOperationEdit, String] {
   match operation.action() {
     AddNode(node) =>
       match doc.lower_insert_node_binding(node.title, node.subtitle) {
-        Some(edit) => Ok(edit)
+        Some(edit) => Ok(ExactLoweredEdit(edit))
         None =>
           Err(
             "cannot lower AddNode for binding '" +
@@ -360,10 +360,11 @@ fn lower_source_operation(
       }
       match
         doc.lower_add_connection(target_node.binding(), source_node.binding()) {
-        Some(edit) => Ok(edit)
+        Some(edit) => Ok(ExactLoweredEdit(edit))
         None => Err("cannot lower ConnectPorts into source")
       }
     }
+    DeleteNodes(nodes) => lower_delete_nodes(doc, nodes)
     MoveNodes(_) =>
       Err("MoveNodes is local layout state; source lowering is not defined")
     SelectNodes(_) =>
@@ -376,16 +377,25 @@ fn lower_source_operation(
 }
 
 ///|
-fn SourceBackedGraph::apply_lowered_edit(
+fn SourceBackedGraph::apply_source_edit(
   self : SourceBackedGraph,
-  edit : @graph_dsl.LoweredGraphEdit,
+  edit : SourceOperationEdit,
 ) -> Result[@graph_dsl.GraphDoc, String] {
   let old_source = self.source
-  let new_source = edit.new_source()
-  match edit.incremental_edit() {
-    Some(incremental_edit) =>
-      self.attachment.apply_edit(incremental_edit, new_source)
-    None => self.attachment.set_source(new_source)
+  let new_source = match edit {
+    ExactLoweredEdit(edit) => {
+      let new_source = edit.new_source()
+      match edit.incremental_edit() {
+        Some(incremental_edit) =>
+          self.attachment.apply_edit(incremental_edit, new_source)
+        None => self.attachment.set_source(new_source)
+      }
+      new_source
+    }
+    WholeSourceReplacement(new_source) => {
+      self.attachment.set_source(new_source)
+      new_source
+    }
   }
   self.source = new_source
   match self.attachment.current_result() {
@@ -419,6 +429,79 @@ fn SourceBackedGraph::append_operation(
   operation : GraphOperation,
 ) -> Unit {
   self.action_log.push(operation)
+}
+
+///|
+fn source_delete_surviving_selection_bindings(
+  doc : @graph_dsl.GraphDoc,
+  interaction : InteractionState,
+  deleted : Array[NodeId],
+) -> Array[String] {
+  let bindings : Array[String] = []
+  for node_id in interaction.selected_nodes {
+    if !@graph_model.node_id_in_array(deleted, node_id) {
+      match graph_node_for_canvas_id(doc, node_id) {
+        Some(node) => append_unique_string(bindings, node.binding())
+        None => ()
+      }
+    }
+  }
+  bindings
+}
+
+///|
+fn source_selection_from_bindings(
+  doc : @graph_dsl.GraphDoc,
+  bindings : Array[String],
+) -> Array[NodeId] {
+  let nodes : Array[NodeId] = []
+  for binding in bindings {
+    match canvas_id_for_binding(doc, binding) {
+      Some(id) => nodes.push(id)
+      None => ()
+    }
+  }
+  nodes
+}
+
+///|
+fn SourceBackedGraph::remap_deleted_interaction(
+  self : SourceBackedGraph,
+  doc : @graph_dsl.GraphDoc,
+  survivor_bindings : Array[String],
+) -> Unit {
+  let selected_nodes = source_selection_from_bindings(doc, survivor_bindings)
+  let selected = if selected_nodes.length() == 0 {
+    None
+  } else {
+    Some(selected_nodes[0])
+  }
+  self.drag_preview = idle_drag_preview()
+  self.interaction = {
+    dragging: None,
+    panning: None,
+    connecting: None,
+    selected,
+    selected_nodes,
+    pointer_down: false,
+    did_move: false,
+  }
+}
+
+///|
+fn SourceBackedGraph::sync_local_operation_state(
+  self : SourceBackedGraph,
+  doc : @graph_dsl.GraphDoc,
+  operation : GraphOperation,
+  survivor_selection_bindings : Array[String],
+) -> Unit {
+  match operation.action() {
+    DeleteNodes(_) => {
+      self.remap_deleted_interaction(doc, survivor_selection_bindings)
+      self.sync_layout_from_state(source_graph_base_canvas_state(self))
+    }
+    _ => ()
+  }
 }
 
 ///|
@@ -815,13 +898,25 @@ pub fn apply_source_graph_operation(
     Err(message) =>
       return source_graph_result_for_graph(graph, false, Some(message))
   }
+  let survivor_selection_bindings = match operation.action() {
+    DeleteNodes(deleted) =>
+      source_delete_surviving_selection_bindings(
+        doc,
+        graph.interaction,
+        deleted,
+      )
+    _ => []
+  }
   let lowered = match lower_source_operation(doc, operation) {
     Ok(edit) => edit
     Err(message) =>
       return source_graph_result_for_graph(graph, false, Some(message))
   }
-  match graph.apply_lowered_edit(lowered) {
+  match graph.apply_source_edit(lowered) {
     Ok(doc) => {
+      graph.sync_local_operation_state(
+        doc, operation, survivor_selection_bindings,
+      )
       graph.append_operation(realized_source_operation(doc, operation))
       source_graph_result_for_graph(graph, true, None)
     }

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -57,6 +57,40 @@ fn operation_result_applied(json_text : String) -> Bool {
 }
 
 ///|
+fn operation_result_message(json_text : String) -> String? {
+  let json = @json.parse(json_text) catch {
+    _ => abort("expected operation result JSON")
+  }
+  match json {
+    Json::Object(fields) =>
+      match fields.get("message") {
+        Some(Json::String(message)) => Some(message)
+        None => None
+        _ => abort("expected operation result message string")
+      }
+    _ => abort("expected operation result object")
+  }
+}
+
+///|
+fn render_selected_nodes(json_text : String) -> Array[Int] {
+  let json = @json.parse(json_text) catch {
+    _ => abort("expected render state JSON")
+  }
+  match json {
+    Json::Object(fields) =>
+      match fields.get("selected_nodes") {
+        Some(value) =>
+          @json.from_json(value) catch {
+            _ => abort("expected selected_nodes array")
+          }
+        None => abort("expected selected_nodes field")
+      }
+    _ => abort("expected render state object")
+  }
+}
+
+///|
 fn ok_operation_log(json_text : String) -> Array[GraphOperation] {
   let json = @json.parse(json_text) catch {
     _ => abort("expected operation log JSON")
@@ -232,6 +266,120 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
       }
     _ => abort("expected two source-backed operations")
   }
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed DeleteNodes removes a safe binding line" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()"
+  let handle = create_source_graph(source)
+  let delete = GraphOperation(DeleteNodes([NodeId(2)]))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, delete.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nreverb = plate()",
+  )
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  match operations {
+    [deleted] =>
+      match deleted.action() {
+        DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId(2)])
+        _ => abort("expected DeleteNodes action")
+      }
+    _ => abort("expected one source-backed delete operation")
+  }
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed DeleteNodes rejects survivor references" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)"
+  let handle = create_source_graph(source)
+  let delete = GraphOperation(DeleteNodes([NodeId(1)]))
+  let result = apply_source_graph_operation(
+    handle,
+    delete.to_json().stringify(),
+  )
+  inspect(operation_result_applied(result), content="false")
+  match operation_result_message(result) {
+    Some(message) =>
+      inspect(message.contains("still references"), content="true")
+    None => abort("expected DeleteNodes rejection message")
+  }
+  inspect(get_source_graph_source(handle), content=source)
+  inspect(get_source_graph_action_log(handle), content="[]")
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed DeleteNodes allows deleting a referenced subgraph together" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)"
+  let handle = create_source_graph(source)
+  let delete = GraphOperation(DeleteNodes([NodeId(1), NodeId(2)]))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, delete.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(get_source_graph_source(handle), content="")
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed DeleteNodes clears transient selection after rewrite" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 2, 0.0, 0.0)
+  source_graph_pointer_up(handle, 2, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [2],
+  )
+  let delete = GraphOperation(DeleteNodes([NodeId(2)]))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, delete.to_json().stringify()),
+    ),
+    content="true",
+  )
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed DeleteNodes remaps selected survivor by binding" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 3, 0.0, 0.0)
+  source_graph_pointer_up(handle, 3, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [3],
+  )
+  let delete = GraphOperation(DeleteNodes([NodeId(2)]))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, delete.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nreverb = plate()",
+  )
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [2],
+  )
   destroy_source_graph(handle)
 }
 

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -24,6 +24,7 @@ options(
         "hover_node",
         "zoom",
         "add_node",
+        "delete_nodes",
         "get_render_state",
         "get_action_log",
         "create_source_graph",

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn create_canvas() -> Int
 
 pub fn create_source_graph(String) -> Int
 
+pub fn delete_nodes(Int, String) -> Unit
+
 pub fn destroy_source_graph(Int) -> Unit
 
 pub fn get_action_log(Int) -> String

--- a/examples/canvas/main/source_delete_lowering.mbt
+++ b/examples/canvas/main/source_delete_lowering.mbt
@@ -1,0 +1,238 @@
+///|
+priv enum SourceOperationEdit {
+  ExactLoweredEdit(@graph_dsl.LoweredGraphEdit)
+  WholeSourceReplacement(String)
+}
+
+///|
+priv struct SourceDeletionSpan {
+  start : Int
+  end : Int
+}
+
+///|
+fn string_in_array(items : Array[String], target : String) -> Bool {
+  for item in items {
+    if item == target {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn append_unique_string(items : Array[String], item : String) -> Unit {
+  if !string_in_array(items, item) {
+    items.push(item)
+  }
+}
+
+///|
+fn deleted_bindings_for_canvas_ids(
+  doc : @graph_dsl.GraphDoc,
+  node_ids : Array[NodeId],
+) -> Result[Array[String], String] {
+  let bindings : Array[String] = []
+  for id in node_ids {
+    match graph_node_for_canvas_id(doc, id) {
+      Some(node) => append_unique_string(bindings, node.binding())
+      None =>
+        return Err(
+          "cannot lower DeleteNodes: missing node " + id.to_int().to_string(),
+        )
+    }
+  }
+  if bindings.length() == 0 {
+    Err("cannot lower DeleteNodes: no nodes selected")
+  } else {
+    Ok(bindings)
+  }
+}
+
+///|
+fn survivor_reference_to_deleted_binding(
+  doc : @graph_dsl.GraphDoc,
+  deleted_bindings : Array[String],
+) -> (String, String)? {
+  for node in doc.nodes() {
+    if !string_in_array(deleted_bindings, node.binding()) {
+      for param in node.params() {
+        match graph_input_reference(param) {
+          Some(binding) if string_in_array(deleted_bindings, binding) =>
+            return Some((node.binding(), binding))
+          _ => ()
+        }
+      }
+    }
+  }
+  None
+}
+
+///|
+fn source_line_delete_end(source : String, end : Int) -> Int {
+  if end >= source.length() {
+    end
+  } else if source[end] == '\r' {
+    if end + 1 < source.length() && source[end + 1] == '\n' {
+      end + 2
+    } else {
+      end + 1
+    }
+  } else if source[end] == '\n' {
+    end + 1
+  } else {
+    end
+  }
+}
+
+///|
+fn previous_line_break_start(source : String, start : Int) -> Int {
+  if start >= 2 && source[start - 2] == '\r' && source[start - 1] == '\n' {
+    start - 2
+  } else if start >= 1 &&
+    (source[start - 1] == '\n' || source[start - 1] == '\r') {
+    start - 1
+  } else {
+    start
+  }
+}
+
+///|
+fn deletion_span_for_graph_node(
+  source : String,
+  node : @graph_dsl.GraphNode,
+) -> SourceDeletionSpan {
+  { start: node.start(), end: source_line_delete_end(source, node.end()) }
+}
+
+///|
+fn compare_deletion_span_start(
+  a : SourceDeletionSpan,
+  b : SourceDeletionSpan,
+) -> Int {
+  if a.start < b.start {
+    -1
+  } else if a.start > b.start {
+    1
+  } else if a.end < b.end {
+    -1
+  } else if a.end > b.end {
+    1
+  } else {
+    0
+  }
+}
+
+///|
+fn compare_deletion_span_start_desc(
+  a : SourceDeletionSpan,
+  b : SourceDeletionSpan,
+) -> Int {
+  0 - compare_deletion_span_start(a, b)
+}
+
+///|
+fn merged_deletion_spans(
+  source : String,
+  spans : Array[SourceDeletionSpan],
+) -> Array[SourceDeletionSpan] {
+  let ordered = spans.copy()
+  ordered.sort_by(compare_deletion_span_start)
+  let merged : Array[SourceDeletionSpan] = []
+  for span in ordered {
+    if merged.length() == 0 {
+      merged.push(span)
+    } else {
+      let last_index = merged.length() - 1
+      let last = merged[last_index]
+      if span.start <= last.end {
+        if span.end > last.end {
+          merged[last_index] = { ..last, end: span.end }
+        }
+      } else {
+        merged.push(span)
+      }
+    }
+  }
+  let adjusted : Array[SourceDeletionSpan] = []
+  for span in merged {
+    let start = if span.end == source.length() {
+      previous_line_break_start(source, span.start)
+    } else {
+      span.start
+    }
+    adjusted.push({ ..span, start, })
+  }
+  adjusted
+}
+
+///|
+fn apply_deletion_spans(
+  source : String,
+  spans : Array[SourceDeletionSpan],
+) -> String? {
+  let ordered = spans.copy()
+  ordered.sort_by(compare_deletion_span_start_desc)
+  let source_len = source.length()
+  let mut next_start = source_len
+  let mut result = source
+  for span in ordered {
+    if span.start < 0 ||
+      span.end < span.start ||
+      span.end > source_len ||
+      span.end > next_start {
+      return None
+    }
+    result = result[:span.start].to_owned() + result[span.end:].to_owned()
+    next_start = span.start
+  }
+  Some(result)
+}
+
+///|
+fn lower_delete_node_bindings(
+  doc : @graph_dsl.GraphDoc,
+  bindings : Array[String],
+) -> Result[String, String] {
+  match survivor_reference_to_deleted_binding(doc, bindings) {
+    Some((survivor, deleted)) =>
+      return Err(
+        "cannot lower DeleteNodes: survivor '" +
+        survivor +
+        "' still references deleted binding '" +
+        deleted +
+        "'",
+      )
+    None => ()
+  }
+  let source = doc.source()
+  let spans : Array[SourceDeletionSpan] = []
+  for binding in bindings {
+    match doc.find_node(binding) {
+      Some(node) => spans.push(deletion_span_for_graph_node(source, node))
+      None =>
+        return Err(
+          "cannot lower DeleteNodes: missing binding '" + binding + "'",
+        )
+    }
+  }
+  match apply_deletion_spans(source, merged_deletion_spans(source, spans)) {
+    Some(new_source) => Ok(new_source)
+    None => Err("cannot lower DeleteNodes into source")
+  }
+}
+
+///|
+fn lower_delete_nodes(
+  doc : @graph_dsl.GraphDoc,
+  node_ids : Array[NodeId],
+) -> Result[SourceOperationEdit, String] {
+  let bindings = match deleted_bindings_for_canvas_ids(doc, node_ids) {
+    Ok(bindings) => bindings
+    Err(message) => return Err(message)
+  }
+  match lower_delete_node_bindings(doc, bindings) {
+    Ok(new_source) => Ok(WholeSourceReplacement(new_source))
+    Err(message) => Err(message)
+  }
+}

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -129,6 +129,51 @@ test('canvas handles create edges and reject invalid gestures', async ({ page })
   expect(runtimeErrors).toEqual([]);
 });
 
+test('selected canvas nodes delete with incident edges from the keyboard', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(edgePaths(page)).toHaveCount(3);
+
+  const node = page.locator('.canvas-node[data-node-id="2"]');
+  await node.click();
+  await expect(node).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+
+  await page.keyboard.press('Delete');
+  await expect(page.locator('.canvas-node')).toHaveCount(5);
+  await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveCount(0);
+  await expect(edgePaths(page)).toHaveCount(1);
+  await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('keyboard deletion ignores text-input focus', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await page.locator('.canvas-node[data-node-id="2"]').click();
+  await page.locator('#node-search').focus();
+  await page.keyboard.press('Backspace');
+
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(edgePaths(page)).toHaveCount(3);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
 test('input handles preview compatibility during a connection drag', async ({ page }) => {
   const runtimeErrors: string[] = [];
   page.on('pageerror', (error) => runtimeErrors.push(error.message));

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -94,6 +94,61 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   expect(runtimeErrors).toEqual([]);
 });
 
+test('source-backed selected node deletion lowers into canonical source', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+
+  const meter = page.locator('.canvas-node[data-node-id="2"]');
+  await meter.click();
+  await expect(meter).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await page.keyboard.press('Delete');
+
+  await expect(page.locator('#source-editor')).toHaveValue('osc = sine(freq: 440Hz)');
+  await expect(page.locator('.canvas-node')).toHaveCount(1);
+  await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveCount(0);
+  await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed deletion rejects unsafe survivor references', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await page.locator('#source-connect').click();
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
+  );
+
+  const osc = page.locator('.canvas-node[data-node-id="1"]');
+  await osc.click();
+  await expect(osc).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await page.keyboard.press('Delete');
+
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
+  );
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+  await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'error');
+  await expect(page.locator('#source-status')).toContainText('Source delete rejected:');
+  await expect(page.locator('#source-status')).toContainText('still references deleted binding');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed deletion ignores source editor focus', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await page.locator('.canvas-node[data-node-id="2"]').click();
+  await page.locator('#source-editor').focus();
+  await page.keyboard.press('Backspace');
+
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
 for (const invalidSource of INVALID_SOURCE_CASES) {
   test(`source-backed apply reports ${invalidSource.name} source as invalid`, async ({ page }) => {
     const runtimeErrors = collectRuntimeErrors(page);

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -18,6 +18,7 @@ export type CanvasModule = {
   hover_node: (h: number, nodeId: number) => void;
   zoom: (h: number, delta: number, cx: number, cy: number) => void;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
+  delete_nodes: (h: number, nodeIdsJson: string) => void;
   get_render_state: (h: number) => string;
   get_action_log: (h: number) => string;
   create_source_graph?: (source: string) => number;
@@ -156,6 +157,7 @@ export type GraphOperation =
       target: number;
       target_port: string;
     }
+  | { version: number; type: 'DeleteNodes'; nodes: number[] }
   | { version: number; type: 'SelectNodes'; nodes: number[] }
   | { version: number; type: 'SetViewport'; viewport: ViewportData };
 
@@ -314,6 +316,23 @@ export class GraphAdapter {
       target: targetNodeId,
       target_port: targetPortId,
     });
+  }
+
+  deleteNodes(nodeIds: number[]): SourceGraphOperationResult | null {
+    this.assertLive();
+    const uniqueNodeIds = [...new Set(nodeIds)].filter((id) => Number.isFinite(id));
+    if (uniqueNodeIds.length === 0) return null;
+    const operation: GraphOperation = {
+      version: 1,
+      type: 'DeleteNodes',
+      nodes: uniqueNodeIds,
+    };
+    if (this.isSourceBacked) {
+      return this.applyOperation(operation);
+    }
+    this.mb.delete_nodes(this.handle, JSON.stringify(uniqueNodeIds));
+    this.emitLatestOperations();
+    return null;
   }
 
   pointerDown(nodeId: number, sx: number, sy: number): void {

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -6,6 +6,7 @@ import {
   type NodeData,
   type PortDef,
   type RenderState,
+  type SourceGraphOperationResult,
   type Tagged,
 } from './graph-adapter';
 
@@ -461,6 +462,55 @@ function cancelSourceConnection(e: PointerEvent): void {
   scheduleRender();
 }
 
+function editableKeyboardTarget(target: EventTarget | null): boolean {
+  const element = target instanceof HTMLElement ? target : null;
+  if (!element) return false;
+  if (element.isContentEditable) return true;
+  const editable = element.closest('input, textarea, select, [contenteditable="true"]');
+  return editable != null;
+}
+
+function sourceOperationDetail(result: SourceGraphOperationResult): string {
+  return result.message ?? (result.diagnostics.length > 0 ? result.diagnostics.join('; ') : 'operation was rejected');
+}
+
+function updateSourceOperationStatus(
+  result: SourceGraphOperationResult,
+  successMessage: string,
+  failurePrefix: string,
+): void {
+  const status = document.getElementById('source-status');
+  if (!status) return;
+  status.setAttribute('data-tone', result.applied ? 'success' : 'error');
+  status.textContent = result.applied
+    ? successMessage
+    : `${failurePrefix}: ${sourceOperationDetail(result)}`;
+}
+
+function syncSourceEditorFromResult(result: SourceGraphOperationResult): void {
+  if (!result.applied) return;
+  const editor = document.getElementById('source-editor') as HTMLTextAreaElement | null;
+  if (editor) editor.value = result.source;
+}
+
+function deleteSelectedNodes(): boolean {
+  const state = lastState ?? adapter.renderState();
+  const selectedNodes = state.selected_nodes ?? [];
+  if (selectedNodes.length === 0) return false;
+  const result = adapter.deleteNodes(selectedNodes);
+  if (result) {
+    syncSourceEditorFromResult(result);
+    updateSourceOperationStatus(
+      result,
+      'Deleted selected nodes through graph-dsl source.',
+      'Source delete rejected',
+    );
+  }
+  hideContextMenu();
+  scheduleRender();
+  return true;
+}
+
 function hideContextMenu(): void {
   contextMenu.hidden = true;
 }
@@ -666,6 +716,16 @@ root.addEventListener('contextmenu', (e: MouseEvent) => {
 
 document.addEventListener('keydown', (e: KeyboardEvent) => {
   if (e.key === 'Escape') hideContextMenu();
+  if (
+    (e.key === 'Delete' || e.key === 'Backspace') &&
+    !e.metaKey &&
+    !e.ctrlKey &&
+    !e.altKey &&
+    !editableKeyboardTarget(e.target)
+  ) {
+    if (deleteSelectedNodes()) e.preventDefault();
+    return;
+  }
   if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'l') {
     e.preventDefault();
     console.table(adapter.actionLog());


### PR DESCRIPTION
Fixes #480.

## Summary
- Add a `DeleteNodes` graph operation that removes selected nodes, incident edges, and deleted IDs from selection state.
- Expose the canvas JS FFI/TypeScript adapter path and wire Delete/Backspace keyboard handling while ignoring editable targets.
- Lower source-backed deletes by removing safe binding lines, rejecting survivor references, and keeping local source-backed selection/layout state consistent.
- Add MoonBit and Playwright coverage for canvas-backed and source-backed deletion flows.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@graph_model.node_id_in_array` | `examples/canvas/graph_model/model.mbt` | Yes | Used for delete/selection membership checks. |
| `GraphOperation` JSON/apply/replay path | `examples/canvas/graph_model/model.mbt` | Yes | Added `DeleteNodes` to the existing operation envelope instead of adding a parallel action channel. |
| `GraphDoc::find_node`, `GraphDoc::nodes`, `GraphNode::start/end` | `loom/examples/graph-dsl/src/graph_doc.mbt` | Yes | Used as the source-map basis for source-backed deletion. |
| `GraphAttachment::set_source` and existing source-backed operation result plumbing | `loom/examples/graph-dsl/src/attachment.mbt`, `examples/canvas/main/graph_dsl_adapter.mbt` | Yes | Reused for multi-line deletion rewrites and diagnostics. |

New helpers added:
- Source deletion span helpers in `examples/canvas/main/source_delete_lowering.mbt`: needed because graph-dsl exposes insert/connect/rename/numeric lowerers, but not binding-line deletion.
- `GraphAdapter.deleteNodes` / JS `delete_nodes`: bridges the existing operation model to keyboard-driven canvas deletion.

## Test plan
- [x] `cd examples/canvas && MOON_WORK=off moon check --target js`
- [x] `cd examples/canvas && MOON_WORK=off moon test --target js`
- [x] `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon fmt && NEW_MOON_MOD=0 MOON_WORK=off moon info`
- [x] `git diff *.mbti` reviewed for intended API surface changes
- [x] `cd examples/canvas/web && npm run build`
- [x] `cd examples/canvas/web && npm run test:e2e`

## Validation
```bash
cd examples/canvas && MOON_WORK=off moon check --target js
cd examples/canvas && MOON_WORK=off moon test --target js
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon fmt && NEW_MOON_MOD=0 MOON_WORK=off moon info
cd examples/canvas/web && npm run build
cd examples/canvas/web && npm run test:e2e
```
