### PR TITLE
feat(editor): word-navigation policy over raw UAX #29 boundaries (experimental)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -443,8 +443,14 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [x] **Restore non-BMP §4.3 cluster-fusing-cursor tests.**
   Resolved (follow-up): `editor/sync_editor_text_wbtest.mbt` now pins `"🇯🇵🇺🇸" + apply_text_edit(4, 0, "🇮") → cursor 8` and `"👩💻" + insert_at(2, "\u{200D}") → cursor 5`.
 
-- [ ] **Word-navigation policy on top of moji's raw UAX boundaries.** moji exposes spec-correct UAX #29 word boundaries (every transition between word/whitespace/punctuation). Editor word-navigation typically wants different semantics — skip whitespace, treat punctuation as part of the word in some contexts, optionally split camelCase/snake_case. Plan: define the policy as a wrapper around `move_cursor_left_word` / `_right_word` in `editor/sync_editor_text.mbt`. Spec §6.3 deliberately deferred this; pick a default policy (Sublime/VS Code-style is a reasonable starting point) and ship behind a config flag if needed.
-  Status: not blocked; standalone canopy-side work.
+- [x] **Word-navigation policy on top of moji's raw UAX boundaries.** moji exposes spec-correct UAX #29 word boundaries (every transition between word/whitespace/punctuation). Editor word-navigation typically wants different semantics — skip whitespace, treat punctuation as part of the word in some contexts, optionally split camelCase/snake_case. Plan: define the policy as a wrapper around `move_cursor_left_word` / `_right_word` in `editor/sync_editor_text.mbt`. Spec §6.3 deliberately deferred this; pick a default policy (Sublime/VS Code-style is a reasonable starting point) and ship behind a config flag if needed.
+  Shipped 2026-07-05 (**experimental** — may be deleted; disposal inventory in
+  `docs/plans/2026-07-05-word-navigation-policy.md`): VS Code-style policy in
+  `editor/word_nav.mbt` (`priv` stop-finders; no config flag — camelCase/
+  snake_case and script-boundary CJK splitting are named follow-ups in the
+  spec, deliberately unbuilt). Landings post-snap to grapheme boundaries,
+  fixing a latent defect (raw UAX word boundaries can fall inside clusters,
+  e.g. GCB=Prepend). Codex-validated design; moji contract unchanged.
 
 - [ ] (perf, P3) `editor/sync_editor_text.mbt::utf16_offset_to_item_pos` is O(n) per call and runs on every mutation path; `gcb_of` does up to 13 binary searches per codepoint; `next/prev_grapheme_boundary` rebuild the boundary array each call (O(n²) for tight loops). Acceptable for canopy's short strings today; documented in `loom/moji/grapheme.mbt` and `loom/moji/README.md`. Concrete fixes when a hot-path actually needs them: ASCII fast path in `gcb_of` (only CR/LF/Control populate `< 0x80`), drop `ch.to_string().length()` allocation in `utf16_offset_to_item_pos` (use `if ch.to_int() >= 0x10000 { 2 } else { 1 }`), and a materialise-once boundary cache for hot callers.
   Status: not blocking; cosmetic perf debt.

--- a/docs/plans/2026-07-05-word-navigation-policy.md
+++ b/docs/plans/2026-07-05-word-navigation-policy.md
@@ -10,8 +10,9 @@ of moji's raw UAX boundaries").
 generate usage signal on its own (zero consumers reach these methods), so
 the review judges consumer existence, not "experiment success". Delete per
 the disposal inventory below **unless** by 2026-08-05 either (a) some
-surface actually binds word navigation to these methods, or (b) a concrete
-plan (GitHub issue) for a headless `SyncEditor` consumer exists. The
+surface actually binds word navigation to these methods, or (b) an open
+GitHub issue, linked from TODO §16, names a headless `SyncEditor` consumer
+and the surface that will bind these methods. The
 grapheme post-snap survives deletion regardless (pre-existing bug fix).
 Do not let the library-framing KEEP default override this rule — the rule
 was set precisely because that default would otherwise decide by inertia.
@@ -62,7 +63,7 @@ the canonical surface before any consumer binds to it.
 | Left-word landing | **Start** of current/previous unit |
 | Whitespace | Never a stop target; always skipped |
 | Punctuation | A run of punctuation/symbols is one stop unit |
-| CJK | Merged into `Other` runs — one stop per run (VS Code default). Script-boundary splitting is a named follow-up, not built now |
+| CJK | Han/Hiragana (WB=Other) stretches merge into `Other` runs — one stop per run (VS Code default); Katakana has its own WB class and stays `Word`. Script-boundary splitting is a named follow-up, not built now |
 | camelCase / snake_case sub-word | Deferred entirely; **no config flag** (YAGNI — zero consumers) |
 | Word-delete / selection | Out of scope; the pure stop-finders are the reserved extension point |
 
@@ -77,8 +78,10 @@ the canonical surface before any consumer binds to it.
      Pure functions of their arguments; no `SyncEditor` dependency.
 2. **`editor/sync_editor_text.mbt`** — the two existing `SyncEditor` word
    methods are rewritten in place to delegate to the stop-finders. Their
-   signatures and the existing top/bottom guards (`cursor == 0`,
-   `cursor == text.length()`) are unchanged. No consumers exist today
+   signatures are unchanged; the old top/bottom guards (`cursor == 0`,
+   `cursor == text.length()`) are removed as redundant — the stop-finders
+   are total and their fallbacks (`0` / `text.length()`) enforce the same
+   edge behavior. No consumers exist today
    (verified 2026-07-04: no FFI export, no example/TS caller), so the
    behavior change has zero blast radius.
 
@@ -108,9 +111,11 @@ invisible character a stop target. Non-BMP codepoints are read with
 
 ### Unit merging
 
-Adjacent `Other` segments merge into one unit. (`Word` segments are already
-maximal runs under UAX; `Whitespace` needs no merging because it is never a
-target.) Merging makes `->`, `...`, and a CJK stretch each a single stop.
+Only adjacent `Other` segments merge into one unit; `Word` segments are
+kept exactly as UAX emits them, so adjacent `Word` units can exist (e.g.
+ALetter ÷ Katakana in `"abcカナ"` — pinned by test) and each is its own
+stop. `Whitespace` needs no merging because it is never a target. Merging
+makes `->`, `...`, and a Han/Hiragana stretch each a single stop.
 
 ### Navigation semantics
 

--- a/docs/plans/2026-07-05-word-navigation-policy.md
+++ b/docs/plans/2026-07-05-word-navigation-policy.md
@@ -22,6 +22,17 @@ word start (left) / word end (right).
 moji's contract stays raw — the policy lives entirely in the `editor`
 package as a wrapper. No moji API changes.
 
+### Consumer framing (user decision 2026-07-05)
+
+No current front-end reaches these methods: CodeMirror surfaces handle word
+navigation client-side, the canvas example uses a native `<input>`, and
+there is no FFI export. The intended consumer is **canopy as a headless
+editor-engine library** — future self-drawn / TUI / embedded editor
+surfaces that drive `SyncEditor` directly. Under that framing these methods
+are canonical engine API, and shipping raw UAX #29 behavior behind them is
+a library trap (call it and get broken navigation); this policy layer fixes
+the canonical surface before any consumer binds to it.
+
 ## Decisions (interview 2026-07-05)
 
 | Axis | Decision |

--- a/docs/plans/2026-07-05-word-navigation-policy.md
+++ b/docs/plans/2026-07-05-word-navigation-policy.md
@@ -1,0 +1,153 @@
+# Word-Navigation Policy over Raw UAX #29 Boundaries
+
+**Status:** Design approved 2026-07-05 (interview-driven brainstorm). Closes the
+first unchecked item of [TODO §16](../TODO.md) ("Word-navigation policy on top
+of moji's raw UAX boundaries").
+
+**GitHub context:** [#216](https://github.com/dowdiness/canopy/issues/216)
+(Unicode Text Correctness), moji shipped in
+[#251](https://github.com/dowdiness/canopy/pull/251).
+
+## Problem
+
+`SyncEditor::move_cursor_left_word` / `move_cursor_right_word`
+(`editor/sync_editor_text.mbt`) currently call `@moji.prev_word_boundary` /
+`next_word_boundary` directly. Raw UAX #29 word boundaries mark **every**
+transition between word, whitespace, and punctuation segments — so raw
+navigation stops at the edge of each whitespace run and at every individual
+punctuation character. No editor user wants that. Editors layer a policy on
+top: skip whitespace, treat punctuation runs as navigable units, land at
+word start (left) / word end (right).
+
+moji's contract stays raw — the policy lives entirely in the `editor`
+package as a wrapper. No moji API changes.
+
+## Decisions (interview 2026-07-05)
+
+| Axis | Decision |
+|------|----------|
+| Reference semantics | VS Code / Sublime style |
+| Right-word landing | **End** of current/next unit (not next unit's start) |
+| Left-word landing | **Start** of current/previous unit |
+| Whitespace | Never a stop target; always skipped |
+| Punctuation | A run of punctuation/symbols is one stop unit |
+| CJK | Merged into `Other` runs — one stop per run (VS Code default). Script-boundary splitting is a named follow-up, not built now |
+| camelCase / snake_case sub-word | Deferred entirely; **no config flag** (YAGNI — zero consumers) |
+| Word-delete / selection | Out of scope; the pure stop-finders are the reserved extension point |
+
+## Design
+
+### Components
+
+1. **`editor/word_nav.mbt`** (new file) — the policy layer:
+   - A `priv` three-way segment classification: `Whitespace`, `Word`, `Other`.
+   - Two `priv` pure stop-finders, `(text : String, pos : Int) -> Int`:
+     one for the next right-word stop, one for the previous left-word stop.
+     Pure functions of their arguments; no `SyncEditor` dependency.
+2. **`editor/sync_editor_text.mbt`** — the two existing `SyncEditor` word
+   methods are rewritten in place to delegate to the stop-finders. Their
+   signatures and the existing top/bottom guards (`cursor == 0`,
+   `cursor == text.length()`) are unchanged. No consumers exist today
+   (verified 2026-07-04: no FFI export, no example/TS caller), so the
+   behavior change has zero blast radius.
+
+### Classification rule
+
+A raw UAX segment (the span between two consecutive entries of
+`@moji.word_boundaries(text)`) is classified by its **first
+non-default-ignorable codepoint** (skipping codepoints where
+`@moji.is_default_ignorable_code_point` holds):
+
+- `Whitespace` — the codepoint satisfies `Char::is_whitespace` (Unicode
+  White_Space property). This predicate, not `wb_of`, decides whitespace:
+  tab (U+0009) has `WB=Other` and would otherwise become a stop target.
+- `Word` — `@moji.wb_of` is one of `WbALetter`, `WbHebrewLetter`,
+  `WbKatakana`, `WbNumeric`, `WbExtendNumLet`.
+- `Other` — everything else: punctuation, symbols, Han/Hiragana ideographs,
+  emoji.
+- A segment consisting **entirely** of default-ignorable codepoints
+  classifies as `Whitespace` (skipped, never a stop target).
+
+Skipping default-ignorable codepoints is load-bearing (Codex validation
+2026-07-05): UAX WB4 does *not* attach Format chars at text start or after
+hard breaks, so e.g. `"\n\u{200E}a"` yields a raw segment led by an
+invisible LRM — naive first-codepoint classification would make an
+invisible character a stop target. Non-BMP codepoints are read with
+`@moji.decode_codepoint_at`.
+
+### Unit merging
+
+Adjacent `Other` segments merge into one unit. (`Word` segments are already
+maximal runs under UAX; `Whitespace` needs no merging because it is never a
+target.) Merging makes `->`, `...`, and a CJK stretch each a single stop.
+
+### Navigation semantics
+
+Over the classified, merged unit list:
+
+- **Right:** land at the end of the first non-whitespace unit whose end is
+  strictly greater than the cursor. If none exists, land at `text.length()`.
+  This yields VS Code behavior in both cases: mid-word → that word's end;
+  at a word end → skip whitespace, land at the next unit's end.
+- **Left:** land at the start of the last non-whitespace unit whose start is
+  strictly less than the cursor. If none exists, land at `0`.
+
+Landing positions are raw UAX word boundaries, but word boundaries are
+**not** always grapheme-cluster boundaries (Codex validation 2026-07-05:
+U+0600 ARABIC NUMBER SIGN is GCB=Prepend / WB=Numeric, so `"\u{600}!"` has a
+word boundary inside one grapheme cluster). To preserve the editor's
+cursor-on-boundary invariant, each landing is post-snapped: right-word
+through `@moji.next_grapheme_boundary` (at-or-after), left-word through
+`@moji.prev_grapheme_boundary` (at-or-before). Both are no-ops in the
+common case. Note the shipped raw methods lack this snap — the rewrite
+fixes that latent defect.
+
+### Error handling
+
+None required: the stop-finders are total functions. Out-of-range cursor
+positions are clamped by the scan formulation itself (`> cursor` / `< cursor`
+comparisons); empty text yields the trivial boundary list and the fallback
+landings (`0` / `text.length()`).
+
+### Performance
+
+One `@moji.word_boundaries` materialization per keypress plus an O(n)
+classification scan — the same complexity class as every existing mutation
+path in this file (`utf16_offset_to_item_pos` is O(n) per call). TODO §16's
+P3 perf item explicitly defers optimization of this class until a measured
+hot path exists (moonbit-perf-investigation gate).
+
+## Testing
+
+- **`editor/word_nav_wbtest.mbt`** (new) — pure stop-finder fixtures:
+  - `"foo bar"` — basic left/right from various offsets (mid-word, at
+    boundaries, at ends).
+  - `"foo->bar"` — punctuation run is one stop unit.
+  - `"foo   bar"`, `"foo\tbar"`, `"foo\nbar"` — whitespace runs (space, tab,
+    newline) skipped, never a target.
+  - `"  foo  "` — leading/trailing whitespace: left from inside leading ws →
+    0; right from inside trailing ws → length.
+  - `""`, all-whitespace text — fallback landings.
+  - CJK: hiragana/kanji stretch = one `Other` unit; katakana run = one
+    `Word` unit; mixed `"日本語 test"` pins the merge behavior.
+  - Emoji + non-BMP: a fixture with an astral-plane codepoint pinning
+    UTF-16 offsets (offsets count code units).
+  - Codex-validation counterexamples: `"\u{600}!"` (landing post-snapped to
+    a grapheme boundary), `"\n\u{200E}a"` and `"\u{200E}a"` (default-
+    ignorable-led segments never become stop targets).
+- **`editor/sync_editor_text_wbtest.mbt`** (existing) — two or three
+  `SyncEditor`-level integration cases confirming the methods delegate
+  correctly and respect the existing guards.
+
+Expected values are worked out by hand from the raw boundary lists (draw the
+segment table per fixture), not computed by formula.
+
+## Follow-ups (named, not built)
+
+- **Script-boundary splitting for CJK** (kanji→hiragana boundary as a stop,
+  bunsetsu-ish navigation): layers on the same unit-merging step without API
+  change; requires a script-classification source moji does not expose today.
+- **Word-delete / word-selection** (`Ctrl+Backspace` family): reuse the pure
+  stop-finders; promote them from `priv` when the consumer appears.
+- **camelCase / snake_case sub-word stops**: VS Code gates these behind
+  separate commands, not the default; same here if ever wanted.

--- a/docs/plans/2026-07-05-word-navigation-policy.md
+++ b/docs/plans/2026-07-05-word-navigation-policy.md
@@ -1,8 +1,18 @@
 # Word-Navigation Policy over Raw UAX #29 Boundaries
 
-**Status:** Design approved 2026-07-05 (interview-driven brainstorm). Closes the
+**Status:** Design approved 2026-07-05 (interview-driven brainstorm).
+**Experimental** — user decision 2026-07-05: real chance of deletion within
+a month; the design is constrained to be cheap to throw away. Closes the
 first unchecked item of [TODO §16](../TODO.md) ("Word-navigation policy on top
 of moji's raw UAX boundaries").
+
+**Disposal inventory** (total cost of deletion): remove
+`editor/word_nav.mbt` + `editor/word_nav_wbtest.mbt`, revert the two
+`SyncEditor` method bodies to raw one-liners, drop the integration test
+blocks. No `.mbti` change either way (helpers are `priv`, method signatures
+unchanged); no FFI/TS/config/moji footprint. **Exception:** the grapheme
+post-snap in the two methods survives deletion — it fixes a pre-existing
+defect independent of the policy.
 
 **GitHub context:** [#216](https://github.com/dowdiness/canopy/issues/216)
 (Unicode Text Correctness), moji shipped in

--- a/docs/plans/2026-07-05-word-navigation-policy.md
+++ b/docs/plans/2026-07-05-word-navigation-policy.md
@@ -6,6 +6,16 @@ a month; the design is constrained to be cheap to throw away. Closes the
 first unchecked item of [TODO §16](../TODO.md) ("Word-navigation policy on top
 of moji's raw UAX boundaries").
 
+**Keep/delete decision rule (2026-08-05 review):** this feature cannot
+generate usage signal on its own (zero consumers reach these methods), so
+the review judges consumer existence, not "experiment success". Delete per
+the disposal inventory below **unless** by 2026-08-05 either (a) some
+surface actually binds word navigation to these methods, or (b) a concrete
+plan (GitHub issue) for a headless `SyncEditor` consumer exists. The
+grapheme post-snap survives deletion regardless (pre-existing bug fix).
+Do not let the library-framing KEEP default override this rule — the rule
+was set precisely because that default would otherwise decide by inertia.
+
 **Disposal inventory** (total cost of deletion): remove
 `editor/word_nav.mbt` + `editor/word_nav_wbtest.mbt`, revert the two
 `SyncEditor` method bodies to raw one-liners, drop the integration test

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -155,20 +155,16 @@ pub fn[T] SyncEditor::move_cursor_right_grapheme(self : SyncEditor[T]) -> Unit {
 }
 
 ///|
+/// Word-navigation policy (VS Code-style) over moji's raw UAX #29
+/// boundaries: left lands at word start, right at word end, whitespace is
+/// skipped, punctuation runs are single units. See `word_nav.mbt`.
 pub fn[T] SyncEditor::move_cursor_left_word(self : SyncEditor[T]) -> Unit {
-  if self.cursor == 0 {
-    return
-  }
-  self.cursor = @moji.prev_word_boundary(self.doc.text(), self.cursor - 1)
+  self.cursor = prev_word_stop(self.doc.text(), self.cursor)
 }
 
 ///|
 pub fn[T] SyncEditor::move_cursor_right_word(self : SyncEditor[T]) -> Unit {
-  let text = self.doc.text()
-  if self.cursor == text.length() {
-    return
-  }
-  self.cursor = @moji.next_word_boundary(text, self.cursor + 1)
+  self.cursor = next_word_stop(self.doc.text(), self.cursor)
 }
 
 ///|

--- a/editor/sync_editor_text_wbtest.mbt
+++ b/editor/sync_editor_text_wbtest.mbt
@@ -305,3 +305,33 @@ test "#216: set_text with non-BMP content stores full emoji" {
   inspect(editor.get_text(), content="😀")
   inspect(editor.get_cursor(), content="2")
 }
+
+///|
+/// Word navigation applies the policy layer (word_nav.mbt), not raw UAX
+/// boundaries: whitespace is skipped, right lands at word end.
+test "word navigation: policy semantics through SyncEditor" {
+  let editor = @probe.new_test_editor("test-agent")
+  editor.set_text("foo bar")
+  editor.move_cursor(0)
+  editor.move_cursor_right_word()
+  inspect(editor.get_cursor(), content="3") // end of "foo", not raw stop at 4
+  editor.move_cursor_right_word()
+  inspect(editor.get_cursor(), content="7")
+  editor.move_cursor_left_word()
+  inspect(editor.get_cursor(), content="4")
+  editor.move_cursor_left_word()
+  inspect(editor.get_cursor(), content="0")
+  editor.move_cursor_left_word() // at 0: stays
+  inspect(editor.get_cursor(), content="0")
+}
+
+///|
+/// Word navigation post-snaps to grapheme boundaries even where a raw UAX
+/// word boundary falls inside a cluster (U+0600 is Prepend/Numeric).
+test "word navigation: landing snapped to grapheme boundary" {
+  let editor = @probe.new_test_editor("test-agent")
+  editor.set_text("\u{600}!")
+  editor.move_cursor(0)
+  editor.move_cursor_right_word()
+  inspect(editor.get_cursor(), content="2") // not 1 (inside the cluster)
+}

--- a/editor/word_nav.mbt
+++ b/editor/word_nav.mbt
@@ -1,0 +1,83 @@
+// Word-navigation policy over moji's raw UAX #29 word boundaries.
+// Design: docs/plans/2026-07-05-word-navigation-policy.md (experimental —
+// see the spec's disposal inventory before extending this file).
+
+///|
+priv enum WordNavClass {
+  Whitespace
+  WordLike
+  Other
+} derive(Eq)
+
+///|
+/// Classify a raw UAX word segment `[start, end)` by its first
+/// non-default-ignorable codepoint. Segments made entirely of
+/// default-ignorable codepoints classify as `Whitespace` so invisible
+/// format characters never become stop targets.
+fn classify_segment(text : String, start : Int, end : Int) -> WordNavClass {
+  let mut i = start
+  while i < end {
+    let (cp, next_i) = @moji.decode_codepoint_at(text, i)
+    if !@moji.is_default_ignorable_code_point(cp) {
+      guard cp.to_char() is Some(ch) else { return Other }
+      if ch.is_whitespace() {
+        return Whitespace
+      }
+      return match @moji.wb_of(cp) {
+        WbALetter | WbHebrewLetter | WbKatakana | WbNumeric | WbExtendNumLet =>
+          WordLike
+        _ => Other
+      }
+    }
+    i = next_i
+  }
+  Whitespace
+}
+
+///|
+/// Classified stop units: raw UAX segments with adjacent `Other` segments
+/// merged, so a punctuation run or CJK stretch is one navigable unit.
+fn word_nav_units(text : String) -> Array[(WordNavClass, Int, Int)] {
+  let bounds = @moji.word_boundaries(text)
+  let units : Array[(WordNavClass, Int, Int)] = []
+  for i in 0..<(bounds.length() - 1) {
+    let start = bounds[i]
+    let end = bounds[i + 1]
+    let kind = classify_segment(text, start, end)
+    match units.last() {
+      Some((Other, merged_start, _)) if kind == Other =>
+        units[units.length() - 1] = (Other, merged_start, end)
+      _ => units.push((kind, start, end))
+    }
+  }
+  units
+}
+
+///|
+/// End of the first non-whitespace unit strictly right of `pos`
+/// (VS Code-style Ctrl+Right), post-snapped to a grapheme boundary
+/// because UAX word boundaries can fall inside grapheme clusters
+/// (e.g. GCB=Prepend codepoints).
+fn next_word_stop(text : String, pos : Int) -> Int {
+  for unit in word_nav_units(text) {
+    let (kind, _, end) = unit
+    if kind != Whitespace && end > pos {
+      return @moji.next_grapheme_boundary(text, end)
+    }
+  }
+  text.length()
+}
+
+///|
+/// Start of the last non-whitespace unit strictly left of `pos`
+/// (VS Code-style Ctrl+Left), post-snapped like `next_word_stop`.
+fn prev_word_stop(text : String, pos : Int) -> Int {
+  let units = word_nav_units(text)
+  for i = units.length() - 1; i >= 0; i = i - 1 {
+    let (kind, start, _) = units[i]
+    if kind != Whitespace && start < pos {
+      return @moji.prev_grapheme_boundary(text, start)
+    }
+  }
+  0
+}

--- a/editor/word_nav_wbtest.mbt
+++ b/editor/word_nav_wbtest.mbt
@@ -1,0 +1,138 @@
+// Fixtures for the word-navigation policy (docs/plans/2026-07-05-word-navigation-policy.md).
+// Expected values are hand-derived from each fixture's raw UAX #29 boundary
+// list (see the segment tables in the design doc's test plan).
+
+///|
+test "basic words: right lands at word end, left at word start" {
+  // "foo bar" — raw boundaries [0,3,4,7]; units foo(0,3) ws(3,4) bar(4,7)
+  let t = "foo bar"
+  inspect(next_word_stop(t, 0), content="3")
+  inspect(next_word_stop(t, 1), content="3")
+  inspect(next_word_stop(t, 3), content="7")
+  inspect(next_word_stop(t, 4), content="7")
+  inspect(next_word_stop(t, 7), content="7")
+  inspect(prev_word_stop(t, 7), content="4")
+  inspect(prev_word_stop(t, 5), content="4")
+  inspect(prev_word_stop(t, 4), content="0")
+  inspect(prev_word_stop(t, 3), content="0")
+  inspect(prev_word_stop(t, 0), content="0")
+}
+
+///|
+test "punctuation run is a single stop unit" {
+  // "foo->bar" — raw [0,3,4,5,8]; '-' and '>' merge into Other(3,5)
+  let t = "foo->bar"
+  inspect(next_word_stop(t, 0), content="3")
+  inspect(next_word_stop(t, 3), content="5")
+  inspect(next_word_stop(t, 4), content="5")
+  inspect(next_word_stop(t, 5), content="8")
+  inspect(prev_word_stop(t, 8), content="5")
+  inspect(prev_word_stop(t, 5), content="3")
+  inspect(prev_word_stop(t, 4), content="3")
+  inspect(prev_word_stop(t, 3), content="0")
+}
+
+///|
+test "whitespace runs are skipped, never targets" {
+  // "foo   bar" — raw [0,3,6,9]
+  let t = "foo   bar"
+  inspect(next_word_stop(t, 3), content="9")
+  inspect(next_word_stop(t, 4), content="9")
+  inspect(prev_word_stop(t, 6), content="0")
+  inspect(prev_word_stop(t, 9), content="6")
+  // tab has WB=Other but must classify as whitespace (Char::is_whitespace)
+  inspect(next_word_stop("foo\tbar", 3), content="7")
+  inspect(prev_word_stop("foo\tbar", 4), content="0")
+  // newline
+  inspect(next_word_stop("foo\nbar", 3), content="7")
+  inspect(prev_word_stop("foo\nbar", 4), content="0")
+}
+
+///|
+test "leading/trailing whitespace falls back to text edges" {
+  // "  foo  " — raw [0,2,5,7]
+  let t = "  foo  "
+  inspect(prev_word_stop(t, 1), content="0")
+  inspect(prev_word_stop(t, 2), content="0")
+  inspect(prev_word_stop(t, 7), content="2")
+  inspect(next_word_stop(t, 5), content="7")
+  inspect(next_word_stop(t, 0), content="5")
+}
+
+///|
+test "empty and all-whitespace text" {
+  inspect(next_word_stop("", 0), content="0")
+  inspect(prev_word_stop("", 0), content="0")
+  inspect(next_word_stop("   ", 0), content="3")
+  inspect(prev_word_stop("   ", 3), content="0")
+}
+
+///|
+test "CJK Other runs merge into one stop unit" {
+  // "日本語 test" — raw [0,1,2,3,4,8]; kanji merge to Other(0,3)
+  let t = "日本語 test"
+  inspect(next_word_stop(t, 0), content="3")
+  inspect(next_word_stop(t, 1), content="3")
+  inspect(next_word_stop(t, 3), content="8")
+  inspect(prev_word_stop(t, 8), content="4")
+  inspect(prev_word_stop(t, 4), content="0")
+  // hiragana+kanji stretch = one unit spanning the whole text
+  let u = "これは日本語です"
+  inspect(next_word_stop(u, 0), content="8")
+  inspect(prev_word_stop(u, 8), content="0")
+  inspect(next_word_stop(u, 3), content="8")
+  inspect(prev_word_stop(u, 3), content="0")
+}
+
+///|
+test "katakana is WordLike; adjacent Word units do not merge" {
+  // "abcカナ" — ALetter÷Katakana boundary; two Word units (0,3)(3,5)
+  let t = "abcカナ"
+  inspect(next_word_stop(t, 0), content="3")
+  inspect(next_word_stop(t, 3), content="5")
+  inspect(prev_word_stop(t, 5), content="3")
+  inspect(prev_word_stop(t, 3), content="0")
+}
+
+///|
+test "non-BMP offsets count UTF-16 code units" {
+  // "𝔞𝔟 x" — U+1D51E/U+1D51F are ALetter, 2 code units each; raw [0,4,5,6]
+  let t = "𝔞𝔟 x"
+  inspect(next_word_stop(t, 0), content="4")
+  inspect(prev_word_stop(t, 6), content="5")
+  inspect(prev_word_stop(t, 4), content="0")
+}
+
+///|
+test "emoji is an Other stop unit" {
+  // "a 🙂 b" — units a(0,1) ws(1,2) emoji(2,4) ws(4,5) b(5,6)
+  let t = "a 🙂 b"
+  inspect(next_word_stop(t, 1), content="4")
+  inspect(next_word_stop(t, 2), content="4")
+  inspect(next_word_stop(t, 4), content="6")
+  inspect(prev_word_stop(t, 5), content="2")
+  inspect(prev_word_stop(t, 2), content="0")
+}
+
+///|
+test "word boundary inside grapheme cluster is post-snapped" {
+  // "\u{600}!" — U+0600 is WB=Numeric / GCB=Prepend: word boundary at 1
+  // falls inside the single grapheme cluster (0,2). Landings must snap.
+  let t = "\u{600}!"
+  inspect(next_word_stop(t, 0), content="2")
+  inspect(prev_word_stop(t, 2), content="0")
+}
+
+///|
+test "default-ignorable chars never become stop targets" {
+  // "\n\u{200E}a" — LRM (default-ignorable, WB=Format) leads its own raw
+  // segment after a hard break; it must classify as skippable.
+  let t = "\n\u{200E}a"
+  inspect(next_word_stop(t, 0), content="3")
+  inspect(prev_word_stop(t, 3), content="2")
+  inspect(prev_word_stop(t, 2), content="0")
+  // text-start LRM
+  let u = "\u{200E}a"
+  inspect(next_word_stop(u, 0), content="2")
+  inspect(prev_word_stop(u, 2), content="1")
+}


### PR DESCRIPTION
## Summary

**Experimental** (real chance of deletion within a month — disposal inventory in the spec): VS Code-style word-navigation policy layered on moji's raw UAX #29 word boundaries, closing the word-navigation item of TODO §16 (#216).

- `editor/word_nav.mbt` (new): `priv` segment classification (`Whitespace`/`WordLike`/`Other` by first non-default-ignorable codepoint), adjacent-`Other` merging (punctuation runs and CJK stretches = one stop unit), and pure stop-finders. Left lands at word start, right at word end, whitespace always skipped.
- `SyncEditor::move_cursor_left_word` / `_right_word` rewritten to delegate. Landings post-snap to grapheme boundaries — raw UAX word boundaries can fall inside grapheme clusters (e.g. `U+0600` GCB=Prepend/WB=Numeric), so this also fixes a latent defect in the previous raw methods.
- Zero `.mbti` change; moji contract untouched (stays raw). No FFI/TS/config footprint.
- Design spec (Codex-validated; both validation counterexamples pinned as tests): `docs/plans/2026-07-05-word-navigation-policy.md`. Named follow-ups deliberately unbuilt: camelCase/snake_case sub-word stops, script-boundary CJK splitting, word-delete/selection.

## Reuse check

- Reused project APIs: `@moji.word_boundaries`, `wb_of`, `decode_codepoint_at`, `is_default_ignorable_code_point`, `next/prev_grapheme_boundary` (all existing moji surface; no new moji API).
- Core APIs checked: `Char::is_whitespace` (reused — decides whitespace, since tab is `WB=Other`), `Int::to_char` (reused — safe codepoint→Char), `Array::last` (reused in merge step). `Iter`/fold rejected for the merge loop: last-element in-place merge is a builder pattern.
- New helpers: `classify_segment`, `word_nav_units`, `next/prev_word_stop` — all `priv`, responsibility boundary = policy layer only (spec §Components).
- Remaining imperative code: codepoint-stepping `while` in `classify_segment` (decode-driven iteration), unit-array builder loop, reverse index scan in `prev_word_stop` — each justified in the spec's implementation policy terms.

## Testing

- 11 whitebox fixture tests (`word_nav_wbtest.mbt`) with hand-derived expected values, incl. tab/newline, CJK merge, katakana non-merge, non-BMP UTF-16 offsets, emoji, `U+0600`+`!` grapheme snap, LRM default-ignorable cases.
- 2 SyncEditor integration tests. Editor package 202/202; only pre-existing vendored rabbita failures elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental word-navigation behavior that skips whitespace, treats punctuation/symbol runs as single stops, and supports improved movement across Unicode text.
* **Bug Fixes**
  * Fixed word-jump landing so cursors snap to valid grapheme boundaries, avoiding positions inside character clusters.
* **Documentation**
  * Updated planning notes and marked the word-navigation item as complete.
* **Tests**
  * Added coverage for word movement across spaces, punctuation, CJK text, emoji, and other Unicode edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->