### PR TITLE
ci: cache MoonBit registry state

### DIFF
--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -18,3 +18,14 @@ runs:
       uses: hustcer/setup-moonbit@v1.22
       env:
         GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Cache MoonBit registry state
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.moon/registry/index
+          ~/.moon/registry/cache
+          ~/.moon/registry/symbols
+        key: moonbit-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/moon.mod.json') }}
+        restore-keys: |
+          moonbit-registry-${{ runner.os }}-${{ runner.arch }}-

--- a/docs/archive/completed-phases/2026-04-01-editor-protocol-design.md
+++ b/docs/archive/completed-phases/2026-04-01-editor-protocol-design.md
@@ -1,5 +1,12 @@
 # EditorProtocol — Framework-Agnostic Integration Layer
 
+**Status:** Completed and archived. The current protocol source of truth is
+[`protocol/README.md`](../../protocol/README.md), the MoonBit implementation in
+[`protocol/`](../../protocol/), and the TypeScript mirror in
+[`adapters/editor-adapter/types.ts`](../../adapters/editor-adapter/types.ts).
+This plan is historical and may describe implementation details as they existed
+when the protocol layer was designed.
+
 ## Why
 
 The examples/ apps duplicate heavy TypeScript logic that MoonBit already knows

--- a/docs/performance/2026-04-01-viewnode-serialization-spike.md
+++ b/docs/performance/2026-04-01-viewnode-serialization-spike.md
@@ -1,7 +1,7 @@
 # ViewNode JSON Serialization — Phase 0 Spike
 
 Date: 2026-04-01
-Context: EditorProtocol design validation (`docs/plans/2026-04-01-editor-protocol-design.md`)
+Context: EditorProtocol design validation (`docs/archive/completed-phases/2026-04-01-editor-protocol-design.md`)
 
 ## Question
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -36,7 +36,7 @@ unit:
 - **ProseMirror tree position** — an offset in the ProseMirror document tree.
   It is not a source-text offset.
 
-PR #555 replaced `UserIntent.SetCursor(position)` with separate cursor intents
+PR #555 replaced the old generic cursor intent with separate cursor intents
 so these units stay separate.
 
 | Field | Direction | Unit | Meaning |

--- a/scripts/moon-update.sh
+++ b/scripts/moon-update.sh
@@ -58,13 +58,13 @@ while :; do
     exit 0
   fi
 
-  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-    echo "moon-update: failed after ${attempt} attempt(s) (exit ${status}); giving up." >&2
+  if ! grep -qiE "$TRANSIENT_RE" "$log"; then
+    echo "moon-update: failure (exit ${status}) is not the transient CDN/network signature; not retrying." >&2
     exit "$status"
   fi
 
-  if ! grep -qiE "$TRANSIENT_RE" "$log"; then
-    echo "moon-update: failure (exit ${status}) is not the transient CDN/network signature; not retrying." >&2
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "moon-update: setup/network failure persisted after ${attempt} attempt(s) (exit ${status}); giving up." >&2
     exit "$status"
   fi
 

--- a/scripts/test-moon-update-wrapper.sh
+++ b/scripts/test-moon-update-wrapper.sh
@@ -39,6 +39,16 @@ LOG
     fi
     echo "fake moon: update succeeded"
     ;;
+  registry-clone-always-transient)
+    cat >&2 <<'LOG'
+Error: update failed
+
+Caused by:
+    0: failed to clone registry index
+    1: non-zero exit code: exit status: 128
+LOG
+    exit 255
+    ;;
   deterministic-missing-package)
     cat >&2 <<'LOG'
 Error: update failed
@@ -87,6 +97,19 @@ assert_eq "$(cat "$transient_attempts")" "2" "transient registry clone should re
 grep -q "transient registry/CDN/network failure" "$transient_output" || {
   echo "error: transient retry message missing" >&2
   cat "$transient_output" >&2
+  exit 1
+}
+
+exhausted_attempts="$tmp_dir/exhausted-attempts"
+exhausted_output="$tmp_dir/exhausted-output.log"
+if run_wrapper registry-clone-always-transient "$exhausted_attempts" "$exhausted_output"; then
+  echo "error: exhausted transient registry clone unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_eq "$(cat "$exhausted_attempts")" "3" "transient registry clone should stop at max attempts"
+grep -q "setup/network failure persisted" "$exhausted_output" || {
+  echo "error: exhausted transient failure did not report setup/network failure" >&2
+  cat "$exhausted_output" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Summary

- Cache the MoonBit registry index/cache/symbols in the shared setup action so CI jobs can avoid fresh registry clones when cache state is available.
- Make exhausted transient `moon update` failures explicitly report a setup/network failure while keeping deterministic dependency failures non-retried.
- Archive the completed editor protocol plan and update the performance doc link to the archived path.

Closes #557.
Closes #559.

## Reuse check

Pure CI/docs/shell-script change. No MoonBit functions, methods, helpers, or types added.

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Shared MoonBit setup action | `.github/actions/setup-moonbit/action.yml` | Yes | Added registry caching once for all CI jobs that use the action. |
| Moon update retry wrapper | `scripts/moon-update.sh` | Yes | Kept centralized retry/backoff behavior and improved final setup/network diagnostics. |
| Documentation doctrine | `docs/development/documentation-doctrine.md` | Yes | Archived the completed protocol plan instead of keeping it in active plans. |

New helpers added (if any):

None.

## Test plan

- [x] `bash -n scripts/moon-update.sh scripts/test-moon-update-wrapper.sh`
- [x] `./scripts/test-moon-update-wrapper.sh`
- [x] `./scripts/check-moon-update-wrapped.sh`
- [x] `rg -n "framework/protocol|SetCursor\\(position\\)" docs/plans protocol adapters/editor-adapter/README.md adapters/editor-adapter/types.ts` produced no output
- [x] `rg -n "2026-04-01-editor-protocol-design" docs README.md .github AGENTS.md --glob '!docs/archive/**'` only reports the performance doc link to the archived plan
- [x] `git diff --check`
- [ ] `NEW_MOON_MOD=0 moon check` passes — not run (CI/docs/shell-only)
- [ ] `NEW_MOON_MOD=0 moon test` passes — not run (CI/docs/shell-only)
- [ ] `git diff *.mbti` reviewed for unintended API surface changes — no `.mbti` changes
- [ ] JS rebuild run if web is affected — not run (not web-code affecting)

## Validation

```bash
bash -n scripts/moon-update.sh scripts/test-moon-update-wrapper.sh
./scripts/test-moon-update-wrapper.sh
./scripts/check-moon-update-wrapped.sh
rg -n "framework/protocol|SetCursor\\(position\\)" docs/plans protocol adapters/editor-adapter/README.md adapters/editor-adapter/types.ts
rg -n "2026-04-01-editor-protocol-design" docs README.md .github AGENTS.md --glob '!docs/archive/**'
git diff --check
```
