### PR TITLE
docs: track PR 720 follow-ups

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -77,6 +77,11 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: `HeadingMarker(Int)`, `CodeFenceOpen(Int, String)`, `Text(String)`, `CodeText(String)` still carry payloads. Some are semantic (heading level, info string), not just raw text — needs design thought on how to derive from source.
   Exit: markdown Token is payload-free where possible, semantic info extracted at point-of-use.
 
+- [ ] Replace Markdown ordered-list `SourceMap` side channel with explicit list payloads.
+  Why: PR #720 temporarily records ordered-list kind in `SourceMap` metadata because Loom's Markdown `Block` API currently folds ordered and unordered list containers into one payload. Orderedness is semantic AST data and should come from Loom's Markdown payload once exposed there.
+  Plan: `docs/plans/2026-06-20-markdown-list-payloads.md`
+  Exit: `ORDERED_LIST_KIND_ROLE` is removed, ordered-list projection/view/FFI/block-mode regressions still pass, and Canopy reads list kind from explicit Loom Markdown list payloads.
+
 - [ ] `SyntaxNode::find[K : ToRawKind]` generic method (low priority).
   Why: 16 `find_token(...to_raw())` callsites remain, but views pattern + `token_text()` already reduce the ergonomic pain. Nice-to-have polish.
   Exit: `pub fn[K : ToRawKind] SyntaxNode::find(self, kind : K) -> SyntaxToken?` in seam.

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -79,8 +79,9 @@ ProseMirror tree positions to this API.
 | `ViewNode` | `protocol/` | Node in the rendered view tree. |
 | `ViewNode::ViewNode(...)` | `protocol/` | Named constructor. |
 | `layout_to_view_tree(layout)` | `protocol/` | Convert a `Layout` from the pretty-printer to a `ViewNode` tree. |
+| `LanguageCapabilities::with_to_view_node` | `editor/` | Install a language-specific `ProjNode` → `ViewNode` converter when generic `Renderable` conversion is not enough. Prefer refining `@protocol.proj_to_view_node`; wire this in `lang/*/companion`, not in `SyncEditor` or frontend adapters. |
 
-**Do not:** Build a parallel view representation outside `ViewNode`/`protocol/`.
+**Do not:** Build a parallel view representation outside `ViewNode`/`protocol/`, or special-case language-specific view semantics in generic editor/frontend code.
 
 ---
 

--- a/docs/plans/2026-06-20-markdown-list-payloads.md
+++ b/docs/plans/2026-06-20-markdown-list-payloads.md
@@ -1,0 +1,40 @@
+# Replace Markdown ordered-list SourceMap side channel with explicit list payloads
+
+## Context
+
+PR #720 updated Loom and restored ordered-list behavior in Canopy's Markdown editor. The current Loom Markdown `Block` API still folds ordered and unordered list containers into the same list payload, so Canopy temporarily preserves orderedness by recording `ORDERED_LIST_KIND_ROLE` in the Markdown projection `SourceMap` and refining `ViewNode.kind_tag` during Markdown-specific view conversion.
+
+That bridge is intentionally temporary. `SourceMap` token spans are good for source ranges and token locations, but ordered-vs-unordered list kind is semantic AST data. Once Loom's Markdown AST exposes list kind directly, Canopy should stop using a SourceMap side channel for this fact.
+
+## Goal
+
+Represent Markdown list kind explicitly in the Loom Markdown AST/projection payload, then migrate Canopy to read orderedness from the projected node kind/payload rather than from `SourceMap` token metadata.
+
+## Non-goals
+
+- Do not add ordered-list fields to the generic `protocol.ViewNode` wire shape.
+- Do not remove token spans used for source ranges, editable text spans, or marker/source display.
+- Do not change Markdown edit semantics beyond removing the ordered-list-kind side channel.
+
+## Implementation outline
+
+1. **Loom Markdown API**
+   - Add an explicit ordered/unordered distinction to the Markdown block representation, e.g. separate `OrderedList` / `UnorderedList` payloads or a list-kind field.
+   - Update Loom Markdown conversion and generated interfaces.
+
+2. **Canopy projection**
+   - Update `lang/markdown/proj/proj_node.mbt` to project the explicit ordered-list payload directly.
+   - Remove `ORDERED_LIST_KIND_ROLE` from `lang/markdown/proj/populate_token_spans.mbt`.
+   - Remove `markdown_view_kind_tag`'s SourceMap side-channel lookup; `proj_to_view_node` may still refine Markdown-specific view details if needed, but not list orderedness.
+
+3. **Canopy editor/FFI paths**
+   - Keep `LanguageCapabilities::with_to_view_node` wiring for Markdown if Markdown still needs language-specific ViewNode conversion.
+   - Keep BlockInput source-marker display for start numbers and `)` delimiters until list payloads carry enough marker style/start data to replace it.
+
+4. **Tests**
+   - Keep PR #720 regressions for projection, FFI, generic editor view patches, preview rendering, block-mode display, and split behavior.
+   - Add/adjust a regression proving orderedness comes from the explicit payload, not a `SourceMap` role.
+
+## Exit condition
+
+`ORDERED_LIST_KIND_ROLE` no longer exists; ordered-list rendering and split regressions still pass; and Canopy's Markdown projection/view code obtains orderedness from Loom's explicit Markdown list payload.

--- a/editor/README.md
+++ b/editor/README.md
@@ -12,7 +12,15 @@ Language-agnostic CRDT editor engine that combines text storage, undo/redo, reac
 - `EphemeralHub` — multi-peer cursor and presence state (encode/apply/broadcast)
 - `SyncMessage` / `encode_message` / `decode_message` — binary protocol framing for CRDT ops, sync requests, and room control
 - `ViewUpdateState` — snapshot used to compute minimal `ViewPatch` sequences
-- `LanguageCapabilities[T]` — per-language hooks wired at construction time (text-edit handler, tree-edit handler, pretty-print, etc.)
+- `LanguageCapabilities[T]` — per-language hooks wired at construction time (text-edit handler, tree-edit handler, pretty-print, ViewNode conversion, etc.)
+
+## Language-specific ViewNode conversion
+
+`LanguageCapabilities::with_to_view_node` is the intended hook when a language needs to convert `ProjNode[T]` to `protocol.ViewNode` differently from the generic `Renderable` path. Use it for language-specific view semantics that are derived from the projection tree, `SourceMap`, annotations, and optional source text.
+
+The converter should keep the generic `ViewNode` wire contract. Prefer calling `@protocol.proj_to_view_node` first, then refining the returned tree narrowly. Markdown uses this path to preserve list-specific view tags while keeping generic editor and FFI view-patch code language-agnostic.
+
+Do not add parallel frontend-only view models or special-case language behavior in `SyncEditor::get_view_tree`; install the converter in the language companion constructor instead.
 
 ## Consumers
 


### PR DESCRIPTION
## Summary
- Track replacing Markdown ordered-list SourceMap side channel with explicit Loom list payloads.
- Document LanguageCapabilities::with_to_view_node as the language-specific ViewNode conversion hook.

## Validation
- NEW_MOON_MOD=0 moon check