### PR TITLE
feat(ideal): migrate action overlay to Tailwind v4

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -188,10 +188,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 9. Ideal Editor
 
-- [ ] Evaluate Tailwind v4 migration for Ideal after CSS de-dup foundation.
-  Why: PR #532 proved Tailwind v4 can scan `.mbt` class strings and that shadow CSS delivery is solved, but a migration still implies broad class-site churn.
-  Plan: GitHub issue #533
-  Exit: either record a no-migration decision with rationale, or add a concrete narrow-slice migration plan with validation and rollback criteria.
+- [ ] Migrate Ideal to Tailwind v4 incrementally.
+  Why: PR #532 proved Tailwind v4 can scan `.mbt` class strings and that shadow CSS delivery is solved; product decision is to adopt Tailwind for design-system maintainability while avoiding broad all-at-once churn.
+  Plan: docs/plans/2026-06-06-ideal-tailwind-v4-migration.md; GitHub issue #533
+  Exit: first narrow slice ships with Tailwind v4 wired for Ideal only, action overlay/name prompt migrated, validation green, and rollback criteria documented.
 
 - [ ] Structure mode — test and polish PM block editor, verify lazy-loading works.
   Note: completion state is unclear; decision pending in `docs/decisions-needed.md`.

--- a/docs/plans/2026-06-06-ideal-tailwind-v4-migration.md
+++ b/docs/plans/2026-06-06-ideal-tailwind-v4-migration.md
@@ -1,0 +1,248 @@
+# Ideal Tailwind v4 Migration
+
+## Why
+
+Ideal should migrate to Tailwind v4 as a deliberate design-system move, not as a
+shadow-CSS de-dup fix. PR #532 already solved shadow stylesheet duplication via
+`editor-shadow.css` + `adoptedStyleSheets`; the Tailwind value is now:
+
+- stronger design-token enforcement through a Tailwind theme layer,
+- easier maintenance by colocating low-level visual choices with the MoonBit
+  views that render them,
+- a shared vocabulary for future Ideal UI work.
+
+GitHub issue: <https://github.com/dowdiness/canopy/issues/533>
+
+## Scope
+
+In:
+- `examples/ideal/web/package.json`
+- `examples/ideal/web/package-lock.json`
+- `examples/ideal/web/vite.config.ts`
+- `examples/ideal/web/index.html` or `examples/ideal/web/styles/editor.css`
+  depending on the documented Tailwind v4/Vite entrypoint
+- `examples/ideal/web/styles/editor.css`
+- `examples/ideal/web/e2e/structural-editing.spec.ts`
+- `examples/ideal/main/view_actions.mbt` for the first migration slice
+
+Out:
+- non-Ideal example apps
+- `leaf-editor.ts`, `text-nodeview.ts`, and `cm-inline.ts`
+- PR #531 status/live-region behavior
+- PR #530 overlay error behavior beyond preserving it
+- PR #532 shadow stylesheet transport beyond reusing it if a later shadow slice
+  needs generated CSS
+- unrelated `loom` submodule dirt
+
+## Current State
+
+- `examples/ideal/web/styles/editor.css` is the live light-DOM stylesheet.
+- `examples/ideal/web/styles/editor-shadow.css` is the live shadow stylesheet and
+  is adopted into `<canopy-editor>` shadow roots.
+- The action overlay and name prompt are light DOM, not shadow DOM.
+- `examples/ideal/web` has no Tailwind dependency today.
+- The archived PR #532 spike proved Tailwind v4.3.0 can scan `.mbt` source with
+  `@source "../main"`; no `_build` JS fallback was needed.
+- There are roughly 150 `class=` surfaces in `examples/ideal/main/**/*.mbt`, so
+  a broad all-at-once utility rewrite is unnecessary risk.
+
+## Desired State
+
+Tailwind v4 is adopted for Ideal only, with a narrow first slice that proves the
+pipeline and the maintainability model without destabilizing the editor.
+
+Observable end state for the first PR:
+
+- Tailwind v4 runs in the Ideal web Vite build.
+- Tailwind scans `examples/ideal/main/**/*.mbt` intentionally, not accidentally.
+- Core Canopy design tokens are represented in Tailwind's theme layer while
+  preserving the existing CSS custom properties used by shadow CSS and runtime
+  integrations.
+- The action overlay/name-prompt slice is Tailwind-owned.
+- Existing semantic class names remain as stable selectors/test hooks
+  (`.action-overlay-panel`, `.action-overlay-item`, `.name-prompt-input`, etc.).
+- Legacy CSS for the migrated overlay/name-prompt properties is removed or
+  reduced to compatibility-only rules; there must not be two live sources of
+  truth for the same migrated declarations.
+
+## Design Choices
+
+### 1. Tailwind as a design-system layer, not an instant rewrite
+
+The first slice should keep semantic classes as compatibility anchors and add
+Tailwind utilities around them. Example shape:
+
+```moonbit
+class="action-overlay-scrim fixed inset-0 z-[50] bg-black/30"
+```
+
+This preserves E2E selectors while allowing migrated visual declarations to live
+with the view code. Later slices can decide case-by-case whether a semantic
+component class remains useful or is only a test hook.
+
+### 2. Token bridge first
+
+Do not duplicate raw color/spacing literals in two systems. Start with the
+existing `:root` custom properties as the compatibility source of truth and map
+Tailwind theme variables to them. Before implementation, confirm the exact
+Tailwind v4 syntax from Context7/current docs, especially whether aliases to CSS
+variables require `@theme inline`.
+
+Candidate token families to expose first:
+
+- colors: `canopy-bg`, `canopy-panel`, `canopy-surface`, `canopy-border`,
+  `canopy-fg`, `canopy-muted`, `canopy-accent`, `canopy-error-text`
+- fonts: `canopy-ui`, `canopy-mono`
+- spacing: `canopy-xs`, `canopy-sm`, `canopy-md`, `canopy-lg`, `canopy-xl`
+- radii: `canopy-sm`, `canopy-md`, `canopy-lg`
+- motion: `duration-canopy-fast`, `ease-canopy-out`
+
+### 3. Avoid broad preflight risk in the first slice
+
+The Ideal stylesheet already has a reset and component-level base rules. The
+first implementation must use the current Tailwind v4 docs to decide whether to
+import full Tailwind or only the theme/utilities layers. Prefer avoiding
+Tailwind preflight in the first slice unless browser verification shows no
+regression.
+
+### 4. One migrated owner per declaration
+
+For every overlay/name-prompt declaration moved to Tailwind utilities, delete the
+same declaration from the legacy overlay block. If a declaration must remain in
+CSS because it is too awkward as a utility (for example a custom keyframe), move
+it into the Tailwind entry as a named utility/component and document why.
+
+## Steps
+
+1. **Doc gate before dependencies**
+   - Use Context7/current Tailwind docs for:
+     - Tailwind v4 + Vite setup,
+     - `@source` behavior for non-standard source files,
+     - CSS-first theme configuration (`@theme` / `@theme inline`),
+     - layer-specific imports if avoiding preflight.
+   - Record the exact docs/version in the PR description.
+
+2. **Install Tailwind for Ideal web only**
+   - Add Tailwind v4 dev dependencies under `examples/ideal/web` only.
+   - Update `examples/ideal/web/package-lock.json` from that directory.
+   - Wire the Vite plugin in `examples/ideal/web/vite.config.ts` per docs.
+   - Do not touch workspace-level package metadata.
+
+3. **Create the Tailwind entry + token bridge**
+   - Keep the existing `/styles/editor.css` light-DOM delivery path unless docs
+     require a different Vite-processed entry.
+   - Add Tailwind imports and explicit `@source` entries for each migrated
+     source file from `examples/ideal/web/styles/editor.css`; the first slice
+     starts with `../../main/view_actions_classes.mbt` only.
+   - Add the first theme-token bridge to existing `--canopy-*` variables.
+   - Add a temporary sentinel utility during local validation only; remove it
+     before commit.
+
+4. **Migrate the action overlay/name prompt slice**
+   - Update `examples/ideal/main/view_actions.mbt` class strings to include
+     Tailwind utilities while preserving semantic classes.
+   - Cover:
+     - scrim
+     - panel sizing/position/surface/border/shadow/animation
+     - list layout
+     - group labels
+     - items including hover/active/danger states
+     - mnemonic badge
+     - label text
+     - name prompt layout/input/focus/placeholder
+     - overlay error
+     - mobile adjustments currently under `@media (max-width: 768px)`
+   - Remove migrated declarations from `editor.css` so the overlay has one live
+     owner.
+
+5. **Add style ownership assertions**
+   - Extend `examples/ideal/web/e2e/structural-editing.spec.ts` with computed
+     style checks for the light-DOM overlay, e.g. background, border color,
+     min-width, z-index, and input focus ring.
+   - Keep existing behavioral overlay tests unchanged.
+
+6. **Build and browser-verify**
+   - Run the validation commands below.
+   - Use Playwright CLI for a manual smoke pass if automated style assertions are
+     inconclusive.
+   - Compare built CSS size before/after; investigate if the first slice grows
+     the built CSS by more than about 10 KiB uncompressed.
+
+7. **Prepare later slices only after the first PR is green**
+   - Toolbar/app shell.
+   - Outline panel and tree rows.
+   - Inspector panel.
+   - Bottom tabs/log panels.
+   - History/Incr graph raw-HTML fragments.
+   - Shadow-owned structure styles only if the first light-DOM migration proves
+     stable and the adopted stylesheet path remains unchanged.
+
+## Acceptance Criteria
+
+- [ ] Tailwind v4 is installed only in `examples/ideal/web`.
+- [ ] The Ideal Vite build generates Tailwind utilities from `.mbt` source.
+- [ ] Tailwind theme tokens bridge to the existing Canopy CSS custom properties.
+- [ ] The action overlay/name-prompt visual declarations are Tailwind-owned.
+- [ ] Existing semantic class selectors used by tests remain valid.
+- [ ] `editor.css` no longer contains duplicate live declarations for the
+      migrated overlay/name-prompt properties.
+- [ ] `leaf-editor.ts`, `text-nodeview.ts`, `cm-inline.ts`, and `loom` are
+      untouched.
+- [ ] Issue #533 can be updated to say migration is approved and first slice is
+      planned/implemented.
+
+## Validation
+
+```bash
+git status --short
+moon check
+moon test
+cd examples/ideal/web && npm run build
+cd examples/ideal/web && npx playwright test e2e/structural-editing.spec.ts --reporter=line
+```
+
+For the PR body, also include:
+
+```bash
+cd examples/ideal/web && wc -c dist/assets/*.css
+rg -n "tailwind|@tailwindcss/vite|@source|@theme" examples/ideal/web
+rg -n "action-overlay|name-prompt" examples/ideal/web/styles/editor.css examples/ideal/main/view_actions.mbt
+```
+
+## Rollback Criteria
+
+Rollback the first Tailwind slice completely if any of these hold:
+
+- Tailwind cannot be made to scan `.mbt` source through documented v4 APIs.
+- The Vite integration requires changing non-Ideal build infrastructure.
+- Overlay behavior or accessibility regresses in Playwright.
+- Computed overlay styles differ materially from the pre-migration baseline and
+  the difference is not an intentional design-system normalization.
+- The first slice causes disproportionate CSS growth (> about 10 KiB
+  uncompressed) without a clear explanation.
+- Preserving semantic selectors plus utility classes proves less maintainable
+  than the existing CSS for this slice.
+
+Rollback means removing Tailwind dependencies, Vite wiring, Tailwind CSS entry
+changes, and `.mbt` utility-class edits, returning to the PR #532 foundation.
+
+## Risks
+
+- Tailwind preflight could subtly alter existing form/button/layout defaults;
+  avoid or explicitly verify it in the first slice.
+- Long utility strings in MoonBit views can become hard to read. Prefer small
+  local string constants for repeated utility groups if the slice becomes noisy.
+- Tailwind utilities and legacy semantic CSS can fight in the cascade. Delete or
+  isolate migrated legacy declarations immediately.
+- Dynamic class fragments such as `depth-{depth}` and `kind-{...}` will need
+  safelisting or a semantic-class bridge in later slices; do not tackle them in
+  the first PR.
+- Raw HTML fragments in history/incr/bottom views require a separate audit
+  because class strings are embedded inside HTML strings.
+
+## Notes
+
+- This plan supersedes the earlier no-migration rationale: the product decision
+  is now to migrate, but incrementally.
+- PR #532 remains the baseline. Tailwind must build on the de-dup foundation, not
+  reopen shadow stylesheet duplication.

--- a/docs/superpowers/specs/2026-06-06-ideal-css-tailwind-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-06-ideal-css-tailwind-foundation-design.md
@@ -1,7 +1,7 @@
 # Ideal editor CSS: de-dup foundation + Tailwind feasibility spike
 
 **Date:** 2026-06-06
-**Status:** Foundation shipped in PR #532; Tailwind migration deferred pending product/payoff decision
+**Status:** Foundation shipped in PR #532; Tailwind migration approved for incremental execution (see `docs/plans/2026-06-06-ideal-tailwind-v4-migration.md`)
 **Scope:** `examples/ideal/` only. The other four apps (`demo-react`, `codemirror_demo`, `resizable`, `disclosure`) are untouched.
 
 This is a design document: it states *what* to build and *why*. The step-ordered *how* lives in the archived implementation plan (`docs/archive/2026-06-06-ideal-css-dedup-foundation-plan.md`).
@@ -34,7 +34,7 @@ This yields a **foundation-first, spike-gated** approach rather than a committed
 
 Runtime verification corrected one important assumption in the original spike shape: the action overlay and name prompt render in the **light DOM**, not inside `<canopy-editor>`'s shadow root. Their live rules are therefore the existing `editor.css` rules. The duplicate overlay block inside `SHADOW_STYLES` was dead shadow CSS and was deleted with the rest of the template literal; no light-DOM CSS was removed.
 
-The shipped foundation still follows the design's core direction: `editor-shadow.css` is now the single source for shadow-owned rules, delivered via a shared constructable stylesheet with `<style>` fallback. The Tailwind spike also passed the remaining technical question: Tailwind v4 can scan `.mbt` class strings via `@source "../main"`. A broader Tailwind migration is feasible but deferred as a product/payoff decision.
+The shipped foundation still follows the design's core direction: `editor-shadow.css` is now the single source for shadow-owned rules, delivered via a shared constructable stylesheet with `<style>` fallback. The Tailwind spike also passed the remaining technical question: Tailwind v4 can scan `.mbt` class strings via `@source "../main"`. The product decision is now to migrate incrementally for design-system maintainability; the first execution slice is tracked in `docs/plans/2026-06-06-ideal-tailwind-v4-migration.md`.
 
 ## Direction (chosen): C — foundation-first, spike-gated
 
@@ -63,9 +63,9 @@ The original cheap experiment targeted the **action overlay** because its classe
 
 **Decision gate (explicit):** a full Tailwind migration should proceed only if the maintainability/token-enforcement payoff justifies the large `class="…"` rewrite. The foundation already delivered the duplication fix, so migration remains optional.
 
-### Step 3 — Broad Tailwind migration (deferred, undesigned)
+### Step 3 — Tailwind migration (approved as incremental follow-up)
 
-Not designed here. Gated on the spike passing **and** the maintainability/enforcement payoff justifying the ~117-site `class="…"` rewrite. If pursued: **Ideal first, never all five apps at once.** Step 1 deliberately splits along the light-tokens / shadow-shell boundary, which gives the spike a stable path **without** locking in any Tailwind-specific file layout.
+The broad migration is not part of PR #532, but is now approved as an incremental Ideal-only follow-up. The first slice deliberately starts with the light-DOM action overlay/name prompt and preserves semantic class selectors while Tailwind takes ownership of migrated declarations. See `docs/plans/2026-06-06-ideal-tailwind-v4-migration.md` for validation and rollback criteria.
 
 ## Testing
 

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -19,16 +19,16 @@ fn view_action_item(
 ) -> @rabbita.Html {
   let is_danger = action.id == "delete" || action.id == "binding_delete"
   let item_class = if is_danger {
-    "action-overlay-item danger"
+    action_overlay_item_danger_class
   } else {
-    "action-overlay-item"
+    action_overlay_item_class
   }
   @html.div(
     class=item_class,
     attrs=menu.item_attrs(index, msg => dispatch(ActionMenu(msg))),
     [
-      @html.span(class="action-mnemonic", [@html.text(action.mnemonic)]),
-      @html.span(class="action-label-text", [@html.text(action.label)]),
+      @html.span(class=action_mnemonic_class, [@html.text(action.mnemonic)]),
+      @html.span(class=action_label_text_class, [@html.text(action.label)]),
     ],
   )
 }
@@ -53,7 +53,7 @@ fn view_action_list(
       if action.group != Core {
         items.push(
           @html.div(
-            class="action-group-label",
+            class=action_group_label_class,
             attrs=@html.Attrs::build().role("separator"),
             [@html.text(group_label(action.group))],
           ),
@@ -62,7 +62,7 @@ fn view_action_list(
     }
     items.push(view_action_item(dispatch, menu, index, action))
   }
-  @html.div(class="action-overlay-list", items)
+  @html.div(class=action_overlay_list_class, items)
 }
 
 ///|
@@ -96,19 +96,23 @@ fn view_name_prompt(
       @rabbita.none
     }
   }
-  @html.div(class="name-prompt-container", [
-    @html.div(class="name-prompt-label", [@html.text(prompt_label)]),
-    @html.div(class="name-prompt-input-row", on_keydown=on_keydown_handler, [
-      @html.input(
-        input_type=@html.InputType::Text,
-        class="name-prompt-input",
-        placeholder="name\u{2026}",
-        value=name_value,
-        autofocus=true,
-        on_input=fn(value) { dispatch(NamePromptInput(value)) },
-        attrs=@html.Attrs::build().aria_label(prompt_label),
-      ),
-    ]),
+  @html.div(class=name_prompt_container_class, [
+    @html.div(class=name_prompt_label_class, [@html.text(prompt_label)]),
+    @html.div(
+      class=name_prompt_input_row_class,
+      on_keydown=on_keydown_handler,
+      [
+        @html.input(
+          input_type=@html.InputType::Text,
+          class=name_prompt_input_class,
+          placeholder="name\u{2026}",
+          value=name_value,
+          autofocus=true,
+          on_input=fn(value) { dispatch(NamePromptInput(value)) },
+          attrs=@html.Attrs::build().aria_label(prompt_label),
+        ),
+      ],
+    ),
   ])
 }
 
@@ -124,7 +128,7 @@ fn view_submenu_choices(
   let items : Array[@rabbita.Html] = []
   items.push(
     @html.div(
-      class="action-group-label",
+      class=action_group_label_class,
       attrs=@html.Attrs::build().role("separator"),
       [@html.text(action.label)],
     ),
@@ -133,16 +137,18 @@ fn view_submenu_choices(
     let (label, _) = choice
     items.push(
       @html.div(
-        class="action-overlay-item",
+        class=action_overlay_item_class,
         attrs=menu.item_attrs(i, msg => dispatch(ActionMenu(msg))),
         [
-          @html.span(class="action-mnemonic", [@html.text((i + 1).to_string())]),
-          @html.span(class="action-label-text", [@html.text(label)]),
+          @html.span(class=action_mnemonic_class, [
+            @html.text((i + 1).to_string()),
+          ]),
+          @html.span(class=action_label_text_class, [@html.text(label)]),
         ],
       ),
     )
   }
-  @html.div(class="action-overlay-list", items)
+  @html.div(class=action_overlay_list_class, items)
 }
 
 ///|
@@ -153,7 +159,7 @@ fn view_action_overlay_error(message : String) -> @rabbita.Html {
     @html.nothing
   } else {
     @html.div(
-      class="action-overlay-error",
+      class=action_overlay_error_class,
       attrs=@html.Attrs::build().role("alert").aria_live("polite"),
       [@html.text(message)],
     )
@@ -195,13 +201,13 @@ fn view_action_overlay(
   @html.fragment([
     // Scrim: click-catching backdrop
     @html.div(
-      class="action-overlay-scrim",
+      class=action_overlay_scrim_class,
       attrs=@menu.scrim_attrs(dispatch(CloseActionOverlay)),
       @html.nothing,
     ),
     // Overlay panel — roving focus moves to the active menu item after render.
     @html.div(
-      class="action-overlay-panel",
+      class=action_overlay_panel_class,
       attrs=model.overlay.menu
         .panel_attrs(msg => dispatch(ActionMenu(msg)))
         .aria_label("Structural editing actions")

--- a/examples/ideal/main/view_actions_classes.mbt
+++ b/examples/ideal/main/view_actions_classes.mbt
@@ -1,0 +1,55 @@
+///|
+// Tailwind utility bundles for the light-DOM action overlay/name prompt.
+// Keep each semantic selector as the first class token: Playwright tests and
+// integration code use those names as stable hooks while Tailwind owns the
+// visual declarations for this migration slice.
+let action_overlay_scrim_class = "action-overlay-scrim fixed inset-0 z-[50] bg-[rgba(0,0,0,0.3)]"
+
+///|
+let action_overlay_panel_class = "action-overlay-panel fixed z-[51] min-w-[200px] max-w-[280px] max-h-[360px] overflow-y-auto bg-canopy-panel border border-solid border-canopy-accent rounded-canopy-lg py-canopy-xs shadow-[0_8px_32px_rgba(0,0,0,0.4),0_0_0_1px_rgba(130,80,223,0.15)] animate-canopy-overlay-enter max-[768px]:min-w-[240px] max-[768px]:max-w-[min(320px,90vw)]"
+
+///|
+let action_overlay_list_class = "action-overlay-list flex flex-col"
+
+///|
+let action_group_label_class = "action-group-label text-canopy-label font-semibold text-canopy-dim tracking-[0.1em] uppercase pt-canopy-sm px-canopy-lg pb-canopy-xs border-t border-solid border-canopy-border mt-canopy-xs"
+
+///|
+let action_overlay_item_base_class = "action-overlay-item flex items-center gap-canopy-sm py-canopy-sm px-canopy-lg cursor-pointer text-canopy-small text-canopy-fg transition-colors duration-(--duration-fast) ease-canopy-out max-[768px]:min-h-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-lg"
+
+///|
+let action_overlay_item_normal_state_class = "hover:bg-[rgba(130,80,223,0.15)] data-[active=true]:bg-[rgba(130,80,223,0.15)]"
+
+///|
+let action_overlay_item_danger_state_class = "danger text-canopy-error-text hover:bg-canopy-error-bg data-[active=true]:bg-canopy-error-bg"
+
+///|
+let action_overlay_item_class : String = action_overlay_item_base_class +
+  " " +
+  action_overlay_item_normal_state_class
+
+///|
+let action_overlay_item_danger_class : String = action_overlay_item_base_class +
+  " " +
+  action_overlay_item_danger_state_class
+
+///|
+let action_mnemonic_class = "action-mnemonic inline-flex items-center justify-center w-[22px] h-[22px] font-canopy-mono text-canopy-label font-semibold text-canopy-accent bg-[rgba(130,80,223,0.2)] rounded-canopy-sm shrink-0 uppercase"
+
+///|
+let action_label_text_class = "action-label-text font-canopy-ui text-canopy-small whitespace-nowrap"
+
+///|
+let name_prompt_container_class = "name-prompt-container py-canopy-md px-canopy-lg flex flex-col gap-canopy-sm"
+
+///|
+let name_prompt_label_class = "name-prompt-label text-canopy-small font-medium text-canopy-secondary"
+
+///|
+let name_prompt_input_row_class = "name-prompt-input-row flex"
+
+///|
+let name_prompt_input_class = "name-prompt-input flex-1 font-canopy-mono text-canopy-small py-canopy-sm px-canopy-md bg-canopy-surface border border-solid border-canopy-border rounded-canopy-md text-canopy-fg outline-none transition-colors duration-(--duration-fast) ease-canopy-out focus:border-canopy-accent focus:shadow-[0_0_0_2px_rgba(130,80,223,0.2)] placeholder:text-canopy-dim max-[768px]:min-h-[44px] max-[768px]:text-canopy-body"
+
+///|
+let action_overlay_error_class = "action-overlay-error text-canopy-label text-canopy-error-text py-canopy-sm px-canopy-lg"

--- a/examples/ideal/web/e2e/structural-editing.spec.ts
+++ b/examples/ideal/web/e2e/structural-editing.spec.ts
@@ -141,6 +141,54 @@ test.describe('Structural Editing - Overlay on Var nodes', () => {
     ).toBeVisible();
   });
 
+  test('Tailwind-owned overlay styles are applied', async ({ page }) => {
+    await openVarActionOverlay(page);
+
+    const overlayStyles = await page.evaluate(() => {
+      const panel = document.querySelector('.action-overlay-panel');
+      const scrim = document.querySelector('.action-overlay-scrim');
+      const activeItem = document.querySelector('.action-overlay-item[data-active="true"]');
+      if (!panel || !scrim || !activeItem) return null;
+      const panelStyle = getComputedStyle(panel);
+      const scrimStyle = getComputedStyle(scrim);
+      const activeStyle = getComputedStyle(activeItem);
+      return {
+        panelBackground: panelStyle.backgroundColor,
+        panelBorder: panelStyle.borderTopColor,
+        panelMinWidth: panelStyle.minWidth,
+        panelZIndex: panelStyle.zIndex,
+        scrimBackground: scrimStyle.backgroundColor,
+        activeBackground: activeStyle.backgroundColor,
+      };
+    });
+
+    expect(overlayStyles).not.toBeNull();
+    expect(overlayStyles?.panelBackground).toBe('rgb(26, 26, 44)');
+    expect(overlayStyles?.panelBorder).toBe('rgb(130, 80, 223)');
+    expect(overlayStyles?.panelMinWidth).toBe('200px');
+    expect(overlayStyles?.panelZIndex).toBe('51');
+    expect(overlayStyles?.scrimBackground).toBe('rgba(0, 0, 0, 0.3)');
+    expect(overlayStyles?.activeBackground).toBe('rgba(130, 80, 223, 0.15)');
+
+    await focusActionByLabel(page, 'Rename');
+    await page.keyboard.press('Enter');
+    const input = page.locator('.name-prompt-input');
+    await expect(input).toBeVisible({ timeout: 5000 });
+    await input.focus();
+    const inputStyles = await input.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return {
+        background: style.backgroundColor,
+        border: style.borderTopColor,
+        boxShadow: style.boxShadow,
+      };
+    });
+    expect(inputStyles.background).toBe('rgb(34, 34, 56)');
+    expect(inputStyles.border).not.toBe('rgb(40, 40, 62)');
+    expect(inputStyles.boxShadow).not.toBe('none');
+    expect(inputStyles.boxShadow).toContain('0px 0px 0px 2px');
+  });
+
   test('Arrow keys, Home, and End move active menu item', async ({ page }) => {
     await openVarActionOverlay(page);
     const items = page.locator('.action-overlay-item');

--- a/examples/ideal/web/package-lock.json
+++ b/examples/ideal/web/package-lock.json
@@ -24,8 +24,10 @@
       "devDependencies": {
         "@lezer/generator": "^1.8.0",
         "@playwright/test": "^1.58.2",
+        "@tailwindcss/vite": "^4.3.0",
         "@types/better-sqlite3": "^7.6.0",
         "@types/ws": "^8.5.0",
+        "tailwindcss": "^4.3.0",
         "tsx": "^4.7.0",
         "typescript": "^5.4.0",
         "vite": "^5.4.0"
@@ -523,6 +525,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@lezer/common": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
@@ -933,6 +985,356 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -1093,8 +1495,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1107,6 +1509,20 @@
       "optional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
+      "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/esbuild": {
@@ -1207,6 +1623,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1241,6 +1664,299 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -1730,6 +2446,27 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tar-fs": {
       "version": "2.1.4",

--- a/examples/ideal/web/package.json
+++ b/examples/ideal/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "canopy-ideal-editor",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -30,11 +31,13 @@
   "devDependencies": {
     "@lezer/generator": "^1.8.0",
     "@playwright/test": "^1.58.2",
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/better-sqlite3": "^7.6.0",
     "@types/ws": "^8.5.0",
+    "tailwindcss": "^4.3.0",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0",
-    "vite": "^5.4.0",
-    "@types/better-sqlite3": "^7.6.0"
+    "vite": "^5.4.0"
   },
   "optionalDependencies": {
     "better-sqlite3": "^11.0.0"

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -1,4 +1,47 @@
+@layer theme, base, components, utilities;
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities) source(none);
+/* Keep source detection as narrow as the migrated slice; expand per slice. */
+@source "../../main/view_actions_classes.mbt";
+
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
+
+@theme inline {
+  --color-canopy-bg: var(--canopy-bg);
+  --color-canopy-header: var(--canopy-header-bg);
+  --color-canopy-panel: var(--canopy-panel-bg);
+  --color-canopy-surface: var(--canopy-surface);
+  --color-canopy-border: var(--canopy-border);
+  --color-canopy-fg: var(--canopy-fg);
+  --color-canopy-fg-inverse: var(--canopy-fg-inverse);
+  --color-canopy-secondary: var(--canopy-text-secondary);
+  --color-canopy-muted: var(--canopy-muted);
+  --color-canopy-dim: var(--canopy-text-dim);
+  --color-canopy-accent: var(--canopy-accent);
+  --color-canopy-error-text: var(--canopy-error-text);
+  --color-canopy-error-bg: var(--canopy-error-bg);
+
+  --font-canopy-ui: var(--canopy-font-ui);
+  --font-canopy-mono: var(--canopy-font-mono);
+
+  --text-canopy-label: var(--text-label);
+  --text-canopy-caption: var(--text-caption);
+  --text-canopy-small: var(--text-small);
+  --text-canopy-body: var(--text-body);
+
+  --spacing-canopy-xs: var(--space-xs);
+  --spacing-canopy-sm: var(--space-sm);
+  --spacing-canopy-md: var(--space-md);
+  --spacing-canopy-lg: var(--space-lg);
+  --spacing-canopy-xl: var(--space-xl);
+
+  --radius-canopy-sm: var(--radius-sm);
+  --radius-canopy-md: var(--radius-md);
+  --radius-canopy-lg: var(--radius-lg);
+
+  --ease-canopy-out: var(--ease-out-quart);
+  --animate-canopy-overlay-enter: overlay-enter var(--duration-fast) var(--ease-out-quart);
+}
 
 :root {
   /* ── Background surfaces (warm navy tint) ────────────── */
@@ -1297,30 +1340,10 @@ canopy-editor {
   scrollbar-color: var(--canopy-scrollbar) transparent;
 }
 
-/* ── Action Overlay ────────────────────────────────────── */
-
-.action-overlay-scrim {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  background: rgba(0, 0, 0, 0.3);
-}
-
-.action-overlay-panel {
-  position: fixed;
-  z-index: 51;
-  min-width: 200px;
-  max-width: 280px;
-  max-height: 360px;
-  overflow-y: auto;
-  background: var(--canopy-panel-bg);
-  border: 1px solid var(--canopy-accent);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4),
-              0 0 0 1px rgba(130, 80, 223, 0.15);
-  padding: var(--space-xs) 0;
-  animation: overlay-enter var(--duration-fast) var(--ease-out-quart);
-}
+/* ── Action Overlay ──────────────────────────────────────
+   Visual declarations for the light-DOM action overlay/name prompt now live in
+   Tailwind utilities in examples/ideal/main/view_actions.mbt. Keep only the
+   keyframes referenced by the Tailwind animation token. */
 
 @keyframes overlay-enter {
   from {
@@ -1330,134 +1353,5 @@ canopy-editor {
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
-  }
-}
-
-.action-overlay-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.action-group-label {
-  font-size: var(--text-label);
-  font-weight: var(--weight-semibold);
-  color: var(--canopy-text-dim);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  padding: var(--space-sm) var(--space-lg) var(--space-xs);
-  border-top: 1px solid var(--canopy-border);
-  margin-top: var(--space-xs);
-}
-
-.action-overlay-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-lg);
-  cursor: pointer;
-  font-size: var(--text-small);
-  color: var(--canopy-fg);
-  transition: background var(--duration-fast) var(--ease-out-quart);
-}
-
-.action-overlay-item:hover,
-.action-overlay-item[data-active="true"] {
-  background: rgba(130, 80, 223, 0.15);
-}
-
-.action-overlay-item.danger {
-  color: var(--canopy-error-text);
-}
-
-.action-overlay-item.danger:hover,
-.action-overlay-item.danger[data-active="true"] {
-  background: var(--canopy-error-bg);
-}
-
-.action-mnemonic {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  font-family: var(--canopy-font-mono);
-  font-size: var(--text-label);
-  font-weight: var(--weight-semibold);
-  color: var(--canopy-accent);
-  background: rgba(130, 80, 223, 0.2);
-  border-radius: var(--radius-sm);
-  flex-shrink: 0;
-  text-transform: uppercase;
-}
-
-.action-label-text {
-  font-family: var(--canopy-font-ui);
-  font-size: var(--text-small);
-  white-space: nowrap;
-}
-
-/* ── Name Prompt ───────────────────────────────────────── */
-
-.name-prompt-container {
-  padding: var(--space-md) var(--space-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-
-.name-prompt-label {
-  font-size: var(--text-small);
-  font-weight: var(--weight-medium);
-  color: var(--canopy-text-secondary);
-}
-
-.name-prompt-input-row {
-  display: flex;
-}
-
-.name-prompt-input {
-  flex: 1;
-  font-family: var(--canopy-font-mono);
-  font-size: var(--text-small);
-  padding: var(--space-sm) var(--space-md);
-  background: var(--canopy-surface);
-  border: 1px solid var(--canopy-border);
-  border-radius: var(--radius-md);
-  color: var(--canopy-fg);
-  outline: none;
-  transition: border-color var(--duration-fast) var(--ease-out-quart);
-}
-
-.name-prompt-input:focus {
-  border-color: var(--canopy-accent);
-  box-shadow: 0 0 0 2px rgba(130, 80, 223, 0.2);
-}
-
-.name-prompt-input::placeholder {
-  color: var(--canopy-text-dim);
-}
-
-.action-overlay-error {
-  font-size: var(--text-label);
-  color: var(--canopy-error-text);
-  padding: var(--space-sm) var(--space-lg);
-}
-
-/* ── Overlay mobile adjustments ────────────────────────── */
-
-@media (max-width: 768px) {
-  .action-overlay-panel {
-    min-width: 240px;
-    max-width: min(320px, 90vw);
-  }
-
-  .action-overlay-item {
-    min-height: 44px;
-    padding: var(--space-md) var(--space-lg);
-  }
-
-  .name-prompt-input {
-    min-height: 44px;
-    font-size: var(--text-body);
   }
 }

--- a/examples/ideal/web/vite.config.ts
+++ b/examples/ideal/web/vite.config.ts
@@ -1,3 +1,4 @@
+import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, type PluginOption } from 'vite';
 import { moonbitPlugin } from '../../web/vite-plugin-moonbit';
 
@@ -9,6 +10,7 @@ const idealEditorOutput = process.env.MOON_WORK === 'off'
 
 export default defineConfig({
   plugins: [
+    tailwindcss(),
     moonbitPlugin({
       modules: [
         {


### PR DESCRIPTION
## Summary

- Add Tailwind v4.3 to `examples/ideal/web` using the Vite plugin and a CSS-first token bridge to existing `--canopy-*` variables.
- Migrate the light-DOM action overlay/name prompt slice to Tailwind utilities while preserving semantic class hooks.
- Remove the migrated overlay/name-prompt declarations from `editor.css`, add computed-style Playwright coverage, and document the incremental migration plan.

Closes #533.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Existing overlay view functions and semantic class hooks | `examples/ideal/main/view_actions.mbt` | Yes | The rendering flow and selectors such as `.action-overlay-panel` / `.name-prompt-input` are preserved; only visual class bundles moved to Tailwind. |
| Existing Canopy design tokens | `examples/ideal/web/styles/editor.css` `:root --canopy-*` | Yes | Tailwind `@theme inline` maps utility tokens back to the existing CSS custom properties instead of introducing a duplicate token source. |
| Shadow stylesheet transport | `examples/ideal/web/src/canopy-editor.ts`, `examples/ideal/web/styles/editor-shadow.css` | Not needed | This first slice is light DOM; the PR #532 adoptedStyleSheets path remains untouched for future shadow-owned slices. |

New helpers added:

- `examples/ideal/main/view_actions_classes.mbt`: private package-level class bundle constants for the migrated overlay/name-prompt slice. This keeps `view_actions.mbt` behavior-focused and gives Tailwind a narrow `.mbt` source file to scan.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (none; newline-only churn reverted)
- [x] JS rebuild run if web is affected (`cd examples/ideal/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
cd examples/ideal/web && npm run build
cd examples/ideal/web && npx playwright test e2e/structural-editing.spec.ts --reporter=line --workers=1
```

Additional notes:

- Built CSS after the narrow first slice: `28389` bytes (`dist/assets/index-*.css`).
- Tailwind docs consulted before adding dependencies: v4.3 Vite install, source detection, theme variables / `@theme inline`, Preflight disabling, and transition-duration docs. Context7 MCP tools were not exposed in this pi harness, so I used official Tailwind docs via `curl`.
