### PR TITLE
Sketch SDEG NodeId side table

### DIFF
--- a/docs/design/sdeg-nodeid-side-table.md
+++ b/docs/design/sdeg-nodeid-side-table.md
@@ -1,0 +1,279 @@
+# SDEG NodeId Side Table Sketch
+
+**Status:** Internal design sketch. Not implemented behavior and not a public API.
+
+This note extracts the Phase 0 Markdown heading spike into the smallest
+side-table shape worth trying before adding a stable entity core or durable
+`EntityId`.
+
+## Intent
+
+Use existing projection `NodeId`s as session-local identity seeds, then keep a
+side table that maps each stable row to the current projection node when the
+entity is live.
+
+The side table is derived state. It must not become the document source of truth
+or bypass language-owned edit lowering.
+
+## First scope
+
+- Entity kind: Markdown headings.
+- Stability: editor session only.
+- Anchors: existing `SourceMap` UTF-16 ranges and token spans.
+- Storage: immutable snapshots or package-private helpers.
+- API: internal/test-local until a second consumer proves reuse.
+
+Out of scope: public `sdeg-*` packages, reload/peer-stable IDs, CRDT persistence,
+a graph store, or replacing projection reconciliation.
+
+## Closed core states, open evidence
+
+Keep control-flow state closed. Lifecycle transitions are invariants, so callers
+should be able to exhaustively reason about them.
+
+```moonbit
+enum EntityStatus {
+  Live
+  Tombstoned
+  Ambiguous
+  Retired
+}
+
+enum MatchConfidence {
+  Exact
+  Probable
+  Ambiguous
+  Missing
+}
+```
+
+Use extensible enums only for extension points whose unknown cases can be safely
+ignored or displayed generically. Matching evidence is the right first use:
+
+```moonbit
+pub(all) extenum EntityEvidence {
+  SameNodeId(NodeId)
+  SameSemanticKey(String)
+  OverlappingSourceRange(Range, Range)
+  CandidateCount(Int)
+}
+```
+
+A language package can add its own evidence without changing the shared shape:
+
+```moonbit
+pub(all) extenum @sdeg.EntityEvidence += {
+  SameHeadingLevel(Int)
+  SameHeadingText(String)
+  SameHeadingSection(String)
+}
+```
+
+Consumers must include a wildcard branch when matching evidence, because another
+package may add constructors later. Do not use `extenum` for lifecycle state or
+other values the core transition algorithm must fully understand.
+
+## Data shape
+
+Use a private wrapper for the stable row key so it is not confused with a current
+projection node. The wrapped value can still be seeded from the original
+`NodeId`.
+
+```moonbit
+struct StableRowId(NodeId)
+
+struct EntityObservation[Kind] {
+  node_id : NodeId
+  kind : Kind
+  semantic_key : String
+  source_range : Range
+  token_spans : Array[(String, Range)]
+}
+
+struct MatchCandidate {
+  node_id : NodeId
+  evidence : Array[EntityEvidence]
+}
+
+struct MatchResult {
+  confidence : MatchConfidence
+  candidates : Array[MatchCandidate]
+  evidence : Array[EntityEvidence]
+}
+
+struct EntityRow[Kind] {
+  stable_id : StableRowId
+  current_id : NodeId?
+  status : EntityStatus
+  last_live : EntityObservation[Kind]
+  candidates : Array[NodeId]
+  evidence : Array[EntityEvidence]
+}
+
+struct EntitySnapshot[Kind] {
+  rows : Array[EntityRow[Kind]]
+}
+```
+
+For Markdown headings, `semantic_key` starts as level plus normalized heading
+text. Other languages may need parent context, declaration role, scope path, or
+nearby-sibling evidence.
+
+## Matcher contract
+
+The matcher should be evidence-bearing, not boolean. A boolean `same_entity`
+throws away the information SDEG needs to explain identity decisions.
+
+```moonbit
+fn[Kind] match_entity(
+  previous : EntityObservation[Kind],
+  current : Array[EntityObservation[Kind]],
+) -> MatchResult
+```
+
+The matcher is language-owned. The side-table algorithm only interprets the
+closed `MatchConfidence` and candidate ids; it stores evidence for diagnostics,
+debug UI, and later confidence tuning.
+
+A preserved projection `NodeId` is an `Exact` candidate and should be considered
+before semantic-key candidates. Without edit provenance, a same-node match is the
+only evidence that the row's original session-local identity survived; a
+semantic singleton elsewhere is only a recovery candidate when the original node
+is absent.
+
+## Advance rule
+
+Given the previous `EntitySnapshot` and current observations:
+
+1. Exclude `Retired` rows from matching.
+2. Match each remaining prior row's `last_live` against current observations.
+3. Build a candidate graph from `StableRowId` to candidate current `NodeId`s.
+4. Resolve live matches as a global one-to-one assignment, not as independent row
+   decisions.
+5. A row becomes `Live` only when it has one assigned current node and no other
+   active row claims that node.
+6. A row becomes `Tombstoned` when it has no candidates.
+7. A row becomes `Ambiguous` when it has multiple candidates, when its only
+   candidate is also claimed by another active row, or when the assignment cannot
+   choose a unique row/node pair without guessing.
+8. Add a current observation as a fresh `Live` row only if it is neither assigned
+   to a live row nor listed as an ambiguous candidate for an existing row.
+
+The one-to-one assignment rule is required even when individual matchers return
+`Exact` or `Probable`: two old rows must never both become live at the same
+current projection node. On conflict, prefer `Ambiguous` with stored candidate
+ids and evidence over a plausible but unprovable match.
+
+Step 8 prevents duplicate representation: an ambiguous candidate must not also
+become a fresh live row until the ambiguity is resolved or the old row is
+retired.
+
+## Lifecycle
+
+```text
+new observation -> Live
+Live + unique match -> Live
+Live + no match -> Tombstoned
+Tombstoned + unique match -> Live
+Live/Tombstoned + multiple matches -> Ambiguous
+Ambiguous + unique match -> Live
+Ambiguous + no match -> Tombstoned
+Tombstoned/Ambiguous + retention expiry -> Retired
+Retired -> no longer participates in matching
+```
+
+Initial retention policy: keep tombstoned and ambiguous rows for the editor
+session. Add bounded retention or garbage collection only after a consumer needs
+it. Once `Retired`, a row is diagnostic history, not a recovery candidate.
+
+## Snapshot invariants
+
+Every produced snapshot must satisfy these invariants:
+
+- `stable_id` is unique across all rows.
+- `Live` rows have `current_id = Some(_)`.
+- `Tombstoned`, `Ambiguous`, and `Retired` rows have `current_id = None`.
+- No two `Live` rows share the same `current_id`.
+- `Ambiguous` rows have one or more candidate ids.
+- Candidate ids recorded on `Ambiguous` rows are not emitted as fresh `Live` rows
+  in the same snapshot.
+- `Retired` rows do not participate in matching and cannot become `Live` again.
+- Every live `current_id` refers to an observation in the current projection
+  snapshot.
+- The side table never mutates source text, projection nodes, source maps, or CRDT
+  state.
+
+These invariants should become package-local tests before any helper leaves the
+white-box spike.
+
+## API sketch
+
+```moonbit
+fn[Kind] EntitySnapshot::from_observations(
+  observations : Array[EntityObservation[Kind]],
+) -> EntitySnapshot[Kind]
+
+fn[Kind] EntitySnapshot::advance(
+  self : EntitySnapshot[Kind],
+  observations : Array[EntityObservation[Kind]],
+  match_entity : (
+    EntityObservation[Kind],
+    Array[EntityObservation[Kind]],
+  ) -> MatchResult,
+) -> EntitySnapshot[Kind]
+
+fn[Kind] EntitySnapshot::row_for_stable_id(
+  self : EntitySnapshot[Kind],
+  stable_id : StableRowId,
+) -> EntityRow[Kind]?
+
+fn[Kind] EntitySnapshot::row_for_current_id(
+  self : EntitySnapshot[Kind],
+  current_id : NodeId,
+) -> EntityRow[Kind]?
+```
+
+Return a new snapshot instead of mutating in place so the shape can later sit
+behind an `incr` derived value.
+
+## Evidence to retain
+
+Rows should explain identity outcomes with: stable row key, current node when
+live, status, last live source range, token spans, semantic key, candidate ids,
+confidence, and evidence. Do not expose byte offsets; source anchors remain
+`SourceMap` UTF-16 ranges.
+
+Good initial evidence for Markdown headings:
+
+- same projection `NodeId`;
+- same heading level;
+- same normalized heading text;
+- overlapping source range;
+- same or nearby section context;
+- candidate count.
+
+## Decision gate
+
+Stay with this side-table shape while identity is session-local and matching is
+language-owned. Revisit a distinct stable entity core only when a real consumer
+needs reload/peer stability, projection-independent graph relations,
+language-independent evidence storage beyond an extensible enum, or durable CRDT
+anchors in matching.
+
+## Next slice
+
+The Markdown white-box spike now mirrors this sketch in
+`lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt`: it has a stable-row
+wrapper, an evidence-bearing matcher, same-node match priority, global
+one-to-one conflict handling, ambiguous candidate retention, retired-row
+behavior, and snapshot invariant tests. Shared heading observation helpers remain
+in `lang/markdown/proj/sdeg_heading_spike_wbtest.mbt`.
+
+Keep that implementation package-private or test-local. Promote a shared helper
+only after another entity kind needs the same lifecycle semantics, and verify
+`moon info` shows no accidental public API drift.
+
+Related:
+
+- [Stable Document Entity Graph](stable-document-entity-graph.md)
+- [SDEG Phase 0 Markdown Heading Spike](../plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md)

--- a/docs/design/stable-document-entity-graph.md
+++ b/docs/design/stable-document-entity-graph.md
@@ -218,5 +218,6 @@ Until then, keep the design internal and side-table based.
 - [Responsibility Map](../architecture/responsibility-map.md)
 - [Range/span unit boundaries](../decisions/2026-06-13-range-span-unit-boundaries.md)
 - [Identity and reuse mechanisms](../decisions/2026-06-01-identity-and-reuse-mechanisms.md)
+- [SDEG NodeId Side Table Sketch](sdeg-nodeid-side-table.md)
 - [Analysis Query Layer](analysis-query-layer.md)
 - [Design Concerns](design-concerns.md)

--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -167,9 +167,21 @@ Decision:
 - Edit-path compatibility remains unvalidated by this spike: the tests exercise
   parse/projection/reconcile directly rather than `MarkdownEditOp`,
   `compute_markdown_edit`, or `SyncEditor` application.
-- Next target: promote the test-only matcher shape into an internal design for
-  `NodeId` side tables with lifecycle/tombstone retention, while keeping public
-  APIs unchanged.
+- A test-only `NodeId` side table with lifecycle rows can keep the original
+  projection `NodeId` as the stable row key, preserve same-node matches before
+  semantic-key recovery, tombstone a deleted heading, recover it on a later
+  unique restore, and keep duplicate restores ambiguous instead of guessing.
+- The side-table semantics have been extracted into
+  `docs/design/sdeg-nodeid-side-table.md` as a small internal design note/API
+  sketch. The white-box side-table helper now lives in
+  `lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt` and mirrors that
+  sketch with a stable-row wrapper, evidence-bearing matching, same-node match
+  priority, one-to-one conflict handling, ambiguous candidate retention,
+  retired-row behavior, and snapshot invariants. Shared heading
+  observation/projection helpers remain in
+  `lang/markdown/proj/sdeg_heading_spike_wbtest.mbt`. Keep public APIs unchanged
+  and avoid introducing a durable `EntityId` until reload/peer stability is
+  required.
 
 ## Acceptance Criteria
 

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -1,0 +1,604 @@
+///| Whitebox side-table tests for the Stable Document Entity Graph Phase 0 idea.
+
+///|
+/// These tests keep the side-table model test-local. They reuse the heading
+/// observation helpers from `sdeg_heading_spike_wbtest.mbt` and validate the
+/// internal lifecycle sketch in `docs/design/sdeg-nodeid-side-table.md`.
+
+///|
+enum HeadingSideTableStatus {
+  HeadingLive
+  HeadingTombstoned
+  HeadingAmbiguous
+  HeadingRetired
+} derive(Eq, Debug)
+
+///|
+struct HeadingStableRowId {
+  seed : @core.NodeId
+} derive(Eq, Debug)
+
+///|
+fn HeadingStableRowId::from_node(id : @core.NodeId) -> HeadingStableRowId {
+  { seed: id }
+}
+
+///|
+enum HeadingSideTableConfidence {
+  HeadingExact
+  HeadingProbable
+  HeadingMatchAmbiguous
+  HeadingMissing
+} derive(Eq, Debug)
+
+///|
+enum HeadingEntityEvidence {
+  HeadingSameNodeId(@core.NodeId)
+  HeadingSameSemanticKey(String)
+  HeadingOverlappingRange(@loomcore.Range, @loomcore.Range)
+  HeadingCandidateCount(Int)
+} derive(Eq, Debug)
+
+///|
+struct HeadingMatchCandidate {
+  id : @core.NodeId
+  evidence : Array[HeadingEntityEvidence]
+} derive(Eq, Debug)
+
+///|
+struct HeadingSideTableMatch {
+  confidence : HeadingSideTableConfidence
+  candidates : Array[HeadingMatchCandidate]
+  evidence : Array[HeadingEntityEvidence]
+} derive(Eq, Debug)
+
+///|
+struct HeadingSideTableRow {
+  stable_id : HeadingStableRowId
+  current_id : @core.NodeId?
+  status : HeadingSideTableStatus
+  last_live : HeadingObservation
+  candidates : Array[@core.NodeId]
+  evidence : Array[HeadingEntityEvidence]
+} derive(Eq, Debug)
+
+///|
+struct HeadingSideTable {
+  rows : Array[HeadingSideTableRow]
+} derive(Eq, Debug)
+
+///|
+fn heading_side_table_live_row(obs : HeadingObservation) -> HeadingSideTableRow {
+  {
+    stable_id: HeadingStableRowId::from_node(obs.id),
+    current_id: Some(obs.id),
+    status: HeadingLive,
+    last_live: obs,
+    candidates: [],
+    evidence: [HeadingSameNodeId(obs.id), HeadingCandidateCount(1)],
+  }
+}
+
+///|
+fn HeadingSideTable::from_observations(
+  observations : Array[HeadingObservation],
+) -> HeadingSideTable {
+  { rows: observations.map(heading_side_table_live_row) }
+}
+
+///|
+fn find_heading_by_id(
+  observations : Array[HeadingObservation],
+  id : @core.NodeId,
+) -> HeadingObservation? {
+  observations.iter().find_first(fn(obs) { obs.id == id })
+}
+
+///|
+fn find_side_table_row(
+  table : HeadingSideTable,
+  stable_id : @core.NodeId,
+) -> HeadingSideTableRow? {
+  let row_id = HeadingStableRowId::from_node(stable_id)
+  table.rows.iter().find_first(fn(row) { row.stable_id == row_id })
+}
+
+///|
+fn side_table_has_stable_id(
+  rows : Array[HeadingSideTableRow],
+  stable_id : HeadingStableRowId,
+) -> Bool {
+  rows.iter().any(fn(row) { row.stable_id == stable_id })
+}
+
+///|
+fn node_id_in(ids : Array[@core.NodeId], id : @core.NodeId) -> Bool {
+  ids.iter().any(fn(candidate_id) { candidate_id == id })
+}
+
+///|
+fn side_table_mentions_current_id(
+  rows : Array[HeadingSideTableRow],
+  current_id : @core.NodeId,
+) -> Bool {
+  rows
+  .iter()
+  .any(fn(row) {
+    row.current_id == Some(current_id) || node_id_in(row.candidates, current_id)
+  })
+}
+
+///|
+fn heading_evidence(
+  previous : HeadingObservation,
+  current : HeadingObservation,
+) -> Array[HeadingEntityEvidence] {
+  let evidence : Array[HeadingEntityEvidence] = []
+  if previous.id == current.id {
+    evidence.push(HeadingSameNodeId(current.id))
+  }
+  if previous.level == current.level && previous.text == current.text {
+    evidence.push(HeadingSameSemanticKey(heading_key(previous)))
+  }
+  if ranges_overlap(previous.range, current.range) {
+    evidence.push(HeadingOverlappingRange(previous.range, current.range))
+  }
+  evidence
+}
+
+///|
+fn heading_candidate(
+  previous : HeadingObservation,
+  current : HeadingObservation,
+) -> HeadingMatchCandidate {
+  { id: current.id, evidence: heading_evidence(previous, current) }
+}
+
+///|
+fn heading_side_table_match(
+  previous : HeadingObservation,
+  current : Array[HeadingObservation],
+) -> HeadingSideTableMatch {
+  let same_node = find_heading_by_id(current, previous.id)
+  let semantic_candidates : Array[HeadingMatchCandidate] = current
+    .iter()
+    .filter(fn(obs) { obs.level == previous.level && obs.text == previous.text })
+    .map(fn(obs) { heading_candidate(previous, obs) })
+    .collect()
+  let semantic_count = semantic_candidates.length()
+  match same_node {
+    Some(obs) => {
+      let candidate = heading_candidate(previous, obs)
+      let evidence = if obs.level == previous.level && obs.text == previous.text {
+        [
+          HeadingSameNodeId(obs.id),
+          HeadingSameSemanticKey(heading_key(previous)),
+          HeadingCandidateCount(1),
+        ]
+      } else {
+        [HeadingSameNodeId(obs.id), HeadingCandidateCount(1)]
+      }
+      { confidence: HeadingExact, candidates: [candidate], evidence }
+    }
+    None if semantic_count == 1 =>
+      {
+        confidence: HeadingProbable,
+        candidates: semantic_candidates,
+        evidence: [
+          HeadingSameSemanticKey(heading_key(previous)),
+          HeadingCandidateCount(1),
+        ],
+      }
+    None if semantic_count > 1 =>
+      {
+        confidence: HeadingMatchAmbiguous,
+        candidates: semantic_candidates,
+        evidence: [
+          HeadingSameSemanticKey(heading_key(previous)),
+          HeadingCandidateCount(semantic_count),
+        ],
+      }
+    None =>
+      {
+        confidence: HeadingMissing,
+        candidates: [],
+        evidence: [HeadingCandidateCount(0)],
+      }
+  }
+}
+
+///|
+fn candidate_ids(match_result : HeadingSideTableMatch) -> Array[@core.NodeId] {
+  match_result.candidates.map(fn(candidate) { candidate.id })
+}
+
+///|
+fn row_active(row : HeadingSideTableRow) -> Bool {
+  row.status != HeadingRetired
+}
+
+///|
+fn candidate_claim_count(
+  matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)],
+  id : @core.NodeId,
+) -> Int {
+  matches
+  .iter()
+  .filter(fn(pair) { node_id_in(candidate_ids(pair.1), id) })
+  .count()
+}
+
+///|
+fn row_from_match(
+  row : HeadingSideTableRow,
+  match_result : HeadingSideTableMatch,
+  current : Array[HeadingObservation],
+  claim_count : (@core.NodeId) -> Int,
+) -> HeadingSideTableRow {
+  let ids = candidate_ids(match_result)
+  if row.status == HeadingRetired {
+    { ..row, current_id: None, candidates: [] }
+  } else if ids.length() == 0 {
+    {
+      ..row,
+      current_id: None,
+      status: HeadingTombstoned,
+      candidates: [],
+      evidence: match_result.evidence,
+    }
+  } else if ids.length() == 1 &&
+    claim_count(ids[0]) == 1 &&
+    (
+      match_result.confidence == HeadingExact ||
+      match_result.confidence == HeadingProbable
+    ) {
+    match find_heading_by_id(current, ids[0]) {
+      Some(current_obs) =>
+        {
+          stable_id: row.stable_id,
+          current_id: Some(current_obs.id),
+          status: HeadingLive,
+          last_live: current_obs,
+          candidates: [],
+          evidence: match_result.evidence,
+        }
+      None =>
+        {
+          ..row,
+          current_id: None,
+          status: HeadingTombstoned,
+          candidates: [],
+          evidence: match_result.evidence,
+        }
+    }
+  } else {
+    {
+      ..row,
+      current_id: None,
+      status: HeadingAmbiguous,
+      candidates: ids,
+      evidence: match_result.evidence,
+    }
+  }
+}
+
+///|
+fn HeadingSideTable::advance(
+  self : HeadingSideTable,
+  current : Array[HeadingObservation],
+) -> HeadingSideTable {
+  let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = []
+  for row in self.rows {
+    if row_active(row) {
+      matches.push((row, heading_side_table_match(row.last_live, current)))
+    }
+  }
+  let next_rows : Array[HeadingSideTableRow] = []
+  for row in self.rows {
+    if row.status == HeadingRetired {
+      next_rows.push({ ..row, current_id: None, candidates: [] })
+    } else {
+      let match_result = heading_side_table_match(row.last_live, current)
+      next_rows.push(
+        row_from_match(row, match_result, current, fn(id) {
+          candidate_claim_count(matches, id)
+        }),
+      )
+    }
+  }
+  for obs in current {
+    if !side_table_mentions_current_id(next_rows, obs.id) &&
+      !side_table_has_stable_id(
+        next_rows,
+        HeadingStableRowId::from_node(obs.id),
+      ) {
+      next_rows.push(heading_side_table_live_row(obs))
+    }
+  }
+  { rows: next_rows }
+}
+
+///|
+fn synthetic_heading(
+  id : Int,
+  text : String,
+  start : Int,
+) -> HeadingObservation {
+  {
+    id: @core.NodeId::from_int(id),
+    level: 1,
+    text,
+    range: @loomcore.Range::new(start, start + text.length() + 2),
+    marker: None,
+    text_span: None,
+  }
+}
+
+///|
+fn heading_side_table_invariants_hold(
+  table : HeadingSideTable,
+  current : Array[HeadingObservation],
+) -> Bool {
+  let stable_ids : Array[HeadingStableRowId] = []
+  let live_ids : Array[@core.NodeId] = []
+  let ambiguous_ids : Array[@core.NodeId] = []
+  let mut ok = true
+  for row in table.rows {
+    if stable_ids.iter().any(fn(id) { id == row.stable_id }) {
+      ok = false
+    } else {
+      stable_ids.push(row.stable_id)
+    }
+    match row.status {
+      HeadingLive =>
+        match row.current_id {
+          Some(current_id) => {
+            if node_id_in(live_ids, current_id) {
+              ok = false
+            } else {
+              live_ids.push(current_id)
+            }
+            if find_heading_by_id(current, current_id) is None {
+              ok = false
+            }
+            if row.candidates.length() != 0 {
+              ok = false
+            }
+          }
+          None => ok = false
+        }
+      HeadingTombstoned =>
+        if row.current_id is Some(_) || row.candidates.length() != 0 {
+          ok = false
+        }
+      HeadingAmbiguous => {
+        if row.current_id is Some(_) || row.candidates.length() == 0 {
+          ok = false
+        }
+        for id in row.candidates {
+          ambiguous_ids.push(id)
+        }
+      }
+      HeadingRetired =>
+        if row.current_id is Some(_) || row.candidates.length() != 0 {
+          ok = false
+        }
+    }
+  }
+  for id in ambiguous_ids {
+    if node_id_in(live_ids, id) {
+      ok = false
+    }
+  }
+  ok
+}
+
+///|
+test "sdeg phase0: NodeId side table preserves same-node matches before semantic ones" {
+  let counter : Ref[Int] = Ref(0)
+  let source = "# A\n# B\n"
+  let next_source = "# C\n# A\n"
+  let (initial_cst, _) = @markdown.parse_cst(source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(source, initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let table = HeadingSideTable::from_observations(before)
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+
+  let (edited, edited_map) = project_after_reconcile(
+    initial, next_source, counter,
+  )
+  let after = collect_heading_observations(edited, edited_map)
+  let c_after = find_heading(after, "C").unwrap()
+  let a_after = find_heading(after, "A").unwrap()
+  let advanced = table.advance(after)
+  let a_row = find_side_table_row(advanced, a_before.id).unwrap()
+  let b_row = find_side_table_row(advanced, b_before.id).unwrap()
+
+  inspect(a_row.status == HeadingLive, content="true")
+  inspect(b_row.status == HeadingLive, content="true")
+  inspect(a_row.current_id == Some(c_after.id), content="true")
+  inspect(b_row.current_id == Some(a_after.id), content="true")
+  inspect(advanced.rows.length(), content="2")
+  inspect(heading_side_table_invariants_hold(advanced, after), content="true")
+}
+
+///|
+test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
+  let counter : Ref[Int] = Ref(0)
+  let initial_source = "# A\n# B\n"
+  let deleted_source = "# B\n"
+  let restored_source = "# A\n# B\n"
+  let (initial_cst, _) = @markdown.parse_cst(initial_source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(initial_source, initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let table = HeadingSideTable::from_observations(before)
+  let a_before = find_heading(before, "A").unwrap()
+
+  let (deleted, deleted_map) = project_after_reconcile(
+    initial, deleted_source, counter,
+  )
+  let deleted_table = table.advance(
+    collect_heading_observations(deleted, deleted_map),
+  )
+  let a_deleted_row = find_side_table_row(deleted_table, a_before.id).unwrap()
+
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, restored_source, counter,
+  )
+  let restored_observations = collect_heading_observations(
+    restored, restored_map,
+  )
+  let a_restored = find_heading(restored_observations, "A").unwrap()
+  let restored_table = deleted_table.advance(restored_observations)
+  let a_restored_row = find_side_table_row(restored_table, a_before.id).unwrap()
+
+  inspect(a_deleted_row.status == HeadingTombstoned, content="true")
+  inspect(a_deleted_row.current_id is None, content="true")
+  inspect(a_restored_row.status == HeadingLive, content="true")
+  inspect(
+    a_restored_row.stable_id == HeadingStableRowId::from_node(a_before.id),
+    content="true",
+  )
+  inspect(a_restored_row.current_id == Some(a_restored.id), content="true")
+}
+
+///|
+test "sdeg phase0: NodeId side table keeps duplicate restore ambiguous" {
+  let counter : Ref[Int] = Ref(0)
+  let initial_source = "# A\n# B\n"
+  let deleted_source = "# B\n"
+  let restored_source = "# A\n# A\n# B\n"
+  let (initial_cst, _) = @markdown.parse_cst(initial_source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(initial_source, initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let table = HeadingSideTable::from_observations(before)
+  let a_before = find_heading(before, "A").unwrap()
+
+  let (deleted, deleted_map) = project_after_reconcile(
+    initial, deleted_source, counter,
+  )
+  let deleted_table = table.advance(
+    collect_heading_observations(deleted, deleted_map),
+  )
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, restored_source, counter,
+  )
+  let restored_observations = collect_heading_observations(
+    restored, restored_map,
+  )
+  let restored_table = deleted_table.advance(restored_observations)
+  let a_restored_row = find_side_table_row(restored_table, a_before.id).unwrap()
+
+  inspect(a_restored_row.status == HeadingAmbiguous, content="true")
+  inspect(a_restored_row.current_id is None, content="true")
+  inspect(a_restored_row.candidates.length(), content="2")
+  inspect(
+    heading_side_table_invariants_hold(restored_table, restored_observations),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase0: NodeId side table conflicts do not double-claim current nodes" {
+  let old_a0 = synthetic_heading(1, "A", 0)
+  let old_a1 = synthetic_heading(2, "A", 4)
+  let current_a = synthetic_heading(100, "A", 0)
+  let table = HeadingSideTable::from_observations([old_a0, old_a1])
+  let advanced = table.advance([current_a])
+  let row0 = find_side_table_row(advanced, old_a0.id).unwrap()
+  let row1 = find_side_table_row(advanced, old_a1.id).unwrap()
+
+  inspect(advanced.rows.length(), content="2")
+  inspect(row0.status == HeadingAmbiguous, content="true")
+  inspect(row1.status == HeadingAmbiguous, content="true")
+  inspect(row0.current_id is None, content="true")
+  inspect(row1.current_id is None, content="true")
+  inspect(node_id_in(row0.candidates, current_a.id), content="true")
+  inspect(node_id_in(row1.candidates, current_a.id), content="true")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [current_a]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase0: NodeId side table invariants hold across lifecycle states" {
+  let counter : Ref[Int] = Ref(0)
+  let source = "# A\n# B\n"
+  let deleted_source = "# B\n"
+  let restored_source = "# A\n# B\n"
+  let (initial_cst, _) = @markdown.parse_cst(source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(source, initial)
+  let initial_observations = collect_heading_observations(initial, initial_map)
+  let table = HeadingSideTable::from_observations(initial_observations)
+
+  let (deleted, deleted_map) = project_after_reconcile(
+    initial, deleted_source, counter,
+  )
+  let deleted_observations = collect_heading_observations(deleted, deleted_map)
+  let deleted_table = table.advance(deleted_observations)
+
+  let (restored, restored_map) = project_after_reconcile(
+    deleted, restored_source, counter,
+  )
+  let restored_observations = collect_heading_observations(
+    restored, restored_map,
+  )
+  let restored_table = deleted_table.advance(restored_observations)
+
+  inspect(
+    heading_side_table_invariants_hold(table, initial_observations),
+    content="true",
+  )
+  inspect(
+    heading_side_table_invariants_hold(deleted_table, deleted_observations),
+    content="true",
+  )
+  inspect(
+    heading_side_table_invariants_hold(restored_table, restored_observations),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase0: NodeId side table retired rows do not revive" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let current_a = synthetic_heading(100, "A", 0)
+  let retired_row = {
+    ..heading_side_table_live_row(old_a),
+    current_id: None,
+    status: HeadingRetired,
+    candidates: [],
+  }
+  let table = { rows: [retired_row] }
+  let advanced = table.advance([current_a])
+  let old_row = find_side_table_row(advanced, old_a.id).unwrap()
+  let fresh_row = find_side_table_row(advanced, current_a.id).unwrap()
+
+  inspect(old_row.status == HeadingRetired, content="true")
+  inspect(old_row.current_id is None, content="true")
+  inspect(fresh_row.status == HeadingLive, content="true")
+  inspect(fresh_row.current_id == Some(current_a.id), content="true")
+  inspect(advanced.rows.length(), content="2")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [current_a]),
+    content="true",
+  )
+}


### PR DESCRIPTION
## Summary

- Define the SDEG Phase 0 direction around existing projection `NodeId` identity plus side tables instead of a new public entity system.
- Add Markdown heading white-box coverage for observed identity behavior, semantic matching evidence, and the internal NodeId side-table lifecycle sketch.
- Document the side-table API sketch, lifecycle/invariants, and keep it internal/test-local until another entity kind proves reuse.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `NodeId`, `ProjNode`, `SourceMap` | `core/` | Yes | Used as the session-local identity seed, projection substrate, and UTF-16 anchor source. |
| `@core.reconcile` | `core/reconcile.mbt` | Yes | Used to observe current projection identity behavior after reparses. |
| `ProjectionIdentityBaseline` / `realign_projection_items_with_optional_edit` | `loom/loom/src/core/projection_identity.mbt` | Yes, for comparison tests | Validated that realignment does not solve sibling reorder or committed delete/restore by itself. |
| `parse_to_proj_node`, `syntax_to_proj_node`, `populate_token_spans` | `lang/markdown/proj/` | Yes | Reused to collect Markdown heading observations from existing projection/source-map data. |

New helpers added (test-only / white-box):

- `HeadingObservation` helpers: collect heading entity observations from existing projection/source-map data for the spike.
- `HeadingSideTable` helpers: model the internal NodeId side-table lifecycle, evidence-bearing matching, ambiguity, conflict handling, retired rows, and invariants before any public API is introduced.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `NEW_MOON_MOD=0 moon test lang/markdown/proj` passes
- [x] `git diff '*.mbti'` reviewed for unintended API surface changes
- [x] JS rebuild not run; docs and MoonBit white-box tests only

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test lang/markdown/proj
NEW_MOON_MOD=0 moon test
git diff -- '*.mbti'
```
