### PR TITLE
chore: adopt incr 0.8.0 (pins + loom pointer + MemoEvent→DerivedEvent)

### DIFF
--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../../loom/examples/graph-dsl",
       "version": "0.1.0"
     },
-    "dowdiness/incr": "0.7.1",
+    "dowdiness/incr": "0.8.0",
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
       "version": "0.12.2"

--- a/lib/cognition/moon.mod
+++ b/lib/cognition/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/cognition"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.7.1",
+  "dowdiness/incr@0.8.0",
 }
 
 repository = "https://github.com/dowdiness/canopy"

--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -73,7 +73,7 @@ fn remember_cell(ids : Array[@incr.CellId], id : @incr.CellId) -> Unit {
 }
 
 ///|
-fn event_from_memo_event(evt : @incr.MemoEvent) -> RecomputeRecord {
+fn event_from_memo_event(evt : @incr.DerivedEvent) -> RecomputeRecord {
   match evt {
     EnteringCompute(e) =>
       {
@@ -109,7 +109,7 @@ fn event_from_memo_event(evt : @incr.MemoEvent) -> RecomputeRecord {
 }
 
 ///|
-fn RecomputeTap::record(self : RecomputeTap, evt : @incr.MemoEvent) -> Unit {
+fn RecomputeTap::record(self : RecomputeTap, evt : @incr.DerivedEvent) -> Unit {
   guard self.active.val else { return }
   let record = event_from_memo_event(evt)
   remember_cell(self.cells, record.cell_id)
@@ -228,7 +228,7 @@ fn record_status(record : RecomputeRecord?) -> VisualNodeStatus {
 /// any previous listener owned by the same runtime.
 pub fn RecomputeTap::attach(rt : @incr.Runtime) -> RecomputeTap raise Failure {
   let tap = { rt, active: Ref(true), events: @hashmap.HashMap([]), cells: [] }
-  rt.on_memo_event(evt => tap.record(evt))
+  rt.on_derived_event(evt => tap.record(evt))
   tap
 }
 

--- a/lib/visualizer/incr_tap_wbtest.mbt
+++ b/lib/visualizer/incr_tap_wbtest.mbt
@@ -21,8 +21,8 @@ test "format_elapsed_ns_picks_unit_by_magnitude" {
 /// no timing. Constructed directly (not via a live tap) so the formatted value
 /// is deterministic — wall-clock timing can't be asserted from a real run.
 test "to_visual_graph surfaces latest elapsed_ns on the recomputed cell only" {
-  let timed_cell : @incr.CellId = { id: 1, runtime_id: 0 }
-  let untimed_cell : @incr.CellId = { id: 2, runtime_id: 0 }
+  let timed_cell : @incr.CellId = { id: 1, runtime_id: @incr.RuntimeId(0) }
+  let untimed_cell : @incr.CellId = { id: 2, runtime_id: @incr.RuntimeId(0) }
   let rev3 : @incr.Revision = { value: 3 }
   let rev4 : @incr.Revision = { value: 4 }
   let timed_node : RecomputeSnapshotNode = {

--- a/lib/visualizer/moon.mod.json
+++ b/lib/visualizer/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "dowdiness/visualizer",
   "version": "0.1.0",
   "deps": {
-    "dowdiness/incr": "0.7.1",
+    "dowdiness/incr": "0.8.0",
     "dowdiness/graphviz": {
       "path": "../../graphviz",
       "version": "0.1.0"

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -21,7 +21,7 @@
       "path": "./loom/moji",
       "version": "0.1.0"
     },
-    "dowdiness/incr": "0.7.1",
+    "dowdiness/incr": "0.8.0",
     "dowdiness/lambda": {
       "path": "./loom/examples/lambda",
       "version": "0.1.0"


### PR DESCRIPTION
Adopt the published **dowdiness/incr 0.8.0** across canopy, completing the loom→canopy bump chain. The loom side merged first as dowdiness/loom#215 (incr 0.7.1→0.8.0 pins).

## Changes
- **Pin** `dowdiness/incr` `0.7.1` → `0.8.0`: root `moon.mod.json`, `examples/canvas`, `lib/visualizer`, `lib/cognition`.
- **Advance loom submodule** `f50267f` → `42a8261` (loom#215 merge commit — incr 0.8.0 pins).
- **lib/visualizer** — migrate off the now-deprecated 0.8.0 API: `@incr.MemoEvent` → `@incr.DerivedEvent`, `rt.on_memo_event` → `rt.on_derived_event`.
- **lib/visualizer wbtest** — construct `CellId.runtime_id` via `@incr.RuntimeId(0)` (0.8.0 promoted `RuntimeId` to a nominal type; a raw `Int` is no longer assignable).

## Why the chain
incr is **registry-resolved** across the dependency graph (not via the `loom/incr` submodule path), so canopy and loom must share a single incr version — hence loom#215 lands first, then this PR bumps canopy's pins + the loom pointer.

## Reuse check
No new APIs. Registry pin-version edits + a rename to the non-deprecated incr symbols + use of the published `RuntimeId` constructor.

## Gating (local)
Full canopy workspace green against incr 0.8.0 — 1320 js + 7 native, 0 failures. Resolved `.mooncakes` incr = `0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded `dowdiness/incr` dependency from 0.7.1 to 0.8.0 across all module configurations and examples
  * Updated subproject tracking references

* **Tests**
  * Refreshed test implementations to maintain compatibility with updated dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->