### PR TITLE
chore(rabbita): adopt v0.12.4 patched

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -132,19 +132,15 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 7. Code Cleanup
 
-- [ ] Resolve the forked Rabbita patch provenance/adoption path.
-  Why: Canopy currently pins the `rabbita` submodule to the forked 0.12.3 patch commit/tag used by the headless-UI experiment. The important patch is the `diff_subs` `update_tagger` behavior needed by canonical `custom_sub` bindings; the fork PR is provenance, not workspace-wide adoption by itself.
-  Plan: `docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md` and `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` §P2.0.
-  Exit: either the patch lands upstream and Canopy updates to an upstream Rabbita release, or the maintained fork/tag policy is documented and the submodule pointer/version pins are updated deliberately; unrelated `closedby` and Warren fixes stay separate.
+- [x] Resolve the forked Rabbita patch provenance/adoption path.
+  Shipped 2026-06-05: Canopy now points `rabbita` at `5f828eb` on `dowdiness/rabbita:update-0.12.4-patched`, pinned by tag `canopy-rabbita-v0.12.4-patched-2026-06-05`. This adopts upstream `rabbita-v0.12.4` plus Canopy's fork-only `diff_subs/update_tagger` patch, and the in-repo Rabbita path-dep pins now say `0.12.4`. If the patch lands upstream later, repoint to the upstream release; Warren remains separate.
 
-- [ ] Upstream Rabbita native-dialog `closedby` attribute support.
-  Why: the P3 dialog spike found `@dialog.show(... modal=true)` already calls native `showModal()`, but backdrop light-dismiss in Chromium depends on emitting `closedby="any"`; Rabbita currently has no public `closedby` attr. MDN marks the `HTMLDialogElement.closedBy` property as non-Baseline, so scope this as an attribute emission API only — no behavior guarantee or polyfill.
-  Plan: Rabbita issue/PR (not opened yet); local prototype is in the rabbita submodule branch `codex/dialog-closedby-attr` with `Attrs::closedby`, `dialog(closedby?)`, docs, and html-package tests.
-  Exit: upstream Rabbita either accepts a limited-support `closedby` attribute API and Canopy updates the submodule, or records a decision to keep explicit backdrop handling in Canopy instead.
+- [x] Upstream Rabbita native-dialog `closedby` attribute support.
+  Shipped upstream in Rabbita PR #118 and release `rabbita-v0.12.4`, then adopted by Canopy through the patched fork gitlink above. Scope remains intentionally narrow: `Attrs::closedby` and `dialog(closedby?)` emit the limited-support attribute only; they do not polyfill light-dismiss behavior or guarantee non-Baseline browser support.
 
 - [ ] Report/fix Warren dangling-symlink discovery failure.
   Why: `warren build` can abort while walking Canopy's workspace root when it hits a dangling symlink such as `loom/target -> _build` before `loom/_build` exists: `OSError(@fs.kind(): ".../loom/target": No such file or directory)`. This is not yet proven WSL2-specific; current evidence points to discovery calling `@fs.kind(path)` without first checking `@fs.exists(path)`.
-  Plan: Rabbita/Warren issue or narrow PR (not opened yet) with a minimal workspace repro and a discovery-walk guard for missing/dangling paths.
+  Plan: upstream issue `moonbit-community/rabbita#119` is open; follow with a narrow PR containing a minimal workspace repro and a discovery-walk guard for missing/dangling paths.
   Exit: Warren skips dangling/missing paths during package discovery; the repro passes; Canopy examples no longer need the static-server workaround for this failure mode.
 
 - [ ] Upgrade `rle` consumers to `dowdiness/rle` 0.2.1 and constructor-style APIs.

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -2,14 +2,15 @@
 
 **Status:** findings (source-verified) + design
 **Date:** 2026-06-04
-**Verified against:** vendored `rabbita/` submodule at **0.12.3** (upstream `moonbit-community/rabbita` main `e3865b2` + canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.3-patched` at `8381bef`, also tagged `canopy-headless-ui-experiment-2026-06-04` on the fork)
+**Verified against:** vendored `rabbita/` submodule at **0.12.4 + Canopy patch** (upstream tag `rabbita-v0.12.4` / commit `2dba2dc`, including `closedby` PR #118, plus canopy's `diff_subs/update_tagger` patch, published on `dowdiness/rabbita:update-0.12.4-patched` at `5f828eb`, also tagged `canopy-rabbita-v0.12.4-patched-2026-06-05` on the fork)
 **PoC:** `examples/disclosure/` (browser-verified, see §4)
 **Follow-up:** P3 native Dialog spike recorded in §5 (docs-only; no `lib/dialog` extraction)
 
-**PR scope / done definition:** record the feasibility findings and land the
-Disclosure PoC as an experiment. Do **not** extract a reusable `lib/disclosure`,
-commit to an animation attribute contract, or adopt rabbita 0.12.3
-workspace-wide in this PR; those are separate follow-up decisions.
+**Original PR scope / done definition:** record the feasibility findings and land
+the Disclosure PoC as an experiment. Do **not** extract a reusable
+`lib/disclosure` or commit to an animation attribute contract. The follow-up
+workspace adoption now points Canopy at the patched Rabbita 0.12.4 fork commit
+listed above.
 
 ## Conclusion
 
@@ -118,9 +119,10 @@ A narrow throwaway spike (not landed as an example or library) was run after PR
 #501 merged, starting from `origin/main` at `7f0888d` with the `rabbita`
 submodule at `8381bef`. The harness rendered one native `<dialog>` and used
 Playwright/Chromium to drive focus, Tab, Escape, page-control clicks, backdrop
-clicks, and a `closedby="any"` injection. Injection was necessary because the
-pinned Rabbita public API cannot emit `closedby`: `Attrs::attribute` is internal
-and there is no `Attrs::closedby` / `dialog(closedby?)` yet.
+clicks, and a `closedby="any"` injection. Injection was necessary for that spike
+because the then-pinned Rabbita API could not emit `closedby`. Rabbita 0.12.4 now
+exposes `Attrs::closedby` and `dialog(closedby?)`, so a rerun should use
+`@html.dialog(closedby="any", ...)` instead of DOM injection.
 
 Findings:
 
@@ -141,10 +143,10 @@ Findings:
   the dialog open and focused the dialog. With `closedby="any"`, Chromium
   light-dismissed and emitted `cancel` followed by `close` through the spike's
   explicit cancel-close path.
-- If Rabbita gains `closedby` support, scope it as an attribute emission API
-  only. MDN marks `HTMLDialogElement.closedBy` as non-Baseline, so consumers
-  still need a fallback or an explicit browser-support decision; Rabbita should
-  not claim a light-dismiss polyfill.
+- Rabbita 0.12.4's `closedby` support is an attribute emission API only. MDN
+  marks `HTMLDialogElement.closedBy` as non-Baseline, so consumers still need a
+  fallback or an explicit browser-support decision; Rabbita does not claim a
+  light-dismiss polyfill.
 
 Implication: a future Dialog primitive can lean on native `showModal()` for the
 Chromium modal/top-layer/inert/focus-return behavior observed here, but the
@@ -152,31 +154,27 @@ primitive must own cancel-close policy and must choose between limited-support
 `closedby` and explicit backdrop handling for light-dismiss. Do not extract
 `lib/dialog` until a real Canopy consumer exists.
 
-## 6. rabbita 0.12.3 adoption status
+## 6. rabbita 0.12.4 patched adoption status
 
-`moon check` (full workspace) is **green** against 0.12.3 + patch after a single fix:
+`moon check` (full workspace) is **green** against 0.12.4 + patch. The single
+0.12.3 compatibility fix remains sufficient:
 
 - **One breaking call site** from upstream PR #117 (void elements lose `children`):
   `examples/ideal/main/view_actions.mbt` — removed a trailing `[@html.text("")]`
   positional child from `@html.input(...)`. (Two more in
   `loom/incr/examples/typed_spreadsheet_rabbita_demo/view.mbt` — loom submodule,
   not a canopy workspace member; only matters if loom's examples are built.)
-- `moon.mod` migration (0.12.3) resolves fine through path-deps; no canopy file
+- `moon.mod` migration resolves fine through path-deps; no canopy file
   auto-migrated.
-- The `"version": "0.12.2"` pins in 6 `moon.mod.json` files are advisory (path-deps
-  use the path) — bump to `0.12.3` for accuracy when adopting.
+- Canopy's Rabbita path-dep pins now say `"version": "0.12.4"` for accuracy.
 
-This experiment PR points the `rabbita` gitlink at `8381bef`, which is published
-on the configured fork remote as `dowdiness/rabbita:update-0.12.3-patched` and
-also pinned by the separate fork tag `canopy-headless-ui-experiment-2026-06-04`,
-so fresh clones can resolve the submodule commit even if the review branch later
-moves. The same branch is under review as `dowdiness/rabbita#1`; it is not merged
-to the fork's main branch, so keep that distinction when deciding whether to
-adopt 0.12.3 broadly.
-
-Remaining to actually adopt 0.12.3 workspace-wide in canopy (out of scope for
-this experiment): merge/review the rabbita patch branch, bump the 6 version
-pins, and fix the loom example sites.
+Canopy now points the `rabbita` gitlink at `5f828eb`, published on the configured
+fork remote as `dowdiness/rabbita:update-0.12.4-patched` and pinned by the
+separate fork tag `canopy-rabbita-v0.12.4-patched-2026-06-05`, so fresh clones
+can resolve the submodule commit even if the review branch later moves. This is
+a maintained-fork adoption, not an upstream-only release adoption: the
+`diff_subs/update_tagger` patch remains fork-only unless it later lands in
+`moonbit-community/rabbita`.
 
 ## 7. Roadmap (phased; prose, not paste-ready)
 
@@ -188,8 +186,8 @@ pins, and fix the loom example sites.
 - **P3 — Dialog primitive** on native `<dialog>`: spike complete (§5). Before
   extracting anything, wait for a real consumer and decide cancel-close policy,
   controlled vs uncontrolled shape (consumer `open` + `on_open_change`, or
-  self-held in a `cell`), and light-dismiss strategy (`closedby="any"` where
-  supported vs explicit backdrop handling).
+  self-held in a `cell`), and light-dismiss strategy (`@html.dialog(closedby="any", ...)`
+  where supported vs explicit backdrop handling).
 - **P4 — Splitter primitive**: reuse `lib/resizable`'s document-`mouseup`
   `custom_sub` pattern; confirm it generalizes.
 - **P5 — Design-system layer**: Tailwind `@utility` presets + CSS-var theme +

--- a/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
+++ b/docs/plans/2026-06-04-rabbita-headless-ui-feasibility.md
@@ -157,7 +157,8 @@ primitive must own cancel-close policy and must choose between limited-support
 ## 6. rabbita 0.12.4 patched adoption status
 
 `moon check` (full workspace) is **green** against 0.12.4 + patch. The single
-0.12.3 compatibility fix remains sufficient:
+compatibility fix introduced during the 0.12.3 upgrade remains sufficient for
+0.12.4:
 
 - **One breaking call site** from upstream PR #117 (void elements lose `children`):
   `examples/ideal/main/view_actions.mbt` — removed a trailing `[@html.text("")]`

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -9,7 +9,7 @@
     "dowdiness/incr": "0.8.0",
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.2"
+      "version": "0.12.4"
     }
   },
   "source": ".",

--- a/examples/codemirror_demo/moon.mod.json
+++ b/examples/codemirror_demo/moon.mod.json
@@ -4,7 +4,7 @@
   "deps": {
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.2"
+      "version": "0.12.4"
     },
     "dowdiness/rabbita_codemirror": {
       "path": "../../lib/rabbita_codemirror",

--- a/examples/disclosure/README.md
+++ b/examples/disclosure/README.md
@@ -1,7 +1,7 @@
 # Disclosure example
 
 Smallest working PoC of the **headless behavior + local styling** pattern on
-rabbita 0.12.3, mirroring `examples/resizable`.
+rabbita 0.12.4, mirroring `examples/resizable`.
 
 - `DisclosureModel` (in `main/client.mbt`) owns state (`open`) and emits ARIA
   via `trigger_attrs` / `content_attrs` returning `@html.Attrs` — no styling.

--- a/examples/disclosure/main/client.mbt
+++ b/examples/disclosure/main/client.mbt
@@ -159,7 +159,7 @@ fn section_view(emit : Emit[Msg], index : Int, section : Section) -> Html {
 fn view(emit : Emit[Msg], model : Model) -> Html {
   div(class="page", [
     div(class="hero", [
-      p(class="eyebrow", "Headless UI · rabbita 0.12.3"),
+      p(class="eyebrow", "Headless UI · rabbita 0.12.4"),
       h1("Disclosure"),
       p(
         class="subtitle",

--- a/examples/disclosure/moon.mod.json
+++ b/examples/disclosure/moon.mod.json
@@ -4,7 +4,7 @@
   "deps": {
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.3"
+      "version": "0.12.4"
     }
   },
   "readme": "README.md",

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -4,7 +4,7 @@
   "deps": {
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.2"
+      "version": "0.12.4"
     },
     "dowdiness/rabbita_codemirror": {
       "path": "../../lib/rabbita_codemirror",

--- a/examples/ideal/web/e2e/outline-navigation.spec.ts
+++ b/examples/ideal/web/e2e/outline-navigation.spec.ts
@@ -59,12 +59,17 @@ test.describe('Outline keyboard navigation', () => {
 
   test('ArrowLeft navigates to previous sibling', async ({ page }) => {
     await selectAndFocus(page, /^module/);
+    const root = await selectedLabel(page).textContent();
+
     await page.keyboard.press('ArrowDown');
+    await expect(selectedLabel(page)).not.toHaveText(root!);
+    const firstChild = await selectedLabel(page).textContent();
+
     await page.keyboard.press('ArrowRight');
-    const secondChild = await selectedLabel(page).textContent();
+    await expect(selectedLabel(page)).not.toHaveText(firstChild!);
 
     await page.keyboard.press('ArrowLeft');
-    await expect(selectedLabel(page)).not.toHaveText(secondChild!);
+    await expect(selectedLabel(page)).toHaveText(firstChild!);
   });
 
   test('ArrowUp from root does nothing', async ({ page }) => {

--- a/examples/resizable/moon.mod.json
+++ b/examples/resizable/moon.mod.json
@@ -4,7 +4,7 @@
   "deps": {
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.2"
+      "version": "0.12.4"
     },
     "dowdiness/rabbita-resizable": {
       "path": "../../lib/resizable",

--- a/lib/rabbita_codemirror/moon.mod.json
+++ b/lib/rabbita_codemirror/moon.mod.json
@@ -4,7 +4,7 @@
   "deps": {
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.2"
+      "version": "0.12.4"
     }
   },
   "readme": "README.md",

--- a/lib/resizable/moon.mod.json
+++ b/lib/resizable/moon.mod.json
@@ -5,7 +5,7 @@
   "deps": {
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.2"
+      "version": "0.12.4"
     }
   },
   "readme": "README.md",


### PR DESCRIPTION
## Summary

- Point the `rabbita` submodule at `dowdiness/rabbita@5f828eb`, based on upstream `rabbita-v0.12.4` plus Canopy's `diff_subs/update_tagger` patch.
- Bump all in-repo Rabbita path-dep pins to `0.12.4` and update the disclosure demo copy.
- Mark the Rabbita `closedby` upstreaming/adoption follow-up complete in docs while preserving the fork-only patch provenance.

Submodule provenance: the Rabbita commit is pushed on `dowdiness/rabbita:update-0.12.4-patched` and pinned by tag `canopy-rabbita-v0.12.4-patched-2026-06-05`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `dialog(closedby?)` | `rabbita/rabbita/html/html.mbt` | Yes | Adopted through Rabbita v0.12.4; docs now recommend the real API instead of DOM injection. |
| `Attrs::closedby` | `rabbita/rabbita/html/attrs.mbt` | Yes | Adopted through Rabbita v0.12.4 as an attribute-emission API. |
| `diff_subs` `update_tagger` behavior | `rabbita/rabbita/tea.mbt` | Yes | Preserved by replaying Canopy's fork patch on top of v0.12.4. |

New helpers added: none.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (none kept)
- [x] JS rebuild run where relevant (`NEW_MOON_MOD=0 moon build --target js`; no `examples/web` changes)

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon build --target js
cd rabbita && NEW_MOON_MOD=0 moon check
cd rabbita && NEW_MOON_MOD=0 moon check --target js
cd rabbita && NEW_MOON_MOD=0 moon test rabbita --target js
git diff --check
```

Known upstream baseline: `cd rabbita && NEW_MOON_MOD=0 moon test --target native` still fails in `rabbita/url/url_test.mbt` due expect-output formatting drift, unrelated to this adoption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated Rabbita dependency to version 0.12.4 across examples and library modules.

* **Documentation**
  * Updated planning documents and task tracking to reflect Rabbita 0.12.4 adoption and completed features.
  * Updated example version references to 0.12.4.

* **Tests**
  * Refined outline navigation test assertions for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->