### PR TITLE
core: add ProjNode::walk_preorder visitor (#791)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/dowdiness/event-graph-walker.git
 [submodule "loom"]
 	path = loom
-	url = https://github.com/dowdiness/loom.git
+	url = https://github.com/dowdiness/loom
 [submodule "svg-dsl"]
 	path = svg-dsl
 	url = https://github.com/dowdiness/svg-dsl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/dowdiness/event-graph-walker.git
 [submodule "loom"]
 	path = loom
-	url = https://github.com/dowdiness/loom
+	url = https://github.com/dowdiness/loom.git
 [submodule "svg-dsl"]
 	path = svg-dsl
 	url = https://github.com/dowdiness/svg-dsl.git

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -102,6 +102,7 @@ pub fn[T, U] ProjNode::fold(Self[T], (FoldNode[T], Array[U]) -> U) -> U
 pub fn[T] ProjNode::id(Self[T]) -> NodeId
 pub fn[T] ProjNode::leaf(T, @seam.SyntaxNode, @ref.Ref[Int]) -> Self[T]
 pub fn[T, U] ProjNode::map(Self[T], (T) -> U raise?) -> Self[U] raise?
+pub fn[T] ProjNode::walk_preorder(Self[T], (FoldNode[T]) -> Unit raise?) -> Unit raise?
 pub impl[T : @dowdiness/loom/core.Renderable] Show for ProjNode[T]
 pub impl[T : ToJson] ToJson for ProjNode[T]
 

--- a/core/proj_node.mbt
+++ b/core/proj_node.mbt
@@ -181,6 +181,39 @@ pub fn[T, U] ProjNode::fold(
 }
 
 ///|
+/// Pre-order visitor over a ProjNode tree.
+///
+/// Calls `visit` with a `FoldNode[T]` (scalar fields only — no `children`
+/// array) for every node in pre-order (parent before children). Unlike
+/// `fold`, this is purely effectful — no return value, no child-result
+/// arrays allocated per node.
+///
+/// **What walk is for:** side-effect traversals — populating a map,
+/// clearing state, collecting diagnostics — that visit every node and
+/// don't need child results.
+///
+/// **What walk is not for:** post-order rebuilds (use `fold`), searches
+/// that short-circuit (use `get_node_in_tree`).
+///
+/// Uses an explicit stack for stack safety on deep trees.
+pub fn[T] ProjNode::walk_preorder(
+  self : ProjNode[T],
+  visit : (FoldNode[T]) -> Unit raise?,
+) -> Unit raise? {
+  let stack : Array[ProjNode[T]] = [self]
+  while stack.length() > 0 {
+    let node = stack.unsafe_pop()
+    visit(FoldNode(node.kind, node.node_id, node.start, node.end))
+    // Push children in reverse order so leftmost is processed first
+    let len = node.children.length()
+    for offset in 0..<len {
+      let i = len - 1 - offset
+      stack.push(node.children[i])
+    }
+  }
+}
+
+///|
 /// Build a NodeId → ProjNode lookup by walking the tree (pre-order).
 /// Pre-order traversal ensures parent is inserted before children,
 /// matching the original recursive implementation.

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -36,9 +36,9 @@ pub fn[T] SourceMap::from_ast(root : ProjNode[T]) -> SourceMap {
 }
 
 ///|
-/// Recursively build the map from an AST node
+/// Walk the tree via walk_preorder to build the node-to-range map
 fn[T] SourceMap::build_from_node(self : SourceMap, node : ProjNode[T]) -> Unit {
-  node.walk_preorder(fn(n) {
+  node.walk_preorder((n) => {
     self.node_to_range[n.id()] = Range::new(n.start, n.end)
   })
 }
@@ -77,20 +77,23 @@ pub fn[T] SourceMap::remove_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  node.walk_preorder(fn(n) {
+  node.walk_preorder((n) => {
     self.node_to_range.remove(n.id())
     self.token_spans.remove(n.id())
   })
 }
 
 ///|
+/// Add entries for a ProjNode subtree to the source map.
+/// Clears any stale token_spans for patched nodes — call
+/// populate_token_spans() afterward to repopulate them.
 /// Does NOT rebuild the sorted ranges array — call rebuild_ranges() after
 /// all patches are done.
 pub fn[T] SourceMap::patch_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  node.walk_preorder(fn(n) {
+  node.walk_preorder((n) => {
     self.node_to_range[n.id()] = Range::new(n.start, n.end)
     self.token_spans.remove(n.id())
   })

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -38,7 +38,7 @@ pub fn[T] SourceMap::from_ast(root : ProjNode[T]) -> SourceMap {
 ///|
 /// Walk the tree via walk_preorder to build the node-to-range map
 fn[T] SourceMap::build_from_node(self : SourceMap, node : ProjNode[T]) -> Unit {
-  node.walk_preorder((n) => {
+  node.walk_preorder(n => {
     self.node_to_range[n.id()] = Range::new(n.start, n.end)
   })
 }
@@ -77,7 +77,7 @@ pub fn[T] SourceMap::remove_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  node.walk_preorder((n) => {
+  node.walk_preorder(n => {
     self.node_to_range.remove(n.id())
     self.token_spans.remove(n.id())
   })
@@ -93,7 +93,7 @@ pub fn[T] SourceMap::patch_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  node.walk_preorder((n) => {
+  node.walk_preorder(n => {
     self.node_to_range[n.id()] = Range::new(n.start, n.end)
     self.token_spans.remove(n.id())
   })

--- a/core/source_map.mbt
+++ b/core/source_map.mbt
@@ -38,14 +38,9 @@ pub fn[T] SourceMap::from_ast(root : ProjNode[T]) -> SourceMap {
 ///|
 /// Recursively build the map from an AST node
 fn[T] SourceMap::build_from_node(self : SourceMap, node : ProjNode[T]) -> Unit {
-  let node_id = NodeId(node.node_id)
-  let range = Range::new(node.start, node.end)
-  self.node_to_range[node_id] = range
-
-  // Process children
-  for child in node.children {
-    self.build_from_node(child)
-  }
+  node.walk_preorder(fn(n) {
+    self.node_to_range[n.id()] = Range::new(n.start, n.end)
+  })
 }
 
 ///|
@@ -69,6 +64,12 @@ pub fn SourceMap::rebuild_ranges(self : SourceMap) -> Unit {
 }
 
 ///|
+/// Get the half-open UTF-16 source range for a node.
+pub fn SourceMap::get_range(self : SourceMap, node_id : NodeId) -> Range? {
+  self.node_to_range.get(node_id)
+}
+
+///|
 /// Remove all entries for a ProjNode subtree from the source map.
 /// Does NOT rebuild the sorted ranges array — call rebuild_ranges() after
 /// all patches are done.
@@ -76,36 +77,23 @@ pub fn[T] SourceMap::remove_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  let node_id = node.id()
-  self.node_to_range.remove(node_id)
-  self.token_spans.remove(node_id)
-  for child in node.children {
-    self.remove_subtree(child)
-  }
+  node.walk_preorder(fn(n) {
+    self.node_to_range.remove(n.id())
+    self.token_spans.remove(n.id())
+  })
 }
 
 ///|
-/// Add entries for a ProjNode subtree to the source map.
-/// Clears any stale token_spans for patched nodes — call
-/// populate_token_spans() afterward to repopulate them.
 /// Does NOT rebuild the sorted ranges array — call rebuild_ranges() after
 /// all patches are done.
 pub fn[T] SourceMap::patch_subtree(
   self : SourceMap,
   node : ProjNode[T],
 ) -> Unit {
-  let node_id = node.id()
-  self.node_to_range[node_id] = Range::new(node.start, node.end)
-  self.token_spans.remove(node_id)
-  for child in node.children {
-    self.patch_subtree(child)
-  }
-}
-
-///|
-/// Get the half-open UTF-16 source range for a node.
-pub fn SourceMap::get_range(self : SourceMap, node_id : NodeId) -> Range? {
-  self.node_to_range.get(node_id)
+  node.walk_preorder(fn(n) {
+    self.node_to_range[n.id()] = Range::new(n.start, n.end)
+    self.token_spans.remove(n.id())
+  })
 }
 
 ///|

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -318,7 +318,7 @@ test "ProjNode::walk_preorder visits all nodes" {
   let visited : Array[Int] = []
   root.walk_preorder(n => visited.push(n.node_id))
   // Pre-order: parent (0), then left child (1), then right child (2)
-  inspect(visited, content="[0, 1, 2]")
+  @debug.assert_eq(visited, [0, 1, 2])
 }
 
 ///|
@@ -326,7 +326,7 @@ test "ProjNode::walk_preorder visits single leaf" {
   let leaf = ProjNode(Leaf("x"), 0, 1, 7, [])
   let visited : Array[Int] = []
   leaf.walk_preorder(n => visited.push(n.node_id))
-  inspect(visited, content="[7]")
+  @debug.assert_eq(visited, [7])
 }
 
 ///|

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -311,6 +311,35 @@ test "ProjNode::fold — stack safety on deep chain" {
 }
 
 ///|
+test "ProjNode::walk_preorder visits all nodes" {
+  let a = ProjNode(Leaf("a"), 0, 1, 1, [])
+  let b = ProjNode(Leaf("b"), 1, 2, 2, [])
+  let root = ProjNode(Branch("r", [Leaf("a"), Leaf("b")]), 0, 3, 0, [a, b])
+  let visited : Array[Int] = []
+  root.walk_preorder(n => visited.push(n.node_id))
+  // Pre-order: parent (0), then left child (1), then right child (2)
+  inspect(visited, content="[0, 1, 2]")
+}
+
+///|
+test "ProjNode::walk_preorder visits single leaf" {
+  let leaf = ProjNode(Leaf("x"), 0, 1, 7, [])
+  let visited : Array[Int] = []
+  leaf.walk_preorder(n => visited.push(n.node_id))
+  inspect(visited, content="[7]")
+}
+
+///|
+test "ProjNode::walk_preorder passes correct FoldNode fields" {
+  let leaf = ProjNode(Leaf("x"), 2, 8, 42, [])
+  let seen : Array[String] = []
+  leaf.walk_preorder(n => {
+    seen.push("\{n.kind}|n.\{n.node_id}|s.\{n.start}|e.\{n.end}")
+  })
+  inspect(seen[0], content="Leaf(\"x\")|n.42|s.2|e.8")
+}
+
+///|
 test "ToJson for ProjNode[TestExpr] compiles" {
   let node = ProjNode(Leaf("x"), 0, 1, 0, [])
   let json = node.to_json()


### PR DESCRIPTION
## Summary

Adds `ProjNode::walk_preorder` — an allocation-free pre-order visitor for effectful traversals — and migrates three SourceMap functions to use it.

## Changes

- `pub fn ProjNode::walk_preorder(self, visit: (FoldNode[T]) -> Unit raise?) -> Unit raise?` — iterative pre-order walk, stack-safe. Passes `FoldNode[T]` (scalar fields only, no `children` array).
- `SourceMap::build_from_node` — migrated to `node.walk_preorder(fn(n) { self.node_to_range[n.id()] = ... })`
- `SourceMap::remove_subtree` — migrated to `node.walk_preorder(fn(n) { remove both maps })`
- `SourceMap::patch_subtree` — migrated to `node.walk_preorder(fn(n) { upsert + remove stale })`

## Verification

**189/189 tests pass** (core + projection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preorder tree traversal utility for nodes.
  * Added a way to retrieve a node’s recorded range directly from the source map.

* **Bug Fixes**
  * Source map updates now apply consistently across entire subtrees when nodes are removed or patched.

* **Tests**
  * Added coverage for preorder traversal order and returned node fields.

* **Chores**
  * Updated the bundled `loom` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->