### PR TITLE
chore(edits): unify free_names_would_rebind via resolver closure

### DIFF
--- a/lang/lambda/edits/scope.mbt
+++ b/lang/lambda/edits/scope.mbt
@@ -285,35 +285,23 @@ fn declaration_id_for_name_at_module_end(
 }
 
 ///|
-fn free_names_would_rebind_at_node(
+/// Whether moving `source_node` would rebind any of its free vars — i.e. some
+/// free var resolves to a different declaration at the move target than at the
+/// source site. `resolve` is the target-site name resolver: per-node scope
+/// graph resolution (`declaration_id_for_name_at_node`) for inline, or
+/// module-root-end resolution (`declaration_id_for_name_at_module_end`) for
+/// extract's module-end target.
+fn free_names_would_rebind(
   g : @scope.ScopeGraph,
   source_node : ProjNode[@ast.Term],
-  target_node_id : NodeId,
   free_names : @immut/hashset.HashSet[String],
+  resolve : (String) -> @scope.DeclId?,
 ) -> Bool {
   let subtree = subtree_node_ids(source_node)
   free_names
   .iter()
   .any(fn(v) {
-    let target_decl = declaration_id_for_name_at_node(g, target_node_id, v)
-    free_name_would_rebind_to(g, source_node, v, target_decl, subtree)
-  })
-}
-
-///|
-fn free_names_would_rebind_at_module_end(
-  g : @scope.ScopeGraph,
-  definition_index : DefinitionIndex,
-  source_node : ProjNode[@ast.Term],
-  free_names : @immut/hashset.HashSet[String],
-) -> Bool {
-  let subtree = subtree_node_ids(source_node)
-  free_names
-  .iter()
-  .any(fn(v) {
-    let target_decl = declaration_id_for_name_at_module_end(
-      g, definition_index, v,
-    )
+    let target_decl = resolve(v)
     free_name_would_rebind_to(g, source_node, v, target_decl, subtree)
   })
 }

--- a/lang/lambda/edits/text_edit_refactor.mbt
+++ b/lang/lambda/edits/text_edit_refactor.mbt
@@ -66,7 +66,9 @@ fn compute_extract_to_let(
         // let is inserted before the lambda, outside its param's scope, so
         // any free var of the extracted expression that resolves via the
         // lambda param would become unbound after extraction.
-        if free_names_would_rebind_at_node(g, node, body_node.id(), fv) {
+        if free_names_would_rebind(g, node, fv, fn(v) {
+            declaration_id_for_name_at_node(g, body_node.id(), v)
+          }) {
           return Err(
             "Cannot extract: expression captures lambda-bound variables",
           )
@@ -163,7 +165,9 @@ fn compute_extract_to_let(
   let would_capture = if module_view.defs.is_empty() {
     free_names_captured_at_use_sites(g, node, fv)
   } else {
-    free_names_would_rebind_at_module_end(g, definition_index, node, fv)
+    free_names_would_rebind(g, node, fv, fn(v) {
+      declaration_id_for_name_at_module_end(g, definition_index, v)
+    })
   }
   if would_capture {
     return Err("Cannot extract: expression captures lambda-bound variables")
@@ -281,7 +285,9 @@ fn compute_inline_definition(
       }
       // Check for capture: would any free var in init be captured by an enclosing scope at the usage site?
       let init_fv = free_vars(def.init.kind, @immut/hashset.new())
-      if free_names_would_rebind_at_node(g, def.init, node_id, init_fv) {
+      if free_names_would_rebind(g, def.init, init_fv, fn(v) {
+          declaration_id_for_name_at_node(g, node_id, v)
+        }) {
         return Err(
           "Cannot inline: would capture variables bound by enclosing lambda",
         )
@@ -378,7 +384,9 @@ fn compute_inline_all_usages(
   // Check for capture: would any free var in init be captured by an enclosing scope at any reference site?
   let init_fv = free_vars(def.init.kind, @immut/hashset.new())
   for rid in ref_ids {
-    if free_names_would_rebind_at_node(g, def.init, rid, init_fv) {
+    if free_names_would_rebind(g, def.init, init_fv, fn(v) {
+        declaration_id_for_name_at_node(g, rid, v)
+      }) {
       return Err(
         "Cannot inline: would capture variables bound by enclosing lambda",
       )


### PR DESCRIPTION
Collapse two near-identical `free_names_would_rebind_at_node` and `free_names_would_rebind_at_module_end` functions into one `free_names_would_rebind` parameterized by a name-resolution closure.

Behavior-preserving — the two old functions differed only in the resolution call (per-node scope graph vs root-module-end). Each callsite passes its resolver inline:

- Block-level extract: `declaration_id_for_name_at_node(g, body_node.id(), v)`
- Root-level extract: `declaration_id_for_name_at_module_end(g, definition_index, v)`
- Inline definition: `declaration_id_for_name_at_node(g, node_id, v)`
- Inline all usages: `declaration_id_for_name_at_node(g, rid, v)`

No public API change (helper is private). 188/202 tests pass (same 14 pre-existing failures as main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of extract-and-inline actions when code references variables from nearby scopes.
  * Reduced the chance of unexpected name changes during moves, extractions, and inlining, especially around nested blocks and file-level edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->