### PR TITLE
chore: update loom and incr to 0.14.2

### DIFF
--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -20,7 +20,7 @@
     },
     "dowdiness/incr": {
       "path": "../../loom/incr/incr",
-      "version": "0.14.0"
+      "version": "0.14.2"
     },
     "dowdiness/rabbita-menu": {
       "path": "../../lib/menu",

--- a/lib/cognition/moon.mod
+++ b/lib/cognition/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/cognition"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.14.0",
+  "dowdiness/incr@0.14.2",
 }
 
 repository = "https://github.com/dowdiness/canopy"

--- a/lib/visualizer/moon.mod
+++ b/lib/visualizer/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/visualizer"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.14.0",
+  "dowdiness/incr@0.14.2",
   "dowdiness/graphviz@0.1.0",
   "dowdiness/svg-dsl@0.1.0",
   "dowdiness/alga@0.3.0",

--- a/moon.mod
+++ b/moon.mod
@@ -6,7 +6,7 @@ import {
   "moonbitlang/quickcheck@0.14.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.16.8",
-  "dowdiness/incr@0.14.0",
+  "dowdiness/incr@0.14.2",
   "dowdiness/event-graph-walker@0.3.0",
   "dowdiness/byte_codec@0.1.0",
   "dowdiness/text_change@0.1.0",


### PR DESCRIPTION
## Summary

- update the vendored Loom submodule to the merge commit for Loom PR #677
- update Canopy's direct `dowdiness/incr` pins to `0.14.2`
- keep all workspace members on the `0.14` minor line

## Context

Loom #677 migrates the lambda typecheck pipeline to `Scope::on_dispose`, so runtime listeners are removed when the attachment scope is disposed. This consumes `dowdiness/incr v0.14.2`.

## Verification

- `NEW_MOON_MOD=0 moon update`
- `NEW_MOON_MOD=0 moon info`
- `NEW_MOON_MOD=0 moon fmt`
- `NEW_MOON_MOD=0 moon check`
- `NEW_MOON_MOD=0 moon test`
- `./scripts/check-shared-substrate.sh`
- `git diff --check`
