### PR TITLE
feat(#807): per-node inline editing controls in JSON tree view

### DIFF
--- a/adapters/editor-adapter/html-adapter.ts
+++ b/adapters/editor-adapter/html-adapter.ts
@@ -200,8 +200,12 @@ export class HTMLAdapter implements EditorAdapter {
           if (labelEl) labelEl.textContent = patch.label;
           if (patch.css_class) {
             const classes = el.className.split(/\s+/).filter(c => !c.startsWith('kind-'));
-            classes.push(`kind-${patch.css_class}`);
+            const kindClass = patch.css_class;
+            classes.push(`kind-${kindClass}`);
             el.className = classes.join(' ');
+            // Keep data-node-kind in sync so refreshInlineControls reads the current type
+            const kindTag = kindClass.charAt(0).toUpperCase() + kindClass.slice(1);
+            el.setAttribute('data-node-kind', kindTag);
           }
         }
         // Update currentTree
@@ -241,7 +245,9 @@ export class HTMLAdapter implements EditorAdapter {
     if (!hasChildren) {
       const wrapper = document.createElement('div');
       wrapper.className = isRoot ? 'tree-node root' : 'tree-node';
+      wrapper.classList.add(`kind-${kindClass}`);
       wrapper.setAttribute('data-node-id', String(node.id));
+      wrapper.setAttribute('data-node-kind', node.kind_tag);
 
       const row = document.createElement('div');
       row.className = 'node-row value-node';
@@ -273,10 +279,11 @@ export class HTMLAdapter implements EditorAdapter {
       wrapper.appendChild(row);
       return wrapper;
     }
-
     const container = document.createElement('div');
     container.className = isRoot ? 'tree-node root' : 'tree-node';
+    container.classList.add(`kind-${kindClass}`);
     container.setAttribute('data-node-id', String(node.id));
+    container.setAttribute('data-node-kind', node.kind_tag);
 
     const row = document.createElement('div');
     row.className = 'node-row';

--- a/examples/web/json.html
+++ b/examples/web/json.html
@@ -349,6 +349,66 @@
       opacity: 1;
     }
 
+
+    /* ── Inline controls (action buttons, type dropdown) ──────── */
+
+    .node-actions {
+      display: none;
+      margin-left: auto;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+
+    .node-row:hover .node-actions,
+    .node-row.selected .node-actions {
+      display: inline-flex;
+    }
+
+    .node-action-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 20px;
+      font-size: 11px;
+      line-height: 1;
+      padding: 0;
+      background: #2a2a3e;
+      color: #7a7a9a;
+      border: 1px solid #3a3a5a;
+      border-radius: 3px;
+      cursor: pointer;
+      font-family: inherit;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+    }
+
+    .node-action-btn:hover {
+      background: #3a3a5a;
+      color: #c8c8e0;
+      border-color: #5a5a7a;
+    }
+
+    .node-action-btn:focus-visible {
+      outline: 2px solid #8250df;
+      outline-offset: 1px;
+    }
+
+    .node-type-select {
+      display: none;
+      font-size: 10px;
+      padding: 1px 2px;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      border: 1px solid #3a3a5a;
+      border-radius: 3px;
+      font-family: inherit;
+      cursor: pointer;
+      max-width: 70px;
+    }
+
+    .node-row.selected .node-type-select {
+      display: inline-block;
+    }
     .decoration-overlay {
       position: absolute;
       pointer-events: none;

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -230,8 +230,7 @@ function refreshInlineControls() {
       const btn = createActionBtn('+', 'add-member', 'Add member key');
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        pendingNodeId = nodeId;
-        showInlineForm('add-member');
+        showInlineForm('add-member', nodeId);
       });
       actions.appendChild(btn);
     } else if (kind === 'array') {
@@ -268,8 +267,7 @@ function refreshInlineControls() {
       const wrapObj = createActionBtn('{}', 'wrap-object', 'Wrap in object');
       wrapObj.addEventListener('click', (e) => {
         e.stopPropagation();
-        pendingNodeId = nodeId;
-        showInlineForm('wrap-object');
+        showInlineForm('wrap-object', nodeId);
       });
       actions.appendChild(wrapObj);
     }
@@ -289,7 +287,8 @@ function refreshInlineControls() {
   }
 }
 
-function showInlineForm(mode: InlineMode) {
+function showInlineForm(mode: InlineMode, targetId?: number | null) {
+  pendingNodeId = targetId ?? null;
   inlineMode = mode;
   inlineFormEl.classList.add('visible');
 
@@ -307,10 +306,10 @@ function showInlineForm(mode: InlineMode) {
     inlineInputEl.value = '';
   }
 
-  // Scroll the selected row into view so the form is visible
-  const targetId = pendingNodeId ?? adapter.getSelectedNodeId();
-  if (targetId !== null) {
-    const rowEl = treeEl.querySelector(`[data-node-id="${targetId}"] > .node-row`);
+  // Scroll the target row into view
+  const scrollId = pendingNodeId ?? adapter.getSelectedNodeId();
+  if (scrollId !== null) {
+    const rowEl = treeEl.querySelector(`[data-node-id="${scrollId}"] > .node-row`);
     if (rowEl) rowEl.scrollIntoView({ block: 'nearest' });
   }
 

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -38,6 +38,7 @@ const decorationOverlay = new DecorationOverlay(editorEl);
 let inlineMode: InlineMode = null;
 let lastText = '';
 let syncScheduled = false;
+let pendingNodeId: number | null = null;
 let suppressInput = false;
 
 function must<T extends HTMLElement>(id: string): T {
@@ -154,6 +155,7 @@ function refresh() {
   const roleSpans = getJsonRoleSpans();
   decorationOverlay.applyDecorations(roleSpansToDecorations(roleSpans));
   updateToolbarState();
+  refreshInlineControls();
 }
 
 function updateToolbarState() {
@@ -171,6 +173,120 @@ function updateToolbarState() {
   changeTypeBtn.disabled = !hasSelection;
   deleteBtn.disabled = !hasSelection || Boolean(isRoot);
   unwrapBtn.disabled = !(kind === 'object' || kind === 'array');
+}
+
+/** Create an inline action button with a data-action attribute. */
+function createActionBtn(label: string, action: string, title: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'node-action-btn';
+  btn.setAttribute('data-action', action);
+  btn.title = title;
+  btn.textContent = label;
+  return btn;
+}
+
+/**
+ * Inject per-row inline controls (action buttons, type dropdown) into tree nodes.
+ * Called after every refresh. Removes stale controls and re-creates from current DOM.
+ */
+function refreshInlineControls() {
+  // Remove stale controls
+  treeEl.querySelectorAll('.node-actions, .node-type-select').forEach(el => el.remove());
+
+  for (const nodeEl of treeEl.querySelectorAll<HTMLElement>('.tree-node')) {
+    const nodeKind = nodeEl.getAttribute('data-node-kind');
+    if (!nodeKind) continue;
+    const nodeId = Number(nodeEl.getAttribute('data-node-id'));
+    if (isNaN(nodeId)) continue;
+    const rowEl = nodeEl.querySelector(':scope > .node-row');
+    if (!rowEl) continue;
+
+    const kind = kindTagToToolbarKind(nodeKind);
+    const isContainer = kind === 'object' || kind === 'array';
+    const isRoot = nodeEl.classList.contains('root');
+    const actions = document.createElement('span');
+    actions.className = 'node-actions';
+
+    // Type dropdown for value (scalar) nodes
+    if (!isContainer && kind !== 'error' && kind !== 'other') {
+      const select = document.createElement('select');
+      select.className = 'node-type-select';
+      for (const t of ['null', 'bool', 'number', 'string', 'array', 'object']) {
+        const opt = document.createElement('option');
+        opt.value = t;
+        opt.textContent = t;
+        if (t === kind) opt.selected = true;
+        select.appendChild(opt);
+      }
+      select.addEventListener('change', () => {
+        applyEdit({ op: 'ChangeType', node_id: nodeId, new_type: select.value });
+      });
+      actions.appendChild(select);
+    }
+
+    // Add-child button (containers only)
+    if (kind === 'object') {
+      const btn = createActionBtn('+', 'add-member', 'Add member key');
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        pendingNodeId = nodeId;
+        showInlineForm('add-member');
+      });
+      actions.appendChild(btn);
+    } else if (kind === 'array') {
+      const btn = createActionBtn('+', 'add-element', 'Add element');
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        hideInlineForm();
+        applyEdit({ op: 'AddElement', array_id: nodeId });
+      });
+      actions.appendChild(btn);
+    }
+
+    // Unwrap (containers only)
+    if (isContainer) {
+      const btn = createActionBtn('↩', 'unwrap', 'Unwrap');
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        hideInlineForm();
+        applyEdit({ op: 'Unwrap', node_id: nodeId });
+      });
+      actions.appendChild(btn);
+    }
+
+    // Wrap buttons
+    if (kind !== 'error' && kind !== 'other') {
+      const wrapArray = createActionBtn('⇥', 'wrap-array', 'Wrap in array');
+      wrapArray.addEventListener('click', (e) => {
+        e.stopPropagation();
+        hideInlineForm();
+        applyEdit({ op: 'WrapInArray', node_id: nodeId });
+      });
+      actions.appendChild(wrapArray);
+
+      const wrapObj = createActionBtn('{}', 'wrap-object', 'Wrap in object');
+      wrapObj.addEventListener('click', (e) => {
+        e.stopPropagation();
+        pendingNodeId = nodeId;
+        showInlineForm('wrap-object');
+      });
+      actions.appendChild(wrapObj);
+    }
+
+    // Delete (never on root)
+    if (!isRoot) {
+      const btn = createActionBtn('×', 'delete', 'Delete');
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        hideInlineForm();
+        applyEdit({ op: 'Delete', node_id: nodeId });
+      });
+      actions.appendChild(btn);
+    }
+
+    rowEl.appendChild(actions);
+  }
 }
 
 function showInlineForm(mode: InlineMode) {
@@ -191,12 +307,20 @@ function showInlineForm(mode: InlineMode) {
     inlineInputEl.value = '';
   }
 
+  // Scroll the selected row into view so the form is visible
+  const targetId = pendingNodeId ?? adapter.getSelectedNodeId();
+  if (targetId !== null) {
+    const rowEl = treeEl.querySelector(`[data-node-id="${targetId}"] > .node-row`);
+    if (rowEl) rowEl.scrollIntoView({ block: 'nearest' });
+  }
+
   inlineInputEl.focus();
   inlineInputEl.select();
 }
 
 function hideInlineForm() {
   inlineMode = null;
+  pendingNodeId = null;
   inlineFormEl.classList.remove('visible');
   inlineLabelEl.textContent = '';
   inlineInputEl.value = '';
@@ -217,8 +341,9 @@ function applyEdit(op: Record<string, unknown>) {
 }
 
 function submitInlineAction() {
-  const selectedId = adapter.getSelectedNodeId();
-  if (selectedId === null || !inlineMode) return;
+  // Prefer pendingNodeId (set by row-level button) over selected node
+  const targetId = pendingNodeId ?? adapter.getSelectedNodeId();
+  if (targetId === null || !inlineMode) return;
 
   const value = inlineInputEl.value.trim();
   if (!value) {
@@ -227,15 +352,15 @@ function submitInlineAction() {
   }
 
   if (inlineMode === 'add-member') {
-    applyEdit({ op: 'AddMember', object_id: selectedId, key: value });
+    applyEdit({ op: 'AddMember', object_id: targetId, key: value });
   } else if (inlineMode === 'wrap-object') {
-    applyEdit({ op: 'WrapInObject', node_id: selectedId, key: value });
+    applyEdit({ op: 'WrapInObject', node_id: targetId, key: value });
   } else if (inlineMode === 'change-type') {
     if (!VALID_TYPES.has(value)) {
       inlineInputEl.focus();
       return;
     }
-    applyEdit({ op: 'ChangeType', node_id: selectedId, new_type: value });
+    applyEdit({ op: 'ChangeType', node_id: targetId, new_type: value });
   }
 
   hideInlineForm();

--- a/examples/web/tests/json-editor.spec.ts
+++ b/examples/web/tests/json-editor.spec.ts
@@ -308,3 +308,84 @@ test.describe('JSON Editor — Tree Rendering Regression', () => {
     await expect(rootNode.locator(':scope > .node-row > .node-count')).toHaveText('1');
   });
 });
+
+test.describe('JSON Editor — Inline Controls', () => {
+
+  test('row-level type dropdown switches value node type', async ({ page }) => {
+    // Load Array — has string, number, bool, null values
+    await loadExample(page, 'Array');
+
+    // Click the first value node (second .node-row — first is the array root)
+    const valueNode = page.locator('.node-row.value-node').first();
+    await valueNode.click();
+    await expect(valueNode).toHaveClass(/selected/);
+
+    // The type dropdown ON the selected row should be visible
+    const typeSelect = valueNode.locator('.node-type-select');
+    await expect(typeSelect).toBeVisible();
+
+    // Switch the type to bool
+    await typeSelect.selectOption('bool');
+
+    // The node should now display as a boolean type
+    await expect(valueNode.locator('.node-tag.bool')).toBeVisible();
+  });
+
+  test('row-level delete button removes a child node', async ({ page }) => {
+    await loadExample(page, 'Array');
+    const countBefore = await treeNodeCount(page);
+
+    // Select a child value node (index 1+)
+    const childRow = page.locator('.node-row').nth(1);
+    await childRow.click();
+
+    // Click the row-level delete button within the selected row
+    const deleteBtn = childRow.locator('.node-action-btn[data-action="delete"]');
+    await expect(deleteBtn).toBeVisible();
+    await deleteBtn.click();
+
+    // Wait for tree to update
+    await expect(page.locator('.node-row')).toHaveCount(countBefore - 1, { timeout: 5000 });
+  });
+
+  test('row-level add element adds to array root', async ({ page }) => {
+    await loadExample(page, 'Array');
+    const countBefore = await treeNodeCount(page);
+
+    // Select the array root
+    await page.locator('.node-row').first().click();
+
+    // Click the row-level add button
+    const addBtn = page.locator('.node-action-btn[data-action="add-element"]');
+    await expect(addBtn).toBeVisible();
+    await addBtn.click();
+
+    // Should now have one more child node
+    await expect(page.locator('.node-row')).toHaveCount(countBefore + 1, { timeout: 5000 });
+  });
+
+  test('type-switch from scalar to array shows container controls', async ({ page }) => {
+    await loadExample(page, 'Array');
+
+    // Select a child row (index 1 is the first value node)
+    const childRow = page.locator('.node-row').nth(1);
+    await childRow.click();
+
+    // Verify it has a type dropdown (scalar controls)
+    const typeSelect = childRow.locator('.node-type-select');
+    await expect(typeSelect).toBeVisible();
+
+    // Switch type from string to array
+    await typeSelect.selectOption('array');
+
+    // After re-render, select the same-position row (may not preserve selection)
+    const newRow = page.locator('.node-row').nth(1);
+    await newRow.click();
+
+    // Container controls should now be visible
+    await expect(newRow.locator('.node-action-btn[data-action="add-element"]')).toBeVisible({ timeout: 5000 });
+
+    // The type dropdown should be gone (containers don't get the inline type select)
+    await expect(newRow.locator('.node-type-select')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Changes

Moves structural edit triggers from the global toolbar into each tree row, positioned contextually by node type.

### HTMLAdapter
- `data-node-kind` attribute on every `.tree-node` element so json-editor can identify node types from the DOM
- `kind-*` CSS class (e.g. `kind-string`, `kind-object`) set during initial `renderNode` (not only via `UpdateNode`)

### json-editor.ts
- `refreshInlineControls()` — post-render pass injecting per-row controls:
  - **Type dropdown** on scalar value nodes (shown on selection, dispatches `ChangeType` immediately)
  - **Contextual action buttons** — add-member/element, unwrap, wrap-in-array/object, delete
  - All buttons call `e.stopPropagation()` to avoid row selection
- `pendingNodeId` — tracks which node a row-level form-opener targets, so submit uses the correct ID
- Inline form scrolls selected row into view when opened

### json.html CSS
- `.node-actions` hidden by default, shown on `.node-row:hover` or `.node-row.selected`
- `.node-action-btn` — compact buttons with purple-accent hover state
- `.node-type-select` — shown only on selected rows

### Tests
4 new Playwright tests: type switch, delete, add-element via row controls. All 22 pass (18 existing + 4 new).

## Verification
- `moon check` — pass
- `moon build --target js` — pass
- `npx playwright test tests/json-editor.spec.ts` — 22 passed (1.2m)