### PR TITLE
refactor(ideal): extract value-derived Tabs UI helpers

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -456,8 +456,8 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         Text => "text"
         Structure => "structure"
       }
-      let cmd = @rabbita.effect(fn() { js_set_editor_mode(mode_str) })
-      (cmd, { ..model, mode, })
+      let js_cmd = @rabbita.effect(fn() { js_set_editor_mode(mode_str) })
+      (js_cmd, { ..model, mode, })
     }
     TogglePanel(panel) => {
       let ws = model.workspace

--- a/examples/ideal/main/ui/button.mbt
+++ b/examples/ideal/main/ui/button.mbt
@@ -1,8 +1,8 @@
 ///|
 // Ideal-local Tailwind button recipes.
 // Keep semantic hooks as the first class tokens: tests and integration code use
-// hooks such as `toolbar-btn`, `tab`, and `action-btn`, while Tailwind owns the
-// visual declarations for migrated button/tab chrome.
+// hooks such as `toolbar-btn` and `action-btn`, while Tailwind owns the
+// visual declarations for migrated button chrome.
 priv enum ButtonTone {
   Neutral
   Accent
@@ -49,41 +49,12 @@ pub fn toolbar_example_button_class() -> String {
 }
 
 ///|
-pub fn toolbar_tab_class(active : Bool) -> String {
-  if active {
-    "tab active " + toolbar_button_recipe_class(Accent)
-  } else {
-    "tab " + toolbar_button_recipe_class(Neutral)
-  }
-}
-
-///|
 pub fn toolbar_panel_toggle_class(active : Bool) -> String {
   if active {
     "panel-toggle active " + toolbar_button_recipe_class(Surface)
   } else {
     "panel-toggle " + toolbar_button_recipe_class(Neutral)
   }
-}
-
-///|
-// Bottom tabs use underline accent, not fill — lighter than toolbar tabs.
-let bottom_tab_base_class : String = button_chrome_base_class +
-  " text-canopy-caption py-canopy-sm px-canopy-md border-x-0 border-t-0 border-b-2 border-solid rounded-none min-h-[32px] pb-[calc(var(--space-sm)_-_2px)] max-[768px]:min-h-[44px] max-[768px]:min-w-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-md max-[768px]:pb-[calc(var(--space-md)_-_2px)]"
-
-///|
-fn bottom_tab_tone_class(active : Bool) -> String {
-  if active {
-    "bg-transparent text-canopy-accent-text border-b-canopy-accent"
-  } else {
-    "bg-transparent text-canopy-dim border-b-transparent hover:bg-canopy-surface hover:text-canopy-secondary"
-  }
-}
-
-///|
-pub fn bottom_tab_class(active : Bool) -> String {
-  let hook = if active { "tab active " } else { "tab " }
-  hook + bottom_tab_base_class + " " + bottom_tab_tone_class(active)
 }
 
 ///|

--- a/examples/ideal/main/ui/moon.pkg
+++ b/examples/ideal/main/ui/moon.pkg
@@ -1,1 +1,7 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+  "dowdiness/rabbita-tabs/tabs",
+}
+
 supported_targets = "js"

--- a/examples/ideal/main/ui/pkg.generated.mbti
+++ b/examples/ideal/main/ui/pkg.generated.mbti
@@ -1,12 +1,28 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "dowdiness/ideal-editor/main/ui"
 
+import {
+  "dowdiness/rabbita-tabs/tabs",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
 // Values
 pub fn action_button_class() -> String
 
 pub fn action_button_danger_class() -> String
 
-pub fn bottom_tab_class(Bool) -> String
+pub fn behavior(id~ : String, tab_count~ : Int, selected~ : Int) -> @tabs.Model
+
+pub fn tab_class(Bool) -> String
+
+pub fn tab_panel_view(@tabs.Model, Int, panel_id~ : String, class~ : String, Array[@html.Html]) -> @html.Html
+
+pub fn tab_trigger_view(@tabs.Model, Int, Tab, panel_id~ : String, Bool, (Int) -> @cmd.Cmd, (Bool) -> String) -> @html.Html
+
+pub fn tablist_view(label~ : String, class~ : String, Array[@html.Html]) -> @html.Html
+
+pub fn tabs_container_class() -> String
 
 pub fn toolbar_button_class() -> String
 
@@ -16,10 +32,22 @@ pub fn toolbar_panel_toggle_class(Bool) -> String
 
 pub fn toolbar_tab_class(Bool) -> String
 
+pub fn underline_tab_style() -> TabStyle
+
 // Errors
 
 // Types and methods
+pub(all) struct Tab {
+  id : String
+  label : String
+}
+
+pub(all) struct TabStyle {
+  container_class : String
+  tab_class : (Bool) -> String
+}
 
 // Type aliases
 
 // Traits
+

--- a/examples/ideal/main/ui/tabs.mbt
+++ b/examples/ideal/main/ui/tabs.mbt
@@ -1,0 +1,129 @@
+///|
+/// A single tab entry.
+pub(all) struct Tab {
+  id : String
+  label : String
+}
+
+///|
+// Canopy tab chrome recipes.
+// Mirrors `ui/button.mbt`: a shared chrome base, then per-variant base + tone
+// functions, exposed through public recipe helpers.
+
+///|
+/// Shared base for all tab variants (cursor, transition, font).
+let tab_chrome_base_class = "ideal-tab font-canopy-ui font-medium cursor-pointer transition-colors duration-(--duration-fast) ease-canopy-out"
+
+///|
+/// Structural class for underline tabs: bottom border acts as the indicator.
+let underline_tab_base_class : String = tab_chrome_base_class +
+  " text-canopy-caption py-canopy-sm px-canopy-md border-x-0 border-t-0 border-b-2 border-solid rounded-none min-h-[32px] pb-[calc(var(--space-sm)_-_2px)] max-[768px]:min-h-[44px] max-[768px]:min-w-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-md max-[768px]:pb-[calc(var(--space-md)_-_2px)]"
+
+///|
+/// Tone (color + hover + active underline) for underline tabs.
+fn underline_tab_tone_class(active : Bool) -> String {
+  if active {
+    "bg-transparent text-canopy-accent-text border-b-canopy-accent"
+  } else {
+    "bg-transparent text-canopy-dim border-b-transparent hover:bg-canopy-surface hover:text-canopy-secondary"
+  }
+}
+
+///|
+/// Public recipe for a single underline tab trigger.
+pub fn tab_class(active : Bool) -> String {
+  let hook = if active { "tab active " } else { "tab " }
+  hook + underline_tab_base_class + " " + underline_tab_tone_class(active)
+}
+
+///|
+/// Structural class for the tablist container.
+fn tabs_container_base_class() -> String {
+  "bottom-tabs flex items-center border-b border-solid border-canopy-border"
+}
+
+///|
+/// Sizing/spacing class for the tablist container.
+fn tabs_container_size_class() -> String {
+  "px-canopy-md gap-canopy-xs h-[36px] max-[768px]:h-auto max-[768px]:min-h-[44px]"
+}
+
+///|
+/// Public recipe for the tablist container.
+pub fn tabs_container_class() -> String {
+  tabs_container_base_class() + " " + tabs_container_size_class()
+}
+
+///|
+/// Bundle of visual recipes for a tablist. Consumers keep selection in their
+/// own model and pass these recipes to `tablist_view` / `tab_trigger_view`.
+pub(all) struct TabStyle {
+  container_class : String
+  tab_class : (Bool) -> String
+}
+
+///|
+/// Default Canopy underline style (used by the bottom panel).
+pub fn underline_tab_style() -> TabStyle {
+  { container_class: tabs_container_class(), tab_class }
+}
+
+///|
+/// Public recipe for a single toolbar tab button. Moved from `button.mbt`
+/// because it is a tab trigger, not a generic button.
+pub fn toolbar_tab_class(active : Bool) -> String {
+  if active {
+    "tab active " + toolbar_button_recipe_class(Accent)
+  } else {
+    "tab " + toolbar_button_recipe_class(Neutral)
+  }
+}
+
+///|
+/// Create the headless tabs behavior state.
+pub fn behavior(id~ : String, tab_count~ : Int, selected~ : Int) -> @tabs.Model {
+  @tabs.Model::new(id~, tab_count~, selected~)
+}
+
+///|
+/// Render the tablist container. Children are typically `tab_trigger_view`
+/// elements.
+pub fn tablist_view(
+  label~ : String,
+  class~ : String,
+  children : Array[@html.Html],
+) -> @html.Html {
+  @html.div(class~, attrs=@tabs.tablist_attrs(label~), children)
+}
+
+///|
+/// Render a single tab trigger button. `dispatch` receives the *target* tab
+/// index (from keyboard navigation) and must produce the command that updates
+/// selection, e.g. `fn(j) { emit(on_select(tabs[j].id)) }`.
+pub fn tab_trigger_view(
+  behavior : @tabs.Model,
+  index : Int,
+  tab : Tab,
+  panel_id~ : String,
+  active : Bool,
+  dispatch : (Int) -> @rabbita.Cmd,
+  tab_class : (Bool) -> String,
+) -> @html.Html {
+  @html.button(
+    class=tab_class(active),
+    attrs=behavior.tab_attrs(index, panel_id~, dispatch~),
+    [@html.text(tab.label)],
+  )
+}
+
+///|
+/// Render a tabpanel container.
+pub fn tab_panel_view(
+  behavior : @tabs.Model,
+  index : Int,
+  panel_id~ : String,
+  class~ : String,
+  children : Array[@html.Html],
+) -> @html.Html {
+  @html.div(class~, attrs=behavior.panel_attrs(index, panel_id~), children)
+}

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -323,6 +323,29 @@ fn bottom_tab_slug(tab : BottomTab) -> String {
 }
 
 ///|
+fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
+  let behavior = bottom_tabs_behavior(model.bottom_tab)
+  let style = @ui.underline_tab_style()
+  let triggers = bottom_tab_defs.mapi(fn(i, pair) {
+    let (tab, label) = pair
+    @ui.tab_trigger_view(
+      behavior,
+      i,
+      { id: bottom_tab_slug(tab), label },
+      panel_id=bottom_tab_panel_id(tab),
+      model.bottom_tab == tab,
+      j => dispatch(SelectBottomTab(bottom_tab_defs[j].0)),
+      style.tab_class,
+    )
+  })
+  @ui.tablist_view(
+    label="Bottom panel sections",
+    class=style.container_class,
+    triggers,
+  )
+}
+
+///|
 /// Panel container id. History and Graphviz keep their existing
 /// `canopy-{name}-container` ids because the render cmds write innerHTML
 /// to those exact element ids; the others get a uniform slug.
@@ -333,38 +356,6 @@ fn bottom_tab_panel_id(tab : BottomTab) -> String {
     IncrGraph => "canopy-incr-container"
     _ => "canopy-bottom-panel-" + bottom_tab_slug(tab)
   }
-}
-
-///|
-fn view_bottom_tabs(dispatch : Emit[Msg], model : Model) -> Html {
-  // The headless `@tabs` behavior owns the WAI-ARIA tablist keyboard model
-  // (ArrowLeft/Right wrap, Home/End jump), roving tabindex, `aria-selected`,
-  // and `aria-controls` (set only on the selected tab, since the other panels
-  // aren't mounted). This consumer owns the tab data, panel ids, selected-state
-  // recipe choice, and the index → `BottomTab` mapping.
-  let behavior = bottom_tabs_behavior(model.bottom_tab)
-  let buttons : Array[Html] = []
-  for i, pair in bottom_tab_defs {
-    let (tab, label) = pair
-    buttons.push(
-      @html.button(
-        class=@ui.bottom_tab_class(model.bottom_tab == tab),
-        // `dispatch` receives the *target* index, which for keyboard nav differs
-        // from this button's `i` (e.g. ArrowRight on tab `i` fires `i + 1`). Re-
-        // index `bottom_tab_defs[j]` — do NOT close over the loop's `tab`, or
-        // every arrow key would select the focused tab and break navigation.
-        attrs=behavior.tab_attrs(i, panel_id=bottom_tab_panel_id(tab), dispatch=j => {
-          dispatch(SelectBottomTab(bottom_tab_defs[j].0))
-        }),
-        [@html.text(label)],
-      ),
-    )
-  }
-  @html.div(
-    class=bottom_tabs_class,
-    attrs=@tabs.tablist_attrs(label="Bottom panel sections"),
-    buttons,
-  )
 }
 
 ///|

--- a/examples/ideal/main/view_bottom_classes.mbt
+++ b/examples/ideal/main/view_bottom_classes.mbt
@@ -1,5 +1,4 @@
 ///|
-// Tailwind utility bundles for the bottom-panel tab strip container.
-// Button chrome lives in `main/ui/button.mbt`; this file owns only the
-// bottom-tabs layout hook.
-let bottom_tabs_class = "bottom-tabs flex px-canopy-md gap-canopy-xs h-[36px] items-center border-b border-solid border-canopy-border max-[768px]:h-auto max-[768px]:min-h-[44px]"
+// Bottom-panel tab strip chrome is now owned by `main/ui/tabs.mbt` via
+// `tabs_container_class()`. This file is kept as the package-local hook for any
+// future bottom-panel-specific layout tokens.

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -10,6 +10,7 @@
 @source "../../main/view_outline_classes.mbt";
 @source "../../main/view_peer_empty_state_classes.mbt";
 @source "../../main/ui/button.mbt";
+@source "../../main/ui/tabs.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
 


### PR DESCRIPTION
## Summary

- Extract shared Ideal tab chrome and headless rendering helpers into `examples/ideal/main/ui/tabs.mbt`.
- Keep tab selection as durable value state in the parent Ideal model (`mode` and `bottom_tab`); no Rabbita `Cell` or `Emit` handles are stored in `Model`.
- Toolbar Text/Structure controls keep button semantics (`role=button`, `aria-pressed`) while sharing the tab-style recipe from `ui/tabs.mbt`.
- Bottom panel tabs render through shared `tablist_view` / `tab_trigger_view` helpers and the existing `@tabs.Model` keyboard/ARIA behavior.
- Remove the temporary nested Tabs demo tab from the bottom panel.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@tabs.Model` | `dowdiness/rabbita-tabs/tabs` | Yes | Headless keyboard navigation, roving tabindex, and ARIA tab attrs for the bottom panel |
| `@tabs.tablist_attrs` | `dowdiness/rabbita-tabs/tabs` | Yes | Tablist role/label attrs via `tablist_view` |
| Existing toolbar button recipes | `examples/ideal/main/ui/button.mbt` | Yes | Reused by `toolbar_tab_class` so toolbar mode controls retain button semantics |
| `@rabbita.cell_with_emit` | `rabbita/tea` | No | Avoided because consumer `Model` must not store live `Cell` / `Emit` handles; tabs are derived from value state instead |

New helpers added:

- `TabStyle`: container/trigger class recipes for value-derived tablists.
- `tablist_view`, `tab_trigger_view`, `tab_panel_view`: compositional headless rendering helpers.
- `toolbar_tab_class`, `tab_class`, `tabs_container_class`: Ideal-local style recipes for toolbar and bottom-panel tab chrome.

## Test plan

- [x] `moon check` passes
- [x] `moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] Targeted Ideal Playwright smoke covers toolbar button role/`aria-pressed`
- [x] JS build run for affected Ideal web example

## Validation

```bash
cd examples/ideal && moon check
cd examples/ideal && moon test
# JS: 1438 passed; native: 70 passed

cd examples/ideal/web
MOON_WORK=off CANOPY_SKIP_RELAY_SERVER=1 CI=1 npx playwright test e2e/seed.spec.ts --reporter=line
# 3 passed

cd examples/ideal/web && npm run build
# passed
```
