### PR TITLE
refactor(lambda): remove binding-id compatibility fallback

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -247,7 +247,8 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   actual LetDef ProjNodes to let_def; drag/drop E2E moves whole binding rows; binding
   actions pass real LetDef ids; scope annotation uses real LetDef ids; binder_span /
   go_to_definition remain source-span based; canvas unchanged.
-  Remaining cleanup (non-blocking): dead ValidateNodeExists binding-id fallback.
+  Post-#677 follow-up cleanup removed the remaining binding-id compatibility
+  fallbacks; action-context plumbing now uses real LetDef ids instead of init ids.
 
 - [ ] Prepare drag-and-drop foundations for `examples/block-editor`.
   Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder.
@@ -501,17 +502,13 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   the `DuplicateBinding on block-local binding` wbtest characterizes this and
   does NOT reparse.
 
-- [ ] Teach `edits/` **extract** op about nested-block scopes — the remaining
-  §20 clause. `compute_extract_to_let` (`text_edit_refactor.mbt`) still hoists
-  the new `let` to the ROOT body and gates capture root-relative, so a
-  block-internal expression with no block-local free var is hoisted unsoundly
-  (out-of-scope reference; #659). It safely refuses the block-local-free-var case
-  (wbtest `ExtractToLet refuses block-internal expr that uses a block-local
-  binding`), but the message is misleading and the capture analysis still has the
-  defs-empty Module-blind half (#651) and the two-path split (#656).
-  Exit: extracting a block-internal expression inserts the `let` into the
-  enclosing block and the result reparses to the intended AST; tracked by #659
-  (hoist target) + #651 / #656 (capture analysis).
+- [x] Teach `edits/` **extract** op about nested-block scopes.
+  Shipped: PR #674 (`f0cf3cf`, 2026-06-16) makes `compute_extract_to_let`
+  find the innermost enclosing `Module` through the scope graph and insert the
+  new `let` inside that block instead of hoisting to the root. wbtests cover
+  block-body insertion, block-def insertion, lambda-in-block ancestry,
+  empty-def blocks, and capture/rebind refusals. GitHub issue #659 remains open
+  for maintainer triage/closure, not for unshipped block-aware extraction code.
 
 ## Shipped history
 

--- a/docs/plans/2026-06-01-letdef-projnode-structural-edit.md
+++ b/docs/plans/2026-06-01-letdef-projnode-structural-edit.md
@@ -101,7 +101,7 @@ Observable outcomes:
    - Keep the existing tuple shape initially if possible: `(name, init, start, binding_id)` where `binding_id` now equals the real `LetDef` node id.
    - Update `to_flat_proj`, `to_flat_proj_incremental`, and `reconcile_flat_proj` to allocate/preserve LetDef ids as first-class node ids.
    - Update `FlatProj::to_proj_node_with_prev_module_id` to wrap each init in a `LetDef` ProjNode using `defs[i].3`.
-   - Update `FlatProj::from_proj_node` to read `LetDef` children and extract their init child. Treat legacy init-only Module children only if tests or migration need a compatibility fallback.
+   - Update the projection-derived definition view to read `LetDef` children and extract their init child. The legacy init-only Module-child fallback was removed after `ModuleProjection` disappeared.
 
 4. **SourceMap and token spans.**
    - Ensure `SourceMap::from_ast` records ranges for LetDef nodes.
@@ -115,9 +115,9 @@ Observable outcomes:
    - Keep `references(g, decl.id)` identity-based; do not reintroduce `Decl.node_id` as the reference key.
 
 6. **Binding edit operations.**
-   - Make `find_binding_for_init` either unnecessary or explicitly return the parent LetDef id for an init child.
+   - Removed `find_binding_for_init`; action context now queries `DefinitionIndex::binding_for_node` for selected LetDef rows only.
    - Update binding actions so a selected LetDef row directly produces `Rename`, `DeleteBinding`, `DuplicateBinding`, `MoveBindingUp`, `MoveBindingDown`, and `InlineAllUsages` with a registry-backed id.
-   - Remove or shrink `ValidateNodeExists` binding-id special cases once binding ids are registry ids.
+   - Binding ops now pass through normal `ValidateNodeExists` registry validation; no binding-id special case remains.
    - Update `get_binding_text_range` to prefer the LetDef node range. Keep init-range/backward-scan fallback only for compatibility tests.
    - Decide whether generic `Drop` on two LetDef nodes delegates to binding move/swap logic or remains in `SyncEditor::move_node` with LetDef-aware whole-range edits. The observable behavior must be whole-binding movement, not init swapping.
 
@@ -206,6 +206,6 @@ git status --short
   - `@scope.binder_span` and `@scope.go_to_definition` solve source-location use cases.
   - `FlatProj` is the current per-binding state carrier.
   - `ProjNode::branch` / `ProjNode::leaf` are sufficient construction primitives; no core projection helper is missing.
-  - `find_binding_for_init` is a workaround for the missing binding row and should shrink or disappear.
+  - `find_binding_for_init` was the workaround for the missing binding row and disappeared after first-class LetDef ids became the only binding handles.
 - Do not conflate this with #129 query/scope-resolution unification; `@scope` binding-index work already shipped the relevant pieces.
 - Do not reopen query-side indexing from `docs/TODO.md:447`; that is a separate performance-gated follow-up.

--- a/docs/superpowers/plans/2026-05-30-retire-resolve-binder.md
+++ b/docs/superpowers/plans/2026-05-30-retire-resolve-binder.md
@@ -107,7 +107,9 @@ around line 143).
   dependence on them (do Step 3's test edits first, or do 2+3 together, so the
   package never fails to compile mid-step).
 - Keep `find_usages`, `collect_var_usages`, `find_binding_for_init`,
-  `collect_lam_env` — still live.
+  `collect_lam_env` — still live at the time of this step. Later cleanup
+  removed `find_binding_for_init` after first-class LetDef ids became the only
+  binding handles.
 - **Verify before deleting:** re-run `moon ide find-references` on each of the
   three symbols and confirm zero remaining references outside the deletions
   themselves. (Pre-Execution check — the first unexpected hit means stop.)

--- a/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
+++ b/docs/superpowers/specs/2026-05-30-lambda-scope-graph-design.md
@@ -9,9 +9,9 @@
 Name-resolution / binding logic for the lambda language is duplicated and ad-hoc
 across ~5 sites:
 
-- `lang/lambda/edits/scope.mbt` (167 lines) — `resolve_binder`,
-  `find_enclosing_lam_binder`, `find_usages`, `collect_lam_env`,
-  `find_binding_for_init`.
+- `lang/lambda/edits/scope.mbt` (167 lines) — historical duplicate helpers:
+  `resolve_binder`, `find_enclosing_lam_binder`, `find_usages`,
+  `collect_lam_env`, and the later-removed `find_binding_for_init`.
 - `lang/lambda/edits/free_vars.mbt` (31 lines) — capture analysis `FV(term, env)`.
 - `lang/lambda/semantic/semantic_projection.mbt` (265 lines) — walks the AST
   threading an environment array, classifies each `Var` as bound/free.

--- a/examples/ideal/main/action_model.mbt
+++ b/examples/ideal/main/action_model.mbt
@@ -5,10 +5,9 @@
 ///|
 /// Detect the action context for a selected node.
 /// Parses the node ID string, looks up the node in the editor's projection,
-/// checks if it's a let-binding row/init, and finds the enclosing Module node.
+/// checks if it's a let-binding row, and finds the enclosing Module node.
 fn detect_action_context(
   editor : @editor.SyncEditor[@ast.Term],
-  companion : @lambda.LambdaCompanion,
   selected_node : String,
 ) -> NodeActionContext? {
   let nid = match parse_node_id(selected_node) {
@@ -19,14 +18,13 @@ fn detect_action_context(
     Some(n) => n
     None => return None
   }
-  let _ = companion
   let definition_index = match editor.get_proj_node() {
     Some(root) => @lambda_proj.DefinitionIndex::from_proj_node(root)
     None => return None
   }
-  // Check if this node is a let-binding row or init expression.
+  // Check if this node is a let-binding row.
   let (is_let_binding, binding_node_id, binding_def_index) = match
-    @lambda_edits.find_binding_for_init(nid, definition_index) {
+    definition_index.binding_for_node(nid) {
     Some((bid, idx)) => (true, Some(bid), Some(idx))
     None => (false, None, None)
   }

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -100,8 +100,7 @@ fn open_action_overlay(
   if node_id_str == "" {
     return model
   }
-  let ctx = match
-    detect_action_context(model.editor, model.companion, node_id_str) {
+  let ctx = match detect_action_context(model.editor, node_id_str) {
     Some(c) => c
     None => return model
   }

--- a/lang/lambda/edits/pkg.generated.mbti
+++ b/lang/lambda/edits/pkg.generated.mbti
@@ -12,8 +12,6 @@ import {
 // Values
 pub fn compute_text_edit(TreeEditOp, EditContext[@ast.Term]) -> Result[(Array[@core.SpanEdit], @core.FocusHint)?, String]
 
-pub fn find_binding_for_init(@core.NodeId, @proj.DefinitionIndex) -> (@core.NodeId, Int)?
-
 pub fn free_vars(@ast.Term, @hashset.HashSet[String]) -> @hashset.HashSet[String]
 
 pub fn get_actions_for_node(@ast.Term, NodeContext) -> Array[Action]

--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -342,14 +342,3 @@ fn free_name_would_rebind_to(
     }
   })
 }
-
-///|
-/// Look up the module binding NodeId for a given init expression or LetDef NodeId.
-/// Init-expression callers are mapped to the parent LetDef id; direct LetDef
-/// callers return the binding id unchanged.
-pub fn find_binding_for_init(
-  init_node_id : NodeId,
-  definition_index : DefinitionIndex,
-) -> (NodeId, Int)? {
-  definition_index.binding_for_node(init_node_id)
-}

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -78,61 +78,6 @@ test "module_def_references: later duplicate shadows body only" {
 }
 
 ///|
-test "find_binding_for_init: maps init ProjNode to binding NodeId" {
-  let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
-  let index = DefinitionIndex::from_proj_node(proj)
-  // First def's init is the LetDef node's child.
-  let init_id = proj.children[0].children[0].id()
-  let binding_node_id = proj.children[0].id()
-  match find_binding_for_init(init_id, index) {
-    Some((binding_id, def_index)) => {
-      inspect(binding_id == binding_node_id, content="true")
-      inspect(def_index, content="0")
-    }
-    None => fail("expected Some")
-  }
-  match find_binding_for_init(binding_node_id, index) {
-    Some((binding_id, def_index)) => {
-      inspect(binding_id == binding_node_id, content="true")
-      inspect(def_index, content="0")
-    }
-    None => fail("expected Some for LetDef id")
-  }
-}
-
-///|
-test "find_binding_for_init: returns None for non-init node" {
-  let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
-  let index = DefinitionIndex::from_proj_node(proj)
-  // Body node is not an init expression
-  let body = proj.children.last().unwrap()
-  inspect(find_binding_for_init(body.id(), index) is None, content="true")
-}
-
-///|
-test "find_binding_for_init: duplicate defs return matching binding order" {
-  let text = "let x = 0\nlet x = x\nx"
-  let (proj, _) = parse_to_proj_node(text)
-  let index = DefinitionIndex::from_proj_node(proj)
-  match find_binding_for_init(proj.children[0].children[0].id(), index) {
-    Some((binding_id, def_index)) => {
-      inspect(binding_id == proj.children[0].id(), content="true")
-      inspect(def_index, content="0")
-    }
-    None => fail("expected first duplicate binding")
-  }
-  match find_binding_for_init(proj.children[1].children[0].id(), index) {
-    Some((binding_id, def_index)) => {
-      inspect(binding_id == proj.children[1].id(), content="true")
-      inspect(def_index, content="1")
-    }
-    None => fail("expected second duplicate binding")
-  }
-}
-
-///|
 test "def_cutoff_at_node: duplicate defs use init-range cutoff" {
   let text = "let x = 0\nlet x = x\nx"
   let (proj, _) = parse_to_proj_node(text)

--- a/lang/lambda/edits/text_edit_binding_source.mbt
+++ b/lang/lambda/edits/text_edit_binding_source.mbt
@@ -88,9 +88,7 @@ fn binding_has_synthetic_fn_params(def : EditModuleBinding) -> Bool {
 /// Lam starts at the binding boundary instead of at a value initializer. This
 /// is only a rejection guard for missing structured roles, not a source scanner.
 fn binding_requires_fn_metadata(def : EditModuleBinding) -> Bool {
-  binding_has_synthetic_fn_params(def) &&
-  def.binding_id != def.init.id() &&
-  def.init.start == def.start
+  binding_has_synthetic_fn_params(def) && def.init.start == def.start
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_module_view.mbt
+++ b/lang/lambda/edits/text_edit_module_view.mbt
@@ -29,19 +29,15 @@ fn edit_root_node(
 }
 
 ///|
-fn edit_binding_from_child(
+fn edit_binding_from_let_def(
   name : String,
-  child : ProjNode[@ast.Term],
+  let_def : ProjNode[@ast.Term],
 ) -> EditModuleBinding {
-  match child.kind {
-    @ast.Term::LetDef(_, _) if child.children.length() > 0 =>
-      {
-        name,
-        init: child.children[0],
-        start: child.start,
-        binding_id: child.id(),
-      }
-    _ => { name, init: child, start: child.start, binding_id: child.id() }
+  {
+    name,
+    init: let_def.children[0],
+    start: let_def.start,
+    binding_id: let_def.id(),
   }
 }
 
@@ -53,7 +49,8 @@ fn edit_binding_by_id(
   match ctx.registry.get(binding_node_id) {
     Some(node) =>
       match node.kind {
-        @ast.Term::LetDef(name, _) => Ok(edit_binding_from_child(name, node))
+        @ast.Term::LetDef(name, _) if node.children.length() > 0 =>
+          Ok(edit_binding_from_let_def(name, node))
         _ => Err("Binding not found: " + binding_node_id.to_string())
       }
     None => Err("Binding not found: " + binding_node_id.to_string())
@@ -78,8 +75,10 @@ fn EditModuleView::from_root(root : ProjNode[@ast.Term]) -> EditModuleView {
       let bindings : Array[EditModuleBinding] = []
       let child_count = root.children.length()
       for i, def in defs {
-        if i + 1 < child_count {
-          bindings.push(edit_binding_from_child(def.0, root.children[i]))
+        if i + 1 < child_count &&
+          root.children[i].kind is @ast.Term::LetDef(_, _) &&
+          root.children[i].children.length() > 0 {
+          bindings.push(edit_binding_from_let_def(def.0, root.children[i]))
         }
       }
       let final_expr = if defs.length() < child_count {

--- a/lang/lambda/edits/text_edit_utils.mbt
+++ b/lang/lambda/edits/text_edit_utils.mbt
@@ -132,7 +132,7 @@ fn get_binding_text_range(
   }
   let binding_end = match source_map.get_range(def.binding_id) {
     Some(binding_range) => binding_range.end
-    None => init_range.end
+    None => return Err("Binding node not in source map")
   }
   if def.start < 0 ||
     def.start > source_text.length() ||

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -715,6 +715,20 @@ test "compute_text_edit: DeleteBinding with unknown id returns error" {
 }
 
 ///|
+test "compute_text_edit: DeleteBinding with init id returns error" {
+  let text = "let x = 0\nx"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let init_id = proj.children[0].children[0].id()
+  let result = compute_text_edit(
+    DeleteBinding(binding_node_id=init_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
 test "compute_text_edit: DuplicateBinding copies binding with _copy suffix" {
   let text = "let x = 42\nlet y = 1\nx + y"
   let (proj, _) = parse_to_proj_node(text)

--- a/lang/lambda/proj/definition_index.mbt
+++ b/lang/lambda/proj/definition_index.mbt
@@ -5,14 +5,10 @@ priv struct DefinitionIndexEntry {
 }
 
 ///|
-fn DefinitionIndexEntry::from_binding(
-  child : ProjNode[@ast.Term],
+fn DefinitionIndexEntry::from_let_def(
+  let_def : ProjNode[@ast.Term],
 ) -> DefinitionIndexEntry {
-  match child.kind {
-    @ast.Term::LetDef(_, _) if child.children.length() > 0 =>
-      { init: child.children[0], binding_id: child.id() }
-    _ => { init: child, binding_id: child.id() }
-  }
+  { init: let_def.children[0], binding_id: let_def.id() }
 }
 
 ///|
@@ -31,8 +27,10 @@ pub fn DefinitionIndex::from_proj_node(
     @ast.Term::Module(defs, _) => {
       let child_count = root.children.length()
       let entries : Array[DefinitionIndexEntry] = [
-        for i, _ in defs if i + 1 < child_count => {
-          DefinitionIndexEntry::from_binding(root.children[i])
+        for i, _ in defs if i + 1 < child_count &&
+        root.children[i].kind is @ast.Term::LetDef(_, _) &&
+        root.children[i].children.length() > 0 => {
+          DefinitionIndexEntry::from_let_def(root.children[i])
         }
       ]
       { entries, }
@@ -48,16 +46,13 @@ pub fn DefinitionIndex::length(self : DefinitionIndex) -> Int {
 }
 
 ///|
-/// Look up the binding handle for a module definition by either its LetDef node
-/// id or its initializer node id.
+/// Look up the binding handle for a module definition by its LetDef node id.
 pub fn DefinitionIndex::binding_for_node(
   self : DefinitionIndex,
   node_id : NodeId,
 ) -> (NodeId, Int)? {
   self.entries
-  .search_by(fn(entry) {
-    entry.binding_id == node_id || entry.init.id() == node_id
-  })
+  .search_by(fn(entry) { entry.binding_id == node_id })
   .map(fn(i) { (self.entries[i].binding_id, i) })
 }
 
@@ -65,8 +60,8 @@ pub fn DefinitionIndex::binding_for_node(
 /// Return the number of preceding module definitions visible at `node_id`.
 ///
 /// Nodes inside definition `i`'s initializer receive cutoff `i`; nodes outside
-/// all initializers receive the full definition count. Missing source ranges use
-/// the full count, matching the legacy edit-scope fallback.
+/// all initializers or missing from the source map receive the full definition
+/// count.
 pub fn DefinitionIndex::cutoff_at_node(
   self : DefinitionIndex,
   source_map : SourceMap,

--- a/lang/lambda/proj/definition_index_wbtest.mbt
+++ b/lang/lambda/proj/definition_index_wbtest.mbt
@@ -1,0 +1,44 @@
+///|
+test "DefinitionIndex::binding_for_node: maps LetDef id to binding index" {
+  let text = "let x = 0\nlet y = 1\nx + y"
+  let (proj, _) = parse_to_proj_node(text)
+  let index = DefinitionIndex::from_proj_node(proj)
+  let binding_node_id = proj.children[0].id()
+  match index.binding_for_node(binding_node_id) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == binding_node_id, content="true")
+      inspect(def_index, content="0")
+    }
+    None => fail("expected first binding")
+  }
+}
+
+///|
+test "DefinitionIndex::binding_for_node: init id is not a binding id" {
+  let text = "let x = 0\nx"
+  let (proj, _) = parse_to_proj_node(text)
+  let index = DefinitionIndex::from_proj_node(proj)
+  let init_id = proj.children[0].children[0].id()
+  inspect(index.binding_for_node(init_id) is None, content="true")
+}
+
+///|
+test "DefinitionIndex::binding_for_node: duplicate defs return binding order" {
+  let text = "let x = 0\nlet x = x\nx"
+  let (proj, _) = parse_to_proj_node(text)
+  let index = DefinitionIndex::from_proj_node(proj)
+  match index.binding_for_node(proj.children[0].id()) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == proj.children[0].id(), content="true")
+      inspect(def_index, content="0")
+    }
+    None => fail("expected first duplicate binding")
+  }
+  match index.binding_for_node(proj.children[1].id()) {
+    Some((binding_id, def_index)) => {
+      inspect(binding_id == proj.children[1].id(), content="true")
+      inspect(def_index, content="1")
+    }
+    None => fail("expected second duplicate binding")
+  }
+}


### PR DESCRIPTION
## Summary

- remove the public `@lambda_edits.find_binding_for_init` compatibility helper
- make `DefinitionIndex::binding_for_node` accept real `LetDef` binding ids only, not init ids
- remove remaining init-child fallback shapes in Lambda edit/module binding views
- update Ideal action-context plumbing to query `DefinitionIndex` directly and refresh #127 cleanup notes

## Reuse check

Existing APIs reused:
- `DefinitionIndex::binding_for_node` remains the binding-action lookup surface, now narrowed to real `LetDef` ids.
- First-class `LetDef` `ProjNode` ids are reused as the only binding handles.
- Existing `ValidateNodeExists` registry validation is reused for binding ops; no binding-id special-case path remains.

Existing APIs checked but not used:
- `@lambda_edits.find_binding_for_init` was the legacy compatibility shim and is removed rather than retained.
- The old init-child fallback in `DefinitionIndexEntry` / `EditModuleBinding` was checked against the post-#677 producer shape and removed.

New helpers:
- `DefinitionIndexEntry::from_let_def` and `edit_binding_from_let_def` only wrap the now-canonical LetDef child shape.

Imperative code:
- Existing builder-style loops in `EditModuleView::from_root` remain unchanged in style; this PR only narrows their accepted child shape.

## Non-goals

- Does not modify #659 / `fix/extract-to-let-block-aware` behavior or block-scope extraction logic.
- Does not resurrect `ModuleProjection` or any PR #677 legacy producer.
- Does not address adjacent Ideal nested-binding action UX beyond removing init-id compatibility plumbing.

## Validation

- `NEW_MOON_MOD=0 moon check lang/lambda/proj lang/lambda/edits examples/ideal/main --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/lambda/proj lang/lambda/edits examples/ideal/main` — 261 passed
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info`
- `git diff -- '*.mbti'` — intended drift: remove `find_binding_for_init` from `lang/lambda/edits/pkg.generated.mbti`
- `git diff --check`
- `bash scripts/check-agent-doc-links.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for binding nodes missing from source maps, ensuring stricter validation.

* **Refactor**
  * Simplified internal binding detection to use a consistent, unified approach.
  * Removed legacy fallback mechanisms for improved code maintainability.

* **Tests**
  * Updated unit tests to verify new binding handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->