### PR TITLE
Close Ideal outline tree E2E coverage gaps

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -125,8 +125,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 6. Testing Gaps
 
-- [ ] E2E tests for outline tree panel.
-  Why: `examples/ideal` outline tree operations (select, collapse, expand, drag-and-drop) have no E2E coverage. Unit tests in `projection/tree_editor_wbtest.mbt` (67 tests) cover the logic, but no browser-level verification exists for the Rabbita-based outline UI.
+- [x] E2E tests for outline tree panel.
+  Shipped 2026-06-07. Audit: the original gap was stale/broad.
+  Already covered: click selection, keyboard navigation, and scroll-to-selection (`examples/ideal/web/e2e/outline-navigation.spec.ts`); tree roles, selection, active-descendant, and collapse ARIA (`examples/ideal/web/e2e/outline-aria.spec.ts`); resize-handle behavior while `.tree-rows` scrolls (`examples/ideal/web/e2e/outline-resizable.spec.ts`).
+  Closed here: collapse/expand descendant visibility plus collapsed badges; light-DOM outline row drag/drop in `examples/ideal/web/e2e/outline-drag-drop.spec.ts`, verifying CRDT/CodeMirror text sync plus outline reorder. Shadow structure-mode drag/drop remains covered separately by `examples/ideal/web/e2e/drag-drop.spec.ts`.
 
 ---
 

--- a/examples/ideal/web/e2e/outline-aria.spec.ts
+++ b/examples/ideal/web/e2e/outline-aria.spec.ts
@@ -52,13 +52,30 @@ test.describe('Outline ARIA (treeview behavior)', () => {
     expect(rowId).toMatch(/^canopy-outline-treeitem-/);
   });
 
-  test('expandable rows expose aria-expanded; collapsing flips it to false', async ({ page }) => {
+  test('collapse/expand hides and restores descendants with a collapsed badge', async ({ page }) => {
     // The root module node has children, so it is expandable.
-    const root = outline(page).locator('.tree-row').first();
+    const rows = outline(page).locator('.tree-row');
+    const root = rows.first();
+    const descendants = outline(page).locator('.tree-row.depth-1');
     await expect(root).toHaveAttribute('aria-expanded', 'true');
+    await expect(descendants).toHaveCount(3);
+    await expect(root.locator('.collapsed-badge')).toHaveCount(0);
+    const expandedRowCount = await rows.count();
+    expect(expandedRowCount).toBeGreaterThan(1);
 
-    // Collapse via the row's toggle button; aria-expanded must become "false".
+    // Collapse via the row's toggle button; descendants leave the DOM and the
+    // badge reports the hidden direct-child count.
     await root.locator('.tree-toggle').click();
     await expect(root).toHaveAttribute('aria-expanded', 'false');
+    await expect(rows).toHaveCount(1);
+    await expect(descendants).toHaveCount(0);
+    await expect(root.locator('.collapsed-badge')).toHaveText('3');
+
+    // Expanding restores the original visible tree and removes the badge.
+    await root.locator('.tree-toggle').click();
+    await expect(root).toHaveAttribute('aria-expanded', 'true');
+    await expect(rows).toHaveCount(expandedRowCount);
+    await expect(descendants).toHaveCount(3);
+    await expect(root.locator('.collapsed-badge')).toHaveCount(0);
   });
 });

--- a/examples/ideal/web/e2e/outline-drag-drop.spec.ts
+++ b/examples/ideal/web/e2e/outline-drag-drop.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  getCodeMirrorText,
+  getEditorText,
+  setEditorText,
+} from './support/editor-state';
+
+async function waitForEditor(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).toHaveTitle('Canopy Editor');
+  await expect(page.getByLabel('AST outline')).toBeVisible();
+  await page.waitForFunction(() => {
+    return document.querySelector('#canopy-text-editor .cm-editor') !== null;
+  }, { timeout: 10000 });
+}
+
+function outline(page: Page) {
+  return page.getByLabel('AST outline');
+}
+
+async function dragOutlineLetDefInside(
+  page: Page,
+  sourceIndex: number,
+  targetIndex: number,
+) {
+  await page.evaluate(async ({ sourceIndex, targetIndex }) => {
+    const rows = Array.from(
+      document.querySelectorAll('.outline-panel .tree-row.kind-let-def'),
+    ) as HTMLElement[];
+    const source = rows[sourceIndex];
+    const target = rows[targetIndex];
+    if (!source || !target) {
+      throw new Error(
+        `Outline let rows not found: source=${sourceIndex}, target=${targetIndex}`,
+      );
+    }
+
+    const transfer = new DataTransfer();
+    const dragEvent = (type: string, element: HTMLElement) => {
+      const rect = element.getBoundingClientRect();
+      return new DragEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        dataTransfer: transfer,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      });
+    };
+    const nextFrame = () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    source.dispatchEvent(dragEvent('dragstart', source));
+    await nextFrame();
+    target.dispatchEvent(dragEvent('dragover', target));
+    await nextFrame();
+    target.dispatchEvent(dragEvent('drop', target));
+    source.dispatchEvent(dragEvent('dragend', source));
+  }, { sourceIndex, targetIndex });
+}
+
+test.describe('Outline tree drag and drop', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForEditor(page);
+  });
+
+  test('light-DOM row drag/drop reorders let definitions and syncs editor text', async ({ page }) => {
+    await setEditorText(page, 'let x = 1\nlet y = 2\nx');
+
+    const letRows = outline(page).locator('.tree-row.kind-let-def');
+    await expect(
+      outline(page).locator('.tree-row').first().locator('.tree-label-text'),
+    ).toHaveText('module [x, y]');
+    await expect(letRows).toHaveCount(2);
+    await expect(letRows.nth(0).locator('.tree-label-text')).toHaveText('let x');
+    await expect(letRows.nth(1).locator('.tree-label-text')).toHaveText('let y');
+
+    await dragOutlineLetDefInside(page, 0, 1);
+
+    await expect.poll(() => getEditorText(page)).toBe('let y = 2\nlet x = 1\nx');
+    await expect
+      .poll(() => getCodeMirrorText(page))
+      .toBe('let y = 2\nlet x = 1\nx');
+    await expect(letRows.nth(0).locator('.tree-label-text')).toHaveText('let y');
+    await expect(letRows.nth(1).locator('.tree-label-text')).toHaveText('let x');
+    await expect(
+      outline(page).locator('.tree-row.outline-dragging'),
+    ).toHaveCount(0);
+    await expect(
+      outline(page).locator('.tree-row.outline-drop-inside'),
+    ).toHaveCount(0);
+  });
+});

--- a/examples/ideal/web/e2e/outline-navigation.spec.ts
+++ b/examples/ideal/web/e2e/outline-navigation.spec.ts
@@ -1,6 +1,6 @@
 // E2E test: outline tree keyboard navigation using navigate_proj.
 import { test, expect } from '@playwright/test';
-import { dispatchExternalCrdtChanged } from './support/dom-events';
+import { setEditorText } from './support/editor-state';
 
 test.describe('Outline keyboard navigation', () => {
   test.beforeEach(async ({ page }) => {
@@ -94,11 +94,7 @@ test.describe('Outline keyboard navigation', () => {
 
   test('click scrolls selected text into view', async ({ page }) => {
     const source = Array.from({ length: 120 }, (_, i) => `let v${i} = ${i}`).join('\n');
-    await page.evaluate((text) => {
-      const g = globalThis as any;
-      g.__canopy_crdt.set_text(g.__canopy_crdt_handle, text);
-    }, source);
-    await dispatchExternalCrdtChanged(page);
+    await setEditorText(page, source);
     const targetNode = page.getByLabel('AST outline')
       .locator('.tree-label-text', { hasText: /^119$/ })
       .first();

--- a/examples/ideal/web/e2e/outline-resizable.spec.ts
+++ b/examples/ideal/web/e2e/outline-resizable.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { dispatchExternalCrdtChanged } from './support/dom-events';
+import { setEditorText } from './support/editor-state';
 
 const resizeHandleSelector = '.panel-resize-handle.outline-resize-handle';
 
@@ -179,11 +179,7 @@ test.describe('Outline panel resizable behavior', () => {
     await page.setViewportSize({ width: 1280, height: 420 });
     await waitForEditor(page);
     const source = Array.from({ length: 120 }, (_, i) => `let v${i} = ${i}`).join('\n');
-    await page.evaluate((text) => {
-      const g = globalThis as any;
-      g.__canopy_crdt.set_text(g.__canopy_crdt_handle, text);
-    }, source);
-    await dispatchExternalCrdtChanged(page);
+    await setEditorText(page, source);
 
     const handle = page.getByRole('separator', { name: 'Resize width' });
     await expect(handle).toBeVisible();

--- a/examples/ideal/web/e2e/support/editor-state.ts
+++ b/examples/ideal/web/e2e/support/editor-state.ts
@@ -1,0 +1,24 @@
+import type { Page } from '@playwright/test';
+import { dispatchExternalCrdtChanged } from './dom-events';
+
+export async function setEditorText(page: Page, text: string) {
+  await page.evaluate((source) => {
+    const g = globalThis as any;
+    g.__canopy_crdt.set_text(g.__canopy_crdt_handle, source);
+  }, text);
+  await dispatchExternalCrdtChanged(page);
+}
+
+export async function getEditorText(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const g = globalThis as any;
+    return g.__canopy_crdt.get_text(g.__canopy_crdt_handle) as string;
+  });
+}
+
+export async function getCodeMirrorText(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const content = document.querySelector('#canopy-text-editor .cm-content');
+    return (content as HTMLElement | null)?.innerText ?? '';
+  });
+}


### PR DESCRIPTION
## Summary

- Close the stale Ideal outline tree E2E TODO by documenting the current coverage audit.
- Expand outline ARIA coverage to assert collapse/expand hides/restores descendants and collapsed badges.
- Add light-DOM outline row drag/drop E2E coverage that verifies outline reorder plus CRDT/CodeMirror text sync.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `dispatchExternalCrdtChanged` | `examples/ideal/web/e2e/support/dom-events.ts` | Yes | Used by the new shared `setEditorText` helper to keep external CRDT updates on the existing event path. |
| Existing structure-mode `dragDrop` helper | `examples/ideal/web/e2e/drag-drop.spec.ts` | No | It targets `canopy-editor` shadow DOM structure blocks and ProseMirror node metadata; this PR needs light-DOM `.outline-panel .tree-row` drag/drop. |
| Existing inline CRDT helpers in E2E specs | `examples/ideal/web/e2e/drag-drop.spec.ts` and outline specs | Partially | Consolidated the outline-facing text helpers into `support/editor-state.ts`; left structure-mode helper scope unchanged to avoid broadening this PR. |

New helpers added (if any):

- `setEditorText(page, text)` in `examples/ideal/web/e2e/support/editor-state.ts`: shared outline E2E setup helper that writes CRDT text and dispatches the existing external-change event.
- `getEditorText(page)` in `examples/ideal/web/e2e/support/editor-state.ts`: reads the CRDT text for behavior assertions.
- `getCodeMirrorText(page)` in `examples/ideal/web/e2e/support/editor-state.ts`: reads visible CodeMirror text so drag/drop tests can assert editor sync, not only CRDT state.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/ideal/web && NEW_MOON_MOD=0 CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run build`)

## Validation

```bash
CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/outline-*.spec.ts --reporter=line
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test
cd examples/ideal/web && NEW_MOON_MOD=0 CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run build
```

Note: `moon info` produced newline-only `.mbti` churn, reviewed and reverted before commit.
