### PR TITLE
fix: remove order-tree from vendored error-suppression lists

### DIFF
--- a/scripts/check-strict.sh
+++ b/scripts/check-strict.sh
@@ -37,10 +37,9 @@ fi
 # Directories are repo-root relative. Matches paths containing "/dir/".
 # event-graph-walker: pre-existing try? warnings
 # loom:           pre-existing [4024] unused_trait_bound + try? warnings
-# order-tree:     pre-existing try? warnings
 # graphviz:       workspace member since #738, pre-existing warnings
 # svg-dsl:        workspace member since #738, pre-existing warnings
-VENDORED_DIRS="rabbita/rabbita event-graph-walker loom order-tree graphviz svg-dsl"
+VENDORED_DIRS="rabbita/rabbita event-graph-walker loom graphviz svg-dsl"
 
 # Build a grep -v pipeline that excludes each vendored directory.
 # For each dir, we match lines containing "/dir/" in the path.

--- a/scripts/vendored-check-common.sh
+++ b/scripts/vendored-check-common.sh
@@ -20,7 +20,7 @@
 #
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
-VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita event-graph-walker loom order-tree graphviz svg-dsl}"
+VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita event-graph-walker loom graphviz svg-dsl}"
 
 run_moon_check_with_vendored_filter() {
     # Parse --keep=<dir> to exclude a directory from vendored suppression.


### PR DESCRIPTION
Order-tree [0020] deprecation-warning fixes landed upstream in order-tree #9 (commit `ccbcda8`). Zero order-tree errors remain under `moon check --deny-warn`.

- Remove `order-tree` from `VENDORED_DIRS` in both scripts
- Update `order-tree` submodule pointer to upstream main