### PR TITLE
feat(redesign): fold no-edit SPI + migrate markdown family (S3 PR2)

### DIFF
--- a/lang/json/companion/json_companion.mbt
+++ b/lang/json/companion/json_companion.mbt
@@ -4,8 +4,8 @@
 
 ///|
 /// Capability record for the JSON language family (S3 lang/runtime SPI).
-/// Default no_edit_policy (ErrorUnhandled) preserves JSON's
-/// "unhandled edit op: ..." behavior.
+/// JSON reports a no-edit (unhandled) op as an error, preserving the
+/// pre-migration "unhandled edit op: ..." message.
 let json_spec : @lang_runtime.LanguageSpec[
   @json.JsonValue,
   @json_edits.JsonEditOp,
@@ -13,7 +13,7 @@ let json_spec : @lang_runtime.LanguageSpec[
   make_parser=fn(s, rt) { @loom.new_parser(s, @json.json_grammar, runtime?=rt) },
   build_memos=@json_proj.build_json_projection_memos,
   compute_edit=@json_edits.compute_json_edit,
-  describe_op=fn(op) { op.to_string() },
+  on_no_edit=fn(op) { Err("unhandled edit op: " + op.to_string()) },
 )
 
 ///|

--- a/lang/markdown/companion/edit_messages_wbtest.mbt
+++ b/lang/markdown/companion/edit_messages_wbtest.mbt
@@ -1,0 +1,59 @@
+// Message/no-op contract pins for apply_markdown_edit error paths (S3
+// lang/runtime migration safety net —
+// docs/plans/2026-06-11-s3-lang-runtime-extraction.md Step 3). Expectations
+// are frozen; do not regenerate them by calling the migrated path.
+
+///|
+test "apply_markdown_edit pin: merge on first block -> silent no-op" {
+  // compute_markdown_edit returns Ok(None) for MergeWithPrevious on the
+  // first sibling; the companion contract maps that to Ok(()) with the
+  // document untouched (markdown's SilentNoOp policy, unlike JSON's error).
+  let ed = new_markdown_editor("pin")
+  ed.set_text("Hello\n\nWorld\n")
+  let first_id = match ed.get_proj_node() {
+    Some(p) => p.children[0].id()
+    None => {
+      fail("expected projection")
+      return
+    }
+  }
+  let result = apply_markdown_edit(
+    ed,
+    MarkdownEditOp::MergeWithPrevious(node_id=first_id),
+    0,
+  )
+  inspect(result is Ok(_), content="true")
+  // Non-vacuity: the no-op must leave the document byte-identical.
+  inspect(ed.get_text(), content=(
+    #|Hello
+    #|
+    #|World
+    #|
+  ))
+}
+
+///|
+test "apply_markdown_edit pin: absent node id -> compute error" {
+  // High child id from a donor doc with more blocks than the target has.
+  let donor = new_markdown_editor("donor")
+  donor.set_text("A\n\nB\n\nC\n\nD\n")
+  let absent_id = match donor.get_proj_node() {
+    Some(p) => p.children[p.children.length() - 1].id()
+    None => {
+      fail("donor: expected projection")
+      return
+    }
+  }
+  let ed = new_markdown_editor("target")
+  ed.set_text("Hello\n")
+  match apply_markdown_edit(
+    ed,
+    MarkdownEditOp::MergeWithPrevious(node_id=absent_id),
+    0,
+  ) {
+    Err(msg) => inspect(msg, content=(
+      #|node not found in projection tree: NodeId(3)
+    ))
+    Ok(_) => fail("expected Err for absent node id")
+  }
+}

--- a/lang/markdown/companion/edit_messages_wbtest.mbt
+++ b/lang/markdown/companion/edit_messages_wbtest.mbt
@@ -24,12 +24,15 @@ test "apply_markdown_edit pin: merge on first block -> silent no-op" {
   )
   inspect(result is Ok(_), content="true")
   // Non-vacuity: the no-op must leave the document byte-identical.
-  inspect(ed.get_text(), content=(
-    #|Hello
-    #|
-    #|World
-    #|
-  ))
+  inspect(
+    ed.get_text(),
+    content=(
+      #|Hello
+      #|
+      #|World
+      #|
+    ),
+  )
 }
 
 ///|
@@ -46,14 +49,19 @@ test "apply_markdown_edit pin: absent node id -> compute error" {
   }
   let ed = new_markdown_editor("target")
   ed.set_text("Hello\n")
-  match apply_markdown_edit(
-    ed,
-    MarkdownEditOp::MergeWithPrevious(node_id=absent_id),
-    0,
-  ) {
-    Err(msg) => inspect(msg, content=(
-      #|node not found in projection tree: NodeId(3)
-    ))
+  match
+    apply_markdown_edit(
+      ed,
+      MarkdownEditOp::MergeWithPrevious(node_id=absent_id),
+      0,
+    ) {
+    Err(msg) =>
+      inspect(
+        msg,
+        content=(
+          #|node not found in projection tree: NodeId(3)
+        ),
+      )
     Ok(_) => fail("expected Err for absent node id")
   }
 }

--- a/lang/markdown/companion/edit_messages_wbtest.mbt
+++ b/lang/markdown/companion/edit_messages_wbtest.mbt
@@ -10,16 +10,12 @@ test "apply_markdown_edit pin: merge on first block -> silent no-op" {
   // document untouched (unlike JSON, which reports an unhandled-op error).
   let ed = new_markdown_editor("pin")
   ed.set_text("Hello\n\nWorld\n")
-  let first_id = match ed.get_proj_node() {
-    Some(p) => p.children[0].id()
-    None => {
-      fail("expected projection")
-      return
-    }
+  guard ed.get_proj_node() is Some(p) && p.children is [first, ..] else {
+    fail("expected projection with children")
   }
   let result = apply_markdown_edit(
     ed,
-    MarkdownEditOp::MergeWithPrevious(node_id=first_id),
+    MarkdownEditOp::MergeWithPrevious(node_id=first.id()),
     0,
   )
   inspect(result is Ok(_), content="true")
@@ -40,19 +36,15 @@ test "apply_markdown_edit pin: absent node id -> compute error" {
   // High child id from a donor doc with more blocks than the target has.
   let donor = new_markdown_editor("donor")
   donor.set_text("A\n\nB\n\nC\n\nD\n")
-  let absent_id = match donor.get_proj_node() {
-    Some(p) => p.children[p.children.length() - 1].id()
-    None => {
-      fail("donor: expected projection")
-      return
-    }
+  guard donor.get_proj_node() is Some(p) && p.children is [.., last] else {
+    fail("donor: expected projection with children")
   }
   let ed = new_markdown_editor("target")
   ed.set_text("Hello\n")
   match
     apply_markdown_edit(
       ed,
-      MarkdownEditOp::MergeWithPrevious(node_id=absent_id),
+      MarkdownEditOp::MergeWithPrevious(node_id=last.id()),
       0,
     ) {
     Err(msg) =>

--- a/lang/markdown/companion/edit_messages_wbtest.mbt
+++ b/lang/markdown/companion/edit_messages_wbtest.mbt
@@ -6,8 +6,8 @@
 ///|
 test "apply_markdown_edit pin: merge on first block -> silent no-op" {
   // compute_markdown_edit returns Ok(None) for MergeWithPrevious on the
-  // first sibling; the companion contract maps that to Ok(()) with the
-  // document untouched (markdown's SilentNoOp policy, unlike JSON's error).
+  // first sibling; markdown's on_no_edit maps that to Ok(()) with the
+  // document untouched (unlike JSON, which reports an unhandled-op error).
   let ed = new_markdown_editor("pin")
   ed.set_text("Hello\n\nWorld\n")
   let first_id = match ed.get_proj_node() {

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -3,19 +3,28 @@
 ///   - structural-edit bridge (`apply_markdown_edit`)
 
 ///|
+/// Capability record for the Markdown language family (S3 lang/runtime SPI).
+/// A no-edit op is a silent no-op (e.g. merge on first block), unlike JSON.
+let markdown_spec : @lang_runtime.LanguageSpec[
+  @markdown.Block,
+  @md_edits.MarkdownEditOp,
+] = @lang_runtime.LanguageSpec::LanguageSpec(
+  make_parser=fn(s, rt) {
+    @loom.new_parser(s, @markdown.markdown_grammar, runtime?=rt)
+  },
+  build_memos=@md_proj.build_markdown_projection_memos,
+  compute_edit=@md_edits.compute_markdown_edit,
+  on_no_edit=fn(_op) { Ok(()) },
+)
+
+///|
 /// Construct a SyncEditor[@markdown.Block] using the standard 3-memo pipeline.
 pub fn new_markdown_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> @editor.SyncEditor[@markdown.Block] {
-  @editor.SyncEditor::new_generic(
-    agent_id,
-    fn(s, rt) { @loom.new_parser(s, @markdown.markdown_grammar, runtime?=rt) },
-    @md_proj.build_markdown_projection_memos,
-    capture_timeout_ms~,
-    parent_runtime?,
-  )
+  markdown_spec.new_editor(agent_id, capture_timeout_ms~, parent_runtime?)
 }
 
 ///|
@@ -95,17 +104,5 @@ pub fn apply_markdown_edit(
   op : @md_edits.MarkdownEditOp,
   timestamp_ms : Int,
 ) -> Result[Unit, String] {
-  let source = editor.get_text()
-  guard editor.get_proj_node() is Some(proj) else {
-    return Err("no projection available")
-  }
-  let source_map = editor.get_source_map()
-  match @md_edits.compute_markdown_edit(op, source, proj, source_map) {
-    Ok(Some((edits, focus_hint))) => {
-      editor.apply_span_edits(edits, focus_hint, timestamp_ms)
-      Ok(())
-    }
-    Ok(None) => Ok(()) // no-op (e.g., merge on first block)
-    Err(msg) => Err(msg)
-  }
+  markdown_spec.apply_edit(editor, op, timestamp_ms)
 }

--- a/lang/markdown/companion/moon.pkg
+++ b/lang/markdown/companion/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/proj" @md_proj,
+  "dowdiness/canopy/lang/runtime" @lang_runtime,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/incr",
   "dowdiness/markdown",

--- a/lang/runtime/README.md
+++ b/lang/runtime/README.md
@@ -11,8 +11,8 @@ differ between languages:
 - `make_parser` — grammar-specific parser construction
 - `build_memos` — the 3-memo projection pipeline (ProjNode, registry, SourceMap)
 - `compute_edit` — structural op → span-level text edits + focus hint
-- `describe_op` / `no_edit_policy` — how an unhandled op is reported
-  (JSON errors; Markdown no-ops)
+- `on_no_edit` — what the language does when `compute_edit` produces no
+  edits (JSON reports "unhandled edit op: ..."; Markdown silently no-ops)
 
 The machinery that does NOT differ lives here once: `new_editor` (SyncEditor
 construction via the generic 3-memo pipeline) and `apply_edit` (the

--- a/lang/runtime/language_spec.mbt
+++ b/lang/runtime/language_spec.mbt
@@ -8,26 +8,16 @@
 // record itself stays unbounded.
 
 ///|
-/// Policy for a `compute_edit` that returns `Ok(None)` (no span edits
-/// computed). Language families differ here: JSON treats an unhandled op as
-/// an error; Markdown treats it as a silent no-op (e.g. merge on first
-/// block).
-///
-/// `pub(all)`: language packages construct their policy variant when building
-/// their LanguageSpec — cross-package construction is the end-state use, not
-/// a migration transient (pub enum constructors are read-only cross-package).
-pub(all) enum NoEditPolicy {
-  ErrorUnhandled
-  SilentNoOp
-}
-
-///|
 /// Per-language capability record for the generic companion runtime.
 ///
 /// `T` is the language's projection payload (e.g. JsonValue, Block, Term);
-/// `Op` is its structural-edit operation enum. `describe_op` renders an op
-/// for the `ErrorUnhandled` message — a closure field rather than a `Show`
-/// bound so the record stays unbounded.
+/// `Op` is its structural-edit operation enum. `on_no_edit` answers "what
+/// should this language do when `compute_edit` produced no span edits
+/// (`Ok(None)`)?" — JSON reports an unhandled-op error, Markdown treats it
+/// as a silent no-op (e.g. merge on first block). A closure field rather
+/// than a policy enum + `Show` bound, so the no-edit behavior (and any
+/// message rendering it needs) stays language-owned and the record stays
+/// unbounded.
 pub struct LanguageSpec[T, Op] {
   priv make_parser : (String, @incr.Runtime?) -> @loom.Parser[T]
   priv build_memos : (@loom.Parser[T]) -> (
@@ -39,8 +29,7 @@ pub struct LanguageSpec[T, Op] {
     (Array[@core.SpanEdit], @core.FocusHint)?,
     String,
   ]
-  priv describe_op : (Op) -> String
-  priv no_edit_policy : NoEditPolicy
+  priv on_no_edit : (Op) -> Result[Unit, String]
 }
 
 ///|
@@ -55,10 +44,9 @@ pub fn[T, Op] LanguageSpec::LanguageSpec(
     (Array[@core.SpanEdit], @core.FocusHint)?,
     String,
   ],
-  describe_op~ : (Op) -> String,
-  no_edit_policy? : NoEditPolicy = ErrorUnhandled,
+  on_no_edit~ : (Op) -> Result[Unit, String],
 ) -> LanguageSpec[T, Op] {
-  { make_parser, build_memos, compute_edit, describe_op, no_edit_policy }
+  { make_parser, build_memos, compute_edit, on_no_edit }
 }
 
 ///|
@@ -102,11 +90,7 @@ pub fn[T : Eq, Op] LanguageSpec::apply_edit(
       editor.apply_span_edits(edits, focus_hint, timestamp_ms)
       Ok(())
     }
-    Ok(None) =>
-      match self.no_edit_policy {
-        ErrorUnhandled => Err("unhandled edit op: " + (self.describe_op)(op))
-        SilentNoOp => Ok(())
-      }
+    Ok(None) => (self.on_no_edit)(op)
     Err(msg) => Err(msg)
   }
 }

--- a/lang/runtime/language_spec_test.mbt
+++ b/lang/runtime/language_spec_test.mbt
@@ -1,6 +1,6 @@
 // Blackbox tests for the LanguageSpec bridge. These pin the runtime-owned
-// message contract — the "no projection available" guard and the
-// NoEditPolicy branches — including paths a concrete language surface may
+// contract — the "no projection available" guard and the Ok(None) →
+// on_no_edit routing — including paths a concrete language surface may
 // not be able to reach (an empty JSON doc still yields a recovered
 // projection root, so the guard is unreachable from lang/json/companion).
 // Stubs are built over the real JSON grammar/memo pipeline.

--- a/lang/runtime/language_spec_test.mbt
+++ b/lang/runtime/language_spec_test.mbt
@@ -6,7 +6,7 @@
 // Stubs are built over the real JSON grammar/memo pipeline.
 
 ///|
-/// Spec whose compute_edit is stubbed; Op = String so describe_op is identity.
+/// Spec whose compute_edit and on_no_edit are stubbed; Op = String.
 /// build_memos defaults to the real JSON pipeline; the guard test overrides
 /// it with an always-None projection memo.
 fn stub_spec(
@@ -16,7 +16,7 @@ fn stub_spec(
     @core.ProjNode[@djson.JsonValue],
     @core.SourceMap,
   ) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String],
-  no_edit_policy : @runtime.NoEditPolicy,
+  on_no_edit : (String) -> Result[Unit, String],
   build_memos? : (@loom.Parser[@djson.JsonValue]) -> (
     @incr.Derived[@core.ProjNode[@djson.JsonValue]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[@djson.JsonValue]]],
@@ -29,8 +29,7 @@ fn stub_spec(
     },
     build_memos~,
     compute_edit~,
-    describe_op=fn(op) { op },
-    no_edit_policy~,
+    on_no_edit~,
   )
 }
 
@@ -42,7 +41,7 @@ test "apply_edit guard pin: None projection -> no projection available" {
     fn(_op, _src, _proj, _sm) {
       Err("compute_edit must not be reached when projection is None")
     },
-    @runtime.NoEditPolicy::ErrorUnhandled,
+    fn(_op) { Err("on_no_edit must not be reached when projection is None") },
     build_memos=fn(parser) {
       let (_proj, registry, source_map) = @json_proj.build_json_projection_memos(
         parser,
@@ -63,25 +62,23 @@ test "apply_edit guard pin: None projection -> no projection available" {
 }
 
 ///|
-test "apply_edit policy pin: Ok(None) + ErrorUnhandled -> unhandled edit op" {
-  let spec = stub_spec(
-    fn(_op, _src, _proj, _sm) { Ok(None) },
-    @runtime.NoEditPolicy::ErrorUnhandled,
-  )
-  let editor = spec.new_editor("policy-test")
+test "apply_edit no-edit pin: Ok(None) routes the op to on_no_edit" {
+  let spec = stub_spec(fn(_op, _src, _proj, _sm) { Ok(None) }, fn(op) {
+    Err("unhandled edit op: " + op)
+  })
+  let editor = spec.new_editor("no-edit-test")
   editor.set_text("42")
   match spec.apply_edit(editor, "StubOp", 0) {
     Err(msg) => inspect(msg, content="unhandled edit op: StubOp")
-    Ok(_) => fail("expected Err under ErrorUnhandled")
+    Ok(_) => fail("expected Err from on_no_edit")
   }
 }
 
 ///|
-test "apply_edit policy pin: Ok(None) + SilentNoOp -> Ok, doc untouched" {
-  let spec = stub_spec(
-    fn(_op, _src, _proj, _sm) { Ok(None) },
-    @runtime.NoEditPolicy::SilentNoOp,
-  )
+test "apply_edit no-edit pin: Ok(None) + Ok on_no_edit -> doc untouched" {
+  let spec = stub_spec(fn(_op, _src, _proj, _sm) { Ok(None) }, fn(_op) {
+    Ok(())
+  })
   let editor = spec.new_editor("noop-test")
   editor.set_text("42")
   inspect(spec.apply_edit(editor, "StubOp", 0) is Ok(_), content="true")
@@ -90,10 +87,9 @@ test "apply_edit policy pin: Ok(None) + SilentNoOp -> Ok, doc untouched" {
 
 ///|
 test "apply_edit passthrough pin: compute Err propagates verbatim" {
-  let spec = stub_spec(
-    fn(_op, _src, _proj, _sm) { Err("boom") },
-    @runtime.NoEditPolicy::ErrorUnhandled,
-  )
+  let spec = stub_spec(fn(_op, _src, _proj, _sm) { Err("boom") }, fn(_op) {
+    Err("on_no_edit must not be reached on compute Err")
+  })
   let editor = spec.new_editor("err-test")
   editor.set_text("42")
   match spec.apply_edit(editor, "StubOp", 0) {

--- a/lang/runtime/pkg.generated.mbti
+++ b/lang/runtime/pkg.generated.mbti
@@ -16,14 +16,9 @@ import {
 pub struct LanguageSpec[T, Op] {
   // private fields
 }
-pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@core.ProjNode[T]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[T]]], @cells.Derived[@core.SourceMap]), compute_edit~ : (Op, String, @core.ProjNode[T], @core.SourceMap) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String], describe_op~ : (Op) -> String, no_edit_policy? : NoEditPolicy) -> Self[T, Op]
+pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@core.ProjNode[T]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[T]]], @cells.Derived[@core.SourceMap]), compute_edit~ : (Op, String, @core.ProjNode[T], @core.SourceMap) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String], on_no_edit~ : (Op) -> Result[Unit, String]) -> Self[T, Op]
 pub fn[T : Eq, Op] LanguageSpec::apply_edit(Self[T, Op], @editor.SyncEditor[T], Op, Int) -> Result[Unit, String]
 pub fn[T, Op] LanguageSpec::new_editor(Self[T, Op], String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : @editor.LanguageCapabilities[T]) -> @editor.SyncEditor[T]
-
-pub(all) enum NoEditPolicy {
-  ErrorUnhandled
-  SilentNoOp
-}
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

S3 (architecture redesign, PR2 of 3): migrate the **Markdown family** onto `lang/runtime`, after amending the `LanguageSpec` SPI shape that grounding markdown exposed as json-biased. Plan: `docs/plans/2026-06-11-s3-lang-runtime-extraction.md` Step 3; PR1: #584.

### SPI amend (Option B, user-approved)

Markdown broke the PR1 SPI in review-by-second-language: `MarkdownEditOp` derives `(Debug, Eq)` — no `Show`/`to_string` — yet the spec required a `describe_op` renderer that markdown's silent-no-op path would never call. `describe_op` and `NoEditPolicy` were not independent axes (the renderer only matters on the error-producing path), so both are folded into one language-owned field:

```
on_no_edit : (Op) -> Result[Unit, String]
```

- JSON: `Err("unhandled edit op: " + op.to_string())` — exact pre-migration message, now language-owned.
- Markdown: `Ok(())` — merge-on-first-block stays a silent no-op.
- The `pub(all) enum NoEditPolicy` surface is deleted entirely.
- Same-day amend of an unconsumed Tier-2 SPI (shipped this cycle in #584, zero external consumers, no release in between) — no deprecation shim per the S0 ADR.

### Markdown migration

`new_markdown_editor` / `apply_markdown_edit` keep byte-identical signatures and delegate via a package-private `markdown_spec`. `export_markdown_text` + ZWSP helpers untouched. **Companion `.mbti` diff is empty**; the only interface change in the PR is the intended `lang/runtime` constructor signature + enum deletion.

### Behavioral-drift mitigation

- Markdown pins written PRE-migration (`edit_messages_wbtest.mbt`): merge-on-first-block → `Ok` with byte-identical doc snapshot (non-vacuity), absent node id → exact `"node not found in projection tree: NodeId(3)"`. Pass unmodified post-migration.
- JSON pins from #584 pass unmodified through the SPI amend.
- `lang/runtime` contract tests updated: guard pin + `Ok(None)` → `on_no_edit` routing (both Err and Ok shapes) + compute-Err passthrough.
- Full workspace green: 257 wasm-gc / 1350 js / 46 native.

### Reuse check

- Reused: `LanguageSpec` SPI from #584 (`new_editor`, `apply_edit`), `compute_markdown_edit` passed as a bare function reference, `build_markdown_projection_memos`.
- Checked, not used: a shared spec-construction helper across json/markdown companions — per-language records ARE the SPI shape; the duplication is the declared extension template (ADDING_A_LANGUAGE).
- New: none beyond the `on_no_edit` field replacing two fields.

### Out of scope

PR3: lambda with optional capability fields (eval/scope/semantic), migrating LAST per plan. S2 surfaces untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
