### PR TITLE
Integrate resizable behavior into Ideal outline panel

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -43,11 +43,7 @@ fn init_model() -> Model raise {
     cm_id: "canopy-text-editor",
     mounted: false,
     mode: Text,
-    workspace: {
-      outline_visible: true,
-      inspector_visible: true,
-      bottom_visible: false,
-    },
+    workspace: initial_workspace_layout(),
     selected_node: None,
     diagnostics_open: false,
     next_timestamp: 1,
@@ -142,7 +138,10 @@ fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
   } else {
     @sub.none
   }
-  @sub.batch([editor_events, cm_events])
+  let outline_resize = model.workspace.outline_resize.subscriptions(msg => {
+    emit(OutlineResize(msg))
+  })
+  @sub.batch([editor_events, cm_events, outline_resize])
 }
 
 ///|
@@ -472,6 +471,10 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       // `view_bottom_content`), so opening/closing the panel re-renders
       // it from scratch — no separate refresh command needed.
       (none, new_model)
+    }
+    OutlineResize(resize_msg) => {
+      let workspace = model.workspace.update_outline_resize(resize_msg)
+      (none, { ..model, workspace, })
     }
     DismissPanels => {
       let ws = model.workspace
@@ -843,6 +846,33 @@ fn view_peer_status(model : Model) -> Html {
 }
 
 ///|
+fn outline_panel_attrs(workspace : WorkspaceLayout) -> @html.Attrs {
+  let attrs = @html.Attrs::build()
+    .role("navigation")
+    .aria_label("AST outline")
+    .style("--outline-panel-width", workspace.outline_width_px())
+  if workspace.outline_resize.is_resizing() {
+    attrs.style("user-select", "none")
+  } else {
+    attrs
+  }
+}
+
+///|
+fn view_outline_resize_handle(
+  dispatch : Emit[Msg],
+  workspace : WorkspaceLayout,
+) -> Html {
+  div(
+    class="panel-resize-handle outline-resize-handle",
+    attrs=workspace.outline_resize.handle_attrs(@resizable.Edge::East, msg => {
+      dispatch(OutlineResize(msg))
+    }),
+    [text("")],
+  )
+}
+
+///|
 fn view(dispatch : Emit[Msg], model : Model) -> Html {
   // Always render panels — toggle visibility via CSS class
   // so CSS transitions work for both enter and exit.
@@ -861,9 +891,7 @@ fn view(dispatch : Emit[Msg], model : Model) -> Html {
   } else {
     "bottom-panel panel-hidden"
   }
-  let outline_attrs = @html.Attrs::build()
-    .role("navigation")
-    .aria_label("AST outline")
+  let outline_attrs = outline_panel_attrs(model.workspace)
   let inspector_attrs = @html.Attrs::build()
     .role("complementary")
     .aria_label("Node inspector")
@@ -890,6 +918,7 @@ fn view(dispatch : Emit[Msg], model : Model) -> Html {
           span(class="panel-label", [text("PEERS")]),
           view_peer_status(model),
         ]),
+        view_outline_resize_handle(dispatch, model.workspace),
       ]),
       view_editor(dispatch, model),
       div(class=inspector_class, attrs=inspector_attrs, [

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -37,6 +37,7 @@ pub struct WorkspaceLayout {
   outline_visible : Bool
   inspector_visible : Bool
   bottom_visible : Bool
+  outline_resize : @resizable.Model
 }
 
 ///|

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -8,6 +8,7 @@ import {
   "dowdiness/rabbita-menu/menu",
   "dowdiness/rabbita-tabs/tabs",
   "dowdiness/rabbita-treeview/treeview",
+  "dowdiness/rabbita-resizable/resizable",
   "dowdiness/dom_boundary",
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,

--- a/examples/ideal/main/msg.mbt
+++ b/examples/ideal/main/msg.mbt
@@ -4,6 +4,7 @@ pub enum Msg {
   // Mode & layout
   SetMode(EditorMode)
   TogglePanel(PanelId)
+  OutlineResize(@resizable.Msg)
   SelectBottomTab(BottomTab)
   // From Web Component events (inspector panel dispatch)
   StructuralEditRequested(op~ : String, node_id~ : String)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -10,6 +10,7 @@ import {
   "dowdiness/event-graph-walker/history",
   "dowdiness/lambda/ast",
   "dowdiness/rabbita-menu/menu",
+  "dowdiness/rabbita-resizable/resizable",
   "dowdiness/rabbita_codemirror",
   "dowdiness/visualizer",
   "moonbitlang/core/immut/hashset",
@@ -137,6 +138,7 @@ pub struct Model {
 pub enum Msg {
   SetMode(EditorMode)
   TogglePanel(PanelId)
+  OutlineResize(@resizable.Msg)
   SelectBottomTab(BottomTab)
   StructuralEditRequested(op~ : String, node_id~ : String)
   Undo
@@ -201,6 +203,7 @@ pub struct WorkspaceLayout {
   outline_visible : Bool
   inspector_visible : Bool
   bottom_visible : Bool
+  outline_resize : @resizable.Model
 }
 
 // Type aliases

--- a/examples/ideal/main/workspace_layout.mbt
+++ b/examples/ideal/main/workspace_layout.mbt
@@ -1,0 +1,32 @@
+///|
+fn initial_outline_resize() -> @resizable.Model {
+  @resizable.Model::new(w=220, h=1, constraints={
+    min_w: 160,
+    max_w: 360,
+    min_h: 1,
+    max_h: 1,
+  })
+}
+
+///|
+fn initial_workspace_layout() -> WorkspaceLayout {
+  {
+    outline_visible: true,
+    inspector_visible: true,
+    bottom_visible: false,
+    outline_resize: initial_outline_resize(),
+  }
+}
+
+///|
+fn WorkspaceLayout::update_outline_resize(
+  self : WorkspaceLayout,
+  resize_msg : @resizable.Msg,
+) -> WorkspaceLayout {
+  { ..self, outline_resize: self.outline_resize.update(resize_msg) }
+}
+
+///|
+fn WorkspaceLayout::outline_width_px(self : WorkspaceLayout) -> String {
+  "\{self.outline_resize.width()}px"
+}

--- a/examples/ideal/main/workspace_layout.mbt
+++ b/examples/ideal/main/workspace_layout.mbt
@@ -1,6 +1,8 @@
 ///|
 fn initial_outline_resize() -> @resizable.Model {
-  @resizable.Model::new(w=220, h=1, constraints={
+  let (viewport_width, _) = viewport_size()
+  let outline_width = if viewport_width <= 1024 { 180 } else { 220 }
+  @resizable.Model::new(w=outline_width, h=1, constraints={
     min_w: 160,
     max_w: 360,
     min_h: 1,

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -22,6 +22,10 @@
       "path": "../../lib/treeview",
       "version": "0.1.0"
     },
+    "dowdiness/rabbita-resizable": {
+      "path": "../../lib/resizable",
+      "version": "0.1.0"
+    },
     "dowdiness/dom_boundary": {
       "path": "../../lib/dom-boundary",
       "version": "0.1.0"

--- a/examples/ideal/web/e2e/outline-resizable.spec.ts
+++ b/examples/ideal/web/e2e/outline-resizable.spec.ts
@@ -17,6 +17,13 @@ async function outlineWidth(page: Page) {
 }
 
 test.describe('Outline panel resizable behavior', () => {
+  test('uses the compact default width on tablet before resizing', async ({ page }) => {
+    await page.setViewportSize({ width: 1000, height: 720 });
+    await waitForEditor(page);
+
+    await expect.poll(() => outlineWidth(page)).toBe(180);
+  });
+
   test('mouse drag widens the real outline panel', async ({ page }) => {
     await waitForEditor(page);
     const handle = page.getByRole('separator', { name: 'Resize width' });

--- a/examples/ideal/web/e2e/outline-resizable.spec.ts
+++ b/examples/ideal/web/e2e/outline-resizable.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from '@playwright/test';
+import { dispatchExternalCrdtChanged } from './support/dom-events';
+
+async function waitForEditor(page: Page) {
+  await page.goto('/');
+  await expect(page).toHaveTitle('Canopy Editor');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+async function outlineWidth(page: Page) {
+  return Math.round(await page.locator('.outline-panel').evaluate((el) => {
+    return (el as HTMLElement).getBoundingClientRect().width;
+  }));
+}
+
+test.describe('Outline panel resizable behavior', () => {
+  test('mouse drag widens the real outline panel', async ({ page }) => {
+    await waitForEditor(page);
+    const handle = page.getByRole('separator', { name: 'Resize width' });
+    await expect(handle).toBeVisible();
+
+    const before = await outlineWidth(page);
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    const y = box.y + box.height / 2;
+    await page.mouse.move(box.x + box.width / 2, y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 64, y, { steps: 6 });
+    await page.mouse.up();
+
+    await expect.poll(() => outlineWidth(page)).toBeGreaterThan(before + 40);
+  });
+
+  test('keyboard arrows nudge the outline panel width', async ({ page }) => {
+    await waitForEditor(page);
+    const handle = page.getByRole('separator', { name: 'Resize width' });
+    await expect(handle).toHaveAttribute('aria-orientation', 'vertical');
+
+    const before = await outlineWidth(page);
+    await handle.focus();
+    await page.keyboard.press('ArrowRight');
+    await expect.poll(() => outlineWidth(page)).toBe(before + 8);
+
+    await page.keyboard.press('ArrowLeft');
+    await expect.poll(() => outlineWidth(page)).toBe(before);
+  });
+
+  test('resize handle stays pinned while the outline tree scrolls', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 420 });
+    await waitForEditor(page);
+    const source = Array.from({ length: 120 }, (_, i) => `let v${i} = ${i}`).join('\n');
+    await page.evaluate((text) => {
+      const g = globalThis as any;
+      g.__canopy_crdt.set_text(g.__canopy_crdt_handle, text);
+    }, source);
+    await dispatchExternalCrdtChanged(page);
+
+    const handle = page.getByRole('separator', { name: 'Resize width' });
+    await expect(handle).toBeVisible();
+    const before = await handle.boundingBox();
+    expect(before).not.toBeNull();
+    if (!before) return;
+
+    const scrollState = await page.evaluate(() => {
+      const panel = document.querySelector('.outline-panel') as HTMLElement;
+      const tree = document.querySelector('.tree-rows') as HTMLElement;
+      panel.scrollTop = 160;
+      tree.scrollTop = 160;
+      return {
+        panelScrollTop: panel.scrollTop,
+        treeScrollTop: tree.scrollTop,
+        treeCanScroll: tree.scrollHeight > tree.clientHeight,
+      };
+    });
+    expect(scrollState.panelScrollTop).toBe(0);
+    expect(scrollState.treeCanScroll).toBe(true);
+    expect(scrollState.treeScrollTop).toBeGreaterThan(0);
+
+    const after = await handle.boundingBox();
+    expect(after).not.toBeNull();
+    if (!after) return;
+    expect(Math.round(after.x)).toBe(Math.round(before.x));
+    expect(Math.round(after.y)).toBe(Math.round(before.y));
+  });
+});

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -216,10 +216,11 @@ button:focus-visible, .action-btn:focus-visible,
 /* ── Outline Panel ──────────────────────────────────────── */
 
 .outline-panel {
-  width: 220px;
+  width: var(--outline-panel-width, 220px);
+  position: relative;
   background: var(--canopy-panel-bg);
   border-right: 1px solid var(--canopy-border);
-  overflow-y: auto;
+  overflow: hidden;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -248,11 +249,56 @@ button:focus-visible, .action-btn:focus-visible,
   margin-top: auto;
 }
 
+.panel-resize-handle {
+  position: absolute;
+  z-index: 2;
+  background: transparent;
+  border: 0;
+}
+
+.outline-resize-handle {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 8px;
+}
+
+.panel-resize-handle::after {
+  content: "";
+  position: absolute;
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-out-quart),
+              background var(--duration-fast) var(--ease-out-quart),
+              box-shadow var(--duration-fast) var(--ease-out-quart);
+}
+
+.outline-resize-handle::after {
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: var(--canopy-border);
+}
+
+.panel-resize-handle:hover::after,
+.panel-resize-handle:focus-visible::after {
+  opacity: 1;
+  background: var(--canopy-accent);
+  box-shadow: 0 0 12px rgba(130, 80, 223, 0.45);
+}
+
+.panel-resize-handle:focus-visible {
+  outline: 2px solid var(--canopy-focus-ring);
+  outline-offset: -2px;
+}
+
 /* ── Tree ───────────────────────────────────────────────── */
 
 .tree-rows {
   padding: 0 var(--space-sm);
   flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .tree-item {
@@ -1017,7 +1063,7 @@ canopy-editor {
 
 /* Tablet: compact panels */
 @media (max-width: 1024px) {
-  .outline-panel { width: 180px; }
+  .outline-panel { width: var(--outline-panel-width, 180px); }
   .inspector-panel { width: 200px; }
 }
 
@@ -1063,6 +1109,8 @@ canopy-editor {
 
   /* Hide spacers on mobile — let flex-gap handle spacing */
   .toolbar-spacer { flex: 0 0 var(--space-xs); }
+
+  .panel-resize-handle { display: none; }
 
   /* ── Panel drawers: slide from edges ───────────────────── */
 


### PR DESCRIPTION
## Summary

- Integrate `dowdiness/rabbita-resizable` into the real Ideal editor outline panel.
- Keep Ideal-owned markup/CSS while routing resize state, messages, and subscriptions through the existing Rabbita app model.
- Add browser coverage for mouse drag and keyboard nudge on the real outline panel.

Closes #507

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@resizable.Model::{new, update, width, is_resizing, handle_attrs, subscriptions}` | `lib/resizable/src/resizable` | Yes | Core behavior for outline panel resize state, view attrs, and document-level drag subscriptions. |
| `@resizable.Edge::East` | `lib/resizable/src/resizable/types.mbt` | Yes | Ideal outline panel only needs an east-edge width resize. |
| `@html.Attrs::{build, style}` | `rabbita/rabbita/html/attrs.mbt` | Yes | Used for consumer-owned outline panel width CSS custom property. |

New helpers added (if any):

- `initial_outline_resize`, `initial_workspace_layout`, `WorkspaceLayout::update_outline_resize`, `WorkspaceLayout::outline_width_px`: keep resize initialization/update formatting local to Ideal workspace layout and avoid duplicating `@resizable` behavior.
- `outline_panel_attrs`, `view_outline_resize_handle`: keep consumer-owned Ideal markup/styling in the editor view while reusing `@resizable` attrs.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon update
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 make check
NEW_MOON_MOD=0 make fmt-check
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon test --release
NEW_MOON_MOD=0 moon build --target js --release
cd examples/resizable && NEW_MOON_MOD=0 moon build --target js
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/outline-resizable.spec.ts e2e/structural-editing.spec.ts --reporter=line
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/editor-features.spec.ts --reporter=line
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/outline-aria.spec.ts e2e/outline-navigation.spec.ts --reporter=line
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run build
```

Manual browser check with `playwright-cli`:

- Mouse drag changed outline width from `220` to `284`.
- Keyboard ArrowRight changed outline width from `284` to `292`.
```
