### PR TITLE
fix(canvas): gate source demo defer sync to js

### DIFF
--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -16,6 +16,10 @@ import {
   "moonbit-community/rabbita/sub",
 }
 
+// Keep this package JS-only until `defer_sync` in `source_demo.mbt` has a
+// non-JS implementation with the same post-mutation defer ordering as browser
+// `queueMicrotask`; a synchronous fallback reintroduces stale source reads.
+
 supported_targets = "js"
 
 options(

--- a/examples/canvas/main/source_demo.mbt
+++ b/examples/canvas/main/source_demo.mbt
@@ -28,18 +28,18 @@ fn js_source_mode_url(enabled : Bool) -> String {
 }
 
 ///|
-/// Run `run` on a microtask. Used to defer the source-graph settle ping so the
-/// synchronous mutation that triggered it completes first (see
+/// Run `run` on a browser microtask. This is load-bearing for the
+/// source-graph settle subscription: settle fires synchronously inside the
+/// attachment mutation, before `SourceBackedGraph.source` has been updated, so
+/// `SyncFromGraph` must run only after that mutation returns (see
 /// `source_graph_change_sub`).
+///
+/// There is deliberately no `#cfg(not(target="js"))` fallback: the source demo
+/// package is pinned to `supported_targets = "js"`, so widening that target set
+/// must first provide a defer primitive with this post-mutation ordering.
 #cfg(target="js")
 extern "js" fn defer_sync(run : () -> Unit) -> Unit =
   #|((run) => { queueMicrotask(() => run()); })
-
-///|
-#cfg(not(target="js"))
-fn defer_sync(run : () -> Unit) -> Unit {
-  run()
-}
 
 ///|
 struct SourceDemoModel {


### PR DESCRIPTION
## Summary

- Remove the synchronous non-JS `defer_sync` fallback from the Canvas source demo so target widening trips a compile-time revisit instead of silently reintroducing stale source reads.
- Document the load-bearing browser microtask ordering at both the `defer_sync` definition and the package `supported_targets = "js"` gate.

Closes #578.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@sub.custom_sub` / `update_tagger` | `moonbit-community/rabbita/sub` | Yes | Existing source-graph subscription flow remains unchanged. |
| `@cmd.Scheduler::add` | `moonbit-community/rabbita/cmd` | Yes | Existing deferred sync enqueue path remains unchanged. |
| `@cmd.delay` / `@sub.every` / `@rabbita.effect` | Rabbita command/subscription APIs | No | These do not provide the required same-turn post-mutation microtask ordering across targets for this settle callback. |

New helpers added (if any):

- None.

## Test plan

- [x] `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon check --target js` passes
- [x] `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon test --target js` passes
- [x] `cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon info --target js`; no `.mbti` diff
- [x] JS rebuild run for affected Canvas web demo (`cd examples/canvas/web && npm run build`)
- [x] Canvas E2E run (`cd examples/canvas/web && npm run test:e2e`)

## Validation

```bash
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon fmt
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon check --target js
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon test --target js
cd examples/canvas && NEW_MOON_MOD=0 MOON_WORK=off moon info --target js
cd examples/canvas/web && npm run build
cd examples/canvas/web && npm run test:e2e
```
