### PR TITLE
feat(ideal): migrate bottom tab chrome to Tailwind

### DIFF
--- a/examples/ideal/main/ui/button.mbt
+++ b/examples/ideal/main/ui/button.mbt
@@ -2,7 +2,7 @@
 // Ideal-local Tailwind button recipes.
 // Keep semantic hooks as the first class tokens: tests and integration code use
 // hooks such as `toolbar-btn`, `tab`, and `action-btn`, while Tailwind owns the
-// visual declarations for this slice.
+// visual declarations for migrated button/tab chrome.
 priv enum ButtonTone {
   Neutral
   Accent
@@ -64,6 +64,26 @@ pub fn toolbar_panel_toggle_class(active : Bool) -> String {
   } else {
     "panel-toggle " + toolbar_button_recipe_class(Neutral)
   }
+}
+
+///|
+// Bottom tabs use underline accent, not fill — lighter than toolbar tabs.
+let bottom_tab_base_class : String = button_chrome_base_class +
+  " text-canopy-caption py-canopy-sm px-canopy-md border-x-0 border-t-0 border-b-2 border-solid rounded-none min-h-[32px] pb-[calc(var(--space-sm)_-_2px)] max-[768px]:min-h-[44px] max-[768px]:min-w-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-md max-[768px]:pb-[calc(var(--space-md)_-_2px)]"
+
+///|
+fn bottom_tab_tone_class(active : Bool) -> String {
+  if active {
+    "bg-transparent text-canopy-accent-text border-b-canopy-accent"
+  } else {
+    "bg-transparent text-canopy-dim border-b-transparent hover:bg-canopy-surface hover:text-canopy-secondary"
+  }
+}
+
+///|
+pub fn bottom_tab_class(active : Bool) -> String {
+  let hook = if active { "tab active " } else { "tab " }
+  hook + bottom_tab_base_class + " " + bottom_tab_tone_class(active)
 }
 
 ///|

--- a/examples/ideal/main/ui/pkg.generated.mbti
+++ b/examples/ideal/main/ui/pkg.generated.mbti
@@ -6,6 +6,8 @@ pub fn action_button_class() -> String
 
 pub fn action_button_danger_class() -> String
 
+pub fn bottom_tab_class(Bool) -> String
+
 pub fn toolbar_button_class() -> String
 
 pub fn toolbar_example_button_class() -> String

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -340,16 +340,15 @@ fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
   // The headless `@tabs` behavior owns the WAI-ARIA tablist keyboard model
   // (ArrowLeft/Right wrap, Home/End jump), roving tabindex, `aria-selected`,
   // and `aria-controls` (set only on the selected tab, since the other panels
-  // aren't mounted). This consumer owns the tab data, panel ids, the
-  // `tab`/`tab active` classes, and the index → `BottomTab` mapping.
+  // aren't mounted). This consumer owns the tab data, panel ids, selected-state
+  // recipe choice, and the index → `BottomTab` mapping.
   let behavior = bottom_tabs_behavior(model.bottom_tab)
   let buttons : Array[Html] = []
-  for i in 0..<bottom_tab_defs.length() {
-    let (tab, label) = bottom_tab_defs[i]
-    let class_name = if model.bottom_tab == tab { "tab active" } else { "tab" }
+  for i, pair in bottom_tab_defs {
+    let (tab, label) = pair
     buttons.push(
       @html.button(
-        class=class_name,
+        class=@ui.bottom_tab_class(model.bottom_tab == tab),
         // `dispatch` receives the *target* index, which for keyboard nav differs
         // from this button's `i` (e.g. ArrowRight on tab `i` fires `i + 1`). Re-
         // index `bottom_tab_defs[j]` — do NOT close over the loop's `tab`, or
@@ -362,7 +361,7 @@ fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
     )
   }
   @html.div(
-    class="bottom-tabs",
+    class=bottom_tabs_class,
     attrs=@tabs.tablist_attrs(label="Bottom panel sections"),
     buttons,
   )

--- a/examples/ideal/main/view_bottom_classes.mbt
+++ b/examples/ideal/main/view_bottom_classes.mbt
@@ -1,0 +1,5 @@
+///|
+// Tailwind utility bundles for the bottom-panel tab strip container.
+// Button chrome lives in `main/ui/button.mbt`; this file owns only the
+// bottom-tabs layout hook.
+let bottom_tabs_class = "bottom-tabs flex px-canopy-md gap-canopy-xs h-[36px] items-center border-b border-solid border-canopy-border max-[768px]:h-auto max-[768px]:min-h-[44px]"

--- a/examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts
+++ b/examples/ideal/web/e2e/bottom-tabs-keyboard.spec.ts
@@ -100,3 +100,107 @@ test.describe('Bottom Panel Tabs — keyboard navigation', () => {
     expect(labelledby).toBe(await crdtTab.getAttribute('id'));
   });
 });
+
+test.describe('Bottom Panel Tabs — Tailwind chrome', () => {
+  test('Tailwind-owned bottom tab strip styles desktop active/inactive and hover', async ({
+    page,
+  }) => {
+    await openBottomTabs(page);
+    await page.getByRole('tab', { name: 'Problems' }).click();
+
+    const styles = await page.evaluate(() => {
+      const byText = (label: string) =>
+        Array.from(document.querySelectorAll<HTMLElement>('.bottom-tabs .tab')).find(
+          (el) => el.textContent?.trim() === label,
+        );
+      const strip = document.querySelector<HTMLElement>('.bottom-tabs');
+      const active = byText('Problems');
+      const inactive = byText('Op Log');
+      if (!strip || !active || !inactive) return null;
+      const stripStyle = getComputedStyle(strip);
+      const activeStyle = getComputedStyle(active);
+      const inactiveStyle = getComputedStyle(inactive);
+      return {
+        stripDisplay: stripStyle.display,
+        stripAlignItems: stripStyle.alignItems,
+        stripHeight: stripStyle.height,
+        stripPaddingLeft: stripStyle.paddingLeft,
+        stripGap: stripStyle.gap,
+        stripBorder: stripStyle.borderBottomColor,
+        activeBackground: activeStyle.backgroundColor,
+        activeColor: activeStyle.color,
+        activeBorderColor: activeStyle.borderBottomColor,
+        activeBorderWidth: activeStyle.borderBottomWidth,
+        inactiveBackground: inactiveStyle.backgroundColor,
+        inactiveColor: inactiveStyle.color,
+        inactiveBorderColor: inactiveStyle.borderBottomColor,
+        inactiveMinHeight: inactiveStyle.minHeight,
+        inactivePaddingBottom: inactiveStyle.paddingBottom,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(styles?.stripDisplay).toBe('flex');
+    expect(styles?.stripAlignItems).toBe('center');
+    expect(styles?.stripHeight).toBe('36px');
+    expect(styles?.stripPaddingLeft).toBe('12px');
+    expect(styles?.stripGap).toBe('4px');
+    expect(styles?.stripBorder).toBe('rgb(40, 40, 62)');
+    expect(styles?.activeBackground).toBe('rgba(0, 0, 0, 0)');
+    expect(styles?.activeColor).toBe('rgb(176, 144, 224)');
+    expect(styles?.activeBorderColor).toBe('rgb(130, 80, 223)');
+    expect(styles?.activeBorderWidth).toBe('2px');
+    expect(styles?.inactiveBackground).toBe('rgba(0, 0, 0, 0)');
+    expect(styles?.inactiveColor).toBe('rgb(138, 138, 170)');
+    expect(styles?.inactiveBorderColor).toBe('rgba(0, 0, 0, 0)');
+    expect(styles?.inactiveMinHeight).toBe('32px');
+    expect(styles?.inactivePaddingBottom).toBe('6px');
+
+    const opLog = page.getByRole('tab', { name: 'Op Log' });
+    await opLog.hover();
+    await expect
+      .poll(async () => opLog.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .toBe('rgb(34, 34, 56)');
+    await expect
+      .poll(async () => opLog.evaluate((el) => getComputedStyle(el).color))
+      .toBe('rgb(184, 184, 208)');
+  });
+
+  test('Tailwind-owned bottom tab strip keeps mobile touch targets', async ({
+    page,
+  }) => {
+    await openBottomTabs(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    const styles = await page.evaluate(() => {
+      const strip = document.querySelector<HTMLElement>('.bottom-tabs');
+      const tab = Array.from(
+        document.querySelectorAll<HTMLElement>('.bottom-tabs .tab'),
+      ).find((el) => el.textContent?.trim() === 'Problems');
+      if (!strip || !tab) return null;
+      const stripStyle = getComputedStyle(strip);
+      const tabStyle = getComputedStyle(tab);
+      const rect = tab.getBoundingClientRect();
+      return {
+        stripHeight: stripStyle.height,
+        stripMinHeight: stripStyle.minHeight,
+        tabMinHeight: tabStyle.minHeight,
+        tabMinWidth: tabStyle.minWidth,
+        tabPaddingTop: tabStyle.paddingTop,
+        tabPaddingBottom: tabStyle.paddingBottom,
+        tabHeight: rect.height,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(
+      Number.parseFloat(styles?.stripHeight ?? '0'),
+    ).toBeGreaterThanOrEqual(44);
+    expect(styles?.stripMinHeight).toBe('44px');
+    expect(styles?.tabMinHeight).toBe('44px');
+    expect(styles?.tabMinWidth).toBe('44px');
+    expect(styles?.tabPaddingTop).toBe('12px');
+    expect(styles?.tabPaddingBottom).toBe('10px');
+    expect(styles?.tabHeight ?? 0).toBeGreaterThanOrEqual(44);
+  });
+});

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -4,6 +4,7 @@
 /* Keep source detection as narrow as the migrated slice; expand per slice. */
 @source "../../main/view_actions_classes.mbt";
 @source "../../main/view_toolbar_classes.mbt";
+@source "../../main/view_bottom_classes.mbt";
 @source "../../main/ui/button.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
@@ -641,46 +642,6 @@ canopy-editor {
               grid-template-rows var(--duration-normal) var(--ease-out-quart);
 }
 
-.bottom-tabs {
-  display: flex;
-  padding: 0 var(--space-md);
-  gap: var(--space-xs);
-  height: 36px;
-  align-items: center;
-  border-bottom: 1px solid var(--canopy-border);
-}
-
-/* Bottom tabs use underline accent, not fill — lighter than toolbar tabs */
-.bottom-tabs .tab {
-  font-family: var(--canopy-font-ui);
-  font-size: var(--text-caption);
-  font-weight: var(--weight-medium);
-  padding: var(--space-sm) var(--space-md);
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  cursor: pointer;
-  background: transparent;
-  color: var(--canopy-text-dim);
-  transition: background var(--duration-fast) var(--ease-out-quart),
-              color var(--duration-fast) var(--ease-out-quart);
-  min-height: 32px;
-  padding-bottom: calc(var(--space-sm) - 2px);
-}
-
-@media (hover: hover) {
-  .bottom-tabs .tab:hover {
-    background: var(--canopy-surface);
-    color: var(--canopy-text-secondary);
-  }
-}
-
-.bottom-tabs .tab.active {
-  background: transparent;
-  color: var(--canopy-accent-text);
-  border-bottom-color: var(--canopy-accent);
-}
-
 .bottom-content {
   padding: var(--space-md) var(--space-lg);
   overflow-y: auto;
@@ -1069,20 +1030,7 @@ canopy-editor {
 
   /* Toolbar compact/scrollable rules moved to Tailwind-owned recipes. */
 
-  /* Touch targets: 44px minimum per WCAG 2.5.8 */
-  .bottom-tabs .tab {
-    min-height: 44px;
-    min-width: 44px;
-    padding: var(--space-md) var(--space-md);
-    padding-bottom: calc(var(--space-md) - 2px);
-  }
-
-  /* Drop the desktop's fixed 36px height on the bottom tab strip so its
-     children's 44px touch targets aren't clipped by an undersized parent. */
-  .bottom-tabs {
-    height: auto;
-    min-height: 44px;
-  }
+  /* Bottom-tab touch target rules moved to Tailwind-owned recipes. */
 
   .panel-resize-handle { display: none; }
 


### PR DESCRIPTION
## Summary

- Migrates the Ideal bottom tab strip chrome to Tailwind-owned class recipes while preserving semantic hooks (`bottom-tabs`, `tab`, `tab active`).
- Reuses the Ideal-local button recipe layer for bottom tab button chrome and adds a narrow bottom strip class source file.
- Removes the legacy `.bottom-tabs` CSS declaration owner and adds computed-style Playwright coverage for desktop, hover, and mobile touch targets.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `button_chrome_base_class` | `examples/ideal/main/ui/button.mbt` | Yes | Shared font/cursor/transition chrome for Ideal button-like controls. |
| `toolbar_tab_class(active)` | `examples/ideal/main/ui/button.mbt` | No | Toolbar tabs use filled active chrome; bottom tabs intentionally use underline accent chrome. |
| `toolbar_button_recipe_class(tone)` | `examples/ideal/main/ui/button.mbt` | Partially | Reused its shared base via `button_chrome_base_class`, but bottom tabs need distinct border/underline sizing. |

New helpers added (if any):

- `bottom_tab_class(active)` — public semantic class recipe for bottom tab hooks + underline chrome; avoids scattering Tailwind strings in `view_bottom.mbt`.
- `bottom_tabs_class` — slice-local static class bundle for the bottom tab strip container.

No CVA-inspired helper was added; this slice did not introduce enough repetition to justify it.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/ideal/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
moon check --deny-warn
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/ideal/web && npm run build
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/bottom-tabs-keyboard.spec.ts --reporter=line
git diff --check
```

Build note: Ideal CSS artifact is `28.73 kB` / gzip `5.88 kB` after this slice.
