### PR TITLE
Extract reusable canvas interaction reducers

### DIFF
--- a/examples/canvas/main/canvas_init.mbt
+++ b/examples/canvas/main/canvas_init.mbt
@@ -276,7 +276,7 @@ fn validate_workflow_document(
 
 ///|
 fn validate_workflow(state : CanvasState) -> Array[ValidationJson] {
-  validate_workflow_document(canvas_document_from_state(state))
+  validate_workflow_document(@graph_model.canvas_document_from_state(state))
 }
 
 ///|

--- a/examples/canvas/main/canvas_runtime.mbt
+++ b/examples/canvas/main/canvas_runtime.mbt
@@ -43,9 +43,9 @@ fn validate_canvas_document(document : CanvasDocument) -> ValidatedCanvas {
       next_node_id: document.next_node_id,
     },
     validation: validate_workflow(
-      canvas_state_from_parts(
+      @graph_model.canvas_state_from_parts(
         document,
-        default_viewport(),
+        @graph_model.default_viewport(),
         @graph_model.empty_interaction(),
         [],
       ),
@@ -79,7 +79,7 @@ fn preview_position_for(
   preview : DragPreview,
   node_id : String,
 ) -> NodePosition? {
-  find_position(preview.positions, NodeId(node_id))
+  @graph_model.find_position(preview.positions, NodeId(node_id))
 }
 
 ///|
@@ -87,28 +87,6 @@ fn render_node_with_preview(node : NodeJson, preview : DragPreview) -> NodeJson 
   match preview_position_for(preview, node.id) {
     None => node
     Some(pos) => { ..node, x: pos.x, y: pos.y }
-  }
-}
-
-///|
-fn canvas_node_with_preview(
-  node : CanvasNode,
-  preview : DragPreview,
-) -> CanvasNode {
-  match preview_position_for(preview, node_id_to_string(node.id)) {
-    None => node
-    Some(pos) => { ..node, x: pos.x, y: pos.y }
-  }
-}
-
-///|
-fn state_with_preview_nodes(
-  state : CanvasState,
-  preview : DragPreview,
-) -> CanvasState {
-  {
-    ..state,
-    nodes: state.nodes.map(fn(node) { canvas_node_with_preview(node, preview) }),
   }
 }
 
@@ -161,7 +139,7 @@ fn inspector_node_for_document(
   document : CanvasDocument,
   node_id : String,
 ) -> InspectorNodeJson? {
-  match find_node(document.nodes, NodeId(node_id)) {
+  match @graph_model.find_node(document.nodes, NodeId(node_id)) {
     None => None
     Some(node) =>
       Some({
@@ -227,7 +205,7 @@ fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
   let scope = @incr.Scope::new(rt)
   let initial = CanvasState::default()
   let document = scope.input(
-    canvas_document_from_state(initial),
+    @graph_model.canvas_document_from_state(initial),
     label="canvas.document",
   )
   let actions = scope.input(
@@ -236,12 +214,12 @@ fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
   )
   let hover = scope.input(None, label="canvas.hover")
   let drag_preview = scope.input(
-    idle_drag_preview(),
+    @graph_model.idle_drag_preview(),
     label="canvas.drag_preview",
   )
   let viewport = scope.input(initial.viewport, label="canvas.viewport")
   let selection = scope.input(
-    selection_from_interaction(initial.interaction),
+    @graph_model.selection_from_interaction(initial.interaction),
     label="canvas.selection",
   )
   let interaction = scope.input(initial.interaction, label="canvas.gesture")
@@ -322,11 +300,11 @@ fn CanvasRuntime::CanvasRuntime() -> CanvasRuntime {
 
 ///|
 fn CanvasRuntime::state_peek(self : CanvasRuntime) -> CanvasState {
-  let interaction = interaction_with_selection(
+  let interaction = @graph_model.interaction_with_selection(
     self.interaction.peek(),
     self.selection.peek(),
   )
-  canvas_state_from_parts(
+  @graph_model.canvas_state_from_parts(
     self.document.peek(),
     self.viewport.peek(),
     interaction,
@@ -339,10 +317,10 @@ fn CanvasRuntime::sync_commit_state(
   self : CanvasRuntime,
   state : CanvasState,
 ) -> Unit {
-  self.document.set(canvas_document_from_state(state))
+  self.document.set(@graph_model.canvas_document_from_state(state))
   self.viewport.set(state.viewport)
-  self.drag_preview.set(idle_drag_preview())
-  self.selection.set(selection_from_interaction(state.interaction))
+  self.drag_preview.set(@graph_model.idle_drag_preview())
+  self.selection.set(@graph_model.selection_from_interaction(state.interaction))
   self.interaction.set(state.interaction)
   self.actions.set(state.action_log.copy())
 }
@@ -370,7 +348,7 @@ fn CanvasRuntime::sync_document_action_state(
   self : CanvasRuntime,
   state : CanvasState,
 ) -> Unit {
-  self.document.set(canvas_document_from_state(state))
+  self.document.set(@graph_model.canvas_document_from_state(state))
   self.actions.set(state.action_log.copy())
 }
 
@@ -381,8 +359,13 @@ fn CanvasRuntime::pointer_down(
   sx : Double,
   sy : Double,
 ) -> Unit {
-  let state = update_pointer_down(self.state_peek(), node_id, sx, sy)
-  self.drag_preview.set(idle_drag_preview())
+  let state = @graph_model.update_pointer_down(
+    self.state_peek(),
+    node_id,
+    sx,
+    sy,
+  )
+  self.drag_preview.set(@graph_model.idle_drag_preview())
   self.interaction.set(state.interaction)
 }
 
@@ -395,9 +378,9 @@ fn CanvasRuntime::pointer_down_handle(
   sy : Double,
 ) -> Unit {
   let state = self.state_peek()
-  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+  let (wx, wy) = @graph_model.screen_to_world(state.viewport, sx, sy)
   self.interaction.set(
-    update_connect_start(state, node_id, port_id, wx, wy).interaction,
+    @graph_model.update_connect_start(state, node_id, port_id, wx, wy).interaction,
   )
 }
 
@@ -410,23 +393,30 @@ fn CanvasRuntime::pointer_move(
   let state = self.state_peek()
   match state.interaction.connecting {
     Some(_) => {
-      let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-      self.interaction.set(update_connect_move(state, wx, wy).interaction)
+      let (wx, wy) = @graph_model.screen_to_world(state.viewport, sx, sy)
+      self.interaction.set(
+        @graph_model.update_connect_move(state, wx, wy).interaction,
+      )
     }
     None =>
       match state.interaction.dragging {
         Some(drag) => {
-          let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+          let (wx, wy) = @graph_model.screen_to_world(state.viewport, sx, sy)
           let new_interaction : InteractionState = {
             ..state.interaction,
             did_move: true,
           }
-          self.drag_preview.set(drag_preview_from_move(drag, wx, wy))
+          self.drag_preview.set(
+            @graph_model.drag_preview_from_move(drag, wx, wy),
+          )
           self.interaction.set(new_interaction)
         }
         None =>
           match state.interaction.panning {
-            Some(_) => self.sync_viewport_state(update_pan_move(state, sx, sy))
+            Some(_) =>
+              self.sync_viewport_state(
+                @graph_model.update_pan_move(state, sx, sy),
+              )
             None => ()
           }
       }
@@ -443,11 +433,13 @@ fn CanvasRuntime::pointer_up(
   let state = self.state_peek()
   let commit_state = match state.interaction.dragging {
     Some(_) if state.interaction.did_move =>
-      state_with_preview_nodes(state, self.drag_preview.peek())
+      @graph_model.state_with_preview_nodes(state, self.drag_preview.peek())
     _ => state
   }
   self.sync_commit_state(
-    update_pointer_up(commit_state, node_id, target_port_id, additive),
+    @graph_model.update_pointer_up(
+      commit_state, node_id, target_port_id, additive,
+    ),
   )
 }
 
@@ -458,7 +450,9 @@ fn CanvasRuntime::zoom(
   cx : Double,
   cy : Double,
 ) -> Unit {
-  self.sync_action_viewport_state(update_zoom(self.state_peek(), delta, cx, cy))
+  self.sync_action_viewport_state(
+    @graph_model.update_zoom(self.state_peek(), delta, cx, cy),
+  )
 }
 
 ///|
@@ -479,8 +473,10 @@ fn CanvasRuntime::add_node(
   sy : Double,
 ) -> Unit {
   let state = self.state_peek()
-  let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-  self.sync_document_action_state(workflow_add_node(state, kind_key, wx, wy))
+  let (wx, wy) = @graph_model.screen_to_world(state.viewport, sx, sy)
+  self.sync_document_action_state(
+    @graph_model.workflow_add_node(state, kind_key, wx, wy),
+  )
 }
 
 ///|
@@ -488,7 +484,9 @@ fn CanvasRuntime::delete_nodes(
   self : CanvasRuntime,
   nodes : Array[NodeId],
 ) -> Unit {
-  self.sync_commit_state(record_action(self.state_peek(), DeleteNodes(nodes)))
+  self.sync_commit_state(
+    @graph_model.record_action(self.state_peek(), DeleteNodes(nodes)),
+  )
 }
 
 ///|
@@ -500,7 +498,7 @@ fn CanvasRuntime::disconnect_ports(
   target_port : String,
 ) -> Unit {
   self.sync_document_action_state(
-    record_action(
+    @graph_model.record_action(
       self.state_peek(),
       DisconnectPorts(source, source_port, target, target_port),
     ),

--- a/examples/canvas/main/canvas_runtime_wbtest.mbt
+++ b/examples/canvas/main/canvas_runtime_wbtest.mbt
@@ -1,0 +1,135 @@
+///|
+fn make_test_state() -> CanvasState {
+  {
+    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    nodes: [
+      @graph_model.make_workflow_node(NodeId("1"), TimerTrigger, 100.0, 100.0),
+      @graph_model.make_workflow_node(NodeId("2"), HttpRequest, 420.0, 100.0),
+      @graph_model.make_workflow_node(NodeId("3"), DataFormatter, 760.0, 100.0),
+    ],
+    edges: [],
+    next_node_id: 4,
+    interaction: @graph_model.empty_interaction(),
+    action_log: [],
+  }
+}
+
+///|
+test "validate_workflow reports missing typed input ports independently" {
+  let nodes = make_test_state().nodes.copy()
+  nodes.push(
+    @graph_model.make_workflow_node(NodeId("4"), ConditionalBranch, 0.0, 0.0),
+  )
+  let state : CanvasState = {
+    ..make_test_state(),
+    nodes,
+    edges: [
+      {
+        id: EdgeId::from_edge(NodeId("3"), "text", NodeId("4"), "text"),
+        source: NodeId("3"),
+        source_port: "text",
+        target: NodeId("4"),
+        target_port: "text",
+      },
+    ],
+  }
+  let messages = validate_workflow(state)
+  assert_true(
+    messages
+    .iter()
+    .any(fn(message) {
+      message.node_id == Some("4") &&
+      message.message.contains("input “rule”")
+    }),
+  )
+  assert_false(
+    messages
+    .iter()
+    .any(fn(message) {
+      message.node_id == Some("4") &&
+      message.message.contains("input “text”")
+    }),
+  )
+}
+
+///|
+test "get_render_state exposes workflow JSON shape" {
+  let handle = create_canvas()
+  let json_str = get_render_state(handle)
+  assert_true(json_str.contains("\"nodes\""))
+  assert_true(json_str.contains("Timer trigger"))
+  assert_true(json_str.contains("\"source_port\""))
+  assert_true(json_str.contains("\"validation\""))
+}
+
+///|
+test "runtime live drag updates preview before one durable MoveNodes commit" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
+  let before = runtime.document.peek()
+  runtime.pointer_down(Some(NodeId("1")), -510.0, -180.0)
+  runtime.pointer_move(-400.0, -100.0)
+
+  let during = runtime.document.peek()
+  inspect(during.nodes[0].x, content="-520")
+  inspect(during.nodes[0].y, content="-190")
+  assert_eq(runtime.actions.peek().length(), 0)
+
+  let preview = runtime.render_state().nodes[0]
+  inspect(preview.x, content="-410")
+  inspect(preview.y, content="-110")
+  assert_eq(before.nodes[0].x, during.nodes[0].x)
+
+  runtime.pointer_up("1", "", false)
+  let after = runtime.document.peek()
+  inspect(after.nodes[0].x, content="-410")
+  inspect(after.nodes[0].y, content="-110")
+  assert_eq(runtime.actions.peek().length(), 1)
+  match runtime.actions.peek()[0].action() {
+    MoveNodes(positions) => {
+      assert_eq(positions.length(), 1)
+      inspect(positions[0].x, content="-410")
+      inspect(positions[0].y, content="-110")
+    }
+    _ => fail("expected MoveNodes action")
+  }
+}
+
+///|
+test "runtime delete_nodes removes selected nodes and incident edges" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.delete_nodes([NodeId("2")])
+  let state = runtime.render_state()
+  assert_eq(state.nodes.length(), 5)
+  assert_eq(state.edges.length(), 1)
+  assert_eq(runtime.actions.peek().length(), 1)
+  match runtime.actions.peek()[0].action() {
+    DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId("2")])
+    _ => fail("expected DeleteNodes action")
+  }
+}
+
+///|
+test "runtime sparse inspector follows hover until a node is selected" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
+  runtime.hover_node("1")
+  match runtime.render_state().inspector {
+    Some(node) => {
+      inspect(node.source, content="hovered")
+      inspect(node.title, content="Timer trigger")
+    }
+    None => fail("expected hovered inspector")
+  }
+
+  runtime.pointer_down(Some(NodeId("2")), -190.0, -190.0)
+  runtime.pointer_up("2", "", false)
+  runtime.hover_node("1")
+  match runtime.render_state().inspector {
+    Some(node) => {
+      inspect(node.source, content="selected")
+      inspect(node.title, content="HTTP request")
+    }
+    None => fail("expected selected inspector")
+  }
+}

--- a/examples/canvas/main/canvas_state.mbt
+++ b/examples/canvas/main/canvas_state.mbt
@@ -4,6 +4,7 @@ pub using @graph_model {
   type CanvasState,
   type ConnectState,
   type DragOrigin,
+  type DragPreview,
   type DragState,
   type Edge,
   type EdgeId,
@@ -21,98 +22,4 @@ pub using @graph_model {
 }
 
 ///|
-using @graph_model {
-  find_node,
-  find_position,
-  make_workflow_node,
-  port_type_by_id,
-  record_action,
-}
-
-///|
-/// Durable workflow graph document. High-frequency UI affordances such as
-/// hover, live drag preview, and viewport live outside this value.
-struct CanvasDocument {
-  nodes : Array[CanvasNode]
-  edges : Array[Edge]
-  next_node_id : Int
-} derive(Debug, Eq)
-
-///|
-/// Ephemeral live-drag overlay. Empty positions means no active preview;
-/// committed node positions remain in `CanvasDocument` until pointerup.
-pub(all) struct DragPreview {
-  positions : Array[NodePosition]
-} derive(Debug, Eq)
-
-///|
-pub impl Show for DragPreview with fn output(self, logger) {
-  logger.write_string(@debug.to_string(self))
-}
-
-///|
-/// Selection is its own UI input so sparse inspector surfaces can depend on it
-/// without reading drag/viewport gesture state.
-struct SelectionState {
-  selected : NodeId?
-  selected_nodes : Array[NodeId]
-} derive(Debug, Eq)
-
-///|
-fn selection_from_interaction(interaction : InteractionState) -> SelectionState {
-  {
-    selected: interaction.selected,
-    selected_nodes: interaction.selected_nodes.copy(),
-  }
-}
-
-///|
-fn interaction_with_selection(
-  interaction : InteractionState,
-  selection : SelectionState,
-) -> InteractionState {
-  {
-    ..interaction,
-    selected: selection.selected,
-    selected_nodes: selection.selected_nodes.copy(),
-  }
-}
-
-///|
-fn idle_drag_preview() -> DragPreview {
-  { positions: [] }
-}
-
-///|
-fn default_viewport() -> Viewport {
-  { x: 760.0, y: 330.0, scale: 0.75 }
-}
-
-///|
-fn canvas_document_from_state(state : CanvasState) -> CanvasDocument {
-  {
-    nodes: state.nodes.copy(),
-    edges: state.edges.copy(),
-    next_node_id: state.next_node_id,
-  }
-}
-
-///|
-fn canvas_state_from_parts(
-  document : CanvasDocument,
-  viewport : Viewport,
-  interaction : InteractionState,
-  action_log : Array[GraphOperation],
-) -> CanvasState {
-  {
-    viewport,
-    nodes: document.nodes.copy(),
-    edges: document.edges.copy(),
-    next_node_id: document.next_node_id,
-    interaction: interaction_with_selection(
-      interaction,
-      selection_from_interaction(interaction),
-    ),
-    action_log: action_log.copy(),
-  }
-}
+using @graph_model {type CanvasDocument, type SelectionState}

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -28,7 +28,7 @@ fn SourceBackedGraph::SourceBackedGraph(source : String) -> SourceBackedGraph {
     source,
     viewport: default_source_graph_viewport(),
     interaction: @graph_model.empty_interaction(),
-    drag_preview: idle_drag_preview(),
+    drag_preview: @graph_model.idle_drag_preview(),
     layout: [],
     action_log: [],
   }
@@ -283,7 +283,7 @@ fn source_graph_canvas_state(graph : SourceBackedGraph) -> CanvasState {
   let state = source_graph_base_canvas_state(graph)
   match graph.interaction.dragging {
     Some(_) if graph.interaction.did_move =>
-      state_with_preview_nodes(state, graph.drag_preview)
+      @graph_model.state_with_preview_nodes(state, graph.drag_preview)
     _ => state
   }
 }
@@ -624,7 +624,7 @@ fn SourceBackedGraph::prune_selection_to_doc(
     [head, ..] => Some(head)
     [] => None
   }
-  self.drag_preview = idle_drag_preview()
+  self.drag_preview = @graph_model.idle_drag_preview()
   self.interaction = {
     dragging: None,
     panning: None,
@@ -728,13 +728,13 @@ fn SourceBackedGraph::pointer_down(
   } else {
     Some(NodeId(node_id))
   }
-  let state = update_pointer_down(
+  let state = @graph_model.update_pointer_down(
     source_graph_base_canvas_state(self),
     target,
     sx,
     sy,
   )
-  self.drag_preview = idle_drag_preview()
+  self.drag_preview = @graph_model.idle_drag_preview()
   self.interaction = state.interaction
 }
 
@@ -747,24 +747,24 @@ fn SourceBackedGraph::pointer_move(
   let state = source_graph_base_canvas_state(self)
   match state.interaction.connecting {
     Some(_) => {
-      let (wx, wy) = screen_to_world(state.viewport, sx, sy)
-      self.interaction = update_connect_move(state, wx, wy).interaction
+      let (wx, wy) = @graph_model.screen_to_world(state.viewport, sx, sy)
+      self.interaction = @graph_model.update_connect_move(state, wx, wy).interaction
     }
     None =>
       match state.interaction.dragging {
         Some(drag) => {
-          let (wx, wy) = screen_to_world(state.viewport, sx, sy)
+          let (wx, wy) = @graph_model.screen_to_world(state.viewport, sx, sy)
           let new_interaction : InteractionState = {
             ..state.interaction,
             did_move: true,
           }
-          self.drag_preview = drag_preview_from_move(drag, wx, wy)
+          self.drag_preview = @graph_model.drag_preview_from_move(drag, wx, wy)
           self.interaction = new_interaction
         }
         None =>
           match state.interaction.panning {
             Some(_) => {
-              let next = update_pan_move(state, sx, sy)
+              let next = @graph_model.update_pan_move(state, sx, sy)
               self.viewport = next.viewport
               self.interaction = next.interaction
             }
@@ -784,13 +784,15 @@ fn SourceBackedGraph::pointer_up(
   let state = source_graph_base_canvas_state(self)
   let commit_state = match state.interaction.dragging {
     Some(_) if state.interaction.did_move =>
-      state_with_preview_nodes(state, self.drag_preview)
+      @graph_model.state_with_preview_nodes(state, self.drag_preview)
     _ => state
   }
-  let next = update_pointer_up(commit_state, node_id, target_port_id, additive)
+  let next = @graph_model.update_pointer_up(
+    commit_state, node_id, target_port_id, additive,
+  )
   self.sync_layout_from_state(next)
   self.viewport = next.viewport
-  self.drag_preview = idle_drag_preview()
+  self.drag_preview = @graph_model.idle_drag_preview()
   self.interaction = next.interaction
   self.action_log = next.action_log.copy()
 }
@@ -802,7 +804,12 @@ fn SourceBackedGraph::zoom(
   cx : Double,
   cy : Double,
 ) -> Unit {
-  let next = update_zoom(source_graph_base_canvas_state(self), delta, cx, cy)
+  let next = @graph_model.update_zoom(
+    source_graph_base_canvas_state(self),
+    delta,
+    cx,
+    cy,
+  )
   self.viewport = next.viewport
   self.action_log = next.action_log.copy()
 }

--- a/examples/canvas/main/pkg.generated.mbti
+++ b/examples/canvas/main/pkg.generated.mbti
@@ -3,7 +3,6 @@ package "dowdiness/canopy-canvas/main"
 
 import {
   "dowdiness/canopy-canvas-graph/graph_model",
-  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -67,18 +66,11 @@ pub fn zoom(Int, Double, Double, Double) -> Unit
 // Errors
 
 // Types and methods
-type CanvasDocument derive(Eq, @debug.Debug)
-
 type CanvasFullRenderJson derive(Eq)
 
 type CanvasRuntime
 
 type ConnectingJson derive(Eq, ToJson)
-
-pub(all) struct DragPreview {
-  positions : Array[@graph_model.NodePosition]
-} derive(Eq, @debug.Debug)
-pub impl Show for DragPreview
 
 type EdgeJson derive(Eq, ToJson)
 
@@ -93,8 +85,6 @@ type NodeParamJson derive(Eq, ToJson)
 type NormalizedCanvas derive(Eq)
 
 type RenderStateJson derive(Eq, ToJson)
-
-type SelectionState derive(Eq, @debug.Debug)
 
 type SourceBackedGraph
 
@@ -118,6 +108,8 @@ pub using @graph_model {type CanvasState}
 pub using @graph_model {type ConnectState}
 
 pub using @graph_model {type DragOrigin}
+
+pub using @graph_model {type DragPreview}
 
 pub using @graph_model {type DragState}
 

--- a/lib/canvas-graph/README.md
+++ b/lib/canvas-graph/README.md
@@ -1,5 +1,19 @@
 # Canopy Canvas Graph
 
-Reusable durable graph model for Canopy canvas workflows: typed node, edge, and
-port identifiers; versioned graph operations; JSON round-tripping; replay; and
-connection validation.
+Reusable graph model and pure interaction core for Canopy canvas workflows.
+
+The library owns:
+
+- stable node/edge/port identifiers
+- durable `CanvasState` / `CanvasDocument` graph snapshots
+- versioned `GraphOperation` JSON round-tripping and replay
+- typed connection validation and operation application
+- pure pan, zoom, drag, selection, connect, and pointer release reducers
+- the small runtime seam (`SelectionState`, `DragPreview`, document/state
+  conversion helpers) shared by the hand-built canvas and source-backed mode
+
+The library does **not** own browser DOM/SVG rendering, TypeScript event
+listeners, JS handle registries, or demo-specific workflow validation copy. The
+`examples/canvas` package keeps the incr runtime, JSON DTO lowering, inspector
+text, and FFI exports so applications can choose their own rendering and
+validation surfaces while reusing the model and reducers here.

--- a/lib/canvas-graph/graph_model/interaction_reducers.mbt
+++ b/lib/canvas-graph/graph_model/interaction_reducers.mbt
@@ -22,7 +22,7 @@ fn update_pan_start(
 ///|
 /// Pan is computed as absolute offset from start_pan to avoid
 /// float accumulation across multiple move events.
-fn update_pan_move(
+pub fn update_pan_move(
   state : CanvasState,
   screen_x : Double,
   screen_y : Double,
@@ -50,7 +50,7 @@ fn update_pan_move(
 ///|
 /// Zoom the viewport toward the cursor position `(cx, cy)` in canvas-local
 /// screen coords. Factor 0.9 = zoom out, 1/0.9 ≈ 1.111 = zoom in.
-fn update_zoom(
+pub fn update_zoom(
   state : CanvasState,
   delta : Double,
   cx : Double,
@@ -70,7 +70,7 @@ fn update_zoom(
 }
 
 ///|
-fn screen_to_world(
+pub fn screen_to_world(
   viewport : Viewport,
   sx : Double,
   sy : Double,
@@ -81,7 +81,7 @@ fn screen_to_world(
 ///|
 /// Dispatch a pointer-down event to pan or drag based on node_id.
 /// Accepts screen coordinates; converts to world coords internally for dragging.
-fn update_pointer_down(
+pub fn update_pointer_down(
   state : CanvasState,
   node_id : NodeId?,
   sx : Double,
@@ -98,7 +98,7 @@ fn update_pointer_down(
 
 ///|
 /// Start an edge-creation gesture from a specific output port.
-fn update_connect_start(
+pub fn update_connect_start(
   state : CanvasState,
   node_id : NodeId,
   port_id : String,
@@ -130,7 +130,7 @@ fn update_connect_start(
 }
 
 ///|
-fn update_connect_move(
+pub fn update_connect_move(
   state : CanvasState,
   world_x : Double,
   world_y : Double,
@@ -173,7 +173,7 @@ fn workflow_node_kind_from_key(key : String) -> WorkflowNodeKind {
 }
 
 ///|
-fn workflow_add_node(
+pub fn workflow_add_node(
   state : CanvasState,
   kind_key : String,
   world_x : Double,
@@ -227,20 +227,20 @@ fn update_connect_end(
 }
 
 ///|
-fn drag_preview_from_move(
+pub fn drag_preview_from_move(
   drag : DragState,
   world_x : Double,
   world_y : Double,
 ) -> DragPreview {
-  let positions : Array[NodePosition] = []
-  for origin in drag.origins {
-    positions.push({
-      node_id: origin.node_id,
-      x: world_x + origin.offset_x,
-      y: world_y + origin.offset_y,
-    })
+  {
+    positions: drag.origins.map(fn(origin) {
+      {
+        node_id: origin.node_id,
+        x: world_x + origin.offset_x,
+        y: world_y + origin.offset_y,
+      }
+    }),
   }
-  { positions, }
 }
 
 ///|
@@ -262,19 +262,17 @@ fn update_node_drag_start(
   match find_node(state.nodes, node_id) {
     None => state
     Some(_) => {
-      let drag_ids = drag_ids_for_node(state, node_id)
-      let origins : Array[DragOrigin] = []
-      for drag_id in drag_ids {
+      let origins = drag_ids_for_node(state, node_id).filter_map(fn(drag_id) {
         match find_node(state.nodes, drag_id) {
-          None => ()
+          None => None
           Some(node) =>
-            origins.push({
+            Some({
               node_id: drag_id,
               offset_x: node.x - world_x,
               offset_y: node.y - world_y,
             })
         }
-      }
+      })
       let drag : DragState = { node_id, origins }
       let new_interaction : InteractionState = {
         ..state.interaction,
@@ -292,14 +290,12 @@ fn final_drag_positions(
   state : CanvasState,
   drag : DragState,
 ) -> Array[NodePosition] {
-  let positions : Array[NodePosition] = []
-  for origin in drag.origins {
+  drag.origins.filter_map(fn(origin) {
     match find_node(state.nodes, origin.node_id) {
-      None => ()
-      Some(node) => positions.push({ node_id: node.id, x: node.x, y: node.y })
+      None => None
+      Some(node) => Some({ node_id: node.id, x: node.x, y: node.y })
     }
-  }
-  positions
+  })
 }
 
 ///|
@@ -307,9 +303,7 @@ fn toggle_selection(nodes : Array[NodeId], id : NodeId) -> Array[NodeId] {
   if nodes.iter().any(fn(n) { n == id }) {
     nodes.filter(fn(n) { n != id })
   } else {
-    let next = nodes.copy()
-    next.push(id)
-    next
+    [..nodes, id]
   }
 }
 
@@ -334,7 +328,7 @@ fn selection_after_click(
 /// Handle pointer release. `node_id` is the canvas node id under the pointer,
 /// or "" if released over the background.
 /// A "click" = pointer_down was true AND no movement occurred → select the node.
-fn update_pointer_up(
+pub fn update_pointer_up(
   state : CanvasState,
   node_id : String,
   target_port_id : String,

--- a/lib/canvas-graph/graph_model/interaction_reducers_wbtest.mbt
+++ b/lib/canvas-graph/graph_model/interaction_reducers_wbtest.mbt
@@ -9,7 +9,7 @@ fn make_test_state() -> CanvasState {
     ],
     edges: [],
     next_node_id: 4,
-    interaction: @graph_model.empty_interaction(),
+    interaction: empty_interaction(),
     action_log: [],
   }
 }
@@ -110,7 +110,7 @@ test "node_drag_start records offsets for the dragged node" {
 
 ///|
 test "node_drag_start includes all selected nodes for multi-drag" {
-  let state = @graph_model.apply_action(
+  let state = apply_action(
     make_test_state(),
     SelectNodes([NodeId("1"), NodeId("2")]),
   )
@@ -138,15 +138,8 @@ test "pointer_up records a MoveNodes action after drag" {
     200.0,
     300.0,
   )
-  let moved_nodes = s0.nodes.map(fn(node) {
-    match find_position(preview.positions, node.id) {
-      None => node
-      Some(pos) => { ..node, x: pos.x, y: pos.y }
-    }
-  })
   let s1 = {
-    ..s0,
-    nodes: moved_nodes,
+    ..state_with_preview_nodes(s0, preview),
     interaction: { ..s0.interaction, did_move: true },
   }
   let s2 = update_pointer_up(s1, "1", "", false)
@@ -172,10 +165,7 @@ test "pointer_up on node without movement selects it" {
 
 ///|
 test "additive click toggles multi-selection" {
-  let state = @graph_model.apply_action(
-    make_test_state(),
-    SelectNodes([NodeId("1")]),
-  )
+  let state = apply_action(make_test_state(), SelectNodes([NodeId("1")]))
   let s0 = update_node_drag_start(state, NodeId("2"), 420.0, 100.0)
   let s1 = update_pointer_up(s0, "2", "", true)
   @debug.assert_eq(s1.interaction.selected_nodes, [NodeId("1"), NodeId("2")])
@@ -186,10 +176,7 @@ test "additive click toggles multi-selection" {
 
 ///|
 test "pointer_up on background deselects" {
-  let state = @graph_model.apply_action(
-    make_test_state(),
-    SelectNodes([NodeId("1")]),
-  )
+  let state = apply_action(make_test_state(), SelectNodes([NodeId("1")]))
   let s0 = update_pan_start(state, 0.0, 0.0)
   let s1 = update_pointer_up(s0, "", "", false)
   inspect(s1.interaction.selected is None, content="true")
@@ -298,123 +285,5 @@ test "workflow_add_node creates typed custom nodes through serializable action" 
   match s.action_log[0].action() {
     WorkflowAction::AddNode(node) => assert_eq(node.id, NodeId("4"))
     _ => fail("expected AddNode action")
-  }
-}
-
-///|
-test "validate_workflow reports missing typed input ports independently" {
-  let nodes = make_test_state().nodes.copy()
-  nodes.push(make_workflow_node(NodeId("4"), ConditionalBranch, 0.0, 0.0))
-  let state : CanvasState = {
-    ..make_test_state(),
-    nodes,
-    edges: [
-      {
-        id: EdgeId::from_edge(NodeId("3"), "text", NodeId("4"), "text"),
-        source: NodeId("3"),
-        source_port: "text",
-        target: NodeId("4"),
-        target_port: "text",
-      },
-    ],
-  }
-  let messages = validate_workflow(state)
-  assert_true(
-    messages
-    .iter()
-    .any(fn(message) {
-      message.node_id == Some("4") &&
-      message.message.contains("input \u{201c}rule\u{201d}")
-    }),
-  )
-  assert_false(
-    messages
-    .iter()
-    .any(fn(message) {
-      message.node_id == Some("4") &&
-      message.message.contains("input \u{201c}text\u{201d}")
-    }),
-  )
-}
-
-///|
-test "get_render_state exposes workflow JSON shape" {
-  let handle = create_canvas()
-  let json_str = get_render_state(handle)
-  assert_true(json_str.contains("\"nodes\""))
-  assert_true(json_str.contains("Timer trigger"))
-  assert_true(json_str.contains("\"source_port\""))
-  assert_true(json_str.contains("\"validation\""))
-}
-
-///|
-test "runtime live drag updates preview before one durable MoveNodes commit" {
-  let runtime = CanvasRuntime::CanvasRuntime()
-  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
-  let before = runtime.document.peek()
-  runtime.pointer_down(Some(NodeId("1")), -510.0, -180.0)
-  runtime.pointer_move(-400.0, -100.0)
-
-  let during = runtime.document.peek()
-  inspect(during.nodes[0].x, content="-520")
-  inspect(during.nodes[0].y, content="-190")
-  assert_eq(runtime.actions.peek().length(), 0)
-
-  let preview = runtime.render_state().nodes[0]
-  inspect(preview.x, content="-410")
-  inspect(preview.y, content="-110")
-  assert_eq(before.nodes[0].x, during.nodes[0].x)
-
-  runtime.pointer_up("1", "", false)
-  let after = runtime.document.peek()
-  inspect(after.nodes[0].x, content="-410")
-  inspect(after.nodes[0].y, content="-110")
-  assert_eq(runtime.actions.peek().length(), 1)
-  match runtime.actions.peek()[0].action() {
-    MoveNodes(positions) => {
-      assert_eq(positions.length(), 1)
-      inspect(positions[0].x, content="-410")
-      inspect(positions[0].y, content="-110")
-    }
-    _ => fail("expected MoveNodes action")
-  }
-}
-
-///|
-test "runtime delete_nodes removes selected nodes and incident edges" {
-  let runtime = CanvasRuntime::CanvasRuntime()
-  runtime.delete_nodes([NodeId("2")])
-  let state = runtime.render_state()
-  assert_eq(state.nodes.length(), 5)
-  assert_eq(state.edges.length(), 1)
-  assert_eq(runtime.actions.peek().length(), 1)
-  match runtime.actions.peek()[0].action() {
-    DeleteNodes(nodes) => @debug.assert_eq(nodes, [NodeId("2")])
-    _ => fail("expected DeleteNodes action")
-  }
-}
-
-///|
-test "runtime sparse inspector follows hover until a node is selected" {
-  let runtime = CanvasRuntime::CanvasRuntime()
-  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
-  runtime.hover_node("1")
-  match runtime.render_state().inspector {
-    Some(node) => {
-      inspect(node.source, content="hovered")
-      inspect(node.title, content="Timer trigger")
-    }
-    None => fail("expected hovered inspector")
-  }
-
-  runtime.pointer_down(Some(NodeId("2")), -190.0, -190.0)
-  runtime.pointer_up("2", "", false)
-  runtime.hover_node("1")
-  match runtime.render_state().inspector {
-    Some(node) => {
-      inspect(node.source, content="selected")
-      inspect(node.title, content="HTTP request")
-    }
-    None => fail("expected selected inspector")
   }
 }

--- a/lib/canvas-graph/graph_model/pkg.generated.mbti
+++ b/lib/canvas-graph/graph_model/pkg.generated.mbti
@@ -13,11 +13,23 @@ pub fn apply_operation(CanvasState, GraphOperation) -> CanvasState
 
 pub fn can_commit_edge(CanvasState, NodeId, String, NodeId, String) -> Bool
 
+pub fn canvas_document_from_state(CanvasState) -> CanvasDocument
+
+pub fn canvas_state_from_parts(CanvasDocument, Viewport, InteractionState, Array[GraphOperation]) -> CanvasState
+
+pub fn default_viewport() -> Viewport
+
+pub fn drag_preview_from_move(DragState, Double, Double) -> DragPreview
+
 pub fn empty_interaction() -> InteractionState
 
 pub fn find_node(Array[CanvasNode], NodeId) -> CanvasNode?
 
 pub fn find_position(Array[NodePosition], NodeId) -> NodePosition?
+
+pub fn idle_drag_preview() -> DragPreview
+
+pub fn interaction_with_selection(InteractionState, SelectionState) -> InteractionState
 
 pub fn make_workflow_node(NodeId, WorkflowNodeKind, Double, Double) -> CanvasNode
 
@@ -29,9 +41,35 @@ pub fn record_action(CanvasState, WorkflowAction) -> CanvasState
 
 pub fn replay_operations(CanvasState, Array[GraphOperation]) -> CanvasState
 
+pub fn screen_to_world(Viewport, Double, Double) -> (Double, Double)
+
+pub fn selection_from_interaction(InteractionState) -> SelectionState
+
+pub fn state_with_preview_nodes(CanvasState, DragPreview) -> CanvasState
+
+pub fn update_connect_move(CanvasState, Double, Double) -> CanvasState
+
+pub fn update_connect_start(CanvasState, NodeId, String, Double, Double) -> CanvasState
+
+pub fn update_pan_move(CanvasState, Double, Double) -> CanvasState
+
+pub fn update_pointer_down(CanvasState, NodeId?, Double, Double) -> CanvasState
+
+pub fn update_pointer_up(CanvasState, String, String, Bool) -> CanvasState
+
+pub fn update_zoom(CanvasState, Double, Double, Double) -> CanvasState
+
+pub fn workflow_add_node(CanvasState, String, Double, Double) -> CanvasState
+
 // Errors
 
 // Types and methods
+pub(all) struct CanvasDocument {
+  nodes : Array[CanvasNode]
+  edges : Array[Edge]
+  next_node_id : Int
+} derive(Eq, @debug.Debug)
+
 pub(all) struct CanvasNode {
   id : NodeId
   x : Double
@@ -72,6 +110,11 @@ pub(all) struct DragOrigin {
   offset_y : Double
 } derive(Eq, @debug.Debug)
 pub impl Show for DragOrigin
+
+pub(all) struct DragPreview {
+  positions : Array[NodePosition]
+} derive(Eq, @debug.Debug)
+pub impl Show for DragPreview
 
 pub(all) struct DragState {
   node_id : NodeId
@@ -158,6 +201,11 @@ pub(all) enum PortType {
   Any
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub impl Show for PortType
+
+pub(all) struct SelectionState {
+  selected : NodeId?
+  selected_nodes : Array[NodeId]
+} derive(Eq, @debug.Debug)
 
 pub(all) struct Viewport {
   x : Double

--- a/lib/canvas-graph/graph_model/runtime_state.mbt
+++ b/lib/canvas-graph/graph_model/runtime_state.mbt
@@ -1,0 +1,119 @@
+///|
+/// Durable workflow graph document. High-frequency UI affordances such as
+/// hover, live drag preview, and viewport live outside this value.
+pub(all) struct CanvasDocument {
+  nodes : Array[CanvasNode]
+  edges : Array[Edge]
+  next_node_id : Int
+} derive(Debug, Eq)
+
+///|
+/// Ephemeral live-drag overlay. Empty positions means no active preview;
+/// committed node positions remain in `CanvasDocument` until pointerup.
+pub(all) struct DragPreview {
+  positions : Array[NodePosition]
+} derive(Debug, Eq)
+
+///|
+pub impl Show for DragPreview with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// Selection is its own UI input so sparse inspector surfaces can depend on it
+/// without reading drag/viewport gesture state.
+pub(all) struct SelectionState {
+  selected : NodeId?
+  selected_nodes : Array[NodeId]
+} derive(Debug, Eq)
+
+///|
+pub fn selection_from_interaction(
+  interaction : InteractionState,
+) -> SelectionState {
+  {
+    selected: interaction.selected,
+    selected_nodes: interaction.selected_nodes.copy(),
+  }
+}
+
+///|
+pub fn interaction_with_selection(
+  interaction : InteractionState,
+  selection : SelectionState,
+) -> InteractionState {
+  {
+    ..interaction,
+    selected: selection.selected,
+    selected_nodes: selection.selected_nodes.copy(),
+  }
+}
+
+///|
+pub fn idle_drag_preview() -> DragPreview {
+  { positions: [] }
+}
+
+///|
+pub fn default_viewport() -> Viewport {
+  { x: 760.0, y: 330.0, scale: 0.75 }
+}
+
+///|
+pub fn canvas_document_from_state(state : CanvasState) -> CanvasDocument {
+  {
+    nodes: state.nodes.copy(),
+    edges: state.edges.copy(),
+    next_node_id: state.next_node_id,
+  }
+}
+
+///|
+pub fn canvas_state_from_parts(
+  document : CanvasDocument,
+  viewport : Viewport,
+  interaction : InteractionState,
+  action_log : Array[GraphOperation],
+) -> CanvasState {
+  {
+    viewport,
+    nodes: document.nodes.copy(),
+    edges: document.edges.copy(),
+    next_node_id: document.next_node_id,
+    interaction: interaction_with_selection(
+      interaction,
+      selection_from_interaction(interaction),
+    ),
+    action_log: action_log.copy(),
+  }
+}
+
+///|
+fn preview_position_for(
+  preview : DragPreview,
+  node_id : NodeId,
+) -> NodePosition? {
+  find_position(preview.positions, node_id)
+}
+
+///|
+fn canvas_node_with_preview(
+  node : CanvasNode,
+  preview : DragPreview,
+) -> CanvasNode {
+  match preview_position_for(preview, node.id) {
+    None => node
+    Some(pos) => { ..node, x: pos.x, y: pos.y }
+  }
+}
+
+///|
+pub fn state_with_preview_nodes(
+  state : CanvasState,
+  preview : DragPreview,
+) -> CanvasState {
+  {
+    ..state,
+    nodes: state.nodes.map(fn(node) { canvas_node_with_preview(node, preview) }),
+  }
+}


### PR DESCRIPTION
## Summary

- extract pure pan/zoom/drag/connect/selection reducers from `examples/canvas` into `lib/canvas-graph/graph_model`
- move the shared runtime seam (`CanvasDocument`, `SelectionState`, `DragPreview`, document/state conversion helpers) into the graph model library
- keep demo-specific incr runtime, render DTO lowering, inspector/validation text, FFI exports, and TS bridge in `examples/canvas`
- move reducer white-box coverage to the library and leave runtime/validation integration coverage in the canvas example

Closes #486
Closes #487

## Reuse check

- Reused existing graph-model APIs: `CanvasState`, `GraphOperation`, `WorkflowAction`, `record_action`, `find_node`, `find_position`, `make_workflow_node`, `apply_action`.
- Checked existing API surface with `moon ide outline`, `moon ide doc`, and `moon ide find-references`; `moon ide doc record_action` hit a moon IDE JSON error at workspace root, but package outline/find-references confirmed the existing API.
- New helpers are extracted from the existing example reducer/runtime seam rather than newly invented behavior.
- Remaining imperative code is builder/stateful runtime or source adapter state management; reducer construction was tightened to `map`/`filter_map` where practical.

## Validation

- `NEW_MOON_MOD=0 moon check`
- `NEW_MOON_MOD=0 moon test`
- `cd lib/canvas-graph && NEW_MOON_MOD=0 MOON_WORK=off moon test`
- `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon check --target js`
- `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon test --target js`
- `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon build --target js --release`
- `git diff --check`

Not run: browser `npm run build` / Playwright E2E because `examples/canvas/web/node_modules` is absent and running the E2E script would perform `npm ci`.
