### PR TITLE
feat(editor/lambda): Slice 3-4 structural-edit identity hint channel

### DIFF
--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -14,6 +14,7 @@ import {
   "dowdiness/pretty",
   "dowdiness/seam",
   "moonbitlang/core/debug",
+  "moonbitlang/core/ref",
 }
 
 // Values
@@ -88,7 +89,7 @@ pub struct SyncEditor[T] {
   // private fields
 }
 pub fn[T] SyncEditor::apply_ephemeral(Self[T], Bytes) -> Unit
-pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int) -> Unit
+pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int, hint? : @dowdiness/canopy/core.IdentityTransform) -> Unit
 pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise
 pub fn[T : Eq] SyncEditor::apply_text_edit(Self[T], Int, Int, String, Int) -> Unit
 pub fn[T : Eq] SyncEditor::apply_text_edit_exact(Self[T], Int, Int, String, Int) -> Bool
@@ -138,7 +139,7 @@ pub fn[T] SyncEditor::move_cursor_left_word(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_word(Self[T]) -> Unit
 pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], TreeEditError]
-pub fn[T] SyncEditor::new_generic(String, (String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : LanguageCapabilities[T]) -> Self[T]
+pub fn[T] SyncEditor::new_generic(String, (String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : LanguageCapabilities[T], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> Self[T]
 pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId?
 pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T]

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -17,6 +17,13 @@ pub struct SyncEditor[T] {
   priv mut ws : JsWebSocket?
   priv session : @sync_session.SyncSession
   priv mut projection_dirty : Bool
+  // Structural-edit identity hints accumulated since the last reconcile.
+  // Structural edits push their IdentityTransform here; raw-text edits push
+  // Opaque (taint) when non-empty. Consumed and cleared once per reparse by
+  // the reconcile_node closure in build_lambda_projection_memos.
+  // T4: cleared exactly once per reconcile pass (never stale).
+  // T1 invariant: hints reference only prev-tree NodeIds valid at push time.
+  priv pending_transforms : Ref[Array[@core.IdentityTransform]]
   // Process-local construction identity. Two `SyncEditor` instances
   // constructed separately have different identities; the same instance
   // always returns the same value. Used as a cache key in history-view
@@ -40,7 +47,16 @@ pub fn[T] SyncEditor::new_generic(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
   capabilities? : LanguageCapabilities[T] = LanguageCapabilities::default(),
+  // Optional shared Ref for the structural-edit hint channel. The caller
+  // (e.g. new_lambda_editor) creates a `Ref([])`, passes it here AND into
+  // build_memos so the reconcile_node closure can consume+clear it. Callers
+  // that don't use hints omit this; they get an isolated Ref that is never read.
+  identity_hints? : Ref[Array[@core.IdentityTransform]],
 ) -> SyncEditor[T] {
+  let pending_transforms = match identity_hints {
+    Some(r) => r
+    None => Ref([])
+  }
   let parser = make_parser("", parent_runtime)
   let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
@@ -59,6 +75,7 @@ pub fn[T] SyncEditor::new_generic(
     ws: None,
     session: @sync_session.SyncSession::SyncSession(),
     projection_dirty: false,
+    pending_transforms,
     identity: next_editor_identity(),
   }
 }
@@ -342,17 +359,41 @@ pub fn[T] SyncEditor::get_node_range(
 // ── Span-edit application ────────────────────────────────────────────────
 
 ///|
+/// Push `Opaque` to `pending_transforms` iff the array is already non-empty.
+/// Raw-text edit paths call this so that any structural hint accumulated before
+/// the raw edit is invalidated (T2: no silent stale-hint trust).
+/// No-op during normal typing when no structural hint is pending.
+fn[T] SyncEditor::taint_pending_transforms(self : SyncEditor[T]) -> Unit {
+  if !self.pending_transforms.val.is_empty() {
+    self.pending_transforms.val.push(@core.IdentityTransform::Opaque)
+  }
+}
+
+///|
 /// Apply a list of SpanEdits through the text CRDT, then adjust the cursor
 /// per the FocusHint. Edits are applied in reverse document order to avoid
 /// position shifts. All edits are recorded for undo.
+///
+/// `hint` carries the structural-edit identity hint for this batch of span
+/// edits. When provided, it is accumulated in `pending_transforms` for the
+/// next reconcile pass. Callers that do not know the hint omit this
+/// parameter (default: not pushed).
 pub fn[T : Eq] SyncEditor::apply_span_edits(
   self : SyncEditor[T],
   edits : Array[@core.SpanEdit],
   focus_hint : @core.FocusHint,
   timestamp_ms : Int,
+  hint? : @core.IdentityTransform,
 ) -> Unit {
   if edits.is_empty() {
     return
+  }
+  // Push hint only when there are actual text edits (structural op had
+  // text effect). Empty-edit structural ops don't cause a reparse, so
+  // no hint is needed (T4: no pointless accumulation).
+  match hint {
+    Some(h) => self.pending_transforms.val.push(h)
+    None => ()
   }
   let old_cursor = self.get_cursor()
   let sorted = edits.copy()
@@ -388,6 +429,7 @@ pub fn[T : Eq] SyncEditor::apply_sync(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
 ) -> Unit raise {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.undo.set_tracking(false)
   self.doc.sync().apply(msg) catch {

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -388,12 +388,11 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
   if edits.is_empty() {
     return
   }
-  // Push hint only when there are actual text edits (structural op had
-  // text effect). Empty-edit structural ops don't cause a reparse, so
-  // no hint is needed (T4: no pointless accumulation).
-  match hint {
-    Some(h) => self.pending_transforms.val.push(h)
-    None => ()
+  // Snapshot text before applying edits so we can detect net-no-op batches
+  // (e.g. CommitEdit with the same text). Only needed when a hint is provided.
+  let text_before : String? = match hint {
+    Some(_) => Some(self.get_text())
+    None => None
   }
   let old_cursor = self.get_cursor()
   let sorted = edits.copy()
@@ -407,6 +406,18 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
       true, // record_undo — grouped by capture timeout
       false, // move_cursor_to_edit_end
     )
+  }
+  // Push hint only when the batch produced an actual text change (T4).
+  // A no-op batch leaves no pending reparse — sync_parser_after_text_change
+  // returns early when old_source == new_source — so the hint would be stale:
+  // it survives into the next structural op's hint map and causes incorrect
+  // freshening of nodes that were not actually re-parsed.
+  match (hint, text_before) {
+    (Some(h), Some(before)) =>
+      if before != self.get_text() {
+        self.pending_transforms.val.push(h)
+      }
+    _ => ()
   }
   match focus_hint {
     @core.FocusHint::RestoreCursor => self.move_cursor(old_cursor)

--- a/editor/sync_editor_hints_wbtest.mbt
+++ b/editor/sync_editor_hints_wbtest.mbt
@@ -61,6 +61,27 @@ test "apply_span_edits with empty edits does not push hint (T4)" {
 }
 
 ///|
+test "apply_span_edits with net-no-op edits does not push hint (T4)" {
+  // A non-empty span batch that replaces text with itself produces no text
+  // change, so sync_parser_after_text_change returns early without triggering
+  // a reparse. The hint must not be queued — otherwise it becomes stale and
+  // corrupts the next structural op's hint map.
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("x")
+  let replace_id = @core.NodeId::from_int(5)
+  let edits : Array[@core.SpanEdit] = [
+    { start: 0, delete_len: 1, inserted: "x" },
+  ]
+  editor.apply_span_edits(
+    edits,
+    @core.FocusHint::RestoreCursor,
+    0,
+    hint=@core.IdentityTransform::Replace(old=replace_id),
+  )
+  inspect(editor.pending_transforms.val.is_empty(), content="true")
+}
+
+///|
 test "T2: set_text taints if pending_transforms non-empty" {
   let editor = @probe.new_test_editor("test")
   let fake_id = @core.NodeId::from_int(1)

--- a/editor/sync_editor_hints_wbtest.mbt
+++ b/editor/sync_editor_hints_wbtest.mbt
@@ -1,0 +1,159 @@
+// Whitebox tests for the structural-edit identity hint channel.
+//
+// Invariants verified here:
+//   T2: raw-text edits push Opaque taint when pending_transforms is non-empty
+//   T4: hints start empty; each structural op appends one hint
+
+///|
+test "pending_transforms starts empty" {
+  let editor = @probe.new_test_editor("test")
+  inspect(editor.pending_transforms.val.is_empty(), content="true")
+}
+
+///|
+test "apply_span_edits with Wrap hint pushes hint" {
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("a")
+  let inner_id = @core.NodeId::from_int(42)
+  let edits : Array[@core.SpanEdit] = [
+    { start: 0, delete_len: 0, inserted: "x(" },
+    { start: 2, delete_len: 0, inserted: ")" },
+  ]
+  editor.apply_span_edits(
+    edits,
+    @core.FocusHint::RestoreCursor,
+    0,
+    hint=@core.IdentityTransform::Wrap(inner=inner_id),
+  )
+  inspect(editor.pending_transforms.val.length(), content="1")
+  let stored = editor.pending_transforms.val[0]
+  inspect(stored is @core.IdentityTransform::Wrap(inner=_), content="true")
+  match stored {
+    @core.IdentityTransform::Wrap(inner=id) =>
+      inspect(id == inner_id, content="true")
+    _ => fail("expected Wrap")
+  }
+}
+
+///|
+test "apply_span_edits without hint leaves pending_transforms unchanged" {
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("a")
+  let edits : Array[@core.SpanEdit] = [
+    { start: 0, delete_len: 0, inserted: "x" },
+  ]
+  editor.apply_span_edits(edits, @core.FocusHint::RestoreCursor, 0)
+  inspect(editor.pending_transforms.val.is_empty(), content="true")
+}
+
+///|
+test "apply_span_edits with empty edits does not push hint (T4)" {
+  let editor = @probe.new_test_editor("test")
+  let fake_id = @core.NodeId::from_int(7)
+  let edits : Array[@core.SpanEdit] = []
+  editor.apply_span_edits(
+    edits,
+    @core.FocusHint::RestoreCursor,
+    0,
+    hint=@core.IdentityTransform::Wrap(inner=fake_id),
+  )
+  inspect(editor.pending_transforms.val.is_empty(), content="true")
+}
+
+///|
+test "T2: set_text taints if pending_transforms non-empty" {
+  let editor = @probe.new_test_editor("test")
+  let fake_id = @core.NodeId::from_int(1)
+  editor.pending_transforms.val.push(
+    @core.IdentityTransform::Wrap(inner=fake_id),
+  )
+  editor.set_text("hello")
+  inspect(editor.pending_transforms.val.length(), content="2")
+  inspect(
+    editor.pending_transforms.val[1] is @core.IdentityTransform::Opaque,
+    content="true",
+  )
+}
+
+///|
+test "T2: set_text does NOT taint when pending_transforms empty" {
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("hello")
+  inspect(editor.pending_transforms.val.is_empty(), content="true")
+}
+
+///|
+test "T2: insert taints if pending_transforms non-empty" {
+  let editor = @probe.new_test_editor("test")
+  let fake_id = @core.NodeId::from_int(2)
+  editor.pending_transforms.val.push(
+    @core.IdentityTransform::Wrap(inner=fake_id),
+  )
+  editor.insert("x") catch {
+    _ => ()
+  }
+  inspect(editor.pending_transforms.val.length(), content="2")
+  inspect(
+    editor.pending_transforms.val[1] is @core.IdentityTransform::Opaque,
+    content="true",
+  )
+}
+
+///|
+test "multiple structural hints accumulate in order" {
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("ab")
+  let id1 = @core.NodeId::from_int(10)
+  let id2 = @core.NodeId::from_int(20)
+  let id3 = @core.NodeId::from_int(30)
+  let edits1 : Array[@core.SpanEdit] = [
+    { start: 0, delete_len: 0, inserted: "w(" },
+  ]
+  let edits2 : Array[@core.SpanEdit] = [
+    { start: 4, delete_len: 0, inserted: ")" },
+  ]
+  editor.apply_span_edits(
+    edits1,
+    @core.FocusHint::RestoreCursor,
+    0,
+    hint=@core.IdentityTransform::Wrap(inner=id1),
+  )
+  editor.apply_span_edits(
+    edits2,
+    @core.FocusHint::RestoreCursor,
+    0,
+    hint=@core.IdentityTransform::Unwrap(wrapper=id2, keep=id3),
+  )
+  inspect(editor.pending_transforms.val.length(), content="2")
+  inspect(
+    editor.pending_transforms.val[0] is @core.IdentityTransform::Wrap(inner=_),
+    content="true",
+  )
+  inspect(
+    editor.pending_transforms.val[1]
+    is @core.IdentityTransform::Unwrap(wrapper=_, keep=_),
+    content="true",
+  )
+}
+
+///|
+test "move_node taints pending_transforms (Finding 3: Move is not identity-preserving)" {
+  let editor = @probe.new_test_editor("test")
+  editor.set_text("f(x) y")
+  let _ = editor.get_proj_node() // force first parse
+  let fake_id = @core.NodeId::from_int(5)
+  // Simulate a pending Wrap op from a prior structural edit
+  editor.pending_transforms.val.push(
+    @core.IdentityTransform::Wrap(inner=fake_id),
+  )
+  // move_node on unknown ids returns Err, but taint_pending_transforms runs first
+  let bad_src = @core.NodeId::from_int(99998)
+  let bad_tgt = @core.NodeId::from_int(99999)
+  let _ = editor.move_node(bad_src, bad_tgt, @core.DropPosition::Before, 0)
+  // Opaque taint was pushed regardless of move_node result
+  inspect(editor.pending_transforms.val.length(), content="2")
+  inspect(
+    editor.pending_transforms.val[1] is @core.IdentityTransform::Opaque,
+    content="true",
+  )
+}

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -41,6 +41,7 @@ pub fn[T : Eq] SyncEditor::insert(
   self : SyncEditor[T],
   text : String,
 ) -> Unit raise {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.cursor = @moji.prev_grapheme_boundary(old_source, self.cursor)
   let insert_start = self.cursor
@@ -59,6 +60,7 @@ pub fn[T : Eq] SyncEditor::insert(
 
 ///|
 pub fn[T : Eq] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
     self.cursor = @moji.prev_grapheme_boundary(old_source, self.cursor)
@@ -96,6 +98,7 @@ pub fn[T : Eq] SyncEditor::delete(self : SyncEditor[T]) -> Bool {
 
 ///|
 pub fn[T : Eq] SyncEditor::backspace(self : SyncEditor[T]) -> Bool {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
     self.cursor = @moji.next_grapheme_boundary(old_source, self.cursor)
@@ -314,6 +317,7 @@ pub fn[T : Eq] SyncEditor::apply_text_edit(
   inserted : String,
   timestamp_ms : Int,
 ) -> Unit {
+  self.taint_pending_transforms()
   self.apply_text_edit_internal(
     start, deleted_len, inserted, timestamp_ms, true, true,
   )
@@ -327,6 +331,7 @@ pub fn[T : Eq] SyncEditor::apply_text_edit_exact(
   inserted : String,
   timestamp_ms : Int,
 ) -> Bool {
+  self.taint_pending_transforms()
   self.apply_text_edit_with_policy(
     start,
     deleted_len,
@@ -359,6 +364,7 @@ pub fn[T : Eq] SyncEditor::set_text(
   if old_text == new_text {
     return
   }
+  self.taint_pending_transforms()
   let splice = @text_change.compute_text_change(old_text, new_text)
   self.apply_text_edit_internal(
     splice.start,
@@ -383,6 +389,7 @@ pub fn[T : Eq] SyncEditor::insert_at(
   if position < 0 || position > text_len {
     return
   }
+  self.taint_pending_transforms()
   self.apply_text_edit_internal(position, 0, text, timestamp_ms, true, false)
 }
 
@@ -399,6 +406,7 @@ pub fn[T : Eq] SyncEditor::delete_at(
   if position < 0 || position >= text_len {
     return false
   }
+  self.taint_pending_transforms()
   self.apply_text_edit_internal(position, 1, "", timestamp_ms, true, false)
   true
 }
@@ -413,6 +421,7 @@ pub fn[T : Eq] SyncEditor::set_text_and_record(
   if old_text == new_text {
     return
   }
+  self.taint_pending_transforms()
   let splice = @text_change.compute_text_change(old_text, new_text)
   self.apply_text_edit_internal(
     splice.start,

--- a/editor/sync_editor_tree_edit.mbt
+++ b/editor/sync_editor_tree_edit.mbt
@@ -151,6 +151,10 @@ pub fn[T : Eq + @loom_core.Renderable] SyncEditor::move_node(
   position : @core.DropPosition,
   timestamp_ms : Int,
 ) -> Result[Array[@core.SpanEdit], TreeEditError] {
+  // A drag-drop restructures the tree non-locally. Invalidate any pending
+  // structural hints so reconcile degrades to LCS for this reparse.
+  // (Move identity preservation deferred to Slice 5+ match_entities.)
+  self.taint_pending_transforms()
   // Legality: self-drop
   guard source_id != target_id else {
     return Err(TreeEditError::ProjectionEdit(detail="Cannot drop onto self"))

--- a/editor/sync_editor_undo.mbt
+++ b/editor/sync_editor_undo.mbt
@@ -6,6 +6,7 @@ pub fn[T : Eq] SyncEditor::insert_and_record(
   text : String,
   timestamp_ms : Int,
 ) -> Unit raise {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.cursor = @moji.prev_grapheme_boundary(old_source, self.cursor)
   let insert_start = self.cursor
@@ -32,6 +33,7 @@ pub fn[T : Eq] SyncEditor::delete_and_record(
   self : SyncEditor[T],
   timestamp_ms : Int,
 ) -> Bool {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
     self.cursor = @moji.prev_grapheme_boundary(old_source, self.cursor)
@@ -73,6 +75,7 @@ pub fn[T : Eq] SyncEditor::backspace_and_record(
   self : SyncEditor[T],
   timestamp_ms : Int,
 ) -> Bool {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   if !@moji.is_grapheme_boundary(old_source, self.cursor) {
     self.cursor = @moji.next_grapheme_boundary(old_source, self.cursor)
@@ -105,6 +108,7 @@ pub fn[T : Eq] SyncEditor::backspace_and_record(
 
 ///|
 pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   try {
     if !self.undo.undo(self.doc) {
@@ -122,6 +126,7 @@ pub fn[T : Eq] SyncEditor::undo(self : SyncEditor[T]) -> Bool {
 
 ///|
 pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
+  self.taint_pending_transforms()
   let old_source = self.doc.text()
   try {
     if !self.undo.redo(self.doc) {
@@ -143,6 +148,7 @@ pub fn[T : Eq] SyncEditor::redo(self : SyncEditor[T]) -> Bool {
 pub fn[T : Eq] SyncEditor::undo_and_export(
   self : SyncEditor[T],
 ) -> @text.SyncMessage? {
+  self.taint_pending_transforms()
   let ver_before = self.doc.version()
   let old_source = self.doc.text()
   let success = try {
@@ -172,6 +178,7 @@ pub fn[T : Eq] SyncEditor::undo_and_export(
 pub fn[T : Eq] SyncEditor::redo_and_export(
   self : SyncEditor[T],
 ) -> @text.SyncMessage? {
+  self.taint_pending_transforms()
   let ver_before = self.doc.version()
   let old_source = self.doc.text()
   let success = try {

--- a/lang/lambda/companion/editor_hints_integration_wbtest.mbt
+++ b/lang/lambda/companion/editor_hints_integration_wbtest.mbt
@@ -1,0 +1,63 @@
+// Integration test for the structural-edit identity hint channel.
+// Verifies that a WrapInLambda op preserves the wrapped node's NodeId
+// across the subsequent reparse (Level-1 grove foundation).
+
+///|
+/// Return the body expression node from a projection root.
+/// For texts with let defs the structure is Module([def, ...], body) and we
+/// need `children[defs.length()]`. For a bare expression (no let defs) the
+/// projection root IS the expression node directly (no Module wrapper).
+fn body_of_bare_expr(
+  root : @core.ProjNode[@ast.Term],
+) -> @core.ProjNode[@ast.Term]? {
+  match root.kind {
+    @ast.Term::Module(defs, _) => root.children.get(defs.length())
+    _ => Some(root)
+  }
+}
+
+///|
+test "WrapInLambda: inner node NodeId preserved after reconcile with hint" {
+  let (editor, companion) = new_lambda_editor("hint-test")
+  editor.set_text("x")
+
+  // 1. First parse: capture body expression NodeId
+  let old_body_id = match editor.get_proj_node() {
+    None => fail("expected proj node for 'x'")
+    Some(root) =>
+      match body_of_bare_expr(root) {
+        None => fail("expected module body child")
+        Some(body) => body.id()
+      }
+  }
+
+  // 2. Apply WrapInLambda: text becomes something like `(f) => x`
+  let wrap_op = @lambda_edits.TreeEditOp::WrapInLambda(
+    node_id=old_body_id,
+    var_name="f",
+  )
+  match apply_lambda_tree_edit(editor, companion, wrap_op, 1) {
+    Err(_) => fail("WrapInLambda failed")
+    Ok(_) => ()
+  }
+
+  // 3. Reparse: find the Lambda's body child
+  // After WrapInLambda the tree is Module → Lam(Param, body).
+  // Module.children[0] = Lam node (new ID)
+  // Lam.children[last] should be the body (old_body_id preserved).
+  let new_body_id : @core.NodeId? = match editor.get_proj_node() {
+    None => fail("expected proj node after wrap")
+    Some(root) =>
+      match body_of_bare_expr(root) {
+        None => fail("expected module body after wrap")
+        Some(lam) =>
+          // Lambda body is the LAST child of the lambda node.
+          lam.children.last().map(fn(c) { c.id() })
+      }
+  }
+
+  match new_body_id {
+    None => fail("lambda has no children")
+    Some(nid) => inspect(nid == old_body_id, content="true")
+  }
+}

--- a/lang/lambda/companion/editor_hints_integration_wbtest.mbt
+++ b/lang/lambda/companion/editor_hints_integration_wbtest.mbt
@@ -61,3 +61,46 @@ test "WrapInLambda: inner node NodeId preserved after reconcile with hint" {
     Some(nid) => inspect(nid == old_body_id, content="true")
   }
 }
+
+///|
+/// Non-vacuity control: without a structural hint, LCS assigns a fresh NodeId
+/// to the inner node after wrapping, proving the hinted test above exercises
+/// the hint channel and not plain LCS behaviour.
+test "WrapInLambda control: LCS alone does NOT preserve inner NodeId" {
+  let (editor, _companion) = new_lambda_editor("control-test")
+  editor.set_text("x")
+
+  // 1. First parse: capture body expression NodeId
+  let old_body_id = match editor.get_proj_node() {
+    None => fail("expected proj node for 'x'")
+    Some(root) =>
+      match body_of_bare_expr(root) {
+        None => fail("expected body node")
+        Some(body) => body.id()
+      }
+  }
+
+  // 2. Raw text replace bypasses the hint channel — pending_transforms stays
+  //    empty so no Opaque taint, and the reconcile runs with an empty hints
+  //    map (pure LCS). Old root was Var(x), new root is Lam(Param, Var(x));
+  //    they differ in kind so LCS assigns a fresh NodeId to the inner Var(x).
+  editor.set_text("(f) => x")
+
+  // 3. Reparse and navigate to Lam's body child.
+  //    body_of_bare_expr returns the Lam node (bare expression root);
+  //    its last child is the body Var(x).
+  let new_body_id : @core.NodeId? = match editor.get_proj_node() {
+    None => fail("expected proj node after set_text")
+    Some(root) =>
+      match body_of_bare_expr(root) {
+        None => fail("expected lam node")
+        Some(lam) => lam.children.last().map(fn(c) { c.id() })
+      }
+  }
+
+  match new_body_id {
+    None => fail("lambda has no children")
+    // LCS gives a fresh id: NOT equal to old_body_id
+    Some(nid) => inspect(nid == old_body_id, content="false")
+  }
+}

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -141,12 +141,17 @@ pub fn new_lambda_editor(
     None,
   )
   let source_map_memo_ref : Ref[@incr.Derived[@core.SourceMap]?] = Ref(None)
+  // Shared structural-edit hint channel: apply_lambda_tree_edit pushes hints
+  // here via apply_span_edits; the reconcile closure in build_lambda_projection_memos
+  // consumes+clears it once per reparse (T4).
+  let hints_ref : Ref[Array[@core.IdentityTransform]] = Ref([])
   let editor = @editor.SyncEditor::new_generic(
     agent_id,
     fn(s, rt) { @loom.new_parser(s, @parser.lambda_grammar, runtime?=rt) },
     fn(parser) {
       let (cached_proj_node, registry_memo, source_map_memo) = @lambda_proj.build_lambda_projection_memos(
         parser,
+        identity_hints=hints_ref,
       )
       cached_proj_node_ref.val = Some(cached_proj_node)
       source_map_memo_ref.val = Some(source_map_memo)
@@ -164,6 +169,7 @@ pub fn new_lambda_editor(
     capabilities=build_lambda_capabilities(
       cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref,
     ),
+    identity_hints=hints_ref,
   )
   let companion : LambdaCompanion = {
     escalation_memo: escalation_memo_ref.val.unwrap(),
@@ -264,7 +270,12 @@ pub fn apply_lambda_tree_edit(
       if edits.is_empty() {
         return Ok(edits)
       }
-      editor.apply_span_edits(edits, focus_hint, timestamp_ms)
+      editor.apply_span_edits(
+        edits,
+        focus_hint,
+        timestamp_ms,
+        hint=op.to_identity_transform(fn(id) { registry.get(id) }),
+      )
       Ok(edits)
     }
     Ok(None) =>

--- a/lang/lambda/edits/pkg.generated.mbti
+++ b/lang/lambda/edits/pkg.generated.mbti
@@ -81,6 +81,7 @@ pub(all) enum TreeEditOp {
   Rename(node_id~ : @core.NodeId, new_name~ : String)
 } derive(@debug.Debug)
 pub fn TreeEditOp::to_generic(Self) -> @core.GenericTreeOp
+pub fn TreeEditOp::to_identity_transform(Self, (@core.NodeId) -> @core.ProjNode[@ast.Term]?) -> @core.IdentityTransform
 pub impl Show for TreeEditOp
 
 // Type aliases

--- a/lang/lambda/edits/tree_lens.mbt
+++ b/lang/lambda/edits/tree_lens.mbt
@@ -95,6 +95,57 @@ pub fn TreeEditOp::to_generic(self : TreeEditOp) -> @core.GenericTreeOp {
 }
 
 ///|
+/// Map this `TreeEditOp` to an identity hint for the reparse reconciler.
+///
+/// `get_node` lets `Unwrap` look up the k-th child of the wrapper (needed to
+/// name the kept child). Returns `Opaque` whenever the hint cannot be derived
+/// (no node found, out-of-bounds child, ambiguous ops). `Opaque` degrades to
+/// standard LCS reconciliation — never produces wrong identity (T3).
+///
+/// Note: ops that don't call `apply_span_edits` (`Select`, `Drop`, etc.) are
+/// never wired to a hint push, so their return value here is unused.
+pub fn TreeEditOp::to_identity_transform(
+  self : TreeEditOp,
+  get_node : (@core.NodeId) -> @core.ProjNode[@ast.Term]?,
+) -> @core.IdentityTransform {
+  match self {
+    // Wrap ops: prev node becomes a child of a new wrapper
+    WrapInLambda(node_id=n, ..)
+    | WrapInApp(node_id=n)
+    | WrapInIf(node_id=n)
+    | WrapInBop(node_id=n, ..)
+    | ExtractToLet(node_id=n, ..) => @core.IdentityTransform::Wrap(inner=n)
+
+    // Unwrap: wrapper removed, keep the k-th child's id
+    Unwrap(node_id=wrapper_id, keep_child_index=k) =>
+      match get_node(wrapper_id) {
+        Some(wrapper) =>
+          match wrapper.children.get(k) {
+            Some(kept) =>
+              @core.IdentityTransform::Unwrap(
+                wrapper=wrapper_id,
+                keep=kept.id(),
+              )
+            None => @core.IdentityTransform::Opaque
+          }
+        None => @core.IdentityTransform::Opaque
+      }
+
+    // Replacement / retirement ops: old identity retires
+    CommitEdit(node_id=n, ..)
+    | InlineDefinition(node_id=n)
+    | ChangeOperator(node_id=n, ..) => @core.IdentityTransform::Replace(old=n)
+
+    // Rename: only a leaf token changes; spine identity preserved
+    Rename(node_id=n, ..) => @core.IdentityTransform::RenameLeaf(node=n)
+
+    // All other ops: degrade to LCS (includes Delete, module-level mutations,
+    // SwapChildren, InlineAllUsages, AddBinding, DuplicateBinding, etc.)
+    _ => @core.IdentityTransform::Opaque
+  }
+}
+
+///|
 fn[T : Renderable] placeholder_text_for_kind(kind : T) -> String {
   T::placeholder(kind)
 }

--- a/lang/lambda/edits/tree_lens.mbt
+++ b/lang/lambda/edits/tree_lens.mbt
@@ -133,10 +133,13 @@ pub fn TreeEditOp::to_identity_transform(
         None => @core.IdentityTransform::Opaque
       }
 
-    // Replacement / retirement ops: old identity retires
-    CommitEdit(node_id=n, ..)
-    | InlineDefinition(node_id=n)
-    | ChangeOperator(node_id=n, ..) => @core.IdentityTransform::Replace(old=n)
+    // Replacement / retirement ops: old identity retires.
+    // ChangeOperator is excluded: it changes only the operator token while
+    // keeping the same operand subtrees. Replace would call assign_fresh_ids on
+    // the whole Bop subtree, losing both operand NodeIds. LCS (Opaque) matches
+    // same-kind Bop→Bop and recurses into children, preserving operand identity.
+    CommitEdit(node_id=n, ..) | InlineDefinition(node_id=n) =>
+      @core.IdentityTransform::Replace(old=n)
 
     // Rename: leaf token changes, spine identity preserved for intra-expression
     // renames. For module-level binding renames the hint is harmlessly ignored:
@@ -145,7 +148,7 @@ pub fn TreeEditOp::to_identity_transform(
     Rename(node_id=n, ..) => @core.IdentityTransform::RenameLeaf(node=n)
 
     // All other ops: degrade to LCS (includes Delete, ExtractToLet,
-    // module-level mutations, SwapChildren, InlineAllUsages, AddBinding, etc.)
+    // ChangeOperator, module-level mutations, SwapChildren, AddBinding, etc.)
     _ => @core.IdentityTransform::Opaque
   }
 }

--- a/lang/lambda/edits/tree_lens.mbt
+++ b/lang/lambda/edits/tree_lens.mbt
@@ -109,12 +109,14 @@ pub fn TreeEditOp::to_identity_transform(
   get_node : (@core.NodeId) -> @core.ProjNode[@ast.Term]?,
 ) -> @core.IdentityTransform {
   match self {
-    // Wrap ops: prev node becomes a child of a new wrapper
+    // Wrap ops: prev node becomes a child of a new wrapper.
+    // ExtractToLet is excluded: it moves N to a new location (def RHS) and
+    // replaces N's site with a Var reference, which is not a structural Wrap.
+    // Degrading to Opaque (T3) lets LCS handle the resulting topology change.
     WrapInLambda(node_id=n, ..)
     | WrapInApp(node_id=n)
     | WrapInIf(node_id=n)
-    | WrapInBop(node_id=n, ..)
-    | ExtractToLet(node_id=n, ..) => @core.IdentityTransform::Wrap(inner=n)
+    | WrapInBop(node_id=n, ..) => @core.IdentityTransform::Wrap(inner=n)
 
     // Unwrap: wrapper removed, keep the k-th child's id
     Unwrap(node_id=wrapper_id, keep_child_index=k) =>
@@ -136,11 +138,14 @@ pub fn TreeEditOp::to_identity_transform(
     | InlineDefinition(node_id=n)
     | ChangeOperator(node_id=n, ..) => @core.IdentityTransform::Replace(old=n)
 
-    // Rename: only a leaf token changes; spine identity preserved
+    // Rename: leaf token changes, spine identity preserved for intra-expression
+    // renames. For module-level binding renames the hint is harmlessly ignored:
+    // module_key_match keys on the binding NAME and misses a renamed binding,
+    // so assign_fresh_ids runs regardless (LCS fallback, no wrong IDs produced).
     Rename(node_id=n, ..) => @core.IdentityTransform::RenameLeaf(node=n)
 
-    // All other ops: degrade to LCS (includes Delete, module-level mutations,
-    // SwapChildren, InlineAllUsages, AddBinding, DuplicateBinding, etc.)
+    // All other ops: degrade to LCS (includes Delete, ExtractToLet,
+    // module-level mutations, SwapChildren, InlineAllUsages, AddBinding, etc.)
     _ => @core.IdentityTransform::Opaque
   }
 }

--- a/lang/lambda/edits/tree_lens_hints_wbtest.mbt
+++ b/lang/lambda/edits/tree_lens_hints_wbtest.mbt
@@ -35,12 +35,12 @@ test "WrapInIf returns Wrap(inner=node_id)" {
 }
 
 ///|
-test "ExtractToLet returns Wrap(inner=node_id)" {
+test "ExtractToLet returns Opaque (not a structural Wrap; T3 conservative)" {
   let id = @core.NodeId::from_int(9)
   let hint = TreeEditOp::ExtractToLet(node_id=id, var_name="x").to_identity_transform(
     no_node,
   )
-  inspect(hint is @core.IdentityTransform::Wrap(inner=_), content="true")
+  inspect(hint is @core.IdentityTransform::Opaque, content="true")
 }
 
 ///|

--- a/lang/lambda/edits/tree_lens_hints_wbtest.mbt
+++ b/lang/lambda/edits/tree_lens_hints_wbtest.mbt
@@ -1,0 +1,111 @@
+// Whitebox tests for TreeEditOp::to_identity_transform.
+// Uses a stub get_node that returns None (covers the common Opaque/degrade path).
+
+///|
+fn no_node(_ : @core.NodeId) -> @core.ProjNode[@ast.Term]? {
+  None
+}
+
+///|
+test "WrapInLambda returns Wrap(inner=node_id)" {
+  let id = @core.NodeId::from_int(5)
+  let hint = TreeEditOp::WrapInLambda(node_id=id, var_name="x").to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::Wrap(inner=_), content="true")
+  match hint {
+    @core.IdentityTransform::Wrap(inner~) =>
+      inspect(inner == id, content="true")
+    _ => fail("expected Wrap")
+  }
+}
+
+///|
+test "WrapInApp returns Wrap(inner=node_id)" {
+  let id = @core.NodeId::from_int(7)
+  let hint = TreeEditOp::WrapInApp(node_id=id).to_identity_transform(no_node)
+  inspect(hint is @core.IdentityTransform::Wrap(inner=_), content="true")
+}
+
+///|
+test "WrapInIf returns Wrap(inner=node_id)" {
+  let id = @core.NodeId::from_int(8)
+  let hint = TreeEditOp::WrapInIf(node_id=id).to_identity_transform(no_node)
+  inspect(hint is @core.IdentityTransform::Wrap(inner=_), content="true")
+}
+
+///|
+test "ExtractToLet returns Wrap(inner=node_id)" {
+  let id = @core.NodeId::from_int(9)
+  let hint = TreeEditOp::ExtractToLet(node_id=id, var_name="x").to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::Wrap(inner=_), content="true")
+}
+
+///|
+test "Unwrap returns Opaque when get_node returns None (T3: degrade)" {
+  let wrapper_id = @core.NodeId::from_int(10)
+  let hint = TreeEditOp::Unwrap(node_id=wrapper_id, keep_child_index=0).to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::Opaque, content="true")
+}
+
+///|
+test "CommitEdit returns Replace" {
+  let id = @core.NodeId::from_int(11)
+  let hint = TreeEditOp::CommitEdit(node_id=id, new_value="x").to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::Replace(old=_), content="true")
+  match hint {
+    @core.IdentityTransform::Replace(old=old_id) =>
+      inspect(old_id == id, content="true")
+    _ => fail("expected Replace")
+  }
+}
+
+///|
+test "Rename returns RenameLeaf" {
+  let id = @core.NodeId::from_int(12)
+  let hint = TreeEditOp::Rename(node_id=id, new_name="bar").to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::RenameLeaf(node=_), content="true")
+}
+
+///|
+test "InlineDefinition returns Replace" {
+  let id = @core.NodeId::from_int(13)
+  let hint = TreeEditOp::InlineDefinition(node_id=id).to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::Replace(old=_), content="true")
+}
+
+///|
+test "Delete returns Opaque (LCS handles deletion natively)" {
+  let id = @core.NodeId::from_int(14)
+  let hint = TreeEditOp::Delete(node_id=id).to_identity_transform(no_node)
+  inspect(hint is @core.IdentityTransform::Opaque, content="true")
+}
+
+///|
+test "Drop returns Opaque (move_node taints instead)" {
+  let src = @core.NodeId::from_int(15)
+  let tgt = @core.NodeId::from_int(16)
+  let hint = TreeEditOp::Drop(
+    source=src,
+    target=tgt,
+    position=@core.DropPosition::Before,
+  ).to_identity_transform(no_node)
+  inspect(hint is @core.IdentityTransform::Opaque, content="true")
+}
+
+///|
+test "SwapChildren returns Opaque" {
+  let id = @core.NodeId::from_int(17)
+  let hint = TreeEditOp::SwapChildren(node_id=id).to_identity_transform(no_node)
+  inspect(hint is @core.IdentityTransform::Opaque, content="true")
+}

--- a/lang/lambda/edits/tree_lens_hints_wbtest.mbt
+++ b/lang/lambda/edits/tree_lens_hints_wbtest.mbt
@@ -85,6 +85,15 @@ test "InlineDefinition returns Replace" {
 }
 
 ///|
+test "ChangeOperator returns Opaque (Replace would freshen operand NodeIds)" {
+  let id = @core.NodeId::from_int(18)
+  let hint = TreeEditOp::ChangeOperator(node_id=id, new_op=@ast.Bop::Minus).to_identity_transform(
+    no_node,
+  )
+  inspect(hint is @core.IdentityTransform::Opaque, content="true")
+}
+
+///|
 test "Delete returns Opaque (LCS handles deletion natively)" {
   let id = @core.NodeId::from_int(14)
   let hint = TreeEditOp::Delete(node_id=id).to_identity_transform(no_node)

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -22,7 +22,7 @@ pub const LET_DEF_NAME_ROLE : String = "name"
 
 pub const PARAM_ROLE : String = "param"
 
-pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
 
 pub fn module_name_role(Int) -> String
 

--- a/lang/lambda/proj/projection_memo.mbt
+++ b/lang/lambda/proj/projection_memo.mbt
@@ -5,10 +5,107 @@
 // deleted flat projection memo stack.
 
 ///|
+/// Convert a flat ordered list of structural-edit hints to the `NodeId`-keyed
+/// map that `@core.reconcile_hinted` consumes.
+///
+/// Returns an empty map if any hint is `Opaque` (T2: degrade to LCS).
+/// The caller is responsible for clearing the hint array after this call (T4).
+fn build_hints_map(
+  hints : Array[@core.IdentityTransform],
+) -> Map[@core.NodeId, @core.IdentityTransform] {
+  let result : Map[@core.NodeId, @core.IdentityTransform] = {}
+  for hint in hints {
+    match hint {
+      @core.IdentityTransform::Opaque => return {}
+      @core.IdentityTransform::Wrap(inner=id) => result[id] = hint
+      @core.IdentityTransform::Unwrap(wrapper=id, ..) => result[id] = hint
+      @core.IdentityTransform::Move(subtree=id) => result[id] = hint
+      @core.IdentityTransform::Replace(old=id) => result[id] = hint
+      @core.IdentityTransform::RenameLeaf(node=id) => result[id] = hint
+      @core.IdentityTransform::InsertSubtree(parent=id, ..) => result[id] = hint
+      @core.IdentityTransform::DeleteSubtree(node=id) => result[id] = hint
+    }
+  }
+  result
+}
+
+///|
+fn reconcile_module_child_hinted(
+  old_children : Array[@core.ProjNode[@ast.Term]],
+  new_child : @core.ProjNode[@ast.Term],
+  matched_index : Int?,
+  counter : Ref[Int],
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+) -> @core.ProjNode[@ast.Term] {
+  match matched_index {
+    Some(i) =>
+      match old_children.get(i) {
+        Some(old_child) =>
+          @core.reconcile_hinted(old_child, new_child, counter, hints)
+        None => @core.assign_fresh_ids(new_child, counter)
+      }
+    None => @core.assign_fresh_ids(new_child, counter)
+  }
+}
+
+///|
+/// Variant of `reconcile_lambda_projection` that threads structural-edit hints
+/// through to `@core.reconcile_hinted`. The hint map is keyed by prev-tree
+/// `NodeId`; an empty map degrades to the same behaviour as `reconcile_lambda_projection`.
+fn reconcile_lambda_projection_hinted(
+  old : @core.ProjNode[@ast.Term],
+  new_ : @core.ProjNode[@ast.Term],
+  counter : Ref[Int],
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+) -> @core.ProjNode[@ast.Term] {
+  match (old.kind, new_.kind) {
+    (Module(old_defs, _), Module(new_defs, _)) => {
+      guard old.children.get(old_defs.length()) is Some(old_body) else {
+        return @core.reconcile_hinted(old, new_, counter, hints)
+      }
+      guard new_.children.get(new_defs.length()) is Some(new_body) else {
+        return @core.reconcile_hinted(old, new_, counter, hints)
+      }
+      let new_matched = module_key_match(
+        old_defs.map(def => def.0),
+        new_defs.map(def => def.0),
+      )
+      let children : Array[@core.ProjNode[@ast.Term]] = [
+        for j in 0..<new_defs.length() => {
+          reconcile_module_child_hinted(
+            old.children,
+            new_.children[j],
+            new_matched[j],
+            counter,
+            hints,
+          )
+        }
+      ]
+      children.push(@core.reconcile_hinted(old_body, new_body, counter, hints))
+      @core.ProjNode::new(
+        new_.kind,
+        new_.start,
+        new_.end,
+        old.node_id,
+        children,
+      )
+    }
+    _ => @core.reconcile_hinted(old, new_, counter, hints)
+  }
+}
+
+///|
 /// Build the 3-memo pipeline (proj, registry, source_map) for the Lambda
 /// editor-facing projection.
+///
+/// `identity_hints` is the shared `Ref` for the structural-edit hint channel,
+/// typically created by `new_lambda_editor` and passed here and into
+/// `SyncEditor::new_generic` as `identity_hints`. When provided, each reconcile
+/// pass consumes+clears the pending hints (T4). When omitted, behaves identically
+/// to passing no hints (falls back to `reconcile_lambda_projection`).
 pub fn build_lambda_projection_memos(
   parser : @loom.Parser[@ast.Term],
+  identity_hints? : Ref[Array[@core.IdentityTransform]],
 ) -> (
   @incr.Derived[@core.ProjNode[@ast.Term]?],
   @incr.Derived[Map[@core.NodeId, @core.ProjNode[@ast.Term]]],
@@ -19,7 +116,16 @@ pub fn build_lambda_projection_memos(
     parser.syntax_tree(),
     to_proj_node,
     populate_token_spans,
-    reconcile_node=reconcile_lambda_projection,
+    reconcile_node=fn(old, new_, counter) {
+      match identity_hints {
+        None => reconcile_lambda_projection(old, new_, counter)
+        Some(hints_ref) => {
+          let hints = build_hints_map(hints_ref.val)
+          hints_ref.val = [] // T4: cleared exactly once per reparse
+          reconcile_lambda_projection_hinted(old, new_, counter, hints)
+        }
+      }
+    },
     label="lambda",
   )
 }


### PR DESCRIPTION
## Summary

- Adds `pending_transforms : Ref[Array[IdentityTransform]]` field to `SyncEditor[T]` as a side-channel for structural-edit identity hints
- `apply_span_edits` gains optional `hint?` param; structural ops push their hint, raw-text ops taint with `Opaque` when pending is non-empty (T2 invariant)
- `build_lambda_projection_memos` gains optional `identity_hints?` param; the `reconcile_node` closure consumes and clears hints once per reparse (T4 invariant)
- `TreeEditOp::to_identity_transform` maps lambda tree ops to `IdentityTransform` variants; degrades conservatively to `Opaque` when the hint cannot be correctly derived (T3 invariant)
- `lambda_editor.mbt` wires a shared `hints_ref` between `new_generic` and `build_lambda_projection_memos`, and passes `hint=op.to_identity_transform(registry.get)` at the capture point in `apply_lambda_tree_edit`

## Invariants

- **T1**: hints reference only prev-tree NodeIds (valid at push time)
- **T2**: raw-text edits taint with `Opaque` when `pending_transforms` is non-empty → degrades reconcile to plain LCS
- **T3**: `to_identity_transform` returns `Opaque` when hint cannot be correctly derived (conservative safe fallback)
- **T4**: hints cleared exactly once per reparse in `reconcile_node` closure

## Tests

- `editor/sync_editor_hints_wbtest.mbt` — 10 tests verifying T2/T4 invariants at the `SyncEditor` layer
- `lang/lambda/edits/tree_lens_hints_wbtest.mbt` — 11 tests verifying every `to_identity_transform` branch
- `lang/lambda/companion/editor_hints_integration_wbtest.mbt` — 2 tests:
  - **Hinted E2E**: `WrapInLambda` applied to `"x"` → inner node's `NodeId` is preserved after reparse (`content="true"`)
  - **Non-vacuity control**: same text via raw `set_text` → LCS assigns a fresh `NodeId` (`content="false"`), proving the hinted test is causal, not coincidental

## Codex review findings addressed

1. `ExtractToLet` was incorrectly mapped to `Wrap(inner=n)` — extract moves the expression to a def RHS and replaces the original site with a Var reference, which is not a structural Wrap. Fixed to `Opaque` (T3 conservative).
2. `Rename → RenameLeaf` is correct for intra-expression renames; for module-level binding renames it is harmlessly ignored (module_key_match misses the renamed key and `assign_fresh_ids` runs regardless). Annotated in code.
3. `ChangeOperator` was incorrectly mapped to `Replace(old=n)` — Replace calls `assign_fresh_ids` on the whole Bop subtree, losing both operand NodeIds even though only the operator token changed. Fixed to `Opaque`; LCS on same-kind Bop→Bop recurses and preserves operand identity.

## Additional fix: drop hint when span batch makes no text change (T4)

`apply_span_edits` previously queued the hint before applying edits. A non-empty but net-no-op batch (e.g. `CommitEdit` with the same text: `delete_len=3, inserted="foo"` on `"foo"`) left a stale hint in `pending_transforms`. `sync_parser_after_text_change` returns early when `old_source == new_source`, so no reparse consumed the hint. The next structural op's `build_hints_map` then included the stale `Replace` entry, incorrectly freshening the unchanged node's subtree.

Fix: snapshot text before the edit loop; push the hint only when the batch produced an actual text change.

## Known gap

`Unwrap`'s positive path (where `get_node(wrapper).children.get(k)` resolves) is not exercised by the integration test — only the `None → Opaque` degrade path is covered. No `Unwrap` op is applied in the E2E flow.

## Reuse check

- `@core.reconcile_hinted` — existing reconcile with hints map (Level-1 grove foundation, PR #690)
- `@core.build_projection_memos` — existing 3-memo pipeline; `reconcile_node` closure wired with `reconcile_lambda_projection_hinted`
- `@core.IdentityTransform` — existing enum for hint variants
- `@core.NodeId::from_int` — existing constructor used in tests
- No new helpers beyond `build_hints_map` and `reconcile_lambda_projection_hinted` (lambda-specific reconcile variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
