### PR TITLE
refactor(lambda): migrate consumers off ModuleProjection

### DIFF
--- a/examples/ideal/main/action_model.mbt
+++ b/examples/ideal/main/action_model.mbt
@@ -19,13 +19,14 @@ fn detect_action_context(
     Some(n) => n
     None => return None
   }
-  let module_projection = match companion.get_module_projection() {
-    Some(fp) => fp
+  let _ = companion
+  let definition_index = match editor.get_proj_node() {
+    Some(root) => @lambda_proj.DefinitionIndex::from_proj_node(root)
     None => return None
   }
   // Check if this node is a let-binding row or init expression.
   let (is_let_binding, binding_node_id, binding_def_index) = match
-    @lambda_edits.find_binding_for_init(nid, module_projection) {
+    @lambda_edits.find_binding_for_init(nid, definition_index) {
     Some((bid, idx)) => (true, Some(bid), Some(idx))
     None => (false, None, None)
   }

--- a/examples/ideal/main/scope_annotation.mbt
+++ b/examples/ideal/main/scope_annotation.mbt
@@ -18,7 +18,7 @@
 //     binder key + all its usages. Uniform for both lambda and module bindings.
 //
 // Data flow:
-//   ModuleProjection + registry + SourceMap → @scope.build → @scope.references
+//   registry + SourceMap → @scope.build → @scope.references
 //     → scope_map → view_outline_node → compute_highlight_set
 //   Nested block Modules are overlaid by building @scope graphs for each nested
 //   Module subtree; the overlay still consumes @scope.references by DeclId and
@@ -97,11 +97,7 @@ fn add_module_scope_annotations(
   if registry.is_empty() {
     return
   }
-  let graph = @scope.build(
-    @lambda_proj.ModuleProjection::from_proj_node(node),
-    registry,
-    source_map,
-  )
+  let graph = @scope.build(registry, source_map)
   add_scope_graph_annotations(scope_map, graph)
 }
 
@@ -159,15 +155,13 @@ fn build_scope_map(
 ) -> Map[@canopy_core.NodeId, ScopeAnnotation] {
   let scope_map : Map[@canopy_core.NodeId, ScopeAnnotation] = {}
   guard editor.get_proj_node() is Some(proj_root) else { return scope_map }
-  guard companion.get_module_projection() is Some(module_projection) else {
-    return scope_map
-  }
+  let _ = companion
   let registry = editor.get_registry()
   if registry.is_empty() {
     return scope_map
   }
   let source_map = editor.get_source_map()
-  let graph = @scope.build(module_projection, registry, source_map)
+  let graph = @scope.build(registry, source_map)
   add_scope_graph_annotations(scope_map, graph)
   add_nested_module_scope_annotations(proj_root, source_map, scope_map)
   rebuild_usage_lists(scope_map)

--- a/examples/ideal/main/scope_annotation_wbtest.mbt
+++ b/examples/ideal/main/scope_annotation_wbtest.mbt
@@ -121,11 +121,7 @@ test "scope_map keys module references by real LetDef declaration" {
   let x_vars = find_all_var_node_ids(proj_root, "x")
   let inner_x_id = x_vars[0]
   let module_x_id = x_vars[x_vars.length() - 1]
-  let graph = @scope.build(
-    companion.get_module_projection().unwrap(),
-    editor.get_registry(),
-    editor.get_source_map(),
-  )
+  let graph = @scope.build(editor.get_registry(), editor.get_source_map())
   let module_decl = @scope.declaration(graph, module_x_id).unwrap()
   let inner_decl = @scope.declaration(graph, inner_x_id).unwrap()
   inspect(module_decl.id == inner_decl.id, content="false")

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -49,7 +49,8 @@ pub fn LambdaCompanion::dispose_analysis_attachment(
 }
 
 ///|
-/// Returns the current ModuleProjection, or `None` when the source is empty.
+/// Temporary flat-projection adapter: returns the current `ModuleProjection`,
+/// or `None` when the source is empty.
 ///
 /// Abort semantics: `Derived::read_or_abort` panics only if the underlying
 /// cell has been disposed or participates in a reactive cycle. The Phase 1
@@ -188,7 +189,7 @@ pub fn new_lambda_editor(
     capture_timeout_ms~,
     parent_runtime?,
     capabilities=build_lambda_capabilities(
-      cached_proj_node_ref, source_map_memo_ref, proj_memo_ref, escalation_memo_ref,
+      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref,
     ),
   )
   let companion : LambdaCompanion = {
@@ -200,21 +201,10 @@ pub fn new_lambda_editor(
 }
 
 ///|
-fn lambda_module_projection_for_capabilities(
-  proj_memo_ref : Ref[@incr.Derived[@lambda_flat.VersionedModuleProjection]?],
-) -> @lambda_proj.ModuleProjection? {
-  match proj_memo_ref.val {
-    Some(memo) => memo.read_or_abort().proj
-    None => None
-  }
-}
-
-///|
 /// Build capabilities using the escalation memo (Tier 1 + Tier 2 merged results).
 fn build_lambda_capabilities(
   cached_proj_node_ref : Ref[@incr.Derived[@core.ProjNode[@ast.Term]?]?],
   source_map_memo_ref : Ref[@incr.Derived[@core.SourceMap]?],
-  proj_memo_ref : Ref[@incr.Derived[@lambda_flat.VersionedModuleProjection]?],
   escalation_memo_ref : Ref[@incr.Derived[Array[@lambda_eval.EvalResult]]?],
 ) -> @editor.LanguageCapabilities[@ast.Term] {
   @editor.LanguageCapabilities::new(
@@ -232,10 +222,9 @@ fn build_lambda_capabilities(
         (Some(root), Some(source_map_memo)) =>
           append_annotation_map(
             annotations,
-            @lambda_semantic.build_semantic_projection_with_module_projection(
+            @lambda_semantic.build_semantic_projection(
               root,
               source_map_memo.read_or_abort(),
-              lambda_module_projection_for_capabilities(proj_memo_ref),
             ).annotations,
           )
         _ => ()
@@ -247,10 +236,9 @@ fn build_lambda_capabilities(
         (Some(proj_memo), Some(source_map_memo)) =>
           match proj_memo.read_or_abort() {
             Some(root) =>
-              @lambda_semantic.build_semantic_projection_with_module_projection(
+              @lambda_semantic.build_semantic_projection(
                 root,
                 source_map_memo.read_or_abort(),
-                lambda_module_projection_for_capabilities(proj_memo_ref),
               ).decorations
             None => []
           }
@@ -286,17 +274,18 @@ pub fn apply_lambda_tree_edit(
       return editor.move_node(source, target, position, timestamp_ms)
     _ => ()
   }
+  let _ = companion
   let source_map = editor.get_source_map()
   let registry = editor.get_registry()
-  let module_projection = match companion.get_module_projection() {
-    Some(fp) => fp
+  let definition_index = match editor.get_proj_node() {
+    Some(root) => @lambda_proj.DefinitionIndex::from_proj_node(root)
     None => return Err(@editor.TreeEditError::ModuleProjectionUnavailable)
   }
   let ctx : @lambda_edits.EditContext[@ast.Term] = {
     source_text: editor.get_text(),
     source_map,
     registry,
-    module_projection,
+    definition_index,
   }
   match @lambda_edits.compute_text_edit(op, ctx) {
     Ok(Some((edits, focus_hint))) => {

--- a/lang/lambda/edits/actions.mbt
+++ b/lang/lambda/edits/actions.mbt
@@ -12,7 +12,7 @@ using @core {type SourceMap}
 
 ///|
 using @lambda_proj {
-  type ModuleProjection,
+  type DefinitionIndex,
   rebuild_kind,
   to_proj_node,
   parse_to_proj_node,

--- a/lang/lambda/edits/pkg.generated.mbti
+++ b/lang/lambda/edits/pkg.generated.mbti
@@ -12,7 +12,7 @@ import {
 // Values
 pub fn compute_text_edit(TreeEditOp, EditContext[@ast.Term]) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String]
 
-pub fn find_binding_for_init(@core.NodeId, @proj.ModuleProjection) -> (@core.NodeId, Int)?
+pub fn find_binding_for_init(@core.NodeId, @proj.DefinitionIndex) -> (@core.NodeId, Int)?
 
 pub fn free_vars(@ast.Term, @hashset.HashSet[String]) -> @hashset.HashSet[String]
 
@@ -40,7 +40,7 @@ pub(all) struct EditContext[T] {
   source_text : String
   source_map : @core.SourceMap
   registry : Map[@core.NodeId, @core.ProjNode[T]]
-  module_projection : @proj.ModuleProjection
+  definition_index : @proj.DefinitionIndex
 }
 
 pub(all) struct NodeContext {

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -1,21 +1,18 @@
 ///|
-/// Identity-based references to a module definition, delegated to the canonical
-/// scope graph query. The old name-based usage scan could over-match a later
-/// shadowing definition's body; this helper first locates the graph-local
-/// `DeclId` for the requested module def, then asks `@scope.references` for only
-/// refs resolved to that declaration.
-fn module_def_references(
+fn module_def_decl_for_binding(
   g : @scope.ScopeGraph,
-  def_index : Int,
-) -> Result[Array[NodeId], String] {
-  for decl in g.decls {
-    match decl.kind {
-      @scope.DeclKind::ModuleDef(def_index=i) if i == def_index =>
-        return Ok(@scope.references(g, decl.id))
-      _ => ()
-    }
+  binding_node_id : NodeId,
+) -> Result[@scope.Decl, String] {
+  match
+    g.decls
+    .iter()
+    .find_first(fn(decl) {
+      decl.node_id == binding_node_id &&
+      decl.kind is @scope.DeclKind::ModuleDef(_)
+    }) {
+    Some(decl) => Ok(decl)
+    None => Err("Binding not found: " + binding_node_id.to_string())
   }
-  Err("No scope declaration for module def index " + def_index.to_string())
 }
 
 ///|
@@ -64,15 +61,6 @@ fn free_names_captured_at_use_sites(
     }
   })
   captured
-}
-
-///|
-fn def_cutoff_at_node(
-  module_projection : ModuleProjection,
-  source_map : SourceMap,
-  node_id : NodeId,
-) -> Int {
-  module_projection.definition_index().cutoff_at_node(source_map, node_id)
 }
 
 ///|
@@ -180,31 +168,23 @@ fn declaration_id_for_name_from_scope(
 ///|
 fn declaration_id_for_name_at_node(
   g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
-  source_map : SourceMap,
   node_id : NodeId,
   name : String,
 ) -> @scope.DeclId? {
-  guard scope_id_for_node(g, node_id) is Some(start_scope) else { return None }
-  declaration_id_for_name_from_scope(
-    g,
-    start_scope,
-    def_cutoff_at_node(module_projection, source_map, node_id),
-    name,
-  )
+  @scope.declaration_for_name_at(g, node_id, name).map(fn(decl) { decl.id })
 }
 
 ///|
 fn declaration_id_for_name_at_module_end(
   g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
+  definition_index : DefinitionIndex,
   name : String,
 ) -> @scope.DeclId? {
   guard root_scope_id(g) is Some(root_scope) else { return None }
   declaration_id_for_name_from_scope(
     g,
     root_scope,
-    module_projection.definition_index().length(),
+    definition_index.length(),
     name,
   )
 }
@@ -212,17 +192,13 @@ fn declaration_id_for_name_at_module_end(
 ///|
 fn free_names_would_rebind_at_node(
   g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
-  source_map : SourceMap,
   source_node : ProjNode[@ast.Term],
   target_node_id : NodeId,
   free_names : @immut/hashset.HashSet[String],
 ) -> Bool {
   let mut rebound = false
   free_names.each(fn(v) {
-    let target_decl = declaration_id_for_name_at_node(
-      g, module_projection, source_map, target_node_id, v,
-    )
+    let target_decl = declaration_id_for_name_at_node(g, target_node_id, v)
     if free_name_would_rebind_to(g, source_node, v, target_decl) {
       rebound = true
     }
@@ -233,14 +209,14 @@ fn free_names_would_rebind_at_node(
 ///|
 fn free_names_would_rebind_at_module_end(
   g : @scope.ScopeGraph,
-  module_projection : ModuleProjection,
+  definition_index : DefinitionIndex,
   source_node : ProjNode[@ast.Term],
   free_names : @immut/hashset.HashSet[String],
 ) -> Bool {
   let mut rebound = false
   free_names.each(fn(v) {
     let target_decl = declaration_id_for_name_at_module_end(
-      g, module_projection, v,
+      g, definition_index, v,
     )
     if free_name_would_rebind_to(g, source_node, v, target_decl) {
       rebound = true
@@ -264,12 +240,12 @@ fn free_name_would_rebind_to(
 }
 
 ///|
-/// Look up the ModuleProjection binding NodeId for a given init expression or LetDef NodeId.
+/// Look up the module binding NodeId for a given init expression or LetDef NodeId.
 /// Init-expression callers are mapped to the parent LetDef id; direct LetDef
 /// callers return the binding id unchanged.
 pub fn find_binding_for_init(
   init_node_id : NodeId,
-  module_projection : ModuleProjection,
+  definition_index : DefinitionIndex,
 ) -> (NodeId, Int)? {
-  module_projection.definition_index().binding_for_node(init_node_id)
+  definition_index.binding_for_node(init_node_id)
 }

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -35,7 +35,11 @@ fn find_var(root : @core.ProjNode[@ast.Term], name : String) -> NodeId {
 /// `declaration` query under test.)
 fn graph_of(
   text : String,
-) -> (@core.ProjNode[@ast.Term], ModuleProjection, @scope.ScopeGraph) raise {
+) -> (
+  @core.ProjNode[@ast.Term],
+  @lambda_proj.ModuleProjection,
+  @scope.ScopeGraph,
+) raise {
   let (proj, fp, g, _sm) = graph_and_sm_of(text)
   (proj, fp, g)
 }
@@ -47,15 +51,20 @@ fn graph_of(
 /// a syntax tree to walk.
 fn graph_and_sm_of(
   text : String,
-) -> (@core.ProjNode[@ast.Term], ModuleProjection, @scope.ScopeGraph, SourceMap) raise {
+) -> (
+  @core.ProjNode[@ast.Term],
+  @lambda_proj.ModuleProjection,
+  @scope.ScopeGraph,
+  SourceMap,
+) raise {
   let (cst, _errs) = @parser.parse_cst(text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = to_proj_node(syntax, Ref(0))
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let sm = SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, sm)
+  let g = @scope.build(registry, sm)
   (proj, fp, g, sm)
 }
 
@@ -208,7 +217,7 @@ fn production_graph_of(
   // token span, not the full LetDef node range.
   populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, sm)
+  let g = @scope.build(registry, sm)
   (proj, registry, g, sm)
 }
 

--- a/lang/lambda/edits/scope_incremental_differential_wbtest.mbt
+++ b/lang/lambda/edits/scope_incremental_differential_wbtest.mbt
@@ -61,7 +61,7 @@ fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
 /// alias the Module id onto an existing init-subtree node id and corrupt the
 /// node-id-keyed registry / SourceMap.
 fn build_graph_from_fp(
-  fp : ModuleProjection,
+  fp : @lambda_proj.ModuleProjection,
   syntax : @seam.SyntaxNode,
   base_id : Int,
 ) -> (
@@ -75,7 +75,7 @@ fn build_graph_from_fp(
   let sm = SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, sm)
+  let g = @scope.build(registry, sm)
   (proj, registry, g, sm)
 }
 
@@ -86,7 +86,7 @@ fn build_graph_from_fp(
 /// `assert_same_var_refs`, `assert_lam_ranges_unique`, `def_init_ranges`,
 /// `normalize_decl`), so node-id values are never compared raw.
 fn assert_incr_matches_full(
-  incr_fp : ModuleProjection,
+  incr_fp : @lambda_proj.ModuleProjection,
   incr_base_id : Int,
   syntax : @seam.SyntaxNode,
   context : String,

--- a/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
+++ b/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
@@ -143,7 +143,7 @@ fn assert_level_b_agrees(
   guard fp_opt is Some(fp) && root_opt is Some(root) else {
     fail("[\{context}] memo projection is None on non-empty source: \{src}")
   }
-  let g_i = @scope.build(fp, reg_i, sm_i)
+  let g_i = @scope.build(reg_i, sm_i)
   let ranges_i = def_init_ranges(root)
   // Full side: a fresh production rebuild of the same current source (the oracle
   // already used by the cross-pipeline PBT).

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -14,14 +14,37 @@ fn scope_test_registry(
 }
 
 ///|
+fn module_def_references_for_test(
+  g : @scope.ScopeGraph,
+  def_index : Int,
+) -> Result[Array[NodeId], String] {
+  for decl in g.decls {
+    match decl.kind {
+      @scope.DeclKind::ModuleDef(def_index=i) if i == def_index =>
+        return Ok(@scope.references(g, decl.id))
+      _ => ()
+    }
+  }
+  Err("No scope declaration for module def index " + def_index.to_string())
+}
+
+///|
+fn def_cutoff_at_node_for_test(
+  definition_index : DefinitionIndex,
+  source_map : SourceMap,
+  node_id : NodeId,
+) -> Int {
+  definition_index.cutoff_at_node(source_map, node_id)
+}
+
+///|
 test "module_def_references: finds Var references in Module body" {
   let text = "let x = 0\nx + x"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
   let source_map = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, source_map)
-  match module_def_references(g, 0) {
+  let g = @scope.build(registry, source_map)
+  match module_def_references_for_test(g, 0) {
     Ok(refs) => inspect(refs.length(), content="2")
     Err(e) => fail(e)
   }
@@ -31,11 +54,10 @@ test "module_def_references: finds Var references in Module body" {
 test "module_def_references: respects shadowing by inner Lam" {
   let text = "let x = 0\n(x) => x"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
   let source_map = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, source_map)
-  match module_def_references(g, 0) {
+  let g = @scope.build(registry, source_map)
+  match module_def_references_for_test(g, 0) {
     Ok(refs) => inspect(refs.length(), content="0")
     Err(e) => fail(e)
   }
@@ -45,11 +67,11 @@ test "module_def_references: respects shadowing by inner Lam" {
 test "module_def_references: later duplicate shadows body only" {
   let text = "let x = 0\nlet x = x\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
   let source_map = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
-  let g = @scope.build(fp, registry, source_map)
-  match (module_def_references(g, 0), module_def_references(g, 1)) {
+  let g = @scope.build(registry, source_map)
+  match
+    (module_def_references_for_test(g, 0), module_def_references_for_test(g, 1)) {
     (Ok(first_refs), Ok(second_refs)) => {
       // The first def is referenced by the second def's init; the body resolves
       // to the second def. This is the identity-based case the old name scan
@@ -65,17 +87,18 @@ test "module_def_references: later duplicate shadows body only" {
 test "find_binding_for_init: maps init ProjNode to binding NodeId" {
   let text = "let x = 0\nlet y = 1\nx + y"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // First def's init is the LetDef node's child.
   let init_id = proj.children[0].children[0].id()
-  match find_binding_for_init(init_id, fp) {
+  let index = fp.definition_index()
+  match find_binding_for_init(init_id, index) {
     Some((binding_id, def_index)) => {
       inspect(binding_id == fp.defs[0].3, content="true")
       inspect(def_index, content="0")
     }
     None => fail("expected Some")
   }
-  match find_binding_for_init(proj.children[0].id(), fp) {
+  match find_binding_for_init(proj.children[0].id(), index) {
     Some((binding_id, def_index)) => {
       inspect(binding_id == fp.defs[0].3, content="true")
       inspect(def_index, content="0")
@@ -88,25 +111,29 @@ test "find_binding_for_init: maps init ProjNode to binding NodeId" {
 test "find_binding_for_init: returns None for non-init node" {
   let text = "let x = 0\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body node is not an init expression
   let body = proj.children.last().unwrap()
-  inspect(find_binding_for_init(body.id(), fp) is None, content="true")
+  inspect(
+    find_binding_for_init(body.id(), fp.definition_index()) is None,
+    content="true",
+  )
 }
 
 ///|
 test "find_binding_for_init: duplicate defs return matching binding order" {
   let text = "let x = 0\nlet x = x\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
-  match find_binding_for_init(fp.defs[0].1.id(), fp) {
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let index = fp.definition_index()
+  match find_binding_for_init(fp.defs[0].1.id(), index) {
     Some((binding_id, def_index)) => {
       inspect(binding_id == fp.defs[0].3, content="true")
       inspect(def_index, content="0")
     }
     None => fail("expected first duplicate binding")
   }
-  match find_binding_for_init(fp.defs[1].1.id(), fp) {
+  match find_binding_for_init(fp.defs[1].1.id(), index) {
     Some((binding_id, def_index)) => {
       inspect(binding_id == fp.defs[1].3, content="true")
       inspect(def_index, content="1")
@@ -119,14 +146,24 @@ test "find_binding_for_init: duplicate defs return matching binding order" {
 test "def_cutoff_at_node: duplicate defs use init-range cutoff" {
   let text = "let x = 0\nlet x = x\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let source_map = SourceMap::from_ast(proj)
   let body = proj.children.last().unwrap()
-  inspect(def_cutoff_at_node(fp, source_map, fp.defs[0].1.id()), content="0")
-  inspect(def_cutoff_at_node(fp, source_map, fp.defs[1].1.id()), content="1")
-  inspect(def_cutoff_at_node(fp, source_map, body.id()), content="2")
+  let index = fp.definition_index()
   inspect(
-    def_cutoff_at_node(fp, source_map, NodeId::from_int(999_999)),
+    def_cutoff_at_node_for_test(index, source_map, fp.defs[0].1.id()),
+    content="0",
+  )
+  inspect(
+    def_cutoff_at_node_for_test(index, source_map, fp.defs[1].1.id()),
+    content="1",
+  )
+  inspect(
+    def_cutoff_at_node_for_test(index, source_map, body.id()),
+    content="2",
+  )
+  inspect(
+    def_cutoff_at_node_for_test(index, source_map, NodeId::from_int(999_999)),
     content="2",
   )
 }

--- a/lang/lambda/edits/text_edit.mbt
+++ b/lang/lambda/edits/text_edit.mbt
@@ -8,7 +8,7 @@ pub(all) struct EditContext[T] {
   source_text : String
   source_map : SourceMap
   registry : Map[NodeId, ProjNode[T]]
-  module_projection : ModuleProjection
+  definition_index : DefinitionIndex
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_binding.mbt
+++ b/lang/lambda/edits/text_edit_binding.mbt
@@ -3,17 +3,14 @@ fn compute_delete_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
+  let { source_text, source_map, .. } = ctx
+  let module_view = edit_module_view(ctx)
+  let def_index = match find_def_index(module_view, binding_node_id) {
     Ok(i) => i
     Err(e) => return Err(e)
   }
   let (let_start, binding_end) = match
-    get_binding_text_range(
-      source_text,
-      source_map,
-      module_projection.defs[def_index],
-    ) {
+    get_binding_text_range(source_text, source_map, module_view.defs[def_index]) {
     Ok(r) => r
     Err(e) => return Err(e)
   }
@@ -32,12 +29,13 @@ fn compute_duplicate_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
+  let { source_text, source_map, .. } = ctx
+  let module_view = edit_module_view(ctx)
+  let def_index = match find_def_index(module_view, binding_node_id) {
     Ok(i) => i
     Err(e) => return Err(e)
   }
-  let def = module_projection.defs[def_index]
+  let def = module_view.defs[def_index]
   let binding_source = match
     binding_rewrite_source(source_text, source_map, def) {
     Ok(source) => source
@@ -45,7 +43,7 @@ fn compute_duplicate_binding(
   }
   // Create copy with _copy suffix on name, preserving source syntax such as
   // `fn` parameter annotations instead of reprinting the desugared Lam spine.
-  let new_name = def.0 + "_copy"
+  let new_name = def.name + "_copy"
   let new_binding = match
     binding_source.renamed_text(source_text, source_map, new_name) {
     Ok(text) => text
@@ -80,8 +78,9 @@ fn compute_move_binding_up(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
+  let { source_text, source_map, .. } = ctx
+  let module_view = edit_module_view(ctx)
+  let def_index = match find_def_index(module_view, binding_node_id) {
     Ok(i) => i
     Err(e) => return Err(e)
   }
@@ -89,20 +88,24 @@ fn compute_move_binding_up(
     return Err("Cannot move first binding up")
   }
   // Scoping guard: check if either name is free in the other's init
-  let cur_def = module_projection.defs[def_index]
-  let prev_def = module_projection.defs[def_index - 1]
+  let cur_def = module_view.defs[def_index]
+  let prev_def = module_view.defs[def_index - 1]
   let empty_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
-  let cur_fv = free_vars(cur_def.1.kind, empty_env)
-  let prev_fv = free_vars(prev_def.1.kind, empty_env)
+  let cur_fv = free_vars(cur_def.init.kind, empty_env)
+  let prev_fv = free_vars(prev_def.init.kind, empty_env)
   // Only check if cur depends on prev: after swap, cur comes first,
   // so prev (now below) wouldn't be in scope for cur's init.
   // The reverse (prev depends on cur) is safe: after swap, cur is above prev.
-  if cur_fv.contains(prev_def.0) {
+  if cur_fv.contains(prev_def.name) {
     return Err(
-      "Cannot move up: " + cur_def.0 + " uses " + prev_def.0 + " in its init",
+      "Cannot move up: " +
+      cur_def.name +
+      " uses " +
+      prev_def.name +
+      " in its init",
     )
   }
-  if cur_def.0 == prev_def.0 {
+  if cur_def.name == prev_def.name {
     return Err("Cannot swap bindings with the same name")
   }
   // Get text ranges for both bindings
@@ -143,29 +146,34 @@ fn compute_move_binding_down(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, module_projection, .. } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
+  let { source_text, source_map, .. } = ctx
+  let module_view = edit_module_view(ctx)
+  let def_index = match find_def_index(module_view, binding_node_id) {
     Ok(i) => i
     Err(e) => return Err(e)
   }
-  if def_index >= module_projection.defs.length() - 1 {
+  if def_index >= module_view.defs.length() - 1 {
     return Err("Cannot move last binding down")
   }
   // Scoping guard: check if either name is free in the other's init
-  let cur_def = module_projection.defs[def_index]
-  let next_def = module_projection.defs[def_index + 1]
+  let cur_def = module_view.defs[def_index]
+  let next_def = module_view.defs[def_index + 1]
   let empty_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
-  let cur_fv = free_vars(cur_def.1.kind, empty_env)
-  let next_fv = free_vars(next_def.1.kind, empty_env)
+  let cur_fv = free_vars(cur_def.init.kind, empty_env)
+  let next_fv = free_vars(next_def.init.kind, empty_env)
   // Only check if next depends on cur: after swap, next comes first,
   // so cur (now below) wouldn't be in scope for next's init.
   // The reverse (cur depends on next) is safe: after swap, next is above cur.
-  if next_fv.contains(cur_def.0) {
+  if next_fv.contains(cur_def.name) {
     return Err(
-      "Cannot move down: " + next_def.0 + " uses " + cur_def.0 + " in its init",
+      "Cannot move down: " +
+      next_def.name +
+      " uses " +
+      cur_def.name +
+      " in its init",
     )
   }
-  if cur_def.0 == next_def.0 {
+  if cur_def.name == next_def.name {
     return Err("Cannot swap bindings with the same name")
   }
   // Get text ranges for both bindings
@@ -205,7 +213,8 @@ fn compute_add_binding(
   ctx : EditContext[@ast.Term],
   module_node_id : NodeId,
 ) -> EditResult {
-  let { registry, module_projection, .. } = ctx
+  let { registry, .. } = ctx
+  let module_view = edit_module_view(ctx)
   // Validate target is a Module node before delegating
   guard registry.get(module_node_id) is Some(node) else {
     return Err("Module not found: " + module_node_id.to_string())
@@ -215,7 +224,7 @@ fn compute_add_binding(
       compute_insert_child(
         ctx,
         module_node_id,
-        module_projection.defs.length(),
+        module_view.defs.length(),
         @ast.Term::Int(0),
       )
     _ => Err("AddBinding target is not a Module node")

--- a/lang/lambda/edits/text_edit_binding_source.mbt
+++ b/lang/lambda/edits/text_edit_binding_source.mbt
@@ -20,12 +20,12 @@ priv enum BindingRewriteKind {
 ///
 /// Lambda projection intentionally stores function definitions as desugared
 /// Lam spines, so parameter type annotations and `fn` block shape do not live
-/// in `def.1.kind`. Binding-level edits that duplicate, rename, or inline a
+/// in `def.init.kind`. Binding-level edits that duplicate, rename, or inline a
 /// source binding must go through this bounded source metadata layer instead
 /// of reprinting the projected Term. If the source spans cannot be recovered,
 /// reject the edit rather than falling back to a lossy `@ast.print_term` rewrite.
 priv struct BindingRewriteSource {
-  def : (String, ProjNode[@ast.Term], Int, NodeId)
+  def : EditModuleBinding
   binding_start : Int
   binding_end : Int
   kind : BindingRewriteKind
@@ -35,17 +35,18 @@ priv struct BindingRewriteSource {
 fn binding_name_range(
   source_text : String,
   source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
+  def : EditModuleBinding,
   binding_start : Int,
   binding_end : Int,
 ) -> Result[(Int, Int), String] {
-  match source_map.get_token_span(def.3, @lambda_proj.LET_DEF_NAME_ROLE) {
+  match
+    source_map.get_token_span(def.binding_id, @lambda_proj.LET_DEF_NAME_ROLE) {
     Some(r) => Ok((r.start, r.end))
     None =>
       tight_name_range(
         source_text,
         @loomcore.Range::new(binding_start, binding_end),
-        def.0,
+        def.name,
       )
   }
 }
@@ -54,7 +55,7 @@ fn binding_name_range(
 fn binding_rewrite_source(
   source_text : String,
   source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
+  def : EditModuleBinding,
 ) -> Result[BindingRewriteSource, String] {
   let (binding_start, binding_end) = match
     get_binding_text_range(source_text, source_map, def) {
@@ -212,7 +213,7 @@ fn BindingRewriteSource::inline_text(
     FnBinding =>
       fn_binding_inline_text(source_text, self.binding_start, self.binding_end)
     ValueBinding =>
-      match source_map.get_range(self.def.1.id()) {
+      match source_map.get_range(self.def.init.id()) {
         Some(r) => Ok(trimmed_source_text(source_text, r))
         None => Err("Cannot inline binding: init source range not found")
       }
@@ -223,7 +224,7 @@ fn BindingRewriteSource::inline_text(
 fn binding_inline_text(
   source_text : String,
   source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
+  def : EditModuleBinding,
 ) -> Result[String, String] {
   match binding_rewrite_source(source_text, source_map, def) {
     Ok(source) => source.inline_text(source_text, source_map)

--- a/lang/lambda/edits/text_edit_middleware.mbt
+++ b/lang/lambda/edits/text_edit_middleware.mbt
@@ -23,7 +23,9 @@ impl EditMiddleware for ValidateNodeExists with fn apply(_self, next, op, ctx) {
       if ctx.registry.contains(id) ||
         (
           op_accepts_binding_id(op) &&
-          module_projection_contains_binding_id(ctx.module_projection, id)
+          edit_module_view(ctx).defs
+          .iter()
+          .any(fn(def) { def.binding_id == id })
         ) {
         next(op, ctx)
       } else {
@@ -44,14 +46,6 @@ fn op_accepts_binding_id(op : TreeEditOp) -> Bool {
     | InlineAllUsages(..) => true
     _ => false
   }
-}
-
-///|
-fn module_projection_contains_binding_id(
-  module_projection : ModuleProjection,
-  node_id : NodeId,
-) -> Bool {
-  module_projection.defs.iter().any(fn(def) { def.3 == node_id })
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_module_view.mbt
+++ b/lang/lambda/edits/text_edit_module_view.mbt
@@ -1,0 +1,118 @@
+///|
+/// Edit-local view of the root module shape, derived from the current
+/// `ProjNode` registry. It replaces `ModuleProjection` as edit context: the
+/// flat projection memo may still store a `ModuleProjection`, but edit handlers
+/// only need the structural `LetDef` children, their source ranges, and the
+/// current body node.
+priv struct EditModuleBinding {
+  name : String
+  init : ProjNode[@ast.Term]
+  start : Int
+  binding_id : NodeId
+}
+
+///|
+priv struct EditModuleView {
+  defs : Array[EditModuleBinding]
+  final_expr : ProjNode[@ast.Term]?
+}
+
+///|
+fn edit_root_node(
+  registry : Map[NodeId, ProjNode[@ast.Term]],
+) -> ProjNode[@ast.Term]? {
+  let parents : Map[NodeId, NodeId] = {}
+  for _id, node in registry {
+    for child in node.children {
+      parents[child.id()] = node.id()
+    }
+  }
+  registry.values().find_first(fn(node) { parents.get(node.id()) is None })
+}
+
+///|
+fn edit_binding_from_child(
+  name : String,
+  child : ProjNode[@ast.Term],
+) -> EditModuleBinding {
+  match child.kind {
+    @ast.Term::LetDef(_, _) if child.children.length() > 0 =>
+      {
+        name,
+        init: child.children[0],
+        start: child.start,
+        binding_id: child.id(),
+      }
+    _ => { name, init: child, start: child.start, binding_id: child.id() }
+  }
+}
+
+///|
+fn edit_binding_by_id(
+  ctx : EditContext[@ast.Term],
+  binding_node_id : NodeId,
+) -> Result[EditModuleBinding, String] {
+  match ctx.registry.get(binding_node_id) {
+    Some(node) =>
+      match node.kind {
+        @ast.Term::LetDef(name, _) => Ok(edit_binding_from_child(name, node))
+        _ => Err("Binding not found: " + binding_node_id.to_string())
+      }
+    None => {
+      let module_view = edit_module_view(ctx)
+      match
+        module_view.defs
+        .iter()
+        .find_first(fn(def) { def.binding_id == binding_node_id }) {
+        Some(def) => Ok(def)
+        None => Err("Binding not found: " + binding_node_id.to_string())
+      }
+    }
+  }
+}
+
+///|
+fn edit_binding_for_decl(
+  ctx : EditContext[@ast.Term],
+  decl : @scope.Decl,
+) -> Result[EditModuleBinding, String] {
+  match decl.kind {
+    @scope.DeclKind::ModuleDef(_) => edit_binding_by_id(ctx, decl.node_id)
+    @scope.DeclKind::LamParam(_) => Err("Expected module binding")
+  }
+}
+
+///|
+fn EditModuleView::from_root(root : ProjNode[@ast.Term]) -> EditModuleView {
+  match root.kind {
+    @ast.Term::Module(defs, _) => {
+      let bindings : Array[EditModuleBinding] = []
+      let child_count = root.children.length()
+      for i, def in defs {
+        if i + 1 < child_count {
+          bindings.push(edit_binding_from_child(def.0, root.children[i]))
+        }
+      }
+      let final_expr = if defs.length() < child_count {
+        let body = root.children[defs.length()]
+        match body.kind {
+          @ast.Term::Unit => None
+          _ => Some(body)
+        }
+      } else {
+        None
+      }
+      { defs: bindings, final_expr }
+    }
+    @ast.Term::Unit => { defs: [], final_expr: None }
+    _ => { defs: [], final_expr: Some(root) }
+  }
+}
+
+///|
+fn edit_module_view(ctx : EditContext[@ast.Term]) -> EditModuleView {
+  match edit_root_node(ctx.registry) {
+    Some(root) => EditModuleView::from_root(root)
+    None => { defs: [], final_expr: None }
+  }
+}

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -4,7 +4,8 @@ fn compute_extract_to_let(
   node_id : NodeId,
   var_name : String,
 ) -> EditResult {
-  let { source_text, source_map, registry, module_projection } = ctx
+  let { source_text, source_map, registry, definition_index } = ctx
+  let module_view = edit_module_view(ctx)
   guard registry.get(node_id) is Some(node) else {
     return Err("Node not found")
   }
@@ -15,12 +16,12 @@ fn compute_extract_to_let(
     Err(e) => return Err(e)
     Ok(_) => ()
   }
-  let g = @scope.build(module_projection, registry, source_map)
+  let g = @scope.build(registry, source_map)
   let fv = free_vars(node.kind, @immut/hashset.new())
-  let would_capture = if module_projection.defs.is_empty() {
+  let would_capture = if module_view.defs.is_empty() {
     free_names_captured_at_use_sites(g, node, fv)
   } else {
-    free_names_would_rebind_at_module_end(g, module_projection, node, fv)
+    free_names_would_rebind_at_module_end(g, definition_index, node, fv)
   }
   if would_capture {
     return Err("Cannot extract: expression captures lambda-bound variables")
@@ -28,8 +29,7 @@ fn compute_extract_to_let(
   // Build edits
   let expr_text = @ast.print_term(node.kind)
   let let_text = "let " + var_name + " = " + expr_text + "\n"
-  if module_projection.defs.is_empty() &&
-    module_projection.final_expr is Some(_) {
+  if module_view.defs.is_empty() && module_view.final_expr is Some(_) {
     // No module — wrap: replace expression with "let name = expr\nname"
     let new_text = let_text + var_name
     Ok(
@@ -48,7 +48,7 @@ fn compute_extract_to_let(
     )
   } else {
     // Has Module — insert let before body, replace expr with var_name
-    let body_start = match module_projection.final_expr {
+    let body_start = match module_view.final_expr {
       Some(body) =>
         match source_map.get_range(body.id()) {
           Some(r) => r.start
@@ -62,7 +62,7 @@ fn compute_extract_to_let(
       // Node is in the body — produce a single edit:
       // Replace body text from body_start to end with:
       //   "let var = expr\n" + (prefix before node) + var_name + (suffix after node)
-      let body_end = match module_projection.final_expr {
+      let body_end = match module_view.final_expr {
         Some(body) =>
           match source_map.get_range(body.id()) {
             Some(r) => r.end
@@ -115,7 +115,7 @@ fn compute_inline_definition(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, registry, module_projection } = ctx
+  let { source_text, source_map, registry, .. } = ctx
   guard registry.get(node_id) is Some(node) else {
     return Err("Node not found: " + node_id.to_string())
   }
@@ -126,38 +126,31 @@ fn compute_inline_definition(
     return Err("Var not in source map")
   }
   // Resolve the binding
-  let g = @scope.build(module_projection, registry, source_map)
+  let g = @scope.build(registry, source_map)
   guard @scope.declaration(g, node_id) is Some(decl) else {
     return Err("No binding found for variable: " + var_name)
   }
   match decl.kind {
     DeclKind::LamParam(..) =>
       return Err("Cannot inline lambda-bound variable: " + var_name)
-    DeclKind::ModuleDef(def_index~) => {
-      let def = module_projection.defs[def_index]
+    DeclKind::ModuleDef(_) => {
+      let def = match edit_binding_for_decl(ctx, decl) {
+        Ok(def) => def
+        Err(e) => return Err(e)
+      }
       let init_text = match binding_inline_text(source_text, source_map, def) {
         Ok(text) => text
         Err(e) => return Err(e)
       }
       // Check for capture: would any free var in init be captured by an enclosing scope at the usage site?
-      let init_fv = free_vars(def.1.kind, @immut/hashset.new())
-      if free_names_would_rebind_at_node(
-          g,
-          module_projection,
-          source_map,
-          def.1,
-          node_id,
-          init_fv,
-        ) {
+      let init_fv = free_vars(def.init.kind, @immut/hashset.new())
+      if free_names_would_rebind_at_node(g, def.init, node_id, init_fv) {
         return Err(
           "Cannot inline: would capture variables bound by enclosing lambda",
         )
       }
       // Check if this is the sole resolved reference.
-      let refs = match module_def_references(g, def_index) {
-        Ok(ids) => ids
-        Err(e) => return Err(e)
-      }
+      let refs = @scope.references(g, decl.id)
       if refs.length() <= 1 {
         // Sole usage — inline and delete the binding
         let (let_start, binding_end) = match
@@ -232,30 +225,23 @@ fn compute_inline_all_usages(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, registry, module_projection } = ctx
-  let def_index = match find_def_index(module_projection, binding_node_id) {
-    Ok(i) => i
-    Err(e) => return Err(e)
-  }
-  let def = module_projection.defs[def_index]
-  let var_name = def.0
+  let { source_text, source_map, registry, .. } = ctx
   // Find all references resolved to this binding.
-  let g = @scope.build(module_projection, registry, source_map)
-  let ref_ids = match module_def_references(g, def_index) {
-    Ok(ids) => ids
+  let g = @scope.build(registry, source_map)
+  let decl = match module_def_decl_for_binding(g, binding_node_id) {
+    Ok(decl) => decl
     Err(e) => return Err(e)
   }
+  let def = match edit_binding_for_decl(ctx, decl) {
+    Ok(def) => def
+    Err(e) => return Err(e)
+  }
+  let var_name = def.name
+  let ref_ids = @scope.references(g, decl.id)
   // Check for capture: would any free var in init be captured by an enclosing scope at any reference site?
-  let init_fv = free_vars(def.1.kind, @immut/hashset.new())
+  let init_fv = free_vars(def.init.kind, @immut/hashset.new())
   for rid in ref_ids {
-    if free_names_would_rebind_at_node(
-        g,
-        module_projection,
-        source_map,
-        def.1,
-        rid,
-        init_fv,
-      ) {
+    if free_names_would_rebind_at_node(g, def.init, rid, init_fv) {
       return Err(
         "Cannot inline: would capture variables bound by enclosing lambda",
       )

--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -10,11 +10,7 @@ fn compute_rename(
         @ast.Term::Var(old_name) =>
           rename_from_var(ctx, node_id, old_name, new_name)
         @ast.Term::Lam(old_name, _) => {
-          let g = @scope.build(
-            ctx.module_projection,
-            ctx.registry,
-            ctx.source_map,
-          )
+          let g = @scope.build(ctx.registry, ctx.source_map)
           rename_lam_param(ctx, g, node_id, n, old_name, new_name)
         }
         _ => rename_binding_by_id(ctx, node_id, new_name)
@@ -251,7 +247,7 @@ fn rename_from_var(
   old_name : String,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let g = @scope.build(ctx.module_projection, ctx.registry, ctx.source_map)
+  let g = @scope.build(ctx.registry, ctx.source_map)
   guard @scope.declaration(g, var_node_id) is Some(decl) else {
     return Err("No binding found for variable: " + old_name)
   }
@@ -279,7 +275,7 @@ fn rename_binding_by_id(
   binding_node_id : NodeId,
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
-  let g = @scope.build(ctx.module_projection, ctx.registry, ctx.source_map)
+  let g = @scope.build(ctx.registry, ctx.source_map)
   guard g.decls
     .iter()
     .find_first(fn(d) {

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -83,13 +83,13 @@ fn ensure_replaceable_node_range(
 }
 
 ///|
-/// Find a module binding's index in module_projection.defs by its NodeId.
+/// Find a module binding's index in an edit module view by its NodeId.
 fn find_def_index(
-  module_projection : ModuleProjection,
+  module_view : EditModuleView,
   binding_node_id : NodeId,
 ) -> Result[Int, String] {
-  for i, def in module_projection.defs {
-    if def.3 == binding_node_id {
+  for i, def in module_view.defs {
+    if def.binding_id == binding_node_id {
       return Ok(i)
     }
   }
@@ -138,18 +138,20 @@ fn find_parent(
 fn get_binding_text_range(
   source_text : String,
   source_map : SourceMap,
-  def : (String, ProjNode[@ast.Term], Int, NodeId),
+  def : EditModuleBinding,
 ) -> Result[(Int, Int), String] {
-  let init_node = def.1
+  let init_node = def.init
   guard source_map.get_range(init_node.id()) is Some(init_range) else {
     return Err("Init node not in source map")
   }
-  let binding_end = match source_map.get_range(def.3) {
+  let binding_end = match source_map.get_range(def.binding_id) {
     Some(binding_range) => binding_range.end
     None => init_range.end
   }
-  if def.2 < 0 || def.2 > source_text.length() || def.2 > binding_end {
+  if def.start < 0 ||
+    def.start > source_text.length() ||
+    def.start > binding_end {
     return Err("Binding start out of source range")
   }
-  Ok((def.2, binding_end))
+  Ok((def.start, binding_end))
 }

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1,7 +1,7 @@
 // Whitebox tests for compute_text_edit
 
 ///|
-/// Parse text and build ProjNode, SourceMap with token spans, registry, and ModuleProjection.
+/// Parse text and build ProjNode, SourceMap with token spans, registry, and definition index.
 /// Uses the full syntax tree → ProjNode pipeline so token spans are populated.
 fn parse_with_token_spans(
   text : String,
@@ -9,7 +9,7 @@ fn parse_with_token_spans(
   ProjNode[@ast.Term],
   SourceMap,
   Map[NodeId, ProjNode[@ast.Term]],
-  ModuleProjection,
+  @lambda_proj.ModuleProjection,
 ) raise {
   let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
   let syntax = @seam.SyntaxNode::from_cst(cst)
@@ -18,7 +18,7 @@ fn parse_with_token_spans(
   let sm = SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax, proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   (proj, sm, registry, fp)
 }
 
@@ -57,9 +57,14 @@ fn make_edit_ctx(
   text : String,
   source_map : SourceMap,
   registry : Map[NodeId, ProjNode[@ast.Term]],
-  fp : ModuleProjection,
+  fp : @lambda_proj.ModuleProjection,
 ) -> EditContext[@ast.Term] {
-  { source_text: text, source_map, registry, module_projection: fp }
+  {
+    source_text: text,
+    source_map,
+    registry,
+    definition_index: fp.definition_index(),
+  }
 }
 
 ///|
@@ -68,7 +73,7 @@ test "compute_text_edit: CommitEdit replaces single expression" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     CommitEdit(node_id=root_id, new_value="99"),
@@ -91,7 +96,7 @@ test "compute_text_edit: CommitEdit replaces left operand in binary expr" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // children[0] is the left operand (Var("x")), span [0, 1)
   let lhs = proj.children[0]
   let result = compute_text_edit(
@@ -115,7 +120,7 @@ test "compute_text_edit: CommitEdit inside fn body preserves braces" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[0].children[0].children[0]
   let result = compute_text_edit(
     CommitEdit(node_id=body.id(), new_value="y"),
@@ -134,7 +139,7 @@ test "compute_text_edit: no-op ops return empty array" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     Select(node_id=NodeId::from_int(0)),
     make_edit_ctx(text, source_map, registry, fp),
@@ -148,7 +153,7 @@ test "compute_text_edit: Delete replaces node with placeholder" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     Delete(node_id=root_id),
@@ -170,7 +175,7 @@ test "compute_text_edit: Delete replaces Var with placeholder" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // children[0] is the left operand Var("x"), span [0, 1)
   let lhs = proj.children[0]
   let result = compute_text_edit(
@@ -193,7 +198,7 @@ test "compute_text_edit: Delete inside fn body preserves braces" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[0].children[0].children[0]
   let result = compute_text_edit(
     Delete(node_id=body.id()),
@@ -212,7 +217,7 @@ test "compute_text_edit: WrapInLambda wraps node in lambda abstraction" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInLambda(node_id=root_id, var_name="x"),
@@ -233,7 +238,7 @@ test "compute_text_edit: WrapInLambda parenthesizes subexpression" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let func = proj.children[0]
   let result = compute_text_edit(
     WrapInLambda(node_id=func.id(), var_name="x"),
@@ -252,7 +257,7 @@ test "compute_text_edit: WrapInApp wraps node in application" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInApp(node_id=root_id),
@@ -273,7 +278,7 @@ test "compute_text_edit: InsertChild into Module inserts def text" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   // Insert a new Int def at index 1 (before the body)
   let result = compute_text_edit(
@@ -297,7 +302,7 @@ test "compute_text_edit: InsertChild into non-Module re-renders parent" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   // Insert a Var child into a Bop node — re-renders with print_term
   let result = compute_text_edit(
@@ -327,7 +332,7 @@ test "compute_text_edit: Drop produces two edits" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // source = children[0] (Var "x"), target = children[1] (Int 1)
   let source_node = proj.children[0]
   let target_node = proj.children[1]
@@ -409,7 +414,7 @@ test "compute_text_edit: Drop with unknown source returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     Drop(source=NodeId::from_int(9999), target=proj.id(), position=Before),
     make_edit_ctx(text, source_map, registry, fp),
@@ -423,7 +428,7 @@ test "compute_text_edit: Drop synthetic multi-param lambda source is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let inner_lam = proj.children[0]
   let body = inner_lam.children[0]
   let result = compute_text_edit(
@@ -439,7 +444,7 @@ test "compute_text_edit: Drop synthetic multi-param lambda target is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let inner_lam = proj.children[0]
   let body_bop = inner_lam.children[0]
   let source = body_bop.children[1]
@@ -456,7 +461,7 @@ test "compute_text_edit: WrapInLambda with unknown node returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     WrapInLambda(node_id=NodeId::from_int(9999), var_name="x"),
     make_edit_ctx(text, source_map, registry, fp),
@@ -470,7 +475,7 @@ test "compute_text_edit: CommitEdit with unknown node returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     CommitEdit(node_id=NodeId::from_int(9999), new_value="x"),
     make_edit_ctx(text, source_map, registry, fp),
@@ -484,7 +489,7 @@ test "compute_text_edit: Unwrap Lam keeps body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let lam_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=lam_id, keep_child_index=0),
@@ -507,7 +512,7 @@ test "compute_text_edit: Unwrap synthetic fn lambda is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let lam = proj.children[0].children[0]
   let result = compute_text_edit(
     Unwrap(node_id=lam.id(), keep_child_index=0),
@@ -522,7 +527,7 @@ test "compute_text_edit: Unwrap synthetic multi-param lambda is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let inner_lam = proj.children[0]
   let result = compute_text_edit(
     Unwrap(node_id=inner_lam.id(), keep_child_index=0),
@@ -537,7 +542,7 @@ test "compute_text_edit: Unwrap Bop keeps left" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let bop_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=bop_id, keep_child_index=0),
@@ -555,7 +560,7 @@ test "compute_text_edit: Unwrap Bop keeps right" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let bop_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=bop_id, keep_child_index=1),
@@ -573,7 +578,7 @@ test "compute_text_edit: WrapInIf wraps node in if-then-else" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInIf(node_id=root_id),
@@ -595,7 +600,7 @@ test "compute_text_edit: WrapInBop wraps node in binary operation" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInBop(node_id=root_id, op=@ast.Bop::Plus),
@@ -618,7 +623,7 @@ test "compute_text_edit: ChangeOperator changes Bop operator" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     ChangeOperator(node_id=root_id, new_op=@ast.Bop::Minus),
@@ -639,7 +644,7 @@ test "compute_text_edit: SwapChildren swaps Bop operands" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     SwapChildren(node_id=root_id),
@@ -660,7 +665,7 @@ test "compute_text_edit: DeleteBinding removes first let line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Delete first binding
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
@@ -682,7 +687,7 @@ test "compute_text_edit: DeleteBinding removes second let line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Delete second binding
   let binding_id = fp.defs[1].3
   let result = compute_text_edit(
@@ -704,7 +709,7 @@ test "compute_text_edit: DeleteBinding removes second fn line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=fp.defs[1].3),
     make_edit_ctx(text, source_map, registry, fp),
@@ -724,7 +729,7 @@ test "compute_text_edit: DeleteBinding removes only binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=binding_id),
@@ -745,7 +750,7 @@ test "compute_text_edit: DeleteBinding with unknown id returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=NodeId::from_int(9999)),
     make_edit_ctx(text, source_map, registry, fp),
@@ -759,7 +764,7 @@ test "compute_text_edit: DuplicateBinding copies binding with _copy suffix" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=binding_id),
@@ -780,7 +785,7 @@ test "compute_text_edit: DuplicateBinding on last binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=binding_id),
@@ -801,7 +806,7 @@ test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=fp.defs[0].3),
     make_edit_ctx(text, source_map, registry, fp),
@@ -824,7 +829,7 @@ test "compute_text_edit: MoveBindingDown swaps two bindings" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
@@ -846,7 +851,7 @@ test "compute_text_edit: MoveBindingDown rejects when scoping violated" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
@@ -861,7 +866,7 @@ test "compute_text_edit: MoveBindingDown rejects last binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[1].3
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
@@ -876,7 +881,7 @@ test "compute_text_edit: MoveBindingUp swaps two bindings" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[1].3
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
@@ -897,7 +902,7 @@ test "compute_text_edit: MoveBindingUp swaps fn bindings" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=fp.defs[1].3),
     make_edit_ctx(text, source_map, registry, fp),
@@ -920,7 +925,7 @@ test "compute_text_edit: AddBinding adds new let line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let module_id = proj.id()
   let result = compute_text_edit(
     AddBinding(module_node_id=module_id),
@@ -941,7 +946,7 @@ test "compute_text_edit: ExtractToLet from body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is Bop(+, Var(x), Int(1)). Extract the whole body expression.
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
@@ -963,7 +968,7 @@ test "compute_text_edit: ExtractToLet sub-expression from body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Extract Var("x") from the body (left operand of +)
   let body = proj.children[proj.children.length() - 1]
   let var_x = body.children[0]
@@ -987,7 +992,7 @@ test "compute_text_edit: ExtractToLet rejects lambda-captured var" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // The body of lambda is Bop(+, Var(x), Int(1)) — child[0] of Lam
   let body = proj.children[0]
   let result = compute_text_edit(
@@ -1033,7 +1038,7 @@ test "compute_text_edit: ExtractToLet bare expression" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     ExtractToLet(node_id=proj.id(), var_name="x"),
     make_edit_ctx(text, source_map, registry, fp),
@@ -1053,7 +1058,7 @@ test "compute_text_edit: InlineDefinition sole usage removes binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is the last child of Module — Var("x")
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
@@ -1070,12 +1075,34 @@ test "compute_text_edit: InlineDefinition sole usage removes binding" {
 }
 
 ///|
+test "compute_text_edit: InlineDefinition nested block uses resolved declaration" {
+  let text = "let x = 0\nlet z = { let x = 1\n  x }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  let inner_body = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=inner_body.id()),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="let x = 0\nlet z = {1 }\nz")
+    }
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
 test "compute_text_edit: InlineDefinition multiple usages keeps binding" {
   let text = "let x = 42\nx + x"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is Bop(+, Var(x), Var(x)). Get the left Var.
   let body = proj.children[proj.children.length() - 1]
   let lhs = body.children[0]
@@ -1100,7 +1127,7 @@ test "compute_text_edit: InlineAllUsages replaces all refs and removes binding" 
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
@@ -1118,12 +1145,34 @@ test "compute_text_edit: InlineAllUsages replaces all refs and removes binding" 
 }
 
 ///|
+test "compute_text_edit: InlineAllUsages nested block uses binding declaration" {
+  let text = "let x = 0\nlet z = { let x = 1\n  x }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    InlineAllUsages(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="let x = 0\nlet z = {1 }\nz")
+    }
+    _ => fail("expected Some edits")
+  }
+}
+
+///|
 test "compute_text_edit: InlineDefinition on non-Var returns error" {
   let text = "42"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     InlineDefinition(node_id=proj.id()),
     make_edit_ctx(text, source_map, registry, fp),
@@ -1137,7 +1186,7 @@ test "compute_text_edit: InlineAllUsages with unknown binding returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=NodeId::from_int(9999)),
     make_edit_ctx(text, source_map, registry, fp),
@@ -1151,7 +1200,7 @@ test "compute_text_edit: InlineAllUsages preserves typed fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=fp.defs[0].3),
     make_edit_ctx(text, source_map, registry, fp),
@@ -1171,7 +1220,7 @@ test "compute_text_edit: InlineDefinition preserves typed fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
@@ -1192,7 +1241,7 @@ test "compute_text_edit: InlineDefinition preserves indented typed fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
@@ -1213,7 +1262,7 @@ test "compute_text_edit: InlineDefinition zero-param fn uses block body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
@@ -1253,7 +1302,7 @@ test "compute_text_edit: InlineDefinition on lambda-bound var returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is Var("x") — child[0] of Lam
   let var_x = proj.children[0]
   let result = compute_text_edit(
@@ -1269,7 +1318,7 @@ test "compute_text_edit: InlineAllUsages no usages just removes binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let binding_id = fp.defs[0].3
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
@@ -1290,7 +1339,7 @@ test "compute_text_edit: InlineAllUsages removes unused second fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=fp.defs[1].3),
     make_edit_ctx(text, source_map, registry, fp),
@@ -1725,6 +1774,23 @@ test "compute_text_edit: InlineDefinition rejects later module-def shadow captur
 }
 
 ///|
+test "compute_text_edit: InlineDefinition rejects nested block shadow capture" {
+  let text = "let y = 0\nlet z = { let x = y\nlet y = 1\nx }\nz"
+  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let _ = proj
+  let block = fp.defs[1].1
+  let block_body = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=block_body.id()),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot inline: would capture variables bound by enclosing lambda\")",
+  )
+}
+
+///|
 test "compute_text_edit: InlineAllUsages rejects capture" {
   let text = "let y = 1\nlet x = y\n(y) => x"
   let (proj, sm, registry, fp) = parse_with_token_spans(text)
@@ -1737,6 +1803,23 @@ test "compute_text_edit: InlineAllUsages rejects capture" {
     make_edit_ctx(text, sm, registry, fp),
   )
   inspect(result is Err(_), content="true")
+}
+
+///|
+test "compute_text_edit: InlineAllUsages rejects nested block shadow capture" {
+  let text = "let y = 0\nlet z = { let x = y\nlet y = 1\nx }\nz"
+  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let _ = proj
+  let block = fp.defs[1].1
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    InlineAllUsages(binding_node_id=binding_id),
+    make_edit_ctx(text, sm, registry, fp),
+  )
+  @debug.debug_inspect(
+    result,
+    content="Err(\"Cannot inline: would capture variables bound by enclosing lambda\")",
+  )
 }
 
 ///|
@@ -1828,7 +1911,7 @@ test "compute_text_edit: Unwrap cursor at replacement start" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let bop_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=bop_id, keep_child_index=1),
@@ -1877,7 +1960,7 @@ test "compute_text_edit: Drop self-drop returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let id = proj.id()
   let result = compute_text_edit(
     Drop(source=id, target=id, position=After),
@@ -1894,7 +1977,7 @@ test "compute_text_edit: Drop descendant-drop returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let child = proj.children[0] // Var(x), inside the Bop
   let result = compute_text_edit(
     Drop(source=proj.id(), target=child.id(), position=After),
@@ -1912,7 +1995,7 @@ test "compute_text_edit: Drop with Before position inserts at target start" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // source = Int(1) at children[1], target = Var(x) at children[0]
   let source_node = proj.children[1]
   let target_node = proj.children[0]
@@ -1941,7 +2024,7 @@ test "compute_text_edit: Drop with unknown target returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = ModuleProjection::from_proj_node(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     Drop(source=proj.id(), target=NodeId::from_int(9999), position=After),
     make_edit_ctx(text, source_map, registry, fp),

--- a/lang/lambda/proj/definition_index.mbt
+++ b/lang/lambda/proj/definition_index.mbt
@@ -14,6 +14,18 @@ fn DefinitionIndexEntry::from_def(
 }
 
 ///|
+fn DefinitionIndexEntry::from_binding(
+  name : String,
+  child : ProjNode[@ast.Term],
+) -> DefinitionIndexEntry {
+  match child.kind {
+    @ast.Term::LetDef(_, _) if child.children.length() > 0 =>
+      { name, init: child.children[0], binding_id: child.id() }
+    _ => { name, init: child, binding_id: child.id() }
+  }
+}
+
+///|
 /// Index of module-level Lambda definitions.
 ///
 /// `ModuleProjection` still owns the projection storage for this slice; this
@@ -28,6 +40,28 @@ fn DefinitionIndex::from_defs(
   defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)],
 ) -> DefinitionIndex {
   { entries: defs.map(fn(def) { DefinitionIndexEntry::from_def(def) }) }
+}
+
+///|
+/// Derive a definition-index view directly from the current projection tree.
+pub fn DefinitionIndex::from_proj_node(
+  root : ProjNode[@ast.Term],
+) -> DefinitionIndex {
+  match root.kind {
+    @ast.Term::Module(defs, _) => {
+      let entries : Array[DefinitionIndexEntry] = []
+      let child_count = root.children.length()
+      for i, def in defs {
+        if i + 1 < child_count {
+          entries.push(
+            DefinitionIndexEntry::from_binding(def.0, root.children[i]),
+          )
+        }
+      }
+      { entries, }
+    }
+    _ => { entries: [] }
+  }
 }
 
 ///|

--- a/lang/lambda/proj/module_projection_wbtest.mbt
+++ b/lang/lambda/proj/module_projection_wbtest.mbt
@@ -75,6 +75,29 @@ test "DefinitionIndex: duplicate lookup and cutoff use source order" {
 }
 
 ///|
+test "DefinitionIndex::from_proj_node: duplicate lookup and cutoff use LetDef children" {
+  let (proj, _) = parse_to_proj_node("let x = 1\nlet x = x\nlet y = x\nx")
+  let index = DefinitionIndex::from_proj_node(proj)
+  inspect(index.length(), content="3")
+  let second_init = proj.children[1].children[0]
+  match index.binding_for_node(second_init.id()) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == proj.children[1].id(), content="true")
+      inspect(def_index, content="1")
+    }
+    None => fail("expected duplicate binding lookup")
+  }
+  let source_map = SourceMap::from_ast(proj)
+  let body = proj.children.last().unwrap()
+  inspect(
+    index.cutoff_at_node(source_map, proj.children[0].children[0].id()),
+    content="0",
+  )
+  inspect(index.cutoff_at_node(source_map, second_init.id()), content="1")
+  inspect(index.cutoff_at_node(source_map, body.id()), content="3")
+}
+
+///|
 test "to_module_projection: no final expression defaults to None" {
   let syntax = parse_syntax("let x = 1\n")
   let fp = to_module_projection(syntax, Ref(0))

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -45,6 +45,7 @@ pub struct DefinitionIndex {
 }
 pub fn DefinitionIndex::binding_for_node(Self, @dowdiness/canopy/core.NodeId) -> (@dowdiness/canopy/core.NodeId, Int)?
 pub fn DefinitionIndex::cutoff_at_node(Self, @dowdiness/canopy/core.SourceMap, @dowdiness/canopy/core.NodeId) -> Int
+pub fn DefinitionIndex::from_proj_node(@dowdiness/canopy/core.ProjNode[@ast.Term]) -> Self
 pub fn DefinitionIndex::length(Self) -> Int
 
 pub struct ModuleProjection {

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -76,7 +76,7 @@ fn root_node(
 /// Pass 2: scopes, decls, and per-node scope+cutoff membership.
 ///
 /// - The root module scope holds the flat top-level `ModuleDef` decls (one per
-///   `module_projection.defs`, binder id preserved from the projection).
+///   root `Module` definition, using the first-class `LetDef` child id).
 /// - Each `Lam` node opens a child `LamParam` scope.
 /// - Each NESTED `Module` node (a block expression) opens a child scope holding
 ///   its own block-local `ModuleDef` decls — this is what makes the graph an
@@ -86,31 +86,32 @@ fn root_node(
 /// `[0, i)` and the body (`i == def_count`) sees all defs; that per-child
 /// cutoff is recorded against the scope in `node_cutoffs`, accumulating the
 /// cutoffs of all enclosing module scopes so each gates visibility independently.
-fn Builder::pass2(
-  self : Builder,
-  module_projection : @lambda_proj.ModuleProjection,
-  root : @core.ProjNode[@ast.Term],
-) -> Unit {
+fn Builder::pass2(self : Builder, root : @core.ProjNode[@ast.Term]) -> Unit {
   let root_scope = self.add_scope(None)
-  for i, def in module_projection.defs {
-    let (name, _init, _start, binder_id) = def
-    let _ = self.add_decl(root_scope, binder_id, name, ModuleDef(def_index=i))
-  }
   match root.kind {
     // Root is the top-level module. Its scope (parent None) and decls are
-    // installed above from `module_projection.defs` — that pre-installation is
-    // the *only* thing distinguishing root from a nested block. The binder ids
-    // are in fact identical to `root.children[i].id()` (see
-    // `ModuleProjection::from_proj_node`); root is kept out of the generic
+    // installed above from the root `Module` children — that pre-installation
+    // is the *only* thing distinguishing root from a nested block. The binder
+    // ids are the first-class `LetDef` child ids; root is kept out of the generic
     // `Module` arm only because that arm would open a *second* scope and
     // re-install the decls. The per-child cutoff descent is shared via
     // `descend_module_children`.
-    @ast.Term::Module(_, _) => {
+    @ast.Term::Module(defs, _) => {
+      for i, def in defs {
+        let _ = self.add_decl(
+          root_scope,
+          root.children[i].id(),
+          def.0,
+          ModuleDef(def_index=i),
+        )
+      }
+      let root_cutoffs : Map[ScopeId, Int] = {}
+      root_cutoffs[root_scope] = defs.length()
       self.node_scope[root.id()] = root_scope
-      self.node_cutoffs[root.id()] = {}
+      self.node_cutoffs[root.id()] = root_cutoffs
       self.descend_module_children(root, root_scope, {})
     }
-    // Bare lambda / expression program: `module_projection.defs` is empty, so
+    // Bare lambda / expression program: there is no root `Module`, so
     // `root_scope` holds no `ModuleDef`. Dispatch through `walk` so the root's
     // own binder (a `Lam` param) is installed.
     _ => {
@@ -128,7 +129,7 @@ fn Builder::pass2(
 /// child sees all defs. `def_count` is derived structurally as
 /// `children.length() - 1` — the body is always the last child (see
 /// `module_node_from_defs`) — so the cutoff stays consistent with the children
-/// actually iterated, independent of `module_projection`'s def count.
+/// actually iterated, independent of any flat projection's def count.
 fn Builder::descend_module_children(
   self : Builder,
   node : @core.ProjNode[@ast.Term],
@@ -179,6 +180,10 @@ fn Builder::walk(
           ModuleDef(def_index=i),
         )
       }
+      let module_cutoffs = cutoffs.copy()
+      module_cutoffs[mod_scope] = defs.length()
+      self.node_scope[node.id()] = mod_scope
+      self.node_cutoffs[node.id()] = module_cutoffs
       self.descend_module_children(node, mod_scope, cutoffs)
     }
     _ =>
@@ -280,14 +285,20 @@ fn Builder::pass3(
 /// come from tree position recorded in pass 2 — so it is not threaded into the
 /// passes.
 pub fn build(
-  module_projection : @lambda_proj.ModuleProjection,
   registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   source_map : @core.SourceMap,
 ) -> ScopeGraph {
   let _ = source_map
   let b = Builder::new()
   let root = root_node(registry)
-  b.pass2(module_projection, root)
+  b.pass2(root)
   b.pass3(registry)
-  { scopes: b.scopes, decls: b.decls, refs: b.refs, module_node_id: root.id() }
+  {
+    scopes: b.scopes,
+    decls: b.decls,
+    refs: b.refs,
+    module_node_id: root.id(),
+    node_scope: b.node_scope,
+    node_cutoffs: b.node_cutoffs,
+  }
 }

--- a/lang/lambda/scope/failures_wbtest.mbt
+++ b/lang/lambda/scope/failures_wbtest.mbt
@@ -3,10 +3,8 @@
 
 ///|
 test "failures: free variable is surfaced with a populated witness" {
-  let (_proj, module_projection, registry, source_map) = build_fixture(
-    "(x) => y",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (_proj, registry, source_map) = build_fixture("(x) => y")
+  let g = build(registry, source_map)
   let fs = failures(g, source_map)
   inspect(fs.length(), content="1")
   inspect(fs[0].name, content="y")
@@ -18,19 +16,17 @@ test "failures: free variable is surfaced with a populated witness" {
 
 ///|
 test "failures: a fully-resolved program has no failures" {
-  let (_proj, module_projection, registry, source_map) = build_fixture(
+  let (_proj, registry, source_map) = build_fixture(
     "let x = 1\nlet y = x\nx + y",
   )
-  let g = build(module_projection, registry, source_map)
+  let g = build(registry, source_map)
   inspect(failures(g, source_map).length(), content="0")
 }
 
 ///|
 test "failures: self-reference in a def init is a reachable failure" {
-  let (_proj, module_projection, registry, source_map) = build_fixture(
-    "let x = x\nx",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (_proj, registry, source_map) = build_fixture("let x = x\nx")
+  let g = build(registry, source_map)
   let fs = failures(g, source_map)
   // The init `x` cannot see its own not-yet-bound def (sequential cutoff); the
   // body `x` resolves. Exactly one failure, and it is the init reference.

--- a/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -13,12 +13,11 @@ fn build_fixture_with_spans(
   let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
-  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let source_map = @core.SourceMap::from_ast(proj)
   @lambda_proj.populate_token_spans(source_map, syntax, proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(proj, registry)
-  let g = build(module_projection, registry, source_map)
+  let g = build(registry, source_map)
   (g, source_map)
 }
 
@@ -36,7 +35,7 @@ test "go_to_definition: shadowed module def — later def wins (production id pa
   // "let x = 1\nlet x = 2\nx" — name:0 "x" at 4..5, name:1 "x" at 14..15.
   // The body var (pos 20) resolves to def_index=1, so the binder span must be
   // 14..15, NOT 4..5. This exercises the module-def binder through the
-  // production ModuleProjection/LetDef id path while Option D supplies the token span.
+  // production first-class LetDef id path while Option D supplies the token span.
   let (g, sm) = build_fixture_with_spans("let x = 1\nlet x = 2\nx")
   guard go_to_definition(g, sm, 20) is Some(r)
   inspect(r.start, content="14")
@@ -99,11 +98,10 @@ test "binder_span: None when token spans were not populated" {
   // A SourceMap built via from_ast without populate_token_spans has no token
   // spans — binder_span must degrade to None, never a wrong location.
   let (proj, _errs) = @lambda_proj.parse_to_proj_node("let x = 1\nx")
-  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(proj, registry)
-  let g = build(module_projection, registry, source_map)
+  let g = build(registry, source_map)
   inspect(g.decls[0].kind is ModuleDef(_), content="true")
   inspect(binder_span(g, g.decls[0], source_map) is None, content="true")
 }

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -79,4 +79,6 @@ pub(all) struct ScopeGraph {
   decls : Array[Decl]
   refs : Array[Ref]
   module_node_id : @core.NodeId
+  node_scope : Map[@core.NodeId, ScopeId]
+  node_cutoffs : Map[@core.NodeId, Map[ScopeId, Int]]
 } derive(Debug)

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -1,19 +1,17 @@
 ///|
-/// Build (proj, module_projection, registry, source_map) from source.
+/// Build (proj, registry, source_map) from source.
 fn build_fixture(
   text : String,
 ) -> (
   @core.ProjNode[@ast.Term],
-  @lambda_proj.ModuleProjection,
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @core.SourceMap,
 ) raise {
   let (proj, _errs) = @lambda_proj.parse_to_proj_node(text)
-  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(proj, registry)
-  (proj, module_projection, registry, source_map)
+  (proj, registry, source_map)
 }
 
 ///|
@@ -42,10 +40,8 @@ fn find_var_node(
 
 ///|
 test "build: module defs become ModuleDef decls in root scope" {
-  let (_proj, module_projection, registry, source_map) = build_fixture(
-    "let a = 1\nlet b = 2\nb",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (_proj, registry, source_map) = build_fixture("let a = 1\nlet b = 2\nb")
+  let g = build(registry, source_map)
   inspect(g.decls.length(), content="2")
   guard g.decls[0].kind is ModuleDef(def_index=d0)
   inspect(d0, content="0")
@@ -103,11 +99,45 @@ fn find_var_in_def_init(
 }
 
 ///|
-test "resolve: lambda param" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "(x) => x",
+test "build: duplicate module defs use structural binder ids and cutoffs" {
+  let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = x\nx")
+  let g = build(registry, source_map)
+  guard proj.kind is @ast.Term::Module(_, _) else { fail("expected module") }
+  inspect(g.decls[0].node_id == proj.children[0].id(), content="true")
+  inspect(g.decls[1].node_id == proj.children[1].id(), content="true")
+  let init_var = find_var_in_def_init(proj, 1, "x")
+  guard declaration(g, init_var) is Some(init_decl)
+  guard init_decl.kind is ModuleDef(def_index=init_index)
+  inspect(init_index, content="0")
+  let body_var = find_var_in_body(proj, "x")
+  guard declaration(g, body_var) is Some(body_decl)
+  guard body_decl.kind is ModuleDef(def_index=body_index)
+  inspect(body_index, content="1")
+}
+
+///|
+test "declaration_for_name_at: module nodes use full local cutoff" {
+  let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = 2\nx")
+  let g = build(registry, source_map)
+  guard declaration_for_name_at(g, proj.id(), "x") is Some(root_decl)
+  guard root_decl.kind is ModuleDef(def_index=root_index)
+  inspect(root_index, content="1")
+
+  let (nested, nested_registry, nested_source_map) = build_fixture(
+    "let z = { let x = 1\nx }\nz",
   )
-  let g = build(module_projection, registry, source_map)
+  let nested_graph = build(nested_registry, nested_source_map)
+  let block = nested.children[0].children[0]
+  guard declaration_for_name_at(nested_graph, block.id(), "x")
+    is Some(block_decl)
+  guard block_decl.kind is ModuleDef(def_index=block_index)
+  inspect(block_index, content="0")
+}
+
+///|
+test "resolve: lambda param" {
+  let (proj, registry, source_map) = build_fixture("(x) => x")
+  let g = build(registry, source_map)
   let var_node = find_var_node(proj, "x")
   guard declaration(g, var_node) is Some(decl)
   inspect(decl.kind is LamParam(_), content="true")
@@ -115,20 +145,16 @@ test "resolve: lambda param" {
 
 ///|
 test "resolve: self-reference is unbound" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "let x = x\nx",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (proj, registry, source_map) = build_fixture("let x = x\nx")
+  let g = build(registry, source_map)
   let init_var = find_var_in_def_init(proj, 0, "x")
   inspect(declaration(g, init_var) is None, content="true")
 }
 
 ///|
 test "resolve: second def init binds to first def" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "let x = 1\nlet x = x\nx",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = x\nx")
+  let g = build(registry, source_map)
   let init_var = find_var_in_def_init(proj, 1, "x")
   guard declaration(g, init_var) is Some(decl)
   guard decl.kind is ModuleDef(def_index~)
@@ -137,10 +163,8 @@ test "resolve: second def init binds to first def" {
 
 ///|
 test "resolve: innermost lambda shadowing" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "(x) => (x) => x",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (proj, registry, source_map) = build_fixture("(x) => (x) => x")
+  let g = build(registry, source_map)
   let var_node = find_var_node(proj, "x")
   guard declaration(g, var_node) is Some(decl)
   inspect(decl.kind is LamParam(_), content="true")
@@ -148,10 +172,8 @@ test "resolve: innermost lambda shadowing" {
 
 ///|
 test "resolve: body binds to latest def" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "let x = 1\nlet x = 2\nx",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (proj, registry, source_map) = build_fixture("let x = 1\nlet x = 2\nx")
+  let g = build(registry, source_map)
   let body_var = find_var_in_body(proj, "x")
   guard declaration(g, body_var) is Some(decl)
   guard decl.kind is ModuleDef(def_index~)
@@ -160,20 +182,16 @@ test "resolve: body binds to latest def" {
 
 ///|
 test "resolve: earlier def cannot see later def" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "let a = b\nlet b = 1\na",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (proj, registry, source_map) = build_fixture("let a = b\nlet b = 1\na")
+  let g = build(registry, source_map)
   let init_var = find_var_in_def_init(proj, 0, "b")
   inspect(declaration(g, init_var) is None, content="true")
 }
 
 ///|
 test "references: identity-based, shadowing-aware" {
-  let (_proj, module_projection, registry, source_map) = build_fixture(
-    "let x = 1\nlet x = 2\nx",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (_proj, registry, source_map) = build_fixture("let x = 1\nlet x = 2\nx")
+  let g = build(registry, source_map)
   let def1 = g.decls[1].id
   let def0 = g.decls[0].id
   inspect(references(g, def1).length() >= 1, content="true")
@@ -182,10 +200,8 @@ test "references: identity-based, shadowing-aware" {
 
 ///|
 test "enclosing_env: lambda params in scope" {
-  let (proj, module_projection, registry, source_map) = build_fixture(
-    "(x, y) => x",
-  )
-  let g = build(module_projection, registry, source_map)
+  let (proj, registry, source_map) = build_fixture("(x, y) => x")
+  let g = build(registry, source_map)
   let var_node = find_var_node(proj, "x")
   let env = enclosing_env(g, var_node)
   inspect(env.contains("x"), content="true")

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "dowdiness/canopy/lang/lambda/scope"
 
 import {
-  "dowdiness/canopy/lang/lambda/proj",
   "dowdiness/lambda/ast",
   "moonbitlang/core/debug",
   "moonbitlang/core/immut/hashset",
@@ -11,9 +10,11 @@ import {
 // Values
 pub fn binder_span(ScopeGraph, Decl, @dowdiness/canopy/core.SourceMap) -> @dowdiness/loom/core.Range?
 
-pub fn build(@proj.ModuleProjection, Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]], @dowdiness/canopy/core.SourceMap) -> ScopeGraph
+pub fn build(Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]], @dowdiness/canopy/core.SourceMap) -> ScopeGraph
 
 pub fn declaration(ScopeGraph, @dowdiness/canopy/core.NodeId) -> Decl?
+
+pub fn declaration_for_name_at(ScopeGraph, @dowdiness/canopy/core.NodeId, String) -> Decl?
 
 pub fn enclosing_env(ScopeGraph, @dowdiness/canopy/core.NodeId) -> @hashset.HashSet[String]
 
@@ -74,6 +75,8 @@ pub(all) struct ScopeGraph {
   decls : Array[Decl]
   refs : Array[Ref]
   module_node_id : @dowdiness/canopy/core.NodeId
+  node_scope : Map[@dowdiness/canopy/core.NodeId, ScopeId]
+  node_cutoffs : Map[@dowdiness/canopy/core.NodeId, Map[ScopeId, Int]]
 } derive(@debug.Debug)
 
 pub(all) struct ScopeId(Int) derive(Compare, Eq, Hash, @debug.Debug)

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -12,6 +12,41 @@ pub fn declaration(g : ScopeGraph, ref_node : @core.NodeId) -> Decl? {
 }
 
 ///|
+/// Resolve `name` as it would be seen from `node`, using the same per-module
+/// sequential cutoffs captured when the scope graph was built.
+pub fn declaration_for_name_at(
+  g : ScopeGraph,
+  node : @core.NodeId,
+  name : String,
+) -> Decl? {
+  guard g.node_scope.get(node) is Some(start_scope) else { return None }
+  guard g.node_cutoffs.get(node) is Some(cutoffs) else { return None }
+  let mut cur : ScopeId? = Some(start_scope)
+  while cur is Some(sid) {
+    let ScopeId(si) = sid
+    let scope = g.scopes[si]
+    let hit = scope.decl_ids
+      .rev_iter()
+      .find_first(fn(did) {
+        let DeclId(di) = did
+        let decl = g.decls[di]
+        decl.name == name &&
+        (match decl.kind {
+          ModuleDef(def_index~) =>
+            cutoffs.get(sid) is Some(cutoff) && def_index < cutoff
+          LamParam(_) => true
+        })
+      })
+    if hit is Some(did) {
+      let DeclId(di) = did
+      return Some(g.decls[di])
+    }
+    cur = scope.parent
+  }
+  None
+}
+
+///|
 /// All reference NodeIds whose resolution points at the declaration `decl`.
 /// Identity-based (keyed on `DeclId`, NOT a name match), so shadowing is
 /// respected. Keying on `DeclId` rather than `Decl.node_id` is deliberate:

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -37,19 +37,23 @@ pub fn build_semantic_projection(
   root : @core.ProjNode[@ast.Term],
   source_map : @core.SourceMap,
 ) -> SemanticProjection {
-  build_semantic_projection_with_module_projection(root, source_map, None)
+  let projection = SemanticProjection::empty()
+  analyze_node(root, source_map, [], projection)
+  push_scope_failures(root, source_map, projection)
+  projection
 }
 
 ///|
+/// Temporary compatibility adapter for callers that still hold the flat
+/// projection memo. Semantic analysis now derives binder ids from the current
+/// `ProjNode` tree and ignores the `ModuleProjection` argument.
 pub fn build_semantic_projection_with_module_projection(
   root : @core.ProjNode[@ast.Term],
   source_map : @core.SourceMap,
   module_projection : @lambda_proj.ModuleProjection?,
 ) -> SemanticProjection {
-  let projection = SemanticProjection::empty()
-  analyze_node(root, source_map, [], projection, module_projection)
-  push_scope_failures(root, source_map, projection)
-  projection
+  let _ = module_projection
+  build_semantic_projection(root, source_map)
 }
 
 ///|
@@ -60,16 +64,10 @@ pub fn build_semantic_projection_with_module_projection(
 /// genuinely reachable, so the squiggle now rests on the resolver of record
 /// instead of a parallel `env.contains` check.
 ///
-/// The scope graph is reconstructed from `root` via `from_proj_node(root)` — it
-/// deliberately does NOT reuse the caller-supplied `module_projection`. Both the
-/// registry and the diagnostic ranges derive from `root`, so deriving the
-/// module projection from `root` too keeps resolution consistent with the tree
-/// the squiggles land on; the caller's projection (which under incremental
-/// editing is reconciled separately) could drift from `root` and mis-gate
-/// definition visibility. The `module_projection` argument is consulted only by
-/// the annotation/decoration walk, whose bound/free overlays deliberately remain
-/// on the environment walk — §6 Step 1 regrounds the structured diagnostic only.
-/// Incremental maintenance (avoiding this rebuild) is §6 Step 3, benchmark-gated.
+/// The scope graph is reconstructed from `root`. Both the registry and the
+/// diagnostic ranges derive from that same tree, so resolution stays consistent
+/// with the spans where squiggles land. Incremental maintenance (avoiding this
+/// rebuild) is §6 Step 3, benchmark-gated.
 fn push_scope_failures(
   root : @core.ProjNode[@ast.Term],
   source_map : @core.SourceMap,
@@ -77,8 +75,7 @@ fn push_scope_failures(
 ) -> Unit {
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(root, registry)
-  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(root)
-  let graph = @lambda_scope.build(module_projection, registry, source_map)
+  let graph = @lambda_scope.build(registry, source_map)
   for failure in @lambda_scope.failures(graph, source_map) {
     guard failure.location is Some(range) else { continue }
     projection.diagnostics.push(
@@ -98,26 +95,25 @@ fn analyze_node(
   source_map : @core.SourceMap,
   env : Array[String],
   projection : SemanticProjection,
-  module_projection : @lambda_proj.ModuleProjection?,
 ) -> Unit {
   match node.kind {
     @ast.Term::Module(defs, _) =>
-      analyze_module(node, source_map, defs, env, projection, module_projection)
+      analyze_module(node, source_map, defs, env, projection)
     @ast.Term::Lam(param, _) =>
       analyze_lambda(node, source_map, param, env, projection)
     @ast.Term::Var(name) | @ast.Term::Unbound(name) =>
       analyze_var(node, source_map, name, env, projection)
     @ast.Term::LetDef(_, _) =>
       for child in node.children {
-        analyze_node(child, source_map, env, projection, None)
+        analyze_node(child, source_map, env, projection)
       }
     @ast.Term::App(_, _) | @ast.Term::Bop(_, _, _) =>
       for child in node.children {
-        analyze_node(child, source_map, env, projection, None)
+        analyze_node(child, source_map, env, projection)
       }
     @ast.Term::If(_, _, _) =>
       for child in node.children {
-        analyze_node(child, source_map, env, projection, None)
+        analyze_node(child, source_map, env, projection)
       }
     @ast.Term::Int(_)
     | @ast.Term::Unit
@@ -133,7 +129,6 @@ fn analyze_module(
   defs : Array[(@ast.VarName, @ast.Term)],
   env : Array[String],
   projection : SemanticProjection,
-  module_projection : @lambda_proj.ModuleProjection?,
 ) -> Unit {
   let scoped = env.copy()
   for i, def in defs {
@@ -141,7 +136,7 @@ fn analyze_module(
     let binder_id = if i < node.children.length() {
       node.children[i].id()
     } else {
-      module_binding_node_id(module_projection, i).unwrap_or(node.id())
+      node.id()
     }
     add_annotation(
       projection,
@@ -166,30 +161,13 @@ fn analyze_module(
       None => ()
     }
     if i < node.children.length() {
-      analyze_node(node.children[i], source_map, scoped, projection, None)
+      analyze_node(node.children[i], source_map, scoped, projection)
     }
     scoped.push(name)
   }
   let body_index = defs.length()
   if body_index < node.children.length() {
-    analyze_node(
-      node.children[body_index],
-      source_map,
-      scoped,
-      projection,
-      None,
-    )
-  }
-}
-
-///|
-fn module_binding_node_id(
-  module_projection : @lambda_proj.ModuleProjection?,
-  def_index : Int,
-) -> @core.NodeId? {
-  match module_projection {
-    Some(fp) if def_index < fp.defs.length() => Some(fp.defs[def_index].3)
-    _ => None
+    analyze_node(node.children[body_index], source_map, scoped, projection)
   }
 }
 
@@ -220,7 +198,7 @@ fn analyze_lambda(
   let scoped = env.copy()
   scoped.push(param)
   if node.children.length() > 0 {
-    analyze_node(node.children[0], source_map, scoped, projection, None)
+    analyze_node(node.children[0], source_map, scoped, projection)
   }
 }
 

--- a/lang/lambda/semantic/semantic_projection_test.mbt
+++ b/lang/lambda/semantic/semantic_projection_test.mbt
@@ -13,15 +13,15 @@ fn parse_fixture(
 ///|
 fn parse_flat_fixture(
   text : String,
-) -> (@core.ProjNode[@ast.Term], @core.SourceMap, @lambda_proj.ModuleProjection) raise {
+) -> (@core.ProjNode[@ast.Term], @core.SourceMap) raise {
   let (cst, _) = @parser.parse_cst(text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
-  let module_projection = @lambda_proj.to_module_projection(syntax, counter)
-  let root = module_projection.to_proj_node(counter)
+  let flat_projection = @lambda_proj.to_module_projection(syntax, counter)
+  let root = flat_projection.to_proj_node(counter)
   let source_map = @core.SourceMap::from_ast(root)
   @lambda_proj.populate_token_spans(source_map, syntax, root)
-  (root, source_map, module_projection)
+  (root, source_map)
 }
 
 ///|
@@ -71,12 +71,8 @@ test "free-variable diagnostic in a module def is scope-sourced" {
   // the scope-graph diagnostic path through the MODULE route (not just the bare
   // lambda route), proving `push_scope_failures` reconstructs and resolves the
   // module-def graph rather than the diagnostic still coming from stale env logic.
-  let (root, source_map, module_projection) = parse_flat_fixture("let a = z\na")
-  let projection = build_semantic_projection_with_module_projection(
-    root,
-    source_map,
-    Some(module_projection),
-  )
+  let (root, source_map) = parse_flat_fixture("let a = z\na")
+  let projection = build_semantic_projection(root, source_map)
   inspect(projection.diagnostics.length(), content="1")
   inspect(projection.diagnostics[0].message, content="Free variable 'z'")
 }
@@ -101,8 +97,7 @@ fn assert_classifiers_agree(program : String) -> Unit raise {
   let projection = build_semantic_projection(root, source_map)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(root, registry)
-  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(root)
-  let graph = @lambda_scope.build(module_projection, registry, source_map)
+  let graph = @lambda_scope.build(registry, source_map)
   for r in graph.refs {
     let scope_free = r.resolution.decl is None
     let anns = match projection.annotations.get(r.node_id) {
@@ -146,8 +141,7 @@ fn scope_free_names(program : String) -> Array[String] raise {
   let (root, source_map) = parse_fixture(program)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(root, registry)
-  let module_projection = @lambda_proj.ModuleProjection::from_proj_node(root)
-  let graph = @lambda_scope.build(module_projection, registry, source_map)
+  let graph = @lambda_scope.build(registry, source_map)
   @lambda_scope.failures(graph, source_map).map(fn(f) { f.name })
 }
 
@@ -180,16 +174,10 @@ test "block classifier non-vacuity: block-local bound, block-free surfaced" {
 
 ///|
 test "semantic projection respects sequential module bindings" {
-  let (root, source_map, module_projection) = parse_flat_fixture(
-    "let x = 1\nlet y = x\nx + y",
-  )
-  let projection = build_semantic_projection_with_module_projection(
-    root,
-    source_map,
-    Some(module_projection),
-  )
-  assert_true(has_annotation(projection, module_projection.defs[0].3, "let x"))
-  assert_true(has_annotation(projection, module_projection.defs[1].3, "let y"))
+  let (root, source_map) = parse_flat_fixture("let x = 1\nlet y = x\nx + y")
+  let projection = build_semantic_projection(root, source_map)
+  assert_true(has_annotation(projection, root.children[0].id(), "let x"))
+  assert_true(has_annotation(projection, root.children[1].id(), "let y"))
   assert_false(has_annotation(projection, root.id(), "let x"))
   assert_false(has_annotation(projection, root.id(), "let y"))
   inspect(projection.diagnostics.length(), content="0")


### PR DESCRIPTION
## Summary

- Migrates Lambda scope, edit, semantic, companion, and ideal-example consumers away from `ModuleProjection` as their primary context.
- Derives scope graph declarations/cutoffs structurally from the current `ProjNode` registry, and adds `DefinitionIndex::from_proj_node` for adapter paths that only need binding lookup/cutoff data.
- Threads resolved `Decl`/`DeclId` through inline/rename paths so block-local and duplicate-definition semantics do not reinterpret root-relative `def_index` values.

Closes #632. Part of #623.

Remaining `ModuleProjection` references are intentional:

- `lang/lambda/proj` and `lang/lambda/flat` still store/build the flat projection until #633/#634.
- `LambdaCompanion::get_module_projection`/`proj_memo` remain temporary adapter boundaries.
- `build_semantic_projection_with_module_projection` remains a compatibility adapter and now ignores the argument.
- Tests still construct `ModuleProjection` for projection/index fixtures and incremental/cross-pipeline parity coverage.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `DefinitionIndex::{length,binding_for_node,cutoff_at_node}` | `lang/lambda/proj/definition_index.mbt` | Yes | Used for edit context binding lookup and module-end cutoff checks. |
| `ScopeGraph`, `declaration`, `references`, `binder_span` | `lang/lambda/scope` | Yes | Inline/rename paths now use graph declarations/IDs instead of root-relative `def_index`. |
| `SourceMap::{get_range,get_token_span}` and lambda token roles | `core` / `lang/lambda/proj` | Yes | Preserves source-owned binding ranges and binder spans. |
| `ProjNode` registry / `@core.collect_registry` | `core` | Yes | Scope and edit module views derive from the current tree/registry rather than flat projection context. |

New helpers added:

- `DefinitionIndex::from_proj_node`: needed to derive the existing definition-index view directly from first-class `LetDef` children when callers no longer hold `ModuleProjection`.
- `ScopeGraph.node_scope` / `node_cutoffs` plus `declaration_for_name_at`: needed for arbitrary name resolution at a node using per-module sequential cutoffs, including nested blocks.
- Private edit module-view helpers in `lang/lambda/edits/text_edit_module_view.mbt`: bounded replacement for `ModuleProjection` in edit handlers; exposes only structural binding rows, init node, source start, binding id, and body.
- Private declaration/binding helpers (`module_def_decl_for_binding`, `edit_binding_for_decl`): keep inline/edit semantics keyed by resolved declarations or structural binding ids.

## Test plan

- [x] Targeted MoonBit tests pass.
- [x] Targeted `moon check --deny-warn` passes.
- [x] `git diff -- '*.mbti'` reviewed for intentional API drift only.
- [x] JS rebuild not run; no web artifacts changed. `examples/ideal/main` was checked with `--deny-warn`.

## Validation

```bash
NEW_MOON_MOD=0 moon test lang/lambda/proj
NEW_MOON_MOD=0 moon test lang/lambda/scope
NEW_MOON_MOD=0 moon test lang/lambda/edits
NEW_MOON_MOD=0 moon test lang/lambda/semantic
NEW_MOON_MOD=0 moon test lang/lambda/companion
NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/scope lang/lambda/edits lang/lambda/semantic lang/lambda/companion --deny-warn
NEW_MOON_MOD=0 moon check examples/ideal/main --deny-warn
git diff --check
git diff -- '*.mbti'
```

Independent `moonbit-reviewer` pass found no blockers.
