### PR TITLE
Migrate Ideal inspector detail chrome to Tailwind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Check moon update is retry-wrapped
         run: ./scripts/check-moon-update-wrapped.sh
 
+      - name: Test moon update retry wrapper
+        run: ./scripts/test-moon-update-wrapper.sh
+
   test-main:
     name: Test Main Module
     runs-on: ubuntu-latest

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -22,7 +22,7 @@ The main gating workflow. Job names match the file:
 
 | Job | What it runs |
 |-----|--------------|
-| `dep-check` | `./scripts/check-deps.sh` |
+| `dep-check` | `./scripts/check-deps.sh`, `./scripts/check-moon-update-wrapped.sh`, `./scripts/test-moon-update-wrapper.sh` |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check .`, `./scripts/run-moon-module.sh test .`, `moon build --release` |
 | `test-submodules` | Matrix over `event-graph-walker`, `loom/loom`, `svg-dsl`, `graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `examples/ideal`, `examples/block-editor`, `examples/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |

--- a/examples/ideal/main/view_inspector.mbt
+++ b/examples/ideal/main/view_inspector.mbt
@@ -65,9 +65,9 @@ fn children_count(node : @proj.InteractiveTreeNode[@ast.Term]) -> Int {
 ///|
 /// Key-value row for the inspector panel.
 fn inspector_row(key : String, value : String) -> Html {
-  div(class="inspector-row", [
-    span(class="inspector-key", [text(key)]),
-    span(class="inspector-value", [text(value)]),
+  div(class=inspector_row_class, [
+    span(class=inspector_key_class, [text(key)]),
+    span(class=inspector_value_class, [text(value)]),
   ])
 }
 
@@ -80,10 +80,7 @@ fn view_node_details(
   let kind_tag = @lambda_proj.term_kind_tag(node.kind)
   let items : Array[Html] = [
     span(class=inspector_label_class(), [text("NODE")]),
-    div(class="inspector-row", [
-      span(class="inspector-key", [text("Kind")]),
-      span(class="inspector-value", [text(kind_tag)]),
-    ]),
+    inspector_row("Kind", kind_tag),
     inspector_row("Label", node.label),
     inspector_row("Children", children_count(node).to_string()),
     inspector_row("ID", node_id_to_string(node.id)),
@@ -103,7 +100,7 @@ fn view_node_details(
       } else {
         slice
       }
-      items.push(div(class="source-preview", [text(preview)]))
+      items.push(div(class=source_preview_class, [text(preview)]))
     }
   }
   let token_spans = model.editor.get_source_map().get_all_token_spans(node.id)
@@ -119,10 +116,12 @@ fn view_node_details(
         ""
       }
       items.push(
-        div(class="token-span-row", [
-          span(class="token-span-role", [text(role)]),
-          span(class="token-span-range", [text("\{span_start}..\{span_end}")]),
-          span(class="token-span-text", [text(span_text)]),
+        div(class=token_span_row_class, [
+          span(class=token_span_role_class, [text(role)]),
+          span(class=token_span_range_class, [
+            text("\{span_start}..\{span_end}"),
+          ]),
+          span(class=token_span_text_class, [text(span_text)]),
         ]),
       )
     }
@@ -159,20 +158,9 @@ fn view_actions(dispatch : Emit[Msg], node_id_str : String) -> Html {
 fn view_crdt_info(model : Model) -> Html {
   div(class=inspector_section_class(), [
     span(class=inspector_label_class(), [text("CRDT")]),
-    div(class="inspector-row", [
-      span(class="inspector-key", [text("Agent")]),
-      span(class="inspector-value", [text("local")]),
-    ]),
-    div(class="inspector-row", [
-      span(class="inspector-key", [text("Timestamp")]),
-      span(class="inspector-value", [text(model.next_timestamp.to_string())]),
-    ]),
-    div(class="inspector-row", [
-      span(class="inspector-key", [text("Text length")]),
-      span(class="inspector-value", [
-        text(model.editor.get_text().length().to_string()),
-      ]),
-    ]),
+    inspector_row("Agent", "local"),
+    inspector_row("Timestamp", model.next_timestamp.to_string()),
+    inspector_row("Text length", model.editor.get_text().length().to_string()),
   ])
 }
 

--- a/examples/ideal/main/view_inspector_classes.mbt
+++ b/examples/ideal/main/view_inspector_classes.mbt
@@ -1,0 +1,33 @@
+///|
+// Tailwind utility bundles for light-DOM inspector detail chrome.
+// Keep semantic hooks as the first class token; panel header/section chrome
+// remains owned by `view_panel_classes.mbt`.
+let inspector_detail_row_layout_class = "flex gap-canopy-sm leading-[var(--leading-normal)]"
+
+///|
+let inspector_row_class : String = "inspector-row " +
+  inspector_detail_row_layout_class +
+  " py-canopy-xs px-0"
+
+///|
+let inspector_key_class = "inspector-key text-canopy-small font-normal text-canopy-muted w-[76px] shrink-0 whitespace-nowrap"
+
+///|
+let inspector_value_class = "inspector-value text-canopy-small font-normal text-canopy-fg font-canopy-mono tracking-[-0.01em] tabular-nums"
+
+///|
+let source_preview_class = "source-preview bg-canopy-surface rounded-canopy-sm py-canopy-sm px-canopy-md mt-canopy-sm font-canopy-mono text-canopy-caption leading-[var(--leading-normal)] text-canopy-fg whitespace-pre overflow-x-auto max-h-[4.5em] overflow-y-auto"
+
+///|
+let token_span_row_class : String = "token-span-row " +
+  inspector_detail_row_layout_class +
+  " py-[2px] px-0 font-canopy-mono text-canopy-caption"
+
+///|
+let token_span_role_class = "token-span-role text-canopy-muted min-w-[52px] shrink-0"
+
+///|
+let token_span_range_class = "token-span-range text-canopy-dim min-w-[44px] shrink-0 tabular-nums"
+
+///|
+let token_span_text_class = "token-span-text text-canopy-identifier"

--- a/examples/ideal/web/e2e/inspector-tailwind.spec.ts
+++ b/examples/ideal/web/e2e/inspector-tailwind.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function waitForEditorReady(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+async function selectNodeWithInspectorDetails(page: Page) {
+  await page.getByRole('button', { name: 'Basics' }).click();
+
+  const firstRow = page.locator('.outline-panel .tree-row').first();
+  await expect(firstRow).toBeVisible();
+  await firstRow.click();
+  await expect(page.locator('.inspector-panel .source-preview')).toBeVisible();
+  await expect(
+    page.locator('.inspector-panel .token-span-row').first(),
+  ).toBeVisible();
+}
+
+async function readInspectorDetailStyles(page: Page) {
+  return page.evaluate(() => {
+    const inspector = document.querySelector<HTMLElement>('.inspector-panel');
+    const row = inspector?.querySelector<HTMLElement>('.inspector-row');
+    const key = row?.querySelector<HTMLElement>('.inspector-key');
+    const value = row?.querySelector<HTMLElement>('.inspector-value');
+    const preview = inspector?.querySelector<HTMLElement>('.source-preview');
+    const tokenRow = inspector?.querySelector<HTMLElement>('.token-span-row');
+    const tokenRole = tokenRow?.querySelector<HTMLElement>('.token-span-role');
+    const tokenRange = tokenRow?.querySelector<HTMLElement>('.token-span-range');
+    const tokenText = tokenRow?.querySelector<HTMLElement>('.token-span-text');
+    if (
+      !row ||
+      !key ||
+      !value ||
+      !preview ||
+      !tokenRow ||
+      !tokenRole ||
+      !tokenRange ||
+      !tokenText
+    ) return null;
+
+    const rowStyle = getComputedStyle(row);
+    const keyStyle = getComputedStyle(key);
+    const valueStyle = getComputedStyle(value);
+    const previewStyle = getComputedStyle(preview);
+    const tokenRowStyle = getComputedStyle(tokenRow);
+    const tokenRoleStyle = getComputedStyle(tokenRole);
+    const tokenRangeStyle = getComputedStyle(tokenRange);
+    const tokenTextStyle = getComputedStyle(tokenText);
+    return {
+      rowClassName: row.className,
+      rowDisplay: rowStyle.display,
+      rowGap: rowStyle.gap,
+      rowPaddingTop: rowStyle.paddingTop,
+      keyFontSize: keyStyle.fontSize,
+      keyFontWeight: keyStyle.fontWeight,
+      keyColor: keyStyle.color,
+      keyWidth: keyStyle.width,
+      keyFlexShrink: keyStyle.flexShrink,
+      keyWhiteSpace: keyStyle.whiteSpace,
+      valueFontSize: valueStyle.fontSize,
+      valueColor: valueStyle.color,
+      valueFontFamily: valueStyle.fontFamily,
+      valueFontVariantNumeric: valueStyle.fontVariantNumeric,
+      valueLetterSpacing: valueStyle.letterSpacing,
+      previewBackground: previewStyle.backgroundColor,
+      previewRadius: previewStyle.borderTopLeftRadius,
+      previewPaddingTop: previewStyle.paddingTop,
+      previewPaddingLeft: previewStyle.paddingLeft,
+      previewMarginTop: previewStyle.marginTop,
+      previewFontSize: previewStyle.fontSize,
+      previewWhiteSpace: previewStyle.whiteSpace,
+      previewOverflowX: previewStyle.overflowX,
+      previewOverflowY: previewStyle.overflowY,
+      tokenRowClassName: tokenRow.className,
+      tokenRowDisplay: tokenRowStyle.display,
+      tokenRowGap: tokenRowStyle.gap,
+      tokenRowPaddingTop: tokenRowStyle.paddingTop,
+      tokenRowFontSize: tokenRowStyle.fontSize,
+      tokenRowFontFamily: tokenRowStyle.fontFamily,
+      tokenRoleColor: tokenRoleStyle.color,
+      tokenRoleMinWidth: tokenRoleStyle.minWidth,
+      tokenRoleFlexShrink: tokenRoleStyle.flexShrink,
+      tokenRangeColor: tokenRangeStyle.color,
+      tokenRangeMinWidth: tokenRangeStyle.minWidth,
+      tokenRangeFontVariantNumeric: tokenRangeStyle.fontVariantNumeric,
+      tokenTextColor: tokenTextStyle.color,
+    };
+  });
+}
+
+test.describe('Ideal Tailwind inspector detail class bundles', () => {
+  test('Tailwind-owned inspector row/source/token chrome styles desktop', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await selectNodeWithInspectorDetails(page);
+
+    const styles = await readInspectorDetailStyles(page);
+
+    expect(styles).not.toBeNull();
+    expect(styles?.rowClassName).toMatch(/^inspector-row\b/);
+    expect(styles?.rowDisplay).toBe('flex');
+    expect(styles?.rowGap).toBe('8px');
+    expect(styles?.rowPaddingTop).toBe('4px');
+    expect(styles?.keyFontSize).toBe('14px');
+    expect(styles?.keyFontWeight).toBe('400');
+    expect(styles?.keyColor).toBe('rgb(136, 136, 168)');
+    expect(styles?.keyWidth).toBe('76px');
+    expect(styles?.keyFlexShrink).toBe('0');
+    expect(styles?.keyWhiteSpace).toBe('nowrap');
+    expect(styles?.valueFontSize).toBe('14px');
+    expect(styles?.valueColor).toBe('rgb(228, 228, 240)');
+    expect(styles?.valueFontFamily).toContain('Iosevka');
+    expect(styles?.valueFontVariantNumeric).toBe('tabular-nums');
+    expect(Number.parseFloat(styles?.valueLetterSpacing ?? '0')).toBeCloseTo(
+      -0.14,
+      2,
+    );
+    expect(styles?.previewBackground).toBe('rgb(34, 34, 56)');
+    expect(styles?.previewRadius).toBe('4px');
+    expect(styles?.previewPaddingTop).toBe('8px');
+    expect(styles?.previewPaddingLeft).toBe('12px');
+    expect(styles?.previewMarginTop).toBe('8px');
+    expect(styles?.previewFontSize).toBe('13px');
+    expect(styles?.previewWhiteSpace).toBe('pre');
+    expect(styles?.previewOverflowX).toBe('auto');
+    expect(styles?.previewOverflowY).toBe('auto');
+    expect(styles?.tokenRowClassName).toMatch(/^token-span-row\b/);
+    expect(styles?.tokenRowDisplay).toBe('flex');
+    expect(styles?.tokenRowGap).toBe('8px');
+    expect(styles?.tokenRowPaddingTop).toBe('2px');
+    expect(styles?.tokenRowFontSize).toBe('13px');
+    expect(styles?.tokenRowFontFamily).toContain('Iosevka');
+    expect(styles?.tokenRoleColor).toBe('rgb(136, 136, 168)');
+    expect(styles?.tokenRoleMinWidth).toBe('52px');
+    expect(styles?.tokenRoleFlexShrink).toBe('0');
+    expect(styles?.tokenRangeColor).toBe('rgb(138, 138, 170)');
+    expect(styles?.tokenRangeMinWidth).toBe('44px');
+    expect(styles?.tokenRangeFontVariantNumeric).toBe('tabular-nums');
+    expect(styles?.tokenTextColor).toBe('rgb(130, 170, 255)');
+  });
+});

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -6,6 +6,7 @@
 @source "../../main/view_toolbar_classes.mbt";
 @source "../../main/view_bottom_classes.mbt";
 @source "../../main/view_panel_classes.mbt";
+@source "../../main/view_inspector_classes.mbt";
 @source "../../main/ui/button.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
@@ -25,6 +26,7 @@
   --color-canopy-accent-hover: var(--canopy-accent-hover);
   --color-canopy-accent-text: var(--canopy-accent-text);
   --color-canopy-accent-border: var(--canopy-accent-border);
+  --color-canopy-identifier: var(--canopy-identifier);
   --color-canopy-error-text: var(--canopy-error-text);
   --color-canopy-error-bg: var(--canopy-error-bg);
   --color-canopy-error-border: var(--canopy-error-border);
@@ -523,31 +525,8 @@ canopy-editor {
 
 /* Inspector section/label chrome is Tailwind-owned via
    examples/ideal/main/view_panel_classes.mbt. */
-
-.inspector-row {
-  display: flex;
-  gap: var(--space-sm);
-  padding: var(--space-xs) 0;
-  line-height: var(--leading-normal);
-}
-
-.inspector-key {
-  font-size: var(--text-small);
-  font-weight: var(--weight-regular);
-  color: var(--canopy-muted);
-  width: 76px;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.inspector-value {
-  font-size: var(--text-small);
-  font-weight: var(--weight-regular);
-  color: var(--canopy-fg);
-  font-family: var(--canopy-font-mono);
-  letter-spacing: -0.01em;
-  font-variant-numeric: tabular-nums;
-}
+/* Inspector row/source/token detail chrome is Tailwind-owned via
+   examples/ideal/main/view_inspector_classes.mbt. */
 
 .inspector-actions {
   display: flex;
@@ -556,47 +535,6 @@ canopy-editor {
 }
 
 /* Inspector action button chrome is Tailwind-owned by main/ui/button.mbt. */
-
-.source-preview {
-  background: var(--canopy-surface);
-  border-radius: var(--radius-sm);
-  padding: var(--space-sm) var(--space-md);
-  margin-top: var(--space-sm);
-  font-family: var(--canopy-font-mono);
-  font-size: var(--text-caption);
-  line-height: var(--leading-normal);
-  color: var(--canopy-fg);
-  white-space: pre;
-  overflow-x: auto;
-  max-height: 4.5em;
-  overflow-y: auto;
-}
-
-.token-span-row {
-  display: flex;
-  gap: var(--space-sm);
-  padding: 2px 0;
-  line-height: var(--leading-normal);
-  font-family: var(--canopy-font-mono);
-  font-size: var(--text-caption);
-}
-
-.token-span-role {
-  color: var(--canopy-muted);
-  min-width: 52px;
-  flex-shrink: 0;
-}
-
-.token-span-range {
-  color: var(--canopy-text-dim);
-  min-width: 44px;
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
-}
-
-.token-span-text {
-  color: var(--canopy-identifier);
-}
 
 /* ── Bottom Panel ───────────────────────────────────────── */
 

--- a/scripts/moon-update.sh
+++ b/scripts/moon-update.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-# Run `moon update` with bounded retries for the transient mooncakes CloudFront
-# CDN flake (issue #467): the CDN intermittently returns HTTP 403 for
-# symbols.zip during registry/symbol resolution. Identical re-runs always clear
-# it, so a small in-job retry auto-recovers without a manual "re-run failed
-# jobs".
+# Run `moon update` with bounded retries for transient mooncakes registry/CDN
+# flakes (issue #467): the CDN intermittently returns HTTP 403 for symbols.zip,
+# and registry-index clones sometimes fail with exit 128. Identical re-runs
+# clear these cases, so a small in-job retry auto-recovers without a manual
+# "re-run failed jobs".
 #
-# Discipline: only the known-transient CDN/network signature is retried. Any
-# other failure (a real toolchain or dependency error) exits immediately with
-# the original status, so a genuine break is never masked by retries.
+# Discipline: only known-transient registry/CDN/network signatures are retried.
+# Any other failure (a real toolchain or dependency error) exits immediately
+# with the original status, so a genuine break is never masked by retries.
 #
 # Runs `moon update` in the current working directory; callers cd into the
 # target module first (the registry it updates is global). Extra args are
@@ -37,12 +37,12 @@ if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] ||
 fi
 
 # Signatures that are unambiguously transient infrastructure noise, never a code
-# or dependency-spec error. Keyed on transient HTTP status semantics (the issue
-# #467 403, plus 429 / 5xx) and network-layer failures — deliberately NOT the
-# generic "client error" (which also covers a deterministic 404 missing package
-# or 401) nor a bare "symbols.zip". Matched case-insensitively against combined
-# stdout+stderr.
-TRANSIENT_RE='403 forbidden|429 too many requests|server error|connection (reset|refused|timed out)|could not resolve host|temporary failure in name resolution|network is unreachable|error sending request|operation timed out'
+# or dependency-spec error. Keyed on registry-index clone failures, transient
+# HTTP status semantics (the issue #467 403, plus 429 / 5xx), and network-layer
+# failures — deliberately NOT the generic "client error" (which also covers a
+# deterministic 404 missing package or 401) nor a bare "symbols.zip". Matched
+# case-insensitively against combined stdout+stderr.
+TRANSIENT_RE='failed to clone registry index|403 forbidden|429 too many requests|server error|connection (reset|refused|timed out)|could not resolve host|temporary failure in name resolution|network is unreachable|error sending request|operation timed out'
 
 # One tempfile for the whole run; `tee` truncates it each attempt. The trap
 # removes it on every exit path, including a signal kill mid-loop.
@@ -69,7 +69,7 @@ while :; do
   fi
 
   delay=$(( BASE_DELAY * attempt ))
-  echo "moon-update: transient CDN/network failure (exit ${status}); attempt ${attempt}/${MAX_ATTEMPTS}, retrying in ${delay}s..." >&2
+  echo "moon-update: transient registry/CDN/network failure (exit ${status}); attempt ${attempt}/${MAX_ATTEMPTS}, retrying in ${delay}s..." >&2
   sleep "$delay"
   attempt=$(( attempt + 1 ))
 done

--- a/scripts/test-moon-update-wrapper.sh
+++ b/scripts/test-moon-update-wrapper.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+
+cat > "$fake_bin/moon" <<'FAKE_MOON'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "update" ]; then
+  echo "fake moon: expected update subcommand" >&2
+  exit 2
+fi
+
+attempt=0
+if [ -f "$FAKE_MOON_ATTEMPTS_FILE" ]; then
+  attempt="$(cat "$FAKE_MOON_ATTEMPTS_FILE")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$FAKE_MOON_ATTEMPTS_FILE"
+
+case "$FAKE_MOON_SCENARIO" in
+  registry-clone-transient)
+    if [ "$attempt" -eq 1 ]; then
+      cat >&2 <<'LOG'
+Error: update failed
+
+Caused by:
+    0: failed to clone registry index
+    1: non-zero exit code: exit status: 128
+LOG
+      exit 255
+    fi
+    echo "fake moon: update succeeded"
+    ;;
+  deterministic-missing-package)
+    cat >&2 <<'LOG'
+Error: update failed
+
+Caused by:
+    0: package not found: moonbitlang/not-a-real-package
+    1: client error (404 Not Found)
+LOG
+    exit 255
+    ;;
+  *)
+    echo "fake moon: unknown scenario: $FAKE_MOON_SCENARIO" >&2
+    exit 2
+    ;;
+esac
+FAKE_MOON
+chmod +x "$fake_bin/moon"
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "error: $label: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+run_wrapper() {
+  local scenario="$1"
+  local attempts_file="$2"
+  local output_file="$3"
+
+  PATH="$fake_bin:$PATH" \
+    FAKE_MOON_SCENARIO="$scenario" \
+    FAKE_MOON_ATTEMPTS_FILE="$attempts_file" \
+    MOON_UPDATE_MAX_ATTEMPTS=3 \
+    MOON_UPDATE_RETRY_DELAY=0 \
+    "$root_dir/scripts/moon-update.sh" >"$output_file" 2>&1
+}
+
+transient_attempts="$tmp_dir/transient-attempts"
+transient_output="$tmp_dir/transient-output.log"
+run_wrapper registry-clone-transient "$transient_attempts" "$transient_output"
+assert_eq "$(cat "$transient_attempts")" "2" "transient registry clone should retry once before success"
+grep -q "transient registry/CDN/network failure" "$transient_output" || {
+  echo "error: transient retry message missing" >&2
+  cat "$transient_output" >&2
+  exit 1
+}
+
+missing_attempts="$tmp_dir/missing-attempts"
+missing_output="$tmp_dir/missing-output.log"
+if run_wrapper deterministic-missing-package "$missing_attempts" "$missing_output"; then
+  echo "error: deterministic missing package unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_eq "$(cat "$missing_attempts")" "1" "deterministic missing package should not retry"
+grep -q "not retrying" "$missing_output" || {
+  echo "error: deterministic failure did not report non-retry" >&2
+  cat "$missing_output" >&2
+  exit 1
+}
+
+echo "ok: moon-update retry wrapper retries registry clone flakes only"


### PR DESCRIPTION
## Summary

- Migrate light-DOM inspector detail chrome (`inspector-row`, `inspector-key`, `inspector-value`, `source-preview`, `token-span-*`) to a private Tailwind class bundle.
- Add narrow Tailwind source scanning for the new bundle and remove legacy CSS declaration owners for the migrated inspector detail styles.
- Add Playwright computed-style coverage for representative inspector rows, source preview, and token spans.
- Harden `moon update` CI retry handling for transient `failed to clone registry index` failures and add a regression script for the wrapper.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `inspector_row` | `examples/ideal/main/view_inspector.mbt` | Yes | Existing markup helper now applies the migrated class bundle for standard key/value rows. |
| `inspector_label_class` / `inspector_section_class` | `examples/ideal/main/view_panel_classes.mbt` | Yes | Kept as the owner for panel/section/label chrome; not expanded to row/source/token detail styles. |
| `@ui.action_button_class` / `@ui.action_button_danger_class` | `examples/ideal/main/ui/button.mbt` | Yes | Existing action button recipe remains the owner for inspector action buttons. |
| `scripts/moon-update.sh` | `scripts/moon-update.sh` | Yes | Existing bounded retry wrapper was extended instead of adding a second dependency-update path. |

New helpers added (if any):

- `examples/ideal/main/view_inspector_classes.mbt`: private slice-local Tailwind class bundle constants for inspector detail chrome. This does not duplicate panel or button recipes because it owns row/source/token detail styling only.
- `inspector_detail_row_layout_class`: private shared utility-fragment constant for the repeated row/token-row flex/gap/line-height bundle inside the same slice.
- `readInspectorDetailStyles(page)`: test-local Playwright helper to keep computed-style collection out of the assertion body.
- `scripts/test-moon-update-wrapper.sh`: CI regression script for the existing `moon-update.sh` wrapper; verifies registry clone flakes retry and deterministic missing-package errors do not.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run because web is affected (`cd examples/ideal/web && npm run build`)
- [x] Inspector detail computed-style Playwright coverage (`cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 npx playwright test e2e/inspector-tailwind.spec.ts --reporter=line`)
- [x] Moon update retry wrapper regression (`./scripts/test-moon-update-wrapper.sh`)
- [x] Bare `moon update` guard (`./scripts/check-moon-update-wrapped.sh`)
- [x] Dependency rules (`./scripts/check-deps.sh`)

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test
cd examples/ideal/web && npm run build
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 npx playwright test e2e/inspector-tailwind.spec.ts --reporter=line
./scripts/test-moon-update-wrapper.sh
./scripts/check-moon-update-wrapped.sh
./scripts/check-deps.sh
bash -n scripts/moon-update.sh scripts/test-moon-update-wrapper.sh scripts/check-moon-update-wrapped.sh
git diff --check
```

Built CSS size: `28,258` bytes before → `28,327` bytes after (`+69`).
