### PR TITLE
fix(sdeg): make heading snapshot validity explicit

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -544,7 +544,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 
 - [ ] Distinguish delete from malformed transient absence (#748).
   Why: The lifecycle `Missing` state conflates a committed delete with a transient parse failure. Both produce zero current observations, but delete should progress toward retirement while a transient absence should recover when the observation reappears.
-  Progress: The side-table API now accepts `is_valid_parse` on initial construction and `advance`. Invalid snapshots hold the lifecycle, create no durable rows, preserve `last_live`, and do not advance absence counters or retirement.
+  Progress: The side-table API now requires an explicit snapshot-validity tag on initial construction and `advance`. Invalid snapshots hold the lifecycle, create no durable rows, preserve `last_live`, and do not advance absence counters or retirement.
   Remaining: Wire the production caller to pass parser/projection validity before calling `advance`; until then, the side-table support is tested but not end-to-end.
   Exit: production wiring passes validity so valid deletes advance while invalid/malformed snapshots hold, or a documented rationale accepts any remaining conflation as a known limitation.
 

--- a/docs/design/sdeg-invariant-review.md
+++ b/docs/design/sdeg-invariant-review.md
@@ -293,7 +293,7 @@ violations · Failure symptoms · Existing evidence · Missing evidence.**
 **I1 — stable_id uniqueness.**
 Every row has a `stable_id` distinct from all others.
 · *Scope:* per snapshot. · *Preserved by:* seeding from a unique `NodeId` +
-fresh-row filter (`side_table_has_stable_id`). · *Allowed violations:* none.
+the table's historical `used_stable_ids` reservation. · *Allowed violations:* none.
 · *Failure symptoms:* two rows alias; current-node index overwrites; lost
 entities. · *Existing evidence:* snapshot-invariant test "stable_id unique"
 (`sdeg_heading_side_table_wbtest.mbt`); enforced in `advance`. · *Missing
@@ -387,8 +387,8 @@ evidence:* invariant test. · *Missing:* none material.
 
 **S5 — no duplicate representation.**
 A node listed as an `Ambiguous` candidate is not also emitted as a fresh `Live`
-row in the same snapshot. · *Preserved by:* `fresh_rows` filter via
-`side_table_mentions_current_id` (checks both `current_id` and `candidates`). ·
+row in the same snapshot. · *Preserved by:* `fresh_rows` filter via the
+`heading_mentioned_current_ids` set (checks both `current_id` and `candidates`). ·
 *Allowed violations:* none. · *Failure:* one node both spawns a new entity and is
 a pending candidate → eventual double identity. · *Existing evidence:* invariant
 test "candidate ids not emitted as fresh Live rows." · *Missing:* test of the
@@ -400,8 +400,9 @@ ordering dependency (fresh rows computed against already-advanced `next_rows`).
 with `current_id: None`. · *Allowed violations:* none. · *Failure:* a retired
 entity resurrects, colliding with a fresh one. · *Existing evidence:* impl
 filters; "retired-row behavior" test; retention-threshold test exercises the
-`Tombstoned → Retired` entry path. · *Missing:* no GC/removal test yet (GC is a
-predicate over retired rows).
+`Tombstoned → Retired` entry path; GC tests remove retired rows while preserving
+historical stable-id reservations. · *Missing:* production GC still needs a live
+pinning-reference set.
 
 **S7 — tree relation is borrowed.**
 SDEG owns no entity-to-entity tree; structure comes from projection children. ·
@@ -472,7 +473,9 @@ currently incidental, not enforced.
 **L1 — absence ladder.**
 First absence → `Missing`; continued absence → `Tombstoned`; when the table has a
 positive retention threshold, a `Tombstoned` row retires once its
-`consecutive_absences` reaches that threshold. · *Scope:* per advance. ·
+`consecutive_absences` reaches that threshold, with thresholds below `3` still
+retiring on the third valid absence because the second valid absence remains an
+observable `Tombstoned` frame. · *Scope:* per advance. ·
 *Preserved by:* `row_from_match` empty-ids arm. · *Allowed violations:* none. ·
 *Failure:* immediate tombstoning loses one-frame-flicker recovery, or unbounded
 retention ignores an explicit threshold. · *Existing evidence:* tests for first
@@ -484,24 +487,27 @@ absence, repeated absence, below-threshold retention, and threshold retirement. 
 unique match can recover them. · *Scope:* session. · *Preserved by:* `..row`
 spread keeps `last_live`. · *Allowed violations:* after `Retired`/GC (undefined).
 · *Failure:* premature discard → unrecoverable restore. · *Existing evidence:*
-restore test. · *Missing:* a bound — retention is "whole session," i.e.
-*unbounded* (a stated risk), with no GC test (G4).
+restore test; GC reservation test shows physical row removal does not make a
+collected `stable_id` reusable. · *Missing:* a production retention bound tied to
+pinning references.
 *Additional invariant (L2a):* `last_live` is updated **only** on an accepted
 `Live` match (`sdeg_heading_side_table.mbt:328`) and carried unchanged through
 `missing`/`tombstoned`/`ambiguous` via row spread (`:316`,`:346`,`:308`) — so the
 recovery substrate never drifts while an entity is absent.
 
 **L3 — Retired is terminal.** · *Preserved by:* S6. · *Existing evidence:* inert
-behavior and threshold-entry behavior. · *Missing:* no row-removal/GC exercise yet.
+behavior, threshold-entry behavior, and row-removal/GC tests that keep retired
+stable ids reserved after physical removal. · *Missing:* production pinning-set
+integration.
 
 **L4 — garbage-collectable is a property, not a state.**
 The design lists it as a lifecycle state; sketch/Phase 1 treat GC as policy. ·
-*Existing evidence:* none — no representation anywhere. · *Missing:* a decision
-on whether GC is a state or a predicate over `Retired` rows, and the safety
-condition (depends on the open "who may reference non-live entities" question)
-(G4/G13). · *Decided (#745):* predicate over `Retired`; safety precondition = no
-pinning reference (see *Decision: reference policy for non-live entities*). The
-`Retired` entry transition is now implemented via the retention threshold (#746).
+*Existing evidence:* `gc_eligible` is a predicate over `Retired`; `collect_garbage`
+physically removes retired rows while preserving historical stable-id reservations.
+· *Missing:* production computation of the live pinning-reference set. · *Decided
+(#745):* predicate over `Retired`; safety precondition = no pinning reference (see
+*Decision: reference policy for non-live entities*). The `Retired` entry transition
+is now implemented via the retention threshold (#746).
 
 **L5 — (DECIDED #745) reference rules for non-live entities.**
 Whether `Missing`/`Tombstoned`/`Ambiguous`/`Retired` entities may be referenced
@@ -534,11 +540,11 @@ ordering. · *Existing evidence:* edit-path tests run advance *after* `SyncEdito
 **Y3 — post-reconciliation ordering.**
 advance consumes observations only after parse + projection reconciliation. ·
 *Preserved by:* convention (the pipeline diagram) plus the side-table
-`is_valid_parse` hold path. · *Existing evidence:* companion edit-path test
-derives observations after `SyncEditor`; #748 wbtests cover invalid snapshots
-that must not advance the lifecycle. · *Missing:* production wiring still must
-source and pass parser/projection validity when the table graduates from
-test-local use (G11).
+validity-tag hold path. · *Existing evidence:* companion edit-path test derives
+observations after `SyncEditor`; #748 wbtests cover invalid snapshots that must
+not advance the lifecycle. · *Missing:* production wiring still must source and
+pass parser/projection validity when the table graduates from test-local use
+(G11).
 
 **Y4 — (DEFERRED/UNTESTABLE) reload + peer stability.**
 Out of scope by design; no durable anchor, deterministic key, or persistent
@@ -566,7 +572,7 @@ required" = the evidence the matcher needs to make the right call.
 | **duplicate** (`# A\n# A`) | confidence → `Ambiguous`; candidate set | distinct `stable_id` per distinct `NodeId` while both present; one-to-one (I4) | `HeadingSameSemanticKey` collision + `CandidateCount>1` | guessing → two rows on one node, or restore to wrong twin. *Avoided* by staying `Ambiguous` (duplicate test). Spurious collision if normalization is loose (Sem4). |
 | **delete** (`# A` removed) | status `Live→Missing→Tombstoned`; `current_id→None` | `stable_id`; `last_live` (recovery substrate) | `CandidateCount(0)` from a valid snapshot | committed delete also drops the projection baseline (Phase 0), so SDEG's retained `last_live` is the *only* recovery path; delete evidence must come from a valid snapshot. |
 | **restore** (deleted heading re-typed) | a new current `NodeId` (in the tested path); status →`Live` | original `stable_id` recovered iff a *unique semantic candidate* exists while the prior node is absent (freshness not required) | `HeadingSameSemanticKey` + unique candidate | duplicate text → stays `Ambiguous` (no guess); different normalization → spawns fresh (not recovered); only works before `Retired`/GC. |
-| **malformed input recovery** | transient `Missing`, then re-`Live` | `stable_id` across the bad window; ideally `NodeId` via `ProjectionIdentityTracker` | `is_valid_parse=false` side-table hold path, plus later NodeId survival (delegated to loom) or semantic recovery | side-table API now prevents premature `Tombstoned`/`Retired` for invalid snapshots; full G2 resolution still depends on production wiring passing the validity signal. |
+| **malformed input recovery** | transient `Missing`, then re-`Live` | `stable_id` across the bad window; ideally `NodeId` via `ProjectionIdentityTracker` | `HeadingSnapshotInvalid` side-table hold path, plus later NodeId survival (delegated to loom) or semantic recovery | side-table API now prevents premature `Tombstoned`/`Retired` for invalid snapshots; full G2 resolution still depends on production wiring passing the validity signal. |
 | **large paste** | many fresh `NodeId`s + fresh rows; possible mass ambiguity | rows whose `NodeId`s survive (untouched headings) | same-node for survivors; fresh for pasted | region-replacing paste freshens `NodeId`s → looks like delete-all+spawn-all; pasted duplicate text mis-resolves; **matching is O(rows×obs)** (nested filters) — scaling not stated as an invariant. |
 | **format-like rewrite** (whitespace/formatter) | source ranges, token spans (shift) | `stable_id`, `NodeId`, `Live`, signature (text unchanged) | same-node + same-key + overlapping-range | low risk; if formatter alters text normalization, key changes but same-node priority still preserves identity. *Holds today* (Phase 0). |
 | **projection regeneration** | full observation set + current-node index rebuilt | rows across regeneration | whatever `NodeId`s/keys survive regeneration | wholesale `NodeId` refresh (non-incremental rebuild) → mass semantic recovery; uniques recovered, duplicates → `Ambiguous`. **Bounded entirely by projection-identity stability** (G8). |
@@ -711,7 +717,8 @@ the three design docs disagree, the code wins and the conflict is flagged.
   still inspect its frozen `last_live` — and a pinning reference would block GC.
 - *Retention:* it *is* the retention boundary; the threshold is configured per
   table, with `0` meaning "never retire".
-- *Open:* no row-removal/GC implementation; the reference rule is decided (#745).
+- *Open:* production row-removal/GC must still be gated by the live pinning set;
+  the test-local `collect_garbage` path preserves historical stable-id reservations.
 
 **garbage-collectable** — *resolved to a predicate, not a state (#745).*
 - *Entry:* **no representation** as a state — and, per #745, none is needed: it is
@@ -895,29 +902,31 @@ Incompatible-interpretation risk: a consumer (outline, AI context) treats a
 `Live` row's heading text as a stable handle and silently relabels.
 
 **G2 — `Missing` conflates "deleted" and "transiently unparseable."**
-*Addressed in the side-table API (#748), not yet end-to-end wiring:* the
-constructor and `advance` now accept `is_valid_parse`. Invalid snapshots create
-no initial rows, create no fresh rows, clear stale current anchors, preserve
-`last_live`, and do not change `consecutive_absences` or advance
-`Missing→Tombstoned→Retired`. Valid snapshots retain the existing delete ladder.
-This gives the side table the mechanism needed to distinguish valid absence
-evidence from malformed-transient absence. *Remaining integration work:* the
-production caller must pass a parser/projection validity signal before G2 is
-fully resolved end to end; otherwise omitting the flag preserves the default
-valid-snapshot behavior for compatibility.
+*Addressed in the side-table API (#748/#764), not yet end-to-end wiring:* the
+constructor and `advance` now require an explicit snapshot-validity tag. Invalid
+snapshots create no initial rows, create no fresh rows, clear stale current
+anchors, preserve `last_live`, and do not change `consecutive_absences` or
+advance `Missing→Tombstoned→Retired`. Valid snapshots retain the existing delete
+ladder. This gives the side table the mechanism needed to distinguish valid
+absence evidence from malformed-transient absence. *Remaining integration work:*
+the production caller must pass a parser/projection validity signal before G2 is
+fully resolved end to end.
 
 **G3 — Retention threshold N was unspecified in the contract and hardwired in
 code.** *Resolved in code (#746):* the side table carries `retention_threshold`
 (`0` means never retire), and rows track `consecutive_absences`. A `Tombstoned`
 row becomes `Retired` when the threshold is positive and the counter reaches it.
-*Remaining doc drift:* the sketch still implies N=1, while the implemented ladder
-keeps first absence as `Missing`.
+Because the first valid absence is always observable as `Missing` and the second
+as `Tombstoned`, thresholds `1` and `2` effectively retire on the third valid
+absence. *Remaining doc drift:* the sketch still implies N=1, while the implemented
+ladder keeps first absence as `Missing`.
 
 **G4 — `retired` entry and `garbage-collectable` were undefined and unreachable.**
 *Resolved in two parts:* `garbage-collectable` is now a predicate over `Retired`
 (#745), and `Retired` has an implemented `Tombstoned → Retired` threshold entry
-(#746). *Remaining work:* no code removes retired rows; future GC must honor the
-no-pinning-reference precondition.
+(#746). `collect_garbage` removes retired rows while preserving historical
+stable-id reservations so a later fresh row cannot reuse a collected entity's id.
+*Remaining work:* production GC must honor the no-pinning-reference precondition.
 
 **G5 — "Global one-to-one assignment" is stated as an invariant but implemented as
 same-node reservation + local candidate-claim counting, not a global solver.** The
@@ -981,13 +990,13 @@ invariant/guard that `stable_id` is non-serializable and absent from any public
 later `pub` accessor).
 
 **G11 — "Successful projection snapshot" is an unencoded precondition of
-`advance`.** *Addressed in the side-table API (#748), not yet end-to-end
-wiring:* `from_observations` and `advance` now encode the precondition with an
-`is_valid_parse` flag. `false` selects the "parse failed → hold" path; `true`
-retains the existing successful-snapshot behavior and remains the default for
-compatibility with existing test-only callers. *Remaining integration work:* the
-production caller must source this from parser/projection diagnostics before
-wiring the side table into the `incr` runtime.
+`advance`.** *Addressed in the side-table API (#748/#764), not yet end-to-end
+wiring:* `from_observations` and `advance` now encode the precondition with a
+required snapshot-validity tag. `HeadingSnapshotInvalid` selects the "parse
+failed → hold" path; `HeadingSnapshotValid` retains the existing
+successful-snapshot behavior. *Remaining integration work:* the production
+caller must source this from parser/projection diagnostics before wiring the
+side table into the `incr` runtime.
 
 **G12 — "Never source of truth" is structural for writes but only conventional
 for reads.** `advance` cannot mutate document state (no handles) — good. But

--- a/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
+++ b/docs/plans/2026-06-18-sdeg-phase1-nodeid-side-table.md
@@ -115,7 +115,10 @@ is only "stable within this editor session and this side table".
 ### Core records
 
 Implementation can start with package-private types like these names. Exact
-field names may change during implementation.
+field names may change during implementation. The current Markdown implementation
+inlines `HeadingSignature` as `level`/`text` fields on `HeadingObservation`, does
+not track `ordinal`, and records historical `stable_id` reservations so physical
+GC cannot make an old session id reusable.
 
 ```moonbit
 struct HeadingSignature {
@@ -250,14 +253,18 @@ Ambiguous -> Missing if all candidates disappear
 ```
 
 For Phase 1, the default retention is "keep all tombstones" (`retention_threshold = 0`).
-Do not introduce production row removal until UI/undo/reload requirements are clearer.
+Positive thresholds are checked after the row has reached `Tombstoned`; because
+first valid absence is `Missing` and second valid absence is `Tombstoned`,
+thresholds below `3` effectively retire on the third valid absence. Do not
+introduce production row removal until UI/undo/reload requirements are clearer.
 
 Invalid or malformed snapshots are not successful projection snapshots. The
-side-table constructor and `advance` accept `is_valid_parse`; when false, the
-table uses a hold path: it creates no initial or fresh rows, clears current
-anchors, preserves `last_live`, and does not increment absence counters or
-advance toward `Retired`. Full G2 resolution still requires production wiring to
-pass a parser/projection validity signal before calling `advance`.
+side-table constructor and `advance` require an explicit snapshot-validity tag;
+when invalid, the table uses a hold path: it creates no initial or fresh rows,
+clears current anchors, preserves `last_live`, and does not increment absence
+counters or advance toward `Retired`. Full G2 resolution still requires
+production wiring to pass a parser/projection validity signal before calling
+`advance`.
 
 ### Expected behavior
 
@@ -359,7 +366,7 @@ committing.
   `docs/plans/2026-06-19-sdeg-reorder-provenance-investigation.md`.
 - The side table should not mutate document state or bypass Markdown edit
   lowering.
-- The validity flag is side-table support, not a substitute for production
+- The validity tag is side-table support, not a substitute for production
   parser/projection diagnostics. Callers must pass the correct validity signal
   when this table graduates from test-local use.
 

--- a/lang/markdown/proj/sdeg_heading_side_table.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table.mbt
@@ -1,5 +1,9 @@
 ///| Internal Markdown heading side table for session-local SDEG Phase 1 snapshots.
 
+// Several side-table records intentionally carry forward-looking fields and
+// constructors while SDEG remains package-private. Keep the suppressions local so
+// `moon check` still reports accidental unused code elsewhere in this package.
+
 ///|
 #warnings("-struct_never_constructed-unused_field")
 priv struct HeadingObservation {
@@ -9,6 +13,13 @@ priv struct HeadingObservation {
   range : @loomcore.Range
   marker : @loomcore.Range?
   text_span : @loomcore.Range?
+}
+
+///|
+#warnings("-unused_constructor")
+priv enum HeadingSnapshotValidity {
+  HeadingSnapshotValid
+  HeadingSnapshotInvalid
 }
 
 ///|
@@ -23,7 +34,7 @@ priv enum HeadingSideTableStatus {
 ///|
 priv struct HeadingStableRowId {
   seed : @core.NodeId
-} derive(Eq)
+} derive(Eq, Hash)
 
 ///|
 fn HeadingStableRowId::from_node(id : @core.NodeId) -> HeadingStableRowId {
@@ -81,6 +92,7 @@ priv struct HeadingSideTableRow {
 priv struct HeadingSideTable {
   rows : Array[HeadingSideTableRow]
   current_index : Map[@core.NodeId, HeadingStableRowId]
+  used_stable_ids : Set[HeadingStableRowId]
   retention_threshold : Int
   next_entity_seed : Int
 }
@@ -112,39 +124,82 @@ fn heading_side_table_live_row(obs : HeadingObservation) -> HeadingSideTableRow 
 fn heading_current_index(
   rows : Array[HeadingSideTableRow],
 ) -> Map[@core.NodeId, HeadingStableRowId] {
-  Map::from_iter(
-    rows
+  let entries : Array[(@core.NodeId, HeadingStableRowId)] = rows
     .iter()
     .filter_map(row => {
       match (row.status, row.current_id) {
         (HeadingLive, Some(id)) => Some((id, row.stable_id))
         _ => None
       }
+    })
+    .collect()
+  let index = Map::from_iter(entries.iter())
+  if index.length() != entries.length() {
+    abort("HeadingSideTable invariant violation: duplicate live current_id")
+  }
+  index
+}
+
+///|
+fn heading_used_stable_ids(
+  rows : Array[HeadingSideTableRow],
+) -> Set[HeadingStableRowId] {
+  Set::from_iter(rows.iter().map(row => row.stable_id))
+}
+
+///|
+fn heading_mentioned_current_ids(
+  rows : Array[HeadingSideTableRow],
+) -> Set[@core.NodeId] {
+  Set::from_iter(
+    rows
+    .iter()
+    .flat_map(row => {
+      let current_ids : Iter[@core.NodeId] = match row.current_id {
+        Some(id) => Iter::singleton(id)
+        None => Iter::empty()
+      }
+      current_ids + row.candidates.iter()
     }),
   )
 }
 
 ///|
+fn next_unused_stable_id(
+  used_stable_ids : Set[HeadingStableRowId],
+  seed : Int,
+) -> (HeadingStableRowId, Int) {
+  let candidate = HeadingStableRowId::from_node(@core.NodeId::from_int(seed))
+  if used_stable_ids.contains(candidate) {
+    next_unused_stable_id(used_stable_ids, seed - 1)
+  } else {
+    (candidate, seed - 1)
+  }
+}
+
+///|
+// Package-private until production side-table wiring; white-box tests exercise it.
 #warnings("-unused_value")
 fn HeadingSideTable::from_observations(
   observations : Array[HeadingObservation],
+  validity~ : HeadingSnapshotValidity,
   retention_threshold? : Int = 0,
-  is_valid_parse? : Bool = true,
 ) -> HeadingSideTable {
-  let rows = if is_valid_parse {
-    observations.map(heading_side_table_live_row)
-  } else {
-    []
+  let rows = match validity {
+    HeadingSnapshotValid => observations.map(heading_side_table_live_row)
+    HeadingSnapshotInvalid => []
   }
   {
     rows,
     current_index: heading_current_index(rows),
+    used_stable_ids: heading_used_stable_ids(rows),
     retention_threshold,
     next_entity_seed: -1,
   }
 }
 
 ///|
+// Package-private current-node index query; used by side-table invariant tests.
 #warnings("-unused_value")
 fn HeadingSideTable::entity_for_current_node(
   self : HeadingSideTable,
@@ -162,36 +217,11 @@ fn find_heading_by_id(
 }
 
 ///|
-fn side_table_has_stable_id(
-  rows : Array[HeadingSideTableRow],
-  stable_id : HeadingStableRowId,
-) -> Bool {
-  rows.iter().any(row => row.stable_id == stable_id)
-}
-
-///|
-fn node_id_in(ids : Array[@core.NodeId], id : @core.NodeId) -> Bool {
-  ids.iter().any(candidate_id => candidate_id == id)
-}
-
-///|
-fn side_table_mentions_current_id(
-  rows : Array[HeadingSideTableRow],
-  current_id : @core.NodeId,
-) -> Bool {
-  rows
-  .iter()
-  .any(row => {
-    row.current_id == Some(current_id) || node_id_in(row.candidates, current_id)
-  })
-}
-
-///|
 fn heading_evidence(
   previous : HeadingObservation,
   current : HeadingObservation,
 ) -> Array[HeadingEntityEvidence] {
-  let evidence : Array[HeadingEntityEvidence] = []
+  let evidence = []
   if previous.id == current.id {
     evidence.push(HeadingSameNodeId(current.id))
   }
@@ -290,7 +320,7 @@ fn candidate_claim_count(
   matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)],
   id : @core.NodeId,
 ) -> Int {
-  matches.iter().filter(pair => node_id_in(candidate_ids(pair.1), id)).count()
+  matches.iter().filter(pair => candidate_ids(pair.1).contains(id)).count()
 }
 
 ///|
@@ -311,7 +341,8 @@ fn current_without_ids(
   current : Array[HeadingObservation],
   excluded_ids : Array[@core.NodeId],
 ) -> Array[HeadingObservation] {
-  current.iter().filter(obs => !node_id_in(excluded_ids, obs.id)).collect()
+  let excluded : Set[@core.NodeId] = Set::from_iter(excluded_ids.iter())
+  current.iter().filter(obs => !excluded.contains(obs.id)).collect()
 }
 
 ///|
@@ -341,6 +372,10 @@ fn heading_side_table_absent_row(
         HeadingTombstoned
       }
     HeadingMissing =>
+      // A Missing row with counter=0 comes from the invalid-snapshot hold path.
+      // Its first later valid absence should stay Missing with counter=1; the
+      // second consecutive valid absence enters Tombstoned so consumers can
+      // observe the missing state before retention/GC policy applies.
       if row.consecutive_absences == 0 {
         HeadingSideTableStatus::HeadingMissing
       } else {
@@ -377,8 +412,11 @@ fn row_from_match(
             match_result.evidence,
             retention_threshold,
           )
-        [id] if match_result.confidence is HeadingExact ||
-          (claim_count(id) == 1 && match_result.confidence is HeadingProbable) =>
+        [id] if claim_count(id) == 1 &&
+          (
+            match_result.confidence is HeadingExact ||
+            match_result.confidence is HeadingProbable
+          ) =>
           match find_heading_by_id(current, id) {
             Some(current_obs) =>
               {
@@ -411,90 +449,103 @@ fn row_from_match(
 }
 
 ///|
+// Package-private until production side-table wiring; white-box tests exercise it.
 #warnings("-unused_value")
 fn HeadingSideTable::advance(
   self : HeadingSideTable,
   current : Array[HeadingObservation],
-  is_valid_parse? : Bool = true,
+  validity~ : HeadingSnapshotValidity,
 ) -> HeadingSideTable {
-  if !is_valid_parse {
-    let rows = self.rows.map(row => {
-      let status = match row.status {
-        HeadingLive | HeadingAmbiguous => HeadingSideTableStatus::HeadingMissing
-        _ => row.status
-      }
-      // Invalid snapshots supply no durable match evidence; keep `evidence` and
-      // `last_live` as last trusted data while clearing current
-      // anchors/candidates and preserving the valid-absence counter.
-      { ..row, current_id: None, status, candidates: [] }
-    })
-    {
-      rows,
-      current_index: heading_current_index(rows),
-      retention_threshold: self.retention_threshold,
-      next_entity_seed: self.next_entity_seed,
-    }
-  } else {
-    let same_node_ids = same_node_claim_ids(self.rows, current)
-    let semantic_current = current_without_ids(current, same_node_ids)
-    let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = self.rows
-      .iter()
-      .filter(row_active)
-      .map(row => {
-        (
-          row,
-          heading_side_table_match_with_same_node_priority(
-            row, current, semantic_current,
-          ),
-        )
-      })
-      .collect()
-    let next_rows = self.rows.map(row => {
-      match row.status {
-        HeadingRetired => { ..row, current_id: None, candidates: [] }
-        _ => {
-          let match_result = matches
-            .iter()
-            .find_first(pair => pair.0.stable_id == row.stable_id)
-            .unwrap().1
-          row_from_match(
-            row,
-            match_result,
-            current,
-            id => candidate_claim_count(matches, id),
-            retention_threshold=self.retention_threshold,
-          )
+  match validity {
+    HeadingSnapshotInvalid => {
+      let rows = self.rows.map(row => {
+        let status = match row.status {
+          HeadingLive | HeadingAmbiguous =>
+            HeadingSideTableStatus::HeadingMissing
+          _ => row.status
         }
+        // Invalid snapshots supply no durable match evidence; keep `evidence` and
+        // `last_live` as last trusted data while clearing current
+        // anchors/candidates and preserving the valid-absence counter.
+        { ..row, current_id: None, status, candidates: [] }
+      })
+      {
+        rows,
+        current_index: heading_current_index(rows),
+        used_stable_ids: self.used_stable_ids,
+        retention_threshold: self.retention_threshold,
+        next_entity_seed: self.next_entity_seed,
       }
-    })
-    let (fresh_rows, next_entity_seed) : (Array[HeadingSideTableRow], Int) = {
-      let result : Array[HeadingSideTableRow] = []
-      let mut seed = self.next_entity_seed
-      for obs in current {
-        if !side_table_mentions_current_id(next_rows, obs.id) &&
-          !side_table_mentions_current_id(result, obs.id) {
-          let base_stable = HeadingStableRowId::from_node(obs.id)
-          if side_table_has_stable_id(next_rows, base_stable) ||
-            side_table_has_stable_id(result, base_stable) {
-            let fallback = @core.NodeId::from_int(seed)
-            seed = seed - 1
-            result.push({
-              ..heading_side_table_live_row(obs),
-              stable_id: HeadingStableRowId::from_node(fallback),
-            })
-          } else {
-            result.push(heading_side_table_live_row(obs))
+    }
+    HeadingSnapshotValid => {
+      let same_node_ids = same_node_claim_ids(self.rows, current)
+      let semantic_current = current_without_ids(current, same_node_ids)
+      let matches : Array[(HeadingSideTableRow, HeadingSideTableMatch)] = self.rows
+        .iter()
+        .filter(row_active)
+        .map(row => {
+          (
+            row,
+            heading_side_table_match_with_same_node_priority(
+              row, current, semantic_current,
+            ),
+          )
+        })
+        .collect()
+      let next_rows = self.rows.map(row => {
+        match row.status {
+          HeadingRetired => { ..row, current_id: None, candidates: [] }
+          _ => {
+            guard matches
+              .iter()
+              .find_first(pair => pair.0.stable_id == row.stable_id)
+              is Some(pair) else {
+              abort(
+                "HeadingSideTable invariant violation: active row has no match",
+              )
+            }
+            let match_result = pair.1
+            row_from_match(
+              row,
+              match_result,
+              current,
+              id => candidate_claim_count(matches, id),
+              retention_threshold=self.retention_threshold,
+            )
           }
         }
+      })
+      let used_stable_ids = self.used_stable_ids.copy()
+      let occupied_current_ids = heading_mentioned_current_ids(next_rows)
+      let (fresh_rows, next_entity_seed) : (Array[HeadingSideTableRow], Int) = {
+        let result : Array[HeadingSideTableRow] = []
+        let mut seed = self.next_entity_seed
+        for obs in current {
+          if !occupied_current_ids.contains(obs.id) {
+            let base_stable = HeadingStableRowId::from_node(obs.id)
+            let (stable_id, next_seed) = if used_stable_ids.contains(
+                base_stable,
+              ) {
+              next_unused_stable_id(used_stable_ids, seed)
+            } else {
+              (base_stable, seed)
+            }
+            seed = next_seed
+            used_stable_ids.add(stable_id)
+            occupied_current_ids.add(obs.id)
+            result.push({ ..heading_side_table_live_row(obs), stable_id, })
+          }
+        }
+        (result, seed)
       }
-      (result, seed)
-    }
-    let rows = next_rows + fresh_rows
-    {
-      rows,
-      current_index: heading_current_index(rows),
-      retention_threshold: self.retention_threshold,
-      next_entity_seed,
+      let rows = next_rows + fresh_rows
+      {
+        rows,
+        current_index: heading_current_index(rows),
+        used_stable_ids,
+        retention_threshold: self.retention_threshold,
+        next_entity_seed,
+      }
     }
   }
 }
@@ -503,6 +554,7 @@ fn HeadingSideTable::advance(
 /// Drop all rows where `gc_eligible` returns `true`. Returns a new table
 /// with only rows that are still active or retainable.
 /// No-op when no retired rows exist.
+// Package-private until production side-table wiring; white-box tests exercise it.
 #warnings("-unused_value")
 fn HeadingSideTable::collect_garbage(
   self : HeadingSideTable,
@@ -511,6 +563,7 @@ fn HeadingSideTable::collect_garbage(
   {
     rows,
     current_index: heading_current_index(rows),
+    used_stable_ids: self.used_stable_ids.copy(),
     retention_threshold: self.retention_threshold,
     next_entity_seed: self.next_entity_seed,
   }

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -169,6 +169,7 @@ fn heading_side_table_invariants_hold(
   .iter()
   .all(row => {
     stable_row_claim_count(table.rows, row.stable_id) == 1 &&
+    table.used_stable_ids.contains(row.stable_id) &&
     evidence_has_any_candidate_count(row.evidence) &&
     heading_side_table_row_shape_valid(row, table.rows, current)
   })
@@ -186,7 +187,10 @@ test "sdeg phase0: NodeId side table preserves same-node matches before semantic
   )
   let initial_map = source_map_for(source, initial)
   let before = collect_heading_observations(initial, initial_map)
-  let table = HeadingSideTable::from_observations(before)
+  let table = HeadingSideTable::from_observations(
+    before,
+    validity=HeadingSnapshotValid,
+  )
   let a_before = find_heading(before, "A").unwrap()
   let b_before = find_heading(before, "B").unwrap()
 
@@ -196,7 +200,7 @@ test "sdeg phase0: NodeId side table preserves same-node matches before semantic
   let after = collect_heading_observations(edited, edited_map)
   let c_after = find_heading(after, "C").unwrap()
   let a_after = find_heading(after, "A").unwrap()
-  let advanced = table.advance(after)
+  let advanced = table.advance(after, validity=HeadingSnapshotValid)
   let a_row = find_side_table_row(advanced, a_before.id).unwrap()
   let b_row = find_side_table_row(advanced, b_before.id).unwrap()
 
@@ -223,16 +227,25 @@ test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
   )
   let initial_map = source_map_for(initial_source, initial)
   let before = collect_heading_observations(initial, initial_map)
-  let table = HeadingSideTable::from_observations(before)
+  let table = HeadingSideTable::from_observations(
+    before,
+    validity=HeadingSnapshotValid,
+  )
   let a_before = find_heading(before, "A").unwrap()
 
   let (deleted, deleted_map) = project_after_reconcile(
     initial, deleted_source, counter,
   )
   let deleted_observations = collect_heading_observations(deleted, deleted_map)
-  let missing_table = table.advance(deleted_observations)
+  let missing_table = table.advance(
+    deleted_observations,
+    validity=HeadingSnapshotValid,
+  )
   let a_missing_row = find_side_table_row(missing_table, a_before.id).unwrap()
-  let tombstoned_table = missing_table.advance(deleted_observations)
+  let tombstoned_table = missing_table.advance(
+    deleted_observations,
+    validity=HeadingSnapshotValid,
+  )
   let a_tombstoned_row = find_side_table_row(tombstoned_table, a_before.id).unwrap()
 
   let (restored, restored_map) = project_after_reconcile(
@@ -242,7 +255,10 @@ test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
     restored, restored_map,
   )
   let a_restored = find_heading(restored_observations, "A").unwrap()
-  let restored_table = tombstoned_table.advance(restored_observations)
+  let restored_table = tombstoned_table.advance(
+    restored_observations,
+    validity=HeadingSnapshotValid,
+  )
   let a_restored_row = find_side_table_row(restored_table, a_before.id).unwrap()
 
   inspect(a_missing_row.status == HeadingMissing, content="true")
@@ -283,7 +299,10 @@ test "sdeg phase0: NodeId side table keeps duplicate restore ambiguous" {
   )
   let initial_map = source_map_for(initial_source, initial)
   let before = collect_heading_observations(initial, initial_map)
-  let table = HeadingSideTable::from_observations(before)
+  let table = HeadingSideTable::from_observations(
+    before,
+    validity=HeadingSnapshotValid,
+  )
   let a_before = find_heading(before, "A").unwrap()
 
   let (deleted, deleted_map) = project_after_reconcile(
@@ -291,6 +310,7 @@ test "sdeg phase0: NodeId side table keeps duplicate restore ambiguous" {
   )
   let deleted_table = table.advance(
     collect_heading_observations(deleted, deleted_map),
+    validity=HeadingSnapshotValid,
   )
   let (restored, restored_map) = project_after_reconcile(
     deleted, restored_source, counter,
@@ -298,7 +318,10 @@ test "sdeg phase0: NodeId side table keeps duplicate restore ambiguous" {
   let restored_observations = collect_heading_observations(
     restored, restored_map,
   )
-  let restored_table = deleted_table.advance(restored_observations)
+  let restored_table = deleted_table.advance(
+    restored_observations,
+    validity=HeadingSnapshotValid,
+  )
   let a_restored_row = find_side_table_row(restored_table, a_before.id).unwrap()
 
   inspect(a_restored_row.status == HeadingAmbiguous, content="true")
@@ -323,8 +346,11 @@ test "sdeg phase0: NodeId side table conflicts do not double-claim current nodes
   let old_a0 = synthetic_heading(1, "A", 0)
   let old_a1 = synthetic_heading(2, "A", 4)
   let current_a = synthetic_heading(100, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a0, old_a1])
-  let advanced = table.advance([current_a])
+  let table = HeadingSideTable::from_observations(
+    [old_a0, old_a1],
+    validity=HeadingSnapshotValid,
+  )
+  let advanced = table.advance([current_a], validity=HeadingSnapshotValid)
   let row0 = find_side_table_row(advanced, old_a0.id).unwrap()
   let row1 = find_side_table_row(advanced, old_a1.id).unwrap()
 
@@ -335,8 +361,40 @@ test "sdeg phase0: NodeId side table conflicts do not double-claim current nodes
   inspect(evidence_has_candidate_count(row1.evidence, 1), content="true")
   inspect(row0.current_id is None, content="true")
   inspect(row1.current_id is None, content="true")
-  inspect(node_id_in(row0.candidates, current_a.id), content="true")
-  inspect(node_id_in(row1.candidates, current_a.id), content="true")
+  inspect(row0.candidates.contains(current_a.id), content="true")
+  inspect(row1.candidates.contains(current_a.id), content="true")
+  inspect(
+    heading_side_table_invariants_hold(advanced, [current_a]),
+    content="true",
+  )
+}
+
+///|
+test "sdeg phase1: defensive exact conflicts stay ambiguous" {
+  let old_a0 = synthetic_heading(1, "A", 0)
+  let old_a1 = synthetic_heading(2, "A shadow", 4)
+  let current_a = synthetic_heading(1, "A", 0)
+  let row0 = heading_side_table_live_row(old_a0)
+  let row1 = { ..heading_side_table_live_row(old_a1), last_live: old_a0 }
+  let rows = [row0, row1]
+  let table = {
+    rows,
+    current_index: heading_current_index(rows),
+    used_stable_ids: heading_used_stable_ids(rows),
+    retention_threshold: 0,
+    next_entity_seed: -1,
+  }
+  let advanced = table.advance([current_a], validity=HeadingSnapshotValid)
+  let row0_after = find_side_table_row(advanced, old_a0.id).unwrap()
+  let row1_after = find_side_table_row(advanced, old_a1.id).unwrap()
+
+  inspect(row0_after.status == HeadingAmbiguous, content="true")
+  inspect(row1_after.status == HeadingAmbiguous, content="true")
+  inspect(row0_after.current_id is None, content="true")
+  inspect(row1_after.current_id is None, content="true")
+  inspect(row0_after.candidates.contains(current_a.id), content="true")
+  inspect(row1_after.candidates.contains(current_a.id), content="true")
+  inspect(advanced.current_index.length(), content="0")
   inspect(
     heading_side_table_invariants_hold(advanced, [current_a]),
     content="true",
@@ -348,8 +406,11 @@ test "sdeg phase1: same-node match wins over duplicate semantic claimant" {
   let old_a0 = synthetic_heading(1, "A", 0)
   let old_a1 = synthetic_heading(2, "A", 4)
   let current_a0 = synthetic_heading(1, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a0, old_a1])
-  let advanced = table.advance([current_a0])
+  let table = HeadingSideTable::from_observations(
+    [old_a0, old_a1],
+    validity=HeadingSnapshotValid,
+  )
+  let advanced = table.advance([current_a0], validity=HeadingSnapshotValid)
   let row0 = find_side_table_row(advanced, old_a0.id).unwrap()
   let row1 = find_side_table_row(advanced, old_a1.id).unwrap()
 
@@ -370,8 +431,11 @@ test "sdeg phase1: same-node match wins over duplicate semantic claimant" {
 test "sdeg phase1: heading level change without same-node evidence stays fresh" {
   let old_a = synthetic_heading(1, "A", 0, level=1)
   let current_a = synthetic_heading(100, "A", 0, level=2)
-  let table = HeadingSideTable::from_observations([old_a])
-  let advanced = table.advance([current_a])
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
+  let advanced = table.advance([current_a], validity=HeadingSnapshotValid)
   let old_row = find_side_table_row(advanced, old_a.id).unwrap()
   let fresh_row = find_side_table_row(advanced, current_a.id).unwrap()
 
@@ -400,13 +464,19 @@ test "sdeg phase0: NodeId side table invariants hold across lifecycle states" {
   )
   let initial_map = source_map_for(source, initial)
   let initial_observations = collect_heading_observations(initial, initial_map)
-  let table = HeadingSideTable::from_observations(initial_observations)
+  let table = HeadingSideTable::from_observations(
+    initial_observations,
+    validity=HeadingSnapshotValid,
+  )
 
   let (deleted, deleted_map) = project_after_reconcile(
     initial, deleted_source, counter,
   )
   let deleted_observations = collect_heading_observations(deleted, deleted_map)
-  let deleted_table = table.advance(deleted_observations)
+  let deleted_table = table.advance(
+    deleted_observations,
+    validity=HeadingSnapshotValid,
+  )
 
   let (restored, restored_map) = project_after_reconcile(
     deleted, restored_source, counter,
@@ -414,7 +484,10 @@ test "sdeg phase0: NodeId side table invariants hold across lifecycle states" {
   let restored_observations = collect_heading_observations(
     restored, restored_map,
   )
-  let restored_table = deleted_table.advance(restored_observations)
+  let restored_table = deleted_table.advance(
+    restored_observations,
+    validity=HeadingSnapshotValid,
+  )
 
   inspect(
     heading_side_table_invariants_hold(table, initial_observations),
@@ -435,13 +508,20 @@ test "sdeg phase1: tombstoned rows retire after retention threshold" {
   let old_a = synthetic_heading(1, "A", 0)
   let table = HeadingSideTable::from_observations(
     [old_a],
+    validity=HeadingSnapshotValid,
     retention_threshold=3,
   )
-  let missing_table = table.advance([])
+  let missing_table = table.advance([], validity=HeadingSnapshotValid)
   let missing_row = find_side_table_row(missing_table, old_a.id).unwrap()
-  let tombstoned_table = missing_table.advance([])
+  let tombstoned_table = missing_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
-  let retired_table = tombstoned_table.advance([])
+  let retired_table = tombstoned_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let retired_row = find_side_table_row(retired_table, old_a.id).unwrap()
 
   inspect(missing_row.status == HeadingMissing, content="true")
@@ -464,10 +544,14 @@ test "sdeg phase1: tombstoned rows stay retained below threshold" {
   let old_a = synthetic_heading(1, "A", 0)
   let table = HeadingSideTable::from_observations(
     [old_a],
+    validity=HeadingSnapshotValid,
     retention_threshold=3,
   )
-  let missing_table = table.advance([])
-  let tombstoned_table = missing_table.advance([])
+  let missing_table = table.advance([], validity=HeadingSnapshotValid)
+  let tombstoned_table = missing_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
 
   inspect(tombstoned_row.status == HeadingTombstoned, content="true")
@@ -479,26 +563,68 @@ test "sdeg phase1: tombstoned rows stay retained below threshold" {
 }
 
 ///|
+test "sdeg phase1: positive retention threshold observes tombstone first" {
+  let old_a = synthetic_heading(1, "A", 0)
+  for threshold in [1, 2] {
+    let table = HeadingSideTable::from_observations(
+      [old_a],
+      validity=HeadingSnapshotValid,
+      retention_threshold=threshold,
+    )
+    let missing_table = table.advance([], validity=HeadingSnapshotValid)
+    let tombstoned_table = missing_table.advance(
+      [],
+      validity=HeadingSnapshotValid,
+    )
+    let retired_table = tombstoned_table.advance(
+      [],
+      validity=HeadingSnapshotValid,
+    )
+    let missing_row = find_side_table_row(missing_table, old_a.id).unwrap()
+    let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
+    let retired_row = find_side_table_row(retired_table, old_a.id).unwrap()
+
+    inspect(missing_row.status == HeadingMissing, content="true")
+    inspect(missing_row.consecutive_absences, content="1")
+    inspect(tombstoned_row.status == HeadingTombstoned, content="true")
+    inspect(tombstoned_row.consecutive_absences, content="2")
+    inspect(retired_row.status == HeadingRetired, content="true")
+    inspect(retired_row.consecutive_absences, content="3")
+    inspect(
+      heading_side_table_invariants_hold(retired_table, []),
+      content="true",
+    )
+  }
+}
+
+///|
 test "sdeg phase1: gc_eligible is true for retired, false for other statuses" {
   let old_a = synthetic_heading(1, "A", 0)
   let table = HeadingSideTable::from_observations(
     [old_a],
+    validity=HeadingSnapshotValid,
     retention_threshold=3,
   )
   let fresh_row = find_side_table_row(table, old_a.id).unwrap()
   inspect(gc_eligible(fresh_row), content="false")
 
-  let missing_table = table.advance([])
+  let missing_table = table.advance([], validity=HeadingSnapshotValid)
   let missing_row = find_side_table_row(missing_table, old_a.id).unwrap()
   inspect(missing_row.status == HeadingMissing, content="true")
   inspect(gc_eligible(missing_row), content="false")
 
-  let tombstoned_table = missing_table.advance([])
+  let tombstoned_table = missing_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
   inspect(tombstoned_row.status == HeadingTombstoned, content="true")
   inspect(gc_eligible(tombstoned_row), content="false")
 
-  let retired_table = tombstoned_table.advance([])
+  let retired_table = tombstoned_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let retired_row = find_side_table_row(retired_table, old_a.id).unwrap()
   inspect(retired_row.status == HeadingRetired, content="true")
   inspect(gc_eligible(retired_row), content="true")
@@ -519,10 +645,11 @@ test "sdeg phase1: retired rows with same NodeId get fallback stable_id" {
   let table = {
     rows,
     current_index: heading_current_index(rows),
+    used_stable_ids: heading_used_stable_ids(rows),
     retention_threshold: 0,
     next_entity_seed: -1,
   }
-  let advanced = table.advance([current_a])
+  let advanced = table.advance([current_a], validity=HeadingSnapshotValid)
   let old_row = find_side_table_row(advanced, old_a.id).unwrap()
   let fresh_row = find_row_by_current_id(advanced.rows, current_a.id).unwrap()
 
@@ -565,12 +692,16 @@ test "sdeg phase1: retired rows with fallback stable_id satisfy invariants" {
   let table = {
     rows,
     current_index: heading_current_index(rows),
+    used_stable_ids: heading_used_stable_ids(rows),
     retention_threshold: 0,
     next_entity_seed: -1,
   }
   let current_a = synthetic_heading(1, "A", 0)
   let current_b = synthetic_heading(2, "B", 0)
-  let advanced = table.advance([current_a, current_b])
+  let advanced = table.advance(
+    [current_a, current_b],
+    validity=HeadingSnapshotValid,
+  )
   let fresh_a = find_row_by_current_id(advanced.rows, current_a.id).unwrap()
   let fresh_b = find_row_by_current_id(advanced.rows, current_b.id).unwrap()
 
@@ -588,8 +719,14 @@ test "sdeg phase1: retired rows with fallback stable_id satisfy invariants" {
 test "sdeg phase1: fresh rows ignore duplicate current NodeIds" {
   let current_a = synthetic_heading(1, "A", 0)
   let duplicate_a = synthetic_heading(1, "A duplicate", 4)
-  let table = HeadingSideTable::from_observations([])
-  let advanced = table.advance([current_a, duplicate_a])
+  let table = HeadingSideTable::from_observations(
+    [],
+    validity=HeadingSnapshotValid,
+  )
+  let advanced = table.advance(
+    [current_a, duplicate_a],
+    validity=HeadingSnapshotValid,
+  )
   let fresh = find_row_by_current_id(advanced.rows, current_a.id).unwrap()
 
   inspect(advanced.rows.length(), content="1")
@@ -610,7 +747,10 @@ test "sdeg phase1: fresh rows ignore duplicate current NodeIds" {
 ///|
 test "sdeg phase1: invalid initial snapshot creates no durable rows" {
   let ghost = synthetic_heading(1, "Ghost", 0)
-  let table = HeadingSideTable::from_observations([ghost], is_valid_parse=false)
+  let table = HeadingSideTable::from_observations(
+    [ghost],
+    validity=HeadingSnapshotInvalid,
+  )
 
   inspect(table.rows.length(), content="0")
   inspect(table.current_index.length(), content="0")
@@ -626,10 +766,11 @@ test "sdeg phase1: invalid advance creates no fresh rows or seed changes" {
   let table = {
     rows,
     current_index: heading_current_index(rows),
+    used_stable_ids: heading_used_stable_ids(rows),
     retention_threshold: 0,
     next_entity_seed: -7,
   }
-  let advanced = table.advance([transient_b], is_valid_parse=false)
+  let advanced = table.advance([transient_b], validity=HeadingSnapshotInvalid)
   let old_row = find_side_table_row(advanced, old_a.id).unwrap()
 
   inspect(advanced.rows.length(), content="1")
@@ -649,8 +790,11 @@ test "sdeg phase1: invalid advance creates no fresh rows or seed changes" {
 ///|
 test "sdeg phase1: invalid advance marks live unavailable without aging" {
   let old_a = synthetic_heading(1, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a])
-  let advanced = table.advance([], is_valid_parse=false)
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
+  let advanced = table.advance([], validity=HeadingSnapshotInvalid)
   let row = find_side_table_row(advanced, old_a.id).unwrap()
 
   inspect(row.status == HeadingMissing, content="true")
@@ -665,10 +809,19 @@ test "sdeg phase1: invalid advance marks live unavailable without aging" {
 ///|
 test "sdeg phase1: invalid absence requires later valid absence before tombstone" {
   let old_a = synthetic_heading(1, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a])
-  let invalid_table = table.advance([], is_valid_parse=false)
-  let valid_missing_table = invalid_table.advance([])
-  let tombstoned_table = valid_missing_table.advance([])
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
+  let invalid_table = table.advance([], validity=HeadingSnapshotInvalid)
+  let valid_missing_table = invalid_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
+  let tombstoned_table = valid_missing_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let invalid_row = find_side_table_row(invalid_table, old_a.id).unwrap()
   let valid_missing_row = find_side_table_row(valid_missing_table, old_a.id).unwrap()
   let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
@@ -694,9 +847,18 @@ test "sdeg phase1: invalid advance clears ambiguous candidates without aging" {
   let old_a0 = synthetic_heading(1, "A", 0)
   let old_a1 = synthetic_heading(2, "A", 4)
   let current_a = synthetic_heading(100, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a0, old_a1])
-  let ambiguous_table = table.advance([current_a])
-  let invalid_table = ambiguous_table.advance([], is_valid_parse=false)
+  let table = HeadingSideTable::from_observations(
+    [old_a0, old_a1],
+    validity=HeadingSnapshotValid,
+  )
+  let ambiguous_table = table.advance(
+    [current_a],
+    validity=HeadingSnapshotValid,
+  )
+  let invalid_table = ambiguous_table.advance(
+    [],
+    validity=HeadingSnapshotInvalid,
+  )
   let row0 = find_side_table_row(invalid_table, old_a0.id).unwrap()
   let row1 = find_side_table_row(invalid_table, old_a1.id).unwrap()
 
@@ -716,15 +878,22 @@ test "sdeg phase1: invalid advance freezes missing and tombstoned rows" {
   let old_a = synthetic_heading(1, "A", 0)
   let table = HeadingSideTable::from_observations(
     [old_a],
+    validity=HeadingSnapshotValid,
     retention_threshold=3,
   )
-  let missing_table = table.advance([])
-  let invalid_missing_table = missing_table.advance([], is_valid_parse=false)
+  let missing_table = table.advance([], validity=HeadingSnapshotValid)
+  let invalid_missing_table = missing_table.advance(
+    [],
+    validity=HeadingSnapshotInvalid,
+  )
   let invalid_missing_row = find_side_table_row(invalid_missing_table, old_a.id).unwrap()
-  let tombstoned_table = missing_table.advance([])
+  let tombstoned_table = missing_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let invalid_tombstoned_table = tombstoned_table.advance(
     [],
-    is_valid_parse=false,
+    validity=HeadingSnapshotInvalid,
   )
   let invalid_tombstoned_row = find_side_table_row(
     invalid_tombstoned_table,
@@ -750,10 +919,19 @@ test "sdeg phase1: invalid advance freezes missing and tombstoned rows" {
 test "sdeg phase1: invalid advance does not update last_live from matches" {
   let old_a = synthetic_heading(1, "A", 0)
   let transient_a = synthetic_heading(1, "A changed", 0)
-  let table = HeadingSideTable::from_observations([old_a])
-  let invalid_table = table.advance([transient_a], is_valid_parse=false)
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
+  let invalid_table = table.advance(
+    [transient_a],
+    validity=HeadingSnapshotInvalid,
+  )
   let invalid_row = find_side_table_row(invalid_table, old_a.id).unwrap()
-  let recovered_table = invalid_table.advance([transient_a])
+  let recovered_table = invalid_table.advance(
+    [transient_a],
+    validity=HeadingSnapshotValid,
+  )
   let recovered_row = find_side_table_row(recovered_table, old_a.id).unwrap()
 
   inspect(invalid_row.status == HeadingMissing, content="true")
@@ -771,11 +949,17 @@ test "sdeg phase1: invalid advance does not update last_live from matches" {
 }
 
 ///|
-test "sdeg phase1: default advance treats empty valid snapshot as delete evidence" {
+test "sdeg phase1: valid advance treats empty snapshot as delete evidence" {
   let old_a = synthetic_heading(1, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a])
-  let missing_table = table.advance([])
-  let tombstoned_table = missing_table.advance([])
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
+  let missing_table = table.advance([], validity=HeadingSnapshotValid)
+  let tombstoned_table = missing_table.advance(
+    [],
+    validity=HeadingSnapshotValid,
+  )
   let missing_row = find_side_table_row(missing_table, old_a.id).unwrap()
   let tombstoned_row = find_side_table_row(tombstoned_table, old_a.id).unwrap()
 
@@ -801,6 +985,7 @@ test "sdeg phase1: collect_garbage removes retired rows only" {
   let table = {
     rows,
     current_index: heading_current_index(rows),
+    used_stable_ids: heading_used_stable_ids(rows),
     retention_threshold: 0,
     next_entity_seed: -1,
   }
@@ -820,9 +1005,84 @@ test "sdeg phase1: collect_garbage removes retired rows only" {
 }
 
 ///|
+test "sdeg phase1: collect_garbage reserves removed stable ids" {
+  let old_a = synthetic_heading(1, "A", 0)
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+    retention_threshold=3,
+  )
+  let retired_table = table
+    .advance([], validity=HeadingSnapshotValid)
+    .advance([], validity=HeadingSnapshotValid)
+    .advance([], validity=HeadingSnapshotValid)
+  let gc_table = retired_table.collect_garbage()
+  let restored_a = synthetic_heading(1, "A", 0)
+  let restored_table = gc_table.advance(
+    [restored_a],
+    validity=HeadingSnapshotValid,
+  )
+  let restored_row = find_row_by_current_id(restored_table.rows, restored_a.id).unwrap()
+
+  inspect(gc_table.rows.length(), content="0")
+  inspect(
+    gc_table.used_stable_ids.contains(HeadingStableRowId::from_node(old_a.id)),
+    content="true",
+  )
+  inspect(restored_row.status == HeadingLive, content="true")
+  inspect(
+    restored_row.stable_id ==
+    HeadingStableRowId::from_node(@core.NodeId::from_int(-1)),
+    content="true",
+  )
+  inspect(restored_table.next_entity_seed, content="-2")
+  inspect(
+    heading_side_table_invariants_hold(restored_table, [restored_a]),
+    content="true",
+  )
+
+  let second_gc_table = restored_table
+    .advance([], validity=HeadingSnapshotValid)
+    .advance([], validity=HeadingSnapshotValid)
+    .advance([], validity=HeadingSnapshotValid)
+    .collect_garbage()
+  let second_restored_a = synthetic_heading(1, "A", 0)
+  let second_restored_table = second_gc_table.advance(
+    [second_restored_a],
+    validity=HeadingSnapshotValid,
+  )
+  let second_restored_row = find_row_by_current_id(
+    second_restored_table.rows,
+    second_restored_a.id,
+  ).unwrap()
+  inspect(second_gc_table.rows.length(), content="0")
+  inspect(
+    second_gc_table.used_stable_ids.contains(
+      HeadingStableRowId::from_node(@core.NodeId::from_int(-1)),
+    ),
+    content="true",
+  )
+  inspect(
+    second_restored_row.stable_id ==
+    HeadingStableRowId::from_node(@core.NodeId::from_int(-2)),
+    content="true",
+  )
+  inspect(second_restored_table.next_entity_seed, content="-3")
+  inspect(
+    heading_side_table_invariants_hold(second_restored_table, [
+      second_restored_a,
+    ]),
+    content="true",
+  )
+}
+
+///|
 test "sdeg phase1: collect_garbage is no-op on table with no retired rows" {
   let old_a = synthetic_heading(1, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a])
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
   let gc_table = table.collect_garbage()
 
   inspect(gc_table.rows.length(), content="1")
@@ -834,12 +1094,15 @@ test "sdeg phase1: absence counter increments under default retention" {
   // With retention_threshold=0, the counter should keep incrementing even
   // after reaching Tombstoned (it was previously capped at 2).
   let old_a = synthetic_heading(1, "A", 0)
-  let table = HeadingSideTable::from_observations([old_a])
-  let t1 = table.advance([]) // abs 1: Missing
-  let t2 = t1.advance([]) // abs 2: Tombstoned
-  let t3 = t2.advance([]) // abs 3: still Tombstoned, counter=3
-  let t4 = t3.advance([]) // abs 4: still Tombstoned, counter=4
-  let t5 = t4.advance([]) // abs 5: still Tombstoned, counter=5
+  let table = HeadingSideTable::from_observations(
+    [old_a],
+    validity=HeadingSnapshotValid,
+  )
+  let t1 = table.advance([], validity=HeadingSnapshotValid) // abs 1: Missing
+  let t2 = t1.advance([], validity=HeadingSnapshotValid) // abs 2: Tombstoned
+  let t3 = t2.advance([], validity=HeadingSnapshotValid) // abs 3: still Tombstoned, counter=3
+  let t4 = t3.advance([], validity=HeadingSnapshotValid) // abs 4: still Tombstoned, counter=4
+  let t5 = t4.advance([], validity=HeadingSnapshotValid) // abs 5: still Tombstoned, counter=5
 
   let r1 = find_side_table_row(t1, old_a.id).unwrap()
   let r2 = find_side_table_row(t2, old_a.id).unwrap()


### PR DESCRIPTION
## Summary
- replace the side-table boolean parse-validity default with a required private `HeadingSnapshotValidity` tag
- preserve historical heading `stable_id` reservations across `collect_garbage`, including repeated same-`NodeId` restore cycles
- clarify retention/GC/validity docs while keeping production parser-validity wiring out of scope for #748

Closes #764.

## Validation
- `NEW_MOON_MOD=0 moon check` — passed, existing warnings only
- `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/markdown/proj` — `56/56` passed
- `NEW_MOON_MOD=0 moon fmt && NEW_MOON_MOD=0 moon info` — passed, existing warnings only
- `git diff --check` — clean
- `git diff -- '*.mbti'` — empty
- `./scripts/check-test-baseline.sh 7 moon test --release` — baseline OK: 7 vendored failures, 0 non-vendored
- `moon build --release` — passed, existing warnings only
- `/parallel-review` + focused re-review — no blockers/warnings after final edits

## Reuse check
- Project APIs reused: `heading_current_index`, `heading_side_table_live_row`, `gc_eligible`, `find_heading_by_id`, existing side-table invariant helpers/tests.
- MoonBit core APIs checked/reused: `Set::{from_iter, contains, add, copy}`, `Map::{from_iter, length}`, `Array::contains`, `Iter::{flat_map, singleton, empty}`, and `Option` pattern matching.
- Existing APIs checked but not used: no broader Map/Set abstraction fit the fallback stable-id seed allocation because it must update a session-local monotonic seed and historical reservation set together.
- New helpers introduced: historical stable-id set construction, mentioned-current-id set construction, and next-unused fallback stable-id selection; each is private and scoped to side-table invariants.
- Remaining imperative code: fresh-row allocation mutates the copied reservation/current-id sets and seed because fallback ID assignment is stateful by design.

## Scope note
Production parser/projection validity wiring remains #748; this PR only makes the package-private side-table API explicit and tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lifecycle and design notes to reflect the latest snapshot-validity and recovery behavior.
  * Clarified retention, invalid-snapshot handling, and garbage-collection expectations.

* **Bug Fixes**
  * Invalid snapshots now correctly preserve prior live state without creating durable rows or advancing absence tracking.
  * Stability of restored identifiers is now maintained across removal and recovery cycles.

* **Tests**
  * Expanded coverage for valid/invalid snapshot flows, empty snapshots, and identifier reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->