### PR TITLE
feat(canvas): replace source-panel poll with reactive incr invalidation (#565 follow-up)

### DIFF
--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -991,6 +991,22 @@ pub fn get_source_graph_source(handle : Int) -> String {
 }
 
 ///|
+/// Subscribe to settle notifications for a registered source-backed graph. The
+/// source panel's reactive `custom_sub` uses this to replace the old 250ms
+/// poll: `listener` fires after every `GraphAttachment` settle (any mutation
+/// origin), and the panel pulls `get_source_graph_source` on the ping. Returns
+/// `None` for an unknown handle.
+fn source_graph_subscribe(
+  handle : Int,
+  listener : () -> Unit,
+) -> @graph_dsl.GraphAttachmentSubscription? {
+  match source_graph_by_handle(handle) {
+    Some(graph) => Some(graph.attachment.subscribe(listener))
+    None => None
+  }
+}
+
+///|
 fn set_source_graph_source_checked(
   handle : Int,
   source : String,

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -28,6 +28,20 @@ fn js_source_mode_url(enabled : Bool) -> String {
 }
 
 ///|
+/// Run `run` on a microtask. Used to defer the source-graph settle ping so the
+/// synchronous mutation that triggered it completes first (see
+/// `source_graph_change_sub`).
+#cfg(target="js")
+extern "js" fn defer_sync(run : () -> Unit) -> Unit =
+  #|((run) => { queueMicrotask(() => run()); })
+
+///|
+#cfg(not(target="js"))
+fn defer_sync(run : () -> Unit) -> Unit {
+  run()
+}
+
+///|
 struct SourceDemoModel {
   handle : Int
   editor : String
@@ -289,17 +303,84 @@ fn source_demo_update(
 }
 
 ///|
+/// Payload for the reactive source-graph change subscription. Carries the
+/// graph handle (which graph to observe) and the tagger that turns a settle
+/// ping into a `SyncFromGraph` message.
+priv suberror SourceGraphSub {
+  GraphChanged(Int, @rabbita.Emit[Unit])
+}
+
+///|
+/// Reactive replacement for the former `@sub.every(250, SyncFromGraph)` poll:
+/// bridges the `GraphAttachment` settle-observer (via `source_graph_subscribe`)
+/// into an `Emit`. It pings on every settle regardless of origin; the
+/// `SyncFromGraph` handler pulls the source and dedupes (`dirty` /
+/// `source == editor` guards), so panel-origin echoes are no-ops.
+///
+/// The ping is delivered on a microtask (see `defer_sync` in the loader): the
+/// settle fires synchronously inside the attachment mutation, before the
+/// `SourceBackedGraph.source` wrapper finishes updating, so a same-tick pull
+/// would read stale source. Deferring also means `scheduler.add` never runs
+/// inside an in-progress drain, so there is no reentrancy to reason about.
+fn source_graph_change_sub(
+  handle : Int,
+  tagger : @rabbita.Emit[Unit],
+) -> @sub.Sub {
+  // Key on the handle only (not the tagger identity) so re-renders rebind the
+  // tagger via `update_tagger` rather than reinstalling the subscription.
+  @sub.custom_sub(
+    "source_graph.changed(handle=\{handle})",
+    @sub.Scope::Local,
+    GraphChanged(handle, tagger),
+    @sub.SubLoader(source_graph_change_sub_loader),
+  )
+}
+
+///|
+fn source_graph_change_sub_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    GraphChanged(handle, tagger) => {
+      let mut current_tagger = tagger
+      match
+        source_graph_subscribe(handle, fn() {
+          // Deliver on a microtask: the settle ping fires *inside* the
+          // attachment mutation, before `SourceBackedGraph.source` (what
+          // `SyncFromGraph` pulls via `get_source_graph_source`) is updated for
+          // a canvas-origin op. Deferring lets that synchronous mutation finish
+          // so the sync reads the canonical post-mutation source — and keeps
+          // `scheduler.add` out of any in-progress drain (no reentrancy).
+          defer_sync(fn() { scheduler.add(current_tagger(())) })
+        }) {
+        Some(subscription) =>
+          Some({
+            unload: fn(_) { subscription.unsubscribe() },
+            update_tagger: fn(payload) {
+              guard payload is GraphChanged(_, new_tagger) else { return }
+              current_tagger = new_tagger
+            },
+          })
+        None => None
+      }
+    }
+    _ => None
+  }
+}
+
+///|
 fn source_demo_subscriptions(
   emit : Emit[SourceDemoMsg],
   model : SourceDemoModel,
 ) -> @sub.Sub {
   // Both subscriptions need the editor to exist: `listen` is a no-op until the
-  // view is registered, and the graph -> editor poll has nothing to sync into
+  // view is registered, and the graph -> editor sync has nothing to push into
   // (and would `set_doc` a not-yet-mounted editor). Gate the whole batch on
   // `mounted` so neither runs before the editor mounts.
   guard model.mounted else { return @sub.none }
   @sub.batch([
-    @sub.every(250, emit(SyncFromGraph)),
+    source_graph_change_sub(model.handle, emit.map(_ => SyncFromGraph)),
     @codemirror.listen(
       SOURCE_CM_EDITOR_ID,
       doc=emit.map(source => EditorSynced(source)),

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -344,15 +344,33 @@ fn source_graph_change_sub_loader(
   match payload {
     GraphChanged(handle, tagger) => {
       let mut current_tagger = tagger
+      // Coalesce a burst of settle pings into a single sync. One CodeMirror
+      // transaction can apply many per-delta loom edits (`apply_codemirror_changes`
+      // settles once per delta), each firing this observer; but `SyncFromGraph`
+      // only pulls the *final* source, so all but one ping per turn are redundant
+      // TEA cycles. Hold `sync_pending` from the first ping until the deferred
+      // sync actually runs, so a multi-range edit or large paste schedules just
+      // one `SyncFromGraph` instead of one per delta.
+      let mut sync_pending = false
       match
         source_graph_subscribe(handle, fn() {
+          guard !sync_pending else { return }
+          sync_pending = true
           // Deliver on a microtask: the settle ping fires *inside* the
           // attachment mutation, before `SourceBackedGraph.source` (what
           // `SyncFromGraph` pulls via `get_source_graph_source`) is updated for
           // a canvas-origin op. Deferring lets that synchronous mutation finish
           // so the sync reads the canonical post-mutation source — and keeps
           // `scheduler.add` out of any in-progress drain (no reentrancy).
-          defer_sync(fn() { scheduler.add(current_tagger(())) })
+          //
+          // Clear `sync_pending` *before* `scheduler.add` so that if draining
+          // the sync somehow provokes a fresh settle, it re-arms and is not
+          // swallowed; settles that merely piled up before this microtask are
+          // already coalesced into this one run.
+          defer_sync(fn() {
+            sync_pending = false
+            scheduler.add(current_tagger(()))
+          })
         }) {
         Some(subscription) =>
           Some({


### PR DESCRIPTION
## Summary

Replaces the canvas source panel's **250ms `SyncFromGraph` poll** with **reactive incr-driven invalidation**, the follow-up deferred from #565 PR1 (#570).

The poll lived at `source_demo.mbt` as `@sub.every(250, emit(SyncFromGraph))` (gated on `model.mounted`, read-gated by `model.dirty`). The blocker was that `GraphAttachment` — already incr-backed (owns `@incr.Scope` + `@incr.Watch[GraphProjectionAttempt]` built from `parser.runtime()`) — exposed **no public observer**. loom PR #273 added that seam; this PR consumes it and deletes the poll.

## loom seam (#273, gitlink `4add99f`→`4fe97aa`)

`GraphAttachment::subscribe(listener)` fires once at the end of every `settle()` — after each `apply_edit` / `set_source` updates `state`/`diagnostics`/`current`/`last_good`, regardless of projection outcome — and returns an idempotent `unsubscribe` handle. `dispose()` clears listeners first. 11 blackbox observer tests merged with it.

## Canvas side

- `graph_dsl_adapter.source_graph_subscribe(handle, listener)` exposes the seam by handle.
- `source_demo` adds a `custom_sub` mirroring `examples/ideal/main/rabbita_dom_sub.mbt` and the canonical rabbita `websocket/listen.mbt` pattern: `priv suberror SourceGraphSub`, `let mut current_tagger` + `update_tagger` rebind, `unload` → `subscription.unsubscribe()`. The key encodes the **handle only** (not tagger identity), so re-renders rebind rather than re-install.
- The listener fires the existing `SyncFromGraph` Emit; **the handler is unchanged**. Only the trigger mechanism changes, not the sync payload.

### Microtask defer

The fire is deferred via `queueMicrotask` (`defer_sync`, dual-cfg mirroring `js_source_mode_url`). `SourceBackedGraph.source` is updated by the adapter *after* `attachment.apply_edit` returns, so a synchronous settle-ping would read stale source through `get_source_graph_source`. The old poll never hit this because it fired on a later tick. Deferring to a microtask reads consistent state. (Verified: this was the root cause of an initial 5-failure E2E run; the defer brought it to 19/19.)

## Validation

- `moon check` (default + js target): clean
- unit tests (js target): 59 pass
- canvas E2E: 19 pass (E2E_EXIT=0, runner's own exit captured to file)
- Codex pre-PR review: **PASS**, no blocking findings

## Reuse check

- Reuses the rabbita `custom_sub` / `suberror` / `update_tagger` binding pattern — no new framework primitive.
- Reuses the existing `SyncFromGraph` Msg + handler — payload identical to the polled path.
- Reuses the loom `GraphAttachment` observer seam (#273) rather than polling public getters.
- `defer_sync` mirrors the existing dual-cfg `js_source_mode_url` extern; no new FFI idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
