### PR TITLE
Extract headless Rabbita context menu primitive

### DIFF
--- a/examples/canvas/main/context_menu.mbt
+++ b/examples/canvas/main/context_menu.mbt
@@ -1,8 +1,8 @@
 // Canvas context-menu Rabbita island.
 //
 // TypeScript still owns graph hit-testing and source-backed action execution;
-// this cell owns the menu surface, roving focus, keyboard handling, and ARIA
-// attrs through `dowdiness/rabbita-menu/menu`.
+// this cell owns the menu surface by composing Canvas item data with
+// `dowdiness/rabbita-context-menu/context_menu`.
 
 ///|
 let context_menu_root_id : String = "context-menu"
@@ -25,14 +25,22 @@ priv struct CanvasContextMenuItem {
 
 ///|
 priv struct CanvasContextMenuPayload {
+  x : Int
+  y : Int
   items : Array[CanvasContextMenuItem]
 } derive(@json.FromJson)
 
 ///|
+fn CanvasContextMenuPayload::anchor(
+  self : CanvasContextMenuPayload,
+) -> @context_menu.Point {
+  @context_menu.Point(x=self.x, y=self.y)
+}
+
+///|
 priv struct CanvasContextMenuModel {
-  visible : Bool
   items : Array[CanvasContextMenuItem]
-  menu : @menu.Model
+  context_menu : @context_menu.Model
   on_select : (String) -> Unit
   on_close : () -> Unit
 }
@@ -41,7 +49,7 @@ priv struct CanvasContextMenuModel {
 priv enum CanvasContextMenuMsg {
   Show(String)
   Hide
-  Menu(@menu.Msg)
+  ContextMenu(@context_menu.Msg)
 }
 
 ///|
@@ -59,24 +67,25 @@ fn context_menu_model(
   on_close : () -> Unit,
 ) -> CanvasContextMenuModel {
   {
-    visible: false,
     items: [],
-    menu: @menu.Model::new(id=context_menu_panel_id, item_count=0),
+    context_menu: @context_menu.Model::new(id=context_menu_panel_id),
     on_select,
     on_close,
   }
 }
 
 ///|
-fn CanvasContextMenuModel::with_items(
+fn CanvasContextMenuModel::with_payload(
   self : CanvasContextMenuModel,
-  items : Array[CanvasContextMenuItem],
+  payload : CanvasContextMenuPayload,
 ) -> CanvasContextMenuModel {
   {
     ..self,
-    visible: true,
-    items,
-    menu: self.menu.reset(item_count=items.length()),
+    items: payload.items,
+    context_menu: self.context_menu.open(
+      anchor=payload.anchor(),
+      item_count=payload.items.length(),
+    ),
   }
 }
 
@@ -84,7 +93,24 @@ fn CanvasContextMenuModel::with_items(
 fn CanvasContextMenuModel::closed(
   self : CanvasContextMenuModel,
 ) -> CanvasContextMenuModel {
-  { ..self, visible: false, items: [], menu: self.menu.reset(item_count=0) }
+  { ..self, items: [], context_menu: self.context_menu.close() }
+}
+
+///|
+fn CanvasContextMenuModel::with_context_menu_msg(
+  self : CanvasContextMenuModel,
+  msg : @context_menu.Msg,
+) -> CanvasContextMenuModel {
+  let context_menu = self.context_menu.update(msg)
+  {
+    ..self,
+    context_menu,
+    items: if context_menu.is_open() {
+      self.items
+    } else {
+      []
+    },
+  }
 }
 
 ///|
@@ -113,32 +139,38 @@ fn context_menu_update(
     Show(json_text) =>
       match decode_context_menu_payload(json_text) {
         Some(payload) => {
-          let model = model.with_items(payload.items)
-          (model.menu.focus_cmd(), model)
+          let model = model.with_payload(payload)
+          (model.context_menu.focus_cmd(), model)
         }
         None => (@rabbita.none, model.closed())
       }
     Hide => (@rabbita.none, model.closed())
-    Menu(menu_msg) =>
-      match menu_msg {
-        @menu.Activate(index) =>
+    ContextMenu(context_menu_msg) =>
+      match context_menu_msg {
+        @context_menu.Activate(index) =>
           match model.items.get(index) {
             Some(item) => {
               let cmd = context_menu_select_cmd(model, item.key)
-              (cmd, model.closed())
+              (cmd, model.with_context_menu_msg(context_menu_msg))
             }
             None => (@rabbita.none, model)
           }
-        @menu.Close => (context_menu_close_cmd(model), model.closed())
-        @menu.Key(_) => (@rabbita.none, model)
-        @menu.FocusNext
-        | @menu.FocusPrevious
-        | @menu.FocusFirst
-        | @menu.FocusLast
-        | @menu.FocusItem(_) => {
-          let model = { ..model, menu: model.menu.update(menu_msg) }
-          let cmd = if menu_msg.requests_focus() {
-            model.menu.focus_cmd()
+        @context_menu.Close => {
+          let cmd = context_menu_close_cmd(model)
+          (cmd, model.with_context_menu_msg(context_menu_msg))
+        }
+        @context_menu.Key(_) => {
+          let model = model.with_context_menu_msg(context_menu_msg)
+          (@rabbita.none, model)
+        }
+        @context_menu.FocusNext
+        | @context_menu.FocusPrevious
+        | @context_menu.FocusFirst
+        | @context_menu.FocusLast
+        | @context_menu.FocusItem(_) => {
+          let model = model.with_context_menu_msg(context_menu_msg)
+          let cmd = if context_menu_msg.requests_focus() {
+            model.context_menu.focus_cmd()
           } else {
             @rabbita.none
           }
@@ -151,14 +183,14 @@ fn context_menu_update(
 ///|
 fn context_menu_item_view(
   emit : @rabbita.Emit[CanvasContextMenuMsg],
-  menu : @menu.Model,
+  context_menu : @context_menu.Model,
   index : Int,
   item : CanvasContextMenuItem,
 ) -> @rabbita.Html {
   @html.button(
     type_="button",
     title=item.description,
-    attrs=menu.item_attrs(index, msg => emit(Menu(msg))),
+    attrs=context_menu.item_attrs(index, msg => emit(ContextMenu(msg))),
     [@html.text(item.label)],
   )
 }
@@ -168,16 +200,16 @@ fn context_menu_view(
   emit : @rabbita.Emit[CanvasContextMenuMsg],
   model : CanvasContextMenuModel,
 ) -> @rabbita.Html {
-  if !model.visible {
+  if !model.context_menu.is_open() {
     return @html.nothing
   }
   let items : Array[@rabbita.Html] = []
   for index, item in model.items {
-    items.push(context_menu_item_view(emit, model.menu, index, item))
+    items.push(context_menu_item_view(emit, model.context_menu, index, item))
   }
   @html.div(
-    attrs=model.menu
-      .panel_attrs(msg => emit(Menu(msg)))
+    attrs=model.context_menu
+      .panel_attrs(msg => emit(ContextMenu(msg)))
       .aria_label("Canvas context menu"),
     items,
   )

--- a/examples/canvas/main/context_menu.mbt
+++ b/examples/canvas/main/context_menu.mbt
@@ -25,8 +25,8 @@ priv struct CanvasContextMenuItem {
 
 ///|
 priv struct CanvasContextMenuPayload {
-  x : Int
-  y : Int
+  x : Float
+  y : Float
   items : Array[CanvasContextMenuItem]
 } derive(@json.FromJson)
 

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -5,7 +5,7 @@ import {
   "dowdiness/canopy-canvas/graph_model",
   "dowdiness/incr",
   "dowdiness/graph-dsl" @graph_dsl,
-  "dowdiness/rabbita-menu/menu",
+  "dowdiness/rabbita-context-menu/context_menu",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -7,8 +7,8 @@
       "version": "0.1.0"
     },
     "dowdiness/incr": "0.8.0",
-    "dowdiness/rabbita-menu": {
-      "path": "../../lib/menu",
+    "dowdiness/rabbita-context-menu": {
+      "path": "../../lib/context-menu",
       "version": "0.1.0"
     },
     "moonbit-community/rabbita": {

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -474,21 +474,27 @@
     #context-menu {
       position: fixed;
       z-index: 10;
+      width: 1px;
+      height: 1px;
+      overflow: visible;
+    }
+    #context-menu[hidden] { display: none; }
+    #context-menu [role="menu"] {
       width: 210px;
       padding: 6px;
       border-radius: 12px;
       background: oklch(21% 0.019 276 / 0.98);
       border: 1px solid var(--line);
       box-shadow: 0 16px 48px oklch(8% 0.012 276 / 0.34);
+      box-sizing: border-box;
     }
-    #context-menu[hidden] { display: none; }
-    #context-menu button {
+    #context-menu [role="menu"] button {
       padding: 8px 9px;
       border-radius: 8px;
       background: transparent;
     }
-    #context-menu button:hover,
-    #context-menu button:focus-visible {
+    #context-menu [role="menu"] button:hover,
+    #context-menu [role="menu"] button:focus-visible {
       background: var(--surface-soft);
       outline: none;
     }

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -836,7 +836,7 @@ root.addEventListener('wheel', (e: WheelEvent) => {
 root.addEventListener('contextmenu', (e: MouseEvent) => {
   e.preventDefault();
   const hit = hitFromTarget(e.target);
-  const anchor = { x: e.clientX, y: e.clientY };
+  const anchor = { x: Math.round(e.clientX), y: Math.round(e.clientY) };
   if (hit.kind === 'edge') {
     selectEdge(hit.edge);
     renderEdgeContextMenu(hit.edge, anchor);

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -615,10 +615,10 @@ function hideContextMenu(): void {
   }
 }
 
-function showContextMenu(items: ContextMenuItem[]): void {
+function showContextMenu(anchor: Point, items: ContextMenuItem[]): void {
   contextMenu.hidden = false;
   contextMenu.dispatchEvent(new CustomEvent(CONTEXT_MENU_SHOW_EVENT, {
-    detail: JSON.stringify({ items }),
+    detail: JSON.stringify({ x: anchor.x, y: anchor.y, items }),
   }));
 }
 
@@ -637,16 +637,16 @@ function renderLibrary(filter = ''): void {
   }
 }
 
-function renderEdgeContextMenu(edge: EdgeData): void {
+function renderEdgeContextMenu(edge: EdgeData, anchor: Point): void {
   contextEdge = edge;
-  showContextMenu([
+  showContextMenu(anchor, [
     { key: EDGE_CONTEXT_MENU_KEY, label: 'Disconnect edge', description: edgeTitle(edge) },
   ]);
 }
 
-function renderContextMenu(): void {
+function renderContextMenu(anchor: Point): void {
   contextEdge = null;
-  showContextMenu(LIBRARY);
+  showContextMenu(anchor, LIBRARY);
 }
 
 function handleContextMenuSelect(key: string): void {
@@ -836,15 +836,14 @@ root.addEventListener('wheel', (e: WheelEvent) => {
 root.addEventListener('contextmenu', (e: MouseEvent) => {
   e.preventDefault();
   const hit = hitFromTarget(e.target);
-  contextMenu.style.left = `${e.clientX}px`;
-  contextMenu.style.top = `${e.clientY}px`;
+  const anchor = { x: e.clientX, y: e.clientY };
   if (hit.kind === 'edge') {
     selectEdge(hit.edge);
-    renderEdgeContextMenu(hit.edge);
+    renderEdgeContextMenu(hit.edge, anchor);
   } else {
     clearSelectedEdge();
     contextPoint = localCoords(e);
-    renderContextMenu();
+    renderContextMenu(anchor);
   }
   scheduleRender();
 });

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -836,7 +836,7 @@ root.addEventListener('wheel', (e: WheelEvent) => {
 root.addEventListener('contextmenu', (e: MouseEvent) => {
   e.preventDefault();
   const hit = hitFromTarget(e.target);
-  const anchor = { x: Math.round(e.clientX), y: Math.round(e.clientY) };
+  const anchor = { x: e.clientX, y: e.clientY };
   if (hit.kind === 'edge') {
     selectEdge(hit.edge);
     renderEdgeContextMenu(hit.edge, anchor);

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -25,6 +25,8 @@ type LibraryItem = {
 
 type ContextMenuItem = LibraryItem;
 
+type Point = { x: number; y: number };
+
 type SourceDemoModule = CanvasModule & {
   sample_graph_dsl_source: () => string;
   mount_source_demo: (h: number, enabled: boolean, onChange: () => void) => void;

--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -1,0 +1,61 @@
+# Rabbita Context Menu
+
+Headless context-menu behavior for Rabbita apps. The package owns open/closed
+state, client-coordinate anchoring, menu ARIA attrs, keyboard navigation, and
+focus commands. It composes over `dowdiness/rabbita-menu/menu`; consumers still
+own item data, rendering, hit-testing, styling, and action execution.
+
+## Use
+
+```mbt nocheck
+struct Model {
+  context_menu : @context_menu.Model
+}
+
+enum Msg {
+  OpenMenu(@context_menu.Point)
+  ContextMenu(@context_menu.Msg)
+}
+
+fn view(emit : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
+  @html.div([
+    @html.div(
+      attrs=model.context_menu.trigger_attrs(point => emit(OpenMenu(point))),
+      "Right-click me",
+    ),
+    if model.context_menu.is_open() {
+      @html.div(
+        attrs=model.context_menu
+          .panel_attrs(msg => emit(ContextMenu(msg)))
+          .aria_label("Actions"),
+        [
+          @html.button(
+            type_="button",
+            attrs=model.context_menu.item_attrs(0, msg => emit(ContextMenu(msg))),
+            "Rename",
+          ),
+        ],
+      )
+    } else {
+      @html.nothing
+    },
+  ])
+}
+```
+
+Open with `model.context_menu.open(anchor=point, item_count=items.length())`,
+then return `model.context_menu.focus_cmd()`. Handle `Activate(index)`, `Close`,
+and `Key(key)` in the consumer. For navigation messages, call
+`Model::update`; when `Msg::requests_focus()` is true, return
+`Model::focus_cmd()` after updating the model.
+
+## Verified Rabbita APIs
+
+Implementation was checked against the vendored Rabbita source, especially:
+
+- `rabbita/rabbita/html/README.mbt.md`
+- `rabbita/rabbita/html/attrs_event.mbt`
+- `rabbita/rabbita/dom/mouse_event.mbt`
+- `rabbita/rabbita/sub/README.mbt.md`
+- `rabbita/rabbita/sub/design.md`
+- `rabbita/rabbita/cmd/commands.mbt`

--- a/lib/context-menu/moon.mod.json
+++ b/lib/context-menu/moon.mod.json
@@ -1,0 +1,29 @@
+{
+  "name": "dowdiness/rabbita-context-menu",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "dowdiness/rabbita-menu": {
+      "path": "../menu",
+      "version": "0.1.0"
+    },
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.4"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [
+    "rabbita",
+    "context-menu",
+    "headless-ui",
+    "component",
+    "moonbit",
+    "tea"
+  ],
+  "description": "Headless context-menu behavior helpers for Rabbita.",
+  "preferred-target": "native",
+  "supported-targets": "js+native"
+}

--- a/lib/context-menu/src/context_menu/attrs.mbt
+++ b/lib/context-menu/src/context_menu/attrs.mbt
@@ -1,5 +1,5 @@
 ///|
-fn px(value : Int) -> String {
+fn px(value : Float) -> String {
   value.to_string() + "px"
 }
 
@@ -30,7 +30,12 @@ pub fn Model::trigger_attrs(
   .base_trigger_attrs()
   .on_contextmenu(event => {
     event.prevent_default()
-    on_open(Point(x=event.get_client_x(), y=event.get_client_y()))
+    on_open(
+      Point(
+        x=Float::from_int(event.get_client_x()),
+        y=Float::from_int(event.get_client_y()),
+      ),
+    )
   })
 }
 

--- a/lib/context-menu/src/context_menu/attrs.mbt
+++ b/lib/context-menu/src/context_menu/attrs.mbt
@@ -1,0 +1,77 @@
+///|
+fn px(value : Int) -> String {
+  value.to_string() + "px"
+}
+
+///|
+fn bool_attr(value : Bool) -> String {
+  if value {
+    "true"
+  } else {
+    "false"
+  }
+}
+
+///|
+fn Model::base_trigger_attrs(self : Model) -> @html.Attrs {
+  @html.Attrs::build()
+  .aria_haspopup("menu")
+  .aria_expanded(bool_attr(self.is_open()))
+  .aria_controls(self.id)
+}
+
+///|
+#cfg(target="js")
+pub fn Model::trigger_attrs(
+  self : Model,
+  on_open : (Point) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  self
+  .base_trigger_attrs()
+  .on_contextmenu(event => {
+    event.prevent_default()
+    on_open(Point(x=event.get_client_x(), y=event.get_client_y()))
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::trigger_attrs(
+  self : Model,
+  on_open : (Point) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  ignore(on_open)
+  self.base_trigger_attrs()
+}
+
+///|
+/// Attributes for the context-menu panel.
+///
+/// The panel is positioned with fixed `left`/`top` styles when the model is
+/// open. Consumers may append styling and labeling attributes after this call.
+pub fn Model::panel_attrs(
+  self : Model,
+  dispatch : (Msg) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  let attrs = self.menu.panel_attrs(menu_msg => {
+    dispatch(Msg::from_menu_msg(menu_msg))
+  })
+  match self.anchor {
+    Some(point) =>
+      attrs
+      .style("position", "fixed")
+      .style("left", px(point.x))
+      .style("top", px(point.y))
+    None => attrs
+  }
+}
+
+///|
+/// Attributes for one context-menu item.
+pub fn Model::item_attrs(
+  self : Model,
+  index : Int,
+  dispatch : (Msg) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  self.menu.item_attrs(index, menu_msg => dispatch(Msg::from_menu_msg(menu_msg)))
+}

--- a/lib/context-menu/src/context_menu/context_menu_test.mbt
+++ b/lib/context-menu/src/context_menu/context_menu_test.mbt
@@ -1,0 +1,37 @@
+///|
+test "context menu opens, exposes anchor, and closes" {
+  let model = @context_menu.Model::new(id="test-menu")
+  inspect(model.is_open(), content="false")
+  guard model.anchor() is None else {
+    fail("closed context menu should not expose an anchor")
+  }
+
+  let model = model.open(anchor=@context_menu.Point(x=12, y=34), item_count=3)
+  inspect(model.is_open(), content="true")
+  guard model.anchor() is Some({ x: 12, y: 34 }) else {
+    fail("open context menu should expose the supplied anchor")
+  }
+
+  let model = model.update(@context_menu.Close)
+  inspect(model.is_open(), content="false")
+  guard model.anchor() is None else {
+    fail("closed context menu should clear the anchor")
+  }
+}
+
+///|
+test "activation closes while navigation requests focus" {
+  let model = @context_menu.Model::new(id="test-menu").open(
+    anchor=@context_menu.Point(x=1, y=2),
+    item_count=2,
+  )
+  inspect(@context_menu.FocusNext.requests_focus(), content="true")
+  inspect(@context_menu.FocusItem(1).requests_focus(), content="false")
+  inspect(@context_menu.Activate(0).requests_focus(), content="false")
+
+  let navigated = model.update(@context_menu.FocusLast)
+  inspect(navigated.is_open(), content="true")
+
+  let activated = navigated.update(@context_menu.Activate(1))
+  inspect(activated.is_open(), content="false")
+}

--- a/lib/context-menu/src/context_menu/context_menu_test.mbt
+++ b/lib/context-menu/src/context_menu/context_menu_test.mbt
@@ -6,10 +6,17 @@ test "context menu opens, exposes anchor, and closes" {
     fail("closed context menu should not expose an anchor")
   }
 
-  let model = model.open(anchor=@context_menu.Point(x=12, y=34), item_count=3)
+  let model = model.open(
+    anchor=@context_menu.Point(x=12.5F, y=34.25F),
+    item_count=3,
+  )
   inspect(model.is_open(), content="true")
-  guard model.anchor() is Some({ x: 12, y: 34 }) else {
-    fail("open context menu should expose the supplied anchor")
+  match model.anchor() {
+    Some(point) => {
+      inspect(point.x, content="12.5")
+      inspect(point.y, content="34.25")
+    }
+    None => fail("open context menu should expose the supplied anchor")
   }
 
   let model = model.update(@context_menu.Close)
@@ -22,7 +29,7 @@ test "context menu opens, exposes anchor, and closes" {
 ///|
 test "activation closes while navigation requests focus" {
   let model = @context_menu.Model::new(id="test-menu").open(
-    anchor=@context_menu.Point(x=1, y=2),
+    anchor=@context_menu.Point(x=1.0F, y=2.0F),
     item_count=2,
   )
   inspect(@context_menu.FocusNext.requests_focus(), content="true")

--- a/lib/context-menu/src/context_menu/moon.pkg
+++ b/lib/context-menu/src/context_menu/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "dowdiness/rabbita-menu/menu",
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/html",
+}
+
+warnings = "-unused_package"
+
+supported_targets = "js+native"

--- a/lib/context-menu/src/context_menu/pkg.generated.mbti
+++ b/lib/context-menu/src/context_menu/pkg.generated.mbti
@@ -1,0 +1,48 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita-context-menu/context_menu"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct Model {
+  // private fields
+}
+pub fn Model::anchor(Self) -> Point?
+pub fn Model::close(Self) -> Self
+pub fn Model::focus_cmd(Self) -> @cmd.Cmd
+pub fn Model::is_open(Self) -> Bool
+pub fn Model::item_attrs(Self, Int, (Msg) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::new(id~ : String) -> Self
+pub fn Model::open(Self, anchor~ : Point, item_count~ : Int) -> Self
+pub fn Model::panel_attrs(Self, (Msg) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::trigger_attrs(Self, (Point) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::update(Self, Msg) -> Self
+
+pub(all) enum Msg {
+  FocusNext
+  FocusPrevious
+  FocusFirst
+  FocusLast
+  FocusItem(Int)
+  Activate(Int)
+  Close
+  Key(String)
+}
+pub fn Msg::requests_focus(Self) -> Bool
+
+pub(all) struct Point {
+  x : Int
+  y : Int
+} derive(Eq)
+pub fn Point::Point(x~ : Int, y~ : Int) -> Self
+
+// Type aliases
+
+// Traits

--- a/lib/context-menu/src/context_menu/pkg.generated.mbti
+++ b/lib/context-menu/src/context_menu/pkg.generated.mbti
@@ -38,10 +38,10 @@ pub(all) enum Msg {
 pub fn Msg::requests_focus(Self) -> Bool
 
 pub(all) struct Point {
-  x : Int
-  y : Int
+  x : Float
+  y : Float
 } derive(Eq)
-pub fn Point::Point(x~ : Int, y~ : Int) -> Self
+pub fn Point::Point(x~ : Float, y~ : Float) -> Self
 
 // Type aliases
 

--- a/lib/context-menu/src/context_menu/types.mbt
+++ b/lib/context-menu/src/context_menu/types.mbt
@@ -1,0 +1,122 @@
+///|
+/// Viewport/client-space anchor for an open context menu.
+pub(all) struct Point {
+  x : Int
+  y : Int
+} derive(Eq)
+
+///|
+/// Create a context-menu anchor point from client coordinates.
+pub fn Point::Point(x~ : Int, y~ : Int) -> Point {
+  { x, y }
+}
+
+///|
+/// Headless context-menu behavior state.
+///
+/// The consumer owns item data, rendering, and action execution. This model
+/// owns open/closed state, the client-space anchor point, and the embedded
+/// `@menu.Model` used for ARIA, roving focus, and keyboard behavior.
+pub struct Model {
+  priv id : String
+  priv menu : @menu.Model
+  priv anchor : Point?
+}
+
+///|
+/// Context-menu behavior messages emitted by panel and item attrs.
+pub(all) enum Msg {
+  FocusNext
+  FocusPrevious
+  FocusFirst
+  FocusLast
+  FocusItem(Int)
+  Activate(Int)
+  Close
+  Key(String)
+}
+
+///|
+fn Msg::from_menu_msg(msg : @menu.Msg) -> Msg {
+  match msg {
+    @menu.FocusNext => FocusNext
+    @menu.FocusPrevious => FocusPrevious
+    @menu.FocusFirst => FocusFirst
+    @menu.FocusLast => FocusLast
+    @menu.FocusItem(index) => FocusItem(index)
+    @menu.Activate(index) => Activate(index)
+    @menu.Close => Close
+    @menu.Key(key) => Key(key)
+  }
+}
+
+///|
+fn Msg::to_menu_msg(self : Msg) -> @menu.Msg {
+  match self {
+    FocusNext => @menu.FocusNext
+    FocusPrevious => @menu.FocusPrevious
+    FocusFirst => @menu.FocusFirst
+    FocusLast => @menu.FocusLast
+    FocusItem(index) => @menu.FocusItem(index)
+    Activate(index) => @menu.Activate(index)
+    Close => @menu.Close
+    Key(key) => @menu.Key(key)
+  }
+}
+
+///|
+/// Create a closed context-menu model for a stable panel id.
+pub fn Model::new(id~ : String) -> Model {
+  { id, menu: @menu.Model::new(id~, item_count=0), anchor: None }
+}
+
+///|
+/// Whether the context menu is currently open.
+pub fn Model::is_open(self : Model) -> Bool {
+  self.anchor is Some(_)
+}
+
+///|
+/// The current client-space anchor when the context menu is open.
+pub fn Model::anchor(self : Model) -> Point? {
+  self.anchor
+}
+
+///|
+/// Open the context menu at `anchor` and reset focus for `item_count` items.
+pub fn Model::open(self : Model, anchor~ : Point, item_count~ : Int) -> Model {
+  { ..self, anchor: Some(anchor), menu: self.menu.reset(item_count~) }
+}
+
+///|
+/// Close the context menu and clear menu item focus state.
+pub fn Model::close(self : Model) -> Model {
+  { ..self, anchor: None, menu: self.menu.reset(item_count=0) }
+}
+
+///|
+/// Apply one context-menu behavior message.
+///
+/// Navigation messages update roving focus. `Activate` and `Close` close the
+/// context menu; consumers should still inspect those messages to perform
+/// domain actions or notify their host shell.
+pub fn Model::update(self : Model, msg : Msg) -> Model {
+  match msg {
+    Activate(_) | Close => self.close()
+    Key(_) => self
+    FocusNext | FocusPrevious | FocusFirst | FocusLast | FocusItem(_) =>
+      { ..self, menu: self.menu.update(msg.to_menu_msg()) }
+  }
+}
+
+///|
+/// Whether handling this message should be followed by `Model::focus_cmd()`.
+pub fn Msg::requests_focus(self : Msg) -> Bool {
+  self.to_menu_msg().requests_focus()
+}
+
+///|
+/// Focus the active menu item after the current render flush.
+pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
+  self.menu.focus_cmd()
+}

--- a/lib/context-menu/src/context_menu/types.mbt
+++ b/lib/context-menu/src/context_menu/types.mbt
@@ -1,13 +1,13 @@
 ///|
 /// Viewport/client-space anchor for an open context menu.
 pub(all) struct Point {
-  x : Int
-  y : Int
+  x : Float
+  y : Float
 } derive(Eq)
 
 ///|
 /// Create a context-menu anchor point from client coordinates.
-pub fn Point::Point(x~ : Int, y~ : Int) -> Point {
+pub fn Point::Point(x~ : Float, y~ : Float) -> Point {
   { x, y }
 }
 

--- a/moon.work
+++ b/moon.work
@@ -6,6 +6,7 @@ members = [
   "./lib/rabbita_codemirror",
   "./lib/resizable",
   "./lib/menu",
+  "./lib/context-menu",
   "./lib/dom-boundary",
   "./lib/visualizer",
   "./lib/semantic",


### PR DESCRIPTION
## Summary

- Extract a narrow `dowdiness/rabbita-context-menu` headless primitive over `lib/menu` for open/closed state, client-coordinate anchoring, attrs, and focus commands.
- Migrate the Canvas context-menu Rabbita island to consume the new primitive while leaving graph hit-testing and action execution in TypeScript.
- Preserve Canvas selectors/behavior and adjust the bridge payload to carry anchor coordinates.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@menu.Model` | `lib/menu/src/menu` | Yes | Embedded for menu ARIA, roving focus, keyboard handling, item attrs, panel attrs, and focus commands. |
| `@html.Attrs::on_contextmenu` | `rabbita/rabbita/html/attrs_event.mbt` | Yes | Used by `Model::trigger_attrs` to prevent default and capture client coordinates. |
| Canvas context-menu helpers | `examples/canvas/main/context_menu.mbt` | Yes | Existing JSON event bridge and consumer-owned item rendering/action callbacks were preserved and narrowed around the new primitive. |
| `@sub.custom_sub` | `rabbita/rabbita/sub` | Yes, only in Canvas bridge | Kept app-specific show/hide custom-event subscriptions in Canvas instead of adding subscription machinery to the primitive. |

New helpers added (if any):

- `@context_menu.Point`: explicit client-coordinate anchor value for context-menu placement.
- `@context_menu.Model`: headless context-menu state boundary; owns open/closed + anchor + embedded menu model.
- `@context_menu.Msg`: mirrors the menu behavior messages at the context-menu package boundary so consumers do not import `lib/menu` directly.
- `Model::trigger_attrs`, `Model::panel_attrs`, `Model::item_attrs`, `Model::open`, `Model::close`, `Model::update`, `Model::focus_cmd`: narrow primitive API required by Canvas.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/canvas/web && npm run build`)
- [x] Canvas Playwright E2E passes (`make test-canvas-e2e`)

## Validation

```bash
moon update
NEW_MOON_MOD=0 moon check --deny-warn
cd lib/context-menu && MOON_WORK=off NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test --release
NEW_MOON_MOD=0 moon build --target js
cd examples/canvas/web && npm run build
make test-canvas-e2e
```
