### PR TITLE
Use lib/menu for Canvas context menu

### DIFF
--- a/examples/canvas/main/context_menu.mbt
+++ b/examples/canvas/main/context_menu.mbt
@@ -1,0 +1,293 @@
+// Canvas context-menu Rabbita island.
+//
+// TypeScript still owns graph hit-testing and source-backed action execution;
+// this cell owns the menu surface, roving focus, keyboard handling, and ARIA
+// attrs through `dowdiness/rabbita-menu/menu`.
+
+///|
+let context_menu_root_id : String = "context-menu"
+
+///|
+let context_menu_panel_id : String = "canvas-context-menu-panel"
+
+///|
+let context_menu_show_event : String = "canopy-canvas-context-menu-show"
+
+///|
+let context_menu_hide_event : String = "canopy-canvas-context-menu-hide"
+
+///|
+priv struct CanvasContextMenuItem {
+  key : String
+  label : String
+  description : String
+} derive(@json.FromJson)
+
+///|
+priv struct CanvasContextMenuPayload {
+  items : Array[CanvasContextMenuItem]
+} derive(@json.FromJson)
+
+///|
+priv struct CanvasContextMenuModel {
+  visible : Bool
+  items : Array[CanvasContextMenuItem]
+  menu : @menu.Model
+  on_select : (String) -> Unit
+  on_close : () -> Unit
+}
+
+///|
+priv enum CanvasContextMenuMsg {
+  Show(String)
+  Hide
+  Menu(@menu.Msg)
+}
+
+///|
+fn decode_context_menu_payload(json_text : String) -> CanvasContextMenuPayload? {
+  let json = @json.parse(json_text) catch { _ => return None }
+  let payload : CanvasContextMenuPayload = @json.from_json(json) catch {
+    _ => return None
+  }
+  Some(payload)
+}
+
+///|
+fn context_menu_model(
+  on_select : (String) -> Unit,
+  on_close : () -> Unit,
+) -> CanvasContextMenuModel {
+  {
+    visible: false,
+    items: [],
+    menu: @menu.Model::new(id=context_menu_panel_id, item_count=0),
+    on_select,
+    on_close,
+  }
+}
+
+///|
+fn CanvasContextMenuModel::with_items(
+  self : CanvasContextMenuModel,
+  items : Array[CanvasContextMenuItem],
+) -> CanvasContextMenuModel {
+  {
+    ..self,
+    visible: true,
+    items,
+    menu: self.menu.reset(item_count=items.length()),
+  }
+}
+
+///|
+fn CanvasContextMenuModel::closed(
+  self : CanvasContextMenuModel,
+) -> CanvasContextMenuModel {
+  { ..self, visible: false, items: [], menu: self.menu.reset(item_count=0) }
+}
+
+///|
+fn context_menu_close_cmd(model : CanvasContextMenuModel) -> @rabbita.Cmd {
+  @rabbita.effect(fn() { (model.on_close)() })
+}
+
+///|
+fn context_menu_select_cmd(
+  model : CanvasContextMenuModel,
+  key : String,
+) -> @rabbita.Cmd {
+  @rabbita.effect(fn() {
+    (model.on_select)(key)
+    (model.on_close)()
+  })
+}
+
+///|
+fn context_menu_update(
+  _emit : @rabbita.Emit[CanvasContextMenuMsg],
+  msg : CanvasContextMenuMsg,
+  model : CanvasContextMenuModel,
+) -> (@rabbita.Cmd, CanvasContextMenuModel) {
+  match msg {
+    Show(json_text) =>
+      match decode_context_menu_payload(json_text) {
+        Some(payload) => {
+          let model = model.with_items(payload.items)
+          (model.menu.focus_cmd(), model)
+        }
+        None => (@rabbita.none, model.closed())
+      }
+    Hide => (@rabbita.none, model.closed())
+    Menu(menu_msg) =>
+      match menu_msg {
+        @menu.Activate(index) =>
+          match model.items.get(index) {
+            Some(item) => {
+              let cmd = context_menu_select_cmd(model, item.key)
+              (cmd, model.closed())
+            }
+            None => (@rabbita.none, model)
+          }
+        @menu.Close => (context_menu_close_cmd(model), model.closed())
+        @menu.Key(_) => (@rabbita.none, model)
+        @menu.FocusNext
+        | @menu.FocusPrevious
+        | @menu.FocusFirst
+        | @menu.FocusLast
+        | @menu.FocusItem(_) => {
+          let model = { ..model, menu: model.menu.update(menu_msg) }
+          let cmd = if menu_msg.requests_focus() {
+            model.menu.focus_cmd()
+          } else {
+            @rabbita.none
+          }
+          (cmd, model)
+        }
+      }
+  }
+}
+
+///|
+fn context_menu_item_view(
+  emit : @rabbita.Emit[CanvasContextMenuMsg],
+  menu : @menu.Model,
+  index : Int,
+  item : CanvasContextMenuItem,
+) -> @rabbita.Html {
+  @html.button(
+    type_="button",
+    title=item.description,
+    attrs=menu.item_attrs(index, msg => emit(Menu(msg))),
+    [@html.text(item.label)],
+  )
+}
+
+///|
+fn context_menu_view(
+  emit : @rabbita.Emit[CanvasContextMenuMsg],
+  model : CanvasContextMenuModel,
+) -> @rabbita.Html {
+  if !model.visible {
+    return @html.nothing
+  }
+  let items : Array[@rabbita.Html] = []
+  for index, item in model.items {
+    items.push(context_menu_item_view(emit, model.menu, index, item))
+  }
+  @html.div(
+    attrs=model.menu
+      .panel_attrs(msg => emit(Menu(msg)))
+      .aria_label("Canvas context menu"),
+    items,
+  )
+}
+
+///|
+#cfg(target="js")
+extern "js" fn context_menu_event_detail(event : @dom.Event) -> String =
+  #| (event) => {
+  #|   const detail = event && "detail" in event ? event.detail : "";
+  #|   return typeof detail === "string" ? detail : "";
+  #| }
+
+///|
+#cfg(target="js")
+priv suberror CanvasContextMenuSub {
+  ShowEvent(@rabbita.Emit[CanvasContextMenuMsg])
+  HideEvent(@rabbita.Emit[CanvasContextMenuMsg])
+}
+
+///|
+#cfg(target="js")
+fn context_menu_event_target() -> @dom.EventTarget {
+  @dom.document()
+  .get_element_by_id(context_menu_root_id)
+  .unwrap()
+  .as_event_target()
+}
+
+///|
+#cfg(target="js")
+fn context_menu_sub_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    CanvasContextMenuSub::ShowEvent(emit) => {
+      let tagger = @ref.Ref(emit)
+      let target = context_menu_event_target()
+      let listener : @dom.Listener = event => {
+        scheduler.add((tagger.val)(Show(context_menu_event_detail(event))))
+      }
+      target.add_event_listener(context_menu_show_event, listener)
+      Some({
+        unload: _ => {
+          target.remove_event_listener(context_menu_show_event, listener)
+        },
+        update_tagger: next => {
+          guard next is CanvasContextMenuSub::ShowEvent(new_emit) else {
+            return
+          }
+          tagger.val = new_emit
+        },
+      })
+    }
+    CanvasContextMenuSub::HideEvent(emit) => {
+      let tagger = @ref.Ref(emit)
+      let target = context_menu_event_target()
+      let listener : @dom.Listener = _ => scheduler.add((tagger.val)(Hide))
+      target.add_event_listener(context_menu_hide_event, listener)
+      Some({
+        unload: _ => {
+          target.remove_event_listener(context_menu_hide_event, listener)
+        },
+        update_tagger: next => {
+          guard next is CanvasContextMenuSub::HideEvent(new_emit) else {
+            return
+          }
+          tagger.val = new_emit
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn context_menu_subscriptions(
+  emit : @rabbita.Emit[CanvasContextMenuMsg],
+  _model : CanvasContextMenuModel,
+) -> @sub.Sub {
+  @sub.batch([
+    @sub.custom_sub(
+      context_menu_show_event,
+      @sub.Scope::Local,
+      CanvasContextMenuSub::ShowEvent(emit),
+      context_menu_sub_loader,
+    ),
+    @sub.custom_sub(
+      context_menu_hide_event,
+      @sub.Scope::Local,
+      CanvasContextMenuSub::HideEvent(emit),
+      context_menu_sub_loader,
+    ),
+  ])
+}
+
+///|
+#cfg(target="js")
+pub fn mount_canvas_context_menu(
+  on_select : (String) -> Unit,
+  on_close : () -> Unit,
+) -> Unit {
+  @rabbita.new(
+    @rabbita.cell(
+      model=context_menu_model(on_select, on_close),
+      update=context_menu_update,
+      view=context_menu_view,
+      subscriptions=context_menu_subscriptions,
+    ),
+  ).mount(context_menu_root_id)
+}

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -1,10 +1,14 @@
 import {
   "moonbitlang/core/json",
   "moonbitlang/core/debug",
+  "moonbitlang/core/ref",
   "dowdiness/canopy-canvas/graph_model",
   "dowdiness/incr",
   "dowdiness/graph-dsl" @graph_dsl,
+  "dowdiness/rabbita-menu/menu",
   "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
 }
@@ -38,6 +42,7 @@ options(
         "apply_source_graph_operation",
         "sample_graph_dsl_source",
         "mount_source_demo",
+        "mount_canvas_context_menu",
         "source_graph_insert_unique",
         "source_graph_pointer_down",
         "source_graph_pointer_move",

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -34,6 +34,8 @@ pub fn get_source_graph_source(Int) -> String
 
 pub fn hover_node(Int, Int) -> Unit
 
+pub fn mount_canvas_context_menu((String) -> Unit, () -> Unit) -> Unit
+
 pub fn mount_source_demo(Int, Bool, () -> Unit) -> Unit
 
 pub fn pointer_down(Int, Int, Double, Double) -> Unit

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -7,6 +7,10 @@
       "version": "0.1.0"
     },
     "dowdiness/incr": "0.8.0",
+    "dowdiness/rabbita-menu": {
+      "path": "../../lib/menu",
+      "version": "0.1.0"
+    },
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
       "version": "0.12.4"

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -13,6 +13,10 @@ function pendingEdgePaths(page: Page): Locator {
   return page.locator('#edges path.edge-pending');
 }
 
+function contextMenuItems(page: Page): Locator {
+  return page.locator('#context-menu [role="menuitem"]');
+}
+
 function inputHandle(page: Page, nodeId: number): Locator {
   return page.locator(`.handle.input[data-node-id="${nodeId}"]`);
 }
@@ -59,6 +63,14 @@ async function canvasBackgroundPoint(page: Page): Promise<Point> {
     x: box.x + 20,
     y: box.y + 20,
   };
+}
+
+async function openBackgroundContextMenu(page: Page): Promise<void> {
+  const box = await page.locator('#canvas-root').boundingBox();
+  if (!box) {
+    throw new Error('canvas root is not visible');
+  }
+  await page.mouse.click(box.x + box.width - 48, box.y + 48, { button: 'right' });
 }
 
 async function dragBetween(page: Page, from: Locator, to: Locator): Promise<void> {
@@ -208,11 +220,65 @@ test('canvas edge context menu disconnects the edge', async ({ page }) => {
   await expect(edgePaths(page)).toHaveCount(3);
 
   await clickEdge(page, 0, 'right');
-  await page.getByRole('button', { name: 'Disconnect edge' }).click();
+  await page.getByRole('menuitem', { name: 'Disconnect edge' }).click();
 
   await expect(page.locator('.canvas-node')).toHaveCount(6);
   await expect(edgePaths(page)).toHaveCount(2);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('canvas context menu supports headless keyboard navigation and dismissal', async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on('pageerror', (error) => runtimeErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      runtimeErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.canvas-node')).toHaveCount(6);
+
+  const menu = page.locator('#context-menu');
+  const items = contextMenuItems(page);
+
+  await openBackgroundContextMenu(page);
+  await expect(menu).toBeVisible();
+  await expect(items).toHaveCount(7);
+  await expect(items.nth(0)).toHaveAttribute('data-active', 'true');
+  await expect(items.nth(0)).toBeFocused();
+
+  await page.keyboard.press('ArrowDown');
+  await expect(items.nth(1)).toHaveAttribute('data-active', 'true');
+  await expect(items.nth(1)).toBeFocused();
+
+  await page.keyboard.press('End');
+  await expect(items.nth(6)).toHaveAttribute('data-active', 'true');
+  await expect(items.nth(6)).toBeFocused();
+
+  await page.keyboard.press('Home');
+  await expect(items.nth(0)).toHaveAttribute('data-active', 'true');
+  await expect(items.nth(0)).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+
+  await openBackgroundContextMenu(page);
+  await expect(items.nth(0)).toBeFocused();
+  await page.keyboard.press('ArrowDown');
+  await expect(items.nth(1)).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('.canvas-node')).toHaveCount(7);
+  await expect(menu).toBeHidden();
+
+  await openBackgroundContextMenu(page);
+  await expect(items.nth(0)).toBeFocused();
+  await page.keyboard.press('ArrowDown');
+  await expect(items.nth(1)).toBeFocused();
+  await page.keyboard.press('Space');
+  await expect(page.locator('.canvas-node')).toHaveCount(8);
+  await expect(menu).toBeHidden();
   expect(runtimeErrors).toEqual([]);
 });
 

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -619,7 +619,7 @@
       <p class="hint" style="margin-top: 12px;">Press ⌘/Ctrl-L to inspect the serialized action log.</p>
     </aside>
 
-    <div id="context-menu" role="menu" hidden></div>
+    <div id="context-menu" hidden></div>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -52,6 +52,7 @@ export type CanvasModule = {
   source_graph_zoom?: (h: number, delta: number, cx: number, cy: number) => void;
   sample_graph_dsl_source?: () => string;
   mount_source_demo?: (h: number, enabled: boolean, onChange: () => void) => void;
+  mount_canvas_context_menu?: (onSelect: (key: string) => void, onClose: () => void) => void;
 };
 
 type SourceCanvasModule = CanvasModule & {

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -23,9 +23,12 @@ type LibraryItem = {
   description: string;
 };
 
+type ContextMenuItem = LibraryItem;
+
 type SourceDemoModule = CanvasModule & {
   sample_graph_dsl_source: () => string;
   mount_source_demo: (h: number, enabled: boolean, onChange: () => void) => void;
+  mount_canvas_context_menu: (onSelect: (key: string) => void, onClose: () => void) => void;
 };
 
 const LIBRARY: LibraryItem[] = [
@@ -39,6 +42,9 @@ const LIBRARY: LibraryItem[] = [
 ];
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
+const CONTEXT_MENU_SHOW_EVENT = 'canopy-canvas-context-menu-show';
+const CONTEXT_MENU_HIDE_EVENT = 'canopy-canvas-context-menu-hide';
+const EDGE_CONTEXT_MENU_KEY = 'disconnect-edge';
 
 let adapter: GraphAdapter;
 let rafPending = false;
@@ -59,6 +65,7 @@ const nodeDivs = new Map<number, HTMLDivElement>();
 const edgePaths = new Map<number, SVGPathElement>();
 let pendingPath: SVGPathElement | null = null;
 let contextPoint: [number, number] = [0, 0];
+let contextEdge: EdgeData | null = null;
 let sourcePointerId = -1;
 let sourceConnecting: Connecting | null = null;
 
@@ -595,8 +602,24 @@ function deleteSelectedNodes(): boolean {
   return true;
 }
 
-function hideContextMenu(): void {
+function hideContextMenuElement(): void {
   contextMenu.hidden = true;
+  contextEdge = null;
+}
+
+function hideContextMenu(): void {
+  const wasOpen = !contextMenu.hidden;
+  hideContextMenuElement();
+  if (wasOpen) {
+    contextMenu.dispatchEvent(new CustomEvent(CONTEXT_MENU_HIDE_EVENT));
+  }
+}
+
+function showContextMenu(items: ContextMenuItem[]): void {
+  contextMenu.hidden = false;
+  contextMenu.dispatchEvent(new CustomEvent(CONTEXT_MENU_SHOW_EVENT, {
+    detail: JSON.stringify({ items }),
+  }));
 }
 
 function renderLibrary(filter = ''): void {
@@ -615,25 +638,23 @@ function renderLibrary(filter = ''): void {
 }
 
 function renderEdgeContextMenu(edge: EdgeData): void {
-  contextMenu.replaceChildren();
-  const disconnect = document.createElement('button');
-  disconnect.type = 'button';
-  disconnect.textContent = 'Disconnect edge';
-  disconnect.title = edgeTitle(edge);
-  disconnect.addEventListener('click', () => disconnectEdge(edge));
-  contextMenu.appendChild(disconnect);
+  contextEdge = edge;
+  showContextMenu([
+    { key: EDGE_CONTEXT_MENU_KEY, label: 'Disconnect edge', description: edgeTitle(edge) },
+  ]);
 }
 
 function renderContextMenu(): void {
-  contextMenu.replaceChildren();
-  for (const item of LIBRARY) {
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.textContent = item.label;
-    button.title = item.description;
-    button.addEventListener('click', () => addNodeAt(item.key, contextPoint));
-    contextMenu.appendChild(button);
+  contextEdge = null;
+  showContextMenu(LIBRARY);
+}
+
+function handleContextMenuSelect(key: string): void {
+  if (key === EDGE_CONTEXT_MENU_KEY) {
+    if (contextEdge) disconnectEdge(contextEdge);
+    return;
   }
+  addNodeAt(key, contextPoint);
 }
 
 // ─── Event wiring ─────────────────────────────────────────────────────────────
@@ -815,6 +836,8 @@ root.addEventListener('wheel', (e: WheelEvent) => {
 root.addEventListener('contextmenu', (e: MouseEvent) => {
   e.preventDefault();
   const hit = hitFromTarget(e.target);
+  contextMenu.style.left = `${e.clientX}px`;
+  contextMenu.style.top = `${e.clientY}px`;
   if (hit.kind === 'edge') {
     selectEdge(hit.edge);
     renderEdgeContextMenu(hit.edge);
@@ -823,9 +846,6 @@ root.addEventListener('contextmenu', (e: MouseEvent) => {
     contextPoint = localCoords(e);
     renderContextMenu();
   }
-  contextMenu.style.left = `${e.clientX}px`;
-  contextMenu.style.top = `${e.clientY}px`;
-  contextMenu.hidden = false;
   scheduleRender();
 });
 
@@ -870,6 +890,9 @@ function requireSourceDemoModule(mb: CanvasModule): SourceDemoModule {
   if (typeof mb.mount_source_demo !== 'function') {
     throw new Error('Canvas module is missing source demo export: mount_source_demo');
   }
+  if (typeof mb.mount_canvas_context_menu !== 'function') {
+    throw new Error('Canvas module is missing context menu export: mount_canvas_context_menu');
+  }
   return mb as SourceDemoModule;
 }
 
@@ -880,6 +903,7 @@ async function init(): Promise<void> {
   adapter = sourceMode
     ? GraphAdapter.createSourceBacked(mod, sourceDemoModule.sample_graph_dsl_source())
     : GraphAdapter.create(mod);
+  sourceDemoModule.mount_canvas_context_menu(handleContextMenuSelect, hideContextMenuElement);
   sourceDemoModule.mount_source_demo(adapter.handleId, sourceMode, scheduleRender);
   renderLibrary();
   render();


### PR DESCRIPTION
## Summary

- Validate Canvas as a second real `lib/menu` consumer by moving only the context-menu surface into a small Rabbita island.
- Reuse `dowdiness/rabbita-menu/menu` for roving focus, keyboard handling, ARIA attrs, activation, and close while keeping Canvas hit-testing/action execution in TypeScript.
- Add Canvas E2E coverage for pointer activation plus Arrow/Home/End, Enter/Space activation, and Escape dismissal.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@menu.Model::{new, reset, update, panel_attrs, item_attrs, focus_cmd}` and `@menu.Msg::requests_focus` | `lib/menu/src/menu` | Yes | Powers the Canvas menu state, keyboard navigation, focus, ARIA roles, activation, and close behavior. |
| `@rabbita.cell` / `@rabbita.new(...).mount(...)` | `moonbit-community/rabbita` | Yes | Mounts a narrow Rabbita context-menu island at the existing `#context-menu` host. |
| `@sub.custom_sub` | `moonbit-community/rabbita/sub` | Yes | Bridges existing TypeScript context-menu show/hide events into the Rabbita cell without broad Canvas runtime extraction. |
| Existing Canvas TS action helpers (`addNodeAt`, `disconnectEdge`, `hideContextMenu`) | `examples/canvas/web/src/main.ts` | Yes | Kept graph hit-testing, source-backed status sync, and action execution in TS. |

New helpers added (current-consumer boundary only):

- `mount_canvas_context_menu`: JS export that mounts the Canvas-specific Rabbita menu island and accepts TS callbacks for selection/close.
- `context_menu_*` helpers in `examples/canvas/main/context_menu.mbt`: private Canvas-specific model/update/view/subscription helpers for the island; they do not expand `lib/menu`.
- TS bridge helpers (`showContextMenu`, `hideContextMenuElement`, `handleContextMenuSelect`): keep the existing Canvas action seam while delegating menu behavior/rendering to Rabbita.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/canvas/web && npm run build`)
- [x] Canvas Playwright E2E (`cd examples/canvas/web && npm run test`) passes

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/canvas/web && npm run build
cd examples/canvas/web && npm run test
```

Closes #510
