### PR TITLE
fix: remove event-graph-walker from vendored error-suppression lists

### DIFF
--- a/scripts/check-strict.sh
+++ b/scripts/check-strict.sh
@@ -35,9 +35,8 @@ fi
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
 # Directories are repo-root relative. Matches paths containing "/dir/".
-# event-graph-walker: pre-existing try? warnings
 # loom:           pre-existing [4024] unused_trait_bound + try? warnings
-VENDORED_DIRS="rabbita/rabbita event-graph-walker loom"
+VENDORED_DIRS="rabbita/rabbita loom"
 
 # Build a grep -v pipeline that excludes each vendored directory.
 # For each dir, we match lines containing "/dir/" in the path.

--- a/scripts/vendored-check-common.sh
+++ b/scripts/vendored-check-common.sh
@@ -20,7 +20,7 @@
 #
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
-VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita event-graph-walker loom}"
+VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita loom}"
 
 run_moon_check_with_vendored_filter() {
     # Parse --keep=<dir> to exclude a directory from vendored suppression.


### PR DESCRIPTION
Event-graph-walker errors already fixed upstream in PR #60 (commit `edfe8ce`). Zero errors under `moon check --deny-warn`.

Remaining VENDORED_DIRS: `rabbita/rabbita loom`