### PR TITLE
feat(canvas): preserve source-backed selection across source reorder

### DIFF
--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -548,10 +548,10 @@ fn SourceBackedGraph::append_operation(
 }
 
 ///|
-fn source_delete_surviving_selection_bindings(
+fn source_selected_node_bindings(
   doc : @graph_dsl.GraphDoc,
   interaction : InteractionState,
-  deleted : Array[NodeId],
+  deleted? : Array[NodeId] = [],
 ) -> Array[String] {
   let bindings : Array[String] = []
   for node_id in interaction.selected_nodes {
@@ -914,8 +914,7 @@ fn set_source_graph_source_checked(
       )
   }
   let selection_bindings = match source_graph_doc_for_render(graph) {
-    Some(doc) =>
-      source_delete_surviving_selection_bindings(doc, graph.interaction, [])
+    Some(doc) => source_selected_node_bindings(doc, graph.interaction)
     None => []
   }
   graph.source = source
@@ -1064,11 +1063,7 @@ pub fn apply_source_graph_operation(
   }
   let survivor_selection_bindings = match operation.action() {
     DeleteNodes(deleted) =>
-      source_delete_surviving_selection_bindings(
-        doc,
-        graph.interaction,
-        deleted,
-      )
+      source_selected_node_bindings(doc, graph.interaction, deleted~)
     _ => []
   }
   let lowered = match lower_source_operation(doc, operation) {

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -581,12 +581,12 @@ fn source_selection_from_bindings(
 }
 
 ///|
-fn SourceBackedGraph::remap_deleted_interaction(
+fn SourceBackedGraph::remap_selection_to_bindings(
   self : SourceBackedGraph,
   doc : @graph_dsl.GraphDoc,
-  survivor_bindings : Array[String],
+  bindings : Array[String],
 ) -> Unit {
-  let selected_nodes = source_selection_from_bindings(doc, survivor_bindings)
+  let selected_nodes = source_selection_from_bindings(doc, bindings)
   let selected = if selected_nodes.length() == 0 {
     None
   } else {
@@ -629,7 +629,7 @@ fn SourceBackedGraph::sync_local_operation_state(
 ) -> Unit {
   match operation.action() {
     DeleteNodes(_) => {
-      self.remap_deleted_interaction(new_doc, survivor_selection_bindings)
+      self.remap_selection_to_bindings(new_doc, survivor_selection_bindings)
       self.sync_layout_from_state(source_graph_base_canvas_state(self))
     }
     RenameNode(node_id, new_binding) =>
@@ -913,10 +913,18 @@ fn set_source_graph_source_checked(
         Some("source graph handle not found"),
       )
   }
+  let selection_bindings = match source_graph_doc_for_render(graph) {
+    Some(doc) =>
+      source_delete_surviving_selection_bindings(doc, graph.interaction, [])
+    None => []
+  }
   graph.source = source
   graph.attachment.set_source(source)
   match source_graph_current_doc(graph) {
-    Ok(_) => source_graph_result_json_for_graph(graph, true, None)
+    Ok(doc) => {
+      graph.remap_selection_to_bindings(doc, selection_bindings)
+      source_graph_result_json_for_graph(graph, true, None)
+    }
     Err(message) =>
       source_graph_result_json_for_graph(graph, false, Some(message))
   }

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -526,6 +526,9 @@ test "source-backed source edit clears selection when binding is removed" {
 }
 
 ///|
+/// Guards the invalid-source branch of `set_source_graph_source_checked`:
+/// selection must NOT be remapped when reparse fails, because render falls
+/// back to the last-good doc whose order still matches the stored numeric ids.
 test "source-backed source edit keeps selection while source is invalid" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)
@@ -535,6 +538,72 @@ test "source-backed source edit keeps selection while source is invalid" {
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
     [2],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed source edit preserves index-0 survivor when later binding removed" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 1, 0.0, 0.0)
+  source_graph_pointer_up(handle, 1, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [1],
+  )
+  set_source_graph_source(handle, "osc = sine(freq: 440Hz)")
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [1],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed source reorder that drops the selected node clears selection" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 2, 0.0, 0.0)
+  source_graph_pointer_up(handle, 2, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [2],
+  )
+  // Reorder the survivors and drop the selected binding (meter) in one edit.
+  set_source_graph_source(handle, "reverb = plate()\nosc = sine(freq: 440Hz)")
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed source reorder preserves multi-selection order by binding" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()"
+  let handle = create_source_graph(source)
+  match source_graph_by_handle(handle) {
+    Some(graph) =>
+      // Select osc (1) then reverb (3); capture order follows selected_nodes.
+      graph.interaction = {
+        dragging: None,
+        panning: None,
+        connecting: None,
+        selected: Some(NodeId(1)),
+        selected_nodes: [NodeId(1), NodeId(3)],
+        pointer_down: false,
+        did_move: false,
+      }
+    None => abort("expected source graph handle")
+  }
+  set_source_graph_source(
+    handle, "reverb = plate()\nmeter = scope()\nosc = sine(freq: 440Hz)",
+  )
+  // reverb=1, osc=3 now; selection keeps capture order [osc, reverb] -> [3, 1].
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [3, 1],
   )
   destroy_source_graph(handle)
 }

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -490,6 +490,56 @@ test "source-backed DeleteNodes remaps selected survivor by binding" {
 }
 
 ///|
+test "source-backed source reorder preserves selection by binding" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 2, 0.0, 0.0)
+  source_graph_pointer_up(handle, 2, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [2],
+  )
+  set_source_graph_source(handle, "meter = scope()\nosc = sine(freq: 440Hz)")
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [1],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed source edit clears selection when binding is removed" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 2, 0.0, 0.0)
+  source_graph_pointer_up(handle, 2, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [2],
+  )
+  set_source_graph_source(handle, "osc = sine(freq: 440Hz)")
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed source edit keeps selection while source is invalid" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  source_graph_pointer_down(handle, 2, 0.0, 0.0)
+  source_graph_pointer_up(handle, 2, "", false)
+  set_source_graph_source(handle, "osc = sine(freq: )")
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [2],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed DisconnectPorts removes only the target input reference" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc, gain: 2)\ntap = scope(input: osc)"
   let handle = create_source_graph(source)


### PR DESCRIPTION
## Summary

Closes #484. Source-backed canvas `NodeId`s are minted fresh as `NodeId(index + 1)` from `GraphDoc::nodes()` order on every render frame, but stored selection (`interaction.selected` / `selected_nodes`) held numeric ids. A **direct source-text edit** that reordered binding lines silently retargeted selection — and therefore the inspector and action payloads — to whatever binding now occupied that doc index. The operation/delete path already remapped selection by binding (PR #490); the direct-edit entry `set_source_graph_source_checked` did not.

## Fix

Capture the selected nodes' bindings against the pre-edit render doc, set the new source, and remap selection back to those bindings' current ids **only on a valid reparse** (dropping bindings that vanished). When the new source is invalid, selection is left untouched because render falls back to the last-good doc whose order still matches the numeric ids.

- Renamed `remap_deleted_interaction` → `remap_selection_to_bindings` (body unchanged; now shared by the delete and set-source paths).
- No public API change (`moon info` shows no `.mbti` diff; all touched symbols are private).

Layout was already binding-keyed and unaffected; `action_log` is historical record, not live targeting, and is out of scope.

## Reuse check

No new helper introduced. The fix wires three existing functions together:

- `source_graph_doc_for_render` — pre-edit doc to capture bindings against.
- `source_delete_surviving_selection_bindings(doc, interaction, [])` — empty `deleted` yields all selected bindings ("nothing deleted ⇒ all selection survives").
- `remap_selection_to_bindings` (+ internal `source_selection_from_bindings`) — remap selection to bindings and clear transient gesture state.

## Tests

TDD: added the failing reorder test first (confirmed RED `[2] != [1]`), then the fix (GREEN). Plus two regression guards. `48 → 50` tests, all pass.

- `source-backed source reorder preserves selection by binding`
- `source-backed source edit clears selection when binding is removed`
- `source-backed source edit keeps selection while source is invalid`

```bash
cd examples/canvas
MOON_WORK=off moon check --target js
MOON_WORK=off moon test --target js   # 50 passed
```

Codex pre-PR review: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
