### PR TITLE
Fix DuplicateBinding reparse soundness

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -498,11 +498,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   `MoveBinding{Up,Down} swaps block-local bindings`,
   `MoveBindingUp rejects first block-local binding`). Follow-up PR #688 added
   adversarial coverage for block-local scoping-violation moves, deleting a
-  still-referenced block binding, and root/block same-name shadowing. Caveat:
-  block-local **duplicate** is now reachable but its output stays unsound — `_copy` is
-  unlexable (#649) and the inserted copy is not re-indented to the block (#650);
-  the `DuplicateBinding on block-local binding` wbtest characterizes this and
-  does NOT reparse.
+  still-referenced block binding, and root/block same-name shadowing.
 
 - [x] Teach `edits/` **extract** op about nested-block scopes.
   Shipped: PR #674 (`f0cf3cf`, 2026-06-16) makes `compute_extract_to_let`

--- a/lang/lambda/edits/text_edit_binding.mbt
+++ b/lang/lambda/edits/text_edit_binding.mbt
@@ -29,6 +29,51 @@ fn compute_delete_binding(
 }
 
 ///|
+fn declaration_names_in_scope(
+  g : @scope.ScopeGraph,
+  scope : @scope.ScopeId,
+) -> @immut/hashset.HashSet[String] {
+  let @scope.ScopeId(si) = scope
+  @immut/hashset.HashSet::from_iter(
+    g.scopes[si].decl_ids
+    .iter()
+    .map(fn(did) {
+      let @scope.DeclId(di) = did
+      g.decls[di].name
+    }),
+  )
+}
+
+///|
+/// Generate a Lambda-valid copy name from `base` that does not collide with any
+/// name in `avoid`. `base` is already a valid Lambda identifier, so appending
+/// decimal digits preserves lexability.
+fn compute_fresh_name(
+  base : String,
+  avoid : @immut/hashset.HashSet[String],
+  captures_existing_use : (String) -> Bool,
+) -> String {
+  for i = 1 {
+    let candidate = base + i.to_string()
+    if !avoid.contains(candidate) && !captures_existing_use(candidate) {
+      break candidate
+    }
+    continue i + 1
+  }
+}
+
+///|
+/// Return the run of space characters starting at `pos`, used as the indentation
+/// prefix for a line that already exists at that position.
+fn leading_whitespace_at(source_text : String, pos : Int) -> String {
+  let suffix = source_text[pos:]
+  match suffix.find_by(fn(ch) { ch != ' ' }) {
+    Some(end) => suffix[:end].to_owned()
+    None => suffix.to_owned()
+  }
+}
+
+///|
 fn compute_duplicate_binding(
   ctx : EditContext[@ast.Term],
   binding_node_id : NodeId,
@@ -48,15 +93,22 @@ fn compute_duplicate_binding(
     Ok(source) => source
     Err(e) => return Err(e)
   }
-  // Create copy with _copy suffix on name, preserving source syntax such as
-  // `fn` parameter annotations instead of reprinting the desugared Lam spine.
-  let new_name = def.name + "_copy"
+  // Create a fresh copy name while preserving source syntax such as `fn`
+  // parameter annotations instead of reprinting the desugared Lam spine.
+  let avoid = @scope.enclosing_env(g, binding_node_id).union(
+    declaration_names_in_scope(g, decl.scope),
+  )
+  let new_name = compute_fresh_name(def.name, avoid, fn(candidate) {
+    rename_captures_existing_use(g, decl, candidate)
+  })
   let new_binding = match
     binding_source.renamed_text(source_text, source_map, new_name) {
     Ok(text) => text
     Err(e) => return Err(e)
   }
-  // Insert after the current binding (after newline)
+  // Insert after the current binding (after newline). Block-local bindings need
+  // the following line's indentation prepended to the inserted copy.
+  let block = find_enclosing_block(g, registry, binding_node_id)
   let binding_end = binding_source.binding_end
   let insert_pos = if binding_end < source_text.length() &&
     source_text[binding_end] == '\n' {
@@ -64,8 +116,17 @@ fn compute_duplicate_binding(
   } else {
     binding_end
   }
-  let insert_text = if insert_pos == binding_end {
-    // No trailing newline — add one before the new binding
+  let insert_text = if block is Some(_) {
+    let indent = leading_whitespace_at(source_text, insert_pos)
+    let copied_indent_len = leading_whitespace_at(new_binding, 0).length()
+    let block_binding = new_binding[copied_indent_len:].to_owned()
+    if insert_pos == binding_end {
+      "\n" + indent + block_binding + "\n"
+    } else {
+      indent + block_binding + "\n"
+    }
+  } else if insert_pos == binding_end {
+    // No trailing newline — add one before the new binding.
     "\n" + new_binding
   } else {
     new_binding + "\n"

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -729,7 +729,7 @@ test "compute_text_edit: DeleteBinding with init id returns error" {
 }
 
 ///|
-test "compute_text_edit: DuplicateBinding copies binding with _copy suffix" {
+test "compute_text_edit: DuplicateBinding copies binding with fresh numeric suffix" {
   let text = "let x = 42\nlet y = 1\nx + y"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
@@ -742,7 +742,7 @@ test "compute_text_edit: DuplicateBinding copies binding with _copy suffix" {
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      inspect(new_text, content="let x = 42\nlet x_copy = 42\nlet y = 1\nx + y")
+      inspect(new_text, content="let x = 42\nlet x1 = 42\nlet y = 1\nx + y")
     }
     _ => fail("expected Some edits")
   }
@@ -762,7 +762,7 @@ test "compute_text_edit: DuplicateBinding on last binding" {
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      inspect(new_text, content="let x = 0\nlet x_copy = 0\nx")
+      inspect(new_text, content="let x = 0\nlet x1 = 0\nx")
     }
     _ => fail("expected Some edits")
   }
@@ -781,10 +781,79 @@ test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
       let new_text = apply_edits(text, edits)
       inspect(
         new_text,
-        content="fn twice(f : Int -> Int, x : Int) { f x }\nfn twice_copy(f : Int -> Int, x : Int) { f x }\ntwice",
+        content="fn twice(f : Int -> Int, x : Int) { f x }\nfn twice1(f : Int -> Int, x : Int) { f x }\ntwice",
       )
     }
     _ => fail("expected Some edits")
+  }
+}
+
+///|
+test "compute_text_edit: DuplicateBinding produces lexable name and reparses (root)" {
+  let text = "let x = 42\nlet y = 1\nx + y"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let binding_id = proj.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (_, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(root_def_names(new_text), content="x,x1,y")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: DuplicateBinding skips existing numeric suffix (root)" {
+  let text = "let x = 42\nlet x1 = 1\nx + x1"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let binding_id = proj.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (_, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(root_def_names(new_text), content="x,x2,x1")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: DuplicateBinding skips suffix that would capture later free reference (root)" {
+  let text = "let x = 42\nlet y = x1\ny"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let binding_id = proj.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (_, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(root_def_names(new_text), content="x,x2,y")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
   }
 }
 
@@ -1041,12 +1110,8 @@ test "compute_text_edit: MoveBindingUp rejects first block-local binding" {
 
 ///|
 test "compute_text_edit: DuplicateBinding on block-local binding" {
-  // Block-local duplicate is now reachable (no longer "Binding not found"). The
-  // output stays unsound for two reasons, both pre-existing and out of scope
-  // here: the `_copy` name is unlexable (underscore is not an identifier char,
-  // tracked as #649), and the inserted copy is not re-indented to the block.
-  // So this characterizes the current raw edit text and deliberately does NOT
-  // reparse; closing #649 is what makes a positive round-trip assertion possible.
+  // Block-local duplicate is reachable, produces a lexable fresh name, and keeps
+  // the inserted binding aligned with the enclosing block.
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
   let (proj, _) = parse_to_proj_node(text)
   let source_map = SourceMap::from_ast(proj)
@@ -1062,8 +1127,93 @@ test "compute_text_edit: DuplicateBinding on block-local binding" {
       let new_text = apply_edits(text, edits)
       inspect(
         new_text,
-        content="let x = 0\nlet z = { let a = 1\n let a_copy = 1\n  let b = 2\n  a }\nz",
+        content="let x = 0\nlet z = { let a = 1\n  let a1 = 1\n  let b = 2\n  a }\nz",
       )
+      inspect(nested_block_def_names(1, new_text), content="a,a1,b")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: DuplicateBinding on block-local binding produces lexable name and reparses with correct indentation" {
+  let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[1].children[0]
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (_, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(
+        new_text,
+        content="let x = 0\nlet z = { let a = 1\n  let a1 = 1\n  let b = 2\n  a }\nz",
+      )
+      inspect(nested_block_def_names(1, new_text), content="a,a1,b")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: DuplicateBinding skips existing numeric suffix (block-local)" {
+  let text = "let z = { let a = 1\n  let a1 = 2\n  a }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[0].children[0]
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (_, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(
+        new_text,
+        content="let z = { let a = 1\n  let a2 = 1\n  let a1 = 2\n  a }\nz",
+      )
+      inspect(nested_block_def_names(0, new_text), content="a,a2,a1")
+    }
+    _ => fail("expected Some edits, got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: DuplicateBinding skips suffix that would capture later free reference (block-local)" {
+  let text = "let z = { let a = 1\n  let b = a1\n  b }\nz"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let block = proj.children[0].children[0]
+  let binding_id = block.children[0].id()
+  let result = compute_text_edit(
+    DuplicateBinding(binding_node_id=binding_id),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      let (_, _) = parse_to_proj_node(new_text) catch {
+        _ => fail("reparse failed: " + new_text)
+      }
+      inspect(
+        new_text,
+        content="let z = { let a = 1\n  let a2 = 1\n  let b = a1\n  b }\nz",
+      )
+      inspect(nested_block_def_names(0, new_text), content="a,a2,b")
     }
     _ => fail("expected Some edits, got: " + @debug.to_string(result))
   }


### PR DESCRIPTION
## Summary
- Generate DuplicateBinding copy names with lexable numeric suffixes (`x1`, `x2`, …) instead of `_copy`
- Re-indent block-local duplicate insertions so edited text reparses cleanly
- Add reparse-gate wbtests for root and block-local duplicates, plus numeric-suffix collision coverage
- Remove the resolved TODO caveat for #649/#650

Fixes #649.
Addresses the DuplicateBinding portion of #650; move/delete indentation remains tracked by #650.

## Reuse check
- Reused `@scope.enclosing_env` to avoid names visible at the duplicated binding.
- Reused scope declarations and existing binding rewrite helpers (`binding_rewrite_source`, `renamed_text`) to preserve original source syntax.
- Checked `@scope.declaration_for_name_at` / `@scope.scope_for_node`; not used directly for fresh-name generation because duplicate needs a scope-wide collision set, not a single name lookup.

## Validation
```bash
NEW_MOON_MOD=0 moon check lang/lambda/edits lang/lambda/scope
NEW_MOON_MOD=0 moon test lang/lambda/edits lang/lambda/scope
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon check lang/lambda/edits lang/lambda/scope
NEW_MOON_MOD=0 moon test lang/lambda/edits lang/lambda/scope
git diff --check
```

Targeted tests passed: `Total tests: 226, passed: 226, failed: 0`.

Note: `git submodule update --init --recursive` could not clone nested `rabbita/templates/rabbita-template` over SSH in this environment, but the submodules required for the targeted MoonBit validation initialized successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block-local binding duplication to correctly preserve indentation and ensure generated code reparses properly.
  
* **Improvements**
  * Enhanced duplicate binding naming mechanism to automatically generate collision-free identifiers instead of using fixed suffixes, preventing conflicts within the current scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->