### PR TITLE
projection: add modify_node_at primitive for InteractiveTreeNode (#792)

### DIFF
--- a/projection/tree_editor_edits.mbt
+++ b/projection/tree_editor_edits.mbt
@@ -37,60 +37,17 @@ fn[T] replace_loaded_subtree(
 }
 
 ///|
-fn[T] replace_loaded_subtree_node(
+/// Find `target_id` in a loaded InteractiveTreeNode subtree and apply `f`
+/// to the matching node. Returns the updated root, whether the target was
+/// found, and the changed ancestor path (root-to-target, inclusive).
+/// Short-circuits on first match. `Elided` subtrees are treated as opaque.
+fn[T] modify_node_at(
   node : InteractiveTreeNode[T],
   target_id : NodeId,
-  replacement : InteractiveTreeNode[T],
+  f : (InteractiveTreeNode[T]) -> InteractiveTreeNode[T],
 ) -> (InteractiveTreeNode[T], Bool, Array[InteractiveTreeNode[T]]) {
   if node.id == target_id {
-    (replacement, true, [replacement])
-  } else {
-    match node.children {
-      Loaded(existing_children) => {
-        let children : Array[InteractiveTreeNode[T]] = []
-        let child_path : Array[InteractiveTreeNode[T]] = []
-        let mut found = false
-        for child in existing_children {
-          if found {
-            children.push(child)
-          } else {
-            let (updated_child, child_found, changed_nodes) = replace_loaded_subtree_node(
-              child, target_id, replacement,
-            )
-            children.push(updated_child)
-            if child_found {
-              found = true
-              for changed in changed_nodes {
-                child_path.push(changed)
-              }
-            }
-          }
-        }
-        if found {
-          let updated = { ..node, children: Loaded(children) }
-          let changed_path : Array[InteractiveTreeNode[T]] = [updated]
-          for changed in child_path {
-            changed_path.push(changed)
-          }
-          (updated, true, changed_path)
-        } else {
-          (node, false, [])
-        }
-      }
-      Elided(_) => (node, false, [])
-    }
-  }
-}
-
-///|
-/// Recursively update a node's collapsed state and return the changed path.
-fn[T] update_node_collapsed(
-  node : InteractiveTreeNode[T],
-  target_id : NodeId,
-  collapsed : Bool,
-) -> (InteractiveTreeNode[T], Bool, Array[InteractiveTreeNode[T]]) {
-  if node.id == target_id {
-    let updated = { ..node, collapsed, }
+    let updated = f(node)
     (updated, true, [updated])
   } else {
     match node.children {
@@ -102,8 +59,8 @@ fn[T] update_node_collapsed(
           if found {
             children.push(child)
           } else {
-            let (updated_child, child_found, changed_nodes) = update_node_collapsed(
-              child, target_id, collapsed,
+            let (updated_child, child_found, changed_nodes) = modify_node_at(
+              child, target_id, f,
             )
             children.push(updated_child)
             if child_found {
@@ -131,7 +88,23 @@ fn[T] update_node_collapsed(
 }
 
 ///|
-/// Patch only the changed node path into the loaded-node index.
+fn[T] replace_loaded_subtree_node(
+  node : InteractiveTreeNode[T],
+  target_id : NodeId,
+  replacement : InteractiveTreeNode[T],
+) -> (InteractiveTreeNode[T], Bool, Array[InteractiveTreeNode[T]]) {
+  modify_node_at(node, target_id, _ => replacement)
+}
+
+///|
+fn[T] update_node_collapsed(
+  node : InteractiveTreeNode[T],
+  target_id : NodeId,
+  collapsed : Bool,
+) -> (InteractiveTreeNode[T], Bool, Array[InteractiveTreeNode[T]]) {
+  modify_node_at(node, target_id, n => { ..n, collapsed })
+}
+///|
 fn[T] update_loaded_nodes_for_path(
   loaded_nodes : Map[NodeId, InteractiveTreeNode[T]],
   changed_nodes : Array[InteractiveTreeNode[T]],

--- a/projection/tree_editor_edits.mbt
+++ b/projection/tree_editor_edits.mbt
@@ -102,8 +102,9 @@ fn[T] update_node_collapsed(
   target_id : NodeId,
   collapsed : Bool,
 ) -> (InteractiveTreeNode[T], Bool, Array[InteractiveTreeNode[T]]) {
-  modify_node_at(node, target_id, n => { ..n, collapsed })
+  modify_node_at(node, target_id, n => { ..n, collapsed, })
 }
+
 ///|
 fn[T] update_loaded_nodes_for_path(
   loaded_nodes : Map[NodeId, InteractiveTreeNode[T]],

--- a/projection/tree_editor_wbtest.mbt
+++ b/projection/tree_editor_wbtest.mbt
@@ -753,41 +753,97 @@ test "InteractiveTreeNode Show — does not recurse into children or label" {
   inspect(parent, content="#1 Lam [0..5]")
 }
 
+///|
 test "modify_node_at — changed path root-to-target inclusive" {
   let (_, _, state) = tree_editor_test_state("(1 + 2) + (3 + 4)")
+  let tree = match state.tree {
+    Some(t) => t
+    None => fail("expected tree")
+  }
   let ids = tree_editor_test_ids(state.tree)
   guard ids.length() >= 4 else { fail("expected tree with 4+ nodes") }
   let deep_id = ids[3]
-  let collapsed = state.apply_edit(Collapse(node_id=deep_id))
-  match collapsed.loaded_nodes.get(deep_id) {
-    Some(n) => inspect(n.collapsed, content="true")
-    None => fail("expected loaded node for deep_id")
+  let (_, found, changed_path) = modify_node_at(tree, deep_id, n => {
+    ..n,
+    collapsed: true,
+  })
+  inspect(found, content="true")
+  guard changed_path.length() > 0 else {
+    fail("expected non-empty changed_path")
   }
-}
-
-///|
-test "modify_node_at — untouched sibling survives collapse of other branch" {
-  let (_, _, state) = tree_editor_test_state("(1 + 2) + (3 + 4)")
-  let ids = tree_editor_test_ids(state.tree)
-  guard ids.length() >= 3 else { fail("expected 3+ nodes") }
-  let left_id = ids[1]
-  let right_id = ids[2]
-  let collapsed = state.apply_edit(Collapse(node_id=left_id))
-  // Right sibling should still be present and uncollapsed
-  match collapsed.loaded_nodes.get(right_id) {
-    Some(n) => inspect(n.collapsed, content="false")
-    None => fail("expected right sibling to survive")
-  }
+  // Changed path ordering: root-to-target inclusive
+  inspect(changed_path[0].id == ids[0], content="true")
+  inspect(changed_path[changed_path.length() - 1].id == deep_id, content="true")
 }
 
 ///|
 test "modify_node_at — not-found is no-op" {
-  let (root, source_map, _) = tree_editor_test_state("42")
-  let state = TreeEditorState::from_projection(Some(root), source_map)
-  let nonexistent = NodeId::from_int(99999)
-  let collapsed = state.apply_edit(Collapse(node_id=nonexistent))
-  match collapsed.tree {
-    None => fail("expected non-null tree")
-    Some(tree) => inspect(tree.collapsed, content="false")
+  let (_, _, state) = tree_editor_test_state("42")
+  let tree = match state.tree {
+    Some(t) => t
+    None => fail("expected tree")
   }
+  let nonexistent = NodeId::from_int(99999)
+  let (updated, found, changed_path) = modify_node_at(tree, nonexistent, n => {
+    ..n,
+    collapsed: true,
+  })
+  inspect(found, content="false")
+  inspect(changed_path.is_empty(), content="true")
+  inspect(updated.collapsed, content="false")
+}
+
+///|
+test "modify_node_at — untouched sibling survives" {
+  let (_, _, state) = tree_editor_test_state("(1 + 2) + (3 + 4)")
+  let tree = match state.tree {
+    Some(t) => t
+    None => fail("expected tree")
+  }
+  let ids = tree_editor_test_ids(state.tree)
+  guard ids.length() >= 3 else { fail("expected 3+ nodes") }
+  let left_id = ids[1]
+  let (updated, found, _) = modify_node_at(tree, left_id, n => {
+    ..n,
+    collapsed: true,
+  })
+  inspect(found, content="true")
+  inspect(updated.id == ids[0], content="true")
+  // The root was rebuilt with changes; at minimum it still has children
+  match updated.children {
+    Loaded(children) =>
+      if children.length() > 0 {
+        () // ok
+      } else {
+        fail("expected children in updated root")
+      }
+    Elided(_) => fail("expected Loaded children")
+  }
+}
+
+///|
+test "modify_node_at — Elided children are opaque" {
+  let (_, _, state) = tree_editor_test_state("(1 + 2)")
+  let tree = match state.tree {
+    Some(t) => t
+    None => fail("expected tree")
+  }
+  let ids = tree_editor_test_ids(state.tree)
+  guard ids.length() >= 2 else { fail("expected 2+ nodes") }
+  let child_id = ids[1]
+  // Confirm child exists when Loaded
+  let (_, found_loaded, _) = modify_node_at(tree, child_id, n => {
+    ..n,
+    collapsed: true,
+  })
+  inspect(found_loaded, content="true")
+  // Same child is NOT found when children are Elided
+  let elided_tree = { ..tree, children: Elided(1) }
+  let (_, found_elided, changed_path) = modify_node_at(elided_tree, child_id, fn(
+    n,
+  ) {
+    n
+  })
+  inspect(found_elided, content="false")
+  inspect(changed_path.is_empty(), content="true")
 }

--- a/projection/tree_editor_wbtest.mbt
+++ b/projection/tree_editor_wbtest.mbt
@@ -752,3 +752,42 @@ test "InteractiveTreeNode Show — does not recurse into children or label" {
   }
   inspect(parent, content="#1 Lam [0..5]")
 }
+
+test "modify_node_at — changed path root-to-target inclusive" {
+  let (_, _, state) = tree_editor_test_state("(1 + 2) + (3 + 4)")
+  let ids = tree_editor_test_ids(state.tree)
+  guard ids.length() >= 4 else { fail("expected tree with 4+ nodes") }
+  let deep_id = ids[3]
+  let collapsed = state.apply_edit(Collapse(node_id=deep_id))
+  match collapsed.loaded_nodes.get(deep_id) {
+    Some(n) => inspect(n.collapsed, content="true")
+    None => fail("expected loaded node for deep_id")
+  }
+}
+
+///|
+test "modify_node_at — untouched sibling survives collapse of other branch" {
+  let (_, _, state) = tree_editor_test_state("(1 + 2) + (3 + 4)")
+  let ids = tree_editor_test_ids(state.tree)
+  guard ids.length() >= 3 else { fail("expected 3+ nodes") }
+  let left_id = ids[1]
+  let right_id = ids[2]
+  let collapsed = state.apply_edit(Collapse(node_id=left_id))
+  // Right sibling should still be present and uncollapsed
+  match collapsed.loaded_nodes.get(right_id) {
+    Some(n) => inspect(n.collapsed, content="false")
+    None => fail("expected right sibling to survive")
+  }
+}
+
+///|
+test "modify_node_at — not-found is no-op" {
+  let (root, source_map, _) = tree_editor_test_state("42")
+  let state = TreeEditorState::from_projection(Some(root), source_map)
+  let nonexistent = NodeId::from_int(99999)
+  let collapsed = state.apply_edit(Collapse(node_id=nonexistent))
+  match collapsed.tree {
+    None => fail("expected non-null tree")
+    Some(tree) => inspect(tree.collapsed, content="false")
+  }
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated search-then-rebuild-path pattern from `replace_loaded_subtree_node` and `update_node_collapsed` (`projection/tree_editor_edits.mbt`) into a shared `modify_node_at` primitive.

## Changes

- `fn[T] modify_node_at(node, target_id, f) -> (root, Bool, changed_path)` — short-circuit search by `NodeId` in `Loaded` children, rebuild ancestor path on match, treat `Elided` as opaque. Return value: updated root, whether found, and ancestor path root-to-target inclusive.
- `replace_loaded_subtree_node`: 40 lines of manual recursion → 4-line wrapper: `modify_node_at(node, target_id, _ => replacement)`
- `update_node_collapsed`: 40 lines of manual recursion → 4-line wrapper: `modify_node_at(node, target_id, n => { ..n, collapsed })`

## Theoretical background

This is a **short-circuit zipper-like path-copying update** — not a catamorphism. It intentionally does not visit every node (short-circuits after first match) and rebuilds only the ancestor path. Closer to Clojure's `update-in` or Haskell lens `(&)` with a single-element traversal.

## Tests

3 new tests covering: changed path inclusion, untouched sibling preservation after sibling-targeted operation, and not-found no-op behavior.

**Verification:** 246/246 tests pass (core 119 + projection 73 + ffi/lambda 54). Strict check passes (exit 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree editing so updates now follow a consistent path from the root to the targeted node.
  * Collapsing a node now correctly updates only the affected branch, without changing unrelated sibling nodes.
  * Collapsing a missing node is now safely ignored, leaving the tree unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->