### PR TITLE
Extract Markdown SDEG heading side table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,9 @@
 ## Reuse check
 
 <!-- Required when adding new functions, methods, helpers, or types. Skip only for pure docs/config changes. -->
+<!-- Include project APIs and actual MoonBit core APIs for the data shape involved
+     (Map/Set/String/StringView/Bytes/Buffer/Option/Result/cmp/math/Array/Iter, etc.).
+     Do not satisfy this by listing only Iter/Array unless the change is purely collection iteration. -->
 
 Existing APIs considered:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,18 @@ Hooks enforce `moon check` after every edit and `moon fmt && moon info` before c
 
 Before defining any new function, method, helper, or type in this repository:
 
-1. Search: `NEW_MOON_MOD=0 moon ide doc "<keyword>"`, `NEW_MOON_MOD=0 moon ide outline <pkg>`, `NEW_MOON_MOD=0 moon ide peek-def <symbol>`, `NEW_MOON_MOD=0 moon ide find-references <symbol>`.
+1. Search project APIs and the relevant MoonBit core APIs:
+   `NEW_MOON_MOD=0 moon ide doc "<keyword>"`,
+   `NEW_MOON_MOD=0 moon ide doc "<CoreType>::*"`,
+   `NEW_MOON_MOD=0 moon ide doc "@<core-package>"`,
+   `NEW_MOON_MOD=0 moon ide outline <pkg>`,
+   `NEW_MOON_MOD=0 moon ide peek-def <symbol>`,
+   `NEW_MOON_MOD=0 moon ide find-references <symbol>`.
 2. State at least 2 candidate existing APIs, or explain why fewer exist.
+   Include actual MoonBit core candidates for the data shape involved (for
+   example `Map`, `Set`, `String`/`StringView`, `Bytes`/`BytesView`,
+   `Buffer`/`StringBuilder`, `Option`/`Result`, `cmp`/`math` helpers,
+   `Array`, `Iter`) rather than listing only `Iter`/`Array` by default.
 3. For each candidate: where defined, what it covers, whether reused, and if not — why not.
 4. If a new helper is unavoidable, state its responsibility boundary explicitly.
 
@@ -144,13 +154,19 @@ See `docs/api-map.md` for the task→existing-API index. Include a **Reuse check
 Extends the Existing API First Rule above from *new definitions* to *all* code.
 
 Do not write new low-level loops, helpers, or data-manipulation code until you
-have searched for existing project APIs and MoonBit/core APIs. Use
-`NEW_MOON_MOD=0 moon ide doc`, `peek-def`, `find-references`, and `outline` to
-discover existing functions and methods.
+have searched for existing project APIs and the actual MoonBit core APIs that
+fit the data shape. Use `NEW_MOON_MOD=0 moon ide doc`, `peek-def`,
+`find-references`, and `outline` to discover existing functions and methods.
 
 **Prefer declarative code:**
 - `match` / `guard` / pattern matching
-- `Iter` methods: `map`, `filter`, `fold`, `collect`
+- MoonBit core APIs for the concrete data shape: `Map`/`Set` lookups,
+  `Option`/`Result` handling, `String`/`StringView`/`Bytes`/`BytesView`
+  slicing, `Buffer`/`StringBuilder`, `cmp`/`math` helpers, plus `Array`/`Iter`
+  methods such as `map`, `filter`, `fold`, `collect`
+- arrow functions for higher-order callbacks (`x => expr`, `(a, b) => { ... }`);
+  reserve `fn(...) { ... }` for named/local function values, explicit
+  `raise`/`async` shape, or recursion
 - list comprehensions when clearer
 - `ArrayView` / `StringView` / `BytesView` instead of copying
 - owning-type methods and constructors
@@ -162,10 +178,11 @@ discover existing functions and methods.
   performance reasons
 
 **Before finalizing, report:**
-1. existing APIs reused
-2. existing APIs checked but not used
-3. any new helper introduced, and why
-4. remaining imperative code, and why it is necessary
+1. existing project APIs reused
+2. MoonBit core APIs checked (not just `Iter`/`Array`) and whether reused
+3. existing APIs checked but not used
+4. any new helper introduced, and why
+5. remaining imperative code, and why it is necessary
 
 Run `moon check` after edits and `moon test` for affected packages.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -260,6 +260,11 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Plan: `docs/plans/2026-03-30-editor-drag-drop-foundation.md` (steps 2-3)
   Exit: `block-editor` exposes positioned block moves plus structural render metadata.
 
+- [ ] Spike Markdown block move provenance for future block UI.
+  Why: SDEG Phase 1 documents pure source reorder as position-stable; future block moves need explicit provenance so identity follows the moved block.
+  Plan: `docs/plans/2026-06-20-markdown-block-move-provenance-spike.md`
+  Exit: accepted or rejected move-provenance contract, with tests or blocker proof showing only explicit provenance can override positional same-node evidence.
+
 - [ ] Convergence tests for concurrent drag-drop.
   Why: concurrent relocations across CRDT peers need convergence guarantees.
   Exit: property tests covering concurrent drop, undo grouping after relocation, and reconciliation.

--- a/docs/plans/2026-03-30-editor-drag-drop-foundation.md
+++ b/docs/plans/2026-03-30-editor-drag-drop-foundation.md
@@ -138,6 +138,8 @@ tests where the interaction becomes user-visible.
 ## Notes
 
 - Browser-native drag-and-drop is input plumbing, not the canonical move model.
+- Markdown/block identity provenance for future block moves is tracked in
+  `docs/plans/2026-06-20-markdown-block-move-provenance-spike.md`.
 - Prefer dedicated drag handles over making the editable surface itself
   draggable.
 - Leave room for future ephemeral drag presence by keeping source/target/

--- a/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
+++ b/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
@@ -64,7 +64,10 @@ previous projection node is absent. Phase 1 should not weaken the matcher to
 recover changes without evidence; it should keep ambiguous or
 provenance-sensitive cases explicit. In particular, pure sibling reorder remains
 out of scope for side-table-only recovery because Phase 0 showed the old
-`NodeId`s are still present but attached by position.
+`NodeId`s are still present but attached by position. Reorder recovery is still
+needed for the future block-based editor UI; the owner should be a language-owned
+block move/reorder edit path that emits explicit move provenance, not the Phase 1
+derived side table guessing around same-node priority.
 
 ## Desired State
 

--- a/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
+++ b/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
@@ -69,6 +69,15 @@ needed for the future block-based editor UI; the owner should be a language-owne
 block move/reorder edit path that emits explicit move provenance, not the Phase 1
 derived side table guessing around same-node priority.
 
+As of 2026-06-20, the first production extraction exists in
+`lang/markdown/proj/sdeg_heading_side_table.mbt`. It keeps the side-table types
+`priv`, moves shared heading observation/range/key helpers out of white-box-only
+files, and updates the existing white-box tests to consume the package-private
+core. Regression tests now record that preserved same-node evidence wins over a
+duplicate retained row's semantic claim, that rows retain explicit evidence for
+same-node/semantic/missing/ambiguous decisions, and that a level-only semantic
+match without preserved `NodeId` remains fresh rather than being recovered.
+
 ## Desired State
 
 A Markdown-internal side table can answer:
@@ -266,19 +275,21 @@ Do not introduce production GC until UI/undo/reload requirements are clearer.
    same-node priority and snapshot invariants. Where lifecycle names conflict,
    this Phase 1 plan supersedes the older sketch: first absence is `Missing`,
    and `Tombstoned` is reached only after the retention threshold.
-2. Extract the test-only observation helpers into package-private helpers inside
-   `lang/markdown/proj/`, still not public.
-3. Add a package-private `HeadingEntityTable` with entity records and current-node
-   index.
-4. Implement update-from-observations for one successful projection snapshot.
+2. [x] Extract the test-only observation helpers into package-private helpers
+   inside `lang/markdown/proj/`, still not public.
+3. [x] Add a package-private heading side table with entity records and a
+   current-node index. The implementation name is `HeadingSideTable`; the plan's
+   earlier `HeadingEntityTable` name was descriptive, not a public contract.
+4. [x] Implement update-from-observations for one successful projection snapshot.
 5. Add tests for:
-   - rename keeps one entity and updates its signature;
-   - pure sibling reorder records the same-node-priority limitation instead of
-     claiming semantic recovery;
-   - delete marks the entity missing/tombstoned;
-   - restore recovers the retained entity;
-   - duplicates produce ambiguity rather than guessed identity;
-   - heading level change remains an explicit fresh-`NodeId` limitation unless a
+   - [x] rename keeps one entity and updates its signature;
+   - [x] pure sibling reorder records the same-node-priority limitation instead
+     of claiming semantic recovery;
+   - [x] delete marks the entity missing/tombstoned;
+   - [x] restore recovers the retained entity;
+   - [x] duplicates produce ambiguity rather than guessed identity;
+   - [x] duplicate retained headings do not demote a preserved same-node match;
+   - [x] heading level change remains an explicit fresh-`NodeId` limitation unless a
      provenance/reconciliation fix is included.
 6. Keep all behavior test-local until the table is needed by a real consumer.
 7. Summarize whether the table should graduate to a generic SDEG-internal
@@ -286,17 +297,18 @@ Do not introduce production GC until UI/undo/reload requirements are clearer.
 
 ## Acceptance Criteria
 
-- [ ] No public `.mbti` surface changes.
-- [ ] Heading observations are extracted from existing `ProjNode` + `SourceMap`.
-- [ ] Pure sibling reorder is documented as a same-node-priority limitation, or
+- [x] No public `.mbti` surface changes.
+- [x] Heading observations are extracted from existing `ProjNode` + `SourceMap`.
+- [x] Pure sibling reorder is documented as a same-node-priority limitation, or
       fixed only with explicit reorder/provenance evidence.
-- [ ] Side table marks delete as missing/tombstoned without deleting the record.
-- [ ] Side table recovers a uniquely restored heading from retained observation.
-- [ ] Duplicate headings are marked ambiguous.
-- [ ] Tests document which evidence produced each decision.
-- [ ] Heading level-change identity is either still documented as an upstream
+- [x] Side table marks delete as missing/tombstoned without deleting the record.
+- [x] Side table recovers a uniquely restored heading from retained observation.
+- [x] Duplicate headings are marked ambiguous.
+- [x] Same-node priority wins over a duplicate retained row's semantic claim.
+- [x] Tests document which evidence produced each decision.
+- [x] Heading level-change identity is either still documented as an upstream
       provenance/reconciliation limitation or fixed with explicit evidence.
-- [ ] No CRDT, frontend protocol, or public SDEG package changes.
+- [x] No CRDT, frontend protocol, or public SDEG package changes.
 
 ## Validation
 

--- a/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
+++ b/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
@@ -75,8 +75,10 @@ As of 2026-06-20, the first production extraction exists in
 files, and updates the existing white-box tests to consume the package-private
 core. Regression tests now record that preserved same-node evidence wins over a
 duplicate retained row's semantic claim, that rows retain explicit evidence for
-same-node/semantic/missing/ambiguous decisions, and that a level-only semantic
-match without preserved `NodeId` remains fresh rather than being recovered.
+same-node/semantic/missing/ambiguous decisions, that first absence is `Missing`
+and repeated absence becomes `Tombstoned`, that the table carries a rebuilt
+current-node index, and that a level-only semantic match without preserved
+`NodeId` remains fresh rather than being recovered.
 
 ## Desired State
 
@@ -291,9 +293,12 @@ Do not introduce production GC until UI/undo/reload requirements are clearer.
    - [x] duplicate retained headings do not demote a preserved same-node match;
    - [x] heading level change remains an explicit fresh-`NodeId` limitation unless a
      provenance/reconciliation fix is included.
-6. Keep all behavior test-local until the table is needed by a real consumer.
-7. Summarize whether the table should graduate to a generic SDEG-internal
-   abstraction or remain Markdown-owned.
+6. [x] Keep all behavior test-local until the table is needed by a real consumer.
+7. [x] Summarize whether the table should graduate to a generic SDEG-internal
+   abstraction or remain Markdown-owned. For now it remains Markdown-owned: the
+   evidence model is heading-signature-specific and pure reorder still needs a
+   future Markdown/block provenance path before a generic SDEG abstraction is
+   justified.
 
 ## Acceptance Criteria
 
@@ -305,6 +310,9 @@ Do not introduce production GC until UI/undo/reload requirements are clearer.
 - [x] Side table recovers a uniquely restored heading from retained observation.
 - [x] Duplicate headings are marked ambiguous.
 - [x] Same-node priority wins over a duplicate retained row's semantic claim.
+- [x] First absence is `Missing`; repeated absence becomes `Tombstoned` while
+      retained observations can still recover.
+- [x] The table carries a rebuilt current-node index for live rows.
 - [x] Tests document which evidence produced each decision.
 - [x] Heading level-change identity is either still documented as an upstream
       provenance/reconciliation limitation or fixed with explicit evidence.

--- a/docs/plans/2026-06-19-sdeg-reorder-provenance-investigation.md
+++ b/docs/plans/2026-06-19-sdeg-reorder-provenance-investigation.md
@@ -1,5 +1,8 @@
 # SDEG Reorder Provenance Investigation
 
+**Status:** done — concluded that Markdown reorder recovery is future block-move
+work, not SDEG Phase 1 side-table work.
+
 ## Why
 
 SDEG Phase 0 showed that pure Markdown sibling reorder is position-stable rather
@@ -57,16 +60,100 @@ Out:
 6. Update the Phase 1 side-table plan with the resulting owner and acceptance
    scope.
 
+## Investigation log
+
+### 2026-06-20 — Phase 0 pure source reorder reproduction
+
+Reproduced with:
+
+```bash
+NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj --filter 'sdeg phase0: heading reorder is currently position-stable, not semantic-stable'
+```
+
+The diagnostic test in `lang/markdown/proj/sdeg_heading_spike_wbtest.mbt`
+records that after `# A\n# B\n` is reconciled to `# B\n# A\n`, both previous
+heading `NodeId`s remain present: previous A's `NodeId` is now attached to B,
+and previous B's `NodeId` is now attached to A. This confirms the Phase 0
+observation: pure source reorder without provenance is position-stable, not
+semantic-stable.
+
+### 2026-06-20 — Markdown edit-path reorder check
+
+Existing Markdown edit operations are `CommitEdit`, `ChangeHeadingLevel`,
+`ToggleListItem`, `Delete`, `InsertBlockAfter`, `SplitBlock`, and
+`MergeWithPrevious`; there is no explicit move/reorder operation. The generic
+Markdown companion bridge computes span edits and calls
+`SyncEditor::apply_span_edits` without an identity hint, so it does not produce
+move provenance for reorder-like outcomes.
+
+Added a companion white-box diagnostic covering the smallest existing edit-path
+way to reach the swapped text: two `CommitEdit` operations, A→B at the first
+heading and B→A at the second heading. The final source is `# B\n# A\n`, but
+identity stays by position: the first heading keeps previous A's `NodeId`, and
+the second heading keeps previous B's `NodeId`. This is replacement provenance,
+not reorder provenance.
+
+Reproduced with:
+
+```bash
+NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/companion --filter 'sdeg phase0: markdown edit path swap is replacement, not reorder provenance'
+```
+
+### 2026-06-20 — Scope decision
+
+Markdown reorder recovery is needed for the future block-based editor UI, where a
+user-visible block move should carry identity with the moved block. It is not a
+Phase 1 side-table deliverable: the current Markdown edit path has no reorder
+operation or move provenance, and building that language-owned block move path
+is a larger structural-edit feature. Until that exists, pure source reorder
+remains a documented same-node-priority limitation rather than a side-table-only
+semantic override.
+
+Existing APIs checked before making that call:
+
+- `core/reconcile.mbt`: `reconcile` / `reconcile_hinted` preserve same-kind
+  siblings by LCS/position unless explicit structural hints exclude old nodes.
+- `core/identity_transform.mbt`: `IdentityTransform::Move` exists as vocabulary,
+  but the generic reconciler currently freshens move-targeted positions; there is
+  no Markdown producer for it.
+- `lang/runtime/language_spec.mbt` and `lang/markdown/companion/`: Markdown
+  structural edits are lowered to span edits without identity hints.
+- `lang/lambda/proj/projection_memo.mbt`: Lambda has custom hinted projection
+  reconciliation, but Markdown does not.
+- Loom `ProjectionIdentityTracker` / `realign_projection_items`: useful for edit
+  windows and failed-input recovery, but the Phase 0 diagnostic records that it
+  does not recover pure sibling reorder.
+
+## Conclusion
+
+Reorder recovery is **not in scope for SDEG Phase 1**. The Phase 1 side table
+should keep same-node priority for ordinary edits and report pure source reorder
+as a known limitation when no explicit provenance is present.
+
+The future owner is **Markdown/block edit lowering plus hinted projection
+reconciliation**: a block-based editor move command should produce an explicit
+move/reorder operation, lower it to text/CRDT edits, and pass identity provenance
+through the existing hint channel or a future equivalent. Projection
+reconciliation should only override positional same-node evidence for that
+explicit move provenance, not for arbitrary source reorder inferred from text.
+
+No prototype fix was added because the current Markdown edit path cannot express
+the required user intent. Adding that path is a larger block-editor structural
+edit feature, not a side-table-only change.
+
+Follow-up spike opened: `docs/plans/2026-06-20-markdown-block-move-provenance-spike.md`.
+
 ## Acceptance criteria
 
-- [ ] The investigation names whether reorder recovery is in scope for Phase 1.
-- [ ] Tests record pure source reorder as position-stable unless explicit
+- [x] The investigation names whether reorder recovery is in scope for Phase 1.
+- [x] Tests record pure source reorder as position-stable unless explicit
       provenance is present.
-- [ ] If a fix is prototyped, same-node priority still wins for ordinary
-      non-reorder edits.
-- [ ] No public API or `.mbti` surface changes unless explicitly justified.
-- [ ] Documentation states the owner: Markdown edit lowering, projection
-      reconciliation, identity realignment, or future SDEG core.
+- [x] If a fix is prototyped, same-node priority still wins for ordinary
+      non-reorder edits. Not applicable: no fix was prototyped because no
+      explicit Markdown reorder provenance exists today.
+- [x] No public API or `.mbti` surface changes unless explicitly justified.
+- [x] Documentation states the owner: Markdown edit lowering plus hinted
+      projection reconciliation for a future block move/reorder edit path.
 
 ## Validation
 

--- a/docs/plans/2026-06-20-markdown-block-move-provenance-spike.md
+++ b/docs/plans/2026-06-20-markdown-block-move-provenance-spike.md
@@ -1,0 +1,136 @@
+# Markdown Block Move Provenance Spike
+
+**Status:** backlog
+
+## Why
+
+Markdown reorder recovery is required for the future block-based editor UI: when a
+user moves a visible block, the block's editing identity should move with it.
+The SDEG reorder provenance investigation showed that current Markdown edits do
+not express that intent. Pure source reorder and replacement-style `CommitEdit`
+sequences are position-stable, so a Phase 1 side table must not infer semantic
+move identity without explicit provenance.
+
+This spike designs and validates the smallest explicit provenance path for a
+future Markdown/block move command.
+
+## Scope
+
+In:
+- `lang/markdown/edits/`
+- `lang/markdown/companion/`
+- `lang/markdown/proj/`
+- `lang/runtime/` if the generic edit bridge needs a hint-bearing return shape
+- `core/` only if existing `IdentityTransform::Move` / `reconcile_hinted` cannot
+  express the needed invariant
+- tests proving identity behavior for explicit block moves
+- documentation updates that connect this spike to block-editor drag/drop plans
+
+Out:
+- polished drag-and-drop UI
+- public `EntityId` or `sdeg-*` packages
+- durable reload/peer-stable identities
+- CRDT schema changes unless the spike proves they are unavoidable
+- side-table-only semantic reorder guessing
+- broad rewrite of Markdown projection reconciliation
+
+## Current State
+
+- `docs/plans/2026-06-19-sdeg-reorder-provenance-investigation.md` concludes
+  reorder recovery is not in SDEG Phase 1 and names this as future work.
+- `lang/markdown/edits/markdown_edit_op.mbt` has no move/reorder operation.
+- `lang/runtime/language_spec.mbt` lowers structural edits to span edits and
+  calls `SyncEditor::apply_span_edits` without identity hints.
+- `editor/sync_editor.mbt` can carry a single `IdentityTransform` hint through
+  `apply_span_edits`, but Markdown does not use that channel.
+- `core/identity_transform.mbt` already has `IdentityTransform::Move`, while
+  `core/reconcile.mbt` currently treats `Move` as editor-owned and freshens the
+  node at the old position unless a language-specific reconciler consumes it.
+- `docs/plans/2026-03-30-editor-drag-drop-foundation.md` tracks the broader
+  block-editor drag/drop foundation; this spike is the identity-provenance slice.
+
+## Desired State
+
+The spike answers, with code/tests or a written rejection:
+
+- What is the minimal Markdown/block move operation shape?
+- How does that operation lower to text edits while preserving source truth,
+  undo, and parser/reconcile flow?
+- How is explicit move provenance delivered to projection reconciliation?
+- Can moved block identity follow the moved heading/block only when explicit
+  provenance is present?
+- Do ordinary replacement edits and pure source reorder keep same-node priority
+  / documented limitation behavior?
+
+## Steps
+
+1. Define candidate move operations, e.g. `MoveBlockBefore(source~, target~)` /
+   `MoveBlockAfter(source~, target~)`, including legality rules for self-target,
+   missing nodes, and same-position no-ops.
+2. Decide how Markdown should pass identity hints through the existing generic
+   companion runtime: extend the edit result shape to include an optional
+   `IdentityTransform`, add a Markdown-specific bridge, or document why the
+   current hint channel is insufficient.
+3. Prototype the smallest source-text lowering for sibling block moves. Keep the
+   source/text patch as the document mutation; do not mutate side-table metadata
+   as source of truth.
+4. Prototype or design the reconciliation owner. Prefer a Markdown-specific
+   hinted reconciler if generic `reconcile_hinted` cannot safely preserve move
+   identity without weakening ordinary same-node priority. Prefer a
+   test-only/private prototype; stop before public API changes unless the
+   prototype proves that a public shape is necessary.
+5. Add white-box tests comparing:
+   - pure source reorder without provenance remains position-stable;
+   - replacement-style edit-path swap remains replacement-by-position;
+   - explicit block move provenance preserves moved block identity;
+   - ordinary non-reorder edits still preserve same-node identity by position.
+6. Update the broader drag/drop foundation plan or TODO item with the chosen
+   provenance contract and any blockers.
+
+## Acceptance Criteria
+
+- [ ] A concrete Markdown/block move operation shape is accepted or rejected with
+      reasons.
+- [ ] The provenance delivery path is named: existing `IdentityTransform::Move`,
+      an extended hint channel, a Markdown-specific bridge, or a documented
+      blocker.
+- [ ] Tests or a written proof-of-blocker show that explicit provenance is the
+      only case where reorder identity can override positional same-node
+      evidence.
+- [ ] Pure source reorder remains documented and tested as a limitation when no
+      explicit provenance is present.
+- [ ] The future block-editor drag/drop plan links to the accepted provenance
+      contract.
+- [ ] No public SDEG/entity ID API is introduced.
+
+## Validation
+
+```bash
+NEW_MOON_MOD=0 moon check
+NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj
+NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/companion
+NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
+git diff -- '*.mbti'
+```
+
+If the spike changes `core/`, `editor/`, or `lang/runtime/`, also run:
+
+```bash
+NEW_MOON_MOD=0 moon test
+```
+
+## Risks
+
+- The generic `IdentityTransform::Move` vocabulary may not be sufficient for a
+  source-text block move without language-specific matching.
+- A text patch can represent a move as delete+insert; provenance must be carried
+  separately or identity will remain position-stable.
+- Generic reconciliation changes could weaken same-node priority for ordinary
+  edits; prefer language-owned logic unless the invariant is proven generic.
+- This may overlap the broader block-editor drag/drop foundation; keep this
+  spike focused on identity provenance, not UI.
+
+## Notes
+
+- Follow-up from `docs/plans/2026-06-19-sdeg-reorder-provenance-investigation.md`.
+- Related broader foundation: `docs/plans/2026-03-30-editor-drag-drop-foundation.md`.

--- a/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
+++ b/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
@@ -30,14 +30,27 @@ fn heading_edit_path_observation(
 }
 
 ///|
+fn heading_edit_path_observations(
+  editor : @editor.SyncEditor[@markdown.Block],
+) -> Array[HeadingEditPathObservation] {
+  let observations : Array[HeadingEditPathObservation] = []
+  let root = editor.get_proj_node().unwrap()
+  let source = editor.get_text()
+  let source_map = editor.get_source_map()
+  for child in root.children {
+    match heading_edit_path_observation(child, source, source_map) {
+      Some(obs) => observations.push(obs)
+      None => ()
+    }
+  }
+  observations
+}
+
+///|
 fn first_heading_edit_path_observation(
   editor : @editor.SyncEditor[@markdown.Block],
 ) -> HeadingEditPathObservation {
-  heading_edit_path_observation(
-    editor.get_proj_node().unwrap().children[0],
-    editor.get_text(),
-    editor.get_source_map(),
-  ).unwrap()
+  heading_edit_path_observations(editor)[0]
 }
 
 ///|
@@ -63,6 +76,46 @@ test "sdeg phase0: heading rename goes through Markdown edit path" {
   inspect(before.id == after.id, content="true")
   inspect(before.text_span_text == Some("Alpha"), content="true")
   inspect(after.text_span_text == Some("Alpha 2"), content="true")
+}
+
+///|
+test "sdeg phase0: markdown edit path swap is replacement, not reorder provenance" {
+  let editor = new_markdown_editor("sdeg-edit-path-reorder")
+  editor.set_text("# A\n# B\n")
+  editor.refresh()
+  let before = heading_edit_path_observations(editor)
+  let a_before = before[0]
+  let b_before = before[1]
+
+  // MarkdownEditOp currently has no move/reorder operation. The smallest
+  // existing edit-path way to reach the swapped source is two text commits,
+  // which records replacement-by-position rather than move provenance.
+  let first_result = apply_markdown_edit(
+    editor,
+    @md_edits.MarkdownEditOp::CommitEdit(node_id=a_before.id, new_text="B"),
+    0,
+  )
+  editor.refresh()
+  let middle = heading_edit_path_observations(editor)
+  let second_result = apply_markdown_edit(
+    editor,
+    @md_edits.MarkdownEditOp::CommitEdit(node_id=middle[1].id, new_text="A"),
+    1,
+  )
+  editor.refresh()
+  let after = heading_edit_path_observations(editor)
+
+  inspect(first_result is Ok(_), content="true")
+  inspect(second_result is Ok(_), content="true")
+  inspect(editor.get_text(), content="# B\n# A\n")
+  inspect(a_before.text, content="A")
+  inspect(b_before.text, content="B")
+  inspect(after[0].text, content="B")
+  inspect(after[1].text, content="A")
+  inspect(after[0].id == a_before.id, content="true")
+  inspect(after[1].id == b_before.id, content="true")
+  inspect(after[0].id == b_before.id, content="false")
+  inspect(after[1].id == a_before.id, content="false")
 }
 
 ///|

--- a/lang/markdown/proj/sdeg_heading_side_table.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table.mbt
@@ -1,0 +1,371 @@
+///| Internal Markdown heading side table for session-local SDEG Phase 1 snapshots.
+
+///|
+#warnings("-struct_never_constructed-unused_field")
+priv struct HeadingObservation {
+  id : @core.NodeId
+  level : Int
+  text : String
+  range : @loomcore.Range
+  marker : @loomcore.Range?
+  text_span : @loomcore.Range?
+}
+
+///|
+priv enum HeadingSideTableStatus {
+  HeadingLive
+  HeadingTombstoned
+  HeadingAmbiguous
+  HeadingRetired
+} derive(Eq)
+
+///|
+priv struct HeadingStableRowId {
+  seed : @core.NodeId
+} derive(Eq)
+
+///|
+fn HeadingStableRowId::from_node(id : @core.NodeId) -> HeadingStableRowId {
+  { seed: id }
+}
+
+///|
+#warnings("-unused_constructor")
+priv enum HeadingSideTableConfidence {
+  HeadingExact
+  HeadingProbable
+  HeadingMatchAmbiguous
+  HeadingMissing
+}
+
+///|
+#warnings("-unused_constructor")
+priv enum HeadingEntityEvidence {
+  HeadingSameNodeId(@core.NodeId)
+  HeadingSameSemanticKey(String)
+  HeadingOverlappingRange(@loomcore.Range, @loomcore.Range)
+  HeadingCandidateCount(Int)
+}
+
+///|
+#warnings("-unused_field")
+priv struct HeadingMatchCandidate {
+  id : @core.NodeId
+  evidence : Array[HeadingEntityEvidence]
+}
+
+///|
+priv struct HeadingSideTableMatch {
+  confidence : HeadingSideTableConfidence
+  candidates : Array[HeadingMatchCandidate]
+  evidence : Array[HeadingEntityEvidence]
+}
+
+///|
+#warnings("-unused_field")
+priv struct HeadingSideTableRow {
+  stable_id : HeadingStableRowId
+  current_id : @core.NodeId?
+  status : HeadingSideTableStatus
+  last_live : HeadingObservation
+  candidates : Array[@core.NodeId]
+  evidence : Array[HeadingEntityEvidence]
+}
+
+///|
+priv struct HeadingSideTable {
+  rows : Array[HeadingSideTableRow]
+}
+
+///|
+fn ranges_overlap(a : @loomcore.Range, b : @loomcore.Range) -> Bool {
+  a.start < b.end && b.start < a.end
+}
+
+///|
+fn heading_key(obs : HeadingObservation) -> String {
+  "h\{obs.level}:\{obs.text}"
+}
+
+///|
+fn heading_side_table_live_row(obs : HeadingObservation) -> HeadingSideTableRow {
+  {
+    stable_id: HeadingStableRowId::from_node(obs.id),
+    current_id: Some(obs.id),
+    status: HeadingLive,
+    last_live: obs,
+    candidates: [],
+    evidence: [HeadingSameNodeId(obs.id), HeadingCandidateCount(1)],
+  }
+}
+
+///|
+#warnings("-unused_value")
+fn HeadingSideTable::from_observations(
+  observations : Array[HeadingObservation],
+) -> HeadingSideTable {
+  { rows: observations.map(heading_side_table_live_row) }
+}
+
+///|
+fn find_heading_by_id(
+  observations : Array[HeadingObservation],
+  id : @core.NodeId,
+) -> HeadingObservation? {
+  observations.iter().find_first(obs => obs.id == id)
+}
+
+///|
+fn side_table_has_stable_id(
+  rows : Array[HeadingSideTableRow],
+  stable_id : HeadingStableRowId,
+) -> Bool {
+  rows.iter().any(row => row.stable_id == stable_id)
+}
+
+///|
+fn node_id_in(ids : Array[@core.NodeId], id : @core.NodeId) -> Bool {
+  ids.iter().any(candidate_id => candidate_id == id)
+}
+
+///|
+fn side_table_mentions_current_id(
+  rows : Array[HeadingSideTableRow],
+  current_id : @core.NodeId,
+) -> Bool {
+  rows
+  .iter()
+  .any(row => {
+    row.current_id == Some(current_id) || node_id_in(row.candidates, current_id)
+  })
+}
+
+///|
+fn heading_evidence(
+  previous : HeadingObservation,
+  current : HeadingObservation,
+) -> Array[HeadingEntityEvidence] {
+  let evidence : Array[HeadingEntityEvidence] = []
+  if previous.id == current.id {
+    evidence.push(HeadingSameNodeId(current.id))
+  }
+  if previous.level == current.level && previous.text == current.text {
+    evidence.push(HeadingSameSemanticKey(heading_key(previous)))
+  }
+  if ranges_overlap(previous.range, current.range) {
+    evidence.push(HeadingOverlappingRange(previous.range, current.range))
+  }
+  evidence
+}
+
+///|
+fn heading_candidate(
+  previous : HeadingObservation,
+  current : HeadingObservation,
+) -> HeadingMatchCandidate {
+  { id: current.id, evidence: heading_evidence(previous, current) }
+}
+
+///|
+fn heading_side_table_match(
+  previous : HeadingObservation,
+  current : Array[HeadingObservation],
+) -> HeadingSideTableMatch {
+  let same_node = find_heading_by_id(current, previous.id)
+  let semantic_candidates : Array[HeadingMatchCandidate] = current
+    .iter()
+    .filter(obs => obs.level == previous.level && obs.text == previous.text)
+    .map(obs => heading_candidate(previous, obs))
+    .collect()
+  let semantic_count = semantic_candidates.length()
+  match same_node {
+    Some(obs) => {
+      let candidate = heading_candidate(previous, obs)
+      let evidence = if obs.level == previous.level && obs.text == previous.text {
+        [
+          HeadingSameNodeId(obs.id),
+          HeadingSameSemanticKey(heading_key(previous)),
+          HeadingCandidateCount(1),
+        ]
+      } else {
+        [HeadingSameNodeId(obs.id), HeadingCandidateCount(1)]
+      }
+      { confidence: HeadingExact, candidates: [candidate], evidence }
+    }
+    None if semantic_count == 1 =>
+      {
+        confidence: HeadingProbable,
+        candidates: semantic_candidates,
+        evidence: [
+          HeadingSameSemanticKey(heading_key(previous)),
+          HeadingCandidateCount(1),
+        ],
+      }
+    None if semantic_count > 1 =>
+      {
+        confidence: HeadingMatchAmbiguous,
+        candidates: semantic_candidates,
+        evidence: [
+          HeadingSameSemanticKey(heading_key(previous)),
+          HeadingCandidateCount(semantic_count),
+        ],
+      }
+    None =>
+      {
+        confidence: HeadingMissing,
+        candidates: [],
+        evidence: [HeadingCandidateCount(0)],
+      }
+  }
+}
+
+///|
+fn candidate_ids(match_result : HeadingSideTableMatch) -> Array[@core.NodeId] {
+  match_result.candidates.map(candidate => candidate.id)
+}
+
+///|
+fn row_active(row : HeadingSideTableRow) -> Bool {
+  row.status != HeadingRetired
+}
+
+///|
+fn candidate_claim_count(
+  matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)],
+  id : @core.NodeId,
+) -> Int {
+  matches.iter().filter(pair => node_id_in(candidate_ids(pair.1), id)).count()
+}
+
+///|
+fn same_node_claim_ids(
+  rows : Array[HeadingSideTableRow],
+  current : Array[HeadingObservation],
+) -> Array[@core.NodeId] {
+  rows
+  .iter()
+  .filter(row_active)
+  .filter(row => find_heading_by_id(current, row.last_live.id) is Some(_))
+  .map(row => row.last_live.id)
+  .collect()
+}
+
+///|
+fn current_without_ids(
+  current : Array[HeadingObservation],
+  excluded_ids : Array[@core.NodeId],
+) -> Array[HeadingObservation] {
+  current.iter().filter(obs => !node_id_in(excluded_ids, obs.id)).collect()
+}
+
+///|
+fn heading_side_table_match_with_same_node_priority(
+  row : HeadingSideTableRow,
+  current : Array[HeadingObservation],
+  semantic_current : Array[HeadingObservation],
+) -> HeadingSideTableMatch {
+  match find_heading_by_id(current, row.last_live.id) {
+    Some(_) => heading_side_table_match(row.last_live, current)
+    None => heading_side_table_match(row.last_live, semantic_current)
+  }
+}
+
+///|
+fn row_from_match(
+  row : HeadingSideTableRow,
+  match_result : HeadingSideTableMatch,
+  current : Array[HeadingObservation],
+  claim_count : (@core.NodeId) -> Int,
+) -> HeadingSideTableRow {
+  let ids = candidate_ids(match_result)
+  match row.status {
+    HeadingRetired => { ..row, current_id: None, candidates: [] }
+    _ =>
+      match ids {
+        [] =>
+          {
+            ..row,
+            current_id: None,
+            status: HeadingTombstoned,
+            candidates: [],
+            evidence: match_result.evidence,
+          }
+        [id] if match_result.confidence is HeadingExact ||
+          (claim_count(id) == 1 && match_result.confidence is HeadingProbable) =>
+          match find_heading_by_id(current, id) {
+            Some(current_obs) =>
+              {
+                stable_id: row.stable_id,
+                current_id: Some(current_obs.id),
+                status: HeadingLive,
+                last_live: current_obs,
+                candidates: [],
+                evidence: match_result.evidence,
+              }
+            None =>
+              {
+                ..row,
+                current_id: None,
+                status: HeadingTombstoned,
+                candidates: [],
+                evidence: match_result.evidence,
+              }
+          }
+        _ =>
+          {
+            ..row,
+            current_id: None,
+            status: HeadingAmbiguous,
+            candidates: ids,
+            evidence: match_result.evidence,
+          }
+      }
+  }
+}
+
+///|
+#warnings("-unused_value")
+fn HeadingSideTable::advance(
+  self : HeadingSideTable,
+  current : Array[HeadingObservation],
+) -> HeadingSideTable {
+  let same_node_ids = same_node_claim_ids(self.rows, current)
+  let semantic_current = current_without_ids(current, same_node_ids)
+  let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = self.rows
+    .iter()
+    .filter(row_active)
+    .map(row => {
+      (
+        row,
+        heading_side_table_match_with_same_node_priority(
+          row, current, semantic_current,
+        ),
+      )
+    })
+    .collect()
+  let next_rows = self.rows.map(row => {
+    match row.status {
+      HeadingRetired => { ..row, current_id: None, candidates: [] }
+      _ => {
+        let match_result = heading_side_table_match_with_same_node_priority(
+          row, current, semantic_current,
+        )
+        row_from_match(row, match_result, current, id => {
+          candidate_claim_count(matches, id)
+        })
+      }
+    }
+  })
+  let fresh_rows : Array[HeadingSideTableRow] = current
+    .iter()
+    .filter(obs => {
+      !side_table_mentions_current_id(next_rows, obs.id) &&
+      !side_table_has_stable_id(
+        next_rows,
+        HeadingStableRowId::from_node(obs.id),
+      )
+    })
+    .map(heading_side_table_live_row)
+    .collect()
+  { rows: next_rows + fresh_rows }
+}

--- a/lang/markdown/proj/sdeg_heading_side_table.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table.mbt
@@ -14,6 +14,7 @@ priv struct HeadingObservation {
 ///|
 priv enum HeadingSideTableStatus {
   HeadingLive
+  HeadingMissing
   HeadingTombstoned
   HeadingAmbiguous
   HeadingRetired
@@ -75,6 +76,7 @@ priv struct HeadingSideTableRow {
 ///|
 priv struct HeadingSideTable {
   rows : Array[HeadingSideTableRow]
+  current_index : Map[@core.NodeId, HeadingStableRowId]
 }
 
 ///|
@@ -100,11 +102,35 @@ fn heading_side_table_live_row(obs : HeadingObservation) -> HeadingSideTableRow 
 }
 
 ///|
+fn heading_current_index(
+  rows : Array[HeadingSideTableRow],
+) -> Map[@core.NodeId, HeadingStableRowId] {
+  let index : Map[@core.NodeId, HeadingStableRowId] = Map([])
+  for row in rows {
+    match (row.status, row.current_id) {
+      (HeadingLive, Some(id)) => index[id] = row.stable_id
+      _ => ()
+    }
+  }
+  index
+}
+
+///|
 #warnings("-unused_value")
 fn HeadingSideTable::from_observations(
   observations : Array[HeadingObservation],
 ) -> HeadingSideTable {
-  { rows: observations.map(heading_side_table_live_row) }
+  let rows = observations.map(heading_side_table_live_row)
+  { rows, current_index: heading_current_index(rows) }
+}
+
+///|
+#warnings("-unused_value")
+fn HeadingSideTable::entity_for_current_node(
+  self : HeadingSideTable,
+  current_id : @core.NodeId,
+) -> HeadingStableRowId? {
+  self.current_index.get(current_id)
 }
 
 ///|
@@ -282,14 +308,19 @@ fn row_from_match(
     HeadingRetired => { ..row, current_id: None, candidates: [] }
     _ =>
       match ids {
-        [] =>
+        [] => {
+          let next_status = match row.status {
+            HeadingMissing | HeadingTombstoned => HeadingTombstoned
+            _ => HeadingMissing
+          }
           {
             ..row,
             current_id: None,
-            status: HeadingTombstoned,
+            status: next_status,
             candidates: [],
             evidence: match_result.evidence,
           }
+        }
         [id] if match_result.confidence is HeadingExact ||
           (claim_count(id) == 1 && match_result.confidence is HeadingProbable) =>
           match find_heading_by_id(current, id) {
@@ -367,5 +398,6 @@ fn HeadingSideTable::advance(
     })
     .map(heading_side_table_live_row)
     .collect()
-  { rows: next_rows + fresh_rows }
+  let rows = next_rows + fresh_rows
+  { rows, current_index: heading_current_index(rows) }
 }

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -1,98 +1,8 @@
 ///| Whitebox side-table tests for the Stable Document Entity Graph Phase 0 idea.
 
 ///|
-/// These tests keep the side-table model test-local. They reuse the heading
-/// observation helpers from `sdeg_heading_spike_wbtest.mbt` and validate the
+/// These tests exercise the package-private side-table model and validate the
 /// internal lifecycle sketch in `docs/design/sdeg-nodeid-side-table.md`.
-
-///|
-enum HeadingSideTableStatus {
-  HeadingLive
-  HeadingTombstoned
-  HeadingAmbiguous
-  HeadingRetired
-} derive(Eq, Debug)
-
-///|
-struct HeadingStableRowId {
-  seed : @core.NodeId
-} derive(Eq, Debug)
-
-///|
-fn HeadingStableRowId::from_node(id : @core.NodeId) -> HeadingStableRowId {
-  { seed: id }
-}
-
-///|
-enum HeadingSideTableConfidence {
-  HeadingExact
-  HeadingProbable
-  HeadingMatchAmbiguous
-  HeadingMissing
-} derive(Eq, Debug)
-
-///|
-enum HeadingEntityEvidence {
-  HeadingSameNodeId(@core.NodeId)
-  HeadingSameSemanticKey(String)
-  HeadingOverlappingRange(@loomcore.Range, @loomcore.Range)
-  HeadingCandidateCount(Int)
-} derive(Eq, Debug)
-
-///|
-struct HeadingMatchCandidate {
-  id : @core.NodeId
-  evidence : Array[HeadingEntityEvidence]
-} derive(Eq, Debug)
-
-///|
-struct HeadingSideTableMatch {
-  confidence : HeadingSideTableConfidence
-  candidates : Array[HeadingMatchCandidate]
-  evidence : Array[HeadingEntityEvidence]
-} derive(Eq, Debug)
-
-///|
-struct HeadingSideTableRow {
-  stable_id : HeadingStableRowId
-  current_id : @core.NodeId?
-  status : HeadingSideTableStatus
-  last_live : HeadingObservation
-  candidates : Array[@core.NodeId]
-  evidence : Array[HeadingEntityEvidence]
-} derive(Eq, Debug)
-
-///|
-struct HeadingSideTable {
-  rows : Array[HeadingSideTableRow]
-} derive(Eq, Debug)
-
-///|
-fn heading_side_table_live_row(obs : HeadingObservation) -> HeadingSideTableRow {
-  {
-    stable_id: HeadingStableRowId::from_node(obs.id),
-    current_id: Some(obs.id),
-    status: HeadingLive,
-    last_live: obs,
-    candidates: [],
-    evidence: [HeadingSameNodeId(obs.id), HeadingCandidateCount(1)],
-  }
-}
-
-///|
-fn HeadingSideTable::from_observations(
-  observations : Array[HeadingObservation],
-) -> HeadingSideTable {
-  { rows: observations.map(heading_side_table_live_row) }
-}
-
-///|
-fn find_heading_by_id(
-  observations : Array[HeadingObservation],
-  id : @core.NodeId,
-) -> HeadingObservation? {
-  observations.iter().find_first(fn(obs) { obs.id == id })
-}
 
 ///|
 fn find_side_table_row(
@@ -100,222 +10,7 @@ fn find_side_table_row(
   stable_id : @core.NodeId,
 ) -> HeadingSideTableRow? {
   let row_id = HeadingStableRowId::from_node(stable_id)
-  table.rows.iter().find_first(fn(row) { row.stable_id == row_id })
-}
-
-///|
-fn side_table_has_stable_id(
-  rows : Array[HeadingSideTableRow],
-  stable_id : HeadingStableRowId,
-) -> Bool {
-  rows.iter().any(fn(row) { row.stable_id == stable_id })
-}
-
-///|
-fn node_id_in(ids : Array[@core.NodeId], id : @core.NodeId) -> Bool {
-  ids.iter().any(fn(candidate_id) { candidate_id == id })
-}
-
-///|
-fn side_table_mentions_current_id(
-  rows : Array[HeadingSideTableRow],
-  current_id : @core.NodeId,
-) -> Bool {
-  rows
-  .iter()
-  .any(fn(row) {
-    row.current_id == Some(current_id) || node_id_in(row.candidates, current_id)
-  })
-}
-
-///|
-fn heading_evidence(
-  previous : HeadingObservation,
-  current : HeadingObservation,
-) -> Array[HeadingEntityEvidence] {
-  let evidence : Array[HeadingEntityEvidence] = []
-  if previous.id == current.id {
-    evidence.push(HeadingSameNodeId(current.id))
-  }
-  if previous.level == current.level && previous.text == current.text {
-    evidence.push(HeadingSameSemanticKey(heading_key(previous)))
-  }
-  if ranges_overlap(previous.range, current.range) {
-    evidence.push(HeadingOverlappingRange(previous.range, current.range))
-  }
-  evidence
-}
-
-///|
-fn heading_candidate(
-  previous : HeadingObservation,
-  current : HeadingObservation,
-) -> HeadingMatchCandidate {
-  { id: current.id, evidence: heading_evidence(previous, current) }
-}
-
-///|
-fn heading_side_table_match(
-  previous : HeadingObservation,
-  current : Array[HeadingObservation],
-) -> HeadingSideTableMatch {
-  let same_node = find_heading_by_id(current, previous.id)
-  let semantic_candidates : Array[HeadingMatchCandidate] = current
-    .iter()
-    .filter(fn(obs) { obs.level == previous.level && obs.text == previous.text })
-    .map(fn(obs) { heading_candidate(previous, obs) })
-    .collect()
-  let semantic_count = semantic_candidates.length()
-  match same_node {
-    Some(obs) => {
-      let candidate = heading_candidate(previous, obs)
-      let evidence = if obs.level == previous.level && obs.text == previous.text {
-        [
-          HeadingSameNodeId(obs.id),
-          HeadingSameSemanticKey(heading_key(previous)),
-          HeadingCandidateCount(1),
-        ]
-      } else {
-        [HeadingSameNodeId(obs.id), HeadingCandidateCount(1)]
-      }
-      { confidence: HeadingExact, candidates: [candidate], evidence }
-    }
-    None if semantic_count == 1 =>
-      {
-        confidence: HeadingProbable,
-        candidates: semantic_candidates,
-        evidence: [
-          HeadingSameSemanticKey(heading_key(previous)),
-          HeadingCandidateCount(1),
-        ],
-      }
-    None if semantic_count > 1 =>
-      {
-        confidence: HeadingMatchAmbiguous,
-        candidates: semantic_candidates,
-        evidence: [
-          HeadingSameSemanticKey(heading_key(previous)),
-          HeadingCandidateCount(semantic_count),
-        ],
-      }
-    None =>
-      {
-        confidence: HeadingMissing,
-        candidates: [],
-        evidence: [HeadingCandidateCount(0)],
-      }
-  }
-}
-
-///|
-fn candidate_ids(match_result : HeadingSideTableMatch) -> Array[@core.NodeId] {
-  match_result.candidates.map(fn(candidate) { candidate.id })
-}
-
-///|
-fn row_active(row : HeadingSideTableRow) -> Bool {
-  row.status != HeadingRetired
-}
-
-///|
-fn candidate_claim_count(
-  matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)],
-  id : @core.NodeId,
-) -> Int {
-  matches
-  .iter()
-  .filter(fn(pair) { node_id_in(candidate_ids(pair.1), id) })
-  .count()
-}
-
-///|
-fn row_from_match(
-  row : HeadingSideTableRow,
-  match_result : HeadingSideTableMatch,
-  current : Array[HeadingObservation],
-  claim_count : (@core.NodeId) -> Int,
-) -> HeadingSideTableRow {
-  let ids = candidate_ids(match_result)
-  if row.status == HeadingRetired {
-    { ..row, current_id: None, candidates: [] }
-  } else if ids.length() == 0 {
-    {
-      ..row,
-      current_id: None,
-      status: HeadingTombstoned,
-      candidates: [],
-      evidence: match_result.evidence,
-    }
-  } else if ids.length() == 1 &&
-    claim_count(ids[0]) == 1 &&
-    (
-      match_result.confidence == HeadingExact ||
-      match_result.confidence == HeadingProbable
-    ) {
-    match find_heading_by_id(current, ids[0]) {
-      Some(current_obs) =>
-        {
-          stable_id: row.stable_id,
-          current_id: Some(current_obs.id),
-          status: HeadingLive,
-          last_live: current_obs,
-          candidates: [],
-          evidence: match_result.evidence,
-        }
-      None =>
-        {
-          ..row,
-          current_id: None,
-          status: HeadingTombstoned,
-          candidates: [],
-          evidence: match_result.evidence,
-        }
-    }
-  } else {
-    {
-      ..row,
-      current_id: None,
-      status: HeadingAmbiguous,
-      candidates: ids,
-      evidence: match_result.evidence,
-    }
-  }
-}
-
-///|
-fn HeadingSideTable::advance(
-  self : HeadingSideTable,
-  current : Array[HeadingObservation],
-) -> HeadingSideTable {
-  let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = []
-  for row in self.rows {
-    if row_active(row) {
-      matches.push((row, heading_side_table_match(row.last_live, current)))
-    }
-  }
-  let next_rows : Array[HeadingSideTableRow] = []
-  for row in self.rows {
-    if row.status == HeadingRetired {
-      next_rows.push({ ..row, current_id: None, candidates: [] })
-    } else {
-      let match_result = heading_side_table_match(row.last_live, current)
-      next_rows.push(
-        row_from_match(row, match_result, current, fn(id) {
-          candidate_claim_count(matches, id)
-        }),
-      )
-    }
-  }
-  for obs in current {
-    if !side_table_mentions_current_id(next_rows, obs.id) &&
-      !side_table_has_stable_id(
-        next_rows,
-        HeadingStableRowId::from_node(obs.id),
-      ) {
-      next_rows.push(heading_side_table_live_row(obs))
-    }
-  }
-  { rows: next_rows }
+  table.rows.iter().find_first(row => row.stable_id == row_id)
 }
 
 ///|
@@ -323,14 +18,103 @@ fn synthetic_heading(
   id : Int,
   text : String,
   start : Int,
+  level? : Int = 1,
 ) -> HeadingObservation {
   {
     id: @core.NodeId::from_int(id),
-    level: 1,
+    level,
     text,
-    range: @loomcore.Range::new(start, start + text.length() + 2),
+    range: @loomcore.Range::new(start, start + text.length() + level + 1),
     marker: None,
     text_span: None,
+  }
+}
+
+///|
+fn evidence_has_same_node(
+  evidence : Array[HeadingEntityEvidence],
+  id : @core.NodeId,
+) -> Bool {
+  evidence
+  .iter()
+  .any(item => {
+    match item {
+      HeadingSameNodeId(candidate) => candidate == id
+      _ => false
+    }
+  })
+}
+
+///|
+fn evidence_has_semantic_key(
+  evidence : Array[HeadingEntityEvidence],
+  key : String,
+) -> Bool {
+  evidence
+  .iter()
+  .any(item => {
+    match item {
+      HeadingSameSemanticKey(candidate) => candidate == key
+      _ => false
+    }
+  })
+}
+
+///|
+fn evidence_has_candidate_count(
+  evidence : Array[HeadingEntityEvidence],
+  count : Int,
+) -> Bool {
+  evidence
+  .iter()
+  .any(item => {
+    match item {
+      HeadingCandidateCount(candidate) => candidate == count
+      _ => false
+    }
+  })
+}
+
+///|
+fn stable_row_claim_count(
+  rows : Array[HeadingSideTableRow],
+  stable_id : HeadingStableRowId,
+) -> Int {
+  rows.iter().filter(row => row.stable_id == stable_id).count()
+}
+
+///|
+fn live_current_claim_count(
+  rows : Array[HeadingSideTableRow],
+  current_id : @core.NodeId,
+) -> Int {
+  rows
+  .iter()
+  .filter(row => row.status == HeadingLive && row.current_id == Some(current_id))
+  .count()
+}
+
+///|
+fn heading_side_table_row_shape_valid(
+  row : HeadingSideTableRow,
+  rows : Array[HeadingSideTableRow],
+  current : Array[HeadingObservation],
+) -> Bool {
+  match row.status {
+    HeadingLive =>
+      match row.current_id {
+        Some(current_id) =>
+          row.candidates.length() == 0 &&
+          find_heading_by_id(current, current_id) is Some(_) &&
+          live_current_claim_count(rows, current_id) == 1
+        None => false
+      }
+    HeadingTombstoned | HeadingRetired =>
+      row.current_id is None && row.candidates.length() == 0
+    HeadingAmbiguous =>
+      row.current_id is None &&
+      row.candidates.length() != 0 &&
+      row.candidates.iter().all(id => live_current_claim_count(rows, id) == 0)
   }
 }
 
@@ -339,58 +123,12 @@ fn heading_side_table_invariants_hold(
   table : HeadingSideTable,
   current : Array[HeadingObservation],
 ) -> Bool {
-  let stable_ids : Array[HeadingStableRowId] = []
-  let live_ids : Array[@core.NodeId] = []
-  let ambiguous_ids : Array[@core.NodeId] = []
-  let mut ok = true
-  for row in table.rows {
-    if stable_ids.iter().any(fn(id) { id == row.stable_id }) {
-      ok = false
-    } else {
-      stable_ids.push(row.stable_id)
-    }
-    match row.status {
-      HeadingLive =>
-        match row.current_id {
-          Some(current_id) => {
-            if node_id_in(live_ids, current_id) {
-              ok = false
-            } else {
-              live_ids.push(current_id)
-            }
-            if find_heading_by_id(current, current_id) is None {
-              ok = false
-            }
-            if row.candidates.length() != 0 {
-              ok = false
-            }
-          }
-          None => ok = false
-        }
-      HeadingTombstoned =>
-        if row.current_id is Some(_) || row.candidates.length() != 0 {
-          ok = false
-        }
-      HeadingAmbiguous => {
-        if row.current_id is Some(_) || row.candidates.length() == 0 {
-          ok = false
-        }
-        for id in row.candidates {
-          ambiguous_ids.push(id)
-        }
-      }
-      HeadingRetired =>
-        if row.current_id is Some(_) || row.candidates.length() != 0 {
-          ok = false
-        }
-    }
-  }
-  for id in ambiguous_ids {
-    if node_id_in(live_ids, id) {
-      ok = false
-    }
-  }
-  ok
+  table.rows
+  .iter()
+  .all(row => {
+    stable_row_claim_count(table.rows, row.stable_id) == 1 &&
+    heading_side_table_row_shape_valid(row, table.rows, current)
+  })
 }
 
 ///|
@@ -423,6 +161,8 @@ test "sdeg phase0: NodeId side table preserves same-node matches before semantic
   inspect(b_row.status == HeadingLive, content="true")
   inspect(a_row.current_id == Some(c_after.id), content="true")
   inspect(b_row.current_id == Some(a_after.id), content="true")
+  inspect(evidence_has_same_node(a_row.evidence, c_after.id), content="true")
+  inspect(evidence_has_same_node(b_row.evidence, a_after.id), content="true")
   inspect(advanced.rows.length(), content="2")
   inspect(heading_side_table_invariants_hold(advanced, after), content="true")
 }
@@ -463,12 +203,24 @@ test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
 
   inspect(a_deleted_row.status == HeadingTombstoned, content="true")
   inspect(a_deleted_row.current_id is None, content="true")
+  inspect(
+    evidence_has_candidate_count(a_deleted_row.evidence, 0),
+    content="true",
+  )
   inspect(a_restored_row.status == HeadingLive, content="true")
   inspect(
     a_restored_row.stable_id == HeadingStableRowId::from_node(a_before.id),
     content="true",
   )
   inspect(a_restored_row.current_id == Some(a_restored.id), content="true")
+  inspect(
+    evidence_has_semantic_key(a_restored_row.evidence, heading_key(a_before)),
+    content="true",
+  )
+  inspect(
+    evidence_has_candidate_count(a_restored_row.evidence, 1),
+    content="true",
+  )
 }
 
 ///|
@@ -506,6 +258,14 @@ test "sdeg phase0: NodeId side table keeps duplicate restore ambiguous" {
   inspect(a_restored_row.current_id is None, content="true")
   inspect(a_restored_row.candidates.length(), content="2")
   inspect(
+    evidence_has_semantic_key(a_restored_row.evidence, heading_key(a_before)),
+    content="true",
+  )
+  inspect(
+    evidence_has_candidate_count(a_restored_row.evidence, 2),
+    content="true",
+  )
+  inspect(
     heading_side_table_invariants_hold(restored_table, restored_observations),
     content="true",
   )
@@ -524,10 +284,56 @@ test "sdeg phase0: NodeId side table conflicts do not double-claim current nodes
   inspect(advanced.rows.length(), content="2")
   inspect(row0.status == HeadingAmbiguous, content="true")
   inspect(row1.status == HeadingAmbiguous, content="true")
+  inspect(evidence_has_candidate_count(row0.evidence, 1), content="true")
+  inspect(evidence_has_candidate_count(row1.evidence, 1), content="true")
   inspect(row0.current_id is None, content="true")
   inspect(row1.current_id is None, content="true")
   inspect(node_id_in(row0.candidates, current_a.id), content="true")
   inspect(node_id_in(row1.candidates, current_a.id), content="true")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [current_a]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: same-node match wins over duplicate semantic claimant" {
+  let old_a0 = synthetic_heading(1, "A", 0)
+  let old_a1 = synthetic_heading(2, "A", 4)
+  let current_a0 = synthetic_heading(1, "A", 0)
+  let table = HeadingSideTable::from_observations([old_a0, old_a1])
+  let advanced = table.advance([current_a0])
+  let row0 = find_side_table_row(advanced, old_a0.id).unwrap()
+  let row1 = find_side_table_row(advanced, old_a1.id).unwrap()
+
+  inspect(row0.status == HeadingLive, content="true")
+  inspect(row0.current_id == Some(current_a0.id), content="true")
+  inspect(evidence_has_same_node(row0.evidence, current_a0.id), content="true")
+  inspect(row1.status == HeadingTombstoned, content="true")
+  inspect(row1.current_id is None, content="true")
+  inspect(evidence_has_candidate_count(row1.evidence, 0), content="true")
+  inspect(advanced.rows.length(), content="2")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [current_a0]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: heading level change without same-node evidence stays fresh" {
+  let old_a = synthetic_heading(1, "A", 0, level=1)
+  let current_a = synthetic_heading(100, "A", 0, level=2)
+  let table = HeadingSideTable::from_observations([old_a])
+  let advanced = table.advance([current_a])
+  let old_row = find_side_table_row(advanced, old_a.id).unwrap()
+  let fresh_row = find_side_table_row(advanced, current_a.id).unwrap()
+
+  inspect(old_row.status == HeadingTombstoned, content="true")
+  inspect(old_row.current_id is None, content="true")
+  inspect(evidence_has_candidate_count(old_row.evidence, 0), content="true")
+  inspect(fresh_row.status == HeadingLive, content="true")
+  inspect(fresh_row.current_id == Some(current_a.id), content="true")
+  inspect(advanced.rows.length(), content="2")
   inspect(
     heading_side_table_invariants_hold(advanced, [current_a]),
     content="true",

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -109,7 +109,7 @@ fn heading_side_table_row_shape_valid(
           live_current_claim_count(rows, current_id) == 1
         None => false
       }
-    HeadingTombstoned | HeadingRetired =>
+    HeadingMissing | HeadingTombstoned | HeadingRetired =>
       row.current_id is None && row.candidates.length() == 0
     HeadingAmbiguous =>
       row.current_id is None &&
@@ -119,10 +119,30 @@ fn heading_side_table_row_shape_valid(
 }
 
 ///|
+fn live_row_count(rows : Array[HeadingSideTableRow]) -> Int {
+  rows.iter().filter(row => row.status == HeadingLive).count()
+}
+
+///|
+fn heading_side_table_index_valid(table : HeadingSideTable) -> Bool {
+  table.current_index.length() == live_row_count(table.rows) &&
+  table.rows
+  .iter()
+  .all(row => {
+    match (row.status, row.current_id) {
+      (HeadingLive, Some(current_id)) =>
+        table.entity_for_current_node(current_id) == Some(row.stable_id)
+      _ => true
+    }
+  })
+}
+
+///|
 fn heading_side_table_invariants_hold(
   table : HeadingSideTable,
   current : Array[HeadingObservation],
 ) -> Bool {
+  heading_side_table_index_valid(table) &&
   table.rows
   .iter()
   .all(row => {
@@ -186,10 +206,11 @@ test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
   let (deleted, deleted_map) = project_after_reconcile(
     initial, deleted_source, counter,
   )
-  let deleted_table = table.advance(
-    collect_heading_observations(deleted, deleted_map),
-  )
-  let a_deleted_row = find_side_table_row(deleted_table, a_before.id).unwrap()
+  let deleted_observations = collect_heading_observations(deleted, deleted_map)
+  let missing_table = table.advance(deleted_observations)
+  let a_missing_row = find_side_table_row(missing_table, a_before.id).unwrap()
+  let tombstoned_table = missing_table.advance(deleted_observations)
+  let a_tombstoned_row = find_side_table_row(tombstoned_table, a_before.id).unwrap()
 
   let (restored, restored_map) = project_after_reconcile(
     deleted, restored_source, counter,
@@ -198,15 +219,17 @@ test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
     restored, restored_map,
   )
   let a_restored = find_heading(restored_observations, "A").unwrap()
-  let restored_table = deleted_table.advance(restored_observations)
+  let restored_table = tombstoned_table.advance(restored_observations)
   let a_restored_row = find_side_table_row(restored_table, a_before.id).unwrap()
 
-  inspect(a_deleted_row.status == HeadingTombstoned, content="true")
-  inspect(a_deleted_row.current_id is None, content="true")
+  inspect(a_missing_row.status == HeadingMissing, content="true")
+  inspect(a_missing_row.current_id is None, content="true")
   inspect(
-    evidence_has_candidate_count(a_deleted_row.evidence, 0),
+    evidence_has_candidate_count(a_missing_row.evidence, 0),
     content="true",
   )
+  inspect(a_tombstoned_row.status == HeadingTombstoned, content="true")
+  inspect(a_tombstoned_row.current_id is None, content="true")
   inspect(a_restored_row.status == HeadingLive, content="true")
   inspect(
     a_restored_row.stable_id == HeadingStableRowId::from_node(a_before.id),
@@ -309,7 +332,7 @@ test "sdeg phase1: same-node match wins over duplicate semantic claimant" {
   inspect(row0.status == HeadingLive, content="true")
   inspect(row0.current_id == Some(current_a0.id), content="true")
   inspect(evidence_has_same_node(row0.evidence, current_a0.id), content="true")
-  inspect(row1.status == HeadingTombstoned, content="true")
+  inspect(row1.status == HeadingMissing, content="true")
   inspect(row1.current_id is None, content="true")
   inspect(evidence_has_candidate_count(row1.evidence, 0), content="true")
   inspect(advanced.rows.length(), content="2")
@@ -328,7 +351,7 @@ test "sdeg phase1: heading level change without same-node evidence stays fresh" 
   let old_row = find_side_table_row(advanced, old_a.id).unwrap()
   let fresh_row = find_side_table_row(advanced, current_a.id).unwrap()
 
-  inspect(old_row.status == HeadingTombstoned, content="true")
+  inspect(old_row.status == HeadingMissing, content="true")
   inspect(old_row.current_id is None, content="true")
   inspect(evidence_has_candidate_count(old_row.evidence, 0), content="true")
   inspect(fresh_row.status == HeadingLive, content="true")
@@ -393,7 +416,8 @@ test "sdeg phase0: NodeId side table retired rows do not revive" {
     status: HeadingRetired,
     candidates: [],
   }
-  let table = { rows: [retired_row] }
+  let rows = [retired_row]
+  let table = { rows, current_index: heading_current_index(rows) }
   let advanced = table.advance([current_a])
   let old_row = find_side_table_row(advanced, old_a.id).unwrap()
   let fresh_row = find_side_table_row(advanced, current_a.id).unwrap()

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -359,12 +359,24 @@ test "sdeg phase0: heading reorder is currently position-stable, not semantic-st
   let after = collect_heading_observations(reordered, reordered_map)
   let b_after = find_heading(after, "B").unwrap()
   let a_after = find_heading(after, "A").unwrap()
+  let after_at_a_previous_id = after
+    .iter()
+    .find_first(fn(obs) { obs.id == a_before.id })
+    .unwrap()
+  let after_at_b_previous_id = after
+    .iter()
+    .find_first(fn(obs) { obs.id == b_before.id })
+    .unwrap()
 
   // Current generic reconcile matches same-kind siblings by position/LCS. That
   // preserves UI positions, but it does not preserve the semantic identity of a
-  // moved heading. This is a Phase 0 finding, not the desired final behavior.
+  // moved heading. Both previous heading NodeIds remain present after the swap:
+  // previous A's NodeId now names B, and previous B's NodeId now names A. This
+  // is a Phase 0 finding, not the desired final behavior.
   inspect(b_after.id == a_before.id, content="true")
   inspect(a_after.id == b_before.id, content="true")
+  inspect(after_at_a_previous_id.text, content="B")
+  inspect(after_at_b_previous_id.text, content="A")
 }
 
 ///|

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -7,16 +7,6 @@
 /// already preserves and where it is still only position-stable.
 
 ///|
-struct HeadingObservation {
-  id : @core.NodeId
-  level : Int
-  text : String
-  range : @loomcore.Range
-  marker : @loomcore.Range?
-  text_span : @loomcore.Range?
-} derive(Eq, Debug)
-
-///|
 enum HeadingIdentityOutcome {
   Preserved
   SemanticMatchWithDifferentNodeId
@@ -166,16 +156,6 @@ fn find_heading(
 ///|
 fn range_contains(outer : @loomcore.Range, inner : @loomcore.Range) -> Bool {
   outer.start <= inner.start && inner.end <= outer.end
-}
-
-///|
-fn ranges_overlap(a : @loomcore.Range, b : @loomcore.Range) -> Bool {
-  a.start < b.end && b.start < a.end
-}
-
-///|
-fn heading_key(obs : HeadingObservation) -> String {
-  "h\{obs.level}:\{obs.text}"
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Extract Markdown heading SDEG side-table core into package-private production code.
- Preserve same-node priority while retaining evidence for semantic recovery, ambiguity, and missing/tombstoned rows.
- Document Phase 1 completion state and strengthen MoonBit reuse-check guidance.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `NodeId`, `ProjNode`, `SourceMap::get_range`, `SourceMap::get_token_span` | `dowdiness/canopy/core`, `lang/markdown/proj` helpers | Yes | Used as the existing projection handle and heading observation source; no new public entity ID introduced. |
| `@loomcore.Range` | `dowdiness/loom/core` | Yes | Used for source/token range evidence; no new range type added. |
| `Array` / `Iter` (`map`, `filter`, `collect`, `any`, `all`, `count`) | MoonBit core | Yes | Used for side-table matching, evidence assertions, and invariant checks. |
| `Option` pattern matching | MoonBit core/prelude | Yes | Used for current-node lookup and row classification. |
| `Map` / `Set` | MoonBit core | Yes (`Map`) | `HeadingSideTable` now carries a rebuilt `Map[NodeId, HeadingStableRowId]` current-node index for live rows. `Set` was not needed because row order and evidence candidates remain row-local. |
| `String` / `StringView` | MoonBit core | Partially | Existing heading text extraction remains string-based from Markdown inline text; no extra slicing/copying helper added in this change. |

New helpers added:

- `HeadingSideTable` and related private row/evidence types: package-private session-local lifecycle table for Markdown headings.
- Matching helpers (`heading_side_table_match`, `row_from_match`, same-node reservation helpers): bounded to classifying one successful projection snapshot; they do not mutate document/editor state.
- `heading_current_index` / `entity_for_current_node`: package-private current-node index rebuild and lookup for live rows.
- White-box evidence assertion helpers: test-only helpers to verify evidence content.

## Notes

- Pure source reorder remains a documented same-node-priority limitation until Markdown/block edit lowering can provide explicit move provenance.
- Absence now follows the planned lifecycle: first absence is `HeadingMissing`; repeated absence becomes `HeadingTombstoned`; retained observations can still recover when a unique semantic match returns.
- `HeadingSideTable` now stores a rebuilt current-node index for live rows while keeping row order/evidence package-private and test-local.
- The table remains Markdown-owned for Phase 1; a generic SDEG abstraction should wait until another language needs the pattern and Markdown/block move provenance exists.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check`
- [x] `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj`
- [x] `NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info`
- [x] `git diff -- '*.mbti'` reviewed; no public API diff
- [x] `NEW_MOON_MOD=0 moon test`

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
NEW_MOON_MOD=0 moon test
```

Full `moon test` result:

- wasm-gc: 266 passed
- js: 1567 passed
- native: 70 passed

