### PR TITLE
feat(context-menu): restore focus after close

### DIFF
--- a/examples/canvas/main/context_menu.mbt
+++ b/examples/canvas/main/context_menu.mbt
@@ -8,6 +8,9 @@
 let context_menu_root_id : String = "context-menu"
 
 ///|
+let canvas_root_id : String = "canvas-root"
+
+///|
 let context_menu_panel_id : String = "canvas-context-menu-panel"
 
 ///|
@@ -68,7 +71,8 @@ fn context_menu_model(
 ) -> CanvasContextMenuModel {
   {
     items: [],
-    context_menu: @context_menu.Model::new(id=context_menu_panel_id),
+    context_menu: @context_menu.Model::new(id=context_menu_panel_id)
+      .with_close_focus_id(canvas_root_id),
     on_select,
     on_close,
   }
@@ -151,12 +155,24 @@ fn context_menu_update(
           match model.items.get(index) {
             Some(item) => {
               let cmd = context_menu_select_cmd(model, item.key)
+              let cmd = if context_menu_msg.requests_close_focus() {
+                @rabbita.batch([cmd, model.context_menu.close_focus_cmd()])
+              } else {
+                cmd
+              }
               (cmd, model.with_context_menu_msg(context_menu_msg))
             }
             None => (@rabbita.none, model)
           }
-        @context_menu.Close => {
-          let cmd = context_menu_close_cmd(model)
+        @context_menu.Close | @context_menu.Dismiss(_) => {
+          let cmd = if context_menu_msg.requests_close_focus() {
+            @rabbita.batch([
+              context_menu_close_cmd(model),
+              model.context_menu.close_focus_cmd(),
+            ])
+          } else {
+            context_menu_close_cmd(model)
+          }
           (cmd, model.with_context_menu_msg(context_menu_msg))
         }
         @context_menu.Key(_) => {

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -241,6 +241,8 @@ test('canvas context menu supports headless keyboard navigation and dismissal', 
   await expect(page.locator('.canvas-node')).toHaveCount(6);
 
   const menu = page.locator('#context-menu');
+  const canvasRoot = page.locator('#canvas-root');
+  const searchInput = page.locator('#node-search');
   const items = contextMenuItems(page);
 
   await openBackgroundContextMenu(page);
@@ -263,15 +265,18 @@ test('canvas context menu supports headless keyboard navigation and dismissal', 
 
   await page.keyboard.press('Escape');
   await expect(menu).toBeHidden();
+  await expect(canvasRoot).toBeFocused();
 
   await openBackgroundContextMenu(page);
-  await page.locator('#node-search').focus();
+  await searchInput.focus();
   await page.keyboard.press('Escape');
   await expect(menu).toBeHidden();
+  await expect(canvasRoot).toBeFocused();
 
   await openBackgroundContextMenu(page);
-  await page.locator('#node-search').click();
+  await searchInput.click();
   await expect(menu).toBeHidden();
+  await expect(searchInput).toBeFocused();
 
   await openBackgroundContextMenu(page);
   await expect(items.nth(0)).toBeFocused();
@@ -280,6 +285,7 @@ test('canvas context menu supports headless keyboard navigation and dismissal', 
   await page.keyboard.press('Enter');
   await expect(page.locator('.canvas-node')).toHaveCount(7);
   await expect(menu).toBeHidden();
+  await expect(canvasRoot).toBeFocused();
 
   await openBackgroundContextMenu(page);
   await expect(items.nth(0)).toBeFocused();
@@ -288,6 +294,7 @@ test('canvas context menu supports headless keyboard navigation and dismissal', 
   await page.keyboard.press('Space');
   await expect(page.locator('.canvas-node')).toHaveCount(8);
   await expect(menu).toBeHidden();
+  await expect(canvasRoot).toBeFocused();
   expect(runtimeErrors).toEqual([]);
 });
 

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -610,7 +610,7 @@
 
     <div id="source-panel-root"></div>
 
-    <section id="canvas-root" aria-label="Workflow canvas">
+    <section id="canvas-root" tabindex="-1" aria-label="Workflow canvas">
       <svg id="edges" xmlns="http://www.w3.org/2000/svg"></svg>
       <div id="world"></div>
     </section>

--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -12,6 +12,13 @@ struct Model {
   context_menu : @context_menu.Model
 }
 
+fn new_model() -> Model {
+  {
+    context_menu: @context_menu.Model::new(id="actions-menu")
+      .with_close_focus_id("menu-origin"),
+  }
+}
+
 enum Msg {
   OpenMenu(@context_menu.Point)
   ContextMenu(@context_menu.Msg)
@@ -55,9 +62,16 @@ and `Key(key)` in the consumer. For navigation messages, call
 
 Return `model.context_menu.subscriptions(...)` from the owning cell's
 subscriptions callback to install reusable dismissal behavior while the menu is
-open. The subscription emits `Close` for outside pointer presses and for Escape
-when focus is outside the menu panel; Escape inside the panel is handled by
-`panel_attrs`.
+open. The subscription emits `Dismiss(PointerOutside)` for outside pointer
+presses and `Dismiss(EscapeKey)` for Escape when focus is outside the menu panel;
+Escape inside the panel is handled by `panel_attrs` as `Close`.
+
+Call `model.context_menu.with_close_focus_id(...)` when a close path should be
+able to restore focus to a stable origin. After handling `Activate`, `Close`, or
+a dismissal message, use `Msg::requests_close_focus()` to decide whether to batch
+`model.context_menu.close_focus_cmd()` with the consumer's close effects. Pointer
+outside dismissal deliberately does not request close-focus restoration, so a
+click into another control can keep focus there.
 
 `Point` is in viewport/client coordinates, including fractional browser
 coordinates when available. `panel_attrs` uses those coordinates for fixed
@@ -67,6 +81,7 @@ coordinates when available. `panel_attrs` uses those coordinates for fixed
 
 Implementation was checked against the vendored Rabbita source, especially:
 
+- `rabbita/rabbita/internal/runtime/README.mbt.md`
 - `rabbita/rabbita/html/README.mbt.md`
 - `rabbita/rabbita/html/attrs_event.mbt`
 - `rabbita/rabbita/dom/mouse_event.mbt`

--- a/lib/context-menu/src/context_menu/attrs_wbtest.mbt
+++ b/lib/context-menu/src/context_menu/attrs_wbtest.mbt
@@ -12,3 +12,18 @@ test "mouse event points preserve fractional client coordinates" {
   inspect(point.x, content="12.5")
   inspect(point.y, content="34.25")
 }
+
+///|
+test "close focus id is preserved across open and close" {
+  let model = Model::new(id="test-menu").with_close_focus_id("canvas-root")
+  guard model.close_focus_id is Some("canvas-root") else {
+    fail("expected close focus id to be stored")
+  }
+  let opened = model.open(anchor=Point(x=1.0F, y=2.0F), item_count=2)
+  guard opened.close_focus_id is Some("canvas-root") else {
+    fail("expected close focus id to survive open")
+  }
+  guard opened.close().close_focus_id is Some("canvas-root") else {
+    fail("expected close focus id to survive close")
+  }
+}

--- a/lib/context-menu/src/context_menu/context_menu_test.mbt
+++ b/lib/context-menu/src/context_menu/context_menu_test.mbt
@@ -42,3 +42,32 @@ test "activation closes while navigation requests focus" {
   let activated = navigated.update(@context_menu.Activate(1))
   inspect(activated.is_open(), content="false")
 }
+
+///|
+test "activation and keyboard close paths request focus restore" {
+  let model = @context_menu.Model::new(id="test-menu").open(
+    anchor=@context_menu.Point(x=1.0F, y=2.0F),
+    item_count=2,
+  )
+
+  inspect(@context_menu.Activate(0).requests_close_focus(), content="true")
+  inspect(@context_menu.Close.requests_close_focus(), content="true")
+  inspect(
+    @context_menu.Dismiss(@context_menu.EscapeKey).requests_close_focus(),
+    content="true",
+  )
+  inspect(
+    @context_menu.Dismiss(@context_menu.PointerOutside).requests_close_focus(),
+    content="false",
+  )
+
+  inspect(model.update(@context_menu.Activate(0)).is_open(), content="false")
+  inspect(
+    model.update(@context_menu.Dismiss(@context_menu.EscapeKey)).is_open(),
+    content="false",
+  )
+  inspect(
+    model.update(@context_menu.Dismiss(@context_menu.PointerOutside)).is_open(),
+    content="false",
+  )
+}

--- a/lib/context-menu/src/context_menu/focus.mbt
+++ b/lib/context-menu/src/context_menu/focus.mbt
@@ -1,0 +1,27 @@
+///|
+#cfg(target="js")
+extern "js" fn focus_element_by_id(id : String) -> Unit =
+  #| (id) => {
+  #|   const el = document.getElementById(id);
+  #|   if (el && typeof el.focus === "function") {
+  #|     el.focus();
+  #|   }
+  #| }
+
+///|
+/// Focus the configured close-focus origin after the current render flush.
+#cfg(target="js")
+pub fn Model::close_focus_cmd(self : Model) -> @rabbita.Cmd {
+  match self.close_focus_id {
+    Some(id) =>
+      @cmd.custom_cmd(_ => focus_element_by_id(id), kind=@cmd.after_render)
+    None => @rabbita.none
+  }
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::close_focus_cmd(self : Model) -> @rabbita.Cmd {
+  ignore(self.close_focus_id)
+  @rabbita.none
+}

--- a/lib/context-menu/src/context_menu/pkg.generated.mbti
+++ b/lib/context-menu/src/context_menu/pkg.generated.mbti
@@ -12,11 +12,17 @@ import {
 // Errors
 
 // Types and methods
+pub(all) enum DismissReason {
+  PointerOutside
+  EscapeKey
+}
+
 pub struct Model {
   // private fields
 }
 pub fn Model::anchor(Self) -> Point?
 pub fn Model::close(Self) -> Self
+pub fn Model::close_focus_cmd(Self) -> @cmd.Cmd
 pub fn Model::focus_cmd(Self) -> @cmd.Cmd
 pub fn Model::is_open(Self) -> Bool
 pub fn Model::item_attrs(Self, Int, (Msg) -> @cmd.Cmd) -> @html.Attrs
@@ -26,6 +32,7 @@ pub fn Model::panel_attrs(Self, (Msg) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::subscriptions(Self, @cmd.Emit[Msg]) -> @sub.Sub
 pub fn Model::trigger_attrs(Self, (Point) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::update(Self, Msg) -> Self
+pub fn Model::with_close_focus_id(Self, String) -> Self
 
 pub(all) enum Msg {
   FocusNext
@@ -35,8 +42,10 @@ pub(all) enum Msg {
   FocusItem(Int)
   Activate(Int)
   Close
+  Dismiss(DismissReason)
   Key(String)
 }
+pub fn Msg::requests_close_focus(Self) -> Bool
 pub fn Msg::requests_focus(Self) -> Bool
 
 pub(all) struct Point {

--- a/lib/context-menu/src/context_menu/subscriptions.mbt
+++ b/lib/context-menu/src/context_menu/subscriptions.mbt
@@ -41,12 +41,12 @@ fn dismissable_layer_loader(
       let target = @dom.document().as_event_target()
       let pointer_listener : @dom.Listener = event => {
         if !event_target_is_inside_element_id(id, event) {
-          scheduler.add((tagger.val)(Close))
+          scheduler.add((tagger.val)(Dismiss(PointerOutside)))
         }
       }
       let key_listener : @dom.Listener = event => {
         if event_is_undismissed_escape(id, event) {
-          scheduler.add((tagger.val)(Close))
+          scheduler.add((tagger.val)(Dismiss(EscapeKey)))
         }
       }
       target.add_event_listener("pointerdown", pointer_listener)
@@ -80,9 +80,10 @@ fn dismissable_layer_sub(id : String, emit : @rabbita.Emit[Msg]) -> @sub.Sub {
 ///|
 /// Subscribe to document-level dismissal behavior while the context menu is open.
 ///
-/// The subscription emits `Close` for outside pointer presses and for `Escape`
-/// when focus is outside the menu panel. `Escape` pressed inside the panel is
-/// handled by `panel_attrs`, which also prevents the default key action.
+/// The subscription emits `Dismiss(PointerOutside)` for outside pointer presses
+/// and `Dismiss(EscapeKey)` for `Escape` when focus is outside the menu panel.
+/// `Escape` pressed inside the panel is handled by `panel_attrs`, which also
+/// prevents the default key action.
 #cfg(target="js")
 pub fn Model::subscriptions(
   self : Model,

--- a/lib/context-menu/src/context_menu/types.mbt
+++ b/lib/context-menu/src/context_menu/types.mbt
@@ -21,10 +21,18 @@ pub struct Model {
   priv id : String
   priv menu : @menu.Model
   priv anchor : Point?
+  priv close_focus_id : String?
 }
 
 ///|
-/// Context-menu behavior messages emitted by panel and item attrs.
+/// Why a document-level dismissable-layer subscription requested close.
+pub(all) enum DismissReason {
+  PointerOutside
+  EscapeKey
+}
+
+///|
+/// Context-menu behavior messages emitted by panel, item attrs, and subscriptions.
 pub(all) enum Msg {
   FocusNext
   FocusPrevious
@@ -33,6 +41,7 @@ pub(all) enum Msg {
   FocusItem(Int)
   Activate(Int)
   Close
+  Dismiss(DismissReason)
   Key(String)
 }
 
@@ -59,7 +68,7 @@ fn Msg::to_menu_msg(self : Msg) -> @menu.Msg {
     FocusLast => @menu.FocusLast
     FocusItem(index) => @menu.FocusItem(index)
     Activate(index) => @menu.Activate(index)
-    Close => @menu.Close
+    Close | Dismiss(_) => @menu.Close
     Key(key) => @menu.Key(key)
   }
 }
@@ -67,7 +76,18 @@ fn Msg::to_menu_msg(self : Msg) -> @menu.Msg {
 ///|
 /// Create a closed context-menu model for a stable panel id.
 pub fn Model::new(id~ : String) -> Model {
-  { id, menu: @menu.Model::new(id~, item_count=0), anchor: None }
+  {
+    id,
+    menu: @menu.Model::new(id~, item_count=0),
+    anchor: None,
+    close_focus_id: None,
+  }
+}
+
+///|
+/// Return focus to `id` for close paths where the consumer requests it.
+pub fn Model::with_close_focus_id(self : Model, id : String) -> Model {
+  { ..self, close_focus_id: Some(id) }
 }
 
 ///|
@@ -97,12 +117,12 @@ pub fn Model::close(self : Model) -> Model {
 ///|
 /// Apply one context-menu behavior message.
 ///
-/// Navigation messages update roving focus. `Activate` and `Close` close the
-/// context menu; consumers should still inspect those messages to perform
-/// domain actions or notify their host shell.
+/// Navigation messages update roving focus. `Activate`, `Close`, and `Dismiss`
+/// close the context menu; consumers should still inspect those messages to
+/// perform domain actions or notify their host shell.
 pub fn Model::update(self : Model, msg : Msg) -> Model {
   match msg {
-    Activate(_) | Close => self.close()
+    Activate(_) | Close | Dismiss(_) => self.close()
     Key(_) => self
     FocusNext | FocusPrevious | FocusFirst | FocusLast | FocusItem(_) =>
       { ..self, menu: self.menu.update(msg.to_menu_msg()) }
@@ -112,7 +132,26 @@ pub fn Model::update(self : Model, msg : Msg) -> Model {
 ///|
 /// Whether handling this message should be followed by `Model::focus_cmd()`.
 pub fn Msg::requests_focus(self : Msg) -> Bool {
-  self.to_menu_msg().requests_focus()
+  match self {
+    FocusNext | FocusPrevious | FocusFirst | FocusLast => true
+    FocusItem(_) | Activate(_) | Close | Dismiss(_) | Key(_) => false
+  }
+}
+
+///|
+/// Whether handling this menu-closing message should restore focus to the
+/// configured close-focus origin.
+pub fn Msg::requests_close_focus(self : Msg) -> Bool {
+  match self {
+    Activate(_) | Close | Dismiss(EscapeKey) => true
+    FocusNext
+    | FocusPrevious
+    | FocusFirst
+    | FocusLast
+    | FocusItem(_)
+    | Dismiss(PointerOutside)
+    | Key(_) => false
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add ContextMenu close-focus origin support via `with_close_focus_id` + `close_focus_cmd`
- distinguish outside-pointer vs Escape dismissal with `DismissReason`, so pointer outside does not steal focus from the clicked target
- migrate Canvas to restore focus to `#canvas-root` for keyboard close and activation paths, with E2E coverage

Depends on #523. Closes #520.

## Reuse check
- Reused `@menu.panel_attrs` for in-panel Escape handling; document-level Escape is now represented as `Dismiss(EscapeKey)` only when focus is outside the panel.
- Reused Rabbita `@cmd.custom_cmd(..., kind=@cmd.after_render)` focus-command pattern from `lib/menu/src/menu/attrs.mbt`.
- Considered `lib/dom-boundary::focus_id`, but did not add that dependency to the standalone `dowdiness/rabbita-context-menu` package; the new focus helper stays a narrow package-local JS command like `lib/menu`.

## Docs checked
- `rabbita/rabbita/internal/runtime/README.mbt.md`
- `rabbita/rabbita/html/README.mbt.md`
- `rabbita/doc/using_subscriptions/readme.mbt.md`
- `rabbita/rabbita/sub/README.mbt.md`
- `rabbita/rabbita/sub/design.md`
- `rabbita/rabbita/dom/README.mbt.md`

## Validation
- `cd lib/context-menu && NEW_MOON_MOD=0 moon check --deny-warn`
- `cd examples/canvas && NEW_MOON_MOD=0 moon check --deny-warn`
- `cd lib/context-menu && NEW_MOON_MOD=0 moon test`
- `cd examples/canvas && NEW_MOON_MOD=0 moon test`
- `NEW_MOON_MOD=0 moon check --deny-warn && NEW_MOON_MOD=0 moon test`
- `cd examples/canvas/web && npx playwright test e2e/canvas-handles.spec.ts -g "canvas context menu supports headless keyboard navigation and dismissal"`
- `cd examples/canvas/web && npm run build`
- `cd examples/canvas/web && npx tsc --noEmit`
