### PR TITLE
refactor(lambda): route if projection through CstFold

### DIFF
--- a/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
+++ b/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
@@ -1,6 +1,6 @@
 # Lambda CstFold modernization decision note (#623)
 
-**Status:** accepted first slices (#628, #629)
+**Status:** accepted first slices (#628, #629, #630); #642 in review
 **Date:** 2026-06-14  
 **Issue:** <https://github.com/dowdiness/canopy/issues/623>
 
@@ -101,8 +101,41 @@ projection without changing editor behavior.
    (`Int`, `Var`, `Hole`) before composite nodes whose `ProjNode.kind` must stay
    consistent with child kinds. Do not change `ModuleProjection` storage, public
    `.mbti` shape, source-map token roles, or the edit bridge in this slice.
-4. Document any retained divergence in the test names/comments rather than
+4. For composite projection nodes, use CstFold only for the parent constructor
+   shape. Do not recursively refold descendants that have already been projected
+   into child `ProjNode`s; rebuild the parent kind from the shallow CstFold shape
+   plus the existing child kinds.
+5. Document any retained divergence in the test names/comments rather than
    silently normalizing it.
+
+### Composite parent-shape rule
+
+`@parser.syntax_node_to_term` is the full recursive fold: it computes every
+child term in the syntax subtree. That is appropriate for leaf/value projection
+and parity tests, but it is the wrong ownership boundary for composite
+`ProjNode` construction because the projection builder has already produced child
+`ProjNode`s with source spans, IDs, child order, source-map meaning, and edit
+identity.
+
+For one-CST-node/one-`ProjNode` composite cases, the safe migration pattern is:
+
+1. Use Loom Lambda's per-node fold algebra to extract only the parent constructor
+   shape with placeholder child terms.
+2. Apply the Canopy compatibility normalization to that shallow shape.
+3. Rebuild the parent `Term` with the already-projected child kinds via
+   `@ast.rebuild_from` / `rebuild_kind`.
+4. Allocate the branch through `ProjNode::branch` so projection metadata remains
+   owned by Canopy.
+
+This is a shallow fold / one-layer fold, not a visitor-specific pattern. In
+recursion-scheme terms, it separates the parent constructor shape from recursive
+child results: the parser/CstFold layer owns semantic constructor selection;
+the projection layer owns identity, spans, and child `ProjNode`s. It also avoids
+repeated suffix refolding for nested composite chains.
+
+Do not apply this pattern blindly to shapes whose projection tree is synthetic
+relative to the CST. `App` and `Bop` remain separate migration problems because
+their CST forms are flat while the current projection shape is nested.
 
 Likely touched files:
 
@@ -116,7 +149,9 @@ Likely touched files:
 
 - #628 — add CstFold parity tests.
 - #629 — decide the block-expression divergence (decided: compatibility adapter).
-- #630 — replace safe hand-built `Term` construction with CstFold.
+- #630 — replace safe leaf/value `Term` construction with CstFold.
+- #642 — migrate safe composite `Term` construction through CstFold-compatible
+  shallow parent shapes.
 - #631 — extract a definition index from `ModuleProjection`.
 - #632 — migrate scope/edit/semantic consumers off `ModuleProjection`.
 - #633 — switch the projection memo stack to the generic 3-memo path.

--- a/lang/lambda/proj/cstfold_compat.mbt
+++ b/lang/lambda/proj/cstfold_compat.mbt
@@ -36,3 +36,19 @@ fn cstfold_projection_compatible_term(term : @ast.Term) -> @ast.Term {
 fn cstfold_projection_compatible_kind(node : @seam.SyntaxNode) -> @ast.Term {
   cstfold_projection_compatible_term(@parser.syntax_node_to_term(node))
 }
+
+///|
+/// Candidate existing APIs checked: `@parser.lambda_fold_node` already exposes
+/// Loom Lambda's per-node CstFold algebra with caller-controlled recursion.
+/// `cstfold_projection_compatible_term` already applies Canopy's block
+/// compatibility normalization to a folded shape. This helper's responsibility
+/// boundary is parent-shape extraction for composite `ProjNode` builders: fold
+/// exactly the requested CST node with placeholder children, normalize that
+/// shallow shape, and leave descendant terms to the already-projected children.
+fn cstfold_projection_compatible_shallow_kind(
+  node : @seam.SyntaxNode,
+) -> @ast.Term {
+  cstfold_projection_compatible_term(
+    @parser.lambda_fold_node(node, fn(_child) { Unit }),
+  )
+}

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -83,12 +83,13 @@ fn cstfold_leaf_node(
 }
 
 ///|
-/// Candidate existing APIs checked: `cstfold_projection_compatible_kind`
-/// already derives the CstFold-compatible composite shape, but its recursive
-/// children come from the raw fold. `rebuild_kind` already reconciles a shape
-/// with projected child kinds via `@ast.rebuild_from`, but it does not allocate
-/// projection metadata. `ProjNode::branch` already owns branch span, child
-/// storage, and fresh ID allocation, but it needs a caller-supplied `Term`.
+/// Candidate existing APIs checked:
+/// `cstfold_projection_compatible_shallow_kind` already derives the
+/// CstFold-compatible composite parent shape without folding descendants.
+/// `rebuild_kind` already reconciles a shape with projected child kinds via
+/// `@ast.rebuild_from`, but it does not allocate projection metadata.
+/// `ProjNode::branch` already owns branch span, child storage, and fresh ID
+/// allocation, but it needs a caller-supplied `Term`.
 /// This wrapper's responsibility boundary is one CST node -> one branch
 /// `ProjNode`: take the CstFold-compatible parent shape, rebuild it with the
 /// already-projected children to preserve recovery behavior, then delegate all
@@ -98,7 +99,7 @@ fn cstfold_branch_node(
   children : Array[ProjNode[@ast.Term]],
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  let shape = cstfold_projection_compatible_kind(node)
+  let shape = cstfold_projection_compatible_shallow_kind(node)
   let kind = rebuild_kind(shape, children)
   ProjNode::branch(kind, node.start(), node.end(), children, counter)
 }

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -83,6 +83,27 @@ fn cstfold_leaf_node(
 }
 
 ///|
+/// Candidate existing APIs checked: `cstfold_projection_compatible_kind`
+/// already derives the CstFold-compatible composite shape, but its recursive
+/// children come from the raw fold. `rebuild_kind` already reconciles a shape
+/// with projected child kinds via `@ast.rebuild_from`, but it does not allocate
+/// projection metadata. `ProjNode::branch` already owns branch span, child
+/// storage, and fresh ID allocation, but it needs a caller-supplied `Term`.
+/// This wrapper's responsibility boundary is one CST node -> one branch
+/// `ProjNode`: take the CstFold-compatible parent shape, rebuild it with the
+/// already-projected children to preserve recovery behavior, then delegate all
+/// branch metadata and identity handling to `ProjNode::branch`.
+fn cstfold_branch_node(
+  node : @seam.SyntaxNode,
+  children : Array[ProjNode[@ast.Term]],
+  counter : Ref[Int],
+) -> ProjNode[@ast.Term] {
+  let shape = cstfold_projection_compatible_kind(node)
+  let kind = rebuild_kind(shape, children)
+  ProjNode::branch(kind, node.start(), node.end(), children, counter)
+}
+
+///|
 fn block_inner_bounds(node : @seam.SyntaxNode) -> (Int, Int) {
   let start = match node.find_token(@syntax.LBraceToken.to_raw()) {
     Some(tok) => tok.end()
@@ -302,13 +323,7 @@ pub fn syntax_to_proj_node(
       Some(n) => syntax_to_proj_node(n, counter)
       None => error_node_for_syntax("missing else branch", node, counter)
     }
-    ProjNode::branch(
-      If(cond.kind, then_.kind, else_.kind),
-      node.start(),
-      node.end(),
-      [cond, then_, else_],
-      counter,
-    )
+    cstfold_branch_node(node, [cond, then_, else_], counter)
   } else if @parser.ParenExprView::cast(node) is Some(v) {
     match v.inner() {
       Some(inner) => {

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -5,6 +5,16 @@ fn cstfold_term(source : String) -> @ast.Term raise {
 }
 
 ///|
+fn cstfold_shallow_first_child(source : String) -> @ast.Term raise {
+  let (cst, _) = @parser.parse_cst(source)
+  let root = @seam.SyntaxNode::from_cst(cst)
+  match root.children() {
+    [expr, ..] => cstfold_projection_compatible_shallow_kind(expr)
+    [] => fail("expected expression child for " + source)
+  }
+}
+
+///|
 fn assert_term_equal(
   context : String,
   expected : @ast.Term,
@@ -155,6 +165,21 @@ test "cstfold parity: valid composite sources agree" {
   assert_clean_projection_kind_matches_fold("(f, x) => f x")
   assert_clean_projection_kind_matches_fold("1 + 2 + 3")
   assert_clean_projection_kind_matches_fold("if x then 1 else 2")
+}
+
+///|
+test "cstfold-backed branch shape does not fold nested if children" {
+  let source = "if x then if y then 1 else 2 else 3"
+  assert_term_equal(
+    "recursive fold should still see the nested if",
+    If(Var("x"), If(Var("y"), Int(1), Int(2)), Int(3)),
+    cstfold_projection_compatible_term(cstfold_term(source)),
+  )
+  assert_term_equal(
+    "shallow IfExpr parent shape should use placeholders for children",
+    If(Unit, Unit, Unit),
+    cstfold_shallow_first_child(source),
+  )
 }
 
 ///|

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -70,6 +70,35 @@ fn assert_projection_matches_compatible_fold(source : String) -> Unit raise {
 }
 
 ///|
+fn assert_projection_metadata(
+  context : String,
+  proj : ProjNode[@ast.Term],
+  expected_start : Int,
+  expected_end : Int,
+  expected_node_id : Int,
+) -> Unit raise {
+  if proj.start != expected_start ||
+    proj.end != expected_end ||
+    proj.node_id != expected_node_id {
+    fail(
+      context +
+      ": expected metadata " +
+      expected_start.to_string() +
+      ".." +
+      expected_end.to_string() +
+      " #" +
+      expected_node_id.to_string() +
+      ", got " +
+      proj.start.to_string() +
+      ".." +
+      proj.end.to_string() +
+      " #" +
+      proj.node_id.to_string(),
+    )
+  }
+}
+
+///|
 fn assert_leaf_projection_metadata(
   source : String,
   expected_kind : @ast.Term,
@@ -93,23 +122,13 @@ fn assert_leaf_projection_metadata(
     folded,
     proj.kind,
   )
-  if proj.start != expected_start || proj.end != expected_end {
-    fail(
-      "expected leaf span " +
-      expected_start.to_string() +
-      ".." +
-      expected_end.to_string() +
-      " for " +
-      source +
-      ", got " +
-      proj.start.to_string() +
-      ".." +
-      proj.end.to_string(),
-    )
-  }
-  if proj.node_id != 0 {
-    fail("expected first leaf node_id 0 for " + source)
-  }
+  assert_projection_metadata(
+    "leaf projection for " + source,
+    proj,
+    expected_start,
+    expected_end,
+    0,
+  )
   if !proj.children.is_empty() {
     fail("expected childless leaf projection for " + source)
   }
@@ -136,6 +155,67 @@ test "cstfold parity: valid composite sources agree" {
   assert_clean_projection_kind_matches_fold("(f, x) => f x")
   assert_clean_projection_kind_matches_fold("1 + 2 + 3")
   assert_clean_projection_kind_matches_fold("if x then 1 else 2")
+}
+
+///|
+test "cstfold-backed if projection preserves branch metadata" {
+  let source = "if x then 1 else 2"
+  let (proj, errors) = parse_to_proj_node(source)
+  if !errors.is_empty() {
+    fail(
+      "expected clean parse for " + source + ", got " + @debug.to_string(errors),
+    )
+  }
+  let folded = cstfold_projection_compatible_term(cstfold_term(source))
+  assert_term_equal(
+    "if parent kind should come from CstFold-compatible term",
+    folded,
+    proj.kind,
+  )
+  assert_projection_metadata("if parent", proj, 0, 18, 3)
+  match proj.children {
+    [cond, then_, else_] => {
+      assert_term_equal("if condition child kind", Var("x"), cond.kind)
+      assert_term_equal("if then child kind", Int(1), then_.kind)
+      assert_term_equal("if else child kind", Int(2), else_.kind)
+      assert_projection_metadata("if condition child", cond, 2, 4, 0)
+      assert_projection_metadata("if then child", then_, 9, 11, 1)
+      assert_projection_metadata("if else child", else_, 16, 18, 2)
+    }
+    _ => fail("expected exactly three if children")
+  }
+}
+
+///|
+test "cstfold-backed if projection preserves recovered child kind" {
+  let source = "if 1 + then 2 else 3"
+  let (proj, errors) = parse_to_proj_node(source)
+  if errors.is_empty() {
+    fail("expected recovery diagnostics for " + source)
+  }
+  let folded = cstfold_projection_compatible_term(cstfold_term(source))
+  if folded == proj.kind {
+    fail(
+      "expected legacy recovered child kind to differ from raw CstFold child",
+    )
+  }
+  assert_term_equal(
+    "if parent should rebuild CstFold-compatible shape from projected children",
+    rebuild_kind(folded, proj.children),
+    proj.kind,
+  )
+  match proj.children {
+    [cond, then_, else_] => {
+      match cond.kind {
+        Bop(Plus, Int(1), Error(projected_msg)) =>
+          inspect(projected_msg.contains("unknown node kind"), content="true")
+        _ => fail("unexpected recovered if condition child")
+      }
+      assert_term_equal("recovered if then child kind", Int(2), then_.kind)
+      assert_term_equal("recovered if else child kind", Int(3), else_.kind)
+    }
+    _ => fail("expected exactly three recovered if children")
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add a private CstFold-backed branch helper for one-CST-node/one-`ProjNode` composite projection construction
- route Lambda `IfExpr` parent construction through a shallow CstFold-compatible parent shape + `rebuild_kind`, while preserving projected children, spans, and IDs
- add CstFold metadata, nested-if shallow-shape, and recovery tests for `IfExpr`
- document the composite parent-shape rule in the Lambda CstFold modernization plan

Closes #642.

## Reuse check
- Reused `@parser.lambda_fold_node` for non-recursive parent-shape extraction.
- Reused `cstfold_projection_compatible_term` for Canopy's block compatibility normalization.
- Reused `rebuild_kind` / `@ast.rebuild_from` to reconcile CstFold parent shape with already-projected children.
- Reused `ProjNode::branch` for span, child storage, and fresh ID allocation.
- Checked but did not migrate `App`/`Bop` because their projection shape is synthetic/nested relative to the flat CST shape.
- New helpers: private `cstfold_projection_compatible_shallow_kind` and `cstfold_branch_node`, bounded to one CST node → one branch `ProjNode`.

## Validation
- `NEW_MOON_MOD=0 moon check lang/lambda/proj --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/lambda/proj`
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info`
- `git diff -- '*.mbti'` (empty after reverting unrelated trailing-newline churn)
- `git diff --check`
- `bash scripts/check-agent-doc-links.sh`
