### PR TITLE
refactor(lambda): route app/bop projection through CstFold

### DIFF
--- a/lang/lambda/proj/cstfold_compat.mbt
+++ b/lang/lambda/proj/cstfold_compat.mbt
@@ -38,17 +38,33 @@ fn cstfold_projection_compatible_kind(node : @seam.SyntaxNode) -> @ast.Term {
 }
 
 ///|
+/// Apply only the top-level block compatibility rules needed by shallow parent
+/// shapes. Do not recurse into `term.children()`: flat AppExpr/BinaryExpr parent
+/// shapes are left-nested, and recursive normalization would reintroduce one
+/// call frame per argument/operator before projection can build its iterative
+/// spine.
+fn cstfold_projection_compatible_shallow_term(term : @ast.Term) -> @ast.Term {
+  match term {
+    Error("empty block") => Unit
+    Module([], body) => body
+    _ => term
+  }
+}
+
+///|
 /// Candidate existing APIs checked: `@parser.lambda_fold_node` already exposes
 /// Loom Lambda's per-node CstFold algebra with caller-controlled recursion.
-/// `cstfold_projection_compatible_term` already applies Canopy's block
-/// compatibility normalization to a folded shape. This helper's responsibility
-/// boundary is parent-shape extraction for composite `ProjNode` builders: fold
-/// exactly the requested CST node with placeholder children, normalize that
-/// shallow shape, and leave descendant terms to the already-projected children.
+/// `cstfold_projection_compatible_term` already applies full Canopy block
+/// compatibility normalization to recursive folds, but shallow composite parent
+/// shapes must avoid recursively walking generated left spines. This helper's
+/// responsibility boundary is parent-shape extraction for composite `ProjNode`
+/// builders: fold exactly the requested CST node with placeholder children,
+/// normalize only that shallow top-level shape, and leave descendant terms to
+/// the already-projected children.
 fn cstfold_projection_compatible_shallow_kind(
   node : @seam.SyntaxNode,
 ) -> @ast.Term {
-  cstfold_projection_compatible_term(
+  cstfold_projection_compatible_shallow_term(
     @parser.lambda_fold_node(node, fn(_child) { Unit }),
   )
 }

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -24,13 +24,22 @@ fn error_node_for_syntax(
 }
 
 ///|
-fn app_node(
+/// Candidate existing APIs checked: `cstfold_branch_node` already handles the
+/// one-CST-node/one-`ProjNode` case, but flat AppExpr/BinaryExpr syntax maps to
+/// multiple nested projection spine nodes. `rebuild_kind` already reconstructs
+/// one parent from a CstFold-derived shape and projected child kinds, while
+/// `ProjNode::branch` owns branch metadata and ID allocation. This helper's
+/// responsibility boundary is exactly one left-spine parent step: preserve the
+/// current two-child `ProjNode` shape and span while taking constructor/operator
+/// data from the supplied shallow CstFold parent shape.
+fn cstfold_left_spine_step(
+  shape : @ast.Term,
   left : ProjNode[@ast.Term],
   right : ProjNode[@ast.Term],
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
   ProjNode::branch(
-    App(left.kind, right.kind),
+    rebuild_kind(shape, [left, right]),
     @cmp.minimum(left.start, right.start),
     @cmp.maximum(left.end, right.end),
     [left, right],
@@ -39,19 +48,50 @@ fn app_node(
 }
 
 ///|
-fn bop_node(
-  op : @ast.Bop,
-  left : ProjNode[@ast.Term],
-  right : ProjNode[@ast.Term],
-  counter : Ref[Int],
-) -> ProjNode[@ast.Term] {
-  ProjNode::branch(
-    Bop(op, left.kind, right.kind),
-    @cmp.minimum(left.start, right.start),
-    @cmp.maximum(left.end, right.end),
-    [left, right],
-    counter,
-  )
+/// Candidate existing APIs checked: `cstfold_projection_compatible_shallow_kind`
+/// produces the whole flat AppExpr parent shape without folding descendants, but
+/// AppExpr projection still allocates one nested `ProjNode` per argument.
+/// `@ast.rebuild_from`/`rebuild_kind` can rebuild one App parent once a shape is
+/// selected, but it does not split the flat CST shape into spine steps. This
+/// helper extracts those App parent shapes from the shallow CstFold spine in the
+/// same inner-to-outer order as projection allocation, without visiting the CST
+/// descendants again. Keep this iterative because generated flat applications
+/// can contain long argument chains.
+fn cstfold_app_spine_shapes(shape : @ast.Term) -> Array[@ast.Term] {
+  let outer_to_inner : Array[@ast.Term] = []
+  for current = shape {
+    match current {
+      App(left_shape, _) => {
+        outer_to_inner.push(current)
+        continue left_shape
+      }
+      _ => break
+    }
+  }
+  outer_to_inner.rev()
+}
+
+///|
+/// Candidate existing APIs checked: `BinaryExprView::ops` exposes parser tokens,
+/// but CstFold is the semantic source of truth for operator classification.
+/// `cstfold_projection_compatible_shallow_kind` gives the complete left-nested
+/// Bop shape with placeholder operands, and `rebuild_kind` rebuilds a single Bop
+/// parent once that parent shape is selected. This helper extracts the Bop
+/// parent shapes in projection construction order so multi-operator chains keep
+/// each operator on the same nested `ProjNode` as before. Keep this iterative
+/// because generated flat binary chains can be long.
+fn cstfold_bop_spine_shapes(shape : @ast.Term) -> Array[@ast.Term] {
+  let outer_to_inner : Array[@ast.Term] = []
+  for current = shape {
+    match current {
+      Bop(_, left_shape, _) => {
+        outer_to_inner.push(current)
+        continue left_shape
+      }
+      _ => break
+    }
+  }
+  outer_to_inner.rev()
 }
 
 ///|
@@ -269,46 +309,56 @@ pub fn syntax_to_proj_node(
       None =>
         error_node_for_syntax("missing function in application", node, counter)
       Some(func_node) => {
-        let mut result = syntax_to_proj_node(func_node, counter)
-        for arg_node in v.args() {
+        let app_shape = cstfold_projection_compatible_shallow_kind(node)
+        let app_shapes = cstfold_app_spine_shapes(app_shape)
+        let args = v.args()
+        let first = syntax_to_proj_node(func_node, counter)
+        for arg_node in args; i = 0, result = first {
+          let shape = match app_shapes.get(i) {
+            Some(shape) => shape
+            None => app_shape
+          }
           let arg = syntax_to_proj_node(arg_node, counter)
-          result = app_node(result, arg, counter)
+          continue i + 1, cstfold_left_spine_step(shape, result, arg, counter)
+        } nobreak {
+          result
         }
-        result
       }
     }
   } else if @parser.BinaryExprView::cast(node) is Some(v) {
     let operands = v.operands()
-    let ops = v.ops()
-    if operands.length() == 0 {
+    let operand_count = operands.length()
+    if operand_count == 0 {
       error_node_for_syntax("empty BinaryExpr", node, counter)
-    } else if operands.length() == 1 {
+    } else if operand_count == 1 {
       syntax_to_proj_node(operands[0], counter)
     } else {
-      // Fold n-ary syntax (`a + b + c`) into binary Term shape.
-      // The parser emits operator+operand pairs, so `ops` and trailing
-      // operands stay balanced; the Error branch guards malformed or
-      // hand-built CSTs, not normal parser output. Check before recursing
-      // so we neither re-overwrite Error nor traverse unreachable operands.
-      let mut result = syntax_to_proj_node(operands[0], counter)
-      let mut missing_at : Int? = None
-      for i = 1; i < operands.length(); i = i + 1 {
-        if i - 1 >= ops.length() {
-          missing_at = Some(operands[i].start())
-          break
+      // Fold n-ary syntax (`a + b + c`) into binary projection shape.
+      // CstFold owns the operator classification for each parent shape, while
+      // the projection builder still owns child IDs, spans, and recovery terms.
+      // Check for a missing CstFold parent shape before recursing into the next
+      // operand so malformed hand-built CSTs preserve the previous recovery
+      // boundary and do not traverse unreachable operands.
+      let bop_shapes = cstfold_bop_spine_shapes(
+        cstfold_projection_compatible_shallow_kind(node),
+      )
+      let first = syntax_to_proj_node(operands[0], counter)
+      for i = 1, result = first; i < operand_count; {
+        match bop_shapes.get(i - 1) {
+          Some(shape) => {
+            let rhs = syntax_to_proj_node(operands[i], counter)
+            continue i + 1, cstfold_left_spine_step(shape, result, rhs, counter)
+          }
+          None =>
+            break error_node_with_span(
+              "missing binary operator",
+              result.start,
+              operands[i].start(),
+              counter,
+            )
         }
-        let rhs = syntax_to_proj_node(operands[i], counter)
-        result = bop_node(ops[i - 1], result, rhs, counter)
-      }
-      match missing_at {
-        Some(end) =>
-          error_node_with_span(
-            "missing binary operator",
-            result.start,
-            end,
-            counter,
-          )
-        None => result
+      } nobreak {
+        result
       }
     }
   } else if @parser.IfExprView::cast(node) is Some(v) {

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -244,6 +244,174 @@ test "cstfold-backed if projection preserves recovered child kind" {
 }
 
 ///|
+test "cstfold-backed flat app and bop shallow shapes do not fold nested children" {
+  let app_source = "f (g x) y"
+  assert_term_equal(
+    "recursive fold should still see the nested app argument",
+    App(App(Var("f"), App(Var("g"), Var("x"))), Var("y")),
+    cstfold_projection_compatible_term(cstfold_term(app_source)),
+  )
+  assert_term_equal(
+    "shallow AppExpr parent shape should use placeholders for flat children",
+    App(App(Unit, Unit), Unit),
+    cstfold_shallow_first_child(app_source),
+  )
+  let bop_source = "1 + (2 - 3) + 4"
+  assert_term_equal(
+    "recursive fold should still see the nested bop operand",
+    Bop(Plus, Bop(Plus, Int(1), Bop(Minus, Int(2), Int(3))), Int(4)),
+    cstfold_projection_compatible_term(cstfold_term(bop_source)),
+  )
+  assert_term_equal(
+    "shallow BinaryExpr parent shape should use placeholders for flat operands",
+    Bop(Plus, Bop(Plus, Unit, Unit), Unit),
+    cstfold_shallow_first_child(bop_source),
+  )
+}
+
+///|
+test "app projection preserves left-nested spine metadata" {
+  let source = "f x y"
+  let (proj, errors) = parse_to_proj_node(source)
+  if !errors.is_empty() {
+    fail(
+      "expected clean parse for " + source + ", got " + @debug.to_string(errors),
+    )
+  }
+  assert_term_equal(
+    "app projection should stay left nested",
+    App(App(Var("f"), Var("x")), Var("y")),
+    proj.kind,
+  )
+  assert_projection_metadata("app outer", proj, 0, 5, 4)
+  match proj.children {
+    [inner, y] => {
+      assert_term_equal(
+        "app outer left child kind",
+        App(Var("f"), Var("x")),
+        inner.kind,
+      )
+      assert_term_equal("app outer right child kind", Var("y"), y.kind)
+      assert_projection_metadata("app inner", inner, 0, 3, 2)
+      assert_projection_metadata("app y child", y, 3, 5, 3)
+      match inner.children {
+        [f, x] => {
+          assert_term_equal("app func child kind", Var("f"), f.kind)
+          assert_term_equal("app first arg child kind", Var("x"), x.kind)
+          assert_projection_metadata("app func child", f, 0, 1, 0)
+          assert_projection_metadata("app first arg child", x, 1, 3, 1)
+        }
+        _ => fail("expected exactly two inner app children")
+      }
+    }
+    _ => fail("expected exactly two outer app children")
+  }
+}
+
+///|
+test "app projection preserves recovered argument child" {
+  let source = "f ("
+  let (proj, errors) = parse_to_proj_node(source)
+  if errors.is_empty() {
+    fail("expected recovery diagnostics for " + source)
+  }
+  let folded = cstfold_projection_compatible_term(cstfold_term(source))
+  if folded == proj.kind {
+    fail("expected recovered app argument to differ from raw CstFold child")
+  }
+  assert_term_equal(
+    "app parent should rebuild CstFold-compatible shape from projected children",
+    rebuild_kind(folded, proj.children),
+    proj.kind,
+  )
+  assert_projection_metadata("recovered app parent", proj, 0, 3, 2)
+  match proj.children {
+    [func, arg] => {
+      assert_term_equal("recovered app func kind", Var("f"), func.kind)
+      match arg.kind {
+        Error(projected_msg) =>
+          inspect(projected_msg.contains("unknown node kind"), content="true")
+        _ => fail("unexpected recovered app argument child")
+      }
+      assert_projection_metadata("recovered app func child", func, 0, 1, 0)
+      assert_projection_metadata("recovered app arg child", arg, 1, 3, 1)
+    }
+    _ => fail("expected exactly two recovered app children")
+  }
+}
+
+///|
+test "bop projection preserves left-nested spine metadata" {
+  let source = "1 + 2 - 3"
+  let (proj, errors) = parse_to_proj_node(source)
+  if !errors.is_empty() {
+    fail(
+      "expected clean parse for " + source + ", got " + @debug.to_string(errors),
+    )
+  }
+  assert_term_equal(
+    "bop projection should stay left nested",
+    Bop(Minus, Bop(Plus, Int(1), Int(2)), Int(3)),
+    proj.kind,
+  )
+  assert_projection_metadata("bop outer", proj, 0, 9, 4)
+  match proj.children {
+    [inner, rhs] => {
+      assert_term_equal(
+        "bop outer left child kind",
+        Bop(Plus, Int(1), Int(2)),
+        inner.kind,
+      )
+      assert_term_equal("bop outer right child kind", Int(3), rhs.kind)
+      assert_projection_metadata("bop inner", inner, 0, 5, 2)
+      assert_projection_metadata("bop rhs child", rhs, 7, 9, 3)
+      match inner.children {
+        [lhs, mid] => {
+          assert_term_equal("bop lhs child kind", Int(1), lhs.kind)
+          assert_term_equal("bop mid child kind", Int(2), mid.kind)
+          assert_projection_metadata("bop lhs child", lhs, 0, 1, 0)
+          assert_projection_metadata("bop mid child", mid, 3, 5, 1)
+        }
+        _ => fail("expected exactly two inner bop children")
+      }
+    }
+    _ => fail("expected exactly two outer bop children")
+  }
+}
+
+///|
+test "bop projection preserves recovered rhs child metadata" {
+  let source = "1 +"
+  let (proj, errors) = parse_to_proj_node(source)
+  if errors.is_empty() {
+    fail("expected recovery diagnostics for " + source)
+  }
+  let folded = cstfold_projection_compatible_term(cstfold_term(source))
+  if folded == proj.kind {
+    fail("expected recovered bop rhs to differ from raw CstFold child")
+  }
+  assert_term_equal(
+    "bop parent should rebuild CstFold-compatible shape from projected children",
+    rebuild_kind(folded, proj.children),
+    proj.kind,
+  )
+  assert_projection_metadata("recovered bop parent", proj, 0, 3, 2)
+  match proj.children {
+    [lhs, rhs] => {
+      assert_term_equal("recovered bop lhs kind", Int(1), lhs.kind)
+      match rhs.kind {
+        Error(projected_msg) =>
+          inspect(projected_msg.contains("unknown node kind"), content="true")
+        _ => fail("unexpected recovered bop rhs child")
+      }
+      assert_projection_metadata("recovered bop lhs child", lhs, 0, 1, 0)
+      assert_projection_metadata("recovered bop rhs child", rhs, 3, 3, 1)
+    }
+    _ => fail("expected exactly two recovered bop children")
+  }
+}
+
+///|
 test "cstfold parity: valid module and fn sources agree" {
   assert_clean_projection_kind_matches_fold("let x = 1\nx + 2")
   assert_clean_projection_kind_matches_fold("fn id(x) { x }\nid")


### PR DESCRIPTION
## Summary

- migrate Lambda `AppExpr` and `BinaryExpr` parent construction from hand-built `App` / `Bop` terms to shallow CstFold-derived spine shapes
- preserve the existing left-nested `ProjNode` shape, child order, source spans, and ID allocation order
- add focused wbtests for App/Bop shallow shape extraction, nested metadata, and recovery behavior

Closes #646.

## Reuse check

Reused:
- `cstfold_projection_compatible_shallow_kind` for one-layer CstFold parent-shape extraction
- `rebuild_kind` / `@ast.rebuild_from` to rebuild parent kinds from already-projected child kinds
- `ProjNode::branch` for branch metadata and fresh ID allocation

Checked but not used directly:
- `@parser.syntax_node_to_term` recursively folds descendants, so it remains inappropriate for App/Bop spine construction
- `BinaryExprView::ops` exposes parser token operators, but CstFold is now the semantic operator-classification source
- `cstfold_branch_node` handles one-CST-node/one-`ProjNode` composites, but App/Bop require multiple nested projection spine nodes

New helper boundary:
- private App/Bop spine-shape helpers only split a shallow CstFold shape into the same inner-to-outer parent steps used by the existing projection spine; they do not recursively refold descendants.

Imperative code remaining:
- no mutable App/Bop accumulator remains; functional loop state is used to preserve allocation order and recovery short-circuit behavior.

## Validation

- `NEW_MOON_MOD=0 moon test lang/lambda/proj` (after adding tests, before implementation)
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon check lang/lambda/proj --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/lambda/proj` (71 passed)
- `NEW_MOON_MOD=0 moon info`
- `git diff -- '*.mbti'` (empty after reverting unrelated trailing-newline churn)
- `git diff --check`
- local code review pass + `moonbit-reviewer`: no high-confidence issues found
