### PR TITLE
Disambiguate cursor intent offsets

### DIFF
--- a/adapters/editor-adapter/CHANGELOG.md
+++ b/adapters/editor-adapter/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CM6Adapter` now applies `SetDiagnostics` patches as inline `cm-diagnostic cm-diagnostic-${severity}` marks with native-tooltip `title` and `data-severity` attributes. `static extensions()` returns the new diagnostic field + plugin alongside the decoration pair. (#227)
 
 ### Changed
+- `UserIntent` cursor intents are now unit-specific: `SetPmCursor(pm_tree_position)` for ProseMirror tree positions and `SetDocCursor(doc_code_unit_offset)` for document code-unit offsets replace the ambiguous `SetCursor(position)` shape.
 - `cm6-adapter.ts`: `DecorationSet` and `ViewUpdate` are now imported with `import type`, fixing the build for downstream TypeScript projects with `verbatimModuleSyntax: true` (a Vite/SvelteKit default).
 - `cm6-adapter.ts`: `PeerCursorWidget.{eq, toDOM, ignoreEvent}` now carry the `override` modifier, fixing the build for downstream projects with `noImplicitOverride: true`.
 

--- a/adapters/editor-adapter/README.md
+++ b/adapters/editor-adapter/README.md
@@ -97,7 +97,7 @@ The MoonBit-side custom `ToJson` impls in `framework/protocol/` are the source o
 
 **Custom decorations.** Send `{ type: "SetDecorations", decorations: [...] }` with a `css_class` namespaced to your project (e.g. `moondsp-pattern-cursor`). Style it in your host CSS. Use the `widget` flag for inline DOM widgets.
 
-**Selection and cursor.** `SetSelection` and `SelectNode` patches drive editor focus. `SetCursor` and `SelectNode` intents come back from the user.
+**Selection and cursor.** `SetSelection` and `SelectNode` patches drive editor focus. `SetPmCursor` (ProseMirror tree positions), `SetDocCursor` (document code-unit offsets), and `SelectNode` intents come back from the user.
 
 ## Versioning
 

--- a/adapters/editor-adapter/cm6-adapter.ts
+++ b/adapters/editor-adapter/cm6-adapter.ts
@@ -263,8 +263,8 @@ export class CM6Adapter implements EditorAdapter {
       if (update.selectionSet && !update.docChanged) {
         const sel = update.state.selection.main;
         this.intentCallback({
-          type: "SetCursor",
-          position: sel.anchor,
+          type: "SetDocCursor",
+          doc_code_unit_offset: sel.anchor,
         });
       }
     });

--- a/adapters/editor-adapter/pm-adapter.ts
+++ b/adapters/editor-adapter/pm-adapter.ts
@@ -172,8 +172,8 @@ export class PMAdapter implements EditorAdapter {
             });
           } else {
             this.intentCallback({
-              type: "SetCursor",
-              position: sel.anchor,
+              type: "SetPmCursor",
+              pm_tree_position: sel.anchor,
             });
           }
         }

--- a/adapters/editor-adapter/types.ts
+++ b/adapters/editor-adapter/types.ts
@@ -45,7 +45,8 @@ export type UserIntent =
   | { type: "TextEdit"; from: number; to: number; insert: string }
   | { type: "StructuralEdit"; node_id: number; op: string; params: Record<string, string> }
   | { type: "SelectNode"; node_id: number }
-  | { type: "SetCursor"; position: number }
+  | { type: "SetPmCursor"; pm_tree_position: number }
+  | { type: "SetDocCursor"; doc_code_unit_offset: number }
   | { type: "Undo" }
   | { type: "Redo" }
   | { type: "CommitEdit"; node_id: number; value: string };

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -412,8 +412,8 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] (perf, P3) `editor/sync_editor_text.mbt::utf16_offset_to_item_pos` is O(n) per call and runs on every mutation path; `gcb_of` does up to 13 binary searches per codepoint; `next/prev_grapheme_boundary` rebuild the boundary array each call (O(n²) for tight loops). Acceptable for canopy's short strings today; documented in `loom/moji/grapheme.mbt` and `loom/moji/README.md`. Concrete fixes when a hot-path actually needs them: ASCII fast path in `gcb_of` (only CR/LF/Control populate `< 0x80`), drop `ch.to_string().length()` allocation in `utf16_offset_to_item_pos` (use `if ch.to_int() >= 0x10000 { 2 } else { 1 }`), and a materialise-once boundary cache for hot callers.
   Status: not blocking; cosmetic perf debt.
 
-- [ ] Disambiguate `UserIntent.SetCursor.position` — same `number` carries PM-tree positions (PMAdapter) and CM-doc code-unit offsets (CM6Adapter). Naming cleanup, not unit conversion.
-  Status: not blocked on moji.
+- [x] Disambiguate cursor intent offsets — replaced generic `UserIntent.SetCursor.position` with `SetPmCursor(pm_tree_position)` and `SetDocCursor(doc_code_unit_offset)`. Naming cleanup only; no unit conversion.
+  Status: completed 2026-06-07.
 
 - [x] Tighten `examples/ideal/web/src/bridge.ts::applySpliceChanges` partial-batch semantics.
   Shipped 2026-06-07: implemented option (a). If splice K in a multi-change batch fails `handle_text_intent_checked` after splices 0..K-1 were applied, the bridge now calls `afterLocalEdit()` before reconciling so peers receive the valid prefix immediately. Playwright coverage in `examples/ideal/web/e2e/bridge-partial-batch.spec.ts` pins both prefix-broadcast and first-splice-failure/no-broadcast behavior.

--- a/examples/prosemirror/src/main.ts
+++ b/examples/prosemirror/src/main.ts
@@ -61,7 +61,8 @@ function handleIntent(intent: UserIntent): void {
     }
 
     case "SelectNode":
-    case "SetCursor":
+    case "SetPmCursor":
+    case "SetDocCursor":
     case "CommitEdit":
       return;
   }

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -8,7 +8,7 @@ This package is the stable contract between the MoonBit engine and the TypeScrip
 
 - `ViewNode` — tree node sent to the frontend; carries `id`, `kind_tag`, `label`, `text`, `text_range`, `token_spans`, and `children`
 - `ViewPatch` — incremental update: `TextChange`, `ReplaceNode`, `InsertChild`, `RemoveChild`, `UpdateNode`, `SetDecorations`, `SetDiagnostics`, `SetSelection`, `SelectNode`, `FullTree`
-- `UserIntent` — frontend-originated action: `TextEdit`, `StructuralEdit`, `SelectNode`, `SetCursor`, `Undo`, `Redo`, `CommitEdit`
+- `UserIntent` — frontend-originated action: `TextEdit`, `StructuralEdit`, `SelectNode`, `SetPmCursor`, `SetDocCursor`, `Undo`, `Redo`, `CommitEdit`
 - `Decoration` / `Diagnostic` / `Severity` — CodeMirror decoration and lint annotations
 - `proj_to_view_node` — converts a `ProjNode[T]` + `SourceMap` into a `ViewNode`
 - `layout_to_view_tree` — converts a pretty-printer `Layout` into a `ViewNode` tree

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -54,7 +54,8 @@ pub(all) enum UserIntent {
   TextEdit(from~ : Int, to~ : Int, insert~ : String)
   StructuralEdit(node_id~ : @dowdiness/canopy/core.NodeId, op~ : String, params~ : Map[String, String])
   SelectNode(node_id~ : @dowdiness/canopy/core.NodeId)
-  SetCursor(position~ : Int)
+  SetPmCursor(pm_tree_position~ : Int)
+  SetDocCursor(doc_code_unit_offset~ : Int)
   Undo
   Redo
   CommitEdit(node_id~ : @dowdiness/canopy/core.NodeId, value~ : String)

--- a/protocol/user_intent.mbt
+++ b/protocol/user_intent.mbt
@@ -16,7 +16,8 @@ pub(all) enum UserIntent {
     params~ : Map[String, String]
   )
   SelectNode(node_id~ : @core.NodeId)
-  SetCursor(position~ : Int)
+  SetPmCursor(pm_tree_position~ : Int)
+  SetDocCursor(doc_code_unit_offset~ : Int)
   Undo
   Redo
   CommitEdit(node_id~ : @core.NodeId, value~ : String)
@@ -25,6 +26,38 @@ pub(all) enum UserIntent {
 ///|
 pub impl Show for UserIntent with fn output(self, logger) {
   logger.write_string(@debug.to_string(self))
+}
+
+///|
+fn user_intent_number_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+  owner : String,
+) -> Int raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(Json::Number(n, ..)) => n.to_int()
+    _ =>
+      raise @json.JsonDecodeError(
+        (path.add_key(key), "\{owner}: '\{key}' must be a number"),
+      )
+  }
+}
+
+///|
+fn user_intent_string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+  owner : String,
+) -> String raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(Json::String(s)) => s
+    _ =>
+      raise @json.JsonDecodeError(
+        (path.add_key(key), "\{owner}: '\{key}' must be a string"),
+      )
+  }
 }
 
 ///|
@@ -51,9 +84,13 @@ pub impl ToJson for UserIntent with fn to_json(self) {
       m["type"] = "SelectNode".to_json()
       m["node_id"] = node_id.to_json()
     }
-    SetCursor(position~) => {
-      m["type"] = "SetCursor".to_json()
-      m["position"] = position.to_json()
+    SetPmCursor(pm_tree_position~) => {
+      m["type"] = "SetPmCursor".to_json()
+      m["pm_tree_position"] = pm_tree_position.to_json()
+    }
+    SetDocCursor(doc_code_unit_offset~) => {
+      m["type"] = "SetDocCursor".to_json()
+      m["doc_code_unit_offset"] = doc_code_unit_offset.to_json()
     }
     Undo => m["type"] = "Undo".to_json()
     Redo => m["type"] = "Redo".to_json()
@@ -81,47 +118,16 @@ pub impl @json.FromJson for UserIntent with fn from_json(json, path) {
   }
   match type_str {
     "TextEdit" => {
-      let from = match m.get("from") {
-        Some(Json::Number(n, ..)) => n.to_int()
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("from"), "TextEdit: 'from' must be a number"),
-          )
-      }
-      let to = match m.get("to") {
-        Some(Json::Number(n, ..)) => n.to_int()
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("to"), "TextEdit: 'to' must be a number"),
-          )
-      }
-      let insert = match m.get("insert") {
-        Some(Json::String(s)) => s
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("insert"), "TextEdit: 'insert' must be a string"),
-          )
-      }
+      let from = user_intent_number_field(m, path, "from", "TextEdit")
+      let to = user_intent_number_field(m, path, "to", "TextEdit")
+      let insert = user_intent_string_field(m, path, "insert", "TextEdit")
       UserIntent::TextEdit(from~, to~, insert~)
     }
     "StructuralEdit" => {
-      let node_id = match m.get("node_id") {
-        Some(Json::Number(n, ..)) => @core.NodeId::from_int(n.to_int())
-        _ =>
-          raise @json.JsonDecodeError(
-            (
-              path.add_key("node_id"),
-              "StructuralEdit: 'node_id' must be a number",
-            ),
-          )
-      }
-      let op = match m.get("op") {
-        Some(Json::String(s)) => s
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("op"), "StructuralEdit: 'op' must be a string"),
-          )
-      }
+      let node_id = @core.NodeId::from_int(
+        user_intent_number_field(m, path, "node_id", "StructuralEdit"),
+      )
+      let op = user_intent_string_field(m, path, "op", "StructuralEdit")
       let params : Map[String, String] = {}
       match m.get("params") {
         Some(Json::Object(pm)) =>
@@ -149,42 +155,30 @@ pub impl @json.FromJson for UserIntent with fn from_json(json, path) {
       UserIntent::StructuralEdit(node_id~, op~, params~)
     }
     "SelectNode" => {
-      let node_id = match m.get("node_id") {
-        Some(Json::Number(n, ..)) => @core.NodeId::from_int(n.to_int())
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("node_id"), "SelectNode: 'node_id' must be a number"),
-          )
-      }
+      let node_id = @core.NodeId::from_int(
+        user_intent_number_field(m, path, "node_id", "SelectNode"),
+      )
       UserIntent::SelectNode(node_id~)
     }
-    "SetCursor" => {
-      let position = match m.get("position") {
-        Some(Json::Number(n, ..)) => n.to_int()
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("position"), "SetCursor: 'position' must be a number"),
-          )
-      }
-      UserIntent::SetCursor(position~)
+    "SetPmCursor" => {
+      let pm_tree_position = user_intent_number_field(
+        m, path, "pm_tree_position", "SetPmCursor",
+      )
+      UserIntent::SetPmCursor(pm_tree_position~)
+    }
+    "SetDocCursor" => {
+      let doc_code_unit_offset = user_intent_number_field(
+        m, path, "doc_code_unit_offset", "SetDocCursor",
+      )
+      UserIntent::SetDocCursor(doc_code_unit_offset~)
     }
     "Undo" => UserIntent::Undo
     "Redo" => UserIntent::Redo
     "CommitEdit" => {
-      let node_id = match m.get("node_id") {
-        Some(Json::Number(n, ..)) => @core.NodeId::from_int(n.to_int())
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("node_id"), "CommitEdit: 'node_id' must be a number"),
-          )
-      }
-      let value = match m.get("value") {
-        Some(Json::String(s)) => s
-        _ =>
-          raise @json.JsonDecodeError(
-            (path.add_key("value"), "CommitEdit: 'value' must be a string"),
-          )
-      }
+      let node_id = @core.NodeId::from_int(
+        user_intent_number_field(m, path, "node_id", "CommitEdit"),
+      )
+      let value = user_intent_string_field(m, path, "value", "CommitEdit")
       UserIntent::CommitEdit(node_id~, value~)
     }
     _ =>

--- a/protocol/user_intent_test.mbt
+++ b/protocol/user_intent_test.mbt
@@ -71,8 +71,30 @@ test "UserIntent::SelectNode round-trip" {
 }
 
 ///|
-test "UserIntent::SetCursor round-trip" {
-  let intent = @protocol.UserIntent::SetCursor(position=42)
+test "UserIntent::SetPmCursor to_json" {
+  let intent = @protocol.UserIntent::SetPmCursor(pm_tree_position=42)
+  let s = intent.to_json().stringify()
+  inspect(s, content="{\"type\":\"SetPmCursor\",\"pm_tree_position\":42}")
+}
+
+///|
+test "UserIntent::SetPmCursor round-trip" {
+  let intent = @protocol.UserIntent::SetPmCursor(pm_tree_position=42)
+  let json = intent.to_json()
+  let decoded : @protocol.UserIntent = @json.from_json(json)
+  assert_eq(intent, decoded)
+}
+
+///|
+test "UserIntent::SetDocCursor to_json" {
+  let intent = @protocol.UserIntent::SetDocCursor(doc_code_unit_offset=42)
+  let s = intent.to_json().stringify()
+  inspect(s, content="{\"type\":\"SetDocCursor\",\"doc_code_unit_offset\":42}")
+}
+
+///|
+test "UserIntent::SetDocCursor round-trip" {
+  let intent = @protocol.UserIntent::SetDocCursor(doc_code_unit_offset=42)
   let json = intent.to_json()
   let decoded : @protocol.UserIntent = @json.from_json(json)
   assert_eq(intent, decoded)
@@ -131,8 +153,18 @@ test "UserIntent from_json rejects non-object" {
 }
 
 ///|
-test "UserIntent from_json string parse" {
-  let json = @json.parse("{\"type\":\"SetCursor\",\"position\":10}")
-  let decoded : @protocol.UserIntent = @json.from_json(json)
-  assert_eq(decoded, @protocol.UserIntent::SetCursor(position=10))
+test "UserIntent from_json parses cursor-specific offsets" {
+  let pm_json = @json.parse(
+    "{\"type\":\"SetPmCursor\",\"pm_tree_position\":10}",
+  )
+  let pm_decoded : @protocol.UserIntent = @json.from_json(pm_json)
+  assert_eq(pm_decoded, @protocol.UserIntent::SetPmCursor(pm_tree_position=10))
+  let doc_json = @json.parse(
+    "{\"type\":\"SetDocCursor\",\"doc_code_unit_offset\":10}",
+  )
+  let doc_decoded : @protocol.UserIntent = @json.from_json(doc_json)
+  assert_eq(
+    doc_decoded,
+    @protocol.UserIntent::SetDocCursor(doc_code_unit_offset=10),
+  )
 }


### PR DESCRIPTION
## Summary

- Split ambiguous `UserIntent.SetCursor(position)` into `SetPmCursor(pm_tree_position)` and `SetDocCursor(doc_code_unit_offset)`.
- Updated PM/CM6 adapters and protocol JSON encode/decode/tests to use unit-specific cursor intent fields.
- Updated protocol/editor-adapter docs, changelog, and TODO status.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@json.from_json` | `moonbitlang/core/json` | Partially | Still need explicit required-field lookup plus variant-specific decode error paths before converting payload values. |
| `json_number_field` / `json_string_field` | `examples/canvas/graph_model/model.mbt` | No | Package-private and graph-model-specific; `protocol` needs local private helpers for its own decode errors. |

New helpers added (if any):

- `user_intent_number_field`: private `UserIntent` JSON required-number decoder with variant/field-specific errors.
- `user_intent_string_field`: private `UserIntent` JSON required-string decoder with variant/field-specific errors.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon test protocol
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info protocol
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/prosemirror && npm run build
cd examples/web && npm run build
git diff -- '*.mbti'  # reviewed: only intended protocol UserIntent variant change
```
