### PR TITLE
feat: add JSX session ownership contract (#886)

### DIFF
--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -27,6 +27,8 @@ pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] reco
 
 pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] reconcile_hinted(ProjNode[T], ProjNode[T], @ref.Ref[Int], Map[NodeId, IdentityTransform], trace_ref? : @ref.Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T]
 
+pub fn[T : @dowdiness/loom/core.TreeNode + @dowdiness/loom/core.Renderable] reconcile_with_exact_key(ProjNode[T], ProjNode[T], @ref.Ref[Int], (T) -> String, trace_ref? : @ref.Ref[Array[ReconcileTraceEvent]]?) -> ProjNode[T]
+
 pub fn to_structured_changes(Array[ReconcileTraceEvent]) -> Array[StructuredChange]
 
 // Errors

--- a/core/reconcile.mbt
+++ b/core/reconcile.mbt
@@ -23,6 +23,37 @@ pub fn[T : TreeNode + Renderable] reconcile(
 }
 
 ///|
+/// Reconcile with a caller-provided exact-key preference for sibling LCS.
+/// The key describes a node's own payload; child structure is fingerprinted by
+/// the reconciler. Exact keys only break ties between same-kind matches: they
+/// cannot reduce the number of matched children, and content edits still fall
+/// back to `TreeNode::same_kind`.
+pub fn[T : TreeNode + Renderable] reconcile_with_exact_key(
+  old : ProjNode[T],
+  new : ProjNode[T],
+  counter : Ref[Int],
+  exact_key : (T) -> String,
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
+) -> ProjNode[T] {
+  let interner : Map[String, Int] = {}
+  let next_fingerprint = Ref(0)
+  let old_fingerprints = exact_fingerprint_map(
+    old, exact_key, interner, next_fingerprint,
+  )
+  let new_fingerprints = exact_fingerprint_map(
+    new, exact_key, interner, next_fingerprint,
+  )
+  reconcile_exact(
+    old,
+    new,
+    counter,
+    old_fingerprints,
+    new_fingerprints,
+    trace_ref~,
+  )
+}
+
+///|
 /// Reconciliation with structural-edit hints. Behaves identically to `reconcile`
 /// when `hints` is empty. A `Wrap` / `Unwrap` hint (keyed by the previous node's
 /// id) lets identity survive a constructor change at a position that positional
@@ -211,6 +242,167 @@ fn[T : TreeNode + Renderable] reconcile_children(
     }
   }
   result
+}
+
+///|
+/// Build position-independent fingerprints once for one projection tree.
+fn[T] exact_fingerprint_map(
+  root : ProjNode[T],
+  exact_key : (T) -> String,
+  interner : Map[String, Int],
+  next_fingerprint : Ref[Int],
+) -> Map[NodeId, Int] {
+  let result : Map[NodeId, Int] = {}
+  let _ = root.fold(fn(node, children : Array[Int]) -> Int {
+    let key = exact_key(node.kind)
+    let signature = key.length().to_string() +
+      ":" +
+      key +
+      "|" +
+      children.length().to_string() +
+      ":" +
+      children.map(id => id.to_string()).join(",")
+    let fingerprint = match interner.get(signature) {
+      Some(id) => id
+      None => {
+        let id = next_fingerprint.val
+        next_fingerprint.val += 1
+        interner[signature] = id
+        id
+      }
+    }
+    result[node.id()] = fingerprint
+    fingerprint
+  })
+  result
+}
+
+///|
+/// Child reconciliation for `reconcile_with_exact_key`.
+///
+/// This path intentionally has no structural-edit hints: the JSX projection
+/// uses it for ordinary streaming updates, while the default/hinted path above
+/// retains the framework's historical LCS tie-breaking contract.
+fn[T : TreeNode + Renderable] reconcile_children_exact(
+  old_children : Array[ProjNode[T]],
+  new_children : Array[ProjNode[T]],
+  counter : Ref[Int],
+  old_fingerprints : Map[NodeId, Int],
+  new_fingerprints : Map[NodeId, Int],
+  parent_id : NodeId,
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
+) -> Array[ProjNode[T]] {
+  let old_len = old_children.length()
+  let new_len = new_children.length()
+  let match_base_score = old_len.min(new_len) + 1
+  let match_score = fn(oi : Int, nj : Int) -> Int {
+    if !T::same_kind(old_children[oi].kind, new_children[nj].kind) {
+      0
+    } else if old_fingerprints[old_children[oi].id()] ==
+      new_fingerprints[new_children[nj].id()] {
+      match_base_score + 1
+    } else {
+      match_base_score
+    }
+  }
+  let dp = Array::makei(old_len + 1, _ => Array::make(new_len + 1, 0))
+  for i = 1; i <= old_len; i = i + 1 {
+    for j = 1; j <= new_len; j = j + 1 {
+      let diagonal = dp[i - 1][j - 1] + match_score(i - 1, j - 1)
+      dp[i][j] = @cmp.maximum(
+        @cmp.maximum(dp[i - 1][j], dp[i][j - 1]),
+        diagonal,
+      )
+    }
+  }
+  let old_matched = Array::make(old_len, -1)
+  let new_matched = Array::make(new_len, -1)
+  let mut i = old_len
+  let mut j = new_len
+  while i > 0 && j > 0 {
+    let score = match_score(i - 1, j - 1)
+    if score > 0 && dp[i][j] == dp[i - 1][j - 1] + score {
+      old_matched[i - 1] = j - 1
+      new_matched[j - 1] = i - 1
+      i = i - 1
+      j = j - 1
+    } else if dp[i - 1][j] >= dp[i][j - 1] {
+      i = i - 1
+    } else {
+      j = j - 1
+    }
+  }
+  let result = [
+    for k in 0..<new_len => {
+      if new_matched[k] >= 0 {
+        let reconciled = reconcile_exact(
+          old_children[new_matched[k]],
+          new_children[k],
+          counter,
+          old_fingerprints,
+          new_fingerprints,
+          trace_ref~,
+        )
+        emit_trace(
+          trace_ref,
+          Matched(
+            parent_id,
+            new_matched[k],
+            k,
+            reconciled.id(),
+            T::kind_tag(reconciled.kind),
+          ),
+        )
+        reconciled
+      } else {
+        let fresh = assign_fresh_ids(new_children[k], counter)
+        emit_trace(
+          trace_ref,
+          Inserted(parent_id, k, fresh.id(), T::kind_tag(fresh.kind)),
+        )
+        fresh
+      }
+    }
+  ]
+  for oi = 0; oi < old_len; oi = oi + 1 {
+    if old_matched[oi] < 0 {
+      emit_trace(
+        trace_ref,
+        Deleted(
+          parent_id,
+          oi,
+          old_children[oi].id(),
+          T::kind_tag(old_children[oi].kind),
+        ),
+      )
+    }
+  }
+  result
+}
+
+///|
+fn[T : TreeNode + Renderable] reconcile_exact(
+  old : ProjNode[T],
+  new : ProjNode[T],
+  counter : Ref[Int],
+  old_fingerprints : Map[NodeId, Int],
+  new_fingerprints : Map[NodeId, Int],
+  trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
+) -> ProjNode[T] {
+  if T::same_kind(old.kind, new.kind) {
+    let reconciled_children = reconcile_children_exact(
+      old.children,
+      new.children,
+      counter,
+      old_fingerprints,
+      new_fingerprints,
+      old.node_id,
+      trace_ref~,
+    )
+    ProjNode(new.kind, new.start, new.end, old.node_id, reconciled_children)
+  } else {
+    assign_fresh_ids(new, counter)
+  }
 }
 
 ///|

--- a/core/reconcile_properties_wbtest.mbt
+++ b/core/reconcile_properties_wbtest.mbt
@@ -315,6 +315,116 @@ test "property: retained siblings keep IDs after child insertion" {
 }
 
 ///|
+fn exact_test_key(expr : TestExpr) -> String {
+  match expr {
+    Leaf(value) => "Leaf:" + value
+    Branch(tag, _) => "Branch:" + tag
+  }
+}
+
+///|
+test "reconcile: append equal-kind siblings preserves positional IDs" {
+  let old_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("b")]), Ref(0))
+  let new_node = to_proj_node(
+    Branch("root", [Leaf("a"), Leaf("b"), Leaf("c")]),
+    Ref(500),
+  )
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  inspect(
+    result.children[0].node_id == old_node.children[0].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[1].node_id == old_node.children[1].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[2].node_id != old_node.children[0].node_id,
+    content="true",
+  )
+}
+
+///|
+test "reconcile: prepend equal-kind siblings preserves positional IDs" {
+  let old_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("b")]), Ref(0))
+  let new_node = to_proj_node(
+    Branch("root", [Leaf("x"), Leaf("a"), Leaf("b")]),
+    Ref(500),
+  )
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  inspect(
+    result.children[1].node_id == old_node.children[0].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[2].node_id == old_node.children[1].node_id,
+    content="true",
+  )
+}
+
+///|
+test "reconcile: middle equal-kind insertion preserves positional IDs" {
+  let old_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("b")]), Ref(0))
+  let new_node = to_proj_node(
+    Branch("root", [Leaf("a"), Leaf("x"), Leaf("b")]),
+    Ref(500),
+  )
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  inspect(
+    result.children[0].node_id == old_node.children[0].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[2].node_id == old_node.children[1].node_id,
+    content="true",
+  )
+}
+
+///|
+test "reconcile: exact preference does not reduce match cardinality" {
+  let old_node = to_proj_node(
+    Branch("root", [Leaf("a"), Leaf("b"), Leaf("c")]),
+    Ref(0),
+  )
+  let new_node = to_proj_node(
+    Branch("root", [Leaf("x"), Leaf("y"), Leaf("z"), Leaf("a")]),
+    Ref(500),
+  )
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  let old_ids : Map[Int, Bool] = {}
+  for child in old_node.children {
+    old_ids[child.node_id] = true
+  }
+  let mut reused = 0
+  for child in result.children {
+    if old_ids.contains(child.node_id) {
+      reused += 1
+    }
+  }
+  inspect(reused, content="3")
+}
+
+///|
 /// Property 6: After deleting a child, the number of reused old IDs equals
 /// the LCS length between old and new children (by same_kind).
 /// We can't assume WHICH old children are matched (LCS tie-breaking is

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -29,7 +29,12 @@ artifact.
 
 The differentiator is therefore not that a model can write JSX. It is that a
 model can safely edit a structured UI while preserving user state and making
-the change inspectable, reversible, and mergeable.
+the change inspectable, reversible, and eventually mergeable.
+
+For V1, "mergeable" is limited to sequential or single-writer edits. Canopy
+does not yet define how concurrent semantic UI edits map to projection identity,
+conflict resolution, or user-visible state. The CRDT source-edit path and the
+future semantic-edit path must not be treated as having the same guarantees.
 
 ## Direction
 
@@ -44,7 +49,9 @@ boundary.
 
 AI changes must preserve user-entered values, focus, selection, and local
 customizations wherever the structure permits. Human edits and AI edits should
-be represented in the same incremental and collaborative model.
+eventually be represented in the same incremental and collaborative model. The
+V1 implementation should first establish these preservation rules for
+sequential edits before claiming concurrent co-editing semantics.
 
 ### Streaming and interruption
 
@@ -90,12 +97,17 @@ needed, require approval before effects occur.
 1. Finish V1 correctness gates: CI, browser validation, and property-based
    coverage for patch ordering, sibling indexes, nested updates, disposal,
    isolation, and failed-apply recovery. See issue #888.
-2. Define a renderer-neutral patch and identity conformance suite.
-3. Demonstrate one end-to-end use case: an AI-assisted, editable data
-   exploration or adaptive-form surface that preserves user state.
-4. Add semantic edits, preview/undo, capability checks, and auditability.
-5. Generalize from JSX to multiple projections only after the shared contract
-   is exercised by a real use case.
+2. Demonstrate one read-only or sandboxed end-to-end use case: an AI-assisted
+   data-exploration or adaptive-form surface that preserves user state. Place a
+   minimal component, action, and data capability boundary before exposing any
+   side effect.
+3. Extract the patch, identity, state-preservation, and capability invariants
+   from that use case, then define the renderer-neutral conformance suite.
+4. Add semantic edits, preview/undo, and auditability. Define concurrent
+   semantic-edit and conflict behavior before describing co-editing as a
+   supported guarantee.
+5. Validate the shared contract with a second materially different adapter,
+   then generalize from JSX to multiple projections.
 
 ## Non-goals
 

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -1,0 +1,108 @@
+# Generative UI direction
+
+## Thesis
+
+Canopy should treat Generative UI as incremental editing of a stateful UI
+program, not as repeated generation of disposable HTML or JSX.
+
+The important property is that an AI-generated view remains editable,
+state-preserving, incrementally updateable, and safe to reconcile with human
+edits. JSX is one projection surface for this idea, not the definition of the
+whole system.
+
+The existing architecture is a good fit:
+
+```text
+source / semantic UI program
+  → incremental parse and projection
+  → stable view identity
+  → patch adapter
+  → UI surface
+```
+
+## Why this matters
+
+Whole-view regeneration causes lost input, remounted components, broken focus,
+unnecessary work, and conflicts between AI and human edits. Incremental
+projection makes the generated result behave more like a shared, editable
+artifact.
+
+The differentiator is therefore not that a model can write JSX. It is that a
+model can safely edit a structured UI while preserving user state and making
+the change inspectable, reversible, and mergeable.
+
+## Direction
+
+### Structured edits instead of whole-view generation
+
+Natural-language requests should eventually lower to semantic UI edits such
+as adding a field, changing a layout, or showing a detail panel. The system
+should validate, preview, reject, undo, and merge these edits at a structural
+boundary.
+
+### Human and AI co-editing
+
+AI changes must preserve user-entered values, focus, selection, and local
+customizations wherever the structure permits. Human edits and AI edits should
+be represented in the same incremental and collaborative model.
+
+### Streaming and interruption
+
+The UI should be useful while generation is incomplete. This requires
+well-defined partial states, placeholders, transaction boundaries, cancellation,
+and resumption rather than treating incomplete output as a fatal parse error.
+
+### Semantic UI with multiple projections
+
+The long-term abstraction should be a semantic UI model that can project to
+JSX/DOM, native UI, canvas, accessibility-oriented views, voice interfaces,
+and other surfaces. Renderer adapters must share one patch and identity
+contract while remaining free to implement platform-specific behavior.
+
+### Capability-bounded generation
+
+Generated UI must not imply unrestricted authority. Components, actions, data
+access, expressions, and side effects should be constrained by explicit
+capabilities and schemas. Structural edits should be auditable and, where
+needed, require approval before effects occur.
+
+## High-value applications
+
+- Adaptive data-exploration workspaces that add filters, charts, and detail
+  views without losing the current query state.
+- Forms that reveal and validate fields based on the user's answers.
+- Educational surfaces that generate exercises, hints, visualizations, and
+  explanations around the learner's current state.
+- Collaborative workspaces where people and AI edit the same structured view.
+- Temporary debugging interfaces assembled from live program state.
+
+## Risks to measure
+
+- Non-deterministic or surprising model edits.
+- State loss during identity changes or reconciliation.
+- Accessibility and responsive-layout regressions.
+- Unsafe actions hidden behind generated controls.
+- Versioning and migration of generated UI structures.
+- Latency, token cost, and bundle/runtime overhead.
+
+## Recommended sequence
+
+1. Finish V1 correctness gates: CI, browser validation, and property-based
+   coverage for patch ordering, sibling indexes, nested updates, disposal,
+   isolation, and failed-apply recovery. See issue #888.
+2. Define a renderer-neutral patch and identity conformance suite.
+3. Demonstrate one end-to-end use case: an AI-assisted, editable data
+   exploration or adaptive-form surface that preserves user state.
+4. Add semantic edits, preview/undo, capability checks, and auditability.
+5. Generalize from JSX to multiple projections only after the shared contract
+   is exercised by a real use case.
+
+## Non-goals
+
+This direction does not require making JSX a universal UI language, allowing
+arbitrary model-generated code, or replacing conventional hand-authored UI.
+The initial goal is a safe incremental bridge between structured generation,
+human editing, and multiple UI projections.
+
+Related: [JSX Incremental Parser for Generative UI](../plans/2026-07-09-jsx-incremental-parser-generative-ui.md),
+[property-based correctness coverage issue #888](https://github.com/dowdiness/canopy/issues/888).

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -15,7 +15,7 @@ The existing architecture is a good fit:
 ```text
 source / semantic UI program
   → incremental parse and projection
-  → stable view identity
+  → session-scoped identity preservation
   → patch adapter
   → UI surface
 ```
@@ -29,12 +29,14 @@ artifact.
 
 The differentiator is therefore not that a model can write JSX. It is that a
 model can safely edit a structured UI while preserving user state and making
-the change inspectable, reversible, and eventually mergeable.
+the change inspectable and reversible. Semantic merging is a later capability,
+not a V1 guarantee.
 
-For V1, "mergeable" is limited to sequential or single-writer edits. Canopy
-does not yet define how concurrent semantic UI edits map to projection identity,
-conflict resolution, or user-visible state. The CRDT source-edit path and the
-future semantic-edit path must not be treated as having the same guarantees.
+For V1, supported edits are limited to sequential or single-writer edits.
+Canopy does not yet define how concurrent semantic UI edits map to projection
+identity, conflict resolution, or user-visible state. The CRDT source-edit path
+and the future semantic-edit path must not be treated as having the same
+guarantees.
 
 ## Direction
 
@@ -97,10 +99,11 @@ needed, require approval before effects occur.
 1. Finish V1 correctness gates: CI, browser validation, and property-based
    coverage for patch ordering, sibling indexes, nested updates, disposal,
    isolation, and failed-apply recovery. See issue #888.
-2. Demonstrate one read-only or sandboxed end-to-end use case: an AI-assisted
-   data-exploration or adaptive-form surface that preserves user state. Place a
-   minimal component, action, and data capability boundary before exposing any
-   side effect.
+2. Demonstrate one read-only end-to-end use case: an AI-assisted JSON/CSV data
+   exploration surface that incrementally produces a table, filters, and a
+   detail/summary panel while preserving user state. Keep generated actions
+   side-effect-free and place the minimal component, action, and data
+   capability boundary before expanding the scope.
 3. Extract the patch, identity, state-preservation, and capability invariants
    from that use case, then define the renderer-neutral conformance suite.
 4. Add semantic edits, preview/undo, and auditability. Define concurrent
@@ -108,6 +111,34 @@ needed, require approval before effects occur.
    supported guarantee.
 5. Validate the shared contract with a second materially different adapter,
    then generalize from JSX to multiple projections.
+
+## First vertical-slice acceptance criteria
+
+The first Generative UI prototype is successful only if it demonstrates all of
+the following:
+
+- Existing input, filter, and selection state survives incremental generation
+  whenever the structure permits.
+- Incomplete or invalid generated input does not destroy the last valid UI.
+- Reapplying the same update produces the same modeled UI result.
+- A failed patch application leaves the committed revision and DOM unchanged.
+- The generated surface is read-only: no network mutation, persistence, or
+  other external side effect is reachable through generated controls.
+- The prototype records enough patch/revision information to inspect what the
+  model changed and to measure update latency.
+
+The prototype should be treated as a sequential or single-writer experiment.
+It does not claim concurrent semantic merging, cross-session identity, or a
+renderer-neutral contract.
+
+## Explicitly deferred
+
+- Concurrent semantic-edit conflict resolution.
+- Persistent or cross-session view identity.
+- General-purpose renderer-neutral APIs.
+- Additional language projections beyond the first validated use case.
+- Formal proof of the JavaScript/DOM boundary; prove pure reconciliation
+  invariants only after they are isolated from the adapter.
 
 ## Non-goals
 

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -72,8 +72,10 @@ contract while remaining free to implement platform-specific behavior.
 
 Generated UI must not imply unrestricted authority. Components, actions, data
 access, expressions, and side effects should be constrained by explicit
-capabilities and schemas. Structural edits should be auditable and, where
-needed, require approval before effects occur.
+capabilities and schemas. The first prototype should use an allowlisted,
+declarative component model with no model-controlled network access, raw HTML,
+navigation, or arbitrary code/expression execution. Structural edits should be
+auditable and, where needed, require approval before effects occur.
 
 ## High-value applications
 
@@ -104,13 +106,13 @@ needed, require approval before effects occur.
    detail/summary panel while preserving user state. Keep generated actions
    side-effect-free and place the minimal component, action, and data
    capability boundary before expanding the scope.
-3. Extract the patch, identity, state-preservation, and capability invariants
-   from that use case, then define the renderer-neutral conformance suite.
-4. Add semantic edits, preview/undo, and auditability. Define concurrent
+3. Extract provisional patch, identity, state-preservation, and capability
+   invariants from that use case.
+4. Validate those provisional invariants with a second materially different
+   adapter, then freeze the renderer-neutral conformance suite and contract.
+5. Add semantic edits, preview/undo, and auditability. Define concurrent
    semantic-edit and conflict behavior before describing co-editing as a
-   supported guarantee.
-5. Validate the shared contract with a second materially different adapter,
-   then generalize from JSX to multiple projections.
+   supported guarantee, then generalize from JSX to multiple projections.
 
 ## First vertical-slice acceptance criteria
 
@@ -122,8 +124,12 @@ the following:
 - Incomplete or invalid generated input does not destroy the last valid UI.
 - Reapplying the same update produces the same modeled UI result.
 - A failed patch application leaves the committed revision and DOM unchanged.
-- The generated surface is read-only: no network mutation, persistence, or
-  other external side effect is reachable through generated controls.
+- The generated surface uses only allowlisted declarative components: no
+  model-controlled network access, persistence, navigation, raw HTML, or
+  arbitrary code/expression execution is reachable through generated controls.
+- Cancelling generation invalidates its generation revision; late chunks from
+  that revision are rejected and cannot overwrite newer committed UI.
+- Resumption starts only from an explicitly selected committed revision.
 - The prototype records enough patch/revision information to inspect what the
   model changed and to measure update latency.
 

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -77,6 +77,47 @@ declarative component model with no model-controlled network access, raw HTML,
 navigation, or arbitrary code/expression execution. Structural edits should be
 auditable and, where needed, require approval before effects occur.
 
+### LLM input boundary
+
+An LLM is an untrusted, asynchronous candidate generator, not the source of
+truth for UI state. Its output must never mutate the committed UI directly.
+The input path is:
+
+```text
+LLM/provider
+  → untrusted candidate
+  → syntax and schema validation
+  → capability validation
+  → base-revision check
+  → candidate projection and preview
+  → committed UI update
+```
+
+The provider transport, request lifecycle, UI-program validation, and renderer
+must remain separate responsibilities. Provider-specific code may fetch and
+decode model responses, but it must not own UI identity, DOM state, or commit
+policy. The request lifecycle owns request identity, observed revision,
+cancellation, stale-completion rejection, and typed failure classification.
+The UI input adapter owns the constrained UI-program schema and candidate
+validation. The renderer only applies validated candidates.
+
+The first implementation should use a replayable fixed-chunk source before
+connecting a live model. This makes incomplete output, duplicate chunks,
+revision conflicts, cancellation, late responses, and deterministic replay
+testable without depending on model behavior.
+
+The output representation should evolve in stages:
+
+1. constrained JSX-like source;
+2. semantic edits such as adding a table or filter;
+3. a renderer-neutral semantic UI program, only after a real use case and a
+   second adapter establish the shared invariants.
+
+Every candidate is evaluated against an explicit base revision. Cancelled or
+stale candidates are rejected, and only a validated candidate can advance the
+committed revision. This boundary is more important than any particular model
+provider or transport API.
+
 ## High-value applications
 
 - Adaptive data-exploration workspaces that add filters, charts, and detail

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -89,7 +89,7 @@ LLM/provider
   → syntax and schema validation
   → capability validation
   → base-revision check
-  → candidate projection and preview
+  → candidate projection and internal dry-run
   → committed UI update
 ```
 
@@ -97,9 +97,11 @@ The provider transport, request lifecycle, UI-program validation, and renderer
 must remain separate responsibilities. Provider-specific code may fetch and
 decode model responses, but it must not own UI identity, DOM state, or commit
 policy. The request lifecycle owns request identity, observed revision,
-cancellation, stale-completion rejection, and typed failure classification.
+cancellation, chunk sequencing and assembly, finalization, stale-completion
+rejection, terminal-state idempotency, and typed failure classification.
 The UI input adapter owns the constrained UI-program schema and candidate
-validation. The renderer only applies validated candidates.
+validation. The renderer only applies validated candidates through the session
+commit boundary.
 
 The first implementation should use a replayable fixed-chunk source before
 connecting a live model. This makes incomplete output, duplicate chunks,
@@ -115,8 +117,17 @@ The output representation should evolve in stages:
 
 Every candidate is evaluated against an explicit base revision. Cancelled or
 stale candidates are rejected, and only a validated candidate can advance the
-committed revision. This boundary is more important than any particular model
-provider or transport API.
+committed revision. A candidate is not committed until DOM application succeeds
+and the session state, registry, mounted IDs, and revision remain consistent.
+If application fails partway through, the existing session recovery and
+dirty-state contract determines whether the previous state is restored or the
+affected UI is rebuilt; the candidate must not be reported as committed. This
+boundary is more important than any particular model provider or transport API.
+
+The input path has two distinct kinds of preview. An internal dry-run or fake
+DOM application is required before committing a candidate. A user-visible
+approval preview is a separate product feature and is deferred beyond the
+first vertical slice.
 
 ## High-value applications
 
@@ -147,8 +158,9 @@ provider or transport API.
    detail/summary panel while preserving user state. Keep generated actions
    side-effect-free and place the minimal component, action, and data
    capability boundary before expanding the scope.
-3. Extract provisional patch, identity, state-preservation, and capability
-   invariants from that use case.
+3. Extract provisional patch, identity, state-preservation, capability, and
+   candidate-commit invariants from that use case. Require internal dry-run
+   validation; defer user-visible approval preview.
 4. Validate those provisional invariants with a second materially different
    adapter, then freeze the renderer-neutral conformance suite and contract.
 5. Add semantic edits, preview/undo, and auditability. Define concurrent
@@ -164,13 +176,18 @@ the following:
   whenever the structure permits.
 - Incomplete or invalid generated input does not destroy the last valid UI.
 - Reapplying the same update produces the same modeled UI result.
-- A failed patch application leaves the committed revision and DOM unchanged.
+- A failed patch application leaves the candidate uncommitted and follows the
+  session recovery/dirty-state contract without falsely advancing revision.
 - The generated surface uses only allowlisted declarative components: no
   model-controlled network access, persistence, navigation, raw HTML, or
   arbitrary code/expression execution is reachable through generated controls.
 - Cancelling generation invalidates its generation revision; late chunks from
   that revision are rejected and cannot overwrite newer committed UI.
 - Resumption starts only from an explicitly selected committed revision.
+- Chunk sequencing, duplicate handling, finalization, and terminal-state
+  idempotency are deterministic and owned by the request lifecycle.
+- Internal dry-run validation succeeds before any candidate commit; a
+  user-visible approval preview is not required for this first slice.
 - The prototype records enough patch/revision information to inspect what the
   model changed and to measure update latency.
 

--- a/docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md
+++ b/docs/plans/2026-07-09-jsx-incremental-parser-generative-ui.md
@@ -842,6 +842,145 @@ doesn't have to rediscover scope boundaries:
   attributes (`{...props}`) — defer indefinitely unless a concrete
   consumer needs them; do not add speculatively.
 
+### V1 contract: FFI sessions and empty-tag recovery (#886)
+
+This section fixes the V1 implementation boundary. V1 solves same-session
+projection identity for the JSX streaming demo; it does not introduce a
+generic `ProjectionShape`, persistent cross-session identity, `Move`/
+`Reparent` patches, or a general DOM transaction/rollback framework.
+
+The stateful FFI surface is:
+
+- `jsx_session_new(source, root_id) -> SessionCreateResult`, where the JSON
+  result contains `handle` (a decimal opaque handle or `null`) and the initial
+  `RenderResult` under `result`;
+- `jsx_session_render(handle, source) -> RenderResult`;
+- `jsx_session_dispose(handle) -> Unit`.
+
+`SessionCreateResult` and `RenderResult` are JSON strings at the JavaScript
+boundary. A successful creation publishes the handle only after the initial
+render commits; a failed creation returns `handle: null`.
+
+`jsx_parse_to_json` remains a stateless inspection API and makes no ID-stability
+promise. The old `jsx_parse_and_render` API may remain as a compatibility
+wrapper for one migration cycle, but it must not remain the owner of global
+parser or DOM state.
+
+The V1 result envelope is versioned and contains `schema_version`, `success`,
+`revision`, `mounted_ids`, `diagnostics`, and `error`. `mounted_ids` are
+decimal strings at the FFI boundary even though the internal `NodeId` remains
+an integer. Recoverable parser diagnostics produce `success=true` when the
+recovered projection is renderable; parse, projection, or render failures
+produce `success=false`.
+
+#### FFI session ownership and disposal
+
+The FFI surface uses an opaque, per-renderer `JsxSession` handle. A session is
+the identity boundary for one logical JSX stream; it is not a process-global
+parser or renderer.
+
+- The caller creates and owns the session. Creation supplies the initial source
+  and the DOM root/container that the session is allowed to modify.
+- The session owns the Loom parser, projection memo(s), previous projected tree,
+  diagnostics state, mounted-node registry, and the identity allocation epoch.
+  The caller never receives or stores the parser or memo separately.
+- A render/update operation plans the source update, recovered projection, ID
+  changes, and DOM patches as one candidate. Only a successful candidate and a
+  successful DOM application advance the committed revision and mounted IDs.
+  Recoverable diagnostics do not prevent a commit when the projection is
+  renderable.
+- Calls for one session are single-threaded and non-reentrant. Separate
+  sessions may exist concurrently and must not share parsers, projection
+  memos, mounted-node registries, or identity state.
+- `NodeId` stability is guaranteed only between successful updates of the same
+  live session. Independent `parse_to_proj_node`/inspection calls and newly
+  created sessions allocate identity independently; equal numeric IDs may
+  recur, but IDs have no cross-session persistence or ownership meaning.
+- Disposal is explicit and idempotent. It unmounts nodes created by the session
+  from the owned container, clears that session's registry, releases the parser
+  and projection references, and invalidates the handle. A later update/render
+  against the handle returns a structured disposed-session error; it never
+  silently creates a replacement session.
+- The compatibility reset disposes all live sessions and invalidates their
+  handles; it does not recycle handles or preserve `NodeId`s. Stateful callers
+  should use explicit dispose/create instead.
+- A parse or projection failure does not advance the committed source,
+  projection, identity allocation, revision, or mounted IDs. The session
+  restores the parser to the last committed source, remains usable, and
+  returns the rejected candidate's diagnostics together with the last
+  committed revision and mounted IDs.
+- V1 does not promise rollback for an arbitrary exception during DOM mutation.
+  If DOM application fails after partial mutation, the session becomes
+  `dirty`; the next successful render must remount the smallest supported
+  mountable ancestor subtree before resuming incremental updates. A future
+  version may replace this recovery path with detached-subtree staging or
+  rollback.
+
+The compatibility convenience function may retain a fresh-session,
+stateless-inspection form, but it must not imply identity stability. The
+stateful web path must migrate away from module-level parser and element
+registries; the DOM root is caller-owned, while the session may remove only
+nodes it created in that root.
+
+#### Empty-tag recovery renderer behavior
+
+`Element(tag="")` remains an explicit recovery projection node so the tree
+inspector, source map, and diagnostics can account for the malformed source.
+It is not a valid DOM element and is never passed to `document.createElement`.
+
+The DOM renderer treats the recovery node as a transparent, non-mountable
+wrapper:
+
+- it emits no `MakeElement`, `SetAttrs`, or `Release` patch for the recovery
+  node itself;
+- it does not add the recovery node's ID to the mounted-ID set;
+- its already-parsed children are visited under the recovery node's parent, with
+  compacted sibling indexes, preserving visible streamed content;
+- attributes on the empty-tag recovery node are ignored by the DOM renderer;
+  their source and diagnostics remain available in the projection/inspector;
+- an empty recovery node with no children produces no DOM operation.
+
+When the recovery node becomes a valid tagged element, the renderer creates a
+new mountable element and renders the recovered children beneath it. Because
+the current patch protocol has no reparent operation, the affected descendant
+subtree is remounted at this transition if it was previously mounted through
+the transparent recovery context. V1 remounts the smallest supported
+mountable ancestor subtree; it does not attempt to preserve descendant DOM
+identity through this boundary. Identity preservation resumes normally on
+subsequent updates of the valid element. This transition is therefore an
+explicit exception to the ordinary same-kind identity guarantee and must have
+its own regression test.
+
+The same remount boundary is used for any element-tag change, including a
+truncated valid tag such as `di` becoming `div`, because V1 has no reparent
+patch and cannot safely move already-mounted descendants across a changed
+element parent.
+
+The contract is intentionally suppressive rather than placeholder-rendering:
+incomplete markup must not add visual chrome to the user's generated UI. The
+tree/debug view may still label the node as a recovery element, and diagnostics
+remain the user-visible explanation for the missing tag.
+
+#### Required acceptance tests
+
+- Two live sessions render independently without cross-session IDs or DOM
+  registry leakage.
+- Initial render commits as revision 1; failed initial render publishes no
+  usable handle and leaves the root untouched.
+- Disposal removes only the session's mounted nodes, is safe to call twice, and
+  rejects later updates.
+- Recoverable diagnostics return success with diagnostics; rejected candidates
+  return failure with the previous committed revision and mounted IDs.
+- A recoverable empty-tag node emits no invalid-element patch while its children
+  remain visible under the original parent.
+- Empty-tag recovery transitioning to a valid tag creates a valid element and
+  remounts the smallest supported mountable ancestor subtree.
+- A simulated DOM-application failure marks the session dirty and the next
+  successful render repairs the affected subtree before incremental updates
+  resume.
+- Stateless inspection documents fresh-ID semantics, while successive updates
+  through one session preserve unaffected same-kind IDs.
+
 ## Risks
 
 - **Phase 0's tcc hang may not be fixable within this plan's timebox.** The

--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -53,6 +53,24 @@ Out:
   those semantics rather than duplicating provider lifecycle rules in the JSX
   renderer.
 
+## Work Ownership
+
+- **Request lifecycle:** pure request/generation state and transition tests;
+  reuse provider-boundary semantics, but keep the first implementation
+  provider-independent.
+- **UI input adapter:** constrained candidate schema, capability validator, and
+  structured rejection diagnostics.
+- **Dry-run model:** patch/model comparison and generated-tree invariants; it
+  must not become a second production DOM implementation.
+- **JSX session adapter:** candidate-to-session wiring and the existing commit,
+  recovery, registry, and revision contract.
+- **Web example:** replay controls, generation status, and the JSON/CSV
+  vertical-slice surface. It does not own revision or commit policy.
+
+The first implementation should prefer existing project APIs in each owner
+package. Any new public type or helper must state its responsibility boundary
+and have a focused test before callers are migrated.
+
 ## Desired State
 
 The vertical slice has this observable pipeline:
@@ -88,6 +106,30 @@ policy, finalization, cancellation, stale-generation rejection, and
 terminal-state idempotency. A late or cancelled generation cannot overwrite a
 newer committed generation.
 
+### Phase 0 transition contract
+
+The following transitions are fixed before implementation begins:
+
+| Current state | Event | Next state | Required effect |
+| --- | --- | --- | --- |
+| `Idle` | `Start(base_revision)` | `Receiving` | allocate generation identity |
+| `Receiving` | next expected `Chunk` | `Receiving` | append exactly once |
+| `Receiving` | duplicate `Chunk` | `Receiving` | no state or candidate change |
+| `Receiving` | gap `Chunk` | `Receiving` or `Rejected` | follow the explicit gap policy |
+| `Receiving` | `Final` | `Validating` | freeze input; reject later chunks |
+| `Receiving` | `Cancel` | `Cancelled` | invalidate generation |
+| `Validating` | valid candidate | `DryRunning` | check base revision |
+| `Validating` | invalid/stale candidate | `Rejected` | preserve committed UI |
+| `DryRunning` | success | `Applying` | no committed revision change yet |
+| `DryRunning` | failure | `Rejected` | preserve or repair per session contract |
+| `Applying` | DOM/session success | `Committed` | advance revision once |
+| `Applying` | DOM/session failure | `Failed` | candidate remains uncommitted |
+| terminal state | any late event | same terminal state | idempotent no-op or typed rejection |
+
+Phase 0 must also decide whether a missing sequence is buffered or rejected,
+whether `Final` is a separate event or a flagged chunk, and which terminal
+state wins when cancellation races with finalization.
+
 ### Candidate and capability boundary
 
 The first candidate language is a constrained JSX-like language or equivalent
@@ -109,24 +151,29 @@ reported as uncommitted.
 
 ## Steps
 
-1. Define the request lifecycle and event envelope as pure domain data. Add
-   deterministic transitions for start, chunk, duplicate, gap, final,
-   cancel, stale, failed, and resumed states.
-2. Add a fixed-chunk replay source and fixtures for complete, incomplete,
+1. **Phase 0 — contract:** define the request lifecycle and event envelope as
+   pure domain data. Resolve every transition-table policy and add deterministic
+   tests for start, chunk, duplicate, gap, final, cancel, stale, failed, and
+   resumed states.
+2. **Phase 1 — replay:** add a fixed-chunk replay source and fixtures for
+   complete, incomplete,
    duplicated, out-of-order, late, cancelled, and resumed generations. Do not
    call a network provider.
-3. Define the constrained UI candidate schema and validator. Keep the
+3. **Phase 2 — candidate boundary:** define the constrained UI candidate schema
+   and validator. Keep the
    allowlist minimal and make rejection diagnostics structured and replayable.
-4. Build the internal dry-run model. Compare candidate projection results with
+4. **Phase 3 — dry-run and commit:** build the internal dry-run model. Compare
+   candidate projection results with
    the expected model, including sibling order, text/element mixtures, nested
    updates, and failed applications. Reuse the existing patch contract rather
    than inventing a second DOM semantics.
 5. Connect validated replay candidates to the existing JSX session. Commit only
    after dry-run and DOM success; preserve the last committed UI on rejection
    or failure.
-6. Implement the read-only JSON/CSV surface with table, filter, and
-   detail/summary updates. Preserve filter and selection state where structure
-   permits.
+6. **Phase 4 — smallest vertical slice:** implement JSON fixture + table first,
+   then add one filter and selection preservation. Only after those pass, add
+   detail/summary and CSV input. Preserve filter and selection state where
+   structure permits.
 7. Add focused and property-based tests, then browser tests for streaming,
    cancellation, late chunks, state preservation, and recovery.
 8. Measure update latency, candidate rejection/repair counts, state-loss
@@ -134,27 +181,66 @@ reported as uncommitted.
 
 ## Acceptance Criteria
 
-- [ ] A complete replay produces the expected table/filter/detail UI.
-- [ ] Incomplete or invalid candidates leave the last committed UI intact.
-- [ ] A stale base revision is rejected without advancing the session revision.
-- [ ] Duplicate chunks are idempotent; out-of-order chunks follow a defined
+- [ ] **AC-01:** A complete replay produces the expected fixture table.
+- [ ] **AC-02:** A filter and selection update preserve supported user state.
+- [ ] **AC-03:** Incomplete or invalid candidates leave the last committed UI
+      intact.
+- [ ] **AC-04:** A stale base revision is rejected without advancing the
+      session revision.
+- [ ] **AC-05:** Duplicate chunks are idempotent; out-of-order chunks follow a
+      defined
       rejection or buffering policy.
-- [ ] Cancellation invalidates the generation; late chunks cannot commit.
-- [ ] Resumption starts only from an explicitly selected committed revision.
-- [ ] Finalization is idempotent and terminal generations cannot accept later
+- [ ] **AC-06:** Cancellation invalidates the generation; late chunks cannot
+      commit.
+- [ ] **AC-07:** Resumption starts only from an explicitly selected committed
+      revision.
+- [ ] **AC-08:** Finalization is idempotent and terminal generations cannot
+      accept later
       chunks.
-- [ ] Dry-run validation completes before any candidate commit.
-- [ ] DOM application failure follows session recovery/dirty-state behavior and
+- [ ] **AC-09:** Dry-run validation completes before any candidate commit.
+- [ ] **AC-10:** DOM application failure follows session recovery/dirty-state
+      behavior and
       never reports the rejected candidate as committed.
-- [ ] The generated surface cannot perform network mutation, persistence,
+- [ ] **AC-11:** The generated surface cannot perform network mutation,
+      persistence,
       navigation, raw HTML insertion, or arbitrary code execution.
-- [ ] Existing filter/selection state is preserved for supported structural
-      updates.
-- [ ] Property tests cover removal-before-insertion, sibling indexes, nested
+- [ ] **AC-12:** Property tests cover removal-before-insertion, sibling indexes,
+      nested
       updates, text/expression-span nodes, and session isolation.
-- [ ] Browser tests cover the same lifecycle against the real JSX session.
-- [ ] The results and measurements are recorded before deciding whether to add
+- [ ] **AC-13:** Browser tests cover the same lifecycle against the real JSX
+      session.
+- [ ] **AC-14:** The results and measurements are recorded before deciding
+      whether to add
       a live provider or freeze a renderer-neutral contract.
+
+Required zero-count safety metrics: stale chunk commits, cancelled-generation
+commits, state loss, falsely committed failed applies, and deterministic replay
+mismatches. Latency, rejection rate, repair count, and memory usage are
+recorded as measurements; this plan does not set performance targets yet.
+
+## Test Matrix
+
+| Acceptance criteria | Pure lifecycle/model | MoonBit package tests | Browser/E2E |
+| --- | --- | --- | --- |
+| AC-01–AC-02 | candidate/model fixtures | JSX session contract | JSON/CSV surface |
+| AC-03–AC-05 | transition + property tests | session recovery | failed/old render |
+| AC-06–AC-08 | cancellation/terminal tests | generation adapter | stop/resume UI |
+| AC-09–AC-11 | validator + dry-run tests | DOM error contract | real DOM commit |
+| AC-12 | patch/model properties | `ffi/jsx` tests | selected lifecycle cases |
+| AC-13–AC-14 | replay/measurement harness | package totals | browser report |
+
+## Exit Gates
+
+- **Gate 0:** transition table policies are decided and every transition has a
+  deterministic test.
+- **Gate 1:** fixed replay passes without network access, including duplicate,
+  stale, cancellation, and finalization cases.
+- **Gate 2:** invalid candidates cannot reach the renderer and AC-09–AC-11
+  pass.
+- **Gate 3:** JSON fixture + table + one filter pass AC-01–AC-10 in both model
+  and browser tests.
+- **Gate 4:** full acceptance matrix and zero-count safety metrics pass. Only
+  then may a live provider or renderer-neutral contract be planned.
 
 ## Validation
 

--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -1,0 +1,207 @@
+# Generative UI input vertical slice
+
+## Why
+
+Canopy now has a JSX incremental parser, session-owned FFI rendering, and a
+direction for Generative UI. The missing implementation boundary is the path
+from an asynchronous model-like input stream to a validated candidate UI.
+
+The first implementation must prove that incomplete, duplicated, cancelled,
+late, or invalid input cannot corrupt the committed UI. It should establish
+this property without depending on a live LLM or a particular provider.
+
+## Scope
+
+In:
+
+- A replayable fixed-chunk input source for the JSX session.
+- A request/generation envelope with request identity, base revision, chunk
+  sequence, finalization, cancellation, and terminal-state rules.
+- Candidate syntax, schema, capability, and base-revision validation.
+- Internal dry-run validation using a pure/fake DOM model before commit.
+- Commit and recovery behavior for the existing session-owned JSX renderer.
+- A read-only JSON/CSV data-exploration vertical slice with table, filter, and
+  detail/summary projections.
+- Property, focused contract, and browser tests for the input lifecycle.
+
+Out:
+
+- Live Gemini or other provider integration.
+- Arbitrary JSX, raw HTML, JavaScript, or model-controlled expressions.
+- Network, persistence, navigation, or other generated side effects.
+- User-visible approval preview (internal dry-run is required).
+- Concurrent semantic editing, cross-session identity, and multi-language
+  renderer generalization.
+- A general-purpose renderer-neutral API.
+
+## Current State
+
+- The Generative UI direction and guarantees are documented in
+  `docs/architecture/generative-ui-direction.md`.
+- JSX sessions own parser/projection/DOM state and expose structured render
+  results through `ffi/jsx/session.mbt`.
+- DOM patch ordering and sibling-index correctness have a regression test in
+  `ffi/jsx/session_contract_wbtest.mbt`; broader property coverage is tracked
+  by [Issue #888](https://github.com/dowdiness/canopy/issues/888).
+- `examples/web/src/genui.js` already replays JSX prefixes through a stateful
+  session, but its source is a local fixed string and its stop behavior is not
+  yet a generation lifecycle contract.
+- `llm/` is a Gemini-specific, whole-response text-edit client. It is not the
+  UI candidate protocol and is intentionally not required for this phase.
+- `lib/cognition` contains provider-boundary concepts for request identity,
+  source revisions, cancellation, stale completion, and typed failures. Reuse
+  those semantics rather than duplicating provider lifecycle rules in the JSX
+  renderer.
+
+## Desired State
+
+The vertical slice has this observable pipeline:
+
+```text
+replayable chunk source
+  → request lifecycle
+  → candidate assembly
+  → syntax/schema/capability validation
+  → base-revision check
+  → internal dry-run against a fake DOM/model
+  → session-owned DOM commit
+```
+
+The LLM/provider is replaceable and not trusted. Only a validated candidate
+whose base revision is current and whose dry-run succeeds may advance the
+committed session revision.
+
+### Input envelope
+
+Each input event carries, at minimum:
+
+```text
+generation_id
+base_revision
+sequence
+payload
+kind = chunk | final | cancel
+```
+
+The request lifecycle owns ordering, duplicate handling, missing-sequence
+policy, finalization, cancellation, stale-generation rejection, and
+terminal-state idempotency. A late or cancelled generation cannot overwrite a
+newer committed generation.
+
+### Candidate and capability boundary
+
+The first candidate language is a constrained JSX-like language or equivalent
+allowlisted UI program. It permits only declarative components needed by the
+vertical slice: table, column, filter, text, stack/panel, and summary.
+
+Validation rejects unknown components, invalid attributes, disallowed data
+access, raw HTML, navigation, URLs controlled by the model, arbitrary code or
+expressions, and any side-effecting action. The renderer receives only
+validated candidates.
+
+### Commit boundary
+
+Candidate state is not committed when parsing or validation succeeds. Commit
+requires successful dry-run and successful DOM application with consistent
+session state, registry, mounted IDs, and revision. If application fails, the
+existing session recovery/dirty-state contract applies and the candidate is
+reported as uncommitted.
+
+## Steps
+
+1. Define the request lifecycle and event envelope as pure domain data. Add
+   deterministic transitions for start, chunk, duplicate, gap, final,
+   cancel, stale, failed, and resumed states.
+2. Add a fixed-chunk replay source and fixtures for complete, incomplete,
+   duplicated, out-of-order, late, cancelled, and resumed generations. Do not
+   call a network provider.
+3. Define the constrained UI candidate schema and validator. Keep the
+   allowlist minimal and make rejection diagnostics structured and replayable.
+4. Build the internal dry-run model. Compare candidate projection results with
+   the expected model, including sibling order, text/element mixtures, nested
+   updates, and failed applications. Reuse the existing patch contract rather
+   than inventing a second DOM semantics.
+5. Connect validated replay candidates to the existing JSX session. Commit only
+   after dry-run and DOM success; preserve the last committed UI on rejection
+   or failure.
+6. Implement the read-only JSON/CSV surface with table, filter, and
+   detail/summary updates. Preserve filter and selection state where structure
+   permits.
+7. Add focused and property-based tests, then browser tests for streaming,
+   cancellation, late chunks, state preservation, and recovery.
+8. Measure update latency, candidate rejection/repair counts, state-loss
+   count, stale-chunk application count, and deterministic replay results.
+
+## Acceptance Criteria
+
+- [ ] A complete replay produces the expected table/filter/detail UI.
+- [ ] Incomplete or invalid candidates leave the last committed UI intact.
+- [ ] A stale base revision is rejected without advancing the session revision.
+- [ ] Duplicate chunks are idempotent; out-of-order chunks follow a defined
+      rejection or buffering policy.
+- [ ] Cancellation invalidates the generation; late chunks cannot commit.
+- [ ] Resumption starts only from an explicitly selected committed revision.
+- [ ] Finalization is idempotent and terminal generations cannot accept later
+      chunks.
+- [ ] Dry-run validation completes before any candidate commit.
+- [ ] DOM application failure follows session recovery/dirty-state behavior and
+      never reports the rejected candidate as committed.
+- [ ] The generated surface cannot perform network mutation, persistence,
+      navigation, raw HTML insertion, or arbitrary code execution.
+- [ ] Existing filter/selection state is preserved for supported structural
+      updates.
+- [ ] Property tests cover removal-before-insertion, sibling indexes, nested
+      updates, text/expression-span nodes, and session isolation.
+- [ ] Browser tests cover the same lifecycle against the real JSX session.
+- [ ] The results and measurements are recorded before deciding whether to add
+      a live provider or freeze a renderer-neutral contract.
+
+## Validation
+
+During implementation, run the smallest affected checks after each change:
+
+```bash
+NEW_MOON_MOD=0 moon check ffi/jsx
+moon test ffi/jsx
+moon test core
+moon test lang/jsx/proj
+```
+
+Before the vertical slice is considered complete:
+
+```bash
+moon fmt
+moon info
+moon check
+moon test
+moon build --target js --release
+cd examples/web && npm run build
+```
+
+Run the relevant browser suite after the web server and built artifacts are
+available. Existing unrelated vendored-browser failures must remain separately
+identified rather than hidden by this plan.
+
+## Risks
+
+- A fake DOM model may accidentally diverge from real DOM behavior; retain
+  browser tests for the commit path.
+- The candidate allowlist may be too broad; begin with the smallest useful
+  component set.
+- Chunk buffering can create unbounded memory; enforce a generation size and
+  sequence limit.
+- Recovery may rebuild more UI than ideal; correctness precedes optimization.
+- Provider-specific concerns may leak into the lifecycle; keep the replay
+  source and provider boundary separate.
+- A successful demo may tempt premature semantic merge or multi-renderer
+  abstraction; require a second adapter and measured invariants first.
+
+## Notes
+
+- The first live provider should be added only after replay and browser tests
+  pass. Adapt `llm/` as a transport/provider implementation; do not make its
+  Gemini-specific `EditAction` contract the Generative UI domain model.
+- `moon prove` is a later option for pure request/reconciliation invariants. It
+  is not a prerequisite for proving the JavaScript/DOM boundary.
+- Related direction: `docs/architecture/generative-ui-direction.md`.
+- Related correctness work: [Issue #888](https://github.com/dowdiness/canopy/issues/888).

--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -66,6 +66,10 @@ Out:
   recovery, registry, and revision contract.
 - **Web example:** replay controls, generation status, and the JSON/CSV
   vertical-slice surface. It does not own revision or commit policy.
+- **Host interaction state:** trusted data bindings, filter values, selection,
+  and allowlisted aggregation parameters remain host-owned. The candidate may
+  reference these capabilities declaratively but cannot execute code or own
+  their mutable state.
 
 The first implementation should prefer existing project APIs in each owner
 package. Any new public type or helper must state its responsibility boundary
@@ -118,23 +122,31 @@ The following transitions are fixed before implementation begins:
 | `Receiving` | gap `Chunk` | `Receiving` or `Rejected` | follow the explicit gap policy |
 | `Receiving` | `Final` | `Validating` | freeze input; reject later chunks |
 | `Receiving` | `Cancel` | `Cancelled` | invalidate generation |
+| `Validating` | `Cancel` | `Cancelled` | invalidate before dry-run |
 | `Validating` | valid candidate | `DryRunning` | check base revision |
 | `Validating` | invalid/stale candidate | `Rejected` | preserve committed UI |
+| `DryRunning` | `Cancel` | `Cancelled` | invalidate before applying |
 | `DryRunning` | success | `Applying` | no committed revision change yet |
 | `DryRunning` | failure | `Rejected` | preserve or repair per session contract |
+| `Applying` | `Cancel` | `Applying` | cancellation is too late; linearize apply |
 | `Applying` | DOM/session success | `Committed` | advance revision once |
 | `Applying` | DOM/session failure | `Failed` | candidate remains uncommitted |
 | terminal state | any late event | same terminal state | idempotent no-op or typed rejection |
 
 Phase 0 must also decide whether a missing sequence is buffered or rejected,
 whether `Final` is a separate event or a flagged chunk, and which terminal
-state wins when cancellation races with finalization.
+state wins when cancellation races with finalization. Cancellation is checked at
+each asynchronous boundary. Once DOM application begins, it is synchronous for
+the purpose of this contract: cancellation cannot interrupt or roll it back,
+and the apply result determines whether the candidate commits.
 
 ### Candidate and capability boundary
 
 The first candidate language is a constrained JSX-like language or equivalent
 allowlisted UI program. It permits only declarative components needed by the
-vertical slice: table, column, filter, text, stack/panel, and summary.
+vertical slice: table, column, filter, text, stack/panel, and summary. Data
+bindings are opaque host-owned references; filter fields/operators, selection
+keys, and summary aggregations come from allowlisted host capabilities.
 
 Validation rejects unknown components, invalid attributes, disallowed data
 access, raw HTML, navigation, URLs controlled by the model, arbitrary code or
@@ -146,8 +158,12 @@ validated candidates.
 Candidate state is not committed when parsing or validation succeeds. Commit
 requires successful dry-run and successful DOM application with consistent
 session state, registry, mounted IDs, and revision. If application fails, the
-existing session recovery/dirty-state contract applies and the candidate is
-reported as uncommitted.
+existing session recovery/dirty-state contract applies: committed source and
+revision remain unchanged, the session is marked dirty, and the candidate is
+reported as uncommitted. V1 permits the DOM to be temporarily dirty after a
+partial failure; the next successful render must remount/repair the dirty root
+before committing a new candidate. Immediate rollback is a separate follow-up
+if the product requires it.
 
 ## Steps
 
@@ -160,16 +176,18 @@ reported as uncommitted.
    duplicated, out-of-order, late, cancelled, and resumed generations. Do not
    call a network provider.
 3. **Phase 2 — candidate boundary:** define the constrained UI candidate schema
-   and validator. Keep the
-   allowlist minimal and make rejection diagnostics structured and replayable.
+   and validator. Keep the allowlist minimal, make rejection diagnostics
+   structured and replayable, and define the lowering from host-owned data
+   bindings and interaction state into the JSX session.
 4. **Phase 3 — dry-run and commit:** build the internal dry-run model. Compare
    candidate projection results with
    the expected model, including sibling order, text/element mixtures, nested
    updates, and failed applications. Reuse the existing patch contract rather
    than inventing a second DOM semantics.
 5. Connect validated replay candidates to the existing JSX session. Commit only
-   after dry-run and DOM success; preserve the last committed UI on rejection
-   or failure.
+   after dry-run and DOM success. On failure, preserve committed source and
+   revision, mark the session dirty, and verify that the next success repairs
+   the dirty root before commit.
 6. **Phase 4 — smallest vertical slice:** implement JSON fixture + table first,
    then add one filter and selection preservation. Only after those pass, add
    detail/summary and CSV input. Preserve filter and selection state where
@@ -183,33 +201,37 @@ reported as uncommitted.
 
 - [ ] **AC-01:** A complete replay produces the expected fixture table.
 - [ ] **AC-02:** A filter and selection update preserve supported user state.
-- [ ] **AC-03:** Incomplete or invalid candidates leave the last committed UI
-      intact.
+- [ ] **AC-03:** Incomplete or invalid candidates leave committed source and
+      revision unchanged; invalid candidates do not reach the renderer.
 - [ ] **AC-04:** A stale base revision is rejected without advancing the
       session revision.
 - [ ] **AC-05:** Duplicate chunks are idempotent; out-of-order chunks follow a
       defined
       rejection or buffering policy.
-- [ ] **AC-06:** Cancellation invalidates the generation; late chunks cannot
-      commit.
+- [ ] **AC-06:** Cancellation invalidates generations before `Applying`; late
+      chunks cannot commit. Cancellation after `Applying` begins is too late
+      and the apply result linearizes.
 - [ ] **AC-07:** Resumption starts only from an explicitly selected committed
       revision.
 - [ ] **AC-08:** Finalization is idempotent and terminal generations cannot
       accept later
       chunks.
 - [ ] **AC-09:** Dry-run validation completes before any candidate commit.
-- [ ] **AC-10:** DOM application failure follows session recovery/dirty-state
-      behavior and
-      never reports the rejected candidate as committed.
+- [ ] **AC-10:** DOM application failure preserves committed source and
+      revision, marks the session dirty, never reports the candidate committed,
+      and the next successful render repairs the dirty root before commit.
 - [ ] **AC-11:** The generated surface cannot perform network mutation,
       persistence,
       navigation, raw HTML insertion, or arbitrary code execution.
 - [ ] **AC-12:** Property tests cover removal-before-insertion, sibling indexes,
       nested
       updates, text/expression-span nodes, and session isolation.
-- [ ] **AC-13:** Browser tests cover the same lifecycle against the real JSX
+- [ ] **AC-13:** Host-owned data bindings, filter/selection state, and
+      allowlisted aggregations lower into the candidate without arbitrary
+      expressions or candidate-owned mutable state.
+- [ ] **AC-14:** Browser tests cover the same lifecycle against the real JSX
       session.
-- [ ] **AC-14:** The results and measurements are recorded before deciding
+- [ ] **AC-15:** The results and measurements are recorded before deciding
       whether to add
       a live provider or freeze a renderer-neutral contract.
 
@@ -226,8 +248,8 @@ recorded as measurements; this plan does not set performance targets yet.
 | AC-03–AC-05 | transition + property tests | session recovery | failed/old render |
 | AC-06–AC-08 | cancellation/terminal tests | generation adapter | stop/resume UI |
 | AC-09–AC-11 | validator + dry-run tests | DOM error contract | real DOM commit |
-| AC-12 | patch/model properties | `ffi/jsx` tests | selected lifecycle cases |
-| AC-13–AC-14 | replay/measurement harness | package totals | browser report |
+| AC-12–AC-13 | patch/model + binding properties | `ffi/jsx` tests | interaction cases |
+| AC-14–AC-15 | replay/measurement harness | package totals | browser report |
 
 ## Exit Gates
 
@@ -238,7 +260,7 @@ recorded as measurements; this plan does not set performance targets yet.
 - **Gate 2:** invalid candidates cannot reach the renderer and AC-09–AC-11
   pass.
 - **Gate 3:** JSON fixture + table + one filter pass AC-01–AC-10 in both model
-  and browser tests.
+  and browser tests, and AC-13 confirms host-owned bindings.
 - **Gate 4:** full acceptance matrix and zero-count safety metrics pass. Only
   then may a live provider or renderer-neutral contract be planned.
 

--- a/examples/web/src/genui.js
+++ b/examples/web/src/genui.js
@@ -22,6 +22,8 @@ const statusBar = document.getElementById('status-bar')
 let isStreaming = false
 let abortStream = false
 let previousNodeIds = new Set()
+let jsxModule = null
+let jsxSessionHandle = null
 
 document.querySelectorAll('[data-example]').forEach(function(btn) {
   btn.addEventListener('click', function() {
@@ -55,6 +57,10 @@ clearBtn.addEventListener('click', function() {
 });
 
 function resetState() {
+  if (jsxModule && jsxSessionHandle !== null) {
+    jsxModule.jsx_session_dispose(jsxSessionHandle)
+    jsxSessionHandle = null
+  }
   previousNodeIds = new Set();
   treeOutput.innerHTML = '<div class="text-center py-8 text-canopy-muted text-xs">Stream JSX to see the tree.</div>';
   htmlPreview.innerHTML = '<div class="text-center py-8 text-canopy-muted text-xs">Stream JSX to see rendered output.</div>';
@@ -113,7 +119,7 @@ function collectNodeIds(root) {
   return ids;
 }
 
-// ── Streaming (MoonBit render via jsx_parse_and_render) ──
+// ── Streaming (MoonBit render via a stateful JSX FFI session) ──
 streamBtn.addEventListener('click', async function() {
   if (isStreaming) { abortStream = true; return; }
   const fullText = sourceInput.value;
@@ -137,18 +143,37 @@ streamBtn.addEventListener('click', async function() {
 
   try {
     const JsxMod = await import('@moonbit/crdt-jsx');
-    JsxMod.reset_jsx_state();
+    jsxModule = JsxMod;
+    if (jsxSessionHandle !== null) {
+      JsxMod.jsx_session_dispose(jsxSessionHandle);
+      jsxSessionHandle = null;
+    }
     statusBar.textContent = 'Streaming ' + prefixes.length + ' steps...';
-    let existingIds = '[]';
+    let finalIds = [];
     for (let si = 0; si < prefixes.length; si++) {
       if (abortStream) break;
       stepNum.textContent = (si + 1) + ' / ' + prefixes.length;
       htmlStepNum.textContent = (si + 1) + ' / ' + prefixes.length;
       streamProgress.innerHTML = '<span class="text-canopy-muted">Step ' + (si + 1) + ':</span> ' + esc(prefixes[si]);
       
-      // MoonBit: parse → reconcile → apply patches in one call
-      existingIds = JsxMod.jsx_parse_and_render(prefixes[si], existingIds);
-      const ids = JSON.parse(existingIds);
+      // The first call creates and renders the session. Later calls update
+      // exactly that session, so parser/projection/DOM ownership stays local.
+      let renderResult;
+      if (si === 0) {
+        const created = JSON.parse(JsxMod.jsx_session_new(prefixes[si], 'html-preview'));
+        if (!created.success || created.handle === null) {
+          throw new Error(created.result?.error?.message || 'JSX session creation failed');
+        }
+        jsxSessionHandle = Number(created.handle);
+        renderResult = created.result;
+      } else {
+        renderResult = JSON.parse(JsxMod.jsx_session_render(jsxSessionHandle, prefixes[si]));
+      }
+      if (!renderResult.success) {
+        throw new Error(renderResult.error?.message || 'JSX session render failed');
+      }
+      const ids = renderResult.mounted_ids;
+      finalIds = ids;
       htmlNodeCount.textContent = ids.length;
       
       // Tree view from batch parse
@@ -175,7 +200,6 @@ streamBtn.addEventListener('click', async function() {
       await new Promise(function(r) { setTimeout(r, si < 5 ? 60 : 100); });
     }
     statusBar.className = 'mt-2 p-1.5 bg-canopy-bg rounded-md text-[11px] text-canopy-muted';
-    const finalIds = JSON.parse(existingIds);
     statusBar.textContent = abortStream ? 'Stopped.' : 'Complete \u2014 ' + finalIds.length + ' DOM nodes rendered.';
   } catch (err) {
     console.error(err);

--- a/ffi/jsx/apply_patches.mbt
+++ b/ffi/jsx/apply_patches.mbt
@@ -94,6 +94,15 @@ fn apply_patches_unchecked(
   let patches_arr : @js.Any = @js.parse(patches_json)
   let len : Int = patches_arr.get("length").cast()
   let ids : Array[Int] = []
+  // Release first so projected insertion indexes are evaluated against the
+  // post-removal sibling list.
+  for i in 0..<len {
+    let patch = patches_arr.at(i)
+    if patch.get("$tag").to_str() == "Release" {
+      let node_id : Int = patch.get("_0").at(0).cast()
+      release_element(registry, node_id)
+    }
+  }
   for i in 0..<len {
     let patch = patches_arr.at(i)
     let tag : String = patch.get("$tag").to_str()
@@ -194,14 +203,9 @@ fn apply_patches_unchecked(
         apply_attrs(el, attrs)
         ids.push(node_id)
       }
-      "Release" => {
-        let node_id : Int = args.at(0).cast()
-        let el = retrieve_element(registry, node_id)
-        if !el.is_nullish() {
-          ignore(el.call("remove", []))
-          forget_element(registry, node_id)
-        }
-      }
+      "Release" =>
+        // Releases are applied in the pass above, before insertions.
+        ()
       _ => ()
     }
   }
@@ -240,6 +244,15 @@ fn retrieve_element(registry : @js.Any, node_id : Int) -> @js.Any {
 ///|
 fn forget_element(registry : @js.Any, node_id : Int) -> Unit {
   let _ = registry.call("delete", [@js.any(node_id)])
+}
+
+///|
+fn release_element(registry : @js.Any, node_id : Int) -> Unit {
+  let el = retrieve_element(registry, node_id)
+  if !el.is_nullish() {
+    ignore(el.call("remove", []))
+    forget_element(registry, node_id)
+  }
 }
 
 ///|

--- a/ffi/jsx/apply_patches.mbt
+++ b/ffi/jsx/apply_patches.mbt
@@ -1,33 +1,99 @@
 ///| Apply DomPatch[] to real DOM elements via js_ffi Any.
 
-///| Container is looked up by ID ("html-preview").
+///|
+/// A legacy container/registry kept only for the compatibility API.
+let legacy_container_id : String = "html-preview"
 
 ///|
-/// Element registry is a module-level JS Map (no globalThis).
-let container_id : String = "html-preview"
+/// JavaScript exceptions are not represented as MoonBit `raise` effects by
+/// `Any::call`. Catch them at the JavaScript boundary so a DOM failure can
+/// become the session's structured `DomApplyError` and dirty-state path.
+extern "js" fn catch_js(callback : @js.Any) -> @js.Any =
+  #|(callback) => {
+  #|  try {
+  #|    return { ok: true, value: callback() };
+  #|  } catch (error) {
+  #|    return { ok: false, error: String(error) };
+  #|  }
+  #|}
 
 ///|
-/// Module-level element registry: created once, persists across FFI calls.
-let element_registry : @js.Any = {
+/// Create a registry owned by one session. Session registries must never be
+/// shared, even when two sessions happen to allocate equal internal NodeIds.
+fn new_element_registry() -> @js.Any {
   let map = @js.global().get("Map")
   map.construct([])
 }
 
 ///|
-/// Clear only the element registry.
-pub fn clear_registry() -> Unit {
-  let _ = element_registry.call("clear", [])
+/// Compatibility registry for the old one-cycle API.
+let legacy_element_registry : @js.Any = new_element_registry()
+
+///|
+fn clear_element_registry(registry : @js.Any) -> Unit {
+  ignore(
+    registry.call("forEach", [
+      @js.fn2(fn(el : @js.Any, _key : @js.Any) {
+        if !el.is_nullish() {
+          ignore(el.call("remove", []))
+        }
+      }),
+    ]),
+  )
+  let _ = registry.call("clear", [])
 }
 
 ///|
-/// Apply patches and return JSON array of remaining NodeIds.
-pub fn apply_patches(patches_json : String) -> String {
-  let container = @js.global()
-    .get("document")
-    .call("getElementById", [@js.any(container_id)])
+/// Clear the legacy compatibility registry.
+pub fn clear_registry() -> Unit {
+  clear_element_registry(legacy_element_registry)
+}
+
+///|
+/// Clear every node owned by one session. The caller must drop the registry
+/// after this call; the DOM nodes are removed before the JS Map is cleared.
+fn clear_session_registry(registry : @js.Any) -> Unit {
+  clear_element_registry(registry)
+}
+
+///|
+/// Apply patches to a specific root and registry. All DOM state used by this
+/// function is supplied by the caller, so separate sessions cannot retrieve or
+/// release each other's nodes.
+fn apply_patches_with_registry(
+  patches_json : String,
+  root_id : String,
+  registry : @js.Any,
+) -> Result[Array[Int], String] {
+  let outcome = catch_js(
+    @js.fn0(fn() {
+      @js.any(apply_patches_unchecked(patches_json, root_id, registry))
+    }),
+  )
+  if !outcome.get("ok").cast() {
+    Err(outcome.get("error").to_str())
+  } else {
+    outcome.get("value").cast()
+  }
+}
+
+///|
+fn apply_patches_unchecked(
+  patches_json : String,
+  root_id : String,
+  registry : @js.Any,
+) -> Result[Array[Int], String] {
+  let document = @js.global().get("document")
+  if document.is_nullish() {
+    return Err("document is unavailable")
+  }
+  let container = document.call("getElementById", [@js.any(root_id)])
+  if container.is_nullish() {
+    return Err("root container is unavailable: " + root_id)
+  }
   let patches_arr : @js.Any = @js.parse(patches_json)
   let len : Int = patches_arr.get("length").cast()
-  let ids : @js.Any = @js.array()
+  let ids : Array[Int] = []
   for i in 0..<len {
     let patch = patches_arr.at(i)
     let tag : String = patch.get("$tag").to_str()
@@ -38,7 +104,11 @@ pub fn apply_patches(patches_json : String) -> String {
         let node_id : Int = args.at(1).cast()
         let tag_name : String = args.at(2).cast()
         let attrs : @js.Any = args.at(3)
+        let index : Int = args.at(4).cast()
         let el = create_element(tag_name)
+        // Stash before the first potentially-throwing DOM call. This makes a
+        // partial application cleanable by the session's disposal path.
+        stash_element(registry, node_id, el)
         ignore(
           el.call("setAttribute", [
             @js.any("data-node-id"),
@@ -49,89 +119,140 @@ pub fn apply_patches(patches_json : String) -> String {
         let parent = if parent_id == -1 {
           container
         } else {
-          retrieve_element(parent_id)
+          retrieve_element(registry, parent_id)
         }
-        ignore(parent.call("appendChild", [el]))
-        stash_element(node_id, el)
-        ignore(ids.call("push", [@js.any(node_id)]))
+        if parent.is_nullish() {
+          return Err("missing parent node: " + parent_id.to_string())
+        }
+        insert_child(parent, el, index)
+        ids.push(node_id)
       }
       "MakeText" => {
         let parent_id : Int = args.at(0).cast()
         let node_id : Int = args.at(1).cast()
         let text : String = args.at(2).cast()
-        let el = @js.global()
-          .get("document")
-          .call("createTextNode", [@js.any(text)])
+        let index : Int = args.at(3).cast()
+        let el = document.call("createTextNode", [@js.any(text)])
+        stash_element(registry, node_id, el)
         let parent = if parent_id == -1 {
           container
         } else {
-          retrieve_element(parent_id)
+          retrieve_element(registry, parent_id)
         }
-        ignore(parent.call("appendChild", [el]))
-        stash_element(node_id, el)
-        ignore(ids.call("push", [@js.any(node_id)]))
+        if parent.is_nullish() {
+          return Err("missing parent node: " + parent_id.to_string())
+        }
+        insert_child(parent, el, index)
+        ids.push(node_id)
       }
       "MakeExprSpan" => {
         let parent_id : Int = args.at(0).cast()
         let node_id : Int = args.at(1).cast()
         let raw : String = args.at(2).cast()
+        let index : Int = args.at(3).cast()
         let el = create_element("span")
+        stash_element(registry, node_id, el)
         el.set("textContent", @js.any("{" + raw + "}"))
         let parent = if parent_id == -1 {
           container
         } else {
-          retrieve_element(parent_id)
+          retrieve_element(registry, parent_id)
         }
-        ignore(parent.call("appendChild", [el]))
-        stash_element(node_id, el)
-        ignore(ids.call("push", [@js.any(node_id)]))
+        if parent.is_nullish() {
+          return Err("missing parent node: " + parent_id.to_string())
+        }
+        insert_child(parent, el, index)
+        ids.push(node_id)
       }
       "SetText" => {
         let node_id : Int = args.at(0).cast()
         let text : String = args.at(1).cast()
-        retrieve_element(node_id).set("textContent", @js.any(text))
-        ignore(ids.call("push", [@js.any(node_id)]))
+        let el = retrieve_element(registry, node_id)
+        if el.is_nullish() {
+          return Err("missing node: " + node_id.to_string())
+        }
+        el.set("textContent", @js.any(text))
+        ids.push(node_id)
       }
       "SetExpr" => {
         let node_id : Int = args.at(0).cast()
         let raw : String = args.at(1).cast()
-        retrieve_element(node_id).set("textContent", @js.any("{" + raw + "}"))
-        ignore(ids.call("push", [@js.any(node_id)]))
+        let el = retrieve_element(registry, node_id)
+        if el.is_nullish() {
+          return Err("missing node: " + node_id.to_string())
+        }
+        el.set("textContent", @js.any("{" + raw + "}"))
+        ids.push(node_id)
       }
       "SetAttrs" => {
         let node_id : Int = args.at(0).cast()
         let attrs : @js.Any = args.at(1)
-        apply_attrs(retrieve_element(node_id), attrs)
-        ignore(ids.call("push", [@js.any(node_id)]))
+        let el = retrieve_element(registry, node_id)
+        if el.is_nullish() {
+          return Err("missing node: " + node_id.to_string())
+        }
+        apply_attrs(el, attrs)
+        ids.push(node_id)
       }
       "Release" => {
         let node_id : Int = args.at(0).cast()
-        let el = retrieve_element(node_id)
-        ignore(el.call("remove", []))
-        forget_element(node_id)
+        let el = retrieve_element(registry, node_id)
+        if !el.is_nullish() {
+          ignore(el.call("remove", []))
+          forget_element(registry, node_id)
+        }
       }
       _ => ()
     }
   }
-  let joined : String = ids.call("join", [@js.any(",")]).cast()
-  "[" + joined + "]"
+  Ok(ids)
+}
+
+///|
+/// Apply patches using the legacy compatibility registry.
+pub fn apply_patches(patches_json : String) -> String {
+  match
+    apply_patches_with_registry(
+      patches_json, legacy_container_id, legacy_element_registry,
+    ) {
+    Ok(ids) => array_ids_to_json(ids)
+    Err(_) => "[]"
+  }
 }
 
 // ── Element registry helpers ────────────────────────────────────────────
 
 ///|
-fn stash_element(node_id : Int, el : @js.Any) -> Unit {
-  let _ = element_registry.call("set", [@js.any(node_id), el])
+fn array_ids_to_json(ids : Array[Int]) -> String {
+  Json::array(ids.map(id => Json::number(id.to_double()))).stringify()
 }
 
 ///|
-fn retrieve_element(node_id : Int) -> @js.Any {
-  element_registry.call("get", [@js.any(node_id)])
+fn stash_element(registry : @js.Any, node_id : Int, el : @js.Any) -> Unit {
+  let _ = registry.call("set", [@js.any(node_id), el])
 }
 
 ///|
-fn forget_element(node_id : Int) -> Unit {
-  let _ = element_registry.call("delete", [@js.any(node_id)])
+fn retrieve_element(registry : @js.Any, node_id : Int) -> @js.Any {
+  registry.call("get", [@js.any(node_id)])
+}
+
+///|
+fn forget_element(registry : @js.Any, node_id : Int) -> Unit {
+  let _ = registry.call("delete", [@js.any(node_id)])
+}
+
+///|
+/// Respect the projected sibling index. `childNodes` is used instead of
+/// `children` because text nodes and expression spans are mounted too.
+fn insert_child(parent : @js.Any, child : @js.Any, index : Int) -> Unit {
+  let child_nodes = parent.get("childNodes")
+  let len : Int = child_nodes.get("length").cast()
+  if index < len {
+    ignore(parent.call("insertBefore", [child, child_nodes.at(index)]))
+  } else {
+    ignore(parent.call("appendChild", [child]))
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────

--- a/ffi/jsx/jsx_ffi.mbt
+++ b/ffi/jsx/jsx_ffi.mbt
@@ -147,28 +147,17 @@ fn get_or_empty_errors(text : String) -> Array[String] {
 }
 
 ///|
-let __state : @js.Any = @js.object()
-
-///|
-/// Parse and render using a shared parser for stable node_ids across calls.
+/// Legacy one-cycle compatibility wrapper. Identity stability belongs to
+/// `jsx_session_new`/`jsx_session_render`; this function intentionally parses
+/// independently on every call and keeps no parser or DOM ownership state.
 pub fn jsx_parse_and_render(text : String, existing_json : String) -> String {
-  let p = __state.get("p")
-  if p.is_nullish() {
-    let parser : @loom.Parser[@jsx_ast.JsxNode] = @loom.new_parser(
-      text, @jsx_ast.jsx_grammar,
-    )
-    let (mem, _, _) = @jsx_proj.build_jsx_projection_memos(parser)
-    __state.set("p", @js.any(parser))
-    __state.set("m", @js.any(mem))
-  } else {
-    let parser : @loom.Parser[@jsx_ast.JsxNode] = p.cast()
-    parser.set_source(text)
+  let parsed : (@canopy_core.ProjNode[@jsx_ast.JsxNode], Array[String])? = Some(
+    @jsx_proj.parse_to_proj_node(text),
+  ) catch {
+    _ => None
   }
-  let mem : @incr.Derived[@canopy_core.ProjNode[@jsx_ast.JsxNode]?] = __state
-    .get("m")
-    .cast()
-  match mem.read_or_abort() {
-    Some(proj) => render_proj(proj, existing_json)
+  match parsed {
+    Some((proj, _)) => render_proj(proj, existing_json)
     None => existing_json
   }
 }
@@ -190,9 +179,9 @@ fn render_proj(
 }
 
 ///|
-/// Reset the parser, projection memos, and DOM element registry.
+/// Reset all stateful sessions and the legacy registry. This is a compatibility
+/// operation for old demo callers; new callers should dispose their handle.
 pub fn reset_jsx_state() -> Unit {
-  __state.set("p", @js.null_())
-  __state.set("m", @js.null_())
+  reset_all_jsx_sessions()
   clear_registry()
 }

--- a/ffi/jsx/moon.pkg
+++ b/ffi/jsx/moon.pkg
@@ -6,6 +6,7 @@ import {
   "dowdiness/jsx" @jsx_ast,
   "dowdiness/loom",
   "moonbitlang/core/json",
+  "moonbitlang/core/string",
 }
 
 supported_targets = "js"
@@ -16,6 +17,9 @@ options(
       "exports": [
         "jsx_parse_to_json",
         "jsx_streaming_to_json",
+        "jsx_session_new",
+        "jsx_session_render",
+        "jsx_session_dispose",
         "jsx_parse_and_render",
         "reset_jsx_state",
         "clear_registry",

--- a/ffi/jsx/pkg.generated.mbti
+++ b/ffi/jsx/pkg.generated.mbti
@@ -10,6 +10,12 @@ pub fn jsx_parse_and_render(String, String) -> String
 
 pub fn jsx_parse_to_json(String) -> String
 
+pub fn jsx_session_dispose(Int) -> Unit
+
+pub fn jsx_session_new(String, String) -> String
+
+pub fn jsx_session_render(Int, String) -> String
+
 pub fn jsx_streaming_to_json(String) -> String
 
 pub fn reset_jsx_state() -> Unit

--- a/ffi/jsx/session.mbt
+++ b/ffi/jsx/session.mbt
@@ -1,0 +1,285 @@
+///| V1 stateful JSX FFI sessions.
+
+///|
+/// A session owns all state that can affect projection identity or DOM
+/// ownership. The process-global map is only a handle index; every value in
+/// it is a complete, session-private ownership record.
+priv struct JsxSession {
+  parser : @loom.Parser[@jsx_ast.JsxNode]
+  proj_memo : @incr.Derived[@canopy_core.ProjNode[@jsx_ast.JsxNode]?]
+  registry_memo : @incr.Derived[
+    Map[@canopy_core.NodeId, @canopy_core.ProjNode[@jsx_ast.JsxNode]],
+  ]
+  source_map_memo : @incr.Derived[@canopy_core.SourceMap]
+  proj_watch : @incr.Watch[@canopy_core.ProjNode[@jsx_ast.JsxNode]?]
+  registry : @js.Any
+  root_id : String
+  mut committed_source : String
+  mut revision : Int
+  mut mounted_ids : Array[Int]
+  mut last_proj : @canopy_core.ProjNode[@jsx_ast.JsxNode]?
+  mut dirty : Bool
+}
+
+///|
+let session_registry : Map[Int, JsxSession] = {}
+
+///|
+let disposed_session_handles : Map[Int, Bool] = {}
+
+///|
+let next_session_handle : Ref[Int] = { val: 1 }
+
+///|
+/// The result schema is deliberately JSON at the JS boundary. `mounted_ids`
+/// are strings so JavaScript callers never depend on MoonBit's internal
+/// integer representation for NodeId.
+fn render_result_json(
+  success : Bool,
+  revision : Int,
+  mounted_ids : Array[Int],
+  diagnostics : Array[String],
+  error : (String, String)?,
+) -> String {
+  let error_json = match error {
+    Some((code, message)) =>
+      Json::object({
+        "code": Json::string(code),
+        "message": Json::string(message),
+      })
+    None => Json::null()
+  }
+  Json::object({
+    "schema_version": Json::number(1.0),
+    "success": Json::boolean(success),
+    "revision": Json::number(revision.to_double()),
+    "mounted_ids": Json::array(
+      mounted_ids.map(id => Json::string(id.to_string())),
+    ),
+    "diagnostics": Json::array(diagnostics.map(Json::string)),
+    "error": error_json,
+  }).stringify()
+}
+
+///|
+fn session_envelope_json(handle : Int?, result_json : String) -> String {
+  let result = @js.parse(result_json)
+  let envelope = @js.object()
+  envelope.set("schema_version", @js.any(1))
+  envelope.set("success", result.get("success"))
+  match handle {
+    Some(value) => envelope.set("handle", @js.any(value.to_string()))
+    None => envelope.set("handle", @js.null_())
+  }
+  envelope.set("result", result)
+  envelope.stringify()
+}
+
+///|
+fn new_jsx_session(source : String, root_id : String) -> JsxSession {
+  let parser = @loom.new_parser(source, @jsx_ast.jsx_grammar)
+  let (proj_memo, registry_memo, source_map_memo) = @jsx_proj.build_jsx_projection_memos(
+    parser,
+  )
+  let proj_watch = proj_memo.watch()
+  {
+    parser,
+    proj_memo,
+    registry_memo,
+    source_map_memo,
+    proj_watch,
+    registry: new_element_registry(),
+    root_id,
+    committed_source: source,
+    revision: 0,
+    mounted_ids: [],
+    last_proj: None,
+    dirty: false,
+  }
+}
+
+///|
+fn has_mount_boundary_transition(
+  old : @canopy_core.ProjNode[@jsx_ast.JsxNode],
+  new : @canopy_core.ProjNode[@jsx_ast.JsxNode],
+) -> Bool {
+  match (old.kind, new.kind) {
+    (
+      @jsx_ast.JsxNode::Element(tag=old_tag, ..),
+      @jsx_ast.JsxNode::Element(tag=new_tag, ..),
+    ) => if old_tag != new_tag { return true }
+    _ => ()
+  }
+  let len = old.children.length().min(new.children.length())
+  for i in 0..<len {
+    if has_mount_boundary_transition(old.children[i], new.children[i]) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Return the parser to the last DOM-committed source after a rejected
+/// candidate. The memo may still retain internal speculative work, so the
+/// session remains dirty and the next successful render must remount.
+fn restore_committed_source(session : JsxSession) -> Unit {
+  session.parser.set_source(session.committed_source)
+}
+
+///|
+fn dispose_jsx_session(session : JsxSession) -> Unit {
+  clear_session_registry(session.registry)
+  // Dependents must go first. The parser-owned views are then collectable
+  // after the session references disappear from the registry.
+  session.source_map_memo.dispose()
+  session.registry_memo.dispose()
+  session.proj_watch.dispose()
+  session.proj_memo.dispose()
+  session.parser.runtime().gc()
+}
+
+///|
+fn render_jsx_session(
+  session : JsxSession,
+  source : String,
+  update_source : Bool,
+) -> String {
+  if update_source {
+    session.parser.set_source(source)
+  }
+  let diagnostics = get_or_empty_errors(source)
+  match session.proj_watch.read() {
+    Ok(Some(proj)) => {
+      let transition = match session.last_proj {
+        Some(old) => has_mount_boundary_transition(old, proj)
+        None => false
+      }
+      let remount = session.dirty || transition
+      if remount {
+        // V1 has no Move/Reparent patch. The supported repair boundary is the
+        // root container, which is also the smallest boundary we can safely
+        // identify without a committed DOM parent graph.
+        clear_element_registry(session.registry)
+      }
+      let existing = if remount { [] } else { session.mounted_ids.copy() }
+      let (patches, _) = @jsx_proj.reconcile(proj, existing)
+      match
+        apply_patches_with_registry(
+          @jsx_proj.dom_patches_to_json(patches),
+          session.root_id,
+          session.registry,
+        ) {
+        Ok(mounted_ids) => {
+          session.revision += 1
+          session.mounted_ids = mounted_ids
+          session.last_proj = Some(proj)
+          session.committed_source = source
+          session.dirty = false
+          render_result_json(
+            true,
+            session.revision,
+            session.mounted_ids,
+            diagnostics,
+            None,
+          )
+        }
+        Err(message) => {
+          session.dirty = true
+          restore_committed_source(session)
+          render_result_json(
+            false,
+            session.revision,
+            session.mounted_ids,
+            diagnostics,
+            Some(("DomApplyError", message)),
+          )
+        }
+      }
+    }
+    Ok(None) => {
+      restore_committed_source(session)
+      render_result_json(
+        false,
+        session.revision,
+        session.mounted_ids,
+        diagnostics,
+        Some(("ProjectionUnavailable", "projection produced no root")),
+      )
+    }
+    Err(_) => {
+      restore_committed_source(session)
+      render_result_json(
+        false,
+        session.revision,
+        session.mounted_ids,
+        diagnostics,
+        Some(("ProjectionError", "projection evaluation failed")),
+      )
+    }
+  }
+}
+
+///|
+fn allocate_session_handle() -> Int {
+  let handle = next_session_handle.val
+  next_session_handle.val += 1
+  handle
+}
+
+///|
+/// Create a session and perform its initial render. A failed initial render
+/// never enters `session_registry` and its partially created DOM is cleaned
+/// through the session-owned registry.
+pub fn jsx_session_new(source : String, root_id : String) -> String {
+  let session = new_jsx_session(source, root_id)
+  let result = render_jsx_session(session, source, false)
+  let result_value = @js.parse(result)
+  if result_value.get("success").cast() {
+    let handle = allocate_session_handle()
+    session_registry.set(handle, session)
+    session_envelope_json(Some(handle), result)
+  } else {
+    dispose_jsx_session(session)
+    session_envelope_json(None, result)
+  }
+}
+
+///|
+/// Render a new source through one live session.
+pub fn jsx_session_render(handle : Int, source : String) -> String {
+  match session_registry.get(handle) {
+    Some(session) => render_jsx_session(session, source, true)
+    None => {
+      let error = if disposed_session_handles.contains(handle) {
+        ("DisposedSession", "session handle has been disposed")
+      } else {
+        ("InvalidSession", "unknown session handle")
+      }
+      render_result_json(false, 0, [], [], Some(error))
+    }
+  }
+}
+
+///|
+/// Explicit, idempotent session disposal.
+pub fn jsx_session_dispose(handle : Int) -> Unit {
+  match session_registry.get(handle) {
+    Some(session) => {
+      dispose_jsx_session(session)
+      session_registry.remove(handle)
+      disposed_session_handles.set(handle, true)
+    }
+    None => ()
+  }
+}
+
+///|
+/// Compatibility reset: dispose all stateful sessions. Handles remain
+/// monotonically invalidated rather than being recycled into new sessions.
+fn reset_all_jsx_sessions() -> Unit {
+  let handles = session_registry.keys().to_array()
+  for handle in handles {
+    jsx_session_dispose(handle)
+  }
+}

--- a/ffi/jsx/session_contract_wbtest.mbt
+++ b/ffi/jsx/session_contract_wbtest.mbt
@@ -1,0 +1,248 @@
+///| Whitebox tests for the V1 JSX FFI session contract.
+
+///|
+extern "js" fn install_session_test_document() -> Unit =
+  #|() => {
+  #|  const makeNode = (tag, text = "") => {
+  #|    const node = {
+  #|      tag,
+  #|      textContent: text,
+  #|      children: [],
+  #|      get childNodes() { return this.children; },
+  #|      parent: null,
+  #|      attrs: {},
+  #|      setAttribute(name, value) { this.attrs[name] = String(value); },
+  #|      appendChild(child) {
+  #|        if (globalThis.__canopySessionFailAppend) throw new Error("append failed");
+  #|        if (child.parent) child.remove();
+  #|        child.parent = this;
+  #|        this.children.push(child);
+  #|        return child;
+  #|      },
+  #|      insertBefore(child, reference) {
+  #|        if (globalThis.__canopySessionFailAppend) throw new Error("append failed");
+  #|        if (child.parent) child.remove();
+  #|        const i = this.children.indexOf(reference);
+  #|        child.parent = this;
+  #|        if (i < 0) this.children.push(child); else this.children.splice(i, 0, child);
+  #|        return child;
+  #|      },
+  #|      remove() {
+  #|        if (!this.parent) return;
+  #|        const i = this.parent.children.indexOf(this);
+  #|        if (i >= 0) this.parent.children.splice(i, 1);
+  #|        this.parent = null;
+  #|      },
+  #|    };
+  #|    return node;
+  #|  };
+  #|  const roots = {
+  #|    "session-root-a": makeNode("root"),
+  #|    "session-root-b": makeNode("root"),
+  #|  };
+  #|  globalThis.__canopySessionRoots = roots;
+  #|  globalThis.__canopySessionFailAppend = false;
+  #|  globalThis.document = {
+  #|    getElementById(id) { return roots[id] || null; },
+  #|    createElement(tag) { return makeNode(tag); },
+  #|    createTextNode(text) { return makeNode("#text", text); },
+  #|  };
+  #|}
+
+///|
+extern "js" fn set_session_test_append_failure(value : Bool) -> Unit =
+  #|(value) => { globalThis.__canopySessionFailAppend = value; }
+
+///|
+extern "js" fn session_test_root_child_count(root_id : String) -> Int =
+  #|(rootId) => globalThis.__canopySessionRoots[rootId].children.length
+
+///|
+extern "js" fn session_test_first_nested_tag(root_id : String) -> String =
+  #|(rootId) => globalThis.__canopySessionRoots[rootId].children[0]?.children[0]?.tag ?? ""
+
+///|
+extern "js" fn session_test_nested_texts(root_id : String) -> String =
+  #|(rootId) => globalThis.__canopySessionRoots[rootId].children[0].children.map(child => child.children[0]?.textContent ?? child.textContent).join("|")
+
+///|
+fn session_test_handle(result : @js.Any) -> Int {
+  let encoded : String = result.get("handle").cast()
+  @string.parse_int(encoded) catch {
+    _ => abort("session result must contain a decimal handle")
+  }
+}
+
+///|
+test "render result uses the versioned envelope and string mounted ids" {
+  let result = render_result_json(
+    true,
+    7,
+    [3, 21],
+    ["recoverable JSX diagnostic"],
+    None,
+  )
+  let json = @js.parse(result)
+  assert_eq(json.get("schema_version").cast(), 1)
+  assert_true(json.get("success").cast())
+  assert_eq(json.get("revision").cast(), 7)
+  let mounted = json.get("mounted_ids")
+  assert_eq(mounted.at(0).to_str(), "3")
+  assert_eq(mounted.at(1).to_str(), "21")
+  assert_eq(
+    json.get("diagnostics").at(0).to_str(),
+    "recoverable JSX diagnostic",
+  )
+  assert_true(json.get("error").is_nullish())
+}
+
+///|
+test "render result exposes structured errors" {
+  let result = render_result_json(
+    false,
+    2,
+    [5],
+    [],
+    Some(("DisposedSession", "session handle has been disposed")),
+  )
+  let json = @js.parse(result)
+  assert_false(json.get("success").cast())
+  assert_eq(json.get("revision").cast(), 2)
+  assert_eq(json.get("mounted_ids").at(0).to_str(), "5")
+  let error = json.get("error")
+  assert_eq(error.get("code").to_str(), "DisposedSession")
+  assert_eq(error.get("message").to_str(), "session handle has been disposed")
+}
+
+///|
+test "failed initial DOM render does not publish a usable handle" {
+  let result = jsx_session_new("<div>hello</div>", "missing-jsx-session-root")
+  let json = @js.parse(result)
+  assert_false(json.get("success").cast())
+  assert_true(json.get("handle").is_nullish())
+  let render = json.get("result")
+  assert_false(render.get("success").cast())
+  assert_eq(render.get("revision").cast(), 0)
+  assert_eq(render.get("mounted_ids").get("length").cast(), 0)
+}
+
+///|
+test "mount-boundary detection is structural, not NodeId-dependent" {
+  let old_text = @jsx_ast.JsxNode::Text("visible")
+  let new_text = @jsx_ast.JsxNode::Text("visible")
+  let old_child = @canopy_core.ProjNode::ProjNode(old_text, 1, 8, 20, [])
+  let new_child = @canopy_core.ProjNode::ProjNode(new_text, 1, 8, 200, [])
+  let old = @canopy_core.ProjNode::ProjNode(
+    @jsx_ast.JsxNode::Element(tag="", attrs=[], children=[old_text]),
+    0,
+    8,
+    10,
+    [old_child],
+  )
+  let new = @canopy_core.ProjNode::ProjNode(
+    @jsx_ast.JsxNode::Element(tag="section", attrs=[], children=[new_text]),
+    0,
+    8,
+    100,
+    [new_child],
+  )
+  assert_true(has_mount_boundary_transition(old, new))
+}
+
+///|
+test "live session commits revisions, preserves ids, and disposes idempotently" {
+  install_session_test_document()
+  let created = @js.parse(jsx_session_new("<div>one</div>", "session-root-a"))
+  assert_true(created.get("success").cast())
+  let handle = session_test_handle(created)
+  let first = created.get("result")
+  assert_eq(first.get("revision").cast(), 1)
+  let first_id : String = first.get("mounted_ids").at(0).cast()
+  assert_eq(session_test_root_child_count("session-root-a"), 1)
+
+  let second = @js.parse(jsx_session_render(handle, "<div>two</div>"))
+  assert_true(second.get("success").cast())
+  assert_eq(second.get("revision").cast(), 2)
+  assert_eq(second.get("mounted_ids").at(0).cast(), first_id)
+
+  jsx_session_dispose(handle)
+  jsx_session_dispose(handle)
+  assert_eq(session_test_root_child_count("session-root-a"), 0)
+  let disposed = @js.parse(jsx_session_render(handle, "<div>three</div>"))
+  assert_false(disposed.get("success").cast())
+  assert_eq(disposed.get("error").get("code").to_str(), "DisposedSession")
+}
+
+///|
+test "live sessions isolate DOM ownership" {
+  install_session_test_document()
+  let a = @js.parse(jsx_session_new("<div>a</div>", "session-root-a"))
+  let b = @js.parse(jsx_session_new("<div>b</div>", "session-root-b"))
+  let handle_a = session_test_handle(a)
+  let handle_b = session_test_handle(b)
+  assert_eq(session_test_root_child_count("session-root-a"), 1)
+  assert_eq(session_test_root_child_count("session-root-b"), 1)
+  jsx_session_dispose(handle_a)
+  assert_eq(session_test_root_child_count("session-root-a"), 0)
+  assert_eq(session_test_root_child_count("session-root-b"), 1)
+  let b_update = @js.parse(jsx_session_render(handle_b, "<div>bb</div>"))
+  assert_true(b_update.get("success").cast())
+  jsx_session_dispose(handle_b)
+}
+
+///|
+test "changed element tags remount descendants across the parent boundary" {
+  install_session_test_document()
+  let created = @js.parse(
+    jsx_session_new("<di><span>x</span></di>", "session-root-a"),
+  )
+  let handle = session_test_handle(created)
+  let updated = @js.parse(
+    jsx_session_render(handle, "<div><span>x</span></div>"),
+  )
+  assert_true(updated.get("success").cast())
+  assert_eq(session_test_first_nested_tag("session-root-a"), "span")
+  jsx_session_dispose(handle)
+}
+
+///|
+test "DOM adapter honors sibling indexes for inserted children" {
+  install_session_test_document()
+  let created = @js.parse(
+    jsx_session_new("<div><span>a</span><span>b</span></div>", "session-root-a"),
+  )
+  let handle = session_test_handle(created)
+  let updated = @js.parse(
+    jsx_session_render(
+      handle, "<div><span>x</span><span>a</span><span>b</span></div>",
+    ),
+  )
+  assert_true(updated.get("success").cast())
+  assert_eq(session_test_nested_texts("session-root-a"), "x|a|b")
+  jsx_session_dispose(handle)
+}
+
+///|
+test "DOM failure keeps the committed revision and next success repairs dirty state" {
+  install_session_test_document()
+  let created = @js.parse(jsx_session_new("<div>one</div>", "session-root-a"))
+  let handle = session_test_handle(created)
+  let committed_id : String = created
+    .get("result")
+    .get("mounted_ids")
+    .at(0)
+    .cast()
+  set_session_test_append_failure(true)
+  let failed = @js.parse(jsx_session_render(handle, "<div><p>two</p></div>"))
+  assert_false(failed.get("success").cast())
+  assert_eq(failed.get("revision").cast(), 1)
+  assert_eq(failed.get("mounted_ids").at(0).cast(), committed_id)
+  assert_eq(failed.get("error").get("code").to_str(), "DomApplyError")
+
+  set_session_test_append_failure(false)
+  let repaired = @js.parse(jsx_session_render(handle, "<div><p>two</p></div>"))
+  assert_true(repaired.get("success").cast())
+  assert_eq(repaired.get("revision").cast(), 2)
+  assert_eq(session_test_root_child_count("session-root-a"), 1)
+  jsx_session_dispose(handle)
+}

--- a/ffi/jsx/session_contract_wbtest.mbt
+++ b/ffi/jsx/session_contract_wbtest.mbt
@@ -223,6 +223,23 @@ test "DOM adapter honors sibling indexes for inserted children" {
 }
 
 ///|
+test "DOM adapter releases removed siblings before inserting replacements" {
+  install_session_test_document()
+  let created = @js.parse(
+    jsx_session_new(
+      "<div><span>a</span><span>b</span><span>c</span></div>", "session-root-a",
+    ),
+  )
+  let handle = session_test_handle(created)
+  let updated = @js.parse(
+    jsx_session_render(handle, "<div><span>b</span><span>c</span>{e}</div>"),
+  )
+  assert_true(updated.get("success").cast())
+  assert_eq(session_test_nested_texts("session-root-a"), "b|c|{e}")
+  jsx_session_dispose(handle)
+}
+
+///|
 test "DOM failure keeps the committed revision and next success repairs dirty state" {
   install_session_test_document()
   let created = @js.parse(jsx_session_new("<div>one</div>", "session-root-a"))

--- a/lang/jsx/proj/proj_node.mbt
+++ b/lang/jsx/proj/proj_node.mbt
@@ -112,9 +112,63 @@ fn build_container(
 }
 
 ///|
+/// Prefer unchanged JSX subtrees when same-kind LCS has multiple alignments.
+fn jsx_attr_key(attr : @jsx.JsxAttr) -> String {
+  let value = match attr.value {
+    @jsx.JsxAttrValue::StringLit(text) => "string:" + text
+    @jsx.JsxAttrValue::ExprSpan(raw~) => "expr:" + raw
+    @jsx.JsxAttrValue::Bare => "bare"
+  }
+  attr.name.length().to_string() +
+  ":" +
+  attr.name +
+  value.length().to_string() +
+  ":" +
+  value
+}
+
+///|
+fn jsx_exact_key(node : @jsx.JsxNode) -> String {
+  match node {
+    Root(..) => "Root"
+    Fragment(..) => "Fragment"
+    Element(tag~, attrs~, ..) => {
+      let attrs_key = attrs
+        .map(attr => {
+          let key = jsx_attr_key(attr)
+          key.length().to_string() + ":" + key
+        })
+        .join("")
+      "Element:" +
+      tag.length().to_string() +
+      ":" +
+      tag +
+      "[" +
+      attrs.length().to_string() +
+      ":" +
+      attrs_key +
+      "]"
+    }
+    Text(text) => "Text:" + text
+    ExprSpan(raw~) => "ExprSpan:" + raw
+    Error(message) => "Error:" + message
+  }
+}
+
+///|
+fn reconcile_jsx_projection(
+  old : @core.ProjNode[@jsx.JsxNode],
+  new : @core.ProjNode[@jsx.JsxNode],
+  counter : Ref[Int],
+  trace_ref : Ref[Array[@core.ReconcileTraceEvent]]?,
+) -> @core.ProjNode[@jsx.JsxNode] {
+  @core.reconcile_with_exact_key(old, new, counter, jsx_exact_key, trace_ref~)
+}
+
+///|
 /// Build the 3-memo pipeline (proj, registry, source_map) for the JSX
 /// projection. Delegates to @core.build_projection_memos exactly per
-/// ADDING_A_LANGUAGE.md Step 4 — no hand-rolled reconciliation.
+/// ADDING_A_LANGUAGE.md Step 4, with JSX-specific exact-subtree matching.
 pub fn build_jsx_projection_memos(
   parser : @loom.Parser[@jsx.JsxNode],
 ) -> (
@@ -127,6 +181,7 @@ pub fn build_jsx_projection_memos(
     parser.syntax_tree(),
     syntax_to_proj_node,
     populate_token_spans,
+    reconcile_node=reconcile_jsx_projection,
     label="jsx",
   )
 }

--- a/lang/jsx/proj/reconcile_wbtest.mbt
+++ b/lang/jsx/proj/reconcile_wbtest.mbt
@@ -48,6 +48,50 @@ fn find_text(patches : Array[DomPatch], expected : String) -> Bool {
 }
 
 ///|
+/// Helper: collect IDs that correspond to mounted DOM nodes.
+fn patch_ids(patches : Array[DomPatch]) -> Array[Int] {
+  let ids : Array[Int] = []
+  for patch in patches {
+    match patch {
+      MakeElement(_, id, _, _, _)
+      | MakeText(_, id, _, _)
+      | MakeExprSpan(_, id, _, _)
+      | SetText(id, _)
+      | SetExpr(id, _)
+      | SetAttrs(id, _) => ids.push(id)
+      Release(_) => ()
+    }
+  }
+  ids
+}
+
+///|
+/// Helper: count element creation patches for one tag.
+fn count_make_element(patches : Array[DomPatch], expected : String) -> Int {
+  let mut count = 0
+  for patch in patches {
+    match patch {
+      MakeElement(_, _, tag, _, _) => if tag == expected { count += 1 }
+      _ => ()
+    }
+  }
+  count
+}
+
+///|
+/// Helper: count text creation patches for one value.
+fn count_make_text(patches : Array[DomPatch], expected : String) -> Int {
+  let mut count = 0
+  for patch in patches {
+    match patch {
+      MakeText(_, _, text, _) => if text == expected { count += 1 }
+      _ => ()
+    }
+  }
+  count
+}
+
+///|
 /// Second render with same text → SetText.
 test "reconcile: existing text produces SetText" {
   let (root, _) = parse_to_proj_node("<p>hello</p>")
@@ -107,6 +151,162 @@ test "reconcile: incomplete tag does not produce empty MakeElement" {
         fail("empty tag must not cross the DOM patch boundary")
       _ => ()
     }
+  }
+}
+
+///|
+/// An explicitly recovered empty-tag element remains in the projection but
+/// is transparent at the DOM patch boundary: its child renders under the
+/// recovery node's parent and the empty tag itself is never mounted.
+test "reconcile: empty-tag recovery is transparent and preserves children" {
+  let text_kind = @jsx.JsxNode::Text("hello")
+  let child = @core.ProjNode::ProjNode(text_kind, 0, 5, 2, [])
+  let recovery_kind = @jsx.JsxNode::Element(tag="", attrs=[], children=[
+    text_kind,
+  ])
+  let recovery = @core.ProjNode::ProjNode(recovery_kind, 0, 5, 1, [child])
+  let root_kind = @jsx.JsxNode::Root(children=[recovery_kind])
+  let root = @core.ProjNode::ProjNode(root_kind, 0, 5, 0, [recovery])
+  let (patches, _) = reconcile(root, [])
+  inspect(patches.length(), content="1")
+  match patches[0] {
+    MakeText(parent_id, _, text, index) => {
+      inspect(parent_id, content="-1")
+      inspect(text, content="hello")
+      inspect(index, content="0")
+    }
+    other =>
+      fail("expected transparent recovery child patch: " + patch_label(other))
+  }
+}
+
+///|
+/// When a duplicate same-kind sibling is appended, only the new tail should
+/// cross the DOM mount boundary on the second render.
+test "reconcile: append equal-kind sibling mounts only the tail" {
+  let (old_root, _) = parse_to_proj_node(
+    "<div><span>a</span><span>b</span></div>",
+  )
+  let (first_patches, _) = reconcile(old_root, [])
+  let existing = patch_ids(first_patches)
+  let (new_raw, _) = parse_to_proj_node(
+    "<div><span>a</span><span>b</span><span>c</span></div>",
+  )
+  let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
+  let (patches, _) = reconcile(new_root, existing)
+  inspect(count_make_element(patches, "div"), content="0")
+  inspect(count_make_element(patches, "span"), content="1")
+  inspect(count_make_text(patches, "a"), content="0")
+  inspect(count_make_text(patches, "b"), content="0")
+  inspect(count_make_text(patches, "c"), content="1")
+  inspect(has_patch(patches, "Release"), content="false")
+}
+
+///|
+/// Attribute differences are part of the exact subtree key, so a same-tag
+/// middle insertion does not retarget either existing sibling.
+test "reconcile: attribute-distinct siblings preserve exact identities" {
+  let (old_root, _) = parse_to_proj_node(
+    "<div><span class=\"a\"/><span class=\"b\"/></div>",
+  )
+  let old_div = old_root.children[0]
+  let (new_raw, _) = parse_to_proj_node(
+    "<div><span class=\"a\"/><span class=\"x\"/><span class=\"b\"/></div>",
+  )
+  let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
+  let new_div = new_root.children[0]
+  inspect(new_div.children[0].id() == old_div.children[0].id(), content="true")
+  inspect(new_div.children[2].id() == old_div.children[1].id(), content="true")
+  inspect(new_div.children[1].id() != old_div.children[0].id(), content="true")
+  inspect(new_div.children[1].id() != old_div.children[1].id(), content="true")
+}
+
+///|
+test "reconcile: attribute key separates delimiter-containing values" {
+  let one = @jsx.JsxNode::Element(
+    tag="div",
+    attrs=[
+      @jsx.JsxAttr::JsxAttr(
+        name="a",
+        value=@jsx.JsxAttrValue::StringLit("x,b=string:y"),
+      ),
+    ],
+    children=[],
+  )
+  let two = @jsx.JsxNode::Element(
+    tag="div",
+    attrs=[
+      @jsx.JsxAttr::JsxAttr(name="a", value=@jsx.JsxAttrValue::StringLit("x")),
+      @jsx.JsxAttr::JsxAttr(name="b", value=@jsx.JsxAttrValue::StringLit("y")),
+    ],
+    children=[],
+  )
+  inspect(jsx_exact_key(one) == jsx_exact_key(two), content="false")
+}
+
+///|
+/// An empty-tag recovery node remains transparent when its existing child is
+/// updated on a later render.
+test "reconcile: empty-tag recovery updates existing child" {
+  let first_text_kind = @jsx.JsxNode::Text("before")
+  let first_child = @core.ProjNode::ProjNode(first_text_kind, 0, 6, 2, [])
+  let first_recovery_kind = @jsx.JsxNode::Element(tag="", attrs=[], children=[
+    first_text_kind,
+  ])
+  let first_recovery = @core.ProjNode::ProjNode(first_recovery_kind, 0, 6, 1, [
+    first_child,
+  ])
+  let first_root_kind = @jsx.JsxNode::Root(children=[first_recovery_kind])
+  let first_root = @core.ProjNode::ProjNode(first_root_kind, 0, 6, 0, [
+    first_recovery,
+  ])
+  let (first_patches, _) = reconcile(first_root, [])
+  let existing = patch_ids(first_patches)
+
+  let next_text_kind = @jsx.JsxNode::Text("after")
+  let next_child = @core.ProjNode::ProjNode(next_text_kind, 0, 5, 2, [])
+  let next_recovery_kind = @jsx.JsxNode::Element(tag="", attrs=[], children=[
+    next_text_kind,
+  ])
+  let next_recovery = @core.ProjNode::ProjNode(next_recovery_kind, 0, 5, 1, [
+    next_child,
+  ])
+  let next_root_kind = @jsx.JsxNode::Root(children=[next_recovery_kind])
+  let next_root = @core.ProjNode::ProjNode(next_root_kind, 0, 5, 0, [
+    next_recovery,
+  ])
+  let (patches, _) = reconcile(next_root, existing)
+  inspect(find_text(patches, "after"), content="true")
+  inspect(has_patch(patches, "MakeText"), content="false")
+  inspect(has_patch(patches, "Release"), content="false")
+}
+
+///|
+/// Removing the child below an empty-tag recovery node releases its mounted
+/// child even though the recovery node itself was never mounted.
+test "reconcile: empty-tag recovery removal releases child" {
+  let text_kind = @jsx.JsxNode::Text("hello")
+  let child = @core.ProjNode::ProjNode(text_kind, 0, 5, 2, [])
+  let recovery_kind = @jsx.JsxNode::Element(tag="", attrs=[], children=[
+    text_kind,
+  ])
+  let recovery = @core.ProjNode::ProjNode(recovery_kind, 0, 5, 1, [child])
+  let root_kind = @jsx.JsxNode::Root(children=[recovery_kind])
+  let root = @core.ProjNode::ProjNode(root_kind, 0, 5, 0, [recovery])
+  let (first_patches, _) = reconcile(root, [])
+  let existing = patch_ids(first_patches)
+
+  let empty_recovery_kind = @jsx.JsxNode::Element(tag="", attrs=[], children=[])
+  let empty_recovery = @core.ProjNode::ProjNode(empty_recovery_kind, 0, 0, 1, [])
+  let empty_root_kind = @jsx.JsxNode::Root(children=[empty_recovery_kind])
+  let empty_root = @core.ProjNode::ProjNode(empty_root_kind, 0, 0, 0, [
+    empty_recovery,
+  ])
+  let (patches, _) = reconcile(empty_root, existing)
+  inspect(patches.length(), content="1")
+  match patches[0] {
+    Release(id) => inspect(id, content="2")
+    other => fail("expected recovery child release: " + patch_label(other))
   }
 }
 

--- a/lang/jsx/proj/streaming_reconcile_wbtest.mbt
+++ b/lang/jsx/proj/streaming_reconcile_wbtest.mbt
@@ -108,3 +108,26 @@ test "streaming: ExprSpan identity stable across closed-content growth" {
     inspect(expr.id() == expr_id, content="true")
   }
 }
+
+///|
+/// Repeated structural siblings must have distinct identities, and appending
+/// another equal-kind sibling must not retarget the existing two.
+test "streaming: duplicate siblings keep distinct identities" {
+  let parser = @loom.new_parser(
+    "<div><span>a</span><span>b</span></div>", @jsx.jsx_grammar,
+  )
+  let (proj_memo, _, _) = build_jsx_projection_memos(parser)
+  let root0 = proj_memo.read_or_abort().unwrap()
+  let div0 = root0.children[0]
+  let first_id = div0.children[0].id()
+  let second_id = div0.children[1].id()
+  inspect(first_id == second_id, content="false")
+
+  parser.set_source("<div><span>a</span><span>b</span><span>c</span></div>")
+  let root1 = proj_memo.read_or_abort().unwrap()
+  let div1 = root1.children[0]
+  inspect(div1.id() == div0.id(), content="true")
+  inspect(div1.children[0].id() == first_id, content="true")
+  inspect(div1.children[1].id() == second_id, content="true")
+  inspect(div1.children[0].id() != div1.children[1].id(), content="true")
+}


### PR DESCRIPTION
## Summary

- Add a versioned JSX FFI session API with per-session parser, projection, DOM registry, revision, diagnostics, and idempotent disposal.
- Define transparent empty-tag recovery rendering and remount on element-tag boundaries where V1 has no reparent patch.
- Migrate the web demo to the stateful API and preserve DOM sibling indexes during insertion.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `build_projection_memos` | `core/projection_memo.mbt` | Yes | Session owns the existing projection memo pipeline. |
| `Derived::watch` / `Watch::dispose` | `loom/incr/incr/cells` | Yes | Keeps the session projection graph alive and releases it on disposal. |
| `Map` | MoonBit core and existing FFI registries | Yes | Session handles and per-session ownership maps. |
| `Result` / `Option` | MoonBit core | Yes | Structured DOM/projection failure paths and optional handles. |
| `Array` / `Iter` | MoonBit core | Yes | Patch IDs and registry cleanup traversal. |

New helpers added:

- `JsxSession`: owns the parser, projection memos, watch, committed source, mounted IDs, and per-session DOM registry.
- `render_result_json`: centralizes the versioned FFI result envelope.
- `apply_patches_with_registry` / `insert_child`: keep DOM ownership session-local and honor patch sibling indexes.
- `has_mount_boundary_transition`: detects tag-parent transitions without depending on NodeId equality.

## Test plan

- [x] `moon check` passes (one pre-existing reserved-keyword warning remains).
- [ ] Full `moon test` is not completely green: wasm-gc 3609/3609 and native 70/70 pass; JS 1840 pass and 2 vendored Rabbita README tests fail because Node has no `document`.
- [x] `git diff *.mbti` reviewed; only the intended reconciliation and session exports changed.
- [x] JS rebuild and `cd examples/web && npm run build` pass.
- [x] Focused FFI contract tests: 9 passed; core: 136 passed; JSX projection: 32 passed.
- [x] Browser smoke checks cover session streaming, disposal, empty-tag transparency, and DOM ownership.

## Validation

```bash
moon check
moon test
cd examples/web && npm run build
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stateful JSX rendering sessions with explicit create, update, and dispose.
  * Introduced structured render results with schema version, revision, mounted node IDs, diagnostics, and typed errors.
  * Improved incremental reconciliation to better preserve stable identities for equal-kind sibling insertions.
  * Added improved handling for temporary/empty JSX tags with transparent recovery rendering.
* **Bug Fixes**
  * Improved DOM patch application to support correct sibling positioning and safer session-scoped element tracking.
  * Strengthened failure and disposal behavior to prevent stale updates after errors.
* **Documentation**
  * Documented the session/FFI contract, update semantics, and recovery/remount rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->