### PR TITLE
feat: Format JSON button for JSON CRDT editor

### DIFF
--- a/examples/web/json.html
+++ b/examples/web/json.html
@@ -502,6 +502,7 @@
           <button id="wrap-object-btn" class="toolbar-btn" type="button">{ Wrap }</button>
           <button id="change-type-btn" class="toolbar-btn" type="button">Type...</button>
           <button id="delete-btn" class="toolbar-btn" type="button">Delete</button>
+          <button id="format-btn" class="toolbar-btn" type="button">Format</button>
           <button id="unwrap-btn" class="toolbar-btn" type="button">Unwrap</button>
 
           <div id="toolbar-inline-form" class="inline-form">

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -22,6 +22,7 @@ const wrapArrayBtn = must<HTMLButtonElement>('wrap-array-btn');
 const wrapObjectBtn = must<HTMLButtonElement>('wrap-object-btn');
 const changeTypeBtn = must<HTMLButtonElement>('change-type-btn');
 const deleteBtn = must<HTMLButtonElement>('delete-btn');
+const formatBtn = must<HTMLButtonElement>('format-btn');
 const unwrapBtn = must<HTMLButtonElement>('unwrap-btn');
 
 const inlineFormEl = must<HTMLDivElement>('toolbar-inline-form');
@@ -325,6 +326,25 @@ function hideInlineForm() {
   inlineInputEl.value = '';
 }
 
+
+/** Pretty-print the JSON text in the editor. Shows an error if invalid. */
+function formatJson() {
+  const text = editorEl.textContent ?? '';
+  if (!text.trim()) return;
+  try {
+    const parsed = JSON.parse(text);
+    const formatted = JSON.stringify(parsed, null, 2);
+    // Set the CRDT model directly, then sync back to DOM + tree
+    crdt.json_set_text(handle, formatted);
+    syncTextFromModel();
+    refresh();
+  } catch (_e) {
+    const item = document.createElement('li');
+    item.className = 'error-item';
+    item.textContent = 'Invalid JSON — cannot format';
+    errorsEl.prepend(item);
+  }
+}
 function applyEdit(op: Record<string, unknown>) {
   const result = crdt.json_apply_edit(handle, JSON.stringify(op), Date.now());
   syncTextFromModel();
@@ -409,6 +429,11 @@ deleteBtn.addEventListener('click', () => {
     hideInlineForm();
     applyEdit({ op: 'Delete', node_id: selectedId });
   }
+});
+
+formatBtn.addEventListener('click', () => {
+  hideInlineForm();
+  formatJson();
 });
 
 unwrapBtn.addEventListener('click', () => {

--- a/examples/web/tests/json-editor.spec.ts
+++ b/examples/web/tests/json-editor.spec.ts
@@ -389,3 +389,54 @@ test.describe('JSON Editor — Inline Controls', () => {
     await expect(newRow.locator('.node-type-select')).not.toBeVisible();
   });
 });
+
+test.describe('JSON Editor — Format', () => {
+
+  test('format button pretty-prints compact JSON', async ({ page }) => {
+    const editor = page.locator('#json-input');
+    const formatBtn = page.locator('#format-btn');
+
+    // Type compact JSON
+    await editor.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('{"a":[1,2],"b":{"c":3}}');
+    await page.waitForTimeout(300);
+
+    // Click Format
+    await formatBtn.click();
+    await page.waitForTimeout(300);
+
+    // Text should be pretty-printed with newlines and indentation
+    const text = await editor.textContent();
+    expect(text).toContain('\n');
+    expect(text).toContain('  "a"');
+    expect(text).toContain('    ');
+  });
+
+  test('format button shows error on invalid JSON', async ({ page }) => {
+    const editor = page.locator('#json-input');
+    const formatBtn = page.locator('#format-btn');
+
+    // Clear and type invalid JSON
+    await editor.click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('{invalid');
+    await page.waitForTimeout(300);
+
+    // Capture text before format attempt
+    const textBefore = await editor.textContent();
+
+    // Click Format
+    await formatBtn.click();
+    await page.waitForTimeout(300);
+
+    // Text must be unchanged (Format didn't apply)
+    const textAfter = await editor.textContent();
+    expect(textAfter).toBe(textBefore);
+
+    // Error should be shown by the Format attempt (not just parser)
+    await expect(page.locator('#parse-errors .error-item').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Changes

Adds a **Format** button to the JSON editor toolbar that pretty-prints the text editor content.

### Implementation
- `formatJson()` reads `editorEl.textContent`, runs `JSON.parse()` + `JSON.stringify(value, null, 2)`
- Syncs formatted text through the CRDT model so the tree view stays consistent
- Invalid JSON shows error in diagnostics panel; text is unchanged
- Button always enabled (no selection needed)

### Tests
2 new Playwright tests:
- `format button pretty-prints compact JSON` — verifies newlines and indentation added
- `format button shows error on invalid JSON` — verifies error shown and text unchanged

Total: 24 tests (22 existing + 2 new)