### PR TITLE
fix(lambda/edits): make ExtractToLet block-aware (#659)

### DIFF
--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -149,6 +149,24 @@ fn root_scope_id(g : @scope.ScopeGraph) -> @scope.ScopeId? {
 }
 
 ///|
+/// Whether `scope_id` contains at least one ModuleDef decl (i.e. it is a
+/// block/module scope, not a pure lambda scope). Used to distinguish nested
+/// block scopes from lambda scopes when deciding the insertion target for
+/// ExtractToLet.
+fn scope_has_module_defs(
+  g : @scope.ScopeGraph,
+  scope_id : @scope.ScopeId,
+) -> Bool {
+  let @scope.ScopeId(si) = scope_id
+  g.scopes[si].decl_ids
+  .iter()
+  .any(fn(did) {
+    let @scope.DeclId(di) = did
+    g.decls[di].kind is @scope.DeclKind::ModuleDef(_)
+  })
+}
+
+///|
 /// Whether `scope` is `ancestor` itself or any descendant of it — i.e. whether
 /// `ancestor` lies on `scope`'s parent chain. Used to test if a reference sits
 /// inside a declaration's visibility region (its declaring scope's subtree).

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -149,21 +149,40 @@ fn root_scope_id(g : @scope.ScopeGraph) -> @scope.ScopeId? {
 }
 
 ///|
-/// Whether `scope_id` contains at least one ModuleDef decl (i.e. it is a
-/// block/module scope, not a pure lambda scope). Used to distinguish nested
-/// block scopes from lambda scopes when deciding the insertion target for
-/// ExtractToLet.
-fn scope_has_module_defs(
+/// Walk up ancestor scopes from `node_id` and return the innermost
+/// enclosing `Term::Module` ProjNode that is not the root module.
+///
+/// The scope builder records nested Module nodes with their own inner
+/// scope in `node_scope` (the Module node itself maps to the scope it
+/// introduces), while Lam nodes keep their outer scope. So for a given
+/// non-root scope `sid`, finding a Module whose `node_scope` entry equals
+/// `sid` identifies the block that introduced that scope. Walking up the
+/// parent chain handles both empty blocks (no ModuleDef decls) and nodes
+/// nested inside a lambda within a block.
+///
+/// Returns None if the node is at root scope or no Module ancestor exists.
+fn find_enclosing_block(
   g : @scope.ScopeGraph,
-  scope_id : @scope.ScopeId,
-) -> Bool {
-  let @scope.ScopeId(si) = scope_id
-  g.scopes[si].decl_ids
-  .iter()
-  .any(fn(did) {
-    let @scope.DeclId(di) = did
-    g.decls[di].kind is @scope.DeclKind::ModuleDef(_)
-  })
+  registry : Map[NodeId, ProjNode[@ast.Term]],
+  node_id : NodeId,
+) -> ProjNode[@ast.Term]? {
+  guard root_scope_id(g) is Some(root) else { return None }
+  let mut cur = g.node_scope.get(node_id)
+  while cur is Some(sid) && sid != root {
+    let module_opt = registry
+      .values()
+      .find_first(fn(n) {
+        n.kind is @ast.Term::Module(_, _) &&
+        g.node_scope.get(n.id()) is Some(nsid) &&
+        nsid == sid
+      })
+    if module_opt is Some(block) {
+      return Some(block)
+    }
+    let @scope.ScopeId(si) = sid
+    cur = g.scopes[si].parent
+  }
+  None
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -15,6 +15,106 @@ fn compute_extract_to_let(
   }
   let g = @scope.build(ctx.registry, ctx.source_map)
   let fv = free_vars(node.kind, @immut/hashset.new())
+  // Build edits
+  let expr_text = @ast.print_term(node.kind)
+  let let_text = "let " + var_name + " = " + expr_text + "\n"
+  // If the node lives in a nested block scope, insert into that block rather
+  // than hoisting to the root. Detect by comparing the node's scope against
+  // the root scope; a non-root scope with ModuleDef decls is a block scope.
+  // NOTE: block detection must run BEFORE the root-relative capture check,
+  // because the block-body sub-path skips that check (the let is inserted at
+  // the same position as the expression, so free vars cannot rebind).
+  let node_scope_id_opt = g.node_scope.get(node_id)
+  let is_block_internal = match (node_scope_id_opt, root_scope_id(g)) {
+    (Some(nid), Some(root)) => nid != root && scope_has_module_defs(g, nid)
+    _ => false
+  }
+  if is_block_internal {
+    let block_scope_id = node_scope_id_opt.unwrap()
+    guard ctx.registry
+      .values()
+      .find_first(fn(n) {
+        n.kind is @ast.Term::Module(_, _) &&
+        g.node_scope.get(n.id()) is Some(sid) &&
+        sid == block_scope_id
+      })
+      is Some(block_node) else {
+      return Err("Cannot extract: enclosing block not found")
+    }
+    let block_view = EditModuleView::from_root(block_node)
+    let block_body_start = match block_view.final_expr {
+      Some(body) =>
+        match ctx.source_map.get_range(body.id()) {
+          Some(r) => r.start
+          None => source_text.length()
+        }
+      None => source_text.length()
+    }
+    if range.start >= block_body_start {
+      // Node is in the block body. The let is inserted immediately before the
+      // body, so free vars of the expression remain in scope — no rebind check.
+      let block_body_end = match block_view.final_expr {
+        Some(body) =>
+          match ctx.source_map.get_range(body.id()) {
+            Some(r) => r.end
+            None => source_text.length()
+          }
+        None => source_text.length()
+      }
+      let prefix = source_text[block_body_start:range.start].to_owned()
+      let suffix = source_text[range.end:block_body_end].to_owned()
+      let new_body_text = let_text + prefix + var_name + suffix
+      return Ok(
+        Some(
+          (
+            [
+              {
+                start: block_body_start,
+                delete_len: block_body_end - block_body_start,
+                inserted: new_body_text,
+              },
+            ],
+            MoveCursor(
+              position=block_body_start + let_text.length() + prefix.length(),
+            ),
+          ),
+        ),
+      )
+    } else {
+      // Node is in a block def. The let is inserted before ALL block defs, so
+      // block-local free vars (not in scope before the first def) would become
+      // unbound. Apply the root-relative capture check as a conservative guard.
+      let would_capture = if module_view.defs.is_empty() {
+        free_names_captured_at_use_sites(g, node, fv)
+      } else {
+        free_names_would_rebind_at_module_end(g, definition_index, node, fv)
+      }
+      if would_capture {
+        return Err("Cannot extract: expression captures lambda-bound variables")
+      }
+      guard block_node.children.length() > 0 else {
+        return Err("Cannot extract: block has no children")
+      }
+      let block_start = block_node.children[0].start
+      return Ok(
+        Some(
+          (
+            [
+              { start: block_start, delete_len: 0, inserted: let_text },
+              {
+                start: range.start,
+                delete_len: range.end - range.start,
+                inserted: var_name,
+              },
+            ],
+            // let_text inserted at block_start < range.start, so range shifts right
+            MoveCursor(position=range.start + let_text.length()),
+          ),
+        ),
+      )
+    }
+  }
+  // Root-level extraction: apply the standard capture check.
   let would_capture = if module_view.defs.is_empty() {
     free_names_captured_at_use_sites(g, node, fv)
   } else {
@@ -23,9 +123,6 @@ fn compute_extract_to_let(
   if would_capture {
     return Err("Cannot extract: expression captures lambda-bound variables")
   }
-  // Build edits
-  let expr_text = @ast.print_term(node.kind)
-  let let_text = "let " + var_name + " = " + expr_text + "\n"
   if module_view.defs.is_empty() && module_view.final_expr is Some(_) {
     // No module — wrap: replace expression with "let name = expr\nname"
     let new_text = let_text + var_name

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -92,15 +92,33 @@ fn compute_extract_to_let(
         ),
       )
     } else {
-      // Node is in a block def. The let is inserted before ALL block defs, so
-      // block-local free vars (not in scope before the first def) would become
-      // unbound. Apply the root-relative capture check as a conservative guard.
-      let would_capture = if module_view.defs.is_empty() {
-        free_names_captured_at_use_sites(g, node, fv)
-      } else {
-        free_names_would_rebind_at_module_end(g, definition_index, node, fv)
+      // Node is in a block def. Insertion is at the block's first def position,
+      // still inside any lambda that encloses the block. Reject if any free var
+      // resolves to a decl whose scope is the block's own inner scope or any
+      // nested scope (scope_is_within). This catches two cases:
+      //   1. Block-local ModuleDefs: not yet visible at the block start (sequential scoping).
+      //   2. Lambda params declared inside the block: not in scope at the block start.
+      // Lambda params declared OUTSIDE the block stay visible at the insertion
+      // point and must not be rejected.
+      let node_subtree = subtree_node_ids(node)
+      let unsafe_ref = match g.node_scope.get(block_node.id()) {
+        Some(bis) =>
+          fv
+          .iter()
+          .any(fn(v) {
+            let var_ids : Array[NodeId] = []
+            collect_var_usages(node, v, var_ids)
+            var_ids.any(fn(vid) {
+              match @scope.declaration(g, vid) {
+                Some(decl) if !node_subtree.contains(decl.node_id) =>
+                  scope_is_within(g, decl.scope, bis)
+                _ => false
+              }
+            })
+          })
+        None => false
       }
-      if would_capture {
+      if unsafe_ref {
         return Err("Cannot extract: expression captures lambda-bound variables")
       }
       // Guard: inserting `let var_name = expr` before all block defs makes
@@ -108,7 +126,6 @@ fn compute_extract_to_let(
       // outside the extracted expression — whether currently resolved or free —
       // must be refused: a resolved use would be retargeted; a free use would
       // become bound. Both change semantics.
-      let node_subtree = subtree_node_ids(node)
       let block_var_ids : Array[NodeId] = []
       collect_var_usages(block_node, var_name, block_var_ids)
       for vid in block_var_ids {

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -61,6 +61,24 @@ fn compute_extract_to_let(
           }
         None => source_text.length()
       }
+      // Guard: inserting `let var_name = expr` makes var_name visible throughout
+      // the new body. Any existing resolved Var(var_name) in the body OUTSIDE
+      // the extracted expression would be silently retargeted to the new binding.
+      if block_view.final_expr is Some(body_node) {
+        let node_subtree = subtree_node_ids(node)
+        let body_var_ids : Array[NodeId] = []
+        collect_var_usages(body_node, var_name, body_var_ids)
+        for vid in body_var_ids {
+          if !node_subtree.contains(vid) &&
+            @scope.declaration(g, vid) is Some(_) {
+            return Err(
+              "Cannot extract: '" +
+              var_name +
+              "' is already bound in the block body",
+            )
+          }
+        }
+      }
       let prefix = source_text[block_body_start:range.start].to_owned()
       let suffix = source_text[range.end:block_body_end].to_owned()
       let new_body_text = let_text + prefix + var_name + suffix

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -19,28 +19,11 @@ fn compute_extract_to_let(
   let expr_text = @ast.print_term(node.kind)
   let let_text = "let " + var_name + " = " + expr_text + "\n"
   // If the node lives in a nested block scope, insert into that block rather
-  // than hoisting to the root. Detect by comparing the node's scope against
-  // the root scope; a non-root scope with ModuleDef decls is a block scope.
-  // NOTE: block detection must run BEFORE the root-relative capture check,
-  // because the block-body sub-path skips that check (the let is inserted at
-  // the same position as the expression, so free vars cannot rebind).
-  let node_scope_id_opt = g.node_scope.get(node_id)
-  let is_block_internal = match (node_scope_id_opt, root_scope_id(g)) {
-    (Some(nid), Some(root)) => nid != root && scope_has_module_defs(g, nid)
-    _ => false
-  }
-  if is_block_internal {
-    let block_scope_id = node_scope_id_opt.unwrap()
-    guard ctx.registry
-      .values()
-      .find_first(fn(n) {
-        n.kind is @ast.Term::Module(_, _) &&
-        g.node_scope.get(n.id()) is Some(sid) &&
-        sid == block_scope_id
-      })
-      is Some(block_node) else {
-      return Err("Cannot extract: enclosing block not found")
-    }
+  // than hoisting to the root. Walk ancestor scopes to find the innermost
+  // enclosing Module (handles empty blocks and lambda-nested nodes correctly).
+  // NOTE: block detection must run BEFORE the root-relative capture check;
+  // the block sub-paths have their own guards.
+  if find_enclosing_block(g, ctx.registry, node_id) is Some(block_node) {
     let block_view = EditModuleView::from_root(block_node)
     let block_body_start = match block_view.final_expr {
       Some(body) =>
@@ -78,6 +61,15 @@ fn compute_extract_to_let(
               "' appears in the block body outside the selected expression",
             )
           }
+        }
+        // Guard: node may sit inside a lambda nested in the block body. The
+        // let is inserted before the lambda, outside its param's scope, so
+        // any free var of the extracted expression that resolves via the
+        // lambda param would become unbound after extraction.
+        if free_names_would_rebind_at_node(g, node, body_node.id(), fv) {
+          return Err(
+            "Cannot extract: expression captures lambda-bound variables",
+          )
         }
       }
       let prefix = source_text[block_body_start:range.start].to_owned()

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -62,19 +62,20 @@ fn compute_extract_to_let(
         None => source_text.length()
       }
       // Guard: inserting `let var_name = expr` makes var_name visible throughout
-      // the new body. Any existing resolved Var(var_name) in the body OUTSIDE
-      // the extracted expression would be silently retargeted to the new binding.
+      // the new body. Any Var(var_name) in the body OUTSIDE the extracted
+      // expression — whether currently resolved or free — must be refused:
+      // a resolved use would be retargeted; a free use would become bound.
+      // Both change semantics.
       if block_view.final_expr is Some(body_node) {
         let node_subtree = subtree_node_ids(node)
         let body_var_ids : Array[NodeId] = []
         collect_var_usages(body_node, var_name, body_var_ids)
         for vid in body_var_ids {
-          if !node_subtree.contains(vid) &&
-            @scope.declaration(g, vid) is Some(_) {
+          if !node_subtree.contains(vid) {
             return Err(
               "Cannot extract: '" +
               var_name +
-              "' is already bound in the block body",
+              "' appears in the block body outside the selected expression",
             )
           }
         }
@@ -111,16 +112,19 @@ fn compute_extract_to_let(
         return Err("Cannot extract: expression captures lambda-bound variables")
       }
       // Guard: inserting `let var_name = expr` before all block defs makes
-      // var_name visible throughout the block. Any existing resolved
-      // Var(var_name) in the block outside the extracted expression would be
-      // silently retargeted to the new binding, changing semantics.
+      // var_name visible throughout the block. Any Var(var_name) in the block
+      // outside the extracted expression — whether currently resolved or free —
+      // must be refused: a resolved use would be retargeted; a free use would
+      // become bound. Both change semantics.
       let node_subtree = subtree_node_ids(node)
       let block_var_ids : Array[NodeId] = []
       collect_var_usages(block_node, var_name, block_var_ids)
       for vid in block_var_ids {
-        if !node_subtree.contains(vid) && @scope.declaration(g, vid) is Some(_) {
+        if !node_subtree.contains(vid) {
           return Err(
-            "Cannot extract: '" + var_name + "' is already bound in this block",
+            "Cannot extract: '" +
+            var_name +
+            "' appears in this block outside the selected expression",
           )
         }
       }

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -110,6 +110,20 @@ fn compute_extract_to_let(
       if would_capture {
         return Err("Cannot extract: expression captures lambda-bound variables")
       }
+      // Guard: inserting `let var_name = expr` before all block defs makes
+      // var_name visible throughout the block. Any existing resolved
+      // Var(var_name) in the block outside the extracted expression would be
+      // silently retargeted to the new binding, changing semantics.
+      let node_subtree = subtree_node_ids(node)
+      let block_var_ids : Array[NodeId] = []
+      collect_var_usages(block_node, var_name, block_var_ids)
+      for vid in block_var_ids {
+        if !node_subtree.contains(vid) && @scope.declaration(g, vid) is Some(_) {
+          return Err(
+            "Cannot extract: '" + var_name + "' is already bound in this block",
+          )
+        }
+      }
       guard block_node.children.length() > 0 else {
         return Err("Cannot extract: block has no children")
       }

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1075,6 +1075,32 @@ test "compute_text_edit: ExtractToLet refuses block-body extraction when var_nam
 }
 
 ///|
+/// Inserting `let var_name = expr` before all block defs makes var_name
+/// visible throughout the block. Any existing Var(var_name) in the block
+/// (in later def initializers or the body) that currently resolves to an
+/// outer binding is silently retargeted, changing semantics. The block-def
+/// path must refuse.
+/// Example: outer `y`, block `{ let a = 1\n  y + a }`, extracting `1` as
+/// `y` would insert `let y = 1` before `let a`, making body `y + a` resolve
+/// `y` to 1 instead of the outer binding.
+test "compute_text_edit: ExtractToLet refuses block-def extraction when var_name would capture block ref" {
+  let text = "let y = 5\nlet z = { let a = 1\n  y + a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // z is proj.children[1] (second root def); block is z's init
+  let z_def = proj.children[1]
+  let block = z_def.children[0]
+  // Extract Int(1) from `let a = 1`: block→LetDef("a")→Int(1)
+  let lit_1 = block.children[0].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=lit_1.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 /// Extracting from a block DEF when the expression uses a block-local binding
 /// defined earlier in the same block is correctly refused. Inserting `let y =
 /// expr` before all block defs would put `expr` before `a`'s binding, leaving

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1008,16 +1008,12 @@ test "compute_text_edit: DuplicateBinding on block-local binding" {
 }
 
 ///|
-/// ExtractToLet is NOT yet block-aware (it always hoists to the ROOT body): see
-/// the §20 extract clause. When the extracted block-internal expression
-/// references a block-local binding, the root-relative capture guard catches it
-/// and refuses — so the unsound hoist is at least avoided for this case. (The
-/// error text says "lambda-bound" but the captured binding here is a module
-/// def; the message is misleading, not the verdict.) The complementary case — a
-/// block-internal expression with NO block-local free var — is NOT guarded and
-/// hoists unsoundly; that is the open bug tracked separately, so it is
-/// deliberately not asserted here as if correct.
-test "compute_text_edit: ExtractToLet refuses block-internal expr that uses a block-local binding" {
+/// ExtractToLet is block-aware for block BODY expressions: inserting `let y =
+/// expr` immediately before the body leaves block-local bindings in scope, so
+/// the extraction succeeds even when the body references block-local names.
+/// Verified by reparsing: root keeps exactly 1 def, block gains `y` as a new
+/// def after `a`, and block body becomes `y`.
+test "compute_text_edit: ExtractToLet handles block body with block-local free var" {
   let text = "let z = { let a = 1\n  a + 1 }\nz"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
@@ -1028,7 +1024,137 @@ test "compute_text_edit: ExtractToLet refuses block-internal expr that uses a bl
     ExtractToLet(node_id=body.id(), var_name="y"),
     make_edit_ctx(text, source_map, registry, proj),
   )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed")
+      }
+      match result_proj.kind {
+        @ast.Term::Module(root_defs, _) => {
+          inspect(root_defs.length(), content="1")
+          let inner_block = result_proj.children[0].children[0]
+          match inner_block.kind {
+            @ast.Term::Module(block_defs, _) => {
+              inspect(block_defs.length(), content="2")
+              inspect(block_defs[0].0, content="a")
+              inspect(block_defs[1].0, content="y")
+            }
+            _ => fail("expected inner block to be Module")
+          }
+        }
+        _ => fail("expected root to be Module")
+      }
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+/// Extracting from a block DEF when the expression uses a block-local binding
+/// defined earlier in the same block is correctly refused. Inserting `let y =
+/// expr` before all block defs would put `expr` before `a`'s binding, leaving
+/// `a` unbound. The root-relative capture guard catches this case.
+test "compute_text_edit: ExtractToLet refuses block-def extraction with block-local free var" {
+  let text = "let z = { let a = 1\n  let b = a + 1\n  b }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // Extract `a + 1` (the init of `let b`): block→LetDef("b")→Add(Var("a"), Int(1))
+  let block = proj.children[0].children[0]
+  let b_init = block.children[1].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=b_init.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
   inspect(result is Err(_), content="true")
+}
+
+///|
+/// Extracting a block-internal expression with no block-local free var inserts
+/// the let inside the enclosing block (not hoisted to root). Verified by
+/// reparsing: root keeps exactly 1 def, and the block gains the new binding
+/// as its first def.
+test "compute_text_edit: ExtractToLet inserts inside block for block-internal def" {
+  let text = "let z = { let a = 1\n  a + 1 }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // Int(1) is: proj→LetDef("z")→block→LetDef("a")→Int(1)
+  let block = proj.children[0].children[0]
+  let lit_1 = block.children[0].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=lit_1.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed")
+      }
+      // The let binding must be inside the block, so root still has exactly 1 def.
+      match result_proj.kind {
+        @ast.Term::Module(root_defs, _) => {
+          inspect(root_defs.length(), content="1")
+          // Block is z's init — it should now have 2 defs: y then a.
+          let inner_block = result_proj.children[0].children[0]
+          match inner_block.kind {
+            @ast.Term::Module(block_defs, _) => {
+              inspect(block_defs.length(), content="2")
+              inspect(block_defs[0].0, content="y")
+              inspect(block_defs[1].0, content="a")
+            }
+            _ => fail("expected inner block to be Module")
+          }
+        }
+        _ => fail("expected root to be Module")
+      }
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+/// Non-first block def: extracting a block-internal expression that is not in
+/// the first binding still inserts let y before all block defs (at block start).
+test "compute_text_edit: ExtractToLet inserts before all block defs for non-first def" {
+  let text = "let z = { let a = 1\n  let b = 2\n  a + b }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // Extract Int(2) from `let b = 2`: proj→LetDef("z")→block→LetDef("b")→Int(2)
+  let block = proj.children[0].children[0]
+  let lit_2 = block.children[1].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=lit_2.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed")
+      }
+      match result_proj.kind {
+        @ast.Term::Module(root_defs, _) => {
+          inspect(root_defs.length(), content="1")
+          let inner_block = result_proj.children[0].children[0]
+          match inner_block.kind {
+            @ast.Term::Module(block_defs, _) => {
+              inspect(block_defs.length(), content="3")
+              inspect(block_defs[0].0, content="y")
+              inspect(block_defs[1].0, content="a")
+              inspect(block_defs[2].0, content="b")
+            }
+            _ => fail("expected inner block to be Module")
+          }
+        }
+        _ => fail("expected root to be Module")
+      }
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1315,6 +1315,54 @@ test "compute_text_edit: ExtractToLet refuses lambda-param rebind in lambda-in-b
 }
 
 ///|
+/// The primary bug-report case: extracting `1` from `let z = { 1 + 2 }` was
+/// inserting at root scope instead of inside the block. Empty-def blocks used
+/// to collapse in projection to their body node (no Module in the registry),
+/// so `find_enclosing_block` returned None. Now empty-def blocks always emit
+/// a Module ProjNode, giving the scope graph a block scope to detect.
+/// Verified by reparsing: root still has 1 def (z), block gains def `y`.
+test "compute_text_edit: ExtractToLet inserts inside empty-def block body" {
+  let text = "let z = { 1 + 2 }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // After Option B: proj→LetDef("z")→Module([], Add)→[Add→[Int(1), Int(2)]]
+  let block = proj.children[0].children[0]
+  let int_1 = block.children[0].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=int_1.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      match result_proj.kind {
+        @ast.Term::Module(root_defs, _) => {
+          inspect(root_defs.length(), content="1")
+          let inner_block = result_proj.children[0].children[0]
+          match inner_block.kind {
+            @ast.Term::Module(block_defs, _) => {
+              inspect(block_defs.length(), content="1")
+              inspect(block_defs[0].0, content="y")
+            }
+            _ =>
+              fail(
+                "expected inner block to be Module, got: " +
+                @debug.to_string(inner_block.kind),
+              )
+          }
+        }
+        _ => fail("expected root to be Module")
+      }
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
 test "compute_text_edit: AddBinding adds new let line" {
   let text = "let x = 0\nx"
   let (proj, _) = parse_to_proj_node(text)

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1250,6 +1250,71 @@ test "compute_text_edit: ExtractToLet inserts before all block defs for non-firs
 }
 
 ///|
+/// Extracting from a lambda body nested inside a block-with-defs must use
+/// block-body insertion, not root insertion. Previously `scope_has_module_defs`
+/// returned false for the lambda scope so the node fell through to root.
+/// The ancestor-scope walk finds the enclosing block Module even when the
+/// selected node is in a lambda scope under the block scope.
+/// Verified by reparsing: root keeps 1 def, block gains a new def `y`.
+test "compute_text_edit: ExtractToLet finds block via ancestor scope for lambda-in-block" {
+  let text = "let z = { let a = 1\n(x) => a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // proj→LetDef("z")→block→[LetDef("a"), Lam("x", Var("a"))]; extract Var("a")
+  let block = proj.children[0].children[0]
+  let var_a = block.children[1].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=var_a.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed")
+      }
+      match result_proj.kind {
+        @ast.Term::Module(root_defs, _) => {
+          inspect(root_defs.length(), content="1")
+          let inner_block = result_proj.children[0].children[0]
+          match inner_block.kind {
+            @ast.Term::Module(block_defs, _) => {
+              inspect(block_defs.length(), content="2")
+              inspect(block_defs[0].0, content="a")
+              inspect(block_defs[1].0, content="y")
+            }
+            _ => fail("expected inner block to be Module")
+          }
+        }
+        _ => fail("expected root to be Module")
+      }
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+/// Extracting a lambda-body expression that captures the lambda param must be
+/// refused even when the lambda is nested inside a block (block-body path).
+/// The let would be inserted before the lambda, outside the param's scope,
+/// making the param references unbound.
+test "compute_text_edit: ExtractToLet refuses lambda-param rebind in lambda-in-block" {
+  let text = "let z = { let a = 1\n(x) => x + a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // proj→LetDef("z")→block→[LetDef("a"), Lam("x", Add(Var("x"), Var("a")))]; extract body
+  let block = proj.children[0].children[0]
+  let lam_body = block.children[1].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=lam_body.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 test "compute_text_edit: AddBinding adds new let line" {
   let text = "let x = 0\nx"
   let (proj, _) = parse_to_proj_node(text)

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1075,6 +1075,48 @@ test "compute_text_edit: ExtractToLet refuses block-body extraction when var_nam
 }
 
 ///|
+/// Free (unresolved) Var(var_name) in the suffix is also a capture: the new
+/// `let var_name = expr` would bind it, changing the program from unbound/stuck
+/// to a resolved value. The check must fire for free uses too, not just
+/// already-resolved ones.
+/// Example: `(a + 1) + y` — `y` is free. Extracting `(a + 1)` as `y` would
+/// produce `let y = a + 1\ny + y` where `y` is now bound.
+test "compute_text_edit: ExtractToLet refuses block-body extraction when var_name would bind free suffix ref" {
+  let text = "let z = { let a = 1\n  (a + 1) + y }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[0].children[0]
+  let body = block.children[block.children.length() - 1]
+  let extracted = body.children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=extracted.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+/// Free (unresolved) Var(var_name) anywhere in the block is also a capture:
+/// inserting `let var_name = expr` before all defs would bind it.
+/// Example: `y` is free in `{ let a = 1\n  y + a }`. Extracting `1` as `y`
+/// would produce `{ let y = 1\n  let a = 1\n  y + a }` where the previously
+/// unbound `y` now resolves.
+test "compute_text_edit: ExtractToLet refuses block-def extraction when var_name would bind free block ref" {
+  let text = "let z = { let a = 1\n  y + a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[0].children[0]
+  let lit_1 = block.children[0].children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=lit_1.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 /// Inserting `let var_name = expr` before all block defs makes var_name
 /// visible throughout the block. Any existing Var(var_name) in the block
 /// (in later def initializers or the body) that currently resolves to an

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1163,6 +1163,64 @@ test "compute_text_edit: ExtractToLet refuses block-def extraction with block-lo
 }
 
 ///|
+/// Lambda param referenced in a block-def init: the param is declared OUTSIDE
+/// the block (in the enclosing lambda), so it stays in scope at the insertion
+/// point. This exercises the scope_is_within check on the block-def path.
+///
+/// Parser wraps the top-level lambda as an unnamed binding, so proj.kind is
+/// Module([("", Lam("x",…))], Unit). Navigation must go through that wrapper.
+test "compute_text_edit: ExtractToLet allows block-def extraction when lambda param is from outside the block" {
+  let text = "fn(x) { let y = x\ny }"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // proj = Module([("", Lam("x", …))], Unit)
+  // proj.children[0] = LetDef("", Lam("x", …))
+  // proj.children[0].children[0] = Lam("x", inner_block)
+  // proj.children[0].children[0].children[0] = inner_block = Module([("y",…)],…)
+  // inner_block.children[0] = LetDef("y", Var("x"))
+  // inner_block.children[0].children[0] = Var("x")  ← target
+  let lam = proj.children[0].children[0]
+  let inner_block = lam.children[0]
+  let let_y = inner_block.children[0]
+  let x_var = let_y.children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=x_var.id(), var_name="v"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      // Root still has 1 def (the unnamed lambda binding); lambda body block
+      // gains the new "v" binding as its first def.
+      match result_proj.kind {
+        @ast.Term::Module(root_defs, _) => {
+          inspect(root_defs.length(), content="1")
+          let lam_block = result_proj.children[0].children[0].children[0]
+          match lam_block.kind {
+            @ast.Term::Module(block_defs, _) => {
+              inspect(block_defs.length(), content="2")
+              inspect(block_defs[0].0, content="v")
+              inspect(block_defs[1].0, content="y")
+            }
+            _ =>
+              fail(
+                "expected lambda body block to be Module, got " +
+                @debug.to_string(lam_block.kind),
+              )
+          }
+        }
+        _ => fail("expected root Module")
+      }
+    }
+    other => fail("expected Ok(Some(_)), got: " + @debug.to_string(other))
+  }
+}
+
+///|
 /// Extracting a block-internal expression with no block-local free var inserts
 /// the let inside the enclosing block (not hoisted to root). Verified by
 /// reparsing: root keeps exactly 1 def, and the block gains the new binding

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1051,6 +1051,30 @@ test "compute_text_edit: ExtractToLet handles block body with block-local free v
 }
 
 ///|
+/// If var_name is already bound in the block body (outside the extracted
+/// expression), inserting `let var_name = expr` would silently retarget those
+/// uses to the new binding, changing semantics. The block-body path must refuse.
+/// Example: `(a + 1) + a` extracting `(a + 1)` as `a` would produce
+/// `let a = (a + 1)\na + a` where the suffix `a` now refers to the new binding
+/// instead of the original `let a = 1`.
+test "compute_text_edit: ExtractToLet refuses block-body extraction when var_name would capture suffix" {
+  let text = "let z = { let a = 1\n  (a + 1) + a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  // Extract `(a + 1)` from the body: block→body→Add(Add(Var(a),Int(1)), Var(a))
+  let block = proj.children[0].children[0]
+  let body = block.children[block.children.length() - 1]
+  // body is Add(Add(Var(a),Int(1)), Var(a)); first child is (a + 1)
+  let extracted = body.children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=extracted.id(), var_name="a"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 /// Extracting from a block DEF when the expression uses a block-local binding
 /// defined earlier in the same block is correctly refused. Inserting `let y =
 /// expr` before all block defs would put `expr` before `a`'s binding, leaving

--- a/lang/lambda/edits/text_edit_wrap.mbt
+++ b/lang/lambda/edits/text_edit_wrap.mbt
@@ -150,13 +150,15 @@ fn compute_insert_child(
         // Insert before the body (last child)
         let body = parent_node.children[parent_node.children.length() - 1]
         match source_map.get_range(body.id()) {
-          Some(r) => r.start
-          None => parent_range.end
+          // Synthetic body (empty-def block): body start equals parent end.
+          // Insert before the closing brace instead of after it.
+          Some(r) if r.start < parent_range.end => r.start
+          _ => parent_range.end - 1
         }
       } else {
         match source_map.get_range(parent_node.children[index].id()) {
-          Some(r) => r.start
-          None => parent_range.start
+          Some(r) if r.start < parent_range.end => r.start
+          _ => parent_range.end - 1
         }
       }
       Ok(

--- a/lang/lambda/proj/cstfold_compat.mbt
+++ b/lang/lambda/proj/cstfold_compat.mbt
@@ -4,14 +4,13 @@
 ///
 /// Loom keeps expression blocks explicit in its raw CstFold term shape:
 /// `{ 1 }` folds to `Module([], Int(1))`, and `{}` folds to
-/// `Error("empty block")`. The Lambda editor already treats a block with no
-/// definitions like grouping syntax and treats an empty block as `Unit`.
-/// Keep that compatibility boundary explicit until the projection pipeline is
-/// fully CstFold-backed.
+/// `Error("empty block")`. Canopy's projection pipeline now matches Loom for
+/// non-empty-body blocks: both produce `Module([], body)` for `{ body }`. The
+/// only remaining divergence is the empty-block `{}`: Loom gives
+/// `Error("empty block")`, Canopy gives `Module([], Unit)`.
 fn cstfold_projection_compatible_term(term : @ast.Term) -> @ast.Term {
   match term {
     Error("empty block") => Unit
-    Module([], body) => cstfold_projection_compatible_term(body)
     _ =>
       match term.children() {
         [] => term
@@ -46,7 +45,6 @@ fn cstfold_projection_compatible_kind(node : @seam.SyntaxNode) -> @ast.Term {
 fn cstfold_projection_compatible_shallow_term(term : @ast.Term) -> @ast.Term {
   match term {
     Error("empty block") => Unit
-    Module([], body) => body
     _ => term
   }
 }

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -393,24 +393,15 @@ pub fn syntax_to_proj_node(
     }
   } else if @parser.BlockExprView::cast(node) is Some(v) {
     // Block expression: { LetDef* Expression? } — same structure as SourceFile.
-    // Collect defs + body, produce Module node (or unwrap single expression).
+    // Collect defs + body, always produce a Module node so the block introduces
+    // its own scope even when it has no definitions. Empty-def blocks produce
+    // Module([], body), which gives extract-to-let a scope boundary to target.
     let defs = v.defs().map(fn(def) { project_let_def(def, counter) })
     let result = match v.body() {
       Some(body) => syntax_to_proj_node(body, counter)
       None => unit_node_at(node.end(), counter)
     }
-    if defs.length() > 0 {
-      module_node_from_defs(defs, result, node.start(), node.end(), counter)
-    } else {
-      // Single expression block: unwrap like ParenExpr
-      ProjNode::new(
-        result.kind,
-        node.start(),
-        node.end(),
-        result.node_id,
-        result.children,
-      )
-    }
+    module_node_from_defs(defs, result, node.start(), node.end(), counter)
   } else if @parser.HoleLiteralView::cast(node) is Some(_) {
     cstfold_leaf_node(node, counter)
   } else {

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -419,9 +419,20 @@ test "cstfold parity: valid module and fn sources agree" {
 }
 
 ///|
-test "cstfold parity: raw block divergence stays behind compatibility adapter" {
-  assert_projection_fold_classification("{ 1 }", Int(1), Module([], Int(1)))
-  assert_projection_fold_classification("{ }", Unit, Error("empty block"))
+test "cstfold parity: block projection agrees with cstfold; empty-block divergence stays behind adapter" {
+  // Non-empty-body blocks: canopy projection now matches Loom CstFold directly.
+  assert_projection_fold_classification(
+    "{ 1 }",
+    Module([], Int(1)),
+    Module([], Int(1)),
+  )
+  // Empty block: canopy gives Module([], Unit), Loom gives Error("empty block").
+  // The compatibility adapter bridges this remaining divergence.
+  assert_projection_fold_classification(
+    "{ }",
+    Module([], Unit),
+    Error("empty block"),
+  )
   assert_term_equal(
     "empty block compatibility normalization",
     Unit,
@@ -436,7 +447,18 @@ test "cstfold parity: raw block divergence stays behind compatibility adapter" {
   )
   assert_projection_matches_compatible_fold("{ 1 }")
   assert_projection_matches_compatible_fold("{ { 1 } }")
-  assert_projection_matches_compatible_fold("let x = { { 1 } }\nx")
+  // Double-nested empty-def block in let-def init position: Loom's
+  // convert_let_def calls convert_function_body on the init expression, which
+  // transparently unwraps an outer empty-def block (defs empty → return body).
+  // Canopy's project_let_def calls syntax_to_proj_node, which preserves all
+  // empty-def blocks as Module nodes. The result: Loom folds to
+  // Module([], Int(1)) as the init (outer unwrapped), while Canopy produces
+  // Module([], Module([], Int(1))) (both levels preserved).
+  assert_projection_fold_classification(
+    "let x = { { 1 } }\nx",
+    Module([("x", Module([], Module([], Int(1))))], Var("x")),
+    Module([("x", Module([], Int(1)))], Var("x")),
+  )
   assert_projection_matches_compatible_fold("{ let x = 1; { x } }")
 }
 


### PR DESCRIPTION
## Summary

`ExtractToLet` was always hoisting the `let` binding to the root body, even when the extracted expression lives inside a block. This PR makes it block-aware and adds capture guards for both paths.

**Commit 1 — block-aware insertion:**
- **Block body path**: inserts `let y = expr` immediately before the body expression.
- **Block def path**: inserts `let y = expr` before all block defs; root-relative capture guard applies.
- Detection: `g.node_scope.get(node_id)` vs `root_scope_id(g)`, with `scope_has_module_defs` to distinguish block scopes from lambda scopes.

**Commit 2 — block-body suffix capture guard (initial):**
- Guard added: collect all `Var(var_name)` in the body, exclude extracted subtree, refuse if any resolve or are free.

**Commit 3 — block-def var_name capture guard (initial):**
- Guard added: same collect/exclude/refuse pattern for the block to catch cases where extracting `1` as `y` silently binds an existing `y` in the block.

**Commit 4 — extend both guards to free references:**
- Both guards now refuse any `Var(var_name)` outside the extracted subtree — resolved or free — since both change semantics.

**Commit 5 — ancestor-scope walk for block detection:**
- Replace `scope_has_module_defs` with `find_enclosing_block` which walks the parent scope chain. Fixes extraction of nodes inside a lambda nested within a block: previously the lambda scope had no `ModuleDef` decls so `scope_has_module_defs` returned false; now the ancestor walk continues to the enclosing block scope and finds the `Module` ProjNode.
- Add `free_names_would_rebind_at_node` guard to the block-body path: since the ancestor walk now lets lambda-nested nodes reach this path, a free var that resolves via the lambda param would become unbound if the let were inserted before the lambda. The guard refuses such extractions.

**Commit 6 — preserve empty-def blocks in projection:**
- Root cause fix: `BlockExprView` nodes with no defs were collapsing to their body expression in `syntax_to_proj_node`, so the scope builder never created a child scope for them. `find_enclosing_block` had nothing to find. Fix: always emit `Module([], body)` for block expressions, giving the scope graph a boundary to anchor block-scope detection.
- Removes `Module([], body)` normalization from the cstfold compat adapter; updates parity tests to document the remaining Loom/Canopy divergence (let-def init path, where Loom's `convert_function_body` transparently unwraps outer empty-def blocks).

## Files changed

- `lang/lambda/edits/scope.mbt`: replace `scope_has_module_defs` with `find_enclosing_block`
- `lang/lambda/edits/text_edit_refactor.mbt`: restructure `compute_extract_to_let` with block-aware paths and capture guards
- `lang/lambda/edits/text_edit_wbtest.mbt`: 11 new tests covering block-body/def paths, resolved and free capture rejection, lambda-in-block ancestor-scope detection, and empty-def block extraction
- `lang/lambda/proj/proj_node.mbt`: always emit `Module` for `BlockExprView` even when defs are empty
- `lang/lambda/proj/cstfold_compat.mbt`: remove obsolete `Module([], body)` normalization rules
- `lang/lambda/proj/proj_node_cstfold_wbtest.mbt`: update parity tests for new block semantics
- `lang/lambda/proj/module_projection_wbtest.mbt`: update `{}` body expectation to `Module([], Unit)`
- `loom`: bump pointer to current main (prerequisite for lambda fixture tests)

## Reuse check

- `EditModuleView::from_root`, `root_scope_id`, `subtree_node_ids`, `collect_var_usages`, `free_names_would_rebind_at_node` — existing helpers reused throughout

## Test plan

- [x] `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/lambda/edits` → 190/190
- [x] `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/lambda/proj` → 78/78
- [x] `moon test` → 1456/1456 JS, 70/70 native

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Extract to Let" refactoring to support block-scoped extraction with improved semantic awareness.
  * Added intelligent detection of variable capture hazards within nested blocks to prevent unintended binding changes.

* **Bug Fixes**
  * Improved handling of block expressions in projection semantics for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->