### PR TITLE
feat(redesign): extract ffi/host registry + migrate language FFI packages (S4 PR1)

### DIFF
--- a/docs/plans/2026-06-12-s4-ffi-host-extraction.md
+++ b/docs/plans/2026-06-12-s4-ffi-host-extraction.md
@@ -1,0 +1,383 @@
+# S4 FFI Host Extraction and Export Manifest Plan
+
+## Context
+
+S4 implements the host-binding part of the architecture redesign after S3's
+language-runtime boundary work. The target is narrow: extract repeated
+Tier-3 FFI host wiring from `ffi/lambda`, `ffi/json`, and `ffi/markdown` into a
+shared internal `ffi/host` package while preserving each `ffi/<L>` package as
+its own MoonBit JS link root. The extraction must not change the editor sync
+surfaces frozen in S2, the `lang/runtime` design from S3, the lambda language
+exception, or the per-entry bundle split that motivated the hand-maintained
+FFI/re-export arrangement.
+
+The measurement spike at `33db8db` is evidence only. It showed that a generic
+`HostRegistry[H]` shape containing per-handle bookkeeping, view-state
+bookkeeping, and a coordinator destroy gateway preserved per-entry Vite chunks
+with sub-kB deltas. Production work must re-derive that shape with intentional
+visibility, constructor, test, and `.mbti` treatment rather than merging the
+spike verbatim.
+
+The two S4 deliverables are deliberately separated by PR gate:
+
+- PR1 extracts `ffi/host` and migrates the three language FFI packages onto it.
+- PR2 introduces declared export manifests and a discrepancy-reporting check
+  while keeping the current hand-maintained export files authoritative.
+
+Deletion of `examples/ideal/main/crdt_reexport.mbt` is out of scope for S4. It
+is a later PR after one release of parallel-run, gated on TS typecheck CI,
+bundle measurement, and runtime smoke across lambda, JSON, and Markdown FFI
+surfaces.
+
+## Decided design summary
+
+`ffi/host` is a Tier-3 internal library dependency. It owns only generic host
+bookkeeping:
+
+- a handle map keyed by the exported integer handle
+- a per-handle `@editor.ViewUpdateState` map for the ordinary view-patch path
+- access to the shared `@workspace.Coordinator` through caller-supplied
+  coordinator instances
+- a destroy gateway that calls `Coordinator::destroy_editor` and removes FFI
+  bookkeeping only after the coordinator accepts destruction
+
+Each `ffi/<L>` remains a separate link root and keeps one process-global
+coordinator instance. Each language package owns its language-specific handle
+record, protected-cell bundle, editor/companion construction, exported function
+names, JSON parsing/serialization choices, and any extra state.
+
+The production registry should be public as a type from `ffi/host`, but not a
+blanket data bag. The planned API is:
+
+- `pub struct HostRegistry[H]` with fields not exported for arbitrary
+  cross-package assignment.
+- A named constructor following the repo convention:
+  `HostRegistry::HostRegistry`.
+- Methods for inserting, looking up, removing, clearing test state, creating or
+  retrieving a view state, and destroying through the coordinator.
+- Any method that mutates internal maps lives in `ffi/host`, because methods
+  must be defined in the owning package and cross-package `pub struct` fields
+  are read-only.
+
+If MoonBit's visibility rules require callers to mutate registry internals
+directly, prefer a small method over `pub(all)` fields. Use `pub(all)` only as a
+last resort for the `HostRegistry` fields, and document the exact compiler
+constraint in the PR body and `.mbti` review. Language handle records and
+protected-cell bundles stay private to their `ffi/<L>` package unless an
+existing white-box test can no longer test the intended behavior without
+promoting visibility; in that case, move or rewrite the test rather than
+exporting internals.
+
+Scope decision: PR1 extracts only registry, ordinary view-state bookkeeping,
+and the coordinator destroy gateway. It does not generalize the
+assemble-handle pattern or protected-cell bundles. The rationale is that
+assembly is where language-specific editor constructors, companion outputs,
+protected-cell constructors, lambda's `last_created_handle`, and lambda's
+analysis attachment disposal semantics meet. Protected-cell bundles are also
+language typed: JSON/Markdown have the seven-cell editor subset, while lambda
+has ten cells plus companion-derived projection/eval/typecheck cells. Forcing
+those into a host protocol would make lambda extras mandatory or create dead
+configuration for JSON and Markdown. Minimal extraction captures the proven
+duplication without weakening the language boundary.
+
+## Step 1 — Add `ffi/host` with registry contract and tests
+
+Create the `ffi/host` package with imports limited to `editor` and
+`workspace/coordinator`. Define the generic registry contract around
+handle-map lifecycle, ordinary view-state lifecycle, and coordinator-mediated
+destroy. The host package must not import any language package, `llm`, `relay`,
+`transport_ws`, JSON/Markdown/Lambda AST packages, or example app package.
+
+Add host-local tests for behavior that is independent of language handles:
+view-state get-or-create returns the same state for the same handle, removing a
+handle removes its view state, destroy refusal leaves bookkeeping intact, and
+destroy success removes bookkeeping. If a realistic destroy test needs a
+registered coordinator editor, use the smallest host-local test handle shape
+and protected-read surface available without depending on a language package.
+
+Expected compile breakpoint: none outside `ffi/host` until language packages
+import it. The first `moon check` may expose MoonBit visibility constraints
+around mutating map fields through methods; fix by adding owning-package
+methods, not by exposing fields.
+
+Expected `.mbti` diff: a new `ffi/host/pkg.generated.mbti` containing only the
+intended `HostRegistry` type and its constructor/methods. Existing
+`ffi/{lambda,json,markdown}/pkg.generated.mbti` files should not change in this
+step.
+
+Verification:
+
+- `NEW_MOON_MOD=0 moon check`
+- `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/host`
+- `NEW_MOON_MOD=0 moon info` and inspect `git diff '*.mbti'`
+- No bundle build required before callers import `ffi/host`
+
+## Step 2 — Migrate JSON FFI onto `ffi/host`
+
+Import `ffi/host` in `ffi/json/moon.pkg` and replace the local `json_handles`
+and `json_view_states` globals with one JSON registry instance. Keep the
+JSON-local coordinator, `JsonHandle`, `JsonProtectedCells`,
+`assemble_json_handle`, and all exported function names unchanged. The JSON
+handle record remains private and still carries `editor`, `editor_id`, and
+`cells`.
+
+The migration order is: add the host dependency, introduce the JSON registry,
+change `assemble_json_handle` to register handles through the host method, then
+port read callsites from direct map access to registry lookup. Port
+`json_compute_view_patches_json` to get its `ViewUpdateState` through the host.
+Finally port `destroy_json_editor` and test cleanup helpers to host methods.
+This order keeps lookup failures easy to diagnose before destroy semantics are
+changed.
+
+White-box tests in `ffi/json/lifecycle_phase1_wbtest.mbt` currently write
+private `json_handles` and `json_view_states` state. Rewrite them to exercise
+the JSON registry through host methods while still validating the JSON
+protected-cell fields from the JSON package. Do not move JSON protected-cell
+tests into `ffi/host`; host cannot know the seven typed cells.
+
+Expected compile breakpoints: references to `json_handles` and
+`json_view_states` fail after the globals are removed; fix package by package
+inside `ffi/json` before touching other languages. If field access into the
+registry fails due to cross-package read-only rules, add a host method for the
+specific operation.
+
+Expected `.mbti` diff: `ffi/json/pkg.generated.mbti` should be unchanged,
+because the JS export surface is unchanged. Any diff must be explained as an
+accidental API leak or corrected before the PR proceeds.
+
+Verification:
+
+- `NEW_MOON_MOD=0 moon check`
+- `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/json`
+- `NEW_MOON_MOD=0 moon info` and inspect `git diff 'ffi/json/pkg.generated.mbti' 'ffi/host/pkg.generated.mbti'`
+- `cd examples/web && npm run build`; record JSON, Markdown, and Lambda chunk
+  sizes even though only JSON was migrated
+
+## Step 3 — Migrate Markdown FFI onto `ffi/host`
+
+Repeat the JSON migration for `ffi/markdown`, keeping the Markdown-local
+coordinator, `MarkdownHandle`, `MarkdownProtectedCells`,
+`assemble_markdown_handle`, structural-edit parsing, sentinel export, and
+manual Markdown view-patch construction unchanged.
+
+The Markdown view path is not identical to JSON: it computes patches manually
+from protected reads, source text, diagnostics, and `diff_view_nodes`. Only the
+state storage moves to `ffi/host`; the patch algorithm stays in
+`ffi/markdown`. This protects the Markdown-specific empty paragraph sentinel
+and diagnostic behavior from being pulled into a generic host API.
+
+Rewrite `ffi/markdown/lifecycle_phase1_wbtest.mbt` cleanup and direct
+bookkeeping checks against the registry methods. Keep tests that validate
+seven-cell protected reads and Markdown patch behavior in the Markdown package.
+
+Expected compile breakpoints: references to `markdown_handles` and
+`markdown_view_states` fail after replacement. Fix all Markdown files and
+white-box tests before moving to lambda so error output stays localized.
+
+Expected `.mbti` diff: `ffi/markdown/pkg.generated.mbti` should be unchanged.
+Only `ffi/host/pkg.generated.mbti` should have the intended new host API.
+
+Verification:
+
+- `NEW_MOON_MOD=0 moon check`
+- `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/markdown`
+- `NEW_MOON_MOD=0 moon info` and inspect `git diff 'ffi/markdown/pkg.generated.mbti' 'ffi/host/pkg.generated.mbti'`
+- `cd examples/web && npm run build`; record JSON, Markdown, and Lambda chunk
+  sizes
+
+## Step 4 — Migrate Lambda FFI onto `ffi/host`
+
+Migrate lambda last because its FFI package is the largest and contains
+language-local extras. Replace only `lambda_handles` and ordinary `view_states`
+with the host registry. Keep all of the following in `ffi/lambda`: the
+coordinator singleton, `LambdaHandle`, `LambdaProtectedCells`, companion
+storage, `last_created_handle`, `pretty_view_states`, LLM functions,
+relay-room state, WebSocket wiring, semantic/pretty projection accessors,
+undo functions, and analysis attachment disposal.
+
+The destroy flow must preserve lambda's current ordering: a refused
+coordinator destroy leaves FFI bookkeeping and analysis attachment intact; an
+accepted destroy removes the ordinary host handle/view state, removes the
+pretty view state, clears `last_created_handle` when appropriate, then disposes
+the companion analysis attachment. Do not make `pretty_view_states` part of
+`ffi/host`; it is lambda-specific state for a separate projection surface.
+
+Rename mechanics must be deliberate. The spike showed that broad textual
+renames can corrupt embedding identifiers such as `clear_lambda_handles`. Use
+semantic rename where possible, or scoped `rg` plus manual edits restricted to
+the FFI bookkeeping identifiers. Do not rewrite exported JS names or embedded
+protocol strings.
+
+Rewrite lambda white-box tests that directly clear or inspect `lambda_handles`
+and `view_states` to go through host registry methods. Tests that validate
+workspace memos, semantic projection, WebSocket integration, relay leaks,
+pretty patches, or protected lambda-specific cells stay in `ffi/lambda`.
+
+Expected compile breakpoints: most lambda files reference `lambda_handles`, so
+expect failures in lifecycle, diagnostics, undo, intent, semantic, ephemeral,
+view, pretty, ws, and wbtests after the registry replacement. Fix in this
+order: lifecycle construction and simple get/set, ordinary view patches,
+diagnostics/projection accessors, undo/intent/ephemeral/semantic/pretty/ws
+callers, then tests. This keeps the package compiling around a single
+canonical lookup path.
+
+Expected `.mbti` diff: `ffi/lambda/pkg.generated.mbti` should be unchanged.
+Any missing, added, or renamed export is a regression. `ffi/host` remains the
+only new public package surface.
+
+Verification:
+
+- `NEW_MOON_MOD=0 moon check`
+- `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/lambda`
+- `NEW_MOON_MOD=0 moon info` and inspect `git diff 'ffi/lambda/pkg.generated.mbti' 'ffi/host/pkg.generated.mbti'`
+- `cd examples/web && npm run build`; record JSON, Markdown, and Lambda chunk
+  sizes
+
+## Step 5 — Host extraction integration sweep
+
+After all three packages compile, remove dead local helper comments that still
+describe per-language handle maps, update FFI README text where it describes
+the lifecycle owner, and verify import boundaries. The sweep should establish
+that `ffi/host` is a dependency of `ffi/{lambda,json,markdown}` only, and that
+none of the three FFI packages stopped being a JS link root.
+
+Review `moon.pkg` brace manifests manually. The FFI export arrays in
+`ffi/lambda/moon.pkg`, `ffi/json/moon.pkg`, and `ffi/markdown/moon.pkg` must
+remain byte-for-byte equivalent except for formatting produced by accepted
+tooling. The host package must have no JS export list.
+
+Expected compile breakpoints: duplicate or stale package imports after the
+last migration. Fix by removing unused imports and keeping language-specific
+imports in language packages, not by moving extra behavior to `ffi/host`.
+
+Verification:
+
+- `NEW_MOON_MOD=0 moon check`
+- `NEW_MOON_MOD=0 moon test`
+- `NEW_MOON_MOD=0 moon info` and inspect all `git diff '*.mbti'`
+- `cd examples/web && npm run build`; include the required PR body table with
+  rows JSON, Markdown, Lambda and columns clean main, with change, delta, gzip
+
+## Step 6 — Add declared export manifests and discrepancy check
+
+In a separate PR, introduce a declared manifest per app as the single source of
+truth for expected FFI exports. Start with the lambda app seam because it has
+both live layers today: `ffi/lambda/moon.pkg` and
+`examples/ideal/main/crdt_reexport.mbt` plus `examples/ideal/main/moon.pkg`.
+The manifest format should be simple, reviewable, and not code-generated in
+this stage. Keep it close to the app or docs path chosen for export-surface
+ownership, and document that the existing hand-maintained files remain
+authoritative during parallel-run.
+
+Add a script/CI check that compares the declared manifest to both live layers.
+The check must parse MoonBit `moon.pkg` brace export lists and the wrapper file
+well enough to report symbol-level discrepancies in three directions:
+manifest-only, `moon.pkg`-only, and wrapper-only. A failure should tell the
+author exactly which symbol is missing from which layer. A raw pass/fail diff
+is not sufficient.
+
+The check does not generate or rewrite `crdt_reexport.mbt`, and it does not
+delete any wrapper. Codegen is reserved for the deletion-time decision after
+one release of manifest parallel-run.
+
+Expected compile breakpoints: none if the manifest and check are additive.
+Script failures are expected on first run until the manifest exactly describes
+the current lambda app seam. Resolve by correcting the manifest or fixing an
+actual hand-maintained discrepancy, not by weakening the check.
+
+Expected `.mbti` diff: none from manifest/check changes unless tests add a
+MoonBit package. Any FFI `.mbti` diff in this PR is suspect.
+
+Verification:
+
+- Run the new manifest discrepancy check locally and confirm symbol-level
+  reporting
+- `NEW_MOON_MOD=0 moon check`
+- `NEW_MOON_MOD=0 moon test`
+- `NEW_MOON_MOD=0 moon info` and inspect `git diff '*.mbti'`
+- `cd examples/web && npm run build`; include the required PR body table with
+  rows JSON, Markdown, Lambda and columns clean main, with change, delta, gzip
+
+## PR slicing and merge gates
+
+PR1 is host extraction only. It may contain `ffi/host`, imports from
+`ffi/{lambda,json,markdown}` to `ffi/host`, migrated white-box tests, README or
+plan-note updates tied to the extraction, and the bundle-size table. It must
+not contain export manifest work, `crdt_reexport.mbt` deletion, protected-cell
+genericization, assemble-handle genericization, S2 surface changes,
+`lang/runtime` changes, or lambda LLM/relay/ws rewiring.
+
+PR2 is export manifest parallel-run only. It may contain manifest files, the
+discrepancy check, CI wiring, tests for the check, and documentation explaining
+parallel-run. It must not delete wrappers or convert current authoritative
+files to generated outputs.
+
+PR3 is deferred deletion and is not part of this plan's implementation scope.
+Its gate is at least one release after PR2, plus TS typecheck CI, bundle
+measurement, and runtime smoke across all three FFI surfaces.
+
+Every PR body must include a bundle-size table with columns `clean main`,
+`with change`, `delta`, and `gzip`; rows `json`, `markdown`, and `lambda`; and
+measurements from `cd examples/web && npm run build`.
+
+## Gates and acceptance criteria
+
+- `ffi/host` exists as an internal shared dependency with no language imports
+  and no JS exports.
+- `ffi/json`, `ffi/markdown`, and `ffi/lambda` remain separate MoonBit link
+  roots with unchanged JS export surfaces.
+- Ordinary handle maps, ordinary view-state maps, and coordinator destroy
+  gateway behavior are shared through `ffi/host`.
+- Protected-cell bundles remain language-local.
+- Lambda-specific companion, `last_created_handle`, `pretty_view_states`,
+  LLM, relay, WebSocket, semantic, and analysis disposal behavior remains
+  language-local.
+- `ffi/{lambda,json,markdown}/pkg.generated.mbti` diffs are empty or explicitly
+  justified as non-breaking; expected public API addition is limited to
+  `ffi/host/pkg.generated.mbti`.
+- Bundle deltas stay in the spike-proven sub-kB range unless a PR explicitly
+  explains and justifies the variance.
+- The export manifest check reports symbol-level discrepancies across the
+  declared manifest, `ffi/lambda/moon.pkg`, `crdt_reexport.mbt`, and
+  `examples/ideal/main/moon.pkg`.
+- `crdt_reexport.mbt` remains present after S4.
+
+## Baseline correction note
+
+The architecture proposal recorded historical S4 bundle baselines of JSON
+277 kB, Markdown 246 kB, and Lambda 546 kB. Those numbers are not
+reproducible: a fresh build at S0 commit `979c2fe` (the proposal's own date)
+yields 370.29 / 333.17 / 683.92 kB — within ~1 kB of current main, proving
+S1–S3 added almost nothing and the recorded numbers came from a different
+method or toolchain. The operative gate is the 2026-06-12 clean-main
+measurement (`examples/web` Vite chunks, minified, pinned submodules):
+
+- JSON: 370.6 kB, gzip 89.0 kB
+- Markdown: 333.6 kB, gzip 80.8 kB
+- Lambda: 685.2 kB, gzip 155.4 kB
+
+Keep the proposal's numbers as historical context only. S4 PRs compare against
+the 2026-06-12 operative gate and against clean `main` in the PR body table.
+The spike delta evidence was JSON +0.26 kB, Markdown +0.26 kB, and Lambda
++0.63 kB, so sub-kB deltas are the expectation for host extraction.
+
+## Risks
+
+- Bundle regression: shared host code could still pull too much into each
+  entry if imports widen. Mitigation: host imports only `editor` and
+  `workspace/coordinator`, bundle table required on every PR.
+- Visibility creep: making registry fields `pub(all)` would turn an internal
+  bookkeeping package into a data bag. Mitigation: prefer owning-package
+  methods and review `.mbti` diffs.
+- Lambda over-generalization: companion, pretty view, LLM, relay, WebSocket,
+  and analysis disposal state could be accidentally pulled into the generic
+  host. Mitigation: PR1 scope is registry/view-state/destroy only.
+- Test migration drift: existing wbtests rely on private maps. Mitigation:
+  rewrite cleanup/introspection through host methods while keeping
+  protected-cell behavior tests in language packages.
+- Rename damage: broad textual replacements can alter exported or embedded
+  identifiers. Mitigation: scoped semantic/manual rename and targeted `rg`
+  review for exported strings.
+- Manifest false confidence: a manifest that only checks one layer could miss
+  the current two-layer export bug class. Mitigation: compare against both
+  `ffi/lambda` and `examples/ideal/main` live layers with symbol-level output.

--- a/docs/research/2026-05-24-shared-runtime-call-flow-grounding.md
+++ b/docs/research/2026-05-24-shared-runtime-call-flow-grounding.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-05-24
 **Status:** Future-planning grounding draft — not current architecture or an implemented contract.
+**Post-S4 PR1 note (2026-06-12):** the per-language FFI globals this doc traces (`lambda_handles`, `view_states`, `markdown_view_states`, …) were replaced by per-package `@host.HostRegistry` instances in the `ffi/host` extraction; file:line anchors into `ffi/*` predate that and no longer resolve, but the destroy-ordering analysis remains valid.
 **Belongs to slice:** §P0b of `docs/research/2026-05-22-spec-aware-workspace.md`.
 **Pairs with:** `docs/research/2026-05-23-observer-discipline-contract.md`.
 

--- a/ffi/host/README.md
+++ b/ffi/host/README.md
@@ -1,0 +1,35 @@
+# ffi/host
+
+Shared host-binding bookkeeping for the language FFI packages
+(`ffi/lambda`, `ffi/json`, `ffi/markdown`). Internal library dependency —
+not a JS link root and exports nothing to JavaScript.
+
+`HostRegistry[H]` owns the generic per-handle state every language FFI
+package needs:
+
+- the handle map keyed by the exported integer handle
+- the per-handle ordinary `ViewUpdateState` for the view-patch path
+- the destroy gateway that routes teardown through
+  `Coordinator::destroy_editor` and removes FFI bookkeeping only after the
+  coordinator accepts destruction (refusal leaves bookkeeping intact)
+
+Everything language-specific stays in each `ffi/<L>` package: the handle
+record type `H`, protected-cell bundles, editor/companion construction,
+exported function names, and lambda's extras (companion storage,
+`last_created_handle`, `pretty_view_states`, LLM/relay/WebSocket wiring,
+analysis attachment disposal).
+
+## Consumers
+
+`ffi/lambda`, `ffi/json`, `ffi/markdown` only. Each keeps its own
+process-global coordinator and registry instance; nothing is shared across
+languages at runtime.
+
+## Dependencies
+
+- `dowdiness/canopy/editor` — `ViewUpdateState`
+- `dowdiness/canopy/workspace/coordinator` — destroy gateway
+
+The package must not import language packages, `llm`, `relay`,
+`transport_ws`, or AST packages — that boundary is what keeps the
+per-entry JS bundles split.

--- a/ffi/host/host.mbt
+++ b/ffi/host/host.mbt
@@ -8,9 +8,11 @@
 ///|
 /// Generic FFI handle registry: handle bookkeeping plus per-handle ordinary
 /// view-update state, with the coordinator destroy gateway routed through
-/// one shared implementation. Fields are private; all mutation goes through
-/// owning-package methods so language packages cannot bypass the destroy
-/// gateway's bookkeeping invariants.
+/// one shared implementation. Fields are private; mutation goes through
+/// owning-package methods. Production teardown must use `destroy` (the
+/// coordinator-gated path); `remove`/`clear` deliberately bypass the
+/// gateway and exist for whitebox-test drains after a direct coordinator
+/// destroy.
 pub struct HostRegistry[H] {
   priv handles : Map[Int, H]
   priv view_states : Map[Int, @editor.ViewUpdateState]
@@ -66,38 +68,36 @@ pub fn[H] HostRegistry::clear(self : HostRegistry[H]) -> Unit {
 }
 
 ///|
-/// Get-or-create the ordinary view-update state for a handle.
+/// Get-or-create the ordinary view-update state for a handle. Callers are
+/// expected to have validated the handle (`get`/`contains`) first; creating
+/// a state for an unregistered id would leak until `clear`.
 pub fn[H] HostRegistry::view_state(
   self : HostRegistry[H],
   id : Int,
 ) -> @editor.ViewUpdateState {
-  match self.view_states.get(id) {
-    Some(s) => s
-    None => {
-      let s = @editor.ViewUpdateState::ViewUpdateState()
-      self.view_states[id] = s
-      s
-    }
-  }
+  self.view_states.get_or_init(id, () => {
+    @editor.ViewUpdateState::ViewUpdateState()
+  })
 }
 
 ///|
 /// Destroy gateway: route teardown through `Coordinator::destroy_editor`.
 /// On refusal the FFI-side bookkeeping is intentionally left intact so
 /// reads of cached state remain valid; on success the handle entry and its
-/// ordinary view state are removed. Returns true when teardown proceeded,
-/// so language packages can remove their language-local extras afterwards.
+/// ordinary view state are removed. The bookkeeping key is derived from
+/// `editor_id.0` — every language package registers handles under that
+/// integer, so taking it as a separate parameter would only invite a
+/// mismatched pair. Returns true when teardown proceeded, so language
+/// packages can remove their language-local extras afterwards.
 pub fn[H] HostRegistry::destroy(
   self : HostRegistry[H],
   coordinator : @workspace.Coordinator,
-  id : Int,
   editor_id : @workspace.EditorId,
   label : String,
 ) -> Bool {
   match coordinator.destroy_editor(editor_id) {
     Ok(_) => {
-      self.handles.remove(id)
-      self.view_states.remove(id)
+      self.remove(editor_id.0)
       true
     }
     Err(report) => {

--- a/ffi/host/host.mbt
+++ b/ffi/host/host.mbt
@@ -1,0 +1,108 @@
+// S4 host-binding registry shared by ffi/{lambda,json,markdown}. Owns only
+// generic per-handle bookkeeping: the handle map keyed by the exported
+// integer handle, the per-handle ordinary view-update state, and the
+// coordinator destroy gateway. Language-specific state (protected-cell
+// bundles, companions, pretty view states, last-created tracking) stays in
+// each ffi/<L> package. See docs/plans/2026-06-12-s4-ffi-host-extraction.md.
+
+///|
+/// Generic FFI handle registry: handle bookkeeping plus per-handle ordinary
+/// view-update state, with the coordinator destroy gateway routed through
+/// one shared implementation. Fields are private; all mutation goes through
+/// owning-package methods so language packages cannot bypass the destroy
+/// gateway's bookkeeping invariants.
+pub struct HostRegistry[H] {
+  priv handles : Map[Int, H]
+  priv view_states : Map[Int, @editor.ViewUpdateState]
+}
+
+///|
+pub fn[H] HostRegistry::HostRegistry() -> HostRegistry[H] {
+  { handles: Map::default(), view_states: Map::default() }
+}
+
+///|
+/// Register a handle under its exported integer id.
+pub fn[H] HostRegistry::insert(
+  self : HostRegistry[H],
+  id : Int,
+  handle : H,
+) -> Unit {
+  self.handles[id] = handle
+}
+
+///|
+pub fn[H] HostRegistry::get(self : HostRegistry[H], id : Int) -> H? {
+  self.handles.get(id)
+}
+
+///|
+pub fn[H] HostRegistry::contains(self : HostRegistry[H], id : Int) -> Bool {
+  self.handles.contains(id)
+}
+
+///|
+/// Number of registered handles.
+pub fn[H] HostRegistry::size(self : HostRegistry[H]) -> Int {
+  self.handles.length()
+}
+
+///|
+/// Remove a handle's FFI bookkeeping (handle entry and its ordinary
+/// view-update state). Does NOT consult the coordinator — use `destroy`
+/// for the gated teardown path. Exists for whitebox test drains that
+/// destroy through the coordinator directly.
+pub fn[H] HostRegistry::remove(self : HostRegistry[H], id : Int) -> Unit {
+  self.handles.remove(id)
+  self.view_states.remove(id)
+}
+
+///|
+/// Clear all bookkeeping. Test-reset helper for whitebox tests that need a
+/// clean per-package registry between cases.
+pub fn[H] HostRegistry::clear(self : HostRegistry[H]) -> Unit {
+  self.handles.clear()
+  self.view_states.clear()
+}
+
+///|
+/// Get-or-create the ordinary view-update state for a handle.
+pub fn[H] HostRegistry::view_state(
+  self : HostRegistry[H],
+  id : Int,
+) -> @editor.ViewUpdateState {
+  match self.view_states.get(id) {
+    Some(s) => s
+    None => {
+      let s = @editor.ViewUpdateState::ViewUpdateState()
+      self.view_states[id] = s
+      s
+    }
+  }
+}
+
+///|
+/// Destroy gateway: route teardown through `Coordinator::destroy_editor`.
+/// On refusal the FFI-side bookkeeping is intentionally left intact so
+/// reads of cached state remain valid; on success the handle entry and its
+/// ordinary view state are removed. Returns true when teardown proceeded,
+/// so language packages can remove their language-local extras afterwards.
+pub fn[H] HostRegistry::destroy(
+  self : HostRegistry[H],
+  coordinator : @workspace.Coordinator,
+  id : Int,
+  editor_id : @workspace.EditorId,
+  label : String,
+) -> Bool {
+  match coordinator.destroy_editor(editor_id) {
+    Ok(_) => {
+      self.handles.remove(id)
+      self.view_states.remove(id)
+      true
+    }
+    Err(report) => {
+      println("\{label} refused: \{report}")
+      false
+    }
+  }
+}

--- a/ffi/host/host_wbtest.mbt
+++ b/ffi/host/host_wbtest.mbt
@@ -53,9 +53,7 @@ test "destroy refusal leaves bookkeeping intact; success removes it" {
   // Refusal path: a workspace dep edge points at the editor.
   let ws_cell = @incr.Derived::Derived(rt, fn() { 0 }, label="host_test_ws")
   coordinator.register_dep(ws_cell.id(), editor_id, d.id())
-  assert_false(
-    reg.destroy(coordinator, editor_id.0, editor_id, "host_test_destroy"),
-  )
+  assert_false(reg.destroy(coordinator, editor_id, "host_test_destroy"))
   assert_true(reg.contains(editor_id.0))
   assert_true(reg.view_states.contains(editor_id.0))
   // The retained view state is the same object, not a recreated one.
@@ -63,9 +61,7 @@ test "destroy refusal leaves bookkeeping intact; success removes it" {
 
   // Success path: edge released → destroy proceeds, bookkeeping removed.
   coordinator.unregister_dep(ws_cell.id(), editor_id, d.id())
-  assert_true(
-    reg.destroy(coordinator, editor_id.0, editor_id, "host_test_destroy"),
-  )
+  assert_true(reg.destroy(coordinator, editor_id, "host_test_destroy"))
   assert_false(reg.contains(editor_id.0))
   assert_false(reg.view_states.contains(editor_id.0))
 }
@@ -78,7 +74,6 @@ test "destroy of an unknown editor id refuses and keeps bookkeeping" {
   assert_false(
     reg.destroy(
       coordinator,
-      99,
       @workspace.EditorId(99),
       "host_test_unknown_destroy",
     ),

--- a/ffi/host/host_wbtest.mbt
+++ b/ffi/host/host_wbtest.mbt
@@ -1,0 +1,87 @@
+// Host-local registry tests: behavior independent of language handles
+// (plan Step 1). Language-typed concerns — protected-cell bundles,
+// companions, pretty view states — are tested in their ffi/<L> packages.
+// Whitebox so assertions can inspect the priv view_states map directly
+// instead of widening the public API for tests.
+
+///|
+test "view_state get-or-create returns the same state for the same handle" {
+  let reg : HostRegistry[String] = HostRegistry::HostRegistry()
+  let s1 = reg.view_state(7)
+  s1.set_had_errors(true)
+  // Same handle → same state object (mutation is visible through re-fetch).
+  assert_true(reg.view_state(7).had_errors)
+  // Different handle → fresh state.
+  assert_false(reg.view_state(8).had_errors)
+}
+
+///|
+test "remove drops the handle and its view state" {
+  let reg : HostRegistry[String] = HostRegistry::HostRegistry()
+  reg.insert(1, "h1")
+  reg.view_state(1).set_had_errors(true)
+  reg.remove(1)
+  assert_false(reg.contains(1))
+  assert_false(reg.view_states.contains(1))
+  // A re-created state is fresh, not the stale pre-remove one.
+  assert_false(reg.view_state(1).had_errors)
+}
+
+///|
+test "clear drops all handles and view states" {
+  let reg : HostRegistry[String] = HostRegistry::HostRegistry()
+  reg.insert(1, "a")
+  reg.insert(2, "b")
+  let _ = reg.view_state(1)
+  assert_eq(reg.size(), 2)
+  reg.clear()
+  assert_eq(reg.size(), 0)
+  assert_false(reg.view_states.contains(1))
+}
+
+///|
+test "destroy refusal leaves bookkeeping intact; success removes it" {
+  let coordinator = @workspace.Coordinator::new()
+  let rt = coordinator.runtime()
+  let d = @incr.Derived::Derived(rt, fn() { 1 }, label="host_test_cell")
+  let pcell = @workspace.ProtectedCell::from_derived("host_test_cell", d)
+  let editor_id = coordinator.register_editor("host_test_agent", [pcell.erase()])
+  let reg : HostRegistry[String] = HostRegistry::HostRegistry()
+  reg.insert(editor_id.0, "handle")
+  reg.view_state(editor_id.0).set_had_errors(true)
+
+  // Refusal path: a workspace dep edge points at the editor.
+  let ws_cell = @incr.Derived::Derived(rt, fn() { 0 }, label="host_test_ws")
+  coordinator.register_dep(ws_cell.id(), editor_id, d.id())
+  assert_false(
+    reg.destroy(coordinator, editor_id.0, editor_id, "host_test_destroy"),
+  )
+  assert_true(reg.contains(editor_id.0))
+  assert_true(reg.view_states.contains(editor_id.0))
+  // The retained view state is the same object, not a recreated one.
+  assert_true(reg.view_state(editor_id.0).had_errors)
+
+  // Success path: edge released → destroy proceeds, bookkeeping removed.
+  coordinator.unregister_dep(ws_cell.id(), editor_id, d.id())
+  assert_true(
+    reg.destroy(coordinator, editor_id.0, editor_id, "host_test_destroy"),
+  )
+  assert_false(reg.contains(editor_id.0))
+  assert_false(reg.view_states.contains(editor_id.0))
+}
+
+///|
+test "destroy of an unknown editor id refuses and keeps bookkeeping" {
+  let coordinator = @workspace.Coordinator::new()
+  let reg : HostRegistry[String] = HostRegistry::HostRegistry()
+  reg.insert(99, "phantom")
+  assert_false(
+    reg.destroy(
+      coordinator,
+      99,
+      @workspace.EditorId(99),
+      "host_test_unknown_destroy",
+    ),
+  )
+  assert_true(reg.contains(99))
+}

--- a/ffi/host/moon.pkg
+++ b/ffi/host/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "dowdiness/canopy/editor",
+  "dowdiness/canopy/workspace/coordinator" @workspace,
+}
+
+import {
+  "dowdiness/incr",
+} for "wbtest"

--- a/ffi/host/pkg.generated.mbti
+++ b/ffi/host/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/ffi/host"
+
+import {
+  "dowdiness/canopy/editor",
+  "dowdiness/canopy/workspace/coordinator",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct HostRegistry[H] {
+  // private fields
+}
+pub fn[H] HostRegistry::HostRegistry() -> Self[H]
+pub fn[H] HostRegistry::clear(Self[H]) -> Unit
+pub fn[H] HostRegistry::contains(Self[H], Int) -> Bool
+pub fn[H] HostRegistry::destroy(Self[H], @coordinator.Coordinator, Int, @coordinator.EditorId, String) -> Bool
+pub fn[H] HostRegistry::get(Self[H], Int) -> H?
+pub fn[H] HostRegistry::insert(Self[H], Int, H) -> Unit
+pub fn[H] HostRegistry::remove(Self[H], Int) -> Unit
+pub fn[H] HostRegistry::size(Self[H]) -> Int
+pub fn[H] HostRegistry::view_state(Self[H], Int) -> @editor.ViewUpdateState
+
+// Type aliases
+
+// Traits
+

--- a/ffi/host/pkg.generated.mbti
+++ b/ffi/host/pkg.generated.mbti
@@ -17,7 +17,7 @@ pub struct HostRegistry[H] {
 pub fn[H] HostRegistry::HostRegistry() -> Self[H]
 pub fn[H] HostRegistry::clear(Self[H]) -> Unit
 pub fn[H] HostRegistry::contains(Self[H], Int) -> Bool
-pub fn[H] HostRegistry::destroy(Self[H], @coordinator.Coordinator, Int, @coordinator.EditorId, String) -> Bool
+pub fn[H] HostRegistry::destroy(Self[H], @coordinator.Coordinator, @coordinator.EditorId, String) -> Bool
 pub fn[H] HostRegistry::get(Self[H], Int) -> H?
 pub fn[H] HostRegistry::insert(Self[H], Int, H) -> Unit
 pub fn[H] HostRegistry::remove(Self[H], Int) -> Unit

--- a/ffi/json/README.md
+++ b/ffi/json/README.md
@@ -21,6 +21,7 @@ No other MoonBit package imports `ffi/json`. Consumed by `examples/web/json.html
 
 - `dowdiness/canopy/editor`
 - `dowdiness/canopy/core`
+- `dowdiness/canopy/ffi/host` — shared handle/view-state registry and coordinator destroy gateway
 - `dowdiness/canopy/lang/json/edits` + `lang/json/companion`
 - `dowdiness/json` — JSON value type
 

--- a/ffi/json/edit.mbt
+++ b/ffi/json/edit.mbt
@@ -8,7 +8,7 @@ pub fn json_apply_edit(
   op_json : String,
   timestamp_ms : Int,
 ) -> String {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) => {
       let json = @core_json.parse(op_json) catch {
         _ => return "error: invalid JSON"

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -19,17 +19,16 @@ priv struct JsonHandle {
 let coordinator : @workspace.Coordinator = @workspace.Coordinator::new()
 
 ///|
-let json_handles : Map[Int, JsonHandle] = Map::default()
-
-///|
-let json_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
+/// Generic handle/view-state bookkeeping shared with the other language FFI
+/// packages via `ffi/host`. Keyed by the exported integer handle.
+let json_registry : @host.HostRegistry[JsonHandle] = @host.HostRegistry::HostRegistry()
 
 // ── Lifecycle ────────────────────────────────────────────────────────────
 
 ///|
 /// Build a JSON editor on the shared runtime, then atomically register its
 /// protected cells with the coordinator. Returns the freshly-allocated
-/// `EditorId`. Aborting at any step leaves `json_handles` untouched
+/// `EditorId`. Aborting at any step leaves `json_registry` untouched
 /// (atomic-boundary observation, spec §3.6).
 fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
   let editor = @json_companion.new_json_editor(
@@ -41,7 +40,7 @@ fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
     agent_id,
     cells.to_protected_reads(),
   )
-  json_handles[editor_id.0] = { editor, editor_id, cells }
+  json_registry.insert(editor_id.0, { editor, editor_id, cells })
   editor_id
 }
 
@@ -54,28 +53,26 @@ pub fn create_json_editor(agent_id : String) -> Int {
 ///|
 /// Destroy a JSON editor and free its resources. The coordinator gateway
 /// refuses if workspace deps still reference the editor; in that case the
-/// FFI-side bookkeeping (json_handles entry, view_states entry) is
+/// FFI-side bookkeeping (registry handle entry, view-state entry) is
 /// intentionally left intact so reads of cached state remain valid.
 pub fn destroy_json_editor(handle : Int) -> Unit {
-  let h = match json_handles.get(handle) {
+  let h = match json_registry.get(handle) {
     Some(v) => v
     None => return
   }
-  match coordinator.destroy_editor(h.editor_id) {
-    Ok(_) => ()
-    Err(report) => {
-      println("destroy_json_editor refused: \{report}")
-      return
-    }
-  }
-  json_handles.remove(handle)
-  json_view_states.remove(handle)
+  let _ = json_registry.destroy(
+    coordinator,
+    handle,
+    h.editor_id,
+    "destroy_json_editor",
+  )
+
 }
 
 ///|
 /// Get current text content of the JSON editor.
 pub fn json_get_text(handle : Int) -> String {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) => h.editor.get_text()
     None => ""
   }
@@ -84,7 +81,7 @@ pub fn json_get_text(handle : Int) -> String {
 ///|
 /// Set text content directly (replaces entire JSON document).
 pub fn json_set_text(handle : Int, new_text : String) -> Unit {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) => h.editor.set_text(new_text)
     None => ()
   }
@@ -102,7 +99,7 @@ pub fn json_set_text(handle : Int, new_text : String) -> Unit {
 /// spurious empty-doc parser diagnostics that consumers were never
 /// previously exposed to (Codex round-2 #1).
 pub fn json_get_errors(handle : Int) -> String {
-  let h = match json_handles.get(handle) {
+  let h = match json_registry.get(handle) {
     Some(v) => v
     None => return "[]"
   }
@@ -122,7 +119,7 @@ pub fn json_get_errors(handle : Int) -> String {
 /// Get the ProjNode tree as JSON string.
 /// Returns "null" if no projection is available or the protected read fails.
 pub fn json_get_proj_node_json(handle : Int) -> String {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) =>
       match coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
         Ok(Some(proj)) => proj.to_json().stringify()
@@ -141,7 +138,7 @@ pub fn json_get_proj_node_json(handle : Int) -> String {
 /// Returns an array of {node_id, start, end} entries, or "[]" if the
 /// protected read fails.
 pub fn json_get_source_map_json(handle : Int) -> String {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) =>
       match coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
         Ok(sm) => sm.to_json().stringify()
@@ -160,7 +157,7 @@ pub fn json_get_source_map_json(handle : Int) -> String {
 /// Get the ViewNode tree as JSON for a JSON editor.
 /// Returns "null" if no projection is available or any protected read fails.
 pub fn json_get_view_tree_json(handle : Int) -> String {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
@@ -200,7 +197,7 @@ pub fn json_get_view_tree_json(handle : Int) -> String {
 /// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
 /// fails.
 pub fn json_compute_view_patches_json(handle : Int) -> String {
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
@@ -234,14 +231,7 @@ pub fn json_compute_view_patches_json(handle : Int) -> String {
           return "[]"
         }
       }
-      let state = match json_view_states.get(handle) {
-        Some(s) => s
-        None => {
-          let s = @editor.ViewUpdateState::ViewUpdateState()
-          json_view_states[handle] = s
-          s
-        }
-      }
+      let state = json_registry.view_state(handle)
       let patches = @editor.compute_view_patches(state, h.editor)
       Json::array(patches.map(fn(p) { p.to_json() })).stringify()
     }

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -66,7 +66,6 @@ pub fn destroy_json_editor(handle : Int) -> Unit {
     h.editor_id,
     "destroy_json_editor",
   )
-
 }
 
 ///|

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -60,12 +60,7 @@ pub fn destroy_json_editor(handle : Int) -> Unit {
     Some(v) => v
     None => return
   }
-  let _ = json_registry.destroy(
-    coordinator,
-    handle,
-    h.editor_id,
-    "destroy_json_editor",
-  )
+  let _ = json_registry.destroy(coordinator, h.editor_id, "destroy_json_editor")
 }
 
 ///|

--- a/ffi/json/lifecycle_phase1_wbtest.mbt
+++ b/ffi/json/lifecycle_phase1_wbtest.mbt
@@ -72,7 +72,7 @@ test "spec §12 #2 (json): destroy refused while depended-upon; succeeds after u
     Ok(_) => ()
     Err(report) => fail("expected Ok after unregister_dep, got \{report}")
   }
-  json_registry.remove(handle)
+  drain_json_handle_after_direct_coordinator_destroy(handle)
 }
 
 ///|
@@ -177,7 +177,7 @@ test "workstream 2 (json): json_get_errors collapses to [] after coordinator des
       )
   }
   assert_eq(json_get_errors(handle), "[]")
-  json_registry.remove(handle)
+  drain_json_handle_after_direct_coordinator_destroy(handle)
 }
 
 ///|

--- a/ffi/json/lifecycle_phase1_wbtest.mbt
+++ b/ffi/json/lifecycle_phase1_wbtest.mbt
@@ -1,7 +1,7 @@
 // Whitebox integration tests for §P0b Phase 1b WS2: JSON FFI editors driven
 // through the workspace coordinator. Covers spec §12 tests 1–4 (7-cell
 // symmetric subset) — these need access to package-private symbols
-// (`json_handles`, `coordinator`, `JsonHandle` fields), so they live in a
+// (`json_registry`, `coordinator`, `JsonHandle` fields), so they live in a
 // `_wbtest.mbt`.
 //
 // §12 #5 (`ProtectedCellDisposed`) is workspace-generic and covered by
@@ -9,27 +9,19 @@
 
 ///|
 fn reset_json_coordinator_for_phase1_tests() -> Unit {
-  let keys = json_handles.keys().to_array()
-  for k in keys {
-    json_handles.remove(k)
-  }
-  let vkeys = json_view_states.keys().to_array()
-  for k in vkeys {
-    json_view_states.remove(k)
-  }
+  json_registry.clear()
 }
 
 ///|
 fn drain_json_handle_after_direct_coordinator_destroy(handle : Int) -> Unit {
-  json_handles.remove(handle)
-  json_view_states.remove(handle)
+  json_registry.remove(handle)
 }
 
 ///|
 test "spec §12 #1 (json): each protected cell reads through read_protected" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_test_agent_one")
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   let id = h.editor_id
   match coordinator.read_protected(id, h.cells.parser_syntax_tree) {
     Ok(_) => ()
@@ -66,7 +58,7 @@ test "spec §12 #1 (json): each protected cell reads through read_protected" {
 test "spec §12 #2 (json): destroy refused while depended-upon; succeeds after unregister_dep" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_test_agent_two")
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   let id = h.editor_id
   let parser_ast_id = h.cells.parser_ast.cell_id()
   let synth_id = parser_ast_id
@@ -80,15 +72,14 @@ test "spec §12 #2 (json): destroy refused while depended-upon; succeeds after u
     Ok(_) => ()
     Err(report) => fail("expected Ok after unregister_dep, got \{report}")
   }
-  json_handles.remove(handle)
-  json_view_states.remove(handle)
+  json_registry.remove(handle)
 }
 
 ///|
 test "spec §12 #3 (json): read_protected after destroy returns EditorDestroyed" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_test_agent_three")
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   let id = h.editor_id
   let parser_source_cell = h.cells.parser_source
   destroy_json_editor(handle)
@@ -106,8 +97,8 @@ test "spec §12 #4 (json): read_protected rejects cells from a different editor"
   reset_json_coordinator_for_phase1_tests()
   let handle_a = create_json_editor("json_agent_alpha")
   let handle_b = create_json_editor("json_agent_beta")
-  let h_a = json_handles.get(handle_a).unwrap()
-  let h_b = json_handles.get(handle_b).unwrap()
+  let h_a = json_registry.get(handle_a).unwrap()
+  let h_b = json_registry.get(handle_b).unwrap()
   match coordinator.read_protected(h_b.editor_id, h_a.cells.parser_ast) {
     Ok(_) => fail("expected CellNotInProtectedSurface")
     Err(report) => assert_eq(report.kind, @workspace.CellNotInProtectedSurface)
@@ -171,23 +162,22 @@ test "workstream 2 (json): json_get_errors collapses to [] after coordinator des
   if alive == "[]" {
     fail("expected non-empty diagnostics pre-destroy, got []")
   }
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   let id = h.editor_id
   match coordinator.destroy_editor(id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
   }
   // FFI bookkeeping retained — coordinator side is destroyed.
-  match json_handles.get(handle) {
+  match json_registry.get(handle) {
     Some(_) => ()
     None =>
       fail(
-        "expected json_handles to retain handle after direct coordinator destroy",
+        "expected json_registry to retain handle after direct coordinator destroy",
       )
   }
   assert_eq(json_get_errors(handle), "[]")
-  json_handles.remove(handle)
-  json_view_states.remove(handle)
+  json_registry.remove(handle)
 }
 
 ///|
@@ -202,7 +192,7 @@ test "workstream 3 (json): json_get_proj_node_json collapses to null after coord
   if alive == "null" {
     fail("expected live projection JSON before coordinator destroy")
   }
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -220,7 +210,7 @@ test "workstream 3 (json): json_get_source_map_json collapses to [] after coordi
   if alive == "[]" {
     fail("expected live source map JSON before coordinator destroy")
   }
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -238,7 +228,7 @@ test "workstream 3 (json): json_get_view_tree_json collapses to null after coord
   if alive == "null" {
     fail("expected live view tree JSON before coordinator destroy")
   }
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -256,7 +246,7 @@ test "workstream 3 (json): json_compute_view_patches_json collapses to [] after 
   if alive == "[]" {
     fail("expected live view patch JSON before coordinator destroy")
   }
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -270,7 +260,7 @@ test "workstream 3 (json): json_apply_edit rejects after coordinator destroy" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_apply_destroy_agent")
   json_set_text(handle, "{\"a\": 1}")
-  let h = json_handles.get(handle).unwrap()
+  let h = json_registry.get(handle).unwrap()
   let node_id = match h.editor.get_proj_node() {
     Some(root) =>
       match root.id().to_json() {

--- a/ffi/json/moon.pkg
+++ b/ffi/json/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/core",
-  "dowdiness/canopy/ffi/host" @host,
+  "dowdiness/canopy/ffi/host",
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/companion" @json_companion,
   "dowdiness/canopy/workspace/coordinator" @workspace,

--- a/ffi/json/moon.pkg
+++ b/ffi/json/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/core",
+  "dowdiness/canopy/ffi/host" @host,
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/companion" @json_companion,
   "dowdiness/canopy/workspace/coordinator" @workspace,

--- a/ffi/lambda/README.md
+++ b/ffi/lambda/README.md
@@ -26,6 +26,7 @@ All symbols in this package are flat free functions exported via the link block.
 ## Dependencies
 
 - `dowdiness/canopy/editor` — `SyncEditor`, `JsWebSocket`, wire protocol
+- `dowdiness/canopy/ffi/host` — shared handle/view-state registry and coordinator destroy gateway
 - `dowdiness/canopy/lang/lambda` — `new_lambda_editor`, `apply_lambda_tree_edit`, etc.
 - `dowdiness/canopy/relay` — `RelayRoom` operations
 - `dowdiness/canopy/llm` — `fix_typos`, `edit_text`
@@ -42,4 +43,4 @@ Unstable — route through `ffi/lambda`. The exported function list changes when
 
 ## Notes
 
-Each editor instance lives in a process-local registry keyed by `Int`. The registry is global and unbounded — `destroy_editor` must be called to prevent leaks. LLM functions return `Promise[String]` and require the JS async runtime (`js_async`).
+Each editor instance lives in a process-local `@host.HostRegistry` keyed by `Int` (shared bookkeeping implementation from `ffi/host`; the instance is package-local). The registry is global and unbounded — `destroy_editor` must be called to prevent leaks. LLM functions return `Promise[String]` and require the JS async runtime (`js_async`).

--- a/ffi/lambda/destroy_editor_wbtest.mbt
+++ b/ffi/lambda/destroy_editor_wbtest.mbt
@@ -4,18 +4,8 @@
 
 ///|
 fn clear_lambda_handles() -> Unit {
-  let keys = lambda_handles.keys().to_array()
-  for k in keys {
-    lambda_handles.remove(k)
-  }
-  let vkeys = view_states.keys().to_array()
-  for k in vkeys {
-    view_states.remove(k)
-  }
-  let pvkeys = pretty_view_states.keys().to_array()
-  for k in pvkeys {
-    pretty_view_states.remove(k)
-  }
+  lambda_registry.clear()
+  pretty_view_states.clear()
   last_created_handle.val = None
 }
 
@@ -25,7 +15,7 @@ test "destroy_editor: clears handle state" {
   let handle = create_editor("test-destroy-1")
   destroy_editor(handle)
   // Whitebox: handle must be removed from the registry
-  inspect(lambda_handles.contains(handle), content="false")
+  inspect(lambda_registry.contains(handle), content="false")
   // Whitebox: last_created_handle must be reset to None
   inspect(last_created_handle.val is None, content="true")
   // Public-API fallback: unknown handle returns empty/default values
@@ -38,7 +28,7 @@ test "destroy_editor: unknown handle is a safe no-op" {
   clear_lambda_handles()
   // Must not crash or abort
   destroy_editor(999999)
-  inspect(lambda_handles.contains(999999), content="false")
+  inspect(lambda_registry.contains(999999), content="false")
 }
 
 ///|
@@ -49,9 +39,9 @@ test "destroy_editor: create → destroy → recreate leaves exactly one entry" 
   // Recreate after teardown — this is the isolation case that a bug
   // in destroy's cleanup (e.g. stale next_handle, leftover scope) could break.
   let h2 = create_editor("agent-b")
-  inspect(lambda_handles.contains(h1), content="false")
-  inspect(lambda_handles.contains(h2), content="true")
-  inspect(lambda_handles.length(), content="1")
+  inspect(lambda_registry.contains(h1), content="false")
+  inspect(lambda_registry.contains(h2), content="true")
+  inspect(lambda_registry.size(), content="1")
   // Cleanup
   destroy_editor(h2)
 }

--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -3,7 +3,7 @@
 ///|
 /// Get AST as DOT format with name resolution coloring
 pub fn get_ast_dot_resolved(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => @lang_lambda.get_lambda_dot_resolved(h.editor)
     None => "digraph { }"
   }
@@ -12,7 +12,7 @@ pub fn get_ast_dot_resolved(handle : Int) -> String {
 ///|
 /// Get AST as pretty-printed string (expression + debug tree)
 pub fn get_ast_pretty(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => @lang_lambda.get_lambda_ast_pretty(h.editor)
     None => ""
   }
@@ -21,7 +21,7 @@ pub fn get_ast_pretty(handle : Int) -> String {
 ///|
 /// Get parse errors as JSON array
 pub fn get_errors_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.get_errors().to_json().stringify()
     None => "[]"
   }
@@ -34,7 +34,7 @@ pub fn get_errors_json(handle : Int) -> String {
 /// named binding (e.g. `let f = y` → `def_name: "f"`); consumers should group,
 /// filter, or badge by this field rather than parsing the message string.
 pub fn get_diagnostics_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       // Read every protected cell this accessor depends on up front; any
       // Err collapses the whole accessor to "[]". Partial diagnostics from a
@@ -120,7 +120,7 @@ pub fn get_diagnostics_json(handle : Int) -> String {
 ///|
 /// Export all operations as a SyncMessage JSON string.
 pub fn export_all_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       h.editor.export_all().to_json_string() catch {
         _ => "{\"ops\":[],\"heads\":[]}"
@@ -132,7 +132,7 @@ pub fn export_all_json(handle : Int) -> String {
 ///|
 /// Export operations since a peer's version as a SyncMessage JSON string.
 pub fn export_since_json(handle : Int, peer_version_json : String) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       try {
         let ver = @text.Version::from_json_string(peer_version_json)
@@ -147,7 +147,7 @@ pub fn export_since_json(handle : Int, peer_version_json : String) -> String {
 ///|
 /// Apply a SyncMessage received from a peer.
 pub fn apply_sync_json(handle : Int, sync_json : String) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       try {
         let msg = @text.SyncMessage::from_json_string(sync_json)
@@ -163,7 +163,7 @@ pub fn apply_sync_json(handle : Int, sync_json : String) -> String {
 ///|
 /// Get the current version as a JSON string.
 pub fn get_version_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.get_version().to_json_string()
     None => "\"\""
   }
@@ -173,7 +173,7 @@ pub fn get_version_json(handle : Int) -> String {
 /// Get the ProjNode tree as JSON string.
 /// Returns "null" if no projection is available or the protected read fails.
 pub fn get_proj_node_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       match coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
         Ok(Some(proj)) => proj.to_json().stringify()
@@ -192,7 +192,7 @@ pub fn get_proj_node_json(handle : Int) -> String {
 /// Returns an array of {node_id, start, end} entries, or "[]" if the
 /// protected read fails.
 pub fn get_source_map_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       match coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
         Ok(sm) => sm.to_json().stringify()

--- a/ffi/lambda/ephemeral.mbt
+++ b/ffi/lambda/ephemeral.mbt
@@ -3,7 +3,7 @@
 ///|
 /// Encode all local ephemeral state as binary (for sending to peers)
 pub fn ephemeral_encode_all(handle : Int) -> Bytes {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.encode_ephemeral_all()
     None => Bytes::new(0)
   }
@@ -12,7 +12,7 @@ pub fn ephemeral_encode_all(handle : Int) -> Bytes {
 ///|
 /// Apply remote ephemeral update (binary received from peer)
 pub fn ephemeral_apply(handle : Int, data : Bytes) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.apply_ephemeral(data)
     None => ()
   }
@@ -25,7 +25,7 @@ pub fn ephemeral_set_presence(
   name : String,
   color : String,
 ) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.set_local_presence(name, color)
     None => ()
   }
@@ -40,7 +40,7 @@ pub fn ephemeral_set_presence_with_selection(
   sel_start : Int,
   sel_end : Int,
 ) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       h.editor.set_local_presence(
         name,
@@ -54,7 +54,7 @@ pub fn ephemeral_set_presence_with_selection(
 ///|
 /// Delete local presence (call on beforeunload for graceful disconnect)
 pub fn ephemeral_delete_presence(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.delete_local_presence()
     None => ()
   }
@@ -63,7 +63,7 @@ pub fn ephemeral_delete_presence(handle : Int) -> Unit {
 ///|
 /// Remove expired ephemeral entries (call on timer)
 pub fn ephemeral_remove_outdated(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.remove_ephemeral_outdated()
     None => ()
   }
@@ -73,7 +73,7 @@ pub fn ephemeral_remove_outdated(handle : Int) -> Unit {
 /// Get adjusted peer cursors as JSON for rendering
 /// Returns: [{"peer_id":"123","cursor":8,"name":"Alice","color":"#ff0000","selection":null}, ...]
 pub fn ephemeral_get_peer_cursors_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let cursors = h.editor.get_peer_cursors()
       let items : Array[String] = []

--- a/ffi/lambda/intent.mbt
+++ b/ffi/lambda/intent.mbt
@@ -9,7 +9,7 @@ pub fn insert_at(
   text : String,
   timestamp_ms : Int,
 ) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.insert_at(position, text, timestamp_ms)
     None => ()
   }
@@ -20,7 +20,7 @@ pub fn insert_at(
 /// Records the operation for undo. Returns false if position is out of bounds.
 /// Used by ProseMirror bridge.
 pub fn delete_at(handle : Int, position : Int, timestamp_ms : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.delete_at(position, timestamp_ms)
     None => false
   }
@@ -34,7 +34,7 @@ pub fn apply_tree_edit_json(
   op_json : String,
   timestamp_ms : Int,
 ) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let json = @json.parse(op_json) catch {
         _ => return "error: invalid JSON"
@@ -70,7 +70,7 @@ pub fn handle_text_intent(
   insert : String,
   timestamp_ms : Int,
 ) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.apply_text_edit(from, deleted_len, insert, timestamp_ms)
     None => ()
   }
@@ -89,7 +89,7 @@ pub fn handle_text_intent_checked(
   insert : String,
   timestamp_ms : Int,
 ) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       h.editor.apply_text_edit_exact(from, deleted_len, insert, timestamp_ms)
     None => false

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -21,7 +21,11 @@ priv struct LambdaHandle {
 let coordinator : @workspace.Coordinator = @workspace.Coordinator::new()
 
 ///|
-let lambda_handles : Map[Int, LambdaHandle] = Map::default()
+/// Generic handle/view-state bookkeeping shared with the other language FFI
+/// packages via `ffi/host`. Keyed by the exported integer handle. Lambda
+/// extras (`pretty_view_states`, `last_created_handle`, companion disposal)
+/// stay language-local.
+let lambda_registry : @host.HostRegistry[LambdaHandle] = @host.HostRegistry::HostRegistry()
 
 ///|
 let last_created_handle : Ref[Int?] = { val: None }
@@ -30,7 +34,7 @@ let last_created_handle : Ref[Int?] = { val: None }
 /// Build a Lambda editor + companion on the shared runtime, then
 /// atomically register them with the coordinator. Returns
 /// the freshly-allocated `EditorId`. Aborting at any step leaves
-/// `lambda_handles` untouched (atomic-boundary observation, spec §8.3).
+/// `lambda_registry` untouched (atomic-boundary observation, spec §8.3).
 fn assemble_lambda_handle(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
@@ -45,7 +49,7 @@ fn assemble_lambda_handle(
     agent_id,
     cells.to_protected_reads(),
   )
-  lambda_handles[editor_id.0] = { editor, companion, editor_id, cells }
+  lambda_registry.insert(editor_id.0, { editor, companion, editor_id, cells })
   last_created_handle.val = Some(editor_id.0)
   editor_id
 }
@@ -55,7 +59,7 @@ fn assemble_lambda_handle(
 pub fn get_sync_editor() -> @editor.SyncEditor[@ast.Term]? {
   match last_created_handle.val {
     Some(handle) =>
-      match lambda_handles.get(handle) {
+      match lambda_registry.get(handle) {
         Some(h) => Some(h.editor)
         None => None
       }
@@ -68,7 +72,7 @@ pub fn get_sync_editor() -> @editor.SyncEditor[@ast.Term]? {
 pub fn get_lambda_companion() -> @lang_lambda.LambdaCompanion? {
   match last_created_handle.val {
     Some(handle) =>
-      match lambda_handles.get(handle) {
+      match lambda_registry.get(handle) {
         Some(h) => Some(h.companion)
         None => None
       }
@@ -88,27 +92,27 @@ pub fn create_editor(agent_id : String) -> Int {
 /// case the FFI-side bookkeeping and analysis attachment are intentionally
 /// left intact so reads of cached state remain valid.
 pub fn destroy_editor(handle : Int) -> Unit {
-  let h = match lambda_handles.get(handle) {
+  let h = match lambda_registry.get(handle) {
     Some(v) => v
     None => return
   }
-  match coordinator.destroy_editor(h.editor_id) {
-    Ok(_) => ()
-    Err(report) => {
-      // Phase 1: log + skip teardown so dep references remain valid.
-      // Phase 2 surfaces this to JS via a dedicated FFI error channel.
-      println("destroy_editor refused: \{report}")
-      return
-    }
+  // The host gateway logs + skips teardown on refusal so dep references
+  // remain valid (Phase 2 surfaces this to JS via a dedicated FFI error
+  // channel). On success it removes the handle entry and ordinary view
+  // state BEFORE we dispose the analysis attachment: if dispose ever raises
+  // (e.g., loom-side cleanup defect), the externally-visible state still
+  // reflects reality — the handle is gone, subsequent FFI calls on it
+  // return the empty/default fallback path. A leaked attachment is
+  // observable only via incr-level inspection; a leaked registry entry
+  // would be observable as a phantom editor.
+  guard lambda_registry.destroy(
+    coordinator,
+    handle,
+    h.editor_id,
+    "destroy_editor",
+  ) else {
+    return
   }
-  // Remove FFI-side bookkeeping BEFORE disposing the analysis attachment. If
-  // dispose ever raises (e.g., loom-side cleanup defect), the externally-visible
-  // state still reflects reality: the handle is gone, subsequent FFI calls on it
-  // return the empty/default fallback path. A leaked attachment is observable
-  // only via incr-level inspection; a leaked lambda_handles entry would be
-  // observable as a phantom editor.
-  lambda_handles.remove(handle)
-  view_states.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
@@ -119,7 +123,7 @@ pub fn destroy_editor(handle : Int) -> Unit {
 ///|
 /// Get current text content
 pub fn get_text(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.get_text()
     None => ""
   }
@@ -128,7 +132,7 @@ pub fn get_text(handle : Int) -> String {
 ///|
 /// Set text content directly (replaces entire document)
 pub fn set_text(handle : Int, new_text : String) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.set_text(new_text)
     None => ()
   }

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -105,12 +105,7 @@ pub fn destroy_editor(handle : Int) -> Unit {
   // return the empty/default fallback path. A leaked attachment is
   // observable only via incr-level inspection; a leaked registry entry
   // would be observable as a phantom editor.
-  guard lambda_registry.destroy(
-    coordinator,
-    handle,
-    h.editor_id,
-    "destroy_editor",
-  ) else {
+  guard lambda_registry.destroy(coordinator, h.editor_id, "destroy_editor") else {
     return
   }
   pretty_view_states.remove(handle)

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -1,6 +1,6 @@
 // Whitebox integration tests for §P0b Phase 1: Lambda FFI editors driven
 // through the workspace coordinator. Covers spec §12 tests 1, 2, 3, 4 —
-// these need access to package-private symbols (`lambda_handles`,
+// these need access to package-private symbols (`lambda_registry`,
 // `coordinator`, `LambdaHandle` fields), so they live in a `_wbtest.mbt`.
 //
 // §12 #5 (`ProtectedCellDisposed`) and §12 #6 (`CycleDetected` mapping)
@@ -18,18 +18,8 @@ fn reset_coordinator_for_phase1_tests() -> Unit {
   // side registrations stay around with alive=true and may leak Watch
   // roots, but each new test gets a fresh EditorId from the monotonic
   // counter, so leakage cannot affect correctness — only memory.
-  let keys = lambda_handles.keys().to_array()
-  for k in keys {
-    lambda_handles.remove(k)
-  }
-  let vkeys = view_states.keys().to_array()
-  for k in vkeys {
-    view_states.remove(k)
-  }
-  let pvkeys = pretty_view_states.keys().to_array()
-  for k in pvkeys {
-    pretty_view_states.remove(k)
-  }
+  lambda_registry.clear()
+  pretty_view_states.clear()
   last_created_handle.val = None
 }
 
@@ -39,8 +29,7 @@ fn drain_lambda_handle_after_direct_coordinator_destroy(
   h : LambdaHandle,
 ) -> Unit {
   h.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle)
-  view_states.remove(handle)
+  lambda_registry.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
@@ -51,7 +40,7 @@ fn drain_lambda_handle_after_direct_coordinator_destroy(
 test "spec §12 #1: each protected cell reads through read_protected" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("test_agent_one")
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   let id = h.editor_id
   // Spec compliance: every cell wired into the bundle must reach
   // `read_protected` with Ok(_) on a freshly-created editor. Reading
@@ -104,7 +93,7 @@ test "spec §12 #1: each protected cell reads through read_protected" {
 test "spec §12 #2: destroy refused while depended-upon; succeeds after unregister_dep" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("test_agent_two")
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   let id = h.editor_id
   let parser_ast_id = h.cells.parser_ast.cell_id()
   // Synthetic workspace memo id — register_dep only stores edges by
@@ -127,8 +116,7 @@ test "spec §12 #2: destroy refused while depended-upon; succeeds after unregist
   // `destroy_editor(handle)` again because the coordinator has already
   // marked the registration alive=false.
   h.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle)
-  view_states.remove(handle)
+  lambda_registry.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
@@ -147,7 +135,7 @@ test "workstream 3: get_view_tree_json collapses to null after coordinator destr
   if alive_json == "null" {
     fail("expected live view tree JSON before coordinator destroy")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -165,7 +153,7 @@ test "workstream 3: compute_view_patches_json collapses to [] after coordinator 
   if alive_json == "[]" {
     fail("expected live view patch JSON before coordinator destroy")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -184,7 +172,7 @@ test "workstream 3: get_semantic_projection_json collapses to empty after coordi
   if alive_json == empty {
     fail("expected live semantic projection JSON before coordinator destroy")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -198,7 +186,7 @@ test "workstream 3: rename_semantic_node rejects after coordinator destroy" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("semantic_rename_coord_destroy_agent")
   set_text(handle, "λx. x")
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   let body_id = match h.editor.get_proj_node() {
     Some(root) =>
       match root.children[0].id().to_json() {
@@ -227,7 +215,7 @@ test "workstream 3: get_pretty_view_json collapses to null after coordinator des
   if alive_json == "null" {
     fail("expected live pretty view JSON before coordinator destroy")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -245,7 +233,7 @@ test "workstream 3: compute_pretty_patches_json collapses to [] after coordinato
   if alive_json == "[]" {
     fail("expected live pretty patch JSON before coordinator destroy")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -258,11 +246,11 @@ test "workstream 3: compute_pretty_patches_json collapses to [] after coordinato
 test "spec §12 #3: read_protected after destroy returns EditorDestroyed" {
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("test_agent_three")
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   let id = h.editor_id
   let parser_source_cell = h.cells.parser_source
   destroy_editor(handle)
-  // The handle is now removed from lambda_handles, but the registration
+  // The handle is now removed from lambda_registry, but the registration
   // in the coordinator stays (alive=false) so the error carries agent_id.
   match coordinator.read_protected(id, parser_source_cell) {
     Ok(_) => fail("expected EditorDestroyed")
@@ -278,8 +266,8 @@ test "spec §12 #4: read_protected rejects cells from a different editor" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("agent_alpha")
   let handle_b = create_editor("agent_beta")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   match coordinator.read_protected(h_b.editor_id, h_a.cells.parser_ast) {
     Ok(_) => fail("expected CellNotInProtectedSurface")
     Err(report) => assert_eq(report.kind, @workspace.CellNotInProtectedSurface)
@@ -330,24 +318,23 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
   if !alive_json.contains("\"def_name\":\"x\"") {
     fail("expected def_name=\"x\" on alive editor, got \{alive_json}")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   let id = h.editor_id
   match coordinator.destroy_editor(id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
   }
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(_) => ()
     None =>
       fail(
-        "expected lambda_handles to retain handle after direct coordinator destroy",
+        "expected lambda_registry to retain handle after direct coordinator destroy",
       )
   }
   // Post-destroy must collapse to "[]" via the Err arm of read_protected.
   assert_eq(get_diagnostics_json(handle), "[]")
   h.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle)
-  view_states.remove(handle)
+  lambda_registry.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None
@@ -369,7 +356,7 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
   if !alive_json.contains("\"level\":\"error\"") {
     fail("expected parse-error diagnostic on alive editor, got \{alive_json}")
   }
-  let h = lambda_handles.get(handle).unwrap()
+  let h = lambda_registry.get(handle).unwrap()
   let id = h.editor_id
   match coordinator.destroy_editor(id) {
     Ok(_) => ()
@@ -377,8 +364,7 @@ test "workstream 1: get_diagnostics_json collapses to [] after coordinator destr
   }
   assert_eq(get_diagnostics_json(handle), "[]")
   h.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle)
-  view_states.remove(handle)
+  lambda_registry.remove(handle)
   pretty_view_states.remove(handle)
   if last_created_handle.val == Some(handle) {
     last_created_handle.val = None

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/editor",
+  "dowdiness/canopy/ffi/host",
   "dowdiness/canopy/lang/lambda" @lang_lambda,
   "dowdiness/canopy/lang/lambda/flat" @lambda_flat,
   "dowdiness/canopy/lang/lambda/eval" @lambda_eval,

--- a/ffi/lambda/pretty.mbt
+++ b/ffi/lambda/pretty.mbt
@@ -54,14 +54,9 @@ pub fn compute_pretty_patches_json(handle : Int) -> String {
           return "[]"
         }
       }
-      let state = match pretty_view_states.get(handle) {
-        Some(s) => s
-        None => {
-          let s = @editor.ViewUpdateState::ViewUpdateState()
-          pretty_view_states[handle] = s
-          s
-        }
-      }
+      let state = pretty_view_states.get_or_init(handle, () => {
+        @editor.ViewUpdateState::ViewUpdateState()
+      })
       let patches = @editor.compute_pretty_patches(state, h.editor)
       Json::array(patches.map(fn(p) { p.to_json() })).stringify()
     }

--- a/ffi/lambda/pretty.mbt
+++ b/ffi/lambda/pretty.mbt
@@ -7,7 +7,7 @@ let pretty_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
 /// Get the pretty-printed ViewNode tree as JSON for a lambda editor.
 /// Returns "null" if any protected read fails.
 pub fn get_pretty_view_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.parser_ast) {
@@ -36,7 +36,7 @@ pub fn get_pretty_view_json(handle : Int) -> String {
 /// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
 /// fails.
 pub fn compute_pretty_patches_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.parser_ast) {

--- a/ffi/lambda/semantic.mbt
+++ b/ffi/lambda/semantic.mbt
@@ -28,7 +28,7 @@ fn empty_semantic_projection_json() -> String {
 /// state; semantic edits still lower through text/CRDT edit paths. Returns the
 /// empty projection if any protected read fails.
 pub fn get_semantic_projection_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let root = match
         coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
@@ -77,7 +77,7 @@ pub fn rename_semantic_node(
   new_name : String,
   timestamp_ms : Int,
 ) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let id = @core.NodeId::from_int(node_id)
       let root = match

--- a/ffi/lambda/semantic_wbtest.mbt
+++ b/ffi/lambda/semantic_wbtest.mbt
@@ -12,7 +12,7 @@ test "get_semantic_projection_json exposes free-variable overlay" {
 test "rename_semantic_node rejects free references" {
   let handle = create_editor("semantic-free-rename-ffi")
   set_text(handle, "λx. y")
-  let body_id = match lambda_handles.get(handle) {
+  let body_id = match lambda_registry.get(handle) {
     Some(h) =>
       match h.editor.get_proj_node() {
         Some(root) =>
@@ -36,7 +36,7 @@ test "rename_semantic_node rejects free references" {
 test "rename_semantic_node renames let binder through flat binding id" {
   let handle = create_editor("semantic-let-rename-ffi")
   set_text(handle, "let x = 1\nx")
-  let binding_id = match lambda_handles.get(handle) {
+  let binding_id = match lambda_registry.get(handle) {
     Some(h) =>
       match h.companion.get_module_projection() {
         Some(module_projection) =>
@@ -57,7 +57,7 @@ test "rename_semantic_node renames let binder through flat binding id" {
 test "rename_semantic_node renames binder and usages through text edits" {
   let handle = create_editor("semantic-rename-ffi")
   set_text(handle, "λx. x")
-  let body_id = match lambda_handles.get(handle) {
+  let body_id = match lambda_registry.get(handle) {
     Some(h) =>
       match h.editor.get_proj_node() {
         Some(root) =>

--- a/ffi/lambda/undo.mbt
+++ b/ffi/lambda/undo.mbt
@@ -18,7 +18,7 @@ pub fn insert_and_record(
   text : String,
   timestamp_ms : Int,
 ) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => try! h.editor.insert_and_record(text, timestamp_ms)
     None => ()
   }
@@ -27,7 +27,7 @@ pub fn insert_and_record(
 ///|
 /// Delete character at cursor (forward delete) and record for undo
 pub fn delete_and_record(handle : Int, timestamp_ms : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.delete_and_record(timestamp_ms)
     None => false
   }
@@ -36,7 +36,7 @@ pub fn delete_and_record(handle : Int, timestamp_ms : Int) -> Bool {
 ///|
 /// Delete character before cursor (backspace) and record for undo
 pub fn backspace_and_record(handle : Int, timestamp_ms : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.backspace_and_record(timestamp_ms)
     None => false
   }
@@ -49,7 +49,7 @@ pub fn set_text_and_record(
   new_text : String,
   timestamp_ms : Int,
 ) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.set_text_and_record(new_text, timestamp_ms)
     None => ()
   }
@@ -58,7 +58,7 @@ pub fn set_text_and_record(
 ///|
 /// Undo the last operation group.
 pub fn undo_manager_undo(handle : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.undo()
     None => false
   }
@@ -67,7 +67,7 @@ pub fn undo_manager_undo(handle : Int) -> Bool {
 ///|
 /// Redo the last undone operation group.
 pub fn undo_manager_redo(handle : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.redo()
     None => false
   }
@@ -77,7 +77,7 @@ pub fn undo_manager_redo(handle : Int) -> Bool {
 /// Undo and return sync ops as JSON for peer broadcast.
 /// Returns empty string if undo stack is empty.
 pub fn undo_and_export_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       match h.editor.undo_and_export() {
         Some(msg) => msg.to_json_string()
@@ -91,7 +91,7 @@ pub fn undo_and_export_json(handle : Int) -> String {
 /// Redo and return sync ops as JSON for peer broadcast.
 /// Returns empty string if redo stack is empty.
 pub fn redo_and_export_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) =>
       match h.editor.redo_and_export() {
         Some(msg) => msg.to_json_string()
@@ -104,7 +104,7 @@ pub fn redo_and_export_json(handle : Int) -> String {
 ///|
 /// Check if undo is possible
 pub fn undo_manager_can_undo(handle : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.can_undo()
     None => false
   }
@@ -113,7 +113,7 @@ pub fn undo_manager_can_undo(handle : Int) -> Bool {
 ///|
 /// Check if redo is possible
 pub fn undo_manager_can_redo(handle : Int) -> Bool {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.can_redo()
     None => false
   }
@@ -122,7 +122,7 @@ pub fn undo_manager_can_redo(handle : Int) -> Bool {
 ///|
 /// Enable or disable undo tracking
 pub fn undo_manager_set_tracking(handle : Int, enabled : Bool) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.set_tracking(enabled)
     None => ()
   }
@@ -131,7 +131,7 @@ pub fn undo_manager_set_tracking(handle : Int, enabled : Bool) -> Unit {
 ///|
 /// Clear both undo and redo stacks
 pub fn undo_manager_clear(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.clear_undo()
     None => ()
   }

--- a/ffi/lambda/view.mbt
+++ b/ffi/lambda/view.mbt
@@ -1,13 +1,10 @@
 // View FFI — ViewNode tree and ViewPatch streams for lambda editors
 
 ///|
-let view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
-
-///|
 /// Get the ViewNode tree as JSON for a lambda editor.
 /// Returns "null" if no projection is available or any protected read fails.
 pub fn get_view_tree_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
@@ -62,7 +59,7 @@ pub fn get_view_tree_json(handle : Int) -> String {
 /// Returns a JSON array of ViewPatch objects, or "[]" if any protected read
 /// fails.
 pub fn compute_view_patches_json(handle : Int) -> String {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
@@ -111,14 +108,7 @@ pub fn compute_view_patches_json(handle : Int) -> String {
           return "[]"
         }
       }
-      let state = match view_states.get(handle) {
-        Some(s) => s
-        None => {
-          let s = @editor.ViewUpdateState::ViewUpdateState()
-          view_states[handle] = s
-          s
-        }
-      }
+      let state = lambda_registry.view_state(handle)
       let patches = @editor.compute_view_patches(state, h.editor)
       Json::array(patches.map(fn(p) { p.to_json() })).stringify()
     }

--- a/ffi/lambda/workspace_memo_handle_wbtest.mbt
+++ b/ffi/lambda/workspace_memo_handle_wbtest.mbt
@@ -10,8 +10,8 @@ test "wmh A1: sanity sum equals known value across two editors" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_a1_a")
   let handle_b = create_editor("wmh_a1_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
       coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
@@ -46,12 +46,10 @@ test "wmh A1: sanity sum equals known value across two editors" {
     Err(r) => fail("teardown destroy h_b: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -63,8 +61,8 @@ test "wmh A2: reactivity — mutation in editor A invalidates and recomputes" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_a2_a")
   let handle_b = create_editor("wmh_a2_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
       coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
@@ -101,12 +99,10 @@ test "wmh A2: reactivity — mutation in editor A invalidates and recomputes" {
     Err(r) => fail("teardown destroy h_b: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -118,8 +114,8 @@ test "wmh A3: clean teardown — destroy succeeds after dispose" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_a3_a")
   let handle_b = create_editor("wmh_a3_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
       coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
@@ -154,12 +150,10 @@ test "wmh A3: clean teardown — destroy succeeds after dispose" {
     Err(r) => fail("A3 expected Ok destroying h_b after dispose, got \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -171,8 +165,8 @@ test "wmh B1: bad-cell rejection + atomicity" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_b1_a")
   let handle_b = create_editor("wmh_b1_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   let bad : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() { 0 })
   // A VALID dep on editor A precedes the bad dep (B's cell named under A, not
   // in A's protected surface). A validate-while-register impl would register
@@ -198,12 +192,10 @@ test "wmh B1: bad-cell rejection + atomicity" {
     Err(r) => fail("B1 destroy h_b: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -215,8 +207,8 @@ test "wmh B2: dead-editor rejection" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_b2_a")
   let handle_b = create_editor("wmh_b2_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   match coordinator.destroy_editor(h_a.editor_id) {
     Ok(_) => ()
     Err(r) => fail("B2 setup: destroy h_a should be Ok, got \{r}")
@@ -234,12 +226,10 @@ test "wmh B2: dead-editor rejection" {
     Err(r) => fail("B2 destroy h_b: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -250,7 +240,7 @@ test "wmh B2: dead-editor rejection" {
 test "panic wmh B3: registering the same memo twice aborts" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_b3_a")
-  let h_a = lambda_handles.get(handle_a).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
   let m : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     match coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
       Ok(s) => s.length()
@@ -278,8 +268,8 @@ test "wmh C: destroy refusal under live handle" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_c_a")
   let handle_b = create_editor("wmh_c_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
       coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
@@ -326,12 +316,10 @@ test "wmh C: destroy refusal under live handle" {
     Err(r) => fail("teardown destroy h_b: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -343,8 +331,8 @@ test "wmh D: idempotent dispose — second dispose is a safe no-op" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("wmh_d_a")
   let handle_b = create_editor("wmh_d_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
       coordinator.read_protected(h_a.editor_id, h_a.cells.parser_source) {
@@ -380,12 +368,10 @@ test "wmh D: idempotent dispose — second dispose is a safe no-op" {
     Err(r) => fail("D destroy h_b: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None

--- a/ffi/lambda/workspace_memo_smoke_wbtest.mbt
+++ b/ffi/lambda/workspace_memo_smoke_wbtest.mbt
@@ -16,8 +16,8 @@ test "smoke 5.1: sanity sum equals known value across two editors" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("smoke_5_1_a")
   let handle_b = create_editor("smoke_5_1_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
 
   // Build the workspace memo on the coordinator's runtime.
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
@@ -67,16 +67,14 @@ test "smoke 5.1: sanity sum equals known value across two editors" {
     Err(r) => fail("teardown destroy h_a: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   match coordinator.destroy_editor(h_b.editor_id) {
     Ok(_) => ()
     Err(r) => fail("teardown destroy h_b: \{r}")
   }
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -88,8 +86,8 @@ test "smoke 5.2: mutation in editor A invalidates workspace memo and recomputes"
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("smoke_5_2_a")
   let handle_b = create_editor("smoke_5_2_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
 
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
@@ -142,16 +140,14 @@ test "smoke 5.2: mutation in editor A invalidates workspace memo and recomputes"
     Err(r) => fail("teardown destroy h_a: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   match coordinator.destroy_editor(h_b.editor_id) {
     Ok(_) => ()
     Err(r) => fail("teardown destroy h_b: \{r}")
   }
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -163,8 +159,8 @@ test "smoke 5.3: destroy_editor refused while workspace memo dep is live" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("smoke_5_3_a")
   let handle_b = create_editor("smoke_5_3_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
 
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
@@ -233,16 +229,14 @@ test "smoke 5.3: destroy_editor refused while workspace memo dep is live" {
     Err(r) => fail("teardown destroy h_a: \{r}")
   }
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   match coordinator.destroy_editor(h_b.editor_id) {
     Ok(_) => ()
     Err(r) => fail("teardown destroy h_b: \{r}")
   }
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None
@@ -254,8 +248,8 @@ test "smoke 5.4: clean teardown sequence — each step returns Ok" {
   reset_coordinator_for_phase1_tests()
   let handle_a = create_editor("smoke_5_4_a")
   let handle_b = create_editor("smoke_5_4_b")
-  let h_a = lambda_handles.get(handle_a).unwrap()
-  let h_b = lambda_handles.get(handle_b).unwrap()
+  let h_a = lambda_registry.get(handle_a).unwrap()
+  let h_b = lambda_registry.get(handle_b).unwrap()
 
   let sum_d : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() {
     let sa = match
@@ -312,12 +306,10 @@ test "smoke 5.4: clean teardown sequence — each step returns Ok" {
 
   // Drain FFI bookkeeping so leaks don't pollute later tests.
   h_a.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_a)
-  view_states.remove(handle_a)
+  lambda_registry.remove(handle_a)
   pretty_view_states.remove(handle_a)
   h_b.companion.dispose_analysis_attachment()
-  lambda_handles.remove(handle_b)
-  view_states.remove(handle_b)
+  lambda_registry.remove(handle_b)
   pretty_view_states.remove(handle_b)
   if last_created_handle.val == Some(handle_b) {
     last_created_handle.val = None

--- a/ffi/lambda/ws.mbt
+++ b/ffi/lambda/ws.mbt
@@ -2,7 +2,7 @@
 
 ///|
 pub fn ws_on_open(handle : Int, ws : @editor.JsWebSocket) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.ws_on_open(ws)
     None => ()
   }
@@ -10,7 +10,7 @@ pub fn ws_on_open(handle : Int, ws : @editor.JsWebSocket) -> Unit {
 
 ///|
 pub fn ws_on_message(handle : Int, data : Bytes) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.ws_on_message(data)
     None => ()
   }
@@ -18,7 +18,7 @@ pub fn ws_on_message(handle : Int, data : Bytes) -> Unit {
 
 ///|
 pub fn ws_on_close(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.ws_on_close()
     None => ()
   }
@@ -26,7 +26,7 @@ pub fn ws_on_close(handle : Int) -> Unit {
 
 ///|
 pub fn ws_broadcast_edit(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.ws_broadcast_edit()
     None => ()
   }
@@ -34,7 +34,7 @@ pub fn ws_broadcast_edit(handle : Int) -> Unit {
 
 ///|
 pub fn ws_broadcast_cursor(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.ws_broadcast_cursor()
     None => ()
   }
@@ -47,7 +47,7 @@ pub fn ws_broadcast_cursor(handle : Int) -> Unit {
 /// `request_id` is compared against the current recovery epoch —
 /// stale firings (response already arrived) are silently ignored.
 pub fn ws_on_watchdog_fire(handle : Int, request_id : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => h.editor.on_watchdog_fire(request_id)
     None => ()
   }
@@ -59,7 +59,7 @@ pub fn ws_on_watchdog_fire(handle : Int, request_id : Int) -> Unit {
 /// which schedules a setTimeout(() => ws_on_watchdog_fire(handle, request_id)).
 /// Call once at editor construction time.
 pub fn ws_enable_watchdog(handle : Int, timeout_ms : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       h.editor.set_watchdog_timeout(timeout_ms)
       h.editor.set_watchdog_scheduler(
@@ -86,7 +86,7 @@ pub fn ws_enable_watchdog(handle : Int, timeout_ms : Int) -> Unit {
 /// registration so late-registering hosts can bootstrap — otherwise
 /// a status that changed before registration would never be observed.
 pub fn ws_set_status_callback(handle : Int) -> Unit {
-  match lambda_handles.get(handle) {
+  match lambda_registry.get(handle) {
     Some(h) => {
       h.editor.set_on_status_change(
         Some(fn(status) {

--- a/ffi/markdown/README.md
+++ b/ffi/markdown/README.md
@@ -20,6 +20,7 @@ No other MoonBit package imports `ffi/markdown`. Consumed by the Markdown block 
 
 - `dowdiness/canopy/editor`
 - `dowdiness/canopy/core`
+- `dowdiness/canopy/ffi/host` — shared handle/view-state registry and coordinator destroy gateway
 - `dowdiness/canopy/lang/markdown/edits` + `lang/markdown/companion`
 - `dowdiness/markdown` — Markdown AST type
 

--- a/ffi/markdown/lifecycle_phase1_wbtest.mbt
+++ b/ffi/markdown/lifecycle_phase1_wbtest.mbt
@@ -1,7 +1,7 @@
 // Whitebox integration tests for §P0b Phase 1b WS2: Markdown FFI editors
 // driven through the workspace coordinator. Covers spec §12 tests 1–4
 // (7-cell symmetric subset) — these need access to package-private
-// symbols (`markdown_handles`, `coordinator`, `MarkdownHandle` fields), so
+// symbols (`markdown_registry`, `coordinator`, `MarkdownHandle` fields), so
 // they live in a `_wbtest.mbt`.
 //
 // §12 #5 (`ProtectedCellDisposed`) is workspace-generic and covered by
@@ -17,27 +17,19 @@ fn reset_markdown_coordinator_for_phase1_tests() -> Unit {
   // registrations stay around with alive=true; each new test gets a fresh
   // EditorId from the monotonic counter so leakage cannot affect
   // correctness, only memory.
-  let keys = markdown_handles.keys().to_array()
-  for k in keys {
-    markdown_handles.remove(k)
-  }
-  let vkeys = markdown_view_states.keys().to_array()
-  for k in vkeys {
-    markdown_view_states.remove(k)
-  }
+  markdown_registry.clear()
 }
 
 ///|
 fn drain_markdown_handle_after_direct_coordinator_destroy(handle : Int) -> Unit {
-  markdown_handles.remove(handle)
-  markdown_view_states.remove(handle)
+  markdown_registry.remove(handle)
 }
 
 ///|
 test "spec §12 #1 (md): each protected cell reads through read_protected" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_test_agent_one")
-  let h = markdown_handles.get(handle).unwrap()
+  let h = markdown_registry.get(handle).unwrap()
   let id = h.editor_id
   match coordinator.read_protected(id, h.cells.parser_syntax_tree) {
     Ok(_) => ()
@@ -74,7 +66,7 @@ test "spec §12 #1 (md): each protected cell reads through read_protected" {
 test "spec §12 #2 (md): destroy refused while depended-upon; succeeds after unregister_dep" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_test_agent_two")
-  let h = markdown_handles.get(handle).unwrap()
+  let h = markdown_registry.get(handle).unwrap()
   let id = h.editor_id
   let parser_ast_id = h.cells.parser_ast.cell_id()
   let synth_id = parser_ast_id
@@ -88,15 +80,14 @@ test "spec §12 #2 (md): destroy refused while depended-upon; succeeds after unr
     Ok(_) => ()
     Err(report) => fail("expected Ok after unregister_dep, got \{report}")
   }
-  markdown_handles.remove(handle)
-  markdown_view_states.remove(handle)
+  markdown_registry.remove(handle)
 }
 
 ///|
 test "spec §12 #3 (md): read_protected after destroy returns EditorDestroyed" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_test_agent_three")
-  let h = markdown_handles.get(handle).unwrap()
+  let h = markdown_registry.get(handle).unwrap()
   let id = h.editor_id
   let parser_source_cell = h.cells.parser_source
   destroy_markdown_editor(handle)
@@ -114,8 +105,8 @@ test "spec §12 #4 (md): read_protected rejects cells from a different editor" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle_a = create_markdown_editor("md_agent_alpha")
   let handle_b = create_markdown_editor("md_agent_beta")
-  let h_a = markdown_handles.get(handle_a).unwrap()
-  let h_b = markdown_handles.get(handle_b).unwrap()
+  let h_a = markdown_registry.get(handle_a).unwrap()
+  let h_b = markdown_registry.get(handle_b).unwrap()
   match coordinator.read_protected(h_b.editor_id, h_a.cells.parser_ast) {
     Ok(_) => fail("expected CellNotInProtectedSurface")
     Err(report) => assert_eq(report.kind, @workspace.CellNotInProtectedSurface)
@@ -202,7 +193,7 @@ test "workstream 2 (md): compute_view_patches collapses to [] after coordinator 
   if !alive.contains("\"FullTree\"") {
     fail("expected pre-destroy initial render to emit FullTree, got \{alive}")
   }
-  let h = markdown_handles.get(handle).unwrap()
+  let h = markdown_registry.get(handle).unwrap()
   let id = h.editor_id
   match coordinator.destroy_editor(id) {
     Ok(_) => ()
@@ -211,16 +202,15 @@ test "workstream 2 (md): compute_view_patches collapses to [] after coordinator 
   // FFI bookkeeping retained — coordinator side is destroyed, but the
   // handle entry stays so subsequent calls still hit the protected-read
   // path (and that path's Err arm produces "[]").
-  match markdown_handles.get(handle) {
+  match markdown_registry.get(handle) {
     Some(_) => ()
     None =>
       fail(
-        "expected markdown_handles to retain handle after direct coordinator destroy",
+        "expected markdown_registry to retain handle after direct coordinator destroy",
       )
   }
   assert_eq(markdown_compute_view_patches_json(handle), "[]")
-  markdown_handles.remove(handle)
-  markdown_view_states.remove(handle)
+  markdown_registry.remove(handle)
 }
 
 ///|
@@ -235,7 +225,7 @@ test "workstream 3 (md): markdown_export_text collapses to empty after coordinat
   if alive == "" {
     fail("expected exported markdown before coordinator destroy")
   }
-  let h = markdown_handles.get(handle).unwrap()
+  let h = markdown_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")
@@ -249,7 +239,7 @@ test "workstream 3 (md): markdown_apply_edit rejects after coordinator destroy" 
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_apply_destroy_agent")
   markdown_set_text(handle, "# Pre-destroy\n")
-  let h = markdown_handles.get(handle).unwrap()
+  let h = markdown_registry.get(handle).unwrap()
   match coordinator.destroy_editor(h.editor_id) {
     Ok(_) => ()
     Err(report) => fail("coordinator destroy: \{report}")

--- a/ffi/markdown/lifecycle_phase1_wbtest.mbt
+++ b/ffi/markdown/lifecycle_phase1_wbtest.mbt
@@ -80,7 +80,7 @@ test "spec §12 #2 (md): destroy refused while depended-upon; succeeds after unr
     Ok(_) => ()
     Err(report) => fail("expected Ok after unregister_dep, got \{report}")
   }
-  markdown_registry.remove(handle)
+  drain_markdown_handle_after_direct_coordinator_destroy(handle)
 }
 
 ///|
@@ -210,7 +210,7 @@ test "workstream 2 (md): compute_view_patches collapses to [] after coordinator 
       )
   }
   assert_eq(markdown_compute_view_patches_json(handle), "[]")
-  markdown_registry.remove(handle)
+  drain_markdown_handle_after_direct_coordinator_destroy(handle)
 }
 
 ///|

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -62,7 +62,6 @@ pub fn destroy_markdown_editor(handle : Int) -> Unit {
   }
   let _ = markdown_registry.destroy(
     coordinator,
-    handle,
     h.editor_id,
     "destroy_markdown_editor",
   )

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -19,17 +19,16 @@ priv struct MarkdownHandle {
 let coordinator : @workspace.Coordinator = @workspace.Coordinator::new()
 
 ///|
-let markdown_handles : Map[Int, MarkdownHandle] = Map::default()
-
-///|
-let markdown_view_states : Map[Int, @editor.ViewUpdateState] = Map::default()
+/// Generic handle/view-state bookkeeping shared with the other language FFI
+/// packages via `ffi/host`. Keyed by the exported integer handle.
+let markdown_registry : @host.HostRegistry[MarkdownHandle] = @host.HostRegistry::HostRegistry()
 
 // ── Lifecycle ────────────────────────────────────────────────────────────
 
 ///|
 /// Build a Markdown editor on the shared runtime, then atomically register
 /// its protected cells with the coordinator. Returns the freshly-allocated
-/// `EditorId`. Aborting at any step leaves `markdown_handles` untouched
+/// `EditorId`. Aborting at any step leaves `markdown_registry` untouched
 /// (atomic-boundary observation, spec §3.6).
 fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId {
   let editor = @md_companion.new_markdown_editor(
@@ -41,7 +40,7 @@ fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId {
     agent_id,
     cells.to_protected_reads(),
   )
-  markdown_handles[editor_id.0] = { editor, editor_id, cells }
+  markdown_registry.insert(editor_id.0, { editor, editor_id, cells })
   editor_id
 }
 
@@ -53,28 +52,25 @@ pub fn create_markdown_editor(agent_id : String) -> Int {
 ///|
 /// Destroy a Markdown editor and free its resources. The coordinator gateway
 /// refuses if workspace deps still reference the editor; in that case the
-/// FFI-side bookkeeping (markdown_handles entry, view_states entry) is
+/// FFI-side bookkeeping (registry handle entry, view-state entry) is
 /// intentionally left intact so reads of cached state remain valid. Phase 1
 /// behavior matches Lambda's `destroy_editor` (spec §5.3).
 pub fn destroy_markdown_editor(handle : Int) -> Unit {
-  let h = match markdown_handles.get(handle) {
+  let h = match markdown_registry.get(handle) {
     Some(v) => v
     None => return
   }
-  match coordinator.destroy_editor(h.editor_id) {
-    Ok(_) => ()
-    Err(report) => {
-      println("destroy_markdown_editor refused: \{report}")
-      return
-    }
-  }
-  markdown_handles.remove(handle)
-  markdown_view_states.remove(handle)
+  let _ = markdown_registry.destroy(
+    coordinator,
+    handle,
+    h.editor_id,
+    "destroy_markdown_editor",
+  )
 }
 
 ///|
 pub fn markdown_get_text(handle : Int) -> String {
-  match markdown_handles.get(handle) {
+  match markdown_registry.get(handle) {
     Some(h) => h.editor.get_text()
     None => ""
   }
@@ -87,7 +83,7 @@ pub fn markdown_get_text(handle : Int) -> String {
 /// ZWSP character itself — leaving ZWSP inside other content (code blocks,
 /// paragraphs with mixed text) untouched.
 pub fn markdown_export_text(handle : Int) -> String {
-  match markdown_handles.get(handle) {
+  match markdown_registry.get(handle) {
     Some(h) => {
       let _ = match
         coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
@@ -113,7 +109,7 @@ pub fn markdown_export_text(handle : Int) -> String {
 
 ///|
 pub fn markdown_set_text(handle : Int, text : String) -> Unit {
-  match markdown_handles.get(handle) {
+  match markdown_registry.get(handle) {
     Some(h) => h.editor.set_text(text)
     None => ()
   }
@@ -140,7 +136,7 @@ pub fn markdown_apply_edit(
   param2 : Int,
   timestamp_ms : Int,
 ) -> String {
-  match markdown_handles.get(handle) {
+  match markdown_registry.get(handle) {
     Some(h) => {
       let nid = @core.NodeId::from_int(node_id)
       let op : @md_edits.MarkdownEditOp = match op_type {
@@ -218,18 +214,11 @@ pub fn markdown_apply_edit(
 /// Derived cell, and reading it raw doesn't violate any cell-protection
 /// invariant.
 pub fn markdown_compute_view_patches_json(handle : Int) -> String {
-  let h = match markdown_handles.get(handle) {
+  let h = match markdown_registry.get(handle) {
     Some(v) => v
     None => return "[]"
   }
-  let state = match markdown_view_states.get(handle) {
-    Some(s) => s
-    None => {
-      let s = @editor.ViewUpdateState::ViewUpdateState()
-      markdown_view_states[handle] = s
-      s
-    }
-  }
+  let state = markdown_registry.view_state(handle)
   let proj_opt = match
     coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
     Ok(p) => p

--- a/ffi/markdown/moon.pkg
+++ b/ffi/markdown/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/core",
+  "dowdiness/canopy/ffi/host",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/companion" @md_companion,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,


### PR DESCRIPTION
## Summary

S4 PR1 of the architecture redesign ([plan](docs/plans/2026-06-12-s4-ffi-host-extraction.md), Steps 1–5): extract the repeated Tier-3 FFI host wiring from `ffi/lambda`, `ffi/json`, and `ffi/markdown` into a shared internal `ffi/host` package, while keeping each `ffi/<L>` its own MoonBit JS link root.

`ffi/host` owns only generic bookkeeping — `HostRegistry[H]` with the handle map keyed by the exported integer handle, the per-handle ordinary `ViewUpdateState`, and the coordinator destroy gateway (refusal leaves FFI bookkeeping intact; success removes it before language-local cleanup). Fields are private; mutation is method-only. Imports are limited to `editor` + `workspace/coordinator`; no JS export list.

Everything language-specific stays language-local per the plan's scope decision: handle records, protected-cell bundles, `assemble_*` constructors, and all lambda extras (companion storage, `last_created_handle`, `pretty_view_states`, LLM/relay/WebSocket wiring, analysis-attachment disposal). Lambda's destroy ordering is preserved: refusal leaves bookkeeping + attachment intact; success removes host bookkeeping, then pretty view state and `last_created_handle`, then disposes the attachment.

Migration order json → markdown → lambda with a per-step `.mbti`-unchanged invariant: `ffi/{json,markdown,lambda}/pkg.generated.mbti` have **zero diff**; the only new public surface is `ffi/host/pkg.generated.mbti`. The three `moon.pkg` export arrays are byte-identical (only the host import line was added). Whitebox tests that wrote the private maps were rewritten against registry methods (`clear`/`remove`/`get`/`contains`/`size`); no visibility was promoted.

## Bundle sizes (`cd examples/web && npm run build`, minified)

| chunk | clean main | with change | delta | gzip (clean → with change) |
|---|---|---|---|---|
| json | 370.64 kB | 371.06 kB | +0.42 kB | 89.0 → 89.17 kB |
| markdown | 333.55 kB | 333.97 kB | +0.42 kB | 80.8 → 81.00 kB |
| lambda | 685.17 kB | 685.57 kB | +0.40 kB | 155.4 → 155.56 kB |

All deltas are in the spike-proven sub-kB range (operative 2026-06-12 gate); per-entry chunk splitting is preserved.

## Reuse check

- Reused: `@workspace.Coordinator::destroy_editor` (gateway), `@editor.ViewUpdateState`, core `Map::get_or_init` for get-or-create (host `view_state` and lambda `pretty_view_states`), existing wbtest drain-helper pattern.
- Checked but not used: no existing generic handle-registry abstraction exists in `core`/`editor`/`lib` (the three per-language map pairs were the duplication this PR removes).
- New surface: `HostRegistry[H]` — responsibility boundary is generic handle/view-state bookkeeping + the destroy gateway only; `contains`/`size` exist for cross-package wbtest assertions (lambda wbtests cannot see host's private fields).

## Pre-PR review

`/code-review` high (7 finder angles, adversarial verify): 4 angles independently flagged the original `destroy(id, editor_id)` parameter pair as a latent mismatched-pair hazard → fixed by deriving the key from `editor_id.0`. Also applied: destroy Ok-arm now calls `remove()`; `get_or_init` for both get-or-create sites; doc-comment no longer overclaims gateway enforcement (`remove`/`clear` are documented test-drain bypasses); drain helpers used consistently in json/markdown wbtests; post-S4 anchor note added to the 2026-05-24 call-flow research doc.

Known seam kept as-is (plan scope): `HostRegistry::destroy` returns `Bool` and logs the refusal report itself; the Phase-2 "surface refusal to JS via a dedicated FFI error channel" will need to widen that return type — deferred with the rest of Phase 2.

## Verification

- `NEW_MOON_MOD=0 moon check` clean after every step
- `NEW_MOON_MOD=0 moon test`: full workspace green (257 wasm-gc / 1355 js / 46 native); per-package: host 5, json 12, markdown 9, lambda 48 (test counts unchanged vs main)
- `git diff '*.mbti'`: only `ffi/host/pkg.generated.mbti` added; language `.mbti` files unchanged
- `ffi/host` imported only by the three FFI packages (verified by grep over all `moon.pkg`)

Out of scope (separate PRs per plan): PR2 export manifests + discrepancy check; PR3 `crdt_reexport.mbt` deletion. No S2 frozen surfaces or `lang/runtime` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
