### PR TITLE
Enable same-list Markdown item moves

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -256,7 +256,7 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   fallbacks; action-context plumbing now uses real LetDef ids instead of init ids.
 
 - [ ] Prepare drag-and-drop foundations for `examples/block-editor`.
-  Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder. Markdown list/list-item moves for issue #724 are no longer blocked on list payloads, but still need parse-shape, identity, ambiguity, marker-renumbering, and separator regressions before legality can widen safely.
+  Why: `move_block` only appends as last child; needs `move_before`/`move_after` for sibling reorder. Markdown list/list-item moves for issue #724 are no longer blocked on list payloads. In progress: same-list item reorder now has parse-shape, identity, ambiguity, marker-renumbering, separator, and unsupported-container regressions; cross-container/list-container legality remains narrow.
   Plan: `docs/plans/2026-03-30-editor-drag-drop-foundation.md` (steps 2-3); issue #724 tracks Markdown list/list-item move provenance.
   Exit: `block-editor` exposes positioned block moves plus structural render metadata.
 

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -391,7 +391,10 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
   // Snapshot text before applying edits so we can detect net-no-op batches
   // (e.g. CommitEdit with the same text). Only needed when a hint is provided.
   let text_before : String? = match hint {
-    Some(_) => Some(self.get_text())
+    Some(h) => {
+      self.pending_transforms.val.push(h)
+      Some(self.get_text())
+    }
     None => None
   }
   let old_cursor = self.get_cursor()
@@ -407,15 +410,13 @@ pub fn[T : Eq] SyncEditor::apply_span_edits(
       false, // move_cursor_to_edit_end
     )
   }
-  // Push hint only when the batch produced an actual text change (T4).
-  // A no-op batch leaves no pending reparse — sync_parser_after_text_change
-  // returns early when old_source == new_source — so the hint would be stale:
-  // it survives into the next structural op's hint map and causes incorrect
-  // freshening of nodes that were not actually re-parsed.
+  // Drop a pre-pushed hint when the batch produced no text change (T4).
+  // Real changes need the hint available during apply_local_text_change's
+  // immediate reconcile pass; no-op batches have no reparse to consume it.
   match (hint, text_before) {
-    (Some(h), Some(before)) =>
-      if before != self.get_text() {
-        self.pending_transforms.val.push(h)
+    (Some(_), Some(before)) =>
+      if before == self.get_text() {
+        let _ = self.pending_transforms.val.pop()
       }
     _ => ()
   }

--- a/lang/markdown/companion/integration_wbtest.mbt
+++ b/lang/markdown/companion/integration_wbtest.mbt
@@ -36,6 +36,54 @@ test "generic view path preserves ordered list kind" {
 }
 
 ///|
+test "move_block: unordered list item move preserves identity" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("- A\n- B\n- C\n")
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(state, ed)
+  let proj = ed.get_proj_node().unwrap()
+  let items = proj.children[0].children
+  let b_id = items[1].id()
+  let result = apply_markdown_edit(
+    ed,
+    MarkdownEditOp::MoveBlock(
+      source=b_id,
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+    0,
+  )
+  inspect(result is Ok(_), content="true")
+  let _ = @editor.compute_view_patches(state, ed)
+  let moved_proj = ed.get_proj_node().unwrap()
+  inspect(moved_proj.children[0].children[0].id() == b_id, content="true")
+}
+
+///|
+test "move_block: ordered list item move preserves identity across renumbering" {
+  let ed = new_markdown_editor("test")
+  ed.set_text("1. A\n2. B\n3. C\n")
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  let _ = @editor.compute_view_patches(state, ed)
+  let proj = ed.get_proj_node().unwrap()
+  let items = proj.children[0].children
+  let c_id = items[2].id()
+  let result = apply_markdown_edit(
+    ed,
+    MarkdownEditOp::MoveBlock(
+      source=c_id,
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+    0,
+  )
+  inspect(result is Ok(_), content="true")
+  let _ = @editor.compute_view_patches(state, ed)
+  let moved_proj = ed.get_proj_node().unwrap()
+  inspect(moved_proj.children[0].children[0].id() == c_id, content="true")
+}
+
+///|
 test "split_block: middle of paragraph" {
   let ed = new_markdown_editor("test")
   ed.set_text("Hello World\n")

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -328,11 +328,19 @@ fn next_ordered_marker(marker : String) -> String? {
     return None
   }
   let marker_body = marker.view(start_offset=marker_start)
-  guard marker_body.find_by(fn(ch) { !(ch is ('0'..='9')) })
-    is Some(delimiter_offset) else {
+  let digit_start = if marker_body.length() > 0 && marker_body[0] == '-' {
+    1
+  } else {
+    0
+  }
+  guard marker_body
+    .view(start_offset=digit_start)
+    .find_by(fn(ch) { !(ch is ('0'..='9')) })
+    is Some(delimiter_offset_from_digit_start) else {
     return None
   }
-  if delimiter_offset == 0 {
+  let delimiter_offset = digit_start + delimiter_offset_from_digit_start
+  if delimiter_offset == digit_start {
     return None
   }
   match marker_body[delimiter_offset] {
@@ -432,4 +440,25 @@ fn find_sibling_context(
     }
   }
   ([], -1)
+}
+
+///|
+/// Find a node's parent, siblings, and index among them.
+fn find_sibling_context_and_parent(
+  root : ProjNode[@markdown.Block],
+  target : NodeId,
+) -> (ProjNode[@markdown.Block]?, Array[ProjNode[@markdown.Block]], Int) {
+  for i in 0..<root.children.length() {
+    if root.children[i].id() == target {
+      return (Some(root), root.children, i)
+    }
+    let (parent, siblings, idx) = find_sibling_context_and_parent(
+      root.children[i],
+      target,
+    )
+    if idx >= 0 {
+      return (parent, siblings, idx)
+    }
+  }
+  (None, [], -1)
 }

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -327,29 +327,261 @@ test "move_block: rejects inside position" {
 }
 
 ///|
-test "move_block: rejects unordered list item within same list" {
-  let source = "- A\n- B\n"
+test "move_block: unordered list item before sibling" {
+  let source = "- A\n- B\n- C\n"
   let (proj, _) = @md_proj.parse_to_proj_node(source)
   let items = proj.children[0].children
-  let a_id = items[0].id()
-  let b_id = items[1].id()
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="- B\n- A\n- C\n")
+}
+
+///|
+test "move_block: unordered list item after sibling" {
+  let source = "- A\n- B\n- C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[0].id(),
+      target=items[1].id(),
+      position=@core.DropPosition::After,
+    ),
+  )
+  inspect(result, content="- B\n- A\n- C\n")
+}
+
+///|
+test "move_block: ordered list item before sibling" {
+  let source = "1. A\n2. B\n3. C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="1. B\n2. A\n3. C\n")
+}
+
+///|
+test "move_block: ordered list item after sibling" {
+  let source = "1. A\n2. B\n3. C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[0].id(),
+      target=items[2].id(),
+      position=@core.DropPosition::After,
+    ),
+  )
+  inspect(result, content="1. B\n2. C\n3. A\n")
+}
+
+///|
+test "move_block: rejects duplicate list item payloads" {
+  let source = "- X\n- X\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: rejects duplicate ordered list item payloads" {
+  let source = "1. X\n2. X\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result is Err(_), content="true")
+}
+
+///|
+test "move_block: renumbers ordered list markers consecutively from 1" {
+  let source = "1. A\n2. B\n3. C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[2].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="1. C\n2. A\n3. B\n")
+}
+
+///|
+test "move_block: renumbers ordered list when first item is empty" {
+  let source = "1. \n2. B\n3. C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="1. B\n2. \n3. C\n")
+}
+
+///|
+test "move_block: moves empty ordered list item with renumbering" {
+  let source = "1. A\n2. \n3. C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="1. \n2. A\n3. C\n")
+}
+
+///|
+test "move_block: preserves ordered list delimiter paren" {
+  let source = "1) A\n2) B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="1) B\n2) A\n")
+}
+
+///|
+test "move_block: inserts padding after empty ordered seed marker" {
+  inspect(ordered_marker_for_content("1.", "B"), content="1. ")
+  inspect(ordered_marker_for_content("1)", "B"), content="1) ")
+  inspect(ordered_marker_for_content("1.", ""), content="1.")
+  inspect(ordered_marker_for_content("1.", "\n  nested"), content="1.")
+}
+
+///|
+test "move_block: preserves ordered list start value" {
+  inspect(next_ordered_marker("-1. ").unwrap(), content="0. ")
+  let source = "4. A\n5. B\n6. C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[2].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result, content="4. C\n5. A\n6. B\n")
+}
+
+///|
+test "move_block: reindents ordered item continuations after renumbering" {
+  let result = reindent_ordered_item_continuations(
+    "A\n   continued\n      nested",
+    old_marker_width=3,
+    new_marker_width=4,
+  )
+  inspect(result, content="A\n    continued\n       nested")
+}
+
+///|
+test "move_block: no-op for adjacent ordered items" {
+  let source = "1. A\n2. B\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = compute_edit_result(
+    source,
+    MoveBlock(
+      source=items[0].id(),
+      target=items[1].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result is Ok(None), content="true")
+}
+
+///|
+test "move_block: uses single newline separator between list items" {
+  let source = "- A\n- B\n- C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
+  let result = apply_edit(
+    source,
+    MoveBlock(
+      source=items[2].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+  )
+  inspect(result.contains("\n\n"), content="false")
+}
+
+///|
+test "move_block: rejects loose list item move" {
+  let source = "- A\n\n- B\n- C\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let items = proj.children[0].children
   inspect_edit_error_contains(
     source,
-    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
-    "issue #724",
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+    "loose lists",
   )
 }
 
 ///|
-test "move_block: rejects ordered list item within same list" {
-  let source = "1. A\n2. B\n"
+test "move_block: rejects whitespace-blank loose list item move" {
+  let source = "1. A\n  \n2. B\n3. C\n"
   let (proj, _) = @md_proj.parse_to_proj_node(source)
   let items = proj.children[0].children
-  let a_id = items[0].id()
-  let b_id = items[1].id()
-  inspect_edit_error(
+  inspect_edit_error_contains(
     source,
-    MoveBlock(source=b_id, target=a_id, position=@core.DropPosition::Before),
+    MoveBlock(
+      source=items[1].id(),
+      target=items[0].id(),
+      position=@core.DropPosition::Before,
+    ),
+    "loose lists",
   )
 }
 

--- a/lang/markdown/edits/compute_move_block.mbt
+++ b/lang/markdown/edits/compute_move_block.mbt
@@ -16,16 +16,42 @@ fn compute_move_block(
   guard position is Before || position is After else {
     return Err("markdown block move supports only before/after positions")
   }
-  let source_siblings = proj.children
-  let source_idx = match
-    root_sibling_index_or_error(proj, source_siblings, source_id, "source") {
-    Ok(idx) => idx
-    Err(msg) => return Err(msg)
+  let (source_parent, source_siblings, source_idx) = find_sibling_context_and_parent(
+    proj, source_id,
+  )
+  if source_idx < 0 {
+    return Err(
+      "source node not found in projection tree: " + source_id.to_string(),
+    )
   }
-  let target_idx = match
-    root_sibling_index_or_error(proj, source_siblings, target_id, "target") {
-    Ok(idx) => idx
-    Err(msg) => return Err(msg)
+  let (target_parent, target_siblings, target_idx) = find_sibling_context_and_parent(
+    proj, target_id,
+  )
+  if target_idx < 0 {
+    return Err(
+      "target node not found in projection tree: " + target_id.to_string(),
+    )
+  }
+  guard source_parent is Some(source_parent_node) else {
+    return Err(
+      "source node not found in projection tree: " + source_id.to_string(),
+    )
+  }
+  guard target_parent is Some(target_parent_node) else {
+    return Err(
+      "target node not found in projection tree: " + target_id.to_string(),
+    )
+  }
+  if source_parent_node.id() != target_parent_node.id() {
+    if is_markdown_list_item(source_siblings[source_idx].kind) {
+      return Err(list_payload_blocker("list-item sources"))
+    }
+    if is_markdown_list_item(target_siblings[target_idx].kind) {
+      return Err(list_payload_blocker("list-item targets"))
+    }
+    return Err(
+      "markdown block move currently supports same-container siblings only",
+    )
   }
   match position {
     Before if source_idx + 1 == target_idx => return Ok(None)
@@ -33,22 +59,32 @@ fn compute_move_block(
     _ => ()
   }
   let source_kind = source_siblings[source_idx].kind
-  // Keep every list container source rejected here until #724 widens
-  // MoveBlock legality with list-item scope, identity, marker-renumbering,
-  // parse-shape, ambiguity, and separator tests.
   if source_kind is @markdown.Block::UnorderedList(_) ||
     source_kind is @markdown.Block::OrderedList(_, _) {
     return Err(list_payload_blocker("list container sources"))
   }
   if source_siblings.any(sibling => {
-      sibling.id() != source_id && sibling.kind == source_kind
+      sibling.id() != source_id &&
+      move_block_payload_equal(sibling.kind, source_kind)
     }) {
     return Err("markdown block move requires a unique source block payload")
   }
-  let (replace_start, replace_end, inserted) = match
-    compute_root_move_source(
-      source, source_siblings, source_idx, target_idx, position, source_map,
-    ) {
+  let move_result = match source_parent_node.id() {
+    parent_id if parent_id == proj.id() =>
+      compute_root_move_source(
+        source, source_siblings, source_idx, target_idx, position, source_map,
+      )
+    _ if is_markdown_list_item(source_kind) &&
+      is_markdown_list_item(target_siblings[target_idx].kind) =>
+      compute_list_item_move_source(
+        source, source_siblings, source_idx, target_idx, position, source_map,
+      )
+    _ =>
+      Err(
+        "markdown block move currently supports root blocks and same-list items only",
+      )
+  }
+  let (replace_start, replace_end, inserted) = match move_result {
     Ok(patch) => patch
     Err(msg) => return Err(msg)
   }
@@ -69,37 +105,50 @@ fn compute_move_block(
 }
 
 ///|
-fn root_sibling_index_or_error(
-  proj : ProjNode[@markdown.Block],
-  root_siblings : Array[ProjNode[@markdown.Block]],
-  node_id : NodeId,
-  role : String,
-) -> Result[Int, String] {
-  match root_siblings.search_by(sibling => sibling.id() == node_id) {
-    Some(idx) => Ok(idx)
-    None => {
-      let (nested_siblings, nested_idx) = find_sibling_context(proj, node_id)
-      if nested_idx >= 0 {
-        if nested_siblings[nested_idx].kind
-          is @markdown.Block::UnorderedListItem(_) ||
-          nested_siblings[nested_idx].kind
-          is @markdown.Block::OrderedListItem(_, _) {
-          return Err(list_payload_blocker("list-item " + role + "s"))
-        }
-        return Err(
-          "markdown block move currently supports root-level blocks only",
-        )
-      }
-      Err(role + " node not found in projection tree: " + node_id.to_string())
-    }
+fn list_payload_blocker(blocked : String) -> String {
+  "markdown block move currently rejects " +
+  blocked +
+  " until issue #724 widens legality beyond same-list item reorders; see docs/TODO.md"
+}
+
+///|
+/// Compare the stable payload used to prove a move source is unambiguous.
+/// Ordered-list item markers are intentionally ignored because supported moves
+/// renumber them during source-text lowering.
+fn move_block_payload_equal(
+  left : @markdown.Block,
+  right : @markdown.Block,
+) -> Bool {
+  match (left, right) {
+    (OrderedListItem(left_inlines, _), OrderedListItem(right_inlines, _)) =>
+      left_inlines == right_inlines
+    _ => left == right
   }
 }
 
 ///|
-fn list_payload_blocker(blocked : String) -> String {
-  "markdown block move currently rejects " +
-  blocked +
-  " until issue #724 is unblocked by explicit ordered/unordered list payloads; see docs/plans/2026-06-20-markdown-list-payloads.md"
+/// Return siblings after moving one entry before/after another same-container
+/// entry. The copy/remove/insert mutation is confined to this array transform.
+fn reordered_siblings(
+  siblings : Array[ProjNode[@markdown.Block]],
+  source_idx : Int,
+  target_idx : Int,
+  position : DropPosition,
+) -> Array[ProjNode[@markdown.Block]] {
+  let reordered = siblings.copy()
+  let source = reordered.remove(source_idx)
+  let adjusted_target_idx = if source_idx < target_idx {
+    target_idx - 1
+  } else {
+    target_idx
+  }
+  let insert_idx = match position {
+    Before => adjusted_target_idx
+    After => adjusted_target_idx + 1
+    Inside => abort("unreachable: inside rejected above")
+  }
+  reordered.insert(insert_idx, source)
+  reordered
 }
 
 ///|
@@ -111,33 +160,7 @@ fn compute_root_move_source(
   position : DropPosition,
   source_map : SourceMap,
 ) -> Result[(Int, Int, String), String] {
-  let without_source = [
-    for idx, sibling in siblings if idx != source_idx => sibling
-  ]
-  let adjusted_target_idx = if source_idx < target_idx {
-    target_idx - 1
-  } else {
-    target_idx
-  }
-  let insert_idx = match position {
-    Before => adjusted_target_idx
-    After => adjusted_target_idx + 1
-    Inside => abort("unreachable: inside rejected above")
-  }
-  // Builder: construct the reordered root-block list once for rendering the
-  // replacement span.
-  let reordered : Array[ProjNode[@markdown.Block]] = []
-  for idx in 0..<=without_source.length() {
-    if idx == insert_idx {
-      reordered.push(siblings[source_idx])
-    } else {
-      let without_source_idx = if idx < insert_idx { idx } else { idx - 1 }
-      match without_source.get(without_source_idx) {
-        Some(node) => reordered.push(node)
-        None => ()
-      }
-    }
-  }
+  let reordered = reordered_siblings(siblings, source_idx, target_idx, position)
   match validate_no_unclosed_code_before_sibling(reordered, source_map) {
     Ok(_) => ()
     Err(msg) => return Err(msg)
@@ -176,6 +199,251 @@ fn compute_root_move_source(
 }
 
 ///|
+fn compute_list_item_move_source(
+  source : String,
+  siblings : Array[ProjNode[@markdown.Block]],
+  source_idx : Int,
+  target_idx : Int,
+  position : DropPosition,
+  source_map : SourceMap,
+) -> Result[(Int, Int, String), String] {
+  let reordered = reordered_siblings(siblings, source_idx, target_idx, position)
+  let first_range = match source_map.get_range(siblings[0].id()) {
+    Some(r) => r
+    None => return Err("first list item not in source map")
+  }
+  let last_range = match
+    source_map.get_range(siblings[siblings.length() - 1].id()) {
+    Some(r) => r
+    None => return Err("last list item not in source map")
+  }
+  match reject_loose_list_separators(source, siblings, source_map) {
+    Ok(_) => ()
+    Err(msg) => return Err(msg)
+  }
+  let ordered_seed = match siblings[0].kind {
+    @markdown.Block::OrderedListItem(_, _) =>
+      ordered_list_marker_seed(source, siblings[0], source_map)
+    _ => None
+  }
+  let buffer = StringBuilder::new()
+  let mut marker = ordered_seed.unwrap_or("")
+  for idx, node in reordered {
+    if idx > 0 {
+      buffer.write_string("\n")
+    }
+    match ordered_seed {
+      Some(_) => {
+        marker = match next_ordered_marker(marker) {
+          Some(next) => next
+          None => return Err("ordered list item marker is not parseable")
+        }
+        match ordered_list_item_content(source, node, source_map, marker) {
+          Ok(content) => {
+            let marker = ordered_marker_for_content(marker, content)
+            buffer.write_string(marker)
+            buffer.write_string(content)
+          }
+          Err(msg) => return Err(msg)
+        }
+      }
+      None =>
+        match block_text_without_trailing_newlines(source, node, source_map) {
+          Ok(text) => buffer.write_string(text)
+          Err(msg) => return Err(msg)
+        }
+    }
+  }
+  buffer.write_string("\n")
+  let replace_end = if last_range.end < source.length() &&
+    source[last_range.end] == '\n' {
+    last_range.end + 1
+  } else {
+    last_range.end
+  }
+  Ok((first_range.start, replace_end, buffer.to_string()))
+}
+
+///|
+fn reject_loose_list_separators(
+  source : String,
+  siblings : Array[ProjNode[@markdown.Block]],
+  source_map : SourceMap,
+) -> Result[Unit, String] {
+  for idx in 0..<(siblings.length() - 1) {
+    let left_range = match source_map.get_range(siblings[idx].id()) {
+      Some(r) => r
+      None => return Err("left list item not in source map")
+    }
+    let right_range = match source_map.get_range(siblings[idx + 1].id()) {
+      Some(r) => r
+      None => return Err("right list item not in source map")
+    }
+    let left_end = block_text_end_without_trailing_newlines(
+      source,
+      left_range.start,
+      left_range.end,
+    )
+    if separator_has_blank_line(source[left_end:right_range.start].to_owned()) {
+      return Err("markdown list item move currently rejects loose lists")
+    }
+  }
+  Ok(())
+}
+
+///|
+fn separator_has_blank_line(separator : String) -> Bool {
+  for idx in 0..<separator.length() {
+    if separator[idx] == '\n' {
+      let mut next = idx + 1
+      while next < separator.length() &&
+            (separator[next] == ' ' || separator[next] == '\t') {
+        next = next + 1
+      }
+      if next < separator.length() && separator[next] == '\n' {
+        return true
+      }
+    }
+  }
+  false
+}
+
+///|
+fn ordered_list_marker_seed(
+  source : String,
+  node : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+) -> String? {
+  match ordered_list_marker_parts(source, node, source_map) {
+    Some((seed, _)) => Some(seed)
+    None => None
+  }
+}
+
+///|
+fn ordered_list_marker_parts(
+  source : String,
+  node : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+) -> (String, Int)? {
+  let range = match source_map.get_range(node.id()) {
+    Some(r) => r
+    None => return None
+  }
+  let mut marker_start = range.start
+  while marker_start < range.end &&
+        (source[marker_start] == ' ' || source[marker_start] == '\t') {
+    marker_start = marker_start + 1
+  }
+  let mut delimiter = marker_start
+  while delimiter < range.end && source[delimiter] is ('0'..='9') {
+    delimiter = delimiter + 1
+  }
+  if delimiter == marker_start || delimiter >= range.end {
+    return None
+  }
+  guard source[delimiter] is ('.' | ')') else { return None }
+  let mut content_start = delimiter + 1
+  while content_start < range.end &&
+        (source[content_start] == ' ' || source[content_start] == '\t') {
+    content_start = content_start + 1
+  }
+  let value = @string.parse_int(source[marker_start:delimiter], base=10) catch {
+    _ => return None
+  }
+  Some(
+    (
+      source[range.start:marker_start].to_owned() +
+      (value - 1).to_string() +
+      source[delimiter:content_start].to_owned(),
+      content_start,
+    ),
+  )
+}
+
+///|
+fn ordered_marker_for_content(marker : String, content : String) -> String {
+  guard content.length() > 0 && content[0] != '\n' else { return marker }
+  if marker.length() > 0 && marker[marker.length() - 1] is (' ' | '\t') {
+    marker
+  } else {
+    marker + " "
+  }
+}
+
+///|
+fn ordered_list_item_content(
+  source : String,
+  node : ProjNode[@markdown.Block],
+  source_map : SourceMap,
+  marker : String,
+) -> Result[String, String] {
+  let range = match source_map.get_range(node.id()) {
+    Some(r) => r
+    None => return Err("ordered list item not in source map")
+  }
+  let content_start = match
+    ordered_list_marker_parts(source, node, source_map) {
+    Some((_, start)) => start
+    None => return Err("ordered list item marker is not parseable")
+  }
+  let end = block_text_end_without_trailing_newlines(
+    source,
+    range.start,
+    range.end,
+  )
+  let content = source[content_start:end].to_owned()
+  let marker = ordered_marker_for_content(marker, content)
+  Ok(
+    reindent_ordered_item_continuations(
+      content,
+      old_marker_width=content_start - range.start,
+      new_marker_width=marker.length(),
+    ),
+  )
+}
+
+///|
+fn reindent_ordered_item_continuations(
+  content : String,
+  old_marker_width~ : Int,
+  new_marker_width~ : Int,
+) -> String {
+  if old_marker_width == new_marker_width || !content.contains("\n") {
+    return content
+  }
+  let buffer = StringBuilder::new()
+  let mut line_start = 0
+  let mut idx = 0
+  while idx < content.length() {
+    if content[idx] == '\n' {
+      buffer.write_string(content[line_start:idx + 1].to_owned())
+      line_start = idx + 1
+      let indent_end = leading_spaces_end(content, line_start)
+      let indent_width = indent_end - line_start
+      if indent_width >= old_marker_width {
+        buffer.write_string(
+          String::make(new_marker_width + indent_width - old_marker_width, ' '),
+        )
+        line_start = indent_end
+      }
+    }
+    idx = idx + 1
+  }
+  buffer.write_string(content[line_start:].to_owned())
+  buffer.to_string()
+}
+
+///|
+fn leading_spaces_end(source : String, start : Int) -> Int {
+  let mut end = start
+  while end < source.length() && source[end] == ' ' {
+    end = end + 1
+  }
+  end
+}
+
+///|
 fn block_text_without_trailing_newlines(
   source : String,
   node : ProjNode[@markdown.Block],
@@ -199,12 +467,11 @@ fn block_text_end_without_trailing_newlines(
   start : Int,
   end : Int,
 ) -> Int {
-  for current_end = end {
-    if current_end > start && source[current_end - 1] == '\n' {
-      continue current_end - 1
-    }
-    break current_end
+  let mut current_end = end
+  while current_end > start && source[current_end - 1] == '\n' {
+    current_end = current_end - 1
   }
+  current_end
 }
 
 ///|
@@ -279,6 +546,8 @@ fn original_adjacent_separator(
 ///|
 fn separator_between(left : @markdown.Block, right : @markdown.Block) -> String {
   match (left, right) {
+    (UnorderedListItem(_), UnorderedListItem(_))
+    | (OrderedListItem(_, _), OrderedListItem(_, _)) => "\n"
     (Paragraph(_), Paragraph(_))
     | (UnorderedList(_), _)
     | (OrderedList(_, _), _) => "\n\n"

--- a/lang/markdown/proj/move_reconcile.mbt
+++ b/lang/markdown/proj/move_reconcile.mbt
@@ -57,12 +57,7 @@ fn reconcile_markdown_projection_hinted(
 
 ///|
 fn has_move_hint(hints : Map[@core.NodeId, @core.IdentityTransform]) -> Bool {
-  for _, hint in hints {
-    if hint is @core.IdentityTransform::Move(_) {
-      return true
-    }
-  }
-  false
+  hints.values().any(hint => hint is @core.IdentityTransform::Move(_))
 }
 
 ///|
@@ -85,7 +80,8 @@ fn reconcile_markdown_children_hinted(
     is_move_source(hints, old_children[i].id())
   })
   let exact_match = (oi, nj) => {
-    old_children[oi].kind == new_children[nj].kind && !excluded_old[oi]
+    markdown_child_match(old_children[oi].kind, new_children[nj].kind) &&
+    !excluded_old[oi]
   }
   // Dynamic-programming table and backtracking arrays are algorithm state for
   // occurrence-stable LCS. Mutation is local to the matcher and mirrors
@@ -150,6 +146,17 @@ fn reconcile_markdown_children_hinted(
 }
 
 ///|
+fn markdown_child_match(old : @markdown.Block, new_ : @markdown.Block) -> Bool {
+  match (old, new_) {
+    (OrderedListItem(old_inlines, _), OrderedListItem(new_inlines, _)) =>
+      old_inlines == new_inlines
+    _ if is_block_container(old) || is_block_container(new_) =>
+      @loomcore.TreeNode::same_kind(old, new_)
+    _ => old == new_
+  }
+}
+
+///|
 fn is_move_source(
   hints : Map[@core.NodeId, @core.IdentityTransform],
   id : @core.NodeId,
@@ -170,7 +177,7 @@ fn markdown_move_pair_counts(
     if old_matched[oi] < 0 && is_move_source(hints, old_child.id()) {
       let count = [
         for ni, new_child in new_children if new_matched[ni] < 0 &&
-        old_child.kind == new_child.kind => new_child
+        markdown_child_match(old_child.kind, new_child.kind) => new_child
       ].length()
       if count > 0 {
         counts[old_child.id()] = count
@@ -195,7 +202,7 @@ fn markdown_move_pair(
     consumed.get(old_child.id()) is None &&
     old_pair_counts.get(old_child.id()) is Some(1) &&
     is_move_source(hints, old_child.id()) &&
-    old_child.kind == new_child.kind => old_child
+    markdown_child_match(old_child.kind, new_child.kind) => old_child
   ]
   match candidates {
     [old_child] => {


### PR DESCRIPTION
## Summary

- Enables same-list Markdown list-item `MoveBlock` operations while keeping list-container and cross-container moves rejected.
- Adds regression coverage for unordered/ordered item reorder parse shape, identity preservation, ambiguity rejection, ordered marker renumbering/delimiters, separators, and unsupported containers.
- Updates Markdown move reconciliation so ordered list items can preserve identity across renumbering.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceMap::get_range` | Markdown/source-map APIs used by edit computation | Yes | Used to derive replacement spans and item source text. |
| `next_ordered_marker` | `lang/markdown/edits/compute_markdown_edit.mbt` | Yes | Reused for ordered marker renumbering instead of adding a second parser/incrementer. |
| `is_markdown_list_item` | `lang/markdown/edits/compute_markdown_edit.mbt` | Yes | Reused for legality checks. |
| `@loomcore.TreeNode::same_kind` | Loom core tree API | Yes | Used for container-kind matching during move reconciliation. |
| `StringBuilder` / `String` slicing | MoonBit core | Yes | Used to assemble replacement list text and extract ordered item content. |
| `Array` operations (`copy`, `remove`, `insert`, comprehensions) | MoonBit core | Yes | Used for same-container sibling reordering and tests. |
| `Map::values().any` | MoonBit core | Yes | Used to simplify move-hint detection. |
| `Option` / `Result` | MoonBit core | Yes | Used for fallible source-map and marker parsing paths. |

New helpers added:

- `find_sibling_context_and_parent`: extends existing sibling lookup by returning the parent needed to distinguish same-list item moves from cross-container moves.
- `move_block_payload_equal`: centralizes ambiguity matching so ordered item markers are ignored during supported renumbering moves.
- `reordered_siblings`: isolates the shared same-container reorder transform.
- `compute_list_item_move_source`: list-item-specific replacement rendering with marker renumbering and separator rules.
- `ordered_list_marker_seed`, `ordered_list_marker_parts`, `ordered_list_item_content`: source-backed ordered marker/content extraction; needed because ordered marker syntax is not part of the stable item payload.
- `markdown_child_match`: reconciliation matching that treats ordered item renumbering as identity-preserving while keeping container matching kind-based.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`) — not applicable; no web JS changes

## Validation

```bash
git diff --check
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/edits
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/companion
NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
NEW_MOON_MOD=0 moon test
```

Notes:

- `moon test`: `1602` JS tests, `267` wasm-gc tests, and `70` native tests passed.
- `moon info` produced unrelated generated-interface trailing-blank-line noise in four packages; it was reviewed and not committed. No `.mbti` API drift is included in this PR.

Refs #724.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for moving list items within the markdown editor while preserving item identity.
  * Ordered lists now properly renumber when items are reordered.
  * Enhanced list marker parsing to handle edge cases.

* **Tests**
  * Added integration and unit tests for list item move operations.
  * Expanded coverage for list renumbering and reordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->