### PR TITLE
docs: capture rabbita headless UI feasibility

### DIFF
--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -2,7 +2,7 @@
 
 **Status:** findings (source-verified) + design
 **Date:** 2026-06-04
-**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `f6361f2`)
+**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `8381bef`)
 **PoC:** `examples/disclosure/` (browser-verified, see §4)
 
 ## Conclusion
@@ -109,7 +109,7 @@ question is animation (CSS grid-rows / `data-state`), deferred.
 - The `"version": "0.12.2"` pins in 6 `moon.mod.json` files are advisory (path-deps
   use the path) — bump to `0.12.3` for accuracy when adopting.
 
-This experiment PR points the `rabbita` gitlink at `f6361f2`, which is published
+This experiment PR points the `rabbita` gitlink at `8381bef`, which is published
 on the configured fork remote as `dowdiness/rabbita:update-0.12.3-patched` so
 fresh clones can resolve the submodule commit. The same branch is under review
 as `dowdiness/rabbita#1`; it is not merged to the fork's main branch, so keep

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -21,6 +21,8 @@ Disclosure. Radix's `asChild` (React `cloneElement`) cannot be reproduced at the
 type level (MoonBit traits: no type params / associated types / HKT), but its
 *intent* — spread a behavior's attrs onto a consumer-chosen element — is fully
 served by returning `@html.Attrs` and applying it via the element's `attrs?` param.
+This is better understood as a prop-getter / render-prop-style lineage than as a
+MoonBit clone of `asChild`.
 
 ## 1. Why
 
@@ -55,17 +57,23 @@ Key design decisions, each grounded in a verified fact:
 1. **`Attrs::build()` chaining is the rabbita-native `getTriggerProps()`** — typed,
    ergonomic: `.aria_expanded(..).aria_controls(..).on_click(..)` (fact b). A
    primitive returns `@html.Attrs`; the consumer spreads it via `attrs=...` and
-   owns all classes. This is the `asChild` substitute (fact e rules out cloneElement).
+   owns all classes. This prop-getter shape serves the useful part of `asChild`
+   without cloneElement (fact e rules out `Html.map`-style wrapping).
 2. **Message lift = `Emit::map` / emit closures**, not `Html::map` (fact e). The
    doc's "selection 1" (Elm-style `Html.map`) is dead; "selection 3" (emit closure
    composition) is first-class. Nested components use `@rabbita.cell` + `Cell::view()`.
 3. **`simple_cell` (Model-only `update`) fits side-effect-free primitives**; full
    `cell` (`(Cmd, Model)` update + `subscriptions`) is for primitives with effects
    (`rabbita:16,35`).
-4. **Native `<dialog>` carries Dialog's hard parts.** rabbita's `@dialog` package is
-   a thin binding over `HTMLDialogElement` (`dialog:9-13`, `dom:301-312`,
-   `html:67`); focus-trap / Esc / light-dismiss are browser-native. The feared
-   "Zag effects → custom subs" work mostly disappears.
+4. **Native `<dialog>` carries some Dialog hard parts, but not all.** rabbita's
+   `@dialog` package is a thin binding over `HTMLDialogElement.show_modal()` /
+   `close()` / `request_close()` (`rabbita/rabbita/dialog/dialog.mbt`,
+   `dom:302-307`, `html:67`). That binding evidence proves the native dialog
+   surface exists; it does **not** prove every expected dialog behavior is free.
+   Modal inertness / focus trapping and Escape close should be validated in P3;
+   light-dismiss is not assumed free and likely needs `closedby="any"` where
+   supported or explicit click handling. So the feared "Zag effects → custom
+   subs" work shrinks, but light-dismiss and focus-return details remain open.
 5. **Splitter/drag** is the one real `custom_sub` case: `on_mouse_move` exists at
    document level (fact d) but document `mouseup` does not — mirror the canonical
    `rabbita/rabbita/websocket/listen.mbt` SubLoader (or an overlay with
@@ -128,9 +136,11 @@ pins, and fix the loom example sites.
 - **P2 — Extract `lib/disclosure`** (`dowdiness/rabbita-disclosure`), mirroring
   `lib/resizable/src/resizable`: `Model`, `Msg`, `update`, `*_attrs`, `new`.
   Cell-ize only when composing stateful instances.
-- **P3 — Dialog primitive** on native `<dialog>`: validate the "focus-trap/Esc is
-  free" claim; settle controlled vs uncontrolled (config record: consumer `open` +
-  `on_open_change`, or self-held in a `cell`).
+- **P3 — Dialog primitive** on native `<dialog>`: validate modal inertness,
+  focus-trap, Escape close, focus return, and light-dismiss behavior in current
+  browsers. Do not assume backdrop click is free; decide between `closedby="any"`
+  (where supported) and explicit click handling. Settle controlled vs uncontrolled
+  (config record: consumer `open` + `on_open_change`, or self-held in a `cell`).
 - **P4 — Splitter primitive**: reuse `lib/resizable`'s document-`mouseup`
   `custom_sub` pattern; confirm it generalizes.
 - **P5 — Design-system layer**: Tailwind `@utility` presets + CSS-var theme +

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -81,7 +81,8 @@ in the type system.
 `examples/disclosure/` (registered in `moon.work`). Headless logic inline in
 `main/client.mbt`: `DisclosureModel` + `trigger_attrs`/`content_attrs` returning
 `@html.Attrs`; consumer `Section` records pair copy with behavior state; view maps
-sections onto native `<button>`/`<div>`; chevron driven **purely by
+sections onto native `<button>`/`<div>`; panels use `role="region"` with
+`aria-labelledby` pointing at stable trigger IDs; chevron is driven **purely by
 `aria-expanded`** in CSS (no extra markup). A small MoonBit test pins the TEA
 `Toggle` update behavior.
 
@@ -89,8 +90,9 @@ Browser-verified headless (warren `dev`/`build` core-dump in this WSL2 env — b
 even on the known-good `examples/resizable`; bypassed via `moon build --target js`
 + static server + Playwright chromium). **10/10 assertions, 0 console errors:**
 sections mount with correct initial state; `aria-controls` == panel `id`;
-`role="region"` present; independent toggle on click; `Enter` toggles focused
-trigger (native button a11y). Visual: on-brand, chevron rotates, panel shows/hides.
+`aria-labelledby` == trigger `id`; `role="region"` present; independent toggle
+on click; `Enter` toggles focused trigger (native button a11y). Visual: on-brand,
+chevron rotates, panel shows/hides.
 
 Validated learning: `hidden` attr gives correct a11y collapse but is instant — open
 question is animation (CSS grid-rows / `data-state`), deferred.

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -81,18 +81,18 @@ in the type system.
 `examples/disclosure/` (registered in `moon.work`). Headless logic inline in
 `main/client.mbt`: `DisclosureModel` + `trigger_attrs`/`content_attrs` returning
 `@html.Attrs`; consumer `Section` records pair copy with behavior state; view maps
-sections onto native `<button>`/`<div>`; panels use `role="region"` with
-`aria-labelledby` pointing at stable trigger IDs; chevron is driven **purely by
-`aria-expanded`** in CSS (no extra markup). A small MoonBit test pins the TEA
-`Toggle` update behavior.
+sections onto native `<button>`/`<div>`; `content_id` is the stable panel id
+referenced by `aria-controls`; chevron is driven **purely by `aria-expanded`** in
+CSS (no extra markup). The example is intentionally a stack of independent
+Disclosure widgets, not an Accordion, so panels are not exposed as `region`
+landmarks. A small MoonBit test pins the TEA `Toggle` update behavior.
 
 Browser-verified headless (warren `dev`/`build` core-dump in this WSL2 env — broken
 even on the known-good `examples/resizable`; bypassed via `moon build --target js`
 + static server + Playwright chromium). **10/10 assertions, 0 console errors:**
 sections mount with correct initial state; `aria-controls` == panel `id`;
-`aria-labelledby` == trigger `id`; `role="region"` present; independent toggle
-on click; `Enter` toggles focused trigger (native button a11y). Visual: on-brand,
-chevron rotates, panel shows/hides.
+independent toggle on click; `Enter` toggles focused trigger (native button a11y).
+Visual: on-brand, chevron rotates, panel shows/hides.
 
 Validated learning: `hidden` attr gives correct a11y collapse but is instant — open
 question is animation (CSS grid-rows / `data-state`), deferred.

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -2,8 +2,13 @@
 
 **Status:** findings (source-verified) + design
 **Date:** 2026-06-04
-**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `8381bef`)
+**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `8381bef`, also tagged `canopy-headless-ui-experiment-2026-06-04` on the fork)
 **PoC:** `examples/disclosure/` (browser-verified, see §4)
+
+**PR scope / done definition:** record the feasibility findings and land the
+Disclosure PoC as an experiment. Do **not** extract a reusable `lib/disclosure`,
+commit to an animation attribute contract, or adopt rabbita 0.12.3
+workspace-wide in this PR; those are separate follow-up decisions.
 
 ## Conclusion
 
@@ -102,8 +107,9 @@ sections mount with correct initial state; `aria-controls` == panel `id`;
 independent toggle on click; `Enter` toggles focused trigger (native button a11y).
 Visual: on-brand, chevron rotates, panel shows/hides.
 
-Validated learning: `hidden` attr gives correct a11y collapse but is instant — open
-question is animation (CSS grid-rows / `data-state`), deferred.
+Validated learning: `hidden` attr gives correct a11y collapse but is instant.
+This experiment does **not** reserve a public `data-state` contract; decide that
+when P1 polish or P2 extraction makes animation part of the primitive contract.
 
 ## 5. rabbita 0.12.3 adoption status
 
@@ -120,10 +126,12 @@ question is animation (CSS grid-rows / `data-state`), deferred.
   use the path) — bump to `0.12.3` for accuracy when adopting.
 
 This experiment PR points the `rabbita` gitlink at `8381bef`, which is published
-on the configured fork remote as `dowdiness/rabbita:update-0.12.3-patched` so
-fresh clones can resolve the submodule commit. The same branch is under review
-as `dowdiness/rabbita#1`; it is not merged to the fork's main branch, so keep
-that distinction when deciding whether to adopt 0.12.3 broadly.
+on the configured fork remote as `dowdiness/rabbita:update-0.12.3-patched` and
+also pinned by the separate fork tag `canopy-headless-ui-experiment-2026-06-04`,
+so fresh clones can resolve the submodule commit even if the review branch later
+moves. The same branch is under review as `dowdiness/rabbita#1`; it is not merged
+to the fork's main branch, so keep that distinction when deciding whether to
+adopt 0.12.3 broadly.
 
 Remaining to actually adopt 0.12.3 workspace-wide in canopy (out of scope for
 this experiment): merge/review the rabbita patch branch, bump the 6 version

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -2,7 +2,7 @@
 
 **Status:** findings (source-verified) + design
 **Date:** 2026-06-04
-**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, local branch `update-0.12.3-patched` `f6361f2`)
+**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `f6361f2`)
 **PoC:** `examples/disclosure/` (browser-verified, see §4)
 
 ## Conclusion
@@ -109,9 +109,15 @@ question is animation (CSS grid-rows / `data-state`), deferred.
 - The `"version": "0.12.2"` pins in 6 `moon.mod.json` files are advisory (path-deps
   use the path) — bump to `0.12.3` for accuracy when adopting.
 
-Remaining to actually adopt 0.12.3 in canopy (out of scope for this experiment):
-push patch `f6361f2` to fork `dowdiness/rabbita` (PR), update canopy submodule
-pointer (PR), bump the 6 version pins, fix the loom example sites.
+This experiment PR points the `rabbita` gitlink at `f6361f2`, which is published
+on the configured fork remote as `dowdiness/rabbita:update-0.12.3-patched` so
+fresh clones can resolve the submodule commit. The same branch is under review
+as `dowdiness/rabbita#1`; it is not merged to the fork's main branch, so keep
+that distinction when deciding whether to adopt 0.12.3 broadly.
+
+Remaining to actually adopt 0.12.3 workspace-wide in canopy (out of scope for
+this experiment): merge/review the rabbita patch branch, bump the 6 version
+pins, and fix the loom example sites.
 
 ## 6. Roadmap (phased; prose, not paste-ready)
 

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -1,0 +1,138 @@
+# Headless UI component library on rabbita × Tailwind — feasibility findings
+
+**Status:** findings (source-verified) + design
+**Date:** 2026-06-04
+**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, local branch `update-0.12.3-patched` `f6361f2`)
+**PoC:** `examples/disclosure/` (browser-verified, see §4)
+
+## Conclusion
+
+**Buildable, and more feasible than first assumed.** A Zag/Radix-style headless
+component library fits rabbita's TEA model cleanly via a two-layer split:
+
+- **Behavior layer** = TEA `Model`/`Msg`/`update` + pure functions that return
+  `@html.Attrs` (the `connect()` / `getTriggerProps()` equivalent). No styling.
+- **Design-system layer** = Tailwind `@utility` presets + CSS variables + a thin
+  MoonBit `enum Variant → to_class() -> String` helper. Lives in CSS, not types.
+
+Canopy **already ships this exact pattern** in `lib/resizable` + `examples/resizable`
+(`@resizable.Model::container_attrs()/handle_attrs()`). The PoC reproduces it for
+Disclosure. Radix's `asChild` (React `cloneElement`) cannot be reproduced at the
+type level (MoonBit traits: no type params / associated types / HKT), but its
+*intent* — spread a behavior's attrs onto a consumer-chosen element — is fully
+served by returning `@html.Attrs` and applying it via the element's `attrs?` param.
+
+## 1. Why
+
+Question raised: can we build a headless (unstyled, accessible, composition-based)
+UI primitive library on rabbita, with a Skeleton-style Tailwind token layer on top?
+The original analysis flagged five rabbita API facts as **unverifiable** (source
+not fetchable over the web). All five are now resolved from the vendored source.
+
+## 2. The five resolved facts (with citations)
+
+Paths are under `rabbita/rabbita/<pkg>/pkg.generated.mbti`.
+
+| # | Question | Answer | Evidence |
+|---|----------|--------|----------|
+| a | Do `@html` elements take `attrs?` | **Yes** — every element has `attrs? : Attrs`; low-level `node(String, Attrs, C)` also exists | `html:69` (`div`), `html:153` (`node`) |
+| b | Is `Attrs::class` public; ARIA surface? | **Yes**, and the full typed ARIA surface is public via the `Attrs::build()` builder | `html:333` (`build`), `:338` (`class`), `:270-322` (`aria_*`), `:412-442` (`on_*`) |
+| c | `@dom.MouseEvent` accessors | Two tiers: raw via `IsMouseEvent` (`get_client_x/_y`, `get_offset_x/_y`, `get_button`…); cooked `@common.Mouse::client_pos()/offset_pos() -> Pos{x,y}` | `dom:780-802`, `common` (`Mouse`) |
+| d | `@sub.on_mouse_up`? | **Absent** (observation confirmed). Present: `on_mouse_move`, `on_key_down/up`, `on_animation_frame`, `on_resize`, `on_scroll`, `on_url_*`, `on_visibility_change`, `every`. Document-level `mouseup` needs `custom_sub` | `sub:19-35`, `custom_sub` `sub:13` |
+| e | `Html::map`/`Cmd::map`/`Sub::map`? | **None exist.** The only map is `Emit::map(Self[A], (B) -> A) -> Self[B]` — the message-lift primitive | grep `::map` → `cmd:40` only |
+
+## 3. Architecture (validated)
+
+```
+Consumer app (TEA: own Model/Msg/update/view)
+  └─ Design-system layer   Tailwind @utility presets + CSS vars + enum Variant→to_class()
+       └─ Behavior layer   Model/Msg/update + *_attrs(state, emit) -> @html.Attrs
+            └─ rabbita      @html / @cmd / @sub / @dom / @dialog
+```
+
+Key design decisions, each grounded in a verified fact:
+
+1. **`Attrs::build()` chaining is the rabbita-native `getTriggerProps()`** — typed,
+   ergonomic: `.aria_expanded(..).aria_controls(..).on_click(..)` (fact b). A
+   primitive returns `@html.Attrs`; the consumer spreads it via `attrs=...` and
+   owns all classes. This is the `asChild` substitute (fact e rules out cloneElement).
+2. **Message lift = `Emit::map` / emit closures**, not `Html::map` (fact e). The
+   doc's "selection 1" (Elm-style `Html.map`) is dead; "selection 3" (emit closure
+   composition) is first-class. Nested components use `@rabbita.cell` + `Cell::view()`.
+3. **`simple_cell` (Model-only `update`) fits side-effect-free primitives**; full
+   `cell` (`(Cmd, Model)` update + `subscriptions`) is for primitives with effects
+   (`rabbita:16,35`).
+4. **Native `<dialog>` carries Dialog's hard parts.** rabbita's `@dialog` package is
+   a thin binding over `HTMLDialogElement` (`dialog:9-13`, `dom:301-312`,
+   `html:67`); focus-trap / Esc / light-dismiss are browser-native. The feared
+   "Zag effects → custom subs" work mostly disappears.
+5. **Splitter/drag** is the one real `custom_sub` case: `on_mouse_move` exists at
+   document level (fact d) but document `mouseup` does not — mirror the canonical
+   `rabbita/rabbita/websocket/listen.mbt` SubLoader (or an overlay with
+   `Attrs::on_mouseup`). `lib/resizable` already does exactly this.
+
+The design-system layer is MoonBit-independent: rabbita view emits `class="…"`
+strings, so Skeleton's approach (preset = Tailwind `@utility`, theme = CSS vars +
+`data-theme`) applies unchanged. Keep variants as `enum Variant → to_class()`, not
+in the type system.
+
+## 4. PoC result — Disclosure
+
+`examples/disclosure/` (registered in `moon.work`). Headless logic inline in
+`main/client.mbt`: `DisclosureModel` + `trigger_attrs`/`content_attrs` returning
+`@html.Attrs`; consumer `Section` records pair copy with behavior state; view maps
+sections onto native `<button>`/`<div>`; chevron driven **purely by
+`aria-expanded`** in CSS (no extra markup). A small MoonBit test pins the TEA
+`Toggle` update behavior.
+
+Browser-verified headless (warren `dev`/`build` core-dump in this WSL2 env — broken
+even on the known-good `examples/resizable`; bypassed via `moon build --target js`
++ static server + Playwright chromium). **10/10 assertions, 0 console errors:**
+sections mount with correct initial state; `aria-controls` == panel `id`;
+`role="region"` present; independent toggle on click; `Enter` toggles focused
+trigger (native button a11y). Visual: on-brand, chevron rotates, panel shows/hides.
+
+Validated learning: `hidden` attr gives correct a11y collapse but is instant — open
+question is animation (CSS grid-rows / `data-state`), deferred.
+
+## 5. rabbita 0.12.3 adoption status
+
+`moon check` (full workspace) is **green** against 0.12.3 + patch after a single fix:
+
+- **One breaking call site** from upstream PR #117 (void elements lose `children`):
+  `examples/ideal/main/view_actions.mbt` — removed a trailing `[@html.text("")]`
+  positional child from `@html.input(...)`. (Two more in
+  `loom/incr/examples/typed_spreadsheet_rabbita_demo/view.mbt` — loom submodule,
+  not a canopy workspace member; only matters if loom's examples are built.)
+- `moon.mod` migration (0.12.3) resolves fine through path-deps; no canopy file
+  auto-migrated.
+- The `"version": "0.12.2"` pins in 6 `moon.mod.json` files are advisory (path-deps
+  use the path) — bump to `0.12.3` for accuracy when adopting.
+
+Remaining to actually adopt 0.12.3 in canopy (out of scope for this experiment):
+push patch `f6361f2` to fork `dowdiness/rabbita` (PR), update canopy submodule
+pointer (PR), bump the 6 version pins, fix the loom example sites.
+
+## 6. Roadmap (phased; prose, not paste-ready)
+
+- **P1 — Polish Disclosure**: expand/collapse animation via CSS `data-state` +
+  grid-rows; keep `aria-expanded`/`hidden` as the source of truth.
+- **P2 — Extract `lib/disclosure`** (`dowdiness/rabbita-disclosure`), mirroring
+  `lib/resizable/src/resizable`: `Model`, `Msg`, `update`, `*_attrs`, `new`.
+  Cell-ize only when composing stateful instances.
+- **P3 — Dialog primitive** on native `<dialog>`: validate the "focus-trap/Esc is
+  free" claim; settle controlled vs uncontrolled (config record: consumer `open` +
+  `on_open_change`, or self-held in a `cell`).
+- **P4 — Splitter primitive**: reuse `lib/resizable`'s document-`mouseup`
+  `custom_sub` pattern; confirm it generalizes.
+- **P5 — Design-system layer**: Tailwind `@utility` presets + CSS-var theme +
+  `enum Variant → to_class()`. No variant logic in types.
+
+## 7. Caveats
+
+- All PoC artifacts under `/tmp/disc-preview/` are ephemeral (moon-built JS + host
+  page); regenerate with `cd examples/disclosure && moon build --target js`.
+- `asChild`'s DX (type-safe single-child prop merge) is genuinely unavailable;
+  the `@html.Attrs` spread is the accepted substitute.
+- Native SSR for the behavior layer is possible (pure Model/Msg/update is target-
+  agnostic) but `@html`/`@dom` view code stays JS-only.

--- a/examples/disclosure/README.md
+++ b/examples/disclosure/README.md
@@ -1,0 +1,31 @@
+# Disclosure example
+
+Smallest working PoC of the **headless behavior + local styling** pattern on
+rabbita 0.12.3, mirroring `examples/resizable`.
+
+- `DisclosureModel` (in `main/client.mbt`) owns state (`open`) and emits ARIA
+  via `trigger_attrs` / `content_attrs` returning `@html.Attrs` — no styling.
+- Section copy and behavior state are paired in `Section` records; the view maps
+  sections instead of indexing fixed positions.
+- The consumer `view` spreads those attrs onto `<button>` / `<div>` via
+  `attrs=...` and supplies all classes locally (`public/styles.css`).
+- Message lift uses an emit closure (`emit(Toggle(index))`).
+
+## Run
+
+```bash
+moon install moonbit-community/warren   # once
+cd examples/disclosure
+warren dev
+```
+
+Open the local URL shown by Warren. If Warren is unavailable in your environment,
+run `moon build --target js` from this directory and static-serve the generated
+bundle with a host page containing `<div id="app"></div>`.
+
+## Manual check
+
+- Click a header: its panel toggles; the chevron rotates (driven by
+  `aria-expanded`, no extra markup).
+- Tab to a header and press Enter/Space: it toggles (native `<button>`).
+- The middle section starts expanded.

--- a/examples/disclosure/README.md
+++ b/examples/disclosure/README.md
@@ -5,13 +5,17 @@ rabbita 0.12.3, mirroring `examples/resizable`.
 
 - `DisclosureModel` (in `main/client.mbt`) owns state (`open`) and emits ARIA
   via `trigger_attrs` / `content_attrs` returning `@html.Attrs` — no styling.
-  Each trigger receives a stable `id`; each `role="region"` panel points back
-  with `aria-labelledby`.
+  `content_id` is the stable panel id referenced by `aria-controls`; it must be
+  unique on the page.
 - Section copy and behavior state are paired in `Section` records; the view maps
   sections instead of indexing fixed positions.
 - The consumer `view` spreads those attrs onto `<button>` / `<div>` via
   `attrs=...` and supplies all classes locally (`public/styles.css`).
 - Message lift uses an emit closure (`emit(Toggle(index))`).
+- This is a stack of independent Disclosure widgets, not a single Accordion:
+  multiple sections may be open, and panels are not exposed as landmarks.
+- The PoC keeps the behavior helpers package-private. Extracting `lib/disclosure`
+  is the P2 step where `DisclosureModel` and `*_attrs` would become public API.
 
 ## Run
 
@@ -31,4 +35,4 @@ bundle with a host page containing `<div id="app"></div>`.
   `aria-expanded`, no extra markup).
 - Tab to a header and press Enter/Space: it toggles (native `<button>`).
 - The middle section starts expanded.
-- Each panel's `aria-labelledby` references its trigger's `id`.
+- Each trigger's `aria-controls` references its panel `id`.

--- a/examples/disclosure/README.md
+++ b/examples/disclosure/README.md
@@ -5,6 +5,8 @@ rabbita 0.12.3, mirroring `examples/resizable`.
 
 - `DisclosureModel` (in `main/client.mbt`) owns state (`open`) and emits ARIA
   via `trigger_attrs` / `content_attrs` returning `@html.Attrs` — no styling.
+  Each trigger receives a stable `id`; each `role="region"` panel points back
+  with `aria-labelledby`.
 - Section copy and behavior state are paired in `Section` records; the view maps
   sections instead of indexing fixed positions.
 - The consumer `view` spreads those attrs onto `<button>` / `<div>` via
@@ -29,3 +31,4 @@ bundle with a host page containing `<div id="app"></div>`.
   `aria-expanded`, no extra markup).
 - Tab to a header and press Enter/Space: it toggles (native `<button>`).
 - The middle section starts expanded.
+- Each panel's `aria-labelledby` references its trigger's `id`.

--- a/examples/disclosure/main/client.mbt
+++ b/examples/disclosure/main/client.mbt
@@ -1,0 +1,177 @@
+// Headless Disclosure PoC.
+//
+// The "behavior layer" (DisclosureModel + its *_attrs methods) carries state
+// and ARIA only — no styling. The consumer's `view` spreads those attrs onto
+// its own elements via `attrs=...` and supplies all classes locally. This
+// mirrors `examples/resizable` / `lib/resizable`, which is canopy's existing
+// instance of the same pattern (Zag `connect()` / Radix prop-spreading).
+
+///|
+using @html {div, button, h1, p}
+
+///|
+using @rabbita {type Cmd, type Emit, type Html}
+
+// ── Behavior layer (headless) ───────────────────────────────────────────────
+
+///|
+struct DisclosureModel {
+  open : Bool
+  content_id : String
+}
+
+///|
+fn DisclosureModel::new(
+  content_id~ : String,
+  open? : Bool = false,
+) -> DisclosureModel {
+  { open, content_id }
+}
+
+///|
+fn DisclosureModel::toggle(self : DisclosureModel) -> DisclosureModel {
+  { ..self, open: !self.open }
+}
+
+///|
+/// Trigger attributes: ARIA state + click wiring. No classes, no styling.
+fn DisclosureModel::trigger_attrs(
+  self : DisclosureModel,
+  on_toggle : Cmd,
+) -> @html.Attrs {
+  @html.Attrs::build()
+  .aria_expanded(if self.open { "true" } else { "false" })
+  .aria_controls(self.content_id)
+  .on_click(_evt => on_toggle)
+}
+
+///|
+/// Content-region attributes: identity + collapsed state.
+fn DisclosureModel::content_attrs(self : DisclosureModel) -> @html.Attrs {
+  @html.Attrs::build().id(self.content_id).role("region").hidden(!self.open)
+}
+
+// ── Consumer app ────────────────────────────────────────────────────────────
+
+///|
+struct Section {
+  title : String
+  body : String
+  disclosure : DisclosureModel
+}
+
+///|
+fn Section::new(
+  title~ : String,
+  body~ : String,
+  content_id~ : String,
+  open? : Bool = false,
+) -> Section {
+  { title, body, disclosure: DisclosureModel::new(content_id~, open~) }
+}
+
+///|
+fn Section::toggle_disclosure(self : Section) -> Section {
+  { ..self, disclosure: self.disclosure.toggle() }
+}
+
+///|
+struct Model {
+  sections : Array[Section]
+}
+
+///|
+enum Msg {
+  Toggle(Int)
+}
+
+///|
+let initial_model : Model = {
+  sections: [
+    Section::new(
+      title="Structure reveals meaning",
+      body="Color, spacing, and nesting communicate relationships before labels do.",
+      content_id="sec-structure",
+    ),
+    Section::new(
+      title="Progressive disclosure",
+      body="Clean and focused by default; reveal depth on demand.",
+      content_id="sec-progressive",
+      open=true,
+    ),
+    Section::new(
+      title="Typography carries weight",
+      body="Inter for UI, JetBrains Mono for code — clear zones, calm confidence.",
+      content_id="sec-typography",
+    ),
+  ],
+}
+
+///|
+fn update(msg : Msg, model : Model) -> Model {
+  match msg {
+    Toggle(i) =>
+      {
+        sections: model.sections.mapi((j, section) => {
+          if j == i {
+            section.toggle_disclosure()
+          } else {
+            section
+          }
+        }),
+      }
+  }
+}
+
+///|
+test "toggle updates selected section only" {
+  let toggled = update(Toggle(0), initial_model)
+  match toggled.sections {
+    [first, second, third] => {
+      assert_eq(first.disclosure.open, true)
+      assert_eq(second.disclosure.open, true)
+      assert_eq(third.disclosure.open, false)
+    }
+    _ => fail("expected three disclosure sections")
+  }
+}
+
+///|
+fn section_view(emit : Emit[Msg], index : Int, section : Section) -> Html {
+  let disclosure = section.disclosure
+  div(class="disclosure", [
+    button(
+      class="disclosure-trigger",
+      attrs=disclosure.trigger_attrs(emit(Toggle(index))),
+      section.title,
+    ),
+    div(class="disclosure-panel", attrs=disclosure.content_attrs(), [
+      p(section.body),
+    ]),
+  ])
+}
+
+///|
+fn view(emit : Emit[Msg], model : Model) -> Html {
+  div(class="page", [
+    div(class="hero", [
+      p(class="eyebrow", "Headless UI · rabbita 0.12.3"),
+      h1("Disclosure"),
+      p(
+        class="subtitle",
+        "Behavior (state + ARIA) is reusable; markup and classes stay local.",
+      ),
+    ]),
+    div(
+      class="stack",
+      model.sections.mapi((i, section) => section_view(emit, i, section)),
+    ),
+  ])
+}
+
+///|
+#cfg(target="js")
+fn main {
+  let app = @rabbita.simple_cell(model=initial_model, update~, view~)
+  @rabbita.new(app).mount("app")
+}

--- a/examples/disclosure/main/client.mbt
+++ b/examples/disclosure/main/client.mbt
@@ -5,6 +5,8 @@
 // its own elements via `attrs=...` and supplies all classes locally. This
 // mirrors `examples/resizable` / `lib/resizable`, which is canopy's existing
 // instance of the same pattern (Zag `connect()` / Radix prop-spreading).
+// This PoC keeps the behavior layer package-private; P2 extraction would be the
+// point where these helpers become a library API.
 
 ///|
 using @html {div, button, h1, p}
@@ -21,6 +23,7 @@ struct DisclosureModel {
 }
 
 ///|
+/// Create disclosure state for a panel whose `content_id` is unique on the page.
 fn DisclosureModel::new(
   content_id~ : String,
   open? : Bool = false,
@@ -34,31 +37,22 @@ fn DisclosureModel::toggle(self : DisclosureModel) -> DisclosureModel {
 }
 
 ///|
-fn DisclosureModel::trigger_id(self : DisclosureModel) -> String {
-  self.content_id + "-trigger"
-}
-
-///|
 /// Trigger attributes: ARIA state + click wiring. No classes, no styling.
 fn DisclosureModel::trigger_attrs(
   self : DisclosureModel,
   on_toggle : Cmd,
 ) -> @html.Attrs {
   @html.Attrs::build()
-  .id(self.trigger_id())
   .aria_expanded(if self.open { "true" } else { "false" })
   .aria_controls(self.content_id)
   .on_click(_evt => on_toggle)
 }
 
 ///|
-/// Content-region attributes: identity + collapsed state.
+/// Content attributes: identity + collapsed state. No landmark role; this PoC is
+/// a stack of independent Disclosure widgets, not an Accordion.
 fn DisclosureModel::content_attrs(self : DisclosureModel) -> @html.Attrs {
-  @html.Attrs::build()
-  .id(self.content_id)
-  .role("region")
-  .aria_labelledby(self.trigger_id())
-  .hidden(!self.open)
+  @html.Attrs::build().id(self.content_id).hidden(!self.open)
 }
 
 // ── Consumer app ────────────────────────────────────────────────────────────

--- a/examples/disclosure/main/client.mbt
+++ b/examples/disclosure/main/client.mbt
@@ -34,12 +34,18 @@ fn DisclosureModel::toggle(self : DisclosureModel) -> DisclosureModel {
 }
 
 ///|
+fn DisclosureModel::trigger_id(self : DisclosureModel) -> String {
+  self.content_id + "-trigger"
+}
+
+///|
 /// Trigger attributes: ARIA state + click wiring. No classes, no styling.
 fn DisclosureModel::trigger_attrs(
   self : DisclosureModel,
   on_toggle : Cmd,
 ) -> @html.Attrs {
   @html.Attrs::build()
+  .id(self.trigger_id())
   .aria_expanded(if self.open { "true" } else { "false" })
   .aria_controls(self.content_id)
   .on_click(_evt => on_toggle)
@@ -48,7 +54,11 @@ fn DisclosureModel::trigger_attrs(
 ///|
 /// Content-region attributes: identity + collapsed state.
 fn DisclosureModel::content_attrs(self : DisclosureModel) -> @html.Attrs {
-  @html.Attrs::build().id(self.content_id).role("region").hidden(!self.open)
+  @html.Attrs::build()
+  .id(self.content_id)
+  .role("region")
+  .aria_labelledby(self.trigger_id())
+  .hidden(!self.open)
 }
 
 // ── Consumer app ────────────────────────────────────────────────────────────

--- a/examples/disclosure/main/moon.pkg
+++ b/examples/disclosure/main/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+}
+
+supported_targets = "js"
+
+options(
+  "is-main": true,
+)

--- a/examples/disclosure/main/pkg.generated.mbti
+++ b/examples/disclosure/main/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "example/disclosure/main"
+
+// Values
+
+// Errors
+
+// Types and methods
+type DisclosureModel
+
+type Model
+
+type Msg
+
+type Section
+
+// Type aliases
+
+// Traits
+

--- a/examples/disclosure/moon.mod.json
+++ b/examples/disclosure/moon.mod.json
@@ -1,0 +1,16 @@
+{
+  "name": "example/disclosure",
+  "version": "0.1.0",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.3"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "description": "Headless disclosure demo (rabbita)",
+  "preferred-target": "js"
+}

--- a/examples/disclosure/public/styles.css
+++ b/examples/disclosure/public/styles.css
@@ -1,0 +1,122 @@
+:root {
+  --base: #1a1a2e;
+  --surface: #21213a;
+  --surface-2: #2a2a48;
+  --border: #34345a;
+  --accent: #8250df;
+  --accent-2: #c792ea;
+  --text: #e7e7f4;
+  --muted: #9a9ac0;
+  --string: #c3e88d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(1200px 600px at 70% -10%, #232342 0%, var(--base) 60%);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 72px 24px 96px;
+}
+
+.hero {
+  margin-bottom: 40px;
+}
+
+.eyebrow {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin: 0 0 8px;
+}
+
+.hero h1 {
+  font-size: 44px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  margin: 0 0 12px;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 52ch;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.disclosure {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+  overflow: hidden;
+}
+
+.disclosure-trigger {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  font: inherit;
+  font-size: 17px;
+  font-weight: 550;
+  padding: 18px 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: background 140ms ease;
+}
+
+.disclosure-trigger:hover {
+  background: rgba(130, 80, 223, 0.08);
+}
+
+.disclosure-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Chevron driven purely by ARIA state — no extra markup. */
+.disclosure-trigger::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--accent-2);
+  border-bottom: 2px solid var(--accent-2);
+  transform: rotate(-45deg);
+  transition: transform 160ms ease;
+  flex: none;
+}
+
+.disclosure-trigger[aria-expanded="true"]::before {
+  transform: rotate(45deg);
+}
+
+.disclosure-panel {
+  padding: 0 20px 20px 40px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.disclosure-panel p {
+  margin: 0;
+}

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -87,7 +87,7 @@ fn view_name_prompt(
       [@html.text(model.overlay.name_error)],
     )
   } else {
-    @html.text("")
+    @html.nothing
   }
   let on_keydown_handler = fn(kb : @html.Keyboard) {
     let key = kb.key()
@@ -110,7 +110,6 @@ fn view_name_prompt(
         autofocus=true,
         on_input=fn(value) { dispatch(NamePromptInput(value)) },
         attrs=@html.Attrs::build().aria_label(prompt_label),
-        [@html.text("")],
       ),
     ]),
     error_el,
@@ -158,7 +157,7 @@ fn view_action_overlay(
   model : Model,
 ) -> @rabbita.Html {
   if !model.overlay.visible {
-    return @html.text("")
+    return @html.nothing
   }
   // Position the overlay panel using inline style from the anchor rect
   let top = model.overlay.anchor_top
@@ -189,7 +188,7 @@ fn view_action_overlay(
         }
       },
       attrs=@html.Attrs::build().aria_hidden("true").tabindex(-1),
-      [@html.text("")],
+      @html.nothing,
     ),
     // Overlay panel — receives focus on open via after_render in main.mbt
     @html.div(

--- a/moon.work
+++ b/moon.work
@@ -14,4 +14,5 @@ members = [
   "./examples/canvas",
   "./examples/codemirror_demo",
   "./examples/resizable",
+  "./examples/disclosure",
 ]


### PR DESCRIPTION
## Summary

- Document source-verified feasibility findings for a Zag/Radix-style headless UI layer on rabbita.
- Add `examples/disclosure`, a small browser-verified PoC that returns headless `@html.Attrs` and keeps styling local.
- Point the experiment at rabbita 0.12.3 + canopy's existing `diff_subs/update_tagger` patch, with the one required Ideal `input` call-site fix.

Note: this PR closes at **findings doc + Disclosure PoC**. It is an experiment-local rabbita submodule move, **not** the workspace-wide rabbita 0.12.3 adoption, and it does not extract `lib/disclosure` or commit to an animation `data-state` API. The referenced rabbita commit is published on `dowdiness/rabbita:update-0.12.3-patched` and pinned by tag `canopy-headless-ui-experiment-2026-06-04`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Model::container_attrs` / `Model::handle_attrs` | `lib/resizable/src/resizable` | Yes, as the reference pattern | N/A |
| `@html.Attrs::build()` + typed ARIA/event setters | `rabbita/rabbita/html` | Yes | N/A |
| `@html.nothing` | `rabbita/rabbita/html` | Yes | N/A |
| `Array::mapi` | `moonbitlang/core/array` | Yes | N/A |

New helpers added:

- `DisclosureModel::{new,toggle,trigger_attrs,content_attrs}` — local PoC behavior layer for Disclosure state + ARIA attrs.
- `Section::{new,toggle_disclosure}` — local example-only pairing of copy with behavior state; avoids fixed-position indexing in the view.
- `section_view` — local rendering helper that spreads behavior attrs onto consumer-owned markup.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes — only the new disclosure generated interface is added
- [x] JS rebuild run if web is affected: `NEW_MOON_MOD=0 moon build --target js --release`

Additional validation:

```bash
cd examples/disclosure && NEW_MOON_MOD=0 moon build --target js
NEW_MOON_MOD=0 moon build --release
```

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon build --target js --release
```

