### PR TITLE
api: rename WorkspaceMemoHandle to WorkspaceCellHandle (#785)

### DIFF
--- a/ffi/lambda/workspace_cell_handle_wbtest.mbt
+++ b/ffi/lambda/workspace_cell_handle_wbtest.mbt
@@ -1,5 +1,5 @@
-// Whitebox integration test for the §P0b workspace memo lifecycle API.
-// Proves Coordinator::register_workspace_memo + WorkspaceMemoHandle drive
+// Whitebox integration test for the §P0b workspace cell lifecycle API.
+// Proves Coordinator::register_workspace_cell + WorkspaceCellHandle drive
 // register_dep / unregister_dep / destroy_editor gateway / read_protected
 // end-to-end against real Lambda editor cells via the global `coordinator`.
 //
@@ -26,12 +26,12 @@ test "wmh A1: sanity sum equals known value across two editors" {
     sa.length() + sb.length()
   })
   let handle = match
-    coordinator.register_workspace_memo(sum_d, [
+    coordinator.register_workspace_cell(sum_d, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
       (h_b.editor_id, h_b.cells.parser_source.cell_id()),
     ]) {
     Ok(h) => h
-    Err(r) => fail("register_workspace_memo: \{r}")
+    Err(r) => fail("register_workspace_cell: \{r}")
   }
   h_a.editor.set_text("abc")
   h_b.editor.set_text("defgh")
@@ -77,12 +77,12 @@ test "wmh A2: reactivity — mutation in editor A invalidates and recomputes" {
     sa.length() + sb.length()
   })
   let handle = match
-    coordinator.register_workspace_memo(sum_d, [
+    coordinator.register_workspace_cell(sum_d, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
       (h_b.editor_id, h_b.cells.parser_source.cell_id()),
     ]) {
     Ok(h) => h
-    Err(r) => fail("register_workspace_memo: \{r}")
+    Err(r) => fail("register_workspace_cell: \{r}")
   }
   h_a.editor.set_text("ab")
   h_b.editor.set_text("cd")
@@ -130,12 +130,12 @@ test "wmh A3: clean teardown — destroy succeeds after dispose" {
     sa.length() + sb.length()
   })
   let handle = match
-    coordinator.register_workspace_memo(sum_d, [
+    coordinator.register_workspace_cell(sum_d, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
       (h_b.editor_id, h_b.cells.parser_source.cell_id()),
     ]) {
     Ok(h) => h
-    Err(r) => fail("register_workspace_memo: \{r}")
+    Err(r) => fail("register_workspace_cell: \{r}")
   }
   h_a.editor.set_text("x")
   h_b.editor.set_text("yz")
@@ -173,7 +173,7 @@ test "wmh B1: bad-cell rejection + atomicity" {
   // the valid edge before hitting the bad one — the destroy assertion below
   // catches that leak, proving all-or-nothing rather than just "rejected".
   match
-    coordinator.register_workspace_memo(bad, [
+    coordinator.register_workspace_cell(bad, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
       (h_a.editor_id, h_b.cells.parser_source.cell_id()),
     ]) {
@@ -215,7 +215,7 @@ test "wmh B2: dead-editor rejection" {
   }
   let m : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() { 0 })
   match
-    coordinator.register_workspace_memo(m, [
+    coordinator.register_workspace_cell(m, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
     ]) {
     Ok(_) => fail("B2 expected EditorDestroyed, got Ok")
@@ -247,11 +247,11 @@ test "panic wmh B3: registering the same memo twice aborts" {
       Err(r) => abort("wmh B3 read: \{r}")
     }
   })
-  let _first = coordinator.register_workspace_memo(m, [
+  let _first = coordinator.register_workspace_cell(m, [
     (h_a.editor_id, h_a.cells.parser_source.cell_id()),
   ])
   // Second registration of the same memo must abort (guard 0b).
-  let _second = coordinator.register_workspace_memo(m, [
+  let _second = coordinator.register_workspace_cell(m, [
     (h_a.editor_id, h_a.cells.parser_source.cell_id()),
   ])
 }
@@ -260,7 +260,7 @@ test "panic wmh B3: registering the same memo twice aborts" {
 test "panic wmh B4: registering with empty deps aborts" {
   reset_coordinator_for_phase1_tests()
   let m : @incr.Derived[Int] = @incr.Derived(coordinator.runtime(), fn() { 0 })
-  let _ = coordinator.register_workspace_memo(m, [])
+  let _ = coordinator.register_workspace_cell(m, [])
 }
 
 ///|
@@ -284,12 +284,12 @@ test "wmh C: destroy refusal under live handle" {
     sa.length() + sb.length()
   })
   let handle = match
-    coordinator.register_workspace_memo(sum_d, [
+    coordinator.register_workspace_cell(sum_d, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
       (h_b.editor_id, h_b.cells.parser_source.cell_id()),
     ]) {
     Ok(h) => h
-    Err(r) => fail("register_workspace_memo: \{r}")
+    Err(r) => fail("register_workspace_cell: \{r}")
   }
   h_a.editor.set_text("hi")
   h_b.editor.set_text("world")
@@ -347,12 +347,12 @@ test "wmh D: idempotent dispose — second dispose is a safe no-op" {
     sa.length() + sb.length()
   })
   let handle = match
-    coordinator.register_workspace_memo(sum_d, [
+    coordinator.register_workspace_cell(sum_d, [
       (h_a.editor_id, h_a.cells.parser_source.cell_id()),
       (h_b.editor_id, h_b.cells.parser_source.cell_id()),
     ]) {
     Ok(h) => h
-    Err(r) => fail("register_workspace_memo: \{r}")
+    Err(r) => fail("register_workspace_cell: \{r}")
   }
   h_a.editor.set_text("x")
   h_b.editor.set_text("yz")

--- a/workspace/coordinator/methods.mbt
+++ b/workspace/coordinator/methods.mbt
@@ -48,21 +48,21 @@ pub fn Coordinator::register_editor(
 }
 
 ///|
-/// Idempotently records a `workspace_memo → editor_cell` dep edge owned by
+/// Idempotently records a `workspace_cell → editor_cell` dep edge owned by
 /// `editor_id`. `destroy_editor` refuses while any such edge points at the
 /// editor. Phase 1 callers: tests for the destroy gateway. Phase 1b+ callers:
-/// workspace memos releasing their own deps on dispose.
+/// workspace cell handles releasing their own deps on dispose.
 pub fn Coordinator::register_dep(
   self : Coordinator,
-  workspace_memo : @incr.CellId,
+  workspace_cell : @incr.CellId,
   editor_id : EditorId,
   editor_cell : @incr.CellId,
 ) -> Unit {
-  let entry = match self.deps.get(workspace_memo) {
+  let entry = match self.deps.get(workspace_cell) {
     Some(arr) => arr
     None => {
       let arr : Array[(EditorId, @incr.CellId)] = []
-      self.deps.set(workspace_memo, arr)
+      self.deps.set(workspace_cell, arr)
       arr
     }
   }
@@ -76,23 +76,23 @@ pub fn Coordinator::register_dep(
 /// Idempotent. Removes the edge if present; no-op if absent.
 pub fn Coordinator::unregister_dep(
   self : Coordinator,
-  workspace_memo : @incr.CellId,
+  workspace_cell : @incr.CellId,
   editor_id : EditorId,
   editor_cell : @incr.CellId,
 ) -> Unit {
-  let entry = match self.deps.get(workspace_memo) {
+  let entry = match self.deps.get(workspace_cell) {
     Some(e) => e
     None => return
   }
   let edge = (editor_id, editor_cell)
   // `Array::remove` is positional, not by-value; rebuild via filter and
-  // write back. Phase 1 dep-counts per workspace memo are small (<10 in
+  // write back. Phase 1 dep-counts per workspace cell are small (<10 in
   // any plausible scenario); profile in Phase 2 if this becomes hot.
   let new_entry = entry.filter(fn(e) { e != edge })
   if new_entry.is_empty() {
-    self.deps.remove(workspace_memo)
+    self.deps.remove(workspace_cell)
   } else {
-    self.deps.set(workspace_memo, new_entry)
+    self.deps.set(workspace_cell, new_entry)
   }
 }
 
@@ -119,10 +119,10 @@ pub fn Coordinator::destroy_editor(
     )
   }
   let referring : Array[@incr.CellId] = []
-  for ws_memo, edges in self.deps {
+  for ws_cell, edges in self.deps {
     for edge in edges {
       if edge.0 == editor_id {
-        referring.push(ws_memo)
+        referring.push(ws_cell)
       }
     }
   }

--- a/workspace/coordinator/pkg.generated.mbti
+++ b/workspace/coordinator/pkg.generated.mbti
@@ -39,7 +39,7 @@ pub fn Coordinator::new() -> Self
 pub fn[T] Coordinator::read_protected(Self, EditorId, ProtectedCell[T]) -> Result[T, AbortReport]
 pub fn Coordinator::register_dep(Self, @types.CellId, EditorId, @types.CellId) -> Unit
 pub fn Coordinator::register_editor(Self, String, Array[ProtectedRead]) -> EditorId
-pub fn[T] Coordinator::register_workspace_memo(Self, @cells.Derived[T], Array[(EditorId, @types.CellId)]) -> Result[WorkspaceMemoHandle[T], AbortReport]
+pub fn[T] Coordinator::register_workspace_cell(Self, @cells.Derived[T], Array[(EditorId, @types.CellId)]) -> Result[WorkspaceCellHandle[T], AbortReport]
 pub fn Coordinator::runtime(Self) -> @cells.Runtime
 pub fn Coordinator::unregister_dep(Self, @types.CellId, EditorId, @types.CellId) -> Unit
 
@@ -64,12 +64,12 @@ pub struct ProtectedRead {
   dispose : () -> Unit
 }
 
-pub struct WorkspaceMemoHandle[T] {
+pub struct WorkspaceCellHandle[T] {
   // private fields
 }
-pub fn[T] WorkspaceMemoHandle::dispose(Self[T]) -> Unit
-pub fn[T] WorkspaceMemoHandle::id(Self[T]) -> @types.CellId
-pub fn[T] WorkspaceMemoHandle::read(Self[T]) -> Result[T, @types.ReadError]
+pub fn[T] WorkspaceCellHandle::dispose(Self[T]) -> Unit
+pub fn[T] WorkspaceCellHandle::id(Self[T]) -> @types.CellId
+pub fn[T] WorkspaceCellHandle::read(Self[T]) -> Result[T, @types.ReadError]
 
 // Type aliases
 

--- a/workspace/coordinator/workspace_cell_handle.mbt
+++ b/workspace/coordinator/workspace_cell_handle.mbt
@@ -1,4 +1,4 @@
-// Coordinator-owned workspace-memo lifecycle API — §P0b Phase 1b.
+// Coordinator-owned workspace cell lifecycle API — §P0b Phase 1b.
 // See docs/superpowers/specs/2026-05-28-p0b-workspace-memo-lifecycle-api-design.md.
 //
 // Collapses the smoke test's manual `watch` + N×`register_dep` +
@@ -6,43 +6,43 @@
 // register/unregister symmetry owned by the handle.
 
 ///|
-/// Owns a registered workspace memo's `Watch` (the GC root) and the exact
+/// Owns a registered workspace cell's `Watch` (the GC root) and the exact
 /// deduplicated edge list it registered. `dispose` replays those edges through
 /// `unregister_dep` so register/unregister symmetry is structurally guaranteed
 /// — the consumer never names the edges twice.
-pub struct WorkspaceMemoHandle[T] {
+pub struct WorkspaceCellHandle[T] {
   priv coordinator : Coordinator
-  priv memo_id : @incr.CellId
+  priv cell_id : @incr.CellId
   priv watch : @incr.Watch[T]
   priv deps : Array[(EditorId, @incr.CellId)]
 }
 
 ///|
 /// Validates every declared dep (editor alive + cell in that editor's
-/// protected surface), then watches+primes `memo` and registers each edge.
+/// protected surface), then watches+primes `cell` and registers each edge.
 /// All-or-nothing: a rejected dep leaves zero coordinator-state delta.
 ///
 /// Both guards `abort` because they signal programming defects, not runtime
 /// conditions (mirroring `register_editor`'s stance):
-/// - empty `deps` — a workspace memo with no cross-editor dependency has no
+/// - empty `deps` — a workspace cell with no cross-editor dependency has no
 ///   gateway role; watch a plain `@incr.Derived` directly instead.
 /// - double-registration — `register_dep` is set-like, so a second handle over
-///   the same memo id would have its gateway protection stripped by the first
+///   the same cell id would have its gateway protection stripped by the first
 ///   handle's dispose.
-pub fn[T] Coordinator::register_workspace_memo(
+pub fn[T] Coordinator::register_workspace_cell(
   self : Coordinator,
-  memo : @incr.Derived[T],
+  cell : @incr.Derived[T],
   deps : Array[(EditorId, @incr.CellId)],
-) -> Result[WorkspaceMemoHandle[T], AbortReport] {
+) -> Result[WorkspaceCellHandle[T], AbortReport] {
   guard !deps.is_empty() else {
     abort(
-      "Coordinator::register_workspace_memo: a workspace memo needs at least one dep — watch a plain @incr.Derived directly instead",
+      "Coordinator::register_workspace_cell: a workspace cell needs at least one dep — watch a plain @incr.Derived directly instead",
     )
   }
-  let memo_id = memo.id()
-  guard self.deps.get(memo_id) is None else {
+  let cell_id = cell.id()
+  guard self.deps.get(cell_id) is None else {
     abort(
-      "Coordinator::register_workspace_memo: memo already registered — a memo may be registered at most once",
+      "Coordinator::register_workspace_cell: cell already registered — a cell may be registered at most once",
     )
   }
   let distinct : Array[(EditorId, @incr.CellId)] = []
@@ -91,38 +91,38 @@ pub fn[T] Coordinator::register_workspace_memo(
   }
   // Establish the GC root. P2: `Watch::read` has no `raise` clause — a cycle is
   // surfaced as `Err`, not a throw — so there is nothing to dispose-on-raise.
-  let w = memo.watch()
+  let w = cell.watch()
   let _ = w.read()
   for d in distinct {
-    self.register_dep(memo_id, d.0, d.1)
+    self.register_dep(cell_id, d.0, d.1)
   }
-  Ok({ coordinator: self, memo_id, watch: w, deps: distinct })
+  Ok({ coordinator: self, cell_id, watch: w, deps: distinct })
 }
 
 ///|
 /// Delegates to the underlying watch. Returns `Err(ReadError)` — a cycle as
 /// `Cycle(CycleError)`, a read on a disposed cell as `Disposed(CellId)`.
-pub fn[T] WorkspaceMemoHandle::read(
-  self : WorkspaceMemoHandle[T],
+pub fn[T] WorkspaceCellHandle::read(
+  self : WorkspaceCellHandle[T],
 ) -> Result[T, @incr.ReadError] {
   self.watch.read()
 }
 
 ///|
-/// The memo's `@incr.CellId` — the id `register_dep` keyed the edges under.
-pub fn[T] WorkspaceMemoHandle::id(
-  self : WorkspaceMemoHandle[T],
+/// The cell's `@incr.CellId` — the id `register_dep` keyed the edges under.
+pub fn[T] WorkspaceCellHandle::id(
+  self : WorkspaceCellHandle[T],
 ) -> @incr.CellId {
-  self.memo_id
+  self.cell_id
 }
 
 ///|
 /// Unregisters every edge this handle registered, then disposes the watch.
 /// Idempotent: a second call is a no-op (guarded by `watch.is_disposed()`).
-pub fn[T] WorkspaceMemoHandle::dispose(self : WorkspaceMemoHandle[T]) -> Unit {
+pub fn[T] WorkspaceCellHandle::dispose(self : WorkspaceCellHandle[T]) -> Unit {
   guard !self.watch.is_disposed() else { return }
   for d in self.deps {
-    self.coordinator.unregister_dep(self.memo_id, d.0, d.1)
+    self.coordinator.unregister_dep(self.cell_id, d.0, d.1)
   }
   self.watch.dispose()
 }


### PR DESCRIPTION
## Summary

Renames the workspace memo lifecycle API ahead of incr's Memo removal (incr#308). The name "memo" was always an approximation — the type wraps `@incr.Derived[T]` + `Watch`, not an incr `Memo`. `CellHandle` aligns with the coordinator's existing `ProtectedCell` and `CellId` vocabulary.

## Changes

| File | Change |
|---|---|
| `workspace/coordinator/workspace_cell_handle.mbt` | New file (renamed from `workspace_memo.mbt`). All identifiers renamed. |
| `workspace/coordinator/methods.mbt` | `workspace_memo` → `workspace_cell` in param names, docs, and comments for `register_dep`/`unregister_dep`/`destroy_editor` |
| `workspace/coordinator/pkg.generated.mbti` | Regenerated — old names replaced |
| `ffi/lambda/workspace_cell_handle_wbtest.mbt` | Renamed from `workspace_memo_handle_wbtest.mbt`. All callsites and fail strings updated |

## Scope notes

- `workspace/probe/gate1_runtime_safety_wbtest.mbt` incr Memo concept comments: deferred to incr#308 bump follow-up per issue scope.
- `ffi/lambda/workspace_memo_smoke_wbtest.mbt`: uses low-level `register_dep`/`unregister_dep` directly, not the renamed API. Comment references to "workspace memo" are about the semantic concept, not the API symbol. Left as-is.

## Verification

**66/66 tests pass** (workspace/coordinator + ffi/lambda). Pure mechanical rename — compiler catches every site.