### PR TITLE
docs: document range/span unit boundaries

### DIFF
--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -4,6 +4,9 @@
 ///|
 /// Generic projection node parameterized by AST type T.
 /// `kind : T` holds the AST node, `children : Array[ProjNode[T]]` holds child projections.
+/// `start` and `end` are UTF-16 code-unit source offsets, interpreted as a
+/// half-open range `[start, end)`. They are not eg-walker item-space positions
+/// and not ProseMirror tree positions.
 pub struct ProjNode[T] {
   node_id : Int
   kind : T
@@ -52,9 +55,10 @@ pub fn[T] ProjNode::leaf(
 }
 
 ///|
-/// Construct a ProjNode with explicit span and children, assigning a fresh id.
-/// Use this for projection branches whose identity is fresh for this build;
-/// keep `ProjNode::new` when preserving or reusing a known node id.
+/// Construct a ProjNode with explicit UTF-16 source span and children,
+/// assigning a fresh id. Use this for projection branches whose identity is
+/// fresh for this build; keep `ProjNode::new` when preserving or reusing a
+/// known node id.
 pub fn[T] ProjNode::branch(
   kind : T,
   start : Int,

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -1,19 +1,22 @@
-// SourceMap: Bidirectional mapping between AST nodes and text positions
-// Enables efficient lookup in both directions for projectional editing
+// SourceMap: Bidirectional mapping between AST nodes and UTF-16 source ranges.
+// Enables efficient lookup in both directions for projectional editing.
 
 ///|
 using @loomcore {type Range}
 
 ///|
-/// Maps between AST node IDs and their text positions
+/// Maps between AST node IDs and half-open UTF-16 code-unit source ranges.
+/// Ranges here are `@loomcore.Range`; do not pass eg-walker item-space ranges
+/// or ProseMirror tree positions to SourceMap APIs.
 pub struct SourceMap {
-  /// NodeId → Range mapping
+  /// NodeId → UTF-16 source range mapping
   node_to_range : Map[NodeId, Range]
   /// Reverse index: position → candidate NodeIds (for point queries)
   /// Uses a simple array of (range, node_id) tuples sorted by start
   ranges : Array[(Range, NodeId)]
-  /// Token-level spans within nodes (e.g., param name in lambda, binding name in let).
-  /// Outer key = NodeId of containing node, inner key = token role name, value = Range.
+  /// Token-level UTF-16 source spans within nodes (e.g., param name in lambda,
+  /// binding name in let). Outer key = NodeId of containing node, inner key =
+  /// token role name, value = Range.
   token_spans : Map[NodeId, Map[String, Range]]
 } derive(Debug, Eq)
 
@@ -100,7 +103,7 @@ pub fn[T] SourceMap::patch_subtree(
 }
 
 ///|
-/// Get the text range for a node
+/// Get the half-open UTF-16 source range for a node.
 pub fn SourceMap::get_range(self : SourceMap, node_id : NodeId) -> Range? {
   self.node_to_range.get(node_id)
 }
@@ -119,7 +122,7 @@ fn SourceMap::node_to_range_at_position(
 }
 
 ///|
-/// Find all nodes that contain a given position.
+/// Find all nodes that contain a given UTF-16 source offset.
 /// Returns nodes sorted by containing-range length descending — outermost
 /// (largest range) first, innermost (smallest range) last. Agrees with
 /// `innermost_node_at`'s `minimum_by_length` semantics: the last element is
@@ -142,7 +145,7 @@ pub fn SourceMap::nodes_at_position(
 }
 
 ///|
-/// Find the innermost (smallest) node containing a position
+/// Find the innermost (smallest) node containing a UTF-16 source offset.
 pub fn SourceMap::innermost_node_at(
   self : SourceMap,
   position : Int,
@@ -168,7 +171,7 @@ pub fn SourceMap::innermost_node_at(
 }
 
 ///|
-/// Find nodes whose ranges overlap with a given range
+/// Find nodes whose UTF-16 source ranges overlap with a given range.
 pub fn SourceMap::nodes_in_range(
   self : SourceMap,
   range : Range,
@@ -186,7 +189,8 @@ pub fn SourceMap::nodes_in_range(
 }
 
 ///|
-/// Shift a range by `delta` using the same deletion semantics as node ranges.
+/// Shift a UTF-16 source range by `delta` using the same deletion semantics as
+/// node ranges.
 fn shift_range(
   r : Range,
   edit_start : Int,
@@ -208,7 +212,7 @@ fn shift_range(
 }
 
 ///|
-/// Update positions after a text deletion.
+/// Update UTF-16 source positions after a text deletion.
 /// Shifts all node ranges and token spans after the deleted range backward.
 pub fn SourceMap::apply_edit(
   self : SourceMap,
@@ -264,9 +268,9 @@ pub fn SourceMap::node_count(self : SourceMap) -> Int {
 }
 
 ///|
-/// Set a token-level span for a specific role within a node.
+/// Set a token-level UTF-16 source span for a specific role within a node.
 /// For example, set_token_span(lambda_id, "param", Range::new(2, 3))
-/// records that the param name occupies characters 2..3.
+/// records that the param name occupies source offsets 2..3.
 pub fn SourceMap::set_token_span(
   self : SourceMap,
   node_id : NodeId,

--- a/core/types.mbt
+++ b/core/types.mbt
@@ -34,6 +34,9 @@ pub impl ToJson for NodeId with fn to_json(self) {
 
 ///|
 /// A text span replacement computed by an edit handler.
+/// `start` and `delete_len` are UTF-16 code-unit offsets/lengths in the
+/// source document coordinate space. Multi-edit arrays are applied in reverse
+/// document order so each edit can use the original source coordinates.
 pub(all) struct SpanEdit {
   start : Int
   delete_len : Int
@@ -95,7 +98,7 @@ fn escape_for_show(s : String) -> String {
 
 ///|
 /// Hint for where to place the cursor after a structural edit.
-/// MoveCursor(position~) uses post-edit coordinates.
+/// MoveCursor(position~) uses post-edit UTF-16 code-unit coordinates.
 pub(all) enum FocusHint {
   RestoreCursor
   MoveCursor(position~ : Int)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -81,10 +81,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: 16 `find_token(...to_raw())` callsites remain, but views pattern + `token_text()` already reduce the ergonomic pain. Nice-to-have polish.
   Exit: `pub fn[K : ToRawKind] SyntaxNode::find(self, kind : K) -> SyntaxToken?` in seam.
 
-- [ ] `lib/range` foundational package.
-  Why: Range (`{ start: Int, end: Int }`) is defined twice (loom/core, event-graph-walker/text) and represented implicitly in seam. A shared `lib/range` package at the bottom of the dependency graph would: (a) unify the duplicate definitions, (b) enable `SyntaxToken::range()` / `SyntaxNode::range()` in seam, (c) retire rle's `FromRange` trait.
-  Touches: lib/range (new), seam, loom/core, rle, canopy/core, event-graph-walker/text. Cross-submodule refactoring.
-  Exit: one Range type used by all layers.
+- [x] Reassess shared `lib/range` primitive for range/span units.
+  Why: issue #415 found repeated range-shaped values across SourceMap, protocol, editor text edits, Loom/seam syntax offsets, and eg-walker item-space positions. `moonbitlang/core/range` was also checked, but it is iteration-only today (`iter` + sealed `Step`) and has no span value type. A single `Range[Int]` would erase the unit distinctions pinned by #216 and PR #555.
+  Decision: do **not** introduce a shared `lib/range` primitive now. Keep `@loomcore.Range` for SourceMap/projection UTF-16 source spans, keep `@text.Pos` / `@text.Range` for eg-walker item-space, keep protocol fields as JSON numbers with explicit unit docs, and add unit-specific wrappers only at concrete risky boundaries.
+  Exit: accepted decision in `docs/decisions/2026-06-13-range-span-unit-boundaries.md`; public/cross-package range docs list units explicitly.
 
 - [ ] Unify Token and SyntaxKind into a single enum (rowan style).
   Why: Token and SyntaxKind overlap — every Token variant has a corresponding SyntaxKind variant. Two independent `to_raw()` impls with hardcoded integers can desynchronize.

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -17,8 +17,8 @@ Refresh with: `NEW_MOON_MOD=0 moon ide outline <pkg>` or `NEW_MOON_MOD=0 moon id
 | `NodeId::from_int` | `core/` | Construct from raw int (avoid unless crossing FFI boundary). |
 | `next_proj_node_id(counter)` | `core/` | Monotonic counter for fresh `ProjNode` IDs. Prefer the constructors below in projection builders. |
 | `ProjNode[T]` | `core/` | Generic projection node carrying value `T`. |
-| `ProjNode::leaf(kind, syntax_node, counter)` | `core/` | Fresh childless projection node spanning a `SyntaxNode`. Preferred for CST leaf projections. |
-| `ProjNode::branch(kind, start, end, children, counter)` | `core/` | Fresh projection node with explicit span and children. Use `ProjNode::new` only when preserving/reusing a known ID. |
+| `ProjNode::leaf(kind, syntax_node, counter)` | `core/` | Fresh childless projection node spanning a `SyntaxNode` in UTF-16 code-unit source offsets. Preferred for CST leaf projections. |
+| `ProjNode::branch(kind, start, end, children, counter)` | `core/` | Fresh projection node with explicit half-open UTF-16 source span. Use `ProjNode::new` only when preserving/reusing a known ID. |
 
 **Do not:** Create parallel `id: Int` fields or ad-hoc node numbering.
 
@@ -28,15 +28,19 @@ Refresh with: `NEW_MOON_MOD=0 moon ide outline <pkg>` or `NEW_MOON_MOD=0 moon id
 
 **Want:** Map node IDs to text ranges, or find nodes at a cursor position.
 
+`SourceMap` ranges are `@loomcore.Range` values interpreted as half-open
+UTF-16 code-unit source offsets. Do not pass eg-walker item-space ranges or
+ProseMirror tree positions to this API.
+
 | API | Location | Notes |
 |-----|----------|-------|
 | `SourceMap` | `core/` | Canonical position index. One per editor instance. |
 | `SourceMap::new()` | `core/` | Constructor. |
-| `SourceMap::get_range(node_id)` | `core/` | `Range?` for a node. |
-| `SourceMap::nodes_at_position(pos)` | `core/` | All nodes covering a position. |
-| `SourceMap::innermost_node_at(pos)` | `core/` | Deepest node at cursor. Use for hover/click. |
-| `SourceMap::nodes_in_range(range)` | `core/` | All nodes overlapping a range. |
-| `SourceMap::apply_edit(edit)` | `core/` | Update ranges after a text edit. Call this, don't rebuild. |
+| `SourceMap::get_range(node_id)` | `core/` | `@loomcore.Range?` for a node, in UTF-16 source offsets. |
+| `SourceMap::nodes_at_position(pos)` | `core/` | All nodes covering a UTF-16 source offset. |
+| `SourceMap::innermost_node_at(pos)` | `core/` | Deepest node at a UTF-16 source offset. Use for hover/click. |
+| `SourceMap::nodes_in_range(range)` | `core/` | All nodes overlapping a UTF-16 source range. |
+| `SourceMap::apply_edit(edit_start, old_range)` | `core/` | Update ranges after a text deletion. Both arguments use UTF-16 source offsets. Call this, don't rebuild. |
 | `SourceMap::rebuild_ranges()` | `core/` | Full rebuild (expensive — prefer `apply_edit`). |
 | `SourceMap::set_token_span` | `core/` | Use for computed token-level ranges. |
 | `SourceMap::set_span_from_token` | `core/` | Preferred direct-token registration helper: finds a direct visible token on a `SyntaxNode` and records its range. |

--- a/docs/decisions/2026-06-13-range-span-unit-boundaries.md
+++ b/docs/decisions/2026-06-13-range-span-unit-boundaries.md
@@ -1,0 +1,64 @@
+# Range/span unit boundaries
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Closes:** GitHub issue #415 once the documentation slice lands
+**Related:** GitHub issue #216 · PR #555 · [API position units](../development/API_REFERENCE.md#position-units) · [protocol unit table](../../protocol/README.md#position-and-offset-units)
+
+## Why this record exists
+
+Canopy has several range-shaped concepts: source-map ranges, protocol spans,
+editor text edits, Loom/seam syntax offsets, and eg-walker text positions.
+They are all small integers, but they do not count the same thing. PR #555
+made this concrete by splitting a generic cursor intent into separate
+`SetPmCursor(pm_tree_position)` and `SetDocCursor(doc_code_unit_offset)`
+variants; a shared raw `Range[Int]` would recreate the same ambiguity for
+spans.
+
+We also checked `moonbitlang/core/range` as a possible common primitive. It is
+not a range value type today: it exports `iter(from~, to~, step?, inclusive?)`
+and a sealed `Step` trait. It has no `Range`/`Span` struct, endpoint accessors,
+or unit semantics to reuse directly.
+
+## Decision
+
+Do **not** introduce a single shared Canopy `lib/range` primitive now, and do
+not standardize on `moonbitlang/core/range` for spans.
+
+Keep unit boundaries explicit:
+
+| Layer / API | Representation today | Unit |
+|---|---|---|
+| `ProjNode.start` / `.end` | `Int` fields | UTF-16 code-unit source offsets, half-open `[start, end)` |
+| `SourceMap` node and token ranges | `@loomcore.Range` | UTF-16 code-unit source offsets, half-open `[start, end)` |
+| Loom/seam syntax nodes and tokens | `Int` offsets from syntax APIs | UTF-16 code-unit source offsets, half-open spans |
+| `SyncEditor` cursor/splice APIs | `Int` | UTF-16 code-unit offsets; cursor-bearing paths snap or validate UAX #29 grapheme boundaries |
+| eg-walker text facade | `@text.Pos` / `@text.Range` | item-space positions, after editor-side conversion from UTF-16 |
+| `protocol` wire fields | JSON numbers / arrays | field-specific; usually UTF-16 document offsets, but PM cursor intents use ProseMirror tree positions |
+
+When a boundary needs stronger safety, introduce a unit-specific wrapper such
+as `DocCodeUnitOffset`, `DocCodeUnitRange`, `ItemOffset`, `ItemRange`, or
+`PmTreePosition`. Prefer labeled constructors such as
+`from_bounds(start~, end~)` and explicit adapters to existing representations.
+Do not add a broad public `RangeLike` trait or generic `Range[T]` until there
+is a demonstrated need that does not erase unit distinctions.
+
+## Design rules for future range work
+
+- Use unit-bearing type names at public or cross-package boundaries.
+- Keep source/document spans half-open by default: `[start, end)`.
+- Prefer labeled constructors over positional `new(3, 8)` when crossing a
+  package boundary.
+- Pin edge-case behavior in constructors or helpers: negative offsets,
+  `end < start`, zero-length spans, overlap vs adjacency, deletion clamping,
+  and UTF-16/grapheme-boundary validation.
+- Keep protocol JSON shapes stable; decode into typed MoonBit wrappers only on
+  the MoonBit side if a boundary warrants it.
+
+## Consequences
+
+- `@loomcore.Range` remains the current SourceMap/projection range type.
+- `@text.Pos` / `@text.Range` remain separate eg-walker item-space types.
+- Protocol fields remain plain JSON numbers, backed by explicit unit docs.
+- A future MoonBit core first-class range type can be revisited only if Canopy
+  can still encode unit distinctions around it.

--- a/docs/development/API_REFERENCE.md
+++ b/docs/development/API_REFERENCE.md
@@ -119,12 +119,15 @@ The `SyncEditor` is the primary facade for the editor application, integrating t
 
 [canopy251]: https://github.com/dowdiness/canopy/pull/251
 
-Three position units appear in the text-editing surface:
+The main position units are:
 
 | Layer | Unit (today) | What it counts |
 |---|---|---|
+| Projection spans (`ProjNode.start` / `.end`, `SourceMap`, token spans, `@loomcore.Range`) | UTF-16 code-unit source offsets, half-open `[start, end)` | Source/CST positions from parser and projection code. These are not eg-walker item-space positions and not ProseMirror tree positions. |
 | Editor cursor and splice APIs (`SyncEditor::*`) | UTF-16 code-unit offset, snapped to a UAX #29 grapheme boundary | Non-BMP code points still occupy 2 code units; combining marks occupy 1 code unit but are not exposed as cursor stops inside a cluster. |
 | Text diff (`@editor.text_diff`, `dowdiness/text_change`) | UTF-16 code-unit offsets aligned to grapheme boundaries | The minimal splice fields still use code-unit lengths, but prefix/suffix comparison walks full grapheme clusters. |
+| Protocol source spans (`ViewNode.text_range`, `TokenSpan`, `ViewPatch.TextChange`, `Decoration`, `Diagnostic`, `TextEdit`, `SetDocCursor`) | UTF-16 document code-unit offsets | JSON numbers at the wire boundary. See `protocol/README.md` for the field-by-field contract. |
+| ProseMirror cursor intent (`SetPmCursor.pm_tree_position`) | ProseMirror tree position | Position in the PM document tree. Convert before calling source-text APIs. |
 | eg-walker text facade (`@text.Pos`, `TextState::len` via `visible_count()`) | Item-space offset | One slot per atomic content `Op`. The editor converts UTF-16 offsets to item-space before calling `@text.Pos` / `@text.Range`. |
 
 No `GraphemeOffset` opaque type exists today. Keep treating public editor

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -41,6 +41,8 @@ so these units stay separate.
 
 | Field | Direction | Unit | Meaning |
 |---|---|---|---|
+| `ViewNode.text_range[0]` / `[1]` | MoonBit → JS | UTF-16 document code-unit offset | Half-open source range occupied by the node. |
+| `TokenSpan.start` / `.end` | MoonBit → JS | UTF-16 document code-unit offset | Half-open token or role span; same coordinate space as `ViewNode.text_range`. |
 | `ViewPatch.TextChange.from` / `.to` | MoonBit → JS | UTF-16 document code-unit offset | Half-open edit range. |
 | `TextEdit.from` / `.to` | JS → MoonBit | UTF-16 document code-unit offset | Half-open edit range. |
 | `ViewPatch.SetSelection.anchor` / `.head` | MoonBit → JS | UTF-16 document code-unit offset | Text selection endpoints. |

--- a/protocol/view_node.mbt
+++ b/protocol/view_node.mbt
@@ -4,8 +4,9 @@
 
 ///|
 /// A coloured / labelled slice of a node's text. `role` is a CSS-class-style
-/// tag (e.g. "keyword", "string", "identifier") and `start`/`end` index into
-/// the document text in the same units as `ViewNode.text_range`.
+/// tag (e.g. "keyword", "string", "identifier") and `start`/`end` are
+/// half-open UTF-16 document code-unit offsets in the same coordinate space as
+/// `ViewNode.text_range`.
 pub(all) struct TokenSpan {
   role : String
   start : Int
@@ -60,7 +61,8 @@ pub impl ToJson for ViewAnnotation with fn to_json(self) {
 /// - `label` is the short human-readable name shown in tree views.
 /// - `text` is the rendered source for this subtree, when applicable.
 /// - `text_range` is the half-open `[start, end)` range in the source
-///   document the node occupies; consistent with `TokenSpan` offsets.
+///   document the node occupies, expressed as UTF-16 document code-unit
+///   offsets; consistent with `TokenSpan` offsets.
 pub(all) struct ViewNode {
   id : @core.NodeId
   kind_tag : String

--- a/protocol/view_patch.mbt
+++ b/protocol/view_patch.mbt
@@ -1,8 +1,8 @@
 // ViewPatch: Incremental patches for the editor protocol.
 
 ///|
-/// Visual decoration applied to a half-open text range `[from, to)` in the
-/// editor's source view.
+/// Visual decoration applied to a half-open UTF-16 document code-unit range
+/// `[from, to)` in the editor's source view.
 ///
 /// `css_class` is the CSS class the frontend should attach to the range;
 /// `widget` indicates that the decoration replaces the range with an inline
@@ -49,8 +49,9 @@ pub impl ToJson for Severity with fn to_json(self) {
 }
 
 ///|
-/// A diagnostic message associated with a half-open text range `[from, to)`.
-/// Used to surface compiler/linter findings to the editor frontend.
+/// A diagnostic message associated with a half-open UTF-16 document code-unit
+/// range `[from, to)`. Used to surface compiler/linter findings to the editor
+/// frontend.
 pub(all) struct Diagnostic {
   from : Int
   to : Int
@@ -77,6 +78,7 @@ pub fn Diagnostic::Diagnostic(
 /// Frontends must treat unknown variants as no-ops so the protocol can be
 /// extended without a breaking change.
 pub(all) enum ViewPatch {
+  /// `from`/`to` are UTF-16 document code-unit offsets.
   TextChange(from~ : Int, to~ : Int, insert~ : String)
   ReplaceNode(node_id~ : @core.NodeId, node~ : ViewNode)
   InsertChild(parent_id~ : @core.NodeId, index~ : Int, child~ : ViewNode)
@@ -89,6 +91,7 @@ pub(all) enum ViewPatch {
   )
   SetDecorations(decorations~ : Array[Decoration])
   SetDiagnostics(diagnostics~ : Array[Diagnostic])
+  /// `anchor`/`head` are UTF-16 document code-unit offsets.
   SetSelection(anchor~ : Int, head~ : Int)
   SelectNode(node_id~ : @core.NodeId)
   FullTree(root~ : ViewNode?)


### PR DESCRIPTION
## Summary

- Record the #415 decision: do not introduce a shared `lib/range` or use `moonbitlang/core/range` as a span primitive today.
- Document unit boundaries for `@loomcore.Range`, `@text.Pos`/`@text.Range`, protocol JSON offsets, PM tree positions, and editor grapheme-aware UTF-16 offsets.
- Add code/API comments for public range-shaped fields in `core` and `protocol`.

Closes #415.

## Validation

- `moon fmt --check core/proj_node.mbt core/source_map.mbt core/types.mbt protocol/view_node.mbt protocol/view_patch.mbt`
- `moon check core protocol`
- `moon info core protocol` (no `.mbti` drift)
- `moon test core protocol` (141 passed)
- `make check-agent-doc-links`
- `git diff --cached --check`

## Reuse check

- Reused existing `@loomcore.Range` for SourceMap/projection UTF-16 source spans.
- Reused existing `@text.Pos` / `@text.Range` for eg-walker item-space; kept separate.
- Checked `moonbitlang/core/range`; not reused because it currently exports iteration helpers only, not a span value type.
- No new helper introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API documentation with standardized conventions and usage patterns for consistency.
  * Updated developer guidance on proper handling of range and offset operations across the codebase.
  * Established consistent documentation standards for position units and coordinate semantics throughout all subsystems.
  * Added architectural decision records documenting range and span handling guidelines for future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->