### PR TITLE
Validate Markdown SDEG heading edit path

### DIFF
--- a/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
+++ b/docs/plans/2026-06-18-sdeg-phase0-markdown-heading-spike.md
@@ -139,7 +139,8 @@ identity is a viable Phase 0 substrate for Markdown headings, with clear limits.
 Observed:
 - `SourceMap` can anchor heading entity observations with the full heading range,
   the marker token span, and the text token span.
-- A heading rename preserves the session-local `NodeId`.
+- A heading rename preserves the session-local `NodeId`, including when routed
+  through `MarkdownEditOp::CommitEdit` and `apply_markdown_edit`.
 - Duplicate headings remain distinguishable by `NodeId` and source range.
 - Inline malformed-to-recovered heading content preserves the heading `NodeId`.
 - Whitespace-only / formatter-like rewrites around headings preserve heading
@@ -151,6 +152,10 @@ Limitations:
   following the heading text/key.
 - Delete followed by restore does not recover the retired heading identity;
   there is no tombstone or last-good semantic side table yet.
+- Heading level changes routed through the Markdown edit path currently freshen
+  the heading `NodeId`; preserving identity for that operation likely belongs in
+  edit provenance hints or projection reconciliation rather than in SDEG side
+  tables.
 
 Decision:
 - Continue with `NodeId` side tables for the next slice.
@@ -164,9 +169,10 @@ Decision:
 - A test-only semantic side-table matcher over `NodeId` can follow simple
   reorder, find delete/restore recovery candidates if the old observation is
   retained, and mark duplicate headings ambiguous.
-- Edit-path compatibility remains unvalidated by this spike: the tests exercise
-  parse/projection/reconcile directly rather than `MarkdownEditOp`,
-  `compute_markdown_edit`, or `SyncEditor` application.
+- Edit-path compatibility is now validated for heading text replacement via
+  `MarkdownEditOp::CommitEdit`, `compute_markdown_edit`, and `SyncEditor`
+  application; a heading level-change edit-path test records the current fresh
+  `NodeId` limitation.
 - A test-only `NodeId` side table with lifecycle rows can keep the original
   projection `NodeId` as the stable row key, preserve same-node matches before
   semantic-key recovery, tombstone a deleted heading, recover it on a later
@@ -194,7 +200,7 @@ Decision:
 - [x] Any identity failure includes recorded evidence and a proposed owner for a
       future fix.
 - [x] No public `EntityId` or `sdeg-*` package is introduced.
-- [ ] Existing Markdown edit application remains on the language/edit/editor path.
+- [x] Existing Markdown edit application remains on the language/edit/editor path.
 - [x] The result is summarized against the decision gates in
       `docs/design/stable-document-entity-graph.md`.
 

--- a/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
+++ b/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
@@ -1,0 +1,91 @@
+///| White-box compatibility test for SDEG Phase 0 Markdown edit path.
+
+///|
+struct HeadingEditPathObservation {
+  id : @core.NodeId
+  level : Int
+  text : String
+  text_span_text : String?
+} derive(Eq, Debug)
+
+///|
+fn heading_edit_path_observation(
+  node : @core.ProjNode[@markdown.Block],
+  source : String,
+  source_map : @core.SourceMap,
+) -> HeadingEditPathObservation? {
+  match node.kind {
+    Heading(level, [Text(text)]) =>
+      Some({
+        id: node.id(),
+        level,
+        text,
+        text_span_text: match source_map.get_token_span(node.id(), "text") {
+          Some(span) => Some(source[span.start:span.end].to_owned())
+          None => None
+        },
+      })
+    _ => None
+  }
+}
+
+///|
+fn first_heading_edit_path_observation(
+  editor : @editor.SyncEditor[@markdown.Block],
+) -> HeadingEditPathObservation {
+  heading_edit_path_observation(
+    editor.get_proj_node().unwrap().children[0],
+    editor.get_text(),
+    editor.get_source_map(),
+  ).unwrap()
+}
+
+///|
+test "sdeg phase0: heading rename goes through Markdown edit path" {
+  let editor = new_markdown_editor("sdeg-edit-path")
+  editor.set_text("# Alpha\n\nBody\n")
+  editor.refresh()
+  let before = first_heading_edit_path_observation(editor)
+
+  let result = apply_markdown_edit(
+    editor,
+    @md_edits.MarkdownEditOp::CommitEdit(node_id=before.id, new_text="Alpha 2"),
+    0,
+  )
+  editor.refresh()
+  let after = first_heading_edit_path_observation(editor)
+
+  inspect(result is Ok(_), content="true")
+  inspect(editor.get_text(), content="# Alpha 2\n\nBody\n")
+  inspect(before.text, content="Alpha")
+  inspect(after.text, content="Alpha 2")
+  inspect(after.level, content="1")
+  inspect(before.id == after.id, content="true")
+  inspect(before.text_span_text == Some("Alpha"), content="true")
+  inspect(after.text_span_text == Some("Alpha 2"), content="true")
+}
+
+///|
+test "sdeg phase0: heading level change through edit path has fresh NodeId" {
+  let editor = new_markdown_editor("sdeg-edit-path-level")
+  editor.set_text("# Alpha\n\nBody\n")
+  editor.refresh()
+  let before = first_heading_edit_path_observation(editor)
+
+  let result = apply_markdown_edit(
+    editor,
+    @md_edits.MarkdownEditOp::ChangeHeadingLevel(node_id=before.id, level=2),
+    0,
+  )
+  editor.refresh()
+  let after = first_heading_edit_path_observation(editor)
+
+  inspect(result is Ok(_), content="true")
+  inspect(editor.get_text(), content="## Alpha\n\nBody\n")
+  inspect(before.text, content="Alpha")
+  inspect(after.text, content="Alpha")
+  inspect(after.level, content="2")
+  inspect(before.id == after.id, content="false")
+  inspect(before.text_span_text == Some("Alpha"), content="true")
+  inspect(after.text_span_text == Some("Alpha"), content="true")
+}


### PR DESCRIPTION
## Summary

- Add Markdown companion white-box tests that route heading edits through `MarkdownEditOp` and `apply_markdown_edit`.
- Verify heading rename observations are derived from `SyncEditor` projection/source-map state, with `NodeId` preserved and source-map text span updated.
- Record the current heading-level-change edit-path limitation: the edit succeeds and source-map observation updates, but the heading receives a fresh `NodeId`.
- Mark the Phase 0 edit-path compatibility acceptance item complete and update the spike results.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `MarkdownEditOp::CommitEdit` | `lang/markdown/edits/markdown_edit_op.mbt` | Yes | Smallest existing Markdown edit operation for heading text replacement. |
| `MarkdownEditOp::ChangeHeadingLevel` | `lang/markdown/edits/markdown_edit_op.mbt` | Yes | Existing Markdown edit operation for heading-level replacement through the same path. |
| `apply_markdown_edit` | `lang/markdown/companion/markdown_companion.mbt` | Yes | Routes through the language/runtime edit bridge into `SyncEditor`. |
| `compute_markdown_edit` | `lang/markdown/edits/compute_markdown_edit.mbt` | Yes, indirectly | Used via `apply_markdown_edit`; direct use would bypass the editor path under test. |
| `SyncEditor::refresh`, `get_proj_node`, `get_source_map`, `get_text` | `editor/` | Yes | Used to force and inspect projection/source-map state after the edit. |
| Direct span mutation / manual string replacement | N/A | No | Would create a parallel mutation path and not validate edit/editor compatibility. |

New helpers added (if any):

- `HeadingEditPathObservation`, `heading_edit_path_observation`, and `first_heading_edit_path_observation`: test-local helpers only, scoped to asserting heading observations are derived from projection and source-map data after the editor edit path runs.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`) — not applicable; test/docs only

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test lang/markdown/companion --filter 'sdeg phase0:*'
NEW_MOON_MOD=0 moon test lang/markdown/edits
NEW_MOON_MOD=0 moon test lang/markdown/proj
NEW_MOON_MOD=0 moon test lang/markdown/sentinel
NEW_MOON_MOD=0 moon test lang/markdown/companion
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
NEW_MOON_MOD=0 moon test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Markdown editing behavior specifications and validation results.

* **Tests**
  * Added compatibility tests for Markdown heading edit operations to validate behavior consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->