### PR TITLE
fix: remove loom from vendored error-suppression lists

### DIFF
--- a/scripts/check-strict.sh
+++ b/scripts/check-strict.sh
@@ -35,8 +35,7 @@ fi
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
 # Directories are repo-root relative. Matches paths containing "/dir/".
-# loom:           pre-existing [4024] unused_trait_bound + try? warnings
-VENDORED_DIRS="rabbita/rabbita loom"
+VENDORED_DIRS="rabbita/rabbita"
 
 # Build a grep -v pipeline that excludes each vendored directory.
 # For each dir, we match lines containing "/dir/" in the path.

--- a/scripts/vendored-check-common.sh
+++ b/scripts/vendored-check-common.sh
@@ -20,7 +20,7 @@
 #
 # When adding a new vendored submodule to moon.work, add its repo-root
 # directory here if it has pre-existing --deny-warn errors.
-VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita loom}"
+VENDORED_DIRS="${VENDORED_DIRS:-rabbita/rabbita}"
 
 run_moon_check_with_vendored_filter() {
     # Parse --keep=<dir> to exclude a directory from vendored suppression.


### PR DESCRIPTION
Loom errors already fixed upstream (commit 1cf6e23). Zero errors under `moon check --deny-warn`.

Remaining VENDORED_DIRS: `rabbita/rabbita` only.