### PR TITLE
Update loom submodule pointer

### DIFF
--- a/adapters/editor-adapter/block-input.css
+++ b/adapters/editor-adapter/block-input.css
@@ -59,6 +59,14 @@
   color: #666;
 }
 
+.block[data-kind="ListItem"][data-list-kind="ordered"] {
+  padding-left: 32px;
+}
+
+.block[data-kind="ListItem"][data-list-kind="ordered"]::before {
+  content: attr(data-list-marker) " ";
+}
+
 /* Code blocks: kind_tag is "Code" or "Code(lang)" */
 .block[data-kind^="Code"] {
   font-family: 'JetBrains Mono', 'Fira Code', monospace;

--- a/adapters/editor-adapter/block-input.ts
+++ b/adapters/editor-adapter/block-input.ts
@@ -21,7 +21,23 @@ export interface BlockInputOptions {
    * changes.
    */
   stripParagraphSentinels?: (s: string) => string;
+
+  /** Return the current source text for marker-sensitive block chrome. */
+  getSourceText?: () => string;
 }
+
+type ListKind = 'ordered' | 'unordered';
+
+type ListContext = {
+  kind: ListKind;
+  index: number;
+  marker?: string;
+};
+
+type FlattenedBlock = {
+  node: ViewNode;
+  listContext?: ListContext;
+};
 
 // ---------------------------------------------------------------------------
 // BlockInput
@@ -36,6 +52,7 @@ export class BlockInput implements EditorAdapter {
   private composing = false;
   private intentCb: ((intent: UserIntent) => void) | null = null;
   private stripParagraphSentinels: (s: string) => string;
+  private getSourceText: (() => string) | null;
 
   constructor(container: HTMLElement, opts: BlockInputOptions = {}) {
     this.container = container;
@@ -45,6 +62,7 @@ export class BlockInput implements EditorAdapter {
     // `markdown_empty_paragraph_sentinel()` exported by `ffi/markdown/`.
     this.stripParagraphSentinels =
       opts.stripParagraphSentinels ?? ((s) => s.replace(/​/g, ''));
+    this.getSourceText = opts.getSourceText ?? null;
     this.container.classList.add('block-editor');
     this.onContainerClick = this.onContainerClick.bind(this);
     this.container.addEventListener('click', this.onContainerClick);
@@ -105,27 +123,64 @@ export class BlockInput implements EditorAdapter {
     if (this.activeBlockId !== null) this.positionTextarea();
   }
 
-  /** Recursively collect editable leaf blocks (flattens containers like UnorderedList) */
-  private collectEditableBlocks(node: ViewNode): ViewNode[] {
-    const result: ViewNode[] = [];
+  /** Recursively collect editable leaf blocks while preserving list context. */
+  private collectEditableBlocks(node: ViewNode): FlattenedBlock[] {
+    const result: FlattenedBlock[] = [];
+    const listKind = this.listKindFor(node.kind_tag);
+    let listIndex = 1;
+
     for (const child of node.children) {
+      const childListContext = listKind && child.kind_tag === 'ListItem'
+        ? {
+          kind: listKind,
+          index: listIndex++,
+          marker: listKind === 'ordered' ? this.sourceListMarker(child) : undefined,
+        }
+        : undefined;
+
       if (child.editable) {
-        result.push(child);
+        result.push({ node: child, listContext: childListContext });
       } else if (child.children.length > 0) {
-        // Container (e.g., UnorderedList) — descend into children
+        // Container (e.g., OrderedList/UnorderedList) — descend into children.
         result.push(...this.collectEditableBlocks(child));
       }
     }
     return result;
   }
 
+  private listKindFor(kindTag: string): ListKind | null {
+    switch (kindTag) {
+      case 'OrderedList': return 'ordered';
+      case 'List':
+      case 'UnorderedList': return 'unordered';
+      default: return null;
+    }
+  }
+
+  private sourceListMarker(node: ViewNode): string | undefined {
+    const source = this.getSourceText?.();
+    const textSpan = node.token_spans.find(span => span.role === 'text');
+    if (!source || !textSpan) return undefined;
+
+    const prefix = source.slice(node.text_range[0], textSpan.start);
+    const marker = prefix.match(/^\s*(\d+[.)])/);
+    return marker?.[1];
+  }
+
   /** Create a semantic block element based on kind_tag. */
-  private createBlockDiv(node: ViewNode): HTMLElement {
+  private createBlockDiv(block: FlattenedBlock): HTMLElement {
+    const { node, listContext } = block;
     const el = this.semanticBlockElement(node.kind_tag);
     el.className = 'block' + (node.id === this.activeBlockId ? ' active' : '');
     if (node.css_class) el.className += ' ' + node.css_class;
     el.dataset.nodeId = String(node.id);
     el.dataset.kind = node.kind_tag;
+    if (listContext) {
+      el.dataset.listKind = listContext.kind;
+      if (listContext.kind === 'ordered') {
+        el.dataset.listMarker = listContext.marker ?? `${listContext.index}.`;
+      }
+    }
 
     const textSpan = document.createElement('span');
     textSpan.className = 'block-text';
@@ -392,10 +447,10 @@ export class BlockInput implements EditorAdapter {
   private moveFocus(direction: -1 | 1): void {
     if (this.activeBlockId === null || !this.currentTree) return;
     const siblings = this.collectEditableBlocks(this.currentTree);
-    const idx = siblings.findIndex(c => c.id === this.activeBlockId);
+    const idx = siblings.findIndex(c => c.node.id === this.activeBlockId);
     const next = siblings[idx + direction];
     if (next) {
-      this.activateBlock(next.id);
+      this.activateBlock(next.node.id);
       // Place cursor at end when moving backward, start when moving forward
       if (this.textarea) {
         const pos = direction === -1 ? this.textarea.value.length : 0;

--- a/adapters/editor-adapter/markdown-preview.ts
+++ b/adapters/editor-adapter/markdown-preview.ts
@@ -20,7 +20,10 @@ function semanticTag(node: ViewNode): HTMLElement {
     case 'Paragraph':
       return document.createElement('p');
     case 'List':
+    case 'UnorderedList':
       return document.createElement('ul');
+    case 'OrderedList':
+      return document.createElement('ol');
     case 'ListItem':
       return document.createElement('li');
     default:

--- a/editor/capabilities.mbt
+++ b/editor/capabilities.mbt
@@ -10,6 +10,12 @@ pub struct LanguageCapabilities[T] {
     Array[@protocol.ViewAnnotation],
   ])?
   priv get_decorations : (() -> Array[@protocol.Decoration])?
+  priv to_view_node : ((
+    @core.ProjNode[T],
+    @core.SourceMap,
+    Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
+    String?,
+  ) -> @protocol.ViewNode)?
   priv pretty_post_process : ((@pretty.Layout[@pretty.SyntaxCategory]) -> @pretty.Layout[
     @pretty.SyntaxCategory,
   ])?
@@ -24,7 +30,32 @@ pub fn[T] LanguageCapabilities::new(
     @pretty.SyntaxCategory,
   ])? = None,
 ) -> LanguageCapabilities[T] {
-  { get_annotations, get_decorations, pretty_post_process, phantom: None }
+  {
+    get_annotations,
+    get_decorations,
+    to_view_node: None,
+    pretty_post_process,
+    phantom: None,
+  }
+}
+
+///|
+pub fn[T] LanguageCapabilities::with_to_view_node(
+  self : LanguageCapabilities[T],
+  to_view_node : (
+    @core.ProjNode[T],
+    @core.SourceMap,
+    Map[@core.NodeId, Array[@protocol.ViewAnnotation]],
+    String?,
+  ) -> @protocol.ViewNode,
+) -> LanguageCapabilities[T] {
+  {
+    get_annotations: self.get_annotations,
+    get_decorations: self.get_decorations,
+    to_view_node: Some(to_view_node),
+    pretty_post_process: self.pretty_post_process,
+    phantom: None,
+  }
 }
 
 ///|
@@ -33,6 +64,7 @@ pub fn[T] LanguageCapabilities::default() -> LanguageCapabilities[T] {
   {
     get_annotations: None,
     get_decorations: None,
+    to_view_node: None,
     pretty_post_process: None,
     phantom: None,
   }

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -84,6 +84,7 @@ pub struct LanguageCapabilities[T] {
 }
 pub fn[T] LanguageCapabilities::default() -> Self[T]
 pub fn[T] LanguageCapabilities::new(get_annotations? : (() -> Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]])?, get_decorations? : (() -> Array[@protocol.Decoration])?, pretty_post_process? : ((@pretty.Layout[@pretty.SyntaxCategory]) -> @pretty.Layout[@pretty.SyntaxCategory])?) -> Self[T]
+pub fn[T] LanguageCapabilities::with_to_view_node(Self[T], (@dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap, Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]], String?) -> @protocol.ViewNode) -> Self[T]
 
 pub struct SyncEditor[T] {
   // private fields

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -40,14 +40,19 @@ pub fn[T : @loom_core.Renderable] SyncEditor::get_view_tree(
         Some(get_ann) => get_ann()
         None => {}
       }
-      Some(
-        @protocol.proj_to_view_node(
-          proj_node,
-          source_map,
-          source_text~,
-          annotations~,
-        ),
-      )
+      match self.capabilities.to_view_node {
+        Some(convert) =>
+          Some(convert(proj_node, source_map, annotations, source_text))
+        None =>
+          Some(
+            @protocol.proj_to_view_node(
+              proj_node,
+              source_map,
+              source_text~,
+              annotations~,
+            ),
+          )
+      }
     }
     None => None
   }

--- a/examples/web/src/markdown-editor.ts
+++ b/examples/web/src/markdown-editor.ts
@@ -62,7 +62,10 @@ const modeTabs = document.querySelectorAll<HTMLButtonElement>('.mode-tab');
 // Adapters
 // ---------------------------------------------------------------------------
 
-const blockInput = new BlockInput(blockContainer, { stripParagraphSentinels });
+const blockInput = new BlockInput(blockContainer, {
+  stripParagraphSentinels,
+  getSourceText: () => crdt.markdown_export_text(handle),
+});
 const preview = new MarkdownPreview(previewContainer);
 
 // ---------------------------------------------------------------------------

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -91,6 +91,24 @@ test.describe('Markdown Block Editor', () => {
     expect(afterCycle).toEqual(originalTexts);
   });
 
+  test('block mode preserves ordered list markers', async ({ page }) => {
+    await switchMode(page, 'Raw');
+    await page.locator('#raw-editor').fill('3. three\n4. four\n');
+    await switchMode(page, 'Block');
+
+    const listItems = page.locator('#block-container .block[data-kind="ListItem"]');
+    await expect(listItems).toHaveCount(2);
+    await expect(listItems.nth(0)).toHaveAttribute('data-list-kind', 'ordered');
+    await expect(listItems.nth(0)).toHaveAttribute('data-list-marker', '3.');
+    await expect(listItems.nth(1)).toHaveAttribute('data-list-marker', '4.');
+
+    await switchMode(page, 'Raw');
+    await page.locator('#raw-editor').fill('1) one\n2) two\n');
+    await switchMode(page, 'Block');
+    await expect(listItems.nth(0)).toHaveAttribute('data-list-marker', '1)');
+    await expect(listItems.nth(1)).toHaveAttribute('data-list-marker', '2)');
+  });
+
   test('structural edit produces valid Markdown', async ({ page }) => {
     // Load Hello example (heading + paragraphs)
     await loadExample(page, 'Hello');

--- a/ffi/markdown/lifecycle_phase1_wbtest.mbt
+++ b/ffi/markdown/lifecycle_phase1_wbtest.mbt
@@ -145,6 +145,18 @@ test "workstream 2 (md): compute_view_patches initial render emits FullTree with
 }
 
 ///|
+test "workstream 2 (md): compute_view_patches preserves ordered list kind" {
+  reset_markdown_coordinator_for_phase1_tests()
+  let handle = create_markdown_editor("md_view_ordered_list_agent")
+  markdown_set_text(handle, "1. one\n2. two\n")
+  let out = markdown_compute_view_patches_json(handle)
+  if !out.contains("\"kind_tag\":\"OrderedList\"") {
+    fail("expected ordered list ViewNode kind_tag, got \{out}")
+  }
+  destroy_markdown_editor(handle)
+}
+
+///|
 /// Incremental-diff path: a second call after a structural change must emit
 /// targeted patches (`UpdateNode` / `ReplaceNode` / `InsertChild` /
 /// `RemoveChild`), not a fresh `FullTree`. The `state.previous` carry-over

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -251,7 +251,7 @@ pub fn markdown_compute_view_patches_json(handle : Int) -> String {
   let current : @protocol.ViewNode? = match proj_opt {
     Some(proj) =>
       Some(
-        @protocol.proj_to_view_node(
+        @md_proj.proj_to_view_node(
           proj,
           source_map,
           source_text=Some(source_text),

--- a/ffi/markdown/moon.pkg
+++ b/ffi/markdown/moon.pkg
@@ -4,6 +4,7 @@ import {
   "dowdiness/canopy/ffi/host",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/companion" @md_companion,
+  "dowdiness/canopy/lang/markdown/proj" @md_proj,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/canopy/protocol",
   "dowdiness/canopy/workspace/coordinator" @workspace,

--- a/lang/markdown/companion/integration_wbtest.mbt
+++ b/lang/markdown/companion/integration_wbtest.mbt
@@ -23,6 +23,19 @@ test "round-trip: new_markdown_editor + apply_markdown_edit" {
 }
 
 ///|
+test "generic view path preserves ordered list kind" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("1. one\n2. two\n")
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let patches = @editor.compute_view_patches(state, ed)
+  match patches {
+    [@protocol.ViewPatch::FullTree(root=Some(root)), ..] =>
+      inspect(root.children[0].kind_tag, content="OrderedList")
+    _ => fail("expected FullTree patch for ordered list")
+  }
+}
+
+///|
 test "split_block: middle of paragraph" {
   let ed = new_markdown_editor("test")
   ed.set_text("Hello World\n")

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -24,7 +24,19 @@ pub fn new_markdown_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> @editor.SyncEditor[@markdown.Block] {
-  markdown_spec.new_editor(agent_id, capture_timeout_ms~, parent_runtime?)
+  markdown_spec.new_editor(
+    agent_id,
+    capture_timeout_ms~,
+    parent_runtime?,
+    capabilities=@editor.LanguageCapabilities::default().with_to_view_node(fn(
+      proj,
+      source_map,
+      annotations,
+      source_text,
+    ) {
+      @md_proj.proj_to_view_node(proj, source_map, annotations~, source_text~)
+    }),
+  )
 }
 
 ///|

--- a/lang/markdown/companion/moon.pkg
+++ b/lang/markdown/companion/moon.pkg
@@ -9,3 +9,7 @@ import {
   "dowdiness/markdown",
   "dowdiness/loom",
 }
+
+import {
+  "dowdiness/canopy/protocol",
+} for "wbtest"

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -260,9 +260,23 @@ fn compute_split_block(
     Some(node) => node.kind is @markdown.ListItem(_)
     None => false
   }
-  let separator = if is_list_item { "\n- " } else { "\n\n" }
-  // Delete from split point to end of block, then insert separator + rest
-  let rest = source[split_pos:range.end].to_owned()
+  let separator = if is_list_item {
+    let marker = source[range.start:text_range.start].to_owned()
+    split_list_item_separator(marker)
+  } else {
+    "\n\n"
+  }
+  // Delete from split point to end of block, then insert separator + rest.
+  // List item source ranges can exclude the following line break; include it
+  // so the inserted marker does not create a blank line between list items.
+  let delete_end = if is_list_item &&
+    range.end < source.length() &&
+    source[range.end] == '\n' {
+    range.end + 1
+  } else {
+    range.end
+  }
+  let rest = source[split_pos:delete_end].to_owned()
   // Trim trailing newline from rest if present
   let trimmed_rest = if rest.length() > 0 && rest[rest.length() - 1] == '\n' {
     rest[:rest.length() - 1].to_owned()
@@ -276,7 +290,7 @@ fn compute_split_block(
         [
           SpanEdit::{
             start: split_pos,
-            delete_len: range.end - split_pos,
+            delete_len: delete_end - split_pos,
             inserted,
           },
         ],
@@ -284,6 +298,48 @@ fn compute_split_block(
       ),
     ),
   )
+}
+
+///|
+/// Return the marker prefix to use when splitting a Markdown list item.
+///
+/// The current Markdown Block API folds ordered and unordered CST list items
+/// into the same `ListItem` payload, so preserve the concrete source marker
+/// instead of synthesizing an unordered `- ` bullet for every split.
+fn split_list_item_separator(marker : String) -> String {
+  match next_ordered_marker(marker) {
+    Some(next) => "\n" + next
+    None => "\n" + marker
+  }
+}
+
+///|
+fn next_ordered_marker(marker : String) -> String? {
+  guard marker.find_by(fn(ch) { ch != ' ' && ch != '\t' }) is Some(marker_start) else {
+    return None
+  }
+  let marker_body = marker.view(start_offset=marker_start)
+  guard marker_body.find_by(fn(ch) { !(ch is ('0'..='9')) })
+    is Some(delimiter_offset) else {
+    return None
+  }
+  if delimiter_offset == 0 {
+    return None
+  }
+  match marker_body[delimiter_offset] {
+    '.' | ')' => {
+      let value = @string.parse_int(marker_body[:delimiter_offset], base=10) catch {
+        _ => return None
+      }
+      Some(
+        marker.view(end_offset=marker_start).to_owned() +
+        (value + 1).to_string() +
+        marker_body[delimiter_offset:delimiter_offset + 1].to_owned() +
+        marker_body[delimiter_offset + 1:].to_owned(),
+      )
+    }
+    _ => None
+  }
 }
 
 ///|

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -100,6 +100,15 @@ test "split_block: mid-cluster offset snaps to next grapheme boundary" {
 }
 
 ///|
+test "split_block: ordered list item keeps ordered marker" {
+  let source = "1. first\n2. second\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let item_id = proj.children[0].children[0].id()
+  let result = apply_edit(source, SplitBlock(node_id=item_id, offset=2))
+  inspect(result, content="1. fi\n2. rst\n2. second\n")
+}
+
+///|
 test "merge_with_previous: first block is no-op" {
   let source = "Hello\n"
   let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")

--- a/lang/markdown/edits/moon.pkg
+++ b/lang/markdown/edits/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/markdown",
   "dowdiness/moji",
+  "moonbitlang/core/string",
 }
 
 import {

--- a/lang/markdown/proj/moon.pkg
+++ b/lang/markdown/proj/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core",
+  "dowdiness/canopy/protocol",
   "dowdiness/incr",
   "dowdiness/markdown",
   "dowdiness/loom",

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/markdown/proj"
 
 import {
+  "dowdiness/canopy/protocol",
   "dowdiness/incr/cells",
   "dowdiness/loom/pipeline",
   "dowdiness/markdown",
@@ -15,6 +16,8 @@ pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block]) -> (@c
 pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@markdown.Block]) -> Unit
+
+pub fn proj_to_view_node(@dowdiness/canopy/core.ProjNode[@markdown.Block], @dowdiness/canopy/core.SourceMap, annotations? : Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]], source_text? : String?) -> @protocol.ViewNode
 
 pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@markdown.Block]
 

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -1,6 +1,9 @@
 ///| Extract token spans from the Markdown CST into the SourceMap.
 
 ///|
+const ORDERED_LIST_KIND_ROLE : String = "markdown:ordered-list-kind"
+
+///|
 pub fn populate_token_spans(
   source_map : @core.SourceMap,
   syntax_root : @seam.SyntaxNode,
@@ -96,15 +99,24 @@ fn populate_block(
       // Full inline content (no prefix to skip)
       set_content_span(source_map, syntax_node, id, "text", None)
     ListItem(_) =>
-      // Full inline content after the list marker
+      // Full inline content after this item's own marker. Compare marker
+      // positions so a nested sublist marker never wins over the outer item
+      // marker when both token kinds are present in the item CST.
       set_content_span(
         source_map,
         syntax_node,
         id,
         "text",
-        Some(ListMarkerToken),
+        list_item_marker_kind(syntax_node),
       )
     UnorderedList(_) => {
+      if @markdown.SyntaxKind::from_raw(syntax_node.kind()) == OrderedListNode {
+        source_map.set_token_span(
+          id,
+          ORDERED_LIST_KIND_ROLE,
+          @loomcore.Range::new(syntax_node.start(), syntax_node.start()),
+        )
+      }
       let syntax_children = collect_syntax_children(
         syntax_node,
         @markdown.SyntaxKind::ListItemNode,
@@ -163,5 +175,28 @@ fn populate_block(
       )
     }
     Error(_) => ()
+  }
+}
+
+///|
+fn list_item_marker_kind(
+  syntax_node : @seam.SyntaxNode,
+) -> @markdown.SyntaxKind? {
+  let unordered = syntax_node.find_token(
+    @markdown.SyntaxKind::ListMarkerToken.to_raw(),
+  )
+  let ordered = syntax_node.find_token(
+    @markdown.SyntaxKind::OrderedListMarkerToken.to_raw(),
+  )
+  match (unordered, ordered) {
+    (Some(u), Some(o)) =>
+      if u.start() < o.start() {
+        Some(ListMarkerToken)
+      } else {
+        Some(OrderedListMarkerToken)
+      }
+    (Some(_), None) => Some(ListMarkerToken)
+    (None, Some(_)) => Some(OrderedListMarkerToken)
+    (None, None) => None
   }
 }

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -42,6 +42,9 @@ fn build_proj_tree(
         counter,
       )
     UnorderedList(_) =>
+      // The current Markdown Block API folds both unordered and ordered CST
+      // list nodes to UnorderedList payloads. Preserve either CST container by
+      // collecting its ListItemNode children from the original syntax node.
       build_container(
         syntax_node,
         block,
@@ -107,10 +110,72 @@ fn is_block_node(kind : @markdown.SyntaxKind) -> Bool {
     HeadingNode
     | ParagraphNode
     | UnorderedListNode
+    | OrderedListNode
     | ListItemNode
     | CodeBlockNode
     | ErrorNode => true
     _ => false
+  }
+}
+
+///|
+/// Convert a Markdown projection to the wire ViewNode shape while preserving
+/// CST list orderedness that the current Block payload does not carry.
+pub fn proj_to_view_node(
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+  annotations? : Map[@core.NodeId, Array[@protocol.ViewAnnotation]] = {},
+  source_text? : String? = None,
+) -> @protocol.ViewNode {
+  let view = @protocol.proj_to_view_node(
+    node,
+    source_map,
+    annotations~,
+    source_text~,
+  )
+  refine_markdown_view_node(view, node, source_map)
+}
+
+///|
+fn refine_markdown_view_node(
+  view : @protocol.ViewNode,
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+) -> @protocol.ViewNode {
+  let children : Array[@protocol.ViewNode] = view.children
+    .iter()
+    .zip(node.children.iter())
+    .map(pair => refine_markdown_view_node(pair.0, pair.1, source_map))
+    .collect()
+  let kind_tag = markdown_view_kind_tag(view.kind_tag, node, source_map)
+  @protocol.ViewNode::ViewNode(
+    id=view.id,
+    kind_tag~,
+    label=view.label,
+    text?=view.text,
+    text_range=view.text_range,
+    token_spans=view.token_spans,
+    editable=view.editable,
+    css_class=kind_tag,
+    children~,
+    annotations=view.annotations,
+  )
+}
+
+///|
+fn markdown_view_kind_tag(
+  fallback : String,
+  node : @core.ProjNode[@markdown.Block],
+  source_map : @core.SourceMap,
+) -> String {
+  match node.kind {
+    UnorderedList(_) =>
+      if source_map.get_token_span(node.id(), ORDERED_LIST_KIND_ROLE) is Some(_) {
+        "OrderedList"
+      } else {
+        fallback
+      }
+    _ => fallback
   }
 }
 

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -28,6 +28,55 @@ test "projection: unordered list" {
 }
 
 ///|
+test "projection: ordered list" {
+  let (proj, _) = parse_to_proj_node("1. first\n2. second\n")
+  inspect(proj.children.length(), content="1")
+  let list = proj.children[0]
+  inspect(list.children.length(), content="2")
+}
+
+///|
+test "source map: ordered list item text excludes marker" {
+  let source = "1. first\n2. second\n"
+  let (proj, _) = parse_to_proj_node(source)
+  let source_map = @core.SourceMap::from_ast(proj)
+  let (cst, _) = @markdown.parse_cst(source)
+  populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
+  let item = proj.children[0].children[0]
+  match source_map.get_token_span(item.id(), "text") {
+    Some(span) =>
+      inspect(source[span.start:span.end].to_owned(), content="first")
+    None => fail("expected ordered list item text span")
+  }
+}
+
+///|
+test "view: ordered list keeps ordered kind tag" {
+  let source = "1. first\n2. second\n"
+  let (proj, _) = parse_to_proj_node(source)
+  let source_map = @core.SourceMap::from_ast(proj)
+  let (cst, _) = @markdown.parse_cst(source)
+  populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
+  let view = proj_to_view_node(proj, source_map, source_text=Some(source))
+  inspect(view.children[0].kind_tag, content="OrderedList")
+}
+
+///|
+test "source map: outer ordered item marker wins over nested bullet" {
+  let source = "1. parent\n   - child\n"
+  let (proj, _) = parse_to_proj_node(source)
+  let source_map = @core.SourceMap::from_ast(proj)
+  let (cst, _) = @markdown.parse_cst(source)
+  populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
+  let item = proj.children[0].children[0]
+  match source_map.get_token_span(item.id(), "text") {
+    Some(span) =>
+      inspect(source[span.start:span.start + 6].to_owned(), content="parent")
+    None => fail("expected outer ordered list item text span")
+  }
+}
+
+///|
 test "projection: code block" {
   let (proj, _) = parse_to_proj_node("```js\nconsole.log(42)\n```")
   inspect(proj.children.length(), content="1")


### PR DESCRIPTION
## Summary

- Update the `loom` submodule pointer from `0a827c3` to `7408ea7`.
- Pull in the latest Markdown/list parsing and MarkdownIR updates from `dowdiness/loom`.
- Preserve ordered-list CST containers in Canopy's Markdown projection/source-map logic after the Loom bump.
- Preserve ordered markers when splitting ordered-list items through Markdown edit operations.
- Preserve ordered-list kind through all Markdown editor view paths and render ordered lists as `<ol>` in preview.
- Preserve ordered-list context when BlockInput flattens list containers so block mode shows numbered markers instead of bullets.
- Preserve source markers in BlockInput display for ordered lists that start above `1.` or use `)` delimiters.
- Pick the earliest item marker token for list-item text spans so nested mixed-list markers do not hide/corrupt outer item text.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyntaxKind::OrderedListNode` / `OrderedListMarkerToken` | `dowdiness/markdown` via Loom | Yes | Used to preserve ordered-list CST nodes and exclude ordered-list markers from editable text spans. |
| `Block::UnorderedList` / `Block::ListItem` | `dowdiness/markdown` via Loom | Yes | Current public Block API folds ordered and unordered CST containers into the existing list payloads. |
| `SourceMap::set_token_span` / `get_token_span` | `core` / `lang/markdown/proj` | Yes | Existing source-map side channel carries ordered-list CST kind until the Markdown Block payload can represent it directly. |
| `@protocol.proj_to_view_node` | `protocol` | Yes | Reused as the base ViewNode converter, then refined only for Markdown ordered-list kind tags. |
| `LanguageCapabilities` | `editor` | Yes | Extended with an optional ViewNode converter so `SyncEditor::get_view_tree` and `@editor.compute_view_patches` route Markdown through the ordered-aware converter. |
| `ViewNode.token_spans` / `text_range` | `protocol` / `adapters/editor-adapter` | Yes | Used with the current source text to recover concrete ordered-list display markers without changing the wire protocol. |
| `BlockInput.collectEditableBlocks` | `adapters/editor-adapter` | Yes | Existing flattening path now preserves list context for editable list items. |
| `MarkdownEditOp::SplitBlock` / `compute_markdown_edit` | `lang/markdown/edits` | Yes | Existing split path now preserves source marker kind instead of synthesizing unordered bullets. |
| `String::find_by`, `String::view`, `@string.parse_int` | `moonbitlang/core/string` | Yes | Used to parse ordered markers declaratively without hand-rolled mutable scan loops. |

New helpers added (if any):

- `split_list_item_separator` / `next_ordered_marker`: package-private edit helpers that infer the concrete list marker from source because the current Markdown `Block::ListItem` payload does not distinguish ordered vs unordered CST list items.
- `proj_to_view_node` / `refine_markdown_view_node`: Markdown-specific ViewNode conversion that preserves ordered-list CST kind on top of the generic protocol converter.
- `LanguageCapabilities::with_to_view_node`: generic editor extension hook for language-specific ViewNode conversion.
- `list_item_marker_kind`: package-private source-map helper that chooses the earliest unordered/ordered item marker for mixed nested-list items.
- `BlockInput` list-context/source-marker helpers: TypeScript-local metadata used only while rendering flattened editable blocks.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for intended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`)
- [x] TS typecheck for affected examples passes
- [x] Markdown Playwright suite passes locally

## Validation

```bash
git -C loom fetch origin --tags
git -C loom branch -r --contains 7408ea7cc268f2c0bfd030fcaa2a11fedca5a51f
./scripts/run-moon-module.sh ci-lenient loom/loom
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/editor
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/edits
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/companion
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/markdown
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
cd examples/web && npm run build
cd examples/web && npx tsc --noEmit
cd examples/prosemirror && npx tsc --noEmit
cd examples/web && npx playwright test tests/markdown-editor.spec.ts --project=chromium
```

Note: local Playwright run emitted Vite/MoonBit OS file-watch-limit warnings from the large local worktree set, but the Markdown test suite passed.
