### PR TITLE
feat(ideal): add Tailwind UI recipes for toolbar chrome

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -278,16 +278,16 @@ fn view_toolbar(dispatch : Emit[Msg], model : Model) -> Html {
   let example_buttons : Array[Html] = examples.map(fn(pair) {
     let (label, code) = pair
     button(
-      class="toolbar-btn example-btn",
+      class=@ui.toolbar_example_button_class(),
       on_click=dispatch(LoadExample(code)),
       [text(label)],
     )
   })
   let toolbar_items : Array[Html] = [
-    span(class="toolbar-title", [text("Canopy Editor")]),
-    div(class="toolbar-spacer", [text("")]),
+    span(class=toolbar_title_class, [text("Canopy Editor")]),
+    div(class=toolbar_spacer_class, [text("")]),
     button(
-      class=if model.mode == Text { "tab active" } else { "tab" },
+      class=@ui.toolbar_tab_class(model.mode == Text),
       on_click=dispatch(SetMode(Text)),
       attrs=@html.Attrs::build().aria_pressed(
         if model.mode == Text {
@@ -299,7 +299,7 @@ fn view_toolbar(dispatch : Emit[Msg], model : Model) -> Html {
       [text("Text")],
     ),
     button(
-      class=if model.mode == Structure { "tab active" } else { "tab" },
+      class=@ui.toolbar_tab_class(model.mode == Structure),
       on_click=dispatch(SetMode(Structure)),
       attrs=@html.Attrs::build().aria_pressed(
         if model.mode == Structure {
@@ -310,16 +310,16 @@ fn view_toolbar(dispatch : Emit[Msg], model : Model) -> Html {
       ),
       [text("Structure")],
     ),
-    div(class="toolbar-spacer", [text("")]),
-    button(class="toolbar-btn", on_click=dispatch(Undo), [text("Undo")]),
-    button(class="toolbar-btn", on_click=dispatch(Redo), [text("Redo")]),
-    div(class="toolbar-spacer", [text("")]),
+    div(class=toolbar_spacer_class, [text("")]),
+    button(class=@ui.toolbar_button_class(), on_click=dispatch(Undo), [
+      text("Undo"),
+    ]),
+    button(class=@ui.toolbar_button_class(), on_click=dispatch(Redo), [
+      text("Redo"),
+    ]),
+    div(class=toolbar_spacer_class, [text("")]),
     button(
-      class=if model.workspace.outline_visible {
-        "panel-toggle active"
-      } else {
-        "panel-toggle"
-      },
+      class=@ui.toolbar_panel_toggle_class(model.workspace.outline_visible),
       on_click=dispatch(TogglePanel(Outline)),
       attrs=@html.Attrs::build().aria_pressed(
         if model.workspace.outline_visible {
@@ -331,11 +331,7 @@ fn view_toolbar(dispatch : Emit[Msg], model : Model) -> Html {
       [text("Outline")],
     ),
     button(
-      class=if model.workspace.inspector_visible {
-        "panel-toggle active"
-      } else {
-        "panel-toggle"
-      },
+      class=@ui.toolbar_panel_toggle_class(model.workspace.inspector_visible),
       on_click=dispatch(TogglePanel(Inspector)),
       attrs=@html.Attrs::build().aria_pressed(
         if model.workspace.inspector_visible {
@@ -347,11 +343,7 @@ fn view_toolbar(dispatch : Emit[Msg], model : Model) -> Html {
       [text("Inspector")],
     ),
     button(
-      class=if model.workspace.bottom_visible {
-        "panel-toggle active"
-      } else {
-        "panel-toggle"
-      },
+      class=@ui.toolbar_panel_toggle_class(model.workspace.bottom_visible),
       on_click=dispatch(TogglePanel(Bottom)),
       attrs=@html.Attrs::build().aria_pressed(
         if model.workspace.bottom_visible {
@@ -362,10 +354,10 @@ fn view_toolbar(dispatch : Emit[Msg], model : Model) -> Html {
       ),
       [text("Panels")],
     ),
-    div(class="toolbar-spacer", [text("")]),
+    div(class=toolbar_spacer_class, [text("")]),
   ]
   example_buttons.each(fn(b) { toolbar_items.push(b) })
-  div(class="toolbar", toolbar_items)
+  div(class=toolbar_class, toolbar_items)
 }
 
 ///|

--- a/examples/ideal/main/moon.pkg
+++ b/examples/ideal/main/moon.pkg
@@ -30,6 +30,7 @@ import {
   "dowdiness/graphviz/lib/layout" @gv_layout,
   "dowdiness/graphviz/lib/svg" @gv_svg,
   "dowdiness/visualizer",
+  "dowdiness/ideal-editor/main/ui",
 }
 
 supported_targets = "js"

--- a/examples/ideal/main/ui/button.mbt
+++ b/examples/ideal/main/ui/button.mbt
@@ -1,0 +1,97 @@
+///|
+// Ideal-local Tailwind button recipes.
+// Keep semantic hooks as the first class tokens: tests and integration code use
+// hooks such as `toolbar-btn`, `tab`, and `action-btn`, while Tailwind owns the
+// visual declarations for this slice.
+priv enum ButtonTone {
+  Neutral
+  Accent
+  Surface
+  Danger
+}
+
+///|
+let button_chrome_base_class = "ideal-button font-canopy-ui font-medium cursor-pointer transition-colors duration-(--duration-fast) ease-canopy-out"
+
+///|
+let toolbar_button_base_class : String = button_chrome_base_class +
+  " text-canopy-caption py-canopy-sm px-canopy-md border-0 rounded-canopy-sm min-h-[32px] max-[768px]:min-h-[44px] max-[768px]:min-w-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-md"
+
+///|
+fn toolbar_button_tone_class(tone : ButtonTone) -> String {
+  match tone {
+    Neutral =>
+      "bg-transparent text-canopy-dim hover:bg-canopy-surface hover:text-canopy-secondary"
+    Accent =>
+      "bg-canopy-accent text-canopy-fg-inverse hover:bg-canopy-accent hover:text-canopy-fg-inverse"
+    Surface =>
+      "bg-canopy-surface text-canopy-fg hover:bg-canopy-surface hover:text-canopy-fg"
+    Danger =>
+      "bg-transparent text-canopy-error-text hover:bg-canopy-error-bg hover:text-canopy-error-text"
+  }
+}
+
+///|
+fn toolbar_button_recipe_class(tone : ButtonTone) -> String {
+  toolbar_button_base_class + " " + toolbar_button_tone_class(tone)
+}
+
+///|
+pub fn toolbar_button_class() -> String {
+  "toolbar-btn " + toolbar_button_recipe_class(Neutral)
+}
+
+///|
+pub fn toolbar_example_button_class() -> String {
+  "toolbar-btn example-btn " +
+  toolbar_button_recipe_class(Neutral) +
+  " max-[768px]:hidden"
+}
+
+///|
+pub fn toolbar_tab_class(active : Bool) -> String {
+  if active {
+    "tab active " + toolbar_button_recipe_class(Accent)
+  } else {
+    "tab " + toolbar_button_recipe_class(Neutral)
+  }
+}
+
+///|
+pub fn toolbar_panel_toggle_class(active : Bool) -> String {
+  if active {
+    "panel-toggle active " + toolbar_button_recipe_class(Surface)
+  } else {
+    "panel-toggle " + toolbar_button_recipe_class(Neutral)
+  }
+}
+
+///|
+let action_button_base_class : String = button_chrome_base_class +
+  " text-canopy-small py-canopy-sm px-canopy-md bg-canopy-surface border border-solid border-transparent rounded-canopy-md text-left"
+
+///|
+fn action_button_tone_class(tone : ButtonTone) -> String {
+  match tone {
+    Danger =>
+      "text-canopy-error-text hover:bg-canopy-error-bg hover:border-canopy-error-border hover:text-canopy-error-text"
+    _ =>
+      "text-canopy-secondary hover:bg-canopy-accent-hover hover:border-canopy-accent-border hover:text-canopy-accent-text"
+  }
+}
+
+///|
+pub fn action_button_class() -> String {
+  "action-btn " +
+  action_button_base_class +
+  " " +
+  action_button_tone_class(Neutral)
+}
+
+///|
+pub fn action_button_danger_class() -> String {
+  "action-btn danger " +
+  action_button_base_class +
+  " " +
+  action_button_tone_class(Danger)
+}

--- a/examples/ideal/main/ui/moon.pkg
+++ b/examples/ideal/main/ui/moon.pkg
@@ -1,0 +1,1 @@
+supported_targets = "js"

--- a/examples/ideal/main/ui/pkg.generated.mbti
+++ b/examples/ideal/main/ui/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/ideal-editor/main/ui"
+
+// Values
+pub fn action_button_class() -> String
+
+pub fn action_button_danger_class() -> String
+
+pub fn toolbar_button_class() -> String
+
+pub fn toolbar_example_button_class() -> String
+
+pub fn toolbar_panel_toggle_class(Bool) -> String
+
+pub fn toolbar_tab_class(Bool) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/examples/ideal/main/view_inspector.mbt
+++ b/examples/ideal/main/view_inspector.mbt
@@ -137,14 +137,14 @@ fn view_actions(dispatch : Emit[Msg], node_id_str : String) -> Html {
     span(class="panel-label", [text("ACTIONS")]),
     div(class="inspector-actions", [
       button(
-        class="action-btn",
+        class=@ui.action_button_class(),
         on_click=dispatch(
           StructuralEditRequested(op="WrapInLambda", node_id=node_id_str),
         ),
         [text("Wrap in \u{03BB}")],
       ),
       button(
-        class="action-btn danger",
+        class=@ui.action_button_danger_class(),
         on_click=dispatch(
           StructuralEditRequested(op="Delete", node_id=node_id_str),
         ),

--- a/examples/ideal/main/view_toolbar_classes.mbt
+++ b/examples/ideal/main/view_toolbar_classes.mbt
@@ -1,0 +1,11 @@
+///|
+// Tailwind utility bundles for the light-DOM toolbar shell.
+// Button chrome lives in `main/ui/button.mbt`; this file owns only the
+// toolbar-specific layout hooks.
+let toolbar_class = "toolbar flex items-center px-canopy-lg h-[48px] bg-canopy-header border-b border-solid border-canopy-border shadow-[0_1px_0_var(--canopy-glow)] gap-canopy-sm shrink-0 max-[768px]:pl-[max(var(--space-sm),env(safe-area-inset-left))] max-[768px]:pr-[max(var(--space-sm),env(safe-area-inset-right))] max-[768px]:gap-canopy-xs max-[768px]:overflow-x-auto max-[768px]:[-webkit-overflow-scrolling:touch] max-[768px]:[scrollbar-width:none] max-[768px]:[&::-webkit-scrollbar]:hidden max-[768px]:landscape:h-[40px]"
+
+///|
+let toolbar_title_class = "toolbar-title text-canopy-body font-medium text-canopy-secondary tracking-[-0.01em] mr-canopy-sm max-[768px]:text-canopy-small max-[480px]:hidden"
+
+///|
+let toolbar_spacer_class = "toolbar-spacer flex-1 max-[768px]:flex-[0_0_var(--space-xs)]"

--- a/examples/ideal/web/e2e/toolbar-tailwind.spec.ts
+++ b/examples/ideal/web/e2e/toolbar-tailwind.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function waitForEditorReady(page: Page, path = '/') {
+  await page.goto(path);
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+async function selectOutlineNode(page: Page) {
+  await page.locator('.tree-row').first().click();
+  await expect(page.locator('.inspector-actions .action-btn').first()).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe('Ideal Tailwind toolbar/button recipes', () => {
+  test('Tailwind-owned toolbar chrome styles desktop states', async ({ page }) => {
+    await waitForEditorReady(page);
+
+    const styles = await page.evaluate(() => {
+      const byText = (selector: string, label: string) =>
+        Array.from(document.querySelectorAll<HTMLElement>(selector)).find(
+          (el) => el.textContent?.trim() === label,
+        );
+      const toolbar = document.querySelector<HTMLElement>('.toolbar');
+      const title = document.querySelector<HTMLElement>('.toolbar-title');
+      const undo = byText('button.toolbar-btn', 'Undo');
+      const textTab = byText('button.tab', 'Text');
+      const inspectorToggle = byText('button.panel-toggle', 'Inspector');
+      if (!toolbar || !title || !undo || !textTab || !inspectorToggle) return null;
+      const toolbarStyle = getComputedStyle(toolbar);
+      const titleStyle = getComputedStyle(title);
+      const undoStyle = getComputedStyle(undo);
+      const textTabStyle = getComputedStyle(textTab);
+      const inspectorStyle = getComputedStyle(inspectorToggle);
+      return {
+        toolbarDisplay: toolbarStyle.display,
+        toolbarAlignItems: toolbarStyle.alignItems,
+        toolbarHeight: toolbarStyle.height,
+        toolbarBackground: toolbarStyle.backgroundColor,
+        toolbarBorder: toolbarStyle.borderBottomColor,
+        toolbarShadow: toolbarStyle.boxShadow,
+        titleFontSize: titleStyle.fontSize,
+        titleColor: titleStyle.color,
+        titleMarginRight: titleStyle.marginRight,
+        undoBackground: undoStyle.backgroundColor,
+        undoColor: undoStyle.color,
+        undoMinHeight: undoStyle.minHeight,
+        undoPaddingLeft: undoStyle.paddingLeft,
+        undoBorderWidth: undoStyle.borderTopWidth,
+        textTabBackground: textTabStyle.backgroundColor,
+        textTabColor: textTabStyle.color,
+        inspectorBackground: inspectorStyle.backgroundColor,
+        inspectorColor: inspectorStyle.color,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(styles?.toolbarDisplay).toBe('flex');
+    expect(styles?.toolbarAlignItems).toBe('center');
+    expect(styles?.toolbarHeight).toBe('48px');
+    expect(styles?.toolbarBackground).toBe('rgb(18, 18, 31)');
+    expect(styles?.toolbarBorder).toBe('rgb(40, 40, 62)');
+    expect(styles?.toolbarShadow).toContain('0px 1px 0px');
+    expect(styles?.titleFontSize).toBe('16px');
+    expect(styles?.titleColor).toBe('rgb(184, 184, 208)');
+    expect(styles?.titleMarginRight).toBe('8px');
+    expect(styles?.undoBackground).toBe('rgba(0, 0, 0, 0)');
+    expect(styles?.undoColor).toBe('rgb(138, 138, 170)');
+    expect(styles?.undoMinHeight).toBe('32px');
+    expect(styles?.undoPaddingLeft).toBe('12px');
+    expect(styles?.undoBorderWidth).toBe('0px');
+    expect(styles?.textTabBackground).toBe('rgb(130, 80, 223)');
+    expect(styles?.textTabColor).toBe('rgb(255, 255, 255)');
+    expect(styles?.inspectorBackground).toBe('rgb(34, 34, 56)');
+    expect(styles?.inspectorColor).toBe('rgb(228, 228, 240)');
+
+    const undo = page.getByRole('button', { name: 'Undo' });
+    await undo.hover();
+    await expect
+      .poll(async () => undo.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .toBe('rgb(34, 34, 56)');
+    await expect
+      .poll(async () => undo.evaluate((el) => getComputedStyle(el).color))
+      .toBe('rgb(184, 184, 208)');
+  });
+
+  test('Tailwind-owned toolbar chrome styles mobile and landscape states', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForEditorReady(page);
+
+    const mobileStyles = await page.evaluate(() => {
+      const byText = (selector: string, label: string) =>
+        Array.from(document.querySelectorAll<HTMLElement>(selector)).find(
+          (el) => el.textContent?.trim() === label,
+        );
+      const toolbar = document.querySelector<HTMLElement>('.toolbar');
+      const title = document.querySelector<HTMLElement>('.toolbar-title');
+      const undo = byText('button.toolbar-btn', 'Undo');
+      const basics = byText('button.example-btn', 'Basics');
+      if (!toolbar || !title || !undo || !basics) return null;
+      const toolbarStyle = getComputedStyle(toolbar);
+      const titleStyle = getComputedStyle(title);
+      const undoStyle = getComputedStyle(undo);
+      const basicsStyle = getComputedStyle(basics);
+      return {
+        toolbarOverflowX: toolbarStyle.overflowX,
+        toolbarGap: toolbarStyle.gap,
+        toolbarPaddingLeft: toolbarStyle.paddingLeft,
+        titleDisplay: titleStyle.display,
+        undoMinHeight: undoStyle.minHeight,
+        undoMinWidth: undoStyle.minWidth,
+        undoPaddingTop: undoStyle.paddingTop,
+        basicsDisplay: basicsStyle.display,
+      };
+    });
+
+    expect(mobileStyles).not.toBeNull();
+    expect(mobileStyles?.toolbarOverflowX).toBe('auto');
+    expect(mobileStyles?.toolbarGap).toBe('4px');
+    expect(mobileStyles?.toolbarPaddingLeft).toBe('8px');
+    expect(mobileStyles?.titleDisplay).toBe('none');
+    expect(mobileStyles?.undoMinHeight).toBe('44px');
+    expect(mobileStyles?.undoMinWidth).toBe('44px');
+    expect(mobileStyles?.undoPaddingTop).toBe('12px');
+    expect(mobileStyles?.basicsDisplay).toBe('none');
+
+    await page.setViewportSize({ width: 700, height: 360 });
+    await expect
+      .poll(async () =>
+        page.locator('.toolbar').evaluate((el) => getComputedStyle(el).height),
+      )
+      .toBe('40px');
+  });
+
+  test('Tailwind-owned action button recipe styles neutral and danger states', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await selectOutlineNode(page);
+
+    const wrap = page.locator('.inspector-actions .action-btn').filter({
+      hasText: 'Wrap in λ',
+    });
+    const danger = page.locator('.inspector-actions .action-btn.danger').filter({
+      hasText: 'Delete',
+    });
+
+    const initialStyles = await wrap.evaluate((wrapEl) => {
+      const dangerEl = document.querySelector<HTMLElement>(
+        '.inspector-actions .action-btn.danger',
+      );
+      if (!dangerEl) return null;
+      const wrapStyle = getComputedStyle(wrapEl);
+      const dangerStyle = getComputedStyle(dangerEl);
+      return {
+        wrapBackground: wrapStyle.backgroundColor,
+        wrapBorder: wrapStyle.borderTopColor,
+        wrapColor: wrapStyle.color,
+        wrapFontSize: wrapStyle.fontSize,
+        wrapRadius: wrapStyle.borderTopLeftRadius,
+        wrapTextAlign: wrapStyle.textAlign,
+        dangerBackground: dangerStyle.backgroundColor,
+        dangerColor: dangerStyle.color,
+      };
+    });
+
+    expect(initialStyles).not.toBeNull();
+    expect(initialStyles?.wrapBackground).toBe('rgb(34, 34, 56)');
+    expect(initialStyles?.wrapBorder).toBe('rgba(0, 0, 0, 0)');
+    expect(initialStyles?.wrapColor).toBe('rgb(184, 184, 208)');
+    expect(initialStyles?.wrapFontSize).toBe('14px');
+    expect(initialStyles?.wrapRadius).toBe('6px');
+    expect(initialStyles?.wrapTextAlign).toBe('left');
+    expect(initialStyles?.dangerBackground).toBe('rgb(34, 34, 56)');
+    expect(initialStyles?.dangerColor).toBe('rgb(239, 68, 68)');
+
+    await wrap.hover();
+    await expect
+      .poll(async () => wrap.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .toBe('rgba(130, 80, 223, 0.12)');
+    await expect
+      .poll(async () => wrap.evaluate((el) => getComputedStyle(el).borderTopColor))
+      .toBe('rgba(130, 80, 223, 0.2)');
+    await expect
+      .poll(async () => wrap.evaluate((el) => getComputedStyle(el).color))
+      .toBe('rgb(176, 144, 224)');
+
+    await danger.hover();
+    await expect
+      .poll(async () => danger.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .toBe('rgba(207, 34, 46, 0.1)');
+    await expect
+      .poll(async () => danger.evaluate((el) => getComputedStyle(el).borderTopColor))
+      .toBe('rgba(207, 34, 46, 0.2)');
+    await expect
+      .poll(async () => danger.evaluate((el) => getComputedStyle(el).color))
+      .toBe('rgb(239, 68, 68)');
+  });
+});

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -3,6 +3,8 @@
 @import "tailwindcss/utilities.css" layer(utilities) source(none);
 /* Keep source detection as narrow as the migrated slice; expand per slice. */
 @source "../../main/view_actions_classes.mbt";
+@source "../../main/view_toolbar_classes.mbt";
+@source "../../main/ui/button.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
 
@@ -18,8 +20,12 @@
   --color-canopy-muted: var(--canopy-muted);
   --color-canopy-dim: var(--canopy-text-dim);
   --color-canopy-accent: var(--canopy-accent);
+  --color-canopy-accent-hover: var(--canopy-accent-hover);
+  --color-canopy-accent-text: var(--canopy-accent-text);
+  --color-canopy-accent-border: var(--canopy-accent-border);
   --color-canopy-error-text: var(--canopy-error-text);
   --color-canopy-error-bg: var(--canopy-error-bg);
+  --color-canopy-error-border: var(--canopy-error-border);
 
   --font-canopy-ui: var(--canopy-font-ui);
   --font-canopy-mono: var(--canopy-font-mono);
@@ -135,7 +141,9 @@
   --duration-slow: 400ms;
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+@layer base {
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+}
 
 body {
   background: var(--canopy-bg);
@@ -196,57 +204,8 @@ button:focus-visible, .action-btn:focus-visible,
 
 /* ── Toolbar ────────────────────────────────────────────── */
 
-.toolbar {
-  display: flex;
-  align-items: center;
-  padding: 0 var(--space-lg);
-  height: 48px;
-  background: var(--canopy-header-bg);
-  border-bottom: 1px solid var(--canopy-border);
-  box-shadow: 0 1px 0 var(--canopy-glow);
-  gap: var(--space-sm);
-  flex-shrink: 0;
-}
-
-.toolbar-title {
-  font-size: var(--text-body);
-  font-weight: var(--weight-medium);
-  color: var(--canopy-text-secondary);
-  letter-spacing: -0.01em;
-  margin-right: var(--space-sm);
-}
-
-.toolbar-spacer { flex: 1; }
-
-.toolbar-btn, .tab, .panel-toggle, .example-btn {
-  font-family: var(--canopy-font-ui);
-  font-size: var(--text-caption);
-  font-weight: var(--weight-medium);
-  padding: var(--space-sm) var(--space-md);
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  background: transparent;
-  color: var(--canopy-text-dim);
-  transition: background var(--duration-fast) var(--ease-out-quart),
-              color var(--duration-fast) var(--ease-out-quart);
-  min-height: 32px;
-}
-
-.tab.active {
-  background: var(--canopy-accent);
-  color: var(--canopy-fg-inverse);
-}
-
-.toolbar-btn:hover, .tab:hover, .panel-toggle:hover, .example-btn:hover {
-  background: var(--canopy-surface);
-  color: var(--canopy-text-secondary);
-}
-
-.panel-toggle.active {
-  background: var(--canopy-surface);
-  color: var(--canopy-fg);
-}
+/* Toolbar shell/button chrome is Tailwind-owned via
+   examples/ideal/main/view_toolbar_classes.mbt and main/ui/button.mbt. */
 
 /* ── Workspace ──────────────────────────────────────────── */
 
@@ -625,37 +584,7 @@ canopy-editor {
   gap: var(--space-xs);
 }
 
-.action-btn {
-  font-family: var(--canopy-font-ui);
-  font-size: var(--text-small);
-  font-weight: var(--weight-medium);
-  padding: var(--space-sm) var(--space-md);
-  background: var(--canopy-surface);
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--canopy-text-secondary);
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--duration-fast) var(--ease-out-quart),
-              border-color var(--duration-fast) var(--ease-out-quart),
-              color var(--duration-fast) var(--ease-out-quart);
-}
-
-.action-btn:hover {
-  background: var(--canopy-accent-hover);
-  border-color: var(--canopy-accent-border);
-  color: var(--canopy-accent-text);
-}
-
-.action-btn.danger {
-  color: var(--canopy-error-text);
-}
-
-.action-btn.danger:hover {
-  background: var(--canopy-error-bg);
-  border-color: var(--canopy-error-border);
-  color: var(--canopy-error-text);
-}
+/* Inspector action button chrome is Tailwind-owned by main/ui/button.mbt. */
 
 .source-preview {
   background: var(--canopy-surface);
@@ -723,9 +652,27 @@ canopy-editor {
 
 /* Bottom tabs use underline accent, not fill — lighter than toolbar tabs */
 .bottom-tabs .tab {
-  border-radius: 0;
+  font-family: var(--canopy-font-ui);
+  font-size: var(--text-caption);
+  font-weight: var(--weight-medium);
+  padding: var(--space-sm) var(--space-md);
+  border: none;
   border-bottom: 2px solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+  background: transparent;
+  color: var(--canopy-text-dim);
+  transition: background var(--duration-fast) var(--ease-out-quart),
+              color var(--duration-fast) var(--ease-out-quart);
+  min-height: 32px;
   padding-bottom: calc(var(--space-sm) - 2px);
+}
+
+@media (hover: hover) {
+  .bottom-tabs .tab:hover {
+    background: var(--canopy-surface);
+    color: var(--canopy-text-secondary);
+  }
 }
 
 .bottom-tabs .tab.active {
@@ -1120,27 +1067,14 @@ canopy-editor {
 
   /* ── Toolbar: compact, scrollable, safe-area aware ─────── */
 
-  .toolbar {
-    padding-left: max(var(--space-sm), env(safe-area-inset-left));
-    padding-right: max(var(--space-sm), env(safe-area-inset-right));
-    gap: var(--space-xs);
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none; /* hide scrollbar on Firefox */
-  }
-
-  .toolbar::-webkit-scrollbar { display: none; }
-
-  .toolbar-title { font-size: var(--text-small); }
-
-  /* Hide example buttons — use the examples via menu on mobile */
-  .example-btn { display: none; }
+  /* Toolbar compact/scrollable rules moved to Tailwind-owned recipes. */
 
   /* Touch targets: 44px minimum per WCAG 2.5.8 */
-  .toolbar-btn, .tab, .panel-toggle {
+  .bottom-tabs .tab {
     min-height: 44px;
     min-width: 44px;
     padding: var(--space-md) var(--space-md);
+    padding-bottom: calc(var(--space-md) - 2px);
   }
 
   /* Drop the desktop's fixed 36px height on the bottom tab strip so its
@@ -1149,9 +1083,6 @@ canopy-editor {
     height: auto;
     min-height: 44px;
   }
-
-  /* Hide spacers on mobile — let flex-gap handle spacing */
-  .toolbar-spacer { flex: 0 0 var(--space-xs); }
 
   .panel-resize-handle { display: none; }
 
@@ -1275,8 +1206,6 @@ canopy-editor {
 
 /* Small phones: further compact */
 @media (max-width: 480px) {
-  .toolbar-title { display: none; }
-
   .outline-panel,
   .inspector-panel {
     width: 100vw;
@@ -1294,22 +1223,10 @@ canopy-editor {
 /* Touch device: suppress hover flicker */
 @media (hover: none) {
   .tree-row:hover { background: transparent; }
-  .toolbar-btn:hover, .tab:hover,
-  .panel-toggle:hover, .example-btn:hover {
-    background: transparent;
-    color: var(--canopy-text-dim);
-  }
-  .tab.active:hover { background: var(--canopy-accent); color: var(--canopy-fg-inverse); }
-  .panel-toggle.active:hover {
-    background: var(--canopy-surface);
-    color: var(--canopy-fg);
-  }
 }
 
 /* Landscape mobile: reduce toolbar + bottom panel height */
 @media (max-width: 768px) and (orientation: landscape) {
-  .toolbar { height: 40px; }
-
   .outline-panel,
   .inspector-panel {
     top: calc(40px + env(safe-area-inset-top, 0px));


### PR DESCRIPTION
## Summary
- add an Ideal-local `main/ui` recipe package for Tailwind-owned button chrome
- migrate the light-DOM toolbar and inspector action buttons to recipe class helpers
- keep Tailwind source scanning explicit and narrow, and remove duplicate legacy CSS owners
- add computed-style Playwright coverage for desktop, mobile/landscape, hover, and danger states

## Reuse check
- Reused the existing `view_actions_classes.mbt` pattern from the overlay/name-prompt slice: semantic hook first, static Tailwind utilities, and no `@apply`.
- Reused Rabbita's existing `button`/view structure; the new recipe layer only owns class strings, not behavior.
- Reused existing CSS custom-property tokens through `@theme inline`; added aliases only for already-existing accent/error derived tokens needed by migrated button states.
- Did not reuse the old toolbar/action-button CSS declarations because this slice needs Tailwind to be the single visual owner. Bottom-tab `.tab` CSS remains CSS-owned and scoped to `.bottom-tabs`.

## Validation
- `cd examples/ideal && moon check`
- `moon check`
- `moon test`
- `NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info`
- `cd examples/ideal/web && npm run build`
- `cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/toolbar-tailwind.spec.ts --reporter=line`

## CSS size
Compared against HEAD (`8d270c2`) with the same Ideal web build:
- baseline: `28.39 kB` / gzip `5.79 kB`
- this PR: `28.98 kB` / gzip `5.89 kB`

## Notes
- No Tailwind `@apply` added.
- `@source` remains explicit; no broad `../../main/**/*.mbt` scanning.
- The existing dirty `loom` submodule in the local checkout was left untouched and is not part of this PR.

## Follow-ups
- #536 tracks a possible CVA-inspired MoonBit helper layer after more recipe repetition appears.
- #537 tracks the Moon IDE Yojson crash encountered during Existing API First checks.
- #538 tracks documenting the Tailwind cascade-layer reset gotcha.
