### PR TITLE
feat(edits): constant folding middleware — FoldConstants pass

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -185,12 +185,18 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ## 8. Handler Chain Follow-ups
 
-- [ ] AST transform pipeline.
+- [x] AST transform pipeline — first pass: constant folding middleware.
+  Shipped: `FoldConstants` middleware in `lang/lambda/edits/text_edit_middleware.mbt` (PR #842). Intercepts `CommitEdit` on `Bop(_, Int(a), Int(b))`, short-circuits with folded `Int(a⊕b)`. Trigger: `CommitEdit` only (non-`CommitEdit` structural ops pass through).
   Why: the `EditMiddleware` trait is ready for composable AST-to-AST transforms (constant folding, dead code elimination, simplification). Each pass becomes a middleware impl that intercepts before `core_dispatch`.
+
+- [ ] Beta reduction middleware — second AST transform pass (#841).
+  Why: `App(Lam(x, body), arg)` should reduce to `body[x := arg]` at edit time, same pattern as constant folding.
+  Design: raw-AST substitute on `@ast.Term` (~25 lines). Capture-avoiding via `@alpha` pipeline or documented limitation on first pass.
+  Plan: follow-up issue #841
+  Exit: `FoldConstants`-style middleware reducing beta-redexes on `CommitEdit`, with positive/negative tests and no regression in existing beta-reducible structural edit ops.
 
 - [ ] Cache navigation path between keystrokes to avoid O(n) DFS per keystroke (GitHub #91).
   Exit: path or zipper is cached in editor state and reused across consecutive keystrokes.
-
 ---
 
 ## 9. Ideal Editor

--- a/lang/lambda/edits/text_edit.mbt
+++ b/lang/lambda/edits/text_edit.mbt
@@ -32,12 +32,20 @@ fn[T] EditContext::resolve(
 
 ///|
 /// Translate a TreeEditOp into text span edits.
-/// Passes through ValidateNodeExists middleware before core dispatch.
+/// Passes through FoldConstants and ValidateNodeExists middleware before
+/// core dispatch. FoldConstants runs outermost so foldable patterns are
+/// caught before validation.
 pub fn compute_text_edit(
   op : TreeEditOp,
   ctx : EditContext[@ast.Term],
 ) -> EditResult raise EditError {
-  ValidateNodeExists::{  }.apply(core_dispatch, op, ctx)
+  FoldConstants::{  }.apply(
+    fn(op_arg, ctx_arg) raise EditError {
+      ValidateNodeExists::{  }.apply(core_dispatch, op_arg, ctx_arg)
+    },
+    op,
+    ctx,
+  )
 }
 
 ///|

--- a/lang/lambda/edits/text_edit_middleware.mbt
+++ b/lang/lambda/edits/text_edit_middleware.mbt
@@ -66,3 +66,65 @@ fn extract_primary_node_id(op : TreeEditOp) -> NodeId? {
     AddBinding(module_node_id~) => Some(module_node_id)
   }
 }
+
+///|
+/// Fold constants at edit time: when a CommitEdit targets a Bop node
+/// with both Int children (e.g. `1 + 2`), replace the entire expression
+/// with the folded result (e.g. `3`). Only fires on CommitEdit — structural
+/// ops (SwapChildren, Unwrap, ChangeOperator, etc.) delegate to core_dispatch
+/// unchanged.
+priv struct FoldConstants {}
+
+///|
+impl EditMiddleware for FoldConstants with fn apply(_self, next, op, ctx) {
+  match try_fold_constant(op, ctx) {
+    Some(result) => result
+    None => next(op, ctx)
+  }
+}
+
+///|
+/// Attempt to fold Bop(Plus, Int(a), Int(b)) → Int(a + b)
+/// or Bop(Minus, Int(a), Int(b)) → Int(a - b).
+/// Only triggers on CommitEdit (user replacing text at the Bop node).
+fn try_fold_constant(
+  op : TreeEditOp,
+  ctx : EditContext[@ast.Term],
+) -> EditResult? {
+  let node_id = match op {
+    CommitEdit(node_id~, ..) => node_id
+    _ => return None
+  }
+  let node = match ctx.registry.get(node_id) {
+    Some(n) => n
+    None => return None
+  }
+  match node.kind {
+    @ast.Term::Bop(op_kind, @ast.Term::Int(a), @ast.Term::Int(b)) => {
+      let folded = match op_kind {
+        @ast.Bop::Plus => a + b
+        @ast.Bop::Minus => a - b
+      }
+      let range = match ctx.source_map.get_range(node_id) {
+        Some(r) => r
+        None => return None
+      }
+      let fold_text = folded.to_string()
+      Some(
+        Some(
+          (
+            [
+              {
+                start: range.start,
+                delete_len: range.end - range.start,
+                inserted: fold_text,
+              },
+            ],
+            RestoreCursor,
+          ),
+        ),
+      )
+    }
+    _ => None
+  }
+}

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -3242,3 +3242,83 @@ test "compute_text_edit: InlineDefinition does not reject block-shadowed free na
     _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
   }
 }
+
+///|
+test "compute_text_edit: FoldConstants folds 1 + 2 to 3 on CommitEdit" {
+  let text = "1 + 2"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let root_id = proj.id()
+  let result = test_edit(
+    CommitEdit(node_id=root_id, new_value="x"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, hint))) => {
+      inspect(apply_edits(text, edits), content="3")
+      inspect(hint, content="RestoreCursor")
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: FoldConstants folds 5 - 3 to 2 on CommitEdit" {
+  let text = "5 - 3"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let root_id = proj.id()
+  let result = test_edit(
+    CommitEdit(node_id=root_id, new_value="x"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, hint))) => {
+      inspect(apply_edits(text, edits), content="2")
+      inspect(hint, content="RestoreCursor")
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: FoldConstants skips non-Bop nodes" {
+  let text = "42"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let root_id = proj.id()
+  let result = test_edit(
+    CommitEdit(node_id=root_id, new_value="99"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="99")
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}
+
+///|
+test "compute_text_edit: FoldConstants skips Bop with non-Int child" {
+  let text = "x + 1"
+  let (proj, _) = parse_to_proj_node(text)
+  let source_map = SourceMap::from_ast(proj)
+  let registry = text_edit_test_registry(proj)
+  let root_id = proj.id()
+  let result = test_edit(
+    CommitEdit(node_id=root_id, new_value="99"),
+    make_edit_ctx(text, source_map, registry, proj),
+  )
+  match result {
+    Ok(Some((edits, _))) => {
+      let new_text = apply_edits(text, edits)
+      inspect(new_text, content="99")
+    }
+    _ => fail("expected Ok(Some(edits)), got: " + @debug.to_string(result))
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first AST transform pass in the `EditMiddleware` pipeline: constant folding of integer binary operations at edit time.

## Changes

**`lang/lambda/edits/text_edit_middleware.mbt`** — `FoldConstants` middleware:
- Intercepts `CommitEdit` on `Bop(_, Int(a), Int(b))` nodes
- Short-circuits `core_dispatch` with a `SpanEdit` replacing the Bop with the folded `Int(a⊕b)`
- Supports `Plus` → `a + b` and `Minus` → `a - b`
- Returns `None` (delegate to `next`) for non-`CommitEdit` ops, non-Bop nodes, or non-Int children
- Graceful degradation: returns `None` on any lookup failure (missing registry, missing source map range)

**`lang/lambda/edits/text_edit.mbt`** — Updated dispatch chain:
- Before: `ValidateNodeExists —> core_dispatch`
- After: `FoldConstants —> ValidateNodeExists —> core_dispatch`
- FoldConstants runs outermost so foldable patterns are caught before validation

**`lang/lambda/edits/text_edit_wbtest.mbt`** — 4 new tests:
- `1 + 2` CommitEdit → `3`
- `5 - 3` CommitEdit → `2`
- `42` CommitEdit → passes through (non-Bop, no fold)
- `x + 1` CommitEdit → passes through (Var child, no fold)

**`docs/TODO.md`** — §8 split into three items: constant folding (done), beta reduction (#841 pending), cache navigation path (#91 pending).

## Design Decisions

- **CommitEdit-only trigger**: structural ops (SwapChildren, ChangeOperator, Unwrap) on foldable Bops pass through unchanged. Only when the user explicitly replaces text at the Bop node is the constant folded.
- **Single-node check**: inspects only the target node via registry lookup. No recursive subtree walk.
- **Graceful degradation**: returns `None` on any lookup failure — never raises.

## Verification

| Suite | Count | Result |
|---|---|---|
| Native (wasm-gc) | 3,682/3,682 | ✅ |
| Native | 70/70 | ✅ |
| JS | 1,720/1,727 | ✅ (7 pre-existing rabbita) |
| check-strict.sh | — | ✅ (0 Canopy errors) |

## Follow-up

Beta reduction middleware tracked in #841 — `(λx.x) 42 → 42` at edit time, same middleware pattern.