### PR TITLE
feat(json): use Derived::map for role spans reactive cell (#782)

### DIFF
--- a/examples/canvas/moon.mod
+++ b/examples/canvas/moon.mod
@@ -7,7 +7,7 @@ import {
   "dowdiness/canopy-canvas-graph@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/rabbita_codemirror@0.0.1",
-  "dowdiness/incr@0.9.0",
+  "dowdiness/incr@0.11.0",
   "dowdiness/rabbita-menu@0.1.0",
   "dowdiness/rabbita-context-menu@0.1.0",
   "dowdiness/rabbita-status@0.1.0",

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -235,23 +235,16 @@ pub fn json_compute_view_patches_json(handle : Int) -> String {
 
 // ── Role spans ──────────────────────────────────────────────────────────
 
+///| Get parser role spans for the current JSON document as a JSON array of
+
 ///|
-/// Get parser role spans for the current JSON document as a JSON array of
-/// {start, end, role} objects. Reads the live syntax tree through the
-/// coordinator's protected surface.
+/// {start, end, role} objects. Read from the reactive protected cell.
 pub fn json_get_role_spans_json(handle : Int) -> String {
-  let h = match json_registry.get(handle) {
-    Some(v) => v
-    None => return "[]"
-  }
-  match coordinator.read_protected(h.editor_id, h.cells.parser_syntax_tree) {
-    Ok(st) => {
-      let spans = @djson.project_json_roles(st)
-      let exports = @djson.export_json_role_spans(spans)
-      Json::array(exports.map(s => s.to_json())).stringify()
-    }
+  guard json_registry.get(handle) is Some(h) else { return "[]" }
+  match coordinator.read_protected(h.editor_id, h.cells.parser_role_spans) {
+    Ok(exports) => Json::array(exports.map(s => s.to_json())).stringify()
     Err(report) => {
-      println("json_get_role_spans_json syntax read: \{report}")
+      println("json_get_role_spans_json cell read: \{report}")
       "[]"
     }
   }

--- a/ffi/json/protected_cells.mbt
+++ b/ffi/json/protected_cells.mbt
@@ -6,13 +6,14 @@
 // freshly-built editor inside `assemble_json_handle` (json_ffi.mbt) and
 // erased to `Array[ProtectedRead]` for registration with the coordinator.
 //
-// 7-cell SyncEditor-generic subset (no language companion + no typecheck
+// 8-cell SyncEditor-generic subset (no language companion + no typecheck
 // pipeline). See docs/superpowers/specs/2026-05-25-p0b-phase1b-ws2-design.md
 // §5.1.
 
 ///|
 priv struct JsonProtectedCells {
   parser_syntax_tree : @workspace.ProtectedCell[@seam.SyntaxNode]
+  parser_role_spans : @workspace.ProtectedCell[Array[@djson.JsonRoleSpanExport]]
   parser_ast : @workspace.ProtectedCell[@djson.JsonValue]
   parser_source : @workspace.ProtectedCell[String]
   parser_diagnostics : @workspace.ProtectedCell[@loom.DiagnosticSet]
@@ -31,6 +32,15 @@ fn JsonProtectedCells::JsonProtectedCells(
     parser_syntax_tree: @workspace.ProtectedCell::from_derived(
       "parser_syntax_view",
       editor.parser_syntax_tree(),
+    ),
+    parser_role_spans: @workspace.ProtectedCell::from_derived(
+      "parser_role_spans",
+      editor
+      .parser_syntax_tree()
+      .map(
+        fn(st) { @djson.export_json_role_spans(@djson.project_json_roles(st)) },
+        label="parser_role_spans",
+      ),
     ),
     parser_ast: @workspace.ProtectedCell::from_derived(
       "parser_ast_view",
@@ -65,6 +75,7 @@ fn JsonProtectedCells::to_protected_reads(
 ) -> Array[@workspace.ProtectedRead] {
   [
     self.parser_syntax_tree.erase(),
+    self.parser_role_spans.erase(),
     self.parser_ast.erase(),
     self.parser_source.erase(),
     self.parser_diagnostics.erase(),

--- a/lib/cognition/moon.mod
+++ b/lib/cognition/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/cognition"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.9.0",
+  "dowdiness/incr@0.11.0",
 }
 
 repository = "https://github.com/dowdiness/canopy"

--- a/lib/visualizer/moon.mod
+++ b/lib/visualizer/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/visualizer"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.9.0",
+  "dowdiness/incr@0.11.0",
   "dowdiness/graphviz@0.1.0",
   "dowdiness/svg-dsl@0.1.0",
   "dowdiness/alga@0.3.0",

--- a/moon.mod
+++ b/moon.mod
@@ -6,7 +6,7 @@ import {
   "moonbitlang/quickcheck@0.14.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.16.8",
-  "dowdiness/incr@0.9.0",
+  "dowdiness/incr@0.11.0",
   "dowdiness/event-graph-walker@0.3.0",
   "dowdiness/byte_codec@0.1.0",
   "dowdiness/text_change@0.1.0",


### PR DESCRIPTION
## Summary

Adds an 8th reactive cell `parser_role_spans` to `JsonProtectedCells`, computed from `parser_syntax_tree` via `Derived::map`. This moves the `project_json_roles` + `export_json_role_spans` pipeline from a lazy-per-FFI-call recomputation into the protected-cell bundle, so it updates reactively.

Also bumps `dowdiness/incr` pin from `@0.9.0` to `@0.11.0` (needed for `Derived::map`) across 4 Canopy-owned `moon.mod` files.

## Changes

| File | Change |
|------|--------|
| `ffi/json/protected_cells.mbt` | Add `parser_role_spans` field, wire via `Derived::map` in constructor, register in `to_protected_reads` |
| `ffi/json/json_ffi.mbt` | Read role spans from the new cell instead of lazy FFI pipeline |
| `moon.mod`, `examples/canvas/moon.mod`, `lib/cognition/moon.mod`, `lib/visualizer/moon.mod` | incr `@0.9.0` → `@0.11.0` |

## Verification

- `moon check` — 0 errors, 0 warnings
- `moon build --target js` — 58 tasks, clean
- `npx playwright test --grep "Role Spans"` — **6/6 passed** (see full output below)
- No `.mbti` changes (all new code is private)

## Reuse check

- `@incr.Derived::map` — new usage, unlocks reactive pipeline
- `@djson.project_json_roles`, `@djson.export_json_role_spans` — existing APIs, unchanged

Closes #782.