### PR TITLE
Start analysis query projection aggregator

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -513,17 +513,22 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 
 ## 21. Analysis Query Layer
 
+- [ ] Phase 2 projection aggregator.
+  Why: Phase 1 proved snapshot-bound structural-search decorations, but lambda still composes ast-grep, semantic, eval, and diagnostic projections through ad-hoc closures and FFI paths.
+  Plan: `docs/plans/2026-06-18-analysis-query-phase2-aggregator.md`
+  Exit: lambda has one named aggregation seam for analysis projections, existing protocol surfaces are unchanged, and tests cover combined semantic + pattern decorations with stale external facts.
+
 - [x] Implement Phase 1 ast-grep range-only analysis overlay (#692).
-  Shipped: PR #699 — `lib/analysis/` (SourceSnapshot, PatternMatchFact, byte_offset_to_utf16) + `analysis/` (facts_to_decorations, from_ast_grep_matches, AstGrepMatch).
+  Shipped: PR #699 added `lib/analysis/` and `analysis/`; PR #704 completed host FFI and lambda editor decoration wiring.
 
 - [x] Add provider range normalization tests for analysis facts (#693).
-  Shipped: PR #699 — analysis_test.mbt covers ASCII, 3-byte BMP (世界), and surrogate-pair emoji (😀) via byte_offset_to_utf16.
+  Shipped: PR #699 covered core byte→UTF-16 conversion; PR #704 added FFI-level non-ASCII coverage.
 
 - [x] Reject stale analysis provider results by source snapshot (#694).
-  Shipped: PR #699 — SourceSnapshot::matches (version + 32-bit hash) gates facts_to_decorations and facts_to_match_list.
+  Shipped: PR #699 added `SourceSnapshot::matches`; PR #704 clears stale lambda pattern facts before view patches are computed.
 
-- [x] Add structural-search match list and jump-to-range UI (#695).
-  Shipped: PR #699 — facts_to_match_list → Array[MatchListEntry] supplies from/to/pattern_id to host for list rendering and jump. Host-side wiring pending.
+- [x] Add structural-search match list projection (#695).
+  Shipped: PR #699 — `facts_to_match_list` supplies `from`/`to`/`pattern_id` for future host list/jump rendering. Host-side list UI remains a follow-up.
 
 ## Shipped history
 

--- a/docs/design/analysis-query-layer.md
+++ b/docs/design/analysis-query-layer.md
@@ -1,6 +1,8 @@
 # Analysis Query Layer
 
-**Status:** Phase 1 implemented — `lib/analysis/` (types + conversion), `analysis/` (rendering + adapter), `rules/` (ast-grep rule). Host FFI wiring pending.  
+**Status:** Phase 1 complete — range-only structural search is wired from
+host-side ast-grep results through normalized analysis facts into lambda editor
+range decorations.
 **Goal:** bring syntax-pattern search, semantic queries, and previewable refactors
 into Canopy without weakening the core text-CRDT pipeline.
 
@@ -196,7 +198,9 @@ expectations are stable.
 
 ### Phase 1 — range-only structural search overlay
 
-Build the smallest useful slice:
+Status: complete for range highlights in the lambda editor.
+
+Built the smallest useful slice:
 
 ```text
 current source snapshot
@@ -210,7 +214,22 @@ Do not include rewrite. Do not require node-id mapping. Do not add protocol
 variants. This phase proves snapshot validation, offset conversion, and derived
 analysis rendering.
 
+Implementation notes:
+
+- The browser demo runs ast-grep from the Vite dev server, not from editor
+  rendering or reactive recomputation.
+- The host sends normalized JSON match payloads into the lambda FFI; MoonBit
+  owns byte-to-UTF-16 conversion at the provider adapter boundary.
+- The lambda companion stores snapshot-bound structural facts and projects them
+  through existing decoration patches.
+- Production builds no-op the browser ast-grep runner unless a host endpoint is
+  provided.
+- No public protocol variant was added.
+
 ### Phase 2 — analysis projection aggregator
+
+Status: started. The active implementation plan is
+[`docs/plans/2026-06-18-analysis-query-phase2-aggregator.md`](../plans/2026-06-18-analysis-query-phase2-aggregator.md).
 
 Route existing language facts through a small internal aggregator:
 
@@ -218,6 +237,11 @@ Route existing language facts through a small internal aggregator:
 - evaluation results;
 - semantic annotations already produced by language packages;
 - diagnostics.
+
+First implementation slice: lambda-local `analysis_projection` helpers compose
+existing semantic/eval projected outputs with snapshot-bound structural pattern
+facts for decorations and annotations. Diagnostics remain on their existing FFI
+path until a larger diagnostic fact shape is justified.
 
 The goal is to learn the shape of the common fact model from real in-process
 analyses before committing to a broad provider abstraction.
@@ -288,9 +312,10 @@ intent-level operations.
 
 ## Success criteria for Phase 1
 
-- ast-grep results are displayed as range highlights for a source snapshot.
-- Stale provider results are rejected deterministically.
-- Byte offsets are converted to UTF-16 ranges before entering analysis state.
-- Non-ASCII test cases prove range conversion correctness.
-- The UI can list matches and jump to a normalized range. *(data layer: `facts_to_match_list` → `MatchListEntry` shipped; host rendering pending)*
-- No changes are required to the public protocol.
+- ast-grep results are displayed as range highlights for a source snapshot. ✅
+- Stale provider results are rejected deterministically. ✅
+- Byte offsets are converted to UTF-16 ranges before entering analysis state. ✅
+- Non-ASCII test cases prove range conversion correctness. ✅
+- The UI can list matches and jump to a normalized range. *(Data projection is
+  available; host-side list/jump rendering remains a follow-up.)*
+- No changes are required to the public protocol. ✅

--- a/docs/plans/2026-06-18-analysis-query-phase2-aggregator.md
+++ b/docs/plans/2026-06-18-analysis-query-phase2-aggregator.md
@@ -1,0 +1,144 @@
+# Analysis Query Layer Phase 2 — Projection Aggregator
+
+## Why
+
+Phase 1 proved that external structural-search results can enter Canopy as
+snapshot-bound analysis facts and render through existing decorations. The
+lambda editor now has two separate projection paths for related derived data:
+
+- host-provided ast-grep pattern facts stored on `LambdaCompanion` refs;
+- in-process semantic, evaluation, and diagnostic data assembled directly in
+  language capability closures and FFI functions.
+
+Phase 2 should introduce a small aggregation seam so these in-process analyses
+are routed through one projection layer before Canopy commits to broader
+provider abstractions or `moon ide` integration.
+
+## Scope
+
+In:
+
+- `docs/design/analysis-query-layer.md` — source design and phase boundaries.
+- `analysis/` — shared rendering/projection helpers for analysis facts.
+- `lib/analysis/` — shared snapshot/fact primitives, only if a minimal new fact
+  wrapper is required.
+- `lang/lambda/companion/lambda_editor.mbt` — first consumer and prototype seam.
+- `lang/lambda/semantic/semantic_projection.mbt` — existing semantic projection
+  input, not a rewrite target unless an adapter boundary is needed.
+- `ffi/lambda/{analysis,view,diagnostics}.mbt` — FFI surfaces affected by the
+  lambda prototype.
+- tests in `analysis/`, `lib/analysis/`, `lang/lambda/companion/`, and
+  `ffi/lambda/` as needed.
+
+Out:
+
+- `moon ide` provider integration. That is Phase 3.
+- rewrite, rename, or edit-plan previews. That is Phase 4.
+- new public protocol variants or exposing raw analysis facts to TypeScript.
+- broad cross-language migration beyond lambda.
+- node-id anchoring as a requirement. Source ranges remain authoritative.
+- persistent semantic database or workspace indexing.
+
+## Current State
+
+- Phase 1 host integration shipped in PR #704.
+- `lib/analysis/source_snapshot.mbt` defines `SourceSnapshot` and stale-result
+  matching by document id, version, hash, and UTF-16 length.
+- `lib/analysis/pattern_match_fact.mbt` defines `PatternMatchFact` with
+  snapshot-bound UTF-16 ranges.
+- `analysis/adapter.mbt` converts ast-grep byte offsets to UTF-16 via
+  `from_ast_grep_matches`; this remains the only ast-grep byte-conversion
+  boundary.
+- `analysis/render.mbt` projects pattern facts to existing
+  `@protocol.Decoration` values and match-list entries.
+- `lang/lambda/companion/lambda_editor.mbt` currently merges semantic
+  decorations and ast-grep decorations in the `get_decorations` capability
+  closure. It separately merges evaluation and semantic annotations in
+  `get_annotations`.
+- `ffi/lambda/diagnostics.mbt` assembles parse/type/eval diagnostics separately
+  from the decoration/annotation path.
+- `editor/capabilities.mbt` and `editor/view_updater.mbt` already provide the
+  public projection seam: annotations, decorations, diagnostics, and view
+  patches.
+
+## Desired State
+
+A narrow lambda-first aggregator owns the composition of analysis projections
+without changing the public protocol:
+
+- structural matches, semantic decorations, semantic annotations, and
+  evaluation annotations have an explicit local composition boundary;
+- diagnostics are either routed through that boundary or explicitly deferred
+  with rationale;
+- snapshot-bound external facts are stale-checked before projection;
+- in-process facts remain derived from existing memo/capability inputs and do
+  not require artificial provider snapshots;
+- output continues through existing protocol surfaces (`SetDecorations`,
+  diagnostics JSON, annotations), not a new fact protocol;
+- the design leaves room for Phase 3 `moon ide` facts without prematurely
+  designing a full provider abstraction.
+
+## Steps
+
+1. **Name the seam.** Decide whether Phase 2 needs a concrete type such as
+   `AnalysisProjection` / `AnalysisStore` or a smaller set of helper functions
+   under `analysis/`. Prefer the smallest type that removes ad-hoc composition
+   from lambda capability closures.
+2. **Model only projected outputs first.** Start with decorations and
+   annotations; keep diagnostics separate unless a minimal adapter is obvious.
+3. **Move pattern fact refs behind the seam.** Replace direct
+   `pattern_facts_ref` / `pattern_snapshot_ref` access in capability closures
+   with a small owned object or helper API.
+4. **Route semantic and eval projections through the same seam.** Reuse
+   existing `build_semantic_projection`, `build_eval_annotations`, and
+   `facts_to_decorations`; do not rewrite semantic analysis.
+5. **Add tests for composition behavior.** Pin that semantic decorations and
+   ast-grep decorations are both present, stale external facts are dropped, and
+   missing external patches do not clear in-process decorations.
+6. **Document follow-ups.** If diagnostics need a larger representation, record
+   the decision and keep them out of the first Phase 2 PR.
+
+## Acceptance Criteria
+
+- [ ] Lambda analysis projection composition has one named seam rather than
+      duplicated ad-hoc merging in capability closures.
+- [ ] Existing semantic/eval decorations and annotations behave as before.
+- [ ] Existing ast-grep decorations remain snapshot-bound and stale-safe.
+- [ ] No new public protocol variant is introduced.
+- [ ] Tests cover combined semantic + pattern decorations and stale external
+      facts.
+- [ ] `docs/design/analysis-query-layer.md` reflects the implemented Phase 2
+      slice and any deferred diagnostics work.
+
+## Validation
+
+```bash
+moon fmt analysis lib/analysis lang/lambda/companion ffi/lambda
+moon info analysis lib/analysis lang/lambda/companion ffi/lambda
+moon check analysis lib/analysis lang/lambda/companion ffi/lambda
+moon test analysis lib/analysis lang/lambda/companion ffi/lambda
+cd examples/web && npx tsc --noEmit
+cd examples/web && npm run build
+```
+
+If public interfaces change, inspect generated `.mbti` diffs for unintended
+API widening.
+
+## Risks
+
+- Over-generalizing the fact model before Phase 3 provider needs are known.
+- Accidentally making in-process semantic/eval data snapshot-bound in a way that
+  does not match their memo lifetimes.
+- Losing incremental decoration behavior by forcing full projections on every
+  view patch.
+- Expanding `LambdaCompanion` public API unnecessarily.
+
+## Notes
+
+- Keep the Existing API First rule active during implementation. Candidate APIs
+  to reuse include `@analysis.facts_to_decorations`,
+  `@analysis.facts_to_match_list`,
+  `@lambda_semantic.build_semantic_projection`, `build_eval_annotations`,
+  `@editor.LanguageCapabilities`, and `@editor.compute_view_patches`.
+- Phase 2 should make Phase 3 easier by clarifying the projection boundary, not
+  by designing the `moon ide` provider itself.

--- a/lang/lambda/companion/analysis_projection.mbt
+++ b/lang/lambda/companion/analysis_projection.mbt
@@ -1,0 +1,76 @@
+// Lambda-local analysis projection aggregation.
+//
+// Phase 2 keeps the aggregation seam deliberately narrow: compose existing
+// projected outputs with snapshot-bound external pattern facts, without adding a
+// public fact protocol or a broad provider abstraction.
+
+///|
+fn analysis_projection_set_pattern_analysis(
+  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
+  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
+  facts : Array[@facts.PatternMatchFact],
+  snapshot : @facts.SourceSnapshot,
+) -> Unit {
+  pattern_facts_ref.val = Some(facts)
+  pattern_snapshot_ref.val = Some(snapshot)
+}
+
+///|
+fn analysis_projection_clear_stale_pattern_analysis(
+  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
+  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
+  current : @facts.SourceSnapshot,
+) -> Unit {
+  match pattern_snapshot_ref.val {
+    Some(snapshot) if snapshot.matches(current) => ()
+    _ => {
+      pattern_facts_ref.val = None
+      pattern_snapshot_ref.val = None
+    }
+  }
+}
+
+///|
+fn analysis_projection_decorations(
+  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
+  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
+  semantic_decorations : Array[@protocol.Decoration],
+) -> Array[@protocol.Decoration] {
+  let pattern_decorations = match
+    (pattern_facts_ref.val, pattern_snapshot_ref.val) {
+    (Some(facts), Some(snapshot)) =>
+      @analysis.facts_to_decorations(facts, snapshot)
+    _ => []
+  }
+  semantic_decorations + pattern_decorations
+}
+
+///|
+fn analysis_projection_annotations(
+  eval_annotations : Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
+  semantic_projection : @lambda_semantic.SemanticProjection?,
+) -> Map[@core.NodeId, Array[@protocol.ViewAnnotation]] {
+  match semantic_projection {
+    Some(projection) =>
+      append_annotation_map(eval_annotations, projection.annotations)
+    None => ()
+  }
+  eval_annotations
+}
+
+///|
+fn append_annotation_map(
+  target : Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
+  extra : Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
+) -> Unit {
+  for node_id, anns in extra {
+    target.update(node_id, fn(existing) {
+      let merged = match existing {
+        Some(current) => current
+        None => []
+      }
+      merged.append(anns)
+      Some(merged)
+    })
+  }
+}

--- a/lang/lambda/companion/editor_view_decorations_test.mbt
+++ b/lang/lambda/companion/editor_view_decorations_test.mbt
@@ -74,3 +74,44 @@ test "semantic decorations are emitted and stable" {
     })
   inspect(repeats_decorations, content="false")
 }
+
+///|
+test "analysis projection combines semantic and pattern decorations" {
+  let (editor, companion) = new_lambda_editor("test-analysis-projection")
+  editor.set_text("(x) => x")
+  let source = editor.get_text()
+  let snapshot = @facts.SourceSnapshot::SourceSnapshot(
+    doc_id="test-analysis-projection",
+    version=0,
+    source~,
+  )
+  companion.set_pattern_analysis(
+    @analysis.from_ast_grep_matches(
+      [
+        @analysis.AstGrepMatch::AstGrepMatch(
+          byte_start=0,
+          byte_end=1,
+          pattern_id="fn-def",
+        ),
+      ],
+      source,
+      snapshot,
+    ),
+    snapshot,
+  )
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let patches = @editor.compute_view_patches(state, editor)
+  let has_combined_decorations = patches
+    .iter()
+    .any(fn(p) {
+      match p {
+        @protocol.ViewPatch::SetDecorations(decorations~) =>
+          decorations.iter().any(fn(d) { d.css_class == "semantic-binder" }) &&
+          decorations
+          .iter()
+          .any(fn(d) { d.css_class == "analysis-match pattern-fn-def" })
+        _ => false
+      }
+    })
+  assert_true(has_combined_decorations)
+}

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -46,8 +46,12 @@ pub fn LambdaCompanion::set_pattern_analysis(
   facts : Array[@facts.PatternMatchFact],
   snapshot : @facts.SourceSnapshot,
 ) -> Unit {
-  self.pattern_facts_ref.val = Some(facts)
-  self.pattern_snapshot_ref.val = Some(snapshot)
+  analysis_projection_set_pattern_analysis(
+    self.pattern_facts_ref,
+    self.pattern_snapshot_ref,
+    facts,
+    snapshot,
+  )
 }
 
 ///|
@@ -56,13 +60,11 @@ pub fn LambdaCompanion::clear_stale_pattern_analysis(
   self : LambdaCompanion,
   current : @facts.SourceSnapshot,
 ) -> Unit {
-  match self.pattern_snapshot_ref.val {
-    Some(snapshot) if snapshot.matches(current) => ()
-    _ => {
-      self.pattern_facts_ref.val = None
-      self.pattern_snapshot_ref.val = None
-    }
-  }
+  analysis_projection_clear_stale_pattern_analysis(
+    self.pattern_facts_ref,
+    self.pattern_snapshot_ref,
+    current,
+  )
 }
 
 ///|
@@ -133,22 +135,6 @@ fn build_eval_annotations(
     }
   }
   annotations
-}
-
-///|
-fn append_annotation_map(
-  target : Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
-  extra : Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
-) -> Unit {
-  for node_id, anns in extra {
-    match target.get(node_id) {
-      Some(existing) =>
-        for ann in anns {
-          existing.push(ann)
-        }
-      None => target[node_id] = anns.copy()
-    }
-  }
 }
 
 ///|
@@ -230,19 +216,18 @@ fn build_lambda_capabilities(
         Some(memo) => memo.read_or_abort()
         None => None
       }
-      let annotations = build_eval_annotations(eval_results, proj_node)
-      match (proj_node, source_map_memo_ref.val) {
+      let eval_annotations = build_eval_annotations(eval_results, proj_node)
+      let semantic_projection = match (proj_node, source_map_memo_ref.val) {
         (Some(root), Some(source_map_memo)) =>
-          append_annotation_map(
-            annotations,
+          Some(
             @lambda_semantic.build_semantic_projection(
               root,
               source_map_memo.read_or_abort(),
-            ).annotations,
+            ),
           )
-        _ => ()
+        _ => None
       }
-      annotations
+      analysis_projection_annotations(eval_annotations, semantic_projection)
     }),
     get_decorations=Some(fn() {
       let semantic_decorations = match
@@ -258,13 +243,9 @@ fn build_lambda_capabilities(
           }
         _ => []
       }
-      let analysis_decorations = match
-        (pattern_facts_ref.val, pattern_snapshot_ref.val) {
-        (Some(facts), Some(snapshot)) =>
-          @analysis.facts_to_decorations(facts, snapshot)
-        _ => []
-      }
-      semantic_decorations + analysis_decorations
+      analysis_projection_decorations(
+        pattern_facts_ref, pattern_snapshot_ref, semantic_decorations,
+      )
     }),
     pretty_post_process=Some(fn(layout) {
       let eval_results = match escalation_memo_ref.val {


### PR DESCRIPTION
## Summary
- start Analysis Query Layer Phase 2 with an active projection-aggregator plan and TODO entry
- add a lambda-local `analysis_projection` seam for composing semantic/eval projected outputs with snapshot-bound pattern facts
- refactor lambda view capabilities to use the new aggregation helpers without changing public protocol or exported interfaces
- add regression coverage for combined semantic + ast-grep pattern decorations

## Reuse check
- Reused `@analysis.facts_to_decorations` for structural pattern facts.
- Reused `@lambda_semantic.build_semantic_projection` for semantic annotations/decorations.
- Reused existing `build_eval_annotations` and `LanguageCapabilities` / `compute_view_patches` flow.
- Checked `Map::update`, `Array::any`, `Array::all`, and package outlines via `moon ide`; used `Map::update` for annotation-map merging.
- New helper introduced: `lang/lambda/companion/analysis_projection.mbt`, scoped to lambda-local projection composition. No public protocol or FFI surface change.

## Validation
- `moon fmt lang/lambda/companion`
- `moon check lang/lambda/companion`
- `moon test lang/lambda/companion` — 82 passed
- `moon check analysis lib/analysis lang/lambda/companion ffi/lambda`
- `moon test analysis lib/analysis lang/lambda/companion ffi/lambda` — 144 passed
- `moon info lang/lambda/companion`
- `git diff --check`

## Notes
- Diagnostics remain on the existing FFI path and are explicitly deferred from this first Phase 2 slice.
- The local `loom` submodule is dirty from unrelated prior state and is intentionally not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Analysis Query Layer design documentation, confirming Phase 1 completion with end-to-end range-based structural search integration.
  * Added Phase 2 Aggregator plan document outlining projection composition strategy for semantic and structural analysis features.

* **Tests**
  * Added test verifying combined semantic and pattern analysis decorations in the lambda editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->