### PR TITLE
feat(core): wire ReconcileTraceEvent emission through reconcile pipeline (#830)

### DIFF
--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub fn[T] assign_fresh_ids(ProjNode[T], @ref.Ref[Int]) -> ProjNode[T]
 
-pub fn[T : @dowdiness/loom/core.TreeNode + Eq] build_projection_memos(@cells.Runtime, @cells.Derived[@seam.SyntaxNode], (@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode[T], (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit, reconcile_node? : (ProjNode[T], ProjNode[T], @ref.Ref[Int]) -> ProjNode[T], label? : String) -> (@cells.Derived[ProjNode[T]?], @cells.Derived[Map[NodeId, ProjNode[T]]], @cells.Derived[SourceMap])
+pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable + Eq] build_projection_memos(@cells.Runtime, @cells.Derived[@seam.SyntaxNode], (@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode[T], (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit, reconcile_node? : (ProjNode[T], ProjNode[T], @ref.Ref[Int]) -> ProjNode[T], label? : String) -> (@cells.Derived[ProjNode[T]?], @cells.Derived[Map[NodeId, ProjNode[T]]], @cells.Derived[SourceMap])
 
 pub fn[T] collect_registry(ProjNode[T], Map[NodeId, ProjNode[T]]) -> Unit
 
@@ -23,9 +23,11 @@ pub fn[T] navigate_proj_cached(NodeId, Direction, ProjNode[T], Array[Int]?) -> (
 
 pub fn next_proj_node_id(@ref.Ref[Int]) -> Int
 
-pub fn[T : @dowdiness/loom/core.TreeNode] reconcile(ProjNode[T], ProjNode[T], @ref.Ref[Int]) -> ProjNode[T]
+pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] reconcile(ProjNode[T], ProjNode[T], @ref.Ref[Int], trace_ref? : @ref.Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T]
 
-pub fn[T : @dowdiness/loom/core.TreeNode] reconcile_hinted(ProjNode[T], ProjNode[T], @ref.Ref[Int], Map[NodeId, IdentityTransform]) -> ProjNode[T]
+pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] reconcile_hinted(ProjNode[T], ProjNode[T], @ref.Ref[Int], Map[NodeId, IdentityTransform], trace_ref? : @ref.Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T]
+
+pub fn to_structured_changes(Array[ReconcileTraceEvent]) -> Array[StructuredChange]
 
 // Errors
 pub(all) suberror EditError {
@@ -123,6 +125,16 @@ pub fn[T] ProjNode::walk_preorder(Self[T], (FoldNode[T]) -> Unit raise?) -> Unit
 pub impl[T : @dowdiness/loom/core.Renderable] Show for ProjNode[T]
 pub impl[T : ToJson] ToJson for ProjNode[T]
 
+pub(all) enum ReconcileTraceEvent {
+  Matched(NodeId, Int, Int, NodeId, String)
+  Inserted(NodeId, Int, NodeId, String)
+  Deleted(NodeId, Int, NodeId, String)
+  Wrapped(NodeId, NodeId, String)
+  Unwrapped(NodeId, NodeId, String)
+  Renamed(NodeId, String)
+  Freshened(NodeId, Int, NodeId, String)
+} derive(Eq)
+
 pub struct SourceMap {
   node_to_range : Map[NodeId, @dowdiness/loom/core.Range]
   ranges : Array[(@dowdiness/loom/core.Range, NodeId)]
@@ -152,6 +164,15 @@ pub(all) struct SpanEdit {
   inserted : String
 } derive(Eq, @debug.Debug)
 pub impl Show for SpanEdit
+
+pub(all) enum StructuredChange {
+  Inserted(NodeId, Int, NodeId, String)
+  Deleted(NodeId, Int, NodeId, String)
+  Wrapped(NodeId, NodeId, String)
+  Unwrapped(NodeId, NodeId, String)
+  Renamed(NodeId, String)
+  Freshened(NodeId, Int, NodeId, String)
+} derive(Eq)
 
 // Type aliases
 

--- a/core/projection_memo.mbt
+++ b/core/projection_memo.mbt
@@ -1,13 +1,19 @@
 ///|
-using @loomcore {trait TreeNode}
+using @loomcore {trait TreeNode, trait Renderable}
 
 ///|
-pub fn[T : TreeNode + Eq] build_projection_memos(
+pub fn[T : TreeNode + Renderable + Eq] build_projection_memos(
   rt : @incr.Runtime,
   syntax_tree : @incr.Derived[@seam.SyntaxNode],
   syntax_to_proj : (@seam.SyntaxNode, Ref[Int]) -> ProjNode[T],
   populate_spans : (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit,
-  reconcile_node? : (ProjNode[T], ProjNode[T], Ref[Int]) -> ProjNode[T] = reconcile,
+  reconcile_node? : (ProjNode[T], ProjNode[T], Ref[Int]) -> ProjNode[T] = fn(
+    o,
+    n,
+    c,
+  ) {
+    reconcile(o, n, c)
+  },
   label? : String = "generic",
 ) -> (
   @incr.Derived[ProjNode[T]?],

--- a/core/reconcile.mbt
+++ b/core/reconcile.mbt
@@ -1,13 +1,25 @@
 // AST reconciliation: preserve ProjNode identities across reparses.
 
 ///|
+fn emit_trace(
+  trace_ref : Ref[Array[ReconcileTraceEvent]]?,
+  event : ReconcileTraceEvent,
+) -> Unit {
+  match trace_ref {
+    Some(r) => r.val.push(event)
+    None => ()
+  }
+}
+
+///|
 /// Generic reconciliation: Preserve node IDs where possible when AST changes.
-pub fn[T : TreeNode] reconcile(
+pub fn[T : TreeNode + Renderable] reconcile(
   old : ProjNode[T],
   new : ProjNode[T],
   counter : Ref[Int],
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T] {
-  reconcile_hinted(old, new, counter, {})
+  reconcile_hinted(old, new, counter, {}, trace_ref~)
 }
 
 ///|
@@ -16,11 +28,12 @@ pub fn[T : TreeNode] reconcile(
 /// id) lets identity survive a constructor change at a position that positional
 /// LCS reconciliation alone would lose — see
 /// docs/architecture/grove-and-structural-identity.md.
-pub fn[T : TreeNode] reconcile_hinted(
+pub fn[T : TreeNode + Renderable] reconcile_hinted(
   old : ProjNode[T],
   new : ProjNode[T],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T] {
   // A structural hint keyed by `old.id()` (wrap / unwrap) takes precedence and
   // may apply even when the new wrapper is the SAME kind as the wrapped node —
@@ -31,7 +44,7 @@ pub fn[T : TreeNode] reconcile_hinted(
   let hinted = if hints.is_empty() {
     NoStructuralHint
   } else {
-    structural_pair(old, new, counter, hints)
+    structural_pair(old, new, counter, hints, trace_ref~)
   }
   match hinted {
     Applied(node) => node
@@ -45,6 +58,8 @@ pub fn[T : TreeNode] reconcile_hinted(
           new.children,
           counter,
           hints,
+          old.node_id,
+          trace_ref~,
         )
         ProjNode(new.kind, new.start, new.end, old.node_id, reconciled_children)
       } else {
@@ -54,11 +69,13 @@ pub fn[T : TreeNode] reconcile_hinted(
 }
 
 ///|
-fn[T : TreeNode] reconcile_children(
+fn[T : TreeNode + Renderable] reconcile_children(
   old_children : Array[ProjNode[T]],
   new_children : Array[ProjNode[T]],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
+  parent_id : NodeId,
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> Array[ProjNode[T]] {
   let old_len = old_children.length()
   let new_len = new_children.length()
@@ -121,17 +138,34 @@ fn[T : TreeNode] reconcile_children(
       old_children, new_children, old_matched, new_matched, hints,
     )
   }
-  [
+  let result = [
     for k in 0..<new_len => {
       if new_matched[k] >= 0 {
-        reconcile_hinted(
+        let reconciled = reconcile_hinted(
           old_children[new_matched[k]],
           new_children[k],
           counter,
           hints,
+          trace_ref~,
         )
+        emit_trace(
+          trace_ref,
+          Matched(
+            parent_id,
+            new_matched[k],
+            k,
+            reconciled.id(),
+            T::kind_tag(reconciled.kind),
+          ),
+        )
+        reconciled
       } else if hints.is_empty() {
-        assign_fresh_ids(new_children[k], counter)
+        let fresh = assign_fresh_ids(new_children[k], counter)
+        emit_trace(
+          trace_ref,
+          Inserted(parent_id, k, fresh.id(), T::kind_tag(fresh.kind)),
+        )
+        fresh
       } else {
         match
           try_unmatched_hint_pair(
@@ -142,13 +176,41 @@ fn[T : TreeNode] reconcile_children(
             consumed,
             counter,
             hints,
+            trace_ref~,
           ) {
-          Some(node) => node
-          None => assign_fresh_ids(new_children[k], counter)
+          Some(node) => {
+            emit_trace(
+              trace_ref,
+              Matched(parent_id, -1, k, node.id(), T::kind_tag(node.kind)),
+            )
+            node
+          }
+          None => {
+            let fresh = assign_fresh_ids(new_children[k], counter)
+            emit_trace(
+              trace_ref,
+              Inserted(parent_id, k, fresh.id(), T::kind_tag(fresh.kind)),
+            )
+            fresh
+          }
         }
       }
     }
   ]
+  for oi = 0; oi < old_len; oi = oi + 1 {
+    if old_matched[oi] < 0 {
+      emit_trace(
+        trace_ref,
+        Deleted(
+          parent_id,
+          oi,
+          old_children[oi].id(),
+          T::kind_tag(old_children[oi].kind),
+        ),
+      )
+    }
+  }
+  result
 }
 
 ///|
@@ -168,21 +230,34 @@ priv enum HintResult[T] {
 /// authoritative: it either applies or forces a degrade-to-fresh. It never
 /// silently falls through to same-kind reconciliation (which would leave the
 /// preserved id on the new wrapper).
-fn[T : TreeNode] structural_pair(
+fn[T : TreeNode + Renderable] structural_pair(
   old : ProjNode[T],
   new : ProjNode[T],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> HintResult[T] {
   match hints.get(old.id()) {
     Some(Wrap(_)) =>
-      match apply_wrap(old, new, counter, hints) {
-        Some(node) => Applied(node)
+      match apply_wrap(old, new, counter, hints, trace_ref~) {
+        Some(node) => {
+          emit_trace(
+            trace_ref,
+            Wrapped(old.id(), node.id(), T::kind_tag(node.kind)),
+          )
+          Applied(node)
+        }
         None => Unlocatable
       }
     Some(Unwrap(keep~, ..)) =>
-      match apply_unwrap(old, new, counter, hints, keep) {
-        Some(node) => Applied(node)
+      match apply_unwrap(old, new, counter, hints, keep, trace_ref~) {
+        Some(node) => {
+          emit_trace(
+            trace_ref,
+            Unwrapped(old.id(), node.id(), T::kind_tag(old.kind)),
+          )
+          Applied(node)
+        }
         None => Unlocatable
       }
     // Replace retires the old identity; Move's identity is editor-owned
@@ -212,7 +287,7 @@ fn lcs_excluded(hints : Map[NodeId, IdentityTransform], id : NodeId) -> Bool {
 ///|
 /// For an LCS-unmatched `new_child`, find a still-unmatched, unconsumed prev
 /// child whose `Wrap`/`Unwrap` hint pairs with it, and carry identity.
-fn[T : TreeNode] try_unmatched_hint_pair(
+fn[T : TreeNode + Renderable] try_unmatched_hint_pair(
   new_child : ProjNode[T],
   old_children : Array[ProjNode[T]],
   old_matched : Array[Int],
@@ -220,6 +295,7 @@ fn[T : TreeNode] try_unmatched_hint_pair(
   consumed : Map[NodeId, Bool],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T]? {
   let candidates = [
     for idx, o in old_children if old_matched[idx] < 0 &&
@@ -235,7 +311,7 @@ fn[T : TreeNode] try_unmatched_hint_pair(
   match candidates {
     [o] => {
       consumed[o.id()] = true
-      match structural_pair(o, new_child, counter, hints) {
+      match structural_pair(o, new_child, counter, hints, trace_ref~) {
         Applied(node) => Some(node)
         _ => None
       }
@@ -292,11 +368,12 @@ fn[T : TreeNode] hint_pairs(
 ///|
 /// Wrap: `wrapper` introduces a level over the prev subtree `old`. Carry `old`'s
 /// identity into the unique same-kind child; the wrapper itself is fresh.
-fn[T : TreeNode] apply_wrap(
+fn[T : TreeNode + Renderable] apply_wrap(
   old : ProjNode[T],
   wrapper : ProjNode[T],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T]? {
   let targets = [
     for idx, c in wrapper.children if T::same_kind(c.kind, old.kind) => idx
@@ -315,7 +392,14 @@ fn[T : TreeNode] apply_wrap(
               c.start,
               c.end,
               old.node_id,
-              reconcile_children(old.children, c.children, counter, hints),
+              reconcile_children(
+                old.children,
+                c.children,
+                counter,
+                hints,
+                old.node_id,
+                trace_ref~,
+              ),
             )
           } else {
             assign_fresh_ids(c, counter)
@@ -339,15 +423,16 @@ fn[T : TreeNode] apply_wrap(
 ///|
 /// Unwrap: the prev `wrapper` is removed and its child `keep` promoted to `new`.
 /// Carry `keep`'s identity into `new`; the wrapper id retires.
-fn[T : TreeNode] apply_unwrap(
+fn[T : TreeNode + Renderable] apply_unwrap(
   wrapper : ProjNode[T],
   new : ProjNode[T],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
   keep : NodeId,
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T]? {
   match find_child(wrapper, keep) {
-    Some(k) => Some(reconcile_hinted(k, new, counter, hints))
+    Some(k) => Some(reconcile_hinted(k, new, counter, hints, trace_ref~))
     None => None
   }
 }

--- a/core/test_expr_wbtest.mbt
+++ b/core/test_expr_wbtest.mbt
@@ -8,7 +8,6 @@
 // and new language editors will not work.
 
 ///|
-using @loomcore {trait Renderable}
 
 ///|
 priv enum TestExpr {
@@ -39,7 +38,7 @@ impl @loomcore.TreeNode for TestExpr with fn same_kind(self, other) {
 }
 
 ///|
-impl Renderable for TestExpr with fn kind_tag(self) {
+impl @loomcore.Renderable for TestExpr with fn kind_tag(self) {
   match self {
     Leaf(_) => "Leaf"
     Branch(_, _) => "Branch"
@@ -47,7 +46,7 @@ impl Renderable for TestExpr with fn kind_tag(self) {
 }
 
 ///|
-impl Renderable for TestExpr with fn label(self) {
+impl @loomcore.Renderable for TestExpr with fn label(self) {
   match self {
     Leaf(s) => s
     Branch(tag, _) => tag
@@ -55,16 +54,16 @@ impl Renderable for TestExpr with fn label(self) {
 }
 
 ///|
-impl Renderable for TestExpr with fn placeholder(_self) {
+impl @loomcore.Renderable for TestExpr with fn placeholder(_self) {
   "?"
 }
 
 ///|
-impl Renderable for TestExpr with fn unparse(self) {
+impl @loomcore.Renderable for TestExpr with fn unparse(self) {
   match self {
     Leaf(s) => s
     Branch(tag, cs) =>
-      tag + "(" + cs.map(c => Renderable::unparse(c)).join(" ") + ")"
+      tag + "(" + cs.map(c => @loomcore.Renderable::unparse(c)).join(" ") + ")"
   }
 }
 


### PR DESCRIPTION
## Summary

Thread an optional `trace_ref` through the reconcile pipeline so callers can collect `ReconcileTraceEvent` structs describing structural changes at each decision point.

## Changes

- **`core/reconcile.mbt`** — Add `emit_trace` helper and `trace_ref?` optional parameter to `reconcile`, `reconcile_hinted`, `reconcile_children`, `structural_pair`, `try_unmatched_hint_pair`, `apply_wrap`, `apply_unwrap`. Emit `Matched`/`Inserted`/`Deleted` events in `reconcile_children`; emit `Wrapped`/`Unwrapped` events in `structural_pair`.
- **`core/projection_memo.mbt`** — Wrap `reconcile` default in a lambda (its type changed with the new optional param). Add `T : Renderable` bound for `kind_tag` support.
- **Trait bound** — `T : TreeNode + Renderable` on all reconciling functions so trace events carry `T::kind_tag(k)` instead of `""`.

## Backward Compatibility

All new parameters default to `None`/unchanged behavior. Existing callers passing `reconcile` as a function value now need a lambda wrapper (already fixed in `projection_memo.mbt`).

Part of #830.