### PR TITLE
perf: speed up benchmark regression CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,7 +79,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Running benchmarks on PR branch..."
-          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer; } > pr_bench.txt 2>&1; then
+          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer -p dowdiness/canopy/editor -p dowdiness/canopy/projection -p dowdiness/canopy/lang/json/companion; } > pr_bench.txt 2>&1; then
             cat pr_bench.txt
           else
             cat pr_bench.txt
@@ -142,7 +142,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Running benchmarks on base branch..."
-          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer; } > base_bench.txt 2>&1; then
+          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer -p dowdiness/canopy/editor -p dowdiness/canopy/projection -p dowdiness/canopy/lang/json/companion; } > base_bench.txt 2>&1; then
             cat base_bench.txt
           else
             echo "(base branch benchmark failed — may not compile)" > base_bench.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Run PR benchmarks
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
         # Targeted bench: compile only packages with benchmarks + their transitive
-        # deps, not all 37 workspace members. Covers EGW (CRDT), btree (data
-        # structures), and visualizer (graphviz/incr).
+        # deps, not all 37 workspace members. Covers EGW, btree, visualizer,
+        # editor, projection, and lang/json/companion.
         continue-on-error: true
         run: |
           echo "Running benchmarks on PR branch..."

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,32 +73,19 @@ jobs:
 
       - name: Run PR benchmarks
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
-        # Workspace includes vendored submodules with pre-existing
-        # benchmark failures.
+        # Targeted bench: compile only packages with benchmarks + their transitive
+        # deps, not all 37 workspace members. Covers EGW (CRDT), btree (data
+        # structures), and visualizer (graphviz/incr).
         continue-on-error: true
         run: |
           echo "Running benchmarks on PR branch..."
-          if ./scripts/run-moon-module.sh bench . > pr_bench.txt 2>&1; then
+          if "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer > pr_bench.txt 2>&1; then
             cat pr_bench.txt
           else
             cat pr_bench.txt
-            echo "(PR benchmark failed — pre-existing vendored submodule issues)"
+            echo "(PR benchmark failed)"
           fi
 
-      - name: Run submodule benchmarks (event-graph-walker)
-        if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
-        # Vendored submodule errors (try? warnings and other pre-existing issues)
-        # surface during workspace bench runs.  Continue on error — the
-        # comparison is informational, not a gate.
-        continue-on-error: true
-        run: |
-          if ./scripts/run-moon-module.sh bench event-graph-walker > pr_egw_bench.txt 2>&1; then
-            cat pr_egw_bench.txt
-          else
-            cat pr_egw_bench.txt
-            echo "(egw benchmark failed — pre-existing vendored submodule issues)"
-            exit 0
-          fi
 
       - name: Upload PR benchmark results
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
@@ -107,7 +94,6 @@ jobs:
           name: pr-benchmark-results
           path: |
             pr_bench.txt
-            pr_egw_bench.txt
           retention-days: 7
 
   benchmark-base:
@@ -126,16 +112,14 @@ jobs:
         with:
           path: |
             base_bench.txt
-            base_egw_bench.txt
-          key: benchmark-base-v2-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
+          key: benchmark-base-v3-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
 
       - name: Validate base benchmark cache
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
         id: base-cache-files
         run: |
           if [ "${{ steps.base-benchmark-cache.outputs.cache-hit }}" = "true" ] && \
-             [ -f base_bench.txt ] && \
-             [ -f base_egw_bench.txt ]; then
+             [ -f base_bench.txt ]; then
             echo "complete=true" >> "$GITHUB_OUTPUT"
           else
             echo "complete=false" >> "$GITHUB_OUTPUT"
@@ -154,30 +138,17 @@ jobs:
 
       - name: Run base benchmarks
         if: (needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch') && steps.base-cache-files.outputs.complete != 'true'
+        # Targeted bench: same -p flags as PR branch for apples-to-apples comparison.
         continue-on-error: true
         run: |
           echo "Running benchmarks on base branch..."
-          if "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release > base_bench.txt 2>&1; then
+          if "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer > base_bench.txt 2>&1; then
             cat base_bench.txt
           else
             echo "(base branch benchmark failed — may not compile)" > base_bench.txt
             cat base_bench.txt
           fi
 
-      - name: Run submodule benchmarks (base - event-graph-walker)
-        if: (needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch') && steps.base-cache-files.outputs.complete != 'true'
-        continue-on-error: true
-        run: |
-          if (
-            cd event-graph-walker
-            "$GITHUB_WORKSPACE/scripts/moon-update.sh"
-            moon bench --release
-          ) > base_egw_bench.txt 2>&1; then
-            cat base_egw_bench.txt
-          else
-            echo "(base branch benchmark failed — may not compile)" > base_egw_bench.txt
-            cat base_egw_bench.txt
-          fi
 
       - name: Save base benchmark cache
         if: always() && (needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch') && steps.base-cache-files.outputs.complete != 'true'
@@ -186,7 +157,6 @@ jobs:
         with:
           path: |
             base_bench.txt
-            base_egw_bench.txt
           key: ${{ steps.base-benchmark-cache.outputs.cache-primary-key }}
 
       - name: Upload base benchmark results
@@ -196,7 +166,6 @@ jobs:
           name: base-benchmark-results
           path: |
             base_bench.txt
-            base_egw_bench.txt
           retention-days: 7
 
   benchmark-comparison:
@@ -259,19 +228,6 @@ jobs:
             echo '```'
             echo ""
 
-            echo "### event-graph-walker Benchmarks"
-            echo ""
-            echo "**Base branch:**"
-            echo '```'
-            cat_benchmark_file benchmark-results/base/base_egw_bench.txt
-            echo '```'
-            echo ""
-
-            echo "**PR branch:**"
-            echo '```'
-            cat_benchmark_file benchmark-results/pr/pr_egw_bench.txt
-            echo '```'
-            echo ""
 
             echo "---"
             echo "*Benchmarks run with \`--release\` flag*"
@@ -321,8 +277,6 @@ jobs:
           path: |
             benchmark-results/base/base_bench.txt
             benchmark-results/pr/pr_bench.txt
-            benchmark-results/base/base_egw_bench.txt
-            benchmark-results/pr/pr_egw_bench.txt
             comparison.md
           retention-days: 30
 
@@ -359,6 +313,12 @@ jobs:
         working-directory: examples/ideal/web
         run: npm ci
 
+      - name: Cache Playwright browsers
+        if: needs.benchmark-gate.outputs.run_editor_response == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('examples/ideal/web/package-lock.json') }}
       - name: Install Playwright browser
         if: needs.benchmark-gate.outputs.run_editor_response == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: examples/ideal/web

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,7 +79,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Running benchmarks on PR branch..."
-          if "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer > pr_bench.txt 2>&1; then
+          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer; } > pr_bench.txt 2>&1; then
             cat pr_bench.txt
           else
             cat pr_bench.txt
@@ -142,7 +142,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Running benchmarks on base branch..."
-          if "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer > base_bench.txt 2>&1; then
+          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer; } > base_bench.txt 2>&1; then
             cat base_bench.txt
           else
             echo "(base branch benchmark failed — may not compile)" > base_bench.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,11 +75,12 @@ jobs:
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
         # Targeted bench: compile only packages with benchmarks + their transitive
         # deps, not all 37 workspace members. Covers EGW, btree, visualizer,
-        # editor, projection, and lang/json/companion.
+        # editor, projection, json/companion, and loom lambda/json/markdown
+        # examples (captured when the loom submodule pointer changes).
         continue-on-error: true
         run: |
           echo "Running benchmarks on PR branch..."
-          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer -p dowdiness/canopy/editor -p dowdiness/canopy/projection -p dowdiness/canopy/lang/json/companion; } > pr_bench.txt 2>&1; then
+          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer -p dowdiness/canopy/editor -p dowdiness/canopy/projection -p dowdiness/canopy/lang/json/companion -p dowdiness/lambda/benchmarks -p dowdiness/json -p dowdiness/markdown; } > pr_bench.txt 2>&1; then
             cat pr_bench.txt
           else
             cat pr_bench.txt
@@ -112,7 +113,7 @@ jobs:
         with:
           path: |
             base_bench.txt
-          key: benchmark-base-v4-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
+          key: benchmark-base-v5-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
 
       - name: Validate base benchmark cache
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'
@@ -142,7 +143,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Running benchmarks on base branch..."
-          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer -p dowdiness/canopy/editor -p dowdiness/canopy/projection -p dowdiness/canopy/lang/json/companion; } > base_bench.txt 2>&1; then
+          if { "$GITHUB_WORKSPACE/scripts/moon-update.sh" && moon bench --release -p dowdiness/event-graph-walker -p dowdiness/btree -p dowdiness/visualizer -p dowdiness/canopy/editor -p dowdiness/canopy/projection -p dowdiness/canopy/lang/json/companion -p dowdiness/lambda/benchmarks -p dowdiness/json -p dowdiness/markdown; } > base_bench.txt 2>&1; then
             cat base_bench.txt
           else
             echo "(base branch benchmark failed — may not compile)" > base_bench.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           path: |
             base_bench.txt
-          key: benchmark-base-v3-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
+          key: benchmark-base-v4-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.ref_name }}
 
       - name: Validate base benchmark cache
         if: needs.benchmark-gate.outputs.run_moon_benchmarks == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

Benchmark Regression CI (benchmark.yml) was taking ~20 min per run on real
code changes. Three changes cut this to ~5-10 min.

### P0 — Scoped `moon bench` with `-p` flags

Replace workspace-root `moon bench --release` (compiles all **37 workspace
members**) with 9 targeted packages that actually have benchmarks:

```bash
moon bench --release \
  -p dowdiness/event-graph-walker \
  -p dowdiness/btree \
  -p dowdiness/visualizer \
  -p dowdiness/canopy/editor \
  -p dowdiness/canopy/projection \
  -p dowdiness/canopy/lang/json/companion \
  -p dowdiness/lambda/benchmarks \
  -p dowdiness/json \
  -p dowdiness/markdown
```

This compiles only 9 packages + their transitive dependencies (14 benchmark
artifacts) instead of the full 37-member workspace. Covers all benchmark
packages in the workspace — EGW, btree, visualizer, editor, projection,
json/companion, and loom lambda/json/markdown examples.

### P1 — Remove redundant EGW benchmark step

EGW is a workspace member, so the root bench already covers it. Removed
from both PR and base jobs, along with all downstream references.
Cache key bumped through v2→v3→v4→v5 as the package set expanded.

### P2 — Cache Playwright browsers

Added `actions/cache` for `~/.cache/ms-playwright` in the
editor-response-benchmark job, saving ~30-60s per run.

### Fix: brace-group redirect

`if cmd1 && cmd2 > file` only redirects `cmd2`; a `moon-update.sh`
failure left no output file. Fixed with `if { cmd1 && cmd2; } > file 2>&1`.

## Impact

| Change | Est. savings |
|--------|-------------|
| P0: `-p` scoped bench (9 pkgs, 14 artifacts) | **10-15 min** |
| P1: Remove redundant EGW | **1-2 min** |
| P2: Playwright cache | **30-60s per editor-response run** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined benchmark runs to compare only the main benchmark set, producing cleaner and more consistent results.
  * Simplified benchmark reports by removing extra submodule sections that were no longer needed.
  * Added browser binary caching for the editor-response benchmark gate, helping reduce setup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->