### PR TITLE
Add Lambda alpha-safe beta pilot

### DIFF
--- a/lang/lambda/alpha/alpha_eq.mbt
+++ b/lang/lambda/alpha/alpha_eq.mbt
@@ -14,14 +14,14 @@ fn alpha_eq_ref(
 ) -> Bool {
   match (left, right) {
     (Bound(left_id), Bound(right_id)) =>
-      match left_to_right.get(left_id) {
-        Some(mapped) => mapped == right_id
-        None =>
-          match right_to_left.get(right_id) {
-            Some(mapped) => mapped == left_id
-            None => left_id == right_id
-          }
-      }
+      left_to_right
+      .get(left_id)
+      .map_or(
+        right_to_left
+        .get(right_id)
+        .map_or(left_id == right_id, mapped => mapped == left_id),
+        mapped => mapped == right_id,
+      )
     (Free(left_free), Free(right_free)) => left_free == right_free
     _ => false
   }

--- a/lang/lambda/alpha/alpha_eq.mbt
+++ b/lang/lambda/alpha/alpha_eq.mbt
@@ -1,0 +1,112 @@
+///|
+pub fn alpha_eq(left : AlphaTerm, right : AlphaTerm) -> Bool {
+  let left_to_right : Map[BinderId, BinderId] = {}
+  let right_to_left : Map[BinderId, BinderId] = {}
+  alpha_eq_term(left, right, left_to_right, right_to_left)
+}
+
+///|
+fn alpha_eq_ref(
+  left : AlphaRef,
+  right : AlphaRef,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  match (left, right) {
+    (Bound(left_id), Bound(right_id)) =>
+      match left_to_right.get(left_id) {
+        Some(mapped) => mapped == right_id
+        None =>
+          match right_to_left.get(right_id) {
+            Some(mapped) => mapped == left_id
+            None => left_id == right_id
+          }
+      }
+    (Free(left_free), Free(right_free)) => left_free == right_free
+    _ => false
+  }
+}
+
+///|
+fn alpha_eq_lam(
+  left_binder : Binder,
+  left_body : AlphaTerm,
+  right_binder : Binder,
+  right_body : AlphaTerm,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  let next_left = left_to_right.copy()
+  let next_right = right_to_left.copy()
+  next_left[left_binder.id] = right_binder.id
+  next_right[right_binder.id] = left_binder.id
+  alpha_eq_term(left_body, right_body, next_left, next_right)
+}
+
+///|
+fn alpha_eq_module(
+  left_defs : Array[(Binder, AlphaTerm)],
+  left_body : AlphaTerm,
+  right_defs : Array[(Binder, AlphaTerm)],
+  right_body : AlphaTerm,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  guard left_defs.length() == right_defs.length() else { return false }
+  let next_left = left_to_right.copy()
+  let next_right = right_to_left.copy()
+  let defs_match = for i in 0..<left_defs.length(); ok = true {
+    if !ok {
+      continue false
+    }
+    let (left_binder, left_init) = left_defs[i]
+    let (right_binder, right_init) = right_defs[i]
+    let same_init = alpha_eq_term(left_init, right_init, next_left, next_right)
+    next_left[left_binder.id] = right_binder.id
+    next_right[right_binder.id] = left_binder.id
+    continue same_init
+  } nobreak {
+    ok
+  }
+  defs_match && alpha_eq_term(left_body, right_body, next_left, next_right)
+}
+
+///|
+fn alpha_eq_term(
+  left : AlphaTerm,
+  right : AlphaTerm,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  match (left, right) {
+    (Int(left_value), Int(right_value)) => left_value == right_value
+    (Unit, Unit) => true
+    (Var(left_ref), Var(right_ref)) =>
+      alpha_eq_ref(left_ref, right_ref, left_to_right, right_to_left)
+    (Lam(left_binder, left_body), Lam(right_binder, right_body)) =>
+      alpha_eq_lam(
+        left_binder, left_body, right_binder, right_body, left_to_right, right_to_left,
+      )
+    (App(left_fn, left_arg), App(right_fn, right_arg)) =>
+      alpha_eq_term(left_fn, right_fn, left_to_right, right_to_left) &&
+      alpha_eq_term(left_arg, right_arg, left_to_right, right_to_left)
+    (Bop(left_op, left_lhs, left_rhs), Bop(right_op, right_lhs, right_rhs)) =>
+      left_op == right_op &&
+      alpha_eq_term(left_lhs, right_lhs, left_to_right, right_to_left) &&
+      alpha_eq_term(left_rhs, right_rhs, left_to_right, right_to_left)
+    (If(left_cond, left_then, left_else), If(right_cond, right_then, right_else)
+    ) =>
+      alpha_eq_term(left_cond, right_cond, left_to_right, right_to_left) &&
+      alpha_eq_term(left_then, right_then, left_to_right, right_to_left) &&
+      alpha_eq_term(left_else, right_else, left_to_right, right_to_left)
+    (LetDef(_, left_init), LetDef(_, right_init)) =>
+      alpha_eq_term(left_init, right_init, left_to_right, right_to_left)
+    (Module(left_defs, left_body), Module(right_defs, right_body)) =>
+      alpha_eq_module(
+        left_defs, left_body, right_defs, right_body, left_to_right, right_to_left,
+      )
+    (Error(left_message), Error(right_message)) => left_message == right_message
+    (Hole(left_index), Hole(right_index)) => left_index == right_index
+    _ => false
+  }
+}

--- a/lang/lambda/alpha/alpha_eq_wbtest.mbt
+++ b/lang/lambda/alpha/alpha_eq_wbtest.mbt
@@ -1,0 +1,24 @@
+///|
+fn identity_lam(id : Int, hint : String) -> AlphaTerm {
+  let binder = test_binder(id, hint)
+  Lam(binder, Var(Bound(binder.id)))
+}
+
+///|
+test "alpha_eq: lambda binder hints do not matter" {
+  assert_true(alpha_eq(identity_lam(0, "x"), identity_lam(1, "y")))
+}
+
+///|
+test "alpha_eq: free and bound references differ" {
+  assert_false(
+    alpha_eq(identity_lam(0, "x"), Lam(test_binder(1, "x"), free_var("x"))),
+  )
+}
+
+///|
+test "alpha_eq: free origin is explicit" {
+  let source_var = Var(Free(test_free("x", SourceVar)))
+  let source_unbound = Var(Free(test_free("x", SourceUnbound)))
+  assert_false(alpha_eq(source_var, source_unbound))
+}

--- a/lang/lambda/alpha/beta_wbtest.mbt
+++ b/lang/lambda/alpha/beta_wbtest.mbt
@@ -1,0 +1,14 @@
+///|
+test "beta pilot: root reduction reifies without capture" {
+  let (proj, graph) = alpha_parse_fixture("((x) => (y) => x) y")
+  guard beta_reduce_root(lower_root(proj, graph)) is Some(reduced) else {
+    fail("expected root beta reduction")
+  }
+  let expected_binder = test_binder(99, "y1")
+  assert_true(alpha_eq(reduced, Lam(expected_binder, free_var("y"))))
+  guard reify(reduced, Source) is @ast.Term::Lam(param, @ast.Term::Var(body)) else {
+    fail("expected reified lambda")
+  }
+  inspect(param, content="y1")
+  inspect(body, content="y")
+}

--- a/lang/lambda/alpha/fixtures_wbtest.mbt
+++ b/lang/lambda/alpha/fixtures_wbtest.mbt
@@ -40,12 +40,10 @@ fn find_var_node(
   if root.kind is @ast.Term::Var(found) && found == name {
     Some(root.id())
   } else {
-    let mut result : @core.NodeId? = None
-    for child in root.children {
-      if result is None {
-        result = find_var_node(child, name)
-      }
-    }
-    result
+    root.children
+    .iter()
+    .map(child => find_var_node(child, name))
+    .find_first(found => found is Some(_))
+    .bind(found => found)
   }
 }

--- a/lang/lambda/alpha/fixtures_wbtest.mbt
+++ b/lang/lambda/alpha/fixtures_wbtest.mbt
@@ -1,0 +1,51 @@
+///|
+fn test_binder(id : Int, hint : String) -> Binder {
+  { id: BinderId(id), hint, origin: Generated(id) }
+}
+
+///|
+fn test_free(name : String, origin : FreeOrigin) -> FreeName {
+  { name, origin }
+}
+
+///|
+fn free_var(name : String) -> AlphaTerm {
+  Var(Free(test_free(name, SourceVar)))
+}
+
+///|
+fn graph_for_root(root : @core.ProjNode[@ast.Term]) -> @scope.ScopeGraph {
+  let source_map = @core.SourceMap::from_ast(root)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  @scope.build(registry, source_map)
+}
+
+///|
+fn alpha_parse_fixture(
+  text : String,
+) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph) raise {
+  let (proj, errors) = @lambda_proj.parse_to_proj_node(text)
+  if errors.length() > 0 {
+    fail("parse diagnostics in alpha fixture")
+  }
+  (proj, graph_for_root(proj))
+}
+
+///|
+fn find_var_node(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId? {
+  if root.kind is @ast.Term::Var(found) && found == name {
+    Some(root.id())
+  } else {
+    let mut result : @core.NodeId? = None
+    for child in root.children {
+      if result is None {
+        result = find_var_node(child, name)
+      }
+    }
+    result
+  }
+}

--- a/lang/lambda/alpha/lower.mbt
+++ b/lang/lambda/alpha/lower.mbt
@@ -31,10 +31,7 @@ fn binder_for_node(
   node_id : @core.NodeId,
   hint : String,
 ) -> Binder {
-  match binders.get(node_id) {
-    Some(binder) => binder
-    None => generated_binder(hint, 0)
-  }
+  binders.get(node_id).map_or(generated_binder(hint, 0), binder => binder)
 }
 
 ///|
@@ -44,14 +41,17 @@ fn lower_ref(
   binders : Map[@core.NodeId, Binder],
   name : String,
 ) -> AlphaTerm {
-  match @scope.declaration(graph, node.id()) {
-    Some(decl) =>
-      match binders.get(decl.node_id) {
-        Some(binder) => Var(Bound(binder.id))
-        None => Error("resolved reference without lowered binder: " + decl.name)
-      }
-    None => Var(Free({ name, origin: SourceVar }))
-  }
+  @scope.declaration(graph, node.id()).map_or(
+    Var(Free({ name, origin: SourceVar })),
+    decl => {
+      binders
+      .get(decl.node_id)
+      .map_or(
+        Error("resolved reference without lowered binder: " + decl.name),
+        binder => Var(Bound(binder.id)),
+      )
+    },
+  )
 }
 
 ///|
@@ -62,10 +62,9 @@ fn lower_child_or_error(
   index : Int,
   label : String,
 ) -> AlphaTerm {
-  match node.children.get(index) {
-    Some(child) => lower_node(child, graph, binders)
-    None => Error("missing " + label)
-  }
+  node.children
+  .get(index)
+  .map_or(Error("missing " + label), child => lower_node(child, graph, binders))
 }
 
 ///|
@@ -91,14 +90,14 @@ fn lower_module(
 ) -> AlphaTerm {
   let lowered_defs : Array[(Binder, AlphaTerm)] = []
   for i, def in defs {
-    match node.children.get(i) {
-      Some(child) =>
-        lowered_defs.push(lower_let_def_child(child, graph, binders, def.0))
-      None =>
-        lowered_defs.push(
-          (generated_binder(def.0, i), Error("missing module definition child")),
-        )
-    }
+    lowered_defs.push(
+      node.children
+      .get(i)
+      .map_or(
+        (generated_binder(def.0, i), Error("missing module definition child")),
+        child => lower_let_def_child(child, graph, binders, def.0),
+      ),
+    )
   }
   let body = lower_child_or_error(
     node,

--- a/lang/lambda/alpha/lower.mbt
+++ b/lang/lambda/alpha/lower.mbt
@@ -1,0 +1,156 @@
+///|
+pub fn lower_root(
+  root : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+) -> AlphaTerm {
+  let binders = source_binders(graph)
+  lower_node(root, graph, binders)
+}
+
+///|
+fn source_binders(graph : @scope.ScopeGraph) -> Map[@core.NodeId, Binder] {
+  let binders : Map[@core.NodeId, Binder] = {}
+  for i, decl in graph.decls {
+    binders[decl.node_id] = {
+      id: BinderId(i),
+      hint: decl.name,
+      origin: SourceDecl(node_id=decl.node_id, hint=decl.name),
+    }
+  }
+  binders
+}
+
+///|
+fn generated_binder(hint : String, salt : Int) -> Binder {
+  { id: BinderId(-1 - salt), hint, origin: Generated(salt) }
+}
+
+///|
+fn binder_for_node(
+  binders : Map[@core.NodeId, Binder],
+  node_id : @core.NodeId,
+  hint : String,
+) -> Binder {
+  match binders.get(node_id) {
+    Some(binder) => binder
+    None => generated_binder(hint, 0)
+  }
+}
+
+///|
+fn lower_ref(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+  name : String,
+) -> AlphaTerm {
+  match @scope.declaration(graph, node.id()) {
+    Some(decl) =>
+      match binders.get(decl.node_id) {
+        Some(binder) => Var(Bound(binder.id))
+        None => Error("resolved reference without lowered binder: " + decl.name)
+      }
+    None => Var(Free({ name, origin: SourceVar }))
+  }
+}
+
+///|
+fn lower_child_or_error(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+  index : Int,
+  label : String,
+) -> AlphaTerm {
+  match node.children.get(index) {
+    Some(child) => lower_node(child, graph, binders)
+    None => Error("missing " + label)
+  }
+}
+
+///|
+fn lower_let_def_child(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+  hint : String,
+) -> (Binder, AlphaTerm) {
+  let binder = binder_for_node(binders, node.id(), hint)
+  let init = lower_child_or_error(
+    node, graph, binders, 0, "let definition init",
+  )
+  (binder, init)
+}
+
+///|
+fn lower_module(
+  node : @core.ProjNode[@ast.Term],
+  defs : Array[(String, @ast.Term)],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+) -> AlphaTerm {
+  let lowered_defs : Array[(Binder, AlphaTerm)] = []
+  for i, def in defs {
+    match node.children.get(i) {
+      Some(child) =>
+        lowered_defs.push(lower_let_def_child(child, graph, binders, def.0))
+      None =>
+        lowered_defs.push(
+          (generated_binder(def.0, i), Error("missing module definition child")),
+        )
+    }
+  }
+  let body = lower_child_or_error(
+    node,
+    graph,
+    binders,
+    defs.length(),
+    "module body",
+  )
+  Module(lowered_defs, body)
+}
+
+///|
+fn lower_node(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+) -> AlphaTerm {
+  match node.kind {
+    @ast.Term::Int(value) => Int(value)
+    @ast.Term::Unit => Unit
+    @ast.Term::Var(name) => lower_ref(node, graph, binders, name)
+    @ast.Term::Unbound(name) => Var(Free({ name, origin: SourceUnbound }))
+    @ast.Term::Lam(name, _) => {
+      let binder = binder_for_node(binders, node.id(), name)
+      Lam(binder, lower_child_or_error(node, graph, binders, 0, "lambda body"))
+    }
+    @ast.Term::App(_, _) =>
+      App(
+        lower_child_or_error(node, graph, binders, 0, "application function"),
+        lower_child_or_error(node, graph, binders, 1, "application argument"),
+      )
+    @ast.Term::Bop(op, _, _) =>
+      Bop(
+        op,
+        lower_child_or_error(node, graph, binders, 0, "binary lhs"),
+        lower_child_or_error(node, graph, binders, 1, "binary rhs"),
+      )
+    @ast.Term::If(_, _, _) =>
+      If(
+        lower_child_or_error(node, graph, binders, 0, "if condition"),
+        lower_child_or_error(node, graph, binders, 1, "if then branch"),
+        lower_child_or_error(node, graph, binders, 2, "if else branch"),
+      )
+    @ast.Term::LetDef(name, _) => {
+      let binder = binder_for_node(binders, node.id(), name)
+      LetDef(
+        binder,
+        lower_child_or_error(node, graph, binders, 0, "let definition init"),
+      )
+    }
+    @ast.Term::Module(defs, _) => lower_module(node, defs, graph, binders)
+    @ast.Term::Error(message) => Error(message)
+    @ast.Term::Hole(index) => Hole(index)
+  }
+}

--- a/lang/lambda/alpha/lower_wbtest.mbt
+++ b/lang/lambda/alpha/lower_wbtest.mbt
@@ -1,0 +1,87 @@
+///|
+test "lower: lambda references resolve to bound binder ids" {
+  let (proj, graph) = alpha_parse_fixture("(x) => x")
+  guard find_var_node(proj, "x") is Some(var_node) else {
+    fail("missing x ref")
+  }
+  guard @scope.declaration(graph, var_node) is Some(_) else {
+    fail("scope graph did not resolve x")
+  }
+  guard lower_root(proj, graph) is Lam(binder, Var(Bound(ref_id))) else {
+    fail("expected lambda with bound body")
+  }
+  inspect(ref_id == binder.id, content="true")
+}
+
+///|
+test "lower: unresolved source var remains free" {
+  let (proj, graph) = alpha_parse_fixture("y")
+  guard find_var_node(proj, "y") is Some(var_node) else {
+    fail("missing y ref")
+  }
+  inspect(@scope.declaration(graph, var_node) is None, content="true")
+  guard lower_root(proj, graph) is Var(Free(free)) else {
+    fail("expected free var")
+  }
+  inspect(free.name, content="y")
+  inspect(free.origin == SourceVar, content="true")
+}
+
+///|
+test "lower: source Unbound origin is preserved" {
+  let root = @core.ProjNode::new(@ast.Term::Unbound("missing"), 0, 7, 0, [])
+  let graph = graph_for_root(root)
+  guard lower_root(root, graph) is Var(Free(free)) else {
+    fail("expected free unbound")
+  }
+  inspect(free.name, content="missing")
+  inspect(free.origin == SourceUnbound, content="true")
+}
+
+///|
+test "lower: source Unbound remains free even when a binder has the same name" {
+  let child = @core.ProjNode::new(@ast.Term::Unbound("x"), 0, 1, 1, [])
+  let root = @core.ProjNode::new(
+    @ast.Term::Lam("x", @ast.Term::Unbound("x")),
+    0,
+    8,
+    0,
+    [child],
+  )
+  let graph = graph_for_root(root)
+  guard lower_root(root, graph) is Lam(_, Var(Free(free))) else {
+    fail("expected lambda body to stay SourceUnbound")
+  }
+  inspect(free.name, content="x")
+  inspect(free.origin == SourceUnbound, content="true")
+}
+
+///|
+test "lower: Error and Hole survive" {
+  let error_root = @core.ProjNode::new(@ast.Term::Error("bad"), 0, 3, 0, [])
+  let hole_root = @core.ProjNode::new(@ast.Term::Hole(2), 0, 1, 0, [])
+  inspect(
+    lower_root(error_root, graph_for_root(error_root)) is Error("bad"),
+    content="true",
+  )
+  inspect(
+    lower_root(hole_root, graph_for_root(hole_root)) is Hole(2),
+    content="true",
+  )
+}
+
+///|
+test "lower: sequential module scope follows ScopeGraph" {
+  let (proj, graph) = alpha_parse_fixture("let x = 1\nlet x = x\nx")
+  guard lower_root(proj, graph) is Module(defs, Var(Bound(body_id))) else {
+    fail("expected lowered module")
+  }
+  guard defs.length() == 2 else { fail("expected two definitions") }
+  let (first_binder, _) = defs[0]
+  let (second_binder, second_init) = defs[1]
+  guard second_init is Var(Bound(init_id)) else {
+    fail("expected second init to reference first x")
+  }
+  inspect(init_id == first_binder.id, content="true")
+  inspect(body_id == second_binder.id, content="true")
+}

--- a/lang/lambda/alpha/moon.pkg
+++ b/lang/lambda/alpha/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/scope",
+  "dowdiness/lambda/ast",
+}
+
+import {
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+} for "wbtest"

--- a/lang/lambda/alpha/pkg.generated.mbti
+++ b/lang/lambda/alpha/pkg.generated.mbti
@@ -1,0 +1,74 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/lambda/alpha"
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/scope",
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn alpha_eq(AlphaTerm, AlphaTerm) -> Bool
+
+pub fn beta_reduce_root(AlphaTerm) -> AlphaTerm?
+
+pub fn lower_root(@core.ProjNode[@ast.Term], @scope.ScopeGraph) -> AlphaTerm
+
+pub fn reify(AlphaTerm, ReifyPolicy) -> @ast.Term
+
+// Errors
+
+// Types and methods
+pub(all) enum AlphaRef {
+  Bound(BinderId)
+  Free(FreeName)
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AlphaTerm {
+  Int(Int)
+  Unit
+  Var(AlphaRef)
+  Lam(Binder, AlphaTerm)
+  App(AlphaTerm, AlphaTerm)
+  Bop(@ast.Bop, AlphaTerm, AlphaTerm)
+  If(AlphaTerm, AlphaTerm, AlphaTerm)
+  LetDef(Binder, AlphaTerm)
+  Module(Array[(Binder, AlphaTerm)], AlphaTerm)
+  Error(String)
+  Hole(Int)
+} derive(Eq, @debug.Debug)
+
+pub(all) struct Binder {
+  id : BinderId
+  hint : String
+  origin : BinderOrigin
+} derive(Eq, @debug.Debug)
+
+pub(all) struct BinderId(Int) derive(Eq, Hash, @debug.Debug)
+
+pub(all) enum BinderOrigin {
+  SourceDecl(node_id~ : @core.NodeId, hint~ : String)
+  Generated(Int)
+} derive(Eq, @debug.Debug)
+
+pub(all) struct FreeName {
+  name : String
+  origin : FreeOrigin
+} derive(Eq, @debug.Debug)
+
+pub(all) enum FreeOrigin {
+  SourceVar
+  SourceUnbound
+  GeneratedFree
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ReifyPolicy {
+  Display
+  Source
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/lang/lambda/alpha/reify.mbt
+++ b/lang/lambda/alpha/reify.mbt
@@ -1,0 +1,195 @@
+///|
+pub fn reify(term : AlphaTerm, policy : ReifyPolicy) -> @ast.Term {
+  let env : Map[BinderId, String] = {}
+  let used : Array[String] = []
+  reify_with(term, policy, env, used)
+}
+
+///|
+fn push_unique(names : Array[String], name : String) -> Unit {
+  if !names.contains(name) {
+    names.push(name)
+  }
+}
+
+///|
+fn merged_names(left : Array[String], right : Array[String]) -> Array[String] {
+  let result = left.copy()
+  for name in right {
+    push_unique(result, name)
+  }
+  result
+}
+
+///|
+fn free_names(term : AlphaTerm) -> Array[String] {
+  match term {
+    Var(Free(free)) => [free.name]
+    Var(Bound(_)) => []
+    Lam(_, body) => free_names(body)
+    App(func, arg) => merged_names(free_names(func), free_names(arg))
+    Bop(_, lhs, rhs) => merged_names(free_names(lhs), free_names(rhs))
+    If(cond, then_, else_) =>
+      merged_names(
+        merged_names(free_names(cond), free_names(then_)),
+        free_names(else_),
+      )
+    LetDef(_, init) => free_names(init)
+    Module(defs, body) => {
+      let result = free_names(body)
+      for def in defs {
+        let (_, init) = def
+        for name in free_names(init) {
+          push_unique(result, name)
+        }
+      }
+      result
+    }
+    Int(_) | Unit | Error(_) | Hole(_) => []
+  }
+}
+
+///|
+fn suffix_free_names(
+  defs : Array[(Binder, AlphaTerm)],
+  body : AlphaTerm,
+  start : Int,
+) -> Array[String] {
+  let result = free_names(body)
+  for i in start..<defs.length() {
+    let (_, init) = defs[i]
+    for name in free_names(init) {
+      push_unique(result, name)
+    }
+  }
+  result
+}
+
+///|
+fn base_hint(hint : String) -> String {
+  if hint == "" {
+    "x"
+  } else {
+    hint
+  }
+}
+
+///|
+fn fresh_name(hint : String, avoid : Array[String]) -> String {
+  let base = base_hint(hint)
+  if !avoid.contains(base) {
+    base
+  } else {
+    for i = 1 {
+      let candidate = base + i.to_string()
+      if !avoid.contains(candidate) {
+        break candidate
+      }
+      continue i + 1
+    }
+  }
+}
+
+///|
+fn reify_ref(
+  alpha_ref : AlphaRef,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+) -> @ast.Term {
+  match alpha_ref {
+    Bound(id) =>
+      match env.get(id) {
+        Some(name) => @ast.Term::Var(name)
+        None =>
+          match policy {
+            Display => @ast.Term::Unbound("bound")
+            Source => @ast.Term::Var("bound")
+          }
+      }
+    Free(free) =>
+      match (policy, free.origin) {
+        (Display, SourceUnbound) => @ast.Term::Unbound(free.name)
+        _ => @ast.Term::Var(free.name)
+      }
+  }
+}
+
+///|
+fn reify_lam(
+  binder : Binder,
+  body : AlphaTerm,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+  used : Array[String],
+) -> @ast.Term {
+  let avoid = merged_names(used, free_names(body))
+  let name = fresh_name(binder.hint, avoid)
+  let next_env = env.copy()
+  next_env[binder.id] = name
+  let next_used = used.copy()
+  push_unique(next_used, name)
+  @ast.Term::Lam(name, reify_with(body, policy, next_env, next_used))
+}
+
+///|
+fn reify_module(
+  defs : Array[(Binder, AlphaTerm)],
+  body : AlphaTerm,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+  used : Array[String],
+) -> @ast.Term {
+  let out_defs : Array[(String, @ast.Term)] = []
+  let next_env = env.copy()
+  let next_used = used.copy()
+  for i, def in defs {
+    let (binder, init) = def
+    let init_term = reify_with(init, policy, next_env, next_used)
+    let avoid = merged_names(next_used, suffix_free_names(defs, body, i + 1))
+    let name = fresh_name(binder.hint, avoid)
+    out_defs.push((name, init_term))
+    next_env[binder.id] = name
+    push_unique(next_used, name)
+  }
+  @ast.Term::Module(out_defs, reify_with(body, policy, next_env, next_used))
+}
+
+///|
+fn reify_with(
+  term : AlphaTerm,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+  used : Array[String],
+) -> @ast.Term {
+  match term {
+    Int(value) => @ast.Term::Int(value)
+    Unit => @ast.Term::Unit
+    Var(alpha_ref) => reify_ref(alpha_ref, policy, env)
+    Lam(binder, body) => reify_lam(binder, body, policy, env, used)
+    App(func, arg) =>
+      @ast.Term::App(
+        reify_with(func, policy, env, used),
+        reify_with(arg, policy, env, used),
+      )
+    Bop(op, lhs, rhs) =>
+      @ast.Term::Bop(
+        op,
+        reify_with(lhs, policy, env, used),
+        reify_with(rhs, policy, env, used),
+      )
+    If(cond, then_, else_) =>
+      @ast.Term::If(
+        reify_with(cond, policy, env, used),
+        reify_with(then_, policy, env, used),
+        reify_with(else_, policy, env, used),
+      )
+    LetDef(binder, init) =>
+      @ast.Term::LetDef(
+        fresh_name(binder.hint, used),
+        reify_with(init, policy, env, used),
+      )
+    Module(defs, body) => reify_module(defs, body, policy, env, used)
+    Error(message) => @ast.Term::Error(message)
+    Hole(index) => @ast.Term::Hole(index)
+  }
+}

--- a/lang/lambda/alpha/reify.mbt
+++ b/lang/lambda/alpha/reify.mbt
@@ -98,14 +98,15 @@ fn reify_ref(
 ) -> @ast.Term {
   match alpha_ref {
     Bound(id) =>
-      match env.get(id) {
-        Some(name) => @ast.Term::Var(name)
-        None =>
-          match policy {
-            Display => @ast.Term::Unbound("bound")
-            Source => @ast.Term::Var("bound")
-          }
-      }
+      env
+      .get(id)
+      .map_or(
+        match policy {
+          Display => @ast.Term::Unbound("bound")
+          Source => @ast.Term::Var("bound")
+        },
+        name => @ast.Term::Var(name),
+      )
     Free(free) =>
       match (policy, free.origin) {
         (Display, SourceUnbound) => @ast.Term::Unbound(free.name)

--- a/lang/lambda/alpha/reify_wbtest.mbt
+++ b/lang/lambda/alpha/reify_wbtest.mbt
@@ -1,0 +1,43 @@
+///|
+test "reify: freshens binders against free names" {
+  let binder = test_binder(0, "y")
+  let term = Lam(binder, free_var("y"))
+  guard reify(term, Source) is @ast.Term::Lam(name, @ast.Term::Var(body)) else {
+    fail("expected reified lambda")
+  }
+  inspect(name, content="y1")
+  inspect(body, content="y")
+}
+
+///|
+test "reify: Display preserves SourceUnbound and Source normalizes it" {
+  let term = Var(Free(test_free("missing", SourceUnbound)))
+  inspect(@ast.print_term(reify(term, Display)), content="<unbound: missing>")
+  inspect(@ast.print_term(reify(term, Source)), content="missing")
+}
+
+///|
+test "reify: Error and Hole survive" {
+  inspect(
+    reify(Error("bad"), Source) is @ast.Term::Error("bad"),
+    content="true",
+  )
+  inspect(reify(Hole(3), Source) is @ast.Term::Hole(3), content="true")
+}
+
+///|
+test "reify: nested binders avoid capturing outer references" {
+  let outer = test_binder(0, "x")
+  let inner = test_binder(1, "x")
+  let term = Lam(outer, Lam(inner, Var(Bound(outer.id))))
+  guard reify(term, Source)
+    is @ast.Term::Lam(
+      outer_name,
+      @ast.Term::Lam(inner_name, @ast.Term::Var(body_name))
+    ) else {
+    fail("expected nested lambdas")
+  }
+  inspect(outer_name, content="x")
+  inspect(inner_name, content="x1")
+  inspect(body_name, content="x")
+}

--- a/lang/lambda/alpha/subst.mbt
+++ b/lang/lambda/alpha/subst.mbt
@@ -1,0 +1,74 @@
+///|
+fn substitute(
+  term : AlphaTerm,
+  target : BinderId,
+  replacement : AlphaTerm,
+) -> AlphaTerm {
+  match term {
+    Var(Bound(id)) => if id == target { replacement } else { term }
+    Var(Free(_)) => term
+    Lam(binder, body) =>
+      if binder.id == target {
+        term
+      } else {
+        Lam(binder, substitute(body, target, replacement))
+      }
+    App(func, arg) =>
+      App(
+        substitute(func, target, replacement),
+        substitute(arg, target, replacement),
+      )
+    Bop(op, lhs, rhs) =>
+      Bop(
+        op,
+        substitute(lhs, target, replacement),
+        substitute(rhs, target, replacement),
+      )
+    If(cond, then_, else_) =>
+      If(
+        substitute(cond, target, replacement),
+        substitute(then_, target, replacement),
+        substitute(else_, target, replacement),
+      )
+    LetDef(binder, init) =>
+      LetDef(binder, substitute(init, target, replacement))
+    Module(defs, body) => substitute_module(defs, body, target, replacement)
+    Int(_) | Unit | Error(_) | Hole(_) => term
+  }
+}
+
+///|
+fn substitute_module(
+  defs : Array[(Binder, AlphaTerm)],
+  body : AlphaTerm,
+  target : BinderId,
+  replacement : AlphaTerm,
+) -> AlphaTerm {
+  let substituted_defs : Array[(Binder, AlphaTerm)] = []
+  let body_visible = for def in defs; target_visible = true {
+    let (binder, init) = def
+    let substituted_init = if target_visible {
+      substitute(init, target, replacement)
+    } else {
+      init
+    }
+    substituted_defs.push((binder, substituted_init))
+    continue target_visible && binder.id != target
+  } nobreak {
+    target_visible
+  }
+  let substituted_body = if body_visible {
+    substitute(body, target, replacement)
+  } else {
+    body
+  }
+  Module(substituted_defs, substituted_body)
+}
+
+///|
+pub fn beta_reduce_root(term : AlphaTerm) -> AlphaTerm? {
+  match term {
+    App(Lam(binder, body), arg) => Some(substitute(body, binder.id, arg))
+    _ => None
+  }
+}

--- a/lang/lambda/alpha/subst_wbtest.mbt
+++ b/lang/lambda/alpha/subst_wbtest.mbt
@@ -1,0 +1,57 @@
+///|
+test "substitute: replaces matching bound references only" {
+  let x = test_binder(0, "x")
+  let y = test_binder(1, "y")
+  let replacement = free_var("z")
+  let term = App(Var(Bound(x.id)), Var(Bound(y.id)))
+  guard substitute(term, x.id, replacement)
+    is App(Var(Free(free)), Var(Bound(rest))) else {
+    fail("expected one replacement")
+  }
+  inspect(free.name, content="z")
+  inspect(rest == y.id, content="true")
+}
+
+///|
+test "substitute: nested unrelated binders are untouched" {
+  let x = test_binder(0, "x")
+  let y = test_binder(1, "y")
+  let term = Lam(y, Var(Bound(y.id)))
+  guard substitute(term, x.id, free_var("z")) is Lam(_, Var(Bound(ref_id))) else {
+    fail("expected lambda to remain bound to y")
+  }
+  inspect(ref_id == y.id, content="true")
+}
+
+///|
+test "substitute: Error and Hole are preserved" {
+  let x = test_binder(0, "x")
+  inspect(
+    substitute(Error("bad"), x.id, free_var("z")) is Error("bad"),
+    content="true",
+  )
+  inspect(substitute(Hole(4), x.id, free_var("z")) is Hole(4), content="true")
+}
+
+///|
+test "substitute: module binder gates later substitutions" {
+  let x = test_binder(0, "x")
+  let term = Module([(x, Var(Bound(x.id)))], Var(Bound(x.id)))
+  guard substitute(term, x.id, free_var("z"))
+    is Module([(_, Var(Free(init_free)))], Var(Bound(body_id))) else {
+    fail("expected init replacement and body shadowing")
+  }
+  inspect(init_free.name, content="z")
+  inspect(body_id == x.id, content="true")
+}
+
+///|
+test "beta_reduce_root: reduces only root lambda applications" {
+  let x = test_binder(0, "x")
+  let term = App(Lam(x, Var(Bound(x.id))), free_var("z"))
+  guard beta_reduce_root(term) is Some(Var(Free(free))) else {
+    fail("expected root beta reduction")
+  }
+  inspect(free.name, content="z")
+  inspect(beta_reduce_root(free_var("z")) is None, content="true")
+}

--- a/lang/lambda/alpha/types.mbt
+++ b/lang/lambda/alpha/types.mbt
@@ -1,0 +1,55 @@
+///|
+pub(all) struct BinderId(Int) derive(Debug, Eq, Hash)
+
+///|
+pub(all) enum BinderOrigin {
+  SourceDecl(node_id~ : @core.NodeId, hint~ : String)
+  Generated(Int)
+} derive(Debug, Eq)
+
+///|
+pub(all) struct Binder {
+  id : BinderId
+  hint : String
+  origin : BinderOrigin
+} derive(Debug, Eq)
+
+///|
+pub(all) enum FreeOrigin {
+  SourceVar
+  SourceUnbound
+  GeneratedFree
+} derive(Debug, Eq)
+
+///|
+pub(all) struct FreeName {
+  name : String
+  origin : FreeOrigin
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AlphaRef {
+  Bound(BinderId)
+  Free(FreeName)
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AlphaTerm {
+  Int(Int)
+  Unit
+  Var(AlphaRef)
+  Lam(Binder, AlphaTerm)
+  App(AlphaTerm, AlphaTerm)
+  Bop(@ast.Bop, AlphaTerm, AlphaTerm)
+  If(AlphaTerm, AlphaTerm, AlphaTerm)
+  LetDef(Binder, AlphaTerm)
+  Module(Array[(Binder, AlphaTerm)], AlphaTerm)
+  Error(String)
+  Hole(Int)
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ReifyPolicy {
+  Display
+  Source
+} derive(Debug, Eq)


### PR DESCRIPTION
## Summary

- Add a Lambda-specific `lang/lambda/alpha` pilot package for alpha-safe transformations.
- Lower projected Lambda terms with `ScopeGraph`, perform root beta reduction by binder identity, and deterministically reify named `@ast.Term` without capture.
- Cover alpha equality, lowering, substitution, reify policies, sequential module scoping, and the canonical `((x) => (y) => x) y` fixture.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `build` | `lang/lambda/scope` | Yes | Builds the binding-resolution graph used by lowering fixtures. |
| `declaration` | `lang/lambda/scope` | Yes | Classifies source `Var` nodes as bound vs free by projection `NodeId`. |
| `collect_registry` | `core` | Yes | Test fixture path for building the scope graph from a projected root. |
| `SourceMap::from_ast` | `core` | Yes | Test fixture source map input for `@scope.build`. |
| `parse_to_proj_node` | `lang/lambda/proj` | Yes, wbtest-only | Parser/projection fixture helper kept out of production alpha imports. |
| `@ast.Term` / `print_term` | `dowdiness/lambda/ast` | Yes | Named boundary and reify-policy assertions. |
| `free_vars` | `lang/lambda/edits` | No | Name-set based; insufficient for binder-identity substitution. |
| `declaration_for_name_at` | `lang/lambda/scope` | No | Lowering needs exact reference-node resolution via `declaration`. |

New helpers added (if any):

- `lang/lambda/alpha` types (`BinderId`, `Binder`, `FreeName`, `AlphaTerm`, etc.): Lambda-specific alpha-safe core for the pilot.
- `alpha_eq` helpers: compare alpha terms by binder correspondence while keeping free-name origin explicit.
- `lower_root` helpers: traverse `ProjNode[@ast.Term]`, reuse `ScopeGraph` facts, and preserve incomplete-term policy.
- substitution/root-beta helpers: private binder-identity substitution plus public root beta step.
- reify helpers: deterministic fresh-name generation and `Display`/`Source` unbound policy.
- wbtest fixture helpers: parse/project/build-graph utilities kept test-only.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (`NEW_MOON_MOD=0 moon check --deny-warn` also passes)
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (`lang/lambda/alpha/pkg.generated.mbti` only)
- [x] JS rebuild run if web is affected (not affected; no web/FFI changes)

## Validation

```bash
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test
git diff --name-only docs/lambda-alpha-safe-core-boundary...HEAD -- '*.mbti'
```
