### PR TITLE
chore(edits/proj): remove dead LetDef compat fallbacks

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -240,14 +240,15 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 10. Editor Drag-and-Drop Follow-ups
 
-- [ ] First-class LetDef ProjNodes for binding-level structural edits (#127).
-  Why: Structure mode already renders PM `let_def` rows and supports drag/drop
-  over them, but the ProjNode tree has no binding node; row IDs are borrowed
-  from init expressions and binding actions use ModuleProjection-only synthetic handles.
-  Plan: `docs/plans/2026-06-01-letdef-projnode-structural-edit.md`
-  Exit: Module children include real LetDef nodes; binding drag/drop/actions use
-  registry-backed LetDef IDs; `@scope.binder_span` / `go_to_definition` remain
-  the source-location path.
+- [x] First-class LetDef ProjNodes for binding-level structural edits (#127).
+  Merged: canopy#448 (336d7e1, 2026-06-01); cleanup PRs #664, #668–#671 (2026-06-15).
+  All acceptance criteria verified 2026-06-15: Module children are [LetDef..., body];
+  scope builder uses LetDef child ids for Decl.node_id; convert.ts/reconciler.ts map
+  actual LetDef ProjNodes to let_def; drag/drop E2E moves whole binding rows; binding
+  actions pass real LetDef ids; scope annotation uses real LetDef ids; binder_span /
+  go_to_definition remain source-span based; canvas unchanged.
+  Remaining legacy cleanup (non-blocking): module_projection.mbt compat layer (~339 lines,
+  labeled "Legacy/test helper") and dead ValidateNodeExists binding-id fallback.
 
 - [ ] Prepare drag-and-drop foundations for `examples/block-editor`.
   Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder.

--- a/docs/plans/2026-06-01-letdef-projnode-structural-edit.md
+++ b/docs/plans/2026-06-01-letdef-projnode-structural-edit.md
@@ -1,6 +1,6 @@
 # First-class LetDef ProjNodes for binding-level structural edits
 
-**Status:** ready
+**Status:** done (canopy#448, cleanup #664/#668–#671; criteria verified 2026-06-15)
 **Date:** 2026-06-01
 **GitHub:** #127
 **Supersedes:** the deferred Option-B endpoint from `docs/plans/2026-05-30-scope-binder-node-id-reconciliation.md` only for structural editing of bindings. Option D remains the source-location solution.
@@ -140,15 +140,15 @@ Observable outcomes:
 
 ## Acceptance Criteria
 
-- [ ] `Module` ProjNodes expose children `[LetDef..., body]`; every LetDef has exactly one init child.
-- [ ] `FlatProj.defs[i].3` is present in the projection registry and identifies the corresponding LetDef node.
-- [ ] `@scope.Decl` for `ModuleDef` uses the LetDef node id, and `@scope.binder_span` still returns the binder-name range.
-- [ ] Structure-mode PM conversion maps actual LetDef ProjNodes to `let_def`; no init-id synthesis remains in `convert.ts` / `reconciler.ts`.
-- [ ] Drag/drop on `.structure-let_def` moves or swaps whole binding rows. Tests must reject the old `let x = 2 / let y = 1` init-swap behavior unless an explicit expression-level drop selected the init child.
-- [ ] Binding actions (`DeleteBinding`, `DuplicateBinding`, `MoveBindingUp`, `MoveBindingDown`, `InlineAllUsages`, binding rename) work when passed the LetDef id.
-- [ ] Module binder row annotations use real LetDef ids where a visible structural row exists; source-location highlighting still uses `@scope.binder_span`; no stale negative UI key is required for top-level/module rows.
-- [ ] Go-to-definition and rename targeting remain source-span based and continue to pass existing Option-D tests.
-- [ ] No canvas/audio-graph files change as part of this refactor.
+- [x] `Module` ProjNodes expose children `[LetDef..., body]`; every LetDef has exactly one init child.
+- [x] `FlatProj.defs[i].3` is present in the projection registry and identifies the corresponding LetDef node. (Production path: EditModuleView.binding_id = LetDef child id; ModuleProjection is a labeled "Legacy/test helper" with compat fallback — by design.)
+- [x] `@scope.Decl` for `ModuleDef` uses the LetDef node id, and `@scope.binder_span` still returns the binder-name range.
+- [x] Structure-mode PM conversion maps actual LetDef ProjNodes to `let_def`; no init-id synthesis remains in `convert.ts` / `reconciler.ts`.
+- [x] Drag/drop on `.structure-let_def` moves or swaps whole binding rows. E2E test (drag-drop.spec.ts:188) verifies `'let x = 1\nlet y = 2\nx'` → `'let y = 2\nlet x = 1\nx'` after Inside drop.
+- [x] Binding actions (`DeleteBinding`, `DuplicateBinding`, `MoveBindingUp`, `MoveBindingDown`, `InlineAllUsages`, binding rename) work when passed the LetDef id.
+- [x] Module binder row annotations use real LetDef ids where a visible structural row exists; source-location highlighting still uses `@scope.binder_span`; no stale negative UI key is required for top-level/module rows.
+- [x] Go-to-definition and rename targeting remain source-span based and continue to pass existing Option-D tests.
+- [x] No canvas/audio-graph files change as part of this refactor.
 
 ## Validation
 

--- a/lang/lambda/edits/text_edit_middleware.mbt
+++ b/lang/lambda/edits/text_edit_middleware.mbt
@@ -20,31 +20,12 @@ priv struct ValidateNodeExists {}
 impl EditMiddleware for ValidateNodeExists with fn apply(_self, next, op, ctx) {
   match extract_primary_node_id(op) {
     Some(id) =>
-      if ctx.registry.contains(id) ||
-        (
-          op_accepts_binding_id(op) &&
-          edit_module_view(ctx).defs
-          .iter()
-          .any(fn(def) { def.binding_id == id })
-        ) {
+      if ctx.registry.contains(id) {
         next(op, ctx)
       } else {
         Err("Node not found: " + id.to_string())
       }
     None => next(op, ctx)
-  }
-}
-
-///|
-fn op_accepts_binding_id(op : TreeEditOp) -> Bool {
-  match op {
-    Rename(..)
-    | DeleteBinding(..)
-    | DuplicateBinding(..)
-    | MoveBindingUp(..)
-    | MoveBindingDown(..)
-    | InlineAllUsages(..) => true
-    _ => false
   }
 }
 

--- a/lang/lambda/edits/text_edit_module_view.mbt
+++ b/lang/lambda/edits/text_edit_module_view.mbt
@@ -57,16 +57,7 @@ fn edit_binding_by_id(
         @ast.Term::LetDef(name, _) => Ok(edit_binding_from_child(name, node))
         _ => Err("Binding not found: " + binding_node_id.to_string())
       }
-    None => {
-      let module_view = edit_module_view(ctx)
-      match
-        module_view.defs
-        .iter()
-        .find_first(fn(def) { def.binding_id == binding_node_id }) {
-        Some(def) => Ok(def)
-        None => Err("Binding not found: " + binding_node_id.to_string())
-      }
-    }
+    None => Err("Binding not found: " + binding_node_id.to_string())
   }
 }
 

--- a/lang/lambda/proj/module_projection.mbt
+++ b/lang/lambda/proj/module_projection.mbt
@@ -283,8 +283,7 @@ fn ModuleProjection::to_proj_node_with_prev_module_id(
 
 ///|
 /// Legacy/test helper: extract a ModuleProjection from a Module ProjNode.
-/// Reads LetDef children and extracts their init child. Legacy init-only
-/// children are accepted as a compatibility fallback.
+/// Reads LetDef children and extracts their init child.
 pub fn ModuleProjection::from_proj_node(
   root : ProjNode[@ast.Term],
 ) -> ModuleProjection {
@@ -294,19 +293,12 @@ pub fn ModuleProjection::from_proj_node(
       for i = 0; i < term_defs.length(); i = i + 1 {
         if i < root.children.length() - 1 {
           let def_child = root.children[i]
-          match def_child.kind {
-            @ast.Term::LetDef(_, _) if def_child.children.length() > 0 => {
-              let init_child = def_child.children[0]
-              defs.push(
-                (term_defs[i].0, init_child, def_child.start, def_child.id()),
-              )
-            }
-            _ => {
-              let init_child = def_child
-              defs.push(
-                (term_defs[i].0, init_child, init_child.start, init_child.id()),
-              )
-            }
+          if def_child.kind is @ast.Term::LetDef(_, _) &&
+            def_child.children.length() > 0 {
+            let init_child = def_child.children[0]
+            defs.push(
+              (term_defs[i].0, init_child, def_child.start, def_child.id()),
+            )
           }
         }
       }


### PR DESCRIPTION
## Summary

Removes three dead-code fallbacks that became unreachable once Module children are always first-class LetDef ProjNodes with real registry ids (landed in #448, cleanup finalized by #664/#668–#671).

- **`module_projection.mbt`**: drop legacy init-only fallback arm in `ModuleProjection::from_proj_node`; only LetDef-typed children are accepted now
- **`text_edit_middleware.mbt`**: drop `op_accepts_binding_id` function + module-view scan branch in `ValidateNodeExists`; LetDef ids are always in the registry so the check was unreachable
- **`text_edit_module_view.mbt`**: collapse registry-miss fallback in `edit_binding_by_id` to a direct `Err` return

Also marks `docs/TODO.md §10` item `[x]` and updates plan status to `done` (acceptance criteria verified 2026-06-15).

## Reuse check

No new types or functions introduced — pure deletion.

## Test plan

- [x] `moon test` — 1446 tests pass (native + js)
- [x] `moon check` — no warnings
- [x] `git diff -- '*.mbti'` — no public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)