### PR TITLE
Add Markdown block move provenance

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -260,10 +260,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Plan: `docs/plans/2026-03-30-editor-drag-drop-foundation.md` (steps 2-3)
   Exit: `block-editor` exposes positioned block moves plus structural render metadata.
 
-- [ ] Spike Markdown block move provenance for future block UI.
+- [x] Spike Markdown block move provenance for future block UI.
   Why: SDEG Phase 1 documents pure source reorder as position-stable; future block moves need explicit provenance so identity follows the moved block.
   Plan: `docs/plans/2026-06-20-markdown-block-move-provenance-spike.md`
-  Exit: accepted or rejected move-provenance contract, with tests or blocker proof showing only explicit provenance can override positional same-node evidence.
+  Exit: accepted `MarkdownEditOp::MoveBlock(source, target, position)` contract with tests showing only explicit provenance moves heading identity.
 
 - [ ] Convergence tests for concurrent drag-drop.
   Why: concurrent relocations across CRDT peers need convergence guarantees.

--- a/docs/plans/2026-03-30-editor-drag-drop-foundation.md
+++ b/docs/plans/2026-03-30-editor-drag-drop-foundation.md
@@ -79,7 +79,11 @@ Out:
 1. Define the canonical move contract shared by both editors.
    Record the payload shape and the supported drop positions for each editor.
    Keep `Before`/`After` as the minimum common contract and treat `Inside` as
-   opt-in where the backend can prove it is valid.
+   opt-in where the backend can prove it is valid. For Markdown/block identity
+   provenance, use the accepted contract from
+   [Markdown Block Move Provenance Spike](2026-06-20-markdown-block-move-provenance-spike.md):
+   `MarkdownEditOp::MoveBlock(source, target, position)` with `Before`/`After`
+   only, lowered to source-text splices plus `IdentityTransform::Move`.
 2. Add positioned move primitives to the movable-tree path used by
    `examples/block-editor`.
    Prefer `move_before` / `move_after` or a single `move_between` primitive

--- a/docs/plans/2026-06-20-markdown-block-move-provenance-spike.md
+++ b/docs/plans/2026-06-20-markdown-block-move-provenance-spike.md
@@ -1,6 +1,6 @@
 # Markdown Block Move Provenance Spike
 
-**Status:** backlog
+**Status:** implemented spike (2026-06-20)
 
 ## Why
 
@@ -62,6 +62,45 @@ The spike answers, with code/tests or a written rejection:
 - Do ordinary replacement edits and pure source reorder keep same-node priority
   / documented limitation behavior?
 
+## Chosen Contract
+
+The spike accepts a minimal Markdown structural operation:
+
+```moonbit
+MarkdownEditOp::MoveBlock(
+  source~ : NodeId,
+  target~ : NodeId,
+  position~ : DropPosition,
+)
+```
+
+Only `DropPosition::Before` and `DropPosition::After` are legal for now;
+`Inside` is rejected until Markdown has a nested-block contract. `source == target`
+and already-adjacent no-op moves return `Ok(None)`. The accepted spike surface
+is root-level block moves only: nested/list-item moves, list-container sources,
+and duplicate exact source payloads are rejected until Markdown list orderedness,
+ancestor reconciliation, and ambiguity handling are represented in the block
+payload. The source-text splice remains the source of truth:
+the operation lowers by re-rendering the affected root-block sequence from the
+same block source slices with separators chosen for each new neighbor pair, so
+paragraph moves preserve required blank-line separation instead of merging
+blocks.
+
+Provenance uses the existing `IdentityTransform::Move(subtree=source)` channel:
+`apply_markdown_edit` passes the hint to `SyncEditor::apply_span_edits`, and the
+Markdown editor now wires a shared pending-hint `Ref` into
+`build_markdown_projection_memos`, matching the Lambda editor pattern. Markdown
+consumes the move with a language-specific reconciler because generic
+`reconcile_hinted` intentionally freshens `Move` at the old position. The
+Markdown reconciler only lets explicit move provenance override positional
+same-node evidence for a unique exact block-kind match among LCS-unmatched
+siblings; ambiguous duplicate moved content degrades to fresh identity rather
+than guessing.
+
+No public SDEG/entity-id API is introduced. The public API changes are limited to
+Markdown's structural edit surface and an optional Markdown projection hint
+parameter required to wire the existing editor hint channel.
+
 ## Steps
 
 1. Define candidate move operations, e.g. `MoveBlockBefore(source~, target~)` /
@@ -89,19 +128,19 @@ The spike answers, with code/tests or a written rejection:
 
 ## Acceptance Criteria
 
-- [ ] A concrete Markdown/block move operation shape is accepted or rejected with
+- [x] A concrete Markdown/block move operation shape is accepted or rejected with
       reasons.
-- [ ] The provenance delivery path is named: existing `IdentityTransform::Move`,
+- [x] The provenance delivery path is named: existing `IdentityTransform::Move`,
       an extended hint channel, a Markdown-specific bridge, or a documented
       blocker.
-- [ ] Tests or a written proof-of-blocker show that explicit provenance is the
+- [x] Tests or a written proof-of-blocker show that explicit provenance is the
       only case where reorder identity can override positional same-node
       evidence.
-- [ ] Pure source reorder remains documented and tested as a limitation when no
+- [x] Pure source reorder remains documented and tested as a limitation when no
       explicit provenance is present.
-- [ ] The future block-editor drag/drop plan links to the accepted provenance
+- [x] The future block-editor drag/drop plan links to the accepted provenance
       contract.
-- [ ] No public SDEG/entity ID API is introduced.
+- [x] No public SDEG/entity ID API is introduced.
 
 ## Validation
 

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -3,39 +3,30 @@
 ///   - structural-edit bridge (`apply_markdown_edit`)
 
 ///|
-/// Capability record for the Markdown language family (S3 lang/runtime SPI).
-/// A no-edit op is a silent no-op (e.g. merge on first block), unlike JSON.
-let markdown_spec : @lang_runtime.LanguageSpec[
-  @markdown.Block,
-  @md_edits.MarkdownEditOp,
-] = @lang_runtime.LanguageSpec::LanguageSpec(
-  make_parser=fn(s, rt) {
-    @loom.new_parser(s, @markdown.markdown_grammar, runtime?=rt)
-  },
-  build_memos=@md_proj.build_markdown_projection_memos,
-  compute_edit=@md_edits.compute_markdown_edit,
-  on_no_edit=fn(_op) { Ok(()) },
-)
-
-///|
 /// Construct a SyncEditor[@markdown.Block] using the standard 3-memo pipeline.
 pub fn new_markdown_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> @editor.SyncEditor[@markdown.Block] {
-  markdown_spec.new_editor(
+  let hints_ref : Ref[Array[@core.IdentityTransform]] = Ref([])
+  @editor.SyncEditor::new_generic(
     agent_id,
+    (s, rt) => @loom.new_parser(s, @markdown.markdown_grammar, runtime?=rt),
+    parser => {
+      @md_proj.build_markdown_projection_memos(parser, identity_hints=hints_ref)
+    },
     capture_timeout_ms~,
     parent_runtime?,
-    capabilities=@editor.LanguageCapabilities::default().with_to_view_node(fn(
+    capabilities=@editor.LanguageCapabilities::default().with_to_view_node((
       proj,
       source_map,
       annotations,
       source_text,
-    ) {
+    ) => {
       @md_proj.proj_to_view_node(proj, source_map, annotations~, source_text~)
     }),
+    identity_hints=hints_ref,
   )
 }
 
@@ -116,5 +107,32 @@ pub fn apply_markdown_edit(
   op : @md_edits.MarkdownEditOp,
   timestamp_ms : Int,
 ) -> Result[Unit, String] {
-  markdown_spec.apply_edit(editor, op, timestamp_ms)
+  let source = editor.get_text()
+  guard editor.get_proj_node() is Some(proj) else {
+    return Err("no projection available")
+  }
+  let source_map = editor.get_source_map()
+  match @md_edits.compute_markdown_edit(op, source, proj, source_map) {
+    Ok(Some((edits, focus_hint))) => {
+      match markdown_identity_hint(op) {
+        Some(hint) =>
+          editor.apply_span_edits(edits, focus_hint, timestamp_ms, hint~)
+        None => editor.apply_span_edits(edits, focus_hint, timestamp_ms)
+      }
+      Ok(())
+    }
+    Ok(None) => Ok(())
+    Err(msg) => Err(msg)
+  }
+}
+
+///|
+fn markdown_identity_hint(
+  op : @md_edits.MarkdownEditOp,
+) -> @core.IdentityTransform? {
+  match op {
+    MoveBlock(source~, ..) =>
+      Some(@core.IdentityTransform::Move(subtree=source))
+    _ => None
+  }
 }

--- a/lang/markdown/companion/moon.pkg
+++ b/lang/markdown/companion/moon.pkg
@@ -3,7 +3,6 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/proj" @md_proj,
-  "dowdiness/canopy/lang/runtime" @lang_runtime,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/incr",
   "dowdiness/markdown",

--- a/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
+++ b/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
@@ -87,9 +87,9 @@ test "sdeg phase0: markdown edit path swap is replacement, not reorder provenanc
   let a_before = before[0]
   let b_before = before[1]
 
-  // MarkdownEditOp currently has no move/reorder operation. The smallest
-  // existing edit-path way to reach the swapped source is two text commits,
-  // which records replacement-by-position rather than move provenance.
+  // Without using the explicit MoveBlock operation, the smallest existing
+  // edit-path way to reach the swapped source is two text commits, which
+  // records replacement-by-position rather than move provenance.
   let first_result = apply_markdown_edit(
     editor,
     @md_edits.MarkdownEditOp::CommitEdit(node_id=a_before.id, new_text="B"),
@@ -116,6 +116,35 @@ test "sdeg phase0: markdown edit path swap is replacement, not reorder provenanc
   inspect(after[1].id == b_before.id, content="true")
   inspect(after[0].id == b_before.id, content="false")
   inspect(after[1].id == a_before.id, content="false")
+}
+
+///|
+test "sdeg spike: explicit markdown block move preserves moved heading identity" {
+  let editor = new_markdown_editor("sdeg-edit-path-explicit-move")
+  editor.set_text("# A\n# B\n")
+  editor.refresh()
+  let before = heading_edit_path_observations(editor)
+  let a_before = before[0]
+  let b_before = before[1]
+
+  let result = apply_markdown_edit(
+    editor,
+    @md_edits.MarkdownEditOp::MoveBlock(
+      source=b_before.id,
+      target=a_before.id,
+      position=@core.DropPosition::Before,
+    ),
+    0,
+  )
+  editor.refresh()
+  let after = heading_edit_path_observations(editor)
+
+  inspect(result is Ok(_), content="true")
+  inspect(editor.get_text(), content="# B\n# A\n")
+  inspect(after[0].text, content="B")
+  inspect(after[1].text, content="A")
+  inspect(after[0].id == b_before.id, content="true")
+  inspect(after[1].id == a_before.id, content="true")
 }
 
 ///|

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -21,6 +21,10 @@ pub fn compute_markdown_edit(
       compute_split_block(source, proj, source_map, node_id, offset)
     MergeWithPrevious(node_id~) =>
       compute_merge_with_previous(source, proj, source_map, node_id)
+    MoveBlock(source=source_id, target=target_id, position~) =>
+      compute_move_block(
+        source, proj, source_map, source_id, target_id, position,
+      )
   }
 }
 

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -1,18 +1,26 @@
 ///| Whitebox tests for Markdown edit ops (pure compute, no SyncEditor).
 
 ///|
-/// Helper: parse, project, populate token spans, compute edit, return new source text.
-fn apply_edit(
+fn compute_edit_result(
   source : String,
   op : MarkdownEditOp,
-) -> String raise @loomcore.LexError {
+) -> Result[(Array[SpanEdit], FocusHint)?, String] raise @loomcore.LexError {
   let (proj, _) = @md_proj.parse_to_proj_node(source)
   let source_map = @core.SourceMap::from_ast(proj)
   // Re-parse to get the SyntaxNode for populate_token_spans
   let (cst, _) = @markdown.parse_cst(source)
   let syntax_root = @seam.SyntaxNode::from_cst(cst)
   @md_proj.populate_token_spans(source_map, syntax_root, proj)
-  match compute_markdown_edit(op, source, proj, source_map) {
+  compute_markdown_edit(op, source, proj, source_map)
+}
+
+///|
+/// Helper: parse, project, populate token spans, compute edit, return new source text.
+fn apply_edit(
+  source : String,
+  op : MarkdownEditOp,
+) -> String raise @loomcore.LexError {
+  match compute_edit_result(source, op) {
     Ok(Some((edits, _))) => {
       let sorted = edits.copy()
       sorted.sort_by(fn(a, b) { b.start.compare(a.start) })
@@ -115,4 +123,236 @@ test "merge_with_previous: first block is no-op" {
   let para_id = proj.children[0].id()
   let result = apply_edit(source, MergeWithPrevious(node_id=para_id))
   inspect(result, content="Hello\n")
+}
+
+///|
+test "move_block: moves sibling before target" {
+  let source = "# A\n# B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
+  )
+  inspect(result, content="# B\n# A\n")
+}
+
+///|
+test "move_block: adjacent after move is no-op" {
+  let source = "# A\n# B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=a_id, target=b_id, position=@core.DropPosition::Before),
+  )
+  inspect(result, content="# A\n# B\n")
+}
+
+///|
+test "move_block: adjacent duplicate before move is no-op" {
+  let source = "# X\n# X\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let first_id = proj.children[0].id()
+  let second_id = proj.children[1].id()
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=first_id,
+      target=second_id,
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result is Ok(None), content="true")
+}
+
+///|
+test "move_block: preserves paragraph blank-line separator before target" {
+  let source = "A\n\nB\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
+  )
+  inspect(result, content="B\n\nA\n")
+}
+
+///|
+test "move_block: preserves paragraph blank-line separator after target" {
+  let source = "A\n\nB\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=a_id, target=b_id, position=@core.DropPosition::After),
+  )
+  inspect(result, content="B\n\nA\n")
+}
+
+///|
+test "move_block: preserves separator when moving final block without trailing newline" {
+  let source = "# A\n# B"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
+  )
+  inspect(result, content="# B\n# A\n")
+}
+
+///|
+test "move_block: preserves separator when moving first block after EOF block" {
+  let source = "# A\n# B"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=a_id, target=b_id, position=@core.DropPosition::After),
+  )
+  inspect(result, content="# B\n# A\n")
+}
+
+///|
+test "move_block: preserves paragraph break left behind by moved heading" {
+  let source = "A\n\n# B\nC\n\nD\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let heading_id = proj.children[1].id()
+  let d_id = proj.children[3].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=heading_id,
+      target=d_id,
+      position=@core.DropPosition::After,
+    ),
+  )
+  inspect(result, content="A\n\nC\n\nD\n# B\n")
+}
+
+///|
+test "move_block: preserves paragraph break at target insertion" {
+  let source = "# H\nP\n\nQ\n\nR\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let p_id = proj.children[1].id()
+  let r_id = proj.children[3].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=p_id, target=r_id, position=@core.DropPosition::Before),
+  )
+  inspect(result, content="# H\nQ\n\nP\n\nR\n")
+}
+
+///|
+test "move_block: preserves root paragraph after list target" {
+  let source = "A\n\n- B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let paragraph_id = proj.children[0].id()
+  let list_id = proj.children[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=paragraph_id,
+      target=list_id,
+      position=@core.DropPosition::After,
+    ),
+  )
+  inspect(result, content="- B\n\nA\n")
+}
+
+///|
+test "move_block: rejects unclosed fenced code before following sibling" {
+  let source = "# A\n```\ncode\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let heading_id = proj.children[0].id()
+  let code_id = proj.children[1].id()
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=heading_id,
+      target=code_id,
+      position=@core.DropPosition::After,
+    ),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: preserves unrelated adjacent sibling separator" {
+  let source = "# A\n\n\n# B\n# C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let c_id = proj.children[2].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(source=c_id, target=a_id, position=@core.DropPosition::Before),
+  )
+  inspect(result, content="# C\n# A\n\n\n# B\n")
+}
+
+///|
+test "move_block: rejects inside position" {
+  let source = "# A\n# B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].id()
+  let b_id = proj.children[1].id()
+  let result = compute_edit_result(
+    source,
+    MoveBlock(source=a_id, target=b_id, position=@core.DropPosition::Inside),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: rejects nested list item moves" {
+  let source = "- A\n- B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let a_id = proj.children[0].children[0].id()
+  let b_id = proj.children[0].children[1].id()
+  let result = compute_edit_result(
+    source,
+    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: rejects list container sources" {
+  let source = "# A\n- B\n- C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let heading_id = proj.children[0].id()
+  let list_id = proj.children[1].id()
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=list_id,
+      target=heading_id,
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: rejects duplicate source payloads" {
+  let source = "# X\n# X\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let first_id = proj.children[0].id()
+  let second_id = proj.children[1].id()
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=second_id,
+      target=first_id,
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result is Err(_), content="true")
 }

--- a/lang/markdown/edits/compute_move_block.mbt
+++ b/lang/markdown/edits/compute_move_block.mbt
@@ -1,0 +1,267 @@
+///| Source-text lowering for explicit Markdown block moves.
+
+///|
+/// Move a sibling block before or after another block.
+fn compute_move_block(
+  source : String,
+  proj : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+  source_id : NodeId,
+  target_id : NodeId,
+  position : DropPosition,
+) -> Result[(Array[SpanEdit], FocusHint)?, String] {
+  if source_id == target_id {
+    return Ok(None)
+  }
+  guard position is Before || position is After else {
+    return Err("markdown block move supports only before/after positions")
+  }
+  let source_siblings = proj.children
+  let source_idx = match
+    source_siblings.search_by(sibling => sibling.id() == source_id) {
+    Some(idx) => idx
+    None => {
+      if find_sibling_context(proj, source_id).1 >= 0 {
+        return Err(
+          "markdown block move currently supports root-level blocks only",
+        )
+      }
+      return Err(
+        "source node not found in projection tree: " + source_id.to_string(),
+      )
+    }
+  }
+  let target_idx = match
+    source_siblings.search_by(sibling => sibling.id() == target_id) {
+    Some(idx) => idx
+    None => {
+      if find_sibling_context(proj, target_id).1 >= 0 {
+        return Err(
+          "markdown block move currently supports root-level blocks only",
+        )
+      }
+      return Err(
+        "target node not found in projection tree: " + target_id.to_string(),
+      )
+    }
+  }
+  match position {
+    Before if source_idx + 1 == target_idx => return Ok(None)
+    After if target_idx + 1 == source_idx => return Ok(None)
+    _ => ()
+  }
+  let source_kind = source_siblings[source_idx].kind
+  if source_kind is @markdown.Block::UnorderedList(_) {
+    return Err(
+      "markdown block move does not yet support list container sources",
+    )
+  }
+  if source_siblings.any(sibling => {
+      sibling.id() != source_id && sibling.kind == source_kind
+    }) {
+    return Err("markdown block move requires a unique source block payload")
+  }
+  let (replace_start, replace_end, inserted) = match
+    compute_root_move_source(
+      source, source_siblings, source_idx, target_idx, position, source_map,
+    ) {
+    Ok(patch) => patch
+    Err(msg) => return Err(msg)
+  }
+  Ok(
+    Some(
+      (
+        [
+          SpanEdit::{
+            start: replace_start,
+            delete_len: replace_end - replace_start,
+            inserted,
+          },
+        ],
+        FocusHint::RestoreCursor,
+      ),
+    ),
+  )
+}
+
+///|
+fn compute_root_move_source(
+  source : String,
+  siblings : Array[ProjNode[@markdown.Block]],
+  source_idx : Int,
+  target_idx : Int,
+  position : DropPosition,
+  source_map : SourceMap,
+) -> Result[(Int, Int, String), String] {
+  let without_source = [
+    for idx, sibling in siblings if idx != source_idx => sibling
+  ]
+  let adjusted_target_idx = if source_idx < target_idx {
+    target_idx - 1
+  } else {
+    target_idx
+  }
+  let insert_idx = match position {
+    Before => adjusted_target_idx
+    After => adjusted_target_idx + 1
+    Inside => abort("unreachable: inside rejected above")
+  }
+  // Builder: construct the reordered root-block list once for rendering the
+  // replacement span.
+  let reordered : Array[ProjNode[@markdown.Block]] = []
+  for idx in 0..<=without_source.length() {
+    if idx == insert_idx {
+      reordered.push(siblings[source_idx])
+    } else {
+      let source_offset = if idx < insert_idx { idx } else { idx - 1 }
+      match without_source.get(source_offset) {
+        Some(node) => reordered.push(node)
+        None => ()
+      }
+    }
+  }
+  match validate_no_unclosed_code_before_sibling(reordered, source_map) {
+    Ok(_) => ()
+    Err(msg) => return Err(msg)
+  }
+  let first_range = match source_map.get_range(siblings[0].id()) {
+    Some(r) => r
+    None => return Err("first sibling not in source map")
+  }
+  let last_range = match
+    source_map.get_range(siblings[siblings.length() - 1].id()) {
+    Some(r) => r
+    None => return Err("last sibling not in source map")
+  }
+  let buffer = StringBuilder::new()
+  for idx, node in reordered {
+    if idx > 0 {
+      match
+        separator_between_nodes(
+          source,
+          siblings,
+          reordered[idx - 1],
+          node,
+          source_map,
+        ) {
+        Ok(separator) => buffer.write_string(separator)
+        Err(msg) => return Err(msg)
+      }
+    }
+    match block_text_without_trailing_newlines(source, node, source_map) {
+      Ok(text) => buffer.write_string(text)
+      Err(msg) => return Err(msg)
+    }
+  }
+  buffer.write_string("\n")
+  Ok((first_range.start, last_range.end, buffer.to_string()))
+}
+
+///|
+fn block_text_without_trailing_newlines(
+  source : String,
+  node : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+) -> Result[String, String] {
+  let range = match source_map.get_range(node.id()) {
+    Some(r) => r
+    None => return Err("node not in source map")
+  }
+  let end = block_text_end_without_trailing_newlines(
+    source,
+    range.start,
+    range.end,
+  )
+  Ok(source[range.start:end].to_owned())
+}
+
+///|
+fn block_text_end_without_trailing_newlines(
+  source : String,
+  start : Int,
+  end : Int,
+) -> Int {
+  for current_end = end {
+    if current_end > start && source[current_end - 1] == '\n' {
+      continue current_end - 1
+    }
+    break current_end
+  }
+}
+
+///|
+fn validate_no_unclosed_code_before_sibling(
+  nodes : Array[ProjNode[@markdown.Block]],
+  source_map : SourceMap,
+) -> Result[Unit, String] {
+  for idx in 0..<(nodes.length() - 1) {
+    if is_unclosed_fenced_code(nodes[idx], source_map) {
+      return Err(
+        "markdown block move does not support unclosed fenced code before another block",
+      )
+    }
+  }
+  Ok(())
+}
+
+///|
+fn is_unclosed_fenced_code(
+  node : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+) -> Bool {
+  node.kind is CodeBlock(_, _) &&
+  source_map.get_token_span(node.id(), "fence_open") is Some(_) &&
+  source_map.get_token_span(node.id(), "fence_close") is None
+}
+
+///|
+fn separator_between_nodes(
+  source : String,
+  siblings : Array[ProjNode[@markdown.Block]],
+  left : ProjNode[@markdown.Block],
+  right : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+) -> Result[String, String] {
+  match original_adjacent_separator(source, siblings, left, right, source_map) {
+    Some(Ok(separator)) => Ok(separator)
+    Some(Err(msg)) => Err(msg)
+    None => Ok(separator_between(left.kind, right.kind))
+  }
+}
+
+///|
+fn original_adjacent_separator(
+  source : String,
+  siblings : Array[ProjNode[@markdown.Block]],
+  left : ProjNode[@markdown.Block],
+  right : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+) -> Result[String, String]? {
+  for idx in 0..<(siblings.length() - 1) {
+    if siblings[idx].id() == left.id() && siblings[idx + 1].id() == right.id() {
+      let left_range = match source_map.get_range(left.id()) {
+        Some(r) => r
+        None => return Some(Err("left sibling not in source map"))
+      }
+      let right_range = match source_map.get_range(right.id()) {
+        Some(r) => r
+        None => return Some(Err("right sibling not in source map"))
+      }
+      let left_end = block_text_end_without_trailing_newlines(
+        source,
+        left_range.start,
+        left_range.end,
+      )
+      return Some(Ok(source[left_end:right_range.start].to_owned()))
+    }
+  }
+  None
+}
+
+///|
+fn separator_between(left : @markdown.Block, right : @markdown.Block) -> String {
+  match (left, right) {
+    (Paragraph(_), Paragraph(_)) | (UnorderedList(_), _) => "\n\n"
+    _ => "\n"
+  }
+}

--- a/lang/markdown/edits/markdown_edit_op.mbt
+++ b/lang/markdown/edits/markdown_edit_op.mbt
@@ -7,6 +7,7 @@ using @core {
   type SourceMap,
   type SpanEdit,
   type FocusHint,
+  type DropPosition,
 }
 
 ///|
@@ -18,4 +19,5 @@ pub(all) enum MarkdownEditOp {
   InsertBlockAfter(node_id~ : NodeId)
   SplitBlock(node_id~ : NodeId, offset~ : Int)
   MergeWithPrevious(node_id~ : NodeId)
+  MoveBlock(source~ : NodeId, target~ : NodeId, position~ : DropPosition)
 } derive(Debug, Eq)

--- a/lang/markdown/edits/pkg.generated.mbti
+++ b/lang/markdown/edits/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub(all) enum MarkdownEditOp {
   InsertBlockAfter(node_id~ : @core.NodeId)
   SplitBlock(node_id~ : @core.NodeId, offset~ : Int)
   MergeWithPrevious(node_id~ : @core.NodeId)
+  MoveBlock(source~ : @core.NodeId, target~ : @core.NodeId, position~ : @core.DropPosition)
 } derive(Eq, @debug.Debug)
 
 // Type aliases

--- a/lang/markdown/proj/moon.pkg
+++ b/lang/markdown/proj/moon.pkg
@@ -6,4 +6,5 @@ import {
   "dowdiness/loom",
   "dowdiness/loom/core" @loomcore,
   "dowdiness/seam",
+  "moonbitlang/core/cmp",
 }

--- a/lang/markdown/proj/move_reconcile.mbt
+++ b/lang/markdown/proj/move_reconcile.mbt
@@ -1,0 +1,218 @@
+///| Markdown-specific reconciliation for explicit block-move provenance.
+
+///|
+/// Generic `@core.reconcile_hinted` intentionally treats `Move` as
+/// editor-owned and freshens the node at the old position. Markdown block moves
+/// are source-text edits, so this package consumes `IdentityTransform::Move`
+/// only when an explicit structural edit supplied it and the moved block has a
+/// unique exact sibling match after reparsing.
+
+///|
+fn build_markdown_hints_map(
+  hints : Array[@core.IdentityTransform],
+) -> Map[@core.NodeId, @core.IdentityTransform] {
+  let result : Map[@core.NodeId, @core.IdentityTransform] = {}
+  for hint in hints {
+    match hint {
+      @core.IdentityTransform::Opaque => return {}
+      @core.IdentityTransform::Wrap(inner=id) => result[id] = hint
+      @core.IdentityTransform::Unwrap(wrapper=id, ..) => result[id] = hint
+      @core.IdentityTransform::Move(subtree=id) => result[id] = hint
+      @core.IdentityTransform::Replace(old=id) => result[id] = hint
+      @core.IdentityTransform::RenameLeaf(node=id) => result[id] = hint
+      @core.IdentityTransform::InsertSubtree(parent=id, ..) => result[id] = hint
+      @core.IdentityTransform::DeleteSubtree(node=id) => result[id] = hint
+    }
+  }
+  result
+}
+
+///|
+fn reconcile_markdown_projection_hinted(
+  old : @core.ProjNode[@markdown.Block],
+  new_ : @core.ProjNode[@markdown.Block],
+  counter : Ref[Int],
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+) -> @core.ProjNode[@markdown.Block] {
+  if hints.is_empty() || !has_move_hint(hints) {
+    return @core.reconcile_hinted(old, new_, counter, hints)
+  }
+  if @loomcore.TreeNode::same_kind(old.kind, new_.kind) &&
+    is_block_container(new_.kind) {
+    return @core.ProjNode::new(
+      new_.kind,
+      new_.start,
+      new_.end,
+      old.node_id,
+      reconcile_markdown_children_hinted(
+        old.children,
+        new_.children,
+        counter,
+        hints,
+      ),
+    )
+  }
+  @core.reconcile_hinted(old, new_, counter, hints)
+}
+
+///|
+fn has_move_hint(hints : Map[@core.NodeId, @core.IdentityTransform]) -> Bool {
+  for _, hint in hints {
+    if hint is @core.IdentityTransform::Move(_) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn is_block_container(block : @markdown.Block) -> Bool {
+  block is Document(_) || block is UnorderedList(_)
+}
+
+///|
+fn reconcile_markdown_children_hinted(
+  old_children : Array[@core.ProjNode[@markdown.Block]],
+  new_children : Array[@core.ProjNode[@markdown.Block]],
+  counter : Ref[Int],
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+) -> Array[@core.ProjNode[@markdown.Block]] {
+  let old_len = old_children.length()
+  let new_len = new_children.length()
+  let excluded_old = Array::makei(old_len, i => {
+    is_move_source(hints, old_children[i].id())
+  })
+  let exact_match = (oi, nj) => {
+    old_children[oi].kind == new_children[nj].kind && !excluded_old[oi]
+  }
+  // Dynamic-programming table and backtracking arrays are algorithm state for
+  // occurrence-stable LCS. Mutation is local to the matcher and mirrors
+  // `@core.reconcile_children`.
+  let dp = Array::makei(old_len + 1, _ => Array::make(new_len + 1, 0))
+  for i = 1; i <= old_len; i = i + 1 {
+    for j = 1; j <= new_len; j = j + 1 {
+      if exact_match(i - 1, j - 1) {
+        dp[i][j] = dp[i - 1][j - 1] + 1
+      } else {
+        dp[i][j] = @cmp.maximum(dp[i - 1][j], dp[i][j - 1])
+      }
+    }
+  }
+  let old_matched = Array::make(old_len, -1)
+  let new_matched = Array::make(new_len, -1)
+  let mut i = old_len
+  let mut j = new_len
+  while i > 0 && j > 0 {
+    if exact_match(i - 1, j - 1) {
+      old_matched[i - 1] = j - 1
+      new_matched[j - 1] = i - 1
+      i = i - 1
+      j = j - 1
+    } else if dp[i - 1][j] >= dp[i][j - 1] {
+      i = i - 1
+    } else {
+      j = j - 1
+    }
+  }
+  // Consumption marker: a previous moved node may be paired at most once.
+  let consumed : Map[@core.NodeId, Bool] = {}
+  let old_pair_counts = markdown_move_pair_counts(
+    old_children, new_children, old_matched, new_matched, hints,
+  )
+  [
+    for k in 0..<new_len => {
+      if new_matched[k] >= 0 {
+        reconcile_markdown_projection_hinted(
+          old_children[new_matched[k]],
+          new_children[k],
+          counter,
+          hints,
+        )
+      } else {
+        match
+          markdown_move_pair(
+            new_children[k],
+            old_children,
+            old_matched,
+            old_pair_counts,
+            consumed,
+            counter,
+            hints,
+          ) {
+          Some(node) => node
+          None => @core.assign_fresh_ids(new_children[k], counter)
+        }
+      }
+    }
+  ]
+}
+
+///|
+fn is_move_source(
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+  id : @core.NodeId,
+) -> Bool {
+  hints.get(id) is Some(@core.IdentityTransform::Move(_))
+}
+
+///|
+fn markdown_move_pair_counts(
+  old_children : Array[@core.ProjNode[@markdown.Block]],
+  new_children : Array[@core.ProjNode[@markdown.Block]],
+  old_matched : Array[Int],
+  new_matched : Array[Int],
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+) -> Map[@core.NodeId, Int] {
+  let counts : Map[@core.NodeId, Int] = {}
+  for oi, old_child in old_children {
+    if old_matched[oi] < 0 && is_move_source(hints, old_child.id()) {
+      let count = [
+        for ni, new_child in new_children if new_matched[ni] < 0 &&
+        old_child.kind == new_child.kind => new_child
+      ].length()
+      if count > 0 {
+        counts[old_child.id()] = count
+      }
+    }
+  }
+  counts
+}
+
+///|
+fn markdown_move_pair(
+  new_child : @core.ProjNode[@markdown.Block],
+  old_children : Array[@core.ProjNode[@markdown.Block]],
+  old_matched : Array[Int],
+  old_pair_counts : Map[@core.NodeId, Int],
+  consumed : Map[@core.NodeId, Bool],
+  counter : Ref[Int],
+  hints : Map[@core.NodeId, @core.IdentityTransform],
+) -> @core.ProjNode[@markdown.Block]? {
+  let candidates = [
+    for idx, old_child in old_children if old_matched[idx] < 0 &&
+    consumed.get(old_child.id()) is None &&
+    old_pair_counts.get(old_child.id()) is Some(1) &&
+    is_move_source(hints, old_child.id()) &&
+    old_child.kind == new_child.kind => old_child
+  ]
+  match candidates {
+    [old_child] => {
+      consumed[old_child.id()] = true
+      Some(
+        @core.ProjNode::new(
+          new_child.kind,
+          new_child.start,
+          new_child.end,
+          old_child.node_id,
+          reconcile_markdown_children_hinted(
+            old_child.children,
+            new_child.children,
+            counter,
+            hints,
+          ),
+        ),
+      )
+    }
+    _ => None
+  }
+}

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 }
 
 // Values
-pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
 
 pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
 

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -184,6 +184,7 @@ fn markdown_view_kind_tag(
 /// projection.
 pub fn build_markdown_projection_memos(
   parser : @loom.Parser[@markdown.Block],
+  identity_hints? : Ref[Array[@core.IdentityTransform]],
 ) -> (
   @incr.Derived[@core.ProjNode[@markdown.Block]?],
   @incr.Derived[Map[@core.NodeId, @core.ProjNode[@markdown.Block]]],
@@ -194,6 +195,16 @@ pub fn build_markdown_projection_memos(
     parser.syntax_tree(),
     syntax_to_proj_node,
     populate_token_spans,
+    reconcile_node=(old, new_, counter) => {
+      match identity_hints {
+        None => @core.reconcile(old, new_, counter)
+        Some(hints_ref) => {
+          let hints = build_markdown_hints_map(hints_ref.val)
+          hints_ref.val = []
+          reconcile_markdown_projection_hinted(old, new_, counter, hints)
+        }
+      }
+    },
     label="markdown",
   )
 }


### PR DESCRIPTION
## Summary

- Add explicit Markdown `MoveBlock(source, target, position)` provenance for future block UI moves.
- Wire Markdown through the existing `IdentityTransform::Move` hint channel with package-private move reconciliation.
- Keep the spike contract narrow and safe: root-level, non-list-container source blocks with unique source payloads; reject `Inside`, nested/list-item moves, list container sources, and duplicate exact source payloads.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `IdentityTransform::Move` | `core/identity_transform.mbt` | Yes | Existing provenance vocabulary for relocated subtrees. |
| `SyncEditor::apply_span_edits(..., hint=...)` | `editor/sync_editor.mbt` | Yes | Existing structural hint delivery channel. |
| `@core.reconcile_hinted` / `@core.reconcile` / `@core.assign_fresh_ids` | `core/reconcile.mbt` | Yes | Reused for normal reconciliation and fallback freshening; generic `Move` handling intentionally freshens, so Markdown owns the move-specific layer. |
| `@core.build_projection_memos` | `core/projection_memo.mbt` | Yes | Existing projection memo wiring with a language-specific reconcile hook. |
| `SourceMap::get_range` | `core/source_map.mbt` | Yes | Existing UTF-16 source range lookup for block text splices. |
| `DropPosition` / `SpanEdit` / `FocusHint` | `core/types.mbt` | Yes | Existing edit position and span-edit shapes. |
| `Array::search_by`, `Array::any`, `Array::makei` | `moonbitlang/core/array` | Yes | Used for sibling lookup, duplicate-payload guard, and LCS arrays. |
| `Map::get` | `moonbitlang/core/builtin` | Yes | Used for hint lookup and consumption bookkeeping. |
| `Option` / `Result` pattern matching | `moonbitlang/core/option`, `moonbitlang/core/result` | Yes | Used for explicit missing-node and edit-result handling. |
| `String` slicing / `String::to_owned` | `moonbitlang/core/string` | Yes | Used to move source text plus separator trivia. |
| `@cmp.maximum` | `moonbitlang/core/cmp` | Yes | Used in the local LCS DP recurrence. |
| `StringBuilder` / `Buffer` | MoonBit core | No | Not needed; edits are small string slices composed into `SpanEdit`s. |
| `Set` / sorted maps | MoonBit core | No | Simple `Map[NodeId, Bool]` is sufficient as a local consumption marker. |

New helpers added:

- `compute_move_block`: Markdown-specific source-text lowering for the narrowed block move contract.
- `build_markdown_hints_map`: converts the editor's pending hint array to the `NodeId`-keyed map used by reconciliation.
- `reconcile_markdown_projection_hinted` and private helpers in `move_reconcile.mbt`: Markdown-specific owner for explicit move provenance, because generic `reconcile_hinted` intentionally does not preserve `Move` identity.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon check --deny-warn` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [ ] JS rebuild run if web is affected (`cd examples/web && npm run build`) — not run; no web/FFI wiring changed.

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon check --deny-warn
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/edits
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/companion
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
NEW_MOON_MOD=0 moon test
```

Full `moon test` results after the final fixes:

- wasm-gc: 266 passed
- js: 1584 passed
- native: 70 passed

Intentional `.mbti` changes:

- `lang/markdown/edits/pkg.generated.mbti`: adds `MarkdownEditOp::MoveBlock`.
- `lang/markdown/proj/pkg.generated.mbti`: adds optional `identity_hints?` to `build_markdown_projection_memos`.

No public SDEG/entity-id API is introduced.





