### PR TITLE
refactor(lambda): trim ModuleProjection compatibility surface

### DIFF
--- a/docs/development/ADDING_A_LANGUAGE.md
+++ b/docs/development/ADDING_A_LANGUAGE.md
@@ -6,10 +6,11 @@ internals.
 
 **Primary example:** Markdown (uses CstFold, 3-memo pattern, clean structure).
 
-> **Don't follow the Lambda pattern.** Lambda predates CstFold, uses a 4-memo
-> ModuleProjection pipeline, and hand-builds AST values from view casts. It's the
-> oldest language integration and carries historical complexity. Use Markdown
-> as your reference; consult JSON where patterns differ.
+> **Don't follow the Lambda pattern.** Lambda predates CstFold, still carries
+> legacy `ModuleProjection` compatibility/reconciliation helpers, and has a
+> custom editor-coupled edit bridge. It's the oldest language integration and
+> carries historical complexity. Use Markdown as your reference; consult JSON
+> where patterns differ.
 
 ## How it fits together
 
@@ -386,11 +387,12 @@ pub fn new_my_editor(
 > **The lambda exception.** `lang/lambda/companion` does NOT go through
 > `LanguageSpec` — its edit path is editor-coupled in ways the SPI
 > deliberately excludes: `compute_text_edit` needs an `EditContext` carrying
-> `registry` + `module_projection`, `apply_lambda_tree_edit` returns a typed
-> `Result[Array[SpanEdit], TreeEditError]` patch trace, and `Drop` delegates
-> to `editor.move_node`. Lambda's eval/scope/semantic extras ride the
-> optional per-instance `LanguageCapabilities` fields instead. Do not copy
-> lambda's shape for a new language; see the decision record in
+> `registry` plus a `DefinitionIndex` derived from the generic `ProjNode` root,
+> `apply_lambda_tree_edit` returns a typed `Result[Array[SpanEdit],
+> TreeEditError]` patch trace, and `Drop` delegates to `editor.move_node`.
+> Lambda's eval/scope/semantic extras ride the optional per-instance
+> `LanguageCapabilities` fields instead. Do not copy lambda's shape for a new
+> language; see the decision record in
 > `docs/plans/2026-06-11-s3-lang-runtime-extraction.md` (Step 4 amendment).
 
 **Package registration:**

--- a/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
+++ b/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
@@ -1,14 +1,14 @@
 # Lambda CstFold modernization decision note (#623)
 
-**Status:** accepted through #633 (generic 3-memo editor-facing projection path)
+**Status:** accepted through #633; updated for #661 compatibility cleanup
 **Date:** 2026-06-14  
 **Issue:** <https://github.com/dowdiness/canopy/issues/623>
 
 ## Decision
 
 Migrate Lambda incrementally toward the CstFold pattern at the **projection
-construction** seam, but keep the Lambda-specific `ModuleProjection` memo layer
-and custom edit bridge for now.
+construction** seam, but keep the Lambda-specific `ModuleProjection`
+compatibility/reconciliation helpers and custom edit bridge for now.
 
 Markdown remains the reference integration for new languages. Lambda stays a
 legacy stress case, not a reference demo. The immediate modernization goal is to
@@ -27,8 +27,9 @@ containing the remaining exceptions.
   - `@lang_runtime.LanguageSpec` for editor construction and edit application.
 - Lambda still uses:
   - `ModuleProjection { defs, final_expr }` in
-    `lang/lambda/proj/module_projection.mbt` for legacy helpers/tests and the
-    #634 removal follow-up.
+    `lang/lambda/proj/module_projection.mbt` for legacy helpers/tests plus the
+    internal root-module reconciliation hook; it is no longer editor-facing
+    projection state.
   - Hand-written view-cast projection in `lang/lambda/proj/proj_node.mbt`.
   - `@core.build_projection_memos` via
     `lang/lambda/proj/projection_memo.mbt` for the editor-facing 3-memo stack
@@ -48,19 +49,20 @@ containing the remaining exceptions.
 | CST -> AST value | `CstFold` + language fold node | duplicated hand-built `Term` construction in Canopy | migrate first |
 | AST/projection tree shape | small AST/syntax parallel walk | bespoke synthetic `Lam`, `App`, `Bop`, `LetDef`, `Module` shapes | preserve initially |
 | Memo pipeline | `@core.build_projection_memos` 3-memo | `@core.build_projection_memos` via `lang/lambda/proj` (#633); legacy `ModuleProjection` no longer has an editor-facing memo | migrated in #633 |
-| Edit bridge | `LanguageSpec::apply_edit` | `EditContext{registry,module_projection}` + typed errors + patch trace + `Drop` via `move_node` | keep custom bridge |
+| Edit bridge | `LanguageSpec::apply_edit` | `EditContext{registry,definition_index}` derived from the generic projection root + typed errors + patch trace + `Drop` via `move_node` | keep custom bridge |
 | New-language guidance | copy Markdown | explicitly do not copy Lambda | leave docs accurate |
 
 ## Blockers to a full migration
 
-1. **`ModuleProjection` is still semantic/editor state.** Scope, semantic
-   decorations, binding actions, and many edit tests consume the flat def view
-   and its LetDef ids. Removing it requires a separate identity/scope design,
-   not just swapping memo helpers.
+1. **`ModuleProjection` remains a compatibility/reconciliation seam, not editor
+   state.** Scope, semantic decorations, binding actions, and production edits
+   now derive from the generic projection root plus `DefinitionIndex`. The
+   remaining flat view is used internally to reconcile root-module binding IDs
+   and by legacy tests being classified under #662.
 2. **The `LanguageSpec` boundary deliberately excludes Lambda's edit bridge.**
-   The S3 amendment records why: Lambda needs registry + module-projection
-   context, returns `TreeEditError` plus the applied `SpanEdit` trace, and
-   delegates `Drop` to `SyncEditor::move_node`.
+   The S3 amendment records why: Lambda needs registry plus a definition index,
+   returns `TreeEditError` plus the applied `SpanEdit` trace, and delegates
+   `Drop` to `SyncEditor::move_node`.
 3. **CstFold and current projection semantics are not byte-for-byte identical.**
    A probe comparing current projection kind with `syntax_node_to_term` showed:
    - `{ 1 }`: current projection `Int(1)`, CstFold term `Module([], Int(1))`.
@@ -71,8 +73,8 @@ containing the remaining exceptions.
    no-definition block-expression structural patterns before parity-checking
    CstFold terms now or adopting them in later projection slices.
 4. **Related issues remain adjacent, not substitutes.**
-   - #129/#scope work centralized queries but did not remove the
-     `ModuleProjection` context requirement.
+   - #129/#scope work centralized queries before #632/#661 removed the
+     production `ModuleProjection` context requirement.
    - #567/`ProjectionIdentityTracker` is relevant for future binder identity,
      but it does not replace Lambda's current projection-diff mechanism.
    - #389 may improve projection API ergonomics later; it is not a current
@@ -158,14 +160,14 @@ Likely touched files:
 - #631 — extract a definition index from `ModuleProjection`.
 - #632 — migrate scope/edit/semantic consumers off `ModuleProjection`.
 - #633 — switch the projection memo stack to the generic 3-memo path.
-- #634 — revisit the Lambda edit bridge after `ModuleProjection` removal.
+- #634 — revisit the Lambda edit bridge after compatibility-surface cleanup.
 - #635 — replace typed-`fn` source scanners with structured token metadata.
 
 ## Non-goals
 
 - Do not migrate Lambda onto `LanguageSpec` in this issue slice.
-- After #633, keep remaining `ModuleProjection` removal and edit-bridge cleanup
-  scoped to #634 instead of broadening memo-stack work into an edit redesign.
+- After #633/#661, keep remaining edit-bridge cleanup scoped to #634 instead of
+  broadening compatibility-surface work into an edit redesign.
 - Do not make #625's source scanner a reusable framework abstraction.
 - Do not reopen binder identity or scope unification under #623 unless a concrete
   projection slice is blocked by them.

--- a/editor/errors.mbt
+++ b/editor/errors.mbt
@@ -8,7 +8,7 @@ pub(all) suberror TreeEditError {
   FieldMustBeNumber(field~ : String)
   UnknownBop(name~ : String)
   UnknownOpType(op_type~ : String)
-  ModuleProjectionUnavailable
+  ProjectionUnavailable
   UnhandledOperation(detail~ : String)
   NodeNotInSourceMap(action~ : String, node_id~ : @core.NodeId)
   NodeNotInRegistry(action~ : String, node_id~ : @core.NodeId)
@@ -25,7 +25,7 @@ pub fn TreeEditError::message(self : TreeEditError) -> String {
     FieldMustBeNumber(field~) => "\{field} must be a number"
     UnknownBop(name~) => "unknown bop: \{name}"
     UnknownOpType(op_type~) => "unknown op type: \{op_type}"
-    ModuleProjectionUnavailable => "No ModuleProjection available"
+    ProjectionUnavailable => "No projection available"
     UnhandledOperation(detail~) => "Unhandled tree edit op: \{detail}"
     NodeNotInSourceMap(action~, node_id~) =>
       "\{action}: node \{node_id} not in source map"

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -51,7 +51,7 @@ pub(all) suberror TreeEditError {
   FieldMustBeNumber(field~ : String)
   UnknownBop(name~ : String)
   UnknownOpType(op_type~ : String)
-  ModuleProjectionUnavailable
+  ProjectionUnavailable
   UnhandledOperation(detail~ : String)
   NodeNotInSourceMap(action~ : String, node_id~ : @dowdiness/canopy/core.NodeId)
   NodeNotInRegistry(action~ : String, node_id~ : @dowdiness/canopy/core.NodeId)

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -251,7 +251,7 @@ pub fn apply_lambda_tree_edit(
   let registry = editor.get_registry()
   let definition_index = match editor.get_proj_node() {
     Some(root) => @lambda_proj.DefinitionIndex::from_proj_node(root)
-    None => return Err(@editor.TreeEditError::ModuleProjectionUnavailable)
+    None => return Err(@editor.TreeEditError::ProjectionUnavailable)
   }
   let ctx : @lambda_edits.EditContext[@ast.Term] = {
     source_text: editor.get_text(),

--- a/lang/lambda/proj/definition_index.mbt
+++ b/lang/lambda/proj/definition_index.mbt
@@ -28,9 +28,10 @@ fn DefinitionIndexEntry::from_binding(
 ///|
 /// Index of module-level Lambda definitions.
 ///
-/// `ModuleProjection` still owns the projection storage for this slice; this
-/// derived index gives definition lookup and binding-id queries a named home
-/// without exposing the underlying tuple layout to new consumers.
+/// Production edit paths derive this from the current `ProjNode` root. The
+/// `ModuleProjection` adapter below exists for the legacy compatibility layer
+/// and root-module reconciliation, but new consumers should use
+/// `DefinitionIndex::from_proj_node`.
 pub struct DefinitionIndex {
   priv entries : Array[DefinitionIndexEntry]
 }
@@ -65,7 +66,9 @@ pub fn DefinitionIndex::from_proj_node(
 }
 
 ///|
-/// Derive the definition-index view for this module projection.
+/// Legacy compatibility adapter: derive the definition-index view for this
+/// module projection. New production callers should use
+/// `DefinitionIndex::from_proj_node`.
 pub fn ModuleProjection::definition_index(
   self : ModuleProjection,
 ) -> DefinitionIndex {

--- a/lang/lambda/proj/module_projection.mbt
+++ b/lang/lambda/proj/module_projection.mbt
@@ -1,19 +1,22 @@
-// Lambda-specific ModuleProjection: flat representation of Module with per-def tracking.
-// Moved from projection/module_projection.mbt to separate language code from framework.
+// Legacy Lambda ModuleProjection compatibility layer.
+//
+// Production editor-facing projection uses the generic 3-memo stack in
+// projection_memo.mbt. This flat view remains only for root-module
+// reconciliation inside this package and for legacy compatibility tests; new
+// production consumers should derive data from ProjNode, SourceMap, registry,
+// and DefinitionIndex instead.
 
 ///|
+/// Legacy flat module view used by compatibility tests and the internal
+/// root-module reconciliation hook. Prefer `ProjNode` + `DefinitionIndex` for
+/// production edit/semantic code.
 pub struct ModuleProjection {
   defs : Array[(String, ProjNode[@ast.Term], Int, NodeId)] // (name, init, start, LetDef id)
   final_expr : ProjNode[@ast.Term]?
 } derive(Debug, Eq)
 
 ///|
-pub fn ModuleProjection::empty() -> ModuleProjection {
-  { defs: [], final_expr: None }
-}
-
-///|
-/// Build a ModuleProjection from a SourceFile SyntaxNode.
+/// Legacy/test helper: build a ModuleProjection from a SourceFile SyntaxNode.
 /// Iterates LetDef children and collects them as flat array entries.
 /// Each entry stores the init subtree plus the real LetDef node id.
 pub fn to_module_projection(
@@ -41,7 +44,8 @@ pub fn to_module_projection(
 }
 
 ///|
-/// Build a ModuleProjection incrementally by comparing old and new CST children.
+/// Legacy/test helper: build a ModuleProjection incrementally by comparing old
+/// and new CST children.
 ///
 /// For each child pair, compares start offset plus underlying CstNodes
 /// structurally. If unchanged, reuses the old ModuleProjection entry directly —
@@ -173,7 +177,7 @@ fn[K : Eq + Hash] key_match(
 ///|
 /// Reconcile two ModuleProjections, preserving node IDs where entries match.
 /// O(n) hash-based matching on def names; reconciles init subtrees individually.
-pub fn reconcile_module_projection(
+fn reconcile_module_projection(
   old_fp : ModuleProjection,
   new_fp : ModuleProjection,
   counter : Ref[Int],
@@ -215,7 +219,7 @@ pub fn reconcile_module_projection(
 }
 
 ///|
-/// Reconstruct a Module ProjNode from ModuleProjection.
+/// Legacy/test helper: reconstruct a Module ProjNode from ModuleProjection.
 /// Uses stored NodeIds for the Module node. Counter only used for Unit fallback.
 pub fn ModuleProjection::to_proj_node(
   self : ModuleProjection,
@@ -232,7 +236,7 @@ pub fn ModuleProjection::to_proj_node(
 /// of allocating a fresh one from the counter. This ensures the root Module
 /// node_id is stable across incremental rebuilds when the content hasn't
 /// changed structurally — which is required for ProseMirror document identity.
-pub fn ModuleProjection::to_proj_node_with_prev_module_id(
+fn ModuleProjection::to_proj_node_with_prev_module_id(
   self : ModuleProjection,
   counter : Ref[Int],
   prev_module_id : Int?,
@@ -278,7 +282,7 @@ pub fn ModuleProjection::to_proj_node_with_prev_module_id(
 }
 
 ///|
-/// Extract a ModuleProjection from a Module ProjNode.
+/// Legacy/test helper: extract a ModuleProjection from a Module ProjNode.
 /// Reads LetDef children and extracts their init child. Legacy init-only
 /// children are accepted as a compatibility fallback.
 pub fn ModuleProjection::from_proj_node(
@@ -319,7 +323,8 @@ pub fn ModuleProjection::from_proj_node(
 }
 
 ///|
-/// Print a ModuleProjection to text. Equivalent to @ast.print_term on the nested spine.
+/// Legacy/test helper: print a ModuleProjection to text. Equivalent to
+/// @ast.print_term on the nested spine.
 pub fn print_module_projection(fp : ModuleProjection) -> String {
   let parts : Array[String] = []
   for def in fp.defs {

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -27,8 +27,6 @@ pub fn print_module_projection(ModuleProjection) -> String
 
 pub fn rebuild_kind(@ast.Term, Array[@dowdiness/canopy/core.ProjNode[@ast.Term]]) -> @ast.Term
 
-pub fn reconcile_module_projection(ModuleProjection, ModuleProjection, @ref.Ref[Int]) -> ModuleProjection
-
 pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
 
 pub fn term_css_class(@ast.Term) -> String
@@ -57,10 +55,8 @@ pub struct ModuleProjection {
   final_expr : @dowdiness/canopy/core.ProjNode[@ast.Term]?
 } derive(Eq, @debug.Debug)
 pub fn ModuleProjection::definition_index(Self) -> DefinitionIndex
-pub fn ModuleProjection::empty() -> Self
 pub fn ModuleProjection::from_proj_node(@dowdiness/canopy/core.ProjNode[@ast.Term]) -> Self
 pub fn ModuleProjection::to_proj_node(Self, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
-pub fn ModuleProjection::to_proj_node_with_prev_module_id(Self, @ref.Ref[Int], Int?) -> @dowdiness/canopy/core.ProjNode[@ast.Term]
 
 // Type aliases
 

--- a/lang/lambda/semantic/pkg.generated.mbti
+++ b/lang/lambda/semantic/pkg.generated.mbti
@@ -3,7 +3,6 @@ package "dowdiness/canopy/lang/lambda/semantic"
 
 import {
   "dowdiness/canopy/core",
-  "dowdiness/canopy/lang/lambda/proj",
   "dowdiness/canopy/protocol",
   "dowdiness/lambda/ast",
   "moonbitlang/core/debug",
@@ -11,8 +10,6 @@ import {
 
 // Values
 pub fn build_semantic_projection(@core.ProjNode[@ast.Term], @core.SourceMap) -> SemanticProjection
-
-pub fn build_semantic_projection_with_module_projection(@core.ProjNode[@ast.Term], @core.SourceMap, @proj.ModuleProjection?) -> SemanticProjection
 
 // Errors
 

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -44,19 +44,6 @@ pub fn build_semantic_projection(
 }
 
 ///|
-/// Temporary compatibility adapter for callers that still hold the flat
-/// projection memo. Semantic analysis now derives binder ids from the current
-/// `ProjNode` tree and ignores the `ModuleProjection` argument.
-pub fn build_semantic_projection_with_module_projection(
-  root : @core.ProjNode[@ast.Term],
-  source_map : @core.SourceMap,
-  module_projection : @lambda_proj.ModuleProjection?,
-) -> SemanticProjection {
-  let _ = module_projection
-  build_semantic_projection(root, source_map)
-}
-
-///|
 /// Source the free-variable diagnostics from the lambda scope graph rather than
 /// the projection's own environment walk (research note 2026-06-13 §6 Step 1).
 /// Each unresolved reference (`resolution.decl == None`) is a witnessed

--- a/lang/lambda/semantic/semantic_projection_test.mbt
+++ b/lang/lambda/semantic/semantic_projection_test.mbt
@@ -11,20 +11,6 @@ fn parse_fixture(
 }
 
 ///|
-fn parse_flat_fixture(
-  text : String,
-) -> (@core.ProjNode[@ast.Term], @core.SourceMap) raise {
-  let (cst, _) = @parser.parse_cst(text)
-  let syntax = @seam.SyntaxNode::from_cst(cst)
-  let counter = Ref(0)
-  let flat_projection = @lambda_proj.to_module_projection(syntax, counter)
-  let root = flat_projection.to_proj_node(counter)
-  let source_map = @core.SourceMap::from_ast(root)
-  @lambda_proj.populate_token_spans(source_map, syntax, root)
-  (root, source_map)
-}
-
-///|
 fn has_annotation(
   projection : SemanticProjection,
   node_id : @core.NodeId,
@@ -71,7 +57,7 @@ test "free-variable diagnostic in a module def is scope-sourced" {
   // the scope-graph diagnostic path through the MODULE route (not just the bare
   // lambda route), proving `push_scope_failures` reconstructs and resolves the
   // module-def graph rather than the diagnostic still coming from stale env logic.
-  let (root, source_map) = parse_flat_fixture("let a = z\na")
+  let (root, source_map) = parse_fixture("let a = z\na")
   let projection = build_semantic_projection(root, source_map)
   inspect(projection.diagnostics.length(), content="1")
   inspect(projection.diagnostics[0].message, content="Free variable 'z'")
@@ -174,7 +160,7 @@ test "block classifier non-vacuity: block-local bound, block-free surfaced" {
 
 ///|
 test "semantic projection respects sequential module bindings" {
-  let (root, source_map) = parse_flat_fixture("let x = 1\nlet y = x\nx + y")
+  let (root, source_map) = parse_fixture("let x = 1\nlet y = x\nx + y")
   let projection = build_semantic_projection(root, source_map)
   assert_true(has_annotation(projection, root.children[0].id(), "let x"))
   assert_true(has_annotation(projection, root.children[1].id(), "let y"))

--- a/lang/runtime/README.md
+++ b/lang/runtime/README.md
@@ -27,11 +27,12 @@ capturing instance memos) are passed to `new_editor`, not stored in the spec.
 
 What the SPI excludes — deliberately: editor-coupled edit application.
 `lang/lambda/companion` keeps its own bridge (`apply_lambda_tree_edit`)
-because its compute context needs `registry` + `module_projection`, its
-error channel is the typed `TreeEditError` with a `SpanEdit` patch-trace
-return, and `Drop` delegates to `editor.move_node`. See the Step 4
-amendment in `docs/plans/2026-06-11-s3-lang-runtime-extraction.md` for the
-decision record and the revisit trigger.
+because its compute context needs the current projection registry plus a
+`DefinitionIndex` derived from the generic `ProjNode` root, its error channel is
+the typed `TreeEditError` with a `SpanEdit` patch-trace return, and `Drop`
+delegates to `editor.move_node`. See the Step 4 amendment in
+`docs/plans/2026-06-11-s3-lang-runtime-extraction.md` for the decision record
+and the revisit trigger.
 
 Dispatch cost: benchmarked free (S3 gate,
 `lang/json/companion/dispatch_benchmark.mbt`) — capability-record indirection


### PR DESCRIPTION
## Summary

- Remove the stale Lambda semantic `ModuleProjection` compatibility adapter and move semantic tests onto the generic `ProjNode` fixture.
- Rename the projection-missing typed error from `ModuleProjectionUnavailable` to `ProjectionUnavailable` while preserving the existing typed error path.
- Shrink the public Lambda `ModuleProjection` API to legacy/test-facing helpers, keeping root-module reconciliation internal, and update runtime/add-language/#623 docs.

Closes #661.
Refs #662.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `build_semantic_projection` | `lang/lambda/semantic/semantic_projection.mbt` | Yes | Replaces the ignored `ModuleProjection?` semantic adapter. |
| `SyncEditor::get_proj_node` | `editor/sync_editor.mbt` | Yes | Existing generic projection accessor used for Lambda edit context. |
| `DefinitionIndex::from_proj_node` | `lang/lambda/proj/definition_index.mbt` | Yes | Existing production path for deriving edit definition context from `ProjNode`. |
| `@core.build_projection_memos` | `core` / used by `lang/lambda/proj/projection_memo.mbt` | Yes | Existing generic 3-memo stack remains the editor-facing projection pipeline. |

New helpers added (if any):

- None.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check --deny-warn` passes
- [x] Targeted Lambda/editor tests pass
- [x] `git diff -- '*.mbti'` reviewed for intended API surface changes
- [ ] Full `NEW_MOON_MOD=0 moon test` not run; targeted suite below covers the changed packages
- [ ] JS rebuild not run; web artifacts are not affected

## Validation

```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/companion lang/lambda/edits lang/lambda/semantic ffi/lambda editor
NEW_MOON_MOD=0 moon test lang/lambda/proj
NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
git diff --check
bash scripts/check-agent-doc-links.sh
```

Review: `moonbit-reviewer` and local code-review found no high-confidence issues.
