### PR TITLE
fix: update Layout pattern matches to new 3-arg constructors

### DIFF
--- a/lang/lambda/eval/eval_memo.mbt
+++ b/lang/lambda/eval/eval_memo.mbt
@@ -241,12 +241,12 @@ pub fn split_at_hardlines(
 
   fn walk(l : @pretty.Layout[@pretty.SyntaxCategory]) -> Unit {
     match l {
-      HardLine => flush()
-      Concat(left, right) => {
+      HardLine(_) => flush()
+      Concat(left, right, _) => {
         walk(left)
         walk(right)
       }
-      Empty => ()
+      Empty(_) => ()
       other => parts.push(other)
     }
   }


### PR DESCRIPTION
Fixes `moon build --target js` which was blocked by a Concat constructor mismatch.

Loom updated `Concat`, `HardLine`, and `Empty` to carry explicit flat-width `Int` fields. Updated `eval_memo.mbt` patterns to match the new signatures.

**Before:** `moon build --target js` → 1 error (Concat requires 3 arguments)
**After:** `moon build --target js` → 0 errors