### PR TITLE
test(genui): complete browser failure recovery slice

### DIFF
--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -263,8 +263,8 @@ Required zero-count safety metrics are recorded separately by source:
 
 Browser measurement run (`npx playwright test tests/genui.spec.ts --grep
 "safety measurements"`, Chromium, 2026-07-13): five valid replay latency
-samples were `288.50, 1.90, 1.30, 4.50, 1.80 ms` (min `1.30`, median `1.90`,
-mean `59.60`, max `288.50`); three invalid and three stale-base candidates
+samples were `195.40, 1.60, 1.40, 1.50, 1.50 ms` (min `1.40`, median `1.50`,
+mean `40.28`, max `195.40`); three invalid and three stale-base candidates
 were rejected (`6/6`, rejection rate `1.0`); one forced DOM failure was
 followed by one successful repair; deterministic fresh-replay mismatch count
 was `0`; Chromium reported heap measurement available with `17,100,000` used

--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -42,12 +42,18 @@ Out:
   results through `ffi/jsx/session.mbt`.
 - The Phase 3 DOM patch semantics and dry-run/DOM boundary are fixed in the
   [JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md).
-- DOM patch ordering and sibling-index correctness have a regression test in
-  `ffi/jsx/session_contract_wbtest.mbt`; broader property coverage is tracked
-  by [Issue #888](https://github.com/dowdiness/canopy/issues/888).
-- `examples/web/src/genui.js` already replays JSX prefixes through a stateful
-  session, but its source is a local fixed string and its stop behavior is not
-  yet a generation lifecycle contract.
+- DOM patch ordering, sibling-index correctness, and duplicate identity
+  preservation are covered by merged Canopy PR #892
+  (`core/reconcile_properties_wbtest.mbt`,
+  `lang/jsx/proj/reconcile_wbtest.mbt`, and
+  `lang/jsx/proj/patch_properties_wbtest.mbt`). Issue #888 is closed.
+- `examples/web/src/genui.js` now replays validated candidates through the
+  session-owned JSX boundary. Its DEV-only `window.__canopyGenUiTest` surface
+  is a thin browser-test call-through, not lifecycle or commit policy.
+- Browser evidence now covers invalid candidates, stale bases, DOM apply
+  failure, dirty-root repair, host-state preservation, and deterministic fresh
+  replay. Candidate replay remains synchronous whole-replay; cancellation and
+  late candidate chunks remain cognition-only evidence.
 - `llm/` is a Gemini-specific, whole-response text-edit client. It is not the
   UI candidate protocol and is intentionally not required for this phase.
 - `lib/cognition` contains provider-boundary concepts for request identity,
@@ -169,102 +175,130 @@ if the product requires it.
 
 ## Steps
 
-1. **Phase 0 — contract:** define the request lifecycle and event envelope as
-   pure domain data. Resolve every transition-table policy and add deterministic
-   tests for start, chunk, duplicate, gap, final, cancel, stale, failed, and
-   resumed states.
-2. **Phase 1 — replay:** add a fixed-chunk replay source and fixtures for
-   complete, incomplete,
-   duplicated, out-of-order, late, cancelled, and resumed generations. Do not
-   call a network provider.
-3. **Phase 2 — candidate boundary:** define the constrained UI candidate schema
-   and validator. Keep the allowlist minimal, make rejection diagnostics
-   structured and replayable, and define the lowering from host-owned data
-   bindings and interaction state into the JSX session.
-4. **Phase 3 — dry-run and commit:** build the internal dry-run model. Compare
-   candidate projection results with
-   the expected model, including sibling order, text/element mixtures, nested
-   updates, and failed applications. Reuse the existing patch contract rather
-   than inventing a second DOM semantics.
-5. Connect validated replay candidates to the existing JSX session. Commit only
-   after dry-run and DOM success. On failure, preserve committed source and
-   revision, mark the session dirty, and verify that the next success repairs
-   the dirty root before commit.
-6. **Phase 4 — smallest vertical slice:** implement JSON fixture + table first,
-   then add one filter and selection preservation. Only after those pass, add
-   detail/summary and CSV input. Preserve filter and selection state where
-   structure permits.
-7. Add focused and property-based tests, then browser tests for streaming,
-   cancellation, late chunks, state preservation, and recovery.
-8. Measure update latency, candidate rejection/repair counts, state-loss
-   count, stale-chunk application count, and deterministic replay results.
+1. **Phase 0–4 implementation:** completed by merged PR #890. This includes
+   the pure lifecycle, fixed replay source, candidate schema/validator,
+   candidate lowering, dry-run model, session commit/recovery contract, and
+   JSON/CSV data-exploration surface.
+2. **Patch-ordering correctness:** completed by merged PR #892. The generic
+   exact-key LCS reconstruction now preserves duplicate sibling identities;
+   focused core/JSX regressions and generated patch properties are landed.
+3. **Browser boundary evidence:** completed in
+   `examples/web/tests/genui.spec.ts` for invalid and stale candidates, DOM
+   apply failure, dirty-root repair, host-owned state preservation, and
+   deterministic fresh replay. No second lifecycle controller was added;
+   cancellation and late candidate chunks remain pure cognition coverage
+   because the exported candidate replay is synchronous.
+4. **Measurements:** completed with a fixed-count browser measurement test.
+   Raw latency samples, rejection counts/rate, repair count, state-loss count,
+   deterministic replay mismatches, and heap availability are recorded below.
 
 ## Acceptance Criteria
 
-- [ ] **AC-01:** A complete replay produces the expected fixture table.
-- [ ] **AC-02:** A filter and selection update preserve supported user state.
-- [ ] **AC-03:** Incomplete or invalid candidates leave committed source and
+- [x] **AC-01:** A complete replay produces the expected fixture table.
+      `examples/web/tests/genui.spec.ts` and the existing candidate browser
+      test cover the JSON fixture table.
+- [x] **AC-02:** A filter and selection update preserve supported user state.
+      The existing browser interaction tests cover filter, selection, detail,
+      and focus preservation.
+- [x] **AC-03:** Incomplete or invalid candidates leave committed source and
       revision unchanged; invalid candidates do not reach the renderer.
-- [ ] **AC-04:** A stale base revision is rejected without advancing the
-      session revision.
-- [ ] **AC-05:** Duplicate chunks are idempotent; out-of-order chunks follow a
-      defined
-      rejection or buffering policy.
-- [ ] **AC-06:** Cancellation invalidates generations before `Applying`; late
-      chunks cannot commit. Cancellation after `Applying` begins is too late
-      and the apply result linearizes.
-- [ ] **AC-07:** Resumption starts only from an explicitly selected committed
-      revision.
-- [ ] **AC-08:** Finalization is idempotent and terminal generations cannot
-      accept later
-      chunks.
-- [ ] **AC-09:** Dry-run validation completes before any candidate commit.
-- [ ] **AC-10:** DOM application failure preserves committed source and
+      `lib/cognition/generative_ui_test.mbt` and the browser invalid-candidate
+      test cover this boundary.
+- [x] **AC-04:** A stale base revision is rejected without advancing the
+      session revision. Covered by cognition/session tests and the browser
+      stale-base test.
+- [x] **AC-05:** Duplicate chunks are idempotent; out-of-order chunks follow a
+      defined rejection policy. Covered by
+      `lib/cognition/generative_ui_test.mbt` and replay tests.
+- [x] **AC-06:** Cancellation invalidates generations before `Applying`; late
+      chunks cannot commit, while cancellation after applying is too late.
+      Covered by deterministic cognition lifecycle tests. The browser candidate
+      API is synchronous and does not claim a browser interleaving test.
+- [x] **AC-07:** Resumption starts only from an explicitly selected committed
+      revision. Covered by the lifecycle tests.
+- [x] **AC-08:** Finalization is idempotent and terminal generations cannot
+      accept later chunks. Covered by the lifecycle tests.
+- [x] **AC-09:** Dry-run validation completes before any candidate commit.
+      Covered by `ffi/jsx/session_contract_wbtest.mbt` and lifecycle tests;
+      the browser suite verifies the subsequent real DOM boundary.
+- [x] **AC-10:** DOM application failure preserves committed source and
       revision, marks the session dirty, never reports the candidate committed,
-      and the next successful render repairs the dirty root before commit.
-- [ ] **AC-11:** The generated surface cannot perform network mutation,
-      persistence,
-      navigation, raw HTML insertion, or arbitrary code execution.
-- [ ] **AC-12:** Property tests cover removal-before-insertion, sibling indexes,
-      nested
-      updates, text/expression-span nodes, and session isolation.
-- [ ] **AC-13:** Host-owned data bindings, filter/selection state, and
+      and the next successful render repairs the dirty root. Covered by
+      `ffi/jsx/render_baseline_wbtest.mbt`, session tests, and the browser
+      failure/recovery test.
+- [x] **AC-11:** The generated surface cannot perform network mutation,
+      persistence, navigation, raw HTML insertion, or arbitrary code execution.
+      Covered by candidate validator/projection tests and the invalid browser
+      candidate test.
+- [ ] **AC-12:** Property tests cover removal-before-insertion, sibling
+      indexes, nested updates, text/expression-span nodes, and session
+      isolation. The generated patch property suite covers patch/model
+      equivalence and the known-positive corruption detector; fixed session
+      contract tests cover isolation, but a dedicated session-isolation
+      property is not yet present.
+- [x] **AC-13:** Host-owned data bindings, filter/selection state, and
       allowlisted aggregations lower into the candidate without arbitrary
-      expressions or candidate-owned mutable state.
+      expressions or candidate-owned mutable state. Covered by candidate,
+      projection, data-explorer, and browser state tests.
 - [ ] **AC-14:** Browser tests cover the same lifecycle against the real JSX
-      session.
-- [ ] **AC-15:** The results and measurements are recorded before deciding
-      whether to add
-      a live provider or freeze a renderer-neutral contract.
+      session. Browser coverage now proves invalid/stale rejection, DOM failure
+      and recovery, state preservation, and deterministic replay. Cancellation,
+      late candidate chunks, and internal dry-run failure remain cognition/
+      MoonBit evidence because the public candidate replay call is synchronous
+      and does not expose internal dry-run state.
+- [x] **AC-15:** Results and measurements are recorded before deciding whether
+      to add a live provider or freeze a renderer-neutral contract. See the
+      dated evidence and metric table below; the live-provider gate remains
+      closed while AC-14 is incomplete.
 
-Required zero-count safety metrics: stale chunk commits, cancelled-generation
-commits, state loss, falsely committed failed applies, and deterministic replay
-mismatches. Latency, rejection rate, repair count, and memory usage are
-recorded as measurements; this plan does not set performance targets yet.
+Required zero-count safety metrics are recorded separately by source:
+
+- cognition lifecycle: cancelled-generation commits `0`; stale/late-generation
+  chunk commits or terminal-event acceptances `0`; deterministic replay
+  mismatches `0` (covered by the cancellation, stale-generation, and terminal
+  event tests in `lib/cognition/generative_ui_test.mbt`);
+- browser session: stale-base candidate commits `0`; host state loss `0`;
+  falsely committed failed DOM applies `0`; deterministic fresh-replay
+  mismatches `0`.
+
+Browser measurement run (`npx playwright test tests/genui.spec.ts --grep
+"safety measurements"`, Chromium, 2026-07-13): five valid replay latency
+samples were `340.50, 1.80, 1.80, 1.60, 1.70 ms` (min `1.60`, median `1.80`,
+mean `69.48`, max `340.50`); three invalid and three stale-base candidates
+were rejected (`6/6`, rejection rate `1.0`); one forced DOM failure was
+followed by one successful repair; deterministic fresh-replay mismatch count
+was `0`; Chromium reported heap measurement available with `17,100,000` used
+and `20,500,000` total bytes in the captured sample. The attached raw JSON
+also contains matching before/after host-state snapshots and failed/repaired
+DOM result summaries; fixed denominators and every latency sample are retained.
 
 ## Test Matrix
 
 | Acceptance criteria | Pure lifecycle/model | MoonBit package tests | Browser/E2E |
 | --- | --- | --- | --- |
 | AC-01–AC-02 | candidate/model fixtures | JSX session contract | JSON/CSV surface |
-| AC-03–AC-05 | transition + property tests | session recovery | failed/old render |
-| AC-06–AC-08 | cancellation/terminal tests | generation adapter | stop/resume UI |
-| AC-09–AC-11 | validator + dry-run tests | DOM error contract | real DOM commit |
-| AC-12–AC-13 | patch/model + binding properties | `ffi/jsx` tests | interaction cases |
-| AC-14–AC-15 | replay/measurement harness | package totals | browser report |
+| AC-03–AC-05 | transition + property tests | session recovery | invalid/stale candidate tests |
+| AC-06–AC-08 | cancellation/terminal tests | generation adapter | cognition-only for candidate cancellation |
+| AC-09–AC-11 | validator + dry-run tests | DOM error contract | real DOM commit and apply-failure recovery |
+| AC-12–AC-13 | patch/model + binding properties | `ffi/jsx` tests | interaction/state-preservation cases |
+| AC-14–AC-15 | replay/measurement harness | package totals | partial lifecycle browser report + attached metrics |
 
 ## Exit Gates
 
-- **Gate 0:** transition table policies are decided and every transition has a
-  deterministic test.
-- **Gate 1:** fixed replay passes without network access, including duplicate,
-  stale, cancellation, and finalization cases.
-- **Gate 2:** invalid candidates cannot reach the renderer and AC-09–AC-11
-  pass.
-- **Gate 3:** JSON fixture + table + one filter pass AC-01–AC-10 in both model
-  and browser tests, and AC-13 confirms host-owned bindings.
-- **Gate 4:** full acceptance matrix and zero-count safety metrics pass. Only
-  then may a live provider or renderer-neutral contract be planned.
+- **Gate 0:** **passed** — transition policies and deterministic lifecycle
+  tests are landed in `lib/cognition`.
+- **Gate 1:** **passed** — fixed replay covers duplicate, stale, cancellation,
+  late, and finalization cases without network access.
+- **Gate 2:** **passed** — invalid candidates are rejected before lowering;
+  validator, dry-run, DOM error, and capability tests cover AC-09–AC-11.
+- **Gate 3:** **partially passed** — model and browser tests cover the JSON/CSV
+  surface, host state, candidate rejection, DOM failure, and recovery. Browser
+  cancellation/late-candidate interleaving and internal dry-run fault
+  injection are intentionally not claimed.
+- **Gate 4:** **not yet passed** — all recorded browser safety counts are zero,
+  but AC-14 remains open for the explicitly bounded browser lifecycle gap.
+  Do not add a live provider or renderer-neutral contract until that gate is
+  closed by an approved evidence decision.
 
 ## Validation
 
@@ -308,10 +342,12 @@ identified rather than hidden by this plan.
 
 ## Notes
 
-- The first live provider should be added only after replay and browser tests
-  pass. Adapt `llm/` as a transport/provider implementation; do not make its
+- The first live provider must remain deferred until the remaining browser
+  lifecycle evidence decision is closed and the recorded metrics are reviewed.
+  Adapt `llm/` only as a transport/provider implementation; do not make its
   Gemini-specific `EditAction` contract the Generative UI domain model.
 - `moon prove` is a later option for pure request/reconciliation invariants. It
   is not a prerequisite for proving the JavaScript/DOM boundary.
 - Related direction: `docs/architecture/generative-ui-direction.md`.
-- Related correctness work: [Issue #888](https://github.com/dowdiness/canopy/issues/888).
+- Related correctness work: merged PR #892, “fix(reconcile): preserve duplicate
+  sibling identities.”

--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -263,8 +263,8 @@ Required zero-count safety metrics are recorded separately by source:
 
 Browser measurement run (`npx playwright test tests/genui.spec.ts --grep
 "safety measurements"`, Chromium, 2026-07-13): five valid replay latency
-samples were `340.50, 1.80, 1.80, 1.60, 1.70 ms` (min `1.60`, median `1.80`,
-mean `69.48`, max `340.50`); three invalid and three stale-base candidates
+samples were `288.50, 1.90, 1.30, 4.50, 1.80 ms` (min `1.30`, median `1.90`,
+mean `59.60`, max `288.50`); three invalid and three stale-base candidates
 were rejected (`6/6`, rejection rate `1.0`); one forced DOM failure was
 followed by one successful repair; deterministic fresh-replay mismatch count
 was `0`; Chromium reported heap measurement available with `17,100,000` used

--- a/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
+++ b/docs/plans/2026-07-12-generative-ui-input-vertical-slice.md
@@ -271,6 +271,8 @@ was `0`; Chromium reported heap measurement available with `17,100,000` used
 and `20,500,000` total bytes in the captured sample. The attached raw JSON
 also contains matching before/after host-state snapshots and failed/repaired
 DOM result summaries; fixed denominators and every latency sample are retained.
+The exact final-run JSON is tracked at
+[`docs/plans/evidence/2026-07-13-generative-ui-safety-metrics.json`](evidence/2026-07-13-generative-ui-safety-metrics.json).
 
 ## Test Matrix
 

--- a/docs/plans/evidence/2026-07-13-generative-ui-safety-metrics.json
+++ b/docs/plans/evidence/2026-07-13-generative-ui-safety-metrics.json
@@ -1,0 +1,88 @@
+{
+  "sample_counts": {
+    "latency": 5,
+    "invalid": 3,
+    "stale": 3,
+    "dom_failure_and_repair": 1,
+    "deterministic_replays": 2
+  },
+  "latency_samples": [
+    {
+      "duration_ms": 195.40000000596046,
+      "success": true,
+      "revision": 2
+    },
+    {
+      "duration_ms": 1.5999999940395355,
+      "success": true,
+      "revision": 2
+    },
+    {
+      "duration_ms": 1.4000000059604645,
+      "success": true,
+      "revision": 2
+    },
+    {
+      "duration_ms": 1.5,
+      "success": true,
+      "revision": 2
+    },
+    {
+      "duration_ms": 1.5,
+      "success": true,
+      "revision": 2
+    }
+  ],
+  "rejection": {
+    "invalid_rejected": 3,
+    "stale_rejected": 3,
+    "attempted": 6,
+    "rate": 1
+  },
+  "stale_base_state": {
+    "before_revision": 2,
+    "after_revision": 2,
+    "before_markup": "<div data-genui-kind=\"stack\">Orders</div>",
+    "after_markup": "<div data-genui-kind=\"stack\">Orders</div>"
+  },
+  "host_state": {
+    "before": {
+      "filter": "paid",
+      "selection": "Selected: Cedar support plan (ord-1003)",
+      "detail": "Cedar support plan",
+      "focusedOrderId": "ord-1003",
+      "selectedTestId": "order-row-ord-1003"
+    },
+    "after": {
+      "filter": "paid",
+      "selection": "Selected: Cedar support plan (ord-1003)",
+      "detail": "Cedar support plan",
+      "focusedOrderId": "ord-1003",
+      "selectedTestId": "order-row-ord-1003"
+    }
+  },
+  "dom_apply": {
+    "failed": {
+      "success": false,
+      "revision": 2,
+      "error_code": "DomApplyError"
+    },
+    "repaired": {
+      "success": true,
+      "revision": 3,
+      "error_code": null
+    }
+  },
+  "repair_count": 1,
+  "zero_counts": {
+    "stale_candidate_commits": 0,
+    "host_state_loss": 0,
+    "falsely_committed_failed_apply": 0,
+    "deterministic_replay_mismatches": 0
+  },
+  "heap": {
+    "available": true,
+    "used_js_heap_size": 17100000,
+    "total_js_heap_size": 20500000
+  }
+}

--- a/docs/superpowers/plans/2026-07-13-generative-ui-browser-failure-recovery.md
+++ b/docs/superpowers/plans/2026-07-13-generative-ui-browser-failure-recovery.md
@@ -113,8 +113,8 @@ Expected: invalid/stale/apply-failure/recovery/determinism tests pass.
   lang/jsx/proj `43/43`.
 - Scoped `moon fmt` and `moon info` passed with no generated interface drift.
 - `npm run build` passed.
-- Playwright GenUI suite passed: `14/14`; the measurement test retained
-  `genui-safety-metrics.json` with the values recorded in the vertical-slice
-  plan.
+- Playwright GenUI suite passed: `14/14`; the final measurement JSON is tracked
+  at `docs/plans/evidence/2026-07-13-generative-ui-safety-metrics.json` and
+  matches the values recorded in the vertical-slice plan.
 - The live-provider gate remains closed because AC-12 and AC-14 are still
   explicitly unchecked.

--- a/docs/superpowers/plans/2026-07-13-generative-ui-browser-failure-recovery.md
+++ b/docs/superpowers/plans/2026-07-13-generative-ui-browser-failure-recovery.md
@@ -1,0 +1,107 @@
+# Generative UI Browser Failure Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add browser evidence for invalid/stale candidate rejection and real DOM apply failure/recovery through the existing GenUI session boundary, then record safety metrics and acceptance evidence without adding a provider or parallel lifecycle.
+
+**Architecture:** Keep lifecycle, validation, dry-run, revision, and recovery policy in the existing MoonBit packages. Add only a thin underscored browser observability surface in `examples/web/src/genui.js` that calls existing FFI exports. Playwright induces DOM failure by monkeypatching the page root, then restores the method and invokes the same real session API for recovery. Cancellation and late candidate chunks remain cognition-only because the current candidate replay export is synchronous.
+
+**Tech Stack:** MoonBit (`NEW_MOON_MOD=0`), Vite, TypeScript, Playwright, existing `@moonbit/crdt-jsx` FFI exports, Markdown evidence.
+
+## Global Constraints
+
+- Do not connect a live Gemini or other provider.
+- Treat candidate input as untrusted; do not add raw HTML, arbitrary code, navigation, persistence, network, or generated side effects.
+- Preserve the functional-core / imperative-shell boundary.
+- Reuse existing lifecycle/session/recovery APIs; do not add a second controller or fake DOM.
+- Run `NEW_MOON_MOD=0 moon check` after every MoonBit file edit.
+- Use one file per edit call and re-read after line-count changes.
+- Keep browser cancellation claims separate from the synchronous candidate replay boundary.
+- Do not touch the Rabbita pointer branch or unrelated submodule state.
+
+---
+
+### Task 1: Add thin browser observability
+
+**Files:**
+- Modify: `examples/web/src/genui.js`
+
+**Interfaces:**
+- Produces `window.__canopyGenUiTest` with call-through methods only:
+  - `replayCandidate(candidateJson, capabilitiesJson)` delegates to the existing `replayCandidate` function.
+  - `replayCandidateAtRevision(baseRevision, candidateJson, capabilitiesJson)` delegates to the existing imported FFI function and returns its parsed result without changing commit policy.
+  - `sessionRevision()` returns the existing `jsxSessionRevision` value.
+  - `resetSession()` delegates to the existing `resetState` function.
+- The surface must not implement lifecycle transitions, validation, revision changes, or recovery.
+
+- [ ] Step 1: Add the underscored test surface beside the existing candidate/session functions.
+- [ ] Step 2: Run the web TypeScript check or Vite build to catch syntax/import errors.
+
+Run: `npm run build` from `examples/web`
+Expected: Vite build succeeds.
+
+- [ ] Step 3: Re-read the edited region and verify the surface contains no duplicated policy.
+
+### Task 2: Add failing browser scenarios
+
+**Files:**
+- Modify: `examples/web/tests/genui.spec.ts`
+
+**Interfaces:**
+- Consumes `window.__canopyGenUiTest` from Task 1.
+- Uses the existing `#html-preview` root and existing Data Explorer controls.
+- Uses a valid candidate fixture and a forbidden `raw_html` candidate fixture defined in the test file.
+
+- [ ] Step 1: Add a test for invalid candidate rejection with unchanged revision and preview.
+- [ ] Step 2: Add a test for stale base-revision rejection with unchanged revision and preview.
+- [ ] Step 3: Add a test that replaces the preview root insertion method with a throwing wrapper, asserts `DomApplyError`, unchanged revision, and no committed success state.
+- [ ] Step 4: Restore the insertion method, submit the same valid candidate, and assert revision advances once and the candidate surface is present.
+- [ ] Step 5: Add host-state assertions for filter, selection, detail text, and focus around the failure/recovery sequence.
+- [ ] Step 6: Add deterministic replay assertions comparing normalized preview markup, mounted-node count, success, and revision from two fresh sessions.
+- [ ] Step 7: Run only the new tests and confirm failures identify missing observability or behavior rather than silently passing.
+
+Run: `npx playwright test tests/genui.spec.ts --grep "candidate|recovery|replay"`
+Expected before implementation: failing tests due to missing test surface or assertions.
+
+### Task 3: Implement the minimum browser support
+
+**Files:**
+- Modify: `examples/web/src/genui.js`
+
+- [ ] Step 1: Implement only the call-through methods specified in Task 1.
+- [ ] Step 2: Run `npm run build` from `examples/web`.
+- [ ] Step 3: Run the focused Playwright scenarios from Task 2.
+
+Expected: invalid/stale/apply-failure/recovery/determinism tests pass.
+
+### Task 4: Record safety metrics and acceptance evidence
+
+**Files:**
+- Modify: `docs/plans/2026-07-12-generative-ui-input-vertical-slice.md`
+- Modify: `examples/web/tests/genui.spec.ts`
+
+**Interfaces:**
+- Records concrete evidence for AC-01 through AC-15.
+- Leaves cancellation/late-candidate browser evidence explicitly marked as cognition-only because the browser candidate API is synchronous.
+- Records zero-count safety metrics and reproducible latency/rejection/repair/heap observations from an attached raw JSON measurement artifact.
+
+- [ ] Step 1: Map each acceptance criterion to exact landed implementation and test paths.
+- [ ] Step 2: Mark only criteria with concrete evidence as complete; leave any unsupported claim unchecked.
+- [ ] Step 3: Replace stale Issue #888 wording with merged PR #892 evidence.
+- [ ] Step 4: Add a dated evidence table for focused MoonBit tests and browser tests.
+- [ ] Step 5: Add a dedicated Playwright measurement test with fixed denominators: five valid replay latency samples, three invalid attempts, three stale-base attempts, one forced failure plus repair, and two deterministic fresh replays.
+- [ ] Step 6: Attach raw JSON containing every `performance.now()` duration, attempt/result counts, state snapshots, repair count, and `performance.memory` availability/values.
+- [ ] Step 7: Add the measured safety metrics, including zero counts and unavailable measurements where the runtime cannot report them; label cognition-derived cancellation values separately.
+- [ ] Step 8: Self-review the plan for stale future-tense Phase 0–4 descriptions and distinguish historical implementation steps from remaining gates.
+
+### Task 5: Verify the complete slice
+
+**Files:**
+- No source changes.
+
+- [ ] Step 1: Run focused MoonBit checks/tests for `lib/cognition`, `ffi/jsx`, and `lang/jsx/proj`.
+- [ ] Step 2: Run scoped `moon fmt` and `moon info` only if MoonBit files changed; inspect generated interface drift.
+- [ ] Step 3: Run `npm run build` from `examples/web`.
+- [ ] Step 4: Run the complete `examples/web/tests/genui.spec.ts` suite.
+- [ ] Step 5: Run `git diff --check` and inspect the final diff for only the intended files.
+- [ ] Step 6: Report that live-provider work remains gated on the recorded evidence.

--- a/docs/superpowers/plans/2026-07-13-generative-ui-browser-failure-recovery.md
+++ b/docs/superpowers/plans/2026-07-13-generative-ui-browser-failure-recovery.md
@@ -34,13 +34,13 @@
   - `resetSession()` delegates to the existing `resetState` function.
 - The surface must not implement lifecycle transitions, validation, revision changes, or recovery.
 
-- [ ] Step 1: Add the underscored test surface beside the existing candidate/session functions.
-- [ ] Step 2: Run the web TypeScript check or Vite build to catch syntax/import errors.
+- [x] Step 1: Add the underscored test surface beside the existing candidate/session functions.
+- [x] Step 2: Run the web TypeScript check or Vite build to catch syntax/import errors.
 
 Run: `npm run build` from `examples/web`
 Expected: Vite build succeeds.
 
-- [ ] Step 3: Re-read the edited region and verify the surface contains no duplicated policy.
+- [x] Step 3: Re-read the edited region and verify the surface contains no duplicated policy.
 
 ### Task 2: Add failing browser scenarios
 
@@ -52,13 +52,13 @@ Expected: Vite build succeeds.
 - Uses the existing `#html-preview` root and existing Data Explorer controls.
 - Uses a valid candidate fixture and a forbidden `raw_html` candidate fixture defined in the test file.
 
-- [ ] Step 1: Add a test for invalid candidate rejection with unchanged revision and preview.
-- [ ] Step 2: Add a test for stale base-revision rejection with unchanged revision and preview.
-- [ ] Step 3: Add a test that replaces the preview root insertion method with a throwing wrapper, asserts `DomApplyError`, unchanged revision, and no committed success state.
-- [ ] Step 4: Restore the insertion method, submit the same valid candidate, and assert revision advances once and the candidate surface is present.
-- [ ] Step 5: Add host-state assertions for filter, selection, detail text, and focus around the failure/recovery sequence.
-- [ ] Step 6: Add deterministic replay assertions comparing normalized preview markup, mounted-node count, success, and revision from two fresh sessions.
-- [ ] Step 7: Run only the new tests and confirm failures identify missing observability or behavior rather than silently passing.
+- [x] Step 1: Add a test for invalid candidate rejection with unchanged revision and preview.
+- [x] Step 2: Add a test for stale base-revision rejection with unchanged revision and preview.
+- [x] Step 3: Add a test that replaces the preview root insertion method with a throwing wrapper, asserts `DomApplyError`, unchanged revision, and no committed success state.
+- [x] Step 4: Restore the insertion method, submit the same valid candidate, and assert revision advances once and the candidate surface is present.
+- [x] Step 5: Add host-state assertions for filter, selection, detail text, and focus around the failure/recovery sequence.
+- [x] Step 6: Add deterministic replay assertions comparing normalized preview markup, mounted-node count, success, and revision from two fresh sessions.
+- [x] Step 7: Run only the new tests and confirm failures identify missing observability or behavior rather than silently passing.
 
 Run: `npx playwright test tests/genui.spec.ts --grep "candidate|recovery|replay"`
 Expected before implementation: failing tests due to missing test surface or assertions.
@@ -68,9 +68,9 @@ Expected before implementation: failing tests due to missing test surface or ass
 **Files:**
 - Modify: `examples/web/src/genui.js`
 
-- [ ] Step 1: Implement only the call-through methods specified in Task 1.
-- [ ] Step 2: Run `npm run build` from `examples/web`.
-- [ ] Step 3: Run the focused Playwright scenarios from Task 2.
+- [x] Step 1: Implement only the call-through methods specified in Task 1.
+- [x] Step 2: Run `npm run build` from `examples/web`.
+- [x] Step 3: Run the focused Playwright scenarios from Task 2.
 
 Expected: invalid/stale/apply-failure/recovery/determinism tests pass.
 
@@ -85,23 +85,36 @@ Expected: invalid/stale/apply-failure/recovery/determinism tests pass.
 - Leaves cancellation/late-candidate browser evidence explicitly marked as cognition-only because the browser candidate API is synchronous.
 - Records zero-count safety metrics and reproducible latency/rejection/repair/heap observations from an attached raw JSON measurement artifact.
 
-- [ ] Step 1: Map each acceptance criterion to exact landed implementation and test paths.
-- [ ] Step 2: Mark only criteria with concrete evidence as complete; leave any unsupported claim unchecked.
-- [ ] Step 3: Replace stale Issue #888 wording with merged PR #892 evidence.
-- [ ] Step 4: Add a dated evidence table for focused MoonBit tests and browser tests.
-- [ ] Step 5: Add a dedicated Playwright measurement test with fixed denominators: five valid replay latency samples, three invalid attempts, three stale-base attempts, one forced failure plus repair, and two deterministic fresh replays.
-- [ ] Step 6: Attach raw JSON containing every `performance.now()` duration, attempt/result counts, state snapshots, repair count, and `performance.memory` availability/values.
-- [ ] Step 7: Add the measured safety metrics, including zero counts and unavailable measurements where the runtime cannot report them; label cognition-derived cancellation values separately.
-- [ ] Step 8: Self-review the plan for stale future-tense Phase 0–4 descriptions and distinguish historical implementation steps from remaining gates.
+- [x] Step 1: Map each acceptance criterion to exact landed implementation and test paths.
+- [x] Step 2: Mark only criteria with concrete evidence as complete; leave any unsupported claim unchecked.
+- [x] Step 3: Replace stale Issue #888 wording with merged PR #892 evidence.
+- [x] Step 4: Add a dated evidence table for focused MoonBit tests and browser tests.
+- [x] Step 5: Add a dedicated Playwright measurement test with fixed denominators: five valid replay latency samples, three invalid attempts, three stale-base attempts, one forced failure plus repair, and two deterministic fresh replays.
+- [x] Step 6: Attach raw JSON containing every `performance.now()` duration, attempt/result counts, state snapshots, repair count, and `performance.memory` availability/values.
+- [x] Step 7: Add the measured safety metrics, including zero counts and unavailable measurements where the runtime cannot report them; label cognition-derived cancellation values separately.
+- [x] Step 8: Self-review the plan for stale future-tense Phase 0–4 descriptions and distinguish historical implementation steps from remaining gates.
 
 ### Task 5: Verify the complete slice
 
 **Files:**
 - No source changes.
 
-- [ ] Step 1: Run focused MoonBit checks/tests for `lib/cognition`, `ffi/jsx`, and `lang/jsx/proj`.
-- [ ] Step 2: Run scoped `moon fmt` and `moon info` only if MoonBit files changed; inspect generated interface drift.
-- [ ] Step 3: Run `npm run build` from `examples/web`.
-- [ ] Step 4: Run the complete `examples/web/tests/genui.spec.ts` suite.
-- [ ] Step 5: Run `git diff --check` and inspect the final diff for only the intended files.
-- [ ] Step 6: Report that live-provider work remains gated on the recorded evidence.
+- [x] Step 1: Run focused MoonBit checks/tests for `lib/cognition`, `ffi/jsx`, and `lang/jsx/proj`.
+- [x] Step 2: Run scoped `moon fmt` and `moon info` only if MoonBit files changed; inspect generated interface drift.
+- [x] Step 3: Run `npm run build` from `examples/web`.
+- [x] Step 4: Run the complete `examples/web/tests/genui.spec.ts` suite.
+- [x] Step 5: Run `git diff --check` and inspect the final diff for only the intended files.
+- [x] Step 6: Report that live-provider work remains gated on the recorded evidence.
+
+## Verification record
+
+- `NEW_MOON_MOD=0 moon check lib/cognition ffi/jsx lang/jsx/proj` passed.
+- Focused MoonBit tests passed: cognition `120/120`, ffi/jsx `49/49`, and
+  lang/jsx/proj `43/43`.
+- Scoped `moon fmt` and `moon info` passed with no generated interface drift.
+- `npm run build` passed.
+- Playwright GenUI suite passed: `14/14`; the measurement test retained
+  `genui-safety-metrics.json` with the values recorded in the vertical-slice
+  plan.
+- The live-provider gate remains closed because AC-12 and AC-14 are still
+  explicitly unchecked.

--- a/docs/superpowers/specs/2026-07-13-generative-ui-browser-failure-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-13-generative-ui-browser-failure-recovery-design.md
@@ -61,14 +61,15 @@ test timing.
 
 The browser run records zero counts for:
 
-- stale candidate commits;
+- stale-base candidate commits;
 - host state-loss events;
 - falsely committed failed DOM applies;
 - deterministic replay mismatches.
 
 The cognition test suite separately records cancelled-generation commits and
-late-generation acceptance as zero. Those values are not presented as browser
-measurements because the browser candidate API is synchronous whole-replay.
+stale/late-generation chunk or terminal-event acceptance as zero. Those values
+are not presented as browser measurements because the browser candidate API is
+synchronous whole-replay.
 
 Latency, rejection rate, repair count, and browser heap usage are reported from
 the attached measurement JSON. Unsupported heap measurements are recorded as

--- a/docs/superpowers/specs/2026-07-13-generative-ui-browser-failure-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-13-generative-ui-browser-failure-recovery-design.md
@@ -1,0 +1,85 @@
+# Generative UI Browser Failure and Recovery Design
+
+## Goal
+
+Close the browser-level evidence gap around the existing Generative UI candidate/session commit boundary without adding a live provider, a second lifecycle controller, or test-only FFI lifecycle semantics.
+
+## Scope
+
+This slice covers browser-observable behavior through the existing exported JSX session APIs:
+
+- invalid candidate rejection before candidate rendering;
+- stale base-revision rejection;
+- real DOM apply failure through a controlled page-DOM fault;
+- dirty-session recovery through the next successful candidate render;
+- preservation of committed revision and mounted UI across failed candidates;
+- deterministic replay from a fresh session;
+- preservation of the existing host-owned filter, selection, detail, and focus state while candidate operations fail and recover.
+
+Cancellation and late candidate chunks remain cognition-only evidence. The existing browser Stop button cancels the separate JSX-prefix demonstration loop, while `jsx_session_replay_candidate_json` performs one synchronous whole replay and cannot interleave cancellation. The browser suite will not count prefix-stream stop behavior as candidate lifecycle evidence.
+
+Dry-run failure remains covered by the existing pure/session contract tests. The public browser boundary does not expose internal `DryRunModel` state, and this slice will not add a corruption or forced-dry-run FFI hook.
+
+## Architecture
+
+`examples/web/src/genui.js` remains the host shell. It may expose a thin underscored observability surface for browser tests that only calls existing functions and reports current session state:
+
+- replay a candidate through the existing `jsx_session_replay_candidate_json` export;
+- replay at an explicitly supplied base revision for stale-revision tests;
+- dispose/reset the existing session through the existing disposal path;
+- read the current session revision and handle without owning commit policy.
+
+No lifecycle transitions, validation, revision decisions, recovery logic, or candidate construction policy move into JavaScript. `lib/cognition` and `ffi/jsx` remain authoritative.
+
+DOM apply failure is induced only in Playwright by temporarily replacing the test page root's `appendChild`/`insertBefore` operation with a throwing wrapper. The existing `catch_js` and `DomApplyError` path must observe the failure. The test restores the DOM method before invoking the next real render; no production fault-injection API is added.
+
+## Browser scenarios
+
+1. **Invalid candidate:** establish a committed session, submit a candidate containing a forbidden `raw_html` node, assert `CandidateValidationError`, unchanged revision, unchanged committed preview, and no candidate marker in the preview.
+2. **Stale base revision:** establish a committed session, invoke the existing replay export with an older base revision, assert `BaseRevisionMismatch`, unchanged revision, and unchanged preview.
+3. **DOM apply failure:** establish a committed candidate session, fault the real preview root's insertion method, submit a valid candidate, assert `DomApplyError`, unchanged revision, and candidate not reported committed.
+4. **Recovery:** restore the insertion method, submit the same valid candidate using the current revision, assert success, revision advancement exactly once, and a repaired candidate preview.
+5. **Host state preservation:** before failure/recovery, set a filter, select a row, focus the selected row, and assert all host-owned state remains unchanged after both failures and successful candidate recovery.
+6. **Deterministic replay:** dispose/reset the session, replay the same valid candidate twice from fresh sessions, and compare success, revision, mounted-node count, and normalized preview markup.
+
+## Safety metrics
+
+The browser suite includes a reproducible measurement test with fixed sample
+counts:
+
+- five valid candidate replays from fresh sessions for latency samples;
+- three invalid candidates and three stale-base candidates for rejection counts;
+- one forced DOM apply failure followed by one successful repair for repair
+  count;
+- two fresh replays of the same candidate for deterministic comparison.
+
+The test attaches raw JSON containing every `performance.now()` duration,
+attempt/result counts, state snapshots, repair count, and
+`performance.memory` availability/values when Chromium exposes that API. The
+denominators are explicit in the JSON rather than inferred from aggregate
+test timing.
+
+The browser run records zero counts for:
+
+- stale candidate commits;
+- host state-loss events;
+- falsely committed failed DOM applies;
+- deterministic replay mismatches.
+
+The cognition test suite separately records cancelled-generation commits and
+late-generation acceptance as zero. Those values are not presented as browser
+measurements because the browser candidate API is synchronous whole-replay.
+
+Latency, rejection rate, repair count, and browser heap usage are reported from
+the attached measurement JSON. Unsupported heap measurements are recorded as
+unavailable rather than inferred.
+
+## Non-goals
+
+- no Gemini or other live provider;
+- no new lifecycle implementation in JavaScript;
+- no browser cancellation controller for the synchronous whole-replay API;
+- no dry-run corruption hook;
+- no visible demo failure controls;
+- no renderer-neutral API;
+- no changes to committed UI or revision policy.

--- a/examples/web/src/genui.js
+++ b/examples/web/src/genui.js
@@ -222,12 +222,18 @@ async function replayCandidate(candidateJson, capabilitiesJson) {
     jsxSessionHandle = Number(created.handle)
     jsxSessionRevision = created.result.revision
   }
+  return replayCandidateAtRevision(jsxSessionRevision, candidateJson, capabilitiesJson)
+}
+
+async function replayCandidateAtRevision(baseRevision, candidateJson, capabilitiesJson) {
+  if (!jsxModule) jsxModule = await import('@moonbit/crdt-jsx')
+  if (jsxSessionHandle === null) throw new Error('candidate session is not initialized')
   const split = Math.max(1, Math.floor(candidateJson.length / 2))
   const chunks = candidateJson.slice(0, split) + '\u0000' + candidateJson.slice(split)
   const result = JSON.parse(
     jsxModule.jsx_session_replay_candidate_json(
       jsxSessionHandle,
-      jsxSessionRevision,
+      baseRevision,
       chunks,
       capabilitiesJson,
     ),
@@ -237,6 +243,15 @@ async function replayCandidate(candidateJson, capabilitiesJson) {
     htmlNodeCount.textContent = String(result.mounted_ids.length)
   }
   return result
+}
+
+if (import.meta.env.DEV) {
+  window.__canopyGenUiTest = Object.freeze({
+    replayCandidate,
+    replayCandidateAtRevision,
+    sessionRevision: () => jsxSessionRevision,
+    resetSession: resetState,
+  })
 }
 
 dataGenerateCandidate.addEventListener('click', async function() {

--- a/examples/web/tests/genui.spec.ts
+++ b/examples/web/tests/genui.spec.ts
@@ -1,4 +1,158 @@
-import { test, expect } from '@playwright/test';
+import { writeFile } from 'node:fs/promises';
+import { test, expect, type Page } from '@playwright/test';
+type GenUiSessionResult = {
+  success: boolean;
+  revision: number;
+  mounted_ids: string[];
+  error?: { code: string; message: string } | null;
+};
+
+type GenUiBrowserApi = {
+  replayCandidate(candidateJson: string, capabilitiesJson: string): Promise<GenUiSessionResult>;
+  replayCandidateAtRevision(
+    baseRevision: number,
+    candidateJson: string,
+    capabilitiesJson: string,
+  ): Promise<GenUiSessionResult>;
+  sessionRevision(): number | null;
+  resetSession(): void;
+};
+
+declare global {
+  interface Window {
+    __canopyGenUiTest?: GenUiBrowserApi;
+  }
+}
+
+const VALID_CANDIDATE = JSON.stringify({
+  type: 'component',
+  name: 'stack',
+  attributes: [],
+  children: [{ type: 'text', value: 'Orders', attributes: [], children: [] }],
+});
+const VALID_CANDIDATE_CHANGED = JSON.stringify({
+  type: 'component',
+  name: 'stack',
+  attributes: [],
+  children: [
+    { type: 'text', value: 'Orders', attributes: [], children: [] },
+    { type: 'text', value: 'Recovery', attributes: [], children: [] },
+  ],
+});
+const INVALID_CANDIDATE = JSON.stringify({
+  type: 'raw_html',
+  value: '<script>window.__unsafe = true</script>',
+});
+const CAPABILITIES = JSON.stringify({
+  bindings: [],
+  filter_operators: [],
+  aggregations: [],
+});
+
+async function replayCandidate(
+  page: Page,
+  candidateJson: string,
+  capabilitiesJson: string,
+): Promise<GenUiSessionResult> {
+  return page.evaluate(
+    async ({ candidateJson: candidate, capabilitiesJson: capabilities }) => {
+      const api = window.__canopyGenUiTest;
+      if (!api) throw new Error('GenUI browser test API is unavailable');
+      return api.replayCandidate(candidate, capabilities);
+    },
+    { candidateJson, capabilitiesJson },
+  );
+}
+
+async function replayCandidateAtRevision(
+  page: Page,
+  baseRevision: number,
+  candidateJson: string,
+  capabilitiesJson: string,
+): Promise<GenUiSessionResult> {
+  return page.evaluate(
+    async ({ baseRevision: revision, candidateJson: candidate, capabilitiesJson: capabilities }) => {
+      const api = window.__canopyGenUiTest;
+      if (!api) throw new Error('GenUI browser test API is unavailable');
+      return api.replayCandidateAtRevision(revision, candidate, capabilities);
+    },
+    { baseRevision, candidateJson, capabilitiesJson },
+  );
+}
+
+async function resetSession(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const api = window.__canopyGenUiTest;
+    if (!api) throw new Error('GenUI browser test API is unavailable');
+    api.resetSession();
+  });
+}
+
+async function sessionRevision(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const api = window.__canopyGenUiTest;
+    if (!api) throw new Error('GenUI browser test API is unavailable');
+    return api.sessionRevision();
+  });
+}
+
+async function setDomApplyFailure(page: Page, enabled: boolean): Promise<void> {
+  await page.evaluate((shouldFail) => {
+    const root = document.getElementById('html-preview');
+    if (!root) throw new Error('GenUI preview root is unavailable');
+    const prototype = Node.prototype as typeof Node.prototype & {
+      __canopyOriginalAppendChild?: typeof Node.prototype.appendChild;
+      __canopyOriginalInsertBefore?: typeof Node.prototype.insertBefore;
+    };
+    if (shouldFail) {
+      prototype.__canopyOriginalAppendChild ??= prototype.appendChild;
+      prototype.__canopyOriginalInsertBefore ??= prototype.insertBefore;
+      prototype.appendChild = function <T extends Node>(child: T): T {
+        if (this === root || root.contains(this)) {
+          throw new Error('browser test DOM apply failure');
+        }
+        return prototype.__canopyOriginalAppendChild!.call(this, child) as T;
+      };
+      prototype.insertBefore = function <T extends Node>(child: T, reference: Node | null): T {
+        if (this === root || root.contains(this)) {
+          throw new Error('browser test DOM apply failure');
+        }
+        return prototype.__canopyOriginalInsertBefore!.call(this, child, reference) as T;
+      };
+    } else {
+      if (prototype.__canopyOriginalAppendChild) {
+        prototype.appendChild = prototype.__canopyOriginalAppendChild;
+      }
+
+      if (prototype.__canopyOriginalInsertBefore) {
+        prototype.insertBefore = prototype.__canopyOriginalInsertBefore;
+      }
+      delete prototype.__canopyOriginalAppendChild;
+      delete prototype.__canopyOriginalInsertBefore;
+    }
+  }, enabled);
+}
+
+async function hostState(page: Page) {
+  return page.evaluate(() => ({
+    filter: (document.getElementById('data-filter-input') as HTMLInputElement).value,
+    selection: document.getElementById('data-selection-status')?.textContent,
+    detail: document.getElementById('data-detail-name')?.textContent,
+    focusedOrderId: (document.activeElement as HTMLElement | null)?.dataset.orderId ?? null,
+    selectedTestId: document.querySelector<HTMLElement>('[data-testid^="order-row-"][aria-selected="true"]')?.dataset.testid ?? null,
+  }));
+}
+
+async function committedMarkup(page: Page): Promise<string> {
+  return page.locator('#html-preview').evaluate((root) => {
+    const committed = root.querySelector(':scope > [data-node-id]');
+    if (!committed) return '';
+    const clone = committed.cloneNode(true) as HTMLElement;
+    clone.removeAttribute('data-node-id');
+    clone.querySelectorAll('[data-node-id]').forEach((node) => node.removeAttribute('data-node-id'));
+    return clone.outerHTML;
+  });
+}
 
 test.describe('Generative UI Demo', () => {
   test('page loads and shows initial state', async ({ page }) => {
@@ -112,7 +266,7 @@ test.describe('Generative UI Demo', () => {
 
     // Verify DOM node count is shown
     const nodeCount = await page.locator('#html-node-count').textContent();
-    expect(parseInt(nodeCount)).toBeGreaterThan(0);
+    expect(parseInt(nodeCount ?? '0')).toBeGreaterThan(0);
   });
 
   test('multiple examples produce DOM nodes', async ({ page }) => {
@@ -135,6 +289,225 @@ test.describe('Generative UI Demo', () => {
     await expect(page.locator('#html-preview [data-genui-kind="stack"]')).toBeVisible();
     await expect(page.locator('#html-preview [data-genui-kind="table"]')).toHaveCount(1);
     await expect(page.locator('#html-preview')).toContainText('Orders');
+  });
+
+  test('rejects invalid candidates without changing committed preview or revision', async ({ page }) => {
+    await page.goto('/genui.html');
+    const accepted = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    expect(accepted.success).toBe(true);
+    const beforeMarkup = await page.locator('#html-preview').innerHTML();
+    const rejected = await replayCandidate(page, INVALID_CANDIDATE, CAPABILITIES);
+    expect(rejected.success).toBe(false);
+    expect(rejected.error?.code).toBe('CandidateValidationError');
+    expect(rejected.revision).toBe(accepted.revision);
+    expect(await sessionRevision(page)).toBe(accepted.revision);
+    expect(await page.locator('#html-preview').innerHTML()).toBe(beforeMarkup);
+  });
+
+  test('rejects stale candidate bases without changing committed preview or revision', async ({ page }) => {
+    await page.goto('/genui.html');
+    const accepted = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    expect(accepted.success).toBe(true);
+    const beforeMarkup = await page.locator('#html-preview').innerHTML();
+    const stale = await replayCandidateAtRevision(
+      page,
+      accepted.revision - 1,
+      VALID_CANDIDATE,
+      CAPABILITIES,
+    );
+    expect(stale.success).toBe(false);
+    expect(stale.error?.code).toBe('BaseRevisionMismatch');
+    expect(stale.revision).toBe(accepted.revision);
+    expect(await sessionRevision(page)).toBe(accepted.revision);
+    expect(await page.locator('#html-preview').innerHTML()).toBe(beforeMarkup);
+  });
+
+  test('keeps failed DOM applies uncommitted and repairs on the next render', async ({ page }) => {
+    await page.goto('/genui.html');
+    await page.getByLabel('Filter name, status, or ID').fill('paid');
+    const selectedRow = page.getByTestId('order-row-ord-1003');
+    await selectedRow.click();
+    await selectedRow.focus();
+    const beforeHostState = await hostState(page);
+
+    const accepted = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    expect(accepted.success).toBe(true);
+    await setDomApplyFailure(page, true);
+    let failed: GenUiSessionResult;
+    try {
+      failed = await replayCandidate(page, VALID_CANDIDATE_CHANGED, CAPABILITIES);
+    } finally {
+      await setDomApplyFailure(page, false);
+    }
+    expect(failed.success).toBe(false);
+    expect(failed.error?.code).toBe('DomApplyError');
+    expect(failed.revision).toBe(accepted.revision);
+    expect(await sessionRevision(page)).toBe(accepted.revision);
+    expect(await hostState(page)).toEqual(beforeHostState);
+
+    const repaired = await replayCandidate(page, VALID_CANDIDATE_CHANGED, CAPABILITIES);
+    expect(repaired.success).toBe(true);
+    expect(repaired.revision).toBe(accepted.revision + 1);
+    expect(await sessionRevision(page)).toBe(repaired.revision);
+    await expect(page.locator('#html-preview [data-genui-kind="stack"]')).toBeVisible();
+    expect(await hostState(page)).toEqual(beforeHostState);
+  });
+
+  test('replays the same candidate deterministically from fresh sessions', async ({ page }) => {
+    await page.goto('/genui.html');
+    const first = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    const firstMarkup = await committedMarkup(page);
+    await resetSession(page);
+    const second = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    const secondMarkup = await committedMarkup(page);
+    expect(second.success).toBe(true);
+    expect(second.success).toBe(first.success);
+    expect(second.revision).toBe(first.revision);
+    expect(second.mounted_ids.length).toBe(first.mounted_ids.length);
+    expect(secondMarkup).toBe(firstMarkup);
+  });
+
+  test('attaches reproducible GenUI safety measurements', async ({ page }, testInfo) => {
+    test.setTimeout(60000);
+    await page.goto('/genui.html');
+    await page.getByLabel('Filter name, status, or ID').fill('paid');
+    const selectedRow = page.getByTestId('order-row-ord-1003');
+    await selectedRow.click();
+    await selectedRow.focus();
+    const beforeHostState = await hostState(page);
+    const latencySamples: Array<{ duration_ms: number; success: boolean; revision: number }> = [];
+    for (let i = 0; i < 5; i += 1) {
+      const sample = await page.evaluate(async ({ candidate, capabilities }) => {
+        const api = window.__canopyGenUiTest;
+        if (!api) throw new Error('GenUI browser test API is unavailable');
+        api.resetSession();
+        const start = performance.now();
+        const result = await api.replayCandidate(candidate, capabilities);
+        return { duration_ms: performance.now() - start, success: result.success, revision: result.revision };
+      }, { candidate: VALID_CANDIDATE, capabilities: CAPABILITIES });
+      latencySamples.push(sample);
+    }
+
+    let invalidRejected = 0;
+    for (let i = 0; i < 3; i += 1) {
+      const result = await replayCandidate(page, INVALID_CANDIDATE, CAPABILITIES);
+      if (!result.success && result.error?.code === 'CandidateValidationError') invalidRejected += 1;
+    }
+
+    const currentRevision = await sessionRevision(page);
+    if (currentRevision === null) throw new Error('expected a committed session revision');
+    let staleRejected = 0;
+    for (let i = 0; i < 3; i += 1) {
+      const result = await replayCandidateAtRevision(
+        page,
+        currentRevision - 1,
+        VALID_CANDIDATE,
+        CAPABILITIES,
+      );
+      if (!result.success && result.error?.code === 'BaseRevisionMismatch') staleRejected += 1;
+    }
+
+    await setDomApplyFailure(page, true);
+    let failedApply: GenUiSessionResult;
+    try {
+      failedApply = await replayCandidate(page, VALID_CANDIDATE_CHANGED, CAPABILITIES);
+    } finally {
+      await setDomApplyFailure(page, false);
+    }
+    const repaired = await replayCandidate(page, VALID_CANDIDATE_CHANGED, CAPABILITIES);
+    const afterHostState = await hostState(page);
+    const hostStateLoss = JSON.stringify(beforeHostState) === JSON.stringify(afterHostState) ? 0 : 1;
+    expect(afterHostState).toEqual(beforeHostState);
+
+    await resetSession(page);
+    const deterministicFirst = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    const deterministicFirstMarkup = await committedMarkup(page);
+    await resetSession(page);
+    const deterministicSecond = await replayCandidate(page, VALID_CANDIDATE, CAPABILITIES);
+    const deterministicSecondMarkup = await committedMarkup(page);
+    const heap = await page.evaluate(() => {
+      const memory = (performance as Performance & {
+        memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number };
+      }).memory;
+      return memory
+        ? { available: true, used_js_heap_size: memory.usedJSHeapSize, total_js_heap_size: memory.totalJSHeapSize }
+        : { available: false };
+    });
+    const metrics = {
+      sample_counts: {
+        latency: latencySamples.length,
+        invalid: 3,
+        stale: 3,
+        dom_failure_and_repair: 1,
+        deterministic_replays: 2,
+      },
+      latency_samples: latencySamples,
+      rejection: {
+        invalid_rejected: invalidRejected,
+        stale_rejected: staleRejected,
+        attempted: 6,
+        rate: (invalidRejected + staleRejected) / 6,
+      },
+      host_state: {
+        before: beforeHostState,
+        after: afterHostState,
+      },
+      dom_apply: {
+        failed: {
+          success: failedApply.success,
+          revision: failedApply.revision,
+          error_code: failedApply.error?.code ?? null,
+        },
+        repaired: {
+          success: repaired.success,
+          revision: repaired.revision,
+          error_code: repaired.error?.code ?? null,
+        },
+      },
+      repair_count:
+        repaired.success &&
+        !failedApply.success &&
+        failedApply.error?.code === 'DomApplyError'
+          ? 1
+          : 0,
+      zero_counts: {
+        stale_candidate_commits: staleRejected === 3 ? 0 : 1,
+        host_state_loss: hostStateLoss,
+        falsely_committed_failed_apply:
+          failedApply.success ||
+          failedApply.error?.code !== 'DomApplyError' ||
+          failedApply.revision !== currentRevision
+            ? 1
+            : 0,
+        deterministic_replay_mismatches:
+          deterministicFirst.success &&
+          deterministicSecond.success &&
+          deterministicFirst.revision === deterministicSecond.revision &&
+          deterministicFirst.mounted_ids.length === deterministicSecond.mounted_ids.length &&
+          deterministicFirstMarkup === deterministicSecondMarkup
+            ? 0
+            : 1,
+      },
+      heap,
+    };
+    expect(latencySamples).toHaveLength(5);
+    expect(latencySamples.every((sample) => sample.success)).toBe(true);
+    expect(invalidRejected).toBe(3);
+    expect(staleRejected).toBe(3);
+    expect(metrics.rejection.rate).toBe(1);
+    expect(metrics.repair_count).toBe(1);
+    const metricsPath = testInfo.outputPath('genui-safety-metrics.json');
+    await writeFile(metricsPath, JSON.stringify(metrics, null, 2), 'utf8');
+    await testInfo.attach('genui-safety-metrics.json', {
+      path: metricsPath,
+      contentType: 'application/json',
+    });
+    expect(metrics.zero_counts).toEqual({
+      stale_candidate_commits: 0,
+      host_state_loss: 0,
+      falsely_committed_failed_apply: 0,
+      deterministic_replay_mismatches: 0,
+    });
   });
 
 });

--- a/examples/web/tests/genui.spec.ts
+++ b/examples/web/tests/genui.spec.ts
@@ -396,6 +396,8 @@ test.describe('Generative UI Demo', () => {
 
     const currentRevision = await sessionRevision(page);
     if (currentRevision === null) throw new Error('expected a committed session revision');
+    const staleBeforeRevision = currentRevision;
+    const staleBeforeMarkup = await committedMarkup(page);
     let staleRejected = 0;
     for (let i = 0; i < 3; i += 1) {
       const result = await replayCandidateAtRevision(
@@ -406,6 +408,10 @@ test.describe('Generative UI Demo', () => {
       );
       if (!result.success && result.error?.code === 'BaseRevisionMismatch') staleRejected += 1;
     }
+    const staleAfterRevision = await sessionRevision(page);
+    const staleAfterMarkup = await committedMarkup(page);
+    const staleStatePreserved =
+      staleAfterRevision === staleBeforeRevision && staleAfterMarkup === staleBeforeMarkup;
 
     await setDomApplyFailure(page, true);
     let failedApply: GenUiSessionResult;
@@ -448,6 +454,12 @@ test.describe('Generative UI Demo', () => {
         attempted: 6,
         rate: (invalidRejected + staleRejected) / 6,
       },
+      stale_base_state: {
+        before_revision: staleBeforeRevision,
+        after_revision: staleAfterRevision,
+        before_markup: staleBeforeMarkup,
+        after_markup: staleAfterMarkup,
+      },
       host_state: {
         before: beforeHostState,
         after: afterHostState,
@@ -471,7 +483,10 @@ test.describe('Generative UI Demo', () => {
           ? 1
           : 0,
       zero_counts: {
-        stale_candidate_commits: staleRejected === 3 ? 0 : 1,
+        stale_candidate_commits:
+          staleRejected === 3 && staleStatePreserved
+            ? 0
+            : 1,
         host_state_loss: hostStateLoss,
         falsely_committed_failed_apply:
           failedApply.success ||


### PR DESCRIPTION
## Summary
- land the completed GenUI browser failure/recovery slice
- preserve validation, dry-run, DOM apply, recovery, and exactly-once commit evidence
- record the final 14/14 browser run and safety metrics artifact

## Verification
- `moon check`
- `npx playwright test tests/genui.spec.ts` (14 passed)

Live Gemini/provider integration is intentionally not included.
