### PR TITLE
perf(visualizer): optimize incr snapshot lookups

### DIFF
--- a/lib/visualizer/incr_tap.mbt
+++ b/lib/visualizer/incr_tap.mbt
@@ -53,21 +53,18 @@ pub struct RecomputeTap {
   // the latest per cell loses nothing while bounding memory.
   priv events : @hashmap.HashMap[@incr.CellId, RecomputeRecord]
   priv cells : Array[@incr.CellId]
+  // Mirrors `cells` for O(1)-expected dedup as events arrive. It is not
+  // drained, because `cells` is the persistent frontier for graph snapshots.
+  priv seen_cells : Set[@incr.CellId]
 }
 
 ///|
-fn contains_cell_id(ids : Array[@incr.CellId], id : @incr.CellId) -> Bool {
-  for cell_id in ids {
-    if cell_id == id {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn remember_cell(ids : Array[@incr.CellId], id : @incr.CellId) -> Unit {
-  if !contains_cell_id(ids, id) {
+fn remember_cell(
+  ids : Array[@incr.CellId],
+  seen : Set[@incr.CellId],
+  id : @incr.CellId,
+) -> Unit {
+  if seen.add_and_check(id) {
     ids.push(id)
   }
 }
@@ -112,26 +109,29 @@ fn event_from_memo_event(evt : @incr.DerivedEvent) -> RecomputeRecord {
 fn RecomputeTap::record(self : RecomputeTap, evt : @incr.DerivedEvent) -> Unit {
   guard self.active.val else { return }
   let record = event_from_memo_event(evt)
-  remember_cell(self.cells, record.cell_id)
+  remember_cell(self.cells, self.seen_cells, record.cell_id)
   self.events.set(record.cell_id, record)
 }
 
 ///|
-fn snapshot_ids(tap : RecomputeTap) -> Array[@incr.CellId] {
+fn RecomputeTap::snapshot_ids(self : RecomputeTap) -> Array[@incr.CellId] {
   let ids : Array[@incr.CellId] = []
-  for id in tap.cells {
-    remember_cell(ids, id)
+  let seen : Set[@incr.CellId] = Set([])
+  for id in self.cells {
+    remember_cell(ids, seen, id)
   }
+  // Queue-style traversal is intentional: the frontier grows as dependencies
+  // and subscribers are discovered from `Runtime::cell_info`.
   let mut i = 0
   while i < ids.length() {
     let id = ids[i]
-    match tap.rt.cell_info(id) {
+    match self.rt.cell_info(id) {
       Some(info) => {
         for dep in info.dependencies {
-          remember_cell(ids, dep)
+          remember_cell(ids, seen, dep)
         }
         for sub in info.subscribers {
-          remember_cell(ids, sub)
+          remember_cell(ids, seen, sub)
         }
       }
       None => ()
@@ -186,24 +186,6 @@ fn snapshot_node_detail(
 }
 
 ///|
-/// Most recent event retained for `id`, if any.
-///
-/// The tap retains at most one record per cell (keep-last-per-cell), so this
-/// single scan returns that cell's only record — both its status and its
-/// latest `elapsed_ns` come from the one lookup.
-fn event_for_cell(
-  events : Array[RecomputeRecord],
-  id : @incr.CellId,
-) -> RecomputeRecord? {
-  for event in events {
-    if event.cell_id == id {
-      return Some(event)
-    }
-  }
-  None
-}
-
-///|
 fn record_status(record : RecomputeRecord?) -> VisualNodeStatus {
   match record {
     Some(event) =>
@@ -227,7 +209,13 @@ fn record_status(record : RecomputeRecord?) -> VisualNodeStatus {
 /// `incr` allows one memo-event listener per runtime, so attaching replaces
 /// any previous listener owned by the same runtime.
 pub fn RecomputeTap::attach(rt : @incr.Runtime) -> RecomputeTap raise Failure {
-  let tap = { rt, active: Ref(true), events: @hashmap.HashMap([]), cells: [] }
+  let tap = {
+    rt,
+    active: Ref(true),
+    events: @hashmap.HashMap([]),
+    cells: [],
+    seen_cells: Set([]),
+  }
   rt.on_derived_event(evt => tap.record(evt))
   tap
 }
@@ -257,7 +245,7 @@ pub fn RecomputeTap::drain_events(
 ///|
 /// Capture the current known dependency graph plus buffered event history.
 pub fn RecomputeTap::snapshot(self : RecomputeTap) -> RecomputeSnapshot {
-  let ids = snapshot_ids(self)
+  let ids = self.snapshot_ids()
   let nodes : Array[RecomputeSnapshotNode] = []
   let edges : Array[RecomputeSnapshotEdge] = []
   for id in ids {
@@ -280,13 +268,28 @@ pub fn RecomputeTap::snapshot(self : RecomputeTap) -> RecomputeSnapshot {
 }
 
 ///|
+fn RecomputeSnapshot::events_by_cell(
+  self : RecomputeSnapshot,
+) -> @hashmap.HashMap[@incr.CellId, RecomputeRecord] {
+  let events_by_cell : @hashmap.HashMap[@incr.CellId, RecomputeRecord] = @hashmap.HashMap(
+    [],
+    capacity=self.events.length(),
+  )
+  for event in self.events {
+    events_by_cell.set(event.cell_id, event)
+  }
+  events_by_cell
+}
+
+///|
 /// Convert an `incr` runtime snapshot to the renderer-neutral visual graph.
 pub fn RecomputeSnapshot::to_visual_graph(
   self : RecomputeSnapshot,
 ) -> VisualGraph {
   let graph = VisualGraph(id="incr")
+  let events_by_cell = self.events_by_cell()
   for node in self.nodes {
-    let record = event_for_cell(self.events, node.id)
+    let record = events_by_cell.get(node.id)
     let elapsed_ns = match record {
       Some(event) => event.elapsed_ns
       None => None

--- a/lib/visualizer/incr_tap_benchmark.mbt
+++ b/lib/visualizer/incr_tap_benchmark.mbt
@@ -1,0 +1,67 @@
+// Incr tap benchmarks — run with: moon bench --release
+
+///|
+const SMALL_BENCH_CELL_COUNT = 256
+
+///|
+const LARGE_BENCH_CELL_COUNT = 2048
+
+///|
+fn make_bench_fanout(
+  count : Int,
+) -> (Array[@incr.Derived[Int]], RecomputeTap) raise Failure {
+  guard count > 0 else {
+    abort("benchmark fanout must contain at least one cell")
+  }
+  let rt = @incr.Runtime()
+  let input = @incr.Signal(rt, 0, label="bench_input")
+  let memos : Array[@incr.Derived[Int]] = []
+  for i in 0..<count {
+    memos.push(
+      @incr.Derived(
+        rt,
+        () => input.get() + i,
+        label="bench_memo_" + i.to_string(),
+      ),
+    )
+  }
+  let tap = RecomputeTap::attach(rt)
+  for memo in memos {
+    ignore(memo.read_or_abort())
+  }
+  (memos, tap)
+}
+
+///|
+fn make_bench_snapshot(count : Int) -> RecomputeSnapshot raise Failure {
+  let (memos, tap) = make_bench_fanout(count)
+  // Keep the derived handles live while the snapshot discovers the graph.
+  ignore(memos.length())
+  tap.snapshot()
+}
+
+///|
+test "bench/incr_tap/snapshot_fanout_256" (b : @bench.T) {
+  let (memos, tap) = make_bench_fanout(SMALL_BENCH_CELL_COUNT)
+  b.keep(memos.length())
+  b.bench(fn() { b.keep(tap.snapshot()) })
+}
+
+///|
+test "bench/incr_tap/snapshot_fanout_2048" (b : @bench.T) {
+  let (memos, tap) = make_bench_fanout(LARGE_BENCH_CELL_COUNT)
+  b.keep(memos.length())
+  b.bench(fn() { b.keep(tap.snapshot()) })
+}
+
+///|
+test "bench/incr_tap/to_visual_graph_fanout_256" (b : @bench.T) {
+  let snapshot = make_bench_snapshot(SMALL_BENCH_CELL_COUNT)
+  b.bench(fn() { b.keep(snapshot.to_visual_graph()) })
+}
+
+///|
+test "bench/incr_tap/to_visual_graph_fanout_2048" (b : @bench.T) {
+  let snapshot = make_bench_snapshot(LARGE_BENCH_CELL_COUNT)
+  b.bench(fn() { b.keep(snapshot.to_visual_graph()) })
+}

--- a/lib/visualizer/moon.pkg
+++ b/lib/visualizer/moon.pkg
@@ -4,4 +4,5 @@ import {
   "dowdiness/graphviz/lib/svg" @graph_svg,
   "dowdiness/incr",
   "moonbitlang/core/hashmap",
+  "moonbitlang/core/bench",
 }


### PR DESCRIPTION
## Summary

Fixes #457.

- add benchmark-gated coverage for `RecomputeTap::snapshot()` and snapshot→visual graph conversion on a large fan-out incr graph
- replace linear cell dedup scans with `Set::add_and_check`
- pre-index snapshot events with `HashMap[CellId, RecomputeRecord]` before per-node status/timing lookup
- keep the visualizer public API unchanged (`pkg.generated.mbti` has no diff)

## Benchmark gate

Baseline before the optimization:

- `bench/incr_tap/snapshot_fanout_2048`: ~8.10ms
- `bench/incr_tap/to_visual_graph_fanout_2048`: ~3.47ms

Current rebased result:

- `bench/incr_tap/snapshot_fanout_2048`: ~581.69µs
- `bench/incr_tap/to_visual_graph_fanout_2048`: ~1.07ms

## Reuse check

- Reused `Set::add_and_check` for O(1)-expected frontier dedup.
- Reused `HashMap::set/get` for event lookup by cell id.
- Reused public `@incr.Signal`, `@incr.Derived`, and `read_or_abort()` APIs in the benchmark setup.
- Checked `HashSet`; kept prelude `Set` for the visualizer implementation.
- New helpers are private and limited to snapshot frontier/event-index construction.
- Remaining imperative code is for mutable builders and queue-style graph expansion.

## Validation

- `NEW_MOON_MOD=0 moon check`
- `moon test --package dowdiness/visualizer`
- `moon bench --release --package dowdiness/visualizer --file incr_tap_benchmark.mbt`
- `NEW_MOON_MOD=0 moon test`
- `NEW_MOON_MOD=0 moon build --target js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized visualization rendering efficiency in the incremental computation visualizer.

* **Tests**
  * Added benchmark tests for snapshot and visual graph generation at various scales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->