### PR TITLE
refactor(lambda): route leaf projection kinds through CstFold

### DIFF
--- a/lang/lambda/proj/cstfold_compat.mbt
+++ b/lang/lambda/proj/cstfold_compat.mbt
@@ -25,6 +25,14 @@ fn cstfold_projection_compatible_term(term : @ast.Term) -> @ast.Term {
 }
 
 ///|
+/// Candidate existing APIs checked: `@parser.syntax_node_to_term` already
+/// converts a CST syntax node through Loom Lambda's CstFold path, but it returns
+/// raw CstFold block semantics. `cstfold_projection_compatible_term` already
+/// normalizes those terms to Canopy projection semantics, but it starts from a
+/// folded `Term` rather than a CST node. This helper's responsibility boundary
+/// is exactly their composition: convert a CST node to a projection-compatible
+/// `Term` by folding with `@parser.syntax_node_to_term`, then applying
+/// `cstfold_projection_compatible_term`.
 fn cstfold_projection_compatible_kind(node : @seam.SyntaxNode) -> @ast.Term {
   cstfold_projection_compatible_term(@parser.syntax_node_to_term(node))
 }

--- a/lang/lambda/proj/cstfold_compat.mbt
+++ b/lang/lambda/proj/cstfold_compat.mbt
@@ -7,9 +7,7 @@
 /// `Error("empty block")`. The Lambda editor already treats a block with no
 /// definitions like grouping syntax and treats an empty block as `Unit`.
 /// Keep that compatibility boundary explicit until the projection pipeline is
-/// fully CstFold-backed. It is private until the production projection path
-/// starts consuming CstFold terms directly; wbtests exercise it meanwhile.
-#warnings("-unused_value")
+/// fully CstFold-backed.
 fn cstfold_projection_compatible_term(term : @ast.Term) -> @ast.Term {
   match term {
     Error("empty block") => Unit
@@ -24,4 +22,9 @@ fn cstfold_projection_compatible_term(term : @ast.Term) -> @ast.Term {
           )
       }
   }
+}
+
+///|
+fn cstfold_projection_compatible_kind(node : @seam.SyntaxNode) -> @ast.Term {
+  cstfold_projection_compatible_term(@parser.syntax_node_to_term(node))
 }

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -67,6 +67,14 @@ fn unit_node_at(pos : Int, counter : Ref[Int]) -> ProjNode[@ast.Term] {
 }
 
 ///|
+/// Candidate existing APIs checked: `ProjNode::leaf` already owns leaf span,
+/// node-id allocation, and childless shape, but it needs a caller-supplied
+/// `Term` kind. `cstfold_projection_compatible_kind` already derives the
+/// CstFold-compatible `Term` kind, but it does not construct a `ProjNode`. This
+/// wrapper is necessary to keep migrated leaf cases from re-pairing those APIs
+/// at each call site. Its responsibility boundary is leaf `ProjNode`
+/// construction only: compute the projection-compatible kind, then delegate all
+/// leaf metadata and identity handling to `ProjNode::leaf`.
 fn cstfold_leaf_node(
   node : @seam.SyntaxNode,
   counter : Ref[Int],

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -67,6 +67,14 @@ fn unit_node_at(pos : Int, counter : Ref[Int]) -> ProjNode[@ast.Term] {
 }
 
 ///|
+fn cstfold_leaf_node(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> ProjNode[@ast.Term] {
+  ProjNode::leaf(cstfold_projection_compatible_kind(node), node, counter)
+}
+
+///|
 fn block_inner_bounds(node : @seam.SyntaxNode) -> (Int, Int) {
   let start = match node.find_token(@syntax.LBraceToken.to_raw()) {
     Some(tok) => tok.end()
@@ -203,14 +211,10 @@ pub fn syntax_to_proj_node(
   node : @seam.SyntaxNode,
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  if @parser.IntLiteralView::cast(node) is Some(v) {
-    let kind : @ast.Term = match v.value() {
-      Some(n) => Int(n)
-      None => Error("invalid integer literal")
-    }
-    ProjNode::leaf(kind, node, counter)
-  } else if @parser.VarRefView::cast(node) is Some(v) {
-    ProjNode::leaf(Var(v.name()), node, counter)
+  if @parser.IntLiteralView::cast(node) is Some(_) {
+    cstfold_leaf_node(node, counter)
+  } else if @parser.VarRefView::cast(node) is Some(_) {
+    cstfold_leaf_node(node, counter)
   } else if @parser.LambdaExprView::cast(node) is Some(v) {
     let body = match v.body() {
       Some(b) => syntax_to_proj_node(b, counter)
@@ -334,7 +338,7 @@ pub fn syntax_to_proj_node(
       )
     }
   } else if @parser.HoleLiteralView::cast(node) is Some(_) {
-    ProjNode::leaf(Hole(0), node, counter)
+    cstfold_leaf_node(node, counter)
   } else {
     error_node_for_syntax(
       "unknown node kind: " + node.kind().to_string(),

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -70,11 +70,64 @@ fn assert_projection_matches_compatible_fold(source : String) -> Unit raise {
 }
 
 ///|
+fn assert_leaf_projection_metadata(
+  source : String,
+  expected_kind : @ast.Term,
+  expected_start : Int,
+  expected_end : Int,
+) -> Unit raise {
+  let (proj, errors) = parse_to_proj_node(source)
+  if !errors.is_empty() {
+    fail(
+      "expected clean parse for " + source + ", got " + @debug.to_string(errors),
+    )
+  }
+  let folded = cstfold_projection_compatible_term(cstfold_term(source))
+  assert_term_equal(
+    "sample should pin CstFold-compatible leaf kind for " + source,
+    expected_kind,
+    folded,
+  )
+  assert_term_equal(
+    "leaf kind should come from CstFold-compatible term for " + source,
+    folded,
+    proj.kind,
+  )
+  if proj.start != expected_start || proj.end != expected_end {
+    fail(
+      "expected leaf span " +
+      expected_start.to_string() +
+      ".." +
+      expected_end.to_string() +
+      " for " +
+      source +
+      ", got " +
+      proj.start.to_string() +
+      ".." +
+      proj.end.to_string(),
+    )
+  }
+  if proj.node_id != 0 {
+    fail("expected first leaf node_id 0 for " + source)
+  }
+  if !proj.children.is_empty() {
+    fail("expected childless leaf projection for " + source)
+  }
+}
+
+///|
 test "cstfold parity: valid leaf and wrapper sources agree" {
   assert_clean_projection_kind_matches_fold("42")
   assert_clean_projection_kind_matches_fold("x")
   assert_clean_projection_kind_matches_fold("_")
   assert_clean_projection_kind_matches_fold("(1)")
+}
+
+///|
+test "cstfold-backed leaf projection preserves leaf metadata" {
+  assert_leaf_projection_metadata("42", Int(42), 0, 2)
+  assert_leaf_projection_metadata("  x", Var("x"), 0, 3)
+  assert_leaf_projection_metadata("_", Hole(0), 0, 1)
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Route Lambda `IntLiteral`, `VarRef`, and `HoleLiteral` projection kinds through existing Loom Lambda CstFold output plus the #629 compatibility adapter.
- Preserve `ProjNode::leaf` construction for leaf spans, node IDs, and childless shape.
- Add white-box coverage pinning CstFold-compatible leaf kinds and ProjNode metadata.

## Reuse check
- Reused `@parser.syntax_node_to_term` for folded Lambda `Term` output.
- Reused `cstfold_projection_compatible_term` to preserve Canopy block-expression semantics decided in #629/#640.
- Reused `ProjNode::leaf` for span/id allocation instead of rebuilding leaf metadata manually.
- Checked `@parser.lambda_fold_node`, `Term::children`, and `@ast.rebuild_from`; `Term::children`/`@ast.rebuild_from` remain used by the compatibility adapter, while direct `lambda_fold_node` use is unnecessary for the leaf-only projection slice.
- Added private helpers only: `cstfold_projection_compatible_kind` owns the SyntaxNode → adapter-normalized Term boundary; `cstfold_leaf_node` owns the leaf ProjNode construction boundary.

## Validation
- `NEW_MOON_MOD=0 moon check lang/lambda/proj --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/lambda/proj`
- `NEW_MOON_MOD=0 moon info`
- `git diff -- '*.mbti'` reviewed; no retained public API diff. Unrelated `moon info` newline churn was reverted.

Closes #630.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and consistency in the internal implementation of syntax analysis and transformation components, consolidating repeated logic into reusable utility functions for better maintainability.

* **Tests**
  * Added new test coverage for metadata preservation in syntax analysis operations, including validation of node classification and boundary information across different syntax element types, improving overall compiler reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->