### PR TITLE
docs(protocol): document coordinate units

### DIFF
--- a/adapters/editor-adapter/README.md
+++ b/adapters/editor-adapter/README.md
@@ -87,7 +87,9 @@ The patch protocol is intentionally minimal. Three rules every engine must respe
 2. **Idempotent re-application.** Applying the same patch sequence twice from the same starting state yields the same result. Adapters may dedupe but engines must not rely on it.
 3. **Synchronous intents.** `UserIntent` events fire synchronously from input. Consumers may respond async, but ordering across an input gesture is preserved.
 
-The MoonBit-side custom `ToJson` impls in `framework/protocol/` are the source of truth for the wire format. TypeScript types in `types.ts` mirror them.
+The MoonBit `ToJson` impls in `protocol/` define the wire format. `types.ts`
+mirrors them. Coordinate units and breaking-change rules live in
+[`protocol/README.md`](../../protocol/README.md#position-and-offset-units).
 
 ## Extension points
 

--- a/adapters/editor-adapter/types.ts
+++ b/adapters/editor-adapter/types.ts
@@ -1,5 +1,5 @@
 // TypeScript type definitions mirroring MoonBit editor protocol types.
-// These match the JSON wire format produced by framework/protocol/ custom ToJson impls.
+// These match the JSON wire format produced by protocol/ custom ToJson impls.
 
 export type ViewNode = {
   id: number;

--- a/docs/plans/2026-04-01-editor-protocol-design.md
+++ b/docs/plans/2026-04-01-editor-protocol-design.md
@@ -26,10 +26,10 @@ variants (each needs its own conversion + reconciliation TS code).
 ## Scope
 
 In:
-- `framework/protocol/` — new package for protocol types (`ViewPatch`,
-  `ViewNode`, `UserIntent`). Separate from `framework/core/` to keep
-  rendering concerns (`css_class`, `editable`, `widget`) out of the
-  structural primitive layer (`NodeId`, `ProjNode`, `SourceMap`).
+- `protocol/` — package for protocol types (`ViewPatch`, `ViewNode`,
+  `UserIntent`). Separate from `core/` to keep rendering concerns
+  (`css_class`, `editable`, `widget`) out of the structural primitive layer
+  (`NodeId`, `ProjNode`, `SourceMap`).
 - `editor/` — new `ViewUpdater` component on `SyncEditor`
 - `examples/web/` — first migration target (simplest, validates types)
 - `examples/ideal/` — migrate from global-state bridge to protocol
@@ -128,14 +128,14 @@ trait Renderable { kind_tag(Self) -> String; label(Self) -> String; placeholder(
 
 ## Protocol Types
 
-All protocol types live in `framework/protocol/`, separate from the
-structural primitives in `framework/core/`. This keeps rendering concerns
-(`css_class`, `editable`, `widget`) out of the core layer.
+All protocol types live in `protocol/`, separate from the structural
+primitives in `core/`. This keeps rendering concerns (`css_class`,
+`editable`, `widget`) out of the core layer.
 
 ### ViewNode — language-agnostic node representation
 
 ```moonbit
-/// framework/protocol/view_node.mbt
+/// protocol/view_node.mbt
 pub(all) struct ViewNode {
   id : NodeId
   kind_tag : String       // from Renderable::kind_tag — "lam", "app", "json_object"
@@ -184,7 +184,7 @@ views use `InteractiveTreeNode` directly; foreign widgets receive
 ### ViewPatch — what changed
 
 ```moonbit
-/// framework/protocol/view_patch.mbt
+/// protocol/view_patch.mbt
 pub enum ViewPatch {
   // Text view (CM6)
   TextChange(from~ : Int, to~ : Int, insert~ : String)
@@ -245,7 +245,7 @@ preserving CM6 inline editor focus.
 ### UserIntent — what the user wants
 
 ```moonbit
-/// framework/protocol/user_intent.mbt
+/// protocol/user_intent.mbt
 pub enum UserIntent {
   // Text editing (from CM6 or contentEditable)
   TextEdit(from~ : Int, to~ : Int, insert~ : String)
@@ -253,9 +253,10 @@ pub enum UserIntent {
   // Structural editing (from PM or outline)
   StructuralEdit(node_id~ : NodeId, op~ : String, params~ : Map[String, String])
 
-  // Selection
+  // Selection / cursor
   SelectNode(node_id~ : NodeId)
-  SetCursor(position~ : Int)
+  SetPmCursor(pm_tree_position~ : Int)
+  SetDocCursor(doc_code_unit_offset~ : Int)
 
   // Undo/redo
   Undo
@@ -460,7 +461,8 @@ type UserIntent =
   | { type: "TextEdit"; from: number; to: number; insert: string }
   | { type: "StructuralEdit"; node_id: number; op: string; params: Record<string, string> }
   | { type: "SelectNode"; node_id: number }
-  | { type: "SetCursor"; position: number }
+  | { type: "SetPmCursor"; pm_tree_position: number }
+  | { type: "SetDocCursor"; doc_code_unit_offset: number }
   | { type: "Undo" }
   | { type: "Redo" }
   | { type: "CommitEdit"; node_id: number; value: string };
@@ -618,9 +620,9 @@ Deprecation timeline:
 2. If > 1ms: design the optimized FFI layer before Phase 1 instead of
    deferring it. If < 1ms: proceed with JSON as initial transport.
 
-### Phase 1: Protocol types + ViewUpdater (framework/protocol + editor)
+### Phase 1: Protocol types + ViewUpdater (`protocol/` + `editor/`)
 
-3. Create `framework/protocol/` package with `moon.pkg.json`
+3. Create `protocol/` package with `moon.pkg.json`
 4. Add `ViewNode`, `TokenSpan`, `ViewPatch`, `Decoration`, `Diagnostic`,
    `UserIntent` types with `fn new(...)` constructors
 5. Add custom `to_json`/`from_json` impls producing object-based JSON
@@ -628,8 +630,8 @@ Deprecation timeline:
 6. Add `proj_to_view_node` helper (ProjNode[T] + SourceMap → ViewNode),
    including Module/let_def wrapper synthesis for Lambda
 7. Add `SyncEditor::compute_view_patches` and `get_view_tree`
-8. Unit tests in `framework/protocol/` (round-trip serialization) and
-   `editor/` (patch computation for insert, delete, wrap, undo edits)
+8. Unit tests in `protocol/` (round-trip serialization) and `editor/`
+   (patch computation for insert, delete, wrap, undo edits)
 
 ### Phase 2: TS adapter library + examples/web migration
 
@@ -704,8 +706,8 @@ Break into independently testable sub-steps:
 
 ## Acceptance Criteria
 
-- [ ] `framework/protocol/` has ViewNode, ViewPatch, UserIntent types
-      with custom object-based `to_json`/`from_json`
+- [ ] `protocol/` has ViewNode, ViewPatch, UserIntent types with custom
+      object-based `to_json`/`from_json`
 - [ ] Phase 0 benchmark confirms JSON round-trip < 1ms at 100-def scale
 - [ ] `SyncEditor::compute_view_patches` returns correct patches for:
   - [ ] Single character insert/delete

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -26,9 +26,49 @@ This package is the stable contract between the MoonBit engine and the TypeScrip
 - `dowdiness/pretty` — `Layout`, `SyntaxCategory`
 - `moonbitlang/core/json` — `ToJson` / `FromJson` derivations
 
+## Position and Offset Units
+
+Protocol positions are plain JSON numbers. Read each number in its declared
+unit:
+
+- **UTF-16 document code-unit offset** — an offset in source text. This matches
+  CodeMirror, JS `String.length`, and `SyncEditor` cursor APIs.
+- **ProseMirror tree position** — an offset in the ProseMirror document tree.
+  It is not a source-text offset.
+
+PR #555 replaced `UserIntent.SetCursor(position)` with separate cursor intents
+so these units stay separate.
+
+| Field | Direction | Unit | Meaning |
+|---|---|---|---|
+| `ViewPatch.TextChange.from` / `.to` | MoonBit → JS | UTF-16 document code-unit offset | Half-open edit range. |
+| `TextEdit.from` / `.to` | JS → MoonBit | UTF-16 document code-unit offset | Half-open edit range. |
+| `ViewPatch.SetSelection.anchor` / `.head` | MoonBit → JS | UTF-16 document code-unit offset | Text selection endpoints. |
+| `Decoration.from` / `.to` | MoonBit → JS | UTF-16 document code-unit offset | Half-open source range for marks or widgets. |
+| `Diagnostic.from` / `.to` | MoonBit → JS | UTF-16 document code-unit offset | Half-open source range for annotations. |
+| `SetPmCursor.pm_tree_position` | JS → MoonBit | ProseMirror tree position | Cursor in the PM tree. Convert before using text APIs. |
+| `SetDocCursor.doc_code_unit_offset` | JS → MoonBit | UTF-16 document code-unit offset | Cursor in source text. |
+
+Editor code may snap UTF-16 offsets to grapheme boundaries before it converts
+them to eg-walker item-space. See [Position Units](../docs/development/API_REFERENCE.md#position-units).
+
 ## Stability
 
 Stable wire format / public surface — changes here break the TypeScript frontend and require coordinated updates to the JS consumer side.
+
+### Stable Wire-Format Change Checklist
+
+Before changing stable `ViewPatch`, `UserIntent`, `Decoration`, or
+`Diagnostic` JSON shapes:
+
+- Add a changelog entry for the changed field or variant.
+- Add a migration note if consumers must change code. Include the reason for
+  the break; for unit changes, cite PR #555-style context.
+- For any MoonBit protocol change, run `moon info` and review
+  `protocol/pkg.generated.mbti` for unintended API diffs.
+- Update `adapters/editor-adapter/types.ts`, adapter emit/apply paths, and
+  serialization or round-trip tests in the same change.
+- Build Canopy demos and known external consumers before release.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Document protocol position/offset units for text edits, selections, decorations, diagnostics, and split cursor intents.
- Add a stable wire-format breaking-change checklist for protocol changes.
- Fix stale `framework/protocol/` references in adapter docs/types and the active editor-protocol plan.

Closes #556.

## Reuse check

Pure docs/comment change. No functions, methods, helpers, or types added.

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Existing Position Units docs | `docs/development/API_REFERENCE.md#position-units` | Yes | Linked from `protocol/README.md` instead of duplicating editor-layer detail. |

New helpers added (if any):

None.

## Test plan

- [x] Markdown link/table review script passed
- [x] `rg -n "framework/protocol" adapters protocol docs --glob '!docs/archive/**'` produced no output
- [x] `git diff --check` passed
- [x] Slopless rerun saved JSON findings under `.slopless/findings/`; remaining findings are readability-score-only on technical docs
- [ ] `NEW_MOON_MOD=0 moon check` passes — not run (docs-only)
- [ ] `NEW_MOON_MOD=0 moon test` passes — not run (docs-only)
- [ ] `git diff *.mbti` reviewed for unintended API surface changes — no `.mbti` changes
- [ ] JS rebuild run if web is affected — not run (docs-only)

## Validation

```bash
python3 - <<'PY'
from pathlib import Path
checks = [
    (Path('protocol/README.md'), Path('../docs/development/API_REFERENCE.md')),
    (Path('adapters/editor-adapter/README.md'), Path('../../protocol/README.md')),
]
for base, target in checks:
    resolved = (base.parent / target).resolve()
    assert resolved.exists(), f'missing link target from {base}: {target}'
lines = Path('protocol/README.md').read_text().splitlines()
start = lines.index('| Field | Direction | Unit | Meaning |')
for line in lines[start:start + 9]:
    if line.startswith('|'):
        cells = [c.strip() for c in line.strip('|').split('|')]
        assert len(cells) == 4, f'table row has {len(cells)} cells: {line}'
print('markdown review: changed links resolve; protocol position table has 4 columns')
PY
rg -n "framework/protocol" adapters protocol docs --glob '!docs/archive/**'
git diff --check
```
