### PR TITLE
Migrate Ideal panel chrome to Tailwind

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -892,10 +892,12 @@ fn view(dispatch : Emit[Msg], model : Model) -> Html {
         [text("")],
       ),
       div(class=outline_class, attrs=outline_attrs, [
-        div(class="panel-header", [span(class="panel-label", [text("OUTLINE")])]),
+        div(class=panel_header_class(), [
+          span(class=panel_label_class(), [text("OUTLINE")]),
+        ]),
         view_outline_content(dispatch, model),
-        div(class="panel-section", [
-          span(class="panel-label", [text("PEERS")]),
+        div(class=panel_section_class(), [
+          span(class=panel_label_class(), [text("PEERS")]),
           view_peer_status(model),
         ]),
         view_outline_resize_handle(dispatch, model.workspace),

--- a/examples/ideal/main/view_inspector.mbt
+++ b/examples/ideal/main/view_inspector.mbt
@@ -79,7 +79,7 @@ fn view_node_details(
 ) -> Html {
   let kind_tag = @lambda_proj.term_kind_tag(node.kind)
   let items : Array[Html] = [
-    span(class="panel-label", [text("NODE")]),
+    span(class=inspector_label_class(), [text("NODE")]),
     div(class="inspector-row", [
       span(class="inspector-key", [text("Kind")]),
       span(class="inspector-value", [text(kind_tag)]),
@@ -127,14 +127,14 @@ fn view_node_details(
       )
     }
   }
-  div(class="panel-section", items)
+  div(class=inspector_section_class(), items)
 }
 
 ///|
 /// Render the actions section of the inspector.
 fn view_actions(dispatch : Emit[Msg], node_id_str : String) -> Html {
-  div(class="panel-section", [
-    span(class="panel-label", [text("ACTIONS")]),
+  div(class=inspector_section_class(), [
+    span(class=inspector_label_class(), [text("ACTIONS")]),
     div(class="inspector-actions", [
       button(
         class=@ui.action_button_class(),
@@ -157,8 +157,8 @@ fn view_actions(dispatch : Emit[Msg], node_id_str : String) -> Html {
 ///|
 /// Render the CRDT info section of the inspector.
 fn view_crdt_info(model : Model) -> Html {
-  div(class="panel-section", [
-    span(class="panel-label", [text("CRDT")]),
+  div(class=inspector_section_class(), [
+    span(class=inspector_label_class(), [text("CRDT")]),
     div(class="inspector-row", [
       span(class="inspector-key", [text("Agent")]),
       span(class="inspector-value", [text("local")]),
@@ -200,7 +200,9 @@ fn view_inspector_content(dispatch : Emit[Msg], model : Model) -> Html {
       ])
   }
   @html.fragment([
-    div(class="panel-header", [span(class="panel-label", [text("INSPECTOR")])]),
+    div(class=panel_header_class(), [
+      span(class=inspector_label_class(), [text("INSPECTOR")]),
+    ]),
     node_section,
     view_crdt_info(model),
   ])

--- a/examples/ideal/main/view_panel_classes.mbt
+++ b/examples/ideal/main/view_panel_classes.mbt
@@ -1,0 +1,34 @@
+///|
+// Tailwind utility bundles for light-DOM panel header/section chrome.
+// Keep semantic hooks as the first class tokens. Inspector helpers keep the
+// existing generic `panel-*` hooks first while also exposing inspector-specific
+// hooks as stable tokens.
+let panel_label_chrome_class = "text-canopy-label font-semibold text-canopy-dim tracking-[0.1em] uppercase leading-[var(--leading-tight)]"
+
+///|
+let panel_section_chrome_class = "py-canopy-md px-canopy-lg border-t border-solid border-canopy-border mt-auto"
+
+///|
+fn panel_header_class() -> String {
+  "panel-header pt-canopy-lg px-canopy-lg pb-canopy-md"
+}
+
+///|
+fn panel_label_class() -> String {
+  "panel-label " + panel_label_chrome_class
+}
+
+///|
+fn panel_section_class() -> String {
+  "panel-section " + panel_section_chrome_class
+}
+
+///|
+fn inspector_label_class() -> String {
+  "panel-label inspector-label " + panel_label_chrome_class
+}
+
+///|
+fn inspector_section_class() -> String {
+  "panel-section inspector-section " + panel_section_chrome_class
+}

--- a/examples/ideal/web/e2e/panel-tailwind.spec.ts
+++ b/examples/ideal/web/e2e/panel-tailwind.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function waitForEditorReady(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+async function ensurePanelOpen(page: Page, name: 'Outline' | 'Inspector') {
+  const toggle = page.getByRole('button', { name });
+  if ((await toggle.getAttribute('aria-pressed')) !== 'true') {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+}
+
+test.describe('Ideal Tailwind panel recipes', () => {
+  test('Tailwind-owned panel header and section chrome styles desktop', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+
+    const styles = await page.evaluate(() => {
+      const outline = document.querySelector<HTMLElement>('.outline-panel');
+      const inspector = document.querySelector<HTMLElement>('.inspector-panel');
+      const outlineHeader = outline?.querySelector<HTMLElement>('.panel-header');
+      const outlineLabel = outlineHeader?.querySelector<HTMLElement>('.panel-label');
+      const outlineSection = outline?.querySelector<HTMLElement>('.panel-section');
+      const inspectorHeader = inspector?.querySelector<HTMLElement>('.panel-header');
+      const inspectorLabel = inspectorHeader?.querySelector<HTMLElement>('.inspector-label');
+      const inspectorSection = inspector?.querySelector<HTMLElement>('.inspector-section');
+      if (
+        !outlineHeader ||
+        !outlineLabel ||
+        !outlineSection ||
+        !inspectorHeader ||
+        !inspectorLabel ||
+        !inspectorSection
+      ) return null;
+
+      const outlineHeaderStyle = getComputedStyle(outlineHeader);
+      const outlineLabelStyle = getComputedStyle(outlineLabel);
+      const outlineSectionStyle = getComputedStyle(outlineSection);
+      const inspectorHeaderStyle = getComputedStyle(inspectorHeader);
+      const inspectorLabelStyle = getComputedStyle(inspectorLabel);
+      const inspectorSectionStyle = getComputedStyle(inspectorSection);
+      return {
+        outlineHeaderPaddingTop: outlineHeaderStyle.paddingTop,
+        outlineHeaderPaddingRight: outlineHeaderStyle.paddingRight,
+        outlineHeaderPaddingBottom: outlineHeaderStyle.paddingBottom,
+        outlineLabelFontSize: outlineLabelStyle.fontSize,
+        outlineLabelFontWeight: outlineLabelStyle.fontWeight,
+        outlineLabelColor: outlineLabelStyle.color,
+        outlineLabelLetterSpacing: outlineLabelStyle.letterSpacing,
+        outlineLabelTextTransform: outlineLabelStyle.textTransform,
+        outlineSectionPaddingTop: outlineSectionStyle.paddingTop,
+        outlineSectionPaddingLeft: outlineSectionStyle.paddingLeft,
+        outlineSectionBorderWidth: outlineSectionStyle.borderTopWidth,
+        outlineSectionBorderColor: outlineSectionStyle.borderTopColor,
+        inspectorHeaderPaddingTop: inspectorHeaderStyle.paddingTop,
+        inspectorLabelHasPanelHook: inspectorLabel.classList.contains('panel-label'),
+        inspectorLabelColor: inspectorLabelStyle.color,
+        inspectorSectionHasPanelHook: inspectorSection.classList.contains('panel-section'),
+        inspectorSectionPaddingTop: inspectorSectionStyle.paddingTop,
+        inspectorSectionBorderWidth: inspectorSectionStyle.borderTopWidth,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(styles?.outlineHeaderPaddingTop).toBe('16px');
+    expect(styles?.outlineHeaderPaddingRight).toBe('16px');
+    expect(styles?.outlineHeaderPaddingBottom).toBe('12px');
+    expect(styles?.outlineLabelFontSize).toBe('11px');
+    expect(styles?.outlineLabelFontWeight).toBe('600');
+    expect(styles?.outlineLabelColor).toBe('rgb(138, 138, 170)');
+    expect(Number.parseFloat(styles?.outlineLabelLetterSpacing ?? '0')).toBeCloseTo(1.1, 1);
+    expect(styles?.outlineLabelTextTransform).toBe('uppercase');
+    expect(styles?.outlineSectionPaddingTop).toBe('12px');
+    expect(styles?.outlineSectionPaddingLeft).toBe('16px');
+    expect(styles?.outlineSectionBorderWidth).toBe('1px');
+    expect(styles?.outlineSectionBorderColor).toBe('rgb(40, 40, 62)');
+    expect(styles?.inspectorHeaderPaddingTop).toBe('16px');
+    expect(styles?.inspectorLabelHasPanelHook).toBe(true);
+    expect(styles?.inspectorLabelColor).toBe('rgb(138, 138, 170)');
+    expect(styles?.inspectorSectionHasPanelHook).toBe(true);
+    expect(styles?.inspectorSectionPaddingTop).toBe('12px');
+    expect(styles?.inspectorSectionBorderWidth).toBe('1px');
+  });
+
+  test('Tailwind-owned panel chrome is present in mobile drawer state', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await ensurePanelOpen(page, 'Outline');
+    await ensurePanelOpen(page, 'Inspector');
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    const styles = await page.evaluate(() => {
+      const outline = document.querySelector<HTMLElement>('.outline-panel');
+      const inspector = document.querySelector<HTMLElement>('.inspector-panel');
+      const outlineHeader = outline?.querySelector<HTMLElement>('.panel-header');
+      const outlineSection = outline?.querySelector<HTMLElement>('.panel-section');
+      const inspectorLabel = inspector?.querySelector<HTMLElement>('.inspector-label');
+      const inspectorSection = inspector?.querySelector<HTMLElement>('.inspector-section');
+      if (!outline || !inspector || !outlineHeader || !outlineSection || !inspectorLabel || !inspectorSection) {
+        return null;
+      }
+      const outlineStyle = getComputedStyle(outline);
+      const inspectorStyle = getComputedStyle(inspector);
+      const outlineHeaderStyle = getComputedStyle(outlineHeader);
+      const outlineSectionStyle = getComputedStyle(outlineSection);
+      const inspectorLabelStyle = getComputedStyle(inspectorLabel);
+      const inspectorSectionStyle = getComputedStyle(inspectorSection);
+      return {
+        outlineClassName: outline.className,
+        inspectorClassName: inspector.className,
+        outlinePosition: outlineStyle.position,
+        inspectorPosition: inspectorStyle.position,
+        outlineWidth: outlineStyle.width,
+        inspectorWidth: inspectorStyle.width,
+        outlineHeaderPaddingTop: outlineHeaderStyle.paddingTop,
+        outlineSectionPaddingLeft: outlineSectionStyle.paddingLeft,
+        outlineSectionBorderColor: outlineSectionStyle.borderTopColor,
+        inspectorLabelFontSize: inspectorLabelStyle.fontSize,
+        inspectorLabelTextTransform: inspectorLabelStyle.textTransform,
+        inspectorSectionPaddingTop: inspectorSectionStyle.paddingTop,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(styles?.outlineClassName).toContain('panel-visible');
+    expect(styles?.inspectorClassName).toContain('panel-visible');
+    expect(styles?.outlinePosition).toBe('fixed');
+    expect(styles?.inspectorPosition).toBe('fixed');
+    expect(styles?.outlineWidth).toBe('390px');
+    expect(styles?.inspectorWidth).toBe('390px');
+    expect(styles?.outlineHeaderPaddingTop).toBe('16px');
+    expect(styles?.outlineSectionPaddingLeft).toBe('16px');
+    expect(styles?.outlineSectionBorderColor).toBe('rgb(40, 40, 62)');
+    expect(styles?.inspectorLabelFontSize).toBe('11px');
+    expect(styles?.inspectorLabelTextTransform).toBe('uppercase');
+    expect(styles?.inspectorSectionPaddingTop).toBe('12px');
+  });
+});

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -5,6 +5,7 @@
 @source "../../main/view_actions_classes.mbt";
 @source "../../main/view_toolbar_classes.mbt";
 @source "../../main/view_bottom_classes.mbt";
+@source "../../main/view_panel_classes.mbt";
 @source "../../main/ui/button.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
@@ -233,24 +234,8 @@ button:focus-visible, .action-btn:focus-visible,
               width 0ms var(--duration-normal);
 }
 
-.panel-header {
-  padding: var(--space-lg) var(--space-lg) var(--space-md);
-}
-
-.panel-label {
-  font-size: var(--text-label);
-  font-weight: var(--weight-semibold);
-  color: var(--canopy-text-dim);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  line-height: var(--leading-tight);
-}
-
-.panel-section {
-  padding: var(--space-md) var(--space-lg);
-  border-top: 1px solid var(--canopy-border);
-  margin-top: auto;
-}
+/* Panel header/label/section chrome is Tailwind-owned via
+   examples/ideal/main/view_panel_classes.mbt. */
 
 .panel-resize-handle {
   position: absolute;
@@ -536,23 +521,8 @@ canopy-editor {
               width 0ms var(--duration-normal);
 }
 
-.inspector-section {
-  padding: var(--space-lg);
-}
-
-.inspector-section + .inspector-section {
-  border-top: 1px solid var(--canopy-border);
-}
-
-.inspector-label {
-  font-size: var(--text-label);
-  font-weight: var(--weight-semibold);
-  color: var(--canopy-text-dim);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  line-height: var(--leading-tight);
-  margin-bottom: var(--space-md);
-}
+/* Inspector section/label chrome is Tailwind-owned via
+   examples/ideal/main/view_panel_classes.mbt. */
 
 .inspector-row {
   display: flex;
@@ -1145,11 +1115,7 @@ canopy-editor {
     font-size: var(--text-small);
   }
 
-  /* ── Peer section at bottom of outline ──────────────────── */
-
-  .panel-section {
-    padding: var(--space-md) var(--space-lg);
-  }
+  /* Panel section chrome is Tailwind-owned via main/view_panel_classes.mbt. */
 }
 
 /* Small phones: further compact */


### PR DESCRIPTION
## Summary

- Migrate light-DOM panel header/label/section chrome to Tailwind utilities via a private Ideal slice-local class bundle.
- Preserve semantic hooks (`panel-header`, `panel-label`, `panel-section`, `inspector-label`, `inspector-section`) while removing legacy CSS declarations that Tailwind now owns.
- Add computed-style Playwright coverage for desktop and mobile drawer panel states.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@ui.toolbar_button_class` / related button helpers | `examples/ideal/main/ui/button.mbt` | No | Button/tab/action chrome only; panel section/header chrome has different semantics. |
| `toolbar_class`, `bottom_tabs_class`, action overlay bundles | `examples/ideal/main/view_*_classes.mbt` | Pattern reused | These are slice-local static Tailwind bundles; the panel slice follows the same private-file pattern. |
| Legacy `.panel-*` / `.inspector-*` CSS rules | `examples/ideal/web/styles/editor.css` | No | Replaced as visual declaration owners to avoid duplicate CSS/Tailwind ownership. |

New helpers added (if any):

- `panel_header_class`, `panel_label_class`, `panel_section_class`, `inspector_label_class`, `inspector_section_class` in `examples/ideal/main/view_panel_classes.mbt`.
  - These are private to the Ideal main package and centralize repeated panel chrome while keeping semantic hooks first.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (no `.mbti` diff)
- [x] JS rebuild run if web is affected (`cd examples/ideal/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon info
cd examples/ideal/web && npm run build
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 npx playwright test e2e/panel-tailwind.spec.ts e2e/toolbar-tailwind.spec.ts e2e/bottom-tabs-keyboard.spec.ts --reporter=line
```
