### PR TITLE
core: add ProjNode::fold catamorphism (#758)

### DIFF
--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -47,6 +47,14 @@ pub(all) enum FocusHint {
 } derive(Eq, @debug.Debug)
 pub impl Show for FocusHint
 
+pub struct FoldNode[T] {
+  kind : T
+  node_id : Int
+  start : Int
+  end : Int
+} derive(Eq, @debug.Debug)
+pub fn[T] FoldNode::id(Self[T]) -> NodeId
+
 pub(all) enum GenericTreeOp {
   Select(node_id~ : NodeId)
   SelectRange(start~ : NodeId, end~ : NodeId)
@@ -90,6 +98,7 @@ pub struct ProjNode[T] {
 } derive(Eq, @debug.Debug)
 pub fn[T] ProjNode::ProjNode(T, Int, Int, Int, Array[Self[T]]) -> Self[T]
 pub fn[T] ProjNode::branch(T, Int, Int, Array[Self[T]], @ref.Ref[Int]) -> Self[T]
+pub fn[T, U] ProjNode::fold(Self[T], (FoldNode[T], Array[U]) -> U) -> U
 pub fn[T] ProjNode::id(Self[T]) -> NodeId
 pub fn[T] ProjNode::leaf(T, @seam.SyntaxNode, @ref.Ref[Int]) -> Self[T]
 pub fn[T, U] ProjNode::map(Self[T], (T) -> U raise?) -> Self[U] raise?

--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -16,6 +16,33 @@ pub struct ProjNode[T] {
 } derive(Debug, Eq)
 
 ///|
+/// Non-recursive carrier for the `fold` algebra: the scalar fields of a
+/// ProjNode without the `children` array. By passing this instead of
+/// `ProjNode[T]`, the algebra cannot bypass the fold by accessing the
+/// original recursive structure.
+pub struct FoldNode[T] {
+  kind : T
+  node_id : Int
+  start : Int
+  end : Int
+} derive(Debug, Eq)
+
+///|
+fn[T] FoldNode::FoldNode(
+  kind : T,
+  node_id : Int,
+  start : Int,
+  end : Int,
+) -> FoldNode[T] {
+  { kind, node_id, start, end }
+}
+
+///|
+pub fn[T] FoldNode::id(self : FoldNode[T]) -> NodeId {
+  NodeId(self.node_id)
+}
+
+///|
 /// Short structural label for inspector + debug traces:
 /// `"#<node_id> <kind_tag> [<start>..<end>]"`. Depth-1 only — children
 /// are not recursed. The kind tag comes from `Renderable::kind_tag` so
@@ -98,7 +125,65 @@ pub fn next_proj_node_id(counter : Ref[Int]) -> Int {
 }
 
 ///|
-/// Build a NodeId → ProjNode lookup by walking the tree.
+/// Bottom-up fold (catamorphism) over a ProjNode tree.
+///
+/// Rebuilds or aggregates the tree: `f` receives a `FoldNode[T]` — the
+/// scalar fields of the current node (`kind`, `start`, `end`, `node_id`)
+/// — combined with the already-folded results of its children. Since
+/// `FoldNode[T]` has no `children` field, the algebra cannot bypass the
+/// fold by recursing manually.
+///
+/// **What fold is for:** aggregate/rebuild operations where the result
+/// for a node depends on the results of its children — counting, summing,
+/// renaming, collecting text, reconstructing with modified fields.
+///
+/// **What fold is not for:** searches that short-circuit (use
+/// `get_node_in_tree`), lookups that need the full `ProjNode` value
+/// (use `collect_registry`), or traversals where insertion order matters.
+///
+/// Uses an explicit stack for stack safety on deep trees.
+pub fn[T, U] ProjNode::fold(
+  self : ProjNode[T],
+  f : (FoldNode[T], Array[U]) -> U,
+) -> U {
+  // Post-order iterative fold. Each frame tracks (node, children_processed_count).
+  let stack : Array[(ProjNode[T], Int)] = [(self, 0)]
+  let results : Array[U] = []
+
+  while stack.length() > 0 {
+    let (node, done) = stack[stack.length() - 1]
+    if done < node.children.length() {
+      // Advance the frame counter and push the next child
+      let top = stack.length() - 1
+      stack[top] = (node, done + 1)
+      stack.push((node.children[done], 0))
+    } else {
+      // All children processed — fold this node
+      let _ = stack.pop()
+      let n = node.children.length()
+      let child_results : Array[U] = []
+      for i in 0..<n {
+        child_results.push(results[results.length() - n + i])
+      }
+      for _ in 0..<n {
+        let _ = results.pop()
+      }
+      results.push(
+        f(
+          FoldNode(node.kind, node.node_id, node.start, node.end),
+          child_results,
+        ),
+      )
+    }
+  }
+
+  results[0]
+}
+
+///|
+/// Build a NodeId → ProjNode lookup by walking the tree (pre-order).
+/// Pre-order traversal ensures parent is inserted before children,
+/// matching the original recursive implementation.
 pub fn[T] collect_registry(
   node : ProjNode[T],
   reg : Map[NodeId, ProjNode[T]],
@@ -111,6 +196,8 @@ pub fn[T] collect_registry(
 
 ///|
 /// Find a node in a ProjNode tree by its NodeId.
+/// Uses early-exit recursion (short-circuits on first match) — fold is not
+/// appropriate for search since it must visit every node.
 pub fn[T] get_node_in_tree(
   root : ProjNode[T],
   target_id : NodeId,
@@ -135,10 +222,9 @@ pub fn[T] assign_fresh_ids(
   node : ProjNode[T],
   counter : Ref[Int],
 ) -> ProjNode[T] {
-  let new_children : Array[ProjNode[T]] = [
-    for child in node.children => assign_fresh_ids(child, counter)
-  ]
-  ProjNode::branch(node.kind, node.start, node.end, new_children, counter)
+  node.fold((n, children) => {
+    ProjNode::branch(n.kind, n.start, n.end, children, counter)
+  })
 }
 
 ///|

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -64,7 +64,7 @@ impl Renderable for TestExpr with fn unparse(self) {
   match self {
     Leaf(s) => s
     Branch(tag, cs) =>
-      tag + "(" + cs.map(fn(c) { Renderable::unparse(c) }).join(" ") + ")"
+      tag + "(" + cs.map(c => Renderable::unparse(c)).join(" ") + ")"
   }
 }
 
@@ -250,6 +250,64 @@ test "get_node_in_tree finds nested node" {
   let found = get_node_in_tree(root, NodeId::from_int(7))
   inspect(found is Some(_), content="true")
   inspect(found.unwrap().kind, content="Leaf(\"target\")")
+}
+
+///|
+test "ProjNode::fold — leaf node returns f(node, [])" {
+  let leaf = ProjNode(Leaf("x"), 0, 1, 0, [])
+  let result = leaf.fold((n, _) => n.kind)
+  inspect(result, content="Leaf(\"x\")")
+}
+
+///|
+test "ProjNode::fold — branch passes folded children to f" {
+  let a = ProjNode(Leaf("a"), 0, 1, 11, [])
+  let b = ProjNode(Leaf("b"), 3, 4, 12, [])
+  let root = ProjNode(Branch("r", [Leaf("a"), Leaf("b")]), 0, 5, 10, [a, b])
+  let result = root.fold((n, children) => {
+    children.length().to_string() + ":" + n.id().to_string()
+  })
+  // root has 2 children, id=10
+  inspect(result, content="2:NodeId(10)")
+}
+
+///|
+test "ProjNode::fold — count_nodes: fold(_, _, (_, child_counts) => 1 + sum(child_counts))" {
+  let a = ProjNode(Leaf("a"), 0, 1, 1, [])
+  let b = ProjNode(Leaf("b"), 1, 2, 2, [])
+  let c = ProjNode(Leaf("c"), 2, 3, 3, [])
+  let middle = ProjNode(Branch("m", [Leaf("b"), Leaf("c")]), 1, 3, 4, [b, c])
+  let root = ProjNode(Branch("r", [Leaf("a"), middle.kind]), 0, 3, 5, [
+    a, middle,
+  ])
+  let count = root.fold((_, child_counts) => {
+    1 + child_counts.fold(init=0, (acc, c) => acc + c)
+  })
+  inspect(count, content="5")
+}
+
+///|
+test "ProjNode::fold — preserves ProjNode structure (identity-like fold)" {
+  let a = ProjNode(Leaf("a"), 0, 1, 1, [])
+  let b = ProjNode(Leaf("b"), 3, 4, 2, [])
+  let root = ProjNode(Branch("r", [Leaf("a"), Leaf("b")]), 0, 5, 0, [a, b])
+  let reconstructed = root.fold((n, children) => {
+    ProjNode(n.kind, n.start, n.end, n.node_id, children)
+  })
+  inspect(reconstructed == root, content="true")
+}
+
+///|
+test "ProjNode::fold — stack safety on deep chain" {
+  // Build a deep chain of 500 nodes (worst-case for recursion)
+  let mut leaf = ProjNode(Leaf("x"), 0, 1, 0, [])
+  for i in 1..<=500 {
+    leaf = ProjNode(Branch("r", [leaf.kind]), 0, 1, i, [leaf])
+  }
+  let count = leaf.fold((_, child_counts) => {
+    1 + (if child_counts.is_empty() { 0 } else { child_counts[0] })
+  })
+  inspect(count, content="501")
 }
 
 ///|


### PR DESCRIPTION
## Summary

Add `ProjNode::fold` — a bottom-up catamorphism over ProjNode trees — and rewrite `assign_fresh_ids` to use it. The fold takes a non-recursive `FoldNode[T]` carrier (scalar fields only, no `children` array) so the algebra cannot bypass the fold by recursing manually.

## Changes

**`core/proj_node.mbt`** (+96 lines)

- `pub struct FoldNode[T]` — carrier with `kind`, `node_id`, `start`, `end` (no `children`). Passed to the fold algebra.
- `pub fn ProjNode::fold(self, f: (FoldNode[T], Array[U]) -> U) -> U` — iterative post-order fold using an explicit stack (stack-safe, mirrors `alga.foldg_iter`).
- `assign_fresh_ids` — rewritten from list-comprehension recursion to `node.fold((n, children) => ProjNode::branch(...))`.

`collect_registry` stays as pre-order recursion (insertion order matters). `get_node_in_tree` stays as early-exit search (fold is full traversal).

## Intentional deviations from the issue text

| Issue proposal | Actual | Reason |
|---|---|---|
| `(T, Array[U]) -> U` algebra | `(FoldNode[T], Array[U]) -> U` | `assign_fresh_ids` needs `start`/`end`/`node_id`, not just `kind` |
| Unify `collect_registry` | Kept pre-order recursion | Needs full `ProjNode` value for registry, and pre-order insertion matters |
| Unify `get_node_in_tree` | Kept early-exit search | Fold is O(n) full traversal; search short-circuits — semantically different tools |
| Recursive fold (implicit) | Iterative (explicit stack) | The issue explicitly requested stack safety for deep trees |

## Tests

5 new tests covering: leaf fold, branch children ordering, count_nodes (aggregate), identity reconstruction (rebuild), 501-node deep chain (stack safety).

**Verification:** 186/186 tests pass (core + projection + lambda + json).