### PR TITLE
chore(canvas): use graph-dsl remove connection lowering

### DIFF
--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -438,6 +438,26 @@ test "source-backed DisconnectPorts removes a trailing input reference" {
 }
 
 ///|
+test "source-backed DisconnectPorts consumes a valid trailing comma" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc,)"
+  let handle = create_source_graph(source)
+  let disconnect = GraphOperation(
+    DisconnectPorts(NodeId(1), "out", NodeId(2), "input"),
+  )
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, disconnect.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 440Hz)\nmeter = scope()",
+  )
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed unique insert chooses a fresh graph-dsl binding" {
   let handle = create_source_graph("reverb = plate()")
   inspect(

--- a/examples/canvas/main/source_disconnect_lowering.mbt
+++ b/examples/canvas/main/source_disconnect_lowering.mbt
@@ -1,110 +1,4 @@
 ///|
-fn horizontal_space(code_unit : UInt16) -> Bool {
-  code_unit == ' ' || code_unit == '\t'
-}
-
-///|
-fn param_start_after_lparen_space(source : String, start : Int) -> Int {
-  let mut cursor = start
-  while cursor > 0 && horizontal_space(source[cursor - 1]) {
-    cursor -= 1
-  }
-  if cursor > 0 && source[cursor - 1] == '(' {
-    cursor
-  } else {
-    start
-  }
-}
-
-///|
-fn param_end_before_rparen_space(source : String, end : Int) -> Int {
-  let mut cursor = end
-  while cursor < source.length() && horizontal_space(source[cursor]) {
-    cursor += 1
-  }
-  if cursor < source.length() && source[cursor] == ')' {
-    cursor
-  } else {
-    end
-  }
-}
-
-///|
-fn graph_param_text_end(param : @graph_dsl.GraphParam) -> Int? {
-  let value_tokens = param.value_tokens()
-  if value_tokens.length() == 0 {
-    return None
-  }
-  let mut end = param.name_token().end()
-  for token in value_tokens {
-    if token.end() > end {
-      end = token.end()
-    }
-  }
-  Some(end)
-}
-
-///|
-fn graph_param_matches_edge(
-  param : @graph_dsl.GraphParam,
-  target_port : String,
-  source_binding : String,
-) -> Bool {
-  param.name() == target_port &&
-  graph_input_reference(param) == Some(source_binding)
-}
-
-///|
-fn disconnect_param_index(
-  params : Array[@graph_dsl.GraphParam],
-  target_port : String,
-  source_binding : String,
-) -> Int? {
-  for index, param in params {
-    if graph_param_matches_edge(param, target_port, source_binding) {
-      return Some(index)
-    }
-  }
-  None
-}
-
-///|
-fn removal_span_for_graph_param(
-  source : String,
-  params : Array[@graph_dsl.GraphParam],
-  index : Int,
-) -> SourceDeletionSpan? {
-  if index < 0 || index >= params.length() {
-    return None
-  }
-  let param = params[index]
-  let start = if index == 0 {
-    param_start_after_lparen_space(source, param.name_token().start())
-  } else {
-    param.name_token().start()
-  }
-  let end = match graph_param_text_end(param) {
-    Some(end) =>
-      if index + 1 < params.length() {
-        end
-      } else {
-        param_end_before_rparen_space(source, end)
-      }
-    None => return None
-  }
-  if index + 1 < params.length() {
-    Some({ start, end: params[index + 1].name_token().start() })
-  } else if index > 0 {
-    match graph_param_text_end(params[index - 1]) {
-      Some(previous_end) => Some({ start: previous_end, end })
-      None => None
-    }
-  } else {
-    Some({ start, end })
-  }
-}
-
-///|
 fn lower_disconnect_ports(
   doc : @graph_dsl.GraphDoc,
   source : NodeId,
@@ -123,18 +17,13 @@ fn lower_disconnect_ports(
     Some(node) => node
     None => return Err("cannot lower DisconnectPorts: missing target node")
   }
-  let params = target_node.params()
-  let index = match
-    disconnect_param_index(params, target_port, source_node.binding()) {
-    Some(index) => index
-    None => return Err("cannot lower DisconnectPorts: missing edge")
-  }
-  let span = match removal_span_for_graph_param(doc.source(), params, index) {
-    Some(span) => span
-    None => return Err("cannot lower DisconnectPorts into source")
-  }
-  match apply_deletion_spans(doc.source(), [span]) {
-    Some(new_source) => Ok(WholeSourceReplacement(new_source))
-    None => Err("cannot lower DisconnectPorts into source")
+  match
+    doc.lower_remove_connection(
+      target_node.binding(),
+      target_port,
+      source_node.binding(),
+    ) {
+    Some(edit) => Ok(ExactLoweredEdit(edit))
+    None => Err("cannot lower DisconnectPorts: missing edge")
   }
 }


### PR DESCRIPTION
## Summary
- Advance the Loom submodule to merged PR dowdiness/loom#213 (`29ddb8d`) for `GraphDoc::lower_remove_connection`.
- Advance again to dowdiness/loom#214 (`f50267f`) for valid trailing-comma consumption when removing a connection.
- Replace Canopy's duplicated Graph DSL disconnect source-span lowering with the upstream helper.
- Add a source-backed canvas regression for deleting `input: osc,` to `scope()`.

## Reuse check
- `@graph_dsl.GraphDoc::lower_add_connection(binding, input_ref)` was insufficient because it only inserts a new `input` parameter.
- `@graph_dsl.GraphDoc::lower_rename_node_binding(old_name, new_name)` was insufficient because it preserves parameters and only edits identifier tokens.
- New upstream `@graph_dsl.GraphDoc::lower_remove_connection(binding, parameter, input_ref)` now covers the needed source deletion, so Canopy reuses it instead of maintaining local span logic.

## Validation
Loom PR dowdiness/loom#213:
- `gh pr checks 213` all passing before merge.
- Merged as `29ddb8d1d3e45ce01b911ba2bb497eee93cdbb1f`.

Loom PR dowdiness/loom#214:
- `NEW_MOON_MOD=0 moon test src --filter '*trailing comma*'` failed before the fix with `blend(,)` and `blend(gain: 1,)`.
- `gh pr checks 214` all passing before merge.
- Merged as `f50267f1d5d3694557d4aa42e8bb292e229481fa`.

Canopy:
- `NEW_MOON_MOD=0 moon test examples/canvas/main --filter '*trailing comma*'`
- `NEW_MOON_MOD=0 moon fmt examples/canvas/main/graph_dsl_adapter_wbtest.mbt`
- `NEW_MOON_MOD=0 moon test examples/canvas/main`
- `NEW_MOON_MOD=0 moon check examples/canvas/main`
- `NEW_MOON_MOD=0 moon info examples/canvas/main`
- `NEW_MOON_MOD=0 moon check`
- `NEW_MOON_MOD=0 moon test`

## Notes
- Left unrelated dirty local state unstaged: `event-graph-walker` and nested `loom/incr`.
