### PR TITLE
feat(canvas): collapse source-backed node identity to the projection token (#565 PR2)

### DIFF
--- a/docs/plans/2026-06-08-565-stable-canvas-node-identity.md
+++ b/docs/plans/2026-06-08-565-stable-canvas-node-identity.md
@@ -115,3 +115,66 @@ Additional structural checks:
 1. Should the string-ID migration include an explicit one-time wire version marker for persisted handles from older numeric IDs?  
 2. Should the delta path in Canvas be switched atomically across the whole source-edit surface or behind a feature flag until all dependent adapters are migrated?  
 3. For `GraphAttachment::apply_edit`, should retries/reconciliation tolerate JS listener dropouts by falling back to `set_source` and accepting one-time churn windows?
+
+## PR2 execution addendum (validated 2026-06-09)
+
+Empirical re-validation (whitebox probe on `GraphAttachment`, since removed) refined
+the design and answered the open questions. Token format is
+`"node#<occurrence>:<binding>"` (e.g. `node#0:osc`), and the tracker realigns ids by
+content on every reparse — including whole-source `set_source`. Measured:
+
+| Path | Survivor/target token |
+|---|---|
+| `set_source` delete of a *different* binding line | **STABLE** (`node#0:reverb` unchanged) |
+| `apply_edit` (delta) delete of a different binding line | **STABLE** |
+| `set_source` *reorder* (swap two bindings) | **CHURNS** (`node#0:osc` → `node#1:osc`) |
+
+Consequences for PR2:
+
+- **No delete-to-delta conversion.** Survivor tokens are stable under the existing
+  whole-source delete path, so `source_delete_lowering` may keep emitting
+  `WholeSourceReplacement`. Selection over a survivor stays valid with **no remap**.
+- **Layer 3 (retire the binding-recovery shim) is correct for delete + param-edit +
+  editor-driven reorder.** A CM6 reorder is a delta delete+insert pair (stable per the
+  empirical table), so editor reorders preserve identity without remap.
+- **`set_source` becomes reset/init-only.** The one residual churn case is an atomic
+  `set_source` reorder — now a programmatic-reset path, not a user gesture. The old
+  `graph_dsl_adapter_wbtest.mbt` "reorder via `set_source` preserves selection by binding"
+  cases (currently asserting positional remap) are rewritten: editor-delta reorders assert
+  identity preservation; any remaining `set_source` reorder asserts the residual
+  (selection cleared/dropped on churn), not remap.
+- **Rename** changes the token (binding is embedded), so a rename-local continuation hook
+  rewrites live `interaction` selection old-token → new-token (replacing today's
+  `rename_layout_binding`, which stays for binding-keyed layout). `action_log` keeps the
+  old token as a historical record — it is display-only (TS `JSON.parse`s it, never
+  replays it against the tracker), so no rewrite there.
+- **EdgeId** is derived from the 4-tuple `(source_token, source_port, target_token,
+  target_port)` (source_port included so multi-output nodes don't collide). No allocator,
+  no `next_edge_id`. Derived ids are consistent within a render; on rename an endpoint
+  token change re-derives the edge id for one render cycle (acceptable; disconnect
+  hit-tests within the current render).
+- **`next_node_id : Int`** is kept only as the hand-built (non-source) canvas mint counter
+  (`NodeId(next_node_id.to_string())`); source-backed and hand-built ids never share a
+  `CanvasState`, so no collision.
+- **Open Q1: no wire-version marker.** No persisted numeric-id JSON exists (no
+  `localStorage`; `action_log` is in-memory per session). Test fixtures migrate to strings.
+- **Lookup:** loom gains `GraphDoc::find_node_by_id(String)` (landed in a loom PR; canopy
+  loom pin bumped). `graph_node_for_canvas_id` resolves via it instead of `nodes[raw-1]`.
+- **Layer 3 mechanism = prune-by-token-existence, not pure deletion.** The binding-capture/
+  replay helpers (`source_selected_node_bindings`, `source_selection_from_bindings`,
+  `remap_selection_to_bindings`, and the `set_source`/`apply_codemirror_changes`/delete
+  capture blocks) are deleted and replaced by a single `prune_selection_to_doc(doc)`:
+  after every reparse, filter `interaction.selected_nodes` to tokens that still resolve via
+  `doc.find_node_by_id`, recompute `selected` as the first survivor (else `None`), reset the
+  drag preview. This is token-existence filtering, not binding re-resolution: survivors keep
+  their stable tokens (so selection persists with no mapping), deleted/churned tokens drop
+  out naturally. `realized_source_operation` is *kept* (it stamps the logged `AddNode` with
+  the new node's real token via `canvas_id_for_binding`) — it is log realization, not
+  selection recovery, so it is out of the shim's scope.
+- **FFI node-id params become `String`.** All pointer/hover entry points
+  (`source_graph_pointer_down/up`, hand-built `pointer_down`, `canvas_init` handlers) take a
+  `String` node id; the `node_id <= 0` "none" sentinel becomes the empty string `""`.
+- **Rename selection hook:** in `sync_local_operation_state`'s `RenameNode` arm, in addition
+  to `rename_layout_binding` (binding-keyed layout, kept), rewrite any occurrence of the
+  renamed node's *old* token in `interaction.selected`/`selected_nodes` to its *new* token
+  (old token from `old_doc` by binding; new token from `new_doc.find_node(new_binding).id()`).

--- a/docs/plans/2026-06-08-565-stable-canvas-node-identity.md
+++ b/docs/plans/2026-06-08-565-stable-canvas-node-identity.md
@@ -156,8 +156,16 @@ Consequences for PR2:
 - **`next_node_id : Int`** is kept only as the hand-built (non-source) canvas mint counter
   (`NodeId(next_node_id.to_string())`); source-backed and hand-built ids never share a
   `CanvasState`, so no collision.
-- **Open Q1: no wire-version marker.** No persisted numeric-id JSON exists (no
-  `localStorage`; `action_log` is in-memory per session). Test fixtures migrate to strings.
+- **Open Q1: bump `GRAPH_OPERATION_VERSION` 1→2 (no compat decode path).** No persisted
+  numeric-id JSON exists to migrate (no `localStorage`; `action_log` is in-memory per
+  session, read-out-only, never replayed into `apply_source_graph_operation`), so a
+  numeric-accepting decode path is unwarranted and would re-introduce the int/token
+  ambiguity this PR removes. But `from_json` gates on `version == GRAPH_OPERATION_VERSION`,
+  so leaving the format-defining marker at 1 while the NodeId wire encoding changed
+  (number→string) would make "v1" denote two incompatible formats. Bumping to 2 keeps the
+  marker honest: any pre-bump payload is rejected with a clear `unsupported version 1`
+  rather than a confusing `expected string`. TS producers and serialization snapshots move
+  to 2 in lockstep. Test fixtures migrate to string ids.
 - **Lookup:** loom gains `GraphDoc::find_node_by_id(String)` (landed in a loom PR; canopy
   loom pin bumped). `graph_node_for_canvas_id` resolves via it instead of `nodes[raw-1]`.
 - **Layer 3 mechanism = prune-by-token-existence, not pure deletion.** The binding-capture/

--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -10,14 +10,14 @@ pub fn create_canvas() -> Int {
 
 ///|
 /// Handle pointer-down. `node_id` is the canvas node id under the pointer,
-/// or 0 for background. Dispatches to pan or drag start internally.
+/// or "" for background. Dispatches to pan or drag start internally.
 pub fn pointer_down(
   handle : Int,
-  node_id : Int,
+  node_id : String,
   sx : Double,
   sy : Double,
 ) -> Unit {
-  let id : NodeId? = if node_id <= 0 { None } else { Some(NodeId(node_id)) }
+  let id : NodeId? = if node_id == "" { None } else { Some(NodeId(node_id)) }
   _registry[handle].pointer_down(id, sx, sy)
 }
 
@@ -25,7 +25,7 @@ pub fn pointer_down(
 /// Pointer-down on an output handle: start an edge-creation gesture.
 pub fn pointer_down_handle(
   handle : Int,
-  node_id : Int,
+  node_id : String,
   port_id : String,
   sx : Double,
   sy : Double,
@@ -48,7 +48,7 @@ pub fn zoom(handle : Int, delta : Double, cx : Double, cy : Double) -> Unit {
 ///|
 pub fn pointer_up(
   handle : Int,
-  node_id : Int,
+  node_id : String,
   target_port_id : String,
   additive : Bool,
 ) -> Unit {
@@ -56,7 +56,7 @@ pub fn pointer_up(
 }
 
 ///|
-pub fn hover_node(handle : Int, node_id : Int) -> Unit {
+pub fn hover_node(handle : Int, node_id : String) -> Unit {
   _registry[handle].hover_node(node_id)
 }
 
@@ -93,9 +93,9 @@ pub fn delete_nodes(handle : Int, node_ids_json : String) -> Unit {
 ///|
 pub fn disconnect_ports(
   handle : Int,
-  source : Int,
+  source : String,
   source_port : String,
-  target : Int,
+  target : String,
   target_port : String,
 ) -> Unit {
   _registry[handle].disconnect_ports(
@@ -116,10 +116,10 @@ struct NodeParamJson {
 } derive(Eq, ToJson)
 
 ///|
-/// Serializable node snapshot. Uses plain Int for `id` to avoid
-/// the NodeId newtype wrapper appearing in JSON output.
+/// Serializable node snapshot. Uses plain String for `id` to carry
+/// the stable NodeId value across the JS boundary.
 struct NodeJson {
-  id : Int
+  id : String
   x : Double
   y : Double
   w : Double
@@ -135,10 +135,10 @@ struct NodeJson {
 
 ///|
 struct EdgeJson {
-  id : Int
-  source : Int
+  id : String
+  source : String
   source_port : String
-  target : Int
+  target : String
   target_port : String
 } derive(Eq, ToJson)
 
@@ -146,7 +146,7 @@ struct EdgeJson {
 /// Serialized in-flight connection. `from` is the source node id;
 /// `cursor_x`/`cursor_y` are world coordinates of the pointer.
 struct ConnectingJson {
-  from : Int
+  from : String
   from_port : String
   cursor_x : Double
   cursor_y : Double
@@ -156,12 +156,12 @@ struct ConnectingJson {
 struct ValidationJson {
   severity : String
   message : String
-  node_id : Int?
+  node_id : String?
 } derive(Eq, ToJson)
 
 ///|
 struct InspectorNodeJson {
-  id : Int
+  id : String
   title : String
   subtitle : String
   configured : Bool
@@ -178,8 +178,8 @@ struct RenderStateJson {
   viewport : Viewport
   nodes : Array[NodeJson]
   edges : Array[EdgeJson]
-  selected : Int?
-  selected_nodes : Array[Int]
+  selected : String?
+  selected_nodes : Array[String]
   connecting : ConnectingJson?
   validation : Array[ValidationJson]
   action_count : Int
@@ -187,16 +187,14 @@ struct RenderStateJson {
 } derive(Eq, ToJson)
 
 ///|
-fn node_id_to_int(id : NodeId) -> Int {
-  let NodeId(n) = id
-  n
+fn node_id_to_string(id : NodeId) -> String {
+  id.to_string()
 }
 
 ///|
 fn node_to_json(n : CanvasNode) -> NodeJson {
-  let NodeId(id) = n.id
   {
-    id,
+    id: n.id.to_string(),
     x: n.x,
     y: n.y,
     w: n.w,
@@ -213,14 +211,11 @@ fn node_to_json(n : CanvasNode) -> NodeJson {
 
 ///|
 fn edge_to_json(e : Edge) -> EdgeJson {
-  let EdgeId(id) = e.id
-  let NodeId(s) = e.source
-  let NodeId(t) = e.target
   {
-    id,
-    source: s,
+    id: e.id.to_string(),
+    source: e.source.to_string(),
     source_port: e.source_port,
-    target: t,
+    target: e.target.to_string(),
     target_port: e.target_port,
   }
 }
@@ -242,7 +237,7 @@ fn append_node_validation(
   node : CanvasNode,
   edges : Array[Edge],
 ) -> Unit {
-  let NodeId(id) = node.id
+  let id = node.id.to_string()
   if !node.configured {
     messages.push({
       severity: "warning",
@@ -289,11 +284,11 @@ fn render_state_json(
   state : CanvasState,
   validation : Array[ValidationJson],
 ) -> RenderStateJson {
-  let selected : Int? = match state.interaction.selected {
+  let selected : String? = match state.interaction.selected {
     None => None
-    Some(id) => Some(node_id_to_int(id))
+    Some(id) => Some(node_id_to_string(id))
   }
-  let selected_nodes = state.interaction.selected_nodes.map(node_id_to_int)
+  let selected_nodes = state.interaction.selected_nodes.map(node_id_to_string)
   {
     viewport: state.viewport,
     nodes: state.nodes.map(node_to_json),

--- a/examples/canvas/main/canvas_runtime.mbt
+++ b/examples/canvas/main/canvas_runtime.mbt
@@ -27,8 +27,8 @@ struct CanvasFullRenderJson {
   viewport : Viewport
   nodes : Array[NodeJson]
   edges : Array[EdgeJson]
-  selected : Int?
-  selected_nodes : Array[Int]
+  selected : String?
+  selected_nodes : Array[String]
   connecting : ConnectingJson?
   validation : Array[ValidationJson]
   action_count : Int
@@ -41,7 +41,6 @@ fn validate_canvas_document(document : CanvasDocument) -> ValidatedCanvas {
       nodes: document.nodes.copy(),
       edges: document.edges.copy(),
       next_node_id: document.next_node_id,
-      next_edge_id: document.next_edge_id,
     },
     validation: validate_workflow(
       canvas_state_from_parts(
@@ -61,7 +60,6 @@ fn normalize_canvas(validated : ValidatedCanvas) -> NormalizedCanvas {
       nodes: validated.document.nodes.copy(),
       edges: validated.document.edges.copy(),
       next_node_id: validated.document.next_node_id,
-      next_edge_id: validated.document.next_edge_id,
     },
     validation: validated.validation.copy(),
   }
@@ -77,7 +75,10 @@ fn lower_canvas(normalized : NormalizedCanvas) -> LoweredCanvas {
 }
 
 ///|
-fn preview_position_for(preview : DragPreview, node_id : Int) -> NodePosition? {
+fn preview_position_for(
+  preview : DragPreview,
+  node_id : String,
+) -> NodePosition? {
   find_position(preview.positions, NodeId(node_id))
 }
 
@@ -94,7 +95,7 @@ fn canvas_node_with_preview(
   node : CanvasNode,
   preview : DragPreview,
 ) -> CanvasNode {
-  match preview_position_for(preview, node_id_to_int(node.id)) {
+  match preview_position_for(preview, node_id_to_string(node.id)) {
     None => node
     Some(pos) => { ..node, x: pos.x, y: pos.y }
   }
@@ -136,11 +137,11 @@ fn render_full_canvas(
   interaction : InteractionState,
   action_count : Int,
 ) -> CanvasFullRenderJson {
-  let selected : Int? = match selection.selected {
+  let selected : String? = match selection.selected {
     None => None
-    Some(id) => Some(node_id_to_int(id))
+    Some(id) => Some(node_id_to_string(id))
   }
-  let selected_nodes = selection.selected_nodes.map(node_id_to_int)
+  let selected_nodes = selection.selected_nodes.map(node_id_to_string)
   {
     viewport,
     nodes: lowered.nodes.map(fn(node) {
@@ -158,7 +159,7 @@ fn render_full_canvas(
 ///|
 fn inspector_node_for_document(
   document : CanvasDocument,
-  node_id : Int,
+  node_id : String,
 ) -> InspectorNodeJson? {
   match find_node(document.nodes, NodeId(node_id)) {
     None => None
@@ -272,7 +273,7 @@ fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
   )
 
   let node_inspector = scope.derived_map(
-    (id : Int) => {
+    (id : String) => {
       inspector_node_for_document(normalized.get_or_abort().document, id)
     },
     label="canvas.inspector.node_by_id",
@@ -284,7 +285,7 @@ fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
       match current_selection.selected {
         Some(id) =>
           inspector_with_source(
-            node_inspector.get_or_abort(node_id_to_int(id)),
+            node_inspector.get_or_abort(node_id_to_string(id)),
             "selected",
           )
         None =>
@@ -292,7 +293,7 @@ fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
             None => None
             Some(id) =>
               inspector_with_source(
-                node_inspector.get_or_abort(node_id_to_int(id)),
+                node_inspector.get_or_abort(node_id_to_string(id)),
                 "hovered",
               )
           }
@@ -435,7 +436,7 @@ fn CanvasRuntime::pointer_move(
 ///|
 fn CanvasRuntime::pointer_up(
   self : CanvasRuntime,
-  node_id : Int,
+  node_id : String,
   target_port_id : String,
   additive : Bool,
 ) -> Unit {
@@ -461,8 +462,8 @@ fn CanvasRuntime::zoom(
 }
 
 ///|
-fn CanvasRuntime::hover_node(self : CanvasRuntime, node_id : Int) -> Unit {
-  let hovered : NodeId? = if node_id <= 0 {
+fn CanvasRuntime::hover_node(self : CanvasRuntime, node_id : String) -> Unit {
+  let hovered : NodeId? = if node_id == "" {
     None
   } else {
     Some(NodeId(node_id))

--- a/examples/canvas/main/canvas_state.mbt
+++ b/examples/canvas/main/canvas_state.mbt
@@ -36,7 +36,6 @@ struct CanvasDocument {
   nodes : Array[CanvasNode]
   edges : Array[Edge]
   next_node_id : Int
-  next_edge_id : Int
 } derive(Debug, Eq)
 
 ///|
@@ -95,7 +94,6 @@ fn canvas_document_from_state(state : CanvasState) -> CanvasDocument {
     nodes: state.nodes.copy(),
     edges: state.edges.copy(),
     next_node_id: state.next_node_id,
-    next_edge_id: state.next_edge_id,
   }
 }
 
@@ -111,7 +109,6 @@ fn canvas_state_from_parts(
     nodes: document.nodes.copy(),
     edges: document.edges.copy(),
     next_node_id: document.next_node_id,
-    next_edge_id: document.next_edge_id,
     interaction: interaction_with_selection(
       interaction,
       selection_from_interaction(interaction),

--- a/examples/canvas/main/canvas_update.mbt
+++ b/examples/canvas/main/canvas_update.mbt
@@ -180,7 +180,7 @@ fn workflow_add_node(
   world_y : Double,
 ) -> CanvasState {
   let node = make_workflow_node(
-    NodeId(state.next_node_id),
+    NodeId(state.next_node_id.to_string()),
     workflow_node_kind_from_key(kind_key),
     world_x,
     world_y,
@@ -331,19 +331,19 @@ fn selection_after_click(
 }
 
 ///|
-/// Handle pointer release. `node_id_int` is the canvas node id under the pointer,
-/// or 0 if released over the background.
+/// Handle pointer release. `node_id` is the canvas node id under the pointer,
+/// or "" if released over the background.
 /// A "click" = pointer_down was true AND no movement occurred → select the node.
 fn update_pointer_up(
   state : CanvasState,
-  node_id_int : Int,
+  node_id : String,
   target_port_id : String,
   additive : Bool,
 ) -> CanvasState {
-  let hovered : NodeId? = if node_id_int <= 0 {
+  let hovered : NodeId? = if node_id == "" {
     None
   } else {
-    Some(NodeId(node_id_int))
+    Some(NodeId(node_id))
   }
   // If a connection gesture is in flight, commit/cancel it and exit.
   match state.interaction.connecting {

--- a/examples/canvas/main/canvas_update_wbtest.mbt
+++ b/examples/canvas/main/canvas_update_wbtest.mbt
@@ -3,13 +3,12 @@ fn make_test_state() -> CanvasState {
   {
     viewport: { x: 0.0, y: 0.0, scale: 1.0 },
     nodes: [
-      make_workflow_node(NodeId(1), TimerTrigger, 100.0, 100.0),
-      make_workflow_node(NodeId(2), HttpRequest, 420.0, 100.0),
-      make_workflow_node(NodeId(3), DataFormatter, 760.0, 100.0),
+      make_workflow_node(NodeId("1"), TimerTrigger, 100.0, 100.0),
+      make_workflow_node(NodeId("2"), HttpRequest, 420.0, 100.0),
+      make_workflow_node(NodeId("3"), DataFormatter, 760.0, 100.0),
     ],
     edges: [],
     next_node_id: 4,
-    next_edge_id: 1,
     interaction: @graph_model.empty_interaction(),
     action_log: [],
   }
@@ -99,9 +98,9 @@ test "zoom keeps cursor world position fixed" {
 ///|
 test "node_drag_start records offsets for the dragged node" {
   let state = make_test_state()
-  let s = update_node_drag_start(state, NodeId(1), 110.0, 120.0)
+  let s = update_node_drag_start(state, NodeId("1"), 110.0, 120.0)
   guard s.interaction.dragging is Some(d)
-  assert_eq(d.node_id, NodeId(1))
+  assert_eq(d.node_id, NodeId("1"))
   assert_eq(d.origins.length(), 1)
   inspect(d.origins[0].offset_x, content="-10")
   inspect(d.origins[0].offset_y, content="-20")
@@ -113,9 +112,9 @@ test "node_drag_start records offsets for the dragged node" {
 test "node_drag_start includes all selected nodes for multi-drag" {
   let state = @graph_model.apply_action(
     make_test_state(),
-    SelectNodes([NodeId(1), NodeId(2)]),
+    SelectNodes([NodeId("1"), NodeId("2")]),
   )
-  let s = update_node_drag_start(state, NodeId(1), 110.0, 120.0)
+  let s = update_node_drag_start(state, NodeId("1"), 110.0, 120.0)
   guard s.interaction.dragging is Some(d)
   assert_eq(d.origins.length(), 2)
 }
@@ -123,14 +122,14 @@ test "node_drag_start includes all selected nodes for multi-drag" {
 ///|
 test "node_drag_start is no-op for unknown node id" {
   let state = make_test_state()
-  let s = update_node_drag_start(state, NodeId(99), 0.0, 0.0)
+  let s = update_node_drag_start(state, NodeId("99"), 0.0, 0.0)
   assert_true(s.interaction.dragging is None)
 }
 
 ///|
 test "pointer_up records a MoveNodes action after drag" {
   let state = make_test_state()
-  let s0 = update_node_drag_start(state, NodeId(1), 110.0, 120.0)
+  let s0 = update_node_drag_start(state, NodeId("1"), 110.0, 120.0)
   let preview = drag_preview_from_move(
     match s0.interaction.dragging {
       Some(drag) => drag
@@ -150,7 +149,7 @@ test "pointer_up records a MoveNodes action after drag" {
     nodes: moved_nodes,
     interaction: { ..s0.interaction, did_move: true },
   }
-  let s2 = update_pointer_up(s1, 1, "", false)
+  let s2 = update_pointer_up(s1, "1", "", false)
   assert_eq(s2.action_log.length(), 1)
   match s2.action_log[0].action() {
     WorkflowAction::MoveNodes(positions) => {
@@ -165,34 +164,34 @@ test "pointer_up records a MoveNodes action after drag" {
 ///|
 test "pointer_up on node without movement selects it" {
   let state = make_test_state()
-  let s0 = update_node_drag_start(state, NodeId(1), 100.0, 100.0)
-  let s1 = update_pointer_up(s0, 1, "", false)
-  @debug.debug_inspect(s1.interaction.selected, content="Some(NodeId(1))")
-  @debug.assert_eq(s1.interaction.selected_nodes, [NodeId(1)])
+  let s0 = update_node_drag_start(state, NodeId("1"), 100.0, 100.0)
+  let s1 = update_pointer_up(s0, "1", "", false)
+  @debug.debug_inspect(s1.interaction.selected, content="Some(NodeId(\"1\"))")
+  @debug.assert_eq(s1.interaction.selected_nodes, [NodeId("1")])
 }
 
 ///|
 test "additive click toggles multi-selection" {
   let state = @graph_model.apply_action(
     make_test_state(),
-    SelectNodes([NodeId(1)]),
+    SelectNodes([NodeId("1")]),
   )
-  let s0 = update_node_drag_start(state, NodeId(2), 420.0, 100.0)
-  let s1 = update_pointer_up(s0, 2, "", true)
-  @debug.assert_eq(s1.interaction.selected_nodes, [NodeId(1), NodeId(2)])
-  let s2 = update_node_drag_start(s1, NodeId(1), 100.0, 100.0)
-  let s3 = update_pointer_up(s2, 1, "", true)
-  @debug.assert_eq(s3.interaction.selected_nodes, [NodeId(2)])
+  let s0 = update_node_drag_start(state, NodeId("2"), 420.0, 100.0)
+  let s1 = update_pointer_up(s0, "2", "", true)
+  @debug.assert_eq(s1.interaction.selected_nodes, [NodeId("1"), NodeId("2")])
+  let s2 = update_node_drag_start(s1, NodeId("1"), 100.0, 100.0)
+  let s3 = update_pointer_up(s2, "1", "", true)
+  @debug.assert_eq(s3.interaction.selected_nodes, [NodeId("2")])
 }
 
 ///|
 test "pointer_up on background deselects" {
   let state = @graph_model.apply_action(
     make_test_state(),
-    SelectNodes([NodeId(1)]),
+    SelectNodes([NodeId("1")]),
   )
   let s0 = update_pan_start(state, 0.0, 0.0)
-  let s1 = update_pointer_up(s0, 0, "", false)
+  let s1 = update_pointer_up(s0, "", "", false)
   inspect(s1.interaction.selected is None, content="true")
   assert_eq(s1.interaction.selected_nodes.length(), 0)
 }
@@ -200,9 +199,9 @@ test "pointer_up on background deselects" {
 ///|
 test "connect_start records source node, source port, and cursor world position" {
   let state = make_test_state()
-  let s = update_connect_start(state, NodeId(1), "tick", 250.0, 80.0)
+  let s = update_connect_start(state, NodeId("1"), "tick", 250.0, 80.0)
   guard s.interaction.connecting is Some(c)
-  assert_eq(c.from_node, NodeId(1))
+  assert_eq(c.from_node, NodeId("1"))
   inspect(c.from_port, content="tick")
   inspect(c.cursor_x, content="250")
   inspect(c.cursor_y, content="80")
@@ -212,7 +211,7 @@ test "connect_start records source node, source port, and cursor world position"
 ///|
 test "connect_move updates cursor world position" {
   let state = make_test_state()
-  let s0 = update_connect_start(state, NodeId(1), "tick", 0.0, 0.0)
+  let s0 = update_connect_start(state, NodeId("1"), "tick", 0.0, 0.0)
   let s1 = update_connect_move(s0, 333.0, 444.0)
   guard s1.interaction.connecting is Some(c)
   inspect(c.cursor_x, content="333")
@@ -223,12 +222,12 @@ test "connect_move updates cursor world position" {
 ///|
 test "connect_end commits compatible typed ports" {
   let state = make_test_state()
-  let s0 = update_connect_start(state, NodeId(1), "tick", 0.0, 0.0)
-  let s1 = update_connect_end(s0, Some(NodeId(2)), Some("in"))
+  let s0 = update_connect_start(state, NodeId("1"), "tick", 0.0, 0.0)
+  let s1 = update_connect_end(s0, Some(NodeId("2")), Some("in"))
   assert_eq(s1.edges.length(), 1)
-  assert_eq(s1.edges[0].source, NodeId(1))
+  assert_eq(s1.edges[0].source, NodeId("1"))
   assert_eq(s1.edges[0].source_port, "tick")
-  assert_eq(s1.edges[0].target, NodeId(2))
+  assert_eq(s1.edges[0].target, NodeId("2"))
   assert_eq(s1.edges[0].target_port, "in")
   assert_true(s1.interaction.connecting is None)
   assert_eq(s1.action_log.length(), 1)
@@ -237,11 +236,11 @@ test "connect_end commits compatible typed ports" {
 ///|
 test "connect_end uses the explicit target port" {
   let nodes = make_test_state().nodes.copy()
-  nodes.push(make_workflow_node(NodeId(4), Custom("Any source"), 0.0, 0.0))
-  nodes.push(make_workflow_node(NodeId(5), ConditionalBranch, 0.0, 0.0))
+  nodes.push(make_workflow_node(NodeId("4"), Custom("Any source"), 0.0, 0.0))
+  nodes.push(make_workflow_node(NodeId("5"), ConditionalBranch, 0.0, 0.0))
   let state : CanvasState = { ..make_test_state(), nodes, }
-  let s0 = update_connect_start(state, NodeId(4), "out", 0.0, 0.0)
-  let s1 = update_connect_end(s0, Some(NodeId(5)), Some("rule"))
+  let s0 = update_connect_start(state, NodeId("4"), "out", 0.0, 0.0)
+  let s1 = update_connect_end(s0, Some(NodeId("5")), Some("rule"))
   assert_eq(s1.edges.length(), 1)
   assert_eq(s1.edges[0].source_port, "out")
   assert_eq(s1.edges[0].target_port, "rule")
@@ -250,8 +249,8 @@ test "connect_end uses the explicit target port" {
 ///|
 test "connect_end rejects incompatible ports" {
   let state = make_test_state()
-  let s0 = update_connect_start(state, NodeId(1), "tick", 0.0, 0.0)
-  let s1 = update_connect_end(s0, Some(NodeId(3)), Some("json"))
+  let s0 = update_connect_start(state, NodeId("1"), "tick", 0.0, 0.0)
+  let s1 = update_connect_end(s0, Some(NodeId("3")), Some("json"))
   assert_eq(s1.edges.length(), 0)
   assert_true(s1.interaction.connecting is None)
   // Rejected attempts are still logged for audit/collaboration streams.
@@ -262,8 +261,8 @@ test "connect_end rejects incompatible ports" {
 test "connect_end does not create self-loops or duplicates" {
   let state = make_test_state()
   let self_loop = update_connect_end(
-    update_connect_start(state, NodeId(2), "json", 0.0, 0.0),
-    Some(NodeId(2)),
+    update_connect_start(state, NodeId("2"), "json", 0.0, 0.0),
+    Some(NodeId("2")),
     Some("in"),
   )
   assert_eq(self_loop.edges.length(), 0)
@@ -272,18 +271,17 @@ test "connect_end does not create self-loops or duplicates" {
     ..make_test_state(),
     edges: [
       {
-        id: EdgeId(1),
-        source: NodeId(1),
+        id: EdgeId::from_edge(NodeId("1"), "tick", NodeId("2"), "in"),
+        source: NodeId("1"),
         source_port: "tick",
-        target: NodeId(2),
+        target: NodeId("2"),
         target_port: "in",
       },
     ],
-    next_edge_id: 2,
   }
   let duplicate = update_connect_end(
-    update_connect_start(with_edge, NodeId(1), "tick", 0.0, 0.0),
-    Some(NodeId(2)),
+    update_connect_start(with_edge, NodeId("1"), "tick", 0.0, 0.0),
+    Some(NodeId("2")),
     Some("in"),
   )
   assert_eq(duplicate.edges.length(), 1)
@@ -298,7 +296,7 @@ test "workflow_add_node creates typed custom nodes through serializable action" 
   assert_eq(s.action_log.length(), 1)
   inspect(s.nodes[3].title, content="Custom step")
   match s.action_log[0].action() {
-    WorkflowAction::AddNode(node) => assert_eq(node.id, NodeId(4))
+    WorkflowAction::AddNode(node) => assert_eq(node.id, NodeId("4"))
     _ => fail("expected AddNode action")
   }
 }
@@ -306,34 +304,35 @@ test "workflow_add_node creates typed custom nodes through serializable action" 
 ///|
 test "validate_workflow reports missing typed input ports independently" {
   let nodes = make_test_state().nodes.copy()
-  nodes.push(make_workflow_node(NodeId(4), ConditionalBranch, 0.0, 0.0))
+  nodes.push(make_workflow_node(NodeId("4"), ConditionalBranch, 0.0, 0.0))
   let state : CanvasState = {
     ..make_test_state(),
     nodes,
     edges: [
       {
-        id: EdgeId(1),
-        source: NodeId(3),
+        id: EdgeId::from_edge(NodeId("3"), "text", NodeId("4"), "text"),
+        source: NodeId("3"),
         source_port: "text",
-        target: NodeId(4),
+        target: NodeId("4"),
         target_port: "text",
       },
     ],
-    next_edge_id: 2,
   }
   let messages = validate_workflow(state)
   assert_true(
     messages
     .iter()
     .any(fn(message) {
-      message.node_id == Some(4) && message.message.contains("input “rule”")
+      message.node_id == Some("4") &&
+      message.message.contains("input \u{201c}rule\u{201d}")
     }),
   )
   assert_false(
     messages
     .iter()
     .any(fn(message) {
-      message.node_id == Some(4) && message.message.contains("input “text”")
+      message.node_id == Some("4") &&
+      message.message.contains("input \u{201c}text\u{201d}")
     }),
   )
 }
@@ -353,7 +352,7 @@ test "runtime live drag updates preview before one durable MoveNodes commit" {
   let runtime = CanvasRuntime::CanvasRuntime()
   runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
   let before = runtime.document.peek()
-  runtime.pointer_down(Some(NodeId(1)), -510.0, -180.0)
+  runtime.pointer_down(Some(NodeId("1")), -510.0, -180.0)
   runtime.pointer_move(-400.0, -100.0)
 
   let during = runtime.document.peek()
@@ -366,7 +365,7 @@ test "runtime live drag updates preview before one durable MoveNodes commit" {
   inspect(preview.y, content="-110")
   assert_eq(before.nodes[0].x, during.nodes[0].x)
 
-  runtime.pointer_up(1, "", false)
+  runtime.pointer_up("1", "", false)
   let after = runtime.document.peek()
   inspect(after.nodes[0].x, content="-410")
   inspect(after.nodes[0].y, content="-110")
@@ -384,13 +383,13 @@ test "runtime live drag updates preview before one durable MoveNodes commit" {
 ///|
 test "runtime delete_nodes removes selected nodes and incident edges" {
   let runtime = CanvasRuntime::CanvasRuntime()
-  runtime.delete_nodes([NodeId(2)])
+  runtime.delete_nodes([NodeId("2")])
   let state = runtime.render_state()
   assert_eq(state.nodes.length(), 5)
   assert_eq(state.edges.length(), 1)
   assert_eq(runtime.actions.peek().length(), 1)
   match runtime.actions.peek()[0].action() {
-    DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId(2)])
+    DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId("2")])
     _ => fail("expected DeleteNodes action")
   }
 }
@@ -399,7 +398,7 @@ test "runtime delete_nodes removes selected nodes and incident edges" {
 test "runtime sparse inspector follows hover until a node is selected" {
   let runtime = CanvasRuntime::CanvasRuntime()
   runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
-  runtime.hover_node(1)
+  runtime.hover_node("1")
   match runtime.render_state().inspector {
     Some(node) => {
       inspect(node.source, content="hovered")
@@ -408,9 +407,9 @@ test "runtime sparse inspector follows hover until a node is selected" {
     None => fail("expected hovered inspector")
   }
 
-  runtime.pointer_down(Some(NodeId(2)), -190.0, -190.0)
-  runtime.pointer_up(2, "", false)
-  runtime.hover_node(1)
+  runtime.pointer_down(Some(NodeId("2")), -190.0, -190.0)
+  runtime.pointer_up("2", "", false)
+  runtime.hover_node("1")
   match runtime.render_state().inspector {
     Some(node) => {
       inspect(node.source, content="selected")

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -58,7 +58,6 @@ fn empty_source_canvas_state() -> CanvasState {
     nodes: [],
     edges: [],
     next_node_id: 1,
-    next_edge_id: 1,
     interaction: @graph_model.empty_interaction(),
     action_log: [],
   }
@@ -79,12 +78,10 @@ fn canvas_id_for_binding(
   doc : @graph_dsl.GraphDoc,
   binding : String,
 ) -> NodeId? {
-  for i, node in doc.nodes() {
-    if node.binding() == binding {
-      return Some(NodeId(i + 1))
-    }
+  match doc.find_node(binding) {
+    Some(node) => Some(NodeId(node.id()))
+    None => None
   }
-  None
 }
 
 ///|
@@ -92,14 +89,7 @@ fn graph_node_for_canvas_id(
   doc : @graph_dsl.GraphDoc,
   id : NodeId,
 ) -> @graph_dsl.GraphNode? {
-  let NodeId(raw_id) = id
-  let index = raw_id - 1
-  let nodes = doc.nodes()
-  if index < 0 || index >= nodes.length() {
-    None
-  } else {
-    Some(nodes[index])
-  }
+  doc.find_node_by_id(id.to_string())
 }
 
 ///|
@@ -155,11 +145,11 @@ fn graph_param_json(param : @graph_dsl.GraphParam) -> NodeParamJson {
 
 ///|
 fn source_node_to_json(
-  doc : @graph_dsl.GraphDoc,
+  node_index : Map[String, @graph_dsl.GraphNode],
   node : CanvasNode,
 ) -> NodeJson {
   let base = node_to_json(node)
-  match graph_node_for_canvas_id(doc, node.id) {
+  match node_index.get(node.id.to_string()) {
     Some(graph_node) =>
       { ..base, params: graph_node.params().map(graph_param_json) }
     None => base
@@ -172,7 +162,7 @@ fn canvas_node_from_graph_node(
   graph_node : @graph_dsl.GraphNode,
 ) -> CanvasNode {
   {
-    id: NodeId(index + 1),
+    id: NodeId(graph_node.id()),
     x: index.to_double() * 300.0,
     y: 0.0,
     w: 250.0,
@@ -229,7 +219,8 @@ fn canvas_from_graph_doc(doc : @graph_dsl.GraphDoc) -> CanvasState {
     nodes.push(canvas_node_from_graph_node(i, graph_node))
   }
   let edges : Array[Edge] = []
-  for target_index, graph_node in doc.nodes() {
+  for graph_node in doc.nodes() {
+    let target = NodeId(graph_node.id())
     for param in graph_node.params() {
       match graph_input_reference(param) {
         None => ()
@@ -238,10 +229,10 @@ fn canvas_from_graph_doc(doc : @graph_dsl.GraphDoc) -> CanvasState {
             None => ()
             Some(source) =>
               edges.push({
-                id: EdgeId(edges.length() + 1),
+                id: EdgeId::from_edge(source, "out", target, param.name()),
                 source,
                 source_port: "out",
-                target: NodeId(target_index + 1),
+                target,
                 target_port: param.name(),
               })
           }
@@ -253,7 +244,6 @@ fn canvas_from_graph_doc(doc : @graph_dsl.GraphDoc) -> CanvasState {
     nodes,
     edges,
     next_node_id: nodes.length() + 1,
-    next_edge_id: edges.length() + 1,
     interaction: @graph_model.empty_interaction(),
     action_log: [],
   }
@@ -547,10 +537,6 @@ fn SourceBackedGraph::apply_codemirror_changes(
   changes : Array[@codemirror.ChangeDelta],
   expected_doc : String,
 ) -> SourceGraphOperationResultJson {
-  let selection_bindings = match source_graph_doc_for_render(self) {
-    Some(doc) => source_selected_node_bindings(doc, self.interaction)
-    None => []
-  }
   for edit, new_source in Iter2(changes_to_edits(self.source, changes).iter()) {
     self.attachment.apply_edit(edit, new_source)
     self.source = new_source
@@ -567,7 +553,9 @@ fn SourceBackedGraph::apply_codemirror_changes(
   }
   match source_graph_current_doc(self) {
     Ok(doc) => {
-      self.remap_selection_to_bindings(doc, selection_bindings)
+      // Identity is the tracker token, stable across delta reparse — selection
+      // survives with no remap; only drop tokens that no longer exist.
+      self.prune_selection_to_doc(doc)
       source_graph_result_json_for_graph(self, true, None)
     }
     Err(message) =>
@@ -621,49 +609,20 @@ fn SourceBackedGraph::append_operation(
 }
 
 ///|
-fn source_selected_node_bindings(
-  doc : @graph_dsl.GraphDoc,
-  interaction : InteractionState,
-  deleted? : Array[NodeId] = [],
-) -> Array[String] {
-  let bindings : Array[String] = []
-  for node_id in interaction.selected_nodes {
-    if !deleted.iter().any(fn(deleted_id) { deleted_id == node_id }) {
-      match graph_node_for_canvas_id(doc, node_id) {
-        Some(node) => append_unique_string(bindings, node.binding())
-        None => ()
-      }
-    }
-  }
-  bindings
-}
-
-///|
-fn source_selection_from_bindings(
-  doc : @graph_dsl.GraphDoc,
-  bindings : Array[String],
-) -> Array[NodeId] {
-  let nodes : Array[NodeId] = []
-  for binding in bindings {
-    match canvas_id_for_binding(doc, binding) {
-      Some(id) => nodes.push(id)
-      None => ()
-    }
-  }
-  nodes
-}
-
-///|
-fn SourceBackedGraph::remap_selection_to_bindings(
+/// Drop any selected node whose tracker token no longer exists in `doc`, and
+/// reset in-flight gesture state. Identity is the token (`NodeId`), stable
+/// across delta reparse, so survivors keep their selection with no remapping;
+/// deleted or atomically-churned tokens fall out naturally.
+fn SourceBackedGraph::prune_selection_to_doc(
   self : SourceBackedGraph,
   doc : @graph_dsl.GraphDoc,
-  bindings : Array[String],
 ) -> Unit {
-  let selected_nodes = source_selection_from_bindings(doc, bindings)
-  let selected = if selected_nodes.length() == 0 {
-    None
-  } else {
-    Some(selected_nodes[0])
+  let selected_nodes = self.interaction.selected_nodes.filter(fn(id) {
+    doc.find_node_by_id(id.to_string()) is Some(_)
+  })
+  let selected = match selected_nodes {
+    [head, ..] => Some(head)
+    [] => None
   }
   self.drag_preview = idle_drag_preview()
   self.interaction = {
@@ -675,6 +634,29 @@ fn SourceBackedGraph::remap_selection_to_bindings(
     pointer_down: false,
     did_move: false,
   }
+}
+
+///|
+/// Rewrite one node's selection token after a rename (the token embeds the
+/// binding, so renaming changes it). This is a rename-local continuation, not
+/// binding-recovery: only the renamed node's `old` token maps to `new`.
+fn SourceBackedGraph::rename_selection_token(
+  self : SourceBackedGraph,
+  old : NodeId,
+  new : NodeId,
+) -> Unit {
+  let selected_nodes = self.interaction.selected_nodes.map(fn(id) {
+    if id == old {
+      new
+    } else {
+      id
+    }
+  })
+  let selected = match self.interaction.selected {
+    Some(id) if id == old => Some(new)
+    other => other
+  }
+  self.interaction = { ..self.interaction, selected, selected_nodes }
 }
 
 ///|
@@ -698,16 +680,24 @@ fn SourceBackedGraph::sync_local_operation_state(
   old_doc : @graph_dsl.GraphDoc,
   new_doc : @graph_dsl.GraphDoc,
   operation : GraphOperation,
-  survivor_selection_bindings : Array[String],
 ) -> Unit {
   match operation.action() {
     DeleteNodes(_) => {
-      self.remap_selection_to_bindings(new_doc, survivor_selection_bindings)
+      self.prune_selection_to_doc(new_doc)
       self.sync_layout_from_state(source_graph_base_canvas_state(self))
     }
     RenameNode(node_id, new_binding) =>
       match graph_node_for_canvas_id(old_doc, node_id) {
-        Some(node) => self.rename_layout_binding(node.binding(), new_binding)
+        Some(node) => {
+          self.rename_layout_binding(node.binding(), new_binding)
+          // The token embeds the binding, so the renamed node's id changes;
+          // carry any live selection of it forward to the new token.
+          match new_doc.find_node(new_binding) {
+            Some(renamed) =>
+              self.rename_selection_token(node_id, NodeId(renamed.id()))
+            None => ()
+          }
+        }
         None => ()
       }
     _ => ()
@@ -729,11 +719,15 @@ fn SourceBackedGraph::sync_layout_from_state(
 ///|
 fn SourceBackedGraph::pointer_down(
   self : SourceBackedGraph,
-  node_id : Int,
+  node_id : String,
   sx : Double,
   sy : Double,
 ) -> Unit {
-  let target : NodeId? = if node_id <= 0 { None } else { Some(NodeId(node_id)) }
+  let target : NodeId? = if node_id == "" {
+    None
+  } else {
+    Some(NodeId(node_id))
+  }
   let state = update_pointer_down(
     source_graph_base_canvas_state(self),
     target,
@@ -783,7 +777,7 @@ fn SourceBackedGraph::pointer_move(
 ///|
 fn SourceBackedGraph::pointer_up(
   self : SourceBackedGraph,
-  node_id : Int,
+  node_id : String,
   target_port_id : String,
   additive : Bool,
 ) -> Unit {
@@ -819,7 +813,7 @@ fn source_graph_node_payload(
   constructor_name : String,
 ) -> CanvasNode {
   {
-    id: NodeId(0),
+    id: NodeId(""),
     x: 0.0,
     y: 0.0,
     w: 250.0,
@@ -900,9 +894,35 @@ fn source_graph_insert_unique_result(
 fn source_graph_connect_sample_result(
   handle : Int,
 ) -> SourceGraphOperationResultJson {
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None =>
+      return source_graph_operation_result_json(
+        false,
+        "",
+        ["source graph handle not found"],
+        0,
+        Some("source graph handle not found"),
+      )
+  }
+  let doc = match source_graph_current_doc(graph) {
+    Ok(doc) => doc
+    Err(message) =>
+      return source_graph_result_json_for_graph(graph, false, Some(message))
+  }
+  let nodes = doc.nodes()
+  guard nodes.length() >= 2 else {
+    return source_graph_result_json_for_graph(
+      graph,
+      false,
+      Some("sample connect needs at least two nodes"),
+    )
+  }
+  let source = NodeId(nodes[0].id())
+  let target = NodeId(nodes[1].id())
   let result_json = apply_source_graph_operation(
     handle,
-    GraphOperation(ConnectPorts(NodeId(1), "out", NodeId(2), "input"))
+    GraphOperation(ConnectPorts(source, "out", target, "input"))
     .to_json()
     .stringify(),
   )
@@ -986,15 +1006,13 @@ fn set_source_graph_source_checked(
         Some("source graph handle not found"),
       )
   }
-  let selection_bindings = match source_graph_doc_for_render(graph) {
-    Some(doc) => source_selected_node_bindings(doc, graph.interaction)
-    None => []
-  }
   graph.source = source
   graph.attachment.set_source(source)
   match source_graph_current_doc(graph) {
     Ok(doc) => {
-      graph.remap_selection_to_bindings(doc, selection_bindings)
+      // Reset/init path: tokens survive content-preserving edits but a reorder
+      // churns them (residual limitation), so prune by token existence.
+      graph.prune_selection_to_doc(doc)
       source_graph_result_json_for_graph(graph, true, None)
     }
     Err(message) =>
@@ -1015,7 +1033,7 @@ pub fn set_source_graph_source_result(handle : Int, source : String) -> String {
 ///|
 pub fn source_graph_pointer_down(
   handle : Int,
-  node_id : Int,
+  node_id : String,
   sx : Double,
   sy : Double,
 ) -> Unit {
@@ -1040,7 +1058,7 @@ pub fn source_graph_pointer_move(
 ///|
 pub fn source_graph_pointer_up(
   handle : Int,
-  node_id : Int,
+  node_id : String,
   target_port_id : String,
   additive : Bool,
 ) -> Unit {
@@ -1071,13 +1089,22 @@ fn source_render_state_string(
 ) -> String {
   let rendered = render_state_json(state, validation)
   match source_graph_doc_for_render(graph) {
-    Some(doc) =>
+    Some(doc) => {
+      // Index the doc's nodes by token once so per-node param resolution is
+      // O(1); resolving each canvas node back through find_node_by_id would be
+      // O(n) per node, i.e. O(n²) over the render.
+      let node_index : Map[String, @graph_dsl.GraphNode] = Map::from_array(
+        doc.nodes().map(fn(graph_node) { (graph_node.id(), graph_node) }),
+      )
       {
         ..rendered,
-        nodes: state.nodes.map(fn(node) { source_node_to_json(doc, node) }),
+        nodes: state.nodes.map(fn(node) {
+          source_node_to_json(node_index, node)
+        }),
       }
       .to_json()
       .stringify()
+    }
     None => rendered.to_json().stringify()
   }
 }
@@ -1134,11 +1161,6 @@ pub fn apply_source_graph_operation(
     Err(message) =>
       return source_graph_result_for_graph(graph, false, Some(message))
   }
-  let survivor_selection_bindings = match operation.action() {
-    DeleteNodes(deleted) =>
-      source_selected_node_bindings(doc, graph.interaction, deleted~)
-    _ => []
-  }
   let lowered = match lower_source_operation(doc, operation) {
     Ok(edit) => edit
     Err(message) =>
@@ -1146,9 +1168,7 @@ pub fn apply_source_graph_operation(
   }
   match graph.apply_source_edit(lowered) {
     Ok(new_doc) => {
-      graph.sync_local_operation_state(
-        doc, new_doc, operation, survivor_selection_bindings,
-      )
+      graph.sync_local_operation_state(doc, new_doc, operation)
       graph.append_operation(realized_source_operation(new_doc, operation))
       source_graph_result_for_graph(graph, true, None)
     }

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -73,7 +73,7 @@ fn operation_result_message(json_text : String) -> String? {
 }
 
 ///|
-fn render_selected_nodes(json_text : String) -> Array[Int] {
+fn render_selected_nodes(json_text : String) -> Array[String] {
   let json = @json.parse(json_text) catch {
     _ => abort("expected render state JSON")
   }
@@ -88,6 +88,27 @@ fn render_selected_nodes(json_text : String) -> Array[Int] {
       }
     _ => abort("expected render state object")
   }
+}
+
+///|
+/// Current graph doc behind a registered handle.
+fn handle_doc(handle : Int) -> @graph_dsl.GraphDoc {
+  match source_graph_by_handle(handle) {
+    Some(graph) => ok_current_graph_doc(graph.attachment.current_result())
+    None => abort("expected source graph handle")
+  }
+}
+
+///|
+/// Tracker token (`NodeId`) for a binding behind a handle. Tokens are not
+/// positionally predictable, so tests fetch them rather than hard-code them.
+fn handle_token(handle : Int, binding : String) -> NodeId {
+  required_canvas_id_for_binding(handle_doc(handle), binding)
+}
+
+///|
+fn handle_token_str(handle : Int, binding : String) -> String {
+  handle_token(handle, binding).to_string()
 }
 
 ///|
@@ -221,7 +242,12 @@ test "ConnectPorts and AddNode lower through source and reparse to canvas graph"
 test "source-backed handle lowers GraphOperation through graph-dsl source" {
   let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
   let connect = GraphOperation(
-    ConnectPorts(NodeId(1), "out", NodeId(2), "input"),
+    ConnectPorts(
+      handle_token(handle, "osc"),
+      "out",
+      handle_token(handle, "meter"),
+      "input",
+    ),
   )
   inspect(
     operation_result_applied(
@@ -233,8 +259,10 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
     get_source_graph_source(handle),
     content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)",
   )
+  // The lowering keys off title/subtitle; the payload id is a placeholder that
+  // `realized_source_operation` replaces with the new node's tracker token.
   let added : CanvasNode = {
-    id: NodeId(3),
+    id: NodeId(""),
     x: 0.0,
     y: 0.0,
     w: 250.0,
@@ -257,11 +285,12 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
     get_source_graph_source(handle),
     content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()",
   )
+  let reverb_token = handle_token(handle, "reverb")
   let operations = ok_operation_log(get_source_graph_action_log(handle))
   match operations {
     [_, added] =>
       match added.action() {
-        AddNode(node) => @debug.assert_eq(node.id, NodeId(3))
+        AddNode(node) => @debug.assert_eq(node.id, reverb_token)
         _ => abort("expected AddNode action")
       }
     _ => abort("expected two source-backed operations")
@@ -273,7 +302,8 @@ test "source-backed handle lowers GraphOperation through graph-dsl source" {
 test "source-backed RenameNode updates binding and references" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)"
   let handle = create_source_graph(source)
-  let rename = GraphOperation(RenameNode(NodeId(1), "lfo"))
+  let osc_token = handle_token(handle, "osc")
+  let rename = GraphOperation(RenameNode(osc_token, "lfo"))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, rename.to_json().stringify()),
@@ -289,7 +319,7 @@ test "source-backed RenameNode updates binding and references" {
     [renamed] =>
       match renamed.action() {
         RenameNode(node_id, name) => {
-          @debug.assert_eq(node_id, NodeId(1))
+          @debug.assert_eq(node_id, osc_token)
           inspect(name, content="lfo")
         }
         _ => abort("expected RenameNode action")
@@ -307,7 +337,7 @@ test "source-backed RenameNode preserves layout keyed by binding" {
     Some(graph) => graph.layout = [{ binding: "osc", x: 42.0, y: 24.0 }]
     None => abort("expected source graph handle")
   }
-  let rename = GraphOperation(RenameNode(NodeId(1), "lfo"))
+  let rename = GraphOperation(RenameNode(handle_token(handle, "osc"), "lfo"))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, rename.to_json().stringify()),
@@ -330,10 +360,39 @@ test "source-backed RenameNode preserves layout keyed by binding" {
 }
 
 ///|
+test "source-backed RenameNode carries selection to the new token" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  let osc = handle_token_str(handle, "osc")
+  source_graph_pointer_down(handle, osc, 0.0, 0.0)
+  source_graph_pointer_up(handle, osc, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [osc],
+  )
+  let rename = GraphOperation(RenameNode(handle_token(handle, "osc"), "lfo"))
+  inspect(
+    operation_result_applied(
+      apply_source_graph_operation(handle, rename.to_json().stringify()),
+    ),
+    content="true",
+  )
+  // Renaming changes the token (it embeds the binding); the rename-local hook
+  // carries the live selection forward to lfo's new token rather than dropping it.
+  let lfo = handle_token_str(handle, "lfo")
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [lfo],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
 test "source-backed SetNodeParam edits a numeric parameter token" {
   let source = "osc = sine(freq: 440Hz, wave: \"saw\")\nmeter = scope()"
   let handle = create_source_graph(source)
-  let set_param = GraphOperation(SetNodeParam(NodeId(1), "freq", "880"))
+  let osc_token = handle_token(handle, "osc")
+  let set_param = GraphOperation(SetNodeParam(osc_token, "freq", "880"))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, set_param.to_json().stringify()),
@@ -349,7 +408,7 @@ test "source-backed SetNodeParam edits a numeric parameter token" {
     [edited] =>
       match edited.action() {
         SetNodeParam(node_id, parameter, value) => {
-          @debug.assert_eq(node_id, NodeId(1))
+          @debug.assert_eq(node_id, osc_token)
           inspect(parameter, content="freq")
           inspect(value, content="880")
         }
@@ -364,7 +423,9 @@ test "source-backed SetNodeParam edits a numeric parameter token" {
 test "source-backed SetNodeParam rejects non-numeric source text" {
   let source = "osc = sine(freq: 440Hz)"
   let handle = create_source_graph(source)
-  let set_param = GraphOperation(SetNodeParam(NodeId(1), "freq", "880Hz"))
+  let set_param = GraphOperation(
+    SetNodeParam(handle_token(handle, "osc"), "freq", "880Hz"),
+  )
   let result = apply_source_graph_operation(
     handle,
     set_param.to_json().stringify(),
@@ -379,7 +440,8 @@ test "source-backed SetNodeParam rejects non-numeric source text" {
 test "source-backed DeleteNodes removes a safe binding line" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()"
   let handle = create_source_graph(source)
-  let delete = GraphOperation(DeleteNodes([NodeId(2)]))
+  let meter_token = handle_token(handle, "meter")
+  let delete = GraphOperation(DeleteNodes([meter_token]))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, delete.to_json().stringify()),
@@ -394,7 +456,7 @@ test "source-backed DeleteNodes removes a safe binding line" {
   match operations {
     [deleted] =>
       match deleted.action() {
-        DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId(2)])
+        DeleteNodes(nodes) => @debug.assert_eq(nodes, [meter_token])
         _ => abort("expected DeleteNodes action")
       }
     _ => abort("expected one source-backed delete operation")
@@ -406,7 +468,7 @@ test "source-backed DeleteNodes removes a safe binding line" {
 test "source-backed DeleteNodes rejects survivor references" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)"
   let handle = create_source_graph(source)
-  let delete = GraphOperation(DeleteNodes([NodeId(1)]))
+  let delete = GraphOperation(DeleteNodes([handle_token(handle, "osc")]))
   let result = apply_source_graph_operation(
     handle,
     delete.to_json().stringify(),
@@ -426,7 +488,9 @@ test "source-backed DeleteNodes rejects survivor references" {
 test "source-backed DeleteNodes allows deleting a referenced subgraph together" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc)"
   let handle = create_source_graph(source)
-  let delete = GraphOperation(DeleteNodes([NodeId(1), NodeId(2)]))
+  let delete = GraphOperation(
+    DeleteNodes([handle_token(handle, "osc"), handle_token(handle, "meter")]),
+  )
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, delete.to_json().stringify()),
@@ -441,19 +505,21 @@ test "source-backed DeleteNodes allows deleting a referenced subgraph together" 
 test "source-backed DeleteNodes clears transient selection after rewrite" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 2, 0.0, 0.0)
-  source_graph_pointer_up(handle, 2, "", false)
+  let meter = handle_token_str(handle, "meter")
+  source_graph_pointer_down(handle, meter, 0.0, 0.0)
+  source_graph_pointer_up(handle, meter, "", false)
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [2],
+    [meter],
   )
-  let delete = GraphOperation(DeleteNodes([NodeId(2)]))
+  let delete = GraphOperation(DeleteNodes([handle_token(handle, "meter")]))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, delete.to_json().stringify()),
     ),
     content="true",
   )
+  // Deleted node's token no longer resolves, so prune drops it.
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
     [],
@@ -462,16 +528,17 @@ test "source-backed DeleteNodes clears transient selection after rewrite" {
 }
 
 ///|
-test "source-backed DeleteNodes remaps selected survivor by binding" {
+test "source-backed DeleteNodes preserves selected survivor by stable token" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 3, 0.0, 0.0)
-  source_graph_pointer_up(handle, 3, "", false)
+  let reverb = handle_token_str(handle, "reverb")
+  source_graph_pointer_down(handle, reverb, 0.0, 0.0)
+  source_graph_pointer_up(handle, reverb, "", false)
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [3],
+    [reverb],
   )
-  let delete = GraphOperation(DeleteNodes([NodeId(2)]))
+  let delete = GraphOperation(DeleteNodes([handle_token(handle, "meter")]))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, delete.to_json().stringify()),
@@ -482,27 +549,73 @@ test "source-backed DeleteNodes remaps selected survivor by binding" {
     get_source_graph_source(handle),
     content="osc = sine(freq: 440Hz)\nreverb = plate()",
   )
+  // The tracker keeps reverb's token across the delete, so selection survives
+  // with no binding remap — the deleted node simply drops out.
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [2],
+    [reverb],
   )
   destroy_source_graph(handle)
 }
 
 ///|
-test "source-backed source reorder preserves selection by binding" {
+test "source-backed set_source reorder churns identity and clears selection" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 2, 0.0, 0.0)
-  source_graph_pointer_up(handle, 2, "", false)
+  let meter = handle_token_str(handle, "meter")
+  source_graph_pointer_down(handle, meter, 0.0, 0.0)
+  source_graph_pointer_up(handle, meter, "", false)
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [2],
+    [meter],
   )
+  // Whole-source set_source is the reset-only path; an atomic reorder churns
+  // tracker tokens (residual limitation), so the selected token no longer
+  // resolves and is pruned. User-facing reorders go through editor deltas,
+  // which preserve identity (next test).
   set_source_graph_source(handle, "meter = scope()\nosc = sine(freq: 440Hz)")
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [1],
+    [],
+  )
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed editor-delta reorder preserves selection by token" {
+  let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
+  let handle = create_source_graph(source)
+  let graph = match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None => abort("expected source graph handle")
+  }
+  let meter = handle_token_str(handle, "meter")
+  source_graph_pointer_down(handle, meter, 0.0, 0.0)
+  source_graph_pointer_up(handle, meter, "", false)
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [meter],
+  )
+  // Reorder as the editor would: delete the first line, then re-insert it after
+  // the second. CodeMirror reports both ranges in pre-transaction coordinates;
+  // applied as ordered deltas, the tracker realigns identity, so `meter`'s token
+  // is unchanged and its selection survives.
+  let first_line = "osc = sine(freq: 440Hz)\n"
+  let reordered = "meter = scope()\nosc = sine(freq: 440Hz)"
+  let _ = graph.apply_codemirror_changes(
+    [
+      @codemirror.ChangeDelta::new(0, first_line.length(), ""),
+      @codemirror.ChangeDelta::new(
+        source.length(),
+        source.length(),
+        "\nosc = sine(freq: 440Hz)",
+      ),
+    ],
+    reordered,
+  )
+  @debug.assert_eq(
+    render_selected_nodes(get_source_graph_render_state(handle)),
+    [meter],
   )
   destroy_source_graph(handle)
 }
@@ -511,11 +624,12 @@ test "source-backed source reorder preserves selection by binding" {
 test "source-backed source edit clears selection when binding is removed" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 2, 0.0, 0.0)
-  source_graph_pointer_up(handle, 2, "", false)
+  let meter = handle_token_str(handle, "meter")
+  source_graph_pointer_down(handle, meter, 0.0, 0.0)
+  source_graph_pointer_up(handle, meter, "", false)
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [2],
+    [meter],
   )
   set_source_graph_source(handle, "osc = sine(freq: 440Hz)")
   @debug.assert_eq(
@@ -527,17 +641,18 @@ test "source-backed source edit clears selection when binding is removed" {
 
 ///|
 /// Guards the invalid-source branch of `set_source_graph_source_checked`:
-/// selection must NOT be remapped when reparse fails, because render falls
-/// back to the last-good doc whose order still matches the stored numeric ids.
+/// selection must NOT be pruned when reparse fails, because render falls back
+/// to the last-good doc whose tokens still resolve the stored selection.
 test "source-backed source edit keeps selection while source is invalid" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 2, 0.0, 0.0)
-  source_graph_pointer_up(handle, 2, "", false)
+  let meter = handle_token_str(handle, "meter")
+  source_graph_pointer_down(handle, meter, 0.0, 0.0)
+  source_graph_pointer_up(handle, meter, "", false)
   set_source_graph_source(handle, "osc = sine(freq: )")
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [2],
+    [meter],
   )
   destroy_source_graph(handle)
 }
@@ -546,16 +661,19 @@ test "source-backed source edit keeps selection while source is invalid" {
 test "source-backed source edit preserves index-0 survivor when later binding removed" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 1, 0.0, 0.0)
-  source_graph_pointer_up(handle, 1, "", false)
+  let osc = handle_token_str(handle, "osc")
+  source_graph_pointer_down(handle, osc, 0.0, 0.0)
+  source_graph_pointer_up(handle, osc, "", false)
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [1],
+    [osc],
   )
+  // Removing a later binding is content-preserving for the survivor, so osc's
+  // token is unchanged and its selection persists.
   set_source_graph_source(handle, "osc = sine(freq: 440Hz)")
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [1],
+    [osc],
   )
   destroy_source_graph(handle)
 }
@@ -564,11 +682,12 @@ test "source-backed source edit preserves index-0 survivor when later binding re
 test "source-backed source reorder that drops the selected node clears selection" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()"
   let handle = create_source_graph(source)
-  source_graph_pointer_down(handle, 2, 0.0, 0.0)
-  source_graph_pointer_up(handle, 2, "", false)
+  let meter = handle_token_str(handle, "meter")
+  source_graph_pointer_down(handle, meter, 0.0, 0.0)
+  source_graph_pointer_up(handle, meter, "", false)
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [2],
+    [meter],
   )
   // Reorder the survivors and drop the selected binding (meter) in one edit.
   set_source_graph_source(handle, "reverb = plate()\nosc = sine(freq: 440Hz)")
@@ -580,30 +699,32 @@ test "source-backed source reorder that drops the selected node clears selection
 }
 
 ///|
-test "source-backed source reorder preserves multi-selection order by binding" {
+test "source-backed set_source reorder churns multi-selection (residual)" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()\nreverb = plate()"
   let handle = create_source_graph(source)
+  let osc = handle_token(handle, "osc")
+  let reverb = handle_token(handle, "reverb")
   match source_graph_by_handle(handle) {
     Some(graph) =>
-      // Select osc (1) then reverb (3); capture order follows selected_nodes.
       graph.interaction = {
         dragging: None,
         panning: None,
         connecting: None,
-        selected: Some(NodeId(1)),
-        selected_nodes: [NodeId(1), NodeId(3)],
+        selected: Some(osc),
+        selected_nodes: [osc, reverb],
         pointer_down: false,
         did_move: false,
       }
     None => abort("expected source graph handle")
   }
+  // Atomic set_source reorder churns both selected tokens; prune drops them.
+  // (Editor-delta reorders, the user-facing path, preserve identity.)
   set_source_graph_source(
     handle, "reverb = plate()\nmeter = scope()\nosc = sine(freq: 440Hz)",
   )
-  // reverb=1, osc=3 now; selection keeps capture order [osc, reverb] -> [3, 1].
   @debug.assert_eq(
     render_selected_nodes(get_source_graph_render_state(handle)),
-    [3, 1],
+    [],
   )
   destroy_source_graph(handle)
 }
@@ -612,8 +733,10 @@ test "source-backed source reorder preserves multi-selection order by binding" {
 test "source-backed DisconnectPorts removes only the target input reference" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc, gain: 2)\ntap = scope(input: osc)"
   let handle = create_source_graph(source)
+  let osc_token = handle_token(handle, "osc")
+  let meter_token = handle_token(handle, "meter")
   let disconnect = GraphOperation(
-    DisconnectPorts(NodeId(1), "out", NodeId(2), "input"),
+    DisconnectPorts(osc_token, "out", meter_token, "input"),
   )
   inspect(
     operation_result_applied(
@@ -630,9 +753,9 @@ test "source-backed DisconnectPorts removes only the target input reference" {
     [disconnected] =>
       match disconnected.action() {
         DisconnectPorts(source, source_port, target, target_port) => {
-          @debug.assert_eq(source, NodeId(1))
+          @debug.assert_eq(source, osc_token)
           inspect(source_port, content="out")
-          @debug.assert_eq(target, NodeId(2))
+          @debug.assert_eq(target, meter_token)
           inspect(target_port, content="input")
         }
         _ => abort("expected DisconnectPorts action")
@@ -647,7 +770,12 @@ test "source-backed DisconnectPorts removes a trailing input reference" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(gain: 2, input: osc)"
   let handle = create_source_graph(source)
   let disconnect = GraphOperation(
-    DisconnectPorts(NodeId(1), "out", NodeId(2), "input"),
+    DisconnectPorts(
+      handle_token(handle, "osc"),
+      "out",
+      handle_token(handle, "meter"),
+      "input",
+    ),
   )
   inspect(
     operation_result_applied(
@@ -667,7 +795,12 @@ test "source-backed DisconnectPorts consumes a valid trailing comma" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope(input: osc,)"
   let handle = create_source_graph(source)
   let disconnect = GraphOperation(
-    DisconnectPorts(NodeId(1), "out", NodeId(2), "input"),
+    DisconnectPorts(
+      handle_token(handle, "osc"),
+      "out",
+      handle_token(handle, "meter"),
+      "input",
+    ),
   )
   inspect(
     operation_result_applied(
@@ -695,13 +828,14 @@ test "source-backed unique insert chooses a fresh graph-dsl binding" {
     get_source_graph_source(handle),
     content="reverb = plate()\nreverb2 = plate()",
   )
+  let reverb2_token = handle_token(handle, "reverb2")
   let operations = ok_operation_log(get_source_graph_action_log(handle))
   match operations {
     [added] =>
       match added.action() {
         AddNode(node) => {
           inspect(node.title, content="reverb2")
-          @debug.assert_eq(node.id, NodeId(2))
+          @debug.assert_eq(node.id, reverb2_token)
         }
         _ => abort("expected AddNode action")
       }
@@ -759,10 +893,10 @@ test "source-backed handle reports invalid source apply status" {
 ///|
 test "source-backed handle rejects graph operations while source is invalid" {
   let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let osc = handle_token(handle, "osc")
+  let meter = handle_token(handle, "meter")
   set_source_graph_source(handle, "osc = sine(freq: )")
-  let connect = GraphOperation(
-    ConnectPorts(NodeId(1), "out", NodeId(2), "input"),
-  )
+  let connect = GraphOperation(ConnectPorts(osc, "out", meter, "input"))
   inspect(
     operation_result_applied(
       apply_source_graph_operation(handle, connect.to_json().stringify()),

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub fn delete_nodes(Int, String) -> Unit
 
 pub fn destroy_source_graph(Int) -> Unit
 
-pub fn disconnect_ports(Int, Int, String, Int, String) -> Unit
+pub fn disconnect_ports(Int, String, String, String, String) -> Unit
 
 pub fn get_action_log(Int) -> String
 
@@ -32,19 +32,19 @@ pub fn get_source_graph_render_state(Int) -> String
 
 pub fn get_source_graph_source(Int) -> String
 
-pub fn hover_node(Int, Int) -> Unit
+pub fn hover_node(Int, String) -> Unit
 
 pub fn mount_canvas_context_menu((String) -> Unit, () -> Unit) -> Unit
 
 pub fn mount_source_demo(Int, Bool, () -> Unit) -> Unit
 
-pub fn pointer_down(Int, Int, Double, Double) -> Unit
+pub fn pointer_down(Int, String, Double, Double) -> Unit
 
-pub fn pointer_down_handle(Int, Int, String, Double, Double) -> Unit
+pub fn pointer_down_handle(Int, String, String, Double, Double) -> Unit
 
 pub fn pointer_move(Int, Double, Double) -> Unit
 
-pub fn pointer_up(Int, Int, String, Bool) -> Unit
+pub fn pointer_up(Int, String, String, Bool) -> Unit
 
 pub fn sample_graph_dsl_source() -> String
 
@@ -54,11 +54,11 @@ pub fn set_source_graph_source_result(Int, String) -> String
 
 pub fn source_graph_insert_unique(Int, String, String) -> String
 
-pub fn source_graph_pointer_down(Int, Int, Double, Double) -> Unit
+pub fn source_graph_pointer_down(Int, String, Double, Double) -> Unit
 
 pub fn source_graph_pointer_move(Int, Double, Double) -> Unit
 
-pub fn source_graph_pointer_up(Int, Int, String, Bool) -> Unit
+pub fn source_graph_pointer_up(Int, String, String, Bool) -> Unit
 
 pub fn source_graph_zoom(Int, Double, Double, Double) -> Unit
 

--- a/examples/canvas/main/source_delete_lowering.mbt
+++ b/examples/canvas/main/source_delete_lowering.mbt
@@ -37,9 +37,7 @@ fn deleted_bindings_for_canvas_ids(
     match graph_node_for_canvas_id(doc, id) {
       Some(node) => append_unique_string(bindings, node.binding())
       None =>
-        return Err(
-          "cannot lower DeleteNodes: missing node " + id.to_int().to_string(),
-        )
+        return Err("cannot lower DeleteNodes: missing node " + id.to_string())
     }
   }
   if bindings.length() == 0 {

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -12,12 +12,31 @@ type Point = {
   y: number;
 };
 
-function inputHandle(page: Page, nodeId: number): Locator {
-  return page.locator(`.handle.input[data-node-id="${nodeId}"]`);
+// Source-backed nodes are identified by the Loom projection token
+// (`node#<n>:<binding>`), exposed in the DOM as `data-node-id`. Tests locate a
+// node by its user-facing binding (the `.node-title`) and resolve the token on
+// demand, so they neither hardcode the internal token format nor break when a
+// rename re-mints the token.
+function sourceNode(page: Page, binding: string): Locator {
+  return page
+    .locator('.canvas-node')
+    .filter({ has: page.locator('.node-title', { hasText: new RegExp(`^${binding}$`) }) });
 }
 
-function outputHandle(page: Page, nodeId: number): Locator {
-  return page.locator(`.handle.output[data-node-id="${nodeId}"]`);
+async function sourceNodeId(page: Page, binding: string): Promise<string> {
+  const id = await sourceNode(page, binding).getAttribute('data-node-id');
+  if (id === null) {
+    throw new Error(`no source-backed node bound as "${binding}"`);
+  }
+  return id;
+}
+
+async function inputHandle(page: Page, binding: string): Promise<Locator> {
+  return page.locator(`.handle.input[data-node-id="${await sourceNodeId(page, binding)}"]`);
+}
+
+async function outputHandle(page: Page, binding: string): Promise<Locator> {
+  return page.locator(`.handle.output[data-node-id="${await sourceNodeId(page, binding)}"]`);
 }
 
 function edgePaths(page: Page): Locator {
@@ -109,7 +128,7 @@ test('source-backed node drag updates local layout without mutating source', asy
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  const node = page.locator('.canvas-node[data-node-id="1"]');
+  const node = sourceNode(page, 'osc');
   const before = await center(node, 'source-backed node');
   await dragBy(page, node.locator('.node-title'), 82, 36);
   const after = await center(node, 'dragged source-backed node');
@@ -127,7 +146,7 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  await dragBetween(page, outputHandle(page, 1), inputHandle(page, 2));
+  await dragBetween(page, await outputHandle(page, 'osc'), await inputHandle(page, 'meter'));
   await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
   await page.mouse.up();
 
@@ -137,8 +156,8 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   expect(runtimeErrors).toEqual([]);
 });
 
-async function selectSourceNode(page: Page, nodeId: number): Promise<void> {
-  const node = page.locator(`.canvas-node[data-node-id="${nodeId}"]`);
+async function selectSourceNode(page: Page, binding: string): Promise<void> {
+  const node = sourceNode(page, binding);
   await node.click();
   await expect(node).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
 }
@@ -150,14 +169,17 @@ test('source-backed inspector rename lowers to canonical source and references',
   await page.locator('#source-connect').click();
   await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
 
-  await selectSourceNode(page, 1);
+  await selectSourceNode(page, 'osc');
   const renameInput = page.locator('#node-rename-input');
   await expect(renameInput).toHaveValue('osc');
   await renameInput.fill('lfo');
   await renameInput.press('Enter');
 
   await expectSource(page, 'lfo = sine(freq: 440Hz)\nmeter = scope(input: lfo)');
-  await expect(page.locator('.canvas-node[data-node-id="1"] .node-title')).toHaveText('lfo');
+  // The rename re-mints the node's token, so the old binding is gone and the new
+  // one is present — the node is now identified as `lfo`.
+  await expect(sourceNode(page, 'osc')).toHaveCount(0);
+  await expect(sourceNode(page, 'lfo')).toHaveCount(1);
   await expect(page.locator('#edges path.edge')).toHaveCount(1);
   await expect(page.locator('#source-status')).toHaveAttribute('data-tone', 'success');
   await expect(page.locator('#source-status')).toContainText(
@@ -173,7 +195,7 @@ test('source-backed inspector numeric parameter edit lowers to canonical source'
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  await selectSourceNode(page, 1);
+  await selectSourceNode(page, 'osc');
   const freqInput = page.locator('#node-param-freq');
   await expect(freqInput).toHaveValue('440');
   await freqInput.fill('880');
@@ -194,7 +216,7 @@ test('source-backed selected edge deletion lowers into canonical source', async 
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  await dragBetween(page, outputHandle(page, 1), inputHandle(page, 2));
+  await dragBetween(page, await outputHandle(page, 'osc'), await inputHandle(page, 'meter'));
   await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
   await page.mouse.up();
   await expect(edgePaths(page)).toHaveCount(1);
@@ -221,14 +243,14 @@ test('source-backed selected node deletion lowers into canonical source', async 
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  const meter = page.locator('.canvas-node[data-node-id="2"]');
+  const meter = sourceNode(page, 'meter');
   await meter.click();
   await expect(meter).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
   await page.keyboard.press('Delete');
 
   await expectSource(page, 'osc = sine(freq: 440Hz)');
   await expect(page.locator('.canvas-node')).toHaveCount(1);
-  await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveCount(0);
+  await expect(sourceNode(page, 'meter')).toHaveCount(0);
   await expect(page.locator('#action-stat')).toHaveText('2 actions logged');
   expect(runtimeErrors).toEqual([]);
 });
@@ -240,7 +262,7 @@ test('source-backed deletion rejects unsafe survivor references', async ({ page 
   await page.locator('#source-connect').click();
   await expectSource(page, 'osc = sine(freq: 440Hz)\nmeter = scope(input: osc)');
 
-  const osc = page.locator('.canvas-node[data-node-id="1"]');
+  const osc = sourceNode(page, 'osc');
   await osc.click();
   await expect(osc).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
   await page.keyboard.press('Delete');
@@ -263,10 +285,8 @@ test('source-backed deletion ignores source editor focus', async ({ page }) => {
   // bubbles to the document handler even from CodeMirror (CM6 does not
   // stopPropagation by default), so `editableKeyboardTarget` is the only thing
   // between this Backspace and `deleteSelectedNodes`.
-  await page.locator('.canvas-node[data-node-id="2"]').click();
-  await expect(page.locator('.canvas-node[data-node-id="2"]')).toHaveClass(
-    /(?:^|\s)selected(?:\s|$)/,
-  );
+  await sourceNode(page, 'meter').click();
+  await expect(sourceNode(page, 'meter')).toHaveClass(/(?:^|\s)selected(?:\s|$)/);
 
   // Put the cursor at the end of the document so Backspace is a real editor
   // edit (deleting the trailing `)`), not a no-op at offset 0.

--- a/examples/canvas/web/e2e/source-backed.spec.ts
+++ b/examples/canvas/web/e2e/source-backed.spec.ts
@@ -23,20 +23,12 @@ function sourceNode(page: Page, binding: string): Locator {
     .filter({ has: page.locator('.node-title', { hasText: new RegExp(`^${binding}$`) }) });
 }
 
-async function sourceNodeId(page: Page, binding: string): Promise<string> {
-  const id = await sourceNode(page, binding).getAttribute('data-node-id');
-  if (id === null) {
-    throw new Error(`no source-backed node bound as "${binding}"`);
-  }
-  return id;
+function inputHandle(page: Page, binding: string): Locator {
+  return sourceNode(page, binding).locator('.handle.input');
 }
 
-async function inputHandle(page: Page, binding: string): Promise<Locator> {
-  return page.locator(`.handle.input[data-node-id="${await sourceNodeId(page, binding)}"]`);
-}
-
-async function outputHandle(page: Page, binding: string): Promise<Locator> {
-  return page.locator(`.handle.output[data-node-id="${await sourceNodeId(page, binding)}"]`);
+function outputHandle(page: Page, binding: string): Locator {
+  return sourceNode(page, binding).locator('.handle.output');
 }
 
 function edgePaths(page: Page): Locator {
@@ -146,7 +138,7 @@ test('source-backed canvas gestures lower into canonical source', async ({ page 
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  await dragBetween(page, await outputHandle(page, 'osc'), await inputHandle(page, 'meter'));
+  await dragBetween(page, outputHandle(page, 'osc'), inputHandle(page, 'meter'));
   await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
   await page.mouse.up();
 
@@ -216,7 +208,7 @@ test('source-backed selected edge deletion lowers into canonical source', async 
   await page.goto('/?source=1');
   await expectSource(page, SAMPLE_SOURCE);
 
-  await dragBetween(page, await outputHandle(page, 'osc'), await inputHandle(page, 'meter'));
+  await dragBetween(page, outputHandle(page, 'osc'), inputHandle(page, 'meter'));
   await expect(page.locator('#edges path.edge-pending')).toHaveCount(1);
   await page.mouse.up();
   await expect(edgePaths(page)).toHaveCount(1);

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -1,9 +1,9 @@
 export type CanvasModule = {
   create_canvas: () => number;
-  pointer_down: (h: number, nodeId: number, sx: number, sy: number) => void;
+  pointer_down: (h: number, nodeId: string, sx: number, sy: number) => void;
   pointer_down_handle: (
     h: number,
-    nodeId: number,
+    nodeId: string,
     portId: string,
     sx: number,
     sy: number,
@@ -11,19 +11,19 @@ export type CanvasModule = {
   pointer_move: (h: number, sx: number, sy: number) => void;
   pointer_up: (
     h: number,
-    nodeId: number,
+    nodeId: string,
     targetPortId: string,
     additive: boolean,
   ) => void;
-  hover_node: (h: number, nodeId: number) => void;
+  hover_node: (h: number, nodeId: string) => void;
   zoom: (h: number, delta: number, cx: number, cy: number) => void;
   add_node: (h: number, kindKey: string, sx: number, sy: number) => void;
   delete_nodes: (h: number, nodeIdsJson: string) => void;
   disconnect_ports: (
     h: number,
-    source: number,
+    source: string,
     sourcePort: string,
-    target: number,
+    target: string,
     targetPort: string,
   ) => void;
   get_render_state: (h: number) => string;
@@ -41,11 +41,11 @@ export type CanvasModule = {
     bindingBase: string,
     constructorName: string,
   ) => string;
-  source_graph_pointer_down?: (h: number, nodeId: number, sx: number, sy: number) => void;
+  source_graph_pointer_down?: (h: number, nodeId: string, sx: number, sy: number) => void;
   source_graph_pointer_move?: (h: number, sx: number, sy: number) => void;
   source_graph_pointer_up?: (
     h: number,
-    nodeId: number,
+    nodeId: string,
     targetPortId: string,
     additive: boolean,
   ) => void;
@@ -69,11 +69,11 @@ type SourceCanvasModule = CanvasModule & {
     bindingBase: string,
     constructorName: string,
   ) => string;
-  source_graph_pointer_down: (h: number, nodeId: number, sx: number, sy: number) => void;
+  source_graph_pointer_down: (h: number, nodeId: string, sx: number, sy: number) => void;
   source_graph_pointer_move: (h: number, sx: number, sy: number) => void;
   source_graph_pointer_up: (
     h: number,
-    nodeId: number,
+    nodeId: string,
     targetPortId: string,
     additive: boolean,
   ) => void;
@@ -107,7 +107,7 @@ export type NodeParamData = {
   editable: boolean;
 };
 export type NodeData = {
-  id: number;
+  id: string;
   x: number;
   y: number;
   w: number;
@@ -121,14 +121,14 @@ export type NodeData = {
   params?: NodeParamData[];
 };
 export type EdgeData = {
-  id: number;
-  source: number;
+  id: string;
+  source: string;
   source_port: string;
-  target: number;
+  target: string;
   target_port: string;
 };
 export type Connecting = {
-  from: number;
+  from: string;
   from_port: string;
   cursor_x: number;
   cursor_y: number;
@@ -136,11 +136,11 @@ export type Connecting = {
 export type ValidationMessage = {
   severity: 'error' | 'warning';
   message: string;
-  node_id?: number;
+  node_id?: string;
 };
 export type ViewportData = { x: number; y: number; scale: number };
 export type InspectorNode = {
-  id: number;
+  id: string;
   title: string;
   subtitle: string;
   configured: boolean;
@@ -152,15 +152,15 @@ export type RenderState = {
   viewport: ViewportData;
   nodes: NodeData[];
   edges: EdgeData[];
-  selected?: number;
-  selected_nodes: number[];
+  selected?: string;
+  selected_nodes: string[];
   connecting?: Connecting;
   validation: ValidationMessage[];
   action_count: number;
   inspector?: InspectorNode;
 };
 
-export type NodePositionData = { node_id: number; x: number; y: number };
+export type NodePositionData = { node_id: string; x: number; y: number };
 
 export type GraphOperation =
   | { version: number; type: 'AddNode'; node: NodeData }
@@ -168,29 +168,29 @@ export type GraphOperation =
   | {
       version: number;
       type: 'ConnectPorts';
-      source: number;
+      source: string;
       source_port: string;
-      target: number;
+      target: string;
       target_port: string;
     }
   | {
       version: number;
       type: 'DisconnectPorts';
-      source: number;
+      source: string;
       source_port: string;
-      target: number;
+      target: string;
       target_port: string;
     }
-  | { version: number; type: 'DeleteNodes'; nodes: number[] }
-  | { version: number; type: 'RenameNode'; node_id: number; name: string }
+  | { version: number; type: 'DeleteNodes'; nodes: string[] }
+  | { version: number; type: 'RenameNode'; node_id: string; name: string }
   | {
       version: number;
       type: 'SetNodeParam';
-      node_id: number;
+      node_id: string;
       parameter: string;
       value: string;
     }
-  | { version: number; type: 'SelectNodes'; nodes: number[] }
+  | { version: number; type: 'SelectNodes'; nodes: string[] }
   | { version: number; type: 'SetViewport'; viewport: ViewportData };
 
 export type GraphOperationCallback = (operation: GraphOperation) => void;
@@ -215,7 +215,7 @@ function requireSourceModule(mb: CanvasModule): SourceCanvasModule {
 
 function sourceNodePayload(binding: string, constructorName: string): NodeData {
   return {
-    id: 0,
+    id: '',
     x: 0,
     y: 0,
     w: 250,
@@ -336,8 +336,8 @@ export class GraphAdapter {
   }
 
   connectPorts(
-    sourceNodeId: number,
-    targetNodeId: number,
+    sourceNodeId: string,
+    targetNodeId: string,
     targetPortId = 'input',
   ): SourceGraphOperationResult {
     return this.applyOperation({
@@ -350,9 +350,9 @@ export class GraphAdapter {
     });
   }
 
-  deleteNodes(nodeIds: number[]): SourceGraphOperationResult | null {
+  deleteNodes(nodeIds: string[]): SourceGraphOperationResult | null {
     this.assertLive();
-    const uniqueNodeIds = [...new Set(nodeIds)].filter((id) => Number.isFinite(id));
+    const uniqueNodeIds = [...new Set(nodeIds)].filter((id) => id.length > 0);
     if (uniqueNodeIds.length === 0) return null;
     const operation: GraphOperation = {
       version: 1,
@@ -367,10 +367,10 @@ export class GraphAdapter {
     return null;
   }
 
-  renameNode(nodeId: number, name: string): SourceGraphOperationResult | null {
+  renameNode(nodeId: string, name: string): SourceGraphOperationResult | null {
     this.assertLive();
     const nextName = name.trim();
-    if (!this.isSourceBacked || !Number.isInteger(nodeId) || nodeId <= 0 || nextName.length === 0) {
+    if (!this.isSourceBacked || nodeId.length === 0 || nextName.length === 0) {
       return null;
     }
     return this.applyOperation({
@@ -382,7 +382,7 @@ export class GraphAdapter {
   }
 
   setNodeParam(
-    nodeId: number,
+    nodeId: string,
     parameter: string,
     value: string,
   ): SourceGraphOperationResult | null {
@@ -391,8 +391,7 @@ export class GraphAdapter {
     const nextValue = value.trim();
     if (
       !this.isSourceBacked ||
-      !Number.isInteger(nodeId) ||
-      nodeId <= 0 ||
+      nodeId.length === 0 ||
       nextParameter.length === 0 ||
       nextValue.length === 0
     ) {
@@ -408,15 +407,15 @@ export class GraphAdapter {
   }
 
   disconnectPorts(
-    sourceNodeId: number,
+    sourceNodeId: string,
     sourcePortId: string,
-    targetNodeId: number,
+    targetNodeId: string,
     targetPortId: string,
   ): SourceGraphOperationResult | null {
     this.assertLive();
     if (
-      !Number.isFinite(sourceNodeId) ||
-      !Number.isFinite(targetNodeId) ||
+      sourceNodeId.length === 0 ||
+      targetNodeId.length === 0 ||
       sourcePortId.length === 0 ||
       targetPortId.length === 0
     ) {
@@ -444,7 +443,7 @@ export class GraphAdapter {
     return null;
   }
 
-  pointerDown(nodeId: number, sx: number, sy: number): void {
+  pointerDown(nodeId: string, sx: number, sy: number): void {
     this.assertLive();
     if (this.isSourceBacked) {
       this.sourceModule().source_graph_pointer_down(this.handle, nodeId, sx, sy);
@@ -454,7 +453,7 @@ export class GraphAdapter {
   }
 
   pointerDownHandle(
-    nodeId: number,
+    nodeId: string,
     portId: string,
     sx: number,
     sy: number,
@@ -472,7 +471,7 @@ export class GraphAdapter {
     }
   }
 
-  pointerUp(nodeId: number, targetPortId: string, additive: boolean): void {
+  pointerUp(nodeId: string, targetPortId: string, additive: boolean): void {
     this.assertLive();
     if (this.isSourceBacked) {
       this.sourceModule().source_graph_pointer_up(
@@ -487,7 +486,7 @@ export class GraphAdapter {
     this.emitLatestOperations();
   }
 
-  hoverNode(nodeId: number): void {
+  hoverNode(nodeId: string): void {
     this.assertCanvasBacked('hoverNode');
     this.mb.hover_node(this.handle, nodeId);
   }

--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -316,7 +316,7 @@ export class GraphAdapter {
 
   insertNode(binding: string, constructorName: string): SourceGraphOperationResult {
     return this.applyOperation({
-      version: 1,
+      version: 2,
       type: 'AddNode',
       node: sourceNodePayload(binding, constructorName),
     });
@@ -341,7 +341,7 @@ export class GraphAdapter {
     targetPortId = 'input',
   ): SourceGraphOperationResult {
     return this.applyOperation({
-      version: 1,
+      version: 2,
       type: 'ConnectPorts',
       source: sourceNodeId,
       source_port: 'out',
@@ -355,7 +355,7 @@ export class GraphAdapter {
     const uniqueNodeIds = [...new Set(nodeIds)].filter((id) => id.length > 0);
     if (uniqueNodeIds.length === 0) return null;
     const operation: GraphOperation = {
-      version: 1,
+      version: 2,
       type: 'DeleteNodes',
       nodes: uniqueNodeIds,
     };
@@ -374,7 +374,7 @@ export class GraphAdapter {
       return null;
     }
     return this.applyOperation({
-      version: 1,
+      version: 2,
       type: 'RenameNode',
       node_id: nodeId,
       name: nextName,
@@ -398,7 +398,7 @@ export class GraphAdapter {
       return null;
     }
     return this.applyOperation({
-      version: 1,
+      version: 2,
       type: 'SetNodeParam',
       node_id: nodeId,
       parameter: nextParameter,
@@ -422,7 +422,7 @@ export class GraphAdapter {
       return null;
     }
     const operation: GraphOperation = {
-      version: 1,
+      version: 2,
       type: 'DisconnectPorts',
       source: sourceNodeId,
       source_port: sourcePortId,

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -67,8 +67,8 @@ const validation = document.getElementById('validation-list') as HTMLDivElement;
 const inspectorNode = document.getElementById('inspector-node') as HTMLDivElement;
 const actionStat = document.getElementById('action-stat') as HTMLSpanElement;
 const contextMenu = document.getElementById('context-menu') as HTMLDivElement;
-const nodeDivs = new Map<number, HTMLDivElement>();
-const edgePaths = new Map<number, SVGPathElement>();
+const nodeDivs = new Map<string, HTMLDivElement>();
+const edgePaths = new Map<string, SVGPathElement>();
 let pendingPath: SVGPathElement | null = null;
 let contextPoint: [number, number] = [0, 0];
 let contextEdge: EdgeData | null = null;
@@ -155,7 +155,7 @@ function clearSelectedEdge(): void {
 
 /** Context for the in-flight connection, resolved once per render. */
 type ConnectCtx = {
-  fromNode: number;
+  fromNode: string;
   fromPort: string;
   sourceType: string | null;
   edges: EdgeData[];
@@ -170,7 +170,7 @@ function portTypesCompatible(source: string, target: string): boolean {
  * Whether dragging from the active source onto this input handle would be
  * accepted, mirroring `can_commit_edge` (self-loop, duplicate edge, type check).
  */
-function inputHandleCompatible(ctx: ConnectCtx, targetNode: number, targetPort: PortDef): boolean {
+function inputHandleCompatible(ctx: ConnectCtx, targetNode: string, targetPort: PortDef): boolean {
   if (ctx.sourceType == null) return false;
   if (ctx.fromNode === targetNode) return false; // self-loop
   const duplicate = ctx.edges.some(
@@ -232,11 +232,11 @@ function render(): void {
   edgesSvg.style.transform = transform;
 
   // Nodes ────────────────────────────────────────────────────────────────────
-  const nodesById = new Map<number, NodeData>();
-  const seenNodes = new Set<number>();
+  const nodesById = new Map<string, NodeData>();
+  const seenNodes = new Set<string>();
   const selected = new Set(state.selected_nodes ?? []);
   const invalidNodeIds = new Set(
-    state.validation.filter((msg) => msg.node_id != null).map((msg) => msg.node_id as number),
+    state.validation.filter((msg) => msg.node_id != null).map((msg) => msg.node_id as string),
   );
 
   // Resolve the in-flight connection's source port type once, so each input
@@ -312,7 +312,7 @@ function render(): void {
   }
 
   // Edges ────────────────────────────────────────────────────────────────────
-  const seenEdges = new Set<number>();
+  const seenEdges = new Set<string>();
   for (const edge of state.edges) {
     const src = nodesById.get(edge.source);
     const dst = nodesById.get(edge.target);
@@ -377,13 +377,13 @@ function renderValidation(state: RenderState): void {
     item.type = 'button';
     item.textContent = message.message;
     if (message.node_id != null) {
-      item.addEventListener('click', () => focusNode(message.node_id as number));
+      item.addEventListener('click', () => focusNode(message.node_id as string));
     }
     validation.appendChild(item);
   }
 }
 
-function commitSourceRename(nodeId: number, currentName: string, nextName: string): void {
+function commitSourceRename(nodeId: string, currentName: string, nextName: string): void {
   const trimmed = nextName.trim();
   if (trimmed === currentName || trimmed.length === 0) return;
   const result = adapter.renameNode(nodeId, trimmed);
@@ -398,7 +398,7 @@ function commitSourceRename(nodeId: number, currentName: string, nextName: strin
 }
 
 function commitSourceParam(
-  nodeId: number,
+  nodeId: string,
   param: NodeParamData,
   nextValue: string,
 ): void {
@@ -567,7 +567,7 @@ function renderInspector(state: RenderState): void {
   inspectorNode.replaceChildren(...children);
 }
 
-function focusNode(nodeId: number): void {
+function focusNode(nodeId: string): void {
   const node = nodeDivs.get(nodeId);
   if (!node) return;
   node.animate([
@@ -580,16 +580,16 @@ function focusNode(nodeId: number): void {
 
 type HitTarget =
   | { kind: 'background' }
-  | { kind: 'node'; nodeId: number }
+  | { kind: 'node'; nodeId: string }
   | { kind: 'edge'; edge: EdgeData }
-  | { kind: 'handle'; nodeId: number; side: 'input' | 'output'; portId: string };
+  | { kind: 'handle'; nodeId: string; side: 'input' | 'output'; portId: string };
 
 function hitFromTarget(target: EventTarget | null): HitTarget {
   let el = target instanceof Element ? target : null;
   while (el && el !== root) {
     const element = el as HTMLElement | SVGElement;
     if (element.dataset?.edgeId) {
-      const edgeId = parseInt(element.dataset.edgeId);
+      const edgeId = element.dataset.edgeId;
       const state = lastState ?? adapter.renderState();
       const edge = state.edges.find((candidate) => candidate.id === edgeId);
       if (edge) return { kind: 'edge', edge };
@@ -597,13 +597,13 @@ function hitFromTarget(target: EventTarget | null): HitTarget {
     if (element.dataset?.handle && element.dataset?.nodeId && element.dataset?.portId) {
       return {
         kind: 'handle',
-        nodeId: parseInt(element.dataset.nodeId),
+        nodeId: element.dataset.nodeId,
         side: element.dataset.handle as 'input' | 'output',
         portId: element.dataset.portId,
       };
     }
     if (element.dataset?.nodeId && element.classList.contains('canvas-node')) {
-      return { kind: 'node', nodeId: parseInt(element.dataset.nodeId) };
+      return { kind: 'node', nodeId: element.dataset.nodeId };
     }
     el = el.parentElement;
   }
@@ -623,8 +623,8 @@ function addNodeAt(kindKey: string, point: [number, number]): void {
   scheduleRender();
 }
 
-function hoverNodeId(hit: HitTarget): number {
-  return hit.kind === 'node' || hit.kind === 'handle' ? hit.nodeId : 0;
+function hoverNodeId(hit: HitTarget): string {
+  return hit.kind === 'node' || hit.kind === 'handle' ? hit.nodeId : '';
 }
 
 function updateHover(hit: HitTarget): void {
@@ -809,7 +809,7 @@ function handleContextMenuSelect(key: string): void {
 // ─── Event wiring ─────────────────────────────────────────────────────────────
 
 let activePointerId = -1;
-let pointerDownNodeId = 0;
+let pointerDownNodeId = '';
 let pointerUpAdditive = false;
 
 root.addEventListener('pointerdown', (e: PointerEvent) => {
@@ -833,7 +833,7 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
     activePointerId = e.pointerId;
     pointerUpAdditive = e.shiftKey || e.metaKey || e.ctrlKey;
     const [sx, sy] = localCoords(e);
-    pointerDownNodeId = hit.kind === 'node' ? hit.nodeId : 0;
+    pointerDownNodeId = hit.kind === 'node' ? hit.nodeId : '';
     adapter.pointerDown(pointerDownNodeId, sx, sy);
     if (hit.kind === 'background') root.classList.add('panning');
     scheduleRender();
@@ -862,10 +862,10 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
       // Only output handles initiate a connection in the prototype.
       if (hit.side === 'output') {
         adapter.pointerDownHandle(hit.nodeId, hit.portId, sx, sy);
-        pointerDownNodeId = 0; // pointerup uses hover target, not down target
+        pointerDownNodeId = ''; // pointerup uses hover target, not down target
       } else {
         // Input handle clicks are inert for now; do not start background pan.
-        pointerDownNodeId = 0;
+        pointerDownNodeId = '';
       }
       break;
     case 'node':
@@ -873,8 +873,8 @@ root.addEventListener('pointerdown', (e: PointerEvent) => {
       adapter.pointerDown(hit.nodeId, sx, sy);
       break;
     case 'background':
-      pointerDownNodeId = 0;
-      adapter.pointerDown(0, sx, sy);
+      pointerDownNodeId = '';
+      adapter.pointerDown('', sx, sy);
       root.classList.add('panning');
       break;
   }
@@ -927,7 +927,7 @@ root.addEventListener('pointerup', (e: PointerEvent) => {
       pointerDownNodeId;
     adapter.pointerUp(upNodeId, '', pointerUpAdditive);
     activePointerId = -1;
-    pointerDownNodeId = 0;
+    pointerDownNodeId = '';
     pointerUpAdditive = false;
     root.classList.remove('panning');
     scheduleRender();
@@ -945,7 +945,7 @@ root.addEventListener('pointerup', (e: PointerEvent) => {
   const targetPortId = hit.kind === 'handle' && hit.side === 'input' ? hit.portId : '';
   adapter.pointerUp(upNodeId, targetPortId, pointerUpAdditive);
   activePointerId = -1;
-  pointerDownNodeId = 0;
+  pointerDownNodeId = '';
   pointerUpAdditive = false;
   root.classList.remove('panning');
   scheduleRender();
@@ -958,18 +958,18 @@ root.addEventListener('pointercancel', (e: PointerEvent) => {
       return;
     }
     if (e.pointerId !== activePointerId) return;
-    adapter.pointerUp(0, '', false);
+    adapter.pointerUp('', '', false);
     activePointerId = -1;
-    pointerDownNodeId = 0;
+    pointerDownNodeId = '';
     pointerUpAdditive = false;
     root.classList.remove('panning');
     scheduleRender();
     return;
   }
   if (e.pointerId !== activePointerId) return;
-  adapter.pointerUp(0, '', false);
+  adapter.pointerUp('', '', false);
   activePointerId = -1;
-  pointerDownNodeId = 0;
+  pointerDownNodeId = '';
   pointerUpAdditive = false;
   root.classList.remove('panning');
   scheduleRender();

--- a/lib/canvas-graph/graph_model/graph_operation_test.mbt
+++ b/lib/canvas-graph/graph_model/graph_operation_test.mbt
@@ -1,6 +1,6 @@
 ///|
 fn node_id(n : Int) -> @graph_model.NodeId {
-  @graph_model.NodeId::from_int(n)
+  @graph_model.NodeId(n.to_string())
 }
 
 ///|
@@ -23,7 +23,6 @@ fn replay_base_state() -> @graph_model.CanvasState {
     ],
     edges: [],
     next_node_id: 3,
-    next_edge_id: 1,
     interaction: @graph_model.empty_interaction(),
     action_log: [],
   }
@@ -41,7 +40,7 @@ test "GraphOperation serializes as a versioned JSON operation" {
   )
   inspect(
     operation.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"ConnectPorts\",\"source\":1,\"source_port\":\"tick\",\"target\":2,\"target_port\":\"in\"}",
+    content="{\"version\":1,\"type\":\"ConnectPorts\",\"source\":\"1\",\"source_port\":\"tick\",\"target\":\"2\",\"target_port\":\"in\"}",
   )
 }
 
@@ -65,7 +64,7 @@ test "DeleteNodes serializes node ids" {
   )
   inspect(
     operation.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"DeleteNodes\",\"nodes\":[1,2]}",
+    content="{\"version\":1,\"type\":\"DeleteNodes\",\"nodes\":[\"1\",\"2\"]}",
   )
   let decoded : @graph_model.GraphOperation = @json.from_json(
     operation.to_json(),
@@ -85,7 +84,7 @@ test "DisconnectPorts serializes endpoint ports" {
   )
   inspect(
     operation.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"DisconnectPorts\",\"source\":1,\"source_port\":\"tick\",\"target\":2,\"target_port\":\"in\"}",
+    content="{\"version\":1,\"type\":\"DisconnectPorts\",\"source\":\"1\",\"source_port\":\"tick\",\"target\":\"2\",\"target_port\":\"in\"}",
   )
   let decoded : @graph_model.GraphOperation = @json.from_json(
     operation.to_json(),
@@ -100,14 +99,14 @@ test "source-backed edit actions serialize node and parameter payloads" {
   )
   inspect(
     rename.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"RenameNode\",\"node_id\":1,\"name\":\"oscillator\"}",
+    content="{\"version\":1,\"type\":\"RenameNode\",\"node_id\":\"1\",\"name\":\"oscillator\"}",
   )
   let set_param = @graph_model.GraphOperation::GraphOperation(
     @graph_model.WorkflowAction::SetNodeParam(node_id(1), "freq", "880"),
   )
   inspect(
     set_param.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"SetNodeParam\",\"node_id\":1,\"parameter\":\"freq\",\"value\":\"880\"}",
+    content="{\"version\":1,\"type\":\"SetNodeParam\",\"node_id\":\"1\",\"parameter\":\"freq\",\"value\":\"880\"}",
   )
   let decoded : Array[@graph_model.GraphOperation] = @json.from_json(
     [rename.to_json(), set_param.to_json()].to_json(),
@@ -189,7 +188,10 @@ test "DeleteNodes removes incident edges and deleted selection" {
   assert_eq(deleted.nodes.length(), 1)
   assert_eq(deleted.edges.length(), 0)
   @debug.assert_eq(deleted.interaction.selected_nodes, [node_id(2)])
-  @debug.debug_inspect(deleted.interaction.selected, content="Some(NodeId(2))")
+  @debug.debug_inspect(
+    deleted.interaction.selected,
+    content="Some(NodeId(\"2\"))",
+  )
 }
 
 ///|
@@ -208,14 +210,18 @@ test "DisconnectPorts removes only the matching edge" {
     edges: [
       ..connected_once.edges,
       {
-        id: @graph_model.EdgeId::from_int(2),
+        id: @graph_model.EdgeId::from_edge(
+          node_id(2),
+          "json",
+          node_id(1),
+          "tick",
+        ),
         source: node_id(2),
         source_port: "json",
         target: node_id(1),
         target_port: "tick",
       },
     ],
-    next_edge_id: 3,
   }
   let disconnected = @graph_model.record_action(
     with_unrelated,

--- a/lib/canvas-graph/graph_model/graph_operation_test.mbt
+++ b/lib/canvas-graph/graph_model/graph_operation_test.mbt
@@ -40,7 +40,7 @@ test "GraphOperation serializes as a versioned JSON operation" {
   )
   inspect(
     operation.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"ConnectPorts\",\"source\":\"1\",\"source_port\":\"tick\",\"target\":\"2\",\"target_port\":\"in\"}",
+    content="{\"version\":2,\"type\":\"ConnectPorts\",\"source\":\"1\",\"source_port\":\"tick\",\"target\":\"2\",\"target_port\":\"in\"}",
   )
 }
 
@@ -64,7 +64,7 @@ test "DeleteNodes serializes node ids" {
   )
   inspect(
     operation.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"DeleteNodes\",\"nodes\":[\"1\",\"2\"]}",
+    content="{\"version\":2,\"type\":\"DeleteNodes\",\"nodes\":[\"1\",\"2\"]}",
   )
   let decoded : @graph_model.GraphOperation = @json.from_json(
     operation.to_json(),
@@ -84,7 +84,7 @@ test "DisconnectPorts serializes endpoint ports" {
   )
   inspect(
     operation.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"DisconnectPorts\",\"source\":\"1\",\"source_port\":\"tick\",\"target\":\"2\",\"target_port\":\"in\"}",
+    content="{\"version\":2,\"type\":\"DisconnectPorts\",\"source\":\"1\",\"source_port\":\"tick\",\"target\":\"2\",\"target_port\":\"in\"}",
   )
   let decoded : @graph_model.GraphOperation = @json.from_json(
     operation.to_json(),
@@ -99,14 +99,14 @@ test "source-backed edit actions serialize node and parameter payloads" {
   )
   inspect(
     rename.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"RenameNode\",\"node_id\":\"1\",\"name\":\"oscillator\"}",
+    content="{\"version\":2,\"type\":\"RenameNode\",\"node_id\":\"1\",\"name\":\"oscillator\"}",
   )
   let set_param = @graph_model.GraphOperation::GraphOperation(
     @graph_model.WorkflowAction::SetNodeParam(node_id(1), "freq", "880"),
   )
   inspect(
     set_param.to_json().stringify(),
-    content="{\"version\":1,\"type\":\"SetNodeParam\",\"node_id\":\"1\",\"parameter\":\"freq\",\"value\":\"880\"}",
+    content="{\"version\":2,\"type\":\"SetNodeParam\",\"node_id\":\"1\",\"parameter\":\"freq\",\"value\":\"880\"}",
   )
   let decoded : Array[@graph_model.GraphOperation] = @json.from_json(
     [rename.to_json(), set_param.to_json()].to_json(),

--- a/lib/canvas-graph/graph_model/model.mbt
+++ b/lib/canvas-graph/graph_model/model.mbt
@@ -2,18 +2,16 @@
 const GRAPH_OPERATION_VERSION : Int = 1
 
 ///|
-/// Integer ID for graph nodes in the canvas model.
-pub(all) struct NodeId(Int) derive(Debug, Eq)
+/// Stable identity for graph nodes in the canvas model. For source-backed
+/// graphs this is the Loom `ProjectionIdentityTracker` token (`GraphNode::id()`,
+/// e.g. `"node#0:osc"`); for the hand-built canvas it is a minted string
+/// (`"7"`, `"8"`, ...). It is the only cross-frame node identity.
+pub(all) struct NodeId(String) derive(Debug, Eq)
 
 ///|
-pub fn NodeId::from_int(n : Int) -> NodeId {
-  NodeId(n)
-}
-
-///|
-pub fn NodeId::to_int(self : NodeId) -> Int {
-  let NodeId(n) = self
-  n
+pub fn NodeId::to_string(self : NodeId) -> String {
+  let NodeId(s) = self
+  s
 }
 
 ///|
@@ -23,29 +21,46 @@ pub impl Show for NodeId with fn output(self, logger) {
 
 ///|
 pub impl ToJson for NodeId with fn to_json(self) {
-  self.to_int().to_json()
+  self.to_string().to_json()
 }
 
 ///|
 pub impl @json.FromJson for NodeId with fn from_json(json, path) {
   match json {
-    Json::Number(n, ..) => NodeId(n.to_int())
-    _ => raise @json.JsonDecodeError((path, "NodeId: expected JSON number"))
+    Json::String(s) => NodeId(s)
+    _ => raise @json.JsonDecodeError((path, "NodeId: expected JSON string"))
   }
 }
 
 ///|
-pub(all) struct EdgeId(Int) derive(Debug, Eq)
+/// Identity for a typed connection, derived deterministically from its
+/// endpoints — `(source, source_port, target, target_port)` — so no allocator
+/// or registry is needed. `source_port` is included so two edges from distinct
+/// output ports of one source to the same target port do not collide.
+pub(all) struct EdgeId(String) derive(Debug, Eq)
 
 ///|
-pub fn EdgeId::from_int(n : Int) -> EdgeId {
-  EdgeId(n)
+pub fn EdgeId::from_edge(
+  source : NodeId,
+  source_port : String,
+  target : NodeId,
+  target_port : String,
+) -> EdgeId {
+  EdgeId(
+    source.to_string() +
+    "|" +
+    source_port +
+    "|" +
+    target.to_string() +
+    "|" +
+    target_port,
+  )
 }
 
 ///|
-pub fn EdgeId::to_int(self : EdgeId) -> Int {
-  let EdgeId(n) = self
-  n
+pub fn EdgeId::to_string(self : EdgeId) -> String {
+  let EdgeId(s) = self
+  s
 }
 
 ///|
@@ -55,14 +70,14 @@ pub impl Show for EdgeId with fn output(self, logger) {
 
 ///|
 pub impl ToJson for EdgeId with fn to_json(self) {
-  self.to_int().to_json()
+  self.to_string().to_json()
 }
 
 ///|
 pub impl @json.FromJson for EdgeId with fn from_json(json, path) {
   match json {
-    Json::Number(n, ..) => EdgeId(n.to_int())
-    _ => raise @json.JsonDecodeError((path, "EdgeId: expected JSON number"))
+    Json::String(s) => EdgeId(s)
+    _ => raise @json.JsonDecodeError((path, "EdgeId: expected JSON string"))
   }
 }
 
@@ -362,13 +377,13 @@ pub impl @json.FromJson for GraphOperation with fn from_json(json, path) {
     }
     "ConnectPorts" => {
       let source = NodeId(
-        json_number_field(fields, path, "source", "ConnectPorts"),
+        json_string_field(fields, path, "source", "ConnectPorts"),
       )
       let source_port = json_string_field(
         fields, path, "source_port", "ConnectPorts",
       )
       let target = NodeId(
-        json_number_field(fields, path, "target", "ConnectPorts"),
+        json_string_field(fields, path, "target", "ConnectPorts"),
       )
       let target_port = json_string_field(
         fields, path, "target_port", "ConnectPorts",
@@ -377,13 +392,13 @@ pub impl @json.FromJson for GraphOperation with fn from_json(json, path) {
     }
     "DisconnectPorts" => {
       let source = NodeId(
-        json_number_field(fields, path, "source", "DisconnectPorts"),
+        json_string_field(fields, path, "source", "DisconnectPorts"),
       )
       let source_port = json_string_field(
         fields, path, "source_port", "DisconnectPorts",
       )
       let target = NodeId(
-        json_number_field(fields, path, "target", "DisconnectPorts"),
+        json_string_field(fields, path, "target", "DisconnectPorts"),
       )
       let target_port = json_string_field(
         fields, path, "target_port", "DisconnectPorts",
@@ -398,14 +413,14 @@ pub impl @json.FromJson for GraphOperation with fn from_json(json, path) {
     }
     "RenameNode" => {
       let node_id = NodeId(
-        json_number_field(fields, path, "node_id", "RenameNode"),
+        json_string_field(fields, path, "node_id", "RenameNode"),
       )
       let name = json_string_field(fields, path, "name", "RenameNode")
       WorkflowAction::RenameNode(node_id, name)
     }
     "SetNodeParam" => {
       let node_id = NodeId(
-        json_number_field(fields, path, "node_id", "SetNodeParam"),
+        json_string_field(fields, path, "node_id", "SetNodeParam"),
       )
       let parameter = json_string_field(
         fields, path, "parameter", "SetNodeParam",
@@ -524,9 +539,10 @@ pub(all) struct CanvasState {
   viewport : Viewport
   nodes : Array[CanvasNode]
   edges : Array[Edge]
+  /// Monotonic counter used by the hand-built (non-source) canvas to mint fresh
+  /// node ids (`NodeId(next_node_id.to_string())`). Source-backed graphs ignore
+  /// it — their identity is the Loom tracker token.
   next_node_id : Int
-  /// Monotonic counter used to mint EdgeIds for newly-created connections.
-  next_edge_id : Int
   interaction : InteractionState
   action_log : Array[GraphOperation]
 } derive(Debug)
@@ -761,7 +777,7 @@ fn append_edge(
   target_port : String,
 ) -> CanvasState {
   let edge : Edge = {
-    id: EdgeId(state.next_edge_id),
+    id: EdgeId::from_edge(source, source_port, target, target_port),
     source,
     source_port,
     target,
@@ -769,7 +785,7 @@ fn append_edge(
   }
   let edges = state.edges.copy()
   edges.push(edge)
-  { ..state, edges, next_edge_id: state.next_edge_id + 1 }
+  { ..state, edges, }
 }
 
 ///|
@@ -941,41 +957,40 @@ pub fn replay_operations(
 /// loop, and parallel-flow concepts.
 pub impl Default for CanvasState with fn default() -> CanvasState {
   let nodes = [
-    make_workflow_node(NodeId(1), TimerTrigger, -520.0, -190.0),
-    make_workflow_node(NodeId(2), HttpRequest, -190.0, -190.0),
-    make_workflow_node(NodeId(3), DataFormatter, 155.0, -190.0),
-    make_workflow_node(NodeId(4), ConditionalBranch, 500.0, -190.0),
-    make_workflow_node(NodeId(5), Loop, 150.0, 60.0),
-    make_workflow_node(NodeId(6), Parallel, 500.0, 70.0),
+    make_workflow_node(NodeId("1"), TimerTrigger, -520.0, -190.0),
+    make_workflow_node(NodeId("2"), HttpRequest, -190.0, -190.0),
+    make_workflow_node(NodeId("3"), DataFormatter, 155.0, -190.0),
+    make_workflow_node(NodeId("4"), ConditionalBranch, 500.0, -190.0),
+    make_workflow_node(NodeId("5"), Loop, 150.0, 60.0),
+    make_workflow_node(NodeId("6"), Parallel, 500.0, 70.0),
   ]
   {
     viewport: { x: 760.0, y: 330.0, scale: 0.75 },
     nodes,
     edges: [
       {
-        id: EdgeId(1),
-        source: NodeId(1),
+        id: EdgeId::from_edge(NodeId("1"), "tick", NodeId("2"), "in"),
+        source: NodeId("1"),
         source_port: "tick",
-        target: NodeId(2),
+        target: NodeId("2"),
         target_port: "in",
       },
       {
-        id: EdgeId(2),
-        source: NodeId(2),
+        id: EdgeId::from_edge(NodeId("2"), "json", NodeId("3"), "json"),
+        source: NodeId("2"),
         source_port: "json",
-        target: NodeId(3),
+        target: NodeId("3"),
         target_port: "json",
       },
       {
-        id: EdgeId(3),
-        source: NodeId(3),
+        id: EdgeId::from_edge(NodeId("3"), "text", NodeId("4"), "text"),
+        source: NodeId("3"),
         source_port: "text",
-        target: NodeId(4),
+        target: NodeId("4"),
         target_port: "text",
       },
     ],
     next_node_id: 7,
-    next_edge_id: 4,
     interaction: empty_interaction(),
     action_log: [],
   }

--- a/lib/canvas-graph/graph_model/model.mbt
+++ b/lib/canvas-graph/graph_model/model.mbt
@@ -1,5 +1,8 @@
 ///|
-const GRAPH_OPERATION_VERSION : Int = 1
+// v2: NodeId/EdgeId wire encoding is a JSON string (the projection token), not
+// the v1 positional integer. The decode gate below rejects v1 payloads, so the
+// bump keeps "version" an honest, single-meaning format marker.
+const GRAPH_OPERATION_VERSION : Int = 2
 
 ///|
 /// Stable identity for graph nodes in the canvas model. For source-backed

--- a/lib/canvas-graph/graph_model/pkg.generated.mbti
+++ b/lib/canvas-graph/graph_model/pkg.generated.mbti
@@ -52,7 +52,6 @@ pub(all) struct CanvasState {
   nodes : Array[CanvasNode]
   edges : Array[Edge]
   next_node_id : Int
-  next_edge_id : Int
   interaction : InteractionState
   action_log : Array[GraphOperation]
 } derive(@debug.Debug)
@@ -89,9 +88,9 @@ pub(all) struct Edge {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub impl Show for Edge
 
-pub(all) struct EdgeId(Int) derive(Eq, @debug.Debug)
-pub fn EdgeId::from_int(Int) -> Self
-pub fn EdgeId::to_int(Self) -> Int
+pub(all) struct EdgeId(String) derive(Eq, @debug.Debug)
+pub fn EdgeId::from_edge(NodeId, String, NodeId, String) -> Self
+pub fn EdgeId::to_string(Self) -> String
 pub impl Show for EdgeId
 pub impl ToJson for EdgeId
 pub impl @json.FromJson for EdgeId
@@ -117,9 +116,8 @@ pub(all) struct InteractionState {
 } derive(Eq, @debug.Debug)
 pub impl Show for InteractionState
 
-pub(all) struct NodeId(Int) derive(Eq, @debug.Debug)
-pub fn NodeId::from_int(Int) -> Self
-pub fn NodeId::to_int(Self) -> Int
+pub(all) struct NodeId(String) derive(Eq, @debug.Debug)
+pub fn NodeId::to_string(Self) -> String
 pub impl Show for NodeId
 pub impl ToJson for NodeId
 pub impl @json.FromJson for NodeId


### PR DESCRIPTION
## Summary

#565 PR2 — collapse source-backed canvas node identity to a **single authority**.
`NodeId` becomes a `String` equal to Loom `ProjectionIdentityTracker`'s
`GraphNode::id()` token (e.g. `"node#0:osc"`), dropping the positional-index ID
path and the binding-recovery shim. `EdgeId` becomes a `String` derived
deterministically from its endpoints, so no allocator/registry is needed.

This makes the projection-identity token the only cross-frame node identity:
selection, inspector params, and edges all key on it, and survive delta edits
because the tracker keeps survivor tokens stable.

## Changes

**Model (`lib/canvas-graph/graph_model/model.mbt`)**
- `NodeId(Int)` → `NodeId(String)`; `EdgeId(Int)` → `EdgeId(String)`
- `EdgeId::from_edge(source, source_port, target, target_port)` derives the id as
  `"src|sport|tgt|tport"` (injective: DSL identifiers are `[A-Za-z_][A-Za-z0-9_]*`
  and tokens are `node#<n>:<binding>`, so no component contains `|`)
- `next_edge_id` field removed; `next_node_id : Int` kept for the hand-built
  canvas, which mints `NodeId(next_node_id.to_string())`
- NodeId/EdgeId JSON codecs emit/expect `Json::String`

**Adapter (`examples/canvas/main/graph_dsl_adapter.mbt`)**
- Node identity = `GraphNode::id()` token throughout; lookups go through the
  loom `GraphDoc::find_node_by_id` added in dowdiness/loom#271
- Layer 3: deleted the binding-recovery shim
  (`source_selected_node_bindings` / `source_selection_from_bindings` /
  `remap_selection_to_bindings`); replaced with token-based
  `prune_selection_to_doc` (survivors keep selection, churned/deleted tokens
  fall out) + a rename hook `rename_selection_token` that carries selection to
  the renamed node's new token
- Render builds a `Map[String, GraphNode]` once per frame so per-node param
  resolution is O(1) instead of O(n) `find_node_by_id` per node

**Hand-built canvas + FFI (`canvas_{init,runtime,state,update}.mbt`, `source_delete_lowering.mbt`)**
- FFI pointer/hover/disconnect params `Int` → `String`, with `""` as the
  background/no-node sentinel
- JSON render/operation structs carry String ids

**TS boundary (`examples/canvas/web/src/{graph-adapter,main}.ts`)**
- node/edge ids `number` → `string`; removed `parseInt`; numeric guards
  (`Number.isInteger/isFinite`, `<= 0`) → `.length === 0`; `0` sentinel → `''`

**E2E (`examples/canvas/web/e2e/source-backed.spec.ts`)**
- source-backed nodes are now located by their binding via a `sourceNode(page,
  'osc')` helper that resolves the token from the DOM on demand, instead of the
  obsolete positional `data-node-id="1"`. No hardcoded token format; the rename
  test asserts the token churn (`osc` gone, `lfo` present). `canvas-handles.spec.ts`
  (hand-built canvas) is unchanged — those nodes keep string ids `"1".."6"`.

**Submodule**
- loom gitlink bumped to `309f4b9` (dowdiness/loom#271 — `GraphDoc::find_node_by_id`)

## Test plan

- canvas: 59/59 (`--target js`)
- canvas-graph: 257 wasm-gc / 1329 js / 46 native
- `tsc --noEmit`: 0 errors
- Playwright E2E (`canvas-handles` + `source-backed`): green
- New/rewritten wbtests assert the token-stability contract: survivor kept by
  stable token across delete; `set_source` reorder churns identity and clears
  selection (documented residual); editor-delta reorder preserves selection;
  RenameNode carries selection to the new token

## Reuse check

Node→GraphNode resolution reuses the loom `GraphDoc::find_node_by_id` (token
key) added in #271, mirroring the existing `find_node` (binding key) — the two
are distinct identities (binding is rename-mutable, token is stable). No new
identity-resolution helper was invented in canopy.

## Review notes

- Pre-PR Codex review: PASS. A 7-angle `/code-review` pass surfaced only one
  live item — an O(n)→O(n²) render lookup — which is fixed in this diff (the
  per-render `Map`); all other candidates were refuted against cited grammar /
  lowering invariants.
- `set_source` reorder clearing selection is an accepted residual limitation
  (the delta-edit path preserves selection; `set_source` is reset/init-only).
