### PR TITLE
fix: remove alga from vendored error-suppression lists, fix rle deprecation warnings

### DIFF
--- a/scripts/check-strict.sh
+++ b/scripts/check-strict.sh
@@ -37,11 +37,10 @@ fi
 # Directories are repo-root relative. Matches paths containing "/dir/".
 # event-graph-walker: pre-existing try? warnings
 # loom:           pre-existing [4024] unused_trait_bound + try? warnings
-# rle:            pre-existing try? warnings
 # order-tree:     pre-existing try? warnings
 # graphviz:       workspace member since #738, pre-existing warnings
 # svg-dsl:        workspace member since #738, pre-existing warnings
-VENDORED_DIRS="rabbita/rabbita alga event-graph-walker loom rle order-tree graphviz svg-dsl"
+VENDORED_DIRS="rabbita/rabbita event-graph-walker loom order-tree graphviz svg-dsl"
 
 # Build a grep -v pipeline that excludes each vendored directory.
 # For each dir, we match lines containing "/dir/" in the path.

--- a/scripts/vendored-check-common.sh
+++ b/scripts/vendored-check-common.sh
@@ -7,7 +7,7 @@
 #
 # Usage:
 #   source vendored-check-common.sh
-#   VENDORED_DIRS="rabbita/rabbita alga ..."
+#   VENDORED_DIRS="rabbita/rabbita ..."
 #   run_moon_check_with_vendored_filter [moon-check-args...]
 #
 # The function runs moon check, then filters errors from vendored paths.
@@ -20,7 +20,7 @@
 #
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
-VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita alga event-graph-walker loom rle order-tree graphviz svg-dsl}"
+VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita event-graph-walker loom order-tree graphviz svg-dsl}"
 
 run_moon_check_with_vendored_filter() {
     # Parse --keep=<dir> to exclude a directory from vendored suppression.


### PR DESCRIPTION
The DirectedGraph trait API mismatches in `alga` were fixed internally in alga commit `d311751`. RLE [0020] deprecation-warning fixes landed in rle #12 (commit `a6ffa40`). Both now produce zero errors under `moon check --deny-warn`.

- Remove `alga` from `VENDORED_DIRS` in `vendored-check-common.sh` and `check-strict.sh`
- Remove `rle` from `VENDORED_DIRS` in both scripts (rle errors fixed upstream)
- Update `rle` submodule pointer to latest main

Closes #741.