### PR TITLE
json editor: add patch log / document history panel

### DIFF
--- a/examples/web/json.html
+++ b/examples/web/json.html
@@ -460,6 +460,126 @@
         max-height: none;
       }
     }
+
+    /* ── Patch log panel ───────────────────────────── */
+
+    .patch-log-panel {
+      margin-top: 20px;
+    }
+
+    .patch-log-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .patch-log-header:hover {
+      background: #2a2a2a;
+    }
+
+    .patch-log-count {
+      background: #252540;
+      color: #7a7a9a;
+      font-size: 11px;
+      padding: 1px 7px;
+      border-radius: 8px;
+      min-width: 20px;
+      text-align: center;
+    }
+
+    .patch-log-toggle {
+      font-size: 11px;
+      color: #5a5a7a;
+      margin-left: auto;
+      transition: transform 0.2s;
+    }
+
+    .patch-log-toggle.collapsed {
+      transform: rotate(-90deg);
+    }
+
+    .patch-log-body {
+      max-height: 480px;
+      overflow-y: auto;
+      padding: 0 16px 16px;
+    }
+
+    .patch-log-body.hidden {
+      display: none;
+    }
+
+    .patch-log-empty {
+      color: #6a6a6a;
+      font-size: 13px;
+      padding: 16px 0;
+      text-align: center;
+    }
+
+    .patch-entry {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 7px 10px;
+      margin: 3px 0;
+      background: #1e1e1e;
+      border: 1px solid #2a2a2a;
+      border-radius: 4px;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .patch-entry:hover {
+      border-color: #3a3a5a;
+    }
+
+    .patch-entry + .patch-entry {
+      margin-top: 4px;
+    }
+
+    .patch-entry-time {
+      color: #5a5a7a;
+      white-space: nowrap;
+      flex-shrink: 0;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .patch-entry-op {
+      font-weight: 600;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .patch-entry-op.Delete { color: #f48771; }
+    .patch-entry-op.AddMember,
+    .patch-entry-op.AddElement { color: #c3e88d; }
+    .patch-entry-op.WrapInArray,
+    .patch-entry-op.WrapInObject { color: #82aaff; }
+    .patch-entry-op.Unwrap { color: #c792ea; }
+    .patch-entry-op.ChangeType { color: #ffcb6b; }
+    .patch-entry-op.RenameKey { color: #89ddff; }
+    .patch-entry-op.CommitEdit { color: #a0a0a0; }
+
+    .patch-entry-params {
+      color: #858585;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .patch-entry-ok {
+      color: #4ec9b0;
+      flex-shrink: 0;
+    }
+
+    .patch-entry-err {
+      color: #f48771;
+      flex-shrink: 0;
+    }
   </style>
 </head>
 <body>
@@ -496,6 +616,7 @@
         </div>
         <div class="toolbar">
           <span class="toolbar-label">Edit:</span>
+
           <button id="add-member-btn" class="toolbar-btn" type="button">+ Member</button>
           <button id="add-element-btn" class="toolbar-btn" type="button">+ Element</button>
           <button id="wrap-array-btn" class="toolbar-btn" type="button">[ Wrap ]</button>
@@ -516,6 +637,16 @@
         <div id="tree-view" class="tree-view"></div>
       </section>
     </div>
+
+      <section class="panel patch-log-panel" id="patch-log-panel">
+        <div class="panel-header patch-log-header" id="patch-log-header">
+          <h2>Edit Log <span id="patch-log-count" class="patch-log-count">0</span></h2>
+          <span id="patch-log-toggle" class="patch-log-toggle">▾</span>
+        </div>
+        <div id="patch-log-body" class="patch-log-body">
+          <div id="patch-log-empty" class="patch-log-empty">No edits yet.</div>
+        </div>
+      </section>
   </div>
 
   <script type="module" src="/src/json-editor.ts"></script>

--- a/examples/web/src/json-editor.ts
+++ b/examples/web/src/json-editor.ts
@@ -31,6 +31,12 @@ const inlineInputEl = must<HTMLInputElement>('toolbar-inline-input');
 const inlineSubmitEl = must<HTMLButtonElement>('toolbar-inline-submit');
 const inlineCancelEl = must<HTMLButtonElement>('toolbar-inline-cancel');
 
+const patchLogEl = must<HTMLDivElement>('patch-log-body');
+const patchLogHeaderEl = must<HTMLDivElement>('patch-log-header');
+const patchLogToggleEl = must<HTMLSpanElement>('patch-log-toggle');
+const patchLogCountEl = must<HTMLSpanElement>('patch-log-count');
+const patchLogEmptyEl = must<HTMLDivElement>('patch-log-empty');
+
 // Protocol-based tree adapter
 const adapter = new HTMLAdapter(treeEl, errorsEl, true);
 
@@ -88,6 +94,99 @@ export function getJsonRoleSpans(): JsonRoleSpanData[] {
   } catch {
     return [];
   }
+}
+
+interface EditLogEntry {
+  op: Record<string, unknown>;
+  ts: number;
+  ok: boolean;
+  error?: string;
+}
+
+const OP_CSS_CLASS: Record<string, string> = {
+  Delete: 'Delete',
+  AddMember: 'AddMember',
+  AddElement: 'AddElement',
+  WrapInArray: 'WrapInArray',
+  WrapInObject: 'WrapInObject',
+  Unwrap: 'Unwrap',
+  ChangeType: 'ChangeType',
+  RenameKey: 'RenameKey',
+  CommitEdit: 'CommitEdit',
+};
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function formatEntryParams(op: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(op)) {
+    if (key === 'op') continue;
+    if (typeof value === 'string') {
+      parts.push(`${key}="${value}"`);
+    } else {
+      parts.push(`${key}=${String(value)}`);
+    }
+  }
+  return parts.join('  ');
+}
+
+function fetchEditLog(): void {
+  const raw = crdt.json_get_edit_log(handle);
+  let entries: EditLogEntry[];
+  try {
+    entries = JSON.parse(raw) as EditLogEntry[];
+  } catch {
+    entries = [];
+  }
+
+  patchLogCountEl.textContent = String(entries.length);
+
+  if (entries.length === 0) {
+    patchLogEmptyEl.classList.remove('hidden');
+    patchLogEl.replaceChildren(patchLogEmptyEl);
+    return;
+  }
+
+  patchLogEmptyEl.classList.add('hidden');
+  const fragment = document.createDocumentFragment();
+
+  for (const entry of entries) {
+    const opName = String(entry.op.op ?? '?');
+    const opClass = OP_CSS_CLASS[opName] ?? '';
+
+    const div = document.createElement('div');
+    div.className = 'patch-entry';
+
+    const timeEl = document.createElement('span');
+    timeEl.className = 'patch-entry-time';
+    timeEl.textContent = formatTimestamp(entry.ts);
+
+    const opEl = document.createElement('span');
+    opEl.className = `patch-entry-op ${opClass}`;
+    opEl.textContent = opName;
+
+    const paramsEl = document.createElement('span');
+    paramsEl.className = 'patch-entry-params';
+    paramsEl.textContent = formatEntryParams(entry.op);
+
+    const statusEl = document.createElement('span');
+    if (entry.ok) {
+      statusEl.className = 'patch-entry-ok';
+      statusEl.textContent = '✓';
+    } else {
+      statusEl.className = 'patch-entry-err';
+      statusEl.textContent = entry.error ? `✗ ${entry.error}` : '✗';
+    }
+
+    div.append(timeEl, opEl, paramsEl, statusEl);
+    fragment.append(div);
+  }
+
+  patchLogEl.replaceChildren(fragment);
 }
 
 /** Convert role span data to Decoration[] for the overlay. */
@@ -349,6 +448,7 @@ function applyEdit(op: Record<string, unknown>) {
   const result = crdt.json_apply_edit(handle, JSON.stringify(op), Date.now());
   syncTextFromModel();
   refresh();
+  fetchEditLog();
 
   if (result !== 'ok') {
     // Prepend the error to the diagnostics list
@@ -467,6 +567,26 @@ document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach((button) =>
   });
 });
 
+// Patch log collapse toggle — keyboard-accessible
+patchLogHeaderEl.setAttribute('role', 'button');
+patchLogHeaderEl.setAttribute('tabindex', '0');
+patchLogHeaderEl.setAttribute('aria-expanded', 'true');
+patchLogHeaderEl.setAttribute('aria-controls', 'patch-log-body');
+
+function togglePatchLog() {
+  const isHidden = patchLogEl.classList.toggle('hidden');
+  patchLogToggleEl.classList.toggle('collapsed');
+  patchLogHeaderEl.setAttribute('aria-expanded', String(!isHidden));
+}
+
+patchLogHeaderEl.addEventListener('click', togglePatchLog);
+patchLogHeaderEl.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    togglePatchLog();
+  }
+});
+
 window.addEventListener('beforeunload', () => {
   adapter.destroy();
   decorationOverlay.dispose();
@@ -482,6 +602,8 @@ if (initialText.trim()) {
 }
 
 adapter.resetCollapseState();
+
 refresh();
+fetchEditLog();
 
 

--- a/ffi/json/edit.mbt
+++ b/ffi/json/edit.mbt
@@ -15,26 +15,53 @@ pub fn json_apply_edit(
       }
       match parse_json_edit_op(json) {
         Ok(op) => {
-          let _ = match
+          // Touch protected reads; failures mean editor unavailable
+          let proj_ok = match
             coordinator.read_protected(h.editor_id, h.cells.cached_proj_node) {
-            Ok(v) => v
+            Ok(_) => true
             Err(report) => {
               println("json_apply_edit proj read: \{report}")
-              return "error: editor unavailable"
+              false
             }
           }
-          let _ = match
+          let source_map_ok = match
             coordinator.read_protected(h.editor_id, h.cells.source_map_memo) {
-            Ok(v) => v
+            Ok(_) => true
             Err(report) => {
               println("json_apply_edit source_map read: \{report}")
-              return "error: editor unavailable"
+              false
             }
           }
-          match @json_companion.apply_json_edit(h.editor, op, timestamp_ms) {
-            Ok(_) => "ok"
-            Err(err) => "error: " + err
+          let result = if proj_ok && source_map_ok {
+            match @json_companion.apply_json_edit(h.editor, op, timestamp_ms) {
+              Ok(_) => "ok"
+              Err(err) => "error: " + err
+            }
+          } else {
+            "error: editor unavailable"
           }
+          // Push to edit log (bounded — oldest entries auto-evicted)
+          let entry_ok = result == "ok"
+          h.edit_log.push({
+            op: json,
+            ts: timestamp_ms,
+            ok: entry_ok,
+            error: if entry_ok {
+              None
+            } else {
+              Some(
+                if result.has_prefix("error: ") {
+                  result[7:].to_owned()
+                } else {
+                  result
+                },
+              )
+            },
+          })
+          while h.edit_log.length() > MAX_EDIT_LOG_SIZE {
+            let _ = h.edit_log.pop()
+          }
+          result
         }
         Err(err) => "error: " + err
       }

--- a/ffi/json/edit_log.mbt
+++ b/ffi/json/edit_log.mbt
@@ -1,0 +1,46 @@
+// Edit log for tracking applied structural edits on JSON documents.
+// Bounded ring buffer stored on JsonHandle, exposed via FFI.
+
+///|
+/// A single edit log entry — captures the operation JSON, timestamp, and result.
+priv struct JsonEditLogEntry {
+  op : Json // parsed from the caller's op_json — reuses existing parse work
+  ts : Int
+  ok : Bool
+  error : String?
+}
+
+///|
+/// Maximum number of edit log entries to retain. A bounded ring buffer
+/// prevents unbounded memory growth under heavy editing.
+const MAX_EDIT_LOG_SIZE = 100
+
+///|
+/// Get the edit log for a JSON editor as a JSON array string.
+/// Each entry: {"op": {...}, "ts": <int>, "ok": <bool>}
+/// The `error` key is omitted when None.
+pub fn json_get_edit_log(handle : Int) -> String {
+  match json_registry.get(handle) {
+    Some(h) => {
+      let entries : Array[Json] = []
+      for entry in h.edit_log.iter() {
+        entries.push(entry.to_json())
+      }
+      Json::array(entries).stringify()
+    }
+    None => "[]"
+  }
+}
+
+///|
+fn JsonEditLogEntry::to_json(self : JsonEditLogEntry) -> Json {
+  let m : Map[String, Json] = {}
+  m["op"] = self.op
+  m["ts"] = Json::number(self.ts.to_double())
+  m["ok"] = self.ok.to_json()
+  match self.error {
+    Some(e) => m["error"] = Json::string(e)
+    None => ()
+  }
+  Json::object(m)
+}

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -10,6 +10,7 @@ priv struct JsonHandle {
   editor : @editor.SyncEditor[@djson.JsonValue]
   editor_id : @workspace.EditorId
   cells : JsonProtectedCells
+  edit_log : @queue.Queue[JsonEditLogEntry]
 }
 
 ///|
@@ -40,7 +41,12 @@ fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
     agent_id,
     cells.to_protected_reads(),
   )
-  json_registry.insert(editor_id.0, { editor, editor_id, cells })
+  json_registry.insert(editor_id.0, {
+    editor,
+    editor_id,
+    cells,
+    edit_log: @queue.Queue::Queue([]),
+  })
   editor_id
 }
 

--- a/ffi/json/moon.pkg
+++ b/ffi/json/moon.pkg
@@ -9,6 +9,7 @@ import {
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",
   "moonbitlang/core/json" @core_json,
+  "moonbitlang/core/queue",
 }
 
 // `cells` field of JsonHandle is read in production by Phase 1b accessors
@@ -33,6 +34,7 @@ options(
         "json_get_view_tree_json",
         "json_compute_view_patches_json",
         "json_get_role_spans_json",
+        "json_get_edit_log",
       ],
     },
   },

--- a/ffi/json/pkg.generated.mbti
+++ b/ffi/json/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn json_apply_edit(Int, String, Int) -> String
 
 pub fn json_compute_view_patches_json(Int) -> String
 
+pub fn json_get_edit_log(Int) -> String
+
 pub fn json_get_errors(Int) -> String
 
 pub fn json_get_proj_node_json(Int) -> String


### PR DESCRIPTION
## Summary

Adds a collapsible patch log panel to the JSON editor, showing each structural edit with timestamp, operation type, key parameters, and outcome. Matches json-joy Explorer's patch log feature.

## Changes

### MoonBit layer (`ffi/json/`)
- **edit_log.mbt** (new): `JsonEditLogEntry` struct storing parsed op JSON, timestamp, and result. Bounded `@queue.Queue` (max 100 entries). `json_get_edit_log(handle)` FFI returning JSON array.
- **json_ffi.mbt**: Added `edit_log` field to `JsonHandle`, initialized in `assemble_json_handle`.
- **edit.mbt**: After `apply_json_edit` succeeds/fails, pushes an entry to the log and trims oldest entries past capacity.
- **moon.pkg**: Added `moonbitlang/core/queue` dep and `json_get_edit_log` JS export.

### UI layer (`examples/web/`)
- **json.html**: Collapsible "Edit Log" panel below the two-column layout. CSS for entry rendering with color-coded operation names.
- **json-editor.ts**: `fetchEditLog()` reads from FFI and renders entries. Wired into `applyEdit()` (structural edits only) and initial page load. Collapse toggle on header click.

## Acceptance

- [x] Structural edits recorded with timestamp and result
- [x] Patch log exposed through FFI (`json_get_edit_log`)
- [x] UI shows collapsible patch log panel
- [x] Each entry displays: time, operation type, key params, success/failure
- [x] Bounded to 100 entries (no unbounded memory growth)

## Verification
- `moon check` — 0 errors
- `moon test ffi/json/` — 12/12 passed
- `moon build --target js --release` — clean, `.d.ts` includes `json_get_edit_log`

Closes #808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Edit Log” (patch log) panel to the JSON editor UI with an edit count, accessible expand/collapse control, and “No edits yet” empty state.
  * Displays recorded edit actions with timestamps, operation details, and success/error status.
  * The log refreshes on initial load and after each successful edit.
* **Bug Fixes**
  * Improved resilience when the editor state isn’t available and when log data can’t be parsed.
* **Chores**
  * Kept the edit log size bounded to prevent unbounded growth.
  * Updated the `loom` subproject pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->