### PR TITLE
feat(genui): add disposable local LLM vertical slice

### DIFF
--- a/docs/plans/2026-07-15-generative-ui-live-provider-experiment-design.md
+++ b/docs/plans/2026-07-15-generative-ui-live-provider-experiment-design.md
@@ -50,9 +50,12 @@ Before the custodian opens the held-out set, the initial manifest freezes the
 job, set digests, answer keys, primary metric, time limit, participant protocol,
 sample counts, four win margins, statistical analysis plan, role/access matrix,
 fixed-explorer version, development rules, prompt, candidate schema,
-model/settings, and cost and safety limits. Gate B separately freezes the later
-harness and projection commit, while Gate C separately freezes provider
-integration.
+model-selection protocol, candidate eligibility, development benchmark,
+settings envelope, tie-breaks, and cost and safety limits. Gate B separately
+freezes the later harness and projection commit. Only after Gemini eligibility
+may the preregistered development-only bake-off select a model; Gate C then
+freezes the exact provider, model ID and version, settings, and provider
+integration before its held-out set is opened.
 Changing a field after its stage freeze invalidates the campaign.
 
 `GENERATE` authorizes only a separately reviewed continuation of the private
@@ -284,12 +287,50 @@ type is justified.
 
 ## Backend and transport contract
 
+### Spike 0 evidence boundary
+
+Spike 0 connected the development-only host to local Ollama
+`gemma4:e2b` and produced one valid bounded recipe for the fixed pending-orders
+case. The run demonstrated the provider-to-schema-to-renderer path. It did not
+establish model value because the schema already fixed the `pending` filter,
+`amount` sum, and answer-required fields.
+
+Observed end-to-end latency ranged from 5.8 to 57.6 seconds. These
+diagnostic runs enter no `S_*`, uplift, power, viability, or model-selection
+calculation, and no result may be generalized from `gemma4:e2b` to stronger
+models or LLMs as a class.
+
+### Development-only model selection
+
+The initial manifest freezes the selection procedure rather than naming a
+winner. Candidate eligibility requires a stable versioned model ID, Gemini
+Developer API structured JSON output, the frozen candidate schema, and the
+preregistered latency, cost, and safety ceilings. The manifest also freezes the
+development cases, repeat count, prompt, temperature, output-token limit,
+timeout, no-replacement failure treatment, primary selection metric, and
+tie-break order.
+
+Only after Gate B establishes Gemini eligibility may provider authors run the
+frozen bake-off on development cases. Select the eligible model with the highest
+task-complete valid-candidate rate. Break a tie by lower median end-to-end
+latency, then lower total cost. A timeout, provider error, invalid candidate,
+task-incomplete candidate, or missing slot scores as failure and is not
+replaced. Record every candidate model and setting, predetermined slot, raw
+metric, exclusion, and the deterministic selection result before the Gate C
+custodian opens held-out cases.
+
+Gate C evaluates one selected model. Trying multiple models on held-out cases
+and reporting only the best is prohibited. A multi-model held-out comparison
+requires a new preregistered campaign, separately powered arms, and multiplicity
+control. Changing the winner, model version, prompt, schema, or settings after
+Gate C freeze invalidates the campaign.
+
 ### Provider selection
 
 - Backend: Gemini Developer API.
-- Endpoint: `POST /v1beta/models/gemini-3.5-flash:generateContent`.
-- Model: explicit `gemini-3.5-flash`; do not use a floating `latest` alias during
-  the 30-run experiment.
+- Endpoint: `POST /v1beta/models/{frozen-model-id}:generateContent`.
+- Model: the explicit versioned winner of the frozen development-only selection
+  procedure; never use a floating `latest` alias.
 - Mode: non-streaming whole response.
 - Output: `application/json` constrained by a provider-side JSON schema matching
   the current candidate tree.
@@ -340,7 +381,7 @@ A successful response has this transport-only envelope:
 ```json
 {
   "attempt_id": "opaque-server-id",
-  "model": "gemini-3.5-flash",
+  "model": "frozen-versioned-model-id",
   "candidate_json": "{...}",
   "usage": {
     "prompt_tokens": 0,
@@ -475,13 +516,16 @@ and pass/fail decision to implementation authors. If Gate A passes, harness and
 projection authors work from the development set only. Before the custodian runs
 Gate B, the campaign freezes the harness and projection code commit, candidate
 schema and capability manifest, fixed-explorer version, rules and prompt digests,
-exact model and settings, metrics, margins, and sample counts.
+metrics, margins, and sample counts. Gate B contains no provider or model arm.
 
-The custodian then executes every arm against the same held-out questions, source
-data, capability surface, time limit, answer keys, and evaluation procedure.
-Gemini uses the preregistered repeat count; failed or timed-out slots remain
-failures and are not replaced. Arm labels and provider metadata remain hidden
-during human review.
+The custodian executes each gate's frozen arms against that gate's held-out
+questions, source data, capability surface, time limit, answer keys, and
+evaluation procedure. Only after Gate B establishes Gemini eligibility do
+provider authors run the frozen development-only model-selection procedure.
+Before Gate C, the campaign freezes its incumbent, selected model and settings,
+provider integration, repeat count, and opaque held-out-task allowlist. Failed
+or timed-out slots remain failures and are not replaced. Arm labels and provider
+metadata remain hidden during human review.
 
 The manifest records set digests, author-role assignments, access events, freeze
 time, reveal time, all frozen implementation digests, blinding, and cost and
@@ -577,9 +621,10 @@ not contain Gemini code, a proxy, credentials, provider transport, retries,
 The harness and projection are experiment apparatus, not an accepted runtime.
 A `FIXED` outcome deletes them unless another accepted use exists. A `RULES`
 outcome retains only the projection required by the accepted deterministic
-behavior. Only Gemini eligibility permits separately reviewed
-provider integration built from development cases; it must not change the frozen
-candidate semantics or reveal held-out cases before the final campaign ends.
+behavior. Only Gemini eligibility permits the frozen development-only model
+selection and separately reviewed provider integration. Both use development
+cases only, must preserve the frozen candidate semantics, and cannot reveal
+held-out cases before the final campaign ends.
 
 ### Decision math
 
@@ -891,11 +936,13 @@ not tests and never run in CI, on page load, or in a production build.
    and eligibility rules, job, primary metric, decision math, development/held-
    out construction, custodian, and non-overlapping author-role access matrix.
 3. Calibrate the standalone oracle pattern, deterministic rules, candidate
-   schema, prompt, sample counts, and win margins on development cases only.
+   schema, prompt, sample counts, win margins, model-selection procedure,
+   candidate eligibility, development benchmark, settings envelope, and
+   tie-breaks on development cases only.
 4. Freeze and approve the initial manifest, complete statistical procedure and
-   script digest, study-ID access and retention controls, exact model/settings,
-   cost ceiling, author roles, access log, and held-out set digest before
-   custodian-only reveal.
+   script digest, study-ID access and retention controls, model-selection
+   protocol, cost ceiling, author roles, access log, and held-out set digest
+   before custodian-only reveal.
 5. The custodian runs Gate A. Only eligible target-user observations can satisfy
    the final oracle-uplift gate; a proxy-only pass may authorize a new target-user
    campaign but the current campaign records `FIXED`.
@@ -908,19 +955,26 @@ not tests and never run in CI, on page load, or in a production build.
 8. The custodian runs Gate B without case-level disclosure. Stop with `RULES`
    only when eligible target-user evidence establishes `rules_capture >= 0.80`
    and `rules_viable`.
-9. Only after Gemini eligibility, freeze the Gate C incumbent identity and the
-   custodian-controlled opaque held-out-task allowlist digest, then approve a
-   separate test-first plan for provider integration. Do not change frozen
-   candidate semantics or use held-out cases during implementation.
-10. Prove the provider-capable session projection with deterministic fixed
+9. Only after Gemini eligibility, review the frozen development-only selection
+   runner and its credential controls before its first request. Execute every
+   predetermined candidate slot, record failures without replacement, apply the
+   frozen metric and tie-breaks, and freeze the selected versioned model and
+   settings before any Gate C held-out access.
+10. Freeze the Gate C incumbent identity and custodian-controlled opaque
+    held-out-task allowlist digest, then approve a separate test-first plan for
+    provider integration. Do not change frozen candidate semantics or use
+    held-out cases during implementation.
+11. Prove the provider-capable session projection with deterministic fixed
     replay, state interaction, and known-negative controls.
-11. Complete implementation review before the first credentialed request. The
-    custodian then runs the frozen held-out Gate C incumbent and Gemini arms with
-    eligible target-user participants, plus all 30 reliability slots, without
-    replacement.
-12. Record `FIXED`, `RULES`, or `GENERATE` and evidence digests before revealing
+12. Complete implementation review and freeze the provider-integration commit,
+    selected model/settings, prompt/schema digests, repeat count, cost and safety
+    limits, and allowlist before the first Gate C credentialed request.
+13. The custodian runs the frozen held-out Gate C incumbent and selected-model
+    arms with eligible target-user participants, plus all 30 reliability slots,
+    without replacement.
+14. Record `FIXED`, `RULES`, or `GENERATE` and evidence digests before revealing
     held-out contents, no later than 2026-07-29.
-13. If `GENERATE`, require a materially different second adapter before freezing
+15. If `GENERATE`, require a materially different second adapter before freezing
     any renderer-neutral provider contract or conformance suite.
 
 ## References

--- a/examples/web/genui.html
+++ b/examples/web/genui.html
@@ -82,7 +82,7 @@
       </div>
     </div>
 
-    <section id="genui-spike" class="mt-4 overflow-hidden rounded-lg border border-canopy-border bg-canopy-surface">
+    <section id="genui-spike" class="mt-4 overflow-hidden rounded-lg border border-canopy-border bg-canopy-surface" hidden>
       <header class="flex flex-col gap-4 border-b border-canopy-border px-4 py-4 lg:flex-row lg:items-start lg:justify-between">
         <div class="max-w-3xl">
           <div class="mb-2 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-canopy-muted">

--- a/examples/web/genui.html
+++ b/examples/web/genui.html
@@ -82,6 +82,96 @@
       </div>
     </div>
 
+    <section id="genui-spike" class="mt-4 overflow-hidden rounded-lg border border-canopy-border bg-canopy-surface">
+      <header class="flex flex-col gap-4 border-b border-canopy-border px-4 py-4 lg:flex-row lg:items-start lg:justify-between">
+        <div class="max-w-3xl">
+          <div class="mb-2 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-canopy-muted">
+            <span class="text-canopy-green">Spike 0</span>
+            <span aria-hidden="true">·</span>
+            <span>Local LLM</span>
+            <span aria-hidden="true">·</span>
+            <span>Development evidence only</span>
+          </div>
+          <h2 class="text-[16px] font-semibold text-canopy-text">Generate a focused view for one unfamiliar-data question</h2>
+          <p id="spike-question" class="mt-2 max-w-[72ch] text-[13px] leading-6 text-canopy-muted"></p>
+        </div>
+        <button id="spike-generate" class="btn-primary min-h-9 self-start px-3" type="button">
+          Generate one-shot view
+        </button>
+      </header>
+
+      <div class="grid min-h-[280px] grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div class="p-4">
+          <div id="spike-empty" class="flex min-h-[240px] items-center justify-center border border-dashed border-canopy-border px-6 text-center">
+            <div class="max-w-md">
+              <p class="text-[13px] text-canopy-text">No generated view yet.</p>
+              <p class="mt-2 text-[11px] leading-5 text-canopy-muted">One local model call will choose a bounded filter, columns, and summary. Invalid output is rejected rather than rendered.</p>
+            </div>
+          </div>
+
+          <div id="spike-loading" class="hidden min-h-[240px] items-center justify-center" role="status" aria-live="polite">
+            <div class="text-center">
+              <div class="mx-auto h-6 w-6 animate-spin rounded-full border-2 border-canopy-border border-t-canopy-green"></div>
+              <p class="mt-3 text-[12px] text-canopy-text">Local model is shaping the view…</p>
+              <p class="mt-1 text-[10px] text-canopy-muted">No retry · hard 120 second timeout</p>
+            </div>
+          </div>
+
+          <div id="spike-result" hidden>
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p class="text-[10px] uppercase tracking-[0.14em] text-canopy-muted">Generated recipe</p>
+                <h3 id="spike-result-title" class="mt-1 text-[15px] font-semibold text-canopy-text"></h3>
+              </div>
+              <span id="spike-filter-chip" class="status-chip status-pending"></span>
+            </div>
+            <dl class="mt-4 grid grid-cols-2 gap-3 border-y border-canopy-border py-3">
+              <div>
+                <dt id="spike-summary-label" class="text-[10px] uppercase tracking-wider text-canopy-muted"></dt>
+                <dd id="spike-summary-value" class="mt-1 text-[20px] text-canopy-green"></dd>
+              </div>
+              <div>
+                <dt class="text-[10px] uppercase tracking-wider text-canopy-muted">Matching orders</dt>
+                <dd id="spike-match-count" class="mt-1 text-[20px] text-canopy-text"></dd>
+              </div>
+            </dl>
+            <div class="mt-3 overflow-x-auto">
+              <table class="w-full text-left text-[12px]" aria-label="Generated focused order view">
+                <thead id="spike-table-head" class="border-b border-canopy-border text-canopy-muted"></thead>
+                <tbody id="spike-table-body"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <div id="spike-error" class="hidden min-h-[240px] items-center justify-center text-center" role="alert">
+            <div class="max-w-md">
+              <p class="text-[13px] text-[#f48771]">The generated view was not rendered.</p>
+              <p id="spike-error-message" class="mt-2 text-[11px] leading-5 text-canopy-muted"></p>
+            </div>
+          </div>
+        </div>
+
+        <aside class="border-t border-canopy-border bg-canopy-bg/40 p-4 lg:border-l lg:border-t-0" aria-labelledby="spike-answer-heading">
+          <h3 id="spike-answer-heading" class="text-[10px] uppercase tracking-[0.14em] text-canopy-green">Your answer</h3>
+          <p class="mt-2 text-[11px] leading-5 text-canopy-muted">Answer after inspecting the generated view. This diagnostic result never enters Gate A.</p>
+          <form id="spike-answer-form" class="mt-4 flex flex-col gap-3">
+            <label class="text-[11px] text-canopy-muted" for="spike-answer-orders">Order IDs, comma separated</label>
+            <input id="spike-answer-orders" class="bg-canopy-bg text-canopy-text border border-canopy-border rounded-md px-2 py-2 text-[12px] font-mono outline-none focus:border-canopy-green" placeholder="ord-1002, ord-1006" autocomplete="off" />
+            <label class="text-[11px] text-canopy-muted" for="spike-answer-total">Total amount</label>
+            <input id="spike-answer-total" class="bg-canopy-bg text-canopy-text border border-canopy-border rounded-md px-2 py-2 text-[12px] font-mono outline-none focus:border-canopy-green" type="number" min="0" step="0.01" placeholder="0.00" />
+            <button id="spike-check-answer" class="btn mt-1 min-h-9" type="submit" disabled>Check development answer</button>
+          </form>
+          <p id="spike-answer-feedback" class="mt-3 min-h-10 text-[11px] leading-5 text-canopy-muted" aria-live="polite"></p>
+          <dl id="spike-telemetry" class="mt-5 grid grid-cols-2 gap-x-3 gap-y-2 border-t border-canopy-border pt-3 text-[10px] text-canopy-muted" hidden>
+            <div><dt>Model</dt><dd id="spike-model" class="mt-0.5 text-canopy-text"></dd></div>
+            <div><dt>Elapsed</dt><dd id="spike-elapsed" class="mt-0.5 text-canopy-text"></dd></div>
+            <div><dt>Prompt</dt><dd id="spike-prompt-tokens" class="mt-0.5 text-canopy-text"></dd></div>
+            <div><dt>Output</dt><dd id="spike-output-tokens" class="mt-0.5 text-canopy-text"></dd></div>
+          </dl>
+        </aside>
+      </div>
+    </section>
+
     <!-- Phase 4: host-owned JSON fixture rendered through a constrained table. -->
     <section id="data-explorer" class="mt-4 bg-canopy-surface border border-canopy-border rounded-lg p-3.5">
       <div class="flex flex-wrap items-center justify-between gap-2 mb-3">

--- a/examples/web/playwright.preview.config.ts
+++ b/examples/web/playwright.preview.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './preview-tests',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+  },
+  webServer: {
+    command: 'npm run build && npx vite preview --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173/genui.html',
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/examples/web/preview-tests/genui-preview.spec.ts
+++ b/examples/web/preview-tests/genui-preview.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test('hides the local-only spike and omits its production endpoint', async ({ page, request }) => {
+  await page.goto('/genui.html');
+
+  await expect(page.locator('#genui-spike')).toBeHidden();
+  await expect(page.locator('#data-generate-candidate')).toBeVisible();
+
+  const response = await request.post('/api/genui-spike', {
+    data: { caseId: 'orders-pending-attention' },
+  });
+  expect(response.status()).toBe(404);
+});

--- a/examples/web/src/genui-spike-case.js
+++ b/examples/web/src/genui-spike-case.js
@@ -1,0 +1,4 @@
+export const GENUI_SPIKE_CASE = Object.freeze({
+  id: 'orders-pending-attention',
+  question: 'Which pending orders require attention, and how much value is tied up?',
+});

--- a/examples/web/src/genui-spike-recipe.js
+++ b/examples/web/src/genui-spike-recipe.js
@@ -1,0 +1,116 @@
+const ORDER_FIELDS = new Set(['id', 'name', 'status', 'amount']);
+
+export const GENUI_RECIPE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['kind', 'title', 'filter', 'columns', 'summary'],
+  properties: {
+    kind: { const: 'filtered_orders' },
+    title: { type: 'string', minLength: 1, maxLength: 80 },
+    filter: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['field', 'operator', 'value'],
+      properties: {
+        field: { const: 'status' },
+        operator: { const: 'equals' },
+        value: { const: 'pending' },
+      },
+    },
+    columns: {
+      type: 'array',
+      minItems: 2,
+      maxItems: 4,
+      uniqueItems: true,
+      items: { enum: [...ORDER_FIELDS] },
+      allOf: [
+        { contains: { const: 'id' } },
+        { contains: { const: 'amount' } },
+      ],
+    },
+    summary: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['field', 'aggregation', 'label'],
+      properties: {
+        field: { const: 'amount' },
+        aggregation: { const: 'sum' },
+        label: { type: 'string', minLength: 1, maxLength: 40 },
+      },
+    },
+  },
+};
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactProperties(value, expected) {
+  const keys = Object.keys(value);
+  return keys.length === expected.length && keys.every((key) => expected.includes(key));
+}
+
+function invalid(error) {
+  return { ok: false, error };
+}
+
+export function parseGenUiRecipe(input) {
+  if (!isRecord(input) || !hasExactProperties(input, ['kind', 'title', 'filter', 'columns', 'summary'])) {
+    return invalid('Recipe properties do not match the allowlist.');
+  }
+  if (input.kind !== 'filtered_orders') {
+    return invalid('Recipe kind must be filtered_orders.');
+  }
+  if (typeof input.title !== 'string' || input.title.trim().length === 0 || input.title.length > 80) {
+    return invalid('Recipe title must contain 1–80 characters.');
+  }
+  if (!isRecord(input.filter) || !hasExactProperties(input.filter, ['field', 'operator', 'value'])) {
+    return invalid('Recipe filter properties do not match the allowlist.');
+  }
+  if (input.filter.field !== 'status' || input.filter.operator !== 'equals' || input.filter.value !== 'pending') {
+    return invalid('Recipe filter must select pending orders for the fixed development question.');
+  }
+  if (
+    !Array.isArray(input.columns) ||
+    input.columns.length < 2 ||
+    input.columns.length > 4 ||
+    !input.columns.every((field) => ORDER_FIELDS.has(field)) ||
+    new Set(input.columns).size !== input.columns.length
+  ) {
+    return invalid('Recipe columns must contain 2–4 unique allowed order fields.');
+  }
+  if (!input.columns.includes('id') || !input.columns.includes('amount')) {
+    return invalid('Recipe columns must include both id and amount to support the fixed development answer.');
+  }
+  if (!isRecord(input.summary) || !hasExactProperties(input.summary, ['field', 'aggregation', 'label'])) {
+    return invalid('Recipe summary properties do not match the allowlist.');
+  }
+  if (
+    input.summary.field !== 'amount' ||
+    input.summary.aggregation !== 'sum' ||
+    typeof input.summary.label !== 'string' ||
+    input.summary.label.trim().length === 0 ||
+    input.summary.label.length > 40
+  ) {
+    return invalid('Recipe summary must provide a short label for the amount sum.');
+  }
+
+  return {
+    ok: true,
+    value: {
+      kind: input.kind,
+      title: input.title.trim(),
+      filter: {
+        field: input.filter.field,
+        operator: input.filter.operator,
+        value: input.filter.value,
+      },
+      columns: [...input.columns],
+      summary: {
+        field: input.summary.field,
+        aggregation: input.summary.aggregation,
+        label: input.summary.label.trim(),
+      },
+    },
+  };
+}

--- a/examples/web/src/genui-spike-recipe.test.mjs
+++ b/examples/web/src/genui-spike-recipe.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { GENUI_RECIPE_SCHEMA, parseGenUiRecipe } from './genui-spike-recipe.js';
+
+const validRecipe = {
+  kind: 'filtered_orders',
+  title: 'Pending orders requiring attention',
+  filter: {
+    field: 'status',
+    operator: 'equals',
+    value: 'pending',
+  },
+  columns: ['id', 'name', 'amount'],
+  summary: {
+    field: 'amount',
+    aggregation: 'sum',
+    label: 'Pending value',
+  },
+};
+
+test('accepts the bounded filtered-orders recipe', () => {
+  assert.deepEqual(parseGenUiRecipe(validRecipe), {
+    ok: true,
+    value: validRecipe,
+  });
+});
+
+test('rejects a column outside the host field allowlist', () => {
+  const result = parseGenUiRecipe({
+    ...validRecipe,
+    columns: ['id', 'name', 'customer_email'],
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /columns/);
+});
+
+test('rejects extra properties instead of silently ignoring them', () => {
+  const result = parseGenUiRecipe({
+    ...validRecipe,
+    answer: 'Vertex renewal and $1,540',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /properties/);
+});
+
+test('rejects unknown recipe variants', () => {
+  const result = parseGenUiRecipe({
+    ...validRecipe,
+    kind: 'arbitrary_html',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /kind/);
+});
+test('rejects a filter that cannot answer the fixed pending-orders question', () => {
+  const result = parseGenUiRecipe({
+    ...validRecipe,
+    filter: { ...validRecipe.filter, value: 'paid' },
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /pending/);
+});
+
+test('rejects columns that omit an answer required by the fixed case', () => {
+  for (const columns of [['name', 'amount'], ['id', 'name']]) {
+    const result = parseGenUiRecipe({ ...validRecipe, columns });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /id.*amount/);
+  }
+});
+
+test('provider schema requires the fields needed for the fixed answer', () => {
+  assert.deepEqual(GENUI_RECIPE_SCHEMA.properties.columns.allOf, [
+    { contains: { const: 'id' } },
+    { contains: { const: 'amount' } },
+  ]);
+});

--- a/examples/web/src/genui.js
+++ b/examples/web/src/genui.js
@@ -291,63 +291,66 @@ function renderSpikeRecipe(recipe, telemetry) {
   setSpikeState('result')
 }
 
-spikeQuestion.textContent = GENUI_SPIKE_CASE.question
-setSpikeState('empty')
+if (import.meta.env.DEV) {
+  document.getElementById('genui-spike').hidden = false
+  spikeQuestion.textContent = GENUI_SPIKE_CASE.question
+  setSpikeState('empty')
 
-spikeGenerate.addEventListener('click', async function() {
-  if (spikeGenerating) return
-  spikeGenerating = true
-  spikeGenerate.disabled = true
-  spikeGenerate.textContent = 'Generating…'
-  spikeCheckAnswer.disabled = true
-  spikeTelemetry.hidden = true
-  spikeAnswerFeedback.textContent = ''
-  setSpikeState('loading')
+  spikeGenerate.addEventListener('click', async function() {
+    if (spikeGenerating) return
+    spikeGenerating = true
+    spikeGenerate.disabled = true
+    spikeGenerate.textContent = 'Generating…'
+    spikeCheckAnswer.disabled = true
+    spikeTelemetry.hidden = true
+    spikeAnswerFeedback.textContent = ''
+    setSpikeState('loading')
 
-  try {
-    const response = await fetch('/api/genui-spike', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ caseId: GENUI_SPIKE_CASE.id }),
-    })
-    const body = await response.json()
-    if (!response.ok) {
-      throw new Error(typeof body?.error === 'string' ? body.error : `Prototype endpoint returned HTTP ${response.status}.`)
+    try {
+      const response = await fetch('/api/genui-spike', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ caseId: GENUI_SPIKE_CASE.id }),
+      })
+      const body = await response.json()
+      if (!response.ok) {
+        throw new Error(typeof body?.error === 'string' ? body.error : `Prototype endpoint returned HTTP ${response.status}.`)
+      }
+
+      const parsedRecipe = parseGenUiRecipe(body?.recipe)
+      if (!parsedRecipe.ok) {
+        throw new Error(`Browser rejected recipe: ${parsedRecipe.error}`)
+      }
+      renderSpikeRecipe(parsedRecipe.value, body?.telemetry)
+    } catch (error) {
+      spikeErrorMessage.textContent = error instanceof Error ? error.message : String(error)
+      setSpikeState('error')
+    } finally {
+      spikeGenerating = false
+      spikeGenerate.disabled = false
+      spikeGenerate.textContent = 'Generate one-shot view'
     }
+  })
 
-    const parsedRecipe = parseGenUiRecipe(body?.recipe)
-    if (!parsedRecipe.ok) {
-      throw new Error(`Browser rejected recipe: ${parsedRecipe.error}`)
-    }
-    renderSpikeRecipe(parsedRecipe.value, body?.telemetry)
-  } catch (error) {
-    spikeErrorMessage.textContent = error instanceof Error ? error.message : String(error)
-    setSpikeState('error')
-  } finally {
-    spikeGenerating = false
-    spikeGenerate.disabled = false
-    spikeGenerate.textContent = 'Generate one-shot view'
-  }
-})
+  spikeAnswerForm.addEventListener('submit', function(event) {
+    event.preventDefault()
+    const submittedIds = spikeAnswerOrders.value
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0)
+      .sort()
+    const idsCorrect = submittedIds.length === spikeExpectedIds.length &&
+      submittedIds.every((id, index) => id === spikeExpectedIds[index])
+    const totalCorrect = Number(spikeAnswerTotal.value) === spikeExpectedTotal
+    const correct = idsCorrect && totalCorrect
 
-spikeAnswerForm.addEventListener('submit', function(event) {
-  event.preventDefault()
-  const submittedIds = spikeAnswerOrders.value
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter((value) => value.length > 0)
-    .sort()
-  const idsCorrect = submittedIds.length === spikeExpectedIds.length &&
-    submittedIds.every((id, index) => id === spikeExpectedIds[index])
-  const totalCorrect = Number(spikeAnswerTotal.value) === spikeExpectedTotal
-  const correct = idsCorrect && totalCorrect
-
-  spikeAnswerFeedback.classList.remove('text-canopy-green', 'text-[#f48771]')
-  spikeAnswerFeedback.classList.add(correct ? 'text-canopy-green' : 'text-[#f48771]')
-  spikeAnswerFeedback.textContent = correct
-    ? 'Correct. The generated view supported the complete development answer.'
-    : 'Not yet. Check both the matching order IDs and the displayed total.'
-})
+    spikeAnswerFeedback.classList.remove('text-canopy-green', 'text-[#f48771]')
+    spikeAnswerFeedback.classList.add(correct ? 'text-canopy-green' : 'text-[#f48771]')
+    spikeAnswerFeedback.textContent = correct
+      ? 'Correct. The generated view supported the complete development answer.'
+      : 'Not yet. Check both the matching order IDs and the displayed total.'
+  })
+}
 
 renderDataExplorer();
 

--- a/examples/web/src/genui.js
+++ b/examples/web/src/genui.js
@@ -6,6 +6,8 @@ import {
   selectOrder,
   summarizeOrders,
 } from './genui-data.ts';
+import { GENUI_SPIKE_CASE } from './genui-spike-case.js';
+import { parseGenUiRecipe } from './genui-spike-recipe.js';
 
 const EXAMPLES = [
   `<div class="bg-gray-800 text-white p-6 rounded-xl shadow-lg max-w-lg">\n  <h1 class="text-2xl font-bold text-emerald-400 mb-2">Hello, World!</h1>\n  <p class="text-gray-300">This is JSX parsed incrementally with Tailwind.</p>\n</div>`,
@@ -45,6 +47,30 @@ const dataDetailId = document.getElementById('data-detail-id')
 const dataDetailName = document.getElementById('data-detail-name')
 const dataDetailStatus = document.getElementById('data-detail-status')
 const dataDetailAmount = document.getElementById('data-detail-amount')
+const spikeQuestion = document.getElementById('spike-question')
+const spikeGenerate = document.getElementById('spike-generate')
+const spikeEmpty = document.getElementById('spike-empty')
+const spikeLoading = document.getElementById('spike-loading')
+const spikeResult = document.getElementById('spike-result')
+const spikeError = document.getElementById('spike-error')
+const spikeErrorMessage = document.getElementById('spike-error-message')
+const spikeResultTitle = document.getElementById('spike-result-title')
+const spikeFilterChip = document.getElementById('spike-filter-chip')
+const spikeSummaryLabel = document.getElementById('spike-summary-label')
+const spikeSummaryValue = document.getElementById('spike-summary-value')
+const spikeMatchCount = document.getElementById('spike-match-count')
+const spikeTableHead = document.getElementById('spike-table-head')
+const spikeTableBody = document.getElementById('spike-table-body')
+const spikeAnswerForm = document.getElementById('spike-answer-form')
+const spikeAnswerOrders = document.getElementById('spike-answer-orders')
+const spikeAnswerTotal = document.getElementById('spike-answer-total')
+const spikeCheckAnswer = document.getElementById('spike-check-answer')
+const spikeAnswerFeedback = document.getElementById('spike-answer-feedback')
+const spikeTelemetry = document.getElementById('spike-telemetry')
+const spikeModel = document.getElementById('spike-model')
+const spikeElapsed = document.getElementById('spike-elapsed')
+const spikePromptTokens = document.getElementById('spike-prompt-tokens')
+const spikeOutputTokens = document.getElementById('spike-output-tokens')
 
 let isStreaming = false
 let abortStream = false
@@ -195,6 +221,133 @@ function appendOrderCell(row, value, className) {
 function formatOrderAmount(amount) {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
 }
+
+const SPIKE_COLUMN_LABELS = {
+  id: 'Order',
+  name: 'Name',
+  status: 'Status',
+  amount: 'Amount',
+}
+const spikeExpectedRows = ORDER_ROWS.filter((row) => row.status === 'pending')
+const spikeExpectedIds = spikeExpectedRows.map((row) => row.id).sort()
+const spikeExpectedTotal = summarizeOrders(spikeExpectedRows).totalAmount
+let spikeGenerating = false
+
+function setSpikeState(state) {
+  spikeEmpty.classList.toggle('hidden', state !== 'empty')
+  spikeLoading.classList.toggle('hidden', state !== 'loading')
+  spikeLoading.classList.toggle('flex', state === 'loading')
+  spikeResult.hidden = state !== 'result'
+  spikeError.classList.toggle('hidden', state !== 'error')
+  spikeError.classList.toggle('flex', state === 'error')
+}
+
+function renderSpikeRecipe(recipe, telemetry) {
+  const matchingRows = ORDER_ROWS.filter((row) => row[recipe.filter.field] === recipe.filter.value)
+  const summary = summarizeOrders(matchingRows)
+
+  spikeResultTitle.textContent = recipe.title
+  spikeFilterChip.textContent = `${recipe.filter.field} = ${recipe.filter.value}`
+  spikeSummaryLabel.textContent = recipe.summary.label
+  spikeSummaryValue.textContent = formatOrderAmount(summary.totalAmount)
+  spikeMatchCount.textContent = String(matchingRows.length)
+
+  const headerRow = document.createElement('tr')
+  recipe.columns.forEach((field) => {
+    const heading = document.createElement('th')
+    heading.className = `px-3 py-2 font-normal ${field === 'amount' ? 'text-right' : ''}`
+    heading.scope = 'col'
+    heading.textContent = SPIKE_COLUMN_LABELS[field]
+    headerRow.append(heading)
+  })
+  spikeTableHead.replaceChildren(headerRow)
+
+  const bodyRows = matchingRows.map((order) => {
+    const row = document.createElement('tr')
+    row.className = 'border-b border-canopy-border/70'
+    recipe.columns.forEach((field) => {
+      const cell = document.createElement('td')
+      cell.className = `px-3 py-2.5 ${field === 'amount' ? 'text-right text-canopy-green' : 'text-canopy-text'}`
+      if (field === 'status') {
+        const status = document.createElement('span')
+        status.className = `status-chip status-${order.status}`
+        status.textContent = order.status
+        cell.append(status)
+      } else {
+        cell.textContent = field === 'amount' ? formatOrderAmount(order.amount) : String(order[field])
+      }
+      row.append(cell)
+    })
+    return row
+  })
+  spikeTableBody.replaceChildren(...bodyRows)
+
+  spikeModel.textContent = typeof telemetry?.model === 'string' ? telemetry.model : 'unknown'
+  spikeElapsed.textContent = Number.isFinite(telemetry?.elapsedMs) ? `${(telemetry.elapsedMs / 1000).toFixed(1)} s` : '—'
+  spikePromptTokens.textContent = Number.isFinite(telemetry?.promptTokens) ? `${telemetry.promptTokens} tokens` : '—'
+  spikeOutputTokens.textContent = Number.isFinite(telemetry?.outputTokens) ? `${telemetry.outputTokens} tokens` : '—'
+  spikeTelemetry.hidden = false
+  spikeCheckAnswer.disabled = false
+  setSpikeState('result')
+}
+
+spikeQuestion.textContent = GENUI_SPIKE_CASE.question
+setSpikeState('empty')
+
+spikeGenerate.addEventListener('click', async function() {
+  if (spikeGenerating) return
+  spikeGenerating = true
+  spikeGenerate.disabled = true
+  spikeGenerate.textContent = 'Generating…'
+  spikeCheckAnswer.disabled = true
+  spikeTelemetry.hidden = true
+  spikeAnswerFeedback.textContent = ''
+  setSpikeState('loading')
+
+  try {
+    const response = await fetch('/api/genui-spike', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ caseId: GENUI_SPIKE_CASE.id }),
+    })
+    const body = await response.json()
+    if (!response.ok) {
+      throw new Error(typeof body?.error === 'string' ? body.error : `Prototype endpoint returned HTTP ${response.status}.`)
+    }
+
+    const parsedRecipe = parseGenUiRecipe(body?.recipe)
+    if (!parsedRecipe.ok) {
+      throw new Error(`Browser rejected recipe: ${parsedRecipe.error}`)
+    }
+    renderSpikeRecipe(parsedRecipe.value, body?.telemetry)
+  } catch (error) {
+    spikeErrorMessage.textContent = error instanceof Error ? error.message : String(error)
+    setSpikeState('error')
+  } finally {
+    spikeGenerating = false
+    spikeGenerate.disabled = false
+    spikeGenerate.textContent = 'Generate one-shot view'
+  }
+})
+
+spikeAnswerForm.addEventListener('submit', function(event) {
+  event.preventDefault()
+  const submittedIds = spikeAnswerOrders.value
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0)
+    .sort()
+  const idsCorrect = submittedIds.length === spikeExpectedIds.length &&
+    submittedIds.every((id, index) => id === spikeExpectedIds[index])
+  const totalCorrect = Number(spikeAnswerTotal.value) === spikeExpectedTotal
+  const correct = idsCorrect && totalCorrect
+
+  spikeAnswerFeedback.classList.remove('text-canopy-green', 'text-[#f48771]')
+  spikeAnswerFeedback.classList.add(correct ? 'text-canopy-green' : 'text-[#f48771]')
+  spikeAnswerFeedback.textContent = correct
+    ? 'Correct. The generated view supported the complete development answer.'
+    : 'Not yet. Check both the matching order IDs and the displayed total.'
+})
 
 renderDataExplorer();
 

--- a/examples/web/tests/genui.spec.ts
+++ b/examples/web/tests/genui.spec.ts
@@ -251,6 +251,38 @@ test.describe('Generative UI Demo', () => {
     await expect(rows.filter({ hasText: 'Acme renewal' })).toContainText('$1,280.50');
   });
 
+  test('renders a validated one-shot recipe and checks the development answer', async ({ page }) => {
+    await page.route('**/api/genui-spike', (route) => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        recipe: {
+          kind: 'filtered_orders',
+          title: 'Pending orders requiring attention',
+          filter: { field: 'status', operator: 'equals', value: 'pending' },
+          columns: ['id', 'name', 'amount'],
+          summary: { field: 'amount', aggregation: 'sum', label: 'Pending value' },
+        },
+        telemetry: {
+          model: 'test-model',
+          elapsedMs: 12,
+          promptTokens: 20,
+          outputTokens: 10,
+        },
+      }),
+    }));
+    await page.goto('/genui.html');
+
+    await page.getByRole('button', { name: 'Generate one-shot view' }).click();
+    await expect(page.locator('#spike-result')).toBeVisible();
+    await expect(page.locator('#spike-summary-value')).toHaveText('$2,180.00');
+    await expect(page.locator('#spike-table-body').getByRole('row')).toHaveCount(2);
+
+    await page.getByLabel('Order IDs, comma separated').fill('ord-1002, ord-1006');
+    await page.getByLabel('Total amount').fill('2180');
+    await page.getByRole('button', { name: 'Check development answer' }).click();
+    await expect(page.locator('#spike-answer-feedback')).toContainText('Correct.');
+  });
+
   test('filters rows while preserving a selected host-owned row', async ({ page }) => {
     await page.goto('/genui.html');
     const table = page.getByRole('table', { name: 'Orders' });

--- a/examples/web/vite-plugin-genui-spike.ts
+++ b/examples/web/vite-plugin-genui-spike.ts
@@ -1,0 +1,133 @@
+import type { Plugin } from 'vite';
+
+import orders from './src/fixtures/orders.json';
+import { GENUI_SPIKE_CASE } from './src/genui-spike-case.js';
+import { GENUI_RECIPE_SCHEMA, parseGenUiRecipe } from './src/genui-spike-recipe.js';
+
+const OLLAMA_URL = 'http://127.0.0.1:11434/api/generate';
+const DEFAULT_MODEL = 'gemma4:e2b';
+const REQUEST_LIMIT_BYTES = 1024;
+const REQUEST_TIMEOUT_MS = 120_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function readRequestBody(request: AsyncIterable<Uint8Array>): Promise<unknown> {
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    size += chunk.byteLength;
+    if (size > REQUEST_LIMIT_BYTES) {
+      throw new Error('Request body exceeds the 1 KiB prototype limit.');
+    }
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+function sendJson(response: { statusCode: number; setHeader(name: string, value: string): void; end(body: string): void }, status: number, body: unknown) {
+  response.statusCode = status;
+  response.setHeader('content-type', 'application/json; charset=utf-8');
+  response.setHeader('cache-control', 'no-store');
+  response.end(JSON.stringify(body));
+}
+
+function buildPrompt() {
+  return [
+    'You design one focused read-only view for a data task.',
+    `Question: ${GENUI_SPIKE_CASE.question}`,
+    `Rows: ${JSON.stringify(orders)}`,
+    'Return only a recipe matching the supplied JSON schema.',
+    'Choose the status filter and columns that help answer the question.',
+    'Do not answer the question in the title or summary label.',
+    'Do not emit HTML, JavaScript, Markdown, explanations, or extra properties.',
+  ].join('\n');
+}
+
+function readMetric(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function genUiSpikePlugin(): Plugin {
+  return {
+    name: 'genui-spike-ollama',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use('/api/genui-spike', async (request, response) => {
+        if (request.method !== 'POST') {
+          sendJson(response, 405, { error: 'Only POST is supported.' });
+          return;
+        }
+
+        try {
+          const body = await readRequestBody(request);
+          if (!isRecord(body) || Object.keys(body).length !== 1 || body.caseId !== GENUI_SPIKE_CASE.id) {
+            sendJson(response, 400, { error: 'Unknown or malformed development case request.' });
+            return;
+          }
+
+          const model = process.env.GENUI_OLLAMA_MODEL ?? DEFAULT_MODEL;
+          const startedAt = performance.now();
+          const providerResponse = await fetch(OLLAMA_URL, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              model,
+              prompt: buildPrompt(),
+              stream: false,
+              format: GENUI_RECIPE_SCHEMA,
+              options: { temperature: 0, num_predict: 256 },
+              keep_alive: '5m',
+            }),
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          });
+
+          if (!providerResponse.ok) {
+            sendJson(response, 502, { error: `Ollama returned HTTP ${providerResponse.status}.` });
+            return;
+          }
+
+          const providerBody: unknown = await providerResponse.json();
+          if (!isRecord(providerBody) || typeof providerBody.response !== 'string') {
+            sendJson(response, 502, { error: 'Ollama returned an invalid response envelope.' });
+            return;
+          }
+
+          let untrustedRecipe: unknown;
+          try {
+            untrustedRecipe = JSON.parse(providerBody.response);
+          } catch {
+            sendJson(response, 502, { error: 'Ollama returned non-JSON recipe content.' });
+            return;
+          }
+
+          const parsedRecipe = parseGenUiRecipe(untrustedRecipe);
+          if (!parsedRecipe.ok) {
+            sendJson(response, 502, { error: `Recipe rejected: ${parsedRecipe.error}` });
+            return;
+          }
+
+          sendJson(response, 200, {
+            recipe: parsedRecipe.value,
+            telemetry: {
+              model: typeof providerBody.model === 'string' ? providerBody.model : model,
+              elapsedMs: Math.round(performance.now() - startedAt),
+              providerDurationMs: readMetric(providerBody.total_duration) === null
+                ? null
+                : Math.round(readMetric(providerBody.total_duration)! / 1_000_000),
+              promptTokens: readMetric(providerBody.prompt_eval_count),
+              outputTokens: readMetric(providerBody.eval_count),
+            },
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const timedOut = error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+          sendJson(response, timedOut ? 504 : 500, {
+            error: timedOut ? 'Local model request timed out.' : `Prototype request failed: ${message}`,
+          });
+        }
+      });
+    },
+  };
+}

--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -2,12 +2,14 @@ import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { moonbitPlugin } from './vite-plugin-moonbit';
 import tailwindcss from '@tailwindcss/vite';
+import { genUiSpikePlugin } from './vite-plugin-genui-spike';
 
 const analyze = process.env.ANALYZE === '1';
 
 export default defineConfig({
   plugins: [
     tailwindcss(),
+    genUiSpikePlugin(),
     moonbitPlugin({
       modules: [
         {

--- a/scripts/test-web-e2e.sh
+++ b/scripts/test-web-e2e.sh
@@ -25,3 +25,8 @@ echo "Running GenUI recipe contract tests..."
 node --test src/genui-spike-recipe.test.mjs
 
 CI="${CI:-1}" npx playwright test "$@"
+
+if [ "$#" -eq 0 ]; then
+    echo "Running GenUI production preview tests..."
+    CI="${CI:-1}" npx playwright test --config=playwright.preview.config.ts
+fi

--- a/scripts/test-web-e2e.sh
+++ b/scripts/test-web-e2e.sh
@@ -21,4 +21,7 @@ if [ ! -d node_modules ]; then
     npm ci
 fi
 
+echo "Running GenUI recipe contract tests..."
+node --test src/genui-spike-recipe.test.mjs
+
 CI="${CI:-1}" npx playwright test "$@"


### PR DESCRIPTION
## Summary

- add a disposable, development-only Ollama vertical slice that turns one fixed orders question into a strictly validated JSON recipe and a host-owned task-specific view
- keep provider traffic and model selection outside the browser while exercising validation, replay, rendering, answer capture, and fail-closed rejection end to end
- amend the experiment design so Spike 0 is feasibility evidence only and any Gate C model is selected by a preregistered development-only bake-off after Gate B eligibility

## Experimental boundaries

- This is not Gate A evidence and does not change the current `FIXED` decision.
- `gemma4:e2b` is a local feasibility model, not a frozen evaluation model and not evidence for general LLM value.
- The spike endpoint is `POST /api/genui-spike`; the canonical later-provider endpoint remains `POST /__canopy_dev/genui/generate`. No compatibility is promised.
- The renderer intentionally uses the fixed JSON development fixture rather than the active JSON/CSV UI toggle. Those sources are equivalent for this case; this behavior must not be generalized into the later host-context design.
- No production provider abstraction, credential UI, streaming, retry, arbitrary code generation, or held-out evidence is introduced.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ORDER_ROWS`, `deriveOrderView`, `summarizeOrders` | `examples/web/src/genui-data.ts` | Yes | Host-owned data and deterministic filtering/aggregation stay authoritative. |
| `replayCandidate` and capability validation | `examples/web/src/genui.js` | Yes | The generated recipe enters the existing replay/validation boundary rather than a second apply path. |
| orders development fixture | `examples/web/src/fixtures/orders.json` | Yes | The server prompt and browser renderer use the same fixed development case. |
| MoonBit `Map`/`Set`/`StringView`/`Array`/`Iter` | MoonBit core | No | This spike adds no MoonBit data manipulation or public MoonBit API; the server and validator are JavaScript. |
| JavaScript `Set`, `Array.filter/map/reduce`, `JSON.parse` | platform APIs | Yes | Used directly for allowlists, deterministic host computation, and bounded parsing. |

New helpers added:

- `parseGenUiRecipe`: owns strict schema-shaped validation plus the fixed development-question invariants; no existing validator accepts this deliberately narrow recipe contract.
- `GENUI_SPIKE_CASE`: one immutable development-only case shared by prompt and validator.
- `genUiSpikePlugin`: a Vite serve-only, loopback-only provider shell; no production/provider-neutral abstraction is created.

Remaining imperative code is limited to request streaming/timeout handling and browser DOM/event wiring.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes — 0 errors; existing workspace warnings remain
- [x] `NEW_MOON_MOD=0 moon test` passes — 1,921 JS + 70 native tests
- [x] `git diff *.mbti` reviewed — no interface changes
- [x] `cd examples/web && npm run build` passes
- [x] `cd examples/web && npx tsc --noEmit` passes
- [x] `CANOPY_SKIP_MOON_BUILD=1 ./scripts/test-web-e2e.sh` passes — 7 recipe contract tests + 73 Playwright tests
- [x] independent final review passes with no blocking findings

## Validation

```bash
NEW_MOON_MOD=0 moon info
moon fmt
moon check
moon test
cd examples/web
npm run build
npx tsc --noEmit
cd ../..
CANOPY_SKIP_MOON_BUILD=1 ./scripts/test-web-e2e.sh
```
