### PR TITLE
Add Lambda alpha-safe core boundary and beta pilot

### DIFF
--- a/docs/decisions/2026-06-15-lambda-alpha-safe-core-boundary.md
+++ b/docs/decisions/2026-06-15-lambda-alpha-safe-core-boundary.md
@@ -1,0 +1,213 @@
+# Lambda alpha-safe transformation boundary
+
+**Date:** 2026-06-15
+**Status:** Accepted
+**Related:**
+[Lambda edit bridge boundary](2026-06-15-lambda-edit-bridge-boundary.md) ·
+[Identity and reuse mechanisms](2026-06-01-identity-and-reuse-mechanisms.md) ·
+[`lang/lambda/scope` design](../superpowers/specs/2026-05-30-lambda-scope-graph-design.md) ·
+loom ADR [Lambda rename consumer](../../loom/docs/decisions/2026-05-20-lambda-rename-consumer.md)
+
+## Context
+
+Lambda currently uses a named user-facing syntax tree. The concrete AST carries
+binder names directly (`Var`, `Lam`, `Module`, `LetDef`), and the editor layer
+keeps source locations through projection nodes, token spans, and `SourceMap`.
+That representation is the right boundary for display, source edits, CRDT text
+integration, and rename UI: users wrote names, and Canopy must preserve those
+names unless an explicit edit changes them.
+
+Binding-sensitive editor operations now have a better source of truth than raw
+string matching: `lang/lambda/scope` builds a NodeId-keyed binding index with
+`Decl`, `Ref`, and `Resolution` facts. Consumers can ask which declaration a
+reference resolves to, which references point at a declaration, and where a
+binder's source token lives. This fixed several root-relative and block-local
+rename/inline mistakes without changing the public named AST.
+
+The missing boundary is transformation. Operations such as beta reduction,
+inline-by-substitution, extract/move with expression relocation, and future
+lambda-aware optimization cannot safely operate by substituting directly into the
+named `Term`: a free name in the replacement can be captured by a binder at the
+use site, and alpha-equivalent programs still have many string-distinct shapes.
+The current evaluator and type checker avoid this by using environments rather
+than syntactic substitution, but future transformation passes need a capture-safe
+intermediate representation.
+
+## Decision
+
+Keep named `Term` as Lambda's user-visible source/projection representation, and
+introduce an alpha-safe internal representation for capture-sensitive
+transformations.
+
+The boundary is:
+
+1. **Named source/projection remains the editor boundary.** `@ast.Term`,
+   `ProjNode`, `SourceMap`, and token roles continue to model user-visible
+   source. This ADR does not change the public shape of the named AST.
+2. **`ScopeGraph` remains the binding-resolution source of truth.** Lowering
+   from named/projection form to the alpha-safe core must use `lang/lambda/scope`
+   facts rather than re-implementing name resolution from strings.
+3. **Capture-sensitive transformations run only on the alpha-safe core.** Beta
+   reduction, substitution, alpha-equivalence, alpha-stable hashing, and future
+   lambda-aware optimizer rewrites must not substitute directly into named
+   `Term` values.
+4. **Reification is the only place that chooses fresh user-visible names.** When
+   an internal transformation must return to source, reification uses
+   deterministic freshening to avoid capture while preserving original name hints
+   when possible.
+5. **User rename and internal alpha-renaming stay separate.** Explicit rename is
+   a source refactor: it should continue to use `ScopeGraph` references and
+   binder spans, reject unsafe captures conservatively, and not silently rename
+   unrelated binders. Automatic alpha-renaming is allowed only as part of a
+   mechanical transformation preview or patch, such as beta reduction or future
+   inline-by-substitution.
+
+## Initial pilot
+
+The first implementation target is a small beta-reduction pilot, not a broad
+inline or optimizer migration.
+
+The pilot should prove the smallest useful end-to-end path:
+
+```text
+named/projection term + ScopeGraph
+  -> alpha-safe core
+  -> capture-safe beta reduction
+  -> deterministic reify for source/display
+```
+
+The canonical fixture is:
+
+```text
+((x) => (y) => x) y
+```
+
+A capture-avoiding beta step must produce a term equivalent to:
+
+```text
+(y1) => y
+```
+
+The exact fresh-name suffix is a policy choice, but it must be deterministic and
+must satisfy the Lambda lexer. The pilot may live behind tests and does not need
+to become a user-facing editor action in its first PR.
+
+## Internal representation boundary
+
+The alpha-safe core should distinguish binding identity from display names. A
+binder carries an internal identity plus a name hint; a variable reference is
+either bound to that identity or free by name. Source-derived binders should keep
+an origin that can be related back to source when needed, but graph-local IDs
+must not be treated as durable identities across rebuilds.
+
+Useful identity lifetimes:
+
+| Identity | Lifetime | Use |
+|---|---|---|
+| `ScopeId`, `DeclId`, `RefId` | One `ScopeGraph` build | Query indexing and resolution facts |
+| `NodeId` + token role | Projection/editor lifetime | Source origin and edit locations |
+| alpha `BinderId` | One lowered/constructed alpha term | Capture-safe substitution and alpha equality |
+| generated binder id | One transformation/reify session | New binders introduced by transformations |
+
+A source-derived alpha binder may remember the graph declaration that produced it
+while lowering, but any state intended to survive a rebuild should retain a
+source origin such as projection `NodeId`, role, and original hint instead of a
+bare graph-local `DeclId`.
+
+## Reification policies
+
+There is no single correct "core to named" operation. Implementations should
+separate at least these policies:
+
+- **Display reify:** preserve readable hints and represent unresolved names in a
+  diagnostic-friendly way.
+- **Source reify:** produce named `Term`/text suitable for insertion into source;
+  free names remain variables, and binders are deterministically freshened
+  against the insertion context.
+- **Canonical reify/keying:** ignore original hints where useful so
+  alpha-equivalent terms get stable comparison/hash keys.
+
+`Unbound(name)` needs an explicit policy because it is a current Lambda
+`Term` variant, not just a display string. Lowering should treat it as an
+unresolved/free reference by default. Display reify should preserve it as
+`Unbound(name)` so diagnostics do not lose meaning. Source reify may normalize it
+to `Var(name)` only when generating source text for insertion, and that policy
+choice must be visible at the call site.
+
+All policies must be total over incomplete editor terms: `Error`, `Hole`, and
+`Unbound` should be preserved or deliberately mapped by the selected reify policy
+rather than causing lowering or reification to abort.
+
+## Existing APIs reused
+
+- `lang/lambda/scope.build` builds the binding index used by lowering and source
+  edit planning.
+- `lang/lambda/scope.declaration` maps projection reference NodeIds to resolved
+  declarations; lowering uses it to decide `Bound` versus `Free`.
+- `lang/lambda/scope.references` remains the identity-based way to enumerate
+  user-visible source references for explicit rename and future multi-edit
+  patches.
+- `lang/lambda/scope.binder_span` and `SourceMap` token spans remain the only
+  accepted way to turn source binders into text edit ranges.
+- The named `@ast.Term` / `TermSym` / pretty-printing layer remains the
+  user-visible source and display representation.
+
+APIs checked but not reused as the transformation core:
+
+- The evaluator and type checker string environments are good for evaluation and
+  checking, but they do not provide an alpha-safe syntactic substitution layer.
+- `lang/lambda/edits/free_vars` remains useful for conservative editor guards,
+  but free-name sets alone cannot identify which binder a reference denotes.
+- The current egraph lambda examples use string payloads for lambda binders and
+  variables; they are not a safe substrate for lambda rewrite rules that perform
+  substitution.
+
+## Non-goals
+
+This ADR does not decide or require:
+
+- extracting a generic `alpha` library in the first implementation;
+- extracting a generic `scope-graph` library;
+- changing the public named Lambda AST;
+- changing explicit rename behavior;
+- exposing beta reduction as a production editor action;
+- migrating the evaluator, type checker, or egraph optimizer;
+- designing imports, prelude lookup, recursive bindings, or mutual recursion;
+- making `ScopeGraph` incremental.
+
+Those remain future work. The first step is a Lambda-specific pilot with clear
+seams so the dependency-free alpha core and scope graph core can later be split
+out if a second language or optimizer needs them.
+
+## Consequences
+
+- Lambda gains a safe place for operations that need substitution without making
+  the editor-facing AST unreadable or de Bruijn-indexed.
+- `ScopeGraph` and alpha core stay separate: one resolves named source; the
+  other performs capture-safe transformations.
+- Inline/extract can continue to reject capture for now. A later PR may extend
+  them to produce a multi-edit patch that includes deterministic alpha-renaming,
+  but that should be a deliberate UX change with preview semantics.
+- Generic library design is deferred until there are at least two real consumers.
+  The pilot should still avoid unnecessary dependencies so extraction remains
+  plausible.
+
+## Validation strategy
+
+The first implementation should add focused tests before any user-facing action:
+
+- alpha-equivalence: `(x) => x` and `(y) => y` compare equal;
+- lowering consistency: each bound alpha reference corresponds to the same
+  declaration reported by `ScopeGraph`;
+- beta capture avoidance: `((x) => (y) => x) y` reifies with the inner binder
+  freshened;
+- sequential module binding: a definition initializer only sees preceding module
+  definitions;
+- free names remain free through substitution and reification;
+- `Unbound(name)` follows the selected reify policy: display reify preserves it,
+  while source reify may deliberately normalize it to `Var(name)`;
+- `Error` and `Hole` survive lowering/reification.
+
+If the pilot touches MoonBit packages, run the affected package tests plus the
+workspace checks required by `AGENTS.md`. A documentation-only ADR change is
+validated with Markdown review and `git diff --check`.

--- a/docs/plans/2026-06-15-lambda-alpha-beta-pilot.md
+++ b/docs/plans/2026-06-15-lambda-alpha-beta-pilot.md
@@ -1,0 +1,315 @@
+# Lambda alpha-safe beta-reduction pilot
+
+**Status:** Draft
+**Date:** 2026-06-15
+**Decision:** [Lambda alpha-safe transformation boundary](../decisions/2026-06-15-lambda-alpha-safe-core-boundary.md)
+
+## Why
+
+Lambda's editor-facing `Term` is intentionally named and source-oriented. That is
+right for projection, rename UI, CRDT text integration, and diagnostics, but it
+is the wrong substrate for syntactic substitution: substituting directly into
+`Var(String)` / `Lam(String, ...)` can capture free variables.
+
+The accepted alpha-safe boundary ADR chooses a small beta-reduction pilot as the
+first implementation target. The pilot should prove the core transformation
+path without changing user-facing edit behavior:
+
+```text
+ProjNode + ScopeGraph -> alpha-safe core -> beta step -> deterministic reify
+```
+
+The canonical fixture is:
+
+```text
+((x) => (y) => x) y
+```
+
+A capture-avoiding beta step must reify to a term equivalent to:
+
+```text
+(y1) => y
+```
+
+## Scope
+
+In:
+
+- `lang/lambda/alpha/` — new Lambda-specific alpha-safe core package for the
+  pilot.
+- `lang/lambda/alpha/moon.pkg` — imports for `@ast.Term`, `@core.ProjNode`, and
+  `@scope.ScopeGraph`.
+- `lang/lambda/alpha/types.mbt` — alpha-safe term, binder, reference, free-name
+  origin, and reify policy types.
+- `lang/lambda/alpha/lower.mbt` — lowering from `ProjNode[@ast.Term]` plus
+  `ScopeGraph` into alpha core.
+- `lang/lambda/alpha/subst.mbt` — capture-safe substitution and root beta step
+  over alpha core.
+- `lang/lambda/alpha/reify.mbt` — deterministic reify back to named `@ast.Term`.
+- `lang/lambda/alpha/alpha_eq.mbt` — alpha-equivalence helper for tests and
+  future hash/keying work.
+- `lang/lambda/alpha/*_wbtest.mbt` — focused whitebox tests for the pilot.
+
+Out:
+
+- No production editor action for beta reduction.
+- No changes to explicit rename behavior.
+- No migration of inline/extract in this slice.
+- No evaluator/typechecker/egraph migration.
+- No generic alpha library extraction yet.
+- No generic ScopeGraph extraction or incremental ScopeGraph redesign.
+- No import, prelude, recursive binding, or mutual-recursion semantics.
+
+## Current State
+
+- `loom/examples/lambda/src/ast/ast.mbt` defines the named `Term` variants used
+  by parser, projection, editor display, evaluator, and type checker.
+- `lang/lambda/scope` builds a NodeId-keyed `ScopeGraph` and exposes:
+  - `build(registry, source_map)`
+  - `declaration(graph, ref_node)`
+  - `declaration_for_name_at(graph, node, name)`
+  - `references(graph, decl.id)`
+  - `binder_span(graph, decl, source_map)`
+- `lang/lambda/edits/text_edit_rename.mbt` already uses `ScopeGraph` identities
+  for source rename and should remain a source-edit refactor, not an automatic
+  alpha-renaming action.
+- `lang/lambda/edits/free_vars.mbt` computes free name sets and remains useful
+  for conservative edit guards, but it does not identify binders.
+- `lang/lambda/proj` can produce a `ProjNode[@ast.Term]`; tests can use
+  `@core.collect_registry`, `@core.SourceMap::from_ast`, and `@scope.build` to
+  build the graph needed for lowering.
+- Current evaluator/typechecker string environments avoid syntactic substitution
+  and are not the pilot target.
+
+## Existing API First
+
+Reuse:
+
+- `@scope.build` as the binding-resolution source for lowering.
+- `@scope.declaration` to lower `Var` / `Unbound` projection nodes to
+  `Bound(binder)` or `Free(name)`.
+- `@core.collect_registry` and `@core.SourceMap::from_ast` in tests to build a
+  `ScopeGraph` from a projected root without introducing new projection plumbing.
+- `@ast.Term` constructors and `@ast.print_term` only at the named
+  boundary/reify tests.
+
+Checked but not used as the alpha transformation substrate:
+
+- `@lambda_eval.Env` and `TypeEnv`: environment-based evaluation/checking, not
+  syntactic substitution.
+- `lang/lambda/edits/free_vars`: name-set based, insufficient for binder
+  identity.
+- Existing egraph lambda string payloads: not alpha-safe for beta/substitution
+  rewrites.
+
+New helper responsibility boundary:
+
+- `lang/lambda/alpha` owns only alpha-safe transformation for Lambda terms. It
+  may depend on current Lambda projection/scope packages for lowering, but it
+  must not apply source edits or become a UI action bridge.
+
+## Desired State
+
+The pilot produces a small, tested alpha-safe transformation layer:
+
+- Lowering maps source-resolved references to internal binder identity.
+- Free names and `Unbound` retain enough origin information for reify policy to
+  distinguish display from source insertion.
+- A root beta step substitutes by binder identity, not by string name.
+- Reify freshens binders deterministically to avoid capturing free names.
+- The canonical beta fixture reifies without capture.
+- `Error` and `Hole` survive lowering/reification.
+
+## Proposed Types
+
+Keep the first slice small and concrete. Avoid premature generic library API.
+Use `pub(all)` only where tests or later packages genuinely need structural
+inspection; otherwise prefer constructors/accessors.
+
+Conceptual shape:
+
+```moonbit
+pub(all) struct BinderId(Int) derive(Eq, Hash, Debug)
+
+pub(all) enum BinderOrigin {
+  SourceDecl(node_id~ : @core.NodeId, hint~ : String)
+  Generated(Int)
+}
+
+pub(all) struct Binder {
+  id : BinderId
+  hint : String
+  origin : BinderOrigin
+}
+
+pub(all) enum FreeOrigin {
+  SourceVar
+  SourceUnbound
+  GeneratedFree
+}
+
+pub(all) struct FreeName {
+  name : String
+  origin : FreeOrigin
+}
+
+pub(all) enum AlphaRef {
+  Bound(BinderId)
+  Free(FreeName)
+}
+
+pub(all) enum AlphaTerm {
+  Int(Int)
+  Unit
+  Var(AlphaRef)
+  Lam(Binder, AlphaTerm)
+  App(AlphaTerm, AlphaTerm)
+  Bop(@ast.Bop, AlphaTerm, AlphaTerm)
+  If(AlphaTerm, AlphaTerm, AlphaTerm)
+  LetDef(Binder, AlphaTerm)
+  Module(Array[(Binder, AlphaTerm)], AlphaTerm)
+  Error(String)
+  Hole(Int)
+}
+```
+
+Notes:
+
+- `FreeOrigin` exists because the ADR requires explicit `Unbound` policy.
+- `SourceDecl` should not store graph-local `DeclId` as durable identity. Use
+  source/projection origin such as `NodeId` and hint.
+- `LetDef` may be useful as a structural mirror for `Term::LetDef`, even if most
+  transformations operate on `Module` definitions.
+
+## Steps
+
+1. Add `lang/lambda/alpha/moon.pkg`.
+   - Production imports: `dowdiness/canopy/core`,
+     `dowdiness/canopy/lang/lambda/scope`, `dowdiness/lambda/ast`, and small
+     core packages needed by the alpha implementation.
+   - Test-only imports under `for "wbtest"`: `dowdiness/canopy/lang/lambda/proj`
+     and `dowdiness/lambda`, mirroring the existing scope tests. Parse/project
+     helpers belong in tests, not production dependencies.
+   - Do not add dependencies on editor/companion/FFI packages.
+
+2. Add `types.mbt`.
+   - Define the pilot types above or a smaller equivalent that still preserves
+     binder identity, hints, free-origin policy, `Error`, and `Hole`.
+   - Add named constructors if public struct fields are not `pub(all)`.
+
+3. Add lowering from projection.
+   - Public entry point: `lower(root, graph) -> AlphaTerm` or
+     `lower_root(root, graph) -> AlphaTerm`.
+   - Traverse `ProjNode[@ast.Term]` so every `Var` / `Unbound` node has a
+     `NodeId` available.
+   - For each binder (`Lam`, `LetDef` in `Module`), create one `BinderId` and a
+     map from the corresponding source declaration to binder id.
+   - For each `Var` / `Unbound`, call `@scope.declaration(graph, node.id())`:
+     - resolved -> `Var(Bound(binder_id))`
+     - unresolved `Var` -> `Var(Free({ name, origin: SourceVar }))`
+     - unresolved `Unbound` -> `Var(Free({ name, origin: SourceUnbound }))`
+   - Preserve `Error` and `Hole`.
+   - Do not re-implement sequential module visibility; trust the `ScopeGraph`
+     resolution result.
+
+4. Add alpha-equivalence.
+   - Ignore binder hints and source origins.
+   - Compare binders by correspondence rather than raw names.
+   - Tests must show `(x) => x` and `(y) => y` are alpha-equivalent.
+
+5. Add capture-safe substitution and beta step.
+   - `substitute(term, binder_id, replacement)` replaces only
+     `Var(Bound(binder_id))`.
+   - It must not inspect names to decide binding.
+   - First beta API can be root-only:
+     `beta_reduce_root(term) -> AlphaTerm?`, reducing `App(Lam(binder, body), arg)`.
+   - No normalization/evaluation loop is required.
+
+6. Add deterministic reify.
+   - Support at least `Display` and `Source` policies.
+   - Compute free names of a binder body before choosing the binder's output
+     name so reify can avoid capturing free references.
+   - Fresh name policy: try `hint`, then `hint1`, `hint2`, ... using a fallback
+     such as `x` for empty or invalid hints.
+   - `Display` policy preserves `SourceUnbound` as `@ast.Term::Unbound(name)`.
+   - `Source` policy may map `SourceUnbound` to `@ast.Term::Var(name)` only at
+     this explicit call site.
+
+7. Add focused tests.
+   - Direct alpha-core tests for alpha-equivalence, substitution, freshening,
+     and `Error`/`Hole` preservation.
+   - Projection-lowering tests that parse/project source, build `ScopeGraph`,
+     lower, and assert bound/free classification matches the graph.
+   - Beta fixture test for `((x) => (y) => x) y` reifying to a capture-free term
+     equivalent to `(y1) => y`.
+   - Sequential module test: in newline-separated source
+     `let x = 1\nlet x = x\nx`, the second initializer's `x` binds to the
+     first definition and the body's `x` binds to the second definition.
+
+8. Keep the pilot unexposed.
+   - Do not add a `TreeEditOp` variant.
+   - Do not update JS FFI.
+   - Do not change companion/editor behavior.
+
+9. Run validation and inspect generated interfaces.
+   - Run `moon check` and `moon test` from the root workspace.
+   - If the new package affects generated interfaces, run `moon fmt && moon info`
+     and inspect `.mbti` diffs for accidental API widening.
+
+## Acceptance Criteria
+
+- [ ] New `lang/lambda/alpha` package exists and is not imported by production
+      editor/FFI paths.
+- [ ] Lowering uses `ScopeGraph` for reference resolution rather than string-only
+      lexical lookup.
+- [ ] `alpha_eq((x) => x, (y) => y)` is true in tests.
+- [ ] Root beta reduction substitutes by `BinderId` and does not capture free
+      names.
+- [ ] The canonical beta fixture reifies with a freshened inner binder.
+- [ ] `Unbound`, `Error`, and `Hole` policies are covered by tests.
+- [ ] Sequential module scoping is covered by a lowering test.
+- [ ] No user-facing edit action or FFI surface changes in this slice.
+
+## Validation
+
+From the repository root:
+
+```bash
+moon check
+moon test
+moon fmt && moon info
+```
+
+Then inspect public interface changes:
+
+```bash
+git diff -- '*.mbti'
+```
+
+If only `lang/lambda/alpha` is added, the `.mbti` diff should expose only the
+new intentional package API. No TypeScript, Playwright, or JS rebuild is required
+unless a later slice wires beta reduction into the web/FFI surface.
+
+## Risks
+
+- **Binder origin confusion:** `DeclId` is graph-local; storing it as durable
+  alpha identity would make cached alpha terms invalid across rebuilds. Use
+  source/projection origin for anything that leaves one lowering run.
+- **Reify capture bug:** choosing a binder name without considering free names in
+  its body recreates the exact bug this pilot is meant to avoid.
+- **Over-generic first slice:** trying to design a reusable alpha library before
+  one Lambda pilot lands may freeze the wrong API. Keep the first package
+  Lambda-specific but dependency-conscious.
+- **Unbound normalization ambiguity:** display and source reify intentionally
+  differ; tests must pin both policies.
+- **MoonBit API widening:** `pub(all)` is convenient for tests but becomes public
+  API. Prefer constructors/accessors unless structural inspection is needed.
+
+## Notes
+
+- This plan intentionally follows the two-layer architecture from the MoonBit
+  expression-problem guidance: named `Term` remains the concrete user/source
+  layer, while alpha core is a second concrete structure for transformation.
+- A later generic extraction should split dependency-free alpha utilities from
+  Lambda's `ScopeGraph`/`ProjNode` adapter only after there is a second consumer
+  or a real optimizer/egraph migration.

--- a/docs/plans/2026-06-15-lambda-alpha-beta-pilot.md
+++ b/docs/plans/2026-06-15-lambda-alpha-beta-pilot.md
@@ -86,8 +86,8 @@ Out:
 Reuse:
 
 - `@scope.build` as the binding-resolution source for lowering.
-- `@scope.declaration` to lower `Var` / `Unbound` projection nodes to
-  `Bound(binder)` or `Free(name)`.
+- `@scope.declaration` to lower `Var` projection nodes to `Bound(binder)` or
+  `Free(name)`; `Unbound` remains an explicit unresolved/free editor term.
 - `@core.collect_registry` and `@core.SourceMap::from_ast` in tests to build a
   `ScopeGraph` from a projected root without introducing new projection plumbing.
 - `@ast.Term` constructors and `@ast.print_term` only at the named
@@ -204,10 +204,12 @@ Notes:
      `NodeId` available.
    - For each binder (`Lam`, `LetDef` in `Module`), create one `BinderId` and a
      map from the corresponding source declaration to binder id.
-   - For each `Var` / `Unbound`, call `@scope.declaration(graph, node.id())`:
+   - For each `Var`, call `@scope.declaration(graph, node.id())`:
      - resolved -> `Var(Bound(binder_id))`
-     - unresolved `Var` -> `Var(Free({ name, origin: SourceVar }))`
-     - unresolved `Unbound` -> `Var(Free({ name, origin: SourceUnbound }))`
+     - unresolved -> `Var(Free({ name, origin: SourceVar }))`
+   - Treat `Unbound` as an explicit unresolved/free editor term by lowering it
+     directly to `Var(Free({ name, origin: SourceUnbound }))`, even when a
+     same-name source binder exists.
    - Preserve `Error` and `Hole`.
    - Do not re-implement sequential module visibility; trust the `ScopeGraph`
      resolution result.

--- a/lang/lambda/alpha/alpha_eq.mbt
+++ b/lang/lambda/alpha/alpha_eq.mbt
@@ -1,0 +1,112 @@
+///|
+pub fn alpha_eq(left : AlphaTerm, right : AlphaTerm) -> Bool {
+  let left_to_right : Map[BinderId, BinderId] = {}
+  let right_to_left : Map[BinderId, BinderId] = {}
+  alpha_eq_term(left, right, left_to_right, right_to_left)
+}
+
+///|
+fn alpha_eq_ref(
+  left : AlphaRef,
+  right : AlphaRef,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  match (left, right) {
+    (Bound(left_id), Bound(right_id)) =>
+      left_to_right
+      .get(left_id)
+      .map_or(
+        right_to_left
+        .get(right_id)
+        .map_or(left_id == right_id, mapped => mapped == left_id),
+        mapped => mapped == right_id,
+      )
+    (Free(left_free), Free(right_free)) => left_free == right_free
+    _ => false
+  }
+}
+
+///|
+fn alpha_eq_lam(
+  left_binder : Binder,
+  left_body : AlphaTerm,
+  right_binder : Binder,
+  right_body : AlphaTerm,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  let next_left = left_to_right.copy()
+  let next_right = right_to_left.copy()
+  next_left[left_binder.id] = right_binder.id
+  next_right[right_binder.id] = left_binder.id
+  alpha_eq_term(left_body, right_body, next_left, next_right)
+}
+
+///|
+fn alpha_eq_module(
+  left_defs : Array[(Binder, AlphaTerm)],
+  left_body : AlphaTerm,
+  right_defs : Array[(Binder, AlphaTerm)],
+  right_body : AlphaTerm,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  guard left_defs.length() == right_defs.length() else { return false }
+  let next_left = left_to_right.copy()
+  let next_right = right_to_left.copy()
+  let defs_match = for i in 0..<left_defs.length(); ok = true {
+    if !ok {
+      continue false
+    }
+    let (left_binder, left_init) = left_defs[i]
+    let (right_binder, right_init) = right_defs[i]
+    let same_init = alpha_eq_term(left_init, right_init, next_left, next_right)
+    next_left[left_binder.id] = right_binder.id
+    next_right[right_binder.id] = left_binder.id
+    continue same_init
+  } nobreak {
+    ok
+  }
+  defs_match && alpha_eq_term(left_body, right_body, next_left, next_right)
+}
+
+///|
+fn alpha_eq_term(
+  left : AlphaTerm,
+  right : AlphaTerm,
+  left_to_right : Map[BinderId, BinderId],
+  right_to_left : Map[BinderId, BinderId],
+) -> Bool {
+  match (left, right) {
+    (Int(left_value), Int(right_value)) => left_value == right_value
+    (Unit, Unit) => true
+    (Var(left_ref), Var(right_ref)) =>
+      alpha_eq_ref(left_ref, right_ref, left_to_right, right_to_left)
+    (Lam(left_binder, left_body), Lam(right_binder, right_body)) =>
+      alpha_eq_lam(
+        left_binder, left_body, right_binder, right_body, left_to_right, right_to_left,
+      )
+    (App(left_fn, left_arg), App(right_fn, right_arg)) =>
+      alpha_eq_term(left_fn, right_fn, left_to_right, right_to_left) &&
+      alpha_eq_term(left_arg, right_arg, left_to_right, right_to_left)
+    (Bop(left_op, left_lhs, left_rhs), Bop(right_op, right_lhs, right_rhs)) =>
+      left_op == right_op &&
+      alpha_eq_term(left_lhs, right_lhs, left_to_right, right_to_left) &&
+      alpha_eq_term(left_rhs, right_rhs, left_to_right, right_to_left)
+    (If(left_cond, left_then, left_else), If(right_cond, right_then, right_else)
+    ) =>
+      alpha_eq_term(left_cond, right_cond, left_to_right, right_to_left) &&
+      alpha_eq_term(left_then, right_then, left_to_right, right_to_left) &&
+      alpha_eq_term(left_else, right_else, left_to_right, right_to_left)
+    (LetDef(_, left_init), LetDef(_, right_init)) =>
+      alpha_eq_term(left_init, right_init, left_to_right, right_to_left)
+    (Module(left_defs, left_body), Module(right_defs, right_body)) =>
+      alpha_eq_module(
+        left_defs, left_body, right_defs, right_body, left_to_right, right_to_left,
+      )
+    (Error(left_message), Error(right_message)) => left_message == right_message
+    (Hole(left_index), Hole(right_index)) => left_index == right_index
+    _ => false
+  }
+}

--- a/lang/lambda/alpha/alpha_eq.mbt
+++ b/lang/lambda/alpha/alpha_eq.mbt
@@ -14,15 +14,12 @@ fn alpha_eq_ref(
 ) -> Bool {
   match (left, right) {
     (Bound(left_id), Bound(right_id)) =>
-      left_to_right
-      .get(left_id)
-      .map_or(
-        right_to_left
-        .get(right_id)
-        .map_or(left_id == right_id, mapped => mapped == left_id),
-        mapped => mapped == right_id,
-      )
-    (Free(left_free), Free(right_free)) => left_free == right_free
+      match (left_to_right.get(left_id), right_to_left.get(right_id)) {
+        (Some(mapped), _) => mapped == right_id
+        (_, Some(mapped)) => mapped == left_id
+        _ => left_id == right_id
+      }
+    (Free(left_free), Free(right_free)) => left_free.name == right_free.name
     _ => false
   }
 }

--- a/lang/lambda/alpha/alpha_eq_wbtest.mbt
+++ b/lang/lambda/alpha/alpha_eq_wbtest.mbt
@@ -17,8 +17,15 @@ test "alpha_eq: free and bound references differ" {
 }
 
 ///|
-test "alpha_eq: free origin is explicit" {
+test "alpha_eq: free origin does not affect free-name equality" {
   let source_var = Var(Free(test_free("x", SourceVar)))
   let source_unbound = Var(Free(test_free("x", SourceUnbound)))
-  assert_false(alpha_eq(source_var, source_unbound))
+  assert_true(alpha_eq(source_var, source_unbound))
+}
+
+///|
+test "alpha_eq: free names must match" {
+  let x = Var(Free(test_free("x", SourceVar)))
+  let y = Var(Free(test_free("y", GeneratedFree)))
+  assert_false(alpha_eq(x, y))
 }

--- a/lang/lambda/alpha/alpha_eq_wbtest.mbt
+++ b/lang/lambda/alpha/alpha_eq_wbtest.mbt
@@ -1,0 +1,24 @@
+///|
+fn identity_lam(id : Int, hint : String) -> AlphaTerm {
+  let binder = test_binder(id, hint)
+  Lam(binder, Var(Bound(binder.id)))
+}
+
+///|
+test "alpha_eq: lambda binder hints do not matter" {
+  assert_true(alpha_eq(identity_lam(0, "x"), identity_lam(1, "y")))
+}
+
+///|
+test "alpha_eq: free and bound references differ" {
+  assert_false(
+    alpha_eq(identity_lam(0, "x"), Lam(test_binder(1, "x"), free_var("x"))),
+  )
+}
+
+///|
+test "alpha_eq: free origin is explicit" {
+  let source_var = Var(Free(test_free("x", SourceVar)))
+  let source_unbound = Var(Free(test_free("x", SourceUnbound)))
+  assert_false(alpha_eq(source_var, source_unbound))
+}

--- a/lang/lambda/alpha/beta_wbtest.mbt
+++ b/lang/lambda/alpha/beta_wbtest.mbt
@@ -1,0 +1,14 @@
+///|
+test "beta pilot: root reduction reifies without capture" {
+  let (proj, graph) = alpha_parse_fixture("((x) => (y) => x) y")
+  guard beta_reduce_root(lower_root(proj, graph)) is Some(reduced) else {
+    fail("expected root beta reduction")
+  }
+  let expected_binder = test_binder(99, "y1")
+  assert_true(alpha_eq(reduced, Lam(expected_binder, free_var("y"))))
+  guard reify(reduced, Source) is @ast.Term::Lam(param, @ast.Term::Var(body)) else {
+    fail("expected reified lambda")
+  }
+  inspect(param, content="y1")
+  inspect(body, content="y")
+}

--- a/lang/lambda/alpha/fixtures_wbtest.mbt
+++ b/lang/lambda/alpha/fixtures_wbtest.mbt
@@ -1,0 +1,49 @@
+///|
+fn test_binder(id : Int, hint : String) -> Binder {
+  { id: BinderId(id), hint, origin: Generated(id) }
+}
+
+///|
+fn test_free(name : String, origin : FreeOrigin) -> FreeName {
+  { name, origin }
+}
+
+///|
+fn free_var(name : String) -> AlphaTerm {
+  Var(Free(test_free(name, SourceVar)))
+}
+
+///|
+fn graph_for_root(root : @core.ProjNode[@ast.Term]) -> @scope.ScopeGraph {
+  let source_map = @core.SourceMap::from_ast(root)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  @scope.build(registry, source_map)
+}
+
+///|
+fn alpha_parse_fixture(
+  text : String,
+) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph) raise {
+  let (proj, errors) = @lambda_proj.parse_to_proj_node(text)
+  if errors.length() > 0 {
+    fail("parse diagnostics in alpha fixture")
+  }
+  (proj, graph_for_root(proj))
+}
+
+///|
+fn find_var_node(
+  root : @core.ProjNode[@ast.Term],
+  name : String,
+) -> @core.NodeId? {
+  if root.kind is @ast.Term::Var(found) && found == name {
+    Some(root.id())
+  } else {
+    root.children
+    .iter()
+    .map(child => find_var_node(child, name))
+    .find_first(found => found is Some(_))
+    .bind(found => found)
+  }
+}

--- a/lang/lambda/alpha/lower.mbt
+++ b/lang/lambda/alpha/lower.mbt
@@ -9,15 +9,20 @@ pub fn lower_root(
 
 ///|
 fn source_binders(graph : @scope.ScopeGraph) -> Map[@core.NodeId, Binder] {
-  let binders : Map[@core.NodeId, Binder] = {}
-  for i, decl in graph.decls {
-    binders[decl.node_id] = {
-      id: BinderId(i),
-      hint: decl.name,
-      origin: SourceDecl(node_id=decl.node_id, hint=decl.name),
-    }
-  }
-  binders
+  Map::from_iter(
+    graph.decls
+    .mapi((i, decl) => {
+      (
+        decl.node_id,
+        {
+          id: BinderId(i),
+          hint: decl.name,
+          origin: SourceDecl(node_id=decl.node_id, hint=decl.name),
+        },
+      )
+    })
+    .iter(),
+  )
 }
 
 ///|
@@ -88,17 +93,14 @@ fn lower_module(
   graph : @scope.ScopeGraph,
   binders : Map[@core.NodeId, Binder],
 ) -> AlphaTerm {
-  let lowered_defs : Array[(Binder, AlphaTerm)] = []
-  for i, def in defs {
-    lowered_defs.push(
-      node.children
-      .get(i)
-      .map_or(
-        (generated_binder(def.0, i), Error("missing module definition child")),
-        child => lower_let_def_child(child, graph, binders, def.0),
-      ),
+  let lowered_defs : Array[(Binder, AlphaTerm)] = defs.mapi((i, def) => {
+    node.children
+    .get(i)
+    .map_or(
+      (generated_binder(def.0, i), Error("missing module definition child")),
+      child => lower_let_def_child(child, graph, binders, def.0),
     )
-  }
+  })
   let body = lower_child_or_error(
     node,
     graph,

--- a/lang/lambda/alpha/lower.mbt
+++ b/lang/lambda/alpha/lower.mbt
@@ -123,6 +123,9 @@ fn lower_node(
     @ast.Term::Int(value) => Int(value)
     @ast.Term::Unit => Unit
     @ast.Term::Var(name) => lower_ref(node, graph, binders, name)
+    // `Unbound` is an explicit unresolved editor term. Keep it free even if the
+    // scope graph has a same-name declaration, so display reify can preserve the
+    // diagnostic-oriented `Unbound` origin.
     @ast.Term::Unbound(name) => Var(Free({ name, origin: SourceUnbound }))
     @ast.Term::Lam(name, _) => {
       let binder = binder_for_node(binders, node, name)

--- a/lang/lambda/alpha/lower.mbt
+++ b/lang/lambda/alpha/lower.mbt
@@ -1,0 +1,155 @@
+///|
+pub fn lower_root(
+  root : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+) -> AlphaTerm {
+  let binders = source_binders(graph)
+  lower_node(root, graph, binders)
+}
+
+///|
+fn source_binders(graph : @scope.ScopeGraph) -> Map[@core.NodeId, Binder] {
+  let binders : Map[@core.NodeId, Binder] = {}
+  for i, decl in graph.decls {
+    binders[decl.node_id] = {
+      id: BinderId(i),
+      hint: decl.name,
+      origin: SourceDecl(node_id=decl.node_id, hint=decl.name),
+    }
+  }
+  binders
+}
+
+///|
+fn generated_binder(hint : String, salt : Int) -> Binder {
+  { id: BinderId(-1 - salt), hint, origin: Generated(salt) }
+}
+
+///|
+fn binder_for_node(
+  binders : Map[@core.NodeId, Binder],
+  node_id : @core.NodeId,
+  hint : String,
+) -> Binder {
+  binders.get(node_id).map_or(generated_binder(hint, 0), binder => binder)
+}
+
+///|
+fn lower_ref(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+  name : String,
+) -> AlphaTerm {
+  @scope.declaration(graph, node.id()).map_or(
+    Var(Free({ name, origin: SourceVar })),
+    decl => {
+      binders
+      .get(decl.node_id)
+      .map_or(
+        Error("resolved reference without lowered binder: " + decl.name),
+        binder => Var(Bound(binder.id)),
+      )
+    },
+  )
+}
+
+///|
+fn lower_child_or_error(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+  index : Int,
+  label : String,
+) -> AlphaTerm {
+  node.children
+  .get(index)
+  .map_or(Error("missing " + label), child => lower_node(child, graph, binders))
+}
+
+///|
+fn lower_let_def_child(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+  hint : String,
+) -> (Binder, AlphaTerm) {
+  let binder = binder_for_node(binders, node.id(), hint)
+  let init = lower_child_or_error(
+    node, graph, binders, 0, "let definition init",
+  )
+  (binder, init)
+}
+
+///|
+fn lower_module(
+  node : @core.ProjNode[@ast.Term],
+  defs : Array[(String, @ast.Term)],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+) -> AlphaTerm {
+  let lowered_defs : Array[(Binder, AlphaTerm)] = []
+  for i, def in defs {
+    lowered_defs.push(
+      node.children
+      .get(i)
+      .map_or(
+        (generated_binder(def.0, i), Error("missing module definition child")),
+        child => lower_let_def_child(child, graph, binders, def.0),
+      ),
+    )
+  }
+  let body = lower_child_or_error(
+    node,
+    graph,
+    binders,
+    defs.length(),
+    "module body",
+  )
+  Module(lowered_defs, body)
+}
+
+///|
+fn lower_node(
+  node : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  binders : Map[@core.NodeId, Binder],
+) -> AlphaTerm {
+  match node.kind {
+    @ast.Term::Int(value) => Int(value)
+    @ast.Term::Unit => Unit
+    @ast.Term::Var(name) => lower_ref(node, graph, binders, name)
+    @ast.Term::Unbound(name) => Var(Free({ name, origin: SourceUnbound }))
+    @ast.Term::Lam(name, _) => {
+      let binder = binder_for_node(binders, node.id(), name)
+      Lam(binder, lower_child_or_error(node, graph, binders, 0, "lambda body"))
+    }
+    @ast.Term::App(_, _) =>
+      App(
+        lower_child_or_error(node, graph, binders, 0, "application function"),
+        lower_child_or_error(node, graph, binders, 1, "application argument"),
+      )
+    @ast.Term::Bop(op, _, _) =>
+      Bop(
+        op,
+        lower_child_or_error(node, graph, binders, 0, "binary lhs"),
+        lower_child_or_error(node, graph, binders, 1, "binary rhs"),
+      )
+    @ast.Term::If(_, _, _) =>
+      If(
+        lower_child_or_error(node, graph, binders, 0, "if condition"),
+        lower_child_or_error(node, graph, binders, 1, "if then branch"),
+        lower_child_or_error(node, graph, binders, 2, "if else branch"),
+      )
+    @ast.Term::LetDef(name, _) => {
+      let binder = binder_for_node(binders, node.id(), name)
+      LetDef(
+        binder,
+        lower_child_or_error(node, graph, binders, 0, "let definition init"),
+      )
+    }
+    @ast.Term::Module(defs, _) => lower_module(node, defs, graph, binders)
+    @ast.Term::Error(message) => Error(message)
+    @ast.Term::Hole(index) => Hole(index)
+  }
+}

--- a/lang/lambda/alpha/lower.mbt
+++ b/lang/lambda/alpha/lower.mbt
@@ -33,10 +33,12 @@ fn generated_binder(hint : String, salt : Int) -> Binder {
 ///|
 fn binder_for_node(
   binders : Map[@core.NodeId, Binder],
-  node_id : @core.NodeId,
+  node : @core.ProjNode[@ast.Term],
   hint : String,
 ) -> Binder {
-  binders.get(node_id).map_or(generated_binder(hint, 0), binder => binder)
+  binders
+  .get(node.id())
+  .map_or(generated_binder(hint, node.node_id), binder => binder)
 }
 
 ///|
@@ -79,7 +81,7 @@ fn lower_let_def_child(
   binders : Map[@core.NodeId, Binder],
   hint : String,
 ) -> (Binder, AlphaTerm) {
-  let binder = binder_for_node(binders, node.id(), hint)
+  let binder = binder_for_node(binders, node, hint)
   let init = lower_child_or_error(
     node, graph, binders, 0, "let definition init",
   )
@@ -123,7 +125,7 @@ fn lower_node(
     @ast.Term::Var(name) => lower_ref(node, graph, binders, name)
     @ast.Term::Unbound(name) => Var(Free({ name, origin: SourceUnbound }))
     @ast.Term::Lam(name, _) => {
-      let binder = binder_for_node(binders, node.id(), name)
+      let binder = binder_for_node(binders, node, name)
       Lam(binder, lower_child_or_error(node, graph, binders, 0, "lambda body"))
     }
     @ast.Term::App(_, _) =>
@@ -144,7 +146,7 @@ fn lower_node(
         lower_child_or_error(node, graph, binders, 2, "if else branch"),
       )
     @ast.Term::LetDef(name, _) => {
-      let binder = binder_for_node(binders, node.id(), name)
+      let binder = binder_for_node(binders, node, name)
       LetDef(
         binder,
         lower_child_or_error(node, graph, binders, 0, "let definition init"),

--- a/lang/lambda/alpha/lower_wbtest.mbt
+++ b/lang/lambda/alpha/lower_wbtest.mbt
@@ -85,3 +85,25 @@ test "lower: sequential module scope follows ScopeGraph" {
   inspect(init_id == first_binder.id, content="true")
   inspect(body_id == second_binder.id, content="true")
 }
+
+///|
+test "lower: generated fallback binder ids use node identity" {
+  let binders : Map[@core.NodeId, Binder] = {}
+  let first = @core.ProjNode::new(
+    @ast.Term::Lam("x", @ast.Term::Unit),
+    0,
+    0,
+    7,
+    [],
+  )
+  let second = @core.ProjNode::new(
+    @ast.Term::Lam("x", @ast.Term::Unit),
+    0,
+    0,
+    8,
+    [],
+  )
+  let first_binder = binder_for_node(binders, first, "x")
+  let second_binder = binder_for_node(binders, second, "x")
+  inspect(first_binder.id == second_binder.id, content="false")
+}

--- a/lang/lambda/alpha/lower_wbtest.mbt
+++ b/lang/lambda/alpha/lower_wbtest.mbt
@@ -1,0 +1,87 @@
+///|
+test "lower: lambda references resolve to bound binder ids" {
+  let (proj, graph) = alpha_parse_fixture("(x) => x")
+  guard find_var_node(proj, "x") is Some(var_node) else {
+    fail("missing x ref")
+  }
+  guard @scope.declaration(graph, var_node) is Some(_) else {
+    fail("scope graph did not resolve x")
+  }
+  guard lower_root(proj, graph) is Lam(binder, Var(Bound(ref_id))) else {
+    fail("expected lambda with bound body")
+  }
+  inspect(ref_id == binder.id, content="true")
+}
+
+///|
+test "lower: unresolved source var remains free" {
+  let (proj, graph) = alpha_parse_fixture("y")
+  guard find_var_node(proj, "y") is Some(var_node) else {
+    fail("missing y ref")
+  }
+  inspect(@scope.declaration(graph, var_node) is None, content="true")
+  guard lower_root(proj, graph) is Var(Free(free)) else {
+    fail("expected free var")
+  }
+  inspect(free.name, content="y")
+  inspect(free.origin == SourceVar, content="true")
+}
+
+///|
+test "lower: source Unbound origin is preserved" {
+  let root = @core.ProjNode::new(@ast.Term::Unbound("missing"), 0, 7, 0, [])
+  let graph = graph_for_root(root)
+  guard lower_root(root, graph) is Var(Free(free)) else {
+    fail("expected free unbound")
+  }
+  inspect(free.name, content="missing")
+  inspect(free.origin == SourceUnbound, content="true")
+}
+
+///|
+test "lower: source Unbound remains free even when a binder has the same name" {
+  let child = @core.ProjNode::new(@ast.Term::Unbound("x"), 0, 1, 1, [])
+  let root = @core.ProjNode::new(
+    @ast.Term::Lam("x", @ast.Term::Unbound("x")),
+    0,
+    8,
+    0,
+    [child],
+  )
+  let graph = graph_for_root(root)
+  guard lower_root(root, graph) is Lam(_, Var(Free(free))) else {
+    fail("expected lambda body to stay SourceUnbound")
+  }
+  inspect(free.name, content="x")
+  inspect(free.origin == SourceUnbound, content="true")
+}
+
+///|
+test "lower: Error and Hole survive" {
+  let error_root = @core.ProjNode::new(@ast.Term::Error("bad"), 0, 3, 0, [])
+  let hole_root = @core.ProjNode::new(@ast.Term::Hole(2), 0, 1, 0, [])
+  inspect(
+    lower_root(error_root, graph_for_root(error_root)) is Error("bad"),
+    content="true",
+  )
+  inspect(
+    lower_root(hole_root, graph_for_root(hole_root)) is Hole(2),
+    content="true",
+  )
+}
+
+///|
+test "lower: sequential module scope follows ScopeGraph" {
+  let (proj, graph) = alpha_parse_fixture("let x = 1\nlet x = x\nx")
+  guard lower_root(proj, graph) is Module(defs, Var(Bound(body_id))) else {
+    fail("expected lowered module")
+  }
+  guard defs.length() == 2 else { fail("expected two definitions") }
+  let (first_binder, _) = defs[0]
+  let (second_binder, second_init) = defs[1]
+  guard second_init is Var(Bound(init_id)) else {
+    fail("expected second init to reference first x")
+  }
+  inspect(init_id == first_binder.id, content="true")
+  inspect(body_id == second_binder.id, content="true")
+}

--- a/lang/lambda/alpha/moon.pkg
+++ b/lang/lambda/alpha/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/scope",
+  "dowdiness/lambda/ast",
+}
+
+import {
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+} for "wbtest"

--- a/lang/lambda/alpha/pkg.generated.mbti
+++ b/lang/lambda/alpha/pkg.generated.mbti
@@ -1,0 +1,74 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/lambda/alpha"
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/scope",
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn alpha_eq(AlphaTerm, AlphaTerm) -> Bool
+
+pub fn beta_reduce_root(AlphaTerm) -> AlphaTerm?
+
+pub fn lower_root(@core.ProjNode[@ast.Term], @scope.ScopeGraph) -> AlphaTerm
+
+pub fn reify(AlphaTerm, ReifyPolicy) -> @ast.Term
+
+// Errors
+
+// Types and methods
+pub(all) enum AlphaRef {
+  Bound(BinderId)
+  Free(FreeName)
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AlphaTerm {
+  Int(Int)
+  Unit
+  Var(AlphaRef)
+  Lam(Binder, AlphaTerm)
+  App(AlphaTerm, AlphaTerm)
+  Bop(@ast.Bop, AlphaTerm, AlphaTerm)
+  If(AlphaTerm, AlphaTerm, AlphaTerm)
+  LetDef(Binder, AlphaTerm)
+  Module(Array[(Binder, AlphaTerm)], AlphaTerm)
+  Error(String)
+  Hole(Int)
+} derive(Eq, @debug.Debug)
+
+pub(all) struct Binder {
+  id : BinderId
+  hint : String
+  origin : BinderOrigin
+} derive(Eq, @debug.Debug)
+
+pub(all) struct BinderId(Int) derive(Eq, Hash, @debug.Debug)
+
+pub(all) enum BinderOrigin {
+  SourceDecl(node_id~ : @core.NodeId, hint~ : String)
+  Generated(Int)
+} derive(Eq, @debug.Debug)
+
+pub(all) struct FreeName {
+  name : String
+  origin : FreeOrigin
+} derive(Eq, @debug.Debug)
+
+pub(all) enum FreeOrigin {
+  SourceVar
+  SourceUnbound
+  GeneratedFree
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ReifyPolicy {
+  Display
+  Source
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/lang/lambda/alpha/reify.mbt
+++ b/lang/lambda/alpha/reify.mbt
@@ -1,0 +1,196 @@
+///|
+pub fn reify(term : AlphaTerm, policy : ReifyPolicy) -> @ast.Term {
+  let env : Map[BinderId, String] = {}
+  let used : Array[String] = []
+  reify_with(term, policy, env, used)
+}
+
+///|
+fn push_unique(names : Array[String], name : String) -> Unit {
+  if !names.contains(name) {
+    names.push(name)
+  }
+}
+
+///|
+fn merged_names(left : Array[String], right : Array[String]) -> Array[String] {
+  let result = left.copy()
+  for name in right {
+    push_unique(result, name)
+  }
+  result
+}
+
+///|
+fn free_names(term : AlphaTerm) -> Array[String] {
+  match term {
+    Var(Free(free)) => [free.name]
+    Var(Bound(_)) => []
+    Lam(_, body) => free_names(body)
+    App(func, arg) => merged_names(free_names(func), free_names(arg))
+    Bop(_, lhs, rhs) => merged_names(free_names(lhs), free_names(rhs))
+    If(cond, then_, else_) =>
+      merged_names(
+        merged_names(free_names(cond), free_names(then_)),
+        free_names(else_),
+      )
+    LetDef(_, init) => free_names(init)
+    Module(defs, body) => {
+      let result = free_names(body)
+      for def in defs {
+        let (_, init) = def
+        for name in free_names(init) {
+          push_unique(result, name)
+        }
+      }
+      result
+    }
+    Int(_) | Unit | Error(_) | Hole(_) => []
+  }
+}
+
+///|
+fn suffix_free_names(
+  defs : Array[(Binder, AlphaTerm)],
+  body : AlphaTerm,
+  start : Int,
+) -> Array[String] {
+  let result = free_names(body)
+  for i in start..<defs.length() {
+    let (_, init) = defs[i]
+    for name in free_names(init) {
+      push_unique(result, name)
+    }
+  }
+  result
+}
+
+///|
+fn base_hint(hint : String) -> String {
+  if hint == "" {
+    "x"
+  } else {
+    hint
+  }
+}
+
+///|
+fn fresh_name(hint : String, avoid : Array[String]) -> String {
+  let base = base_hint(hint)
+  if !avoid.contains(base) {
+    base
+  } else {
+    for i = 1 {
+      let candidate = base + i.to_string()
+      if !avoid.contains(candidate) {
+        break candidate
+      }
+      continue i + 1
+    }
+  }
+}
+
+///|
+fn reify_ref(
+  alpha_ref : AlphaRef,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+) -> @ast.Term {
+  match alpha_ref {
+    Bound(id) =>
+      env
+      .get(id)
+      .map_or(
+        match policy {
+          Display => @ast.Term::Unbound("bound")
+          Source => @ast.Term::Var("bound")
+        },
+        name => @ast.Term::Var(name),
+      )
+    Free(free) =>
+      match (policy, free.origin) {
+        (Display, SourceUnbound) => @ast.Term::Unbound(free.name)
+        _ => @ast.Term::Var(free.name)
+      }
+  }
+}
+
+///|
+fn reify_lam(
+  binder : Binder,
+  body : AlphaTerm,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+  used : Array[String],
+) -> @ast.Term {
+  let avoid = merged_names(used, free_names(body))
+  let name = fresh_name(binder.hint, avoid)
+  let next_env = env.copy()
+  next_env[binder.id] = name
+  let next_used = used.copy()
+  push_unique(next_used, name)
+  @ast.Term::Lam(name, reify_with(body, policy, next_env, next_used))
+}
+
+///|
+fn reify_module(
+  defs : Array[(Binder, AlphaTerm)],
+  body : AlphaTerm,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+  used : Array[String],
+) -> @ast.Term {
+  let out_defs : Array[(String, @ast.Term)] = []
+  let next_env = env.copy()
+  let next_used = used.copy()
+  for i, def in defs {
+    let (binder, init) = def
+    let init_term = reify_with(init, policy, next_env, next_used)
+    let avoid = merged_names(next_used, suffix_free_names(defs, body, i + 1))
+    let name = fresh_name(binder.hint, avoid)
+    out_defs.push((name, init_term))
+    next_env[binder.id] = name
+    push_unique(next_used, name)
+  }
+  @ast.Term::Module(out_defs, reify_with(body, policy, next_env, next_used))
+}
+
+///|
+fn reify_with(
+  term : AlphaTerm,
+  policy : ReifyPolicy,
+  env : Map[BinderId, String],
+  used : Array[String],
+) -> @ast.Term {
+  match term {
+    Int(value) => @ast.Term::Int(value)
+    Unit => @ast.Term::Unit
+    Var(alpha_ref) => reify_ref(alpha_ref, policy, env)
+    Lam(binder, body) => reify_lam(binder, body, policy, env, used)
+    App(func, arg) =>
+      @ast.Term::App(
+        reify_with(func, policy, env, used),
+        reify_with(arg, policy, env, used),
+      )
+    Bop(op, lhs, rhs) =>
+      @ast.Term::Bop(
+        op,
+        reify_with(lhs, policy, env, used),
+        reify_with(rhs, policy, env, used),
+      )
+    If(cond, then_, else_) =>
+      @ast.Term::If(
+        reify_with(cond, policy, env, used),
+        reify_with(then_, policy, env, used),
+        reify_with(else_, policy, env, used),
+      )
+    LetDef(binder, init) =>
+      @ast.Term::LetDef(
+        fresh_name(binder.hint, used),
+        reify_with(init, policy, env, used),
+      )
+    Module(defs, body) => reify_module(defs, body, policy, env, used)
+    Error(message) => @ast.Term::Error(message)
+    Hole(index) => @ast.Term::Hole(index)
+  }
+}

--- a/lang/lambda/alpha/reify.mbt
+++ b/lang/lambda/alpha/reify.mbt
@@ -35,16 +35,11 @@ fn free_names(term : AlphaTerm) -> Array[String] {
         free_names(else_),
       )
     LetDef(_, init) => free_names(init)
-    Module(defs, body) => {
-      let result = free_names(body)
-      for def in defs {
+    Module(defs, body) =>
+      defs.fold(init=free_names(body), (names, def) => {
         let (_, init) = def
-        for name in free_names(init) {
-          push_unique(result, name)
-        }
-      }
-      result
-    }
+        merged_names(names, free_names(init))
+      })
     Int(_) | Unit | Error(_) | Hole(_) => []
   }
 }
@@ -55,14 +50,10 @@ fn suffix_free_names(
   body : AlphaTerm,
   start : Int,
 ) -> Array[String] {
-  let result = free_names(body)
-  for i in start..<defs.length() {
-    let (_, init) = defs[i]
-    for name in free_names(init) {
-      push_unique(result, name)
-    }
-  }
-  result
+  defs[start:].fold(init=free_names(body), (names, def) => {
+    let (_, init) = def
+    merged_names(names, free_names(init))
+  })
 }
 
 ///|

--- a/lang/lambda/alpha/reify.mbt
+++ b/lang/lambda/alpha/reify.mbt
@@ -45,15 +45,20 @@ fn free_names(term : AlphaTerm) -> Array[String] {
 }
 
 ///|
-fn suffix_free_names(
+fn suffix_free_name_sets(
   defs : Array[(Binder, AlphaTerm)],
   body : AlphaTerm,
-  start : Int,
-) -> Array[String] {
-  defs[start:].fold(init=free_names(body), (names, def) => {
-    let (_, init) = def
-    merged_names(names, free_names(init))
-  })
+) -> Array[Array[String]] {
+  let initial : (Array[String], Array[Array[String]]) = (free_names(body), [])
+  let (_, reversed_suffixes) = defs
+    .rev_iter()
+    .fold(init=initial, (state, def) => {
+      let (suffix_after, suffixes) = state
+      suffixes.push(suffix_after)
+      let (_, init) = def
+      (merged_names(suffix_after, free_names(init)), suffixes)
+    })
+  reversed_suffixes.rev()
 }
 
 ///|
@@ -134,10 +139,11 @@ fn reify_module(
   let out_defs : Array[(String, @ast.Term)] = []
   let next_env = env.copy()
   let next_used = used.copy()
+  let suffix_avoids = suffix_free_name_sets(defs, body)
   for i, def in defs {
     let (binder, init) = def
     let init_term = reify_with(init, policy, next_env, next_used)
-    let avoid = merged_names(next_used, suffix_free_names(defs, body, i + 1))
+    let avoid = merged_names(next_used, suffix_avoids[i])
     let name = fresh_name(binder.hint, avoid)
     out_defs.push((name, init_term))
     next_env[binder.id] = name

--- a/lang/lambda/alpha/reify.mbt
+++ b/lang/lambda/alpha/reify.mbt
@@ -62,11 +62,48 @@ fn suffix_free_name_sets(
 }
 
 ///|
-fn base_hint(hint : String) -> String {
-  if hint == "" {
-    "x"
+fn is_identifier_start(ch : Char) -> Bool {
+  let code = ch.to_int()
+  (code >= 'A' && code <= 'Z') || (code >= 'a' && code <= 'z')
+}
+
+///|
+fn is_identifier_char(ch : Char) -> Bool {
+  is_identifier_start(ch) ||
+  ({
+    let code = ch.to_int()
+    code >= '0' && code <= '9'
+  })
+}
+
+///|
+fn is_lambda_keyword(name : String) -> Bool {
+  match name {
+    "if" | "then" | "else" | "fn" | "let" => true
+    _ => false
+  }
+}
+
+///|
+fn is_valid_identifier_hint(hint : String) -> Bool {
+  if is_lambda_keyword(hint) {
+    false
   } else {
+    match hint {
+      [first, .. rest] =>
+        is_identifier_start(first) &&
+        rest.iter().all(ch => is_identifier_char(ch))
+      "" => false
+    }
+  }
+}
+
+///|
+fn base_hint(hint : String) -> String {
+  if is_valid_identifier_hint(hint) {
     hint
+  } else {
+    "x"
   }
 }
 

--- a/lang/lambda/alpha/reify_wbtest.mbt
+++ b/lang/lambda/alpha/reify_wbtest.mbt
@@ -62,3 +62,21 @@ test "reify: module binders avoid suffix free names" {
   inspect(later_free, content="y")
   inspect(body_name, content="y1")
 }
+
+///|
+test "reify: invalid binder hints fall back to lexable names" {
+  let invalid = test_binder(0, "x_copy")
+  let keyword = test_binder(1, "if")
+  let digit = test_binder(2, "1x")
+  let term = Lam(invalid, Lam(keyword, Lam(digit, Unit)))
+  guard reify(term, Source)
+    is @ast.Term::Lam(
+      invalid_name,
+      @ast.Term::Lam(keyword_name, @ast.Term::Lam(digit_name, @ast.Term::Unit))
+    ) else {
+    fail("expected nested lambdas")
+  }
+  inspect(invalid_name, content="x")
+  inspect(keyword_name, content="x1")
+  inspect(digit_name, content="x2")
+}

--- a/lang/lambda/alpha/reify_wbtest.mbt
+++ b/lang/lambda/alpha/reify_wbtest.mbt
@@ -41,3 +41,24 @@ test "reify: nested binders avoid capturing outer references" {
   inspect(inner_name, content="x1")
   inspect(body_name, content="x")
 }
+
+///|
+test "reify: module binders avoid suffix free names" {
+  let first = test_binder(0, "y")
+  let second = test_binder(1, "z")
+  let term = Module(
+    [(first, Unit), (second, free_var("y"))],
+    Var(Bound(first.id)),
+  )
+  guard reify(term, Source)
+    is @ast.Term::Module(
+      [(first_name, @ast.Term::Unit), (second_name, @ast.Term::Var(later_free))],
+      @ast.Term::Var(body_name)
+    ) else {
+    fail("expected reified module")
+  }
+  inspect(first_name, content="y1")
+  inspect(second_name, content="z")
+  inspect(later_free, content="y")
+  inspect(body_name, content="y1")
+}

--- a/lang/lambda/alpha/reify_wbtest.mbt
+++ b/lang/lambda/alpha/reify_wbtest.mbt
@@ -1,0 +1,43 @@
+///|
+test "reify: freshens binders against free names" {
+  let binder = test_binder(0, "y")
+  let term = Lam(binder, free_var("y"))
+  guard reify(term, Source) is @ast.Term::Lam(name, @ast.Term::Var(body)) else {
+    fail("expected reified lambda")
+  }
+  inspect(name, content="y1")
+  inspect(body, content="y")
+}
+
+///|
+test "reify: Display preserves SourceUnbound and Source normalizes it" {
+  let term = Var(Free(test_free("missing", SourceUnbound)))
+  inspect(@ast.print_term(reify(term, Display)), content="<unbound: missing>")
+  inspect(@ast.print_term(reify(term, Source)), content="missing")
+}
+
+///|
+test "reify: Error and Hole survive" {
+  inspect(
+    reify(Error("bad"), Source) is @ast.Term::Error("bad"),
+    content="true",
+  )
+  inspect(reify(Hole(3), Source) is @ast.Term::Hole(3), content="true")
+}
+
+///|
+test "reify: nested binders avoid capturing outer references" {
+  let outer = test_binder(0, "x")
+  let inner = test_binder(1, "x")
+  let term = Lam(outer, Lam(inner, Var(Bound(outer.id))))
+  guard reify(term, Source)
+    is @ast.Term::Lam(
+      outer_name,
+      @ast.Term::Lam(inner_name, @ast.Term::Var(body_name))
+    ) else {
+    fail("expected nested lambdas")
+  }
+  inspect(outer_name, content="x")
+  inspect(inner_name, content="x1")
+  inspect(body_name, content="x")
+}

--- a/lang/lambda/alpha/subst.mbt
+++ b/lang/lambda/alpha/subst.mbt
@@ -1,0 +1,74 @@
+///|
+fn substitute(
+  term : AlphaTerm,
+  target : BinderId,
+  replacement : AlphaTerm,
+) -> AlphaTerm {
+  match term {
+    Var(Bound(id)) => if id == target { replacement } else { term }
+    Var(Free(_)) => term
+    Lam(binder, body) =>
+      if binder.id == target {
+        term
+      } else {
+        Lam(binder, substitute(body, target, replacement))
+      }
+    App(func, arg) =>
+      App(
+        substitute(func, target, replacement),
+        substitute(arg, target, replacement),
+      )
+    Bop(op, lhs, rhs) =>
+      Bop(
+        op,
+        substitute(lhs, target, replacement),
+        substitute(rhs, target, replacement),
+      )
+    If(cond, then_, else_) =>
+      If(
+        substitute(cond, target, replacement),
+        substitute(then_, target, replacement),
+        substitute(else_, target, replacement),
+      )
+    LetDef(binder, init) =>
+      LetDef(binder, substitute(init, target, replacement))
+    Module(defs, body) => substitute_module(defs, body, target, replacement)
+    Int(_) | Unit | Error(_) | Hole(_) => term
+  }
+}
+
+///|
+fn substitute_module(
+  defs : Array[(Binder, AlphaTerm)],
+  body : AlphaTerm,
+  target : BinderId,
+  replacement : AlphaTerm,
+) -> AlphaTerm {
+  let substituted_defs : Array[(Binder, AlphaTerm)] = []
+  let body_visible = for def in defs; target_visible = true {
+    let (binder, init) = def
+    let substituted_init = if target_visible {
+      substitute(init, target, replacement)
+    } else {
+      init
+    }
+    substituted_defs.push((binder, substituted_init))
+    continue target_visible && binder.id != target
+  } nobreak {
+    target_visible
+  }
+  let substituted_body = if body_visible {
+    substitute(body, target, replacement)
+  } else {
+    body
+  }
+  Module(substituted_defs, substituted_body)
+}
+
+///|
+pub fn beta_reduce_root(term : AlphaTerm) -> AlphaTerm? {
+  match term {
+    App(Lam(binder, body), arg) => Some(substitute(body, binder.id, arg))
+    _ => None
+  }
+}

--- a/lang/lambda/alpha/subst_wbtest.mbt
+++ b/lang/lambda/alpha/subst_wbtest.mbt
@@ -1,0 +1,57 @@
+///|
+test "substitute: replaces matching bound references only" {
+  let x = test_binder(0, "x")
+  let y = test_binder(1, "y")
+  let replacement = free_var("z")
+  let term = App(Var(Bound(x.id)), Var(Bound(y.id)))
+  guard substitute(term, x.id, replacement)
+    is App(Var(Free(free)), Var(Bound(rest))) else {
+    fail("expected one replacement")
+  }
+  inspect(free.name, content="z")
+  inspect(rest == y.id, content="true")
+}
+
+///|
+test "substitute: nested unrelated binders are untouched" {
+  let x = test_binder(0, "x")
+  let y = test_binder(1, "y")
+  let term = Lam(y, Var(Bound(y.id)))
+  guard substitute(term, x.id, free_var("z")) is Lam(_, Var(Bound(ref_id))) else {
+    fail("expected lambda to remain bound to y")
+  }
+  inspect(ref_id == y.id, content="true")
+}
+
+///|
+test "substitute: Error and Hole are preserved" {
+  let x = test_binder(0, "x")
+  inspect(
+    substitute(Error("bad"), x.id, free_var("z")) is Error("bad"),
+    content="true",
+  )
+  inspect(substitute(Hole(4), x.id, free_var("z")) is Hole(4), content="true")
+}
+
+///|
+test "substitute: module binder gates later substitutions" {
+  let x = test_binder(0, "x")
+  let term = Module([(x, Var(Bound(x.id)))], Var(Bound(x.id)))
+  guard substitute(term, x.id, free_var("z"))
+    is Module([(_, Var(Free(init_free)))], Var(Bound(body_id))) else {
+    fail("expected init replacement and body shadowing")
+  }
+  inspect(init_free.name, content="z")
+  inspect(body_id == x.id, content="true")
+}
+
+///|
+test "beta_reduce_root: reduces only root lambda applications" {
+  let x = test_binder(0, "x")
+  let term = App(Lam(x, Var(Bound(x.id))), free_var("z"))
+  guard beta_reduce_root(term) is Some(Var(Free(free))) else {
+    fail("expected root beta reduction")
+  }
+  inspect(free.name, content="z")
+  inspect(beta_reduce_root(free_var("z")) is None, content="true")
+}

--- a/lang/lambda/alpha/types.mbt
+++ b/lang/lambda/alpha/types.mbt
@@ -1,0 +1,55 @@
+///|
+pub(all) struct BinderId(Int) derive(Debug, Eq, Hash)
+
+///|
+pub(all) enum BinderOrigin {
+  SourceDecl(node_id~ : @core.NodeId, hint~ : String)
+  Generated(Int)
+} derive(Debug, Eq)
+
+///|
+pub(all) struct Binder {
+  id : BinderId
+  hint : String
+  origin : BinderOrigin
+} derive(Debug, Eq)
+
+///|
+pub(all) enum FreeOrigin {
+  SourceVar
+  SourceUnbound
+  GeneratedFree
+} derive(Debug, Eq)
+
+///|
+pub(all) struct FreeName {
+  name : String
+  origin : FreeOrigin
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AlphaRef {
+  Bound(BinderId)
+  Free(FreeName)
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AlphaTerm {
+  Int(Int)
+  Unit
+  Var(AlphaRef)
+  Lam(Binder, AlphaTerm)
+  App(AlphaTerm, AlphaTerm)
+  Bop(@ast.Bop, AlphaTerm, AlphaTerm)
+  If(AlphaTerm, AlphaTerm, AlphaTerm)
+  LetDef(Binder, AlphaTerm)
+  Module(Array[(Binder, AlphaTerm)], AlphaTerm)
+  Error(String)
+  Hole(Int)
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ReifyPolicy {
+  Display
+  Source
+} derive(Debug, Eq)


### PR DESCRIPTION
## Summary

- Record the Lambda alpha-safe transformation boundary ADR and the beta pilot plan.
- Add `lang/lambda/alpha` as a Lambda-specific alpha-safe core for lowering from `ProjNode + ScopeGraph`, binder-id substitution, root beta reduction, alpha equality, and deterministic reify.
- Cover the canonical capture-avoidance fixture `((x) => (y) => x) y` reifying as `(y1) => y`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@scope.build` | `lang/lambda/scope` | Yes | Builds the binding graph used by alpha lowering tests. |
| `@scope.declaration` | `lang/lambda/scope` | Yes | Maps projection references to binder identities during lowering. |
| `@core.collect_registry` / `@core.SourceMap::from_ast` | `lang/lambda/core` | Yes | Reused in tests to construct the source map and registry for `ScopeGraph`. |
| named `@ast.Term` constructors | `loom/examples/lambda/src/ast` | Yes | Kept as the source/display boundary for reification. |
| evaluator/typechecker envs | `lang/lambda/eval`, Lambda typechecker | No | Useful for evaluation/checking, but not an alpha-safe syntactic substitution substrate. |
| `lang/lambda/edits/free_vars` | `lang/lambda/edits` | No | Name-set based guards do not identify which binder a reference denotes. |
| existing lambda egraph string payloads | `loom/egraph/examples/lambda-opt` | No | Current payloads are name-based and remain follow-up work after this alpha pilot. |

New helpers added (if any):

- `AlphaTerm`, `AlphaRef`, `Binder`, `BinderId`, `FreeName`, `ReifyPolicy`: the new internal Lambda alpha core boundary types.
- `lower_root`: the only source/projection-to-alpha entry point in this pilot.
- `alpha_eq`: alpha-equivalence helper for tests and future canonical keying work.
- `beta_reduce_root`: root-only beta pilot over binder identity, intentionally not a production editor action.
- `reify`: deterministic alpha-core-to-named boundary with explicit display/source policy.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check --deny-warn` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes (`lang/lambda/alpha/pkg.generated.mbti` is the intended new public API)
- [x] JS rebuild not run; web artifacts are not affected
- [x] Code review run before PR; no high-confidence issues found

## Validation

```bash
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alpha-safe core infrastructure for Lambda expressions, enabling safe variable transformations and beta reduction without capture errors.

* **Documentation**
  * Defined architectural decision record (ADR) for Lambda's alpha-safe transformation boundary.
  * Added implementation plan for alpha-safe beta-reduction pilot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->