### PR TITLE
test(lambda): verify ExtractToLet block capture

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -509,8 +509,11 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   find the innermost enclosing `Module` through the scope graph and insert the
   new `let` inside that block instead of hoisting to the root. wbtests cover
   block-body insertion, block-def insertion, lambda-in-block ancestry,
-  empty-def blocks, and capture/rebind refusals. GitHub issue #659 remains open
-  for maintainer triage/closure, not for unshipped block-aware extraction code.
+  empty-def blocks, and capture/rebind refusals. Verified via scope-graph wbtests
+  that block-body insertion preserves resolution of block-local free vars even when
+  shadowing outer bindings. The block-body path inserts after all defs so block-local
+  visibility is maintained — no scope_is_within guard needed (unlike block-def path).
+  Closes #659.
 
 ## Shipped history
 

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1580,6 +1580,143 @@ test "compute_text_edit: ExtractToLet inserts inside empty-def block body" {
 }
 
 ///|
+/// Build a fresh scope graph for a reparsed projection.
+fn scope_graph_for_proj(proj : ProjNode[@ast.Term]) -> @scope.ScopeGraph {
+  let registry = text_edit_test_registry(proj)
+  let source_map = SourceMap::from_ast(proj)
+  @scope.build(registry, source_map)
+}
+
+///|
+/// Assert that `var_node` resolves to `expected_decl_node` in `g`.
+fn expect_var_resolves_to(
+  g : @scope.ScopeGraph,
+  var_node : ProjNode[@ast.Term],
+  expected_name : String,
+  expected_decl_node : ProjNode[@ast.Term],
+  unresolved_message : String,
+) -> Unit raise {
+  match @scope.declaration(g, var_node.id()) {
+    Some(decl) => {
+      inspect(decl.name, content=expected_name)
+      inspect(decl.node_id == expected_decl_node.id(), content="true")
+    }
+    None => fail(unresolved_message)
+  }
+}
+
+///|
+test "compute_text_edit: ExtractToLet block-body preserves resolution when block-local def shadows outer var [#659]" {
+  let text = "let a = 0\nlet z = { let a = 1\n  a + 1 }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[1].children[0]
+  let body = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=body.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(root_def_names(new_text), content="a,z")
+      inspect(nested_block_def_names(1, new_text), content="a,y")
+      let g = scope_graph_for_proj(result_proj)
+      let result_block = result_proj.children[1].children[0]
+      let y_init = result_block.children[1].children[0]
+      expect_var_resolves_to(
+        g,
+        y_init.children[0],
+        "a",
+        result_block.children[0],
+        "`a` in y's init is unresolved (expected block-local resolution)",
+      )
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: ExtractToLet block-body sub-expr preserves block-local free var resolution [#659]" {
+  let text = "let a = 0\nlet z = { let a = 1\n  (a + 2) + a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[1].children[0]
+  let body = block.children[block.children.length() - 1]
+  let extracted = body.children[0]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=extracted.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      let g = scope_graph_for_proj(result_proj)
+      let result_block = result_proj.children[1].children[0]
+      let y_init = result_block.children[1].children[0]
+      expect_var_resolves_to(
+        g,
+        y_init.children[0],
+        "a",
+        result_block.children[0],
+        "`a` in y's init is unresolved",
+      )
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: ExtractToLet block-body preserves mixed inner/outer free var resolution [#659]" {
+  let text = "let x = 10\nlet z = { let a = 1\n  a + x }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[1].children[0]
+  let body = block.children[block.children.length() - 1]
+  let result = compute_text_edit(
+    ExtractToLet(node_id=body.id(), var_name="y"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(root_def_names(new_text), content="x,z")
+      inspect(nested_block_def_names(1, new_text), content="a,y")
+      let g = scope_graph_for_proj(result_proj)
+      let result_block = result_proj.children[1].children[0]
+      let y_init = result_block.children[1].children[0]
+      expect_var_resolves_to(
+        g,
+        y_init.children[0],
+        "a",
+        result_block.children[0],
+        "`a` in y's init is unresolved",
+      )
+      expect_var_resolves_to(
+        g,
+        y_init.children[1],
+        "x",
+        result_proj.children[0],
+        "`x` in y's init is unresolved",
+      )
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
 test "compute_text_edit: AddBinding adds new let line" {
   let text = "let x = 0\nx"
   let (proj, _) = parse_to_proj_node(text)


### PR DESCRIPTION
## Summary
- add regression wbtests for #659 that apply ExtractToLet, apply emitted edits, reparse the edited text, and rebuild the scope graph
- verify block-body extraction preserves block-local binding resolution under root shadowing
- verify mixed block-local/root free vars continue to resolve to their original declarations
- update TODO to record that #659 is verified/closed with scope-graph evidence

## Reuse check
- Reused `parse_to_proj_node`, `SourceMap::from_ast`, `text_edit_test_registry`, `compute_text_edit`, and `apply_edits` from existing text-edit tests.
- Reused `@scope.build` and `@scope.declaration` to validate the reparsed AST's scope graph.
- Reused existing `root_def_names` and `nested_block_def_names` structural helpers.
- Checked `scope_for_node`, `declaration_for_name_at`, and existing rebind helpers; no implementation helper was needed because current main already preserves the intended behavior.

## Validation
- `NEW_MOON_MOD=0 moon check lang/lambda/edits lang/lambda/scope`
- `NEW_MOON_MOD=0 moon test lang/lambda/edits lang/lambda/scope` — 220/220 passing
- `NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info`
- `.mbti` drift inspected; unrelated EOF whitespace-only generated-interface changes were reverted
- `git diff --check`

## Notes
- GitHub #659 was already closed with verification evidence because current `origin/main` behavior passes these reproduction tests; this PR preserves that evidence as regression coverage.
