### PR TITLE
fix: remove graphviz and svg-dsl from vendored error-suppression lists

### DIFF
--- a/scripts/check-strict.sh
+++ b/scripts/check-strict.sh
@@ -37,9 +37,7 @@ fi
 # Directories are repo-root relative. Matches paths containing "/dir/".
 # event-graph-walker: pre-existing try? warnings
 # loom:           pre-existing [4024] unused_trait_bound + try? warnings
-# graphviz:       workspace member since #738, pre-existing warnings
-# svg-dsl:        workspace member since #738, pre-existing warnings
-VENDORED_DIRS="rabbita/rabbita event-graph-walker loom graphviz svg-dsl"
+VENDORED_DIRS="rabbita/rabbita event-graph-walker loom"
 
 # Build a grep -v pipeline that excludes each vendored directory.
 # For each dir, we match lines containing "/dir/" in the path.

--- a/scripts/vendored-check-common.sh
+++ b/scripts/vendored-check-common.sh
@@ -20,7 +20,7 @@
 #
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
-VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita event-graph-walker loom graphviz svg-dsl}"
+VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita event-graph-walker loom}"
 
 run_moon_check_with_vendored_filter() {
     # Parse --keep=<dir> to exclude a directory from vendored suppression.


### PR DESCRIPTION
graphviz and svg-dsl both produce zero errors under `moon check --deny-warn`. Remove from VENDORED_DIRS in both scripts.

Remaining VENDORED_DIRS: `rabbita/rabbita event-graph-walker loom`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated check settings so fewer directory paths are ignored during validation.
  * As a result, warnings and errors from two previously excluded areas will now appear in check results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->