### PR TITLE
Archive analysis query Phase 2 plan

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -513,10 +513,10 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 
 ## 21. Analysis Query Layer
 
-- [ ] Phase 2 projection aggregator.
-  Why: Phase 1 proved snapshot-bound structural-search decorations, but lambda still composes ast-grep, semantic, eval, and diagnostic projections through ad-hoc closures and FFI paths.
-  Plan: `docs/plans/2026-06-18-analysis-query-phase2-aggregator.md`
-  Exit: lambda has one named aggregation seam for analysis projections, existing protocol surfaces are unchanged, and tests cover combined semantic + pattern decorations with stale external facts.
+- [ ] Decide whether diagnostics join the analysis projection aggregator (#710).
+  Why: Phase 2 shipped the lambda-local decoration/annotation aggregation seam in PR #706 and PR #708, but parse/type/eval diagnostics still use existing FFI/protocol paths. That is intentional until a larger diagnostic fact shape is justified.
+  Plan: `docs/archive/completed-phases/2026-06-18-analysis-query-phase2-aggregator.md`
+  Exit: diagnostics are either explicitly kept out of the aggregator with a stable rationale, or routed through a typed diagnostic fact shape without adding public protocol variants.
 
 - [x] Implement Phase 1 ast-grep range-only analysis overlay (#692).
   Shipped: PR #699 added `lib/analysis/` and `analysis/`; PR #704 completed host FFI and lambda editor decoration wiring.

--- a/docs/archive/completed-phases/2026-06-18-analysis-query-phase2-aggregator.md
+++ b/docs/archive/completed-phases/2026-06-18-analysis-query-phase2-aggregator.md
@@ -1,5 +1,10 @@
 # Analysis Query Layer Phase 2 — Projection Aggregator
 
+Status: complete. Shipped via PR #706 (`9d520ff`) and PR #708 (`fabf2ee`) on
+2026-06-18. The result is deliberately lambda-local: shared
+`AnalysisProjection` promotion remains deferred until a second language has
+multiple real projected analysis inputs to merge.
+
 ## Why
 
 Phase 1 proved that external structural-search results can enter Canopy as
@@ -10,9 +15,9 @@ lambda editor now has two separate projection paths for related derived data:
 - in-process semantic, evaluation, and diagnostic data assembled directly in
   language capability closures and FFI functions.
 
-Phase 2 should introduce a small aggregation seam so these in-process analyses
-are routed through one projection layer before Canopy commits to broader
-provider abstractions or `moon ide` integration.
+Phase 2 introduced a small aggregation seam so these in-process analyses route
+through one projection layer before Canopy commits to broader provider
+abstractions or `moon ide` integration.
 
 ## Scope
 
@@ -38,6 +43,20 @@ Out:
 - broad cross-language migration beyond lambda.
 - node-id anchoring as a requirement. Source ranges remain authoritative.
 - persistent semantic database or workspace indexing.
+
+## Completion Summary
+
+- PR #706 introduced `lang/lambda/companion/analysis_projection.mbt` and routed
+  lambda semantic/eval annotations plus semantic/pattern decorations through it.
+- PR #708 refined the seam into a private `AnalysisProjection` object that owns
+  snapshot-bound pattern-analysis state atomically, and added regression coverage
+  for stale external pattern facts preserving in-process semantic decorations.
+- JSON was checked as the first cross-language generalization candidate and did
+  not justify a shared API: JSON has structural projection plus parser
+  diagnostics, but no semantic annotations, language decorations, evaluation
+  facts, or snapshot-bound external facts to compose.
+- Diagnostics remain on existing FFI/protocol paths until a larger diagnostic
+  fact shape is justified.
 
 ## Current State
 

--- a/docs/design/analysis-query-layer.md
+++ b/docs/design/analysis-query-layer.md
@@ -228,8 +228,9 @@ Implementation notes:
 
 ### Phase 2 — analysis projection aggregator
 
-Status: started. The active implementation plan is
-[`docs/plans/2026-06-18-analysis-query-phase2-aggregator.md`](../plans/2026-06-18-analysis-query-phase2-aggregator.md).
+Status: complete for the lambda-local aggregation seam. The completed
+implementation plan is archived at
+[`docs/archive/completed-phases/2026-06-18-analysis-query-phase2-aggregator.md`](../archive/completed-phases/2026-06-18-analysis-query-phase2-aggregator.md).
 
 Route existing language facts through a small internal aggregator:
 


### PR DESCRIPTION
## Summary

- Archive the completed Analysis Query Layer Phase 2 projection aggregator plan.
- Mark the design doc's Phase 2 status as complete for the lambda-local aggregation seam.
- Replace the completed TODO with diagnostics fact-shape follow-up #710.

## Validation

```bash
git diff --check
rg -n "docs/plans/2026-06-18-analysis-query-phase2-aggregator|Phase 2 projection aggregator" docs README.md AGENTS.md || true
```

## Notes

Unrelated dirty `loom` submodule state is intentionally not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated analysis query layer documentation to mark Phase 2 projection aggregator as complete.
  * Refined backlog task to focus on diagnostics routing decisions.
  * Added completion summary documenting implementation details and current design limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->