### PR TITLE
feat(redesign): substrate governance ADR + egw resolver-identity CI guard (S5a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Check shared-substrate version drift
         run: ./scripts/check-shared-substrate.sh
 
+      - name: Check egw resolver identity
+        run: ./scripts/check-egw-resolver-identity.sh
+
       - name: Check moon update is retry-wrapped
         run: ./scripts/check-moon-update-wrapped.sh
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -22,7 +22,7 @@ The main gating workflow. Job names match the file:
 
 | Job | What it runs |
 |-----|--------------|
-| `dep-check` | `./scripts/check-deps.sh`, `./scripts/check-moon-update-wrapped.sh`, `./scripts/test-moon-update-wrapper.sh` |
+| `dep-check` | `./scripts/check-deps.sh`, `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh` |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check .`, `./scripts/run-moon-module.sh test .`, `moon build --release` |
 | `test-submodules` | Matrix over `event-graph-walker`, `loom/loom`, `svg-dsl`, `graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `examples/ideal`, `examples/block-editor`, `examples/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |

--- a/docs/decisions/2026-06-10-shared-substrate-incr-version-lock.md
+++ b/docs/decisions/2026-06-10-shared-substrate-incr-version-lock.md
@@ -2,6 +2,11 @@
 
 **Date:** 2026-06-10
 **Status:** Accepted (decision record)
+**Amended by:** [Substrate governance: one consumption policy per dependency](2026-06-12-substrate-governance.md)
+(2026-06-12 — generalizes this record's single-dependency policy to all
+`dowdiness/*` substrate and adds the `event-graph-walker` resolver-identity
+guard alongside the incr drift guard; the lock value, bump protocol, and
+deferred cross-repo extension point below remain authoritative here)
 **Closes:** [#441](https://github.com/dowdiness/canopy/issues/441) (BAND 1b — cross-repo `incr` version-lock)
 **Related:**
 [Ecosystem vision §5.2 / §5.7 / §7.3](../research/2026-06-01-moondsp-canopy-ecosystem-vision.md) ·

--- a/docs/decisions/2026-06-12-substrate-governance.md
+++ b/docs/decisions/2026-06-12-substrate-governance.md
@@ -1,0 +1,128 @@
+# Substrate governance: one consumption policy per dependency
+
+**Date:** 2026-06-12
+**Status:** Accepted (decision record)
+**Amends:** [Shared-substrate `incr` version lock](2026-06-10-shared-substrate-incr-version-lock.md)
+(generalizes its single-dependency policy to the full `dowdiness/*` substrate;
+does not replace it — the incr lock value, bump protocol, and deferred
+cross-repo extension point remain authoritative there)
+**Related:** architecture redesign proposal §6 S5a
+([docs/plans/2026-06-11-architecture-redesign-proposal.md](../plans/2026-06-11-architecture-redesign-proposal.md)) ·
+resolver-identity guard `scripts/check-egw-resolver-identity.sh` (this PR) ·
+incr drift guard `scripts/check-shared-substrate.sh` ([#574](https://github.com/dowdiness/canopy/pull/574))
+
+## Why this record exists
+
+The 2026-06-10 ADR governs one dependency (`incr`). The redesign proposal's
+substrate rule generalizes it: **every `dowdiness/*` dependency has one
+declared ownership policy — either a single consumption mechanism, or an
+explicit dual-source exception with resolver-identity CI and a removal /
+re-evaluation date.** This record names that policy per dependency and
+documents the one exception that exists today: `event-graph-walker`.
+
+## What moon actually does with two sources (probed 2026-06-12)
+
+`dowdiness/event-graph-walker` is declared from four manifests in a canopy
+workspace build: three path-dep the **direct submodule** `./event-graph-walker`
+(canopy root, `examples/ideal`, `examples/block-editor`) and one path-deps
+**loom's nested copy** `loom/event-graph-walker` (`loom/examples/lambda`,
+via `../../event-graph-walker`). Probe findings, against the canopy CI
+toolchain on this date:
+
+1. **moon dedupes the module by name and silently picks one winner.** The
+   resolved package graph (`_build/packages.json`) sources *every*
+   `dowdiness/event-graph-walker` package from the nested copy — including for
+   the three members that explicitly path-dep the direct submodule. Zero
+   occurrences of the direct path; no warning, no error. Which copy wins is
+   unspecified behavior, observed not documented.
+2. **moon validates no version constraint on path-deps.** With the winning
+   copy's `moon.mod` edited to `version = "9.9.9"` against canopy's declared
+   `"version": "0.3.0"`, `moon check` exits 0 with no diagnostic.
+3. **Identity holds today by accident, not machinery.** Both gitlinks pin
+   `b72d481` (egw 0.3.0). Nothing in the toolchain keeps them aligned; a
+   drifted pair would mean canopy builds against an egw it does not declare,
+   with zero signal.
+
+These probes are point-in-time facts about an unspecified toolchain behavior —
+the guard below asserts identity precisely so that the winner-selection rule
+never matters.
+
+## Decision
+
+1. **One governed consumption policy per `dowdiness/*` dependency** (table
+   below). New dependencies declare their mechanism on introduction; a second
+   mechanism for an existing dependency requires amending this record with a
+   dual-source exception entry (guard + date), not just a manifest edit.
+
+2. **`event-graph-walker` is the sole dual-source exception**, transitional.
+   Its two sources (direct submodule + loom's nested copy) are guarded by
+   `scripts/check-egw-resolver-identity.sh` in the Dependency Rules CI job:
+   both gitlinks must pin the same commit, and that commit's declared version
+   must match canopy's manifest. The guard reads what the *commits* pin
+   (gitlink level), so a same-version-string / different-content drift — which
+   no version check can see and moon never reports — fails CI.
+
+3. **De-dup direction (binds S5b): loom migrates to registry
+   `event-graph-walker`; canopy keeps its direct submodule.** The originally
+   drafted inverse — drop canopy's submodule and path-dep loom's nested copy —
+   was rejected (Codex amendment): it would add a loom PR + pointer bump as a
+   merge gate to *every* egw change. After S5b executes, loom's nested copy
+   disappears, canopy's direct submodule becomes the single source within the
+   canopy workspace (its path-dep shadowing loom's registry pin — the same
+   normal override semantics as order-tree below), and the exception entry
+   here is closed. The guard fails loudly if the nested gitlink disappears, so
+   the S5b PR must update it deliberately to compare submodule version against
+   loom's registry pin.
+
+4. **Re-evaluation date: 2026-09-12.** If S5b has not executed by then, this
+   exception must be re-justified or the de-dup re-planned — dual-source
+   without a horizon is exactly what this record exists to prevent.
+
+## Policy table (verified 2026-06-12)
+
+Mechanisms: `registry` (mooncakes pin) · `in-repo` (path-dep to a canopy
+workspace directory) · `submodule` (path-dep into a vendored submodule) ·
+`dual` (exception, guarded).
+
+| Dependency | Mechanism | Policy notes |
+|------------|-----------|--------------|
+| `dowdiness/incr` | registry 0.9.0 | Governed by the 2026-06-10 version-lock ADR; intra-repo drift guard `check-shared-substrate.sh` |
+| `dowdiness/event-graph-walker` | **dual** (direct submodule + loom nested copy) | Exception §2–4 above; guard `check-egw-resolver-identity.sh`; closes with S5b; re-evaluate by 2026-09-12 |
+| loom family: `loom`, `seam`, `pretty`, `text_change`, `moji`, `lambda`, `json`, `markdown`, `egglog`, `egraph`, `graph-dsl` | submodule (`./loom/...`) | Single mechanism — every consumer path-deps into the one vendored loom tree |
+| in-repo libs: `byte_codec`, `zipper`, `btree`, `visualizer`, `dom_boundary`, `canopy-canvas-graph`, `rabbita_codemirror`, `rabbita-menu`, `rabbita-tabs`, `rabbita-treeview`, `rabbita-resizable`, `rabbita-status`, `rabbita-context-menu` | in-repo | Single mechanism — workspace members path-dep'ing each other |
+| `dowdiness/order-tree` | submodule (`./order-tree`) | canopy's path-dep shadows egw's registry pin 0.1.0 inside the workspace build — normal moon override semantics, one declared source per build context, not a dual-source exception |
+| `dowdiness/alga` | submodule (`./alga`) | Same shadowing shape (egw pins 0.3.0, graphviz pins 0.2.0; the path-dep wins in-workspace) |
+| `dowdiness/svg-dsl` | submodule (`./svg-dsl`) | Shadows graphviz's registry pin in-workspace |
+| `dowdiness/graphviz` | submodule (`./graphviz`) | Shadows loom's registry pin 0.1.0 in-workspace |
+| `dowdiness/rle` | registry 0.2.2 | The `./rle` submodule is **build-inert** — no manifest path-deps it; builds resolve rle from the registry (`.mooncakes`). Kept for development against rle source; flagged: if it is still inert at the S5b re-evaluation, remove it or wire it in |
+| `moonbit-community/rabbita` | submodule (`./rabbita`, vendored fork) | Single mechanism; fork status and patch documented in CLAUDE.md / the rabbita skill |
+
+**Shadowing is not dual-source.** A registry pin inside a vendored module's
+own manifest (egw pinning order-tree, graphviz pinning svg-dsl) is that
+module's *standalone-build* declaration; inside the canopy workspace exactly
+one path-dep'd directory provides the module, so there is one source per build
+context and nothing to guard. The egw case is categorically different: **two
+path-dep'd directories with the same module name in one workspace build**,
+where moon picks a winner silently. That shape — and only that shape —
+requires a resolver-identity guard.
+
+## Consequences
+
+- A drifted egw pair (the silent failure probe 1+2 prove possible) now fails
+  the Dependency Rules job with the bump order spelled out
+  (egw → loom → canopy, per the version-lock ADR's bottom-up protocol).
+- S5b has its direction decided here and a forcing function: the guard breaks
+  loudly when loom drops its nested copy, so the topology change and the guard
+  update land in the same PR.
+- Introducing a second source for any other substrate dependency has a named
+  cost: amend this record, add a guard, set a date — or don't do it.
+- The build-inert `./rle` submodule has a dated disposition instead of being
+  silently carried.
+
+## Source of truth on drift
+
+Manifests and gitlinks are authoritative; the table is a 2026-06-12 snapshot.
+If they disagree, update this record. The durable content is the judgment:
+one mechanism per dependency, exceptions are guarded and dated, and
+resolver identity is enforced by CI because the toolchain has been shown to
+enforce nothing.

--- a/scripts/check-egw-resolver-identity.sh
+++ b/scripts/check-egw-resolver-identity.sh
@@ -62,7 +62,10 @@ fi
 # version must match what canopy's moon.mod.json claims for the dep — moon
 # itself never checks this (probe above).
 pinned_version=$(git -C event-graph-walker show "${direct_sha}:moon.mod" \
-  | sed -n 's/^version = "\(.*\)"/\1/p')
+  | sed -n 's/^version = "\(.*\)"/\1/p') \
+  || fail "cannot read moon.mod from event-graph-walker at ${direct_sha}
+  (submodule object store missing the pinned commit? run:
+  git submodule update --init --recursive)"
 [ -n "${pinned_version}" ] \
   || fail "cannot extract version from event-graph-walker moon.mod at ${direct_sha}"
 

--- a/scripts/check-egw-resolver-identity.sh
+++ b/scripts/check-egw-resolver-identity.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# event-graph-walker resolver-identity guard (S5a dual-source exception;
+# docs/decisions/2026-06-12-substrate-governance.md).
+#
+# Invariant: the two egw sources reachable in a canopy build pin the SAME
+# commit, and that commit's declared version matches canopy's manifest:
+#   (a) canopy's direct submodule   — gitlink HEAD:event-graph-walker
+#   (b) loom's nested submodule     — gitlink <HEAD:loom>:event-graph-walker
+#
+# Why this is enforced here and nowhere else (probed 2026-06-12, moon in
+# canopy CI toolchain): moon dedupes the module by NAME and silently picks one
+# winner — the resolved package graph (_build/packages.json) sources every
+# dowdiness/event-graph-walker package from the nested copy (b), even for
+# workspace members whose manifest path-deps the direct submodule (a). moon
+# also validates no version constraint on path-deps: with the winning copy's
+# moon.mod set to version 9.9.9 against canopy's declared "0.3.0", moon check
+# exits 0 with no warning. So if the two gitlinks drift, canopy builds against
+# whichever copy moon happens to pick, with zero toolchain signal.
+#
+# This guard asserts what the COMMITS pin (gitlink-level), not what local
+# working trees contain. It requires the loom submodule (and its nested egw)
+# to be initialized — CI checks out with `submodules: recursive`.
+#
+# If the nested copy disappears from loom's tree (S5b: loom migrates to
+# registry egw), this guard must be UPDATED in the same PR to compare canopy's
+# submodule version against loom's registry pin — it fails loudly rather than
+# guessing.
+set -euo pipefail
+cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+fail() { echo "check-egw-resolver-identity: $*" >&2; exit 1; }
+
+direct_sha=$(git rev-parse HEAD:event-graph-walker) \
+  || fail "cannot read gitlink HEAD:event-graph-walker"
+loom_sha=$(git rev-parse HEAD:loom) \
+  || fail "cannot read gitlink HEAD:loom"
+
+if ! git -C loom rev-parse --verify "${loom_sha}^{commit}" >/dev/null 2>&1; then
+  fail "loom submodule object store lacks the pinned commit ${loom_sha}.
+  Initialize submodules first: git submodule update --init --recursive"
+fi
+
+if ! nested_sha=$(git -C loom rev-parse "${loom_sha}:event-graph-walker" 2>/dev/null); then
+  fail "loom@${loom_sha} has no event-graph-walker gitlink.
+  The dual-source topology this guard asserts has changed (S5b executed?).
+  Update this guard in the same PR: compare canopy's submodule version
+  against loom's registry pin instead. See
+  docs/decisions/2026-06-12-substrate-governance.md."
+fi
+
+if [ "${direct_sha}" != "${nested_sha}" ]; then
+  fail "event-graph-walker gitlink drift between the two resolution paths:
+    canopy direct submodule (HEAD:event-graph-walker):      ${direct_sha}
+    loom nested submodule   (<HEAD:loom>:event-graph-walker): ${nested_sha}
+  moon silently builds the whole workspace against ONE of these (observed:
+  the nested copy) — a drifted pair means canopy may not be building the egw
+  it declares. Bump the lagging gitlink; bump order per the version-lock ADR:
+  egw -> loom -> canopy (each merged before its parent advances)."
+fi
+
+# Version layer: the (now provably single) pinned egw commit's declared
+# version must match what canopy's moon.mod.json claims for the dep — moon
+# itself never checks this (probe above).
+pinned_version=$(git -C event-graph-walker show "${direct_sha}:moon.mod" \
+  | sed -n 's/^version = "\(.*\)"/\1/p')
+[ -n "${pinned_version}" ] \
+  || fail "cannot extract version from event-graph-walker moon.mod at ${direct_sha}"
+
+declared_version=$(python3 -c "
+import json
+spec = json.load(open('moon.mod.json'))['deps']['dowdiness/event-graph-walker']
+print(spec['version'] if isinstance(spec, dict) else spec)
+") || fail "cannot read dowdiness/event-graph-walker dep from moon.mod.json"
+
+if [ "${pinned_version}" != "${declared_version}" ]; then
+  fail "event-graph-walker version mismatch:
+    pinned submodule commit declares: ${pinned_version}
+    canopy moon.mod.json declares:    ${declared_version}
+  moon does not validate path-dep versions — align them by hand."
+fi
+
+echo "OK — both egw resolution paths pin ${direct_sha} (version ${pinned_version})."


### PR DESCRIPTION
## Summary

- **S5a of the architecture redesign** (proposal §6): substrate governance ADR + `event-graph-walker` resolver-identity CI guard. Governance + guard only — S5b (the actual de-dup) and S4 PR3 (`crdt_reexport.mbt` deletion) are explicitly out of scope.
- New ADR `docs/decisions/2026-06-12-substrate-governance.md`: one consumption policy per `dowdiness/*` dependency; egw is the sole dual-source exception (transitional, re-evaluate by **2026-09-12**). **Amends, does not replace,** the 2026-06-10 incr version-lock ADR. Binds the S5b direction: loom migrates to registry egw, canopy keeps its direct submodule (the inverse was rejected per the Codex amendment — it adds a loom PR gate to every egw change).
- New guard `scripts/check-egw-resolver-identity.sh` in the Dependency Rules job, next to `check-shared-substrate.sh`.

## Pre-stage unknown resolved (probed 2026-06-12)

The proposal pinned "moon's dual-egw resolution behavior" as an unknown to establish before writing the ADR. Probes (clean spike worktree at `03d35b6`):

1. **moon dedupes the module by name and silently picks one winner.** Four manifests declare `dowdiness/event-graph-walker` — three path-dep the direct submodule (root, `examples/ideal`, `examples/block-editor`), one path-deps loom's nested copy (`loom/examples/lambda`). The resolved package graph (`_build/packages.json`) sources **all 171** egw package references from the nested copy and **zero** from the direct submodule. No warning, no error.
2. **moon validates no version constraint on path-deps.** With the winning copy's `moon.mod` edited to `version = "9.9.9"` against canopy's declared `"0.3.0"`, `moon check` exits 0 with no diagnostic.
3. Both gitlinks pin `b72d481` (0.3.0) today — identity by accident, not machinery.

Hence the guard asserts identity at the **gitlink level** (commit SHA), not just version strings: a same-version/different-content drift is invisible to every other layer.

## Positive controls (pattern from #588)

Detector demonstrated against known-bad states before trusting its pass:

- **Control 1 — gitlink drift** (throwaway commit moving the direct gitlink to `HEAD~1`): exits 1, prints both SHAs and the bump order (`egw -> loom -> canopy`).
- **Control 2 — declared-version mismatch** (`moon.mod.json` edited to `0.4.0`): exits 1, prints `pinned 0.3.0` vs `declared 0.4.0`.
- Restored state: exits 0 — `OK — both egw resolution paths pin b72d481... (version 0.3.0)`.

The guard also fails loudly (with instructions) if loom's nested egw gitlink disappears, forcing the S5b PR to update it deliberately.

## Reuse check

No new MoonBit symbols (bash + docs only).

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `load_manifest()` dual-format parser | `scripts/check-shared-substrate.sh` | No | Repo convention is self-contained guard scripts (check-shared-substrate.sh itself documents forking from check-deps.sh); this guard needs one version string from one known-format manifest, commit-level via `git show`, which the workspace-sweeping parser doesn't do |
| repo-root `cd` preamble | `check-deps.sh` / `check-shared-substrate.sh` | Yes | Same idiom copied verbatim |
| Dependency Rules CI job | `.github/workflows/ci.yml` | Yes | Guard added as a step, no new job |

## Also fixed

`docs/CI_CD.md`'s `dep-check` row was already stale (missing `check-shared-substrate.sh` from #574 and `check-export-manifest.mjs` from #588); updated to match the actual step list including the new guard.

## Validation

- `shellcheck` clean; guard passes on the branch (`EXIT=0`).
- Both positive controls demonstrated (above).
- No MoonBit code touched — no `.mbti` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
