### PR TITLE
feat(ideal): single-source shadow CSS via adoptedStyleSheets (de-dup foundation)

### DIFF
--- a/docs/plans/2026-06-06-ideal-css-dedup-foundation-plan.md
+++ b/docs/plans/2026-06-06-ideal-css-dedup-foundation-plan.md
@@ -1,0 +1,106 @@
+# Ideal CSS De-dup Foundation + Tailwind v4 Spike Plan
+
+## Scope and hard constraints
+- Scope fence: `examples/ideal/` only.
+- Preserve byte-stable class names and exact selector semantics used by current tests.
+- Do not touch `leaf-editor.ts`, `text-nodeview.ts`, `cm-inline.ts` CSS injection architecture.
+- No redesign of PR #530/#529 artifacts; only relocation + de-dup.
+- Verification must use Playwright CLI (WSL2).
+- Vite light-DOM stylesheet load (`/styles/editor.css`) must remain.
+
+## 1) Audit & classify all relevant selectors (shadow-only / light-only / overlap)
+- Read source anchors already identified:
+  - `examples/ideal/web/styles/editor.css`
+  - `examples/ideal/web/src/canopy-editor.ts` (constructor + `SHADOW_STYLES`)
+  - `examples/ideal/main/view_actions.mbt`
+  - `examples/ideal/main/view_outline.mbt` / `view_inspector.mbt` (for other potential overlap)
+  - `examples/ideal/web/e2e/structural-editing.spec.ts`
+  - `examples/ideal/web/src/canopy-editor.ts` constructor lines (~42–46 and ~248)
+- Class provenance pass (script/grep), then tag by rendering surface:
+  - `examples/ideal/main/**/*.mbt`: light-host authored view classes.
+  - `examples/ideal/web/src/**/*.ts`: treat class writers in CM/PM nodeviews as shadow-rendered; treat `view_editor.mbt` and top-level non-shadow UI as light DOM.
+- Practical commands:
+  - `rg -o '\.(?:[A-Za-z_][A-Za-z0-9_-]*)(?:[-: .][^,{]*)*' examples/ideal/web/styles/editor.css`
+  - `sed -n '248,620p' examples/ideal/web/src/canopy-editor.ts | rg '^\s*\.[A-Za-z.#:]'`
+  - `rg -n 'class=\"|className\s*=\s*"|class: \"|\.class\(' examples/ideal/main examples/ideal/web/src`
+  - `rg -n 'class\s*=\"action-overlay|action-label|name-prompt|peer-cursor|structure-|ProseMirror' examples/ideal/main examples/ideal/web/src`
+- Produce a 3-bucket output artifact (local temp, non-committed):
+  - `light-only`
+  - `shadow-only`
+  - `overlap` plus `overlap-dead-in-light` (no light-DOM consumer found)
+- **Verification command**: produce the buckets as a markdown file or console dump and require every overlap selector to have one of the above buckets plus per-selector light-DOM usage proof.
+- **Expected result**: overlap-set should contain action-overlay and name-prompt selectors; confirm if `overlap-dead-in-light` is non-empty.
+
+## 2) Create dedicated shadow stylesheet file
+- Create: `examples/ideal/web/styles/editor-shadow.css`.
+- Move into it:
+  - all `shadow-only` rules from `SHADOW_STYLES`.
+  - all overlay-related overlap selectors currently in `SHADOW_STYLES` that are `overlap-dead-in-light`.
+- Keep `:root` token definitions in `examples/ideal/web/styles/editor.css` only.
+- Do not include non-overlay shadow-only rules if they are already covered by `editor.css` token semantics.
+- **Verification command**:
+  - `rg -n 'SHADOW_STYLES|ProseMirror|structure-|peer-cursor|action-overlay|name-prompt|:starting-style' examples/ideal/web/styles/editor-shadow.css`
+- **Expected result**: selectors in shadow file are only the intended subset; `editor.css` still contains unchanged `:root` block.
+
+## 3) Wire delivery via `?inline` + single shared `CSSStyleSheet` + fallback
+- In `examples/ideal/web/src/canopy-editor.ts`:
+  - import shadow css once with Vite inline import, e.g. `import shadowStyles from '../styles/editor-shadow.css?inline'`
+  - replace `SHADOW_STYLES` constant usage.
+  - instantiate one module-level `CSSStyleSheet`, `replaceSync(shadowStyles)` once (lazy or static singleton), and assign through `shadowRoot.adoptedStyleSheets`.
+  - feature-detect fallback:
+    - if `adoptedStyleSheets` available: append shared sheet to `this.shadowRoot.adoptedStyleSheets`
+    - else: append `<style>` with `textContent = shadowStyles`.
+- Ensure no duplicate append: only one shared stylesheet object for all components.
+- Preserve existing light-DOM editor css link in `examples/ideal/web/index.html` unchanged (`/styles/editor.css`).
+- Remove `SHADOW_STYLES` constant block from `canopy-editor.ts`.
+- **Verification command (compilation breakpoint)**:
+  - `cd examples/ideal/web && npm run build`
+- **Expected result**: TS build passes; no `SHADOW_STYLES` reference remains.
+
+## 4) Dead-CSS removal in light-DOM sheet
+- In `examples/ideal/web/styles/editor.css`, delete overlap selectors validated as `overlap-dead-in-light`.
+- Leave overlap selectors still used in light DOM untouched.
+- Optionally keep temporary audit notes in file-local comments until cleanup commit.
+- **Verification command**:
+  - `rg -n '\.action-overlay-scrim|\.action-overlay-panel|\.action-overlay-list|\.action-overlay-item|\.action-group-label|\.action-mnemonic|\.action-label-text|\.name-prompt-(container|label|input|input-row|error)' examples/ideal/web/styles/editor.css`
+- **Expected result**: only truly-used light-DOM selectors remain; dead overlap selectors are removed.
+
+## 5) Tailwind v4 spike (overlay-only, on top of adopted-sheet path)
+- Spike assets are throwaway:
+  - `examples/ideal/web/styles/overlay-tailwind.css`
+  - `examples/ideal/web/vite.config.ts` temporary plugin wiring (if absent)
+- First, confirm status:
+  - `cd examples/ideal/web && rg -n 'tailwind|@tailwindcss/vite|@source|@import "tailwindcss"' vite.config.ts src styles`
+  - expected: no existing Tailwind v4 setup in `web` today.
+- Spike stylesheet draft:
+  - `@import "tailwindcss" source(none);`
+  - `@source "../../main/**/*.mbt"`
+  - fallback if `.mbt` not scanned: `@source "../../_build/js/release/build/main/**/*.js"` (or exact main js file)
+  - add `@layer base { :host { ... } }` for minimal reset consistency
+  - add only action-overlay utility classes used by `view_actions.mbt`
+- Temporarily route shadow injection to spike stylesheet via one explicit temporary toggle (or local file swap) while executing the spike; keep production path unchanged unless spike passes.
+- Adopted-sheet transport remains the same as Step 3 (no separate mechanism).
+- PASS/FAIL gate:
+  - PASS: scan picks up MBT action classes; overlay renders with computed styles via adopted stylesheet path; existing structural overlay test + new computed-style assertion pass.
+  - FAIL: do not merge any Tailwind files; keep Step 3 as shipping baseline.
+
+## 6) Tests
+- Keep current e2e suite green.
+- Add one Playwright computed-style assertion (single new assertion) against shadow-rendered overlay in:
+  - `examples/ideal/web/e2e/structural-editing.spec.ts`
+- Proposed pattern:
+  - open Var action overlay.
+  - resolve `const overlay = page.locator('canopy-editor').locator('.action-overlay-panel')`.
+  - after visibility assert, read `getComputedStyle` for a property defined by shadow css (e.g. `backgroundColor`, `minWidth`, `zIndex`).
+  - assert non-default value from the intended overlay style.
+- **Verification command**:
+  - `cd examples/ideal/web && npx playwright test e2e/structural-editing.spec.ts --reporter=line`
+- **Expected result**: existing tests pass and the new computed-style assertion catches style regression in shadow transport.
+
+## Resolutions to open questions (design-owner decisions)
+1. **`.mbt` scanning in Tailwind v4.** Confirm the current v4 `@source` extractor behavior against docs via **Context7** at the start of Step 5 (not from memory). Empirically test `.mbt` scanning first; the `_build` JS `@source` is the committed fallback if `.mbt` is not picked up. This is a *spike question* — resolving it is the spike's purpose, not a blocker.
+2. **Browser matrix for the fallback.** Target evergreen browsers (Chrome/Edge/Firefox, Safari 16.4+), where `adoptedStyleSheets` is native. The `<style>.textContent` fallback exists only as essentially-free insurance for Safari <16.4; no special test matrix is required.
+3. **Spike dependency install.** Acceptable as a throwaway devDependency in `examples/ideal/web`. If the spike FAILS, the dep and all spike assets (`overlay-tailwind.css`, vite plugin wiring, the temporary injection toggle) are removed; none of it ships in the Step 1–4 foundation.
+
+## Execution-risk note (human-judgment checkpoint)
+The single highest-risk step is the **surface classification in Step 1** (which class renders in light DOM vs the shadow root). Misclassification silently regresses styling. Do **not** fully mechanize this: grep gives provenance, but the light-vs-shadow rendering surface of each class requires reading the view/nodeview that emits it. Treat the 3-bucket output as a reviewed artifact before any deletion in Step 4.

--- a/docs/plans/2026-06-06-ideal-css-dedup-foundation-plan.md
+++ b/docs/plans/2026-06-06-ideal-css-dedup-foundation-plan.md
@@ -104,3 +104,54 @@
 
 ## Execution-risk note (human-judgment checkpoint)
 The single highest-risk step is the **surface classification in Step 1** (which class renders in light DOM vs the shadow root). Misclassification silently regresses styling. Do **not** fully mechanize this: grep gives provenance, but the light-vs-shadow rendering surface of each class requires reading the view/nodeview that emits it. Treat the 3-bucket output as a reviewed artifact before any deletion in Step 4.
+
+## Runtime findings (2026-06-06, during execution) — corrections
+
+A Playwright probe in structure mode returned
+`{"inLight":true,"inShadow":false,"rootKind":"document(light)"}` for
+`.action-overlay-panel`. This **inverts** the pre-execution assumption:
+
+- The action overlay / name prompt render in the **light DOM** (the Rabbita
+  view tree; `view_editor.mbt` renders `<canopy-editor>` with empty children,
+  so the overlay is a light-DOM sibling, not shadow content). Their live
+  stylesheet is `editor.css`.
+- Therefore the overlay block in the old `SHADOW_STYLES` string was **dead**.
+  De-dup was achieved by deleting it (with the whole const); `editor.css` was
+  left **untouched**. **Step 4 (dead-light removal) is moot** — there was no
+  dead light-DOM CSS to remove.
+- `editor-shadow.css` contains only the genuinely shadow-rendered rules:
+  `:host`, `#editor-root`, `.ProseMirror`, `.structure-*`, `.drop-*`,
+  `.peer-cursor-*`, `.peer-selection`.
+
+**Implication for Step 5 (spike):** the ~117 `.mbt` class sites are **light
+DOM**, so Tailwind on them is normal (no shadow problem). The shadow-delivery
+question is decoupled and already answered generically by the adopted-sheet
+foundation (any CSS, incl. Tailwind-generated, adopts into the shadow the same
+way — proven by the new computed-style test). The only load-bearing spike
+unknown that remains is **(a): can Tailwind v4 scan `.mbt` class strings?**
+The shadow-component spike target (`.structure-block`) is TS-rendered
+(`structure-runtime`), not `.mbt`, so it does not test the scan question.
+
+**Status:** Steps 1–4 (foundation) DONE + verified (commit on
+`ideal-css-dedup-foundation`). Step 5 spike re-scoped to question (a).
+
+## Spike results (2026-06-06) — Step 5 gate: PASS
+
+- **(a) Can Tailwind v4 scan `.mbt` class strings?** PROVEN YES. With
+  `@import "tailwindcss" source(none); @source "../main";`, the Tailwind v4.3.0
+  CLI emitted `.bg-red-500` after a sentinel utility was added to one `.mbt`
+  view; reverting the sentinel removed it from the output (negative control →
+  non-vacuous). `.mbt` is non-binary text, so v4's `@source` heuristic scans it
+  and the regex extractor finds class tokens regardless of MoonBit syntax. No
+  `_build` JS fallback needed. (All spike assets — devDeps, spike CSS, sentinel
+  — were reverted; nothing shipped.)
+- **(b) Can Tailwind utilities reach the shadow root?** Generic — any CSS,
+  including Tailwind-generated, adopts into the shadow via the foundation's
+  `adoptedStyleSheets` path (proven by the new computed-style e2e). Moot for the
+  overlay specifically, which renders in light DOM.
+
+**Conclusion:** A Tailwind v4 migration of the Ideal editor is FEASIBLE. The
+remaining gate is the *payoff vs. ~117-site churn* judgment (Step 3), which is a
+product decision — NOT a technical blocker. The foundation (Steps 1–4) already
+delivered the stated goals (duplication killed, shadow CSS in a real file,
+tokens intact), so the broader migration is an optional enhancement.

--- a/docs/superpowers/specs/2026-06-06-ideal-css-tailwind-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-06-ideal-css-tailwind-foundation-design.md
@@ -1,0 +1,80 @@
+# Ideal editor CSS: de-dup foundation + Tailwind feasibility spike
+
+**Date:** 2026-06-06
+**Status:** Design (validated by Codex, `sound-with-caveats`, corrections folded in)
+**Scope:** `examples/ideal/` only. The other four apps (`demo-react`, `codemirror_demo`, `resizable`, `disclosure`) are untouched.
+
+This is a design document: it states *what* to build and *why*. The step-ordered *how* lives in the separate implementation plan (authored by Codex, per "Opus orchestrates, Codex plans").
+
+## Problem
+
+The Ideal editor maintains the same visual rules twice:
+
+- `examples/ideal/web/styles/editor.css` — light DOM, 1463 lines.
+- A `SHADOW_STYLES` template-literal constant in `examples/ideal/web/src/canopy-editor.ts` (definition at line 248, injected via `<style>.textContent` into a `mode: 'open'` shadow root at lines 42–46).
+
+Renaming or editing a shared rule requires touching both, or shadow-rendered elements silently go unstyled. This duplication is documented (`project_ideal_overlay_css_dual_location`) and was caught by Codex in PR #530.
+
+User goals (confirmed): **kill the duplication**, **improve maintainability**, **design-token consistency**. *Not* team-familiarity/DX.
+
+## The reframe: what actually causes the duplication
+
+The duplication is **not** caused by the absence of a utility framework. It is caused by a CSS scoping asymmetry:
+
+- **Custom properties cross the shadow boundary** via inheritance. That is why `SHADOW_STYLES` writes `var(--canopy-bg, fallback)` without redefining the token — the `:root` token defs already reach into the shadow tree. Design-token consistency (goal 3) is therefore *already* solved at the token-definition level.
+- **Class-based rules do not cross the shadow boundary.** A `.action-overlay { … }` rule in the light-DOM stylesheet cannot style an element inside the shadow root. So the rules are hand-authored a second time inside `SHADOW_STYLES`.
+
+The minimal fix is therefore: **author the shadow rules once, deliver that one stylesheet into the shadow root** via `adoptedStyleSheets`. This needs no framework.
+
+**Consequence for the Tailwind question:** Tailwind would need this *same* delivery path — its generated sheet must also be adopted into each shadow root. So Tailwind does not dissolve the duplication "for free"; the adopted-stylesheet transport is the real fix, reusable with or without Tailwind. Tailwind's *distinctive* value over plain single-source CSS is only (a) utility colocation in the `.mbt` views and (b) token *enforcement* via `@theme` — and that value costs an unproven `.mbt` content-scanner plus a ~117-site `class="…"` rewrite.
+
+This yields a **foundation-first, spike-gated** approach rather than a committed migration.
+
+## Direction (chosen): C — foundation-first, spike-gated
+
+### Step 1 — De-dup foundation (ships the duplication fix immediately)
+
+**Files in scope:** `canopy-editor.ts`, `editor.css`, and one new stylesheet file — **not** `leaf-editor.ts`/`text-nodeview.ts`, which inject CodeMirror 6's own styles via `createInlineCm({ root: this.shadowRoot })`, a different mechanism that carries no `SHADOW_STYLES` constant. The audit notes them but Step 1 does not restructure them.
+
+**1. Audit & classify (empirical — read and diff, do not assume).** Partition every rule in `editor.css` and the single `SHADOW_STYLES` block into three buckets:
+
+- **light-only** — `:root` token defs, `body`, the `canopy-editor` host element, scrollbar preflight, media-query/responsive rules. These are coupled to document-level layout and **stay in `editor.css`**. Moving them into a shadow sheet would be inert or leak.
+- **shadow-only** — classes emitted only inside the shadow tree (`structure-*`, `drop-*`, peer-cursor decorations) that are **not** present in `editor.css`. These are not duplicated; they simply relocate from the string into the new file.
+- **overlap** — the genuine duplication (rules present in both sources). For each overlap rule the audit asks: *does any light-DOM element actually use this class?* If **no**, the light-DOM copy is dead CSS → delete it. If **yes**, it is single-sourced and delivered to both contexts.
+
+**2. Single source for shadow rules.** The shadow-needed set (shadow-only + the shadow side of overlaps) moves into **one new stylesheet file**, which becomes the authoritative source for shadow styling. Token defs remain in `editor.css` and continue to inherit into the shadow.
+
+**3. Delivery via `adoptedStyleSheets`.** Import the new file with Vite `?inline` → construct **one** shared `CSSStyleSheet` → assign it to the shadow root's `adoptedStyleSheets`, deleting the `SHADOW_STYLES` constant. Chosen over the current `<style>.textContent` because a single parsed sheet is shared across all editor instances, and — decisively — it is the exact transport the Tailwind spike reuses. A **feature-detect fallback** to `<style>.textContent` (reusing the same `?inline` string) guarantees no engine loses shadow styling.
+
+**Invariant — relocation, not redesign.** Overlay class names are asserted by exact name in Playwright (`.action-overlay-panel`, `.action-overlay-item[data-active="true"]`, `.name-prompt-container`). All class names and selector semantics are held byte-stable. PR #530 (overlay error fold) and #529 (resizable) behavior is preserved.
+
+### Step 2 — Tailwind v4 feasibility spike (one component, throwaway)
+
+A cheap experiment on the **action overlay only**, reusing Step 1's adopted-sheet transport. It must answer two yes/no questions:
+
+- **Scan:** Can Tailwind v4 extract a class string from `.mbt` source via an `@source` glob over `examples/ideal/**/*.mbt`? (The overlay classes are generated in `view_actions.mbt`, so the scanner premise is real. Fallback: scan the generated JS under `_build/`.)
+- **Deliver:** Can the generated utilities — including the preflight/`@layer base` reset and a `:host` rule — land *inside* the `canopy-editor` shadow root via the adopted sheet and visually render?
+
+**Verification:** Playwright CLI (WSL2 — no browser MCP), asserting *computed style* on the overlay element inside the shadow root, not merely text presence.
+
+**Decision gate (explicit):** the spike passes only if **both** scan and deliver succeed **and** the result visually matches. On pass → evaluate Step 3 scope. On fail → stop; Step 1 has already delivered the duplication fix, so no work is wasted.
+
+### Step 3 — Broad Tailwind migration (deferred, undesigned)
+
+Not designed here. Gated on the spike passing **and** the maintainability/enforcement payoff justifying the ~117-site `class="…"` rewrite. If pursued: **Ideal first, never all five apps at once.** Step 1 deliberately splits along the light-tokens / shadow-shell boundary, which gives the spike a stable path **without** locking in any Tailwind-specific file layout.
+
+## Testing
+
+- Existing Ideal Playwright e2e suite must stay green through Step 1 (relocation should be behavior-neutral).
+- **New computed-style assertion** on a shadow-rendered overlay element. The prior e2e asserted *text*, not *style* — that gap is precisely how the duplication hid. This assertion closes it and guards the de-dup.
+
+## Non-goals / scope fence
+
+- No changes outside `examples/ideal/`.
+- No "while we're here" cleanup of PR #530/#529 CSS — those rules move byte-stable.
+- No restructuring of the `leaf-editor.ts`/`text-nodeview.ts` CM6 injection path.
+- No commitment to Tailwind. Step 1 stands on its own; Tailwind is evaluated, not assumed.
+
+## Validation record
+
+- Codex design review (2026-06-06): verdict `sound-with-caveats`. Core framing (custom-props cross the boundary, class rules do not, `adoptedStyleSheets` is the de-dup transport Tailwind also needs) confirmed correct. Corrections folded in: (1) `SHADOW_STYLES` is `canopy-editor.ts`-only — verified; (2) shadow set is not a clean subset of `editor.css` — `structure-*`/`drop-*`/peer-cursor are shadow-only, so the audit must move the full shadow set, not just overlaps; (3) `adoptedStyleSheets` needs a `<style>` fallback.

--- a/examples/ideal/web/e2e/structural-editing.spec.ts
+++ b/examples/ideal/web/e2e/structural-editing.spec.ts
@@ -256,3 +256,22 @@ test.describe('Structural Editing - Overlay on Var nodes', () => {
     await expect(page.locator('.action-overlay-panel')).not.toBeVisible();
   });
 });
+
+test.describe('Shadow stylesheet delivery', () => {
+  // Guards the de-dup foundation: shadow-root styles are now a single source
+  // (styles/editor-shadow.css) adopted via adoptedStyleSheets, not a duplicated
+  // SHADOW_STYLES string. `.structure-block`'s border exists ONLY in
+  // editor-shadow.css (absent from the light-DOM editor.css), so a non-zero
+  // computed border proves the adopted stylesheet reached the shadow root.
+  // The prior suite asserted text/existence, not computed style — that gap is
+  // how the light/shadow CSS duplication hid.
+  test('adopted shadow CSS styles structure blocks', async ({ page }) => {
+    await setupStructureMode(page);
+    const borderTopWidth = await page.evaluate(() => {
+      const ce = document.querySelector('canopy-editor');
+      const block = ce?.shadowRoot?.querySelector('.structure-block');
+      return block ? getComputedStyle(block).borderTopWidth : null;
+    });
+    expect(borderTopWidth).toBe('1px');
+  });
+});

--- a/examples/ideal/web/e2e/structural-editing.spec.ts
+++ b/examples/ideal/web/e2e/structural-editing.spec.ts
@@ -267,11 +267,15 @@ test.describe('Shadow stylesheet delivery', () => {
   // how the light/shadow CSS duplication hid.
   test('adopted shadow CSS styles structure blocks', async ({ page }) => {
     await setupStructureMode(page);
-    const borderTopWidth = await page.evaluate(() => {
-      const ce = document.querySelector('canopy-editor');
-      const block = ce?.shadowRoot?.querySelector('.structure-block');
-      return block ? getComputedStyle(block).borderTopWidth : null;
+    const result = await page.evaluate(() => {
+      const shadow = document.querySelector('canopy-editor')?.shadowRoot;
+      const block = shadow?.querySelector('.structure-block');
+      return {
+        adoptedStyleSheets: shadow?.adoptedStyleSheets.length ?? null,
+        borderTopWidth: block ? getComputedStyle(block).borderTopWidth : null,
+      };
     });
-    expect(borderTopWidth).toBe('1px');
+    expect(result.adoptedStyleSheets).toBeGreaterThan(0);
+    expect(result.borderTopWidth).toBe('1px');
   });
 });

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -65,9 +65,17 @@ export class CanopyEditor extends HTMLElement {
     this.shadow = this.attachShadow({ mode: 'open' });
 
     const sheet = getShadowSheet();
+    let adopted = false;
     if (sheet && 'adoptedStyleSheets' in this.shadow) {
-      this.shadow.adoptedStyleSheets = [...this.shadow.adoptedStyleSheets, sheet];
-    } else {
+      try {
+        this.shadow.adoptedStyleSheets = [...this.shadow.adoptedStyleSheets, sheet];
+        adopted = true;
+      } catch {
+        // If assignment is present but rejected, keep the editor styled via
+        // the same inline CSS string rather than failing custom-element setup.
+      }
+    }
+    if (!adopted) {
       const style = document.createElement('style');
       style.textContent = shadowStyles;
       this.shadow.appendChild(style);

--- a/examples/ideal/web/src/canopy-editor.ts
+++ b/examples/ideal/web/src/canopy-editor.ts
@@ -1,5 +1,28 @@
 import { CanopyEvents } from "./events";
 import type { CrdtModule } from './types';
+// Single source of truth for shadow-root styles. `?inline` yields the
+// processed CSS as a string (no automatic <style> injection) so we can both
+// adopt it as a constructable stylesheet and fall back to a <style> element.
+import shadowStyles from '../styles/editor-shadow.css?inline';
+
+// One constructable stylesheet shared across every <canopy-editor> instance.
+// Lazily built; null if the engine lacks constructable-stylesheet support, in
+// which case callers fall back to a per-instance <style> element.
+let sharedShadowSheet: CSSStyleSheet | null = null;
+let shadowSheetUnsupported = false;
+function getShadowSheet(): CSSStyleSheet | null {
+  if (shadowSheetUnsupported) return null;
+  if (sharedShadowSheet) return sharedShadowSheet;
+  try {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(shadowStyles);
+    sharedShadowSheet = sheet;
+    return sheet;
+  } catch {
+    shadowSheetUnsupported = true;
+    return null;
+  }
+}
 
 type StructureModeSession = {
   applyRemote(syncJson: string): string;
@@ -41,9 +64,14 @@ export class CanopyEditor extends HTMLElement {
     super();
     this.shadow = this.attachShadow({ mode: 'open' });
 
-    const style = document.createElement('style');
-    style.textContent = SHADOW_STYLES;
-    this.shadow.appendChild(style);
+    const sheet = getShadowSheet();
+    if (sheet && 'adoptedStyleSheets' in this.shadow) {
+      this.shadow.adoptedStyleSheets = [...this.shadow.adoptedStyleSheets, sheet];
+    } else {
+      const style = document.createElement('style');
+      style.textContent = shadowStyles;
+      this.shadow.appendChild(style);
+    }
 
     this.editorContainer = document.createElement('div');
     this.editorContainer.id = 'editor-root';
@@ -242,313 +270,3 @@ export class CanopyEditor extends HTMLElement {
 }
 
 customElements.define('canopy-editor', CanopyEditor);
-
-// ── Shadow DOM Styles ─────────────────────────────────────
-
-const SHADOW_STYLES = `
-  :host {
-    display: block;
-    width: 100%;
-    height: 100%;
-    font-family: var(--canopy-font-mono, 'Iosevka', monospace);
-    background: var(--canopy-bg, #161625);
-    color: var(--canopy-fg, #e4e4f0);
-  }
-  #editor-root {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-  }
-
-  /* ProseMirror base (structure mode) */
-  .ProseMirror {
-    position: relative;
-    word-wrap: break-word;
-    white-space: pre-wrap;
-    font-family: var(--canopy-font-mono, 'Iosevka', monospace);
-    font-size: var(--text-code, 1.125rem);
-    line-height: 1.6;
-    outline: none;
-    min-height: 200px;
-  }
-
-  /* Structure mode blocks */
-  .structure-block {
-    border: 1px solid var(--canopy-border, #28283e);
-    border-radius: 6px;
-    margin: 4px 0;
-    padding: 8px 12px;
-    background: rgba(255, 255, 255, 0.02);
-  }
-  .structure-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
-  .structure-grip {
-    color: var(--canopy-muted, #8888a8);
-    cursor: grab;
-    font-size: 0.6875rem;
-  }
-  .structure-badge {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    padding: 1px 5px;
-    border-radius: 3px;
-    background: rgba(255, 255, 255, 0.04);
-  }
-  .structure-label {
-    font-family: var(--canopy-font-mono, monospace);
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--canopy-fg, #e4e4f0);
-  }
-  .structure-children {
-    margin-left: 20px;
-    margin-top: 6px;
-  }
-  .structure-leaf {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
-  }
-  .structure-value {
-    font-family: var(--canopy-font-mono, monospace);
-    font-size: 13px;
-    color: var(--canopy-fg, #e4e4f0);
-  }
-  .structure-block.drop-before {
-    border-top: 2px solid var(--canopy-accent, #8250df);
-  }
-  .structure-block.drop-after {
-    border-bottom: 2px solid var(--canopy-accent, #8250df);
-  }
-  .structure-block.drop-inside {
-    outline: 2px solid var(--canopy-accent, #8250df);
-    outline-offset: -2px;
-  }
-  .structure-block.dragging {
-    opacity: 0.4;
-  }
-
-  /* Peer cursor decorations (CM6 text mode) */
-  .peer-cursor-widget {
-    position: relative;
-    display: inline;
-    border-left: 2px solid var(--color);
-    margin-left: -1px;
-    pointer-events: none;
-  }
-  .peer-cursor-label {
-    position: absolute;
-    bottom: 100%;
-    left: -1px;
-    background: var(--color);
-    color: #fff;
-    font-size: 10px;
-    font-family: system-ui, sans-serif;
-    padding: 1px 4px;
-    border-radius: 2px 2px 2px 0;
-    white-space: nowrap;
-    pointer-events: none;
-    opacity: 0.9;
-  }
-  .peer-selection {
-    background-color: var(--color);
-    opacity: 0.2;
-  }
-
-  /* Action overlay (which-key / action sheet) */
-  .action-overlay-scrim {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.35);
-    z-index: 100;
-    opacity: 1;
-    transition: opacity 100ms cubic-bezier(0.25, 1, 0.5, 1);
-  }
-  @starting-style {
-    .action-overlay-scrim { opacity: 0; }
-  }
-  .action-overlay-panel {
-    position: fixed;
-    z-index: 101;
-    min-width: 200px;
-    max-width: 320px;
-    background: var(--canopy-panel-bg, #1a1a2c);
-    border: 1px solid var(--canopy-border, #28283e);
-    border-radius: 6px;
-    padding: 4px 0;
-    box-shadow: 0 8px 32px var(--canopy-shadow-heavy, rgba(0, 0, 0, 0.5));
-    font-family: var(--canopy-font-mono, 'Iosevka', monospace);
-    font-size: var(--text-small, 0.875rem);
-    outline: none;
-    opacity: 1;
-    transform: translateY(0);
-    transition: opacity 120ms cubic-bezier(0.25, 1, 0.5, 1),
-                transform 120ms cubic-bezier(0.25, 1, 0.5, 1);
-  }
-  @starting-style {
-    .action-overlay-panel { opacity: 0; transform: translateY(4px); }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .action-overlay-scrim,
-    .action-overlay-panel {
-      transition: none;
-    }
-  }
-  .action-overlay-list {
-    display: flex;
-    flex-direction: column;
-  }
-  .action-overlay-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
-    min-height: 44px;
-    box-sizing: border-box;
-    cursor: pointer;
-    color: var(--canopy-fg, #e4e4f0);
-    transition: background 0.1s;
-    outline: none;
-  }
-  .action-overlay-item:hover,
-  .action-overlay-item:focus-visible,
-  .action-overlay-item[data-active="true"] {
-    background: var(--canopy-accent-hover, rgba(130, 80, 223, 0.12));
-  }
-  .action-overlay-item:focus-visible {
-    outline: 2px solid var(--canopy-focus-ring, #a070ef);
-    outline-offset: -2px;
-  }
-  .action-overlay-item.danger {
-    color: var(--canopy-error-text, #ef4444);
-  }
-  .action-overlay-item.danger:hover,
-  .action-overlay-item.danger:focus-visible,
-  .action-overlay-item.danger[data-active="true"] {
-    background: var(--canopy-error-bg, rgba(207, 34, 46, 0.1));
-  }
-  .action-overlay-item.danger .action-mnemonic {
-    background: var(--canopy-error-bg, rgba(207, 34, 46, 0.1));
-    color: var(--canopy-error-text, #ef4444);
-  }
-  .action-mnemonic {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    height: 20px;
-    padding: 0 4px;
-    border-radius: 3px;
-    background: var(--canopy-scrollbar, rgba(255, 255, 255, 0.08));
-    color: var(--canopy-keyword, #c792ea);
-    font-size: var(--text-label, 0.6875rem);
-    font-weight: var(--weight-semibold, 600);
-  }
-  .action-label-text {
-    color: inherit;
-  }
-  .action-group-label {
-    padding: 4px 12px 2px;
-    font-size: var(--text-label, 0.6875rem);
-    font-weight: var(--weight-semibold, 600);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--canopy-text-dim, #8a8aaa);
-  }
-
-  /* Name prompt */
-  .name-prompt-container {
-    padding: 8px 12px;
-  }
-  .name-prompt-label {
-    font-size: var(--text-label, 0.6875rem);
-    color: var(--canopy-muted, #8888a8);
-    margin-bottom: 4px;
-  }
-  .name-prompt-input-row {
-    display: flex;
-    gap: 8px;
-  }
-  .name-prompt-input {
-    flex: 1;
-    background: var(--canopy-hover-overlay, rgba(255, 255, 255, 0.03));
-    border: 1px solid var(--canopy-border, #28283e);
-    border-radius: 4px;
-    padding: 4px 8px;
-    color: var(--canopy-fg, #e4e4f0);
-    font-family: var(--canopy-font-mono, 'Iosevka', monospace);
-    font-size: var(--text-small, 0.875rem);
-    outline: none;
-  }
-  .name-prompt-input:focus {
-    border-color: var(--canopy-focus-ring, #a070ef);
-  }
-  .action-overlay-error {
-    font-size: var(--text-label, 0.6875rem);
-    color: var(--canopy-error-text, #ef4444);
-    padding: var(--space-sm, 0.5rem) var(--space-lg, 1rem);
-  }
-
-  /* Mobile: bottom sheet instead of positioned popover */
-  @media (max-width: 767px) {
-    .action-overlay-scrim {
-      background: rgba(0, 0, 0, 0.5);
-    }
-    .action-overlay-panel {
-      top: auto !important;
-      left: 0 !important;
-      right: 0;
-      bottom: 0;
-      max-width: none;
-      width: 100%;
-      border-radius: 12px 12px 0 0;
-      padding-top: 12px;
-      padding-bottom: env(safe-area-inset-bottom, 8px);
-      max-height: 60vh;
-      transform: translateY(0);
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
-    }
-    /* Drag handle — visual affordance for bottom sheet */
-    .action-overlay-panel::before {
-      content: '';
-      display: block;
-      width: 32px;
-      height: 4px;
-      border-radius: 2px;
-      background: var(--canopy-scrollbar, rgba(255, 255, 255, 0.08));
-      margin: 0 auto 8px;
-    }
-    .action-overlay-item {
-      padding: 12px 16px;
-      min-height: 48px;
-      gap: 12px;
-    }
-    .action-mnemonic {
-      min-width: 24px;
-      height: 24px;
-      font-size: var(--text-caption, 0.8125rem);
-    }
-    .action-label-text {
-      font-size: var(--text-body, 1rem);
-    }
-    .action-group-label {
-      padding: 8px 16px 4px;
-    }
-    .name-prompt-container {
-      padding: 12px 16px;
-    }
-    .name-prompt-input {
-      padding: 8px 12px;
-      font-size: var(--text-body, 1rem);
-    }
-  }
-`;

--- a/examples/ideal/web/styles/editor-shadow.css
+++ b/examples/ideal/web/styles/editor-shadow.css
@@ -1,0 +1,136 @@
+/*
+ * Shadow-DOM styles for the <canopy-editor> web component.
+ *
+ * Single source of truth for everything that renders INSIDE the editor's
+ * shadow root: the host/container, the ProseMirror structure-mode surface,
+ * and CodeMirror peer-cursor decorations. Delivered via adoptedStyleSheets
+ * (see canopy-editor.ts), with a <style> fallback for engines without
+ * constructable stylesheet support.
+ *
+ * Design tokens (--canopy-*, --space-*, --text-*) are NOT defined here: they
+ * live in editor.css on :root and inherit across the shadow boundary (custom
+ * properties pierce shadow roots). The inline var() fallbacks below are belt-
+ * and-suspenders defaults.
+ *
+ * The action overlay / name prompt render in the LIGHT DOM (the Rabbita view
+ * tree, not the shadow root) and are styled by editor.css — deliberately NOT
+ * duplicated here. Verified at runtime 2026-06-06.
+ */
+
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+  font-family: var(--canopy-font-mono, 'Iosevka', monospace);
+  background: var(--canopy-bg, #161625);
+  color: var(--canopy-fg, #e4e4f0);
+}
+
+#editor-root {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ProseMirror base (structure mode) */
+.ProseMirror {
+  position: relative;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  font-family: var(--canopy-font-mono, 'Iosevka', monospace);
+  font-size: var(--text-code, 1.125rem);
+  line-height: 1.6;
+  outline: none;
+  min-height: 200px;
+}
+
+/* Structure mode blocks */
+.structure-block {
+  border: 1px solid var(--canopy-border, #28283e);
+  border-radius: 6px;
+  margin: 4px 0;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+.structure-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.structure-grip {
+  color: var(--canopy-muted, #8888a8);
+  cursor: grab;
+  font-size: 0.6875rem;
+}
+.structure-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.04);
+}
+.structure-label {
+  font-family: var(--canopy-font-mono, monospace);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--canopy-fg, #e4e4f0);
+}
+.structure-children {
+  margin-left: 20px;
+  margin-top: 6px;
+}
+.structure-leaf {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+.structure-value {
+  font-family: var(--canopy-font-mono, monospace);
+  font-size: 13px;
+  color: var(--canopy-fg, #e4e4f0);
+}
+.structure-block.drop-before {
+  border-top: 2px solid var(--canopy-accent, #8250df);
+}
+.structure-block.drop-after {
+  border-bottom: 2px solid var(--canopy-accent, #8250df);
+}
+.structure-block.drop-inside {
+  outline: 2px solid var(--canopy-accent, #8250df);
+  outline-offset: -2px;
+}
+.structure-block.dragging {
+  opacity: 0.4;
+}
+
+/* Peer cursor decorations (CM6 text mode) */
+.peer-cursor-widget {
+  position: relative;
+  display: inline;
+  border-left: 2px solid var(--color);
+  margin-left: -1px;
+  pointer-events: none;
+}
+.peer-cursor-label {
+  position: absolute;
+  bottom: 100%;
+  left: -1px;
+  background: var(--color);
+  color: #fff;
+  font-size: 10px;
+  font-family: system-ui, sans-serif;
+  padding: 1px 4px;
+  border-radius: 2px 2px 2px 0;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0.9;
+}
+.peer-selection {
+  background-color: var(--color);
+  opacity: 0.2;
+}


### PR DESCRIPTION
## What

Kills the light/shadow CSS duplication in the Ideal editor and proves out a Tailwind v4 path without committing to it.

- **`examples/ideal/web/styles/editor-shadow.css`** (new) is the single source for genuinely shadow-rendered rules (`:host`, `#editor-root`, `.ProseMirror`, `.structure-*`, `.drop-*`, `.peer-cursor-*`, `.peer-selection`).
- `canopy-editor.ts` imports that stylesheet with `?inline`, constructs one shared `CSSStyleSheet`, and adopts it into each shadow root. The same CSS string is used for the `<style>` fallback, including if `adoptedStyleSheets` assignment is present but rejected at runtime.
- The duplicated **`SHADOW_STYLES`** template-literal constant in `canopy-editor.ts` is deleted.
- **`editor.css` is untouched.**
- Docs record the implementation plan, runtime correction, and Tailwind feasibility spike result.

## Why this shape (runtime-proven correction)

The pre-work assumption was that the action overlay renders in the shadow root. A Playwright probe disproved it: the overlay + name prompt render in the **light DOM** (the Rabbita view renders `<canopy-editor>` with empty children; the overlay is a light-DOM sibling) — `{"inLight":true,"inShadow":false}`.

So the overlay's live styles were always in `editor.css`; the copy in `SHADOW_STYLES` was **dead**. De-dup = delete the dead shadow copy, leave `editor.css` alone. Custom properties (`--canopy-*`) already cross the shadow boundary via inheritance, so design tokens needed no change.

## Tailwind feasibility (spike — informational, nothing Tailwind shipped here)

A throwaway spike (reverted) confirmed Tailwind v4 `@source "../main"` scans `.mbt` source: a sentinel utility added to one `.mbt` view appeared in the generated CSS; reverting it removed the class (negative control). A full migration is feasible; the open question is payoff vs. the ~117-site `class="…"` rewrite — deferred as a product decision. See `docs/plans/2026-06-06-ideal-css-dedup-foundation-plan.md`.

## Testing

Automated:

- `moon check`
- `moon test`
- `NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info`
  - checked generated `.mbti` churn afterward; newline-only changes were reverted.
- `cd examples/ideal/web && npm run build`
- `cd examples/ideal/web && npx playwright test e2e/structural-editing.spec.ts --reporter=line` — 14/14 pass.

Manual Playwright CLI smoke:

- `canopy-editor.shadowRoot.adoptedStyleSheets.length === 1`
- shadow `.structure-block` computed `borderTopWidth === "1px"`
- `.action-overlay-panel` is light DOM: `{"inLight":true,"inShadow":false,"rootKind":"document(light)"}`

## Reuse check

- Reused the existing Web platform `adoptedStyleSheets` API for shadow delivery rather than inventing a delivery layer; it is also the transport any future Tailwind sheet would use.
- Reused the existing `structural-editing.spec.ts` shadow-piercing pattern for the new computed-style assertion.
- No new MoonBit API introduced. `leaf-editor.ts`/`text-nodeview.ts` CM6 injection (`createInlineCm({ root })`) is a separate mechanism and is intentionally left as-is.

## Scope

Code changes are fenced to `examples/ideal/web/`; docs were added under `docs/`. The other example apps are untouched. PR #530/#529 class names and behavior are preserved byte-for-byte (relocation, not redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
