### PR TITLE
Gate SDEG heading side table lifecycle on parse validity

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -543,9 +543,10 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 ## 22. SDEG Lifecycle
 
 - [ ] Distinguish delete from malformed transient absence (#748).
-  Why: The lifecycle `Missing` state conflates a committed delete with a transient parse failure. Both produce zero current observations, but delete should progress toward retirement while a transient absence should recover when the observation reappears. The side table and its consumer cannot tell the difference today.
-  Plan: Invariant review G2 blocks this; the likely fix needs edit provenance or a validity flag on the projection snapshot before `advance` is called.
-  Exit: `Missing` rows created by different stimuli (delete vs malformed) can be distinguished, or a documented rationale accepts the conflation as a known limitation.
+  Why: The lifecycle `Missing` state conflates a committed delete with a transient parse failure. Both produce zero current observations, but delete should progress toward retirement while a transient absence should recover when the observation reappears.
+  Progress: The side-table API now accepts `is_valid_parse` on initial construction and `advance`. Invalid snapshots hold the lifecycle, create no durable rows, preserve `last_live`, and do not advance absence counters or retirement.
+  Remaining: Wire the production caller to pass parser/projection validity before calling `advance`; until then, the side-table support is tested but not end-to-end.
+  Exit: production wiring passes validity so valid deletes advance while invalid/malformed snapshots hold, or a documented rationale accepts any remaining conflation as a known limitation.
 
 ## Shipped history
 

--- a/docs/design/sdeg-invariant-review.md
+++ b/docs/design/sdeg-invariant-review.md
@@ -533,11 +533,12 @@ ordering. · *Existing evidence:* edit-path tests run advance *after* `SyncEdito
 
 **Y3 — post-reconciliation ordering.**
 advance consumes observations only after parse + projection reconciliation. ·
-*Preserved by:* convention (the pipeline diagram). · *Existing evidence:*
-companion edit-path test derives observations after `SyncEditor`. · *Missing:*
-the **"successful projection snapshot" precondition is unencoded** — advance has
-no validity flag, so a failed/partial parse can be fed in and misfire the
-lifecycle (G11).
+*Preserved by:* convention (the pipeline diagram) plus the side-table
+`is_valid_parse` hold path. · *Existing evidence:* companion edit-path test
+derives observations after `SyncEditor`; #748 wbtests cover invalid snapshots
+that must not advance the lifecycle. · *Missing:* production wiring still must
+source and pass parser/projection validity when the table graduates from
+test-local use (G11).
 
 **Y4 — (DEFERRED/UNTESTABLE) reload + peer stability.**
 Out of scope by design; no durable anchor, deterministic key, or persistent
@@ -563,9 +564,9 @@ required" = the evidence the matcher needs to make the right call.
 | **rename** (`# A`→`# A2`) | signature (level+text), source range, token spans, recorded evidence | `stable_id`, current `NodeId` (same-node), `Live`, one-to-one anchor | `HeadingSameNodeId` (NodeId survives the edit path) | if `NodeId` were freshened, rename ≡ delete+spawn → identity lost. *Holds today* (Phase 0 + edit-path rename test). |
 | **reorder** (`# A\n# B`→`# B\n# A`) | ordinal/position; which `ProjNode` each `NodeId` attaches to | (today) *nothing semantic* — explicitly "position-stable, not semantic-stable" | would need explicit **move provenance** (`IdentityTransform::Move`); side-table-only has none | **silent semantic misattribution** — all structural invariants green, meaning wrong (I5/Sem3). Corrected by the explicit block-move path for root siblings (#723) and same-list items (#731); cross-container / list-container moves stay rejected — see *Decision: Markdown move-provenance scope* (#724). |
 | **duplicate** (`# A\n# A`) | confidence → `Ambiguous`; candidate set | distinct `stable_id` per distinct `NodeId` while both present; one-to-one (I4) | `HeadingSameSemanticKey` collision + `CandidateCount>1` | guessing → two rows on one node, or restore to wrong twin. *Avoided* by staying `Ambiguous` (duplicate test). Spurious collision if normalization is loose (Sem4). |
-| **delete** (`# A` removed) | status `Live→Missing→Tombstoned`; `current_id→None` | `stable_id`; `last_live` (recovery substrate) | `CandidateCount(0)` | **`Missing` conflates delete with malformed absence** (G2); committed delete also drops the projection baseline (Phase 0), so SDEG's retained `last_live` is the *only* recovery path. |
+| **delete** (`# A` removed) | status `Live→Missing→Tombstoned`; `current_id→None` | `stable_id`; `last_live` (recovery substrate) | `CandidateCount(0)` from a valid snapshot | committed delete also drops the projection baseline (Phase 0), so SDEG's retained `last_live` is the *only* recovery path; delete evidence must come from a valid snapshot. |
 | **restore** (deleted heading re-typed) | a new current `NodeId` (in the tested path); status →`Live` | original `stable_id` recovered iff a *unique semantic candidate* exists while the prior node is absent (freshness not required) | `HeadingSameSemanticKey` + unique candidate | duplicate text → stays `Ambiguous` (no guess); different normalization → spawns fresh (not recovered); only works before `Retired`/GC. |
-| **malformed input recovery** | transient `Missing`, then re-`Live` | `stable_id` across the bad window; ideally `NodeId` via `ProjectionIdentityTracker` | NodeId survival (delegated to loom) or semantic recovery | premature `Tombstoned` if absent > ladder; **indistinguishable from delete** (G2); SDEG inherits the tracker's limits (G8). |
+| **malformed input recovery** | transient `Missing`, then re-`Live` | `stable_id` across the bad window; ideally `NodeId` via `ProjectionIdentityTracker` | `is_valid_parse=false` side-table hold path, plus later NodeId survival (delegated to loom) or semantic recovery | side-table API now prevents premature `Tombstoned`/`Retired` for invalid snapshots; full G2 resolution still depends on production wiring passing the validity signal. |
 | **large paste** | many fresh `NodeId`s + fresh rows; possible mass ambiguity | rows whose `NodeId`s survive (untouched headings) | same-node for survivors; fresh for pasted | region-replacing paste freshens `NodeId`s → looks like delete-all+spawn-all; pasted duplicate text mis-resolves; **matching is O(rows×obs)** (nested filters) — scaling not stated as an invariant. |
 | **format-like rewrite** (whitespace/formatter) | source ranges, token spans (shift) | `stable_id`, `NodeId`, `Live`, signature (text unchanged) | same-node + same-key + overlapping-range | low risk; if formatter alters text normalization, key changes but same-node priority still preserves identity. *Holds today* (Phase 0). |
 | **projection regeneration** | full observation set + current-node index rebuilt | rows across regeneration | whatever `NodeId`s/keys survive regeneration | wholesale `NodeId` refresh (non-incremental rebuild) → mass semantic recovery; uniques recovered, duplicates → `Ambiguous`. **Bounded entirely by projection-identity stability** (G8). |
@@ -673,8 +674,12 @@ the three design docs disagree, the code wins and the conflict is flagged.
 - *Allowed references:* `current_id = None`; retains `last_live`.
 - *Retention:* whole session unless a positive table retention threshold later
   retires the row after it has become `Tombstoned`.
-- *Open:* **cannot distinguish "deleted" from "malformed-transient"** (G2); does
-  **not exist** in the sketch (sketch jumps straight to `Tombstoned`).
+- *Open:* side-table API support for G2 now distinguishes valid absence
+  evidence from invalid snapshots: invalid snapshots can mark current anchors
+  unavailable but do not advance the tombstone ladder. Full end-to-end G2
+  resolution still depends on production wiring passing the validity signal.
+  `Missing` does **not exist** in the sketch (sketch jumps straight to
+  `Tombstoned`).
 
 **ambiguous**
 - *Entry:* active row with >1 candidate, or whose sole candidate is contested, or
@@ -723,6 +728,12 @@ the three design docs disagree, the code wins and the conflict is flagged.
   implemented as a side-table setting (G3/#746).
 
 ### Derived transition table
+
+The table below describes valid/successful projection snapshots. Invalid
+snapshots use the side-table hold path: no initial or fresh rows are created,
+`Live`/`Ambiguous` rows become `Missing` with current anchors cleared,
+`Missing`/`Tombstoned`/`Retired` stay in place, `last_live` is preserved, and
+`consecutive_absences` does not change.
 
 `✓` implemented & tested · `(impl)` in code, not directly tested ·
 `(design-only)` named in a doc but **not** in code · `✗` impossible today.
@@ -884,16 +895,16 @@ Incompatible-interpretation risk: a consumer (outline, AI context) treats a
 `Live` row's heading text as a stable handle and silently relabels.
 
 **G2 — `Missing` conflates "deleted" and "transiently unparseable."**
-Both produce zero candidates → `Missing` → `Tombstoned`, on the same ladder, with
-no distinguishing signal. The named "stable across malformed intermediate input"
-scope cannot be honored because the table cannot tell a malformed parse from a
-real deletion. *Needed:* either an edit-provenance signal ("this advance follows
-a delete") or a parse-validity signal feeding `advance`, plus an invariant that
-malformed-transient absence must not advance the tombstone ladder. *Evidence
-note:* the wbtests cover delete/restore and edit-path cases but **not** transient
-malformed absence distinct from delete (`stable-document-entity-graph.md:181`
-requests the scope; no test exercises it) — so the invariant is currently
-unevidenced as well as unstated.
+*Addressed in the side-table API (#748), not yet end-to-end wiring:* the
+constructor and `advance` now accept `is_valid_parse`. Invalid snapshots create
+no initial rows, create no fresh rows, clear stale current anchors, preserve
+`last_live`, and do not change `consecutive_absences` or advance
+`Missing→Tombstoned→Retired`. Valid snapshots retain the existing delete ladder.
+This gives the side table the mechanism needed to distinguish valid absence
+evidence from malformed-transient absence. *Remaining integration work:* the
+production caller must pass a parser/projection validity signal before G2 is
+fully resolved end to end; otherwise omitting the flag preserves the default
+valid-snapshot behavior for compatibility.
 
 **G3 — Retention threshold N was unspecified in the contract and hardwired in
 code.** *Resolved in code (#746):* the side table carries `retention_threshold`
@@ -970,12 +981,13 @@ invariant/guard that `stable_id` is non-serializable and absent from any public
 later `pub` accessor).
 
 **G11 — "Successful projection snapshot" is an unencoded precondition of
-`advance`.** The signature takes raw observations with no validity flag; nothing
-stops a caller wiring `advance` into the `incr` runtime from calling it on a
-failed/partial parse, misfiring the lifecycle (compounds G2). *Needed:* encode
-the precondition (a validity-tagged input or a separate "parse failed → hold"
-path) and an invariant that `advance` runs only on reconciled, successful
-projections.
+`advance`.** *Addressed in the side-table API (#748), not yet end-to-end
+wiring:* `from_observations` and `advance` now encode the precondition with an
+`is_valid_parse` flag. `false` selects the "parse failed → hold" path; `true`
+retains the existing successful-snapshot behavior and remains the default for
+compatibility with existing test-only callers. *Remaining integration work:* the
+production caller must source this from parser/projection diagnostics before
+wiring the side table into the `incr` runtime.
 
 **G12 — "Never source of truth" is structural for writes but only conventional
 for reads.** `advance` cannot mutate document state (no handles) — good. But

--- a/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
+++ b/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
@@ -252,6 +252,13 @@ Ambiguous -> Missing if all candidates disappear
 For Phase 1, the default retention is "keep all tombstones" (`retention_threshold = 0`).
 Do not introduce production row removal until UI/undo/reload requirements are clearer.
 
+Invalid or malformed snapshots are not successful projection snapshots. The
+side-table constructor and `advance` accept `is_valid_parse`; when false, the
+table uses a hold path: it creates no initial or fresh rows, clears current
+anchors, preserves `last_live`, and does not increment absence counters or
+advance toward `Retired`. Full G2 resolution still requires production wiring to
+pass a parser/projection validity signal before calling `advance`.
+
 ### Expected behavior
 
 - Rename: preserved by `NodeId`; signature changes on the same entity.
@@ -276,7 +283,8 @@ Do not introduce production row removal until UI/undo/reload requirements are cl
    `docs/design/sdeg-nodeid-side-table.md`; treat those as prior evidence for
    same-node priority and snapshot invariants. Where lifecycle names conflict,
    this Phase 1 plan supersedes the older sketch: first absence is `Missing`,
-   and `Tombstoned` is reached only after the retention threshold.
+   repeated absence reaches `Tombstoned`, and only `Retired` is gated by the
+   retention threshold.
 2. [x] Extract the test-only observation helpers into package-private helpers
    inside `lang/markdown/proj/`, still not public.
 3. [x] Add a package-private heading side table with entity records and a
@@ -317,6 +325,9 @@ Do not introduce production row removal until UI/undo/reload requirements are cl
 - [x] Heading level-change identity is either still documented as an upstream
       provenance/reconciliation limitation or fixed with explicit evidence.
 - [x] Tombstoned rows can retire behind an explicit retention threshold.
+- [x] Invalid snapshots hold the lifecycle instead of minting rows or advancing
+      the absence/retirement ladder; production wiring must still supply the
+      validity signal end to end.
 - [x] No CRDT, frontend protocol, or public SDEG package changes.
 
 ## Validation
@@ -348,6 +359,9 @@ committing.
   `docs/plans/2026-06-19-sdeg-reorder-provenance-investigation.md`.
 - The side table should not mutate document state or bypass Markdown edit
   lowering.
+- The validity flag is side-table support, not a substitute for production
+  parser/projection diagnostics. Callers must pass the correct validity signal
+  when this table graduates from test-local use.
 
 ## Notes
 

--- a/lang/markdown/proj/sdeg_heading_side_table.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table.mbt
@@ -71,6 +71,9 @@ priv struct HeadingSideTableRow {
   last_live : HeadingObservation
   candidates : Array[@core.NodeId]
   evidence : Array[HeadingEntityEvidence]
+  // Counts consecutive valid-snapshot absences. `Missing` with zero absences
+  // means no valid absence evidence has been observed yet, usually because an
+  // invalid snapshot used the hold path.
   consecutive_absences : Int
 }
 
@@ -126,8 +129,13 @@ fn heading_current_index(
 fn HeadingSideTable::from_observations(
   observations : Array[HeadingObservation],
   retention_threshold? : Int = 0,
+  is_valid_parse? : Bool = true,
 ) -> HeadingSideTable {
-  let rows = observations.map(heading_side_table_live_row)
+  let rows = if is_valid_parse {
+    observations.map(heading_side_table_live_row)
+  } else {
+    []
+  }
   {
     rows,
     current_index: heading_current_index(rows),
@@ -319,6 +327,38 @@ fn heading_side_table_match_with_same_node_priority(
 }
 
 ///|
+fn heading_side_table_absent_row(
+  row : HeadingSideTableRow,
+  evidence : Array[HeadingEntityEvidence],
+  retention_threshold : Int,
+) -> HeadingSideTableRow {
+  let new_absences = row.consecutive_absences + 1
+  let next_status = match row.status {
+    HeadingTombstoned =>
+      if retention_threshold > 0 && new_absences >= retention_threshold {
+        HeadingRetired
+      } else {
+        HeadingTombstoned
+      }
+    HeadingMissing =>
+      if row.consecutive_absences == 0 {
+        HeadingSideTableStatus::HeadingMissing
+      } else {
+        HeadingTombstoned
+      }
+    _ => HeadingSideTableStatus::HeadingMissing
+  }
+  {
+    ..row,
+    current_id: None,
+    status: next_status,
+    candidates: [],
+    evidence,
+    consecutive_absences: new_absences,
+  }
+}
+
+///|
 fn row_from_match(
   row : HeadingSideTableRow,
   match_result : HeadingSideTableMatch,
@@ -331,27 +371,12 @@ fn row_from_match(
     HeadingRetired => { ..row, current_id: None, candidates: [] }
     _ =>
       match ids {
-        [] => {
-          let new_absences = row.consecutive_absences + 1
-          let next_status = match row.status {
-            HeadingTombstoned =>
-              if retention_threshold > 0 && new_absences >= retention_threshold {
-                HeadingRetired
-              } else {
-                HeadingTombstoned
-              }
-            HeadingMissing => HeadingTombstoned
-            _ => HeadingMissing
-          }
-          {
-            ..row,
-            current_id: None,
-            status: next_status,
-            candidates: [],
-            evidence: match_result.evidence,
-            consecutive_absences: new_absences,
-          }
-        }
+        [] =>
+          heading_side_table_absent_row(
+            row,
+            match_result.evidence,
+            retention_threshold,
+          )
         [id] if match_result.confidence is HeadingExact ||
           (claim_count(id) == 1 && match_result.confidence is HeadingProbable) =>
           match find_heading_by_id(current, id) {
@@ -365,28 +390,12 @@ fn row_from_match(
                 evidence: match_result.evidence,
                 consecutive_absences: 0,
               }
-            None => {
-              let new_absences = row.consecutive_absences + 1
-              let next_status = match row.status {
-                HeadingTombstoned =>
-                  if retention_threshold > 0 &&
-                    new_absences >= retention_threshold {
-                    HeadingRetired
-                  } else {
-                    HeadingTombstoned
-                  }
-                HeadingMissing => HeadingTombstoned
-                _ => HeadingMissing
-              }
-              {
-                ..row,
-                current_id: None,
-                status: next_status,
-                candidates: [],
-                evidence: match_result.evidence,
-                consecutive_absences: new_absences,
-              }
-            }
+            None =>
+              heading_side_table_absent_row(
+                row,
+                match_result.evidence,
+                retention_threshold,
+              )
           }
         _ =>
           {
@@ -406,65 +415,87 @@ fn row_from_match(
 fn HeadingSideTable::advance(
   self : HeadingSideTable,
   current : Array[HeadingObservation],
+  is_valid_parse? : Bool = true,
 ) -> HeadingSideTable {
-  let same_node_ids = same_node_claim_ids(self.rows, current)
-  let semantic_current = current_without_ids(current, same_node_ids)
-  let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = self.rows
-    .iter()
-    .filter(row_active)
-    .map(row => {
-      (
-        row,
-        heading_side_table_match_with_same_node_priority(
-          row, current, semantic_current,
-        ),
-      )
-    })
-    .collect()
-  let next_rows = self.rows.map(row => {
-    match row.status {
-      HeadingRetired => { ..row, current_id: None, candidates: [] }
-      _ => {
-        let match_result = matches
-          .iter()
-          .find_first(pair => pair.0.stable_id == row.stable_id)
-          .unwrap().1
-        row_from_match(
-          row,
-          match_result,
-          current,
-          id => candidate_claim_count(matches, id),
-          retention_threshold=self.retention_threshold,
-        )
+  if !is_valid_parse {
+    let rows = self.rows.map(row => {
+      let status = match row.status {
+        HeadingLive | HeadingAmbiguous => HeadingSideTableStatus::HeadingMissing
+        _ => row.status
       }
+      // Invalid snapshots supply no durable match evidence; keep `evidence` and
+      // `last_live` as last trusted data while clearing current
+      // anchors/candidates and preserving the valid-absence counter.
+      { ..row, current_id: None, status, candidates: [] }
+    })
+    {
+      rows,
+      current_index: heading_current_index(rows),
+      retention_threshold: self.retention_threshold,
+      next_entity_seed: self.next_entity_seed,
     }
-  })
-  let (fresh_rows, next_entity_seed) : (Array[HeadingSideTableRow], Int) = {
-    let result : Array[HeadingSideTableRow] = []
-    let mut seed = self.next_entity_seed
-    for obs in current {
-      if !side_table_mentions_current_id(next_rows, obs.id) {
-        let base_stable = HeadingStableRowId::from_node(obs.id)
-        if side_table_has_stable_id(next_rows, base_stable) {
-          let fallback = @core.NodeId::from_int(seed)
-          seed = seed - 1
-          result.push({
-            ..heading_side_table_live_row(obs),
-            stable_id: HeadingStableRowId::from_node(fallback),
-          })
-        } else {
-          result.push(heading_side_table_live_row(obs))
+  } else {
+    let same_node_ids = same_node_claim_ids(self.rows, current)
+    let semantic_current = current_without_ids(current, same_node_ids)
+    let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = self.rows
+      .iter()
+      .filter(row_active)
+      .map(row => {
+        (
+          row,
+          heading_side_table_match_with_same_node_priority(
+            row, current, semantic_current,
+          ),
+        )
+      })
+      .collect()
+    let next_rows = self.rows.map(row => {
+      match row.status {
+        HeadingRetired => { ..row, current_id: None, candidates: [] }
+        _ => {
+          let match_result = matches
+            .iter()
+            .find_first(pair => pair.0.stable_id == row.stable_id)
+            .unwrap().1
+          row_from_match(
+            row,
+            match_result,
+            current,
+            id => candidate_claim_count(matches, id),
+            retention_threshold=self.retention_threshold,
+          )
         }
       }
+    })
+    let (fresh_rows, next_entity_seed) : (Array[HeadingSideTableRow], Int) = {
+      let result : Array[HeadingSideTableRow] = []
+      let mut seed = self.next_entity_seed
+      for obs in current {
+        if !side_table_mentions_current_id(next_rows, obs.id) &&
+          !side_table_mentions_current_id(result, obs.id) {
+          let base_stable = HeadingStableRowId::from_node(obs.id)
+          if side_table_has_stable_id(next_rows, base_stable) ||
+            side_table_has_stable_id(result, base_stable) {
+            let fallback = @core.NodeId::from_int(seed)
+            seed = seed - 1
+            result.push({
+              ..heading_side_table_live_row(obs),
+              stable_id: HeadingStableRowId::from_node(fallback),
+            })
+          } else {
+            result.push(heading_side_table_live_row(obs))
+          }
+        }
+      }
+      (result, seed)
     }
-    (result, seed)
-  }
-  let rows = next_rows + fresh_rows
-  {
-    rows,
-    current_index: heading_current_index(rows),
-    retention_threshold: self.retention_threshold,
-    next_entity_seed,
+    let rows = next_rows + fresh_rows
+    {
+      rows,
+      current_index: heading_current_index(rows),
+      retention_threshold: self.retention_threshold,
+      next_entity_seed,
+    }
   }
 }
 

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -585,6 +585,207 @@ test "sdeg phase1: retired rows with fallback stable_id satisfy invariants" {
 }
 
 ///|
+test "sdeg phase1: fresh rows ignore duplicate current NodeIds" {
+  let current_a = synthetic_heading(1, "A", 0)
+  let duplicate_a = synthetic_heading(1, "A duplicate", 4)
+  let table = HeadingSideTable::from_observations([])
+  let advanced = table.advance([current_a, duplicate_a])
+  let fresh = find_row_by_current_id(advanced.rows, current_a.id).unwrap()
+
+  inspect(advanced.rows.length(), content="1")
+  inspect(fresh.status == HeadingLive, content="true")
+  inspect(fresh.current_id == Some(current_a.id), content="true")
+  inspect(
+    fresh.stable_id == HeadingStableRowId::from_node(current_a.id),
+    content="true",
+  )
+  inspect(fresh.last_live.text, content="A")
+  inspect(advanced.next_entity_seed, content="-1")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [current_a, duplicate_a]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: invalid initial snapshot creates no durable rows" {
+  let ghost = synthetic_heading(1, "Ghost", 0)
+  let table = HeadingSideTable::from_observations([ghost], is_valid_parse=false)
+
+  inspect(table.rows.length(), content="0")
+  inspect(table.current_index.length(), content="0")
+  inspect(table.next_entity_seed, content="-1")
+  inspect(heading_side_table_invariants_hold(table, [ghost]), content="true")
+}
+
+///|
+test "sdeg phase1: invalid advance creates no fresh rows or seed changes" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let transient_b = synthetic_heading(2, "B", 4)
+  let rows = [heading_side_table_live_row(old_a)]
+  let table = {
+    rows,
+    current_index: heading_current_index(rows),
+    retention_threshold: 0,
+    next_entity_seed: -7,
+  }
+  let advanced = table.advance([transient_b], is_valid_parse=false)
+  let old_row = find_side_table_row(advanced, old_a.id).unwrap()
+
+  inspect(advanced.rows.length(), content="1")
+  inspect(advanced.next_entity_seed, content="-7")
+  inspect(
+    find_row_by_current_id(advanced.rows, transient_b.id) is None,
+    content="true",
+  )
+  inspect(old_row.status == HeadingMissing, content="true")
+  inspect(old_row.consecutive_absences, content="0")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [transient_b]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: invalid advance marks live unavailable without aging" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let table = HeadingSideTable::from_observations([old_a])
+  let advanced = table.advance([], is_valid_parse=false)
+  let row = find_side_table_row(advanced, old_a.id).unwrap()
+
+  inspect(row.status == HeadingMissing, content="true")
+  inspect(row.current_id is None, content="true")
+  inspect(row.candidates.length(), content="0")
+  inspect(row.consecutive_absences, content="0")
+  inspect(row.last_live.id == old_a.id, content="true")
+  inspect(row.last_live.text, content="A")
+  inspect(heading_side_table_invariants_hold(advanced, []), content="true")
+}
+
+///|
+test "sdeg phase1: invalid absence requires later valid absence before tombstone" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let table = HeadingSideTable::from_observations([old_a])
+  let invalid_table = table.advance([], is_valid_parse=false)
+  let valid_missing_table = invalid_table.advance([])
+  let tombstoned_table = valid_missing_table.advance([])
+  let invalid_row = find_side_table_row(invalid_table, old_a.id).unwrap()
+  let valid_missing_row = find_side_table_row(valid_missing_table, old_a.id).unwrap()
+  let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
+
+  inspect(invalid_row.status == HeadingMissing, content="true")
+  inspect(invalid_row.consecutive_absences, content="0")
+  inspect(valid_missing_row.status == HeadingMissing, content="true")
+  inspect(valid_missing_row.consecutive_absences, content="1")
+  inspect(tombstoned_row.status == HeadingTombstoned, content="true")
+  inspect(tombstoned_row.consecutive_absences, content="2")
+  inspect(
+    heading_side_table_invariants_hold(valid_missing_table, []),
+    content="true",
+  )
+  inspect(
+    heading_side_table_invariants_hold(tombstoned_table, []),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: invalid advance clears ambiguous candidates without aging" {
+  let old_a0 = synthetic_heading(1, "A", 0)
+  let old_a1 = synthetic_heading(2, "A", 4)
+  let current_a = synthetic_heading(100, "A", 0)
+  let table = HeadingSideTable::from_observations([old_a0, old_a1])
+  let ambiguous_table = table.advance([current_a])
+  let invalid_table = ambiguous_table.advance([], is_valid_parse=false)
+  let row0 = find_side_table_row(invalid_table, old_a0.id).unwrap()
+  let row1 = find_side_table_row(invalid_table, old_a1.id).unwrap()
+
+  inspect(row0.status == HeadingMissing, content="true")
+  inspect(row1.status == HeadingMissing, content="true")
+  inspect(row0.candidates.length(), content="0")
+  inspect(row1.candidates.length(), content="0")
+  inspect(row0.consecutive_absences, content="0")
+  inspect(row1.consecutive_absences, content="0")
+  inspect(row0.last_live.id == old_a0.id, content="true")
+  inspect(row1.last_live.id == old_a1.id, content="true")
+  inspect(heading_side_table_invariants_hold(invalid_table, []), content="true")
+}
+
+///|
+test "sdeg phase1: invalid advance freezes missing and tombstoned rows" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    retention_threshold=3,
+  )
+  let missing_table = table.advance([])
+  let invalid_missing_table = missing_table.advance([], is_valid_parse=false)
+  let invalid_missing_row = find_side_table_row(invalid_missing_table, old_a.id).unwrap()
+  let tombstoned_table = missing_table.advance([])
+  let invalid_tombstoned_table = tombstoned_table.advance(
+    [],
+    is_valid_parse=false,
+  )
+  let invalid_tombstoned_row = find_side_table_row(
+    invalid_tombstoned_table,
+    old_a.id,
+  ).unwrap()
+
+  inspect(invalid_missing_row.status == HeadingMissing, content="true")
+  inspect(invalid_missing_row.consecutive_absences, content="1")
+  inspect(invalid_tombstoned_row.status == HeadingTombstoned, content="true")
+  inspect(invalid_tombstoned_row.consecutive_absences, content="2")
+  inspect(gc_eligible(invalid_tombstoned_row), content="false")
+  inspect(
+    heading_side_table_invariants_hold(invalid_missing_table, []),
+    content="true",
+  )
+  inspect(
+    heading_side_table_invariants_hold(invalid_tombstoned_table, []),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: invalid advance does not update last_live from matches" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let transient_a = synthetic_heading(1, "A changed", 0)
+  let table = HeadingSideTable::from_observations([old_a])
+  let invalid_table = table.advance([transient_a], is_valid_parse=false)
+  let invalid_row = find_side_table_row(invalid_table, old_a.id).unwrap()
+  let recovered_table = invalid_table.advance([transient_a])
+  let recovered_row = find_side_table_row(recovered_table, old_a.id).unwrap()
+
+  inspect(invalid_row.status == HeadingMissing, content="true")
+  inspect(invalid_row.current_id is None, content="true")
+  inspect(invalid_row.last_live.text, content="A")
+  inspect(invalid_row.consecutive_absences, content="0")
+  inspect(recovered_row.status == HeadingLive, content="true")
+  inspect(recovered_row.current_id == Some(transient_a.id), content="true")
+  inspect(recovered_row.last_live.text, content="A changed")
+  inspect(recovered_row.consecutive_absences, content="0")
+  inspect(
+    heading_side_table_invariants_hold(recovered_table, [transient_a]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: default advance treats empty valid snapshot as delete evidence" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let table = HeadingSideTable::from_observations([old_a])
+  let missing_table = table.advance([])
+  let tombstoned_table = missing_table.advance([])
+  let missing_row = find_side_table_row(missing_table, old_a.id).unwrap()
+  let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
+
+  inspect(missing_row.status == HeadingMissing, content="true")
+  inspect(missing_row.consecutive_absences, content="1")
+  inspect(tombstoned_row.status == HeadingTombstoned, content="true")
+  inspect(tombstoned_row.consecutive_absences, content="2")
+}
+
+///|
 test "sdeg phase1: collect_garbage removes retired rows only" {
   // Create a table with a retired row (manually constructed) and a live row
   let old_a = synthetic_heading(1, "A", 0)


### PR DESCRIPTION
## Summary

- Add `is_valid_parse` to the Markdown heading side-table constructor and `advance` path.
- Treat invalid snapshots as a hold/unavailable state: no fresh rows, no matching, no `last_live` update, no absence-counter aging, and no retirement progression.
- Add white-box coverage for invalid initial snapshots, invalid advance behavior, delayed tombstoning after invalid absence, retained `last_live`, and default valid behavior.
- Update SDEG docs/TODO to describe side-table API support while leaving production validity wiring as the remaining end-to-end #748 step.

Refs #748.

## Reuse check

- Reused existing `HeadingSideTable` lifecycle states, `consecutive_absences`, `heading_current_index`, and valid-snapshot matching/fresh-row logic.
- Checked/reused MoonBit core APIs for this data shape: `Array::map`, `Array::iter`/`filter`/`collect`, `Map::from_iter`, and `Option` pattern matching.
- Did not add edit-provenance plumbing or new public types; the change stays package-private and should not alter `.mbti` output.
- Remaining imperative code is the existing valid-snapshot fresh-row seed loop; invalid snapshots bypass it to preserve `next_entity_seed`.

## Testing

- `NEW_MOON_MOD=0 moon check lang/markdown/proj --deny-warn`
- `NEW_MOON_MOD=0 moon test lang/markdown/proj`
- `NEW_MOON_MOD=0 moon info lang/markdown/proj`
- `git diff -- '*.mbti'` (empty)
