### PR TITLE
Add ProjNode map

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -115,21 +115,32 @@ jobs:
           path: |
             base_bench.txt
             base_egw_bench.txt
-          key: benchmark-base-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
+          key: benchmark-base-v2-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
+
+      - name: Validate base benchmark cache
+        id: base-cache-files
+        run: |
+          if [ "${{ steps.base-benchmark-cache.outputs.cache-hit }}" = "true" ] && \
+             [ -f base_bench.txt ] && \
+             [ -f base_egw_bench.txt ]; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "complete=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout base branch
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        if: steps.base-cache-files.outputs.complete != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref || github.event.repository.default_branch }}
           submodules: recursive
 
       - name: Set up MoonBit
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        if: steps.base-cache-files.outputs.complete != 'true'
         uses: ./.github/actions/setup-moonbit
 
       - name: Run base benchmarks
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        if: steps.base-cache-files.outputs.complete != 'true'
         continue-on-error: true
         run: |
           echo "Running benchmarks on base branch..."
@@ -141,7 +152,7 @@ jobs:
           fi
 
       - name: Run submodule benchmarks (base - event-graph-walker)
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        if: steps.base-cache-files.outputs.complete != 'true'
         continue-on-error: true
         run: |
           if (
@@ -156,7 +167,7 @@ jobs:
           fi
 
       - name: Save base benchmark cache
-        if: always() && steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        if: always() && steps.base-cache-files.outputs.complete != 'true'
         continue-on-error: true
         uses: actions/cache/save@v5
         with:
@@ -197,6 +208,15 @@ jobs:
       - name: Compare results
         id: compare
         run: |
+          cat_benchmark_file() {
+            path="$1"
+            if [ -f "$path" ]; then
+              cat "$path"
+            else
+              echo "(benchmark output unavailable: $path missing)"
+            fi
+          }
+
           base_ref="${{ github.base_ref || github.event.repository.default_branch }}"
           {
             echo "## Benchmark Comparison Report"
@@ -208,13 +228,13 @@ jobs:
             echo ""
             echo "**Base branch:**"
             echo '```'
-            cat benchmark-results/base/base_bench.txt
+            cat_benchmark_file benchmark-results/base/base_bench.txt
             echo '```'
             echo ""
 
             echo "**PR branch:**"
             echo '```'
-            cat benchmark-results/pr/pr_bench.txt
+            cat_benchmark_file benchmark-results/pr/pr_bench.txt
             echo '```'
             echo ""
 
@@ -222,13 +242,13 @@ jobs:
             echo ""
             echo "**Base branch:**"
             echo '```'
-            cat benchmark-results/base/base_egw_bench.txt
+            cat_benchmark_file benchmark-results/base/base_egw_bench.txt
             echo '```'
             echo ""
 
             echo "**PR branch:**"
             echo '```'
-            cat benchmark-results/pr/pr_egw_bench.txt
+            cat_benchmark_file benchmark-results/pr/pr_egw_bench.txt
             echo '```'
             echo ""
 

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -88,11 +88,11 @@ pub struct ProjNode[T] {
   start : Int
   end : Int
 } derive(Eq, @debug.Debug)
+pub fn[T] ProjNode::ProjNode(T, Int, Int, Int, Array[Self[T]]) -> Self[T]
 pub fn[T] ProjNode::branch(T, Int, Int, Array[Self[T]], @ref.Ref[Int]) -> Self[T]
 pub fn[T] ProjNode::id(Self[T]) -> NodeId
 pub fn[T] ProjNode::leaf(T, @seam.SyntaxNode, @ref.Ref[Int]) -> Self[T]
 pub fn[T, U] ProjNode::map(Self[T], (T) -> U raise?) -> Self[U] raise?
-pub fn[T] ProjNode::new(T, Int, Int, Int, Array[Self[T]]) -> Self[T]
 pub impl[T : @dowdiness/loom/core.Renderable] Show for ProjNode[T]
 pub impl[T : ToJson] ToJson for ProjNode[T]
 

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -91,6 +91,7 @@ pub struct ProjNode[T] {
 pub fn[T] ProjNode::branch(T, Int, Int, Array[Self[T]], @ref.Ref[Int]) -> Self[T]
 pub fn[T] ProjNode::id(Self[T]) -> NodeId
 pub fn[T] ProjNode::leaf(T, @seam.SyntaxNode, @ref.Ref[Int]) -> Self[T]
+pub fn[T, U] ProjNode::map(Self[T], (T) -> U raise?) -> Self[U] raise?
 pub fn[T] ProjNode::new(T, Int, Int, Int, Array[Self[T]]) -> Self[T]
 pub impl[T : @dowdiness/loom/core.Renderable] Show for ProjNode[T]
 pub impl[T : ToJson] ToJson for ProjNode[T]

--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -32,7 +32,7 @@ pub impl[T : @loomcore.Renderable] Show for ProjNode[T] with fn output(
 }
 
 ///|
-pub fn[T] ProjNode::new(
+pub fn[T] ProjNode::ProjNode(
   kind : T,
   start : Int,
   end : Int,
@@ -47,7 +47,7 @@ pub fn[T, U] ProjNode::map(
   self : ProjNode[T],
   f : (T) -> U raise?,
 ) -> ProjNode[U] raise? {
-  ProjNode::new(
+  ProjNode(
     f(self.kind),
     self.start,
     self.end,
@@ -58,21 +58,21 @@ pub fn[T, U] ProjNode::map(
 
 ///|
 /// Construct a childless ProjNode spanning a syntax node, assigning a fresh id.
-/// Projection builders should prefer this for syntax leaves instead of pairing
-/// `next_proj_node_id` with `ProjNode::new` at each call site.
+/// Projection builders should prefer this for syntax leaves instead of manually
+/// pairing `next_proj_node_id` with `ProjNode(...)` at each call site.
 pub fn[T] ProjNode::leaf(
   kind : T,
   node : @seam.SyntaxNode,
   counter : Ref[Int],
 ) -> ProjNode[T] {
-  ProjNode::new(kind, node.start(), node.end(), next_proj_node_id(counter), [])
+  ProjNode(kind, node.start(), node.end(), next_proj_node_id(counter), [])
 }
 
 ///|
 /// Construct a ProjNode with explicit UTF-16 source span and children,
 /// assigning a fresh id. Use this for projection branches whose identity is
-/// fresh for this build; keep `ProjNode::new` when preserving or reusing a
-/// known node id.
+/// fresh for this build; call `ProjNode(...)` directly when preserving or
+/// reusing a known node id.
 pub fn[T] ProjNode::branch(
   kind : T,
   start : Int,
@@ -80,7 +80,7 @@ pub fn[T] ProjNode::branch(
   children : Array[ProjNode[T]],
   counter : Ref[Int],
 ) -> ProjNode[T] {
-  ProjNode::new(kind, start, end, next_proj_node_id(counter), children)
+  ProjNode(kind, start, end, next_proj_node_id(counter), children)
 }
 
 ///|

--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -43,6 +43,20 @@ pub fn[T] ProjNode::new(
 }
 
 ///|
+pub fn[T, U] ProjNode::map(
+  self : ProjNode[T],
+  f : (T) -> U raise?,
+) -> ProjNode[U] raise? {
+  ProjNode::new(
+    f(self.kind),
+    self.start,
+    self.end,
+    self.node_id,
+    self.children.map(child => child.map(f)),
+  )
+}
+
+///|
 /// Construct a childless ProjNode spanning a syntax node, assigning a fresh id.
 /// Projection builders should prefer this for syntax leaves instead of pairing
 /// `next_proj_node_id` with `ProjNode::new` at each call site.

--- a/core/proj_zipper_wbtest.mbt
+++ b/core/proj_zipper_wbtest.mbt
@@ -5,7 +5,7 @@
 
 ///|
 fn make_node(id : Int, children : Array[ProjNode[Int]]) -> ProjNode[Int] {
-  ProjNode::new(id, 0, 0, id, children)
+  ProjNode(id, 0, 0, id, children)
 }
 
 // Test tree:

--- a/core/reconcile.mbt
+++ b/core/reconcile.mbt
@@ -46,13 +46,7 @@ pub fn[T : TreeNode] reconcile_hinted(
           counter,
           hints,
         )
-        ProjNode::new(
-          new.kind,
-          new.start,
-          new.end,
-          old.node_id,
-          reconciled_children,
-        )
+        ProjNode(new.kind, new.start, new.end, old.node_id, reconciled_children)
       } else {
         assign_fresh_ids(new, counter)
       }
@@ -316,7 +310,7 @@ fn[T : TreeNode] apply_wrap(
             // directly and reconcile their children. Routing through
             // reconcile_hinted here would re-apply `old`'s own wrap hint and
             // push the id one level too deep.
-            ProjNode::new(
+            ProjNode(
               c.kind,
               c.start,
               c.end,
@@ -329,7 +323,7 @@ fn[T : TreeNode] apply_wrap(
         }
       ]
       Some(
-        ProjNode::new(
+        ProjNode(
           wrapper.kind,
           wrapper.start,
           wrapper.end,

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -22,18 +22,14 @@ fn mk_hints(
 ///|
 test "Wrap hint at a child position carries the inner id" {
   // old: root#1 -> Leaf#5
-  let inner = ProjNode::new(Leaf("x"), 0, 1, 5, [])
-  let old = ProjNode::new(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
+  let inner = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
   // new: root -> Branch wrapper -> Leaf  (Leaf#5 got wrapped one level deeper)
-  let new_inner = ProjNode::new(Leaf("x"), 1, 2, 90, [])
-  let wrapper = ProjNode::new(Branch("w", [Leaf("x")]), 1, 3, 91, [new_inner])
-  let new_ = ProjNode::new(
-    Branch("root", [Branch("w", [Leaf("x")])]),
-    0,
-    5,
-    92,
-    [wrapper],
-  )
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 1, 3, 91, [new_inner])
+  let new_ = ProjNode(Branch("root", [Branch("w", [Leaf("x")])]), 0, 5, 92, [
+    wrapper,
+  ])
   let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
   let result = reconcile_hinted(old, new_, Ref(1000), hints)
   // root keeps id 1 (same_kind Branch)
@@ -46,14 +42,14 @@ test "Wrap hint at a child position carries the inner id" {
 ///|
 test "Unwrap hint at a child position carries the kept id" {
   // old: root#1 -> wrapper#10 -> Leaf#5
-  let kept = ProjNode::new(Leaf("x"), 1, 2, 5, [])
-  let wrapper = ProjNode::new(Branch("w", [Leaf("x")]), 1, 3, 10, [kept])
-  let old = ProjNode::new(Branch("root", [Branch("w", [Leaf("x")])]), 0, 5, 1, [
+  let kept = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 1, 3, 10, [kept])
+  let old = ProjNode(Branch("root", [Branch("w", [Leaf("x")])]), 0, 5, 1, [
     wrapper,
   ])
   // new: root -> Leaf  (wrapper removed, Leaf promoted)
-  let new_child = ProjNode::new(Leaf("x"), 1, 2, 90, [])
-  let new_ = ProjNode::new(Branch("root", [Leaf("x")]), 0, 5, 91, [new_child])
+  let new_child = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 5, 91, [new_child])
   let hints = mk_hints([
     (10, Unwrap(wrapper=NodeId::from_int(10), keep=NodeId::from_int(5))),
   ])
@@ -65,17 +61,13 @@ test "Unwrap hint at a child position carries the kept id" {
 
 ///|
 test "without a hint, a wrap loses the inner id (degrades to fresh)" {
-  let inner = ProjNode::new(Leaf("x"), 0, 1, 5, [])
-  let old = ProjNode::new(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
-  let new_inner = ProjNode::new(Leaf("x"), 1, 2, 90, [])
-  let wrapper = ProjNode::new(Branch("w", [Leaf("x")]), 1, 3, 91, [new_inner])
-  let new_ = ProjNode::new(
-    Branch("root", [Branch("w", [Leaf("x")])]),
-    0,
-    5,
-    92,
-    [wrapper],
-  )
+  let inner = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 1, 3, 91, [new_inner])
+  let new_ = ProjNode(Branch("root", [Branch("w", [Leaf("x")])]), 0, 5, 92, [
+    wrapper,
+  ])
   let result = reconcile_hinted(old, new_, Ref(1000), {})
   // no hint → LCS cannot pair Leaf#5 with the Branch wrapper → inner is fresh
   inspect(result.children[0].children[0].node_id >= 1000, content="true")
@@ -83,15 +75,13 @@ test "without a hint, a wrap loses the inner id (degrades to fresh)" {
 
 ///|
 test "ambiguous wrap target degrades to fresh (two same-kind children)" {
-  let inner = ProjNode::new(Leaf("x"), 0, 1, 5, [])
-  let old = ProjNode::new(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
+  let inner = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
   // wrapper has TWO Leaf children → cannot disambiguate which carries id 5
-  let la = ProjNode::new(Leaf("a"), 1, 2, 90, [])
-  let lb = ProjNode::new(Leaf("b"), 2, 3, 91, [])
-  let wrapper = ProjNode::new(Branch("w", [Leaf("a"), Leaf("b")]), 1, 4, 92, [
-    la, lb,
-  ])
-  let new_ = ProjNode::new(
+  let la = ProjNode(Leaf("a"), 1, 2, 90, [])
+  let lb = ProjNode(Leaf("b"), 2, 3, 91, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("a"), Leaf("b")]), 1, 4, 92, [la, lb])
+  let new_ = ProjNode(
     Branch("root", [Branch("w", [Leaf("a"), Leaf("b")])]),
     0,
     6,
@@ -108,22 +98,16 @@ test "ambiguous wrap target degrades to fresh (two same-kind children)" {
 ///|
 test "same-kind Wrap carries the wrapped node id, not the new wrapper" {
   // old: root#1 -> a#5 (Branch) -> Leaf#6
-  let a_leaf = ProjNode::new(Leaf("x"), 0, 1, 6, [])
-  let a = ProjNode::new(Branch("a", [Leaf("x")]), 0, 2, 5, [a_leaf])
-  let old = ProjNode::new(Branch("root", [Branch("a", [Leaf("x")])]), 0, 5, 1, [
-    a,
-  ])
+  let a_leaf = ProjNode(Leaf("x"), 0, 1, 6, [])
+  let a = ProjNode(Branch("a", [Leaf("x")]), 0, 2, 5, [a_leaf])
+  let old = ProjNode(Branch("root", [Branch("a", [Leaf("x")])]), 0, 5, 1, [a])
   // new: a#5 wrapped in another Branch of the SAME kind (Branch -> Branch)
-  let new_a_leaf = ProjNode::new(Leaf("x"), 1, 2, 90, [])
-  let new_a = ProjNode::new(Branch("a", [Leaf("x")]), 1, 3, 91, [new_a_leaf])
-  let wrapper = ProjNode::new(
-    Branch("w", [Branch("a", [Leaf("x")])]),
-    1,
-    4,
-    92,
-    [new_a],
-  )
-  let new_ = ProjNode::new(
+  let new_a_leaf = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_a = ProjNode(Branch("a", [Leaf("x")]), 1, 3, 91, [new_a_leaf])
+  let wrapper = ProjNode(Branch("w", [Branch("a", [Leaf("x")])]), 1, 4, 92, [
+    new_a,
+  ])
+  let new_ = ProjNode(
     Branch("root", [Branch("w", [Branch("a", [Leaf("x")])])]),
     0,
     5,
@@ -141,21 +125,15 @@ test "same-kind Wrap carries the wrapped node id, not the new wrapper" {
 ///|
 test "two old children claiming one wrapper degrade to fresh" {
   // old: root#1 -> [Leaf#5, Leaf#6], both hinted as wrapped
-  let l5 = ProjNode::new(Leaf("x"), 0, 1, 5, [])
-  let l6 = ProjNode::new(Leaf("y"), 1, 2, 6, [])
-  let old = ProjNode::new(Branch("root", [Leaf("x"), Leaf("y")]), 0, 3, 1, [
-    l5, l6,
-  ])
+  let l5 = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let l6 = ProjNode(Leaf("y"), 1, 2, 6, [])
+  let old = ProjNode(Branch("root", [Leaf("x"), Leaf("y")]), 0, 3, 1, [l5, l6])
   // new: root -> single wrapper Branch with one Leaf child
-  let new_leaf = ProjNode::new(Leaf("x"), 0, 1, 90, [])
-  let wrapper = ProjNode::new(Branch("w", [Leaf("x")]), 0, 2, 91, [new_leaf])
-  let new_ = ProjNode::new(
-    Branch("root", [Branch("w", [Leaf("x")])]),
-    0,
-    3,
-    92,
-    [wrapper],
-  )
+  let new_leaf = ProjNode(Leaf("x"), 0, 1, 90, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 0, 2, 91, [new_leaf])
+  let new_ = ProjNode(Branch("root", [Branch("w", [Leaf("x")])]), 0, 3, 92, [
+    wrapper,
+  ])
   let hints = mk_hints([
     (5, Wrap(inner=NodeId::from_int(5))),
     (6, Wrap(inner=NodeId::from_int(6))),
@@ -168,25 +146,23 @@ test "two old children claiming one wrapper degrade to fresh" {
 ///|
 test "same-kind Wrap with ambiguous target degrades to fresh (no id on wrapper)" {
   // old: root#1 -> a#5 (Branch)
-  let a_leaf = ProjNode::new(Leaf("x"), 0, 1, 6, [])
-  let a = ProjNode::new(Branch("a", [Leaf("x")]), 0, 2, 5, [a_leaf])
-  let old = ProjNode::new(Branch("root", [Branch("a", [Leaf("x")])]), 0, 5, 1, [
-    a,
-  ])
+  let a_leaf = ProjNode(Leaf("x"), 0, 1, 6, [])
+  let a = ProjNode(Branch("a", [Leaf("x")]), 0, 2, 5, [a_leaf])
+  let old = ProjNode(Branch("root", [Branch("a", [Leaf("x")])]), 0, 5, 1, [a])
   // new: a#5 "wrapped" in a same-kind Branch that has TWO Branch children →
   // the wrapped node cannot be located unambiguously.
-  let c1_leaf = ProjNode::new(Leaf("x"), 1, 2, 90, [])
-  let c1 = ProjNode::new(Branch("a", [Leaf("x")]), 1, 3, 91, [c1_leaf])
-  let c2_leaf = ProjNode::new(Leaf("y"), 3, 4, 92, [])
-  let c2 = ProjNode::new(Branch("b", [Leaf("y")]), 3, 5, 93, [c2_leaf])
-  let wrapper = ProjNode::new(
+  let c1_leaf = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let c1 = ProjNode(Branch("a", [Leaf("x")]), 1, 3, 91, [c1_leaf])
+  let c2_leaf = ProjNode(Leaf("y"), 3, 4, 92, [])
+  let c2 = ProjNode(Branch("b", [Leaf("y")]), 3, 5, 93, [c2_leaf])
+  let wrapper = ProjNode(
     Branch("w", [Branch("a", [Leaf("x")]), Branch("b", [Leaf("y")])]),
     1,
     5,
     94,
     [c1, c2],
   )
-  let new_ = ProjNode::new(
+  let new_ = ProjNode(
     Branch("root", [
       Branch("w", [Branch("a", [Leaf("x")]), Branch("b", [Leaf("y")])]),
     ]),
@@ -205,16 +181,16 @@ test "same-kind Wrap with ambiguous target degrades to fresh (no id on wrapper)"
 ///|
 test "one hint matching two new wrappers degrades to fresh" {
   // old: root#1 -> Leaf#5 (hinted as wrapped)
-  let l5 = ProjNode::new(Leaf("x"), 0, 1, 5, [])
-  let old = ProjNode::new(Branch("root", [Leaf("x")]), 0, 3, 1, [l5])
+  let l5 = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [l5])
   // new: root -> [wrapperA(Leaf), wrapperB(Leaf)] — two same-kind wrappers, each
   // a valid wrap target for #5, so the wrapped node is not locatable in exactly
   // one new sibling.
-  let a_leaf = ProjNode::new(Leaf("x"), 0, 1, 90, [])
-  let wa = ProjNode::new(Branch("w", [Leaf("x")]), 0, 2, 91, [a_leaf])
-  let b_leaf = ProjNode::new(Leaf("x"), 2, 3, 92, [])
-  let wb = ProjNode::new(Branch("w", [Leaf("x")]), 2, 4, 93, [b_leaf])
-  let new_ = ProjNode::new(
+  let a_leaf = ProjNode(Leaf("x"), 0, 1, 90, [])
+  let wa = ProjNode(Branch("w", [Leaf("x")]), 0, 2, 91, [a_leaf])
+  let b_leaf = ProjNode(Leaf("x"), 2, 3, 92, [])
+  let wb = ProjNode(Branch("w", [Leaf("x")]), 2, 4, 93, [b_leaf])
+  let new_ = ProjNode(
     Branch("root", [Branch("w", [Leaf("x")]), Branch("w", [Leaf("x")])]),
     0,
     4,
@@ -231,18 +207,16 @@ test "one hint matching two new wrappers degrades to fresh" {
 ///|
 test "hinted old child is not consumed by an LCS match against the wrong sibling" {
   // old: root#1 -> [Leaf#5 (hinted wrapped), Leaf#6]
-  let l5 = ProjNode::new(Leaf("x"), 0, 1, 5, [])
-  let l6 = ProjNode::new(Leaf("y"), 1, 2, 6, [])
-  let old = ProjNode::new(Branch("root", [Leaf("x"), Leaf("y")]), 0, 3, 1, [
-    l5, l6,
-  ])
+  let l5 = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let l6 = ProjNode(Leaf("y"), 1, 2, 6, [])
+  let old = ProjNode(Branch("root", [Leaf("x"), Leaf("y")]), 0, 3, 1, [l5, l6])
   // new: [Leaf(new), Branch(Leaf)] — the standalone Leaf is same_kind as #5, but
   // per the hint #5 belongs to the Branch wrapper. LCS must not consume #5
   // against the standalone Leaf first.
-  let nl = ProjNode::new(Leaf("z"), 0, 1, 90, [])
-  let w_leaf = ProjNode::new(Leaf("x"), 1, 2, 91, [])
-  let wrapper = ProjNode::new(Branch("w", [Leaf("x")]), 1, 3, 92, [w_leaf])
-  let new_ = ProjNode::new(
+  let nl = ProjNode(Leaf("z"), 0, 1, 90, [])
+  let w_leaf = ProjNode(Leaf("x"), 1, 2, 91, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 1, 3, 92, [w_leaf])
+  let new_ = ProjNode(
     Branch("root", [Leaf("z"), Branch("w", [Leaf("x")])]),
     0,
     3,
@@ -258,21 +232,13 @@ test "hinted old child is not consumed by an LCS match against the wrong sibling
 ///|
 test "Replace hint retires the old id (node is fresh, not preserved)" {
   // old: root#1 -> a#5 (Branch)
-  let a_leaf = ProjNode::new(Leaf("x"), 0, 1, 6, [])
-  let a = ProjNode::new(Branch("a", [Leaf("x")]), 0, 2, 5, [a_leaf])
-  let old = ProjNode::new(Branch("root", [Branch("a", [Leaf("x")])]), 0, 5, 1, [
-    a,
-  ])
+  let a_leaf = ProjNode(Leaf("x"), 0, 1, 6, [])
+  let a = ProjNode(Branch("a", [Leaf("x")]), 0, 2, 5, [a_leaf])
+  let old = ProjNode(Branch("root", [Branch("a", [Leaf("x")])]), 0, 5, 1, [a])
   // new: a same-kind Branch occupies #5's position, but the edit replaced it.
-  let n_leaf = ProjNode::new(Leaf("y"), 0, 1, 90, [])
-  let n = ProjNode::new(Branch("b", [Leaf("y")]), 0, 2, 91, [n_leaf])
-  let new_ = ProjNode::new(
-    Branch("root", [Branch("b", [Leaf("y")])]),
-    0,
-    5,
-    92,
-    [n],
-  )
+  let n_leaf = ProjNode(Leaf("y"), 0, 1, 90, [])
+  let n = ProjNode(Branch("b", [Leaf("y")]), 0, 2, 91, [n_leaf])
+  let new_ = ProjNode(Branch("root", [Branch("b", [Leaf("y")])]), 0, 5, 92, [n])
   let hints = mk_hints([(5, Replace(old=NodeId::from_int(5)))])
   let result = reconcile_hinted(old, new_, Ref(1000), hints)
   // same-kind would normally preserve #5; Replace retires it → the node is fresh

--- a/core/reconcile_properties_wbtest.mbt
+++ b/core/reconcile_properties_wbtest.mbt
@@ -63,7 +63,7 @@ fn to_proj_node(expr : TestExpr, counter : Ref[Int]) -> ProjNode[TestExpr] {
     Branch(_, cs) => cs.map(fn(c) { to_proj_node(c, counter) })
   }
   let id = next_proj_node_id(counter)
-  ProjNode::new(expr, 0, 0, id, children)
+  ProjNode(expr, 0, 0, id, children)
 }
 
 ///|
@@ -765,7 +765,7 @@ fn to_proj_node_with_spans(
       cs.map(fn(c) { to_proj_node_with_spans(c, counter, span_offset) })
   }
   let id = next_proj_node_id(counter)
-  ProjNode::new(expr, my_span, my_span + 1, id, children)
+  ProjNode(expr, my_span, my_span + 1, id, children)
 }
 
 ///|

--- a/core/source_map_properties_wbtest.mbt
+++ b/core/source_map_properties_wbtest.mbt
@@ -112,7 +112,7 @@ fn to_proj_node_with_ranges(
       let end = start + s.length().max(1)
       offset.val = end
       let id = next_proj_node_id(counter)
-      ProjNode::new(expr, start, end, id, [])
+      ProjNode(expr, start, end, id, [])
     }
     Branch(_, cs) => {
       let start = offset.val
@@ -123,7 +123,7 @@ fn to_proj_node_with_ranges(
       let end = offset.val.max(start + 1)
       offset.val = end
       let id = next_proj_node_id(counter)
-      ProjNode::new(expr, start, end, id, children)
+      ProjNode(expr, start, end, id, children)
     }
   }
 }

--- a/core/source_map_wbtest.mbt
+++ b/core/source_map_wbtest.mbt
@@ -43,7 +43,7 @@ test "patch_subtree clears stale token spans" {
   sm.node_to_range[nid] = @loomcore.Range::new(0, 10)
   sm.set_token_span(nid, "param", @loomcore.Range::new(2, 4))
   // Patch the node — should clear its token spans
-  let node : ProjNode[Int] = ProjNode::new(42, 0, 12, 1, [])
+  let node : ProjNode[Int] = ProjNode(42, 0, 12, 1, [])
   sm.patch_subtree(node)
   let spans = sm.get_all_token_spans(nid)
   inspect(spans.length(), content="0")

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -107,7 +107,7 @@ test "TestExpr fixture surface is frozen (drift guard vs workspace/probe)" {
 
 ///|
 test "ProjNode[TestExpr] — construction and field access" {
-  let leaf = ProjNode::new(Leaf("x"), 0, 1, 0, [])
+  let leaf = ProjNode(Leaf("x"), 0, 1, 0, [])
   inspect(leaf.kind, content="Leaf(\"x\")")
   inspect(leaf.start, content="0")
   inspect(leaf.end, content="1")
@@ -135,7 +135,7 @@ test "ProjNode::leaf allocates a fresh id from syntax span" {
 ///|
 test "ProjNode::branch allocates a fresh id" {
   let counter = Ref(7)
-  let child = ProjNode::new(Leaf("x"), 0, 1, 0, [])
+  let child = ProjNode(Leaf("x"), 0, 1, 0, [])
   let branch = ProjNode::branch(
     Branch("root", [Leaf("x")]),
     0,
@@ -150,9 +150,9 @@ test "ProjNode::branch allocates a fresh id" {
 
 ///|
 test "ProjNode::map transforms kinds recursively and preserves metadata" {
-  let left = ProjNode::new(Leaf("a"), 1, 2, 11, [])
-  let right = ProjNode::new(Leaf("b"), 3, 4, 12, [])
-  let root = ProjNode::new(Branch("root", [Leaf("a"), Leaf("b")]), 0, 5, 10, [
+  let left = ProjNode(Leaf("a"), 1, 2, 11, [])
+  let right = ProjNode(Leaf("b"), 3, 4, 12, [])
+  let root = ProjNode(Branch("root", [Leaf("a"), Leaf("b")]), 0, 5, 10, [
     left, right,
   ])
   let mapped = root.map(kind => Renderable::label(kind))
@@ -172,7 +172,7 @@ test "ProjNode::map transforms kinds recursively and preserves metadata" {
 
 ///|
 test "ProjNode::map propagates raising callbacks" {
-  let root = ProjNode::new(Leaf("boom"), 0, 4, 10, [])
+  let root = ProjNode(Leaf("boom"), 0, 4, 10, [])
   let caught = try {
     let _ = root.map(kind => {
       match kind {
@@ -190,21 +190,21 @@ test "ProjNode::map propagates raising callbacks" {
 
 ///|
 test "ProjNode Show — depth-1 only, uses Renderable::kind_tag" {
-  let leaf = ProjNode::new(Leaf("x"), 0, 1, 0, [])
+  let leaf = ProjNode(Leaf("x"), 0, 1, 0, [])
   inspect(leaf, content="#0 Leaf [0..1]")
 }
 
 ///|
 test "ProjNode Show — Branch with children does not recurse into kind/children" {
-  let child = ProjNode::new(Leaf("a"), 0, 1, 1, [])
-  let root = ProjNode::new(Branch("root", [Leaf("a")]), 0, 5, 7, [child])
+  let child = ProjNode(Leaf("a"), 0, 1, 1, [])
+  let root = ProjNode(Branch("root", [Leaf("a")]), 0, 5, 7, [child])
   inspect(root, content="#7 Branch [0..5]")
 }
 
 ///|
 test "SourceMap::from_ast works with TestExpr" {
-  let child = ProjNode::new(Leaf("a"), 0, 1, 1, [])
-  let root = ProjNode::new(Branch("root", [Leaf("a")]), 0, 5, 0, [child])
+  let child = ProjNode(Leaf("a"), 0, 1, 1, [])
+  let root = ProjNode(Branch("root", [Leaf("a")]), 0, 5, 0, [child])
   let sm = SourceMap::from_ast(root)
   inspect(sm.node_count(), content="2")
   inspect(sm.get_range(NodeId::from_int(0)) is Some(_), content="true")
@@ -213,8 +213,8 @@ test "SourceMap::from_ast works with TestExpr" {
 
 ///|
 test "reconcile preserves IDs when kinds match" {
-  let old = ProjNode::new(Leaf("x"), 0, 1, 42, [])
-  let new_ = ProjNode::new(Leaf("y"), 0, 1, 99, [])
+  let old = ProjNode(Leaf("x"), 0, 1, 42, [])
+  let new_ = ProjNode(Leaf("y"), 0, 1, 99, [])
   let counter = Ref(100)
   let result = reconcile(old, new_, counter)
   // same_kind(Leaf, Leaf) is true → old ID preserved
@@ -224,8 +224,8 @@ test "reconcile preserves IDs when kinds match" {
 
 ///|
 test "reconcile assigns fresh IDs when kinds differ" {
-  let old = ProjNode::new(Leaf("x"), 0, 1, 42, [])
-  let new_ = ProjNode::new(Branch("b", []), 0, 3, 99, [])
+  let old = ProjNode(Leaf("x"), 0, 1, 42, [])
+  let new_ = ProjNode(Branch("b", []), 0, 3, 99, [])
   let counter = Ref(100)
   let result = reconcile(old, new_, counter)
   // same_kind(Leaf, Branch) is false → fresh ID
@@ -234,8 +234,8 @@ test "reconcile assigns fresh IDs when kinds differ" {
 
 ///|
 test "assign_fresh_ids renumbers entire subtree" {
-  let child = ProjNode::new(Leaf("a"), 0, 1, 0, [])
-  let root = ProjNode::new(Branch("r", [Leaf("a")]), 0, 5, 1, [child])
+  let child = ProjNode(Leaf("a"), 0, 1, 0, [])
+  let root = ProjNode(Branch("r", [Leaf("a")]), 0, 5, 1, [child])
   let counter = Ref(50)
   let result = assign_fresh_ids(root, counter)
   // post-order: child gets 50, parent gets 51
@@ -245,8 +245,8 @@ test "assign_fresh_ids renumbers entire subtree" {
 
 ///|
 test "get_node_in_tree finds nested node" {
-  let leaf = ProjNode::new(Leaf("target"), 2, 8, 7, [])
-  let root = ProjNode::new(Branch("r", [Leaf("target")]), 0, 10, 0, [leaf])
+  let leaf = ProjNode(Leaf("target"), 2, 8, 7, [])
+  let root = ProjNode(Branch("r", [Leaf("target")]), 0, 10, 0, [leaf])
   let found = get_node_in_tree(root, NodeId::from_int(7))
   inspect(found is Some(_), content="true")
   inspect(found.unwrap().kind, content="Leaf(\"target\")")
@@ -254,7 +254,7 @@ test "get_node_in_tree finds nested node" {
 
 ///|
 test "ToJson for ProjNode[TestExpr] compiles" {
-  let node = ProjNode::new(Leaf("x"), 0, 1, 0, [])
+  let node = ProjNode(Leaf("x"), 0, 1, 0, [])
   let json = node.to_json()
   inspect(json.stringify().length() > 0, content="true")
 }

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -149,6 +149,46 @@ test "ProjNode::branch allocates a fresh id" {
 }
 
 ///|
+test "ProjNode::map transforms kinds recursively and preserves metadata" {
+  let left = ProjNode::new(Leaf("a"), 1, 2, 11, [])
+  let right = ProjNode::new(Leaf("b"), 3, 4, 12, [])
+  let root = ProjNode::new(Branch("root", [Leaf("a"), Leaf("b")]), 0, 5, 10, [
+    left, right,
+  ])
+  let mapped = root.map(kind => Renderable::label(kind))
+  inspect(mapped.node_id, content="10")
+  inspect(mapped.kind, content="root")
+  inspect(mapped.start, content="0")
+  inspect(mapped.end, content="5")
+  inspect(mapped.children[0].node_id, content="11")
+  inspect(mapped.children[0].kind, content="a")
+  inspect(mapped.children[0].start, content="1")
+  inspect(mapped.children[0].end, content="2")
+  inspect(mapped.children[1].node_id, content="12")
+  inspect(mapped.children[1].kind, content="b")
+  inspect(mapped.children[1].start, content="3")
+  inspect(mapped.children[1].end, content="4")
+}
+
+///|
+test "ProjNode::map propagates raising callbacks" {
+  let root = ProjNode::new(Leaf("boom"), 0, 4, 10, [])
+  let caught = try {
+    let _ = root.map(kind => {
+      match kind {
+        Leaf("boom") => fail("boom")
+        Leaf(s) => s
+        Branch(tag, _) => tag
+      }
+    })
+    false
+  } catch {
+    _ => true
+  }
+  inspect(caught, content="true")
+}
+
+///|
 test "ProjNode Show — depth-1 only, uses Renderable::kind_tag" {
   let leaf = ProjNode::new(Leaf("x"), 0, 1, 0, [])
   inspect(leaf, content="#0 Leaf [0..1]")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -168,7 +168,7 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
   Exit: shared core function parameterized by token/node creation callbacks; three variants are thin wrappers.
 
 - [x] Hoist ProjNode id-allocation boilerplate into `@core` (`core/proj_node.mbt`). (finding B from PR #383)
-  Shipped (#437): `@core` exposes `ProjNode::leaf[T](kind, node : @seam.SyntaxNode, counter)` and `ProjNode::branch[T](kind, start, end, children, counter)`. Lambda/JSON/Markdown projection builders now use the shared helpers for fresh syntax leaves/branches; ID-preserving sites keep raw `ProjNode::new`. `.mbti` change is limited to the two new `@core` exports.
+  Shipped (#437): `@core` exposes `ProjNode::leaf[T](kind, node : @seam.SyntaxNode, counter)` and `ProjNode::branch[T](kind, start, end, children, counter)`. Lambda/JSON/Markdown projection builders now use the shared helpers for fresh syntax leaves/branches; ID-preserving sites keep raw `ProjNode`. `.mbti` change is limited to the two new `@core` exports.
 
 - [x] Add an `EditContext` node-resolution helper (`lang/lambda/edits/text_edit.mbt`). (finding C from PR #383)
   Why: nearly every `compute_*` handler opens with the same pair of guards keyed on one `node_id` — `registry.get(id)` then `source_map.get_range(id)`, both erroring "Node not found" — made visible by the PR #383 guard sweep. `EditContext` already holds both maps.

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -18,7 +18,7 @@ Refresh with: `NEW_MOON_MOD=0 moon ide outline <pkg>` or `NEW_MOON_MOD=0 moon id
 | `next_proj_node_id(counter)` | `core/` | Monotonic counter for fresh `ProjNode` IDs. Prefer the constructors below in projection builders. |
 | `ProjNode[T]` | `core/` | Generic projection node carrying value `T`. |
 | `ProjNode::leaf(kind, syntax_node, counter)` | `core/` | Fresh childless projection node spanning a `SyntaxNode` in UTF-16 code-unit source offsets. Preferred for CST leaf projections. |
-| `ProjNode::branch(kind, start, end, children, counter)` | `core/` | Fresh projection node with explicit half-open UTF-16 source span. Use `ProjNode::new` only when preserving/reusing a known ID. |
+| `ProjNode::branch(kind, start, end, children, counter)` | `core/` | Fresh projection node with explicit half-open UTF-16 source span. Use `ProjNode` only when preserving/reusing a known ID. |
 
 **Do not:** Create parallel `id: Int` fields or ad-hoc node numbering.
 

--- a/docs/archive/2026-03-10-memo-derived-projnode-design.md
+++ b/docs/archive/2026-03-10-memo-derived-projnode-design.md
@@ -208,7 +208,7 @@ If the CST has errors, `syntax_to_proj_node` produces `Error(...)` nodes. Reconc
 | `syntax_to_proj_node(node, counter)` | **Made pub** — used by SyncEditor's Memo |
 | `unwrap_expression_root(node)` | **Made pub** — SyncEditor's Memo must mirror `parse_to_proj_node` root handling |
 | `SourceMap::new/rebuild/get_range/innermost_node_at` | No change |
-| `ProjNode::new(...)` | No change |
+| `ProjNode(...)` | No change |
 
 ### Functions that change
 

--- a/docs/archive/2026-03-18-projectional-edit-text-delta-plan.md
+++ b/docs/archive/2026-03-18-projectional-edit-text-delta-plan.md
@@ -488,7 +488,7 @@ InsertChild needs to determine the insertion position within the parent. For Mod
                 }
                 _ => {
                   // Non-Module parent: re-render whole parent with child inserted
-                  let new_child_node = ProjNode::new(kind, 0, 0, 0, [])
+                  let new_child_node = ProjNode(kind, 0, 0, 0, [])
                   let new_parent = insert_child_at(parent_node, index, new_child_node)
                   let new_text = @ast.print_term(new_parent.kind)
                   Ok(Some([{ start: parent_range.start, delete_len: parent_range.end - parent_range.start, inserted: new_text }]))

--- a/docs/archive/2026-03-29-json-projectional-editor-impl.md
+++ b/docs/archive/2026-03-29-json-projectional-editor-impl.md
@@ -749,7 +749,7 @@ pub fn syntax_to_proj_node(
     // StringValue node contains a StringToken child. Extract its text.
     let raw = node.token_text(@json.StringToken.to_raw())
     let inner = @json.parse_json_string(raw)
-    ProjNode::new(
+    ProjNode(
       @json.String(inner),
       node.start(), node.end(),
       @core.next_proj_node_id(counter),
@@ -759,7 +759,7 @@ pub fn syntax_to_proj_node(
     // NumberValue node contains a NumberToken child. Extract its text.
     let text = node.token_text(@json.NumberToken.to_raw())
     let n = try { @strconv.parse_double(text) } catch { _ => 0.0 }
-    ProjNode::new(
+    ProjNode(
       @json.Number(n),
       node.start(), node.end(),
       @core.next_proj_node_id(counter),
@@ -768,21 +768,21 @@ pub fn syntax_to_proj_node(
   } else if kind == @json.BoolValue.to_raw() {
     // BoolValue node contains either TrueKeyword or FalseKeyword token.
     let b = node.find_token(@json.TrueKeyword.to_raw()) is Some(_)
-    ProjNode::new(
+    ProjNode(
       @json.Bool(b),
       node.start(), node.end(),
       @core.next_proj_node_id(counter),
       [],
     )
   } else if kind == @json.NullValue.to_raw() {
-    ProjNode::new(
+    ProjNode(
       @json.Null,
       node.start(), node.end(),
       @core.next_proj_node_id(counter),
       [],
     )
   } else if kind == @json.ErrorNode.to_raw() {
-    ProjNode::new(
+    ProjNode(
       @json.Error("parse error"),
       node.start(), node.end(),
       @core.next_proj_node_id(counter),
@@ -793,7 +793,7 @@ pub fn syntax_to_proj_node(
     match node.nth_child(0) {
       Some(child) => syntax_to_proj_node(child, counter)
       None =>
-        ProjNode::new(
+        ProjNode(
           @json.Null,
           node.start(), node.end(),
           @core.next_proj_node_id(counter),
@@ -806,7 +806,7 @@ pub fn syntax_to_proj_node(
     match node.nth_child(0) {
       Some(value_node) => syntax_to_proj_node(value_node, counter)
       None =>
-        ProjNode::new(
+        ProjNode(
           @json.Error("empty member"),
           node.start(), node.end(),
           @core.next_proj_node_id(counter),
@@ -814,7 +814,7 @@ pub fn syntax_to_proj_node(
         )
     }
   } else {
-    ProjNode::new(
+    ProjNode(
       @json.Error("unknown node kind"),
       node.start(), node.end(),
       @core.next_proj_node_id(counter),
@@ -836,7 +836,7 @@ fn build_object_node(
       members.push((key, value_kind))
       // Use the MemberNode's span for the child ProjNode, not the value's span.
       // This ensures SourceMap::get_range() covers "key": value for delete.
-      let member_proj = ProjNode::new(
+      let member_proj = ProjNode(
         value_proj.kind,
         child.start(),  // MemberNode start
         child.end(),    // MemberNode end
@@ -846,7 +846,7 @@ fn build_object_node(
       children.push(member_proj)
     }
   }
-  ProjNode::new(
+  ProjNode(
     @json.Object(members),
     node.start(), node.end(),
     @core.next_proj_node_id(counter),
@@ -866,7 +866,7 @@ fn build_array_node(
     items.push(proj.kind)
     children.push(proj)
   }
-  ProjNode::new(
+  ProjNode(
     @json.Array(items),
     node.start(), node.end(),
     @core.next_proj_node_id(counter),
@@ -903,7 +903,7 @@ fn extract_member(
   let value_proj = match member_node.nth_child(0) {
     Some(v) => syntax_to_proj_node(v, counter)
     None =>
-      ProjNode::new(
+      ProjNode(
         @json.Error("missing value"),
         member_node.start(), member_node.end(),
         @core.next_proj_node_id(counter),

--- a/docs/archive/2026-04-04-markdown-block-editor-impl.md
+++ b/docs/archive/2026-04-04-markdown-block-editor-impl.md
@@ -401,7 +401,7 @@ pub fn syntax_to_proj_node(
         Some(tok) => tok.text()
         None => ""
       }
-      @core.ProjNode::new(
+      @core.ProjNode(
         @markdown.Block::Error(err_text),
         node.start(),
         node.end(),
@@ -410,7 +410,7 @@ pub fn syntax_to_proj_node(
       )
     }
     _ =>
-      @core.ProjNode::new(
+      @core.ProjNode(
         @markdown.Block::Paragraph([]),
         node.start(),
         node.end(),
@@ -431,7 +431,7 @@ fn build_document(
       children.push(syntax_to_proj_node(child, counter))
     }
   }
-  @core.ProjNode::new(
+  @core.ProjNode(
     @markdown.Block::Document([]),
     node.start(),
     node.end(),
@@ -455,7 +455,7 @@ fn build_heading(
     }
     None => 1
   }
-  @core.ProjNode::new(
+  @core.ProjNode(
     @markdown.Block::Heading(level, []),
     node.start(),
     node.end(),
@@ -470,7 +470,7 @@ fn build_leaf(
   counter : Ref[Int],
   kind : @markdown.Block,
 ) -> @core.ProjNode[@markdown.Block] {
-  @core.ProjNode::new(
+  @core.ProjNode(
     kind,
     node.start(),
     node.end(),
@@ -490,7 +490,7 @@ fn build_list(
       children.push(syntax_to_proj_node(child, counter))
     }
   }
-  @core.ProjNode::new(
+  @core.ProjNode(
     @markdown.Block::UnorderedList([]),
     node.start(),
     node.end(),
@@ -512,7 +512,7 @@ fn build_code_block(
       }
     None => ""
   }
-  @core.ProjNode::new(
+  @core.ProjNode(
     @markdown.Block::CodeBlock(info, ""),
     node.start(),
     node.end(),

--- a/docs/archive/completed-phases/2026-03-21-framework-extraction-phase1.md
+++ b/docs/archive/completed-phases/2026-03-21-framework-extraction-phase1.md
@@ -303,10 +303,10 @@ pub struct ProjNode[T] {
 
 - [ ] **Step 2: Update ProjNode methods**
 
-Update `ProjNode::new` and `ProjNode::id`:
+Update `ProjNode` and `ProjNode::id`:
 ```moonbit
 ///|
-pub fn ProjNode::new[T](
+pub fn ProjNode[T](
   kind : T,
   start : Int,
   end : Int,
@@ -373,7 +373,7 @@ pub fn reconcile[T : TreeNode + Eq](
     let reconciled_children = reconcile_children(
       old.children, new.children, counter,
     )
-    ProjNode::new(
+    ProjNode(
       new.kind, new.start, new.end, old.node_id, reconciled_children,
     )
   } else {

--- a/docs/archive/completed-phases/2026-03-22-incremental-sourcemap-registry.md
+++ b/docs/archive/completed-phases/2026-03-22-incremental-sourcemap-registry.md
@@ -161,11 +161,11 @@ In `projection/source_map_wbtest.mbt`, add:
 ```moonbit
 ///|
 test "SourceMap::remove_subtree removes node and children" {
-  let parent = ProjNode::new(
+  let parent = ProjNode(
     App(Var("f"), Var("x")),
     0, 5, 1,
-    [ProjNode::new(Var("f"), 0, 1, 2, []),
-     ProjNode::new(Var("x"), 2, 5, 3, [])],
+    [ProjNode(Var("f"), 0, 1, 2, []),
+     ProjNode(Var("x"), 2, 5, 3, [])],
   )
   let sm = SourceMap::from_ast(parent)
   inspect(sm.node_count(), content="3")
@@ -177,11 +177,11 @@ test "SourceMap::remove_subtree removes node and children" {
 ///|
 test "SourceMap::patch_subtree adds new node entries" {
   let sm = SourceMap::new()
-  let node = ProjNode::new(
+  let node = ProjNode(
     App(Var("f"), Var("x")),
     0, 5, 10,
-    [ProjNode::new(Var("f"), 0, 1, 11, []),
-     ProjNode::new(Var("x"), 2, 5, 12, [])],
+    [ProjNode(Var("f"), 0, 1, 11, []),
+     ProjNode(Var("x"), 2, 5, 12, [])],
   )
   sm.patch_subtree(node)
   inspect(sm.node_count(), content="3")
@@ -191,11 +191,11 @@ test "SourceMap::patch_subtree adds new node entries" {
 
 ///|
 test "SourceMap::remove_subtree then patch_subtree replaces entries" {
-  let old_child = ProjNode::new(Int(1), 10, 11, 5, [])
-  let old_root = ProjNode::new(
+  let old_child = ProjNode(Int(1), 10, 11, 5, [])
+  let old_root = ProjNode(
     Module([("x", Int(1))], Int(1)),
     0, 15, 1,
-    [old_child, ProjNode::new(Int(1), 12, 15, 6, [])],
+    [old_child, ProjNode(Int(1), 12, 15, 6, [])],
   )
   let sm = SourceMap::from_ast(old_root)
   inspect(sm.node_count(), content="3")
@@ -205,7 +205,7 @@ test "SourceMap::remove_subtree then patch_subtree replaces entries" {
   inspect(sm.node_count(), content="2")
 
   // Add new child subtree
-  let new_child = ProjNode::new(Int(2), 10, 11, 7, [])
+  let new_child = ProjNode(Int(2), 10, 11, 7, [])
   sm.patch_subtree(new_child)
   sm.rebuild_ranges()  // must be callable cross-package
   inspect(sm.node_count(), content="3")

--- a/docs/archive/completed-phases/2026-03-29-ast-zipper-impl.md
+++ b/docs/archive/completed-phases/2026-03-29-ast-zipper-impl.md
@@ -768,7 +768,7 @@ test "find_proj_node_for_focus at root" {
   let term = @ast.Int(42)
   let z = from_root(term)
   // Build a minimal ProjNode manually
-  let proj = @core.ProjNode::new(term, 0, 2, @core.next_proj_node_id({ val: 0 }), [])
+  let proj = @core.ProjNode(term, 0, 2, @core.next_proj_node_id({ val: 0 }), [])
   let found = find_proj_node_for_focus(z, proj)
   inspect!(found.is_empty(), content="false")
 }
@@ -928,4 +928,4 @@ git add -A && git commit -m "chore: update .mbti interfaces for zipper package"
 
 4. **Test output format.** MoonBit's `inspect!` uses `derive(Show)` output. Run `moon test --update` if the exact string format doesn't match — then verify the updated snapshot is correct.
 
-5. **ProjNode construction in tests.** The `ProjNode` struct may require `pub(all)` access or a constructor. Check if `ProjNode::new` exists or if struct literal construction works from the test package. If not, use whitebox tests (the `_wbtest.mbt` suffix).
+5. **ProjNode construction in tests.** The `ProjNode` struct may require `pub(all)` access or a constructor. Check if `ProjNode` exists or if struct literal construction works from the test package. If not, use whitebox tests (the `_wbtest.mbt` suffix).

--- a/docs/decisions/2026-03-29-framework-genericity-contract.md
+++ b/docs/decisions/2026-03-29-framework-genericity-contract.md
@@ -31,7 +31,7 @@ This type has different structure than `@ast.Term` (variable-arity children, no 
 
 | Test | What it verifies |
 |---|---|
-| ProjNode construction | `ProjNode::new` and field access work with any T |
+| ProjNode construction | `ProjNode` and field access work with any T |
 | SourceMap::from_ast | Source map builds correctly for non-lambda trees |
 | reconcile (preserve IDs) | Uses `TreeNode::same_kind`, not Term-specific patterns |
 | reconcile (fresh IDs) | Kind mismatch detection is generic |

--- a/docs/design/07-loomgen-design.md
+++ b/docs/design/07-loomgen-design.md
@@ -506,7 +506,7 @@ pub fn reconcile_ast(old : ProjNode, new : ProjNode, counter : Ref[Int]) -> Proj
         old.children, new.children, counter,
         same_tag=same_kind_tag, reconcile=reconcile_ast,
       )
-      ProjNode::new(rebuild_kind(new.kind, children), ...)
+      ProjNode(rebuild_kind(new.kind, children), ...)
     }
     // ... other cases ...
   }

--- a/docs/development/ADDING_A_LANGUAGE.md
+++ b/docs/development/ADDING_A_LANGUAGE.md
@@ -167,7 +167,7 @@ fn build_proj_tree(
       build_container(syntax_node, ast, collect_block_children(syntax_node), counter)
     // Leaf: no children
     _ =>
-      @core.ProjNode::new(
+      @core.ProjNode(
         ast,
         syntax_node.start(),
         syntax_node.end(),

--- a/docs/plans/2026-04-04-scope-colored-tree-view-impl.md
+++ b/docs/plans/2026-04-04-scope-colored-tree-view-impl.md
@@ -49,13 +49,13 @@
 ///|
 test "go_down focuses first child" {
   // Tree: Node(0, [Node(1, []), Node(2, [])])
-  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(10), 0, 1, 1, [],
   )
-  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(20), 2, 3, 2, [],
   )
-  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Module([], @ast.Unit), 0, 3, 0, [child0, child1],
   )
   let z = RoseZipper::from_root(root)
@@ -66,10 +66,10 @@ test "go_down focuses first child" {
 
 ///|
 test "go_down then go_up is identity" {
-  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(10), 0, 1, 1, [],
   )
-  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Module([], @ast.Unit), 0, 1, 0, [child0],
   )
   let z = RoseZipper::from_root(root)
@@ -80,13 +80,13 @@ test "go_down then go_up is identity" {
 
 ///|
 test "go_right moves to next sibling" {
-  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(10), 0, 1, 1, [],
   )
-  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(20), 2, 3, 2, [],
   )
-  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Module([], @ast.Unit), 0, 3, 0, [child0, child1],
   )
   let z = RoseZipper::from_root(root)
@@ -98,13 +98,13 @@ test "go_right moves to next sibling" {
 
 ///|
 test "go_left moves to previous sibling" {
-  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(10), 0, 1, 1, [],
   )
-  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(20), 2, 3, 2, [],
   )
-  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Module([], @ast.Unit), 0, 3, 0, [child0, child1],
   )
   let z = RoseZipper::from_root(root)
@@ -116,10 +116,10 @@ test "go_left moves to previous sibling" {
 
 ///|
 test "go_right at last sibling returns None" {
-  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(10), 0, 1, 1, [],
   )
-  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Module([], @ast.Unit), 0, 1, 0, [child0],
   )
   let z = RoseZipper::from_root(root)
@@ -129,7 +129,7 @@ test "go_right at last sibling returns None" {
 
 ///|
 test "go_down on leaf returns None" {
-  let leaf : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let leaf : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(42), 0, 1, 0, [],
   )
   let z = RoseZipper::from_root(leaf)
@@ -138,16 +138,16 @@ test "go_down on leaf returns None" {
 
 ///|
 test "path_indices round-trips via focus_at" {
-  let gc0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let gc0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Var("x"), 0, 1, 10, [],
   )
-  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child0 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Lam("x", @ast.Var("x")), 0, 3, 1, [gc0],
   )
-  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let child1 : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Int(20), 4, 5, 2, [],
   )
-  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode::new(
+  let root : @canopy_core.ProjNode[@ast.Term] = @canopy_core.ProjNode(
     @ast.Module([], @ast.Unit), 0, 5, 0, [child0, child1],
   )
   // Navigate to grandchild
@@ -237,7 +237,7 @@ fn[T] RoseZipper::go_up(self : RoseZipper[T]) -> RoseZipper[T]? {
   for node in ctx.right {
     children.push(node)
   }
-  let parent = @canopy_core.ProjNode::new(
+  let parent = @canopy_core.ProjNode(
     ctx.parent_kind,
     ctx.parent_start,
     ctx.parent_end,

--- a/docs/plans/2026-05-09-cohesion-audit.md
+++ b/docs/plans/2026-05-09-cohesion-audit.md
@@ -79,7 +79,7 @@ imports that become redundant, name collision risks.
 **Source order in merged file:**
 1. (existing) imports / `using` declarations
 2. (existing) `pub struct ProjNode[T]`, `pub impl[T : Debug] Show for ProjNode[T]`
-3. (existing) `pub fn[T] ProjNode::new`, `ProjNode::id`
+3. (existing) `pub fn[T] ProjNode`, `ProjNode::id`
 4. (existing) `pub fn next_proj_node_id`, `collect_registry`, `get_node_in_tree`, `assign_fresh_ids`
 5. **(new)** `pub impl[T : ToJson] ToJson for ProjNode[T]` — moved from `proj_node_json.mbt`
 

--- a/docs/superpowers/archive/2026-03-10-memo-derived-projnode.md
+++ b/docs/superpowers/archive/2026-03-10-memo-derived-projnode.md
@@ -107,9 +107,9 @@ git commit -m "feat: expose ReactiveParser::runtime() for downstream Memos"
 ```moonbit
 // In projection/ — whitebox test
 test "ProjNode structural equality" {
-  let a = ProjNode::new(@ast.Int(42), 0, 2, 1, [])
-  let b = ProjNode::new(@ast.Int(42), 0, 2, 1, [])
-  let c = ProjNode::new(@ast.Int(99), 0, 2, 1, [])
+  let a = ProjNode(@ast.Int(42), 0, 2, 1, [])
+  let b = ProjNode(@ast.Int(42), 0, 2, 1, [])
+  let c = ProjNode(@ast.Int(99), 0, 2, 1, [])
   assert_true(a == b)
   assert_true(a != c)
 }
@@ -180,8 +180,8 @@ And update the recursive call:
 
 Note: `new_id` changes from `NodeId` (returned by `model.new_node_id()`) to `Int` (returned by `next_proj_node_id(counter)`). Remove the `.0` accessor in the return:
 ```moonbit
-  // Was: ProjNode::new(node.kind, node.start, node.end, new_id.0, new_children)
-  ProjNode::new(node.kind, node.start, node.end, new_id, new_children)
+  // Was: ProjNode(node.kind, node.start, node.end, new_id.0, new_children)
+  ProjNode(node.kind, node.start, node.end, new_id, new_children)
 ```
 
 - [ ] **Step 2: Change `reconcile_children` signature**
@@ -727,7 +727,7 @@ fn update_node_in_tree(
     for child in root.children {
       new_children.push(update_node_in_tree(child, target_id, new_node))
     }
-    ProjNode::new(
+    ProjNode(
       rebuild_kind(root.kind, new_children),
       root.start,
       root.end,
@@ -746,7 +746,7 @@ fn remove_child_at(node : ProjNode, index : Int) -> ProjNode {
       new_children.push(child)
     }
   }
-  ProjNode::new(
+  ProjNode(
     rebuild_kind(node.kind, new_children),
     node.start,
     node.end,
@@ -768,7 +768,7 @@ fn insert_child_at(node : ProjNode, index : Int, child : ProjNode) -> ProjNode {
   if index >= node.children.length() {
     new_children.push(child)
   }
-  ProjNode::new(
+  ProjNode(
     rebuild_kind(node.kind, new_children),
     node.start,
     node.end,
@@ -948,7 +948,7 @@ pub fn apply_edit_to_proj(
     CommitEdit(node_id~, new_value~) => {
       let (parsed, _) = parse_to_proj_node(new_value)
       let new_node = assign_fresh_ids(parsed, counter)
-      let replacement = ProjNode::new(
+      let replacement = ProjNode(
         new_node.kind, new_node.start, new_node.end,
         node_id.0, new_node.children,
       )

--- a/docs/superpowers/archive/2026-03-14-source-file-grammar-switch.md
+++ b/docs/superpowers/archive/2026-03-14-source-file-grammar-switch.md
@@ -121,7 +121,7 @@ pub fn source_file_to_proj_node(
   let mut result = match final_proj {
     Some(p) => p
     None =>
-      ProjNode::new(
+      ProjNode(
         Unit,
         root.end(),
         root.end(),
@@ -131,7 +131,7 @@ pub fn source_file_to_proj_node(
   }
   for i = defs.length() - 1; i >= 0; i = i - 1 {
     let (name, init, def_node) = defs[i]
-    result = ProjNode::new(
+    result = ProjNode(
       Let(name, init.kind, result.kind),
       def_node.start(),
       result.end,

--- a/docs/superpowers/archive/2026-03-17-flat-proj.md
+++ b/docs/superpowers/archive/2026-03-17-flat-proj.md
@@ -579,12 +579,12 @@ pub fn FlatProj::to_proj_node(self : FlatProj, counter : Ref[Int]) -> ProjNode {
       } else {
         0
       }
-      ProjNode::new(Unit, end_pos, end_pos, next_proj_node_id(counter), [])
+      ProjNode(Unit, end_pos, end_pos, next_proj_node_id(counter), [])
     }
   }
   for i = self.defs.length() - 1; i >= 0; i = i - 1 {
     let (name, init, def_start, id) = self.defs[i]
-    result = ProjNode::new(
+    result = ProjNode(
       Let(name, init.kind, result.kind),
       def_start,
       result.end,

--- a/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
+++ b/docs/superpowers/plans/2026-05-30-lambda-scope-graph.md
@@ -29,7 +29,7 @@ trust the *old* assumptions some of these correct:
   `@core.NodeId(n)`. Source: `core/types.mbt:6`.
 - **ProjNode:** `@core.ProjNode[T]` with `.id() -> NodeId`, `.children`,
   `.kind`, `.start`, `.end`; construct via
-  `@core.ProjNode::new(kind, start, end, node_id, children)`. Source:
+  `@core.ProjNode(kind, start, end, node_id, children)`. Source:
   `core/proj_node.mbt:7,32`.
 - **Registry walk:** `@core.collect_registry(node, reg)` fills
   `reg : Map[@core.NodeId, @core.ProjNode[T]]` by walking the tree. Source:
@@ -304,8 +304,8 @@ fn find_var_node(
 ///|
 test "build_parent_map: child maps to parent" {
   // Hand-built tree: root(id=0) Lam with one child Var(id=1).
-  let child = @core.ProjNode::new(@ast.Term::Var("x"), 0, 1, 1, [])
-  let root = @core.ProjNode::new(
+  let child = @core.ProjNode(@ast.Term::Var("x"), 0, 1, 1, [])
+  let root = @core.ProjNode(
     @ast.Term::Lam("x", @ast.Term::Var("x")),
     0,
     5,

--- a/lang/lambda/alpha/lower_wbtest.mbt
+++ b/lang/lambda/alpha/lower_wbtest.mbt
@@ -29,7 +29,7 @@ test "lower: unresolved source var remains free" {
 
 ///|
 test "lower: source Unbound origin is preserved" {
-  let root = @core.ProjNode::new(@ast.Term::Unbound("missing"), 0, 7, 0, [])
+  let root = @core.ProjNode(@ast.Term::Unbound("missing"), 0, 7, 0, [])
   let graph = graph_for_root(root)
   guard lower_root(root, graph) is Var(Free(free)) else {
     fail("expected free unbound")
@@ -40,8 +40,8 @@ test "lower: source Unbound origin is preserved" {
 
 ///|
 test "lower: source Unbound remains free even when a binder has the same name" {
-  let child = @core.ProjNode::new(@ast.Term::Unbound("x"), 0, 1, 1, [])
-  let root = @core.ProjNode::new(
+  let child = @core.ProjNode(@ast.Term::Unbound("x"), 0, 1, 1, [])
+  let root = @core.ProjNode(
     @ast.Term::Lam("x", @ast.Term::Unbound("x")),
     0,
     8,
@@ -58,8 +58,8 @@ test "lower: source Unbound remains free even when a binder has the same name" {
 
 ///|
 test "lower: Error and Hole survive" {
-  let error_root = @core.ProjNode::new(@ast.Term::Error("bad"), 0, 3, 0, [])
-  let hole_root = @core.ProjNode::new(@ast.Term::Hole(2), 0, 1, 0, [])
+  let error_root = @core.ProjNode(@ast.Term::Error("bad"), 0, 3, 0, [])
+  let hole_root = @core.ProjNode(@ast.Term::Hole(2), 0, 1, 0, [])
   inspect(
     lower_root(error_root, graph_for_root(error_root)) is Error("bad"),
     content="true",
@@ -89,20 +89,8 @@ test "lower: sequential module scope follows ScopeGraph" {
 ///|
 test "lower: generated fallback binder ids use node identity" {
   let binders : Map[@core.NodeId, Binder] = {}
-  let first = @core.ProjNode::new(
-    @ast.Term::Lam("x", @ast.Term::Unit),
-    0,
-    0,
-    7,
-    [],
-  )
-  let second = @core.ProjNode::new(
-    @ast.Term::Lam("x", @ast.Term::Unit),
-    0,
-    0,
-    8,
-    [],
-  )
+  let first = @core.ProjNode(@ast.Term::Lam("x", @ast.Term::Unit), 0, 0, 7, [])
+  let second = @core.ProjNode(@ast.Term::Lam("x", @ast.Term::Unit), 0, 0, 8, [])
   let first_binder = binder_for_node(binders, first, "x")
   let second_binder = binder_for_node(binders, second, "x")
   inspect(first_binder.id == second_binder.id, content="false")

--- a/lang/lambda/edits/text_edit_delete.mbt
+++ b/lang/lambda/edits/text_edit_delete.mbt
@@ -30,7 +30,7 @@ fn compute_delete(ctx : EditContext[@ast.Term], node_id : NodeId) -> EditResult 
           let new_children = Array::makei(parent_node.children.length(), fn(i) {
             let c = parent_node.children[i]
             if i == child_index {
-              ProjNode::new(pk, c.start, c.end, c.node_id, [])
+              ProjNode(pk, c.start, c.end, c.node_id, [])
             } else {
               c
             }

--- a/lang/lambda/edits/text_edit_wrap.mbt
+++ b/lang/lambda/edits/text_edit_wrap.mbt
@@ -177,7 +177,7 @@ fn compute_insert_child(
         Ok(_) => ()
       }
       // Re-render whole parent with new child inserted
-      let new_child = ProjNode::new(kind, 0, 0, 0, [])
+      let new_child = ProjNode(kind, 0, 0, 0, [])
       let new_parent = insert_child_at(parent_node, index, new_child)
       let new_text = @ast.print_term(new_parent.kind)
       Ok(

--- a/lang/lambda/edits/tree_lens.mbt
+++ b/lang/lambda/edits/tree_lens.mbt
@@ -174,7 +174,7 @@ fn insert_child_at(
   if index >= node.children.length() {
     new_children.push(child)
   }
-  ProjNode::new(
+  ProjNode(
     rebuild_kind(node.kind, new_children),
     node.start,
     node.end,

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -11,7 +11,7 @@ fn error_node_with_span(
   end : Int,
   counter : Ref[Int],
 ) -> ProjNode[@ast.Term] {
-  ProjNode::new(Error(message), start, end, @core.next_proj_node_id(counter), [])
+  ProjNode(Error(message), start, end, @core.next_proj_node_id(counter), [])
 }
 
 ///|
@@ -103,7 +103,7 @@ priv struct ProjectedLetDef {
 
 ///|
 fn unit_node_at(pos : Int, counter : Ref[Int]) -> ProjNode[@ast.Term] {
-  ProjNode::new(Unit, pos, pos, @core.next_proj_node_id(counter), [])
+  ProjNode(Unit, pos, pos, @core.next_proj_node_id(counter), [])
 }
 
 ///|
@@ -163,7 +163,7 @@ fn with_tight_syntax_range(
   syntax : @seam.SyntaxNode,
 ) -> ProjNode[@ast.Term] {
   let (start, end) = syntax.tight_span()
-  ProjNode::new(proj.kind, start, end, proj.node_id, proj.children)
+  ProjNode(proj.kind, start, end, proj.node_id, proj.children)
 }
 
 ///|
@@ -381,7 +381,7 @@ pub fn syntax_to_proj_node(
         // Unwrap to inner Term (no Paren variant in Term), but keep
         // the outer ParenExpr span so positions on ( and ) are covered.
         let inner_node = syntax_to_proj_node(inner, counter)
-        ProjNode::new(
+        ProjNode(
           inner_node.kind,
           node.start(),
           node.end(),

--- a/lang/lambda/proj/projection_memo.mbt
+++ b/lang/lambda/proj/projection_memo.mbt
@@ -82,13 +82,7 @@ fn reconcile_lambda_projection_hinted(
         }
       ]
       children.push(@core.reconcile_hinted(old_body, new_body, counter, hints))
-      @core.ProjNode::new(
-        new_.kind,
-        new_.start,
-        new_.end,
-        old.node_id,
-        children,
-      )
+      @core.ProjNode(new_.kind, new_.start, new_.end, old.node_id, children)
     }
     _ => @core.reconcile_hinted(old, new_, counter, hints)
   }
@@ -217,13 +211,7 @@ fn reconcile_lambda_projection(
         }
       ]
       children.push(@core.reconcile(old_body, new_body, counter))
-      @core.ProjNode::new(
-        new_.kind,
-        new_.start,
-        new_.end,
-        old.node_id,
-        children,
-      )
+      @core.ProjNode(new_.kind, new_.start, new_.end, old.node_id, children)
     }
     _ => @core.reconcile(old, new_, counter)
   }

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -54,14 +54,10 @@ test "build: module defs become ModuleDef decls in root scope" {
 ///|
 test "build_parent_map: child maps to parent" {
   // Hand-built tree: root(id=0) Lam with one child Var(id=1).
-  let child = @core.ProjNode::new(@ast.Term::Var("x"), 0, 1, 1, [])
-  let root = @core.ProjNode::new(
-    @ast.Term::Lam("x", @ast.Term::Var("x")),
-    0,
-    5,
-    0,
-    [child],
-  )
+  let child = @core.ProjNode(@ast.Term::Var("x"), 0, 1, 1, [])
+  let root = @core.ProjNode(@ast.Term::Lam("x", @ast.Term::Var("x")), 0, 5, 0, [
+    child,
+  ])
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = {}
   @core.collect_registry(root, registry)
   let parents = build_parent_map(registry)

--- a/lang/markdown/proj/move_reconcile.mbt
+++ b/lang/markdown/proj/move_reconcile.mbt
@@ -39,7 +39,7 @@ fn reconcile_markdown_projection_hinted(
   }
   if @loomcore.TreeNode::same_kind(old.kind, new_.kind) &&
     is_block_container(new_.kind) {
-    return @core.ProjNode::new(
+    return @core.ProjNode(
       new_.kind,
       new_.start,
       new_.end,
@@ -208,7 +208,7 @@ fn markdown_move_pair(
     [old_child] => {
       consumed[old_child.id()] = true
       Some(
-        @core.ProjNode::new(
+        @core.ProjNode(
           new_child.kind,
           new_child.start,
           new_child.end,

--- a/projection/source_map_wbtest.mbt
+++ b/projection/source_map_wbtest.mbt
@@ -133,14 +133,14 @@ test "apply_edit with zero-length deletion does nothing" {
 
 ///|
 test "SourceMap::remove_subtree removes node and children" {
-  let parent = ProjNode::new(
+  let parent = ProjNode(
     @ast.Term::App(@ast.Term::Var("f"), @ast.Term::Var("x")),
     0,
     5,
     1,
     [
-      ProjNode::new(@ast.Term::Var("f"), 0, 1, 2, []),
-      ProjNode::new(@ast.Term::Var("x"), 2, 5, 3, []),
+      ProjNode(@ast.Term::Var("f"), 0, 1, 2, []),
+      ProjNode(@ast.Term::Var("x"), 2, 5, 3, []),
     ],
   )
   let sm = SourceMap::from_ast(parent)
@@ -153,14 +153,14 @@ test "SourceMap::remove_subtree removes node and children" {
 ///|
 test "SourceMap::patch_subtree adds new node entries" {
   let sm = SourceMap::new()
-  let node = ProjNode::new(
+  let node = ProjNode(
     @ast.Term::App(@ast.Term::Var("f"), @ast.Term::Var("x")),
     0,
     5,
     10,
     [
-      ProjNode::new(@ast.Term::Var("f"), 0, 1, 11, []),
-      ProjNode::new(@ast.Term::Var("x"), 2, 5, 12, []),
+      ProjNode(@ast.Term::Var("f"), 0, 1, 11, []),
+      ProjNode(@ast.Term::Var("x"), 2, 5, 12, []),
     ],
   )
   sm.patch_subtree(node)
@@ -171,13 +171,13 @@ test "SourceMap::patch_subtree adds new node entries" {
 
 ///|
 test "SourceMap::remove_subtree then patch_subtree replaces entries" {
-  let old_child = ProjNode::new(@ast.Term::Int(1), 10, 11, 5, [])
-  let old_root = ProjNode::new(
+  let old_child = ProjNode(@ast.Term::Int(1), 10, 11, 5, [])
+  let old_root = ProjNode(
     @ast.Term::Module([("x", @ast.Term::Int(1))], @ast.Term::Int(1)),
     0,
     15,
     1,
-    [old_child, ProjNode::new(@ast.Term::Int(1), 12, 15, 6, [])],
+    [old_child, ProjNode(@ast.Term::Int(1), 12, 15, 6, [])],
   )
   let sm = SourceMap::from_ast(old_root)
   inspect(sm.node_count(), content="3")
@@ -185,7 +185,7 @@ test "SourceMap::remove_subtree then patch_subtree replaces entries" {
   sm.remove_subtree(old_child)
   inspect(sm.node_count(), content="2")
 
-  let new_child = ProjNode::new(@ast.Term::Int(2), 10, 11, 7, [])
+  let new_child = ProjNode(@ast.Term::Int(2), 10, 11, 7, [])
   sm.patch_subtree(new_child)
   sm.rebuild_ranges()
   inspect(sm.node_count(), content="3")


### PR DESCRIPTION
## Summary
- Add `ProjNode::map` for AST payload transformation while preserving projection metadata.
- Mirror `RoseNode::map` with raise-polymorphic callback/result shape.
- Migrate `ProjNode` construction from deprecated `ProjNode::new(...)` factory syntax to the custom struct constructor `ProjNode(...)` / `@core.ProjNode(...)`.
- Sweep tracked docs/history so no tracked `ProjNode::new` references remain.
- Add tests for recursive mapping, metadata preservation, raising callback propagation, and constructor syntax.

## Reuse check
- Reused the new `ProjNode(...)` constructor to preserve `node_id`, `start`, and `end` while rebuilding nodes.
- Reused core `Array::map` for recursive child transformation.
- Checked `Result` APIs; not used because `map` should propagate raises directly rather than boxing them.
- Mirrored shipped `RoseNode::map` and `RoseNode::RoseNode` API shape from `lib/zipper`.

## Validation
- RED: `NEW_MOON_MOD=0 moon test core/test_expr_wbtest.mbt --filter "ProjNode[TestExpr]*"` failed before the constructor with `The value identifier ProjNode is unbound`.
- `git ls-files`-scoped tracked-file scan for `ProjNode::new` / `@core.ProjNode::new` / `@canopy_core.ProjNode::new` → no matches.
- `NEW_MOON_MOD=0 moon fmt core lang/lambda/alpha lang/lambda/proj lang/lambda/scope lang/lambda/edits lang/markdown/proj projection`
- `NEW_MOON_MOD=0 moon check core lang/lambda/alpha lang/lambda/proj lang/lambda/scope lang/lambda/edits lang/markdown/proj projection --deny-warn`
- `NEW_MOON_MOD=0 moon test core lang/lambda/alpha lang/lambda/proj lang/lambda/scope lang/lambda/edits lang/markdown/proj projection` → `Total tests: 555, passed: 555, failed: 0.`
- `NEW_MOON_MOD=0 moon info core`
- Broad `NEW_MOON_MOD=0 moon check --deny-warn` was attempted; it is blocked by pre-existing vendored submodule warnings in `order-tree`/`rle`, not by this diff.
- `git diff -- '*.mbti'` → `ProjNode::new` removed, `ProjNode::ProjNode(...)` added, `ProjNode::map(...)` retained.

Closes #759
