### PR TITLE
Wire ast-grep decorations into lambda editor

### DIFF
--- a/analysis/render.mbt
+++ b/analysis/render.mbt
@@ -19,6 +19,29 @@ pub fn facts_to_match_list(
 }
 
 ///|
+fn css_class_segment(input : String) -> String {
+  let segment = StringView::from_iter(
+    input
+    .iter()
+    .map(fn(ch) {
+      if ch.is_ascii_alphabetic() ||
+        ch.is_ascii_digit() ||
+        ch == '-' ||
+        ch == '_' {
+        ch
+      } else {
+        '-'
+      }
+    }),
+  ).to_owned()
+  if segment == "" {
+    "unknown"
+  } else {
+    segment
+  }
+}
+
+///|
 pub fn facts_to_decorations(
   facts : Array[@facts.PatternMatchFact],
   snapshot : @facts.SourceSnapshot,
@@ -30,7 +53,7 @@ pub fn facts_to_decorations(
     @protocol.Decoration::Decoration(
       from=f.from,
       to=f.to,
-      css_class="analysis-match pattern-" + f.pattern_id,
+      css_class="analysis-match pattern-" + css_class_segment(f.pattern_id),
       data=f.pattern_id,
     )
   })

--- a/examples/ideal/export-manifest.json
+++ b/examples/ideal/export-manifest.json
@@ -68,6 +68,7 @@
     "ws_set_status_callback",
     "get_view_tree_json",
     "compute_view_patches_json",
+    "apply_ast_grep_results_json",
     "handle_text_intent",
     "handle_text_intent_checked",
     "handle_undo",

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -79,12 +79,37 @@
     }
 
     #editor {
+      position: relative;
+      z-index: 1;
       min-height: 200px;
       outline: none;
       font-size: 16px;
       line-height: 1.5;
       white-space: pre-wrap;
       word-wrap: break-word;
+    }
+
+    .decoration-overlay {
+      position: absolute;
+      pointer-events: none;
+      z-index: 0;
+      overflow: hidden;
+    }
+
+    .decoration-mark {
+      position: absolute;
+      pointer-events: none;
+      border-radius: 2px;
+    }
+
+    .analysis-match {
+      background: rgba(78, 201, 176, 0.15);
+      border-bottom: 1px dashed rgba(78, 201, 176, 0.45);
+    }
+
+    .pattern-moonbit-fn-def {
+      background: rgba(130, 170, 255, 0.14);
+      border-bottom-color: rgba(130, 170, 255, 0.55);
     }
 
     #editor:empty:before {

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -12,6 +12,7 @@
         "ws": "^8.21.0"
       },
       "devDependencies": {
+        "@ast-grep/cli": "^0.43.0",
         "@playwright/test": "^1.60.0",
         "@types/ws": "^8.5.12",
         "playwright": "^1.57.0",
@@ -67,6 +68,158 @@
         "prosemirror-view": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.43.0.tgz",
+      "integrity": "sha512-DGi6xXAOBJubGg9QWqTeW8PzKSGHWEOa3uxXspEfYf532yb3lHmNJAcKMl1d+O9Xs9bTcNeDLC8se+O+tirEFQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.43.0",
+        "@ast-grep/cli-darwin-x64": "0.43.0",
+        "@ast-grep/cli-linux-arm64-gnu": "0.43.0",
+        "@ast-grep/cli-linux-x64-gnu": "0.43.0",
+        "@ast-grep/cli-win32-arm64-msvc": "0.43.0",
+        "@ast-grep/cli-win32-ia32-msvc": "0.43.0",
+        "@ast-grep/cli-win32-x64-msvc": "0.43.0"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.43.0.tgz",
+      "integrity": "sha512-0i63gSBbgriPaRpFsbP3yETxolHPK2JAZbpcGbFOytB7QTnKAguwhlKmIOkUGKfsCzYiEq1awY0EBmvjMONXOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.43.0.tgz",
+      "integrity": "sha512-SPkj00HGKpYdqReUmso2ftG5Xgd+bWNFH4i9fubLxsWzn4ey2G6sotPruaOtcrzxb9xH+8kmhN7KJfm1k8Atzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.43.0.tgz",
+      "integrity": "sha512-U8+2fkcY8sBxNHHBYZ33vTa7C97GFAB+Kj6gFzVMSqK8Ve1Aw+DxhVWD4i/PBryDdmWb4/erjGSkTQtdhVa2vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.43.0.tgz",
+      "integrity": "sha512-r/o9Mag6OZmGevY9OJjatuUKDOX1rSvgo29qSfxpMbIciiH3hkzEW/2w1xTPZI8xnM7iC+k+CkGoknmoXVTYGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.43.0.tgz",
+      "integrity": "sha512-oHa4ruD87xccnqFuR+Pmx6F/suHV0YtibuyZ6SxUqgpNJAFZiUNAiFblzhEgQ5gp03e8B012P/Yy/7GYOvxOLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.43.0.tgz",
+      "integrity": "sha512-RSzz9bKzSEutWgX7/g84guudEp75Q990CYpG/TBasdJP+U27zX8aA9d5p1+o/lF0hw3UoTYuFCGG8PU/QelfNQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.43.0.tgz",
+      "integrity": "sha512-/5dDD9B65vVuHCdVHN5+tIDquhE5s43S5CgEn88w1BgQaoayf+nRnUO4ZFez6SqyCGqAfa/yZdoaOQ9N2ySa1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@canopy/editor-adapter": {

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -14,6 +14,7 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.43.0",
     "@playwright/test": "^1.60.0",
     "@types/ws": "^8.5.12",
     "playwright": "^1.57.0",

--- a/examples/web/src/ast-grep-runner.ts
+++ b/examples/web/src/ast-grep-runner.ts
@@ -1,0 +1,37 @@
+export type AstGrepMatch = {
+  byte_start: number;
+  byte_end: number;
+  pattern_id: string;
+};
+
+type AstGrepApiResponse = {
+  matches?: AstGrepMatch[];
+  error?: string;
+};
+
+export async function runAnalysis(
+  text: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<AstGrepMatch[]> {
+  if (text.trim() === '') return [];
+
+  const importMeta = import.meta as ImportMeta & { env?: { DEV?: boolean } };
+  if (!importMeta.env?.DEV) return [];
+
+  const response = await fetch('/api/ast-grep', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text }),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`ast-grep request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = (await response.json()) as AstGrepApiResponse;
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+  return payload.matches ?? [];
+}

--- a/examples/web/src/decoration-overlay.ts
+++ b/examples/web/src/decoration-overlay.ts
@@ -1,0 +1,114 @@
+import type { Decoration } from '@canopy/editor-adapter/types';
+
+export class DecorationOverlay {
+  private readonly overlay: HTMLDivElement;
+  private decorations: Decoration[] = [];
+  private resizeObserver: ResizeObserver;
+  private frame: number | null = null;
+
+  constructor(private readonly editorEl: HTMLElement) {
+    const host = editorEl.parentElement ?? editorEl;
+    const hostStyle = window.getComputedStyle(host);
+    if (hostStyle.position === 'static') {
+      host.style.position = 'relative';
+    }
+
+    this.overlay = document.createElement('div');
+    this.overlay.className = 'decoration-overlay';
+    this.overlay.setAttribute('aria-hidden', 'true');
+    host.appendChild(this.overlay);
+
+    this.resizeObserver = new ResizeObserver(() => this.scheduleRender());
+    this.resizeObserver.observe(editorEl);
+    window.addEventListener('scroll', this.handleScroll, true);
+  }
+
+  applyDecorations(decorations: Decoration[]) {
+    this.decorations = decorations.filter(deco => deco.to > deco.from && !deco.widget);
+    this.scheduleRender();
+  }
+
+  dispose() {
+    if (this.frame !== null) cancelAnimationFrame(this.frame);
+    this.resizeObserver.disconnect();
+    window.removeEventListener('scroll', this.handleScroll, true);
+    this.overlay.remove();
+  }
+
+  private readonly handleScroll = () => this.scheduleRender();
+
+  private scheduleRender() {
+    if (this.frame !== null) return;
+    this.frame = requestAnimationFrame(() => {
+      this.frame = null;
+      this.render();
+    });
+  }
+
+  private render() {
+    this.overlay.replaceChildren();
+    const host = this.overlay.parentElement;
+    if (!host) return;
+
+    const hostRect = host.getBoundingClientRect();
+    const editorRect = this.editorEl.getBoundingClientRect();
+    Object.assign(this.overlay.style, {
+      left: `${editorRect.left - hostRect.left + host.scrollLeft}px`,
+      top: `${editorRect.top - hostRect.top + host.scrollTop}px`,
+      width: `${editorRect.width}px`,
+      height: `${editorRect.height}px`,
+    });
+
+    for (const decoration of this.decorations) {
+      const range = this.rangeForOffsets(decoration.from, decoration.to);
+      if (!range) continue;
+      const rects = Array.from(range.getClientRects());
+      range.detach();
+
+      for (const rect of rects) {
+        if (rect.width <= 0 || rect.height <= 0) continue;
+        const mark = document.createElement('div');
+        mark.className = `decoration-mark ${decoration.css_class}`;
+        mark.dataset.patternId = decoration.data ?? '';
+        Object.assign(mark.style, {
+          left: `${rect.left - editorRect.left + this.editorEl.scrollLeft}px`,
+          top: `${rect.top - editorRect.top + this.editorEl.scrollTop}px`,
+          width: `${rect.width}px`,
+          height: `${rect.height}px`,
+        });
+        this.overlay.appendChild(mark);
+      }
+    }
+  }
+
+  private rangeForOffsets(from: number, to: number): Range | null {
+    const start = this.findTextPosition(from);
+    const end = this.findTextPosition(to);
+    if (!start || !end) return null;
+
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+    return range;
+  }
+
+  private findTextPosition(offset: number): { node: Text; offset: number } | null {
+    const walker = document.createTreeWalker(this.editorEl, NodeFilter.SHOW_TEXT);
+    let remaining = offset;
+    let lastText: Text | null = null;
+
+    for (let node = walker.nextNode() as Text | null; node; node = walker.nextNode() as Text | null) {
+      lastText = node;
+      const length = node.data.length;
+      if (remaining <= length) {
+        return { node, offset: remaining };
+      }
+      remaining -= length;
+    }
+
+    if (lastText && remaining === 0) {
+      return { node: lastText, offset: lastText.data.length };
+    }
+    return null;
+  }
+}

--- a/examples/web/src/editor.ts
+++ b/examples/web/src/editor.ts
@@ -3,7 +3,9 @@
 import * as crdt from '@moonbit/crdt-lambda';
 import * as graphviz from '@moonbit/graphviz';
 import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
-import type { ViewPatch } from '@canopy/editor-adapter/types';
+import type { Decoration, ViewPatch } from '@canopy/editor-adapter/types';
+import { runAnalysis } from './ast-grep-runner';
+import { DecorationOverlay } from './decoration-overlay';
 
 export function createEditor(agentId: string) {
   const handle = crdt.create_editor(agentId);
@@ -15,15 +17,25 @@ export function createEditor(agentId: string) {
 
   // Protocol-based pretty-print adapter
   const prettyAdapter = new HTMLAdapter(astOutputEl);
+  const decorationOverlay = new DecorationOverlay(editorEl);
+  const analysisApi = crdt as typeof crdt & {
+    apply_ast_grep_results_json(handle: number, matchesJson: string): string;
+    compute_view_patches_json(handle: number): string;
+  };
 
   let lastText = '';
   let scheduled = false;
+  let analysisGeneration = 0;
+  let analysisTimer: number | null = null;
+  let analysisAbortController: AbortController | null = null;
 
   function updateUI() {
     const text = editorEl.textContent || '';
     if (text !== lastText) {
       crdt.set_text(handle, text);
       lastText = text;
+      decorationOverlay.applyDecorations([]);
+      scheduleAnalysis(text);
     }
 
     // AST visualization (DOT → SVG via graphviz module)
@@ -66,6 +78,50 @@ export function createEditor(agentId: string) {
           return `<li class="diag-item diag-${d.level}">${badge}${escapeHTML(d.message)}</li>`;
         })
         .join('');
+    }
+  }
+
+  function scheduleAnalysis(text: string) {
+    const generation = ++analysisGeneration;
+    if (analysisTimer !== null) {
+      window.clearTimeout(analysisTimer);
+    }
+    if (analysisAbortController !== null) {
+      analysisAbortController.abort();
+      analysisAbortController = null;
+    }
+    analysisTimer = window.setTimeout(() => {
+      analysisTimer = null;
+      void applyAnalysis(text, generation);
+    }, 150);
+  }
+
+  async function applyAnalysis(text: string, generation: number) {
+    const controller = new AbortController();
+    analysisAbortController = controller;
+    try {
+      const matches = await runAnalysis(text, { signal: controller.signal });
+      if (generation !== analysisGeneration) return;
+
+      const result = analysisApi.apply_ast_grep_results_json(handle, JSON.stringify(matches));
+      if (result !== 'ok') {
+        console.warn(`ast-grep analysis rejected: ${result}`);
+        return;
+      }
+
+      const patches: ViewPatch[] = JSON.parse(analysisApi.compute_view_patches_json(handle));
+      const decorations = patches.flatMap((patch): Decoration[] =>
+        patch.type === 'SetDecorations' ? patch.decorations : [],
+      );
+      decorationOverlay.applyDecorations(decorations);
+    } catch (error) {
+      if (controller.signal.aborted || generation !== analysisGeneration) return;
+      console.warn('ast-grep analysis failed', error);
+      decorationOverlay.applyDecorations([]);
+    } finally {
+      if (analysisAbortController === controller) {
+        analysisAbortController = null;
+      }
     }
   }
 

--- a/examples/web/src/editor.ts
+++ b/examples/web/src/editor.ts
@@ -34,7 +34,7 @@ export function createEditor(agentId: string) {
     if (text !== lastText) {
       crdt.set_text(handle, text);
       lastText = text;
-      decorationOverlay.applyDecorations([]);
+      applyDecorationPatches(JSON.parse(analysisApi.compute_view_patches_json(handle)));
       scheduleAnalysis(text);
     }
 
@@ -110,10 +110,7 @@ export function createEditor(agentId: string) {
       }
 
       const patches: ViewPatch[] = JSON.parse(analysisApi.compute_view_patches_json(handle));
-      const decorations = patches.flatMap((patch): Decoration[] =>
-        patch.type === 'SetDecorations' ? patch.decorations : [],
-      );
-      decorationOverlay.applyDecorations(decorations);
+      applyDecorationPatches(patches);
     } catch (error) {
       if (controller.signal.aborted || generation !== analysisGeneration) return;
       console.warn('ast-grep analysis failed', error);
@@ -122,6 +119,18 @@ export function createEditor(agentId: string) {
       if (analysisAbortController === controller) {
         analysisAbortController = null;
       }
+    }
+  }
+
+  function applyDecorationPatches(patches: ViewPatch[]) {
+    let decorations: Decoration[] | null = null;
+    for (const patch of patches) {
+      if (patch.type === 'SetDecorations') {
+        decorations = patch.decorations;
+      }
+    }
+    if (decorations !== null) {
+      decorationOverlay.applyDecorations(decorations);
     }
   }
 

--- a/examples/web/src/editor.ts
+++ b/examples/web/src/editor.ts
@@ -114,7 +114,6 @@ export function createEditor(agentId: string) {
     } catch (error) {
       if (controller.signal.aborted || generation !== analysisGeneration) return;
       console.warn('ast-grep analysis failed', error);
-      decorationOverlay.applyDecorations([]);
     } finally {
       if (analysisAbortController === controller) {
         analysisAbortController = null;

--- a/examples/web/vite-plugin-moonbit.ts
+++ b/examples/web/vite-plugin-moonbit.ts
@@ -1,6 +1,7 @@
 import { exec, spawn, type ChildProcess } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile, access } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
 
@@ -306,41 +307,49 @@ async function runAstGrep(text: string): Promise<Array<{ byte_start: number; byt
 
   const repoRoot = path.resolve(process.cwd(), '../..');
   const astGrepBin = process.env.AST_GREP_BIN ?? path.resolve(process.cwd(), 'node_modules/.bin/sg');
-  const { stdout, stderr, code } = await runProcess(
-    astGrepBin,
-    [
-      'scan',
-      '-c', 'sgconfig.yml',
-      '--rule', 'rules/moonbit-fn-def.yml',
-      '--stdin',
-      '--json=stream',
-    ],
-    text,
-    repoRoot,
-    5_000,
-  );
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'canopy-ast-grep-'));
+  const tempFile = path.join(tempDir, 'input.mbt');
 
-  if (code !== 0) {
-    throw new Error(stderr || `ast-grep exited with code ${code}`);
+  try {
+    await writeFile(tempFile, text, 'utf8');
+    const { stdout, stderr, code } = await runProcess(
+      astGrepBin,
+      [
+        'scan',
+        '-c', 'sgconfig.yml',
+        '--filter', '^moonbit-fn-def$',
+        tempFile,
+        '--json=stream',
+      ],
+      '',
+      repoRoot,
+      5_000,
+    );
+
+    if (code !== 0) {
+      throw new Error(stderr || `ast-grep exited with code ${code}`);
+    }
+
+    return stdout
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => JSON.parse(line) as AstGrepJsonMatch)
+      .map(match => {
+        const start = match.range?.byteOffset?.start;
+        const end = match.range?.byteOffset?.end;
+        if (typeof start !== 'number' || typeof end !== 'number') {
+          throw new Error('ast-grep result missing byte offsets');
+        }
+        return {
+          byte_start: start,
+          byte_end: end,
+          pattern_id: match.ruleId ?? 'moonbit-fn-def',
+        };
+      });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
   }
-
-  return stdout
-    .split('\n')
-    .map(line => line.trim())
-    .filter(Boolean)
-    .map(line => JSON.parse(line) as AstGrepJsonMatch)
-    .map(match => {
-      const start = match.range?.byteOffset?.start;
-      const end = match.range?.byteOffset?.end;
-      if (typeof start !== 'number' || typeof end !== 'number') {
-        throw new Error('ast-grep result missing byte offsets');
-      }
-      return {
-        byte_start: start,
-        byte_end: end,
-        pattern_id: match.ruleId ?? 'moonbit-fn-def',
-      };
-    });
 }
 
 function runProcess(

--- a/examples/web/vite-plugin-moonbit.ts
+++ b/examples/web/vite-plugin-moonbit.ts
@@ -305,8 +305,9 @@ async function runAstGrep(text: string): Promise<Array<{ byte_start: number; byt
   if (text.trim() === '') return [];
 
   const repoRoot = path.resolve(process.cwd(), '../..');
+  const astGrepBin = process.env.AST_GREP_BIN ?? path.resolve(process.cwd(), 'node_modules/.bin/sg');
   const { stdout, stderr, code } = await runProcess(
-    'sg',
+    astGrepBin,
     [
       'scan',
       '-c', 'sgconfig.yml',

--- a/examples/web/vite-plugin-moonbit.ts
+++ b/examples/web/vite-plugin-moonbit.ts
@@ -129,6 +129,28 @@ export function moonbitPlugin(options: MoonBitPluginOptions): Plugin {
     },
 
     configureServer(server: ViteDevServer) {
+      server.middlewares.use('/api/ast-grep', async (req, res) => {
+        if (req.method !== 'POST') {
+          res.statusCode = 405;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ error: 'method not allowed' }));
+          return;
+        }
+
+        try {
+          const body = JSON.parse(await readRequestBody(req, 1_000_000)) as { text?: unknown };
+          const text = typeof body.text === 'string' ? body.text : '';
+          const matches = await runAstGrep(text);
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ matches }));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          res.statusCode = message.includes('request body too large') ? 413 : 500;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ error: message }));
+        }
+      });
+
       if (watch) {
         // Start MoonBit watch mode for each module
         console.log('[MoonBit] Starting watch mode...');
@@ -257,6 +279,110 @@ async function buildAllModules(
 /**
  * Build a single MoonBit module
  */
+type AstGrepJsonMatch = {
+  ruleId?: string;
+  range?: { byteOffset?: { start?: number; end?: number } };
+};
+
+async function readRequestBody(
+  req: import('node:http').IncomingMessage,
+  maxBytes: number,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    totalBytes += buffer.byteLength;
+    if (totalBytes > maxBytes) {
+      throw new Error('request body too large for ast-grep analysis');
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function runAstGrep(text: string): Promise<Array<{ byte_start: number; byte_end: number; pattern_id: string }>> {
+  if (text.trim() === '') return [];
+
+  const repoRoot = path.resolve(process.cwd(), '../..');
+  const { stdout, stderr, code } = await runProcess(
+    'sg',
+    [
+      'scan',
+      '-c', 'sgconfig.yml',
+      '--rule', 'rules/moonbit-fn-def.yml',
+      '--stdin',
+      '--json=stream',
+    ],
+    text,
+    repoRoot,
+    5_000,
+  );
+
+  if (code !== 0) {
+    throw new Error(stderr || `ast-grep exited with code ${code}`);
+  }
+
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as AstGrepJsonMatch)
+    .map(match => {
+      const start = match.range?.byteOffset?.start;
+      const end = match.range?.byteOffset?.end;
+      if (typeof start !== 'number' || typeof end !== 'number') {
+        throw new Error('ast-grep result missing byte offsets');
+      }
+      return {
+        byte_start: start,
+        byte_end: end,
+        pattern_id: match.ruleId ?? 'moonbit-fn-def',
+      };
+    });
+}
+
+function runProcess(
+  command: string,
+  args: string[],
+  input: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    child.stdout?.on('data', data => { stdout += data.toString(); });
+    child.stderr?.on('data', data => { stderr += data.toString(); });
+    child.on('error', error => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('close', code => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        stdout,
+        stderr: timedOut ? `ast-grep timed out after ${timeoutMs}ms` : stderr,
+        code,
+      });
+    });
+    child.stdin?.end(input);
+  });
+}
+
 async function buildModule(
   mod: MoonBitModule & { absolutePath: string },
   target: string,

--- a/ffi/lambda/analysis.mbt
+++ b/ffi/lambda/analysis.mbt
@@ -1,0 +1,103 @@
+// Lambda editor analysis FFI — host ast-grep results -> MoonBit analysis facts.
+
+///|
+fn json_int_field(m : Map[String, Json], key : String) -> Result[Int, String] {
+  match m.get(key) {
+    Some(Json::Number(n, ..)) => {
+      let i = n.to_int()
+      if i.to_double() == n {
+        Ok(i)
+      } else {
+        Err("field '" + key + "' must be an integer")
+      }
+    }
+    Some(_) => Err("field '" + key + "' must be a number")
+    None => Err("missing field '" + key + "'")
+  }
+}
+
+///|
+fn json_string_field(
+  m : Map[String, Json],
+  key : String,
+) -> Result[String, String] {
+  match m.get(key) {
+    Some(Json::String(s)) => Ok(s)
+    Some(_) => Err("field '" + key + "' must be a string")
+    None => Err("missing field '" + key + "'")
+  }
+}
+
+///|
+fn parse_ast_grep_match(json : Json) -> Result[@analysis.AstGrepMatch, String] {
+  let m = match json {
+    Json::Object(m) => m
+    _ => return Err("match entry must be an object")
+  }
+  let byte_start = match json_int_field(m, "byte_start") {
+    Ok(v) => v
+    Err(e) => return Err(e)
+  }
+  let byte_end = match json_int_field(m, "byte_end") {
+    Ok(v) => v
+    Err(e) => return Err(e)
+  }
+  let pattern_id = match json_string_field(m, "pattern_id") {
+    Ok(v) => v
+    Err(e) => return Err(e)
+  }
+  Ok(@analysis.AstGrepMatch::AstGrepMatch(byte_start~, byte_end~, pattern_id~))
+}
+
+///|
+fn parse_ast_grep_matches(
+  json : Json,
+) -> Result[Array[@analysis.AstGrepMatch], String] {
+  let entries = match json {
+    Json::Array(entries) => entries
+    _ => return Err("expected an array of ast-grep matches")
+  }
+  let matches : Array[@analysis.AstGrepMatch] = []
+  for entry in entries {
+    match parse_ast_grep_match(entry) {
+      Ok(m) => matches.push(m)
+      Err(e) => return Err(e)
+    }
+  }
+  Ok(matches)
+}
+
+///|
+/// Apply JSON-encoded ast-grep results for a lambda editor handle.
+///
+/// The JSON shape is:
+/// `[ { "byte_start": number, "byte_end": number, "pattern_id": string }, ... ]`.
+/// Byte offsets are converted to UTF-16 positions only inside
+/// `@analysis.from_ast_grep_matches`, which is the provider adapter boundary.
+pub fn apply_ast_grep_results_json(
+  handle : Int,
+  matches_json : String,
+) -> String {
+  let h = match lambda_registry.get(handle) {
+    Some(h) => h
+    None => return "error: invalid handle"
+  }
+  let json = @json.parse(matches_json) catch {
+    err => return "parse error: " + err.to_string()
+  }
+  let matches = match parse_ast_grep_matches(json) {
+    Ok(matches) => matches
+    Err(e) => return "parse error: " + e
+  }
+  let source = h.editor.get_text()
+  let snapshot = @facts.SourceSnapshot::SourceSnapshot(
+    doc_id=h.editor_id.0.to_string(),
+    version=0,
+    source~,
+  )
+  h.companion.set_pattern_analysis(
+    @analysis.from_ast_grep_matches(matches, source, snapshot),
+    snapshot,
+  )
+  "ok"
+}

--- a/ffi/lambda/analysis_wbtest.mbt
+++ b/ffi/lambda/analysis_wbtest.mbt
@@ -1,0 +1,44 @@
+///|
+test "compute_view_patches clears stale ast-grep decorations" {
+  let handle = create_editor("analysis-stale-decorations")
+  set_text(handle, "x")
+  let result = apply_ast_grep_results_json(
+    handle, "[{\"byte_start\":0,\"byte_end\":1,\"pattern_id\":\"fn-def\"}]",
+  )
+  inspect(result, content="ok")
+  let initial_patches = compute_view_patches_json(handle)
+  assert_true(initial_patches.contains("analysis-match pattern-fn-def"))
+  set_text(handle, "xy")
+  let stale_patches = compute_view_patches_json(handle)
+  assert_false(stale_patches.contains("analysis-match pattern-fn-def"))
+  destroy_editor(handle)
+}
+
+///|
+test "apply_ast_grep_results_json converts byte offsets to utf16 decorations" {
+  let handle = create_editor("analysis-unicode-offsets")
+  set_text(handle, "éx")
+  let result = apply_ast_grep_results_json(
+    handle, "[{\"byte_start\":2,\"byte_end\":3,\"pattern_id\":\"unicode-id\"}]",
+  )
+  inspect(result, content="ok")
+  let patches = compute_view_patches_json(handle)
+  assert_true(patches.contains("\"from\":1"))
+  assert_true(patches.contains("\"to\":2"))
+  assert_true(patches.contains("analysis-match pattern-unicode-id"))
+  destroy_editor(handle)
+}
+
+///|
+test "apply_ast_grep_results_json sanitizes pattern ids for css classes" {
+  let handle = create_editor("analysis-css-class-sanitize")
+  set_text(handle, "x")
+  let result = apply_ast_grep_results_json(
+    handle, "[{\"byte_start\":0,\"byte_end\":1,\"pattern_id\":\"fn/def:α\"}]",
+  )
+  inspect(result, content="ok")
+  let patches = compute_view_patches_json(handle)
+  assert_true(patches.contains("analysis-match pattern-fn-def--"))
+  assert_true(patches.contains("\"data\":\"fn/def:α\""))
+  destroy_editor(handle)
+}

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "dowdiness/canopy/analysis",
   "dowdiness/canopy/editor",
   "dowdiness/canopy/ffi/host",
   "dowdiness/canopy/ffi/io",
@@ -15,6 +16,7 @@ import {
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",
   "dowdiness/event-graph-walker/text",
+  "dowdiness/analysis" @facts,
   "moonbitlang/async/js_async",
   "moonbitlang/core/buffer",
   "moonbitlang/core/json",
@@ -102,6 +104,7 @@ options(
         "ws_set_status_callback",
         "get_view_tree_json",
         "compute_view_patches_json",
+        "apply_ast_grep_results_json",
         "handle_text_intent",
         "handle_text_intent_checked",
         "handle_undo",

--- a/ffi/lambda/pkg.generated.mbti
+++ b/ffi/lambda/pkg.generated.mbti
@@ -11,6 +11,8 @@ import {
 }
 
 // Values
+pub fn apply_ast_grep_results_json(Int, String) -> String
+
 pub fn apply_sync_json(Int, String) -> String
 
 pub fn apply_tree_edit_json(Int, String, Int) -> String

--- a/ffi/lambda/view.mbt
+++ b/ffi/lambda/view.mbt
@@ -94,6 +94,13 @@ pub fn compute_view_patches_json(handle : Int) -> String {
           return "[]"
         }
       }
+      let source = h.editor.get_text()
+      let snapshot = @facts.SourceSnapshot::SourceSnapshot(
+        doc_id=h.editor_id.0.to_string(),
+        version=0,
+        source~,
+      )
+      h.companion.clear_stale_pattern_analysis(snapshot)
       let state = lambda_registry.view_state(handle)
       let patches = @editor.compute_view_patches(state, h.editor)
       Json::array(patches.map(fn(p) { p.to_json() })).stringify()

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -10,6 +10,8 @@ pub struct LambdaCompanion {
   // Falls back to Tier 1 results when no definitions are Suppressed.
   priv escalation_memo : @incr.Derived[Array[@lambda_eval.EvalResult]]
   priv analysis : @parser.LambdaAnalysis
+  priv pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?]
+  priv pattern_snapshot_ref : Ref[@facts.SourceSnapshot?]
 }
 
 ///|
@@ -35,6 +37,32 @@ pub fn LambdaCompanion::dispose_analysis_attachment(
   self : LambdaCompanion,
 ) -> Unit {
   self.analysis.dispose()
+}
+
+///|
+/// Replace host-provided pattern analysis facts used by editor decorations.
+pub fn LambdaCompanion::set_pattern_analysis(
+  self : LambdaCompanion,
+  facts : Array[@facts.PatternMatchFact],
+  snapshot : @facts.SourceSnapshot,
+) -> Unit {
+  self.pattern_facts_ref.val = Some(facts)
+  self.pattern_snapshot_ref.val = Some(snapshot)
+}
+
+///|
+/// Drop host-provided pattern analysis if it no longer matches the current source.
+pub fn LambdaCompanion::clear_stale_pattern_analysis(
+  self : LambdaCompanion,
+  current : @facts.SourceSnapshot,
+) -> Unit {
+  match self.pattern_snapshot_ref.val {
+    Some(snapshot) if snapshot.matches(current) => ()
+    _ => {
+      self.pattern_facts_ref.val = None
+      self.pattern_snapshot_ref.val = None
+    }
+  }
 }
 
 ///|
@@ -130,6 +158,8 @@ pub fn new_lambda_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
+  let pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?] = Ref(None)
+  let pattern_snapshot_ref : Ref[@facts.SourceSnapshot?] = Ref(None)
   // Ref side-channels let the build_memos callback publish companion memos
   // back out to the enclosing scope for companion construction + capabilities
   // wiring.
@@ -167,13 +197,16 @@ pub fn new_lambda_editor(
     capture_timeout_ms~,
     parent_runtime?,
     capabilities=build_lambda_capabilities(
-      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref,
+      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref, pattern_facts_ref,
+      pattern_snapshot_ref,
     ),
     identity_hints=hints_ref,
   )
   let companion : LambdaCompanion = {
     escalation_memo: escalation_memo_ref.val.unwrap(),
     analysis: analysis_ref.val.unwrap(),
+    pattern_facts_ref,
+    pattern_snapshot_ref,
   }
   (editor, companion)
 }
@@ -184,6 +217,8 @@ fn build_lambda_capabilities(
   cached_proj_node_ref : Ref[@incr.Derived[@core.ProjNode[@ast.Term]?]?],
   source_map_memo_ref : Ref[@incr.Derived[@core.SourceMap]?],
   escalation_memo_ref : Ref[@incr.Derived[Array[@lambda_eval.EvalResult]]?],
+  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
+  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
 ) -> @editor.LanguageCapabilities[@ast.Term] {
   @editor.LanguageCapabilities::new(
     get_annotations=Some(fn() {
@@ -210,7 +245,8 @@ fn build_lambda_capabilities(
       annotations
     }),
     get_decorations=Some(fn() {
-      match (cached_proj_node_ref.val, source_map_memo_ref.val) {
+      let semantic_decorations = match
+        (cached_proj_node_ref.val, source_map_memo_ref.val) {
         (Some(cached_proj_memo), Some(source_map_memo)) =>
           match cached_proj_memo.read_or_abort() {
             Some(root) =>
@@ -222,6 +258,13 @@ fn build_lambda_capabilities(
           }
         _ => []
       }
+      let analysis_decorations = match
+        (pattern_facts_ref.val, pattern_snapshot_ref.val) {
+        (Some(facts), Some(snapshot)) =>
+          @analysis.facts_to_decorations(facts, snapshot)
+        _ => []
+      }
+      semantic_decorations + analysis_decorations
     }),
     pretty_post_process=Some(fn(layout) {
       let eval_results = match escalation_memo_ref.val {

--- a/lang/lambda/companion/moon.pkg
+++ b/lang/lambda/companion/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "dowdiness/canopy/analysis",
+  "dowdiness/analysis" @facts,
   "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
   "dowdiness/canopy/lang/lambda/eval" @lambda_eval,

--- a/lang/lambda/companion/pkg.generated.mbti
+++ b/lang/lambda/companion/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/lambda/companion"
 
 import {
+  "dowdiness/analysis",
   "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/edits",
@@ -34,10 +35,12 @@ pub fn parse_tree_edit_op(Json) -> @edits.TreeEditOp raise @editor.TreeEditError
 pub struct LambdaCompanion {
   // private fields
 }
+pub fn LambdaCompanion::clear_stale_pattern_analysis(Self, @analysis.SourceSnapshot) -> Unit
 pub fn LambdaCompanion::dispose_analysis_attachment(Self) -> Unit
 pub fn LambdaCompanion::escalation_memo(Self) -> @cells.Derived[Array[@eval.EvalResult]]
 pub fn LambdaCompanion::get_eval_annotations(Self, @core.ProjNode[@ast.Term]?) -> Map[@core.NodeId, Array[@protocol.ViewAnnotation]]
 pub fn LambdaCompanion::get_eval_results(Self) -> Array[@eval.EvalResult]
+pub fn LambdaCompanion::set_pattern_analysis(Self, Array[@analysis.PatternMatchFact], @analysis.SourceSnapshot) -> Unit
 pub fn LambdaCompanion::typecheck_output(Self) -> @cells.Derived[@typecheck.ModuleTypeResult]
 
 // Type aliases


### PR DESCRIPTION
## Summary
- add lambda FFI to accept ast-grep JSON matches and convert them through the existing analysis adapter/rendering layer
- merge host-provided pattern facts into lambda editor decorations and clear stale facts when source snapshots no longer match
- add Vite dev-server ast-grep CLI endpoint, frontend runner, and overlay rendering for lambda editor decorations
- harden follow-up review findings: dev-only production no-op, abort stale requests, timeout `sg`, cap request bodies, sanitize CSS class segments, and add regression tests

## Reuse check
- Reused `@analysis.from_ast_grep_matches` as the only byte-offset to UTF-16 conversion boundary.
- Reused `@analysis.facts_to_decorations` and extended it only to sanitize CSS class segments.
- Reused existing lambda FFI JSON pattern from `compute_view_patches_json` / `ViewPatch::SetDecorations`.
- Checked ast-grep JS packages in `examples/web/package.json` and `node_modules`; none were present, so host integration uses the `sg` CLI from the Vite dev server.

## Validation
- `moon fmt analysis ffi/lambda lang/lambda/companion`
- `moon check analysis ffi/lambda lang/lambda/companion`
- `moon test analysis ffi/lambda lang/lambda/companion` — 143 passed
- `moon info analysis ffi/lambda lang/lambda/companion`
- `cd examples/web && npx tsc --noEmit`
- `cd examples/web && npm run build` — passed with existing large chunk warning
- `printf 'fn twice(f : Int -> Int, x : Int) { f (f x) }' | sg scan -c sgconfig.yml --rule rules/moonbit-fn-def.yml --stdin --json=stream | head -20`

## Notes
- The `loom` submodule worktree is dirty from pre-existing local changes and is intentionally not included in this PR.
