### PR TITLE
Extract reusable status live-region behavior

### DIFF
--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -6,6 +6,7 @@ import {
   "dowdiness/incr",
   "dowdiness/graph-dsl" @graph_dsl,
   "dowdiness/rabbita-context-menu/context_menu",
+  "dowdiness/rabbita-status/status",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -33,7 +33,7 @@ struct SourceDemoModel {
   editor : String
   dirty : Bool
   status : String
-  tone : String
+  status_tone : @status.Tone
   on_change : () -> Unit
 }
 
@@ -76,9 +76,9 @@ fn source_demo_status_from_result(
   result : SourceGraphOperationResultJson,
   success_message : String,
   failure_prefix : String,
-) -> (String, String) {
+) -> (String, @status.Tone) {
   if result.applied {
-    (success_message, "success")
+    (success_message, @status.Success)
   } else {
     let detail = match result.message {
       Some(message) => message
@@ -89,7 +89,7 @@ fn source_demo_status_from_result(
           result.diagnostics.join("; ")
         }
     }
-    (failure_prefix + ": " + detail, "error")
+    (failure_prefix + ": " + detail, @status.Error)
   }
 }
 
@@ -106,23 +106,23 @@ fn source_demo_update(
       let result = set_source_graph_source_checked(model.handle, model.editor)
       let success_message = "Source applied; render state is reparsed from Loom GraphDoc."
       let failure_prefix = "Current source is invalid; canvas is rendering last-good graph"
-      let (status, tone) = source_demo_status_from_result(
+      let (status, status_tone) = source_demo_status_from_result(
         result, success_message, failure_prefix,
       )
       (
         source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, tone },
+        { ..model, editor: result.source, dirty: false, status, status_tone },
       )
     }
     ConnectSample => {
       let result = source_graph_connect_sample_result(model.handle)
       let success_message = "Connected meter.input to osc.out through graph-dsl source."
-      let (status, tone) = source_demo_status_from_result(
+      let (status, status_tone) = source_demo_status_from_result(
         result, success_message, "Source operation rejected",
       )
       (
         source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, tone },
+        { ..model, editor: result.source, dirty: false, status, status_tone },
       )
     }
     InsertReverb => {
@@ -132,12 +132,12 @@ fn source_demo_update(
         "plate",
       )
       let success_message = "Inserted reverb = plate() from canonical source."
-      let (status, tone) = source_demo_status_from_result(
+      let (status, status_tone) = source_demo_status_from_result(
         result, success_message, "Source operation rejected",
       )
       (
         source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, tone },
+        { ..model, editor: result.source, dirty: false, status, status_tone },
       )
     }
     SyncFromGraph => {
@@ -154,7 +154,7 @@ fn source_demo_update(
             ..model,
             editor: source,
             status: "Source synchronized from graph-dsl backing store.",
-            tone: "success",
+            status_tone: @status.Success,
           },
         )
       }
@@ -168,11 +168,6 @@ fn source_demo_subscriptions(
   _model : SourceDemoModel,
 ) -> @sub.Sub {
   @sub.every(250, emit(SyncFromGraph))
-}
-
-///|
-fn source_status_attrs(tone : String) -> @html.Attrs {
-  @html.Attrs::build().data_set("tone", tone)
 }
 
 ///|
@@ -222,7 +217,7 @@ fn source_demo_view(
       p(
         id="source-status",
         class="hint source-status",
-        attrs=source_status_attrs(model.tone),
+        attrs=model.status_tone.attrs(),
         style=["margin-top: 12px"],
         [text(model.status)],
       ),
@@ -246,7 +241,7 @@ pub fn mount_source_demo(
     editor: get_source_graph_source(handle),
     dirty: false,
     status: "Source mode active: operations lower into graph-dsl text.",
-    tone: "success",
+    status_tone: @status.Info,
     on_change,
   }
   @rabbita.new(

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -11,6 +11,10 @@
       "path": "../../lib/context-menu",
       "version": "0.1.0"
     },
+    "dowdiness/rabbita-status": {
+      "path": "../../lib/status",
+      "version": "0.1.0"
+    },
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
       "version": "0.12.4"

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -215,8 +215,12 @@ for (const invalidSource of INVALID_SOURCE_CASES) {
     await expect(page.locator('.canvas-node')).toHaveCount(2);
     await expect(page.locator('#edges path.edge')).toHaveCount(0);
     await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
-    await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'error');
-    await expect(page.locator('#source-status')).toContainText(
+    const status = page.locator('#source-status');
+    await expect(status).toHaveAttribute('role', 'status');
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+    await expect(status).toHaveAttribute('aria-atomic', 'true');
+    await expect(status).toHaveAttribute('data-tone', 'error');
+    await expect(status).toContainText(
       'Current source is invalid; canvas is rendering last-good graph: current source is not graph-valid:',
     );
     await expect(page.locator('#validation-list .validation-item.error').first()).toBeVisible();
@@ -257,7 +261,12 @@ test('source-backed mode mutates canonical source and render state together', as
   await page.locator('#source-apply').click();
   await expect(page.locator('.canvas-node')).toHaveCount(4);
   await expect(page.locator('#edges path.edge')).toHaveCount(2);
-  await expect(page.locator('#source-status')).toHaveText(
+  const status = page.locator('#source-status');
+  await expect(status).toHaveAttribute('role', 'status');
+  await expect(status).toHaveAttribute('aria-live', 'polite');
+  await expect(status).toHaveAttribute('aria-atomic', 'true');
+  await expect(status).toHaveAttribute('data-tone', 'success');
+  await expect(status).toHaveText(
     'Source applied; render state is reparsed from Loom GraphDoc.',
   );
 

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -813,13 +813,19 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
 
 ///|
 fn view_peer_status(model : Model) -> Html {
-  let (dot_class, label) : (String, String) = match model.sync_status {
-    Connected => ("peer-dot connected", "You (connected)")
-    Connecting => ("peer-dot connecting", "Connecting\u{2026}")
-    Offline => ("peer-dot offline", "Offline \u{2014} reconnecting\u{2026}")
-    Error => ("peer-dot error", "Connection error")
+  let (dot_class, label, tone) : (String, String, @status.Tone) = match
+    model.sync_status {
+    Connected => ("peer-dot connected", "You (connected)", @status.Success)
+    Connecting => ("peer-dot connecting", "Connecting\u{2026}", @status.Info)
+    Offline =>
+      (
+        "peer-dot offline",
+        "Offline \u{2014} reconnecting\u{2026}",
+        @status.Info,
+      )
+    Error => ("peer-dot error", "Connection error", @status.Error)
   }
-  div(class="peer-item", [
+  div(class="peer-item", attrs=tone.attrs(), [
     div(class=dot_class, attrs=@html.Attrs::build().aria_hidden("true"), [
       text(""),
     ]),

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -9,6 +9,7 @@ import {
   "dowdiness/rabbita-tabs/tabs",
   "dowdiness/rabbita-treeview/treeview",
   "dowdiness/rabbita-resizable/resizable",
+  "dowdiness/rabbita-status/status",
   "dowdiness/dom_boundary",
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/canopy/ffi/lambda" @ffi,

--- a/examples/ideal/moon.mod.json
+++ b/examples/ideal/moon.mod.json
@@ -26,6 +26,10 @@
       "path": "../../lib/resizable",
       "version": "0.1.0"
     },
+    "dowdiness/rabbita-status": {
+      "path": "../../lib/status",
+      "version": "0.1.0"
+    },
     "dowdiness/dom_boundary": {
       "path": "../../lib/dom-boundary",
       "version": "0.1.0"

--- a/lib/status/README.md
+++ b/lib/status/README.md
@@ -1,0 +1,44 @@
+# Rabbita Status
+
+Headless status/live-region behavior for Rabbita apps. The package owns the
+small semantic tone vocabulary and ARIA live-region attributes; the consumer owns
+message copy, domain status calculation, HTML structure, and styling.
+
+## Use
+
+```mbt nocheck
+struct Model {
+  status_text : String
+  status_tone : @status.Tone
+}
+
+fn view(_emit : @rabbita.Emit[Msg], model : Model) -> @rabbita.Html {
+  @html.p(
+    class="status-line",
+    attrs=model.status_tone.attrs(),
+    [@html.text(model.status_text)],
+  )
+}
+```
+
+Use `Info`, `Success`, and `Error` for domain tone mapping. `Tone::attrs()` emits
+`role="status"`, `aria-live="polite"`, `aria-atomic="true"`, and
+`data-tone="info|success|error"`. Consumers can chain additional attrs or use
+wrapper parameters for ids, classes, and styling.
+
+## Consumer evaluation
+
+- Canvas source-backed Apply status is the first real consumer.
+- Ideal peer sync status was evaluated and migrated as a second feedback
+  surface; it fits the API because Ideal keeps the sync-state mapping and label
+  copy while this package supplies only the live-region/tone attrs.
+
+## Verified Rabbita APIs
+
+Implementation was checked against the vendored Rabbita source, especially:
+
+- `rabbita/doc/002_writing_html/readme.mbt.md`
+- `rabbita/rabbita/html/README.mbt.md`
+- `rabbita/rabbita/html/design.md`
+- `rabbita/rabbita/html/pkg.generated.mbti` — `Attrs::{build, role, aria_live,
+  aria_atomic, data_set}`.

--- a/lib/status/moon.mod.json
+++ b/lib/status/moon.mod.json
@@ -1,0 +1,27 @@
+{
+  "name": "dowdiness/rabbita-status",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "moonbit-community/rabbita": {
+      "path": "../../rabbita/rabbita",
+      "version": "0.12.4"
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/dowdiness/canopy",
+  "license": "Apache-2.0",
+  "keywords": [
+    "rabbita",
+    "status",
+    "live-region",
+    "headless-ui",
+    "component",
+    "moonbit",
+    "tea",
+    "aria"
+  ],
+  "description": "Headless status/live-region behavior helpers for Rabbita.",
+  "preferred-target": "native",
+  "supported-targets": "js+native"
+}

--- a/lib/status/src/status/attrs.mbt
+++ b/lib/status/src/status/attrs.mbt
@@ -1,0 +1,12 @@
+///|
+/// ARIA live-region attrs for a status element.
+///
+/// The element announces text changes politely and atomically while exposing a
+/// stable `data-tone` hook for consumer-owned styling and tests.
+pub fn Tone::attrs(self : Tone) -> @html.Attrs {
+  @html.Attrs::build()
+  .role("status")
+  .aria_live("polite")
+  .aria_atomic("true")
+  .data_set("tone", self.data_value())
+}

--- a/lib/status/src/status/moon.pkg
+++ b/lib/status/src/status/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbit-community/rabbita/html",
+}
+
+supported_targets = "js+native"

--- a/lib/status/src/status/pkg.generated.mbti
+++ b/lib/status/src/status/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/rabbita-status/status"
+
+import {
+  "moonbit-community/rabbita/html",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum Tone {
+  Info
+  Success
+  Error
+} derive(Eq)
+pub fn Tone::attrs(Self) -> @html.Attrs
+
+// Type aliases
+
+// Traits
+

--- a/lib/status/src/status/status_wbtest.mbt
+++ b/lib/status/src/status/status_wbtest.mbt
@@ -1,0 +1,6 @@
+///|
+test "tone data values are stable" {
+  assert_eq(Info.data_value(), "info")
+  assert_eq(Success.data_value(), "success")
+  assert_eq(Error.data_value(), "error")
+}

--- a/lib/status/src/status/types.mbt
+++ b/lib/status/src/status/types.mbt
@@ -1,0 +1,19 @@
+///|
+/// Semantic tone for a short app-feedback status message.
+///
+/// Consumers own message copy and domain mapping. The behavior only exposes the
+/// stable tone vocabulary used by `Tone::attrs` for `data-tone`.
+pub(all) enum Tone {
+  Info
+  Success
+  Error
+} derive(Eq)
+
+///|
+fn Tone::data_value(self : Tone) -> String {
+  match self {
+    Info => "info"
+    Success => "success"
+    Error => "error"
+  }
+}

--- a/moon.work
+++ b/moon.work
@@ -7,6 +7,7 @@ members = [
   "./lib/resizable",
   "./lib/menu",
   "./lib/context-menu",
+  "./lib/status",
   "./lib/tabs",
   "./lib/treeview",
   "./lib/dom-boundary",


### PR DESCRIPTION
## Summary

- Add `dowdiness/rabbita-status/status`, a small headless status/live-region behavior with `Info` / `Success` / `Error` tones and polite ARIA attrs.
- Move Canvas source-backed Apply status to the reusable behavior while keeping message copy/domain status calculation in Canvas.
- Evaluate and migrate Ideal peer sync status as a second consumer.

Closes #508.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Attrs::{role, aria_live, aria_atomic, data_set}` | `moonbit-community/rabbita/html` | Yes | `Tone::attrs()` composes the existing Rabbita attr builder; no lower-level DOM API needed. |
| `source_status_attrs` | `examples/canvas/main/source_demo.mbt` | No | This was Canvas-local and stringly typed (`data-tone` only); replaced by the reusable tone/live-region behavior. |
| `view_peer_status` sync mapping | `examples/ideal/main/main.mbt` | Partially | Ideal still owns sync-state labels and domain mapping; only the live-region/tone attrs moved to `lib/status`. |

New helpers added:

- `@status.Tone`: shared semantic status tone vocabulary for app feedback.
- `@status.Tone::attrs`: emits polite live-region attrs plus stable `data-tone` for consumer-owned styling/tests.
- private `Tone::data_value`: internal tone-to-attribute mapping, kept private so callers use the enum instead of strings.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check --deny-warn` passes
- [x] `NEW_MOON_MOD=0 moon test --release` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`npm test` web servers ran `prebuild:moonbit` for Canvas and Ideal)

## Validation

```bash
NEW_MOON_MOD=0 moon update
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test --release
NEW_MOON_MOD=0 moon fmt --check
NEW_MOON_MOD=0 moon info
cd examples/canvas/web && npm test -- e2e/source-backed.spec.ts --reporter=line
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm test -- e2e/editor-features.spec.ts -g "shows connection status" --reporter=line
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status/live-region library providing semantic tones (Info, Success, Error) for application feedback.
  * Integrated ARIA live-region attributes for improved accessibility.

* **Documentation**
  * Added status library documentation with usage examples.

* **Tests**
  * Added verification tests for status functionality and attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->