### PR TITLE
Consume Markdown list payloads

### DIFF
--- a/adapters/editor-adapter/block-input.css
+++ b/adapters/editor-adapter/block-input.css
@@ -48,22 +48,28 @@
 .block[data-kind="H5"],
 .block[data-kind="H6"] { font-size: 1em; font-weight: 600; }
 
-.block[data-kind="ListItem"] {
+.block[data-kind="ListItem"],
+.block[data-kind="UnorderedListItem"],
+.block[data-kind="OrderedListItem"] {
   padding-left: 24px;
 }
 
-.block[data-kind="ListItem"]::before {
+.block[data-kind="ListItem"]::before,
+.block[data-kind="UnorderedListItem"]::before,
+.block[data-kind="OrderedListItem"]::before {
   content: "\2022 ";
   position: absolute;
   left: 8px;
   color: #666;
 }
 
-.block[data-kind="ListItem"][data-list-kind="ordered"] {
+.block[data-kind="ListItem"][data-list-kind="ordered"],
+.block[data-kind="OrderedListItem"] {
   padding-left: 32px;
 }
 
-.block[data-kind="ListItem"][data-list-kind="ordered"]::before {
+.block[data-kind="ListItem"][data-list-kind="ordered"]::before,
+.block[data-kind="OrderedListItem"]::before {
   content: attr(data-list-marker) " ";
 }
 

--- a/adapters/editor-adapter/block-input.ts
+++ b/adapters/editor-adapter/block-input.ts
@@ -130,7 +130,7 @@ export class BlockInput implements EditorAdapter {
     let listIndex = 1;
 
     for (const child of node.children) {
-      const childListContext = listKind && child.kind_tag === 'ListItem'
+      const childListContext = listKind && this.isListItemKind(child.kind_tag)
         ? {
           kind: listKind,
           index: listIndex++,
@@ -155,6 +155,12 @@ export class BlockInput implements EditorAdapter {
       case 'UnorderedList': return 'unordered';
       default: return null;
     }
+  }
+
+  private isListItemKind(kindTag: string): boolean {
+    return kindTag === 'ListItem' ||
+      kindTag === 'UnorderedListItem' ||
+      kindTag === 'OrderedListItem';
   }
 
   private sourceListMarker(node: ViewNode): string | undefined {
@@ -202,7 +208,9 @@ export class BlockInput implements EditorAdapter {
     if (hLevel > 0) return document.createElement(`h${hLevel}`);
     switch (kindTag) {
       case 'Paragraph': return document.createElement('p');
-      case 'ListItem': return document.createElement('p');
+      case 'ListItem':
+      case 'UnorderedListItem':
+      case 'OrderedListItem': return document.createElement('p');
       default:
         if (kindTag.startsWith('Code'))
           return document.createElement('pre');

--- a/adapters/editor-adapter/markdown-preview.ts
+++ b/adapters/editor-adapter/markdown-preview.ts
@@ -25,6 +25,8 @@ function semanticTag(node: ViewNode): HTMLElement {
     case 'OrderedList':
       return document.createElement('ol');
     case 'ListItem':
+    case 'UnorderedListItem':
+    case 'OrderedListItem':
       return document.createElement('li');
     default:
       // Code blocks: kind_tag is "Code" or "Code(lang)"

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,6 +157,7 @@ behavior** — check the code before relying on any specific detail.
 
 Recently completed (for quick reference):
 
+- [Markdown List Payloads](archive/completed-phases/2026-06-20-markdown-list-payloads.md)
 - [Canvas Handles And Edges](archive/completed-phases/2026-05-14-canvas-handles-edges.md)
 - [Lambda Annotation Plumbing — Design](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-design.md)
 - [Lambda Annotation Plumbing — Impl](archive/completed-phases/2026-04-18-lambda-annotation-plumbing-impl.md)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -77,10 +77,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Why: `HeadingMarker(Int)`, `CodeFenceOpen(Int, String)`, `Text(String)`, `CodeText(String)` still carry payloads. Some are semantic (heading level, info string), not just raw text — needs design thought on how to derive from source.
   Exit: markdown Token is payload-free where possible, semantic info extracted at point-of-use.
 
-- [ ] Replace Markdown ordered-list `SourceMap` side channel with explicit list payloads.
-  Why: PR #720 temporarily records ordered-list kind in `SourceMap` metadata because Loom's Markdown `Block` API currently folds ordered and unordered list containers into one payload. Orderedness is semantic AST data and should come from Loom's Markdown payload once exposed there. Issue #724 list/list-item move provenance is blocked on this migration.
-  Plan: `docs/plans/2026-06-20-markdown-list-payloads.md`
-  Exit: `ORDERED_LIST_KIND_ROLE` is removed, ordered-list projection/view/FFI/block-mode regressions still pass, and Canopy reads list kind from explicit Loom Markdown list payloads.
+- [x] Replace Markdown ordered-list `SourceMap` side channel with explicit list payloads.
+  Done: Loom PR #429 exposed `OrderedList` / `UnorderedListItem` / `OrderedListItem` payloads with ordered marker metadata; Canopy PR #730 removed `ORDERED_LIST_KIND_ROLE` and reads list kind from Loom payloads.
+  Plan: `docs/archive/completed-phases/2026-06-20-markdown-list-payloads.md`
+  Exit: `ORDERED_LIST_KIND_ROLE` is removed, ordered-list projection/view/FFI/block-mode regressions pass, and Canopy reads list kind from explicit Loom Markdown list payloads.
 
 - [ ] `SyntaxNode::find[K : ToRawKind]` generic method (low priority).
   Why: 16 `find_token(...to_raw())` callsites remain, but views pattern + `token_text()` already reduce the ergonomic pain. Nice-to-have polish.
@@ -256,8 +256,8 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   fallbacks; action-context plumbing now uses real LetDef ids instead of init ids.
 
 - [ ] Prepare drag-and-drop foundations for `examples/block-editor`.
-  Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder. Markdown list/list-item moves for issue #724 remain blocked on explicit ordered/unordered list payloads before legality can widen safely. Before broader Markdown list/root moves, add separator regressions for synthesized paragraph-to-list neighbors rather than relying only on fallback separators.
-  Plan: `docs/plans/2026-03-30-editor-drag-drop-foundation.md` (steps 2-3)
+  Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder. Markdown list/list-item moves for issue #724 are no longer blocked on list payloads, but still need parse-shape, identity, ambiguity, marker-renumbering, and separator regressions before legality can widen safely.
+  Plan: `docs/plans/2026-03-30-editor-drag-drop-foundation.md` (steps 2-3); issue #724 tracks Markdown list/list-item move provenance.
   Exit: `block-editor` exposes positioned block moves plus structural render metadata.
 
 - [x] Spike Markdown block move provenance for future block UI.

--- a/docs/archive/completed-phases/2026-06-20-markdown-list-payloads.md
+++ b/docs/archive/completed-phases/2026-06-20-markdown-list-payloads.md
@@ -1,5 +1,7 @@
 # Replace Markdown ordered-list SourceMap side channel with explicit list payloads
 
+**Status:** Complete — Loom PR #429 added explicit Markdown list payloads; Canopy PR #730 consumes them and removes `ORDERED_LIST_KIND_ROLE` while keeping list/list-item `MoveBlock` legality rejected for #724.
+
 ## Context
 
 PR #720 updated Loom and restored ordered-list behavior in Canopy's Markdown editor. The current Loom Markdown `Block` API still folds ordered and unordered list containers into the same list payload, so Canopy temporarily preserves orderedness by recording `ORDERED_LIST_KIND_ROLE` in the Markdown projection `SourceMap` and refining `ViewNode.kind_tag` during Markdown-specific view conversion.

--- a/docs/development/ADDING_A_LANGUAGE.md
+++ b/docs/development/ADDING_A_LANGUAGE.md
@@ -75,7 +75,9 @@ pub(all) enum Block {
   Heading(Int, Array[Inline])
   Paragraph(Array[Inline])
   UnorderedList(Array[Block])
-  ListItem(Array[Inline])
+  OrderedList(Array[Block], OrderedListMarker?)
+  UnorderedListItem(Array[Inline])
+  OrderedListItem(Array[Inline], OrderedListMarker?)
   CodeBlock(String, String)     // language, content
   Error(String)
 } derive(Eq, Debug)

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -96,7 +96,9 @@ test.describe('Markdown Block Editor', () => {
     await page.locator('#raw-editor').fill('3. three\n4. four\n');
     await switchMode(page, 'Block');
 
-    const listItems = page.locator('#block-container .block[data-kind="ListItem"]');
+    const listItems = page.locator(
+      '#block-container .block[data-kind="ListItem"], #block-container .block[data-kind="OrderedListItem"]',
+    );
     await expect(listItems).toHaveCount(2);
     await expect(listItems.nth(0)).toHaveAttribute('data-list-kind', 'ordered');
     await expect(listItems.nth(0)).toHaveAttribute('data-list-marker', '3.');

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -126,7 +126,7 @@ fn compute_toggle_list_item(
     None => source[range.start:range.end].to_owned()
   }
   let is_list_item = match @core.get_node_in_tree(proj, node_id) {
-    Some(node) => node.kind is @markdown.ListItem(_)
+    Some(node) => is_markdown_list_item(node.kind)
     None => false
   }
   let (new_text, prefix_len) = if is_list_item {
@@ -261,7 +261,7 @@ fn compute_split_block(
   // Split point in source coordinates
   let split_pos = text_range.start + split_offset
   let is_list_item = match @core.get_node_in_tree(proj, node_id) {
-    Some(node) => node.kind is @markdown.ListItem(_)
+    Some(node) => is_markdown_list_item(node.kind)
     None => false
   }
   let separator = if is_list_item {
@@ -305,11 +305,16 @@ fn compute_split_block(
 }
 
 ///|
+fn is_markdown_list_item(block : @markdown.Block) -> Bool {
+  block is @markdown.Block::UnorderedListItem(_) ||
+  block is @markdown.Block::OrderedListItem(_, _)
+}
+
+///|
 /// Return the marker prefix to use when splitting a Markdown list item.
 ///
-/// The current Markdown Block API folds ordered and unordered CST list items
-/// into the same `ListItem` payload, so preserve the concrete source marker
-/// instead of synthesizing an unordered `- ` bullet for every split.
+/// Preserve the concrete source marker instead of synthesizing an unordered
+/// `- ` bullet for every split.
 fn split_list_item_separator(marker : String) -> String {
   match next_ordered_marker(marker) {
     Some(next) => "\n" + next

--- a/lang/markdown/edits/compute_move_block.mbt
+++ b/lang/markdown/edits/compute_move_block.mbt
@@ -33,11 +33,11 @@ fn compute_move_block(
     _ => ()
   }
   let source_kind = source_siblings[source_idx].kind
-  // Current Loom Markdown folds ordered and unordered list containers into
-  // UnorderedList. When explicit ordered-list payloads land, keep every list
-  // container source rejected here until #724 widens MoveBlock legality with
-  // list-item scope, identity, and marker-renumbering tests.
-  if source_kind is @markdown.Block::UnorderedList(_) {
+  // Keep every list container source rejected here until #724 widens
+  // MoveBlock legality with list-item scope, identity, marker-renumbering,
+  // parse-shape, ambiguity, and separator tests.
+  if source_kind is @markdown.Block::UnorderedList(_) ||
+    source_kind is @markdown.Block::OrderedList(_, _) {
     return Err(list_payload_blocker("list container sources"))
   }
   if source_siblings.any(sibling => {
@@ -80,7 +80,10 @@ fn root_sibling_index_or_error(
     None => {
       let (nested_siblings, nested_idx) = find_sibling_context(proj, node_id)
       if nested_idx >= 0 {
-        if nested_siblings[nested_idx].kind is @markdown.Block::ListItem(_) {
+        if nested_siblings[nested_idx].kind
+          is @markdown.Block::UnorderedListItem(_) ||
+          nested_siblings[nested_idx].kind
+          is @markdown.Block::OrderedListItem(_, _) {
           return Err(list_payload_blocker("list-item " + role + "s"))
         }
         return Err(
@@ -276,7 +279,9 @@ fn original_adjacent_separator(
 ///|
 fn separator_between(left : @markdown.Block, right : @markdown.Block) -> String {
   match (left, right) {
-    (Paragraph(_), Paragraph(_)) | (UnorderedList(_), _) => "\n\n"
+    (Paragraph(_), Paragraph(_))
+    | (UnorderedList(_), _)
+    | (OrderedList(_, _), _) => "\n\n"
     _ =>
       // Default root siblings (heading/code/paragraph before non-paragraph)
       // use a single newline unless an original adjacent separator is reused.

--- a/lang/markdown/proj/move_reconcile.mbt
+++ b/lang/markdown/proj/move_reconcile.mbt
@@ -67,7 +67,9 @@ fn has_move_hint(hints : Map[@core.NodeId, @core.IdentityTransform]) -> Bool {
 
 ///|
 fn is_block_container(block : @markdown.Block) -> Bool {
-  block is Document(_) || block is UnorderedList(_)
+  block is Document(_) ||
+  block is UnorderedList(_) ||
+  block is OrderedList(_, _)
 }
 
 ///|

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -1,9 +1,6 @@
 ///| Extract token spans from the Markdown CST into the SourceMap.
 
 ///|
-const ORDERED_LIST_KIND_ROLE : String = "markdown:ordered-list-kind"
-
-///|
 pub fn populate_token_spans(
   source_map : @core.SourceMap,
   syntax_root : @seam.SyntaxNode,
@@ -98,7 +95,7 @@ fn populate_block(
     Paragraph(_) =>
       // Full inline content (no prefix to skip)
       set_content_span(source_map, syntax_node, id, "text", None)
-    ListItem(_) =>
+    UnorderedListItem(_) | OrderedListItem(_, _) =>
       // Full inline content after this item's own marker. Compare marker
       // positions so a nested sublist marker never wins over the outer item
       // marker when both token kinds are present in the item CST.
@@ -109,14 +106,7 @@ fn populate_block(
         "text",
         list_item_marker_kind(syntax_node),
       )
-    UnorderedList(_) => {
-      if @markdown.SyntaxKind::from_raw(syntax_node.kind()) == OrderedListNode {
-        source_map.set_token_span(
-          id,
-          ORDERED_LIST_KIND_ROLE,
-          @loomcore.Range::new(syntax_node.start(), syntax_node.start()),
-        )
-      }
+    UnorderedList(_) | OrderedList(_, _) => {
       let syntax_children = collect_syntax_children(
         syntax_node,
         @markdown.SyntaxKind::ListItemNode,

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -41,10 +41,7 @@ fn build_proj_tree(
         collect_block_children(syntax_node),
         counter,
       )
-    UnorderedList(_) =>
-      // The current Markdown Block API folds both unordered and ordered CST
-      // list nodes to UnorderedList payloads. Preserve either CST container by
-      // collecting its ListItemNode children from the original syntax node.
+    UnorderedList(_) | OrderedList(_, _) =>
       build_container(
         syntax_node,
         block,
@@ -119,64 +116,14 @@ fn is_block_node(kind : @markdown.SyntaxKind) -> Bool {
 }
 
 ///|
-/// Convert a Markdown projection to the wire ViewNode shape while preserving
-/// CST list orderedness that the current Block payload does not carry.
+/// Convert a Markdown projection to the wire ViewNode shape.
 pub fn proj_to_view_node(
   node : @core.ProjNode[@markdown.Block],
   source_map : @core.SourceMap,
   annotations? : Map[@core.NodeId, Array[@protocol.ViewAnnotation]] = {},
   source_text? : String? = None,
 ) -> @protocol.ViewNode {
-  let view = @protocol.proj_to_view_node(
-    node,
-    source_map,
-    annotations~,
-    source_text~,
-  )
-  refine_markdown_view_node(view, node, source_map)
-}
-
-///|
-fn refine_markdown_view_node(
-  view : @protocol.ViewNode,
-  node : @core.ProjNode[@markdown.Block],
-  source_map : @core.SourceMap,
-) -> @protocol.ViewNode {
-  let children : Array[@protocol.ViewNode] = view.children
-    .iter()
-    .zip(node.children.iter())
-    .map(pair => refine_markdown_view_node(pair.0, pair.1, source_map))
-    .collect()
-  let kind_tag = markdown_view_kind_tag(view.kind_tag, node, source_map)
-  @protocol.ViewNode::ViewNode(
-    id=view.id,
-    kind_tag~,
-    label=view.label,
-    text?=view.text,
-    text_range=view.text_range,
-    token_spans=view.token_spans,
-    editable=view.editable,
-    css_class=kind_tag,
-    children~,
-    annotations=view.annotations,
-  )
-}
-
-///|
-fn markdown_view_kind_tag(
-  fallback : String,
-  node : @core.ProjNode[@markdown.Block],
-  source_map : @core.SourceMap,
-) -> String {
-  match node.kind {
-    UnorderedList(_) =>
-      if source_map.get_token_span(node.id(), ORDERED_LIST_KIND_ROLE) is Some(_) {
-        "OrderedList"
-      } else {
-        fallback
-      }
-    _ => fallback
-  }
+  @protocol.proj_to_view_node(node, source_map, annotations~, source_text~)
 }
 
 ///|

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -32,6 +32,10 @@ test "projection: ordered list" {
   let (proj, _) = parse_to_proj_node("1. first\n2. second\n")
   inspect(proj.children.length(), content="1")
   let list = proj.children[0]
+  match list.kind {
+    OrderedList(_, Some(marker)) => inspect(marker.text(), content="1.")
+    _ => fail("expected ordered-list payload")
+  }
   inspect(list.children.length(), content="2")
 }
 
@@ -51,12 +55,10 @@ test "source map: ordered list item text excludes marker" {
 }
 
 ///|
-test "view: ordered list keeps ordered kind tag" {
+test "view: ordered list keeps ordered kind tag from payload" {
   let source = "1. first\n2. second\n"
   let (proj, _) = parse_to_proj_node(source)
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, _) = @markdown.parse_cst(source)
-  populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let view = proj_to_view_node(proj, source_map, source_text=Some(source))
   inspect(view.children[0].kind_tag, content="OrderedList")
 }

--- a/lib/semantic/annotate.mbt
+++ b/lib/semantic/annotate.mbt
@@ -34,7 +34,8 @@ fn classify(index : Int, children : Array[@md.Block]) -> Role? {
     @md.Paragraph(_) if children.get(index + 1) is Some(@md.CodeBlock(_, _)) =>
       Some(CodeExplanation)
     @md.Paragraph(_) if index == 0 => Some(Abstract)
-    @md.UnorderedList(_) if prev is Some(@md.Heading(_, _)) => Some(KeyPoints)
+    @md.UnorderedList(_) | @md.OrderedList(_, _) if prev
+      is Some(@md.Heading(_, _)) => Some(KeyPoints)
     _ => None
   }
 }

--- a/lib/semantic/annotate_test.mbt
+++ b/lib/semantic/annotate_test.mbt
@@ -38,9 +38,25 @@ test "list after heading → KeyPoints" {
   let doc = @md.Document([
     @md.Heading(1, [@md.Text("Features")]),
     @md.UnorderedList([
-      @md.ListItem([@md.Text("Fast")]),
-      @md.ListItem([@md.Text("Safe")]),
+      @md.UnorderedListItem([@md.Text("Fast")]),
+      @md.UnorderedListItem([@md.Text("Safe")]),
     ]),
+  ])
+  let map = annotate_symbolic(doc)
+  inspect(map[1], content="RuleBased(KeyPoints)")
+}
+
+///|
+test "ordered list after heading → KeyPoints" {
+  let doc = @md.Document([
+    @md.Heading(1, [@md.Text("Steps")]),
+    @md.OrderedList(
+      [
+        @md.OrderedListItem([@md.Text("First")], None),
+        @md.OrderedListItem([@md.Text("Second")], None),
+      ],
+      None,
+    ),
   ])
   let map = annotate_symbolic(doc)
   inspect(map[1], content="RuleBased(KeyPoints)")
@@ -91,8 +107,8 @@ test "mixed document — full annotation" {
     @md.Paragraph([@md.Text("Section intro")]),
     @md.Heading(2, [@md.Text("Features")]),
     @md.UnorderedList([
-      @md.ListItem([@md.Text("A")]),
-      @md.ListItem([@md.Text("B")]),
+      @md.UnorderedListItem([@md.Text("A")]),
+      @md.UnorderedListItem([@md.Text("B")]),
     ]),
     @md.Paragraph([@md.Text("Code explanation")]),
     @md.CodeBlock("moonbit", "fn main {}"),


### PR DESCRIPTION
## Summary
- update Loom submodule to `1e384f2` / dowdiness/loom#429 for explicit Markdown list payloads
- remove the temporary `ORDERED_LIST_KIND_ROLE` SourceMap side channel and let Markdown view kind come from `Block::OrderedList(_, _)`
- update Markdown projection/edit paths, semantic annotations, block input, and preview rendering for `UnorderedListItem` / `OrderedListItem`

## Context
This completes the active dependency in `docs/plans/2026-06-20-markdown-list-payloads.md`: ordered/unordered list kind is now semantic Loom AST data instead of Canopy SourceMap metadata.

This does **not** widen Markdown `MoveBlock` legality. List containers and list-item contexts remain rejected until #724 adds parse-shape, identity, ambiguity, marker-renumbering, and separator coverage.

## Reuse check
- Reused Loom `Block::OrderedList(_, _)`, `Block::UnorderedListItem(_)`, and `Block::OrderedListItem(_, _)` payloads from dowdiness/loom#429.
- Reused existing `@protocol.proj_to_view_node` directly after removing Markdown-specific SourceMap kind refinement.
- Reused existing source marker spans for list-item split/block-mode display.
- Checked core/project APIs: `Array::map`, `Array::zip`, `Map::get`, `Option::map`, Loom `Renderable::kind_tag`, and Markdown `Block` constructors.
- New helper: `is_markdown_list_item`, scoped to Markdown edit operations.

## Validation
```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 ./scripts/build-js.sh
cd examples/web && npm ci && npx tsc --noEmit
```

Results:
```text
moon test: Total tests: 267 passed [wasm-gc], 1590 passed [js], 70 passed [native]
examples/web tsc: passed after JS artifact build
```

## Notes
- `moon info` produced no retained `.mbti` drift in Canopy.
- `rabbita/templates/rabbita-template` recursive submodule clone still requires SSH access if fully recursing into all nested submodules; not needed for this validation path.
- No ADR needed: this implements the existing Markdown list payload plan rather than introducing a new architectural decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced list handling to properly distinguish between ordered and unordered lists, ensuring consistent preservation and rendering across editing modes.

* **Tests**
  * Updated tests to validate correct list behavior in block and preview modes.

* **Documentation**
  * Updated development guide examples for improved list structure representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->