### PR TITLE
Broadcast partial bridge edit batches

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -415,8 +415,8 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Disambiguate `UserIntent.SetCursor.position` — same `number` carries PM-tree positions (PMAdapter) and CM-doc code-unit offsets (CM6Adapter). Naming cleanup, not unit conversion.
   Status: not blocked on moji.
 
-- [ ] Tighten `examples/ideal/web/src/bridge.ts::applySpliceChanges` partial-batch semantics. Today: if splice K in a multi-change batch fails the `handle_text_intent_checked` bounds check, splices 0..K-1 stay applied to the CRDT but skip the immediate `afterLocalEdit()` broadcast — they ride the next successful edit's `export_since_json` delta. Pre-existing behavior preserved by #246, flagged by Codex on that PR. Options: (a) call `afterLocalEdit()` if anything was applied, broadcasting the valid prefix immediately; (b) make batches atomic with a snapshot/rollback API; (c) leave as-is and document. Prefer (a) — minimal change, removes the cross-replica gap.
-  Status: not blocked on moji.
+- [x] Tighten `examples/ideal/web/src/bridge.ts::applySpliceChanges` partial-batch semantics.
+  Shipped 2026-06-07: implemented option (a). If splice K in a multi-change batch fails `handle_text_intent_checked` after splices 0..K-1 were applied, the bridge now calls `afterLocalEdit()` before reconciling so peers receive the valid prefix immediately. Playwright coverage in `examples/ideal/web/e2e/bridge-partial-batch.spec.ts` pins both prefix-broadcast and first-splice-failure/no-broadcast behavior.
 
 ---
 

--- a/examples/ideal/web/e2e/bridge-partial-batch.spec.ts
+++ b/examples/ideal/web/e2e/bridge-partial-batch.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('CrdtBridge partial batch handling', () => {
+  test('broadcasts a valid prefix when a later splice in the same batch fails', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const result = await page.evaluate(async () => {
+      const { CrdtBridge } = await import('/src/bridge.ts');
+      const calls: Array<{ from: number; deleteLen: number; insert: string }> = [];
+      const crdt = {
+        get_source_map_json: () => JSON.stringify([{ node_id: 7, start: 10 }]),
+        get_proj_node_json: () => 'null',
+        handle_text_intent_checked: (
+          _handle: number,
+          from: number,
+          deleteLen: number,
+          insert: string,
+          _timestampMs: number,
+        ) => {
+          calls.push({ from, deleteLen, insert });
+          return calls.length === 1;
+        },
+      };
+      const bridge = new CrdtBridge(123, crdt as any);
+      let broadcasts = 0;
+      bridge.setBroadcast(() => {
+        broadcasts += 1;
+      });
+
+      bridge.handleLeafEdit(7, [
+        { from: 0, to: 0, insert: 'a' },
+        { from: 999, to: 1000, insert: 'b' },
+      ]);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      return { broadcasts, calls };
+    });
+
+    expect(result.broadcasts).toBe(1);
+    expect(result.calls).toEqual([
+      { from: 10, deleteLen: 0, insert: 'a' },
+      { from: 1010, deleteLen: 1, insert: 'b' },
+    ]);
+  });
+
+  test('does not broadcast when the first splice fails', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const result = await page.evaluate(async () => {
+      const { CrdtBridge } = await import('/src/bridge.ts');
+      const calls: Array<{ from: number; deleteLen: number; insert: string }> = [];
+      const crdt = {
+        get_source_map_json: () => JSON.stringify([{ node_id: 7, start: 10 }]),
+        get_proj_node_json: () => 'null',
+        handle_text_intent_checked: (
+          _handle: number,
+          from: number,
+          deleteLen: number,
+          insert: string,
+          _timestampMs: number,
+        ) => {
+          calls.push({ from, deleteLen, insert });
+          return false;
+        },
+      };
+      const bridge = new CrdtBridge(123, crdt as any);
+      let broadcasts = 0;
+      bridge.setBroadcast(() => {
+        broadcasts += 1;
+      });
+
+      bridge.handleLeafEdit(7, [{ from: 0, to: 1, insert: 'a' }]);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      return { broadcasts, calls };
+    });
+
+    expect(result.broadcasts).toBe(0);
+    expect(result.calls).toEqual([{ from: 10, deleteLen: 1, insert: 'a' }]);
+  });
+});

--- a/examples/ideal/web/src/bridge.ts
+++ b/examples/ideal/web/src/bridge.ts
@@ -147,10 +147,10 @@ export class CrdtBridge {
    * edit to peers before reconcile runs. The checked variant rejects the
    * splice instead, mirroring the old `delete_at`-returns-false recovery path.
    *
-   * A multi-change batch where splice K fails leaves splices 0..K-1 applied
-   * to the CRDT but un-broadcast on this edit; the next successful edit's
-   * `export_since_json` broadcast carries them as part of the CRDT delta.
-   * This matches the prior per-char loop's behavior — preserved, not new.
+   * If a multi-change batch fails after applying an earlier splice, broadcast
+   * that valid prefix immediately before reconciling. Otherwise peers can miss
+   * the prefix until a later successful edit happens to export the pending CRDT
+   * delta.
    */
   private applySpliceChanges(
     basePos: number,
@@ -158,6 +158,7 @@ export class CrdtBridge {
     changes: { from: number; to: number; insert: string }[],
   ): boolean {
     let posOffset = 0;
+    let appliedAny = false;
     for (const change of changes) {
       const deleteLen = change.to - change.from;
       const ok = this.crdt.handle_text_intent_checked(
@@ -173,8 +174,12 @@ export class CrdtBridge {
           basePos + change.from + posOffset,
           "deleteLen=", deleteLen,
         );
+        if (appliedAny) {
+          this.afterLocalEdit();
+        }
         return false;
       }
+      appliedAny = true;
       posOffset += change.insert.length - deleteLen;
     }
     return true;


### PR DESCRIPTION
## Summary

- Broadcast valid splice prefixes immediately when a later splice in `CrdtBridge.applySpliceChanges` fails bounds validation.
- Update the bridge comment and TODO entry to reflect the tightened partial-batch semantics.
- Add Playwright coverage for prefix-broadcast and first-splice-failure/no-broadcast behavior.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `afterLocalEdit()` | `examples/ideal/web/src/bridge.ts` | Yes | Existing local-edit publication path already invalidates the source map, broadcasts, and schedules reconcile; reused for valid prefixes. |
| `scheduleReconcile()` | `examples/ideal/web/src/bridge.ts` | Yes | Existing drift recovery path remains responsible for reconcile scheduling when no valid splice was applied. |
| `handle_text_intent_checked` | MoonBit CRDT bridge exposed via `examples/ideal/web/src/types.ts` | Yes | The checked splice path remains the source of truth for bounds validation. |
| `handleLeafEdit()` | `examples/ideal/web/src/bridge.ts` | Yes | Tests exercise the public bridge entrypoint instead of reaching into the private `applySpliceChanges` method. |

New helpers added (if any):

- None in production code.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/ideal/web && NEW_MOON_MOD=0 CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run build`)

## Validation

```bash
cd examples/ideal/web && CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npx playwright test e2e/bridge-partial-batch.spec.ts --reporter=line
NEW_MOON_MOD=0 moon check
cd examples/ideal/web && NEW_MOON_MOD=0 CANOPY_SKIP_RELAY_SERVER=1 VITE_CANOPY_SKIP_SYNC=1 npm run build
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test
```

Note: `moon info` produced newline-only `.mbti` churn, reviewed and reverted before commit.
