### PR TITLE
feat(canvas): lower CodeMirror change deltas into ordered loom edits

### DIFF
--- a/examples/canvas/main/codemirror_source_bridge.mbt
+++ b/examples/canvas/main/codemirror_source_bridge.mbt
@@ -1,0 +1,50 @@
+///|
+/// Bridge from CodeMirror change deltas to sequential loom source edits.
+///
+/// CodeMirror delivers every replaced range of a single transaction in the
+/// coordinates of the document *before* that transaction. Loom's
+/// `GraphAttachment::apply_edit` instead expects a sequence of edits, each
+/// expressed against the document as it stands immediately before that one
+/// edit, paired with the full source text the edit produces. This module
+/// performs that translation so a multi-change transaction reaches the source
+/// store as ordered, individually-applicable `@core.Edit`s.
+
+///|
+/// Translate an ordered batch of CodeMirror changes into the sequence of
+/// `(@core.Edit, new_source)` pairs that reproduce the same final document
+/// when applied left to right.
+fn changes_to_edits(
+  base_doc : String,
+  changes : Array[@codemirror.ChangeDelta],
+) -> Array[(@core.Edit, String)] {
+  let edits = []
+  let mut source = base_doc
+  // Running shift between pre-transaction coordinates (what CodeMirror reports)
+  // and the evolving document: every applied change moves later offsets by
+  // `new_len - old_len`. CodeMirror yields changes ascending and
+  // non-overlapping, so accumulating the shift left to right is sufficient.
+  let mut shift = 0
+  for change in changes {
+    let start = change.from + shift
+    let old_len = change.to - change.from
+    let new_len = change.insert.length()
+    source = splice_code_units(source, start, old_len, change.insert)
+    edits.push((@core.Edit::new(start, old_len, new_len), source))
+    shift += new_len - old_len
+  }
+  edits
+}
+
+///|
+/// Replace `[start, start + old_len)` of `source` with `insert`, indexing in
+/// UTF-16 code units to match CodeMirror and loom edit coordinates.
+fn splice_code_units(
+  source : String,
+  start : Int,
+  old_len : Int,
+  insert : String,
+) -> String {
+  source.view(end_offset=start).to_owned() +
+  insert +
+  source.view(start_offset=start + old_len).to_owned()
+}

--- a/examples/canvas/main/codemirror_source_bridge_wbtest.mbt
+++ b/examples/canvas/main/codemirror_source_bridge_wbtest.mbt
@@ -1,0 +1,46 @@
+///|
+/// A multi-change CodeMirror transaction reaches the source store as separate,
+/// ordered loom edits — each rebased onto the document the previous edit
+/// produced, and paired with the full source it yields.
+///
+/// Base document `abcdef`, one transaction with two replaced ranges (CodeMirror
+/// yields them ascending and non-overlapping, in pre-transaction coordinates):
+///   - replace [1,2) "b" with "XY"
+///   - delete  [4,5) "e"
+/// Worked by hand:
+///   change 1: start 1 (+0), old_len 1, new_len 2 -> "aXYcdef"; running shift +1
+///   change 2: start 4 (+1)=5, old_len 1, new_len 0 -> "aXYcdf"
+test "multi-change transaction lowers to ordered, rebased edits" {
+  let result = changes_to_edits("abcdef", [
+    @codemirror.ChangeDelta::new(1, 2, "XY"),
+    @codemirror.ChangeDelta::new(4, 5, ""),
+  ])
+  inspect(result.length(), content="2")
+  let (edit0, source0) = result[0]
+  inspect(edit0.start, content="1")
+  inspect(edit0.old_len, content="1")
+  inspect(edit0.new_len, content="2")
+  inspect(source0, content="aXYcdef")
+  let (edit1, source1) = result[1]
+  inspect(edit1.start, content="5")
+  inspect(edit1.old_len, content="1")
+  inspect(edit1.new_len, content="0")
+  inspect(source1, content="aXYcdf")
+}
+
+///|
+/// Offsets are UTF-16 code units end to end, so a change spanning a non-BMP
+/// (surrogate-pair) glyph carries `old_len == 2` and splices on code-unit
+/// boundaries. Base `a😀b` (code units: a=0, 😀=1..3, b=3); replace the emoji
+/// span [1,3) with "z" -> edit start 1, old_len 2, new_len 1, source "azb".
+test "code-unit coordinates survive a non-BMP change" {
+  let result = changes_to_edits("a😀b", [
+    @codemirror.ChangeDelta::new(1, 3, "z"),
+  ])
+  inspect(result.length(), content="1")
+  let (edit, source) = result[0]
+  inspect(edit.start, content="1")
+  inspect(edit.old_len, content="2")
+  inspect(edit.new_len, content="1")
+  inspect(source, content="azb")
+}

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -525,6 +525,63 @@ fn SourceBackedGraph::apply_source_edit(
 }
 
 ///|
+/// Apply one CodeMirror transaction — delivered as an ordered batch of
+/// pre-transaction `ChangeDelta`s — to the source-backed graph as a sequence
+/// of loom edits.
+///
+/// `changes_to_edits` rebases each change onto the document the previous one
+/// produced, so the attachment's incremental reparse sees the same per-edit
+/// stream a user typing into the editor would generate, rather than one
+/// whole-document replacement. If the batch leaves the source not graph-valid
+/// it is rolled back to the pre-batch source, matching `apply_source_edit`.
+fn SourceBackedGraph::apply_codemirror_changes(
+  self : SourceBackedGraph,
+  changes : Array[@codemirror.ChangeDelta],
+) -> SourceGraphOperationResultJson {
+  let old_source = self.source
+  let selection_bindings = match source_graph_doc_for_render(self) {
+    Some(doc) => source_selected_node_bindings(doc, self.interaction)
+    None => []
+  }
+  for edit, new_source in Iter2(changes_to_edits(self.source, changes).iter()) {
+    self.attachment.apply_edit(edit, new_source)
+    self.source = new_source
+  }
+  match source_graph_current_doc(self) {
+    Ok(doc) => {
+      self.remap_selection_to_bindings(doc, selection_bindings)
+      source_graph_result_json_for_graph(self, true, None)
+    }
+    Err(message) => {
+      self.source = old_source
+      self.attachment.set_source(old_source)
+      source_graph_result_json_for_graph(self, false, Some(message))
+    }
+  }
+}
+
+///|
+/// Handle-addressed entry point for applying a CodeMirror transaction to a
+/// registered source-backed graph. The source CodeMirror editor's
+/// `listen(on_change=...)` subscription forwards its `ChangeDelta` batch here.
+fn apply_source_graph_codemirror_changes(
+  handle : Int,
+  changes : Array[@codemirror.ChangeDelta],
+) -> SourceGraphOperationResultJson {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph.apply_codemirror_changes(changes)
+    None =>
+      source_graph_operation_result_json(
+        false,
+        "",
+        ["source graph handle not found"],
+        0,
+        Some("source graph handle not found"),
+      )
+  }
+}
+
+///|
 fn realized_source_operation(
   doc : @graph_dsl.GraphDoc,
   operation : GraphOperation,

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -5,6 +5,8 @@ import {
   "dowdiness/canopy-canvas-graph/graph_model",
   "dowdiness/incr",
   "dowdiness/graph-dsl" @graph_dsl,
+  "dowdiness/loom/core",
+  "dowdiness/rabbita_codemirror" @codemirror,
   "dowdiness/rabbita-context-menu/context_menu",
   "dowdiness/rabbita-status/status",
   "moonbit-community/rabbita",

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -38,8 +38,16 @@ struct SourceDemoModel {
 }
 
 ///|
+/// Element id of the source-panel CodeMirror editor. The editor itself is
+/// mounted as a separate piece of work; `source_demo_subscriptions` already
+/// listens for its per-change deltas so the lowering path is exercised end to
+/// end the moment a view is attached to this id.
+const SOURCE_CM_EDITOR_ID = "source-editor-cm"
+
+///|
 enum SourceDemoMsg {
   EditorChanged(String)
+  SourceChanged(Array[@codemirror.ChangeDelta])
   ApplySource
   ConnectSample
   InsertReverb
@@ -102,6 +110,18 @@ fn source_demo_update(
   match msg {
     EditorChanged(source) =>
       (@rabbita.none, { ..model, editor: source, dirty: true })
+    SourceChanged(changes) => {
+      let result = apply_source_graph_codemirror_changes(model.handle, changes)
+      let success_message = "Editor changes lowered into graph-dsl source."
+      let failure_prefix = "Editor change rejected; canvas is rendering last-good graph"
+      let (status, status_tone) = source_demo_status_from_result(
+        result, success_message, failure_prefix,
+      )
+      (
+        source_demo_notify(model),
+        { ..model, editor: result.source, dirty: false, status, status_tone },
+      )
+    }
     ApplySource => {
       let result = set_source_graph_source_checked(model.handle, model.editor)
       let success_message = "Source applied; render state is reparsed from Loom GraphDoc."
@@ -167,7 +187,13 @@ fn source_demo_subscriptions(
   emit : Emit[SourceDemoMsg],
   _model : SourceDemoModel,
 ) -> @sub.Sub {
-  @sub.every(250, emit(SyncFromGraph))
+  @sub.batch([
+    @sub.every(250, emit(SyncFromGraph)),
+    @codemirror.listen(
+      SOURCE_CM_EDITOR_ID,
+      on_change=emit.map(changes => SourceChanged(changes)),
+    ),
+  ])
 }
 
 ///|

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -10,6 +10,14 @@
       "path": "../../lib/canvas-graph",
       "version": "0.1.0"
     },
+    "dowdiness/loom": {
+      "path": "../../loom/loom",
+      "version": "0.1.0"
+    },
+    "dowdiness/rabbita_codemirror": {
+      "path": "../../lib/rabbita_codemirror",
+      "version": "0.0.1"
+    },
     "dowdiness/incr": "0.8.0",
     "dowdiness/rabbita-context-menu": {
       "path": "../../lib/context-menu",

--- a/lib/rabbita_codemirror/codemirror.mbt
+++ b/lib/rabbita_codemirror/codemirror.mbt
@@ -26,6 +26,31 @@ pub fn SelRange::new(from : Int, to : Int) -> SelRange {
 }
 
 ///|
+/// A single replaced range within one CodeMirror transaction, expressed in
+/// the coordinates of the document *before* the transaction was applied.
+///
+/// This mirrors the `(fromA, toA, inserted)` triple CodeMirror's
+/// `ChangeSet.iterChanges` yields: `[from, to)` is the replaced span in the
+/// pre-transaction document (UTF-16 code units) and `insert` is the
+/// replacement text. Deletions carry an empty `insert`; pure insertions carry
+/// `from == to`.
+///
+/// The type is deliberately CodeMirror-agnostic of any downstream edit model:
+/// consumers translate an ordered `Array[ChangeDelta]` into whatever
+/// sequential edit representation their document store expects.
+pub struct ChangeDelta {
+  from : Int
+  to : Int
+  insert : String
+} derive(Eq, Debug)
+
+///|
+/// Construct a `ChangeDelta` from a pre-transaction span and its replacement.
+pub fn ChangeDelta::new(from : Int, to : Int, insert : String) -> ChangeDelta {
+  { from, to, insert }
+}
+
+///|
 #cfg(target="js")
 priv struct CmEntry {
   view : @js_ffi.CmView
@@ -49,7 +74,8 @@ priv suberror CmSubscription {
     String,
     doc~ : @cmd.Emit[String]?,
     selection~ : @cmd.Emit[SelRange]?,
-    focus~ : @cmd.Emit[Bool]?
+    focus~ : @cmd.Emit[Bool]?,
+    changes~ : @cmd.Emit[Array[ChangeDelta]]?
   )
 }
 
@@ -164,7 +190,9 @@ fn no_op_update_listener(
   view : @js_ffi.CmView,
   compartment : @js_ffi.Compartment,
 ) -> @js_ffi.Disposable {
-  @js_ffi.js_add_update_listener(view, compartment, _ => (), _ => (), _ => ())
+  @js_ffi.js_add_update_listener(view, compartment, _ => (), _ => (), _ => (), _ => {
+    ()
+  })
 }
 
 ///|
@@ -227,6 +255,21 @@ fn selection_from_value(value : @js_value.Value) -> SelRange {
 }
 
 ///|
+/// Decode the JS `[{ from, to, insert }, ...]` array produced by the update
+/// listener's `iterChanges` walk into an ordered `Array[ChangeDelta]`.
+#cfg(target="js")
+fn change_deltas_from_value(value : @js_value.Value) -> Array[ChangeDelta] {
+  let items : Array[@js_value.Value] = value.cast()
+  items.map(fn(item) {
+    ChangeDelta::new(
+      item.get_with_string("from"),
+      item.get_with_string("to"),
+      item.get_with_string("insert"),
+    )
+  })
+}
+
+///|
 #cfg(target="js")
 fn reconfigure(
   view : @js_ffi.CmView,
@@ -284,8 +327,9 @@ fn build_listen_key(
   has_doc : Bool,
   has_selection : Bool,
   has_focus : Bool,
+  has_changes : Bool,
 ) -> String {
-  "codemirror.listen(id=\{id},doc=\{has_doc},selection=\{has_selection},focus=\{has_focus})"
+  "codemirror.listen(id=\{id},doc=\{has_doc},selection=\{has_selection},focus=\{has_focus},changes=\{has_changes})"
 }
 
 ///|
@@ -295,12 +339,13 @@ fn cm_sub_loader(
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    CmListen(id, doc~, selection~, focus~) => {
+    CmListen(id, doc~, selection~, focus~, changes~) => {
       guard editors.get(id) is Some(entry) else { return None }
 
       let mut doc_tagger = doc
       let mut selection_tagger = selection
       let mut focus_tagger = focus
+      let mut changes_tagger = changes
 
       fn on_doc(value : @js_value.Value) {
         guard doc_tagger is Some(msg) else { return }
@@ -314,6 +359,10 @@ fn cm_sub_loader(
         guard focus_tagger is Some(msg) else { return }
         scheduler.add(msg(value.cast()))
       }
+      fn on_changes(value : @js_value.Value) {
+        guard changes_tagger is Some(msg) else { return }
+        scheduler.add(msg(change_deltas_from_value(value)))
+      }
 
       entry.update_disposable.dispose()
       let disposable = @js_ffi.js_add_update_listener(
@@ -322,16 +371,20 @@ fn cm_sub_loader(
         on_doc,
         on_selection,
         on_focus,
+        on_changes,
       )
       editors[id] = { ..entry, update_disposable: disposable }
 
       Some({
         unload: fn(_) { disposable.dispose() },
         update_tagger: fn(payload) {
-          guard payload is CmListen(_, doc~, selection~, focus~) else { return }
+          guard payload is CmListen(_, doc~, selection~, focus~, changes~) else {
+            return
+          }
           doc_tagger = doc
           selection_tagger = selection
           focus_tagger = focus
+          changes_tagger = changes
         },
       })
     }
@@ -629,24 +682,32 @@ pub fn set_line_wrapping(
 }
 
 ///|
-/// Subscribe to CodeMirror document, selection, and focus changes.
+/// Subscribe to CodeMirror document, selection, focus, and per-change changes.
+///
+/// `on_change` is additive: it delivers every replaced range of a transaction
+/// as an ordered `Array[ChangeDelta]` in pre-transaction coordinates, leaving
+/// the existing whole-document `doc` callback untouched. A consumer that only
+/// wants the post-change text keeps using `doc`; one that needs to replay the
+/// transaction as discrete edits subscribes to `on_change`.
 #cfg(target="js")
 pub fn listen(
   id : String,
   doc? : @cmd.Emit[String],
   selection? : @cmd.Emit[SelRange],
   focus? : @cmd.Emit[Bool],
+  on_change? : @cmd.Emit[Array[ChangeDelta]],
 ) -> @sub.Sub {
   let has_doc = doc is Some(_)
   let has_selection = selection is Some(_)
   let has_focus = focus is Some(_)
+  let has_changes = on_change is Some(_)
 
-  guard has_doc || has_selection || has_focus else { @sub.none }
-  let key = build_listen_key(id, has_doc, has_selection, has_focus)
+  guard has_doc || has_selection || has_focus || has_changes else { @sub.none }
+  let key = build_listen_key(id, has_doc, has_selection, has_focus, has_changes)
   @sub.custom_sub(
     key,
     Local,
-    CmListen(id, doc~, selection~, focus~),
+    CmListen(id, doc~, selection~, focus~, changes=on_change),
     cm_sub_loader,
   )
 }

--- a/lib/rabbita_codemirror/codemirror_wbtest.mbt
+++ b/lib/rabbita_codemirror/codemirror_wbtest.mbt
@@ -1,16 +1,16 @@
 ///|
 test "listen key format" {
   inspect(
-    build_listen_key("a", true, true, false),
-    content="codemirror.listen(id=a,doc=true,selection=true,focus=false)",
+    build_listen_key("a", true, true, false, true),
+    content="codemirror.listen(id=a,doc=true,selection=true,focus=false,changes=true)",
   )
 }
 
 ///|
 test "listen key deterministic" {
   inspect(
-    build_listen_key("a", true, false, false) ==
-    build_listen_key("a", true, false, false),
+    build_listen_key("a", true, false, false, false) ==
+    build_listen_key("a", true, false, false, false),
     content="true",
   )
 }
@@ -18,8 +18,8 @@ test "listen key deterministic" {
 ///|
 test "listen key id matters" {
   inspect(
-    build_listen_key("a", true, false, false) ==
-    build_listen_key("b", true, false, false),
+    build_listen_key("a", true, false, false, false) ==
+    build_listen_key("b", true, false, false, false),
     content="false",
   )
 }
@@ -27,8 +27,8 @@ test "listen key id matters" {
 ///|
 test "listen key doc flag matters" {
   inspect(
-    build_listen_key("a", true, false, false) ==
-    build_listen_key("a", false, false, false),
+    build_listen_key("a", true, false, false, false) ==
+    build_listen_key("a", false, false, false, false),
     content="false",
   )
 }
@@ -36,8 +36,17 @@ test "listen key doc flag matters" {
 ///|
 test "listen key selection and focus flags matter" {
   inspect(
-    build_listen_key("a", false, true, false) ==
-    build_listen_key("a", false, false, true),
+    build_listen_key("a", false, true, false, false) ==
+    build_listen_key("a", false, false, true, false),
+    content="false",
+  )
+}
+
+///|
+test "listen key changes flag matters" {
+  inspect(
+    build_listen_key("a", false, false, false, false) ==
+    build_listen_key("a", false, false, false, true),
     content="false",
   )
 }

--- a/lib/rabbita_codemirror/js/codemirror.mbt
+++ b/lib/rabbita_codemirror/js/codemirror.mbt
@@ -342,8 +342,9 @@ extern "js" fn js_add_update_listener_raw(
   on_doc : (@js_value.Value) -> Unit,
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
+  on_changes : (@js_value.Value) -> Unit,
 ) -> () -> Unit =
-  #| (view, compartment, onDoc, onSelection, onFocusChange) => {
+  #| (view, compartment, onDoc, onSelection, onFocusChange, onChanges) => {
   #|   const key = Symbol.for("dowdiness.rabbita_codemirror");
   #|   const slot = globalThis[key];
   #|   const cm = view._cmModule;
@@ -354,6 +355,13 @@ extern "js" fn js_add_update_listener_raw(
   #|   const listener = cm.EditorView.updateListener.of(update => {
   #|     if (update.docChanged && !isApplying()) {
   #|       onDoc(update.state.doc.toString());
+  #|     }
+  #|     if (update.docChanged && !isApplying()) {
+  #|       const deltas = [];
+  #|       update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+  #|         deltas.push({ from: fromA, to: toA, insert: inserted.toString() });
+  #|       });
+  #|       onChanges(deltas);
   #|     }
   #|     if ((update.selectionSet || update.docChanged) && !isApplying()) {
   #|       const sel = update.state.selection.main;
@@ -404,6 +412,7 @@ pub fn js_add_update_listener(
   on_doc : (@js_value.Value) -> Unit,
   on_selection : (@js_value.Value) -> Unit,
   on_focus_change : (@js_value.Value) -> Unit,
+  on_changes : (@js_value.Value) -> Unit,
 ) -> Disposable {
   Disposable(
     js_add_update_listener_raw(
@@ -412,6 +421,7 @@ pub fn js_add_update_listener(
       on_doc,
       on_selection,
       on_focus_change,
+      on_changes,
     ),
   )
 }

--- a/lib/rabbita_codemirror/js/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/js/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "dowdiness/rabbita_codemirror/js"
 // Values
 pub fn cm_module_of(@moonbit-community/rabbita/js.Value) -> CmModule
 
-pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit) -> Disposable
+pub fn js_add_update_listener(CmView, Compartment, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit, (@moonbit-community/rabbita/js.Value) -> Unit) -> Disposable
 
 pub fn js_compartment_new(CmModule) -> Compartment
 

--- a/lib/rabbita_codemirror/pkg.generated.mbti
+++ b/lib/rabbita_codemirror/pkg.generated.mbti
@@ -6,12 +6,13 @@ import {
   "dowdiness/rabbita_codemirror/addon/theme",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/sub",
+  "moonbitlang/core/debug",
 }
 
 // Values
 pub fn insert(String, Int, String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 
-pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool]) -> @sub.Sub
+pub fn listen(String, doc? : @cmd.Emit[String], selection? : @cmd.Emit[SelRange], focus? : @cmd.Emit[Bool], on_change? : @cmd.Emit[Array[ChangeDelta]]) -> @sub.Sub
 
 pub fn mount(String, String, init_doc? : String, source? : String, initial_theme? : @theme.Theme?, initial_readonly? : Bool, initial_keymap? : @keymap.Keymap?, initial_line_numbers? : Bool, initial_line_wrapping? : Bool, on_mounted? : @cmd.Cmd, failed? : @cmd.Emit[String], initial_extension? : ((@moonbit-community/rabbita/js.Value) -> @dowdiness/rabbita_codemirror/js.Extension raise)?) -> @cmd.Cmd
 
@@ -38,6 +39,13 @@ pub fn unmount(String, failed? : @cmd.Emit[String]) -> @cmd.Cmd
 // Errors
 
 // Types and methods
+pub struct ChangeDelta {
+  from : Int
+  to : Int
+  insert : String
+} derive(Eq, @debug.Debug)
+pub fn ChangeDelta::new(Int, Int, String) -> Self
+
 pub struct SelRange {
   from : Int
   to : Int


### PR DESCRIPTION
## Summary
Extends the `rabbita_codemirror` `listen` binding with an additive `on_change` callback that delivers each replaced range of a CodeMirror transaction as an ordered `Array[ChangeDelta]` (pre-transaction coordinates, from `iterChanges`), and adds a canvas consumer that lowers those deltas into ordered `@core.Edit`s applied through `GraphAttachment::apply_edit`.

## Binding (additive — existing consumers unaffected)
- New loom-agnostic `ChangeDelta { from, to, insert }`.
- `listen` gains a trailing optional `on_change? : @cmd.Emit[Array[ChangeDelta]]`; threaded through the `CmListen` suberror, the sub loader (`changes` tagger rebound in `update_tagger`), and the sub key. The JS `iterChanges` walk is guarded by `update.docChanged && !isApplying()` so programmatic dispatches do not echo.

## Canvas consumer (conversion + wiring; editor mount deferred)
- `changes_to_edits(base, [ChangeDelta]) -> [(@core.Edit, String)]`: rebases each change onto the document the previous one produced (running offset), splicing in UTF-16 code units.
- `apply_codemirror_changes` folds the edits through `apply_edit` in order, with whole-batch rollback if the result is no longer graph-valid.
- Wired via `listen(on_change=...)` on the source panel; inert until an editor mounts at `source-editor-cm`.

## Reuse check
- **`@core.Edit`** (loom): reused `Edit::new` / `{ start, old_len, new_len }` — no new edit type.
- **`GraphAttachment::apply_edit` / `set_source`**: reused; rollback mirrors the existing `apply_source_edit`.
- **`String::view`**: reused for code-unit slicing instead of array conversion (offsets verified UTF-16 code units).
- **`Iter2(arr.iter())`**: reused prelude type for two-binder tuple destructuring instead of a body `let`.
- **`source_graph_*` result/registry helpers**: reused for the handle-addressed entry point.
- New surface limited to `ChangeDelta` (binding) + the pure `changes_to_edits` + the consumer — no duplicate delta/edit types.

## Tests
- Canvas: 55/55 (adds multi-change + non-BMP `changes_to_edits` cases).
- Binding: 8/8 (adds the `changes` key-flag case).
- Codex review: PASS, no findings.

## Notes
- The `listen(on_change=...)` subscription is inert until a CodeMirror editor is mounted at `source-editor-cm` (mount deferred to a follow-up); the sub loader no-ops for an unmounted id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
