### PR TITLE
Refine lambda analysis projection seam

### DIFF
--- a/docs/design/analysis-query-layer.md
+++ b/docs/design/analysis-query-layer.md
@@ -238,10 +238,18 @@ Route existing language facts through a small internal aggregator:
 - semantic annotations already produced by language packages;
 - diagnostics.
 
-First implementation slice: lambda-local `analysis_projection` helpers compose
+First implementation slice: a lambda-local `AnalysisProjection` object composes
 existing semantic/eval projected outputs with snapshot-bound structural pattern
 facts for decorations and annotations. Diagnostics remain on their existing FFI
 path until a larger diagnostic fact shape is justified.
+
+JSON was checked as the first cross-language generalization candidate. It only
+has the structural projection stack plus parser diagnostics routed through the
+generic editor view/update surfaces; it has no semantic annotations, language
+decorations, evaluation facts, or snapshot-bound external facts to compose. A
+JSON-local aggregator would therefore be a no-op wrapper, so the common
+`AnalysisProjection` API remains deferred until a second language has multiple
+real projected analysis inputs.
 
 The goal is to learn the shape of the common fact model from real in-process
 analyses before committing to a broad provider abstraction.

--- a/docs/plans/2026-06-18-analysis-query-phase2-aggregator.md
+++ b/docs/plans/2026-06-18-analysis-query-phase2-aggregator.md
@@ -51,10 +51,11 @@ Out:
   boundary.
 - `analysis/render.mbt` projects pattern facts to existing
   `@protocol.Decoration` values and match-list entries.
-- `lang/lambda/companion/lambda_editor.mbt` currently merges semantic
-  decorations and ast-grep decorations in the `get_decorations` capability
-  closure. It separately merges evaluation and semantic annotations in
-  `get_annotations`.
+- `lang/lambda/companion/analysis_projection.mbt` owns the lambda-local
+  aggregation seam. Its private `AnalysisProjection` object stores
+  snapshot-bound pattern facts and composes them with semantic decorations,
+  semantic annotations, and eval annotations before they reach the existing
+  capability closures.
 - `ffi/lambda/diagnostics.mbt` assembles parse/type/eval diagnostics separately
   from the decoration/annotation path.
 - `editor/capabilities.mbt` and `editor/view_updater.mbt` already provide the
@@ -100,15 +101,15 @@ without changing the public protocol:
 
 ## Acceptance Criteria
 
-- [ ] Lambda analysis projection composition has one named seam rather than
+- [x] Lambda analysis projection composition has one named seam rather than
       duplicated ad-hoc merging in capability closures.
-- [ ] Existing semantic/eval decorations and annotations behave as before.
-- [ ] Existing ast-grep decorations remain snapshot-bound and stale-safe.
-- [ ] No new public protocol variant is introduced.
-- [ ] Tests cover combined semantic + pattern decorations and stale external
+- [x] Existing semantic/eval decorations and annotations behave as before.
+- [x] Existing ast-grep decorations remain snapshot-bound and stale-safe.
+- [x] No new public protocol variant is introduced.
+- [x] Tests cover combined semantic + pattern decorations and stale external
       facts.
-- [ ] `docs/design/analysis-query-layer.md` reflects the implemented Phase 2
-      slice and any deferred diagnostics work.
+- [x] `docs/design/analysis-query-layer.md` reflects the implemented Phase 2
+      slice and deferred diagnostics work.
 
 ## Validation
 
@@ -140,5 +141,15 @@ API widening.
   `@analysis.facts_to_match_list`,
   `@lambda_semantic.build_semantic_projection`, `build_eval_annotations`,
   `@editor.LanguageCapabilities`, and `@editor.compute_view_patches`.
+- JSON generalization checkpoint (2026-06-18): `lang/json/companion` only
+  constructs a default-capability `LanguageSpec` around
+  `build_json_projection_memos`; `lang/json/proj` builds the structural
+  `ProjNode`/registry/source-map stack; `ffi/json` exposes parser diagnostics
+  and generic view patches through `@editor.compute_view_patches`. JSON does not
+  currently have semantic annotations, language decorations, evaluation facts,
+  or snapshot-bound external facts to compose, so a JSON-local aggregator would
+  be a no-op wrapper around existing protocol surfaces. Keep the Phase 2 seam
+  lambda-local and defer shared `AnalysisProjection` promotion until a second
+  language has at least two real projected analysis inputs to merge.
 - Phase 2 should make Phase 3 easier by clarifying the projection boundary, not
   by designing the `moon ide` provider itself.

--- a/lang/lambda/companion/analysis_projection.mbt
+++ b/lang/lambda/companion/analysis_projection.mbt
@@ -5,48 +5,57 @@
 // public fact protocol or a broad provider abstraction.
 
 ///|
-fn analysis_projection_set_pattern_analysis(
-  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
-  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
-  facts : Array[@facts.PatternMatchFact],
-  snapshot : @facts.SourceSnapshot,
-) -> Unit {
-  pattern_facts_ref.val = Some(facts)
-  pattern_snapshot_ref.val = Some(snapshot)
+priv struct SnapshotPatternAnalysis {
+  facts : Array[@facts.PatternMatchFact]
+  snapshot : @facts.SourceSnapshot
 }
 
 ///|
-fn analysis_projection_clear_stale_pattern_analysis(
-  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
-  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
+priv struct AnalysisProjection {
+  pattern_analysis_ref : Ref[SnapshotPatternAnalysis?]
+}
+
+///|
+fn AnalysisProjection::new() -> AnalysisProjection {
+  { pattern_analysis_ref: Ref(None) }
+}
+
+///|
+fn AnalysisProjection::set_pattern_analysis(
+  self : AnalysisProjection,
+  facts : Array[@facts.PatternMatchFact],
+  snapshot : @facts.SourceSnapshot,
+) -> Unit {
+  self.pattern_analysis_ref.val = Some({ facts, snapshot })
+}
+
+///|
+fn AnalysisProjection::clear_stale_pattern_analysis(
+  self : AnalysisProjection,
   current : @facts.SourceSnapshot,
 ) -> Unit {
-  match pattern_snapshot_ref.val {
-    Some(snapshot) if snapshot.matches(current) => ()
-    _ => {
-      pattern_facts_ref.val = None
-      pattern_snapshot_ref.val = None
-    }
+  match self.pattern_analysis_ref.val {
+    Some(analysis) if analysis.snapshot.matches(current) => ()
+    _ => self.pattern_analysis_ref.val = None
   }
 }
 
 ///|
-fn analysis_projection_decorations(
-  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
-  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
+fn AnalysisProjection::decorations(
+  self : AnalysisProjection,
   semantic_decorations : Array[@protocol.Decoration],
 ) -> Array[@protocol.Decoration] {
-  let pattern_decorations = match
-    (pattern_facts_ref.val, pattern_snapshot_ref.val) {
-    (Some(facts), Some(snapshot)) =>
-      @analysis.facts_to_decorations(facts, snapshot)
-    _ => []
+  let pattern_decorations = match self.pattern_analysis_ref.val {
+    Some(analysis) =>
+      @analysis.facts_to_decorations(analysis.facts, analysis.snapshot)
+    None => []
   }
   semantic_decorations + pattern_decorations
 }
 
 ///|
-fn analysis_projection_annotations(
+fn AnalysisProjection::annotations(
+  _self : AnalysisProjection,
   eval_annotations : Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
   semantic_projection : @lambda_semantic.SemanticProjection?,
 ) -> Map[@core.NodeId, Array[@protocol.ViewAnnotation]] {

--- a/lang/lambda/companion/editor_view_decorations_test.mbt
+++ b/lang/lambda/companion/editor_view_decorations_test.mbt
@@ -115,3 +115,56 @@ test "analysis projection combines semantic and pattern decorations" {
     })
   assert_true(has_combined_decorations)
 }
+
+///|
+test "analysis projection drops stale pattern decorations but keeps semantic decorations" {
+  let (editor, companion) = new_lambda_editor(
+    "test-analysis-stale-keeps-semantic",
+  )
+  editor.set_text("(x) => x")
+  let source = editor.get_text()
+  let stale_snapshot = @facts.SourceSnapshot::SourceSnapshot(
+    doc_id="test-analysis-stale-keeps-semantic",
+    version=0,
+    source~,
+  )
+  companion.set_pattern_analysis(
+    @analysis.from_ast_grep_matches(
+      [
+        @analysis.AstGrepMatch::AstGrepMatch(
+          byte_start=0,
+          byte_end=1,
+          pattern_id="fn-def",
+        ),
+      ],
+      source,
+      stale_snapshot,
+    ),
+    stale_snapshot,
+  )
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(state, editor)
+  editor.set_text("(x) => x ")
+  let current_source = editor.get_text()
+  companion.clear_stale_pattern_analysis(
+    @facts.SourceSnapshot::SourceSnapshot(
+      doc_id="test-analysis-stale-keeps-semantic",
+      version=0,
+      source=current_source,
+    ),
+  )
+  let patches = @editor.compute_view_patches(state, editor)
+  let has_semantic_without_pattern = patches
+    .iter()
+    .any(fn(p) {
+      match p {
+        @protocol.ViewPatch::SetDecorations(decorations~) =>
+          decorations.iter().any(fn(d) { d.css_class == "semantic-binder" }) &&
+          !decorations
+          .iter()
+          .any(fn(d) { d.css_class == "analysis-match pattern-fn-def" })
+        _ => false
+      }
+    })
+  assert_true(has_semantic_without_pattern)
+}

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -10,8 +10,7 @@ pub struct LambdaCompanion {
   // Falls back to Tier 1 results when no definitions are Suppressed.
   priv escalation_memo : @incr.Derived[Array[@lambda_eval.EvalResult]]
   priv analysis : @parser.LambdaAnalysis
-  priv pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?]
-  priv pattern_snapshot_ref : Ref[@facts.SourceSnapshot?]
+  priv analysis_projection : AnalysisProjection
 }
 
 ///|
@@ -46,12 +45,7 @@ pub fn LambdaCompanion::set_pattern_analysis(
   facts : Array[@facts.PatternMatchFact],
   snapshot : @facts.SourceSnapshot,
 ) -> Unit {
-  analysis_projection_set_pattern_analysis(
-    self.pattern_facts_ref,
-    self.pattern_snapshot_ref,
-    facts,
-    snapshot,
-  )
+  self.analysis_projection.set_pattern_analysis(facts, snapshot)
 }
 
 ///|
@@ -60,11 +54,7 @@ pub fn LambdaCompanion::clear_stale_pattern_analysis(
   self : LambdaCompanion,
   current : @facts.SourceSnapshot,
 ) -> Unit {
-  analysis_projection_clear_stale_pattern_analysis(
-    self.pattern_facts_ref,
-    self.pattern_snapshot_ref,
-    current,
-  )
+  self.analysis_projection.clear_stale_pattern_analysis(current)
 }
 
 ///|
@@ -144,8 +134,7 @@ pub fn new_lambda_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
-  let pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?] = Ref(None)
-  let pattern_snapshot_ref : Ref[@facts.SourceSnapshot?] = Ref(None)
+  let analysis_projection = AnalysisProjection::new()
   // Ref side-channels let the build_memos callback publish companion memos
   // back out to the enclosing scope for companion construction + capabilities
   // wiring.
@@ -183,16 +172,14 @@ pub fn new_lambda_editor(
     capture_timeout_ms~,
     parent_runtime?,
     capabilities=build_lambda_capabilities(
-      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref, pattern_facts_ref,
-      pattern_snapshot_ref,
+      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref, analysis_projection,
     ),
     identity_hints=hints_ref,
   )
   let companion : LambdaCompanion = {
     escalation_memo: escalation_memo_ref.val.unwrap(),
     analysis: analysis_ref.val.unwrap(),
-    pattern_facts_ref,
-    pattern_snapshot_ref,
+    analysis_projection,
   }
   (editor, companion)
 }
@@ -203,8 +190,7 @@ fn build_lambda_capabilities(
   cached_proj_node_ref : Ref[@incr.Derived[@core.ProjNode[@ast.Term]?]?],
   source_map_memo_ref : Ref[@incr.Derived[@core.SourceMap]?],
   escalation_memo_ref : Ref[@incr.Derived[Array[@lambda_eval.EvalResult]]?],
-  pattern_facts_ref : Ref[Array[@facts.PatternMatchFact]?],
-  pattern_snapshot_ref : Ref[@facts.SourceSnapshot?],
+  analysis_projection : AnalysisProjection,
 ) -> @editor.LanguageCapabilities[@ast.Term] {
   @editor.LanguageCapabilities::new(
     get_annotations=Some(fn() {
@@ -227,7 +213,7 @@ fn build_lambda_capabilities(
           )
         _ => None
       }
-      analysis_projection_annotations(eval_annotations, semantic_projection)
+      analysis_projection.annotations(eval_annotations, semantic_projection)
     }),
     get_decorations=Some(fn() {
       let semantic_decorations = match
@@ -243,9 +229,7 @@ fn build_lambda_capabilities(
           }
         _ => []
       }
-      analysis_projection_decorations(
-        pattern_facts_ref, pattern_snapshot_ref, semantic_decorations,
-      )
+      analysis_projection.decorations(semantic_decorations)
     }),
     pretty_post_process=Some(fn(layout) {
       let eval_results = match escalation_memo_ref.val {


### PR DESCRIPTION
## Summary

- Wrap lambda-local pattern analysis state in a private `AnalysisProjection` object.
- Store snapshot-bound pattern facts atomically as `SnapshotPatternAnalysis`.
- Add regression coverage that stale pattern decorations are dropped without clearing in-process semantic decorations.
- Document the JSON generalization checkpoint and why shared `AnalysisProjection` promotion remains deferred.

## Reuse check

- Reused `SourceSnapshot::matches` for stale-result rejection.
- Reused `@analysis.facts_to_decorations` for external pattern fact rendering.
- Reused existing lambda semantic/eval projection builders and `@editor.LanguageCapabilities` / `@editor.compute_view_patches` protocol surfaces.
- Checked JSON companion/proj/FFI surfaces; JSON has no semantic annotations, language decorations, evaluation facts, or snapshot-bound external facts to compose, so no shared API was introduced.

## Validation

```bash
moon fmt lang/lambda/companion
moon info lang/lambda/companion ffi/lambda analysis lib/analysis
NEW_MOON_MOD=0 moon check lang/lambda/companion ffi/lambda analysis lib/analysis
NEW_MOON_MOD=0 moon test lang/lambda/companion ffi/lambda analysis lib/analysis
```

Targeted results: 145 tests passed.

## Notes

Unrelated dirty `loom` submodule state is intentionally not included in this PR.
