### PR TITLE
test(lambda): decide block CstFold compatibility

### DIFF
--- a/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
+++ b/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
@@ -64,11 +64,9 @@ containing the remaining exceptions.
    - `{ }`: current projection `Unit`, CstFold term `Error("empty block")`.
    - `(1)` and `fn f() { 1 }\nf` already agree.
    #629 decided to preserve current Canopy editor semantics and keep Loom's raw
-   CstFold semantics intact. The explicit compatibility boundary is
-   `cstfold_projection_compatible_term` in `lang/lambda/proj`: it recursively
-   normalizes `Module([], body)` to `body` and `Error("empty block")` to `Unit`
-   before parity-checking CstFold terms now or adopting them in later projection
-   slices.
+   CstFold semantics intact. The compatibility boundary normalizes known
+   no-definition block-expression structural patterns before parity-checking
+   CstFold terms now or adopting them in later projection slices.
 4. **Related issues remain adjacent, not substitutes.**
    - #129/#scope work centralized queries but did not remove the
      `ModuleProjection` context requirement.

--- a/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
+++ b/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
@@ -1,6 +1,6 @@
 # Lambda CstFold modernization decision note (#623)
 
-**Status:** proposed first slice  
+**Status:** accepted first slices (#628, #629)
 **Date:** 2026-06-14  
 **Issue:** <https://github.com/dowdiness/canopy/issues/623>
 
@@ -63,8 +63,12 @@ containing the remaining exceptions.
    - `{ 1 }`: current projection `Int(1)`, CstFold term `Module([], Int(1))`.
    - `{ }`: current projection `Unit`, CstFold term `Error("empty block")`.
    - `(1)` and `fn f() { 1 }\nf` already agree.
-   These differences need an explicit compatibility decision before replacing
-   the root builder wholesale.
+   #629 decided to preserve current Canopy editor semantics and keep Loom's raw
+   CstFold semantics intact. The explicit compatibility boundary is
+   `cstfold_projection_compatible_term` in `lang/lambda/proj`: it recursively
+   normalizes `Module([], body)` to `body` and `Error("empty block")` to `Unit`
+   before parity-checking CstFold terms now or adopting them in later projection
+   slices.
 4. **Related issues remain adjacent, not substitutes.**
    - #129/#scope work centralized queries but did not remove the
      `ModuleProjection` context requirement.
@@ -87,8 +91,9 @@ projection without changing editor behavior.
    - **must agree for valid representative sources**: ints, vars, parens,
      `fn` bindings, multi-param arrows, apps, binary expressions, `if`, holes,
      normal modules; or
-   - **legacy divergence**: block-expression empty/single-expression behavior,
-     until a compatibility decision is made; or
+   - **compatibility divergence**: block-expression empty/single-expression
+     behavior remains raw-CstFold divergent but adapter-normalized to current
+     editor semantics; or
    - **recovery divergence**: malformed/recovery CSTs whose current projection
      and CstFold error normalization intentionally differ.
 3. Move one safe `Term` construction responsibility from
@@ -112,7 +117,7 @@ Likely touched files:
 ## Issue slicing
 
 - #628 — add CstFold parity tests.
-- #629 — decide the block-expression divergence.
+- #629 — decide the block-expression divergence (decided: compatibility adapter).
 - #630 — replace safe hand-built `Term` construction with CstFold.
 - #631 — extract a definition index from `ModuleProjection`.
 - #632 — migrate scope/edit/semantic consumers off `ModuleProjection`.

--- a/lang/lambda/proj/cstfold_compat.mbt
+++ b/lang/lambda/proj/cstfold_compat.mbt
@@ -1,0 +1,27 @@
+///|
+/// Normalize Loom Lambda CstFold terms to Canopy's current projection kind
+/// semantics for block expressions.
+///
+/// Loom keeps expression blocks explicit in its raw CstFold term shape:
+/// `{ 1 }` folds to `Module([], Int(1))`, and `{}` folds to
+/// `Error("empty block")`. The Lambda editor already treats a block with no
+/// definitions like grouping syntax and treats an empty block as `Unit`.
+/// Keep that compatibility boundary explicit until the projection pipeline is
+/// fully CstFold-backed. It is private until the production projection path
+/// starts consuming CstFold terms directly; wbtests exercise it meanwhile.
+#warnings("-unused_value")
+fn cstfold_projection_compatible_term(term : @ast.Term) -> @ast.Term {
+  match term {
+    Error("empty block") => Unit
+    Module([], body) => cstfold_projection_compatible_term(body)
+    _ =>
+      match term.children() {
+        [] => term
+        children =>
+          @ast.rebuild_from(
+            term,
+            children.map(fn(child) { cstfold_projection_compatible_term(child) }),
+          )
+      }
+  }
+}

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -54,6 +54,17 @@ fn assert_projection_fold_classification(
 }
 
 ///|
+fn assert_projection_matches_compatible_fold(source : String) -> Unit raise {
+  let (proj, _errors) = parse_to_proj_node(source)
+  let folded = cstfold_projection_compatible_term(cstfold_term(source))
+  assert_term_equal(
+    "expected projection/CstFold compatibility for " + source,
+    folded,
+    proj.kind,
+  )
+}
+
+///|
 test "cstfold parity: valid leaf and wrapper sources agree" {
   assert_clean_projection_kind_matches_fold("42")
   assert_clean_projection_kind_matches_fold("x")
@@ -77,9 +88,15 @@ test "cstfold parity: valid module and fn sources agree" {
 }
 
 ///|
-test "cstfold parity: block expression legacy divergence is pinned" {
+test "cstfold parity: raw block divergence stays behind compatibility adapter" {
   assert_projection_fold_classification("{ 1 }", Int(1), Module([], Int(1)))
   assert_projection_fold_classification("{ }", Unit, Error("empty block"))
+  assert_projection_matches_compatible_fold("{ 1 }")
+  assert_projection_matches_compatible_fold("{ }")
+  assert_projection_matches_compatible_fold("{ { 1 } }")
+  assert_projection_matches_compatible_fold("let x = { }\nx")
+  assert_projection_matches_compatible_fold("let x = { { 1 } }\nx")
+  assert_projection_matches_compatible_fold("{ let x = 1; { x } }")
 }
 
 ///|

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -55,7 +55,12 @@ fn assert_projection_fold_classification(
 
 ///|
 fn assert_projection_matches_compatible_fold(source : String) -> Unit raise {
-  let (proj, _errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(source)
+  if !errors.is_empty() {
+    fail(
+      "expected clean parse for " + source + ", got " + @debug.to_string(errors),
+    )
+  }
   let folded = cstfold_projection_compatible_term(cstfold_term(source))
   assert_term_equal(
     "expected projection/CstFold compatibility for " + source,
@@ -91,10 +96,20 @@ test "cstfold parity: valid module and fn sources agree" {
 test "cstfold parity: raw block divergence stays behind compatibility adapter" {
   assert_projection_fold_classification("{ 1 }", Int(1), Module([], Int(1)))
   assert_projection_fold_classification("{ }", Unit, Error("empty block"))
+  assert_term_equal(
+    "empty block compatibility normalization",
+    Unit,
+    cstfold_projection_compatible_term(Error("empty block")),
+  )
+  assert_term_equal(
+    "nested empty block compatibility normalization",
+    Module([("x", Unit)], Var("x")),
+    cstfold_projection_compatible_term(
+      Module([("x", Error("empty block"))], Var("x")),
+    ),
+  )
   assert_projection_matches_compatible_fold("{ 1 }")
-  assert_projection_matches_compatible_fold("{ }")
   assert_projection_matches_compatible_fold("{ { 1 } }")
-  assert_projection_matches_compatible_fold("let x = { }\nx")
   assert_projection_matches_compatible_fold("let x = { { 1 } }\nx")
   assert_projection_matches_compatible_fold("{ let x = 1; { x } }")
 }


### PR DESCRIPTION
## Summary

- Preserve current Canopy Lambda block-expression projection semantics while keeping Loom's raw CstFold behavior intact.
- Add a private CstFold compatibility adapter and parity coverage for raw-vs-adapted no-def block cases.
- Record the #629 compatibility decision in the #623 modernization note.

Closes #629.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `Term::children` | `dowdiness/lambda/ast` | Yes | Recursively visits term children without duplicating variant traversal. |
| `@ast.rebuild_from` | `dowdiness/lambda/ast` | Yes | Rebuilds recursive terms after normalizing children. |
| `Array::map` | `moonbitlang/core` | Yes | Applies the adapter recursively without manual accumulator loops. |
| `Term::canonical` | `dowdiness/lambda/ast` | No | Canonicalizes AST shape generally; it does not encode Canopy's block compatibility rewrite. |
| `Term::same_kind` | `dowdiness/lambda/ast` | No | Kind comparison only; it cannot transform raw CstFold terms. |

New helpers added (if any):

- `cstfold_projection_compatible_term`: private compatibility boundary for normalizing raw Loom Lambda CstFold terms to current Canopy projection semantics (`Module([], body)` unwraps; `Error("empty block")` becomes `Unit`).

## Test plan

- [x] `NEW_MOON_MOD=0 moon check lang/lambda/proj --deny-warn`
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/proj`
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/flat`
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/companion`
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/edits`
- [x] `NEW_MOON_MOD=0 moon fmt`
- [x] `NEW_MOON_MOD=0 moon info`
- [x] `git diff -- '*.mbti'` reviewed; final diff empty after reverting unrelated newline-only churn
- [x] JS rebuild not run; web unaffected

## Validation

```bash
NEW_MOON_MOD=0 moon check lang/lambda/proj --deny-warn
NEW_MOON_MOD=0 moon test lang/lambda/proj
NEW_MOON_MOD=0 moon test lang/lambda/flat
NEW_MOON_MOD=0 moon test lang/lambda/companion
NEW_MOON_MOD=0 moon test lang/lambda/edits
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Lambda CstFold modernization decision notes with accepted architectural changes and clarified compatibility boundaries for module handling.

* **Tests**
  * Enhanced test coverage for block expression compatibility, ensuring consistent behavior across various source code patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->