### PR TITLE
feat(treeview): extract headless WAI-ARIA tree behavior (#506)

### DIFF
--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -7,6 +7,7 @@ import {
   "dowdiness/rabbita_codemirror/js" @cm_js,
   "dowdiness/rabbita-menu/menu",
   "dowdiness/rabbita-tabs/tabs",
+  "dowdiness/rabbita-treeview/treeview",
   "dowdiness/dom_boundary",
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,

--- a/examples/ideal/main/view_outline.mbt
+++ b/examples/ideal/main/view_outline.mbt
@@ -29,14 +29,8 @@ fn outline_row_rendered(
     return false
   }
   match node.children {
-    @proj.Loaded(children) => {
-      for child in children {
-        if outline_row_rendered(child, key) {
-          return true
-        }
-      }
-      false
-    }
+    @proj.Loaded(children) =>
+      children.iter().any(child => outline_row_rendered(child, key))
     @proj.Elided(_) => false
   }
 }
@@ -196,11 +190,11 @@ fn view_outline_node(
   // `Elided` children mean the subtree exists but isn't materialized, so it is
   // expandable, not a leaf.
   let expansion : @treeview.Expansion = if is_leaf {
-    @treeview.Leaf
+    Leaf
   } else if node.collapsed {
-    @treeview.Collapsed
+    Collapsed
   } else {
-    @treeview.Expanded
+    Expanded
   }
   // Drag-and-drop event handlers chain onto the treeitem ARIA attrs. Selection,
   // click, and drag stay app-owned; the behavior contributes ARIA only.
@@ -339,11 +333,11 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
   let handle_keydown = fn(kb : @html.Keyboard) {
     let key = kb.key()
     match @treeview.command_for_key(key) {
-      Some(@treeview.NavUp) => navigate(@canopy_core.Direction::Up)
-      Some(@treeview.NavDown) => navigate(@canopy_core.Direction::Down)
-      Some(@treeview.NavLeft) => navigate(@canopy_core.Direction::Left)
-      Some(@treeview.NavRight) => navigate(@canopy_core.Direction::Right)
-      Some(@treeview.Activate) =>
+      Some(NavUp) => navigate(@canopy_core.Direction::Up)
+      Some(NavDown) => navigate(@canopy_core.Direction::Down)
+      Some(NavLeft) => navigate(@canopy_core.Direction::Left)
+      Some(NavRight) => navigate(@canopy_core.Direction::Right)
+      Some(Activate) =>
         match get_selected_node_id(model) {
           Some(nid) => {
             let op = if model.outline_state.collapsed_nodes.contains(nid) {

--- a/examples/ideal/main/view_outline.mbt
+++ b/examples/ideal/main/view_outline.mbt
@@ -4,6 +4,64 @@ fn node_id_to_string(id : @canopy_core.NodeId) -> String {
   id.0.to_string()
 }
 
+///|
+/// Headless `@treeview` behavior for the outline. The id prefix is the single
+/// source of the treeitem DOM-id scheme, so the container's
+/// `aria-activedescendant` and each row's `id` round-trip. Rebuilt per use —
+/// the behavior is stateless; selection/expansion live in `model`.
+fn outline_tree_model() -> @treeview.Model {
+  @treeview.Model::new(id="canopy-outline")
+}
+
+///|
+/// Whether the row for `key` is currently rendered, i.e. reachable from the
+/// outline root without descending through a collapsed node. Mirrors exactly
+/// what `view_outline_node` emits (collapsed subtrees render no children), so the
+/// caller never points `aria-activedescendant` at a non-rendered id.
+fn outline_row_rendered(
+  node : @proj.InteractiveTreeNode[@ast.Term],
+  key : String,
+) -> Bool {
+  if node_id_to_string(node.id) == key {
+    return true
+  }
+  if node.collapsed {
+    return false
+  }
+  match node.children {
+    @proj.Loaded(children) => {
+      for child in children {
+        if outline_row_rendered(child, key) {
+          return true
+        }
+      }
+      false
+    }
+    @proj.Elided(_) => false
+  }
+}
+
+///|
+/// The selected node's key, but only when its row is actually rendered. Drives
+/// `aria-activedescendant`: a selection that has scrolled out of the rendered
+/// tree (e.g. an ancestor collapsed, or a re-projection dropped the node) yields
+/// `None` rather than an active descendant that resolves to nothing.
+fn outline_active_node_key(model : Model) -> String? {
+  let sel = match model.selected_node {
+    Some(s) => s
+    None => return None
+  }
+  let root = match model.outline_state.tree {
+    Some(r) => r
+    None => return None
+  }
+  if outline_row_rendered(root, sel) {
+    Some(sel)
+  } else {
+    None
+  }
+}
+
 // NOTE: Position detection (Before/After/Inside) based on mouse-Y is not yet
 // implemented for the outline panel. Rabbita's @html.DragEvent is package-private,
 // so we can't pass it to extern "js" for bounding-rect computation.
@@ -130,10 +188,30 @@ fn view_outline_node(
       row_items.push(span(class="collapsed-badge", [text(count.to_string())]))
     }
   }
-  let select_cmd = dispatch(OutlineNodeClicked(node_id_to_string(node.id)))
-  // Drag-and-drop event handlers
+  let node_key = node_id_to_string(node.id)
+  let select_cmd = dispatch(OutlineNodeClicked(node_key))
+  // WAI-ARIA treeitem state (role / id / level / selected / expanded) from the
+  // headless `@treeview` behavior. `aria-level` is 1-based per the APG, so we
+  // pass `depth + 1`. A `Loaded`-but-empty node is a leaf (no `aria-expanded`);
+  // `Elided` children mean the subtree exists but isn't materialized, so it is
+  // expandable, not a leaf.
+  let expansion : @treeview.Expansion = if is_leaf {
+    @treeview.Leaf
+  } else if node.collapsed {
+    @treeview.Collapsed
+  } else {
+    @treeview.Expanded
+  }
+  // Drag-and-drop event handlers chain onto the treeitem ARIA attrs. Selection,
+  // click, and drag stay app-owned; the behavior contributes ARIA only.
   let node_id = node.id
-  let drag_attrs = @html.Attrs::build()
+  let row_attrs = outline_tree_model()
+    .treeitem_attrs(
+      node_key~,
+      level=depth + 1,
+      selected=is_selected,
+      expansion~,
+    )
     .draggable("true")
     .on_dragstart(fn(e) {
       e.stop_propagation()
@@ -155,7 +233,7 @@ fn view_outline_node(
   let row = div(
     class=row_class,
     on_click=select_cmd,
-    attrs=drag_attrs,
+    attrs=row_attrs,
     row_items,
   )
   let child_views : Array[Html] = if node.collapsed {
@@ -242,30 +320,30 @@ fn build_outline_eval_annotations(
 ///|
 /// Render outline tree view with keyboard navigation (original tree mode).
 fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
+  let navigate = fn(direction : @canopy_core.Direction) {
+    match navigate_outline(model, direction) {
+      Some(id) => dispatch(OutlineNavigate(id))
+      None => @rabbita.none
+    }
+  }
+  // The headless `@treeview` behavior owns the tree keyboard vocabulary. The
+  // four directional commands map onto domain `navigate_proj`; Activate (Enter)
+  // toggles collapse/expand. Keys the behavior does not claim — Delete/Backspace
+  // (structural edit), "." (action overlay), Escape — fall through unchanged.
+  //
+  // Compatibility mode: arrows drive *domain* navigation (parent/child/sibling
+  // via `navigate_proj`), NOT the WAI-ARIA APG expand/collapse-on-arrow model.
+  // The locked outline E2E asserts these navigate_proj semantics; `@treeview`
+  // keeps its `TreeCommand`s direction-named precisely so this consumer can
+  // assign that meaning. See `lib/treeview` for the rationale.
   let handle_keydown = fn(kb : @html.Keyboard) {
     let key = kb.key()
-    match key {
-      "ArrowUp" =>
-        match navigate_outline(model, @canopy_core.Direction::Up) {
-          Some(id) => dispatch(OutlineNavigate(id))
-          None => @rabbita.none
-        }
-      "ArrowDown" =>
-        match navigate_outline(model, @canopy_core.Direction::Down) {
-          Some(id) => dispatch(OutlineNavigate(id))
-          None => @rabbita.none
-        }
-      "ArrowLeft" =>
-        match navigate_outline(model, @canopy_core.Direction::Left) {
-          Some(id) => dispatch(OutlineNavigate(id))
-          None => @rabbita.none
-        }
-      "ArrowRight" =>
-        match navigate_outline(model, @canopy_core.Direction::Right) {
-          Some(id) => dispatch(OutlineNavigate(id))
-          None => @rabbita.none
-        }
-      "Enter" =>
+    match @treeview.command_for_key(key) {
+      Some(@treeview.NavUp) => navigate(@canopy_core.Direction::Up)
+      Some(@treeview.NavDown) => navigate(@canopy_core.Direction::Down)
+      Some(@treeview.NavLeft) => navigate(@canopy_core.Direction::Left)
+      Some(@treeview.NavRight) => navigate(@canopy_core.Direction::Right)
+      Some(@treeview.Activate) =>
         match get_selected_node_id(model) {
           Some(nid) => {
             let op = if model.outline_state.collapsed_nodes.contains(nid) {
@@ -277,28 +355,31 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
           }
           None => @rabbita.none
         }
-      "Delete" | "Backspace" =>
-        match get_selected_node_id(model) {
-          Some(nid) =>
-            dispatch(
-              OutlineStructuralEdit(
-                @lambda_edits.TreeEditOp::Delete(node_id=nid),
-              ),
-            )
-          None => @rabbita.none
+      None =>
+        match key {
+          "Delete" | "Backspace" =>
+            match get_selected_node_id(model) {
+              Some(nid) =>
+                dispatch(
+                  OutlineStructuralEdit(
+                    @lambda_edits.TreeEditOp::Delete(node_id=nid),
+                  ),
+                )
+              None => @rabbita.none
+            }
+          "." =>
+            match model.selected_node {
+              Some(_) => dispatch(OpenActionOverlayFromOutline)
+              None => @rabbita.none
+            }
+          "Escape" =>
+            if model.overlay.visible {
+              dispatch(CloseActionOverlay)
+            } else {
+              dispatch(OutlineNavigate(""))
+            }
+          _ => @rabbita.none
         }
-      "." =>
-        match model.selected_node {
-          Some(_) => dispatch(OpenActionOverlayFromOutline)
-          None => @rabbita.none
-        }
-      "Escape" =>
-        if model.overlay.visible {
-          dispatch(CloseActionOverlay)
-        } else {
-          dispatch(OutlineNavigate(""))
-        }
-      _ => @rabbita.none
     }
   }
   // Build eval annotations map: NodeId → Array[EvalResult]
@@ -308,7 +389,15 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
       div(
         class="tree-rows",
         on_keydown=handle_keydown,
-        attrs=@html.Attrs::build().tabindex(0),
+        // `role="tree"` + roving-free active-descendant: focus stays on this
+        // container (tabindex=0) and the selected row is tracked by id, matching
+        // the pre-existing container-focus model the E2E relies on. The label is
+        // deliberately distinct from the ancestor "AST outline" region so
+        // accessibility-name lookups stay unambiguous.
+        attrs=outline_tree_model().tree_attrs(
+          label="Outline tree",
+          active_node_key?=outline_active_node_key(model),
+        ),
         [view_outline_node(dispatch, root, 0, model, eval_annotations)],
       )
     None => @html.p(class="no-tree-note", "No AST available")

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -18,6 +18,10 @@
       "path": "../../lib/tabs",
       "version": "0.1.0"
     },
+    "dowdiness/rabbita-treeview": {
+      "path": "../../lib/treeview",
+      "version": "0.1.0"
+    },
     "dowdiness/dom_boundary": {
       "path": "../../lib/dom-boundary",
       "version": "0.1.0"

--- a/examples/ideal/web/e2e/outline-aria.spec.ts
+++ b/examples/ideal/web/e2e/outline-aria.spec.ts
@@ -1,0 +1,64 @@
+// E2E test: WAI-ARIA tree semantics emitted by the headless `@treeview`
+// behavior (lib/treeview). The behavior's `tree_attrs` / `treeitem_attrs` return
+// opaque `@html.Attrs`, so the rendered DOM is their only coverage. These tests
+// pin the active-descendant tree pattern: focus stays on the container, the
+// active row is tracked by `aria-activedescendant`, and rows carry
+// role/level/selected/expanded.
+import { test, expect } from '@playwright/test';
+
+test.describe('Outline ARIA (treeview behavior)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveTitle('Canopy Editor');
+    await page.getByRole('button', { name: 'Basics' }).click();
+    await expect(page.getByLabel('AST outline')).toBeVisible();
+  });
+
+  function outline(page: import('@playwright/test').Page) {
+    return page.getByLabel('AST outline');
+  }
+
+  test('tree container exposes role=tree and a distinct label', async ({ page }) => {
+    const rows = outline(page).locator('.tree-rows');
+    await expect(rows).toHaveAttribute('role', 'tree');
+    // Distinct from the ancestor "AST outline" region so getByLabel stays unambiguous.
+    await expect(rows).toHaveAttribute('aria-label', 'Outline tree');
+    await expect(rows).toHaveAttribute('tabindex', '0');
+    // getByLabel('AST outline') must still resolve to exactly one element.
+    await expect(page.getByLabel('AST outline')).toHaveCount(1);
+  });
+
+  test('rows are treeitems with a 1-based aria-level', async ({ page }) => {
+    const root = outline(page).locator('.tree-row').first();
+    await expect(root).toHaveAttribute('role', 'treeitem');
+    // depth 0 → aria-level 1 (WAI-ARIA APG is 1-based).
+    await expect(root).toHaveAttribute('aria-level', '1');
+  });
+
+  test('selecting a node sets aria-selected and wires aria-activedescendant', async ({ page }) => {
+    const tree = outline(page).locator('.tree-rows');
+    const targetLabel = outline(page).locator('.tree-label-text', { hasText: /^module/ }).first();
+    await targetLabel.click();
+
+    const selectedRow = outline(page).locator('.tree-row.selected');
+    await expect(selectedRow).toHaveAttribute('aria-selected', 'true');
+
+    // The container's active descendant must point at the selected row's id,
+    // and that id must resolve to an existing element.
+    const activeId = await tree.getAttribute('aria-activedescendant');
+    expect(activeId).toBeTruthy();
+    const rowId = await selectedRow.getAttribute('id');
+    expect(activeId).toBe(rowId);
+    expect(rowId).toMatch(/^canopy-outline-treeitem-/);
+  });
+
+  test('expandable rows expose aria-expanded; collapsing flips it to false', async ({ page }) => {
+    // The root module node has children, so it is expandable.
+    const root = outline(page).locator('.tree-row').first();
+    await expect(root).toHaveAttribute('aria-expanded', 'true');
+
+    // Collapse via the row's toggle button; aria-expanded must become "false".
+    await root.locator('.tree-toggle').click();
+    await expect(root).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/lib/treeview/README.md
+++ b/lib/treeview/README.md
@@ -1,0 +1,107 @@
+# Rabbita TreeView
+
+Headless WAI-ARIA tree behavior for Rabbita apps. The package owns the tree's
+ARIA scheme (`role="tree"`/`"treeitem"`, `aria-level`, `aria-selected`,
+`aria-expanded`, and the active-descendant relationship) plus a small, tested
+keyboard vocabulary; the consumer owns the tree data, node labels, selection and
+expansion state, navigation logic, click/drag handling, HTML structure, and
+styling.
+
+The behavior is **derived, not a store**: there is no `Msg`/`update` loop and no
+durable state. Selection and expansion live in the consumer's own model and are
+passed in per render — a `Model` only carries the stable id prefix so the
+container's `aria-activedescendant` and each row's `id` agree. This mirrors
+`lib/tabs`. It works because the tree's navigation target is necessarily
+domain-specific (it depends on the consumer's tree shape), so the behavior never
+needs to hold the tree; it reports a *command* and the consumer maps it onto its
+own domain.
+
+## Active-descendant, not roving tabindex
+
+This package implements the **active-descendant** WAI-ARIA tree pattern: focus
+stays on the tree container (`tabindex="0"`), and the active row is tracked by
+`aria-activedescendant` rather than by moving DOM focus between rows. Pass the
+selected node's key to `tree_attrs(active_node_key?=...)`; omit it when there is
+no selection (or when the selected node is not currently rendered, e.g. inside a
+collapsed subtree).
+
+## Keyboard model is direction-named (compatibility mode)
+
+`command_for_key` decodes a `keydown` key into a `TreeCommand`:
+
+| Key | `TreeCommand` |
+|-----|---------------|
+| ArrowUp | `NavUp` |
+| ArrowDown | `NavDown` |
+| ArrowLeft | `NavLeft` |
+| ArrowRight | `NavRight` |
+| Enter | `Activate` |
+| anything else | `None` (falls through to the consumer's own keys) |
+
+The four `Nav*` commands are **direction-named on purpose**. The package does
+*not* bake in the WAI-ARIA APG arrow model (ArrowRight = expand-or-first-child,
+ArrowLeft = collapse-or-parent). A consumer is free to assign that meaning, but
+it can also map the arrows onto pure domain navigation — which is what Canopy's
+Ideal outline does (the arrows drive `navigate_proj` parent/child/sibling moves,
+and `Activate` toggles collapse/expand). Keeping the commands direction-named is
+what lets a single behavior serve both interpretations.
+
+## Use
+
+```mbt nocheck
+fn outline_model() -> @treeview.Model {
+  @treeview.Model::new(id="canopy-outline")
+}
+
+// Container: focus holder + active-descendant.
+@html.div(
+  class="tree-rows",
+  on_keydown=fn(kb) {
+    match @treeview.command_for_key(kb.key()) {
+      Some(@treeview.NavUp) => navigate(Up)
+      Some(@treeview.NavDown) => navigate(Down)
+      // ... NavLeft / NavRight / Activate ...
+      None => handle_app_key(kb.key()) // Delete, Escape, typeahead, ...
+    }
+  },
+  attrs=outline_model().tree_attrs(label="Outline tree", active_node_key?=selected),
+  rows,
+)
+
+// Each row: ARIA only; selection/click/drag stay yours.
+@html.div(
+  class="tree-row",
+  on_click=select_cmd,
+  attrs=outline_model()
+    .treeitem_attrs(node_key=key, level=depth + 1, selected~, expansion~)
+    .draggable("true"), // chain your own handlers on
+  row_items,
+)
+```
+
+**Invariant — the consumer must pass the same `id` prefix to every `Model` it
+builds for one tree, and the `active_node_key` passed to `tree_attrs` must equal
+the `node_key` of the selected row.** The library owns the treeitem id scheme
+(`<id>-treeitem-<node_key>`), so `aria-activedescendant` round-trips to a row
+`id` only when the keys match. `aria-level` is 1-based per the WAI-ARIA APG —
+pass `depth + 1` for a zero-based depth. `Leaf` nodes emit no `aria-expanded`.
+
+## Scope boundaries
+
+Behavior-only, like `lib/tabs`:
+
+- **Not owned:** node data, labels, selection/expansion state, navigation target
+  computation, click/drag/structural-edit (Delete/Backspace) handling, drag-drop
+  position detection, any tree data-structure.
+- **Not implemented (deliberate):** WAI-ARIA APG arrow expand/collapse, Home/End,
+  typeahead, multi-select. These can be added when a consumer needs them; the
+  Ideal outline's navigation is directional/domain, not flat-list, so first/last
+  and arrow-expand have no single correct meaning here yet.
+
+## Verified Rabbita APIs
+
+Checked against the vendored Rabbita source:
+
+- `rabbita/rabbita/html/pkg.generated.mbti` — `Attrs::{role, tabindex, id,
+  aria_label, aria_activedescendant, aria_level, aria_selected, aria_expanded}`.
+- `rabbita/doc/002_writing_html/readme.mbt.md` — `Attrs::build()` chaining.

--- a/lib/treeview/moon.mod.json
+++ b/lib/treeview/moon.mod.json
@@ -1,0 +1,27 @@
+{
+  "name": "dowdiness/rabbita-treeview",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.4"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [
+    "rabbita",
+    "treeview",
+    "tree",
+    "headless-ui",
+    "component",
+    "moonbit",
+    "tea",
+    "aria"
+  ],
+  "description": "Headless WAI-ARIA tree behavior helpers for Rabbita.",
+  "preferred-target": "native",
+  "supported-targets": "js+native"
+}

--- a/lib/treeview/src/treeview/attrs.mbt
+++ b/lib/treeview/src/treeview/attrs.mbt
@@ -1,0 +1,59 @@
+///|
+fn bool_attr(value : Bool) -> String {
+  if value {
+    "true"
+  } else {
+    "false"
+  }
+}
+
+///|
+/// ARIA attrs for the tree container element.
+///
+/// Sets `role="tree"`, a `tabindex="0"` so the container is the single focus
+/// holder (the active-descendant pattern: focus stays on the container, the
+/// active row is tracked by id rather than by moving DOM focus), and a label.
+/// `aria-activedescendant` points at the selected row's treeitem id when
+/// `active_node_key` is `Some` and is omitted otherwise (no selection, or the
+/// selected node is not currently rendered).
+///
+/// `label` must NOT duplicate an `aria-label` already on an ancestor region, or
+/// accessibility-tree name lookups become ambiguous; give the tree its own name.
+pub fn Model::tree_attrs(
+  self : Model,
+  label~ : String,
+  active_node_key? : String,
+) -> @html.Attrs {
+  let attrs = @html.Attrs::build().role("tree").aria_label(label).tabindex(0)
+  match active_node_key {
+    Some(key) => attrs.aria_activedescendant(self.treeitem_id(key))
+    None => attrs
+  }
+}
+
+///|
+/// ARIA attrs for a single treeitem row.
+///
+/// Sets the behavior-owned `id`, `role="treeitem"`, `aria-level` (1-based per
+/// WAI-ARIA APG — the consumer passes `depth + 1`), `aria-selected`, and
+/// `aria-expanded` only for non-leaf nodes. Selection, click, drag, and keyboard
+/// handling stay consumer-owned: the consumer spreads these attrs onto its row
+/// and chains its own handlers on, and reads keys through `command_for_key` in
+/// its container-level `on_keydown`.
+pub fn Model::treeitem_attrs(
+  self : Model,
+  node_key~ : String,
+  level~ : Int,
+  selected~ : Bool,
+  expansion~ : Expansion,
+) -> @html.Attrs {
+  let attrs = @html.Attrs::build()
+    .id(self.treeitem_id(node_key))
+    .role("treeitem")
+    .aria_level(level.to_string())
+    .aria_selected(bool_attr(selected))
+  match expanded_value(expansion) {
+    Some(value) => attrs.aria_expanded(value)
+    None => attrs
+  }
+}

--- a/lib/treeview/src/treeview/moon.pkg
+++ b/lib/treeview/src/treeview/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "moonbit-community/rabbita/html",
+}
+
+warnings = "-unused_package"
+
+supported_targets = "js+native"

--- a/lib/treeview/src/treeview/pkg.generated.mbti
+++ b/lib/treeview/src/treeview/pkg.generated.mbti
@@ -1,0 +1,41 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita-treeview/treeview"
+
+import {
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn command_for_key(String) -> TreeCommand?
+
+pub fn expanded_value(Expansion) -> String?
+
+// Errors
+
+// Types and methods
+pub(all) enum Expansion {
+  Leaf
+  Collapsed
+  Expanded
+} derive(Eq, @debug.Debug)
+
+pub struct Model {
+  // private fields
+}
+pub fn Model::new(id~ : String) -> Self
+pub fn Model::tree_attrs(Self, label~ : String, active_node_key? : String) -> @html.Attrs
+pub fn Model::treeitem_attrs(Self, node_key~ : String, level~ : Int, selected~ : Bool, expansion~ : Expansion) -> @html.Attrs
+
+pub(all) enum TreeCommand {
+  NavUp
+  NavDown
+  NavLeft
+  NavRight
+  Activate
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/lib/treeview/src/treeview/pkg.generated.mbti
+++ b/lib/treeview/src/treeview/pkg.generated.mbti
@@ -3,13 +3,10 @@ package "dowdiness/rabbita-treeview/treeview"
 
 import {
   "moonbit-community/rabbita/html",
-  "moonbitlang/core/debug",
 }
 
 // Values
 pub fn command_for_key(String) -> TreeCommand?
-
-pub fn expanded_value(Expansion) -> String?
 
 // Errors
 
@@ -18,7 +15,7 @@ pub(all) enum Expansion {
   Leaf
   Collapsed
   Expanded
-} derive(Eq, @debug.Debug)
+}
 
 pub struct Model {
   // private fields
@@ -33,7 +30,7 @@ pub(all) enum TreeCommand {
   NavLeft
   NavRight
   Activate
-} derive(Eq, @debug.Debug)
+}
 
 // Type aliases
 

--- a/lib/treeview/src/treeview/treeview_wbtest.mbt
+++ b/lib/treeview/src/treeview/treeview_wbtest.mbt
@@ -1,0 +1,40 @@
+///|
+test "command_for_key maps the four arrows" {
+  inspect(command_for_key("ArrowUp") is Some(NavUp), content="true")
+  inspect(command_for_key("ArrowDown") is Some(NavDown), content="true")
+  inspect(command_for_key("ArrowLeft") is Some(NavLeft), content="true")
+  inspect(command_for_key("ArrowRight") is Some(NavRight), content="true")
+}
+
+///|
+test "command_for_key maps Enter to Activate" {
+  inspect(command_for_key("Enter") is Some(Activate), content="true")
+}
+
+///|
+test "command_for_key leaves app-owned keys unclaimed" {
+  // Delete / Backspace (structural edit), "." (action overlay), Escape
+  // (close/deselect), and typeahead are the consumer's, not the behavior's.
+  inspect(command_for_key("Delete") is None, content="true")
+  inspect(command_for_key("Backspace") is None, content="true")
+  inspect(command_for_key("Escape") is None, content="true")
+  inspect(command_for_key(".") is None, content="true")
+  inspect(command_for_key(" ") is None, content="true")
+  inspect(command_for_key("Home") is None, content="true")
+  inspect(command_for_key("End") is None, content="true")
+  inspect(command_for_key("a") is None, content="true")
+}
+
+///|
+test "expanded_value omits the attr for leaves" {
+  inspect(expanded_value(Leaf) is None, content="true")
+  inspect(expanded_value(Collapsed) is Some("false"), content="true")
+  inspect(expanded_value(Expanded) is Some("true"), content="true")
+}
+
+///|
+test "treeitem_id uses the node key as suffix" {
+  let model = Model::new(id="canopy-outline")
+  assert_eq(model.treeitem_id("42"), "canopy-outline-treeitem-42")
+  assert_eq(model.treeitem_id("7"), "canopy-outline-treeitem-7")
+}

--- a/lib/treeview/src/treeview/types.mbt
+++ b/lib/treeview/src/treeview/types.mbt
@@ -1,0 +1,89 @@
+///|
+/// A semantic keyboard intent for a tree, decoded from a raw `keydown` key.
+///
+/// The behavior reports the *intent*; the consumer maps it onto its own domain.
+/// The four `Nav*` commands are directional moves whose meaning (move to
+/// parent / child / sibling, or expand / collapse) is decided by the consumer,
+/// because the target depends on the consumer's tree structure — a headless
+/// behavior cannot compute it. `Activate` is the Enter intent (the Ideal outline
+/// maps it to toggle collapse/expand).
+///
+/// This is a deliberate *compatibility mode*: the Ideal outline drives its arrows
+/// through domain navigation (`@canopy_core.navigate_proj`), not the WAI-ARIA APG
+/// arrow model (ArrowRight = expand-or-first-child, ArrowLeft = collapse-or-parent).
+/// The commands stay direction-named so a consumer is free to assign either
+/// meaning; the package does not bake the APG arrow semantics in.
+pub(all) enum TreeCommand {
+  NavUp
+  NavDown
+  NavLeft
+  NavRight
+  Activate
+} derive(Eq, Debug)
+
+///|
+/// Decode a `keydown` key string into the tree command it should trigger, or
+/// `None` for keys this behavior does not own. Returning `None` lets the
+/// consumer's own keys (Delete / Backspace / Escape / typeahead / etc.) fall
+/// through unchanged.
+pub fn command_for_key(key : String) -> TreeCommand? {
+  match key {
+    "ArrowUp" => Some(NavUp)
+    "ArrowDown" => Some(NavDown)
+    "ArrowLeft" => Some(NavLeft)
+    "ArrowRight" => Some(NavRight)
+    "Enter" => Some(Activate)
+    _ => None
+  }
+}
+
+///|
+/// The disclosure state of a tree node, controlling `aria-expanded`.
+///
+/// `Leaf` nodes have no children and emit no `aria-expanded` (per WAI-ARIA, the
+/// attribute is meaningless on a node that can never expand). `Collapsed` and
+/// `Expanded` emit `"false"` / `"true"`.
+pub(all) enum Expansion {
+  Leaf
+  Collapsed
+  Expanded
+} derive(Eq, Debug)
+
+///|
+/// The `aria-expanded` value for an expansion state, or `None` when the
+/// attribute must be omitted (leaves).
+pub fn expanded_value(expansion : Expansion) -> String? {
+  match expansion {
+    Leaf => None
+    Collapsed => Some("false")
+    Expanded => Some("true")
+  }
+}
+
+///|
+/// Headless tree behavior: owns only the stable treeitem DOM-id scheme.
+///
+/// Like `lib/tabs`, the behavior is derived, not a store. There is no durable
+/// state here — selection and expansion live in the consumer's own model and are
+/// passed in per render. `Model` carries just the id prefix so the
+/// container's `aria-activedescendant` and each row's `id` stay internally
+/// consistent (mirrors `lib/tabs`' private `tab_button_id`).
+pub struct Model {
+  priv id : String
+}
+
+///|
+/// Create tree behavior state for a stable id prefix.
+pub fn Model::new(id~ : String) -> Model {
+  { id, }
+}
+
+///|
+/// The stable DOM id for the treeitem identified by `node_key`. Internal: the
+/// behavior owns the id scheme, so `tree_attrs` (via `aria-activedescendant`) and
+/// `treeitem_attrs` (via `id`) always agree. `node_key` is a consumer-owned
+/// stable string per node (e.g. a stringified NodeId); the behavior never
+/// interprets it.
+fn Model::treeitem_id(self : Model, node_key : String) -> String {
+  self.id + "-treeitem-" + node_key
+}

--- a/lib/treeview/src/treeview/types.mbt
+++ b/lib/treeview/src/treeview/types.mbt
@@ -19,7 +19,7 @@ pub(all) enum TreeCommand {
   NavLeft
   NavRight
   Activate
-} derive(Eq, Debug)
+}
 
 ///|
 /// Decode a `keydown` key string into the tree command it should trigger, or
@@ -47,12 +47,13 @@ pub(all) enum Expansion {
   Leaf
   Collapsed
   Expanded
-} derive(Eq, Debug)
+}
 
 ///|
 /// The `aria-expanded` value for an expansion state, or `None` when the
-/// attribute must be omitted (leaves).
-pub fn expanded_value(expansion : Expansion) -> String? {
+/// attribute must be omitted (leaves). Internal: consumers pass an `Expansion`
+/// to `treeitem_attrs`, which maps it; the string contract is the package's.
+fn expanded_value(expansion : Expansion) -> String? {
   match expansion {
     Leaf => None
     Collapsed => Some("false")

--- a/moon.work
+++ b/moon.work
@@ -8,6 +8,7 @@ members = [
   "./lib/menu",
   "./lib/context-menu",
   "./lib/tabs",
+  "./lib/treeview",
   "./lib/dom-boundary",
   "./lib/visualizer",
   "./lib/semantic",


### PR DESCRIPTION
## Summary

Closes #506. Extracts a reusable **headless WAI-ARIA tree behavior** `lib/treeview` (`dowdiness/rabbita-treeview`) from the Ideal outline panel, mirroring the merged `lib/tabs` (#517) and `lib/context-menu` (#516).

**Behavior-only.** The package owns:
- the ARIA scheme — `role="tree"`/`"treeitem"`, `aria-level` (1-based), `aria-selected`, `aria-expanded`, and `aria-activedescendant`;
- a tested key→`TreeCommand` keyboard vocabulary (`command_for_key`);
- the private treeitem DOM-id scheme.

The consumer keeps everything domain-specific: tree construction, node labels, selection/expansion state, `navigate_proj` target computation, click/drag, and structural edits (Delete/Backspace).

## Design (Codex-validated)

- **Stateless / derived, no `Msg` store.** The navigation target is domain-specific (`@canopy_core.navigate_proj` over `NodeId`s), so the behavior never needs to hold the tree — it reports an intent and the consumer maps it. (The "TreeView needs more state than Tabs" open question resolved to *no store*.)
- **Active-descendant pattern, not roving tabindex.** Focus stays on the `.tree-rows` container; the active row is tracked by `aria-activedescendant`. This matches the pre-existing container-focus model the outline E2E relies on (`.tree-rows.focus()`), whereas roving tabindex would move the focus target and break it. `outline_active_node_key` gates the active id to the *rendered* selection, so it never dangles to a row hidden by a collapsed ancestor or dropped by re-projection.
- **Compatibility mode (intentional spec divergence).** Arrows drive *domain* navigation (parent/child/sibling via `navigate_proj`), **not** the WAI-ARIA APG expand/collapse-on-arrow model, because the locked outline E2E asserts the `navigate_proj` semantics. `TreeCommand`s stay direction-named (`NavUp/Down/Left/Right` + `Activate`) precisely so the meaning is consumer-assigned. Documented in the package README and a consumer comment.

## Non-goals (deliberate)

No drag/drop position detection, no projection-tree data-structure changes, no JSON/tree migration, and no WAI-ARIA arrow expand/collapse / Home-End / typeahead until a second consumer needs them.

## Changes

- New `lib/treeview/` package (`types.mbt` keyboard model + id scheme; `attrs.mbt` ARIA builders; 5 wbtests; README; generated `.mbti`).
- Registered in `moon.work` + `examples/ideal/moon.mod.json` + `examples/ideal/main/moon.pkg`.
- Migrated `examples/ideal/main/view_outline.mbt` (behavior-preserving).
- New browser ARIA regression spec `examples/ideal/web/e2e/outline-aria.spec.ts` — the only coverage of the opaque `*_attrs` outputs.

## Verification

- `NEW_MOON_MOD=0 moon check --deny-warn` + `moon fmt --check` green (lib + Ideal + workspace).
- `NEW_MOON_MOD=0 moon test`: 1316 js + 31 native, incl. 5 new wbtests.
- `NEW_MOON_MOD=0 moon build --target js --release` green.
- Playwright E2E **69 green, 0 failures**: `outline-navigation` (8, locked) + `editor-features`/`scope-coloring`/`seed`/`drag-drop`/`structural-editing` (57) + `outline-aria` (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
