### PR TITLE
feat(jsx): lang/jsx/proj — CST to ProjNode[JsxNode] read-only projection

### DIFF
--- a/docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md
+++ b/docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md
@@ -621,63 +621,89 @@ subpackage, not `edits/` or `companion/`.
 **File:** `lang/jsx/proj/proj_node.mbt` (~60-120 lines, per the guide's own
 estimate for this step)
 
-- [ ] **Step 1:** `lang/jsx/proj/moon.pkg`:
+- [x] **Step 1:** `lang/jsx/proj/moon.pkg` — done 2026-07-11, added
+  `"dowdiness/jsx/syntax" @syntax` beyond this snippet (needed for
+  `AttrNode`/token-kind filtering in Steps 2 and Task 2.2). Also required
+  registering `dowdiness/jsx@0.1.0` in canopy's root `moon.mod` import
+  list (not just `moon.work` membership) — `moon check` failed with
+  "containing module is not imported" until both were added.
   ```
   import {
     "dowdiness/canopy/core" @core,
     "dowdiness/incr" @incr,
     "dowdiness/jsx" @jsx,
+    "dowdiness/jsx/syntax" @syntax,
     "dowdiness/loom" @loom,
     "dowdiness/loom/core" @loomcore,
     "dowdiness/seam" @seam,
   }
   ```
-- [ ] **Step 2:** Implement `syntax_to_proj_node` / `build_proj_tree`,
-  pattern-matching on `JsxNode`, following the guide's `Document(blocks)`
-  container-vs-leaf example (Element/Fragment are containers; Text/ExprSpan
-  are leaves).
-- [ ] **Step 3:** Add `parse_to_proj_node(text : String)` convenience
-  function per the guide's exact signature.
-- [ ] **Step 4:** `moon check`.
+- [x] **Step 2:** Implemented `syntax_to_proj_node` / `build_proj_tree` in
+  `proj_node.mbt`, done 2026-07-11. Container/leaf split follows
+  `JsxNode`'s own `TreeNode::children` grouping (`loom/examples/jsx/proj_traits.mbt`):
+  `Root`/`Fragment`/`Element` are containers, `Text`/`ExprSpan`/`Error` are
+  leaves — verified by direct read of `jsx_fold_node` in
+  `loom/examples/jsx/grammar.mbt` that this matches the CST shape.
+  Divergence from the guide's `Document(blocks)` example: `Element`'s CST
+  children interleave `AttrNode`s with content children (confirmed by
+  reading `jsx_fold_node`'s own `node.children().filter(c => c.kind() !=
+  attr_kind)` filtering), so `build_proj_tree` needs the same filter
+  (`element_content_children`) before the parallel walk — `Root`/`Fragment`
+  have no such filtering need. `fold_node` itself is reached via
+  `@jsx.jsx_grammar.fold_node` (a `Grammar` struct field), not a
+  separately-exported top-level function like markdown's
+  `markdown_fold_node` — jsx's `pkg.generated.mbti` doesn't export one.
+- [x] **Step 3:** Added `parse_to_proj_node(text : String)` — done
+  2026-07-11, matches the guide's signature exactly.
+- [x] **Step 4:** `moon check lang/jsx/proj` — done 2026-07-11, clean (0
+  errors; `@incr`/`@loom` unused-import warnings expected until Task 2.3
+  consumes them).
 
 ### Task 2.2: Token spans
 
 **File:** `lang/jsx/proj/populate_token_spans.mbt` (~80-150 lines)
 
-- [ ] **Step 1:** Define role conventions for JSX, following Markdown's
-  table pattern: `"tag_name"`, `"attr_name"`, `"attr_value"`, `"text"`,
-  `"expr_raw"` (the opaque `{...}` content span — needed later if/when
-  Phase 3 wires an editor, but populate it now since it's free to compute
-  alongside the others), `"open_bracket"`/`"close_bracket"` for element
-  delimiters.
-- [ ] **Step 2:** Implement `populate_token_spans`, parallel-walking syntax
-  tree and projection tree per the guide's pattern, calling
-  `source_map.set_token_span(proj_id, role, range)`.
-- [ ] **Step 3:** `moon check`.
-- [ ] **Step 4 (checkpoint whitebox test):**
-  `lang/jsx/proj/proj_node_wbtest.mbt`:
-  ```moonbit
-  test "parse and project basic element" {
-    let (root, errors) = parse_to_proj_node("<div>hello</div>")
-    inspect(errors.length(), content="0")
-    inspect(root.kind.kind_tag(), content="Element")
-  }
-  ```
-  (Verified against current syntax in `lang/markdown/proj/proj_node_wbtest.mbt`
-  — that file uses plain `inspect(...)`/`parse_to_proj_node(...)`, not the
-  deprecated postfix-`!` error-propagation call form; do not copy the `!`
-  form from ADDING_A_LANGUAGE.md's own prose example without checking
-  current code first.)
-  Run: `moon test -p dowdiness/canopy/lang/jsx/proj`
+- [x] **Step 1:** Role conventions defined 2026-07-11 per the plan's list,
+  plus one addition: `"attr_name"`/`"attr_value"` are index-suffixed
+  (`"attr_name:0"`, `"attr_value:0"`, ...) because attributes aren't
+  separate `ProjNode`s (excluded from `TreeNode::children`), so their
+  spans must attach to the owning `Element`'s id — a plain role string
+  would collide across an element with more than one attribute
+  (`SourceMap` holds one `Range` per `(id, role)`). Documented inline in
+  `populate_attrs`'s doc comment.
+- [x] **Step 2:** Implemented in `populate_token_spans.mbt`, done
+  2026-07-11. `"close_bracket"` needed extra care beyond the guide's
+  pattern: an element's close tag reuses the same token kinds as its open
+  tag (`OpenTagStartToken`, `TagNameToken`, `TagEndToken` all appear
+  twice for a container element — confirmed by reading
+  `loom/examples/jsx/cst_parser.mbt`'s close-tag comment), so
+  `close_bracket` takes the *last* `TagEndToken` (via
+  `tokens_of_kind`), not `find_token`'s first-match default; an unclosed
+  element (Design B case 2) has neither a self-close nor a `TagEndToken`
+  and correctly gets no `close_bracket` span.
+- [x] **Step 3:** `moon check lang/jsx/proj` — done 2026-07-11, clean.
+- [x] **Step 4 (checkpoint whitebox test):** written in
+  `lang/jsx/proj/proj_node_wbtest.mbt`, done 2026-07-11 — 8 tests, all
+  passing. The plan's literal snippet above needed one correction before
+  it would pass: `parse_to_proj_node` always wraps in `Root` (Task 1.2
+  Step 5's later AST divergence — a streaming prefix can have several
+  roots — postdates this snippet), so `root.kind.kind_tag()` is `"Root"`,
+  not `"Element"`; the actual test asserts `root.children[0].kind.kind_tag()
+  == "Element"` instead. Confirmed by first running the plan's exact
+  snippet and observing the failure before editing it (not just spot-copied).
+  Run: `moon test -p dowdiness/canopy/lang/jsx/proj` → 8/8 passed.
 
 ### Task 2.3: Memo builder
 
 **File:** end of `lang/jsx/proj/proj_node.mbt` (~15 lines)
 
-- [ ] **Step 1:** Implement `build_jsx_projection_memos`, delegating to
-  `@core.build_projection_memos` exactly per the guide's template (do not
-  hand-roll reconciliation).
-- [ ] **Step 2:** `moon check`.
+- [x] **Step 1:** Implemented `build_jsx_projection_memos` — done
+  2026-07-11, delegates to `@core.build_projection_memos` with no
+  `reconcile_node` override (uses its default, `@core.reconcile`), exactly
+  per the guide's basic template — no hand-rolled reconciliation.
+- [x] **Step 2:** `moon check lang/jsx/proj --deny-warn` — done
+  2026-07-11, clean (the `@incr`/`@loom` unused-import warnings from Task
+  2.1 Step 4 are gone now that this step consumes them).
 
 ### Task 2.4: Streaming-reconciliation existence-proof test
 
@@ -686,74 +712,57 @@ plan's "Why" section — not optional, not generic coverage.
 
 **File:** `lang/jsx/proj/streaming_reconcile_wbtest.mbt`
 
-- [ ] **Step 1:** Pick a fixed JSX fixture with at least 3 nested elements
-  and one `{expr}` child, e.g.
-  `<div><h1>{title}</h1><p>hello world</p></div>`.
-- [ ] **Step 2:** Write a test that feeds the parser this text in at least 6
-  increasing prefixes, and make sure at least two of them cut **mid-token**,
-  not just at clean JSX-token boundaries — LLM token streams don't align
-  with JSX tokens, so a test that only ever cuts cleanly (`<div><h1>`, never
-  `<di`) doesn't exercise Task 1.1 Step 2 cases 3/4 at all. Example prefix
-  sequence: `<di` (mid-tag-name), `<div><h1` (mid-tag-name again), `<div><h1>`,
-  `<div><h1>{titl` (mid-expression), `<div><h1>{title}</h1><p>hello`
-  (mid-text), full string. Use the same `Parser[JsxAst]`/incremental
-  re-parse entry point Markdown's integration test uses — that test lives
-  at `lang/markdown/companion/integration_wbtest.mbt` (in `companion/`, not
-  `proj/`; verified by direct read, correcting an earlier draft of this
-  plan). Since Phase 2 explicitly does not create a `lang/jsx/companion/`
-  package, this test must drive the incremental parser directly (whatever
-  `Parser[JsxAst]`/`apply_edit`-equivalent entry point `loom/loom/pipeline/`
-  exposes) from inside `lang/jsx/proj/streaming_reconcile_wbtest.mbt` — read
-  the companion test only for the call shape, do not conclude a companion
-  package is needed to write this test.
-- [ ] **Step 3:** Record the `NodeId` assigned to the outer `<div>`
-  element's `ProjNode` and to the `<h1>` element's `ProjNode` **at their
-  first appearance** in the tree — which, per Task 1.1 Step 2 case 2's
-  requirement, is while they are still unclosed, not after the whole
-  fixture has streamed in. (An earlier draft of this task recorded NodeIds
-  "once fully parsed" — for the outer `<div>`, that's only true at the
-  *final* prefix, making any stability assertion vacuous since there are no
-  later prefixes left to check against. Recording at first appearance is
-  the only version of this test that actually exercises the
-  unclosed→closed identity transition, which is the property the whole
-  plan's premise depends on.) Assert those specific `NodeId`s are identical
-  across every subsequent prefix, including the mid-token ones from Step 2.
-  **Recording-point clarification (2026-07-11, decided at Task 1.2 Step 6):**
-  "first appearance" means the first prefix where the element exists *with
-  its complete tag name* — for the example sequence, `<div>` first counts
-  at `<div><h1`, not at `<di`. Task 1.2 made `Element`'s
-  `TreeNode::same_kind` tag-sensitive (loom `proj_traits.mbt`: `di` and
-  `div` are different element types, so downstream state must not carry
-  over), which means a mid-tag-name prefix like `<di` holds an
-  `Element(tag="di")` whose ProjNode ID legitimately resets once when the
-  tag completes. Recording at a mid-tag-name prefix would therefore fail
-  by design, not by bug. The mid-token prefixes still participate in the
-  stability assertion for every element whose tag completed earlier, and
-  identity through *content* growth stays covered because `Text`/`ExprSpan`
-  `same_kind` are deliberately content-insensitive. Optionally add a
-  companion assertion pinning the one-time reset (`<di`'s element ID ≠
-  `<div`'s) so the tag-completion boundary is documented behavior.
-- [ ] **Step 4:** Also assert every prefix from the first point `<div>` has
-  been opened onward produces a non-empty `children` array on the outer
-  element's `ProjNode`, even before `</div>` arrives — Task 1.1 Step 2 case
-  2's hard requirement, checked end-to-end here.
-- [ ] **Step 5:** For the `{title}` expression specifically, additionally
-  test the growing-opaque-span sub-case from Task 1.1 Step 1 (`{titl` →
-  `{title` → `{title}`) and assert whichever identity behavior that design
-  doc specified (single leaf with mutating content, vs. new node per
-  partial parse) — do not leave this case unchecked just because Step 3
-  covers element-level identity; span-level identity is a distinct claim.
-- [ ] **Step 6:** `moon test -p dowdiness/canopy/lang/jsx/proj`.
+- [x] **Step 1:** Fixture chosen exactly as the plan's example —
+  `<div><h1>{title}</h1><p>hello world</p></div>` (3 elements: div, h1, p;
+  1 expr child) — `streaming_fixture` in `streaming_reconcile_wbtest.mbt`.
+- [x] **Step 2:** Implemented using the plan's exact 6-prefix example
+  sequence verbatim (`streaming_prefixes`), driving a raw
+  `@loom.new_parser(text, @jsx.jsx_grammar)` + `parser.set_source(...)`
+  directly — confirmed by reading `lang/markdown/companion/integration_wbtest.mbt`
+  for the call shape only, and finding the more on-point precedent in
+  `lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt` (a proj-level
+  wbtest already using `@loom.new_parser` + `parser.set_source` +
+  `derived.read_or_abort()` with no companion package involved) — no
+  `lang/jsx/companion/` package created.
+- [x] **Step 3:** Recorded `div`'s and `h1`'s `NodeId`s at prefix index 1
+  (`"<div><h1"`) per the recording-point clarification — both tags are
+  already complete and stable at that prefix. Added the optional
+  companion assertion: prefix 0's `<di` element's id differs from `div`'s
+  recorded id (`inspect(di_id == div_id, content="false")`).
+- [x] **Step 4:** Asserted `div.children.length() > 0` for every prefix
+  from index 1 onward (indices 2-5 in the loop, plus index 1 itself at
+  the point of recording) — done, same test.
+- [x] **Step 5:** Implemented as two separate tests (Design A's note
+  requires two distinct claims, not one):
+  `"streaming: ExprSpan identity stable across unclosed-to-closed growth"`
+  (`<h1>{titl` → `<h1>{title` → `<h1>{title}`, the plan's literal
+  example) and `"streaming: ExprSpan identity stable across closed-content
+  growth"` (`<h1>{a}` → `<h1>{ab}` → `<h1>{abc}`, covering Design A's other
+  required case — content mutating while the span stays closed at every
+  step, which the unclosed→closed sequence never exercises). Both assert
+  `ProjNode` id stability, confirming `@core.reconcile`'s `same_kind`-based
+  identity preservation as designed.
+- [x] **Step 6:** `moon test -p dowdiness/canopy/lang/jsx/proj` — done
+  2026-07-11: 11/11 passed (8 from Task 2.2 + 3 streaming tests).
 
 ### Acceptance Criteria (Phase 2)
 
-- [ ] `moon test -p dowdiness/canopy/lang/jsx/proj` passes, including the
-      Task 2.4 streaming-reconciliation test
-- [ ] `moon check` (workspace) clean
-- [ ] `moon info`, `git diff -- '*.mbti'` reviewed
-- [ ] No `lang/jsx/edits/` or `lang/jsx/companion/` package created (explicit
-      scope boundary — flag it in review if a future agent adds one under
-      this plan without an explicit scope amendment)
+- [x] `moon test -p dowdiness/canopy/lang/jsx/proj` passes, including the
+      Task 2.4 streaming-reconciliation test — 11/11, 2026-07-11
+- [x] `moon check` (workspace) clean — 2026-07-11, 0 errors (1
+      pre-existing unrelated warning in `lang/lambda`, not touched by this
+      work)
+- [x] `moon info`, `git diff -- '*.mbti'` reviewed — 2026-07-11. Running
+      `moon fmt`/`moon info` at the workspace root reformatted files in
+      several *unrelated* submodules (`alga`, `event-graph-walker`,
+      `graphviz`, `order-tree`, `rabbita`, `svg-dsl`) as a side effect of
+      `moon.work`'s full-workspace fan-out (toolchain-skew line-wrap
+      drift, no semantic change) — reverted with `git checkout -- .` in
+      each before committing; only `lang/jsx/proj`'s own new
+      `pkg.generated.mbti` is part of this change. See
+      `reference_moon_fmt_workspace_cascade` memory.
+- [x] No `lang/jsx/edits/` or `lang/jsx/companion/` package created —
+      confirmed: `lang/jsx/` contains only `proj/`
 
 ### Validation (Phase 2)
 

--- a/docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md
+++ b/docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md
@@ -677,11 +677,27 @@ estimate for this step)
   tag (`OpenTagStartToken`, `TagNameToken`, `TagEndToken` all appear
   twice for a container element — confirmed by reading
   `loom/examples/jsx/cst_parser.mbt`'s close-tag comment), so
-  `close_bracket` takes the *last* `TagEndToken` (via
-  `tokens_of_kind`), not `find_token`'s first-match default; an unclosed
-  element (Design B case 2) has neither a self-close nor a `TagEndToken`
-  and correctly gets no `close_bracket` span.
+  `close_bracket` takes the *last* `TagEndToken` (via `tokens_of_kind`),
+  not `find_token`'s first-match default.
+  **Codex post-impl review (2026-07-11) caught a real bug here**: the
+  first cut took *any* last match, so an unclosed element (Design B case
+  2, e.g. `<div><span>text`) — whose only direct `TagEndToken` is the
+  open tag's own `>`, since `parse_content` in `cst_parser.mbt` is only
+  reached after that token is already emitted, and `emit_close_tag`
+  contributes a second one only when a real `</tag>` closer exists —
+  wrongly got that open-tag `>` recorded as `close_bracket` instead of
+  `None`. Fixed to require `tokens_of_kind(TagEndToken).length() >= 2`
+  before taking the last match. Regression coverage added in
+  `lang/jsx/proj/populate_token_spans_wbtest.mbt` (new file, 3 tests):
+  unclosed element → no `close_bracket`; closed element → `close_bracket`
+  at its own `>`; nested same-tag elements (`<div><div>x</div></div>`)
+  each get their own distinct `close_bracket` span. Confirmed red
+  (`Some({start: 4, end: 5})` instead of `None`) against the pre-fix code
+  before reapplying the fix, per test-first discipline.
 - [x] **Step 3:** `moon check lang/jsx/proj` — done 2026-07-11, clean.
+  Re-verified 2026-07-11 after the close_bracket fix above: `moon check`
+  workspace-wide clean, `moon test -p dowdiness/canopy/lang/jsx/proj` →
+  14/14 passed (11 original + 3 new regression tests).
 - [x] **Step 4 (checkpoint whitebox test):** written in
   `lang/jsx/proj/proj_node_wbtest.mbt`, done 2026-07-11 — 8 tests, all
   passing. The plan's literal snippet above needed one correction before
@@ -743,7 +759,19 @@ plan's "Why" section — not optional, not generic coverage.
   `ProjNode` id stability, confirming `@core.reconcile`'s `same_kind`-based
   identity preservation as designed.
 - [x] **Step 6:** `moon test -p dowdiness/canopy/lang/jsx/proj` — done
-  2026-07-11: 11/11 passed (8 from Task 2.2 + 3 streaming tests).
+  2026-07-11: 11/11 passed (8 from Task 2.2 + 3 streaming tests; 14/14
+  after the Task 2.2 Step 2 close_bracket regression tests were added).
+
+**Known coverage gap (Codex post-impl review, 2026-07-11, not fixed —
+scope call, not an oversight):** the fixture/prefix list above is
+prescribed verbatim by this plan and intentionally not extended. Codex
+flagged that it doesn't exercise identity/span stability while an
+*attribute* streams in (`<div cla` → `<div class="a"`) or while a
+self-closing tag completes (`<div/` → `<div/>`). Both are real streaming
+cases per Task 1.1's Design B, but neither is part of the plan's chosen
+existence-proof fixture. Left as a documented gap rather than silently
+expanding Task 2.4's locked scope; a future task should add it if a real
+consumer needs attribute-level or self-close streaming guarantees.
 
 ### Acceptance Criteria (Phase 2)
 

--- a/lang/jsx/proj/moon.pkg
+++ b/lang/jsx/proj/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "dowdiness/canopy/core",
+  "dowdiness/incr",
+  "dowdiness/jsx",
+  "dowdiness/jsx/syntax",
+  "dowdiness/loom",
+  "dowdiness/loom/core" @loomcore,
+  "dowdiness/seam",
+}

--- a/lang/jsx/proj/pkg.generated.mbti
+++ b/lang/jsx/proj/pkg.generated.mbti
@@ -1,0 +1,28 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/lang/jsx/proj"
+
+import {
+  "dowdiness/incr/cells",
+  "dowdiness/jsx",
+  "dowdiness/loom/pipeline",
+  "dowdiness/seam",
+  "moonbitlang/core/ref",
+}
+
+// Values
+pub fn build_jsx_projection_memos(@pipeline.Parser[@jsx.JsxNode]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@jsx.JsxNode]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
+
+pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[String]) raise @dowdiness/loom/core.LexError
+
+pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]) -> Unit
+
+pub fn syntax_to_proj_node(@seam.SyntaxNode, @ref.Ref[Int]) -> @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/lang/jsx/proj/populate_token_spans.mbt
+++ b/lang/jsx/proj/populate_token_spans.mbt
@@ -88,10 +88,13 @@ fn populate_element_delimiters(
         @loomcore.Range::new(tok.start(), tok.end()),
       )
     None =>
+      // A direct TagEndToken always includes the open tag's own `>`
+      // (parse_content is only reached after emitting it) — a real close
+      // tag contributes a second one via emit_close_tag. One match means
+      // the element is unclosed (Design B case 2): no close_bracket.
       match
         syntax_node.tokens_of_kind(@syntax.SyntaxKind::TagEndToken.to_raw()) {
-        [] => ()
-        toks => {
+        [_, ..] as toks if toks.length() >= 2 => {
           let last = toks[toks.length() - 1]
           source_map.set_token_span(
             id,
@@ -99,6 +102,7 @@ fn populate_element_delimiters(
             @loomcore.Range::new(last.start(), last.end()),
           )
         }
+        _ => ()
       }
   }
 }

--- a/lang/jsx/proj/populate_token_spans.mbt
+++ b/lang/jsx/proj/populate_token_spans.mbt
@@ -1,0 +1,235 @@
+///| Extract token spans from the JSX CST into the SourceMap.
+///
+/// Role conventions: "tag_name", "attr_name"/"attr_value" (index-suffixed,
+/// see populate_attrs), "text", "expr_raw" (opaque `{...}` content, no
+/// braces), "open_bracket"/"close_bracket" for element/fragment
+/// delimiters. Not consumed by anything in Phase 2 (read-only) — populated
+/// now for Phase 3's eventual editor, per the plan.
+
+///|
+pub fn populate_token_spans(
+  source_map : @core.SourceMap,
+  syntax_root : @seam.SyntaxNode,
+  proj_root : @core.ProjNode[@jsx.JsxNode],
+) -> Unit {
+  populate_node(source_map, syntax_root, proj_root)
+}
+
+///|
+fn populate_node(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  proj_node : @core.ProjNode[@jsx.JsxNode],
+) -> Unit {
+  let id = proj_node.id()
+  match proj_node.kind {
+    Root(..) =>
+      populate_children(source_map, syntax_node.children(), proj_node.children)
+    Element(..) => {
+      populate_element_delimiters(source_map, syntax_node, id)
+      populate_attrs(source_map, syntax_node, id)
+      populate_children(
+        source_map,
+        element_content_children(syntax_node),
+        proj_node.children,
+      )
+    }
+    Fragment(..) => {
+      populate_fragment_delimiters(source_map, syntax_node, id)
+      populate_children(source_map, syntax_node.children(), proj_node.children)
+    }
+    Text(_) =>
+      source_map.set_token_span(
+        id,
+        "text",
+        @loomcore.Range::new(syntax_node.start(), syntax_node.end()),
+      )
+    ExprSpan(..) => populate_expr_raw(source_map, syntax_node, id, "expr_raw")
+    Error(_) => ()
+  }
+}
+
+///|
+fn populate_children(
+  source_map : @core.SourceMap,
+  syntax_children : Array[@seam.SyntaxNode],
+  proj_children : Array[@core.ProjNode[@jsx.JsxNode]],
+) -> Unit {
+  let len = syntax_children.length().min(proj_children.length())
+  for i in 0..<len {
+    populate_node(source_map, syntax_children[i], proj_children[i])
+  }
+}
+
+///|
+/// "open_bracket" = the open tag's leading `<`; "close_bracket" = the
+/// self-close `/>` if present, else the close tag's trailing `>` if
+/// present (an unclosed element per Design B case 2 has neither).
+fn populate_element_delimiters(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  id : @core.NodeId,
+) -> Unit {
+  set_optional_token_span(
+    source_map,
+    syntax_node,
+    id,
+    "open_bracket",
+    @syntax.SyntaxKind::OpenTagStartToken,
+  )
+  match
+    syntax_node.direct_token_of_kind(
+      @syntax.SyntaxKind::SelfCloseEndToken.to_raw(),
+    ) {
+    Some(tok) =>
+      source_map.set_token_span(
+        id,
+        "close_bracket",
+        @loomcore.Range::new(tok.start(), tok.end()),
+      )
+    None =>
+      match
+        syntax_node.tokens_of_kind(@syntax.SyntaxKind::TagEndToken.to_raw()) {
+        [] => ()
+        toks => {
+          let last = toks[toks.length() - 1]
+          source_map.set_token_span(
+            id,
+            "close_bracket",
+            @loomcore.Range::new(last.start(), last.end()),
+          )
+        }
+      }
+  }
+}
+
+///|
+fn populate_fragment_delimiters(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  id : @core.NodeId,
+) -> Unit {
+  set_optional_token_span(
+    source_map,
+    syntax_node,
+    id,
+    "open_bracket",
+    @syntax.SyntaxKind::FragmentOpenToken,
+  )
+  set_optional_token_span(
+    source_map,
+    syntax_node,
+    id,
+    "close_bracket",
+    @syntax.SyntaxKind::FragmentCloseToken,
+  )
+}
+
+///|
+fn set_optional_token_span(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  id : @core.NodeId,
+  role : String,
+  kind : @syntax.SyntaxKind,
+) -> Unit {
+  match syntax_node.find_token(kind.to_raw()) {
+    Some(tok) =>
+      source_map.set_token_span(
+        id,
+        role,
+        @loomcore.Range::new(tok.start(), tok.end()),
+      )
+    None => ()
+  }
+}
+
+///|
+/// Attributes aren't separate ProjNodes (TreeNode::children excludes
+/// them), so their spans attach to the owning Element's id. A plain
+/// "attr_name"/"attr_value" role would collide across multiple
+/// attributes on one element (SourceMap holds one Range per (id, role));
+/// index-suffix each role instead.
+fn populate_attrs(
+  source_map : @core.SourceMap,
+  element_syntax_node : @seam.SyntaxNode,
+  id : @core.NodeId,
+) -> Unit {
+  let attr_kind = @syntax.SyntaxKind::AttrNode.to_raw()
+  let attrs = element_syntax_node.direct_children_of_kind(attr_kind)
+  for i, attr_node in attrs.iter2() {
+    set_optional_token_span(
+      source_map,
+      attr_node,
+      id,
+      "attr_name:" + i.to_string(),
+      @syntax.SyntaxKind::AttrNameToken,
+    )
+    let value_role = "attr_value:" + i.to_string()
+    match
+      attr_node.direct_token_of_kind(
+        @syntax.SyntaxKind::AttrStringLitToken.to_raw(),
+      ) {
+      Some(tok) =>
+        source_map.set_token_span(
+          id,
+          value_role,
+          @loomcore.Range::new(tok.start(), tok.end()),
+        )
+      None =>
+        match
+          attr_node.direct_token_of_kind(
+            @syntax.SyntaxKind::AttrStringLitUnterminatedToken.to_raw(),
+          ) {
+          Some(tok) =>
+            source_map.set_token_span(
+              id,
+              value_role,
+              @loomcore.Range::new(tok.start(), tok.end()),
+            )
+          None =>
+            match
+              attr_node.direct_child_of_kind(
+                @syntax.SyntaxKind::ExprSpanNode.to_raw(),
+              ) {
+              Some(expr_node) =>
+                source_map.set_token_span(
+                  id,
+                  value_role,
+                  @loomcore.Range::new(expr_node.start(), expr_node.end()),
+                )
+              None => ()
+            }
+        }
+    }
+  }
+}
+
+///|
+/// Content span between the braces, excluding them — the raw
+/// unparsed expression text (Design B case 4's ExprRawText/
+/// ExprStringUnterminated chunks, concatenated by span rather than text).
+fn populate_expr_raw(
+  source_map : @core.SourceMap,
+  syntax_node : @seam.SyntaxNode,
+  id : @core.NodeId,
+  role : String,
+) -> Unit {
+  let content_start = match
+    syntax_node.find_token(@syntax.SyntaxKind::BraceOpenToken.to_raw()) {
+    Some(tok) => tok.end()
+    None => syntax_node.start()
+  }
+  let content_end = match
+    syntax_node.find_token(@syntax.SyntaxKind::BraceCloseToken.to_raw()) {
+    Some(tok) => tok.start()
+    None => syntax_node.end()
+  }
+  if content_start <= content_end {
+    source_map.set_token_span(
+      id,
+      role,
+      @loomcore.Range::new(content_start, content_end),
+    )
+  }
+}

--- a/lang/jsx/proj/populate_token_spans_wbtest.mbt
+++ b/lang/jsx/proj/populate_token_spans_wbtest.mbt
@@ -1,0 +1,51 @@
+///| Regression tests for populate_token_spans (Task 2.3), including a
+/// Codex-review-caught bug (2026-07-11): an unclosed element's lone
+/// open-tag `>` was being recorded as its `close_bracket`, and nested
+/// same-tag elements' `close_bracket` disambiguation was unverified.
+
+///|
+fn source_map_for(
+  text : String,
+) -> (@core.ProjNode[@jsx.JsxNode], @core.SourceMap) {
+  let parser = @loom.new_parser(text, @jsx.jsx_grammar)
+  let (proj_memo, _, source_map_memo) = build_jsx_projection_memos(parser)
+  let root = proj_memo.read_or_abort().unwrap()
+  let source_map = source_map_memo.read_or_abort()
+  (root, source_map)
+}
+
+///|
+test "token spans: unclosed element has no close_bracket" {
+  let (root, source_map) = source_map_for("<div><span>text")
+  let div = root.children[0]
+  inspect(
+    source_map.get_token_span(div.id(), "close_bracket") is None,
+    content="true",
+  )
+}
+
+///|
+test "token spans: closed element has close_bracket at its own '>'" {
+  // "<p>hi</p>" — the close tag's '>' is the last character, offset 8..9.
+  let (root, source_map) = source_map_for("<p>hi</p>")
+  let p = root.children[0]
+  let span = source_map.get_token_span(p.id(), "close_bracket").unwrap()
+  inspect(span.start, content="8")
+  inspect(span.end, content="9")
+}
+
+///|
+test "token spans: nested same-tag elements each get their own close_bracket" {
+  // "<div><div>x</div></div>" — inner '>' at 16..17, outer '>' at 22..23.
+  let (root, source_map) = source_map_for("<div><div>x</div></div>")
+  let outer = root.children[0]
+  let inner = outer.children[0]
+  let outer_span = source_map
+    .get_token_span(outer.id(), "close_bracket")
+    .unwrap()
+  let inner_span = source_map
+    .get_token_span(inner.id(), "close_bracket")
+    .unwrap()
+  inspect(inner_span.start, content="16")
+  inspect(outer_span.start, content="22")
+}

--- a/lang/jsx/proj/proj_node.mbt
+++ b/lang/jsx/proj/proj_node.mbt
@@ -1,0 +1,104 @@
+///| CST → ProjNode[@jsx.JsxNode] projection for JSX.
+///
+/// Uses CstFold to get a fully-populated JsxNode (element tags, attrs,
+/// text, opaque expression spans). The ProjNode tree mirrors the AST's
+/// own container/leaf split (see loom/examples/jsx/proj_traits.mbt
+/// TreeNode::children): Root/Fragment/Element are containers, Text/
+/// ExprSpan/Error are leaves.
+
+///|
+/// Convenience: parse source and project in one call (for tests and REPL).
+pub fn parse_to_proj_node(
+  text : String,
+) -> (@core.ProjNode[@jsx.JsxNode], Array[String]) raise @loomcore.LexError {
+  let (cst, diagnostics) = @jsx.parse_cst(text)
+  let syntax_node = @seam.SyntaxNode::from_cst(cst)
+  let errors = diagnostics.map(fn(d) { d.message })
+  let root = syntax_to_proj_node(syntax_node, Ref(0))
+  (root, errors)
+}
+
+///|
+pub fn syntax_to_proj_node(
+  node : @seam.SyntaxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@jsx.JsxNode] {
+  // CstFold produces a fully-populated JsxNode (tags, attrs, text, expr
+  // spans already folded in).
+  let fold = @loomcore.CstFold::new(@jsx.jsx_grammar.fold_node)
+  let ast = fold.fold(node)
+  build_proj_tree(node, ast, counter)
+}
+
+///|
+fn build_proj_tree(
+  syntax_node : @seam.SyntaxNode,
+  ast : @jsx.JsxNode,
+  counter : Ref[Int],
+) -> @core.ProjNode[@jsx.JsxNode] {
+  match ast {
+    Root(..) | Fragment(..) =>
+      build_container(syntax_node, ast, syntax_node.children(), counter)
+    Element(..) =>
+      build_container(
+        syntax_node,
+        ast,
+        element_content_children(syntax_node),
+        counter,
+      )
+    Text(_) | ExprSpan(..) | Error(_) =>
+      @core.ProjNode::leaf(ast, syntax_node, counter)
+  }
+}
+
+///|
+/// An Element's CST children interleave AttrNodes with its content
+/// children (child elements/text/expr spans) — AttrNodes fold into the
+/// AST's `attrs` field, not `children`, so they must be excluded here to
+/// keep the parallel walk aligned with `ast.children()`.
+fn element_content_children(node : @seam.SyntaxNode) -> Array[@seam.SyntaxNode] {
+  let attr_kind = @syntax.SyntaxKind::AttrNode.to_raw()
+  node.children().filter(c => c.kind() != attr_kind)
+}
+
+///|
+fn build_container(
+  syntax_node : @seam.SyntaxNode,
+  ast : @jsx.JsxNode,
+  syntax_children : Array[@seam.SyntaxNode],
+  counter : Ref[Int],
+) -> @core.ProjNode[@jsx.JsxNode] {
+  let ast_children = ast.children()
+  let len = syntax_children.length().min(ast_children.length())
+  let children : Array[@core.ProjNode[@jsx.JsxNode]] = []
+  for i in 0..<len {
+    children.push(build_proj_tree(syntax_children[i], ast_children[i], counter))
+  }
+  @core.ProjNode::branch(
+    ast,
+    syntax_node.start(),
+    syntax_node.end(),
+    children,
+    counter,
+  )
+}
+
+///|
+/// Build the 3-memo pipeline (proj, registry, source_map) for the JSX
+/// projection. Delegates to @core.build_projection_memos exactly per
+/// ADDING_A_LANGUAGE.md Step 4 — no hand-rolled reconciliation.
+pub fn build_jsx_projection_memos(
+  parser : @loom.Parser[@jsx.JsxNode],
+) -> (
+  @incr.Derived[@core.ProjNode[@jsx.JsxNode]?],
+  @incr.Derived[Map[@core.NodeId, @core.ProjNode[@jsx.JsxNode]]],
+  @incr.Derived[@core.SourceMap],
+) {
+  @core.build_projection_memos(
+    parser.runtime(),
+    parser.syntax_tree(),
+    syntax_to_proj_node,
+    populate_token_spans,
+    label="jsx",
+  )
+}

--- a/lang/jsx/proj/proj_node_wbtest.mbt
+++ b/lang/jsx/proj/proj_node_wbtest.mbt
@@ -1,0 +1,82 @@
+///| Whitebox tests for JSX projection (Task 2.2 Step 4 checkpoint).
+
+///|
+test "parse and project basic element" {
+  // parse_to_proj_node always wraps in Root (Task 1.2 Step 5: a streaming
+  // prefix can legally have several roots) — the plan's original snippet
+  // predates that AST divergence and asserted "Element" directly at the
+  // top; check the wrapped element instead.
+  let (root, errors) = parse_to_proj_node("<div>hello</div>")
+  inspect(errors.length(), content="0")
+  inspect(root.kind.kind_tag(), content="Root")
+  inspect(root.children[0].kind.kind_tag(), content="Element")
+}
+
+///|
+test "projection: root wraps top-level nodes" {
+  let (root, _) = parse_to_proj_node("<div/>")
+  inspect(root.kind.kind_tag(), content="Root")
+  inspect(root.children.length(), content="1")
+}
+
+///|
+test "projection: element with text child" {
+  let (root, errors) = parse_to_proj_node("<p>hello world</p>")
+  inspect(errors.length(), content="0")
+  let el = root.children[0]
+  inspect(el.children.length(), content="1")
+  inspect(el.children[0].kind.kind_tag(), content="Text")
+}
+
+///|
+test "projection: nested elements" {
+  let (root, errors) = parse_to_proj_node(
+    "<div><h1>title</h1><p>body</p></div>",
+  )
+  inspect(errors.length(), content="0")
+  let div = root.children[0]
+  inspect(div.children.length(), content="2")
+  inspect(div.children[0].kind.kind_tag(), content="Element")
+  inspect(div.children[1].kind.kind_tag(), content="Element")
+}
+
+///|
+test "projection: attrs are excluded from proj children" {
+  let (root, errors) = parse_to_proj_node("<div class=\"a\" id=\"b\">x</div>")
+  inspect(errors.length(), content="0")
+  let div = root.children[0]
+  // Only the Text child appears — the two attrs must not be counted.
+  inspect(div.children.length(), content="1")
+  inspect(div.children[0].kind.kind_tag(), content="Text")
+}
+
+///|
+test "projection: expression span child" {
+  let (root, errors) = parse_to_proj_node("<p>{title}</p>")
+  inspect(errors.length(), content="0")
+  let p = root.children[0]
+  inspect(p.children[0].kind.kind_tag(), content="ExprSpan")
+}
+
+///|
+test "projection: fragment" {
+  let (root, errors) = parse_to_proj_node("<><span/><span/></>")
+  inspect(errors.length(), content="0")
+  let fragment = root.children[0]
+  inspect(fragment.kind.kind_tag(), content="Fragment")
+  inspect(fragment.children.length(), content="2")
+}
+
+///|
+test "projection: unclosed element still exposes parsed children" {
+  let (root, errors) = parse_to_proj_node("<div><span>text")
+  // Design B case 2: diagnostics are pushed, but children are not
+  // discarded.
+  inspect(errors.length() > 0, content="true")
+  let div = root.children[0]
+  inspect(div.kind.kind_tag(), content="Element")
+  inspect(div.children.length(), content="1")
+  let span = div.children[0]
+  inspect(span.children.length(), content="1")
+  inspect(span.children[0].kind.kind_tag(), content="Text")
+}

--- a/lang/jsx/proj/streaming_reconcile_wbtest.mbt
+++ b/lang/jsx/proj/streaming_reconcile_wbtest.mbt
@@ -1,0 +1,110 @@
+///| Task 2.4 — streaming-reconciliation existence-proof test.
+///
+/// Simulates an LLM streaming JSX token-by-token by feeding the parser
+/// monotonically growing prefixes of a fixed fixture and asserting that
+/// NodeIds already assigned to fully-tag-named ancestor elements do not
+/// change as later siblings/descendants are appended. This is the actual
+/// generative-UI value proposition from this plan's "Why" section — not
+/// generic coverage.
+
+///|
+let streaming_fixture : String = "<div><h1>{title}</h1><p>hello world</p></div>"
+
+///|
+/// 6 monotonically growing prefixes of the fixture; indices 0 and 1 both
+/// cut mid-token (mid-tag-name), per Task 1.1 Step 2 cases 3/4 — LLM
+/// token streams don't align with JSX token boundaries.
+let streaming_prefixes : Array[String] = [
+  "<di", // mid-tag-name (outer element)
+   "<div><h1", // mid-tag-name (inner element; outer tag now complete)
+   "<div><h1>", "<div><h1>{titl", // mid-expression
+   "<div><h1>{title}</h1><p>hello", // mid-text
+   streaming_fixture, // full string
+]
+
+///|
+test "streaming: element identity stable from first complete-tag-name appearance" {
+  let parser = @loom.new_parser(streaming_prefixes[0], @jsx.jsx_grammar)
+  let (proj_memo, _, _) = build_jsx_projection_memos(parser)
+
+  // Prefix 0 ("<di"): the outer element's tag is truncated mid-word — a
+  // transient Element(tag="di") that must NOT share identity with the
+  // eventual Element(tag="div") once the tag name completes (Element's
+  // same_kind is tag-sensitive by design — one identity reset at
+  // streaming tag completion).
+  let root0 = proj_memo.read_or_abort().unwrap()
+  let di_id = root0.children[0].id()
+
+  // Prefix 1 ("<div><h1"): the outer element's tag is now complete
+  // ("div") and never changes again for the rest of the stream — this is
+  // the recording point per the plan's Task 2.4 Step 3 recording-point
+  // clarification, not prefix 0.
+  parser.set_source(streaming_prefixes[1])
+  let root1 = proj_memo.read_or_abort().unwrap()
+  let div = root1.children[0]
+  let div_id = div.id()
+  inspect(div.kind.kind_tag(), content="Element")
+  // Companion assertion (plan's optional note): the one-time reset is
+  // real — "<di"'s id must differ from "<div"'s.
+  inspect(di_id == div_id, content="false")
+
+  // The inner element's tag ("h1") is also already complete at this same
+  // prefix — it cannot grow into anything else before the fixture's own
+  // `>` arrives — so it is recorded here too.
+  let h1 = div.children[0]
+  let h1_id = h1.id()
+  inspect(h1.kind.kind_tag(), content="Element")
+
+  // Remaining prefixes: both IDs stay stable, and div's children stay
+  // non-empty throughout (Task 1.1 Step 2 case 2's hard requirement — an
+  // unclosed element still exposes its already-parsed children).
+  for i in 2..<streaming_prefixes.length() {
+    parser.set_source(streaming_prefixes[i])
+    let root = proj_memo.read_or_abort().unwrap()
+    let div_now = root.children[0]
+    inspect(div_now.id() == div_id, content="true")
+    inspect(div_now.children.length() > 0, content="true")
+    let h1_now = div_now.children[0]
+    inspect(h1_now.id() == h1_id, content="true")
+  }
+}
+
+///|
+/// Design A's "Growing opaque ExprSpan identity" — required test 1 of 2:
+/// stability across an unclosed prefix growing into a closed one.
+test "streaming: ExprSpan identity stable across unclosed-to-closed growth" {
+  let prefixes : Array[String] = ["<h1>{titl", "<h1>{title", "<h1>{title}"]
+  let parser = @loom.new_parser(prefixes[0], @jsx.jsx_grammar)
+  let (proj_memo, _, _) = build_jsx_projection_memos(parser)
+  let root0 = proj_memo.read_or_abort().unwrap()
+  let expr0 = root0.children[0].children[0]
+  inspect(expr0.kind.kind_tag(), content="ExprSpan")
+  let expr_id = expr0.id()
+  for i in 1..<prefixes.length() {
+    parser.set_source(prefixes[i])
+    let root = proj_memo.read_or_abort().unwrap()
+    let expr = root.children[0].children[0]
+    inspect(expr.kind.kind_tag(), content="ExprSpan")
+    inspect(expr.id() == expr_id, content="true")
+  }
+}
+
+///|
+/// Design A's "Growing opaque ExprSpan identity" — required test 2 of 2:
+/// stability across content mutation while the span stays closed at
+/// every step (a distinct claim from the unclosed-to-closed case above —
+/// both are CST re-parses of a re-tagged-ExprSpan node, but this one
+/// never passes through an unclosed intermediate state).
+test "streaming: ExprSpan identity stable across closed-content growth" {
+  let prefixes : Array[String] = ["<h1>{a}", "<h1>{ab}", "<h1>{abc}"]
+  let parser = @loom.new_parser(prefixes[0], @jsx.jsx_grammar)
+  let (proj_memo, _, _) = build_jsx_projection_memos(parser)
+  let root0 = proj_memo.read_or_abort().unwrap()
+  let expr_id = root0.children[0].children[0].id()
+  for i in 1..<prefixes.length() {
+    parser.set_source(prefixes[i])
+    let root = proj_memo.read_or_abort().unwrap()
+    let expr = root.children[0].children[0]
+    inspect(expr.id() == expr_id, content="true")
+  }
+}

--- a/moon.mod
+++ b/moon.mod
@@ -18,6 +18,7 @@ import {
   "dowdiness/order-tree@0.1.0",
   "dowdiness/pretty@0.1.0",
   "dowdiness/markdown@0.1.0",
+  "dowdiness/jsx@0.1.0",
   "dowdiness/zipper@0.1.0",
   "dowdiness/analysis@0.1.0",
   "dowdiness/egglog@0.1.0",

--- a/moon.work
+++ b/moon.work
@@ -7,6 +7,7 @@ members = [
   "./event-graph-walker",
   "./order-tree",
   "./loom/examples/markdown",
+  "./loom/examples/jsx",
   "./loom/examples/json",
   "./loom/examples/lambda",
   "./loom/examples/graph-dsl",


### PR DESCRIPTION
## Summary
- Phase 2 (Tasks 2.1–2.4) of `docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md`: adds `lang/jsx/proj/`, a read-only CST→`ProjNode[JsxNode]` projection for the JSX language integration, following `docs/development/ADDING_A_LANGUAGE.md`.
- `proj_node.mbt`: `syntax_to_proj_node`/`build_proj_tree` (CstFold → AST → ProjNode, filtering `AttrNode` out of Element's CST children) and `build_jsx_projection_memos`, delegating to `@core.build_projection_memos` with no hand-rolled reconciliation.
- `populate_token_spans.mbt`: SourceMap token-span population (open/close brackets, attrs, text, opaque `expr_raw`).
- `streaming_reconcile_wbtest.mbt`: the plan's required Task 2.4 existence-proof test — feeds a `@loom.Parser` monotonically-growing, mid-token-cutting prefixes of a fixed JSX fixture and asserts `NodeId` stability for elements once their tag name is a complete token, and for `ExprSpan` nodes across unclosed→closed and closed-content growth.
- Registers `dowdiness/jsx` in canopy's root `moon.mod`/`moon.work` (workspace membership alone wasn't sufficient for `moon check`).
- Includes a real bug fix caught by Codex post-implementation review: `close_bracket` was wrongly recorded on unclosed elements (the open tag's own `>` was mistaken for a close tag's `>`); fixed with 3 new regression tests in `populate_token_spans_wbtest.mbt`, confirmed red against the pre-fix code first.

No `lang/jsx/edits/` or `lang/jsx/companion/` package — Phase 2 is explicitly read-only per plan scope; bidirectional editing is deferred to Phase 3.

## Reuse check
- `@core.build_projection_memos`, `@core.ProjNode::leaf`/`branch`, `@core.SourceMap::set_token_span` — reused directly, no hand-rolled reconciliation or span storage.
- `@loomcore.CstFold` — reused for CST→AST folding (mirrors markdown/JSON's own integrations).
- `element_content_children`'s `AttrNode` filter mirrors the filtering already done in `loom/examples/jsx`'s own AST-fold code (`jsx_fold_node`) — not a new pattern, kept parallel to the existing convention.

## Test plan
- [x] `moon test -p dowdiness/canopy/lang/jsx/proj` — 14/14 passed
- [x] `moon check` (workspace) — clean (1 pre-existing unrelated warning in `lang/lambda`, untouched by this PR)
- [x] `moon info` / `git diff -- '*.mbti'` reviewed — only `lang/jsx/proj`'s own new interface file
- [x] Codex post-implementation review performed; one real bug found and fixed with regression tests (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)