### PR TITLE
Rank related posts with resurfacing signals

### DIFF
--- a/examples/web/posts.html
+++ b/examples/web/posts.html
@@ -276,7 +276,7 @@
     }
 
     .related-meta time,
-    .related-match {
+    .related-reason {
       color: var(--muted);
       font-size: 0.72rem;
       font-weight: 700;
@@ -284,8 +284,19 @@
       text-transform: uppercase;
     }
 
-    .related-match {
+    .related-reasons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
+      align-items: center;
+    }
+
+    .related-reason[data-kind="match"] {
       color: color-mix(in oklab, var(--secondary), var(--accent) 20%);
+    }
+
+    .related-reason[data-kind="resurfacing"] {
+      color: color-mix(in oklab, var(--success), var(--text) 18%);
     }
 
     .related-text {
@@ -293,6 +304,28 @@
       color: var(--secondary);
       white-space: pre-wrap;
       overflow-wrap: anywhere;
+    }
+
+    .related-open {
+      justify-self: start;
+      margin-top: var(--space-xs);
+      padding: 4px 10px;
+      background: color-mix(in oklab, var(--surface), var(--accent) 8%);
+      color: var(--secondary);
+      border: 1px solid color-mix(in oklab, var(--border), var(--accent) 24%);
+      border-radius: 999px;
+      cursor: pointer;
+      font-size: 0.76rem;
+      font-weight: 800;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .related-open:hover,
+    .related-open:focus-visible {
+      color: var(--text);
+      border-color: color-mix(in oklab, var(--accent), var(--border) 30%);
+      outline: none;
     }
 
     .timeline {
@@ -324,6 +357,11 @@
       background: var(--surface-soft);
       border: 1px solid var(--border);
       border-radius: 16px;
+    }
+
+    .post-item[data-highlighted="true"] article {
+      border-color: color-mix(in oklab, var(--accent), var(--border) 25%);
+      box-shadow: 0 0 0 3px var(--accent-soft);
     }
 
     .post-item time {

--- a/examples/web/src/post-app.ts
+++ b/examples/web/src/post-app.ts
@@ -1,4 +1,5 @@
-import { PostRetrievalIndex, type RelatedPost } from './post-retrieval';
+import { LocalPostEventStore } from './post-events';
+import { PostRetrievalIndex, type RelatedPost, type RankingReason } from './post-retrieval';
 import { type LocalPost, LocalPostStore } from './post-store';
 
 const form = document.getElementById('post-form') as HTMLFormElement;
@@ -13,6 +14,7 @@ const relatedCountEl = document.getElementById('related-count') as HTMLSpanEleme
 const relatedListEl = document.getElementById('related-list') as HTMLUListElement;
 
 const store = new LocalPostStore(window.localStorage);
+const eventStore = new LocalPostEventStore(window.localStorage);
 const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
   month: 'short',
   day: 'numeric',
@@ -21,7 +23,8 @@ const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
 });
 
 let posts: LocalPost[] = [];
-let retrievalIndex = new PostRetrievalIndex(posts);
+let highlightedPostId: string | null = null;
+let retrievalIndex = new PostRetrievalIndex(posts, eventStore.engagementByPost());
 
 function pluralizePosts(count: number): string {
   return count === 1 ? '1 post' : `${count} posts`;
@@ -47,6 +50,9 @@ function syncSubmitState(): void {
 function renderPost(post: LocalPost): HTMLLIElement {
   const item = document.createElement('li');
   item.className = 'post-item';
+  item.dataset.postId = post.id;
+  item.tabIndex = -1;
+  item.dataset.highlighted = post.id === highlightedPostId ? 'true' : 'false';
 
   const article = document.createElement('article');
 
@@ -59,6 +65,14 @@ function renderPost(post: LocalPost): HTMLLIElement {
 
   article.append(time, text);
   item.append(article);
+  return item;
+}
+
+function renderRankingReason(reason: RankingReason): HTMLSpanElement {
+  const item = document.createElement('span');
+  item.className = 'related-reason';
+  item.dataset.kind = reason.kind;
+  item.textContent = reason.label;
   return item;
 }
 
@@ -75,16 +89,23 @@ function renderRelatedPost(result: RelatedPost): HTMLLIElement {
   time.dateTime = result.post.createdAt;
   time.textContent = formatTimestamp(result.post.createdAt);
 
-  const match = document.createElement('span');
-  match.className = 'related-match';
-  match.textContent = `Echoes ${result.matchedTerms.slice(0, 3).join(' · ')}`;
+  const reasons = document.createElement('div');
+  reasons.className = 'related-reasons';
+  reasons.append(...result.reasons.map(renderRankingReason));
 
   const text = document.createElement('p');
   text.className = 'related-text';
   text.textContent = result.post.text;
 
-  meta.append(time, match);
-  article.append(meta, text);
+  const openButton = document.createElement('button');
+  openButton.type = 'button';
+  openButton.className = 'related-open';
+  openButton.textContent = 'Open';
+  openButton.setAttribute('aria-label', `Open related post: ${result.post.text.slice(0, 80)}`);
+  openButton.addEventListener('click', () => openRelatedPost(result));
+
+  meta.append(time, reasons);
+  article.append(meta, text, openButton);
   item.append(article);
   return item;
 }
@@ -98,7 +119,37 @@ function renderRelated(): void {
 
 function replacePosts(nextPosts: LocalPost[]): void {
   posts = nextPosts;
-  retrievalIndex = new PostRetrievalIndex(posts);
+  retrievalIndex = new PostRetrievalIndex(posts, eventStore.engagementByPost());
+}
+
+function focusTimelinePost(postId: string): void {
+  window.requestAnimationFrame(() => {
+    const item = Array.from(listEl.querySelectorAll<HTMLLIElement>('.post-item')).find(
+      candidate => candidate.dataset.postId === postId,
+    );
+    item?.focus({ preventScroll: true });
+    item?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  });
+}
+
+function openRelatedPost(result: RelatedPost): void {
+  let recorded = true;
+  try {
+    eventStore.recordRelatedOpened(result.post.id);
+  } catch {
+    recorded = false;
+  }
+
+  highlightedPostId = result.post.id;
+  replacePosts(posts);
+  render();
+  focusTimelinePost(result.post.id);
+  setStatus(
+    recorded
+      ? 'Opened a related post. Revisited posts get a small ranking boost.'
+      : 'Opened a related post, but could not save its revisit signal.',
+    recorded ? 'success' : 'error',
+  );
 }
 
 function render(): void {
@@ -134,6 +185,12 @@ function submitDraft(): void {
 
   try {
     const post = store.add(text);
+    try {
+      eventStore.recordPostCreated(post.id);
+    } catch {
+      // Event tracking is best-effort; the post itself is the durable user data.
+    }
+    highlightedPostId = null;
     replacePosts([post, ...posts]);
     draft.value = '';
     syncSubmitState();

--- a/examples/web/src/post-events.ts
+++ b/examples/web/src/post-events.ts
@@ -1,0 +1,112 @@
+export type LocalPostEventType = 'post_created' | 'related_opened';
+
+export interface LocalPostEvent {
+  readonly id: string;
+  readonly type: LocalPostEventType;
+  readonly postId: string;
+  readonly createdAt: string;
+}
+
+export interface PostEngagementSignals {
+  readonly relatedOpenCount: number;
+  readonly lastRelatedOpenedAt?: string;
+}
+
+const POST_EVENT_STORAGE_KEY = 'canopy.post-events.v1';
+
+function isLocalPostEvent(value: unknown): value is LocalPostEvent {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const record = value as Record<string, unknown>;
+  const type = record.type;
+  return (
+    typeof record.id === 'string' &&
+    (type === 'post_created' || type === 'related_opened') &&
+    typeof record.postId === 'string' &&
+    record.postId.length > 0 &&
+    typeof record.createdAt === 'string' &&
+    !Number.isNaN(Date.parse(record.createdAt))
+  );
+}
+
+function newestEventFirst(a: LocalPostEvent, b: LocalPostEvent): number {
+  return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+}
+
+function createEventId(now: Date): string {
+  const time = now.getTime().toString(36);
+  const random = Math.random().toString(36).slice(2, 10);
+  return `post-event-${time}-${random}`;
+}
+
+function createEvent(type: LocalPostEventType, postId: string, now: Date): LocalPostEvent {
+  return {
+    id: createEventId(now),
+    type,
+    postId,
+    createdAt: now.toISOString(),
+  };
+}
+
+export class LocalPostEventStore {
+  constructor(
+    private readonly storage: Storage,
+    private readonly key = POST_EVENT_STORAGE_KEY,
+  ) {}
+
+  all(): LocalPostEvent[] {
+    try {
+      const raw = this.storage.getItem(this.key);
+      if (raw === null) return [];
+
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+
+      return parsed.filter(isLocalPostEvent).sort(newestEventFirst);
+    } catch {
+      return [];
+    }
+  }
+
+  recordPostCreated(postId: string, now = new Date()): LocalPostEvent {
+    return this.append(createEvent('post_created', postId, now));
+  }
+
+  recordRelatedOpened(postId: string, now = new Date()): LocalPostEvent {
+    return this.append(createEvent('related_opened', postId, now));
+  }
+
+  engagementByPost(): ReadonlyMap<string, PostEngagementSignals> {
+    const summaries = new Map<string, PostEngagementSignals>();
+
+    for (const event of this.all()) {
+      if (event.type !== 'related_opened') continue;
+
+      const current = summaries.get(event.postId);
+      const currentLastOpened = current?.lastRelatedOpenedAt;
+      const eventTime = Date.parse(event.createdAt);
+      const currentLastOpenedTime =
+        currentLastOpened === undefined ? Number.NEGATIVE_INFINITY : Date.parse(currentLastOpened);
+      const nextLastOpened =
+        currentLastOpened === undefined || eventTime > currentLastOpenedTime
+          ? event.createdAt
+          : currentLastOpened;
+
+      summaries.set(event.postId, {
+        relatedOpenCount: (current?.relatedOpenCount ?? 0) + 1,
+        lastRelatedOpenedAt: nextLastOpened,
+      });
+    }
+
+    return summaries;
+  }
+
+  private append(event: LocalPostEvent): LocalPostEvent {
+    this.save([event, ...this.all()].sort(newestEventFirst));
+    return event;
+  }
+
+  private save(events: LocalPostEvent[]): void {
+    this.storage.setItem(this.key, JSON.stringify(events));
+  }
+}

--- a/examples/web/src/post-retrieval.ts
+++ b/examples/web/src/post-retrieval.ts
@@ -1,9 +1,18 @@
+import type { PostEngagementSignals } from './post-events';
 import type { LocalPost } from './post-store';
+
+export type RankingReasonKind = 'match' | 'resurfacing' | 'recent';
+
+export interface RankingReason {
+  readonly kind: RankingReasonKind;
+  readonly label: string;
+}
 
 export interface RelatedPost {
   readonly post: LocalPost;
   readonly score: number;
   readonly matchedTerms: readonly string[];
+  readonly reasons: readonly RankingReason[];
 }
 
 export interface RetrievalOptions {
@@ -21,7 +30,15 @@ interface IndexedPost {
   readonly profile: TokenProfile;
 }
 
+interface ScoreBreakdown {
+  readonly lexical: number;
+  readonly resurfacing: number;
+  readonly recency: number;
+}
+
 const DEFAULT_RELATED_LIMIT = 5;
+const RESURFACING_BOOST = 0.9;
+const MAX_RECENCY_BOOST = 0.08;
 
 // #593 intentionally starts with a tiny browser-local lexical scorer instead of
 // wiring the experimental MoonBit `echo` package into Vite. Keeping the app on
@@ -100,12 +117,21 @@ const STOP_WORDS = new Set([
 export class PostRetrievalIndex {
   private readonly indexedPosts: readonly IndexedPost[];
   private readonly documentFrequency: ReadonlyMap<string, number>;
+  private readonly oldestPostTime: number;
+  private readonly newestPostTime: number;
 
-  constructor(posts: readonly LocalPost[]) {
+  constructor(
+    posts: readonly LocalPost[],
+    private readonly engagementByPost: ReadonlyMap<string, PostEngagementSignals> = new Map(),
+  ) {
     this.indexedPosts = posts
       .map(post => ({ post, profile: profileText(post.text) }))
       .filter(({ profile }) => profile.totalTerms > 0);
     this.documentFrequency = buildDocumentFrequency(this.indexedPosts);
+
+    const postTimes = this.indexedPosts.map(({ post }) => Date.parse(post.createdAt));
+    this.oldestPostTime = postTimes.length === 0 ? 0 : Math.min(...postTimes);
+    this.newestPostTime = postTimes.length === 0 ? 0 : Math.max(...postTimes);
   }
 
   query(draftText: string, options: RetrievalOptions = {}): RelatedPost[] {
@@ -128,6 +154,23 @@ export class PostRetrievalIndex {
     );
     if (matchedTerms.length === 0) return null;
 
+    const engagement = this.engagementByPost.get(indexedPost.post.id);
+    const score = this.scoreBreakdown(query, indexedPost, matchedTerms, engagement);
+
+    return {
+      post: indexedPost.post,
+      score: totalScore(score),
+      matchedTerms,
+      reasons: buildRankingReasons(matchedTerms, engagement, score),
+    };
+  }
+
+  private scoreBreakdown(
+    query: TokenProfile,
+    indexedPost: IndexedPost,
+    matchedTerms: readonly string[],
+    engagement: PostEngagementSignals | undefined,
+  ): ScoreBreakdown {
     const weightedOverlap = matchedTerms.reduce((score, term) => {
       const frequency = this.documentFrequency.get(term) ?? 0;
       const idf = Math.log(1 + this.indexedPosts.length / (1 + frequency));
@@ -138,11 +181,57 @@ export class PostRetrievalIndex {
     const lengthPenalty = Math.sqrt(indexedPost.profile.totalTerms);
 
     return {
-      post: indexedPost.post,
-      score: (weightedOverlap * (1 + queryCoverage)) / lengthPenalty,
-      matchedTerms,
+      lexical: (weightedOverlap * (1 + queryCoverage)) / lengthPenalty,
+      resurfacing: resurfacingScore(engagement),
+      recency: this.recencyScore(indexedPost.post.createdAt),
     };
   }
+
+  private recencyScore(createdAt: string): number {
+    if (this.newestPostTime <= this.oldestPostTime) return 0;
+
+    const createdTime = Date.parse(createdAt);
+    if (Number.isNaN(createdTime)) return 0;
+
+    const normalizedAge =
+      (createdTime - this.oldestPostTime) / (this.newestPostTime - this.oldestPostTime);
+    return Math.max(0, Math.min(1, normalizedAge)) * MAX_RECENCY_BOOST;
+  }
+}
+
+function resurfacingScore(engagement: PostEngagementSignals | undefined): number {
+  return engagement === undefined ? 0 : Math.log1p(engagement.relatedOpenCount) * RESURFACING_BOOST;
+}
+
+function totalScore(score: ScoreBreakdown): number {
+  return score.lexical + score.resurfacing + score.recency;
+}
+
+function buildRankingReasons(
+  matchedTerms: readonly string[],
+  engagement: PostEngagementSignals | undefined,
+  score: ScoreBreakdown,
+): RankingReason[] {
+  const reasons: RankingReason[] = [
+    { kind: 'match', label: `Echoes ${formatMatchedTerms(matchedTerms)}` },
+  ];
+
+  if (engagement !== undefined && score.resurfacing > 0) {
+    reasons.push({
+      kind: 'resurfacing',
+      label: `Revisited ${engagement.relatedOpenCount}x`,
+    });
+  }
+
+  if (score.recency > 0) {
+    reasons.push({ kind: 'recent', label: 'Newer post' });
+  }
+
+  return reasons;
+}
+
+function formatMatchedTerms(matchedTerms: readonly string[]): string {
+  return matchedTerms.slice(0, 3).join(' · ');
 }
 
 function profileText(text: string): TokenProfile {

--- a/examples/web/tests/post-app.spec.ts
+++ b/examples/web/tests/post-app.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 const POST_STORAGE_KEY = 'canopy.posts.v1';
+const POST_EVENT_STORAGE_KEY = 'canopy.post-events.v1';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/posts.html');
@@ -19,6 +20,14 @@ test.describe('local-first post app', () => {
       'Remember the product wedge: post exists before retrieval.',
     ]);
     await expect(page.locator('#post-count')).toHaveText('1 post');
+
+    const events = await page.evaluate(
+      key => JSON.parse(window.localStorage.getItem(key) ?? '[]') as unknown[],
+      POST_EVENT_STORAGE_KEY,
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'post_created' })]),
+    );
 
     await page.reload();
 
@@ -119,5 +128,66 @@ test.describe('local-first post app', () => {
 
     await input.fill('');
     await expect(relatedPanel).toBeHidden();
+  });
+
+  test('boosts revisited related posts and explains why they surfaced', async ({ page }) => {
+    const olderText = 'Sync recovery policy keeps retry buffer before merge.';
+    const newerText = 'Sync recovery policy keeps retry buffer before commit.';
+
+    await page.evaluate(
+      ({ key, posts }) => window.localStorage.setItem(key, JSON.stringify(posts)),
+      {
+        key: POST_STORAGE_KEY,
+        posts: [
+          {
+            id: 'post-sync-commit',
+            text: newerText,
+            createdAt: '2026-06-10T09:00:00.000Z',
+          },
+          {
+            id: 'post-sync-merge',
+            text: olderText,
+            createdAt: '2026-06-08T09:00:00.000Z',
+          },
+        ],
+      },
+    );
+    await page.reload();
+
+    const input = page.getByLabel('Write');
+    const relatedTexts = page.locator('.related-text');
+
+    await input.fill('sync recovery policy retry buffer');
+
+    await expect(relatedTexts).toHaveText([newerText, olderText]);
+
+    await page
+      .locator('.related-item')
+      .filter({ hasText: 'merge' })
+      .getByRole('button', { name: /Open related post/ })
+      .click();
+
+    await expect(page.locator('.post-item[data-highlighted="true"] p')).toHaveText(olderText);
+    await expect(relatedTexts).toHaveText([olderText, newerText]);
+    await expect(page.locator('.related-item').first().locator('.related-reason')).toContainText([
+      'Echoes sync · recovery · policy',
+      'Revisited 1x',
+    ]);
+
+    const events = await page.evaluate(
+      key => JSON.parse(window.localStorage.getItem(key) ?? '[]') as unknown[],
+      POST_EVENT_STORAGE_KEY,
+    );
+    const relatedOpenEvent = events.find(
+      (event): event is Record<string, unknown> =>
+        typeof event === 'object' &&
+        event !== null &&
+        (event as Record<string, unknown>).type === 'related_opened',
+    );
+    expect(relatedOpenEvent).toMatchObject({
+      type: 'related_opened',
+      postId: 'post-sync-merge',
+    });
+    expect(Object.prototype.hasOwnProperty.call(relatedOpenEvent ?? {}, 'queryText')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add local post event storage for created/opened related-post events
- feed related-open counts into retrieval ranking and expose ranking reason badges
- add an Open action that highlights the surfaced timeline post without persisting draft/query text

Closes #594

## Validation
- `git diff --check`
- `cd examples/web && npx tsc --noEmit`
- `cd examples/web && npx playwright test tests/post-app.spec.ts`
- `cd examples/web && npm run build` (passes; existing large chunk warning remains)

## Reuse check
- Reused `LocalPostStore` storage pattern and existing `PostRetrievalIndex` ranking seam.
- Reused the existing related-post Playwright fixture style and localStorage setup.
- New helper boundary: `LocalPostEventStore` owns local event persistence and engagement summarization for the post prototype only.