### PR TITLE
refactor(lambda): use token metadata for typed fn rewrites

### DIFF
--- a/lang/lambda/edits/text_edit_binding_source.mbt
+++ b/lang/lambda/edits/text_edit_binding_source.mbt
@@ -1,18 +1,11 @@
 ///|
-fn binding_starts_with_fn(source_text : String, start : Int) -> Bool {
-  start + 2 <= source_text.length() &&
-  source_text[start] == 'f' &&
-  source_text[start + 1] == 'n' &&
-  (
-    start + 2 == source_text.length() ||
-    !is_identifier_code(source_text[start + 2])
-  )
-}
-
-///|
 priv enum BindingRewriteKind {
   ValueBinding
-  FnBinding
+  FnBinding(
+    param_list~ : @loomcore.Range,
+    body~ : @loomcore.Range,
+    has_params~ : Bool
+  )
 }
 
 ///|
@@ -52,6 +45,55 @@ fn binding_name_range(
 }
 
 ///|
+fn binding_structured_role_range(
+  source_map : SourceMap,
+  def : EditModuleBinding,
+  role : String,
+  binding_start : Int,
+  binding_end : Int,
+  label : String,
+) -> Result[@loomcore.Range, String] {
+  match source_map.get_token_span(def.binding_id, role) {
+    Some(range) =>
+      if binding_start <= range.start &&
+        range.start <= range.end &&
+        range.end <= binding_end {
+        Ok(range)
+      } else {
+        Err("Cannot rewrite fn binding: " + label + " range out of binding")
+      }
+    None => Err("Cannot rewrite fn binding: " + label + " range not found")
+  }
+}
+
+///|
+fn binding_has_fn_params(
+  source_map : SourceMap,
+  def : EditModuleBinding,
+) -> Bool {
+  source_map.get_token_span(
+    def.binding_id,
+    @lambda_proj.FN_BINDING_PARAM_NAME_ROLE,
+  )
+  is Some(_)
+}
+
+///|
+fn binding_has_synthetic_fn_params(def : EditModuleBinding) -> Bool {
+  def.init.kind is @ast.Term::Lam(_, _)
+}
+
+///|
+/// Detects the desugared-Lam shape that only `fn` bindings produce: the outer
+/// Lam starts at the binding boundary instead of at a value initializer. This
+/// is only a rejection guard for missing structured roles, not a source scanner.
+fn binding_requires_fn_metadata(def : EditModuleBinding) -> Bool {
+  binding_has_synthetic_fn_params(def) &&
+  def.binding_id != def.init.id() &&
+  def.init.start == def.start
+}
+
+///|
 fn binding_rewrite_source(
   source_text : String,
   source_map : SourceMap,
@@ -62,18 +104,48 @@ fn binding_rewrite_source(
     Ok(r) => r
     Err(e) => return Err(e)
   }
-  let binding_kind_start = match
-    first_non_space_in_range(
-      source_text,
-      @loomcore.Range::new(binding_start, binding_end),
+  let kind = match
+    source_map.get_token_span(
+      def.binding_id,
+      @lambda_proj.FN_BINDING_KEYWORD_ROLE,
     ) {
-    Some(pos) => pos
-    None => binding_start
-  }
-  let kind = if binding_starts_with_fn(source_text, binding_kind_start) {
-    FnBinding
-  } else {
-    ValueBinding
+    Some(_) => {
+      let param_list = match
+        binding_structured_role_range(
+          source_map,
+          def,
+          @lambda_proj.FN_BINDING_PARAM_LIST_ROLE,
+          binding_start,
+          binding_end,
+          "parameter list",
+        ) {
+        Ok(range) => range
+        Err(e) => return Err(e)
+      }
+      let body = match
+        binding_structured_role_range(
+          source_map,
+          def,
+          @lambda_proj.FN_BINDING_BODY_ROLE,
+          binding_start,
+          binding_end,
+          "body",
+        ) {
+        Ok(range) => range
+        Err(e) => return Err(e)
+      }
+      FnBinding(
+        param_list~,
+        body~,
+        has_params=binding_has_fn_params(source_map, def),
+      )
+    }
+    None =>
+      if binding_requires_fn_metadata(def) {
+        return Err("Cannot rewrite fn binding: keyword range not found")
+      } else {
+        ValueBinding
+      }
   }
   Ok({ def, binding_start, binding_end, kind })
 }
@@ -119,84 +191,15 @@ fn trimmed_source_text(source_text : String, range : @loomcore.Range) -> String 
 }
 
 ///|
-fn find_char_in_range(
-  source_text : String,
-  needle : UInt16,
-  start : Int,
-  end : Int,
-) -> Int? {
-  for pos in start..<end {
-    if source_text[pos] == needle {
-      return Some(pos)
-    }
-  }
-  None
-}
-
-///|
-fn range_has_non_space(source_text : String, start : Int, end : Int) -> Bool {
-  for pos in start..<end {
-    if !is_space_code(source_text[pos]) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn matching_right_paren(
-  source_text : String,
-  open_pos : Int,
-  end : Int,
-) -> Result[Int, String] {
-  // Tiny source scanner state machine: depth tracks nested parens in types.
-  let mut depth = 0
-  for pos in open_pos..<end {
-    if source_text[pos] == '(' {
-      depth = depth + 1
-    } else if source_text[pos] == ')' {
-      depth = depth - 1
-      if depth == 0 {
-        return Ok(pos)
-      }
-    }
-  }
-  Err("Cannot inline fn binding: parameter list end not found")
-}
-
-///|
 fn fn_binding_inline_text(
   source_text : String,
-  binding_start : Int,
-  binding_end : Int,
+  param_list : @loomcore.Range,
+  body_range : @loomcore.Range,
+  has_params : Bool,
 ) -> Result[String, String] {
-  let param_start = match
-    find_char_in_range(source_text, '(', binding_start, binding_end) {
-    Some(pos) => pos
-    None => return Err("Cannot inline fn binding: parameter list not found")
-  }
-  let param_end = match
-    matching_right_paren(source_text, param_start, binding_end) {
-    Ok(pos) => pos + 1
-    Err(e) => return Err(e)
-  }
-  let body_start = match
-    first_non_space_in_range(
-      source_text,
-      @loomcore.Range::new(param_end, binding_end),
-    ) {
-    Some(pos) => pos
-    None => return Err("Cannot inline fn binding: body not found")
-  }
-  if source_text[body_start] != '{' {
-    return Err("Cannot inline fn binding: expected block body")
-  }
-  let params = source_text[param_start:param_end].to_owned()
-  let body = trimmed_source_text(
-    source_text,
-    @loomcore.Range::new(body_start, binding_end),
-  )
-  if range_has_non_space(source_text, param_start + 1, param_end - 1) {
+  let params = source_text[param_list.start:param_list.end].to_owned()
+  let body = trimmed_source_text(source_text, body_range)
+  if has_params {
     Ok("(" + params + " => " + body + ")")
   } else {
     Ok(body)
@@ -210,8 +213,8 @@ fn BindingRewriteSource::inline_text(
   source_map : SourceMap,
 ) -> Result[String, String] {
   match self.kind {
-    FnBinding =>
-      fn_binding_inline_text(source_text, self.binding_start, self.binding_end)
+    FnBinding(param_list~, body~, has_params~) =>
+      fn_binding_inline_text(source_text, param_list, body, has_params)
     ValueBinding =>
       match source_map.get_range(self.def.init.id()) {
         Some(r) => Ok(trimmed_source_text(source_text, r))

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -757,9 +757,7 @@ test "compute_text_edit: DuplicateBinding on last binding" {
 ///|
 test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
   let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
-  let (proj, _) = parse_to_proj_node(text)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = text_edit_test_registry(proj)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let result = compute_text_edit(
     DuplicateBinding(binding_node_id=proj.children[0].id()),
     make_edit_ctx(text, source_map, registry, proj),
@@ -1322,9 +1320,7 @@ test "compute_text_edit: InlineAllUsages with unknown binding returns error" {
 ///|
 test "compute_text_edit: InlineAllUsages preserves typed fn binding" {
   let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice id 1"
-  let (proj, _) = parse_to_proj_node(text)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = text_edit_test_registry(proj)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let result = compute_text_edit(
     InlineAllUsages(binding_node_id=proj.children[0].id()),
     make_edit_ctx(text, source_map, registry, proj),
@@ -1341,9 +1337,7 @@ test "compute_text_edit: InlineAllUsages preserves typed fn binding" {
 ///|
 test "compute_text_edit: InlineDefinition preserves typed fn binding" {
   let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
-  let (proj, _) = parse_to_proj_node(text)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = text_edit_test_registry(proj)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
@@ -1361,9 +1355,7 @@ test "compute_text_edit: InlineDefinition preserves typed fn binding" {
 ///|
 test "compute_text_edit: InlineDefinition preserves indented typed fn binding" {
   let text = "  fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
-  let (proj, _) = parse_to_proj_node(text)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = text_edit_test_registry(proj)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
@@ -1381,9 +1373,7 @@ test "compute_text_edit: InlineDefinition preserves indented typed fn binding" {
 ///|
 test "compute_text_edit: InlineDefinition zero-param fn uses block body" {
   let text = "fn answer() { 42 }\nanswer"
-  let (proj, _) = parse_to_proj_node(text)
-  let source_map = SourceMap::from_ast(proj)
-  let registry = text_edit_test_registry(proj)
+  let (proj, source_map, registry) = parse_with_token_spans(text)
   let body = proj.children[proj.children.length() - 1]
   let result = compute_text_edit(
     InlineDefinition(node_id=body.id()),
@@ -1395,6 +1385,68 @@ test "compute_text_edit: InlineDefinition zero-param fn uses block body" {
       inspect(new_text, content="{ 42 }")
     }
     _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: InlineDefinition zero-param fn with lambda body uses block body" {
+  let text = "fn make() { (x) => x }\nmake"
+  let (proj, source_map, registry) = parse_with_token_spans(text)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="{ (x) => x }")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: InlineDefinition typed fn rejects missing keyword span" {
+  let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Err(msg) =>
+      inspect(msg, content="Cannot rewrite fn binding: keyword range not found")
+    _ => fail("expected structured metadata rejection")
+  }
+}
+
+///|
+test "compute_text_edit: InlineDefinition typed fn rejects missing parameter span" {
+  let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  source_map.set_token_span(
+    proj.children[0].id(),
+    @lambda_proj.FN_BINDING_KEYWORD_ROLE,
+    @loomcore.Range::new(0, 2),
+  )
+  let registry = text_edit_test_registry(proj)
+  let body = proj.children[proj.children.length() - 1]
+  let result = compute_text_edit(
+    InlineDefinition(node_id=body.id()),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Err(msg) =>
+      inspect(
+        msg,
+        content="Cannot rewrite fn binding: parameter list range not found",
+      )
+    _ => fail("expected structured metadata rejection")
   }
 }
 

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -11,6 +11,14 @@ import {
 }
 
 // Values
+pub const FN_BINDING_BODY_ROLE : String = "fn:body"
+
+pub const FN_BINDING_KEYWORD_ROLE : String = "fn:keyword"
+
+pub const FN_BINDING_PARAM_LIST_ROLE : String = "fn:param-list"
+
+pub const FN_BINDING_PARAM_NAME_ROLE : String = "fn:param-name"
+
 pub const LET_DEF_NAME_ROLE : String = "name"
 
 pub const PARAM_ROLE : String = "param"

--- a/lang/lambda/proj/populate_token_spans.mbt
+++ b/lang/lambda/proj/populate_token_spans.mbt
@@ -74,6 +74,89 @@ fn collect_token_spans_source_file(
 }
 
 ///|
+fn direct_child_of_kind(
+  node : @seam.SyntaxNode,
+  kind : @syntax.SyntaxKind,
+) -> @seam.SyntaxNode? {
+  node
+  .children()
+  .iter()
+  .find_first(child => @syntax.SyntaxKind::from_raw(child.kind()) == kind)
+}
+
+///|
+fn set_syntax_node_span_role(
+  source_map : SourceMap,
+  node_id : @core.NodeId,
+  role : String,
+  syntax_node : @seam.SyntaxNode,
+) -> Unit {
+  source_map.set_token_span(
+    node_id,
+    role,
+    @loomcore.Range::new(syntax_node.start(), syntax_node.end()),
+  )
+}
+
+///|
+fn set_fn_body_span_role(
+  source_map : SourceMap,
+  node_id : @core.NodeId,
+  body : @seam.SyntaxNode,
+) -> Unit {
+  match
+    (
+      body.find_token(@syntax.LBraceToken.to_raw()),
+      body.tokens_of_kind(@syntax.RBraceToken.to_raw()).last(),
+    ) {
+    (Some(left), Some(right)) =>
+      source_map.set_token_span(
+        node_id,
+        FN_BINDING_BODY_ROLE,
+        @loomcore.Range::new(left.start(), right.end()),
+      )
+    _ => ()
+  }
+}
+
+///|
+fn collect_token_spans_fn_binding(
+  source_map : SourceMap,
+  def_view : @parser.LetDefView,
+  let_def_node : ProjNode[@ast.Term],
+) -> Unit {
+  let def_syn = def_view.syntax_node()
+  guard def_syn.find_token(@syntax.FnKeyword.to_raw()) is Some(fn_tok) else {
+    return
+  }
+  source_map.set_token_span(
+    let_def_node.id(),
+    FN_BINDING_KEYWORD_ROLE,
+    @loomcore.Range::new(fn_tok.start(), fn_tok.end()),
+  )
+  if direct_child_of_kind(def_syn, @syntax.ParamList) is Some(params) {
+    set_syntax_node_span_role(
+      source_map,
+      let_def_node.id(),
+      FN_BINDING_PARAM_LIST_ROLE,
+      params,
+    )
+  }
+  match param_ident_tokens(def_syn) {
+    [first, ..] =>
+      source_map.set_token_span(
+        let_def_node.id(),
+        FN_BINDING_PARAM_NAME_ROLE,
+        @loomcore.Range::new(first.start(), first.end()),
+      )
+    [] => ()
+  }
+  if def_view.init() is Some(body) {
+    set_fn_body_span_role(source_map, let_def_node.id(), body)
+  }
+}
+
+///|
 /// Record the binder-name token span for one LetDef row and recurse into its
 /// initializer. The canonical span lives on the LetDef node; the module-level
 /// `name:<i>` span remains as a migration fallback for older callers.
@@ -97,6 +180,7 @@ fn collect_token_spans_let_def(
     def_syn,
     @syntax.IdentToken.to_raw(),
   )
+  collect_token_spans_fn_binding(source_map, def_view, let_def_node)
   guard def_view.init() is Some(init_syn) && let_def_node.children.length() > 0 else {
     return
   }
@@ -169,13 +253,7 @@ fn collect_token_spans_left_spine(
 
 ///|
 fn param_ident_tokens(node : @seam.SyntaxNode) -> Array[@seam.SyntaxToken] {
-  let param_list = node
-    .children()
-    .iter()
-    .find_first(child => {
-      @syntax.SyntaxKind::from_raw(child.kind()) == @syntax.ParamList
-    })
-  match param_list {
+  match direct_child_of_kind(node, @syntax.ParamList) {
     Some(params) => {
       let tokens : Array[@seam.SyntaxToken] = []
       let mut expect_param = true

--- a/lang/lambda/proj/populate_token_spans_wbtest.mbt
+++ b/lang/lambda/proj/populate_token_spans_wbtest.mbt
@@ -11,18 +11,31 @@ fn parse_proj_with_token_spans(
 }
 
 ///|
+fn expect_role_span(
+  source_map : SourceMap,
+  node : ProjNode[@ast.Term],
+  role : String,
+  start : Int,
+  end : Int,
+) -> Unit raise {
+  guard source_map.get_token_span(node.id(), role) is Some(span) else {
+    fail("missing \{role} span")
+  }
+  if span.start != start || span.end != end {
+    fail(
+      "expected \{role} span \{start}..\{end}, got \{span.start}..\{span.end}",
+    )
+  }
+}
+
+///|
 fn expect_param_span(
   source_map : SourceMap,
   node : ProjNode[@ast.Term],
   start : Int,
   end : Int,
 ) -> Unit raise {
-  guard source_map.get_token_span(node.id(), PARAM_ROLE) is Some(span) else {
-    fail("missing param span")
-  }
-  if span.start != start || span.end != end {
-    fail("expected param span \{start}..\{end}, got \{span.start}..\{span.end}")
-  }
+  expect_role_span(source_map, node, PARAM_ROLE, start, end)
 }
 
 ///|
@@ -94,6 +107,44 @@ test "populate_token_spans: typed fn params ignore type identifiers" {
   let fn_lam = proj.children[0].children[0]
   expect_param_span(source_map, fn_lam, 9, 10)
   expect_param_span(source_map, fn_lam.children[0], 25, 26)
+}
+
+///|
+test "populate_token_spans: typed fn binding has structured rewrite spans" {
+  let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  let let_def = proj.children[0]
+  expect_role_span(source_map, let_def, FN_BINDING_KEYWORD_ROLE, 0, 2)
+  expect_role_span(source_map, let_def, FN_BINDING_PARAM_LIST_ROLE, 8, 33)
+  expect_role_span(source_map, let_def, FN_BINDING_PARAM_NAME_ROLE, 9, 10)
+  expect_role_span(source_map, let_def, FN_BINDING_BODY_ROLE, 34, 41)
+}
+
+///|
+test "populate_token_spans: zero-param fn has no binding param-name span" {
+  let text = "fn make() { (x) => x }\nmake"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  let let_def = proj.children[0]
+  expect_role_span(source_map, let_def, FN_BINDING_KEYWORD_ROLE, 0, 2)
+  expect_role_span(source_map, let_def, FN_BINDING_PARAM_LIST_ROLE, 7, 9)
+  expect_role_span(source_map, let_def, FN_BINDING_BODY_ROLE, 10, 22)
+  inspect(
+    source_map.get_token_span(let_def.id(), FN_BINDING_PARAM_NAME_ROLE) is None,
+    content="true",
+  )
+}
+
+///|
+test "populate_token_spans: let binding with nested fn is not marked as fn" {
+  let text = "let x = { fn y() { 1 }\n  y }\nx"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  let outer_let = proj.children[0]
+  inspect(
+    source_map.get_token_span(outer_let.id(), FN_BINDING_KEYWORD_ROLE) is None,
+    content="true",
+  )
+  let nested_let = outer_let.children[0].children[0]
+  expect_role_span(source_map, nested_let, FN_BINDING_KEYWORD_ROLE, 10, 12)
 }
 
 ///|

--- a/lang/lambda/proj/token_roles.mbt
+++ b/lang/lambda/proj/token_roles.mbt
@@ -13,6 +13,26 @@ pub const PARAM_ROLE : String = "param"
 pub const LET_DEF_NAME_ROLE : String = "name"
 
 ///|
+/// Role key for a typed `fn` binding's keyword token (stored on the `LetDef`).
+pub const FN_BINDING_KEYWORD_ROLE : String = "fn:keyword"
+
+///|
+/// Role key for a typed `fn` binding's full parameter-list span, including
+/// type annotations and surrounding parentheses (stored on the `LetDef`).
+pub const FN_BINDING_PARAM_LIST_ROLE : String = "fn:param-list"
+
+///|
+/// Role key for the first parameter name token of a non-empty typed `fn`
+/// binding parameter list (stored on the `LetDef`). Absence means the `fn`
+/// has an empty `()` parameter list.
+pub const FN_BINDING_PARAM_NAME_ROLE : String = "fn:param-name"
+
+///|
+/// Role key for a typed `fn` binding's brace-delimited body span (stored on the
+/// `LetDef`).
+pub const FN_BINDING_BODY_ROLE : String = "fn:body"
+
+///|
 /// Role key for module def `def_index`'s name token (stored on the Module node).
 /// Compatibility fallback while callers migrate to `LET_DEF_NAME_ROLE` on the
 /// first-class LetDef node.


### PR DESCRIPTION
## Summary

- Populate structured typed `fn` metadata on Lambda `LetDef` nodes: keyword, parameter list, first parameter name, and brace-delimited body spans.
- Consume those token roles in binding duplicate/inline rewrites, removing the typed `fn` raw source scanners and rejecting missing metadata instead of reprinting projected terms.
- Add regressions for typed `fn` preservation, missing metadata rejection, nested `fn` metadata, and zero-parameter `fn` bodies whose body expression is itself a lambda.

Closes #635.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceMap::set_token_span` / `get_token_span` | `core/source_map.mbt` | Yes | Used as the structured metadata channel between projection and edits. |
| `SyntaxNode::find_token` / `tokens_of_kind` | `loom/seam/syntax_node.mbt` | Yes | Used to locate `fn` and body brace tokens structurally. |
| `SyntaxNode::children().iter().find_first` | `loom/seam/syntax_node.mbt` + core iter APIs | Yes | Used by a private helper to find direct CST children such as `ParamList`. |
| `LetDefView::syntax_node` / `init` | `loom/examples/lambda/src/views.mbt` | Yes | Used to access the typed `fn` CST node and its block body. |
| existing `param_ident_tokens` | `lang/lambda/proj/populate_token_spans.mbt` | Yes | Reused for both Lam-param spans and the new non-empty typed-`fn` parameter marker. |

New helpers added:

- `direct_child_of_kind`: private `populate_token_spans` helper for direct CST child lookup; replaces duplicated `children().find_first` logic.
- `set_syntax_node_span_role`: private helper for storing a syntax node's full span as a role.
- `set_fn_body_span_role`: private helper that records the brace-delimited block body span rather than the broader block node span.
- `collect_token_spans_fn_binding`: private typed-`fn` metadata producer scoped to Lambda `LetDef` nodes.
- `binding_structured_role_range`: private edit-side validation for required structured role spans within a binding.
- `binding_has_fn_params` / `binding_has_synthetic_fn_params` / `binding_requires_fn_metadata`: private edit-side predicates separating structured param presence from the synthetic Lam-shape missing-metadata guard.

## Test plan

- [ ] `NEW_MOON_MOD=0 moon check` passes (not run; targeted packages below)
- [ ] `NEW_MOON_MOD=0 moon test` passes (not run; targeted packages below)
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (not applicable; Lambda MoonBit-only change)

## Validation

```bash
NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/edits --deny-warn
NEW_MOON_MOD=0 moon test lang/lambda/edits --filter '*zero-param fn*'
NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/edits
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
git diff HEAD~1..HEAD -- '*.mbti'
git diff --check
```

Targeted test result after rebase onto latest `origin/main`: `lang/lambda/proj lang/lambda/edits` passed, 264 tests.

`.mbti` review: only intended public API drift is `lang/lambda/proj/pkg.generated.mbti` adding typed `fn` token role constants.
