### PR TITLE
Preserve fractional context-menu trigger anchors

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -138,6 +138,11 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 - [x] Upstream Rabbita native-dialog `closedby` attribute support.
   Shipped upstream in Rabbita PR #118 and release `rabbita-v0.12.4`, then adopted by Canopy through the patched fork gitlink above. Scope remains intentionally narrow: `Attrs::closedby` and `dialog(closedby?)` emit the limited-support attribute only; they do not polyfill light-dismiss behavior or guarantee non-Baseline browser support.
 
+- [ ] Upstream Rabbita fractional `MouseEvent` coordinates.
+  Why: browser `MouseEvent.clientX/clientY` are JS numbers, but Rabbita currently exposes `get_client_x()` / `get_client_y()` as `Int`, forcing Canopy's context-menu primitive to use a private raw-JS workaround to preserve fractional anchors.
+  Plan: upstream Rabbita issue/PR; decide with maintainers whether the canonical accessors can be corrected to `Double` directly or need a compatibility migration path.
+  Exit: Rabbita exposes fractional client coordinates through its public `MouseEvent` API; Canopy removes the private `lib/context-menu` JS accessors and consumes the upstream API.
+
 - [ ] Report/fix Warren dangling-symlink discovery failure.
   Why: `warren build` can abort while walking Canopy's workspace root when it hits a dangling symlink such as `loom/target -> _build` before `loom/_build` exists: `OSError(@fs.kind(): ".../loom/target": No such file or directory)`. This is not yet proven WSL2-specific; current evidence points to discovery calling `@fs.kind(path)` without first checking `@fs.exists(path)`.
   Plan: upstream issue `moonbit-community/rabbita#119` is open; follow with a narrow PR containing a minimal workspace repro and a discovery-walk guard for missing/dangling paths.

--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -49,6 +49,10 @@ and `Key(key)` in the consumer. For navigation messages, call
 `Model::update`; when `Msg::requests_focus()` is true, return
 `Model::focus_cmd()` after updating the model.
 
+`Point` is in viewport/client coordinates, including fractional browser
+coordinates when available. `panel_attrs` uses those coordinates for fixed
+`left`/`top` anchoring.
+
 ## Verified Rabbita APIs
 
 Implementation was checked against the vendored Rabbita source, especially:

--- a/lib/context-menu/src/context_menu/attrs.mbt
+++ b/lib/context-menu/src/context_menu/attrs.mbt
@@ -22,6 +22,23 @@ fn Model::base_trigger_attrs(self : Model) -> @html.Attrs {
 
 ///|
 #cfg(target="js")
+extern "js" fn mouse_event_client_x(event : @dom.MouseEvent) -> Double = "(event) => event.clientX"
+
+///|
+#cfg(target="js")
+extern "js" fn mouse_event_client_y(event : @dom.MouseEvent) -> Double = "(event) => event.clientY"
+
+///|
+#cfg(target="js")
+fn Point::from_mouse_event(event : @dom.MouseEvent) -> Point {
+  Point(
+    x=Float::from_double(mouse_event_client_x(event)),
+    y=Float::from_double(mouse_event_client_y(event)),
+  )
+}
+
+///|
+#cfg(target="js")
 pub fn Model::trigger_attrs(
   self : Model,
   on_open : (Point) -> @rabbita.Cmd,
@@ -30,12 +47,7 @@ pub fn Model::trigger_attrs(
   .base_trigger_attrs()
   .on_contextmenu(event => {
     event.prevent_default()
-    on_open(
-      Point(
-        x=Float::from_int(event.get_client_x()),
-        y=Float::from_int(event.get_client_y()),
-      ),
-    )
+    on_open(Point::from_mouse_event(event))
   })
 }
 

--- a/lib/context-menu/src/context_menu/attrs_wbtest.mbt
+++ b/lib/context-menu/src/context_menu/attrs_wbtest.mbt
@@ -1,0 +1,14 @@
+///|
+#cfg(target="js")
+extern "js" fn test_mouse_event(
+  client_x : Double,
+  client_y : Double,
+) -> @dom.MouseEvent = "(clientX, clientY) => ({ clientX, clientY })"
+
+///|
+#cfg(target="js")
+test "mouse event points preserve fractional client coordinates" {
+  let point = Point::from_mouse_event(test_mouse_event(12.5, 34.25))
+  inspect(point.x, content="12.5")
+  inspect(point.y, content="34.25")
+}


### PR DESCRIPTION
## Summary

- Read raw `MouseEvent.clientX/clientY` as JS numbers for `ContextMenu.trigger_attrs` instead of using Rabbita DOM's current `Int` accessors.
- Add a JS-target white-box regression test for fractional event coordinates.
- Document that `Point` is viewport/client space and feeds fixed panel anchoring.

Closes #518.

## Reuse check

- Candidate: `@dom.MouseEvent.get_client_x/get_client_y` in `rabbita/rabbita/dom/mouse_event.mbt`. Covers client coordinates, but returns `Int`, which is the precision loss this issue fixes, so not reused for trigger anchors.
- Candidate: Canvas TypeScript bridge in `examples/canvas/web/src/main.ts`. Already preserves raw fractional browser coordinates for Canvas, but it is a consumer bridge, not the generic Rabbita `trigger_attrs` path.

New private helper boundary: `Point::from_mouse_event` is JS-only and only converts a browser `MouseEvent` into the existing `Point` model type while preserving fractional client coordinates.

## Rabbita docs/source checked

- `rabbita/rabbita/html/README.mbt.md`
- `rabbita/rabbita/html/attrs_event.mbt`
- `rabbita/rabbita/dom/mouse_event.mbt`
- `rabbita/rabbita/dom/README.mbt.md`

## Validation

- `NEW_MOON_MOD=0 moon check --deny-warn`
- `cd lib/context-menu && NEW_MOON_MOD=0 moon test`
- `cd lib/context-menu && NEW_MOON_MOD=0 moon test --target js`
- `NEW_MOON_MOD=0 moon test --release`
- `cd examples/canvas/web && npm run build`

