### PR TITLE
feat(lambda): block-local delete/duplicate/move binding ops (§20 binding clause)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -492,24 +492,46 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   `Rename block-local binding leaves root binding intact`, `Rename block-local
   binding by binder id`, `Rename block reference to outer binding renames root`.
 
-- [ ] Teach `edits/` **inline / extract / binding** ops about nested-block scopes.
-  Why: rename is fixed (above) by delegating to the already-block-aware `@scope`
-  API. But `text_edit_refactor.mbt` (inline/extract) and `text_edit_binding.mbt`
-  still convert the block-aware `Decl` into a root-relative `def_index`:
-  `module_def_references(g, def_index)` returns the FIRST decl at that index (root
-  wins over a block-local def at the same index), and `module_projection.defs[
-  def_index]` / `find_def_index` index the ROOT module's defs only. So inlining a
-  block-local `x` inlines the ROOT def's value, and the capture guard
-  (`def_cutoff_at_node` + `declaration_id_for_name_from_scope`, scope.mbt) applies
-  one root-relative cutoff. Pre-existing blind spot, already unsound today —
-  rename-only is strict progress, not a regression.
-  Plan: GitHub issue — for references/binder, decl-thread the same way rename now
-  does. For the *capture analysis* (a hypothetical-position query: "what would
-  name N resolve to if the init moved to position P"), generalize to the
-  per-(node, scope) cutoff model the builder uses (`lang/lambda/scope/builder.mbt`
-  `node_cutoffs`), keying each `def_index` to its declaring scope.
-  Exit: inlining/extracting a block-local binding (`let y = { let x = 1; x }`)
-  operates on the block-local `x`, with a wbtest fixture asserting it.
+- [x] Teach `edits/` **inline** ops about nested-block scopes.
+  Shipped: `compute_inline_definition` / `compute_inline_all_usages`
+  (`text_edit_refactor.mbt`) thread the block-aware `Decl` straight through —
+  `module_def_decl_for_binding(g, id)` → `edit_binding_for_decl(ctx, decl)` for
+  the def view, `@scope.references(g, decl.id)` for usages, and the node-relative
+  `free_names_would_rebind_at_node` for the capture guard. No root-relative
+  `def_index` round-trip. wbtests: `InlineDefinition nested block uses resolved
+  declaration`, `InlineAllUsages nested block uses binding declaration`
+  (#636 / #655).
+
+- [x] Teach `edits/` **binding** ops (delete / duplicate / move) about
+  nested-block scopes.
+  Shipped: `compute_delete_binding` / `compute_duplicate_binding` /
+  `compute_move_binding_{up,down}` (`text_edit_binding.mbt`) dropped the
+  root-only `edit_module_view` + `find_def_index` + `module_view.defs[i]` path
+  for the same decl-threaded shape as inline. The move ops find their swap
+  neighbour with `sibling_module_def_decl(g, decl.scope, def_index ± 1)` —
+  `def_index` is scope-local (the builder assigns it per scope, root and nested
+  block alike), so adjacent indices in the same scope are the move neighbours;
+  the first/last guards became `def_index == 0` (up) / `sibling is None` (down).
+  The name-based `free_vars` move guard is unchanged. wbtests assert SOUNDNESS by
+  reparsing the result (`DeleteBinding removes block-local binding`,
+  `MoveBinding{Up,Down} swaps block-local bindings`,
+  `MoveBindingUp rejects first block-local binding`). Caveat: block-local
+  **duplicate** is now reachable but its output stays unsound — `_copy` is
+  unlexable (#649) and the inserted copy is not re-indented to the block (#650);
+  the `DuplicateBinding on block-local binding` wbtest characterizes this and
+  does NOT reparse.
+
+- [ ] Teach `edits/` **extract** op about nested-block scopes — the remaining
+  §20 clause. `compute_extract_to_let` (`text_edit_refactor.mbt`) still hoists
+  the new `let` to the ROOT body and gates capture root-relative, so a
+  block-internal expression with no block-local free var is hoisted unsoundly
+  (out-of-scope reference; #659). It safely refuses the block-local-free-var case
+  (wbtest `ExtractToLet refuses block-internal expr that uses a block-local
+  binding`), but the message is misleading and the capture analysis still has the
+  defs-empty Module-blind half (#651) and the two-path split (#656).
+  Exit: extracting a block-internal expression inserts the `let` into the
+  enclosing block and the result reparses to the intended AST; tracked by #659
+  (hoist target) + #651 / #656 (capture analysis).
 
 ## Shipped history
 

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -16,6 +16,31 @@ fn module_def_decl_for_binding(
 }
 
 ///|
+/// The sibling module-binding decl in `scope` at `target_index`, or None when no
+/// `ModuleDef` in that scope holds that index. `def_index` is scope-local (the
+/// builder assigns `ModuleDef(def_index=i)` per scope, root and nested block
+/// alike), so adjacent indices in the SAME scope are the move-up/down neighbours
+/// — this is what makes the binding move ops block-local-aware rather than
+/// root-relative.
+fn sibling_module_def_decl(
+  g : @scope.ScopeGraph,
+  scope : @scope.ScopeId,
+  target_index : Int,
+) -> @scope.Decl? {
+  let @scope.ScopeId(si) = scope
+  g.scopes[si].decl_ids
+  .iter()
+  .map(fn(did) {
+    let @scope.DeclId(di) = did
+    g.decls[di]
+  })
+  .find_first(fn(decl) {
+    decl.kind is @scope.DeclKind::ModuleDef(def_index~) &&
+    def_index == target_index
+  })
+}
+
+///|
 /// Recursively collect Var nodes matching the given name, stopping at shadowing Lam params.
 fn collect_var_usages(
   node : ProjNode[@ast.Term],

--- a/lang/lambda/edits/text_edit_binding.mbt
+++ b/lang/lambda/edits/text_edit_binding.mbt
@@ -3,14 +3,18 @@ fn compute_delete_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, .. } = ctx
-  let module_view = edit_module_view(ctx)
-  let def_index = match find_def_index(module_view, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, registry, .. } = ctx
+  let g = @scope.build(registry, source_map)
+  let decl = match module_def_decl_for_binding(g, binding_node_id) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
+  let def = match edit_binding_for_decl(ctx, decl) {
+    Ok(d) => d
     Err(e) => return Err(e)
   }
   let (let_start, binding_end) = match
-    get_binding_text_range(source_text, source_map, module_view.defs[def_index]) {
+    get_binding_text_range(source_text, source_map, def) {
     Ok(r) => r
     Err(e) => return Err(e)
   }
@@ -29,13 +33,16 @@ fn compute_duplicate_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, .. } = ctx
-  let module_view = edit_module_view(ctx)
-  let def_index = match find_def_index(module_view, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, registry, .. } = ctx
+  let g = @scope.build(registry, source_map)
+  let decl = match module_def_decl_for_binding(g, binding_node_id) {
+    Ok(d) => d
     Err(e) => return Err(e)
   }
-  let def = module_view.defs[def_index]
+  let def = match edit_binding_for_decl(ctx, decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
   let binding_source = match
     binding_rewrite_source(source_text, source_map, def) {
     Ok(source) => source
@@ -78,18 +85,33 @@ fn compute_move_binding_up(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, .. } = ctx
-  let module_view = edit_module_view(ctx)
-  let def_index = match find_def_index(module_view, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, registry, .. } = ctx
+  let g = @scope.build(registry, source_map)
+  let decl = match module_def_decl_for_binding(g, binding_node_id) {
+    Ok(d) => d
     Err(e) => return Err(e)
+  }
+  guard decl.kind is @scope.DeclKind::ModuleDef(def_index~) else {
+    return Err("Binding is not a module definition")
   }
   if def_index == 0 {
     return Err("Cannot move first binding up")
   }
+  // Move neighbour is the def at def_index - 1 in the SAME scope (block-local
+  // aware), not a root sibling.
+  let prev_decl = match sibling_module_def_decl(g, decl.scope, def_index - 1) {
+    Some(d) => d
+    None => return Err("Cannot move first binding up")
+  }
+  let cur_def = match edit_binding_for_decl(ctx, decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
+  let prev_def = match edit_binding_for_decl(ctx, prev_decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
   // Scoping guard: check if either name is free in the other's init
-  let cur_def = module_view.defs[def_index]
-  let prev_def = module_view.defs[def_index - 1]
   let empty_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let cur_fv = free_vars(cur_def.init.kind, empty_env)
   let prev_fv = free_vars(prev_def.init.kind, empty_env)
@@ -146,18 +168,30 @@ fn compute_move_binding_down(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, .. } = ctx
-  let module_view = edit_module_view(ctx)
-  let def_index = match find_def_index(module_view, binding_node_id) {
-    Ok(i) => i
+  let { source_text, source_map, registry, .. } = ctx
+  let g = @scope.build(registry, source_map)
+  let decl = match module_def_decl_for_binding(g, binding_node_id) {
+    Ok(d) => d
     Err(e) => return Err(e)
   }
-  if def_index >= module_view.defs.length() - 1 {
-    return Err("Cannot move last binding down")
+  guard decl.kind is @scope.DeclKind::ModuleDef(def_index~) else {
+    return Err("Binding is not a module definition")
+  }
+  // Move neighbour is the def at def_index + 1 in the SAME scope (block-local
+  // aware); its absence means this is the last binding in its block.
+  let next_decl = match sibling_module_def_decl(g, decl.scope, def_index + 1) {
+    Some(d) => d
+    None => return Err("Cannot move last binding down")
+  }
+  let cur_def = match edit_binding_for_decl(ctx, decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
+  }
+  let next_def = match edit_binding_for_decl(ctx, next_decl) {
+    Ok(d) => d
+    Err(e) => return Err(e)
   }
   // Scoping guard: check if either name is free in the other's init
-  let cur_def = module_view.defs[def_index]
-  let next_def = module_view.defs[def_index + 1]
   let empty_env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let cur_fv = free_vars(cur_def.init.kind, empty_env)
   let next_fv = free_vars(next_def.init.kind, empty_env)

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -83,20 +83,6 @@ fn ensure_replaceable_node_range(
 }
 
 ///|
-/// Find a module binding's index in an edit module view by its NodeId.
-fn find_def_index(
-  module_view : EditModuleView,
-  binding_node_id : NodeId,
-) -> Result[Int, String] {
-  for i, def in module_view.defs {
-    if def.binding_id == binding_node_id {
-      return Ok(i)
-    }
-  }
-  Err("Binding not found: " + binding_node_id.to_string())
-}
-
-///|
 /// Compute (start, length) for deleting a binding line, consuming
 /// the adjacent newline if present (trailing preferred, else leading).
 fn binding_delete_range(

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -920,6 +920,166 @@ test "compute_text_edit: MoveBindingUp swaps fn bindings" {
 }
 
 ///|
+/// Reparse `text` and return the definition names, in order, of the binding
+/// block held in root definition `def_index`'s initialiser. Used by the
+/// block-local binding-op tests to assert SOUNDNESS structurally (the edited
+/// text reparses to the intended block shape), not just by string match — a
+/// botched swap can string-match an expectation while reparsing to a different
+/// structure (see the #649/#650 reparse-gate lesson).
+fn nested_block_def_names(def_index : Int, text : String) -> String raise {
+  let (proj, _) = parse_to_proj_node(text)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  match fp.defs[def_index].1.kind {
+    @ast.Term::Module(defs, _) => defs.map(fn(d) { d.0 }).join(",")
+    _ => ""
+  }
+}
+
+///|
+test "compute_text_edit: DeleteBinding removes block-local binding" {
+  // `b` is block-local to `z`'s initialiser; root-relative lookup would reject
+  // it. The block-aware op deletes it and the result reparses to a block with
+  // only `a`.
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  let binding_id = block.children[1].id()
+  let result = compute_text_edit(
+    DeleteBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="let x = 0\nlet z = { let a = 1\n  a }\nz")
+      inspect(nested_block_def_names(1, new_text), content="a")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: MoveBindingDown swaps block-local bindings" {
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    MoveBindingDown(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      // Soundness: reparses to the block with defs in swapped order.
+      inspect(nested_block_def_names(1, new_text), content="b,a")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: MoveBindingUp swaps block-local bindings" {
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  let binding_id = block.children[1].id()
+  let result = compute_text_edit(
+    MoveBindingUp(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(nested_block_def_names(1, new_text), content="b,a")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: MoveBindingUp rejects first block-local binding" {
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  // `a` is the first def in the block scope (scope-local def_index 0).
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    MoveBindingUp(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "compute_text_edit: DuplicateBinding on block-local binding" {
+  // Block-local duplicate is now reachable (no longer "Binding not found"). The
+  // output stays unsound for two reasons, both pre-existing and out of scope
+  // here: the `_copy` name is unlexable (underscore is not an identifier char,
+  // tracked as #649), and the inserted copy is not re-indented to the block.
+  // So this characterizes the current raw edit text and deliberately does NOT
+  // reparse; closing #649 is what makes a positive round-trip assertion possible.
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[1].1
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(
+        new_text,
+        content="let x = 0\nlet z = { let a = 1\n let a_copy = 1\n  let b = 2\n  a }\nz",
+      )
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+/// ExtractToLet is NOT yet block-aware (it always hoists to the ROOT body): see
+/// the §20 extract clause. When the extracted block-internal expression
+/// references a block-local binding, the root-relative capture guard catches it
+/// and refuses — so the unsound hoist is at least avoided for this case. (The
+/// error text says "lambda-bound" but the captured binding here is a module
+/// def; the message is misleading, not the verdict.) The complementary case — a
+/// block-internal expression with NO block-local free var — is NOT guarded and
+/// hoists unsoundly; that is the open bug tracked separately, so it is
+/// deliberately not asserted here as if correct.
+test "compute_text_edit: ExtractToLet refuses block-internal expr that uses a block-local binding" {
+  let text = "let z = { let a = 1\n  a + 1 }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let block = fp.defs[0].1
+  let body = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=body.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, fp),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 test "compute_text_edit: AddBinding adds new let line" {
   let text = "let x = 0\nx"
   let (proj, _) = parse_to_proj_node(text)


### PR DESCRIPTION
## Summary

Makes the binding edit ops **block-local-aware**, closing §20's binding-ops
clause (inline was already shipped in #636 / #655).

`compute_delete_binding` / `compute_duplicate_binding` /
`compute_move_binding_{up,down}` (`text_edit_binding.mbt`) previously resolved a
binding via the root-only `edit_module_view` + `find_def_index` +
`module_view.defs[i]` path, so a `let` inside a nested `{ ... }` block was
rejected with `Err("Binding not found")`. They now route through the same
decl-threaded shape the inline ops already use:
`module_def_decl_for_binding(g, id)` → `edit_binding_for_decl(ctx, decl)`.

The move ops find their swap neighbour with the new
`sibling_module_def_decl(g, decl.scope, def_index ± 1)`. `def_index` is
scope-local (the builder assigns `ModuleDef(def_index=i)` per scope, root and
nested block alike), so adjacent indices in the same scope are the neighbours;
the first/last guards became `def_index == 0` (up) / `sibling is None` (down).
The name-based `free_vars` move scoping guard is unchanged. `find_def_index` is
now dead and removed.

## Tests

New wbtests assert **soundness by reparsing** the edited text and checking block
def order/membership (not string match alone), per the #649/#650 reparse-gate
lesson:

- `DeleteBinding removes block-local binding`
- `MoveBindingDown swaps block-local bindings`
- `MoveBindingUp swaps block-local bindings`
- `MoveBindingUp rejects first block-local binding`
- `DuplicateBinding on block-local binding` — characterizes current output and
  deliberately does **not** reparse (see caveat).

Each of the four capability tests was confirmed to fail on `main`'s ops with
exactly `Err("Binding not found: NodeId(..)")` before the fix. All 171 edits
tests pass; workspace check is clean; existing root-level binding-op tests are
unchanged (no regression). Codex pre-PR review: PASS, no findings.

## Caveats / follow-ups

- Block-local **duplicate** is now reachable but its output stays unsound —
  `_copy` is unlexable (#649) and the inserted copy is not re-indented to the
  block (#650). Tracked there; not fixed here.
- §20's **extract** clause remains open: `compute_extract_to_let` still hoists
  block-internal expressions to the root body, unsound for the
  no-block-local-free-var case (**filed #659**); the capture analysis also has
  the defs-empty Module-blind half (#651) and two-path split (#656). A
  safe-refuse regression test (`ExtractToLet refuses block-internal expr that
  uses a block-local binding`) pins the one block-internal case extract handles
  safely today. The §20 TODO entry is split accordingly.

## Reuse check

- **Reused:** `module_def_decl_for_binding`, `edit_binding_for_decl`,
  `edit_binding_by_id`, `edit_binding_from_child`, `get_binding_text_range`,
  `binding_rewrite_source`, `@scope.build`, `@scope.Decl` / `DeclKind` — the
  exact APIs the inline ops (`compute_inline_definition` /
  `compute_inline_all_usages`) already use. This PR brings binding ops to parity
  with that proven pattern rather than inventing a parallel path.
- **New:** one private helper `sibling_module_def_decl(g, scope, target_index)`
  in `edits/scope.mbt` — there was no existing "sibling def at index N in this
  scope" query (the root-relative code indexed `module_view.defs` directly,
  which only the now-removed `find_def_index` did). Responsibility boundary:
  scope-confined sibling lookup over `g.scopes[si].decl_ids`, used only by the
  two move ops.
- **Removed:** `find_def_index` (`text_edit_utils.mbt`) — dead after the port.

Closes the §20 inline + binding-ops clauses (extract clause tracked by #659 /
#651 / #656).
