### PR TITLE
Add RoseNode map and constructor API

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,9 +5,43 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  benchmark-gate:
+    name: Benchmark Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_benchmarks: ${{ steps.filter.outputs.run_benchmarks }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Detect benchmark-relevant changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_benchmarks:
+              - '**/*.mbt'
+              - '**/moon.pkg'
+              - '**/moon.mod'
+              - '**/moon.mod.json'
+              - 'moon.work'
+              - '.github/actions/setup-moonbit/**'
+              - '.github/workflows/benchmark.yml'
+              - 'scripts/moon-update.sh'
+              - 'scripts/run-moon-module.sh'
+              - 'examples/ideal/web/**'
+
   benchmark-comparison:
     name: Compare Benchmarks
+    needs: benchmark-gate
+    if: needs.benchmark-gate.outputs.run_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -175,6 +209,8 @@ jobs:
 
   editor-response-benchmark:
     name: Editor Response Benchmark
+    needs: benchmark-gate
+    if: needs.benchmark-gate.outputs.run_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,43 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  benchmark-gate:
-    name: Benchmark Gate
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      run_benchmarks: ${{ steps.filter.outputs.run_benchmarks }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Detect benchmark-relevant changes
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            run_benchmarks:
-              - '**/*.mbt'
-              - '**/moon.pkg'
-              - '**/moon.mod'
-              - '**/moon.mod.json'
-              - 'moon.work'
-              - '.github/actions/setup-moonbit/**'
-              - '.github/workflows/benchmark.yml'
-              - 'scripts/moon-update.sh'
-              - 'scripts/run-moon-module.sh'
-              - 'examples/ideal/web/**'
-
   benchmark-comparison:
     name: Compare Benchmarks
-    needs: benchmark-gate
-    if: needs.benchmark-gate.outputs.run_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -209,8 +175,6 @@ jobs:
 
   editor-response-benchmark:
     name: Editor Response Benchmark
-    needs: benchmark-gate
-    if: needs.benchmark-gate.outputs.run_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch

--- a/docs/plans/2026-04-07-rose-tree-zipper-impl.md
+++ b/docs/plans/2026-04-07-rose-tree-zipper-impl.md
@@ -16,7 +16,7 @@
 1. `cd lib/zipper && moon check` passes with 0 errors, 0 warnings (except deprecated core imports if any)
 2. `cd lib/zipper && moon test` passes all tests
 3. `moon check` (canopy root) passes — no regressions
-4. `lib/zipper/pkg.generated.mbti` exports exactly: `RoseNode::new`, `RoseZipper::from_root`, `go_down`, `go_up`, `go_left`, `go_right`, `to_tree`, `replace`, `modify`, `depth`, `child_index`, `is_root`, `is_leaf`, `num_children`, `to_path`, `focus_at`
+4. `lib/zipper/pkg.generated.mbti` exports exactly: `RoseNode::RoseNode`, `RoseZipper::from_root`, `go_down`, `go_up`, `go_left`, `go_right`, `to_tree`, `replace`, `modify`, `depth`, `child_index`, `is_root`, `is_leaf`, `num_children`, `to_path`, `focus_at`
 
 ---
 
@@ -93,13 +93,13 @@ Create `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "RoseNode leaf and internal construction" {
-  let leaf = RoseNode::new(data=1)
+  let leaf = RoseNode::RoseNode(data=1)
   inspect(leaf.data, content="1")
   inspect(leaf.children.length(), content="0")
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   inspect(tree.children.length(), content="3")
   inspect(tree.children[1].data, content="2")
@@ -127,7 +127,7 @@ pub(all) struct RoseNode[T] {
 } derive(Debug, Eq)
 
 ///|
-pub fn[T] RoseNode::new(
+pub fn[T] RoseNode::RoseNode(
   data~ : T,
   children? : Array[RoseNode[T]] = [],
 ) -> RoseNode[T] {
@@ -166,7 +166,7 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "from_root creates zipper at root" {
-  let tree = RoseNode::new(data="hello")
+  let tree = RoseNode::RoseNode(data="hello")
   let z = RoseZipper::from_root(tree)
   inspect(z.focus.data, content="hello")
   inspect(z.depth(), content="0")
@@ -199,10 +199,10 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "go_down to first child" {
-  let tree = RoseNode::new(data="root", children=[
-    RoseNode::new(data="a"),
-    RoseNode::new(data="b"),
-    RoseNode::new(data="c"),
+  let tree = RoseNode::RoseNode(data="root", children=[
+    RoseNode::RoseNode(data="a"),
+    RoseNode::RoseNode(data="b"),
+    RoseNode::RoseNode(data="c"),
   ])
   let z = RoseZipper::from_root(tree)
   let z1 = z.go_down().unwrap()
@@ -211,10 +211,10 @@ test "go_down to first child" {
 }
 
 test "go_down with index" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=10),
-    RoseNode::new(data=20),
-    RoseNode::new(data=30),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=10),
+    RoseNode::RoseNode(data=20),
+    RoseNode::RoseNode(data=30),
   ])
   let z = RoseZipper::from_root(tree)
   let z2 = z.go_down(index=2).unwrap()
@@ -222,26 +222,26 @@ test "go_down with index" {
 }
 
 test "go_down boundary: leaf returns None" {
-  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  let z = RoseZipper::from_root(RoseNode::RoseNode(data=1))
   inspect(z.go_down(), content="None")
 }
 
 test "go_down boundary: negative index returns None" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.go_down(index=-1), content="None")
 }
 
 test "go_down boundary: out of bounds returns None" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.go_down(index=5), content="None")
 }
 
 test "go_up from child returns parent" {
-  let tree = RoseNode::new(data="root", children=[
-    RoseNode::new(data="a"),
-    RoseNode::new(data="b"),
+  let tree = RoseNode::RoseNode(data="root", children=[
+    RoseNode::RoseNode(data="a"),
+    RoseNode::RoseNode(data="b"),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   let z2 = z.go_up().unwrap()
@@ -250,15 +250,15 @@ test "go_up from child returns parent" {
 }
 
 test "go_up at root returns None" {
-  let z = RoseZipper::from_root(RoseNode::new(data=42))
+  let z = RoseZipper::from_root(RoseNode::RoseNode(data=42))
   inspect(z.go_up(), content="None")
 }
 
 test "go_down then go_up round-trip preserves tree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
-    RoseNode::new(data=3),
-    RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=5)]),
+    RoseNode::RoseNode(data=3),
+    RoseNode::RoseNode(data=4),
   ])
   let z = RoseZipper::from_root(tree)
   let z2 = z.go_down().unwrap().go_up().unwrap()
@@ -322,7 +322,7 @@ pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
       let children : Array[RoseNode[T]] = ctx.left.rev().to_array()
       children.push(self.focus)
       ctx.right.each(fn(n) { children.push(n) })
-      let parent = RoseNode::new(data=ctx.data, children~)
+      let parent = RoseNode::RoseNode(data=ctx.data, children~)
       Some({ focus: parent, path: rest, depth: self.depth - 1 })
     }
   }
@@ -355,10 +355,10 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "go_right traverses siblings" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   inspect(z.focus.data, content="1")
@@ -370,10 +370,10 @@ test "go_right traverses siblings" {
 }
 
 test "go_left traverses siblings backward" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down(index=2).unwrap()
   inspect(z.focus.data, content="3")
@@ -385,26 +385,26 @@ test "go_left traverses siblings backward" {
 }
 
 test "go_left at first child returns None" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   inspect(z.go_left(), content="None")
 }
 
 test "go_left and go_right at root return None" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.go_left(), content="None")
   inspect(z.go_right(), content="None")
 }
 
 test "go_right then go_left round-trip" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   let z2 = z.go_right().unwrap().go_left().unwrap()
@@ -412,10 +412,10 @@ test "go_right then go_left round-trip" {
 }
 
 test "lateral then up preserves tree" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree)
     .go_down().unwrap()
@@ -512,19 +512,19 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "to_tree from root is identity" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
-    RoseNode::new(data=3),
-    RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=5)]),
+    RoseNode::RoseNode(data=3),
+    RoseNode::RoseNode(data=4),
   ])
   assert_eq(RoseZipper::from_root(tree).to_tree(), tree)
 }
 
 test "to_tree from deep position reconstructs full tree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
-    RoseNode::new(data=3),
-    RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=5)]),
+    RoseNode::RoseNode(data=3),
+    RoseNode::RoseNode(data=4),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap().go_down().unwrap()
   inspect(z.focus.data, content="5")
@@ -532,12 +532,12 @@ test "to_tree from deep position reconstructs full tree" {
 }
 
 test "replace changes focused subtree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
-  let z2 = z.replace(RoseNode::new(data=99))
+  let z2 = z.replace(RoseNode::RoseNode(data=99))
   inspect(z2.focus.data, content="99")
   let rebuilt = z2.to_tree()
   inspect(rebuilt.children[1].data, content="99")
@@ -546,13 +546,13 @@ test "replace changes focused subtree" {
 }
 
 test "modify transforms focused subtree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
   let z2 = z.modify(fn(n) {
-    RoseNode::new(data=n.data * 10, children=n.children)
+    RoseNode::RoseNode(data=n.data * 10, children=n.children)
   })
   inspect(z2.focus.data, content="30")
   // verify modify propagates through to_tree
@@ -562,18 +562,18 @@ test "modify transforms focused subtree" {
 }
 
 test "replace at root" {
-  let tree = RoseNode::new(data=1)
+  let tree = RoseNode::RoseNode(data=1)
   let z = RoseZipper::from_root(tree)
-  let z2 = z.replace(RoseNode::new(data=99))
+  let z2 = z.replace(RoseNode::RoseNode(data=99))
   inspect(z2.focus.data, content="99")
-  assert_eq(z2.to_tree(), RoseNode::new(data=99))
+  assert_eq(z2.to_tree(), RoseNode::RoseNode(data=99))
 }
 
 test "modify at root" {
-  let tree = RoseNode::new(data=5, children=[RoseNode::new(data=10)])
+  let tree = RoseNode::RoseNode(data=5, children=[RoseNode::RoseNode(data=10)])
   let z = RoseZipper::from_root(tree)
   let z2 = z.modify(fn(n) {
-    RoseNode::new(data=n.data * 2, children=n.children)
+    RoseNode::RoseNode(data=n.data * 2, children=n.children)
   })
   let rebuilt = z2.to_tree()
   inspect(rebuilt.data, content="10")
@@ -646,8 +646,8 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "depth tracks navigation depth" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1, children=[RoseNode::new(data=2)]),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1, children=[RoseNode::RoseNode(data=2)]),
   ])
   let z = RoseZipper::from_root(tree)
   inspect(z.depth(), content="0")
@@ -658,10 +658,10 @@ test "depth tracks navigation depth" {
 }
 
 test "child_index tracks position among siblings" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree)
   inspect(z.child_index(), content="None")
@@ -674,7 +674,7 @@ test "child_index tracks position among siblings" {
 }
 
 test "is_root and is_leaf" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.is_root(), content="true")
   inspect(z.is_leaf(), content="false")
@@ -684,9 +684,9 @@ test "is_root and is_leaf" {
 }
 
 test "num_children" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree)
   inspect(z.num_children(), content="2")
@@ -760,12 +760,12 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "to_path returns child indices from root" {
-  let tree = RoseNode::new(data="r", children=[
-    RoseNode::new(data="a", children=[
-      RoseNode::new(data="x"),
-      RoseNode::new(data="y"),
+  let tree = RoseNode::RoseNode(data="r", children=[
+    RoseNode::RoseNode(data="a", children=[
+      RoseNode::RoseNode(data="x"),
+      RoseNode::RoseNode(data="y"),
     ]),
-    RoseNode::new(data="b"),
+    RoseNode::RoseNode(data="b"),
   ])
   let z = RoseZipper::from_root(tree)
     .go_down().unwrap()
@@ -775,17 +775,17 @@ test "to_path returns child indices from root" {
 }
 
 test "to_path at root is empty" {
-  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  let z = RoseZipper::from_root(RoseNode::RoseNode(data=1))
   inspect(z.to_path(), content="[]")
 }
 
 test "focus_at navigates to position" {
-  let tree = RoseNode::new(data="r", children=[
-    RoseNode::new(data="a", children=[
-      RoseNode::new(data="x"),
-      RoseNode::new(data="y"),
+  let tree = RoseNode::RoseNode(data="r", children=[
+    RoseNode::RoseNode(data="a", children=[
+      RoseNode::RoseNode(data="x"),
+      RoseNode::RoseNode(data="y"),
     ]),
-    RoseNode::new(data="b"),
+    RoseNode::RoseNode(data="b"),
   ])
   let z = RoseZipper::focus_at(tree, [0, 1]).unwrap()
   inspect(z.focus.data, content="y")
@@ -793,15 +793,15 @@ test "focus_at navigates to position" {
 }
 
 test "focus_at with empty path stays at root" {
-  let tree = RoseNode::new(data=1)
+  let tree = RoseNode::RoseNode(data=1)
   let z = RoseZipper::focus_at(tree, []).unwrap()
   inspect(z.focus.data, content="1")
   inspect(z.is_root(), content="true")
 }
 
 test "focus_at returns None on invalid path" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
   ])
   inspect(RoseZipper::focus_at(tree, [0, 5]), content="None")
   inspect(RoseZipper::focus_at(tree, [3]), content="None")
@@ -809,12 +809,12 @@ test "focus_at returns None on invalid path" {
 }
 
 test "to_path and focus_at round-trip" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1, children=[
-      RoseNode::new(data=3),
-      RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1, children=[
+      RoseNode::RoseNode(data=3),
+      RoseNode::RoseNode(data=4),
     ]),
-    RoseNode::new(data=2),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree)
     .go_down().unwrap()
@@ -895,9 +895,9 @@ Append to `lib/zipper/zipper_test.mbt`:
 
 ```moonbit
 test "persistence: old zipper unchanged after navigation" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree)
   let z1 = z.go_down().unwrap()
@@ -970,7 +970,7 @@ Expected: PASS
 Run: `cat lib/zipper/pkg.generated.mbti`
 
 Verify the public API matches the spec:
-- `RoseNode::new`
+- `RoseNode::RoseNode`
 - `RoseZipper::from_root`, `go_down`, `go_up`, `go_left`, `go_right`
 - `RoseZipper::to_tree`, `replace`, `modify`
 - `RoseZipper::depth`, `child_index`, `is_root`, `is_leaf`, `num_children`

--- a/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
+++ b/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
@@ -70,7 +70,7 @@ pub fn[T] RoseNode::RoseNode(data~ : T, children? : Array[RoseNode[T]] = []) -> 
 pub fn[T] RoseZipper::from_root(tree : RoseNode[T]) -> RoseZipper[T]
 ```
 
-`RoseNode::RoseNode(data=x)` creates a leaf. `RoseNode::RoseNode(data=x, children=kids)` creates an internal node.
+`RoseNode(data=x)` creates a leaf. `RoseNode(data=x, children=kids)` creates an internal node.
 
 ### Navigation
 

--- a/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
+++ b/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
@@ -33,9 +33,9 @@ The zipper is then: `(Focus, List[Context])` — the focused subtree plus a stac
 pub(all) struct RoseNode[T] {
   data : T
   children : Array[RoseNode[T]]
-
-  fn new(data~ : T, children? : Array[RoseNode[T]] = []) -> RoseNode[T]
 } derive(Debug, Eq)
+
+fn[T] RoseNode::RoseNode(data~ : T, children? : Array[RoseNode[T]] = []) -> RoseNode[T]
 
 pub(all) struct RoseCtx[T] {
   data : T
@@ -70,7 +70,7 @@ pub fn[T] RoseNode::RoseNode(data~ : T, children? : Array[RoseNode[T]] = []) -> 
 pub fn[T] RoseZipper::from_root(tree : RoseNode[T]) -> RoseZipper[T]
 ```
 
-`RoseNode(data=x)` creates a leaf. `RoseNode(data=x, children=kids)` creates an internal node.
+`RoseNode::RoseNode(data=x)` creates a leaf. `RoseNode::RoseNode(data=x, children=kids)` creates an internal node.
 
 ### Navigation
 
@@ -163,7 +163,7 @@ ProjNode stays separate. The zipper library does not depend on canopy/core. When
 ```moonbit
 // In canopy/core or consumer package — NOT in lib/zipper
 fn proj_to_rose[T](p : ProjNode[T]) -> @zipper.RoseNode[ProjData[T]] {
-  @zipper.RoseNode(
+  @zipper.RoseNode::RoseNode(
     data=ProjData(node_id=p.node_id, kind=p.kind, start=p.start, end=p.end),
     children=p.children.map(proj_to_rose),
   )
@@ -193,7 +193,7 @@ The O(n) conversion cost is paid once, duplicating the tree into `RoseNode` form
 
 1. ~~`derive(Show, Eq)` through `@list.List[RoseNode[T]]` nesting~~ — resolved: use `derive(Debug, Eq)` + manual `Show` impl via `@debug.to_string`.
 2. ~~`@list.List` pattern syntax~~ — resolved: `Empty` and `More(head, tail=rest)` for matching; `@list.cons()` and `@list.List::default()` for construction.
-3. ~~`fn new()` declaration-inside-struct with generic type parameters~~ — resolved: define constructor outside struct as `fn[T] RoseNode::RoseNode(...)`.
+3. ~~declaration-inside-struct constructor with generic type parameters~~ — resolved: define constructor outside struct as `fn[T] RoseNode::RoseNode(...)`.
 4. ~~`go_down(index? : Int = 0)` optional parameter~~ — resolved: use `?` syntax, not `~`.
 
 ## What Phase 1 Does NOT Include

--- a/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
+++ b/docs/superpowers/specs/2026-04-07-rose-tree-zipper-library-design.md
@@ -66,7 +66,7 @@ pub(all) struct RoseZipper[T] {
 ### Construction
 
 ```moonbit
-pub fn[T] RoseNode::new(data~ : T, children? : Array[RoseNode[T]] = []) -> RoseNode[T]
+pub fn[T] RoseNode::RoseNode(data~ : T, children? : Array[RoseNode[T]] = []) -> RoseNode[T]
 pub fn[T] RoseZipper::from_root(tree : RoseNode[T]) -> RoseZipper[T]
 ```
 
@@ -193,7 +193,7 @@ The O(n) conversion cost is paid once, duplicating the tree into `RoseNode` form
 
 1. ~~`derive(Show, Eq)` through `@list.List[RoseNode[T]]` nesting~~ — resolved: use `derive(Debug, Eq)` + manual `Show` impl via `@debug.to_string`.
 2. ~~`@list.List` pattern syntax~~ — resolved: `Empty` and `More(head, tail=rest)` for matching; `@list.cons()` and `@list.List::default()` for construction.
-3. ~~`fn new()` declaration-inside-struct with generic type parameters~~ — resolved: define constructor outside struct as `fn[T] RoseNode::new(...)`.
+3. ~~`fn new()` declaration-inside-struct with generic type parameters~~ — resolved: define constructor outside struct as `fn[T] RoseNode::RoseNode(...)`.
 4. ~~`go_down(index? : Int = 0)` optional parameter~~ — resolved: use `?` syntax, not `~`.
 
 ## What Phase 1 Does NOT Include

--- a/lib/zipper/README.md
+++ b/lib/zipper/README.md
@@ -6,7 +6,7 @@ This is a foundational data structure, used wherever code needs to express navig
 
 ## Public API
 
-- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode::new(data~, children?~)`
+- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode(data=..., children=...)`
 - `RoseZipper[T]` — focused navigation state; build with `RoseZipper::from_root(node)`
 - `go_up`, `go_down(index?)`, `go_left`, `go_right` — return `Self?`, `None` when the move is impossible
 - `focus_at(node, path)` — jump to a position by index path; `to_path(self)` is its inverse

--- a/lib/zipper/README.md
+++ b/lib/zipper/README.md
@@ -6,7 +6,7 @@ This is a foundational data structure, used wherever code needs to express navig
 
 ## Public API
 
-- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode(data=..., children=...)`
+- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode::RoseNode(data=..., children=...)`
 - `RoseZipper[T]` — focused navigation state; build with `RoseZipper::from_root(node)`
 - `go_up`, `go_down(index?)`, `go_left`, `go_right` — return `Self?`, `None` when the move is impossible
 - `focus_at(node, path)` — jump to a position by index path; `to_path(self)` is its inverse

--- a/lib/zipper/README.md
+++ b/lib/zipper/README.md
@@ -6,7 +6,7 @@ This is a foundational data structure, used wherever code needs to express navig
 
 ## Public API
 
-- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode::RoseNode(data=..., children=...)`
+- `RoseNode[T]` — immutable tree node (`data : T`, `children : Array[Self[T]]`); construct with `RoseNode(data=..., children=...)`
 - `RoseZipper[T]` — focused navigation state; build with `RoseZipper::from_root(node)`
 - `go_up`, `go_down(index?)`, `go_left`, `go_right` — return `Self?`, `None` when the move is impossible
 - `focus_at(node, path)` — jump to a position by index path; `to_path(self)` is its inverse

--- a/lib/zipper/navigate.mbt
+++ b/lib/zipper/navigate.mbt
@@ -46,7 +46,7 @@ pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
       children.rev_in_place() // left was stored nearest-first; restore tree order
       children.push(self.focus)
       ctx.right.each(fn(n) { children.push(n) })
-      let parent = RoseNode::new(data=ctx.data, children~)
+      let parent = RoseNode(data=ctx.data, children~)
       Some({ focus: parent, path: rest, depth: self.depth - 1 })
     }
   }

--- a/lib/zipper/navigate.mbt
+++ b/lib/zipper/navigate.mbt
@@ -46,7 +46,7 @@ pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
       children.rev_in_place() // left was stored nearest-first; restore tree order
       children.push(self.focus)
       ctx.right.each(fn(n) { children.push(n) })
-      let parent = RoseNode::RoseNode(data=ctx.data, children~)
+      let parent = RoseNode(data=ctx.data, children~)
       Some({ focus: parent, path: rest, depth: self.depth - 1 })
     }
   }

--- a/lib/zipper/navigate.mbt
+++ b/lib/zipper/navigate.mbt
@@ -46,7 +46,7 @@ pub fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
       children.rev_in_place() // left was stored nearest-first; restore tree order
       children.push(self.focus)
       ctx.right.each(fn(n) { children.push(n) })
-      let parent = RoseNode(data=ctx.data, children~)
+      let parent = RoseNode::RoseNode(data=ctx.data, children~)
       Some({ focus: parent, path: rest, depth: self.depth - 1 })
     }
   }

--- a/lib/zipper/pkg.generated.mbti
+++ b/lib/zipper/pkg.generated.mbti
@@ -23,7 +23,8 @@ pub(all) struct RoseNode[T] {
   data : T
   children : Array[RoseNode[T]]
 } derive(Eq, @debug.Debug)
-pub fn[T] RoseNode::new(data~ : T, children? : Array[Self[T]]) -> Self[T]
+pub fn[T] RoseNode::RoseNode(data~ : T, children? : Array[Self[T]]) -> Self[T]
+pub fn[T, U] RoseNode::map(Self[T], (T) -> U raise?) -> Self[U] raise?
 pub impl[T : @debug.Debug] Show for RoseNode[T]
 
 pub(all) struct RoseZipper[T] {

--- a/lib/zipper/rose_node.mbt
+++ b/lib/zipper/rose_node.mbt
@@ -27,11 +27,19 @@ pub impl[T : Debug] Show for RoseNode[T] with fn output(self, logger) {
 }
 
 ///|
-pub fn[T] RoseNode::new(
+pub fn[T] RoseNode::RoseNode(
   data~ : T,
   children? : Array[RoseNode[T]] = [],
 ) -> RoseNode[T] {
   { data, children }
+}
+
+///|
+pub fn[T, U] RoseNode::map(
+  self : RoseNode[T],
+  f : (T) -> U raise?,
+) -> RoseNode[U] raise? {
+  RoseNode(data=f(self.data), children=self.children.map(child => child.map(f)))
 }
 
 ///|

--- a/lib/zipper/rose_node.mbt
+++ b/lib/zipper/rose_node.mbt
@@ -39,7 +39,7 @@ pub fn[T, U] RoseNode::map(
   self : RoseNode[T],
   f : (T) -> U raise?,
 ) -> RoseNode[U] raise? {
-  RoseNode::RoseNode(data=f(self.data), children=self.children.map(child => child.map(f)))
+  RoseNode(data=f(self.data), children=self.children.map(child => child.map(f)))
 }
 
 ///|

--- a/lib/zipper/rose_node.mbt
+++ b/lib/zipper/rose_node.mbt
@@ -39,7 +39,7 @@ pub fn[T, U] RoseNode::map(
   self : RoseNode[T],
   f : (T) -> U raise?,
 ) -> RoseNode[U] raise? {
-  RoseNode(data=f(self.data), children=self.children.map(child => child.map(f)))
+  RoseNode::RoseNode(data=f(self.data), children=self.children.map(child => child.map(f)))
 }
 
 ///|

--- a/lib/zipper/zipper_properties_wbtest.mbt
+++ b/lib/zipper/zipper_properties_wbtest.mbt
@@ -6,18 +6,18 @@
 /// Bounded-depth recursive generator for RoseNode[Int] trees.
 fn gen_rose_node(rs : @splitmix.RandomState, depth : Int) -> RoseNode[Int] {
   if depth <= 0 {
-    RoseNode(data=rs.split().next_positive_int() % 100)
+    RoseNode::RoseNode(data=rs.split().next_positive_int() % 100)
   } else {
     let coin = rs.split().next_positive_int() % 3
     if coin == 0 {
-      RoseNode(data=rs.split().next_positive_int() % 100)
+      RoseNode::RoseNode(data=rs.split().next_positive_int() % 100)
     } else {
       let child_count = rs.split().next_positive_int() % 4
       let children : Array[RoseNode[Int]] = []
       for _ in 0..<child_count {
         children.push(gen_rose_node(rs.split(), depth - 1))
       }
-      RoseNode(data=rs.split().next_positive_int() % 100, children~)
+      RoseNode::RoseNode(data=rs.split().next_positive_int() % 100, children~)
     }
   }
 }

--- a/lib/zipper/zipper_properties_wbtest.mbt
+++ b/lib/zipper/zipper_properties_wbtest.mbt
@@ -6,18 +6,18 @@
 /// Bounded-depth recursive generator for RoseNode[Int] trees.
 fn gen_rose_node(rs : @splitmix.RandomState, depth : Int) -> RoseNode[Int] {
   if depth <= 0 {
-    RoseNode::RoseNode(data=rs.split().next_positive_int() % 100)
+    RoseNode(data=rs.split().next_positive_int() % 100)
   } else {
     let coin = rs.split().next_positive_int() % 3
     if coin == 0 {
-      RoseNode::RoseNode(data=rs.split().next_positive_int() % 100)
+      RoseNode(data=rs.split().next_positive_int() % 100)
     } else {
       let child_count = rs.split().next_positive_int() % 4
       let children : Array[RoseNode[Int]] = []
       for _ in 0..<child_count {
         children.push(gen_rose_node(rs.split(), depth - 1))
       }
-      RoseNode::RoseNode(data=rs.split().next_positive_int() % 100, children~)
+      RoseNode(data=rs.split().next_positive_int() % 100, children~)
     }
   }
 }

--- a/lib/zipper/zipper_properties_wbtest.mbt
+++ b/lib/zipper/zipper_properties_wbtest.mbt
@@ -6,18 +6,18 @@
 /// Bounded-depth recursive generator for RoseNode[Int] trees.
 fn gen_rose_node(rs : @splitmix.RandomState, depth : Int) -> RoseNode[Int] {
   if depth <= 0 {
-    RoseNode::new(data=rs.split().next_positive_int() % 100)
+    RoseNode(data=rs.split().next_positive_int() % 100)
   } else {
     let coin = rs.split().next_positive_int() % 3
     if coin == 0 {
-      RoseNode::new(data=rs.split().next_positive_int() % 100)
+      RoseNode(data=rs.split().next_positive_int() % 100)
     } else {
       let child_count = rs.split().next_positive_int() % 4
       let children : Array[RoseNode[Int]] = []
       for _ in 0..<child_count {
         children.push(gen_rose_node(rs.split(), depth - 1))
       }
-      RoseNode::new(data=rs.split().next_positive_int() % 100, children~)
+      RoseNode(data=rs.split().next_positive_int() % 100, children~)
     }
   }
 }

--- a/lib/zipper/zipper_test.mbt
+++ b/lib/zipper/zipper_test.mbt
@@ -1,20 +1,42 @@
 ///|
 test "RoseNode leaf and internal construction" {
-  let leaf = RoseNode::new(data=1)
+  let leaf = RoseNode::RoseNode(data=1)
   inspect(leaf.data, content="1")
   inspect(leaf.children.length(), content="0")
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   inspect(tree.children.length(), content="3")
   inspect(tree.children[1].data, content="2")
 }
 
 ///|
+test "RoseNode map transforms leaf and children data" {
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3, children=[RoseNode::RoseNode(data=4)]),
+  ])
+  let mapped = tree.map(x => x.to_string())
+  inspect(mapped.data, content="1")
+  inspect(mapped.children[0].data, content="2")
+  inspect(mapped.children[1].data, content="3")
+  inspect(mapped.children[1].children[0].data, content="4")
+}
+
+///|
+test "RoseNode map identity preserves tree" {
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=3)]),
+  ])
+  assert_eq(tree.map(x => x), tree)
+}
+
+///|
 test "from_root creates zipper at root" {
-  let tree = RoseNode::new(data="hello")
+  let tree = RoseNode::RoseNode(data="hello")
   let z = RoseZipper::from_root(tree)
   inspect(z.focus.data, content="hello")
   inspect(z.depth, content="0")
@@ -22,10 +44,10 @@ test "from_root creates zipper at root" {
 
 ///|
 test "go_down to first child" {
-  let tree = RoseNode::new(data="root", children=[
-    RoseNode::new(data="a"),
-    RoseNode::new(data="b"),
-    RoseNode::new(data="c"),
+  let tree = RoseNode::RoseNode(data="root", children=[
+    RoseNode::RoseNode(data="a"),
+    RoseNode::RoseNode(data="b"),
+    RoseNode::RoseNode(data="c"),
   ])
   let z = RoseZipper::from_root(tree)
   let z1 = z.go_down().unwrap()
@@ -35,10 +57,10 @@ test "go_down to first child" {
 
 ///|
 test "go_down with index" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=10),
-    RoseNode::new(data=20),
-    RoseNode::new(data=30),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=10),
+    RoseNode::RoseNode(data=20),
+    RoseNode::RoseNode(data=30),
   ])
   let z = RoseZipper::from_root(tree)
   let z2 = z.go_down(index=2).unwrap()
@@ -47,29 +69,29 @@ test "go_down with index" {
 
 ///|
 test "go_down boundary: leaf returns None" {
-  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  let z = RoseZipper::from_root(RoseNode::RoseNode(data=1))
   inspect(z.go_down() is None, content="true")
 }
 
 ///|
 test "go_down boundary: negative index returns None" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.go_down(index=-1) is None, content="true")
 }
 
 ///|
 test "go_down boundary: out of bounds returns None" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.go_down(index=5) is None, content="true")
 }
 
 ///|
 test "go_up from child returns parent" {
-  let tree = RoseNode::new(data="root", children=[
-    RoseNode::new(data="a"),
-    RoseNode::new(data="b"),
+  let tree = RoseNode::RoseNode(data="root", children=[
+    RoseNode::RoseNode(data="a"),
+    RoseNode::RoseNode(data="b"),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   let z2 = z.go_up().unwrap()
@@ -79,16 +101,16 @@ test "go_up from child returns parent" {
 
 ///|
 test "go_up at root returns None" {
-  let z = RoseZipper::from_root(RoseNode::new(data=42))
+  let z = RoseZipper::from_root(RoseNode::RoseNode(data=42))
   inspect(z.go_up() is None, content="true")
 }
 
 ///|
 test "go_down then go_up round-trip preserves tree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
-    RoseNode::new(data=3),
-    RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=5)]),
+    RoseNode::RoseNode(data=3),
+    RoseNode::RoseNode(data=4),
   ])
   let z = RoseZipper::from_root(tree)
   let z2 = z.go_down().unwrap().go_up().unwrap()
@@ -97,10 +119,10 @@ test "go_down then go_up round-trip preserves tree" {
 
 ///|
 test "go_right traverses siblings" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   inspect(z.focus.data, content="1")
@@ -113,10 +135,10 @@ test "go_right traverses siblings" {
 
 ///|
 test "go_left traverses siblings backward" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down(index=2).unwrap()
   inspect(z.focus.data, content="3")
@@ -129,9 +151,9 @@ test "go_left traverses siblings backward" {
 
 ///|
 test "go_left at first child returns None" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   inspect(z.go_left() is None, content="true")
@@ -139,7 +161,7 @@ test "go_left at first child returns None" {
 
 ///|
 test "go_left and go_right at root return None" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.go_left() is None, content="true")
   inspect(z.go_right() is None, content="true")
@@ -147,10 +169,10 @@ test "go_left and go_right at root return None" {
 
 ///|
 test "go_right then go_left round-trip" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap()
   let z2 = z.go_right().unwrap().go_left().unwrap()
@@ -159,10 +181,10 @@ test "go_right then go_left round-trip" {
 
 ///|
 test "lateral then up preserves tree" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree)
     .go_down()
@@ -176,20 +198,20 @@ test "lateral then up preserves tree" {
 
 ///|
 test "to_tree from root is identity" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
-    RoseNode::new(data=3),
-    RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=5)]),
+    RoseNode::RoseNode(data=3),
+    RoseNode::RoseNode(data=4),
   ])
   assert_eq(RoseZipper::from_root(tree).to_tree(), tree)
 }
 
 ///|
 test "to_tree from deep position reconstructs full tree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2, children=[RoseNode::new(data=5)]),
-    RoseNode::new(data=3),
-    RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2, children=[RoseNode::RoseNode(data=5)]),
+    RoseNode::RoseNode(data=3),
+    RoseNode::RoseNode(data=4),
   ])
   let z = RoseZipper::from_root(tree).go_down().unwrap().go_down().unwrap()
   inspect(z.focus.data, content="5")
@@ -198,12 +220,12 @@ test "to_tree from deep position reconstructs full tree" {
 
 ///|
 test "replace changes focused subtree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
-  let z2 = z.replace(RoseNode::new(data=99))
+  let z2 = z.replace(RoseNode::RoseNode(data=99))
   inspect(z2.focus.data, content="99")
   let rebuilt = z2.to_tree()
   inspect(rebuilt.children[1].data, content="99")
@@ -213,13 +235,13 @@ test "replace changes focused subtree" {
 
 ///|
 test "modify transforms focused subtree" {
-  let tree = RoseNode::new(data=1, children=[
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=1, children=[
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree).go_down(index=1).unwrap()
   let z2 = z.modify(fn(n) {
-    RoseNode::new(data=n.data * 10, children=n.children)
+    RoseNode::RoseNode(data=n.data * 10, children=n.children)
   })
   inspect(z2.focus.data, content="30")
   // verify modify propagates through to_tree
@@ -230,19 +252,19 @@ test "modify transforms focused subtree" {
 
 ///|
 test "replace at root" {
-  let tree = RoseNode::new(data=1)
+  let tree = RoseNode::RoseNode(data=1)
   let z = RoseZipper::from_root(tree)
-  let z2 = z.replace(RoseNode::new(data=99))
+  let z2 = z.replace(RoseNode::RoseNode(data=99))
   inspect(z2.focus.data, content="99")
-  assert_eq(z2.to_tree(), RoseNode::new(data=99))
+  assert_eq(z2.to_tree(), RoseNode::RoseNode(data=99))
 }
 
 ///|
 test "modify at root" {
-  let tree = RoseNode::new(data=5, children=[RoseNode::new(data=10)])
+  let tree = RoseNode::RoseNode(data=5, children=[RoseNode::RoseNode(data=10)])
   let z = RoseZipper::from_root(tree)
   let z2 = z.modify(fn(n) {
-    RoseNode::new(data=n.data * 2, children=n.children)
+    RoseNode::RoseNode(data=n.data * 2, children=n.children)
   })
   let rebuilt = z2.to_tree()
   inspect(rebuilt.data, content="10")
@@ -251,8 +273,8 @@ test "modify at root" {
 
 ///|
 test "depth tracks navigation depth" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1, children=[RoseNode::new(data=2)]),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1, children=[RoseNode::RoseNode(data=2)]),
   ])
   let z = RoseZipper::from_root(tree)
   inspect(z.depth(), content="0")
@@ -264,10 +286,10 @@ test "depth tracks navigation depth" {
 
 ///|
 test "child_index tracks position among siblings" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
-    RoseNode::new(data=3),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
+    RoseNode::RoseNode(data=3),
   ])
   let z = RoseZipper::from_root(tree)
   inspect(z.child_index() is None, content="true")
@@ -281,7 +303,7 @@ test "child_index tracks position among siblings" {
 
 ///|
 test "is_root and is_leaf" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   let z = RoseZipper::from_root(tree)
   inspect(z.is_root(), content="true")
   inspect(z.is_leaf(), content="false")
@@ -292,9 +314,9 @@ test "is_root and is_leaf" {
 
 ///|
 test "num_children" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree)
   inspect(z.num_children(), content="2")
@@ -304,12 +326,12 @@ test "num_children" {
 
 ///|
 test "to_path returns child indices from root" {
-  let tree = RoseNode::new(data="r", children=[
-    RoseNode::new(data="a", children=[
-      RoseNode::new(data="x"),
-      RoseNode::new(data="y"),
+  let tree = RoseNode::RoseNode(data="r", children=[
+    RoseNode::RoseNode(data="a", children=[
+      RoseNode::RoseNode(data="x"),
+      RoseNode::RoseNode(data="y"),
     ]),
-    RoseNode::new(data="b"),
+    RoseNode::RoseNode(data="b"),
   ])
   let z = RoseZipper::from_root(tree)
     .go_down()
@@ -322,18 +344,18 @@ test "to_path returns child indices from root" {
 
 ///|
 test "to_path at root is empty" {
-  let z = RoseZipper::from_root(RoseNode::new(data=1))
+  let z = RoseZipper::from_root(RoseNode::RoseNode(data=1))
   @debug.debug_inspect(z.to_path(), content="[]")
 }
 
 ///|
 test "focus_at navigates to position" {
-  let tree = RoseNode::new(data="r", children=[
-    RoseNode::new(data="a", children=[
-      RoseNode::new(data="x"),
-      RoseNode::new(data="y"),
+  let tree = RoseNode::RoseNode(data="r", children=[
+    RoseNode::RoseNode(data="a", children=[
+      RoseNode::RoseNode(data="x"),
+      RoseNode::RoseNode(data="y"),
     ]),
-    RoseNode::new(data="b"),
+    RoseNode::RoseNode(data="b"),
   ])
   let z = RoseZipper::focus_at(tree, [0, 1]).unwrap()
   inspect(z.focus.data, content="y")
@@ -342,7 +364,7 @@ test "focus_at navigates to position" {
 
 ///|
 test "focus_at with empty path stays at root" {
-  let tree = RoseNode::new(data=1)
+  let tree = RoseNode::RoseNode(data=1)
   let z = RoseZipper::focus_at(tree, []).unwrap()
   inspect(z.focus.data, content="1")
   inspect(z.is_root(), content="true")
@@ -350,7 +372,7 @@ test "focus_at with empty path stays at root" {
 
 ///|
 test "focus_at returns None on invalid path" {
-  let tree = RoseNode::new(data=0, children=[RoseNode::new(data=1)])
+  let tree = RoseNode::RoseNode(data=0, children=[RoseNode::RoseNode(data=1)])
   inspect(RoseZipper::focus_at(tree, [0, 5]) is None, content="true")
   inspect(RoseZipper::focus_at(tree, [3]) is None, content="true")
   inspect(RoseZipper::focus_at(tree, [-1]) is None, content="true")
@@ -358,12 +380,12 @@ test "focus_at returns None on invalid path" {
 
 ///|
 test "to_path and focus_at round-trip" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1, children=[
-      RoseNode::new(data=3),
-      RoseNode::new(data=4),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1, children=[
+      RoseNode::RoseNode(data=3),
+      RoseNode::RoseNode(data=4),
     ]),
-    RoseNode::new(data=2),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree)
     .go_down()
@@ -378,9 +400,9 @@ test "to_path and focus_at round-trip" {
 
 ///|
 test "persistence: old zipper unchanged after navigation" {
-  let tree = RoseNode::new(data=0, children=[
-    RoseNode::new(data=1),
-    RoseNode::new(data=2),
+  let tree = RoseNode::RoseNode(data=0, children=[
+    RoseNode::RoseNode(data=1),
+    RoseNode::RoseNode(data=2),
   ])
   let z = RoseZipper::from_root(tree)
   let z1 = z.go_down().unwrap()


### PR DESCRIPTION
## Summary
- add RoseNode::map for structure-preserving data transformation
- migrate RoseNode::new to MoonBit custom constructor RoseNode::RoseNode / RoseNode(...)
- update zipper tests, generated interface, and zipper docs

Closes #760

## Verification
- MOON_WORK=off moon -C lib/zipper check --deny-warn
- MOON_WORK=off moon -C lib/zipper test (38 passed, 0 failed)

## Notes
- Staged/committed only the intended zipper/docs files; local submodule dirtiness is unstaged and not part of this PR.
- Codex pre-PR review was attempted but unavailable due MCP timeouts/model support; local checks above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tree-mapping capability so node values can be transformed across an entire structure.
  * Updated node creation to use a clearer constructor style in the public API.

* **Documentation**
  * Aligned library docs and design notes with the updated constructor and mapping behavior.

* **Tests**
  * Expanded and updated coverage for tree construction, navigation, persistence, and subtree updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->