### PR TITLE
Move Ideal action overlay into Rabbita child cell

### DIFF
--- a/examples/ideal/main/action_overlay_exec.mbt
+++ b/examples/ideal/main/action_overlay_exec.mbt
@@ -3,15 +3,13 @@
 /// Returns (Cmd, Model) after execution.
 fn execute_action(
   model : Model,
+  runtime : ActionOverlayRuntime,
+  context : NodeActionContext,
   action : @lambda_edits.Action,
   choice : String,
   name : String,
 ) -> (Cmd, Model) {
-  let ctx = match model.overlay.node_context {
-    Some(c) => c
-    None => return (none, model)
-  }
-  match build_tree_edit_op(action.id, ctx, choice, name) {
+  match build_tree_edit_op(action.id, context, choice, name) {
     Ok(Some(op)) =>
       match
         @lambda.apply_lambda_tree_edit(
@@ -27,27 +25,15 @@ fn execute_action(
           let new_model = refresh({
             ..model,
             next_timestamp: model.next_timestamp + 1,
-            overlay: closed_overlay(),
+            overlay_runtime: None,
           })
           let text = new_model.editor.get_text()
           let cmd = sync_after_local_model_change(new_model, text)
           (cmd, new_model)
         }
-        Err(err) => {
-          let overlay = { ..model.overlay, error: err.message() }
-          (none, { ..model, overlay, })
-        }
+        Err(err) => (runtime.send(SetError(err.message())), model)
       }
-    Ok(None) => {
-      let result = model.overlay.show_name_prompt(action)
-      (
-        focus_selector_after_render(".name-prompt-input"),
-        { ..model, overlay: result.state },
-      )
-    }
-    Err(msg) => {
-      let overlay = { ..model.overlay, error: msg }
-      (none, { ..model, overlay, })
-    }
+    Ok(None) => (runtime.send(ShowNamePrompt(action)), model)
+    Err(msg) => (runtime.send(SetError(msg)), model)
   }
 }

--- a/examples/ideal/main/action_overlay_exec.mbt
+++ b/examples/ideal/main/action_overlay_exec.mbt
@@ -25,7 +25,7 @@ fn execute_action(
           let new_model = refresh({
             ..model,
             next_timestamp: model.next_timestamp + 1,
-            overlay_runtime: None,
+            overlay: model.overlay.close(),
           })
           let text = new_model.editor.get_text()
           let cmd = sync_after_local_model_change(new_model, text)

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -1,10 +1,24 @@
 ///|
-pub(all) enum OverlayMsg {
+enum OverlayMsg {
   Menu(@menu.Msg)
   KeyPressed(String)
   NameInput(String)
   NameSubmit
   NameCancel
+  SetError(String)
+  ShowNamePrompt(@lambda_edits.Action)
+}
+
+///|
+enum OverlayOutput {
+  ExecuteAction(
+    token~ : Int,
+    context~ : NodeActionContext,
+    @lambda_edits.Action,
+    choice~ : String,
+    name~ : String
+  )
+  CloseOverlay(token~ : Int)
 }
 
 ///|
@@ -243,5 +257,66 @@ fn OverlayState::update(self : OverlayState, msg : OverlayMsg) -> OverlayUpdate 
     NameInput(value) => self.handle_name_input(value)
     NameSubmit => self.handle_name_submit()
     NameCancel => overlay_update(self, CloseOverlay)
+    SetError(message) =>
+      overlay_update({ ..self, error: message }, NoOverlayEffect)
+    ShowNamePrompt(action) => self.show_name_prompt(action)
   }
+}
+
+///|
+fn overlay_effect_to_cmd(
+  parent_emit : @rabbita.Emit[Msg],
+  token : Int,
+  result : OverlayUpdate,
+) -> Cmd {
+  match result.effect {
+    NoOverlayEffect => none
+    FocusMenu => result.state.menu.focus_cmd()
+    FocusNamePrompt => focus_selector_after_render(".name-prompt-input")
+    ExecuteAction(action, choice~, name~) =>
+      match result.state.node_context {
+        Some(context) =>
+          parent_emit(
+            ActionOverlayEffect(
+              OverlayOutput::ExecuteAction(
+                token~,
+                context~,
+                action,
+                choice~,
+                name~,
+              ),
+            ),
+          )
+        None => none
+      }
+    CloseOverlay =>
+      parent_emit(ActionOverlayEffect(OverlayOutput::CloseOverlay(token~)))
+  }
+}
+
+///|
+fn overlay_cell_update(
+  parent_emit : @rabbita.Emit[Msg],
+  token : Int,
+  _emit : @rabbita.Emit[OverlayMsg],
+  msg : OverlayMsg,
+  state : OverlayState,
+) -> (Cmd, OverlayState) {
+  let result = state.update(msg)
+  (overlay_effect_to_cmd(parent_emit, token, result), result.state)
+}
+
+///|
+fn create_overlay_cell(
+  parent_emit : @rabbita.Emit[Msg],
+  token : Int,
+  initial_state : OverlayState,
+) -> (@rabbita.Emit[OverlayMsg], @rabbita.Cell) {
+  @rabbita.cell_with_emit(
+    model=initial_state,
+    update=fn(emit, msg, state) {
+      overlay_cell_update(parent_emit, token, emit, msg, state)
+    },
+    view=fn(emit, state) { view_overlay(emit, state) },
+  )
 }

--- a/examples/ideal/main/action_overlay_runtime.mbt
+++ b/examples/ideal/main/action_overlay_runtime.mbt
@@ -1,0 +1,22 @@
+///|
+struct ActionOverlayRuntime {
+  cell : @rabbita.Cell
+  emit : @rabbita.Emit[OverlayMsg]
+  // Runtime identity for child-to-parent outputs. The parent drops the child
+  // cell by clearing `overlay_runtime`; queued outputs from an older cell are
+  // ignored when this token no longer matches the current runtime.
+  token : Int
+}
+
+///|
+fn ActionOverlayRuntime::send(
+  self : ActionOverlayRuntime,
+  msg : OverlayMsg,
+) -> Cmd {
+  (self.emit)(msg)
+}
+
+///|
+fn ActionOverlayRuntime::view(self : ActionOverlayRuntime) -> @rabbita.Html {
+  self.cell.view()
+}

--- a/examples/ideal/main/action_overlay_runtime.mbt
+++ b/examples/ideal/main/action_overlay_runtime.mbt
@@ -1,9 +1,33 @@
 ///|
+struct ActionOverlayHost {
+  runtime : ActionOverlayRuntime?
+  next_token : Int
+}
+
+///|
+fn ActionOverlayHost::empty() -> ActionOverlayHost {
+  { runtime: None, next_token: 1 }
+}
+
+///|
+fn ActionOverlayHost::mount(
+  self : ActionOverlayHost,
+  runtime : ActionOverlayRuntime,
+) -> ActionOverlayHost {
+  { runtime: Some(runtime), next_token: self.next_token + 1 }
+}
+
+///|
+fn ActionOverlayHost::close(self : ActionOverlayHost) -> ActionOverlayHost {
+  { ..self, runtime: None }
+}
+
+///|
 struct ActionOverlayRuntime {
   cell : @rabbita.Cell
   emit : @rabbita.Emit[OverlayMsg]
   // Runtime identity for child-to-parent outputs. The parent drops the child
-  // cell by clearing `overlay_runtime`; queued outputs from an older cell are
+  // cell by clearing the host runtime; queued outputs from an older cell are
   // ignored when this token no longer matches the current runtime.
   token : Int
 }

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -9,28 +9,11 @@ fn OverlayState::is_open(self : OverlayState) -> Bool {
 
 ///|
 fn open_action_overlay_from_event(
+  parent_emit : @rabbita.Emit[Msg],
   model : Model,
   node_id_str : String,
 ) -> (Cmd, Model) {
-  let new_model = open_action_overlay(model, node_id_str)
-  if new_model.overlay.is_open() {
-    (new_model.overlay.menu.focus_cmd(), new_model)
-  } else {
-    (none, new_model)
-  }
-}
-
-///|
-fn closed_overlay() -> OverlayState {
-  {
-    mode: Closed,
-    actions: [],
-    node_context: None,
-    error: "",
-    anchor_top: 0,
-    anchor_left: 0,
-    menu: @menu.Model::new(id="ideal-action-overlay-menu", item_count=0),
-  }
+  open_action_overlay(parent_emit, model, node_id_str)
 }
 
 ///|
@@ -93,40 +76,56 @@ fn parse_anchor_rect(json_str : String) -> (Int, Int) {
 ///|
 /// Open the action overlay for the given node ID string.
 fn open_action_overlay(
+  parent_emit : @rabbita.Emit[Msg],
   model : Model,
   node_id_str : String,
   rect_json? : String = js_get_selected_node_rect(),
-) -> Model {
+) -> (Cmd, Model) {
   if node_id_str == "" {
-    return model
+    return (none, model)
   }
   let ctx = match detect_action_context(model.editor, node_id_str) {
     Some(c) => c
-    None => return model
+    None => return (none, model)
   }
   let proj_ctx = to_proj_context(ctx)
   let actions = @lambda_edits.get_actions_for_node(ctx.kind, proj_ctx)
   if actions.is_empty() {
-    return model
+    return (none, model)
   }
   let (anchor_top, anchor_left) = parse_anchor_rect(rect_json)
-  js_set_overlay_open(true)
-  {
-    ..model,
-    overlay: {
-      mode: MainMenu,
-      actions,
-      node_context: Some(ctx),
-      error: "",
-      anchor_top,
-      anchor_left,
-      menu: model.overlay.menu.reset(item_count=actions.length()),
-    },
+  let token = model.next_overlay_token
+  let initial_state = {
+    mode: MainMenu,
+    actions,
+    node_context: Some(ctx),
+    error: "",
+    anchor_top,
+    anchor_left,
+    menu: @menu.Model::new(
+      id="ideal-action-overlay-menu",
+      item_count=actions.length(),
+    ),
   }
+  let (overlay_emit, cell) = create_overlay_cell(
+    parent_emit, token, initial_state,
+  )
+  js_set_overlay_open(true)
+  (
+    initial_state.menu.focus_cmd(),
+    {
+      ..model,
+      overlay_runtime: Some({ cell, emit: overlay_emit, token }),
+      next_overlay_token: token + 1,
+    },
+  )
 }
 
 ///|
+/// Close the overlay and drop its child cell. In Rabbita's explicit lifecycle
+/// model, removing the runtime from the parent model makes the child inactive;
+/// any queued outputs from that child are rejected by token checks.
 fn close_action_overlay(model : Model) -> (Cmd, Model) {
   js_set_overlay_open(false)
-  (none, { ..model, overlay: closed_overlay() })
+  (none, { ..model, overlay_runtime: None })
 }

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -94,7 +94,7 @@ fn open_action_overlay(
     return (none, model)
   }
   let (anchor_top, anchor_left) = parse_anchor_rect(rect_json)
-  let token = model.next_overlay_token
+  let token = model.overlay.next_token
   let initial_state = {
     mode: MainMenu,
     actions,
@@ -115,8 +115,7 @@ fn open_action_overlay(
     initial_state.menu.focus_cmd(),
     {
       ..model,
-      overlay_runtime: Some({ cell, emit: overlay_emit, token }),
-      next_overlay_token: token + 1,
+      overlay: model.overlay.mount({ cell, emit: overlay_emit, token }),
     },
   )
 }
@@ -127,5 +126,5 @@ fn open_action_overlay(
 /// any queued outputs from that child are rejected by token checks.
 fn close_action_overlay(model : Model) -> (Cmd, Model) {
   js_set_overlay_open(false)
-  (none, { ..model, overlay_runtime: None })
+  (none, { ..model, overlay: model.overlay.close() })
 }

--- a/examples/ideal/main/action_overlay_update.mbt
+++ b/examples/ideal/main/action_overlay_update.mbt
@@ -11,7 +11,7 @@ fn handle_overlay_event(
   model : Model,
   overlay_event : OverlayEvent,
 ) -> (Cmd, Model) {
-  match model.overlay_runtime {
+  match model.overlay.runtime {
     Some(runtime) => (runtime.send(overlay_event.to_overlay_msg()), model)
     None => (none, model)
   }
@@ -25,11 +25,11 @@ fn OverlayOutput::token(self : OverlayOutput) -> Int {
 }
 
 ///|
-fn current_overlay_runtime_for_output(
-  runtime : ActionOverlayRuntime?,
+fn ActionOverlayHost::current_runtime_for_output(
+  self : ActionOverlayHost,
   output : OverlayOutput,
 ) -> ActionOverlayRuntime? {
-  match runtime {
+  match self.runtime {
     Some(runtime) =>
       if runtime.token == output.token() {
         Some(runtime)
@@ -47,13 +47,13 @@ fn current_overlay_runtime_for_output(
 fn handle_overlay_output(model : Model, output : OverlayOutput) -> (Cmd, Model) {
   match output {
     ExecuteAction(context~, action, choice~, name~, ..) =>
-      match current_overlay_runtime_for_output(model.overlay_runtime, output) {
+      match model.overlay.current_runtime_for_output(output) {
         Some(runtime) =>
           execute_action(model, runtime, context, action, choice, name)
         None => (none, model)
       }
     CloseOverlay(..) =>
-      match current_overlay_runtime_for_output(model.overlay_runtime, output) {
+      match model.overlay.current_runtime_for_output(output) {
         Some(_) => close_action_overlay(model)
         None => (none, model)
       }

--- a/examples/ideal/main/action_overlay_update.mbt
+++ b/examples/ideal/main/action_overlay_update.mbt
@@ -1,18 +1,61 @@
 ///|
-fn apply_overlay_effect(model : Model, effect : OverlayEffect) -> (Cmd, Model) {
-  match effect {
-    NoOverlayEffect => (none, model)
-    FocusMenu => (model.overlay.menu.focus_cmd(), model)
-    FocusNamePrompt =>
-      (focus_selector_after_render(".name-prompt-input"), model)
-    ExecuteAction(action, choice~, name~) =>
-      execute_action(model, action, choice, name)
-    CloseOverlay => close_action_overlay(model)
+fn OverlayEvent::to_overlay_msg(self : OverlayEvent) -> OverlayMsg {
+  match self {
+    OverlayKeyPressed(key) => KeyPressed(key)
+    OverlayNameCancel => NameCancel
   }
 }
 
 ///|
-fn handle_overlay_msg(model : Model, overlay_msg : OverlayMsg) -> (Cmd, Model) {
-  let result = model.overlay.update(overlay_msg)
-  apply_overlay_effect({ ..model, overlay: result.state }, result.effect)
+fn handle_overlay_event(
+  model : Model,
+  overlay_event : OverlayEvent,
+) -> (Cmd, Model) {
+  match model.overlay_runtime {
+    Some(runtime) => (runtime.send(overlay_event.to_overlay_msg()), model)
+    None => (none, model)
+  }
+}
+
+///|
+fn OverlayOutput::token(self : OverlayOutput) -> Int {
+  match self {
+    ExecuteAction(token~, _, ..) | CloseOverlay(token~) => token
+  }
+}
+
+///|
+fn current_overlay_runtime_for_output(
+  runtime : ActionOverlayRuntime?,
+  output : OverlayOutput,
+) -> ActionOverlayRuntime? {
+  match runtime {
+    Some(runtime) =>
+      if runtime.token == output.token() {
+        Some(runtime)
+      } else {
+        None
+      }
+    None => None
+  }
+}
+
+///|
+/// Apply child-cell outputs only when they come from the currently mounted
+/// overlay runtime. This prevents delayed outputs from a closed/reopened
+/// overlay from executing against the wrong node context.
+fn handle_overlay_output(model : Model, output : OverlayOutput) -> (Cmd, Model) {
+  match output {
+    ExecuteAction(context~, action, choice~, name~, ..) =>
+      match current_overlay_runtime_for_output(model.overlay_runtime, output) {
+        Some(runtime) =>
+          execute_action(model, runtime, context, action, choice, name)
+        None => (none, model)
+      }
+    CloseOverlay(..) =>
+      match current_overlay_runtime_for_output(model.overlay_runtime, output) {
+        Some(_) => close_action_overlay(model)
+        None => (none, model)
+      }
+  }
 }

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -50,7 +50,8 @@ fn init_model() -> Model raise {
     next_timestamp: 1,
     bottom_tab: Problems,
     sync_status: Connecting,
-    overlay: closed_overlay(),
+    overlay_runtime: None,
+    next_overlay_token: 1,
     scope_map: build_scope_map(editor, companion),
     highlight_set: @immut/hashset.new(),
     drag_source: None,
@@ -449,7 +450,7 @@ fn apply_structural_edit_request(
 }
 
 ///|
-fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
+fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
   match msg {
     SetMode(mode) => {
       let mode_str : String = match mode {
@@ -669,12 +670,7 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
         None => return (none, model)
       }
       let rect_json = js_get_outline_selected_rect()
-      let new_model = open_action_overlay(model, node_id_str, rect_json~)
-      if new_model.overlay.is_open() {
-        (new_model.overlay.menu.focus_cmd(), new_model)
-      } else {
-        (none, new_model)
-      }
+      open_action_overlay(emit, model, node_id_str, rect_json~)
     }
     SyncStatusChanged(status) => {
       let sync_status : SyncStatus = match status {
@@ -688,8 +684,9 @@ fn update(_dispatch : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
     }
     OpenActionOverlayForNode(node_id_str)
     | LongPressTriggeredForNode(node_id_str) =>
-      open_action_overlay_from_event(model, node_id_str)
-    ActionOverlay(overlay_msg) => handle_overlay_msg(model, overlay_msg)
+      open_action_overlay_from_event(emit, model, node_id_str)
+    ActionOverlay(overlay_event) => handle_overlay_event(model, overlay_event)
+    ActionOverlayEffect(output) => handle_overlay_output(model, output)
     // ── Outline drag-and-drop ──────
     OutlineDragStart(node_id) => (none, { ..model, drag_source: Some(node_id) })
     OutlineDragOver(target_id, position) =>
@@ -921,7 +918,10 @@ fn view(dispatch : Emit[Msg], model : Model) -> Html {
       ]),
     ]),
     div(class=bottom_class, [view_bottom_content(dispatch, model)]),
-    view_action_overlay(dispatch, model),
+    match model.overlay_runtime {
+      Some(runtime) => runtime.view()
+      None => @html.nothing
+    },
   ])
 }
 

--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -50,8 +50,7 @@ fn init_model() -> Model raise {
     next_timestamp: 1,
     bottom_tab: Problems,
     sync_status: Connecting,
-    overlay_runtime: None,
-    next_overlay_token: 1,
+    overlay: ActionOverlayHost::empty(),
     scope_map: build_scope_map(editor, companion),
     highlight_set: @immut/hashset.new(),
     drag_source: None,
@@ -918,7 +917,7 @@ fn view(dispatch : Emit[Msg], model : Model) -> Html {
       ]),
     ]),
     div(class=bottom_class, [view_bottom_content(dispatch, model)]),
-    match model.overlay_runtime {
+    match model.overlay.runtime {
       Some(runtime) => runtime.view()
       None => @html.nothing
     },

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -162,6 +162,7 @@ test "overlay update name cancel closes overlay" {
 ///|
 test "overlay outputs only match their originating runtime token" {
   let runtime = test_overlay_runtime(7)
+  let host = ActionOverlayHost::empty().mount(runtime)
   let action = test_action_by_id("delete")
   let matching = OverlayOutput::ExecuteAction(
     token=7,
@@ -177,12 +178,21 @@ test "overlay outputs only match their originating runtime token" {
     choice="",
     name="",
   )
+  inspect(host.current_runtime_for_output(matching) is Some(_), content="true")
+  inspect(host.current_runtime_for_output(stale) is None, content="true")
+}
+
+///|
+test "overlay close outputs only match their originating runtime token" {
+  let host = ActionOverlayHost::empty().mount(test_overlay_runtime(7))
   inspect(
-    current_overlay_runtime_for_output(Some(runtime), matching) is Some(_),
+    host.current_runtime_for_output(OverlayOutput::CloseOverlay(token=7))
+    is Some(_),
     content="true",
   )
   inspect(
-    current_overlay_runtime_for_output(Some(runtime), stale) is None,
+    host.current_runtime_for_output(OverlayOutput::CloseOverlay(token=8))
+    is None,
     content="true",
   )
 }

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -1,6 +1,193 @@
 // Whitebox tests for update helpers.
 
 ///|
+fn test_actions() -> Array[@lambda_edits.Action] {
+  @lambda_edits.get_actions_for_node(
+    @ast.Term::Unit,
+    @lambda_edits.NodeContext::new(),
+  )
+}
+
+///|
+fn test_action_by_id(id : String) -> @lambda_edits.Action {
+  test_actions().iter().find_first(fn(action) { action.id == id }).unwrap()
+}
+
+///|
+fn test_overlay_context() -> NodeActionContext {
+  {
+    node_id: @canopy_core.NodeId::from_int(1),
+    kind: @ast.Term::Unit,
+    is_let_binding: false,
+    binding_node_id: None,
+    binding_def_index: None,
+    module_node_id: None,
+  }
+}
+
+///|
+fn test_overlay_state(mode : OverlayMode) -> OverlayState {
+  let actions = test_actions()
+  {
+    mode,
+    actions,
+    node_context: Some(test_overlay_context()),
+    error: "",
+    anchor_top: 0,
+    anchor_left: 0,
+    menu: @menu.Model::new(
+      id="ideal-action-overlay-menu-test",
+      item_count=actions.length(),
+    ),
+  }
+}
+
+///|
+fn test_parent_emit() -> @rabbita.Emit[Msg] {
+  let (emit, _) : (@rabbita.Emit[Msg], @rabbita.Cell) = @rabbita.simple_cell_with_emit(
+    model=0,
+    update=fn(_ : Msg, count) { count },
+    view=fn(_, _) { @html.nothing },
+  )
+  emit
+}
+
+///|
+fn test_overlay_runtime(token : Int) -> ActionOverlayRuntime {
+  let state = test_overlay_state(MainMenu)
+  let (emit, cell) = create_overlay_cell(test_parent_emit(), token, state)
+  { cell, emit, token }
+}
+
+///|
+test "overlay update dispatches main menu mnemonic action" {
+  let delete_action = test_action_by_id("delete")
+  let result = test_overlay_state(MainMenu).update(KeyPressed("d"))
+  match result.effect {
+    ExecuteAction(action, choice~, name~) => {
+      inspect(action.id, content="delete")
+      inspect(choice, content="")
+      inspect(name, content="")
+    }
+    _ => inspect("unexpected", content="ExecuteAction")
+  }
+  match result.state.mode {
+    MainMenu => inspect("main", content="main")
+    _ => inspect("unexpected", content="MainMenu")
+  }
+  inspect(delete_action.id, content="delete")
+}
+
+///|
+test "overlay update dispatches valid submenu numbered choice" {
+  let wrap_bop_action = test_action_by_id("wrap_bop")
+  let result = test_overlay_state(Submenu(wrap_bop_action)).update(
+    Menu(@menu.Activate(0)),
+  )
+  match result.effect {
+    ExecuteAction(action, choice~, name~) => {
+      inspect(action.id, content="wrap_bop")
+      inspect(choice, content="Plus")
+      inspect(name, content="")
+    }
+    _ => inspect("unexpected", content="ExecuteAction")
+  }
+}
+
+///|
+test "overlay update recovers invalid submenu key to focused main menu" {
+  let wrap_bop_action = test_action_by_id("wrap_bop")
+  let result = test_overlay_state(Submenu(wrap_bop_action)).update(
+    KeyPressed("z"),
+  )
+  match result.state.mode {
+    MainMenu => inspect("main", content="main")
+    _ => inspect("unexpected", content="MainMenu")
+  }
+  match result.effect {
+    FocusMenu => inspect("focus", content="focus")
+    _ => inspect("unexpected", content="FocusMenu")
+  }
+  inspect(result.state.error, content="")
+}
+
+///|
+test "overlay public key event preserves submenu invalid-key recovery" {
+  let wrap_bop_action = test_action_by_id("wrap_bop")
+  let result = test_overlay_state(Submenu(wrap_bop_action)).update(
+    OverlayKeyPressed("z").to_overlay_msg(),
+  )
+  match result.state.mode {
+    MainMenu => inspect("main", content="main")
+    _ => inspect("unexpected", content="MainMenu")
+  }
+  match result.effect {
+    FocusMenu => inspect("focus", content="focus")
+    _ => inspect("unexpected", content="FocusMenu")
+  }
+}
+
+///|
+test "overlay update keeps empty name submit in prompt with error" {
+  let wrap_lambda_action = test_action_by_id("wrap_lambda")
+  let state = test_overlay_state(NamePrompt(wrap_lambda_action, value="stale"))
+  let input_result = state.update(NameInput(""))
+  let result = input_result.state.update(NameSubmit)
+  match result.effect {
+    NoOverlayEffect => inspect("none", content="none")
+    _ => inspect("unexpected", content="NoOverlayEffect")
+  }
+  match result.state.mode {
+    NamePrompt(action, value~) => {
+      inspect(action.id, content="wrap_lambda")
+      inspect(value, content="")
+    }
+    _ => inspect("unexpected", content="NamePrompt")
+  }
+  inspect(result.state.error, content="Enter a name to continue")
+}
+
+///|
+test "overlay update name cancel closes overlay" {
+  let wrap_lambda_action = test_action_by_id("wrap_lambda")
+  let result = test_overlay_state(NamePrompt(wrap_lambda_action, value="x")).update(
+    NameCancel,
+  )
+  match result.effect {
+    CloseOverlay => inspect("close", content="close")
+    _ => inspect("unexpected", content="CloseOverlay")
+  }
+}
+
+///|
+test "overlay outputs only match their originating runtime token" {
+  let runtime = test_overlay_runtime(7)
+  let action = test_action_by_id("delete")
+  let matching = OverlayOutput::ExecuteAction(
+    token=7,
+    context=test_overlay_context(),
+    action,
+    choice="",
+    name="",
+  )
+  let stale = OverlayOutput::ExecuteAction(
+    token=8,
+    context=test_overlay_context(),
+    action,
+    choice="",
+    name="",
+  )
+  inspect(
+    current_overlay_runtime_for_output(Some(runtime), matching) is Some(_),
+    content="true",
+  )
+  inspect(
+    current_overlay_runtime_for_output(Some(runtime), stale) is None,
+    content="true",
+  )
+}
+
+///|
 test "parse_node_id valid" {
   inspect(parse_node_id("42") is Some(_), content="true")
 }

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -103,8 +103,7 @@ pub struct Model {
   next_timestamp : Int
   bottom_tab : BottomTab
   sync_status : SyncStatus
-  overlay_runtime : ActionOverlayRuntime?
-  next_overlay_token : Int
+  overlay : ActionOverlayHost
   scope_map : Map[@canopy_core.NodeId, ScopeAnnotation]
   highlight_set : @immut/hashset.HashSet[@canopy_core.NodeId]
   // Outline drag-and-drop state

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -53,6 +53,7 @@ pub enum SyncStatus {
 /// implicit `(visible, submenu, pending_action)` encoding so that illegal
 /// combinations — a closed overlay with a pending action, or a submenu and a
 /// name prompt active at once — are unrepresentable.
+#warnings("-unused_constructor")
 enum OverlayMode {
   Closed
   MainMenu
@@ -102,7 +103,8 @@ pub struct Model {
   next_timestamp : Int
   bottom_tab : BottomTab
   sync_status : SyncStatus
-  overlay : OverlayState
+  overlay_runtime : ActionOverlayRuntime?
+  next_overlay_token : Int
   scope_map : Map[@canopy_core.NodeId, ScopeAnnotation]
   highlight_set : @immut/hashset.HashSet[@canopy_core.NodeId]
   // Outline drag-and-drop state

--- a/examples/ideal/main/msg.mbt
+++ b/examples/ideal/main/msg.mbt
@@ -1,6 +1,13 @@
 ///|
 #warnings("-unused_constructor")
-pub enum Msg {
+enum OverlayEvent {
+  OverlayKeyPressed(String)
+  OverlayNameCancel
+}
+
+///|
+#warnings("-unused_constructor-unused_field")
+enum Msg {
   // Mode & layout
   SetMode(EditorMode)
   TogglePanel(PanelId)
@@ -33,7 +40,12 @@ pub enum Msg {
   SyncStatusChanged(String)
   // Action overlay
   OpenActionOverlayForNode(String)
-  ActionOverlay(OverlayMsg)
+  ActionOverlay(OverlayEvent)
+  // Internal bridge from the mounted overlay child cell back into the parent
+  // update loop. This stays package-private with the app's Rabbita message
+  // type; every output carries a runtime token so stale child-cell commands are
+  // ignored.
+  ActionOverlayEffect(OverlayOutput)
   LongPressTriggeredForNode(String)
   // Outline drag-and-drop
   OutlineDragStart(@canopy_core.NodeId)

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -5,14 +5,11 @@ import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/companion",
-  "dowdiness/canopy/lang/lambda/edits",
   "dowdiness/canopy/lib/js",
   "dowdiness/canopy/projection",
   "dowdiness/event-graph-walker/history",
   "dowdiness/lambda/ast",
-  "dowdiness/rabbita-menu/menu",
   "dowdiness/rabbita-resizable/resizable",
-  "dowdiness/rabbita_codemirror",
   "dowdiness/visualizer",
   "moonbitlang/core/immut/hashset",
 }
@@ -91,6 +88,8 @@ pub fn undo_manager_undo(Int) -> Bool
 // Errors
 
 // Types and methods
+type ActionOverlayRuntime
+
 pub enum BottomTab {
   Problems
   OpLog
@@ -132,7 +131,8 @@ pub struct Model {
   next_timestamp : Int
   bottom_tab : BottomTab
   sync_status : SyncStatus
-  overlay : OverlayState
+  overlay_runtime : ActionOverlayRuntime?
+  next_overlay_token : Int
   scope_map : Map[@core.NodeId, ScopeAnnotation]
   highlight_set : @hashset.HashSet[@core.NodeId]
   drag_source : @core.NodeId?
@@ -143,55 +143,19 @@ pub struct Model {
   incr_tap : @visualizer.RecomputeTap
 }
 
-pub enum Msg {
-  SetMode(EditorMode)
-  TogglePanel(PanelId)
-  OutlineResize(@resizable.Msg)
-  SelectBottomTab(BottomTab)
-  StructuralEditRequested(op~ : String, node_id~ : String)
-  Undo
-  Redo
-  OpenFile
-  SaveFile
-  FileLoaded(String)
-  TreeEdited(@edits.TreeEditOp)
-  DismissPanels
-  LoadExample(String)
-  OutlineNodeClicked(String)
-  OutlineNavigate(String)
-  OutlineStructuralEdit(@edits.TreeEditOp)
-  OpenActionOverlayFromOutline
-  SyncStatusChanged(String)
-  OpenActionOverlayForNode(String)
-  ActionOverlay(OverlayMsg)
-  LongPressTriggeredForNode(String)
-  OutlineDragStart(@core.NodeId)
-  OutlineDragOver(@core.NodeId, @core.DropPosition)
-  OutlineDragLeave
-  OutlineDrop(@core.NodeId, @core.DropPosition)
-  OutlineDragEnd
-  StructureNodeSelected(String)
-  StructureStructuralEdit(op~ : String, node_id~ : String)
-  ExternalCrdtChanged
-  CmMounted
-  CmDocChanged(String)
-  CmSelectionChanged(@rabbita_codemirror.SelRange)
-  CmFocusChanged(Bool)
-}
+type Msg
 
 type NodeActionContext
 
 type OverlayEffect
 
+type OverlayEvent
+
 type OverlayMode
 
-pub(all) enum OverlayMsg {
-  Menu(@menu.Msg)
-  KeyPressed(String)
-  NameInput(String)
-  NameSubmit
-  NameCancel
-}
+type OverlayMsg
+
+type OverlayOutput
 
 type OverlayState
 

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -88,6 +88,8 @@ pub fn undo_manager_undo(Int) -> Bool
 // Errors
 
 // Types and methods
+type ActionOverlayHost
+
 type ActionOverlayRuntime
 
 pub enum BottomTab {
@@ -131,8 +133,7 @@ pub struct Model {
   next_timestamp : Int
   bottom_tab : BottomTab
   sync_status : SyncStatus
-  overlay_runtime : ActionOverlayRuntime?
-  next_overlay_token : Int
+  overlay : ActionOverlayHost
   scope_map : Map[@core.NodeId, ScopeAnnotation]
   highlight_set : @hashset.HashSet[@core.NodeId]
   drag_source : @core.NodeId?

--- a/examples/ideal/main/rabbita_dom_sub.mbt
+++ b/examples/ideal/main/rabbita_dom_sub.mbt
@@ -151,7 +151,7 @@ fn editor_dom_event_subscriptions(emit : @rabbita.Emit[Msg]) -> @sub.Sub {
     custom_event_sub(
       EditorHost,
       ActionKey,
-      emit.map(key => ActionOverlay(KeyPressed(key))),
+      emit.map(key => ActionOverlay(OverlayKeyPressed(key))),
     ),
     custom_event_sub(
       EditorHost,

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -12,7 +12,7 @@ fn group_label(group : @lambda_edits.ActionGroup) -> String {
 ///|
 /// Render a single action row with mnemonic badge and label.
 fn view_action_item(
-  dispatch : @rabbita.Emit[Msg],
+  emit : @rabbita.Emit[OverlayMsg],
   menu : @menu.Model,
   index : Int,
   action : @lambda_edits.Action,
@@ -25,7 +25,7 @@ fn view_action_item(
   }
   @html.div(
     class=item_class,
-    attrs=menu.item_attrs(index, msg => dispatch(ActionOverlay(Menu(msg)))),
+    attrs=menu.item_attrs(index, msg => emit(Menu(msg))),
     [
       @html.span(class=action_mnemonic_class, [@html.text(action.mnemonic)]),
       @html.span(class=action_label_text_class, [@html.text(action.label)]),
@@ -36,7 +36,7 @@ fn view_action_item(
 ///|
 /// Render the main action list grouped by Core / Wrap / Binding / Module.
 fn view_action_list(
-  dispatch : @rabbita.Emit[Msg],
+  emit : @rabbita.Emit[OverlayMsg],
   menu : @menu.Model,
   actions : Array[@lambda_edits.Action],
 ) -> @rabbita.Html {
@@ -60,7 +60,7 @@ fn view_action_list(
         )
       }
     }
-    items.push(view_action_item(dispatch, menu, index, action))
+    items.push(view_action_item(emit, menu, index, action))
   }
   @html.div(class=action_overlay_list_class, items)
 }
@@ -79,19 +79,19 @@ fn name_prompt_label(action : @lambda_edits.Action) -> String {
 ///|
 /// Render the name prompt input.
 fn view_name_prompt(
-  dispatch : @rabbita.Emit[Msg],
-  model : Model,
+  emit : @rabbita.Emit[OverlayMsg],
+  state : OverlayState,
 ) -> @rabbita.Html {
-  let (prompt_label, name_value) = match model.overlay.mode {
+  let (prompt_label, name_value) = match state.mode {
     NamePrompt(action, value~) => (name_prompt_label(action), value)
     _ => ("Enter name", "")
   }
   let on_keydown_handler = fn(kb : @html.Keyboard) {
     let key = kb.key()
     if key == "Enter" {
-      dispatch(ActionOverlay(NameSubmit))
+      emit(NameSubmit)
     } else if key == "Escape" {
-      dispatch(ActionOverlay(NameCancel))
+      emit(NameCancel)
     } else {
       @rabbita.none
     }
@@ -108,7 +108,7 @@ fn view_name_prompt(
           placeholder="name\u{2026}",
           value=name_value,
           autofocus=true,
-          on_input=fn(value) { dispatch(ActionOverlay(NameInput(value))) },
+          on_input=fn(value) { emit(NameInput(value)) },
           attrs=@html.Attrs::build().aria_label(prompt_label),
         ),
       ],
@@ -119,7 +119,7 @@ fn view_name_prompt(
 ///|
 /// Render submenu choices (e.g., Plus/Minus for change_op, left/right for unwrap).
 fn view_submenu_choices(
-  dispatch : @rabbita.Emit[Msg],
+  emit : @rabbita.Emit[OverlayMsg],
   menu : @menu.Model,
   action : @lambda_edits.Action,
   kind : @ast.Term,
@@ -138,7 +138,7 @@ fn view_submenu_choices(
     items.push(
       @html.div(
         class=action_overlay_item_class,
-        attrs=menu.item_attrs(i, msg => dispatch(ActionOverlay(Menu(msg)))),
+        attrs=menu.item_attrs(i, msg => emit(Menu(msg))),
         [
           @html.span(class=action_mnemonic_class, [
             @html.text((i + 1).to_string()),
@@ -169,44 +169,37 @@ fn view_action_overlay_error(message : String) -> @rabbita.Html {
 ///|
 /// Render the action overlay: scrim + positioned panel.
 /// Returns nothing if the overlay is not visible.
-fn view_action_overlay(
-  dispatch : @rabbita.Emit[Msg],
-  model : Model,
+fn view_overlay(
+  emit : @rabbita.Emit[OverlayMsg],
+  state : OverlayState,
 ) -> @rabbita.Html {
-  if !model.overlay.is_open() {
+  if !state.is_open() {
     return @html.nothing
   }
   // Position the overlay panel using inline style from the anchor rect
-  let top = model.overlay.anchor_top
-  let left = model.overlay.anchor_left
+  let top = state.anchor_top
+  let left = state.anchor_left
   let position_style = "top: \{top}px; left: \{left}px;"
   // Determine content: name prompt, submenu, or main action list
-  let content : @rabbita.Html = match model.overlay.mode {
-    NamePrompt(_, ..) => view_name_prompt(dispatch, model)
+  let content : @rabbita.Html = match state.mode {
+    NamePrompt(_, ..) => view_name_prompt(emit, state)
     Submenu(sub_action) =>
-      match model.overlay.node_context {
+      match state.node_context {
         Some(ctx) =>
-          view_submenu_choices(
-            dispatch,
-            model.overlay.menu,
-            sub_action,
-            ctx.kind,
-          )
-        None =>
-          view_action_list(dispatch, model.overlay.menu, model.overlay.actions)
+          view_submenu_choices(emit, state.menu, sub_action, ctx.kind)
+        None => view_action_list(emit, state.menu, state.actions)
       }
-    MainMenu | Closed =>
-      view_action_list(dispatch, model.overlay.menu, model.overlay.actions)
+    MainMenu | Closed => view_action_list(emit, state.menu, state.actions)
   }
-  let panel_attrs = match model.overlay.mode {
+  let panel_attrs = match state.mode {
     NamePrompt(_, ..) =>
       @html.Attrs::build()
       .role("dialog")
       .aria_label("Structural editing name prompt")
       .style_attr(position_style)
     _ =>
-      model.overlay.menu
-      .panel_attrs(msg => dispatch(ActionOverlay(Menu(msg))))
+      state.menu
+      .panel_attrs(msg => emit(Menu(msg)))
       .aria_label("Structural editing actions")
       .style_attr(position_style)
   }
@@ -214,12 +207,12 @@ fn view_action_overlay(
     // Scrim: click-catching backdrop
     @html.div(
       class=action_overlay_scrim_class,
-      attrs=@menu.scrim_attrs(dispatch(ActionOverlay(NameCancel))),
+      attrs=@menu.scrim_attrs(emit(NameCancel)),
       @html.nothing,
     ),
     // Overlay panel — roving focus moves to the active menu item after render.
     @html.div(class=action_overlay_panel_class, attrs=panel_attrs, [
-      view_action_overlay_error(model.overlay.error),
+      view_action_overlay_error(state.error),
       content,
     ]),
   ])

--- a/examples/ideal/main/view_outline.mbt
+++ b/examples/ideal/main/view_outline.mbt
@@ -367,7 +367,7 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
               None => @rabbita.none
             }
           "Escape" =>
-            match model.overlay_runtime {
+            match model.overlay.runtime {
               Some(_) => dispatch(ActionOverlay(OverlayNameCancel))
               None => dispatch(OutlineNavigate(""))
             }

--- a/examples/ideal/main/view_outline.mbt
+++ b/examples/ideal/main/view_outline.mbt
@@ -367,10 +367,9 @@ fn view_outline_tree(dispatch : Emit[Msg], model : Model) -> Html {
               None => @rabbita.none
             }
           "Escape" =>
-            if model.overlay.is_open() {
-              dispatch(ActionOverlay(NameCancel))
-            } else {
-              dispatch(OutlineNavigate(""))
+            match model.overlay_runtime {
+              Some(_) => dispatch(ActionOverlay(OverlayNameCancel))
+              None => dispatch(OutlineNavigate(""))
             }
           _ => @rabbita.none
         }

--- a/examples/ideal/web/e2e/structural-editing.spec.ts
+++ b/examples/ideal/web/e2e/structural-editing.spec.ts
@@ -141,6 +141,25 @@ test.describe('Structural Editing - Overlay on Var nodes', () => {
     ).toBeVisible();
   });
 
+  test('overlay menu exposes roles and active item state', async ({ page }) => {
+    await openVarActionOverlay(page);
+
+    const overlay = page.locator('.action-overlay-panel');
+    await expect(overlay).toHaveAttribute('role', 'menu');
+    await expect(overlay).toHaveAttribute('aria-label', 'Structural editing actions');
+    await expect(page.locator('.action-overlay-scrim')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+
+    const items = overlay.locator('.action-overlay-item');
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+    await expect(items.first()).toHaveAttribute('role', 'menuitem');
+    await expect(items.first()).toHaveAttribute('data-active', 'true');
+    await expect(overlay.locator('.action-overlay-item[data-active="true"]')).toHaveCount(1);
+  });
+
   test('Tailwind-owned overlay styles are applied', async ({ page }) => {
     await openVarActionOverlay(page);
 


### PR DESCRIPTION
## Summary

- move the Ideal action overlay into an explicit Rabbita child-cell runtime
- keep the parent responsible for overlay lifecycle and editor/domain effects, while the child owns overlay-local update/view state
- narrow parent-routed overlay inputs to `OverlayEvent` and keep child `OverlayMsg`/`OverlayOutput` opaque
- add runtime tokens plus context-bearing outputs so stale child-cell commands from closed/reopened overlays are ignored
- add whitebox coverage for overlay update behavior, public key-event recovery, and output token matching

## Reuse check

- Reused existing `OverlayState::update` as the pure headless state machine instead of replacing transition logic.
- Reused existing `@menu.Model` APIs (`new`, `reset`, `keydown_msg`, `panel_attrs`, `item_attrs`, `focus_cmd`) for menu state, ARIA attrs, and focus behavior.
- Reused Rabbita `cell_with_emit` and `Cell::view` for the child-cell runtime rather than inventing a custom lifecycle.
- Checked direct parent-owned overlay routing from PR #686 and preserved the `Msg::ActionOverlay(...)` route as a narrowed public event bridge.
- Added only the small `ActionOverlayRuntime` wrapper needed to hold the opaque child cell, its emitter, and stale-output token.

## Validation

```bash
cd examples/ideal
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon test ./main --release
NEW_MOON_MOD=0 moon test --release
```

Results:

- targeted main tests: `41 passed`
- full Ideal release tests: JS `1508 passed`, native `70 passed`

## Review

- Ran ensemble review on the initial child-cell extraction.
- Addressed the warnings by hiding `Msg`/overlay output internals from the generated interface and adding token/context checks for stale child-cell outputs.


## Follow-up after ensemble review

- Replaced the public `Model.overlay_runtime` / `Model.next_overlay_token` fields with opaque `Model.overlay : ActionOverlayHost`.
- Added stale-token coverage for `CloseOverlay` outputs.
- Added Playwright coverage for overlay menu roles, active item state, and scrim `aria-hidden`.

Additional validation after follow-up:

```bash
cd examples/ideal
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test ./main --release
NEW_MOON_MOD=0 moon test --release
```

Results: targeted main tests `42 passed`; full Ideal release tests JS `1509 passed`, native `70 passed`.
