### PR TITLE
feat(codex): prototype Codex unified-diff → UserIntent::TextEdit lowering

### DIFF
--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -17,8 +17,10 @@
 // line-based and its content lines reach MoonBit already decoded to `String`
 // (UTF-16), there is no explicit UTF-8 byte -> UTF-16 conversion step — the
 // decode at the transport boundary absorbs it. The risk that survives is
-// grapheme-splitting by a too-fine minimal diff, which is why the splice is
-// computed at GRAPHEME granularity and driven through `apply_text_edit_exact`.
+// grapheme-splitting by a too-fine minimal diff, which is why the sub-line
+// splice delegates to the shared GRAPHEME-granular leaf
+// (@text_change.compute_text_change) and is driven through
+// `apply_text_edit_exact`.
 
 ///|
 /// Lower a unified-diff `update` payload into TextEdit intents against `doc`.
@@ -46,9 +48,20 @@ pub fn unified_diff_to_intents(
       "codex lowering: stale diff — document line \{edit_line} does not match the patch old text",
     )
   }
-  let (from_in_line, del, insert) = minimal_splice(old_text, new_text)
-  let from = line_start + from_in_line
-  [@protocol.UserIntent::TextEdit(from~, to=from + del, insert~)]
+  // Sub-line splice reuses the repository's shared, grapheme-aligned diff leaf
+  // (@text_change.compute_text_change — the same helper SyncEditor::set_text
+  // drives through), so future fixes to the centralized text-change logic reach
+  // Codex lowering too. Its endpoints land on grapheme-cluster boundaries by
+  // construction, which is what `apply_text_edit_exact` then re-checks.
+  let change = @text_change.compute_text_change(old_text, new_text)
+  let from = line_start + change.start
+  [
+    @protocol.UserIntent::TextEdit(
+      from~,
+      to=from + change.delete_len,
+      insert=change.inserted,
+    ),
+  ]
 }
 
 ///|
@@ -64,45 +77,6 @@ pub fn[T : Eq] apply_intent_exact(
     fail("codex lowering prototype: only TextEdit is supported")
   }
   se.apply_text_edit_exact(from, to - from, insert, timestamp_ms)
-}
-
-///|
-/// Minimal sub-line splice between `old` and `new` as a `(from, del, insert)`
-/// triple in UTF-16 code units, with endpoints aligned to GRAPHEME-cluster
-/// boundaries by construction.
-///
-/// Common prefix and suffix are matched a whole cluster at a time, so the
-/// returned `from`/`from + del` never split a surrogate pair or a combining
-/// sequence. This resolves the research note's §5 chain (sub-line minimal ->
-/// mid-grapheme possible -> grapheme alignment required) at the diff step,
-/// leaving `apply_text_edit_exact` as a pure seatbelt rather than a routine
-/// rejecter of legitimate edits.
-fn minimal_splice(old : String, new : String) -> (Int, Int, String) {
-  let ob = @moji.grapheme_boundaries(old)
-  let nb = @moji.grapheme_boundaries(new)
-  let onc = ob.length() - 1 // number of grapheme clusters in `old`
-  let nnc = nb.length() - 1
-  let bound = onc.min(nnc)
-  // longest common grapheme prefix, then suffix (suffix cannot overlap prefix:
-  // it scans the remaining `bound - p` clusters), so `from <= to` always holds.
-  let p = for k in 0..<bound {
-    if old[ob[k]:ob[k + 1]] != new[nb[k]:nb[k + 1]] {
-      break k
-    }
-  } nobreak {
-    bound
-  }
-  let s = for k in 0..<(bound - p) {
-    if old[ob[onc - 1 - k]:ob[onc - k]] != new[nb[nnc - 1 - k]:nb[nnc - k]] {
-      break k
-    }
-  } nobreak {
-    bound - p
-  }
-  let from = ob[p]
-  let to = ob[onc - s]
-  let insert = new[nb[p]:nb[nnc - s]].to_owned()
-  (from, to - from, insert)
 }
 
 ///|

--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -1,0 +1,157 @@
+// Codex app-server edit lowering (prototype).
+//
+// Lowers a Codex `FileChange.update` unified diff into `@protocol.UserIntent`
+// TextEdit operations and drives them into a `SyncEditor` under the EXACT
+// (grapheme-boundary-checked) policy. Background and verification record:
+// docs/research/2026-06-13-canopy-codex-app-server-lowering.md.
+//
+// Prototype scope (§8 of the research note is OUT of scope): exactly one
+// changed line (one `-` line + one `+` line) inside a single `update` hunk.
+// Multi-hunk diffs, `add`/`delete` whole-document variants, `move_path`, and
+// concurrent-edit fuzzy hunk apply are deliberately unsupported here.
+//
+// Design note (refines the research note's framing): because a unified diff is
+// line-based and its content lines reach MoonBit already decoded to `String`
+// (UTF-16), there is no explicit UTF-8 byte -> UTF-16 conversion step — the
+// decode at the transport boundary absorbs it. The risk that survives is
+// grapheme-splitting by a too-fine minimal diff, which is why the splice is
+// computed at GRAPHEME granularity and driven through `apply_text_edit_exact`.
+
+///|
+/// Lower a unified-diff `update` payload into TextEdit intents against `doc`.
+///
+/// `doc` is the current document text (UTF-16); `diff` is the unified-diff
+/// string from `FileChange.update.unified_diff`. Returns one TextEdit per
+/// changed line (prototype: exactly one).
+pub fn unified_diff_to_intents(
+  doc : String,
+  diff : String,
+) -> Array[@protocol.UserIntent] raise {
+  let (line_1based, old_line, new_line) = parse_single_line_update(diff)
+  let line_start = line_start_offset(doc, line_1based)
+  let (from_in_line, del, insert) = minimal_splice(old_line, new_line)
+  let from = line_start + from_in_line
+  [@protocol.UserIntent::TextEdit(from~, to=from + del, insert~)]
+}
+
+///|
+/// Drive a single lowered intent into the editor under EXACT-boundary policy.
+/// Returns `false` (document unchanged) if the splice endpoints are not
+/// grapheme boundaries or are out of range — the load-bearing seatbelt.
+pub fn[T : Eq] apply_intent_exact(
+  se : @editor.SyncEditor[T],
+  intent : @protocol.UserIntent,
+  timestamp_ms : Int,
+) -> Bool raise {
+  guard intent is @protocol.UserIntent::TextEdit(from~, to~, insert~) else {
+    fail("codex lowering prototype: only TextEdit is supported")
+  }
+  se.apply_text_edit_exact(from, to - from, insert, timestamp_ms)
+}
+
+///|
+/// Minimal sub-line splice between `old` and `new` as a `(from, del, insert)`
+/// triple in UTF-16 code units, with endpoints aligned to GRAPHEME-cluster
+/// boundaries by construction.
+///
+/// Common prefix and suffix are matched a whole cluster at a time, so the
+/// returned `from`/`from + del` never split a surrogate pair or a combining
+/// sequence. This resolves the research note's §5 chain (sub-line minimal ->
+/// mid-grapheme possible -> grapheme alignment required) at the diff step,
+/// leaving `apply_text_edit_exact` as a pure seatbelt rather than a routine
+/// rejecter of legitimate edits.
+fn minimal_splice(old : String, new : String) -> (Int, Int, String) {
+  let ob = @moji.grapheme_boundaries(old)
+  let nb = @moji.grapheme_boundaries(new)
+  let onc = ob.length() - 1 // number of grapheme clusters in `old`
+  let nnc = nb.length() - 1
+  let bound = if onc < nnc { onc } else { nnc }
+  // longest common grapheme prefix, then suffix (suffix cannot overlap prefix:
+  // it scans the remaining `bound - p` clusters), so `from <= to` always holds.
+  let p = for k in 0..<bound {
+    if old[ob[k]:ob[k + 1]] != new[nb[k]:nb[k + 1]] {
+      break k
+    }
+  } nobreak {
+    bound
+  }
+  let s = for k in 0..<(bound - p) {
+    if old[ob[onc - 1 - k]:ob[onc - k]] != new[nb[nnc - 1 - k]:nb[nnc - k]] {
+      break k
+    }
+  } nobreak {
+    bound - p
+  }
+  let from = ob[p]
+  let to = ob[onc - s]
+  let insert = new[nb[p]:nb[nnc - s]].to_owned()
+  (from, to - from, insert)
+}
+
+///|
+/// UTF-16 offset of the start of the given 1-based line in `doc`.
+fn line_start_offset(doc : String, line_1based : Int) -> Int {
+  if line_1based <= 1 {
+    return 0
+  }
+  let mut count = 1
+  for i in 0..<doc.length() {
+    if doc[i] is '\n' {
+      count += 1
+      if count == line_1based {
+        return i + 1
+      }
+    }
+  }
+  doc.length()
+}
+
+///|
+/// Parse a single-changed-line `update` hunk: returns the 1-based old start
+/// line plus the old and new line contents (marker stripped).
+fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
+  let mut line_no : Int? = None
+  let mut old_line : String? = None
+  let mut new_line : String? = None
+  // Gate on hunk state: `---`/`+++` file headers (and any `diff`/`index`
+  // preamble) appear ONLY before the first `@@`. After it, branch on the
+  // single marker char so content lines that themselves begin with `-`/`+`
+  // (e.g. a Markdown frontmatter `---`, raw diff line `----`) are not mistaken
+  // for file headers.
+  let mut in_hunk = false
+  for line in diff.split("\n") {
+    if line.has_prefix("@@") {
+      line_no = Some(parse_hunk_old_start(line.to_owned()))
+      in_hunk = true
+    } else if in_hunk {
+      if line.has_prefix("-") {
+        old_line = Some(line[1:].to_owned())
+      } else if line.has_prefix("+") {
+        new_line = Some(line[1:].to_owned())
+      }
+      // context (' ' prefix) and other lines are ignored in this single-line
+      // prototype
+    }
+    // lines before the first `@@` are file headers / preamble — ignored
+  }
+  guard line_no is Some(ln) else { fail("codex lowering: no hunk header") }
+  guard old_line is Some(o) else { fail("codex lowering: no '-' line") }
+  guard new_line is Some(n) else { fail("codex lowering: no '+' line") }
+  (ln, o, n)
+}
+
+///|
+/// Extract the old start line `A` from a hunk header `@@ -A[,B] +C[,D] @@`.
+fn parse_hunk_old_start(header : String) -> Int raise {
+  for tok in header.split(" ") {
+    if tok.has_prefix("-") {
+      let body = tok[1:]
+      let num = match body.split(",").next() {
+        Some(v) => v.to_owned()
+        None => body.to_owned()
+      }
+      return @string.parse_int(num)
+    }
+  }
+  fail("codex lowering: malformed hunk header")
+}

--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -65,7 +65,7 @@ fn minimal_splice(old : String, new : String) -> (Int, Int, String) {
   let nb = @moji.grapheme_boundaries(new)
   let onc = ob.length() - 1 // number of grapheme clusters in `old`
   let nnc = nb.length() - 1
-  let bound = if onc < nnc { onc } else { nnc }
+  let bound = onc.min(nnc)
   // longest common grapheme prefix, then suffix (suffix cannot overlap prefix:
   // it scans the remaining `bound - p` clusters), so `from <= to` always holds.
   let p = for k in 0..<bound {
@@ -146,10 +146,11 @@ fn parse_hunk_old_start(header : String) -> Int raise {
   guard header.split(" ").find_first(tok => tok.has_prefix("-")) is Some(tok) else {
     fail("codex lowering: malformed hunk header")
   }
-  let body = tok[1:]
-  let num = match body.split(",").next() {
-    Some(v) => v.to_owned()
-    None => body.to_owned()
+  // `@@ -A[,B]` — take the field before the optional comma. `split` always
+  // yields at least one element, so a `None` here means an empty old-start
+  // (a malformed header); fail explicitly rather than silently reusing it.
+  guard tok[1:].split(",").next() is Some(start_field) else {
+    fail("codex lowering: empty hunk old-start field")
   }
-  @string.parse_int(num)
+  @string.parse_int(start_field.to_owned())
 }

--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -94,22 +94,26 @@ fn line_start_offset(doc : String, line_1based : Int) -> Int {
   if line_1based <= 1 {
     return 0
   }
-  let mut count = 1
-  for i in 0..<doc.length() {
+  for i in 0..<doc.length(); line = 1 {
     if doc[i] is '\n' {
-      count += 1
-      if count == line_1based {
-        return i + 1
+      if line + 1 == line_1based {
+        break i + 1
       }
+      continue line + 1
     }
+    continue line
+  } nobreak {
+    doc.length()
   }
-  doc.length()
 }
 
 ///|
 /// Parse a single-changed-line `update` hunk: returns the 1-based old start
 /// line plus the old and new line contents (marker stripped).
 fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
+  // `for .. in` + `mut` is allowed here as a genuine parser STATE MACHINE: the
+  // `in_hunk` flag gates how each line is interpreted, and the three result
+  // slots accumulate across that state — not a simple accumulator.
   let mut line_no : Int? = None
   let mut old_line : String? = None
   let mut new_line : String? = None

--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -6,9 +6,12 @@
 // docs/research/2026-06-13-canopy-codex-app-server-lowering.md.
 //
 // Prototype scope (§8 of the research note is OUT of scope): exactly one
-// changed line (one `-` line + one `+` line) inside a single `update` hunk.
-// Multi-hunk diffs, `add`/`delete` whole-document variants, `move_path`, and
-// concurrent-edit fuzzy hunk apply are deliberately unsupported here.
+// changed line (one `-` line + one `+` line) inside a single `update` hunk,
+// applied only when the document line still matches the patch's old text.
+// Multi-hunk diffs, multi-line hunks, `add`/`delete` whole-document variants,
+// `move_path`, `\ No newline at end of file` semantics, and concurrent /
+// stale apply are REJECTED with a clear error here — never silently
+// mishandled, which would corrupt unrelated text.
 //
 // Design note (refines the research note's framing): because a unified diff is
 // line-based and its content lines reach MoonBit already decoded to `String`
@@ -27,9 +30,19 @@ pub fn unified_diff_to_intents(
   doc : String,
   diff : String,
 ) -> Array[@protocol.UserIntent] raise {
-  let (line_1based, old_line, new_line) = parse_single_line_update(diff)
-  let line_start = line_start_offset(doc, line_1based)
-  let (from_in_line, del, insert) = minimal_splice(old_line, new_line)
+  let (edit_line, old_text, new_text) = parse_single_line_update(diff)
+  let line_start = line_start_offset(doc, edit_line)
+  let line_end = line_end_offset(doc, line_start)
+  // Stale-diff guard: this prototype does no fuzzy/concurrent apply, so the
+  // targeted document line MUST currently equal the patch's old text. Without
+  // it, a stale hunk would splice grapheme-aligned offsets into unrelated
+  // content and `apply_text_edit_exact` would accept the corruption.
+  guard doc[line_start:line_end] == old_text[:] else {
+    fail(
+      "codex lowering: stale diff — document line \{edit_line} does not match the patch old text",
+    )
+  }
+  let (from_in_line, del, insert) = minimal_splice(old_text, new_text)
   let from = line_start + from_in_line
   [@protocol.UserIntent::TextEdit(from~, to=from + del, insert~)]
 }
@@ -108,40 +121,72 @@ fn line_start_offset(doc : String, line_1based : Int) -> Int {
 }
 
 ///|
-/// Parse a single-changed-line `update` hunk: returns the 1-based old start
-/// line plus the old and new line contents (marker stripped).
+/// UTF-16 offset of the end of the line that starts at `start` — the next
+/// `\n`, or the end of the document.
+fn line_end_offset(doc : String, start : Int) -> Int {
+  for i in start..<doc.length() {
+    if doc[i] is '\n' {
+      break i
+    }
+  } nobreak {
+    doc.length()
+  }
+}
+
+///|
+/// Parse a single-changed-line `update` hunk. Returns `(old_line_number,
+/// old_text, new_text)` where `old_line_number` is the 1-based old-side line
+/// of the `-` line (NOT the hunk's first line — a hunk may carry leading
+/// context). Rejects anything outside the prototype's scope.
+///
+/// `for .. in` + `mut` is allowed here as a genuine parser STATE MACHINE:
+/// `cur_old` (Some once the `@@` header is seen) tracks the old-side line
+/// number, and the slots accumulate across that state. Per the unified-diff
+/// model, context (` `) and deleted (`-`) lines advance the old side; added
+/// (`+`) lines do not. Out-of-scope inputs — more than one hunk, more than one
+/// changed pair, or a `\ No newline at end of file` marker — fail rather than
+/// being silently dropped or mis-applied.
 fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
-  // `for .. in` + `mut` is allowed here as a genuine parser STATE MACHINE: the
-  // `in_hunk` flag gates how each line is interpreted, and the three result
-  // slots accumulate across that state — not a simple accumulator.
-  let mut line_no : Int? = None
-  let mut old_line : String? = None
-  let mut new_line : String? = None
-  // Gate on hunk state: `---`/`+++` file headers (and any `diff`/`index`
-  // preamble) appear ONLY before the first `@@`. After it, branch on the
-  // single marker char so content lines that themselves begin with `-`/`+`
-  // (e.g. a Markdown frontmatter `---`, raw diff line `----`) are not mistaken
-  // for file headers.
-  let mut in_hunk = false
+  let mut cur_old : Int? = None // None until the first `@@`; else next old line
+  let mut hunks = 0
+  let mut old_at : (Int, String)? = None // (old line number, content) of `-`
+  let mut old_count = 0
+  let mut new_text : String? = None
+  let mut new_count = 0
   for line in diff.split("\n") {
     if line.has_prefix("@@") {
-      line_no = Some(parse_hunk_old_start(line.to_owned()))
-      in_hunk = true
-    } else if in_hunk {
+      hunks += 1
+      cur_old = Some(parse_hunk_old_start(line.to_owned()))
+    } else if line.has_prefix("\\") {
+      // `\ No newline at end of file`: trailing-newline semantics unsupported.
+      fail("codex lowering: EOF-newline marker unsupported (out of scope)")
+    } else if cur_old is Some(n) {
       if line.has_prefix("-") {
-        old_line = Some(line[1:].to_owned())
+        old_at = Some((n, line[1:].to_owned()))
+        old_count += 1
+        cur_old = Some(n + 1)
       } else if line.has_prefix("+") {
-        new_line = Some(line[1:].to_owned())
+        new_text = Some(line[1:].to_owned())
+        new_count += 1
+      } else if line.has_prefix(" ") {
+        cur_old = Some(n + 1) // context line advances the old side
       }
-      // context (' ' prefix) and other lines are ignored in this single-line
-      // prototype
     }
     // lines before the first `@@` are file headers / preamble — ignored
   }
-  guard line_no is Some(ln) else { fail("codex lowering: no hunk header") }
-  guard old_line is Some(o) else { fail("codex lowering: no '-' line") }
-  guard new_line is Some(n) else { fail("codex lowering: no '+' line") }
-  (ln, o, n)
+  guard hunks <= 1 else {
+    fail("codex lowering: multi-hunk update unsupported (out of scope)")
+  }
+  guard old_count <= 1 && new_count <= 1 else {
+    fail("codex lowering: multi-line update unsupported (out of scope)")
+  }
+  guard old_at is Some((edit_line, old_text)) else {
+    fail("codex lowering: no hunk `-` line")
+  }
+  guard new_text is Some(new_text) else {
+    fail("codex lowering: no hunk `+` line")
+  }
+  (edit_line, old_text, new_text)
 }
 
 ///|

--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -31,7 +31,11 @@ pub fn unified_diff_to_intents(
   diff : String,
 ) -> Array[@protocol.UserIntent] raise {
   let (edit_line, old_text, new_text) = parse_single_line_update(diff)
-  let line_start = line_start_offset(doc, edit_line)
+  // Absent-line guard: a missing target line must NOT collapse to EOF and then
+  // match an empty `old_text` — that would apply the edit as an EOF insertion.
+  guard line_start_offset(doc, edit_line) is Some(line_start) else {
+    fail("codex lowering: target line \{edit_line} is absent from the document")
+  }
   let line_end = line_end_offset(doc, line_start)
   // Stale-diff guard: this prototype does no fuzzy/concurrent apply, so the
   // targeted document line MUST currently equal the patch's old text. Without
@@ -102,21 +106,24 @@ fn minimal_splice(old : String, new : String) -> (Int, Int, String) {
 }
 
 ///|
-/// UTF-16 offset of the start of the given 1-based line in `doc`.
-fn line_start_offset(doc : String, line_1based : Int) -> Int {
+/// UTF-16 offset of the start of the given 1-based line in `doc`, or `None` if
+/// the document has fewer than `line_1based` lines. The absent case must stay
+/// distinct from an empty line that genuinely exists at EOF — otherwise a
+/// missing target line collapses to EOF and a `""` old-text check passes.
+fn line_start_offset(doc : String, line_1based : Int) -> Int? {
   if line_1based <= 1 {
-    return 0
+    return Some(0)
   }
   for i in 0..<doc.length(); line = 1 {
     if doc[i] is '\n' {
       if line + 1 == line_1based {
-        break i + 1
+        break Some(i + 1)
       }
       continue line + 1
     }
     continue line
   } nobreak {
-    doc.length()
+    None
   }
 }
 
@@ -153,6 +160,11 @@ fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
   let mut old_count = 0
   let mut new_text : String? = None
   let mut new_count = 0
+  // A genuine single-line REPLACE emits `+new` immediately after `-old`. A `-`
+  // and `+` separated by context is a delete + insert at different positions
+  // (move-shaped) — out of scope — so track whether the `+` is adjacent.
+  let mut prev_was_minus = false
+  let mut plus_follows_minus = false
   for line in diff.split("\n") {
     if line.has_prefix("@@") {
       hunks += 1
@@ -168,9 +180,11 @@ fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
       } else if line.has_prefix("+") {
         new_text = Some(line[1:].to_owned())
         new_count += 1
+        plus_follows_minus = prev_was_minus
       } else if line.has_prefix(" ") {
         cur_old = Some(n + 1) // context line advances the old side
       }
+      prev_was_minus = line.has_prefix("-")
     }
     // lines before the first `@@` are file headers / preamble — ignored
   }
@@ -180,13 +194,18 @@ fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
   guard old_count <= 1 && new_count <= 1 else {
     fail("codex lowering: multi-line update unsupported (out of scope)")
   }
-  guard old_at is Some((edit_line, old_text)) else {
+  guard old_at is Some((edit_line, old_body)) else {
     fail("codex lowering: no hunk `-` line")
   }
-  guard new_text is Some(new_text) else {
+  guard new_text is Some(new_body) else {
     fail("codex lowering: no hunk `+` line")
   }
-  (edit_line, old_text, new_text)
+  guard plus_follows_minus else {
+    fail(
+      "codex lowering: separated delete/insert update unsupported (out of scope)",
+    )
+  }
+  (edit_line, old_body, new_body)
 }
 
 ///|

--- a/codex/lowering.mbt
+++ b/codex/lowering.mbt
@@ -143,15 +143,13 @@ fn parse_single_line_update(diff : String) -> (Int, String, String) raise {
 ///|
 /// Extract the old start line `A` from a hunk header `@@ -A[,B] +C[,D] @@`.
 fn parse_hunk_old_start(header : String) -> Int raise {
-  for tok in header.split(" ") {
-    if tok.has_prefix("-") {
-      let body = tok[1:]
-      let num = match body.split(",").next() {
-        Some(v) => v.to_owned()
-        None => body.to_owned()
-      }
-      return @string.parse_int(num)
-    }
+  guard header.split(" ").find_first(tok => tok.has_prefix("-")) is Some(tok) else {
+    fail("codex lowering: malformed hunk header")
   }
-  fail("codex lowering: malformed hunk header")
+  let body = tok[1:]
+  let num = match body.split(",").next() {
+    Some(v) => v.to_owned()
+    None => body.to_owned()
+  }
+  @string.parse_int(num)
 }

--- a/codex/lowering_test.mbt
+++ b/codex/lowering_test.mbt
@@ -22,12 +22,11 @@ test "codex lowering: update diff deletes first of two adjacent emoji" {
     #|-🧑🧒
     #|+🧒
   let intents = unified_diff_to_intents(se.get_text(), diff)
-  let mut all_accepted = true
-  for intent in intents {
-    if !apply_intent_exact(se, intent, 1) {
-      all_accepted = false
-    }
-  }
+  // Apply every lowered intent; the document is correct only if all are
+  // accepted by EXACT. `apply...` is the left operand so it always runs.
+  let all_accepted = intents.fold(init=true, (ok, intent) => {
+    apply_intent_exact(se, intent, 1) && ok
+  })
   assert_true(all_accepted)
   assert_eq(se.get_text(), "🧒")
 }
@@ -46,12 +45,11 @@ test "codex lowering: content line starting with dashes is not a file header" {
     #|----
     #|+***
   let intents = unified_diff_to_intents(se.get_text(), diff)
-  let mut all_accepted = true
-  for intent in intents {
-    if !apply_intent_exact(se, intent, 1) {
-      all_accepted = false
-    }
-  }
+  // Apply every lowered intent; the document is correct only if all are
+  // accepted by EXACT. `apply...` is the left operand so it always runs.
+  let all_accepted = intents.fold(init=true, (ok, intent) => {
+    apply_intent_exact(se, intent, 1) && ok
+  })
   assert_true(all_accepted)
   assert_eq(se.get_text(), "***")
 }

--- a/codex/lowering_test.mbt
+++ b/codex/lowering_test.mbt
@@ -142,3 +142,44 @@ test "codex lowering: EOF-newline marker is rejected" {
   }
   assert_true(raised)
 }
+
+///|
+/// P1 (separated delete/insert): a single `-`/`+` separated by context is a
+/// delete + insert at different positions (move-shaped), not a replace.
+/// `a\nb\nc` with `-a` … `+x` means "drop line 1, append x" — pairing them as
+/// a replace would corrupt line 1 (`x\nb\nc`). It must be rejected.
+test "codex lowering: separated delete/insert is rejected" {
+  let diff =
+    #|@@ -1,3 +1,3 @@
+    #|-a
+    #| b
+    #| c
+    #|+x
+  let raised = try {
+    let _ = unified_diff_to_intents("a\nb\nc", diff)
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(raised)
+}
+
+///|
+/// P2 (absent target line): a hunk whose target line does not exist in the
+/// current document must fail, not collapse to EOF and match an empty
+/// `old_text`. Here the patch edits line 2 (empty -> `bar`) but the document
+/// `foo` has only line 1, so applying it would insert at EOF (`foobar`).
+test "codex lowering: edit targeting an absent line is rejected" {
+  let diff =
+    #|@@ -1,2 +1,2 @@
+    #| foo
+    #|-
+    #|+bar
+  let raised = try {
+    let _ = unified_diff_to_intents("foo", diff)
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(raised)
+}

--- a/codex/lowering_test.mbt
+++ b/codex/lowering_test.mbt
@@ -1,0 +1,69 @@
+// Prototype tests for Codex unified-diff -> UserIntent::TextEdit lowering.
+//
+// Vector rationale (non-vacuity): the two emoji U+1F9D1 (🧑) and U+1F9D2 (🧒)
+// share the same UTF-16 high surrogate (D83E) and differ only in the low
+// surrogate (DFD1 vs DFD2). A code-unit-granular minimal diff therefore stops
+// its common prefix AFTER the shared high surrogate, yielding a mid-surrogate
+// offset that `apply_text_edit_exact` rejects (or that lands wrong) — so the
+// full-text-match assertion FAILS for a broken converter and passes only for a
+// grapheme-granular one. See
+// docs/research/2026-06-13-canopy-codex-app-server-lowering.md §4-§6.
+
+///|
+/// Accept path + full-text-match. Deletes the first of two adjacent emoji via
+/// a single-line `update` diff. Only a grapheme-correct converter both is
+/// accepted by EXACT and reproduces the intended document.
+test "codex lowering: update diff deletes first of two adjacent emoji" {
+  let se = @probe.new_test_editor("codex-agent")
+  se.apply_text_edit(0, 0, "🧑🧒", 0)
+  assert_eq(se.get_text(), "🧑🧒")
+  let diff =
+    #|@@ -1 +1 @@
+    #|-🧑🧒
+    #|+🧒
+  let intents = unified_diff_to_intents(se.get_text(), diff)
+  let mut all_accepted = true
+  for intent in intents {
+    if !apply_intent_exact(se, intent, 1) {
+      all_accepted = false
+    }
+  }
+  assert_true(all_accepted)
+  assert_eq(se.get_text(), "🧒")
+}
+
+///|
+/// Regression (Codex pre-PR review): a content line that itself begins with
+/// `-` must not be mistaken for a `---` file header. Document line `---`
+/// (Markdown frontmatter delimiter) appears in the diff as the raw line
+/// `----`; the old "skip any `---` prefix" parser dropped it. With hunk-state
+/// gating the marker is stripped to content `---`, replaced by `***`.
+test "codex lowering: content line starting with dashes is not a file header" {
+  let se = @probe.new_test_editor("codex-agent")
+  se.apply_text_edit(0, 0, "---", 0)
+  let diff =
+    #|@@ -1 +1 @@
+    #|----
+    #|+***
+  let intents = unified_diff_to_intents(se.get_text(), diff)
+  let mut all_accepted = true
+  for intent in intents {
+    if !apply_intent_exact(se, intent, 1) {
+      all_accepted = false
+    }
+  }
+  assert_true(all_accepted)
+  assert_eq(se.get_text(), "***")
+}
+
+///|
+/// Seatbelt: EXACT must reject a hand-fed mid-grapheme offset, leaving the
+/// document unchanged — proving the guard is load-bearing independent of the
+/// converter. Offset 1 is the low surrogate of the first emoji.
+test "codex lowering: EXACT rejects a hand-fed mid-grapheme offset" {
+  let se = @probe.new_test_editor("codex-agent")
+  se.apply_text_edit(0, 0, "🧑🧒", 0)
+  let accepted = se.apply_text_edit_exact(1, 2, "", 1)
+  assert_false(accepted)
+  assert_eq(se.get_text(), "🧑🧒")
+}

--- a/codex/lowering_test.mbt
+++ b/codex/lowering_test.mbt
@@ -65,3 +65,80 @@ test "codex lowering: EXACT rejects a hand-fed mid-grapheme offset" {
   assert_false(accepted)
   assert_eq(se.get_text(), "🧑🧒")
 }
+
+///|
+/// P1: a hunk with a leading context line must edit the actually-changed line,
+/// not the hunk's first line. Document `a\nb`; the hunk changes line 2
+/// (`b` -> `c`) behind one context line. A parser that used the hunk start
+/// (line 1) would corrupt line 1 (`c\nb`); tracking the old-side line yields
+/// `a\nc`.
+test "codex lowering: leading context selects the correct old line" {
+  let se = @probe.new_test_editor("codex-agent")
+  se.apply_text_edit(0, 0, "a\nb", 0)
+  let diff =
+    #|@@ -1,2 +1,2 @@
+    #| a
+    #|-b
+    #|+c
+  let intents = unified_diff_to_intents(se.get_text(), diff)
+  let all_accepted = intents.fold(init=true, (ok, intent) => {
+    apply_intent_exact(se, intent, 1) && ok
+  })
+  assert_true(all_accepted)
+  assert_eq(se.get_text(), "a\nc")
+}
+
+///|
+/// P2a: a stale hunk — the document line no longer equals the patch's old text
+/// — must be rejected, not spliced into unrelated content.
+test "codex lowering: stale diff is rejected" {
+  let diff =
+    #|@@ -1 +1 @@
+    #|-foo
+    #|+fOO
+  let raised = try {
+    let _ = unified_diff_to_intents("bar", diff)
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(raised)
+}
+
+///|
+/// P2b: an `update` hunk with more than one changed pair is out of scope and
+/// must fail rather than silently keeping only the last pair.
+test "codex lowering: multi-line update is rejected" {
+  let diff =
+    #|@@ -1,2 +1,2 @@
+    #|-a
+    #|+x
+    #|-b
+    #|+y
+  let raised = try {
+    let _ = unified_diff_to_intents("a\nb", diff)
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(raised)
+}
+
+///|
+/// P2c: a `\ No newline at end of file` marker changes trailing-newline
+/// semantics the prototype does not model, so it must be rejected rather than
+/// silently dropped (which would leave the document's old `\n` in place).
+test "codex lowering: EOF-newline marker is rejected" {
+  let diff =
+    #|@@ -1 +1 @@
+    #|-foo
+    #|+bar
+    #|\ No newline at end of file
+  let raised = try {
+    let _ = unified_diff_to_intents("foo", diff)
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(raised)
+}

--- a/codex/moon.pkg
+++ b/codex/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "dowdiness/canopy/protocol",
   "dowdiness/canopy/editor",
-  "dowdiness/moji",
+  "dowdiness/text_change",
   "moonbitlang/core/string",
 }
 

--- a/codex/moon.pkg
+++ b/codex/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "dowdiness/canopy/protocol",
+  "dowdiness/canopy/editor",
+  "dowdiness/moji",
+  "moonbitlang/core/string",
+}
+
+import {
+  "dowdiness/canopy/workspace/probe",
+  "dowdiness/canopy/editor",
+} for "test"
+
+options(
+  is_main: false,
+)

--- a/codex/pkg.generated.mbti
+++ b/codex/pkg.generated.mbti
@@ -1,0 +1,21 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/codex"
+
+import {
+  "dowdiness/canopy/editor",
+  "dowdiness/canopy/protocol",
+}
+
+// Values
+pub fn[T : Eq] apply_intent_exact(@editor.SyncEditor[T], @protocol.UserIntent, Int) -> Bool raise
+
+pub fn unified_diff_to_intents(String, String) -> Array[@protocol.UserIntent] raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/docs/research/2026-06-13-canopy-codex-app-server-lowering.md
+++ b/docs/research/2026-06-13-canopy-codex-app-server-lowering.md
@@ -82,20 +82,48 @@ The MoonBit dispatch already exists in the FFI layer (`ffi/lambda/intent.mbt`):
   (returns `false` if an endpoint is off a grapheme boundary or out of range; doc
   unchanged on rejection).
 
-So the from/to→deleted_len collapse and the snap/exact choice are MoonBit
-concerns, not TypeScript. The TS adapter (`adapters/editor-adapter/cm6-adapter.ts`)
-only produces the `{type:"TextEdit", from, to, insert}` JSON.
+So the `from/to→deleted_len` collapse and the snap/exact choice are MoonBit
+concerns, not TypeScript. The TS adapter
+(`adapters/editor-adapter/cm6-adapter.ts:255`) only produces the
+`{type:"TextEdit", from, to, insert}` JSON — i.e. the **CM6 bridge** computes
+`from/to` on the **TS** side (strategy (a)-like, §4). The `codex/` prototype is
+different: it computes the splice **entirely in MoonBit** from the diff string,
+with **no TS offset step** (strategy (b), §4).
 
-## 4. The crux: offset-unit conversion (stated precisely)
+## 4. The crux: endpoint grapheme alignment (stated precisely)
 
 `TextEdit.from`/`.to` are **UTF-16 document code-unit offsets**, half-open
-(`protocol/README.md:45`; field types `Int`). Codex's diff coordinates are
-**UTF-8 lines/bytes**. An adapter must convert. Three precise claims — all
-code-verified and empirically demonstrated (§6), so stated as settled:
+(`protocol/README.md:45`; field types `Int`). The crux is that **edit endpoints
+must land on grapheme-cluster boundaries**; the coordinate system the adapter
+works in changes only *how* a misalignment is produced, never *whether* it can
+be. Two adapter strategies make this concrete:
 
-1. **The skew is nonzero even for BMP multibyte.** A single `é` (precomposed
-   U+00E9) is 2 UTF-8 bytes but 1 UTF-16 code unit. So a byte→UTF-16 converter is
-   **always** required; ASCII-only intuition is wrong even without emoji.
+- **(a) Trust the diff's byte-columns.** Codex diff content is **UTF-8
+  lines/bytes**; mapping a byte-column directly to a `TextEdit` offset requires a
+  **UTF-8 byte → UTF-16 code-unit** conversion. The *conversion error* is the
+  misalignment source.
+- **(b) Discard byte-columns, re-diff line contents.** Take only the line
+  *number* from the hunk header and recompute the splice from the `-`/`+` line
+  *contents* (already decoded to UTF-16 `String`). No byte→UTF-16 arithmetic
+  occurs — but the minimal diff **must be computed at grapheme granularity**, or
+  a common prefix/suffix boundary splits a surrogate pair / combining sequence.
+  The *granularity error* is the misalignment source.
+
+Same crux, two coordinate systems. Three precise claims — all code-verified and
+empirically demonstrated (§6), so stated as settled:
+
+1. **The skew is nonzero even for BMP multibyte.** Under (a): a single `é`
+   (precomposed U+00E9) is 2 UTF-8 bytes but 1 UTF-16 code unit, so a byte→UTF-16
+   converter is **always** required; ASCII-only intuition is wrong even without
+   emoji. Under (b) the failure has the same *shape* — a code-unit-granular
+   minimal diff splits a grapheme on innocuous-looking input — but a different
+   verified witness: the probe case is **non-BMP**, two emoji sharing a UTF-16
+   high surrogate (🧑🧒 = U+1F9D1 / U+1F9D2, both `D83E …`), where a code-unit
+   common prefix stops mid-surrogate so the splice endpoint lands inside the
+   cluster (§6). This is **not** a tight parallel of (a): (a) holds *even for
+   BMP* multibyte, whereas (b)'s verified break is non-BMP. The BMP analogue for
+   (b) — a combining sequence (`e` + U+0301) split between base and mark — is
+   plausible but **not yet probed**, so it is not asserted here.
 2. **The skew becomes a *rejectable* error only when it lands mid-cluster** —
    inside a surrogate pair or a combining sequence. When the skew instead lands on
    a *different but valid* grapheme boundary, the result is an edit **correctly
@@ -115,6 +143,18 @@ grapheme boundary. The snap site (`SnapToGrapheme`, `:231-251`) uses
 `@moji.prev/next_grapheme_boundary`, then `apply_local_text_change` constructs the
 `@loom_core.Edit` for the CRDT — i.e. snap precedes the eg-walker item-space Edit,
 matching `protocol/README.md:52-53`.
+
+**Which strategy the prototype took.** The `codex/` adapter prototype chose
+**(b)**: `parse_single_line_update` reads only the line *number* from the hunk
+header, and `minimal_splice` recomputes the splice from the `-`/`+` line contents
+at grapheme granularity (`codex/lowering.mbt` design note). So the byte→UTF-16
+conversion of (a) never appears in that code — but the crux did not vanish, it
+**moved** to minimal-diff granularity, which `minimal_splice` addresses head-on.
+Read §4's earlier "offset-unit conversion" name as the **(a)-manifestation** of a
+coordinate-independent requirement, not as the crux itself. This generalization
+is exactly §5's deduction chain (sub-line minimal → mid-grapheme possible →
+grapheme alignment required → Exact seatbelt); §5 was the correct statement of
+the crux all along.
 
 ## 5. Policy: deduced, then precedented
 
@@ -161,6 +201,14 @@ decomposed `e` + U+0301 (3 bytes / 2 units) would shift them:
 
 The probe was removed after observation (not committed), consistent with
 prototype-first discipline.
+
+A **second, committed** probe exhibits the same crux under strategy (b)
+(`codex/lowering_test.mbt`): document `🧑🧒` → `🧒`, where the two emoji share
+UTF-16 high surrogate `D83E`. A code-unit-granular minimal diff stops the common
+prefix mid-surrogate (Exact rejects / full-text-match fails); a grapheme-granular
+one yields `(from=0, del=2)` and accepts. The §6 table above is the **(a)**
+manifestation (byte-as-UTF-16 naive converter); this is the **(b)** manifestation
+— the same claim 1–3 in different coordinates.
 
 ## 7. Placement
 


### PR DESCRIPTION
## What

Prototype `codex/` adapter package (Tier-3, peer of `transport_ws`) that lowers a Codex `FileChange.update` unified diff into `@protocol.UserIntent::TextEdit` and drives it into a `SyncEditor` via `apply_text_edit_exact` (EXACT grapheme-boundary policy). Verifies the text-level lowering seam de-risked by `docs/research/2026-06-13-canopy-codex-app-server-lowering.md` (merged in #606).

- `unified_diff_to_intents(doc, diff)` — parses a single-line `update` hunk, computes the minimal sub-line splice at **grapheme** granularity (endpoints aligned by construction), emits one `TextEdit`.
- `apply_intent_exact(se, intent, ts)` — collapses `from/to → deleted_len` and drives `apply_text_edit_exact` as the load-bearing seatbelt.

`core` / `editor` / `protocol` stay Codex-free; `codex` depends on them.

## Design refinement vs the research note

The note frames the crux as "UTF-8 byte → UTF-16 conversion." In MoonBit that step **dissolves**: a unified diff is line-based (hunk headers are line counts) and its content lines arrive already decoded to a UTF-16 `String` at the transport boundary. The surviving risk is **grapheme-splitting** by a too-fine minimal diff, which is why the splice is grapheme-granular and `apply_text_edit_exact` is the seatbelt. Captured as a `Design note` comment in `codex/lowering.mbt`.

## Tests (3, all green)

1. **Non-vacuous accept + full-text-match** — `"🧑🧒" → "🧒"`. The two emoji share UTF-16 high surrogate `D83E`, so a code-unit-granular diff lands mid-surrogate and fails; only a grapheme-granular converter passes. (Demonstrated empirically during development: the code-unit version failed this vector, the grapheme version passes.)
2. **Hunk-header regression** (Codex pre-PR review catch) — a content line starting with `---` (Markdown frontmatter, raw diff line `----`) must not be parsed as a file header. Fixed via hunk-state gating.
3. **Seatbelt** — a hand-fed mid-grapheme offset is rejected by EXACT, document unchanged.

## Scope (deliberate)

Single-hunk, single-changed-line `update` only. Deferred (research note §8, guarded explicitly — no silent fallback): multi-hunk, `add`/`delete` whole-document variants, `move_path`, concurrent-edit fuzzy apply, `StructuralEdit`/`CommitEdit` lowering, and the WebSocket/app-server client (exercised separately by `scripts/codex-app-server-turn.py`).

## Reuse check

- **Reused:** `@moji.grapheme_boundaries`, `@protocol.UserIntent::TextEdit`, `@editor.SyncEditor::apply_text_edit_exact`, `@probe.new_test_editor` (test fixture).
- **Checked, not used:** searched for an existing UTF-8 byte → UTF-16 offset helper (`moon ide doc "*utf16*"`, moji API) — none exists; the refinement above explains why none is needed.
- **New helpers (package-internal, no existing equivalent):** `minimal_splice`, `line_start_offset`, `parse_single_line_update`, `parse_hunk_old_start` — unified-diff parsing + grapheme-splice computation specific to this adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting unified diffs into text edit operations with grapheme boundary enforcement.
  * Improved text editing precision for edge cases including emoji and special characters.

* **Tests**
  * Added regression tests for diff parsing, emoji handling, and grapheme boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->