### PR TITLE
Technical Debt & CI milestone: moon.mod migration + E2E MoonBit isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,12 @@ jobs:
             _build/js/release/build/dowdiness/canopy/ffi/markdown/moonbit.d.ts
             _build/js/release/build/dowdiness/graphviz/browser/browser.js
             _build/js/release/build/dowdiness/graphviz/browser/browser.d.ts
+            _build/js/release/build/dowdiness/ideal-editor/main/main.js
+            _build/js/release/build/dowdiness/ideal-editor/main/main.d.ts
+            _build/js/release/build/dowdiness/ideal-editor/main/moonbit.d.ts
+            _build/js/release/build/dowdiness/canopy-canvas/main/main.js
+            _build/js/release/build/dowdiness/canopy-canvas/main/main.d.ts
+            _build/js/release/build/dowdiness/canopy-canvas/main/moonbit.d.ts
           retention-days: 7
 
   typecheck-ts-examples:
@@ -364,22 +370,25 @@ jobs:
         run: ./scripts/update-moon-deps.sh
 
       - name: Build web
-        run: ./scripts/build-web.sh
-
   web-e2e:
     name: Web E2E
+    needs: [build-js]
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
       options: --ipc=host
+    env:
+      CANOPY_SKIP_MOON_BUILD: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: Set up MoonBit
-        uses: ./.github/actions/setup-moonbit
+      - name: Download MoonBit JS artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: moonbit-js-build
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -392,26 +401,28 @@ jobs:
         working-directory: examples/web
         run: npm ci
 
-      - name: Update MoonBit dependencies
-        run: ./scripts/update-moon-deps.sh
-
       - name: Run web Playwright suite
         run: ./scripts/test-web-e2e.sh
 
   ideal-web-e2e:
     name: Ideal Web E2E
+    needs: [build-js]
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
       options: --ipc=host
+    env:
+      CANOPY_SKIP_MOON_BUILD: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: Set up MoonBit
-        uses: ./.github/actions/setup-moonbit
+      - name: Download MoonBit JS artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: moonbit-js-build
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -429,18 +440,23 @@ jobs:
 
   demo-react-e2e:
     name: Demo React E2E
+    needs: [build-js]
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
       options: --ipc=host
+    env:
+      CANOPY_SKIP_MOON_BUILD: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: Set up MoonBit
-        uses: ./.github/actions/setup-moonbit
+      - name: Download MoonBit JS artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: moonbit-js-build
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -453,26 +469,28 @@ jobs:
         working-directory: examples/demo-react
         run: npm ci
 
-      - name: Update MoonBit dependencies
-        run: ./scripts/update-moon-deps.sh
-
       - name: Run demo-react Playwright suite
         run: ./scripts/test-demo-react-e2e.sh
 
   canvas-e2e:
     name: Canvas E2E
+    needs: [build-js]
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
       options: --ipc=host
+    env:
+      CANOPY_SKIP_MOON_BUILD: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: Set up MoonBit
-        uses: ./.github/actions/setup-moonbit
+      - name: Download MoonBit JS artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: moonbit-js-build
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,12 @@ jobs:
         with:
           name: moonbit-js-build
 
+      - name: Verify downloaded artifacts
+        run: |
+          test -f _build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js
+          test -f _build/js/release/build/dowdiness/canopy/ffi/json/json.js
+          echo "All required MoonBit JS artifacts verified"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -423,6 +429,11 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: moonbit-js-build
+
+      - name: Verify downloaded artifacts
+        run: |
+          test -f _build/js/release/build/dowdiness/ideal-editor/main/main.js
+          echo "All required MoonBit JS artifacts verified"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -458,6 +469,11 @@ jobs:
         with:
           name: moonbit-js-build
 
+      - name: Verify downloaded artifacts
+        run: |
+          test -f _build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js
+          echo "All required MoonBit JS artifacts verified"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -491,6 +507,11 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: moonbit-js-build
+
+      - name: Verify downloaded artifacts
+        run: |
+          test -f _build/js/release/build/dowdiness/canopy-canvas/main/main.js
+          echo "All required MoonBit JS artifacts verified"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ See [docs/development/ADDING_A_LANGUAGE.md](docs/development/ADDING_A_LANGUAGE.m
 
 ## Package Map
 
-The SessionStart hook runs `scripts/package-overview.sh` which provides a live package map at the start of every session. Use `moon ide outline <path>` to explore any package's public API before modifying it. Read `moon.mod.json` for module dependencies.
+The SessionStart hook runs `scripts/package-overview.sh` which provides a live package map at the start of every session. Use `moon ide outline <path>` to explore any package's public API before modifying it. Read `moon.mod` for module dependencies.
 
 ## Documentation
 
@@ -206,7 +206,7 @@ Use pi subagents as follows:
   exact-pattern changes.
 - `scout`: broad non-MoonBit reconnaissance or unfamiliar non-MoonBit areas.
 - `moonbit-scout`: MoonBit/Canopy reconnaissance involving `.mbt`, `.mbti`,
-  `moon.pkg`, `moon.mod.json`, package roots, or `moon ide`.
+  `moon.pkg`, `moon.mod` (`moon.mod.json` in legacy submodules), package roots, or `moon ide`.
 - `planner`: non-MoonBit implementation planning after reconnaissance.
 - `moonbit-planner`: MoonBit implementation planning requiring Existing API
   First, package-root validation, `.mbti` drift checks, proof/docs/TS/submodule

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -16,7 +16,7 @@ GitHub repo and MoonBit-module mapping on top of that list.
 | `rle/` | [dowdiness/rle](https://github.com/dowdiness/rle) | `dowdiness/rle` |
 | `order-tree/` | [dowdiness/order-tree](https://github.com/dowdiness/order-tree) | `dowdiness/order-tree` (backs event-graph-walker) |
 | `alga/` | [dowdiness/alga](https://github.com/dowdiness/alga) | `dowdiness/alga` (backs event-graph-walker) |
-| `rabbita/` | [dowdiness/rabbita](https://github.com/dowdiness/rabbita) | vendored community UI library — not a root `moon.mod.json` dependency |
+| `rabbita/` | [dowdiness/rabbita](https://github.com/dowdiness/rabbita) | vendored community UI library — not a root `moon.mod` dependency |
 
 ## `event-graph-walker/` Module (Core CRDT Library)
 
@@ -62,8 +62,8 @@ This covers the loom packages most central to the editor; it is **not** exhausti
 and `dowdiness/egraph` from loom. `loom` is itself a nested monorepo:
 `loom/.gitmodules` declares `incr`/`egraph`/`egglog`/`event-graph-walker` as
 submodules and `loom/examples/` adds `json`/`markdown`. loom has no top-level
-module file — each package owns its own `moon.mod.json`; `loom/.gitmodules` plus
-the root `moon.mod.json` are authoritative for loom's package set and what the
+module file — each package owns its own `moon.mod`; `loom/.gitmodules` plus
+the root `moon.mod` are authoritative for loom's package set and what the
 root consumes.
 
 **See:** [loom/README.md](../../loom/README.md) for detailed documentation.
@@ -148,26 +148,21 @@ crdt (depends on event-graph-walker + dowdiness/lambda + dowdiness/json + dowdin
 
 ## MoonBit Module Configuration
 
-The root [`moon.mod.json`](../../moon.mod.json) is the **authoritative** list of
+The root [`moon.mod`](../../moon.mod) is the **authoritative** list of
 `dowdiness/*` dependencies — do not re-curate the full set here, or it re-drifts
 (this section previously listed 5 of 15 deps and went stale).
 
-Two declaration shapes appear there:
-
-```json
-{
-  "deps": {
-    // path dep — resolves to an in-repo submodule directory
-    "dowdiness/loom": { "path": "./loom/loom" },
-    // registry dep — pinned to a published mooncakes version
-    "dowdiness/incr": "0.5.2"
-  }
+```toml
+import {
+  # path dep — resolved via moon.work workspace membership
+  "dowdiness/loom@0.1.0",
+  # registry dep — pinned to a published mooncakes version
+  "dowdiness/incr@0.11.0",
 }
 ```
-
-Most `dowdiness/*` deps are path deps into the submodules above; `incr` is the
+Most `dowdiness/*` deps are path deps via workspace membership in `moon.work`; `incr` is the
 notable exception, consumed as a registry version. For the complete, current
-list, read `moon.mod.json` directly.
+list, read `moon.mod` directly.
 
 ## Run Tests
 

--- a/docs/architecture/responsibility-map.md
+++ b/docs/architecture/responsibility-map.md
@@ -87,7 +87,7 @@ packages — update those through the `loom` submodule, not separate repositorie
 The libraries below are all implemented and wired into Canopy. The "Repository"
 column is the actual update boundary; "Integration" is where Canopy consumes it.
 
-**Group A — Direct dependencies** (in canopy root `moon.mod.json`):
+**Group A — Direct dependencies** (in canopy root `moon.mod`):
 
 | Library | Responsibility | Repository | Integration |
 |---|---|---|---|

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -75,8 +75,7 @@ def iter_files(target):
 MANIFEST_NAMES = ("moon.mod.json", "moon.mod")
 
 def iter_manifests():
-    """Yield every module manifest, legacy (moon.mod.json) or experimental
-    TOML (moon.mod, adopted by event-graph-walker and lib/cognition)."""
+    """Yield every module manifest — moon.mod (TOML) or moon.mod.json (legacy, still in some submodules)."""
     for name in MANIFEST_NAMES:
         yield from iter_files(name)
 

--- a/scripts/check-egw-resolver-identity.sh
+++ b/scripts/check-egw-resolver-identity.sh
@@ -90,8 +90,7 @@ def members():
     return re.findall(r'"([^"]+)"', m.group(1))
 
 def declared_in(member):
-    """Return (manifest_rel, version-or-None) if the member declares TARGET,
-    else None. Handles JSON moon.mod.json and experimental TOML moon.mod."""
+    """Return (manifest_rel, version-or-None) if the member declares TARGET, else None. Handles both moon.mod (TOML) and moon.mod.json (legacy)."""
     for name in ("moon.mod.json", "moon.mod"):
         p = os.path.normpath(os.path.join(member, name))
         if not os.path.isfile(p):

--- a/scripts/check-shared-substrate.sh
+++ b/scripts/check-shared-substrate.sh
@@ -117,10 +117,11 @@ for member in workspace_members():
     if spec is None:
         continue
     manifest_rel = os.path.relpath(manifest, ROOT)
-    # spec is either a version string (registry dep) or a dict. moon.mod.json
-    # supports the object form {"path": ...} (rule-E shape) and {"version": ...}
-    # (lib/visualizer used this earlier). Normalize before minor extraction so a
-    # structured spec never reaches minor_of as a non-string.
+    # moon.mod.json: spec is a version string (registry) or dict with
+    # {"path": ...} (rule-E) / {"version": ...}. moon.mod (TOML) deps are
+    # always "pkg@version" strings, so only strings reach here from moon.mod.
+    # Normalize before minor extraction so a structured spec never reaches
+    # minor_of as a non-string.
     if isinstance(spec, dict):
         if "path" in spec:
             path_deps.append((member, manifest_rel, spec["path"]))

--- a/scripts/dump-deps.sh
+++ b/scripts/dump-deps.sh
@@ -98,10 +98,24 @@ def parse_manifest_deps(path):
                     yield name, "other", json.dumps(spec)
         else:
             text = open(path).read()
-            import_block = re.search(r'import\s*\{([^}]+)\}', text, re.DOTALL)
-            if not import_block:
+            # Find the first `import {` and extract the balanced-brace body.
+            # Uses a simple depth counter instead of [^}]+ so it handles
+            # nested braces if the TOML format evolves inline tables.
+            m = re.search(r'import\s*\{', text)
+            if not m:
                 return
-            body = import_block.group(1)
+            start = m.end()
+            depth = 1
+            i = start
+            while i < len(text) and depth > 0:
+                if text[i] == '{':
+                    depth += 1
+                elif text[i] == '}':
+                    depth -= 1
+                i += 1
+            if depth != 0:
+                return
+            body = text[start:i-1]
             for dep_match in re.finditer(r'"([^"]+)@([^"]+)"', body):
                 yield dep_match.group(1), "registry", dep_match.group(2)
     except Exception:

--- a/scripts/dump-deps.sh
+++ b/scripts/dump-deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Dump every moon.pkg's import edges (scope-aware) and every moon.mod.json's
-# path-deps, for the whole repo minus noise. Output format is TSV; see the two
-# section headers below.
+# Dump every moon.pkg's import edges (scope-aware) and every module-level
+# path-deps, for the whole repo minus noise. Output format is TSV; see the
+# two section headers below. Handles both moon.mod.json and moon.mod (TOML).
 #
 # Usage: scripts/dump-deps.sh > docs/architecture/dep-graph-$(date +%F).txt
 set -euo pipefail
@@ -12,6 +12,8 @@ import json
 import os
 import re
 import sys
+
+MANIFEST_NAMES = ("moon.mod.json", "moon.mod")
 
 ROOT = os.getcwd()
 SKIP_DIR_NAMES = {
@@ -34,17 +36,23 @@ def iter_files(target_name):
             yield os.path.join(dirpath, target_name)
 
 def module_for(path):
-    """Walk up from path to find the nearest moon.mod.json; return (module_name, module_root)."""
+    """Walk up from path to find the nearest moon.mod.json or moon.mod (TOML); return (module_name, module_root)."""
     d = os.path.dirname(path)
     while True:
-        mmj = os.path.join(d, "moon.mod.json")
-        if os.path.isfile(mmj):
-            try:
-                with open(mmj, "r") as f:
-                    data = json.load(f)
-                return data.get("name", "?"), d
-            except Exception:
-                return "?", d
+        for name in MANIFEST_NAMES:
+            mp = os.path.join(d, name)
+            if os.path.isfile(mp):
+                try:
+                    if name.endswith(".json"):
+                        with open(mp) as f:
+                            data = json.load(f)
+                        return data.get("name", "?"), d
+                    else:
+                        text = open(mp).read()
+                        m = re.search(r'^\s*name\s*=\s*"([^"]+)"', text, re.MULTILINE)
+                        return (m.group(1), d) if m else ("?", d)
+                except Exception:
+                    return "?", d
         parent = os.path.dirname(d)
         if parent == d:
             return "?", ROOT
@@ -71,20 +79,33 @@ def parse_moon_pkg(path):
         for s in STR_LIT.finditer(body):
             yield scope, s.group(1)
 
-def parse_moon_mod_deps(path):
-    """Yield (dep_name, kind, detail) for each declared dep."""
+def parse_manifest_deps(path):
+    """Yield (dep_name, kind, detail) for each declared dep in moon.mod.json or moon.mod (TOML).
+
+    moon.mod.json: deps are dict entries (registry version string or {"path": …}).
+    moon.mod:      deps are "pkg@version" entries inside import { … } (all registry).
+    """
     try:
-        with open(path, "r") as f:
-            data = json.load(f)
-    except Exception:
-        return
-    for name, spec in (data.get("deps") or {}).items():
-        if isinstance(spec, str):
-            yield name, "registry", spec
-        elif isinstance(spec, dict) and "path" in spec:
-            yield name, "path", spec["path"]
+        if path.endswith(".json"):
+            with open(path) as f:
+                data = json.load(f)
+            for name, spec in (data.get("deps") or {}).items():
+                if isinstance(spec, str):
+                    yield name, "registry", spec
+                elif isinstance(spec, dict) and "path" in spec:
+                    yield name, "path", spec["path"]
+                else:
+                    yield name, "other", json.dumps(spec)
         else:
-            yield name, "other", json.dumps(spec)
+            text = open(path).read()
+            import_block = re.search(r'import\s*\{([^}]+)\}', text, re.DOTALL)
+            if not import_block:
+                return
+            body = import_block.group(1)
+            for dep_match in re.finditer(r'"([^"]+)@([^"]+)"', body):
+                yield dep_match.group(1), "registry", dep_match.group(2)
+    except Exception:
+        pass
 
 # -------------------------------------------------------------------
 # Section A: package-level imports (moon.pkg)
@@ -103,22 +124,27 @@ for r in rows_a:
     print("\t".join(r))
 
 print()
-# -------------------------------------------------------------------
-# Section B: module-level path deps (moon.mod.json)
-# -------------------------------------------------------------------
-print("### SECTION B: module-level deps (moon.mod.json)")
+print("### SECTION B: module-level deps")
 print("# columns: module_name\tmodule_path\tdep_name\tkind\tdetail")
 rows_b = []
-for mmj in iter_files("moon.mod.json"):
-    try:
-        with open(mmj, "r") as f:
-            data = json.load(f)
-    except Exception:
-        continue
-    name = data.get("name", "?")
-    mod_path = os.path.relpath(os.path.dirname(mmj), ROOT) or "."
-    for dep_name, kind, detail in parse_moon_mod_deps(mmj):
-        rows_b.append((name, mod_path, dep_name, kind, detail))
+for manifest_name in MANIFEST_NAMES:
+    for mm in iter_files(manifest_name):
+        try:
+            if mm.endswith(".json"):
+                with open(mm) as f:
+                    data = json.load(f)
+            else:
+                text = open(mm).read()
+                data = {"name": "?"}
+                m_name = re.search(r'^\s*name\s*=\s*"([^"]+)"', text, re.MULTILINE)
+                if m_name:
+                    data["name"] = m_name.group(1)
+        except Exception:
+            continue
+        name = data.get("name", "?")
+        mod_path = os.path.relpath(os.path.dirname(mm), ROOT) or "."
+        for dep_name, kind, detail in parse_manifest_deps(mm):
+            rows_b.append((name, mod_path, dep_name, kind, detail))
 rows_b.sort()
 for r in rows_b:
     print("\t".join(r))

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -26,7 +26,7 @@ tar -czf "$RELEASE_DIR/canopy-moonbit-${VERSION}.tar.gz" \
     _build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.js \
     _build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.d.ts \
     _build/js/release/build/dowdiness/canopy/ffi/markdown/moonbit.d.ts \
-    moon.mod.json \
+    moon.mod \
     moon.pkg \
     README.md \
     README.mbt.md \

--- a/scripts/run-moon-module.sh
+++ b/scripts/run-moon-module.sh
@@ -17,9 +17,8 @@ fi
 ACTION="$1"
 MODULE_DIR="$2"
 
-# Accept either manifest format: moon.mod.json (legacy) or moon.mod (the
-# experimental TOML format that event-graph-walker main adopted). moon reads
-# both as dependencies and as a primary module under NEW_MOON_MOD=0.
+# Accept either manifest format: moon.mod (TOML) or moon.mod.json (legacy).
+# moon reads both under NEW_MOON_MOD=0.
 if [ ! -f "$PROJECT_ROOT/$MODULE_DIR/moon.mod.json" ] &&
    [ ! -f "$PROJECT_ROOT/$MODULE_DIR/moon.mod" ]; then
     echo "Module root not found: $MODULE_DIR (expected moon.mod.json or moon.mod at $PROJECT_ROOT/$MODULE_DIR)" >&2
@@ -28,10 +27,8 @@ fi
 
 cd "$PROJECT_ROOT/$MODULE_DIR"
 
-# Keep mixed-manifest modules buildable while Canopy still has legacy
-# moon.mod.json path-dependency exceptions. This mode accepts both moon.mod and
-# moon.mod.json without requiring every local path dependency to become a
-# moon.work member.
+# Keep both manifest formats buildable. NEW_MOON_MOD=0 accepts both moon.mod and
+# moon.mod.json so local path-deps in moon.mod.json still resolve.
 export NEW_MOON_MOD="${NEW_MOON_MOD:-0}"
 
 DENY_WARN_FLAGS=(--deny-warn)

--- a/scripts/test-canvas-e2e.sh
+++ b/scripts/test-canvas-e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-
-# Build the canvas MoonBit JS output and run canvas Playwright tests.
-
+#
+# Run canvas Playwright E2E tests. Skips the MoonBit dep update step when
+# CANOPY_SKIP_MOON_BUILD=1 (CI uses pre-built artifacts from build-js).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,11 +9,13 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_ROOT"
 
-(
-    cd examples/canvas
-    # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
-    "$SCRIPT_DIR/moon-update.sh"
-)
+if [[ "${CANOPY_SKIP_MOON_BUILD:-0}" != "1" ]]; then
+    (
+        cd examples/canvas
+        # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+        "$SCRIPT_DIR/moon-update.sh"
+    )
+fi
 
 echo "Running canvas Playwright E2E..."
 cd examples/canvas/web
@@ -24,8 +26,10 @@ if [ ! -d node_modules ]; then
 fi
 
 # Workspace mode: vite/tsconfig paths point to workspace-level _build
-# (../../_build/...). Explicitly unset MOON_WORK so child processes
-# (vite → moon build) use workspace membership for rabbita lib deps.
+# (../../_build/...). unset MOON_WORK so the Vite plugin's `moon build`
+# (local dev only) uses workspace membership for rabbita lib deps.
+# In CI, CANOPY_SKIP_MOON_BUILD=1 skips MoonBit entirely and vite-plugin
+# loads pre-built artifacts from the build-js download.
 unset MOON_WORK
 
 CI="${CI:-1}" npx playwright test "$@"

--- a/scripts/test-demo-react-e2e.sh
+++ b/scripts/test-demo-react-e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-
-# Build the current MoonBit JS outputs and run demo-react Playwright tests.
-
+#
+# Run demo-react Playwright E2E tests. Skips the MoonBit JS build step when
+# CANOPY_SKIP_MOON_BUILD=1 (CI uses pre-built artifacts from build-js).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,7 +9,9 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_ROOT"
 
-"$SCRIPT_DIR/build-js.sh"
+if [[ "${CANOPY_SKIP_MOON_BUILD:-0}" != "1" ]]; then
+    "$SCRIPT_DIR/build-js.sh"
+fi
 
 echo "Running demo-react Playwright E2E..."
 cd examples/demo-react

--- a/scripts/test-focus.sh
+++ b/scripts/test-focus.sh
@@ -24,22 +24,26 @@ case "$FILE" in
   *_test.mbt|*_wbtest.mbt|*_benchmark.mbt) exit 0 ;;
 esac
 
-# Find the repo root (nearest directory with moon.mod.json)
+# Find the repo root (nearest directory with moon.mod.json or moon.mod)
 DIR=$(dirname "$FILE")
 ROOT="$DIR"
 while [ "$ROOT" != "/" ]; do
-  if [ -f "$ROOT/moon.mod.json" ]; then
+  if [ -f "$ROOT/moon.mod.json" ] || [ -f "$ROOT/moon.mod" ]; then
     break
   fi
   ROOT=$(dirname "$ROOT")
 done
 
-if [ ! -f "$ROOT/moon.mod.json" ]; then
+if [ ! -f "$ROOT/moon.mod.json" ] && [ ! -f "$ROOT/moon.mod" ]; then
   exit 0  # Not in a moon project
 fi
 
-# Get module name from moon.mod.json
-MOD_NAME=$(jq -r '.name' "$ROOT/moon.mod.json")
+# Get module name from moon.mod.json or moon.mod (TOML)
+if [ -f "$ROOT/moon.mod.json" ]; then
+  MOD_NAME=$(jq -r '.name' "$ROOT/moon.mod.json")
+else
+  MOD_NAME=$(grep -oP '^name\s*=\s*"\K[^"]+' "$ROOT/moon.mod")
+fi
 
 # Get relative path from root to the file's directory
 REL_DIR=$(realpath --relative-to="$ROOT" "$DIR")

--- a/scripts/test-ideal-web-e2e.sh
+++ b/scripts/test-ideal-web-e2e.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-
-# Build the Ideal editor MoonBit JS output and run the non-performance
-# Playwright E2E specs. The editor-response perf spec is gated separately by
+#
+# Run Ideal editor Playwright E2E specs (non-performance). Skips the MoonBit
+# dep update step when CANOPY_SKIP_MOON_BUILD=1 (CI uses pre-built artifacts
+# from build-js). The editor-response perf spec is gated separately by
 # .github/workflows/benchmark.yml.
 
 set -euo pipefail
@@ -11,11 +12,13 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_ROOT"
 
-(
-    cd examples/ideal
-    # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
-    "$SCRIPT_DIR/moon-update.sh"
-)
+if [[ "${CANOPY_SKIP_MOON_BUILD:-0}" != "1" ]]; then
+    (
+        cd examples/ideal
+        # Retry-wrapped: transient mooncakes CDN 403 (issue #467) auto-recovers.
+        "$SCRIPT_DIR/moon-update.sh"
+    )
+fi
 
 echo "Running Ideal editor Playwright E2E..."
 cd examples/ideal/web

--- a/scripts/test-web-e2e.sh
+++ b/scripts/test-web-e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-
-# Build the current MoonBit JS outputs and run web Playwright tests.
-
+#
+# Run web Playwright E2E tests. Skips the MoonBit JS build step when
+# CANOPY_SKIP_MOON_BUILD=1 (CI uses pre-built artifacts from build-js).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,7 +9,9 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_ROOT"
 
-"$SCRIPT_DIR/build-js.sh"
+if [[ "${CANOPY_SKIP_MOON_BUILD:-0}" != "1" ]]; then
+    "$SCRIPT_DIR/build-js.sh"
+fi
 
 echo "Running web Playwright E2E..."
 cd examples/web

--- a/scripts/validate-ci-yaml.sh
+++ b/scripts/validate-ci-yaml.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Validate all GitHub Actions workflow YAML files in .github/workflows/.
+# Uses js-yaml for proper structural parsing.
+# Exit code 0 = all valid, 1 = any invalid.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Ensure js-yaml is available
+if ! node -e "require('js-yaml')" 2>/dev/null; then
+  npm install --no-save --silent js-yaml
+fi
+
+errors=0
+for f in "$REPO_ROOT"/.github/workflows/*.yml; do
+  name="$(basename "$f")"
+  if node -e "
+    const yaml = require('js-yaml');
+    const fs = require('fs');
+    try {
+      yaml.load(fs.readFileSync('$f', 'utf8'));
+    } catch(e) {
+      console.error('$name: ' + e.message);
+      process.exit(1);
+    }
+  " 2>/dev/null; then
+    echo "  ✅ $name"
+  else
+    echo "  ❌ $name — invalid YAML"
+    errors=$((errors + 1))
+  fi
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo "❌ $errors workflow file(s) have YAML errors"
+  exit 1
+fi
+echo "✅ All workflow YAML files valid"


### PR DESCRIPTION
## Summary

Closes the open items in the **Technical Debt & CI** milestone across three tracked issues.

## Changes

### #491: moon.mod migration (scripts + docs)
- `dump-deps.sh`: rewritten to parse both `moon.mod.json` (JSON dict deps) and `moon.mod` (TOML `"pkg@version"` import blocks). Module root detection, dep parsing, and Section B iteration handle both formats.
- `test-focus.sh`: root detection checks for either `moon.mod.json` or `moon.mod`; module name extracted from TOML via `grep -oP`.
- `package-release.sh`: artifact list references `moon.mod` instead of `moon.mod.json`.
- `docs/architecture/modules.md`, `docs/architecture/responsibility-map.md`, `AGENTS.md`: manifest references updated, TOML example shown.
- Stale-comment cleanup in `check-deps.sh`, `check-egw-resolver-identity.sh`, `check-shared-substrate.sh`, `run-moon-module.sh` — replaced "experimental" framing with neutral descriptions.

### #561 Path B: E2E jobs isolated from MoonBit registry
- `build-js` now uploads ALL workspace JS artifacts: canopy FFI + graphviz/browser + ideal-editor/main + canopy-canvas/main (17 files).
- All 4 E2E jobs (`web-e2e`, `ideal-web-e2e`, `demo-react-e2e`, `canvas-e2e`) are refactored:
  - `needs: [build-js]` — wait for the build job
  - Download pre-built `moonbit-js-build` artifacts via `actions/download-artifact`
  - No MoonBit setup, no `moon update`, no `moon build`
  - `CANOPY_SKIP_MOON_BUILD: 1` env var set
- E2E test scripts guard MoonBit build/update behind `CANOPY_SKIP_MOON_BUILD` — local development still works (env var defaults to `0`, builds as before).
- The `vite-plugin-moonbit` plugin already detects CI mode and skips `moon build` when pre-built artifacts exist (line 69, 94-98) — no plugin changes needed.

## Verification
- `moon check`: 0 errors across workspace
- `dump-deps.sh`: successfully parses both manifest formats, output verified
- `test-focus.sh`: correctly detects `moon.mod` root, runs focused tests
- CI YAML structurally validated (grep-based structural checks on all 4 E2E jobs)