### PR TITLE
refactor(edits): add EditContext::resolve to collapse node-lookup prologues

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -167,9 +167,9 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 - [x] Add an `EditContext` node-resolution helper (`lang/lambda/edits/text_edit.mbt`). (finding C from PR #383)
   Why: nearly every `compute_*` handler opens with the same pair of guards keyed on one `node_id` — `registry.get(id)` then `source_map.get_range(id)`, both erroring "Node not found" — made visible by the PR #383 guard sweep. `EditContext` already holds both maps.
-  Shipped: `EditContext::resolve[T](self, node_id) -> Result[(ProjNode[T], @loomcore.Range), String]` added to `text_edit.mbt`; 13 handler prologues across 6 files (commit, delete, drop, structural×3, wrap×4, refactor×2) collapsed to single `resolve()` call; error messages standardised to "Node not found: {id}"; body-level redundant `registry.get` fallbacks in `compute_delete` eliminated.
+  Shipped: `EditContext::resolve[T](self, node_id) -> (ProjNode[T], @loomcore.Range) raise ResolveError` added to `text_edit.mbt`; 13 handler prologues across 6 files (commit, delete, drop, structural×3, wrap×4, refactor×2) collapsed to single `resolve()` call; error messages standardised to "Node not found: {id}"; body-level redundant `registry.get` fallbacks in `compute_delete` eliminated. Note: `ResolveError` is a zero-info bridge type (tracked in #667 for cleanup alongside finding D).
 
-- [ ] Evaluate moving the edit layer from `Result[_, String]` to a `raise EditError` model (`lang/lambda/edits`). (finding D from PR #383)
+- [ ] Evaluate moving the edit layer from `Result[_, String]` to a `raise EditError` model (`lang/lambda/edits`). (finding D from PR #383, #667)
   Why: the `match x { Ok(v) => v; Err(e) => return Err(e) }` passthroughs left in PR #383 exist only because MoonBit has no `?`-propagation for plain `Result`. A raising error model would auto-propagate them away and let the Some/None guards sit on raising accessors. Larger design call — touches `EditResult` and error-type design; see the `moonbit-error-handling` skill.
   Exit: decision recorded (adopt or keep `Result`) with rationale; if adopted, passthroughs removed and `EditResult` retyped.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -165,9 +165,9 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 - [x] Hoist ProjNode id-allocation boilerplate into `@core` (`core/proj_node.mbt`). (finding B from PR #383)
   Shipped (#437): `@core` exposes `ProjNode::leaf[T](kind, node : @seam.SyntaxNode, counter)` and `ProjNode::branch[T](kind, start, end, children, counter)`. Lambda/JSON/Markdown projection builders now use the shared helpers for fresh syntax leaves/branches; ID-preserving sites keep raw `ProjNode::new`. `.mbti` change is limited to the two new `@core` exports.
 
-- [ ] Add an `EditContext` node-resolution helper (`lang/lambda/edits/text_edit.mbt`). (finding C from PR #383)
+- [x] Add an `EditContext` node-resolution helper (`lang/lambda/edits/text_edit.mbt`). (finding C from PR #383)
   Why: nearly every `compute_*` handler opens with the same pair of guards keyed on one `node_id` — `registry.get(id)` then `source_map.get_range(id)`, both erroring "Node not found" — made visible by the PR #383 guard sweep. `EditContext` already holds both maps.
-  Exit: `EditContext::resolve(self, node_id) -> Result[(ProjNode[T], Range), String]` (or `require_node` / `require_range`); the ~10 handler prologues collapse to one call; behavior and error messages preserved.
+  Shipped: `EditContext::resolve[T](self, node_id) -> Result[(ProjNode[T], @loomcore.Range), String]` added to `text_edit.mbt`; 13 handler prologues across 6 files (commit, delete, drop, structural×3, wrap×4, refactor×2) collapsed to single `resolve()` call; error messages standardised to "Node not found: {id}"; body-level redundant `registry.get` fallbacks in `compute_delete` eliminated.
 
 - [ ] Evaluate moving the edit layer from `Result[_, String]` to a `raise EditError` model (`lang/lambda/edits`). (finding D from PR #383)
   Why: the `match x { Ok(v) => v; Err(e) => return Err(e) }` passthroughs left in PR #383 exist only because MoonBit has no `?`-propagation for plain `Result`. A raising error model would auto-propagate them away and let the Some/None guards sit on raising accessors. Larger design call — touches `EditResult` and error-type design; see the `moonbit-error-handling` skill.

--- a/lang/lambda/edits/text_edit.mbt
+++ b/lang/lambda/edits/text_edit.mbt
@@ -15,6 +15,22 @@ pub(all) struct EditContext[T] {
 pub type EditResult = Result[(Array[SpanEdit], FocusHint)?, String]
 
 ///|
+/// Look up both the projection node and its source range for a given node_id.
+/// Returns Err("Node not found: {id}") if either lookup fails.
+fn[T] EditContext::resolve(
+  self : EditContext[T],
+  node_id : NodeId,
+) -> Result[(ProjNode[T], @loomcore.Range), String] {
+  guard self.source_map.get_range(node_id) is Some(range) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  guard self.registry.get(node_id) is Some(node) else {
+    return Err("Node not found: " + node_id.to_string())
+  }
+  Ok((node, range))
+}
+
+///|
 /// Translate a TreeEditOp into text span edits.
 /// Passes through ValidateNodeExists middleware before core dispatch.
 pub fn compute_text_edit(

--- a/lang/lambda/edits/text_edit.mbt
+++ b/lang/lambda/edits/text_edit.mbt
@@ -15,19 +15,24 @@ pub(all) struct EditContext[T] {
 pub type EditResult = Result[(Array[SpanEdit], FocusHint)?, String]
 
 ///|
+priv suberror ResolveError {
+  ResolveError(String)
+}
+
+///|
 /// Look up both the projection node and its source range for a given node_id.
-/// Returns Err("Node not found: {id}") if either lookup fails.
+/// Raises ResolveError("Node not found: {id}") if either lookup fails.
 fn[T] EditContext::resolve(
   self : EditContext[T],
   node_id : NodeId,
-) -> Result[(ProjNode[T], @loomcore.Range), String] {
+) -> (ProjNode[T], @loomcore.Range) raise ResolveError {
   guard self.source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
+    raise ResolveError("Node not found: " + node_id.to_string())
   }
   guard self.registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+    raise ResolveError("Node not found: " + node_id.to_string())
   }
-  Ok((node, range))
+  (node, range)
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_commit.mbt
+++ b/lang/lambda/edits/text_edit_commit.mbt
@@ -4,9 +4,8 @@ fn compute_commit(
   node_id : NodeId,
   new_value : String,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_commit.mbt
+++ b/lang/lambda/edits/text_edit_commit.mbt
@@ -4,11 +4,9 @@ fn compute_commit(
   node_id : NodeId,
   new_value : String,
 ) -> EditResult {
-  guard ctx.source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard ctx.registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_delete.mbt
+++ b/lang/lambda/edits/text_edit_delete.mbt
@@ -28,16 +28,14 @@ fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult 
           let target = parent_node.children[child_index]
           let pk = placeholder_term_for_kind(target.kind)
           // Build new children array with placeholder at child_index
-          let new_children : Array[ProjNode[@ast.Term]] = []
-          for i, c in parent_node.children {
+          let new_children = Array::makei(parent_node.children.length(), fn(i) {
+            let c = parent_node.children[i]
             if i == child_index {
-              new_children.push(
-                ProjNode::new(pk, c.start, c.end, c.node_id, []),
-              )
+              ProjNode::new(pk, c.start, c.end, c.node_id, [])
             } else {
-              new_children.push(c)
+              c
             }
-          }
+          })
           let new_parent_kind = rebuild_kind(parent_node.kind, new_children)
           let new_text = @ast.print_term(new_parent_kind)
           match ctx.source_map.get_range(parent_id) {

--- a/lang/lambda/edits/text_edit_delete.mbt
+++ b/lang/lambda/edits/text_edit_delete.mbt
@@ -1,8 +1,7 @@
 ///|
 fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match find_parent(ctx.registry, node_id) {
     Some((parent_id, parent_node, child_index)) =>

--- a/lang/lambda/edits/text_edit_delete.mbt
+++ b/lang/lambda/edits/text_edit_delete.mbt
@@ -1,10 +1,10 @@
 ///|
 fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
-  match find_parent(registry, node_id) {
+  match find_parent(ctx.registry, node_id) {
     Some((parent_id, parent_node, child_index)) =>
       match parent_node.kind {
         @ast.Term::Error(_) =>
@@ -40,13 +40,10 @@ fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult 
           }
           let new_parent_kind = rebuild_kind(parent_node.kind, new_children)
           let new_text = @ast.print_term(new_parent_kind)
-          match source_map.get_range(parent_id) {
+          match ctx.source_map.get_range(parent_id) {
             None => {
               // No parent range — fall back to simple placeholder
-              let placeholder = match registry.get(node_id) {
-                Some(node) => placeholder_text_for_kind(node.kind)
-                None => "a"
-              }
+              let placeholder = placeholder_text_for_kind(node.kind)
               Ok(
                 Some(
                   (
@@ -112,10 +109,7 @@ fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult 
       }
     None => {
       // No parent found — this is the root node. Just use placeholder.
-      let placeholder = match registry.get(node_id) {
-        Some(node) => placeholder_text_for_kind(node.kind)
-        None => "a"
-      }
+      let placeholder = placeholder_text_for_kind(node.kind)
       Ok(
         Some(
           (

--- a/lang/lambda/edits/text_edit_drop.mbt
+++ b/lang/lambda/edits/text_edit_drop.mbt
@@ -8,13 +8,11 @@ fn compute_drop(
   // Legality: self-drop
   guard source != target else { return Err("Cannot drop onto self") }
   let { source_text, .. } = ctx
-  let (source_node, source_range) = match ctx.resolve(source) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (source_node, source_range) = ctx.resolve(source) catch {
+    ResolveError(e) => return Err(e)
   }
-  let (target_node, target_range) = match ctx.resolve(target) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (target_node, target_range) = ctx.resolve(target) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, source, source_node, source_range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_drop.mbt
+++ b/lang/lambda/edits/text_edit_drop.mbt
@@ -7,18 +7,14 @@ fn compute_drop(
 ) -> EditResult {
   // Legality: self-drop
   guard source != target else { return Err("Cannot drop onto self") }
-  let { source_text, source_map, .. } = ctx
-  guard source_map.get_range(source) is Some(source_range) else {
-    return Err("Source node not found")
+  let { source_text, .. } = ctx
+  let (source_node, source_range) = match ctx.resolve(source) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
-  guard source_map.get_range(target) is Some(target_range) else {
-    return Err("Target node not found")
-  }
-  guard ctx.registry.get(source) is Some(source_node) else {
-    return Err("Source node not found")
-  }
-  guard ctx.registry.get(target) is Some(target_node) else {
-    return Err("Target node not found")
+  let (target_node, target_range) = match ctx.resolve(target) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, source, source_node, source_range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -220,9 +220,9 @@ fn compute_inline_all_usages(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, registry, .. } = ctx
+  let { source_text, .. } = ctx
   // Find all references resolved to this binding.
-  let g = @scope.build(registry, source_map)
+  let g = @scope.build(ctx.registry, ctx.source_map)
   let decl = match module_def_decl_for_binding(g, binding_node_id) {
     Ok(decl) => decl
     Err(e) => return Err(e)
@@ -245,7 +245,7 @@ fn compute_inline_all_usages(
   let init_text = if ref_ids.is_empty() {
     ""
   } else {
-    match binding_inline_text(source_text, source_map, def) {
+    match binding_inline_text(source_text, ctx.source_map, def) {
       Ok(text) => text
       Err(e) => return Err(e)
     }
@@ -255,7 +255,7 @@ fn compute_inline_all_usages(
   // Collect reference ranges, sorted by position (descending)
   let ref_ranges : Array[(Int, Int)] = []
   for rid in ref_ids {
-    if source_map.get_range(rid) is Some(r) {
+    if ctx.source_map.get_range(rid) is Some(r) {
       ref_ranges.push((r.start, r.end))
     }
   }
@@ -265,7 +265,7 @@ fn compute_inline_all_usages(
   }
   // Delete the binding
   let (let_start, binding_end) = match
-    get_binding_text_range(source_text, source_map, def) {
+    get_binding_text_range(source_text, ctx.source_map, def) {
     Ok(r) => r
     Err(e) => return Err(e)
   }

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -4,17 +4,16 @@ fn compute_extract_to_let(
   node_id : NodeId,
   var_name : String,
 ) -> EditResult {
-  let { source_text, source_map, registry, definition_index } = ctx
+  let { source_text, definition_index, .. } = ctx
   let module_view = edit_module_view(ctx)
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
     Ok(_) => ()
   }
-  let g = @scope.build(registry, source_map)
+  let g = @scope.build(ctx.registry, ctx.source_map)
   let fv = free_vars(node.kind, @immut/hashset.new())
   let would_capture = if module_view.defs.is_empty() {
     free_names_captured_at_use_sites(g, node, fv)
@@ -48,7 +47,7 @@ fn compute_extract_to_let(
     // Has Module — insert let before body, replace expr with var_name
     let body_start = match module_view.final_expr {
       Some(body) =>
-        match source_map.get_range(body.id()) {
+        match ctx.source_map.get_range(body.id()) {
           Some(r) => r.start
           None => source_text.length()
         }
@@ -62,7 +61,7 @@ fn compute_extract_to_let(
       //   "let var = expr\n" + (prefix before node) + var_name + (suffix after node)
       let body_end = match module_view.final_expr {
         Some(body) =>
-          match source_map.get_range(body.id()) {
+          match ctx.source_map.get_range(body.id()) {
             Some(r) => r.end
             None => source_text.length()
           }
@@ -113,16 +112,15 @@ fn compute_inline_definition(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let { source_text, source_map, registry, .. } = ctx
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let { source_text, .. } = ctx
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   guard node.kind is @ast.Term::Var(var_name) else {
     return Err("InlineDefinition requires a Var node")
   }
   // Resolve the binding
-  let g = @scope.build(registry, source_map)
+  let g = @scope.build(ctx.registry, ctx.source_map)
   guard @scope.declaration(g, node_id) is Some(decl) else {
     return Err("No binding found for variable: " + var_name)
   }
@@ -134,7 +132,8 @@ fn compute_inline_definition(
         Ok(def) => def
         Err(e) => return Err(e)
       }
-      let init_text = match binding_inline_text(source_text, source_map, def) {
+      let init_text = match
+        binding_inline_text(source_text, ctx.source_map, def) {
         Ok(text) => text
         Err(e) => return Err(e)
       }
@@ -150,7 +149,7 @@ fn compute_inline_definition(
       if refs.length() <= 1 {
         // Sole usage — inline and delete the binding
         let (let_start, binding_end) = match
-          get_binding_text_range(source_text, source_map, def) {
+          get_binding_text_range(source_text, ctx.source_map, def) {
           Ok(r) => r
           Err(e) => return Err(e)
         }

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -6,11 +6,9 @@ fn compute_extract_to_let(
 ) -> EditResult {
   let { source_text, source_map, registry, definition_index } = ctx
   let module_view = edit_module_view(ctx)
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found")
-  }
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Range not found")
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -116,14 +114,12 @@ fn compute_inline_definition(
   node_id : NodeId,
 ) -> EditResult {
   let { source_text, source_map, registry, .. } = ctx
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   guard node.kind is @ast.Term::Var(var_name) else {
     return Err("InlineDefinition requires a Var node")
-  }
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Var not in source map")
   }
   // Resolve the binding
   let g = @scope.build(registry, source_map)

--- a/lang/lambda/edits/text_edit_structural.mbt
+++ b/lang/lambda/edits/text_edit_structural.mbt
@@ -4,12 +4,9 @@ fn compute_unwrap(
   node_id : NodeId,
   keep_child_index : Int,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -44,12 +41,9 @@ fn compute_swap_children(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -100,12 +94,9 @@ fn compute_change_operator(
   node_id : NodeId,
   new_op : @ast.Bop,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_structural.mbt
+++ b/lang/lambda/edits/text_edit_structural.mbt
@@ -4,9 +4,8 @@ fn compute_unwrap(
   node_id : NodeId,
   keep_child_index : Int,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -41,9 +40,8 @@ fn compute_swap_children(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -94,9 +92,8 @@ fn compute_change_operator(
   node_id : NodeId,
   new_op : @ast.Bop,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_wrap.mbt
+++ b/lang/lambda/edits/text_edit_wrap.mbt
@@ -4,9 +4,8 @@ fn compute_wrap_lambda(
   node_id : NodeId,
   var_name : String,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -38,9 +37,8 @@ fn compute_wrap_app(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -68,9 +66,8 @@ fn compute_wrap_if(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -101,9 +98,8 @@ fn compute_wrap_bop(
   node_id : NodeId,
   op : @ast.Bop,
 ) -> EditResult {
-  let (node, range) = match ctx.resolve(node_id) {
-    Ok(r) => r
-    Err(e) => return Err(e)
+  let (node, range) = ctx.resolve(node_id) catch {
+    ResolveError(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)

--- a/lang/lambda/edits/text_edit_wrap.mbt
+++ b/lang/lambda/edits/text_edit_wrap.mbt
@@ -4,19 +4,16 @@ fn compute_wrap_lambda(
   node_id : NodeId,
   var_name : String,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found in registry")
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
     Ok(_) => ()
   }
   let wrapped = @ast.print_term(@ast.Term::Lam(var_name, node.kind))
-  let wrapped = match find_parent(registry, node_id) {
+  let wrapped = match find_parent(ctx.registry, node_id) {
     Some(_) => "(" + wrapped + ")"
     None => wrapped
   }
@@ -41,12 +38,9 @@ fn compute_wrap_app(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found in registry")
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -74,12 +68,9 @@ fn compute_wrap_if(
   ctx : EditContext[@ast.Term],
   node_id : NodeId,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)
@@ -110,12 +101,9 @@ fn compute_wrap_bop(
   node_id : NodeId,
   op : @ast.Bop,
 ) -> EditResult {
-  let { source_map, registry, .. } = ctx
-  guard source_map.get_range(node_id) is Some(range) else {
-    return Err("Node not found: " + node_id.to_string())
-  }
-  guard registry.get(node_id) is Some(node) else {
-    return Err("Node not found: " + node_id.to_string())
+  let (node, range) = match ctx.resolve(node_id) {
+    Ok(r) => r
+    Err(e) => return Err(e)
   }
   match ensure_replaceable_node_range(ctx, node_id, node, range) {
     Err(e) => return Err(e)


### PR DESCRIPTION
## Summary

- Adds `fn[T] EditContext::resolve(self, node_id) -> (ProjNode[T], @loomcore.Range) raise ResolveError` to `text_edit.mbt` — collapses the repeated two-guard prologue (`source_map.get_range` + `registry.get`, both failing `"Node not found: {id}"`) that appeared in every `compute_*` handler. Closes docs/TODO.md §7 (finding C from PR #383).
- Migrates 13 handler prologues across 6 files: `compute_commit`, `compute_unwrap`, `compute_swap_children`, `compute_change_operator`, `compute_wrap_{lambda,app,if,bop}`, `compute_delete`, `compute_drop`, `compute_extract_to_let`, `compute_inline_definition`. Standardises all error messages to include the node id. Also eliminates two body-level redundant `registry.get` fallbacks in `compute_delete` (node guaranteed by `resolve`).
- Replaces the `new_children` push-loop in `compute_delete` with `Array::makei` — the transform is index-based with no inter-iteration dependency.
- Drops redundant `source_map`/`registry` destructures from `compute_extract_to_let` and `compute_inline_definition`; access goes through `ctx.source_map`/`ctx.registry` to match the resolved node.
- Aligns `compute_inline_all_usages` with migrated siblings (consistent `ctx.source_map`/`ctx.registry` access).

**Known limitation:** `ResolveError` is a zero-information bridge type — both guard arms emit the same string and every call site immediately unwraps it back to `String`. Tracked for cleanup alongside the `EditError` migration in #667.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `EditContext::resolve` | `text_edit.mbt` (new) | new helper | No prior equivalent existed; this PR adds it |
| `Array::makei` | `moonbitlang/core/array` | ✓ reused | Replaces push-loop in `compute_delete` |

New helpers added:

- `EditContext::resolve[T](self, node_id) -> (ProjNode[T], @loomcore.Range) raise ResolveError` — private to the `lang/lambda/edits` package. Pairs the two maps already on `EditContext` into a single raising lookup. No existing API covered this.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes (177/177, 0 count delta)
- [x] `git diff *.mbti` reviewed — no public API surface changes (`resolve` is package-private)
- [x] JS not affected (no FFI or web layer touched)

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test -p lang/lambda/edits
```
