### PR TITLE
SDEG: surface positional semantic drift

### DIFF
--- a/docs/design/sdeg-invariant-review.md
+++ b/docs/design/sdeg-invariant-review.md
@@ -380,27 +380,26 @@ evidence:* snapshot-invariant test "no two Live rows share current_id." ·
 one node still cannot violate it (the impl path for same-node rows bypasses the
 claim graph — G5).
 
-**I5 — (MISSING) `NodeId` continuity is positional, not semantic.**
+**I5 — `NodeId` continuity is positional, not semantic.**
 Same-node evidence proves *position-stable* continuity; it does **not** prove the
-entity means the same thing. Should be stated as an explicit non-guarantee.
+entity means the same thing. This is now the explicit consumer contract.
 
 *Scope:* always.
 
-*Preserved by:* nothing — it is a *limit*, currently
-implicit.
+*Preserved by:* documentation plus drift evidence on same-node `Live` matches.
 
 *Allowed violations:* this is the violated property under reorder.
 
 *Failure symptoms:* silent semantic misattribution (old-A row now labels
-content-B), with *all* other invariants green.
+content-B), with *all* other invariants green, unless the drift evidence is read.
 
 *Existing evidence:* the reorder
-diagnostic tests record the *fact* (NodeIds swap attachment) but assert it as
-"expected limitation," not as a named invariant.
+diagnostic tests record both facts now: NodeIds swap attachment, and the
+side-table evidence marks semantic drift instead of leaving the `Live` match
+silent.
 
-*Missing evidence:* an
-invariant + test asserting "no consumer may treat a `Live` row's meaning as
-stable across edits that can reorder siblings without move provenance" (G1).
+*Remaining gap:* this is still a non-guarantee until explicit move provenance
+turns the reorder case into semantic preservation (G1).
 
 ### Structural invariants
 
@@ -600,10 +599,11 @@ is preserved; only that a node binding exists.
 *Failure:* reorder.
 
 *Existing
-evidence:* none (the design accepts the violation as a limitation).
+evidence:* the side-table reorder test now records semantic drift on same-node
+`Live` matches, making the violation visible rather than silent.
 
 *Missing:*
-the entire invariant, plus a corrective mechanism (move provenance) gated behind
+the invariant itself, plus a corrective mechanism (move provenance) gated behind
 a future block-edit path (G1).
 
 **Sem4 — (MISSING) normalization contract for keys.**
@@ -1139,20 +1139,23 @@ Ordered by severity. Each is a place where behavior depends on an **unstated
 invariant** or where a future implementation could diverge incompatibly. Missing
 *invariants*, not missing features.
 
-**G1 — No invariant captures semantic correctness of identity (the central gap).**
+**G1 — Semantic correctness of identity is only partially enforced (the central gap).**
 Every snapshot invariant is structural: uniqueness, Some/None, and no-shared-node.
-None asserts that a `Live` row *means* what its `last_live` says. Reorder
-satisfies all invariants while being semantically wrong.
+None can *prove* that a `Live` row means what its `last_live` says. Reorder still
+satisfies all structural invariants while being semantically wrong.
 
-*Needed:* an explicit invariant pair:
+*Implemented now:* the positional non-guarantee is stated, and the reorder
+failure is surfaced:
 
 - I5: "same-node = positional, not semantic";
-- Sem3: "identity should track meaning; not guaranteed across reorder without
-  move provenance".
+- Sem3 remains missing as a preservation invariant, but reorder now records
+  semantic drift instead of staying silent.
 
-The design also needs a stated consumer contract that meaning is unstable across
-sibling reorder. Otherwise a consumer such as outline or AI context can treat a
-`Live` row's heading text as a stable handle and silently relabel it.
+The Markdown heading side table now makes the reorder failure visible by keeping
+the row `Live` while recording semantic drift evidence on same-node matches.
+That closes the "silent relabel" part of the gap. The remaining gap is the
+corrective mechanism itself: move provenance is still required before reorder can
+count as semantic preservation rather than merely visible positional reuse.
 
 **G2 — `Missing` conflates "deleted" and "transiently unparseable."**
 *Resolved for Markdown heading side tables (#748/#764/#767):* the constructor and

--- a/docs/design/stable-document-entity-graph.md
+++ b/docs/design/stable-document-entity-graph.md
@@ -76,22 +76,29 @@ evidence.
 The system should record why identity was preserved or refreshed: range
 continuity, same syntactic role, stable semantic key, edit provenance, retained
 projection identity, language hints, or fallback matching. It should also record
-when identity is ambiguous or low confidence.
+when identity is ambiguous, low confidence, or positionally preserved while the
+semantic signature drifted.
 
 This evidence is valuable even before it drives behavior. The first spike should
 surface it in tests and debug views so identity failures become explainable.
 
-> **Review note (positional ≠ semantic).** A surviving projection `NodeId`
+> **Consumer contract (positional ≠ semantic).** A surviving projection `NodeId`
 > proves projection-*handle* continuity rather than semantic continuity.
 >
 > Pure sibling reorder keeps the old `NodeId`s but re-attaches them by position,
 > so same-node evidence is positional and meaning-stability is *not* guaranteed
 > across reorder without explicit move provenance.
 >
-> Consumers must not treat a live entity's meaning as stable across such edits.
+> Consumers must not treat a `Live` row's meaning as stable across such edits.
+> When same-node reuse keeps the row `Live` but the row's previous semantic
+> signature no longer matches the current observation, the side table should
+> surface that drift as evidence rather than silently treating the match as
+> semantically preserved.
+>
 > Explicit move provenance (`MarkdownEditOp::MoveBlock`) supplies the corrective
 > `IdentityTransform::Move` for root-sibling (#723) and same-list item (#731)
-> reorders.
+> reorders. Without that corrective path, `Live` means "currently anchored" rather
+> than "same meaning survived."
 >
 > Cross-container moves stay rejected because the sibling-level reconciler cannot
 > follow a node across a container boundary without ancestor-aware reconciliation.
@@ -99,7 +106,9 @@ surface it in tests and debug views so identity failures become explainable.
 > alone, so a moved list cannot be uniquely identified.
 >
 > See [SDEG Invariant & Semantics Review](sdeg-invariant-review.md) (I5/Sem3, G1,
-> and *Decision: Markdown move-provenance scope*).
+> and *Decision: Markdown move-provenance scope*), plus
+> [2026-06-19 reorder provenance investigation](../archive/2026-06-19-sdeg-reorder-provenance-investigation.md)
+> and [2026-06-20 block move provenance spike](../archive/2026-06-20-markdown-block-move-provenance-spike.md).
 
 ## Stability scopes
 

--- a/lang/markdown/proj/sdeg_heading_side_table.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table.mbt
@@ -55,6 +55,7 @@ priv enum HeadingSideTableConfidence {
 priv enum HeadingEntityEvidence {
   HeadingSameNodeId(@core.NodeId)
   HeadingSameSemanticKey(String)
+  HeadingSemanticDrift(String, String)
   HeadingOverlappingRange(@loomcore.Range, @loomcore.Range)
   HeadingCandidateCount(Int)
 } derive(Eq)
@@ -105,6 +106,20 @@ fn ranges_overlap(a : @loomcore.Range, b : @loomcore.Range) -> Bool {
 ///|
 fn heading_key(obs : HeadingObservation) -> String {
   "h\{obs.level}:\{obs.text}"
+}
+
+///|
+fn heading_drift_evidence(
+  previous : HeadingObservation,
+  current : HeadingObservation,
+) -> HeadingEntityEvidence? {
+  let previous_key = heading_key(previous)
+  let current_key = heading_key(current)
+  if previous_key != current_key {
+    Some(HeadingSemanticDrift(previous_key, current_key))
+  } else {
+    None
+  }
 }
 
 ///|
@@ -385,6 +400,9 @@ fn heading_evidence(
   let evidence = []
   if previous.id == current.id {
     evidence.push(HeadingSameNodeId(current.id))
+    if heading_drift_evidence(previous, current) is Some(drift) {
+      evidence.push(drift)
+    }
   }
   if previous.level == current.level && previous.text == current.text {
     evidence.push(HeadingSameSemanticKey(heading_key(previous)))

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -69,6 +69,23 @@ fn evidence_has_semantic_key(
 }
 
 ///|
+fn evidence_has_semantic_drift(
+  evidence : Array[HeadingEntityEvidence],
+  previous_key : String,
+  current_key : String,
+) -> Bool {
+  evidence
+  .iter()
+  .any(item => {
+    match item {
+      HeadingSemanticDrift(previous_candidate, current_candidate) =>
+        previous_candidate == previous_key && current_candidate == current_key
+      _ => false
+    }
+  })
+}
+
+///|
 fn evidence_has_candidate_count(
   evidence : Array[HeadingEntityEvidence],
   count : Int,
@@ -211,6 +228,51 @@ test "sdeg phase0: NodeId side table preserves same-node matches before semantic
   inspect(evidence_has_same_node(a_row.evidence, c_after.id), content="true")
   inspect(evidence_has_same_node(b_row.evidence, a_after.id), content="true")
   inspect(advanced.rows.length(), content="2")
+  inspect(heading_side_table_invariants_hold(advanced, after), content="true")
+}
+
+///|
+test "sdeg phase0: NodeId side table records semantic drift on same-node reorder" {
+  let counter : Ref[Int] = Ref(0)
+  let source = "# A\n# B\n"
+  let next_source = "# B\n# A\n"
+  let (initial_cst, _) = @markdown.parse_cst(source)
+  let initial = syntax_to_proj_node(
+    @seam.SyntaxNode::from_cst(initial_cst),
+    counter,
+  )
+  let initial_map = source_map_for(source, initial)
+  let before = collect_heading_observations(initial, initial_map)
+  let table = HeadingSideTable::from_observations(
+    before,
+    validity=HeadingSnapshotValid,
+  )
+  let a_before = find_heading(before, "A").unwrap()
+  let b_before = find_heading(before, "B").unwrap()
+  let (reordered, reordered_map) = project_after_reconcile(
+    initial, next_source, counter,
+  )
+  let after = collect_heading_observations(reordered, reordered_map)
+  let a_after = find_heading(after, "A").unwrap()
+  let b_after = find_heading(after, "B").unwrap()
+  let advanced = table.advance(after, validity=HeadingSnapshotValid)
+  let a_row = find_side_table_row(advanced, a_before.id).unwrap()
+  let b_row = find_side_table_row(advanced, b_before.id).unwrap()
+
+  inspect(a_row.status == HeadingLive, content="true")
+  inspect(b_row.status == HeadingLive, content="true")
+  inspect(a_row.current_id == Some(b_after.id), content="true")
+  inspect(b_row.current_id == Some(a_after.id), content="true")
+  inspect(evidence_has_same_node(a_row.evidence, b_after.id), content="true")
+  inspect(evidence_has_same_node(b_row.evidence, a_after.id), content="true")
+  inspect(
+    evidence_has_semantic_drift(a_row.evidence, "h1:A", "h1:B"),
+    content="true",
+  )
+  inspect(
+    evidence_has_semantic_drift(b_row.evidence, "h1:B", "h1:A"),
+    content="true",
+  )
   inspect(heading_side_table_invariants_hold(advanced, after), content="true")
 }
 


### PR DESCRIPTION
## Summary
- surface same-node semantic drift as internal SDEG evidence without changing lifecycle semantics
- add a white-box reorder test that keeps rows `Live` but records the positional/semantic mismatch
- state the positional-vs-semantic consumer contract in the SDEG design docs

Closes #747.

## Verification
- `moon check`
- `moon test lang/markdown/proj`
- `git diff -- '*.mbti'`

## Review
- fallback pre-PR reviewer: no high-confidence issues found
- Codex pre-PR review attempt timed out