### PR TITLE
docs(lambda): decide edit bridge boundary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,9 @@ behavior** — check the code before relying on any specific detail.
 - [Shared-substrate `incr` version lock](decisions/2026-06-10-shared-substrate-incr-version-lock.md)
   — locks canopy/loom/moondsp at incr minor 0.9, the bottom-up paired-bump protocol,
   and why cross-repo CI is deferred until shared-runtime work needs it (closes #441).
+- [Lambda edit bridge boundary](decisions/2026-06-15-lambda-edit-bridge-boundary.md)
+  — keeps Lambda's typed-error, patch-trace, editor-coupled bridge outside
+  `LanguageSpec` after `ModuleProjection` removal (closes #634).
 
 ## Historical / Archive
 

--- a/docs/decisions/2026-06-15-lambda-edit-bridge-boundary.md
+++ b/docs/decisions/2026-06-15-lambda-edit-bridge-boundary.md
@@ -1,0 +1,49 @@
+# Lambda edit bridge boundary after `ModuleProjection` removal
+
+**Date:** 2026-06-15  
+**Status:** Accepted  
+**Closes:** <https://github.com/dowdiness/canopy/issues/634>  
+**Related:**
+[#623](https://github.com/dowdiness/canopy/issues/623) ·
+[#633](https://github.com/dowdiness/canopy/issues/633) ·
+[#661](https://github.com/dowdiness/canopy/issues/661) ·
+[#662](https://github.com/dowdiness/canopy/issues/662) ·
+[#668](https://github.com/dowdiness/canopy/pull/668)
+
+## Decision
+
+Keep Lambda's thin `apply_lambda_tree_edit` bridge. Do not adapt Lambda to
+`LanguageSpec::apply_edit`, and do not introduce a richer generic runtime API
+for Lambda alone.
+
+After the `ModuleProjection` cleanup, the required edit context is no longer the
+main blocker: Lambda's registry and `DefinitionIndex` can be derived from the
+current generic `ProjNode` root. The remaining boundary is the application
+contract. Lambda returns typed `TreeEditError`s plus the applied `SpanEdit` trace,
+and its `Drop` operation delegates to the editor-owned `move_node` path. Those
+are deliberately outside `LanguageSpec`, whose shared contract is
+`compute_edit -> apply_span_edits -> Result[Unit, String]` for the JSON/Markdown
+shape.
+
+## Audit table
+
+| Dimension | Generic SPI principle | Lambda bridge principle | Boundary decision |
+|---|---|---|---|
+| Context ownership | Shared bridges should depend only on language-neutral document state. | Language-specific lookup structures may be derived locally from that state. | Do not widen the SPI for derivable context alone. |
+| Success and failure shape | The common path reports coarse success or string failure. | Lambda preserves structured failure categories and applied edit traces. | Keep the contracts separate unless consumers migrate deliberately. |
+| Error semantics | Generic callers need stable messages, not language-owned categories. | Lambda callers rely on language-owned categories for precise UI behavior. | Preserve the richer channel for Lambda. |
+| Trace obligations | The shared bridge applies edits internally and hides patch details. | Lambda must expose the applied patch trace to downstream instrumentation. | Preserve the trace requirement. |
+| Move semantics | Generic edits are language-computed text patches. | Some Lambda moves are editor-coupled because validity depends on editor-owned placeholder and separator rules. | Keep editor-coupled moves out of the SPI until another language shares the need. |
+| Consumer expectations | JSON and Markdown consumers observe only coarse success or failure. | Lambda consumers expect stable structured messages and patch traces. | Keep the Lambda facade stable. |
+
+## Consequences
+
+- `lang/runtime` remains the Tier 2 SPI for JSON/Markdown-style languages.
+- Lambda remains a documented exception and a legacy stress case, not a new
+  language template.
+- If a future language only needs a registry or index derivable from `ProjNode`,
+  derive it in that language's closure rather than widening `LanguageSpec`.
+- Revisit the generic SPI only when at least one non-Lambda language needs the
+  same richer shape: typed edit errors, successful patch traces, or editor-owned
+  move/drop semantics. At that point, design the generic API for both languages
+  together instead of creating a Lambda-only `LanguageSpecV2`.

--- a/docs/development/ADDING_A_LANGUAGE.md
+++ b/docs/development/ADDING_A_LANGUAGE.md
@@ -385,15 +385,15 @@ pub fn new_my_editor(
 ```
 
 > **The lambda exception.** `lang/lambda/companion` does NOT go through
-> `LanguageSpec` — its edit path is editor-coupled in ways the SPI
-> deliberately excludes: `compute_text_edit` needs an `EditContext` carrying
-> `registry` plus a `DefinitionIndex` derived from the generic `ProjNode` root,
-> `apply_lambda_tree_edit` returns a typed `Result[Array[SpanEdit],
-> TreeEditError]` patch trace, and `Drop` delegates to `editor.move_node`.
-> Lambda's eval/scope/semantic extras ride the optional per-instance
-> `LanguageCapabilities` fields instead. Do not copy lambda's shape for a new
-> language; see the decision record in
-> `docs/plans/2026-06-11-s3-lang-runtime-extraction.md` (Step 4 amendment).
+> `LanguageSpec` for edit application. After `ModuleProjection` removal,
+> Lambda's `registry` and `DefinitionIndex` are derived from the generic
+> `ProjNode` root, so context alone is not the reason to widen the SPI. The
+> remaining mismatch is the application contract: `apply_lambda_tree_edit`
+> returns a typed `Result[Array[SpanEdit], TreeEditError]` patch trace, and
+> `Drop` delegates to `editor.move_node`. Lambda's eval/scope/semantic extras
+> ride the optional per-instance `LanguageCapabilities` fields instead. Do not
+> copy lambda's shape for a new language; see the post-cleanup decision record
+> in `docs/decisions/2026-06-15-lambda-edit-bridge-boundary.md`.
 
 **Package registration:**
 

--- a/docs/plans/2026-06-11-s3-lang-runtime-extraction.md
+++ b/docs/plans/2026-06-11-s3-lang-runtime-extraction.md
@@ -128,10 +128,13 @@ JSON is the clearest non-lambda reference shape: the companion surface is compac
 > the responsibility map and restated lambda in the spec's vocabulary; the
 > apply path failed every condition for raising it into the SPI:
 >
-> 1. `compute_text_edit` requires `EditContext{source_text, source_map,
->    registry, module_projection}` — not the spec's
->    `(Op, String, ProjNode[T], SourceMap)`; widening would force dead
->    context on json/markdown.
+> 1. At the time, `compute_text_edit` required
+>    `EditContext{source_text, source_map, registry, module_projection}` — not
+>    the spec's `(Op, String, ProjNode[T], SourceMap)`; widening would have
+>    forced dead context on json/markdown. The post-`ModuleProjection` #634
+>    audit narrowed this point: Lambda's registry and `DefinitionIndex` are now
+>    derivable from the generic `ProjNode` root, so context alone is no longer
+>    the deciding blocker.
 > 2. `apply_lambda_tree_edit` returns `Result[Array[SpanEdit],
 >    TreeEditError]` — a typed public error surface plus a patch trace
 >    consumed by `ffi/lambda` (intent.mbt, semantic.mbt) via the
@@ -149,10 +152,11 @@ JSON is the clearest non-lambda reference shape: the companion surface is compac
 > verification that S4 ffi/host extraction is not blocked (ffi already
 > consumes the bridge through the facade).
 >
-> **Revisit trigger:** raise `apply_edit` into the spec only if a future
-> language needs registry/module-projection context AND a typed error
-> channel — i.e. if `LanguageSpec[T, Op, Err]` + a context record would
-> serve at least two languages without dead config in any of them.
+> **Revisit trigger (updated by #634):** raise `apply_edit` into the spec only
+> if a future non-Lambda language needs the same richer application contract —
+> typed edit errors, successful `SpanEdit` traces, or editor-owned move/drop
+> semantics — and the resulting API would serve at least two languages without
+> dead config in any of them.
 >
 > PR3 therefore ships: this decision record, the ADDING_A_LANGUAGE.md
 > template update (LanguageSpec is the path for new languages; lambda

--- a/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
+++ b/docs/plans/2026-06-14-lambda-cstfold-modernization-623.md
@@ -1,6 +1,7 @@
 # Lambda CstFold modernization decision note (#623)
 
-**Status:** accepted through #633; updated for #661 compatibility cleanup
+**Status:** accepted through \#634; updated for #668 test classification and the
+\#634 edit-bridge boundary decision
 **Date:** 2026-06-14  
 **Issue:** <https://github.com/dowdiness/canopy/issues/623>
 
@@ -8,7 +9,8 @@
 
 Migrate Lambda incrementally toward the CstFold pattern at the **projection
 construction** seam, but keep the Lambda-specific `ModuleProjection`
-compatibility/reconciliation helpers and custom edit bridge for now.
+compatibility/reconciliation helpers and the custom edit bridge as the #634
+post-cleanup boundary.
 
 Markdown remains the reference integration for new languages. Lambda stays a
 legacy stress case, not a reference demo. The immediate modernization goal is to
@@ -49,7 +51,7 @@ containing the remaining exceptions.
 | CST -> AST value | `CstFold` + language fold node | duplicated hand-built `Term` construction in Canopy | migrate first |
 | AST/projection tree shape | small AST/syntax parallel walk | bespoke synthetic `Lam`, `App`, `Bop`, `LetDef`, `Module` shapes | preserve initially |
 | Memo pipeline | `@core.build_projection_memos` 3-memo | `@core.build_projection_memos` via `lang/lambda/proj` (#633); legacy `ModuleProjection` no longer has an editor-facing memo | migrated in #633 |
-| Edit bridge | `LanguageSpec::apply_edit` | `EditContext{registry,definition_index}` derived from the generic projection root + typed errors + patch trace + `Drop` via `move_node` | keep custom bridge |
+| Edit bridge | `LanguageSpec::apply_edit` | `EditContext{registry,definition_index}` derived from the generic projection root + typed errors + patch trace + `Drop` via `move_node` | keep custom bridge (#634) |
 | New-language guidance | copy Markdown | explicitly do not copy Lambda | leave docs accurate |
 
 ## Blockers to a full migration
@@ -60,9 +62,11 @@ containing the remaining exceptions.
    remaining flat view is used internally to reconcile root-module binding IDs
    and by legacy tests being classified under #662.
 2. **The `LanguageSpec` boundary deliberately excludes Lambda's edit bridge.**
-   The S3 amendment records why: Lambda needs registry plus a definition index,
-   returns `TreeEditError` plus the applied `SpanEdit` trace, and delegates
-   `Drop` to `SyncEditor::move_node`.
+   The #634 audit records the post-`ModuleProjection` boundary: Lambda's
+   registry and definition index are now derived from the generic projection
+   root, so context alone is no longer the deciding blocker. The bridge remains
+   separate because it returns `TreeEditError` plus the applied `SpanEdit`
+   trace, and delegates `Drop` to `SyncEditor::move_node`.
 3. **CstFold and current projection semantics are not byte-for-byte identical.**
    A probe comparing current projection kind with `syntax_node_to_term` showed:
    - `{ 1 }`: current projection `Int(1)`, CstFold term `Module([], Int(1))`.
@@ -160,14 +164,17 @@ Likely touched files:
 - #631 — extract a definition index from `ModuleProjection`.
 - #632 — migrate scope/edit/semantic consumers off `ModuleProjection`.
 - #633 — switch the projection memo stack to the generic 3-memo path.
-- #634 — revisit the Lambda edit bridge after compatibility-surface cleanup.
+- #634 — revisit the Lambda edit bridge after compatibility-surface cleanup
+  (decided: keep the thin Lambda bridge; see
+  `docs/decisions/2026-06-15-lambda-edit-bridge-boundary.md`).
 - #635 — replace typed-`fn` source scanners with structured token metadata.
 
 ## Non-goals
 
 - Do not migrate Lambda onto `LanguageSpec` in this issue slice.
-- After #633/#661, keep remaining edit-bridge cleanup scoped to #634 instead of
-  broadening compatibility-surface work into an edit redesign.
+- After #633/#661/#668, keep the #634 edit-bridge decision docs-only unless a
+  future implementation slice deliberately migrates typed errors, patch traces,
+  or editor-owned `Drop` semantics for more than Lambda.
 - Do not make #625's source scanner a reusable framework abstraction.
 - Do not reopen binder identity or scope unification under #623 unless a concrete
   projection slice is blocked by them.

--- a/lang/lambda/README.md
+++ b/lang/lambda/README.md
@@ -1,39 +1,65 @@
 # lang/lambda
 
-Thin facade for the lambda-calculus editor language. Re-exports the handful of types and functions that consumers (`editor/` tests and `ffi/lambda/`) actually call through this path, sourced from the three currently-imported subpackages `edits`, `eval`, and `companion`. The projection subpackage (`proj`) is not re-exported here — consumers that need it import the subpackage directly.
+Thin facade for the lambda-calculus editor language. Re-exports the handful of
+symbols that consumers (`editor/` tests and `ffi/lambda/`) call through this
+path, sourced from the currently-imported subpackages `edits`, `eval`, and
+`companion`. The projection subpackage (`proj`) is not re-exported here;
+consumers that need it import the subpackage directly.
 
-The facade was originally much larger; in 2026-05 it was trimmed to the symbols with live callers. Consumers that need more reach into the subpackages directly (see `examples/ideal/main/moon.pkg`).
+The facade was originally much larger; in 2026-05 it was trimmed to the symbols
+with live callers. Consumers that need more reach should import subpackages
+directly (see `examples/ideal/main/moon.pkg`).
 
 ## Public API
 
 Re-exported from `lang/lambda/edits`:
+
 - type `TreeEditOp`
-- type `DropPosition` (canonical origin is `@core`; `lang/lambda/edits` re-re-exports it, so consumers see it through either path)
+- type `DropPosition` (canonical origin is `@core`; `lang/lambda/edits`
+  re-re-exports it, so consumers see it through either path)
 
 Re-exported from `lang/lambda/companion`:
+
 - type `LambdaCompanion`
 - `new_lambda_editor(agent_id, capture_timeout_ms?, parent_runtime?) -> (SyncEditor[Term], LambdaCompanion)`
-- `apply_lambda_tree_edit(editor, companion, op, cursor)`
-- `get_lambda_ast`, `get_lambda_ast_pretty`, `get_lambda_resolution`, `get_lambda_dot_resolved`
+- `apply_lambda_tree_edit(editor, companion, op, timestamp_ms)`
+- `get_lambda_ast`, `get_lambda_ast_pretty`, `get_lambda_resolution`,
+  `get_lambda_dot_resolved`
 - `parse_tree_edit_op`
 
 Re-exported from `lang/lambda/eval`:
+
 - type `EvalResult`
 
 ## Consumers
 
-- `ffi/lambda/` — JS FFI surface; calls `new_lambda_editor`, `apply_lambda_tree_edit`, `parse_tree_edit_op`, and the AST/pretty accessors.
-- `editor/` (blackbox tests only) — uses `@lambda.get_lambda_ast` and related accessors to drive integration tests.
-- `examples/ideal/main/` — additionally uses `LambdaCompanion`, `EvalResult`, `DropPosition`, `TreeEditOp`; imports `lang/lambda/edits` directly for the rest.
+- `ffi/lambda/` — JS FFI surface; calls `new_lambda_editor`,
+  `apply_lambda_tree_edit`, `parse_tree_edit_op`, and the AST/pretty accessors.
+- `editor/` (blackbox tests only) — uses `@lambda.get_lambda_ast` and related
+  accessors to drive integration tests.
+- `examples/ideal/main/` — additionally uses `LambdaCompanion`, `EvalResult`,
+  `DropPosition`, `TreeEditOp`; imports `lang/lambda/edits` directly for the
+  rest.
 
 ## Dependencies
 
-`lang/lambda/edits`, `lang/lambda/eval`, `lang/lambda/companion`. The `proj` subpackage is not re-exported here; consumers that need it should import it directly.
+`lang/lambda/edits`, `lang/lambda/eval`, `lang/lambda/companion`. The `proj`
+subpackage is not re-exported here; consumers that need it should import it
+directly.
 
 ## Stability
 
-Experimental — the lambda language is the reference implementation for new editor features. The facade surface evolves as features are wired up; expect re-exports to be added as new consumers appear.
+Experimental. Lambda is a legacy stress case for editor features, not the
+template for adding a new language; use Markdown for that. The facade surface
+evolves as features are wired up, and re-exports are added when new consumers
+need them.
 
 ## Notes
 
-There is no top-level logic in this package. Earlier revisions included a `reconcile_ast.mbt` file re-exporting `@core.reconcile`, which had no callers and was removed. Lambda's editor-facing projection memos now live in `lang/lambda/proj` via `build_lambda_projection_memos`, a thin wrapper around `@core.build_projection_memos`.
+There is no top-level logic in this package. Earlier revisions included a
+`reconcile_ast.mbt` file re-exporting `@core.reconcile`, which had no callers
+and was removed. Lambda's editor-facing projection memos now live in
+`lang/lambda/proj` via `build_lambda_projection_memos`, a thin wrapper around
+`@core.build_projection_memos`. Lambda's edit bridge intentionally remains
+outside `LanguageSpec`; see
+`docs/decisions/2026-06-15-lambda-edit-bridge-boundary.md`.

--- a/lang/runtime/README.md
+++ b/lang/runtime/README.md
@@ -26,13 +26,14 @@ unbounded. Per-instance capabilities (e.g. lambda's eval/semantic closures
 capturing instance memos) are passed to `new_editor`, not stored in the spec.
 
 What the SPI excludes — deliberately: editor-coupled edit application.
-`lang/lambda/companion` keeps its own bridge (`apply_lambda_tree_edit`)
-because its compute context needs the current projection registry plus a
-`DefinitionIndex` derived from the generic `ProjNode` root, its error channel is
-the typed `TreeEditError` with a `SpanEdit` patch-trace return, and `Drop`
-delegates to `editor.move_node`. See the Step 4 amendment in
-`docs/plans/2026-06-11-s3-lang-runtime-extraction.md` for the decision record
-and the revisit trigger.
+`lang/lambda/companion` keeps its own bridge (`apply_lambda_tree_edit`). After
+`ModuleProjection` removal, Lambda's registry and `DefinitionIndex` are derived
+from the generic `ProjNode` root, so context alone is no longer the deciding
+mismatch. The bridge remains Lambda-specific because it returns a typed
+`TreeEditError` plus the applied `SpanEdit` patch trace, and `Drop` delegates to
+`editor.move_node`. See
+`docs/decisions/2026-06-15-lambda-edit-bridge-boundary.md` for the post-cleanup
+decision.
 
 Dispatch cost: benchmarked free (S3 gate,
 `lang/json/companion/dispatch_benchmark.mbt`) — capability-record indirection


### PR DESCRIPTION
## Summary

- Adds a post-`ModuleProjection` decision record for #634.
- Decision: keep Lambda's thin `apply_lambda_tree_edit` bridge; do not migrate it to `LanguageSpec::apply_edit` or introduce a Lambda-only generic runtime API.
- Updates runtime/new-language docs and the #623/S3 plan notes to clarify that context is now derivable from `ProjNode`, while typed errors, patch trace, and editor-owned `Drop` remain the boundary.
- Fixes stale `apply_lambda_tree_edit(..., cursor)` wording to `timestamp_ms`.

Closes #634.

## Decision audit

| Dimension | Outcome |
|---|---|
| Required context | Registry/`DefinitionIndex` are now derivable from the generic `ProjNode` root; context alone is not a reason to widen `LanguageSpec`. |
| Return type / patch trace | Lambda still returns `Result[Array[SpanEdit], TreeEditError]`; `LanguageSpec::apply_edit` returns `Result[Unit, String]`. |
| Typed errors | Keep `TreeEditError`; do not flatten unless Lambda FFI/public consumers are deliberately migrated. |
| Drop/move_node | Keep Lambda's `Drop` special-case through `SyncEditor::move_node`. |
| Callers | Preserve `ffi/lambda/intent.mbt`, `ffi/lambda/semantic.mbt`, and editor/example facade behavior. |

## Reuse check

- Reused/checked: `LanguageSpec::apply_edit`, `compute_text_edit`, `EditContext`, `DefinitionIndex::from_proj_node`, `SyncEditor::move_node`, `TreeEditError`.
- No new MoonBit helpers or runtime APIs introduced.
- Existing API discovery: used `moon ide outline` for `lang/runtime/language_spec.mbt`, `lang/lambda/companion/lambda_editor.mbt`, and `lang/lambda/edits/text_edit.mbt`; `moon ide doc/peek-def` hit a local IDE JSON parse error, so I cross-checked by reading the definitions and running validation.

## Validation

- `NEW_MOON_MOD=0 moon check lang/lambda/companion lang/lambda/edits ffi/lambda editor lang/runtime --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/lambda/companion lang/lambda/edits ffi/lambda editor lang/runtime` (485 passed)
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info` (reviewed `.mbti`; only unrelated trailing blank-line churn, reverted)
- `git diff -- '*.mbti'` (empty)
- `git diff --check`
- `bash scripts/check-agent-doc-links.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new architectural decision record documenting language bridge design.
  * Updated language integration guide with revised references to bridge architecture documentation.
  * Clarified runtime documentation scope and bridge responsibilities.
  * Updated language-specific README with revised API parameter documentation (`timestamp_ms` parameter).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->