### PR TITLE
refactor: replace inline decl lookup in rename_binding_by_id with shared helper

### DIFF
--- a/lang/lambda/edits/text_edit_rename.mbt
+++ b/lang/lambda/edits/text_edit_rename.mbt
@@ -284,13 +284,9 @@ fn rename_binding_by_id(
   new_name : String,
 ) -> Result[(Array[SpanEdit], FocusHint)?, String] {
   let g = @scope.build(ctx.registry, ctx.source_map)
-  guard g.decls
-    .iter()
-    .find_first(fn(d) {
-      d.node_id == binding_node_id && d.kind is DeclKind::ModuleDef(_)
-    })
-    is Some(decl) else {
-    return Err("Binding not found: " + binding_node_id.to_string())
+  let decl = match module_def_decl_for_binding(g, binding_node_id) {
+    Ok(d) => d
+    Err(e) => return Err(e)
   }
   rename_module_binding(ctx, g, decl, decl.name, new_name)
 }

--- a/lang/lambda/edits/text_lens_regression_wbtest.mbt
+++ b/lang/lambda/edits/text_lens_regression_wbtest.mbt
@@ -5,7 +5,10 @@ test "reconcile_ast rebuilds rendered text after same-shape edit" {
   let (old_root, _) = parse_to_proj_node("x + 1")
   let (new_root, _) = parse_to_proj_node("x + 2")
   let reconciled = @core.reconcile(old_root, new_root, Ref(100))
-  inspect(@ast.print_term(reconciled.kind), content=(
-    #|x + 2
-  ))
+  inspect(
+    @ast.print_term(reconciled.kind),
+    content=(
+      #|x + 2
+    ),
+  )
 }


### PR DESCRIPTION
## Summary

Closes #653.

`rename_binding_by_id` hand-rolled a `g.decls.iter().find_first(...)` scan duplicating the `module_def_decl_for_binding` helper in `scope.mbt`. Replaced with the shared helper — same error type (`String`), same error message, same call pattern as 5 other callers.

## Verification

- `moon check`: 0 errors
- `moon test -p lang/lambda/edits`: 180/202 pass, 22 pre-existing failures unchanged (confirmed via `git stash` comparison)
- Ensemble review (2/3): PASS from reviewer-flash and reviewer-mimo (Qwen quota-exhausted, no findings from either completed review)

## Files changed

- `lang/lambda/edits/text_edit_rename.mbt` — inline guard → shared helper
- `lang/lambda/edits/text_lens_regression_wbtest.mbt` — moonfmt only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binding rename behavior so missing or unresolved bindings are handled more reliably during text edits.
  * Preserved the same expected edited text output when reconciling expressions.

* **Tests**
  * Updated a regression test to use a clearer multi-line assertion format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->