### PR TITLE
Fix menu focus scope

### DIFF
--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -59,9 +59,13 @@ then return `@rabbita.batch([model.context_menu.position_cmd(), model.context_me
 Handle `Activate(index)`, `Close`, `Dismiss(reason)`, and `Key(key)` in the
 consumer. For navigation messages, call `Model::update`; when
 `Msg::requests_focus()` is true, return `Model::focus_cmd()` after updating the
-model. If the context menu is rendered under a scoped container or open shadow
-root, use `Model::focus_cmd_within(root_id=...)` instead so item focus is looked
-up through the same scoped menu strategy as `lib/menu`.
+model.
+
+`Model::focus_cmd_within(root_id=...)` only scopes active-item focus through the
+same lookup strategy as `lib/menu`. It does not make the full context-menu flow
+shadow-root-ready: `position_cmd()` and `subscriptions()` still resolve the panel
+from `document.getElementById(self.id)`, so context-menu panels should remain
+document-visible until scoped positioning and dismissal APIs exist.
 
 Return `model.context_menu.subscriptions(...)` from the owning cell's
 subscriptions callback to install reusable dismissal behavior while the menu is

--- a/lib/context-menu/README.md
+++ b/lib/context-menu/README.md
@@ -59,7 +59,9 @@ then return `@rabbita.batch([model.context_menu.position_cmd(), model.context_me
 Handle `Activate(index)`, `Close`, `Dismiss(reason)`, and `Key(key)` in the
 consumer. For navigation messages, call `Model::update`; when
 `Msg::requests_focus()` is true, return `Model::focus_cmd()` after updating the
-model.
+model. If the context menu is rendered under a scoped container or open shadow
+root, use `Model::focus_cmd_within(root_id=...)` instead so item focus is looked
+up through the same scoped menu strategy as `lib/menu`.
 
 Return `model.context_menu.subscriptions(...)` from the owning cell's
 subscriptions callback to install reusable dismissal behavior while the menu is

--- a/lib/context-menu/src/context_menu/context_menu_test.mbt
+++ b/lib/context-menu/src/context_menu/context_menu_test.mbt
@@ -89,3 +89,114 @@ test "activation and keyboard close paths request focus restore" {
     content="false",
   )
 }
+
+///|
+#cfg(target="js")
+struct FocusCmdTestScheduler {
+  mut after_render_count : Int
+  hooks : @cmd.Hooks
+}
+
+///|
+#cfg(target="js")
+fn FocusCmdTestScheduler::new() -> FocusCmdTestScheduler {
+  { after_render_count: 0, hooks: { url_request: None, url_changed: None } }
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn run_effect(self, kind, f) {
+  match kind {
+    Immediately => f(self)
+    AfterRender => {
+      self.after_render_count = self.after_render_count + 1
+      f(self)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn queue_message(
+  self,
+  _id,
+  _send_message,
+) {
+  ignore(self)
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn drain_message(self) {
+  ignore(self)
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn hooks(self) {
+  self.hooks
+}
+
+///|
+#cfg(target="js")
+extern "js" fn install_shadow_focus_fixture(
+  root_id : String,
+  item_id : String,
+) -> Unit =
+  #| (rootId, itemId) => {
+  #|   globalThis.__contextMenuFocusLog = [];
+  #|   const shadowItem = {
+  #|     id: itemId,
+  #|     children: [],
+  #|     focus() {
+  #|       globalThis.__contextMenuFocusLog.push("shadow:" + this.id);
+  #|     },
+  #|   };
+  #|   const documentItem = {
+  #|     id: itemId,
+  #|     children: [],
+  #|     focus() {
+  #|       globalThis.__contextMenuFocusLog.push("document:" + this.id);
+  #|     },
+  #|   };
+  #|   const shadowRoot = {
+  #|     children: [shadowItem],
+  #|     getElementById(id) { return id === itemId ? shadowItem : null; },
+  #|   };
+  #|   const host = { id: rootId, children: [], shadowRoot };
+  #|   globalThis.document = {
+  #|     getElementById(id) {
+  #|       if (id === rootId) return host;
+  #|       if (id === itemId) return documentItem;
+  #|       return null;
+  #|     },
+  #|   };
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn focus_log() -> String =
+  #| () => (globalThis.__contextMenuFocusLog || []).join(",")
+
+///|
+#cfg(target="js")
+extern "js" fn clear_focus_fixture() -> Unit =
+  #| () => {
+  #|   delete globalThis.document;
+  #|   delete globalThis.__contextMenuFocusLog;
+  #| }
+
+///|
+#cfg(target="js")
+test "focus_cmd_within delegates scoped focus to the embedded menu" {
+  let model = @context_menu.Model::new(id="test-menu")
+    .open(anchor=@context_menu.Point(x=1.0F, y=2.0F), item_count=2)
+    .update(@context_menu.FocusNext)
+  install_shadow_focus_fixture("menu-host", "test-menu-item-1")
+  let scheduler = FocusCmdTestScheduler::new()
+  scheduler.add(model.focus_cmd_within(root_id="menu-host"))
+  let log = focus_log()
+  clear_focus_fixture()
+  inspect(scheduler.after_render_count, content="1")
+  inspect(log, content="shadow:test-menu-item-1")
+}

--- a/lib/context-menu/src/context_menu/pkg.generated.mbti
+++ b/lib/context-menu/src/context_menu/pkg.generated.mbti
@@ -29,6 +29,7 @@ pub fn Model::anchor(Self) -> Point?
 pub fn Model::close(Self) -> Self
 pub fn Model::close_focus_cmd(Self) -> @cmd.Cmd
 pub fn Model::focus_cmd(Self) -> @cmd.Cmd
+pub fn Model::focus_cmd_within(Self, root_id~ : String) -> @cmd.Cmd
 pub fn Model::is_open(Self) -> Bool
 pub fn Model::item_attrs(Self, Int, (Msg) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::new(id~ : String) -> Self

--- a/lib/context-menu/src/context_menu/types.mbt
+++ b/lib/context-menu/src/context_menu/types.mbt
@@ -204,6 +204,8 @@ pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
 
 ///|
 /// Focus the active menu item within a scoped root after the current render flush.
+/// This only scopes item focus; positioning and dismissal still expect a
+/// document-visible panel id.
 pub fn Model::focus_cmd_within(self : Model, root_id~ : String) -> @rabbita.Cmd {
   self.menu.focus_cmd_within(root_id~)
 }

--- a/lib/context-menu/src/context_menu/types.mbt
+++ b/lib/context-menu/src/context_menu/types.mbt
@@ -201,3 +201,9 @@ pub fn Msg::requests_close_focus(self : Msg) -> Bool {
 pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
   self.menu.focus_cmd()
 }
+
+///|
+/// Focus the active menu item within a scoped root after the current render flush.
+pub fn Model::focus_cmd_within(self : Model, root_id~ : String) -> @rabbita.Cmd {
+  self.menu.focus_cmd_within(root_id~)
+}

--- a/lib/menu/README.md
+++ b/lib/menu/README.md
@@ -37,6 +37,18 @@ navigation messages with `Model::update`; when `Msg::requests_focus()` is true,
 return `Model::focus_cmd()` after the model is updated so roving tabindex moves
 actual DOM focus after Rabbita patches the view.
 
+## Focus scope
+
+`Model::focus_cmd()` uses Rabbita's after-render command hook and focuses the
+active item with document-level `getElementById`. Use it for normal light-DOM
+menus whose generated item ids are document-unique.
+
+For menus rendered inside a scoped container or an open shadow root, use
+`Model::focus_cmd_within(root_id=...)` instead. `root_id` is resolved from the
+document; if that element has `shadowRoot`, lookup happens inside the shadow
+root, otherwise lookup happens under the root element. Closed shadow roots or
+roots that cannot be found by document id need a consumer-owned custom command.
+
 ## Verified Rabbita APIs
 
 Implementation was checked against the vendored Rabbita source, especially:

--- a/lib/menu/src/menu/attrs.mbt
+++ b/lib/menu/src/menu/attrs.mbt
@@ -119,6 +119,15 @@ pub fn scrim_attrs(on_close : @rabbita.Cmd) -> @html.Attrs {
 
 ///|
 #cfg(target="js")
+fn Model::focused_item_id(self : Model) -> String? {
+  match self.focused {
+    Some(index) => Some(self.item_id(index))
+    None => None
+  }
+}
+
+///|
+#cfg(target="js")
 extern "js" fn focus_element_by_id(id : String) -> Unit =
   #| (id) => {
   #|   const el = document.getElementById(id);
@@ -129,19 +138,69 @@ extern "js" fn focus_element_by_id(id : String) -> Unit =
 
 ///|
 #cfg(target="js")
-pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
-  match self.focused {
-    Some(index) => {
-      let id = self.item_id(index)
-      @cmd.custom_cmd(_ => focus_element_by_id(id), kind=@cmd.after_render)
-    }
+extern "js" fn focus_element_by_id_within(
+  root_id : String,
+  id : String,
+) -> Unit =
+  #| (rootId, id) => {
+  #|   if (typeof document === "undefined") return;
+  #|   const root = document.getElementById(rootId);
+  #|   const scope = root && root.shadowRoot ? root.shadowRoot : root;
+  #|   const findById = (node, targetId) => {
+  #|     if (!node) return null;
+  #|     if (typeof node.getElementById === "function") {
+  #|       const found = node.getElementById(targetId);
+  #|       if (found) return found;
+  #|     }
+  #|     if (node.id === targetId) return node;
+  #|     const children = node.children || [];
+  #|     for (let i = 0; i < children.length; i += 1) {
+  #|       const found = findById(children[i], targetId);
+  #|       if (found) return found;
+  #|     }
+  #|     return null;
+  #|   };
+  #|   const el = findById(scope, id);
+  #|   if (el && typeof el.focus === "function") {
+  #|     el.focus();
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+fn Model::focus_item_cmd(
+  self : Model,
+  focus : (String) -> Unit,
+) -> @rabbita.Cmd {
+  match self.focused_item_id() {
+    Some(id) => @cmd.custom_cmd(_ => focus(id), kind=@cmd.after_render)
     None => @rabbita.none
   }
+}
+
+///|
+#cfg(target="js")
+pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
+  self.focus_item_cmd(focus_element_by_id)
 }
 
 ///|
 #cfg(not(target="js"))
 pub fn Model::focus_cmd(self : Model) -> @rabbita.Cmd {
   ignore(self)
+  @rabbita.none
+}
+
+///|
+#cfg(target="js")
+pub fn Model::focus_cmd_within(self : Model, root_id~ : String) -> @rabbita.Cmd {
+  self.focus_item_cmd(id => focus_element_by_id_within(root_id, id))
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Model::focus_cmd_within(self : Model, root_id~ : String) -> @rabbita.Cmd {
+  ignore(self)
+  ignore(root_id)
   @rabbita.none
 }

--- a/lib/menu/src/menu/menu_wbtest.mbt
+++ b/lib/menu/src/menu/menu_wbtest.mbt
@@ -76,3 +76,108 @@ test "text keys are ignored for empty menus" {
   inspect(model.keydown_msg("r") is None, content="true")
   inspect(model.keydown_msg("Enter") is None, content="true")
 }
+
+///|
+#cfg(target="js")
+struct FocusCmdTestScheduler {
+  mut after_render_count : Int
+  hooks : @cmd.Hooks
+}
+
+///|
+#cfg(target="js")
+fn FocusCmdTestScheduler::new() -> FocusCmdTestScheduler {
+  { after_render_count: 0, hooks: { url_request: None, url_changed: None } }
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn run_effect(self, kind, f) {
+  match kind {
+    Immediately => f(self)
+    AfterRender => {
+      self.after_render_count = self.after_render_count + 1
+      f(self)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn queue_message(
+  self,
+  _id,
+  _send_message,
+) {
+  ignore(self)
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn drain_message(self) {
+  ignore(self)
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for FocusCmdTestScheduler with fn hooks(self) {
+  self.hooks
+}
+
+///|
+#cfg(target="js")
+extern "js" fn install_shadow_focus_fixture(
+  root_id : String,
+  item_id : String,
+) -> Unit =
+  #| (rootId, itemId) => {
+  #|   globalThis.__menuFocusLog = [];
+  #|   const shadowItem = {
+  #|     id: itemId,
+  #|     children: [],
+  #|     focus() { globalThis.__menuFocusLog.push("shadow:" + this.id); },
+  #|   };
+  #|   const documentItem = {
+  #|     id: itemId,
+  #|     children: [],
+  #|     focus() { globalThis.__menuFocusLog.push("document:" + this.id); },
+  #|   };
+  #|   const shadowRoot = {
+  #|     children: [shadowItem],
+  #|     getElementById(id) { return id === itemId ? shadowItem : null; },
+  #|   };
+  #|   const host = { id: rootId, children: [], shadowRoot };
+  #|   globalThis.document = {
+  #|     getElementById(id) {
+  #|       if (id === rootId) return host;
+  #|       if (id === itemId) return documentItem;
+  #|       return null;
+  #|     },
+  #|   };
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn focus_log() -> String =
+  #| () => (globalThis.__menuFocusLog || []).join(",")
+
+///|
+#cfg(target="js")
+extern "js" fn clear_focus_fixture() -> Unit =
+  #| () => {
+  #|   delete globalThis.document;
+  #|   delete globalThis.__menuFocusLog;
+  #| }
+
+///|
+#cfg(target="js")
+test "focus_cmd_within searches a shadow host before document duplicates" {
+  let model = Model::new(id="menu", item_count=2).update(FocusNext)
+  install_shadow_focus_fixture("menu-host", "menu-item-1")
+  let scheduler = FocusCmdTestScheduler::new()
+  scheduler.add(model.focus_cmd_within(root_id="menu-host"))
+  let log = focus_log()
+  clear_focus_fixture()
+  inspect(scheduler.after_render_count, content="1")
+  inspect(log, content="shadow:menu-item-1")
+}

--- a/lib/menu/src/menu/pkg.generated.mbti
+++ b/lib/menu/src/menu/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub struct Model {
   // private fields
 }
 pub fn Model::focus_cmd(Self) -> @cmd.Cmd
+pub fn Model::focus_cmd_within(Self, root_id~ : String) -> @cmd.Cmd
 pub fn Model::item_attrs(Self, Int, (Msg) -> @cmd.Cmd) -> @html.Attrs
 pub fn Model::keydown_msg(Self, String) -> Msg?
 pub fn Model::new(id~ : String, item_count~ : Int) -> Self


### PR DESCRIPTION
## Summary

- Add `Model::focus_cmd_within(root_id~)` for scoped/headless menu item focus.
- Keep existing document-level `Model::focus_cmd()` behavior unchanged for Ideal and other light-DOM consumers.
- Document document-global vs scoped/open-shadow-root focus strategy.
- Add a JS whitebox regression covering duplicate document id vs scoped shadow-host lookup.

Closes #511.

## Reuse check

- Reused Rabbita `@cmd.custom_cmd(..., kind=@cmd.after_render)` for after-patch focus effects.
- Reused menu-owned item id generation through a private `focused_item_id()` helper.
- Considered adjacent document-global patterns in `lib/tabs` and `lib/context-menu`, but left them unchanged because #511 is scoped to `lib/menu` item focus.
- Did not reuse `lib/dom-boundary`: it is document-global and JS-only, while `lib/menu` must keep its `js+native` package contract.

## Validation

- `NEW_MOON_MOD=0 moon check --deny-warn`
- `NEW_MOON_MOD=0 moon test`
- `NEW_MOON_MOD=0 moon build --target js --release`
- `NEW_MOON_MOD=0 moon test --target js lib/menu/src/menu`
- `cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/structural-editing.spec.ts --reporter=line`
- `git diff --check`
