### PR TITLE
docs(agents): fix workspace/submodule drift, thin duplicated sections, add impl policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,11 +79,15 @@ Use PRs for submodule changes; never push to a submodule's main without asking.
 
 ## Rabbita Conventions
 
+<!-- textlint-disable slopless/word-repetition -->
+
 Rabbita is vendored at `./rabbita/` (fork of `moonbit-community/rabbita` with the
 `diff_subs` `update_tagger` patch — see
 `docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` §P2.0). Its docs
 (`rabbita/doc/*`, `rabbita/rabbita/*/{README.mbt.md,design.md}`) are
 authoritative: when they disagree with a plan or pasted spec, the docs win.
+
+<!-- textlint-enable slopless/word-repetition -->
 
 The `.claude/skills/rabbita` skill auto-invokes on rabbita work (`@sub`, `@cmd`,
 `@html`, `@dom`, `@http`, bindings) and carries the doc checklist, idiom rules,
@@ -118,7 +122,11 @@ The base rule (microbenchmark before optimizing) applies. Additionally: stale pr
 
 ### Quality & Edit Workflow
 
+<!-- textlint-disable slopless/word-repetition -->
+
 Hooks enforce `moon check` after every edit and `moon fmt && moon info` before commits. After edits, also run `moon test` and rebuild JS if web is affected. For packages with `"proof-enabled": true`, also run `moon prove` from the proof package directory. After `moon info`, check `git diff *.mbti` for unintended trait bound changes — widening a bound is an API regression even if all current consumers satisfy it. See [docs/development/task-tracking.md](docs/development/task-tracking.md) for tracking workflow.
+
+<!-- textlint-enable slopless/word-repetition -->
 
 ### Existing API First Rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,42 +71,23 @@ cd loom/examples/lambda && moon bench --release
 
 ## Submodule Workflow
 
-### Updating submodules
-```bash
-git submodule update --remote        # Pull latest from all submodules
-git add <changed-submodules>         # Stage only the pointers that moved (git status)
-git commit -m "chore: update submodules"
-```
-
-### Making changes to a submodule
-```bash
-cd event-graph-walker
-# make changes, commit, push
-cd ..
-git add event-graph-walker
-git commit -m "chore: update event-graph-walker submodule"
-```
+`git submodule update --remote` pulls latest; stage only the pointers that
+actually moved (`git add <changed-submodules>`). When editing a submodule, commit
+and **push it to its own remote before** committing the parent pointer or opening
+a parent PR — CI fails if the referenced submodule commit isn't on its remote.
+Use PRs for submodule changes; never push to a submodule's main without asking.
 
 ## Rabbita Conventions
 
-Rabbita is vendored at `./rabbita/` (fork of `moonbit-community/rabbita`
-with the `diff_subs` `update_tagger` patch applied — see
-`docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` §P2.0).
+Rabbita is vendored at `./rabbita/` (fork of `moonbit-community/rabbita` with the
+`diff_subs` `update_tagger` patch — see
+`docs/plans/2026-05-18-codemirror-rabbita-binding-phase2.md` §P2.0). Its docs
+(`rabbita/doc/*`, `rabbita/rabbita/*/{README.mbt.md,design.md}`) are
+authoritative: when they disagree with a plan or pasted spec, the docs win.
 
-When designing, implementing, or reviewing code that uses `@sub`,
-`@cmd`, `@html`, `@dom`, `@http`, `custom_sub`, `suberror`, or that
-authors / modifies a rabbita binding (`lib/rabbita_codemirror`, future
-libraries): **the files under `rabbita/doc/*` and
-`rabbita/rabbita/*/{README.mbt.md,design.md}` are authoritative.** Read
-them before designing. Cite the specific paths you used.
-
-If rabbita docs disagree with older `docs/plans/*.md` or with a spec
-the user pasted, the rabbita docs win — revise the plan, not the
-implementation.
-
-The `.claude/skills/rabbita` skill auto-invokes on rabbita-related
-prompts and contains the doc reading checklist + inline idiom rules +
-canonical binding patterns. Invoke manually with `/rabbita` if needed.
+The `.claude/skills/rabbita` skill auto-invokes on rabbita work (`@sub`, `@cmd`,
+`@html`, `@dom`, `@http`, bindings) and carries the doc checklist, idiom rules,
+and canonical patterns — read it before designing.
 
 ## Adding a New Language
 
@@ -188,19 +169,14 @@ Run `moon check` after edits and `moon test` for affected packages.
 
 ## Model Routing
 
-Route tasks based on judgment complexity, not importance.
+Route by judgment complexity, not importance: Opus for architecture/novel
+design/debugging, Sonnet for clear-spec implementation (50+ lines) and pre-merge
+review, Haiku for mechanical work (renames, formatting, rote migration). Under
+~50 lines / 1-3 files, implement inline — no delegation.
 
-| Task type | Model | Mechanism |
-|-----------|-------|-----------|
-| Architecture, novel design, debugging wrong approaches | Opus | Direct (default) |
-| Implementation (50+ lines, clear spec) | Sonnet | `Agent(model: "sonnet")` |
-| Code review (pre-merge) | Sonnet | `/parallel-review` or `Agent(subagent_type: "code-reviewer")` |
-| Mechanical (renames, formatting, rote migration) | Haiku | `Agent(model: "haiku")` |
-| Under 50 lines, 1-3 files | Current model | No delegation — implement inline |
-
-**Delegation requires clear scope.** If you can't list the exact files to modify, research first. Vague delegation wastes the agent's time exploring.
-
-**Use `/delegate` skill** before composing Agent prompts for non-trivial delegation. It provides the handoff format and task-type templates.
+Delegation requires clear scope — if you can't list the files to touch, research
+first. Use the `/delegate` skill for the handoff format and task templates, and
+`/parallel-review` or `Agent(subagent_type: "code-reviewer")` for review.
 
 ## Code Review Expectations
 
@@ -213,8 +189,7 @@ Route tasks based on judgment complexity, not importance.
 - When asked to 'commit remaining files', interpret generously even if phrasing is unclear
 - **NEVER merge PRs until CI is fully green.** Run `gh pr checks <NUMBER>` and show the raw output — do not summarize or paraphrase. If any check is `pending`, `fail`, or `skipped`, STOP and report the exact status. Skipped is NOT passing. Do not claim CI is green without verifying.
 - After rebasing or refactoring, verify file paths haven't shifted unexpectedly. Run `git diff --stat` to confirm only intended files changed.
-- When making changes across submodules, always push submodule commits to remote BEFORE pushing the parent repo or creating parent PRs. CI will fail if submodule commits aren't available on remote.
-- Always use PRs for submodule changes — never push directly to main branches of submodules without asking first.
+- Submodule push-order and PR rules: see [Submodule Workflow](#submodule-workflow).
 
 ## Design Context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,24 +15,24 @@ git submodule update --init --recursive
 
 ### Test & Build
 ```bash
-# Workspace-root commands cover all in-repo modules listed in `moon.work`:
-# canopy + lib/{text-change,zipper,btree,moji,rabbita_codemirror,dom-boundary,
-# visualizer,semantic} + examples/{ideal,block-editor,canvas,codemirror_demo}.
+# Workspace-root commands cover every in-repo module listed in `moon.work`
+# (canopy root + all lib/* and examples/* members). Read `moon.work` for the
+# current member list — do not maintain a copy here; it drifts.
 moon test                           # All workspace members
 moon check                          # Lint across workspace
 moon info && moon fmt               # Format & update interfaces
 
-# Submodules are NOT workspace members — still need fanout:
-cd event-graph-walker && moon test  # CRDT library tests
-cd loom/loom && moon test           # Parser framework tests
-cd loom/seam && moon test           # CST library tests
-cd loom/examples/lambda && moon test # Lambda parser tests
-cd loom/examples/json && moon test
-cd loom/examples/markdown && moon test
+# Submodules are NOT workspace members — each needs its own:
+cd <submodule> && moon test
+# The authoritative tested set is CI's "Test Submodules" matrix in
+# .github/workflows/ci.yml (currently event-graph-walker, loom, svg-dsl,
+# graphviz). rle, order-tree, alga, and vendored rabbita are pure deps —
+# no separate test step; consumers exercise them.
 ```
 
-The canonical CI fan-out is described in `.github/workflows/ci.yml`. Use that
-file as the source of truth if this list drifts.
+`.github/workflows/ci.yml` is the source of truth for the full fan-out — its
+`Test Submodules` and `Test MoonBit Examples` matrices list exactly what is
+checked and tested. Read it rather than trusting any list reproduced here.
 
 JS build artifacts are namespaced under the module path: `_build/js/release/build/dowdiness/canopy/ffi/{lambda,json,markdown}/...`. Vite configs, tsconfigs, `scripts/build-js.sh`, `scripts/package-release.sh`, and CI artifact uploads all reference this namespaced path.
 
@@ -44,6 +44,17 @@ cd examples/web && npm run dev      # Dev server (localhost:5173)
 # Markdown editor: http://localhost:5173/markdown.html
 moon build --target js              # Build for web
 ```
+
+TypeScript front-ends live alongside the MoonBit examples and are typechecked +
+E2E-tested separately in CI (they are NOT covered by `moon test`):
+
+- **TS typecheck** (`Type Check TS Examples`): `examples/{web,prosemirror,demo-react}`
+- **Playwright E2E** jobs: `examples/web`, `examples/ideal/web`,
+  `examples/demo-react`, `examples/canvas/web`
+
+JS artifacts must be built (`moon build --target js`) before these run. See the
+matching jobs in `.github/workflows/ci.yml` for the exact commands and the
+pinned Playwright container per suite.
 
 ### Formal Verification
 ```bash
@@ -63,7 +74,7 @@ cd loom/examples/lambda && moon bench --release
 ### Updating submodules
 ```bash
 git submodule update --remote        # Pull latest from all submodules
-git add event-graph-walker loom      # Stage submodule pointer updates
+git add <changed-submodules>         # Stage only the pointers that moved (git status)
 git commit -m "chore: update submodules"
 ```
 
@@ -139,6 +150,36 @@ Before defining any new function, method, helper, or type in this repository:
 
 See `docs/api-map.md` for the task→existing-API index. Include a **Reuse check** section in your PR (PR template enforces this).
 
+### MoonBit Implementation Policy
+
+Extends the Existing API First Rule above from *new definitions* to *all* code.
+
+Do not write new low-level loops, helpers, or data-manipulation code until you
+have searched for existing project APIs and MoonBit/core APIs. Use
+`NEW_MOON_MOD=0 moon ide doc`, `peek-def`, `find-references`, and `outline` to
+discover existing functions and methods.
+
+**Prefer declarative code:**
+- `match` / `guard` / pattern matching
+- `Iter` methods: `map`, `filter`, `fold`, `collect`
+- list comprehensions when clearer
+- `ArrayView` / `StringView` / `BytesView` instead of copying
+- owning-type methods and constructors
+- existing project functions over new helpers
+
+**Avoid incidental mutation:**
+- justify every `let mut`, push loop, manual index loop, and `while` loop
+- use mutation only for builders, true state machines, interop, or measured
+  performance reasons
+
+**Before finalizing, report:**
+1. existing APIs reused
+2. existing APIs checked but not used
+3. any new helper introduced, and why
+4. remaining imperative code, and why it is necessary
+
+Run `moon check` after edits and `moon test` for affected packages.
+
 ## Architecture Conventions
 
 - When adding shared content, use symlinks or references to a single source of truth. Never embed copies of shared files — flag the duplication problem first.
@@ -177,22 +218,13 @@ Route tasks based on judgment complexity, not importance.
 
 ## Design Context
 
-**Personality:** Elegant, Thoughtful, Deep — beauty emerging from structure.
+**Elegant, Thoughtful, Deep** — beauty emerging from structure. Dark, focused,
+typography-driven; deep navy base with restrained purple accent. References: Zed,
+Dark/Luna, Strudel. Anti-references: generic SaaS, toy/playground aesthetics.
 
-**References:** Zed Editor, Dark/Luna, Strudel (strudel.cc)
-
-**Anti-references:** Generic SaaS, toy/playground aesthetics.
-
-**Design Principles:**
-1. **Structure reveals meaning** — color, spacing, nesting communicate relationships before labels
-2. **Progressive disclosure** — clean and focused by default, reveal depth on demand
-3. **Typography carries weight** — Inter (UI) vs JetBrains Mono (code) creates clear zones
-4. **Color is semantic, not decorative** — every color means something, no color without purpose
-5. **Calm confidence** — solid and trustworthy, never frantic. Subtle transitions, generous whitespace
-
-**Palette:** Deep navy base (`#1a1a2e`), purple accent (`#8250df`), syntax colors: keyword `#c792ea`, identifier `#82aaff`, number `#f78c6c`, string `#c3e88d`, operator `#ff5370`
-
-See `.impeccable.md` for full design tokens and context.
+`.impeccable.md` is the single source of truth for the full design context —
+personality, principles, palette, fonts, and design tokens. Read it before any
+UI/visual work; do not duplicate token values here (they drift).
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Run `moon check` after edits and `moon test` for affected packages.
 
 ## Model Routing
 
-Route by judgment complexity, not importance: Opus for architecture/novel
+Route by judgment complexity rather than importance: Opus for architecture/novel
 design/debugging, Sonnet for clear-spec implementation (50+ lines) and pre-merge
 review, Haiku for mechanical work (renames, formatting, rote migration). Under
 ~50 lines / 1-3 files, implement inline — no delegation.


### PR DESCRIPTION
## Summary

Health pass over `AGENTS.md` (which `CLAUDE.md` symlinks to). Fixes factual drift, removes duplicated/stale content, and adds an implementation policy.

- **Workspace member list** — dropped the stale hand-maintained list (it named the removed `lib/moji` and the non-member `lib/text-change`, and undercounted 15 lib + 6 examples as 8 + 4). Replaced with a pointer to `moon.work`, since root-level workspace commands cover every member regardless.
- **Submodule fanout** — corrected to CI's `Test Submodules` matrix (`event-graph-walker`, `loom`, `svg-dsl`, `graphviz`); noted `rle`/`order-tree`/`alga`/vendored `rabbita` are pure deps; deferred the full set to `ci.yml`.
- **`git add` example** — generalized to `<changed-submodules>` (no longer stages only 2 of 8 after a `--remote` pull-all).
- **TS-example surface** — documented the TypeScript typecheck + Playwright E2E jobs CI runs but workspace tests don't.
- **Design Context** — thinned to a pointer at `.impeccable.md` (the duplicated block was also stale: `Inter`/`JetBrains Mono` vs the current `Manrope`/`Iosevka` tokens).
- **MoonBit Implementation Policy** — added as a sibling of the Existing API First Rule: declarative-first, justify mutation, reuse-report before finalizing.

## Reuse check

N/A — pure documentation change. No functions, methods, helpers, or types added.

## Test plan

Docs-only; no code or build impact. Every claim was validated against the repo before committing:

- [x] All 27 referenced paths + 4 markdown file-links exist
- [x] Submodule/example lists cross-checked against `.github/workflows/ci.yml` matrices
- [x] `examples/web/{json,markdown}.html`, `ffi/{lambda,json,markdown}`, and the PR template's "Reuse check" section confirmed present
- [x] `"proof-enabled": true` confirmed in `lib/semantic/proof/moon.pkg`
- [x] Code fences balanced; heading hierarchy clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines and workspace testing procedures for clarity and consistency.
  * Expanded guidance on TypeScript example handling, including typechecking and E2E testing requirements.
  * Refined submodule workflow rules and implementation policies.
  * Improved design context documentation and quality workflow standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->