### PR TITLE
feat(tabs): extract reusable headless Tabs behavior (#505)

### DIFF
--- a/docs/plans/2026-06-05-505-headless-tabs.md
+++ b/docs/plans/2026-06-05-505-headless-tabs.md
@@ -1,0 +1,91 @@
+# #505 — Migrate Ideal bottom tabs to a reusable headless Tabs behavior
+
+**Status:** execution spec · **Date:** 2026-06-05 · **Issue:** #505
+**Precedent:** `lib/menu` (the already-merged headless primitive; mirror it).
+**Design owner:** Opus · **Plan authoring:** Codex ("Opus orchestrates, Codex plans").
+
+## Goal
+
+Extract the WAI-ARIA tablist keyboard/ARIA behavior currently inlined in
+`examples/ideal/main/view_bottom.mbt` (`view_bottom_tabs`, `bottom_panel_attrs`,
+and the id/slug/focus helpers) into a reusable headless package `lib/tabs`
+(module `dowdiness/rabbita-tabs`, package `dowdiness/rabbita-tabs/tabs`), and
+make the Ideal editor consume it. Behavior-preserving for the user.
+
+## Converged design (the WHAT)
+
+**Responsibility split.**
+- Library owns the tab-**button** id scheme: `tab_button_id(i) = id + "-tab-" + i`
+  (mirrors menu's `item_id`). Verified safe: nothing references the old slug
+  button ids.
+- Consumer owns **panel** ids and passes them in — mandatory because
+  History/Graphviz/IncrGraph keep legacy ids `canopy-{name}-container` that
+  render cmds write `innerHTML` to and E2E specs locate. Must be preserved.
+- Behavior is **derived/stateless**: durable selection stays in the consumer's
+  `model.bottom_tab : BottomTab`. The library `Model` is a per-render snapshot
+  built from `(id, tab_count, selected)`. No stored `@tabs.Model`, no
+  `Msg`/`update` (unlike menu, whose focus state is ephemeral/consumer-external).
+- **Automatic activation** (selection follows focus): arrow/Home/End immediately
+  select+focus the target tab — exactly today's behavior. Horizontal only:
+  ArrowLeft/Right wrap, Home/End jump; ArrowUp/Down intentionally unhandled
+  (APG reserves them for scroll).
+
+**Public API (`lib/tabs/src/tabs`).**
+- `Model::new(id~, tab_count~, selected~)` — clamp `tab_count >= 0`, `selected`
+  into `[0, tab_count-1]`; `tab_count==0` deterministic + safe across all getters.
+- `Model::nav_target(self, key) -> Int?` — pure keyboard core (the unit-tested
+  surface). None for unhandled keys and for `tab_count==0` (no mod-by-zero).
+- `Model::tab_button_id(self, index) -> String`.
+- `Model::tablist_attrs(self, label~) -> @html.Attrs` — role=tablist, aria-label.
+- `Model::tab_attrs(self, index, panel_id~, dispatch : (Int) -> @cmd.Cmd)` —
+  id, role=tab, aria-selected, roving tabindex, aria-controls **only when
+  selected**; on_click → dispatch(index); on_keydown → nav_target → prevent_default
+  + dispatch(target) else none. `#cfg(target="js")` / non-js split like menu.
+- `Model::panel_attrs(self, index, panel_id~)` — id=panel_id, role=tabpanel,
+  aria-labelledby=tab_button_id(index), tabindex=0.
+- `Model::focus_cmd(self)` — focus selected tab button after_render; #cfg split.
+
+The `dispatch : (Int) -> @cmd.Cmd` callback keeps the library domain-agnostic;
+the consumer maps index→`BottomTab`.
+
+## Steps (Codex-authored)
+
+1. Create `lib/tabs` skeleton mirroring `lib/menu` (moon.mod.json, src/tabs/moon.pkg,
+   types.mbt, attrs.mbt, tabs_wbtest.mbt, README.md). Check + test.
+2. `Model::new` + `nav_target` + `tab_button_id` in types.mbt. Define `tab_count==0`.
+3. `tablist_attrs`/`tab_attrs`/`panel_attrs`/`focus_cmd` in attrs.mbt (js/non-js split,
+   reuse menu's `focus_element_by_id` extern shape).
+4. `tabs_wbtest.mbt`: nav_target (arrows/Home/End/wrap/unhandled/empty), `new`
+   clamping, `tab_button_id` format, aria-controls-only-when-selected.
+5. `NEW_MOON_MOD=0 moon info && moon fmt`; review `pkg.generated.mbti` diff = minimal.
+6. Register `./lib/tabs` in `moon.work`. Workspace check.
+7. Import `dowdiness/rabbita-tabs/tabs` in `examples/ideal/main/moon.pkg` (as `@tabs`).
+8. Migrate `view_bottom_tabs`: rename local `tabs` → `tab_defs`; build one
+   `@tabs.Model::new(id="canopy-bottom-tabs", tab_count=…, selected=…)`; replace
+   per-button attrs with `@tabs.tab_attrs(i, panel_id=bottom_tab_panel_id(tab),
+   dispatch=fn(j) => dispatch(SelectBottomTab(tab_defs[j].0)))`; keep class strings + labels.
+9. Replace `bottom_panel_attrs` body with `@tabs.panel_attrs(index, panel_id=…)`;
+   keep `bottom_tab_panel_id` (legacy-id exceptions) and `bottom_tab_slug`.
+   Remove now-unused `bottom_tab_button_id`.
+10. Rewire `SelectBottomTab` focus: `bottom_tab_focus_cmd` builds the `@tabs.Model`
+    for the selected tab and returns `focus_cmd()`. No new model field.
+11. `moon info && moon fmt` for ideal/main; review .mbti diff (imports only).
+12. New E2E `examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts`: focus a tab,
+    ArrowRight/Left/Home/End move selection+focus & aria-selected; ArrowUp/Down do not.
+13. Workspace `moon test` + ideal `moon test` + tab E2E specs (build recipe below).
+14. Sanity: legacy container ids intact; role/name selectors still pass.
+
+## Verification
+
+- Per-edit: `NEW_MOON_MOD=0 moon check` (package dir, then consumer).
+- `NEW_MOON_MOD=0 moon info && moon fmt`; `git diff *.mbti` minimal.
+- `NEW_MOON_MOD=0 moon test` (lib/tabs + workspace + ideal).
+- E2E (WSL2 recipe — warren dev/build may core-dump): build JS via
+  `examples/ideal/web` → `npm run prebuild:moonbit` (= `MOON_WORK=off moon build
+  --target js --release`), serve, then `npx playwright test e2e/editor-features.spec.ts
+  e2e/history.spec.ts e2e/incr-graph.spec.ts e2e/bottom-tabs-keyboard.spec.ts`.
+
+## Non-goals
+
+No vertical tabs, no manual-activation mode, no panel-content/SVG-cache changes,
+no bottom-panel UI redesign, no public-API growth beyond in-package callers.

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -6,6 +6,7 @@ import {
   "dowdiness/rabbita_codemirror" @cm,
   "dowdiness/rabbita_codemirror/js" @cm_js,
   "dowdiness/rabbita-menu/menu",
+  "dowdiness/rabbita-tabs/tabs",
   "dowdiness/dom_boundary",
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,

--- a/examples/ideal/main/rabbita_dom_cmd.mbt
+++ b/examples/ideal/main/rabbita_dom_cmd.mbt
@@ -12,16 +12,6 @@ fn dom_after_render_result(
 }
 
 ///|
-fn focus_id_after_render(
-  id : String,
-  on_error? : (@dom_boundary.DomBoundaryError) -> @rabbita.Cmd = fn(_) {
-    @rabbita.none
-  },
-) -> @rabbita.Cmd {
-  dom_after_render_result(() => @dom_boundary.focus_id(id), on_error~)
-}
-
-///|
 fn focus_selector_after_render(
   selector : String,
   on_error? : (@dom_boundary.DomBoundaryError) -> @rabbita.Cmd = fn(_) {

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -272,10 +272,17 @@ let bottom_tab_defs : Array[(BottomTab, String)] = [
 ]
 
 ///|
-/// Ordinal of a tab within `bottom_tab_defs`. The fallback `0` is unreachable —
-/// every `BottomTab` variant appears in the list.
+/// Ordinal of a tab within `bottom_tab_defs`. Deriving the index from the defs
+/// list (rather than a hard-coded `match`) keeps tab *order* single-sourced, so
+/// reordering the tablist can't desync the index. A `BottomTab` absent from the
+/// list is a defect, not a fallback case: aliasing it to `0` would silently give
+/// it the Problems tab's id / focus / `SelectBottomTab` target, so we abort
+/// loudly instead. Unreachable today — every variant is listed.
 fn bottom_tab_index(tab : BottomTab) -> Int {
-  bottom_tab_defs.search_by(pair => pair.0 == tab).unwrap_or(0)
+  match bottom_tab_defs.search_by(pair => pair.0 == tab) {
+    Some(index) => index
+    None => abort("BottomTab variant missing from bottom_tab_defs")
+  }
 }
 
 ///|
@@ -343,6 +350,10 @@ fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
     buttons.push(
       @html.button(
         class=class_name,
+        // `dispatch` receives the *target* index, which for keyboard nav differs
+        // from this button's `i` (e.g. ArrowRight on tab `i` fires `i + 1`). Re-
+        // index `bottom_tab_defs[j]` — do NOT close over the loop's `tab`, or
+        // every arrow key would select the focused tab and break navigation.
         attrs=behavior.tab_attrs(i, panel_id=bottom_tab_panel_id(tab), dispatch=j => {
           dispatch(SelectBottomTab(bottom_tab_defs[j].0))
         }),
@@ -365,6 +376,9 @@ fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
 /// History/Graphviz). APG: a tabpanel with no focusable content must be
 /// in the tab sequence itself.
 fn bottom_panel_attrs(tab : BottomTab) -> @html.Attrs {
+  // `panel_attrs` reads only the behavior's id prefix and the explicit index, so
+  // the Model's `selected` is irrelevant here — `bottom_panel_attrs` is called
+  // for whichever panel renders, not necessarily the selected one.
   bottom_tabs_behavior(tab).panel_attrs(
     bottom_tab_index(tab),
     panel_id=bottom_tab_panel_id(tab),

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -275,12 +275,7 @@ let bottom_tab_defs : Array[(BottomTab, String)] = [
 /// Ordinal of a tab within `bottom_tab_defs`. The fallback `0` is unreachable —
 /// every `BottomTab` variant appears in the list.
 fn bottom_tab_index(tab : BottomTab) -> Int {
-  for i in 0..<bottom_tab_defs.length() {
-    if bottom_tab_defs[i].0 == tab {
-      return i
-    }
-  }
-  0
+  bottom_tab_defs.search_by(pair => pair.0 == tab).unwrap_or(0)
 }
 
 ///|

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -257,18 +257,57 @@ fn render_history_html(model : Model) -> String {
 }
 
 ///|
-/// Focus the active tab's button after the next render. Roving tabindex
-/// makes inactive tabs unreachable via Tab; without this, arrow-key
-/// navigation would leave focus stranded on the previous (now
-/// `tabindex="-1"`) button. Click-driven switches are no-ops because the
-/// browser already focuses the clicked button.
-fn bottom_tab_focus_cmd(tab : BottomTab) -> @rabbita.Cmd {
-  focus_id_after_render(bottom_tab_button_id(tab))
+/// Canonical bottom-tab order: the single source of truth for tab ordering,
+/// labels, the tab ↔ index mapping, and the tab count. The headless `@tabs`
+/// behavior is parameterized by index, so this list — not the behavior — owns
+/// which `BottomTab` each tablist position is.
+let bottom_tab_defs : Array[(BottomTab, String)] = [
+  (Problems, "Problems"),
+  (OpLog, "Op Log"),
+  (Patch, "Patch"),
+  (History, "History"),
+  (CrdtState, "CRDT State"),
+  (Graphviz, "Graphviz"),
+  (IncrGraph, "Incr Graph"),
+]
+
+///|
+/// Ordinal of a tab within `bottom_tab_defs`. The fallback `0` is unreachable —
+/// every `BottomTab` variant appears in the list.
+fn bottom_tab_index(tab : BottomTab) -> Int {
+  for i in 0..<bottom_tab_defs.length() {
+    if bottom_tab_defs[i].0 == tab {
+      return i
+    }
+  }
+  0
 }
 
 ///|
-/// Stable slug per tab — used for both the tab button id and the tabpanel
-/// id, so `aria-controls` ↔ `aria-labelledby` round-trips cleanly.
+/// Headless tablist behavior for the bottom panel, with `selected` taken from
+/// the durable `model.bottom_tab`. Rebuilt per use: selection lives in the
+/// model, not in the behavior (no second source of truth).
+fn bottom_tabs_behavior(selected : BottomTab) -> @tabs.Model {
+  @tabs.Model::new(
+    id="canopy-bottom-tabs",
+    tab_count=bottom_tab_defs.length(),
+    selected=bottom_tab_index(selected),
+  )
+}
+
+///|
+/// Focus the selected tab's button after the next render. Roving tabindex makes
+/// inactive tabs unreachable via Tab; without this, arrow-key navigation would
+/// leave focus stranded on the previous (now `tabindex="-1"`) button.
+/// Click-driven switches are no-ops because the browser already focuses the
+/// clicked button.
+fn bottom_tab_focus_cmd(tab : BottomTab) -> @rabbita.Cmd {
+  bottom_tabs_behavior(tab).focus_cmd()
+}
+
+///|
+/// Stable slug per tab — used for the tabpanel container id (see
+/// `bottom_tab_panel_id`).
 fn bottom_tab_slug(tab : BottomTab) -> String {
   match tab {
     Problems => "problems"
@@ -279,11 +318,6 @@ fn bottom_tab_slug(tab : BottomTab) -> String {
     Graphviz => "graphviz"
     IncrGraph => "incr"
   }
-}
-
-///|
-fn bottom_tab_button_id(tab : BottomTab) -> String {
-  "canopy-bottom-tab-" + bottom_tab_slug(tab)
 }
 
 ///|
@@ -301,78 +335,29 @@ fn bottom_tab_panel_id(tab : BottomTab) -> String {
 
 ///|
 fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
-  let tabs : Array[(BottomTab, String)] = [
-    (Problems, "Problems"),
-    (OpLog, "Op Log"),
-    (Patch, "Patch"),
-    (History, "History"),
-    (CrdtState, "CRDT State"),
-    (Graphviz, "Graphviz"),
-    (IncrGraph, "Incr Graph"),
-  ]
-  // Build buttons with WAI-ARIA tabs keyboard support: arrow keys
-  // navigate, Home/End jump to ends, and roving tabindex keeps the focus
-  // budget at one (active tab is tabindex=0; others are -1, so the page
-  // Tab key skips over inactive tabs).
-  let n = tabs.length()
-  let first_tab = tabs[0].0
-  let last_tab = tabs[n - 1].0
+  // The headless `@tabs` behavior owns the WAI-ARIA tablist keyboard model
+  // (ArrowLeft/Right wrap, Home/End jump), roving tabindex, `aria-selected`,
+  // and `aria-controls` (set only on the selected tab, since the other panels
+  // aren't mounted). This consumer owns the tab data, panel ids, the
+  // `tab`/`tab active` classes, and the index → `BottomTab` mapping.
+  let behavior = bottom_tabs_behavior(model.bottom_tab)
   let buttons : Array[Html] = []
-  for i in 0..<n {
-    let (tab, label) = tabs[i]
-    let prev_tab = tabs[(i + n - 1) % n].0
-    let next_tab = tabs[(i + 1) % n].0
-    let active = model.bottom_tab == tab
-    let class_name = if active { "tab active" } else { "tab" }
-    // `aria-controls` is set only on the active tab — the other panels
-    // aren't mounted (`view_bottom_content` matches on `bottom_tab` and
-    // returns one), so cross-referencing missing IDs would mislead AT.
-    // The `aria-labelledby` on the active panel still ties it back to
-    // its tab button.
-    let mut attrs = @html.Attrs::build()
-      .id(bottom_tab_button_id(tab))
-      .role("tab")
-      .aria_selected(if active { "true" } else { "false" })
-      .tabindex(if active { 0 } else { -1 })
-      .on_keydown(fn(ev) {
-        // Horizontal tablist: APG reserves ArrowUp/Down for normal scroll;
-        // only ArrowLeft/Right + Home/End move between tabs. Cancel the
-        // browser default for handled keys — Home/End and arrow keys
-        // otherwise scroll the page or scroll containers, so without
-        // prevent_default the viewport jumps while focus moves between
-        // tabs.
-        let target_tab = match ev.key() {
-          "ArrowLeft" => Some(prev_tab)
-          "ArrowRight" => Some(next_tab)
-          "Home" => Some(first_tab)
-          "End" => Some(last_tab)
-          _ => None
-        }
-        match target_tab {
-          Some(t) => {
-            ev.prevent_default()
-            dispatch(SelectBottomTab(t))
-          }
-          None => @rabbita.none
-        }
-      })
-    if active {
-      attrs = attrs.aria_controls(bottom_tab_panel_id(tab))
-    }
+  for i in 0..<bottom_tab_defs.length() {
+    let (tab, label) = bottom_tab_defs[i]
+    let class_name = if model.bottom_tab == tab { "tab active" } else { "tab" }
     buttons.push(
       @html.button(
         class=class_name,
-        on_click=dispatch(SelectBottomTab(tab)),
-        attrs~,
+        attrs=behavior.tab_attrs(i, panel_id=bottom_tab_panel_id(tab), dispatch=j => {
+          dispatch(SelectBottomTab(bottom_tab_defs[j].0))
+        }),
         [@html.text(label)],
       ),
     )
   }
   @html.div(
     class="bottom-tabs",
-    attrs=@html.Attrs::build()
-      .role("tablist")
-      .aria_label("Bottom panel sections"),
+    attrs=@tabs.tablist_attrs(label="Bottom panel sections"),
     buttons,
   )
 }
@@ -385,11 +370,10 @@ fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
 /// History/Graphviz). APG: a tabpanel with no focusable content must be
 /// in the tab sequence itself.
 fn bottom_panel_attrs(tab : BottomTab) -> @html.Attrs {
-  @html.Attrs::build()
-  .id(bottom_tab_panel_id(tab))
-  .role("tabpanel")
-  .aria_labelledby(bottom_tab_button_id(tab))
-  .tabindex(0)
+  bottom_tabs_behavior(tab).panel_attrs(
+    bottom_tab_index(tab),
+    panel_id=bottom_tab_panel_id(tab),
+  )
 }
 
 ///|

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -14,6 +14,10 @@
       "path": "../../lib/menu",
       "version": "0.1.0"
     },
+    "dowdiness/rabbita-tabs": {
+      "path": "../../lib/tabs",
+      "version": "0.1.0"
+    },
     "dowdiness/dom_boundary": {
       "path": "../../lib/dom-boundary",
       "version": "0.1.0"

--- a/examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts
+++ b/examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts
@@ -67,6 +67,11 @@ test.describe('Bottom Panel Tabs — keyboard navigation', () => {
     await expect(problems).toBeFocused();
   });
 
+  // This covers that vertical arrows don't move selection/focus. That they also
+  // don't suppress page scroll (no over-eager preventDefault) is guaranteed
+  // structurally — nav_target returns None for these keys, so the keydown handler
+  // never calls prevent_default — and is asserted at the unit level by the
+  // "nav_target ignores vertical arrows" test in lib/tabs/src/tabs/tabs_wbtest.mbt.
   test('ArrowUp / ArrowDown do not change the selected tab', async ({ page }) => {
     const problems = page.getByRole('tab', { name: 'Problems' });
 

--- a/examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts
+++ b/examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+// Keyboard navigation for the bottom-panel tablist, now driven by the headless
+// `@tabs` behavior (lib/tabs). Automatic activation: Arrow/Home/End immediately
+// move selection AND focus. Horizontal model only — ArrowUp/Down are ignored
+// (APG reserves them for scrolling).
+
+async function openBottomTabs(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await expect(page).toHaveTitle('Canopy Editor');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(
+    () => document.querySelector('#canopy-text-editor .cm-editor') !== null,
+    { timeout: 10000 },
+  );
+  await page.getByRole('button', { name: 'Panels' }).click();
+  await expect(page.getByRole('tab', { name: 'Problems' })).toBeVisible();
+}
+
+test.describe('Bottom Panel Tabs — keyboard navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await openBottomTabs(page);
+    // Establish a known starting point: click selects + focuses the first tab.
+    await page.getByRole('tab', { name: 'Problems' }).click();
+    await expect(page.getByRole('tab', { name: 'Problems' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  test('ArrowRight / ArrowLeft move selection and focus', async ({ page }) => {
+    const problems = page.getByRole('tab', { name: 'Problems' });
+    const opLog = page.getByRole('tab', { name: 'Op Log' });
+
+    await problems.press('ArrowRight');
+    await expect(opLog).toHaveAttribute('aria-selected', 'true');
+    await expect(opLog).toBeFocused();
+    await expect(problems).toHaveAttribute('aria-selected', 'false');
+    // Roving tabindex: the selected tab is the only one in the Tab sequence.
+    await expect(opLog).toHaveAttribute('tabindex', '0');
+    await expect(problems).toHaveAttribute('tabindex', '-1');
+
+    await opLog.press('ArrowLeft');
+    await expect(problems).toHaveAttribute('aria-selected', 'true');
+    await expect(problems).toBeFocused();
+  });
+
+  test('ArrowLeft from the first tab wraps to the last', async ({ page }) => {
+    const problems = page.getByRole('tab', { name: 'Problems' });
+    const incrGraph = page.getByRole('tab', { name: 'Incr Graph' });
+
+    await problems.press('ArrowLeft');
+    await expect(incrGraph).toHaveAttribute('aria-selected', 'true');
+    await expect(incrGraph).toBeFocused();
+  });
+
+  test('Home and End jump to the ends', async ({ page }) => {
+    const problems = page.getByRole('tab', { name: 'Problems' });
+    const incrGraph = page.getByRole('tab', { name: 'Incr Graph' });
+
+    await problems.press('End');
+    await expect(incrGraph).toHaveAttribute('aria-selected', 'true');
+    await expect(incrGraph).toBeFocused();
+
+    await incrGraph.press('Home');
+    await expect(problems).toHaveAttribute('aria-selected', 'true');
+    await expect(problems).toBeFocused();
+  });
+
+  test('ArrowUp / ArrowDown do not change the selected tab', async ({ page }) => {
+    const problems = page.getByRole('tab', { name: 'Problems' });
+
+    await problems.press('ArrowDown');
+    await expect(problems).toHaveAttribute('aria-selected', 'true');
+    await expect(problems).toBeFocused();
+
+    await problems.press('ArrowUp');
+    await expect(problems).toHaveAttribute('aria-selected', 'true');
+    await expect(problems).toBeFocused();
+  });
+
+  test('selected tab is wired to its panel via ARIA', async ({ page }) => {
+    const crdtTab = page.getByRole('tab', { name: 'CRDT State' });
+    await crdtTab.click();
+    await expect(crdtTab).toHaveAttribute('aria-selected', 'true');
+    // aria-controls is set only on the selected tab; wait for the re-render.
+    await expect(crdtTab).toHaveAttribute('aria-controls', /\S+/);
+
+    const controls = await crdtTab.getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+    const panel = page.locator(`#${controls}`);
+    await expect(panel).toHaveAttribute('role', 'tabpanel');
+    // aria-labelledby points back at the (behavior-owned) tab button id.
+    const labelledby = await panel.getAttribute('aria-labelledby');
+    expect(labelledby).toBe(await crdtTab.getAttribute('id'));
+  });
+});

--- a/lib/tabs/README.md
+++ b/lib/tabs/README.md
@@ -41,10 +41,16 @@ fn view(emit : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
 }
 ```
 
-Render the active tabpanel with `Model::panel_attrs(index, panel_id=...)`, passing
-the same consumer-owned panel id used for `aria-controls`. After updating the
-selected tab in the consumer model, return `Model::focus_cmd()` so roving tabindex
-moves actual DOM focus once Rabbita patches the view.
+Render the active tabpanel with `Model::panel_attrs(index, panel_id=...)`. After
+updating the selected tab in the consumer model, return `Model::focus_cmd()` so
+roving tabindex moves actual DOM focus once Rabbita patches the view.
+
+**Invariant — the consumer owns panel ids and must pass the same `panel_id` for a
+given tab to both `tab_attrs` and `panel_attrs`.** `tab_attrs` emits
+`aria-controls=panel_id` on the selected tab and `panel_attrs` emits that id as
+the panel's `id`; the library can't enforce that they agree, so a mismatch
+silently breaks the tab↔panel ARIA relationship with no compile error. (Tab
+*button* ids are owned by the library, so `aria-labelledby` always round-trips.)
 
 ## Verified Rabbita APIs
 

--- a/lib/tabs/README.md
+++ b/lib/tabs/README.md
@@ -1,0 +1,56 @@
+# Rabbita Tabs
+
+Headless tablist behavior for Rabbita apps. The package owns roving tabindex,
+horizontal keyboard navigation (ArrowLeft/Right wrap, Home/End jump), focus
+movement, and ARIA roles/relationships; the consumer owns the tab data, panel
+ids, selected state, HTML structure, and styling.
+
+The behavior is automatic-activation (selection follows focus) and derived, not a
+store: durable selection stays in the consumer's own model, and a `Model` is
+rebuilt each render from `(id, tab_count, selected)`. Keyboard navigation reports
+the tab index that should become selected; the consumer maps that index onto its
+own domain via the `dispatch` callback.
+
+## Use
+
+```mbt nocheck
+fn view(emit : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
+  let tab_defs = [(Problems, "Problems"), (OpLog, "Op Log")]
+  let selected = index_of(model.bottom_tab, tab_defs)
+  let tabs = @tabs.Model::new(
+    id="canopy-bottom-tabs",
+    tab_count=tab_defs.length(),
+    selected~,
+  )
+  let buttons = []
+  for i in 0..<tab_defs.length() {
+    let (tab, label) = tab_defs[i]
+    buttons.push(
+      @html.button(
+        class="tab",
+        attrs=tabs.tab_attrs(
+          i,
+          panel_id=panel_id(tab),
+          dispatch=j => emit(SelectTab(tab_defs[j].0)),
+        ),
+        label,
+      ),
+    )
+  }
+  @html.div(class="tabs", attrs=@tabs.tablist_attrs(label="Sections"), buttons)
+}
+```
+
+Render the active tabpanel with `Model::panel_attrs(index, panel_id=...)`, passing
+the same consumer-owned panel id used for `aria-controls`. After updating the
+selected tab in the consumer model, return `Model::focus_cmd()` so roving tabindex
+moves actual DOM focus once Rabbita patches the view.
+
+## Verified Rabbita APIs
+
+Implementation was checked against the vendored Rabbita source, especially:
+
+- `rabbita/rabbita/html/{attrs.mbt,attrs_event.mbt,README.mbt.md}`
+- `rabbita/doc/002_writing_html/readme.mbt.md`
+- `rabbita/doc/004_using_command/readme.mbt.md`
+- `rabbita/rabbita/cmd/commands.mbt`

--- a/lib/tabs/moon.mod.json
+++ b/lib/tabs/moon.mod.json
@@ -1,0 +1,25 @@
+{
+  "name": "dowdiness/rabbita-tabs",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.4"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [
+    "rabbita",
+    "tabs",
+    "headless-ui",
+    "component",
+    "moonbit",
+    "tea"
+  ],
+  "description": "Headless tablist behavior helpers for Rabbita.",
+  "preferred-target": "native",
+  "supported-targets": "js+native"
+}

--- a/lib/tabs/src/tabs/attrs.mbt
+++ b/lib/tabs/src/tabs/attrs.mbt
@@ -1,0 +1,118 @@
+///|
+fn bool_attr(value : Bool) -> String {
+  if value {
+    "true"
+  } else {
+    "false"
+  }
+}
+
+///|
+/// Attrs for the tablist container element.
+pub fn tablist_attrs(label~ : String) -> @html.Attrs {
+  @html.Attrs::build().role("tablist").aria_label(label)
+}
+
+///|
+/// Roving-tabindex and ARIA attrs for the tab button at `index`. `aria-controls`
+/// is set only on the selected tab — the other panels are not mounted, so
+/// cross-referencing missing ids would mislead assistive tech. The selected
+/// panel's `aria-labelledby` still ties it back to its tab button.
+fn Model::base_tab_attrs(
+  self : Model,
+  index : Int,
+  panel_id : String,
+) -> @html.Attrs {
+  let selected = self.is_selected(index)
+  let attrs = @html.Attrs::build()
+    .id(self.tab_button_id(index))
+    .role("tab")
+    .aria_selected(bool_attr(selected))
+    .tabindex(if selected { 0 } else { -1 })
+  if selected {
+    attrs.aria_controls(panel_id)
+  } else {
+    attrs
+  }
+}
+
+///|
+#cfg(target="js")
+pub fn Model::tab_attrs(
+  self : Model,
+  index : Int,
+  panel_id~ : String,
+  dispatch~ : (Int) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  self
+  .base_tab_attrs(index, panel_id)
+  .on_click(_ => dispatch(index))
+  .on_keydown(event => {
+    match self.nav_target(event.key()) {
+      Some(target) => {
+        event.prevent_default()
+        dispatch(target)
+      }
+      None => @rabbita.none
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::tab_attrs(
+  self : Model,
+  index : Int,
+  panel_id~ : String,
+  dispatch~ : (Int) -> @rabbita.Cmd,
+) -> @html.Attrs {
+  ignore(dispatch)
+  self.base_tab_attrs(index, panel_id)
+}
+
+///|
+/// ARIA attrs for the tabpanel at `index`. The panel id is consumer-owned so
+/// existing/legacy container ids survive the migration; `aria-labelledby` points
+/// back at the behavior-owned tab button id.
+pub fn Model::panel_attrs(
+  self : Model,
+  index : Int,
+  panel_id~ : String,
+) -> @html.Attrs {
+  @html.Attrs::build()
+  .id(panel_id)
+  .role("tabpanel")
+  .aria_labelledby(self.tab_button_id(index))
+  .tabindex(0)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn focus_element_by_id(id : String) -> Unit =
+  #| (id) => {
+  #|   const el = document.getElementById(id);
+  #|   if (el && typeof el.focus === "function") {
+  #|     el.focus();
+  #|   }
+  #| }
+
+///|
+/// Focus the selected tab button after the next render. Roving tabindex makes
+/// inactive tabs unreachable via Tab, so keyboard navigation would otherwise
+/// leave focus stranded on the previous (now `tabindex="-1"`) button.
+#cfg(target="js")
+pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
+  if self.tab_count <= 0 {
+    @rabbita.none
+  } else {
+    let id = self.tab_button_id(self.selected)
+    @cmd.custom_cmd(_ => focus_element_by_id(id), kind=@cmd.after_render)
+  }
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
+  ignore(self)
+  @rabbita.none
+}

--- a/lib/tabs/src/tabs/moon.pkg
+++ b/lib/tabs/src/tabs/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
+warnings = "-unused_package"
+
+supported_targets = "js+native"

--- a/lib/tabs/src/tabs/pkg.generated.mbti
+++ b/lib/tabs/src/tabs/pkg.generated.mbti
@@ -1,0 +1,28 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita-tabs/tabs"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
+// Values
+pub fn tablist_attrs(label~ : String) -> @html.Attrs
+
+// Errors
+
+// Types and methods
+pub struct Model {
+  // private fields
+}
+pub fn Model::focus_cmd(Self) -> @cmd.Cmd
+pub fn Model::nav_target(Self, String) -> Int?
+pub fn Model::new(id~ : String, tab_count~ : Int, selected~ : Int) -> Self
+pub fn Model::panel_attrs(Self, Int, panel_id~ : String) -> @html.Attrs
+pub fn Model::tab_attrs(Self, Int, panel_id~ : String, dispatch~ : (Int) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::tab_button_id(Self, Int) -> String
+
+// Type aliases
+
+// Traits
+

--- a/lib/tabs/src/tabs/pkg.generated.mbti
+++ b/lib/tabs/src/tabs/pkg.generated.mbti
@@ -20,7 +20,6 @@ pub fn Model::nav_target(Self, String) -> Int?
 pub fn Model::new(id~ : String, tab_count~ : Int, selected~ : Int) -> Self
 pub fn Model::panel_attrs(Self, Int, panel_id~ : String) -> @html.Attrs
 pub fn Model::tab_attrs(Self, Int, panel_id~ : String, dispatch~ : (Int) -> @cmd.Cmd) -> @html.Attrs
-pub fn Model::tab_button_id(Self, Int) -> String
 
 // Type aliases
 

--- a/lib/tabs/src/tabs/tabs_wbtest.mbt
+++ b/lib/tabs/src/tabs/tabs_wbtest.mbt
@@ -1,0 +1,67 @@
+///|
+fn assert_selected(model : Model, expected : Int) -> Unit raise {
+  assert_eq(model.selected, expected)
+}
+
+///|
+test "new clamps negative tab counts to zero" {
+  let model = Model::new(id="tabs", tab_count=-3, selected=1)
+  assert_eq(model.tab_count, 0)
+  assert_selected(model, 0)
+}
+
+///|
+test "new clamps selected into range" {
+  assert_selected(Model::new(id="tabs", tab_count=4, selected=2), 2)
+  assert_selected(Model::new(id="tabs", tab_count=4, selected=9), 3)
+  assert_selected(Model::new(id="tabs", tab_count=4, selected=-1), 0)
+  assert_selected(Model::new(id="tabs", tab_count=0, selected=2), 0)
+}
+
+///|
+test "tab_button_id uses index suffix" {
+  let model = Model::new(id="canopy-bottom-tabs", tab_count=3, selected=0)
+  assert_eq(model.tab_button_id(0), "canopy-bottom-tabs-tab-0")
+  assert_eq(model.tab_button_id(2), "canopy-bottom-tabs-tab-2")
+}
+
+///|
+test "nav_target wraps around with arrows" {
+  let model = Model::new(id="tabs", tab_count=3, selected=0)
+  inspect(model.nav_target("ArrowRight") is Some(1), content="true")
+  inspect(model.nav_target("ArrowLeft") is Some(2), content="true")
+  let last = Model::new(id="tabs", tab_count=3, selected=2)
+  inspect(last.nav_target("ArrowRight") is Some(0), content="true")
+}
+
+///|
+test "nav_target jumps to ends with Home and End" {
+  let model = Model::new(id="tabs", tab_count=5, selected=2)
+  inspect(model.nav_target("Home") is Some(0), content="true")
+  inspect(model.nav_target("End") is Some(4), content="true")
+}
+
+///|
+test "nav_target ignores vertical arrows and other keys" {
+  let model = Model::new(id="tabs", tab_count=3, selected=1)
+  inspect(model.nav_target("ArrowUp") is None, content="true")
+  inspect(model.nav_target("ArrowDown") is None, content="true")
+  inspect(model.nav_target("Enter") is None, content="true")
+  inspect(model.nav_target(" ") is None, content="true")
+  inspect(model.nav_target("a") is None, content="true")
+}
+
+///|
+test "nav_target is empty-safe with no tabs" {
+  let model = Model::new(id="tabs", tab_count=0, selected=0)
+  inspect(model.nav_target("ArrowRight") is None, content="true")
+  inspect(model.nav_target("Home") is None, content="true")
+}
+
+///|
+test "nav_target on a single tab stays put" {
+  let model = Model::new(id="tabs", tab_count=1, selected=0)
+  inspect(model.nav_target("ArrowRight") is Some(0), content="true")
+  inspect(model.nav_target("ArrowLeft") is Some(0), content="true")
+  inspect(model.nav_target("End") is Some(0), content="true")
+}

--- a/lib/tabs/src/tabs/types.mbt
+++ b/lib/tabs/src/tabs/types.mbt
@@ -24,12 +24,8 @@ fn normalized_count(tab_count : Int) -> Int {
 fn clamp_selected(selected : Int, tab_count : Int) -> Int {
   if tab_count <= 0 {
     0
-  } else if selected < 0 {
-    0
-  } else if selected >= tab_count {
-    tab_count - 1
   } else {
-    selected
+    selected.max(0).min(tab_count - 1)
   }
 }
 
@@ -48,8 +44,10 @@ pub fn Model::new(id~ : String, tab_count~ : Int, selected~ : Int) -> Model {
 }
 
 ///|
-/// The stable DOM id for the tab button at `index`.
-pub fn Model::tab_button_id(self : Model, index : Int) -> String {
+/// The stable DOM id for the tab button at `index`. Internal: the behavior owns
+/// the button-id scheme, so `tab_attrs`/`panel_attrs`/`focus_cmd` stay
+/// internally consistent (matches `lib/menu`'s private `item_id`).
+fn Model::tab_button_id(self : Model, index : Int) -> String {
   self.id + "-tab-" + index.to_string()
 }
 

--- a/lib/tabs/src/tabs/types.mbt
+++ b/lib/tabs/src/tabs/types.mbt
@@ -1,0 +1,74 @@
+///|
+/// Headless tablist behavior state: a stable id prefix, the number of tabs, and
+/// the index of the selected tab.
+///
+/// The behavior is derived, not a store. Durable selection lives in the
+/// consumer's own model; a `Model` is rebuilt each render from
+/// `(id, tab_count, selected)`. This is automatic-activation (selection follows
+/// focus): keyboard navigation reports the tab index that should become
+/// selected, and the consumer maps that index onto its own domain.
+pub struct Model {
+  priv id : String
+  priv tab_count : Int
+  priv selected : Int
+}
+
+///|
+fn normalized_count(tab_count : Int) -> Int {
+  tab_count.max(0)
+}
+
+///|
+/// Clamp a selected index into `[0, tab_count - 1]`, falling back to `0` when
+/// there are no tabs so downstream getters stay total.
+fn clamp_selected(selected : Int, tab_count : Int) -> Int {
+  if tab_count <= 0 {
+    0
+  } else if selected < 0 {
+    0
+  } else if selected >= tab_count {
+    tab_count - 1
+  } else {
+    selected
+  }
+}
+
+///|
+fn Model::is_selected(self : Model, index : Int) -> Bool {
+  self.selected == index
+}
+
+///|
+/// Create tab behavior state for a stable id prefix, tab count, and the
+/// currently selected tab index. `tab_count` is clamped to non-negative and
+/// `selected` into `[0, tab_count - 1]` (`0` when there are no tabs).
+pub fn Model::new(id~ : String, tab_count~ : Int, selected~ : Int) -> Model {
+  let tab_count = normalized_count(tab_count)
+  { id, tab_count, selected: clamp_selected(selected, tab_count) }
+}
+
+///|
+/// The stable DOM id for the tab button at `index`.
+pub fn Model::tab_button_id(self : Model, index : Int) -> String {
+  self.id + "-tab-" + index.to_string()
+}
+
+///|
+/// Map a `keydown` key to the tab index that should become selected, following
+/// the horizontal WAI-ARIA tablist model: ArrowLeft / ArrowRight wrap around,
+/// Home / End jump to the ends. Returns `None` for keys this behavior does not
+/// handle (including ArrowUp / ArrowDown, which APG reserves for scrolling) and
+/// when there are no tabs.
+pub fn Model::nav_target(self : Model, key : String) -> Int? {
+  if self.tab_count <= 0 {
+    None
+  } else {
+    match key {
+      "ArrowLeft" => Some((self.selected + self.tab_count - 1) % self.tab_count)
+      "ArrowRight" => Some((self.selected + 1) % self.tab_count)
+      "Home" => Some(0)
+      "End" => Some(self.tab_count - 1)
+      _ => None
+    }
+  }
+}

--- a/moon.work
+++ b/moon.work
@@ -7,6 +7,7 @@ members = [
   "./lib/resizable",
   "./lib/menu",
   "./lib/context-menu",
+  "./lib/tabs",
   "./lib/dom-boundary",
   "./lib/visualizer",
   "./lib/semantic",


### PR DESCRIPTION
## Summary

Closes #505. Extracts the WAI-ARIA tablist behavior that was inlined in the Ideal bottom panel into a reusable headless primitive **`lib/tabs`** (module `dowdiness/rabbita-tabs`), mirroring the existing `lib/menu` primitive, and migrates `examples/ideal` to consume it. **Behavior-preserving for the user.**

### Responsibility split
- **Library owns:** roving tabindex, the horizontal keyboard model (ArrowLeft/Right wrap, Home/End jump; ArrowUp/Down ignored per APG), `aria-selected`, `aria-controls` (selected tab only), focus-after-render, and the tab-**button** id scheme.
- **Consumer owns:** the **panel** ids (preserving the legacy `canopy-{history,graphviz,incr}-container` ids that render cmds write `innerHTML` to and E2E specs locate), tab data/labels/`tab`-`tab active` classes, durable selection (`model.bottom_tab`), and the index → `BottomTab` mapping.

Behavior is **derived per render** from `(id, tab_count, selected)`, not a second store — so no `Msg`/`update` machinery is introduced (selection already lives in the consumer model). Automatic activation (selection follows focus), matching today's behavior.

### Public API (`dowdiness/rabbita-tabs/tabs`)
`Model::new(id~, tab_count~, selected~)`, `nav_target`, `tab_button_id`, `tablist_attrs(label~)`, `tab_attrs(index, panel_id~, dispatch~)`, `panel_attrs(index, panel_id~)`, `focus_cmd()`. `#cfg(target="js")` / non-js split for the event/focus attrs, exactly like `lib/menu`.

## Reuse check
- **`lib/menu`** — the existing sibling headless primitive; `lib/tabs` mirrors its package layout, `Attrs::build()` chaining, `#cfg` split, and `focus_element_by_id` extern. Not reused directly because menu is single-active-roving-focus with ephemeral focus state + a `Msg`/`update` loop, whereas tabs is automatic-activation with durable consumer-owned selection and no internal state machine.
- **`focus_id_after_render` / `@dom_boundary.focus_id`** (consumer helper) — the old tab focus path; replaced by the library's self-contained `focus_cmd` (matching `lib/menu`). Removed the now-dead `focus_id_after_render`; its siblings (`focus_selector_after_render`, `scroll_selector_after_render`) remain in use.
- New public surface is minimal (see `lib/tabs/src/tabs/pkg.generated.mbti`); the Ideal `main` `.mbti` is unchanged (all consumer functions are private).

## Verification
- `lib/tabs`: 8 whitebox unit tests (keyboard model, clamping, id format); `moon check` js+native; JS release build confirmed the `extern "js"` focus lands in the bundle.
- Workspace `moon test`: 0 failures. Ideal: 1316 js + 24 native pass. `moon check --deny-warn` + `moon fmt --check` clean.
- **E2E** (chromium): new `bottom-tabs-keyboard.spec.ts` (arrow/Home/End nav, wrap, ArrowUp/Down-ignored, tab↔panel ARIA round-trip) — 5/5; regression net `editor-features.spec.ts` (31, incl. Bottom Panel Tabs) + `incr-graph.spec.ts` + `history.spec.ts` all green.
- Codex pre-PR review: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
