### PR TITLE
feat(canvas): add explicit fan-in ports

### DIFF
--- a/examples/canvas/web/src/graph-adapter.ts
+++ b/examples/canvas/web/src/graph-adapter.ts
@@ -98,7 +98,12 @@ const SOURCE_METHODS = [
 
 export type Tagged = string | [string, ...unknown[]];
 export type NodeKind = ['Workflow', Tagged];
-export type PortDef = { id: string; label: string; port_type: Tagged };
+export type PortDef = {
+  id: string;
+  label: string;
+  port_type: Tagged;
+  allows_fan_in?: boolean;
+};
 export type NodeParamData = {
   name: string;
   value_kind: string;

--- a/examples/canvas/web/src/main.ts
+++ b/examples/canvas/web/src/main.ts
@@ -168,7 +168,8 @@ function portTypesCompatible(source: string, target: string): boolean {
 
 /**
  * Whether dragging from the active source onto this input handle would be
- * accepted, mirroring `can_commit_edge` (self-loop, duplicate edge, type check).
+ * accepted, mirroring `can_commit_edge` (self-loop, duplicate edge, fan-in,
+ * type check).
  */
 function inputHandleCompatible(ctx: ConnectCtx, targetNode: string, targetPort: PortDef): boolean {
   if (ctx.sourceType == null) return false;
@@ -181,6 +182,10 @@ function inputHandleCompatible(ctx: ConnectCtx, targetNode: string, targetPort: 
       e.target_port === targetPort.id,
   );
   if (duplicate) return false;
+  const occupied = ctx.edges.some(
+    (e) => e.target === targetNode && e.target_port === targetPort.id,
+  );
+  if (occupied && targetPort.allows_fan_in !== true) return false;
   return portTypesCompatible(ctx.sourceType, portTypeName(targetPort.port_type));
 }
 

--- a/lib/canvas-graph/graph_model/graph_operation_test.mbt
+++ b/lib/canvas-graph/graph_model/graph_operation_test.mbt
@@ -29,6 +29,48 @@ fn replay_base_state() -> @graph_model.CanvasState {
 }
 
 ///|
+fn fan_in_base_state(allows_fan_in : Bool) -> @graph_model.CanvasState {
+  let target = {
+    ..@graph_model.make_workflow_node(
+      node_id(3),
+      @graph_model.WorkflowNodeKind::Custom("Join"),
+      760.0,
+      100.0,
+    ),
+    inputs: [
+      @graph_model.port(
+        "in",
+        "flow",
+        @graph_model.PortType::Flow,
+        allows_fan_in~,
+      ),
+    ],
+  }
+  {
+    viewport: { x: 0.0, y: 0.0, scale: 1.0 },
+    nodes: [
+      @graph_model.make_workflow_node(
+        node_id(1),
+        @graph_model.WorkflowNodeKind::TimerTrigger,
+        100.0,
+        100.0,
+      ),
+      @graph_model.make_workflow_node(
+        node_id(2),
+        @graph_model.WorkflowNodeKind::TimerTrigger,
+        420.0,
+        100.0,
+      ),
+      target,
+    ],
+    edges: [],
+    next_node_id: 4,
+    interaction: @graph_model.empty_interaction(),
+    action_log: [],
+  }
+}
+
+///|
 test "GraphOperation serializes as a versioned JSON operation" {
   let operation = @graph_model.GraphOperation::GraphOperation(
     @graph_model.WorkflowAction::ConnectPorts(
@@ -237,4 +279,111 @@ test "DisconnectPorts removes only the matching edge" {
   @debug.assert_eq(disconnected.edges[0].source, node_id(2))
   @debug.assert_eq(disconnected.edges[0].target, node_id(1))
   assert_eq(disconnected.action_log.length(), 2)
+}
+
+///|
+test "default input ports reject a second distinct incoming edge" {
+  let connected_once = @graph_model.record_action(
+    fan_in_base_state(false),
+    @graph_model.WorkflowAction::ConnectPorts(
+      node_id(1),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+  )
+  assert_eq(connected_once.edges.length(), 1)
+  inspect(
+    @graph_model.can_commit_edge(
+      connected_once,
+      node_id(2),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+    content="false",
+  )
+  let rejected = @graph_model.record_action(
+    connected_once,
+    @graph_model.WorkflowAction::ConnectPorts(
+      node_id(2),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+  )
+  assert_eq(rejected.edges.length(), 1)
+  assert_eq(rejected.action_log.length(), 2)
+}
+
+///|
+test "explicit fan-in input ports accept distinct incoming edges" {
+  let connected_once = @graph_model.record_action(
+    fan_in_base_state(true),
+    @graph_model.WorkflowAction::ConnectPorts(
+      node_id(1),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+  )
+  inspect(
+    @graph_model.can_commit_edge(
+      connected_once,
+      node_id(2),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+    content="true",
+  )
+  inspect(
+    @graph_model.can_commit_edge(
+      connected_once,
+      node_id(1),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+    content="false",
+  )
+  let connected_twice = @graph_model.record_action(
+    connected_once,
+    @graph_model.WorkflowAction::ConnectPorts(
+      node_id(2),
+      "tick",
+      node_id(3),
+      "in",
+    ),
+  )
+  assert_eq(connected_twice.edges.length(), 2)
+}
+
+///|
+test "PortDef JSON defaults fan-in capability to false" {
+  let json = @json.parse(
+    "{\"id\":\"in\",\"label\":\"flow\",\"port_type\":\"Flow\"}",
+  ) catch {
+    _ => abort("expected valid PortDef JSON")
+  }
+  let decoded : @graph_model.PortDef = @json.from_json(json)
+  inspect(decoded.allows_fan_in, content="false")
+  match decoded.to_json() {
+    Json::Object(fields) => assert_true(fields.get("allows_fan_in") is None)
+    _ => abort("expected PortDef object JSON")
+  }
+  let fan_in = @graph_model.port(
+    "in",
+    "flow",
+    @graph_model.PortType::Flow,
+    allows_fan_in=true,
+  )
+  match fan_in.to_json() {
+    Json::Object(fields) =>
+      match fields.get("allows_fan_in") {
+        Some(Json::True) => ()
+        _ => abort("expected explicit fan-in flag in PortDef JSON")
+      }
+    _ => abort("expected PortDef object JSON")
+  }
 }

--- a/lib/canvas-graph/graph_model/model.mbt
+++ b/lib/canvas-graph/graph_model/model.mbt
@@ -102,15 +102,62 @@ pub impl Show for PortType with fn output(self, logger) {
 }
 
 ///|
-pub(all) struct PortDef {
+/// Port metadata shared by render DTOs and graph operations. Prefer the
+/// `port` constructor so new optional capabilities receive their defaults.
+pub struct PortDef {
   id : String
   label : String
   port_type : PortType
-} derive(Debug, Eq, ToJson, FromJson)
+  /// Input ports with this flag accept multiple distinct incoming edges.
+  /// Output ports carry the field for one shared port shape, but validation
+  /// only consults it on target input ports.
+  allows_fan_in : Bool
+} derive(Debug, Eq)
 
 ///|
 pub impl Show for PortDef with fn output(self, logger) {
   logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub impl ToJson for PortDef with fn to_json(self) {
+  let fields : Map[String, Json] = {}
+  fields["id"] = self.id.to_json()
+  fields["label"] = self.label.to_json()
+  fields["port_type"] = self.port_type.to_json()
+  if self.allows_fan_in {
+    fields["allows_fan_in"] = true.to_json()
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl @json.FromJson for PortDef with fn from_json(json, path) {
+  let fields = match json {
+    Json::Object(fields) => fields
+    _ => raise @json.JsonDecodeError((path, "PortDef: expected JSON object"))
+  }
+  let port_type : PortType = @json.from_json(
+    require_json_field(fields, path, "port_type", "PortDef"),
+  )
+  let allows_fan_in = match fields.get("allows_fan_in") {
+    None => false
+    Some(Json::True) => true
+    Some(Json::False) => false
+    Some(_) =>
+      raise @json.JsonDecodeError(
+        (
+          path.add_key("allows_fan_in"),
+          "PortDef: 'allows_fan_in' must be a boolean",
+        ),
+      )
+  }
+  {
+    id: json_string_field(fields, path, "id", "PortDef"),
+    label: json_string_field(fields, path, "label", "PortDef"),
+    port_type,
+    allows_fan_in,
+  }
 }
 
 ///|
@@ -556,8 +603,13 @@ pub impl Show for CanvasState with fn output(self, logger) {
 }
 
 ///|
-pub fn port(id : String, label : String, port_type : PortType) -> PortDef {
-  { id, label, port_type }
+pub fn port(
+  id : String,
+  label : String,
+  port_type : PortType,
+  allows_fan_in? : Bool = false,
+) -> PortDef {
+  { id, label, port_type, allows_fan_in }
 }
 
 ///|
@@ -734,13 +786,29 @@ fn port_type_compatible(source : PortType, target : PortType) -> Bool {
 }
 
 ///|
+fn port_by_id(ports : Array[PortDef], id : String) -> PortDef? {
+  ports.iter().find_first(fn(port) { port.id == id })
+}
+
+///|
 pub fn port_type_by_id(ports : Array[PortDef], id : String) -> PortType? {
-  for port in ports {
-    if port.id == id {
-      return Some(port.port_type)
-    }
+  match port_by_id(ports, id) {
+    Some(port) => Some(port.port_type)
+    None => None
   }
-  None
+}
+
+///|
+fn target_port_has_capacity(
+  edges : Array[Edge],
+  target : NodeId,
+  target_port : String,
+  target_def : PortDef,
+) -> Bool {
+  target_def.allows_fan_in ||
+  !edges
+  .iter()
+  .any(fn(edge) { edge.target == target && edge.target_port == target_port })
 }
 
 ///|
@@ -759,11 +827,17 @@ pub fn can_commit_edge(
       (Some(source_node), Some(target_node)) =>
         match
           (
-            port_type_by_id(source_node.outputs, source_port),
-            port_type_by_id(target_node.inputs, target_port),
+            port_by_id(source_node.outputs, source_port),
+            port_by_id(target_node.inputs, target_port),
           ) {
-          (Some(source_type), Some(target_type)) =>
-            port_type_compatible(source_type, target_type)
+          (Some(source_def), Some(target_def)) =>
+            port_type_compatible(source_def.port_type, target_def.port_type) &&
+            target_port_has_capacity(
+              state.edges,
+              target,
+              target_port,
+              target_def,
+            )
           _ => false
         }
       _ => false

--- a/lib/canvas-graph/graph_model/pkg.generated.mbti
+++ b/lib/canvas-graph/graph_model/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub fn interaction_with_selection(InteractionState, SelectionState) -> Interacti
 
 pub fn make_workflow_node(NodeId, WorkflowNodeKind, Double, Double) -> CanvasNode
 
-pub fn port(String, String, PortType) -> PortDef
+pub fn port(String, String, PortType, allows_fan_in? : Bool) -> PortDef
 
 pub fn port_type_by_id(Array[PortDef], String) -> PortType?
 
@@ -185,12 +185,15 @@ pub(all) struct PanState {
 } derive(Eq, @debug.Debug)
 pub impl Show for PanState
 
-pub(all) struct PortDef {
+pub struct PortDef {
   id : String
   label : String
   port_type : PortType
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+  allows_fan_in : Bool
+} derive(Eq, @debug.Debug)
 pub impl Show for PortDef
+pub impl ToJson for PortDef
+pub impl @json.FromJson for PortDef
 
 pub(all) enum PortType {
   Flow


### PR DESCRIPTION
## Summary

- Add explicit `PortDef.allows_fan_in` capability to the reusable canvas graph model.
- Make `can_commit_edge` reject a second distinct incoming edge to an occupied input unless that input opts into fan-in.
- Keep the TypeScript compatibility preview aligned with MoonBit validation.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Iter::find_first` | `moonbitlang/core/builtin` | Yes | Used for `port_by_id` to return the matching port value directly. |
| `Array::search_by` | `moonbitlang/core/array` | No | It returns an index; the validation path needs the `PortDef` value. |
| `port_type_by_id` | `lib/canvas-graph/graph_model/model.mbt` | Preserved | Still public for callers that only need the type; `can_commit_edge` now needs the full port metadata. |

New helpers added:

- `port_by_id`: private lookup helper for full `PortDef` metadata.
- `target_port_has_capacity`: private capacity predicate that isolates the explicit fan-in rule.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/canvas/web && npm run build`)

## Validation

```bash
cd lib/canvas-graph
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test graph_model/graph_operation_test.mbt

cd examples/canvas
NEW_MOON_MOD=0 MOON_WORK=off moon check --target js --deny-warn
NEW_MOON_MOD=0 MOON_WORK=off moon test --target js

cd examples/canvas/web
npm run build
npm run test:e2e
```

All passed. Canvas web E2E: 19 passed.

## API notes

`PortDef` now has an explicit `allows_fan_in` field and is constructor-driven (`pub struct` plus `port(..., allows_fan_in?=false)`) so future capability defaults do not require downstream record-literal construction. `pkg.generated.mbti` was reviewed; this API surface change is intentional.
