### PR TITLE
feat(context-menu): add dismissable layer subscriptions

### DIFF
--- a/examples/canvas/main/context_menu.mbt
+++ b/examples/canvas/main/context_menu.mbt
@@ -290,7 +290,7 @@ fn context_menu_sub_loader(
 #cfg(target="js")
 fn context_menu_subscriptions(
   emit : @rabbita.Emit[CanvasContextMenuMsg],
-  _model : CanvasContextMenuModel,
+  model : CanvasContextMenuModel,
 ) -> @sub.Sub {
   @sub.batch([
     @sub.custom_sub(
@@ -305,6 +305,7 @@ fn context_menu_subscriptions(
       CanvasContextMenuSub::HideEvent(emit),
       context_menu_sub_loader,
     ),
+    model.context_menu.subscriptions(emit.map(msg => ContextMenu(msg))),
   ])
 }
 

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -265,6 +265,15 @@ test('canvas context menu supports headless keyboard navigation and dismissal', 
   await expect(menu).toBeHidden();
 
   await openBackgroundContextMenu(page);
+  await page.locator('#node-search').focus();
+  await page.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+
+  await openBackgroundContextMenu(page);
+  await page.locator('#node-search').click();
+  await expect(menu).toBeHidden();
+
+  await openBackgroundContextMenu(page);
   await expect(items.nth(0)).toBeFocused();
   await page.keyboard.press('ArrowDown');
   await expect(items.nth(1)).toBeFocused();

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -851,7 +851,6 @@ root.addEventListener('contextmenu', (e: MouseEvent) => {
 });
 
 document.addEventListener('keydown', (e: KeyboardEvent) => {
-  if (e.key === 'Escape') hideContextMenu();
   if (
     (e.key === 'Delete' || e.key === 'Backspace') &&
     !e.metaKey &&
@@ -870,10 +869,6 @@ document.addEventListener('keydown', (e: KeyboardEvent) => {
     e.preventDefault();
     console.table(adapter.actionLog());
   }
-});
-
-document.addEventListener('pointerdown', (e: PointerEvent) => {
-  if (!contextMenu.contains(e.target as Node)) hideContextMenu();
 });
 
 search.addEventListener('input', () => renderLibrary(search.value));

--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -41,6 +41,10 @@ fn view(emit : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
     },
   ])
 }
+
+fn subscriptions(emit : @rabbita.Emit[Msg], model : Model) -> @sub.Sub {
+  model.context_menu.subscriptions(emit.map(msg => ContextMenu(msg)))
+}
 ```
 
 Open with `model.context_menu.open(anchor=point, item_count=items.length())`,
@@ -48,6 +52,12 @@ then return `model.context_menu.focus_cmd()`. Handle `Activate(index)`, `Close`,
 and `Key(key)` in the consumer. For navigation messages, call
 `Model::update`; when `Msg::requests_focus()` is true, return
 `Model::focus_cmd()` after updating the model.
+
+Return `model.context_menu.subscriptions(...)` from the owning cell's
+subscriptions callback to install reusable dismissal behavior while the menu is
+open. The subscription emits `Close` for outside pointer presses and for Escape
+when focus is outside the menu panel; Escape inside the panel is handled by
+`panel_attrs`.
 
 `Point` is in viewport/client coordinates, including fractional browser
 coordinates when available. `panel_attrs` uses those coordinates for fixed
@@ -60,6 +70,8 @@ Implementation was checked against the vendored Rabbita source, especially:
 - `rabbita/rabbita/html/README.mbt.md`
 - `rabbita/rabbita/html/attrs_event.mbt`
 - `rabbita/rabbita/dom/mouse_event.mbt`
+- `rabbita/doc/using_subscriptions/readme.mbt.md`
 - `rabbita/rabbita/sub/README.mbt.md`
 - `rabbita/rabbita/sub/design.md`
+- `rabbita/rabbita/dom/README.mbt.md`
 - `rabbita/rabbita/cmd/commands.mbt`

--- a/lib/context-menu/src/context_menu/moon.pkg
+++ b/lib/context-menu/src/context_menu/moon.pkg
@@ -1,8 +1,11 @@
 import {
+  "moonbitlang/core/ref",
   "dowdiness/rabbita-menu/menu",
   "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
 }
 
 warnings = "-unused_package"

--- a/lib/context-menu/src/context_menu/pkg.generated.mbti
+++ b/lib/context-menu/src/context_menu/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "dowdiness/rabbita-context-menu/context_menu"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
 }
 
 // Values
@@ -22,6 +23,7 @@ pub fn Model::item_attrs(Self, Int, (Msg) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::new(id~ : String) -> Self
 pub fn Model::open(Self, anchor~ : Point, item_count~ : Int) -> Self
 pub fn Model::panel_attrs(Self, (Msg) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::subscriptions(Self, @cmd.Emit[Msg]) -> @sub.Sub
 pub fn Model::trigger_attrs(Self, (Point) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::update(Self, Msg) -> Self
 

--- a/lib/context-menu/src/context_menu/subscriptions.mbt
+++ b/lib/context-menu/src/context_menu/subscriptions.mbt
@@ -1,0 +1,106 @@
+///|
+#cfg(target="js")
+priv suberror DismissableLayerSub {
+  DismissableLayer(String, @rabbita.Emit[Msg])
+}
+
+///|
+#cfg(target="js")
+extern "js" fn event_target_is_inside_element_id(
+  id : String,
+  event : @dom.Event,
+) -> Bool =
+  #| (id, event) => {
+  #|   const root = document.getElementById(id);
+  #|   const target = event && event.target;
+  #|   return !!(root && target instanceof Node && root.contains(target));
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn event_is_undismissed_escape(
+  id : String,
+  event : @dom.Event,
+) -> Bool =
+  #| (id, event) => {
+  #|   if (!event || event.key !== "Escape" || event.defaultPrevented) return false;
+  #|   const root = document.getElementById(id);
+  #|   const target = event.target;
+  #|   return !(root && target instanceof Node && root.contains(target));
+  #| }
+
+///|
+#cfg(target="js")
+fn dismissable_layer_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    DismissableLayer(id, emit) => {
+      let tagger = @ref.Ref(emit)
+      let target = @dom.document().as_event_target()
+      let pointer_listener : @dom.Listener = event => {
+        if !event_target_is_inside_element_id(id, event) {
+          scheduler.add((tagger.val)(Close))
+        }
+      }
+      let key_listener : @dom.Listener = event => {
+        if event_is_undismissed_escape(id, event) {
+          scheduler.add((tagger.val)(Close))
+        }
+      }
+      target.add_event_listener("pointerdown", pointer_listener)
+      target.add_event_listener("keydown", key_listener)
+      Some({
+        unload: _ => {
+          target.remove_event_listener("pointerdown", pointer_listener)
+          target.remove_event_listener("keydown", key_listener)
+        },
+        update_tagger: payload => {
+          guard payload is DismissableLayer(_, new_emit) else { return }
+          tagger.val = new_emit
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn dismissable_layer_sub(id : String, emit : @rabbita.Emit[Msg]) -> @sub.Sub {
+  @sub.custom_sub(
+    "context-menu.dismissable-layer(id=\{id})",
+    @sub.Scope::Local,
+    DismissableLayer(id, emit),
+    dismissable_layer_loader,
+  )
+}
+
+///|
+/// Subscribe to document-level dismissal behavior while the context menu is open.
+///
+/// The subscription emits `Close` for outside pointer presses and for `Escape`
+/// when focus is outside the menu panel. `Escape` pressed inside the panel is
+/// handled by `panel_attrs`, which also prevents the default key action.
+#cfg(target="js")
+pub fn Model::subscriptions(
+  self : Model,
+  emit : @rabbita.Emit[Msg],
+) -> @sub.Sub {
+  if self.is_open() {
+    dismissable_layer_sub(self.id, emit)
+  } else {
+    @sub.none
+  }
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::subscriptions(
+  self : Model,
+  emit : @rabbita.Emit[Msg],
+) -> @sub.Sub {
+  ignore((self, emit))
+  @sub.none
+}


### PR DESCRIPTION
## Summary
- add ContextMenu `Model::subscriptions` for reusable outside-pointer and outside-Escape dismissal
- migrate Canvas Rabbita island to the reusable dismissal subscription
- remove Canvas document-level TS outside-click/Escape close listeners and extend E2E coverage

Closes #519.

## Reuse check
- Reused Rabbita `@sub.custom_sub` + `RunningSub.update_tagger` stable-tagger pattern from `rabbita/rabbita/sub/design.md` and existing Canopy custom subscriptions.
- Reused existing `@menu.panel_attrs` Escape handling for in-panel keydown; the new document listener ignores in-panel Escape to avoid duplicate close messages.
- Reused `@dom.document().as_event_target().add_event_listener` from Rabbita DOM bindings; only added narrow JS predicates for `Node.contains`/Escape filtering because Rabbita does not expose `contains` directly.

## Docs checked
- `rabbita/doc/using_subscriptions/readme.mbt.md`
- `rabbita/rabbita/sub/README.mbt.md`
- `rabbita/rabbita/sub/design.md`
- `rabbita/rabbita/dom/README.mbt.md`
- `rabbita/rabbita/html/README.mbt.md`
- `rabbita/rabbita/html/design.md`

## Validation
- `cd lib/context-menu && NEW_MOON_MOD=0 moon check --deny-warn`
- `cd examples/canvas && NEW_MOON_MOD=0 moon check --deny-warn`
- `NEW_MOON_MOD=0 moon check --deny-warn`
- `NEW_MOON_MOD=0 moon test`
- `cd examples/canvas/web && npx playwright test e2e/canvas-handles.spec.ts -g "canvas context menu supports headless keyboard navigation and dismissal"`
- `cd examples/canvas/web && npm run build`
- `cd examples/canvas/web && npx tsc --noEmit`
