### PR TITLE
feat(ideal/ui): extract action overlay item tones into ui/menu_item.mbt

### DIFF
--- a/examples/ideal/main/ui/menu_item.mbt
+++ b/examples/ideal/main/ui/menu_item.mbt
@@ -1,0 +1,32 @@
+///|
+/// Ideal-local Tailwind menu/item tone recipes.
+/// Keep semantic hooks as the first class tokens: the `hook` parameter
+/// carries the semantic selector (e.g. `"action-overlay-item"`), and the
+/// tone variant adds interactive state classes on top of the base chrome.
+priv enum MenuItemTone {
+  Normal
+  Danger
+}
+
+///|
+let menu_item_base_class = "flex items-center gap-canopy-sm py-canopy-sm px-canopy-lg cursor-pointer text-canopy-small text-canopy-fg transition-colors duration-(--duration-fast) ease-canopy-out max-[768px]:min-h-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-lg"
+
+///|
+fn menu_item_tone_class(tone : MenuItemTone) -> String {
+  match tone {
+    Normal =>
+      "hover:bg-[rgba(130,80,223,0.15)] data-[active=true]:bg-[rgba(130,80,223,0.15)]"
+    Danger =>
+      "danger text-canopy-error-text hover:bg-canopy-error-bg data-[active=true]:bg-canopy-error-bg"
+  }
+}
+
+///|
+pub fn menu_item_class(hook : String) -> String {
+  cx([hook, menu_item_base_class, menu_item_tone_class(Normal)])
+}
+
+///|
+pub fn menu_item_danger_class(hook : String) -> String {
+  cx([hook, menu_item_base_class, menu_item_tone_class(Danger)])
+}

--- a/examples/ideal/main/ui/pkg.generated.mbti
+++ b/examples/ideal/main/ui/pkg.generated.mbti
@@ -18,6 +18,10 @@ pub fn inspector_label_class() -> String
 
 pub fn inspector_section_class() -> String
 
+pub fn menu_item_class(String) -> String
+
+pub fn menu_item_danger_class(String) -> String
+
 pub fn panel_label_class() -> String
 
 pub fn panel_section_class() -> String

--- a/examples/ideal/main/view_actions.mbt
+++ b/examples/ideal/main/view_actions.mbt
@@ -19,9 +19,9 @@ fn view_action_item(
 ) -> @rabbita.Html {
   let is_danger = action.id == "delete" || action.id == "binding_delete"
   let item_class = if is_danger {
-    action_overlay_item_danger_class
+    @ui.menu_item_danger_class("action-overlay-item")
   } else {
-    action_overlay_item_class
+    @ui.menu_item_class("action-overlay-item")
   }
   @html.div(
     class=item_class,
@@ -137,7 +137,7 @@ fn view_submenu_choices(
     let (label, _) = choice
     items.push(
       @html.div(
-        class=action_overlay_item_class,
+        class=@ui.menu_item_class("action-overlay-item"),
         attrs=menu.item_attrs(i, msg => emit(Menu(msg))),
         [
           @html.span(class=action_mnemonic_class, [

--- a/examples/ideal/main/view_actions_classes.mbt
+++ b/examples/ideal/main/view_actions_classes.mbt
@@ -15,25 +15,6 @@ let action_overlay_list_class = "action-overlay-list flex flex-col"
 let action_group_label_class = "action-group-label text-canopy-label font-semibold text-canopy-dim tracking-[0.1em] uppercase pt-canopy-sm px-canopy-lg pb-canopy-xs border-t border-solid border-canopy-border mt-canopy-xs"
 
 ///|
-let action_overlay_item_base_class = "action-overlay-item flex items-center gap-canopy-sm py-canopy-sm px-canopy-lg cursor-pointer text-canopy-small text-canopy-fg transition-colors duration-(--duration-fast) ease-canopy-out max-[768px]:min-h-[44px] max-[768px]:py-canopy-md max-[768px]:px-canopy-lg"
-
-///|
-let action_overlay_item_normal_state_class = "hover:bg-[rgba(130,80,223,0.15)] data-[active=true]:bg-[rgba(130,80,223,0.15)]"
-
-///|
-let action_overlay_item_danger_state_class = "danger text-canopy-error-text hover:bg-canopy-error-bg data-[active=true]:bg-canopy-error-bg"
-
-///|
-let action_overlay_item_class : String = action_overlay_item_base_class +
-  " " +
-  action_overlay_item_normal_state_class
-
-///|
-let action_overlay_item_danger_class : String = action_overlay_item_base_class +
-  " " +
-  action_overlay_item_danger_state_class
-
-///|
 let action_mnemonic_class = "action-mnemonic inline-flex items-center justify-center w-[22px] h-[22px] font-canopy-mono text-canopy-label font-semibold text-canopy-accent bg-[rgba(130,80,223,0.2)] rounded-canopy-sm shrink-0 uppercase"
 
 ///|

--- a/examples/ideal/web/styles/editor.css
+++ b/examples/ideal/web/styles/editor.css
@@ -13,6 +13,7 @@
 @source "../../main/ui/tabs.mbt";
 @source "../../main/ui/recipe.mbt";
 @source "../../main/ui/panel.mbt";
+@source "../../main/ui/menu_item.mbt";
 
 /* Fonts loaded via <link> in index.html (avoids CSS @import waterfall) */
 


### PR DESCRIPTION
## Summary

Extract action overlay item tones (Normal/Danger) from `view_actions_classes.mbt` into `ui/menu_item.mbt` following the recipe pattern established in PR #822 and #823.

Closes #824.

## Changes

- **New:** `examples/ideal/main/ui/menu_item.mbt` — `priv enum MenuItemTone { Normal, Danger }` with `pub fn menu_item_class(String)` and `pub fn menu_item_danger_class(String)` leveraging `cx()`
- **Updated:** `view_actions.mbt` — 3 call sites use `@ui.menu_item_class` / `@ui.menu_item_danger_class`
- **Deleted:** 5 constants from `view_actions_classes.mbt` (base class, 2 state classes, 2 composed constants)
- **Infra:** `@source` for `menu_item.mbt` in `editor.css`

## Notes

- The base class was stripped of the `action-overlay-item` prefix — the hook is now passed as a parameter by the caller, avoiding duplication in `cx()`.
- `MenuItemTone` is `priv` (cannot appear in a public function signature per MoonBit rules), so two convenience functions are exposed instead of a single parameterized one — matching the `action_button_class` / `action_button_danger_class` pattern in `button.mbt`.

## Verification

- `moon check`: 0 errors
- `moon fmt && moon info`: correctly adds 2 public symbols to `.mbti`
- `moon test --target js`: 5451 tests, 5381 passed, 70 failed (identical to main — all pre-existing)