### PR TITLE
Add local-first posts prototype

### DIFF
--- a/examples/web/posts.html
+++ b/examples/web/posts.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Canopy Posts</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --panel: #1e1e36;
+      --surface: #252540;
+      --surface-soft: color-mix(in oklab, var(--surface), var(--bg) 46%);
+      --border: #2a2a48;
+      --text: #e8e8f0;
+      --secondary: #c8c8e0;
+      --muted: #777796;
+      --accent: #8250df;
+      --accent-soft: color-mix(in oklab, var(--accent), transparent 82%);
+      --success: #28c840;
+      --error: #ff5370;
+      --space-xs: 4px;
+      --space-sm: 8px;
+      --space-md: 12px;
+      --space-lg: 16px;
+      --space-xl: 24px;
+      --space-2xl: 32px;
+      --space-3xl: 48px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 18% 0%, color-mix(in oklab, var(--accent), transparent 84%), transparent 30rem),
+        var(--bg);
+      color: var(--text);
+      font-family: Manrope, Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+
+    button,
+    textarea {
+      font: inherit;
+    }
+
+    .shell {
+      width: min(920px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: clamp(32px, 7vw, 72px) 0;
+    }
+
+    header {
+      display: grid;
+      gap: var(--space-sm);
+      margin-bottom: var(--space-2xl);
+    }
+
+    .eyebrow {
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 12ch;
+      color: var(--text);
+      font-size: clamp(2.4rem, 8vw, 5rem);
+      line-height: 0.94;
+      letter-spacing: -0.065em;
+    }
+
+    .lede {
+      max-width: 58ch;
+      margin: var(--space-md) 0 0;
+      color: var(--secondary);
+      font-size: 1rem;
+    }
+
+    .composer {
+      display: grid;
+      gap: var(--space-lg);
+      padding: var(--space-xl);
+      background: color-mix(in oklab, var(--panel), var(--bg) 18%);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+    }
+
+    label {
+      display: grid;
+      gap: var(--space-sm);
+      color: var(--secondary);
+      font-size: 0.9rem;
+      font-weight: 700;
+    }
+
+    textarea {
+      width: 100%;
+      min-height: 168px;
+      resize: vertical;
+      padding: var(--space-lg);
+      background: var(--bg);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      outline: none;
+      font-family: Iosevka, "JetBrains Mono", "Fira Code", Consolas, monospace;
+      font-size: 1rem;
+      line-height: 1.7;
+    }
+
+    textarea::placeholder {
+      color: var(--muted);
+    }
+
+    textarea:focus {
+      border-color: color-mix(in oklab, var(--accent), var(--border) 25%);
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    .composer-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md);
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .hint {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+
+    kbd {
+      padding: 1px 6px;
+      background: var(--surface);
+      color: var(--secondary);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-family: Iosevka, "JetBrains Mono", Consolas, monospace;
+      font-size: 0.78rem;
+    }
+
+    .post-button {
+      min-width: 116px;
+      padding: 10px 18px;
+      background: var(--accent);
+      color: var(--text);
+      border: 1px solid color-mix(in oklab, var(--accent), white 10%);
+      border-radius: 999px;
+      cursor: pointer;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+      transition: transform 120ms ease, background 120ms ease, opacity 120ms ease;
+    }
+
+    .post-button:hover:not(:disabled) {
+      background: color-mix(in oklab, var(--accent), white 8%);
+      transform: translateY(-1px);
+    }
+
+    .post-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.46;
+    }
+
+    .status-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md);
+      align-items: center;
+      justify-content: space-between;
+      min-height: 24px;
+    }
+
+    #post-status {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    #post-status[data-tone="success"] {
+      color: color-mix(in oklab, var(--success), var(--text) 18%);
+    }
+
+    #post-status[data-tone="error"] {
+      color: var(--error);
+    }
+
+    #post-count {
+      color: var(--secondary);
+      font-size: 0.86rem;
+      font-weight: 700;
+    }
+
+    .timeline {
+      display: grid;
+      gap: var(--space-lg);
+      margin-top: var(--space-2xl);
+    }
+
+    .timeline h2 {
+      margin: 0;
+      color: var(--secondary);
+      font-size: 0.88rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .post-list {
+      display: grid;
+      gap: var(--space-md);
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .post-item article {
+      display: grid;
+      gap: var(--space-sm);
+      padding: var(--space-lg);
+      background: var(--surface-soft);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+    }
+
+    .post-item time {
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .post-item p {
+      margin: 0;
+      color: var(--text);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    .empty-state {
+      padding: var(--space-2xl);
+      background: color-mix(in oklab, var(--panel), transparent 20%);
+      border: 1px dashed color-mix(in oklab, var(--border), var(--secondary) 12%);
+      border-radius: 16px;
+      color: var(--muted);
+    }
+
+    .empty-state p {
+      max-width: 46ch;
+      margin: 0;
+    }
+
+    @media (max-width: 640px) {
+      .shell {
+        width: min(100% - 24px, 920px);
+        padding: var(--space-2xl) 0;
+      }
+
+      .composer {
+        padding: var(--space-lg);
+        border-radius: 14px;
+      }
+
+      .composer-actions,
+      .status-row {
+        align-items: stretch;
+        flex-direction: column;
+      }
+
+      .post-button {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header>
+      <p class="eyebrow">Local-first prototype</p>
+      <h1>Post to yourself.</h1>
+      <p class="lede">One field, no folders, no API key. This slice only proves that text can be posted and survive a reload; resurfacing comes after the post loop exists.</p>
+    </header>
+
+    <form class="composer" id="post-form">
+      <label for="post-input">
+        Write
+        <textarea id="post-input" name="post" placeholder="A thought, reminder, note, or question for future you…" autocomplete="off"></textarea>
+      </label>
+
+      <div class="composer-actions">
+        <p class="hint"><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Enter</kbd> posts. Plain <kbd>Enter</kbd> keeps writing.</p>
+        <button class="post-button" id="post-submit" type="submit">Post</button>
+      </div>
+
+      <div class="status-row" aria-live="polite">
+        <p id="post-status"></p>
+        <span id="post-count">0 posts</span>
+      </div>
+    </form>
+
+    <section class="timeline" aria-labelledby="timeline-title">
+      <h2 id="timeline-title">Chronological fallback · newest first</h2>
+      <div class="empty-state" id="empty-state">
+        <p>No posts yet. Write the smallest thing worth remembering and reload the page to prove it stays.</p>
+      </div>
+      <ul class="post-list" id="post-list"></ul>
+    </section>
+  </main>
+
+  <script type="module" src="/src/post-app.ts"></script>
+</body>
+</html>

--- a/examples/web/src/post-app.ts
+++ b/examples/web/src/post-app.ts
@@ -1,0 +1,118 @@
+import { type LocalPost, LocalPostStore } from './post-store';
+
+const form = document.getElementById('post-form') as HTMLFormElement;
+const draft = document.getElementById('post-input') as HTMLTextAreaElement;
+const submitButton = document.getElementById('post-submit') as HTMLButtonElement;
+const statusEl = document.getElementById('post-status') as HTMLParagraphElement;
+const countEl = document.getElementById('post-count') as HTMLSpanElement;
+const listEl = document.getElementById('post-list') as HTMLUListElement;
+const emptyEl = document.getElementById('empty-state') as HTMLDivElement;
+
+const store = new LocalPostStore(window.localStorage);
+const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+let posts: LocalPost[] = [];
+
+function pluralizePosts(count: number): string {
+  return count === 1 ? '1 post' : `${count} posts`;
+}
+
+function setStatus(message: string, tone: 'idle' | 'success' | 'error' = 'idle'): void {
+  statusEl.textContent = message;
+  statusEl.dataset.tone = tone;
+}
+
+function formatTimestamp(value: string): string {
+  return dateTimeFormat.format(new Date(value));
+}
+
+function syncSubmitState(): void {
+  submitButton.disabled = draft.value.trim().length === 0;
+}
+
+function renderPost(post: LocalPost): HTMLLIElement {
+  const item = document.createElement('li');
+  item.className = 'post-item';
+
+  const article = document.createElement('article');
+
+  const time = document.createElement('time');
+  time.dateTime = post.createdAt;
+  time.textContent = formatTimestamp(post.createdAt);
+
+  const text = document.createElement('p');
+  text.textContent = post.text;
+
+  article.append(time, text);
+  item.append(article);
+  return item;
+}
+
+function render(): void {
+  countEl.textContent = pluralizePosts(posts.length);
+  listEl.replaceChildren(...posts.map(renderPost));
+  listEl.hidden = posts.length === 0;
+  emptyEl.hidden = posts.length !== 0;
+}
+
+function loadPosts(): void {
+  try {
+    posts = store.all();
+    render();
+    setStatus(`${pluralizePosts(posts.length)} stored locally on this device.`);
+  } catch (error) {
+    posts = [];
+    render();
+    setStatus(
+      `Could not read saved posts: ${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    );
+  }
+}
+
+function submitDraft(): void {
+  const text = draft.value.trim();
+  if (text.length === 0) {
+    setStatus('Write something before posting.', 'error');
+    draft.focus();
+    return;
+  }
+
+  try {
+    const post = store.add(text);
+    posts = [post, ...posts];
+    draft.value = '';
+    syncSubmitState();
+    render();
+    setStatus('Posted. It will still be here after reload.', 'success');
+    draft.focus();
+  } catch (error) {
+    setStatus(
+      `Could not save this post: ${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    );
+  }
+}
+
+form.addEventListener('submit', event => {
+  event.preventDefault();
+  submitDraft();
+});
+
+draft.addEventListener('keydown', event => {
+  if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+    event.preventDefault();
+    submitDraft();
+  }
+});
+
+draft.addEventListener('input', syncSubmitState);
+
+loadPosts();
+syncSubmitState();
+draft.focus();

--- a/examples/web/src/post-store.ts
+++ b/examples/web/src/post-store.ts
@@ -1,0 +1,69 @@
+export interface LocalPost {
+  readonly id: string;
+  readonly text: string;
+  readonly createdAt: string;
+}
+
+const POST_STORAGE_KEY = 'canopy.posts.v1';
+
+function isLocalPost(value: unknown): value is LocalPost {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.text === 'string' &&
+    record.text.trim().length > 0 &&
+    typeof record.createdAt === 'string' &&
+    !Number.isNaN(Date.parse(record.createdAt))
+  );
+}
+
+function newestFirst(a: LocalPost, b: LocalPost): number {
+  return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+}
+
+function createId(now: Date): string {
+  const time = now.getTime().toString(36);
+  const random = Math.random().toString(36).slice(2, 10);
+  return `post-${time}-${random}`;
+}
+
+function createPost(text: string, now = new Date()): LocalPost {
+  return {
+    id: createId(now),
+    text: text.trim(),
+    createdAt: now.toISOString(),
+  };
+}
+
+export class LocalPostStore {
+  constructor(
+    private readonly storage: Storage,
+    private readonly key = POST_STORAGE_KEY,
+  ) {}
+
+  all(): LocalPost[] {
+    try {
+      const raw = this.storage.getItem(this.key);
+      if (raw === null) return [];
+
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+
+      return parsed.filter(isLocalPost).sort(newestFirst);
+    } catch {
+      return [];
+    }
+  }
+
+  add(text: string, now = new Date()): LocalPost {
+    const post = createPost(text, now);
+    this.save([post, ...this.all()].sort(newestFirst));
+    return post;
+  }
+
+  private save(posts: LocalPost[]): void {
+    this.storage.setItem(this.key, JSON.stringify(posts));
+  }
+}

--- a/examples/web/tests/post-app.spec.ts
+++ b/examples/web/tests/post-app.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/posts.html');
+  await expect(page.getByRole('heading', { name: 'Post to yourself.' })).toBeVisible();
+});
+
+test.describe('local-first post app', () => {
+  test('posts text with the button and keeps it after reload', async ({ page }) => {
+    const input = page.getByLabel('Write');
+
+    await input.fill('Remember the product wedge: post exists before retrieval.');
+    await page.getByRole('button', { name: 'Post' }).click();
+
+    await expect(input).toHaveValue('');
+    await expect(page.locator('.post-item p')).toHaveText([
+      'Remember the product wedge: post exists before retrieval.',
+    ]);
+    await expect(page.locator('#post-count')).toHaveText('1 post');
+
+    await page.reload();
+
+    await expect(page.locator('.post-item p')).toHaveText([
+      'Remember the product wedge: post exists before retrieval.',
+    ]);
+    await expect(page.locator('#post-count')).toHaveText('1 post');
+  });
+
+  test('Ctrl+Enter posts while plain Enter keeps writing', async ({ page }) => {
+    const input = page.getByLabel('Write');
+
+    await input.fill('First line');
+    await input.press('Enter');
+    await input.pressSequentially('Second line');
+
+    await expect(input).toHaveValue('First line\nSecond line');
+    await expect(page.locator('.post-item')).toHaveCount(0);
+
+    await input.press('Control+Enter');
+
+    await expect(page.locator('.post-item p')).toHaveText(['First line\nSecond line']);
+    await expect(input).toHaveValue('');
+  });
+
+  test('shows the chronological fallback newest first', async ({ page }) => {
+    const input = page.getByLabel('Write');
+
+    await input.fill('Older post');
+    await input.press('Control+Enter');
+    await input.fill('Newer post');
+    await input.press('Control+Enter');
+
+    await expect(page.locator('.post-item p')).toHaveText([
+      'Newer post',
+      'Older post',
+    ]);
+  });
+});

--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         json: 'json.html',
         memo: 'memo.html',
         markdown: 'markdown.html',
+        posts: 'posts.html',
       },
     },
   },


### PR DESCRIPTION
## Summary

- Adds `examples/web/posts.html`, a text-only local-first "post to yourself" prototype for #592.
- Stores posts in browser `localStorage`, renders a newest-first chronological fallback list, and supports button plus `Ctrl`/`⌘` + `Enter` submit.
- Adds Playwright coverage for post creation, reload persistence, multiline keyboard behavior, and newest-first ordering.

Closes #592.
Part of #591.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Web Storage API (`localStorage`) | Browser platform | Yes | Smallest local-first durable store for this text-only prototype; avoids premature CRDT/IndexedDB/sync work. |
| DOM `textContent` / `replaceChildren` | Browser platform | Yes | Renders user text without HTML injection and keeps the UI dependency-free. |
| `Intl.DateTimeFormat` | Browser platform | Yes | Formats post timestamps without adding a date dependency. |
| Vite multi-page input | `examples/web/vite.config.ts` | Yes | Registers `posts.html` alongside existing pages in the current host. |
| `echo` similarity engine | `echo/README.md` | No | #592 intentionally validates durable posting before #593 related-post surfacing. |
| Gemini memo spike | `examples/web/memo.html`, `examples/web/src/memo-editor.ts` | No | It is an AI editor spike with API-key flow, not the write-to-self product wedge. |

New helpers added (if any):

- `LocalPostStore` — tiny browser-storage boundary for loading and appending validated local posts.
- `isLocalPost` — validates stored JSON before rendering it back into the UI.
- `createPost` / `createId` / `newestFirst` — private store helpers for normalized post records and chronological ordering.
- UI helpers in `post-app.ts` (`renderPost`, `render`, `submitDraft`, etc.) — page-local DOM glue; not shared API.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes — no `.mbti` changes in this PR diff
- [x] JS rebuild run if web is affected (`cd examples/web && CI=1 npm run build`)

Additional validation:

```bash
cd examples/web && npx tsc --noEmit
cd examples/web && CI=true npx playwright test tests/post-app.spec.ts --reporter=line
cd examples/web && CI=true npx playwright test --reporter=line
```

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
```
