### PR TITLE
Surface related posts while writing

### DIFF
--- a/examples/web/posts.html
+++ b/examples/web/posts.html
@@ -200,6 +200,101 @@
       font-weight: 700;
     }
 
+    .related-panel {
+      display: grid;
+      gap: var(--space-md);
+      margin-top: var(--space-xl);
+      padding: var(--space-lg);
+      background: color-mix(in oklab, var(--panel), var(--bg) 8%);
+      border: 1px solid color-mix(in oklab, var(--border), var(--accent) 14%);
+      border-radius: 16px;
+    }
+
+    .related-panel[hidden] {
+      display: none;
+    }
+
+    .related-heading {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm) var(--space-lg);
+      align-items: flex-end;
+      justify-content: space-between;
+    }
+
+    .related-kicker {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: 0.13em;
+      text-transform: uppercase;
+    }
+
+    .related-heading h2 {
+      margin: var(--space-xs) 0 0;
+      color: var(--text);
+      font-size: 1rem;
+      letter-spacing: -0.01em;
+    }
+
+    #related-count {
+      color: var(--secondary);
+      font-size: 0.82rem;
+      font-weight: 700;
+    }
+
+    .related-list {
+      display: grid;
+      gap: 0;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .related-item article {
+      display: grid;
+      gap: var(--space-xs);
+      padding: var(--space-md) 0;
+      border-top: 1px solid var(--border);
+    }
+
+    .related-item:first-child article {
+      padding-top: 0;
+      border-top: 0;
+    }
+
+    .related-item:last-child article {
+      padding-bottom: 0;
+    }
+
+    .related-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
+      align-items: center;
+    }
+
+    .related-meta time,
+    .related-match {
+      color: var(--muted);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .related-match {
+      color: color-mix(in oklab, var(--secondary), var(--accent) 20%);
+    }
+
+    .related-text {
+      margin: 0;
+      color: var(--secondary);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
     .timeline {
       display: grid;
       gap: var(--space-lg);
@@ -271,6 +366,7 @@
       }
 
       .composer-actions,
+      .related-heading,
       .status-row {
         align-items: stretch;
         flex-direction: column;
@@ -287,7 +383,7 @@
     <header>
       <p class="eyebrow">Local-first prototype</p>
       <h1>Post to yourself.</h1>
-      <p class="lede">One field, no folders, no API key. This slice only proves that text can be posted and survive a reload; resurfacing comes after the post loop exists.</p>
+      <p class="lede">One field, no folders, no API key. As you write, a few old posts return quietly underneath; the stream stays newest-first when you just want chronology.</p>
     </header>
 
     <form class="composer" id="post-form">
@@ -306,6 +402,17 @@
         <span id="post-count">0 posts</span>
       </div>
     </form>
+
+    <section class="related-panel" id="related-panel" aria-labelledby="related-title" hidden>
+      <div class="related-heading">
+        <div>
+          <p class="related-kicker">Returning while writing</p>
+          <h2 id="related-title">Related posts</h2>
+        </div>
+        <span id="related-count">0 related posts</span>
+      </div>
+      <ul class="related-list" id="related-list"></ul>
+    </section>
 
     <section class="timeline" aria-labelledby="timeline-title">
       <h2 id="timeline-title">Chronological fallback · newest first</h2>

--- a/examples/web/src/post-app.ts
+++ b/examples/web/src/post-app.ts
@@ -1,3 +1,4 @@
+import { PostRetrievalIndex, type RelatedPost } from './post-retrieval';
 import { type LocalPost, LocalPostStore } from './post-store';
 
 const form = document.getElementById('post-form') as HTMLFormElement;
@@ -7,6 +8,9 @@ const statusEl = document.getElementById('post-status') as HTMLParagraphElement;
 const countEl = document.getElementById('post-count') as HTMLSpanElement;
 const listEl = document.getElementById('post-list') as HTMLUListElement;
 const emptyEl = document.getElementById('empty-state') as HTMLDivElement;
+const relatedPanelEl = document.getElementById('related-panel') as HTMLElement;
+const relatedCountEl = document.getElementById('related-count') as HTMLSpanElement;
+const relatedListEl = document.getElementById('related-list') as HTMLUListElement;
 
 const store = new LocalPostStore(window.localStorage);
 const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
@@ -17,9 +21,14 @@ const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
 });
 
 let posts: LocalPost[] = [];
+let retrievalIndex = new PostRetrievalIndex(posts);
 
 function pluralizePosts(count: number): string {
   return count === 1 ? '1 post' : `${count} posts`;
+}
+
+function pluralizeRelated(count: number): string {
+  return count === 1 ? '1 related post' : `${count} related posts`;
 }
 
 function setStatus(message: string, tone: 'idle' | 'success' | 'error' = 'idle'): void {
@@ -53,20 +62,60 @@ function renderPost(post: LocalPost): HTMLLIElement {
   return item;
 }
 
+function renderRelatedPost(result: RelatedPost): HTMLLIElement {
+  const item = document.createElement('li');
+  item.className = 'related-item';
+
+  const article = document.createElement('article');
+
+  const meta = document.createElement('div');
+  meta.className = 'related-meta';
+
+  const time = document.createElement('time');
+  time.dateTime = result.post.createdAt;
+  time.textContent = formatTimestamp(result.post.createdAt);
+
+  const match = document.createElement('span');
+  match.className = 'related-match';
+  match.textContent = `Echoes ${result.matchedTerms.slice(0, 3).join(' · ')}`;
+
+  const text = document.createElement('p');
+  text.className = 'related-text';
+  text.textContent = result.post.text;
+
+  meta.append(time, match);
+  article.append(meta, text);
+  item.append(article);
+  return item;
+}
+
+function renderRelated(): void {
+  const relatedPosts = retrievalIndex.query(draft.value, { limit: 5 });
+  relatedCountEl.textContent = pluralizeRelated(relatedPosts.length);
+  relatedListEl.replaceChildren(...relatedPosts.map(renderRelatedPost));
+  relatedPanelEl.hidden = relatedPosts.length === 0;
+}
+
+function replacePosts(nextPosts: LocalPost[]): void {
+  posts = nextPosts;
+  retrievalIndex = new PostRetrievalIndex(posts);
+}
+
 function render(): void {
   countEl.textContent = pluralizePosts(posts.length);
   listEl.replaceChildren(...posts.map(renderPost));
   listEl.hidden = posts.length === 0;
   emptyEl.hidden = posts.length !== 0;
+  renderRelated();
 }
 
 function loadPosts(): void {
   try {
-    posts = store.all();
+    replacePosts(store.all());
     render();
     setStatus(`${pluralizePosts(posts.length)} stored locally on this device.`);
   } catch (error) {
-    posts = [];
+    replacePosts([]);
     render();
     setStatus(
       `Could not read saved posts: ${error instanceof Error ? error.message : String(error)}`,
@@ -85,7 +134,7 @@ function submitDraft(): void {
 
   try {
     const post = store.add(text);
-    posts = [post, ...posts];
+    replacePosts([post, ...posts]);
     draft.value = '';
     syncSubmitState();
     render();
@@ -111,7 +160,10 @@ draft.addEventListener('keydown', event => {
   }
 });
 
-draft.addEventListener('input', syncSubmitState);
+draft.addEventListener('input', () => {
+  syncSubmitState();
+  renderRelated();
+});
 
 loadPosts();
 syncSubmitState();

--- a/examples/web/src/post-retrieval.ts
+++ b/examples/web/src/post-retrieval.ts
@@ -1,0 +1,188 @@
+import type { LocalPost } from './post-store';
+
+export interface RelatedPost {
+  readonly post: LocalPost;
+  readonly score: number;
+  readonly matchedTerms: readonly string[];
+}
+
+export interface RetrievalOptions {
+  readonly limit?: number;
+}
+
+interface TokenProfile {
+  readonly uniqueTerms: ReadonlySet<string>;
+  readonly counts: ReadonlyMap<string, number>;
+  readonly totalTerms: number;
+}
+
+interface IndexedPost {
+  readonly post: LocalPost;
+  readonly profile: TokenProfile;
+}
+
+const DEFAULT_RELATED_LIMIT = 5;
+
+// #593 intentionally starts with a tiny browser-local lexical scorer instead of
+// wiring the experimental MoonBit `echo` package into Vite. Keeping the app on
+// this module boundary lets `echo` replace the scorer once it has a production
+// browser FFI surface.
+const STOP_WORDS = new Set([
+  'a',
+  'about',
+  'after',
+  'also',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'been',
+  'before',
+  'being',
+  'by',
+  'could',
+  'for',
+  'from',
+  'had',
+  'has',
+  'have',
+  'how',
+  'i',
+  'in',
+  'into',
+  'is',
+  'it',
+  'just',
+  'me',
+  'my',
+  'no',
+  'not',
+  'note',
+  'notes',
+  'of',
+  'on',
+  'or',
+  'our',
+  'post',
+  'posts',
+  'remember',
+  'should',
+  'that',
+  'the',
+  'their',
+  'them',
+  'these',
+  'they',
+  'thing',
+  'things',
+  'this',
+  'those',
+  'to',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'where',
+  'while',
+  'who',
+  'why',
+  'will',
+  'with',
+  'would',
+  'yes',
+  'you',
+  'your',
+]);
+
+export class PostRetrievalIndex {
+  private readonly indexedPosts: readonly IndexedPost[];
+  private readonly documentFrequency: ReadonlyMap<string, number>;
+
+  constructor(posts: readonly LocalPost[]) {
+    this.indexedPosts = posts
+      .map(post => ({ post, profile: profileText(post.text) }))
+      .filter(({ profile }) => profile.totalTerms > 0);
+    this.documentFrequency = buildDocumentFrequency(this.indexedPosts);
+  }
+
+  query(draftText: string, options: RetrievalOptions = {}): RelatedPost[] {
+    const limit = Math.max(0, options.limit ?? DEFAULT_RELATED_LIMIT);
+    if (limit === 0 || this.indexedPosts.length === 0) return [];
+
+    const query = profileText(draftText);
+    if (query.totalTerms === 0) return [];
+
+    return this.indexedPosts
+      .map(indexedPost => this.scorePost(query, indexedPost))
+      .filter((result): result is RelatedPost => result !== null)
+      .sort(compareRelatedPosts)
+      .slice(0, limit);
+  }
+
+  private scorePost(query: TokenProfile, indexedPost: IndexedPost): RelatedPost | null {
+    const matchedTerms = Array.from(query.uniqueTerms).filter(term =>
+      indexedPost.profile.uniqueTerms.has(term),
+    );
+    if (matchedTerms.length === 0) return null;
+
+    const weightedOverlap = matchedTerms.reduce((score, term) => {
+      const frequency = this.documentFrequency.get(term) ?? 0;
+      const idf = Math.log(1 + this.indexedPosts.length / (1 + frequency));
+      const termFrequency = indexedPost.profile.counts.get(term) ?? 1;
+      return score + idf * (1 + Math.log(termFrequency));
+    }, 0);
+    const queryCoverage = matchedTerms.length / query.uniqueTerms.size;
+    const lengthPenalty = Math.sqrt(indexedPost.profile.totalTerms);
+
+    return {
+      post: indexedPost.post,
+      score: (weightedOverlap * (1 + queryCoverage)) / lengthPenalty,
+      matchedTerms,
+    };
+  }
+}
+
+function profileText(text: string): TokenProfile {
+  const counts = new Map<string, number>();
+
+  for (const match of text.normalize('NFKC').toLowerCase().matchAll(/[\p{L}\p{N}]+/gu)) {
+    const term = normalizeTerm(match[0]);
+    if (term.length < 2 || STOP_WORDS.has(term)) continue;
+    counts.set(term, (counts.get(term) ?? 0) + 1);
+  }
+
+  return {
+    uniqueTerms: new Set(counts.keys()),
+    counts,
+    totalTerms: Array.from(counts.values()).reduce((sum, count) => sum + count, 0),
+  };
+}
+
+function normalizeTerm(term: string): string {
+  if (term.length > 5 && term.endsWith('ies')) return `${term.slice(0, -3)}y`;
+  if (term.length > 5 && term.endsWith('ing')) return term.slice(0, -3);
+  if (term.length > 4 && term.endsWith('ed')) return term.slice(0, -2);
+  if (term.length > 4 && term.endsWith('s')) return term.slice(0, -1);
+  return term;
+}
+
+function buildDocumentFrequency(posts: readonly IndexedPost[]): ReadonlyMap<string, number> {
+  const frequency = new Map<string, number>();
+
+  for (const { profile } of posts) {
+    for (const term of profile.uniqueTerms) {
+      frequency.set(term, (frequency.get(term) ?? 0) + 1);
+    }
+  }
+
+  return frequency;
+}
+
+function compareRelatedPosts(a: RelatedPost, b: RelatedPost): number {
+  const scoreDelta = b.score - a.score;
+  if (Math.abs(scoreDelta) > Number.EPSILON) return scoreDelta;
+  return Date.parse(b.post.createdAt) - Date.parse(a.post.createdAt);
+}

--- a/examples/web/tests/post-app.spec.ts
+++ b/examples/web/tests/post-app.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const POST_STORAGE_KEY = 'canopy.posts.v1';
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/posts.html');
   await expect(page.getByRole('heading', { name: 'Post to yourself.' })).toBeVisible();
@@ -54,5 +56,68 @@ test.describe('local-first post app', () => {
       'Newer post',
       'Older post',
     ]);
+  });
+
+  test('surfaces related posts while typing a draft', async ({ page }) => {
+    await page.evaluate(
+      ({ key, posts }) => window.localStorage.setItem(key, JSON.stringify(posts)),
+      {
+        key: POST_STORAGE_KEY,
+        posts: [
+          {
+            id: 'post-basil-window',
+            text: 'Basil seedlings recovered on the kitchen window shelf after I stopped overwatering.',
+            createdAt: '2026-06-10T09:00:00.000Z',
+          },
+          {
+            id: 'post-herb-light',
+            text: 'The kitchen window gets stronger afternoon light, so tender herbs move there first.',
+            createdAt: '2026-06-09T09:00:00.000Z',
+          },
+          {
+            id: 'post-basil-soup',
+            text: 'Tomato basil soup worked best with the small grocery basil, not the dried jar.',
+            createdAt: '2026-06-08T09:00:00.000Z',
+          },
+          {
+            id: 'post-parser-baseline',
+            text: 'Projection identity baseline only advances after semantic lowering succeeds.',
+            createdAt: '2026-06-07T09:00:00.000Z',
+          },
+          {
+            id: 'post-running-shoes',
+            text: 'Replace the running shoes before the next long trail loop.',
+            createdAt: '2026-06-06T09:00:00.000Z',
+          },
+        ],
+      },
+    );
+    await page.reload();
+
+    const input = page.getByLabel('Write');
+    const relatedPanel = page.locator('#related-panel');
+    const relatedTexts = page.locator('.related-text');
+
+    await expect(relatedPanel).toBeHidden();
+
+    await input.pressSequentially('basil kitchen window');
+
+    await expect(relatedPanel).toBeVisible();
+    await expect(page.locator('#related-count')).toHaveText('3 related posts');
+    await expect(relatedTexts).toHaveText([
+      'Basil seedlings recovered on the kitchen window shelf after I stopped overwatering.',
+      'The kitchen window gets stronger afternoon light, so tender herbs move there first.',
+      'Tomato basil soup worked best with the small grocery basil, not the dried jar.',
+    ]);
+
+    await input.fill('parser identity baseline');
+
+    await expect(page.locator('#related-count')).toHaveText('1 related post');
+    await expect(relatedTexts).toHaveText([
+      'Projection identity baseline only advances after semantic lowering succeeds.',
+    ]);
+
+    await input.fill('');
+    await expect(relatedPanel).toBeHidden();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a tiny browser-local retrieval boundary that ranks stored posts by lexical overlap while the user is drafting.
- Renders an unobtrusive “Related posts” panel under the composer without changing the newest-first chronological fallback.
- Covers draft typing → related-post surfacing in the posts Playwright suite.

Closes #593.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `LocalPostStore` / `LocalPost` | `examples/web/src/post-store.ts` | Yes | The retrieval index consumes the same local post shape and stays outside the storage boundary. |
| Existing post rendering flow | `examples/web/src/post-app.ts` | Yes | Related rendering follows the same DOM-construction style and keeps `render()` as the sync point. |
| `Corpus` | `echo/README.md` / `echo` | No | `echo` is documented as experimental/offline with no production consumers; this prototype keeps a replaceable TS retrieval boundary until a browser FFI surface exists. |

New helpers added (if any):

- `PostRetrievalIndex`, `RelatedPost`, and small internal token/scoring helpers in `examples/web/src/post-retrieval.ts`: isolated browser-local scorer for #593’s prototype surface.
- `renderRelated*` helpers in `examples/web/src/post-app.ts`: DOM-only presentation for the related-post panel.

## Test plan

- [ ] `NEW_MOON_MOD=0 moon check` passes — not run; no MoonBit changes.
- [ ] `NEW_MOON_MOD=0 moon test` passes — not run; no MoonBit changes.
- [x] `git diff *.mbti` reviewed for unintended API surface changes — commit contains no `.mbti` changes; unrelated dirty generated files were left untouched.
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`)

## Validation

```bash
cd examples/web && npx tsc --noEmit
cd examples/web && npm run build
cd examples/web && npx playwright test tests/post-app.spec.ts
```

Browser inspection: seeded local posts in `posts.html`, typed `basil kitchen window`, and verified the related-post panel surfaced three quiet matches while the chronological fallback stayed newest-first. Playwright passed with the known local MoonBit watcher OS file-watch-limit warnings.
