### PR TITLE
feat(lambda): teach edits inline/extract/binding ops about nested-block scopes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -492,24 +492,23 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   `Rename block-local binding leaves root binding intact`, `Rename block-local
   binding by binder id`, `Rename block reference to outer binding renames root`.
 
-- [ ] Teach `edits/` **inline / extract / binding** ops about nested-block scopes.
-  Why: rename is fixed (above) by delegating to the already-block-aware `@scope`
-  API. But `text_edit_refactor.mbt` (inline/extract) and `text_edit_binding.mbt`
-  still convert the block-aware `Decl` into a root-relative `def_index`:
-  `module_def_references(g, def_index)` returns the FIRST decl at that index (root
-  wins over a block-local def at the same index), and `module_projection.defs[
-  def_index]` / `find_def_index` index the ROOT module's defs only. So inlining a
-  block-local `x` inlines the ROOT def's value, and the capture guard
-  (`def_cutoff_at_node` + `declaration_id_for_name_from_scope`, scope.mbt) applies
-  one root-relative cutoff. Pre-existing blind spot, already unsound today —
-  rename-only is strict progress, not a regression.
-  Plan: GitHub issue — for references/binder, decl-thread the same way rename now
-  does. For the *capture analysis* (a hypothetical-position query: "what would
-  name N resolve to if the init moved to position P"), generalize to the
-  per-(node, scope) cutoff model the builder uses (`lang/lambda/scope/builder.mbt`
-  `node_cutoffs`), keying each `def_index` to its declaring scope.
-  Exit: inlining/extracting a block-local binding (`let y = { let x = 1; x }`)
-  operates on the block-local `x`, with a wbtest fixture asserting it.
+- [x] Teach `edits/` **inline / extract / binding** ops about nested-block scopes.
+  Shipped (plan: `docs/plans/2026-06-14-edits-nested-block-scopes.md`). Inline and
+  the binding ops now decl-thread like rename: they resolve the binder to its
+  block-aware `@scope.Decl` (`decl_for_binding_node`) and synthesize the def-view
+  from `decl.node_id` (`def_view_from_decl`) instead of indexing the ROOT
+  `module_projection.defs`; references come from `@scope.references(g, decl.id)`,
+  and move-up/down swap same-scope siblings (`sibling_def_decl`). The capture
+  analysis (the hypothetical-position query) is now the builder's own per-(node,
+  scope) cutoff model, persisted on `ScopeGraph` (`node_scope` + `node_cutoffs`)
+  and exposed as `@scope.resolve_name_at` / `resolve_at_module_root_end`; the
+  parallel root-cutoff resolver (`def_cutoff_at_node` +
+  `declaration_id_for_name_from_scope`) and `module_def_references` are deleted —
+  no 4th resolver. `free_name_would_rebind_to` also gained a subtree filter so a
+  nested-block shadow *inside* an inlined init is no longer a false capture.
+  wbtests: `text_edit_nested_block_wbtest.mbt` (inline def-lookup, inline
+  capture-query, nested-shadow non-capture, block-local DuplicateBinding) +
+  `resolve_name_at_wbtest.mbt` (the two queries + module-node totality).
 
 ## Shipped history
 

--- a/docs/plans/2026-06-14-edits-nested-block-scopes.md
+++ b/docs/plans/2026-06-14-edits-nested-block-scopes.md
@@ -1,0 +1,128 @@
+# Teach `edits/` resolvers about nested-block scopes (RFA Step 1 follow-up)
+
+Closes the remaining root-relative blind spot in docs/TODO.md §20 for
+inline / extract / binding ops. RFA Step 1 (#636) made the scope-graph builder
+model nested-block (`Module`) scopes; #645 taught rename. This does the same for
+the remaining `edits/` resolvers, **reusing the builder's per-(node,scope) cutoff
+model** rather than adding a fourth resolver.
+
+## Two independent unsoundnesses
+
+**A — def lookup (inline).** `compute_inline_definition` resolves the block-aware
+`decl : ModuleDef(def_index)` via `@scope.declaration`, then reads
+`module_projection.defs[def_index]` (ROOT defs only). For a block-local def this
+returns the root def at that index (or out-of-bounds when the block has more defs
+than root). `module_def_references(g, def_index)` likewise matches the *first*
+decl at a shared index — root wins.
+
+**B — capture analysis (inline + extract).** `def_cutoff_at_node` +
+`declaration_id_for_name_from_scope` apply ONE root-relative `Int` cutoff to every
+module scope on the parent chain. Nested blocks each carry their own sequential
+cutoff (the builder's `node_cutoffs : Map[NodeId, Map[ScopeId, Int]]`), so a free
+var in the inlined init is resolved with the wrong cutoff at a nested use site.
+This is a parallel re-implementation of `Builder::resolve`.
+
+Pinned by two failing wbtests in `text_edit_nested_block_wbtest.mbt`.
+
+## Invariants established during orientation (verified, not assumed)
+
+- For ANY `ModuleDef` decl (root or nested), `decl.node_id` is the **LetDef
+  projection node**: root via `def.3`, nested via `node.children[i].id()` from
+  `module_node_from_defs`. `registry.get(decl.node_id).children[0]` is the init.
+- The synthesized tuple `(decl.name, letdef.children[0], letdef.start,
+  decl.node_id)` is byte-identical to `module_projection.defs[i]` for a root decl
+  — same extraction `from_proj_node` performs (including its legacy
+  non-LetDef-child fallback: then init = the node itself, start/id = the node's).
+  So ONE unified path replaces the root path too, guarded by existing root tests.
+- Binding ops (delete/duplicate/move-up/move-down/InlineAllUsages) enter via
+  `find_def_index`, which returns `Err` for a block-local binder (unique node id,
+  no false match) → **incapable, not unsound**. Only `compute_inline_definition`
+  emits wrong edits. Extract's capture query is unsound via Problem B.
+
+## Design
+
+### Problem A — thread the block-aware `decl` (mirror #645)
+
+1. New edits-local helper, single unified path (no root/nested branch at the call
+   site — forbidden by conventions):
+   `fn def_view_from_decl(registry, decl) -> (String, ProjNode[@ast.Term], Int, NodeId)?`
+   — reads the LetDef node at `decl.node_id`, extracts init child (with the same
+   legacy fallback as `from_proj_node`), returns the tuple shape the existing
+   text helpers (`get_binding_text_range`, `binding_inline_text`,
+   `binding_delete_range`, `binding_rewrite_source`) already consume.
+2. `compute_inline_definition`: keep `@scope.declaration(g, node_id)`; for
+   `ModuleDef(_)` thread `decl` → `def_view_from_decl` for the tuple, and use
+   `@scope.references(g, decl.id)` for the sole-usage count. Drop the `def_index`
+   read.
+3. `compute_inline_all_usages` + the four binding ops: resolve `binding_node_id`
+   to its decl via `g.decls.find_first(d.node_id == id && ModuleDef)` (the #645
+   `rename_binding_by_id` pattern), then `def_view_from_decl`. This makes them
+   block-capable (capability extension riding on the same mechanism).
+   - Move-up/move-down need same-scope SIBLINGS, not `defs[index±1]`: select the
+     sibling decls in `decl.scope` ordered by `def_index`, take the neighbour.
+     (If sibling selection proves materially larger than the soundness core, it
+     may be split to a follow-up with a NAMED boundary — decided at impl time, not
+     silently.)
+4. Delete `find_def_index`-as-root-only and `module_def_references` once unused.
+
+### Problem B — expose the builder's per-node resolution
+
+1. `@scope` graph.mbt: add `node_scope : Map[NodeId, ScopeId]` and
+   `node_cutoffs : Map[NodeId, Map[ScopeId, Int]]` to `ScopeGraph`; persist both
+   in `build`. Update builder.mbt's "transient … never stored" comment — that was
+   a choice, now retired because hypothetical-position queries need it.
+2. Factor `Builder::resolve`'s gating (ModuleDef by cutoff, LamParam always) into
+   a shared free function over `(scopes, decls, start_scope, cutoffs, name)`,
+   called by both `pass3` and the public query — **one resolver, not a retyped
+   copy**.
+3. Add `pub fn resolve_name_at(g, node_id, name) -> Decl?`: look up
+   `g.node_scope[node_id]` + `g.node_cutoffs[node_id]`, run the shared resolver,
+   map `DeclId → Decl`. `None` when `node_id` was not walked (absent from
+   `node_scope`). Storing `node_scope` for EVERY walked node makes this total even
+   when the target is a non-ref/non-decl node (extract's body target) — the
+   current `scope_id_for_node` can't see those.
+4. edits/scope.mbt: replace `declaration_id_for_name_at_node` with
+   `@scope.resolve_name_at(g, target_node_id, name)`. Delete `def_cutoff_at_node`,
+   `declaration_id_for_name_from_scope`, and `root_scope_id` / `scope_id_for_node`
+   once unused.
+
+### Problem B — two correctness revisions (Codex design review)
+
+- **Extract "module end" target (HIGH).** Do NOT derive the target from
+  `module_projection.final_expr`: `from_proj_node` maps a synthetic root `Unit`
+  body to `None`, so a `None`/absent body would make `resolve_name_at` no-op and
+  silently SKIP the capture check (e.g. extracting `v` from `let a = v\nlet v = 1`
+  would miss the rebind to root `v`). Instead add a dedicated
+  `pub fn resolve_at_module_root_end(g, name) -> Decl?` that resolves in the ROOT
+  scope (parent `None`) with cutoff = count of `ModuleDef` decls in that scope
+  (all root defs visible). Total, no body-node dependency. `compute_extract_to_let`
+  inserts the new `let` at root, so root-end resolution is the matching target.
+- **Occurrence filter (MEDIUM).** `free_name_would_rebind_to` collects `Var(name)`
+  occurrences via `collect_var_usages`, which stops at lambda shadowing but NOT at
+  nested-`Module` shadowing — so for init `a + { let a = 1\n  a }` it visits the
+  block-local `a` and falsely rejects. Fix: only occurrences FREE in the init can
+  rebind. An occurrence is internally bound iff its resolved decl's binder node is
+  a structural descendant of the init node. So: compare `@scope.declaration(g,
+  occurrence)` against the target resolution ONLY when the occurrence's decl
+  `node_id` is NOT in the init subtree (collect the subtree's node ids once); an
+  unbound occurrence (`None`) rebinds iff the target binds it. This subsumes both
+  lambda and block shadowing uniformly. (`free_vars` already computes the free
+  NAME set correctly via sequential Module scoping — this fixes only the
+  per-occurrence enumeration.)
+
+## Tests
+
+- A, B: the two pinned inline wbtests (must pass; B must remain non-vacuous — after
+  A is fixed it fails via spurious capture REJECTION until B is fixed).
+- Extract: add a wbtest extracting an expression inside a block whose free var is
+  block-local — sound behavior is to REJECT extraction to the root module (the var
+  would become unbound), verifying the capture query sees the rebind.
+- Binding ops: add a delete/duplicate wbtest on a block-local binder (now capable).
+- Regression: full `edits/` + `scope/` suites stay green (180 baseline).
+
+## Non-goals
+
+- No 4th resolver; no `module_projection`-root indexing left in inline.
+- Block-local extract *placement* (inserting the new `let` into the block instead
+  of root) is a feature, not this soundness fix — out of scope.
+- Incremental layer reading `node_cutoffs` — already future work in the design spec.

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -111,45 +111,38 @@ fn rename_captures_existing_use(
 }
 
 ///|
-/// Whether moving `source_node` (an init expression) to `target_node_id` would
-/// rebind any of its free vars — i.e. some free var resolves to a different
-/// declaration at the target site than at the source. The target resolution uses
-/// the scope graph's per-(node,scope) cutoffs (`@scope.resolve_name_at`), so it
-/// is correct for nested-block scopes, not a single root-relative cutoff.
-fn free_names_would_rebind_at_node(
-  g : @scope.ScopeGraph,
-  source_node : ProjNode[@ast.Term],
-  target_node_id : NodeId,
-  free_names : @immut/hashset.HashSet[String],
-) -> Bool {
-  let subtree : Map[NodeId, ProjNode[@ast.Term]] = {}
-  @core.collect_registry(source_node, subtree)
-  free_names
-  .iter()
-  .any(fn(v) {
-    let target_decl = @scope.resolve_name_at(g, target_node_id, v).map(fn(d) {
-      d.id
-    })
-    free_name_would_rebind_to(g, source_node, subtree, v, target_decl)
-  })
+/// The registry (NodeId → ProjNode) of every node under `node`. The
+/// "bound-within-init" filter in `free_name_would_rebind_to` tests membership in
+/// this set; building it once lets an inline over N use sites reuse it instead of
+/// re-walking the init per site.
+fn subtree_registry(
+  node : ProjNode[@ast.Term],
+) -> Map[NodeId, ProjNode[@ast.Term]] {
+  let reg : Map[NodeId, ProjNode[@ast.Term]] = {}
+  @core.collect_registry(node, reg)
+  reg
 }
 
 ///|
-/// Whether moving `source_node` to the END of the root module (where extract
-/// inserts a new top-level `let`) would rebind any of its free vars. The target
-/// resolution is root-module-end (`@scope.resolve_at_module_root_end`), which is
-/// total even when the module body is a synthetic `Unit`.
-fn free_names_would_rebind_at_module_end(
+/// Whether moving `source_node` (an init expression) would rebind any of its free
+/// vars — i.e. some free var resolves to a different declaration at the move
+/// target than at the source. `resolve` is the target-site resolver, supplied per
+/// op: per-node `@scope.resolve_name_at` for inline, or
+/// `@scope.resolve_at_module_root_end` for extract's module-end target (total even
+/// when the module body is a synthetic `Unit`). `subtree` (from `subtree_registry`
+/// on `source_node`) carries the bound-within-init filter; the caller builds it
+/// once so a multi-site inline does not re-walk the init per site.
+fn free_names_would_rebind(
   g : @scope.ScopeGraph,
   source_node : ProjNode[@ast.Term],
+  subtree : Map[NodeId, ProjNode[@ast.Term]],
   free_names : @immut/hashset.HashSet[String],
+  resolve : (String) -> @scope.Decl?,
 ) -> Bool {
-  let subtree : Map[NodeId, ProjNode[@ast.Term]] = {}
-  @core.collect_registry(source_node, subtree)
   free_names
   .iter()
   .any(fn(v) {
-    let target_decl = @scope.resolve_at_module_root_end(g, v).map(fn(d) { d.id })
+    let target_decl = resolve(v).map(fn(d) { d.id })
     free_name_would_rebind_to(g, source_node, subtree, v, target_decl)
   })
 }

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -1,24 +1,4 @@
 ///|
-/// Identity-based references to a module definition, delegated to the canonical
-/// scope graph query. The old name-based usage scan could over-match a later
-/// shadowing definition's body; this helper first locates the graph-local
-/// `DeclId` for the requested module def, then asks `@scope.references` for only
-/// refs resolved to that declaration.
-fn module_def_references(
-  g : @scope.ScopeGraph,
-  def_index : Int,
-) -> Result[Array[NodeId], String] {
-  for decl in g.decls {
-    match decl.kind {
-      @scope.DeclKind::ModuleDef(def_index=i) if i == def_index =>
-        return Ok(@scope.references(g, decl.id))
-      _ => ()
-    }
-  }
-  Err("No scope declaration for module def index " + def_index.to_string())
-}
-
-///|
 /// Recursively collect Var nodes matching the given name, stopping at shadowing Lam params.
 fn collect_var_usages(
   node : ProjNode[@ast.Term],
@@ -67,15 +47,6 @@ fn free_names_captured_at_use_sites(
 }
 
 ///|
-fn def_cutoff_at_node(
-  module_projection : ModuleProjection,
-  source_map : SourceMap,
-  node_id : NodeId,
-) -> Int {
-  module_projection.definition_index().cutoff_at_node(source_map, node_id)
-}
-
-///|
 fn scope_id_for_node(
   g : @scope.ScopeGraph,
   node_id : NodeId,
@@ -88,11 +59,6 @@ fn scope_id_for_node(
       .find_first(fn(d) { d.node_id == node_id })
       .map(fn(d) { d.scope })
   }
-}
-
-///|
-fn root_scope_id(g : @scope.ScopeGraph) -> @scope.ScopeId? {
-  g.scopes.iter().find_first(fn(s) { s.parent is None }).map(fn(s) { s.id })
 }
 
 ///|
@@ -145,121 +111,79 @@ fn rename_captures_existing_use(
 }
 
 ///|
-fn declaration_id_for_name_from_scope(
-  g : @scope.ScopeGraph,
-  start_scope : @scope.ScopeId,
-  cutoff : Int,
-  name : String,
-) -> @scope.DeclId? {
-  let mut cur : @scope.ScopeId? = Some(start_scope)
-  while cur is Some(sid) {
-    let @scope.ScopeId(si) = sid
-    let scope = g.scopes[si]
-    let mut hit : @scope.DeclId? = None
-    for did in scope.decl_ids {
-      let @scope.DeclId(di) = did
-      let decl = g.decls[di]
-      if decl.name == name {
-        match decl.kind {
-          @scope.DeclKind::ModuleDef(def_index~) =>
-            if def_index < cutoff {
-              hit = Some(did)
-            }
-          @scope.DeclKind::LamParam(_) => hit = Some(did)
-        }
-      }
-    }
-    if hit is Some(_) {
-      return hit
-    }
-    cur = scope.parent
-  }
-  None
-}
-
-///|
-fn declaration_id_for_name_at_node(
-  g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
-  source_map : SourceMap,
-  node_id : NodeId,
-  name : String,
-) -> @scope.DeclId? {
-  guard scope_id_for_node(g, node_id) is Some(start_scope) else { return None }
-  declaration_id_for_name_from_scope(
-    g,
-    start_scope,
-    def_cutoff_at_node(module_projection, source_map, node_id),
-    name,
-  )
-}
-
-///|
-fn declaration_id_for_name_at_module_end(
-  g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
-  name : String,
-) -> @scope.DeclId? {
-  guard root_scope_id(g) is Some(root_scope) else { return None }
-  declaration_id_for_name_from_scope(
-    g,
-    root_scope,
-    module_projection.definition_index().length(),
-    name,
-  )
-}
-
-///|
+/// Whether moving `source_node` (an init expression) to `target_node_id` would
+/// rebind any of its free vars — i.e. some free var resolves to a different
+/// declaration at the target site than at the source. The target resolution uses
+/// the scope graph's per-(node,scope) cutoffs (`@scope.resolve_name_at`), so it
+/// is correct for nested-block scopes, not a single root-relative cutoff.
 fn free_names_would_rebind_at_node(
   g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
-  source_map : SourceMap,
   source_node : ProjNode[@ast.Term],
   target_node_id : NodeId,
   free_names : @immut/hashset.HashSet[String],
 ) -> Bool {
-  let mut rebound = false
-  free_names.each(fn(v) {
-    let target_decl = declaration_id_for_name_at_node(
-      g, module_projection, source_map, target_node_id, v,
-    )
-    if free_name_would_rebind_to(g, source_node, v, target_decl) {
-      rebound = true
-    }
+  let subtree : Map[NodeId, ProjNode[@ast.Term]] = {}
+  @core.collect_registry(source_node, subtree)
+  free_names
+  .iter()
+  .any(fn(v) {
+    let target_decl = @scope.resolve_name_at(g, target_node_id, v).map(fn(d) {
+      d.id
+    })
+    free_name_would_rebind_to(g, source_node, subtree, v, target_decl)
   })
-  rebound
 }
 
 ///|
+/// Whether moving `source_node` to the END of the root module (where extract
+/// inserts a new top-level `let`) would rebind any of its free vars. The target
+/// resolution is root-module-end (`@scope.resolve_at_module_root_end`), which is
+/// total even when the module body is a synthetic `Unit`.
 fn free_names_would_rebind_at_module_end(
   g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
   source_node : ProjNode[@ast.Term],
   free_names : @immut/hashset.HashSet[String],
 ) -> Bool {
-  let mut rebound = false
-  free_names.each(fn(v) {
-    let target_decl = declaration_id_for_name_at_module_end(
-      g, module_projection, v,
-    )
-    if free_name_would_rebind_to(g, source_node, v, target_decl) {
-      rebound = true
-    }
+  let subtree : Map[NodeId, ProjNode[@ast.Term]] = {}
+  @core.collect_registry(source_node, subtree)
+  free_names
+  .iter()
+  .any(fn(v) {
+    let target_decl = @scope.resolve_at_module_root_end(g, v).map(fn(d) { d.id })
+    free_name_would_rebind_to(g, source_node, subtree, v, target_decl)
   })
-  rebound
 }
 
 ///|
+/// Whether any free occurrence of `name` in `source_node` currently resolves to
+/// a declaration other than `target_decl` (the declaration `name` would resolve
+/// to at the move target). Occurrences bound WITHIN `source_node` — to a lambda
+/// param or a nested-block def in the init — are excluded: moving the init does
+/// not change their binding. `subtree` is the registry of all nodes under
+/// `source_node` (built once by the caller via `@core.collect_registry`), used
+/// to test that "bound within". An unbound occurrence rebinds iff the target
+/// binds the name.
 fn free_name_would_rebind_to(
   g : @scope.ScopeGraph,
   source_node : ProjNode[@ast.Term],
+  subtree : Map[NodeId, ProjNode[@ast.Term]],
   name : String,
   target_decl : @scope.DeclId?,
 ) -> Bool {
   let var_ids : Array[NodeId] = []
   collect_var_usages(source_node, name, var_ids)
   var_ids.any(fn(vid) {
-    @scope.declaration(g, vid).map(fn(d) { d.id }) != target_decl
+    match @scope.declaration(g, vid) {
+      // Bound inside the init (its binder is in the subtree) → unaffected.
+      Some(d) =>
+        if subtree.contains(d.node_id) {
+          false
+        } else {
+          Some(d.id) != target_decl
+        }
+      // Free/unbound at source → rebinds iff the target site binds the name.
+      None => target_decl is Some(_)
+    }
   })
 }
 

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -13,53 +13,10 @@ fn scope_test_registry(
   registry
 }
 
-///|
-test "module_def_references: finds Var references in Module body" {
-  let text = "let x = 0\nx + x"
-  let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, source_map)
-  match module_def_references(g, 0) {
-    Ok(refs) => inspect(refs.length(), content="2")
-    Err(e) => fail(e)
-  }
-}
-
-///|
-test "module_def_references: respects shadowing by inner Lam" {
-  let text = "let x = 0\n(x) => x"
-  let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, source_map)
-  match module_def_references(g, 0) {
-    Ok(refs) => inspect(refs.length(), content="0")
-    Err(e) => fail(e)
-  }
-}
-
-///|
-test "module_def_references: later duplicate shadows body only" {
-  let text = "let x = 0\nlet x = x\nx"
-  let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, source_map)
-  match (module_def_references(g, 0), module_def_references(g, 1)) {
-    (Ok(first_refs), Ok(second_refs)) => {
-      // The first def is referenced by the second def's init; the body resolves
-      // to the second def. This is the identity-based case the old name scan
-      // could not distinguish when callers started at def_index + 1.
-      inspect(first_refs.length(), content="1")
-      inspect(second_refs.length(), content="1")
-    }
-    (Err(e), _) | (_, Err(e)) => fail(e)
-  }
-}
+// The `module_def_references` edits-local wrapper was removed when inline/binding
+// ops were taught block-local scopes (docs/TODO.md §20): references are now read
+// directly via `@scope.references(g, decl.id)`, whose identity-based,
+// shadowing-correct behavior is owned and tested by the `@scope` package.
 
 ///|
 test "find_binding_for_init: maps init ProjNode to binding NodeId" {
@@ -113,20 +70,4 @@ test "find_binding_for_init: duplicate defs return matching binding order" {
     }
     None => fail("expected second duplicate binding")
   }
-}
-
-///|
-test "def_cutoff_at_node: duplicate defs use init-range cutoff" {
-  let text = "let x = 0\nlet x = x\nx"
-  let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
-  let source_map = SourceMap::from_ast(proj)
-  let body = proj.children.last().unwrap()
-  inspect(def_cutoff_at_node(fp, source_map, fp.defs[0].1.id()), content="0")
-  inspect(def_cutoff_at_node(fp, source_map, fp.defs[1].1.id()), content="1")
-  inspect(def_cutoff_at_node(fp, source_map, body.id()), content="2")
-  inspect(
-    def_cutoff_at_node(fp, source_map, NodeId::from_int(999_999)),
-    content="2",
-  )
 }

--- a/lang/lambda/edits/text_edit_binding.mbt
+++ b/lang/lambda/edits/text_edit_binding.mbt
@@ -3,17 +3,13 @@ fn compute_delete_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, .. } = ctx
+  let (_, _, def) = match def_for_binding(ctx, binding_node_id) {
+    Ok(t) => t
     Err(e) => return Err(e)
   }
   let (let_start, binding_end) = match
-    get_binding_text_range(
-      source_text,
-      source_map,
-      module_projection.defs[def_index],
-    ) {
+    get_binding_text_range(source_text, source_map, def) {
     Ok(r) => r
     Err(e) => return Err(e)
   }
@@ -32,12 +28,11 @@ fn compute_duplicate_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, .. } = ctx
+  let (_, _, def) = match def_for_binding(ctx, binding_node_id) {
+    Ok(t) => t
     Err(e) => return Err(e)
   }
-  let def = module_projection.defs[def_index]
   let binding_source = match
     binding_rewrite_source(source_text, source_map, def) {
     Ok(source) => source
@@ -45,6 +40,8 @@ fn compute_duplicate_binding(
   }
   // Create copy with _copy suffix on name, preserving source syntax such as
   // `fn` parameter annotations instead of reprinting the desugared Lam spine.
+  // NOTE: `_` is not a lexable identifier char in this language, so `_copy`
+  // does not round-trip — pre-existing, all bindings; tracked in #649.
   let new_name = def.0 + "_copy"
   let new_binding = match
     binding_source.renamed_text(source_text, source_map, new_name) {
@@ -80,17 +77,19 @@ fn compute_move_binding_up(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, registry, .. } = ctx
+  let (g, decl, cur_def) = match def_for_binding(ctx, binding_node_id) {
+    Ok(t) => t
     Err(e) => return Err(e)
   }
-  if def_index == 0 {
+  guard sibling_def_decl(g, decl, -1) is Some(prev_decl) else {
     return Err("Cannot move first binding up")
   }
   // Scoping guard: check if either name is free in the other's init
-  let cur_def = module_projection.defs[def_index]
-  let prev_def = module_projection.defs[def_index - 1]
+  let prev_def = match def_view_from_decl(registry, source_map, prev_decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
   let empty_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let cur_fv = free_vars(cur_def.1.kind, empty_env)
   let prev_fv = free_vars(prev_def.1.kind, empty_env)
@@ -143,17 +142,19 @@ fn compute_move_binding_down(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, registry, .. } = ctx
+  let (g, decl, cur_def) = match def_for_binding(ctx, binding_node_id) {
+    Ok(t) => t
     Err(e) => return Err(e)
   }
-  if def_index >= module_projection.defs.length() - 1 {
+  guard sibling_def_decl(g, decl, 1) is Some(next_decl) else {
     return Err("Cannot move last binding down")
   }
   // Scoping guard: check if either name is free in the other's init
-  let cur_def = module_projection.defs[def_index]
-  let next_def = module_projection.defs[def_index + 1]
+  let next_def = match def_view_from_decl(registry, source_map, next_decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
   let empty_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let cur_fv = free_vars(cur_def.1.kind, empty_env)
   let next_fv = free_vars(next_def.1.kind, empty_env)

--- a/lang/lambda/edits/text_edit_legacy_compat_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_legacy_compat_wbtest.mbt
@@ -1,0 +1,58 @@
+// Regression test for the legacy init-only ModuleProjection compat shape.
+//
+// `ModuleProjection::from_proj_node` (lang/lambda/proj/module_projection.mbt)
+// accepts two def-child shapes: the production LetDef row (`LetDef(_, _)` whose
+// `children[0]` is the init) AND a legacy fallback where the def child IS the
+// init node directly (no LetDef wrapper), recorded with `def.3 = init_child.id()`.
+// The scope builder then sets that decl's `node_id` to the init node, so
+// `def_view_from_decl` sees an init node — not a LetDef — at `decl.node_id`.
+//
+// The helper must mirror from_proj_node's discriminator (key on the `LetDef`
+// KIND, not mere child presence): a compound init like `App(f, x)` HAS children,
+// so a child-presence fallback would mis-read its first child `f` as the init.
+
+///|
+test "def_view_from_decl: legacy init-only compound def keeps the whole init, not its first child" {
+  // Legacy shape: the Module's def child is the App init directly (no LetDef
+  // row). from_proj_node's `_ =>` arm records `decl.node_id = app_init.id()`.
+  let f = @core.ProjNode::new(@ast.Term::Var("f"), 8, 9, 10, [])
+  let x = @core.ProjNode::new(@ast.Term::Var("x"), 10, 11, 11, [])
+  let app_init = @core.ProjNode::new(
+    @ast.Term::App(@ast.Term::Var("f"), @ast.Term::Var("x")),
+    8,
+    11,
+    12,
+    [f, x],
+  )
+  let body = @core.ProjNode::new(@ast.Term::Var("g"), 12, 13, 13, [])
+  let root = @core.ProjNode::new(
+    @ast.Term::Module(
+      [("g", @ast.Term::App(@ast.Term::Var("f"), @ast.Term::Var("x")))],
+      @ast.Term::Var("g"),
+    ),
+    0,
+    13,
+    1,
+    [app_init, body],
+  )
+  let source_map = SourceMap::from_ast(root)
+  let registry = text_edit_test_registry(root)
+  let fp = ModuleProjection::from_proj_node(root)
+  let g = @scope.build(fp, registry, source_map)
+  guard decl_for_binding_node(g, app_init.id()) is Some(decl) else {
+    fail(
+      "expected a ModuleDef decl whose node is the legacy init-only def child",
+    )
+  }
+  match def_view_from_decl(registry, source_map, decl) {
+    Ok((name, init, _start, letdef_id)) => {
+      inspect(name, content="g")
+      // The init must be the App node ITSELF (id 12), never its first child
+      // `f` (id 10) — the bug current HEAD exhibits (wrong output, not Err).
+      inspect(init.id() == app_init.id(), content="true")
+      inspect(init.kind is @ast.Term::App(_, _), content="true")
+      inspect(letdef_id == app_init.id(), content="true")
+    }
+    Err(e) => fail("expected def-view for legacy init-only def, got Err: " + e)
+  }
+}

--- a/lang/lambda/edits/text_edit_nested_block_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_nested_block_wbtest.mbt
@@ -1,0 +1,267 @@
+// Failing tests for docs/TODO.md §20 "Teach edits/ resolvers about nested-block
+// scopes". RFA Step 1 (#636) made the scope-graph builder model nested-block
+// (`Module`) scopes, and #645 taught rename. Inline still converts the
+// block-aware `@scope.Decl` back to a root-relative `def_index`, so a block-local
+// binding is mis-resolved against the root module's `defs`.
+//
+// Two independent unsoundnesses, one test each:
+//   A — def lookup: `module_projection.defs[def_index]` reads the ROOT def at a
+//       block-relative index (root def wins at a shared index).
+//   B — capture analysis: `def_cutoff_at_node` applies ONE root-relative cutoff
+//       to every module scope on the chain, so a free var in the inlined init is
+//       resolved with the wrong cutoff at the nested use site.
+//
+// Both navigate the ProjNode tree structurally (confirmed layout); assertions are
+// substring-based so they are robust to inline whitespace normalization.
+
+///|
+/// Problem A. A block-local `x` shadows a root `x` at the SAME def_index (0).
+/// Inlining the block-local `x` must use the BLOCK init (`2`) and delete the
+/// BLOCK binding — never the root def at index 0.
+///
+/// Buggy path: `@scope.declaration` resolves the body `x` to the block-local
+/// decl `ModuleDef(def_index=0)`, then `module_projection.defs[0]` yields the
+/// ROOT `x` (init `1`); `module_def_references(g, 0)` matches the first decl at
+/// index 0 (also root). Result deletes `let x = 1` and inlines `1` — the root
+/// binding is destroyed and the wrong value substituted.
+test "InlineDefinition: block-local binding does not resolve to root def at shared index" {
+  let text = "let x = 1\nlet y = { let x = 2\n  x }\ny"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  // proj.children = [LetDef(x), LetDef(y), body Var(y)]
+  // let_y.children[0] = block Module; block.children = [LetDef(x), body Var(x)]
+  let block = proj.children[1].children[0]
+  let block_body_x = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=block_body_x.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      // Sound: root `let x = 1` survives; the block binding `let x = 2` is the
+      // one removed by the sole-usage inline.
+      let sound = new_text.contains("let x = 1") &&
+        !new_text.contains("let x = 2")
+      inspect(sound, content="true")
+    }
+    Ok(None) => fail("expected inline edits, got None")
+    Err(e) => fail("expected inline edits, got Err: " + e)
+  }
+}
+
+///|
+/// Problem B. The inlined init carries a free var whose resolution depends on the
+/// per-scope cutoff. The block-local `b = a` is inlined into the block body; its
+/// free `a` must resolve to the block-local `a` at the use site exactly as it did
+/// at the binding site, so the inline is SOUND and must be allowed.
+///
+/// Buggy path (after Problem A is fixed): `def_cutoff_at_node` for the block body
+/// finds the ROOT def whose range contains it — root def 0 (`r`) — so the cutoff
+/// is 0 and is wrongly applied to the BLOCK scope too. With cutoff 0 the block's
+/// own `a` (block-index 0) is gated out (`0 < 0` is false), so `a` resolves to
+/// None at the target while it resolves to the block-local `a` at the source.
+/// The capture check therefore sees a spurious rebind and REJECTS a sound inline.
+/// Passing requires resolving `a` with the block's own cutoff (the builder's
+/// per-(node,scope) `node_cutoffs`), not a single root cutoff.
+test "InlineDefinition: free var in block-local init keeps its nested-scope resolution" {
+  let text = "let r = { let a = 1\n  let b = a\n  b }\nlet z = 0"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  // proj.children = [LetDef(r), LetDef(z), body]
+  // r.children[0] = block Module; block.children = [LetDef(a), LetDef(b), body Var(b)]
+  let block = proj.children[0].children[0]
+  let block_body_b = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=block_body_b.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      // Sound: `b` is inlined to `a` and its binding removed; `a` and `z` bindings
+      // are untouched. (A spurious capture rejection returns Err, failing below.)
+      let sound = new_text.contains("let a = 1") &&
+        new_text.contains("let z = 0") &&
+        !new_text.contains("let b")
+      inspect(sound, content="true")
+    }
+    Ok(None) => fail("expected inline edits, got None")
+    Err(e) =>
+      fail("expected inline edits (sound inline wrongly rejected): " + e)
+  }
+}
+
+///|
+/// Problem B, occurrence filter. The inlined init `g + { let g = 1\n  g }` has a
+/// FREE `g` (resolving to the root `g`) and a block-local `g` bound inside a
+/// nested block in the init. Only the free `g` can rebind; the block-local one is
+/// unaffected by the move. The old capture check enumerated occurrences with
+/// `collect_var_usages`, which stops at lambda shadowing but NOT nested-`Module`
+/// shadowing, so it visited the block-local `g`, saw it resolve differently from
+/// the target, and falsely REJECTED a sound inline. The subtree filter excludes
+/// occurrences bound inside the init, so the inline is allowed.
+test "InlineDefinition: nested-block shadow inside an inlined init is not a false capture" {
+  let text = "let g = 5\nlet f = g + { let g = 1\n  g }\nf"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  let body_f = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body_f.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      // Sound: the init is inlined (so a `+` appears in the body) and the root
+      // `g` binding is untouched. The block-local `g` must not cause a rejection.
+      let sound = new_text.contains("let g = 5") && new_text.contains("+")
+      inspect(sound, content="true")
+    }
+    Ok(None) => fail("expected inline edits, got None")
+    Err(e) => fail("expected inline edits (false nested-block capture): " + e)
+  }
+}
+
+///|
+/// Capability extension. Binding ops entered via the root-only `find_def_index`,
+/// which returned `Err` for a block-local binder. Resolving the binder to its
+/// scope-graph decl lets duplicate REACH a block-local `x`: the copy is inserted
+/// INSIDE the block (a second binding), not rejected and not placed at root.
+///
+/// We assert only that block-scoped insertion (this PR's contribution) by
+/// re-parsing and counting the block's bindings. We do NOT assert the copy's name
+/// or the re-parsed body: the `_copy` suffix is not lexable in this language, so
+/// the output does not round-trip — a pre-existing, all-bindings defect tracked
+/// in #649. The count survives that fix (it stays two bindings).
+test "DuplicateBinding: reaches a block-local binding (copy inserted in the block)" {
+  let text = "let y = { let x = 1\n  x }\ny"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  // proj.children[0] = LetDef(y); .children[0] = block; .children[0] = LetDef(x)
+  let block_let_x = proj.children[0].children[0].children[0]
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=block_let_x.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (np, _) = parse_to_proj_node(new_text)
+      // np.children[0] = LetDef(y); .children[0] = block (y's init).
+      let block_defs = np.children[0].children[0].children
+        .iter()
+        .filter(fn(c) { c.kind is @ast.Term::LetDef(_, _) })
+        .count()
+      inspect(block_defs, content="2")
+    }
+    Ok(None) => fail("expected duplicate edits, got None")
+    Err(e) => fail("expected duplicate edits on block-local binding: " + e)
+  }
+}
+
+///|
+/// Extract inserts the new `let` at the ROOT module, so extracting an expression
+/// that references a BLOCK-LOCAL binding must be rejected — at root the name is
+/// unbound, so the extracted let would change meaning. The capture check resolves
+/// the free name at root-module-end (`resolve_at_module_root_end` → None for a
+/// block-local) and sees the rebind. Guards the extract path's module-end target.
+test "ExtractToLet: rejects extracting an expression that captures a block-local binding" {
+  let text = "let r = { let a = 1\n  a + a }\nlet z = 0"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  // proj.children[0] = LetDef(r); .children[0] = block;
+  // block.children = [LetDef(a), body Bop(a + a)]
+  let block = proj.children[0].children[0]
+  let block_body = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=block_body.id(), var_name="t"),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+/// Capability extension. Move-up resolves the binder block-locally and swaps
+/// same-scope siblings (`sibling_def_decl`), so a block-local binding moves within
+/// its own block. Under the old root-only `find_def_index` this returned `Err`.
+test "MoveBindingUp: swaps two block-local bindings" {
+  let text = "let r = { let a = 1\n  let b = 2\n  a }\nlet z = 0"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  // block.children = [LetDef(a), LetDef(b), body Var(a)]
+  let block = proj.children[0].children[0]
+  let block_let_b = block.children[1]
+  let result = compute_text_edit(
+    MoveBindingUp(binding_node_id=block_let_b.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      // Assert the re-parsed STRUCTURE, not the byte text: `b` now precedes `a`
+      // within the block and the root stays `[r, z]`. The position-based span
+      // swap leaves malformed leading indentation (cosmetic — re-parses to 0
+      // errors, correct AST), tracked in #650; a structure assertion survives
+      // that fix where a byte snapshot would not.
+      let (np, _) = parse_to_proj_node(new_text)
+      let label = fn(c : ProjNode[@ast.Term]) -> String {
+        match c.kind {
+          @ast.Term::LetDef(n, _) => "def:" + n
+          @ast.Term::Var(v) => "var:" + v
+          _ => "other"
+        }
+      }
+      let root = np.children.map(label)
+      let block = np.children[0].children[0].children.map(label)
+      inspect(
+        root.join(",") + " | " + block.join(","),
+        content="def:r,def:z,other | def:b,def:a,var:a",
+      )
+    }
+    Ok(None) => fail("expected move edits, got None")
+    Err(e) => fail("expected move on block-local binding: " + e)
+  }
+}
+
+///|
+/// Capability extension. InlineAllUsages resolves the binder block-locally and
+/// reads its references via `@scope.references(g, decl.id)`, so a block-local
+/// binding's uses are inlined without conflation with a root def at the same index.
+test "InlineAllUsages: works on a block-local binding" {
+  let text = "let r = { let a = 1\n  a + a }\nlet z = 0"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = ModuleProjection::from_proj_node(proj)
+  let block = proj.children[0].children[0]
+  let block_let_a = block.children[0]
+  let result = compute_text_edit(
+    InlineAllUsages(binding_node_id=block_let_a.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      // The block binding is gone and its uses replaced by `1`; root `z` untouched.
+      let inlined = !new_text.contains("let a = 1") &&
+        new_text.contains("1") &&
+        new_text.contains("let z = 0")
+      inspect(inlined, content="true")
+    }
+    Ok(None) => fail("expected inline-all edits, got None")
+    Err(e) => fail("expected inline-all on block-local binding: " + e)
+  }
+}

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -20,7 +20,7 @@ fn compute_extract_to_let(
   let would_capture = if module_projection.defs.is_empty() {
     free_names_captured_at_use_sites(g, node, fv)
   } else {
-    free_names_would_rebind_at_module_end(g, module_projection, node, fv)
+    free_names_would_rebind_at_module_end(g, node, fv)
   }
   if would_capture {
     return Err("Cannot extract: expression captures lambda-bound variables")
@@ -133,31 +133,28 @@ fn compute_inline_definition(
   match decl.kind {
     DeclKind::LamParam(..) =>
       return Err("Cannot inline lambda-bound variable: " + var_name)
-    DeclKind::ModuleDef(def_index~) => {
-      let def = module_projection.defs[def_index]
+    // The decl is already the block-aware declaration the var resolves to; build
+    // the def-view from it (NOT from a root-relative `module_projection.defs`
+    // index, which a block-local def shares with a root def).
+    DeclKind::ModuleDef(_) => {
+      let def = match def_view_from_decl(registry, source_map, decl) {
+        Ok(d) => d
+        Err(e) => return Err(e)
+      }
       let init_text = match binding_inline_text(source_text, source_map, def) {
         Ok(text) => text
         Err(e) => return Err(e)
       }
       // Check for capture: would any free var in init be captured by an enclosing scope at the usage site?
       let init_fv = free_vars(def.1.kind, @immut/hashset.new())
-      if free_names_would_rebind_at_node(
-          g,
-          module_projection,
-          source_map,
-          def.1,
-          node_id,
-          init_fv,
-        ) {
+      if free_names_would_rebind_at_node(g, def.1, node_id, init_fv) {
         return Err(
           "Cannot inline: would capture variables bound by enclosing lambda",
         )
       }
-      // Check if this is the sole resolved reference.
-      let refs = match module_def_references(g, def_index) {
-        Ok(ids) => ids
-        Err(e) => return Err(e)
-      }
+      // Check if this is the sole resolved reference (identity-based, so a
+      // block-local def's refs are not conflated with a root def at the same index).
+      let refs = @scope.references(g, decl.id)
       if refs.length() <= 1 {
         // Sole usage — inline and delete the binding
         let (let_start, binding_end) = match
@@ -232,30 +229,19 @@ fn compute_inline_all_usages(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, registry, module_projection } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, .. } = ctx
+  // Resolve the binder to its block-aware declaration (root or block-local).
+  let (g, decl, def) = match def_for_binding(ctx, binding_node_id) {
+    Ok(t) => t
     Err(e) => return Err(e)
   }
-  let def = module_projection.defs[def_index]
   let var_name = def.0
-  // Find all references resolved to this binding.
-  let g = @scope.build(module_projection, registry, source_map)
-  let ref_ids = match module_def_references(g, def_index) {
-    Ok(ids) => ids
-    Err(e) => return Err(e)
-  }
+  // All references resolved to THIS declaration (identity-based, shadowing-correct).
+  let ref_ids = @scope.references(g, decl.id)
   // Check for capture: would any free var in init be captured by an enclosing scope at any reference site?
   let init_fv = free_vars(def.1.kind, @immut/hashset.new())
   for rid in ref_ids {
-    if free_names_would_rebind_at_node(
-        g,
-        module_projection,
-        source_map,
-        def.1,
-        rid,
-        init_fv,
-      ) {
+    if free_names_would_rebind_at_node(g, def.1, rid, init_fv) {
       return Err(
         "Cannot inline: would capture variables bound by enclosing lambda",
       )

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -20,7 +20,9 @@ fn compute_extract_to_let(
   let would_capture = if module_projection.defs.is_empty() {
     free_names_captured_at_use_sites(g, node, fv)
   } else {
-    free_names_would_rebind_at_module_end(g, node, fv)
+    free_names_would_rebind(g, node, subtree_registry(node), fv, fn(v) {
+      @scope.resolve_at_module_root_end(g, v)
+    })
   }
   if would_capture {
     return Err("Cannot extract: expression captures lambda-bound variables")
@@ -147,7 +149,11 @@ fn compute_inline_definition(
       }
       // Check for capture: would any free var in init be captured by an enclosing scope at the usage site?
       let init_fv = free_vars(def.1.kind, @immut/hashset.new())
-      if free_names_would_rebind_at_node(g, def.1, node_id, init_fv) {
+      let subtree = subtree_registry(def.1)
+      let captures = free_names_would_rebind(g, def.1, subtree, init_fv, fn(v) {
+        @scope.resolve_name_at(g, node_id, v)
+      })
+      if captures {
         return Err(
           "Cannot inline: would capture variables bound by enclosing lambda",
         )
@@ -238,10 +244,15 @@ fn compute_inline_all_usages(
   let var_name = def.0
   // All references resolved to THIS declaration (identity-based, shadowing-correct).
   let ref_ids = @scope.references(g, decl.id)
-  // Check for capture: would any free var in init be captured by an enclosing scope at any reference site?
+  // Check for capture: would any free var in init be captured by an enclosing
+  // scope at any reference site? The init subtree is the same for every site, so
+  // build it once before the loop rather than re-walking it per reference.
   let init_fv = free_vars(def.1.kind, @immut/hashset.new())
+  let subtree = subtree_registry(def.1)
   for rid in ref_ids {
-    if free_names_would_rebind_at_node(g, def.1, rid, init_fv) {
+    if free_names_would_rebind(g, def.1, subtree, init_fv, fn(v) {
+        @scope.resolve_name_at(g, rid, v)
+      }) {
       return Err(
         "Cannot inline: would capture variables bound by enclosing lambda",
       )

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -83,17 +83,93 @@ fn ensure_replaceable_node_range(
 }
 
 ///|
-/// Find a module binding's index in module_projection.defs by its NodeId.
-fn find_def_index(
-  module_projection : ModuleProjection,
+/// Resolve a binding (LetDef) node id to its scope-graph `ModuleDef`
+/// declaration, block-locally. Unlike a root-relative `module_projection.defs`
+/// scan, this matches the binder's structural node id against every decl in the
+/// graph, so a block-local binder resolves to its own scope's declaration.
+/// Mirrors #645's `rename_binding_by_id`.
+fn decl_for_binding_node(
+  g : @scope.ScopeGraph,
   binding_node_id : NodeId,
-) -> Result[Int, String] {
-  for i, def in module_projection.defs {
-    if def.3 == binding_node_id {
-      return Ok(i)
-    }
+) -> @scope.Decl? {
+  g.decls
+  .iter()
+  .find_first(fn(d) {
+    d.node_id == binding_node_id && d.kind is @scope.DeclKind::ModuleDef(_)
+  })
+}
+
+///|
+/// Synthesize the `(name, init, start, letdef_id)` def-view tuple consumed by the
+/// binding text helpers from a `ModuleDef` declaration's LetDef projection node.
+/// Uniform for root and nested decls — `decl.node_id` is always the LetDef node,
+/// whose first child is the init expression, mirroring
+/// `ModuleProjection::from_proj_node`'s unconditional `children[0]` extraction.
+/// Returns `Err` if that child is absent (rather than aborting like the indexing
+/// in `from_proj_node`). The start comes from the LetDef node's source range (the
+/// binding span's start).
+fn def_view_from_decl(
+  registry : Map[NodeId, ProjNode[@ast.Term]],
+  source_map : SourceMap,
+  decl : @scope.Decl,
+) -> Result[(String, ProjNode[@ast.Term], Int, NodeId), String] {
+  guard registry.get(decl.node_id) is Some(letdef) else {
+    return Err("Binding node not in registry: " + decl.node_id.to_string())
   }
-  Err("Binding not found: " + binding_node_id.to_string())
+  guard source_map.get_range(decl.node_id) is Some(r) else {
+    return Err("Binding node not in source map: " + decl.node_id.to_string())
+  }
+  guard letdef.children.get(0) is Some(init) else {
+    return Err("Binding node has no init child: " + decl.node_id.to_string())
+  }
+  Ok((decl.name, init, r.start, decl.node_id))
+}
+
+///|
+/// Resolve a binding node to the scope graph, its block-local `ModuleDef`
+/// declaration, and the synthesized `(name, init, start, letdef_id)` def-view —
+/// the shared preamble of every binding op (delete/duplicate/move/inline-all).
+/// Block-local via `decl_for_binding_node`, so a nested binder resolves to its
+/// own scope's declaration rather than a root def at the same index.
+fn def_for_binding(
+  ctx : EditContext[@ast.Term],
+  binding_node_id : NodeId,
+) -> Result[
+  (@scope.ScopeGraph, @scope.Decl, (String, ProjNode[@ast.Term], Int, NodeId)),
+  String,
+] {
+  let { source_map, registry, module_projection, .. } = ctx
+  let g = @scope.build(module_projection, registry, source_map)
+  guard decl_for_binding_node(g, binding_node_id) is Some(decl) else {
+    return Err("Binding not found: " + binding_node_id.to_string())
+  }
+  match def_view_from_decl(registry, source_map, decl) {
+    Ok(def) => Ok((g, decl, def))
+    Err(e) => Err(e)
+  }
+}
+
+///|
+/// The same-scope sibling declaration at scope-relative offset `offset` from
+/// `decl` (e.g. -1 = previous binding, +1 = next), or None at the boundary.
+/// Keyed on `decl.scope` + scope-relative `def_index`, so move-up/down swap the
+/// correct neighbour within a nested block — never a root def at the same index.
+fn sibling_def_decl(
+  g : @scope.ScopeGraph,
+  decl : @scope.Decl,
+  offset : Int,
+) -> @scope.Decl? {
+  guard decl.kind is @scope.DeclKind::ModuleDef(def_index~) else { return None }
+  let target = def_index + offset
+  g.decls
+  .iter()
+  .find_first(fn(d) {
+    d.scope == decl.scope &&
+    (match d.kind {
+      @scope.DeclKind::ModuleDef(def_index=i) => i == target
+      _ => false
+    })
+  })
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -149,10 +149,7 @@ fn def_for_binding(
   guard decl_for_binding_node(g, binding_node_id) is Some(decl) else {
     return Err("Binding not found: " + binding_node_id.to_string())
   }
-  match def_view_from_decl(registry, source_map, decl) {
-    Ok(def) => Ok((g, decl, def))
-    Err(e) => Err(e)
-  }
+  def_view_from_decl(registry, source_map, decl).map(fn(def) { (g, decl, def) })
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -101,26 +101,32 @@ fn decl_for_binding_node(
 
 ///|
 /// Synthesize the `(name, init, start, letdef_id)` def-view tuple consumed by the
-/// binding text helpers from a `ModuleDef` declaration's LetDef projection node.
-/// Uniform for root and nested decls — `decl.node_id` is always the LetDef node,
-/// whose first child is the init expression, mirroring
-/// `ModuleProjection::from_proj_node`'s unconditional `children[0]` extraction.
-/// Returns `Err` if that child is absent (rather than aborting like the indexing
-/// in `from_proj_node`). The start comes from the LetDef node's source range (the
-/// binding span's start).
+/// binding text helpers from a `ModuleDef` declaration's projection node. Mirrors
+/// `ModuleProjection::from_proj_node`'s two accepted def-child shapes exactly: a
+/// production `LetDef` row carries the init at `children[0]`; the legacy init-only
+/// compat shape (from_proj_node's `_ =>` fallback) records the init node itself as
+/// `decl.node_id`, so that node IS the init. The discriminator is the node KIND,
+/// NOT child presence — a compound init like `App(f, x)` has children, so a
+/// child-presence test would wrongly pick its first child `f`. `start` comes from
+/// the node's source range (the binding span's start).
 fn def_view_from_decl(
   registry : Map[NodeId, ProjNode[@ast.Term]],
   source_map : SourceMap,
   decl : @scope.Decl,
 ) -> Result[(String, ProjNode[@ast.Term], Int, NodeId), String] {
-  guard registry.get(decl.node_id) is Some(letdef) else {
+  guard registry.get(decl.node_id) is Some(node) else {
     return Err("Binding node not in registry: " + decl.node_id.to_string())
   }
   guard source_map.get_range(decl.node_id) is Some(r) else {
     return Err("Binding node not in source map: " + decl.node_id.to_string())
   }
-  guard letdef.children.get(0) is Some(init) else {
-    return Err("Binding node has no init child: " + decl.node_id.to_string())
+  // Production LetDef row → init is children[0]; legacy init-only def child → the
+  // node itself is the init (mirrors from_proj_node's `LetDef(_,_) if children>0`
+  // arm vs its `_ =>` fallback). Keyed on kind so a compound init is never
+  // mistaken for its first child.
+  let init = match node.kind {
+    @ast.Term::LetDef(_, _) if node.children.length() > 0 => node.children[0]
+    _ => node
   }
   Ok((decl.name, init, r.start, decl.node_id))
 }

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -164,14 +164,21 @@ fn sibling_def_decl(
 ) -> @scope.Decl? {
   guard decl.kind is @scope.DeclKind::ModuleDef(def_index~) else { return None }
   let target = def_index + offset
-  g.decls
+  // Walk only the binder's own scope's decls — the scope-relative sibling lives
+  // in `decl.scope`'s decl list — rather than scanning every decl in the graph.
+  let @scope.ScopeId(si) = decl.scope
+  g.scopes[si].decl_ids
   .iter()
-  .find_first(fn(d) {
-    d.scope == decl.scope &&
-    (match d.kind {
+  .find_first(fn(did) {
+    let @scope.DeclId(di) = did
+    match g.decls[di].kind {
       @scope.DeclKind::ModuleDef(def_index=i) => i == target
       _ => false
-    })
+    }
+  })
+  .map(fn(did) {
+    let @scope.DeclId(di) = did
+    g.decls[di]
   })
 }
 

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -19,12 +19,14 @@ fn build_parent_map(
 ///|
 /// Mutable builder state accumulated across passes.
 ///
-/// `node_cutoffs` is transient pass-2 state (never stored in the graph): for
-/// each node it records the sequential cutoff of every enclosing module scope
-/// — a `ModuleDef(def_index)` in scope `s` is visible to the node only if
-/// `def_index < node_cutoffs[node][s]`. Lambda scopes never appear (they hold
-/// no `ModuleDef`). This generalises the former single-`Int` cutoff so nested
-/// blocks each carry their own sequential position independently.
+/// `node_cutoffs` records, for each node, the sequential cutoff of every
+/// enclosing module scope — a `ModuleDef(def_index)` in scope `s` is visible to
+/// the node only if `def_index < node_cutoffs[node][s]`. Lambda scopes never
+/// appear (they hold no `ModuleDef`). This generalises the former single-`Int`
+/// cutoff so nested blocks each carry their own sequential position
+/// independently. Both `node_scope` and `node_cutoffs` are persisted into the
+/// built `ScopeGraph` so `resolve_name_at` can answer hypothetical-position
+/// queries; they were formerly transient pass-2 state.
 priv struct Builder {
   scopes : Array[Scope]
   decls : Array[Decl]
@@ -107,7 +109,15 @@ fn Builder::pass2(
     // `descend_module_children`.
     @ast.Term::Module(_, _) => {
       self.node_scope[root.id()] = root_scope
-      self.node_cutoffs[root.id()] = {}
+      // The root module node's own scope is `root_scope`, so its cutoff map must
+      // cover it (the resolver asserts every module scope on the chain is keyed).
+      // Module-start semantics (0 root defs visible) mirror the bare-expression
+      // arm below and make `resolve_name_at(g, module_node_id, _)` total — it
+      // returns None at the container node rather than aborting. Children get
+      // their own per-position cutoffs via `descend_module_children`.
+      let root_cutoffs : Map[ScopeId, Int] = {}
+      root_cutoffs[root_scope] = 0
+      self.node_cutoffs[root.id()] = root_cutoffs
       self.descend_module_children(root, root_scope, {})
     }
     // Bare lambda / expression program: `module_projection.defs` is empty, so
@@ -220,18 +230,36 @@ fn Builder::resolve(
   start_scope : ScopeId,
   cutoffs : Map[ScopeId, Int],
 ) -> Resolution {
+  resolve_in(self.scopes, self.decls, name, start_scope, cutoffs)
+}
+
+///|
+/// Resolve `name` from `start_scope` upward over the given `scopes`/`decls`,
+/// gating `ModuleDef` decls by the per-scope `cutoffs` and treating `LamParam`
+/// decls as always visible. This is the single canonical resolver shared by
+/// pass 3 (via `Builder::resolve`) and the public `resolve_name_at` query — both
+/// must agree, so there is one implementation, not a copy. See `Builder::resolve`
+/// for the cutoff invariant (`cutoffs.get(sid).unwrap()` asserts that every
+/// module scope on the chain was recorded for this resolution).
+fn resolve_in(
+  scopes : Array[Scope],
+  decls : Array[Decl],
+  name : String,
+  start_scope : ScopeId,
+  cutoffs : Map[ScopeId, Int],
+) -> Resolution {
   let visited : Array[ScopeId] = []
   let mut cur : ScopeId? = Some(start_scope)
   while cur is Some(sid) {
     let ScopeId(si) = sid
-    let scope = self.scopes[si]
+    let scope = scopes[si]
     // later decls win within a scope (shadowing), so search in reverse and take
     // the first match; module-scope decls respect the per-scope cutoff.
     let hit = scope.decl_ids
       .rev_iter()
       .find_first(fn(did) {
         let DeclId(di) = did
-        let decl = self.decls[di]
+        let decl = decls[di]
         decl.name == name &&
         (match decl.kind {
           ModuleDef(def_index~) => def_index < cutoffs.get(sid).unwrap()
@@ -289,5 +317,12 @@ pub fn build(
   let root = root_node(registry)
   b.pass2(module_projection, root)
   b.pass3(registry)
-  { scopes: b.scopes, decls: b.decls, refs: b.refs, module_node_id: root.id() }
+  {
+    scopes: b.scopes,
+    decls: b.decls,
+    refs: b.refs,
+    module_node_id: root.id(),
+    node_scope: b.node_scope,
+    node_cutoffs: b.node_cutoffs,
+  }
 }

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -79,4 +79,11 @@ pub(all) struct ScopeGraph {
   decls : Array[Decl]
   refs : Array[Ref]
   module_node_id : @core.NodeId
+  // Per-node resolution inputs, retained from the builder so consumers can ask
+  // hypothetical-position questions ("what would `name` resolve to AT this
+  // node?", `resolve_name_at`). `node_cutoffs` keys each `ModuleDef`'s
+  // sequential visibility per enclosing module scope; lambda scopes never appear
+  // (they hold no `ModuleDef`). Every walked node has an entry in both.
+  node_scope : Map[@core.NodeId, ScopeId]
+  node_cutoffs : Map[@core.NodeId, Map[ScopeId, Int]]
 } derive(Debug)

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -181,6 +181,37 @@ test "references: identity-based, shadowing-aware" {
 }
 
 ///|
+/// A forward reference from a LATER sibling's init counts toward the earlier
+/// def. In `let x = 0\nlet x = x\nx`, def1's init `x` cannot see itself
+/// (sequential `let`), so it resolves to def0 — `references(def0)` must include
+/// it. The body `x` resolves to the latest binder (def1). Regression guard: if
+/// forward-init references stopped being recorded, `references(def0)` drops to 0.
+test "references: forward reference from a later sibling init counts" {
+  let (_proj, module_projection, registry, source_map) = build_fixture(
+    "let x = 0\nlet x = x\nx",
+  )
+  let g = build(module_projection, registry, source_map)
+  let def0 = g.decls[0].id
+  let def1 = g.decls[1].id
+  inspect(references(g, def0).length(), content="1")
+  inspect(references(g, def1).length(), content="1")
+}
+
+///|
+/// A module binding whose only use sits inside a SHADOWING lambda has zero
+/// references: in `let x = 0\n(x) => x` the body `x` is bound by the lambda
+/// param, not the module `x`. Regression guard for shadow-aware reference
+/// counting (a shadow-blind counter would report 1).
+test "references: use under a shadowing lambda does not count" {
+  let (_proj, module_projection, registry, source_map) = build_fixture(
+    "let x = 0\n(x) => x",
+  )
+  let g = build(module_projection, registry, source_map)
+  let def0 = g.decls[0].id
+  inspect(references(g, def0).length(), content="0")
+}
+
+///|
 test "enclosing_env: lambda params in scope" {
   let (proj, module_projection, registry, source_map) = build_fixture(
     "(x, y) => x",

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -23,6 +23,10 @@ pub fn go_to_definition(ScopeGraph, @dowdiness/canopy/core.SourceMap, Int) -> @d
 
 pub fn references(ScopeGraph, DeclId) -> Array[@dowdiness/canopy/core.NodeId]
 
+pub fn resolve_at_module_root_end(ScopeGraph, String) -> Decl?
+
+pub fn resolve_name_at(ScopeGraph, @dowdiness/canopy/core.NodeId, String) -> Decl?
+
 // Errors
 
 // Types and methods
@@ -74,6 +78,8 @@ pub(all) struct ScopeGraph {
   decls : Array[Decl]
   refs : Array[Ref]
   module_node_id : @dowdiness/canopy/core.NodeId
+  node_scope : Map[@dowdiness/canopy/core.NodeId, ScopeId]
+  node_cutoffs : Map[@dowdiness/canopy/core.NodeId, Map[ScopeId, Int]]
 } derive(@debug.Debug)
 
 pub(all) struct ScopeId(Int) derive(Compare, Eq, Hash, @debug.Debug)

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -98,6 +98,62 @@ pub fn go_to_definition(
 }
 
 ///|
+/// Hypothetical-position resolution: the declaration that `name` would resolve
+/// to if referenced AT `node_id`'s position — i.e. from `node_id`'s scope, with
+/// `node_id`'s per-(node,scope) cutoffs. This is the exact resolver pass 3 uses
+/// for real references, so it correctly respects nested-block sequential cutoffs
+/// (unlike a single root-relative cutoff). `None` when `node_id` was not walked
+/// (absent from `node_scope`) or `name` is unbound there.
+///
+/// Callers must pass the actual site where a moved/inlined expression would land
+/// (e.g. the replacement use site for inline), not an enclosing binding node.
+pub fn resolve_name_at(
+  g : ScopeGraph,
+  node_id : @core.NodeId,
+  name : String,
+) -> Decl? {
+  guard g.node_scope.get(node_id) is Some(start) else { return None }
+  let cutoffs = g.node_cutoffs.get(node_id).unwrap()
+  match resolve_in(g.scopes, g.decls, name, start, cutoffs).decl {
+    Some(did) => {
+      let DeclId(di) = did
+      Some(g.decls[di])
+    }
+    None => None
+  }
+}
+
+///|
+/// The declaration `name` resolves to at the END of the root module — after all
+/// root-level definitions, where a newly inserted top-level `let` (extract) would
+/// sit. Resolves in the root scope with cutoff = the count of root `ModuleDef`
+/// decls, so every root def is visible. Unlike deriving a body node from
+/// `module_projection.final_expr` (a synthetic `Unit` body has no real node),
+/// this is total: it never silently skips the capture check.
+pub fn resolve_at_module_root_end(g : ScopeGraph, name : String) -> Decl? {
+  guard g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root) else {
+    return None
+  }
+  let cutoff = root.decl_ids.fold(init=0, fn(acc, did) {
+    let DeclId(di) = did
+    if g.decls[di].kind is ModuleDef(_) {
+      acc + 1
+    } else {
+      acc
+    }
+  })
+  let cutoffs : Map[ScopeId, Int] = {}
+  cutoffs[root.id] = cutoff
+  match resolve_in(g.scopes, g.decls, name, root.id, cutoffs).decl {
+    Some(did) => {
+      let DeclId(di) = did
+      Some(g.decls[di])
+    }
+    None => None
+  }
+}
+
+///|
 /// The set of names bound in scopes enclosing `node` — the FULL lexical
 /// environment (lambda params AND module defs). This is a SUPERSET of the
 /// retired edits-package `collect_lam_env` (which returned only lambda params);

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -8,6 +8,21 @@ fn ScopeGraph::decl_of(self : ScopeGraph, did : DeclId) -> Decl {
 }
 
 ///|
+/// Resolve `name` from `start` (gating `ModuleDef` decls by `cutoffs`) to its
+/// `Decl`. The shared tail of the public hypothetical-position queries, so the
+/// `resolve_in` argument threading and `DeclId -> Decl` mapping exist once.
+fn ScopeGraph::resolve_to_decl(
+  self : ScopeGraph,
+  name : String,
+  start : ScopeId,
+  cutoffs : Map[ScopeId, Int],
+) -> Decl? {
+  resolve_in(self.scopes, self.decls, name, start, cutoffs).decl.map(fn(did) {
+    self.decl_of(did)
+  })
+}
+
+///|
 /// The declaration a reference resolves to, or None if unresolved (free).
 pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
   g.refs
@@ -120,9 +135,7 @@ pub fn resolve_name_at(
 ) -> Decl? {
   guard g.node_scope.get(node_id) is Some(start) else { return None }
   let cutoffs = g.node_cutoffs.get(node_id).unwrap()
-  resolve_in(g.scopes, g.decls, name, start, cutoffs).decl.map(fn(did) {
-    g.decl_of(did)
-  })
+  g.resolve_to_decl(name, start, cutoffs)
 }
 
 ///|
@@ -142,9 +155,7 @@ pub fn resolve_at_module_root_end(g : ScopeGraph, name : String) -> Decl? {
     .count()
   let cutoffs : Map[ScopeId, Int] = {}
   cutoffs[root.id] = cutoff
-  resolve_in(g.scopes, g.decls, name, root.id, cutoffs).decl.map(fn(did) {
-    g.decl_of(did)
-  })
+  g.resolve_to_decl(name, root.id, cutoffs)
 }
 
 ///|

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -1,14 +1,20 @@
 ///|
+/// Resolve a `DeclId` (graph-local identity) to its `Decl` record. The single
+/// place that unwraps the `DeclId` index, so the `g.decls[di]` lookup is not
+/// re-spelled at every resolution site.
+fn ScopeGraph::decl_of(self : ScopeGraph, did : DeclId) -> Decl {
+  let DeclId(di) = did
+  self.decls[di]
+}
+
+///|
 /// The declaration a reference resolves to, or None if unresolved (free).
 pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
   g.refs
   .iter()
   .find_first(fn(r) { r.node_id == ref_node })
   .bind(fn(r) { r.resolution.decl })
-  .map(fn(did) {
-    let DeclId(di) = did
-    g.decls[di]
-  })
+  .map(fn(did) { g.decl_of(did) })
 }
 
 ///|
@@ -114,13 +120,9 @@ pub fn resolve_name_at(
 ) -> Decl? {
   guard g.node_scope.get(node_id) is Some(start) else { return None }
   let cutoffs = g.node_cutoffs.get(node_id).unwrap()
-  match resolve_in(g.scopes, g.decls, name, start, cutoffs).decl {
-    Some(did) => {
-      let DeclId(di) = did
-      Some(g.decls[di])
-    }
-    None => None
-  }
+  resolve_in(g.scopes, g.decls, name, start, cutoffs).decl.map(fn(did) {
+    g.decl_of(did)
+  })
 }
 
 ///|
@@ -134,23 +136,15 @@ pub fn resolve_at_module_root_end(g : ScopeGraph, name : String) -> Decl? {
   guard g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root) else {
     return None
   }
-  let cutoff = root.decl_ids.fold(init=0, fn(acc, did) {
-    let DeclId(di) = did
-    if g.decls[di].kind is ModuleDef(_) {
-      acc + 1
-    } else {
-      acc
-    }
-  })
+  let cutoff = root.decl_ids
+    .iter()
+    .filter(fn(did) { g.decl_of(did).kind is ModuleDef(_) })
+    .count()
   let cutoffs : Map[ScopeId, Int] = {}
   cutoffs[root.id] = cutoff
-  match resolve_in(g.scopes, g.decls, name, root.id, cutoffs).decl {
-    Some(did) => {
-      let DeclId(di) = did
-      Some(g.decls[di])
-    }
-    None => None
-  }
+  resolve_in(g.scopes, g.decls, name, root.id, cutoffs).decl.map(fn(did) {
+    g.decl_of(did)
+  })
 }
 
 ///|
@@ -176,8 +170,7 @@ pub fn enclosing_env(
     let ScopeId(si) = sid
     let scope = g.scopes[si]
     for did in scope.decl_ids {
-      let DeclId(di) = did
-      env = env.add(g.decls[di].name)
+      env = env.add(g.decl_of(did).name)
     }
     cur = scope.parent
   }

--- a/lang/lambda/scope/resolve_name_at_wbtest.mbt
+++ b/lang/lambda/scope/resolve_name_at_wbtest.mbt
@@ -1,0 +1,55 @@
+// Tests for the hypothetical-position resolvers `resolve_name_at` and
+// `resolve_at_module_root_end` (the model the edits/ capture analysis reuses
+// instead of a single root-relative cutoff). The fixture has a root `a` AND a
+// block-local `a`, so a single root cutoff would mis-resolve the nested case.
+
+///|
+/// `let a = 99\nlet r = { let a = 1\n  let b = a\n  b }`
+/// proj.children = [LetDef(a), LetDef(r), body]; r.children[0] = block;
+/// block.children = [LetDef(a), LetDef(b), body Var(b)].
+fn resolve_fixture() -> (
+  ScopeGraph,
+  @core.NodeId, // root LetDef(a) id
+  @core.NodeId, // block LetDef(a) id
+  @core.ProjNode[@ast.Term], // proj root (for find_var_node)
+) raise {
+  let text = "let a = 99\nlet r = { let a = 1\n  let b = a\n  b }"
+  let (proj, module_projection, registry, source_map) = build_fixture(text)
+  let g = build(module_projection, registry, source_map)
+  let root_a = proj.children[0].id()
+  let block = proj.children[1].children[0]
+  let block_a = block.children[0].id()
+  (g, root_a, block_a, proj)
+}
+
+///|
+test "resolve_name_at: block body resolves a free name to the BLOCK-LOCAL binder" {
+  let (g, root_a, block_a, proj) = resolve_fixture()
+  // The block body `b` sees the block's own `a` (block-index 0), so `a` resolved
+  // AT that position must be the block-local binder, not the root `a`.
+  let body_b = find_var_node(proj, "b")
+  guard resolve_name_at(g, body_b, "a") is Some(decl)
+  inspect(decl.name, content="a")
+  inspect(decl.node_id == block_a, content="true")
+  inspect(decl.node_id == root_a, content="false")
+}
+
+///|
+test "resolve_name_at: the root module node is a total query (None, not abort)" {
+  let (g, _root_a, _block_a, _proj) = resolve_fixture()
+  // The container module node is not a resolution site; resolving any name there
+  // must return None rather than aborting on a missing root-scope cutoff.
+  inspect(resolve_name_at(g, g.module_node_id, "a") is None, content="true")
+  inspect(resolve_name_at(g, g.module_node_id, "nope") is None, content="true")
+}
+
+///|
+test "resolve_at_module_root_end: resolves to the ROOT binder, not a block-local one" {
+  let (g, root_a, block_a, _proj) = resolve_fixture()
+  // At module end every ROOT def is visible; the block-local `a` is not in scope.
+  guard resolve_at_module_root_end(g, "a") is Some(decl)
+  inspect(decl.node_id == root_a, content="true")
+  inspect(decl.node_id == block_a, content="false")
+  // A block-only name is unbound at module end (so extract sees it would rebind).
+  inspect(resolve_at_module_root_end(g, "b") is None, content="true")
+}


### PR DESCRIPTION
## What

Teaches the `edits/` **inline / extract / binding** ops about nested-block scopes, closing the remaining root-relative blind spot from `docs/TODO.md` §20.

Inline, extract, and the binding ops (delete/duplicate/move) resolved a block-aware `@scope.Decl` back to a root-relative `def_index`, so a block-local binding sharing a `def_index` with a root def was mis-resolved to the root def (unsound inline/extract) or rejected outright (incapable binding ops).

## How (no 4th resolver — reuse the builder's per-(node,scope) model)

- Persist the builder's `node_scope` and `node_cutoffs` on `ScopeGraph` so the hypothetical-position capture query ("what would N resolve to if moved to P") uses the same cutoff model the builder already computes.
- Expose `@scope.resolve_name_at` (per-node) and `@scope.resolve_at_module_root_end` (extract's module-end target, total even when the module body is a synthetic Unit).
- Delete the parallel root-relative resolvers in `edits/scope.mbt`; synthesize the def-view from the decl's own node (`def_view_from_decl`).
- Factor the binding-op preamble (graph build, block-aware binder→decl, def-view) into one `def_for_binding` helper.
- Filter capture occurrences bound within the moved init (lambda param OR nested-block def) so a shadow inside an inlined init is not a false capture. The subtree is built once per rebind check via `@core.collect_registry`.

## Capability scope (verified by re-parsing each op's actual output)

- **inline / extract / move / delete / inline-all** re-parse to the correct AST for block-local bindings.
- **duplicate** now *reaches* block-local binders (no longer rejected), but its `_copy` suffix is not a lexable identifier in this language, so the copy's name does not round-trip — a pre-existing, all-bindings defect tracked in **#649** (which also scopes the proper fresh-name/renaming mechanism).
- Indentation drift on the position-based span ops is cosmetic (re-parses cleanly), tracked in **#650**.

## Reuse check

- **`@scope.resolve_name_at` / `resolve_at_module_root_end`** — new accessors over the builder's existing `node_cutoffs`/`node_scope`, rather than a 4th hand-rolled resolver. The parallel root-cutoff resolvers (`def_cutoff_at_node`, `declaration_id_for_name_*`) and `module_def_references` are **deleted**.
- **`@core.collect_registry`** — reused for the bound-within-init subtree (replaces a per-free-name immutable-union recomputation).
- **`@scope.references(g, decl.id)`** — identity-based, shadowing-correct reference lookup owned/tested by `@scope`; the edits-local `module_def_references` wrapper is gone.
- **`def_for_binding`** — new helper, sole responsibility: the shared binding-op preamble. Used by delete/duplicate/move/inline-all.

## Tests

`text_edit_nested_block_wbtest.mbt` (inline shared-index soundness, nested-scope free-var resolution, false-capture filter, block-local extract rejection, block-local duplicate-reaches / move-swap / inline-all — all asserted by **re-parsing** op output, not byte snapshots) + `resolve_name_at_wbtest.mbt` (per-node block-local resolution, root-node totality, module-end root binder) + restored `references`-count coverage (forward-init ref, lambda-shadow non-count).

## Follow-ups filed

#649 (duplicate `_copy` unlexable / proper renaming mechanism), #650 (cosmetic indentation drift), #651 (`free_names_captured_at_use_sites` Module-blind), #652 (`resolve_at_module_root_end` drift), #653 (rename should reuse `decl_for_binding_node`).

## Note

Rebased onto `origin/main` over #648 ("extract module definition index"): #648's `find_binding_for_init` refactor (`definition_index().binding_for_node`) and its `find_binding_for_init: duplicate defs` test are preserved; its `def_cutoff_at_node` test was removed alongside the function this PR deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unsoundness in inline definition, extraction, and binding edit operations when working with nested-block scopes; name resolution is now block-aware and shadowing-correct, improving capture and sibling/ordering behavior.

* **Tests**
  * Added regression coverage for nested-block scope scenarios across inline, extract, duplicate, and move binding operations.
  * Added scope-resolution regression tests, including legacy compatibility for definition view behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->