### PR TITLE
test: tune btree quickcheck shrinkers

### DIFF
--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -311,6 +311,12 @@ fn push_query_case_shrinks(
     if start != 0 || end_ != total || pos != 0 {
       results.push({ items, start: 0, end_: total, pos: 0 })
     }
+    if start != 0 || end_ != total || pos != total + 1 {
+      results.push({ items, start: 0, end_: total, pos: total + 1 })
+    }
+    if start != total - 1 || end_ != total || pos != total {
+      results.push({ items, start: total - 1, end_: total, pos: total })
+    }
     if start != 0 || end_ != total || pos != total - 1 {
       results.push({ items, start: 0, end_: total, pos: total - 1 })
     }
@@ -335,6 +341,9 @@ fn push_query_case_shrinks(
   }
   if pos > total && pos != total + 1 {
     results.push({ items, start, end_, pos: total + 1 })
+  }
+  if start > end_ {
+    results.push({ items, start: end_, end_: start, pos })
   }
   for next_start in @qc.Shrink::shrink(start) {
     results.push({ items, start: next_start, end_, pos })
@@ -567,6 +576,13 @@ impl @qc.Shrink for OpSequenceCase with fn shrink(case_) {
         ops: case_.ops[:half].to_owned(),
         min_degree: case_.min_degree,
       })
+      let suffix_start = len - half
+      if suffix_start != 0 && suffix_start != half {
+        results.push({
+          ops: case_.ops[suffix_start:len].to_owned(),
+          min_degree: case_.min_degree,
+        })
+      }
     }
     if len > 1 {
       results.push({

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -1646,6 +1646,12 @@ fn push_delete_range_shrinks(
     if start != 0 || end_ != total {
       results.push({ items, start: 0, end_: total })
     }
+    if start != total || end_ != total {
+      results.push({ items, start: total, end_: total })
+    }
+    if start != total - 1 || end_ != total {
+      results.push({ items, start: total - 1, end_: total })
+    }
     let mid = total / 2
     if start != mid || end_ != mid {
       results.push({ items, start: mid, end_: mid })
@@ -1665,6 +1671,9 @@ fn push_delete_range_shrinks(
   }
   if end_ > total && end_ != total + 1 {
     results.push({ items, start, end_: total + 1 })
+  }
+  if start > end_ {
+    results.push({ items, start: end_, end_: start })
   }
   for next_start in @qc.Shrink::shrink(start) {
     results.push({ items, start: next_start, end_ })


### PR DESCRIPTION
## Summary
- Add additional Query/DeleteRange shrink candidates to preserve valid/salient boundary classes.
- Add sequence-half suffix shrink candidate in OpSequenceCase to isolate failures in tail operations.
- Keep shrinkers shape-compatible with existing generators (items/shapes unchanged).

## Validation
- rtk moon check --deny-warn
- rtk moon test lib/btree
- rtk moon test