### PR TITLE
[codex] add btree quickcheck shrinkers

### DIFF
--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -296,7 +296,73 @@ impl @quickcheck.Arbitrary for QueryCase with fn arbitrary(size, rs) {
 }
 
 ///|
-impl @qc.Shrink for QueryCase
+fn push_query_case_shrinks(
+  results : Array[QueryCase],
+  items : Array[(Int, Int)],
+  start : Int,
+  end_ : Int,
+  pos : Int,
+) -> Unit {
+  let total = generated_items_span(items)
+  if start != 0 || end_ != 0 || pos != 0 {
+    results.push({ items, start: 0, end_: 0, pos: 0 })
+  }
+  if total > 0 {
+    if start != 0 || end_ != total || pos != 0 {
+      results.push({ items, start: 0, end_: total, pos: 0 })
+    }
+    if start != 0 || end_ != total || pos != total - 1 {
+      results.push({ items, start: 0, end_: total, pos: total - 1 })
+    }
+    if start != 0 || end_ != total || pos != total {
+      results.push({ items, start: 0, end_: total, pos: total })
+    }
+  }
+  if start < 0 && start != -1 {
+    results.push({ items, start: -1, end_, pos })
+  }
+  if end_ < 0 && end_ != -1 {
+    results.push({ items, start, end_: -1, pos })
+  }
+  if pos < 0 && pos != -1 {
+    results.push({ items, start, end_, pos: -1 })
+  }
+  if start > total && start != total + 1 {
+    results.push({ items, start: total + 1, end_, pos })
+  }
+  if end_ > total && end_ != total + 1 {
+    results.push({ items, start, end_: total + 1, pos })
+  }
+  if pos > total && pos != total + 1 {
+    results.push({ items, start, end_, pos: total + 1 })
+  }
+  for next_start in @qc.Shrink::shrink(start) {
+    results.push({ items, start: next_start, end_, pos })
+  }
+  for next_end in @qc.Shrink::shrink(end_) {
+    results.push({ items, start, end_: next_end, pos })
+  }
+  for next_pos in @qc.Shrink::shrink(pos) {
+    results.push({ items, start, end_, pos: next_pos })
+  }
+}
+
+///|
+impl @qc.Shrink for QueryCase with fn shrink(case_) {
+  let results : Array[QueryCase] = []
+  push_query_case_shrinks(
+    results,
+    case_.items,
+    case_.start,
+    case_.end_,
+    case_.pos,
+  )
+  for items in shrink_generated_items(case_.items) {
+    results.push({ items, start: case_.start, end_: case_.end_, pos: case_.pos })
+    push_query_case_shrinks(results, items, case_.start, case_.end_, case_.pos)
+  }
+  results.iter()
+}
 
 ///|
 fn prop_view_find_get_at_matches_model(case_ : QueryCase) -> Bool {
@@ -367,6 +433,93 @@ impl @quickcheck.Arbitrary for ModelOp with fn arbitrary(size, rs) {
 }
 
 ///|
+impl @qc.Shrink for ModelOp with fn shrink(op) {
+  let results : Array[ModelOp] = []
+  match op {
+    Append(id, span) => {
+      if id > 1 {
+        results.push(Append(1, span))
+      }
+      if span > 1 {
+        results.push(Append(id, 1))
+      }
+    }
+    Insert(pos, id, span) => {
+      if pos != 0 {
+        results.push(Insert(0, id, span))
+      }
+      if pos < 0 && pos != -1 {
+        results.push(Insert(-1, id, span))
+      }
+      if id > 1 {
+        results.push(Insert(pos, 1, span))
+      }
+      if span > 1 {
+        results.push(Insert(pos, id, 1))
+      }
+      for next_pos in @qc.Shrink::shrink(pos) {
+        results.push(Insert(next_pos, id, span))
+      }
+    }
+    DeleteAt(pos) => {
+      if pos != 0 {
+        results.push(DeleteAt(0))
+      }
+      if pos < 0 && pos != -1 {
+        results.push(DeleteAt(-1))
+      }
+      for next_pos in @qc.Shrink::shrink(pos) {
+        results.push(DeleteAt(next_pos))
+      }
+    }
+    DeleteRange(start, end_) => {
+      if start != 0 || end_ != 0 {
+        results.push(DeleteRange(0, 0))
+      }
+      if start < 0 && start != -1 {
+        results.push(DeleteRange(-1, end_))
+      }
+      if end_ < 0 && end_ != -1 {
+        results.push(DeleteRange(start, -1))
+      }
+      if start != end_ {
+        results.push(DeleteRange(start, start))
+      }
+      for next_start in @qc.Shrink::shrink(start) {
+        results.push(DeleteRange(next_start, end_))
+      }
+      for next_end in @qc.Shrink::shrink(end_) {
+        results.push(DeleteRange(start, next_end))
+      }
+    }
+    Query(pos, start, end_) => {
+      if pos != 0 || start != 0 || end_ != 0 {
+        results.push(Query(0, 0, 0))
+      }
+      if pos < 0 && pos != -1 {
+        results.push(Query(-1, start, end_))
+      }
+      if start < 0 && start != -1 {
+        results.push(Query(pos, -1, end_))
+      }
+      if end_ < 0 && end_ != -1 {
+        results.push(Query(pos, start, -1))
+      }
+      for next_pos in @qc.Shrink::shrink(pos) {
+        results.push(Query(next_pos, start, end_))
+      }
+      for next_start in @qc.Shrink::shrink(start) {
+        results.push(Query(pos, next_start, end_))
+      }
+      for next_end in @qc.Shrink::shrink(end_) {
+        results.push(Query(pos, start, next_end))
+      }
+    }
+  }
+  results.iter()
+}
+
+///|
 impl @quickcheck.Arbitrary for OpSequenceCase with fn arbitrary(size, rs) {
   let capped = if size < 0 { 0 } else if size > 32 { 32 } else { size }
   let op_count = rs.split().next_positive_int() % (capped + 1)
@@ -385,7 +538,60 @@ impl @quickcheck.Arbitrary for OpSequenceCase with fn arbitrary(size, rs) {
 }
 
 ///|
-impl @qc.Shrink for OpSequenceCase
+fn push_min_degree_shrinks(
+  results : Array[OpSequenceCase],
+  ops : Array[ModelOp],
+  min_degree : Int,
+) -> Unit {
+  if min_degree == DEFAULT_MIN_DEGREE {
+    results.push({ ops, min_degree: 5 })
+    results.push({ ops, min_degree: 3 })
+    results.push({ ops, min_degree: 2 })
+  } else if min_degree > 3 {
+    results.push({ ops, min_degree: 3 })
+    results.push({ ops, min_degree: 2 })
+  } else if min_degree > 2 {
+    results.push({ ops, min_degree: 2 })
+  }
+}
+
+///|
+impl @qc.Shrink for OpSequenceCase with fn shrink(case_) {
+  let results : Array[OpSequenceCase] = []
+  let len = case_.ops.length()
+  if len > 0 {
+    results.push({ ops: case_.ops[:0].to_owned(), min_degree: case_.min_degree })
+    let half = len / 2
+    if half > 0 {
+      results.push({
+        ops: case_.ops[:half].to_owned(),
+        min_degree: case_.min_degree,
+      })
+    }
+    if len > 1 {
+      results.push({
+        ops: case_.ops[:len - 1].to_owned(),
+        min_degree: case_.min_degree,
+      })
+      for i in 0..<len {
+        results.push({
+          ops: array_without_at(case_.ops, i),
+          min_degree: case_.min_degree,
+        })
+      }
+    }
+    for i in 0..<len {
+      for op in @qc.Shrink::shrink(case_.ops[i]) {
+        results.push({
+          ops: array_replaced_at(case_.ops, i, op),
+          min_degree: case_.min_degree,
+        })
+      }
+    }
+  }
+  push_min_degree_shrinks(results, case_.ops, case_.min_degree)
+  results.iter()
+}
 
 ///|
 fn apply_model_op(

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -1540,6 +1540,82 @@ fn generated_delete_range(
 }
 
 ///|
+fn generated_items_span(items : Array[(Int, Int)]) -> Int {
+  items.fold(init=0, fn(acc, item) { acc + item.1 })
+}
+
+///|
+fn[T] array_without_at(items : Array[T], index : Int) -> Array[T] {
+  Array::makei(items.length() - 1, fn(i) {
+    if i < index {
+      items[i]
+    } else {
+      items[i + 1]
+    }
+  })
+}
+
+///|
+fn[T] array_replaced_at(items : Array[T], index : Int, item : T) -> Array[T] {
+  Array::makei(items.length(), fn(i) {
+    if i == index {
+      item
+    } else {
+      items[i]
+    }
+  })
+}
+
+///|
+fn push_generated_items_prefix(
+  results : Array[Array[(Int, Int)]],
+  items : Array[(Int, Int)],
+  target_len : Int,
+) -> Unit {
+  if target_len > 0 && target_len < items.length() {
+    results.push(items[:target_len].to_owned())
+  }
+}
+
+///|
+fn shrink_generated_items(items : Array[(Int, Int)]) -> Iter[Array[(Int, Int)]] {
+  let results : Array[Array[(Int, Int)]] = []
+  let len = items.length()
+  guard len > 0 else { return results.iter() }
+  results.push(items[:0].to_owned())
+  push_generated_items_prefix(results, items, 1)
+  push_generated_items_prefix(results, items, 4)
+  push_generated_items_prefix(results, items, 5)
+  push_generated_items_prefix(results, items, 21)
+  if len > 1 {
+    let half = len / 2
+    push_generated_items_prefix(results, items, half)
+    results.push(items[:len - 1].to_owned())
+    for i in 0..<len {
+      results.push(array_without_at(items, i))
+    }
+  }
+  for i in 0..<len {
+    let (id, span) = items[i]
+    if id > 1 {
+      results.push(array_replaced_at(items, i, (1, span)))
+      let half_id = id / 2
+      if half_id > 1 {
+        results.push(array_replaced_at(items, i, (half_id, span)))
+      }
+    }
+    if span > 1 {
+      results.push(array_replaced_at(items, i, (id, 1)))
+      let half_span = span / 2
+      if half_span > 1 {
+        results.push(array_replaced_at(items, i, (id, half_span)))
+      }
+    }
+  }
+  results.iter()
+}
+
+///|
 impl @quickcheck.Arbitrary for DeleteRangeCase with fn arbitrary(size, rs) {
   let capped = if size < 0 { 0 } else if size > 32 { 32 } else { size }
   let item_count = generated_delete_item_count(capped, rs.split())
@@ -1556,7 +1632,58 @@ impl @quickcheck.Arbitrary for DeleteRangeCase with fn arbitrary(size, rs) {
 }
 
 ///|
-impl @qc.Shrink for DeleteRangeCase
+fn push_delete_range_shrinks(
+  results : Array[DeleteRangeCase],
+  items : Array[(Int, Int)],
+  start : Int,
+  end_ : Int,
+) -> Unit {
+  let total = generated_items_span(items)
+  if start != 0 || end_ != 0 {
+    results.push({ items, start: 0, end_: 0 })
+  }
+  if total > 0 {
+    if start != 0 || end_ != total {
+      results.push({ items, start: 0, end_: total })
+    }
+    let mid = total / 2
+    if start != mid || end_ != mid {
+      results.push({ items, start: mid, end_: mid })
+    }
+    if start != 0 || end_ != mid {
+      results.push({ items, start: 0, end_: mid })
+    }
+  }
+  if start < 0 && start != -1 {
+    results.push({ items, start: -1, end_ })
+  }
+  if end_ < 0 && end_ != -1 {
+    results.push({ items, start, end_: -1 })
+  }
+  if start > total && start != total + 1 {
+    results.push({ items, start: total + 1, end_ })
+  }
+  if end_ > total && end_ != total + 1 {
+    results.push({ items, start, end_: total + 1 })
+  }
+  for next_start in @qc.Shrink::shrink(start) {
+    results.push({ items, start: next_start, end_ })
+  }
+  for next_end in @qc.Shrink::shrink(end_) {
+    results.push({ items, start, end_: next_end })
+  }
+}
+
+///|
+impl @qc.Shrink for DeleteRangeCase with fn shrink(case_) {
+  let results : Array[DeleteRangeCase] = []
+  push_delete_range_shrinks(results, case_.items, case_.start, case_.end_)
+  for items in shrink_generated_items(case_.items) {
+    results.push({ items, start: case_.start, end_: case_.end_ })
+    push_delete_range_shrinks(results, items, case_.start, case_.end_)
+  }
+  results.iter()
+}
 
 ///|
 fn prop_delete_range_preserves_invariants(case_ : DeleteRangeCase) -> Bool {


### PR DESCRIPTION
## Summary

Adds real `@qc.Shrink` implementations for the generated btree QuickCheck cases introduced by PR #493:

- `DeleteRangeCase` now shrinks generated items and delete bounds while preserving positive item spans.
- `QueryCase` now shrinks generated items plus query range/position edge cases.
- `OpSequenceCase` now shrinks operation sequences, individual operations, and min-degree classes without changing generator distribution.

## Why

The property coverage from PR #493 was already in place, but failing cases still minimized poorly because the custom case shrinkers were no-ops. These shrinkers keep useful edge classes available while making counterexamples smaller and easier to inspect.

## Reuse Check

- Reused `@qc.Shrink::shrink` for primitive integer field shrinking instead of inventing numeric shrink logic.
- Reused `Array::makei` for scoped array copy/remove/replace helpers; new helpers are private and only cover repeated local test-case reshaping.

## Validation

- `rtk moon update`
- `rtk moon check --deny-warn`
- `rtk moon test lib/btree`
- `rtk moon test`
- `rtk git diff --check`

Note: the local worktree still has unrelated dirty submodule markers for `event-graph-walker` and `loom`; they are not staged or included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced property-based testing with improved shrinking strategies for B-tree operations, including better boundary value handling and edge case minimization.
  * Implemented specialized shrinking logic for test cases and operations, enabling more effective discovery of edge cases and generation of focused minimal examples.
  * Strengthened test reliability by improving how failing test scenarios are minimized and reported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/canopy/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->