### PR TITLE
test(canvas): add graph runtime contract coverage

### DIFF
--- a/examples/canvas/main/canvas_runtime_contract_wbtest.mbt
+++ b/examples/canvas/main/canvas_runtime_contract_wbtest.mbt
@@ -1,0 +1,263 @@
+///|
+fn contract_runtime_operations(
+  runtime : CanvasRuntime,
+) -> Array[GraphOperation] {
+  ok_operation_log(runtime.action_log_json())
+}
+
+///|
+fn contract_source_graph(handle : Int) -> SourceBackedGraph {
+  match source_graph_by_handle(handle) {
+    Some(graph) => graph
+    None => abort("expected source graph handle")
+  }
+}
+
+///|
+fn contract_state_node(state : CanvasState, id : NodeId) -> CanvasNode {
+  match @graph_model.find_node(state.nodes, id) {
+    Some(node) => node
+    None => abort("missing canvas state node: " + id.to_string())
+  }
+}
+
+///|
+fn contract_render_node(render : RenderStateJson, id : String) -> NodeJson {
+  match render.nodes.search_by(fn(node) { node.id == id }) {
+    Some(index) => render.nodes[index]
+    None => abort("missing render node: " + id)
+  }
+}
+
+///|
+fn contract_assert_close(actual : Double, expected : Double) -> Unit raise {
+  assert_true((actual - expected).abs() < 1.0e-9)
+}
+
+///|
+fn contract_screen_point(
+  viewport : Viewport,
+  world_x : Double,
+  world_y : Double,
+) -> (Double, Double) {
+  (world_x * viewport.scale + viewport.x, world_y * viewport.scale + viewport.y)
+}
+
+///|
+fn contract_expect_move_nodes(
+  operation : GraphOperation,
+  expected : Array[NodePosition],
+) -> Unit raise {
+  match operation.action() {
+    MoveNodes(positions) => @debug.assert_eq(positions, expected)
+    _ => fail("expected MoveNodes action")
+  }
+}
+
+///|
+fn contract_expect_select_nodes(
+  operation : GraphOperation,
+  expected : Array[NodeId],
+) -> Unit raise {
+  match operation.action() {
+    SelectNodes(nodes) => @debug.assert_eq(nodes, expected)
+    _ => fail("expected SelectNodes action")
+  }
+}
+
+///|
+test "runtime contract: pointermove previews before one durable MoveNodes commit" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  let node_id = NodeId("1")
+  let before_node = contract_state_node(runtime.state_peek(), node_id)
+  let (start_sx, start_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    before_node.x,
+    before_node.y,
+  )
+  runtime.pointer_down(Some(node_id), start_sx, start_sy)
+
+  let (mid_sx, mid_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    -410.0,
+    -110.0,
+  )
+  runtime.pointer_move(mid_sx, mid_sy)
+  let during_node = contract_state_node(runtime.state_peek(), node_id)
+  contract_assert_close(during_node.x, before_node.x)
+  contract_assert_close(during_node.y, before_node.y)
+  assert_eq(contract_runtime_operations(runtime).length(), 0)
+  let mid_preview = contract_render_node(runtime.render_state(), "1")
+  contract_assert_close(mid_preview.x, -410.0)
+  contract_assert_close(mid_preview.y, -110.0)
+
+  let (final_sx, final_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    -390.0,
+    -95.0,
+  )
+  runtime.pointer_move(final_sx, final_sy)
+  assert_eq(contract_runtime_operations(runtime).length(), 0)
+  let final_preview = contract_render_node(runtime.render_state(), "1")
+  contract_assert_close(final_preview.x, -390.0)
+  contract_assert_close(final_preview.y, -95.0)
+
+  runtime.pointer_up("1", "", false)
+  let after_node = contract_state_node(runtime.state_peek(), node_id)
+  contract_assert_close(after_node.x, -390.0)
+  contract_assert_close(after_node.y, -95.0)
+  let operations = contract_runtime_operations(runtime)
+  assert_eq(operations.length(), 1)
+  contract_expect_move_nodes(operations[0], [{ node_id, x: -390.0, y: -95.0 }])
+}
+
+///|
+test "runtime contract: panning logs viewport only on pointerup" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  let before = runtime.render_state().viewport
+  runtime.pointer_down(None, 10.0, 20.0)
+  runtime.pointer_move(30.0, 55.0)
+  let during = runtime.render_state()
+  contract_assert_close(during.viewport.x, before.x + 20.0)
+  contract_assert_close(during.viewport.y, before.y + 35.0)
+  assert_eq(during.action_count, 0)
+  assert_eq(contract_runtime_operations(runtime).length(), 0)
+
+  runtime.pointer_move(40.0, 65.0)
+  runtime.pointer_up("", "", false)
+  let after = runtime.render_state()
+  let operations = contract_runtime_operations(runtime)
+  assert_eq(after.action_count, 1)
+  assert_eq(operations.length(), 1)
+  match operations[0].action() {
+    SetViewport(viewport) => @debug.assert_eq(viewport, after.viewport)
+    _ => fail("expected SetViewport action")
+  }
+}
+
+///|
+test "runtime contract: zoom logs one viewport operation immediately" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  runtime.zoom(-1.0, 500.0, 400.0)
+  let after = runtime.render_state()
+  let operations = contract_runtime_operations(runtime)
+  assert_eq(after.action_count, 1)
+  assert_eq(operations.length(), 1)
+  match operations[0].action() {
+    SetViewport(viewport) => @debug.assert_eq(viewport, after.viewport)
+    _ => fail("expected SetViewport action")
+  }
+}
+
+///|
+test "runtime contract: click selection is pointerup-only and additive" {
+  let runtime = CanvasRuntime::CanvasRuntime()
+  let node1 = NodeId("1")
+  let first_node = contract_state_node(runtime.state_peek(), node1)
+  let (one_sx, one_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    first_node.x,
+    first_node.y,
+  )
+  runtime.pointer_down(Some(node1), one_sx, one_sy)
+  assert_eq(runtime.render_state().selected_nodes.length(), 0)
+  assert_eq(contract_runtime_operations(runtime).length(), 0)
+
+  runtime.pointer_up("1", "", false)
+  @debug.assert_eq(runtime.render_state().selected_nodes, ["1"])
+  let first_operations = contract_runtime_operations(runtime)
+  assert_eq(first_operations.length(), 1)
+  contract_expect_select_nodes(first_operations[0], [node1])
+
+  let node2 = NodeId("2")
+  let second_node = contract_state_node(runtime.state_peek(), node2)
+  let (two_sx, two_sy) = contract_screen_point(
+    runtime.render_state().viewport,
+    second_node.x,
+    second_node.y,
+  )
+  runtime.pointer_down(Some(node2), two_sx, two_sy)
+  runtime.pointer_up("2", "", true)
+  @debug.assert_eq(runtime.render_state().selected_nodes, ["1", "2"])
+  let second_operations = contract_runtime_operations(runtime)
+  assert_eq(second_operations.length(), 2)
+  contract_expect_select_nodes(second_operations[1], [node1, node2])
+
+  runtime.pointer_down(Some(node1), one_sx, one_sy)
+  runtime.pointer_up("1", "", true)
+  @debug.assert_eq(runtime.render_state().selected_nodes, ["2"])
+  let third_operations = contract_runtime_operations(runtime)
+  assert_eq(third_operations.length(), 3)
+  contract_expect_select_nodes(third_operations[2], [node2])
+}
+
+///|
+test "source-backed runtime contract: pointermove previews before one local MoveNodes commit" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let graph = contract_source_graph(handle)
+  let osc = handle_token(handle, "osc")
+  let before = source_graph_base_canvas_state(graph)
+  let before_node = contract_state_node(before, osc)
+  let (start_sx, start_sy) = contract_screen_point(
+    before.viewport,
+    before_node.x,
+    before_node.y,
+  )
+  source_graph_pointer_down(handle, osc.to_string(), start_sx, start_sy)
+
+  let (mid_sx, mid_sy) = contract_screen_point(before.viewport, 80.0, 40.0)
+  source_graph_pointer_move(handle, mid_sx, mid_sy)
+  let durable_during = contract_state_node(
+    source_graph_base_canvas_state(graph),
+    osc,
+  )
+  contract_assert_close(durable_during.x, before_node.x)
+  contract_assert_close(durable_during.y, before_node.y)
+  assert_eq(ok_operation_log(get_source_graph_action_log(handle)).length(), 0)
+  let mid_preview = contract_state_node(source_graph_canvas_state(graph), osc)
+  contract_assert_close(mid_preview.x, 80.0)
+  contract_assert_close(mid_preview.y, 40.0)
+
+  let (final_sx, final_sy) = contract_screen_point(before.viewport, 90.0, 60.0)
+  source_graph_pointer_move(handle, final_sx, final_sy)
+  assert_eq(ok_operation_log(get_source_graph_action_log(handle)).length(), 0)
+  let final_preview = contract_state_node(source_graph_canvas_state(graph), osc)
+  contract_assert_close(final_preview.x, 90.0)
+  contract_assert_close(final_preview.y, 60.0)
+
+  source_graph_pointer_up(handle, osc.to_string(), "", false)
+  let after_node = contract_state_node(
+    source_graph_base_canvas_state(graph),
+    osc,
+  )
+  contract_assert_close(after_node.x, 90.0)
+  contract_assert_close(after_node.y, 60.0)
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  assert_eq(operations.length(), 1)
+  contract_expect_move_nodes(operations[0], [{ node_id: osc, x: 90.0, y: 60.0 }])
+  destroy_source_graph(handle)
+}
+
+///|
+test "source-backed runtime contract: panning logs viewport only on pointerup" {
+  let handle = create_source_graph("osc = sine(freq: 440Hz)\nmeter = scope()")
+  let graph = contract_source_graph(handle)
+  let before = source_graph_base_canvas_state(graph).viewport
+  source_graph_pointer_down(handle, "", 10.0, 20.0)
+  source_graph_pointer_move(handle, 30.0, 55.0)
+  let during = source_graph_base_canvas_state(graph)
+  contract_assert_close(during.viewport.x, before.x + 20.0)
+  contract_assert_close(during.viewport.y, before.y + 35.0)
+  assert_eq(ok_operation_log(get_source_graph_action_log(handle)).length(), 0)
+
+  source_graph_pointer_move(handle, 40.0, 65.0)
+  source_graph_pointer_up(handle, "", "", false)
+  let after = source_graph_base_canvas_state(graph)
+  let operations = ok_operation_log(get_source_graph_action_log(handle))
+  assert_eq(operations.length(), 1)
+  match operations[0].action() {
+    SetViewport(viewport) => @debug.assert_eq(viewport, after.viewport)
+    _ => fail("expected SetViewport action")
+  }
+  destroy_source_graph(handle)
+}

--- a/examples/canvas/main/canvas_runtime_wbtest.mbt
+++ b/examples/canvas/main/canvas_runtime_wbtest.mbt
@@ -63,39 +63,6 @@ test "get_render_state exposes workflow JSON shape" {
 }
 
 ///|
-test "runtime live drag updates preview before one durable MoveNodes commit" {
-  let runtime = CanvasRuntime::CanvasRuntime()
-  runtime.viewport.set({ x: 0.0, y: 0.0, scale: 1.0 })
-  let before = runtime.document.peek()
-  runtime.pointer_down(Some(NodeId("1")), -510.0, -180.0)
-  runtime.pointer_move(-400.0, -100.0)
-
-  let during = runtime.document.peek()
-  inspect(during.nodes[0].x, content="-520")
-  inspect(during.nodes[0].y, content="-190")
-  assert_eq(runtime.actions.peek().length(), 0)
-
-  let preview = runtime.render_state().nodes[0]
-  inspect(preview.x, content="-410")
-  inspect(preview.y, content="-110")
-  assert_eq(before.nodes[0].x, during.nodes[0].x)
-
-  runtime.pointer_up("1", "", false)
-  let after = runtime.document.peek()
-  inspect(after.nodes[0].x, content="-410")
-  inspect(after.nodes[0].y, content="-110")
-  assert_eq(runtime.actions.peek().length(), 1)
-  match runtime.actions.peek()[0].action() {
-    MoveNodes(positions) => {
-      assert_eq(positions.length(), 1)
-      inspect(positions[0].x, content="-410")
-      inspect(positions[0].y, content="-110")
-    }
-    _ => fail("expected MoveNodes action")
-  }
-}
-
-///|
 test "runtime delete_nodes removes selected nodes and incident edges" {
   let runtime = CanvasRuntime::CanvasRuntime()
   runtime.delete_nodes([NodeId("2")])


### PR DESCRIPTION
## Summary

- Closes #614 by moving runtime behavior coverage into a dedicated `canvas_runtime_contract_wbtest.mbt` file.
- Adds observable contract tests for runtime drag preview vs durable commit, pan/zoom action logging, selection transitions, and source-backed parity.
- Removes the older live-drag test that asserted `@incr.Input` field layout directly.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ok_operation_log` | `examples/canvas/main/graph_dsl_adapter_wbtest.mbt` | Yes | Reused to decode action logs instead of adding another parser. |
| `handle_token` | `examples/canvas/main/graph_dsl_adapter_wbtest.mbt` | Yes | Reused to fetch source-backed tracker tokens. |
| `CanvasRuntime::render_state` / `CanvasRuntime::action_log_json` | `examples/canvas/main/canvas_runtime.mbt` | Yes | Tests assert observable runtime output instead of reading `@incr.Input` fields. |
| `source_graph_base_canvas_state` / `source_graph_canvas_state` | `examples/canvas/main/graph_dsl_adapter.mbt` | Yes | Tests compare source-backed durable state and preview overlay behavior through existing seams. |
| `@graph_model.find_node` | `lib/canvas-graph/graph_model/model.mbt` | Yes | Reused for node lookup in contract assertions. |

New helpers added:

- `contract_runtime_operations`: small test-only wrapper around existing `ok_operation_log(runtime.action_log_json())`.
- `contract_source_graph`: test-only handle unwrap with a clear failure message.
- `contract_state_node` / `contract_render_node`: test-only observable node lookup helpers.
- `contract_assert_close`: test-only floating-point equality tolerance for viewport/layout assertions.
- `contract_screen_point`: test-only inverse of viewport lowering needed to drive pointer APIs from desired world positions.
- `contract_expect_move_nodes` / `contract_expect_select_nodes`: test-only action shape assertions.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (no `.mbti` diff)
- [ ] JS rebuild run if web is affected (`cd examples/web && npm run build`) — N/A, test-only canvas MoonBit changes; canvas JS-target checks were run instead.

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon check --target js
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon test --target js
git diff --check
```
