### PR TITLE
fix(reconcile): preserve duplicate sibling identities

### DIFF
--- a/core/reconcile.mbt
+++ b/core/reconcile.mbt
@@ -281,8 +281,9 @@ fn[T] exact_fingerprint_map(
 /// Child reconciliation for `reconcile_with_exact_key`.
 ///
 /// This path intentionally has no structural-edit hints: the JSX projection
-/// uses it for ordinary streaming updates, while the default/hinted path above
-/// retains the framework's historical LCS tie-breaking contract.
+/// uses it for ordinary streaming updates. It computes the primary LCS
+/// optimum, then reconstructs from the front using the earliest feasible
+/// diagonal so duplicate siblings retain stable prefix identities.
 fn[T : TreeNode + Renderable] reconcile_children_exact(
   old_children : Array[ProjNode[T]],
   new_children : Array[ProjNode[T]],
@@ -305,31 +306,39 @@ fn[T : TreeNode + Renderable] reconcile_children_exact(
       match_base_score
     }
   }
-  let dp = Array::makei(old_len + 1, _ => Array::make(new_len + 1, 0))
-  for i = 1; i <= old_len; i = i + 1 {
-    for j = 1; j <= new_len; j = j + 1 {
-      let diagonal = dp[i - 1][j - 1] + match_score(i - 1, j - 1)
-      dp[i][j] = @cmp.maximum(
-        @cmp.maximum(dp[i - 1][j], dp[i][j - 1]),
+  let suffix = Array::makei(old_len + 1, _ => Array::make(new_len + 1, 0))
+  let mut suffix_i = old_len
+  while suffix_i > 0 {
+    suffix_i -= 1
+    let mut suffix_j = new_len
+    while suffix_j > 0 {
+      suffix_j -= 1
+      let diagonal = suffix[suffix_i + 1][suffix_j + 1] +
+        match_score(suffix_i, suffix_j)
+      suffix[suffix_i][suffix_j] = @cmp.maximum(
+        @cmp.maximum(
+          suffix[suffix_i + 1][suffix_j],
+          suffix[suffix_i][suffix_j + 1],
+        ),
         diagonal,
       )
     }
   }
   let old_matched = Array::make(old_len, -1)
   let new_matched = Array::make(new_len, -1)
-  let mut i = old_len
-  let mut j = new_len
-  while i > 0 && j > 0 {
-    let score = match_score(i - 1, j - 1)
-    if score > 0 && dp[i][j] == dp[i - 1][j - 1] + score {
-      old_matched[i - 1] = j - 1
-      new_matched[j - 1] = i - 1
-      i = i - 1
-      j = j - 1
-    } else if dp[i - 1][j] >= dp[i][j - 1] {
-      i = i - 1
+  let mut oi = 0
+  let mut nj = 0
+  while oi < old_len && nj < new_len {
+    let score = match_score(oi, nj)
+    if score > 0 && score + suffix[oi + 1][nj + 1] == suffix[oi][nj] {
+      old_matched[oi] = nj
+      new_matched[nj] = oi
+      oi += 1
+      nj += 1
+    } else if suffix[oi][nj + 1] == suffix[oi][nj] {
+      nj += 1
     } else {
-      j = j - 1
+      oi += 1
     }
   }
   let result = [

--- a/core/reconcile_properties_wbtest.mbt
+++ b/core/reconcile_properties_wbtest.mbt
@@ -425,6 +425,76 @@ test "reconcile: exact preference does not reduce match cardinality" {
 }
 
 ///|
+test "reconcile: exact duplicate append preserves prefix identities" {
+  let old_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("a")]), Ref(0))
+  let new_node = to_proj_node(
+    Branch("root", [Leaf("a"), Leaf("a"), Leaf("a")]),
+    Ref(500),
+  )
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  inspect(
+    result.children[0].node_id == old_node.children[0].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[1].node_id == old_node.children[1].node_id,
+    content="true",
+  )
+  inspect(result.children[2].node_id >= 1000, content="true")
+}
+
+///|
+test "reconcile: exact duplicate deletion preserves prefix identities" {
+  let old_node = to_proj_node(
+    Branch("root", [Leaf("a"), Leaf("a"), Leaf("a")]),
+    Ref(0),
+  )
+  let new_node = to_proj_node(Branch("root", [Leaf("a"), Leaf("a")]), Ref(500))
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  inspect(
+    result.children[0].node_id == old_node.children[0].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[1].node_id == old_node.children[1].node_id,
+    content="true",
+  )
+}
+
+///|
+test "reconcile: mixed same-kind tie chooses earliest feasible pair" {
+  let old_node = to_proj_node(
+    Branch("root", [Leaf("a"), Leaf("b"), Leaf("c"), Leaf("d")]),
+    Ref(0),
+  )
+  let new_node = to_proj_node(Branch("root", [Leaf("w"), Leaf("x")]), Ref(500))
+  let result = reconcile_with_exact_key(
+    old_node,
+    new_node,
+    Ref(1000),
+    exact_test_key,
+  )
+  inspect(
+    result.children[0].node_id == old_node.children[0].node_id,
+    content="true",
+  )
+  inspect(
+    result.children[1].node_id == old_node.children[1].node_id,
+    content="true",
+  )
+}
+
+///|
 /// Property 6: After deleting a child, the number of reused old IDs equals
 /// the LCS length between old and new children (by same_kind).
 /// We can't assume WHICH old children are matched (LCS tie-breaking is

--- a/docs/superpowers/plans/2026-07-13-jsx-patch-properties.md
+++ b/docs/superpowers/plans/2026-07-13-jsx-patch-properties.md
@@ -1,0 +1,190 @@
+# JSX Patch Property Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic QuickCheck coverage proving that generated JSX reconcile patches, including releases, insertions, text, expression spans, and nested updates, produce the same final fake-DOM model as a fresh render.
+
+**Architecture:** Reuse the existing pure `DryRunModel` in `lang/jsx/proj/dry_run.mbt` as the fake DOM model. Generate bounded old/new declarative trees in a whitebox test, lower them to `ProjNode[JsxNode]`, reconcile the new tree against the old mounted IDs, apply the incremental patches to the old model, and compare the result with applying a fresh patch set for the reconciled new tree. The property exposed a real exact-key LCS identity defect, so the implementation also updates generic exact-key reconstruction to preserve earliest feasible sibling identities; no DOM, FFI, session API, or `DomPatch` contract changes.
+
+**Tech Stack:** MoonBit, `@qc` QuickCheck, `@splitmix.RandomState`, `@canopy_core.ProjNode`, `@jsx.JsxNode`, `DryRunModel`, `reconcile`, `reconcile_jsx_projection`.
+
+## Global Constraints
+
+- Reuse the existing `DryRunModel`; do not create a second fake-DOM implementation.
+- Keep generated trees bounded to depth four and at most three children per element.
+- Include Element, Text, and ExprSpan nodes in the generator; use nested elements so parent/child insertion is exercised.
+- Keep all new helpers package-private and test-only.
+- Do not change `DomPatch`, `DryRunModel::apply`, or the JSX session API. Change generic exact-key reconciliation only because the independent duplicate-sibling regression exposed a real identity defect.
+- Keep the existing explicit release-before-insert regression test.
+- Add QuickCheck imports only to `lang/jsx/proj/moon.pkg` under `for "wbtest"`.
+- Run `NEW_MOON_MOD=0 moon check lang/jsx/proj` after every MoonBit edit.
+- Record any QuickCheck seed or shrunk counterexample if a property fails.
+
+## Existing API Reuse Check
+
+- `DryRunModel::empty` and `DryRunModel::apply` in `lang/jsx/proj/dry_run.mbt`: reused as the only fake-DOM state transition and failure boundary.
+- `reconcile` in `lang/jsx/proj/reconcile.mbt`: reused to generate incremental `DomPatch` sequences and mounted IDs.
+- `reconcile_jsx_projection` in `lang/jsx/proj/proj_node.mbt`: reused to assign stable IDs from exact JSX subtree matching before patch generation.
+- `@canopy_core.ProjNode::ProjNode` and `@jsx.JsxNode` constructors: reused to build test projections without a parser or DOM.
+- `@quickcheck.Arbitrary`, `@qc.Shrink`, and `@qc.quick_check_fn`: reused for bounded generated cases and deterministic shrinking.
+- `Array` is the correct core collection for ordered children and patch lists; `@set.Set` is reused for uniqueness membership, while `Iter` is reused for lazy structural shrinking. `Map` was considered but is unnecessary for the test-only uniqueness predicate.
+
+---
+
+### Task 1: Wire QuickCheck dependencies for the projection whitebox package
+
+**Files:**
+- Modify: `lang/jsx/proj/moon.pkg`
+
+**Interfaces:**
+- Consumes: the existing projection package imports.
+- Produces: `moonbitlang/core/quickcheck`, `moonbitlang/core/quickcheck/splitmix`, and `moonbitlang/quickcheck` available only to whitebox tests.
+
+- [x] **Step 1: Add the existing `for "wbtest"` QuickCheck import block**
+
+Match the established `core/moon.pkg` and `ffi/jsx/moon.pkg` pattern:
+
+```moonbit
+import {
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/splitmix",
+  "moonbitlang/quickcheck" @qc,
+} for "wbtest"
+```
+
+- [x] **Step 2: Run the package check**
+
+Run:
+
+```bash
+NEW_MOON_MOD=0 moon check lang/jsx/proj
+```
+
+Expected: the package still checks successfully; no production behavior changes.
+
+- [ ] **Step 3: Commit only if this isolated wiring is independently useful**
+
+Do not create a separate commit unless the repository workflow requires it; keep the import with the property-test commit otherwise.
+
+---
+
+### Task 2: Add the generated old/new patch-model property
+
+**Files:**
+- Create: `lang/jsx/proj/patch_properties_wbtest.mbt`
+
+**Interfaces:**
+- Consumes: `DryRunModel`, `DomPatch`, `reconcile`, `reconcile_jsx_projection`, `@core.ProjNode`, and `@jsx.JsxNode`.
+- Produces: one package-private QuickCheck property and one named whitebox test.
+
+- [x] **Step 1: Define a bounded generated tree and pair**
+
+Use a test-only enum with the three mounted node kinds:
+
+```moonbit
+enum PatchTree {
+  Element(tag~ : String, children~ : Array[PatchTree])
+  Text(value~ : String)
+  ExprSpan(raw~ : String)
+} derive(Debug, Eq)
+
+struct PatchTreePair {
+  old : PatchTree
+  new : PatchTree
+} derive(Debug)
+
+Implement `@quickcheck.Arbitrary` for `PatchTreePair` and structural `@qc.Shrink` implementations for both `PatchTree` and `PatchTreePair`. Shrinking must enumerate strictly simpler cases: remove the whole element child list, shrink child arrays through the built-in `Array` shrinker, shrink text and expression strings through the built-in `String` shrinker, and shrink each pair side independently. Generate depth at most four, zero through three children, fixed element tags (`div`, `span`, `p`), and varied text/raw values including empty, short, and punctuation-containing strings. The generator must produce nested elements as well as text/expression leaves. A failing property must therefore report a small tree with a reproducible seed rather than the original random tree.
+
+- [x] **Step 2: Lower generated trees to typed projections**
+
+Implement a test-only recursive helper returning paired `JsxNode` and `ProjNode[JsxNode]` values. Assign mounted-node IDs from `Ref(1)` for the old tree and a disjoint range such as `Ref(100_000)` for the provisional new tree; wrap each generated tree in a root projection with root ID `0`. Use empty attributes so the property focuses on patch ordering and mounted content rather than attribute normalization. Assert that every mounted ID is unique and that mounted IDs never include root ID `0`.
+
+- [x] **Step 3: Define the model-equivalence property**
+
+For each generated pair:
+
+1. Build the old projection.
+2. Reconcile it against an empty mounted-ID set and apply those patches to `DryRunModel::empty()`.
+3. Build a fresh new projection with provisional IDs from the disjoint range and call `reconcile_jsx_projection(old, new, Ref(1_000_000), None)` to obtain the identity-preserving new projection.
+4. Reconcile the new projection against the old mounted IDs and apply the incremental patches to the old model.
+5. Separately reconcile the identity-preserving new projection against an empty mounted-ID set and apply the fresh patches to an empty model.
+6. Return true only when incremental application succeeds, fresh application succeeds, every reported reachable-ID array is unique and excludes root ID `0`, the final model shapes are equal, and both paths report the same reachable mounted IDs.
+
+This explicitly exercises release-before-insert because the generated old/new sibling lists may remove and insert nodes at different indexes. It also covers nested parent IDs and text/expression nodes. The property proves final fake-DOM shape/order, not duplicate-key identity tie-breaking; that identity contract is asserted separately below.
+
+- [x] **Step 4: Add deterministic fixed regressions alongside the property**
+
+- `[Text("a"), ExprSpan("x"), Text("b")] → [Text("b"), Text("new"), ExprSpan("y")]`;
+- nested removal followed by insertion under the same surviving parent;
+- a mixed element/text/expression sibling update;
+- duplicate-key JSX siblings where old `[span("a"), span("a")]` becomes `[span("a"), span("a"), span("a")]`; add the independent identity/LCS regression in `lang/jsx/proj/reconcile_wbtest.mbt` and generic append/deletion/mixed-key tie regressions in `core/reconcile_properties_wbtest.mbt`, asserting earliest feasible old IDs and fresh IDs for genuinely inserted nodes. The model-equivalence oracle cannot provide this independent identity check.
+
+Each case must assert the final `DryRunModel::shape()` exactly, not merely that `apply` returns `Ok`.
+
+- [x] **Step 5: Calibrate the model-equivalence detector**
+
+Use one deterministic old/new transition with an insertion, corrupt exactly one emitted `Make*` patch's sibling index to a different in-bounds index in a test-only patch array, require the corrupted `apply` to succeed, and assert that its shape differs from the fresh-render oracle. This known-positive control proves the comparison rejects the historical sibling-order failure without introducing a second fake-DOM implementation.
+
+- [x] **Step 6: Run the new tests**
+
+Run:
+
+```bash
+NEW_MOON_MOD=0 moon check lang/jsx/proj
+NEW_MOON_MOD=0 moon test lang/jsx/proj
+```
+
+Expected: the new fixed cases and QuickCheck property pass. If the property exposes a real defect, retain the failure seed/counterexample, then change the smallest production boundary required by that counterexample.
+
+---
+
+### Task 3: Verify the complete issue contract
+
+**Files:**
+- Modify: `core/reconcile.mbt` (exact-key LCS reconstruction defect exposed by the independent identity regression)
+- Modify: `core/reconcile_properties_wbtest.mbt` (generic exact-key identity regressions)
+- Modify: `lang/jsx/proj/pkg.generated.mbti` only if generated interfaces change
+- Modify: `lang/jsx/proj/reconcile_wbtest.mbt` (JSX duplicate-key identity regression)
+- No browser files are expected to change.
+
+- [x] **Step 1: Run focused package validation**
+
+```bash
+NEW_MOON_MOD=0 moon check lang/jsx/proj
+NEW_MOON_MOD=0 moon test lang/jsx/proj
+NEW_MOON_MOD=0 moon test ffi/jsx
+```
+
+- [x] **Step 2: Run formatting and interface generation**
+
+```bash
+NEW_MOON_MOD=0 moon fmt lang/jsx/proj
+NEW_MOON_MOD=0 moon info lang/jsx/proj
+```
+
+Inspect `lang/jsx/proj/pkg.generated.mbti`; the new helpers are test-only, so no public API change is expected.
+
+- [x] **Step 3: Inspect the diff**
+
+Confirm the change provides evidence for:
+
+- generated final sibling order;
+- release-before-insert;
+- text and expression-span nodes;
+- nested updates;
+- deterministic property generation and shrinking;
+- session/DOM production code unchanged unless a property found a genuine defect.
+
+- [x] **Step 4: Run whitespace validation**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 5: Commit the focused test change**
+
+```bash
+git add lang/jsx/proj/moon.pkg lang/jsx/proj/patch_properties_wbtest.mbt
+# Include pkg.generated.mbti only if moon info changed it intentionally.
+git commit -m "test(jsx): property-test patch application ordering"
+```

--- a/lang/jsx/proj/moon.pkg
+++ b/lang/jsx/proj/moon.pkg
@@ -8,3 +8,10 @@ import {
   "dowdiness/seam",
   "moonbitlang/core/json",
 }
+
+import {
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/splitmix",
+  "moonbitlang/core/set",
+  "moonbitlang/quickcheck" @qc,
+} for "wbtest"

--- a/lang/jsx/proj/patch_properties_wbtest.mbt
+++ b/lang/jsx/proj/patch_properties_wbtest.mbt
@@ -1,0 +1,353 @@
+///|
+/// Test-only generated trees for DOM patch application properties.
+enum PatchTree {
+  Element(tag~ : String, children~ : Array[PatchTree])
+  Text(value~ : String)
+  ExprSpan(raw~ : String)
+} derive(Debug, Eq)
+
+///|
+struct PatchTreePair {
+  old : PatchTree
+  new : PatchTree
+} derive(Debug)
+
+///|
+fn PatchTreePair::PatchTreePair(
+  old~ : PatchTree,
+  new~ : PatchTree,
+) -> PatchTreePair {
+  { old, new }
+}
+
+///|
+impl @quickcheck.Arbitrary for PatchTreePair with fn arbitrary(size, rs) {
+  let depth = if size < 1 { 1 } else if size > 4 { 4 } else { size }
+  PatchTreePair(
+    old=gen_patch_tree(rs.split(), depth),
+    new=gen_patch_tree(rs.split(), depth),
+  )
+}
+
+///|
+impl @qc.Shrink for PatchTree with fn shrink(tree) {
+  match tree {
+    PatchTree::Element(tag~, children~) =>
+      if children.is_empty() {
+        Iter::empty()
+      } else {
+        Iter::singleton(PatchTree::Element(tag~, children=[])).concat(
+          @qc.Shrink::shrink(children).map(children1 => {
+            PatchTree::Element(tag~, children=children1)
+          }),
+        )
+      }
+    PatchTree::Text(value~) =>
+      @qc.Shrink::shrink(value).map(value1 => PatchTree::Text(value=value1))
+    PatchTree::ExprSpan(raw~) =>
+      @qc.Shrink::shrink(raw).map(raw1 => PatchTree::ExprSpan(raw=raw1))
+  }
+}
+
+///|
+impl @qc.Shrink for PatchTreePair with fn shrink(pair) {
+  let old = pair.old
+  let new = pair.new
+  @qc.Shrink::shrink(old)
+  .map(old1 => PatchTreePair(old=old1, new~))
+  .concat(@qc.Shrink::shrink(new).map(new1 => PatchTreePair(old~, new=new1)))
+}
+
+///|
+fn gen_patch_tree(rs : @splitmix.RandomState, depth : Int) -> PatchTree {
+  if depth <= 0 {
+    gen_patch_leaf(rs)
+  } else {
+    let choice = rs.split().next_positive_int() % 4
+    if choice == 0 {
+      gen_patch_leaf(rs.split())
+    } else {
+      let tags = ["div", "span", "p"]
+      let tag = tags[rs.split().next_positive_int() % tags.length()]
+      let child_count = rs.split().next_positive_int() % 4
+      let children = Array::makei(child_count, _ => {
+        gen_patch_tree(rs.split(), depth - 1)
+      })
+      PatchTree::Element(tag~, children~)
+    }
+  }
+}
+
+///|
+fn gen_patch_leaf(rs : @splitmix.RandomState) -> PatchTree {
+  let values = ["", "a", "b", "<", ">", "{", "}", "&", "a<> {}"]
+  let value = values[rs.next_positive_int() % values.length()]
+  if rs.split().next_positive_int() % 2 == 0 {
+    PatchTree::Text(value~)
+  } else {
+    PatchTree::ExprSpan(raw=value)
+  }
+}
+
+///|
+fn lower_patch_tree(
+  tree : PatchTree,
+  counter : Ref[Int],
+) -> (@jsx.JsxNode, @core.ProjNode[@jsx.JsxNode]) {
+  match tree {
+    PatchTree::Element(tag~, children~) => {
+      let lowered = children.map(child => lower_patch_tree(child, counter))
+      let jsx_children = lowered.map(pair => pair.0)
+      let proj_children = lowered.map(pair => pair.1)
+      let kind = @jsx.JsxNode::Element(tag~, attrs=[], children=jsx_children)
+      let node = @core.ProjNode::ProjNode(
+        kind,
+        0,
+        0,
+        @core.next_proj_node_id(counter),
+        proj_children,
+      )
+      (kind, node)
+    }
+    PatchTree::Text(value~) => {
+      let kind = @jsx.JsxNode::Text(value)
+      let node = @core.ProjNode::ProjNode(
+        kind,
+        0,
+        0,
+        @core.next_proj_node_id(counter),
+        [],
+      )
+      (kind, node)
+    }
+    PatchTree::ExprSpan(raw~) => {
+      let kind = @jsx.JsxNode::ExprSpan(raw~)
+      let node = @core.ProjNode::ProjNode(
+        kind,
+        0,
+        0,
+        @core.next_proj_node_id(counter),
+        [],
+      )
+      (kind, node)
+    }
+  }
+}
+
+///|
+fn lower_patch_root(
+  tree : PatchTree,
+  counter : Ref[Int],
+) -> @core.ProjNode[@jsx.JsxNode] {
+  let (kind, node) = lower_patch_tree(tree, counter)
+  let root_kind = @jsx.JsxNode::Root(children=[kind])
+  @core.ProjNode::ProjNode(root_kind, 0, 0, 0, [node])
+}
+
+///|
+fn patch_tree_ids(root : @core.ProjNode[@jsx.JsxNode]) -> Array[Int] {
+  let ids : Array[Int] = []
+  for child in root.children {
+    collect_patch_tree_ids(child, ids)
+  }
+  ids
+}
+
+///|
+fn collect_patch_tree_ids(
+  node : @core.ProjNode[@jsx.JsxNode],
+  ids : Array[Int],
+) -> Unit {
+  ids.push(node.node_id)
+  for child in node.children {
+    collect_patch_tree_ids(child, ids)
+  }
+}
+
+///|
+fn patch_ids_unique_and_mounted(ids : Array[Int]) -> Bool {
+  !ids.contains(0) && all_unique_patch_ids(ids)
+}
+
+///|
+fn all_unique_patch_ids(ids : Array[Int]) -> Bool {
+  let seen = @set.Set::Set([])
+  for id in ids {
+    if !seen.add_and_check(id) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn prop_generated_patch_model_equivalence(pair : PatchTreePair) -> Bool {
+  let old = lower_patch_root(pair.old, Ref(1))
+  let new_raw = lower_patch_root(pair.new, Ref(100_000))
+  if !patch_ids_unique_and_mounted(patch_tree_ids(old)) {
+    return false
+  }
+  if !patch_ids_unique_and_mounted(patch_tree_ids(new_raw)) {
+    return false
+  }
+
+  let (old_first_patches, old_mounted) = reconcile(old, [])
+  let old_model = match DryRunModel::empty().apply(old_first_patches) {
+    Ok(model) => model
+    Err(_) => return false
+  }
+  let new = reconcile_jsx_projection(old, new_raw, Ref(1_000_000), None)
+  let (incremental_patches, incremental_ids) = reconcile(new, old_mounted)
+  let (fresh_patches, fresh_ids) = reconcile(new, [])
+  let incremental_model = match old_model.apply(incremental_patches) {
+    Ok(model) => model
+    Err(_) => return false
+  }
+  let fresh_model = match DryRunModel::empty().apply(fresh_patches) {
+    Ok(model) => model
+    Err(_) => return false
+  }
+  patch_ids_unique_and_mounted(incremental_ids) &&
+  patch_ids_unique_and_mounted(fresh_ids) &&
+  incremental_ids == fresh_ids &&
+  incremental_model.shape() == fresh_model.shape()
+}
+
+///|
+test "property: generated patch application matches fresh render" {
+  @qc.quick_check_fn(prop_generated_patch_model_equivalence)
+}
+
+///|
+fn corrupt_first_make_index(patches : Array[DomPatch]) -> Array[DomPatch] {
+  let changed = Ref(false)
+  let result : Array[DomPatch] = []
+  for patch in patches {
+    match patch {
+      MakeElement(parent_id, node_id, tag, attrs, index) if !changed.val => {
+        changed.val = true
+        result.push(
+          MakeElement(
+            parent_id,
+            node_id,
+            tag,
+            attrs,
+            if index == 0 {
+              1
+            } else {
+              0
+            },
+          ),
+        )
+      }
+      MakeText(parent_id, node_id, value, index) if !changed.val => {
+        changed.val = true
+        result.push(
+          MakeText(parent_id, node_id, value, if index == 0 { 1 } else { 0 }),
+        )
+      }
+      MakeExprSpan(parent_id, node_id, raw, index) if !changed.val => {
+        changed.val = true
+        result.push(
+          MakeExprSpan(parent_id, node_id, raw, if index == 0 { 1 } else { 0 }),
+        )
+      }
+      _ => result.push(patch)
+    }
+  }
+  result
+}
+
+///|
+test "property detector rejects in-bounds insertion-index corruption" {
+  let old_tree = PatchTree::Element(tag="div", children=[
+    PatchTree::Text(value="a"),
+    PatchTree::Text(value="b"),
+  ])
+  let new_tree = PatchTree::Element(tag="div", children=[
+    PatchTree::Text(value="a"),
+    PatchTree::Text(value="new"),
+    PatchTree::Text(value="b"),
+  ])
+  let old = lower_patch_root(old_tree, Ref(1))
+  let new_raw = lower_patch_root(new_tree, Ref(100_000))
+  let (old_patches, old_ids) = reconcile(old, [])
+  let old_model = DryRunModel::empty().apply(old_patches).unwrap()
+  let new = reconcile_jsx_projection(old, new_raw, Ref(1_000_000), None)
+  let (incremental, _) = reconcile(new, old_ids)
+  let (fresh, _) = reconcile(new, [])
+  let expected = DryRunModel::empty().apply(fresh).unwrap()
+  let corrupted = corrupt_first_make_index(incremental)
+  let corrupted_model = old_model.apply(corrupted).unwrap()
+  inspect(corrupted_model.shape() != expected.shape(), content="true")
+}
+
+///|
+fn apply_patch_transition(
+  old_tree : PatchTree,
+  new_tree : PatchTree,
+) -> DryRunModel {
+  let old = lower_patch_root(old_tree, Ref(1))
+  let new_raw = lower_patch_root(new_tree, Ref(100_000))
+  let (old_patches, old_ids) = reconcile(old, [])
+  let old_model = DryRunModel::empty().apply(old_patches).unwrap()
+  let new = reconcile_jsx_projection(old, new_raw, Ref(1_000_000), None)
+  let (patches, _) = reconcile(new, old_ids)
+  old_model.apply(patches).unwrap()
+}
+
+///|
+test "patch transition preserves text and expression sibling ordering" {
+  let result = apply_patch_transition(
+    PatchTree::Element(tag="div", children=[
+      PatchTree::Text(value="a"),
+      PatchTree::ExprSpan(raw="x"),
+      PatchTree::Text(value="b"),
+    ]),
+    PatchTree::Element(tag="div", children=[
+      PatchTree::Text(value="b"),
+      PatchTree::Text(value="new"),
+      PatchTree::ExprSpan(raw="y"),
+    ]),
+  )
+  inspect(result.shape(), content="[E(4,div,0,[T(1,b),T(1000000,new),X(2,y)])]")
+}
+
+///|
+test "patch transition handles nested removal and insertion" {
+  let result = apply_patch_transition(
+    PatchTree::Element(tag="div", children=[
+      PatchTree::Element(tag="span", children=[PatchTree::Text(value="old")]),
+    ]),
+    PatchTree::Element(tag="div", children=[
+      PatchTree::Element(tag="span", children=[
+        PatchTree::Text(value="new"),
+        PatchTree::ExprSpan(raw="value"),
+      ]),
+    ]),
+  )
+  inspect(
+    result.shape(),
+    content="[E(3,div,0,[E(2,span,0,[T(1,new),X(1000000,value)])])]",
+  )
+}
+
+///|
+test "patch transition handles mixed element text and expression siblings" {
+  let result = apply_patch_transition(
+    PatchTree::Element(tag="div", children=[
+      PatchTree::Element(tag="span", children=[]),
+      PatchTree::Text(value="old"),
+      PatchTree::ExprSpan(raw="old"),
+    ]),
+    PatchTree::Element(tag="div", children=[
+      PatchTree::Text(value="new"),
+      PatchTree::Element(tag="span", children=[]),
+      PatchTree::ExprSpan(raw="new"),
+    ]),
+  )
+  inspect(
+    result.shape(),
+    content="[E(4,div,0,[T(1000000,new),E(1,span,0,[]),X(3,new)])]",
+  )
+}

--- a/lang/jsx/proj/reconcile_wbtest.mbt
+++ b/lang/jsx/proj/reconcile_wbtest.mbt
@@ -203,6 +203,44 @@ test "reconcile: append equal-kind sibling mounts only the tail" {
 }
 
 ///|
+/// Exact duplicate sibling keys preserve existing IDs positionally.
+test "reconcile: duplicate exact siblings preserve identity order" {
+  let (old_root, _) = parse_to_proj_node(
+    "<div><span>a</span><span>a</span></div>",
+  )
+  let old_div = old_root.children[0]
+  let (new_raw, _) = parse_to_proj_node(
+    "<div><span>a</span><span>a</span><span>a</span></div>",
+  )
+  let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
+  let new_div = new_root.children[0]
+  inspect(new_div.children[0].id() == old_div.children[0].id(), content="true")
+  inspect(new_div.children[1].id() == old_div.children[1].id(), content="true")
+  inspect(new_div.children[2].id() != old_div.children[0].id(), content="true")
+  inspect(new_div.children[2].id() != old_div.children[1].id(), content="true")
+  inspect(
+    @core.NodeId::op_ge(new_div.children[2].id(), @core.NodeId::from_int(1000)),
+    content="true",
+  )
+}
+
+///|
+/// Removing an exact duplicate preserves the earliest existing identities.
+test "reconcile: duplicate exact siblings preserve prefix on deletion" {
+  let (old_root, _) = parse_to_proj_node(
+    "<div><span>a</span><span>a</span><span>a</span></div>",
+  )
+  let old_div = old_root.children[0]
+  let (new_raw, _) = parse_to_proj_node(
+    "<div><span>a</span><span>a</span></div>",
+  )
+  let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
+  let new_div = new_root.children[0]
+  inspect(new_div.children[0].id() == old_div.children[0].id(), content="true")
+  inspect(new_div.children[1].id() == old_div.children[1].id(), content="true")
+}
+
+///|
 /// Attribute differences are part of the exact subtree key, so a same-tag
 /// middle insertion does not retarget either existing sibling.
 test "reconcile: attribute-distinct siblings preserve exact identities" {


### PR DESCRIPTION
## Summary

- Preserve prefix-stable identities for duplicate exact-key siblings during reconciliation.
- Add core and JSX regressions for duplicate append, deletion, insertion, and mixed ties.
- Add QuickCheck coverage for generated JSX patch application, including releases, insertions, nested updates, text, and expression spans.

## Verification

- `NEW_MOON_MOD=0 moon check core lang/jsx/proj`
- `NEW_MOON_MOD=0 moon test core` — 139 passed
- `NEW_MOON_MOD=0 moon test lang/jsx/proj` — 43 passed
- `NEW_MOON_MOD=0 moon test ffi/jsx` — 49 passed
- `NEW_MOON_MOD=0 moon fmt core lang/jsx/proj`
- `NEW_MOON_MOD=0 moon info core lang/jsx/proj`
- `git diff --check`

The full workspace JS run still reports two pre-existing vendored Rabbita DOM README failures (`document is not defined`); the same failures reproduce when testing `rabbita/rabbita/dom` directly.

The DryRunModel property oracle verifies incremental-vs-fresh patch application and final fake-DOM shape/order. It is not an independent proof of projection identity because both paths share reconciliation and patch generation. Dedicated core/JSX identity regressions cover that boundary.

Closes #888