### PR TITLE
Refactor Ideal overlay toward value-owned boundary

### DIFF
--- a/examples/ideal/main/action_overlay_exec.mbt
+++ b/examples/ideal/main/action_overlay_exec.mbt
@@ -38,7 +38,13 @@ fn execute_action(
           (none, { ..model, overlay, })
         }
       }
-    Ok(None) => show_name_prompt(model, action)
+    Ok(None) => {
+      let result = model.overlay.show_name_prompt(action)
+      (
+        focus_selector_after_render(".name-prompt-input"),
+        { ..model, overlay: result.state },
+      )
+    }
     Err(msg) => {
       let overlay = { ..model.overlay, error: msg }
       (none, { ..model, overlay, })

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -1,97 +1,231 @@
 ///|
-fn show_name_prompt(
-  model : Model,
-  action : @lambda_edits.Action,
-) -> (Cmd, Model) {
-  let overlay = {
-    ..model.overlay,
-    mode: NamePrompt(action, value=""),
-    error: "",
-    menu: model.overlay.menu.reset(item_count=0),
-  }
-  (focus_selector_after_render(".name-prompt-input"), { ..model, overlay, })
+pub(all) enum OverlayMsg {
+  Menu(@menu.Msg)
+  KeyPressed(String)
+  NameInput(String)
+  NameSubmit
+  NameCancel
 }
 
 ///|
-fn overlay_context_kind(model : Model) -> @ast.Term {
-  match model.overlay.node_context {
+enum OverlayEffect {
+  NoOverlayEffect
+  FocusMenu
+  FocusNamePrompt
+  ExecuteAction(@lambda_edits.Action, choice~ : String, name~ : String)
+  CloseOverlay
+}
+
+///|
+struct OverlayUpdate {
+  state : OverlayState
+  effect : OverlayEffect
+}
+
+///|
+fn overlay_update(
+  state : OverlayState,
+  effect : OverlayEffect,
+) -> OverlayUpdate {
+  { state, effect }
+}
+
+///|
+fn OverlayState::show_name_prompt(
+  self : OverlayState,
+  action : @lambda_edits.Action,
+) -> OverlayUpdate {
+  overlay_update(
+    {
+      ..self,
+      mode: NamePrompt(action, value=""),
+      error: "",
+      menu: self.menu.reset(item_count=0),
+    },
+    FocusNamePrompt,
+  )
+}
+
+///|
+fn OverlayState::context_kind(self : OverlayState) -> @ast.Term {
+  match self.node_context {
     Some(ctx) => ctx.kind
     None => @ast.Term::Unit
   }
 }
 
 ///|
-fn submenu_choices(
-  model : Model,
+fn OverlayState::submenu_choices(
+  self : OverlayState,
   action : @lambda_edits.Action,
 ) -> Array[(String, String)] {
-  get_submenu_choices(action.id, overlay_context_kind(model))
+  get_submenu_choices(action.id, self.context_kind())
 }
 
 ///|
-fn open_submenu(
-  model : Model,
+fn OverlayState::open_submenu(
+  self : OverlayState,
   action : @lambda_edits.Action,
   item_count : Int,
-) -> (Cmd, Model) {
-  let overlay = {
-    ..model.overlay,
-    mode: Submenu(action),
-    // Navigating into a submenu is a fresh attempt — clear any stale error so
-    // it doesn't linger across the now-visible (all-mode) error surface.
-    error: "",
-    menu: model.overlay.menu.reset(item_count~),
-  }
-  (overlay.menu.focus_cmd(), { ..model, overlay, })
+) -> OverlayUpdate {
+  overlay_update(
+    {
+      ..self,
+      mode: Submenu(action),
+      // Navigating into a submenu is a fresh attempt — clear any stale error so
+      // it doesn't linger across the now-visible (all-mode) error surface.
+      error: "",
+      menu: self.menu.reset(item_count~),
+    },
+    FocusMenu,
+  )
 }
 
 ///|
-fn reset_main_menu(model : Model) -> Model {
-  let overlay = {
-    ..model.overlay,
-    mode: MainMenu,
-    // Returning to the main menu is a fresh attempt — clear any stale error.
-    error: "",
-    menu: model.overlay.menu.reset(item_count=model.overlay.actions.length()),
-  }
-  { ..model, overlay, }
-}
-
-///|
-/// Dispatch an action immediately, open a submenu for choice-based actions,
-/// or open the name prompt for input-requiring actions.
-fn dispatch_or_prompt(
-  model : Model,
+fn OverlayState::dispatch_or_prompt(
+  self : OverlayState,
   action : @lambda_edits.Action,
-) -> (Cmd, Model) {
+) -> OverlayUpdate {
   if action.needs_input {
-    show_name_prompt(model, action)
+    self.show_name_prompt(action)
   } else {
-    let choices = submenu_choices(model, action)
+    let choices = self.submenu_choices(action)
     match choices {
-      [] => execute_action(model, action, "", "")
-      _ => open_submenu(model, action, choices.length())
+      [] => overlay_update(self, ExecuteAction(action, choice="", name=""))
+      _ => self.open_submenu(action, choices.length())
     }
   }
 }
 
 ///|
-fn execute_submenu_choice(
-  model : Model,
+fn OverlayState::execute_submenu_choice(
+  self : OverlayState,
   action : @lambda_edits.Action,
   index : Int,
-) -> (Cmd, Model)? {
-  let choices = submenu_choices(model, action)
+) -> OverlayUpdate? {
+  let choices = self.submenu_choices(action)
   if index >= 0 && index < choices.length() {
     let (_, value) = choices[index]
-    Some(execute_action(model, action, value, ""))
+    Some(overlay_update(self, ExecuteAction(action, choice=value, name="")))
   } else {
     None
   }
 }
 
 ///|
-fn close_submenu(model : Model) -> (Cmd, Model) {
-  let model = reset_main_menu(model)
-  (model.overlay.menu.focus_cmd(), model)
+fn OverlayState::handle_text_key(
+  self : OverlayState,
+  key : String,
+) -> OverlayUpdate {
+  match self.mode {
+    Submenu(sub_action) => {
+      let parsed = @string.parse_int(key) catch { _ => 0 }
+      let idx = parsed - 1 // "1" → 0, "2" → 1, etc.
+      match self.execute_submenu_choice(sub_action, idx) {
+        Some(result) => result
+        None => overlay_update(self, NoOverlayEffect)
+      }
+    }
+    // In name prompt mode, let the view handle input.
+    NamePrompt(_, ..) => overlay_update(self, NoOverlayEffect)
+    MainMenu => {
+      // Match mnemonic: find the action whose mnemonic matches the key.
+      let matched = self.actions.iter().find_first(fn(a) { a.mnemonic == key })
+      match matched {
+        Some(action) => self.dispatch_or_prompt(action)
+        None => overlay_update(self, NoOverlayEffect)
+      }
+    }
+    Closed => overlay_update(self, NoOverlayEffect)
+  }
+}
+
+///|
+fn OverlayState::handle_menu_msg(
+  self : OverlayState,
+  menu_msg : @menu.Msg,
+) -> OverlayUpdate {
+  match menu_msg {
+    @menu.Activate(index) =>
+      match self.mode {
+        Submenu(sub_action) =>
+          match self.execute_submenu_choice(sub_action, index) {
+            Some(result) => result
+            None => overlay_update(self, NoOverlayEffect)
+          }
+        _ =>
+          if index >= 0 && index < self.actions.length() {
+            self.dispatch_or_prompt(self.actions[index])
+          } else {
+            overlay_update(self, NoOverlayEffect)
+          }
+      }
+    @menu.Close => overlay_update(self, CloseOverlay)
+    @menu.Key(key) => self.handle_text_key(key)
+    @menu.FocusNext
+    | @menu.FocusPrevious
+    | @menu.FocusFirst
+    | @menu.FocusLast
+    | @menu.FocusItem(_) => {
+      let next = { ..self, menu: self.menu.update(menu_msg) }
+      let effect = if menu_msg.requests_focus() {
+        FocusMenu
+      } else {
+        NoOverlayEffect
+      }
+      overlay_update(next, effect)
+    }
+  }
+}
+
+///|
+fn OverlayState::handle_name_input(
+  self : OverlayState,
+  value : String,
+) -> OverlayUpdate {
+  match self.mode {
+    NamePrompt(action, ..) =>
+      overlay_update(
+        { ..self, mode: NamePrompt(action, value~), error: "" },
+        NoOverlayEffect,
+      )
+    _ => overlay_update(self, NoOverlayEffect)
+  }
+}
+
+///|
+fn OverlayState::handle_name_submit(self : OverlayState) -> OverlayUpdate {
+  match self.mode {
+    NamePrompt(action, value~) => {
+      let name = value.trim().to_owned()
+      if name == "" {
+        overlay_update(
+          { ..self, error: "Enter a name to continue" },
+          NoOverlayEffect,
+        )
+      } else {
+        overlay_update(self, ExecuteAction(action, choice="", name~))
+      }
+    }
+    _ => overlay_update(self, NoOverlayEffect)
+  }
+}
+
+///|
+fn OverlayState::update(self : OverlayState, msg : OverlayMsg) -> OverlayUpdate {
+  match msg {
+    Menu(menu_msg) => self.handle_menu_msg(menu_msg)
+    KeyPressed(key) =>
+      if key == "" {
+        overlay_update(self, NoOverlayEffect)
+      } else {
+        match self.menu.keydown_msg(key) {
+          Some(menu_msg) => self.handle_menu_msg(menu_msg)
+          None => overlay_update(self, NoOverlayEffect)
+        }
+      }
+    NameInput(value) => self.handle_name_input(value)
+    NameSubmit => self.handle_name_submit()
+    NameCancel => overlay_update(self, CloseOverlay)
+  }
 }

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -82,6 +82,22 @@ fn OverlayState::open_submenu(
 }
 
 ///|
+fn OverlayState::reset_main_menu(self : OverlayState) -> OverlayState {
+  {
+    ..self,
+    mode: MainMenu,
+    // Returning to the main menu is a fresh attempt — clear any stale error.
+    error: "",
+    menu: self.menu.reset(item_count=self.actions.length()),
+  }
+}
+
+///|
+fn OverlayState::close_submenu(self : OverlayState) -> OverlayUpdate {
+  overlay_update(self.reset_main_menu(), FocusMenu)
+}
+
+///|
 fn OverlayState::dispatch_or_prompt(
   self : OverlayState,
   action : @lambda_edits.Action,
@@ -123,7 +139,7 @@ fn OverlayState::handle_text_key(
       let idx = parsed - 1 // "1" → 0, "2" → 1, etc.
       match self.execute_submenu_choice(sub_action, idx) {
         Some(result) => result
-        None => overlay_update(self, NoOverlayEffect)
+        None => self.close_submenu()
       }
     }
     // In name prompt mode, let the view handle input.

--- a/examples/ideal/main/action_overlay_update.mbt
+++ b/examples/ideal/main/action_overlay_update.mbt
@@ -1,106 +1,18 @@
 ///|
-fn handle_action_text_key(model : Model, key : String) -> (Cmd, Model) {
-  match model.overlay.mode {
-    Submenu(sub_action) => {
-      let idx = @string.parse_int(key) catch { _ => -1 }
-      let idx = idx - 1 // "1" → 0, "2" → 1, etc.
-      match execute_submenu_choice(model, sub_action, idx) {
-        Some(result) => result
-        None => close_submenu(model)
-      }
-    }
-    // In name prompt mode, let the view handle input.
-    NamePrompt(_, ..) => (none, model)
-    MainMenu => {
-      // Match mnemonic: find the action whose mnemonic matches the key.
-      let matched = model.overlay.actions
-        .iter()
-        .find_first(fn(a) { a.mnemonic == key })
-      match matched {
-        Some(action) => dispatch_or_prompt(model, action)
-        None => (none, model)
-      }
-    }
-    Closed => (none, model)
+fn apply_overlay_effect(model : Model, effect : OverlayEffect) -> (Cmd, Model) {
+  match effect {
+    NoOverlayEffect => (none, model)
+    FocusMenu => (model.overlay.menu.focus_cmd(), model)
+    FocusNamePrompt =>
+      (focus_selector_after_render(".name-prompt-input"), model)
+    ExecuteAction(action, choice~, name~) =>
+      execute_action(model, action, choice, name)
+    CloseOverlay => close_action_overlay(model)
   }
 }
 
 ///|
-fn handle_navigation_menu_msg(
-  model : Model,
-  menu_msg : @menu.Msg,
-) -> (Cmd, Model) {
-  let overlay = { ..model.overlay, menu: model.overlay.menu.update(menu_msg) }
-  let model = { ..model, overlay, }
-  if menu_msg.requests_focus() {
-    (model.overlay.menu.focus_cmd(), model)
-  } else {
-    (none, model)
-  }
-}
-
-///|
-fn handle_action_menu_msg(model : Model, menu_msg : @menu.Msg) -> (Cmd, Model) {
-  match menu_msg {
-    @menu.Activate(index) =>
-      match model.overlay.mode {
-        Submenu(sub_action) =>
-          match execute_submenu_choice(model, sub_action, index) {
-            Some(result) => result
-            None => (none, model)
-          }
-        _ =>
-          if index >= 0 && index < model.overlay.actions.length() {
-            dispatch_or_prompt(model, model.overlay.actions[index])
-          } else {
-            (none, model)
-          }
-      }
-    @menu.Close => close_action_overlay(model)
-    @menu.Key(key) => handle_action_text_key(model, key)
-    @menu.FocusNext
-    | @menu.FocusPrevious
-    | @menu.FocusFirst
-    | @menu.FocusLast
-    | @menu.FocusItem(_) => handle_navigation_menu_msg(model, menu_msg)
-  }
-}
-
-///|
-fn handle_action_key(model : Model, key : String) -> (Cmd, Model) {
-  match model.overlay.menu.keydown_msg(key) {
-    Some(menu_msg) => handle_action_menu_msg(model, menu_msg)
-    None => (none, model)
-  }
-}
-
-///|
-fn handle_name_prompt_input(model : Model, value : String) -> (Cmd, Model) {
-  match model.overlay.mode {
-    NamePrompt(action, ..) => {
-      let overlay = {
-        ..model.overlay,
-        mode: NamePrompt(action, value~),
-        error: "",
-      }
-      (none, { ..model, overlay, })
-    }
-    _ => (none, model)
-  }
-}
-
-///|
-fn handle_name_prompt_submit(model : Model) -> (Cmd, Model) {
-  match model.overlay.mode {
-    NamePrompt(action, value~) => {
-      let name = value.trim().to_owned()
-      if name == "" {
-        let overlay = { ..model.overlay, error: "Enter a name to continue" }
-        (none, { ..model, overlay, })
-      } else {
-        execute_action(model, action, "", name)
-      }
-    }
-    _ => (none, model)
-  }
+fn handle_overlay_msg(model : Model, overlay_msg : OverlayMsg) -> (Cmd, Model) {
+  let result = model.overlay.update(overlay_msg)
+  apply_overlay_effect({ ..model, overlay: result.state }, result.effect)
 }

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -689,17 +689,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     OpenActionOverlayForNode(node_id_str)
     | LongPressTriggeredForNode(node_id_str) =>
       open_action_overlay_from_event(model, node_id_str)
-    CloseActionOverlay => close_action_overlay(model)
-    ActionMenu(menu_msg) => handle_action_menu_msg(model, menu_msg)
-    ActionKeyPressed(key) =>
-      if key == "" {
-        (none, model)
-      } else {
-        handle_action_key(model, key)
-      }
-    NamePromptInput(value) => handle_name_prompt_input(model, value)
-    NamePromptSubmit => handle_name_prompt_submit(model)
-    NamePromptCancel => close_action_overlay(model)
+    ActionOverlay(overlay_msg) => handle_overlay_msg(model, overlay_msg)
     // ── Outline drag-and-drop ──────
     OutlineDragStart(node_id) => (none, { ..model, drag_source: Some(node_id) })
     OutlineDragOver(target_id, position) =>

--- a/examples/ideal/main/msg.mbt
+++ b/examples/ideal/main/msg.mbt
@@ -33,12 +33,7 @@ pub enum Msg {
   SyncStatusChanged(String)
   // Action overlay
   OpenActionOverlayForNode(String)
-  CloseActionOverlay
-  ActionMenu(@menu.Msg)
-  ActionKeyPressed(String)
-  NamePromptInput(String)
-  NamePromptSubmit
-  NamePromptCancel
+  ActionOverlay(OverlayMsg)
   LongPressTriggeredForNode(String)
   // Outline drag-and-drop
   OutlineDragStart(@canopy_core.NodeId)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -163,12 +163,7 @@ pub enum Msg {
   OpenActionOverlayFromOutline
   SyncStatusChanged(String)
   OpenActionOverlayForNode(String)
-  CloseActionOverlay
-  ActionMenu(@menu.Msg)
-  ActionKeyPressed(String)
-  NamePromptInput(String)
-  NamePromptSubmit
-  NamePromptCancel
+  ActionOverlay(OverlayMsg)
   LongPressTriggeredForNode(String)
   OutlineDragStart(@core.NodeId)
   OutlineDragOver(@core.NodeId, @core.DropPosition)
@@ -186,9 +181,21 @@ pub enum Msg {
 
 type NodeActionContext
 
+type OverlayEffect
+
 type OverlayMode
 
+pub(all) enum OverlayMsg {
+  Menu(@menu.Msg)
+  KeyPressed(String)
+  NameInput(String)
+  NameSubmit
+  NameCancel
+}
+
 type OverlayState
+
+type OverlayUpdate
 
 pub enum PanelId {
   Outline

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -151,7 +151,7 @@ fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
     custom_event_sub(
       EditorHost,
       ActionKey,
-      emit.map(key => ActionKeyPressed(key)),
+      emit.map(key => ActionOverlay(KeyPressed(key))),
     ),
     custom_event_sub(
       EditorHost,

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -25,7 +25,7 @@ fn view_action_item(
   }
   @html.div(
     class=item_class,
-    attrs=menu.item_attrs(index, msg => dispatch(ActionMenu(msg))),
+    attrs=menu.item_attrs(index, msg => dispatch(ActionOverlay(Menu(msg)))),
     [
       @html.span(class=action_mnemonic_class, [@html.text(action.mnemonic)]),
       @html.span(class=action_label_text_class, [@html.text(action.label)]),
@@ -89,9 +89,9 @@ fn view_name_prompt(
   let on_keydown_handler = fn(kb : @html.Keyboard) {
     let key = kb.key()
     if key == "Enter" {
-      dispatch(NamePromptSubmit)
+      dispatch(ActionOverlay(NameSubmit))
     } else if key == "Escape" {
-      dispatch(NamePromptCancel)
+      dispatch(ActionOverlay(NameCancel))
     } else {
       @rabbita.none
     }
@@ -108,7 +108,7 @@ fn view_name_prompt(
           placeholder="name\u{2026}",
           value=name_value,
           autofocus=true,
-          on_input=fn(value) { dispatch(NamePromptInput(value)) },
+          on_input=fn(value) { dispatch(ActionOverlay(NameInput(value))) },
           attrs=@html.Attrs::build().aria_label(prompt_label),
         ),
       ],
@@ -138,7 +138,7 @@ fn view_submenu_choices(
     items.push(
       @html.div(
         class=action_overlay_item_class,
-        attrs=menu.item_attrs(i, msg => dispatch(ActionMenu(msg))),
+        attrs=menu.item_attrs(i, msg => dispatch(ActionOverlay(Menu(msg)))),
         [
           @html.span(class=action_mnemonic_class, [
             @html.text((i + 1).to_string()),
@@ -198,21 +198,29 @@ fn view_action_overlay(
     MainMenu | Closed =>
       view_action_list(dispatch, model.overlay.menu, model.overlay.actions)
   }
+  let panel_attrs = match model.overlay.mode {
+    NamePrompt(_, ..) =>
+      @html.Attrs::build()
+      .role("dialog")
+      .aria_label("Structural editing name prompt")
+      .style_attr(position_style)
+    _ =>
+      model.overlay.menu
+      .panel_attrs(msg => dispatch(ActionOverlay(Menu(msg))))
+      .aria_label("Structural editing actions")
+      .style_attr(position_style)
+  }
   @html.fragment([
     // Scrim: click-catching backdrop
     @html.div(
       class=action_overlay_scrim_class,
-      attrs=@menu.scrim_attrs(dispatch(CloseActionOverlay)),
+      attrs=@menu.scrim_attrs(dispatch(ActionOverlay(NameCancel))),
       @html.nothing,
     ),
     // Overlay panel — roving focus moves to the active menu item after render.
-    @html.div(
-      class=action_overlay_panel_class,
-      attrs=model.overlay.menu
-        .panel_attrs(msg => dispatch(ActionMenu(msg)))
-        .aria_label("Structural editing actions")
-        .style_attr(position_style),
-      [view_action_overlay_error(model.overlay.error), content],
-    ),
+    @html.div(class=action_overlay_panel_class, attrs=panel_attrs, [
+      view_action_overlay_error(model.overlay.error),
+      content,
+    ]),
   ])
 }

--- a/examples/ideal/main/view_outline.mbt
+++ b/examples/ideal/main/view_outline.mbt
@@ -368,7 +368,7 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
             }
           "Escape" =>
             if model.overlay.is_open() {
-              dispatch(CloseActionOverlay)
+              dispatch(ActionOverlay(NameCancel))
             } else {
               dispatch(OutlineNavigate(""))
             }


### PR DESCRIPTION
## Summary

- Refactor Ideal action overlay messages into a single `ActionOverlay(OverlayMsg)` boundary with value-owned `OverlayState::update` transitions.
- Keep parent-owned effects (`editor`, `companion`, node context, focus commands) in the parent update path via `OverlayEffect` application.
- Avoid storing Rabbita `Cell`, `Emit`, callbacks, or `Cmd` handles in `Model`; overlay state remains value-owned and uses existing `@menu.Model` value state.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@menu.Model::reset`, `update`, `keydown_msg`, `focus_cmd`, `panel_attrs`, `item_attrs` | `lib/menu/src/menu/*` | Yes | Reused for menu/submenu value state, roving focus, and panel/item attrs. |
| `@resizable.Model` / attrs | `lib/resizable/src/resizable/*` | No | Inspected as another value-owned child model pattern; overlay behavior is menu/input state rather than resizable layout state. |
| `open_action_overlay`, `close_action_overlay`, `closed_overlay`, `is_open` | `examples/ideal/main/action_overlay_state.mbt` | Yes | Preserved lifecycle helpers and kept parent-owned close/focus effects outside pure overlay transition logic. |
| `execute_action`, `get_submenu_choices`, name prompt helpers | `examples/ideal/main/action_overlay_exec.mbt`, `action_model.mbt`, `view_actions.mbt` | Yes | Reused existing action execution and submenu-choice logic; delegated state transitions around them instead of duplicating editor/companion effects. |
| Value-derived tabs helper pattern | `examples/ideal/main/ui/tabs.mbt` | Yes | Followed the value-owned child-state direction and did not reintroduce stored Rabbita handles. |

New helpers added (if any):

- `OverlayMsg`: overlay-local messages grouped under parent `Msg::ActionOverlay`.
- `OverlayEffect`: separates pure overlay state transitions from parent-owned effects.
- `OverlayUpdate`: returns the next `OverlayState` plus an `OverlayEffect`.
- `OverlayState::*` transition methods in `action_overlay_flow.mbt`: localize menu/key/name-prompt state-machine logic behind the overlay state boundary.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/ideal && moon build --target js`)

## Validation

```bash
NEW_MOON_MOD=0 moon fmt --check
git diff --check
moon info
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/ideal && moon check --deny-warn
cd examples/ideal && moon test --release
cd examples/ideal && moon build --target js
./scripts/test-ideal-web-e2e.sh e2e/structural-editing.spec.ts
```

Targeted Ideal Playwright result: `15 passed`.

MoonBit test totals observed:

- `Total tests: 1438, passed: 1438, failed: 0. [js]`
- `Total tests: 70, passed: 70, failed: 0. [native]`
