### PR TITLE
refactor(ideal): move NodeActionContext from child OverlayState to parent ActionOverlayHost

### DIFF
--- a/docs/plans/2026-06-18-ideal-overlay-architecture.md
+++ b/docs/plans/2026-06-18-ideal-overlay-architecture.md
@@ -1,0 +1,407 @@
+# Ideal Overlay Architecture Refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `NodeActionContext` from child `OverlayState` into parent `ActionOverlayHost` so the child signals intent only and the parent owns application context.
+
+**Architecture:** Remove `node_context : NodeActionContext?` from `OverlayState`; replace with `kind : @ast.Term`. Add `context : NodeActionContext?` to `ActionOverlayHost` (alongside `runtime`). Drop `context~` from `OverlayOutput::ExecuteAction` and read it from `model.overlay.context` in the parent handler. All 7 affected files change together — field removal cascades immediately.
+
+**Tech Stack:** MoonBit, Rabbita TEA framework. Working directory: `examples/ideal/main/`. Build: `NEW_MOON_MOD=0 moon check`, `NEW_MOON_MOD=0 moon test`, `NEW_MOON_MOD=0 moon info && NEW_MOON_MOD=0 moon fmt`.
+
+## Global Constraints
+
+- Prefix all moon commands with `NEW_MOON_MOD=0` to prevent auto-migration of `moon.mod.json`
+- Do not touch `action_overlay_exec.mbt` — `execute_action` receives context from its caller and needs no change
+- Do not change token mechanism, `OverlayEvent`/`OverlayMsg` separation, or cell structure
+- Worktree: `/home/antisatori/ghq/github.com/dowdiness/canopy-ideal-overlay`, branch `refactor/ideal-overlay-architecture`
+
+---
+
+### Task 1: Refactor overlay ownership boundary (all 7 files)
+
+All changes are cascade-coupled: removing `node_context` from `OverlayState` breaks callers in all other files simultaneously. Make all edits, then verify compile and tests pass as a unit.
+
+**Files:**
+- Modify: `examples/ideal/main/model.mbt:67-78`
+- Modify: `examples/ideal/main/action_overlay_runtime.mbt:1-20`
+- Modify: `examples/ideal/main/action_overlay_flow.mbt:13-22, 63-69, 267-295`
+- Modify: `examples/ideal/main/action_overlay_state.mbt:98-121`
+- Modify: `examples/ideal/main/action_overlay_update.mbt:47-54`
+- Modify: `examples/ideal/main/view_actions.mbt:186-191`
+- Modify: `examples/ideal/main/main_wbtest.mbt:29-43, 165-178`
+
+**Interfaces:**
+- Produces: `ActionOverlayHost::mount(context : NodeActionContext, runtime : ActionOverlayRuntime) -> ActionOverlayHost`
+- Produces: `OverlayState.kind : @ast.Term` (replaces `node_context : NodeActionContext?`)
+- Produces: `OverlayOutput::ExecuteAction(token~, action, choice~, name~)` (no context~)
+
+---
+
+- [ ] **Step 1: Edit `model.mbt` — replace `node_context` with `kind` in `OverlayState`**
+
+Replace lines 67–78:
+
+```moonbit
+///|
+struct OverlayState {
+  mode : OverlayMode
+  actions : Array[@lambda_edits.Action]
+  kind : @ast.Term
+  // The most recent failure to act. Overlay-wide, not prompt-specific: an
+  // action can fail to apply from MainMenu or Submenu just as from NamePrompt,
+  // so the error is rendered in the panel for any open mode (view_actions.mbt).
+  error : String
+  anchor_top : Int
+  anchor_left : Int
+  menu : @menu.Model
+}
+```
+
+---
+
+- [ ] **Step 2: Edit `action_overlay_runtime.mbt` — add `context` to `ActionOverlayHost`**
+
+Replace the struct definition and its three methods (`empty`, `mount`, `close`):
+
+```moonbit
+struct ActionOverlayHost {
+  runtime : ActionOverlayRuntime?
+  context : NodeActionContext?
+  next_token : Int
+}
+
+fn ActionOverlayHost::empty() -> ActionOverlayHost {
+  { runtime: None, context: None, next_token: 1 }
+}
+
+fn ActionOverlayHost::mount(
+  self : ActionOverlayHost,
+  context : NodeActionContext,
+  runtime : ActionOverlayRuntime,
+) -> ActionOverlayHost {
+  { runtime: Some(runtime), context: Some(context), next_token: self.next_token + 1 }
+}
+
+fn ActionOverlayHost::close(self : ActionOverlayHost) -> ActionOverlayHost {
+  { ..self, runtime: None, context: None }
+}
+```
+
+---
+
+- [ ] **Step 3: Edit `action_overlay_flow.mbt` — three changes**
+
+**3a. `OverlayOutput::ExecuteAction` — drop `context~` (lines 13–22):**
+
+```moonbit
+///|
+enum OverlayOutput {
+  ExecuteAction(
+    token~ : Int,
+    @lambda_edits.Action,
+    choice~ : String,
+    name~ : String
+  )
+  CloseOverlay(token~ : Int)
+}
+```
+
+**3b. `OverlayState::context_kind` — return `self.kind` directly (lines 64–69):**
+
+```moonbit
+///|
+fn OverlayState::context_kind(self : OverlayState) -> @ast.Term {
+  self.kind
+}
+```
+
+**3c. `overlay_effect_to_cmd` ExecuteAction arm — remove dead `match result.state.node_context` guard (lines 276–291):**
+
+Replace:
+```moonbit
+    ExecuteAction(action, choice~, name~) =>
+      match result.state.node_context {
+        Some(context) =>
+          parent_emit(
+            ActionOverlayEffect(
+              OverlayOutput::ExecuteAction(
+                token~,
+                context~,
+                action,
+                choice~,
+                name~,
+              ),
+            ),
+          )
+        None => none
+      }
+```
+
+With:
+```moonbit
+    ExecuteAction(action, choice~, name~) =>
+      parent_emit(
+        ActionOverlayEffect(
+          OverlayOutput::ExecuteAction(token~, action, choice~, name~),
+        ),
+      )
+```
+
+---
+
+- [ ] **Step 4: Edit `action_overlay_state.mbt` — update `open_action_overlay` (lines 98–121)**
+
+Two changes inside the function body:
+
+1. `initial_state` construction: replace `node_context: Some(ctx)` with `kind: ctx.kind`
+2. `model.overlay.mount(...)` call: add `ctx` as first argument
+
+```moonbit
+///|
+/// Open the action overlay for the given node ID string.
+fn open_action_overlay(
+  parent_emit : @rabbita.Emit[Msg],
+  model : Model,
+  node_id_str : String,
+  rect_json? : String = js_get_selected_node_rect(),
+) -> (Cmd, Model) {
+  if node_id_str == "" {
+    return (none, model)
+  }
+  let ctx = match detect_action_context(model.editor, node_id_str) {
+    Some(c) => c
+    None => return (none, model)
+  }
+  let proj_ctx = to_proj_context(ctx)
+  let actions = @lambda_edits.get_actions_for_node(ctx.kind, proj_ctx)
+  if actions.is_empty() {
+    return (none, model)
+  }
+  let (anchor_top, anchor_left) = parse_anchor_rect(rect_json)
+  let token = model.overlay.next_token
+  let initial_state = {
+    mode: MainMenu,
+    actions,
+    kind: ctx.kind,
+    error: "",
+    anchor_top,
+    anchor_left,
+    menu: @menu.Model::new(
+      id="ideal-action-overlay-menu",
+      item_count=actions.length(),
+    ),
+  }
+  let (overlay_emit, cell) = create_overlay_cell(
+    parent_emit, token, initial_state,
+  )
+  js_set_overlay_open(true)
+  (
+    initial_state.menu.focus_cmd(),
+    {
+      ..model,
+      overlay: model.overlay.mount(ctx, { cell, emit: overlay_emit, token }),
+    },
+  )
+}
+```
+
+---
+
+- [ ] **Step 5: Edit `action_overlay_update.mbt` — update `handle_overlay_output` (lines 47–61)**
+
+Replace the `ExecuteAction` arm to drop `context~` from the pattern and read `model.overlay.context` instead:
+
+```moonbit
+///|
+/// Apply child-cell outputs only when they come from the currently mounted
+/// overlay runtime. This prevents delayed outputs from a closed/reopened
+/// overlay from executing against the wrong node context.
+fn handle_overlay_output(model : Model, output : OverlayOutput) -> (Cmd, Model) {
+  match output {
+    ExecuteAction(action, choice~, name~, ..) =>
+      match model.overlay.current_runtime_for_output(output) {
+        Some(runtime) =>
+          match model.overlay.context {
+            Some(context) =>
+              execute_action(model, runtime, context, action, choice, name)
+            None => (none, model)
+          }
+        None => (none, model)
+      }
+    CloseOverlay(..) =>
+      match model.overlay.current_runtime_for_output(output) {
+        Some(_) => close_action_overlay(model)
+        None => (none, model)
+      }
+  }
+}
+```
+
+---
+
+- [ ] **Step 6: Edit `view_actions.mbt` — fix Submenu arm in `view_overlay` (lines 186–191)**
+
+Replace:
+```moonbit
+    Submenu(sub_action) =>
+      match state.node_context {
+        Some(ctx) =>
+          view_submenu_choices(emit, state.menu, sub_action, ctx.kind)
+        None => view_action_list(emit, state.menu, state.actions)
+      }
+```
+
+With:
+```moonbit
+    Submenu(sub_action) =>
+      view_submenu_choices(emit, state.menu, sub_action, state.kind)
+```
+
+---
+
+- [ ] **Step 7: Edit `main_wbtest.mbt` — update test helpers and token tests**
+
+**7a. `test_overlay_state` (lines 29–43):** Replace `node_context: Some(test_overlay_context())` with `kind: @ast.Term::Unit`:
+
+```moonbit
+///|
+fn test_overlay_state(mode : OverlayMode) -> OverlayState {
+  let actions = test_actions()
+  {
+    mode,
+    actions,
+    kind: @ast.Term::Unit,
+    error: "",
+    anchor_top: 0,
+    anchor_left: 0,
+    menu: @menu.Model::new(
+      id="ideal-action-overlay-menu-test",
+      item_count=actions.length(),
+    ),
+  }
+}
+```
+
+**7b. `test_overlay_runtime` (line 58):** Update `mount` call:
+
+```moonbit
+///|
+fn test_overlay_runtime(token : Int) -> ActionOverlayRuntime {
+  let state = test_overlay_state(MainMenu)
+  let (emit, cell) = create_overlay_cell(test_parent_emit(), token, state)
+  { cell, emit, token }
+}
+```
+
+(No change needed here — `test_overlay_runtime` doesn't call `mount`.)
+
+**7c. Token tests `"overlay outputs only match their originating runtime token"` (lines 163–183):** Two changes:
+1. `ActionOverlayHost::empty().mount(runtime)` → `ActionOverlayHost::empty().mount(test_overlay_context(), runtime)`
+2. `OverlayOutput::ExecuteAction(token=7, context=..., ...)` → drop `context=`
+
+```moonbit
+///|
+test "overlay outputs only match their originating runtime token" {
+  let runtime = test_overlay_runtime(7)
+  let host = ActionOverlayHost::empty().mount(test_overlay_context(), runtime)
+  let action = test_action_by_id("delete")
+  let matching = OverlayOutput::ExecuteAction(
+    token=7,
+    action,
+    choice="",
+    name="",
+  )
+  let stale = OverlayOutput::ExecuteAction(
+    token=8,
+    action,
+    choice="",
+    name="",
+  )
+  inspect(host.current_runtime_for_output(matching) is Some(_), content="true")
+  inspect(host.current_runtime_for_output(stale) is None, content="true")
+}
+```
+
+---
+
+- [ ] **Step 8: Run `moon check` — expect zero errors**
+
+```bash
+cd /home/antisatori/ghq/github.com/dowdiness/canopy-ideal-overlay
+NEW_MOON_MOD=0 moon check
+```
+
+Expected: no errors. If errors appear, read the error message and trace to the exact line — the field rename cascades are fully accounted for in steps 1–7; any error points to a site the plan missed.
+
+---
+
+- [ ] **Step 9: Run `moon test` — expect all tests pass**
+
+```bash
+NEW_MOON_MOD=0 moon test -p examples/ideal/main
+```
+
+Expected: all existing tests pass, including the snapshot tests and overlay token tests. No new test cases are added — the refactor is behaviour-preserving by construction (the parent always had the context; we are only changing where it is stored).
+
+---
+
+- [ ] **Step 10: Update interfaces and format**
+
+```bash
+NEW_MOON_MOD=0 moon info && NEW_MOON_MOD=0 moon fmt
+```
+
+Then check for unintended API surface changes:
+
+```bash
+git -C /home/antisatori/ghq/github.com/dowdiness/canopy-ideal-overlay diff *.mbti
+```
+
+The `OverlayOutput`, `OverlayState`, and `ActionOverlayHost` types are package-internal (not exported via `.mbti`), so no `.mbti` changes are expected. If a `.mbti` file changed, inspect it — it may indicate an unintended public API exposure.
+
+---
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C /home/antisatori/ghq/github.com/dowdiness/canopy-ideal-overlay add \
+  examples/ideal/main/model.mbt \
+  examples/ideal/main/action_overlay_runtime.mbt \
+  examples/ideal/main/action_overlay_flow.mbt \
+  examples/ideal/main/action_overlay_state.mbt \
+  examples/ideal/main/action_overlay_update.mbt \
+  examples/ideal/main/view_actions.mbt \
+  examples/ideal/main/main_wbtest.mbt
+
+git -C /home/antisatori/ghq/github.com/dowdiness/canopy-ideal-overlay commit -m \
+  "refactor(ideal): move NodeActionContext from child OverlayState to parent ActionOverlayHost
+
+Child signals intent only (action + choice + name). Parent owns and retrieves
+application context. Removes dead None-guard in overlay_effect_to_cmd and dead
+optional wrapping in OverlayState (node_context was always Some on a live overlay).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `OverlayState`: remove `node_context`, add `kind` — Task 1 Step 1 ✓
+- `ActionOverlayHost`: add `context`, update `mount`/`close`/`empty` — Task 1 Step 2 ✓
+- `OverlayOutput::ExecuteAction`: drop `context~` — Task 1 Step 3a ✓
+- `overlay_effect_to_cmd`: remove dead None guard — Task 1 Step 3c ✓
+- `context_kind()`: return `self.kind` directly — Task 1 Step 3b ✓
+- `open_action_overlay`: store ctx in host, pass ctx.kind to child — Task 1 Step 4 ✓
+- `handle_overlay_output`: read `model.overlay.context` — Task 1 Step 5 ✓
+- `view_actions.mbt` Submenu arm: use `state.kind` directly — Task 1 Step 6 ✓
+- `main_wbtest.mbt`: update constructor and token tests — Task 1 Step 7 ✓
+- `action_overlay_exec.mbt`: no change — confirmed excluded ✓
+
+**Placeholder scan:** No TBDs, no "similar to Task N", all code blocks complete.
+
+**Type consistency:**
+- `ActionOverlayHost::mount(context : NodeActionContext, runtime : ActionOverlayRuntime)` — Step 2 defines it; Step 4 and Step 7c call it with `(ctx, { cell, emit, token })` and `(test_overlay_context(), runtime)` — consistent ✓
+- `OverlayState.kind : @ast.Term` — Step 1 defines it; Step 3b, 4, 6, 7a use it — consistent ✓
+- `OverlayOutput::ExecuteAction(token~, action, choice~, name~)` — Step 3a defines it; Step 3c constructs it; Step 5 pattern-matches it; Step 7c constructs in tests — consistent ✓

--- a/docs/plans/2026-06-18-ideal-overlay-architecture.md
+++ b/docs/plans/2026-06-18-ideal-overlay-architecture.md
@@ -295,9 +295,9 @@ fn test_overlay_runtime(token : Int) -> ActionOverlayRuntime {
 
 (No change needed here — `test_overlay_runtime` doesn't call `mount`.)
 
-**7c. Token tests `"overlay outputs only match their originating runtime token"` (lines 163–183):** Two changes:
-1. `ActionOverlayHost::empty().mount(runtime)` → `ActionOverlayHost::empty().mount(test_overlay_context(), runtime)`
-2. `OverlayOutput::ExecuteAction(token=7, context=..., ...)` → drop `context=`
+**7c. Both token tests (lines 163–198):** Three changes across two tests:
+1. Both `ActionOverlayHost::empty().mount(runtime)` calls → add `test_overlay_context()` as first argument
+2. `OverlayOutput::ExecuteAction(token=7, context=..., ...)` and `(token=8, context=..., ...)` → drop `context=`
 
 ```moonbit
 ///|
@@ -319,6 +319,21 @@ test "overlay outputs only match their originating runtime token" {
   )
   inspect(host.current_runtime_for_output(matching) is Some(_), content="true")
   inspect(host.current_runtime_for_output(stale) is None, content="true")
+}
+
+///|
+test "overlay close outputs only match their originating runtime token" {
+  let host = ActionOverlayHost::empty().mount(test_overlay_context(), test_overlay_runtime(7))
+  inspect(
+    host.current_runtime_for_output(OverlayOutput::CloseOverlay(token=7))
+    is Some(_),
+    content="true",
+  )
+  inspect(
+    host.current_runtime_for_output(OverlayOutput::CloseOverlay(token=8))
+    is None,
+    content="true",
+  )
 }
 ```
 
@@ -402,6 +417,6 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 **Placeholder scan:** No TBDs, no "similar to Task N", all code blocks complete.
 
 **Type consistency:**
-- `ActionOverlayHost::mount(context : NodeActionContext, runtime : ActionOverlayRuntime)` — Step 2 defines it; Step 4 and Step 7c call it with `(ctx, { cell, emit, token })` and `(test_overlay_context(), runtime)` — consistent ✓
+- `ActionOverlayHost::mount(context : NodeActionContext, runtime : ActionOverlayRuntime)` — Step 2 defines it; Step 4 calls `mount(ctx, { cell, emit, token })`; Step 7c calls `mount(test_overlay_context(), runtime)` in both token tests (confirmed by Codex review) — consistent ✓
 - `OverlayState.kind : @ast.Term` — Step 1 defines it; Step 3b, 4, 6, 7a use it — consistent ✓
 - `OverlayOutput::ExecuteAction(token~, action, choice~, name~)` — Step 3a defines it; Step 3c constructs it; Step 5 pattern-matches it; Step 7c constructs in tests — consistent ✓

--- a/docs/superpowers/specs/2026-06-18-ideal-overlay-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-18-ideal-overlay-architecture-design.md
@@ -1,0 +1,199 @@
+# Ideal Overlay Architecture — Reference Design
+
+**Date:** 2026-06-18  
+**Scope:** `examples/ideal/main/` — action overlay refactor  
+**Status:** Approved for implementation
+
+---
+
+## Problem
+
+The Ideal editor's action overlay uses a Rabbita child cell for UI isolation
+(the skip-dirty optimization: menu keypresses do not re-render the parent's
+outline tree). This is correct. However, `NodeActionContext` — application
+context derived from the parent's editor projection — is stored inside the
+child cell's `OverlayState` and relayed back to the parent in the
+`ExecuteAction` output payload. The context takes a round-trip:
+
+```
+parent detects ctx → stores in child OverlayState.node_context
+child reads ctx.kind for submenu rendering
+child embeds full ctx in OverlayOutput::ExecuteAction
+parent receives ctx back → uses it in execute_action
+```
+
+This violates the responsibility boundary: the child cell owns UI navigation
+state; the parent owns application context. The child was holding application
+data on behalf of the parent, and the dead-code `None` arm in `context_kind()`
+reveals that `node_context` was always `Some(...)` — the optional wrapping
+served no purpose.
+
+---
+
+## Design Principle
+
+**Child cell owns UI navigation state. Parent owns application context.
+Nothing crosses the boundary twice.**
+
+The child signals *intent* (`action + choice + name`). The parent retrieves
+its own context when handling that signal. Context is detected once in the
+parent, stored once in the parent, consumed once in the parent.
+
+---
+
+## Architecture
+
+### `OverlayState` — pure UI state (child-owned)
+
+Remove `node_context : NodeActionContext?`. Add `kind : @ast.Term` directly.
+
+```
+struct OverlayState {
+  mode       : OverlayMode
+  actions    : Array[@lambda_edits.Action]
+  kind       : @ast.Term      // only what the child needs for submenu choices
+  error      : String
+  anchor_top : Int
+  anchor_left : Int
+  menu       : @menu.Model
+}
+```
+
+Rationale:
+- The child only reads `ctx.kind` (via `context_kind()` → `submenu_choices()`).
+- `node_context` was always `Some(...)` on a live overlay; the `None` fallback
+  was dead code. `kind` is unconditional — no optional wrapping needed.
+- Full `NodeActionContext` is application state, not UI state.
+
+### `ActionOverlayHost` — gains application context (parent-owned)
+
+```
+struct ActionOverlayHost {
+  runtime    : ActionOverlayRuntime?
+  context    : NodeActionContext?   // application context, owned here
+  next_token : Int
+}
+```
+
+`mount` takes `context : NodeActionContext` and stores it alongside the
+runtime. `close` clears both `runtime` and `context` together (they are
+always co-valid). `empty` initialises `context: None`.
+
+### `OverlayOutput` — context drops out of the wire
+
+```
+enum OverlayOutput {
+  ExecuteAction(token~ : Int, @lambda_edits.Action, choice~ : String, name~ : String)
+  CloseOverlay(token~ : Int)
+}
+```
+
+`context~` is removed. The parent reads `model.overlay.context` when handling
+`ExecuteAction` — it always has the current context because it owns it.
+
+### Data flow (after)
+
+```
+open_action_overlay:
+  parent detects ctx
+  → stores ctx in ActionOverlayHost.context
+  → passes only ctx.kind into OverlayState
+
+child execution path:
+  child reads self.kind for submenu choices
+  → emits OverlayOutput::ExecuteAction(token, action, choice, name)
+
+handle_overlay_output:
+  parent validates token
+  → reads model.overlay.context
+  → calls execute_action(model, runtime, context, action, choice, name)
+```
+
+Context takes a one-way trip. The child never holds it.
+
+---
+
+## What Stays the Same
+
+### Token system
+
+Still necessary. The child communicates back to the parent via `parent_emit`
+(enqueuing into the **parent's** inbox). Rabbita's `live_map` lifecycle guard
+applies only to a cell's own inbox — messages routed through `parent_emit`
+bypass it. The token is the correct manual equivalent for stale-output
+rejection when using the captured-parent-emit pattern.
+
+Rule: whenever a Rabbita child cell uses `parent_emit` for child→parent
+signaling, the parent must provide an independent stale-output guard. The
+token in `ActionOverlayHost` is the canonical form.
+
+### `OverlayEvent` encapsulation boundary
+
+`OverlayKeyPressed` / `OverlayNameCancel` remain a distinct type from
+`OverlayMsg`. The parent `Msg` type never exposes child-internal message
+types. `OverlayEvent::to_overlay_msg()` is the explicit translation layer.
+
+### Child cell (`Cell`)
+
+The Rabbita skip-dirty optimisation is the reason for using a child cell:
+menu keypresses mark only the child dirty, not the parent. Without the child
+cell, every keystroke would trigger a full re-render of the parent's outline
+tree. The cell boundary is justified.
+
+### `parent_emit` capture
+
+The established Rabbita pattern for child→parent signaling: the child's
+update closure captures `parent_emit` at cell-creation time. The parent's
+`Emit[Msg]` is stable (root cell), so the captured reference is always valid.
+
+---
+
+## Files and Changes
+
+| File | Change |
+|------|--------|
+| `model.mbt` | `OverlayState`: remove `node_context`, add `kind : @ast.Term` |
+| `action_overlay_runtime.mbt` | `ActionOverlayHost`: add `context : NodeActionContext?`; update `empty`, `mount` (new param), `close` |
+| `action_overlay_flow.mbt` | `OverlayOutput::ExecuteAction`: drop `context~`; `overlay_effect_to_cmd`: remove dead `None` guard on `node_context`; `open_action_overlay`: store `ctx` in host, pass `ctx.kind` to child state |
+| `action_overlay_state.mbt` | `context_kind()`: returns `self.kind` directly (no `Option` unwrap) |
+| `action_overlay_update.mbt` | `handle_overlay_output` `ExecuteAction` arm: read `model.overlay.context` instead of receiving it from output |
+
+`action_overlay_exec.mbt` — no change. `execute_action` still receives
+`context` from its caller (`handle_overlay_output`).
+
+---
+
+## Reference Implementation Notes
+
+This design demonstrates the canonical Rabbita child-cell pattern for an
+ephemeral overlay with parent-context execution:
+
+1. **State partitioning**: child holds navigation state, parent holds
+   application context. Determined by who *owns* the data, not who *uses* it.
+
+2. **Signal vs. data**: child output carries only intent signals
+   (`action`, `choice`, `name`). Application data flows from parent context,
+   not from child output.
+
+3. **Stale-output guard**: token in `ActionOverlayHost` matches the token
+   embedded in `OverlayOutput`. This is mandatory whenever `parent_emit` is
+   used for child→parent communication.
+
+4. **Lifecycle co-validity**: `runtime` and `context` in `ActionOverlayHost`
+   are always `Some` or `None` together. They are set together in `mount` and
+   cleared together in `close`. Co-valid fields should be co-managed.
+
+5. **No dead optionals**: `OverlayState.kind : @ast.Term` replaces
+   `node_context : NodeActionContext?` which was always `Some` on a live
+   overlay. Represent invariants in types: if a field is always `Some`, it
+   should not be `Option`.
+
+---
+
+## Non-Goals
+
+- Changing the token mechanism or `parent_emit` pattern
+- Changing `OverlayEvent` / `OverlayMsg` separation
+- Eliminating the child cell or changing the skip-dirty behaviour
+- Touching the action execution logic in `action_overlay_exec.mbt`
+- Any UI or styling changes

--- a/docs/superpowers/specs/2026-06-18-ideal-overlay-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-18-ideal-overlay-architecture-design.md
@@ -154,9 +154,11 @@ update closure captures `parent_emit` at cell-creation time. The parent's
 |------|--------|
 | `model.mbt` | `OverlayState`: remove `node_context`, add `kind : @ast.Term` |
 | `action_overlay_runtime.mbt` | `ActionOverlayHost`: add `context : NodeActionContext?`; update `empty`, `mount` (new param), `close` |
-| `action_overlay_flow.mbt` | `OverlayOutput::ExecuteAction`: drop `context~`; `overlay_effect_to_cmd`: remove dead `None` guard on `node_context`; `open_action_overlay`: store `ctx` in host, pass `ctx.kind` to child state |
-| `action_overlay_state.mbt` | `context_kind()`: returns `self.kind` directly (no `Option` unwrap) |
+| `action_overlay_flow.mbt` | `OverlayOutput::ExecuteAction`: drop `context~`; `overlay_effect_to_cmd`: remove dead `None` guard; `context_kind()`: return `self.kind` directly |
+| `action_overlay_state.mbt` | `open_action_overlay`: store `ctx` in host (`mount(ctx, runtime)`), pass `ctx.kind` into child `initial_state` |
 | `action_overlay_update.mbt` | `handle_overlay_output` `ExecuteAction` arm: read `model.overlay.context` instead of receiving it from output |
+| `view_actions.mbt` | `view_overlay` Submenu arm: replace `match state.node_context { Some(ctx) => view_submenu_choices(…ctx.kind) … }` with direct `view_submenu_choices(…state.kind)` |
+| `main_wbtest.mbt` | `test_overlay_state`: replace `node_context: Some(…)` with `kind: @ast.Term::Unit`; token tests: drop `context=` from `OverlayOutput::ExecuteAction`; `ActionOverlayHost::empty().mount(runtime)` → `mount(ctx, runtime)` |
 
 `action_overlay_exec.mbt` — no change. `execute_action` still receives
 `context` from its caller (`handle_overlay_output`).

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -264,6 +264,11 @@ fn overlay_effect_to_cmd(
     NoOverlayEffect => none
     FocusMenu => result.state.menu.focus_cmd()
     FocusNamePrompt => focus_selector_after_render(".name-prompt-input")
+    // Unconditional emit is safe: close() atomically clears both runtime and
+    // context (and does NOT increment next_token), so queued outputs from a
+    // closed overlay are caught by the parent's token guard in
+    // handle_overlay_output. If close() is ever split into two steps, restore
+    // the child-side guard here.
     ExecuteAction(action, choice~, name~) =>
       parent_emit(
         ActionOverlayEffect(

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -13,7 +13,6 @@ enum OverlayMsg {
 enum OverlayOutput {
   ExecuteAction(
     token~ : Int,
-    context~ : NodeActionContext,
     @lambda_edits.Action,
     choice~ : String,
     name~ : String
@@ -62,10 +61,7 @@ fn OverlayState::show_name_prompt(
 
 ///|
 fn OverlayState::context_kind(self : OverlayState) -> @ast.Term {
-  match self.node_context {
-    Some(ctx) => ctx.kind
-    None => @ast.Term::Unit
-  }
+  self.kind
 }
 
 ///|
@@ -274,21 +270,11 @@ fn overlay_effect_to_cmd(
     FocusMenu => result.state.menu.focus_cmd()
     FocusNamePrompt => focus_selector_after_render(".name-prompt-input")
     ExecuteAction(action, choice~, name~) =>
-      match result.state.node_context {
-        Some(context) =>
-          parent_emit(
-            ActionOverlayEffect(
-              OverlayOutput::ExecuteAction(
-                token~,
-                context~,
-                action,
-                choice~,
-                name~,
-              ),
-            ),
-          )
-        None => none
-      }
+      parent_emit(
+        ActionOverlayEffect(
+          OverlayOutput::ExecuteAction(token~, action, choice~, name~),
+        ),
+      )
     CloseOverlay =>
       parent_emit(ActionOverlayEffect(OverlayOutput::CloseOverlay(token~)))
   }

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -60,16 +60,11 @@ fn OverlayState::show_name_prompt(
 }
 
 ///|
-fn OverlayState::context_kind(self : OverlayState) -> @ast.Term {
-  self.kind
-}
-
-///|
 fn OverlayState::submenu_choices(
   self : OverlayState,
   action : @lambda_edits.Action,
 ) -> Array[(String, String)] {
-  get_submenu_choices(action.id, self.context_kind())
+  get_submenu_choices(action.id, self.kind)
 }
 
 ///|

--- a/examples/ideal/main/action_overlay_runtime.mbt
+++ b/examples/ideal/main/action_overlay_runtime.mbt
@@ -1,25 +1,31 @@
 ///|
 struct ActionOverlayHost {
   runtime : ActionOverlayRuntime?
+  context : NodeActionContext?
   next_token : Int
 }
 
 ///|
 fn ActionOverlayHost::empty() -> ActionOverlayHost {
-  { runtime: None, next_token: 1 }
+  { runtime: None, context: None, next_token: 1 }
 }
 
 ///|
 fn ActionOverlayHost::mount(
   self : ActionOverlayHost,
+  context : NodeActionContext,
   runtime : ActionOverlayRuntime,
 ) -> ActionOverlayHost {
-  { runtime: Some(runtime), next_token: self.next_token + 1 }
+  {
+    runtime: Some(runtime),
+    context: Some(context),
+    next_token: self.next_token + 1,
+  }
 }
 
 ///|
 fn ActionOverlayHost::close(self : ActionOverlayHost) -> ActionOverlayHost {
-  { ..self, runtime: None }
+  { ..self, runtime: None, context: None }
 }
 
 ///|

--- a/examples/ideal/main/action_overlay_runtime.mbt
+++ b/examples/ideal/main/action_overlay_runtime.mbt
@@ -1,4 +1,9 @@
 ///|
+// `runtime` and `context` are co-valid: both Some when mounted, both None when
+// closed. `mount`/`close`/`empty` are the only write paths and must stay in
+// lockstep. TODO: consolidate into a single
+// `active: (NodeActionContext, ActionOverlayRuntime)?` field to make this
+// invariant structurally unrepresentable-to-violate.
 struct ActionOverlayHost {
   runtime : ActionOverlayRuntime?
   context : NodeActionContext?

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -95,6 +95,10 @@ fn open_action_overlay(
   }
   let (anchor_top, anchor_left) = parse_anchor_rect(rect_json)
   let token = model.overlay.next_token
+  // `kind` here and `ctx` passed to mount() below both derive from the same
+  // local `ctx`. OverlayState.kind (used for rendering) and
+  // ActionOverlayHost.context.kind (used for execution) are therefore always
+  // identical; they must not be set from different sources.
   let initial_state = {
     mode: MainMenu,
     actions,

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -98,7 +98,7 @@ fn open_action_overlay(
   let initial_state = {
     mode: MainMenu,
     actions,
-    node_context: Some(ctx),
+    kind: ctx.kind,
     error: "",
     anchor_top,
     anchor_left,
@@ -115,7 +115,7 @@ fn open_action_overlay(
     initial_state.menu.focus_cmd(),
     {
       ..model,
-      overlay: model.overlay.mount({ cell, emit: overlay_emit, token }),
+      overlay: model.overlay.mount(ctx, { cell, emit: overlay_emit, token }),
     },
   )
 }

--- a/examples/ideal/main/action_overlay_update.mbt
+++ b/examples/ideal/main/action_overlay_update.mbt
@@ -46,16 +46,13 @@ fn ActionOverlayHost::current_runtime_for_output(
 /// overlay from executing against the wrong node context.
 fn handle_overlay_output(model : Model, output : OverlayOutput) -> (Cmd, Model) {
   match output {
-    ExecuteAction(action, choice~, name~, ..) =>
-      match model.overlay.current_runtime_for_output(output) {
-        Some(runtime) =>
-          match model.overlay.context {
-            Some(context) =>
-              execute_action(model, runtime, context, action, choice, name)
-            None => (none, model)
-          }
-        None => (none, model)
+    ExecuteAction(action, choice~, name~, ..) => {
+      guard model.overlay.current_runtime_for_output(output) is Some(runtime) else {
+        return (none, model)
       }
+      guard model.overlay.context is Some(context) else { return (none, model) }
+      execute_action(model, runtime, context, action, choice, name)
+    }
     CloseOverlay(..) =>
       match model.overlay.current_runtime_for_output(output) {
         Some(_) => close_action_overlay(model)

--- a/examples/ideal/main/action_overlay_update.mbt
+++ b/examples/ideal/main/action_overlay_update.mbt
@@ -46,10 +46,14 @@ fn ActionOverlayHost::current_runtime_for_output(
 /// overlay from executing against the wrong node context.
 fn handle_overlay_output(model : Model, output : OverlayOutput) -> (Cmd, Model) {
   match output {
-    ExecuteAction(context~, action, choice~, name~, ..) =>
+    ExecuteAction(action, choice~, name~, ..) =>
       match model.overlay.current_runtime_for_output(output) {
         Some(runtime) =>
-          execute_action(model, runtime, context, action, choice, name)
+          match model.overlay.context {
+            Some(context) =>
+              execute_action(model, runtime, context, action, choice, name)
+            None => (none, model)
+          }
         None => (none, model)
       }
     CloseOverlay(..) =>

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -194,6 +194,13 @@ test "overlay close outputs only match their originating runtime token" {
 }
 
 ///|
+test "mount sets context on host" {
+  let ctx = test_overlay_context()
+  let host = ActionOverlayHost::empty().mount(ctx, test_overlay_runtime(7))
+  inspect(host.context is Some(_), content="true")
+}
+
+///|
 test "parse_node_id valid" {
   inspect(parse_node_id("42") is Some(_), content="true")
 }

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -31,7 +31,7 @@ fn test_overlay_state(mode : OverlayMode) -> OverlayState {
   {
     mode,
     actions,
-    node_context: Some(test_overlay_context()),
+    kind: @ast.Term::Unit,
     error: "",
     anchor_top: 0,
     anchor_left: 0,
@@ -162,29 +162,25 @@ test "overlay update name cancel closes overlay" {
 ///|
 test "overlay outputs only match their originating runtime token" {
   let runtime = test_overlay_runtime(7)
-  let host = ActionOverlayHost::empty().mount(runtime)
+  let host = ActionOverlayHost::empty().mount(test_overlay_context(), runtime)
   let action = test_action_by_id("delete")
   let matching = OverlayOutput::ExecuteAction(
     token=7,
-    context=test_overlay_context(),
     action,
     choice="",
     name="",
   )
-  let stale = OverlayOutput::ExecuteAction(
-    token=8,
-    context=test_overlay_context(),
-    action,
-    choice="",
-    name="",
-  )
+  let stale = OverlayOutput::ExecuteAction(token=8, action, choice="", name="")
   inspect(host.current_runtime_for_output(matching) is Some(_), content="true")
   inspect(host.current_runtime_for_output(stale) is None, content="true")
 }
 
 ///|
 test "overlay close outputs only match their originating runtime token" {
-  let host = ActionOverlayHost::empty().mount(test_overlay_runtime(7))
+  let host = ActionOverlayHost::empty().mount(
+    test_overlay_context(),
+    test_overlay_runtime(7),
+  )
   inspect(
     host.current_runtime_for_output(OverlayOutput::CloseOverlay(token=7))
     is Some(_),

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -67,7 +67,7 @@ enum OverlayMode {
 struct OverlayState {
   mode : OverlayMode
   actions : Array[@lambda_edits.Action]
-  node_context : NodeActionContext?
+  kind : @ast.Term
   // The most recent failure to act. Overlay-wide, not prompt-specific: an
   // action can fail to apply from MainMenu or Submenu just as from NamePrompt,
   // so the error is rendered in the panel for any open mode (view_actions.mbt).

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -184,11 +184,7 @@ fn view_overlay(
   let content : @rabbita.Html = match state.mode {
     NamePrompt(_, ..) => view_name_prompt(emit, state)
     Submenu(sub_action) =>
-      match state.node_context {
-        Some(ctx) =>
-          view_submenu_choices(emit, state.menu, sub_action, ctx.kind)
-        None => view_action_list(emit, state.menu, state.actions)
-      }
+      view_submenu_choices(emit, state.menu, sub_action, state.kind)
     MainMenu | Closed => view_action_list(emit, state.menu, state.actions)
   }
   let panel_attrs = match state.mode {


### PR DESCRIPTION
## Summary

- Moves `NodeActionContext` from child `OverlayState` into parent `ActionOverlayHost` — the child signals intent only (action + choice + name); the parent owns and retrieves application context
- Removes a dead `None`-guard in `overlay_effect_to_cmd` that was unreachable in practice (ExecuteAction could only fire on a live overlay)
- Removes dead optional wrapping in `OverlayState` (`node_context` was always `Some` on a live overlay; replaced by `kind : @ast.Term`)
- `ActionOverlayHost::mount(context, runtime)` gains `context` as first param; `close()` clears both fields atomically; `empty()` initialises both to `None`
- Follow-on: inline `context_kind()` passthrough, flatten nested match in `handle_overlay_output` to sequential guard statements

**Code review fixes (post-implementation):**
- Invariant comment + TODO on `ActionOverlayHost` (lockstep `runtime`/`context`; future consolidation into `active: (NodeActionContext, ActionOverlayRuntime)?`)
- Comment explaining why `overlay_effect_to_cmd` emits unconditionally (atomicity of `close()` is the precondition)
- Comment in `open_action_overlay` noting `OverlayState.kind` and `ActionOverlayHost.context.kind` derive from the same `ctx`
- Test: `"mount sets context on host"` guards against a regression where `mount()` sets runtime but not context

## Reuse check

All changed types (`OverlayState`, `OverlayOutput`, `ActionOverlayHost`) are package-internal to `examples/ideal/main` — no `.mbti` changes. `action_overlay_exec.mbt` is untouched.

## Test plan

- [ ] `moon check` — zero errors, zero warnings
- [ ] `moon test --target js` — 1861/1861 passed
- [ ] `git diff *.mbti` — no changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
