### PR TITLE
adopt Derived::map/map2 in remaining 3 canopy sites (#772)

### DIFF
--- a/examples/canvas/main/canvas_runtime.mbt
+++ b/examples/canvas/main/canvas_runtime.mbt
@@ -106,14 +106,20 @@ fn CanvasRuntime::with_host_policy(policy : CanvasHostPolicy) -> CanvasRuntime {
     () => policy.validate_canvas_document(document.get()),
     label="canvas.validation",
   )
-  let normalized = scope.derived(
-    () => normalize_canvas(validated.get_or_abort()),
+  let normalized = validated.map_eq(
+    v => normalize_canvas(v),
     label="canvas.normalization",
   )
-  let lowered = scope.derived(
-    () => policy.lower_canvas(normalized.get_or_abort()),
+  let lowered = normalized.map_eq(
+    n => policy.lower_canvas(n),
     label="canvas.lowering",
   )
+  // Register mapped cells for deterministic scope disposal — replacing
+  // scope.derived (which auto-registers) with map_eq would otherwise leave
+  // normalized/lowered unregistered, creating a contract gap vs original code.
+  // This is about disposal determinism, not GC rooting (the watch chain keeps
+  // them alive either way).
+  scope.add_cell_ids([normalized.id(), lowered.id()])
   let render = scope.derived(
     () => {
       policy.render_full_canvas(

--- a/lib/cognition/provider_boundary_reactive.mbt
+++ b/lib/cognition/provider_boundary_reactive.mbt
@@ -283,9 +283,9 @@ fn ProviderPlanningGraph::ProviderPlanningGraph(
     },
     label="cognition_provider_request_descriptor",
   )
-  let status_cell = scope.derived(
-    fn() {
-      match request_cell.get_or_abort() {
+  let status_cell = request_cell.map_eq(
+    request => {
+      match request {
         Some(request) => {
           let state = provider_state_for_request(request_states.get(), request).unwrap_or(
             ProviderRequestState::pending(request),
@@ -303,9 +303,9 @@ fn ProviderPlanningGraph::ProviderPlanningGraph(
     },
     label="cognition_provider_status",
   )
-  let retry_classification_cell = scope.derived(
-    fn() {
-      match status_cell.get_or_abort() {
+  let retry_classification_cell = status_cell.map_eq(
+    status => {
+      match status {
         Some(status) =>
           match status.status() {
             ProviderRequestStatus::Failed(error) =>
@@ -317,6 +317,11 @@ fn ProviderPlanningGraph::ProviderPlanningGraph(
     },
     label="cognition_provider_retry_classification",
   )
+  // Register mapped cells for deterministic scope disposal — replacing
+  // scope.derived (which auto-registers) with map_eq would otherwise leave
+  // status_cell/retry_classification_cell unregistered, creating a contract
+  // gap vs original code. Disposal determinism, not GC rooting.
+  scope.add_cell_ids([status_cell.id(), retry_classification_cell.id()])
   let next_driver_action_cell = scope.derived(
     fn() {
       provider_next_driver_action_for_states(

--- a/workspace/probe/gate1_runtime_safety_wbtest.mbt
+++ b/workspace/probe/gate1_runtime_safety_wbtest.mbt
@@ -213,10 +213,13 @@ test "P0a gate #1 §C — rooting a cross-editor Memo transitively pins both inp
   let parser_b = json_parser_on(shared_rt, "[2]")
   let id_a : @incr.CellId = parser_a.source().id()
   let id_b : @incr.CellId = parser_b.source().id()
-  let cross : @incr.Derived[Int] = @incr.Derived::Derived(shared_rt, fn() {
-    parser_a.source().get_or_abort().length() +
-    parser_b.source().get_or_abort().length()
-  })
+  let cross : @incr.Derived[Int] = parser_a
+    .source()
+    .map2_eq(
+      parser_b.source(),
+      (a, b) => a.length() + b.length(),
+      label="cross",
+    )
   // Force first computation via read_or_abort (outside-the-graph read) so
   // cross's dependency list is populated before observe/gc.
   let initial : Int = cross.read_or_abort()


### PR DESCRIPTION
## Summary

Convert 3 remaining `scope.derived(...)` / `Derived::Derived(...)` sites to `Derived::map_eq` / `Derived::map2_eq`, following the pattern established in #784.

## Changes (3 files, +28/−14)

### `workspace/probe/gate1_runtime_safety_wbtest.mbt`
Raw `Derived::Derived(rt, fn)` → `parser_a.source().map2_eq(parser_b.source(), (a, b) => { a.length() + b.length() })`

### `examples/canvas/main/canvas_runtime.mbt`
`normalized`/`lowered` — chained `scope.derived` → `Derived::map_eq`. `validated` and `render` retained as `scope.derived` (Input source / multi-input). `scope.add_cell_ids` added for deterministic scope disposal parity with the original `scope.derived` cells.

### `lib/cognition/provider_boundary_reactive.mbt`
`status_cell`/`retry_classification_cell` — `scope.derived` → `Derived::map_eq`. First-from-Input cells and multi-input cells retained as `scope.derived`. `scope.add_cell_ids` added for the same reason.

## Design decisions
- **`map_eq`/`map2_eq`** throughout (not plain `map`) — preserves `Scope::derived`'s Eq-backdating semantics
- **Arrow functions** for all callbacks — `x => f(x)`, `(a, b) => { ... }`
- **`scope.add_cell_ids`** with comments explaining deterministic disposal (not GC rooting)
- **`scope.derived` retained** where upstream is `Input[T]` (no `map`/`map_eq` on Input)

## Verification
- `moon check`: 0 errors
- `moon build --target js`: clean
- `moon test` (wasm-gc): 3650/3650 passed
- incr version alignment: all 9 members on 0.11.0
- No `.mbti` surface changes

Closes #772