### PR TITLE
Harden Markdown list move blockers

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -78,7 +78,7 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Exit: markdown Token is payload-free where possible, semantic info extracted at point-of-use.
 
 - [ ] Replace Markdown ordered-list `SourceMap` side channel with explicit list payloads.
-  Why: PR #720 temporarily records ordered-list kind in `SourceMap` metadata because Loom's Markdown `Block` API currently folds ordered and unordered list containers into one payload. Orderedness is semantic AST data and should come from Loom's Markdown payload once exposed there.
+  Why: PR #720 temporarily records ordered-list kind in `SourceMap` metadata because Loom's Markdown `Block` API currently folds ordered and unordered list containers into one payload. Orderedness is semantic AST data and should come from Loom's Markdown payload once exposed there. Issue #724 list/list-item move provenance is blocked on this migration.
   Plan: `docs/plans/2026-06-20-markdown-list-payloads.md`
   Exit: `ORDERED_LIST_KIND_ROLE` is removed, ordered-list projection/view/FFI/block-mode regressions still pass, and Canopy reads list kind from explicit Loom Markdown list payloads.
 
@@ -256,7 +256,7 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   fallbacks; action-context plumbing now uses real LetDef ids instead of init ids.
 
 - [ ] Prepare drag-and-drop foundations for `examples/block-editor`.
-  Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder.
+  Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder. Markdown list/list-item moves for issue #724 remain blocked on explicit ordered/unordered list payloads before legality can widen safely. Before broader Markdown list/root moves, add separator regressions for synthesized paragraph-to-list neighbors rather than relying only on fallback separators.
   Plan: `docs/plans/2026-03-30-editor-drag-drop-foundation.md` (steps 2-3)
   Exit: `block-editor` exposes positioned block moves plus structural render metadata.
 

--- a/docs/archive/2026-06-20-markdown-block-move-provenance-spike.md
+++ b/docs/archive/2026-06-20-markdown-block-move-provenance-spike.md
@@ -76,15 +76,17 @@ MarkdownEditOp::MoveBlock(
 
 Only `DropPosition::Before` and `DropPosition::After` are legal for now;
 `Inside` is rejected until Markdown has a nested-block contract. `source == target`
-and already-adjacent no-op moves return `Ok(None)`. The accepted spike surface
-is root-level block moves only: nested/list-item moves, list-container sources,
-and duplicate exact source payloads are rejected until Markdown list orderedness,
-ancestor reconciliation, and ambiguity handling are represented in the block
-payload. The source-text splice remains the source of truth:
-the operation lowers by re-rendering the affected root-block sequence from the
-same block source slices with separators chosen for each new neighbor pair, so
-paragraph moves preserve required blank-line separation instead of merging
-blocks.
+and already-adjacent no-op moves return `Ok(None)`. PR #723 shipped the accepted
+root-level block move surface only: nested/list-item moves, list-container
+sources, and duplicate exact source payloads remain rejected. The list/list-item
+work is now tracked as issue #724 and is blocked first on the Loom Markdown list
+payload migration in `docs/plans/2026-06-20-markdown-list-payloads.md`; after
+that, Canopy still needs list-item scope lowering/reconciliation and ordered
+marker renumbering before widening the gates. The source-text splice remains the
+source of truth: the operation lowers by re-rendering the affected root-block
+sequence from the same block source slices with separators chosen for each new
+neighbor pair, so paragraph moves preserve required blank-line separation instead
+of merging blocks.
 
 Provenance uses the existing `IdentityTransform::Move(subtree=source)` channel:
 `apply_markdown_edit` passes the hint to `SyncEditor::apply_span_edits`, and the

--- a/docs/plans/2026-06-20-markdown-list-payloads.md
+++ b/docs/plans/2026-06-20-markdown-list-payloads.md
@@ -6,6 +6,8 @@ PR #720 updated Loom and restored ordered-list behavior in Canopy's Markdown edi
 
 That bridge is intentionally temporary. `SourceMap` token spans are good for source ranges and token locations, but ordered-vs-unordered list kind is semantic AST data. Once Loom's Markdown AST exposes list kind directly, Canopy should stop using a SourceMap side channel for this fact.
 
+Issue #724 (Markdown list/list-item move provenance) is a downstream consumer of this migration: list-container and list-item `MoveBlock` support remains rejected until orderedness is represented in the Markdown block payload rather than the temporary SourceMap side channel. The #724 starter patch hardened those rejection messages and negative tests only; it did not widen `MoveBlock` legality.
+
 ## Goal
 
 Represent Markdown list kind explicitly in the Loom Markdown AST/projection payload, then migrate Canopy to read orderedness from the projected node kind/payload rather than from `SourceMap` token metadata.
@@ -34,6 +36,14 @@ Represent Markdown list kind explicitly in the Loom Markdown AST/projection payl
 4. **Tests**
    - Keep PR #720 regressions for projection, FFI, generic editor view patches, preview rendering, block-mode display, and split behavior.
    - Add/adjust a regression proving orderedness comes from the explicit payload, not a `SourceMap` role.
+
+## Package boundary and validation
+
+- The Loom Markdown API change lives in the `loom` submodule. Follow the submodule workflow: test the submodule in place, commit and push the Loom change to its own remote before staging the parent pointer.
+- Canopy must be able to read the list kind across the package boundary. If Loom uses a struct payload, expose the data through `pub(all)` fields or public constructors/accessors rather than assuming Canopy can construct or read package-private fields.
+- Updating the payload shape must also update generated interfaces and any `@markdown.Block` pattern matches in Canopy. In particular, `lang/markdown/edits/compute_move_block.mbt` currently rejects list container sources by matching the folded `UnorderedList(_)` payload; keep ordered and unordered list containers rejected after the payload split until #724 adds list-item scope, identity-preservation, and marker-renumbering tests.
+- Validate with Loom's Markdown tests plus Canopy Markdown projection/edit/companion tests, then run `moon fmt && moon info` and check generated `.mbti` drift in both the submodule and parent checkout.
+- Before widening Markdown block moves near lists, add a regression for synthesized paragraph-to-list separators; the current root move renderer only preserves original adjacent separators and otherwise uses its fallback separator rules.
 
 ## Exit condition
 

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -38,6 +38,23 @@ fn apply_edit(
 }
 
 ///|
+fn inspect_edit_error(source : String, op : MarkdownEditOp) -> Unit raise {
+  inspect(compute_edit_result(source, op) is Err(_), content="true")
+}
+
+///|
+fn inspect_edit_error_contains(
+  source : String,
+  op : MarkdownEditOp,
+  fragment : String,
+) -> Unit raise {
+  match compute_edit_result(source, op) {
+    Err(msg) => inspect(msg.contains(fragment.view()), content="true")
+    Ok(_) => inspect(false, content="true")
+  }
+}
+
+///|
 test "commit_edit: change paragraph text" {
   let source = "Hello world\n"
   let (proj, _) = @md_proj.parse_to_proj_node("Hello world\n")
@@ -303,24 +320,69 @@ test "move_block: rejects inside position" {
   let (proj, _) = @md_proj.parse_to_proj_node(source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
-  let result = compute_edit_result(
+  inspect_edit_error(
     source,
     MoveBlock(source=a_id, target=b_id, position=@core.DropPosition::Inside),
   )
-  inspect(result is Err(_), content="true")
 }
 
 ///|
-test "move_block: rejects nested list item moves" {
+test "move_block: rejects unordered list item within same list" {
   let source = "- A\n- B\n"
   let (proj, _) = @md_proj.parse_to_proj_node(source)
-  let a_id = proj.children[0].children[0].id()
-  let b_id = proj.children[0].children[1].id()
-  let result = compute_edit_result(
+  let items = proj.children[0].children
+  let a_id = items[0].id()
+  let b_id = items[1].id()
+  inspect_edit_error_contains(
+    source,
+    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
+    "issue #724",
+  )
+}
+
+///|
+test "move_block: rejects ordered list item within same list" {
+  let source = "1. A\n2. B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let a_id = items[0].id()
+  let b_id = items[1].id()
+  inspect_edit_error(
     source,
     MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
   )
-  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: rejects cross-list item move" {
+  let source = "- A\n- B\n\nbetween\n\n- C\n- D\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let list1_items = proj.children[0].children
+  let list2_items = proj.children[2].children
+  inspect_edit_error(
+    source,
+    MoveBlock(
+      source=list1_items[0].id(),
+      target=list2_items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+}
+
+///|
+test "move_block: rejects ordered-to-unordered list item move" {
+  let source = "1. A\n2. B\n\n- C\n- D\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let ordered_items = proj.children[0].children
+  let unordered_items = proj.children[1].children
+  inspect_edit_error(
+    source,
+    MoveBlock(
+      source=ordered_items[0].id(),
+      target=unordered_items[0].id(),
+      position=@core.DropPosition::After,
+    ),
+  )
 }
 
 ///|
@@ -329,15 +391,63 @@ test "move_block: rejects list container sources" {
   let (proj, _) = @md_proj.parse_to_proj_node(source)
   let heading_id = proj.children[0].id()
   let list_id = proj.children[1].id()
-  let result = compute_edit_result(
+  inspect_edit_error_contains(
     source,
     MoveBlock(
       source=list_id,
       target=heading_id,
       position=@core.DropPosition::Before,
     ),
+    "list container sources",
   )
-  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: rejects ordered list container source" {
+  let source = "# H\n1. A\n2. B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let heading_id = proj.children[0].id()
+  let ordered_list_id = proj.children[1].id()
+  inspect_edit_error(
+    source,
+    MoveBlock(
+      source=ordered_list_id,
+      target=heading_id,
+      position=@core.DropPosition::Before,
+    ),
+  )
+}
+
+///|
+test "move_block: rejects root target for list item source" {
+  let source = "- A\n# B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let item_id = proj.children[0].children[0].id()
+  let heading_id = proj.children[1].id()
+  inspect_edit_error_contains(
+    source,
+    MoveBlock(
+      source=item_id,
+      target=heading_id,
+      position=@core.DropPosition::Before,
+    ),
+    "list-item sources",
+  )
+}
+
+///|
+test "move_block: inside position rejected before list-item checks" {
+  let source = "- A\n- B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  inspect_edit_error(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Inside,
+    ),
+  )
 }
 
 ///|

--- a/lang/markdown/edits/compute_move_block.mbt
+++ b/lang/markdown/edits/compute_move_block.mbt
@@ -18,32 +18,14 @@ fn compute_move_block(
   }
   let source_siblings = proj.children
   let source_idx = match
-    source_siblings.search_by(sibling => sibling.id() == source_id) {
-    Some(idx) => idx
-    None => {
-      if find_sibling_context(proj, source_id).1 >= 0 {
-        return Err(
-          "markdown block move currently supports root-level blocks only",
-        )
-      }
-      return Err(
-        "source node not found in projection tree: " + source_id.to_string(),
-      )
-    }
+    root_sibling_index_or_error(proj, source_siblings, source_id, "source") {
+    Ok(idx) => idx
+    Err(msg) => return Err(msg)
   }
   let target_idx = match
-    source_siblings.search_by(sibling => sibling.id() == target_id) {
-    Some(idx) => idx
-    None => {
-      if find_sibling_context(proj, target_id).1 >= 0 {
-        return Err(
-          "markdown block move currently supports root-level blocks only",
-        )
-      }
-      return Err(
-        "target node not found in projection tree: " + target_id.to_string(),
-      )
-    }
+    root_sibling_index_or_error(proj, source_siblings, target_id, "target") {
+    Ok(idx) => idx
+    Err(msg) => return Err(msg)
   }
   match position {
     Before if source_idx + 1 == target_idx => return Ok(None)
@@ -51,10 +33,12 @@ fn compute_move_block(
     _ => ()
   }
   let source_kind = source_siblings[source_idx].kind
+  // Current Loom Markdown folds ordered and unordered list containers into
+  // UnorderedList. When explicit ordered-list payloads land, keep every list
+  // container source rejected here until #724 widens MoveBlock legality with
+  // list-item scope, identity, and marker-renumbering tests.
   if source_kind is @markdown.Block::UnorderedList(_) {
-    return Err(
-      "markdown block move does not yet support list container sources",
-    )
+    return Err(list_payload_blocker("list container sources"))
   }
   if source_siblings.any(sibling => {
       sibling.id() != source_id && sibling.kind == source_kind
@@ -82,6 +66,37 @@ fn compute_move_block(
       ),
     ),
   )
+}
+
+///|
+fn root_sibling_index_or_error(
+  proj : ProjNode[@markdown.Block],
+  root_siblings : Array[ProjNode[@markdown.Block]],
+  node_id : NodeId,
+  role : String,
+) -> Result[Int, String] {
+  match root_siblings.search_by(sibling => sibling.id() == node_id) {
+    Some(idx) => Ok(idx)
+    None => {
+      let (nested_siblings, nested_idx) = find_sibling_context(proj, node_id)
+      if nested_idx >= 0 {
+        if nested_siblings[nested_idx].kind is @markdown.Block::ListItem(_) {
+          return Err(list_payload_blocker("list-item " + role + "s"))
+        }
+        return Err(
+          "markdown block move currently supports root-level blocks only",
+        )
+      }
+      Err(role + " node not found in projection tree: " + node_id.to_string())
+    }
+  }
+}
+
+///|
+fn list_payload_blocker(blocked : String) -> String {
+  "markdown block move currently rejects " +
+  blocked +
+  " until issue #724 is unblocked by explicit ordered/unordered list payloads; see docs/plans/2026-06-20-markdown-list-payloads.md"
 }
 
 ///|
@@ -113,8 +128,8 @@ fn compute_root_move_source(
     if idx == insert_idx {
       reordered.push(siblings[source_idx])
     } else {
-      let source_offset = if idx < insert_idx { idx } else { idx - 1 }
-      match without_source.get(source_offset) {
+      let without_source_idx = if idx < insert_idx { idx } else { idx - 1 }
+      match without_source.get(without_source_idx) {
         Some(node) => reordered.push(node)
         None => ()
       }
@@ -262,6 +277,9 @@ fn original_adjacent_separator(
 fn separator_between(left : @markdown.Block, right : @markdown.Block) -> String {
   match (left, right) {
     (Paragraph(_), Paragraph(_)) | (UnorderedList(_), _) => "\n\n"
-    _ => "\n"
+    _ =>
+      // Default root siblings (heading/code/paragraph before non-paragraph)
+      // use a single newline unless an original adjacent separator is reused.
+      "\n"
   }
 }


### PR DESCRIPTION
## Summary

- Keep Markdown list/list-item `MoveBlock` cases conservatively rejected for #724, with clearer blocker messages pointing at the explicit list-payload migration.
- Add negative regression coverage for unordered/ordered list item moves, cross-list moves, list-container sources, root/list-item targets, and `Inside` ordering.
- Update TODO/plan/archive docs to record that list/list-item move provenance is blocked on explicit ordered/unordered list payloads plus later scope/identity/marker-renumbering tests.

Refs #724.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `find_sibling_context` | `lang/markdown/edits` | Yes | Used to distinguish nested/list-item ids from missing ids before returning blocker errors. |
| `compute_edit_result` | `lang/markdown/edits/compute_markdown_edit_wbtest.mbt` | Yes | Test helper continues to exercise the pure edit lowering path. |
| `@md_proj.parse_to_proj_node` | Markdown projection package | Yes | Tests use projected Markdown shape for ids. |
| `Array::search_by` | `moonbitlang/core/array` | Yes | Reused for root sibling lookup. |
| `Option` pattern matching | `moonbitlang/core/option` | Yes | Reused for lookup results. |
| `Result` pattern matching | `moonbitlang/core/result` | Yes | Reused in error-message assertions. |
| `String::contains` / `String::view` | `moonbitlang/core/string` | Yes | Reused to assert blocker message fragments. |
| `StringBuilder` | `moonbitlang/core/builtin` | Existing use | Existing root renderer builder remains unchanged. |
| `Map`, `Set`, `Bytes`/`BytesView`, `Buffer`, `cmp`, `math` | MoonBit core | No | Checked; not needed for small lookup/message/test assertions. |

New helpers added:

- `root_sibling_index_or_error`: private helper to deduplicate source/target root-sibling lookup and nested/list-item blocker handling.
- `list_payload_blocker`: private helper to keep the long #724/list-payload blocker message consistent.
- `inspect_edit_error` / `inspect_edit_error_contains`: private test helpers for negative edit assertions and blocker-message checks.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [ ] JS rebuild run if web is affected (`cd examples/web && npm run build`) — not applicable; no web artifacts changed
- [x] `bash ./scripts/check-agent-doc-links.sh` passes

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test lang/markdown/edits
bash ./scripts/check-agent-doc-links.sh
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
NEW_MOON_MOD=0 moon test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog entries with refined rationale for block-movement features and dependencies.
  * Clarified accepted surface specifications for block-move operations and documented follow-up tracking.
  * Added guidance for ordered-list migration planning and package boundary validation.

* **Tests**
  * Extended test coverage for block-movement validation with new error-assertion helpers and additional negative test cases.

* **Refactor**
  * Improved internal code organization for block-movement computation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->