### PR TITLE
Add alpha-stable Lambda canonical keys

### DIFF
--- a/lang/lambda/alpha/alpha_key.mbt
+++ b/lang/lambda/alpha/alpha_key.mbt
@@ -1,0 +1,180 @@
+///|
+enum AlphaKeyRef {
+  KBound(Int)
+  KUnscopedBound(BinderId)
+  KFree(String)
+} derive(Eq, Hash)
+
+///|
+enum AlphaKeyRepr {
+  KInt(Int)
+  KUnit
+  KVar(AlphaKeyRef)
+  KLam(AlphaKeyRepr)
+  KApp(AlphaKeyRepr, AlphaKeyRepr)
+  KBop(@ast.Bop, AlphaKeyRepr, AlphaKeyRepr)
+  KIf(AlphaKeyRepr, AlphaKeyRepr, AlphaKeyRepr)
+  KLetDef(AlphaKeyRepr)
+  KModule(Array[AlphaKeyRepr], AlphaKeyRepr)
+  KError(String)
+  KHole(Int)
+} derive(Eq)
+
+///|
+/// Opaque canonical key for an `AlphaTerm`.
+///
+/// `AlphaKey` equality and hashing are stable under alpha-renaming of scoped
+/// binders. Free references are keyed by their textual free name only; their
+/// `FreeOrigin` is diagnostic/source provenance and does not affect the key.
+/// The internal representation is private so future hash-consing/egraph work can
+/// change the encoding without changing callers.
+pub struct AlphaKey {
+  priv repr : AlphaKeyRepr
+} derive(Eq)
+
+///|
+impl Hash for AlphaKeyRepr with fn hash_combine(self, hasher) {
+  match self {
+    KInt(value) => {
+      hasher.combine_int(0)
+      hasher.combine_int(value)
+    }
+    KUnit => hasher.combine_int(1)
+    KVar(alpha_ref) => {
+      hasher.combine_int(2)
+      alpha_ref.hash_combine(hasher)
+    }
+    KLam(body) => {
+      hasher.combine_int(3)
+      body.hash_combine(hasher)
+    }
+    KApp(fn_key, arg_key) => {
+      hasher.combine_int(4)
+      fn_key.hash_combine(hasher)
+      arg_key.hash_combine(hasher)
+    }
+    KBop(op, lhs_key, rhs_key) => {
+      hasher.combine_int(5)
+      hasher.combine_int(key_bop_index(op))
+      lhs_key.hash_combine(hasher)
+      rhs_key.hash_combine(hasher)
+    }
+    KIf(cond_key, then_key, else_key) => {
+      hasher.combine_int(6)
+      cond_key.hash_combine(hasher)
+      then_key.hash_combine(hasher)
+      else_key.hash_combine(hasher)
+    }
+    KLetDef(init_key) => {
+      hasher.combine_int(7)
+      init_key.hash_combine(hasher)
+    }
+    KModule(def_keys, body_key) => {
+      hasher.combine_int(8)
+      hasher.combine_int(def_keys.length())
+      def_keys.iter().each(fn(def_key) { def_key.hash_combine(hasher) })
+      body_key.hash_combine(hasher)
+    }
+    KError(message) => {
+      hasher.combine_int(9)
+      hasher.combine_string(message)
+    }
+    KHole(index) => {
+      hasher.combine_int(10)
+      hasher.combine_int(index)
+    }
+  }
+}
+
+///|
+pub impl Hash for AlphaKey with fn hash_combine(self, hasher) {
+  self.repr.hash_combine(hasher)
+}
+
+///|
+/// Build a whole-term canonical key for `term`.
+///
+/// Binder positions are numbered deterministically from the root traversal, so
+/// the result is intended for whole `AlphaTerm` keys rather than context-free
+/// subterm extraction.
+pub fn alpha_key(term : AlphaTerm) -> AlphaKey {
+  let env : Map[BinderId, Int] = {}
+  let (key, _) = key_term(term, env, 0)
+  AlphaKey::{ repr: key }
+}
+
+///|
+fn key_ref(alpha_ref : AlphaRef, env : Map[BinderId, Int]) -> AlphaKeyRef {
+  match alpha_ref {
+    Bound(id) =>
+      match env.get(id) {
+        Some(index) => KBound(index)
+        None => KUnscopedBound(id)
+      }
+    Free(free) => KFree(free.name)
+  }
+}
+
+///|
+fn key_bop_index(op : @ast.Bop) -> Int {
+  match op {
+    @ast.Bop::Plus => 0
+    @ast.Bop::Minus => 1
+  }
+}
+
+///|
+fn key_term(
+  term : AlphaTerm,
+  env : Map[BinderId, Int],
+  next : Int,
+) -> (AlphaKeyRepr, Int) {
+  match term {
+    Int(value) => (KInt(value), next)
+    Unit => (KUnit, next)
+    Var(alpha_ref) => (KVar(key_ref(alpha_ref, env)), next)
+    Lam(binder, body) => {
+      let next_env = env.copy()
+      next_env[binder.id] = next
+      let (body_key, after_body) = key_term(body, next_env, next + 1)
+      (KLam(body_key), after_body)
+    }
+    App(fn_term, arg) => {
+      let (fn_key, after_fn) = key_term(fn_term, env, next)
+      let (arg_key, after_arg) = key_term(arg, env, after_fn)
+      (KApp(fn_key, arg_key), after_arg)
+    }
+    Bop(op, lhs, rhs) => {
+      let (lhs_key, after_lhs) = key_term(lhs, env, next)
+      let (rhs_key, after_rhs) = key_term(rhs, env, after_lhs)
+      (KBop(op, lhs_key, rhs_key), after_rhs)
+    }
+    If(cond, then_term, else_term) => {
+      let (cond_key, after_cond) = key_term(cond, env, next)
+      let (then_key, after_then) = key_term(then_term, env, after_cond)
+      let (else_key, after_else) = key_term(else_term, env, after_then)
+      (KIf(cond_key, then_key, else_key), after_else)
+    }
+    LetDef(_, init) => {
+      let (init_key, after_init) = key_term(init, env, next)
+      (KLetDef(init_key), after_init)
+    }
+    Module(defs, body) => {
+      let next_env = env.copy()
+      let def_keys : Array[AlphaKeyRepr] = []
+      let current_next = for def in defs; current_next = next {
+        let (binder, init) = def
+        let (init_key, after_init) = key_term(init, next_env, current_next)
+        def_keys.push(init_key)
+        next_env[binder.id] = after_init
+        continue after_init + 1
+      } nobreak {
+        current_next
+      }
+      let (body_key, after_body) = key_term(body, next_env, current_next)
+      (KModule(def_keys, body_key), after_body)
+    }
+    Error(message) => (KError(message), next)
+    Hole(index) => (KHole(index), next)
+  }
+}

--- a/lang/lambda/alpha/alpha_key_wbtest.mbt
+++ b/lang/lambda/alpha/alpha_key_wbtest.mbt
@@ -1,0 +1,131 @@
+///|
+test "alpha_key: lambda binder identities do not matter" {
+  assert_true(
+    alpha_key(identity_lam(0, "x")) == alpha_key(identity_lam(1, "y")),
+  )
+}
+
+///|
+test "alpha_key: free and bound references differ" {
+  let bound = identity_lam(0, "x")
+  let free = Lam(test_binder(1, "x"), free_var("x"))
+  assert_false(alpha_key(bound) == alpha_key(free))
+}
+
+///|
+test "alpha_key: free origin does not affect free-name key" {
+  let source_var = Var(Free(test_free("x", SourceVar)))
+  let source_unbound = Var(Free(test_free("x", SourceUnbound)))
+  assert_true(alpha_key(source_var) == alpha_key(source_unbound))
+}
+
+///|
+fn assert_alpha_eq_key_agree(left : AlphaTerm, right : AlphaTerm) -> Unit raise {
+  assert_true(alpha_eq(left, right) == (alpha_key(left) == alpha_key(right)))
+}
+
+///|
+test "alpha_key: agrees with alpha_eq across constructors" {
+  let x = test_binder(10, "x")
+  let y = test_binder(11, "y")
+  let z = test_binder(12, "z")
+  let cases : Array[(AlphaTerm, AlphaTerm)] = [
+    (Int(1), Int(1)),
+    (Int(1), Int(2)),
+    (Unit, Unit),
+    (
+      Var(Free(test_free("x", SourceVar))),
+      Var(Free(test_free("x", GeneratedFree))),
+    ),
+    (identity_lam(1, "a"), identity_lam(2, "b")),
+    (identity_lam(1, "a"), Lam(test_binder(2, "b"), free_var("b"))),
+    (App(identity_lam(1, "a"), Int(1)), App(identity_lam(2, "b"), Int(1))),
+    (Bop(@ast.Bop::Plus, Int(1), Int(2)), Bop(@ast.Bop::Plus, Int(1), Int(2))),
+    (Bop(@ast.Bop::Plus, Int(1), Int(2)), Bop(@ast.Bop::Minus, Int(1), Int(2))),
+    (
+      If(Var(Free(test_free("c", SourceVar))), Int(1), Int(2)),
+      If(free_var("c"), Int(1), Int(2)),
+    ),
+    (LetDef(x, Int(1)), LetDef(y, Int(1))),
+    (
+      Module([(x, Int(1))], Var(Bound(x.id))),
+      Module([(y, Int(1))], Var(Bound(y.id))),
+    ),
+    (Error("bad"), Error("bad")),
+    (Hole(3), Hole(3)),
+    (Var(Bound(x.id)), Var(Bound(x.id))),
+    (Var(Bound(x.id)), Var(Bound(z.id))),
+  ]
+  cases
+  .iter()
+  .each(fn(pair) raise {
+    let (left, right) = pair
+    assert_alpha_eq_key_agree(left, right)
+  })
+}
+
+///|
+test "alpha_key: module definitions scope sequentially" {
+  let first_left = test_binder(1, "a")
+  let second_left = test_binder(2, "b")
+  let first_right = test_binder(10, "x")
+  let second_right = test_binder(20, "y")
+  let left = Module(
+    [(first_left, Int(1)), (second_left, Var(Bound(first_left.id)))],
+    Var(Bound(second_left.id)),
+  )
+  let right = Module(
+    [(first_right, Int(1)), (second_right, Var(Bound(first_right.id)))],
+    Var(Bound(second_right.id)),
+  )
+  assert_true(alpha_eq(left, right))
+  assert_true(alpha_key(left) == alpha_key(right))
+}
+
+///|
+test "alpha_key: module shape and body references affect key" {
+  let first = test_binder(1, "a")
+  let second = test_binder(2, "b")
+  let one_def = Module([(first, Int(1))], Var(Bound(first.id)))
+  let two_defs = Module(
+    [(first, Int(1)), (second, Int(2))],
+    Var(Bound(second.id)),
+  )
+  let different_body = Module([(first, Int(1))], free_var("a"))
+  assert_false(alpha_eq(one_def, two_defs))
+  assert_false(alpha_key(one_def) == alpha_key(two_defs))
+  assert_false(alpha_eq(one_def, different_body))
+  assert_false(alpha_key(one_def) == alpha_key(different_body))
+}
+
+///|
+test "alpha_key: nested lambdas distinguish referenced binder" {
+  let x = test_binder(1, "x")
+  let y = test_binder(2, "y")
+  let left = Lam(x, Lam(y, Var(Bound(x.id))))
+  let x2 = test_binder(10, "x")
+  let y2 = test_binder(20, "y")
+  let right = Lam(x2, Lam(y2, Var(Bound(y2.id))))
+  assert_false(alpha_eq(left, right))
+  assert_false(alpha_key(left) == alpha_key(right))
+}
+
+///|
+test "alpha_key: error and hole payloads are preserved" {
+  assert_true(alpha_key(Error("bad")) == alpha_key(Error("bad")))
+  assert_false(alpha_key(Error("bad")) == alpha_key(Error("worse")))
+  assert_true(alpha_key(Hole(3)) == alpha_key(Hole(3)))
+  assert_false(alpha_key(Hole(3)) == alpha_key(Hole(4)))
+}
+
+///|
+test "alpha_key: standalone let definition drops binder" {
+  assert_true(
+    alpha_key(LetDef(test_binder(1, "x"), Int(1))) ==
+    alpha_key(LetDef(test_binder(2, "y"), Int(1))),
+  )
+  assert_false(
+    alpha_key(LetDef(test_binder(1, "x"), Int(1))) ==
+    alpha_key(LetDef(test_binder(1, "x"), Int(2))),
+  )
+}

--- a/lang/lambda/alpha/pkg.generated.mbti
+++ b/lang/lambda/alpha/pkg.generated.mbti
@@ -11,6 +11,8 @@ import {
 // Values
 pub fn alpha_eq(AlphaTerm, AlphaTerm) -> Bool
 
+pub fn alpha_key(AlphaTerm) -> AlphaKey
+
 pub fn beta_reduce_root(AlphaTerm) -> AlphaTerm?
 
 pub fn lower_root(@core.ProjNode[@ast.Term], @scope.ScopeGraph) -> AlphaTerm
@@ -20,6 +22,15 @@ pub fn reify(AlphaTerm, ReifyPolicy) -> @ast.Term
 // Errors
 
 // Types and methods
+pub struct AlphaKey {
+  // private fields
+} derive(Eq)
+pub impl Hash for AlphaKey
+
+type AlphaKeyRef derive(Eq, Hash)
+
+type AlphaKeyRepr derive(Eq)
+
 pub(all) enum AlphaRef {
   Bound(BinderId)
   Free(FreeName)


### PR DESCRIPTION
## Summary

- Add opaque `AlphaKey` plus `alpha_key(AlphaTerm) -> AlphaKey` for Lambda alpha terms.
- Canonicalize scoped bound refs by deterministic binder position instead of raw `BinderId`.
- Keep free refs policy-aware/documented: keys use textual free names and ignore `FreeOrigin`, matching current `alpha_eq` behavior.
- Add focused alpha-key tests, including module shape/body coverage and `alpha_eq(a,b) iff alpha_key(a)==alpha_key(b)` examples for the first supported slice.

Closes #680.

## Reuse check

- Reused core `Hash`/`Hasher`, `Map`, `Array::iter().each`, and existing alpha test fixtures.
- Checked core hashing/key/container APIs before adding package-local key helpers.
- New helpers are private canonicalization internals; public surface is limited to opaque `AlphaKey` and `alpha_key`.
- Remaining imperative code is limited to environment updates and module key array construction.

## Validation

- `NEW_MOON_MOD=0 moon check --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/lambda/alpha` — 32 passed
- `NEW_MOON_MOD=0 moon test` — 266 wasm-gc + 1518 js + 70 native passed
- `NEW_MOON_MOD=0 moon info`
- `NEW_MOON_MOD=0 moon fmt`
- `git diff --check`
