### PR TITLE
feat(canvas): mount CodeMirror in source panel, lower edits live (#565 PR1)

### DIFF
--- a/docs/plans/2026-06-08-565-option-b-editor-authoritative-source.md
+++ b/docs/plans/2026-06-08-565-option-b-editor-authoritative-source.md
@@ -1,0 +1,110 @@
+# #565 Option (b): editor-authoritative source, no caller rollback
+
+**Status:** Implemented (Codex-validated design: SOUND-WITH-CAVEATS; pre-PR review PASS after a dirty-flag fix).
+**Supersedes:** the `model.dirty` whole-source recovery branch shipped in `990256c`.
+
+## Problem (from /code-review of PR #570)
+
+Three confirmed findings share one root cause — the adapter rebases CodeMirror
+deltas onto `SourceBackedGraph.source`, which can diverge from the editor's
+actual buffer:
+
+- **P1 / dirty recovery:** on a rejected edit, `apply_codemirror_changes`
+  rolls the graph back (`self.source = old_source; attachment.set_source(old_source)`)
+  while CodeMirror keeps the user's text. The next delta (editor coordinates)
+  is spliced onto last-good → corruption (`220Hz` → `220Hz440Hz`). The shipped
+  `990256c` fix recovers via whole-source reparse, but that **churns node
+  identity — the exact property #565 exists to preserve.**
+- **#1 stale-editor window:** TS-side ops (inspector rename/param, canvas
+  delete/connect via `apply_source_graph_operation`) mutate `self.source` but
+  do not update the editor (the removed `syncSourceEditorFromResult`); only the
+  250 ms poll syncs it. Typing in that window rebases stale-buffer deltas onto
+  the mutated source → corruption.
+- **#3 inconsistent rollback:** `set_source_graph_source_checked` does **not**
+  roll back on parse failure (leaves `self.source` = invalid text), while
+  `apply_codemirror_changes` does. The two source-mutation paths disagree.
+
+## Key facts established by reading the code
+
+- `GraphAttachment` (loom `examples/graph-dsl/src/attachment.mbt`) keeps
+  `current_source` even when the parse fails (`apply_edit`/`set_source` never
+  roll back internally); on failure it sets `state=…Blocked`, `current=Err`,
+  but retains the previous `last_good : GraphDoc?`.
+- `source_graph_doc_for_render` already renders `current_result()` when `Ok`,
+  else `last_good()` — so an invalid `current_source` does not break rendering.
+- The identity tracker (`ProjectionIdentityTracker`) has
+  `record_failed_input_with_optional_edit` (called on parse failure) and
+  `realign_success_with_optional_edit` (called on the next success) —
+  **designed to preserve node identity across a sequence of incremental edits
+  that pass through invalid intermediate states.** A `set_source` reset
+  discards this and re-baselines identity.
+
+Conclusion: the caller-side rollback is the sole divergence source. The
+attachment is already built to hold an invalid `current_source` and recover
+incrementally with stable identity.
+
+## Invariant
+
+> `SourceBackedGraph.source` (and the attachment's `current_source`) always
+> equals the CodeMirror editor's current buffer. The rendered graph is derived:
+> `current_result()` when valid, else `last_good()`.
+
+The editor is the single source of truth for text; the graph is downstream.
+
+## Changes
+
+1. **`apply_codemirror_changes(changes, expected_doc)`** (new `expected_doc`
+   param = the editor's authoritative post-transaction buffer):
+   - Apply the per-delta edits incrementally against `self.source`
+     (`changes_to_edits` unchanged), feeding `attachment.apply_edit` — identity
+     preserved through invalid states by the tracker.
+   - **Stale-editor guard (fixes #1):** if after applying, `self.source !=
+     expected_doc`, the editor had diverged from `self.source` (a TS op moved
+     the graph out from under the stale editor). The incremental result is not
+     what the user sees, so reparse the editor's authoritative text via
+     `attachment.set_source(expected_doc)`. This resolves the conflict
+     editor-wins (the racing TS-op change is superseded by the keystroke) — no
+     corruption. Rare: only within the sub-250 ms window before the poll syncs.
+   - **No rollback on parse failure.** `self.source` stays = `expected_doc`.
+     Render falls back to `last_good`. `applied = current_result is Ok`.
+2. **`source_demo` `SourceChanged`:** delete the `model.dirty` branch; always
+   call the incremental entry, passing `model.editor` (current post-`EditorSynced`
+   buffer) as `expected_doc`. `dirty = !result.applied`.
+3. **`dirty` semantics = "editor's current source is not graph-valid"** (status
+   + poll gate only). Fixes #2: button-op rejections (Connect/Insert via
+   `apply_source_edit`, which rolls back and leaves the editor's valid text
+   untouched) must set `dirty=false`, not `true`. CM-edit / ApplySource invalid
+   → `dirty=true`. (Mechanism: derive `dirty` from current source validity, not
+   from `result.applied`, OR set `dirty=false` on the button-op result path.)
+4. **`set_source_graph_source_checked`:** keep no-rollback (now consistent with
+   the invariant). Fix the misleading "rendering last-good" comment in
+   `source_demo` to state the source string is the editor's text and only the
+   *render* uses `last_good`.
+5. **`apply_source_edit` (TS-op path):** keep its rollback — a rejected TS op
+   never touched the editor, so `self.source` must stay = editor = last-good.
+6. **`SyncFromGraph` poll:** unchanged in mechanism. Under the invariant the
+   poll naturally no-ops when in sync (`source == editor`) and `set_doc`s after
+   a TS op (closing #1's window in ≤250 ms). The sub-250 ms race is resolved
+   editor-wins by the stale guard in (1); a future incr-reactive follow-up
+   replaces the poll with immediate cross-app sync.
+
+## Tests
+
+- **Identity preservation (new, the headline):** drive an invalid→valid
+  incremental recovery and assert node IDs are *stable* across it (proving the
+  whole-source churn is gone). Whitebox on the adapter or E2E via the visualizer
+  / node `data-node-id`.
+- Existing dirty-recovery E2E (`220Hz440Hz`) still passes — now via incremental.
+- **#1:** TS rename, then type in the stale editor within the window → coherent
+  source, no corruption (editor-wins).
+- **#2:** rejected ConnectSample leaves `dirty=false`; a subsequent graph change
+  still syncs to the editor via the poll.
+- Adapter whitebox: `self.source == expected_doc` after both valid and invalid
+  CM edits; `last_good` render survives an invalid edit; no rollback.
+
+## Non-goals
+
+- Immediate cross-app editor sync after TS ops (the proper #1 fix) — deferred to
+  the incr-reactive invalidation follow-up; the stale guard makes the window
+  safe (no corruption) in the meantime.
+- Changing `changes_to_edits` (correct as-is for in-coordinate deltas).

--- a/docs/plans/2026-06-08-565-stable-canvas-node-identity.md
+++ b/docs/plans/2026-06-08-565-stable-canvas-node-identity.md
@@ -1,0 +1,117 @@
+# #565 — Stable source-backed canvas node identity
+
+## Problem
+
+Current behavior is driven by a dual-identity model: positional node IDs in the canvas model coexist with source-layer reparsing and a separate binding-recovery shim. The canvas ID path is currently created from indices (for example `NodeId(index + 1)`) while source-side remapping relies on binding maps (`examples/canvas/main/graph_dsl_adapter.mbt:170-176`, `:240-246`, `:226-230`). That split makes selection/inspector/action IDs fragile when ordering changes because the canonical tracker authority is not consistently used end-to-end (`examples/canvas/main/graph_dsl_adapter.mbt:551-605`, `:623-641`, `:901-930`).  
+
+`GraphNode::id()` is not unstable in a clean delete; observed churn appears when the reparse path is coarse-grained (atomic whole-source or atomic replace semantics). The Loom `ProjectionIdentityTracker` keeps IDs stable by edit-window realignment of positional changes, with fresh allocation only when the edit crosses its continuity guarantees (`loom/loom/src/core/projection_identity.mbt:625-631`, `:657-667`, `:710-759`, `:815-824`).
+
+## Empirical findings (proven 2026-06-08)
+
+Keep this table as the behavioral ground truth:
+
+| Reparse/repair path | `GraphNode::id()` behavior |
+|---|---|
+| Whole-source `set_source` reorder (atomic) | `node#0:x` and `node#1:x` swap (id churn) |
+| `apply_edit` atomic replace spanning move | `node#0:x` and `node#1:x` swap (id churn) |
+| `apply_edit` delete-then-insert per edit | id for surviving moved node remains stable |
+| Clean delete / localized param edit | previously existing ids remain stable |
+
+The row above is consistent with `GraphNode::id()` being token-based binding identity plus the tracker’s realignment behavior (`loom/loom/src/core/projection_identity.mbt:531-560`, `:565-588`, `:625-631`, `:657-667`, `:710-759`, `:815-824`).  
+
+`projection.mbt` currently enforces duplicate-binding rejection for the grammar source, which remains a hard prerequisite if identity is keyed to tracker tokens (`loom/examples/graph-dsl/src/projection.mbt:283-292`).
+
+## Constraints
+
+1. `NodeId/EdgeId` are shared model primitives with JSON contracts and are currently `pub(all) struct Int` wrappers in `lib/canvas-graph/graph_model/model.mbt:6,38`. Codec paths currently serialize numeric identifiers (`lib/canvas-graph/graph_model/model.mbt:25-35`, `:55-65`, `:57-67`, `:174-183`, `:288-329`).  
+
+2. The source panel currently exposes a whole-document path: `EditorChanged(String)` is fed through `set_source_graph_source_checked` and `attachment.set_source` (`examples/canvas/main/source_demo.mbt:42-43`, `:101-107`, `:192-203`), with parse/reparse paths that are coarse and can trigger churn (`examples/canvas/main/graph_dsl_adapter.mbt:901-929`).  
+
+3. Duplicate-binding rejection is present in the source projection and is non-negotiable for token identity correctness (`loom/examples/graph-dsl/src/projection.mbt:283-292`).  
+
+4. Rabbitita binding direction says reusable bindings should expose subscription-shaped APIs via `@sub` (rather than raw FFI consumption), with payload-tagging semantics and stable subscription keys (`rabbita/rabbita/sub/design.md:1-77`, `rabbita/doc/using_subscriptions/readme.mbt.md:1-155`, `rabbita/rabbita/websocket/listen.mbt:1-117`). The existing `lib/rabbita_codemirror/codemirror.mbt:634-652` listen signature currently emits whole-doc only, so extension must occur in the binding layer.
+
+## Design
+
+### Layer 1 — Identity as a String
+
+Collapse identity to a single authority: Loom `ProjectionIdentityTracker` tokens (`GraphNode::id()`), with `NodeId` moved to `String` and no registry/binding-recovery layer.
+
+- `NodeId` is a `String` equal to `GraphNode::id()` from the tracker, and is the only cross-frame identity for nodes (`loom/examples/graph-dsl/src/graph_doc.mbt:171-205`).
+- `EdgeId` is derived deterministically from `(source_node_id, target_node_id, target_port)`; there is no mutable `Int` allocator for edges and no global edge registry.  
+- Delete all intern-table/recovery behavior, because identity is now intrinsic in tokens and does not need remapping from a secondary map.
+
+This replaces current positional minting (`NodeId(index + 1)`) in canvas projection and source adapter (`examples/canvas/main/graph_dsl_adapter.mbt:170-176`, `:226-230`, `:240-246`) and aligns JS/TS payload surfaces with the shared model’s adapter contract.
+
+Because ID is now tracker-owned:
+- `examples/canvas/main/canvas_init.mbt` must produce string IDs from pointer events for the hand-built canvas (`examples/canvas/main/canvas_init.mbt:1-32`).
+- `examples/canvas/web/src/graph-adapter.ts` should carry opaque string handles in source-backed operations and pointer data attributes.
+
+Rename behavior: rename churn is expected in the tracker (`GraphNode::id()` token changes), so a local hook is required to rewrite selection/inspector/action references from old NodeId to new NodeId inside the canvas operation path. The existing precedent is `rename_layout_binding` (`examples/canvas/main/graph_dsl_adapter.mbt:608-620`). This is a rename-specific continuation step, not binding-recovery.
+
+### Layer 2 — Feed the tracker edits (delta editor)
+
+Canvas source editing must provide per-change deltas into the tracker:
+- Current canvas demos already have CM6 plumbing that produces ordered changes (`examples/ideal/web/src/cm-inline.ts:20-27`, `examples/ideal/web/src/leaf-editor.ts:37-38`, `examples/ideal/web/src/bridge.ts:68`, `examples/ideal/web/src/bridge.ts:155-186`) and maps to `@core.Edit` (`examples/ideal/main/crdt_reexport.mbt:171-181`, `editor/sync_editor_text.mbt:323-339`).
+- `lib/rabbita_codemirror/codemirror.mbt:634-652` currently emits only whole-doc deltas, so we must extend the binding to expose structured `{from, to, insert}` edit payloads through `listen`.  
+
+Binding implementation requirements:
+- Follow canonical Sub-binding pattern in `rabbita/rabbita/websocket/listen.mbt` (private `suberror`, `let mut tagger`, `update_tagger`, function-based API, and key that tracks presence only, not tagger identity) (`rabbita/rabbita/websocket/listen.mbt:1-117`).
+- Match subscription invariants from `rabbita/doc/using_subscriptions/readme.mbt.md` and `rabbita/rabbita/sub/design.md` (`rabbita/doc/using_subscriptions/readme.mbt.md:1-155`, `rabbita/rabbita/sub/design.md:1-77`).
+- JS side consumes `update.changes.iterChanges()`, maps to `@core.Edit.new(start, old_len, new_len)` equivalents, and emits per-change callbacks.
+
+Operationally, `Canvas` source panel should call `apply_edit` for each change sequentially (a CM6 transaction may contain multiple changes; applying in order preserves moved-node stability), and rely on whole-source `set_source` only for initialization/programmatic resets.
+
+### Layer 3 — Retire now-dead selection remap plumbing
+
+With token identities and change-based feeding, the previous central remap utilities are no longer required:
+- `source_selected_node_bindings`
+- `source_selection_from_bindings`
+- `remap_selection_to_bindings`
+- `sync_local_operation_state` remap arm for delete
+- `set_source_graph_source_checked` capture/replay block
+
+Current source-side call points:
+- `graph_dsl_adapter.mbt` remap utilities and capture blocks (`:551-605`, `:623-641`, `:901-930`).
+- `sync_local_operation_state` path in local operation handling (`:1064-1080`) currently carries delete remap behavior that becomes dead code under Layer 1+2.
+
+This closes #565 and makes #566 obsolete because identity restoration is intrinsic rather than reconstructed.
+
+## Implementation staging
+
+The two architectural axes remain separable:
+
+1. **Option A — Land both together:** implement String identity and delta-editor in one PR so selection/inspector stability is guaranteed in reorder scenarios.
+2. **Option B — Identity-first with transitional bridge:** keep existing whole-source `set_source` during rollout by converting old->new source into edits or retaining a temporary, explicitly marked recovery bridge; delete that bridge once Layer 2 lands.
+
+Both options preserve the empirical constraint that source-backed tests relying on binding-preserved reorder semantics only fully pass when granular edits are active.
+
+## Residual limitations
+
+Single transaction atomic replace that reorders multiple nodes can still churn IDs under Layer 1 if it is not expressed as granular edits; this is currently the same fundamental boundary as Loom’s token allocator behavior when the edit window no longer provides continuity (`loom/loom/src/core/projection_identity.mbt:625-631`, `:657-667`, `:710-759`, `:815-824`).  
+
+A future bulk formatter command emitting one large replace must be sequenced as granular deltas to avoid broader churn; this is an editor pipeline choice, not a model fault.  
+
+Multi-selects spanning churned nodes still degrade to fresh identities on the affected nodes in those atomic paths, with unaffected nodes and unrelated references retaining identity stability.
+
+## Test plan (failing-first)
+
+All listed tests remain source-backed design-level checks; assertions migrate to string IDs where currently numeric.
+
+- Selection/inspector survive delta-driven source reorder with no remap call (`examples/canvas/main/graph_dsl_adapter_wbtest.mbt:493`).
+- Selection survives delete of an earlier node and does not remap via binding helpers (`examples/canvas/main/graph_dsl_adapter_wbtest.mbt:441-490`).
+- A node keeps identity across unrelated parameter edits (`loom/loom/src/core/projection_identity.mbt` behavior + `examples/canvas/main/graph_dsl_adapter_wbtest.mbt` existing reorder/delete probes).
+- New node IDs are never reused; deleted node IDs are never resurfaced.
+- Rename preserves identity through the rename-local hook (`examples/canvas/main/graph_dsl_adapter.mbt:608-620`).
+- Existing source-backed wbtests continue: clear/delete/multi-select order/invalid-source no-remap (`examples/canvas/main/graph_dsl_adapter_wbtest.mbt:441-490`, `:529-543`, `:564-607`).
+
+Additional structural checks:
+- `lib/canvas-graph/graph_model/model.mbt:25-35`, `:55-65`, `:288-329` updated to string JSON handling without semantic downgrade.
+- `examples/canvas/web/src/graph-adapter.ts` pointer and payload paths updated to opaque string IDs.
+- `lib/rabbita_codemirror/codemirror.mbt` and JS binding layer accept and emit structured deltas with suberror-safe callback semantics.
+
+## Open questions
+
+1. Should the string-ID migration include an explicit one-time wire version marker for persisted handles from older numeric IDs?  
+2. Should the delta path in Canvas be switched atomically across the whole source-edit surface or behind a feature flag until all dependent adapters are migrated?  
+3. For `GraphAttachment::apply_edit`, should retries/reconciliation tolerate JS listener dropouts by falling back to `set_source` and accepting one-time churn windows?

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -532,13 +532,21 @@ fn SourceBackedGraph::apply_source_edit(
 /// `changes_to_edits` rebases each change onto the document the previous one
 /// produced, so the attachment's incremental reparse sees the same per-edit
 /// stream a user typing into the editor would generate, rather than one
-/// whole-document replacement. If the batch leaves the source not graph-valid
-/// it is rolled back to the pre-batch source, matching `apply_source_edit`.
+/// whole-document replacement.
+///
+/// The editor is the source of truth for text: `self.source` always tracks the
+/// editor's buffer (`expected_doc`, the editor's authoritative post-transaction
+/// text), and the rendered graph is derived — `current_result()` when valid,
+/// else `last_good()` (see `source_graph_doc_for_render`). We therefore do NOT
+/// roll back when a batch leaves the source not graph-valid: the attachment
+/// keeps the invalid `current_source` and its identity tracker realigns node
+/// identity across the failed intermediate parses, so the next valid keystroke
+/// recovers incrementally with stable identity (no whole-source churn).
 fn SourceBackedGraph::apply_codemirror_changes(
   self : SourceBackedGraph,
   changes : Array[@codemirror.ChangeDelta],
+  expected_doc : String,
 ) -> SourceGraphOperationResultJson {
-  let old_source = self.source
   let selection_bindings = match source_graph_doc_for_render(self) {
     Some(doc) => source_selected_node_bindings(doc, self.interaction)
     None => []
@@ -547,16 +555,23 @@ fn SourceBackedGraph::apply_codemirror_changes(
     self.attachment.apply_edit(edit, new_source)
     self.source = new_source
   }
+  // Stale-editor guard: the deltas are expressed against the editor's
+  // pre-transaction buffer. If the incremental result does not equal the
+  // editor's authoritative post-transaction text, `self.source` had diverged
+  // from the editor (an out-of-band TS-side graph mutation moved the source out
+  // from under a stale editor). Reparse the editor's text so the keystroke wins
+  // over the racing mutation, rather than splicing onto a mismatched base.
+  if self.source != expected_doc {
+    self.attachment.set_source(expected_doc)
+    self.source = expected_doc
+  }
   match source_graph_current_doc(self) {
     Ok(doc) => {
       self.remap_selection_to_bindings(doc, selection_bindings)
       source_graph_result_json_for_graph(self, true, None)
     }
-    Err(message) => {
-      self.source = old_source
-      self.attachment.set_source(old_source)
+    Err(message) =>
       source_graph_result_json_for_graph(self, false, Some(message))
-    }
   }
 }
 
@@ -567,9 +582,10 @@ fn SourceBackedGraph::apply_codemirror_changes(
 fn apply_source_graph_codemirror_changes(
   handle : Int,
   changes : Array[@codemirror.ChangeDelta],
+  expected_doc : String,
 ) -> SourceGraphOperationResultJson {
   match source_graph_by_handle(handle) {
-    Some(graph) => graph.apply_codemirror_changes(changes)
+    Some(graph) => graph.apply_codemirror_changes(changes, expected_doc)
     None =>
       source_graph_operation_result_json(
         false,

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -774,6 +774,74 @@ test "source-backed handle rejects graph operations while source is invalid" {
 }
 
 ///|
+/// Option (b) invariant: editor-originated CodeMirror edits are NOT rolled back
+/// on parse failure, so `source` tracks the editor through transiently-invalid
+/// states and the next valid keystroke recovers incrementally — preserving node
+/// identity, the property a whole-source reparse would churn.
+test "source-backed CodeMirror edit recovers from invalid state preserving node identity" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None => abort("expected source graph handle")
+  }
+  let before = ok_current_graph_doc(graph.attachment.current_result())
+  let osc_id = graph_node_id(before, "osc")
+  let meter_id = graph_node_id(before, "meter")
+
+  // Delete `440Hz`, leaving the source transiently invalid. No rollback: the
+  // source follows the editor while the canvas keeps rendering last-good.
+  let invalid_doc = "osc = sine(freq: )\nmeter = scope()"
+  let reject = graph.apply_codemirror_changes(
+    [@codemirror.ChangeDelta::new(17, 22, "")],
+    invalid_doc,
+  )
+  inspect(reject.applied, content="false")
+  @debug.assert_eq(graph.source, invalid_doc)
+  @debug.assert_eq(
+    graph_node_id(ok_last_good(graph.attachment.last_good()), "osc"),
+    osc_id,
+  )
+
+  // Type a new valid value. Recovery lowers incrementally against the (invalid)
+  // editor text, so node identity is stable end to end.
+  let valid_doc = "osc = sine(freq: 220Hz)\nmeter = scope()"
+  let accept = graph.apply_codemirror_changes(
+    [@codemirror.ChangeDelta::new(17, 17, "220Hz")],
+    valid_doc,
+  )
+  inspect(accept.applied, content="true")
+  @debug.assert_eq(graph.source, valid_doc)
+  let after = ok_current_graph_doc(graph.attachment.current_result())
+  @debug.assert_eq(graph_node_id(after, "osc"), osc_id)
+  @debug.assert_eq(graph_node_id(after, "meter"), meter_id)
+  destroy_source_graph(handle)
+}
+
+///|
+/// Option (b) stale-editor guard: when `source` has diverged from the editor
+/// (an out-of-band graph mutation moved it), the incremental result no longer
+/// equals the editor's authoritative buffer, so the adapter reparses that
+/// buffer (editor-wins) instead of splicing the deltas onto a mismatched base.
+test "source-backed CodeMirror edit reparses editor text when source diverged" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None => abort("expected source graph handle")
+  }
+  // The editor's authoritative buffer (e.g. after a reorder) does not match
+  // what the delta produces from the current `source`, modelling a stale base.
+  let editor_doc = "meter = scope()\nosc = sine(freq: 440Hz)"
+  let result = graph.apply_codemirror_changes(
+    [@codemirror.ChangeDelta::new(0, 0, "x")],
+    editor_doc,
+  )
+  // No corruption: source equals the editor's text exactly, reparsed valid.
+  inspect(result.applied, content="true")
+  @debug.assert_eq(graph.source, editor_doc)
+  destroy_source_graph(handle)
+}
+
+///|
 test "invalid source keeps last-good canvas graph available" {
   let attachment = @graph_dsl.GraphAttachment::GraphAttachment(GRAPH_DSL_SAMPLE)
   let good = ok_current_graph_doc(attachment.current_result())

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -2,7 +2,7 @@
 using @rabbita {type Cmd, type Emit, type Html}
 
 ///|
-using @html {a, aside, button, div, h2, nothing, p, span, textarea, text}
+using @html {a, aside, button, div, h2, nothing, p, span, text}
 
 ///|
 #cfg(target="js")
@@ -31,27 +31,38 @@ fn js_source_mode_url(enabled : Bool) -> String {
 struct SourceDemoModel {
   handle : Int
   editor : String
+  // `dirty` is true while the CodeMirror buffer diverges from the graph's
+  // canonical source — i.e. the user has typed edits that have not (or could
+  // not) be lowered. It gates `SyncFromGraph` so the periodic graph→editor
+  // push never clobbers in-progress (possibly transiently-invalid) typing.
   dirty : Bool
+  mounted : Bool
   status : String
   status_tone : @status.Tone
   on_change : () -> Unit
 }
 
 ///|
-/// Element id of the source-panel CodeMirror editor. The editor itself is
-/// mounted as a separate piece of work; `source_demo_subscriptions` already
-/// listens for its per-change deltas so the lowering path is exercised end to
-/// end the moment a view is attached to this id.
+/// Element id of the source-panel CodeMirror editor. It serves as both the
+/// host DOM element id (the `view` renders an empty `div` with this id) and the
+/// binding's logical editor id, so `mount` and `listen` address the same view.
 const SOURCE_CM_EDITOR_ID = "source-editor-cm"
 
 ///|
 enum SourceDemoMsg {
-  EditorChanged(String)
+  // Full post-change CodeMirror document; tracks the editor's text so `Apply`
+  // and `SyncFromGraph` reason against what the user actually sees, even when
+  // a change was rolled back by the graph.
+  EditorSynced(String)
+  // Ordered per-change deltas of one CodeMirror transaction; lowered into the
+  // graph-dsl source through `apply_edit`.
   SourceChanged(Array[@codemirror.ChangeDelta])
   ApplySource
   ConnectSample
   InsertReverb
   SyncFromGraph
+  Mounted
+  MountFailed(String)
 }
 
 ///|
@@ -80,6 +91,25 @@ fn source_demo_notify(model : SourceDemoModel) -> Cmd {
 }
 
 ///|
+/// Mount the source-panel CodeMirror editor into the `SOURCE_CM_EDITOR_ID`
+/// host and report readiness through `Mounted`. The per-change `listen`
+/// subscription only attaches once `mounted` is true, because the binding's
+/// sub loader is a no-op until the editor exists in its registry.
+fn mount_source_cm_cmd(
+  emit : Emit[SourceDemoMsg],
+  model : SourceDemoModel,
+) -> Cmd {
+  @codemirror.mount(
+    SOURCE_CM_EDITOR_ID,
+    SOURCE_CM_EDITOR_ID,
+    init_doc=model.editor,
+    source="global:__canopy_codemirror",
+    on_mounted=emit(Mounted),
+    failed=emit.map(message => MountFailed(message)),
+  )
+}
+
+///|
 fn source_demo_status_from_result(
   result : SourceGraphOperationResultJson,
   success_message : String,
@@ -102,14 +132,38 @@ fn source_demo_status_from_result(
 }
 
 ///|
+/// Fold a graph-side operation result (Connect / Insert / Apply) into the next
+/// command and model. On success the canonical `result.source` is pushed back
+/// into CodeMirror via `set_doc` (echo-suppressed, skip-equal) and the editor
+/// is marked clean; on rejection the editor keeps the user's text and stays
+/// dirty so the canvas continues rendering the last-good graph.
+fn source_demo_result_step(
+  model : SourceDemoModel,
+  result : SourceGraphOperationResultJson,
+  status : String,
+  status_tone : @status.Tone,
+) -> (Cmd, SourceDemoModel) {
+  if result.applied {
+    (
+      @rabbita.batch([
+        source_demo_notify(model),
+        @codemirror.set_doc(SOURCE_CM_EDITOR_ID, result.source),
+      ]),
+      { ..model, editor: result.source, dirty: false, status, status_tone },
+    )
+  } else {
+    (source_demo_notify(model), { ..model, dirty: true, status, status_tone })
+  }
+}
+
+///|
 fn source_demo_update(
   _emit : Emit[SourceDemoMsg],
   msg : SourceDemoMsg,
   model : SourceDemoModel,
 ) -> (Cmd, SourceDemoModel) {
   match msg {
-    EditorChanged(source) =>
-      (@rabbita.none, { ..model, editor: source, dirty: true })
+    EditorSynced(source) => (@rabbita.none, { ..model, editor: source })
     SourceChanged(changes) => {
       let result = apply_source_graph_codemirror_changes(model.handle, changes)
       let success_message = "Editor changes lowered into graph-dsl source."
@@ -117,9 +171,13 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, failure_prefix,
       )
+      // The edit originates in CodeMirror, which already holds the user's text,
+      // so never push it back here (a transiently-invalid keystroke rolled back
+      // to last-good would otherwise revert in-progress typing). `EditorSynced`
+      // keeps `editor` current; we only record validity through `dirty`.
       (
         source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, status_tone },
+        { ..model, dirty: !result.applied, status, status_tone },
       )
     }
     ApplySource => {
@@ -129,10 +187,7 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, failure_prefix,
       )
-      (
-        source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, status_tone },
-      )
+      source_demo_result_step(model, result, status, status_tone)
     }
     ConnectSample => {
       let result = source_graph_connect_sample_result(model.handle)
@@ -140,10 +195,7 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, "Source operation rejected",
       )
-      (
-        source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, status_tone },
-      )
+      source_demo_result_step(model, result, status, status_tone)
     }
     InsertReverb => {
       let result = source_graph_insert_unique_result(
@@ -155,12 +207,11 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, "Source operation rejected",
       )
-      (
-        source_demo_notify(model),
-        { ..model, editor: result.source, dirty: false, status, status_tone },
-      )
+      source_demo_result_step(model, result, status, status_tone)
     }
     SyncFromGraph => {
+      // Keep out of the way while the editor holds unapplied edits, so the
+      // periodic poll never overwrites in-progress typing.
       if model.dirty {
         return (@rabbita.none, model)
       }
@@ -169,7 +220,7 @@ fn source_demo_update(
         (@rabbita.none, model)
       } else {
         (
-          @rabbita.none,
+          @codemirror.set_doc(SOURCE_CM_EDITOR_ID, source),
           {
             ..model,
             editor: source,
@@ -179,26 +230,35 @@ fn source_demo_update(
         )
       }
     }
+    Mounted => (@rabbita.none, { ..model, mounted: true })
+    MountFailed(message) =>
+      (
+        @rabbita.none,
+        {
+          ..model,
+          mounted: false,
+          status: "CodeMirror failed to mount: " + message,
+          status_tone: @status.Error,
+        },
+      )
   }
 }
 
 ///|
 fn source_demo_subscriptions(
   emit : Emit[SourceDemoMsg],
-  _model : SourceDemoModel,
+  model : SourceDemoModel,
 ) -> @sub.Sub {
-  @sub.batch([
-    @sub.every(250, emit(SyncFromGraph)),
+  let cm_listen = if model.mounted {
     @codemirror.listen(
       SOURCE_CM_EDITOR_ID,
+      doc=emit.map(source => EditorSynced(source)),
       on_change=emit.map(changes => SourceChanged(changes)),
-    ),
-  ])
-}
-
-///|
-fn source_textarea_attrs() -> @html.Attrs {
-  @html.Attrs::build().spellcheck(false).aria_label("Graph DSL source")
+    )
+  } else {
+    @sub.none
+  }
+  @sub.batch([@sub.every(250, emit(SyncFromGraph)), cm_listen])
 }
 
 ///|
@@ -212,12 +272,11 @@ fn source_demo_view(
     attrs=@html.Attrs::build().aria_label("Graph DSL source"),
     [
       div(class="panel-title", [h2("Graph source"), span("Canonical DSL")]),
-      textarea(
-        id="source-editor",
-        class="source-editor",
-        value=model.editor,
-        on_input=emit.map(source => EditorChanged(source)),
-        attrs=source_textarea_attrs(),
+      // CodeMirror mounts into this host imperatively; the `nothing` child
+      // keeps rabbita's vdom from reconciling (and clearing) the editor DOM.
+      div(
+        id=SOURCE_CM_EDITOR_ID,
+        class="source-editor source-editor-cm",
         nothing,
       ),
       div(class="source-actions", [
@@ -252,6 +311,7 @@ fn source_demo_view(
 }
 
 ///|
+#warnings("-alert_unstable")
 #cfg(target="js")
 pub fn mount_source_demo(
   handle : Int,
@@ -266,16 +326,18 @@ pub fn mount_source_demo(
     handle,
     editor: get_source_graph_source(handle),
     dirty: false,
+    mounted: false,
     status: "Source mode active: operations lower into graph-dsl text.",
     status_tone: @status.Info,
     on_change,
   }
-  @rabbita.new(
-    @rabbita.cell(
-      model~,
-      update=source_demo_update,
-      view=source_demo_view,
-      subscriptions=source_demo_subscriptions,
-    ),
-  ).mount("source-panel-root")
+  let (emit, cell) = @rabbita.cell_with_emit(
+    model~,
+    update=source_demo_update,
+    view=source_demo_view,
+    subscriptions=source_demo_subscriptions,
+  )
+  @rabbita.new(cell)
+  ..with_init(mount_source_cm_cmd(emit, model))
+  .mount("source-panel-root")
 }

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -31,10 +31,10 @@ fn js_source_mode_url(enabled : Bool) -> String {
 struct SourceDemoModel {
   handle : Int
   editor : String
-  // `dirty` is true while the CodeMirror buffer diverges from the graph's
-  // canonical source — i.e. the user has typed edits that have not (or could
-  // not) be lowered. It gates `SyncFromGraph` so the periodic graph→editor
-  // push never clobbers in-progress (possibly transiently-invalid) typing.
+  // `dirty` is true while the editor's current text is not graph-valid. The
+  // source always tracks the editor buffer (see `apply_codemirror_changes`), so
+  // `dirty` is purely a status/validity signal; it also gates `SyncFromGraph`
+  // as a guard against pushing an out-of-band source over invalid typing.
   dirty : Bool
   mounted : Bool
   status : String
@@ -135,13 +135,21 @@ fn source_demo_status_from_result(
 /// Fold a graph-side operation result (Connect / Insert / Apply) into the next
 /// command and model. On success the canonical `result.source` is pushed back
 /// into CodeMirror via `set_doc` (echo-suppressed, skip-equal) and the editor
-/// is marked clean; on rejection the editor keeps the user's text and stays
-/// dirty so the canvas continues rendering the last-good graph.
+/// is marked clean.
+///
+/// `dirty_on_reject` is the dirty flag to set when the operation is rejected.
+/// `dirty` means "the editor's current text is not graph-valid". A rejected
+/// Apply leaves the editor holding the invalid source it tried to apply, so it
+/// passes `true`. Connect / Insert never touch the editor (and can be rejected
+/// for an already-invalid current source, before any rollback), so they must
+/// PRESERVE the prior `dirty` by passing `model.dirty` — not force it `false`,
+/// which would wrongly clear dirtiness the editor still has.
 fn source_demo_result_step(
   model : SourceDemoModel,
   result : SourceGraphOperationResultJson,
   status : String,
   status_tone : @status.Tone,
+  dirty_on_reject~ : Bool,
 ) -> (Cmd, SourceDemoModel) {
   if result.applied {
     (
@@ -152,7 +160,10 @@ fn source_demo_result_step(
       { ..model, editor: result.source, dirty: false, status, status_tone },
     )
   } else {
-    (source_demo_notify(model), { ..model, dirty: true, status, status_tone })
+    (
+      source_demo_notify(model),
+      { ..model, dirty: dirty_on_reject, status, status_tone },
+    )
   }
 }
 
@@ -165,29 +176,25 @@ fn source_demo_update(
   match msg {
     EditorSynced(source) => (@rabbita.none, { ..model, editor: source })
     SourceChanged(changes) => {
-      // Incremental lowering rebases each CodeMirror delta onto the graph's
-      // current source, which only matches the editor while they agree. Once
-      // `dirty` (a prior edit was rejected and rolled back to last-good), the
-      // deltas are expressed against the diverged editor buffer, so replaying
-      // them onto last-good would splice into the wrong coordinates and corrupt
-      // the source. While dirty, recover by reparsing the whole buffer instead
-      // (`EditorSynced`, delivered before this message, has `editor` current);
-      // identity-preserving incremental lowering resumes once the editor and
-      // graph are back in sync.
-      let result = if model.dirty {
-        set_source_graph_source_checked(model.handle, model.editor)
-      } else {
-        apply_source_graph_codemirror_changes(model.handle, changes)
-      }
+      // The editor is the source of truth for text. Lower the change
+      // incrementally, passing the editor's post-change buffer (`model.editor`,
+      // set by the preceding `EditorSynced`) as the authoritative target: the
+      // adapter keeps its source equal to the editor and reconciles editor-wins
+      // if an out-of-band graph mutation diverged them, so a transiently-invalid
+      // edit recovers incrementally with stable node identity (no whole-source
+      // churn). We never `set_doc` here — CodeMirror already holds the text; the
+      // canvas keeps rendering the last-good graph while the source is invalid,
+      // and `dirty` only records that validity.
+      let result = apply_source_graph_codemirror_changes(
+        model.handle,
+        changes,
+        model.editor,
+      )
       let success_message = "Editor changes lowered into graph-dsl source."
       let failure_prefix = "Editor change rejected; canvas is rendering last-good graph"
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, failure_prefix,
       )
-      // The edit originates in CodeMirror, which already holds the user's text,
-      // so never push it back here (a transiently-invalid keystroke rolled back
-      // to last-good would otherwise revert in-progress typing). `EditorSynced`
-      // keeps `editor` current; we only record validity through `dirty`.
       (
         source_demo_notify(model),
         { ..model, dirty: !result.applied, status, status_tone },
@@ -200,7 +207,15 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, failure_prefix,
       )
-      source_demo_result_step(model, result, status, status_tone)
+      // Apply lowers the editor's own text, so a rejection leaves the editor
+      // holding invalid source → dirty.
+      source_demo_result_step(
+        model,
+        result,
+        status,
+        status_tone,
+        dirty_on_reject=true,
+      )
     }
     ConnectSample => {
       let result = source_graph_connect_sample_result(model.handle)
@@ -208,7 +223,14 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, "Source operation rejected",
       )
-      source_demo_result_step(model, result, status, status_tone)
+      // A rejected connect never edits the editor, so its validity is unchanged.
+      source_demo_result_step(
+        model,
+        result,
+        status,
+        status_tone,
+        dirty_on_reject=model.dirty,
+      )
     }
     InsertReverb => {
       let result = source_graph_insert_unique_result(
@@ -220,7 +242,14 @@ fn source_demo_update(
       let (status, status_tone) = source_demo_status_from_result(
         result, success_message, "Source operation rejected",
       )
-      source_demo_result_step(model, result, status, status_tone)
+      // A rejected insert never edits the editor, so its validity is unchanged.
+      source_demo_result_step(
+        model,
+        result,
+        status,
+        status_tone,
+        dirty_on_reject=model.dirty,
+      )
     }
     SyncFromGraph => {
       // Keep out of the way while the editor holds unapplied edits, so the

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -274,11 +274,13 @@ fn source_demo_update(
     }
     Mounted => (@rabbita.none, { ..model, mounted: true })
     MountFailed(message) =>
+      // `mounted` stays at its prior value (false): mount fires once via
+      // `with_init`, so a failure can only arrive while `mounted` is still
+      // false. No need to set it here.
       (
         @rabbita.none,
         {
           ..model,
-          mounted: false,
           status: "CodeMirror failed to mount: " + message,
           status_tone: @status.Error,
         },
@@ -291,16 +293,19 @@ fn source_demo_subscriptions(
   emit : Emit[SourceDemoMsg],
   model : SourceDemoModel,
 ) -> @sub.Sub {
-  let cm_listen = if model.mounted {
+  // Both subscriptions need the editor to exist: `listen` is a no-op until the
+  // view is registered, and the graph -> editor poll has nothing to sync into
+  // (and would `set_doc` a not-yet-mounted editor). Gate the whole batch on
+  // `mounted` so neither runs before the editor mounts.
+  guard model.mounted else { return @sub.none }
+  @sub.batch([
+    @sub.every(250, emit(SyncFromGraph)),
     @codemirror.listen(
       SOURCE_CM_EDITOR_ID,
       doc=emit.map(source => EditorSynced(source)),
       on_change=emit.map(changes => SourceChanged(changes)),
-    )
-  } else {
-    @sub.none
-  }
-  @sub.batch([@sub.every(250, emit(SyncFromGraph)), cm_listen])
+    ),
+  ])
 }
 
 ///|

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -165,7 +165,20 @@ fn source_demo_update(
   match msg {
     EditorSynced(source) => (@rabbita.none, { ..model, editor: source })
     SourceChanged(changes) => {
-      let result = apply_source_graph_codemirror_changes(model.handle, changes)
+      // Incremental lowering rebases each CodeMirror delta onto the graph's
+      // current source, which only matches the editor while they agree. Once
+      // `dirty` (a prior edit was rejected and rolled back to last-good), the
+      // deltas are expressed against the diverged editor buffer, so replaying
+      // them onto last-good would splice into the wrong coordinates and corrupt
+      // the source. While dirty, recover by reparsing the whole buffer instead
+      // (`EditorSynced`, delivered before this message, has `editor` current);
+      // identity-preserving incremental lowering resumes once the editor and
+      // graph are back in sync.
+      let result = if model.dirty {
+        set_source_graph_source_checked(model.handle, model.editor)
+      } else {
+        apply_source_graph_codemirror_changes(model.handle, changes)
+      }
       let success_message = "Editor changes lowered into graph-dsl source."
       let failure_prefix = "Editor change rejected; canvas is rendering last-good graph"
       let (status, status_tone) = source_demo_status_from_result(

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -295,6 +295,55 @@ for (const invalidSource of INVALID_SOURCE_CASES) {
   });
 }
 
+test('source-backed editor recovers from a transiently-invalid edit without corrupting incremental deltas', async ({
+  page,
+}) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto('/?source=1');
+  await expectSource(page, SAMPLE_SOURCE);
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+
+  // Delete `440Hz` with an incremental edit, leaving the buffer transiently
+  // invalid (`osc = sine(freq: )`). The graph rolls back to last-good and the
+  // editor diverges (dirty) — the precondition for the rebase corruption.
+  const content = page.locator('#source-editor-cm .cm-content');
+  await content.click();
+  await page.keyboard.press('ControlOrMeta+Home');
+  for (let i = 0; i < 'osc = sine(freq: '.length; i++) {
+    await page.keyboard.press('ArrowRight');
+  }
+  for (let i = 0; i < '440Hz'.length; i++) {
+    await page.keyboard.press('Shift+ArrowRight');
+  }
+  await page.keyboard.press('Delete');
+  await expectSource(page, 'osc = sine(freq: )\nmeter = scope()');
+  await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'error');
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+
+  // Type a different valid value at the cursor. With the buffer dirty, each
+  // keystroke's delta is expressed against the editor text, not the graph's
+  // rolled-back last-good source; replaying incrementally would splice into
+  // the wrong coordinates (e.g. `220Hz440Hz`). It must recover and re-apply to
+  // the graph as exactly the typed text.
+  await page.keyboard.type('220Hz');
+
+  // The CodeMirror buffer transiently shows the typed text either way, so the
+  // graph source is the real observable. Let the 250ms graph→editor poll run a
+  // couple of cycles: when the graph and editor disagree (only possible if the
+  // graph was corrupted) the poll pushes the canonical source back into the
+  // buffer. With the rebase fixed the graph holds exactly `220Hz`, the poll is
+  // a no-op, and the buffer stays put; without the fix the deltas replay
+  // against the rolled-back last-good source and the poll surfaces the
+  // corrupted `220Hz440Hz` here.
+  await page.waitForTimeout(600);
+  expect(await cmText(page)).toBe('osc = sine(freq: 220Hz)\nmeter = scope()');
+  await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+
+  expect(runtimeErrors).toEqual([]);
+});
+
 test('source-backed mode mutates canonical source and render state together', async ({ page }) => {
   const runtimeErrors = collectRuntimeErrors(page);
 

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -24,6 +24,29 @@ function edgePaths(page: Page): Locator {
   return page.locator('#edges path.edge');
 }
 
+// The source panel renders a CodeMirror editor (contenteditable), not a
+// textarea. Read its document by joining the rendered `.cm-line` divs with
+// newlines, normalizing the NBSPs CodeMirror uses for runs of spaces.
+async function cmText(page: Page): Promise<string> {
+  const lines = await page.locator('#source-editor-cm .cm-line').allTextContents();
+  return lines.map((line) => line.replace(/ /g, ' ')).join('\n');
+}
+
+// CodeMirror updates asynchronously (mount, set_doc echo, the 250ms graph
+// poll), so poll the document rather than reading it once.
+async function expectSource(page: Page, expected: string): Promise<void> {
+  await expect.poll(() => cmText(page)).toBe(expected);
+}
+
+// Replace the whole CodeMirror document, the way a user select-all + paste
+// would: the resulting transaction flows through `listen(on_change=...)` and
+// lowers into graph-dsl source.
+async function setSource(page: Page, text: string): Promise<void> {
+  await page.locator('#source-editor-cm .cm-content').click();
+  await page.keyboard.press('ControlOrMeta+A');
+  await page.keyboard.insertText(text);
+}
+
 async function center(locator: Locator, label: string): Promise<Point> {
   const box = await locator.boundingBox();
   if (!box) {
@@ -84,7 +107,7 @@ test('source-backed node drag updates local layout without mutating source', asy
   const runtimeErrors = collectRuntimeErrors(page);
 
   await page.goto('/?source=1');
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
 
   const node = page.locator('.canvas-node[data-node-id="1"]');
   const before = await center(node, 'source-backed node');
@@ -93,7 +116,7 @@ test('source-backed node drag updates local layout without mutating source', asy
 
   expect(after.x - before.x).toBeGreaterThan(60);
   expect(after.y - before.y).toBeGreaterThan(20);
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   expect(runtimeErrors).toEqual([]);
 });
@@ -102,15 +125,13 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   const runtimeErrors = collectRuntimeErrors(page);
 
   await page.goto('/?source=1');
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
 
   await dragBetween(page, outputHandle(page, 1), inputHandle(page, 2));
   await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
   await page.mouse.up();
 
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
-  );
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
   await expect(page.locator('#edges path.edge')).toHaveCount(1);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   expect(runtimeErrors).toEqual([]);
@@ -127,9 +148,7 @@ test('source-backed inspector rename lowers to canonical source and references',
 
   await page.goto('/?source=1');
   await page.locator('#source-connect').click();
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
-  );
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
 
   await selectSourceNode(page, 1);
   const renameInput = page.locator('#node-rename-input');
@@ -137,9 +156,7 @@ test('source-backed inspector rename lowers to canonical source and references',
   await renameInput.fill('lfo');
   await renameInput.press('Enter');
 
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'lfo = sine(freq: 440Hz)\nmeter = scope(input: lfo)',
-  );
+  await expectSource(page, 'lfo = sine(freq: 440Hz)\nmeter = scope(input: lfo)');
   await expect(page.locator('.canvas-node[data-node-id="1"] .node-title')).toHaveText('lfo');
   await expect(page.locator('#edges path.edge')).toHaveCount(1);
   await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
@@ -154,7 +171,7 @@ test('source-backed inspector numeric parameter edit lowers to canonical source'
   const runtimeErrors = collectRuntimeErrors(page);
 
   await page.goto('/?source=1');
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
 
   await selectSourceNode(page, 1);
   const freqInput = page.locator('#node-param-freq');
@@ -162,9 +179,7 @@ test('source-backed inspector numeric parameter edit lowers to canonical source'
   await freqInput.fill('880');
   await freqInput.press('Enter');
 
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 880Hz)\nmeter = scope()',
-  );
+  await expectSource(page, 'osc = sine(freq: 880Hz)\nmeter = scope()');
   await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
   await expect(page.locator('#source-status')).toContainText(
     'Updated freq through graph-dsl source.',
@@ -177,21 +192,19 @@ test('source-backed selected edge deletion lowers into canonical source', async 
   const runtimeErrors = collectRuntimeErrors(page);
 
   await page.goto('/?source=1');
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
 
   await dragBetween(page, outputHandle(page, 1), inputHandle(page, 2));
   await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
   await page.mouse.up();
   await expect(edgePaths(page)).toHaveCount(1);
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
-  );
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
 
   await clickEdge(page, 0);
   await expect(edgePaths(page).first()).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
   await page.keyboard.press('Backspace');
 
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
   await expect(page.locator('.canvas-node')).toHaveCount(2);
   await expect(edgePaths(page)).toHaveCount(0);
   await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
@@ -206,14 +219,14 @@ test('source-backed selected node deletion lowers into canonical source', async 
   const runtimeErrors = collectRuntimeErrors(page);
 
   await page.goto('/?source=1');
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
 
   const meter = page.locator('.canvas-node[data-node-id="2"]');
   await meter.click();
   await expect(meter).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
   await page.keyboard.press('Delete');
 
-  await expect(page.locator('#source-editor')).toHaveValue('osc = sine(freq: 440Hz)');
+  await expectSource(page, 'osc = sine(freq: 440Hz)');
   await expect(page.locator('.canvas-node')).toHaveCount(1);
   await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveCount(0);
   await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
@@ -225,18 +238,14 @@ test('source-backed deletion rejects unsafe survivor references', async ({ page 
 
   await page.goto('/?source=1');
   await page.locator('#source-connect').click();
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
-  );
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
 
   const osc = page.locator('.canvas-node[data-node-id="1"]');
   await osc.click();
   await expect(osc).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
   await page.keyboard.press('Delete');
 
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
-  );
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
   await expect(page.locator('.canvas-node')).toHaveCount(2);
   await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'error');
   await expect(page.locator('#source-status')).toContainText('Source delete rejected:');
@@ -249,7 +258,7 @@ test('source-backed deletion ignores source editor focus', async ({ page }) => {
 
   await page.goto('/?source=1');
   await page.locator('.canvas-node[data-node-id="2"]').click();
-  await page.locator('#source-editor').focus();
+  await page.locator('#source-editor-cm .cm-content').focus();
   await page.keyboard.press('Backspace');
 
   await expect(page.locator('.canvas-node')).toHaveCount(2);
@@ -262,13 +271,13 @@ for (const invalidSource of INVALID_SOURCE_CASES) {
     const runtimeErrors = collectRuntimeErrors(page);
 
     await page.goto('/?source=1');
-    await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+    await expectSource(page, SAMPLE_SOURCE);
     await expect(page.locator('.canvas-node')).toHaveCount(2);
 
-    await page.locator('#source-editor').fill(invalidSource.source);
+    await setSource(page, invalidSource.source);
     await page.locator('#source-apply').click();
 
-    await expect(page.locator('#source-editor')).toHaveValue(invalidSource.source);
+    await expectSource(page, invalidSource.source);
     await expect(page.locator('.canvas-node')).toHaveCount(2);
     await expect(page.locator('#edges path.edge')).toHaveCount(0);
     await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
@@ -293,26 +302,26 @@ test('source-backed mode mutates canonical source and render state together', as
 
   await expect(page.locator('#source-panel')).toBeVisible();
   await expect(page.locator('#source-mode-toggle')).toHaveText('Return to canvas runtime');
-  await expect(page.locator('#source-editor')).toHaveValue(SAMPLE_SOURCE);
+  await expectSource(page, SAMPLE_SOURCE);
   await expect(page.locator('.canvas-node')).toHaveCount(2);
   await expect(page.locator('#edges path.edge')).toHaveCount(0);
   await expect(page.locator('#action-stat')).toHaveText('0 actions logged');
 
   await page.locator('#source-connect').click();
-  await expect(page.locator('#source-editor')).toHaveValue(
-    'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)',
-  );
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
   await expect(page.locator('#edges path.edge')).toHaveCount(1);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
 
   await page.locator('#source-insert').click();
-  await expect(page.locator('#source-editor')).toHaveValue(
+  await expectSource(
+    page,
     'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()',
   );
   await expect(page.locator('.canvas-node')).toHaveCount(3);
   await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
 
-  await page.locator('#source-editor').fill(
+  await setSource(
+    page,
     'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()\ntap = scope(input: reverb)',
   );
   await page.locator('#source-apply').click();

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -257,10 +257,26 @@ test('source-backed deletion ignores source editor focus', async ({ page }) => {
   const runtimeErrors = collectRuntimeErrors(page);
 
   await page.goto('/?source=1');
+  await expect(page.locator('.canvas-node')).toHaveCount(2);
+
+  // Select a canvas node so a missing focus guard WOULD delete it. The keydown
+  // bubbles to the document handler even from CodeMirror (CM6 does not
+  // stopPropagation by default), so `editableKeyboardTarget` is the only thing
+  // between this Backspace and `deleteSelectedNodes`.
   await page.locator('.canvas-node[data-node-id="2"]').click();
+  await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveClass(
+    /(?:^|\s)selected(?:\s|$)/,
+  );
+
+  // Put the cursor at the end of the document so Backspace is a real editor
+  // edit (deleting the trailing `)`), not a no-op at offset 0.
   await page.locator('#source-editor-cm .cm-content').focus();
+  await page.keyboard.press('ControlOrMeta+End');
   await page.keyboard.press('Backspace');
 
+  // The keystroke edited the source editor ...
+  await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(');
+  // ... and did NOT delete the selected canvas node (the focus guard held).
   await expect(page.locator('.canvas-node')).toHaveCount(2);
   await expect(page.locator('#action-stat')).toHaveText('1 action logged');
   expect(runtimeErrors).toEqual([]);

--- a/examples/canvas/web/package-lock.json
+++ b/examples/canvas/web/package-lock.json
@@ -5,10 +5,62 @@
   "packages": {
     "": {
       "name": "canopy-canvas",
+      "dependencies": {
+        "@codemirror/commands": "^6.5.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.26.0"
+      },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "typescript": "^5.4.0",
         "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+      "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -401,6 +453,36 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
@@ -814,6 +896,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -1025,6 +1113,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1098,6 +1192,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     }
   }
 }

--- a/examples/canvas/web/package.json
+++ b/examples/canvas/web/package.json
@@ -11,6 +11,11 @@
     "prebuild": "npm run prebuild:moonbit",
     "prebuild:moonbit": "cd .. && MOON_WORK=off moon build --target js --release"
   },
+  "dependencies": {
+    "@codemirror/commands": "^6.5.0",
+    "@codemirror/state": "^6.4.0",
+    "@codemirror/view": "^6.26.0"
+  },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "typescript": "^5.4.0",

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -1,3 +1,6 @@
+import * as cmCommands from '@codemirror/commands';
+import * as cmState from '@codemirror/state';
+import * as cmView from '@codemirror/view';
 import {
   GraphAdapter,
   type CanvasModule,
@@ -385,7 +388,6 @@ function commitSourceRename(nodeId: number, currentName: string, nextName: strin
   if (trimmed === currentName || trimmed.length === 0) return;
   const result = adapter.renameNode(nodeId, trimmed);
   if (!result) return;
-  syncSourceEditorFromResult(result);
   updateSourceOperationStatus(
     result,
     'Renamed node binding through graph-dsl source.',
@@ -404,7 +406,6 @@ function commitSourceParam(
   if (trimmed === param.value || trimmed.length === 0) return;
   const result = adapter.setNodeParam(nodeId, param.name, trimmed);
   if (!result) return;
-  syncSourceEditorFromResult(result);
   updateSourceOperationStatus(
     result,
     `Updated ${param.name} through graph-dsl source.`,
@@ -699,12 +700,6 @@ function updateSourceOperationStatus(
     : `${failurePrefix}: ${sourceOperationDetail(result)}`;
 }
 
-function syncSourceEditorFromResult(result: SourceGraphOperationResult): void {
-  if (!result.applied) return;
-  const editor = document.getElementById('source-editor') as HTMLTextAreaElement | null;
-  if (editor) editor.value = result.source;
-}
-
 function disconnectEdge(edge: EdgeData): boolean {
   const result = adapter.disconnectPorts(
     edge.source,
@@ -713,7 +708,6 @@ function disconnectEdge(edge: EdgeData): boolean {
     edge.target_port,
   );
   if (result) {
-    syncSourceEditorFromResult(result);
     updateSourceOperationStatus(
       result,
       'Disconnected selected edge through graph-dsl source.',
@@ -745,7 +739,6 @@ function deleteSelectedNodes(): boolean {
   if (selectedNodes.length === 0) return false;
   const result = adapter.deleteNodes(selectedNodes);
   if (result) {
-    syncSourceEditorFromResult(result);
     updateSourceOperationStatus(
       result,
       'Deleted selected nodes through graph-dsl source.',
@@ -1046,7 +1039,15 @@ function requireSourceDemoModule(mb: CanvasModule): SourceDemoModule {
   return mb as SourceDemoModule;
 }
 
+// The source-panel CodeMirror editor loads via `mount(source="global:…")`,
+// so bundle the CM6 namespace and publish it before the MoonBit module mounts.
+// This keeps the editor deterministic and offline (no esm.sh fetch at runtime).
+const canopyGlobal = globalThis as typeof globalThis & {
+  __canopy_codemirror?: Record<string, unknown>;
+};
+
 async function init(): Promise<void> {
+  canopyGlobal.__canopy_codemirror = { ...cmState, ...cmView, ...cmCommands };
   const mod = await import('@moonbit/canopy-canvas') as CanvasModule;
   const sourceDemoModule = requireSourceDemoModule(mod);
   const sourceMode = sourceDemoRequested();

--- a/lib/rabbita_codemirror/js/codemirror.mbt
+++ b/lib/rabbita_codemirror/js/codemirror.mbt
@@ -358,9 +358,12 @@ extern "js" fn js_add_update_listener_raw(
   #|     }
   #|     if (update.docChanged && !isApplying()) {
   #|       const deltas = [];
+  #|       // `individual = true` keeps adjacent changes as separate ranges;
+  #|       // the default (false) coalesces neighbours into one merged range,
+  #|       // which would collapse the per-range ChangeDelta contract.
   #|       update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
   #|         deltas.push({ from: fromA, to: toA, insert: inserted.toString() });
-  #|       });
+  #|       }, true);
   #|       onChanges(deltas);
   #|     }
   #|     if ((update.selectionSet || update.docChanged) && !isApplying()) {


### PR DESCRIPTION
## Summary

Completes #565 PR1 (delta editor) on the consumer side: the canvas source panel now mounts a real **CodeMirror** editor in place of the `<textarea>`, so editing the source lowers into graph-dsl **per change** — `on_change` → `changes_to_edits` → `apply_edit` — exercising the binding's additive `on_change` path live.

Follows #569 (the lowering + binding half, merged at `c2a7f04`).

## Changes

- **`lib/rabbita_codemirror/js/codemirror.mbt`** — P2 fix: `update.changes.iterChanges(cb, true)`. CodeMirror's `iterChanges` defaults `individual=false`, coalescing *adjacent* changes into one merged range; `true` keeps every replaced range separate, honoring the per-range `ChangeDelta` contract.
- **`examples/canvas/main/source_demo.mbt`** — the mount + TEA logic (mirrors `examples/ideal/main/main.mbt`):
  - `cell_with_emit` + `..with_init(mount_source_cm_cmd)`; `@codemirror.mount(source="global:__canopy_codemirror")`.
  - `listen(doc=EditorSynced, on_change=SourceChanged)` gated behind `model.mounted` — the binding's sub loader is a no-op until the editor is in its registry, so without the gate the sub installs once before mount and never re-attaches.
  - `EditorSynced` tracks CodeMirror's true text; `SourceChanged` lowers and records validity via `dirty` but **never** `set_doc`s — a transiently-invalid keystroke rolled back to last-good must not revert in-progress typing. `dirty` gates the 250 ms `SyncFromGraph` poll. Programmatic ops (Connect/Insert/Apply) `set_doc` only when applied.
- **`examples/canvas/web/src/main.ts`** + **`package.json`** — bundle `@codemirror/{state,view,commands}` into `globalThis.__canopy_codemirror` before the MoonBit module loads (offline/deterministic, no esm.sh in a tested E2E path). Removes the now-dead `syncSourceEditorFromResult` (it wrote the removed textarea) and its 4 call sites; canvas-gesture changes now reach CodeMirror via the panel's poll.
- **`examples/canvas/web/e2e/source-backed.spec.ts`** — migrated `#source-editor` `toHaveValue` → `cmText` (reads `.cm-line`), `fill` → `setSource` (select-all + `insertText`), and editor `.focus()` → `.cm-content`.
- **`docs/plans/2026-06-08-565-stable-canvas-node-identity.md`** — the #565 design doc (PR1 + PR2 spec).

## Reuse check

Reuses `@codemirror.{mount,listen,set_doc}` and the existing `apply_source_graph_codemirror_changes` bridge; mirrors the ideal editor's mount pattern. No new types or helpers introduced on the model side.

## Validation

- `moon check --target js` + `moon test --target js` — 1631 pass.
- Canvas Playwright E2E — **18/18 pass** (source-backed 11 + canvas-handles 7), including a positive-control probe confirming canvas/inspector gestures sync CodeMirror via the poll with operation status intact.
- Codex pre-PR review: PASS, no blocking findings.

## Follow-up (agreed, not in this PR)

Replace the 250 ms `SyncFromGraph` poll with **incr-based invalidation**: expose a change-event on `GraphAttachment` (loom submodule) and bridge it via a rabbita `custom_sub`, deleting the poll. `GraphAttachment` is already incr-backed internally; it just doesn't surface a hook yet.

## Not in scope

#565 **PR2** (String `NodeId = id()` identity migration) is separate and later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the textarea source editor with a CodeMirror-based editor for a smoother, incremental editing experience.
* **Improvements**
  * More robust graph↔editor sync: incremental deltas, stale-editor guard, and editor-authoritative recovery that preserves node identity without unexpected rollbacks.
* **Tests**
  * Updated and added end-to-end tests to validate CodeMirror interactions and recovery from transient invalid edits.
* **Documentation**
  * Added design proposals describing stable node identity and editor-authoritative source approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->