### PR TITLE
feat(redesign): extract lang/runtime SPI + migrate JSON family (S3 PR1)

### DIFF
--- a/docs/plans/2026-06-11-s3-lang-runtime-extraction.md
+++ b/docs/plans/2026-06-11-s3-lang-runtime-extraction.md
@@ -1,0 +1,194 @@
+# S3 Lang Runtime Extraction Plan
+
+## Scope and non-goals
+
+S3 extracts shared Tier-2 companion mechanics into `lang/runtime` while preserving all Tier-1 editor sync surfaces and S2 shipped interfaces (`sync_session/`, `transport_ws/`, `editor` sync surfaces, and deprecated `sync_protocol.mbt`).
+
+This plan is execution-only; it does not redesign architecture.
+
+Non-goals:
+- No `ffi/host` extraction (reserved for S4).
+- No edits to `ffi` consumer behavior contract beyond adding migration-safe delegation.
+- No transport/sync session rewiring.
+
+Cross-cutting constraints:
+- Respect MoonBit cross-package rules: enum constructors are package-owned, methods are package-defined, and `using` scopes are file-local.
+- Preserve `SyncEditor` text API bounds (`fn[T : Eq]`) by keeping capability-record construction in language packages where concrete `T` is known.
+- Keep closure-record runtime API unbounded on `T`, with dispatch performed through concrete builders.
+- Keep all manifests in `moon.pkg` brace syntax; avoid editing JSON manifest format.
+- Every changed step must include a compile-breakpoint point and the fix that resolves it.
+- Per step run `NEW_MOON_MOD=0 moon info` and inspect `git diff '*.mbti'` for visibility/trait-bound drift.
+- Do not widen visibility unless required by the final API contract.
+- Add deprecated compatibility symbols for moved public symbols with at least one release window.
+
+Benchmark rule from this stage: direct-call/hot-path split is not required; keep unified closure-record dispatch and retain existing dispatch benchmark file under `lang/json/companion/` for continuity.
+
+The language migration order is fixed as: first `json`, then `markdown`, then `lambda` (because `lambda` has optional/extra capabilities and the protocol is intentionally broader).
+
+---
+
+## Step 1 — Introduce `lang/runtime` shared companion layer
+
+### What this step does
+- Create a new `lang/runtime` package with shared companion types and helper functions for:
+  - companion editor constructor protocol
+  - tree-edit application protocol
+  - memo attachment + projection protocol
+  - message-normalized structural edit plumbing
+- Define a runtime record type that represents only shared responsibilities and is reusable by all languages.
+- Keep `lambda`’s richer behavior as optional protocol slots:
+  - optional `eval` hooks
+  - optional `scope` hooks
+  - optional `semantic` hooks
+  - unsupported paths must return an explicit, user-visible unsupported message rather than diverging behavior.
+- Define the shared message/error contract once in `lang/runtime` and preserve existing message strings where externally observed.
+
+### Invariants maintained
+- No changes to text pipeline hot-path inside `editor/sync_editor_text.mbt`.
+- `handle_text_intent` still funnels through existing `SyncEditor.apply_span_edits` semantics and `FocusHint` ordering.
+- `lang/*/companion` package API behavior remains externally equivalent behind deprecations during transition.
+
+### Compile breakpoint + fix
+- Expected break: existing language companions import helpers now moved into `lang/runtime`, creating unresolved symbol errors in `lang/json/companion`, `lang/markdown/companion`, and `lang/lambda/companion`.
+- Fix in same step: create temporary public facades in `lang/runtime` with the old-facing names imported by language companions, then migrate each language in later steps.
+
+### Verification gates for this step
+- `NEW_MOON_MOD=0 moon check` for touched package graph.
+- `NEW_MOON_MOD=0 moon info` + `git diff '*.mbti'` with explicit signoff that no breaking signature widening/regressions were introduced.
+- A focused build of `lang/runtime` only (plus its direct deps), then targeted probe import smoke in a tiny caller to ensure package compiles under cross-package module boundaries.
+
+---
+
+## Step 2 — Migrate JSON companion flow into `lang/runtime`
+
+### Why first: grounding choice
+JSON is the clearest non-lambda reference shape: the companion surface is compact, editor construction and memo attachment are already separable, and round-trip intent tests are already message-oriented. It grounds shared abstractions with the least protocol ambiguity.
+
+### What this step does
+- Move shared logic from `lang/json/companion` into `lang/runtime` while leaving JSON-specific parser and AST transforms in `lang/json`.
+- In `lang/runtime`, implement JSON’s migration by a language-specific constructor callback that supplies:
+  - parser + editor initialization
+  - memo-build policy
+  - `apply_json_edit` bridge implementation
+- Preserve exact `new_json_editor` semantics and `apply_json_edit` external messages during transition:
+  - keep compatibility aliases in `lang/json` entrypoints that delegate to runtime APIs.
+- Maintain the `json` companion’s benchmark and intent test harness by keeping their module-facing function names stable.
+
+### Invariants maintained
+- Parse/op-to-span semantics remain structurally identical (including operation matching order, span emission sequence, and cursor/focus hint handling).
+- Memo attachment output remains isomorphic by value and ordering so existing consumers are not order-sensitive.
+- Existing JSON error and diagnostic message text remains unchanged for externally asserted paths.
+
+### Compile breakpoint + fix
+- Breakpoint A: direct calls from `ffi/json` and tests expecting `new_json_editor` / `apply_json_edit` paths in `lang/json`/`lang/json/companion` fail after extraction.
+- Fix: re-export deprecated aliases in `lang/json/top.mbt` and `lang/json/companion` (or whichever module currently owns public symbols) that forward to runtime entrypoints with no behavior change.
+- Breakpoint B: any moved helper relying on package-local `using` imports loses scope after move.
+- Fix: move helper imports explicitly into each moved file and make runtime modules import modules directly.
+
+### Verification gates (JSON)
+- JSON snapshot tests: run package wbtests and assert serialized snapshots still match expected corpus.
+- Round-trip edit wbtests: run JSON edit integration tests with explicit message assertions (not only success), verifying both successful and error paths.
+- Differential tests: compare old vs runtime-mediated outputs on the same edit stream with non-vacuity assertions (i.e., ensure emitted document/projection/focus actually change where expected and that no silent no-op regression is accepted).
+- Workspace/probe integration: run `workspace/probe` tests that exercise JSON sessions, including identity and runtime-safety probes.
+- Project commands in addition to checks: `NEW_MOON_MOD=0 moon check`, `NEW_MOON_MOD=0 moon test`, plus `NEW_MOON_MOD=0 moon info` with `git diff '*.mbti'`.
+
+---
+
+## Step 3 — Migrate markdown companion flow into `lang/runtime`
+
+### What this step does
+- Migrate `lang/markdown/companion` through runtime primitives exactly as in JSON, preserving markdown parser and fold shapes.
+- Preserve existing markdown integration wbtest names and snapshots by keeping public-facing symbols stable through deprecated forwarding aliases.
+- Normalize message-producing branches so they route through the runtime-defined message envelope.
+
+### Invariants maintained
+- The markdown fold-to-edit path remains stable across span compute and editor application.
+- Message ordering and focus reconciliation order are preserved.
+- Existing markdown-specific behavior remains in `lang/markdown` modules and only shared orchestration moves.
+
+### Compile breakpoint + fix
+- Breakpoint: markdown companion symbols referenced by `ffi/markdown` and markdown examples resolve to symbols still in old package locations.
+- Fix: install temporary compatibility shims in `lang/markdown/top.mbt` (and/or companion module if needed) that delegate to runtime, then remove after second-step transition complete.
+- Breakpoint: enum-boundary issues if any markdown AST enum was indirectly constructed in moved helper code.
+- Fix: keep enum constructors and constructors’ owning module unchanged; move only orchestration paths.
+
+### Verification gates (Markdown)
+- Snapshot tests in markdown companion/test files must still match.
+- Round-trip edit wbtests with explicit message assertions on both parse-and-apply and reconciliation output.
+- Differential non-vacuity tests between pre/post migration markdown edit outputs and message vectors.
+- Workspace/probe integration for markdown scenarios.
+- `NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test` on touched set.
+
+---
+
+## Step 4 — Migrate lambda companion flow and optional capabilities
+
+### What this step does
+- Migrate `lang/lambda/companion` orchestration into `lang/runtime` by adapting the complex lambda companion shape onto the generic runtime dispatch.
+- Keep lambda-specific extra fields in the runtime capability record as optional (eval/scope/semantic). Unsupported paths return explicit errors and preserve external message text.
+- Preserve `lang/lambda/top.mbt` public contracts and companion exports during migration via deprecations.
+- Keep lambda benchmark behavior unchanged and retain current benchmark files.
+
+### Invariants maintained
+- Existing lambda parse-tree edit application shape and focus behavior remain unchanged where supported.
+- Unsupported optional capability requests do not panic or crash; they fail with deterministic, tested messages.
+- Existing direct-language semantic overlays remain package-owned; runtime only calls into them through callbacks.
+- No hot-path behavior split is introduced; still unified closure-record dispatch.
+
+### Compile breakpoint + fix
+- Breakpoint A: `lang/lambda/companion` currently returns tuple-shaped data used by several callsites; moving orchestration may change construction type if callbacks are flattened.
+- Fix: keep lambda-specific public facade signatures unchanged by preserving lambda-specific return adapters in `lang/lambda/top.mbt` and forwarding to runtime internals.
+- Breakpoint B: `fn[T]` unbounded closure record fields conflict with `SyncEditor` text method expectations.
+- Fix: keep `T : Eq` constraints in constructor/builder closures inside `lang/lambda` and `lang/json`/`markdown` language packages; runtime record remains unbounded and stores already-instantiated closures.
+
+### Verification gates (Lambda)
+- Snapshot tests for lambda companion and overlay-related suites.
+- Round-trip edit wbtests with assertions on message text and message shape (including unsupported optional capability branches).
+- Differential tests for successful edits and expected-failure branches with non-vacuity assertions.
+- Probe/identity integration tests over lambda sample sessions.
+- `NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test` on touched set, and `git diff '*.mbti'` review for accidental API leakage.
+
+---
+
+## Step 5 — Consolidate runtime API, deprecations, and proof of migration completeness
+
+### What this step does
+- Finalize `lang/runtime` API into public contract intended for S3 only, ensuring each `lang/*` package has one compatibility surface and one runtime-mediated implementation path.
+- Remove temporary internal duplicate helper code that became dead after migration.
+- Add/update migration notes and add/adjust the `docs/development/ADDING_A_LANGUAGE.md` references that were made stale by this extraction.
+- Ensure ffi consumers remain source-compatible without requiring `lang/runtime` awareness.
+
+### Invariants maintained
+- Every moved public symbol still callable via deprecated alias until at least one release cycle.
+- No API obligations from the Tier-2 boundary are relaxed.
+- Package-level ownership invariants: constructors remain where owning enum/type originally lives.
+
+### Compile breakpoint + fix
+- Breakpoint: stale temporary aliases or duplicate exports creating ambiguous import paths across runtime/language modules.
+- Fix: run package-by-package compile to find collisions, then keep exactly one canonical symbol path and one explicit deprecated forwarder path.
+
+### Verification gates
+- Per-step invariants sweep:
+  - `NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test`.
+  - `NEW_MOON_MOD=0 moon info` with `git diff '*.mbti'` review.
+  - Snapshot + message-asserted wbtests for all three languages in one pass.
+  - differential + non-vacuity tests for all three in aggregate.
+  - workspace/probe package integration across language sessions.
+- JS-facing example readiness check:
+  - build JS artifacts before any web/example test gates as required by repo convention.
+  - ensure web/demo examples run with existing external JS entrypoints.
+
+---
+
+## PR slicing and merge gating
+
+Proposed slice:
+- PR1: `lang/runtime` package + `json` migration.
+- PR2: `markdown` migration using `lang/runtime`.
+- PR3: `lambda` migration with optional capability fields.
+
+For each PR:
+- keep workspace green before handoff with `NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test`.
+- keep example apps operational (`moon build --target js` precondition where app suites depend on JS artifacts).
+- keep temporary compatibility aliases for moved public symbols.
+- do not touch S2 surfaces; explicitly validate no changes in `sync_session/`, `transport_ws/`, editor sync shims.

--- a/lang/json/companion/dispatch_benchmark.mbt
+++ b/lang/json/companion/dispatch_benchmark.mbt
@@ -74,7 +74,7 @@ fn run_text_intent_dispatch_bench(
   let mut i = 0
   let mut inserted = false
   b.bench(fn() {
-    let pos = positions[(i / 2) % positions.length()]
+    let pos = positions[i / 2 % positions.length()]
     let (del, ins) = if inserted { (1, "") } else { (0, "1") }
     match mode {
       Direct => editor.apply_text_edit(pos, del, ins, i)

--- a/lang/json/companion/dispatch_benchmark.mbt
+++ b/lang/json/companion/dispatch_benchmark.mbt
@@ -1,0 +1,184 @@
+// S3 capability-dispatch gate benchmark (architecture redesign proposal
+// § Notes unknown 3). Measures the cost of routing the handle_text_intent
+// hot path (SyncEditor::apply_text_edit) through a capability record of
+// closures — the lang/runtime SPI shape — against today's direct method
+// call. Two layers:
+//   1. realistic keystroke pairs on a JSON document (full edit pipeline)
+//   2. isolated call-shape microbench bounding the per-call indirection
+// Run with: moon bench --release -p dowdiness/canopy/lang/json/companion
+
+///|
+/// Mirrors the S3 capability-record shape: hot text ops as mandatory
+/// closure fields plus one optional field (the LanguageCapabilities
+/// pattern) to measure the per-call Option unwrap.
+priv struct TextOpsCaps {
+  apply_text_edit : (Int, Int, String, Int) -> Unit
+  apply_text_edit_opt : ((Int, Int, String, Int) -> Unit)?
+}
+
+///|
+fn make_text_ops_caps(
+  editor : @editor.SyncEditor[@json.JsonValue],
+) -> TextOpsCaps {
+  {
+    apply_text_edit: fn(from, del, ins, ts) {
+      editor.apply_text_edit(from, del, ins, ts)
+    },
+    apply_text_edit_opt: Some(fn(from, del, ins, ts) {
+      editor.apply_text_edit(from, del, ins, ts)
+    }),
+  }
+}
+
+///|
+priv enum DispatchMode {
+  Direct
+  CapsField
+  CapsOptField
+}
+
+///|
+/// Realistic hot path: alternating insert/delete keystroke pairs through
+/// apply_text_edit, rotating the edit position across member-value spots
+/// so no single operand stays JIT-hot. The capability record is built ONCE
+/// before the loop (S3 stores it in the handle at construction time).
+fn run_text_intent_dispatch_bench(
+  b : @bench.T,
+  member_count : Int,
+  mode : DispatchMode,
+) -> Unit {
+  let source = json_bench_object(member_count)
+  let editor = new_json_editor("bench")
+  editor.set_text(source)
+  ignore(editor.get_proj_node())
+  ignore(editor.get_source_map())
+  let caps = make_text_ops_caps(editor)
+  // Edit positions: just after the value digit of 4 members spread across
+  // the doc. Member i line: `  "k<i>": <i>` — find positions by scanning.
+  let positions : Array[Int] = []
+  let quarter = member_count / 4
+  for q in 0..<4 {
+    let idx = q * quarter
+    let needle = "\"k\{idx}\": "
+    let mut found = -1
+    for p in 0..<(source.length() - needle.length()) {
+      if source.view(start_offset=p, end_offset=p + needle.length()) ==
+        needle.view() {
+        found = p + needle.length()
+        break
+      }
+    }
+    guard found >= 0 else { abort("bench setup: member k\{idx} not found") }
+    positions.push(found)
+  }
+  let mut i = 0
+  let mut inserted = false
+  b.bench(fn() {
+    let pos = positions[(i / 2) % positions.length()]
+    let (del, ins) = if inserted { (1, "") } else { (0, "1") }
+    match mode {
+      Direct => editor.apply_text_edit(pos, del, ins, i)
+      CapsField => (caps.apply_text_edit)(pos, del, ins, i)
+      CapsOptField =>
+        match caps.apply_text_edit_opt {
+          Some(f) => f(pos, del, ins, i)
+          None => ()
+        }
+    }
+    inserted = !inserted
+    i += 1
+    b.keep(i)
+  })
+}
+
+///|
+test "text intent dispatch - direct call (100 members)" (b : @bench.T) {
+  run_text_intent_dispatch_bench(b, 100, Direct)
+}
+
+///|
+test "text intent dispatch - caps field (100 members)" (b : @bench.T) {
+  run_text_intent_dispatch_bench(b, 100, CapsField)
+}
+
+///|
+test "text intent dispatch - caps optional field (100 members)" (b : @bench.T) {
+  run_text_intent_dispatch_bench(b, 100, CapsOptField)
+}
+
+///|
+test "text intent dispatch - direct call (1000 members)" (b : @bench.T) {
+  run_text_intent_dispatch_bench(b, 1000, Direct)
+}
+
+///|
+test "text intent dispatch - caps field (1000 members)" (b : @bench.T) {
+  run_text_intent_dispatch_bench(b, 1000, CapsField)
+}
+
+///|
+test "text intent dispatch - caps optional field (1000 members)" (b : @bench.T) {
+  run_text_intent_dispatch_bench(b, 1000, CapsOptField)
+}
+
+// ── Isolated call-shape microbench ──────────────────────────────────────
+// Bounds the absolute per-call indirection cost with a trivial body so the
+// dispatch itself dominates. 1000 calls per iteration, varied operands.
+
+///|
+fn dispatch_probe_work(a : Int, c : Int, s : String, t : Int) -> Int {
+  a + c + s.length() + t
+}
+
+///|
+priv struct ProbeCaps {
+  f : (Int, Int, String, Int) -> Int
+  g : ((Int, Int, String, Int) -> Int)?
+}
+
+///|
+const PROBE_CALLS = 1000
+
+///|
+test "isolated dispatch - direct call x1000" (b : @bench.T) {
+  b.bench(fn() {
+    let mut acc = 0
+    for i in 0..<PROBE_CALLS {
+      acc += dispatch_probe_work(i, i + 1, "x", i * 3)
+    }
+    b.keep(acc)
+  })
+}
+
+///|
+test "isolated dispatch - caps field x1000" (b : @bench.T) {
+  let caps : ProbeCaps = {
+    f: fn(a, c, s, t) { dispatch_probe_work(a, c, s, t) },
+    g: None,
+  }
+  b.bench(fn() {
+    let mut acc = 0
+    for i in 0..<PROBE_CALLS {
+      acc += (caps.f)(i, i + 1, "x", i * 3)
+    }
+    b.keep(acc)
+  })
+}
+
+///|
+test "isolated dispatch - caps optional field x1000" (b : @bench.T) {
+  let caps : ProbeCaps = {
+    f: fn(a, c, s, t) { dispatch_probe_work(a, c, s, t) },
+    g: Some(fn(a, c, s, t) { dispatch_probe_work(a, c, s, t) }),
+  }
+  b.bench(fn() {
+    let mut acc = 0
+    for i in 0..<PROBE_CALLS {
+      match caps.g {
+        Some(f) => acc += f(i, i + 1, "x", i * 3)
+        None => ()
+      }
+    }
+    b.keep(acc)
+  })
+}

--- a/lang/json/companion/edit_messages_wbtest.mbt
+++ b/lang/json/companion/edit_messages_wbtest.mbt
@@ -1,0 +1,52 @@
+// Message-contract pins for apply_json_edit error paths (S3 lang/runtime
+// migration safety net — docs/plans/2026-06-11-s3-lang-runtime-extraction.md
+// Step 2). Expectations are frozen string literals; do not regenerate them
+// by calling the migrated path.
+
+// Note: the bridge's "no projection available" guard and the
+// "unhandled edit op" policy branch are unreachable through the JSON surface
+// (an empty JSON doc still yields a recovered projection root, and every
+// JsonEditOp is handled). Those two messages are pinned in lang/runtime's
+// own tests against a stubbed None projection / Ok(None) compute.
+
+///|
+test "apply_json_edit message pin: unwrap root scalar -> compute error" {
+  let editor = new_json_editor("target")
+  editor.set_text("42")
+  let root_id = match editor.get_proj_node() {
+    Some(p) => p.id()
+    None => {
+      fail("expected projection")
+      return
+    }
+  }
+  match apply_json_edit(editor, JsonEditOp::Unwrap(node_id=root_id), 0) {
+    Err(msg) => inspect(msg, content=(
+      #|unwrap requires exactly one child, found 0
+    ))
+    Ok(_) => fail("expected Err for unwrap on root scalar")
+  }
+}
+
+///|
+test "apply_json_edit message pin: absent node id -> compute error" {
+  // Take a high child id from a donor with many nodes, then apply against a
+  // single-scalar editor whose id space cannot contain it.
+  let donor = new_json_editor("donor")
+  donor.set_text("{\"a\": 1, \"b\": 2, \"c\": 3}")
+  let absent_id = match donor.get_proj_node() {
+    Some(p) => p.children[p.children.length() - 1].id()
+    None => {
+      fail("donor: expected projection")
+      return
+    }
+  }
+  let editor = new_json_editor("target")
+  editor.set_text("42")
+  match apply_json_edit(editor, JsonEditOp::Delete(node_id=absent_id), 0) {
+    Err(msg) => inspect(msg, content=(
+      #|node not found in source map
+    ))
+    Ok(_) => fail("expected Err for absent node id")
+  }
+}

--- a/lang/json/companion/edit_messages_wbtest.mbt
+++ b/lang/json/companion/edit_messages_wbtest.mbt
@@ -21,9 +21,13 @@ test "apply_json_edit message pin: unwrap root scalar -> compute error" {
     }
   }
   match apply_json_edit(editor, JsonEditOp::Unwrap(node_id=root_id), 0) {
-    Err(msg) => inspect(msg, content=(
-      #|unwrap requires exactly one child, found 0
-    ))
+    Err(msg) =>
+      inspect(
+        msg,
+        content=(
+          #|unwrap requires exactly one child, found 0
+        ),
+      )
     Ok(_) => fail("expected Err for unwrap on root scalar")
   }
 }
@@ -44,9 +48,13 @@ test "apply_json_edit message pin: absent node id -> compute error" {
   let editor = new_json_editor("target")
   editor.set_text("42")
   match apply_json_edit(editor, JsonEditOp::Delete(node_id=absent_id), 0) {
-    Err(msg) => inspect(msg, content=(
-      #|node not found in source map
-    ))
+    Err(msg) =>
+      inspect(
+        msg,
+        content=(
+          #|node not found in source map
+        ),
+      )
     Ok(_) => fail("expected Err for absent node id")
   }
 }

--- a/lang/json/companion/json_companion.mbt
+++ b/lang/json/companion/json_companion.mbt
@@ -3,6 +3,20 @@
 //   - structural-edit bridge (`apply_json_edit`)
 
 ///|
+/// Capability record for the JSON language family (S3 lang/runtime SPI).
+/// Default no_edit_policy (ErrorUnhandled) preserves JSON's
+/// "unhandled edit op: ..." behavior.
+let json_spec : @lang_runtime.LanguageSpec[
+  @json.JsonValue,
+  @json_edits.JsonEditOp,
+] = @lang_runtime.LanguageSpec::LanguageSpec(
+  make_parser=fn(s, rt) { @loom.new_parser(s, @json.json_grammar, runtime?=rt) },
+  build_memos=@json_proj.build_json_projection_memos,
+  compute_edit=@json_edits.compute_json_edit,
+  describe_op=fn(op) { op.to_string() },
+)
+
+///|
 /// Create a new SyncEditor for JSON documents.
 /// Uses the generic 3-memo pipeline (no ModuleProjection).
 pub fn new_json_editor(
@@ -10,13 +24,7 @@ pub fn new_json_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> @editor.SyncEditor[@json.JsonValue] {
-  @editor.SyncEditor::new_generic(
-    agent_id,
-    fn(s, rt) { @loom.new_parser(s, @json.json_grammar, runtime?=rt) },
-    @json_proj.build_json_projection_memos,
-    capture_timeout_ms~,
-    parent_runtime?,
-  )
+  json_spec.new_editor(agent_id, capture_timeout_ms~, parent_runtime?)
 }
 
 ///|
@@ -27,17 +35,5 @@ pub fn apply_json_edit(
   op : @json_edits.JsonEditOp,
   timestamp_ms : Int,
 ) -> Result[Unit, String] {
-  let source = editor.get_text()
-  guard editor.get_proj_node() is Some(proj) else {
-    return Err("no projection available")
-  }
-  let source_map = editor.get_source_map()
-  match @json_edits.compute_json_edit(op, source, proj, source_map) {
-    Ok(Some((edits, focus_hint))) => {
-      editor.apply_span_edits(edits, focus_hint, timestamp_ms)
-      Ok(())
-    }
-    Ok(None) => Err("unhandled edit op: " + op.to_string())
-    Err(msg) => Err(msg)
-  }
+  json_spec.apply_edit(editor, op, timestamp_ms)
 }

--- a/lang/json/companion/moon.pkg
+++ b/lang/json/companion/moon.pkg
@@ -2,6 +2,7 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/proj" @json_proj,
+  "dowdiness/canopy/lang/runtime" @lang_runtime,
   "dowdiness/incr",
   "dowdiness/json",
   "dowdiness/loom",

--- a/lang/runtime/README.md
+++ b/lang/runtime/README.md
@@ -1,0 +1,30 @@
+# lang/runtime
+
+Generic companion runtime — Tier 2 language SPI
+(`docs/decisions/2026-06-11-library-api-boundary.md`). Extracted in
+architecture-redesign stage S3
+(`docs/plans/2026-06-11-s3-lang-runtime-extraction.md`).
+
+A `LanguageSpec[T, Op]` bundles, per language family, the closures that
+differ between languages:
+
+- `make_parser` — grammar-specific parser construction
+- `build_memos` — the 3-memo projection pipeline (ProjNode, registry, SourceMap)
+- `compute_edit` — structural op → span-level text edits + focus hint
+- `describe_op` / `no_edit_policy` — how an unhandled op is reported
+  (JSON errors; Markdown no-ops)
+
+The machinery that does NOT differ lives here once: `new_editor` (SyncEditor
+construction via the generic 3-memo pipeline) and `apply_edit` (the
+structural-edit bridge: compute spans → `apply_span_edits` → cursor per
+FocusHint).
+
+Records over traits: MoonBit traits are Self-based without type parameters,
+and the orphan rule blocks downstream impls. Closure fields also discharge
+per-language bounds (`Eq`, `Show`) at construction time, so the record stays
+unbounded. Per-instance capabilities (e.g. lambda's eval/semantic closures
+capturing instance memos) are passed to `new_editor`, not stored in the spec.
+
+Dispatch cost: benchmarked free (S3 gate,
+`lang/json/companion/dispatch_benchmark.mbt`) — capability-record indirection
+is sub-ns/call against a ~3 ms keystroke pipeline, on both wasm-gc and js.

--- a/lang/runtime/language_spec.mbt
+++ b/lang/runtime/language_spec.mbt
@@ -1,0 +1,112 @@
+// Generic companion runtime (architecture redesign S3, Tier 2 language SPI —
+// docs/decisions/2026-06-11-library-api-boundary.md). One LanguageSpec per
+// language bundles the closures that differ between language families; the
+// editor-construction and structural-edit bridge machinery lives here once.
+// Closure record rather than a trait: MoonBit traits are Self-based without
+// type parameters, and the orphan rule blocks downstream impls — closures
+// also discharge per-language bounds (Eq, Show) at construction time so the
+// record itself stays unbounded.
+
+///|
+/// Policy for a `compute_edit` that returns `Ok(None)` (no span edits
+/// computed). Language families differ here: JSON treats an unhandled op as
+/// an error; Markdown treats it as a silent no-op (e.g. merge on first
+/// block).
+///
+/// `pub(all)`: language packages construct their policy variant when building
+/// their LanguageSpec — cross-package construction is the end-state use, not
+/// a migration transient (pub enum constructors are read-only cross-package).
+pub(all) enum NoEditPolicy {
+  ErrorUnhandled
+  SilentNoOp
+}
+
+///|
+/// Per-language capability record for the generic companion runtime.
+///
+/// `T` is the language's projection payload (e.g. JsonValue, Block, Term);
+/// `Op` is its structural-edit operation enum. `describe_op` renders an op
+/// for the `ErrorUnhandled` message — a closure field rather than a `Show`
+/// bound so the record stays unbounded.
+pub struct LanguageSpec[T, Op] {
+  priv make_parser : (String, @incr.Runtime?) -> @loom.Parser[T]
+  priv build_memos : (@loom.Parser[T]) -> (
+    @incr.Derived[@core.ProjNode[T]?],
+    @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
+    @incr.Derived[@core.SourceMap],
+  )
+  priv compute_edit : (Op, String, @core.ProjNode[T], @core.SourceMap) -> Result[
+    (Array[@core.SpanEdit], @core.FocusHint)?,
+    String,
+  ]
+  priv describe_op : (Op) -> String
+  priv no_edit_policy : NoEditPolicy
+}
+
+///|
+pub fn[T, Op] LanguageSpec::LanguageSpec(
+  make_parser~ : (String, @incr.Runtime?) -> @loom.Parser[T],
+  build_memos~ : (@loom.Parser[T]) -> (
+    @incr.Derived[@core.ProjNode[T]?],
+    @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
+    @incr.Derived[@core.SourceMap],
+  ),
+  compute_edit~ : (Op, String, @core.ProjNode[T], @core.SourceMap) -> Result[
+    (Array[@core.SpanEdit], @core.FocusHint)?,
+    String,
+  ],
+  describe_op~ : (Op) -> String,
+  no_edit_policy? : NoEditPolicy = ErrorUnhandled,
+) -> LanguageSpec[T, Op] {
+  { make_parser, build_memos, compute_edit, describe_op, no_edit_policy }
+}
+
+///|
+/// Construct a SyncEditor from this spec (standard 3-memo pipeline).
+/// Per-instance capabilities (e.g. lambda's eval/semantic closures capturing
+/// instance memos) are passed here, not stored in the spec.
+pub fn[T, Op] LanguageSpec::new_editor(
+  self : LanguageSpec[T, Op],
+  agent_id : String,
+  capture_timeout_ms? : Int = 500,
+  parent_runtime? : @incr.Runtime,
+  capabilities? : @editor.LanguageCapabilities[T] = @editor.LanguageCapabilities::default(),
+) -> @editor.SyncEditor[T] {
+  @editor.SyncEditor::new_generic(
+    agent_id,
+    self.make_parser,
+    self.build_memos,
+    capture_timeout_ms~,
+    parent_runtime?,
+    capabilities~,
+  )
+}
+
+///|
+/// Bridge a structural edit op into the text CRDT: compute span-level edits
+/// via the spec, then apply them through `SyncEditor::apply_span_edits`
+/// (incremental-parser-aware, recorded for undo, cursor per FocusHint).
+pub fn[T : Eq, Op] LanguageSpec::apply_edit(
+  self : LanguageSpec[T, Op],
+  editor : @editor.SyncEditor[T],
+  op : Op,
+  timestamp_ms : Int,
+) -> Result[Unit, String] {
+  let source = editor.get_text()
+  guard editor.get_proj_node() is Some(proj) else {
+    return Err("no projection available")
+  }
+  let source_map = editor.get_source_map()
+  match (self.compute_edit)(op, source, proj, source_map) {
+    Ok(Some((edits, focus_hint))) => {
+      editor.apply_span_edits(edits, focus_hint, timestamp_ms)
+      Ok(())
+    }
+    Ok(None) =>
+      match self.no_edit_policy {
+        ErrorUnhandled => Err("unhandled edit op: " + (self.describe_op)(op))
+        SilentNoOp => Ok(())
+      }
+    Err(msg) => Err(msg)
+  }
+}

--- a/lang/runtime/language_spec_test.mbt
+++ b/lang/runtime/language_spec_test.mbt
@@ -17,7 +17,9 @@ fn stub_spec(
   no_edit_policy : @runtime.NoEditPolicy,
 ) -> @runtime.LanguageSpec[@djson.JsonValue, String] {
   @runtime.LanguageSpec::LanguageSpec(
-    make_parser=fn(s, rt) { @loom.new_parser(s, @djson.json_grammar, runtime?=rt) },
+    make_parser=fn(s, rt) {
+      @loom.new_parser(s, @djson.json_grammar, runtime?=rt)
+    },
     build_memos=@json_proj.build_json_projection_memos,
     compute_edit~,
     describe_op=fn(op) { op },
@@ -30,7 +32,9 @@ test "apply_edit guard pin: None projection -> no projection available" {
   // build_memos variant whose proj memo always yields None — the
   // known-positive control for the guard branch.
   let spec : @runtime.LanguageSpec[@djson.JsonValue, String] = @runtime.LanguageSpec::LanguageSpec(
-    make_parser=fn(s, rt) { @loom.new_parser(s, @djson.json_grammar, runtime?=rt) },
+    make_parser=fn(s, rt) {
+      @loom.new_parser(s, @djson.json_grammar, runtime?=rt)
+    },
     build_memos=fn(parser) {
       let (_proj, registry, source_map) = @json_proj.build_json_projection_memos(
         parser,

--- a/lang/runtime/language_spec_test.mbt
+++ b/lang/runtime/language_spec_test.mbt
@@ -1,0 +1,95 @@
+// Blackbox tests for the LanguageSpec bridge. These pin the runtime-owned
+// message contract — the "no projection available" guard and the
+// NoEditPolicy branches — including paths a concrete language surface may
+// not be able to reach (an empty JSON doc still yields a recovered
+// projection root, so the guard is unreachable from lang/json/companion).
+// Stubs are built over the real JSON grammar/memo pipeline.
+
+///|
+/// Spec whose compute_edit is stubbed; Op = String so describe_op is identity.
+fn stub_spec(
+  compute_edit : (
+    String,
+    String,
+    @core.ProjNode[@djson.JsonValue],
+    @core.SourceMap,
+  ) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String],
+  no_edit_policy : @runtime.NoEditPolicy,
+) -> @runtime.LanguageSpec[@djson.JsonValue, String] {
+  @runtime.LanguageSpec::LanguageSpec(
+    make_parser=fn(s, rt) { @loom.new_parser(s, @djson.json_grammar, runtime?=rt) },
+    build_memos=@json_proj.build_json_projection_memos,
+    compute_edit~,
+    describe_op=fn(op) { op },
+    no_edit_policy~,
+  )
+}
+
+///|
+test "apply_edit guard pin: None projection -> no projection available" {
+  // build_memos variant whose proj memo always yields None — the
+  // known-positive control for the guard branch.
+  let spec : @runtime.LanguageSpec[@djson.JsonValue, String] = @runtime.LanguageSpec::LanguageSpec(
+    make_parser=fn(s, rt) { @loom.new_parser(s, @djson.json_grammar, runtime?=rt) },
+    build_memos=fn(parser) {
+      let (_proj, registry, source_map) = @json_proj.build_json_projection_memos(
+        parser,
+      )
+      let none_proj : @incr.Derived[@core.ProjNode[@djson.JsonValue]?] = @incr.Derived::Derived(
+        parser.runtime(),
+        fn() { None },
+      )
+      (none_proj, registry, source_map)
+    },
+    compute_edit=fn(_op, _src, _proj, _sm) {
+      Err("compute_edit must not be reached when projection is None")
+    },
+    describe_op=fn(op) { op },
+  )
+  let editor = spec.new_editor("guard-test")
+  editor.set_text("42")
+  match spec.apply_edit(editor, "AnyOp", 0) {
+    Err(msg) => inspect(msg, content="no projection available")
+    Ok(_) => fail("expected Err when projection is None")
+  }
+}
+
+///|
+test "apply_edit policy pin: Ok(None) + ErrorUnhandled -> unhandled edit op" {
+  let spec = stub_spec(
+    fn(_op, _src, _proj, _sm) { Ok(None) },
+    @runtime.NoEditPolicy::ErrorUnhandled,
+  )
+  let editor = spec.new_editor("policy-test")
+  editor.set_text("42")
+  match spec.apply_edit(editor, "StubOp", 0) {
+    Err(msg) => inspect(msg, content="unhandled edit op: StubOp")
+    Ok(_) => fail("expected Err under ErrorUnhandled")
+  }
+}
+
+///|
+test "apply_edit policy pin: Ok(None) + SilentNoOp -> Ok, doc untouched" {
+  let spec = stub_spec(
+    fn(_op, _src, _proj, _sm) { Ok(None) },
+    @runtime.NoEditPolicy::SilentNoOp,
+  )
+  let editor = spec.new_editor("noop-test")
+  editor.set_text("42")
+  inspect(spec.apply_edit(editor, "StubOp", 0) is Ok(_), content="true")
+  inspect(editor.get_text(), content="42")
+}
+
+///|
+test "apply_edit passthrough pin: compute Err propagates verbatim" {
+  let spec = stub_spec(
+    fn(_op, _src, _proj, _sm) { Err("boom") },
+    @runtime.NoEditPolicy::ErrorUnhandled,
+  )
+  let editor = spec.new_editor("err-test")
+  editor.set_text("42")
+  match spec.apply_edit(editor, "StubOp", 0) {
+    Err(msg) => inspect(msg, content="boom")
+    Ok(_) => fail("expected Err passthrough")
+  }
+}

--- a/lang/runtime/language_spec_test.mbt
+++ b/lang/runtime/language_spec_test.mbt
@@ -7,6 +7,8 @@
 
 ///|
 /// Spec whose compute_edit is stubbed; Op = String so describe_op is identity.
+/// build_memos defaults to the real JSON pipeline; the guard test overrides
+/// it with an always-None projection memo.
 fn stub_spec(
   compute_edit : (
     String,
@@ -15,12 +17,17 @@ fn stub_spec(
     @core.SourceMap,
   ) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String],
   no_edit_policy : @runtime.NoEditPolicy,
+  build_memos? : (@loom.Parser[@djson.JsonValue]) -> (
+    @incr.Derived[@core.ProjNode[@djson.JsonValue]?],
+    @incr.Derived[Map[@core.NodeId, @core.ProjNode[@djson.JsonValue]]],
+    @incr.Derived[@core.SourceMap],
+  ) = @json_proj.build_json_projection_memos,
 ) -> @runtime.LanguageSpec[@djson.JsonValue, String] {
   @runtime.LanguageSpec::LanguageSpec(
     make_parser=fn(s, rt) {
       @loom.new_parser(s, @djson.json_grammar, runtime?=rt)
     },
-    build_memos=@json_proj.build_json_projection_memos,
+    build_memos~,
     compute_edit~,
     describe_op=fn(op) { op },
     no_edit_policy~,
@@ -31,10 +38,11 @@ fn stub_spec(
 test "apply_edit guard pin: None projection -> no projection available" {
   // build_memos variant whose proj memo always yields None — the
   // known-positive control for the guard branch.
-  let spec : @runtime.LanguageSpec[@djson.JsonValue, String] = @runtime.LanguageSpec::LanguageSpec(
-    make_parser=fn(s, rt) {
-      @loom.new_parser(s, @djson.json_grammar, runtime?=rt)
+  let spec = stub_spec(
+    fn(_op, _src, _proj, _sm) {
+      Err("compute_edit must not be reached when projection is None")
     },
+    @runtime.NoEditPolicy::ErrorUnhandled,
     build_memos=fn(parser) {
       let (_proj, registry, source_map) = @json_proj.build_json_projection_memos(
         parser,
@@ -45,10 +53,6 @@ test "apply_edit guard pin: None projection -> no projection available" {
       )
       (none_proj, registry, source_map)
     },
-    compute_edit=fn(_op, _src, _proj, _sm) {
-      Err("compute_edit must not be reached when projection is None")
-    },
-    describe_op=fn(op) { op },
   )
   let editor = spec.new_editor("guard-test")
   editor.set_text("42")

--- a/lang/runtime/moon.pkg
+++ b/lang/runtime/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/editor",
+  "dowdiness/incr",
+  "dowdiness/loom",
+}
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/json/proj" @json_proj,
+  "dowdiness/incr",
+  "dowdiness/json" @djson,
+  "dowdiness/loom",
+} for "test"

--- a/lang/runtime/pkg.generated.mbti
+++ b/lang/runtime/pkg.generated.mbti
@@ -1,0 +1,31 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/runtime"
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/editor",
+  "dowdiness/incr/cells",
+  "dowdiness/loom/pipeline",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct LanguageSpec[T, Op] {
+  // private fields
+}
+pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@core.ProjNode[T]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[T]]], @cells.Derived[@core.SourceMap]), compute_edit~ : (Op, String, @core.ProjNode[T], @core.SourceMap) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String], describe_op~ : (Op) -> String, no_edit_policy? : NoEditPolicy) -> Self[T, Op]
+pub fn[T : Eq, Op] LanguageSpec::apply_edit(Self[T, Op], @editor.SyncEditor[T], Op, Int) -> Result[Unit, String]
+pub fn[T, Op] LanguageSpec::new_editor(Self[T, Op], String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : @editor.LanguageCapabilities[T]) -> @editor.SyncEditor[T]
+
+pub(all) enum NoEditPolicy {
+  ErrorUnhandled
+  SilentNoOp
+}
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

S3 (architecture redesign, PR1 of 3): create `lang/runtime` — the Tier-2 generic companion SPI — and migrate the JSON family onto it. Plan: `docs/plans/2026-06-11-s3-lang-runtime-extraction.md` (Codex-authored per "Opus orchestrates, Codex plans"); umbrella: `docs/plans/2026-06-11-architecture-redesign-proposal.md` § Steps 4.

### Benchmark gate (proposal § Notes unknown 3) — PASSED before any design work

Capability-record dispatch vs direct call on the `handle_text_intent` hot path (`moon bench --release`, both wasm-gc AND js targets):

| Benchmark | wasm-gc (direct / caps / opt-caps) | js |
|---|---|---|
| keystroke, 100-member JSON doc | 2.91 / 2.76 / 2.72 ms | 2.93 / 2.89 / 2.88 ms |
| keystroke, 1000-member doc | 33.6 / 33.9 / 34.7 ms | 35.6 / 37.5 / 35.3 ms |
| isolated dispatch ×1000 calls | 490 / 471 / 466 ns | 475 / 469 / 476 ns |

Orderings flip between variants across sizes/targets → noise, not systematic cost; indirection is sub-ns/call against a ~3 ms keystroke pipeline. **GO — no hot/cold direct-call split needed.** Benchmark kept in-tree (`lang/json/companion/dispatch_benchmark.mbt`).

### What moved

- **`lang/runtime`** (new): `LanguageSpec[T, Op]` closure record (`make_parser`, `build_memos`, `compute_edit`, `describe_op`, `no_edit_policy`) + the shared machinery: `new_editor` (3-memo SyncEditor construction) and `apply_edit` (structural-edit bridge: compute spans → `apply_span_edits` → FocusHint). Records over traits: MoonBit traits are Self-based without type params + orphan rule; closure fields discharge per-language bounds (Eq/Show) at construction so the record stays unbounded (`apply_edit` itself carries `T : Eq` as a plain fn bound).
- **`lang/json/companion`**: `new_json_editor` / `apply_json_edit` keep byte-identical signatures and delegate through a package-private `json_spec`. **Companion `.mbti` diff is empty** — ffi/json and all consumers untouched.
- `NoEditPolicy` is `pub(all)`: language packages construct their policy variant when building specs — end-state cross-package construction, not a migration transient (pub enum ctors are read-only cross-package, error 4036).

### Behavioral-drift mitigation (the named S3 risk)

- Error-message contract pinned in `edit_messages_wbtest.mbt` BEFORE the migration (frozen literals, captured against the pre-migration code) — passes unmodified after.
- Runtime-owned messages pinned in `lang/runtime/language_spec_test.mbt`, including the "no projection available" guard via a stubbed always-None projection memo (the guard is unreachable through the JSON surface — an empty JSON doc still yields a recovered projection root) and both `NoEditPolicy` branches.
- Full workspace `moon check` + `moon test` green: 257 wasm-gc / 1348 js / 46 native.

### Reuse check

- Reused: `SyncEditor::new_generic`, `apply_span_edits`, `@core.build_projection_memos` pipeline (via `@json_proj`), existing `compute_json_edit` passed as a bare function reference, `@incr.Derived::Derived` for the test stub.
- Checked, not used: `editor/capabilities.mbt` `LanguageCapabilities[T]` — orthogonal (view-pipeline extension points, per-instance); kept as the `capabilities?` param on `new_editor` rather than folded into the spec, since lambda builds them per instance from memo refs.
- New: `LanguageSpec[T, Op]` + `NoEditPolicy` — the S3 SPI itself; responsibility boundary documented in `lang/runtime/README.md`.

### Out of scope (per plan)

PR2: markdown migration. PR3: lambda with optional capability fields. S2 surfaces (`sync_session/`, `transport_ws/`, editor sync shims) untouched. No `ffi/host` work (S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
