### PR TITLE
feat: apply Loom JSON role spans as editor decorations

### DIFF
--- a/examples/web/json.html
+++ b/examples/web/json.html
@@ -118,6 +118,7 @@
       background: #1e1e1e;
       border: 1px solid #3c3c3c;
       border-radius: 4px;
+      position: relative;
       outline: none;
       font-size: 15px;
       line-height: 1.6;
@@ -277,6 +278,48 @@
     .node-tag.bool,
     .node-tag.null {
       color: #569cd6;
+    }
+
+    .decoration-overlay {
+      position: absolute;
+      pointer-events: none;
+      z-index: 1;
+      overflow: hidden;
+    }
+
+    .decoration-mark {
+      position: absolute;
+      pointer-events: none;
+      border-radius: 2px;
+    }
+
+    .json-role-property-key {
+      background-color: rgba(156, 220, 254, 0.12);
+    }
+
+    .json-role-string-value {
+      background-color: rgba(206, 145, 120, 0.15);
+    }
+
+    .json-role-number-literal {
+      background-color: rgba(181, 206, 168, 0.13);
+    }
+
+    .json-role-boolean-literal {
+      background-color: rgba(86, 156, 214, 0.13);
+    }
+
+    .json-role-null-literal {
+      background-color: rgba(86, 156, 214, 0.13);
+    }
+
+    .json-role-punctuation {
+      background-color: rgba(128, 128, 128, 0.10);
+    }
+
+    .json-role-error {
+      background-color: rgba(244, 135, 113, 0.18);
+      border-bottom: 1px wavy #f48771;
     }
 
     @media (max-width: 900px) {

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -1,5 +1,7 @@
 import * as crdt from '@moonbit/crdt-json';
 import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
+import { DecorationOverlay } from './decoration-overlay';
+import type { Decoration } from '@canopy/editor-adapter/types';
 import type { ViewPatch, ViewNode } from '@canopy/editor-adapter/types';
 
 type InlineMode = 'add-member' | 'wrap-object' | 'change-type' | null;
@@ -31,6 +33,8 @@ const inlineCancelEl = must<HTMLButtonElement>('toolbar-inline-cancel');
 // Protocol-based tree adapter
 const adapter = new HTMLAdapter(treeEl, errorsEl);
 
+const decorationOverlay = new DecorationOverlay(editorEl);
+
 let inlineMode: InlineMode = null;
 let lastText = '';
 let syncScheduled = false;
@@ -56,6 +60,45 @@ function kindTagToToolbarKind(kindTag: string): string {
     case 'Error': return 'error';
     default: return 'other';
   }
+}
+
+const ROLE_TO_CSS_CLASS: Record<string, string> = {
+  'property-key': 'json-role-property-key',
+  'string-value': 'json-role-string-value',
+  'number-literal': 'json-role-number-literal',
+  'boolean-literal': 'json-role-boolean-literal',
+  'null-literal': 'json-role-null-literal',
+  'punctuation': 'json-role-punctuation',
+  'error': 'json-role-error',
+};
+
+export interface JsonRoleSpanData {
+  start: number;
+  end: number;
+  role: string;
+}
+
+/** Fetch current JSON role spans from the MoonBit parser and return as typed data. */
+export function getJsonRoleSpans(): JsonRoleSpanData[] {
+  const raw = crdt.json_get_role_spans_json(handle);
+  try {
+    return JSON.parse(raw) as JsonRoleSpanData[];
+  } catch {
+    return [];
+  }
+}
+
+/** Convert role span data to Decoration[] for the overlay. */
+function roleSpansToDecorations(spans: JsonRoleSpanData[]): Decoration[] {
+  return spans
+    .filter(s => s.end > s.start)
+    .map(s => ({
+      from: s.start,
+      to: s.end,
+      css_class: ROLE_TO_CSS_CLASS[s.role] ?? '',
+      data: null,
+      widget: false,
+    }));
 }
 
 function scheduleTextSync() {
@@ -108,7 +151,8 @@ function refresh() {
       adapter.applyPatches([{ type: 'SelectNode', node_id: root.id }]);
     }
   }
-
+  const roleSpans = getJsonRoleSpans();
+  decorationOverlay.applyDecorations(roleSpansToDecorations(roleSpans));
   updateToolbarState();
 }
 
@@ -275,6 +319,7 @@ document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach((button) =>
 
 window.addEventListener('beforeunload', () => {
   adapter.destroy();
+  decorationOverlay.dispose();
   crdt.destroy_json_editor(handle);
 });
 

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -334,26 +334,3 @@ if (initialText.trim()) {
 refresh();
 
 
-/**
- * Role span with UTF-16 source offsets and a stable lower-kebab role name.
- * Role strings: property-key | string-value | number-literal | boolean-literal
- * | null-literal | punctuation | error
- */
-export interface JsonRoleSpanData {
-  start: number;
-  end: number;
-  role: string;
-}
-
-/**
- * Read current syntax role spans from the JSON editor.
- * Returns an empty array on empty document or error.
- */
-export function getJsonRoleSpans(): JsonRoleSpanData[] {
-  const raw = crdt.json_get_role_spans_json(handle);
-  try {
-    return JSON.parse(raw) as JsonRoleSpanData[];
-  } catch {
-    return [];
-  }
-}

--- a/examples/web/tests/json-editor.spec.ts
+++ b/examples/web/tests/json-editor.spec.ts
@@ -185,6 +185,11 @@ test.describe('JSON Editor — Role Spans', () => {
       return mod.getJsonRoleSpans();
     });
   }
+    return page.evaluate(async () => {
+      const mod = await import('/src/json-editor.ts');
+      return mod.getJsonRoleSpans();
+    });
+  }
 
   test('simple object returns property-key and string-value spans', async ({ page }) => {
     await loadExample(page, 'Object');
@@ -203,7 +208,21 @@ test.describe('JSON Editor — Role Spans', () => {
     }).toBe(true);
   });
 
-  test('typing broken JSON produces error role spans', async ({ page }) => {
+  test('decoration marks visible in overlay', async ({ page }) => {
+    await loadExample(page, 'Object');
+    const firstMark = page.locator('.decoration-overlay .decoration-mark').first();
+    await expect(firstMark).toBeVisible();
+    const bgColor = await firstMark.evaluate(el => getComputedStyle(el).backgroundColor);
+    // Completely transparent is rgba(0, 0, 0, 0); role classes set a visible background.
+    expect(bgColor).not.toBe('rgba(0, 0, 0, 0)');
+    const count = await page.locator('.decoration-overlay .decoration-mark').count();
+    expect(count).toBeGreaterThan(0);
+    expect(bgColor).not.toBe('rgba(0, 0, 0, 0)');
+    const count = await page.locator('.decoration-overlay .decoration-mark').count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('error input shows error decoration', async ({ page }) => {
     const editor = page.locator('#json-input');
     await editor.click();
     await page.keyboard.press('Control+A');
@@ -224,7 +243,7 @@ test.describe('JSON Editor — Role Spans', () => {
     await expect(errors.first()).toBeVisible();
   });
 
-  test('fixing broken JSON clears error role spans', async ({ page }) => {
+  test('fixing error clears error decorations', async ({ page }) => {
     const editor = page.locator('#json-input');
     await editor.click();
     await page.keyboard.press('Control+A');
@@ -239,5 +258,6 @@ test.describe('JSON Editor — Role Spans', () => {
     await page.keyboard.type('{"ok": 1}');
     // Error should clear
     await expect.poll(async () => !(await roleSpans(page)).some(s => s.role === 'error')).toBe(true);
+  });
   });
 });

--- a/examples/web/tests/json-editor.spec.ts
+++ b/examples/web/tests/json-editor.spec.ts
@@ -185,11 +185,6 @@ test.describe('JSON Editor — Role Spans', () => {
       return mod.getJsonRoleSpans();
     });
   }
-    return page.evaluate(async () => {
-      const mod = await import('/src/json-editor.ts');
-      return mod.getJsonRoleSpans();
-    });
-  }
 
   test('simple object returns property-key and string-value spans', async ({ page }) => {
     await loadExample(page, 'Object');
@@ -215,10 +210,6 @@ test.describe('JSON Editor — Role Spans', () => {
     const bgColor = await firstMark.evaluate(el => getComputedStyle(el).backgroundColor);
     // Completely transparent is rgba(0, 0, 0, 0); role classes set a visible background.
     expect(bgColor).not.toBe('rgba(0, 0, 0, 0)');
-    const count = await page.locator('.decoration-overlay .decoration-mark').count();
-    expect(count).toBeGreaterThan(0);
-    expect(bgColor).not.toBe('rgba(0, 0, 0, 0)');
-    const count = await page.locator('.decoration-overlay .decoration-mark').count();
     expect(count).toBeGreaterThan(0);
   });
 
@@ -258,6 +249,5 @@ test.describe('JSON Editor — Role Spans', () => {
     await page.keyboard.type('{"ok": 1}');
     // Error should clear
     await expect.poll(async () => !(await roleSpans(page)).some(s => s.role === 'error')).toBe(true);
-  });
   });
 });

--- a/examples/web/tests/json-editor.spec.ts
+++ b/examples/web/tests/json-editor.spec.ts
@@ -210,6 +210,7 @@ test.describe('JSON Editor — Role Spans', () => {
     const bgColor = await firstMark.evaluate(el => getComputedStyle(el).backgroundColor);
     // Completely transparent is rgba(0, 0, 0, 0); role classes set a visible background.
     expect(bgColor).not.toBe('rgba(0, 0, 0, 0)');
+    const count = await page.locator('.decoration-overlay .decoration-mark').count();
     expect(count).toBeGreaterThan(0);
   });
 

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -257,3 +257,27 @@ pub fn json_compute_view_patches_json(handle : Int) -> String {
     None => "[]"
   }
 }
+
+// ── Role spans ──────────────────────────────────────────────────────────
+
+///|
+/// Get parser role spans for the current JSON document as a JSON array of
+/// {start, end, role} objects. Reads the live syntax tree through the
+/// coordinator's protected surface.
+pub fn json_get_role_spans_json(handle : Int) -> String {
+  let h = match json_registry.get(handle) {
+    Some(v) => v
+    None => return "[]"
+  }
+  match coordinator.read_protected(h.editor_id, h.cells.parser_syntax_tree) {
+    Ok(st) => {
+      let spans = @djson.project_json_roles(st)
+      let exports = @djson.export_json_role_spans(spans)
+      Json::array(exports.map(s => s.to_json())).stringify()
+    }
+    Err(report) => {
+      println("json_get_role_spans_json syntax read: \{report}")
+      "[]"
+    }
+  }
+}

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -7,7 +7,7 @@
 
 ///|
 priv struct JsonHandle {
-  editor : @editor.SyncEditor[@loom_json.JsonValue]
+  editor : @editor.SyncEditor[@djson.JsonValue]
   editor_id : @workspace.EditorId
   cells : JsonProtectedCells
 }
@@ -142,31 +142,6 @@ pub fn json_get_source_map_json(handle : Int) -> String {
         }
       }
     None => "[]"
-  }
-}
-
-// ── Role spans ───────────────────────────────────────────────────────────
-
-///|
-/// Get JSON syntax role spans as a JSON array of {start, end, role} objects.
-/// Reads the current parser syntax tree through the coordinator's protected
-/// surface. Returns "[]" on protected read failure.
-pub fn json_get_role_spans_json(handle : Int) -> String {
-  let h = match json_registry.get(handle) {
-    Some(v) => v
-    None => return "[]"
-  }
-  match coordinator.read_protected(h.editor_id, h.cells.parser_syntax_tree) {
-    Ok(syntax) => {
-      let spans = @loom_json.project_json_roles(syntax)
-      let exports = @loom_json.export_json_role_spans(spans)
-      let json_values = exports.map(e => e.to_json())
-      Json::array(json_values).stringify()
-    }
-    Err(report) => {
-      println("json_get_role_spans_json syntax tree read: \{report}")
-      "[]"
-    }
   }
 }
 

--- a/ffi/json/moon.pkg
+++ b/ffi/json/moon.pkg
@@ -5,7 +5,7 @@ import {
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/companion" @json_companion,
   "dowdiness/canopy/workspace/coordinator" @workspace,
-  "dowdiness/json" @loom_json,
+  "dowdiness/json" @djson,
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",
   "moonbitlang/core/json" @core_json,

--- a/ffi/json/protected_cells.mbt
+++ b/ffi/json/protected_cells.mbt
@@ -16,9 +16,7 @@ priv struct JsonProtectedCells {
   parser_ast : @workspace.ProtectedCell[@djson.JsonValue]
   parser_source : @workspace.ProtectedCell[String]
   parser_diagnostics : @workspace.ProtectedCell[@loom.DiagnosticSet]
-  cached_proj_node : @workspace.ProtectedCell[
-    @core.ProjNode[@djson.JsonValue]?,
-  ]
+  cached_proj_node : @workspace.ProtectedCell[@core.ProjNode[@djson.JsonValue]?]
   registry_memo : @workspace.ProtectedCell[
     Map[@core.NodeId, @core.ProjNode[@djson.JsonValue]],
   ]

--- a/ffi/json/protected_cells.mbt
+++ b/ffi/json/protected_cells.mbt
@@ -13,21 +13,21 @@
 ///|
 priv struct JsonProtectedCells {
   parser_syntax_tree : @workspace.ProtectedCell[@seam.SyntaxNode]
-  parser_ast : @workspace.ProtectedCell[@loom_json.JsonValue]
+  parser_ast : @workspace.ProtectedCell[@djson.JsonValue]
   parser_source : @workspace.ProtectedCell[String]
   parser_diagnostics : @workspace.ProtectedCell[@loom.DiagnosticSet]
   cached_proj_node : @workspace.ProtectedCell[
-    @core.ProjNode[@loom_json.JsonValue]?,
+    @core.ProjNode[@djson.JsonValue]?,
   ]
   registry_memo : @workspace.ProtectedCell[
-    Map[@core.NodeId, @core.ProjNode[@loom_json.JsonValue]],
+    Map[@core.NodeId, @core.ProjNode[@djson.JsonValue]],
   ]
   source_map_memo : @workspace.ProtectedCell[@core.SourceMap]
 }
 
 ///|
 fn JsonProtectedCells::JsonProtectedCells(
-  editor : @editor.SyncEditor[@loom_json.JsonValue],
+  editor : @editor.SyncEditor[@djson.JsonValue],
 ) -> JsonProtectedCells {
   {
     parser_syntax_tree: @workspace.ProtectedCell::from_derived(


### PR DESCRIPTION
## Summary

Applies Loom JSON role spans as visual decorations on the contenteditable JSON editor. The pipeline spans MoonBit FFI, TypeScript integration, CSS styling, and E2E tests.

## Changes

### MoonBit FFI (`ffi/json/`)
- **`json_get_role_spans_json(handle)`** — reads the `parser_syntax_tree` through the coordinator's protected surface, projects roles via `@djson.project_json_roles`, exports via `@djson.export_json_role_spans`, returns JSON array of `{start, end, role}` objects.
- Uses a **lazy read** approach (not a reactive `Derived` cell) because `Derived::map` is currently unresolvable from `ffi/json`. Tracked in #782 for when incr releases a version supporting it.

### TypeScript (`examples/web/`)
- **`json-editor.ts`**: Creates `DecorationOverlay` instance, exports `getJsonRoleSpans()`, converts spans to `Decoration[]` via `roleSpansToDecorations()`, applies in `refresh()`.
- **`json.html`**: Adds `.decoration-overlay` / `.decoration-mark` base styles and 7 role-specific CSS classes (`json-role-property-key`, `-string-value`, `-number-literal`, `-boolean-literal`, `-null-literal`, `-punctuation`, `-error`) with semi-transparent backgrounds.

### Tests
- **5 new E2E tests** spanning role span content per example, overlay mark visibility, error role, and error clearing on fix.

## Related
- Closes #775
- Creates #782 (tracking `Derived::map` migration)