### PR TITLE
feat(web): add same-input ask mode for posts

### DIFF
--- a/examples/web/posts.html
+++ b/examples/web/posts.html
@@ -148,17 +148,34 @@
       font-size: 0.78rem;
     }
 
-    .post-button {
+    .composer-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
+      align-items: center;
+    }
+
+    .post-button,
+    .ask-button {
       min-width: 116px;
       padding: 10px 18px;
-      background: var(--accent);
-      color: var(--text);
-      border: 1px solid color-mix(in oklab, var(--accent), white 10%);
       border-radius: 999px;
       cursor: pointer;
       font-weight: 800;
       letter-spacing: 0.01em;
-      transition: transform 120ms ease, background 120ms ease, opacity 120ms ease;
+      transition: transform 120ms ease, background 120ms ease, border-color 120ms ease, opacity 120ms ease;
+    }
+
+    .post-button {
+      background: var(--accent);
+      color: var(--text);
+      border: 1px solid color-mix(in oklab, var(--accent), white 10%);
+    }
+
+    .ask-button {
+      background: color-mix(in oklab, var(--surface), var(--accent) 10%);
+      color: var(--secondary);
+      border: 1px solid color-mix(in oklab, var(--border), var(--accent) 26%);
     }
 
     .post-button:hover:not(:disabled) {
@@ -166,7 +183,14 @@
       transform: translateY(-1px);
     }
 
-    .post-button:disabled {
+    .ask-button:hover:not(:disabled) {
+      color: var(--text);
+      border-color: color-mix(in oklab, var(--accent), var(--border) 30%);
+      transform: translateY(-1px);
+    }
+
+    .post-button:disabled,
+    .ask-button:disabled {
       cursor: not-allowed;
       opacity: 0.46;
     }
@@ -250,6 +274,17 @@
       margin: 0;
       padding: 0;
       list-style: none;
+    }
+
+    .related-empty {
+      margin: 0;
+      padding-top: var(--space-sm);
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .related-empty[hidden] {
+      display: none;
     }
 
     .related-item article {
@@ -410,7 +445,9 @@
         flex-direction: column;
       }
 
-      .post-button {
+      .composer-buttons,
+      .post-button,
+      .ask-button {
         width: 100%;
       }
     }
@@ -432,7 +469,10 @@
 
       <div class="composer-actions">
         <p class="hint"><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Enter</kbd> posts. Plain <kbd>Enter</kbd> keeps writing.</p>
-        <button class="post-button" id="post-submit" type="submit">Post</button>
+        <div class="composer-buttons">
+          <button class="ask-button" id="post-ask" type="button">Ask</button>
+          <button class="post-button" id="post-submit" type="submit">Post</button>
+        </div>
       </div>
 
       <div class="status-row" aria-live="polite">
@@ -444,11 +484,12 @@
     <section class="related-panel" id="related-panel" aria-labelledby="related-title" hidden>
       <div class="related-heading">
         <div>
-          <p class="related-kicker">Returning while writing</p>
+          <p class="related-kicker" id="related-kicker">Returning while writing</p>
           <h2 id="related-title">Related posts</h2>
         </div>
         <span id="related-count">0 related posts</span>
       </div>
+      <p class="related-empty" id="related-empty" hidden>No matching source posts yet. Try words you remember from the post.</p>
       <ul class="related-list" id="related-list"></ul>
     </section>
 

--- a/examples/web/src/post-app.ts
+++ b/examples/web/src/post-app.ts
@@ -4,13 +4,17 @@ import { type LocalPost, LocalPostStore } from './post-store';
 
 const form = document.getElementById('post-form') as HTMLFormElement;
 const draft = document.getElementById('post-input') as HTMLTextAreaElement;
+const askButton = document.getElementById('post-ask') as HTMLButtonElement;
 const submitButton = document.getElementById('post-submit') as HTMLButtonElement;
 const statusEl = document.getElementById('post-status') as HTMLParagraphElement;
 const countEl = document.getElementById('post-count') as HTMLSpanElement;
 const listEl = document.getElementById('post-list') as HTMLUListElement;
 const emptyEl = document.getElementById('empty-state') as HTMLDivElement;
 const relatedPanelEl = document.getElementById('related-panel') as HTMLElement;
+const relatedKickerEl = document.getElementById('related-kicker') as HTMLParagraphElement;
+const relatedTitleEl = document.getElementById('related-title') as HTMLHeadingElement;
 const relatedCountEl = document.getElementById('related-count') as HTMLSpanElement;
+const relatedEmptyEl = document.getElementById('related-empty') as HTMLParagraphElement;
 const relatedListEl = document.getElementById('related-list') as HTMLUListElement;
 
 const store = new LocalPostStore(window.localStorage);
@@ -22,8 +26,39 @@ const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
   minute: '2-digit',
 });
 
+type RelatedPanelMode = 'writing' | 'ask';
+
+interface RelatedPanelCopy {
+  readonly kicker: string;
+  readonly title: string;
+  readonly formatCount: (count: number) => string;
+  readonly openButtonText: string;
+  readonly openLabelPrefix: string;
+  readonly openedLabel: string;
+}
+
+const RELATED_PANEL_COPY: Record<RelatedPanelMode, RelatedPanelCopy> = {
+  writing: {
+    kicker: 'Returning while writing',
+    title: 'Related posts',
+    formatCount: pluralizeRelated,
+    openButtonText: 'Open',
+    openLabelPrefix: 'Open related post',
+    openedLabel: 'related post',
+  },
+  ask: {
+    kicker: 'Asked from your posts',
+    title: 'Source posts',
+    formatCount: pluralizeSources,
+    openButtonText: 'Open source',
+    openLabelPrefix: 'Open source post',
+    openedLabel: 'source post',
+  },
+};
+
 let posts: LocalPost[] = [];
 let highlightedPostId: string | null = null;
+let relatedMode: RelatedPanelMode = 'writing';
 let retrievalIndex = new PostRetrievalIndex(posts, eventStore.engagementByPost());
 
 function pluralizePosts(count: number): string {
@@ -32,6 +67,10 @@ function pluralizePosts(count: number): string {
 
 function pluralizeRelated(count: number): string {
   return count === 1 ? '1 related post' : `${count} related posts`;
+}
+
+function pluralizeSources(count: number): string {
+  return count === 1 ? '1 source post' : `${count} source posts`;
 }
 
 function setStatus(message: string, tone: 'idle' | 'success' | 'error' = 'idle'): void {
@@ -44,7 +83,9 @@ function formatTimestamp(value: string): string {
 }
 
 function syncSubmitState(): void {
-  submitButton.disabled = draft.value.trim().length === 0;
+  const isEmpty = draft.value.trim().length === 0;
+  askButton.disabled = isEmpty;
+  submitButton.disabled = isEmpty;
 }
 
 function renderPost(post: LocalPost): HTMLLIElement {
@@ -76,7 +117,8 @@ function renderRankingReason(reason: RankingReason): HTMLSpanElement {
   return item;
 }
 
-function renderRelatedPost(result: RelatedPost): HTMLLIElement {
+function renderRelatedPost(result: RelatedPost, mode: RelatedPanelMode): HTMLLIElement {
+  const copy = RELATED_PANEL_COPY[mode];
   const item = document.createElement('li');
   item.className = 'related-item';
 
@@ -100,8 +142,11 @@ function renderRelatedPost(result: RelatedPost): HTMLLIElement {
   const openButton = document.createElement('button');
   openButton.type = 'button';
   openButton.className = 'related-open';
-  openButton.textContent = 'Open';
-  openButton.setAttribute('aria-label', `Open related post: ${result.post.text.slice(0, 80)}`);
+  openButton.textContent = copy.openButtonText;
+  openButton.setAttribute(
+    'aria-label',
+    `${copy.openLabelPrefix}: ${result.post.text.slice(0, 80)}`,
+  );
   openButton.addEventListener('click', () => openRelatedPost(result));
 
   meta.append(time, reasons);
@@ -110,11 +155,22 @@ function renderRelatedPost(result: RelatedPost): HTMLLIElement {
   return item;
 }
 
-function renderRelated(): void {
+function renderRelated(): number {
   const relatedPosts = retrievalIndex.query(draft.value, { limit: 5 });
-  relatedCountEl.textContent = pluralizeRelated(relatedPosts.length);
-  relatedListEl.replaceChildren(...relatedPosts.map(renderRelatedPost));
-  relatedPanelEl.hidden = relatedPosts.length === 0;
+  const copy = RELATED_PANEL_COPY[relatedMode];
+  const isAskMode = relatedMode === 'ask';
+  const hasResults = relatedPosts.length > 0;
+
+  relatedKickerEl.textContent = copy.kicker;
+  relatedTitleEl.textContent = copy.title;
+  relatedCountEl.textContent = copy.formatCount(relatedPosts.length);
+  relatedListEl.replaceChildren(
+    ...relatedPosts.map(result => renderRelatedPost(result, relatedMode)),
+  );
+  relatedEmptyEl.hidden = !(isAskMode && !hasResults);
+  relatedPanelEl.hidden = !isAskMode && !hasResults;
+
+  return relatedPosts.length;
 }
 
 function replacePosts(nextPosts: LocalPost[]): void {
@@ -144,10 +200,11 @@ function openRelatedPost(result: RelatedPost): void {
   replacePosts(posts);
   render();
   focusTimelinePost(result.post.id);
+  const openedLabel = RELATED_PANEL_COPY[relatedMode].openedLabel;
   setStatus(
     recorded
-      ? 'Opened a related post. Revisited posts get a small ranking boost.'
-      : 'Opened a related post, but could not save its revisit signal.',
+      ? `Opened a ${openedLabel}. Revisited posts get a small ranking boost.`
+      : `Opened a ${openedLabel}, but could not save its revisit signal.`,
     recorded ? 'success' : 'error',
   );
 }
@@ -191,6 +248,7 @@ function submitDraft(): void {
       // Event tracking is best-effort; the post itself is the durable user data.
     }
     highlightedPostId = null;
+    relatedMode = 'writing';
     replacePosts([post, ...posts]);
     draft.value = '';
     syncSubmitState();
@@ -205,6 +263,25 @@ function submitDraft(): void {
   }
 }
 
+function askDraft(): void {
+  const queryText = draft.value.trim();
+  if (queryText.length === 0) {
+    setStatus('Write a question before asking.', 'error');
+    draft.focus();
+    return;
+  }
+
+  relatedMode = 'ask';
+  const sourceCount = renderRelated();
+  setStatus(
+    sourceCount === 0
+      ? 'No source posts matched that question. Nothing was posted.'
+      : `Found ${pluralizeSources(sourceCount)}. Nothing was posted.`,
+    sourceCount === 0 ? 'idle' : 'success',
+  );
+  draft.focus();
+}
+
 form.addEventListener('submit', event => {
   event.preventDefault();
   submitDraft();
@@ -217,7 +294,10 @@ draft.addEventListener('keydown', event => {
   }
 });
 
+askButton.addEventListener('click', askDraft);
+
 draft.addEventListener('input', () => {
+  relatedMode = 'writing';
   syncSubmitState();
   renderRelated();
 });

--- a/examples/web/tests/post-app.spec.ts
+++ b/examples/web/tests/post-app.spec.ts
@@ -130,6 +130,56 @@ test.describe('local-first post app', () => {
     await expect(relatedPanel).toBeHidden();
   });
 
+  test('asks the same input for source posts without posting the question', async ({ page }) => {
+    const question = 'what did I decide about sync recovery?';
+    const sourceText = 'For sync recovery we decided to retry locally before merging remote commits.';
+
+    await page.evaluate(
+      ({ key, posts }) => window.localStorage.setItem(key, JSON.stringify(posts)),
+      {
+        key: POST_STORAGE_KEY,
+        posts: [
+          {
+            id: 'post-sync-recovery',
+            text: sourceText,
+            createdAt: '2026-06-10T09:00:00.000Z',
+          },
+          {
+            id: 'post-basil-window',
+            text: 'Basil seedlings recovered on the kitchen window shelf after I stopped overwatering.',
+            createdAt: '2026-06-09T09:00:00.000Z',
+          },
+        ],
+      },
+    );
+    await page.reload();
+
+    const input = page.getByLabel('Write');
+
+    await input.fill(question);
+    await page.getByRole('button', { name: 'Ask' }).click();
+
+    await expect(input).toHaveValue(question);
+    await expect(page.locator('#related-panel')).toBeVisible();
+    await expect(page.locator('#related-kicker')).toHaveText('Asked from your posts');
+    await expect(page.locator('#related-title')).toHaveText('Source posts');
+    await expect(page.locator('#related-count')).toHaveText('1 source post');
+    await expect(page.locator('.related-text')).toHaveText([sourceText]);
+    await expect(page.locator('#post-count')).toHaveText('2 posts');
+
+    const storedPosts = await page.evaluate(
+      key => JSON.parse(window.localStorage.getItem(key) ?? '[]') as Array<{ text: string }>,
+      POST_STORAGE_KEY,
+    );
+    expect(storedPosts.map(post => post.text)).not.toContain(question);
+
+    const eventPayload = await page.evaluate(
+      key => window.localStorage.getItem(key),
+      POST_EVENT_STORAGE_KEY,
+    );
+    expect(eventPayload ?? '').not.toContain(question);
+  });
+
   test('boosts revisited related posts and explains why they surfaced', async ({ page }) => {
     const olderText = 'Sync recovery policy keeps retry buffer before merge.';
     const newerText = 'Sync recovery policy keeps retry buffer before commit.';


### PR DESCRIPTION
## Summary

- Add an explicit Ask action beside Post in the local-first post composer.
- Reuse the local post retrieval index to show source posts/provenance for questions without generating answers.
- Cover that Ask preserves the draft, does not create a post, and does not persist raw question text in event payloads.

Closes #595

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `PostRetrievalIndex.query` | `examples/web/src/post-retrieval.ts` | Yes | Ask mode uses the same local retrieval seam as related-post resurfacing. |
| `LocalPostStore.add` | `examples/web/src/post-store.ts` | Yes, for Post only | Ask deliberately avoids this path so question text is not stored as a post. |
| `LocalPostEventStore.recordRelatedOpened` | `examples/web/src/post-events.ts` | Yes, for Open source/related | Existing revisit signal remains best-effort and does not include query text. |

New helpers added (if any):

- `RelatedPanelMode` / `RelatedPanelCopy` / `RELATED_PANEL_COPY`: centralizes writing-vs-ask panel labels and avoids scattering mode conditionals.
- `pluralizeSources`: source-post count copy for Ask mode.
- `askDraft`: explicit Ask action handler, separate from `submitDraft` so posting remains the default path.

## Test plan

- [ ] `NEW_MOON_MOD=0 moon check` passes (not run; web-only TS/HTML change)
- [ ] `NEW_MOON_MOD=0 moon test` passes (not run; web-only TS/HTML change)
- [x] `git diff *.mbti` reviewed for unintended API surface changes (no `.mbti` changes)
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`)

## Validation

```bash
cd examples/web && npx tsc --noEmit
cd examples/web && npx playwright test tests/post-app.spec.ts
cd examples/web && npm run build
```
