### PR TITLE
feat(block-editor): render metadata for drop-target validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ The base rule (microbenchmark before optimizing) applies. Additionally: stale pr
 
 Hooks enforce `moon check` after every edit and `moon fmt && moon info` before commits. After edits, also run `moon test` and rebuild JS if web is affected. For packages with `"proof-enabled": true`, also run `moon prove` from the proof package directory. After `moon info`, check `git diff *.mbti` for unintended trait bound changes — widening a bound is an API regression even if all current consumers satisfy it. See [docs/development/task-tracking.md](docs/development/task-tracking.md) for tracking workflow.
 
+**One file per edit call.** A single `edit` targeting lines from two different files with one snapshot hash will silently corrupt the second file. Always re-read for a fresh hash between edits, even within the same package.
+
 <!-- textlint-enable slopless/word-repetition -->
 
 ### Existing API First Rule

--- a/docs/plans/2026-06-26-concurrent-drop-convergence-tests.md
+++ b/docs/plans/2026-06-26-concurrent-drop-convergence-tests.md
@@ -1,0 +1,229 @@
+# Concurrent Drag-Drop Convergence Tests
+
+**Status:** Scoping plan
+**Date:** 2026-06-26
+**Dependency:** `SyncEditor::move_node` (landed), `apply_lambda_tree_edit` Drop route (landed)
+
+## Problem
+
+Concurrent drag-drop (structural `Drop` `TreeEditOp` operations issued concurrently across CRDT peers) has no editor-level convergence test coverage. The existing coverage lives at two layers:
+
+1. **CRDT / movable tree** (`event-graph-walker/container/document_test.mbt:428-489`): `Document::move_node_after` / `move_node_before` convergence — tests the `TreeMoveOp` CRDT layer. Does not exercise the structural-edit pipeline (span edits, placeholders, projection reconcile).
+
+2. **Text-level SyncEditor** (`editor/sync_editor_test.mbt:81-96`): `insert` convergence — tests the text CRDT layer only. Does not test structural edits.
+
+The TODO exit criterion: *"property tests covering concurrent drop, undo grouping after relocation, and reconciliation"* — so the centerpiece is a **quickcheck model**, not hand-written tests. Named deterministic tests punctuate the property.
+
+## Key Design Constraint
+
+`SyncEditor::move_node` semantics:
+
+| `DropPosition` | Behavior |
+|---|---|
+| `Before` / `After` | **Move:** source expr replaced with placeholder; source text inserted before/after target. Source vacates its position. |
+| `Inside` | **Exchange/Swap:** both nodes exchange their expression content (text swap). Neither node vacates. |
+
+`Inside` is **not** "move into target as child" — it's a symmetric content swap. This constrains the test model: concurrent-swap tests check CRDT ordering of identical-intent swaps; concurrent move-vs-swap tests check conflicting-intent arbitration.
+
+### Undo constraint
+
+`SyncEditor.undo` reverts only the local editor's own delta — remote ops applied via `apply_sync` are not captured in the local undo stack. This means after both peers drop + sync:
+
+- Editor 1's undo reverts Editor 1's span edits only (Editor 2's edits persist locally)
+- Editor 2's undo reverts Editor 2's span edits only
+
+After both undo + bidirectional sync, both editors converge on the mutual undo state (both drops reverted, initial seed restored). The undo assertions below account for this: they assert convergence after each sync round, not immediate identity with the initial seed.
+
+## Scope
+
+**Test-only.** No blueprint changes, no new SyncEditor methods, no new `TreeEditOp` variants. All machinery is live — this fills the gap between the CRDT layer and the text layer at the structural-edit pipeline level.
+
+## Test Structure
+
+**File:** `lang/lambda/companion/drop_convergence_test.mbt` (new blackbox test file)
+
+The lambda companion package already imports `@qc` (`moon.pkg` line 20).
+
+## Model Layer
+
+A small generator that produces **pairs of concurrent Drop operations** on a shared initial seed text.
+
+### Types
+
+```moonbit
+enum DropPosition { Before; After; Inside }
+
+struct ConcurrentDropScenario {
+  seed_text : String
+  peer1_drop : DropOp
+  peer2_drop : DropOp
+}
+
+struct DropOp {
+  source_idx : Int   // index into the seed's top-level children
+  target_idx : Int   // index into the seed's top-level children
+  position : DropPosition
+}
+```
+
+### Arbitrary instance
+
+```moonbit
+impl @qc.Arbitrary for ConcurrentDropScenario with fn arbitrary(size, rs) {
+  // 1. Pick a seed AST with 3-6 top-level children from a small fixed set
+  //    of seed strings (e.g. "a b c", "f(x) g(y) h(z)", "f(a) g(b) h(c) i(d)").
+  // 2. Pick source and target indices (0..n-1, source != target) for each peer.
+  //    Both peers pick from the seed's children independently.
+  // 3. Pick DropPosition for each peer.
+  // 4. Return { seed_text, peer1_drop, peer2_drop }
+}
+```
+
+### Properties
+
+#### P1: Concurrent drops converge
+
+Given scenario, set up two editors on `seed_text`, apply each peer's drop, sync bidirectional, assert:
+
+```
+ed1.get_text() == ed2.get_text()
+get_lambda_ast(ed1) == get_lambda_ast(ed2)
+ed1.get_proj_node() is Some(_)
+ed2.get_proj_node() is Some(_)
+```
+
+Quickcheck over 200 iterations.
+
+#### P2: Undo grouping — local drop's multi-span edit undoes as one step
+
+Given scenario, after drops + sync converge:
+
+1. Both editors report `can_undo()` = true (undo stack is non-empty — the local drop, which was a multi-span edit)
+2. Both editors' `undo()` succeeds (no crash, returns success)
+3. After bidirectional sync of undo operations: both converge again (`text == text`, `AST == AST`, valid ProjNode)
+4. (Diagnostic) If both peers are back at the initial seed text after undo sync, the inverse span edits cleanly commuted. This is expected but not guaranteed — inverse edits applied to interleaved remote text may not reconstruct the literal seed. The hard assertion is step 3: convergence + valid ProjNode.
+
+Quickcheck over 100 iterations.
+
+#### P3: Reconciliation produces no structural errors
+
+After each sync round: the projection memo returns `Some(proj)`, the source map resolves every `NodeId` referenced by the ProjNode, and the AST round-trips (unparse → reparse → same AST). Quickcheck over 200 iterations.
+
+### Shrink instance
+
+The shrink produces shorter seed text (fewer children) and replaces both drop positions with `Before` (least structurally disruptive), shrinking toward the minimal scenario that still diverges.
+
+### Wrinkles
+
+- The seed text must be parseable lambda. A fixed set of 3-4 seed strings (with varying structure: only leaves, mix of leaves and branches) avoids generation of malformed input.
+- Source/target indices refer to the **initial** AST children. After a move, the child list reshuffles — but both peers start from the same initial text and apply their drop to that same initial state, so indices resolve the same way before any sync happens.
+- The model is small by design (2 peers, 2 concurrent drops) to keep the state space tractable. Multi-round concurrent scenarios would need a generator of op sequences, which is future work.
+
+## Named Regression Tests (Deterministic)
+
+These are fixed-scenario spot checks that exercise specific failure modes. They also serve as documentation of what edge cases the property generator covers.
+
+### R1: Different sources, same target, both Before
+
+- Peer 1: `Drop(source=a, target=b, Before)` — a already precedes b in seed
+- Peer 2: `Drop(source=c, target=b, Before)` — c moves before b
+
+After sync: both converge. Verifies two sources targeting the same position.
+
+### R2: Same source, different targets, both Before — CRDT arbitrates relocation
+
+- Peer 1: `Drop(source=b, target=a, Before)` — b moves before a
+- Peer 2: `Drop(source=b, target=c, Before)` — b moves before c
+- Both ops move the same node `b` to different positions. The CRDT must arbitrate the relocation conflict. After sync: converge.
+
+### R3: Both peers issue same exchange (Inside, same pair)
+
+- Both peers: `Drop(source=a, target=b, Inside)` — both swap a↔b identically
+- Sync: still convergent. No CRDT conflict since both produced identical CRDT ops.
+- Verifies that identical concurrent swaps don't diverge.
+
+### R4: Exchange vs move (Inside vs Before) on same pair — conflicting intent
+
+- Peer 1: `Drop(source=a, target=b, Inside)` — exchange/swap
+- Peer 2: `Drop(source=a, target=b, Before)` — move-before
+- The CRDT must arbitrate conflicting interpretation of "drop a at b" (swap vs relocate). After sync: converge.
+
+### R5: Drop + concurrent text edit — structural-text interop
+
+- Peer 1: `Drop(source=b, target=a, Before)` — structural edit
+- Peer 2: `insert("x")` at cursor 0 — raw text edit
+- After sync: converge. Verifies structural edit + raw text edit interop through the shared CRDT.
+
+### R6: Undo after concurrent drops — grouped undo then resync
+
+- Seed: `"a b c"`
+- Peer 1: `Drop(source=b, target=a, Before)`
+- Peer 2: `Drop(source=c, target=a, After)`
+- Sync → converge
+- Assert `can_undo()` for both editors
+- Both `undo()` → succeeds without crash
+- Bidirectional sync → converge again (text == text, AST == AST)
+- (Diagnostic) If both peers are back at `"a b c"`, the inverse span edits commuted cleanly. This is not guaranteed when remote edits interleave — hard assertion is convergence above.
+
+### R7: Three-peer convergence (sanity)
+
+- Seed: `"a b c"`
+- Three peers, each issues a different drop (different source-target pairs)
+- All-pairs bidirectional sync
+- Every pair converges on text + AST
+
+## Timestamp Strategy
+
+Each peer issues its ops with increasing timestamps, starting from 1. CRDT ops from different agents at the same timestamp are ordered by agent id tiebreak.
+
+- Peer 1: `timestamp_ms = 1`
+- Peer 2: `timestamp_ms = 1`
+
+This matches real-world usage: concurrent ops from different clients are ordered by client id.
+
+## Risks
+
+1. **`get_lambda_ast` returns `Term`** — if `Term` does not `derive(Eq)`, fall back to string comparison: `@ast.print_term(get_lambda_ast(ed1)) == @ast.print_term(get_lambda_ast(ed2))`.
+
+2. **Node ID instability after sync** — after sync+reparse, a given structural node may have a different `NodeId`. The test model uses **indices into the initial children array**, not cached NodeIds.
+
+3. **Memo stabilization** — `get_proj_node()` returns `Option` from a reactive memo. Guard with `guard ... is Some(proj)` before accessing children.
+
+4. **incr runtime isolation** — each editor owns its own incr runtime. No cross-editor dependency.
+
+5. **Seed text must be valid lambda** — fixed seed set avoids generation of syntactically invalid input.
+
+6. **Quickcheck size parameter** — `size` drives the number of children in the seed. Map `size = 0` → smallest seed ("a b"); larger sizes pick seeds with more children and branching.
+
+7. **`move_node` timestamp reuse** — two peers using the same timestamp value is fine (agent-ID tiebreak). A peer reusing the same local timestamp for consecutive ops would be a bug, avoided here by each peer issuing exactly one drop per test.
+
+8. **R1: move Before where source already precedes target** — `move_node` Before where the source is already first is a no-op in text terms (source stays in place, placeholder replaces nothing meaningful). The CRDT still records the op. Both peers converge trivially, leaving the other peer's conflicting move as the interesting test.
+
+9. **Undo R6 final seed assertion** — after both undo + sync, both peers should converge on the initial seed provided undo operations are CRDT text ops that commute. If this assertion fails consistently, the undo property (P2) will still verify convergence after undo + sync without asserting specific content. The R6 test is the diagnostic that will surface the actual behavior.
+
+## Exit Criteria
+
+- `drop_convergence_test.mbt` exists with:
+  - **3 quickcheck properties** (P1 concurrent drops converge, P2 undo after drops, P3 no structural errors)
+  - **7 named regression tests** (R1-R7)
+- `moon test` passes in the lambda companion package
+- Every property test runs ≥100 iterations
+- Every test asserts text convergence AND AST convergence AND ProjNode validity
+
+## Non-Goals
+
+- No changes to SyncEditor, move_node, lambda companion, or TreeEditOp
+- No changes to the CRDT layer (MovableTree, Document)
+- No new helper methods on SyncEditor
+- No performance benchmarking
+- No multi-round concurrent op sequences (future work)
+
+## Plan Steps
+
+1. Create `lang/lambda/companion/drop_convergence_test.mbt`
+2. Implement helpers: `setup_two_peers`, `apply_drop`, `assert_converged`
+3. Implement model types: `ConcurrentDropScenario`, `DropOp`, `Arbitrary`, `Shrink`
+4. Implement 3 quickcheck properties (P1, P2, P3)
+5. Implement 7 named regression tests (R1-R7)
+6. Run `moon test` in lambda companion → fix any failures
+7. Run `moon test` across workspace → verify no downstream breakage

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -173,12 +173,13 @@ test "export: divider" {
   let _ = doc.create_block(Divider)
   inspect(block_doc_to_markdown(doc), content="---\n")
 }
+
 ///|
 test "export: nested blocks are indented" {
   let doc = BlockDoc::new("alice")
   let parent = doc.create_block(Paragraph)
   doc.set_text(parent, "parent")
-  let child = doc.create_block(Paragraph, parent=parent)
+  let child = doc.create_block(Paragraph, parent~)
   doc.set_text(child, "child")
   let out = block_doc_to_markdown(doc)
   inspect(out, content="parent\n  child\n")
@@ -585,6 +586,33 @@ test "move_block: descendant-drop rejected by CRDT cycle detection" {
     _ => ()
   }
   inspect(caught_cycle, content="true")
+}
+
+///|
+test "move_block Before/After with ref_parent preserves nested block's parent" {
+  let doc = BlockDoc::new("alice")
+  let parent = doc.create_block(Paragraph)
+  let child_a = doc.create_block(Paragraph, parent~)
+  let child_b = doc.create_block(Paragraph, parent~)
+  doc.set_text(child_a, "a")
+  doc.set_text(child_b, "b")
+  // Reorder: move child_a after child_b, staying under parent
+  doc.move_block(
+    child_a,
+    child_b,
+    @canopy_core.DropPosition::After,
+    ref_parent=parent,
+  ) catch {
+    _ => ()
+  }
+  let children = doc.children(parent)
+  inspect(children.length(), content="2")
+  // child_b is now first, child_a is second
+  inspect(doc.get_text(children[0]), content="b")
+  inspect(doc.get_text(children[1]), content="a")
+  // Neither block escaped to root
+  let root_children = doc.children(root_block_id)
+  inspect(root_children.length(), content="1") // only parent at root
 }
 
 // TODO: sync tests require container-level sync API (SyncMessage, VersionVector)

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -173,6 +173,16 @@ test "export: divider" {
   let _ = doc.create_block(Divider)
   inspect(block_doc_to_markdown(doc), content="---\n")
 }
+///|
+test "export: nested blocks are indented" {
+  let doc = BlockDoc::new("alice")
+  let parent = doc.create_block(Paragraph)
+  doc.set_text(parent, "parent")
+  let child = doc.create_block(Paragraph, parent=parent)
+  doc.set_text(child, "child")
+  let out = block_doc_to_markdown(doc)
+  inspect(out, content="parent\n  child\n")
+}
 
 // ── Markdown import tests ─────────────────────────────────────────────────
 

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -173,12 +173,13 @@ test "export: divider" {
   let _ = doc.create_block(Divider)
   inspect(block_doc_to_markdown(doc), content="---\n")
 }
+
 ///|
 test "export: nested blocks are indented" {
   let doc = BlockDoc::new("alice")
   let parent = doc.create_block(Paragraph)
   doc.set_text(parent, "parent")
-  let child = doc.create_block(Paragraph, parent=parent)
+  let child = doc.create_block(Paragraph, parent~)
   doc.set_text(child, "child")
   let out = block_doc_to_markdown(doc)
   inspect(out, content="parent\n  child\n")

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -173,13 +173,12 @@ test "export: divider" {
   let _ = doc.create_block(Divider)
   inspect(block_doc_to_markdown(doc), content="---\n")
 }
-
 ///|
 test "export: nested blocks are indented" {
   let doc = BlockDoc::new("alice")
   let parent = doc.create_block(Paragraph)
   doc.set_text(parent, "parent")
-  let child = doc.create_block(Paragraph, parent~)
+  let child = doc.create_block(Paragraph, parent=parent)
   doc.set_text(child, "child")
   let out = block_doc_to_markdown(doc)
   inspect(out, content="parent\n  child\n")
@@ -586,33 +585,6 @@ test "move_block: descendant-drop rejected by CRDT cycle detection" {
     _ => ()
   }
   inspect(caught_cycle, content="true")
-}
-
-///|
-test "move_block Before/After with ref_parent preserves nested block's parent" {
-  let doc = BlockDoc::new("alice")
-  let parent = doc.create_block(Paragraph)
-  let child_a = doc.create_block(Paragraph, parent~)
-  let child_b = doc.create_block(Paragraph, parent~)
-  doc.set_text(child_a, "a")
-  doc.set_text(child_b, "b")
-  // Reorder: move child_a after child_b, staying under parent
-  doc.move_block(
-    child_a,
-    child_b,
-    @canopy_core.DropPosition::After,
-    ref_parent=parent,
-  ) catch {
-    _ => ()
-  }
-  let children = doc.children(parent)
-  inspect(children.length(), content="2")
-  // child_b is now first, child_a is second
-  inspect(doc.get_text(children[0]), content="b")
-  inspect(doc.get_text(children[1]), content="a")
-  // Neither block escaped to root
-  let root_children = doc.children(root_block_id)
-  inspect(root_children.length(), content="1") // only parent at root
 }
 
 // TODO: sync tests require container-level sync API (SyncMessage, VersionVector)

--- a/examples/block-editor/main/block_export.mbt
+++ b/examples/block-editor/main/block_export.mbt
@@ -1,18 +1,37 @@
+///| Export a BlockDoc to Markdown.
 ///|
-/// Export a BlockDoc to Markdown.
-///
-/// Rules:
-/// - Blank line between all block pairs except consecutive same-style list items
-/// - Numbered list items renumbered from 1
-/// - Code: ```lang\n…\n```
-/// - Divider: ---
-/// - Raw: verbatim content
+///| Rules:
+///| - Blank line between all block pairs except consecutive same-style list items
+///| - Numbered list items renumbered from 1 per container
+///| - Code: ```lang\n…\n```
+///| - Divider: ---
+///| - Raw: verbatim content
+///| - Nested blocks indented by 2 spaces per depth level
 pub fn block_doc_to_markdown(doc : BlockDoc) -> String {
-  let buf = StringBuilder::new()
-  let children = doc.children(root_block_id)
+  let buf = StringBuilder()
+  emit_children(buf, doc, root_block_id, 0)
+  buf.to_string()
+}
+
+fn emit_children(
+  buf : StringBuilder,
+  doc : BlockDoc,
+  parent_id : @container.TreeNodeId,
+  depth : Int,
+) -> Unit {
+  let children = doc.children(parent_id)
   let len = children.length()
   let mut numbered_counter = 1
   let mut prev_type : BlockType? = None
+  let indent = if depth > 0 {
+    let s = StringBuilder()
+    for _ in 0..<depth {
+      s.write_string("  ")
+    }
+    s.to_string()
+  } else {
+    ""
+  }
   for i in 0..<len {
     let id = children[i]
     let bt = doc.get_type(id)
@@ -26,17 +45,18 @@ pub fn block_doc_to_markdown(doc : BlockDoc) -> String {
         buf.write_string("\n")
       }
     }
-    // Reset counter for any non-Numbered block type
     match bt {
       ListItem(Numbered) => ()
       _ => numbered_counter = 1
     }
     match bt {
       Paragraph => {
+        buf.write_string(indent)
         buf.write_string(text)
         buf.write_string("\n")
       }
       Heading(n) => {
+        buf.write_string(indent)
         for _ in 0..<n {
           buf.write_string("#")
         }
@@ -45,11 +65,13 @@ pub fn block_doc_to_markdown(doc : BlockDoc) -> String {
         buf.write_string("\n")
       }
       ListItem(Bullet) => {
+        buf.write_string(indent)
         buf.write_string("- ")
         buf.write_string(text)
         buf.write_string("\n")
       }
       ListItem(Numbered) => {
+        buf.write_string(indent)
         buf.write_string(numbered_counter.to_string())
         buf.write_string(". ")
         buf.write_string(text)
@@ -57,6 +79,7 @@ pub fn block_doc_to_markdown(doc : BlockDoc) -> String {
         numbered_counter = numbered_counter + 1
       }
       ListItem(Todo) => {
+        buf.write_string(indent)
         if doc.get_checked(id) {
           buf.write_string("- [x] ")
         } else {
@@ -66,24 +89,34 @@ pub fn block_doc_to_markdown(doc : BlockDoc) -> String {
         buf.write_string("\n")
       }
       Quote => {
+        buf.write_string(indent)
         buf.write_string("> ")
         buf.write_string(text)
         buf.write_string("\n")
       }
       Code(lang) => {
+        buf.write_string(indent)
         buf.write_string("```")
         buf.write_string(lang)
         buf.write_string("\n")
+        buf.write_string(indent)
         buf.write_string(text)
-        buf.write_string("\n```\n")
+        buf.write_string("\n")
+        buf.write_string(indent)
+        buf.write_string("```\n")
       }
-      Divider => buf.write_string("---\n")
+      Divider => {
+        buf.write_string(indent)
+        buf.write_string("---\n")
+      }
       Raw => {
+        buf.write_string(indent)
         buf.write_string(text)
         buf.write_string("\n")
       }
     }
+    // Recurse into children (nested blocks)
+    emit_children(buf, doc, id, depth + 1)
     prev_type = Some(bt)
   }
-  buf.to_string()
 }

--- a/examples/block-editor/main/block_export.mbt
+++ b/examples/block-editor/main/block_export.mbt
@@ -1,18 +1,28 @@
 ///| Export a BlockDoc to Markdown.
+
 ///|
+
 ///| Rules:
+
 ///| - Blank line between all block pairs except consecutive same-style list items
+
 ///| - Numbered list items renumbered from 1 per container
+
 ///| - Code: ```lang\n…\n```
+
 ///| - Divider: ---
+
 ///| - Raw: verbatim content
-///| - Nested blocks indented by 2 spaces per depth level
+
+///|
+/// - Nested blocks indented by 2 spaces per depth level
 pub fn block_doc_to_markdown(doc : BlockDoc) -> String {
   let buf = StringBuilder()
   emit_children(buf, doc, root_block_id, 0)
   buf.to_string()
 }
 
+///|
 fn emit_children(
   buf : StringBuilder,
   doc : BlockDoc,

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -54,59 +54,114 @@ fn parse_block_id(s : String) -> @container.TreeNodeId {
 }
 
 ///|
+fn count_blocks(doc : BlockDoc, parent_id : @container.TreeNodeId) -> Int {
+  let children = doc.children(parent_id)
+  for child in children; acc = children.length() {
+    continue acc + count_blocks(doc, child)
+  } nobreak {
+    acc
+  }
+}
+
+///|
+fn emit_block_json(
+  buf : StringBuilder,
+  doc : BlockDoc,
+  id : @container.TreeNodeId,
+  parent_key : String,
+  depth : Int,
+  child_index : Int,
+) -> Unit {
+  let bt = doc.get_type(id)
+  buf
+  ..write_string("{\"id\":\"")
+  ..write_json_escaped(@container.tree_node_id_key(id))
+  ..write_string("\",\"block_type\":\"")
+  ..write_json_escaped(block_type_name(bt))
+  .write_string("\",\"level\":\"")
+  match bt {
+    Heading(n) => buf.write_json_escaped(n.to_string())
+    _ => ()
+  }
+  buf.write_string("\",\"list_style\":\"")
+  match bt {
+    ListItem(Bullet) => buf.write_string("bullet")
+    ListItem(Numbered) => buf.write_string("numbered")
+    ListItem(Todo) => buf.write_string("todo")
+    _ => ()
+  }
+  buf
+  ..write_string("\",\"checked\":")
+  ..write_string(if doc.get_checked(id) { "true" } else { "false" })
+  ..write_string(",\"index\":")
+  ..write_string(child_index.to_string())
+  ..write_string(",\"parent_id\":\"")
+  ..write_json_escaped(parent_key)
+  ..write_string("\",\"depth\":")
+  ..write_string(depth.to_string())
+  ..write_string(",\"child_count\":")
+  ..write_string(doc.children(id).length().to_string())
+  ..write_string(",\"is_alive\":true")
+  ..write_string(",\"text\":\"")
+  ..write_json_escaped(doc.get_text(id))
+  .write_string("\"}")
+  ()
+}
+
+///|
+/// Emit JSON for all blocks in the subtree rooted at `parent_id`, in preorder.
+/// `is_first` tracks whether this is the first block in the overall array (no comma prefix).
+fn emit_blocks(
+  buf : StringBuilder,
+  doc : BlockDoc,
+  parent_id : @container.TreeNodeId,
+  depth : Int,
+  is_first : Ref[Bool],
+) -> Unit {
+  let children = doc.children(parent_id)
+  let parent_key = @container.tree_node_id_key(parent_id)
+  for i in 0..<children.length() {
+    let id = children[i]
+    if is_first.val {
+      is_first.val = false
+    } else {
+      buf.write_string(",")
+    }
+    emit_block_json(buf, doc, id, parent_key, depth, i)
+    // Recurse into children
+    emit_blocks(buf, doc, id, depth + 1, is_first)
+  }
+}
+
+///| Return the full block tree as JSON, in preorder (parents before children).
+
+///|
+
+///| Each block object contains: id, block_type, level, list_style, checked,
+
+///| index (sibling order), parent_id, depth, child_count, is_alive, text.
+
+///|
+/// Blocks with children appear before their descendants in the array (preorder).
 pub fn get_render_state(handle : Int) -> String {
   match docs.get(handle) {
     Some(doc) => {
-      let buf = StringBuilder::new()
-      let children = doc.children(root_block_id)
-      let parent_key = @container.tree_node_id_key(root_block_id)
-      buf.write_string("{\"block_count\":")
-      buf.write_string(children.length().to_string())
-      buf.write_string(",\"blocks\":[")
-      for i in 0..<children.length() {
-        if i > 0 {
-          buf.write_string(",")
-        }
-        let id = children[i]
-        let bt = doc.get_type(id)
-        buf.write_string("{\"id\":\"")
-        write_json_escaped(buf, @container.tree_node_id_key(id))
-        buf.write_string("\",\"block_type\":\"")
-        write_json_escaped(buf, block_type_name(bt))
-        buf.write_string("\",\"level\":\"")
-        match bt {
-          Heading(n) => write_json_escaped(buf, n.to_string())
-          _ => ()
-        }
-        buf.write_string("\",\"list_style\":\"")
-        match bt {
-          ListItem(Bullet) => buf.write_string("bullet")
-          ListItem(Numbered) => buf.write_string("numbered")
-          ListItem(Todo) => buf.write_string("todo")
-          _ => ()
-        }
-        buf.write_string("\",\"checked\":")
-        buf.write_string(if doc.get_checked(id) { "true" } else { "false" })
-        buf.write_string(",\"index\":")
-        buf.write_string(i.to_string())
-        buf.write_string(",\"parent_id\":\"")
-        write_json_escaped(buf, parent_key)
-        buf.write_string("\",\"text\":\"")
-        write_json_escaped(buf, doc.get_text(id))
-        buf.write_string("\"}")
-      }
-      buf.write_string("]}")
-      buf.to_string()
+      let buf = StringBuilder()
+      let total = count_blocks(doc, root_block_id)
+      buf
+      ..write_string("{\"block_count\":")
+      ..write_string(total.to_string())
+      .write_string(",\"blocks\":[")
+      emit_blocks(buf, doc, root_block_id, 0, { val: true })
+      buf..write_string("]}").to_string()
     }
     None => "{\"block_count\":0,\"blocks\":[]}"
   }
 }
 
 ///|
-/// Escape a string for JSON output. Handles required escapes (RFC 8259 §7)
-/// and writes directly to the buffer without per-character allocation.
-fn write_json_escaped(buf : StringBuilder, s : String) -> Unit {
-  // Track start of unescaped run to batch-copy normal characters
+/// Escape a string and append to this buffer. Handles required JSON escapes (RFC 8259 §7).
+fn StringBuilder::write_json_escaped(self : StringBuilder, s : String) -> Unit {
   let mut run_start = 0
   for i in 0..<s.length() {
     let ch = s[i]
@@ -121,7 +176,6 @@ fn write_json_escaped(buf : StringBuilder, s : String) -> Unit {
     } else if ch == '\t' {
       Some("\\t")
     } else if ch.to_int() < 0x20 {
-      // JSON requires all control chars below U+0020 to be \uXXXX escaped
       let hi = (ch.to_int() >> 4) & 0xf
       let lo = ch.to_int() & 0xf
       Some("\\u00" + hex_char(hi).to_string() + hex_char(lo).to_string())
@@ -130,19 +184,17 @@ fn write_json_escaped(buf : StringBuilder, s : String) -> Unit {
     }
     match escape {
       Some(esc) => {
-        // Flush the unescaped run before writing the escape sequence
         if run_start < i {
-          buf.write_string(s[run_start:i].to_owned())
+          self.write_string(s[run_start:i].to_owned())
         }
-        buf.write_string(esc)
+        self.write_string(esc)
         run_start = i + 1
       }
       None => ()
     }
   }
-  // Flush any remaining unescaped tail
   if run_start < s.length() {
-    buf.write_string(s[run_start:].to_owned())
+    self.write_string(s[run_start:].to_owned())
   }
 }
 

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -281,6 +281,7 @@ pub fn editor_move_block(
   id_str : String,
   ref_id_str : String,
   position_str : String,
+  ref_parent_id_str : String,
 ) -> Bool {
   match docs.get(handle) {
     Some(doc) => {
@@ -292,7 +293,8 @@ pub fn editor_move_block(
       }
       let id = parse_block_id(id_str)
       let ref_id = parse_block_id(ref_id_str)
-      doc.move_block(id, ref_id, position) catch {
+      let ref_parent = parse_block_id(ref_parent_id_str)
+      doc.move_block(id, ref_id, position, ref_parent~) catch {
         _ => return false
       }
       true

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -281,7 +281,6 @@ pub fn editor_move_block(
   id_str : String,
   ref_id_str : String,
   position_str : String,
-  ref_parent_id_str : String,
 ) -> Bool {
   match docs.get(handle) {
     Some(doc) => {
@@ -293,8 +292,7 @@ pub fn editor_move_block(
       }
       let id = parse_block_id(id_str)
       let ref_id = parse_block_id(ref_id_str)
-      let ref_parent = parse_block_id(ref_parent_id_str)
-      doc.move_block(id, ref_id, position, ref_parent~) catch {
+      doc.move_block(id, ref_id, position) catch {
         _ => return false
       }
       true

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -101,7 +101,8 @@ fn emit_block_json(
   ..write_string(depth.to_string())
   ..write_string(",\"child_count\":")
   ..write_string(doc.children(id).length().to_string())
-  ..write_string(",\"is_alive\":true")
+  ..write_string(",\"is_alive\":")
+  ..write_string(if doc.is_alive(id) { "true" } else { "false" })
   ..write_string(",\"text\":\"")
   ..write_json_escaped(doc.get_text(id))
   .write_string("\"}")
@@ -120,6 +121,7 @@ fn emit_blocks(
 ) -> Unit {
   let children = doc.children(parent_id)
   let parent_key = @container.tree_node_id_key(parent_id)
+  // Indexed loop: i is the sibling index passed to emit_block_json.
   for i in 0..<children.length() {
     let id = children[i]
     if is_first.val {

--- a/examples/block-editor/main/block_init_wbtest.mbt
+++ b/examples/block-editor/main/block_init_wbtest.mbt
@@ -148,5 +148,9 @@ test "get_render_state includes depth and child_count" {
   inspect(String::contains(json, "\"depth\":1"), content="true")
   inspect(String::contains(json, "\"child_count\":1"), content="true")
   inspect(String::contains(json, "\"is_alive\":true"), content="true")
-  inspect(String::contains(json, "\"parent"), content="true")
+  let parent_key = @container.tree_node_id_key(parent)
+  inspect(
+    String::contains(json, "\"parent_id\":\"\{parent_key}\""),
+    content="true",
+  )
 }

--- a/examples/block-editor/main/block_init_wbtest.mbt
+++ b/examples/block-editor/main/block_init_wbtest.mbt
@@ -60,16 +60,15 @@ test "parse_block_id: zero counter" {
 
 ///|
 test "write_json_escaped: special characters" {
-  let buf = StringBuilder::new()
-  write_json_escaped(buf, "hello \"world\" \\ new\nline\ttab")
+  let buf = StringBuilder()
+  buf.write_json_escaped("hello \"world\" \\ new\nline\ttab")
   inspect(buf.to_string(), content="hello \\\"world\\\" \\\\ new\\nline\\ttab")
 }
 
 ///|
 test "write_json_escaped: control characters" {
-  let buf = StringBuilder::new()
-  // ASCII control char 0x01 (SOH)
-  write_json_escaped(buf, "\u0001")
+  let buf = StringBuilder()
+  buf.write_json_escaped("\u0001")
   inspect(buf.to_string(), content="\\u0001")
 }
 
@@ -134,4 +133,20 @@ test "editor_set_block_type changes type" {
   let json2 = get_render_state(h)
   inspect(String::contains(json2, "heading"), content="true")
   inspect(String::contains(json2, "Hello"), content="true")
+}
+
+///|
+test "get_render_state includes depth and child_count" {
+  let h = create_editor("test_depth")
+  let doc = docs.get(h).unwrap()
+  let parent = doc.create_block(Paragraph)
+  doc.set_text(parent, "parent")
+  let child = doc.create_block(Paragraph, parent~)
+  doc.set_text(child, "child")
+  let json = get_render_state(h)
+  inspect(String::contains(json, "\"depth\":0"), content="true")
+  inspect(String::contains(json, "\"depth\":1"), content="true")
+  inspect(String::contains(json, "\"child_count\":1"), content="true")
+  inspect(String::contains(json, "\"is_alive\":true"), content="true")
+  inspect(String::contains(json, "\"parent"), content="true")
 }

--- a/examples/block-editor/main/pkg.generated.mbti
+++ b/examples/block-editor/main/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub fn editor_import_markdown(Int, String) -> Unit
 
 pub fn editor_insert_block_after(Int, String, String) -> String
 
-pub fn editor_move_block(Int, String, String, String, String) -> Bool
+pub fn editor_move_block(Int, String, String, String) -> Bool
 
 pub fn editor_set_block_text(Int, String, String) -> Unit
 
@@ -57,7 +57,7 @@ pub fn BlockDoc::get_text(Self, @movable_tree.TreeNodeId) -> String
 pub fn BlockDoc::get_type(Self, @movable_tree.TreeNodeId) -> BlockType
 pub fn BlockDoc::insert_char(Self, @movable_tree.TreeNodeId, Int, String) -> Unit
 pub fn BlockDoc::is_alive(Self, @movable_tree.TreeNodeId) -> Bool
-pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, @movable_tree.TreeNodeId, @core.DropPosition, ref_parent? : @movable_tree.TreeNodeId) -> Unit raise @container.DocumentError
+pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, @movable_tree.TreeNodeId, @core.DropPosition) -> Unit raise @container.DocumentError
 pub fn BlockDoc::new(String) -> Self raise @container.DocumentError
 pub fn BlockDoc::set_checked(Self, @movable_tree.TreeNodeId, Bool) -> Unit
 pub fn BlockDoc::set_text(Self, @movable_tree.TreeNodeId, String) -> Unit

--- a/examples/block-editor/main/pkg.generated.mbti
+++ b/examples/block-editor/main/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub fn editor_import_markdown(Int, String) -> Unit
 
 pub fn editor_insert_block_after(Int, String, String) -> String
 
-pub fn editor_move_block(Int, String, String, String) -> Bool
+pub fn editor_move_block(Int, String, String, String, String) -> Bool
 
 pub fn editor_set_block_text(Int, String, String) -> Unit
 
@@ -57,7 +57,7 @@ pub fn BlockDoc::get_text(Self, @movable_tree.TreeNodeId) -> String
 pub fn BlockDoc::get_type(Self, @movable_tree.TreeNodeId) -> BlockType
 pub fn BlockDoc::insert_char(Self, @movable_tree.TreeNodeId, Int, String) -> Unit
 pub fn BlockDoc::is_alive(Self, @movable_tree.TreeNodeId) -> Bool
-pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, @movable_tree.TreeNodeId, @core.DropPosition) -> Unit raise @container.DocumentError
+pub fn BlockDoc::move_block(Self, @movable_tree.TreeNodeId, @movable_tree.TreeNodeId, @core.DropPosition, ref_parent? : @movable_tree.TreeNodeId) -> Unit raise @container.DocumentError
 pub fn BlockDoc::new(String) -> Self raise @container.DocumentError
 pub fn BlockDoc::set_checked(Self, @movable_tree.TreeNodeId, Bool) -> Unit
 pub fn BlockDoc::set_text(Self, @movable_tree.TreeNodeId, String) -> Unit

--- a/examples/block-editor/web/src/main.ts
+++ b/examples/block-editor/web/src/main.ts
@@ -9,6 +9,9 @@ interface Block {
   checked: boolean;
   index: number;
   parent_id: string;
+  depth: number;
+  child_count: number;
+  is_alive: boolean;
   text: string;
 }
 
@@ -33,10 +36,14 @@ let currentDropPosition: DropPosition | null = null;
 // Seed
 ed.editor_import_markdown(handle, '# Welcome\n\nStart typing here.\n');
 
+// Block index for drop-target validation (rebuilt on each render)
+let blockById: Map<string, Block> = new Map();
+
 // ── Render ─────────────────────────────────────────────────────────────
 function render() {
   const state: RenderState = JSON.parse(ed.get_render_state(handle));
   const liveIds = new Set<string>();
+  blockById = buildBlockIndex(state);
 
   for (const block of state.blocks) {
     liveIds.add(block.id);
@@ -67,6 +74,11 @@ function render() {
       });
       div.prepend(grip);
 
+      // Editable text goes in a separate span so textContent updates don't nuke the grip
+      const textSpan = document.createElement('span');
+      textSpan.className = 'text-content';
+      textSpan.contentEditable = block.block_type === 'divider' ? 'false' : 'true';
+      div.append(textSpan);
       wireDragTarget(div);
       wireEvents(div);
       container.appendChild(div);
@@ -80,12 +92,15 @@ function render() {
     div.dataset.checked = String(block.checked);
     div.dataset.index = String(block.index);
     div.dataset.parentId = block.parent_id;
-    div.contentEditable = block.block_type === 'divider' ? 'false' : 'true';
     applyAriaRoles(div, block);
 
-    // Only update text if not focused (avoid clobbering cursor)
-    if (document.activeElement !== div && div.textContent !== block.text) {
-      div.textContent = block.text;
+    // Update the .text-content span — never nuke the grip child
+    const textSpan = div.querySelector('.text-content') as HTMLSpanElement | null;
+    if (textSpan) {
+      textSpan.contentEditable = block.block_type === 'divider' ? 'false' : 'true';
+      if (document.activeElement !== textSpan && textSpan.textContent !== block.text) {
+        textSpan.textContent = block.text;
+      }
     }
   }
 
@@ -138,6 +153,44 @@ function applyAriaRoles(div: HTMLDivElement, block: Block) {
   }
 }
 
+// ── Drop-target validation ──────────────────────────────────────────
+function buildBlockIndex(state: RenderState): Map<string, Block> {
+  const map = new Map<string, Block>();
+  for (const block of state.blocks) {
+    map.set(block.id, block);
+  }
+  return map;
+}
+
+/** Walk parent chain: is `id` inside the subtree of `potentialAncestor`?
+    Stops when root is reached (key not in block index). */
+function isDescendant(id: string, potentialAncestor: string, index: Map<string, Block>): boolean {
+  let current: string | undefined = id;
+  while (current) {
+    if (current === potentialAncestor) return true;
+    const block = index.get(current);
+    if (!block) break; // Root sentinel or unknown id — stop
+    current = block.parent_id;
+  }
+  return false;
+}
+
+function validateDropTarget(
+  sourceId: string,
+  targetId: string,
+  _position: DropPosition,
+  index: Map<string, Block>,
+): boolean {
+  const source = index.get(sourceId);
+  const target = index.get(targetId);
+  if (!source || !target) return false;
+  if (!source.is_alive || !target.is_alive) return false;
+  if (sourceId === targetId) return false;
+  // Reject dropping onto a descendant (would orphan the subtree)
+  if (isDescendant(targetId, sourceId, index)) return false;
+  return true;
+}
+
 // ── Drag targeting ──────────────────────────────────────────────────���─
 function computeDropPosition(e: DragEvent, div: HTMLDivElement): DropPosition {
   const rect = div.getBoundingClientRect();
@@ -161,6 +214,13 @@ function wireDragTarget(div: HTMLDivElement) {
     const id = div.dataset.blockId!;
     if (id === dragSourceId) return;
 
+    // Validate drop target — reject descendant and invalid targets
+    if (dragSourceId && !validateDropTarget(dragSourceId, id, computeDropPosition(e, div), blockById)) {
+      e.dataTransfer!.dropEffect = 'none';
+      if (currentDropTarget === div) clearDropIndicators();
+      return;
+    }
+
     e.dataTransfer!.dropEffect = 'move';
     const position = computeDropPosition(e, div);
 
@@ -182,7 +242,8 @@ function wireDragTarget(div: HTMLDivElement) {
   div.addEventListener('drop', (e) => {
     e.preventDefault();
     const targetId = div.dataset.blockId!;
-    if (dragSourceId && dragSourceId !== targetId && currentDropPosition) {
+    // Validate drop target before committing
+    if (dragSourceId && dragSourceId !== targetId && currentDropPosition && validateDropTarget(dragSourceId, targetId, currentDropPosition, blockById)) {
       ed.editor_move_block(handle, dragSourceId, targetId, currentDropPosition);
       render();
     }
@@ -205,11 +266,14 @@ function wireEvents(div: HTMLDivElement) {
       return;
     }
     const id = div.dataset.blockId!;
-    ed.editor_set_block_text(handle, id, div.textContent || '');
+    const textSpan = div.querySelector('.text-content') as HTMLSpanElement | null;
+    ed.editor_set_block_text(handle, id, textSpan?.textContent ?? '');
   });
 
   div.addEventListener('keydown', (e: KeyboardEvent) => {
     const id = div.dataset.blockId!;
+    const textSpan = div.querySelector('.text-content') as HTMLSpanElement | null;
+    const spanText = textSpan?.textContent ?? '';
 
     // Enter → insert block after
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -217,12 +281,15 @@ function wireEvents(div: HTMLDivElement) {
       const newId = ed.editor_insert_block_after(handle, id, 'paragraph');
       render();
       const newDiv = blockDivs.get(newId);
-      if (newDiv) newDiv.focus();
+      if (newDiv) {
+        const newSpan = newDiv.querySelector('.text-content') as HTMLSpanElement | null;
+        (newSpan ?? newDiv).focus();
+      }
       return;
     }
 
     // Backspace on empty → delete block, focus neighbor (keep at least one block)
-    if (e.key === 'Backspace' && (div.textContent || '') === '') {
+    if (e.key === 'Backspace' && spanText === '') {
       const prev = div.previousElementSibling as HTMLDivElement | null;
       const next = div.nextElementSibling as HTMLDivElement | null;
       if (!prev && !next) return; // Don't delete the only block
@@ -231,10 +298,12 @@ function wireEvents(div: HTMLDivElement) {
       render();
       const target = prev || next;
       if (target) {
-        target.focus();
+        const targetSpan = target.querySelector('.text-content') as HTMLSpanElement | null;
+        const focusTarget = targetSpan ?? target;
+        focusTarget.focus();
         const sel = window.getSelection();
-        if (sel && target.childNodes.length > 0) {
-          sel.selectAllChildren(target);
+        if (sel && focusTarget.childNodes.length > 0) {
+          sel.selectAllChildren(focusTarget);
           sel.collapseToEnd();
         }
       }
@@ -243,17 +312,20 @@ function wireEvents(div: HTMLDivElement) {
 
     // Space → check autoformat
     if (e.key === ' ') {
-      const text = div.textContent || '';
+      const text = spanText;
       const fmt = detectAutoformat(text);
       if (fmt) {
         e.preventDefault();
         ed.editor_set_block_type(handle, id, fmt.type, fmt.level, fmt.listStyle);
         ed.editor_set_block_text(handle, id, '');
         suppressNextInput = true;
-        div.textContent = '';
+        if (textSpan) textSpan.textContent = '';
         render();
         const updated = blockDivs.get(id);
-        if (updated) updated.focus();
+        if (updated) {
+          const updatedSpan = updated.querySelector('.text-content') as HTMLSpanElement | null;
+          (updatedSpan ?? updated).focus();
+        }
         dismissShortcutHints();
       }
     }

--- a/examples/block-editor/web/src/main.ts
+++ b/examples/block-editor/web/src/main.ts
@@ -243,9 +243,11 @@ function wireDragTarget(div: HTMLDivElement) {
   div.addEventListener('drop', (e) => {
     e.preventDefault();
     const targetId = div.dataset.blockId!;
+    const targetParentId = div.dataset.parentId ?? '';
     // Validate drop target before committing
     if (dragSourceId && dragSourceId !== targetId && currentDropPosition && validateDropTarget(dragSourceId, targetId, currentDropPosition, blockById)) {
-      ed.editor_move_block(handle, dragSourceId, targetId, currentDropPosition);
+      // Pass targetParentId so Before/After preserve the target's parent for nested blocks.
+      ed.editor_move_block(handle, dragSourceId, targetId, currentDropPosition, targetParentId);
       render();
     }
     clearDropIndicators();

--- a/examples/block-editor/web/src/main.ts
+++ b/examples/block-editor/web/src/main.ts
@@ -243,9 +243,9 @@ function wireDragTarget(div: HTMLDivElement) {
   div.addEventListener('drop', (e) => {
     e.preventDefault();
     const targetId = div.dataset.blockId!;
-    const targetParentId = div.dataset.parentId ?? '';
+    const targetParentId = div.dataset.parentId;
     // Validate drop target before committing
-    if (dragSourceId && dragSourceId !== targetId && currentDropPosition && validateDropTarget(dragSourceId, targetId, currentDropPosition, blockById)) {
+    if (dragSourceId && dragSourceId !== targetId && currentDropPosition && targetParentId && validateDropTarget(dragSourceId, targetId, currentDropPosition, blockById)) {
       // Pass targetParentId so Before/After preserve the target's parent for nested blocks.
       ed.editor_move_block(handle, dragSourceId, targetId, currentDropPosition, targetParentId);
       render();

--- a/examples/block-editor/web/src/main.ts
+++ b/examples/block-editor/web/src/main.ts
@@ -52,7 +52,7 @@ function render() {
     if (!div) {
       div = document.createElement('div');
       div.classList.add('block');
-      div.contentEditable = 'true';
+      div.contentEditable = 'false';
       div.dataset.blockId = block.id;
 
       // Drag handle — a non-editable grip that makes the block draggable
@@ -92,6 +92,7 @@ function render() {
     div.dataset.checked = String(block.checked);
     div.dataset.index = String(block.index);
     div.dataset.parentId = block.parent_id;
+    div.contentEditable = 'false';
     applyAriaRoles(div, block);
 
     // Update the .text-content span — never nuke the grip child

--- a/examples/block-editor/web/tsconfig.json
+++ b/examples/block-editor/web/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "paths": {
-      "@moonbit/canopy-block-editor": ["../_build/js/release/build/main/main.d.ts"]
+      "@moonbit/canopy-block-editor": ["../../../_build/js/release/build/dowdiness/canopy-block-editor/main/main.d.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/examples/block-editor/web/vite.config.ts
+++ b/examples/block-editor/web/vite.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
       modules: [
         {
           name: '@moonbit/canopy-block-editor',
-          path: '..',
-          output: '_build/js/release/build/main/main.js',
+          path: '../../..',
+          output: '_build/js/release/build/dowdiness/canopy-block-editor/main/main.js',
         },
       ],
     }) as PluginOption,

--- a/examples/ideal/main/action_overlay_error.mbt
+++ b/examples/ideal/main/action_overlay_error.mbt
@@ -1,0 +1,20 @@
+///|
+/// Typed failures that the action overlay can surface. Closed because there are
+/// exactly three known error sources; migrate to `extenum` if plugin packages
+/// ever need overlay-specific typed failures.
+#warnings("-unused_constructor")
+enum OverlayError {
+  EmptyName
+  BuildActionFailed(String)
+  ApplyActionFailed(String)
+} derive(Debug)
+
+///|
+/// Single source of truth for all user-facing overlay error copy.
+fn format_overlay_error(err : OverlayError) -> String {
+  match err {
+    EmptyName => "Enter a name to continue"
+    BuildActionFailed(msg) => "Build failed: \{msg}"
+    ApplyActionFailed(msg) => "Apply failed: \{msg}"
+  }
+}

--- a/examples/ideal/main/action_overlay_error.mbt
+++ b/examples/ideal/main/action_overlay_error.mbt
@@ -2,7 +2,6 @@
 /// Typed failures that the action overlay can surface. Closed because there are
 /// exactly three known error sources; migrate to `extenum` if plugin packages
 /// ever need overlay-specific typed failures.
-#warnings("-unused_constructor")
 enum OverlayError {
   EmptyName
   BuildActionFailed(String)

--- a/examples/ideal/main/action_overlay_exec.mbt
+++ b/examples/ideal/main/action_overlay_exec.mbt
@@ -31,9 +31,10 @@ fn execute_action(
           let cmd = sync_after_local_model_change(new_model, text)
           (cmd, new_model)
         }
-        Err(err) => (runtime.send(SetError(err.message())), model)
+        Err(err) =>
+          (runtime.send(SetError(ApplyActionFailed(err.message()))), model)
       }
     Ok(None) => (runtime.send(ShowNamePrompt(action)), model)
-    Err(msg) => (runtime.send(SetError(msg)), model)
+    Err(msg) => (runtime.send(SetError(BuildActionFailed(msg))), model)
   }
 }

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -5,7 +5,7 @@ enum OverlayMsg {
   NameInput(String)
   NameSubmit
   NameCancel
-  SetError(String)
+  SetError(OverlayError)
   ShowNamePrompt(@lambda_edits.Action)
 }
 
@@ -52,7 +52,7 @@ fn OverlayState::show_name_prompt(
     {
       ..self,
       mode: NamePrompt(action, value=""),
-      error: "",
+      error: None,
       menu: self.menu.reset(item_count=0),
     },
     FocusNamePrompt,
@@ -79,7 +79,7 @@ fn OverlayState::open_submenu(
       mode: Submenu(action),
       // Navigating into a submenu is a fresh attempt — clear any stale error so
       // it doesn't linger across the now-visible (all-mode) error surface.
-      error: "",
+      error: None,
       menu: self.menu.reset(item_count~),
     },
     FocusMenu,
@@ -92,7 +92,7 @@ fn OverlayState::reset_main_menu(self : OverlayState) -> OverlayState {
     ..self,
     mode: MainMenu,
     // Returning to the main menu is a fresh attempt — clear any stale error.
-    error: "",
+    error: None,
     menu: self.menu.reset(item_count=self.actions.length()),
   }
 }
@@ -207,7 +207,7 @@ fn OverlayState::handle_name_input(
   match self.mode {
     NamePrompt(action, ..) =>
       overlay_update(
-        { ..self, mode: NamePrompt(action, value~), error: "" },
+        { ..self, mode: NamePrompt(action, value~), error: None },
         NoOverlayEffect,
       )
     _ => overlay_update(self, NoOverlayEffect)
@@ -220,10 +220,7 @@ fn OverlayState::handle_name_submit(self : OverlayState) -> OverlayUpdate {
     NamePrompt(action, value~) => {
       let name = value.trim().to_owned()
       if name == "" {
-        overlay_update(
-          { ..self, error: "Enter a name to continue" },
-          NoOverlayEffect,
-        )
+        overlay_update({ ..self, error: Some(EmptyName) }, NoOverlayEffect)
       } else {
         overlay_update(self, ExecuteAction(action, choice="", name~))
       }
@@ -248,8 +245,8 @@ fn OverlayState::update(self : OverlayState, msg : OverlayMsg) -> OverlayUpdate 
     NameInput(value) => self.handle_name_input(value)
     NameSubmit => self.handle_name_submit()
     NameCancel => overlay_update(self, CloseOverlay)
-    SetError(message) =>
-      overlay_update({ ..self, error: message }, NoOverlayEffect)
+    SetError(err) =>
+      overlay_update({ ..self, error: Some(err) }, NoOverlayEffect)
     ShowNamePrompt(action) => self.show_name_prompt(action)
   }
 }

--- a/examples/ideal/main/action_overlay_flow.mbt
+++ b/examples/ideal/main/action_overlay_flow.mbt
@@ -157,7 +157,6 @@ fn OverlayState::handle_text_key(
         None => overlay_update(self, NoOverlayEffect)
       }
     }
-    Closed => overlay_update(self, NoOverlayEffect)
   }
 }
 

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -1,5 +1,8 @@
 ///|
 /// True when the overlay is showing any of its open modes.
+/// All three current variants are open; closed state lives in the parent host
+/// layer. Match is kept (rather than returning `true` directly) so that adding
+/// a non-open mode to `OverlayMode` forces a compile-time update here.
 fn OverlayState::is_open(self : OverlayState) -> Bool {
   match self.mode {
     MainMenu | Submenu(_) | NamePrompt(_, ..) => true

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -2,7 +2,6 @@
 /// True when the overlay is showing any of its open modes.
 fn OverlayState::is_open(self : OverlayState) -> Bool {
   match self.mode {
-    Closed => false
     MainMenu | Submenu(_) | NamePrompt(_, ..) => true
   }
 }

--- a/examples/ideal/main/action_overlay_state.mbt
+++ b/examples/ideal/main/action_overlay_state.mbt
@@ -103,7 +103,7 @@ fn open_action_overlay(
     mode: MainMenu,
     actions,
     kind: ctx.kind,
-    error: "",
+    error: None,
     anchor_top,
     anchor_left,
     menu: @menu.Model::new(

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -32,7 +32,7 @@ fn test_overlay_state(mode : OverlayMode) -> OverlayState {
     mode,
     actions,
     kind: @ast.Term::Unit,
-    error: "",
+    error: None,
     anchor_top: 0,
     anchor_left: 0,
     menu: @menu.Model::new(
@@ -108,7 +108,7 @@ test "overlay update recovers invalid submenu key to focused main menu" {
     FocusMenu => inspect("focus", content="focus")
     _ => inspect("unexpected", content="FocusMenu")
   }
-  inspect(result.state.error, content="")
+  inspect(result.state.error is None, content="true")
 }
 
 ///|
@@ -144,7 +144,7 @@ test "overlay update keeps empty name submit in prompt with error" {
     }
     _ => inspect("unexpected", content="NamePrompt")
   }
-  inspect(result.state.error, content="Enter a name to continue")
+  inspect(result.state.error is Some(EmptyName), content="true")
 }
 
 ///|
@@ -322,4 +322,66 @@ test "structural_edit_op_to_tree_edit returns None for unrebuildable ops" {
     structural_edit_op_to_tree_edit("UnknownOp", nid) is None,
     content="true",
   )
+}
+
+// ── OverlayError typed-error tests ───────────────────────────────────────────
+
+///|
+test "overlay error: SetError(BuildActionFailed) stores typed variant" {
+  let result = test_overlay_state(MainMenu).update(
+    SetError(BuildActionFailed("bad op")),
+  )
+  inspect(
+    result.state.error is Some(BuildActionFailed("bad op")),
+    content="true",
+  )
+  match result.effect {
+    NoOverlayEffect => ()
+    _ => inspect("unexpected", content="NoOverlayEffect")
+  }
+}
+
+///|
+test "overlay error: SetError(ApplyActionFailed) stores typed variant" {
+  let result = test_overlay_state(MainMenu).update(
+    SetError(ApplyActionFailed("apply failed")),
+  )
+  inspect(
+    result.state.error is Some(ApplyActionFailed("apply failed")),
+    content="true",
+  )
+}
+
+///|
+test "overlay error: cleared on name prompt open" {
+  let wrap_lambda_action = test_action_by_id("wrap_lambda")
+  let state_with_error = test_overlay_state(MainMenu).update(
+      SetError(EmptyName),
+    ).state
+  let result = state_with_error.update(ShowNamePrompt(wrap_lambda_action))
+  inspect(result.state.error is None, content="true")
+  inspect(result.state.mode is NamePrompt(_, ..), content="true")
+}
+
+///|
+test "overlay error: cleared on submenu open" {
+  let wrap_bop_action = test_action_by_id("wrap_bop")
+  let state_with_error = test_overlay_state(MainMenu).update(
+      SetError(EmptyName),
+    ).state
+  let choices = state_with_error.submenu_choices(wrap_bop_action)
+  let result = state_with_error.open_submenu(wrap_bop_action, choices.length())
+  inspect(result.state.error is None, content="true")
+  inspect(result.state.mode is Submenu(_), content="true")
+}
+
+///|
+test "overlay error: cleared on main menu reset (close_submenu)" {
+  let wrap_bop_action = test_action_by_id("wrap_bop")
+  let state_with_error = test_overlay_state(Submenu(wrap_bop_action)).update(
+      SetError(ApplyActionFailed("stale")),
+    ).state
+  let result = state_with_error.close_submenu()
+  inspect(result.state.error is None, content="true")
+  inspect(result.state.mode is MainMenu, content="true")
 }

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -385,3 +385,24 @@ test "overlay error: cleared on main menu reset (close_submenu)" {
   inspect(result.state.error is None, content="true")
   inspect(result.state.mode is MainMenu, content="true")
 }
+
+///|
+test "format_overlay_error: EmptyName" {
+  inspect(format_overlay_error(EmptyName), content="Enter a name to continue")
+}
+
+///|
+test "format_overlay_error: BuildActionFailed carries message" {
+  inspect(
+    format_overlay_error(BuildActionFailed("bad op")),
+    content="Build failed: bad op",
+  )
+}
+
+///|
+test "format_overlay_error: ApplyActionFailed carries message" {
+  inspect(
+    format_overlay_error(ApplyActionFailed("apply failed")),
+    content="Apply failed: apply failed",
+  )
+}

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -71,7 +71,8 @@ struct OverlayState {
   // The most recent failure to act. Overlay-wide, not prompt-specific: an
   // action can fail to apply from MainMenu or Submenu just as from NamePrompt,
   // so the error is rendered in the panel for any open mode (view_actions.mbt).
-  error : String
+  // None unambiguously means "no error"; Some(e) means a specific typed failure.
+  error : OverlayError?
   anchor_top : Int
   anchor_left : Int
   menu : @menu.Model

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -49,10 +49,11 @@ pub enum SyncStatus {
 } derive(Eq)
 
 ///|
-/// The overlay's mode: exactly one of four states. Replaces the former
+/// The overlay's mode: exactly one of three open states. Replaces the former
 /// implicit `(visible, submenu, pending_action)` encoding so that illegal
-/// combinations — a closed overlay with a pending action, or a submenu and a
-/// name prompt active at once — are unrepresentable.
+/// combinations — a submenu and a name prompt active at once — are
+/// unrepresentable. Closed state lives in the parent host layer
+/// (`ActionOverlayHost.active = None`), not here.
 enum OverlayMode {
   MainMenu
   Submenu(@lambda_edits.Action)

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -53,9 +53,7 @@ pub enum SyncStatus {
 /// implicit `(visible, submenu, pending_action)` encoding so that illegal
 /// combinations — a closed overlay with a pending action, or a submenu and a
 /// name prompt active at once — are unrepresentable.
-#warnings("-unused_constructor")
 enum OverlayMode {
-  Closed
   MainMenu
   Submenu(@lambda_edits.Action)
   // `value` is the text typed into the name prompt — genuinely prompt-local,

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -11,6 +11,7 @@ import {
   "dowdiness/lambda/ast",
   "dowdiness/rabbita-resizable/resizable",
   "dowdiness/visualizer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/immut/hashset",
 }
 
@@ -149,6 +150,8 @@ type Msg
 type NodeActionContext
 
 type OverlayEffect
+
+type OverlayError derive(@debug.Debug)
 
 type OverlayEvent
 

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -154,15 +154,15 @@ fn view_submenu_choices(
 ///|
 /// Render an overlay-wide error. Actions can fail from any open overlay mode
 /// (MainMenu, Submenu, or NamePrompt), so errors live at the panel top.
-fn view_action_overlay_error(message : String) -> @rabbita.Html {
-  if message == "" {
-    @html.nothing
-  } else {
-    @html.div(
-      class=action_overlay_error_class,
-      attrs=@html.Attrs::build().role("alert").aria_live("polite"),
-      [@html.text(message)],
-    )
+fn view_action_overlay_error(err : OverlayError?) -> @rabbita.Html {
+  match err {
+    None => @html.nothing
+    Some(e) =>
+      @html.div(
+        class=action_overlay_error_class,
+        attrs=@html.Attrs::build().role("alert").aria_live("polite"),
+        [@html.text(format_overlay_error(e))],
+      )
   }
 }
 

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -185,7 +185,7 @@ fn view_overlay(
     NamePrompt(_, ..) => view_name_prompt(emit, state)
     Submenu(sub_action) =>
       view_submenu_choices(emit, state.menu, sub_action, state.kind)
-    MainMenu | Closed => view_action_list(emit, state.menu, state.actions)
+    MainMenu => view_action_list(emit, state.menu, state.actions)
   }
   let panel_attrs = match state.mode {
     NamePrompt(_, ..) =>

--- a/scripts/check-shared-substrate.sh
+++ b/scripts/check-shared-substrate.sh
@@ -6,10 +6,11 @@
 # graph aborts at runtime on cross-runtime reads, so a silent skew (e.g. the
 # lib/cognition TOML pin that evaded the #572 bump grep) is a latent break.
 #
-# Scope: canopy workspace members enumerated in moon.work (root + lib/* +
-# examples/*). Submodules (loom, event-graph-walker) and worktrees are NOT
-# members and are intentionally out of scope. Cross-repo (moondsp) coordination
-# is deferred to a #441 follow-up.
+# Scope: all members enumerated in moon.work, which includes root, lib/*,
+# examples/*, and loom/* packages (loom's workspace members were added in #740
+# and are subject to the same Single-Runtime constraint). event-graph-walker is
+# also a workspace member but does not depend on incr. Worktrees and the
+# moondsp cross-repo are out of scope; moondsp coordination deferred to #441.
 #
 # Exits non-zero if member incr minors disagree, printing the offending pins.
 # Intended to run in CI as a required per-PR check, mirroring check-deps.sh.


### PR DESCRIPTION
## Summary

Expands `get_render_state()` to emit recursive preorder block metadata with `depth`, `child_count`, `is_alive`, and real `parent_id`. Adds TypeScript drop-target validator wired into `dragover`/`drop` handlers. Fixes text-content isolation to preserve drag handle across renders. Fixes Vite build path for workspace-root layout.

## Changes

- **block_init.mbt**: Recursive `emit_blocks`/`emit_block_json` helpers; `count_blocks` (functional accumulator); doc-comment on `get_render_state`
- **block_init_wbtest.mbt**: Test for depth/child_count on nested blocks
- **main.ts**: `Block` interface with `depth`, `child_count`, `is_alive`; `blockById` index; `validateDropTarget` (self, descendant, alive checks); text in `.text-content` span
- **vite.config.ts**: Fixed `path`/`output` for workspace-root build layout
- All 64 tests pass, `moon check` clean, `npm run build` produces 104KB bundle

## Verification

- [x] `moon check` clean
- [x] 64/64 tests pass
- [x] `moon build --target js --release` succeeds
- [x] `npm run build` succeeds (104KB)
- [x] `tsc --noEmit` clean (1 pre-existing WASM import)
- [x] `moon fmt`/`moon info` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block editor rendering now includes richer subtree metadata (depth, child count, parent reference, and live status).
  * Action overlay now shows typed, more specific error messages for build/apply failures and empty-name input.

* **Bug Fixes**
  * Improved drag-and-drop behavior with stricter drop validation and safer move commitment, plus more reliable focus/text editing using a dedicated editable region.
  * Markdown export now consistently indents nested blocks.

* **Tests / Documentation**
  * Added/updated tests for rendered output details, overlay typed errors, Markdown indentation, and a plan for concurrent drop convergence testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->