### PR TITLE
fix(lambda): preserve typed fn binding rewrites

### DIFF
--- a/lang/lambda/edits/text_edit_binding.mbt
+++ b/lang/lambda/edits/text_edit_binding.mbt
@@ -38,22 +38,21 @@ fn compute_duplicate_binding(
     Err(e) => return Err(e)
   }
   let def = module_projection.defs[def_index]
-  let (let_start, binding_end) = match
-    get_binding_text_range(source_text, source_map, def) {
-    Ok(r) => r
+  let binding_source = match
+    binding_rewrite_source(source_text, source_map, def) {
+    Ok(source) => source
     Err(e) => return Err(e)
   }
   // Create copy with _copy suffix on name, preserving source syntax such as
   // `fn` parameter annotations instead of reprinting the desugared Lam spine.
   let new_name = def.0 + "_copy"
   let new_binding = match
-    renamed_binding_text(
-      source_text, source_map, def, let_start, binding_end, new_name,
-    ) {
+    binding_source.renamed_text(source_text, source_map, new_name) {
     Ok(text) => text
     Err(e) => return Err(e)
   }
   // Insert after the current binding (after newline)
+  let binding_end = binding_source.binding_end
   let insert_pos = if binding_end < source_text.length() &&
     source_text[binding_end] == '\n' {
     binding_end + 1

--- a/lang/lambda/edits/text_edit_binding_source.mbt
+++ b/lang/lambda/edits/text_edit_binding_source.mbt
@@ -1,0 +1,232 @@
+///|
+fn binding_starts_with_fn(source_text : String, start : Int) -> Bool {
+  start + 2 <= source_text.length() &&
+  source_text[start] == 'f' &&
+  source_text[start + 1] == 'n' &&
+  (
+    start + 2 == source_text.length() ||
+    !is_identifier_code(source_text[start + 2])
+  )
+}
+
+///|
+priv enum BindingRewriteKind {
+  ValueBinding
+  FnBinding
+}
+
+///|
+/// Source-owned metadata for binding rewrites.
+///
+/// Lambda projection intentionally stores function definitions as desugared
+/// Lam spines, so parameter type annotations and `fn` block shape do not live
+/// in `def.1.kind`. Binding-level edits that duplicate, rename, or inline a
+/// source binding must go through this bounded source metadata layer instead
+/// of reprinting the projected Term. If the source spans cannot be recovered,
+/// reject the edit rather than falling back to a lossy `@ast.print_term` rewrite.
+priv struct BindingRewriteSource {
+  def : (String, ProjNode[@ast.Term], Int, NodeId)
+  binding_start : Int
+  binding_end : Int
+  kind : BindingRewriteKind
+}
+
+///|
+fn binding_name_range(
+  source_text : String,
+  source_map : SourceMap,
+  def : (String, ProjNode[@ast.Term], Int, NodeId),
+  binding_start : Int,
+  binding_end : Int,
+) -> Result[(Int, Int), String] {
+  match source_map.get_token_span(def.3, @lambda_proj.LET_DEF_NAME_ROLE) {
+    Some(r) => Ok((r.start, r.end))
+    None =>
+      tight_name_range(
+        source_text,
+        @loomcore.Range::new(binding_start, binding_end),
+        def.0,
+      )
+  }
+}
+
+///|
+fn binding_rewrite_source(
+  source_text : String,
+  source_map : SourceMap,
+  def : (String, ProjNode[@ast.Term], Int, NodeId),
+) -> Result[BindingRewriteSource, String] {
+  let (binding_start, binding_end) = match
+    get_binding_text_range(source_text, source_map, def) {
+    Ok(r) => r
+    Err(e) => return Err(e)
+  }
+  let binding_kind_start = match
+    first_non_space_in_range(
+      source_text,
+      @loomcore.Range::new(binding_start, binding_end),
+    ) {
+    Some(pos) => pos
+    None => binding_start
+  }
+  let kind = if binding_starts_with_fn(source_text, binding_kind_start) {
+    FnBinding
+  } else {
+    ValueBinding
+  }
+  Ok({ def, binding_start, binding_end, kind })
+}
+
+///|
+fn BindingRewriteSource::renamed_text(
+  self : BindingRewriteSource,
+  source_text : String,
+  source_map : SourceMap,
+  new_name : String,
+) -> Result[String, String] {
+  let (name_start, name_end) = match
+    binding_name_range(
+      source_text,
+      source_map,
+      self.def,
+      self.binding_start,
+      self.binding_end,
+    ) {
+    Ok(r) => r
+    Err(e) => return Err(e)
+  }
+  Ok(
+    source_text[self.binding_start:name_start].to_owned() +
+    new_name +
+    source_text[name_end:self.binding_end].to_owned(),
+  )
+}
+
+///|
+fn trimmed_source_text(source_text : String, range : @loomcore.Range) -> String {
+  let start = match first_non_space_in_range(source_text, range) {
+    Some(pos) => pos
+    None => range.start
+  }
+  // Mutable end walks backward over trivia without allocating an intermediate slice.
+  let mut end = range.end
+  // Stateful backward scan is bounded to the source range and stops at content.
+  while end > start && is_space_code(source_text[end - 1]) {
+    end = end - 1
+  }
+  source_text[start:end].to_owned()
+}
+
+///|
+fn find_char_in_range(
+  source_text : String,
+  needle : UInt16,
+  start : Int,
+  end : Int,
+) -> Int? {
+  for pos in start..<end {
+    if source_text[pos] == needle {
+      return Some(pos)
+    }
+  }
+  None
+}
+
+///|
+fn range_has_non_space(source_text : String, start : Int, end : Int) -> Bool {
+  for pos in start..<end {
+    if !is_space_code(source_text[pos]) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn matching_right_paren(
+  source_text : String,
+  open_pos : Int,
+  end : Int,
+) -> Result[Int, String] {
+  // Tiny source scanner state machine: depth tracks nested parens in types.
+  let mut depth = 0
+  for pos in open_pos..<end {
+    if source_text[pos] == '(' {
+      depth = depth + 1
+    } else if source_text[pos] == ')' {
+      depth = depth - 1
+      if depth == 0 {
+        return Ok(pos)
+      }
+    }
+  }
+  Err("Cannot inline fn binding: parameter list end not found")
+}
+
+///|
+fn fn_binding_inline_text(
+  source_text : String,
+  binding_start : Int,
+  binding_end : Int,
+) -> Result[String, String] {
+  let param_start = match
+    find_char_in_range(source_text, '(', binding_start, binding_end) {
+    Some(pos) => pos
+    None => return Err("Cannot inline fn binding: parameter list not found")
+  }
+  let param_end = match
+    matching_right_paren(source_text, param_start, binding_end) {
+    Ok(pos) => pos + 1
+    Err(e) => return Err(e)
+  }
+  let body_start = match
+    first_non_space_in_range(
+      source_text,
+      @loomcore.Range::new(param_end, binding_end),
+    ) {
+    Some(pos) => pos
+    None => return Err("Cannot inline fn binding: body not found")
+  }
+  if source_text[body_start] != '{' {
+    return Err("Cannot inline fn binding: expected block body")
+  }
+  let params = source_text[param_start:param_end].to_owned()
+  let body = trimmed_source_text(
+    source_text,
+    @loomcore.Range::new(body_start, binding_end),
+  )
+  if range_has_non_space(source_text, param_start + 1, param_end - 1) {
+    Ok("(" + params + " => " + body + ")")
+  } else {
+    Ok(body)
+  }
+}
+
+///|
+fn BindingRewriteSource::inline_text(
+  self : BindingRewriteSource,
+  source_text : String,
+  source_map : SourceMap,
+) -> Result[String, String] {
+  match self.kind {
+    FnBinding =>
+      fn_binding_inline_text(source_text, self.binding_start, self.binding_end)
+    ValueBinding =>
+      match source_map.get_range(self.def.1.id()) {
+        Some(r) => Ok(trimmed_source_text(source_text, r))
+        None => Err("Cannot inline binding: init source range not found")
+      }
+  }
+}
+
+///|
+fn binding_inline_text(
+  source_text : String,
+  source_map : SourceMap,
+  def : (String, ProjNode[@ast.Term], Int, NodeId),
+) -> Result[String, String] {
+  match binding_rewrite_source(source_text, source_map, def) {
+    Ok(source) => source.inline_text(source_text, source_map)
+    Err(e) => Err(e)
+  }
+}

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -83,17 +83,6 @@ fn ensure_replaceable_node_range(
 }
 
 ///|
-fn binding_starts_with_fn(source_text : String, start : Int) -> Bool {
-  start + 2 <= source_text.length() &&
-  source_text[start] == 'f' &&
-  source_text[start + 1] == 'n' &&
-  (
-    start + 2 == source_text.length() ||
-    !is_identifier_code(source_text[start + 2])
-  )
-}
-
-///|
 /// Find a module binding's index in module_projection.defs by its NodeId.
 fn find_def_index(
   module_projection : ModuleProjection,
@@ -163,75 +152,4 @@ fn get_binding_text_range(
     return Err("Binding start out of source range")
   }
   Ok((def.2, binding_end))
-}
-
-///|
-fn binding_name_range(
-  source_text : String,
-  source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
-  binding_start : Int,
-  binding_end : Int,
-) -> Result[(Int, Int), String] {
-  match source_map.get_token_span(def.3, @lambda_proj.LET_DEF_NAME_ROLE) {
-    Some(r) => Ok((r.start, r.end))
-    None =>
-      tight_name_range(
-        source_text,
-        @loomcore.Range::new(binding_start, binding_end),
-        def.0,
-      )
-  }
-}
-
-///|
-fn renamed_binding_text(
-  source_text : String,
-  source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
-  binding_start : Int,
-  binding_end : Int,
-  new_name : String,
-) -> Result[String, String] {
-  let (name_start, name_end) = match
-    binding_name_range(source_text, source_map, def, binding_start, binding_end) {
-    Ok(r) => r
-    Err(e) => return Err(e)
-  }
-  Ok(
-    source_text[binding_start:name_start].to_owned() +
-    new_name +
-    source_text[name_end:binding_end].to_owned(),
-  )
-}
-
-///|
-fn trimmed_source_text(source_text : String, range : @loomcore.Range) -> String {
-  let start = match first_non_space_in_range(source_text, range) {
-    Some(pos) => pos
-    None => range.start
-  }
-  // Mutable end walks backward over trivia without allocating an intermediate slice.
-  let mut end = range.end
-  // Stateful backward scan is bounded to the source range and stops at content.
-  while end > start && is_space_code(source_text[end - 1]) {
-    end = end - 1
-  }
-  source_text[start:end].to_owned()
-}
-
-///|
-fn binding_inline_text(
-  source_text : String,
-  source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
-) -> Result[String, String] {
-  if binding_starts_with_fn(source_text, def.2) {
-    Err("Cannot inline fn binding while preserving parameter annotations")
-  } else {
-    match source_map.get_range(def.1.id()) {
-      Some(r) => Ok(trimmed_source_text(source_text, r))
-      None => Ok(@ast.print_term(def.1.kind))
-    }
-  }
 }

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -797,7 +797,7 @@ test "compute_text_edit: DuplicateBinding on last binding" {
 
 ///|
 test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
-  let text = "fn id(x : Int) { x }\nid 1"
+  let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
@@ -811,7 +811,7 @@ test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
       let new_text = apply_edits(text, edits)
       inspect(
         new_text,
-        content="fn id(x : Int) { x }\nfn id_copy(x : Int) { x }\nid 1",
+        content="fn twice(f : Int -> Int, x : Int) { f x }\nfn twice_copy(f : Int -> Int, x : Int) { f x }\ntwice",
       )
     }
     _ => fail("expected Some edits")
@@ -1146,8 +1146,8 @@ test "compute_text_edit: InlineAllUsages with unknown binding returns error" {
 }
 
 ///|
-test "compute_text_edit: InlineAllUsages rejects fn binding with usages" {
-  let text = "fn id(x : Int) { x }\nid"
+test "compute_text_edit: InlineAllUsages preserves typed fn binding" {
+  let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice id 1"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
@@ -1156,15 +1156,18 @@ test "compute_text_edit: InlineAllUsages rejects fn binding with usages" {
     InlineAllUsages(binding_node_id=fp.defs[0].3),
     make_edit_ctx(text, source_map, registry, fp),
   )
-  @debug.debug_inspect(
-    result,
-    content="Err(\"Cannot inline fn binding while preserving parameter annotations\")",
-  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="((f : Int -> Int, x : Int) => { f x }) id 1")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
 }
 
 ///|
-test "compute_text_edit: InlineDefinition rejects fn binding" {
-  let text = "fn id(x : Int) { x }\nid"
+test "compute_text_edit: InlineDefinition preserves typed fn binding" {
+  let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
@@ -1174,10 +1177,55 @@ test "compute_text_edit: InlineDefinition rejects fn binding" {
     InlineDefinition(node_id=body.id()),
     make_edit_ctx(text, source_map, registry, fp),
   )
-  @debug.debug_inspect(
-    result,
-    content="Err(\"Cannot inline fn binding while preserving parameter annotations\")",
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="((f : Int -> Int, x : Int) => { f x })")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: InlineDefinition preserves indented typed fn binding" {
+  let text = "  fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, source_map, registry, fp),
   )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="((f : Int -> Int, x : Int) => { f x })")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: InlineDefinition zero-param fn uses block body" {
+  let text = "fn answer() { 42 }\nanswer"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="{ 42 }")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Preserve Lambda typed `fn` binding metadata through source-owned binding rewrites.
- DuplicateBinding now copies/renames binding source through a bounded metadata layer instead of reprinting desugared `Lam` spines.
- InlineDefinition / InlineAllUsages now preserve typed `fn` annotations by lowering source `fn` bindings to annotated arrow-lambda source when needed.

Closes #622.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `get_binding_text_range` | `lang/lambda/edits/text_edit_utils.mbt` | Yes | Reused as the source-span boundary for binding rewrites. |
| `SourceMap::get_range` / `SourceMap::get_token_span` | `dowdiness/canopy/core` | Yes | Reused for init ranges and binding-name token spans. |
| `tight_name_range` | `lang/lambda/edits/text_edit_rename.mbt` | Yes | Reused as fallback binding-name range discovery. |
| `first_non_space_in_range` | `lang/lambda/edits/text_edit_utils.mbt` | Yes | Reused for trivia-aware binding kind and body detection. |

New helpers added (if any):

- `BindingRewriteSource` / `BindingRewriteKind`: package-private metadata boundary for source-owned binding rewrites; needed because `ModuleProjection.defs` stores desugared `Lam` terms without typed parameter source.
- `binding_rewrite_source`, `BindingRewriteSource::renamed_text`, `BindingRewriteSource::inline_text`: centralize duplicate/inline source reconstruction so future binding edits do not fall back to lossy `@ast.print_term(def.1.kind)`.
- `fn_binding_inline_text`, `matching_right_paren`, `find_char_in_range`, `range_has_non_space`, `trimmed_source_text`: small package-private source scanners/slicers for reconstructing annotated arrow-lambda source from `fn` binding text. No existing parser API exposes typed parameter-list source as an edit-ready fragment.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild not run; no web/JS artifacts affected

## Validation

```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon check --deny-warn lang/lambda/edits lang/lambda/proj
NEW_MOON_MOD=0 moon test lang/lambda/edits lang/lambda/proj
NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
```
