### PR TITLE
refactor(lambda): extract module definition index

### DIFF
--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -72,16 +72,7 @@ fn def_cutoff_at_node(
   source_map : SourceMap,
   node_id : NodeId,
 ) -> Int {
-  guard source_map.get_range(node_id) is Some(r) else {
-    return module_projection.defs.length()
-  }
-  module_projection.defs
-  .search_by(fn(def) {
-    source_map.get_range(def.1.id()) is Some(dr) &&
-    r.start >= dr.start &&
-    r.start < dr.end
-  })
-  .unwrap_or(module_projection.defs.length())
+  module_projection.definition_index().cutoff_at_node(source_map, node_id)
 }
 
 ///|
@@ -213,7 +204,7 @@ fn declaration_id_for_name_at_module_end(
   declaration_id_for_name_from_scope(
     g,
     root_scope,
-    module_projection.defs.length(),
+    module_projection.definition_index().length(),
     name,
   )
 }
@@ -280,10 +271,5 @@ pub fn find_binding_for_init(
   init_node_id : NodeId,
   module_projection : ModuleProjection,
 ) -> (NodeId, Int)? {
-  for i, def in module_projection.defs {
-    if def.3 == init_node_id || def.1.id() == init_node_id {
-      return Some((def.3, i))
-    }
-  }
-  None
+  module_projection.definition_index().binding_for_node(init_node_id)
 }

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -90,6 +90,43 @@ test "find_binding_for_init: returns None for non-init node" {
   let (proj, _) = parse_to_proj_node(text)
   let fp = ModuleProjection::from_proj_node(proj)
   // Body node is not an init expression
-  let body = proj.children[proj.children.length() - 1]
+  let body = proj.children.last().unwrap()
   inspect(find_binding_for_init(body.id(), fp) is None, content="true")
+}
+
+///|
+test "find_binding_for_init: duplicate defs return matching binding order" {
+  let text = "let x = 0\nlet x = x\nx"
+  let (proj, _) = parse_to_proj_node(text)
+  let fp = ModuleProjection::from_proj_node(proj)
+  match find_binding_for_init(fp.defs[0].1.id(), fp) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == fp.defs[0].3, content="true")
+      inspect(def_index, content="0")
+    }
+    None => fail("expected first duplicate binding")
+  }
+  match find_binding_for_init(fp.defs[1].1.id(), fp) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == fp.defs[1].3, content="true")
+      inspect(def_index, content="1")
+    }
+    None => fail("expected second duplicate binding")
+  }
+}
+
+///|
+test "def_cutoff_at_node: duplicate defs use init-range cutoff" {
+  let text = "let x = 0\nlet x = x\nx"
+  let (proj, _) = parse_to_proj_node(text)
+  let fp = ModuleProjection::from_proj_node(proj)
+  let source_map = SourceMap::from_ast(proj)
+  let body = proj.children.last().unwrap()
+  inspect(def_cutoff_at_node(fp, source_map, fp.defs[0].1.id()), content="0")
+  inspect(def_cutoff_at_node(fp, source_map, fp.defs[1].1.id()), content="1")
+  inspect(def_cutoff_at_node(fp, source_map, body.id()), content="2")
+  inspect(
+    def_cutoff_at_node(fp, source_map, NodeId::from_int(999_999)),
+    content="2",
+  )
 }

--- a/lang/lambda/proj/definition_index.mbt
+++ b/lang/lambda/proj/definition_index.mbt
@@ -1,0 +1,85 @@
+///|
+priv struct DefinitionIndexEntry {
+  name : String
+  init : ProjNode[@ast.Term]
+  binding_id : NodeId
+}
+
+///|
+fn DefinitionIndexEntry::from_def(
+  def : (String, ProjNode[@ast.Term], Int, NodeId),
+) -> DefinitionIndexEntry {
+  let (name, init, _start, binding_id) = def
+  { name, init, binding_id }
+}
+
+///|
+/// Index of module-level Lambda definitions.
+///
+/// `ModuleProjection` still owns the projection storage for this slice; this
+/// derived index gives definition lookup and binding-id queries a named home
+/// without exposing the underlying tuple layout to new consumers.
+pub struct DefinitionIndex {
+  priv entries : Array[DefinitionIndexEntry]
+}
+
+///|
+fn DefinitionIndex::from_defs(
+  defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)],
+) -> DefinitionIndex {
+  { entries: defs.map(fn(def) { DefinitionIndexEntry::from_def(def) }) }
+}
+
+///|
+/// Derive the definition-index view for this module projection.
+pub fn ModuleProjection::definition_index(
+  self : ModuleProjection,
+) -> DefinitionIndex {
+  DefinitionIndex::from_defs(self.defs)
+}
+
+///|
+/// Number of indexed module definitions, preserving source order.
+pub fn DefinitionIndex::length(self : DefinitionIndex) -> Int {
+  self.entries.length()
+}
+
+///|
+fn DefinitionIndex::names(self : DefinitionIndex) -> Array[String] {
+  self.entries.map(fn(entry) { entry.name })
+}
+
+///|
+/// Look up the binding handle for a module definition by either its LetDef node
+/// id or its initializer node id.
+pub fn DefinitionIndex::binding_for_node(
+  self : DefinitionIndex,
+  node_id : NodeId,
+) -> (NodeId, Int)? {
+  self.entries
+  .search_by(fn(entry) {
+    entry.binding_id == node_id || entry.init.id() == node_id
+  })
+  .map(fn(i) { (self.entries[i].binding_id, i) })
+}
+
+///|
+/// Return the number of preceding module definitions visible at `node_id`.
+///
+/// Nodes inside definition `i`'s initializer receive cutoff `i`; nodes outside
+/// all initializers receive the full definition count. Missing source ranges use
+/// the full count, matching the legacy edit-scope fallback.
+pub fn DefinitionIndex::cutoff_at_node(
+  self : DefinitionIndex,
+  source_map : SourceMap,
+  node_id : NodeId,
+) -> Int {
+  guard source_map.get_range(node_id) is Some(r) else { return self.length() }
+  self.entries
+  .search_by(fn(entry) {
+    source_map.get_range(entry.init.id()) is Some(dr) &&
+    r.start >= dr.start &&
+    r.start < dr.end
+  })
+  .unwrap_or(self.length())
+}

--- a/lang/lambda/proj/module_projection.mbt
+++ b/lang/lambda/proj/module_projection.mbt
@@ -180,8 +180,8 @@ pub fn reconcile_module_projection(
 ) -> ModuleProjection {
   let old_defs = old_fp.defs
   let new_defs = new_fp.defs
-  let old_names = old_defs.map(d => d.0)
-  let new_names = new_defs.map(d => d.0)
+  let old_names = old_fp.definition_index().names()
+  let new_names = new_fp.definition_index().names()
   let new_matched = key_match(old_names, new_names)
 
   // Build reconciled defs

--- a/lang/lambda/proj/module_projection_wbtest.mbt
+++ b/lang/lambda/proj/module_projection_wbtest.mbt
@@ -38,6 +38,43 @@ test "to_module_projection: multiple let defs" {
 }
 
 ///|
+test "to_module_projection: duplicate defs keep source order and binding IDs" {
+  let syntax = parse_syntax("let x = 1\nlet x = x\nlet y = x\nx")
+  let fp = to_module_projection(syntax, Ref(0))
+  inspect(fp.defs.length(), content="3")
+  inspect(fp.defs.map(fn(def) { def.0 }).join(","), content="x,x,y")
+  inspect(fp.defs[0].3 != fp.defs[1].3, content="true")
+  inspect(fp.defs[1].3 != fp.defs[2].3, content="true")
+  let proj = fp.to_proj_node(Ref(100))
+  inspect(proj.children[0].id() == fp.defs[0].3, content="true")
+  inspect(proj.children[1].id() == fp.defs[1].3, content="true")
+  inspect(proj.children[2].id() == fp.defs[2].3, content="true")
+  inspect(proj.children[0].kind, content="LetDef(\"x\", Int(1))")
+  inspect(proj.children[1].kind, content="LetDef(\"x\", Var(\"x\"))")
+}
+
+///|
+test "DefinitionIndex: duplicate lookup and cutoff use source order" {
+  let syntax = parse_syntax("let x = 1\nlet x = x\nlet y = x\nx")
+  let fp = to_module_projection(syntax, Ref(0))
+  let index = fp.definition_index()
+  inspect(index.length(), content="3")
+  match index.binding_for_node(fp.defs[1].1.id()) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == fp.defs[1].3, content="true")
+      inspect(def_index, content="1")
+    }
+    None => fail("expected duplicate binding lookup")
+  }
+  let proj = fp.to_proj_node(Ref(100))
+  let source_map = SourceMap::from_ast(proj)
+  let body = proj.children.last().unwrap()
+  inspect(index.cutoff_at_node(source_map, fp.defs[0].1.id()), content="0")
+  inspect(index.cutoff_at_node(source_map, fp.defs[1].1.id()), content="1")
+  inspect(index.cutoff_at_node(source_map, body.id()), content="3")
+}
+
+///|
 test "to_module_projection: no final expression defaults to None" {
   let syntax = parse_syntax("let x = 1\n")
   let fp = to_module_projection(syntax, Ref(0))

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -40,10 +40,18 @@ pub fn to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.P
 // Errors
 
 // Types and methods
+pub struct DefinitionIndex {
+  // private fields
+}
+pub fn DefinitionIndex::binding_for_node(Self, @dowdiness/canopy/core.NodeId) -> (@dowdiness/canopy/core.NodeId, Int)?
+pub fn DefinitionIndex::cutoff_at_node(Self, @dowdiness/canopy/core.SourceMap, @dowdiness/canopy/core.NodeId) -> Int
+pub fn DefinitionIndex::length(Self) -> Int
+
 pub struct ModuleProjection {
   defs : Array[(String, @dowdiness/canopy/core.ProjNode[@ast.Term], Int, @dowdiness/canopy/core.NodeId)]
   final_expr : @dowdiness/canopy/core.ProjNode[@ast.Term]?
 } derive(Eq, @debug.Debug)
+pub fn ModuleProjection::definition_index(Self) -> DefinitionIndex
 pub fn ModuleProjection::empty() -> Self
 pub fn ModuleProjection::from_proj_node(@dowdiness/canopy/core.ProjNode[@ast.Term]) -> Self
 pub fn ModuleProjection::to_proj_node(Self, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]


### PR DESCRIPTION
## Summary

- Add an opaque Lambda `DefinitionIndex` derived from `ModuleProjection` so definition lookup/binding metadata has a named home separate from projection storage.
- Migrate the edits scope consumer for binding lookup and cutoff queries to the new index without changing `ModuleProjection` storage or removing it.
- Pin duplicate/shadowed definition ordering, binding IDs, and lookup/cutoff behavior with focused tests.

Closes #631.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ModuleProjection` | `lang/lambda/proj/module_projection.mbt` | Yes | Kept as storage/source of truth; `DefinitionIndex` is derived from it for this slice. |
| `key_match` | `lang/lambda/proj/module_projection.mbt` | Yes | Preserves existing duplicate-name occurrence matching for reconciliation. |
| `SourceMap::get_range` | `core` via `SourceMap` | Yes | Used by `DefinitionIndex::cutoff_at_node` to preserve legacy init-range cutoff behavior. |
| `Array::search_by` / `Array::map` / `Array::last` | `moonbitlang/core/array` | Yes | Used for declarative lookup/key extraction/test access instead of new loops where practical. |
| `@scope.ScopeGraph` queries | `lang/lambda/scope` | Checked | Scope graph owns resolved declarations/references, but not `ModuleProjection` binding-id and init-range cutoff metadata. |

New helpers added (if any):

- `DefinitionIndex`: opaque definition-index view derived from `ModuleProjection`; owns module-definition lookup/binding metadata queries without exposing the tuple layout to new consumers.
- `DefinitionIndexEntry`: private entry type for `DefinitionIndex` internals.
- `ModuleProjection::definition_index`: derives the index from current storage.
- `DefinitionIndex::length`, `DefinitionIndex::binding_for_node`, `DefinitionIndex::cutoff_at_node`: minimal query surface needed by the migrated edits consumer.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/scope lang/lambda/edits --deny-warn` passes
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/edits lang/lambda/scope` passes
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/flat` passes
- [x] `NEW_MOON_MOD=0 moon info` run
- [x] `git diff -- '*.mbti'` reviewed for unintended API surface changes
- [x] JS rebuild not needed; web/JS artifacts unaffected

## Validation

```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/scope lang/lambda/edits --deny-warn
NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/edits lang/lambda/scope
NEW_MOON_MOD=0 moon test lang/lambda/flat
NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
git diff --check
```
