### PR TITLE
docs: record rabbita dialog spike findings

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -132,6 +132,21 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 7. Code Cleanup
 
+- [ ] Resolve the forked Rabbita patch provenance/adoption path.
+  Why: Canopy currently pins the `rabbita` submodule to the forked 0.12.3 patch commit/tag used by the headless-UI experiment. The important patch is the `diff_subs` `update_tagger` behavior needed by canonical `custom_sub` bindings; the fork PR is provenance, not workspace-wide adoption by itself.
+  Plan: `docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md` and `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` §P2.0.
+  Exit: either the patch lands upstream and Canopy updates to an upstream Rabbita release, or the maintained fork/tag policy is documented and the submodule pointer/version pins are updated deliberately; unrelated `closedby` and Warren fixes stay separate.
+
+- [ ] Upstream Rabbita native-dialog `closedby` attribute support.
+  Why: the P3 dialog spike found `@dialog.show(... modal=true)` already calls native `showModal()`, but backdrop light-dismiss in Chromium depends on emitting `closedby="any"`; Rabbita currently has no public `closedby` attr. MDN marks the `HTMLDialogElement.closedBy` property as non-Baseline, so scope this as an attribute emission API only — no behavior guarantee or polyfill.
+  Plan: Rabbita issue/PR (not opened yet); local prototype is in the rabbita submodule branch `codex/dialog-closedby-attr` with `Attrs::closedby`, `dialog(closedby?)`, docs, and html-package tests.
+  Exit: upstream Rabbita either accepts a limited-support `closedby` attribute API and Canopy updates the submodule, or records a decision to keep explicit backdrop handling in Canopy instead.
+
+- [ ] Report/fix Warren dangling-symlink discovery failure.
+  Why: `warren build` can abort while walking Canopy's workspace root when it hits a dangling symlink such as `loom/target -> _build` before `loom/_build` exists: `OSError(@fs.kind(): ".../loom/target": No such file or directory)`. This is not yet proven WSL2-specific; current evidence points to discovery calling `@fs.kind(path)` without first checking `@fs.exists(path)`.
+  Plan: Rabbita/Warren issue or narrow PR (not opened yet) with a minimal workspace repro and a discovery-walk guard for missing/dangling paths.
+  Exit: Warren skips dangling/missing paths during package discovery; the repro passes; Canopy examples no longer need the static-server workaround for this failure mode.
+
 - [ ] Upgrade `rle` consumers to `dowdiness/rle` 0.2.1 and constructor-style APIs.
   Why: the stale `feature/container-phase3-blockdoc-sync` branch only bumped the `rle` submodule pointer to v0.2.1. The actual consumer modules still pin `dowdiness/rle` 0.2.0, and rle 0.2.1 deprecates `Rle::new()` / `PrefixSums::new()`.
   Exit: `lib/btree`, `event-graph-walker`, and `order-tree` resolve the intended `dowdiness/rle` version, downstream code uses custom constructors such as `Rle()` / `PrefixSums()`, and CI passes.

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -4,6 +4,7 @@
 **Date:** 2026-06-04
 **Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `8381bef`, also tagged `canopy-headless-ui-experiment-2026-06-04` on the fork)
 **PoC:** `examples/disclosure/` (browser-verified, see §4)
+**Follow-up:** P3 native Dialog spike recorded in §5 (docs-only; no `lib/dialog` extraction)
 
 **PR scope / done definition:** record the feasibility findings and land the
 Disclosure PoC as an experiment. Do **not** extract a reusable `lib/disclosure`,
@@ -111,7 +112,47 @@ Validated learning: `hidden` attr gives correct a11y collapse but is instant.
 This experiment does **not** reserve a public `data-state` contract; decide that
 when P1 polish or P2 extraction makes animation part of the primitive contract.
 
-## 5. rabbita 0.12.3 adoption status
+## 5. P3 result — native Dialog spike
+
+A narrow throwaway spike (not landed as an example or library) was run after PR
+#501 merged, starting from `origin/main` at `7f0888d` with the `rabbita`
+submodule at `8381bef`. The harness rendered one native `<dialog>` and used
+Playwright/Chromium to drive focus, Tab, Escape, page-control clicks, backdrop
+clicks, and a `closedby="any"` injection. Injection was necessary because the
+pinned Rabbita public API cannot emit `closedby`: `Attrs::attribute` is internal
+and there is no `Attrs::closedby` / `dialog(closedby?)` yet.
+
+Findings:
+
+- `@dialog.show("dialog-spike", modal=true)` is Rabbita's command wrapper over
+  native `showModal()`. In Chromium it opened a real modal top-layer dialog;
+  the autofocus input was focused. Tab did not reach page controls (observed
+  sequence: `dialog-input -> dialog-close -> BODY -> dialog-input`). Clicking a
+  page button behind the modal kept the page-click counter at `0` and did not
+  focus that page button.
+- Escape emitted Rabbita `on_cancel`. Rabbita's `push_cancel` calls
+  `prevent_default()`, so a dialog with `on_cancel` does not close automatically;
+  the app must decide whether to close. The spike returned
+  `@dialog.close(..., return_value="cancelled")` from `update`, then received
+  `on_close` with the same return value.
+- Chromium returned focus to the trigger (`#open-modal`) after Escape, explicit
+  close-button close, and `closedby="any"` backdrop close.
+- Backdrop click is `closedby`-dependent. Without `closedby`, backdrop click kept
+  the dialog open and focused the dialog. With `closedby="any"`, Chromium
+  light-dismissed and emitted `cancel` followed by `close` through the spike's
+  explicit cancel-close path.
+- If Rabbita gains `closedby` support, scope it as an attribute emission API
+  only. MDN marks `HTMLDialogElement.closedBy` as non-Baseline, so consumers
+  still need a fallback or an explicit browser-support decision; Rabbita should
+  not claim a light-dismiss polyfill.
+
+Implication: a future Dialog primitive can lean on native `showModal()` for the
+Chromium modal/top-layer/inert/focus-return behavior observed here, but the
+primitive must own cancel-close policy and must choose between limited-support
+`closedby` and explicit backdrop handling for light-dismiss. Do not extract
+`lib/dialog` until a real Canopy consumer exists.
+
+## 6. rabbita 0.12.3 adoption status
 
 `moon check` (full workspace) is **green** against 0.12.3 + patch after a single fix:
 
@@ -137,24 +178,24 @@ Remaining to actually adopt 0.12.3 workspace-wide in canopy (out of scope for
 this experiment): merge/review the rabbita patch branch, bump the 6 version
 pins, and fix the loom example sites.
 
-## 6. Roadmap (phased; prose, not paste-ready)
+## 7. Roadmap (phased; prose, not paste-ready)
 
 - **P1 — Polish Disclosure**: expand/collapse animation via CSS `data-state` +
   grid-rows; keep `aria-expanded`/`hidden` as the source of truth.
 - **P2 — Extract `lib/disclosure`** (`dowdiness/rabbita-disclosure`), mirroring
   `lib/resizable/src/resizable`: `Model`, `Msg`, `update`, `*_attrs`, `new`.
   Cell-ize only when composing stateful instances.
-- **P3 — Dialog primitive** on native `<dialog>`: validate modal inertness,
-  focus-trap, Escape close, focus return, and light-dismiss behavior in current
-  browsers. Do not assume backdrop click is free; decide between `closedby="any"`
-  (where supported) and explicit click handling. Settle controlled vs uncontrolled
-  (config record: consumer `open` + `on_open_change`, or self-held in a `cell`).
+- **P3 — Dialog primitive** on native `<dialog>`: spike complete (§5). Before
+  extracting anything, wait for a real consumer and decide cancel-close policy,
+  controlled vs uncontrolled shape (consumer `open` + `on_open_change`, or
+  self-held in a `cell`), and light-dismiss strategy (`closedby="any"` where
+  supported vs explicit backdrop handling).
 - **P4 — Splitter primitive**: reuse `lib/resizable`'s document-`mouseup`
   `custom_sub` pattern; confirm it generalizes.
 - **P5 — Design-system layer**: Tailwind `@utility` presets + CSS-var theme +
   `enum Variant → to_class()`. No variant logic in types.
 
-## 7. Caveats
+## 8. Caveats
 
 - All PoC artifacts under `/tmp/disc-preview/` are ephemeral (moon-built JS + host
   page); regenerate with `cd examples/disclosure && moon build --target js`.


### PR DESCRIPTION
## Summary
- record P3 native dialog spike findings in the Rabbita headless UI feasibility doc
- add active TODO follow-ups for Rabbita closedby, Warren discovery, and forked Rabbita patch adoption
- keep this PR docs-only; no dialog library extraction and no Rabbita submodule bump

## Validation
- NEW_MOON_MOD=0 moon check
- NEW_MOON_MOD=0 moon test

## Reuse check
- Reused Rabbita's existing @dialog.show(... modal=true) / native showModal binding as the basis for the spike conclusions.
- Reused the existing headless-UI feasibility plan as the canonical record instead of adding a second plan or library API.
- Did not extract a new helper or primitive; future lib/dialog remains gated on a real consumer.