### PR TITLE
test(lambda): classify ModuleProjection test coverage

### DIFF
--- a/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
+++ b/lang/lambda/edits/scope_cross_pipeline_pbt_wbtest.mbt
@@ -1,12 +1,12 @@
 // Cross-pipeline resolution-equivalence property test (docs/TODO.md §20).
 //
 // WHAT THIS PINS
-// Two pipelines build a `ModuleProjection` from the same source, then a scope graph
-// resolves each Var reference to a declaration. Both pipelines assign a module
-// def's binder id (`defs[i].3`) to a real LetDef node:
-//   - TEST path (`graph_and_sm_of` / `from_proj_node`): extracts the id from the
-//     parsed LetDef child;
-//   - legacy ModuleProjection path (`production_graph_of` /
+// Two pipelines build a scope graph from the same source, then resolve each
+// Var reference to a declaration. Both pipelines assign a module def's binder
+// id to a real LetDef node:
+//   - generic test path (`graph_and_sm_of`): uses the direct SyntaxNode →
+//     ProjNode tree and its parsed LetDef children;
+//   - legacy ModuleProjection path (`legacy_module_projection_graph_of` /
 //     `to_module_projection`): stores the id in ModuleProjection and
 //     reconstructs the LetDef child from it.
 // Resolution never reads `node_id` (`Builder::resolve` matches name + def_index
@@ -34,9 +34,9 @@
 // def, a different lambda, or to free) into a match.
 //
 // SCOPE / NON-GOALS
-// This is a pure test-path-vs-legacy-ModuleProjection-path equivalence over a
-// single parse. It does NOT exercise `to_module_projection_incremental` or the
-// editor-facing generic `@incr` memo layer. It also
+// This is a pure generic-ProjNode-vs-legacy-ModuleProjection-path equivalence
+// over a single parse. It does NOT exercise `to_module_projection_incremental`
+// or the editor-facing generic `@incr` memo layer. It also
 // cannot catch a bug shared by both pipelines inside `@scope.build`; the frozen
 // hand-derived oracle in `scope_equivalence_wbtest.mbt` covers that blind spot
 // and is intentionally retained alongside this generator.
@@ -79,7 +79,7 @@ fn assert_same_var_refs(
   }
   for k, _ in m1 {
     guard m2.get(k) is Some(_) else {
-      fail("Var ref \{k} present in test pipeline but missing in production")
+      fail("Var ref \{k} present in left pipeline but missing on right")
     }
   }
 }
@@ -104,11 +104,11 @@ fn assert_lam_ranges_unique(
 }
 
 ///|
-/// Source ranges of a Module's def inits, indexed by def_index. Both pipelines
-/// reconstruct the Module with the def inits as its first N children (in def
-/// order), built from the same `syntax_to_proj_node`, so this array is
-/// pipeline-independent. Empty for a non-Module root (no module defs exist).
-fn def_init_ranges(root : ProjNode[@ast.Term]) -> Array[String] {
+/// Source ranges of a Module's LetDef binding rows, indexed by def_index. Both
+/// pipelines reconstruct the Module with those LetDef nodes as its first N
+/// children (in def order), so this array is pipeline-independent. Empty for a
+/// non-Module root (no module defs exist).
+fn def_binding_ranges(root : ProjNode[@ast.Term]) -> Array[String] {
   match root.kind {
     Module(term_defs, _) =>
       [
@@ -122,8 +122,8 @@ fn def_init_ranges(root : ProjNode[@ast.Term]) -> Array[String] {
 
 ///|
 /// Reduce a resolved declaration to a pipeline-independent key. Module decls
-/// use (def_index, name, init source range); lambda decls use the binder Lam
-/// node's source range (looked up in THAT pipeline's own registry) plus the
+/// use (def_index, name, LetDef row source range); lambda decls use the binder
+/// Lam node's source range (looked up in THAT pipeline's own registry) plus the
 /// name. Both kinds key on a SOURCE RANGE, not a node id or a bare index, so a
 /// future pipeline divergence that re-indexed defs (same def_index → different
 /// source def with a coincidentally equal name) cannot collapse a real
@@ -132,17 +132,17 @@ fn def_init_ranges(root : ProjNode[@ast.Term]) -> Array[String] {
 fn normalize_decl(
   decl : @scope.Decl?,
   registry : Map[NodeId, ProjNode[@ast.Term]],
-  init_ranges : Array[String],
+  def_ranges : Array[String],
 ) -> String raise {
   match decl {
     None => "free"
     Some(d) =>
       match d.kind {
         ModuleDef(def_index~) => {
-          guard def_index >= 0 && def_index < init_ranges.length() else {
+          guard def_index >= 0 && def_index < def_ranges.length() else {
             fail("ModuleDef def_index \{def_index} out of range")
           }
-          "module:\{def_index}:\{d.name}:\{init_ranges[def_index]}"
+          "module:\{def_index}:\{d.name}:\{def_ranges[def_index]}"
         }
         LamParam(lam_id~) => {
           guard registry.get(lam_id) is Some(n) else {
@@ -240,13 +240,13 @@ fn check_agreement(text : String, expect_clean? : Bool = true) -> Unit raise {
       fail("expected clean parse but got \{diags.length()} diagnostic(s)")
     }
   }
-  // Pipeline 1: test path (from_proj_node), with token spans for binder_span.
-  let (proj1, _fp1, g1, sm1) = graph_and_sm_of(text)
+  // Pipeline 1: generic ProjNode path, with token spans for binder_span.
+  let (proj1, g1, sm1) = graph_and_sm_of(text)
   let reg1 = scope_test_registry(proj1)
-  let ranges1 = def_init_ranges(proj1)
+  let ranges1 = def_binding_ranges(proj1)
   // Pipeline 2: legacy ModuleProjection path (to_module_projection), with token spans.
-  let (proj2, reg2, g2, sm2) = production_graph_of(text)
-  let ranges2 = def_init_ranges(proj2)
+  let (proj2, reg2, g2, sm2) = legacy_module_projection_graph_of(text)
+  let ranges2 = def_binding_ranges(proj2)
   assert_resolution_agrees(
     ResolutionSide(
       graph=g1,
@@ -261,8 +261,8 @@ fn check_agreement(text : String, expect_clean? : Bool = true) -> Unit raise {
       registry=reg2,
       source_map=sm2,
       ranges=ranges2,
-      value_label="production",
-      binder_label="production",
+      value_label="legacy",
+      binder_label="legacy ModuleProjection",
     ),
     context_prefix="",
     binder_span_disagreement="binder location disagrees across pipelines",
@@ -398,14 +398,15 @@ test "cross-pipeline: fixed sanity case agrees" {
 }
 
 ///|
-/// Generated well-formed sources must resolve identically across both
-/// `ModuleProjection` construction pipelines (docs/TODO.md §20). The cross-pipeline
-/// property is near-tautological (resolution ignores `node_id`; both pipelines
-/// build defs from the same syntax in the same order), so a few hundred cases
+/// Generated well-formed sources must resolve identically across both generic
+/// ProjNode and legacy ModuleProjection construction pipelines (docs/TODO.md
+/// §20). The cross-pipeline property is near-tautological (resolution ignores
+/// `node_id`; both pipelines build defs from the same syntax in the same order),
+/// so a few hundred cases
 /// give the same confidence as thousands — `max_success` is sized for CI cost,
 /// not coverage. The edge-set fixtures above carry the structurally tricky
 /// cases that random generation is unlikely to hit.
-test "property: resolution agrees across both ModuleProjection pipelines" {
+test "property: resolution agrees across generic and legacy ModuleProjection pipelines" {
   @qc.quick_check_fn_error(
     fn(gs : GenSource) -> Unit raise { check_agreement(@ast.print_term(gs.0)) },
     max_success=300,

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -29,19 +29,15 @@ fn find_var(root : @core.ProjNode[@ast.Term], name : String) -> NodeId {
 }
 
 ///|
-/// Build a scope graph for a source string and return the parsed root, its
-/// flat projection, and the graph. (The ModuleProjection is the structural source of
-/// truth for module binder identities — it is built independently of the
-/// `declaration` query under test.)
+/// Build the generic ProjNode/registry/SourceMap scope path for a source
+/// string and return the parsed root plus graph. Module binder identity comes
+/// from the LetDef nodes in the ProjNode tree; the legacy ModuleProjection
+/// reconstruction path is pinned separately below.
 fn graph_of(
   text : String,
-) -> (
-  @core.ProjNode[@ast.Term],
-  @lambda_proj.ModuleProjection,
-  @scope.ScopeGraph,
-) raise {
-  let (proj, fp, g, _sm) = graph_and_sm_of(text)
-  (proj, fp, g)
+) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph) raise {
+  let (proj, g, _sm) = graph_and_sm_of(text)
+  (proj, g)
 }
 
 ///|
@@ -51,21 +47,15 @@ fn graph_of(
 /// a syntax tree to walk.
 fn graph_and_sm_of(
   text : String,
-) -> (
-  @core.ProjNode[@ast.Term],
-  @lambda_proj.ModuleProjection,
-  @scope.ScopeGraph,
-  SourceMap,
-) raise {
+) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph, SourceMap) raise {
   let (cst, _errs) = @parser.parse_cst(text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = to_proj_node(syntax, Ref(0))
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let sm = SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax, proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(registry, sm)
-  (proj, fp, g, sm)
+  (proj, g, sm)
 }
 
 // The following tests certify that `@scope.declaration` resolves each lambda
@@ -78,18 +68,17 @@ fn graph_and_sm_of(
 //
 // Binder-identity asymmetry: for LAMBDA cases the resolved `decl.node_id` is
 // checked against the Lam node located STRUCTURALLY in the tree (`proj.id()` /
-// `proj.children[..]`), independent of the ModuleProjection — a genuine non-circular
-// check (case 6 distinguishes inner vs outer). For MODULE cases identity is
-// carried by `def_index` alone: these fixtures build the ModuleProjection via
-// `from_proj_node`, where `decl.node_id == fp.defs[def_index].3` holds by
-// construction, so re-asserting it would be tautological. The legacy
-// ModuleProjection meaning of a module binder id is pinned separately by the
-// `to_module_projection` contract test at the bottom of this file.
+// `proj.children[..]`) — a genuine non-circular check (case 6 distinguishes
+// inner vs outer). For MODULE cases identity is carried by `def_index` alone;
+// re-asserting the LetDef node id would merely restate how this generic
+// ProjNode fixture builds the tree. The legacy ModuleProjection meaning of a
+// module binder id is pinned separately by the `to_module_projection` contract
+// test at the bottom of this file.
 
 ///|
 test "declaration() resolves a Var to its enclosing Lam param" {
   // (x) => x — the body Var binds to the lambda parameter (the Lam node itself).
-  let (proj, _fp, g) = graph_of("(x) => x")
+  let (proj, g) = graph_of("(x) => x")
   let ref_id = proj.children[0].id() // body Var x
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -103,7 +92,7 @@ test "declaration() resolves a Var to its enclosing Lam param" {
 ///|
 test "declaration() resolves a body Var to its module def" {
   // let x = 0\nx — the body Var binds to def 0.
-  let (proj, _fp, g) = graph_of("let x = 0\nx")
+  let (proj, g) = graph_of("let x = 0\nx")
   let ref_id = find_var(proj, "x") // body Var (init is Int 0, no Var)
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -117,7 +106,7 @@ test "declaration() resolves a body Var to its module def" {
 test "declaration() leaves a self-referential def init unbound" {
   // let x = x\nx — the first Var (the init `x`) cannot see def 0 from inside
   // def 0 (cutoff = 0), so it is free.
-  let (proj, _fp, g) = graph_of("let x = x\nx")
+  let (proj, g) = graph_of("let x = x\nx")
   let ref_id = find_var(proj, "x") // first Var = def 0's init
   inspect(@scope.declaration(g, ref_id) is None, content="true")
 }
@@ -125,7 +114,7 @@ test "declaration() leaves a self-referential def init unbound" {
 ///|
 test "declaration() picks the latest shadowing module def" {
   // let x = 1\nlet x = 2\nx — the body Var binds to the LATER def (index 1).
-  let (proj, _fp, g) = graph_of("let x = 1\nlet x = 2\nx")
+  let (proj, g) = graph_of("let x = 1\nlet x = 2\nx")
   let ref_id = find_var(proj, "x") // body Var (both inits are Ints)
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -139,7 +128,7 @@ test "declaration() picks the latest shadowing module def" {
 test "declaration() does not let an earlier def see a later one" {
   // let a = b\nlet b = 1\na — `b` in def 0's init cannot see def 1 (cutoff = 0),
   // so it is free.
-  let (proj, _fp, g) = graph_of("let a = b\nlet b = 1\na")
+  let (proj, g) = graph_of("let a = b\nlet b = 1\na")
   let ref_id = find_var(proj, "b") // the `b` in `a = b`
   inspect(@scope.declaration(g, ref_id) is None, content="true")
 }
@@ -147,7 +136,7 @@ test "declaration() does not let an earlier def see a later one" {
 ///|
 test "declaration() resolves to the nearest enclosing Lam under shadowing" {
   // (x) => (x) => x — the innermost Var binds to the INNER lambda param.
-  let (proj, _fp, g) = graph_of("(x) => (x) => x")
+  let (proj, g) = graph_of("(x) => (x) => x")
   let ref_id = find_var(proj, "x") // the single (innermost) Var
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -162,7 +151,7 @@ test "declaration() resolves to the nearest enclosing Lam under shadowing" {
 test "declaration() lets a Lam param shadow a same-name module def" {
   // let x = 0\n(x) => x — the Var inside the lambda binds to the lambda param,
   // NOT the module def.
-  let (proj, _fp, g) = graph_of("let x = 0\n(x) => x")
+  let (proj, g) = graph_of("let x = 0\n(x) => x")
   let ref_id = find_var(proj, "x") // Var inside the body Lam
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -178,7 +167,7 @@ test "declaration() lets a Lam param shadow a same-name module def" {
 test "declaration() resolves a later def's init to an earlier same-name def" {
   // let x = 1\nlet x = x\nx — the init Var of def 1 binds to def 0 (cutoff = 1
   // excludes def 1 itself), not to itself.
-  let (proj, _fp, g) = graph_of("let x = 1\nlet x = x\nx")
+  let (proj, g) = graph_of("let x = 1\nlet x = x\nx")
   let ref_id = find_var(proj, "x") // first Var = def 1's init `x`
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")
@@ -190,11 +179,12 @@ test "declaration() resolves a later def's init to an earlier same-name def" {
 
 ///|
 /// Build a scope graph through the legacy ModuleProjection pipeline —
-/// `to_module_projection` rather than `from_proj_node` (used by `graph_of`
-/// above). Both paths assign module binder ids to real LetDef nodes; this
-/// fixture keeps the flat-entry reconstruction path covered after the live
-/// editor-facing memos moved to the generic 3-memo path.
-fn production_graph_of(
+/// `to_module_projection` followed by `to_proj_node`, rather than the direct
+/// SyntaxNode → ProjNode path used by `graph_of` above. Both paths assign
+/// module binder ids to real LetDef nodes; this fixture keeps the flat-entry
+/// reconstruction path covered after the live editor-facing memos moved to the
+/// generic 3-memo path.
+fn legacy_module_projection_graph_of(
   text : String,
 ) -> (
   @core.ProjNode[@ast.Term],
@@ -229,8 +219,10 @@ fn production_graph_of(
 /// (with the module `"name:<def_index>"` fallback during migration), not the
 /// full node range. The companion assertion that this location is
 /// pipeline-independent lives in the cross-pipeline PBT.
-test "ModuleProjection path: module binder located via binder_span (Option D, supersedes §20 gap)" {
-  let (proj, registry, g, sm) = production_graph_of("let x = 0\nx")
+test "legacy ModuleProjection path: module binder located via binder_span (Option D, supersedes §20 gap)" {
+  let (proj, registry, g, sm) = legacy_module_projection_graph_of(
+    "let x = 0\nx",
+  )
   let ref_id = find_var(proj, "x") // body Var x
   guard @scope.declaration(g, ref_id) is Some(d) else {
     fail("expected resolved declaration")

--- a/lang/lambda/edits/scope_incremental_differential_wbtest.mbt
+++ b/lang/lambda/edits/scope_incremental_differential_wbtest.mbt
@@ -1,7 +1,7 @@
 // Incremental ↔ full differential resolution test (docs/TODO.md §20, plan step 3).
 //
 // WHAT THIS PINS
-// Drives the INCREMENTAL ModuleProjection path — `to_module_projection_incremental` (which reuses
+// Drives the legacy/test INCREMENTAL ModuleProjection path — `to_module_projection_incremental` (which reuses
 // unchanged def subtrees + `reconcile_module_projection` to preserve binder ids) — across
 // an EDIT SEQUENCE, and asserts that a scope graph built from the incrementally
 // reconciled `ModuleProjection` resolves every Var reference IDENTICALLY to one built from
@@ -42,7 +42,7 @@
 /// Fresh full parse of a source string into a positioned SyntaxNode. Two
 /// independent parses of the same text yield structurally-equal (Eq) `CstNode`s,
 /// so feeding successive parses to `to_module_projection_incremental` exercises its reuse
-/// branch faithfully — the same input distribution the production memo sees.
+/// branch faithfully — the input distribution the former flat memo path used.
 fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
   let (cst, _diags) = @parser.parse_cst(text)
   @seam.SyntaxNode::from_cst(cst)
@@ -50,7 +50,7 @@ fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
 
 ///|
 /// Reconstruct a scope graph from a prebuilt `ModuleProjection` + the source's SyntaxNode,
-/// exactly as the production reconstruct flow does (`production_graph_of`):
+/// exactly as the legacy flat reconstruction flow does (`legacy_module_projection_graph_of`):
 /// `fp.to_proj_node` → `SourceMap::from_ast` → `populate_token_spans` → registry →
 /// `@scope.build`. `base_id` MUST be the high-water mark of the counter that built
 /// `fp` (its `.val` after `to_module_projection`/`to_module_projection_incremental`); `to_proj_node`
@@ -81,7 +81,7 @@ fn build_graph_from_fp(
 /// Assert the scope graph from an incremental `ModuleProjection` resolves identically to
 /// one from a fresh full `to_module_projection` of the same `syntax`. Reuses the
 /// cross-pipeline PBT's pipeline-INDEPENDENT comparison leaves (`collect_var_refs`,
-/// `assert_same_var_refs`, `assert_lam_ranges_unique`, `def_init_ranges`,
+/// `assert_same_var_refs`, `assert_lam_ranges_unique`, `def_binding_ranges`,
 /// `normalize_decl`), so node-id values are never compared raw.
 fn assert_incr_matches_full(
   incr_fp : @lambda_proj.ModuleProjection,
@@ -99,8 +99,8 @@ fn assert_incr_matches_full(
     syntax,
     full_counter.val,
   )
-  let ranges_i = def_init_ranges(proj_i)
-  let ranges_f = def_init_ranges(proj_f)
+  let ranges_i = def_binding_ranges(proj_i)
+  let ranges_f = def_binding_ranges(proj_f)
   assert_resolution_agrees(
     ResolutionSide(
       graph=g_i,
@@ -127,8 +127,8 @@ fn assert_incr_matches_full(
 /// Drive an edit sequence: parse `sources[0]` fully, then for each subsequent
 /// source re-parse fresh, reconcile via `to_module_projection_incremental` against the
 /// previous tree+proj, and assert the differential AFTER EVERY edit. The counter
-/// is threaded persistently across the whole sequence (as the production memo's
-/// `next_id_ref` is), so binder ids accumulate rather than reset.
+/// is threaded persistently across the whole legacy-helper sequence (as the old
+/// flat memo's `next_id_ref` was), so binder ids accumulate rather than reset.
 fn run_diff_sequence(sources : Array[String]) -> Unit raise {
   guard sources.length() >= 1 else {
     fail("run_diff_sequence needs >=1 source")

--- a/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
+++ b/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
@@ -129,9 +129,9 @@ fn assert_level_b_agrees(
     fail("[\{context}] memo projection is None on non-empty source: \{src}")
   }
   let g_i = @scope.build(reg_i, sm_i)
-  let ranges_i = def_init_ranges(root)
+  let ranges_i = def_binding_ranges(root)
   let (proj_f, reg_f, g_f, sm_f) = fresh_generic_graph_of(src)
-  let ranges_f = def_init_ranges(proj_f)
+  let ranges_f = def_binding_ranges(proj_f)
   assert_resolution_agrees(
     ResolutionSide(
       graph=g_i,

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -3,13 +3,7 @@ fn scope_test_registry(
   root : ProjNode[@ast.Term],
 ) -> Map[NodeId, ProjNode[@ast.Term]] {
   let registry : Map[NodeId, ProjNode[@ast.Term]] = {}
-  fn register(node : ProjNode[@ast.Term]) {
-    registry[node.id()] = node
-    for child in node.children {
-      register(child)
-    }
-  }
-  register(root)
+  @core.collect_registry(root, registry)
   registry
 }
 
@@ -87,20 +81,20 @@ test "module_def_references: later duplicate shadows body only" {
 test "find_binding_for_init: maps init ProjNode to binding NodeId" {
   let text = "let x = 0\nlet y = 1\nx + y"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let index = DefinitionIndex::from_proj_node(proj)
   // First def's init is the LetDef node's child.
   let init_id = proj.children[0].children[0].id()
-  let index = fp.definition_index()
+  let binding_node_id = proj.children[0].id()
   match find_binding_for_init(init_id, index) {
     Some((binding_id, def_index)) => {
-      inspect(binding_id == fp.defs[0].3, content="true")
+      inspect(binding_id == binding_node_id, content="true")
       inspect(def_index, content="0")
     }
     None => fail("expected Some")
   }
-  match find_binding_for_init(proj.children[0].id(), index) {
+  match find_binding_for_init(binding_node_id, index) {
     Some((binding_id, def_index)) => {
-      inspect(binding_id == fp.defs[0].3, content="true")
+      inspect(binding_id == binding_node_id, content="true")
       inspect(def_index, content="0")
     }
     None => fail("expected Some for LetDef id")
@@ -111,31 +105,27 @@ test "find_binding_for_init: maps init ProjNode to binding NodeId" {
 test "find_binding_for_init: returns None for non-init node" {
   let text = "let x = 0\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
+  let index = DefinitionIndex::from_proj_node(proj)
   // Body node is not an init expression
   let body = proj.children.last().unwrap()
-  inspect(
-    find_binding_for_init(body.id(), fp.definition_index()) is None,
-    content="true",
-  )
+  inspect(find_binding_for_init(body.id(), index) is None, content="true")
 }
 
 ///|
 test "find_binding_for_init: duplicate defs return matching binding order" {
   let text = "let x = 0\nlet x = x\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let index = fp.definition_index()
-  match find_binding_for_init(fp.defs[0].1.id(), index) {
+  let index = DefinitionIndex::from_proj_node(proj)
+  match find_binding_for_init(proj.children[0].children[0].id(), index) {
     Some((binding_id, def_index)) => {
-      inspect(binding_id == fp.defs[0].3, content="true")
+      inspect(binding_id == proj.children[0].id(), content="true")
       inspect(def_index, content="0")
     }
     None => fail("expected first duplicate binding")
   }
-  match find_binding_for_init(fp.defs[1].1.id(), index) {
+  match find_binding_for_init(proj.children[1].children[0].id(), index) {
     Some((binding_id, def_index)) => {
-      inspect(binding_id == fp.defs[1].3, content="true")
+      inspect(binding_id == proj.children[1].id(), content="true")
       inspect(def_index, content="1")
     }
     None => fail("expected second duplicate binding")
@@ -146,16 +136,23 @@ test "find_binding_for_init: duplicate defs return matching binding order" {
 test "def_cutoff_at_node: duplicate defs use init-range cutoff" {
   let text = "let x = 0\nlet x = x\nx"
   let (proj, _) = parse_to_proj_node(text)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let source_map = SourceMap::from_ast(proj)
   let body = proj.children.last().unwrap()
-  let index = fp.definition_index()
+  let index = DefinitionIndex::from_proj_node(proj)
   inspect(
-    def_cutoff_at_node_for_test(index, source_map, fp.defs[0].1.id()),
+    def_cutoff_at_node_for_test(
+      index,
+      source_map,
+      proj.children[0].children[0].id(),
+    ),
     content="0",
   )
   inspect(
-    def_cutoff_at_node_for_test(index, source_map, fp.defs[1].1.id()),
+    def_cutoff_at_node_for_test(
+      index,
+      source_map,
+      proj.children[1].children[0].id(),
+    ),
     content="1",
   )
   inspect(

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -5,12 +5,7 @@
 /// Uses the full syntax tree → ProjNode pipeline so token spans are populated.
 fn parse_with_token_spans(
   text : String,
-) -> (
-  ProjNode[@ast.Term],
-  SourceMap,
-  Map[NodeId, ProjNode[@ast.Term]],
-  @lambda_proj.ModuleProjection,
-) raise {
+) -> (ProjNode[@ast.Term], SourceMap, Map[NodeId, ProjNode[@ast.Term]]) raise {
   let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
@@ -18,8 +13,7 @@ fn parse_with_token_spans(
   let sm = SourceMap::from_ast(proj)
   populate_token_spans(sm, syntax, proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  (proj, sm, registry, fp)
+  (proj, sm, registry)
 }
 
 ///|
@@ -28,13 +22,7 @@ fn text_edit_test_registry(
   root : ProjNode[@ast.Term],
 ) -> Map[NodeId, ProjNode[@ast.Term]] {
   let registry : Map[NodeId, ProjNode[@ast.Term]] = {}
-  fn register(node : ProjNode[@ast.Term]) {
-    registry[node.id()] = node
-    for child in node.children {
-      register(child)
-    }
-  }
-  register(root)
+  @core.collect_registry(root, registry)
   registry
 }
 
@@ -57,13 +45,13 @@ fn make_edit_ctx(
   text : String,
   source_map : SourceMap,
   registry : Map[NodeId, ProjNode[@ast.Term]],
-  fp : @lambda_proj.ModuleProjection,
+  root : ProjNode[@ast.Term],
 ) -> EditContext[@ast.Term] {
   {
     source_text: text,
     source_map,
     registry,
-    definition_index: fp.definition_index(),
+    definition_index: DefinitionIndex::from_proj_node(root),
   }
 }
 
@@ -73,11 +61,10 @@ test "compute_text_edit: CommitEdit replaces single expression" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     CommitEdit(node_id=root_id, new_value="99"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -96,12 +83,11 @@ test "compute_text_edit: CommitEdit replaces left operand in binary expr" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // children[0] is the left operand (Var("x")), span [0, 1)
   let lhs = proj.children[0]
   let result = compute_text_edit(
     CommitEdit(node_id=lhs.id(), new_value="y"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -120,11 +106,10 @@ test "compute_text_edit: CommitEdit inside fn body preserves braces" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[0].children[0].children[0]
   let result = compute_text_edit(
     CommitEdit(node_id=body.id(), new_value="y"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -139,10 +124,9 @@ test "compute_text_edit: no-op ops return empty array" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     Select(node_id=NodeId::from_int(0)),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   @debug.debug_inspect(result, content="Ok(Some(([], RestoreCursor)))")
 }
@@ -153,11 +137,10 @@ test "compute_text_edit: Delete replaces node with placeholder" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     Delete(node_id=root_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -175,12 +158,11 @@ test "compute_text_edit: Delete replaces Var with placeholder" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // children[0] is the left operand Var("x"), span [0, 1)
   let lhs = proj.children[0]
   let result = compute_text_edit(
     Delete(node_id=lhs.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -198,11 +180,10 @@ test "compute_text_edit: Delete inside fn body preserves braces" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[0].children[0].children[0]
   let result = compute_text_edit(
     Delete(node_id=body.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -217,11 +198,10 @@ test "compute_text_edit: WrapInLambda wraps node in lambda abstraction" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInLambda(node_id=root_id, var_name="x"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -238,11 +218,10 @@ test "compute_text_edit: WrapInLambda parenthesizes subexpression" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let func = proj.children[0]
   let result = compute_text_edit(
     WrapInLambda(node_id=func.id(), var_name="x"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -257,11 +236,10 @@ test "compute_text_edit: WrapInApp wraps node in application" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInApp(node_id=root_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -278,12 +256,11 @@ test "compute_text_edit: InsertChild into Module inserts def text" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   // Insert a new Int def at index 1 (before the body)
   let result = compute_text_edit(
     InsertChild(parent=root_id, index=1, kind=@ast.Term::Int(0)),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -302,12 +279,11 @@ test "compute_text_edit: InsertChild into non-Module re-renders parent" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   // Insert a Var child into a Bop node — re-renders with print_term
   let result = compute_text_edit(
     InsertChild(parent=root_id, index=0, kind=@ast.Term::Var("z")),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -332,13 +308,12 @@ test "compute_text_edit: Drop produces two edits" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // source = children[0] (Var "x"), target = children[1] (Int 1)
   let source_node = proj.children[0]
   let target_node = proj.children[1]
   let result = compute_text_edit(
     Drop(source=source_node.id(), target=target_node.id(), position=After),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -359,12 +334,12 @@ test "compute_text_edit: Drop produces two edits" {
 ///|
 test "compute_text_edit: Drop LetDef Inside moves the whole binding row after target" {
   let text = "let x = 1\nlet y = 2\nx"
-  let (proj, source_map, registry, fp) = parse_with_token_spans(text)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let source = proj.children[0]
   let target = proj.children[1]
   let result = compute_text_edit(
     Drop(source=source.id(), target=target.id(), position=Inside),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -385,12 +360,12 @@ test "compute_text_edit: Drop LetDef Inside moves the whole binding row after ta
 ///|
 test "compute_text_edit: Drop LetDef Before moves the whole binding row before target" {
   let text = "let x = 1\nlet y = 2\nx"
-  let (proj, source_map, registry, fp) = parse_with_token_spans(text)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let source = proj.children[1]
   let target = proj.children[0]
   let result = compute_text_edit(
     Drop(source=source.id(), target=target.id(), position=Before),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -414,10 +389,9 @@ test "compute_text_edit: Drop with unknown source returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     Drop(source=NodeId::from_int(9999), target=proj.id(), position=Before),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -428,12 +402,11 @@ test "compute_text_edit: Drop synthetic multi-param lambda source is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let inner_lam = proj.children[0]
   let body = inner_lam.children[0]
   let result = compute_text_edit(
     Drop(source=inner_lam.id(), target=body.id(), position=After),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -444,13 +417,12 @@ test "compute_text_edit: Drop synthetic multi-param lambda target is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let inner_lam = proj.children[0]
   let body_bop = inner_lam.children[0]
   let source = body_bop.children[1]
   let result = compute_text_edit(
     Drop(source=source.id(), target=inner_lam.id(), position=Before),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -461,10 +433,9 @@ test "compute_text_edit: WrapInLambda with unknown node returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     WrapInLambda(node_id=NodeId::from_int(9999), var_name="x"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -475,10 +446,9 @@ test "compute_text_edit: CommitEdit with unknown node returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     CommitEdit(node_id=NodeId::from_int(9999), new_value="x"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -489,11 +459,10 @@ test "compute_text_edit: Unwrap Lam keeps body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let lam_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=lam_id, keep_child_index=0),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, hint))) => {
@@ -512,11 +481,10 @@ test "compute_text_edit: Unwrap synthetic fn lambda is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let lam = proj.children[0].children[0]
   let result = compute_text_edit(
     Unwrap(node_id=lam.id(), keep_child_index=0),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -527,11 +495,10 @@ test "compute_text_edit: Unwrap synthetic multi-param lambda is rejected" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let inner_lam = proj.children[0]
   let result = compute_text_edit(
     Unwrap(node_id=inner_lam.id(), keep_child_index=0),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -542,11 +509,10 @@ test "compute_text_edit: Unwrap Bop keeps left" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let bop_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=bop_id, keep_child_index=0),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => inspect(apply_edits(text, edits), content="1")
@@ -560,11 +526,10 @@ test "compute_text_edit: Unwrap Bop keeps right" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let bop_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=bop_id, keep_child_index=1),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => inspect(apply_edits(text, edits), content="2")
@@ -578,11 +543,10 @@ test "compute_text_edit: WrapInIf wraps node in if-then-else" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInIf(node_id=root_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, hint))) => {
@@ -600,11 +564,10 @@ test "compute_text_edit: WrapInBop wraps node in binary operation" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     WrapInBop(node_id=root_id, op=@ast.Bop::Plus),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, hint))) => {
@@ -623,11 +586,10 @@ test "compute_text_edit: ChangeOperator changes Bop operator" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     ChangeOperator(node_id=root_id, new_op=@ast.Bop::Minus),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, hint))) => {
@@ -644,11 +606,10 @@ test "compute_text_edit: SwapChildren swaps Bop operands" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let root_id = proj.id()
   let result = compute_text_edit(
     SwapChildren(node_id=root_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, hint))) => {
@@ -665,12 +626,11 @@ test "compute_text_edit: DeleteBinding removes first let line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Delete first binding
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -687,12 +647,11 @@ test "compute_text_edit: DeleteBinding removes second let line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Delete second binding
-  let binding_id = fp.defs[1].3
+  let binding_id = proj.children[1].id()
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -709,10 +668,9 @@ test "compute_text_edit: DeleteBinding removes second fn line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
-    DeleteBinding(binding_node_id=fp.defs[1].3),
-    make_edit_ctx(text, source_map, registry, fp),
+    DeleteBinding(binding_node_id=proj.children[1].id()),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -729,11 +687,10 @@ test "compute_text_edit: DeleteBinding removes only binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -750,10 +707,9 @@ test "compute_text_edit: DeleteBinding with unknown id returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=NodeId::from_int(9999)),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -764,11 +720,10 @@ test "compute_text_edit: DuplicateBinding copies binding with _copy suffix" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -785,11 +740,10 @@ test "compute_text_edit: DuplicateBinding on last binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -806,10 +760,9 @@ test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
-    DuplicateBinding(binding_node_id=fp.defs[0].3),
-    make_edit_ctx(text, source_map, registry, fp),
+    DuplicateBinding(binding_node_id=proj.children[0].id()),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -829,11 +782,10 @@ test "compute_text_edit: MoveBindingDown swaps two bindings" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -851,11 +803,10 @@ test "compute_text_edit: MoveBindingDown rejects when scoping violated" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -866,11 +817,10 @@ test "compute_text_edit: MoveBindingDown rejects last binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[1].3
+  let binding_id = proj.children[1].id()
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -881,11 +831,10 @@ test "compute_text_edit: MoveBindingUp swaps two bindings" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[1].3
+  let binding_id = proj.children[1].id()
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -902,10 +851,9 @@ test "compute_text_edit: MoveBindingUp swaps fn bindings" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
-    MoveBindingUp(binding_node_id=fp.defs[1].3),
-    make_edit_ctx(text, source_map, registry, fp),
+    MoveBindingUp(binding_node_id=proj.children[1].id()),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -928,8 +876,7 @@ test "compute_text_edit: MoveBindingUp swaps fn bindings" {
 /// structure (see the #649/#650 reparse-gate lesson).
 fn nested_block_def_names(def_index : Int, text : String) -> String raise {
   let (proj, _) = parse_to_proj_node(text)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  match fp.defs[def_index].1.kind {
+  match proj.children[def_index].children[0].kind {
     @ast.Term::Module(defs, _) => defs.map(fn(d) { d.0 }).join(",")
     _ => ""
   }
@@ -944,12 +891,11 @@ test "compute_text_edit: DeleteBinding removes block-local binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   let binding_id = block.children[1].id()
   let result = compute_text_edit(
     DeleteBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -964,12 +910,12 @@ test "compute_text_edit: DeleteBinding removes block-local binding" {
 ///|
 test "compute_text_edit: MoveBindingDown swaps block-local bindings" {
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let block = fp.defs[1].1
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let block = proj.children[1].children[0]
   let binding_id = block.children[0].id()
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -992,12 +938,12 @@ test "compute_text_edit: MoveBindingDown swaps block-local bindings" {
 ///|
 test "compute_text_edit: MoveBindingUp swaps block-local bindings" {
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let block = fp.defs[1].1
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let block = proj.children[1].children[0]
   let binding_id = block.children[1].id()
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1023,13 +969,12 @@ test "compute_text_edit: MoveBindingUp rejects first block-local binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   // `a` is the first def in the block scope (scope-local def_index 0).
   let binding_id = block.children[0].id()
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1046,12 +991,11 @@ test "compute_text_edit: DuplicateBinding on block-local binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   let binding_id = block.children[0].id()
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1080,12 +1024,11 @@ test "compute_text_edit: ExtractToLet refuses block-internal expr that uses a bl
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let block = fp.defs[0].1
+  let block = proj.children[0].children[0]
   let body = block.children[block.children.length() - 1]
   let result = compute_text_edit(
     ExtractToLet(node_id=body.id(), var_name="y"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1096,11 +1039,10 @@ test "compute_text_edit: AddBinding adds new let line" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let module_id = proj.id()
   let result = compute_text_edit(
     AddBinding(module_node_id=module_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1117,12 +1059,11 @@ test "compute_text_edit: ExtractToLet from body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is Bop(+, Var(x), Int(1)). Extract the whole body expression.
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     ExtractToLet(node_id=body.id(), var_name="y"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1139,13 +1080,12 @@ test "compute_text_edit: ExtractToLet sub-expression from body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Extract Var("x") from the body (left operand of +)
   let body = proj.children[proj.children.length() - 1]
   let var_x = body.children[0]
   let result = compute_text_edit(
     ExtractToLet(node_id=var_x.id(), var_name="z"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1163,12 +1103,11 @@ test "compute_text_edit: ExtractToLet rejects lambda-captured var" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // The body of lambda is Bop(+, Var(x), Int(1)) — child[0] of Lam
   let body = proj.children[0]
   let result = compute_text_edit(
     ExtractToLet(node_id=body.id(), var_name="y"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1176,11 +1115,11 @@ test "compute_text_edit: ExtractToLet rejects lambda-captured var" {
 ///|
 test "compute_text_edit: ExtractToLet rejects module-def enclosing env capture" {
   let text = "let x = y\nlet y = 1\n0"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
-  let init_y = fp.defs[0].1
+  let (proj, sm, registry) = parse_with_token_spans(text)
+  let init_y = proj.children[0].children[0]
   let result = compute_text_edit(
     ExtractToLet(node_id=init_y.id(), var_name="z"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -1191,11 +1130,11 @@ test "compute_text_edit: ExtractToLet rejects module-def enclosing env capture" 
 ///|
 test "compute_text_edit: ExtractToLet rejects later module-def shadow capture" {
   let text = "let y = 1\nlet x = y\nlet y = 2\n0"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
-  let init_y = fp.defs[1].1
+  let (proj, sm, registry) = parse_with_token_spans(text)
+  let init_y = proj.children[1].children[0]
   let result = compute_text_edit(
     ExtractToLet(node_id=init_y.id(), var_name="z"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -1209,10 +1148,9 @@ test "compute_text_edit: ExtractToLet bare expression" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     ExtractToLet(node_id=proj.id(), var_name="x"),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1229,12 +1167,11 @@ test "compute_text_edit: InlineDefinition sole usage removes binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is the last child of Module — Var("x")
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1251,12 +1188,11 @@ test "compute_text_edit: InlineDefinition nested block uses resolved declaration
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   let inner_body = block.children[block.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=inner_body.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1273,13 +1209,12 @@ test "compute_text_edit: InlineDefinition multiple usages keeps binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is Bop(+, Var(x), Var(x)). Get the left Var.
   let body = proj.children[proj.children.length() - 1]
   let lhs = body.children[0]
   let result = compute_text_edit(
     InlineDefinition(node_id=lhs.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1298,11 +1233,10 @@ test "compute_text_edit: InlineAllUsages replaces all refs and removes binding" 
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1321,12 +1255,11 @@ test "compute_text_edit: InlineAllUsages nested block uses binding declaration" 
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   let binding_id = block.children[0].id()
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1343,10 +1276,9 @@ test "compute_text_edit: InlineDefinition on non-Var returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     InlineDefinition(node_id=proj.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1357,10 +1289,9 @@ test "compute_text_edit: InlineAllUsages with unknown binding returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=NodeId::from_int(9999)),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1371,10 +1302,9 @@ test "compute_text_edit: InlineAllUsages preserves typed fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
-    InlineAllUsages(binding_node_id=fp.defs[0].3),
-    make_edit_ctx(text, source_map, registry, fp),
+    InlineAllUsages(binding_node_id=proj.children[0].id()),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1391,11 +1321,10 @@ test "compute_text_edit: InlineDefinition preserves typed fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1412,11 +1341,10 @@ test "compute_text_edit: InlineDefinition preserves indented typed fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1433,11 +1361,10 @@ test "compute_text_edit: InlineDefinition zero-param fn uses block body" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1451,10 +1378,10 @@ test "compute_text_edit: InlineDefinition zero-param fn uses block body" {
 ///|
 test "compute_text_edit: InlineAllUsages first duplicate preserves shadowed body" {
   let text = "let x = 0\nlet x = x\nx"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let result = compute_text_edit(
-    InlineAllUsages(binding_node_id=fp.defs[0].3),
-    make_edit_ctx(text, sm, registry, fp),
+    InlineAllUsages(binding_node_id=proj.children[0].id()),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1473,12 +1400,11 @@ test "compute_text_edit: InlineDefinition on lambda-bound var returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // Body is Var("x") — child[0] of Lam
   let var_x = proj.children[0]
   let result = compute_text_edit(
     InlineDefinition(node_id=var_x.id()),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1489,11 +1415,10 @@ test "compute_text_edit: InlineAllUsages no usages just removes binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1510,10 +1435,9 @@ test "compute_text_edit: InlineAllUsages removes unused second fn binding" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
-    InlineAllUsages(binding_node_id=fp.defs[1].3),
-    make_edit_ctx(text, source_map, registry, fp),
+    InlineAllUsages(binding_node_id=proj.children[1].id()),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1527,12 +1451,12 @@ test "compute_text_edit: InlineAllUsages removes unused second fn binding" {
 ///|
 test "compute_text_edit: Rename lambda param" {
   let text = "(x) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // proj is Lam("x", Var("x"))
   let lam_id = proj.id()
   let result = compute_text_edit(
     Rename(node_id=lam_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1546,12 +1470,12 @@ test "compute_text_edit: Rename lambda param" {
 ///|
 test "compute_text_edit: Rename var resolves to lambda binder" {
   let text = "(x) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // body Var("x") is child[0] of Lam
   let var_x = proj.children[0]
   let result = compute_text_edit(
     Rename(node_id=var_x.id(), new_name="z"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1565,12 +1489,12 @@ test "compute_text_edit: Rename var resolves to lambda binder" {
 ///|
 test "compute_text_edit: Rename module binding" {
   let text = "let x = 42\nx"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
-  // Use the binding_node_id from module_projection
-  let binding_id = fp.defs[0].3
+  let (proj, sm, registry) = parse_with_token_spans(text)
+  // Use the binding LetDef node id from the generic ProjNode tree.
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     Rename(node_id=binding_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1584,11 +1508,11 @@ test "compute_text_edit: Rename module binding" {
 ///|
 test "compute_text_edit: Rename module binding to same name remains valid" {
   let text = "let x = 42\nx"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
-  let binding_id = fp.defs[0].3
+  let (proj, sm, registry) = parse_with_token_spans(text)
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     Rename(node_id=binding_id, new_name="x"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1602,12 +1526,12 @@ test "compute_text_edit: Rename module binding to same name remains valid" {
 ///|
 test "compute_text_edit: Rename module binding via Var" {
   let text = "let x = 42\nx"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // body is Var("x") — last child of Module
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     Rename(node_id=body.id(), new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1631,7 +1555,7 @@ test "compute_text_edit: Rename block-local binding leaves root binding intact" 
     #|let y = { let x = 2
     #|  x }
     #|y
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // The block body `x` is the unique Var("x") in the program.
   guard registry.values().find_first(fn(n) { n.kind is @ast.Term::Var("x") })
     is Some(inner_x) else {
@@ -1640,7 +1564,7 @@ test "compute_text_edit: Rename block-local binding leaves root binding intact" 
   let inner_x_id = inner_x.id()
   let result = compute_text_edit(
     Rename(node_id=inner_x_id, new_name="w"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1670,13 +1594,13 @@ test "compute_text_edit: Rename block binder rejects capture of existing target 
     #|let z = { let x = 2
     #|  y }
     #|z
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // proj.children[1] = LetDef z; its init[0] is the block Module; that block's
   // child[0] is the nested LetDef x binder.
   let nested_x = proj.children[1].children[0].children[0]
   let result = compute_text_edit(
     Rename(node_id=nested_x.id(), new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1691,13 +1615,13 @@ test "compute_text_edit: Rename block-local binding by binder id" {
     #|let y = { let x = 2
     #|  x }
     #|y
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // proj.children[1] = LetDef y; its init child[0] is the block Module;
   // that block's child[0] is the nested LetDef x.
   let nested_let_def = proj.children[1].children[0].children[0]
   let result = compute_text_edit(
     Rename(node_id=nested_let_def.id(), new_name="w"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -1724,7 +1648,7 @@ test "compute_text_edit: Rename block reference to outer binding renames root" {
     #|let y = { let z = 2
     #|  x }
     #|y
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // The block body `x` (unique Var("x")) resolves to the root `x`.
   guard registry.values().find_first(fn(n) { n.kind is @ast.Term::Var("x") })
     is Some(inner_x) else {
@@ -1733,7 +1657,7 @@ test "compute_text_edit: Rename block reference to outer binding renames root" {
   let inner_x_id = inner_x.id()
   let result = compute_text_edit(
     Rename(node_id=inner_x_id, new_name="w"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -1753,10 +1677,10 @@ test "compute_text_edit: Rename block reference to outer binding renames root" {
 ///|
 test "compute_text_edit: Rename first duplicate module binding preserves shadowed body" {
   let text = "let x = 0\nlet x = x\nx"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let result = compute_text_edit(
-    Rename(node_id=fp.defs[0].3, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    Rename(node_id=proj.children[0].id(), new_name="y"),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1772,17 +1696,16 @@ test "compute_text_edit: Rename first duplicate module binding preserves shadowe
 ///|
 test "compute_text_edit: Rename module binding with multiple usages" {
   let text = "let x = 42\nx + x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
-  let binding_id = fp.defs[0].3
+  let (proj, sm, registry) = parse_with_token_spans(text)
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     Rename(node_id=binding_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      // Note: right operand's range may include leading space from CST
-      inspect(new_text.contains("let y = 42"), content="true")
+      inspect(new_text, content="let y = 42\ny + y")
     }
     _ => fail("expected Some edits")
   }
@@ -1791,12 +1714,12 @@ test "compute_text_edit: Rename module binding with multiple usages" {
 ///|
 test "compute_text_edit: Rename nested lambda" {
   let text = "(x, y) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   // Rename outer lambda param "x" to "z"
   let outer_id = proj.id()
   let result = compute_text_edit(
     Rename(node_id=outer_id, new_name="z"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1810,11 +1733,11 @@ test "compute_text_edit: Rename nested lambda" {
 ///|
 test "compute_text_edit: Rename typed fn second param ignores type identifiers" {
   let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let inner_lam = proj.children[0].children[0].children[0]
   let result = compute_text_edit(
     Rename(node_id=inner_lam.id(), new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1831,11 +1754,11 @@ test "compute_text_edit: Rename typed fn second param ignores type identifiers" 
 ///|
 test "compute_text_edit: Rename with unknown node returns error" {
   let text = "42"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = proj
   let result = compute_text_edit(
     Rename(node_id=NodeId::from_int(9999), new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1844,11 +1767,11 @@ test "compute_text_edit: Rename with unknown node returns error" {
 test "compute_text_edit: Rename rejects capture of free variable" {
   // (x) => y  — renaming x to y would capture the free y
   let text = "(x) => y"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let lam_id = proj.id()
   let result = compute_text_edit(
     Rename(node_id=lam_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1857,11 +1780,11 @@ test "compute_text_edit: Rename rejects capture of free variable" {
 test "compute_text_edit: Rename rejects capture by inner lambda binder" {
   // (x, y) => x — renaming outer x to y would rebind the use to inner y.
   let text = "(x, y) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let outer_lam_id = proj.id()
   let result = compute_text_edit(
     Rename(node_id=outer_lam_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1869,13 +1792,13 @@ test "compute_text_edit: Rename rejects capture by inner lambda binder" {
 ///|
 test "compute_text_edit: Rename rejects duplicate module binding name" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = proj
   // Rename binding x → y should fail because y already exists
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     Rename(node_id=binding_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1884,12 +1807,12 @@ test "compute_text_edit: Rename rejects duplicate module binding name" {
 test "compute_text_edit: Rename module binding rejects inner lambda capture" {
   // let x = 0\n(y) => x — renaming x→y would capture at the inner (y) =>
   let text = "let x = 0\n(y) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = proj
-  let binding_id = fp.defs[0].3
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     Rename(node_id=binding_id, new_name="y"),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1898,7 +1821,7 @@ test "compute_text_edit: Rename module binding rejects inner lambda capture" {
 test "compute_text_edit: InlineDefinition rejects capture" {
   // let y = 1\nlet x = y\n(y) => x — inlining x would produce (y) => y (capture)
   let text = "let y = 1\nlet x = y\n(y) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = sm
   // Body is (y) => x — the Lam node
   let body = proj.children[proj.children.length() - 1]
@@ -1906,7 +1829,7 @@ test "compute_text_edit: InlineDefinition rejects capture" {
   let var_x = body.children[0]
   let result = compute_text_edit(
     InlineDefinition(node_id=var_x.id()),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1914,11 +1837,11 @@ test "compute_text_edit: InlineDefinition rejects capture" {
 ///|
 test "compute_text_edit: InlineDefinition allows same module-def reference" {
   let text = "let y = 1\nlet x = y\nx"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -1932,11 +1855,11 @@ test "compute_text_edit: InlineDefinition allows same module-def reference" {
 ///|
 test "compute_text_edit: InlineDefinition rejects later module-def shadow capture" {
   let text = "let y = 1\nlet x = y\nlet y = 2\nx"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -1947,13 +1870,13 @@ test "compute_text_edit: InlineDefinition rejects later module-def shadow captur
 ///|
 test "compute_text_edit: InlineDefinition rejects nested block shadow capture" {
   let text = "let y = 0\nlet z = { let x = y\nlet y = 1\nx }\nz"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = proj
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   let block_body = block.children[block.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=block_body.id()),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -1964,14 +1887,14 @@ test "compute_text_edit: InlineDefinition rejects nested block shadow capture" {
 ///|
 test "compute_text_edit: InlineAllUsages rejects capture" {
   let text = "let y = 1\nlet x = y\n(y) => x"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = proj
   let _ = sm
   // Binding "x" is at def index 1
-  let binding_id = fp.defs[1].3
+  let binding_id = proj.children[1].id()
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -1979,13 +1902,13 @@ test "compute_text_edit: InlineAllUsages rejects capture" {
 ///|
 test "compute_text_edit: InlineAllUsages rejects nested block shadow capture" {
   let text = "let y = 0\nlet z = { let x = y\nlet y = 1\nx }\nz"
-  let (proj, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let _ = proj
-  let block = fp.defs[1].1
+  let block = proj.children[1].children[0]
   let binding_id = block.children[0].id()
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=binding_id),
-    make_edit_ctx(text, sm, registry, fp),
+    make_edit_ctx(text, sm, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -1996,10 +1919,10 @@ test "compute_text_edit: InlineAllUsages rejects nested block shadow capture" {
 ///|
 test "compute_text_edit: InlineAllUsages allows same module-def reference" {
   let text = "let y = 1\nlet x = y\nx"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let result = compute_text_edit(
-    InlineAllUsages(binding_node_id=fp.defs[1].3),
-    make_edit_ctx(text, sm, registry, fp),
+    InlineAllUsages(binding_node_id=proj.children[1].id()),
+    make_edit_ctx(text, sm, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -2013,10 +1936,10 @@ test "compute_text_edit: InlineAllUsages allows same module-def reference" {
 ///|
 test "compute_text_edit: InlineAllUsages rejects later module-def shadow capture" {
   let text = "let y = 1\nlet x = y\nlet y = 2\nx"
-  let (_, sm, registry, fp) = parse_with_token_spans(text)
+  let (proj, sm, registry) = parse_with_token_spans(text)
   let result = compute_text_edit(
-    InlineAllUsages(binding_node_id=fp.defs[1].3),
-    make_edit_ctx(text, sm, registry, fp),
+    InlineAllUsages(binding_node_id=proj.children[1].id()),
+    make_edit_ctx(text, sm, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -2027,11 +1950,11 @@ test "compute_text_edit: InlineAllUsages rejects later module-def shadow capture
 ///|
 test "compute_text_edit: middleware rejects missing node for structural ops" {
   let text = "42"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let fake_id = NodeId::from_int(99999)
   let result = compute_text_edit(
     Delete(node_id=fake_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   @debug.debug_inspect(result, content="Err(\"Node not found: NodeId(99999)\")")
 }
@@ -2040,11 +1963,11 @@ test "compute_text_edit: middleware rejects missing node for structural ops" {
 test "compute_text_edit: MoveBindingUp allows valid swap where prev uses cur" {
   // prev (x) uses cur's name (y) — after swap, y comes first so ref is valid
   let text = "let x = y\nlet y = 0\nx"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let binding_id = fp.defs[1].3
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let binding_id = proj.children[1].id()
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -2059,11 +1982,11 @@ test "compute_text_edit: MoveBindingUp allows valid swap where prev uses cur" {
 test "compute_text_edit: MoveBindingDown allows valid swap where cur uses next" {
   // cur (x) uses next's name (y) — after swap, y comes first so ref is valid
   let text = "let x = y\nlet y = 0\nx"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let binding_id = fp.defs[0].3
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let binding_id = proj.children[0].id()
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -2079,12 +2002,12 @@ test "compute_text_edit: MoveBindingUp rejects when swap would re-target prev's 
   // let x=1; let c=x; let x=2 — c's init refs "x" (resolves to x=1).
   // Moving x=2 up past c would make c see x=2 instead; semantics change.
   let text = "let x = 1\nlet c = x\nlet x = 2\nc"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   // defs[2] is `let x = 2`
-  let binding_id = fp.defs[2].3
+  let binding_id = proj.children[2].id()
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -2094,12 +2017,12 @@ test "compute_text_edit: MoveBindingDown rejects when swap would re-target cur's
   // let b=0; let cur=b; let b=1 — cur's init refs "b", currently resolves
   // to b=0 (earlier def). Moving cur down past b=1 would shadow b=0 with b=1.
   let text = "let b = 0\nlet cur = b\nlet b = 1\ncur"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   // defs[1] is `let cur = b`
-  let binding_id = fp.defs[1].3
+  let binding_id = proj.children[1].id()
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -2111,12 +2034,12 @@ test "compute_text_edit: MoveBindingUp rejects when block-local init resolves na
   // `x` from the outer def to the inner one — no earlier SAME-scope sibling
   // named "x" exists, but the outer resolution is enough to block.
   let text = "let x = 0\nlet z = { let c = x; let x = 2; c }\nz"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let block = fp.defs[1].1
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let block = proj.children[1].children[0]
   let binding_id = block.children[1].id() // `let x = 2`
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -2127,12 +2050,12 @@ test "compute_text_edit: MoveBindingDown rejects when block-local init resolves 
   // Moving `let c = y` below `let y = 2` would retarget c's `y` from the
   // outer def to the inner one — same outer-scope retargeting case as above.
   let text = "let y = 0\nlet z = { let c = y; let y = 2; c }\nz"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let block = fp.defs[1].1
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let block = proj.children[1].children[0]
   let binding_id = block.children[0].id() // `let c = y`
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -2143,11 +2066,11 @@ test "compute_text_edit: MoveBindingUp allows free→bound improvement when no e
   // exists — the reference was free before the swap and becomes bound after.
   // init_ref_resolves returns false (ref is free) → ALLOW (not an unconditional block).
   let text = "let a = x\nlet x = 0\na"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let binding_id = fp.defs[1].3 // `let x = 0`
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let binding_id = proj.children[1].id() // `let x = 0`
   let result = compute_text_edit(
     MoveBindingUp(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -2162,11 +2085,11 @@ test "compute_text_edit: MoveBindingDown allows free→bound improvement when no
   // exists — the reference was free before the swap and becomes bound after.
   // init_ref_resolves returns false (ref is free) → ALLOW (not an unconditional block).
   let text = "let a = b\nlet b = 0\na"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let binding_id = fp.defs[0].3 // `let a = b`
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let binding_id = proj.children[0].id() // `let a = b`
   let result = compute_text_edit(
     MoveBindingDown(binding_node_id=binding_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) =>
@@ -2183,11 +2106,10 @@ test "compute_text_edit: Unwrap cursor at replacement start" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let bop_id = proj.id()
   let result = compute_text_edit(
     Unwrap(node_id=bop_id, keep_child_index=1),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((_, hint))) =>
@@ -2204,11 +2126,11 @@ test "compute_text_edit: Unwrap cursor at replacement start" {
 ///|
 test "compute_text_edit: InsertChild rejects negative index" {
   let text = "let x = 0\nx"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
-  let module_id = fp.final_expr.unwrap().id()
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let module_id = proj.children.last().unwrap().id()
   let result = compute_text_edit(
     InsertChild(parent=module_id, index=-1, kind=@ast.Term::Int(0)),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -2216,12 +2138,12 @@ test "compute_text_edit: InsertChild rejects negative index" {
 ///|
 test "compute_text_edit: AddBinding rejects non-Module target" {
   let text = "42"
-  let (_, source_map, registry, fp) = parse_with_token_spans(text)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let root_id = NodeId::from_int(0)
   // root is an Int, not a Module
   let result = compute_text_edit(
     AddBinding(module_node_id=root_id),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }
@@ -2232,11 +2154,10 @@ test "compute_text_edit: Drop self-drop returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let id = proj.id()
   let result = compute_text_edit(
     Drop(source=id, target=id, position=After),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   @debug.debug_inspect(result, content="Err(\"Cannot drop onto self\")")
 }
@@ -2249,11 +2170,10 @@ test "compute_text_edit: Drop descendant-drop returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let child = proj.children[0] // Var(x), inside the Bop
   let result = compute_text_edit(
     Drop(source=proj.id(), target=child.id(), position=After),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   @debug.debug_inspect(
     result,
@@ -2267,13 +2187,12 @@ test "compute_text_edit: Drop with Before position inserts at target start" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   // source = Int(1) at children[1], target = Var(x) at children[0]
   let source_node = proj.children[1]
   let target_node = proj.children[0]
   let result = compute_text_edit(
     Drop(source=source_node.id(), target=target_node.id(), position=Before),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   match result {
     Ok(Some((edits, _))) => {
@@ -2296,10 +2215,9 @@ test "compute_text_edit: Drop with unknown target returns error" {
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
-  let fp = @lambda_proj.ModuleProjection::from_proj_node(proj)
   let result = compute_text_edit(
     Drop(source=proj.id(), target=NodeId::from_int(9999), position=After),
-    make_edit_ctx(text, source_map, registry, fp),
+    make_edit_ctx(text, source_map, registry, proj),
   )
   inspect(result is Err(_), content="true")
 }

--- a/lang/lambda/proj/module_projection_wbtest.mbt
+++ b/lang/lambda/proj/module_projection_wbtest.mbt
@@ -1,3 +1,12 @@
+// Legacy ModuleProjection compatibility contract.
+//
+// Production-facing Lambda projection/edit paths use ProjNode + registry +
+// SourceMap + DefinitionIndex, with editor-facing memoization provided by the
+// generic 3-memo stack in projection_memo.mbt. This file intentionally keeps
+// direct coverage for the remaining legacy/test/internal flat view:
+// to_module_projection*, ModuleProjection roundtrips, root-module
+// reconciliation, and the compatibility definition-index adapter.
+
 ///|
 fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
   let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }


### PR DESCRIPTION
## Summary

- Convert Lambda edit/scope tests that were only using `ModuleProjection` to build edit context over to generic `ProjNode` + `DefinitionIndex::from_proj_node` + registry/source-map fixtures.
- Keep remaining `ModuleProjection` test references as explicit legacy/test coverage for `to_module_projection*`, flat reconstruction, root-module reconciliation, and cross-pipeline identity checks.
- Update stale “production path” wording so Lambda tests distinguish generic editor-facing coverage from legacy compatibility contracts.

Closes #662.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `DefinitionIndex::from_proj_node` | `lang/lambda/proj/definition_index.mbt` | Yes | Used for generic edit/scope fixtures instead of deriving indexes through `ModuleProjection`. |
| `@core.collect_registry` | `core/proj_node.mbt` | Yes | Replaced test-local hand-rolled registry walkers. |
| `SourceMap::from_ast` | `core/source_map.mbt` | Yes | Kept as the source-map construction path for generic fixtures. |
| `to_module_projection*` | `lang/lambda/proj/module_projection.mbt` | Yes, legacy-only | Retained only where tests explicitly cover legacy flat-view compatibility, incremental helper behavior, and cross-pipeline equivalence. |

New helpers added (if any):

- None. Existing test helpers were narrowed/renamed only (`make_edit_ctx`, `def_binding_ranges`, `legacy_module_projection_graph_of`).

## Test plan

- [x] `NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/edits lang/lambda/semantic --deny-warn` passes
- [x] `NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/edits lang/lambda/semantic` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (empty after reverting unrelated trailing-newline churn)
- [x] JS rebuild not run; tests/comments only, web not affected

## Validation

```bash
NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/edits lang/lambda/semantic --deny-warn
NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/edits lang/lambda/semantic
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
git diff --check
```
