### PR TITLE
fix(ideal): scope overlay name prompt value vs error, surface errors in all modes

### DIFF
--- a/examples/ideal/main/action_overlay_exec.mbt
+++ b/examples/ideal/main/action_overlay_exec.mbt
@@ -34,13 +34,13 @@ fn execute_action(
           (cmd, new_model)
         }
         Err(err) => {
-          let overlay = { ..model.overlay, name_error: err.message() }
+          let overlay = { ..model.overlay, error: err.message() }
           (none, { ..model, overlay, })
         }
       }
     Ok(None) => show_name_prompt(model, action)
     Err(msg) => {
-      let overlay = { ..model.overlay, name_error: msg }
+      let overlay = { ..model.overlay, error: msg }
       (none, { ..model, overlay, })
     }
   }

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -5,9 +5,8 @@ fn show_name_prompt(
 ) -> (Cmd, Model) {
   let overlay = {
     ..model.overlay,
-    mode: NamePrompt(action),
-    name_value: "",
-    name_error: "",
+    mode: NamePrompt(action, value=""),
+    error: "",
     menu: model.overlay.menu.reset(item_count=0),
   }
   (focus_selector_after_render(".name-prompt-input"), { ..model, overlay, })
@@ -38,6 +37,9 @@ fn open_submenu(
   let overlay = {
     ..model.overlay,
     mode: Submenu(action),
+    // Navigating into a submenu is a fresh attempt — clear any stale error so
+    // it doesn't linger across the now-visible (all-mode) error surface.
+    error: "",
     menu: model.overlay.menu.reset(item_count~),
   }
   (overlay.menu.focus_cmd(), { ..model, overlay, })
@@ -48,6 +50,8 @@ fn reset_main_menu(model : Model) -> Model {
   let overlay = {
     ..model.overlay,
     mode: MainMenu,
+    // Returning to the main menu is a fresh attempt — clear any stale error.
+    error: "",
     menu: model.overlay.menu.reset(item_count=model.overlay.actions.length()),
   }
   { ..model, overlay, }

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -3,7 +3,7 @@
 fn OverlayState::is_open(self : OverlayState) -> Bool {
   match self.mode {
     Closed => false
-    MainMenu | Submenu(_) | NamePrompt(_) => true
+    MainMenu | Submenu(_) | NamePrompt(_, ..) => true
   }
 }
 
@@ -26,8 +26,7 @@ fn closed_overlay() -> OverlayState {
     mode: Closed,
     actions: [],
     node_context: None,
-    name_value: "",
-    name_error: "",
+    error: "",
     anchor_top: 0,
     anchor_left: 0,
     menu: @menu.Model::new(id="ideal-action-overlay-menu", item_count=0),
@@ -119,8 +118,7 @@ fn open_action_overlay(
       mode: MainMenu,
       actions,
       node_context: Some(ctx),
-      name_value: "",
-      name_error: "",
+      error: "",
       anchor_top,
       anchor_left,
       menu: model.overlay.menu.reset(item_count=actions.length()),

--- a/examples/ideal/main/action_overlay_update.mbt
+++ b/examples/ideal/main/action_overlay_update.mbt
@@ -10,7 +10,7 @@ fn handle_action_text_key(model : Model, key : String) -> (Cmd, Model) {
       }
     }
     // In name prompt mode, let the view handle input.
-    NamePrompt(_) => (none, model)
+    NamePrompt(_, ..) => (none, model)
     MainMenu => {
       // Match mnemonic: find the action whose mnemonic matches the key.
       let matched = model.overlay.actions
@@ -71,5 +71,36 @@ fn handle_action_key(model : Model, key : String) -> (Cmd, Model) {
   match model.overlay.menu.keydown_msg(key) {
     Some(menu_msg) => handle_action_menu_msg(model, menu_msg)
     None => (none, model)
+  }
+}
+
+///|
+fn handle_name_prompt_input(model : Model, value : String) -> (Cmd, Model) {
+  match model.overlay.mode {
+    NamePrompt(action, ..) => {
+      let overlay = {
+        ..model.overlay,
+        mode: NamePrompt(action, value~),
+        error: "",
+      }
+      (none, { ..model, overlay, })
+    }
+    _ => (none, model)
+  }
+}
+
+///|
+fn handle_name_prompt_submit(model : Model) -> (Cmd, Model) {
+  match model.overlay.mode {
+    NamePrompt(action, value~) => {
+      let name = value.trim().to_owned()
+      if name == "" {
+        let overlay = { ..model.overlay, error: "Enter a name to continue" }
+        (none, { ..model, overlay, })
+      } else {
+        execute_action(model, action, "", name)
+      }
+    }
+    _ => (none, model)
   }
 }

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -675,26 +675,8 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       } else {
         handle_action_key(model, key)
       }
-    NamePromptInput(value) => {
-      let overlay = { ..model.overlay, name_value: value, name_error: "" }
-      (none, { ..model, overlay, })
-    }
-    NamePromptSubmit => {
-      let name = model.overlay.name_value.trim().to_owned()
-      if name == "" {
-        let overlay = {
-          ..model.overlay,
-          name_error: "Enter a name to continue",
-        }
-        return (none, { ..model, overlay, })
-      }
-      let overlay = { ..model.overlay, name_value: name }
-      let model = { ..model, overlay, }
-      match model.overlay.mode {
-        NamePrompt(action) => execute_action(model, action, "", name)
-        _ => (none, model)
-      }
-    }
+    NamePromptInput(value) => handle_name_prompt_input(model, value)
+    NamePromptSubmit => handle_name_prompt_submit(model)
     NamePromptCancel => close_action_overlay(model)
     // ── Outline drag-and-drop ──────
     OutlineDragStart(node_id) => (none, { ..model, drag_source: Some(node_id) })

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -56,7 +56,9 @@ enum OverlayMode {
   Closed
   MainMenu
   Submenu(@lambda_edits.Action)
-  NamePrompt(@lambda_edits.Action)
+  // `value` is the text typed into the name prompt — genuinely prompt-local,
+  // so it lives in the variant rather than as a flat OverlayState field.
+  NamePrompt(@lambda_edits.Action, value~ : String)
 }
 
 ///|
@@ -64,8 +66,10 @@ struct OverlayState {
   mode : OverlayMode
   actions : Array[@lambda_edits.Action]
   node_context : NodeActionContext?
-  name_value : String
-  name_error : String
+  // The most recent failure to act. Overlay-wide, not prompt-specific: an
+  // action can fail to apply from MainMenu or Submenu just as from NamePrompt,
+  // so the error is rendered in the panel for any open mode (view_actions.mbt).
+  error : String
   anchor_top : Int
   anchor_left : Int
   menu : @menu.Model

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -66,30 +66,25 @@ fn view_action_list(
 }
 
 ///|
+fn name_prompt_label(action : @lambda_edits.Action) -> String {
+  match action.id {
+    "rename" | "binding_rename" => "New name"
+    "extract_to_let" => "Variable name"
+    "wrap_lambda" => "Parameter name"
+    "add_binding" => "Binding name"
+    _ => action.label
+  }
+}
+
+///|
 /// Render the name prompt input.
 fn view_name_prompt(
   dispatch : @rabbita.Emit[Msg],
   model : Model,
 ) -> @rabbita.Html {
-  let prompt_label = match model.overlay.mode {
-    NamePrompt(action) =>
-      match action.id {
-        "rename" | "binding_rename" => "New name"
-        "extract_to_let" => "Variable name"
-        "wrap_lambda" => "Parameter name"
-        "add_binding" => "Binding name"
-        _ => action.label
-      }
-    _ => "Enter name"
-  }
-  let error_el : @rabbita.Html = if model.overlay.name_error != "" {
-    @html.div(
-      class="name-prompt-error",
-      attrs=@html.Attrs::build().role("alert").aria_live("polite"),
-      [@html.text(model.overlay.name_error)],
-    )
-  } else {
-    @html.nothing
+  let (prompt_label, name_value) = match model.overlay.mode {
+    NamePrompt(action, value~) => (name_prompt_label(action), value)
+    _ => ("Enter name", "")
   }
   let on_keydown_handler = fn(kb : @html.Keyboard) {
     let key = kb.key()
@@ -108,13 +103,12 @@ fn view_name_prompt(
         input_type=@html.InputType::Text,
         class="name-prompt-input",
         placeholder="name\u{2026}",
-        value=model.overlay.name_value,
+        value=name_value,
         autofocus=true,
         on_input=fn(value) { dispatch(NamePromptInput(value)) },
         attrs=@html.Attrs::build().aria_label(prompt_label),
       ),
     ]),
-    error_el,
   ])
 }
 
@@ -152,6 +146,21 @@ fn view_submenu_choices(
 }
 
 ///|
+/// Render an overlay-wide error. Actions can fail from any open overlay mode
+/// (MainMenu, Submenu, or NamePrompt), so errors live at the panel top.
+fn view_action_overlay_error(message : String) -> @rabbita.Html {
+  if message == "" {
+    @html.nothing
+  } else {
+    @html.div(
+      class="action-overlay-error",
+      attrs=@html.Attrs::build().role("alert").aria_live("polite"),
+      [@html.text(message)],
+    )
+  }
+}
+
+///|
 /// Render the action overlay: scrim + positioned panel.
 /// Returns nothing if the overlay is not visible.
 fn view_action_overlay(
@@ -167,7 +176,7 @@ fn view_action_overlay(
   let position_style = "top: \{top}px; left: \{left}px;"
   // Determine content: name prompt, submenu, or main action list
   let content : @rabbita.Html = match model.overlay.mode {
-    NamePrompt(_) => view_name_prompt(dispatch, model)
+    NamePrompt(_, ..) => view_name_prompt(dispatch, model)
     Submenu(sub_action) =>
       match model.overlay.node_context {
         Some(ctx) =>
@@ -197,7 +206,7 @@ fn view_action_overlay(
         .panel_attrs(msg => dispatch(ActionMenu(msg)))
         .aria_label("Structural editing actions")
         .style_attr(position_style),
-      [content],
+      [view_action_overlay_error(model.overlay.error), content],
     ),
   ])
 }

--- a/examples/ideal/web/e2e/structural-editing.spec.ts
+++ b/examples/ideal/web/e2e/structural-editing.spec.ts
@@ -238,7 +238,7 @@ test.describe('Structural Editing - Overlay on Var nodes', () => {
     });
     await page.locator('.name-prompt-input').focus();
     await page.keyboard.press('Enter');
-    await expect(page.locator('.name-prompt-error')).toContainText('Enter a name to continue');
+    await expect(page.locator('.action-overlay-error')).toContainText('Enter a name to continue');
   });
 
   test('Escape cancels name prompt', async ({ page }) => {

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -491,10 +491,10 @@ const SHADOW_STYLES = `
   .name-prompt-input:focus {
     border-color: var(--canopy-focus-ring, #a070ef);
   }
-  .name-prompt-error {
+  .action-overlay-error {
     font-size: var(--text-label, 0.6875rem);
     color: var(--canopy-error-text, #ef4444);
-    margin-top: 4px;
+    padding: var(--space-sm, 0.5rem) var(--space-lg, 1rem);
   }
 
   /* Mobile: bottom sheet instead of positioned popover */

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -1389,10 +1389,10 @@ canopy-editor {
   color: var(--canopy-text-dim);
 }
 
-.name-prompt-error {
+.action-overlay-error {
   font-size: var(--text-label);
   color: var(--canopy-error-text);
-  padding-top: var(--space-xs);
+  padding: var(--space-sm) var(--space-lg);
 }
 
 /* ── Overlay mobile adjustments ────────────────────────── */


### PR DESCRIPTION
## Summary

Structural-editing action overlay (examples/ideal): split `OverlayState`'s `name_value`/`name_error` fields by their **real scope**, and fix a latent invisible-error bug as a consequence.

- **`name_value` → `NamePrompt(action, value~ : String)`.** The typed text is genuinely prompt-local, so it belongs inside the enum variant. "Value set while not prompting" is now unrepresentable.
- **`name_error` → overlay-wide `OverlayState.error`.** Errors are *not* prompt-specific — an action can fail to apply from `MainMenu` or `Submenu` just as from `NamePrompt`. The error now renders at the panel top (`view_action_overlay_error`) for **any** open mode, and clears on fresh-attempt transitions (`show_name_prompt`, `open_submenu`, `reset_main_menu`, and on `NamePromptInput`).

### Bug this fixes

`execute_action` sets the error after a failed `apply_lambda_tree_edit` (`action_overlay_exec.mbt`). That can happen while the overlay is in `MainMenu` or `Submenu` mode (called from `dispatch_or_prompt` and `execute_submenu_choice`). The old renderer displayed `name_error` only inside `view_name_prompt`, so a failed non-input or submenu action **stored an error that was never shown** — the overlay silently no-op'd with no feedback. The error now surfaces from every open mode.

The build-error path in those modes was already defensively dead (`get_actions_for_node` guards each context precondition), but the **apply-error path is live** (`apply_lambda_tree_edit` returns `ModuleProjectionUnavailable` / `UnhandledOperation` / `ProjectionEdit` for any op).

CSS: `.name-prompt-error` → `.action-overlay-error` (overlay-wide) in **both** the light-DOM `editor.css` and the duplicated shadow-DOM `SHADOW_STYLES` in `canopy-editor.ts`; e2e assertion updated.

## Reuse check

- No new types/helpers beyond minimal view extractions (`name_prompt_label`, `view_action_overlay_error`, `handle_name_prompt_input/submit`) introduced by an in-session `/simplify` pass — all are local to `examples/ideal/main`, no public-API surface (the `OverlayMode`/`OverlayState` types are private; `pkg.generated.mbti` is unchanged).
- Reused the existing `NamePrompt` variant (added a labelled field) rather than introducing a parallel state container.
- No new error type — reused the existing `String` error channel and the existing `.action-overlay-*` class family.

## Test plan

- `moon check --deny-warn` — clean
- `moon test` — 1316 [js] + 36 [native], 0 failed
- `npx playwright test e2e/structural-editing.spec.ts` — 13/13 (first run had cold-start flakiness on app load; green on warm build)

## Notes

- **Independent of #529** (resizable outline panel). This branch is based on `main` and shares no logic with the resizable work; the two were untangled from a working tree where both had been staged together.
- **Pre-existing duplication flagged:** the overlay CSS lives in two places — `web/styles/editor.css` (light DOM) and `web/src/canopy-editor.ts` `SHADOW_STYLES` (shadow DOM). This PR keeps them in sync but does not deduplicate; a single-source-of-truth follow-up is worth considering.
- **Minor behavior note:** on a *failed* name-prompt submit the input now retains the user's exact (untrimmed) text rather than the trimmed copy. The applied edit still uses the trimmed name, so this is sub-cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
