### PR TITLE
fix(redesign): egw guard scans all workspace-member declared versions (S5a follow-up)

### DIFF
--- a/docs/decisions/2026-06-12-substrate-governance.md
+++ b/docs/decisions/2026-06-12-substrate-governance.md
@@ -58,7 +58,12 @@ never matters.
    Its two sources (direct submodule + loom's nested copy) are guarded by
    `scripts/check-egw-resolver-identity.sh` in the Dependency Rules CI job:
    both gitlinks must pin the same commit, and that commit's declared version
-   must match canopy's manifest. The guard reads what the *commits* pin
+   must match every canopy workspace member manifest that declares the dep
+   (root, `examples/ideal`, `examples/block-editor` today — discovered by
+   scanning `moon.work` members, so a future consumer is covered
+   automatically; submodule-owned manifests such as loom's belong to their
+   own repos and are covered by the gitlink check instead). The guard reads
+   what the *commits* pin
    (gitlink level), so a same-version-string / different-content drift — which
    no version check can see and moon never reports — fails CI.
 

--- a/scripts/check-egw-resolver-identity.sh
+++ b/scripts/check-egw-resolver-identity.sh
@@ -59,8 +59,12 @@ if [ "${direct_sha}" != "${nested_sha}" ]; then
 fi
 
 # Version layer: the (now provably single) pinned egw commit's declared
-# version must match what canopy's moon.mod.json claims for the dep — moon
-# itself never checks this (probe above).
+# version must match what EVERY canopy workspace member that declares the dep
+# claims for it — moon itself never checks this (probe above), and a bump PR
+# that edits the root manifest + gitlinks can silently miss the example
+# manifests (examples/ideal, examples/block-editor also pin a version).
+# Scope: moon.work members, mirroring check-shared-substrate.sh — submodule
+# manifests (e.g. loom/examples/lambda's) belong to their own repos.
 pinned_version=$(git -C event-graph-walker show "${direct_sha}:moon.mod" \
   | sed -n 's/^version = "\(.*\)"/\1/p') \
   || fail "cannot read moon.mod from event-graph-walker at ${direct_sha}
@@ -69,17 +73,68 @@ pinned_version=$(git -C event-graph-walker show "${direct_sha}:moon.mod" \
 [ -n "${pinned_version}" ] \
   || fail "cannot extract version from event-graph-walker moon.mod at ${direct_sha}"
 
-declared_version=$(python3 -c "
+PINNED_VERSION="${pinned_version}" python3 - <<'PY' || exit 1
 import json
-spec = json.load(open('moon.mod.json'))['deps']['dowdiness/event-graph-walker']
-print(spec['version'] if isinstance(spec, dict) else spec)
-") || fail "cannot read dowdiness/event-graph-walker dep from moon.mod.json"
+import os
+import re
+import sys
 
-if [ "${pinned_version}" != "${declared_version}" ]; then
-  fail "event-graph-walker version mismatch:
-    pinned submodule commit declares: ${pinned_version}
-    canopy moon.mod.json declares:    ${declared_version}
-  moon does not validate path-dep versions — align them by hand."
-fi
+TARGET = "dowdiness/event-graph-walker"
+pinned = os.environ["PINNED_VERSION"]
+
+def members():
+    text = re.sub(r'#[^\n]*', '', open("moon.work").read())
+    m = re.search(r'members\s*=\s*\[(.*?)\]', text, re.DOTALL)
+    if not m:
+        sys.exit("check-egw-resolver-identity: moon.work has no members array")
+    return re.findall(r'"([^"]+)"', m.group(1))
+
+def declared_in(member):
+    """Return (manifest_rel, version-or-None) if the member declares TARGET,
+    else None. Handles JSON moon.mod.json and experimental TOML moon.mod."""
+    for name in ("moon.mod.json", "moon.mod"):
+        p = os.path.normpath(os.path.join(member, name))
+        if not os.path.isfile(p):
+            continue
+        if name.endswith(".json"):
+            try:
+                spec = (json.load(open(p)).get("deps") or {}).get(TARGET)
+            except Exception as e:
+                sys.exit(f"check-egw-resolver-identity: cannot parse {p}: {e}")
+            if spec is None:
+                return None
+            version = spec.get("version") if isinstance(spec, dict) else spec
+            return p, version
+        text = re.sub(r'#[^\n]*', '', open(p).read())
+        m = re.search(
+            r'"' + re.escape(TARGET) + r'(?:@([^"]+))?"\s*(?:=\s*\{([^}]*)\})?',
+            text)
+        if m is None:
+            return None
+        version = m.group(1)
+        if version is None and m.group(2):
+            vm = re.search(r'version\s*=\s*"([^"]+)"', m.group(2))
+            version = vm.group(1) if vm else None
+        return p, version
+    return None
+
+found = [d for d in (declared_in(m) for m in members()) if d is not None]
+if not found:
+    # The root manifest path-deps egw today; an empty scan means the scanner
+    # is broken or the topology changed — never a clean pass.
+    sys.exit(f"check-egw-resolver-identity: no workspace member declares "
+             f"{TARGET} — scanner or topology broken, refusing to pass")
+
+stale = [(p, v) for p, v in found if v is not None and v != pinned]
+if stale:
+    lines = "\n".join(f"    {p}: declares {v}" for p, v in stale)
+    sys.exit(f"check-egw-resolver-identity: {TARGET} version mismatch — "
+             f"pinned submodule commit declares {pinned}, but:\n{lines}\n"
+             f"  moon does not validate path-dep versions — align them by hand.")
+
+print(f"  {len(found)} workspace manifest(s) agree on version {pinned}:")
+for p, _ in found:
+    print(f"    {p}")
+PY
 
 echo "OK — both egw resolution paths pin ${direct_sha} (version ${pinned_version})."


### PR DESCRIPTION
## Summary

- Follow-up to #589, resolving the Codex P2 review comment: the guard's declared-version layer read only the root `moon.mod.json`, but **three** workspace members pin a version for `dowdiness/event-graph-walker` (root, `examples/ideal`, `examples/block-editor`). A bump PR editing root + gitlinks could leave the example manifests stale while the guard printed OK.
- The guard now discovers declarers by scanning `moon.work` members (JSON `moon.mod.json` and TOML `moon.mod` forms), fails on any divergent pin, and **refuses to pass if the scan finds zero declarers** (vacuity control — an empty scan means a broken scanner or changed topology, never a clean pass).
- Scope deliberately excludes submodule-owned manifests (e.g. `loom/examples/lambda`'s): they belong to their own repos and are covered by the gitlink-identity check.
- ADR §Decision 2 wording updated to match.

## Positive controls

- `examples/ideal/moon.mod.json` pinned to `0.2.0` → exit 1: `version mismatch — pinned submodule commit declares 0.3.0, but: examples/ideal/moon.mod.json: declares 0.2.0`
- Restored → exit 0: `3 workspace manifest(s) agree on version 0.3.0` (lists all three paths)
- shellcheck clean.

## Reuse check

No new MoonBit symbols (bash/python-in-script + ADR wording).

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `workspace_members()` / `load_manifest()` | `scripts/check-shared-substrate.sh` | Pattern reused (moon.work members regex + dual-format parsing), code not shared | Repo convention is self-contained guard scripts (check-shared-substrate.sh itself documents forking from check-deps.sh) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance documentation to clarify how dependency version declarations are validated across all system configurations and how certain managed dependencies are handled.

* **Improvements**
  * Enhanced dependency validation to check version consistency across all configuration files rather than only the primary one, with improved error reporting that lists specific files and their declared versions when mismatches are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->