### PR TITLE
test(lambda): E2E integration coverage for Unwrap identity hint path

### DIFF
--- a/lang/lambda/companion/editor_hints_integration_wbtest.mbt
+++ b/lang/lambda/companion/editor_hints_integration_wbtest.mbt
@@ -119,6 +119,7 @@ test "Unwrap: body node NodeId preserved after reconcile with hint" {
   guard body_of_bare_expr(root) is Some(lam) else {
     fail("expected bare-expr root")
   }
+  inspect(lam.kind is @ast.Term::Lam(_, _), content="true")
   guard lam.children.get(0) is Some(body) else { fail("lam has no body child") }
   let lam_id = lam.id()
   let old_body_id = body.id()
@@ -156,6 +157,7 @@ test "Unwrap control: LCS alone does NOT preserve body NodeId" {
     fail("expected proj node for '(f) => x'")
   }
   guard body_of_bare_expr(root) is Some(lam) else { fail("expected lam node") }
+  inspect(lam.kind is @ast.Term::Lam(_, _), content="true")
   guard lam.children.get(0) is Some(body) else { fail("lam has no body child") }
   let old_body_id = body.id()
 

--- a/lang/lambda/companion/editor_hints_integration_wbtest.mbt
+++ b/lang/lambda/companion/editor_hints_integration_wbtest.mbt
@@ -1,5 +1,5 @@
-// Integration test for the structural-edit identity hint channel.
-// Verifies that a WrapInLambda op preserves the wrapped node's NodeId
+// Integration tests for the structural-edit identity hint channel.
+// Verifies that WrapInLambda and Unwrap ops preserve inner NodeIds
 // across the subsequent reparse (Level-1 grove foundation).
 
 ///|
@@ -103,4 +103,74 @@ test "WrapInLambda control: LCS alone does NOT preserve inner NodeId" {
     // LCS gives a fresh id: NOT equal to old_body_id
     Some(nid) => inspect(nid == old_body_id, content="false")
   }
+}
+
+///|
+test "Unwrap: body node NodeId preserved after reconcile with hint" {
+  let (editor, companion) = new_lambda_editor("unwrap-hint-test")
+  editor.set_text("(f) => x")
+
+  // 1. First parse: capture Lam id (wrapper) and body Var id.
+  //    body_of_bare_expr returns the Lam node directly (bare-expression root).
+  //    Lam has exactly one child: the body (keep_child_index=0).
+  guard editor.get_proj_node() is Some(root) else {
+    fail("expected proj node for '(f) => x'")
+  }
+  guard body_of_bare_expr(root) is Some(lam) else {
+    fail("expected bare-expr root")
+  }
+  guard lam.children.get(0) is Some(body) else { fail("lam has no body child") }
+  let lam_id = lam.id()
+  let old_body_id = body.id()
+
+  // 2. Apply Unwrap: text becomes "x"
+  let unwrap_op = @lambda_edits.TreeEditOp::Unwrap(
+    node_id=lam_id,
+    keep_child_index=0,
+  )
+  guard apply_lambda_tree_edit(editor, companion, unwrap_op, 2) is Ok(_) else {
+    fail("Unwrap failed")
+  }
+
+  // 3. Reparse: root is now the Var node (bare expression).
+  //    body_of_bare_expr returns it directly.
+  guard editor.get_proj_node() is Some(root) else {
+    fail("expected proj node after unwrap")
+  }
+  guard body_of_bare_expr(root) is Some(var_node) else {
+    fail("expected var node after unwrap")
+  }
+  inspect(var_node.id() == old_body_id, content="true")
+}
+
+///|
+/// Non-vacuity control: without a structural hint, LCS assigns a fresh NodeId
+/// to the body Var after unwrapping, proving the hinted test above exercises
+/// the hint channel and not plain LCS behaviour.
+test "Unwrap control: LCS alone does NOT preserve body NodeId" {
+  let (editor, _companion) = new_lambda_editor("unwrap-control-test")
+  editor.set_text("(f) => x")
+
+  // 1. Capture body Var NodeId from the initial parse.
+  guard editor.get_proj_node() is Some(root) else {
+    fail("expected proj node for '(f) => x'")
+  }
+  guard body_of_bare_expr(root) is Some(lam) else { fail("expected lam node") }
+  guard lam.children.get(0) is Some(body) else { fail("lam has no body child") }
+  let old_body_id = body.id()
+
+  // 2. Raw text replace bypasses the hint channel — pending_transforms stays
+  //    empty so no hint is pushed. Old root was Lam(f, Var(x)), new root is
+  //    Var(x); they differ in kind so LCS assigns a fresh NodeId to Var(x).
+  editor.set_text("x")
+
+  // 3. Reparse: root is now the Var node.
+  guard editor.get_proj_node() is Some(root) else {
+    fail("expected proj node after set_text")
+  }
+  guard body_of_bare_expr(root) is Some(var_node) else {
+    fail("expected var node")
+  }
+  // LCS gives a fresh id: NOT equal to old_body_id
+  inspect(var_node.id() == old_body_id, content="false")
 }


### PR DESCRIPTION
## Summary

- Adds `"Unwrap: body node NodeId preserved after reconcile with hint"` — the positive path test: applies `Unwrap(keep_child_index=0)` via the hint channel on `"(f) => x"` and verifies the body Var's NodeId survives the reparse
- Adds `"Unwrap control: LCS alone does NOT preserve body NodeId"` — the non-vacuity control: the same starting state but bypassing the hint channel via `set_text`, confirming LCS assigns a fresh id (so the hinted test exercises real channel behaviour, not a vacuous pass)
- Updates the file header to reflect that the file now covers both WrapInLambda and Unwrap ops

The Unwrap degrade path (`None → Opaque`) was already covered in `lang/lambda/edits/tree_lens_hints_wbtest.mbt`; this PR adds the missing happy-path E2E coverage after PR #697 wired the hint channel.

## Reuse check

- `body_of_bare_expr` — existing helper in the same file; no new helper introduced
- `new_lambda_editor` / `apply_lambda_tree_edit` — existing companions; no new imports
- `@lambda_edits.TreeEditOp::Unwrap` — existing op; `keep_child_index=0` confirmed against `text_edit_wbtest.mbt:457` and `proj_node.mbt:213`

## Test plan

- [ ] `NEW_MOON_MOD=0 moon test --target js -p dowdiness/canopy/lang/lambda/companion` → 81/81 passed
- [ ] `NEW_MOON_MOD=0 moon check` → clean
- [ ] `NEW_MOON_MOD=0 moon fmt` → no reformatting needed
- [ ] `.mbti` unchanged (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new integration tests to verify structural-edit identity hint integration for the Unwrap feature, including a control test to confirm expected behavior without the hint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->