### PR TITLE
Bridge Lambda alpha core into egraph

### DIFF
--- a/lang/lambda/alpha_egraph_adapter/README.mbt.md
+++ b/lang/lambda/alpha_egraph_adapter/README.mbt.md
@@ -1,0 +1,15 @@
+# Lambda alpha egraph adapter
+
+This package is a **Canopy adapter** between the Lambda alpha core and the
+shared `dowdiness/egraph` engine. It intentionally lives in Canopy rather than
+inside `dowdiness/egraph` because its boundary types are Canopy-specific:
+
+- `lang/lambda/alpha.AlphaTerm`, `BinderId`, and `AlphaRef`
+- `lang/lambda/scope.ScopeGraph`
+- `core.ProjNode[@ast.Term]`
+- the named Lambda `@ast.Term` source/projection boundary
+
+Generic egraph improvements should still go to `dowdiness/egraph` when they do
+not depend on these Canopy Lambda types. This package only supplies the
+Lambda-specific lowering/optimization/reification adapter and keeps parser or
+projection helpers out of production imports.

--- a/lang/lambda/alpha_egraph_adapter/analysis.mbt
+++ b/lang/lambda/alpha_egraph_adapter/analysis.mbt
@@ -1,0 +1,315 @@
+///|
+priv enum ConstValue {
+  Unknown
+  Known(Int)
+  Conflict
+} derive(Eq)
+
+///|
+priv struct EvalState {
+  val : ConstValue
+  has_incomplete : Bool
+}
+
+///|
+fn known_bop_value(op : @ast.Bop, left : Int, right : Int) -> Int {
+  match op {
+    Plus => left + right
+    Minus => left - right
+  }
+}
+
+///|
+fn union_node(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  class_id : @egraph.Id,
+  node : AlphaLang,
+) -> Unit {
+  eg.union(class_id, eg.add(node)) |> ignore
+}
+
+///|
+fn subst_id(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  target : @alpha.BinderId,
+  value_id : @egraph.Id,
+  body_id : @egraph.Id,
+) -> @egraph.Id {
+  eg.add(ASubst(target, value_id, body_id))
+}
+
+///|
+fn subst_defs(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  defs : Array[(@alpha.Binder, @egraph.Id)],
+  target : @alpha.BinderId,
+  value_id : @egraph.Id,
+) -> (Array[(@alpha.Binder, @egraph.Id)], Bool) {
+  for def in defs; state = ([], true) {
+    let (rewritten_defs, target_visible) : (
+      Array[(@alpha.Binder, @egraph.Id)],
+      Bool,
+    ) = state
+    let (binder, init_id) = def
+    let new_init = if target_visible {
+      subst_id(eg, target, value_id, init_id)
+    } else {
+      init_id
+    }
+    rewritten_defs.push((binder, new_init))
+    continue (rewritten_defs, target_visible && binder.id != target)
+  } nobreak {
+    state
+  }
+}
+
+///|
+fn apply_subst(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  subst_class : @egraph.Id,
+  target : @alpha.BinderId,
+  value_id : @egraph.Id,
+  node : AlphaLang,
+) -> Unit {
+  match node {
+    AVar(Bound(id)) =>
+      if id == target {
+        eg.union(subst_class, value_id) |> ignore
+      } else {
+        union_node(eg, subst_class, AVar(Bound(id)))
+      }
+    AVar(Free(free)) => union_node(eg, subst_class, AVar(Free(free)))
+    AInt(value) => union_node(eg, subst_class, AInt(value))
+    AUnit => union_node(eg, subst_class, AUnit)
+    ALam(binder, body_id) =>
+      if binder.id == target {
+        union_node(eg, subst_class, ALam(binder, body_id))
+      } else {
+        union_node(
+          eg,
+          subst_class,
+          ALam(binder, subst_id(eg, target, value_id, body_id)),
+        )
+      }
+    AApp(func_id, arg_id) =>
+      union_node(
+        eg,
+        subst_class,
+        AApp(
+          subst_id(eg, target, value_id, func_id),
+          subst_id(eg, target, value_id, arg_id),
+        ),
+      )
+    ABop(op, lhs_id, rhs_id) =>
+      union_node(
+        eg,
+        subst_class,
+        ABop(
+          op,
+          subst_id(eg, target, value_id, lhs_id),
+          subst_id(eg, target, value_id, rhs_id),
+        ),
+      )
+    AIf(cond_id, then_id, else_id) =>
+      union_node(
+        eg,
+        subst_class,
+        AIf(
+          subst_id(eg, target, value_id, cond_id),
+          subst_id(eg, target, value_id, then_id),
+          subst_id(eg, target, value_id, else_id),
+        ),
+      )
+    ALetDef(binder, init_id) =>
+      union_node(
+        eg,
+        subst_class,
+        ALetDef(binder, subst_id(eg, target, value_id, init_id)),
+      )
+    AModule(defs, body_id) => {
+      let (new_defs, body_visible) = subst_defs(eg, defs, target, value_id)
+      let new_body = if body_visible {
+        subst_id(eg, target, value_id, body_id)
+      } else {
+        body_id
+      }
+      union_node(eg, subst_class, AModule(new_defs, new_body))
+    }
+    AError(message) => union_node(eg, subst_class, AError(message))
+    AHole(index) => union_node(eg, subst_class, AHole(index))
+    ASubst(_, _, _) => ()
+  }
+}
+
+///|
+fn merge_const(left : ConstValue, right : ConstValue) -> ConstValue {
+  match (left, right) {
+    (Conflict, _) | (_, Conflict) => Conflict
+    (Unknown, value) | (value, Unknown) => value
+    (Known(left_value), Known(right_value)) =>
+      if left_value == right_value {
+        left
+      } else {
+        Conflict
+      }
+  }
+}
+
+///|
+fn make_const_value(
+  node : AlphaLang,
+  get_data : (@egraph.Id) -> EvalState,
+) -> ConstValue {
+  match node {
+    AInt(value) => Known(value)
+    ABop(op, lhs, rhs) =>
+      match (get_data(lhs).val, get_data(rhs).val) {
+        (Known(left), Known(right)) => Known(known_bop_value(op, left, right))
+        (Conflict, _) | (_, Conflict) => Conflict
+        _ => Unknown
+      }
+    AIf(cond, then_, else_) =>
+      match get_data(cond).val {
+        Known(0) => get_data(else_).val
+        Known(_) => get_data(then_).val
+        Conflict => Conflict
+        Unknown => Unknown
+      }
+    AUnit
+    | AVar(_)
+    | ALam(_, _)
+    | AApp(_, _)
+    | ALetDef(_, _)
+    | AModule(_, _)
+    | AError(_)
+    | AHole(_)
+    | ASubst(_, _, _) => Unknown
+  }
+}
+
+///|
+fn has_incomplete_node(
+  node : AlphaLang,
+  get_data : (@egraph.Id) -> EvalState,
+) -> Bool {
+  match node {
+    AError(_) | AHole(_) => true
+    AInt(_) | AUnit | AVar(_) => false
+    ALam(_, body) | ALetDef(_, body) => get_data(body).has_incomplete
+    AApp(func, arg) | ABop(_, func, arg) | ASubst(_, func, arg) =>
+      get_data(func).has_incomplete || get_data(arg).has_incomplete
+    AIf(cond, then_, else_) =>
+      get_data(cond).has_incomplete ||
+      get_data(then_).has_incomplete ||
+      get_data(else_).has_incomplete
+    AModule(defs, body) =>
+      get_data(body).has_incomplete ||
+      defs
+      .iter()
+      .any(fn(def) {
+        let (_, init) = def
+        get_data(init).has_incomplete
+      })
+  }
+}
+
+///|
+fn canonical_class(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  id : @egraph.Id,
+) -> @egraph.EClass[AlphaLang]? {
+  eg.egraph.classes.get(eg.find(id))
+}
+
+///|
+fn apply_beta_from_app(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  class_id : @egraph.Id,
+  func_id : @egraph.Id,
+  arg_id : @egraph.Id,
+) -> Unit {
+  if eg.get_data(arg_id).has_incomplete {
+    return
+  }
+  match canonical_class(eg, func_id) {
+    None => ()
+    Some(func_class) =>
+      for func_node in func_class.nodes {
+        match func_node {
+          ALam(binder, body_id) =>
+            eg.union(class_id, eg.add(ASubst(binder.id, arg_id, body_id)))
+            |> ignore
+          _ => ()
+        }
+      }
+  }
+}
+
+///|
+fn apply_subst_from_node(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  class_id : @egraph.Id,
+  target : @alpha.BinderId,
+  value_id : @egraph.Id,
+  body_id : @egraph.Id,
+) -> Unit {
+  match canonical_class(eg, body_id) {
+    None => ()
+    Some(body_class) =>
+      for body_node in body_class.nodes {
+        apply_subst(eg, class_id, target, value_id, body_node)
+      }
+  }
+}
+
+///|
+fn modify_node(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  class_id : @egraph.Id,
+  node : AlphaLang,
+) -> Unit {
+  match node {
+    AApp(func_id, arg_id) => apply_beta_from_app(eg, class_id, func_id, arg_id)
+    ASubst(target, value_id, body_id) =>
+      apply_subst_from_node(eg, class_id, target, value_id, body_id)
+    _ => ()
+  }
+}
+
+///|
+fn eval_analysis() -> @egraph.Analysis[AlphaLang, EvalState] {
+  {
+    make: fn(node, get_data) {
+      {
+        val: make_const_value(node, get_data),
+        has_incomplete: has_incomplete_node(node, get_data),
+      }
+    },
+    merge: fn(left, right) {
+      let val = merge_const(left.val, right.val)
+      let has_incomplete = left.has_incomplete || right.has_incomplete
+      let result : EvalState = { val, has_incomplete }
+      (
+        result,
+        {
+          a_changed: left.val != val || left.has_incomplete != has_incomplete,
+          b_changed: right.val != val || right.has_incomplete != has_incomplete,
+        },
+      )
+    },
+    modify: fn(eg, id) {
+      match eg.get_data(id).val {
+        Known(value) => union_node(eg, id, AInt(value))
+        Unknown | Conflict => ()
+      }
+      let class_id = eg.find(id)
+      match eg.egraph.classes.get(class_id) {
+        None => ()
+        Some(class) =>
+          for node in class.nodes {
+            modify_node(eg, class_id, node)
+          }
+      }
+    },
+  }
+}

--- a/lang/lambda/alpha_egraph_adapter/convert.mbt
+++ b/lang/lambda/alpha_egraph_adapter/convert.mbt
@@ -1,0 +1,156 @@
+///|
+fn alpha_term_add(
+  eg : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  term : @alpha.AlphaTerm,
+) -> @egraph.Id {
+  match term {
+    Int(value) => eg.add(AInt(value))
+    Unit => eg.add(AUnit)
+    Var(alpha_ref) => eg.add(AVar(alpha_ref))
+    Lam(binder, body) => {
+      let body_id = alpha_term_add(eg, body)
+      eg.add(ALam(binder, body_id))
+    }
+    App(func, arg) => {
+      let func_id = alpha_term_add(eg, func)
+      let arg_id = alpha_term_add(eg, arg)
+      eg.add(AApp(func_id, arg_id))
+    }
+    Bop(op, lhs, rhs) => {
+      let lhs_id = alpha_term_add(eg, lhs)
+      let rhs_id = alpha_term_add(eg, rhs)
+      eg.add(ABop(op, lhs_id, rhs_id))
+    }
+    If(cond, then_, else_) => {
+      let cond_id = alpha_term_add(eg, cond)
+      let then_id = alpha_term_add(eg, then_)
+      let else_id = alpha_term_add(eg, else_)
+      eg.add(AIf(cond_id, then_id, else_id))
+    }
+    LetDef(binder, init) => {
+      let init_id = alpha_term_add(eg, init)
+      eg.add(ALetDef(binder, init_id))
+    }
+    Module(defs, body) => {
+      let def_ids = defs.map(fn(def) {
+        let (binder, init) = def
+        (binder, alpha_term_add(eg, init))
+      })
+      let body_id = alpha_term_add(eg, body)
+      eg.add(AModule(def_ids, body_id))
+    }
+    Error(message) => eg.add(AError(message))
+    Hole(index) => eg.add(AHole(index))
+  }
+}
+
+///|
+fn substitute_alpha(
+  term : @alpha.AlphaTerm,
+  target : @alpha.BinderId,
+  replacement : @alpha.AlphaTerm,
+) -> @alpha.AlphaTerm {
+  match term {
+    Var(Bound(id)) => if id == target { replacement } else { term }
+    Var(Free(_)) => term
+    Lam(binder, body) =>
+      if binder.id == target {
+        term
+      } else {
+        @alpha.AlphaTerm::Lam(
+          binder,
+          substitute_alpha(body, target, replacement),
+        )
+      }
+    App(func, arg) =>
+      @alpha.AlphaTerm::App(
+        substitute_alpha(func, target, replacement),
+        substitute_alpha(arg, target, replacement),
+      )
+    Bop(op, lhs, rhs) =>
+      @alpha.AlphaTerm::Bop(
+        op,
+        substitute_alpha(lhs, target, replacement),
+        substitute_alpha(rhs, target, replacement),
+      )
+    If(cond, then_, else_) =>
+      @alpha.AlphaTerm::If(
+        substitute_alpha(cond, target, replacement),
+        substitute_alpha(then_, target, replacement),
+        substitute_alpha(else_, target, replacement),
+      )
+    LetDef(binder, init) =>
+      @alpha.AlphaTerm::LetDef(
+        binder,
+        substitute_alpha(init, target, replacement),
+      )
+    Module(defs, body) =>
+      substitute_alpha_module(defs, body, target, replacement)
+    Int(_) | Unit | Error(_) | Hole(_) => term
+  }
+}
+
+///|
+fn substitute_alpha_module(
+  defs : Array[(@alpha.Binder, @alpha.AlphaTerm)],
+  body : @alpha.AlphaTerm,
+  target : @alpha.BinderId,
+  replacement : @alpha.AlphaTerm,
+) -> @alpha.AlphaTerm {
+  let substituted_defs : Array[(@alpha.Binder, @alpha.AlphaTerm)] = []
+  let body_visible = for def in defs; target_visible = true {
+    let (binder, init) = def
+    let substituted_init = if target_visible {
+      substitute_alpha(init, target, replacement)
+    } else {
+      init
+    }
+    substituted_defs.push((binder, substituted_init))
+    continue target_visible && binder.id != target
+  } nobreak {
+    target_visible
+  }
+  let substituted_body = if body_visible {
+    substitute_alpha(body, target, replacement)
+  } else {
+    body
+  }
+  @alpha.AlphaTerm::Module(substituted_defs, substituted_body)
+}
+
+///|
+fn rec_expr_to_alpha(rec : @egraph.RecExpr[AlphaLang]) -> @alpha.AlphaTerm {
+  let nodes = rec.nodes
+  let terms : Array[@alpha.AlphaTerm] = []
+  for node in nodes {
+    let term = match node {
+      AInt(value) => @alpha.AlphaTerm::Int(value)
+      AUnit => @alpha.AlphaTerm::Unit
+      AVar(alpha_ref) => @alpha.AlphaTerm::Var(alpha_ref)
+      ALam(binder, body) => @alpha.AlphaTerm::Lam(binder, terms[body.0])
+      AApp(func, arg) => @alpha.AlphaTerm::App(terms[func.0], terms[arg.0])
+      ABop(op, lhs, rhs) =>
+        @alpha.AlphaTerm::Bop(op, terms[lhs.0], terms[rhs.0])
+      AIf(cond, then_, else_) =>
+        @alpha.AlphaTerm::If(terms[cond.0], terms[then_.0], terms[else_.0])
+      ALetDef(binder, init) => @alpha.AlphaTerm::LetDef(binder, terms[init.0])
+      AModule(defs, body) =>
+        @alpha.AlphaTerm::Module(
+          defs.map(fn(def) {
+            let (binder, init) = def
+            (binder, terms[init.0])
+          }),
+          terms[body.0],
+        )
+      AError(message) => @alpha.AlphaTerm::Error(message)
+      AHole(index) => @alpha.AlphaTerm::Hole(index)
+      ASubst(target, value, body) =>
+        substitute_alpha(terms[body.0], target, terms[value.0])
+    }
+    terms.push(term)
+  }
+  match terms {
+    [.., root] => root
+    [] => abort("empty extracted alpha expression")
+  }
+}

--- a/lang/lambda/alpha_egraph_adapter/lang.mbt
+++ b/lang/lambda/alpha_egraph_adapter/lang.mbt
@@ -1,0 +1,255 @@
+///|
+// Private e-node language for the Canopy Lambda alpha adapter.
+//
+// This is not a generic `dowdiness/egraph` language: it embeds Canopy's
+// `@alpha.Binder`, `@alpha.AlphaRef`, and named-source reification policy so the
+// shared egraph engine can optimize Lambda terms without owning Canopy-specific
+// scope or projection dependencies.
+priv enum AlphaLang {
+  AInt(Int)
+  AUnit
+  AVar(@alpha.AlphaRef)
+  ALam(@alpha.Binder, @egraph.Id)
+  AApp(@egraph.Id, @egraph.Id)
+  ABop(@ast.Bop, @egraph.Id, @egraph.Id)
+  AIf(@egraph.Id, @egraph.Id, @egraph.Id)
+  ALetDef(@alpha.Binder, @egraph.Id)
+  AModule(Array[(@alpha.Binder, @egraph.Id)], @egraph.Id)
+  AError(String)
+  AHole(Int)
+  ASubst(@alpha.BinderId, @egraph.Id, @egraph.Id)
+} derive(Eq)
+
+///|
+fn hash_bop_index(op : @ast.Bop) -> Int {
+  match op {
+    Plus => 0
+    Minus => 1
+  }
+}
+
+///|
+fn hash_origin(origin : @alpha.BinderOrigin, hasher : Hasher) -> Unit {
+  match origin {
+    SourceDecl(node_id~, hint~) => {
+      hasher.combine_int(0)
+      hasher.combine_int(node_id.0)
+      hasher.combine_string(hint)
+    }
+    Generated(salt) => {
+      hasher.combine_int(1)
+      hasher.combine_int(salt)
+    }
+  }
+}
+
+///|
+fn hash_binder(binder : @alpha.Binder, hasher : Hasher) -> Unit {
+  binder.id.hash_combine(hasher)
+  hasher.combine_string(binder.hint)
+  hash_origin(binder.origin, hasher)
+}
+
+///|
+fn hash_free_origin(origin : @alpha.FreeOrigin, hasher : Hasher) -> Unit {
+  match origin {
+    SourceVar => hasher.combine_int(0)
+    SourceUnbound => hasher.combine_int(1)
+    GeneratedFree => hasher.combine_int(2)
+  }
+}
+
+///|
+fn hash_free_name(free : @alpha.FreeName, hasher : Hasher) -> Unit {
+  hasher.combine_string(free.name)
+  hash_free_origin(free.origin, hasher)
+}
+
+///|
+fn hash_ref(alpha_ref : @alpha.AlphaRef, hasher : Hasher) -> Unit {
+  match alpha_ref {
+    Bound(id) => {
+      hasher.combine_int(0)
+      id.hash_combine(hasher)
+    }
+    Free(free) => {
+      hasher.combine_int(1)
+      hash_free_name(free, hasher)
+    }
+  }
+}
+
+///|
+impl Hash for AlphaLang with fn hash_combine(self, hasher) {
+  match self {
+    AInt(value) => {
+      hasher.combine_int(0)
+      hasher.combine_int(value)
+    }
+    AUnit => hasher.combine_int(1)
+    AVar(alpha_ref) => {
+      hasher.combine_int(2)
+      hash_ref(alpha_ref, hasher)
+    }
+    ALam(binder, body) => {
+      hasher.combine_int(3)
+      hash_binder(binder, hasher)
+      body.hash_combine(hasher)
+    }
+    AApp(func, arg) => {
+      hasher.combine_int(4)
+      func.hash_combine(hasher)
+      arg.hash_combine(hasher)
+    }
+    ABop(op, lhs, rhs) => {
+      hasher.combine_int(5)
+      hasher.combine_int(hash_bop_index(op))
+      lhs.hash_combine(hasher)
+      rhs.hash_combine(hasher)
+    }
+    AIf(cond, then_, else_) => {
+      hasher.combine_int(6)
+      cond.hash_combine(hasher)
+      then_.hash_combine(hasher)
+      else_.hash_combine(hasher)
+    }
+    ALetDef(binder, init) => {
+      hasher.combine_int(7)
+      hash_binder(binder, hasher)
+      init.hash_combine(hasher)
+    }
+    AModule(defs, body) => {
+      hasher.combine_int(8)
+      hasher.combine_int(defs.length())
+      defs
+      .iter()
+      .each(fn(def) {
+        let (binder, init) = def
+        hash_binder(binder, hasher)
+        init.hash_combine(hasher)
+      })
+      body.hash_combine(hasher)
+    }
+    AError(message) => {
+      hasher.combine_int(9)
+      hasher.combine_string(message)
+    }
+    AHole(index) => {
+      hasher.combine_int(10)
+      hasher.combine_int(index)
+    }
+    ASubst(target, value, body) => {
+      hasher.combine_int(11)
+      target.hash_combine(hasher)
+      value.hash_combine(hasher)
+      body.hash_combine(hasher)
+    }
+  }
+}
+
+///|
+impl @egraph.ENode for AlphaLang with fn arity(self) {
+  match self {
+    AInt(_) | AUnit | AVar(_) | AError(_) | AHole(_) => 0
+    ALam(_, _) | ALetDef(_, _) => 1
+    AApp(_, _) | ABop(_, _, _) | ASubst(_, _, _) => 2
+    AIf(_, _, _) => 3
+    AModule(defs, _) => defs.length() + 1
+  }
+}
+
+///|
+impl @egraph.ENode for AlphaLang with fn child(self, i) {
+  match self {
+    ALam(_, body) | ALetDef(_, body) => body
+    AApp(func, arg) | ABop(_, func, arg) | ASubst(_, func, arg) =>
+      if i == 0 {
+        func
+      } else {
+        arg
+      }
+    AIf(cond, then_, else_) =>
+      if i == 0 {
+        cond
+      } else if i == 1 {
+        then_
+      } else {
+        else_
+      }
+    AModule(defs, body) => if i < defs.length() { defs[i].1 } else { body }
+    AInt(_) | AUnit | AVar(_) | AError(_) | AHole(_) => abort("no children")
+  }
+}
+
+///|
+impl @egraph.ENode for AlphaLang with fn map_children(self, f) {
+  match self {
+    AInt(_) | AUnit | AVar(_) | AError(_) | AHole(_) => self
+    ALam(binder, body) => ALam(binder, f(body))
+    AApp(func, arg) => AApp(f(func), f(arg))
+    ABop(op, lhs, rhs) => ABop(op, f(lhs), f(rhs))
+    AIf(cond, then_, else_) => AIf(f(cond), f(then_), f(else_))
+    ALetDef(binder, init) => ALetDef(binder, f(init))
+    AModule(defs, body) =>
+      AModule(
+        defs.map(fn(def) {
+          let (binder, init) = def
+          (binder, f(init))
+        }),
+        f(body),
+      )
+    ASubst(target, value, body) => ASubst(target, f(value), f(body))
+  }
+}
+
+///|
+impl @egraph.ENodeRepr for AlphaLang with fn op_tag(self) {
+  match self {
+    AInt(_) => "Num"
+    AUnit => "Unit"
+    AVar(_) => "Var"
+    ALam(_, _) => "Lam"
+    AApp(_, _) => "App"
+    ABop(Plus, _, _) => "Add"
+    ABop(Minus, _, _) => "Minus"
+    AIf(_, _, _) => "If"
+    ALetDef(_, _) => "LetDef"
+    AModule(_, _) => "Module"
+    AError(_) => "Error"
+    AHole(_) => "Hole"
+    ASubst(_, _, _) => "Subst"
+  }
+}
+
+///|
+impl @egraph.ENodeRepr for AlphaLang with fn payload(self) {
+  match self {
+    AInt(value) => Some(value.to_string())
+    AVar(Free(free)) => Some(free.name)
+    AVar(Bound(id)) => Some(id.0.to_string())
+    ALam(binder, _) | ALetDef(binder, _) => Some(binder.hint)
+    AError(message) => Some(message)
+    AHole(index) => Some(index.to_string())
+    AUnit
+    | AApp(_, _)
+    | ABop(_, _, _)
+    | AIf(_, _, _)
+    | AModule(_, _)
+    | ASubst(_, _, _) => None
+  }
+}
+
+///|
+impl @egraph.ENodeRepr for AlphaLang with fn from_op(tag, payload, children) {
+  match (tag, payload, children) {
+    ("Num", Some(s), []) => Some(AInt(@string.parse_int(s))) catch { _ => None }
+    ("Unit", None, []) => Some(AUnit)
+    ("Var", Some(name), []) =>
+      Some(AVar(Free({ name, origin: @alpha.FreeOrigin::GeneratedFree })))
+    ("Add", None, [lhs, rhs]) => Some(ABop(Plus, lhs, rhs))
+    ("Minus", None, [lhs, rhs]) => Some(ABop(Minus, lhs, rhs))
+    ("App", None, [func, arg]) => Some(AApp(func, arg))
+    ("If", None, [cond, then_, else_]) => Some(AIf(cond, then_, else_))
+    _ => None
+  }
+}

--- a/lang/lambda/alpha_egraph_adapter/moon.pkg
+++ b/lang/lambda/alpha_egraph_adapter/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/alpha",
+  "dowdiness/canopy/lang/lambda/scope",
+  "dowdiness/egraph",
+  "dowdiness/lambda/ast",
+  "moonbitlang/core/string",
+}
+
+import {
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+} for "wbtest"

--- a/lang/lambda/alpha_egraph_adapter/optimize.mbt
+++ b/lang/lambda/alpha_egraph_adapter/optimize.mbt
@@ -1,0 +1,51 @@
+///|
+// `@egraph.Runner` currently owns a plain `EGraph`; this adapter needs
+// `AnalyzedEGraph` so beta and constant-folding hooks run during rebuild.
+fn run_saturation(
+  analyzed : @egraph.AnalyzedEGraph[AlphaLang, EvalState],
+  rules : Array[@egraph.Rewrite],
+) -> Unit {
+  let node_limit = 5000
+  let iter_limit = 30
+  for _ in 0..<iter_limit {
+    let applied = rules.fold(init=0, fn(count, rule) {
+      count + analyzed.egraph.apply_rewrite(rule)
+    })
+    analyzed.rebuild()
+    if applied == 0 || analyzed.size() > node_limit {
+      break
+    }
+  }
+}
+
+///|
+/// Optimize an alpha-safe Lambda term through the shared `dowdiness/egraph`
+/// engine.
+///
+/// This package is the Canopy-specific adapter layer: it depends on
+/// `lang/lambda/alpha` and keeps binders as `BinderId`-backed alpha references
+/// during saturation, while the egraph package remains a generic engine. The
+/// named `@ast.Term` boundary is handled by `optimize_projected`, which lowers
+/// through `ScopeGraph` before calling this function and reifies only after
+/// extraction.
+pub fn optimize_alpha(term : @alpha.AlphaTerm) -> @alpha.AlphaTerm {
+  let analyzed = @egraph.AnalyzedEGraph::AnalyzedEGraph(eval_analysis())
+  let root = alpha_term_add(analyzed, term)
+  analyzed.rebuild()
+  run_saturation(analyzed, safe_rules())
+  let (_, rec) = analyzed.extract(root, @egraph.ast_size())
+  rec_expr_to_alpha(rec)
+}
+
+///|
+/// Lower a projected Lambda root through Canopy's `ScopeGraph`, optimize the
+/// alpha term with the shared egraph engine, then reify to the named AST
+/// boundary. Parser/projection helpers should stay at test or caller boundaries;
+/// this production path accepts already-projected source plus its scope graph.
+pub fn optimize_projected(
+  root : @core.ProjNode[@ast.Term],
+  graph : @scope.ScopeGraph,
+  policy? : @alpha.ReifyPolicy = Source,
+) -> @ast.Term {
+  @alpha.reify(optimize_alpha(@alpha.lower_root(root, graph)), policy)
+}

--- a/lang/lambda/alpha_egraph_adapter/optimize_wbtest.mbt
+++ b/lang/lambda/alpha_egraph_adapter/optimize_wbtest.mbt
@@ -1,0 +1,100 @@
+///|
+fn graph_for_root(root : @core.ProjNode[@ast.Term]) -> @scope.ScopeGraph {
+  let source_map = @core.SourceMap::from_ast(root)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
+  @core.collect_registry(root, registry)
+  @scope.build(registry, source_map)
+}
+
+///|
+fn parse_fixture(
+  text : String,
+) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph) raise {
+  let (proj, errors) = @lambda_proj.parse_to_proj_node(text)
+  if errors.length() > 0 {
+    fail("parse diagnostics in alpha-egraph fixture")
+  }
+  (proj, graph_for_root(proj))
+}
+
+///|
+fn generated_binder(id : Int, hint : String) -> @alpha.Binder {
+  { id: @alpha.BinderId(id), hint, origin: @alpha.BinderOrigin::Generated(id) }
+}
+
+///|
+fn source_free(name : String) -> @alpha.AlphaTerm {
+  @alpha.AlphaTerm::Var(Free({ name, origin: @alpha.FreeOrigin::SourceVar }))
+}
+
+///|
+test "alpha egraph: canonical capture fixture stays capture-free" {
+  let (proj, graph) = parse_fixture("((x) => (y) => x) y")
+  let optimized = optimize_alpha(@alpha.lower_root(proj, graph))
+  let expected = @alpha.AlphaTerm::Lam(
+    generated_binder(99, "y1"),
+    source_free("y"),
+  )
+  assert_true(@alpha.alpha_key(optimized) == @alpha.alpha_key(expected))
+  guard @alpha.reify(optimized, Source)
+    is @ast.Term::Lam(param, @ast.Term::Var(body)) else {
+    fail("expected reified lambda")
+  }
+  inspect(param, content="y1")
+  inspect(body, content="y")
+}
+
+///|
+test "alpha egraph: projected boundary lowers through scope and reifies" {
+  let (proj, graph) = parse_fixture("((x) => (y) => x) y")
+  guard optimize_projected(proj, graph)
+    is @ast.Term::Lam(param, @ast.Term::Var(body)) else {
+    fail("expected projected optimizer to reify lambda")
+  }
+  inspect(param, content="y1")
+  inspect(body, content="y")
+}
+
+///|
+test "alpha egraph: arithmetic rules and folding reuse egraph extraction" {
+  let (proj, graph) = parse_fixture("((n) => n + 0) (1 + 2)")
+  let optimized = optimize_alpha(@alpha.lower_root(proj, graph))
+  inspect(@alpha.reify(optimized, Source), content="Int(3)")
+}
+
+///|
+test "alpha egraph: duplicated beta argument extracts without residual subst" {
+  let (proj, graph) = parse_fixture("((n) => n + n) (1 + 2)")
+  let optimized = optimize_alpha(@alpha.lower_root(proj, graph))
+  inspect(@alpha.reify(optimized, Source), content="Int(6)")
+}
+
+///|
+test "alpha egraph: untyped arithmetic identity does not erase lambda" {
+  let (proj, graph) = parse_fixture("((x) => x) + 0")
+  guard optimize_projected(proj, graph)
+    is @ast.Term::Bop(Plus, @ast.Term::Lam(_, _), @ast.Term::Int(0)) else {
+    fail("expected non-numeric arithmetic operand to remain stuck")
+  }
+}
+
+///|
+test "alpha egraph: beta does not erase hole arguments" {
+  let (proj, graph) = parse_fixture("((x) => 1) _")
+  guard optimize_projected(proj, graph)
+    is @ast.Term::App(@ast.Term::Lam(_, @ast.Term::Int(1)), @ast.Term::Hole(_)) else {
+    fail("expected beta to preserve incomplete argument")
+  }
+}
+
+///|
+test "alpha egraph: beta does not erase error arguments" {
+  let term = @alpha.AlphaTerm::App(
+    @alpha.AlphaTerm::Lam(generated_binder(1, "x"), @alpha.AlphaTerm::Int(1)),
+    @alpha.AlphaTerm::Error("bad argument"),
+  )
+  guard optimize_alpha(term)
+    is @alpha.AlphaTerm::App(_, @alpha.AlphaTerm::Error(_)) else {
+    fail("expected beta to preserve error argument")
+  }
+}

--- a/lang/lambda/alpha_egraph_adapter/pkg.generated.mbti
+++ b/lang/lambda/alpha_egraph_adapter/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/lambda/alpha_egraph_adapter"
+
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/alpha",
+  "dowdiness/canopy/lang/lambda/scope",
+  "dowdiness/lambda/ast",
+}
+
+// Values
+pub fn optimize_alpha(@alpha.AlphaTerm) -> @alpha.AlphaTerm
+
+pub fn optimize_projected(@core.ProjNode[@ast.Term], @scope.ScopeGraph, policy? : @alpha.ReifyPolicy) -> @ast.Term
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/lang/lambda/alpha_egraph_adapter/rules.mbt
+++ b/lang/lambda/alpha_egraph_adapter/rules.mbt
@@ -1,0 +1,9 @@
+///|
+// Do not install untyped arithmetic identity rewrites such as `?x + 0 => ?x`.
+// `optimize_projected` accepts arbitrary projected Lambda terms, so `?x` may be
+// a lambda, unit, hole, or other non-numeric term that the evaluator would leave
+// stuck/type-erroneous. Constant folding remains analysis-driven and only unions
+// with integer literals when the e-class data proves a concrete integer value.
+fn safe_rules() -> Array[@egraph.Rewrite] {
+  []
+}


### PR DESCRIPTION
## Summary

- Add `lang/lambda/alpha_egraph_adapter`, a Canopy-side adapter from `AlphaTerm` into the existing `dowdiness/egraph` stack.
- Keep `@ast.Term + ScopeGraph` as the source/projection boundary via `optimize_projected`, lowering to alpha terms before saturation and reifying only after extraction.
- Document the package boundary: Lambda/scope/projection-specific code stays in Canopy; generic egraph improvements still belong in `dowdiness/egraph`.
- Cover the canonical capture fixture `((x) => (y) => x) y`, arithmetic/beta folding, and residual substitution extraction.

Closes #679.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `lower_root` / `reify` / `alpha_key` | `lang/lambda/alpha` | Yes | Adapter boundary lowers/reifies through the alpha core and uses alpha keys in tests. |
| `ScopeGraph` | `lang/lambda/scope` | Yes | `optimize_projected` accepts the existing scope graph rather than reparsing or rebuilding name resolution. |
| `AnalyzedEGraph`, `Analysis`, `Rewrite`, `extract`, `ast_size` | `dowdiness/egraph` | Yes | Reuses the existing egraph engine for saturation, analysis hooks, rewrites, and extraction. |
| `Runner` | `dowdiness/egraph` | No | Current `Runner` owns plain `EGraph`; this adapter needs `AnalyzedEGraph` rebuild hooks for beta/constant-folding analysis. |
| `loom/egraph/examples/lambda-opt` | `loom/egraph/examples/lambda-opt` | Reference only | It is string/name-based (`LVar(String)`, `LLam(String, ...)`, `LSubst(String, ...)`) and unsafe as the alpha-safe substitution substrate. |

New helpers added (if any):

- Private `AlphaLang` e-node language: represents alpha terms in `dowdiness/egraph` without raw binder strings as substitution identity.
- Private analysis/substitution helpers in `analysis.mbt`: implement beta and constant-folding hooks over `AnalyzedEGraph`.
- Private conversion helpers in `convert.mbt`: translate `AlphaTerm <-> AlphaLang` and resolve residual explicit substitutions after extraction; needed because the alpha package's substitution helper is private.
- `README.mbt.md`: records why this adapter remains in Canopy instead of the generic egraph package.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`) — not web-affecting

## Validation

```bash
moon fmt lang/lambda/alpha_egraph_adapter
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
```

Also run:

```bash
moon check lang/lambda/alpha_egraph_adapter --deny-warn
moon test lang/lambda/alpha_egraph_adapter
moon info lang/lambda/alpha_egraph_adapter
moon check --deny-warn
moon test
make check
make test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lambda expression optimization using e-graph rewriting with constant propagation.
  * Enabled optimization of standalone Lambda terms and scope-aware optimization within larger codebases.
  * Introduced arithmetic simplification rules including zero elimination and constant folding.

* **Documentation**
  * Added comprehensive adapter documentation describing architecture and implementation boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->