### PR TITLE
feat(scope): resolve nested-block scopes + reground free-var diagnostic (RFA Step 1)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -479,6 +479,26 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Remaining: gated query-indexing is the only open scope follow-up here; the
   binder-location plan itself is complete.
 
+- [ ] Teach `edits/` resolvers about nested-block (`Module`) scopes.
+  Why: RFA Step 1 (#617) made the scope-graph builder model nested-block scopes,
+  so `failures()`/diagnostics resolve block-local bindings correctly. But
+  `edits/scope.mbt`'s parallel resolver (`declaration_id_for_name_from_scope` +
+  `def_cutoff_at_node`) still applies one root-relative cutoff to every
+  `ModuleDef` scope, and `text_edit_rename.mbt` / inline interpret
+  `DeclKind::ModuleDef(def_index)` against `ctx.module_projection.defs` (the root
+  module only). Top-level rename is unaffected (verified: edits/ suite green),
+  but renaming or referencing a *block-local* binding is now unsound — the graph
+  resolves it to a nested decl whose `def_index` is block-relative, which the
+  edits layer reads as root-relative. Pre-existing blind spot, newly reachable
+  because the graph now emits nested `ModuleDef` decls (Codex pre-PR review,
+  #617).
+  Plan: GitHub issue — generalize the edits resolver to the per-(node, scope)
+  cutoff model the builder now uses (see `lang/lambda/scope/builder.mbt`
+  `node_cutoffs`), keying `def_index` to its declaring scope rather than the root
+  module.
+  Exit: a rename of a block-local binding (`let y = { let x = 1; x }`) renames
+  only the block-local `x`, with a wbtest fixture asserting it.
+
 ## Shipped history
 
 Completed items (with PR references and shipping notes) are preserved in

--- a/docs/research/2026-06-13-reachable-failure-analysis.md
+++ b/docs/research/2026-06-13-reachable-failure-analysis.md
@@ -104,14 +104,26 @@ resolution**:
 **The decisive difference (Codex-confirmed):** unlike Method-Ray's type domain,
 lambda name resolution is **exact** for the current language — resolution walks
 parent scopes and returns `decl: None` only after exhausting the chain
-(`builder.mbt:143,152,164,175`); `ModuleDef` is a deterministic sequential cutoff,
-not open/dynamic binding. A free variable *is* free. So the false-positive caveat
+(`builder.mbt` `resolve`); `ModuleDef` is a deterministic sequential cutoff, not
+open/dynamic binding. A free variable *is* free. So the false-positive caveat
 that dooms a naive type-domain port **does not bite in the scope domain** — this is
 where Canopy can earn the name "ReachableFailure" on solid ground.
 
+Exactness was not free, though. When this note was written the builder modelled
+only `Lam` scopes; nested-block expressions (which lower to nested `Module` nodes)
+had no scope, so block-local bindings resolved as free — exactness held for flat
+top-level programs but *failed* for blocks. Step 1 (#617) extended `pass2` to open
+a child scope per nested `Module` with its own sequential cutoff (the per-(node,
+scope) `node_cutoffs` map in `builder.mbt`), restoring exactness across blocks. A
+reference-by-reference differential oracle against the semantic env-walk
+(`lang/lambda/semantic/semantic_projection_test.mbt`) now guards it.
+
 Caveat to track: the exactness claim holds *for today's lexical lambda language*. If
 lambda gains open/extensible modules or dynamic binding, scope resolution becomes
-approximate and the genuine-reachable property weakens.
+approximate and the genuine-reachable property weakens. Separately, the `edits/`
+rename/refactor resolver still reads `ModuleDef(def_index)` as root-relative, so it
+does **not** yet resolve block-local bindings correctly — tracked in `docs/TODO.md`
+§20.
 
 ## 5. What exists vs. what's missing (Codex corrections folded in)
 

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -18,16 +18,24 @@ fn build_parent_map(
 
 ///|
 /// Mutable builder state accumulated across passes.
+///
+/// `node_cutoffs` is transient pass-2 state (never stored in the graph): for
+/// each node it records the sequential cutoff of every enclosing module scope
+/// — a `ModuleDef(def_index)` in scope `s` is visible to the node only if
+/// `def_index < node_cutoffs[node][s]`. Lambda scopes never appear (they hold
+/// no `ModuleDef`). This generalises the former single-`Int` cutoff so nested
+/// blocks each carry their own sequential position independently.
 priv struct Builder {
   scopes : Array[Scope]
   decls : Array[Decl]
   refs : Array[Ref]
   node_scope : Map[@core.NodeId, ScopeId]
+  node_cutoffs : Map[@core.NodeId, Map[ScopeId, Int]]
 }
 
 ///|
 fn Builder::new() -> Builder {
-  { scopes: [], decls: [], refs: [], node_scope: {} }
+  { scopes: [], decls: [], refs: [], node_scope: {}, node_cutoffs: {} }
 }
 
 ///|
@@ -65,20 +73,34 @@ fn root_node(
 }
 
 ///|
-/// Pass 2: root module scope, ModuleDef decls (one per flat def), and a child
-/// LamParam scope per Lam node. Records node→scope membership.
+/// Pass 2: scopes, decls, and per-node scope+cutoff membership.
+///
+/// - The root module scope holds the flat top-level `ModuleDef` decls (one per
+///   `module_projection.defs`, binder id preserved from the projection).
+/// - Each `Lam` node opens a child `LamParam` scope.
+/// - Each NESTED `Module` node (a block expression) opens a child scope holding
+///   its own block-local `ModuleDef` decls — this is what makes the graph an
+///   exact resolver for blocks, matching the semantic env-walk.
+///
+/// Within any module scope, child `i` (definition `i`'s initialiser) sees defs
+/// `[0, i)` and the body (`i == def_count`) sees all defs; that per-child
+/// cutoff is recorded against the scope in `node_cutoffs`, accumulating the
+/// cutoffs of all enclosing module scopes so each gates visibility independently.
 fn Builder::pass2(
   self : Builder,
   module_projection : @lambda_proj.ModuleProjection,
   root : @core.ProjNode[@ast.Term],
 ) -> Unit {
-  let root_scope = self.add_scope(None)
-  for i, def in module_projection.defs {
-    let (name, _init, _start, binder_id) = def
-    let _ = self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
-  }
-  fn walk(node : @core.ProjNode[@ast.Term], current : ScopeId) -> Unit {
+  // Single self-recursive walker (local mutual recursion is unavailable in
+  // current MoonBit, so the module-children descent is inlined in both the
+  // nested-`Module` arm and the root setup below).
+  fn walk(
+    node : @core.ProjNode[@ast.Term],
+    current : ScopeId,
+    cutoffs : Map[ScopeId, Int],
+  ) -> Unit {
     self.node_scope[node.id()] = current
+    self.node_cutoffs[node.id()] = cutoffs
     match node.kind {
       @ast.Term::Lam(param, _) => {
         let lam_scope = self.add_scope(Some(current))
@@ -89,17 +111,61 @@ fn Builder::pass2(
           LamParam(lam_id=node.id()),
         )
         for child in node.children {
-          walk(child, lam_scope)
+          walk(child, lam_scope, cutoffs)
+        }
+      }
+      @ast.Term::Module(defs, _) => {
+        let mod_scope = self.add_scope(Some(current))
+        for i, def in defs {
+          let _ = self.add_decl(
+            mod_scope,
+            node.children[i].id(),
+            def.0,
+            ModuleDef(def_index=i),
+          )
+        }
+        let def_count = defs.length()
+        for i, child in node.children {
+          let scoped = cutoffs.copy()
+          scoped[mod_scope] = if i < def_count { i } else { def_count }
+          walk(child, mod_scope, scoped)
         }
       }
       _ =>
         for child in node.children {
-          walk(child, current)
+          walk(child, current, cutoffs)
         }
     }
   }
 
-  walk(root, root_scope)
+  let root_scope = self.add_scope(None)
+  for i, def in module_projection.defs {
+    let (name, _init, _start, binder_id) = def
+    let _ = self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
+  }
+  match root.kind {
+    // Top-level module: its scope and decls are installed above, so descend its
+    // children directly (not through the `Module` arm, which would open a
+    // second scope and re-install the defs from the wrong binder ids).
+    @ast.Term::Module(_, _) => {
+      self.node_scope[root.id()] = root_scope
+      self.node_cutoffs[root.id()] = {}
+      let root_def_count = module_projection.defs.length()
+      for i, child in root.children {
+        let scoped : Map[ScopeId, Int] = {}
+        scoped[root_scope] = if i < root_def_count { i } else { root_def_count }
+        walk(child, root_scope, scoped)
+      }
+    }
+    // Bare lambda / expression program: `module_projection.defs` is empty, so
+    // `root_scope` holds no `ModuleDef`. Dispatch through `walk` so the root's
+    // own binder (a `Lam` param) is installed.
+    _ => {
+      let scoped : Map[ScopeId, Int] = {}
+      scoped[root_scope] = 0
+      walk(root, root_scope, scoped)
+    }
+  }
 }
 
 ///|
@@ -117,58 +183,42 @@ fn Builder::add_ref(
 }
 
 ///|
-/// Which flat-def index a node sits within, by source position; returns the
-/// def count (body sentinel) when the node is in the module body. This is now
-/// the sole implementation of def-range containment for the lambda language.
-fn containing_def_index(
-  module_projection : @lambda_proj.ModuleProjection,
-  source_map : @core.SourceMap,
-  node_id : @core.NodeId,
-) -> Int {
-  guard source_map.get_range(node_id) is Some(r) else {
-    return module_projection.defs.length()
-  }
-  let pos = r.start
-  module_projection.defs
-  .search_by(fn(def) {
-    let (_n, init, _s, _id) = def
-    source_map.get_range(init.id()) is Some(dr) &&
-    pos >= dr.start &&
-    pos < dr.end
-  })
-  .unwrap_or(module_projection.defs.length())
-}
-
-///|
-/// Resolve `name` from `start_scope` upward. ModuleDef decls are visible only
-/// if def_index < cutoff (sequential rule). Records scopes visited that did
-/// not contain the name (negative observation).
+/// Resolve `name` from `start_scope` upward. A `ModuleDef` decl in scope `sid`
+/// is visible only if `def_index < cutoffs[sid]` (the sequential rule, applied
+/// per module scope so nested blocks gate independently); `LamParam` decls are
+/// always visible. Records scopes visited that did not contain the name
+/// (negative observation).
+///
+/// Invariant: every module scope on the parent chain from `start_scope` to the
+/// root was entered during pass 2's walk for this reference, so it is present
+/// in `cutoffs`; `cutoffs.get(sid).unwrap()` therefore asserts that invariant
+/// (a missing entry is a structural defect and a loud abort is correct), and is
+/// only ever consulted for `ModuleDef` decls — lambda scopes are never looked up.
 fn Builder::resolve(
   self : Builder,
   name : String,
   start_scope : ScopeId,
-  cutoff : Int,
+  cutoffs : Map[ScopeId, Int],
 ) -> Resolution {
   let visited : Array[ScopeId] = []
   let mut cur : ScopeId? = Some(start_scope)
   while cur is Some(sid) {
     let ScopeId(si) = sid
     let scope = self.scopes[si]
-    let mut hit : DeclId? = None
-    // later decls win within a scope (shadowing); module scope respects cutoff.
-    for did in scope.decl_ids {
-      let DeclId(di) = did
-      let decl = self.decls[di]
-      if decl.name == name {
-        match decl.kind {
-          ModuleDef(def_index~) => if def_index < cutoff { hit = Some(did) }
-          LamParam(_) => hit = Some(did)
-        }
-      }
-    }
-    if hit is Some(_) {
-      return { decl: hit, visited_scopes: visited }
-    }
+    // later decls win within a scope (shadowing), so search in reverse and take
+    // the first match; module-scope decls respect the per-scope cutoff.
+    let hit = scope.decl_ids
+      .rev_iter()
+      .find_first(fn(did) {
+        let DeclId(di) = did
+        let decl = self.decls[di]
+        decl.name == name &&
+        (match decl.kind {
+          ModuleDef(def_index~) => def_index < cutoffs.get(sid).unwrap()
+          LamParam(_) => true
+        })
+      })
+    guard hit is None else { return { decl: hit, visited_scopes: visited } }
     visited.push(sid)
     cur = scope.parent
   }
@@ -185,9 +235,7 @@ fn Builder::resolve(
 /// correct — silently defaulting to the root scope would mis-resolve it.
 fn Builder::pass3(
   self : Builder,
-  module_projection : @lambda_proj.ModuleProjection,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
-  source_map : @core.SourceMap,
 ) -> Unit {
   for _id, node in registry {
     let name = match node.kind {
@@ -197,22 +245,29 @@ fn Builder::pass3(
     }
     guard name is Some(n) else { continue }
     let scope = self.node_scope.get(node.id()).unwrap()
-    let cutoff = containing_def_index(module_projection, source_map, node.id())
-    let resolution = self.resolve(n, scope, cutoff)
+    let cutoffs = self.node_cutoffs.get(node.id()).unwrap()
+    let resolution = self.resolve(n, scope, cutoffs)
     self.add_ref(scope, node.id(), n, resolution)
   }
 }
 
 ///|
 /// Build the scope graph (Pass 2 then Pass 3).
+///
+/// `source_map` is the graph's companion coordinate input retained on the public
+/// constructor (callers already hold it and `failures()` consumes it for
+/// reference locations). Resolution itself is now purely structural — cutoffs
+/// come from tree position recorded in pass 2 — so it is not threaded into the
+/// passes.
 pub fn build(
   module_projection : @lambda_proj.ModuleProjection,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
+  let _ = source_map
   let b = Builder::new()
   let root = root_node(registry)
   b.pass2(module_projection, root)
-  b.pass3(module_projection, registry, source_map)
+  b.pass3(registry)
   { scopes: b.scopes, decls: b.decls, refs: b.refs, module_node_id: root.id() }
 }

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -91,71 +91,24 @@ fn Builder::pass2(
   module_projection : @lambda_proj.ModuleProjection,
   root : @core.ProjNode[@ast.Term],
 ) -> Unit {
-  // Single self-recursive walker (local mutual recursion is unavailable in
-  // current MoonBit, so the module-children descent is inlined in both the
-  // nested-`Module` arm and the root setup below).
-  fn walk(
-    node : @core.ProjNode[@ast.Term],
-    current : ScopeId,
-    cutoffs : Map[ScopeId, Int],
-  ) -> Unit {
-    self.node_scope[node.id()] = current
-    self.node_cutoffs[node.id()] = cutoffs
-    match node.kind {
-      @ast.Term::Lam(param, _) => {
-        let lam_scope = self.add_scope(Some(current))
-        let _ = self.add_decl(
-          lam_scope,
-          node.id(),
-          param,
-          LamParam(lam_id=node.id()),
-        )
-        for child in node.children {
-          walk(child, lam_scope, cutoffs)
-        }
-      }
-      @ast.Term::Module(defs, _) => {
-        let mod_scope = self.add_scope(Some(current))
-        for i, def in defs {
-          let _ = self.add_decl(
-            mod_scope,
-            node.children[i].id(),
-            def.0,
-            ModuleDef(def_index=i),
-          )
-        }
-        let def_count = defs.length()
-        for i, child in node.children {
-          let scoped = cutoffs.copy()
-          scoped[mod_scope] = if i < def_count { i } else { def_count }
-          walk(child, mod_scope, scoped)
-        }
-      }
-      _ =>
-        for child in node.children {
-          walk(child, current, cutoffs)
-        }
-    }
-  }
-
   let root_scope = self.add_scope(None)
   for i, def in module_projection.defs {
     let (name, _init, _start, binder_id) = def
     let _ = self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
   }
   match root.kind {
-    // Top-level module: its scope and decls are installed above, so descend its
-    // children directly (not through the `Module` arm, which would open a
-    // second scope and re-install the defs from the wrong binder ids).
+    // Root is the top-level module. Its scope (parent None) and decls are
+    // installed above from `module_projection.defs` — that pre-installation is
+    // the *only* thing distinguishing root from a nested block. The binder ids
+    // are in fact identical to `root.children[i].id()` (see
+    // `ModuleProjection::from_proj_node`); root is kept out of the generic
+    // `Module` arm only because that arm would open a *second* scope and
+    // re-install the decls. The per-child cutoff descent is shared via
+    // `descend_module_children`.
     @ast.Term::Module(_, _) => {
       self.node_scope[root.id()] = root_scope
       self.node_cutoffs[root.id()] = {}
-      let root_def_count = module_projection.defs.length()
-      for i, child in root.children {
-        let scoped : Map[ScopeId, Int] = {}
-        scoped[root_scope] = if i < root_def_count { i } else { root_def_count }
-        walk(child, root_scope, scoped)
-      }
+      self.descend_module_children(root, root_scope, {})
     }
     // Bare lambda / expression program: `module_projection.defs` is empty, so
     // `root_scope` holds no `ModuleDef`. Dispatch through `walk` so the root's
@@ -163,8 +116,75 @@ fn Builder::pass2(
     _ => {
       let scoped : Map[ScopeId, Int] = {}
       scoped[root_scope] = 0
-      walk(root, root_scope, scoped)
+      self.walk(root, root_scope, scoped)
     }
+  }
+}
+
+///|
+/// Descend the children of a module node (root or nested block) under
+/// `module_scope`, recording each child's sequential cutoff for that scope:
+/// definition `i` (its initialiser) sees defs `[0, i)`, and the trailing body
+/// child sees all defs. `def_count` is derived structurally as
+/// `children.length() - 1` — the body is always the last child (see
+/// `module_node_from_defs`) — so the cutoff stays consistent with the children
+/// actually iterated, independent of `module_projection`'s def count.
+fn Builder::descend_module_children(
+  self : Builder,
+  node : @core.ProjNode[@ast.Term],
+  module_scope : ScopeId,
+  base : Map[ScopeId, Int],
+) -> Unit {
+  let def_count = node.children.length() - 1
+  for i, child in node.children {
+    let scoped = base.copy()
+    scoped[module_scope] = if i < def_count { i } else { def_count }
+    self.walk(child, module_scope, scoped)
+  }
+}
+
+///|
+/// Walk a node, recording its scope and cutoff map. `Lam` nodes open a child
+/// `LamParam` scope; nested-block `Module` nodes open a child scope holding
+/// their own block-local `ModuleDef` decls and descend via
+/// `descend_module_children`. Everything else recurses in the same scope.
+fn Builder::walk(
+  self : Builder,
+  node : @core.ProjNode[@ast.Term],
+  current : ScopeId,
+  cutoffs : Map[ScopeId, Int],
+) -> Unit {
+  self.node_scope[node.id()] = current
+  self.node_cutoffs[node.id()] = cutoffs
+  match node.kind {
+    @ast.Term::Lam(param, _) => {
+      let lam_scope = self.add_scope(Some(current))
+      let _ = self.add_decl(
+        lam_scope,
+        node.id(),
+        param,
+        LamParam(lam_id=node.id()),
+      )
+      for child in node.children {
+        self.walk(child, lam_scope, cutoffs)
+      }
+    }
+    @ast.Term::Module(defs, _) => {
+      let mod_scope = self.add_scope(Some(current))
+      for i, def in defs {
+        let _ = self.add_decl(
+          mod_scope,
+          node.children[i].id(),
+          def.0,
+          ModuleDef(def_index=i),
+        )
+      }
+      self.descend_module_children(node, mod_scope, cutoffs)
+    }
+    _ =>
+      for child in node.children {
+        self.walk(child, current, cutoffs)
+      }
   }
 }
 

--- a/lang/lambda/scope/failures.mbt
+++ b/lang/lambda/scope/failures.mbt
@@ -1,0 +1,57 @@
+///|
+/// A witnessed unresolved reference — a free variable surfaced with the exact
+/// reason it is free. `ScopeGraph` resolution returns `decl == None` only after
+/// exhausting the lexical scope chain, so for today's lambda language a
+/// `ReachableFailure` is genuinely *reachable*, not merely *possible* (research
+/// note 2026-06-13 §4): both the failure and its witness are exact. Distinct
+/// from `incr`'s `ReachableDerived` (cell liveness / GC-anchoring) despite the
+/// shared word — see the note's naming-discipline aside (§5).
+///
+/// - `name`: the unresolved reference's identifier.
+/// - `location`: the reference's source span when recorded; `None` when the
+///   `SourceMap` holds no range for the node (nothing to draw). Diagnostic
+///   consumers filter on `location is Some(_)`; impact-query consumers want the
+///   whole set.
+/// - `witness`: the scopes searched and found NOT to contain `name`
+///   (`Resolution.visited_scopes`) — the dependency footprint of the negative
+///   observation, shared (not copied) from the resolution.
+pub(all) struct ReachableFailure {
+  name : String
+  location : @loomcore.Range?
+  witness : Array[ScopeId]
+} derive(Debug)
+
+///|
+fn ReachableFailure::ReachableFailure(
+  name~ : String,
+  location~ : @loomcore.Range?,
+  witness~ : Array[ScopeId],
+) -> ReachableFailure {
+  { name, location, witness }
+}
+
+///|
+/// Derived view over the scope graph: every unresolved (free) reference,
+/// surfaced as a witnessed `ReachableFailure`. The failure predicate is
+/// `resolution.decl is None`; the witness is `resolution.visited_scopes`; the
+/// location is the reference node's recorded source span.
+///
+/// Total over the graph's refs: this is the failure SET that feeds both the
+/// free-variable diagnostic (research note §6 Step 1, which it now sources) and
+/// the future before/after impact diff (§6 Step 2 — that diff must key on
+/// pipeline-independent semantic identity, never the graph-local `DeclId`/
+/// `NodeId`).
+pub fn failures(
+  g : ScopeGraph,
+  source_map : @core.SourceMap,
+) -> Array[ReachableFailure] {
+  [
+    for r in g.refs if r.resolution.decl is None => {
+      ReachableFailure(
+        name=r.name,
+        location=source_map.get_range(r.node_id),
+        witness=r.resolution.visited_scopes,
+      )
+    }
+  ]
+}

--- a/lang/lambda/scope/failures_wbtest.mbt
+++ b/lang/lambda/scope/failures_wbtest.mbt
@@ -1,0 +1,39 @@
+// Whitebox tests for the `failures()` derived view. Reuses `build_fixture`
+// from `graph_wbtest.mbt` (same whitebox test module).
+
+///|
+test "failures: free variable is surfaced with a populated witness" {
+  let (_proj, module_projection, registry, source_map) = build_fixture(
+    "(x) => y",
+  )
+  let g = build(module_projection, registry, source_map)
+  let fs = failures(g, source_map)
+  inspect(fs.length(), content="1")
+  inspect(fs[0].name, content="y")
+  // y was searched against the lambda-param scope and the root scope and bound
+  // by neither — the witness records that negative observation.
+  inspect(fs[0].witness.length() >= 1, content="true")
+  inspect(fs[0].location is Some(_), content="true")
+}
+
+///|
+test "failures: a fully-resolved program has no failures" {
+  let (_proj, module_projection, registry, source_map) = build_fixture(
+    "let x = 1\nlet y = x\nx + y",
+  )
+  let g = build(module_projection, registry, source_map)
+  inspect(failures(g, source_map).length(), content="0")
+}
+
+///|
+test "failures: self-reference in a def init is a reachable failure" {
+  let (_proj, module_projection, registry, source_map) = build_fixture(
+    "let x = x\nx",
+  )
+  let g = build(module_projection, registry, source_map)
+  let fs = failures(g, source_map)
+  // The init `x` cannot see its own not-yet-bound def (sequential cutoff); the
+  // body `x` resolves. Exactly one failure, and it is the init reference.
+  inspect(fs.length(), content="1")
+  inspect(fs[0].name, content="x")
+}

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -17,6 +17,8 @@ pub fn declaration(ScopeGraph, @dowdiness/canopy/core.NodeId) -> Decl?
 
 pub fn enclosing_env(ScopeGraph, @dowdiness/canopy/core.NodeId) -> @hashset.HashSet[String]
 
+pub fn failures(ScopeGraph, @dowdiness/canopy/core.SourceMap) -> Array[ReachableFailure]
+
 pub fn go_to_definition(ScopeGraph, @dowdiness/canopy/core.SourceMap, Int) -> @dowdiness/loom/core.Range?
 
 pub fn references(ScopeGraph, DeclId) -> Array[@dowdiness/canopy/core.NodeId]
@@ -38,6 +40,12 @@ pub(all) enum DeclKind {
   LamParam(lam_id~ : @dowdiness/canopy/core.NodeId)
   ModuleDef(def_index~ : Int)
 } derive(Eq, @debug.Debug)
+
+pub(all) struct ReachableFailure {
+  name : String
+  location : @dowdiness/loom/core.Range?
+  witness : Array[ScopeId]
+} derive(@debug.Debug)
 
 pub(all) struct Ref {
   id : RefId

--- a/lang/lambda/semantic/moon.pkg
+++ b/lang/lambda/semantic/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/canopy/lang/lambda/scope" @lambda_scope,
   "dowdiness/canopy/protocol",
   "dowdiness/lambda/ast",
   "moonbitlang/core/json",

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -48,7 +48,45 @@ pub fn build_semantic_projection_with_module_projection(
 ) -> SemanticProjection {
   let projection = SemanticProjection::empty()
   analyze_node(root, source_map, [], projection, module_projection)
+  push_scope_failures(root, source_map, projection)
   projection
+}
+
+///|
+/// Source the free-variable diagnostics from the lambda scope graph rather than
+/// the projection's own environment walk (research note 2026-06-13 §6 Step 1).
+/// Each unresolved reference (`resolution.decl == None`) is a witnessed
+/// `ReachableFailure`; for today's lexical lambda language that failure is
+/// genuinely reachable, so the squiggle now rests on the resolver of record
+/// instead of a parallel `env.contains` check.
+///
+/// The scope graph is reconstructed from `root` (the same tree the diagnostic
+/// ranges come from) so resolution and locations share a single source of
+/// truth; the optional `module_projection` argument is only consulted by the
+/// annotation/decoration walk. Those visual bound/free annotations and
+/// decorations deliberately remain on the environment walk — §6 Step 1 regrounds
+/// the structured diagnostic only. Incremental maintenance is §6 Step 3,
+/// benchmark-gated.
+fn push_scope_failures(
+  root : @core.ProjNode[@ast.Term],
+  source_map : @core.SourceMap,
+  projection : SemanticProjection,
+) -> Unit {
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(root)
+  let graph = @lambda_scope.build(module_projection, registry, source_map)
+  for failure in @lambda_scope.failures(graph, source_map) {
+    guard failure.location is Some(range) else { continue }
+    projection.diagnostics.push(
+      @protocol.Diagnostic(
+        from=range.start,
+        to=range.end,
+        severity=@protocol.SevWarning,
+        message="Free variable '" + failure.name + "'",
+      ),
+    )
+  }
 }
 
 ///|
@@ -221,18 +259,6 @@ fn analyze_var(
       "semantic-free",
       name,
     )
-    match source_map.get_range(node.id()) {
-      Some(range) =>
-        projection.diagnostics.push(
-          @protocol.Diagnostic(
-            from=range.start,
-            to=range.end,
-            severity=@protocol.SevWarning,
-            message="Free variable '" + name + "'",
-          ),
-        )
-      None => ()
-    }
   }
 }
 

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -60,13 +60,16 @@ pub fn build_semantic_projection_with_module_projection(
 /// genuinely reachable, so the squiggle now rests on the resolver of record
 /// instead of a parallel `env.contains` check.
 ///
-/// The scope graph is reconstructed from `root` (the same tree the diagnostic
-/// ranges come from) so resolution and locations share a single source of
-/// truth; the optional `module_projection` argument is only consulted by the
-/// annotation/decoration walk. Those visual bound/free annotations and
-/// decorations deliberately remain on the environment walk — §6 Step 1 regrounds
-/// the structured diagnostic only. Incremental maintenance is §6 Step 3,
-/// benchmark-gated.
+/// The scope graph is reconstructed from `root` via `from_proj_node(root)` — it
+/// deliberately does NOT reuse the caller-supplied `module_projection`. Both the
+/// registry and the diagnostic ranges derive from `root`, so deriving the
+/// module projection from `root` too keeps resolution consistent with the tree
+/// the squiggles land on; the caller's projection (which under incremental
+/// editing is reconciled separately) could drift from `root` and mis-gate
+/// definition visibility. The `module_projection` argument is consulted only by
+/// the annotation/decoration walk, whose bound/free overlays deliberately remain
+/// on the environment walk — §6 Step 1 regrounds the structured diagnostic only.
+/// Incremental maintenance (avoiding this rebuild) is §6 Step 3, benchmark-gated.
 fn push_scope_failures(
   root : @core.ProjNode[@ast.Term],
   source_map : @core.SourceMap,

--- a/lang/lambda/semantic/semantic_projection_test.mbt
+++ b/lang/lambda/semantic/semantic_projection_test.mbt
@@ -66,6 +66,119 @@ test "semantic projection reports free variable" {
 }
 
 ///|
+test "free-variable diagnostic in a module def is scope-sourced" {
+  // `z` is free in def 0's init; the body `a` resolves to def 0. This exercises
+  // the scope-graph diagnostic path through the MODULE route (not just the bare
+  // lambda route), proving `push_scope_failures` reconstructs and resolves the
+  // module-def graph rather than the diagnostic still coming from stale env logic.
+  let (root, source_map, module_projection) = parse_flat_fixture("let a = z\na")
+  let projection = build_semantic_projection_with_module_projection(
+    root,
+    source_map,
+    Some(module_projection),
+  )
+  inspect(projection.diagnostics.length(), content="1")
+  inspect(projection.diagnostics[0].message, content="Free variable 'z'")
+}
+
+///|
+/// Differential oracle. The scope-graph classifier (`failures()`, i.e.
+/// `resolution.decl is None`) must agree, reference-by-reference, with the
+/// environment walk (`analyze_var`'s "bound "/"free " annotation) that drives
+/// the visual decorations. The env walk recurses into nested blocks with a
+/// sequential `scoped` env, so it is the oracle here.
+///
+/// Hand-checked oracle spot-check (shadowing): for
+/// `let x = 1\nlet y = { let x = 2; x }\ny`, the block's `x` shadows the outer
+/// `x`; the block body `x` resolves to the block `x`; every reference is bound,
+/// so the env walk reports 0 free — which is correct.
+///
+/// This is the test that would have caught the block-scope regression: before
+/// the builder modelled nested-block (`Module`) scopes, the graph reported
+/// block-local bindings as free while the env walk bound them.
+fn assert_classifiers_agree(program : String) -> Unit raise {
+  let (root, source_map) = parse_fixture(program)
+  let projection = build_semantic_projection(root, source_map)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(root)
+  let graph = @lambda_scope.build(module_projection, registry, source_map)
+  for r in graph.refs {
+    let scope_free = r.resolution.decl is None
+    let anns = match projection.annotations.get(r.node_id) {
+      Some(anns) => anns
+      None => []
+    }
+    let env_free = anns.iter().any(fn(a) { a.label == "free " + r.name })
+    let env_bound = anns.iter().any(fn(a) { a.label == "bound " + r.name })
+    // The env walk must classify every reference exactly once; "no annotation"
+    // is itself a regression (Codex pre-PR finding), not an implicit "bound".
+    if env_free == env_bound {
+      fail(
+        "env walk did not classify `" +
+        r.name +
+        "` exactly once in `" +
+        program +
+        "` (free=" +
+        env_free.to_string() +
+        " bound=" +
+        env_bound.to_string() +
+        ")",
+      )
+    }
+    if scope_free != env_free {
+      fail(
+        "classifier disagreement in `" +
+        program +
+        "` for `" +
+        r.name +
+        "`: scope_free=" +
+        scope_free.to_string() +
+        " env_free=" +
+        env_free.to_string(),
+      )
+    }
+  }
+}
+
+///|
+fn scope_free_names(program : String) -> Array[String] raise {
+  let (root, source_map) = parse_fixture(program)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(root)
+  let graph = @lambda_scope.build(module_projection, registry, source_map)
+  @lambda_scope.failures(graph, source_map).map(fn(f) { f.name })
+}
+
+///|
+test "scope and env classifiers agree on block programs" {
+  // block-local binding: `x` is bound inside the block (was the regression)
+  assert_classifiers_agree("let y = { let x = 1; x }\ny")
+  // doubly-nested blocks: two simultaneously non-trivial cutoffs
+  assert_classifiers_agree("let o = { let a = 1; { let b = a; b } }\no")
+  // block def shadows an outer def
+  assert_classifiers_agree("let x = 1\nlet y = { let x = 2; x }\ny")
+  // cross-boundary ref to an outer def that precedes the block (sequential)
+  assert_classifiers_agree("let a = 1\nlet y = { let b = a; b }\ny")
+  // genuine free var inside a block — both classifiers must agree it is free
+  assert_classifiers_agree("let y = { let b = q; b }\ny")
+}
+
+///|
+test "block classifier non-vacuity: block-local bound, block-free surfaced" {
+  // The block-local `x` must NOT be reported free (it is bound in the block).
+  assert_false(scope_free_names("let y = { let x = 1; x }\ny").contains("x"))
+  // A genuinely free `q` inside a block MUST be surfaced, and it must be the
+  // ONLY failure — length 1 + contains `q` proves the set is exactly `["q"]`,
+  // closing the reverse direction the per-ref oracle leaves open (a silently
+  // dropped ref would under-report here).
+  let block_free = scope_free_names("let y = { let b = q; b }\ny")
+  assert_eq(block_free.length(), 1)
+  assert_true(block_free.contains("q"))
+}
+
+///|
 test "semantic projection respects sequential module bindings" {
   let (root, source_map, module_projection) = parse_flat_fixture(
     "let x = 1\nlet y = x\nx + y",


### PR DESCRIPTION
## Summary

- **Adds `failures(g, sm) -> Array[ReachableFailure]`** — a derived view over the lambda scope graph surfacing each unresolved reference (`resolution.decl is None`) as a witnessed `ReachableFailure` (source span + `visited_scopes` witness). Research note 2026-06-13 §6 Step 1.
- **Regrounds the free-variable diagnostic** onto `failures()` (`push_scope_failures`); the semantic env-walk now drives only the bound/free annotations and decorations.
- **Fixes the builder to model nested-block (`Module`) scopes** so block-local bindings resolve correctly: `pass2` opens a child scope per nested `Module` with its own block-local `ModuleDef` decls, and the single-`Int` `containing_def_index` is replaced by a per-`(node, scope)` `node_cutoffs` map so each module scope on the chain gates visibility independently. Without this, the regrounded diagnostic regressed block programs.
- **Guards the two classifiers** (scope graph vs env-walk) with a reference-by-reference differential oracle over a block corpus — it fails on the old builder, passes on the new.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `g.refs` / `Ref.resolution.decl` | `lang/lambda/scope/graph.mbt` | Yes | `failures()` derives over existing resolution; no new resolution logic |
| `Resolution.visited_scopes` | `graph.mbt` | Yes | reused verbatim as the failure witness |
| `@core.SourceMap::get_range` | `core` | Yes | reference-span lookup for locations |
| `@protocol.Diagnostic` | `protocol` | Yes | diagnostic emission (the regrounding target) |
| `DeclKind::ModuleDef(def_index)` | `graph.mbt` | Yes | block-local decls reuse it — no new variant, so no `edits/` exhaustive-match cascade |
| `Array::rev_iter` + `Iter::find_first` | `moonbitlang/core` | Yes | declarative last-match-wins in `resolve` (replaced a `let mut` find-loop) |
| `containing_def_index` | `builder.mbt` (prior) | No — deleted | resolution is now purely structural (tree-position cutoffs); source positions no longer needed |

New helpers added:

- `pub struct ReachableFailure` + `pub fn failures(...)` — the derived view itself; no existing equivalent (the RFA Step 1 deliverable).
- `push_scope_failures` (private) — sources the free-var diagnostic from `failures()`.
- `Builder.node_cutoffs` (private field) — builder-internal per-`(node, scope)` cutoff map; not stored in the graph, so **no `.mbti`/`ScopeGraph` change**.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes — full lambda suite green (1387 js / 257 wasm-gc / 70 native, 0 failures)
- [x] `git diff *.mbti` reviewed — only the intended `failures`/`ReachableFailure` additions to `scope/pkg.generated.mbti`; `build`'s public signature unchanged; `resolve`/`pass3`/`push_scope_failures` are private
- [x] JS rebuild — N/A (no FFI/JS surface change; MoonBit lambda packages only)

## Out of scope (filed, not fixed)

`edits/scope.mbt` keeps a third, still-root-relative resolver, so block-local **rename** remains unsound. Top-level rename is unaffected (edits/ suite green). Tracked in `docs/TODO.md` §20.

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
```

Refs #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic reporting for unresolved variable references, capturing source locations and scope information.

* **Bug Fixes**
  * Improved scope resolution for nested blocks to correctly handle block-local variable bindings.

* **Documentation**
  * Updated backlog items and research notes regarding scope modeling and nested-block scope handling.

* **Tests**
  * Added test coverage for unresolved variable detection and scope resolution validation across block-scoped programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->