### PR TITLE
feat(context-menu): add viewport positioning

### DIFF
--- a/examples/canvas/main/context_menu.mbt
+++ b/examples/canvas/main/context_menu.mbt
@@ -71,8 +71,9 @@ fn context_menu_model(
 ) -> CanvasContextMenuModel {
   {
     items: [],
-    context_menu: @context_menu.Model::new(id=context_menu_panel_id)
-      .with_close_focus_id(canvas_root_id),
+    context_menu: @context_menu.Model::new(id=context_menu_panel_id).with_close_focus_id(
+      canvas_root_id,
+    ),
     on_select,
     on_close,
   }
@@ -144,7 +145,13 @@ fn context_menu_update(
       match decode_context_menu_payload(json_text) {
         Some(payload) => {
           let model = model.with_payload(payload)
-          (model.context_menu.focus_cmd(), model)
+          (
+            @rabbita.batch([
+              model.context_menu.position_cmd(),
+              model.context_menu.focus_cmd(),
+            ]),
+            model,
+          )
         }
         None => (@rabbita.none, model.closed())
       }

--- a/examples/canvas/web/e2e/canvas-handles.spec.ts
+++ b/examples/canvas/web/e2e/canvas-handles.spec.ts
@@ -73,6 +73,14 @@ async function openBackgroundContextMenu(page: Page): Promise<void> {
   await page.mouse.click(box.x + box.width - 48, box.y + 48, { button: 'right' });
 }
 
+async function openBottomRightContextMenu(page: Page): Promise<void> {
+  const box = await page.locator('#canvas-root').boundingBox();
+  if (!box) {
+    throw new Error('canvas root is not visible');
+  }
+  await page.mouse.click(box.x + box.width - 4, box.y + box.height - 4, { button: 'right' });
+}
+
 async function dragBetween(page: Page, from: Locator, to: Locator): Promise<void> {
   const start = await center(from, 'source handle');
   const end = await center(to, 'target handle');
@@ -277,6 +285,21 @@ test('canvas context menu supports headless keyboard navigation and dismissal', 
   await searchInput.click();
   await expect(menu).toBeHidden();
   await expect(searchInput).toBeFocused();
+
+  await openBottomRightContextMenu(page);
+  await expect(page.locator('#context-menu [role="menu"]')).toBeVisible();
+  await expect.poll(async () => {
+    const box = await page.locator('#context-menu [role="menu"]').boundingBox();
+    const viewport = page.viewportSize();
+    if (!box || !viewport) return false;
+    return box.x >= 0 &&
+      box.y >= 0 &&
+      box.x + box.width <= viewport.width &&
+      box.y + box.height <= viewport.height;
+  }).toBe(true);
+  await page.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+  await expect(canvasRoot).toBeFocused();
 
   await openBackgroundContextMenu(page);
   await expect(items.nth(0)).toBeFocused();

--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -55,10 +55,11 @@ fn subscriptions(emit : @rabbita.Emit[Msg], model : Model) -> @sub.Sub {
 ```
 
 Open with `model.context_menu.open(anchor=point, item_count=items.length())`,
-then return `model.context_menu.focus_cmd()`. Handle `Activate(index)`, `Close`,
-and `Key(key)` in the consumer. For navigation messages, call
-`Model::update`; when `Msg::requests_focus()` is true, return
-`Model::focus_cmd()` after updating the model.
+then return `@rabbita.batch([model.context_menu.position_cmd(), model.context_menu.focus_cmd()])`.
+Handle `Activate(index)`, `Close`, `Dismiss(reason)`, and `Key(key)` in the
+consumer. For navigation messages, call `Model::update`; when
+`Msg::requests_focus()` is true, return `Model::focus_cmd()` after updating the
+model.
 
 Return `model.context_menu.subscriptions(...)` from the owning cell's
 subscriptions callback to install reusable dismissal behavior while the menu is
@@ -74,8 +75,14 @@ outside dismissal deliberately does not request close-focus restoration, so a
 click into another control can keep focus there.
 
 `Point` is in viewport/client coordinates, including fractional browser
-coordinates when available. `panel_attrs` uses those coordinates for fixed
-`left`/`top` anchoring.
+coordinates when available. `panel_attrs` uses those coordinates for initial
+fixed `left`/`top` anchoring. `Model::position_cmd(positioning?)` can then
+measure the rendered panel after render and apply `Positioning` options:
+
+- `offset_x` / `offset_y` add a visual offset from the anchor.
+- `viewport_margin` controls the minimum gap from viewport edges.
+- `collision=ClampToViewport` keeps the measured panel visible; use
+  `NoCollisionHandling` to keep raw anchor positioning.
 
 ## Verified Rabbita APIs
 

--- a/lib/context-menu/src/context_menu/attrs_wbtest.mbt
+++ b/lib/context-menu/src/context_menu/attrs_wbtest.mbt
@@ -27,3 +27,30 @@ test "close focus id is preserved across open and close" {
     fail("expected close focus id to survive close")
   }
 }
+
+///|
+test "positioning defaults clamp to viewport" {
+  let positioning = Positioning::default()
+  inspect(positioning.offset_x, content="0")
+  inspect(positioning.offset_y, content="0")
+  inspect(positioning.viewport_margin, content="8")
+  guard positioning.collision is ClampToViewport else {
+    fail("expected default positioning to clamp to viewport")
+  }
+}
+
+///|
+test "positioning constructor preserves offsets and collision strategy" {
+  let positioning = Positioning(
+    offset_x=4.5F,
+    offset_y=6.25F,
+    viewport_margin=12.0F,
+    collision=NoCollisionHandling,
+  )
+  inspect(positioning.offset_x, content="4.5")
+  inspect(positioning.offset_y, content="6.25")
+  inspect(positioning.viewport_margin, content="12")
+  guard positioning.collision is NoCollisionHandling else {
+    fail("expected explicit collision strategy")
+  }
+}

--- a/lib/context-menu/src/context_menu/context_menu_test.mbt
+++ b/lib/context-menu/src/context_menu/context_menu_test.mbt
@@ -44,6 +44,24 @@ test "activation closes while navigation requests focus" {
 }
 
 ///|
+test "positioning defaults and custom strategies are public values" {
+  let default_positioning = @context_menu.Positioning::default()
+  guard default_positioning == @context_menu.Positioning() else {
+    fail("expected default positioning to match the default constructor")
+  }
+
+  let custom_positioning = @context_menu.Positioning(
+    offset_x=4.5F,
+    offset_y=6.25F,
+    viewport_margin=12.0F,
+    collision=@context_menu.NoCollisionHandling,
+  )
+  guard custom_positioning != default_positioning else {
+    fail("expected custom positioning options to differ from defaults")
+  }
+}
+
+///|
 test "activation and keyboard close paths request focus restore" {
   let model = @context_menu.Model::new(id="test-menu").open(
     anchor=@context_menu.Point(x=1.0F, y=2.0F),

--- a/lib/context-menu/src/context_menu/pkg.generated.mbti
+++ b/lib/context-menu/src/context_menu/pkg.generated.mbti
@@ -12,6 +12,11 @@ import {
 // Errors
 
 // Types and methods
+pub(all) enum CollisionStrategy {
+  NoCollisionHandling
+  ClampToViewport
+} derive(Eq)
+
 pub(all) enum DismissReason {
   PointerOutside
   EscapeKey
@@ -29,6 +34,7 @@ pub fn Model::item_attrs(Self, Int, (Msg) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::new(id~ : String) -> Self
 pub fn Model::open(Self, anchor~ : Point, item_count~ : Int) -> Self
 pub fn Model::panel_attrs(Self, (Msg) -> @cmd.Cmd) -> @html.Attrs
+pub fn Model::position_cmd(Self, positioning? : Positioning) -> @cmd.Cmd
 pub fn Model::subscriptions(Self, @cmd.Emit[Msg]) -> @sub.Sub
 pub fn Model::trigger_attrs(Self, (Point) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::update(Self, Msg) -> Self
@@ -54,6 +60,13 @@ pub(all) struct Point {
 } derive(Eq)
 pub fn Point::Point(x~ : Float, y~ : Float) -> Self
 
+pub struct Positioning {
+  // private fields
+} derive(Eq)
+pub fn Positioning::Positioning(offset_x? : Float, offset_y? : Float, viewport_margin? : Float, collision? : CollisionStrategy) -> Self
+pub fn Positioning::default() -> Self
+
 // Type aliases
 
 // Traits
+

--- a/lib/context-menu/src/context_menu/positioning.mbt
+++ b/lib/context-menu/src/context_menu/positioning.mbt
@@ -1,0 +1,73 @@
+///|
+#cfg(target="js")
+extern "js" fn apply_panel_position(
+  id : String,
+  anchor_x : Double,
+  anchor_y : Double,
+  offset_x : Double,
+  offset_y : Double,
+  viewport_margin : Double,
+  collision : Int,
+) -> Unit =
+  #| (id, anchorX, anchorY, offsetX, offsetY, viewportMargin, collision) => {
+  #|   const el = document.getElementById(id);
+  #|   if (!el) return;
+  #|
+  #|   let left = anchorX + offsetX;
+  #|   let top = anchorY + offsetY;
+  #|
+  #|   if (collision === 1) {
+  #|     const rect = el.getBoundingClientRect();
+  #|     const width = Number.isFinite(rect.width) ? rect.width : 0;
+  #|     const height = Number.isFinite(rect.height) ? rect.height : 0;
+  #|     const margin = Math.max(0, viewportMargin);
+  #|     const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+  #|     const maxTop = Math.max(margin, window.innerHeight - height - margin);
+  #|     left = Math.min(Math.max(margin, left), maxLeft);
+  #|     top = Math.min(Math.max(margin, top), maxTop);
+  #|   }
+  #|
+  #|   el.style.position = "fixed";
+  #|   el.style.left = `${left}px`;
+  #|   el.style.top = `${top}px`;
+  #| }
+
+///|
+/// Position the open panel after render using the supplied strategy.
+///
+/// `Point` anchors are client/viewport coordinates. The command measures the
+/// rendered panel and applies viewport clamping when requested.
+#cfg(target="js")
+pub fn Model::position_cmd(
+  self : Model,
+  positioning? : Positioning = Positioning::default(),
+) -> @rabbita.Cmd {
+  match self.anchor {
+    Some(anchor) =>
+      @cmd.custom_cmd(
+        _ => {
+          apply_panel_position(
+            self.id,
+            anchor.x.to_double(),
+            anchor.y.to_double(),
+            positioning.offset_x.to_double(),
+            positioning.offset_y.to_double(),
+            positioning.viewport_margin.to_double(),
+            positioning.collision.code(),
+          )
+        },
+        kind=@cmd.after_render,
+      )
+    None => @rabbita.none
+  }
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::position_cmd(
+  self : Model,
+  positioning? : Positioning = Positioning::default(),
+) -> @rabbita.Cmd {
+  ignore((self, positioning))
+  @rabbita.none
+}

--- a/lib/context-menu/src/context_menu/types.mbt
+++ b/lib/context-menu/src/context_menu/types.mbt
@@ -12,6 +12,48 @@ pub fn Point::Point(x~ : Float, y~ : Float) -> Point {
 }
 
 ///|
+/// How the default positioning command handles viewport collision.
+pub(all) enum CollisionStrategy {
+  NoCollisionHandling
+  ClampToViewport
+} derive(Eq)
+
+///|
+/// Positioning options for `Model::position_cmd`.
+pub struct Positioning {
+  priv offset_x : Float
+  priv offset_y : Float
+  priv viewport_margin : Float
+  priv collision : CollisionStrategy
+} derive(Eq)
+
+///|
+/// Create positioning options for a context-menu panel.
+pub fn Positioning::Positioning(
+  offset_x? : Float = 0.0F,
+  offset_y? : Float = 0.0F,
+  viewport_margin? : Float = 8.0F,
+  collision? : CollisionStrategy = ClampToViewport,
+) -> Positioning {
+  { offset_x, offset_y, viewport_margin, collision }
+}
+
+///|
+/// Default positioning: no visual offset and viewport clamping with 8px margin.
+pub fn Positioning::default() -> Positioning {
+  Positioning()
+}
+
+///|
+#cfg(target="js")
+fn CollisionStrategy::code(self : CollisionStrategy) -> Int {
+  match self {
+    NoCollisionHandling => 0
+    ClampToViewport => 1
+  }
+}
+
+///|
 /// Headless context-menu behavior state.
 ///
 /// The consumer owns item data, rendering, and action execution. This model


### PR DESCRIPTION
## Summary
- add ContextMenu `Positioning` options and `position_cmd` after-render measured placement
- support default viewport clamping while preserving client/viewport `Point` coordinates and fractional anchors
- migrate Canvas to run the positioning command on open and add browser coverage for bottom-right collision

Depends on #524. Closes #521.

## Reuse check
- Reused existing `panel_attrs` inline fixed `left`/`top` as the initial placement path, rather than replacing the rendering contract.
- Reused Rabbita `@cmd.custom_cmd(..., kind=@cmd.after_render)` for post-render DOM measurement/adjustment, matching existing focus-command patterns.
- Considered CSS-only clamping, but it cannot reliably account for measured panel width/height; the new helper owns only placement math and leaves item rendering/styling consumer-owned.

## Docs checked
- `rabbita/rabbita/html/README.mbt.md`
- `rabbita/rabbita/html/design.md`
- `rabbita/rabbita/internal/runtime/README.mbt.md`
- `rabbita/rabbita/dom/README.mbt.md`

## Validation
- `cd lib/context-menu && NEW_MOON_MOD=0 moon check --deny-warn`
- `cd examples/canvas && NEW_MOON_MOD=0 moon check --deny-warn`
- `cd lib/context-menu && NEW_MOON_MOD=0 moon test`
- `cd examples/canvas && NEW_MOON_MOD=0 moon test`
- `NEW_MOON_MOD=0 moon check --deny-warn && NEW_MOON_MOD=0 moon test`
- `cd examples/canvas/web && npx playwright test e2e/canvas-handles.spec.ts -g "canvas context menu supports headless keyboard navigation and dismissal"`
- `cd examples/canvas/web && npm run build`
- `cd examples/canvas/web && npx tsc --noEmit`
