### PR TITLE
refactor(test): QueryCase shrink witness methodization

### DIFF
--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -356,10 +356,16 @@ fn push_query_case_shrinks(
   }
 }
 
+///|
 fn query_case_abs(value : Int) -> Int {
-  if value < 0 { -value } else { value }
+  if value < 0 {
+    -value
+  } else {
+    value
+  }
 }
 
+///|
 fn QueryCase::is_minimal_witness(self : QueryCase) -> Bool {
   self.start == 0 &&
   self.end_ == 0 &&
@@ -369,6 +375,7 @@ fn QueryCase::is_minimal_witness(self : QueryCase) -> Bool {
   self.items[0].1 == 1
 }
 
+///|
 fn QueryCase::shrink_score(self : QueryCase) -> Int {
   let len = self.items.length()
   if len == 0 {
@@ -378,12 +385,18 @@ fn QueryCase::shrink_score(self : QueryCase) -> Int {
   for item in self.items {
     item_score = item_score + query_case_abs(item.0) + item.1
   }
-  len * 1_000 + item_score + query_case_abs(self.start) + query_case_abs(self.end_) +
-    query_case_abs(self.pos)
+  len * 1_000 +
+  item_score +
+  query_case_abs(self.start) +
+  query_case_abs(self.end_) +
+  query_case_abs(self.pos)
 }
 
+///|
 fn QueryCase::to_stable_witness(self : QueryCase) -> QueryCase {
-  fn shrink_query_case_to_stable_witness_inner(current : QueryCase) -> QueryCase {
+  fn shrink_query_case_to_stable_witness_inner(
+    current : QueryCase,
+  ) -> QueryCase {
     let current_score = current.shrink_score()
     let mut next_case : QueryCase? = None
     let mut next_score = current_score
@@ -718,28 +731,17 @@ test "property: operation sequences match array model" {
   @qc.quick_check_fn(prop_operation_sequence_matches_model)
 }
 
+///|
 test "regression: QueryCase shrinker reaches stable minimal witness" {
   let seed : QueryCase = {
-    items: [
-      (8, 7),
-      (7, 5),
-      (6, 3),
-      (5, 6),
-      (4, 4),
-      (3, 2),
-    ],
+    items: [(8, 7), (7, 5), (6, 3), (5, 6), (4, 4), (3, 2)],
     start: 27,
     end_: 34,
     pos: 99,
   }
   let shrunk_once = seed.to_stable_witness()
   let shrunk_twice = shrunk_once.to_stable_witness()
-  let expected : QueryCase = {
-    items: [(1, 1)],
-    start: 0,
-    end_: 0,
-    pos: 0,
-  }
+  let expected : QueryCase = { items: [(1, 1)], start: 0, end_: 0, pos: 0 }
   inspect(shrunk_once.items.length(), content="1")
   inspect(shrunk_once.start, content="0")
   inspect(shrunk_once.end_, content="0")

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -272,7 +272,7 @@ struct QueryCase {
   start : Int
   end_ : Int
   pos : Int
-} derive(Debug)
+} derive(Debug, Eq)
 
 ///|
 impl @quickcheck.Arbitrary for QueryCase with fn arbitrary(size, rs) {
@@ -354,6 +354,55 @@ fn push_query_case_shrinks(
   for next_pos in @qc.Shrink::shrink(pos) {
     results.push({ items, start, end_, pos: next_pos })
   }
+}
+
+fn query_case_abs(value : Int) -> Int {
+  if value < 0 { -value } else { value }
+}
+
+fn QueryCase::is_minimal_witness(self : QueryCase) -> Bool {
+  self.start == 0 &&
+  self.end_ == 0 &&
+  self.pos == 0 &&
+  self.items.length() == 1 &&
+  self.items[0].0 == 1 &&
+  self.items[0].1 == 1
+}
+
+fn QueryCase::shrink_score(self : QueryCase) -> Int {
+  let len = self.items.length()
+  if len == 0 {
+    return 1_000_000
+  }
+  let mut item_score = 0
+  for item in self.items {
+    item_score = item_score + query_case_abs(item.0) + item.1
+  }
+  len * 1_000 + item_score + query_case_abs(self.start) + query_case_abs(self.end_) +
+    query_case_abs(self.pos)
+}
+
+fn QueryCase::to_stable_witness(self : QueryCase) -> QueryCase {
+  fn shrink_query_case_to_stable_witness_inner(current : QueryCase) -> QueryCase {
+    let current_score = current.shrink_score()
+    let mut next_case : QueryCase? = None
+    let mut next_score = current_score
+    for candidate in QueryCase::shrink(current) {
+      if candidate.is_minimal_witness() {
+        return candidate
+      }
+      let score = candidate.shrink_score()
+      if score < next_score {
+        next_case = Some(candidate)
+        next_score = score
+      }
+    }
+    match next_case {
+      Some(next) => shrink_query_case_to_stable_witness_inner(next)
+      None => current
+    }
+  }
+  shrink_query_case_to_stable_witness_inner(self)
 }
 
 ///|
@@ -667,6 +716,40 @@ test "property: from_sorted exact content matches array model" {
 ///|
 test "property: operation sequences match array model" {
   @qc.quick_check_fn(prop_operation_sequence_matches_model)
+}
+
+test "regression: QueryCase shrinker reaches stable minimal witness" {
+  let seed : QueryCase = {
+    items: [
+      (8, 7),
+      (7, 5),
+      (6, 3),
+      (5, 6),
+      (4, 4),
+      (3, 2),
+    ],
+    start: 27,
+    end_: 34,
+    pos: 99,
+  }
+  let shrunk_once = seed.to_stable_witness()
+  let shrunk_twice = shrunk_once.to_stable_witness()
+  let expected : QueryCase = {
+    items: [(1, 1)],
+    start: 0,
+    end_: 0,
+    pos: 0,
+  }
+  inspect(shrunk_once.items.length(), content="1")
+  inspect(shrunk_once.start, content="0")
+  inspect(shrunk_once.end_, content="0")
+  inspect(shrunk_once.pos, content="0")
+  inspect(shrunk_once.items[0].0, content="1")
+  inspect(shrunk_once.items[0].1, content="1")
+  inspect(shrunk_once.shrink_score(), content="1002")
+  inspect(shrunk_once.is_minimal_witness(), content="true")
+  inspect(shrunk_once == expected, content="true")
+  inspect(shrunk_once == shrunk_twice, content="true")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- refactor QueryCase shrink witness checks into test-local methods
- add a regression test that shrinks a known QueryCase seed to the stable minimal witness
- keep existing shrink semantics intact while asserting witness shape and idempotence

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@qc.Shrink::shrink` | quickcheck shrink trait used by `QueryCase::shrink` | Yes | The stable-witness helper walks the existing shrink stream rather than adding a second shrinker. |
| `push_query_case_shrinks` / `shrink_generated_items` | `lib/btree/btree_property_wbtest.mbt` / shared btree white-box test helpers | Yes | Existing shape-producing helpers remain authoritative; the new method only scores and follows their candidates for the regression. |
| `Float::abs` / `Rational::abs` | MoonBit core/x docs from `moon ide doc "abs"` | No | They do not provide an `Int` absolute value for this test-local scoring helper. |

New helpers added:

- `query_case_abs`: test-local integer magnitude helper for shrink scores.
- `QueryCase::is_minimal_witness`: names the regression's expected canonical witness shape.
- `QueryCase::shrink_score`: gives the regression helper a monotone score for walking shrink candidates.
- `QueryCase::to_stable_witness`: follows existing shrink candidates to a stable local witness for the regression test.

## Test plan

- [x] `rtk moon check lib/btree --deny-warn` passes
- [x] `rtk moon test lib/btree` passes
- [x] `NEW_MOON_MOD=0 moon fmt --check` passes
- [x] `NEW_MOON_MOD=0 moon info` run; generated `.mbti` newline-only churn reviewed and not included
- [x] JS rebuild not needed (test-only btree change)

## Validation

```bash
rtk moon check lib/btree --deny-warn
rtk moon test lib/btree
NEW_MOON_MOD=0 moon fmt --check
NEW_MOON_MOD=0 moon info
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced B-tree property testing with improved witness shrinking capabilities and stability validation to ensure reliable test case minimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->