### PR TITLE
Probe Markdown heading identity for SDEG

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,9 @@ behavior** — check the code before relying on any specific detail.
 - [Analysis Query Layer](design/analysis-query-layer.md) — conservative design
   for ast-grep-style syntax search, `moon ide`-style semantic queries, and
   previewable refactors through snapshot-bound internal facts.
+- [Stable Document Entity Graph](design/stable-document-entity-graph.md) —
+  direction for growing a stable editing-entity layer from the existing
+  projection identity pipeline.
 - [Design Concerns](design/design-concerns.md) — open problems and future
   considerations.
 - [Decisions Needed](decisions-needed.md) — open architectural questions.

--- a/docs/design/stable-document-entity-graph.md
+++ b/docs/design/stable-document-entity-graph.md
@@ -1,0 +1,222 @@
+# Stable Document Entity Graph
+
+**Status:** Design direction, not implemented behavior.
+
+This note names the direction for Canopy's next identity layer. It should guide
+experiments and plans, but code and generated interfaces remain authoritative.
+The first implementation work should be a narrow spike, not a new framework.
+
+## Thesis
+
+Canopy needs a stable editing-entity layer, but it should grow out of the
+existing projection identity pipeline rather than start as a parallel identity
+system.
+
+The target model is:
+
+```text
+Text / CRDT document     durable source of truth
+Lossless CST            parsed source facts
+Stable entity layer     stable index over editing targets
+Incremental views       derived UI, diagnostics, outline, AI context
+```
+
+The stable entity layer is not an AST, and it is not a copy of the CST. It is a
+thin, evidence-bearing index that says which editing targets exist now, where
+they are anchored in the current source/projection, and how confidently they
+correspond to targets from a previous state.
+
+## Current stance
+
+Do not introduce a new public entity ID system first.
+
+Canopy already has projection identity, source mapping, edit lowering, and
+incremental projection machinery. Treat that as **Phase 0 of the stable entity
+layer**. The first task is to measure and extend it, not replace it.
+
+The initial stable entity layer should be a side-table model over existing
+projection identity:
+
+- projection identity provides session-local entity identity;
+- source maps provide current source anchors;
+- projection children provide the primary tree relation;
+- side tables add semantic status, evidence, diagnostics, and optional semantic
+  anchors;
+- derived views remain scheduled through the incremental runtime.
+
+Only split out a distinct entity ID when a concrete spike shows that projection
+identity cannot satisfy the required stability scope.
+
+## Source of truth
+
+The stable entity layer must never become the document's source of truth.
+
+Structural edits follow this path:
+
+```text
+user intent
+  -> language-owned edit calculation
+  -> source/text patch
+  -> CRDT/editor mutation
+  -> parse
+  -> projection reconciliation
+  -> stable entity side tables
+  -> derived views
+```
+
+Updating entity metadata alone must not count as editing the document. This
+keeps text, collaboration, undo, parser recovery, and projection state on the
+same path.
+
+## Identity is a hypothesis
+
+Stable identity is not a fact that is always knowable. It is a hypothesis with
+evidence.
+
+The system should record why identity was preserved or refreshed: range
+continuity, same syntactic role, stable semantic key, edit provenance, retained
+projection identity, language hints, or fallback matching. It should also record
+when identity is ambiguous or low confidence.
+
+This evidence is valuable even before it drives behavior. The first spike should
+surface it in tests and debug views so identity failures become explainable.
+
+## Stability scopes
+
+The design must name the stability scope before exposing any ID beyond an
+internal experiment.
+
+Important scopes are:
+
+- stable across a single reparse;
+- stable across malformed intermediate input;
+- stable across an editor session;
+- stable across reload;
+- stable across collaborating peers.
+
+The Phase 0 assumption is intentionally modest: stable entities are
+**session-local** and derived from the current projection identity pipeline.
+Reload-stable and peer-stable identities require either durable anchors,
+deterministic keys, or a persistent side store, and should not be promised by
+the initial API.
+
+## Anchors and units
+
+Anchors must carry explicit coordinate semantics. Canopy has multiple integer
+coordinate spaces, including source-code-unit offsets, parser spans, CRDT item
+positions, and frontend tree positions. Stable entity APIs must not expose raw
+position integers without naming the unit.
+
+The first spike should anchor entities with the existing source snapshot and
+source-map ranges. CRDT operation anchors can be added later through an adapter
+once the required durability behavior is proven.
+
+## Relationship to event-graph-walker
+
+`event-graph-walker` remains the durable collaboration substrate. It owns causal
+history, text/tree CRDT semantics, sync, and undo. The stable entity layer should
+compose with it, not duplicate it.
+
+Not every semantic entity should become a durable CRDT object. Use durable CRDT
+identity for document objects whose structure is itself collaboratively edited,
+such as blocks or user-created structural nodes. Treat syntax-derived entities,
+such as headings or declarations, as extracted and reconciled unless a product
+case proves they need durable identity.
+
+## Relationship to the incremental runtime
+
+The stable entity layer stores facts and evidence. It should not own ad-hoc
+cache invalidation. Labels, outlines, diagnostics, projections, semantic
+summaries, and AI context are derived values and should flow through the
+incremental runtime.
+
+The first usable slice should avoid a mutable entity store that later has to be
+wrapped reactively. Prefer immutable snapshots and explicit change summaries
+until the dependency shape is known.
+
+## Language boundary
+
+The core model is language-agnostic, but entity extraction and edit lowering are
+language-owned.
+
+A language adapter should answer:
+
+- which projection nodes count as stable editing entities;
+- which source/token anchors define those entities;
+- which language-owned keys help preserve identity;
+- how a structural intent lowers to source edits;
+- how to report identity evidence and ambiguity.
+
+The reference spike should use Markdown headings before MoonBit declarations,
+because Markdown has the more mature projection and edit stack in Canopy today.
+
+## Lifecycle model
+
+The stable entity layer needs lifecycle states, but the first implementation
+should keep them diagnostic until behavior is proven.
+
+Useful states include:
+
+- live: currently anchored and usable;
+- missing: temporarily absent, often due to malformed input;
+- ambiguous: multiple plausible matches exist;
+- tombstoned: retained for recovery, undo, or diagnostics;
+- retired: no longer eligible for matching;
+- garbage-collectable: safe to discard from side tables.
+
+Before lifecycle states drive behavior, define a transition table and retention
+policy. In particular, specify whether non-live entities may be referenced by
+edges, diagnostics, selections, undo, or debug tooling.
+
+## Phase 0 spike
+
+The next step is a design spike, not a broad package split.
+
+Scope:
+
+1. Choose Markdown headings as the first entity kind.
+2. Treat existing projection identity as the entity reference.
+3. Use current source-map ranges as anchors.
+4. Add diagnostic side tables for status and matching evidence.
+5. Test rename, reorder, duplicate headings, delete/restore, malformed input,
+   and large paste/format-like edits.
+6. Verify that edits still flow through the existing language edit path.
+
+Success means the existing pipeline preserves identity well enough for common
+heading edits and produces explainable failures for the cases it cannot handle.
+
+Failure does not immediately justify a new entity core. First try adding better
+language hints, identity evidence, and projection-identity realignment. Only
+separate entity identity from projection identity after those routes are shown to
+be insufficient.
+
+## Decision gates
+
+Create a distinct stable entity core only if the spike demonstrates at least one
+of these needs:
+
+- projection identity cannot model the needed lifecycle;
+- identity must survive reload or peer synchronization;
+- semantic entities need graph relations beyond the projection tree;
+- language-independent evidence and diagnostics cannot be expressed as side
+  tables;
+- durable CRDT anchors must participate directly in matching.
+
+Until then, keep the design internal and side-table based.
+
+## Non-goals for the first slice
+
+- No new general-purpose ECS.
+- No parallel rendered view tree.
+- No public stable entity API.
+- No persistent semantic entity storage in the CRDT layer.
+- No full graph store before a single entity kind proves the need.
+- No raw byte-range anchors at package boundaries.
+
+## Related guidance
+
+- [Responsibility Map](../architecture/responsibility-map.md)
+- [Range/span unit boundaries](../decisions/2026-06-13-range-span-unit-boundaries.md)
+- [Identity and reuse mechanisms](../decisions/2026-06-01-identity-and-reuse-mechanisms.md)
+- [Analysis Query Layer](analysis-query-layer.md)
+- [Design Concerns](design-concerns.md)

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -1,0 +1,201 @@
+# SDEG Phase 0 Markdown Heading Spike
+
+## Why
+
+Canopy needs a stable editing-entity layer, but the repository already has
+projection identity, source maps, edit lowering, and incremental projection
+memos. Before introducing a new Stable Document Entity Graph (SDEG) core or a
+new `EntityId`, validate whether the existing identity pipeline can support the
+first SDEG use case as a side-table layer.
+
+This spike tests Markdown headings as stable editing entities. The goal is to
+learn where existing `NodeId`/projection identity is sufficient, where it fails,
+and what evidence would make failures explainable.
+
+## Scope
+
+In:
+- `docs/design/stable-document-entity-graph.md`
+- `core/` projection identity helpers, only if a small test-only observation hook
+  is needed
+- `lang/markdown/proj/` heading projection and token span behavior
+- `lang/markdown/edits/` existing edit path, if needed for rename/move tests
+- Markdown-focused tests under the owning Markdown packages
+
+Out:
+- creating a public `sdeg-*` package family
+- introducing a distinct public `EntityId`
+- changing event-graph-walker APIs
+- persisting semantic entities into CRDT state
+- adding a general graph store or ECS layer
+- changing frontend protocol types
+
+## Current State
+
+- `core/` owns `NodeId`, `ProjNode`, `SourceMap`, generic reconciliation, and
+  structural identity hints.
+- `SourceMap` maps projection nodes to UTF-16 source ranges and token spans.
+- `build_projection_memos` builds the projection tree, registry, and source map
+  as `incr` derived values.
+- `IdentityTransform` records editor-owned structural hints for reconciliation.
+- Loom's `ProjectionIdentityTracker` preserves stable projection leaves across
+  malformed intermediate input using source ranges and domain keys.
+- `LanguageSpec::apply_edit` lowers language edit operations to `SpanEdit`s and
+  applies them through the editor path.
+- The design direction is recorded in
+  `docs/design/stable-document-entity-graph.md`: Phase 0 should treat existing
+  projection identity as the first stable entity substrate.
+
+Constraints:
+- Public source ranges are UTF-16 code-unit offsets. Do not introduce byte-range
+  anchors in this spike.
+- Do not bypass existing Markdown edit lowering or `SyncEditor` text mutation.
+- Treat code and generated `.mbti` files as authoritative when docs drift.
+
+## Desired State
+
+A narrow Markdown heading experiment answers these questions:
+
+1. Can a Markdown heading be treated as a session-local stable entity using the
+   existing `NodeId`?
+2. Do heading rename, reorder, deletion/restoration, duplicates, malformed input,
+   and paste/formatter-like rewrites preserve or explain identity well enough?
+3. Can `SourceMap` provide the current heading anchor and relevant token spans
+   without new range primitives?
+4. Can identity outcomes be reported as evidence side tables without changing the
+   document source of truth?
+5. Is a distinct SDEG core justified, or should the next step extend existing
+   projection identity and side-table APIs?
+
+## Proposed Observation Model
+
+Keep this spike internal or test-only. Do not publish the model as stable API.
+
+A minimal observation record may contain:
+
+- heading `NodeId`
+- heading level and normalized heading text/key
+- current UTF-16 source range from `SourceMap`
+- optional token span for the marker/text if already available or easy to record
+- parent/section context if already derivable from the projection tree
+- identity outcome: preserved, fresh, missing, ambiguous, or retired
+- evidence: same range, overlapping range, same level, same text/key, same
+  relative order, same parent context, or fallback/fresh allocation
+
+This can begin as assertions in tests rather than a reusable library type.
+
+## Steps
+
+1. **Inventory Markdown heading projection**
+   - Locate the Markdown projection shape for headings.
+   - Confirm which `ProjNode` corresponds to a heading-level editing entity.
+   - Confirm whether token spans are currently populated for heading marker/text.
+
+2. **Add test-only heading observation helpers**
+   - Walk a Markdown `ProjNode` tree and collect heading observations keyed by
+     `NodeId`.
+   - Read current anchors from `SourceMap`.
+   - Keep helpers package-private or white-box-test-local unless reuse is proven.
+
+3. **Pin baseline identity behavior**
+   - Write tests for:
+     - rename: `# A` → `# A2`
+     - reorder: `# A\n# B` → `# B\n# A`
+     - duplicate headings: `# A\n# A`
+     - delete and restore
+     - malformed/intermediate input followed by recovery
+     - large paste or formatter-like rewrite
+   - For each case, assert either preservation or an explicit, documented fresh /
+     ambiguous outcome.
+
+4. **Record evidence for failures**
+   - For cases where `NodeId` is not preserved but preservation seems desirable,
+     record the evidence that would have allowed a better match.
+   - Classify whether the fix belongs in:
+     - Markdown edit hints,
+     - projection reconciliation,
+     - `ProjectionIdentityTracker`-style item realignment,
+     - a side-table mapping from semantic entity IDs to current `NodeId`s,
+     - or a future SDEG core.
+
+5. **Validate edit-path compatibility**
+   - If a rename/edit operation is included, route it through existing Markdown
+     edit lowering and editor application.
+   - Confirm the spike does not mutate the observation side tables as the source
+     of truth.
+
+6. **Write the spike conclusion**
+   - Update this plan or add a short result note summarizing:
+     - what existing identity already covers,
+     - which cases fail,
+     - which extension point should be tried next,
+     - whether a distinct `EntityId` is justified yet.
+
+## Acceptance Criteria
+
+- [ ] Markdown heading observations can be collected from existing projection and
+      source-map data.
+- [ ] Tests cover rename, reorder, duplicate headings, delete/restore,
+      malformed recovery, and paste/formatter-like rewrites.
+- [ ] Each test has an explicit identity expectation: preserve, fresh,
+      ambiguous, or known limitation.
+- [ ] Any identity failure includes recorded evidence and a proposed owner for a
+      future fix.
+- [ ] No public `EntityId` or `sdeg-*` package is introduced.
+- [ ] Existing Markdown edit application remains on the language/edit/editor path.
+- [ ] The result is summarized against the decision gates in
+      `docs/design/stable-document-entity-graph.md`.
+
+## Validation
+
+From the workspace root:
+
+```bash
+moon check
+moon test
+moon fmt && moon info
+```
+
+For the Markdown slice, also run the relevant Markdown packages once the touched
+files are known. Prefer package-local validation first, then the workspace root
+commands above.
+
+After `moon info`, inspect generated interface drift:
+
+```bash
+git diff -- '*.mbti'
+```
+
+Expected result for a test-only/internal spike: no unintended public interface
+expansion.
+
+## Risks
+
+- Existing `NodeId` may be stable enough for simple edits but not for reorder or
+  duplicate headings. That is useful evidence, not failure of the spike.
+- Adding reusable abstractions too early could create a second identity system.
+  Keep the first slice observational.
+- Markdown projection shape may not expose heading entities at exactly the level
+  desired by SDEG. If so, record whether the projection shape or the stable
+  entity layer should adapt.
+- Range unit mistakes are easy because positions are plain integers in several
+  APIs. Keep all spike anchors in UTF-16 source coordinates.
+- Malformed-input recovery may belong in Loom's projection identity tracker, not
+  Canopy core. Do not duplicate that mechanism without a concrete gap.
+
+## Notes
+
+Related docs:
+
+- `docs/design/stable-document-entity-graph.md`
+- `docs/architecture/responsibility-map.md`
+- `docs/decisions/2026-06-01-identity-and-reuse-mechanisms.md`
+- `docs/decisions/2026-06-13-range-span-unit-boundaries.md`
+
+Recommended next decision after the spike:
+
+- If existing projection identity is sufficient, continue with side tables over
+  `NodeId`.
+- If specific matching cases fail, extend hints or item realignment first.
+- If reload/peer durability or graph relations become mandatory, plan a separate
+  SDEG core with explicit stability scope and adapters.

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -131,19 +131,46 @@ This can begin as assertions in tests rather than a reusable library type.
      - which extension point should be tried next,
      - whether a distinct `EntityId` is justified yet.
 
+## Spike Results
+
+Initial white-box tests in `lang/markdown/proj/` show that existing projection
+identity is a viable Phase 0 substrate for Markdown headings, with clear limits.
+
+Observed:
+- `SourceMap` can anchor heading entity observations with the full heading range,
+  the marker token span, and the text token span.
+- A heading rename preserves the session-local `NodeId`.
+- Duplicate headings remain distinguishable by `NodeId` and source range.
+- Inline malformed-to-recovered heading content preserves the heading `NodeId`.
+- Whitespace-only / formatter-like rewrites around headings preserve heading
+  `NodeId`s.
+
+Limitations:
+- Reordering sibling headings is currently position-stable, not
+  semantic-stable: identity stays with the projection position instead of
+  following the heading text/key.
+- Delete followed by restore does not recover the retired heading identity;
+  there is no tombstone or last-good semantic side table yet.
+
+Decision:
+- Continue with `NodeId` side tables for the next slice.
+- Do not introduce a public `EntityId` or `sdeg-*` package yet.
+- Next target: test-only matching evidence and lifecycle observation for
+  reorder and delete/restore cases.
+
 ## Acceptance Criteria
 
-- [ ] Markdown heading observations can be collected from existing projection and
+- [x] Markdown heading observations can be collected from existing projection and
       source-map data.
-- [ ] Tests cover rename, reorder, duplicate headings, delete/restore,
+- [x] Tests cover rename, reorder, duplicate headings, delete/restore,
       malformed recovery, and paste/formatter-like rewrites.
-- [ ] Each test has an explicit identity expectation: preserve, fresh,
+- [x] Each test has an explicit identity expectation: preserve, fresh,
       ambiguous, or known limitation.
 - [ ] Any identity failure includes recorded evidence and a proposed owner for a
       future fix.
-- [ ] No public `EntityId` or `sdeg-*` package is introduced.
-- [ ] Existing Markdown edit application remains on the language/edit/editor path.
-- [ ] The result is summarized against the decision gates in
+- [x] No public `EntityId` or `sdeg-*` package is introduced.
+- [x] Existing Markdown edit application remains on the language/edit/editor path.
+- [x] The result is summarized against the decision gates in
       `docs/design/stable-document-entity-graph.md`.
 
 ## Validation

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -161,8 +161,12 @@ Decision:
   these two gaps: pure sibling reorder falls into a changed window and receives
   fresh IDs, and a committed delete drops the old item from the successful
   baseline.
-- Next target: try semantic side-table matching over `NodeId`, with explicit
-  handling for move/reorder and tombstone recovery candidates.
+- A test-only semantic side-table matcher over `NodeId` can follow simple
+  reorder, find delete/restore recovery candidates if the old observation is
+  retained, and mark duplicate headings ambiguous.
+- Next target: promote the test-only matcher shape into an internal design for
+  `NodeId` side tables with lifecycle/tombstone retention, while keeping public
+  APIs unchanged.
 
 ## Acceptance Criteria
 

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -164,6 +164,9 @@ Decision:
 - A test-only semantic side-table matcher over `NodeId` can follow simple
   reorder, find delete/restore recovery candidates if the old observation is
   retained, and mark duplicate headings ambiguous.
+- Edit-path compatibility remains unvalidated by this spike: the tests exercise
+  parse/projection/reconcile directly rather than `MarkdownEditOp`,
+  `compute_markdown_edit`, or `SyncEditor` application.
 - Next target: promote the test-only matcher shape into an internal design for
   `NodeId` side tables with lifecycle/tombstone retention, while keeping public
   APIs unchanged.
@@ -179,7 +182,7 @@ Decision:
 - [x] Any identity failure includes recorded evidence and a proposed owner for a
       future fix.
 - [x] No public `EntityId` or `sdeg-*` package is introduced.
-- [x] Existing Markdown edit application remains on the language/edit/editor path.
+- [ ] Existing Markdown edit application remains on the language/edit/editor path.
 - [x] The result is summarized against the decision gates in
       `docs/design/stable-document-entity-graph.md`.
 

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -157,9 +157,12 @@ Decision:
 - Do not introduce a public `EntityId` or `sdeg-*` package yet.
 - Test-only matching evidence can already detect semantic reorder mismatches and
   delete/restore recovery candidates without changing document behavior.
-- Next target: decide whether that evidence should feed improved Markdown edit
-  hints, `ProjectionIdentityTracker`-style item realignment, or a semantic
-  side-table mapping.
+- `ProjectionIdentityTracker` / `realign_projection_items` is not sufficient for
+  these two gaps: pure sibling reorder falls into a changed window and receives
+  fresh IDs, and a committed delete drops the old item from the successful
+  baseline.
+- Next target: try semantic side-table matching over `NodeId`, with explicit
+  handling for move/reorder and tombstone recovery candidates.
 
 ## Acceptance Criteria
 

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -155,8 +155,11 @@ Limitations:
 Decision:
 - Continue with `NodeId` side tables for the next slice.
 - Do not introduce a public `EntityId` or `sdeg-*` package yet.
-- Next target: test-only matching evidence and lifecycle observation for
-  reorder and delete/restore cases.
+- Test-only matching evidence can already detect semantic reorder mismatches and
+  delete/restore recovery candidates without changing document behavior.
+- Next target: decide whether that evidence should feed improved Markdown edit
+  hints, `ProjectionIdentityTracker`-style item realignment, or a semantic
+  side-table mapping.
 
 ## Acceptance Criteria
 
@@ -166,7 +169,7 @@ Decision:
       malformed recovery, and paste/formatter-like rewrites.
 - [x] Each test has an explicit identity expectation: preserve, fresh,
       ambiguous, or known limitation.
-- [ ] Any identity failure includes recorded evidence and a proposed owner for a
+- [x] Any identity failure includes recorded evidence and a proposed owner for a
       future fix.
 - [x] No public `EntityId` or `sdeg-*` package is introduced.
 - [x] Existing Markdown edit application remains on the language/edit/editor path.

--- a/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
+++ b/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
@@ -1,0 +1,280 @@
+# SDEG Phase 1 NodeId Side Table Design
+
+## Why
+
+The Phase 0 Markdown heading spike showed that Canopy's existing projection
+identity pipeline is a good substrate for stable editing entities, but `NodeId`
+itself is not semantic identity:
+
+- heading rename, malformed inline recovery, and whitespace rewrites preserve
+  `NodeId`;
+- sibling reorder is position-stable rather than semantic-stable;
+- committed delete/restore cannot recover a retired heading identity;
+- `ProjectionIdentityTracker` / `realign_projection_items` does not cover those
+  two gaps;
+- a test-only semantic matcher can detect simple reorder, delete/restore
+  recovery candidates, and duplicate-heading ambiguity.
+
+This plan designs the next internal slice: a package-private Markdown heading
+side table over `NodeId`, not a new public SDEG core.
+
+## Scope
+
+In:
+- `lang/markdown/proj/` package-private heading identity helpers.
+- White-box tests in `lang/markdown/proj/`.
+- Existing `NodeId`, `ProjNode`, `SourceMap`, and token spans.
+- Documentation updates to this plan and the Phase 0 plan if conclusions change.
+
+Out:
+- public `EntityId` or `sdeg-*` packages.
+- CRDT / event-graph-walker anchor integration.
+- reload-stable or peer-stable identity.
+- frontend protocol changes.
+- generic cross-language entity graph abstractions.
+- production UI behavior changes until tests prove the model.
+
+## Current State
+
+The current spike file `lang/markdown/proj/sdeg_heading_spike_wbtest.mbt`
+contains test-only observations and match evidence. It proves:
+
+- `SourceMap` can provide UTF-16 heading anchors and marker/text token spans.
+- `NodeId` is a usable current projection handle.
+- semantic side-table matching over observations can classify:
+  - unique semantic match;
+  - ambiguous duplicate-heading match;
+  - missing heading.
+
+The missing piece is lifecycle: retaining old observations across snapshots and
+mapping a stable session entity to its current `NodeId` when the projection
+`NodeId` changes.
+
+## Desired State
+
+A Markdown-internal side table can answer:
+
+- Which session-local heading entity does this current `NodeId` represent?
+- Which current `NodeId`, if any, represents this retained heading entity?
+- Was a heading preserved by `NodeId`, semantically reattached, newly spawned,
+  missing, ambiguous, or retired?
+- What evidence justifies that decision?
+
+The side table remains internal and session-local. It does not promise reload or
+peer durability.
+
+## Design
+
+### Identity vocabulary
+
+Use two names to avoid confusing projection identity with semantic identity:
+
+- **Current node**: the current projection `NodeId` attached to a `ProjNode`.
+- **Session entity ref**: a package-private stable ref for a heading entity,
+  initially derived from the first `NodeId` that represented it.
+
+A session entity ref may be represented as a private wrapper around `NodeId` in
+implementation, but it must not be exposed as a public `EntityId`. Its contract
+is only "stable within this editor session and this side table".
+
+### Core records
+
+Implementation can start with package-private types like these names. Exact
+field names may change during implementation.
+
+```moonbit
+struct HeadingSignature {
+  level : Int
+  text : String
+}
+
+struct HeadingObservation {
+  node_id : @core.NodeId
+  signature : HeadingSignature
+  range : @loomcore.Range
+  marker : @loomcore.Range?
+  text_span : @loomcore.Range?
+  ordinal : Int
+}
+
+struct HeadingEntityRef {
+  origin_node : @core.NodeId
+}
+
+enum HeadingEntityStatus {
+  Live(current~ : @core.NodeId)
+  Missing
+  Tombstoned
+  Ambiguous(candidates~ : Array[@core.NodeId])
+  Retired
+}
+
+struct HeadingEntityRecord {
+  entity : HeadingEntityRef
+  status : HeadingEntityStatus
+  last_observation : HeadingObservation
+  last_seen_epoch : Int
+}
+
+enum HeadingMatchConfidence {
+  High
+  Medium
+  Ambiguous
+  Missing
+}
+
+struct HeadingMatchEvidence {
+  same_signature : Bool
+  range_overlaps : Bool
+  ordinal_distance : Int
+  candidate_count : Int
+  node_id_preserved : Bool
+  confidence : HeadingMatchConfidence
+}
+```
+
+Keep these private until a second language needs the same pattern.
+
+### Side-table shape
+
+The internal table should maintain both directions:
+
+```text
+entity_ref -> HeadingEntityRecord
+current_node_id -> entity_ref
+```
+
+The current-node index is rebuilt each update from live records. The entity
+records retain missing/tombstoned observations for recovery.
+
+### Matching pipeline
+
+For each successful projection snapshot:
+
+1. Extract current heading observations from `ProjNode` + `SourceMap`.
+2. Match by preserved current `NodeId` first.
+   - If an existing live record's current node still appears, keep that entity.
+3. Match remaining current observations against retained records by semantic
+   evidence.
+   - Primary key: heading level + normalized heading text.
+   - Tie-breakers: range overlap, ordinal distance, surrounding section context
+     if available later.
+4. Classify unmatched retained records.
+   - `Live -> Missing` when absent for the first update.
+   - `Missing -> Tombstoned` when still absent after the retention threshold.
+   - `Tombstoned -> Retired` only after an explicit GC policy exists.
+5. Classify unmatched current observations.
+   - Spawn a new session entity unless the candidate set is ambiguous.
+6. Rebuild the current-node index.
+
+### Confidence rules for Phase 1
+
+Start deliberately conservative:
+
+- **High**: exactly one retained record and exactly one current observation share
+  the same signature, or the current `NodeId` is preserved.
+- **Ambiguous**: more than one retained or current observation shares the same
+  signature.
+- **Missing**: no current observation matches a retained record.
+- **Medium**: reserve for future range/ordinal/context-assisted matches; do not
+  rely on it in Phase 1 behavior.
+
+This means duplicate headings remain ambiguous instead of being guessed.
+
+### Lifecycle policy
+
+Initial lifecycle should be observable and conservative:
+
+```text
+Live -> Missing      when no match exists in the current successful projection
+Missing -> Live      when a unique semantic match returns
+Missing -> Tombstoned after N successful epochs, where N is small/test-controlled
+Tombstoned -> Live   when a unique semantic recovery match appears
+Tombstoned -> Retired only in tests that explicitly exercise GC policy
+Ambiguous -> Live    when ambiguity resolves uniquely
+Ambiguous -> Missing if all candidates disappear
+```
+
+For Phase 1, the default retention can be "keep all tombstones during the test".
+Do not introduce production GC until UI/undo/reload requirements are clearer.
+
+### Expected behavior
+
+- Rename: preserved by `NodeId`; signature changes on the same entity.
+- Reorder: semantic side table maps old A to current A and old B to current B
+  even when projection `NodeId`s swapped.
+- Delete: missing/tombstoned record retained for the deleted heading.
+- Restore: unique semantic match recovers the retained entity with a new current
+  `NodeId`.
+- Duplicate headings: ambiguous; no semantic reattachment unless future evidence
+  disambiguates.
+
+## Steps
+
+1. Extract the test-only observation helpers into package-private helpers inside
+   `lang/markdown/proj/`, still not public.
+2. Add a package-private `HeadingEntityTable` with entity records and current-node
+   index.
+3. Implement update-from-observations for one successful projection snapshot.
+4. Add tests for:
+   - rename keeps one entity and updates its signature;
+   - reorder preserves semantic entities despite current `NodeId` changes;
+   - delete marks the entity missing/tombstoned;
+   - restore recovers the retained entity;
+   - duplicates produce ambiguity rather than guessed identity.
+5. Keep all behavior test-local until the table is needed by a real consumer.
+6. Summarize whether the table should graduate to a generic SDEG-internal
+   abstraction or remain Markdown-owned.
+
+## Acceptance Criteria
+
+- [ ] No public `.mbti` surface changes.
+- [ ] Heading observations are extracted from existing `ProjNode` + `SourceMap`.
+- [ ] Side table preserves semantic identity across simple sibling reorder.
+- [ ] Side table marks delete as missing/tombstoned without deleting the record.
+- [ ] Side table recovers a uniquely restored heading from retained observation.
+- [ ] Duplicate headings are marked ambiguous.
+- [ ] Tests document which evidence produced each decision.
+- [ ] No CRDT, frontend protocol, or public SDEG package changes.
+
+## Validation
+
+```bash
+moon check
+moon test lang/markdown/proj
+moon test
+NEW_MOON_MOD=0 moon fmt
+NEW_MOON_MOD=0 moon info
+git diff -- '*.mbti'
+```
+
+The expected `.mbti` diff is empty. If `moon info` introduces unrelated trailing
+blank-line churn in generated interfaces, revert those unrelated files before
+committing.
+
+## Risks
+
+- A private wrapper around `NodeId` can become a de facto public `EntityId` if it
+  escapes. Keep it package-private.
+- Text+level matching is intentionally weak. It is useful for the first slice but
+  must mark duplicates ambiguous.
+- Retaining tombstones without GC can grow unbounded. Phase 1 should keep this
+  test-local or editor-session-local until a retention policy is designed.
+- Reorder behavior may need edit provenance later. Do not encode current simple
+  matching as the final SDEG algorithm.
+- The side table should not mutate document state or bypass Markdown edit
+  lowering.
+
+## Notes
+
+This design supports the current direction:
+
+```text
+current projection handle = NodeId
+session semantic continuity = internal side table
+future durable identity = only if reload/peer requirements demand it
+```
+
+If this phase succeeds, the next design question is how to expose side-table facts
+to derived views through `incr` without making the table itself the document
+source of truth.

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -35,6 +35,21 @@ struct HeadingMatchEvidence {
 } derive(Eq, Debug)
 
 ///|
+enum HeadingSemanticConfidence {
+  SemanticHigh
+  SemanticAmbiguous
+  SemanticMissing
+} derive(Eq, Debug)
+
+///|
+struct HeadingSemanticMatch {
+  previous_id : @core.NodeId
+  current_id : @core.NodeId?
+  confidence : HeadingSemanticConfidence
+  candidate_count : Int
+} derive(Eq, Debug)
+
+///|
 fn inline_text_to(
   inlines : Array[@markdown.Inline],
   buf : StringBuilder,
@@ -218,6 +233,39 @@ fn realign_headings_from_baseline(
 }
 
 ///|
+fn semantic_match_heading(
+  previous : HeadingObservation,
+  current : Array[HeadingObservation],
+) -> HeadingSemanticMatch {
+  let candidates : Array[HeadingObservation] = current
+    .iter()
+    .filter(fn(obs) { obs.level == previous.level && obs.text == previous.text })
+    .collect()
+  if candidates.length() == 1 {
+    {
+      previous_id: previous.id,
+      current_id: Some(candidates[0].id),
+      confidence: SemanticHigh,
+      candidate_count: 1,
+    }
+  } else if candidates.length() == 0 {
+    {
+      previous_id: previous.id,
+      current_id: None,
+      confidence: SemanticMissing,
+      candidate_count: 0,
+    }
+  } else {
+    {
+      previous_id: previous.id,
+      current_id: None,
+      confidence: SemanticAmbiguous,
+      candidate_count: candidates.length(),
+    }
+  }
+}
+
+///|
 fn heading_match_evidence(
   previous : HeadingObservation,
   current : HeadingObservation,
@@ -381,6 +429,36 @@ test "sdeg phase0: matching evidence detects semantic reorder mismatch" {
 }
 
 ///|
+test "sdeg phase0: semantic side-table matcher follows simple heading reorder" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n# B\n", initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+
+  let (reordered, reordered_map) = project_after_reconcile(
+    initial, "# B\n# A\n", counter,
+  )
+  let after = collect_heading_observations(reordered, reordered_map)
+  let a_after = find_heading(after, "A").unwrap()
+  let b_after = find_heading(after, "B").unwrap()
+  let a_match = semantic_match_heading(a_before, after)
+  let b_match = semantic_match_heading(b_before, after)
+
+  inspect(a_match.confidence == SemanticHigh, content="true")
+  inspect(b_match.confidence == SemanticHigh, content="true")
+  inspect(a_match.current_id == Some(a_after.id), content="true")
+  inspect(b_match.current_id == Some(b_after.id), content="true")
+  inspect(a_match.current_id == Some(a_before.id), content="false")
+  inspect(b_match.current_id == Some(b_before.id), content="false")
+}
+
+///|
 test "sdeg phase0: duplicate headings remain distinguishable by NodeId and range" {
   let (proj, source_map) = project_source("# A\n# A\n")
   let observations = collect_heading_observations(proj, source_map)
@@ -389,6 +467,19 @@ test "sdeg phase0: duplicate headings remain distinguishable by NodeId and range
   inspect(observations[1].text, content="A")
   inspect(observations[0].id == observations[1].id, content="false")
   inspect(observations[0].range == observations[1].range, content="false")
+}
+
+///|
+test "sdeg phase0: semantic side-table matcher marks duplicate headings ambiguous" {
+  let (proj, source_map) = project_source("# A\n# A\n")
+  let observations = collect_heading_observations(proj, source_map)
+  let match0 = semantic_match_heading(observations[0], observations)
+  let match1 = semantic_match_heading(observations[1], observations)
+
+  inspect(match0.confidence == SemanticAmbiguous, content="true")
+  inspect(match1.confidence == SemanticAmbiguous, content="true")
+  inspect(match0.candidate_count, content="2")
+  inspect(match1.candidate_count, content="2")
 }
 
 ///|
@@ -484,6 +575,35 @@ test "sdeg phase0: matching evidence detects delete-restore recovery candidate" 
   inspect(evidence.outcome == SemanticMatchWithDifferentNodeId, content="true")
   inspect(evidence.same_text && evidence.same_level, content="true")
   inspect(evidence.node_id_preserved, content="false")
+}
+
+///|
+test "sdeg phase0: semantic side-table matcher finds delete-restore candidate" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n# B\n", initial)
+  let a_initial = find_heading(
+    collect_heading_observations(initial, initial_map),
+    "A",
+  ).unwrap()
+
+  let (deleted, _) = project_after_reconcile(initial, "# B\n", counter)
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, "# A\n# B\n", counter,
+  )
+  let restored_observations = collect_heading_observations(
+    restored, restored_map,
+  )
+  let a_restored = find_heading(restored_observations, "A").unwrap()
+  let match_result = semantic_match_heading(a_initial, restored_observations)
+
+  inspect(match_result.confidence == SemanticHigh, content="true")
+  inspect(match_result.current_id == Some(a_restored.id), content="true")
+  inspect(match_result.current_id == Some(a_initial.id), content="false")
 }
 
 ///|

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -158,6 +158,66 @@ fn ranges_overlap(a : @loomcore.Range, b : @loomcore.Range) -> Bool {
 }
 
 ///|
+fn heading_key(obs : HeadingObservation) -> String {
+  "h\{obs.level}:\{obs.text}"
+}
+
+///|
+fn heading_leaf(obs : HeadingObservation) -> @loomcore.ProjectionLeaf {
+  @loomcore.ProjectionLeaf::new(
+    obs.range.start,
+    obs.range.end,
+    heading_key(obs),
+  )
+}
+
+///|
+fn stable_heading_leaf(
+  obs : HeadingObservation,
+) -> @loomcore.StableProjectionLeaf[@core.NodeId] {
+  @loomcore.StableProjectionLeaf::new(
+    obs.range.start,
+    obs.range.end,
+    heading_key(obs),
+    obs.id,
+  )
+}
+
+///|
+fn heading_baseline(
+  source : String,
+  observations : Array[HeadingObservation],
+) -> @loomcore.ProjectionIdentityBaseline[@core.NodeId] {
+  @loomcore.ProjectionIdentityBaseline::new(
+    source,
+    observations.map(stable_heading_leaf),
+  )
+}
+
+///|
+fn realign_headings_from_baseline(
+  baseline : @loomcore.ProjectionIdentityBaseline[@core.NodeId],
+  next_source : String,
+  observations : Array[HeadingObservation],
+  fresh_start : Int,
+) -> Array[HeadingObservation] {
+  let fresh_counter : Ref[Int] = Ref(fresh_start)
+  @loomcore.realign_projection_items_with_optional_edit(
+    baseline,
+    next_source,
+    observations,
+    heading_leaf,
+    fn(obs, id) { { ..obs, id, } },
+    fn(_leaf) {
+      let id = @core.NodeId::from_int(fresh_counter.val)
+      fresh_counter.val = fresh_counter.val + 1
+      id
+    },
+    None,
+  )
+}
+
+///|
 fn heading_match_evidence(
   previous : HeadingObservation,
   current : HeadingObservation,
@@ -251,6 +311,40 @@ test "sdeg phase0: heading reorder is currently position-stable, not semantic-st
 }
 
 ///|
+test "sdeg phase0: ProjectionIdentityTracker does not solve heading reorder" {
+  let counter : Ref[Int] = Ref(0)
+  let source = "# A\n# B\n"
+  let next_source = "# B\n# A\n"
+  let (initial_cst, _) = @markdown.parse_cst(source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(source, initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let baseline = heading_baseline(source, before)
+
+  let (reordered, reordered_map) = project_after_reconcile(
+    initial, next_source, counter,
+  )
+  let after = collect_heading_observations(reordered, reordered_map)
+  let realigned = realign_headings_from_baseline(
+    baseline, next_source, after, 1000,
+  )
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+  let a_realigned = find_heading(realigned, "A").unwrap()
+  let b_realigned = find_heading(realigned, "B").unwrap()
+
+  // The existing ProjectionIdentityTracker/realign_projection_items algorithm is
+  // edit-window oriented. It is useful for malformed-input recovery and local
+  // replacement windows, but a pure sibling reorder falls into the changed
+  // window and receives fresh IDs rather than semantic move identities.
+  inspect(a_realigned.id == a_before.id, content="false")
+  inspect(b_realigned.id == b_before.id, content="false")
+}
+
+///|
 test "sdeg phase0: matching evidence detects semantic reorder mismatch" {
   let counter : Ref[Int] = Ref(0)
   let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
@@ -323,6 +417,44 @@ test "sdeg phase0: delete and restore currently cannot recover the retired headi
   // Without a tombstone/baseline side table, restoring text creates or reuses a
   // projection identity from the current tree, not the retired semantic heading.
   inspect(a_restored.id == a_initial.id, content="false")
+}
+
+///|
+test "sdeg phase0: ProjectionIdentityTracker does not recover after committed delete" {
+  let counter : Ref[Int] = Ref(0)
+  let initial_source = "# A\n# B\n"
+  let deleted_source = "# B\n"
+  let restored_source = "# A\n# B\n"
+  let (initial_cst, _) = @markdown.parse_cst(initial_source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(initial_source, initial)
+  let initial_observations = collect_heading_observations(initial, initial_map)
+  let a_initial = find_heading(initial_observations, "A").unwrap()
+
+  let (deleted, deleted_map) = project_after_reconcile(
+    initial, deleted_source, counter,
+  )
+  let deleted_observations = collect_heading_observations(deleted, deleted_map)
+  let deleted_baseline = heading_baseline(deleted_source, deleted_observations)
+
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, restored_source, counter,
+  )
+  let restored_observations = collect_heading_observations(
+    restored, restored_map,
+  )
+  let realigned = realign_headings_from_baseline(
+    deleted_baseline, restored_source, restored_observations, 2000,
+  )
+  let a_realigned = find_heading(realigned, "A").unwrap()
+
+  // Once deletion has committed as the successful baseline, the old A identity
+  // is no longer present for ProjectionIdentityTracker to preserve. Recovering
+  // it requires a tombstone/semantic side table rather than item realignment.
+  inspect(a_realigned.id == a_initial.id, content="false")
 }
 
 ///|

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -1,0 +1,287 @@
+///| Whitebox spike tests for the Stable Document Entity Graph Phase 0 idea.
+
+///|
+/// These tests intentionally do not add a public SDEG API. They treat Markdown
+/// headings as session-local entities backed by existing `NodeId`, `ProjNode`,
+/// and `SourceMap` data, then pin what the current projection identity pipeline
+/// already preserves and where it is still only position-stable.
+
+///|
+struct HeadingObservation {
+  id : @core.NodeId
+  level : Int
+  text : String
+  range : @loomcore.Range
+  marker : @loomcore.Range?
+  text_span : @loomcore.Range?
+} derive(Eq, Debug)
+
+///|
+fn inline_text_to(
+  inlines : Array[@markdown.Inline],
+  buf : StringBuilder,
+) -> Unit {
+  for inline in inlines {
+    match inline {
+      Text(s) => buf.write_string(s)
+      Bold(children) => inline_text_to(children, buf)
+      Italic(children) => inline_text_to(children, buf)
+      InlineCode(s) => buf.write_string(s)
+      Link(children, _url) => inline_text_to(children, buf)
+      Error(s) => buf.write_string(s)
+    }
+  }
+}
+
+///|
+fn inline_text(inlines : Array[@markdown.Inline]) -> String {
+  let buf = StringBuilder::new()
+  inline_text_to(inlines, buf)
+  buf.to_string()
+}
+
+///|
+fn heading_observation(
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+) -> HeadingObservation? {
+  match node.kind {
+    Heading(level, inlines) =>
+      match source_map.get_range(node.id()) {
+        Some(range) =>
+          Some({
+            id: node.id(),
+            level,
+            text: inline_text(inlines),
+            range,
+            marker: source_map.get_token_span(node.id(), "marker"),
+            text_span: source_map.get_token_span(node.id(), "text"),
+          })
+        None => None
+      }
+    _ => None
+  }
+}
+
+///|
+fn collect_heading_observations_into(
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+  out : Array[HeadingObservation],
+) -> Unit {
+  match heading_observation(node, source_map) {
+    Some(obs) => out.push(obs)
+    None => ()
+  }
+  for child in node.children {
+    collect_heading_observations_into(child, source_map, out)
+  }
+}
+
+///|
+fn collect_heading_observations(
+  root : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+) -> Array[HeadingObservation] {
+  let out : Array[HeadingObservation] = []
+  collect_heading_observations_into(root, source_map, out)
+  out
+}
+
+///|
+fn source_map_for(
+  source : String,
+  proj : @core.ProjNode[@markdown.Block],
+) -> @core.SourceMap raise @loomcore.LexError {
+  let source_map = @core.SourceMap::from_ast(proj)
+  let (cst, _) = @markdown.parse_cst(source)
+  let syntax_root = @seam.SyntaxNode::from_cst(cst)
+  populate_token_spans(source_map, syntax_root, proj)
+  source_map
+}
+
+///|
+fn project_source(
+  source : String,
+) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise @loomcore.LexError {
+  let (proj, _) = parse_to_proj_node(source)
+  (proj, source_map_for(source, proj))
+}
+
+///|
+fn project_after_reconcile(
+  old : @core.ProjNode[@markdown.Block],
+  next_source : String,
+  counter : Ref[Int],
+) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise @loomcore.LexError {
+  let (cst, _) = @markdown.parse_cst(next_source)
+  let syntax_root = @seam.SyntaxNode::from_cst(cst)
+  let raw = syntax_to_proj_node(syntax_root, counter)
+  let reconciled = @core.reconcile(old, raw, counter)
+  (reconciled, source_map_for(next_source, reconciled))
+}
+
+///|
+fn find_heading(
+  observations : Array[HeadingObservation],
+  text : String,
+) -> HeadingObservation? {
+  observations.iter().find_first(fn(obs) { obs.text == text })
+}
+
+///|
+fn range_contains(outer : @loomcore.Range, inner : @loomcore.Range) -> Bool {
+  outer.start <= inner.start && inner.end <= outer.end
+}
+
+///|
+test "sdeg phase0: heading observation is backed by SourceMap ranges" {
+  let (proj, source_map) = project_source("# Title\n\nBody")
+  let observations = collect_heading_observations(proj, source_map)
+  inspect(observations.length(), content="1")
+  let heading = observations[0]
+  inspect(heading.level, content="1")
+  inspect(heading.text, content="Title")
+  inspect(heading.range.start, content="0")
+  inspect(heading.marker is Some(_), content="true")
+  inspect(heading.text_span is Some(_), content="true")
+  match (heading.marker, heading.text_span) {
+    (Some(marker), Some(text_span)) => {
+      inspect(range_contains(heading.range, marker), content="true")
+      inspect(range_contains(heading.range, text_span), content="true")
+    }
+    _ => fail("expected heading marker and text spans")
+  }
+}
+
+///|
+test "sdeg phase0: heading rename preserves session-local NodeId" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# Alpha\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# Alpha\n", initial)
+  let initial_heading = collect_heading_observations(initial, initial_map)[0]
+
+  let (renamed, renamed_map) = project_after_reconcile(
+    initial, "# Alpha 2\n", counter,
+  )
+  let renamed_heading = collect_heading_observations(renamed, renamed_map)[0]
+
+  inspect(renamed_heading.id == initial_heading.id, content="true")
+  inspect(renamed_heading.text, content="Alpha 2")
+}
+
+///|
+test "sdeg phase0: heading reorder is currently position-stable, not semantic-stable" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n# B\n", initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+
+  let (reordered, reordered_map) = project_after_reconcile(
+    initial, "# B\n# A\n", counter,
+  )
+  let after = collect_heading_observations(reordered, reordered_map)
+  let b_after = find_heading(after, "B").unwrap()
+  let a_after = find_heading(after, "A").unwrap()
+
+  // Current generic reconcile matches same-kind siblings by position/LCS. That
+  // preserves UI positions, but it does not preserve the semantic identity of a
+  // moved heading. This is a Phase 0 finding, not the desired final behavior.
+  inspect(b_after.id == a_before.id, content="true")
+  inspect(a_after.id == b_before.id, content="true")
+}
+
+///|
+test "sdeg phase0: duplicate headings remain distinguishable by NodeId and range" {
+  let (proj, source_map) = project_source("# A\n# A\n")
+  let observations = collect_heading_observations(proj, source_map)
+  inspect(observations.length(), content="2")
+  inspect(observations[0].text, content="A")
+  inspect(observations[1].text, content="A")
+  inspect(observations[0].id == observations[1].id, content="false")
+  inspect(observations[0].range == observations[1].range, content="false")
+}
+
+///|
+test "sdeg phase0: delete and restore currently cannot recover the retired heading id" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n# B\n", initial)
+  let a_initial = find_heading(
+    collect_heading_observations(initial, initial_map),
+    "A",
+  ).unwrap()
+
+  let (deleted, _) = project_after_reconcile(initial, "# B\n", counter)
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, "# A\n# B\n", counter,
+  )
+  let a_restored = find_heading(
+    collect_heading_observations(restored, restored_map),
+    "A",
+  ).unwrap()
+
+  // Without a tombstone/baseline side table, restoring text creates or reuses a
+  // projection identity from the current tree, not the retired semantic heading.
+  inspect(a_restored.id == a_initial.id, content="false")
+}
+
+///|
+test "sdeg phase0: inline malformed-to-recovered heading preserves heading NodeId" {
+  let counter : Ref[Int] = Ref(0)
+  let malformed_source = "# **unclosed\n"
+  let (initial_cst, _) = @markdown.parse_cst(malformed_source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(malformed_source, initial)
+  let initial_heading = collect_heading_observations(initial, initial_map)[0]
+
+  let recovered_source = "# **unclosed**\n"
+  let (recovered, recovered_map) = project_after_reconcile(
+    initial, recovered_source, counter,
+  )
+  let recovered_heading = collect_heading_observations(recovered, recovered_map)[0]
+
+  inspect(recovered_heading.id == initial_heading.id, content="true")
+  inspect(recovered_heading.text.contains("unclosed"), content="true")
+}
+
+///|
+test "sdeg phase0: format-like whitespace rewrite preserves heading NodeIds" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n\n# B\n", initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+
+  let (rewritten, rewritten_map) = project_after_reconcile(
+    initial, "# A\n\n\n# B\n", counter,
+  )
+  let after = collect_heading_observations(rewritten, rewritten_map)
+  let a_after = find_heading(after, "A").unwrap()
+  let b_after = find_heading(after, "B").unwrap()
+
+  inspect(a_after.id == a_before.id, content="true")
+  inspect(b_after.id == b_before.id, content="true")
+}

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -17,6 +17,24 @@ struct HeadingObservation {
 } derive(Eq, Debug)
 
 ///|
+enum HeadingIdentityOutcome {
+  Preserved
+  SemanticMatchWithDifferentNodeId
+  Fresh
+} derive(Eq, Debug)
+
+///|
+struct HeadingMatchEvidence {
+  previous_id : @core.NodeId
+  current_id : @core.NodeId
+  outcome : HeadingIdentityOutcome
+  same_level : Bool
+  same_text : Bool
+  range_overlaps : Bool
+  node_id_preserved : Bool
+} derive(Eq, Debug)
+
+///|
 fn inline_text_to(
   inlines : Array[@markdown.Inline],
   buf : StringBuilder,
@@ -135,6 +153,37 @@ fn range_contains(outer : @loomcore.Range, inner : @loomcore.Range) -> Bool {
 }
 
 ///|
+fn ranges_overlap(a : @loomcore.Range, b : @loomcore.Range) -> Bool {
+  a.start < b.end && b.start < a.end
+}
+
+///|
+fn heading_match_evidence(
+  previous : HeadingObservation,
+  current : HeadingObservation,
+) -> HeadingMatchEvidence {
+  let node_id_preserved = previous.id == current.id
+  let same_level = previous.level == current.level
+  let same_text = previous.text == current.text
+  let outcome = if node_id_preserved {
+    Preserved
+  } else if same_level && same_text {
+    SemanticMatchWithDifferentNodeId
+  } else {
+    Fresh
+  }
+  {
+    previous_id: previous.id,
+    current_id: current.id,
+    outcome,
+    same_level,
+    same_text,
+    range_overlaps: ranges_overlap(previous.range, current.range),
+    node_id_preserved,
+  }
+}
+
+///|
 test "sdeg phase0: heading observation is backed by SourceMap ranges" {
   let (proj, source_map) = project_source("# Title\n\nBody")
   let observations = collect_heading_observations(proj, source_map)
@@ -202,6 +251,42 @@ test "sdeg phase0: heading reorder is currently position-stable, not semantic-st
 }
 
 ///|
+test "sdeg phase0: matching evidence detects semantic reorder mismatch" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n# B\n", initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+
+  let (reordered, reordered_map) = project_after_reconcile(
+    initial, "# B\n# A\n", counter,
+  )
+  let after = collect_heading_observations(reordered, reordered_map)
+  let a_after = find_heading(after, "A").unwrap()
+  let b_after = find_heading(after, "B").unwrap()
+  let a_evidence = heading_match_evidence(a_before, a_after)
+  let b_evidence = heading_match_evidence(b_before, b_after)
+
+  inspect(
+    a_evidence.outcome == SemanticMatchWithDifferentNodeId,
+    content="true",
+  )
+  inspect(
+    b_evidence.outcome == SemanticMatchWithDifferentNodeId,
+    content="true",
+  )
+  inspect(a_evidence.same_text && a_evidence.same_level, content="true")
+  inspect(b_evidence.same_text && b_evidence.same_level, content="true")
+  inspect(a_evidence.node_id_preserved, content="false")
+  inspect(b_evidence.node_id_preserved, content="false")
+}
+
+///|
 test "sdeg phase0: duplicate headings remain distinguishable by NodeId and range" {
   let (proj, source_map) = project_source("# A\n# A\n")
   let observations = collect_heading_observations(proj, source_map)
@@ -238,6 +323,35 @@ test "sdeg phase0: delete and restore currently cannot recover the retired headi
   // Without a tombstone/baseline side table, restoring text creates or reuses a
   // projection identity from the current tree, not the retired semantic heading.
   inspect(a_restored.id == a_initial.id, content="false")
+}
+
+///|
+test "sdeg phase0: matching evidence detects delete-restore recovery candidate" {
+  let counter : Ref[Int] = Ref(0)
+  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for("# A\n# B\n", initial)
+  let a_initial = find_heading(
+    collect_heading_observations(initial, initial_map),
+    "A",
+  ).unwrap()
+
+  let (deleted, _) = project_after_reconcile(initial, "# B\n", counter)
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, "# A\n# B\n", counter,
+  )
+  let a_restored = find_heading(
+    collect_heading_observations(restored, restored_map),
+    "A",
+  ).unwrap()
+  let evidence = heading_match_evidence(a_initial, a_restored)
+
+  inspect(evidence.outcome == SemanticMatchWithDifferentNodeId, content="true")
+  inspect(evidence.same_text && evidence.same_level, content="true")
+  inspect(evidence.node_id_preserved, content="false")
 }
 
 ///|

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -46,6 +46,7 @@ struct HeadingSemanticMatch {
   previous_id : @core.NodeId
   current_id : @core.NodeId?
   confidence : HeadingSemanticConfidence
+  retained_count : Int
   candidate_count : Int
 } derive(Eq, Debug)
 
@@ -235,32 +236,40 @@ fn realign_headings_from_baseline(
 ///|
 fn semantic_match_heading(
   previous : HeadingObservation,
+  retained : Array[HeadingObservation],
   current : Array[HeadingObservation],
 ) -> HeadingSemanticMatch {
+  let same_signature = fn(obs : HeadingObservation) {
+    obs.level == previous.level && obs.text == previous.text
+  }
+  let retained_count = retained.iter().filter(same_signature).count()
   let candidates : Array[HeadingObservation] = current
     .iter()
-    .filter(fn(obs) { obs.level == previous.level && obs.text == previous.text })
+    .filter(same_signature)
     .collect()
-  if candidates.length() == 1 {
+  if retained_count > 1 || candidates.length() > 1 {
+    {
+      previous_id: previous.id,
+      current_id: None,
+      confidence: SemanticAmbiguous,
+      retained_count,
+      candidate_count: candidates.length(),
+    }
+  } else if candidates.length() == 1 {
     {
       previous_id: previous.id,
       current_id: Some(candidates[0].id),
       confidence: SemanticHigh,
+      retained_count,
       candidate_count: 1,
-    }
-  } else if candidates.length() == 0 {
-    {
-      previous_id: previous.id,
-      current_id: None,
-      confidence: SemanticMissing,
-      candidate_count: 0,
     }
   } else {
     {
       previous_id: previous.id,
       current_id: None,
-      confidence: SemanticAmbiguous,
-      candidate_count: candidates.length(),
+      confidence: SemanticMissing,
+      retained_count,
+      candidate_count: 0,
     }
   }
 }
@@ -447,8 +456,8 @@ test "sdeg phase0: semantic side-table matcher follows simple heading reorder" {
   let after = collect_heading_observations(reordered, reordered_map)
   let a_after = find_heading(after, "A").unwrap()
   let b_after = find_heading(after, "B").unwrap()
-  let a_match = semantic_match_heading(a_before, after)
-  let b_match = semantic_match_heading(b_before, after)
+  let a_match = semantic_match_heading(a_before, before, after)
+  let b_match = semantic_match_heading(b_before, before, after)
 
   inspect(a_match.confidence == SemanticHigh, content="true")
   inspect(b_match.confidence == SemanticHigh, content="true")
@@ -473,13 +482,40 @@ test "sdeg phase0: duplicate headings remain distinguishable by NodeId and range
 test "sdeg phase0: semantic side-table matcher marks duplicate headings ambiguous" {
   let (proj, source_map) = project_source("# A\n# A\n")
   let observations = collect_heading_observations(proj, source_map)
-  let match0 = semantic_match_heading(observations[0], observations)
-  let match1 = semantic_match_heading(observations[1], observations)
+  let match0 = semantic_match_heading(
+    observations[0],
+    observations,
+    observations,
+  )
+  let match1 = semantic_match_heading(
+    observations[1],
+    observations,
+    observations,
+  )
 
   inspect(match0.confidence == SemanticAmbiguous, content="true")
   inspect(match1.confidence == SemanticAmbiguous, content="true")
   inspect(match0.candidate_count, content="2")
   inspect(match1.candidate_count, content="2")
+}
+
+///|
+test "sdeg phase0: retained duplicate headings stay ambiguous after one remains" {
+  let (previous_proj, previous_map) = project_source("# A\n# A\n")
+  let previous = collect_heading_observations(previous_proj, previous_map)
+  let (current_proj, current_map) = project_source("# A\n")
+  let current = collect_heading_observations(current_proj, current_map)
+  let match0 = semantic_match_heading(previous[0], previous, current)
+  let match1 = semantic_match_heading(previous[1], previous, current)
+
+  inspect(match0.confidence == SemanticAmbiguous, content="true")
+  inspect(match1.confidence == SemanticAmbiguous, content="true")
+  inspect(match0.retained_count, content="2")
+  inspect(match1.retained_count, content="2")
+  inspect(match0.candidate_count, content="1")
+  inspect(match1.candidate_count, content="1")
+  inspect(match0.current_id is None, content="true")
+  inspect(match1.current_id is None, content="true")
 }
 
 ///|
@@ -599,7 +635,11 @@ test "sdeg phase0: semantic side-table matcher finds delete-restore candidate" {
     restored, restored_map,
   )
   let a_restored = find_heading(restored_observations, "A").unwrap()
-  let match_result = semantic_match_heading(a_initial, restored_observations)
+  let match_result = semantic_match_heading(
+    a_initial,
+    [a_initial],
+    restored_observations,
+  )
 
   inspect(match_result.confidence == SemanticHigh, content="true")
   inspect(match_result.current_id == Some(a_restored.id), content="true")


### PR DESCRIPTION
## Summary
- document the Stable Document Entity Graph direction and Phase 0/Phase 1 plans
- add Markdown heading white-box spike tests over existing NodeId/ProjNode/SourceMap identity
- record findings for reorder, delete/restore, ProjectionIdentityTracker limits, and semantic side-table matching

## Review follow-ups
- retained duplicate heading matches now stay ambiguous (`# A\n# A\n` → `# A\n` does not let two retained entities claim one current `NodeId`)
- Phase 0 plan now leaves edit-path validation unchecked because the spike tests exercise parse/projection/reconcile directly, not `MarkdownEditOp` / `compute_markdown_edit` / `SyncEditor`

## Validation
- `moon check`
- `moon test lang/markdown/proj`
- `moon test`
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon info`
- inspected `git diff -- '*.mbti'` and reverted unrelated generated-interface whitespace churn

## CI
- Latest `gh pr checks 716` has all required jobs passing except `Compare Benchmarks`, which is still pending.

## Notes
- No public SDEG API or EntityId introduced.
- The existing dirty `loom` submodule in the worktree was not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation and planning for stable document entity graph infrastructure, including guidance on session-local entity stability and reconciliation strategies for Markdown headings.

* **Tests**
  * Added comprehensive test suite validating stable entity behavior across heading rename, reorder, delete, and restore scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
