### PR TITLE
docs: record loomgen RawKind/content-hash identity decision (L1-A)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,11 @@ behavior** — check the code before relying on any specific detail.
 - [Lambda edit bridge boundary](decisions/2026-06-15-lambda-edit-bridge-boundary.md)
   — keeps Lambda's typed-error, patch-trace, editor-coupled bridge outside
   `LanguageSpec` after `ModuleProjection` removal (closes #634).
+- [loomgen RawKind vs content-hash identity (L1-A)](decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md)
+  — severity of loomgen's sequential-renumber bug is MILD (nothing persisted/transmitted
+  keys off the seam content hash); constrain loomgen with an append-only kind→raw
+  registry (fork (i)), holding the seam hash-name migration (fork (ii)) as a documented
+  escalation (loom #427 / #729).
 
 ## Historical / Archive
 

--- a/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
+++ b/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
@@ -55,22 +55,32 @@ favoring fork (ii)); if the hash is in-memory only, the blast radius is one reco
 (**mild**, fork (i) suffices). Reading the actual persistence/transmission layer
 settles it.
 
-**What survives — or is transmitted — across a loomgen build boundary?** Three
-surfaces: (a) source **text** files; (b) the SQLite op log
-([`store.ts`](../../examples/ideal/web/server/store.ts)); and (c) the ideal web app's
-**full CRDT state**, saved to `localStorage` via `crdt.export_all_json` and restored
-via `apply_sync_json` ([`examples/ideal/web/src/main.ts`](../../examples/ideal/web/src/main.ts):128/:449),
-and sent to peers as the same payload ([`examples/ideal/web/src/sync.ts`](../../examples/ideal/web/src/sync.ts):120).
-All three are **text/CRDT-based**: text is ground truth, re-parsed into a fresh CST
-under the current numbering. So the question reduces to: *does any of these carry a
-seam content-hash or RawKind int?*
+**What survives — or is transmitted — across a loomgen build boundary?** Every
+persisted or transmitted artifact reduces to one of **two payload classes**, no
+matter how many transports carry them: (a) source **text** files; and (b) the
+text-CRDT op stream — `@text.SyncMessage` (op runs + version heads), or the opaque
+relayed op strings derived from it. Class (b) travels over *several* transports, all
+audited below: the dev SQLite op log
+([`store.ts`](../../examples/ideal/web/server/store.ts)), the Cloudflare relay's
+Durable Object SQL ([`relay-worker.js`](../../examples/ideal/web/relay-worker.js)),
+the ideal web app's `localStorage` snapshot + peer sync via `crdt.export_all_json` /
+`apply_sync_json` ([`main.ts`](../../examples/ideal/web/src/main.ts):128/:449,
+[`sync.ts`](../../examples/ideal/web/src/sync.ts):120), and the `SyncEditor`
+WebSocket broadcast (`export_all().to_json_string()` wrapped in `@wire.CrdtOps`,
+[`sync_editor_ws.mbt`](../../editor/sync_editor_ws.mbt):59-65). Both classes are
+**text/CRDT-based**: text is ground truth, re-parsed into a fresh CST under the
+current numbering, and the op stream is character-level CRDT operations *upstream of*
+parsing. So the question reduces to: *does any of these carry a seam content-hash or
+RawKind int?*
 
 Evidence (as of 2026-06-23):
 
 | Surface | What it carries | Keys off seam hash? |
 |---------|-----------------|---------------------|
-| Op log persistence ([`examples/ideal/web/server/store.ts`](../../examples/ideal/web/server/store.ts)) | opaque relayed op strings, `(id, room_id, data)` | no |
+| Op log persistence — dev relay ([`examples/ideal/web/server/store.ts`](../../examples/ideal/web/server/store.ts)) | opaque relayed op strings, `(id, room_id, data)` | no |
+| Op log persistence — Cloudflare relay DO SQL ([`examples/ideal/web/relay-worker.js`](../../examples/ideal/web/relay-worker.js):18-22,:65-69) | opaque relayed op strings, `operations(id, data)`, stored on `"operation"` and replayed verbatim on `"join"` — never parsed | no |
 | Full CRDT state: `localStorage` snapshot + peer sync ([`ffi/lambda/diagnostics.mbt`](../../ffi/lambda/diagnostics.mbt) `export_all_json`/`apply_sync_json` → `@text.SyncMessage`) | `{ runs : Array[@core.OpRun], heads : Array[@core.RawVersion] }` — text op runs + agent/seq version frontier (eg-walker `@core`, **not** seam; `event-graph-walker/text/sync.mbt`) | no — text-CRDT ops, upstream of parsing |
+| `SyncEditor` WS broadcast ([`editor/sync_editor_ws.mbt`](../../editor/sync_editor_ws.mbt):59-65 `ws_broadcast_edit` → `@wire.CrdtOps`) | `export_all().to_json_string()` — the same `@text.SyncMessage` payload, UTF-16LE framed | no — same text-CRDT op stream |
 | The op itself ([`protocol/user_intent.mbt`](../../protocol/user_intent.mbt) `UserIntent`) | `TextEdit(from, to, insert)` (text edits) + `StructuralEdit`/`SelectNode`/`CommitEdit` addressing by `@core.NodeId` | no |
 | `NodeId` ([`core/types.mbt`](../../core/types.mbt) `struct NodeId(Int)`) | allocation-order int (`assign_fresh_ids` counter), "survives reparses" | no — not hash-derived |
 | Wire view/annotation ([`protocol/view_node.mbt`](../../protocol/view_node.mbt)) | `ViewNode.kind_tag : String` (AST variant **name**), `ViewAnnotation.kind/label/severity : String`, `TokenSpan.role : String`, UTF-16 offsets | no — keys off **names** + NodeId |

--- a/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
+++ b/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-23
 **Status:** Accepted (decision record)
-**Related:** loom [#427](https://github.com/dowdiness/canopy/issues/427) (gate: fix L1-A + re-baseline before loomgen build) ·
+**Related:** loom [#427](https://github.com/dowdiness/loom/issues/427) (gate: fix L1-A + re-baseline before loomgen build) ·
 canopy [#729](https://github.com/dowdiness/canopy/issues/729) (the L1-A fix in `07-loomgen-design.md`) ·
 [`07-loomgen-design.md`](../design/07-loomgen-design.md) ·
 [2026-06-01 identity-and-reuse-mechanisms](2026-06-01-identity-and-reuse-mechanisms.md) ·
@@ -15,8 +15,8 @@ The Layer-1 adversarial pass on the loomgen design (loom §4.5, 2026-06-20) foun
 latent **correctness bug — "L1-A"** — and left one question explicitly unresolved:
 how bad is it? This record settles the severity from evidence and decides the fix.
 It is **non-blocking** for the merged `@grammar` work; it is the *emitter's* gate
-(loom #427), distinct from the #444 throughput gate (perf, already done) and #449
-(deep-subtree reuse, a different axis).
+(loom #427), distinct from the loom #444 throughput gate (perf, already done) and
+loom #449 (deep-subtree reuse, a different axis).
 
 ## The bug (L1-A)
 

--- a/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
+++ b/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
@@ -55,23 +55,33 @@ favoring fork (ii)); if the hash is in-memory only, the blast radius is one reco
 (**mild**, fork (i) suffices). Reading the actual persistence/transmission layer
 settles it.
 
-**What survives — or is transmitted — across a loomgen build boundary?** Every
-persisted or transmitted artifact reduces to one of **two payload classes**, no
-matter how many transports carry them: (a) source **text** files; and (b) the
-text-CRDT op stream — `@text.SyncMessage` (op runs + version heads), or the opaque
-relayed op strings derived from it. Class (b) travels over *several* transports, all
-audited below: the dev SQLite op log
-([`store.ts`](../../examples/ideal/web/server/store.ts)), the Cloudflare relay's
-Durable Object SQL ([`relay-worker.js`](../../examples/ideal/web/relay-worker.js)),
-the ideal web app's `localStorage` snapshot + peer sync via `crdt.export_all_json` /
-`apply_sync_json` ([`main.ts`](../../examples/ideal/web/src/main.ts):128/:449,
-[`sync.ts`](../../examples/ideal/web/src/sync.ts):120), and the `SyncEditor`
-WebSocket broadcast (`export_all().to_json_string()` wrapped in `@wire.CrdtOps`,
-[`sync_editor_ws.mbt`](../../editor/sync_editor_ws.mbt):59-65). Both classes are
-**text/CRDT-based**: text is ground truth, re-parsed into a fresh CST under the
-current numbering, and the op stream is character-level CRDT operations *upstream of*
-parsing. So the question reduces to: *does any of these carry a seam content-hash or
-RawKind int?*
+**What survives — or is transmitted — across a loomgen build boundary?** The
+transmitted frames are a **closed enum** — `@wire.SyncMessage`
+([`protocol/wire/wire.mbt`](../../protocol/wire/wire.mbt):5-13): `CrdtOps`,
+`RelayedCrdtOps`, `SyncRequest`, `SyncResponse`, `EphemeralUpdate`, `PeerJoined`,
+`PeerLeft` — and persistence stores those frames' payloads (or source text)
+verbatim. Walking the *whole* enum, every frame falls into one of **three classes**,
+none carrying CST structure:
+
+- **(a) source text** — files on disk; ground truth, re-parsed into a fresh CST
+  under the current numbering.
+- **(b) the text-CRDT op stream** — `@text.SyncMessage` (op runs + version heads),
+  character-level operations *upstream of* parsing; carried by `CrdtOps` /
+  `RelayedCrdtOps` / `SyncResponse`, with `SyncRequest` carrying only the version
+  frontier. This class travels over *several* transports, all auditing identically:
+  the dev SQLite op log
+  ([`store.ts`](../../examples/ideal/web/server/store.ts)), the Cloudflare relay's
+  Durable Object SQL ([`relay-worker.js`](../../examples/ideal/web/relay-worker.js)),
+  the ideal web app's `localStorage` snapshot + peer sync via `crdt.export_all_json`
+  / `apply_sync_json` ([`main.ts`](../../examples/ideal/web/src/main.ts):128/:449,
+  [`sync.ts`](../../examples/ideal/web/src/sync.ts):120), and the `SyncEditor` WS
+  broadcast ([`sync_editor_ws.mbt`](../../editor/sync_editor_ws.mbt):59-65).
+- **(c) ephemeral / control metadata** — `EphemeralUpdate` (cursor & presence:
+  I64 text offsets + name/color/peer-id) and `PeerJoined` / `PeerLeft` (peer-id
+  strings, connection control). No document structure at all.
+
+So the question reduces to: *does any frame in the closed set — or any persisted
+payload — carry a seam content-hash or RawKind int?*
 
 Evidence (as of 2026-06-23):
 
@@ -81,6 +91,8 @@ Evidence (as of 2026-06-23):
 | Op log persistence — Cloudflare relay DO SQL ([`examples/ideal/web/relay-worker.js`](../../examples/ideal/web/relay-worker.js):18-22,:65-69) | opaque relayed op strings, `operations(id, data)`, stored on `"operation"` and replayed verbatim on `"join"` — never parsed | no |
 | Full CRDT state: `localStorage` snapshot + peer sync ([`ffi/lambda/diagnostics.mbt`](../../ffi/lambda/diagnostics.mbt) `export_all_json`/`apply_sync_json` → `@text.SyncMessage`) | `{ runs : Array[@core.OpRun], heads : Array[@core.RawVersion] }` — text op runs + agent/seq version frontier (eg-walker `@core`, **not** seam; `event-graph-walker/text/sync.mbt`) | no — text-CRDT ops, upstream of parsing |
 | `SyncEditor` WS broadcast ([`editor/sync_editor_ws.mbt`](../../editor/sync_editor_ws.mbt):59-65 `ws_broadcast_edit` → `@wire.CrdtOps`) | `export_all().to_json_string()` — the same `@text.SyncMessage` payload, UTF-16LE framed | no — same text-CRDT op stream |
+| Ephemeral cursor/presence (`@wire.EphemeralUpdate`; [`editor/sync_editor.mbt`](../../editor/sync_editor.mbt):126-157 `set_local_presence`, `sync_editor_ws.mbt:69-73`) | `cursor`/`selection` as I64 **text offsets** + `peer_id`/`name`/`color` strings | no — positions + presence metadata, no NodeId or kind |
+| Peer/connection control (`@wire.PeerJoined`/`PeerLeft`; [`protocol/wire/wire.mbt`](../../protocol/wire/wire.mbt):5-13) | peer-id strings; join triggers ephemeral + full-CRDT catch-up (audited above) | no — control frames carry no document data |
 | The op itself ([`protocol/user_intent.mbt`](../../protocol/user_intent.mbt) `UserIntent`) | `TextEdit(from, to, insert)` (text edits) + `StructuralEdit`/`SelectNode`/`CommitEdit` addressing by `@core.NodeId` | no |
 | `NodeId` ([`core/types.mbt`](../../core/types.mbt) `struct NodeId(Int)`) | allocation-order int (`assign_fresh_ids` counter), "survives reparses" | no — not hash-derived |
 | Wire view/annotation ([`protocol/view_node.mbt`](../../protocol/view_node.mbt)) | `ViewNode.kind_tag : String` (AST variant **name**), `ViewAnnotation.kind/label/severity : String`, `TokenSpan.role : String`, UTF-16 offsets | no — keys off **names** + NodeId |
@@ -97,7 +109,10 @@ accelerator (interning, reuse, `Eq` fast-path), recomputed every run from whatev
 `to_raw()` currently returns. Nothing persisted or transmitted keys off it; the
 identity that *does* persist (NodeId, ProjectionIdentityTracker) is allocation-order /
 source-offset based, the wire layer addresses by stable **names**, and the full CRDT
-state export (localStorage + peer sync) carries text operations, not CST structure. A
+state export (localStorage + peer sync) carries text operations, not CST structure.
+Walking the closed `@wire.SyncMessage` enum confirms it: every remaining frame
+(`SyncRequest` version frontier, `EphemeralUpdate` cursor/presence, `PeerJoined` /
+`PeerLeft` control) carries versions, positions, or peer ids — never CST structure. A
 RawKind renumber is therefore internally consistent within a single recompile — its
 blast radius is one rebuild of all in-tree consumers, with no stale persisted state.
 **Severity is MILD.**

--- a/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
+++ b/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
@@ -55,16 +55,22 @@ favoring fork (ii)); if the hash is in-memory only, the blast radius is one reco
 (**mild**, fork (i) suffices). Reading the actual persistence/transmission layer
 settles it.
 
-**What survives from one loomgen build to the next?** Only two things: (a) source
-**text** files, and (b) the SQLite op log. Text is ground truth — re-parsed into a
-fresh CST under the current numbering, immune to renumbering. So the question reduces
-to: *does a persisted/transmitted op carry a seam content-hash or RawKind int?*
+**What survives — or is transmitted — across a loomgen build boundary?** Three
+surfaces: (a) source **text** files; (b) the SQLite op log
+([`store.ts`](../../examples/ideal/web/server/store.ts)); and (c) the ideal web app's
+**full CRDT state**, saved to `localStorage` via `crdt.export_all_json` and restored
+via `apply_sync_json` ([`examples/ideal/web/src/main.ts`](../../examples/ideal/web/src/main.ts):128/:449),
+and sent to peers as the same payload ([`examples/ideal/web/src/sync.ts`](../../examples/ideal/web/src/sync.ts):120).
+All three are **text/CRDT-based**: text is ground truth, re-parsed into a fresh CST
+under the current numbering. So the question reduces to: *does any of these carry a
+seam content-hash or RawKind int?*
 
 Evidence (as of 2026-06-23):
 
 | Surface | What it carries | Keys off seam hash? |
 |---------|-----------------|---------------------|
 | Op log persistence ([`examples/ideal/web/server/store.ts`](../../examples/ideal/web/server/store.ts)) | opaque relayed op strings, `(id, room_id, data)` | no |
+| Full CRDT state: `localStorage` snapshot + peer sync ([`ffi/lambda/diagnostics.mbt`](../../ffi/lambda/diagnostics.mbt) `export_all_json`/`apply_sync_json` → `@text.SyncMessage`) | `{ runs : Array[@core.OpRun], heads : Array[@core.RawVersion] }` — text op runs + agent/seq version frontier (eg-walker `@core`, **not** seam; `event-graph-walker/text/sync.mbt`) | no — text-CRDT ops, upstream of parsing |
 | The op itself ([`protocol/user_intent.mbt`](../../protocol/user_intent.mbt) `UserIntent`) | `TextEdit(from, to, insert)` (text edits) + `StructuralEdit`/`SelectNode`/`CommitEdit` addressing by `@core.NodeId` | no |
 | `NodeId` ([`core/types.mbt`](../../core/types.mbt) `struct NodeId(Int)`) | allocation-order int (`assign_fresh_ids` counter), "survives reparses" | no — not hash-derived |
 | Wire view/annotation ([`protocol/view_node.mbt`](../../protocol/view_node.mbt)) | `ViewNode.kind_tag : String` (AST variant **name**), `ViewAnnotation.kind/label/severity : String`, `TokenSpan.role : String`, UTF-16 offsets | no — keys off **names** + NodeId |
@@ -80,7 +86,8 @@ but is **absent** across `protocol/`, `ffi/`, `editor/`, `sync_session/`,
 accelerator (interning, reuse, `Eq` fast-path), recomputed every run from whatever
 `to_raw()` currently returns. Nothing persisted or transmitted keys off it; the
 identity that *does* persist (NodeId, ProjectionIdentityTracker) is allocation-order /
-source-offset based, and the wire layer already addresses by stable **names**. A
+source-offset based, the wire layer addresses by stable **names**, and the full CRDT
+state export (localStorage + peer sync) carries text operations, not CST structure. A
 RawKind renumber is therefore internally consistent within a single recompile — its
 blast radius is one rebuild of all in-tree consumers, with no stale persisted state.
 **Severity is MILD.**

--- a/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
+++ b/docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md
@@ -1,0 +1,170 @@
+# loomgen RawKind numbering vs. seam content-hash identity (L1-A)
+
+**Date:** 2026-06-23
+**Status:** Accepted (decision record)
+**Related:** loom [#427](https://github.com/dowdiness/canopy/issues/427) (gate: fix L1-A + re-baseline before loomgen build) ·
+canopy [#729](https://github.com/dowdiness/canopy/issues/729) (the L1-A fix in `07-loomgen-design.md`) ·
+[`07-loomgen-design.md`](../design/07-loomgen-design.md) ·
+[2026-06-01 identity-and-reuse-mechanisms](2026-06-01-identity-and-reuse-mechanisms.md) ·
+loom analysis [`2026-06-20-parser-generation-direction.md` §4.5](../../loom/docs/analysis/2026-06-20-parser-generation-direction.md) ·
+loom ADR [`2026-03-14-physical-equal-interner`](../../loom/docs/decisions/2026-03-14-physical-equal-interner.md)
+
+## Why this record exists
+
+The Layer-1 adversarial pass on the loomgen design (loom §4.5, 2026-06-20) found a
+latent **correctness bug — "L1-A"** — and left one question explicitly unresolved:
+how bad is it? This record settles the severity from evidence and decides the fix.
+It is **non-blocking** for the merged `@grammar` work; it is the *emitter's* gate
+(loom #427), distinct from the #444 throughput gate (perf, already done) and #449
+(deep-subtree reuse, a different axis).
+
+## The bug (L1-A)
+
+Two statements in the codebase collide:
+
+1. **loomgen's promised contract** ([`07-loomgen-design.md`](../design/07-loomgen-design.md),
+   "Generation idempotency"): generated `syntax_kind.g.mbt` has *"Stable ordering,
+   sequential `to_raw` integers, never reads `.g.mbt` as input."*
+
+2. **The real hand-maintained registry**
+   ([`loom/examples/lambda/syntax/syntax_kind.mbt`](../../loom/examples/lambda/syntax/syntax_kind.mbt),
+   as of 2026-06-23): `to_raw` is an **append-only stability registry**, not a
+   sequence. Raw `24` and `26` are skipped (`LetKeyword => 23`, `EqToken => 25`,
+   `LetDef => 27`); `FnKeyword => 43` and `FatArrowToken => 44` are appended despite
+   their mid-enum positions; comments hand-annotate `// NEW:` and `// (raw 37)`.
+
+A *sequential* regenerator that never reads prior state renumbers existing kinds on
+any `Term`-enum edit (insert a variant mid-enum → every later kind shifts) — actively
+undoing the discipline the gaps and comments encode.
+
+**Why this is identity-affecting, not cosmetic.** Seam bakes the raw int into
+structural identity ([`loom/seam/cst_node.mbt`](../../loom/seam/cst_node.mbt), as of
+2026-06-23): `CstToken::CstToken` computes
+`combine_hash(combine_hash(k, string_hash(text)), provenance)` with `k = RawKind.inner`
+(`:48`); `CstNode::new` seeds the recursive structural hash with `let mut h = k`
+(`:279`); and `Eq` compares `self.kind == other.kind` directly after the hash
+fast-path (`:143`, `:380`). The hash feeds `Eq`/`Hash`/interning/reuse — load-bearing
+(see the physical-equal-interner ADR, O(n²)→O(n)). So renumbering a kind changes the
+content hash **and** structural identity of every node containing it.
+
+## Severity: MILD — settled by evidence
+
+The open question (loom §4.5): *does any persisted/transmitted artifact key off the
+seam content hash?* If yes, a renumber silently invalidates persisted state (**severe**,
+favoring fork (ii)); if the hash is in-memory only, the blast radius is one recompile
+(**mild**, fork (i) suffices). Reading the actual persistence/transmission layer
+settles it.
+
+**What survives from one loomgen build to the next?** Only two things: (a) source
+**text** files, and (b) the SQLite op log. Text is ground truth — re-parsed into a
+fresh CST under the current numbering, immune to renumbering. So the question reduces
+to: *does a persisted/transmitted op carry a seam content-hash or RawKind int?*
+
+Evidence (as of 2026-06-23):
+
+| Surface | What it carries | Keys off seam hash? |
+|---------|-----------------|---------------------|
+| Op log persistence ([`examples/ideal/web/server/store.ts`](../../examples/ideal/web/server/store.ts)) | opaque relayed op strings, `(id, room_id, data)` | no |
+| The op itself ([`protocol/user_intent.mbt`](../../protocol/user_intent.mbt) `UserIntent`) | `TextEdit(from, to, insert)` (text edits) + `StructuralEdit`/`SelectNode`/`CommitEdit` addressing by `@core.NodeId` | no |
+| `NodeId` ([`core/types.mbt`](../../core/types.mbt) `struct NodeId(Int)`) | allocation-order int (`assign_fresh_ids` counter), "survives reparses" | no — not hash-derived |
+| Wire view/annotation ([`protocol/view_node.mbt`](../../protocol/view_node.mbt)) | `ViewNode.kind_tag : String` (AST variant **name**), `ViewAnnotation.kind/label/severity : String`, `TokenSpan.role : String`, UTF-16 offsets | no — keys off **names** + NodeId |
+| Source map (`core/source_map.mbt` `to_json`) | node id / range / token-role spans | no raw kind |
+| Persistent identity (`ProjectionIdentityTracker`, see [identity ADR](2026-06-01-identity-and-reuse-mechanisms.md) mechanism #2) | **source offset + key** windows | no |
+| `content_hash` / `structural_path` / `.md.annotations.json` | — | **do not exist** in code or on disk; named only as the loom §4.5 inferred open question |
+
+Corroborating: `to_raw` fires (calibrated) in seam and the lambda language package,
+but is **absent** across `protocol/`, `ffi/`, `editor/`, `sync_session/`,
+`transport_ws/`, and `adapters/` — the raw int never escapes the MoonBit process.
+
+**Conclusion.** The seam content hash is a **runtime, in-memory** structural-equality
+accelerator (interning, reuse, `Eq` fast-path), recomputed every run from whatever
+`to_raw()` currently returns. Nothing persisted or transmitted keys off it; the
+identity that *does* persist (NodeId, ProjectionIdentityTracker) is allocation-order /
+source-offset based, and the wire layer already addresses by stable **names**. A
+RawKind renumber is therefore internally consistent within a single recompile — its
+blast radius is one rebuild of all in-tree consumers, with no stale persisted state.
+**Severity is MILD.**
+
+## Decision
+
+**Adopt fork (i): constrain loomgen with a persistent append-only kind→raw registry.**
+Since loomgen is *unimplemented* ([`07-loomgen-design.md`](../design/07-loomgen-design.md),
+"implementation not started"), fork (i) costs ~nothing today: it is a **doc-contract
+correction** that writes down the invariant the hand-discipline already enforces. The
+concrete action is correcting the "Generation idempotency" section (its false
+"sequential / never-reads" promise).
+
+**Hold fork (ii) (migrate seam's content hash onto a stable kind name) as the
+documented escalation path**, triggered only if the severity precondition ever
+becomes true (see *Escalation trigger* below).
+
+### The corrected loomgen idempotency contract
+
+This block replaces the false "Generation idempotency" promise in
+[`07-loomgen-design.md`](../design/07-loomgen-design.md). It is the load-bearing
+artifact of fork (i) — the exact obligation loomgen must honor.
+
+loomgen reads a persistent, append-only **kind→raw registry** as a second input.
+Existing kinds keep their assigned raw across any `Term`-enum edit; retired or deleted
+kinds keep their raw as a tombstone (never reissued); only newly introduced kinds
+receive a fresh raw (the next unused integer). Regeneration is **idempotent given the
+registry**: re-running loomgen with the same `Term` enum *and* registry produces
+identical `.g.mbt` files, and editing the enum reshuffles nothing already assigned. The
+registry's concrete form — a sidecar manifest, `#loom.kind(raw=N)` annotations on the
+`Term` variants, or reading the prior generated output — is a loomgen implementation
+choice; the contract is only that such a stable record exists and is honored.
+
+## Rationale
+
+1. **Problem-first.** The persisted-staleness problem fork (ii) solves **does not
+   exist today** (severity MILD). Don't pay a high-risk source migration for a
+   non-manifest problem.
+
+2. **(i) matches the proven hand-discipline.** The existing registry already does
+   exactly this, by hand. loomgen merely automates it. (i) preserves a known-correct
+   invariant; it does not invent one.
+
+3. **(ii) relocates the registry — it does not eliminate it.** "Move identity onto the
+   kind name" frees loomgen to renumber, but to keep hashing fast on seam's hottest
+   path you must intern kind names to stable ints — which is a name→int registry living
+   *inside seam* instead of in loomgen. The stability requirement moves; it does not
+   vanish. Meanwhile the migration touches the most performance-critical, most-ADR'd
+   invariant in the system (physical-equal-interner; #396's source-span tradeoff). High
+   risk, mild payoff. (Both reviewers — advisor + Codex — confirmed this argument.)
+
+4. **(iii) deterministic name-hashed raws — rejected.** A scheme where loomgen derives
+   raws by hashing kind names (stateless, no registry file) was considered. It buys
+   little over (i): it requires collision handling, discards the hand-curated numbering
+   and its comments, and forces a one-time full renumber — all for no benefit given
+   mild severity. Rejected.
+
+5. **Reserve the extension point, don't just defer.** Recording fork (ii) with a precise
+   trigger means the coupling (raw-int-as-identity) is a *documented known limitation*
+   with a ready escalation, not a silent landmine.
+
+## Escalation trigger (when fork (ii) becomes necessary)
+
+Re-open this decision and execute fork (ii) if **any persisted or cross-build-transmitted
+artifact comes to key off the seam content hash or a raw RawKind int** — concretely, if
+a future feature (a) writes a CST content-hash or RawKind into the op log, a document
+save format, a wire message, or an annotation cache, **and** (b) reads it back in a
+later build for comparison or lookup. Until both hold, the hash stays in-memory and (i)
+is sufficient. The regression signal: a new persisted field whose value is, or derives
+from, `CstNode.hash` / `CstToken.hash` / `RawKind.inner`.
+
+## Where the fix lands (cross-repo)
+
+- **canopy** owns the fix: correct the "Generation idempotency" section of
+  [`07-loomgen-design.md`](../design/07-loomgen-design.md) per the contract above
+  (resolves the substance of #729). **No seam code changes** under fork (i).
+- **loom** #427 (the gate) references this record; the seam hash contract in
+  `loom/seam/cst_node.mbt` is **unchanged**.
+- loom analysis §4.5's open question is now settled by this record (MILD).
+
+## Source of truth on drift
+
+Code and generated `.mbti` files are authoritative. This record names specific
+files/lines **as of 2026-06-23** to fix the evidence map; if a name here disagrees with
+the code, the code wins and this record should be updated. The durable content is the
+**judgment**: severity is MILD because nothing persisted/transmitted keys off the seam
+hash; fork (i) now, fork (ii) only on the escalation trigger.

--- a/docs/design/07-loomgen-design.md
+++ b/docs/design/07-loomgen-design.md
@@ -378,7 +378,23 @@ Each gets its own `SyntaxKind` token variant. Naming derives from the Token vari
 
 ### Generation idempotency
 
-Running `loomgen` twice with the same input produces identical `.g.mbt` files. Stable ordering, sequential `to_raw` integers, never reads `.g.mbt` as input.
+Running `loomgen` twice with the same `Term` enum **and** kind→raw registry produces
+identical `.g.mbt` files, with stable ordering.
+
+`to_raw` integers are **not** a fresh sequence assigned per run. loomgen reads a
+persistent, append-only **kind→raw registry** as a second input: existing kinds keep
+their assigned raw across any `Term`-enum edit, retired or deleted kinds keep their raw
+as a tombstone (never reissued), and only newly introduced kinds receive a fresh raw
+(the next unused integer). Regeneration is therefore **idempotent given the registry** —
+editing the enum reshuffles nothing already assigned.
+
+This is load-bearing, not cosmetic: seam bakes the raw int into CST structural identity
+(the `CstNode` / `CstToken` content hash, which feeds `Eq` / `Hash` / interning /
+reuse), so a naive sequential renumber on any enum edit would break node identity. The
+registry's concrete form — a sidecar manifest, `#loom.kind(raw=N)` annotations on the
+`Term` variants, or reading the prior generated output — is a loomgen implementation
+choice; the contract is only that such a stable record exists and is honored. See
+[decision: loomgen RawKind vs content-hash identity (L1-A)](../decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md).
 
 ## Generator Architecture
 


### PR DESCRIPTION
## What

Settle and document the **loomgen L1-A** RawKind / content-hash identity bug (loom #427 / #729).

`loomgen`'s design promised "sequential `to_raw` integers, never reads `.g.mbt`," but the real `syntax_kind.mbt` is an **append-only stability registry** (skipped raws 24/26; `FnKeyword => 43`, `FatArrowToken => 44` appended out of enum position). Seam bakes the raw int into the CST content hash (which feeds `Eq` / `Hash` / interning / reuse), so a naive sequential renumber on any `Term`-enum edit would break node identity.

## Severity: MILD — settled by evidence

The open question was whether any **persisted or transmitted** artifact keys off the seam hash (severe) or it is in-memory only (mild). Traced the layers:

- The op log (`examples/ideal/web/server/store.ts`) holds opaque ops; the op itself (`protocol/user_intent.mbt` `UserIntent`) is `TextEdit(from, to, insert)` plus `NodeId`-addressed structural ops.
- `NodeId` (`core/types.mbt`) is an allocation-order `Int` that "survives reparses" — **not** hash-derived.
- The wire view layer (`protocol/view_node.mbt`) keys off `kind_tag : String` (the variant **name**) + `NodeId`; `SourceMap::to_json` emits no raw kind.
- `content_hash` / `structural_path` / `.md.annotations.json` exist **nowhere** (code or disk); `to_raw` never escapes seam (calibrated grep).

So a RawKind renumber is internally consistent within a single recompile — blast radius is one rebuild, with no stale persisted state. **Mild.**

## Decision

- **Fork (i), now:** constrain loomgen with an append-only kind→raw registry. Because loomgen is unimplemented, this is a doc-contract correction of the "Generation idempotency" section (writing down the invariant `syntax_kind.mbt` already enforces by hand).
- **Fork (ii), as documented escalation:** migrate the seam content hash onto a stable kind name — triggered only if a persisted/transmitted artifact ever comes to key off the seam hash. Key argument: fork (ii) *relocates* the registry into seam (name→int interning) rather than eliminating it, so it is disproportionate risk on the hottest invariant for a non-manifest problem.
- **Fork (iii)** (name-hashed deterministic raws) rejected — collision handling + discards the curated numbering + forces a one-time full renumber, for no benefit over (i) given mild severity.

## Files (docs-only)

- `docs/decisions/2026-06-23-loomgen-rawkind-content-hash-identity.md` *(new)* — the decision record (evidence table, rationale, corrected idempotency contract, escalation trigger).
- `docs/design/07-loomgen-design.md` — corrected "Generation idempotency" section.
- `docs/README.md` — ADR index entry.

No seam or loomgen code changed. The decision was validated by the advisor and Codex (severity + fork choice), and the docs landing passed a substantiated Codex pre-PR review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
