### PR TITLE
fix(lambda): hide scope graph node maps

### DIFF
--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -133,14 +133,7 @@ fn scope_id_for_node(
   g : @scope.ScopeGraph,
   node_id : NodeId,
 ) -> @scope.ScopeId? {
-  match g.refs.iter().find_first(fn(r) { r.node_id == node_id }) {
-    Some(r) => Some(r.scope)
-    None =>
-      g.decls
-      .iter()
-      .find_first(fn(d) { d.node_id == node_id })
-      .map(fn(d) { d.scope })
-  }
+  @scope.scope_for_node(g, node_id)
 }
 
 ///|
@@ -167,13 +160,13 @@ fn find_enclosing_block(
   node_id : NodeId,
 ) -> ProjNode[@ast.Term]? {
   guard root_scope_id(g) is Some(root) else { return None }
-  let mut cur = g.node_scope.get(node_id)
+  let mut cur = @scope.scope_for_node(g, node_id)
   while cur is Some(sid) && sid != root {
     let module_opt = registry
       .values()
       .find_first(fn(n) {
         n.kind is @ast.Term::Module(_, _) &&
-        g.node_scope.get(n.id()) is Some(nsid) &&
+        @scope.scope_for_node(g, n.id()) is Some(nsid) &&
         nsid == sid
       })
     if module_opt is Some(block) {

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -101,7 +101,7 @@ fn compute_extract_to_let(
       // Lambda params declared OUTSIDE the block stay visible at the insertion
       // point and must not be rejected.
       let node_subtree = subtree_node_ids(node)
-      let unsafe_ref = match g.node_scope.get(block_node.id()) {
+      let unsafe_ref = match @scope.scope_for_node(g, block_node.id()) {
         Some(bis) =>
           fv
           .iter()

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -19,8 +19,9 @@ fn build_parent_map(
 ///|
 /// Mutable builder state accumulated across passes.
 ///
-/// `node_cutoffs` is transient pass-2 state (never stored in the graph): for
-/// each node it records the sequential cutoff of every enclosing module scope
+/// `node_cutoffs` is builder-owned pass-2 state, persisted privately as
+/// `ScopeGraph.node_cutoffs`: for each node it records the sequential cutoff of
+/// every enclosing module scope
 /// — a `ModuleDef(def_index)` in scope `s` is visible to the node only if
 /// `def_index < node_cutoffs[node][s]`. Lambda scopes never appear (they hold
 /// no `ModuleDef`). This generalises the former single-`Int` cutoff so nested

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -79,6 +79,6 @@ pub(all) struct ScopeGraph {
   decls : Array[Decl]
   refs : Array[Ref]
   module_node_id : @core.NodeId
-  node_scope : Map[@core.NodeId, ScopeId]
-  node_cutoffs : Map[@core.NodeId, Map[ScopeId, Int]]
+  priv node_scope : Map[@core.NodeId, ScopeId]
+  priv node_cutoffs : Map[@core.NodeId, Map[ScopeId, Int]]
 } derive(Debug)

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -207,3 +207,63 @@ test "enclosing_env: lambda params in scope" {
   inspect(env.contains("x"), content="true")
   inspect(env.contains("y"), content="true")
 }
+
+///|
+test "scope_for_node: ref node uses resolution start scope" {
+  let (proj, registry, source_map) = build_fixture("let x = 1\nx")
+  let g = build(registry, source_map)
+  let body_var = find_var_in_body(proj, "x")
+  guard g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root)
+  inspect(scope_for_node(g, body_var) == Some(root.id), content="true")
+}
+
+///|
+test "scope_for_node: module declaration node uses declaring scope" {
+  let (proj, registry, source_map) = build_fixture("let x = 1\nx")
+  let g = build(registry, source_map)
+  guard g.scopes.iter().find_first(fn(s) { s.parent is None }) is Some(root)
+  inspect(
+    scope_for_node(g, proj.children[0].id()) == Some(root.id),
+    content="true",
+  )
+}
+
+///|
+test "scope_for_node: lambda binder node uses expression scope" {
+  let (proj, registry, source_map) = build_fixture("(x) => x")
+  let g = build(registry, source_map)
+  guard g.decls.iter().find_first(fn(d) { d.kind is LamParam(_) }) is Some(decl)
+  inspect(decl.node_id == proj.id(), content="true")
+  inspect(scope_for_node(g, proj.id()) != Some(decl.scope), content="true")
+  guard scope_for_node(g, proj.id()) is Some(expr_scope)
+  let ScopeId(expr_i) = expr_scope
+  inspect(g.scopes[expr_i].parent is None, content="true")
+  let ScopeId(decl_i) = decl.scope
+  inspect(g.scopes[decl_i].parent == Some(expr_scope), content="true")
+}
+
+///|
+test "scope_for_node: unknown node returns none" {
+  let (_proj, registry, source_map) = build_fixture("let x = 1\nx")
+  let g = build(registry, source_map)
+  inspect(
+    scope_for_node(g, @core.NodeId::from_int(999_999)) is None,
+    content="true",
+  )
+}
+
+///|
+test "scope_for_node: block-local ref uses block scope" {
+  let (proj, registry, source_map) = build_fixture(
+    "let z = { let x = 1\nx }\nz",
+  )
+  let g = build(registry, source_map)
+  guard proj.kind is @ast.Term::Module(_, _) else { fail("expected module") }
+  let block = proj.children[0].children[0]
+  let block_var = find_var_node(block, "x")
+  guard scope_for_node(g, block_var) is Some(sid) else {
+    fail("expected scope for block variable")
+  }
+  let ScopeId(si) = sid
+  inspect(g.scopes[si].parent is Some(_), content="true")
+}

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub fn references(ScopeGraph, DeclId) -> Array[@dowdiness/canopy/core.NodeId]
 
 pub fn remap_failures(Array[ReachableFailure], Array[@dowdiness/canopy/core.SpanEdit]) -> Array[ReachableFailure]
 
+pub fn scope_for_node(ScopeGraph, @dowdiness/canopy/core.NodeId) -> ScopeId?
+
 // Errors
 
 // Types and methods
@@ -84,8 +86,7 @@ pub(all) struct ScopeGraph {
   decls : Array[Decl]
   refs : Array[Ref]
   module_node_id : @dowdiness/canopy/core.NodeId
-  node_scope : Map[@dowdiness/canopy/core.NodeId, ScopeId]
-  node_cutoffs : Map[@dowdiness/canopy/core.NodeId, Map[ScopeId, Int]]
+  // private fields
 } derive(@debug.Debug)
 
 pub(all) struct ScopeId(Int) derive(Compare, Eq, Hash, @debug.Debug)

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -19,7 +19,7 @@ pub fn declaration_for_name_at(
   node : @core.NodeId,
   name : String,
 ) -> Decl? {
-  guard g.node_scope.get(node) is Some(start_scope) else { return None }
+  guard scope_for_node(g, node) is Some(start_scope) else { return None }
   guard g.node_cutoffs.get(node) is Some(cutoffs) else { return None }
   let mut cur : ScopeId? = Some(start_scope)
   while cur is Some(sid) {
@@ -44,6 +44,19 @@ pub fn declaration_for_name_at(
     cur = scope.parent
   }
   None
+}
+
+///|
+/// The scope that the structural `node_id` belongs to. For a reference node,
+/// this is the scope where resolution starts. For a module-definition binder
+/// node, this is its declaring module scope. Lambda parameter declarations are
+/// represented by the owning `Lam` node, which is also an expression node; for
+/// that node this query returns the lambda expression's enclosing scope, while
+/// the parameter's declaring scope is recorded on the corresponding `Decl`.
+/// Returns `None` when the `node_id` was not recorded during scope-graph
+/// construction.
+pub fn scope_for_node(g : ScopeGraph, node_id : @core.NodeId) -> ScopeId? {
+  g.node_scope.get(node_id)
 }
 
 ///|
@@ -141,14 +154,7 @@ pub fn enclosing_env(
   g : ScopeGraph,
   node : @core.NodeId,
 ) -> @immut/hashset.HashSet[String] {
-  let start = match g.refs.iter().find_first(fn(r) { r.node_id == node }) {
-    Some(r) => Some(r.scope)
-    None =>
-      g.decls
-      .iter()
-      .find_first(fn(d) { d.node_id == node })
-      .map(fn(d) { d.scope })
-  }
+  let start = scope_for_node(g, node)
   let mut env : @immut/hashset.HashSet[String] = @immut/hashset.new()
   let mut cur = start
   while cur is Some(sid) {


### PR DESCRIPTION
## Summary

- Route lambda edit scope lookup through persisted `ScopeGraph.node_scope` via a new `scope_for_node` query.
- Hide `ScopeGraph.node_scope` and `node_cutoffs` behind query APIs so consumers no longer read the maps directly.
- Add white-box regression coverage for `scope_for_node` on refs, declarations, lambda binder nodes, unknown nodes, and block-local references.

Addresses #656 points 2–3 only; leaves the remaining #656 items open.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `declaration_for_name_at` | `lang/lambda/scope/query.mbt` | No | Resolves names to declarations, not structural node-to-scope ownership. |
| `enclosing_env` | `lang/lambda/scope/query.mbt` | No | Computes visible names for a node, not the node's persisted scope id. |
| `references` | `lang/lambda/scope/query.mbt` | No | Maps declarations to reference node IDs, not nodes to scopes. |

New helpers added (if any):

- `scope_for_node(g, node_id) -> ScopeId?`: smallest query API for the already-persisted node scope map, replacing external direct field access.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check lang/lambda/edits lang/lambda/scope` passes
- [x] `NEW_MOON_MOD=0 moon test -p lang/lambda/scope` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes; intended drift removes `node_scope` / `node_cutoffs` fields and adds `scope_for_node`
- [x] JS rebuild not run; web is not affected

## Validation

```bash
NEW_MOON_MOD=0 moon check lang/lambda/edits lang/lambda/scope
NEW_MOON_MOD=0 moon test -p lang/lambda/scope
NEW_MOON_MOD=0 moon info
```

