### PR TITLE
feat(canvas): support direct edge deletion

### DIFF
--- a/examples/canvas/graph_model/graph_operation_test.mbt
+++ b/examples/canvas/graph_model/graph_operation_test.mbt
@@ -74,6 +74,26 @@ test "DeleteNodes serializes node ids" {
 }
 
 ///|
+test "DisconnectPorts serializes endpoint ports" {
+  let operation = @graph_model.GraphOperation::GraphOperation(
+    @graph_model.WorkflowAction::DisconnectPorts(
+      node_id(1),
+      "tick",
+      node_id(2),
+      "in",
+    ),
+  )
+  inspect(
+    operation.to_json().stringify(),
+    content="{\"version\":1,\"type\":\"DisconnectPorts\",\"source\":1,\"source_port\":\"tick\",\"target\":2,\"target_port\":\"in\"}",
+  )
+  let decoded : @graph_model.GraphOperation = @json.from_json(
+    operation.to_json(),
+  )
+  @debug.assert_eq(decoded, operation)
+}
+
+///|
 test "operation log round-trips and replays into canvas graph state" {
   let added = @graph_model.make_workflow_node(
     node_id(3),
@@ -138,4 +158,45 @@ test "DeleteNodes removes incident edges and deleted selection" {
   assert_eq(deleted.edges.length(), 0)
   @debug.assert_eq(deleted.interaction.selected_nodes, [node_id(2)])
   @debug.debug_inspect(deleted.interaction.selected, content="Some(NodeId(2))")
+}
+
+///|
+test "DisconnectPorts removes only the matching edge" {
+  let connected_once = @graph_model.record_action(
+    replay_base_state(),
+    @graph_model.WorkflowAction::ConnectPorts(
+      node_id(1),
+      "tick",
+      node_id(2),
+      "in",
+    ),
+  )
+  let with_unrelated : @graph_model.CanvasState = {
+    ..connected_once,
+    edges: [
+      ..connected_once.edges,
+      {
+        id: @graph_model.EdgeId::from_int(2),
+        source: node_id(2),
+        source_port: "json",
+        target: node_id(1),
+        target_port: "tick",
+      },
+    ],
+    next_edge_id: 3,
+  }
+  let disconnected = @graph_model.record_action(
+    with_unrelated,
+    @graph_model.WorkflowAction::DisconnectPorts(
+      node_id(1),
+      "tick",
+      node_id(2),
+      "in",
+    ),
+  )
+  assert_eq(disconnected.nodes.length(), 2)
+  assert_eq(disconnected.edges.length(), 1)
+  @debug.assert_eq(disconnected.edges[0].source, node_id(2))
+  @debug.assert_eq(disconnected.edges[0].target, node_id(1))
+  assert_eq(disconnected.action_log.length(), 2)
 }

--- a/examples/canvas/graph_model/model.mbt
+++ b/examples/canvas/graph_model/model.mbt
@@ -182,6 +182,7 @@ pub(all) enum WorkflowAction {
   AddNode(CanvasNode)
   MoveNodes(Array[NodePosition])
   ConnectPorts(NodeId, String, NodeId, String)
+  DisconnectPorts(NodeId, String, NodeId, String)
   DeleteNodes(Array[NodeId])
   SelectNodes(Array[NodeId])
   SetViewport(Viewport)
@@ -291,6 +292,13 @@ pub impl ToJson for GraphOperation with fn to_json(self) {
       fields["target"] = target.to_json()
       fields["target_port"] = target_port.to_json()
     }
+    DisconnectPorts(source, source_port, target, target_port) => {
+      fields["type"] = "DisconnectPorts".to_json()
+      fields["source"] = source.to_json()
+      fields["source_port"] = source_port.to_json()
+      fields["target"] = target.to_json()
+      fields["target_port"] = target_port.to_json()
+    }
     DeleteNodes(nodes) => {
       fields["type"] = "DeleteNodes".to_json()
       fields["nodes"] = nodes.to_json()
@@ -353,6 +361,21 @@ pub impl @json.FromJson for GraphOperation with fn from_json(json, path) {
         fields, path, "target_port", "ConnectPorts",
       )
       WorkflowAction::ConnectPorts(source, source_port, target, target_port)
+    }
+    "DisconnectPorts" => {
+      let source = NodeId(
+        json_number_field(fields, path, "source", "DisconnectPorts"),
+      )
+      let source_port = json_string_field(
+        fields, path, "source_port", "DisconnectPorts",
+      )
+      let target = NodeId(
+        json_number_field(fields, path, "target", "DisconnectPorts"),
+      )
+      let target_port = json_string_field(
+        fields, path, "target_port", "DisconnectPorts",
+      )
+      WorkflowAction::DisconnectPorts(source, source_port, target, target_port)
     }
     "DeleteNodes" => {
       let nodes : Array[NodeId] = @json.from_json(
@@ -744,6 +767,34 @@ fn edge_incident_to_nodes(edge : Edge, nodes : Array[NodeId]) -> Bool {
 }
 
 ///|
+fn edge_matches_ports(
+  edge : Edge,
+  source : NodeId,
+  source_port : String,
+  target : NodeId,
+  target_port : String,
+) -> Bool {
+  edge.source == source &&
+  edge.source_port == source_port &&
+  edge.target == target &&
+  edge.target_port == target_port
+}
+
+///|
+fn disconnect_ports_from_state(
+  state : CanvasState,
+  source : NodeId,
+  source_port : String,
+  target : NodeId,
+  target_port : String,
+) -> CanvasState {
+  let edges = state.edges.filter(fn(edge) {
+    !edge_matches_ports(edge, source, source_port, target, target_port)
+  })
+  { ..state, edges, }
+}
+
+///|
 fn delete_nodes_from_state(
   state : CanvasState,
   deleted : Array[NodeId],
@@ -814,6 +865,10 @@ pub fn apply_action(
       } else {
         state
       }
+    DisconnectPorts(source, source_port, target, target_port) =>
+      disconnect_ports_from_state(
+        state, source, source_port, target, target_port,
+      )
     DeleteNodes(nodes) => delete_nodes_from_state(state, nodes)
     SelectNodes(nodes) => set_selection(state, nodes)
     SetViewport(viewport) => { ..state, viewport, }

--- a/examples/canvas/graph_model/pkg.generated.mbti
+++ b/examples/canvas/graph_model/pkg.generated.mbti
@@ -180,6 +180,7 @@ pub(all) enum WorkflowAction {
   AddNode(CanvasNode)
   MoveNodes(Array[NodePosition])
   ConnectPorts(NodeId, String, NodeId, String)
+  DisconnectPorts(NodeId, String, NodeId, String)
   DeleteNodes(Array[NodeId])
   SelectNodes(Array[NodeId])
   SetViewport(Viewport)

--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -91,6 +91,22 @@ pub fn delete_nodes(handle : Int, node_ids_json : String) -> Unit {
 }
 
 ///|
+pub fn disconnect_ports(
+  handle : Int,
+  source : Int,
+  source_port : String,
+  target : Int,
+  target_port : String,
+) -> Unit {
+  _registry[handle].disconnect_ports(
+    NodeId(source),
+    source_port,
+    NodeId(target),
+    target_port,
+  )
+}
+
+///|
 /// Serializable node snapshot. Uses plain Int for `id` to avoid
 /// the NodeId newtype wrapper appearing in JSON output.
 struct NodeJson {

--- a/examples/canvas/main/canvas_runtime.mbt
+++ b/examples/canvas/main/canvas_runtime.mbt
@@ -491,6 +491,22 @@ fn CanvasRuntime::delete_nodes(
 }
 
 ///|
+fn CanvasRuntime::disconnect_ports(
+  self : CanvasRuntime,
+  source : NodeId,
+  source_port : String,
+  target : NodeId,
+  target_port : String,
+) -> Unit {
+  self.sync_document_action_state(
+    record_action(
+      self.state_peek(),
+      DisconnectPorts(source, source_port, target, target_port),
+    ),
+  )
+}
+
+///|
 fn CanvasRuntime::render_state(self : CanvasRuntime) -> RenderStateJson {
   render_state_from_parts(
     self.render_watch.read_or_abort(),

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -365,6 +365,8 @@ fn lower_source_operation(
       }
     }
     DeleteNodes(nodes) => lower_delete_nodes(doc, nodes)
+    DisconnectPorts(source, source_port, target, target_port) =>
+      lower_disconnect_ports(doc, source, source_port, target, target_port)
     MoveNodes(_) =>
       Err("MoveNodes is local layout state; source lowering is not defined")
     SelectNodes(_) =>

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -384,6 +384,60 @@ test "source-backed DeleteNodes remaps selected survivor by binding" {
 }
 
 ///|
+test "source-backed DisconnectPorts removes only the target input reference" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc, gain: 2)\ntap = scope(input: osc)"
+  let handle = create_source_graph(source)
+  let disconnect = GraphOperation(
+    DisconnectPorts(NodeId(1), "out", NodeId(2), "input"),
+  )
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, disconnect.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nmeter = scope(gain: 2)\ntap = scope(input: osc)",
+  )
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  match operations {
+    [disconnected] =>
+      match disconnected.action() {
+        DisconnectPorts(source, source_port, target, target_port) => {
+          @debug.assert_eq(source, NodeId(1))
+          inspect(source_port, content="out")
+          @debug.assert_eq(target, NodeId(2))
+          inspect(target_port, content="input")
+        }
+        _ => abort("expected DisconnectPorts action")
+      }
+    _ => abort("expected one source-backed disconnect operation")
+  }
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed DisconnectPorts removes a trailing input reference" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(gain: 2, input: osc)"
+  let handle = create_source_graph(source)
+  let disconnect = GraphOperation(
+    DisconnectPorts(NodeId(1), "out", NodeId(2), "input"),
+  )
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, disconnect.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nmeter = scope(gain: 2)",
+  )
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed unique insert chooses a fresh graph-dsl binding" {
   let handle = create_source_graph("reverb = plate()")
   inspect(

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -25,6 +25,7 @@ options(
         "zoom",
         "add_node",
         "delete_nodes",
+        "disconnect_ports",
         "get_render_state",
         "get_action_log",
         "create_source_graph",

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -20,6 +20,8 @@ pub fn delete_nodes(Int, String) -> Unit
 
 pub fn destroy_source_graph(Int) -> Unit
 
+pub fn disconnect_ports(Int, Int, String, Int, String) -> Unit
+
 pub fn get_action_log(Int) -> String
 
 pub fn get_render_state(Int) -> String

--- a/examples/canvas/main/source_disconnect_lowering.mbt
+++ b/examples/canvas/main/source_disconnect_lowering.mbt
@@ -1,0 +1,140 @@
+///|
+fn horizontal_space(code_unit : UInt16) -> Bool {
+  code_unit == ' ' || code_unit == '\t'
+}
+
+///|
+fn param_start_after_lparen_space(source : String, start : Int) -> Int {
+  let mut cursor = start
+  while cursor > 0 && horizontal_space(source[cursor - 1]) {
+    cursor -= 1
+  }
+  if cursor > 0 && source[cursor - 1] == '(' {
+    cursor
+  } else {
+    start
+  }
+}
+
+///|
+fn param_end_before_rparen_space(source : String, end : Int) -> Int {
+  let mut cursor = end
+  while cursor < source.length() && horizontal_space(source[cursor]) {
+    cursor += 1
+  }
+  if cursor < source.length() && source[cursor] == ')' {
+    cursor
+  } else {
+    end
+  }
+}
+
+///|
+fn graph_param_text_end(param : @graph_dsl.GraphParam) -> Int? {
+  let value_tokens = param.value_tokens()
+  if value_tokens.length() == 0 {
+    return None
+  }
+  let mut end = param.name_token().end()
+  for token in value_tokens {
+    if token.end() > end {
+      end = token.end()
+    }
+  }
+  Some(end)
+}
+
+///|
+fn graph_param_matches_edge(
+  param : @graph_dsl.GraphParam,
+  target_port : String,
+  source_binding : String,
+) -> Bool {
+  param.name() == target_port &&
+  graph_input_reference(param) == Some(source_binding)
+}
+
+///|
+fn disconnect_param_index(
+  params : Array[@graph_dsl.GraphParam],
+  target_port : String,
+  source_binding : String,
+) -> Int? {
+  for index, param in params {
+    if graph_param_matches_edge(param, target_port, source_binding) {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+fn removal_span_for_graph_param(
+  source : String,
+  params : Array[@graph_dsl.GraphParam],
+  index : Int,
+) -> SourceDeletionSpan? {
+  if index < 0 || index >= params.length() {
+    return None
+  }
+  let param = params[index]
+  let start = if index == 0 {
+    param_start_after_lparen_space(source, param.name_token().start())
+  } else {
+    param.name_token().start()
+  }
+  let end = match graph_param_text_end(param) {
+    Some(end) =>
+      if index + 1 < params.length() {
+        end
+      } else {
+        param_end_before_rparen_space(source, end)
+      }
+    None => return None
+  }
+  if index + 1 < params.length() {
+    Some({ start, end: params[index + 1].name_token().start() })
+  } else if index > 0 {
+    match graph_param_text_end(params[index - 1]) {
+      Some(previous_end) => Some({ start: previous_end, end })
+      None => None
+    }
+  } else {
+    Some({ start, end })
+  }
+}
+
+///|
+fn lower_disconnect_ports(
+  doc : @graph_dsl.GraphDoc,
+  source : NodeId,
+  source_port : String,
+  target : NodeId,
+  target_port : String,
+) -> Result[SourceOperationEdit, String] {
+  if source_port != "out" {
+    return Err("graph-dsl source disconnections must use port 'out'")
+  }
+  let source_node = match graph_node_for_canvas_id(doc, source) {
+    Some(node) => node
+    None => return Err("cannot lower DisconnectPorts: missing source node")
+  }
+  let target_node = match graph_node_for_canvas_id(doc, target) {
+    Some(node) => node
+    None => return Err("cannot lower DisconnectPorts: missing target node")
+  }
+  let params = target_node.params()
+  let index = match
+    disconnect_param_index(params, target_port, source_node.binding()) {
+    Some(index) => index
+    None => return Err("cannot lower DisconnectPorts: missing edge")
+  }
+  let span = match removal_span_for_graph_param(doc.source(), params, index) {
+    Some(span) => span
+    None => return Err("cannot lower DisconnectPorts into source")
+  }
+  match apply_deletion_spans(doc.source(), [span]) {
+    Some(new_source) => Ok(WholeSourceReplacement(new_source))
+    None => Err("cannot lower DisconnectPorts into source")
+  }
+}

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -32,6 +32,24 @@ async function center(locator: Locator, label: string): Promise<Point> {
   };
 }
 
+async function edgeMidpoint(edge: Locator): Promise<Point> {
+  return edge.evaluate((path) => {
+    const svgPath = path as SVGPathElement;
+    const point = svgPath.getPointAtLength(svgPath.getTotalLength() / 2);
+    const matrix = svgPath.getScreenCTM();
+    if (!matrix) throw new Error('edge path has no screen transform');
+    return {
+      x: point.x * matrix.a + point.y * matrix.c + matrix.e,
+      y: point.x * matrix.b + point.y * matrix.d + matrix.f,
+    };
+  });
+}
+
+async function clickEdge(page: Page, index: number, button: 'left' | 'right' = 'left'): Promise<void> {
+  const point = await edgeMidpoint(edgePaths(page).nth(index));
+  await page.mouse.click(point.x, point.y, { button });
+}
+
 async function canvasBackgroundPoint(page: Page): Promise<Point> {
   const box = await page.locator('#canvas-root').boundingBox();
   if (!box) {
@@ -151,6 +169,50 @@ test('selected canvas nodes delete with incident edges from the keyboard', async
   await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveCount(0);
   await expect(edgePaths(page)).toHaveCount(1);
   await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('selected canvas edge deletes with keyboard without removing nodes', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(edgePaths(page)).toHaveCount(3);
+
+  await clickEdge(page, 1);
+  await expect(edgePaths(page).nth(1)).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await page.keyboard.press('Delete');
+
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(edgePaths(page)).toHaveCount(2);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('canvas edge context menu disconnects the edge', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(edgePaths(page)).toHaveCount(3);
+
+  await clickEdge(page, 0, 'right');
+  await page.getByRole('button', { name: 'Disconnect edge' }).click();
+
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+  await expect(edgePaths(page)).toHaveCount(2);
+  await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   expect(runtimeErrors).toEqual([]);
 });
 

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -20,6 +20,10 @@ function outputHandle(page: Page, nodeId: number): Locator {
   return page.locator(`.handle.output[data-node-id="${nodeId}"]`);
 }
 
+function edgePaths(page: Page): Locator {
+  return page.locator('#edges path.edge');
+}
+
 async function center(locator: Locator, label: string): Promise<Point> {
   const box = await locator.boundingBox();
   if (!box) {
@@ -37,6 +41,24 @@ async function dragBetween(page: Page, from: Locator, to: Locator): Promise<void
   await page.mouse.move(start.x, start.y);
   await page.mouse.down();
   await page.mouse.move(end.x, end.y, { steps: 8 });
+}
+
+async function edgeMidpoint(edge: Locator): Promise<Point> {
+  return edge.evaluate((path) => {
+    const svgPath = path as SVGPathElement;
+    const point = svgPath.getPointAtLength(svgPath.getTotalLength() / 2);
+    const matrix = svgPath.getScreenCTM();
+    if (!matrix) throw new Error('edge path has no screen transform');
+    return {
+      x: point.x * matrix.a + point.y * matrix.c + matrix.e,
+      y: point.x * matrix.b + point.y * matrix.d + matrix.f,
+    };
+  });
+}
+
+async function clickEdge(page: Page, index: number): Promise<void> {
+  const point = await edgeMidpoint(edgePaths(page).nth(index));
+  await page.mouse.click(point.x, point.y);
 }
 
 async function dragBy(page: Page, locator: Locator, dx: number, dy: number): Promise<void> {
@@ -91,6 +113,35 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   );
   await expect(page.locator('#edges path.edge')).toHaveCount(1);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed selected edge deletion lowers into canonical source', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+
+  await dragBetween(page, outputHandle(page, 1), inputHandle(page, 2));
+  await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
+  await page.mouse.up();
+  await expect(edgePaths(page)).toHaveCount(1);
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
+  );
+
+  await clickEdge(page, 0);
+  await expect(edgePaths(page).first()).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+  await page.keyboard.press('Backspace');
+
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+  await expect(edgePaths(page)).toHaveCount(0);
+  await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
+  await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
+  await expect(page.locator('#source-status')).toContainText(
+    'Disconnected selected edge through graph-dsl source.',
+  );
   expect(runtimeErrors).toEqual([]);
 });
 

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -70,6 +70,8 @@
     #edges {
       position: absolute;
       top: 0; left: 0;
+      width: 100%;
+      height: 100%;
       overflow: visible;
       pointer-events: none;
       transform-origin: 0 0;
@@ -78,6 +80,15 @@
       fill: none;
       stroke: oklch(62% 0.095 292 / 0.78);
       stroke-width: 2;
+      pointer-events: stroke;
+      cursor: pointer;
+      transition: stroke 120ms ease, stroke-width 120ms ease, filter 120ms ease;
+    }
+    #edges path.edge:hover,
+    #edges path.edge.selected {
+      stroke: oklch(76% 0.15 292 / 0.96);
+      stroke-width: 4;
+      filter: drop-shadow(0 0 8px oklch(63% 0.12 292 / 0.42));
     }
     #edges path.edge-pending {
       fill: none;

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -19,6 +19,13 @@ export type CanvasModule = {
   zoom: (h: number, delta: number, cx: number, cy: number) => void;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   delete_nodes: (h: number, nodeIdsJson: string) => void;
+  disconnect_ports: (
+    h: number,
+    source: number,
+    sourcePort: string,
+    target: number,
+    targetPort: string,
+  ) => void;
   get_render_state: (h: number) => string;
   get_action_log: (h: number) => string;
   create_source_graph?: (source: string) => number;
@@ -152,6 +159,14 @@ export type GraphOperation =
   | {
       version: number;
       type: 'ConnectPorts';
+      source: number;
+      source_port: string;
+      target: number;
+      target_port: string;
+    }
+  | {
+      version: number;
+      type: 'DisconnectPorts';
       source: number;
       source_port: string;
       target: number;
@@ -331,6 +346,43 @@ export class GraphAdapter {
       return this.applyOperation(operation);
     }
     this.mb.delete_nodes(this.handle, JSON.stringify(uniqueNodeIds));
+    this.emitLatestOperations();
+    return null;
+  }
+
+  disconnectPorts(
+    sourceNodeId: number,
+    sourcePortId: string,
+    targetNodeId: number,
+    targetPortId: string,
+  ): SourceGraphOperationResult | null {
+    this.assertLive();
+    if (
+      !Number.isFinite(sourceNodeId) ||
+      !Number.isFinite(targetNodeId) ||
+      sourcePortId.length === 0 ||
+      targetPortId.length === 0
+    ) {
+      return null;
+    }
+    const operation: GraphOperation = {
+      version: 1,
+      type: 'DisconnectPorts',
+      source: sourceNodeId,
+      source_port: sourcePortId,
+      target: targetNodeId,
+      target_port: targetPortId,
+    };
+    if (this.isSourceBacked) {
+      return this.applyOperation(operation);
+    }
+    this.mb.disconnect_ports(
+      this.handle,
+      sourceNodeId,
+      sourcePortId,
+      targetNodeId,
+      targetPortId,
+    );
     this.emitLatestOperations();
     return null;
   }

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -62,6 +62,9 @@ let contextPoint: [number, number] = [0, 0];
 let sourcePointerId = -1;
 let sourceConnecting: Connecting | null = null;
 
+type EdgeSelection = Pick<EdgeData, 'source' | 'source_port' | 'target' | 'target_port'>;
+let selectedEdge: EdgeSelection | null = null;
+
 // ─── Geometry ────────────────────────────────────────────────────────────────
 
 function portOffset(n: NodeData, side: 'input' | 'output', portId: string): number {
@@ -102,6 +105,34 @@ function portTypeName(portType: Tagged): string {
 
 function portTitle(port: PortDef): string {
   return `${port.label}: ${portTypeName(port.port_type)}`;
+}
+
+function edgeSelectionFromEdge(edge: EdgeData): EdgeSelection {
+  return {
+    source: edge.source,
+    source_port: edge.source_port,
+    target: edge.target,
+    target_port: edge.target_port,
+  };
+}
+
+function edgeMatchesSelection(edge: EdgeData, selection: EdgeSelection): boolean {
+  return edge.source === selection.source &&
+    edge.source_port === selection.source_port &&
+    edge.target === selection.target &&
+    edge.target_port === selection.target_port;
+}
+
+function edgeTitle(edge: EdgeData): string {
+  return `${edge.source}.${edge.source_port} → ${edge.target}.${edge.target_port}`;
+}
+
+function selectEdge(edge: EdgeData): void {
+  selectedEdge = edgeSelectionFromEdge(edge);
+}
+
+function clearSelectedEdge(): void {
+  selectedEdge = null;
 }
 
 // ─── Connection compatibility (display only) ───────────────────────────────────
@@ -176,6 +207,10 @@ function scheduleRender(): void {
 function render(): void {
   rafPending = false;
   const state = adapter.renderState();
+  const edgeSelection = selectedEdge;
+  if (edgeSelection && !state.edges.some((edge) => edgeMatchesSelection(edge, edgeSelection))) {
+    selectedEdge = null;
+  }
   lastState = state;
 
   const { x, y, scale } = state.viewport;
@@ -281,6 +316,10 @@ function render(): void {
     }
     path.setAttribute('d', bezierPath(sx, sy, tx, ty));
     path.setAttribute('data-edge-id', String(edge.id));
+    path.classList.toggle('selected', selectedEdge != null && edgeMatchesSelection(edge, selectedEdge));
+    path.setAttribute('role', 'button');
+    path.setAttribute('tabindex', '0');
+    path.setAttribute('aria-label', `Disconnect ${edgeTitle(edge)}`);
   }
   for (const [id, path] of edgePaths) {
     if (!seenEdges.has(id)) { path.remove(); edgePaths.delete(id); }
@@ -378,21 +417,29 @@ function focusNode(nodeId: number): void {
 type HitTarget =
   | { kind: 'background' }
   | { kind: 'node'; nodeId: number }
+  | { kind: 'edge'; edge: EdgeData }
   | { kind: 'handle'; nodeId: number; side: 'input' | 'output'; portId: string };
 
 function hitFromTarget(target: EventTarget | null): HitTarget {
-  let el = target as HTMLElement | null;
+  let el = target instanceof Element ? target : null;
   while (el && el !== root) {
-    if (el.dataset?.handle && el.dataset?.nodeId && el.dataset?.portId) {
+    const element = el as HTMLElement | SVGElement;
+    if (element.dataset?.edgeId) {
+      const edgeId = parseInt(element.dataset.edgeId);
+      const state = lastState ?? adapter.renderState();
+      const edge = state.edges.find((candidate) => candidate.id === edgeId);
+      if (edge) return { kind: 'edge', edge };
+    }
+    if (element.dataset?.handle && element.dataset?.nodeId && element.dataset?.portId) {
       return {
         kind: 'handle',
-        nodeId: parseInt(el.dataset.nodeId),
-        side: el.dataset.handle as 'input' | 'output',
-        portId: el.dataset.portId,
+        nodeId: parseInt(element.dataset.nodeId),
+        side: element.dataset.handle as 'input' | 'output',
+        portId: element.dataset.portId,
       };
     }
-    if (el.dataset?.nodeId && el.classList.contains('canvas-node')) {
-      return { kind: 'node', nodeId: parseInt(el.dataset.nodeId) };
+    if (element.dataset?.nodeId && element.classList.contains('canvas-node')) {
+      return { kind: 'node', nodeId: parseInt(element.dataset.nodeId) };
     }
     el = el.parentElement;
   }
@@ -400,6 +447,7 @@ function hitFromTarget(target: EventTarget | null): HitTarget {
 }
 
 function addNodeAt(kindKey: string, point: [number, number]): void {
+  clearSelectedEdge();
   if (adapter.isSourceBacked) {
     adapter.insertUniqueNode(kindKey, kindKey);
     hideContextMenu();
@@ -412,7 +460,7 @@ function addNodeAt(kindKey: string, point: [number, number]): void {
 }
 
 function hoverNodeId(hit: HitTarget): number {
-  return hit.kind === 'background' ? 0 : hit.nodeId;
+  return hit.kind === 'node' || hit.kind === 'handle' ? hit.nodeId : 0;
 }
 
 function updateHover(hit: HitTarget): void {
@@ -422,6 +470,7 @@ function updateHover(hit: HitTarget): void {
 
 function startSourceConnection(e: PointerEvent, hit: HitTarget): void {
   if (hit.kind !== 'handle' || hit.side !== 'output') return;
+  clearSelectedEdge();
   hideContextMenu();
   root.setPointerCapture(e.pointerId);
   sourcePointerId = e.pointerId;
@@ -493,6 +542,40 @@ function syncSourceEditorFromResult(result: SourceGraphOperationResult): void {
   if (editor) editor.value = result.source;
 }
 
+function disconnectEdge(edge: EdgeData): boolean {
+  const result = adapter.disconnectPorts(
+    edge.source,
+    edge.source_port,
+    edge.target,
+    edge.target_port,
+  );
+  if (result) {
+    syncSourceEditorFromResult(result);
+    updateSourceOperationStatus(
+      result,
+      'Disconnected selected edge through graph-dsl source.',
+      'Source disconnect rejected',
+    );
+  }
+  clearSelectedEdge();
+  hideContextMenu();
+  scheduleRender();
+  return true;
+}
+
+function deleteSelectedEdge(): boolean {
+  const edgeSelection = selectedEdge;
+  if (!edgeSelection) return false;
+  const state = lastState ?? adapter.renderState();
+  const edge = state.edges.find((candidate) => edgeMatchesSelection(candidate, edgeSelection));
+  if (!edge) {
+    clearSelectedEdge();
+    scheduleRender();
+    return true;
+  }
+  return disconnectEdge(edge);
+}
+
 function deleteSelectedNodes(): boolean {
   const state = lastState ?? adapter.renderState();
   const selectedNodes = state.selected_nodes ?? [];
@@ -506,6 +589,7 @@ function deleteSelectedNodes(): boolean {
       'Source delete rejected',
     );
   }
+  clearSelectedEdge();
   hideContextMenu();
   scheduleRender();
   return true;
@@ -530,6 +614,16 @@ function renderLibrary(filter = ''): void {
   }
 }
 
+function renderEdgeContextMenu(edge: EdgeData): void {
+  contextMenu.replaceChildren();
+  const disconnect = document.createElement('button');
+  disconnect.type = 'button';
+  disconnect.textContent = 'Disconnect edge';
+  disconnect.title = edgeTitle(edge);
+  disconnect.addEventListener('click', () => disconnectEdge(edge));
+  contextMenu.appendChild(disconnect);
+}
+
 function renderContextMenu(): void {
   contextMenu.replaceChildren();
   for (const item of LIBRARY) {
@@ -552,11 +646,18 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
   if (adapter.isSourceBacked) {
     if (e.button !== 0) return;
     const hit = hitFromTarget(e.target);
+    if (hit.kind === 'edge') {
+      hideContextMenu();
+      selectEdge(hit.edge);
+      scheduleRender();
+      return;
+    }
     if (hit.kind === 'handle') {
       startSourceConnection(e, hit);
       return;
     }
     if (activePointerId !== -1) return;
+    clearSelectedEdge();
     hideContextMenu();
     root.setPointerCapture(e.pointerId);
     activePointerId = e.pointerId;
@@ -574,11 +675,17 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
   if (e.button !== 0 || (isMacLike && e.ctrlKey)) return;
   if (activePointerId !== -1) return;
   hideContextMenu();
+  const hit = hitFromTarget(e.target);
+  if (hit.kind === 'edge') {
+    selectEdge(hit.edge);
+    scheduleRender();
+    return;
+  }
+  clearSelectedEdge();
   root.setPointerCapture(e.pointerId);
   activePointerId = e.pointerId;
   pointerUpAdditive = e.shiftKey || e.metaKey || e.ctrlKey;
   const [sx, sy] = localCoords(e);
-  const hit = hitFromTarget(e.target);
 
   switch (hit.kind) {
     case 'handle':
@@ -707,11 +814,19 @@ root.addEventListener('wheel', (e: WheelEvent) => {
 
 root.addEventListener('contextmenu', (e: MouseEvent) => {
   e.preventDefault();
-  contextPoint = localCoords(e);
-  renderContextMenu();
+  const hit = hitFromTarget(e.target);
+  if (hit.kind === 'edge') {
+    selectEdge(hit.edge);
+    renderEdgeContextMenu(hit.edge);
+  } else {
+    clearSelectedEdge();
+    contextPoint = localCoords(e);
+    renderContextMenu();
+  }
   contextMenu.style.left = `${e.clientX}px`;
   contextMenu.style.top = `${e.clientY}px`;
   contextMenu.hidden = false;
+  scheduleRender();
 });
 
 document.addEventListener('keydown', (e: KeyboardEvent) => {
@@ -723,6 +838,10 @@ document.addEventListener('keydown', (e: KeyboardEvent) => {
     !e.altKey &&
     !editableKeyboardTarget(e.target)
   ) {
+    if (selectedEdge) {
+      if (deleteSelectedEdge()) e.preventDefault();
+      return;
+    }
     if (deleteSelectedNodes()) e.preventDefault();
     return;
   }


### PR DESCRIPTION
Fixes #481

## Summary

- Add a `DisconnectPorts(source, source_port, target, target_port)` graph operation for direct edge deletion without relying on render-derived edge IDs.
- Make rendered canvas SVG edges selectable/hit-testable, with Delete/Backspace and context-menu disconnect support.
- Lower source-backed edge deletion to canonical Graph DSL source by removing the matching target input-reference parameter while preserving nodes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `GraphOperation` JSON/apply/replay plumbing | `examples/canvas/graph_model/model.mbt`, `examples/canvas/web/src/graph-adapter.ts`, `examples/canvas/main/graph_dsl_adapter.mbt` | Yes | Extended with `DisconnectPorts` rather than adding a parallel operation channel. |
| `GraphDoc` / `GraphNode` / `GraphParam` accessors | `loom/examples/graph-dsl/src/graph_doc.mbt` | Yes | Used to resolve source/target bindings and locate the target parameter/reference. |
| `GraphDoc::lower_add_connection` | `loom/examples/graph-dsl/src/lowering.mbt` | No | Covers insertion only; disconnect needs source-span deletion for an existing parameter. |
| `DeleteNodes` source lowering | `examples/canvas/main/source_delete_lowering.mbt` | Partially | Reused deletion-span application helpers; not reused semantically because node deletion removes binding lines and incident edges, while edge deletion preserves nodes. |

New helpers added:

- `disconnect_ports_from_state` and `edge_matches_ports`: canvas reducer support for removing exactly the matching endpoint/port tuple.
- `source_disconnect_lowering.mbt` helpers: source-backed parameter-span calculation for first/middle/trailing/sole Graph DSL input-reference parameters.
- `GraphAdapter.disconnectPorts`: TypeScript bridge that reuses `applyOperation` in source-backed mode and the FFI export in canvas-backed mode.
- Edge-selection helpers in `examples/canvas/web/src/main.ts`: local UI state for selecting current rendered edges while sending stable endpoint/port operations.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/canvas/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 make check
NEW_MOON_MOD=0 make fmt-check
NEW_MOON_MOD=0 moon test
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon test --release
cd examples/canvas/web && npm run build
cd examples/canvas/web && npx tsc --noEmit
cd examples/canvas/web && npx playwright test e2e/canvas-handles.spec.ts e2e/source-backed.spec.ts
```

Note: unrelated dirty `loom` submodule work was preserved and not included in this PR.
