### PR TITLE
feat(view): display StructuredChange events in Patch panel with source snippets

### DIFF
--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub fn[T] assign_fresh_ids(ProjNode[T], @ref.Ref[Int]) -> ProjNode[T]
 
-pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable + Eq] build_projection_memos(@cells.Runtime, @cells.Derived[@seam.SyntaxNode], (@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode[T], (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit, reconcile_node? : (ProjNode[T], ProjNode[T], @ref.Ref[Int]) -> ProjNode[T], trace_ref? : @ref.Ref[Array[ReconcileTraceEvent]]?, label? : String) -> (@cells.Derived[ProjNode[T]?], @cells.Derived[Map[NodeId, ProjNode[T]]], @cells.Derived[SourceMap])
+pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable + Eq] build_projection_memos(@cells.Runtime, @cells.Derived[@seam.SyntaxNode], (@seam.SyntaxNode, @ref.Ref[Int]) -> ProjNode[T], (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit, reconcile_node? : (ProjNode[T], ProjNode[T], @ref.Ref[Int], @ref.Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T], trace_ref? : @ref.Ref[Array[ReconcileTraceEvent]]?, label? : String) -> (@cells.Derived[ProjNode[T]?], @cells.Derived[Map[NodeId, ProjNode[T]]], @cells.Derived[SourceMap])
 
 pub fn[T] collect_registry(ProjNode[T], Map[NodeId, ProjNode[T]]) -> Unit
 

--- a/core/projection_memo.mbt
+++ b/core/projection_memo.mbt
@@ -7,14 +7,12 @@ pub fn[T : TreeNode + Renderable + Eq] build_projection_memos(
   syntax_tree : @incr.Derived[@seam.SyntaxNode],
   syntax_to_proj : (@seam.SyntaxNode, Ref[Int]) -> ProjNode[T],
   populate_spans : (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit,
-  reconcile_node? : (ProjNode[T], ProjNode[T], Ref[Int], Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T] = fn(
-    o,
-    n,
-    c,
-    tr,
-  ) {
-    reconcile(o, n, c, trace_ref=tr)
-  },
+  reconcile_node? : (
+    ProjNode[T],
+    ProjNode[T],
+    Ref[Int],
+    Ref[Array[ReconcileTraceEvent]]?,
+  ) -> ProjNode[T] = fn(o, n, c, tr) { reconcile(o, n, c, trace_ref=tr) },
   trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
   label? : String = "generic",
 ) -> (

--- a/core/projection_memo.mbt
+++ b/core/projection_memo.mbt
@@ -7,12 +7,13 @@ pub fn[T : TreeNode + Renderable + Eq] build_projection_memos(
   syntax_tree : @incr.Derived[@seam.SyntaxNode],
   syntax_to_proj : (@seam.SyntaxNode, Ref[Int]) -> ProjNode[T],
   populate_spans : (SourceMap, @seam.SyntaxNode, ProjNode[T]) -> Unit,
-  reconcile_node? : (ProjNode[T], ProjNode[T], Ref[Int]) -> ProjNode[T] = fn(
+  reconcile_node? : (ProjNode[T], ProjNode[T], Ref[Int], Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T] = fn(
     o,
     n,
     c,
+    tr,
   ) {
-    reconcile(o, n, c)
+    reconcile(o, n, c, trace_ref=tr)
   },
   trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
   label? : String = "generic",
@@ -34,11 +35,7 @@ pub fn[T : TreeNode + Renderable + Eq] build_projection_memos(
         None => ()
       }
       let result = match prev_proj_ref.val {
-        Some(old) =>
-          match trace_ref {
-            Some(_) => reconcile(old, new_proj, counter, trace_ref~)
-            None => reconcile_node(old, new_proj, counter)
-          }
+        Some(old) => reconcile_node(old, new_proj, counter, trace_ref)
         None => new_proj
       }
       prev_proj_ref.val = Some(result)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -229,10 +229,10 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 - [x] Inspector — Patch panel. *Part of Inspector traceability workstream.* Shipped in PR #323 (2026-05-22, commit `0c093ac`).
   Scrollable log of recent `SpanEdit`s with back-reference to producing `GenericTreeOp` (each row uses `edit.to_string()`), rendered by `view_patch_log` in `view_bottom.mbt`.
 
-- [ ] Structure-aware diff display from reconciliation trace (#830).
-  Why: the Patch panel shows character-level `SpanEdit`s even for structural edits like Wrap; the reconciler already knows "this was a Wrap" but discards it after reconciliation.
+- [x] Structure-aware diff display from reconciliation trace (#830).
+  Why: the Patch panel shows character-level SpanEdits even for structural edits like Wrap; the reconciler already knows "this was a Wrap" but discards it after reconciliation.
   Plan: `docs/plans/2026-07-02-structure-aware-diff-display.md`
-  Status: `ReconcileTraceEvent` and `StructuredChange` enum types + `to_structured_changes` filter shipped in `core/diff_event.mbt`. The reconciliation emission plumbing (`trace_ref` threading through 7 functions in `core/reconcile.mbt`) is deferred — the types are the foundation.
+  Status: Rendering in the Ideal editor's Patch tab — shows Inserted/Deleted/Wrapped/etc as a `<details>` section with source text snippets.
   Exit: `core/reconcile.mbt` emits an opt-in `ReconcileTraceEvent` trace; Patch panel renders filtered `StructuredChange` events (e.g. "Wrapped #42 in Lambda") alongside the existing SpanEdit log.
 
 - [ ] IdentityTransform hints in undo/redo for identity-preserving undo (#831).

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -503,56 +503,44 @@ fn format_structured_change(
       s
     }
   }
+  fn format_kind_change(
+    prefix : String,
+    kind_tag : String,
+    node_id : @canopy_core.NodeId,
+  ) -> String {
+    let s = snippet(node_id)
+    if s.is_empty() {
+      prefix + " " + kind_tag
+    } else {
+      prefix + " " + kind_tag + " '" + truncate(s) + "'"
+    }
+  }
   match c {
-    @canopy_core.Inserted(_, index, node_id, kind_tag) => {
-      let s = snippet(node_id)
-      if s.is_empty() {
-        "+ \{kind_tag}"
-      } else {
-        "+ \{kind_tag} '\{truncate(s)}'"
-      }
-    }
-    @canopy_core.Deleted(_, _, node_id, kind_tag) => {
-      let s = snippet(node_id)
-      if s.is_empty() {
-        "- \{kind_tag}"
-      } else {
-        "- \{kind_tag} '\{truncate(s)}'"
-      }
-    }
+    @canopy_core.Inserted(_, _, node_id, kind_tag) =>
+      format_kind_change("+", kind_tag, node_id)
+    @canopy_core.Deleted(_, _, node_id, kind_tag) =>
+      format_kind_change("-", kind_tag, node_id)
     @canopy_core.Wrapped(inner_id, wrapper_node_id, wrapper_kind) => {
       let s = snippet(wrapper_node_id)
       let s = if s.is_empty() { snippet(inner_id) } else { s }
       if s.is_empty() {
-        "⊞ \{wrapper_kind}"
+        "⊞ " + wrapper_kind
       } else {
-        "⊞ \{wrapper_kind} '\{truncate(s)}'"
+        "⊞ " + wrapper_kind + " '" + truncate(s) + "'"
       }
     }
     @canopy_core.Unwrapped(wrapper_id, _, wrapper_kind) => {
       let s = snippet(wrapper_id)
       if s.is_empty() {
-        "⊟ \{wrapper_kind}"
+        "⊟ " + wrapper_kind
       } else {
-        "⊟ \{wrapper_kind} '\{truncate(s)}'"
+        "⊟ " + wrapper_kind + " '" + truncate(s) + "'"
       }
     }
-    @canopy_core.Renamed(node_id, kind_tag) => {
-      let s = snippet(node_id)
-      if s.is_empty() {
-        "→ \{kind_tag}"
-      } else {
-        "→ \{kind_tag} '\{truncate(s)}'"
-      }
-    }
-    @canopy_core.Freshened(_, _, node_id, kind_tag) => {
-      let s = snippet(node_id)
-      if s.is_empty() {
-        "~ \{kind_tag}"
-      } else {
-        "~ \{kind_tag} '\{truncate(s)}'"
-      }
-    }
+    @canopy_core.Renamed(node_id, kind_tag) =>
+      format_kind_change("→", kind_tag, node_id)
+    @canopy_core.Freshened(_, _, node_id, kind_tag) =>
+      format_kind_change("~", kind_tag, node_id)
   }
 }
 
@@ -606,13 +594,18 @@ fn view_patch_log(model : Model) -> Html {
     ]
   }
   if log.is_empty() {
-    @html.div(class="bottom-content", attrs=bottom_panel_attrs(Patch), [
-      @html.span(class="no-problems", [
-        @html.text(
-          "No patches yet. Structure-mode edits aren't traced here — see the Op Log tab.",
-        ),
-      ]),
-    ])
+    @html.div(
+      class="bottom-content",
+      attrs=bottom_panel_attrs(Patch),
+      structural_block +
+      [
+        @html.span(class="no-problems", [
+          @html.text(
+            "No patches yet. Structure-mode edits aren't traced here — see the Op Log tab.",
+          ),
+        ]),
+      ],
+    )
   } else {
     let n = log.length()
     let items : Array[Html] = Array::new(capacity=n)

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -492,13 +492,13 @@ fn format_structured_change(
 ) -> String {
   fn snippet(node_id : @canopy_core.NodeId) -> String {
     match source_map.get_range(node_id) {
-      Some(r) => source_text[r.start:r.end].to_string()
+      Some(r) => source_text[r.start:r.end].to_owned()
       None => ""
     }
   }
   fn truncate(s : String) -> String {
     if s.length() > 60 {
-      s[0:60].to_string() + "..."
+      s[0:60].to_owned() + "..."
     } else {
       s
     }

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -483,6 +483,57 @@ fn view_op_log(model : Model) -> Html {
 }
 
 ///|
+/// Format a single StructuredChange as human-readable text for the Patch panel.
+/// Shows the kind tag and the actual source text at the affected position.
+fn format_structured_change(
+  c : @canopy_core.StructuredChange,
+  source_map : @canopy_core.SourceMap,
+  source_text : String,
+) -> String {
+  fn snippet(node_id : @canopy_core.NodeId) -> String {
+    match source_map.get_range(node_id) {
+      Some(r) => source_text.substring(r.start, r.end)
+      None => ""
+    }
+  }
+  fn truncate(s : String) -> String {
+    if s.length() > 60 { s.substring(0, 60) + "..." } else { s }
+  }
+  match c {
+    @canopy_core.Inserted(_, index, node_id, kind_tag) => {
+      let s = snippet(node_id)
+      if s.is_empty() { "+ \{kind_tag}" }
+      else { "+ \{kind_tag} '\{truncate(s)}'" }
+    }
+    @canopy_core.Deleted(_, _, node_id, kind_tag) => {
+      let s = snippet(node_id)
+      if s.is_empty() { "- \{kind_tag}" }
+      else { "- \{kind_tag} '\{truncate(s)}'" }
+    }
+    @canopy_core.Wrapped(inner_id, wrapper_node_id, wrapper_kind) => {
+      let s = snippet(wrapper_node_id)
+      let s = if s.is_empty() { snippet(inner_id) } else { s }
+      if s.is_empty() { "⊞ \{wrapper_kind}" }
+      else { "⊞ \{wrapper_kind} '\{truncate(s)}'" }
+    }
+    @canopy_core.Unwrapped(wrapper_id, _, wrapper_kind) => {
+      let s = snippet(wrapper_id)
+      if s.is_empty() { "⊟ \{wrapper_kind}" }
+      else { "⊟ \{wrapper_kind} '\{truncate(s)}'" }
+    }
+    @canopy_core.Renamed(node_id, kind_tag) => {
+      let s = snippet(node_id)
+      if s.is_empty() { "→ \{kind_tag}" }
+      else { "→ \{kind_tag} '\{truncate(s)}'" }
+    }
+    @canopy_core.Freshened(_, _, node_id, kind_tag) => {
+      let s = snippet(node_id)
+      if s.is_empty() { "~ \{kind_tag}" }
+      else { "~ \{kind_tag} '\{truncate(s)}'" }
+    }
+  }
+}
+
 /// Render the Patch panel — paired (op label, SpanEdits) rows.
 /// Mirrors `view_op_log` shape: most-recent first, capped to MAX_PATCH_LOG.
 /// Each entry surfaces the producing `GenericTreeOp` label as a header row
@@ -499,6 +550,34 @@ fn view_patch_log(model : Model) -> Html {
     )
   }
   let log = model.patch_log
+  // Force projection memo to recompute so trace_ref is populated
+  let _ = model.editor.get_proj_node()
+  // Read structural changes from the reconciliation trace
+  // Read the source map to resolve positions for structured change display
+  let source_map = model.editor.get_source_map()
+  // Read the editor text to extract source snippets for structural changes
+  let source_text = model.editor.get_text()
+  let structured_changes = model.companion.get_structured_changes()
+  // Build the structural-changes details block when events are present
+  let structural_block : Array[Html] = if structured_changes.is_empty() {
+    []
+  } else {
+    let change_rows : Array[Html] = structured_changes.map(fn(c) {
+      @html.div(class="patch-structural-change", [
+        @html.span(class="patch-change-text", [
+          @html.text(format_structured_change(c, source_map, source_text)),
+        ]),
+      ])
+    })
+    [
+      @html.node("details", @html.Attrs::build().class("patch-structural-details"), [
+        @html.node("summary", @html.Attrs::build(), [
+          @html.text("Structural changes"),
+        ]),
+        @html.div(class="patch-structural-body", change_rows),
+      ]),
+    ]
+  }
   if log.is_empty() {
     @html.div(class="bottom-content", attrs=bottom_panel_attrs(Patch), [
       @html.span(class="no-problems", [
@@ -530,7 +609,7 @@ fn view_patch_log(model : Model) -> Html {
     @html.div(
       class="bottom-content patch-log",
       attrs=bottom_panel_attrs(Patch),
-      items,
+      structural_block + items,
     )
   }
 }

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -492,13 +492,13 @@ fn format_structured_change(
 ) -> String {
   fn snippet(node_id : @canopy_core.NodeId) -> String {
     match source_map.get_range(node_id) {
-      Some(r) => source_text.substring(r.start, r.end)
+      Some(r) => source_text[r.start:r.end].to_string()
       None => ""
     }
   }
   fn truncate(s : String) -> String {
     if s.length() > 60 {
-      s.substring(0, 60) + "..."
+      s[0:60].to_string() + "..."
     } else {
       s
     }

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -497,43 +497,66 @@ fn format_structured_change(
     }
   }
   fn truncate(s : String) -> String {
-    if s.length() > 60 { s.substring(0, 60) + "..." } else { s }
+    if s.length() > 60 {
+      s.substring(0, 60) + "..."
+    } else {
+      s
+    }
   }
   match c {
     @canopy_core.Inserted(_, index, node_id, kind_tag) => {
       let s = snippet(node_id)
-      if s.is_empty() { "+ \{kind_tag}" }
-      else { "+ \{kind_tag} '\{truncate(s)}'" }
+      if s.is_empty() {
+        "+ \{kind_tag}"
+      } else {
+        "+ \{kind_tag} '\{truncate(s)}'"
+      }
     }
     @canopy_core.Deleted(_, _, node_id, kind_tag) => {
       let s = snippet(node_id)
-      if s.is_empty() { "- \{kind_tag}" }
-      else { "- \{kind_tag} '\{truncate(s)}'" }
+      if s.is_empty() {
+        "- \{kind_tag}"
+      } else {
+        "- \{kind_tag} '\{truncate(s)}'"
+      }
     }
     @canopy_core.Wrapped(inner_id, wrapper_node_id, wrapper_kind) => {
       let s = snippet(wrapper_node_id)
       let s = if s.is_empty() { snippet(inner_id) } else { s }
-      if s.is_empty() { "⊞ \{wrapper_kind}" }
-      else { "⊞ \{wrapper_kind} '\{truncate(s)}'" }
+      if s.is_empty() {
+        "⊞ \{wrapper_kind}"
+      } else {
+        "⊞ \{wrapper_kind} '\{truncate(s)}'"
+      }
     }
     @canopy_core.Unwrapped(wrapper_id, _, wrapper_kind) => {
       let s = snippet(wrapper_id)
-      if s.is_empty() { "⊟ \{wrapper_kind}" }
-      else { "⊟ \{wrapper_kind} '\{truncate(s)}'" }
+      if s.is_empty() {
+        "⊟ \{wrapper_kind}"
+      } else {
+        "⊟ \{wrapper_kind} '\{truncate(s)}'"
+      }
     }
     @canopy_core.Renamed(node_id, kind_tag) => {
       let s = snippet(node_id)
-      if s.is_empty() { "→ \{kind_tag}" }
-      else { "→ \{kind_tag} '\{truncate(s)}'" }
+      if s.is_empty() {
+        "→ \{kind_tag}"
+      } else {
+        "→ \{kind_tag} '\{truncate(s)}'"
+      }
     }
     @canopy_core.Freshened(_, _, node_id, kind_tag) => {
       let s = snippet(node_id)
-      if s.is_empty() { "~ \{kind_tag}" }
-      else { "~ \{kind_tag} '\{truncate(s)}'" }
+      if s.is_empty() {
+        "~ \{kind_tag}"
+      } else {
+        "~ \{kind_tag} '\{truncate(s)}'"
+      }
     }
   }
 }
 
+///|
 /// Render the Patch panel — paired (op label, SpanEdits) rows.
 /// Mirrors `view_op_log` shape: most-recent first, capped to MAX_PATCH_LOG.
 /// Each entry surfaces the producing `GenericTreeOp` label as a header row
@@ -570,12 +593,16 @@ fn view_patch_log(model : Model) -> Html {
       ])
     })
     [
-      @html.node("details", @html.Attrs::build().class("patch-structural-details"), [
-        @html.node("summary", @html.Attrs::build(), [
-          @html.text("Structural changes"),
-        ]),
-        @html.div(class="patch-structural-body", change_rows),
-      ]),
+      @html.node(
+        "details",
+        @html.Attrs::build().class("patch-structural-details"),
+        [
+          @html.node("summary", @html.Attrs::build(), [
+            @html.text("Structural changes"),
+          ]),
+          @html.div(class="patch-structural-body", change_rows),
+        ],
+      ),
     ]
   }
   if log.is_empty() {

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -16,6 +16,7 @@ pub struct LambdaCompanion {
   // panel or to drive custom trace visualizations.
   priv trace_ref : Ref[Array[@core.ReconcileTraceEvent]]
 }
+
 ///|
 /// Read the current reconciliation trace, filter to user-facing
 /// StructuredChange events (discards Matched events), and return them.

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -11,6 +11,18 @@ pub struct LambdaCompanion {
   priv escalation_memo : @incr.Derived[Array[@lambda_eval.EvalResult]]
   priv analysis : @parser.LambdaAnalysis
   priv analysis_projection : AnalysisProjection
+  // Reconciliation trace events populated on every reconcile pass. The caller
+  // reads this to display structural changes alongside SpanEdits in the Patch
+  // panel or to drive custom trace visualizations.
+  priv trace_ref : Ref[Array[@core.ReconcileTraceEvent]]
+}
+///|
+/// Read the current reconciliation trace, filter to user-facing
+/// StructuredChange events (discards Matched events), and return them.
+pub fn LambdaCompanion::get_structured_changes(
+  self : LambdaCompanion,
+) -> Array[@core.StructuredChange] {
+  @core.to_structured_changes(self.trace_ref.val)
 }
 
 ///|
@@ -135,6 +147,9 @@ pub fn new_lambda_editor(
   parent_runtime? : @incr.Runtime,
 ) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
   let analysis_projection = AnalysisProjection::new()
+  // Reconciliation trace accumulator. Populated on every reconcile pass;
+  // the caller reads `trace_ref.val` after projection changes.
+  let trace_ref : Ref[Array[@core.ReconcileTraceEvent]] = Ref([])
   // Ref side-channels let the build_memos callback publish companion memos
   // back out to the enclosing scope for companion construction + capabilities
   // wiring.
@@ -157,6 +172,7 @@ pub fn new_lambda_editor(
       let (cached_proj_node, registry_memo, source_map_memo) = @lambda_proj.build_lambda_projection_memos(
         parser,
         identity_hints=hints_ref,
+        trace_ref=Some(trace_ref),
       )
       cached_proj_node_ref.val = Some(cached_proj_node)
       source_map_memo_ref.val = Some(source_map_memo)
@@ -180,6 +196,7 @@ pub fn new_lambda_editor(
     escalation_memo: escalation_memo_ref.val.unwrap(),
     analysis: analysis_ref.val.unwrap(),
     analysis_projection,
+    trace_ref,
   }
   (editor, companion)
 }

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -22,7 +22,7 @@ pub const LET_DEF_NAME_ROLE : String = "name"
 
 pub const PARAM_ROLE : String = "param"
 
-pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]], trace_ref? : @ref.Ref[Array[@dowdiness/canopy/core.ReconcileTraceEvent]]?) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
 
 pub fn module_name_role(Int) -> String
 

--- a/lang/lambda/proj/projection_memo.mbt
+++ b/lang/lambda/proj/projection_memo.mbt
@@ -42,7 +42,13 @@ fn reconcile_module_child_hinted(
     Some(i) =>
       match old_children.get(i) {
         Some(old_child) =>
-          @core.reconcile_hinted(old_child, new_child, counter, hints, trace_ref~)
+          @core.reconcile_hinted(
+            old_child,
+            new_child,
+            counter,
+            hints,
+            trace_ref~,
+          )
         None => @core.assign_fresh_ids(new_child, counter)
       }
     None => @core.assign_fresh_ids(new_child, counter)
@@ -84,7 +90,9 @@ fn reconcile_lambda_projection_hinted(
           )
         }
       ]
-      children.push(@core.reconcile_hinted(old_body, new_body, counter, hints, trace_ref~))
+      children.push(
+        @core.reconcile_hinted(old_body, new_body, counter, hints, trace_ref~),
+      )
       @core.ProjNode(new_.kind, new_.start, new_.end, old.node_id, children)
     }
     _ => @core.reconcile_hinted(old, new_, counter, hints, trace_ref~)
@@ -120,11 +128,17 @@ pub fn build_lambda_projection_memos(
         Some(hints_ref) => {
           let hints = build_hints_map(hints_ref.val)
           hints_ref.val = [] // T4: cleared exactly once per reparse
-          reconcile_lambda_projection_hinted(old, new_, counter, hints, trace_ref=tr)
+          reconcile_lambda_projection_hinted(
+            old,
+            new_,
+            counter,
+            hints,
+            trace_ref=tr,
+          )
         }
       }
     },
-    trace_ref=trace_ref,
+    trace_ref~,
     label="lambda",
   )
 }
@@ -176,7 +190,8 @@ fn reconcile_module_child(
   match matched_index {
     Some(i) =>
       match old_children.get(i) {
-        Some(old_child) => @core.reconcile(old_child, new_child, counter, trace_ref~)
+        Some(old_child) =>
+          @core.reconcile(old_child, new_child, counter, trace_ref~)
         None => @core.assign_fresh_ids(new_child, counter)
       }
     None => @core.assign_fresh_ids(new_child, counter)

--- a/lang/lambda/proj/projection_memo.mbt
+++ b/lang/lambda/proj/projection_memo.mbt
@@ -36,12 +36,13 @@ fn reconcile_module_child_hinted(
   matched_index : Int?,
   counter : Ref[Int],
   hints : Map[@core.NodeId, @core.IdentityTransform],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> @core.ProjNode[@ast.Term] {
   match matched_index {
     Some(i) =>
       match old_children.get(i) {
         Some(old_child) =>
-          @core.reconcile_hinted(old_child, new_child, counter, hints)
+          @core.reconcile_hinted(old_child, new_child, counter, hints, trace_ref~)
         None => @core.assign_fresh_ids(new_child, counter)
       }
     None => @core.assign_fresh_ids(new_child, counter)
@@ -57,14 +58,15 @@ fn reconcile_lambda_projection_hinted(
   new_ : @core.ProjNode[@ast.Term],
   counter : Ref[Int],
   hints : Map[@core.NodeId, @core.IdentityTransform],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> @core.ProjNode[@ast.Term] {
   match (old.kind, new_.kind) {
     (Module(old_defs, _), Module(new_defs, _)) => {
       guard old.children.get(old_defs.length()) is Some(old_body) else {
-        return @core.reconcile_hinted(old, new_, counter, hints)
+        return @core.reconcile_hinted(old, new_, counter, hints, trace_ref~)
       }
       guard new_.children.get(new_defs.length()) is Some(new_body) else {
-        return @core.reconcile_hinted(old, new_, counter, hints)
+        return @core.reconcile_hinted(old, new_, counter, hints, trace_ref~)
       }
       let new_matched = module_key_match(
         old_defs.map(def => def.0),
@@ -78,13 +80,14 @@ fn reconcile_lambda_projection_hinted(
             new_matched[j],
             counter,
             hints,
+            trace_ref~,
           )
         }
       ]
-      children.push(@core.reconcile_hinted(old_body, new_body, counter, hints))
+      children.push(@core.reconcile_hinted(old_body, new_body, counter, hints, trace_ref~))
       @core.ProjNode(new_.kind, new_.start, new_.end, old.node_id, children)
     }
-    _ => @core.reconcile_hinted(old, new_, counter, hints)
+    _ => @core.reconcile_hinted(old, new_, counter, hints, trace_ref~)
   }
 }
 
@@ -100,6 +103,7 @@ fn reconcile_lambda_projection_hinted(
 pub fn build_lambda_projection_memos(
   parser : @loom.Parser[@ast.Term],
   identity_hints? : Ref[Array[@core.IdentityTransform]],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> (
   @incr.Derived[@core.ProjNode[@ast.Term]?],
   @incr.Derived[Map[@core.NodeId, @core.ProjNode[@ast.Term]]],
@@ -110,16 +114,17 @@ pub fn build_lambda_projection_memos(
     parser.syntax_tree(),
     to_proj_node,
     populate_token_spans,
-    reconcile_node=fn(old, new_, counter) {
+    reconcile_node=fn(old, new_, counter, tr) {
       match identity_hints {
-        None => reconcile_lambda_projection(old, new_, counter)
+        None => reconcile_lambda_projection(old, new_, counter, trace_ref=tr)
         Some(hints_ref) => {
           let hints = build_hints_map(hints_ref.val)
           hints_ref.val = [] // T4: cleared exactly once per reparse
-          reconcile_lambda_projection_hinted(old, new_, counter, hints)
+          reconcile_lambda_projection_hinted(old, new_, counter, hints, trace_ref=tr)
         }
       }
     },
+    trace_ref=trace_ref,
     label="lambda",
   )
 }
@@ -166,11 +171,12 @@ fn reconcile_module_child(
   new_child : @core.ProjNode[@ast.Term],
   matched_index : Int?,
   counter : Ref[Int],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> @core.ProjNode[@ast.Term] {
   match matched_index {
     Some(i) =>
       match old_children.get(i) {
-        Some(old_child) => @core.reconcile(old_child, new_child, counter)
+        Some(old_child) => @core.reconcile(old_child, new_child, counter, trace_ref~)
         None => @core.assign_fresh_ids(new_child, counter)
       }
     None => @core.assign_fresh_ids(new_child, counter)
@@ -187,14 +193,15 @@ fn reconcile_lambda_projection(
   old : @core.ProjNode[@ast.Term],
   new_ : @core.ProjNode[@ast.Term],
   counter : Ref[Int],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> @core.ProjNode[@ast.Term] {
   match (old.kind, new_.kind) {
     (Module(old_defs, _), Module(new_defs, _)) => {
       guard old.children.get(old_defs.length()) is Some(old_body) else {
-        return @core.reconcile(old, new_, counter)
+        return @core.reconcile(old, new_, counter, trace_ref~)
       }
       guard new_.children.get(new_defs.length()) is Some(new_body) else {
-        return @core.reconcile(old, new_, counter)
+        return @core.reconcile(old, new_, counter, trace_ref~)
       }
       let new_matched = module_key_match(
         old_defs.map(def => def.0),
@@ -207,12 +214,13 @@ fn reconcile_lambda_projection(
             new_.children[j],
             new_matched[j],
             counter,
+            trace_ref~,
           )
         }
       ]
-      children.push(@core.reconcile(old_body, new_body, counter))
+      children.push(@core.reconcile(old_body, new_body, counter, trace_ref~))
       @core.ProjNode(new_.kind, new_.start, new_.end, old.node_id, children)
     }
-    _ => @core.reconcile(old, new_, counter)
+    _ => @core.reconcile(old, new_, counter, trace_ref~)
   }
 }

--- a/lang/markdown/proj/move_reconcile.mbt
+++ b/lang/markdown/proj/move_reconcile.mbt
@@ -33,9 +33,10 @@ fn reconcile_markdown_projection_hinted(
   new_ : @core.ProjNode[@markdown.Block],
   counter : Ref[Int],
   hints : Map[@core.NodeId, @core.IdentityTransform],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> @core.ProjNode[@markdown.Block] {
   if hints.is_empty() || !has_move_hint(hints) {
-    return @core.reconcile_hinted(old, new_, counter, hints)
+    return @core.reconcile_hinted(old, new_, counter, hints, trace_ref~)
   }
   if @loomcore.TreeNode::same_kind(old.kind, new_.kind) &&
     is_block_container(new_.kind) {
@@ -49,10 +50,11 @@ fn reconcile_markdown_projection_hinted(
         new_.children,
         counter,
         hints,
+        trace_ref~,
       ),
     )
   }
-  @core.reconcile_hinted(old, new_, counter, hints)
+  @core.reconcile_hinted(old, new_, counter, hints, trace_ref~)
 }
 
 ///|
@@ -73,6 +75,7 @@ fn reconcile_markdown_children_hinted(
   new_children : Array[@core.ProjNode[@markdown.Block]],
   counter : Ref[Int],
   hints : Map[@core.NodeId, @core.IdentityTransform],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> Array[@core.ProjNode[@markdown.Block]] {
   let old_len = old_children.length()
   let new_len = new_children.length()
@@ -125,6 +128,7 @@ fn reconcile_markdown_children_hinted(
           new_children[k],
           counter,
           hints,
+          trace_ref~,
         )
       } else {
         match
@@ -136,6 +140,7 @@ fn reconcile_markdown_children_hinted(
             consumed,
             counter,
             hints,
+            trace_ref~,
           ) {
           Some(node) => node
           None => @core.assign_fresh_ids(new_children[k], counter)
@@ -196,6 +201,7 @@ fn markdown_move_pair(
   consumed : Map[@core.NodeId, Bool],
   counter : Ref[Int],
   hints : Map[@core.NodeId, @core.IdentityTransform],
+  trace_ref? : Ref[Array[@core.ReconcileTraceEvent]]? = None,
 ) -> @core.ProjNode[@markdown.Block]? {
   let candidates = [
     for idx, old_child in old_children if old_matched[idx] < 0 &&
@@ -218,6 +224,7 @@ fn markdown_move_pair(
             new_child.children,
             counter,
             hints,
+            trace_ref~,
           ),
         ),
       )

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -168,11 +168,17 @@ fn build_markdown_projection_memos_with_heading_side_table(
     populate_token_spans,
     reconcile_node=(old, new_, counter, trace_ref) => {
       match identity_hints {
-        None => @core.reconcile(old, new_, counter, trace_ref=trace_ref)
+        None => @core.reconcile(old, new_, counter, trace_ref~)
         Some(hints_ref) => {
           let hints = build_markdown_hints_map(hints_ref.val)
           hints_ref.val = []
-          reconcile_markdown_projection_hinted(old, new_, counter, hints, trace_ref=trace_ref)
+          reconcile_markdown_projection_hinted(
+            old,
+            new_,
+            counter,
+            hints,
+            trace_ref~,
+          )
         }
       }
     },

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -166,13 +166,13 @@ fn build_markdown_projection_memos_with_heading_side_table(
     parser.syntax_tree(),
     syntax_to_proj_node,
     populate_token_spans,
-    reconcile_node=(old, new_, counter) => {
+    reconcile_node=(old, new_, counter, trace_ref) => {
       match identity_hints {
-        None => @core.reconcile(old, new_, counter)
+        None => @core.reconcile(old, new_, counter, trace_ref=trace_ref)
         Some(hints_ref) => {
           let hints = build_markdown_hints_map(hints_ref.val)
           hints_ref.val = []
-          reconcile_markdown_projection_hinted(old, new_, counter, hints)
+          reconcile_markdown_projection_hinted(old, new_, counter, hints, trace_ref=trace_ref)
         }
       }
     },


### PR DESCRIPTION
## Summary

Wires the reconciliation trace from `build_projection_memos` into the Ideal editor's Patch panel, displaying structural changes (Inserted/Deleted/Wrapped/Unwrapped) as a `<details>` section above the `SpanEdit` log entries.

### Key fixes

- **Fixed `reconcile_node` signature** in `build_projection_memos`: changed from 3-arg to 4-arg (adds `trace_ref`), **always calls `reconcile_node`** (previously swapped to default `reconcile` when `trace_ref` was `Some` — silently disabling Lambda's hint-based reconciliation)
- **Threaded `trace_ref`** through all reconcile paths in Lambda and Markdown projections
- **Stored trace** in `LambdaCompanion`, exposed via `get_structured_changes()`

### Display format

Shows source text snippets at affected positions instead of raw NodeIds:

```
+ Var 'x'              — inserted node
- Lambda '(fn x => x)' — deleted node  
⊞ Lambda '...'         — wrapped in a Lambda
⊟ Lambda '...'         — unwrapped Lambda
→ Var 'x'              — renamed
~ Var 'x'              — freshened
```

### Verification

- `moon check` passes on all 5 affected packages
- 119/119 core tests pass
- `moon check --deny-warn` clean on core/
- Formatting and `.mbti` reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Patch panel now shows a “Structural changes” section with clearer labels and source snippets for reconciliation-driven edits.
  * Added structured change details to editor reconciliation so more change types can be displayed in the UI.
* **Bug Fixes**
  * Reconciliation now preserves and forwards trace information more consistently across projection updates, improving the accuracy of displayed diff details.
* **Documentation**
  * Marked the structured diff display work as completed in the project notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->