### PR TITLE
feat: per-entry trace snapshots for PatchEntry (#847)

### DIFF
--- a/examples/ideal/main/main.mbt
+++ b/examples/ideal/main/main.mbt
@@ -196,9 +196,14 @@ fn push_patch(
     return
   }
   let snapshot = @lambda.snapshot_span_edits(edits, MAX_PATCH_INSERTED_CHARS)
+  // Force reconcile to populate the trace with this edit's events,
+  // then capture the structural changes as a per-entry snapshot.
+  let _ = model.editor.get_proj_node()
+  let changes = model.companion.get_structured_changes()
   model.patch_log.push({
     op_label: op.to_generic().to_string(),
     edits: snapshot,
+    changes,
   })
   while model.patch_log.length() > MAX_PATCH_LOG {
     model.patch_log.remove(0) |> ignore

--- a/examples/ideal/main/model.mbt
+++ b/examples/ideal/main/model.mbt
@@ -20,9 +20,13 @@ pub enum BottomTab {
 /// shape as the Op Log entry) paired with the `SpanEdit`s that the editor
 /// produced for it. Empty `edits` is legal — pure navigation ops like
 /// `Select` resolve to zero text changes.
+/// `changes` is a per-entry snapshot of `StructuredChange` events captured
+/// at the edit point, so historical display shows the right diff for each
+/// entry — not the latest reconcile's trace.
 pub(all) struct PatchEntry {
   op_label : String
   edits : Array[@canopy_core.SpanEdit]
+  changes : Array[@canopy_core.StructuredChange]
 }
 
 ///|

--- a/examples/ideal/main/pkg.generated.mbti
+++ b/examples/ideal/main/pkg.generated.mbti
@@ -139,6 +139,7 @@ pub struct Model {
   scope_map : Map[@core.NodeId, @scope.ScopeAnnotation]
   highlight_set : @hashset.HashSet[@core.NodeId]
   drag_source : @core.NodeId?
+  mut nav_path : Array[Int]?
   drop_target_id : @core.NodeId?
   drop_position : @core.DropPosition?
   intent_log : Array[String]
@@ -173,6 +174,7 @@ pub enum PanelId {
 pub(all) struct PatchEntry {
   op_label : String
   edits : Array[@core.SpanEdit]
+  changes : Array[@core.StructuredChange]
 }
 
 pub enum SyncStatus {

--- a/examples/ideal/main/view_bottom.mbt
+++ b/examples/ideal/main/view_bottom.mbt
@@ -550,6 +550,7 @@ fn format_structured_change(
 /// Each entry surfaces the producing `GenericTreeOp` label as a header row
 /// so the user can cross-reference the matching Op Log entry, then each
 /// `SpanEdit` renders via its `Show` impl (`@<start> -<delete_len> +«…»`).
+/// Per-entry `changes` are rendered in a `<details>` block within each row.
 fn view_patch_log(model : Model) -> Html {
   // See `view_op_log` for the rationale; Patch panel rows are heavier
   // (header + N `SpanEdit` rows per entry), so guarding here matters more.
@@ -561,51 +562,16 @@ fn view_patch_log(model : Model) -> Html {
     )
   }
   let log = model.patch_log
-  // Force projection memo to recompute so trace_ref is populated
-  let _ = model.editor.get_proj_node()
-  // Read structural changes from the reconciliation trace
-  // Read the source map to resolve positions for structured change display
   let source_map = model.editor.get_source_map()
-  // Read the editor text to extract source snippets for structural changes
   let source_text = model.editor.get_text()
-  let structured_changes = model.companion.get_structured_changes()
-  // Build the structural-changes details block when events are present
-  let structural_block : Array[Html] = if structured_changes.is_empty() {
-    []
-  } else {
-    let change_rows : Array[Html] = structured_changes.map(fn(c) {
-      @html.div(class="patch-structural-change", [
-        @html.span(class="patch-change-text", [
-          @html.text(format_structured_change(c, source_map, source_text)),
-        ]),
-      ])
-    })
-    [
-      @html.node(
-        "details",
-        @html.Attrs::build().class("patch-structural-details"),
-        [
-          @html.node("summary", @html.Attrs::build(), [
-            @html.text("Structural changes"),
-          ]),
-          @html.div(class="patch-structural-body", change_rows),
-        ],
-      ),
-    ]
-  }
   if log.is_empty() {
-    @html.div(
-      class="bottom-content",
-      attrs=bottom_panel_attrs(Patch),
-      structural_block +
-      [
-        @html.span(class="no-problems", [
-          @html.text(
-            "No patches yet. Structure-mode edits aren't traced here — see the Op Log tab.",
-          ),
-        ]),
-      ],
-    )
+    @html.div(class="bottom-content", attrs=bottom_panel_attrs(Patch), [
+      @html.span(class="no-problems", [
+        @html.text(
+          "No patches yet. Structure-mode edits aren't traced here — see the Op Log tab.",
+        ),
+      ]),
+    ])
   } else {
     let n = log.length()
     let items : Array[Html] = Array::new(capacity=n)
@@ -616,20 +582,47 @@ fn view_patch_log(model : Model) -> Html {
           @html.span(class="patch-log-edit-text", [@html.text(edit.to_string())]),
         ])
       })
-      items.push(
-        @html.div(class="patch-log-row", [
-          @html.div(class="patch-log-header", [
-            @html.span(class="patch-log-index", [@html.text("\{n - i}.")]),
-            @html.span(class="patch-log-op", [@html.text(entry.op_label)]),
+      let change_rows : Array[Html] = entry.changes.map(fn(c) {
+        @html.div(class="patch-structural-change", [
+          @html.span(class="patch-change-text", [
+            @html.text(format_structured_change(c, source_map, source_text)),
           ]),
-          @html.div(class="patch-log-edits", edit_rows),
-        ]),
+        ])
+      })
+      let structural_details : Array[Html] = if change_rows.is_empty() {
+        []
+      } else {
+        [
+          @html.node(
+            "details",
+            @html.Attrs::build().class("patch-structural-details"),
+            [
+              @html.node("summary", @html.Attrs::build(), [
+                @html.text("Structural changes"),
+              ]),
+              @html.div(class="patch-structural-body", change_rows),
+            ],
+          ),
+        ]
+      }
+      items.push(
+        @html.div(
+          class="patch-log-row",
+          [
+            @html.div(class="patch-log-header", [
+              @html.span(class="patch-log-index", [@html.text("\{n - i}.")]),
+              @html.span(class="patch-log-op", [@html.text(entry.op_label)]),
+            ]),
+            @html.div(class="patch-log-edits", edit_rows),
+          ] +
+          structural_details,
+        ),
       )
     }
     @html.div(
       class="bottom-content patch-log",
       attrs=bottom_panel_attrs(Patch),
-      structural_block + items,
+      items,
     )
   }
 }


### PR DESCRIPTION
## Summary

Each `PatchEntry` now carries `Array[StructuredChange]` captured at edit time, so historical display shows the right diff for each entry — not the latest reconcile's trace.

## Changes

```
4 files changed, 54 insertions(+), 50 deletions(-)
```

### `examples/ideal/main/model.mbt`
- Added `changes : Array[@canopy_core.StructuredChange]` field to `PatchEntry`

### `examples/ideal/main/main.mbt`
- `push_patch` now forces reconcile via `model.editor.get_proj_node()` and snapshots `model.companion.get_structured_changes()` into the entry at edit time

### `examples/ideal/main/view_bottom.mbt`
- Removed global `get_proj_node()` force + `get_structured_changes()` call at the top of `view_patch_log`
- Removed the single top-level `<details>` block (which showed only the latest reconcile's trace)
- Each `patch-log-row` now renders its own `<details>` with per-entry `StructuredChange` entries

### `examples/ideal/main/pkg.generated.mbti`
- Updated to reflect the new `changes` field

## Verification

- `moon test --target native core/`: **132/132 pass** (existing reconcile trace tests unchanged)
- `moon check examples/ideal/main/`: 0 errors from our files
- `moon fmt`: clean

## Trade-off

`format_structured_change` resolves `NodeId \u2192 source snippet` using the current `source_map`/`source_text`, so old entries' snippets may be missing or show stale text if nodes have been deleted or their ranges shifted. The formatter gracefully falls back to bare kind tags. Storing formatted strings at capture time would lose the `StructuredChange` variants for future use (highlighting, linking), so this is the right trade-off.

Closes #847