### PR TITLE
feat(lambda): resolve block-local bindings in edits/ rename (RFA Step 1 follow-up)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -479,25 +479,37 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Remaining: gated query-indexing is the only open scope follow-up here; the
   binder-location plan itself is complete.
 
-- [ ] Teach `edits/` resolvers about nested-block (`Module`) scopes.
-  Why: RFA Step 1 (#617) made the scope-graph builder model nested-block scopes,
-  so `failures()`/diagnostics resolve block-local bindings correctly. But
-  `edits/scope.mbt`'s parallel resolver (`declaration_id_for_name_from_scope` +
-  `def_cutoff_at_node`) still applies one root-relative cutoff to every
-  `ModuleDef` scope, and `text_edit_rename.mbt` / inline interpret
-  `DeclKind::ModuleDef(def_index)` against `ctx.module_projection.defs` (the root
-  module only). Top-level rename is unaffected (verified: edits/ suite green),
-  but renaming or referencing a *block-local* binding is now unsound — the graph
-  resolves it to a nested decl whose `def_index` is block-relative, which the
-  edits layer reads as root-relative. Pre-existing blind spot, newly reachable
-  because the graph now emits nested `ModuleDef` decls (Codex pre-PR review,
-  #617).
-  Plan: GitHub issue — generalize the edits resolver to the per-(node, scope)
-  cutoff model the builder now uses (see `lang/lambda/scope/builder.mbt`
-  `node_cutoffs`), keying `def_index` to its declaring scope rather than the root
-  module.
-  Exit: a rename of a block-local binding (`let y = { let x = 1; x }`) renames
-  only the block-local `x`, with a wbtest fixture asserting it.
+- [x] Block-local **rename** soundness (§20 exit criterion).
+  Shipped: `rename_from_var` / `rename_binding_by_id` / `rename_module_binding`
+  in `text_edit_rename.mbt` no longer round-trip the block-aware `Decl` back into
+  a root-relative `def_index`. They thread the resolved `Decl` + graph straight
+  through, deriving references via `@scope.references(g, decl.id)`, the binder
+  span directly off the decl's own `LetDef` node (no root `module_node_id`
+  fallback for nested decls), and the dup-name guard off the decl's own scope
+  siblings. Block-local var-rename AND binder-click rename are now sound; the
+  capture guard stays conservative (over-rejects when `new_name` is bound in an
+  ancestor the renamed binder would shadow — sound, never mis-renames). wbtests:
+  `Rename block-local binding leaves root binding intact`, `Rename block-local
+  binding by binder id`, `Rename block reference to outer binding renames root`.
+
+- [ ] Teach `edits/` **inline / extract / binding** ops about nested-block scopes.
+  Why: rename is fixed (above) by delegating to the already-block-aware `@scope`
+  API. But `text_edit_refactor.mbt` (inline/extract) and `text_edit_binding.mbt`
+  still convert the block-aware `Decl` into a root-relative `def_index`:
+  `module_def_references(g, def_index)` returns the FIRST decl at that index (root
+  wins over a block-local def at the same index), and `module_projection.defs[
+  def_index]` / `find_def_index` index the ROOT module's defs only. So inlining a
+  block-local `x` inlines the ROOT def's value, and the capture guard
+  (`def_cutoff_at_node` + `declaration_id_for_name_from_scope`, scope.mbt) applies
+  one root-relative cutoff. Pre-existing blind spot, already unsound today —
+  rename-only is strict progress, not a regression.
+  Plan: GitHub issue — for references/binder, decl-thread the same way rename now
+  does. For the *capture analysis* (a hypothetical-position query: "what would
+  name N resolve to if the init moved to position P"), generalize to the
+  per-(node, scope) cutoff model the builder uses (`lang/lambda/scope/builder.mbt`
+  `node_cutoffs`), keying each `def_index` to its declaring scope.
+  Exit: inlining/extracting a block-local binding (`let y = { let x = 1; x }`)
+  operates on the block-local `x`, with a wbtest fixture asserting it.
 
 ## Shipped history
 

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -105,6 +105,55 @@ fn root_scope_id(g : @scope.ScopeGraph) -> @scope.ScopeId? {
 }
 
 ///|
+/// Whether `scope` is `ancestor` itself or any descendant of it — i.e. whether
+/// `ancestor` lies on `scope`'s parent chain. Used to test if a reference sits
+/// inside a declaration's visibility region (its declaring scope's subtree).
+fn scope_is_within(
+  g : @scope.ScopeGraph,
+  scope : @scope.ScopeId,
+  ancestor : @scope.ScopeId,
+) -> Bool {
+  let mut cur : @scope.ScopeId? = Some(scope)
+  while cur is Some(sid) {
+    if sid == ancestor {
+      return true
+    }
+    let @scope.ScopeId(si) = sid
+    cur = g.scopes[si].parent
+  }
+  false
+}
+
+///|
+/// Whether renaming `decl` to `new_name` would CAPTURE an existing reference: a
+/// `Var(new_name)` used inside `decl`'s scope subtree that currently resolves to
+/// a binding OUTSIDE that subtree (or is free). After the rename the new local
+/// binder would shadow that outer binding and silently re-target the reference,
+/// so such a rename must be rejected. References already resolving inside the
+/// subtree are unaffected; same-scope siblings are handled by the dup-name guard.
+fn rename_captures_existing_use(
+  g : @scope.ScopeGraph,
+  decl : @scope.Decl,
+  new_name : String,
+) -> Bool {
+  g.refs
+  .iter()
+  .any(fn(r) {
+    r.name == new_name &&
+    scope_is_within(g, r.scope, decl.scope) &&
+    (match r.resolution.decl {
+      // Free use inside the region → would become bound to the renamed decl.
+      None => true
+      // Bound to a binding outside the region → would be shadowed (captured).
+      Some(rid) => {
+        let @scope.DeclId(di) = rid
+        !scope_is_within(g, g.decls[di].scope, decl.scope)
+      }
+    })
+  })
+}
+
+///|
 fn declaration_id_for_name_from_scope(
   g : @scope.ScopeGraph,
   start_scope : @scope.ScopeId,

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -322,14 +322,17 @@ fn module_binder_name_range(
 /// root-relative `def_index` — so every lookup (references, binder location,
 /// sibling collision) stays scoped to the declaration's own block.
 ///
-/// Capture analysis is conservative: a rename is rejected if `new_name` is
-/// visible in ANY enclosing scope at a usage site, including an ancestor that
-/// the renamed binder would shadow. This over-approximates the capture set,
-/// which is sound (never mis-renames) but may reject some legal renames; a
-/// precise scope-bounded analysis is tracked in docs/TODO.md §20. It also does
-/// not rewrite a previously-free `Var(new_name)` elsewhere, so — as with the
-/// existing top-level rename — alpha-renaming that newly captures an unrelated
-/// free occurrence is out of scope.
+/// Capture analysis is conservative (sound — never mis-renames — but may reject
+/// some legal renames; precise scope-bounded analysis is tracked in
+/// docs/TODO.md §20). It rejects in both directions:
+/// - D's own references rebinding OUTWARD: `new_name` visible in any enclosing
+///   scope at a usage site (`name_captured_at_node`), including an ancestor the
+///   renamed binder would shadow;
+/// - an existing `new_name` use captured INWARD: a `Var(new_name)` inside D's
+///   region resolving outside it (or free) that the renamed binder would shadow
+///   (`rename_captures_existing_use`).
+/// The inward check over-approximates (e.g. a same-scope use before D, or D's own
+/// initializer, is rejected though sequentially safe).
 fn rename_module_binding(
   ctx : EditContext[@ast.Term],
   g : @scope.ScopeGraph,
@@ -349,6 +352,15 @@ fn rename_module_binding(
     }) else {
     return Err(
       "Cannot rename: binding '" + new_name + "' already exists in this scope",
+    )
+  }
+  // Guard: an EXISTING new_name use inside the decl's region would be captured
+  // by the renamed binder (e.g. a block body `y` resolving to an outer `y`).
+  guard !rename_captures_existing_use(g, decl, new_name) else {
+    return Err(
+      "Cannot rename: '" +
+      new_name +
+      "' is already used at a site the renamed binding would capture",
     )
   }
   // References resolved to THIS declaration (identity-based, shadowing-correct).

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -9,8 +9,14 @@ fn compute_rename(
       match n.kind {
         @ast.Term::Var(old_name) =>
           rename_from_var(ctx, node_id, old_name, new_name)
-        @ast.Term::Lam(old_name, _) =>
-          rename_lam_param(ctx, node_id, n, old_name, new_name)
+        @ast.Term::Lam(old_name, _) => {
+          let g = @scope.build(
+            ctx.module_projection,
+            ctx.registry,
+            ctx.source_map,
+          )
+          rename_lam_param(ctx, g, node_id, n, old_name, new_name)
+        }
         _ => rename_binding_by_id(ctx, node_id, new_name)
       }
     None => rename_binding_by_id(ctx, node_id, new_name)
@@ -146,13 +152,13 @@ fn new_name_captured_before_lam(
 /// Rename a Lam's parameter and all bound Var occurrences in its body.
 fn rename_lam_param(
   ctx : EditContext[@ast.Term],
+  g : @scope.ScopeGraph,
   lam_id : NodeId,
   lam_node : ProjNode[@ast.Term],
   old_name : String,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
   let source_map = ctx.source_map
-  let g = @scope.build(ctx.module_projection, ctx.registry, source_map)
   let ref_ids = match lambda_param_references(g, lam_id) {
     Ok(ids) => ids
     Err(e) => return Err(e)
@@ -253,7 +259,7 @@ fn rename_from_var(
     DeclKind::LamParam(lam_id~) =>
       match ctx.registry.get(lam_id) {
         Some(lam_node) =>
-          rename_lam_param(ctx, lam_id, lam_node, old_name, new_name)
+          rename_lam_param(ctx, g, lam_id, lam_node, old_name, new_name)
         None => Err("Lambda node not found in registry")
       }
     // The decl is already the block-aware declaration the var resolves to;

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -256,116 +256,120 @@ fn rename_from_var(
           rename_lam_param(ctx, lam_id, lam_node, old_name, new_name)
         None => Err("Lambda node not found in registry")
       }
-    DeclKind::ModuleDef(def_index~) => {
-      // Find the Module node in the registry.
-      // Mutable slot records the first hit without materializing registry entries.
-      let mut module_id : NodeId? = None
-      // Manual scan can break as soon as the Module node is found.
-      for pid, pnode in ctx.registry {
-        if pnode.kind is @ast.Term::Module(_, _) {
-          module_id = Some(pid)
-          break
-        }
-      }
-      match module_id {
-        Some(mid) =>
-          rename_module_binding(ctx, mid, def_index, old_name, new_name)
-        None => Err("Module node not found in registry")
-      }
-    }
+    // The decl is already the block-aware declaration the var resolves to;
+    // thread it straight through (its `def_index` is scope-relative and must
+    // NOT be re-interpreted against the root module's defs).
+    DeclKind::ModuleDef(_) =>
+      rename_module_binding(ctx, g, decl, old_name, new_name)
   }
 }
 
 ///|
-/// Rename a module binding by its binding_node_id.
+/// Rename a module binding by its binding_node_id. Resolves the binder to its
+/// graph declaration by structural node id, so a block-local LetDef binder
+/// renames its own scope's binding rather than a root def at the same index.
 fn rename_binding_by_id(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let def_index = match find_def_index(ctx.module_projection, binding_node_id) {
-    Ok(i) => i
-    Err(e) => return Err(e)
+  let g = @scope.build(ctx.module_projection, ctx.registry, ctx.source_map)
+  guard g.decls
+    .iter()
+    .find_first(fn(d) {
+      d.node_id == binding_node_id && d.kind is DeclKind::ModuleDef(_)
+    })
+    is Some(decl) else {
+    return Err("Binding not found: " + binding_node_id.to_string())
   }
-  let old_name = ctx.module_projection.defs[def_index].0
-  // Find Module node.
-  // Mutable slot records the first hit without materializing registry entries.
-  let mut module_id : NodeId? = None
-  // Manual scan can break as soon as the Module node is found.
-  for pid, pnode in ctx.registry {
-    if pnode.kind is @ast.Term::Module(_, _) {
-      module_id = Some(pid)
-      break
-    }
-  }
-  match module_id {
-    Some(mid) => rename_module_binding(ctx, mid, def_index, old_name, new_name)
-    None => Err("Module node not found in registry")
+  rename_module_binding(ctx, g, decl, decl.name, new_name)
+}
+
+///|
+/// The binder NAME token span for a module definition, read directly from the
+/// decl's own `LetDef` node so a block-local binder is located in its own scope.
+/// The `module_name_role` compatibility spans live only on the ROOT module node,
+/// so that fallback fires solely for a root-scope decl; a nested decl with no
+/// `LetDef` span has no sound fallback and stays `None` (caller errors), never
+/// resolving to a root-relative location.
+fn module_binder_name_range(
+  g : @scope.ScopeGraph,
+  decl : @scope.Decl,
+  source_map : SourceMap,
+) -> @loomcore.Range? {
+  match
+    source_map.get_token_span(decl.node_id, @lambda_proj.LET_DEF_NAME_ROLE) {
+    Some(r) => Some(r)
+    None =>
+      if root_scope_id(g) is Some(rs) && decl.scope == rs {
+        match decl.kind {
+          DeclKind::ModuleDef(def_index~) =>
+            source_map.get_token_span(
+              g.module_node_id,
+              @lambda_proj.module_name_role(def_index),
+            )
+          _ => None
+        }
+      } else {
+        None
+      }
   }
 }
 
 ///|
-/// Core rename logic for a module-level binding: renames the binding name token + all usages.
+/// Core rename logic for a module-level binding (top-level OR block-local).
+/// Operates on the resolved `decl` and the graph that produced it — never on a
+/// root-relative `def_index` — so every lookup (references, binder location,
+/// sibling collision) stays scoped to the declaration's own block.
+///
+/// Capture analysis is conservative: a rename is rejected if `new_name` is
+/// visible in ANY enclosing scope at a usage site, including an ancestor that
+/// the renamed binder would shadow. This over-approximates the capture set,
+/// which is sound (never mis-renames) but may reject some legal renames; a
+/// precise scope-bounded analysis is tracked in docs/TODO.md §20. It also does
+/// not rewrite a previously-free `Var(new_name)` elsewhere, so — as with the
+/// existing top-level rename — alpha-renaming that newly captures an unrelated
+/// free occurrence is out of scope.
 fn rename_module_binding(
   ctx : EditContext[@ast.Term],
-  module_id : NodeId,
-  def_index : Int,
+  g : @scope.ScopeGraph,
+  decl : @scope.Decl,
   old_name : String,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let { source_map, registry, module_projection, .. } = ctx
-  // Guard: check if another binding already uses new_name
-  for i, def in module_projection.defs {
-    if i != def_index && def.0 == new_name {
+  let source_map = ctx.source_map
+  // No-op rename: nothing to edit, and dup/capture checks do not apply.
+  guard new_name != old_name else { return Ok(Some(([], RestoreCursor))) }
+  // Guard: a sibling binding in the SAME scope already uses new_name. Keyed on
+  // the declaration's scope (block-local aware), not the root module's defs.
+  for d2 in g.decls {
+    if d2.scope == decl.scope && d2.id != decl.id && d2.name == new_name {
       return Err(
-        "Cannot rename: binding '" +
-        new_name +
-        "' already exists at index " +
-        i.to_string(),
+        "Cannot rename: binding '" + new_name + "' already exists in this scope",
       )
     }
   }
-  // Find all references resolved to this binding.
-  let g = @scope.build(module_projection, registry, source_map)
-  let ref_ids = match module_def_references(g, def_index) {
-    Ok(ids) => ids
-    Err(e) => return Err(e)
-  }
-  // Guard: check if new_name would be captured by an enclosing scope at any reference site
+  // References resolved to THIS declaration (identity-based, shadowing-correct).
+  let ref_ids = @scope.references(g, decl.id)
+  // Guard: new_name would be captured by an enclosing scope at a usage site.
   for ref_id in ref_ids {
-    if new_name != old_name && name_captured_at_node(g, ref_id, new_name) {
+    if name_captured_at_node(g, ref_id, new_name) {
       return Err(
         "Cannot rename: '" +
         new_name +
-        "' is bound by an enclosing lambda at a usage site",
+        "' is bound by an enclosing scope at a usage site",
       )
     }
   }
   let edits : Array[SpanEdit] = []
-  // Get the binder-name token span. Prefer the first-class LetDef node; keep
-  // the module-level `name:<i>` lookup as a migration fallback for older maps.
-  let binding_node_id = module_projection.defs[def_index].3
-  let name_range = match
-    source_map.get_token_span(binding_node_id, @lambda_proj.LET_DEF_NAME_ROLE) {
-    Some(r) => Some(r)
-    None =>
-      source_map.get_token_span(
-        module_id,
-        @lambda_proj.module_name_role(def_index),
-      )
+  guard module_binder_name_range(g, decl, source_map) is Some(range) else {
+    return Err("No token span for binding name: " + decl.name)
   }
-  match name_range {
-    Some(range) =>
-      edits.push({
-        start: range.start,
-        delete_len: range.end - range.start,
-        inserted: new_name,
-      })
-    None =>
-      return Err(
-        "No token span for binding name at def index " + def_index.to_string(),
-      )
-  }
+  edits.push({
+    start: range.start,
+    delete_len: range.end - range.start,
+    inserted: new_name,
+  })
   let ref_ranges : Array[(Int, Int)] = []
   // Push loop lets us abort on the first invalid range before emitting edits.
   for rid in ref_ids {

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -342,24 +342,26 @@ fn rename_module_binding(
   guard new_name != old_name else { return Ok(Some(([], RestoreCursor))) }
   // Guard: a sibling binding in the SAME scope already uses new_name. Keyed on
   // the declaration's scope (block-local aware), not the root module's defs.
-  for d2 in g.decls {
-    if d2.scope == decl.scope && d2.id != decl.id && d2.name == new_name {
-      return Err(
-        "Cannot rename: binding '" + new_name + "' already exists in this scope",
-      )
-    }
+  guard !g.decls
+    .iter()
+    .any(fn(d2) {
+      d2.scope == decl.scope && d2.id != decl.id && d2.name == new_name
+    }) else {
+    return Err(
+      "Cannot rename: binding '" + new_name + "' already exists in this scope",
+    )
   }
   // References resolved to THIS declaration (identity-based, shadowing-correct).
   let ref_ids = @scope.references(g, decl.id)
   // Guard: new_name would be captured by an enclosing scope at a usage site.
-  for ref_id in ref_ids {
-    if name_captured_at_node(g, ref_id, new_name) {
-      return Err(
-        "Cannot rename: '" +
-        new_name +
-        "' is bound by an enclosing scope at a usage site",
-      )
-    }
+  guard !ref_ids
+    .iter()
+    .any(fn(ref_id) { name_captured_at_node(g, ref_id, new_name) }) else {
+    return Err(
+      "Cannot rename: '" +
+      new_name +
+      "' is bound by an enclosing scope at a usage site",
+    )
   }
   let edits : Array[SpanEdit] = []
   guard module_binder_name_range(g, decl, source_map) is Some(range) else {

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -286,37 +286,6 @@ fn rename_binding_by_id(
 }
 
 ///|
-/// The binder NAME token span for a module definition, read directly from the
-/// decl's own `LetDef` node so a block-local binder is located in its own scope.
-/// The `module_name_role` compatibility spans live only on the ROOT module node,
-/// so that fallback fires solely for a root-scope decl; a nested decl with no
-/// `LetDef` span has no sound fallback and stays `None` (caller errors), never
-/// resolving to a root-relative location.
-fn module_binder_name_range(
-  g : @scope.ScopeGraph,
-  decl : @scope.Decl,
-  source_map : SourceMap,
-) -> @loomcore.Range? {
-  match
-    source_map.get_token_span(decl.node_id, @lambda_proj.LET_DEF_NAME_ROLE) {
-    Some(r) => Some(r)
-    None =>
-      if root_scope_id(g) is Some(rs) && decl.scope == rs {
-        match decl.kind {
-          DeclKind::ModuleDef(def_index~) =>
-            source_map.get_token_span(
-              g.module_node_id,
-              @lambda_proj.module_name_role(def_index),
-            )
-          _ => None
-        }
-      } else {
-        None
-      }
-  }
-}
-
-///|
 /// Core rename logic for a module-level binding (top-level OR block-local).
 /// Operates on the resolved `decl` and the graph that produced it — never on a
 /// root-relative `def_index` — so every lookup (references, binder location,
@@ -376,7 +345,10 @@ fn rename_module_binding(
     )
   }
   let edits : Array[SpanEdit] = []
-  guard module_binder_name_range(g, decl, source_map) is Some(range) else {
+  // `@scope.binder_span` locates the binder block-locally (it reads
+  // `LET_DEF_NAME_ROLE` off the decl's own `LetDef` node and only falls back to
+  // the root `module_name_role` for a root-scope decl).
+  guard @scope.binder_span(g, decl, source_map) is Some(range) else {
     return Err("No token span for binding name: " + decl.name)
   }
   edits.push({

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1440,6 +1440,28 @@ test "compute_text_edit: Rename block-local binding leaves root binding intact" 
 }
 
 ///|
+/// Capturing an EXISTING use of the target name must be rejected. The block body
+/// `y` resolves to the root `y`; renaming the nested `x` binder to `y` would
+/// silently re-bind that `y` to the new local — so the rename must fail rather
+/// than change the meaning of an existing reference.
+test "compute_text_edit: Rename block binder rejects capture of existing target use" {
+  let text =
+    #|let y = 1
+    #|let z = { let x = 2
+    #|  y }
+    #|z
+  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  // proj.children[1] = LetDef z; its init[0] is the block Module; that block's
+  // child[0] is the nested LetDef x binder.
+  let nested_x = proj.children[1].children[0].children[0]
+  let result = compute_text_edit(
+    Rename(node_id=nested_x.id(), new_name="y"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 /// Block-local rename via the BINDER-CLICK path (`rename_binding_by_id`). The
 /// nested `LetDef` node is resolved to its own block declaration by structural
 /// node id, so it renames the block-local `x`, not the root def at index 0.

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1399,6 +1399,122 @@ test "compute_text_edit: Rename module binding via Var" {
 }
 
 ///|
+/// Block-local rename soundness (docs/TODO.md §20 exit criterion).
+/// Root `x` (def_index 0) and the block-local `x` (also def_index 0) collide on
+/// index, so a root-relative resolver renames the WRONG binding. The only
+/// `Var("x")` in the whole tree is the block body usage, so we locate it by
+/// scanning the registry — renaming it must touch ONLY the block binder + body,
+/// leaving the unrelated root `let x = 1` intact.
+test "compute_text_edit: Rename block-local binding leaves root binding intact" {
+  let text =
+    #|let x = 1
+    #|let y = { let x = 2
+    #|  x }
+    #|y
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  // The block body `x` is the unique Var("x") in the program.
+  let mut inner_x : NodeId? = None
+  for id, node in registry {
+    if node.kind is @ast.Term::Var("x") {
+      inner_x = Some(id)
+    }
+  }
+  guard inner_x is Some(inner_x_id) else {
+    fail("could not locate block-local Var(\"x\")")
+  }
+  let result = compute_text_edit(
+    Rename(node_id=inner_x_id, new_name="w"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(
+        new_text,
+        content=(
+          #|let x = 1
+          #|let y = { let w = 2
+          #|  w }
+          #|y
+        ),
+      )
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+/// Block-local rename via the BINDER-CLICK path (`rename_binding_by_id`). The
+/// nested `LetDef` node is resolved to its own block declaration by structural
+/// node id, so it renames the block-local `x`, not the root def at index 0.
+test "compute_text_edit: Rename block-local binding by binder id" {
+  let text =
+    #|let x = 1
+    #|let y = { let x = 2
+    #|  x }
+    #|y
+  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  // proj.children[1] = LetDef y; its init child[0] is the block Module;
+  // that block's child[0] is the nested LetDef x.
+  let nested_let_def = proj.children[1].children[0].children[0]
+  let result = compute_text_edit(
+    Rename(node_id=nested_let_def.id(), new_name="w"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) =>
+      inspect(
+        apply_edits(text, edits),
+        content=(
+          #|let x = 1
+          #|let y = { let w = 2
+          #|  w }
+          #|y
+        ),
+      )
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+/// A reference inside a block that resolves to an OUTER (root) binding must
+/// still rename the root binding — confirms the decl-threading change keeps
+/// block→outer resolution sound, not just block-local.
+test "compute_text_edit: Rename block reference to outer binding renames root" {
+  let text =
+    #|let x = 1
+    #|let y = { let z = 2
+    #|  x }
+    #|y
+  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  // The block body `x` (unique Var("x")) resolves to the root `x`.
+  let mut inner_x : NodeId? = None
+  for id, node in registry {
+    if node.kind is @ast.Term::Var("x") {
+      inner_x = Some(id)
+    }
+  }
+  guard inner_x is Some(inner_x_id) else { fail("could not locate Var(\"x\")") }
+  let result = compute_text_edit(
+    Rename(node_id=inner_x_id, new_name="w"),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) =>
+      inspect(
+        apply_edits(text, edits),
+        content=(
+          #|let w = 1
+          #|let y = { let z = 2
+          #|  w }
+          #|y
+        ),
+      )
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
 test "compute_text_edit: Rename first duplicate module binding preserves shadowed body" {
   let text = "let x = 0\nlet x = x\nx"
   let (_, sm, registry, fp) = parse_with_token_spans(text)

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1413,15 +1413,11 @@ test "compute_text_edit: Rename block-local binding leaves root binding intact" 
     #|y
   let (_, sm, registry, fp) = parse_with_token_spans(text)
   // The block body `x` is the unique Var("x") in the program.
-  let mut inner_x : NodeId? = None
-  for id, node in registry {
-    if node.kind is @ast.Term::Var("x") {
-      inner_x = Some(id)
-    }
-  }
-  guard inner_x is Some(inner_x_id) else {
+  guard registry.values().find_first(fn(n) { n.kind is @ast.Term::Var("x") })
+    is Some(inner_x) else {
     fail("could not locate block-local Var(\"x\")")
   }
+  let inner_x_id = inner_x.id()
   let result = compute_text_edit(
     Rename(node_id=inner_x_id, new_name="w"),
     make_edit_ctx(text, sm, registry, fp),
@@ -1488,13 +1484,11 @@ test "compute_text_edit: Rename block reference to outer binding renames root" {
     #|y
   let (_, sm, registry, fp) = parse_with_token_spans(text)
   // The block body `x` (unique Var("x")) resolves to the root `x`.
-  let mut inner_x : NodeId? = None
-  for id, node in registry {
-    if node.kind is @ast.Term::Var("x") {
-      inner_x = Some(id)
-    }
+  guard registry.values().find_first(fn(n) { n.kind is @ast.Term::Var("x") })
+    is Some(inner_x) else {
+    fail("could not locate Var(\"x\")")
   }
-  guard inner_x is Some(inner_x_id) else { fail("could not locate Var(\"x\")") }
+  let inner_x_id = inner_x.id()
   let result = compute_text_edit(
     Rename(node_id=inner_x_id, new_name="w"),
     make_edit_ctx(text, sm, registry, fp),

--- a/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -44,6 +44,18 @@ test "go_to_definition: shadowed module def — later def wins (production id pa
 }
 
 ///|
+test "go_to_definition: block-local def — body var jumps to the block binder" {
+  // "let x = { let y = 1\n  y }\nx" — nested name "y" at 14..15; the block body
+  // "y" is at position 22. It must jump to the BLOCK-LOCAL binder (14..15),
+  // proving binder_span locates a nested decl on its own LetDef node and never
+  // falls back to the root module-name span.
+  let (g, sm) = build_fixture_with_spans("let x = { let y = 1\n  y }\nx")
+  guard go_to_definition(g, sm, 22) is Some(r)
+  inspect(r.start, content="14")
+  inspect(r.end, content="15")
+}
+
+///|
 test "go_to_definition: lambda param — body var jumps to the param token" {
   // "(x) => x" — param "x" at 1..2; body var "x" at 7.
   let (g, sm) = build_fixture_with_spans("(x) => x")

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -34,7 +34,11 @@ pub fn references(g : ScopeGraph, decl : DeclId) -> Array[@core.NodeId] {
 /// - lambda param: the `"param"` token span on the `Lam` node;
 /// - module def: the `"name"` token span on the `LetDef` node, with the
 ///   module-level `"name:<def_index>"` span as a migration fallback.
-/// Failure is always `None`, never a wrong location.
+/// Failure is always `None`, never a wrong location. The `module_name_role`
+/// fallback spans live only on the ROOT module node (`g.module_node_id`), so it
+/// is consulted ONLY for a root-scope decl; a nested-block decl with no `LetDef`
+/// span returns `None` rather than a root-relative (wrong) location — preserving
+/// the "never a wrong location" guarantee for block-local binders.
 pub fn binder_span(
   g : ScopeGraph,
   decl : Decl,
@@ -47,11 +51,17 @@ pub fn binder_span(
       match
         source_map.get_token_span(decl.node_id, @lambda_proj.LET_DEF_NAME_ROLE) {
         Some(range) => Some(range)
-        None =>
-          source_map.get_token_span(
-            g.module_node_id,
-            @lambda_proj.module_name_role(def_index),
-          )
+        None => {
+          let ScopeId(si) = decl.scope
+          if g.scopes[si].parent is None {
+            source_map.get_token_span(
+              g.module_node_id,
+              @lambda_proj.module_name_role(def_index),
+            )
+          } else {
+            None
+          }
+        }
       }
   }
 }


### PR DESCRIPTION
## What

Makes block-local (nested-`Module`) binding **rename** sound in the lambda
projectional editor — closing the `docs/TODO.md` §20 exit criterion.

RFA Step 1 (#636) taught the scope-graph builder nested-block scopes, so
`@scope.declaration` now returns block-local declarations. But the edits-layer
rename resolved a var to its block-aware `@scope.Decl`, then **threw that
identity away** — converting it back to a root-relative `def_index` and
re-deriving references/binder against the **root** module. A block-local binding
shares a `def_index` with a root def, so renaming it rewrote the wrong (root)
binding.

### Failing test (now passing)

```
let x = 1
let y = { let x = 2
  x }
y
```

Renaming the block-local `x` → `w` used to rewrite `let x = 1` → `let w = 1`
(root) and leave the block untouched. Now it renames only the block binder + its
body use.

## How

Thread the resolved `Decl` + graph straight through `rename_from_var`,
`rename_binding_by_id`, and `rename_module_binding`, deriving everything from the
already-block-aware `@scope` API:

- references via `@scope.references(g, decl.id)` (identity-based, shadowing-correct);
- binder span read directly off the decl's own `LetDef` node (new
  `module_binder_name_range`); the root `module_name_role` fallback is gated to
  root-scope decls, so a nested binder can never resolve to a root-relative span;
- dup-name guard keyed on the decl's own scope siblings, not the root defs;
- `rename_binding_by_id` resolves the binder by structural node id, so
  binder-click rename of a nested `LetDef` works too;
- no-op (`new_name == old_name`) short-circuit before the dup/capture guards.

This **deletes** the parallel root-relative resolution rather than patching it —
aligned with `project_lambda_three_parallel_resolvers` (don't add block-awareness
to a third independent resolver; delegate to `@scope`).

## Scope / non-goals (deliberate, documented)

- **Capture analysis stays conservative** — rejects a rename if `new_name` is
  visible in any enclosing scope at a use site. Sound (never mis-renames); may
  over-reject a legal rename the renamed binder would shadow.
- **Alpha-rename completeness** — capturing a previously-free `Var(new_name)`
  elsewhere is unchanged (same as existing top-level rename), out of scope.
- **Inline / extract / binding ops** remain root-relative (still block-unsound,
  pre-existing) — tracked as a §20 follow-up. Rename-only is strict progress, no
  regression.

## Reuse check

- **Existing APIs reused:** `@scope.references`, `@scope.declaration`,
  `@scope.enclosing_env` (via `name_captured_at_node`), `root_scope_id`,
  `ref_edit_range`, `@lambda_proj.{LET_DEF_NAME_ROLE, module_name_role}`. The
  `@scope` query layer was already block-aware; this PR routes rename through it.
- **Checked but not used:** `@scope.binder_span` — its `ModuleDef` fallback to
  the root `module_node_id` would silently mis-locate a nested binder, so rename
  reads `LET_DEF_NAME_ROLE` directly (with a root-gated fallback) instead.
- **New helper:** `module_binder_name_range` — single responsibility: locate a
  module def's binder name span block-locally, with no root fallback for nested
  decls.
- **Imperative code:** mirrors existing rename helpers (push loops that abort on
  first invalid range; reverse-sorted span edits).

## Tests

3 new wbtests (block-local var rename, binder-click rename, block→outer
reference rename). `lang/lambda/{scope,semantic,proj,edits}` all green (247
tests). Design + diff Codex-validated (3 rounds).
