### PR TITLE
feat(canvas): edit source-backed nodes from inspector

### DIFF
--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -107,6 +107,15 @@ pub fn disconnect_ports(
 }
 
 ///|
+struct NodeParamJson {
+  name : String
+  value_kind : String
+  value : String
+  unit : String?
+  editable : Bool
+} derive(Eq, ToJson)
+
+///|
 /// Serializable node snapshot. Uses plain Int for `id` to avoid
 /// the NodeId newtype wrapper appearing in JSON output.
 struct NodeJson {
@@ -121,6 +130,7 @@ struct NodeJson {
   inputs : Array[PortDef]
   outputs : Array[PortDef]
   configured : Bool
+  params : Array[NodeParamJson]
 } derive(Eq, ToJson)
 
 ///|
@@ -197,6 +207,7 @@ fn node_to_json(n : CanvasNode) -> NodeJson {
     inputs: n.inputs,
     outputs: n.outputs,
     configured: n.configured,
+    params: [],
   }
 }
 

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -103,6 +103,70 @@ fn graph_node_for_canvas_id(
 }
 
 ///|
+fn graph_param_value_kind_text(kind : @graph_dsl.GraphValueKind) -> String {
+  match kind {
+    @graph_dsl.Numeric => "numeric"
+    @graph_dsl.StringValue => "string"
+    @graph_dsl.EnumValue => "enum"
+    @graph_dsl.InputRef => "input-ref"
+  }
+}
+
+///|
+fn graph_param_token_text(
+  param : @graph_dsl.GraphParam,
+  role : @graph_dsl.GraphTokenRole,
+) -> String? {
+  let tokens = param.value_tokens()
+  match tokens.search_by(fn(token) { token.role() == role }) {
+    Some(index) => Some(tokens[index].text())
+    None => None
+  }
+}
+
+///|
+fn graph_param_value_text(param : @graph_dsl.GraphParam) -> String {
+  let role = match param.value_kind() {
+    @graph_dsl.Numeric => @graph_dsl.NumericParameter
+    @graph_dsl.StringValue => @graph_dsl.StringField
+    @graph_dsl.EnumValue => @graph_dsl.EnumField
+    @graph_dsl.InputRef => @graph_dsl.InputReference
+  }
+  match graph_param_token_text(param, role) {
+    Some(text) => text
+    None => ""
+  }
+}
+
+///|
+fn graph_param_json(param : @graph_dsl.GraphParam) -> NodeParamJson {
+  let value_kind = param.value_kind()
+  {
+    name: param.name(),
+    value_kind: graph_param_value_kind_text(value_kind),
+    value: graph_param_value_text(param),
+    unit: graph_param_token_text(param, @graph_dsl.Unit),
+    editable: match value_kind {
+      @graph_dsl.Numeric => true
+      _ => false
+    },
+  }
+}
+
+///|
+fn source_node_to_json(
+  doc : @graph_dsl.GraphDoc,
+  node : CanvasNode,
+) -> NodeJson {
+  let base = node_to_json(node)
+  match graph_node_for_canvas_id(doc, node.id) {
+    Some(graph_node) =>
+      { ..base, params: graph_node.params().map(graph_param_json) }
+    None => base
+  }
+}
+
+///|
 fn canvas_node_from_graph_node(
   index : Int,
   graph_node : @graph_dsl.GraphNode,
@@ -326,6 +390,53 @@ fn source_graph_current_doc(
 }
 
 ///|
+fn lower_rename_node(
+  doc : @graph_dsl.GraphDoc,
+  node_id : NodeId,
+  new_name : String,
+) -> Result[SourceOperationEdit, String] {
+  let node = match graph_node_for_canvas_id(doc, node_id) {
+    Some(node) => node
+    None => return Err("cannot lower RenameNode: missing node")
+  }
+  match doc.lower_rename_node_binding(node.binding(), new_name) {
+    Some(edit) => Ok(ExactLoweredEdit(edit))
+    None =>
+      Err(
+        "cannot lower RenameNode for binding '" +
+        node.binding() +
+        "' to '" +
+        new_name +
+        "'",
+      )
+  }
+}
+
+///|
+fn lower_set_node_param(
+  doc : @graph_dsl.GraphDoc,
+  node_id : NodeId,
+  parameter : String,
+  value : String,
+) -> Result[SourceOperationEdit, String] {
+  let node = match graph_node_for_canvas_id(doc, node_id) {
+    Some(node) => node
+    None => return Err("cannot lower SetNodeParam: missing node")
+  }
+  match doc.lower_set_numeric(node.binding(), parameter, value) {
+    Some(edit) => Ok(ExactLoweredEdit(edit))
+    None =>
+      Err(
+        "cannot lower SetNodeParam for binding '" +
+        node.binding() +
+        "' parameter '" +
+        parameter +
+        "'",
+      )
+  }
+}
+
+///|
 fn lower_source_operation(
   doc : @graph_dsl.GraphDoc,
   operation : GraphOperation,
@@ -365,6 +476,9 @@ fn lower_source_operation(
       }
     }
     DeleteNodes(nodes) => lower_delete_nodes(doc, nodes)
+    RenameNode(node_id, new_name) => lower_rename_node(doc, node_id, new_name)
+    SetNodeParam(node_id, parameter, value) =>
+      lower_set_node_param(doc, node_id, parameter, value)
     DisconnectPorts(source, source_port, target, target_port) =>
       lower_disconnect_ports(doc, source, source_port, target, target_port)
     MoveNodes(_) =>
@@ -491,17 +605,38 @@ fn SourceBackedGraph::remap_deleted_interaction(
 }
 
 ///|
+fn SourceBackedGraph::rename_layout_binding(
+  self : SourceBackedGraph,
+  old_binding : String,
+  new_binding : String,
+) -> Unit {
+  self.layout = self.layout.map(fn(position) {
+    if position.binding == old_binding {
+      { ..position, binding: new_binding }
+    } else {
+      position
+    }
+  })
+}
+
+///|
 fn SourceBackedGraph::sync_local_operation_state(
   self : SourceBackedGraph,
-  doc : @graph_dsl.GraphDoc,
+  old_doc : @graph_dsl.GraphDoc,
+  new_doc : @graph_dsl.GraphDoc,
   operation : GraphOperation,
   survivor_selection_bindings : Array[String],
 ) -> Unit {
   match operation.action() {
     DeleteNodes(_) => {
-      self.remap_deleted_interaction(doc, survivor_selection_bindings)
+      self.remap_deleted_interaction(new_doc, survivor_selection_bindings)
       self.sync_layout_from_state(source_graph_base_canvas_state(self))
     }
+    RenameNode(node_id, new_binding) =>
+      match graph_node_for_canvas_id(old_doc, node_id) {
+        Some(node) => self.rename_layout_binding(node.binding(), new_binding)
+        None => ()
+      }
     _ => ()
   }
 }
@@ -849,11 +984,30 @@ pub fn source_graph_zoom(
 }
 
 ///|
+fn source_render_state_string(
+  graph : SourceBackedGraph,
+  state : CanvasState,
+  validation : Array[ValidationJson],
+) -> String {
+  let rendered = render_state_json(state, validation)
+  match source_graph_doc_for_render(graph) {
+    Some(doc) =>
+      {
+        ..rendered,
+        nodes: state.nodes.map(fn(node) { source_node_to_json(doc, node) }),
+      }
+      .to_json()
+      .stringify()
+    None => rendered.to_json().stringify()
+  }
+}
+
+///|
 pub fn get_source_graph_render_state(handle : Int) -> String {
   match source_graph_by_handle(handle) {
     Some(graph) => {
       let state = source_graph_canvas_state(graph)
-      render_state_string(state, source_graph_validation(graph))
+      source_render_state_string(graph, state, source_graph_validation(graph))
     }
     None =>
       render_state_string(empty_source_canvas_state(), [
@@ -915,11 +1069,11 @@ pub fn apply_source_graph_operation(
       return source_graph_result_for_graph(graph, false, Some(message))
   }
   match graph.apply_source_edit(lowered) {
-    Ok(doc) => {
+    Ok(new_doc) => {
       graph.sync_local_operation_state(
-        doc, operation, survivor_selection_bindings,
+        doc, new_doc, operation, survivor_selection_bindings,
       )
-      graph.append_operation(realized_source_operation(doc, operation))
+      graph.append_operation(realized_source_operation(new_doc, operation))
       source_graph_result_for_graph(graph, true, None)
     }
     Err(message) => source_graph_result_for_graph(graph, false, Some(message))

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -270,6 +270,112 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
 }
 
 ///|
+test "source-backed RenameNode updates binding and references" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)"
+  let handle = create_source_graph(source)
+  let rename = GraphOperation(RenameNode(NodeId(1), "lfo"))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, rename.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="lfo = sine(freq: 440Hz)\nmeter = scope(input: lfo)",
+  )
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  match operations {
+    [renamed] =>
+      match renamed.action() {
+        RenameNode(node_id, name) => {
+          @debug.assert_eq(node_id, NodeId(1))
+          inspect(name, content="lfo")
+        }
+        _ => abort("expected RenameNode action")
+      }
+    _ => abort("expected one source-backed rename operation")
+  }
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed RenameNode preserves layout keyed by binding" {
+  let source = "osc = sine(freq: 440Hz)"
+  let handle = create_source_graph(source)
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.layout = [{ binding: "osc", x: 42.0, y: 24.0 }]
+    None => abort("expected source graph handle")
+  }
+  let rename = GraphOperation(RenameNode(NodeId(1), "lfo"))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, rename.to_json().stringify()),
+    ),
+    content="true",
+  )
+  match source_graph_by_handle(handle) {
+    Some(graph) =>
+      match graph.layout {
+        [position] => {
+          inspect(position.binding, content="lfo")
+          inspect(position.x, content="42")
+          inspect(position.y, content="24")
+        }
+        _ => abort("expected one layout position")
+      }
+    None => abort("expected source graph handle")
+  }
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed SetNodeParam edits a numeric parameter token" {
+  let source = "osc = sine(freq: 440Hz, wave: \"saw\")\nmeter = scope()"
+  let handle = create_source_graph(source)
+  let set_param = GraphOperation(SetNodeParam(NodeId(1), "freq", "880"))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, set_param.to_json().stringify()),
+    ),
+    content="true",
+  )
+  inspect(
+    get_source_graph_source(handle),
+    content="osc = sine(freq: 880Hz, wave: \"saw\")\nmeter = scope()",
+  )
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  match operations {
+    [edited] =>
+      match edited.action() {
+        SetNodeParam(node_id, parameter, value) => {
+          @debug.assert_eq(node_id, NodeId(1))
+          inspect(parameter, content="freq")
+          inspect(value, content="880")
+        }
+        _ => abort("expected SetNodeParam action")
+      }
+    _ => abort("expected one source-backed parameter operation")
+  }
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed SetNodeParam rejects non-numeric source text" {
+  let source = "osc = sine(freq: 440Hz)"
+  let handle = create_source_graph(source)
+  let set_param = GraphOperation(SetNodeParam(NodeId(1), "freq", "880Hz"))
+  let result = apply_source_graph_operation(
+    handle,
+    set_param.to_json().stringify(),
+  )
+  inspect(operation_result_applied(result), content="false")
+  inspect(get_source_graph_source(handle), content=source)
+  inspect(get_source_graph_action_log(handle), content="[]")
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed DeleteNodes removes a safe binding line" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()"
   let handle = create_source_graph(source)

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -88,6 +88,8 @@ type LoweredCanvas derive(Eq)
 
 type NodeJson derive(Eq, ToJson)
 
+type NodeParamJson derive(Eq, ToJson)
+
 type NormalizedCanvas derive(Eq)
 
 type RenderStateJson derive(Eq, ToJson)

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -116,6 +116,63 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   expect(runtimeErrors).toEqual([]);
 });
 
+async function selectSourceNode(page: Page, nodeId: number): Promise<void> {
+  const node = page.locator(`.canvas-node[data-node-id="${nodeId}"]`);
+  await node.click();
+  await expect(node).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
+}
+
+test('source-backed inspector rename lowers to canonical source and references', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await page.locator('#source-connect').click();
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
+  );
+
+  await selectSourceNode(page, 1);
+  const renameInput = page.locator('#node-rename-input');
+  await expect(renameInput).toHaveValue('osc');
+  await renameInput.fill('lfo');
+  await renameInput.press('Enter');
+
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'lfo = sine(freq: 440Hz)\nmeter = scope(input: lfo)',
+  );
+  await expect(page.locator('.canvas-node[data-node-id="1"] .node-title')).toHaveText('lfo');
+  await expect(page.locator('#edges path.edge')).toHaveCount(1);
+  await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
+  await expect(page.locator('#source-status')).toContainText(
+    'Renamed node binding through graph-dsl source.',
+  );
+  await expect(page.locator('#action-stat')).toHaveText('3 actions logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
+test('source-backed inspector numeric parameter edit lowers to canonical source', async ({ page }) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+
+  await selectSourceNode(page, 1);
+  const freqInput = page.locator('#node-param-freq');
+  await expect(freqInput).toHaveValue('440');
+  await freqInput.fill('880');
+  await freqInput.press('Enter');
+
+  await expect(page.locator('#source-editor')).toHaveValue(
+    'osc = sine(freq: 880Hz)\nmeter = scope()',
+  );
+  await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
+  await expect(page.locator('#source-status')).toContainText(
+    'Updated freq through graph-dsl source.',
+  );
+  await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
+  expect(runtimeErrors).toEqual([]);
+});
+
 test('source-backed selected edge deletion lowers into canonical source', async ({ page }) => {
   const runtimeErrors = collectRuntimeErrors(page);
 

--- a/examples/canvas/web/index.html
+++ b/examples/canvas/web/index.html
@@ -308,6 +308,52 @@
       font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
       font-size: 10.5px;
     }
+    .inspector-source-editor {
+      display: grid;
+      gap: 8px;
+      margin-top: var(--space-sm);
+    }
+    .inspector-param-list {
+      display: grid;
+      gap: 6px;
+    }
+    .inspector-field {
+      display: grid;
+      grid-template-columns: minmax(64px, 0.45fr) minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 7px;
+      color: var(--text-faint);
+      font-size: 11px;
+    }
+    .inspector-field > span:first-child {
+      color: var(--text-muted);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+      letter-spacing: -0.01em;
+    }
+    .inspector-field input {
+      min-width: 0;
+      height: 28px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 0 8px;
+      color: var(--text);
+      background: oklch(22% 0.021 276 / 0.86);
+      font: 12px "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+      outline: none;
+    }
+    .inspector-field input:focus {
+      border-color: oklch(78% 0.07 276 / 0.58);
+      box-shadow: 0 0 0 2px oklch(58% 0.13 276 / 0.20);
+    }
+    .param-unit,
+    .param-readonly-value {
+      color: var(--text-faint);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+      font-size: 10.5px;
+    }
+    .inspector-field.readonly {
+      grid-template-columns: minmax(64px, 0.45fr) minmax(0, 1fr);
+    }
     .validation-item.warning {
       color: oklch(83% 0.07 54);
       background: oklch(30% 0.035 54 / 0.34);

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -370,7 +370,7 @@ export class GraphAdapter {
   renameNode(nodeId: number, name: string): SourceGraphOperationResult | null {
     this.assertLive();
     const nextName = name.trim();
-    if (!this.isSourceBacked || !Number.isFinite(nodeId) || nextName.length === 0) {
+    if (!this.isSourceBacked || !Number.isInteger(nodeId) || nodeId <= 0 || nextName.length === 0) {
       return null;
     }
     return this.applyOperation({
@@ -391,7 +391,8 @@ export class GraphAdapter {
     const nextValue = value.trim();
     if (
       !this.isSourceBacked ||
-      !Number.isFinite(nodeId) ||
+      !Number.isInteger(nodeId) ||
+      nodeId <= 0 ||
       nextParameter.length === 0 ||
       nextValue.length === 0
     ) {

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -99,6 +99,13 @@ const SOURCE_METHODS = [
 export type Tagged = string | [string, ...unknown[]];
 export type NodeKind = ['Workflow', Tagged];
 export type PortDef = { id: string; label: string; port_type: Tagged };
+export type NodeParamData = {
+  name: string;
+  value_kind: string;
+  value: string;
+  unit?: string;
+  editable: boolean;
+};
 export type NodeData = {
   id: number;
   x: number;
@@ -111,6 +118,7 @@ export type NodeData = {
   inputs: PortDef[];
   outputs: PortDef[];
   configured: boolean;
+  params?: NodeParamData[];
 };
 export type EdgeData = {
   id: number;
@@ -174,6 +182,14 @@ export type GraphOperation =
       target_port: string;
     }
   | { version: number; type: 'DeleteNodes'; nodes: number[] }
+  | { version: number; type: 'RenameNode'; node_id: number; name: string }
+  | {
+      version: number;
+      type: 'SetNodeParam';
+      node_id: number;
+      parameter: string;
+      value: string;
+    }
   | { version: number; type: 'SelectNodes'; nodes: number[] }
   | { version: number; type: 'SetViewport'; viewport: ViewportData };
 
@@ -349,6 +365,45 @@ export class GraphAdapter {
     this.mb.delete_nodes(this.handle, JSON.stringify(uniqueNodeIds));
     this.emitLatestOperations();
     return null;
+  }
+
+  renameNode(nodeId: number, name: string): SourceGraphOperationResult | null {
+    this.assertLive();
+    const nextName = name.trim();
+    if (!this.isSourceBacked || !Number.isFinite(nodeId) || nextName.length === 0) {
+      return null;
+    }
+    return this.applyOperation({
+      version: 1,
+      type: 'RenameNode',
+      node_id: nodeId,
+      name: nextName,
+    });
+  }
+
+  setNodeParam(
+    nodeId: number,
+    parameter: string,
+    value: string,
+  ): SourceGraphOperationResult | null {
+    this.assertLive();
+    const nextParameter = parameter.trim();
+    const nextValue = value.trim();
+    if (
+      !this.isSourceBacked ||
+      !Number.isFinite(nodeId) ||
+      nextParameter.length === 0 ||
+      nextValue.length === 0
+    ) {
+      return null;
+    }
+    return this.applyOperation({
+      version: 1,
+      type: 'SetNodeParam',
+      node_id: nodeId,
+      parameter: nextParameter,
+      value: nextValue,
+    });
   }
 
   disconnectPorts(

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -4,6 +4,7 @@ import {
   type Connecting,
   type EdgeData,
   type NodeData,
+  type NodeParamData,
   type PortDef,
   type RenderState,
   type SourceGraphOperationResult,
@@ -379,9 +380,156 @@ function renderValidation(state: RenderState): void {
   }
 }
 
+function commitSourceRename(nodeId: number, currentName: string, nextName: string): void {
+  const trimmed = nextName.trim();
+  if (trimmed === currentName || trimmed.length === 0) return;
+  const result = adapter.renameNode(nodeId, trimmed);
+  if (!result) return;
+  syncSourceEditorFromResult(result);
+  updateSourceOperationStatus(
+    result,
+    'Renamed node binding through graph-dsl source.',
+    'Source rename rejected',
+  );
+  clearSelectedEdge();
+  scheduleRender();
+}
+
+function commitSourceParam(
+  nodeId: number,
+  param: NodeParamData,
+  nextValue: string,
+): void {
+  const trimmed = nextValue.trim();
+  if (trimmed === param.value || trimmed.length === 0) return;
+  const result = adapter.setNodeParam(nodeId, param.name, trimmed);
+  if (!result) return;
+  syncSourceEditorFromResult(result);
+  updateSourceOperationStatus(
+    result,
+    `Updated ${param.name} through graph-dsl source.`,
+    'Source parameter edit rejected',
+  );
+  clearSelectedEdge();
+  scheduleRender();
+}
+
+function bindCommitOnChange(
+  input: HTMLInputElement,
+  originalValue: string,
+  commit: (value: string) => void,
+): void {
+  let committed = false;
+  const commitOnce = () => {
+    if (committed) return;
+    committed = true;
+    commit(input.value);
+  };
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitOnce();
+      input.blur();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      committed = true;
+      input.value = originalValue;
+      input.blur();
+    }
+  });
+  input.addEventListener('change', commitOnce);
+}
+
+function safeParamInputId(paramName: string): string {
+  return `node-param-${paramName.replace(/[^a-z0-9_-]/gi, '-')}`;
+}
+
+function renderSourceNodeEditor(node: NodeData): HTMLDivElement {
+  const editor = document.createElement('div');
+  editor.className = 'inspector-source-editor';
+
+  const bindingLabel = document.createElement('label');
+  bindingLabel.className = 'inspector-field';
+  bindingLabel.htmlFor = 'node-rename-input';
+  const bindingText = document.createElement('span');
+  bindingText.textContent = 'Binding';
+  const bindingInput = document.createElement('input');
+  bindingInput.id = 'node-rename-input';
+  bindingInput.type = 'text';
+  bindingInput.value = node.title;
+  bindingInput.autocomplete = 'off';
+  bindingInput.spellcheck = false;
+  bindingInput.setAttribute('aria-label', 'Node binding');
+  bindCommitOnChange(bindingInput, node.title, (value) => {
+    commitSourceRename(node.id, node.title, value);
+  });
+  bindingLabel.replaceChildren(bindingText, bindingInput);
+  editor.appendChild(bindingLabel);
+
+  const params = node.params ?? [];
+  if (params.length === 0) return editor;
+
+  const paramList = document.createElement('div');
+  paramList.className = 'inspector-param-list';
+  for (const param of params) {
+    const row = document.createElement('label');
+    row.className = `inspector-field param ${param.editable ? 'editable' : 'readonly'}`;
+    const id = safeParamInputId(param.name);
+    row.htmlFor = id;
+    const name = document.createElement('span');
+    name.textContent = param.name;
+    if (param.editable) {
+      const input = document.createElement('input');
+      input.id = id;
+      input.type = 'text';
+      input.inputMode = 'decimal';
+      input.value = param.value;
+      input.autocomplete = 'off';
+      input.spellcheck = false;
+      input.setAttribute('aria-label', `Parameter ${param.name}`);
+      bindCommitOnChange(input, param.value, (value) => {
+        commitSourceParam(node.id, param, value);
+      });
+      if (param.unit) {
+        const unit = document.createElement('span');
+        unit.className = 'param-unit';
+        unit.textContent = param.unit;
+        row.replaceChildren(name, input, unit);
+      } else {
+        row.replaceChildren(name, input);
+      }
+    } else {
+      const value = document.createElement('span');
+      value.className = 'param-readonly-value';
+      value.textContent = param.unit ? `${param.value}${param.unit}` : param.value;
+      row.replaceChildren(name, value);
+    }
+    paramList.appendChild(row);
+  }
+  editor.appendChild(paramList);
+  return editor;
+}
+
 function renderInspector(state: RenderState): void {
   inspectorNode.replaceChildren();
-  if (!state.inspector) {
+  const selectedNodeId = state.selected ?? state.selected_nodes?.[0];
+  const selectedNode = selectedNodeId != null
+    ? state.nodes.find((candidate) => candidate.id === selectedNodeId)
+    : undefined;
+  const inspector = state.inspector ?? (
+    adapter.isSourceBacked && selectedNode
+      ? {
+          id: selectedNode.id,
+          title: selectedNode.title,
+          subtitle: selectedNode.subtitle,
+          configured: selectedNode.configured,
+          input_count: selectedNode.inputs.length,
+          output_count: selectedNode.outputs.length,
+          source: 'selected',
+        }
+      : undefined
+  );
+  if (!inspector) {
     const empty = document.createElement('div');
     empty.className = 'inspector-empty';
     empty.textContent = 'Select or hover a node to inspect its sparse derived details.';
@@ -389,7 +537,7 @@ function renderInspector(state: RenderState): void {
     return;
   }
 
-  const item = state.inspector;
+  const item = inspector;
   const status = item.configured ? 'Configured' : 'Needs config';
   const source = item.source === 'selected' ? 'Selected node' : 'Hovered node';
 
@@ -409,7 +557,13 @@ function renderInspector(state: RenderState): void {
   const portsSpan = document.createElement('span');
   portsSpan.textContent = `${item.input_count} in · ${item.output_count} out`;
   meta.replaceChildren(statusSpan, portsSpan);
-  inspectorNode.replaceChildren(eyebrow, title, subtitle, meta);
+
+  const children: HTMLElement[] = [eyebrow, title, subtitle, meta];
+  if (adapter.isSourceBacked && item.source === 'selected') {
+    const node = state.nodes.find((candidate) => candidate.id === item.id);
+    if (node) children.push(renderSourceNodeEditor(node));
+  }
+  inspectorNode.replaceChildren(...children);
 }
 
 function focusNode(nodeId: number): void {

--- a/lib/canvas-graph/graph_model/graph_operation_test.mbt
+++ b/lib/canvas-graph/graph_model/graph_operation_test.mbt
@@ -94,6 +94,38 @@ test "DisconnectPorts serializes endpoint ports" {
 }
 
 ///|
+test "source-backed edit actions serialize node and parameter payloads" {
+  let rename = @graph_model.GraphOperation::GraphOperation(
+    @graph_model.WorkflowAction::RenameNode(node_id(1), "oscillator"),
+  )
+  inspect(
+    rename.to_json().stringify(),
+    content="{\"version\":1,\"type\":\"RenameNode\",\"node_id\":1,\"name\":\"oscillator\"}",
+  )
+  let set_param = @graph_model.GraphOperation::GraphOperation(
+    @graph_model.WorkflowAction::SetNodeParam(node_id(1), "freq", "880"),
+  )
+  inspect(
+    set_param.to_json().stringify(),
+    content="{\"version\":1,\"type\":\"SetNodeParam\",\"node_id\":1,\"parameter\":\"freq\",\"value\":\"880\"}",
+  )
+  let decoded : Array[@graph_model.GraphOperation] = @json.from_json(
+    [rename.to_json(), set_param.to_json()].to_json(),
+  )
+  @debug.assert_eq(decoded, [rename, set_param])
+}
+
+///|
+test "RenameNode updates the canvas node title" {
+  let renamed = @graph_model.apply_action(
+    replay_base_state(),
+    @graph_model.WorkflowAction::RenameNode(node_id(1), "Daily trigger"),
+  )
+  inspect(renamed.nodes[0].title, content="Daily trigger")
+  inspect(renamed.nodes[1].title, content="HTTP request")
+}
+
+///|
 test "operation log round-trips and replays into canvas graph state" {
   let added = @graph_model.make_workflow_node(
     node_id(3),

--- a/lib/canvas-graph/graph_model/model.mbt
+++ b/lib/canvas-graph/graph_model/model.mbt
@@ -184,6 +184,8 @@ pub(all) enum WorkflowAction {
   ConnectPorts(NodeId, String, NodeId, String)
   DisconnectPorts(NodeId, String, NodeId, String)
   DeleteNodes(Array[NodeId])
+  RenameNode(NodeId, String)
+  SetNodeParam(NodeId, String, String)
   SelectNodes(Array[NodeId])
   SetViewport(Viewport)
 } derive(Debug, Eq, ToJson)
@@ -303,6 +305,17 @@ pub impl ToJson for GraphOperation with fn to_json(self) {
       fields["type"] = "DeleteNodes".to_json()
       fields["nodes"] = nodes.to_json()
     }
+    RenameNode(node_id, name) => {
+      fields["type"] = "RenameNode".to_json()
+      fields["node_id"] = node_id.to_json()
+      fields["name"] = name.to_json()
+    }
+    SetNodeParam(node_id, parameter, value) => {
+      fields["type"] = "SetNodeParam".to_json()
+      fields["node_id"] = node_id.to_json()
+      fields["parameter"] = parameter.to_json()
+      fields["value"] = value.to_json()
+    }
     SelectNodes(nodes) => {
       fields["type"] = "SelectNodes".to_json()
       fields["nodes"] = nodes.to_json()
@@ -382,6 +395,23 @@ pub impl @json.FromJson for GraphOperation with fn from_json(json, path) {
         require_json_field(fields, path, "nodes", "DeleteNodes"),
       )
       WorkflowAction::DeleteNodes(nodes)
+    }
+    "RenameNode" => {
+      let node_id = NodeId(
+        json_number_field(fields, path, "node_id", "RenameNode"),
+      )
+      let name = json_string_field(fields, path, "name", "RenameNode")
+      WorkflowAction::RenameNode(node_id, name)
+    }
+    "SetNodeParam" => {
+      let node_id = NodeId(
+        json_number_field(fields, path, "node_id", "SetNodeParam"),
+      )
+      let parameter = json_string_field(
+        fields, path, "parameter", "SetNodeParam",
+      )
+      let value = json_string_field(fields, path, "value", "SetNodeParam")
+      WorkflowAction::SetNodeParam(node_id, parameter, value)
     }
     "SelectNodes" => {
       let nodes : Array[NodeId] = @json.from_json(
@@ -851,6 +881,17 @@ pub fn apply_action(
         state, source, source_port, target, target_port,
       )
     DeleteNodes(nodes) => delete_nodes_from_state(state, nodes)
+    RenameNode(node_id, name) => {
+      let nodes = state.nodes.map(fn(node) {
+        if node.id == node_id {
+          { ..node, title: name }
+        } else {
+          node
+        }
+      })
+      { ..state, nodes, }
+    }
+    SetNodeParam(_, _, _) => state
     SelectNodes(nodes) => set_selection(state, nodes)
     SetViewport(viewport) => { ..state, viewport, }
   }

--- a/lib/canvas-graph/graph_model/pkg.generated.mbti
+++ b/lib/canvas-graph/graph_model/pkg.generated.mbti
@@ -174,6 +174,8 @@ pub(all) enum WorkflowAction {
   ConnectPorts(NodeId, String, NodeId, String)
   DisconnectPorts(NodeId, String, NodeId, String)
   DeleteNodes(Array[NodeId])
+  RenameNode(NodeId, String)
+  SetNodeParam(NodeId, String, String)
   SelectNodes(Array[NodeId])
   SetViewport(Viewport)
 } derive(Eq, ToJson, @debug.Debug)


### PR DESCRIPTION
## Summary

- Add graph operations for source-backed node rename and numeric parameter edits, lowering them through Graph DSL source and action logging.
- Surface Graph DSL parameters in source-backed render state and add inspector controls for binding rename / numeric parameter edits.
- Cover rename, parameter edit, layout preservation, source synchronization, and browser behavior with MoonBit + Playwright tests.

Closes #482

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `GraphDoc::lower_rename_node_binding` | `loom/examples/graph-dsl/src/lowering.mbt` | Yes | Used for binding rename plus input-reference updates. |
| `GraphDoc::lower_set_numeric` | `loom/examples/graph-dsl/src/lowering.mbt` | Yes | Used for numeric parameter edits while preserving unit tokens. |
| `LoweredGraphEdit::{new_source, incremental_edit}` | `loom/examples/graph-dsl/src/lowering.mbt` | Yes | Reused by existing `SourceBackedGraph::apply_source_edit`. |
| `GraphAttachment::{apply_edit, set_source}` | `loom/examples/graph-dsl/src/attachment.mbt` | Yes | Keeps source canonical and reparses through Loom state. |
| `GraphParam::{name, value_kind, value_tokens}` / `GraphToken::{role, text}` | `loom/examples/graph-dsl/src/graph_doc.mbt` | Yes | Used to project params into source-backed render JSON. |
| `GraphAdapter.applyOperation` | `examples/canvas/web/src/graph-adapter.ts` | Yes | Used for new TS rename/param methods to preserve source-backed action flow. |
| `syncSourceEditorFromResult` / `updateSourceOperationStatus` | `examples/canvas/web/src/main.ts` | Yes | Reused for inspector edit source/status synchronization. |

New helpers added (if any):

- `lower_rename_node` / `lower_set_node_param`: adapter-local NodeId-to-GraphDoc binding resolution plus existing Graph DSL lowerer calls.
- `graph_param_*` / `source_node_to_json`: adapter-local projection of Graph DSL params into canvas render JSON for the inspector.
- `source_render_state_string`: source-backed render-state specialization that enriches nodes with source params.
- `rename_layout_binding`: keeps local layout keyed by binding when a source-backed rename changes the binding.
- TS inspector helpers (`commitSourceRename`, `commitSourceParam`, `bindCommitOnChange`, `renderSourceNodeEditor`): DOM glue for source-backed inspector edits.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/canvas/web && npm run build`)

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
cd examples/canvas/web && npm run build
cd examples/canvas/web && npm run test:e2e -- --reporter=line
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node renaming: Rename canvas nodes directly via the inspector UI.
  * Node parameter editing: Edit node parameters (e.g., frequency) in the inspector.
  * Source synchronization: Node changes automatically update source code in source-backed projects.
  * Action tracking: Rename and parameter operations logged in action history.

* **Tests**
  * Added end-to-end tests for node rename and parameter edit functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->