### PR TITLE
test(redesign): restore generic-pipeline coverage + dedup TestExpr fixture (#600, #601)

### DIFF
--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -64,7 +64,7 @@ impl Renderable for TestExpr with fn unparse(self) {
   match self {
     Leaf(s) => s
     Branch(tag, cs) =>
-      tag + "(" + cs.map(fn(c) { Renderable::unparse(c) }).join(", ") + ")"
+      tag + "(" + cs.map(fn(c) { Renderable::unparse(c) }).join(" ") + ")"
   }
 }
 
@@ -74,6 +74,35 @@ impl ToJson for TestExpr with fn to_json(self) {
     Leaf(s) => Json::string(s)
     Branch(tag, _) => Json::string(tag)
   }
+}
+
+///|
+// Drift guard for the TestExpr fixture (issue #601).
+//
+// TestExpr is intentionally duplicated: this `priv` copy backs core's "works
+// with any AST" contract and cannot import the `workspace/probe` copy without a
+// layering cycle (probe depends on core). The other copy is `pub(all)` in
+// `workspace/probe/test_expr.mbt` and backs the editor's neutral grammar.
+// To stop the two from drifting silently, BOTH files pin their TestExpr's
+// observable surface to the SAME frozen literals below — a frozen reference,
+// never a call back through the other copy (layering forbids it anyway), so a
+// change to EITHER definition's unparse / placeholder / kind_tag / label /
+// children fails its own file's guard. Keep the two literal blocks
+// byte-identical; if you change one, change the other (see
+// `workspace/probe/test_grammar_contract_wbtest.mbt`,
+// "TestExpr fixture surface is frozen").
+test "TestExpr fixture surface is frozen (drift guard vs workspace/probe)" {
+  let sample : TestExpr = Branch("f", [Leaf("x"), Leaf("y")])
+  inspect(Renderable::kind_tag(sample), content="Branch")
+  inspect(Renderable::label(sample), content="f")
+  inspect(Renderable::placeholder(sample), content="?")
+  inspect(Renderable::unparse(sample), content="f(x y)")
+  inspect(@loomcore.TreeNode::children(sample).length(), content="2")
+  let leaf : TestExpr = Leaf("x")
+  inspect(Renderable::kind_tag(leaf), content="Leaf")
+  inspect(Renderable::label(leaf), content="x")
+  inspect(Renderable::unparse(leaf), content="x")
+  inspect(@loomcore.TreeNode::children(leaf).length(), content="0")
 }
 
 ///|

--- a/editor/view_updater_test.mbt
+++ b/editor/view_updater_test.mbt
@@ -15,6 +15,57 @@ test "get_view_tree returns ViewNode for non-empty editor" {
 }
 
 ///|
+// #2 (issue #600): the empty / first-render generic editor. Unlike lambda
+// (whose empty source folds to `None`), the neutral TestExpr grammar always
+// yields the empty-document `Branch("", [])`, so `get_view_tree` is `Some` even
+// with no text and the first `compute_view_patches` emits a `FullTree`. This
+// pins the generic empty-document behavior, which the moved lambda companion
+// test (`editor_view_decorations_test.mbt`) does not cover.
+test "empty generic editor yields an empty-document view and a FullTree patch" {
+  let editor = @probe.new_test_editor("test")
+  // No text inserted.
+  let tree = editor.get_view_tree()
+  assert_true(tree is Some(_))
+  let node = tree.unwrap()
+  inspect(node.kind_tag, content="Branch")
+  inspect(node.label, content="")
+  inspect(node.children.length(), content="0")
+  // First render emits a FullTree patch (previous view is None).
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let patches = @editor.compute_view_patches(state, editor)
+  let has_full_tree = patches
+    .iter()
+    .any(fn(p) {
+      match p {
+        @protocol.ViewPatch::FullTree(_) => true
+        _ => false
+      }
+    })
+  assert_true(has_full_tree)
+}
+
+///|
+// #3 (issue #600): NodeId stability across an unrelated sibling edit, on the
+// neutral grammar. Editing one sibling's label must not renumber an untouched
+// sibling — `reconcile` preserves the NodeId when `same_kind` holds. The moved
+// lambda companion test asserts this only against lambda's Module/def-index
+// projection; this pins it for the generic pipeline.
+test "NodeId stable across an unrelated sibling edit" {
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("f(x y)")
+  // root Branch("") -> child Branch("f") -> [Leaf("x"), Leaf("y")]
+  let root = editor.get_proj_node().unwrap()
+  let x_id = root.children[0].children[0].id()
+  // Edit only the sibling: "y" -> "z". The "x" leaf is untouched.
+  editor.set_text("f(x z)")
+  // "x" must keep its identity: the same NodeId still resolves to Leaf("x").
+  match editor.get_node(x_id) {
+    Some(node) => inspect(node.kind, content="Leaf(\"x\")")
+    None => fail("x leaf lost its NodeId after an unrelated sibling edit")
+  }
+}
+
+///|
 test "initial state produces FullTree patch" {
   let editor = @probe.new_test_editor("test")
   editor.set_text("f(x)")
@@ -59,7 +110,14 @@ test "unchanged tree produces no tree patches" {
 }
 
 ///|
-test "single character edit produces UpdateNode or ReplaceNode for changed leaf" {
+// #8 (issue #600): a pure leaf-label change must emit a minimal `UpdateNode`,
+// not a `ReplaceNode`. The Leaf("a") -> Leaf("b") edit keeps the kind (so
+// `same_kind` holds, the NodeId is preserved) and TestExpr has all-None
+// capabilities — no eval-annotation churn to force a wider patch. The earlier
+// UpdateNode-OR-ReplaceNode looseness only existed to tolerate lambda's
+// eval-annotation diffs, which the generic pipeline does not produce. Assert
+// the tight shape so diff minimality is actually verified.
+test "single character leaf edit produces a minimal UpdateNode (not ReplaceNode)" {
   let editor = @probe.new_test_editor("test")
   editor.set_text("a")
   let state = @editor.ViewUpdateState::ViewUpdateState()
@@ -67,17 +125,27 @@ test "single character edit produces UpdateNode or ReplaceNode for changed leaf"
   // Change "a" to "b"
   editor.set_text("b")
   let patches = @editor.compute_view_patches(state, editor)
-  // Should contain an UpdateNode or ReplaceNode reflecting the new value "b".
-  let has_update = patches
+  // The new label "b" arrives via UpdateNode...
+  let has_update_b = patches
     .iter()
     .any(fn(p) {
       match p {
         @protocol.ViewPatch::UpdateNode(label~, ..) => label == "b"
-        @protocol.ViewPatch::ReplaceNode(node~, ..) => node.label == "b"
         _ => false
       }
     })
-  assert_true(has_update)
+  assert_true(has_update_b)
+  // ...and NOT via a ReplaceNode (which would mean the diff rebuilt the leaf
+  // instead of updating it in place).
+  let has_replace = patches
+    .iter()
+    .any(fn(p) {
+      match p {
+        @protocol.ViewPatch::ReplaceNode(_) => true
+        _ => false
+      }
+    })
+  assert_false(has_replace)
 }
 
 ///|

--- a/workspace/probe/test_grammar_contract_wbtest.mbt
+++ b/workspace/probe/test_grammar_contract_wbtest.mbt
@@ -88,6 +88,58 @@ test "total over a lone surrogate half — no abort" {
 }
 
 ///|
+// #5 (issue #600): the generic `get_errors` / diagnostics contract is exercised
+// against TestExpr's SINGLE structural error shape — an unclosed '('. This is
+// by design, not an oversight, and the limitation is documented here so it
+// cannot be mistaken for missing coverage. The grammar is deliberately TOTAL
+// (see test_grammar.mbt header): every other malformed input (stray
+// punctuation, garbage, non-BMP runs, lone surrogate halves) becomes a silent
+// lexer gap rather than a diagnostic. Adding a second error shape would require
+// a non-total parser path and risk the totality invariant the contract tests
+// above pin — so the single trigger is intentional. This test pins both sides:
+// exactly one diagnostic for the one trigger, and zero for silent-gap garbage.
+test "TestExpr reports exactly one structural diagnostic kind (unclosed '(')" {
+  let ed = new_test_editor("agent")
+  ed.insert("foo(")
+  let errs = ed.get_errors()
+  inspect(errs.length(), content="1")
+  inspect(errs[0].has_prefix("unclosed '('"), content="true")
+  // Totality: garbage punctuation is a silent lexer gap, NOT a diagnostic, so
+  // there is no second error shape to broaden the contract with.
+  let ed2 = new_test_editor("agent")
+  ed2.insert("@#$%^&")
+  inspect(ed2.get_errors().length(), content="0")
+}
+
+///|
+// Drift guard for the TestExpr fixture (issue #601).
+//
+// This `pub(all)` TestExpr (workspace/probe/test_expr.mbt) was promoted from
+// the `priv` copy in `core/test_expr_wbtest.mbt`, which core's "works with any
+// AST" contract must keep (probe depends on core, so the priv copy cannot be
+// replaced by importing this one without a layering cycle). To stop the two
+// from drifting silently, BOTH files pin their TestExpr's observable surface to
+// the SAME frozen literals below — a frozen reference, never a call back
+// through the other copy, so a change to EITHER definition's unparse /
+// placeholder / kind_tag / label / children fails its own file's guard. Keep
+// the two literal blocks byte-identical; if you change one, change the other
+// (see `core/test_expr_wbtest.mbt`,
+// "TestExpr fixture surface is frozen (drift guard vs workspace/probe)").
+test "TestExpr fixture surface is frozen (drift guard vs core)" {
+  let sample : TestExpr = Branch("f", [Leaf("x"), Leaf("y")])
+  inspect(@loomcore.Renderable::kind_tag(sample), content="Branch")
+  inspect(@loomcore.Renderable::label(sample), content="f")
+  inspect(@loomcore.Renderable::placeholder(sample), content="?")
+  inspect(@loomcore.Renderable::unparse(sample), content="f(x y)")
+  inspect(@loomcore.TreeNode::children(sample).length(), content="2")
+  let leaf : TestExpr = Leaf("x")
+  inspect(@loomcore.Renderable::kind_tag(leaf), content="Leaf")
+  inspect(@loomcore.Renderable::label(leaf), content="x")
+  inspect(@loomcore.Renderable::unparse(leaf), content="x")
+  inspect(@loomcore.TreeNode::children(leaf).length(), content="0")
+}
+
+///|
 test "proj node available for non-empty editor" {
   let ed = new_test_editor("agent")
   ed.insert("f(x)")


### PR DESCRIPTION
Follow-ups to the editor-neutral `TestExpr` grammar work (#602). Closes #600, closes #601. Test-only — no public `.mbti` change; `editor/` imports no `lang/*` (check-deps `[G]` clean).

## #601 — deduplicate / drift-guard the `TestExpr` fixture

The two copies had **already drifted**: `core/test_expr_wbtest.mbt` used `", "` in `unparse`, `workspace/probe/test_expr.mbt` used `" "` (the s-expr separator its grammar actually round-trips). A single shared home is blocked by layering (rule `[F]`: `core` imports only `core`/`protocol`/substrate; `probe` depends on `core`), so the `priv` copy stays.

- Reconciled `core`'s separator `", "` → `" "` (it was never asserted anywhere in `core`).
- Added a frozen-reference drift guard in **both** files, each pinning its **own** copy's observable surface (`unparse` / `placeholder` / `kind_tag` / `label` / children) to **byte-identical** literals. Non-circular — no call back through the other copy (layering forbids it anyway); a change to either definition fails its own file's guard.

## #600 — restore generic-pipeline coverage lost to the companion move

The moved tests now exercise these behaviors only against lambda's projection (whose semantics differ from the language-agnostic `SyncEditor` + `@core.build_projection_memos` path). Re-added for the neutral grammar:

- **#2 empty-document view.** Empty/first-render generic editor yields `Branch("", [])` (`get_view_tree` is `Some`, not lambda's `None`) and a `FullTree` patch.
- **#3 NodeId stability.** A node keeps its `NodeId` after an unrelated sibling edit (`f(x y)` → `f(x z)`, re-query `x` by id).
- **#5 diagnostics breadth.** Pinned + **documented** `TestExpr`'s single structural diagnostic (`unclosed '('`); a second error shape is intentionally absent to keep the parser total (garbage stays a silent lexer gap). Chose document-the-limit over adding a parser path, to protect the totality invariant.
- **#8 diff minimality.** Tightened the single-char leaf edit from `UpdateNode`-OR-`ReplaceNode` to a minimal `UpdateNode` (asserts no `ReplaceNode`); the looseness only existed to tolerate lambda eval-annotation churn the generic pipeline never produces.

## Reuse check

No new functions/types/helpers — only test cases using existing `SyncEditor` accessors (`get_view_tree`, `get_proj_node`, `get_node`, `get_errors`, `compute_view_patches`) and the existing `@probe.new_test_editor` fixture. The `core` `unparse` edit reuses the existing impl.

## Verification

- All six new tests were teeth-verified: each fails under a temporary inverted change, then reverted (both drift guards via flipped separator; `#8` via expecting `ReplaceNode`; `#3` via a bogus id; `#2` via the empty-doc child count; `#5` via the garbage diagnostic count).
- Full `moon test`: **1368 passed [js] / 46 passed [native]**, 0 failed.
- `./scripts/check-deps.sh`: clean (206 packages, no violations).
- Codex pre-PR review: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
