### PR TITLE
Migrate Ideal peer empty-state chrome to Tailwind

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -805,22 +805,18 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
 
 ///|
 fn view_peer_status(model : Model) -> Html {
-  let (dot_class, label, tone) : (String, String, @status.Tone) = match
-    model.sync_status {
-    Connected => ("peer-dot connected", "You (connected)", @status.Success)
-    Connecting => ("peer-dot connecting", "Connecting\u{2026}", @status.Info)
-    Offline =>
-      (
-        "peer-dot offline",
-        "Offline \u{2014} reconnecting\u{2026}",
-        @status.Info,
-      )
-    Error => ("peer-dot error", "Connection error", @status.Error)
+  let (label, tone) : (String, @status.Tone) = match model.sync_status {
+    Connected => ("You (connected)", @status.Success)
+    Connecting => ("Connecting\u{2026}", @status.Info)
+    Offline => ("Offline \u{2014} reconnecting\u{2026}", @status.Info)
+    Error => ("Connection error", @status.Error)
   }
-  div(class="peer-item", attrs=tone.attrs(), [
-    div(class=dot_class, attrs=@html.Attrs::build().aria_hidden("true"), [
-      text(""),
-    ]),
+  div(class=peer_item_class, attrs=tone.attrs(), [
+    div(
+      class=peer_dot_class(model.sync_status),
+      attrs=@html.Attrs::build().aria_hidden("true"),
+      [text("")],
+    ),
     span(class="peer-label", [text(label)]),
   ])
 }

--- a/examples/ideal/main/view_inspector.mbt
+++ b/examples/ideal/main/view_inspector.mbt
@@ -176,13 +176,13 @@ fn view_inspector_content(dispatch : Emit[Msg], model : Model) -> Html {
             view_node_details(node, model),
             view_actions(dispatch, sel_id),
           ])
-        None => p(class="no-tree-note", "No matching node")
+        None => p(class=no_tree_note_class, "No matching node")
       }
     }
     None =>
-      div(class="empty-state", [
+      div(class=empty_state_class, [
         p(
-          class="empty-state-text",
+          class=empty_state_text_class,
           "Click a node in the outline or editor to inspect it",
         ),
       ])

--- a/examples/ideal/main/view_outline.mbt
+++ b/examples/ideal/main/view_outline.mbt
@@ -239,7 +239,7 @@ fn view_outline_node(
           view_outline_node(dispatch, child, depth + 1, model, eval_annotations)
         })
       @proj.Elided(n) =>
-        [@html.p(class="no-tree-note", "\{n} hidden descendants")]
+        [@html.p(class=no_tree_note_class, "\{n} hidden descendants")]
     }
   }
   let all : Array[Html] = [row]
@@ -394,7 +394,7 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
         ),
         [view_outline_node(dispatch, root, 0, model, eval_annotations)],
       )
-    None => @html.p(class="no-tree-note", "No AST available")
+    None => @html.p(class=no_tree_note_class, "No AST available")
   }
 }
 

--- a/examples/ideal/main/view_peer_empty_state_classes.mbt
+++ b/examples/ideal/main/view_peer_empty_state_classes.mbt
@@ -1,0 +1,34 @@
+///|
+// Tailwind utility bundles for light-DOM peer status, no-tree note, and
+// empty-state chrome. Keep semantic hooks as the first class tokens;
+// Rabbita/status subscriptions own behavior and ARIA attributes.
+let no_tree_note_class = "no-tree-note text-canopy-small text-canopy-muted p-canopy-lg"
+
+///|
+let peer_item_class = "peer-item flex items-center gap-canopy-sm text-canopy-small text-canopy-secondary py-canopy-xs px-0"
+
+///|
+let peer_dot_chrome_class = "w-[7px] h-[7px] rounded-full shrink-0"
+
+///|
+fn peer_dot_state_class(status : SyncStatus) -> String {
+  match status {
+    Connected =>
+      "connected bg-canopy-string shadow-[0_0_6px_var(--canopy-string)] animate-[pulse-connected_2s_ease-in-out_infinite]"
+    Connecting =>
+      "connecting bg-canopy-number shadow-[0_0_4px_var(--canopy-number)] animate-[pulse-connecting_1s_ease-in-out_infinite]"
+    Offline => "offline bg-canopy-muted shadow-none opacity-60"
+    Error => "error bg-canopy-operator shadow-[0_0_6px_var(--canopy-operator)]"
+  }
+}
+
+///|
+fn peer_dot_class(status : SyncStatus) -> String {
+  "peer-dot " + peer_dot_state_class(status) + " " + peer_dot_chrome_class
+}
+
+///|
+let empty_state_class = "empty-state p-canopy-lg"
+
+///|
+let empty_state_text_class = "empty-state-text text-canopy-small text-canopy-dim leading-[var(--leading-relaxed)]"

--- a/examples/ideal/web/e2e/outline-peer-empty-tailwind.spec.ts
+++ b/examples/ideal/web/e2e/outline-peer-empty-tailwind.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function waitForEditorReady(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'Text' })).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+async function dispatchEditorEvent(
+  page: Page,
+  type: string,
+  detail: Record<string, string>,
+) {
+  await page.evaluate(({ type, detail }) => {
+    const editor = document.querySelector('#canopy-editor');
+    if (!editor) throw new Error('Canopy editor host is not mounted');
+    editor.dispatchEvent(new CustomEvent(type, {
+      detail,
+      bubbles: true,
+      composed: true,
+    }));
+  }, { type, detail });
+}
+
+async function readPeerStyles(page: Page, dotSelector: string) {
+  return page.evaluate((selector) => {
+    const item = document.querySelector<HTMLElement>('.peer-item');
+    const dot = document.querySelector<HTMLElement>(selector);
+    if (!item || !dot) return null;
+
+    const itemStyle = getComputedStyle(item);
+    const dotStyle = getComputedStyle(dot);
+    return {
+      peerClassName: item.className,
+      peerDisplay: itemStyle.display,
+      peerAlignItems: itemStyle.alignItems,
+      peerGap: itemStyle.gap,
+      peerFontSize: itemStyle.fontSize,
+      peerColor: itemStyle.color,
+      peerPaddingTop: itemStyle.paddingTop,
+      peerPaddingLeft: itemStyle.paddingLeft,
+      dotClassName: dot.className,
+      dotWidth: dotStyle.width,
+      dotHeight: dotStyle.height,
+      dotRadius: dotStyle.borderTopLeftRadius,
+      dotFlexShrink: dotStyle.flexShrink,
+      dotBackground: dotStyle.backgroundColor,
+      dotBoxShadow: dotStyle.boxShadow,
+      dotAnimationName: dotStyle.animationName,
+      dotAnimationDuration: dotStyle.animationDuration,
+      dotAnimationIterationCount: dotStyle.animationIterationCount,
+    };
+  }, dotSelector);
+}
+
+async function readInspectorEmptyStyles(page: Page) {
+  return page.evaluate(() => {
+    const empty = document.querySelector<HTMLElement>('.inspector-panel .empty-state');
+    const text = empty?.querySelector<HTMLElement>('.empty-state-text');
+    if (!empty || !text) return null;
+
+    const emptyStyle = getComputedStyle(empty);
+    const textStyle = getComputedStyle(text);
+    return {
+      emptyClassName: empty.className,
+      emptyPaddingTop: emptyStyle.paddingTop,
+      emptyPaddingLeft: emptyStyle.paddingLeft,
+      textClassName: text.className,
+      textFontSize: textStyle.fontSize,
+      textColor: textStyle.color,
+      textLineHeight: textStyle.lineHeight,
+    };
+  });
+}
+
+async function readNoTreeNoteStyles(page: Page) {
+  return page.evaluate(() => {
+    const note = document.querySelector<HTMLElement>('.inspector-panel .no-tree-note');
+    if (!note) return null;
+
+    const style = getComputedStyle(note);
+    return {
+      noteClassName: note.className,
+      noteFontSize: style.fontSize,
+      noteColor: style.color,
+      notePaddingTop: style.paddingTop,
+      notePaddingLeft: style.paddingLeft,
+    };
+  });
+}
+
+test.describe('Ideal Tailwind outline peer and empty-state class bundles', () => {
+  test('Tailwind-owned peer item and status dot chrome styles connected/error states', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+
+    await dispatchEditorEvent(page, 'sync-status', { status: 'connected' });
+    await expect(page.locator('.peer-dot.connected')).toBeVisible();
+    const connected = await readPeerStyles(page, '.peer-dot.connected');
+
+    expect(connected).not.toBeNull();
+    expect(connected?.peerClassName).toMatch(/^peer-item\b/);
+    expect(connected?.peerDisplay).toBe('flex');
+    expect(connected?.peerAlignItems).toBe('center');
+    expect(connected?.peerGap).toBe('8px');
+    expect(connected?.peerFontSize).toBe('14px');
+    expect(connected?.peerColor).toBe('rgb(184, 184, 208)');
+    expect(connected?.peerPaddingTop).toBe('4px');
+    expect(connected?.peerPaddingLeft).toBe('0px');
+    expect(connected?.dotClassName).toMatch(/^peer-dot connected\b/);
+    expect(connected?.dotWidth).toBe('7px');
+    expect(connected?.dotHeight).toBe('7px');
+    expect(Number.parseFloat(connected?.dotRadius ?? '0')).toBeGreaterThan(3);
+    expect(connected?.dotFlexShrink).toBe('0');
+    expect(connected?.dotBackground).toBe('rgb(195, 232, 141)');
+    expect(connected?.dotBoxShadow).toContain('rgb(195, 232, 141)');
+    expect(connected?.dotBoxShadow).toContain('6px');
+    expect(connected?.dotAnimationName).toBe('pulse-connected');
+    expect(connected?.dotAnimationDuration).toBe('2s');
+    expect(connected?.dotAnimationIterationCount).toBe('infinite');
+
+    await dispatchEditorEvent(page, 'sync-status', { status: 'error' });
+    await expect(page.locator('.peer-dot.error')).toBeVisible();
+    const error = await readPeerStyles(page, '.peer-dot.error');
+
+    expect(error).not.toBeNull();
+    expect(error?.dotClassName).toMatch(/^peer-dot error\b/);
+    expect(error?.dotBackground).toBe('rgb(255, 83, 112)');
+    expect(error?.dotBoxShadow).toContain('rgb(255, 83, 112)');
+    expect(error?.dotBoxShadow).toContain('6px');
+    expect(error?.dotAnimationName).toBe('none');
+  });
+
+  test('Tailwind-owned inspector empty and no-tree note chrome styles', async ({
+    page,
+  }) => {
+    await waitForEditorReady(page);
+    await expect(page.locator('.inspector-panel .empty-state-text')).toContainText(
+      'Click a node in the outline or editor to inspect it',
+    );
+
+    const empty = await readInspectorEmptyStyles(page);
+
+    expect(empty).not.toBeNull();
+    expect(empty?.emptyClassName).toMatch(/^empty-state\b/);
+    expect(empty?.emptyPaddingTop).toBe('16px');
+    expect(empty?.emptyPaddingLeft).toBe('16px');
+    expect(empty?.textClassName).toMatch(/^empty-state-text\b/);
+    expect(empty?.textFontSize).toBe('14px');
+    expect(empty?.textColor).toBe('rgb(138, 138, 170)');
+    expect(Number.parseFloat(empty?.textLineHeight ?? '0')).toBeCloseTo(23.1, 1);
+
+    await dispatchEditorEvent(page, 'node-selected', { nodeId: '__missing-node__' });
+    await expect(page.locator('.inspector-panel .no-tree-note')).toHaveText(
+      'No matching node',
+    );
+
+    const noTree = await readNoTreeNoteStyles(page);
+
+    expect(noTree).not.toBeNull();
+    expect(noTree?.noteClassName).toMatch(/^no-tree-note\b/);
+    expect(noTree?.noteFontSize).toBe('14px');
+    expect(noTree?.noteColor).toBe('rgb(136, 136, 168)');
+    expect(noTree?.notePaddingTop).toBe('16px');
+    expect(noTree?.notePaddingLeft).toBe('16px');
+  });
+});

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -8,6 +8,7 @@
 @source "../../main/view_panel_classes.mbt";
 @source "../../main/view_inspector_classes.mbt";
 @source "../../main/view_outline_classes.mbt";
+@source "../../main/view_peer_empty_state_classes.mbt";
 @source "../../main/ui/button.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
@@ -29,6 +30,9 @@
   --color-canopy-accent-border: var(--canopy-accent-border);
   --color-canopy-focus-ring: var(--canopy-focus-ring);
   --color-canopy-identifier: var(--canopy-identifier);
+  --color-canopy-number: var(--canopy-number);
+  --color-canopy-string: var(--canopy-string);
+  --color-canopy-operator: var(--canopy-operator);
   --color-canopy-error-text: var(--canopy-error-text);
   --color-canopy-error-bg: var(--canopy-error-bg);
   --color-canopy-error-border: var(--canopy-error-border);
@@ -369,52 +373,10 @@ body {
   color: var(--canopy-error);
 }
 
-.no-tree-note {
-  font-size: var(--text-small);
-  color: var(--canopy-muted);
-  padding: var(--space-lg);
-}
+/* No-tree note and peer chrome are Tailwind-owned via
+   examples/ideal/main/view_peer_empty_state_classes.mbt. */
 
 /* ── Peers ──────────────────────────────────────────────── */
-
-.peer-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-size: var(--text-small);
-  color: var(--canopy-text-secondary);
-  padding: var(--space-xs) 0;
-}
-
-.peer-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.peer-dot.connected {
-  background: var(--canopy-string);
-  box-shadow: 0 0 6px var(--canopy-string);
-  animation: pulse-connected 2s ease-in-out infinite;
-}
-
-.peer-dot.connecting {
-  background: var(--canopy-number);
-  box-shadow: 0 0 4px var(--canopy-number);
-  animation: pulse-connecting 1s ease-in-out infinite;
-}
-
-.peer-dot.offline {
-  background: var(--canopy-muted);
-  box-shadow: none;
-  opacity: 0.6;
-}
-
-.peer-dot.error {
-  background: var(--canopy-operator);
-  box-shadow: 0 0 6px var(--canopy-operator);
-}
 
 @keyframes pulse-connected {
   0%, 100% { opacity: 1; }
@@ -428,15 +390,8 @@ body {
 
 /* ── Empty States ──────────────────────────────────────── */
 
-.empty-state {
-  padding: var(--space-lg);
-}
-
-.empty-state-text {
-  font-size: var(--text-small);
-  color: var(--canopy-text-dim);
-  line-height: var(--leading-relaxed);
-}
+/* Empty-state chrome is Tailwind-owned via
+   examples/ideal/main/view_peer_empty_state_classes.mbt. */
 
 /* ── Editor ─────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary

- Migrates light-DOM peer status, no-tree note, and inspector empty-state chrome to Tailwind utility bundles.
- Preserves semantic hooks (`peer-item`, `peer-dot *`, `no-tree-note`, `empty-state`, `empty-state-text`) while removing the legacy CSS declarations from `editor.css`.
- Adds computed-style Playwright coverage for representative peer dot/status and empty/no-tree chrome.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyncStatus` | `examples/ideal/main/model.mbt` | Yes | Reused as the typed peer-dot status variant source instead of introducing a new enum. |
| `@status.Tone::attrs` | `lib/status` via `examples/ideal/main/main.mbt` | Yes | Existing live-region/status ARIA behavior remains unchanged; only the class bundle moved. |
| `outline_resize_handle_class` / outline class bundle pattern | `examples/ideal/main/view_outline_classes.mbt` | Pattern only | Existing file owns the prior resize-handle slice; the new slice gets a separate private owner to avoid mixing unrelated CSS owners. |
| `inspector_row_class` / inspector detail bundle pattern | `examples/ideal/main/view_inspector_classes.mbt` | Pattern only | Existing file owns inspector detail chrome; empty-state/peer/no-tree chrome is separate slice ownership. |

New helpers added (all package-private in `examples/ideal/main/view_peer_empty_state_classes.mbt`):

- `no_tree_note_class`: Tailwind bundle for the stable `no-tree-note` hook.
- `peer_item_class`: Tailwind bundle for the stable `peer-item` hook.
- `peer_dot_state_class`: maps existing `SyncStatus` to stable peer-dot status hooks plus Tailwind state utilities.
- `peer_dot_class`: composes the stable `peer-dot` hook, status hook, and static dot chrome.
- `empty_state_class`, `empty_state_text_class`: Tailwind bundles for inspector empty-state hooks.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run because Ideal web is affected (`cd examples/ideal/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon info
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm test -- e2e/outline-peer-empty-tailwind.spec.ts --reporter=line
cd examples/ideal/web && npm run build
```

Focused Playwright: `2 passed`.

Built CSS size: `31,165 bytes / 6,139 gzip`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized peer status UI construction to use named CSS class constants instead of hardcoded strings.
  * Consolidated peer empty-state styling into dedicated class utilities.
  * Updated inspector and outline views to reference named style classes.

* **Style**
  * Added missing syntax color theme variables for enhanced syntax highlighting.

* **Tests**
  * Added end-to-end test coverage for peer status and empty-state UI styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->