### PR TITLE
feat(redesign): import-graph lint for package boundary rules [F]-[I]

### DIFF
--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -22,7 +22,7 @@ The main gating workflow. Job names match the file:
 
 | Job | What it runs |
 |-----|--------------|
-| `dep-check` | `./scripts/check-deps.sh`, `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh` |
+| `dep-check` | `./scripts/check-deps.sh` (module-scope rules [A]–[E] + canopy package-layering rules [F]–[I]; the rules table lives in the script header), `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh` |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check .`, `./scripts/run-moon-module.sh test .`, `moon build --release` |
 | `test-submodules` | Matrix over `event-graph-walker`, `loom/loom`, `svg-dsl`, `graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `examples/ideal`, `examples/block-editor`, `examples/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/env bash
 # Scope-aware dependency-rule checker.
 #
-# Rules (see docs/plans/2026-04-22-moonbit-workspace-reorganization.md):
+# Module-scope rules (see docs/plans/2026-04-22-moonbit-workspace-reorganization.md):
 #   [A] lib/*         must not import dowdiness/canopy/*
 #   [B] lib/*         must not import example modules
 #   [C] submodule/*   must not import dowdiness/canopy/*
 #   [D] submodule/*   must not import example modules
 #   [E] submodule/*   must not path-dep into dowdiness/canopy (moon.mod.json or moon.mod)
 #
-# Applies to all scopes (normal, test, wbtest) for [A]–[D].
+# Package-level layering rules inside the dowdiness/canopy module (see
+# docs/plans/2026-06-11-architecture-redesign-proposal.md, "Dependency and
+# boundary rules"):
+#   [F] core/** and protocol/** (incl. protocol/wire) import substrate only:
+#       their canopy-internal imports must stay within {core/**, protocol/**}
+#       — no language, transport, or app imports.
+#   [G] editor/** must not import dowdiness/canopy/lang/* in ANY scope,
+#       test/wbtest included. Dated exceptions are listed in
+#       EDITOR_LANG_EXCEPTIONS below; each waiver is printed on every run
+#       (never silent) and FAILS the check if it stops matching anything.
+#   [H] relay/** imports only dowdiness/canopy/protocol/wire,
+#       dowdiness/byte_codec, and moonbitlang/* — never editor.
+#   [I] lang/** must not import dowdiness/canopy/ffi/*; a language
+#       lang/<L>/** must not import another language lang/<M>/**
+#       (lang/runtime is shared SPI, importable by every language);
+#       lang/runtime must not import any language in normal scope
+#       (test-scope fixtures are allowed).
+#
+# Applies to all scopes (normal, test, wbtest) for [A]–[D] and [F]–[I]
+# (the one scope carve-out is [I]'s lang/runtime clause, noted above).
 # Exits non-zero on any violation. Intended to run in CI.
 set -euo pipefail
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
@@ -161,6 +180,69 @@ def is_canopy(sym):
 def is_example(sym):
     return any(sym == n or sym.startswith(n + "/") for n in example_modules)
 
+# --- Package-level layering rules within dowdiness/canopy ([F]-[I]) ---
+
+def canopy_pkg(sym):
+    """Package path inside the canopy module ('' for the root package),
+    or None if sym is not a canopy import."""
+    if sym == CANOPY:
+        return ""
+    if sym.startswith(CANOPY + "/"):
+        return sym[len(CANOPY) + 1:]
+    return None
+
+def under(pkg, roots):
+    return any(pkg == r or pkg.startswith(r + "/") for r in roots)
+
+SUBSTRATE_ONLY_ROOTS = ("core", "protocol")  # [F] — protocol covers protocol/wire
+RELAY_ALLOWED = (CANOPY + "/protocol/wire", "dowdiness/byte_codec")  # [H]
+
+# [G] dated exceptions: (package, scope, import) -> reason. A waiver is
+# printed on every run; a listed exception that no longer matches any
+# import FAILS the check, so this list cannot rot silently.
+_LAMBDA_FIXTURE_REASON = (
+    "dated 2026-06-12: editor's lambda test fixture is pending replacement "
+    "by a TestExpr-style neutral grammar (redesign proposal, 'Dependency "
+    "and boundary rules'); remove this entry when editor tests stop "
+    "importing lang/lambda"
+)
+EDITOR_LANG_EXCEPTIONS = {
+    ("editor", "test", CANOPY + "/lang/lambda"): _LAMBDA_FIXTURE_REASON,
+    ("editor", "wbtest", CANOPY + "/lang/lambda"): _LAMBDA_FIXTURE_REASON,
+}
+exceptions_used = set()
+
+def check_canopy_layering(pkg, scope, sym):
+    """Yield [F]-[I] violation strings for one import of a canopy package."""
+    target = canopy_pkg(sym)
+    if under(pkg, SUBSTRATE_ONLY_ROOTS) and target is not None \
+            and not under(target, SUBSTRATE_ONLY_ROOTS):
+        yield (f"[F] {pkg} ({scope}) → {sym} "
+               f"(core/protocol import substrate only)")
+    if under(pkg, ("editor",)) and target is not None \
+            and under(target, ("lang",)):
+        key = (pkg, scope, sym)
+        if key in EDITOR_LANG_EXCEPTIONS:
+            exceptions_used.add(key)
+        else:
+            yield f"[G] {pkg} ({scope}) → {sym} (editor must not import lang/*)"
+    if under(pkg, ("relay",)) \
+            and sym not in RELAY_ALLOWED and not sym.startswith("moonbitlang/"):
+        yield (f"[H] {pkg} ({scope}) → {sym} "
+               f"(relay allowlist: protocol/wire, byte_codec, moonbitlang/*)")
+    if under(pkg, ("lang",)) and target is not None:
+        if under(target, ("ffi",)):
+            yield f"[I] {pkg} ({scope}) → {sym} (lang must not import ffi/*)"
+        elif under(target, ("lang",)) and target != "lang":
+            own = pkg.split("/")[1] if "/" in pkg else None
+            tgt = target.split("/")[1]
+            if own == "runtime":
+                if tgt != "runtime" and scope == "normal":
+                    yield (f"[I] {pkg} ({scope}) → {sym} "
+                           f"(lang/runtime must not depend on a language)")
+            elif tgt not in ("runtime", own):
+                yield f"[I] {pkg} ({scope}) → {sym} (cross-language import)"
+
 # --- Scan package imports ---
 violations = []
 scanned_pkgs = 0
@@ -179,6 +261,8 @@ for pkg_file in iter_files("moon.pkg"):
             violations.append(f"[C] submodule pkg {pkg_rel} ({mod_name}, {scope}) → {sym}")
         if cat == "submodule" and is_example(sym):
             violations.append(f"[D] submodule pkg {pkg_rel} ({mod_name}, {scope}) → {sym}")
+        if cat == "canopy":
+            violations.extend(check_canopy_layering(pkg_rel, scope, sym))
 
 # --- Scan module path-deps ---
 scanned_mods = 0
@@ -192,13 +276,22 @@ for mmj in iter_manifests():
         # Rule E is about path-deps only; registry deps (string value, or
         # dict without "path" key) are not targeted by this rule even if the
         # name would match. If we ever want to forbid registry-deps on canopy
-        # too, add rule F.
+        # too, add a new rule letter.
         if not (isinstance(spec, dict) and "path" in spec):
             continue
         if is_canopy(dep_name):
             violations.append(f"[E] submodule mod {name} has path-dep → {dep_name}")
 
 # --- Report ---
+for key in sorted(EDITOR_LANG_EXCEPTIONS):
+    if key in exceptions_used:
+        print(f"NOTE [G] waived: {key[0]} ({key[1]}) → {key[2]} — "
+              f"{EDITOR_LANG_EXCEPTIONS[key]}")
+    else:
+        violations.append(
+            f"[G] STALE exception: {key[0]} ({key[1]}) → {key[2]} no longer "
+            f"matches any import — remove it from EDITOR_LANG_EXCEPTIONS")
+
 if violations:
     print("Dependency rule violations:", file=sys.stderr)
     for v in violations:

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -10,24 +10,42 @@
 #
 # Package-level layering rules inside the dowdiness/canopy module (see
 # docs/plans/2026-06-11-architecture-redesign-proposal.md, "Dependency and
-# boundary rules"):
+# boundary rules"). "Language grammar" below = the out-of-module grammar
+# modules in GRAMMAR_MODULES (dowdiness/lambda, dowdiness/json,
+# dowdiness/markdown) — importing one is a language import even though it
+# bypasses dowdiness/canopy/lang.
 #   [F] core/** and protocol/** (incl. protocol/wire) import substrate only:
-#       their canopy-internal imports must stay within {core/**, protocol/**}
-#       — no language, transport, or app imports.
-#   [G] editor/** must not import dowdiness/canopy/lang/* in ANY scope,
-#       test/wbtest included. Dated exceptions are listed in
-#       EDITOR_LANG_EXCEPTIONS below; each waiver is printed on every run
-#       (never silent) and FAILS the check if it stops matching anything.
-#   [H] relay/** imports only dowdiness/canopy/protocol/wire,
-#       dowdiness/byte_codec, and moonbitlang/* — never editor.
+#       canopy-internal imports must stay within {core/**, protocol/**},
+#       and no language grammar.
+#   [G] editor/** must not import dowdiness/canopy/lang/* or a language
+#       grammar in ANY scope, test/wbtest included.
+#   [H] relay/** imports only protocol/wire, byte_codec, its own subtree,
+#       and moonbitlang/* — never editor.
 #   [I] lang/** must not import dowdiness/canopy/ffi/*; a language
-#       lang/<L>/** must not import another language lang/<M>/**
+#       lang/<L>/** must not import another language's packages or grammar
 #       (lang/runtime is shared SPI, importable by every language);
-#       lang/runtime must not import any language in normal scope
+#       lang/runtime itself must not import any language in normal scope
 #       (test-scope fixtures are allowed).
 #
-# Applies to all scopes (normal, test, wbtest) for [A]–[D] and [F]–[I]
-# (the one scope carve-out is [I]'s lang/runtime clause, noted above).
+# Dated waivers live in the EXCEPTIONS table below, keyed
+# (rule, package, scope, import). Each waiver is printed on every run
+# (never silent) and FAILS the check once it stops matching anything.
+#
+# All scopes (normal, test, wbtest) are checked for [A]-[D] and [F]-[I];
+# the scope carve-outs are [I]'s lang/runtime clause and the scope-keyed
+# EXCEPTIONS entries.
+#
+# NOT enforced here (deliberate gaps — do not read this lint as the full
+# proposal section):
+#   - the general "L(n) depends only on L(n-1)" layering (only the named
+#     pairs above are checked);
+#   - the positive clause "lang/<L> depends on lang/runtime + its grammar
+#     only" — lang/* importing editor/core/protocol is the current S3
+#     design and passes;
+#   - editor/** importing ffi/*, and ffi/** imports generally;
+#   - "ffi/<L> is the only home of editor-state JSON serialization"
+#     (not expressible as an import rule).
+#
 # Exits non-zero on any violation. Intended to run in CI.
 set -euo pipefail
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
@@ -174,11 +192,15 @@ example_modules = {n for n, c in module_category.items() if c == "example"}
 
 CANOPY = "dowdiness/canopy"
 
+def under(path, roots):
+    """True when path equals a root or is nested under one (segment-aware)."""
+    return any(path == r or path.startswith(r + "/") for r in roots)
+
 def is_canopy(sym):
-    return sym == CANOPY or sym.startswith(CANOPY + "/")
+    return canopy_pkg(sym) is not None
 
 def is_example(sym):
-    return any(sym == n or sym.startswith(n + "/") for n in example_modules)
+    return under(sym, example_modules)
 
 # --- Package-level layering rules within dowdiness/canopy ([F]-[I]) ---
 
@@ -191,67 +213,109 @@ def canopy_pkg(sym):
         return sym[len(CANOPY) + 1:]
     return None
 
-def under(pkg, roots):
-    return any(pkg == r or pkg.startswith(r + "/") for r in roots)
-
 SUBSTRATE_ONLY_ROOTS = ("core", "protocol")  # [F] — protocol covers protocol/wire
-RELAY_ALLOWED = (CANOPY + "/protocol/wire", "dowdiness/byte_codec")  # [H]
-
-# [G] dated exceptions: (package, scope, import) -> reason. A waiver is
-# printed on every run; a listed exception that no longer matches any
-# import FAILS the check, so this list cannot rot silently.
-_LAMBDA_FIXTURE_REASON = (
-    "dated 2026-06-12: editor's lambda test fixture is pending replacement "
-    "by a TestExpr-style neutral grammar (redesign proposal, 'Dependency "
-    "and boundary rules'); remove this entry when editor tests stop "
-    "importing lang/lambda"
+RELAY_ALLOWED_ROOTS = (  # [H] — each allows its own subpackages
+    CANOPY + "/protocol/wire",
+    CANOPY + "/relay",  # intra-component imports if relay ever splits
+    "dowdiness/byte_codec",
 )
-EDITOR_LANG_EXCEPTIONS = {
-    ("editor", "test", CANOPY + "/lang/lambda"): _LAMBDA_FIXTURE_REASON,
-    ("editor", "wbtest", CANOPY + "/lang/lambda"): _LAMBDA_FIXTURE_REASON,
+
+# Out-of-module grammar/language modules, keyed by the lang/<L> that owns
+# each. A language may import its own grammar; nobody else's. core/protocol
+# and editor may import none of them (a grammar import IS a language import
+# for [F]/[G] purposes, just routed around dowdiness/canopy/lang).
+GRAMMAR_MODULES = {
+    "dowdiness/lambda": "lambda",
+    "dowdiness/json": "json",
+    "dowdiness/markdown": "markdown",
+}
+
+def grammar_lang(sym):
+    """Owning language of an out-of-module grammar import, or None."""
+    for root, lang in GRAMMAR_MODULES.items():
+        if under(sym, (root,)):
+            return lang
+    return None
+
+# Dated waivers: (rule, package, scope, import) -> reason. A waiver is
+# printed on every run; a listed entry that no longer matches any import
+# FAILS the check, so this table cannot rot silently. Adding a waiver for
+# any rule is a data edit here, not new machinery.
+_LAMBDA_FIXTURE_REASON = (
+    "dated 2026-06-12, re-evaluate by 2026-09-12: editor's lambda test "
+    "fixture is pending replacement by a TestExpr-style neutral grammar "
+    "(redesign proposal, 'Dependency and boundary rules'); remove this "
+    "entry when editor tests stop importing it"
+)
+EXCEPTIONS = {
+    ("G", "editor", scope, sym): _LAMBDA_FIXTURE_REASON
+    for scope, sym in (
+        ("test", CANOPY + "/lang/lambda"),
+        ("wbtest", CANOPY + "/lang/lambda"),
+        ("test", "dowdiness/lambda"),
+        ("test", "dowdiness/lambda/ast"),
+    )
 }
 exceptions_used = set()
+
+def waived(rule, pkg, scope, sym):
+    key = (rule, pkg, scope, sym)
+    if key in EXCEPTIONS:
+        exceptions_used.add(key)
+        return True
+    return False
 
 def check_canopy_layering(pkg, scope, sym):
     """Yield [F]-[I] violation strings for one import of a canopy package."""
     target = canopy_pkg(sym)
-    if under(pkg, SUBSTRATE_ONLY_ROOTS) and target is not None \
-            and not under(target, SUBSTRATE_ONLY_ROOTS):
-        yield (f"[F] {pkg} ({scope}) → {sym} "
-               f"(core/protocol import substrate only)")
-    if under(pkg, ("editor",)) and target is not None \
-            and under(target, ("lang",)):
-        key = (pkg, scope, sym)
-        if key in EDITOR_LANG_EXCEPTIONS:
-            exceptions_used.add(key)
-        else:
-            yield f"[G] {pkg} ({scope}) → {sym} (editor must not import lang/*)"
+    glang = grammar_lang(sym)
+    if under(pkg, SUBSTRATE_ONLY_ROOTS):
+        if target is not None and not under(target, SUBSTRATE_ONLY_ROOTS):
+            yield (f"[F] {pkg} ({scope}) → {sym} "
+                   f"(core/protocol import substrate only)")
+        if glang is not None:
+            yield (f"[F] {pkg} ({scope}) → {sym} "
+                   f"(core/protocol must not import a language grammar)")
+    if under(pkg, ("editor",)):
+        is_lang_import = (target is not None and under(target, ("lang",))) \
+            or glang is not None
+        if is_lang_import and not waived("G", pkg, scope, sym):
+            yield (f"[G] {pkg} ({scope}) → {sym} "
+                   f"(editor must not import lang/* or a language grammar)")
     if under(pkg, ("relay",)) \
-            and sym not in RELAY_ALLOWED and not sym.startswith("moonbitlang/"):
+            and not under(sym, RELAY_ALLOWED_ROOTS) \
+            and not sym.startswith("moonbitlang/"):
         yield (f"[H] {pkg} ({scope}) → {sym} "
-               f"(relay allowlist: protocol/wire, byte_codec, moonbitlang/*)")
-    if under(pkg, ("lang",)) and target is not None:
-        if under(target, ("ffi",)):
+               f"(relay allowlist: {', '.join(RELAY_ALLOWED_ROOTS)}, "
+               f"moonbitlang/*)")
+    if pkg.startswith("lang/"):
+        own = pkg.split("/")[1]
+        if target is not None and under(target, ("ffi",)):
             yield f"[I] {pkg} ({scope}) → {sym} (lang must not import ffi/*)"
-        elif under(target, ("lang",)) and target != "lang":
-            own = pkg.split("/")[1] if "/" in pkg else None
-            tgt = target.split("/")[1]
-            if own == "runtime":
-                if tgt != "runtime" and scope == "normal":
-                    yield (f"[I] {pkg} ({scope}) → {sym} "
-                           f"(lang/runtime must not depend on a language)")
-            elif tgt not in ("runtime", own):
-                yield f"[I] {pkg} ({scope}) → {sym} (cross-language import)"
+        other_lang = (target is not None and target.startswith("lang/")
+                      and target.split("/")[1] not in ("runtime", own))
+        other_grammar = glang is not None and glang != own
+        if own == "runtime":
+            # Shared SPI: language imports are test-fixture-only.
+            if (other_lang or other_grammar) and scope == "normal":
+                yield (f"[I] {pkg} ({scope}) → {sym} "
+                       f"(lang/runtime must not depend on a language)")
+        elif other_lang or other_grammar:
+            yield f"[I] {pkg} ({scope}) → {sym} (cross-language import)"
 
 # --- Scan package imports ---
 violations = []
 scanned_pkgs = 0
+canopy_import_counts = {}  # canopy pkg_rel -> number of parsed imports
 
 for pkg_file in iter_files("moon.pkg"):
     scanned_pkgs += 1
     mod_name, _ = nearest_module(pkg_file)
     cat = module_category.get(mod_name, "other")
-    pkg_rel = os.path.relpath(os.path.dirname(pkg_file), ROOT) or "."
+    pkg_rel = (os.path.relpath(os.path.dirname(pkg_file), ROOT) or ".") \
+        .replace(os.sep, "/")
+    if cat == "canopy":
+        canopy_import_counts.setdefault(pkg_rel, 0)
     for scope, sym in parse_imports(pkg_file):
         if cat == "lib" and is_canopy(sym):
             violations.append(f"[A] lib pkg {pkg_rel} ({mod_name}, {scope}) → {sym}")
@@ -262,6 +326,7 @@ for pkg_file in iter_files("moon.pkg"):
         if cat == "submodule" and is_example(sym):
             violations.append(f"[D] submodule pkg {pkg_rel} ({mod_name}, {scope}) → {sym}")
         if cat == "canopy":
+            canopy_import_counts[pkg_rel] += 1
             violations.extend(check_canopy_layering(pkg_rel, scope, sym))
 
 # --- Scan module path-deps ---
@@ -283,14 +348,24 @@ for mmj in iter_manifests():
             violations.append(f"[E] submodule mod {name} has path-dep → {dep_name}")
 
 # --- Report ---
-for key in sorted(EDITOR_LANG_EXCEPTIONS):
+for key in sorted(EXCEPTIONS):
+    rule, pkg, scope, sym = key
     if key in exceptions_used:
-        print(f"NOTE [G] waived: {key[0]} ({key[1]}) → {key[2]} — "
-              f"{EDITOR_LANG_EXCEPTIONS[key]}")
+        print(f"NOTE [{rule}] waived: {pkg} ({scope}) → {sym} — "
+              f"{EXCEPTIONS[key]}")
+    elif canopy_import_counts.get(pkg, 0) == 0:
+        # Distinguish a removed import from a scanner that never parsed the
+        # package — following the stale-removal advice here would silently
+        # disable the rule while the real problem is a broken scan.
+        gap = (f"[{rule}] SCAN GAP: package {pkg} (waived in EXCEPTIONS) "
+               f"yielded no imports — manifest missing or unparsable; fix "
+               f"the scan before touching the exception table")
+        if gap not in violations:
+            violations.append(gap)
     else:
         violations.append(
-            f"[G] STALE exception: {key[0]} ({key[1]}) → {key[2]} no longer "
-            f"matches any import — remove it from EDITOR_LANG_EXCEPTIONS")
+            f"[{rule}] STALE exception: {pkg} ({scope}) → {sym} no longer "
+            f"matches any import — remove it from EXCEPTIONS")
 
 if violations:
     print("Dependency rule violations:", file=sys.stderr)


### PR DESCRIPTION
Ships the redesign proposal's last acceptance criterion: **"Import-graph lint enforcing the boundary rules runs in CI"** (`docs/plans/2026-06-11-architecture-redesign-proposal.md`, "Dependency and boundary rules").

## What

Extends `scripts/check-deps.sh` (already in the `dep-check` CI job) with package-level layering rules inside the `dowdiness/canopy` module, reusing the existing manifest/import parsing machinery — **no fourth manifest parser** (the repo's agreed extraction trigger stays untripped):

| Rule | Boundary |
|------|----------|
| `[F]` | `core/**`, `protocol/**` (incl. `protocol/wire`) import substrate only: canopy-internal imports stay within that set, and no language grammar module |
| `[G]` | `editor/**` must not import `dowdiness/canopy/lang/*` **or a language grammar** in any scope, test/wbtest included |
| `[H]` | `relay/**` allowlist: `protocol/wire`, `byte_codec`, its own subtree, `moonbitlang/*` — never editor |
| `[I]` | `lang/**` never imports `ffi/*`; `lang/<L>` never imports another language's packages or grammar; `lang/runtime` never depends on a language in normal scope (test fixtures allowed) |

"Language grammar" = the out-of-module grammar modules `dowdiness/lambda`, `dowdiness/json`, `dowdiness/markdown` — importing one is a language import even though it bypasses `dowdiness/canopy/lang` (hole found during review by three independent finder angles; `core` importing `dowdiness/lambda` previously passed).

## Dated exception (not a silent skip)

The proposal's "lambda test fixture replaced by a TestExpr-style neutral grammar" has **not** landed — `editor/moon.pkg` still imports `dowdiness/canopy/lang/lambda` (test+wbtest) and `dowdiness/lambda{,/ast}` (test) across 17 test files. The rule ships with 4 waiver entries in a generic `EXCEPTIONS` table keyed `(rule, package, scope, import)`:

- each waiver is **printed on every run** (`NOTE [G] waived: ...`), never silent;
- a waiver that stops matching **fails the check as STALE** (forces lockstep cleanup when the TestExpr fixture lands);
- a waived package that yields zero parsed imports fails as **SCAN GAP** (a broken scanner can't masquerade as a stale waiver);
- reason text carries `dated 2026-06-12, re-evaluate by 2026-09-12` (same re-evaluation date as the S5a substrate exception).

The script header also lists what is deliberately **NOT** enforced (full L(n) layering, the lang positive-allowlist clause, editor→ffi, ffi/** imports) so the lint isn't misread as the whole proposal section.

## Positive controls (all demonstrated locally)

| Control | Injection | Result |
|---------|-----------|--------|
| `[F]` internal | `core` → `dowdiness/canopy/editor` | fired |
| `[F]` grammar | `core` → `dowdiness/lambda` | fired (passed before review fix) |
| `[G]` | `editor` → `dowdiness/canopy/lang/json/proj` | fired |
| `[G]` grammar | `editor` → `dowdiness/json` | fired |
| `[H]` | `relay` → `dowdiness/canopy/editor` | fired |
| `[I]` ffi | `lang/json/edits` → `dowdiness/canopy/ffi/host` | fired |
| `[I]` cross-lang | `lang/json/edits` → `lang/markdown/sentinel` | fired |
| `[I]` cross-grammar | `lang/markdown/proj` → `dowdiness/json` | fired |
| `[I]` runtime | `lang/runtime` → `lang/json/proj` (normal) | fired |
| `[H]` intra-relay (negative) | `relay` → `dowdiness/canopy/relay/frames` | no false positive |
| STALE | remove editor wbtest lambda import | fired |
| SCAN GAP | make `editor/moon.pkg` unparsable | fired, deduped to one line |

Clean tree: `OK — 206 packages and 73 modules scanned, no rule violations.` (exit 0, 4 waiver NOTEs printed).

## Reuse check

- Reused: `check-deps.sh`'s existing `parse_imports` / `_import_block` / `load_manifest` / `classify` / `nearest_module` machinery, the new-format `moon.pkg` brace-syntax parser included; the existing rule-letter scheme and violation report.
- Checked, not duplicated: `check-shared-substrate.sh` / `check-egw-resolver-identity.sh` parsers (different seam: resolution identity vs import direction).
- Consolidated: `is_canopy` / `is_example` now delegate to the new `under()` / `canopy_pkg()` primitives instead of keeping parallel prefix predicates.
- New helpers: `under`, `canopy_pkg`, `grammar_lang`, `waived`, `check_canopy_layering` — all scoped to the canopy package-layering rule family.

## Docs

`docs/CI_CD.md` `dep-check` row annotated with the rule coverage (points at the script header as the rules table, so the doc stops going stale per-rule).

/code-review: 7 finder angles, 27 candidates, ~9 accepted and fixed in the second commit (grammar-module hole, [H] segment-aware targets, generic exception table, SCAN GAP, lang-root mislabel, predicate consolidation, os.sep normalization, header gap list); refuted: stdout-consumer concerns (nothing parses this output; verified against ci.yml), stale-counted-as-violation (by design — forces lockstep waiver cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
