### PR TITLE
docs: prioritize human-centered knowledge environment

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -27,7 +27,7 @@ The interface scales from minimal (newcomer) to full workbench (researcher) via 
 3. **Typography carries weight** — Inter for UI (clean, professional), JetBrains Mono for code (precise, technical). The contrast between UI and code fonts should create clear zones.
 4. **Color is semantic, not decorative** — every color means something. Purple = structure/accent, syntax colors follow consistent language semantics. No color without purpose.
 5. **Calm confidence** — the interface should feel solid and trustworthy, never frantic or busy. Subtle transitions, restrained hover states, generous whitespace. Generated or inferred changes must not steal attention from the person's own work.
-6. **Accessible equivalence** — every interaction available visually must have an equivalent keyboard and screen-reader path. Accessibility is a design requirement on parity, not a fallback layer.
+6. **Accessible equivalence** — see [human-centered product principles: accessible equivalence](docs/architecture/human-centered-product-principles.md#accessible-equivalence). Logical focus order matches visual order, focus indicators are visible, dynamic changes are announced to screen readers, and meaning never relies on color alone.
 
 ### Design Tokens
 ```

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,5 +1,10 @@
 ## Design Context
 
+Behavior invariants for how Canopy acts toward its users are defined in
+the [Human-centered product principles](docs/architecture/human-centered-product-principles.md).
+The design principles below extend those invariants into visual and
+interaction form.
+
 ### Users
 Canopy serves all audiences through progressive disclosure:
 - **PL researchers** exploring CRDT + incremental parsing internals (need transparency)
@@ -18,10 +23,11 @@ The interface scales from minimal (newcomer) to full workbench (researcher) via 
 
 ### Design Principles
 1. **Structure reveals meaning** — the visual design should make the AST structure legible at a glance. Color, spacing, and nesting communicate relationships before the user reads labels.
-2. **Progressive disclosure** — start clean and focused, reveal depth on demand. Every panel toggle should feel like opening a drawer, not being overwhelmed.
+2. **Progressive disclosure** — start clean and focused, reveal depth on demand. Every panel toggle should feel like opening a drawer, not being overwhelmed. Disclosure must preserve cognitive stability: the person should never lose their place when depth appears.
 3. **Typography carries weight** — Inter for UI (clean, professional), JetBrains Mono for code (precise, technical). The contrast between UI and code fonts should create clear zones.
 4. **Color is semantic, not decorative** — every color means something. Purple = structure/accent, syntax colors follow consistent language semantics. No color without purpose.
-5. **Calm confidence** — the interface should feel solid and trustworthy, never frantic or busy. Subtle transitions, restrained hover states, generous whitespace.
+5. **Calm confidence** — the interface should feel solid and trustworthy, never frantic or busy. Subtle transitions, restrained hover states, generous whitespace. Generated or inferred changes must not steal attention from the person's own work.
+6. **Accessible equivalence** — every interaction available visually must have an equivalent keyboard and screen-reader path. Accessibility is a design requirement on parity, not a fallback layer.
 
 ### Design Tokens
 ```

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -84,7 +84,11 @@ Canopy is a framework as much as an editor. Define a grammar for your language, 
 
 But the long-term vision goes further. The code editor is a vertical slice of something larger: **a system where you write freely, provisional structure emerges as revisable hypotheses, and relevant context is offered with reasons and under your control.** Every layer of the editor — incremental computation, semantic analysis, reactive projections, peer-to-peer sync — is a building block for that system.
 
-Read more: [Product Vision](docs/architecture/product-vision.md) · [The Projectional Bridge](docs/architecture/vision-projectional-bridge.md) · [Multi-Representation System](docs/architecture/multi-representation-system.md) · [Human-centered product principles](docs/architecture/human-centered-product-principles.md)
+Read more: [Product Vision](docs/architecture/product-vision.md) ·
+[Personal Knowledge Environment Direction](docs/architecture/personal-knowledge-environment-direction.md) ·
+[The Projectional Bridge](docs/architecture/vision-projectional-bridge.md) ·
+[Multi-Representation System](docs/architecture/multi-representation-system.md) ·
+[Human-centered product principles](docs/architecture/human-centered-product-principles.md)
 
 ## Framework Design
 
@@ -171,6 +175,7 @@ highlights:
 
 **Vision and architecture:**
 - [Product Vision](docs/architecture/product-vision.md) — the full picture: write, negotiate structure, surface context
+- [Personal Knowledge Environment Direction](docs/architecture/personal-knowledge-environment-direction.md) — resumable technical project memory
 - [The Projectional Bridge](docs/architecture/vision-projectional-bridge.md) — why: syntax → semantics → intent → mental model
 - [Multi-Representation System](docs/architecture/multi-representation-system.md) — the Printable trait family and expression problem
 - [Incremental Hylomorphism](docs/architecture/Incremental-Hylomorphism.md) — the compositional engine underneath

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -2,6 +2,8 @@
 
 **Write. It structures itself.**
 
+Structure emerges visibly and reversibly; you remain the author.
+
 ![Demo: type code, see evaluation results update live](docs/demo.gif)
 
 Canopy reads your code as a live structure rather than flat text. As you type, it reparses incrementally, tracks scope and types, evaluates expressions, and formats the result — without breaking your flow. Two people can edit the same document at once with no server, and edits merge automatically.
@@ -12,9 +14,9 @@ Canopy reads your code as a live structure rather than flat text. As you type, i
 
 Most editors treat source code as flat text. You type characters, and the tool does its best to guess what you meant — syntax highlighting, auto-complete, error squiggles — all reconstructed after the fact from dead text.
 
-Canopy treats your program as a living structure. Text and syntax tree are **two synchronized views** of the same document. Type in one, the other updates. Restructure in one, the other follows. The editor doesn't guess what your code means — it knows, because it maintains the meaning incrementally as you type.
+Canopy treats your program as a living structure. Text and syntax tree are **two synchronized views** of the same document. Type in one, the other updates. Restructure in one, the other follows. The editor exposes an explicit, inspectable semantic model — scope, bindings, types, values — derived from the text rather than substituted for it.
 
-The goal: **close the gap between what you think and what the tool understands.** When the editor holds the same mental model you do — scope, types, values, dependencies — it can show you what matters, when it matters, without you having to search for it.
+The goal: **close the gap between what you think and what the tool can show you.** By making its current semantic model visible and correctable through the source — scope, types, values, dependencies — the editor can offer relevant context with reasons, under your control.
 
 ## What it looks like
 
@@ -28,7 +30,7 @@ if result then result else 0
 
 As you type this, Canopy:
 - Parses incrementally (one character change → one subtree reparse)
-- Resolves scope (knows `x` is bound by the arrow-lambda parameter, `double` refers to the definition above)
+- Resolves scope (tracks that `x` is bound by the arrow-lambda parameter and `double` refers to the definition above)
 - Formats with syntax highlighting through the pretty-printer
 - Evaluates `double 5 → 10` and `if result then result else 0 → 10`
 - Synchronizes with any connected peer via CRDT
@@ -80,9 +82,9 @@ The targets currently exercised in CI are **JavaScript** (web demo, FFI) and
 
 Canopy is a framework as much as an editor. Define a grammar for your language, implement a few traits, and you get incremental parsing, structural editing, pretty-printing, and CRDT collaboration out of the box.
 
-But the long-term vision goes further. The code editor is a vertical slice of something larger: **a system where you write freely, structure emerges automatically, and the right information surfaces when you need it.** Every layer of the editor — incremental computation, semantic analysis, reactive projections, peer-to-peer sync — is a building block for that system.
+But the long-term vision goes further. The code editor is a vertical slice of something larger: **a system where you write freely, provisional structure emerges as revisable hypotheses, and relevant context is offered with reasons and under your control.** Every layer of the editor — incremental computation, semantic analysis, reactive projections, peer-to-peer sync — is a building block for that system.
 
-Read more: [Product Vision](docs/architecture/product-vision.md) · [The Projectional Bridge](docs/architecture/vision-projectional-bridge.md) · [Multi-Representation System](docs/architecture/multi-representation-system.md)
+Read more: [Product Vision](docs/architecture/product-vision.md) · [The Projectional Bridge](docs/architecture/vision-projectional-bridge.md) · [Multi-Representation System](docs/architecture/multi-representation-system.md) · [Human-centered product principles](docs/architecture/human-centered-product-principles.md)
 
 ## Framework Design
 
@@ -168,7 +170,7 @@ of the docs into a learning path, API/reference, and contributor material. The
 highlights:
 
 **Vision and architecture:**
-- [Product Vision](docs/architecture/product-vision.md) — the full picture: write, auto-structure, surface
+- [Product Vision](docs/architecture/product-vision.md) — the full picture: write, negotiate structure, surface context
 - [The Projectional Bridge](docs/architecture/vision-projectional-bridge.md) — why: syntax → semantics → intent → mental model
 - [Multi-Representation System](docs/architecture/multi-representation-system.md) — the Printable trait family and expression problem
 - [Incremental Hylomorphism](docs/architecture/Incremental-Hylomorphism.md) — the compositional engine underneath

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,21 +23,27 @@ material is grouped at the bottom and is not required reading.
 Read in order to build a mental model of the system.
 
 1. **[Product Vision](architecture/product-vision.md)** — what Canopy is trying
-   to be: write, auto-structure, surface.
-2. **[The Projectional Bridge](architecture/vision-projectional-bridge.md)** —
+   to be: write, negotiate structure, and surface context.
+2. **[Personal Knowledge Environment Direction](architecture/personal-knowledge-environment-direction.md)**
+   — near-term primary product direction: human-centered personal knowledge
+   environment with resumable technical project memory as the initial wedge.
+3. **[Human-centered product principles](architecture/human-centered-product-principles.md)**
+   — canonical product behavior invariants: human authority, negotiable
+   structure, contestability, and product gates.
+4. **[The Projectional Bridge](architecture/vision-projectional-bridge.md)** —
    why: syntax → semantics → intent → mental model.
-3. **[Architecture Overview](architecture.md)** — single-page summary of the
+5. **[Architecture Overview](architecture.md)** — single-page summary of the
    pipeline, package responsibilities, key invariants, and extension points.
-4. **[System Architecture Diagram](architecture/ARCHITECTURE_DIAGRAM.md)** —
+6. **[System Architecture Diagram](architecture/ARCHITECTURE_DIAGRAM.md)** —
    high-level data flow: Text CRDT → Incremental Parse → Projection → Rendering.
-5. **[Module Structure](architecture/modules.md)** — how the monorepo and
+7. **[Module Structure](architecture/modules.md)** — how the monorepo and
    submodules map onto that pipeline.
-6. **[Responsibility Map](architecture/responsibility-map.md)** — ownership
+8. **[Responsibility Map](architecture/responsibility-map.md)** — ownership
    boundaries, reuse-first APIs, and the current extension priority order.
-7. **[Incremental Hylomorphism](architecture/Incremental-Hylomorphism.md)** —
+9. **[Incremental Hylomorphism](architecture/Incremental-Hylomorphism.md)** —
    the compositional engine underneath.
-8. **[Multi-Representation System](architecture/multi-representation-system.md)**
-   — the `Printable` trait family (Show, Debug, Source, Pretty).
+10. **[Multi-Representation System](architecture/multi-representation-system.md)**
+    — the `Printable` trait family (Show, Debug, Source, Pretty).
 
 > The earlier "Projectional Editing" deep-dive has been archived to
 > [`archive/PROJECTIONAL_EDITING.md`](archive/PROJECTIONAL_EDITING.md). It is

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,6 +35,27 @@ Plan template: [Plan Template](plans/TEMPLATE.md)
 
 ---
 
+## 0. Near-term priority: personal knowledge environment
+
+**Note:** Canopy's current implementation is a projectional editor with CRDT
+collaboration, and the sections below still track that work. Near-term product
+development now prioritizes the **Personal Knowledge Environment** direction:
+resumable technical project memory, with the projectional editor preserved in
+maintenance and proving-ground mode.
+
+- [ ] Deliver the first Personal Knowledge Environment vertical slice: import
+  a user-selected pi session snapshot into a fixed, source-backed Resume View.
+  Why: the initial wedge should restore a technical work session without asking
+  the person to enter the same context twice.
+  Plan: `docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md`
+  Direction: `docs/architecture/personal-knowledge-environment-direction.md`
+  Exit: the same session renders as chronology and Resume views; an unfamiliar
+  reviewer can identify the goal, verified outcome, unresolved question or
+  next step, and source evidence within five minutes, and the Resume condition
+  improves correctness, time, or both without losing traceability.
+
+---
+
 ## 1. CI/CD & Automation
 
 - [ ] If wasm support is added later, add a dedicated wasm implementation and CI job.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -49,10 +49,13 @@ maintenance and proving-ground mode.
   the person to enter the same context twice.
   Plan: `docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md`
   Direction: `docs/architecture/personal-knowledge-environment-direction.md`
-  Exit: the same session renders as chronology and Resume views; an unfamiliar
-  reviewer can identify the goal, verified outcome, unresolved question or
-  next step, and source evidence within five minutes, and the Resume condition
-  improves correctness, time, or both without losing traceability.
+  Exit: fixed fixture and explicit import satisfy the plan's
+  correctness/privacy/traceability criteria; on an unseen transcript,
+  evaluator identifies goal, one verified outcome, unresolved question or next
+  step, and opens source evidence within five minutes; Resume improves
+  correctness, time, or both vs chronology.
+  Later gate: expansion is governed by the direction document's
+  product-evidence gate using actual work across sessions.
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -41,8 +41,14 @@ the files inside `docs/architecture/`.
 
 ## Vision
 
-- **[Product Vision](product-vision.md)** — the full product: write,
-  auto-structure, surface.
+- **[Product Vision](product-vision.md)** — the full product: write, negotiate
+  structure, and surface context.
+- **[Personal Knowledge Environment Direction](personal-knowledge-environment-direction.md)** —
+  near-term primary product direction: human-centered personal knowledge
+  environment with resumable technical project memory as the initial wedge.
+- **[Human-centered product principles](human-centered-product-principles.md)**
+  — canonical behavior invariants for authority, negotiable structure,
+  orientation, accessible equivalence, and product gates.
 - **[The Projectional Bridge](vision-projectional-bridge.md)** — bridging
   syntax → semantics → intent → mental model.
 - **[Structure-Format Research](structure-format-research.md)** — PL research

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -223,5 +223,27 @@ arbitrary model-generated code, or replacing conventional hand-authored UI.
 The initial goal is a safe incremental bridge between structured generation,
 human editing, and multiple UI projections.
 
-Related: [JSX Incremental Parser for Generative UI](../plans/2026-07-09-jsx-incremental-parser-generative-ui.md),
-[property-based correctness coverage issue #888](https://github.com/dowdiness/canopy/issues/888).
+## Human outcome gate
+
+Generated UI changes are meaningful only when they meet the product-level
+gates defined in [Human-centered product principles](human-centered-product-principles.md):
+
+- **Legible and governable.** Every generated change can be read and
+  understood. Consequential changes require explicit acceptance or a narrow,
+  revocable policy the person chose.
+- **Orientation-preserving.** Generated changes do not steal attention,
+  fragment the user's place in the document, or create cognitively unstable
+  transitions.
+- **Accessible equivalence.** Every generated control has a keyboard and
+  screen-reader equivalent path. Accessibility is not a fallback.
+- **Rationale and reversal.** Each generated change carries a reason the
+  person can read, and can be undone without losing prior state.
+- **Net value over fixed alternatives.** The generated outcome must produce
+  a measurably better result on a named task than a fixed, rules-based
+  alternative. Novelty alone is not justification.
+
+These gates are product requirements, not technical implementation details.
+They sit above the commit and candidate contracts defined in this document.
+
+Related: [JSX Incremental Parser for Generative UI](../plans/2026-07-09-jsx-incremental-parser-generative-ui.md)
+and [property-based correctness coverage issue #888](https://github.com/dowdiness/canopy/issues/888).

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -226,21 +226,21 @@ human editing, and multiple UI projections.
 ## Human outcome gate
 
 Generated UI changes are meaningful only when they meet the product-level
-gates defined in [Human-centered product principles](human-centered-product-principles.md):
+gates defined in [Human-centered product principles](human-centered-product-principles.md).
+This document's generative-UI-specific interpretation:
 
-- **Legible and governable.** Every generated change can be read and
-  understood. Consequential changes require explicit acceptance or a narrow,
-  revocable policy the person chose.
-- **Orientation-preserving.** Generated changes do not steal attention,
-  fragment the user's place in the document, or create cognitively unstable
-  transitions.
-- **Accessible equivalence.** Every generated control has a keyboard and
-  screen-reader equivalent path. Accessibility is not a fallback.
-- **Rationale and reversal.** Each generated change carries a reason the
-  person can read, and can be undone without losing prior state.
-- **Net value over fixed alternatives.** The generated outcome must produce
-  a measurably better result on a named task than a fixed, rules-based
-  alternative. Novelty alone is not justification.
+- **Candidate rationale/provenance tied to the exact candidate/revision.**
+  Every generated change carries a reason the person can read, linked to the
+  specific candidate and base revision that produced it.
+- **Preview/rejection cannot mutate committed state.** Internal dry-run must
+  validate a candidate before it reaches the session commit boundary; rejected
+  candidates change no committed state.
+- **Apply/recovery preserves focus, selection, and orientation.** Generated
+  changes preserve user-entered values, focus, selection, and local
+  customizations whenever the structure permits.
+- **Generated outcomes are compared with fixed/rules alternatives.** The
+  generated outcome must produce a measurably better result on a named task
+  than a fixed, rules-based alternative. Novelty alone is not justification.
 
 These gates are product requirements, not technical implementation details.
 They sit above the commit and candidate contracts defined in this document.

--- a/docs/architecture/human-centered-product-principles.md
+++ b/docs/architecture/human-centered-product-principles.md
@@ -1,0 +1,120 @@
+# Human-centered product principles
+
+Canopy is a thinking instrument that helps people stay oriented while moving
+between thought, structure, and action. These principles govern how the
+product behaves toward the person using it. They are the canonical reference;
+other documents link here rather than restating the rules.
+
+## Principles
+
+### Human authority
+
+The person decides. The system proposes structure, surfaces context, and
+generates changes, but every consequential system-originated transition is
+inspectable and governed by explicit human authority or a revocable policy the
+person chose. The tool does not override the person's judgment about their own
+work.
+
+### Negotiable structure
+
+Structure produced by the system — links, clusters, groupings, projections —
+is provisional. It is offered as a revisable hypothesis, not an established
+fact. The person can name, correct, suppress, or replace any inferred
+structure with their own. Explicit user-authored organization always takes
+precedence over inferred organization.
+
+### Legibility and reasons
+
+When the system acts — surfacing context, proposing a link, generating a UI
+change — it explains why, in a way the person can read without special
+tools. Opaque justifications are not sufficient. The person should be able
+to understand and evaluate each proposal before deciding.
+
+### Reversibility and contestability
+
+Every system-originated document or interface change has a reversal path, and
+every interpretation can be challenged. An irreversible external effect
+requires explicit approval before it occurs. The person must be able to contest
+a classification, a link, a generated change, or a resurfaced item without
+losing their place.
+
+### Cognitive stability and pacing
+
+The interface must not become cognitively unstable. Changes — especially
+generated or inferred ones — must not steal attention, fragment
+orientation, or force the person into a reactive loop. The person controls
+the pace. Proactive behavior is quiet by default and opt-in.
+
+### Accessible equivalence
+
+Every interaction available through a visual or generated interface must
+have an equivalent path through keyboard navigation and screen-reader
+accessible controls. Accessibility is not a fallback layer; it is a
+design requirement on parity.
+
+### Local ownership and data minimization
+
+The person owns local copies of their data, with peer-to-peer sync that does not
+require a central server. The system transmits no more data than the current
+action requires and does not depend on external services to preserve the
+person's work.
+
+## Anti-goals
+
+The following are explicit non-goals. A feature that introduces any of
+these patterns is rejected regardless of its technical merits:
+
+- **Consentless curation** — the system modifying, hiding, or
+  reorganizing the person's content without an explicit, reversible
+  decision.
+- **Attention and engagement optimization** — optimizing for time spent,
+  click-through, or return frequency rather than for the person's stated
+  task.
+- **One machine interpretation as truth** — presenting a single
+  algorithmic output as the correct reading of the person's work, without
+  alternative views or correction paths.
+- **Cognitively unstable UI** — interfaces that change faster than the
+  person can orient, or that introduce surprise state transitions without
+  clear cause and reversal.
+- **Inaccessible fallback** — any interaction path that degrades to a
+  non-equivalent experience for keyboard or screen-reader users.
+- **Machine-readable but human-unintelligible audit** — logging or
+  justification formats that only a tool, not the person, can interpret.
+- **Technical safety mistaken for product value** — treating schema
+  validation, sandboxing, or deterministic replay as sufficient evidence
+  that the product serves the person well.
+
+## Product gates
+
+Every significant product change must pass the applicable agency and inclusion
+gates before it can be claimed complete. Adaptive or generated behavior must
+pass all three gates:
+
+### Agency and contestability gate
+
+The person can inspect the change, understand its reason, accept or reject it,
+and reverse it after the fact. Irreversible external effects require explicit
+approval before execution.
+
+### Inclusion and cognitive steady-state gate
+
+The change is accessible through keyboard and screen reader on equal
+terms. It does not destabilize orientation, demand attention faster than
+the person can process, or create a reactive loop the person cannot
+escape.
+
+### Net-value gate
+
+The change produces a measurably better outcome on a named task than a fixed,
+deterministic, rules-based alternative. Novelty alone is not justification; the
+generated or adaptive behavior must earn its complexity.
+
+## Generative instruments
+
+Canopy's generated surfaces — whether UI, structure, or context — are
+instruments the person plays, not outputs the system delivers. A
+generated change is meaningful only when it is legible, acceptable or
+rejectable, reversible, oriented to the person's current task, equivalent
+across input modalities, and accompanied by a reason. Generation that
+cannot meet these conditions is not shipped, regardless of its
+sophistication.

--- a/docs/architecture/human-centered-product-principles.md
+++ b/docs/architecture/human-centered-product-principles.md
@@ -1,120 +1,103 @@
 # Human-centered product principles
 
 Canopy is a thinking instrument that helps people stay oriented while moving
-between thought, structure, and action. These principles govern how the
-product behaves toward the person using it. They are the canonical reference;
-other documents link here rather than restating the rules.
+between thought, structure, and action. These are the canonical product
+invariants; other documents link here rather than restating them.
 
 ## Principles
 
 ### Human authority
 
-The person decides. The system proposes structure, surfaces context, and
-generates changes, but every consequential system-originated transition is
-inspectable and governed by explicit human authority or a revocable policy the
-person chose. The tool does not override the person's judgment about their own
-work.
+The system proposes structure, surfaces context, and generates changes, but
+every consequential system-originated transition is inspectable and governed by
+explicit human authority or a revocable policy the person chose. The tool does
+not override the person's judgment about their own work.
 
 ### Negotiable structure
 
-Structure produced by the system — links, clusters, groupings, projections —
-is provisional. It is offered as a revisable hypothesis, not an established
-fact. The person can name, correct, suppress, or replace any inferred
-structure with their own. Explicit user-authored organization always takes
-precedence over inferred organization.
+System-produced structure — links, clusters, groupings, projections — is a
+revisable hypothesis, not an established fact. The person can name, correct,
+suppress, or replace any inferred structure. Explicit user-authored
+organization always takes precedence over inferred organization.
 
 ### Legibility and reasons
 
-When the system acts — surfacing context, proposing a link, generating a UI
-change — it explains why, in a way the person can read without special
-tools. Opaque justifications are not sufficient. The person should be able
-to understand and evaluate each proposal before deciding.
+When the system acts, it explains why in a way the person can read without
+special tools. Opaque justifications are not sufficient.
 
 ### Reversibility and contestability
 
-Every system-originated document or interface change has a reversal path, and
-every interpretation can be challenged. An irreversible external effect
-requires explicit approval before it occurs. The person must be able to contest
-a classification, a link, a generated change, or a resurfaced item without
-losing their place.
+Every system-originated change has a reversal path, and every interpretation
+can be challenged without displacing the person's current work. An irreversible
+external effect requires explicit approval before it occurs.
 
 ### Cognitive stability and pacing
 
-The interface must not become cognitively unstable. Changes — especially
-generated or inferred ones — must not steal attention, fragment
-orientation, or force the person into a reactive loop. The person controls
-the pace. Proactive behavior is quiet by default and opt-in.
+Changes must not steal attention, fragment orientation, or force the person
+into a reactive loop. The person controls the pace. Proactive behavior is
+quiet by default and opt-in.
 
 ### Accessible equivalence
 
-Every interaction available through a visual or generated interface must
-have an equivalent path through keyboard navigation and screen-reader
-accessible controls. Accessibility is not a fallback layer; it is a
-design requirement on parity.
+Every interaction available through a visual or generated interface must have
+an equivalent path through keyboard navigation and screen-reader accessible
+controls. Accessibility is a design requirement on parity, not a fallback
+layer.
 
 ### Local ownership and data minimization
 
-The person owns local copies of their data, with peer-to-peer sync that does not
-require a central server. The system transmits no more data than the current
-action requires and does not depend on external services to preserve the
-person's work.
+The person owns local copies of their data, with peer-to-peer sync that does
+not require a central server. The system transmits no more data than the
+current action requires and does not depend on external services to preserve
+the person's work.
 
 ## Anti-goals
 
-The following are explicit non-goals. A feature that introduces any of
-these patterns is rejected regardless of its technical merits:
+Features that introduce any of these patterns are rejected regardless of
+technical merit:
 
-- **Consentless curation** — the system modifying, hiding, or
-  reorganizing the person's content without an explicit, reversible
-  decision.
-- **Attention and engagement optimization** — optimizing for time spent,
-  click-through, or return frequency rather than for the person's stated
-  task.
-- **One machine interpretation as truth** — presenting a single
-  algorithmic output as the correct reading of the person's work, without
-  alternative views or correction paths.
-- **Cognitively unstable UI** — interfaces that change faster than the
-  person can orient, or that introduce surprise state transitions without
-  clear cause and reversal.
-- **Inaccessible fallback** — any interaction path that degrades to a
-  non-equivalent experience for keyboard or screen-reader users.
-- **Machine-readable but human-unintelligible audit** — logging or
-  justification formats that only a tool, not the person, can interpret.
-- **Technical safety mistaken for product value** — treating schema
-  validation, sandboxing, or deterministic replay as sufficient evidence
-  that the product serves the person well.
+- **Consentless curation** — modifying, hiding, or reorganizing content
+  without an explicit, reversible decision.
+- **Attention optimization** — optimizing for time spent, click-through, or
+  return frequency rather than the person's stated task.
+- **One interpretation as truth** — presenting a single algorithmic output as
+  the correct reading without alternative views or correction paths.
+- **Cognitively unstable UI** — interfaces that change faster than the person
+  can orient, or that introduce surprise transitions without clear cause and
+  reversal.
+- **Inaccessible fallback** — any path that degrades to a non-equivalent
+  experience for keyboard or screen-reader users.
+- **Machine-unintelligible audit** — logging or justification formats that
+  only a tool, not the person, can interpret.
+- **Technical safety as product value** — treating schema validation,
+  sandboxing, or deterministic replay as sufficient evidence the product
+  serves the person.
 
 ## Product gates
 
-Every significant product change must pass the applicable agency and inclusion
-gates before it can be claimed complete. Adaptive or generated behavior must
-pass all three gates:
+Every significant product change must pass the applicable gates. Adaptive or
+generated behavior must pass all three:
 
-### Agency and contestability gate
+### Agency and contestability
 
 The person can inspect the change, understand its reason, accept or reject it,
-and reverse it after the fact. Irreversible external effects require explicit
-approval before execution.
+and reverse it. Irreversible external effects require explicit approval before
+execution.
 
-### Inclusion and cognitive steady-state gate
+### Inclusion and cognitive steady-state
 
-The change is accessible through keyboard and screen reader on equal
-terms. It does not destabilize orientation, demand attention faster than
-the person can process, or create a reactive loop the person cannot
-escape.
+The change is accessible through keyboard and screen reader on equal terms. It
+does not destabilize orientation or create an inescapable reactive loop.
 
-### Net-value gate
+### Net value
 
 The change produces a measurably better outcome on a named task than a fixed,
-deterministic, rules-based alternative. Novelty alone is not justification; the
-generated or adaptive behavior must earn its complexity.
+deterministic, rules-based alternative. Novelty alone is not justification.
 
 ## Generative instruments
 
-Canopy's generated surfaces — whether UI, structure, or context — are
-instruments the person plays, not outputs the system delivers. A
-generated change is meaningful only when it is legible, acceptable or
-rejectable, reversible, oriented to the person's current task, equivalent
-across input modalities, and accompanied by a reason. Generation that
-cannot meet these conditions is not shipped, regardless of its
-sophistication.
+Generated surfaces are instruments the person plays, not outputs the system
+delivers. A generated change is meaningful only when it is legible, acceptable
+or rejectable, reversible, oriented to the person's task, equivalent across
+input modalities, and accompanied by a reason. Generation that cannot meet
+these conditions is not shipped.

--- a/docs/architecture/personal-knowledge-environment-direction.md
+++ b/docs/architecture/personal-knowledge-environment-direction.md
@@ -1,45 +1,37 @@
 # Personal knowledge environment direction
 
 **Status:** near-term primary product direction. This document states the
-strategic reorientation and the principles that govern it. It does not describe
+strategic reorientation and governing principles; it does not describe
 implemented behavior.
 
 ## Strategic reorientation
 
 Canopy's long-term vision — write, negotiate structure, surface context — is
 unchanged. The current implementation remains a projectional editor with CRDT
-collaboration. The near-term product direction, however, shifts primary
-development effort toward a **human-centered personal knowledge environment**
-whose initial wedge is resumable technical project memory for developers and
-researchers.
+collaboration. Near-term primary development effort shifts to a
+**human-centered personal knowledge environment** whose initial wedge is
+resumable technical project memory for developers and researchers.
 
-The projectional editor is preserved in maintenance and proving-ground mode. It
-is not abandoned: its incremental, collaborative, and multi-representation
-capabilities remain available when the product needs them. The
-product-development priority, however, is the knowledge environment. The
-editor's role will be reconsidered once the knowledge environment has produced
-measurable product evidence.
+The projectional editor is preserved in maintenance and proving-ground mode.
+Its incremental, collaborative, and multi-representation capabilities remain
+available. The editor's role will be reconsidered once the knowledge
+environment has produced measurable product evidence.
 
 ## Initial wedge: resumable technical project memory
 
-Technical work — a codebase, a research thread, a multi-session analysis —
-loses continuity every time a person stops and restarts. Today, resumption is
-manual: the person rereads, reorients, and reconstructs the state that was
-obvious last time. The initial wedge is a tool that captures enough semantic
+Technical work loses continuity every time a person stops and restarts.
+Resumption is manual: the person rereads, reorients, and reconstructs the
+state that was obvious last time. The initial wedge captures enough semantic
 activity during a work session that the same person can resume from a
-checkpoint rather than from cold memory; shared authority and collaborative
-resumption remain separate product questions.
+checkpoint rather than cold memory.
 
-The wedge is deliberately narrow:
+Deliberately narrow:
 
-- **Project-scoped.** One work context at a time (one repository, one research
-  thread, one analysis), not system-wide surveillance of everything a person
-  does.
+- **Project-scoped.** Capture is limited to one explicit work context at a time.
 - **Integrated with tools already in use.** Capture happens through an existing
-  agent runtime during technical work and requires no new always-on background
-  process.
-- **Resume-first.** The first useful output is "where did I leave off, and
-  what was I doing," not a full knowledge graph.
+  agent runtime; no new always-on background process.
+- **Resume-first.** The first useful output is "where did I leave off," not a
+  full knowledge graph.
 
 ## Core loop: Capture → checkpoint → Resume
 
@@ -50,162 +42,120 @@ Capture semantic activity
     → ...
 ```
 
-Three stages, each with a distinct authority boundary.
+**Capture** observes semantic activity — what the person was doing at the
+level of intent and outcome, not raw keystrokes. Project-scoped, opt-in.
+Observes tool invocations, proposals, file-level changes, and session
+transitions with stable identity and provenance.
 
-**Capture** observes semantic activity during a work session. Semantic means
-"what the person was doing at the level of intent and outcome," not raw
-keystrokes or screen pixels. Capture is project-scoped, opt-in, and under the
-person's control. It observes tool invocations, proposals, file-level changes,
-and session transitions — the activity that has project meaning — and records
-them with stable identity and provenance.
+**Checkpoint** records goals, decisions, open questions, and next actions the
+person wants to encounter again. Anchors are human-authored or explicitly
+accepted; the system does not infer decisions from an agent transcript. A
+deterministic reducer organizes accepted anchors so the same inputs produce
+the same state.
 
-**Checkpoint** records the goals, decisions, open questions, and next actions
-the person wants to encounter again. In the first slice, those anchors are
-human-authored or explicitly accepted; the system does not infer decisions
-from an agent transcript. A deterministic reducer selects and organizes the
-accepted anchors, so the same activity and checkpoint records produce the same
-state. Later slices may add semantic or generated candidates, subject to
-review gates.
-
-**Resume** reconstructs orientation from the latest checkpoint plus any new
-activity since the checkpoint. It is a derived view that renders what the
-checkpoint says, supplemented by what has happened since, while leaving the
-checkpoint unchanged.
+**Resume** reconstructs orientation from the latest checkpoint plus new
+activity since. A derived view over the checkpoint, supplemented by
+subsequent activity, leaving the checkpoint unchanged.
 
 ## Semantic activity, not surveillance
 
-Capture is explicitly semantic and project-scoped. The boundary between
-semantic activity and surveillance is drawn by what the capture system is
-allowed to observe:
+The boundary is what capture is allowed to observe:
 
-- **Captured:** tool invocations with their declared identity, proposals with
-  their base revision and outcome, file-level changes attributed to a session,
-  session lifecycle transitions (start, fork, compaction, end), and the
-  declared identity of the model or agent involved.
-- **Not captured in the first slice:** raw keyboard or screen input, system
-  prompts, context-file contents, hidden reasoning traces, credentials or API
-  keys, arbitrary full tool output, and anything the person has not opted in
-  to.
+| Captured | Not captured in first slice |
+|---|---|
+| Tool invocations with declared identity | Raw keyboard or screen input |
+| Proposals with base revision and outcome | System prompts, context-file contents |
+| File-level changes attributed to a session | Hidden reasoning traces |
+| Session lifecycle (start, fork, compaction, end) | Credentials or API keys |
+| Declared model/agent identity | Arbitrary full tool output |
+| | Anything not opted in |
 
-Capture candidates — proposed additions to curated memory — are not themselves
-authoritative. A candidate becomes curated memory only after the person, or a
-deterministic policy the person chose, accepts it. The no-duplicate-entry
-principle applies at ingestion: replaying an activity event with the same
-stable identity must not create another ledger entry or another accepted
-memory.
+Capture candidates are not authoritative. A candidate becomes curated memory
+only after the person, or a deterministic policy the person chose, accepts it.
+Replay with the same stable identity must not create a duplicate entry.
 
 ## Authority and provenance
 
-Three distinct authorities coexist, and the boundaries between them are
-enforced, not advisory.
+Three distinct authorities with enforced boundaries:
 
-1. **The agent runtime owns the conversation session.** Prompt history, model
-   responses, tool invocations, and session persistence live in the agent
-   runtime's session store. The agent runtime is authoritative for what the
-   model saw and said.
-2. **The knowledge environment owns imported activity and curated memory.**
-   Once activity is imported — with stable identity, idempotent replay, and
-   provenance — it belongs to the knowledge environment's store. Curated
-   memory derived from that activity also belongs here.
-3. **The person owns decisions about what to capture, what to keep, and what
-   to delete.** Capture is opt-in. Curated memory is inspectable and
-   correctable. Deletion is explicit and honored.
+1. **Agent runtime** owns the conversation session — prompt history, model
+   responses, tool invocations, persistence. Authoritative for what the model
+   saw and said.
+2. **Knowledge environment** owns imported activity and curated memory, once
+   imported with stable identity, idempotent replay, and provenance.
+3. **Person** owns decisions about what to capture, keep, and delete. Capture
+   is opt-in; curated memory is inspectable and correctable; deletion is
+   explicit.
 
-Provenance travels with every record: its source session, source event, actor,
-ancestry, and relevant document revision when one exists. Records that lack
-the provenance required for their event kind are rejected at the boundary.
+Provenance travels with every record: source session, source event, actor,
+ancestry, and relevant document revision. Records lacking required provenance
+are rejected.
 
 ## Local ownership and privacy
 
 Canopy-owned activity data, curated memory, and checkpoints live on the
-person's devices. There is no required external service and the capture path
-must not transmit another copy of agent-session data. Any later synchronization
-must preserve local ownership and pass its own collaboration and deletion
-review.
+person's devices. No required external service; capture must not transmit
+another copy of agent-session data. Any later synchronization must preserve
+local ownership and pass its own collaboration and deletion review.
 
 The first slice makes no provider call. The agent runtime may already use an
-external model under its own policy, but capture adds no provider disclosure of
-its own. A later provider-assisted feature requires a separate data-egress and
+external model under its own policy, but capture adds no provider disclosure.
+A later provider-assisted feature requires a separate data-egress and
 product-value gate.
 
-## Deterministic fixed baseline before semantic or generated behavior
+These rules are specific applications of the
+[human-centered product principles](human-centered-product-principles.md).
 
-Every semantic or generated behavior must pass through a deterministic fixed
-baseline before it can be trusted as product.
+## Deterministic baseline before semantic or generated behavior
 
-- The activity reducer is deterministic. The same input events produce the
-  same checkpoint, every time, with no provider call.
-- The Resume view is deterministic over a fixed checkpoint plus a fixed event
+- The activity reducer is deterministic. Same inputs → same checkpoint, no
+  provider call.
+- The Resume view is deterministic over a fixed checkpoint plus fixed event
   log. No generated summarization in the first slice.
-- A fixed, inspectable transcript representing a work session is the first
-  acceptance artifact. The Resume View renders that transcript faithfully
-  before any semantic capture, provider call, or generated summary is
-  introduced.
+- A fixed, inspectable transcript is the first acceptance artifact. The Resume
+  view renders it faithfully before any semantic capture, provider call, or
+  generated summary.
 
-Semantic capture candidates and generated summaries are introduced only after
-the fixed baseline is proven correct, inspected, and accepted.
+Semantic candidates and generated summaries remain out of scope until this
+baseline is proven correct, inspected, and accepted.
 
 ## Generated UI: disposable projection, never authority
 
-Generative or adaptive UI — including generated Resume views — is a
-disposable projection over curated memory. It is never itself knowledge
-authority. The rules carried forward from the existing generative UI
-direction:
+Generative or adaptive UI is a disposable projection over curated memory. It
+cannot mutate authoritative records directly, and rejected output changes no
+committed state. Authoritative changes require the proposal and commit boundary;
+the fixed deterministic view remains available.
 
-- Generated output cannot mutate curated memory or activity records directly.
-- Any mutation of authoritative state flows through the proposal and
-  commit boundary.
-- A failed or rejected generated view must not advance committed state.
-- The person can always revert to the fixed deterministic view.
+## Review gates
 
-## Review gates and go-no-go conditions
-
-The shift to PKE as near-term primary direction is conditional. The following
-gates must pass before further product investment is justified.
-
-### First-slice gate (exit of the first plan)
+### First-slice gate
 
 - A fixed transcript of representative activity events exists and is
   inspectable.
-- A Resume View renders the fixed transcript as a chronological activity list
-  plus a checkpoint summary.
-- The rendering is deterministic: the same transcript produces the same view
-  every time, with no provider call.
-- A person unfamiliar with the transcript can read the Resume View and
-  correctly answer "what was this session doing, and where did it leave off"
-  within a predeclared bound, and can trace each answer to source activity.
+- A Resume view renders it as a chronological activity list plus checkpoint
+  summary.
+- Rendering is deterministic: same transcript → same view, no provider call.
+- A person unfamiliar with the transcript can read the view and correctly
+  answer "what was this session doing, and where did it leave off" within a
+  predeclared bound, tracing each answer to source activity.
 
-### Product-evidence gate (before expanding beyond the first slice)
+### Product-evidence gate
 
-- At least one external developer or researcher uses the Resume View as part
-  of their actual work across multiple sessions.
-- Resumption time — measured from "opened the tool" to "oriented on current
-  state" — is measurably shorter than the person's unaided baseline.
+- At least one external developer or researcher uses the Resume view during
+  actual work across multiple sessions.
+- Resumption time, measured from opening the tool to orientation, is shorter
+  than the person's unaided baseline.
 - The person can name at least one specific decision or claim surfaced by the
-  tool that they would otherwise have had to reconstruct manually.
+  tool they would otherwise have reconstructed manually.
 
 If the product-evidence gate does not pass, the direction is reconsidered.
-Projectional-editor development may return to primary priority, or a narrower
-knowledge-environment hypothesis may be tested; the evidence decides rather
-than this document predetermining the outcome.
-
-## Relationship to existing direction documents
-
-The PKE direction does not replace the product vision. It changes the current
-priority and applies existing principles to a narrower wedge:
-
-- The [product vision](product-vision.md) remains the long-term destination.
-- The first slice treats an external agent runtime as a read-only capture
-  source. It does not require Canopy to own an agent loop or grant an agent
-  mutation authority.
-- The [human-centered product principles](human-centered-product-principles.md)
-  continue to govern all product behavior. The PKE direction is a specific
-  application of those principles to a new initial wedge.
+Evidence decides rather than this document predetermining the outcome.
 
 ## Related documentation
 
-- [Product Vision](product-vision.md) — the long-term destination.
-- [Human-centered product principles](human-centered-product-principles.md) —
-  canonical behavior invariants.
-- [Pi session activity → Resume view prototype](../plans/2026-07-16-pi-activity-capture-resume-prototype.md)
-  — first concrete slice.
+The [product vision](product-vision.md) remains the long-term destination, and
+[human-centered product principles](human-centered-product-principles.md) govern
+this direction. The first slice treats the external agent runtime as a
+read-only source; Canopy neither owns its loop nor grants it mutation authority.
+Implementation starts with the
+[Pi session activity → Resume view prototype](../plans/2026-07-16-pi-activity-capture-resume-prototype.md).

--- a/docs/architecture/personal-knowledge-environment-direction.md
+++ b/docs/architecture/personal-knowledge-environment-direction.md
@@ -35,7 +35,7 @@ Deliberately narrow:
 
 ## Core loop: Capture → checkpoint → Resume
 
-```
+```text
 Capture semantic activity
     → checkpoint curated memory
     → Resume from checkpoint in next session
@@ -87,9 +87,8 @@ Three distinct authorities with enforced boundaries:
    is opt-in; curated memory is inspectable and correctable; deletion is
    explicit.
 
-Provenance travels with every record: source session, source event, actor,
-ancestry, and relevant document revision. Records lacking required provenance
-are rejected.
+Provenance accompanies every activity and memory record so Resume claims can
+be traced to their source.
 
 ## Local ownership and privacy
 

--- a/docs/architecture/personal-knowledge-environment-direction.md
+++ b/docs/architecture/personal-knowledge-environment-direction.md
@@ -1,160 +1,102 @@
 # Personal knowledge environment direction
 
-**Status:** near-term primary product direction. This document states the
-strategic reorientation and governing principles; it does not describe
-implemented behavior.
+**Status:** near-term primary product direction. This document states strategy
+and product invariants; it does not describe implemented behavior.
 
-## Strategic reorientation
+## Decision
 
 Canopy's long-term vision — write, negotiate structure, surface context — is
 unchanged. The current implementation remains a projectional editor with CRDT
-collaboration. Near-term primary development effort shifts to a
-**human-centered personal knowledge environment** whose initial wedge is
-resumable technical project memory for developers and researchers.
+collaboration. Near-term development shifts to a **human-centered personal
+knowledge environment**, beginning with resumable technical project memory for
+developers and researchers.
 
-The projectional editor is preserved in maintenance and proving-ground mode.
-Its incremental, collaborative, and multi-representation capabilities remain
-available. The editor's role will be reconsidered once the knowledge
-environment has produced measurable product evidence.
+The projectional editor remains in maintenance and proving-ground mode. Its
+incremental, collaborative, and multi-representation capabilities stay
+available when product evidence calls for them.
 
-## Initial wedge: resumable technical project memory
+## Initial wedge
 
-Technical work loses continuity every time a person stops and restarts.
-Resumption is manual: the person rereads, reorients, and reconstructs the
-state that was obvious last time. The initial wedge captures enough semantic
-activity during a work session that the same person can resume from a
-checkpoint rather than cold memory.
+Technical work loses continuity across interruptions. The first product should
+help a person resume one explicit project without rereading an entire history.
+It is deliberately:
 
-Deliberately narrow:
+- **Project-scoped:** one selected work context, never system-wide surveillance.
+- **Integrated:** it captures semantic events from tools already in use.
+- **Resume-first:** it restores orientation before attempting a knowledge graph.
 
-- **Project-scoped.** Capture is limited to one explicit work context at a time.
-- **Integrated with tools already in use.** Capture happens through an existing
-  agent runtime; no new always-on background process.
-- **Resume-first.** The first useful output is "where did I leave off," not a
-  full knowledge graph.
-
-## Core loop: Capture → checkpoint → Resume
+## Capture → checkpoint → Resume
 
 ```text
 Capture semantic activity
-    → checkpoint curated memory
-    → Resume from checkpoint in next session
-    → ...
+    → checkpoint accepted anchors
+    → Resume in the next session
 ```
 
-**Capture** observes semantic activity — what the person was doing at the
-level of intent and outcome, not raw keystrokes. Project-scoped, opt-in.
-Observes tool invocations, proposals, file-level changes, and session
-transitions with stable identity and provenance.
+| Stage | Role | Authority |
+|---|---|---|
+| Capture | Record intent, outcomes, file changes, and session transitions with stable identity and provenance. | Imported activity remains evidence, not curated knowledge. |
+| Checkpoint | Preserve goals, decisions, open questions, and next actions. | Anchors are human-authored or explicitly accepted; agent prose cannot promote itself. |
+| Resume | Combine the latest checkpoint with subsequent activity. | The view is derived and cannot rewrite its sources. |
 
-**Checkpoint** records goals, decisions, open questions, and next actions the
-person wants to encounter again. Anchors are human-authored or explicitly
-accepted; the system does not infer decisions from an agent transcript. A
-deterministic reducer organizes accepted anchors so the same inputs produce
-the same state.
+Replay of the same stable activity identity is a no-op.
 
-**Resume** reconstructs orientation from the latest checkpoint plus new
-activity since. A derived view over the checkpoint, supplemented by
-subsequent activity, leaving the checkpoint unchanged.
+## Capture boundary
 
-## Semantic activity, not surveillance
-
-The boundary is what capture is allowed to observe:
-
-| Captured | Not captured in first slice |
+| Included | Excluded from the first slice |
 |---|---|
-| Tool invocations with declared identity | Raw keyboard or screen input |
-| Proposals with base revision and outcome | System prompts, context-file contents |
-| File-level changes attributed to a session | Hidden reasoning traces |
-| Session lifecycle (start, fork, compaction, end) | Credentials or API keys |
-| Declared model/agent identity | Arbitrary full tool output |
-| | Anything not opted in |
+| Tool invocations and outcomes | Raw keyboard, screen, clipboard, or microphone capture |
+| Revision-bound proposals | System prompts and context-file contents |
+| File changes attributed to the session | Hidden reasoning and credentials |
+| Session lifecycle and declared agent identity | Arbitrary full tool output or anything not opted in |
 
-Capture candidates are not authoritative. A candidate becomes curated memory
-only after the person, or a deterministic policy the person chose, accepts it.
-Replay with the same stable identity must not create a duplicate entry.
+A capture candidate becomes curated memory only after the person, or a
+revocable deterministic policy they chose, accepts it. The canonical
+[human-centered product principles](human-centered-product-principles.md)
+supply the governing rules for consent, pacing, accessibility, and reversal.
 
 ## Authority and provenance
 
-Three distinct authorities with enforced boundaries:
-
-1. **Agent runtime** owns the conversation session — prompt history, model
-   responses, tool invocations, persistence. Authoritative for what the model
-   saw and said.
-2. **Knowledge environment** owns imported activity and curated memory, once
-   imported with stable identity, idempotent replay, and provenance.
-3. **Person** owns decisions about what to capture, keep, and delete. Capture
-   is opt-in; curated memory is inspectable and correctable; deletion is
-   explicit.
+| Owner | Owns |
+|---|---|
+| Agent runtime | Conversation history, model responses, tool invocations, and session persistence |
+| Knowledge environment | Bounded imported activity and accepted curated memory |
+| Person | What to capture, accept, correct, retain, and delete |
 
 Provenance accompanies every activity and memory record so Resume claims can
 be traced to their source.
 
-## Local ownership and privacy
+## Local ownership
 
-Canopy-owned activity data, curated memory, and checkpoints live on the
-person's devices. No required external service; capture must not transmit
-another copy of agent-session data. Any later synchronization must preserve
-local ownership and pass its own collaboration and deletion review.
+Canopy-owned activity, checkpoints, and curated memory stay on the person's
+devices. The capture path adds no provider call or second transmission of agent
+session data. Any later provider use or synchronization requires a separate
+data-egress, collaboration, deletion, and product-value review.
 
-The first slice makes no provider call. The agent runtime may already use an
-external model under its own policy, but capture adds no provider disclosure.
-A later provider-assisted feature requires a separate data-egress and
-product-value gate.
+## Fixed baseline before generation
 
-These rules are specific applications of the
-[human-centered product principles](human-centered-product-principles.md).
-
-## Deterministic baseline before semantic or generated behavior
-
-- The activity reducer is deterministic. Same inputs → same checkpoint, no
-  provider call.
-- The Resume view is deterministic over a fixed checkpoint plus fixed event
-  log. No generated summarization in the first slice.
-- A fixed, inspectable transcript is the first acceptance artifact. The Resume
-  view renders it faithfully before any semantic capture, provider call, or
-  generated summary.
+The first acceptance artifact is a fixed, inspectable transcript rendered as
+chronology and a deterministic Resume view. The same inputs must produce the
+same checkpoint and view without a provider call.
 
 Semantic candidates and generated summaries remain out of scope until this
-baseline is proven correct, inspected, and accepted.
+baseline is correct, inspected, and accepted. Generative or adaptive views are
+disposable projections: they cannot mutate authoritative records, rejected
+output changes no committed state, and the fixed view remains available.
 
-## Generated UI: disposable projection, never authority
+## Gates
 
-Generative or adaptive UI is a disposable projection over curated memory. It
-cannot mutate authoritative records directly, and rejected output changes no
-committed state. Authoritative changes require the proposal and commit boundary;
-the fixed deterministic view remains available.
+| Gate | Pass condition |
+|---|---|
+| First slice | An unfamiliar evaluator identifies the session goal, verified outcome, unresolved question or next step, and source evidence within a predeclared bound. Rendering is deterministic. |
+| Product evidence | An external developer or researcher uses Resume during actual work across multiple sessions; time from opening the tool to orientation improves over their unaided baseline; at least one useful surfaced claim remains traceable to its source. |
 
-## Review gates
-
-### First-slice gate
-
-- A fixed transcript of representative activity events exists and is
-  inspectable.
-- A Resume view renders it as a chronological activity list plus checkpoint
-  summary.
-- Rendering is deterministic: same transcript → same view, no provider call.
-- A person unfamiliar with the transcript can read the view and correctly
-  answer "what was this session doing, and where did it leave off" within a
-  predeclared bound, tracing each answer to source activity.
-
-### Product-evidence gate
-
-- At least one external developer or researcher uses the Resume view during
-  actual work across multiple sessions.
-- Resumption time, measured from opening the tool to orientation, is shorter
-  than the person's unaided baseline.
-- The person can name at least one specific decision or claim surfaced by the
-  tool they would otherwise have reconstructed manually.
-
-If the product-evidence gate does not pass, the direction is reconsidered.
-Evidence decides rather than this document predetermining the outcome.
+If the product-evidence gate fails, the direction is reconsidered. Evidence may
+justify a narrower hypothesis or renewed projectional-editor investment.
 
 ## Related documentation
 
 The [product vision](product-vision.md) remains the long-term destination, and
 [human-centered product principles](human-centered-product-principles.md) govern
-this direction. The first slice treats the external agent runtime as a
-read-only source; Canopy neither owns its loop nor grants it mutation authority.
-Implementation starts with the
+this direction. The first implementation is the
 [Pi session activity → Resume view prototype](../plans/2026-07-16-pi-activity-capture-resume-prototype.md).

--- a/docs/architecture/personal-knowledge-environment-direction.md
+++ b/docs/architecture/personal-knowledge-environment-direction.md
@@ -1,0 +1,211 @@
+# Personal knowledge environment direction
+
+**Status:** near-term primary product direction. This document states the
+strategic reorientation and the principles that govern it. It does not describe
+implemented behavior.
+
+## Strategic reorientation
+
+Canopy's long-term vision — write, negotiate structure, surface context — is
+unchanged. The current implementation remains a projectional editor with CRDT
+collaboration. The near-term product direction, however, shifts primary
+development effort toward a **human-centered personal knowledge environment**
+whose initial wedge is resumable technical project memory for developers and
+researchers.
+
+The projectional editor is preserved in maintenance and proving-ground mode. It
+is not abandoned: its incremental, collaborative, and multi-representation
+capabilities remain available when the product needs them. The
+product-development priority, however, is the knowledge environment. The
+editor's role will be reconsidered once the knowledge environment has produced
+measurable product evidence.
+
+## Initial wedge: resumable technical project memory
+
+Technical work — a codebase, a research thread, a multi-session analysis —
+loses continuity every time a person stops and restarts. Today, resumption is
+manual: the person rereads, reorients, and reconstructs the state that was
+obvious last time. The initial wedge is a tool that captures enough semantic
+activity during a work session that the same person can resume from a
+checkpoint rather than from cold memory; shared authority and collaborative
+resumption remain separate product questions.
+
+The wedge is deliberately narrow:
+
+- **Project-scoped.** One work context at a time (one repository, one research
+  thread, one analysis), not system-wide surveillance of everything a person
+  does.
+- **Integrated with tools already in use.** Capture happens through an existing
+  agent runtime during technical work and requires no new always-on background
+  process.
+- **Resume-first.** The first useful output is "where did I leave off, and
+  what was I doing," not a full knowledge graph.
+
+## Core loop: Capture → checkpoint → Resume
+
+```
+Capture semantic activity
+    → checkpoint curated memory
+    → Resume from checkpoint in next session
+    → ...
+```
+
+Three stages, each with a distinct authority boundary.
+
+**Capture** observes semantic activity during a work session. Semantic means
+"what the person was doing at the level of intent and outcome," not raw
+keystrokes or screen pixels. Capture is project-scoped, opt-in, and under the
+person's control. It observes tool invocations, proposals, file-level changes,
+and session transitions — the activity that has project meaning — and records
+them with stable identity and provenance.
+
+**Checkpoint** records the goals, decisions, open questions, and next actions
+the person wants to encounter again. In the first slice, those anchors are
+human-authored or explicitly accepted; the system does not infer decisions
+from an agent transcript. A deterministic reducer selects and organizes the
+accepted anchors, so the same activity and checkpoint records produce the same
+state. Later slices may add semantic or generated candidates, subject to
+review gates.
+
+**Resume** reconstructs orientation from the latest checkpoint plus any new
+activity since the checkpoint. It is a derived view that renders what the
+checkpoint says, supplemented by what has happened since, while leaving the
+checkpoint unchanged.
+
+## Semantic activity, not surveillance
+
+Capture is explicitly semantic and project-scoped. The boundary between
+semantic activity and surveillance is drawn by what the capture system is
+allowed to observe:
+
+- **Captured:** tool invocations with their declared identity, proposals with
+  their base revision and outcome, file-level changes attributed to a session,
+  session lifecycle transitions (start, fork, compaction, end), and the
+  declared identity of the model or agent involved.
+- **Not captured in the first slice:** raw keyboard or screen input, system
+  prompts, context-file contents, hidden reasoning traces, credentials or API
+  keys, arbitrary full tool output, and anything the person has not opted in
+  to.
+
+Capture candidates — proposed additions to curated memory — are not themselves
+authoritative. A candidate becomes curated memory only after the person, or a
+deterministic policy the person chose, accepts it. The no-duplicate-entry
+principle applies at ingestion: replaying an activity event with the same
+stable identity must not create another ledger entry or another accepted
+memory.
+
+## Authority and provenance
+
+Three distinct authorities coexist, and the boundaries between them are
+enforced, not advisory.
+
+1. **The agent runtime owns the conversation session.** Prompt history, model
+   responses, tool invocations, and session persistence live in the agent
+   runtime's session store. The agent runtime is authoritative for what the
+   model saw and said.
+2. **The knowledge environment owns imported activity and curated memory.**
+   Once activity is imported — with stable identity, idempotent replay, and
+   provenance — it belongs to the knowledge environment's store. Curated
+   memory derived from that activity also belongs here.
+3. **The person owns decisions about what to capture, what to keep, and what
+   to delete.** Capture is opt-in. Curated memory is inspectable and
+   correctable. Deletion is explicit and honored.
+
+Provenance travels with every record: its source session, source event, actor,
+ancestry, and relevant document revision when one exists. Records that lack
+the provenance required for their event kind are rejected at the boundary.
+
+## Local ownership and privacy
+
+Canopy-owned activity data, curated memory, and checkpoints live on the
+person's devices. There is no required external service and the capture path
+must not transmit another copy of agent-session data. Any later synchronization
+must preserve local ownership and pass its own collaboration and deletion
+review.
+
+The first slice makes no provider call. The agent runtime may already use an
+external model under its own policy, but capture adds no provider disclosure of
+its own. A later provider-assisted feature requires a separate data-egress and
+product-value gate.
+
+## Deterministic fixed baseline before semantic or generated behavior
+
+Every semantic or generated behavior must pass through a deterministic fixed
+baseline before it can be trusted as product.
+
+- The activity reducer is deterministic. The same input events produce the
+  same checkpoint, every time, with no provider call.
+- The Resume view is deterministic over a fixed checkpoint plus a fixed event
+  log. No generated summarization in the first slice.
+- A fixed, inspectable transcript representing a work session is the first
+  acceptance artifact. The Resume View renders that transcript faithfully
+  before any semantic capture, provider call, or generated summary is
+  introduced.
+
+Semantic capture candidates and generated summaries are introduced only after
+the fixed baseline is proven correct, inspected, and accepted.
+
+## Generated UI: disposable projection, never authority
+
+Generative or adaptive UI — including generated Resume views — is a
+disposable projection over curated memory. It is never itself knowledge
+authority. The rules carried forward from the existing generative UI
+direction:
+
+- Generated output cannot mutate curated memory or activity records directly.
+- Any mutation of authoritative state flows through the proposal and
+  commit boundary.
+- A failed or rejected generated view must not advance committed state.
+- The person can always revert to the fixed deterministic view.
+
+## Review gates and go-no-go conditions
+
+The shift to PKE as near-term primary direction is conditional. The following
+gates must pass before further product investment is justified.
+
+### First-slice gate (exit of the first plan)
+
+- A fixed transcript of representative activity events exists and is
+  inspectable.
+- A Resume View renders the fixed transcript as a chronological activity list
+  plus a checkpoint summary.
+- The rendering is deterministic: the same transcript produces the same view
+  every time, with no provider call.
+- A person unfamiliar with the transcript can read the Resume View and
+  correctly answer "what was this session doing, and where did it leave off"
+  within a predeclared bound, and can trace each answer to source activity.
+
+### Product-evidence gate (before expanding beyond the first slice)
+
+- At least one external developer or researcher uses the Resume View as part
+  of their actual work across multiple sessions.
+- Resumption time — measured from "opened the tool" to "oriented on current
+  state" — is measurably shorter than the person's unaided baseline.
+- The person can name at least one specific decision or claim surfaced by the
+  tool that they would otherwise have had to reconstruct manually.
+
+If the product-evidence gate does not pass, the direction is reconsidered.
+Projectional-editor development may return to primary priority, or a narrower
+knowledge-environment hypothesis may be tested; the evidence decides rather
+than this document predetermining the outcome.
+
+## Relationship to existing direction documents
+
+The PKE direction does not replace the product vision. It changes the current
+priority and applies existing principles to a narrower wedge:
+
+- The [product vision](product-vision.md) remains the long-term destination.
+- The first slice treats an external agent runtime as a read-only capture
+  source. It does not require Canopy to own an agent loop or grant an agent
+  mutation authority.
+- The [human-centered product principles](human-centered-product-principles.md)
+  continue to govern all product behavior. The PKE direction is a specific
+  application of those principles to a new initial wedge.
+
+## Related documentation
+
+- [Product Vision](product-vision.md) — the long-term destination.
+- [Human-centered product principles](human-centered-product-principles.md) —
+  canonical behavior invariants.
+- [Pi session activity → Resume view prototype](../plans/2026-07-16-pi-activity-capture-resume-prototype.md)
+  — first concrete slice.

--- a/docs/architecture/product-vision.md
+++ b/docs/architecture/product-vision.md
@@ -74,7 +74,7 @@ opt-in and quiet by default.
 
 ### Model A: context while writing
 
-When the person starts writing, relevant past posts can surface with
+Only after the person opts in may relevant past posts surface with
 reasons. "I've considered this before" is offered, not imposed. Beyond
 passive recall: "this is where you left off last time." The person
 controls whether and when this appears.

--- a/docs/architecture/product-vision.md
+++ b/docs/architecture/product-vision.md
@@ -1,19 +1,29 @@
-# Product vision: write, structure, surface
+# Product vision: write, negotiate structure, surface context
 
 The full product vision for Canopy — beyond the code editor, toward a
-personal knowledge environment where writing is the only action, structure
-emerges automatically, and the right information surfaces when needed.
+personal thinking workbench where writing is the primary action, provisional
+structure emerges as revisable hypotheses, and relevant context is offered
+with reasons and under the person's control.
 
-## The Core Loop
+See [Human-centered product principles](human-centered-product-principles.md)
+for the behavior invariants this vision is designed around. The
+[Personal Knowledge Environment direction](personal-knowledge-environment-direction.md)
+records the current product priority and its first resumable-project-memory
+wedge.
+
+## The core loop
 
 ```
-Write → auto-structure → right info surfaces → better writing → ...
+Write → provisional structure → relevant context with reasons → better thinking → ...
 ```
 
-The user never organizes. They write. The system maintains meaning
-incrementally. When the user needs information, it's already there.
+The person is not required to organize before writing. They may organize
+explicitly whenever that helps. Structure also emerges as provisional,
+navigable hypotheses that the person can inspect, correct, pin, suppress, or
+replace. When context is needed, the system offers relevant context with reasons
+— one candidate view the person can accept or decline.
 
-## Input: The "Post" Action
+## Input: the 'post' action
 
 The reason posting on Twitter feels lightweight is that it requires no
 structure — no title, no categories, no format. You write and send.
@@ -23,58 +33,67 @@ inputs must be as effortless as text. Writing text, pasting a URL,
 dropping an image, inserting code, attaching a file — all are the same
 single action: **posting**.
 
-There is one input field at all times, and the system determines
-content type automatically.
+The default capture surface is one input field. The system proposes a content
+type and the person can correct it.
 
-There are no concepts like "new document" or "new task." There is only
-**post**.
+Named documents, tasks, and collections may be created or emerge later, but
+none is required before capture. The lightweight default action is **post**.
 
-## Storage: Automatic Structuring
+## Storage: provisional structuring
 
 Three layers, each building on the last.
 
-### Layer 1: Automatic Linking
+### Layer 1: proposed linking
 
 The system detects relationships between posts — semantic similarity,
-shared references, common keywords — and connects them without explicit
-links. Users do not "create" links; they **discover** them.
+shared references, common keywords — and proposes links. The person
+can accept, name, correct, or suppress each one. Explicit
+user-authored links remain first-class and are never replaced by
+inferred ones.
 
-### Layer 2: Automatic Clustering
+### Layer 2: proposed clustering
 
 As posts accumulate, similar ones form groups. Clusters like
-"MoonBit-related," "reading notes," or "shopping" emerge organically.
-Users may name them, but clusters function without labels. These are
-not static folders but dynamic, evolving **islands**.
+"MoonBit-related," "reading notes," or "shopping" emerge as proposals.
+The person can name them, pin them, merge them, or dismiss them.
+Clusters function without labels but remain negotiable. These are not
+static folders but dynamic, revisable **islands**.
 
-### Layer 3: Pattern Detection
+### Layer 3: pattern detection
 
 The system identifies meta-level patterns: "posts of this type appear
 every Monday," "no updates on this project for three weeks," "these
-two topics frequently appear together."
+two topics frequently appear together." Patterns are surfaced with
+reasons and remain one view among many — they do not replace
+chronological or user-defined ordering.
 
-## Output: returning the right information
+## Output: offering relevant context
 
-Three models, depending on when and how information returns.
+Three models, depending on when and how context returns. All are
+opt-in and quiet by default.
 
-### Model A: Return While Writing
+### Model A: context while writing
 
-When the user starts writing, relevant past posts surface in real time.
-"I've considered this before" is automatically brought up. Beyond
-passive recall: "this is where you left off last time."
+When the person starts writing, relevant past posts can surface with
+reasons. "I've considered this before" is offered, not imposed. Beyond
+passive recall: "this is where you left off last time." The person
+controls whether and when this appears.
 
-### Model B: Return When Asked
+### Model B: context when asked
 
-Users write questions into the same input field: "What was the title of
+People write questions into the same input field: "What was the title of
 that book?" or "What was the conclusion of last month's project?" The
-system constructs answers from past posts — a personal search engine
-that ranks by meaning rather than keywords.
+system constructs answers from past posts — a search interface that
+ranks by meaning rather than keywords, with sources shown.
 
-### Model C: Return Proactively
+### Model C: context offered proactively
 
-The system initiates: "You marked this 'to be reviewed' three days ago
+The system can offer: "You marked this 'to be reviewed' three days ago
 but no conclusion reached," or "These two notes might be related."
-Unlike social media notifications, these continue and support the
-user's own thinking.
+Unlike engagement-optimized notifications, these are opt-in, quiet by
+default, and support the person's own thinking rather than competing
+for attention. Revisit frequency may influence ordering, while the
+person remains the authority on importance.
 
 ## Key design difference: writing to yourself
 
@@ -82,54 +101,58 @@ Twitter is for writing to others. This system is for **writing to
 yourself**.
 
 The timeline need not be chronological. In personal notes, the most
-recent item is not always the most important — the most **relevant**
-item at the current moment deserves priority.
-
-The default view orders posts by relevance to the present context, and
-chronological order becomes one filter among many.
+recent item is not always the most useful — a relevant item at the
+current moment may deserve priority. But relevance is one inspectable
+projection among chronological, pinned, and user-defined views. The
+person chooses.
 
 Instead of likes or retweets, there is **resurfacing**. When a past
-post is revisited, its importance increases, and related posts rise
-with it. Revisit frequency becomes a signal that feeds automatic
-structuring.
+post is revisited, its visibility in relevant-context views can
+increase. The person can inspect, reset, or suppress that signal.
 
-## The Cold Pitch
+## The cold pitch
 
 > **Canopy**
 >
 > Write. It structures itself.
 >
-> One input. No folders, no categories, no organizing. Just write —
-> text, code, links, images. The system parses, links, clusters, and
-> surfaces what you need, when you need it.
+> Structure emerges visibly and reversibly; you remain the author.
 >
-> Think of it as a second brain that thinks alongside you. It
-> remembers what you wrote, finds connections you missed, and brings
-> back the right context while you're writing — not after you search
-> for it.
+> One input. No mandatory folders, no required categories. Just write —
+> text, code, links, images. The system proposes links, clusters, and
+> relevant context with reasons — all inspectable, correctable, and
+> under your control.
+>
+> Think of it as a thinking workbench that remembers context without
+> speaking for you. It shows connections you can accept or dismiss,
+> offers relevant context while you're writing, and keeps your data
+> on your devices.
 >
 > Works across devices with no server — your thoughts sync peer-to-peer.
 
-## From Here to There
+## From here to there
 
-The code editor (lambda calculus, JSON) is the proving ground. Every
-piece of the product vision is validated first in the editor context:
+The code editor (lambda calculus, JSON) remains one proving ground for the
+product vision, but it is no longer a mandatory sequence for every product
+feature. The near-term Personal Knowledge Environment work validates
+capture and resumption directly, then reuses editor infrastructure only when
+it improves a named task.
 
-| Product feature | Editor equivalent | Status |
-|---|---|---|
-| Unified input | Text CRDT input | Done |
-| Auto-structuring | Incremental parsing + projection | Done |
-| Semantic linking | Name resolution, type inference | In progress |
-| Return while writing | Live inline evaluation | Next |
-| Return when asked | Egglog semantic queries | Planned |
-| Return proactively | Reactive triggers on semantic changes | Future |
-| Multi-device sync | CRDT peer-to-peer | Done |
-| Relevance ordering | Semantic-model-driven view selection | Future |
+| Product capability | Existing proving-ground evidence |
+|---|---|
+| Unified input | Text CRDT input and the local-first Posts prototype |
+| Provisional structuring | Incremental parsing and projection |
+| Semantic linking | Name resolution, type inference, and explained lexical retrieval |
+| Context while writing | Live inline evaluation and related-post retrieval |
+| Context when asked | Source-post retrieval |
+| Multi-device sync | CRDT peer-to-peer collaboration |
+| Multiple representations | Text, structure, timeline, and related-context views |
 
-Each row is a step from editor to product. The editor isn't a
-detour — it's the vertical slice that proves every layer works.
+These mappings are reusable evidence, not a product-development checklist. The
+[Personal Knowledge Environment direction](personal-knowledge-environment-direction.md)
+owns the current priority and its review gates.
 
-## Appendix: Technical Foundations
+## Appendix: Technical foundations
 
 How each product layer maps to Canopy's existing infrastructure.
 
@@ -139,11 +162,11 @@ recalculating affected relationships when new data arrives. Directly
 served by the reactive signal graph in `loom/incr`.
 
 **CRDT synchronization (event-graph-walker)** — The "stream of posts +
-automatic linking" model aligns with CRDT architecture. The event graph
+proposed linking" model aligns with CRDT architecture. The event graph
 provides multi-device sync with no central server. Write on your phone,
 links update on your laptop.
 
-**Semantic model (egglog)** — Automatic linking, clustering, and
+**Semantic model (egglog)** — Proposed linking, clustering, and
 retrieval are relational queries over meaning. Egglog's Datalog engine
 can express: `SimilarTo(post_a, post_b)`, `ReferencesUrl(post, url)`,
 `InCluster(post, cluster)`, `StaleReview(post, days)`.
@@ -158,7 +181,8 @@ all structured thought:
 
 ```
 Raw post (syntax)        →  text in the input field
-Linked post (semantics)  →  connections, clusters, types discovered
-Surfaced post (intent)   →  right info at the right time
-Understood (mental model) →  the system fits how you think
+Linked post (semantics)  →  connections, clusters, types proposed
+Offered post (intent)    →  relevant context with reasons, under user control
+Understood (orientation) →  the person chooses representations;
+                             the system does not claim their mental model
 ```

--- a/docs/architecture/vision-projectional-bridge.md
+++ b/docs/architecture/vision-projectional-bridge.md
@@ -99,10 +99,8 @@ intent.
 
 The structure-format IR problem is not "how to annotate trees."
 
-Program meaning must be explicit enough for projections to render it at
-multiple levels of abstraction. Building the semantic model (egglog + incr
-reactive graph) moves toward that goal; a tree annotation mechanism alone does
-not.
+Projections across abstraction levels require a shared explicit semantic model
+rather than separate encoded meanings.
 
 ### Editing is bidirectional
 

--- a/docs/architecture/vision-projectional-bridge.md
+++ b/docs/architecture/vision-projectional-bridge.md
@@ -2,6 +2,9 @@
 
 Why Canopy exists and what projectional editing is for.
 
+See [Human-centered product principles](human-centered-product-principles.md)
+for the behavior invariants this vision is designed around.
+
 ## The Gap
 
 You write `let double = (x) => x + x`. You know what it means: a
@@ -15,10 +18,10 @@ Every time you refactor, debug, or explain code, you are translating
 between your understanding and the tool's flat character buffer. This
 translation is the tax you pay for using a text editor.
 
-The gap is wider than it appears. Users have something in mind when
-they write — not always a concrete plan, but a wish, a thirst to
-alleviate a pain. They are good at judging bad products but terrible
-at articulating what they want in explicit words or images.
+The gap is wider than it appears. People often begin with a felt need rather
+than a concrete plan, and they may recognize a mismatch before they can describe
+the desired form. The interface should help them express and revise intent
+gradually instead of requiring a complete specification up front.
 
 Syntax-level editing forces this intention down through multiple
 abstraction layers before it reaches the machine:
@@ -28,10 +31,10 @@ Mental Model  →  Intent  →  Semantics  →  Syntax
   (felt)        (hidden)    (explicit)    (mechanical)
 ```
 
-Each translation loses fidelity. The distance between what the user
-wants and what they can manipulate (syntax) is too far. This is why
-programming is hard — not because logic is hard, but because the
-interface is at the wrong level.
+Each translation can lose fidelity. The distance between what the person wants
+and what they can manipulate in syntax is one source of programming difficulty.
+Representations at more useful abstraction levels can reduce that translation
+tax without pretending that the machine already knows the person's intent.
 
 ## The Bridge
 
@@ -49,21 +52,31 @@ Each representation brings the user one step closer to the thing they
 care about. Multiple representations of the same underlying semantic
 enable the user to work at whichever level fits their current thinking.
 
+The machine interpretations at each level — scope analysis, type
+inference, clustering, relevance ranking — are provisional, plural,
+visible, correctable, and reversible. They may preserve ambiguity
+rather than resolving it prematurely. The person chooses which
+representations to work with; the system does not claim the person's
+mental model.
+
 The goal is not just "multiple views of code." It is a **progressive
 bridge** from mechanical program to human understanding — transforming
 mere mechanical program into readable syntax, into explicit semantics,
 into understandable intention, and finally fitting into the user's
-mental model.
+chosen working representation.
 
-## The Unity of Computer
+## The unity of computer
 
-When the tool meets the user at their mental model — when they no
-longer translate between what they mean and what they type — the
-computer becomes part of the body. This feeling, the unity of computer,
-is the natural relationship between human mind and computer program
-achieved with ease.
+When the tool meets the user at their level of chosen representation —
+when they no longer translate between what they mean and what they
+type — the computer becomes part of the body. This feeling, the unity
+of computer, is the natural relationship between human mind and
+computer program achieved with ease.
 
-This is what Canopy is for.
+This is what Canopy is for. The system offers representations that
+bring the user closer to their intent, but it does not claim to hold
+the user's mental model. The person remains the authority over
+meaning.
 
 ## Implications for Design
 
@@ -86,10 +99,10 @@ intent.
 
 The structure-format IR problem is not "how to annotate trees."
 
-The real question is how to represent program meaning explicitly
-enough that projections can render from it at multiple levels of
-abstraction. Building the semantic model (egglog + incr reactive
-graph) gets us there; designing a tree annotation mechanism does not.
+Program meaning must be explicit enough for projections to render it at
+multiple levels of abstraction. Building the semantic model (egglog + incr
+reactive graph) moves toward that goal; a tree annotation mechanism alone does
+not.
 
 ### Editing is bidirectional
 

--- a/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
+++ b/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
@@ -1,0 +1,449 @@
+# Pi session activity → Resume view prototype
+
+**Status:** ready for Phase 0. Live transport and long-term storage remain
+separate follow-ups gated by the fixed prototype.
+
+## Why
+
+A developer or researcher who stops work on a technical project must later
+reconstruct the goal, verified outcomes, unresolved questions, and next step.
+The initial wedge of the
+[Personal Knowledge Environment direction](../architecture/personal-knowledge-environment-direction.md)
+is resumable technical project memory: capture work already expressed through
+an agent session, then restore orientation without requiring duplicate notes.
+
+Pi already persists the current conversation as a structured, branching JSONL
+session. The smallest falsifiable slice is therefore not a new capture daemon or
+a new MoonBit framework. It is an explicit import of a sanitized pi session
+into the existing browser product prototype, followed by a deterministic,
+source-backed Resume View. A live extension is considered only after that fixed
+view proves useful.
+
+## Scope
+
+In for the first slice:
+
+- `examples/web/` — reuse the existing local-first product prototype and Vite /
+  Playwright harness; add a separate Resume page rather than a new app.
+- A bounded pi session-v3 JSONL decoder and normalized activity model in pure
+  TypeScript.
+- A sanitized fixed fixture derived from a representative Canopy pi session.
+- A deterministic chronological view and Resume View over the same activity.
+- An explicit browser file-import path for a pi session snapshot.
+- Playwright coverage for provenance, branch selection, compaction preservation,
+  accessibility, and deterministic rendering.
+- A small orientation pilot comparing the Resume View with the chronological
+  fallback.
+
+Deferred until the fixed slice passes:
+
+- A project-local pi extension for capture policy and checkpoint markers.
+- Automatic or live delivery from pi to Canopy.
+- Canopy-owned durable activity storage, retention, and synchronization.
+- A MoonBit activity package or public API.
+- Semantic or generated checkpoint candidates.
+
+Out:
+
+- Raw keyboard, clipboard, microphone, or screen capture.
+- System prompts, context-file contents, hidden reasoning, credentials, API
+  keys, or provider payloads.
+- Moving raw user or assistant message bodies into the normalized activity
+  model without explicit excerpt selection and a fail-closed content check.
+- Persisting arbitrary full tool output in Canopy.
+- Treating assistant prose, compaction summaries, or generated UI as knowledge
+  authority.
+- Agent mutation authority over Canopy or pi sessions.
+- External provider calls.
+- System-wide or multi-project background capture.
+
+## Current state
+
+### Existing Canopy product prototype
+
+`examples/web/posts.html` already provides the least-wrong prototype host. It
+has one-field local capture, a chronological fallback, source-backed lexical
+retrieval, explicit ranking reasons, keyboard behavior, and Playwright tests.
+Its implementation is split across:
+
+- `examples/web/src/post-app.ts`
+- `examples/web/src/post-store.ts`
+- `examples/web/src/post-events.ts`
+- `examples/web/src/post-retrieval.ts`
+- `examples/web/tests/post-app.spec.ts`
+- `examples/web/vite.config.ts`
+
+The Resume prototype should share this Vite app and visual language but must not
+force pi activity into the existing post or engagement schemas. Posts are
+person-authored content; imported agent activity has different identity,
+provenance, privacy, and deletion requirements.
+
+### Integration boundary
+
+The external agent runtime remains authoritative for its conversation session;
+Canopy owns only the bounded imported projection and later curated memory. This
+slice is read-only with respect to pi, does not grant the agent mutation
+authority, and does not require Canopy to own an agent loop.
+
+### Verified pi surface
+
+The inspected pi package is `@earendil-works/pi-coding-agent` 0.80.7. Its
+`docs/extensions.md`, `docs/session-format.md`, exported TypeScript declarations,
+and input-transform examples establish the following:
+
+| Surface | Verified behavior relevant here |
+|---|---|
+| `input` | Raw input before skill/template expansion; extension commands bypass it; no pi entry ID is exposed. |
+| `before_agent_start` | Effective expanded prompt before the agent loop; no pi entry ID is exposed. |
+| `message_end` | Finalized message value; the event itself exposes no session entry ID and fires before that message is persisted. |
+| `tool_execution_start` | Tool call ID, name, and arguments. |
+| `tool_execution_end` | Tool call ID, name, result, and error status; arguments must be correlated from the start event. |
+| `agent_settled` | No automatic retry, compaction retry, or queued continuation remains. |
+| Session events | Start, shutdown, compaction, actual tree navigation, and pre-fork intent are distinct events. A successful fork starts a new session with a parent-session relationship. |
+| Custom entries | `pi.appendEntry()` persists extension data without adding it to LLM context. |
+| Session storage | Version-3 JSONL entries form a tree through `id` and `parentId`; compaction appends a summary and does not delete older entries. |
+
+The live hooks do **not** justify deriving an activity ID from a pi entry ID.
+Offline import can use native entry IDs; a future extension must mint and persist
+its own capture identity when no native ID is exposed.
+
+### Missing behavior
+
+- No bounded decoder imports pi session entries into Canopy.
+- No normalized activity model separates human input, assistant claims, tool
+  evidence, checkpoints, and session lifecycle.
+- No Resume View compares a reduced orientation surface with chronology.
+- No product evidence shows that the reduced view improves resumption.
+
+## Reuse check
+
+| Candidate | Decision |
+|---|---|
+| `examples/web/posts.html` and its Vite/Playwright setup | Reuse as the prototype host and interaction precedent. |
+| `LocalPostStore` / `LocalPostEventStore` | Do not reuse as activity authority. Their browser-local post and engagement IDs do not represent pi session ancestry or import replay. |
+| `PostRetrievalIndex` | Do not use in the fixed slice. Resume must first be a deterministic projection of explicit records, not relevance ranking. |
+| `lib/cognition` | Do not use as raw activity storage. It is a downstream context/indexing candidate, not conversation or curated-memory authority. |
+| `GenerativeUiReplaySource` and provider identity wrappers | Checked as reducer/replay and opaque-ID precedents, but not imported. Reusing them would couple unrelated domains and force a MoonBit boundary before the UX is validated. |
+| Event-graph snapshot provenance | Checked as a causal-provenance precedent, but not imported across the submodule boundary. Pi ancestry remains pi-session ancestry. |
+| MoonBit `Map`, `Set`, `Array`/`ArrayView`, `Option`/`Result`, `StringView`, and `BytesView` | Checked for a later MoonBit extraction. The first slice adds no MoonBit API, loop, helper, or collection code, so none is needed yet. |
+
+If the fixed prototype succeeds, a follow-up plan must repeat Existing API First
+before extracting a private MoonBit package. That extraction must not acquire an
+`incr` dependency unless measured product behavior requires reactivity.
+
+## Authority and data model
+
+The prototype keeps four layers distinct.
+
+1. **Pi source session.** Pi remains authoritative for what the person sent,
+   what the assistant returned, which tools ran, and how the conversation
+   branched.
+2. **Imported activity.** A bounded, read-only projection copies only the event
+   classes permitted by the import policy. Every item retains a source-session
+   and source-entry reference.
+3. **Checkpoint anchors.** Goals, decisions, questions, and next actions are
+   human-authored or explicitly accepted fixture records. The fixed reducer does
+   not infer them from assistant prose.
+4. **Resume View.** A disposable projection over imported activity and accepted
+   anchors. It cannot modify either.
+
+Assistant text is a claim, not verification. A successful tool result is
+observed evidence, not proof of the wider claim. A compaction or branch summary
+is source material with provenance, not a replacement for earlier activity.
+
+### Message-content boundary
+
+The fixed fixture contains manually sanitized excerpts. For an imported real
+session, the decoder first normalizes metadata and source references while raw
+message bodies remain in a transient source buffer. The normalized model is
+metadata-only by default. A person may explicitly select a bounded user or
+assistant excerpt for the in-memory Resume View; before it crosses the boundary,
+a fail-closed check rejects credential-shaped tokens, private-key material, and
+other configured sensitive patterns with a diagnostic. The first slice offers
+no override for rejected text and writes no selected excerpt to browser
+persistence.
+
+This policy minimizes an additional Canopy copy; it does not claim to sanitize
+the independently retained pi source session or detect every possible secret.
+Tool content never uses this excerpt path. Tool-specific allowlists admit only
+the minimum arguments and outcome metadata needed for orientation.
+
+### Stable identity
+
+- Native imported entry: `(pi session ID, pi entry ID)`.
+- Tool lifecycle: correlate start/end with `(pi session ID, toolCallId)` while
+  retaining the containing source-entry reference when available.
+- Future extension-only record: `(pi session ID, extension-minted capture ID)`;
+  the minted ID must be stored in a custom entry before replay can rely on it.
+- Canonical content and digests may support integrity checks, but identical text
+  in different turns remains distinct activity.
+
+Re-importing the same source identity is a semantic no-op. Equal identity with
+different canonical content is an integrity error, not an update.
+
+## Functional core and imperative shell
+
+The first slice keeps the boundary inside `examples/web`:
+
+- **Functional core:** bounded JSONL decode, normalization, branch-path
+  selection, idempotent reduction, checkpoint selection, and Resume model
+  projection. These functions accept explicit values, return values or
+  diagnostics, and do not read the DOM, filesystem, clock, network, or
+  `localStorage`.
+- **Imperative shell:** browser file selection, file reading, fixture loading,
+  DOM rendering, focus management, and user-visible import errors.
+
+Validated results expose readonly values or defensive copies. The decoder
+rejects unsupported shapes with structured diagnostics rather than silently
+inventing defaults.
+
+## Desired state
+
+After Phases 0–2:
+
+1. `resume.html` displays a fixed chronological activity list and a fixed Resume
+   View from the same sanitized pi fixture.
+2. The Resume View shows a source-backed current goal, accepted decisions,
+   verified outcomes, unresolved questions, next step, and changed artifacts
+   only when the fixture contains evidence for them.
+3. Every displayed claim links to or identifies its source session entry.
+4. A person can explicitly import a pi JSONL snapshot without transmitting or
+   persistently storing it in Canopy.
+5. Branches remain distinct, compaction does not erase prior activity, and
+   replay does not duplicate entries.
+6. The fixed view is keyboard operable and screen-reader legible.
+7. A comparison with the chronological fallback records whether the reduction
+   actually improves orientation. No product-value claim is made if it does
+   not.
+
+## Steps
+
+### Phase 0 — Fixed transcript and view
+
+1. Add a sanitized version-3 pi fixture under
+   `examples/web/tests/fixtures/`. It must contain:
+   - a session header and stable native entry ancestry;
+   - a human-authored goal;
+   - read, edit, and validation tool activity, including one failed result;
+   - assistant claims clearly distinguished from tool evidence;
+   - explicit accepted checkpoint anchors for a decision, unresolved question,
+     and next step;
+   - a compaction entry while retaining the covered source entries;
+   - at least two terminal tree paths so branch selection is exercised.
+
+2. Add a pure bounded decoder. It accepts session version 3 and returns
+   normalized activity or structured diagnostics. Before reading or retaining
+   content, the shell enforces documented limits for file bytes, line bytes,
+   entry count, ancestry depth, and selected-excerpt length. Duplicate entry
+   IDs, missing parents, ancestry cycles, unsupported versions, and malformed
+   JSONL fail closed. The decoder retains redacted provider/model identity but
+   drops thinking blocks, images, unknown custom messages, raw provider
+   metadata, tool result bodies, and unsupported entries from the imported
+   model. Tool arguments use a per-tool allowlist; generic argument objects
+   never cross the boundary.
+
+3. Add a pure reducer and Resume projection. It must:
+   - collapse replay by stable source identity;
+   - reject identity/content mismatch;
+   - preserve source order and ancestry;
+   - select only explicit accepted checkpoint anchors;
+   - keep assistant claims separate from verified tool outcomes;
+   - return source references for every Resume item.
+
+4. Add `examples/web/resume.html` and a thin DOM shell. Follow the existing
+   posts prototype's typography and interaction principles, but use semantic
+   headings, lists, buttons, status text, and source links appropriate to a
+   read-only orientation view. Register `resume.html` in the explicit Vite
+   input map and assert that the production build emits `dist/resume.html`.
+
+5. Render chronology and Resume side by side or through an explicit view toggle.
+   Neither view may mutate the normalized activity.
+
+6. Add Playwright tests for deterministic output, source traceability,
+   duplicate replay, identity collision, branch selection, compaction
+   preservation, keyboard navigation, and accessible names/structure.
+
+### Phase 1 — Explicit pi session import
+
+1. Add a file-picker action that accepts one user-selected `.jsonl` snapshot.
+   The browser reads it in memory. The first slice does not scan `~/.pi`, watch
+   files, or write imported content to `localStorage`.
+2. Display the source session ID, working directory, timestamp, and selected
+   branch before rendering imported content.
+3. If multiple terminal branches exist, require an explicit branch selection.
+   Do not call `/fork` children branches of the same file: forked sessions have
+   their own session file and optional parent-session reference.
+4. Preserve all selected-path activity across compaction. Display compaction
+   summaries as labeled source claims; never substitute them for or delete
+   covered activity in the knowledge ledger.
+5. Show rejected-entry counts and diagnostics. Unsupported or sensitive content
+   is omitted visibly, not silently treated as absent evidence.
+6. Provide a clear `Forget imported session` action. Because the first slice
+   has no Canopy persistence, clearing the page state or reloading removes the
+   imported copy; deleting the original pi session remains a separate action.
+
+### Phase 2 — Dogfood and comparison
+
+1. Import sanitized snapshots from real Canopy development sessions, including
+   the session that established the PKE direction.
+2. Before each pilot, predeclare the orientation questions and time bound.
+   Questions must cover the session goal, at least one verified outcome, the
+   unresolved question, and the next step.
+3. Compare the Resume View with the chronological fallback. Use matched
+   transcripts and counterbalance presentation order when more than one person
+   participates. Record correctness, time to orientation, missing evidence,
+   source-opening behavior, and corrections.
+4. Iterate the fixed view through direct human feedback. Do not add automatic
+   ranking, summarization, or generated UI to compensate for an inadequate
+   event model.
+5. Stop if the Resume View does not improve orientation over chronology. Record
+   the failed hypothesis before widening capture.
+
+### Phase 3 — Project-local pi extension (gated follow-up)
+
+Only begin after Phases 0–2 pass.
+
+1. Add a trusted project-local extension under
+   `.pi/extensions/canopy-capture/`. The extension may observe `input`,
+   `before_agent_start`, finalized messages, paired tool start/end events,
+   `agent_settled`, and session lifecycle events.
+2. Do not duplicate native message bodies in custom entries. Use custom entries
+   for capture policy, extension-minted identity, explicit checkpoint markers,
+   and sanitized correlation metadata that native entries cannot express.
+3. Expose unambiguous commands such as `/canopy-capture on|off|status` and a
+   persistent visible status indicator. `off` suppresses new Canopy custom
+   records but does not change pi's independent native session persistence.
+   Extension-originated inputs are not classified as human input.
+4. Persist each accepted custom record immediately with `pi.appendEntry()`.
+   Do not describe an in-memory buffer as a durable outbox.
+5. A hook failure must return control to pi unchanged. Capture must not modify
+   prompts, block tools, call a provider, or depend on Canopy being available.
+6. Live delivery to a Canopy process is outside this plan. Any later transport
+   requires a durable local outbox, idempotent acknowledgment, cancellation,
+   retention, and failure-isolation plan before network or socket code lands.
+
+## Acceptance criteria
+
+### Fixed core and view
+
+- [ ] The sanitized fixture decodes without unsupported implicit defaults.
+- [ ] Oversized input, unsupported versions, malformed JSONL, duplicate native
+      IDs, missing parents, and ancestry cycles fail closed with diagnostics.
+- [ ] Replaying an imported source identity is a no-op; equal identity with
+      different content is an integrity diagnostic.
+- [ ] The same normalized activity produces byte-for-byte equivalent Resume
+      model output across repeated runs.
+- [ ] The explicit Vite input map includes `resume.html`, and a production build
+      emits `examples/web/dist/resume.html`.
+- [ ] Assistant claims, tool evidence, and human-accepted anchors are visibly
+      distinct.
+- [ ] Every Resume item exposes a source reference.
+- [ ] Compaction leaves covered activity available and labels its summary as a
+      summary.
+- [ ] Multiple terminal branches require an explicit selection and never merge
+      silently.
+- [ ] Keyboard and screen-reader users can import, choose a branch, switch views,
+      inspect sources, and forget imported state on equivalent terms.
+
+### Explicit import
+
+- [ ] A person can select a current pi session snapshot and render it without
+      entering the same prompt again.
+- [ ] No imported session content is written to browser persistence in the
+      first slice.
+- [ ] Thinking blocks, images, raw provider metadata, system/context material,
+      unknown custom messages, and full tool-result bodies do not enter the
+      normalized Canopy activity model.
+- [ ] Raw user and assistant text stays outside the normalized model by default;
+      only explicitly selected bounded excerpts that pass the fail-closed
+      content check enter the in-memory view.
+- [ ] Import diagnostics state what was omitted and why.
+- [ ] Reloading or using `Forget imported session` clears the Canopy copy while
+      leaving the independently owned pi session unchanged.
+
+### Falsifiable product test
+
+For a transcript the evaluator has not seen, the predeclared Resume condition
+passes only if the evaluator can, within five minutes:
+
+1. state the primary task;
+2. identify at least one verified outcome without treating assistant prose as
+   verification;
+3. identify the unresolved question or next step; and
+4. open the source evidence for each answer.
+
+The same questions are attempted with the chronological fallback. Record both
+correctness and time. Passing the five-minute bound alone does not establish
+product value: the Resume View must improve correctness, time, or both without
+reducing source traceability. This is a pilot result, not a statistical claim.
+
+### Gated extension
+
+- [ ] The extension is not started until the fixed-view product test passes.
+- [ ] Custom entries do not copy native user or assistant message bodies.
+- [ ] Extension-minted IDs survive session reload because they are persisted in
+      custom entries.
+- [ ] Capture-off state is visible and suppresses new Canopy custom records
+      without claiming to disable pi's native session persistence.
+- [ ] Extension failure never blocks or transforms pi input or tool execution.
+
+## Validation
+
+```bash
+# Workspace baseline and JS artifacts
+NEW_MOON_MOD=0 moon check
+NEW_MOON_MOD=0 moon test
+moon build --target js
+
+# Existing web prototype plus new Resume page
+cd examples/web
+npx tsc --noEmit
+npm run build
+npx playwright test tests/post-app.spec.ts tests/pi-resume.spec.ts
+
+# If Phase 3 is later authorized
+pi -e .pi/extensions/canopy-capture/index.ts
+
+# Documentation and interface drift
+cd ../..
+NEW_MOON_MOD=0 moon info
+git diff -- '*.mbti'
+git diff --check
+```
+
+If the web page changes visually, run the browser prototype and inspect it with
+human feedback before treating Playwright as sufficient evidence.
+
+## Risks
+
+- **Imported-content sensitivity.** A pi session may contain secrets in ordinary
+  user text or tool output. Explicit file selection does not make the content
+  safe. Metadata-first normalization, explicit bounded excerpt selection, and
+  fail-closed checks minimize the additional Canopy projection, but false
+  negatives remain possible and the source session remains sensitive and
+  independently retained by pi.
+- **False checkpoint authority.** A fluent assistant summary can look like a
+  decision. The fixed slice accepts only explicit human-authored or accepted
+  anchors.
+- **Branch ambiguity.** A JSONL file can contain several terminal paths, while a
+  fork is a separate child session. Conflating the two would produce a false
+  history.
+- **Format coupling.** The decoder targets pi session v3. A new pi format must
+  fail closed until its migration or compatibility contract is reviewed.
+- **Premature abstraction.** Extracting a MoonBit activity framework before the
+  Resume interaction stabilizes would turn product uncertainty into public API
+  debt.
+- **Surveillance drift.** Failure of the fixed view is not evidence that more
+  passive capture is needed. Every wider source requires a named missing signal
+  and a new privacy review.
+
+## Notes
+
+- Pi owns its session even after import. Canopy owns only the bounded imported
+  projection and any later curated memory. Deleting one copy does not imply
+  deletion of the other.
+- `lib/cognition` may later index accepted activity-derived context, but it does
+  not become the raw activity ledger.
+- Generated or adaptive Resume instruments remain disposable projections and
+  are considered only after the deterministic view beats the chronological
+  alternative.

--- a/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
+++ b/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
@@ -1,359 +1,236 @@
 # Pi session activity → Resume view prototype
 
-**Status:** ready for Phase 0. Live transport and long-term storage remain
-separate follow-ups gated by the fixed prototype.
+**Status:** ready for Phase 0. Live transport and durable Canopy storage are
+gated follow-ups.
 
-## Why
+## Goal and scope
 
-A developer who stops work must later reconstruct goal, verified outcomes,
-unresolved questions, and next step. The
-[PKE direction](../architecture/personal-knowledge-environment-direction.md)
-initial wedge is resumable technical project memory. Pi already persists
-structured, branching JSONL sessions. The smallest falsifiable slice is an
-explicit import of a sanitized pi session into the existing browser prototype,
-followed by a deterministic source-backed Resume View.
-
-## Scope
+A person should be able to resume technical work from a pi session without
+re-entering the same context. The first slice imports a sanitized session into
+the existing web prototype and compares a deterministic, source-backed Resume
+view with chronology.
 
 | In | Out |
 |---|---|
-| `examples/web/` — reuse prototype host, Vite/Playwright harness; separate Resume page | Raw keyboard, clipboard, microphone, or screen capture |
-| Bounded pi session-v3 JSONL decoder and normalized activity model in pure TypeScript | System prompts, context-file contents, hidden reasoning, credentials, API keys, provider payloads |
-| Sanitized fixed fixture from a representative Canopy pi session | Moving raw message bodies into the normalized model without explicit excerpt selection and fail-closed content check |
-| Deterministic chronological view and Resume View | Persisting arbitrary full tool output |
-| Explicit browser file-import path for a pi session snapshot | Treating assistant prose, compaction summaries, or generated UI as knowledge authority |
-| Playwright coverage for provenance, branch selection, compaction, accessibility, deterministic rendering | Agent mutation authority over Canopy or pi sessions |
-| Small orientation pilot comparing Resume View with chronological fallback | External provider calls; system-wide or multi-project background capture |
+| Reuse `examples/web/` and its Vite/Playwright harness | New app, MoonBit package, or public API |
+| Bounded pi session-v3 JSONL decoder in pure TypeScript | Raw keyboard, screen, clipboard, or microphone capture |
+| Sanitized fixed fixture, chronology, and Resume view | System/context prompts, hidden reasoning, credentials, provider payloads |
+| Explicit browser import of one selected snapshot | Persistent imported content or arbitrary full tool output |
+| Provenance, branch, compaction, accessibility, and determinism tests | Agent mutation authority, external provider calls, generated summaries |
+| Pilot against the chronological fallback | System-wide, multi-project, automatic, or live capture |
 
-**Deferred** until fixed slice passes: project-local pi extension for capture
-policy and checkpoint markers; automatic or live delivery from pi to Canopy;
-Canopy-owned durable storage and synchronization; MoonBit activity package;
-semantic or generated checkpoint candidates.
-
-## Current state
-
-### Existing Canopy product prototype
-
-`examples/web/posts.html` provides the prototype host: one-field local
-capture, chronological fallback, source-backed lexical retrieval, explicit
-ranking reasons, keyboard behavior, Playwright tests. Implementation split:
-
-- `examples/web/src/post-app.ts`, `post-store.ts`, `post-events.ts`,
-  `post-retrieval.ts`
-- `examples/web/tests/post-app.spec.ts`
-- `examples/web/vite.config.ts`
-
-The Resume prototype shares this Vite app and visual language but must not
-force pi activity into the existing post or engagement schemas. Posts are
-person-authored; imported agent activity has different identity, provenance,
-privacy, and deletion requirements.
-
-### Integration boundary
-
-The external agent runtime remains authoritative for its conversation session;
-Canopy owns only the bounded imported projection. This slice is read-only with
-respect to pi and does not grant the agent mutation authority.
-
-### Verified pi surface
-
-Package `@earendil-works/pi-coding-agent` 0.80.7. Source:
-`docs/extensions.md`, `docs/session-format.md`, exported TypeScript
-declarations, input-transform examples.
-
-| Surface | Verified behavior |
-|---|---|
-| `input` | Raw input before skill/template expansion; extension commands bypass it; no pi entry ID exposed. |
-| `before_agent_start` | Effective expanded prompt before agent loop; no pi entry ID exposed. |
-| `message_end` | Finalized message value; no session entry ID exposed; fires before message is persisted. |
-| `tool_execution_start` | Tool call ID, name, and arguments. |
-| `tool_execution_end` | Tool call ID, name, result, and error status; arguments correlated from start event. |
-| `agent_settled` | No automatic retry, compaction retry, or queued continuation remains. |
-| Session events | Start, shutdown, compaction, tree navigation, pre-fork intent are distinct. A successful fork starts a new session with parent-session relationship. |
-| Custom entries | `pi.appendEntry()` persists extension data without adding it to LLM context. |
-| Session storage | Version-3 JSONL entries form a tree through `id`/`parentId`; compaction appends a summary, does not delete older entries. |
-
-Live hooks do **not** justify deriving an activity ID from a pi entry ID.
-Offline import uses native entry IDs; a future extension must mint and persist
-its own capture identity when no native ID is exposed.
+A project-local pi extension, live delivery, durable activity storage,
+synchronization, and semantic candidates remain deferred until the fixed slice
+passes.
 
 ## Reuse check
 
+The existing `examples/web` Posts page, application modules, Playwright spec,
+and Vite configuration provide the local-first product and test harness.
+
 | Candidate | Decision |
 |---|---|
-| `examples/web/posts.html` + Vite/Playwright | Reuse as prototype host and interaction precedent. |
-| `LocalPostStore` / `LocalPostEventStore` | Do not reuse. Browser-local post/engagement IDs do not represent pi session ancestry or import replay. |
-| `PostRetrievalIndex` | Do not use in fixed slice. Resume must be deterministic projection, not relevance ranking. |
-| `lib/cognition` | Do not use as raw activity storage. Downstream context/indexing candidate, not conversation authority. |
-| `GenerativeUiReplaySource` + provider identity wrappers | Checked as reducer/replay and opaque-ID precedents; not imported. Would couple unrelated domains. |
-| Event-graph snapshot provenance | Checked as causal-provenance precedent; not imported across submodule boundary. |
-| MoonBit core collections | Checked for later extraction. First slice adds no MoonBit code. |
+| Posts page and Vite/Playwright setup | Reuse as prototype host and interaction precedent. |
+| Post and engagement stores | Do not reuse: pi activity has session ancestry, replay, privacy, and deletion semantics. |
+| `PostRetrievalIndex` | Defer: the fixed Resume view is a deterministic projection, not relevance ranking. |
+| `lib/cognition` and Generative UI replay/identity types | Use as design precedents only; raw activity is a separate authority. |
+| MoonBit core collections and event-graph provenance | Checked for later extraction; Phase 0 adds no MoonBit code. |
 
-If the fixed prototype succeeds, a follow-up must repeat Existing API First
-before extracting a MoonBit package. That extraction must not acquire an
-`incr` dependency unless measured behavior requires reactivity.
+A later MoonBit extraction must repeat Existing API First and must not acquire
+an `incr` dependency without measured need.
 
-## Authority and data model
+## Verified pi 0.80.7 contract
 
-Four distinct layers:
+Sources: pi `docs/extensions.md`, `docs/session-format.md`, exported TypeScript
+declarations, and input-transform examples.
 
-1. **Pi source session** — authoritative for what was sent, returned, which
-   tools ran, how conversation branched.
-2. **Imported activity** — bounded read-only projection; every item retains
-   source-session and source-entry reference.
-3. **Checkpoint anchors** — goals, decisions, questions, next actions are
-   human-authored or explicitly accepted. Fixed reducer does not infer from
-   assistant prose.
-4. **Resume View** — disposable projection over imported activity and accepted
-   anchors. Cannot modify either.
+| Surface | Verified behavior |
+|---|---|
+| `input` | Raw input before skill/template expansion; extension commands bypass it; no pi entry ID is exposed. |
+| `before_agent_start` | Effective expanded prompt before the agent loop; no pi entry ID is exposed. |
+| `message_end` | Finalized message value; no entry ID is exposed; fires before persistence. |
+| `tool_execution_start` | Tool call ID, name, and arguments. |
+| `tool_execution_end` | Tool call ID, name, result, and error status; arguments come from the paired start event. |
+| `agent_settled` | No automatic retry, compaction retry, or queued continuation remains. |
+| Session events | Start, shutdown, compaction, tree navigation, and pre-fork intent are distinct; a successful fork creates a session with a parent-session relationship. |
+| Custom entries | `pi.appendEntry()` persists extension data outside LLM context. |
+| Session storage | Version-3 JSONL uses `id`/`parentId`; compaction appends a summary and retains older entries. |
 
-Assistant text is a claim, not verification. A successful tool result is
-observed evidence. A compaction or branch summary is source material with
-provenance, not a replacement for earlier activity.
+Live hooks cannot derive identity from a pi entry ID they do not expose.
 
-### Message-content boundary
+## Core contract
 
-The fixed fixture contains manually sanitized excerpts. For an imported real
-session: the decoder normalizes metadata and source references while raw
-message bodies remain in a transient source buffer. The normalized model is
-metadata-only by default. A person may explicitly select a bounded excerpt for
-the in-memory view; before it crosses the boundary, a fail-closed check
-rejects credential-shaped tokens, private-key material, and other configured
-sensitive patterns with a diagnostic. The first slice offers no override for
-rejected text and writes no excerpt to browser persistence. Tool content never
-uses this excerpt path. Tool-specific allowlists admit only minimum arguments
-and outcome metadata needed for orientation.
+### Authority
 
-This minimizes an additional Canopy copy; it does not claim to sanitize the
-independently retained pi source session or detect every possible secret.
+| Layer | Authority |
+|---|---|
+| Pi source session | What the person sent, what the assistant returned, tools run, and conversation ancestry |
+| Imported activity | Bounded read-only projection with source-session and source-entry references |
+| Checkpoint anchors | Human-authored or explicitly accepted goals, decisions, questions, and next actions |
+| Resume view | Disposable projection that cannot modify sources or anchors |
 
-### Stable identity
+Assistant text is a claim. A successful tool result is observed evidence, not
+proof of a broader claim. Compaction and branch summaries remain source material
+and cannot replace covered activity.
 
-- **Native imported entry:** `(pi session ID, pi entry ID)`.
-- **Tool lifecycle:** correlate start/end with `(pi session ID, toolCallId)`,
-  retaining the containing source-entry reference when available.
-- **Future extension-only record:** `(pi session ID, extension-minted capture
-  ID)`; minted ID must be stored in a custom entry before replay can rely on
-  it.
-- Content digests may support integrity checks, but identical text in
-  different turns remains distinct activity.
+### Identity and content
 
-Re-importing the same source identity is a semantic no-op. Equal identity with
-different content is an integrity error, not an update.
+- Native identity is `(pi session ID, pi entry ID)`.
+- Tool start/end correlate through `(pi session ID, toolCallId)` and retain the
+  containing source entry when available.
+- A future extension uses `(pi session ID, extension-minted capture ID)` and
+  persists that ID in a custom entry before replay.
+- Content digests support integrity checks, never identity; equal identity with
+  different canonical content is an error.
+- Replay of an existing identity is a no-op.
 
-## Functional core and imperative shell
+The fixed fixture contains manually sanitized excerpts. A real import first
+normalizes metadata and source references while raw bodies remain transient.
+The normalized model is metadata-only by default. Only an explicitly selected,
+bounded excerpt that passes fail-closed sensitive-pattern checks may enter the
+in-memory view; rejected text has no override in the first slice. Nothing is
+written to browser persistence. Tool data uses per-tool argument allowlists and
+never imports full result bodies. Omissions are visible diagnostics.
 
-- **Functional core:** bounded JSONL decode, normalization, branch-path
-  selection, idempotent reduction, checkpoint selection, Resume model
-  projection. Accept explicit values, return values or diagnostics; no
-  DOM/filesystem/clock/network/`localStorage` access.
-- **Imperative shell:** browser file selection, reading, fixture loading, DOM
-  rendering, focus management, user-visible import errors.
+### Functional core and imperative shell
 
-Validated results expose readonly values or defensive copies. The decoder
-rejects unsupported shapes with structured diagnostics.
+| Core | Shell |
+|---|---|
+| JSONL decode, normalization, branch selection, idempotent reduction, checkpoint selection, Resume projection | File selection/read, fixture load, DOM render, focus management, diagnostics |
 
-## Steps
+The core accepts explicit values and returns readonly results or diagnostics. It
+does not access the DOM, filesystem, clock, network, or `localStorage`.
+
+## Delivery
 
 ### Phase 0 — Fixed transcript and view
 
-1. Add sanitized v3 pi fixture under `examples/web/tests/fixtures/` containing:
-   session header and stable native entry ancestry; human-authored goal;
-   read/edit/validation tool activity including one failed result; assistant
-   claims distinguished from tool evidence; explicit accepted checkpoint
-   anchors (decision, unresolved question, next step); compaction entry
-   retaining covered source entries; at least two terminal tree paths.
+1. Add a sanitized v3 fixture under `examples/web/tests/fixtures/` with a
+   session header, ancestry, human goal, read/edit/validation activity, one
+   failed result, assistant claims, accepted decision/question/next-step
+   anchors, compaction, and at least two terminal paths.
+2. Add a pure decoder. Before reading or retaining content, enforce limits for
+   file bytes, line bytes, entry count, ancestry depth, and excerpt length.
+   Reject malformed JSONL, unsupported versions, duplicate IDs, missing
+   parents, and cycles. Retain only allowlisted metadata.
+3. Add a pure reducer and Resume projection preserving order, ancestry,
+   accepted anchors, evidence distinctions, and source references.
+4. Add `resume.html`, register it in the Vite input map, and render chronology
+   and Resume without mutating normalized activity.
+5. Add Playwright coverage for the contract below.
 
-2. Add pure bounded decoder. Accepts session v3; returns normalized activity
-   or structured diagnostics. Before reading or retaining content, the shell
-   enforces documented limits for file bytes, line bytes, entry count, ancestry
-   depth, and selected-excerpt length. Duplicate
-   IDs, missing parents, ancestry cycles, unsupported versions, malformed
-   JSONL fail closed. Retains redacted provider/model identity; drops thinking
-   blocks, images, unknown custom messages, raw provider metadata, tool result
-   bodies, unsupported entries. Tool arguments use per-tool allowlist.
+Phase 0 passes when:
 
-3. Add pure reducer and Resume projection: collapse replay by stable source
-   identity; reject identity/content mismatch; preserve source order and
-   ancestry; select only explicit accepted checkpoint anchors; keep assistant
-   claims separate from verified tool outcomes; return source references for
-   every Resume item.
+- [ ] The same normalized activity produces byte-for-byte equivalent Resume
+      model output across repeated runs.
+- [ ] Invalid bounds, versions, JSONL, identity, parentage, and cycles fail with
+      diagnostics.
+- [ ] Replay is a no-op; identity/content mismatch is an integrity error.
+- [ ] `dist/resume.html` is emitted by the production build.
+- [ ] Human anchors, assistant claims, and tool evidence remain distinct and
+      source-linked.
+- [ ] Compaction retains covered activity; terminal branches require explicit
+      selection and never merge silently.
+- [ ] Keyboard and screen-reader users can switch views and inspect evidence on
+      equivalent terms.
 
-4. Add `examples/web/resume.html` and thin DOM shell. Follow posts prototype
-   typography and interaction principles. Use semantic headings, lists,
-   buttons, status text, source links. Register in Vite input map; assert
-   production build emits `dist/resume.html`.
+### Phase 1 — Explicit session import
 
-5. Render chronology and Resume side by side or through explicit view toggle.
-   Neither view may mutate normalized activity.
+1. Accept one user-selected `.jsonl` snapshot in memory; never scan `~/.pi`,
+   watch files, or persist the import.
+2. Show session ID, working directory, timestamp, and selected branch.
+3. Require selection when several terminal paths exist. Same-file branches and
+   `/fork` child sessions remain distinct.
+4. Preserve selected-path activity across compaction; label summaries as
+   summaries.
+5. Show omissions and rejected-entry diagnostics, plus a `Forget imported
+   session` action. Clearing or reloading removes the Canopy copy; deleting the
+   pi session is separate.
 
-6. Add Playwright tests for deterministic output, source traceability,
-   duplicate replay, identity collision, branch selection, compaction
-   preservation, keyboard navigation, accessible names/structure.
+Phase 1 passes when:
 
-### Phase 1 — Explicit pi session import
+- [ ] A current pi snapshot renders without re-entering its prompt.
+- [ ] No imported content reaches browser persistence.
+- [ ] Excluded blocks, metadata, custom messages, and tool bodies remain outside
+      the normalized model; only accepted excerpts enter the in-memory view.
+- [ ] Diagnostics explain omissions, and Forget clears only the Canopy copy.
 
-1. File-picker accepts one user-selected `.jsonl` snapshot. Browser reads in
-   memory. First slice does not scan `~/.pi`, watch files, or write to
-   `localStorage`.
-2. Display source session ID, working directory, timestamp, selected branch
-   before rendering content.
-3. Multiple terminal branches require explicit selection. Do not conflate
-   `/fork` children with same-file branches: forked sessions have their own
-   session file and optional parent-session reference.
-4. Preserve all selected-path activity across compaction. Display compaction
-   summaries as labeled source claims; never substitute for or delete covered
-   activity.
-5. Show rejected-entry counts and diagnostics. Unsupported or sensitive content
-   is omitted visibly, not silently.
-6. `Forget imported session` action. First slice has no Canopy persistence;
-   clearing page state or reloading removes the imported copy. Deleting the
-   original pi session remains separate.
+### Phase 2 — Dogfood and compare
 
-### Phase 2 — Dogfood and comparison
+Use sanitized real Canopy sessions, including the session that established the
+PKE direction. Before each pilot, predeclare the time bound and questions
+covering goal, verified outcome, unresolved question, and next step. Compare
+matched Resume and chronology conditions, counterbalance order when possible,
+and record correctness, orientation time, source openings, missing evidence,
+and corrections. Iterate the fixed view through direct human feedback before
+widening capture.
 
-1. Import sanitized snapshots from real Canopy development sessions, including
-   the PKE direction session.
-2. Predeclare orientation questions and time bound before each pilot. Questions
-   must cover: session goal, at least one verified outcome, unresolved
-   question, next step.
-3. Compare Resume View with chronological fallback. Matched transcripts,
-   counterbalanced order with multiple participants. Record correctness, time
-   to orientation, missing evidence, source-opening behavior, corrections.
-4. Iterate through direct human feedback. Do not add automatic ranking,
-   summarization, or generated UI to compensate for an inadequate event model.
-5. Stop if Resume View does not improve orientation over chronology. Record
-   failed hypothesis before widening capture.
-
-### Phase 3 — Project-local pi extension (gated)
-
-Only after Phases 0–2 pass.
-
-1. Add trusted project-local extension under `.pi/extensions/canopy-capture/`.
-   May observe `input`, `before_agent_start`, finalized messages, paired tool
-   start/end, `agent_settled`, session lifecycle.
-2. Do not duplicate native message bodies in custom entries. Use custom entries
-   for capture policy, extension-minted identity, explicit checkpoint markers,
-   sanitized correlation metadata.
-3. Expose commands `/canopy-capture on|off|status` with persistent visible
-   status indicator. `off` suppresses new Canopy custom records but does not
-   change pi's native session persistence. Extension-originated inputs are not
-   classified as human input.
-4. Persist each accepted custom record immediately with `pi.appendEntry()`. Do
-   not describe an in-memory buffer as a durable outbox.
-5. Hook failure returns control to pi unchanged. Capture must not modify
-   prompts, block tools, call a provider, or depend on Canopy availability.
-6. Live delivery to Canopy is outside this plan. Later transport requires
-   durable local outbox, idempotent acknowledgment, cancellation, retention,
-   and failure-isolation plan before network or socket code.
-
-## Acceptance criteria
-
-### Fixed core and view
-
-- [ ] Sanitized fixture decodes without unsupported implicit defaults.
-- [ ] Oversized input, unsupported versions, malformed JSONL, duplicate native
-      IDs, missing parents, ancestry cycles fail closed with diagnostics.
-- [ ] Replaying an imported source identity is a no-op; equal identity with
-      different content is an integrity diagnostic.
-- [ ] Same normalized activity produces byte-for-byte equivalent Resume model
-      output across repeated runs.
-- [ ] Explicit Vite input map includes `resume.html`; production build emits
-      `examples/web/dist/resume.html`.
-- [ ] Assistant claims, tool evidence, and human-accepted anchors are visibly
-      distinct.
-- [ ] Every Resume item exposes a source reference.
-- [ ] Compaction leaves covered activity available and labels its summary as a
-      summary.
-- [ ] Multiple terminal branches require explicit selection and never merge
-      silently.
-- [ ] Keyboard and screen-reader users can import, choose a branch, switch
-      views, inspect sources, and forget imported state on equivalent terms.
-
-### Explicit import
-
-- [ ] A person can select a current pi session snapshot and render it without
-      re-entering the same prompt.
-- [ ] No imported session content is written to browser persistence in first
-      slice.
-- [ ] Thinking blocks, images, raw provider metadata, system/context material,
-      unknown custom messages, full tool-result bodies do not enter the
-      normalized activity model.
-- [ ] Raw user/assistant text stays outside the normalized model by default;
-      only explicitly selected bounded excerpts passing fail-closed content
-      check enter the in-memory view.
-- [ ] Import diagnostics state what was omitted and why.
-- [ ] Reloading or `Forget imported session` clears the Canopy copy while
-      leaving the pi session unchanged.
-
-### Falsifiable product test
-
-For an unseen transcript, the predeclared Resume condition passes only if the
-evaluator can, within five minutes:
+The pilot passes only when an evaluator of an unseen transcript can, within five
+minutes:
 
 1. state the primary task;
-2. identify at least one verified outcome without treating assistant prose as
-   verification;
-3. identify the unresolved question or next step;
-4. open the source evidence for each answer.
+2. identify a verified outcome without treating assistant prose as proof;
+3. identify the unresolved question or next step; and
+4. open source evidence for each answer.
 
-The same questions are attempted with the chronological fallback. Record both
-correctness and time. Passing the five-minute bound alone does not establish
-product value: the Resume View must improve correctness, time, or both without
-reducing source traceability. Pilot result, not a statistical claim.
+Resume must improve correctness, time, or both without reducing traceability.
+Otherwise record the failed hypothesis and stop before widening capture.
 
-### Gated extension
+### Phase 3 — Project-local extension (gated)
 
-- [ ] Extension not started until fixed-view product test passes.
-- [ ] Custom entries do not copy native user or assistant message bodies.
-- [ ] Extension-minted IDs survive session reload because they are persisted in
-      custom entries.
-- [ ] Capture-off state is visible and suppresses new Canopy custom records
-      without claiming to disable pi's native session persistence.
-- [ ] Extension failure never blocks or transforms pi input or tool execution.
+Only after Phases 0–2 pass:
+
+1. Add `.pi/extensions/canopy-capture/` observing `input`,
+   `before_agent_start`, finalized messages, paired tool start/end events,
+   `agent_settled`, and session lifecycle events.
+2. Store only policy, extension-minted identity, explicit checkpoint markers,
+   and sanitized correlation metadata in custom entries; never duplicate native
+   message bodies.
+3. Provide `/canopy-capture on|off|status` and a persistent indicator. `off`
+   suppresses Canopy custom records but not pi's native persistence.
+   Extension-originated inputs are never classified as human input.
+4. Persist accepted custom records immediately. Hook failure must not transform
+   input, block tools, call a provider, or depend on Canopy availability.
+
+Phase 3 passes when extension IDs survive reload, capture-off state is visible,
+and extension failure leaves pi input and tool execution unchanged. Live
+transport remains out of scope; it requires a separate durable-outbox,
+idempotent-acknowledgment, cancellation, retention, and failure-isolation plan.
 
 ## Validation
 
 ```bash
-# Workspace baseline and JS artifacts
 NEW_MOON_MOD=0 moon check
 NEW_MOON_MOD=0 moon test
 moon build --target js
 
-# Existing web prototype plus new Resume page
 cd examples/web
 npx tsc --noEmit
 npm run build
 npx playwright test tests/post-app.spec.ts tests/pi-resume.spec.ts
 cd ../..
 
-# If Phase 3 is later authorized
+# Only after Phase 3 authorization
 pi -e .pi/extensions/canopy-capture/index.ts
 
-# Documentation and interface drift
 NEW_MOON_MOD=0 moon info
 git diff -- '*.mbti'
 git diff --check
 ```
 
-If the web page changes visually, run the browser prototype and inspect with
-human feedback before treating Playwright as sufficient evidence.
+If the page changes visually, inspect it with human feedback before treating
+Playwright as sufficient evidence.
 
 ## Risks
 
-- **Imported-content sensitivity.** Pi sessions may contain secrets in ordinary
-  text or tool output. Explicit file selection does not make content safe.
-  Metadata-first normalization, bounded excerpt selection, and fail-closed
-  checks minimize the additional Canopy projection, but false negatives remain
-  possible and the source session remains independently retained by pi.
-- **False checkpoint authority.** A fluent assistant summary can look like a
-  decision. Fixed slice accepts only explicit human-authored or accepted
-  anchors.
-- **Branch ambiguity.** A JSONL file can contain several terminal paths; a
-  fork is a separate child session. Conflating them produces false history.
-- **Format coupling.** Decoder targets pi session v3. A new format must fail
-  closed until migration or compatibility is reviewed.
-- **Premature abstraction.** Extracting a MoonBit framework before the Resume
-  interaction stabilizes turns product uncertainty into public API debt.
-- **Surveillance drift.** Fixed-view failure is not evidence that more passive
-  capture is needed. Every wider source requires a named missing signal and a
-  new privacy review.
+- **Sensitive input:** explicit file selection is not sanitization; false
+  negatives remain possible and pi retains its independent source session.
+- **False authority:** fluent assistant prose can resemble a decision; only
+  human-authored or accepted anchors enter checkpoints.
+- **Branch ambiguity:** same-file paths and forked child sessions are different
+  histories.
+- **Format coupling:** unsupported pi formats fail closed until reviewed.
+- **Premature abstraction:** a MoonBit framework before UX validation creates
+  API debt.
+- **Surveillance drift:** a failed view does not justify broader passive
+  capture; every source needs a named missing signal and privacy review.

--- a/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
+++ b/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
@@ -5,381 +5,305 @@ separate follow-ups gated by the fixed prototype.
 
 ## Why
 
-A developer or researcher who stops work on a technical project must later
-reconstruct the goal, verified outcomes, unresolved questions, and next step.
-The initial wedge of the
-[Personal Knowledge Environment direction](../architecture/personal-knowledge-environment-direction.md)
-is resumable technical project memory: capture work already expressed through
-an agent session, then restore orientation without requiring duplicate notes.
-
-Pi already persists the current conversation as a structured, branching JSONL
-session. The smallest falsifiable slice is therefore not a new capture daemon or
-a new MoonBit framework. It is an explicit import of a sanitized pi session
-into the existing browser product prototype, followed by a deterministic,
-source-backed Resume View. A live extension is considered only after that fixed
-view proves useful.
+A developer who stops work must later reconstruct goal, verified outcomes,
+unresolved questions, and next step. The
+[PKE direction](../architecture/personal-knowledge-environment-direction.md)
+initial wedge is resumable technical project memory. Pi already persists
+structured, branching JSONL sessions. The smallest falsifiable slice is an
+explicit import of a sanitized pi session into the existing browser prototype,
+followed by a deterministic source-backed Resume View.
 
 ## Scope
 
-In for the first slice:
+| In | Out |
+|---|---|
+| `examples/web/` — reuse prototype host, Vite/Playwright harness; separate Resume page | Raw keyboard, clipboard, microphone, or screen capture |
+| Bounded pi session-v3 JSONL decoder and normalized activity model in pure TypeScript | System prompts, context-file contents, hidden reasoning, credentials, API keys, provider payloads |
+| Sanitized fixed fixture from a representative Canopy pi session | Moving raw message bodies into the normalized model without explicit excerpt selection and fail-closed content check |
+| Deterministic chronological view and Resume View | Persisting arbitrary full tool output |
+| Explicit browser file-import path for a pi session snapshot | Treating assistant prose, compaction summaries, or generated UI as knowledge authority |
+| Playwright coverage for provenance, branch selection, compaction, accessibility, deterministic rendering | Agent mutation authority over Canopy or pi sessions |
+| Small orientation pilot comparing Resume View with chronological fallback | External provider calls; system-wide or multi-project background capture |
 
-- `examples/web/` — reuse the existing local-first product prototype and Vite /
-  Playwright harness; add a separate Resume page rather than a new app.
-- A bounded pi session-v3 JSONL decoder and normalized activity model in pure
-  TypeScript.
-- A sanitized fixed fixture derived from a representative Canopy pi session.
-- A deterministic chronological view and Resume View over the same activity.
-- An explicit browser file-import path for a pi session snapshot.
-- Playwright coverage for provenance, branch selection, compaction preservation,
-  accessibility, and deterministic rendering.
-- A small orientation pilot comparing the Resume View with the chronological
-  fallback.
-
-Deferred until the fixed slice passes:
-
-- A project-local pi extension for capture policy and checkpoint markers.
-- Automatic or live delivery from pi to Canopy.
-- Canopy-owned durable activity storage, retention, and synchronization.
-- A MoonBit activity package or public API.
-- Semantic or generated checkpoint candidates.
-
-Out:
-
-- Raw keyboard, clipboard, microphone, or screen capture.
-- System prompts, context-file contents, hidden reasoning, credentials, API
-  keys, or provider payloads.
-- Moving raw user or assistant message bodies into the normalized activity
-  model without explicit excerpt selection and a fail-closed content check.
-- Persisting arbitrary full tool output in Canopy.
-- Treating assistant prose, compaction summaries, or generated UI as knowledge
-  authority.
-- Agent mutation authority over Canopy or pi sessions.
-- External provider calls.
-- System-wide or multi-project background capture.
+**Deferred** until fixed slice passes: project-local pi extension for capture
+policy and checkpoint markers; automatic or live delivery from pi to Canopy;
+Canopy-owned durable storage and synchronization; MoonBit activity package;
+semantic or generated checkpoint candidates.
 
 ## Current state
 
 ### Existing Canopy product prototype
 
-`examples/web/posts.html` already provides the least-wrong prototype host. It
-has one-field local capture, a chronological fallback, source-backed lexical
-retrieval, explicit ranking reasons, keyboard behavior, and Playwright tests.
-Its implementation is split across:
+`examples/web/posts.html` provides the prototype host: one-field local
+capture, chronological fallback, source-backed lexical retrieval, explicit
+ranking reasons, keyboard behavior, Playwright tests. Implementation split:
 
-- `examples/web/src/post-app.ts`
-- `examples/web/src/post-store.ts`
-- `examples/web/src/post-events.ts`
-- `examples/web/src/post-retrieval.ts`
+- `examples/web/src/post-app.ts`, `post-store.ts`, `post-events.ts`,
+  `post-retrieval.ts`
 - `examples/web/tests/post-app.spec.ts`
 - `examples/web/vite.config.ts`
 
-The Resume prototype should share this Vite app and visual language but must not
+The Resume prototype shares this Vite app and visual language but must not
 force pi activity into the existing post or engagement schemas. Posts are
-person-authored content; imported agent activity has different identity,
-provenance, privacy, and deletion requirements.
+person-authored; imported agent activity has different identity, provenance,
+privacy, and deletion requirements.
 
 ### Integration boundary
 
 The external agent runtime remains authoritative for its conversation session;
-Canopy owns only the bounded imported projection and later curated memory. This
-slice is read-only with respect to pi, does not grant the agent mutation
-authority, and does not require Canopy to own an agent loop.
+Canopy owns only the bounded imported projection. This slice is read-only with
+respect to pi and does not grant the agent mutation authority.
 
 ### Verified pi surface
 
-The inspected pi package is `@earendil-works/pi-coding-agent` 0.80.7. Its
-`docs/extensions.md`, `docs/session-format.md`, exported TypeScript declarations,
-and input-transform examples establish the following:
+Package `@earendil-works/pi-coding-agent` 0.80.7. Source:
+`docs/extensions.md`, `docs/session-format.md`, exported TypeScript
+declarations, input-transform examples.
 
-| Surface | Verified behavior relevant here |
+| Surface | Verified behavior |
 |---|---|
-| `input` | Raw input before skill/template expansion; extension commands bypass it; no pi entry ID is exposed. |
-| `before_agent_start` | Effective expanded prompt before the agent loop; no pi entry ID is exposed. |
-| `message_end` | Finalized message value; the event itself exposes no session entry ID and fires before that message is persisted. |
+| `input` | Raw input before skill/template expansion; extension commands bypass it; no pi entry ID exposed. |
+| `before_agent_start` | Effective expanded prompt before agent loop; no pi entry ID exposed. |
+| `message_end` | Finalized message value; no session entry ID exposed; fires before message is persisted. |
 | `tool_execution_start` | Tool call ID, name, and arguments. |
-| `tool_execution_end` | Tool call ID, name, result, and error status; arguments must be correlated from the start event. |
+| `tool_execution_end` | Tool call ID, name, result, and error status; arguments correlated from start event. |
 | `agent_settled` | No automatic retry, compaction retry, or queued continuation remains. |
-| Session events | Start, shutdown, compaction, actual tree navigation, and pre-fork intent are distinct events. A successful fork starts a new session with a parent-session relationship. |
+| Session events | Start, shutdown, compaction, tree navigation, pre-fork intent are distinct. A successful fork starts a new session with parent-session relationship. |
 | Custom entries | `pi.appendEntry()` persists extension data without adding it to LLM context. |
-| Session storage | Version-3 JSONL entries form a tree through `id` and `parentId`; compaction appends a summary and does not delete older entries. |
+| Session storage | Version-3 JSONL entries form a tree through `id`/`parentId`; compaction appends a summary, does not delete older entries. |
 
-The live hooks do **not** justify deriving an activity ID from a pi entry ID.
-Offline import can use native entry IDs; a future extension must mint and persist
+Live hooks do **not** justify deriving an activity ID from a pi entry ID.
+Offline import uses native entry IDs; a future extension must mint and persist
 its own capture identity when no native ID is exposed.
-
-### Missing behavior
-
-- No bounded decoder imports pi session entries into Canopy.
-- No normalized activity model separates human input, assistant claims, tool
-  evidence, checkpoints, and session lifecycle.
-- No Resume View compares a reduced orientation surface with chronology.
-- No product evidence shows that the reduced view improves resumption.
 
 ## Reuse check
 
 | Candidate | Decision |
 |---|---|
-| `examples/web/posts.html` and its Vite/Playwright setup | Reuse as the prototype host and interaction precedent. |
-| `LocalPostStore` / `LocalPostEventStore` | Do not reuse as activity authority. Their browser-local post and engagement IDs do not represent pi session ancestry or import replay. |
-| `PostRetrievalIndex` | Do not use in the fixed slice. Resume must first be a deterministic projection of explicit records, not relevance ranking. |
-| `lib/cognition` | Do not use as raw activity storage. It is a downstream context/indexing candidate, not conversation or curated-memory authority. |
-| `GenerativeUiReplaySource` and provider identity wrappers | Checked as reducer/replay and opaque-ID precedents, but not imported. Reusing them would couple unrelated domains and force a MoonBit boundary before the UX is validated. |
-| Event-graph snapshot provenance | Checked as a causal-provenance precedent, but not imported across the submodule boundary. Pi ancestry remains pi-session ancestry. |
-| MoonBit `Map`, `Set`, `Array`/`ArrayView`, `Option`/`Result`, `StringView`, and `BytesView` | Checked for a later MoonBit extraction. The first slice adds no MoonBit API, loop, helper, or collection code, so none is needed yet. |
+| `examples/web/posts.html` + Vite/Playwright | Reuse as prototype host and interaction precedent. |
+| `LocalPostStore` / `LocalPostEventStore` | Do not reuse. Browser-local post/engagement IDs do not represent pi session ancestry or import replay. |
+| `PostRetrievalIndex` | Do not use in fixed slice. Resume must be deterministic projection, not relevance ranking. |
+| `lib/cognition` | Do not use as raw activity storage. Downstream context/indexing candidate, not conversation authority. |
+| `GenerativeUiReplaySource` + provider identity wrappers | Checked as reducer/replay and opaque-ID precedents; not imported. Would couple unrelated domains. |
+| Event-graph snapshot provenance | Checked as causal-provenance precedent; not imported across submodule boundary. |
+| MoonBit core collections | Checked for later extraction. First slice adds no MoonBit code. |
 
-If the fixed prototype succeeds, a follow-up plan must repeat Existing API First
-before extracting a private MoonBit package. That extraction must not acquire an
-`incr` dependency unless measured product behavior requires reactivity.
+If the fixed prototype succeeds, a follow-up must repeat Existing API First
+before extracting a MoonBit package. That extraction must not acquire an
+`incr` dependency unless measured behavior requires reactivity.
 
 ## Authority and data model
 
-The prototype keeps four layers distinct.
+Four distinct layers:
 
-1. **Pi source session.** Pi remains authoritative for what the person sent,
-   what the assistant returned, which tools ran, and how the conversation
-   branched.
-2. **Imported activity.** A bounded, read-only projection copies only the event
-   classes permitted by the import policy. Every item retains a source-session
-   and source-entry reference.
-3. **Checkpoint anchors.** Goals, decisions, questions, and next actions are
-   human-authored or explicitly accepted fixture records. The fixed reducer does
-   not infer them from assistant prose.
-4. **Resume View.** A disposable projection over imported activity and accepted
-   anchors. It cannot modify either.
+1. **Pi source session** — authoritative for what was sent, returned, which
+   tools ran, how conversation branched.
+2. **Imported activity** — bounded read-only projection; every item retains
+   source-session and source-entry reference.
+3. **Checkpoint anchors** — goals, decisions, questions, next actions are
+   human-authored or explicitly accepted. Fixed reducer does not infer from
+   assistant prose.
+4. **Resume View** — disposable projection over imported activity and accepted
+   anchors. Cannot modify either.
 
 Assistant text is a claim, not verification. A successful tool result is
-observed evidence, not proof of the wider claim. A compaction or branch summary
-is source material with provenance, not a replacement for earlier activity.
+observed evidence. A compaction or branch summary is source material with
+provenance, not a replacement for earlier activity.
 
 ### Message-content boundary
 
 The fixed fixture contains manually sanitized excerpts. For an imported real
-session, the decoder first normalizes metadata and source references while raw
+session: the decoder normalizes metadata and source references while raw
 message bodies remain in a transient source buffer. The normalized model is
-metadata-only by default. A person may explicitly select a bounded user or
-assistant excerpt for the in-memory Resume View; before it crosses the boundary,
-a fail-closed check rejects credential-shaped tokens, private-key material, and
-other configured sensitive patterns with a diagnostic. The first slice offers
-no override for rejected text and writes no selected excerpt to browser
-persistence.
+metadata-only by default. A person may explicitly select a bounded excerpt for
+the in-memory view; before it crosses the boundary, a fail-closed check
+rejects credential-shaped tokens, private-key material, and other configured
+sensitive patterns with a diagnostic. The first slice offers no override for
+rejected text and writes no excerpt to browser persistence. Tool content never
+uses this excerpt path. Tool-specific allowlists admit only minimum arguments
+and outcome metadata needed for orientation.
 
-This policy minimizes an additional Canopy copy; it does not claim to sanitize
-the independently retained pi source session or detect every possible secret.
-Tool content never uses this excerpt path. Tool-specific allowlists admit only
-the minimum arguments and outcome metadata needed for orientation.
+This minimizes an additional Canopy copy; it does not claim to sanitize the
+independently retained pi source session or detect every possible secret.
 
 ### Stable identity
 
-- Native imported entry: `(pi session ID, pi entry ID)`.
-- Tool lifecycle: correlate start/end with `(pi session ID, toolCallId)` while
+- **Native imported entry:** `(pi session ID, pi entry ID)`.
+- **Tool lifecycle:** correlate start/end with `(pi session ID, toolCallId)`,
   retaining the containing source-entry reference when available.
-- Future extension-only record: `(pi session ID, extension-minted capture ID)`;
-  the minted ID must be stored in a custom entry before replay can rely on it.
-- Canonical content and digests may support integrity checks, but identical text
-  in different turns remains distinct activity.
+- **Future extension-only record:** `(pi session ID, extension-minted capture
+  ID)`; minted ID must be stored in a custom entry before replay can rely on
+  it.
+- Content digests may support integrity checks, but identical text in
+  different turns remains distinct activity.
 
 Re-importing the same source identity is a semantic no-op. Equal identity with
-different canonical content is an integrity error, not an update.
+different content is an integrity error, not an update.
 
 ## Functional core and imperative shell
 
-The first slice keeps the boundary inside `examples/web`:
-
 - **Functional core:** bounded JSONL decode, normalization, branch-path
-  selection, idempotent reduction, checkpoint selection, and Resume model
-  projection. These functions accept explicit values, return values or
-  diagnostics, and do not read the DOM, filesystem, clock, network, or
-  `localStorage`.
-- **Imperative shell:** browser file selection, file reading, fixture loading,
-  DOM rendering, focus management, and user-visible import errors.
+  selection, idempotent reduction, checkpoint selection, Resume model
+  projection. Accept explicit values, return values or diagnostics; no
+  DOM/filesystem/clock/network/`localStorage` access.
+- **Imperative shell:** browser file selection, reading, fixture loading, DOM
+  rendering, focus management, user-visible import errors.
 
 Validated results expose readonly values or defensive copies. The decoder
-rejects unsupported shapes with structured diagnostics rather than silently
-inventing defaults.
-
-## Desired state
-
-After Phases 0–2:
-
-1. `resume.html` displays a fixed chronological activity list and a fixed Resume
-   View from the same sanitized pi fixture.
-2. The Resume View shows a source-backed current goal, accepted decisions,
-   verified outcomes, unresolved questions, next step, and changed artifacts
-   only when the fixture contains evidence for them.
-3. Every displayed claim links to or identifies its source session entry.
-4. A person can explicitly import a pi JSONL snapshot without transmitting or
-   persistently storing it in Canopy.
-5. Branches remain distinct, compaction does not erase prior activity, and
-   replay does not duplicate entries.
-6. The fixed view is keyboard operable and screen-reader legible.
-7. A comparison with the chronological fallback records whether the reduction
-   actually improves orientation. No product-value claim is made if it does
-   not.
+rejects unsupported shapes with structured diagnostics.
 
 ## Steps
 
 ### Phase 0 — Fixed transcript and view
 
-1. Add a sanitized version-3 pi fixture under
-   `examples/web/tests/fixtures/`. It must contain:
-   - a session header and stable native entry ancestry;
-   - a human-authored goal;
-   - read, edit, and validation tool activity, including one failed result;
-   - assistant claims clearly distinguished from tool evidence;
-   - explicit accepted checkpoint anchors for a decision, unresolved question,
-     and next step;
-   - a compaction entry while retaining the covered source entries;
-   - at least two terminal tree paths so branch selection is exercised.
+1. Add sanitized v3 pi fixture under `examples/web/tests/fixtures/` containing:
+   session header and stable native entry ancestry; human-authored goal;
+   read/edit/validation tool activity including one failed result; assistant
+   claims distinguished from tool evidence; explicit accepted checkpoint
+   anchors (decision, unresolved question, next step); compaction entry
+   retaining covered source entries; at least two terminal tree paths.
 
-2. Add a pure bounded decoder. It accepts session version 3 and returns
-   normalized activity or structured diagnostics. Before reading or retaining
-   content, the shell enforces documented limits for file bytes, line bytes,
-   entry count, ancestry depth, and selected-excerpt length. Duplicate entry
-   IDs, missing parents, ancestry cycles, unsupported versions, and malformed
-   JSONL fail closed. The decoder retains redacted provider/model identity but
-   drops thinking blocks, images, unknown custom messages, raw provider
-   metadata, tool result bodies, and unsupported entries from the imported
-   model. Tool arguments use a per-tool allowlist; generic argument objects
-   never cross the boundary.
+2. Add pure bounded decoder. Accepts session v3; returns normalized activity
+   or structured diagnostics. Before reading or retaining content, the shell
+   enforces documented limits for file bytes, line bytes, entry count, ancestry
+   depth, and selected-excerpt length. Duplicate
+   IDs, missing parents, ancestry cycles, unsupported versions, malformed
+   JSONL fail closed. Retains redacted provider/model identity; drops thinking
+   blocks, images, unknown custom messages, raw provider metadata, tool result
+   bodies, unsupported entries. Tool arguments use per-tool allowlist.
 
-3. Add a pure reducer and Resume projection. It must:
-   - collapse replay by stable source identity;
-   - reject identity/content mismatch;
-   - preserve source order and ancestry;
-   - select only explicit accepted checkpoint anchors;
-   - keep assistant claims separate from verified tool outcomes;
-   - return source references for every Resume item.
+3. Add pure reducer and Resume projection: collapse replay by stable source
+   identity; reject identity/content mismatch; preserve source order and
+   ancestry; select only explicit accepted checkpoint anchors; keep assistant
+   claims separate from verified tool outcomes; return source references for
+   every Resume item.
 
-4. Add `examples/web/resume.html` and a thin DOM shell. Follow the existing
-   posts prototype's typography and interaction principles, but use semantic
-   headings, lists, buttons, status text, and source links appropriate to a
-   read-only orientation view. Register `resume.html` in the explicit Vite
-   input map and assert that the production build emits `dist/resume.html`.
+4. Add `examples/web/resume.html` and thin DOM shell. Follow posts prototype
+   typography and interaction principles. Use semantic headings, lists,
+   buttons, status text, source links. Register in Vite input map; assert
+   production build emits `dist/resume.html`.
 
-5. Render chronology and Resume side by side or through an explicit view toggle.
-   Neither view may mutate the normalized activity.
+5. Render chronology and Resume side by side or through explicit view toggle.
+   Neither view may mutate normalized activity.
 
 6. Add Playwright tests for deterministic output, source traceability,
    duplicate replay, identity collision, branch selection, compaction
-   preservation, keyboard navigation, and accessible names/structure.
+   preservation, keyboard navigation, accessible names/structure.
 
 ### Phase 1 — Explicit pi session import
 
-1. Add a file-picker action that accepts one user-selected `.jsonl` snapshot.
-   The browser reads it in memory. The first slice does not scan `~/.pi`, watch
-   files, or write imported content to `localStorage`.
-2. Display the source session ID, working directory, timestamp, and selected
-   branch before rendering imported content.
-3. If multiple terminal branches exist, require an explicit branch selection.
-   Do not call `/fork` children branches of the same file: forked sessions have
-   their own session file and optional parent-session reference.
+1. File-picker accepts one user-selected `.jsonl` snapshot. Browser reads in
+   memory. First slice does not scan `~/.pi`, watch files, or write to
+   `localStorage`.
+2. Display source session ID, working directory, timestamp, selected branch
+   before rendering content.
+3. Multiple terminal branches require explicit selection. Do not conflate
+   `/fork` children with same-file branches: forked sessions have their own
+   session file and optional parent-session reference.
 4. Preserve all selected-path activity across compaction. Display compaction
-   summaries as labeled source claims; never substitute them for or delete
-   covered activity in the knowledge ledger.
+   summaries as labeled source claims; never substitute for or delete covered
+   activity.
 5. Show rejected-entry counts and diagnostics. Unsupported or sensitive content
-   is omitted visibly, not silently treated as absent evidence.
-6. Provide a clear `Forget imported session` action. Because the first slice
-   has no Canopy persistence, clearing the page state or reloading removes the
-   imported copy; deleting the original pi session remains a separate action.
+   is omitted visibly, not silently.
+6. `Forget imported session` action. First slice has no Canopy persistence;
+   clearing page state or reloading removes the imported copy. Deleting the
+   original pi session remains separate.
 
 ### Phase 2 — Dogfood and comparison
 
 1. Import sanitized snapshots from real Canopy development sessions, including
-   the session that established the PKE direction.
-2. Before each pilot, predeclare the orientation questions and time bound.
-   Questions must cover the session goal, at least one verified outcome, the
-   unresolved question, and the next step.
-3. Compare the Resume View with the chronological fallback. Use matched
-   transcripts and counterbalance presentation order when more than one person
-   participates. Record correctness, time to orientation, missing evidence,
-   source-opening behavior, and corrections.
-4. Iterate the fixed view through direct human feedback. Do not add automatic
-   ranking, summarization, or generated UI to compensate for an inadequate
-   event model.
-5. Stop if the Resume View does not improve orientation over chronology. Record
-   the failed hypothesis before widening capture.
+   the PKE direction session.
+2. Predeclare orientation questions and time bound before each pilot. Questions
+   must cover: session goal, at least one verified outcome, unresolved
+   question, next step.
+3. Compare Resume View with chronological fallback. Matched transcripts,
+   counterbalanced order with multiple participants. Record correctness, time
+   to orientation, missing evidence, source-opening behavior, corrections.
+4. Iterate through direct human feedback. Do not add automatic ranking,
+   summarization, or generated UI to compensate for an inadequate event model.
+5. Stop if Resume View does not improve orientation over chronology. Record
+   failed hypothesis before widening capture.
 
-### Phase 3 — Project-local pi extension (gated follow-up)
+### Phase 3 — Project-local pi extension (gated)
 
-Only begin after Phases 0–2 pass.
+Only after Phases 0–2 pass.
 
-1. Add a trusted project-local extension under
-   `.pi/extensions/canopy-capture/`. The extension may observe `input`,
-   `before_agent_start`, finalized messages, paired tool start/end events,
-   `agent_settled`, and session lifecycle events.
+1. Add trusted project-local extension under `.pi/extensions/canopy-capture/`.
+   May observe `input`, `before_agent_start`, finalized messages, paired tool
+   start/end, `agent_settled`, session lifecycle.
 2. Do not duplicate native message bodies in custom entries. Use custom entries
    for capture policy, extension-minted identity, explicit checkpoint markers,
-   and sanitized correlation metadata that native entries cannot express.
-3. Expose unambiguous commands such as `/canopy-capture on|off|status` and a
-   persistent visible status indicator. `off` suppresses new Canopy custom
-   records but does not change pi's independent native session persistence.
-   Extension-originated inputs are not classified as human input.
-4. Persist each accepted custom record immediately with `pi.appendEntry()`.
-   Do not describe an in-memory buffer as a durable outbox.
-5. A hook failure must return control to pi unchanged. Capture must not modify
-   prompts, block tools, call a provider, or depend on Canopy being available.
-6. Live delivery to a Canopy process is outside this plan. Any later transport
-   requires a durable local outbox, idempotent acknowledgment, cancellation,
-   retention, and failure-isolation plan before network or socket code lands.
+   sanitized correlation metadata.
+3. Expose commands `/canopy-capture on|off|status` with persistent visible
+   status indicator. `off` suppresses new Canopy custom records but does not
+   change pi's native session persistence. Extension-originated inputs are not
+   classified as human input.
+4. Persist each accepted custom record immediately with `pi.appendEntry()`. Do
+   not describe an in-memory buffer as a durable outbox.
+5. Hook failure returns control to pi unchanged. Capture must not modify
+   prompts, block tools, call a provider, or depend on Canopy availability.
+6. Live delivery to Canopy is outside this plan. Later transport requires
+   durable local outbox, idempotent acknowledgment, cancellation, retention,
+   and failure-isolation plan before network or socket code.
 
 ## Acceptance criteria
 
 ### Fixed core and view
 
-- [ ] The sanitized fixture decodes without unsupported implicit defaults.
+- [ ] Sanitized fixture decodes without unsupported implicit defaults.
 - [ ] Oversized input, unsupported versions, malformed JSONL, duplicate native
-      IDs, missing parents, and ancestry cycles fail closed with diagnostics.
+      IDs, missing parents, ancestry cycles fail closed with diagnostics.
 - [ ] Replaying an imported source identity is a no-op; equal identity with
       different content is an integrity diagnostic.
-- [ ] The same normalized activity produces byte-for-byte equivalent Resume
-      model output across repeated runs.
-- [ ] The explicit Vite input map includes `resume.html`, and a production build
-      emits `examples/web/dist/resume.html`.
+- [ ] Same normalized activity produces byte-for-byte equivalent Resume model
+      output across repeated runs.
+- [ ] Explicit Vite input map includes `resume.html`; production build emits
+      `examples/web/dist/resume.html`.
 - [ ] Assistant claims, tool evidence, and human-accepted anchors are visibly
       distinct.
 - [ ] Every Resume item exposes a source reference.
 - [ ] Compaction leaves covered activity available and labels its summary as a
       summary.
-- [ ] Multiple terminal branches require an explicit selection and never merge
+- [ ] Multiple terminal branches require explicit selection and never merge
       silently.
-- [ ] Keyboard and screen-reader users can import, choose a branch, switch views,
-      inspect sources, and forget imported state on equivalent terms.
+- [ ] Keyboard and screen-reader users can import, choose a branch, switch
+      views, inspect sources, and forget imported state on equivalent terms.
 
 ### Explicit import
 
 - [ ] A person can select a current pi session snapshot and render it without
-      entering the same prompt again.
-- [ ] No imported session content is written to browser persistence in the
-      first slice.
+      re-entering the same prompt.
+- [ ] No imported session content is written to browser persistence in first
+      slice.
 - [ ] Thinking blocks, images, raw provider metadata, system/context material,
-      unknown custom messages, and full tool-result bodies do not enter the
-      normalized Canopy activity model.
-- [ ] Raw user and assistant text stays outside the normalized model by default;
-      only explicitly selected bounded excerpts that pass the fail-closed
-      content check enter the in-memory view.
+      unknown custom messages, full tool-result bodies do not enter the
+      normalized activity model.
+- [ ] Raw user/assistant text stays outside the normalized model by default;
+      only explicitly selected bounded excerpts passing fail-closed content
+      check enter the in-memory view.
 - [ ] Import diagnostics state what was omitted and why.
-- [ ] Reloading or using `Forget imported session` clears the Canopy copy while
-      leaving the independently owned pi session unchanged.
+- [ ] Reloading or `Forget imported session` clears the Canopy copy while
+      leaving the pi session unchanged.
 
 ### Falsifiable product test
 
-For a transcript the evaluator has not seen, the predeclared Resume condition
-passes only if the evaluator can, within five minutes:
+For an unseen transcript, the predeclared Resume condition passes only if the
+evaluator can, within five minutes:
 
 1. state the primary task;
 2. identify at least one verified outcome without treating assistant prose as
    verification;
-3. identify the unresolved question or next step; and
+3. identify the unresolved question or next step;
 4. open the source evidence for each answer.
 
 The same questions are attempted with the chronological fallback. Record both
 correctness and time. Passing the five-minute bound alone does not establish
 product value: the Resume View must improve correctness, time, or both without
-reducing source traceability. This is a pilot result, not a statistical claim.
+reducing source traceability. Pilot result, not a statistical claim.
 
 ### Gated extension
 
-- [ ] The extension is not started until the fixed-view product test passes.
+- [ ] Extension not started until fixed-view product test passes.
 - [ ] Custom entries do not copy native user or assistant message bodies.
 - [ ] Extension-minted IDs survive session reload because they are persisted in
       custom entries.
@@ -411,39 +335,25 @@ git diff -- '*.mbti'
 git diff --check
 ```
 
-If the web page changes visually, run the browser prototype and inspect it with
+If the web page changes visually, run the browser prototype and inspect with
 human feedback before treating Playwright as sufficient evidence.
 
 ## Risks
 
-- **Imported-content sensitivity.** A pi session may contain secrets in ordinary
-  user text or tool output. Explicit file selection does not make the content
-  safe. Metadata-first normalization, explicit bounded excerpt selection, and
-  fail-closed checks minimize the additional Canopy projection, but false
-  negatives remain possible and the source session remains sensitive and
-  independently retained by pi.
+- **Imported-content sensitivity.** Pi sessions may contain secrets in ordinary
+  text or tool output. Explicit file selection does not make content safe.
+  Metadata-first normalization, bounded excerpt selection, and fail-closed
+  checks minimize the additional Canopy projection, but false negatives remain
+  possible and the source session remains independently retained by pi.
 - **False checkpoint authority.** A fluent assistant summary can look like a
-  decision. The fixed slice accepts only explicit human-authored or accepted
+  decision. Fixed slice accepts only explicit human-authored or accepted
   anchors.
-- **Branch ambiguity.** A JSONL file can contain several terminal paths, while a
-  fork is a separate child session. Conflating the two would produce a false
-  history.
-- **Format coupling.** The decoder targets pi session v3. A new pi format must
-  fail closed until its migration or compatibility contract is reviewed.
-- **Premature abstraction.** Extracting a MoonBit activity framework before the
-  Resume interaction stabilizes would turn product uncertainty into public API
-  debt.
-- **Surveillance drift.** Failure of the fixed view is not evidence that more
-  passive capture is needed. Every wider source requires a named missing signal
-  and a new privacy review.
-
-## Notes
-
-- Pi owns its session even after import. Canopy owns only the bounded imported
-  projection and any later curated memory. Deleting one copy does not imply
-  deletion of the other.
-- `lib/cognition` may later index accepted activity-derived context, but it does
-  not become the raw activity ledger.
-- Generated or adaptive Resume instruments remain disposable projections and
-  are considered only after the deterministic view beats the chronological
-  alternative.
+- **Branch ambiguity.** A JSONL file can contain several terminal paths; a
+  fork is a separate child session. Conflating them produces false history.
+- **Format coupling.** Decoder targets pi session v3. A new format must fail
+  closed until migration or compatibility is reviewed.
+- **Premature abstraction.** Extracting a MoonBit framework before the Resume
+  interaction stabilizes turns product uncertainty into public API debt.
+- **Surveillance drift.** Fixed-view failure is not evidence that more passive
+  capture is needed. Every wider source requires a named missing signal and a
+  new privacy review.

--- a/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
+++ b/docs/plans/2026-07-16-pi-activity-capture-resume-prototype.md
@@ -324,12 +324,12 @@ cd examples/web
 npx tsc --noEmit
 npm run build
 npx playwright test tests/post-app.spec.ts tests/pi-resume.spec.ts
+cd ../..
 
 # If Phase 3 is later authorized
 pi -e .pi/extensions/canopy-capture/index.ts
 
 # Documentation and interface drift
-cd ../..
 NEW_MOON_MOD=0 moon info
 git diff -- '*.mbti'
 git diff --check


### PR DESCRIPTION
## Summary

- Add canonical human-centered product principles for authority, negotiable structure, legibility, reversibility, cognitive stability, accessible equivalence, local ownership, and product-value gates.
- Set a personal knowledge environment as the near-term product direction, with resumable technical project memory as the first wedge and the projectional editor preserved in maintenance/proving-ground mode.
- Define a falsifiable pi session activity → Resume view prototype that reuses the existing `examples/web` Posts/Vite/Playwright substrate, starts with explicit JSONL import and a deterministic fixed view, and gates any live extension or generated behavior on product evidence.
- Align the README, Product Vision, Projectional Bridge, Generative UI direction, design context, documentation indexes, and TODO with the same human-authority model.

## Reuse check

Pure documentation change; no functions, methods, helpers, types, or public APIs are added.

Existing implementation and APIs considered by the prototype plan:

| API / precedent | Location | Reused? | Reason |
|---|---|---:|---|
| Local-first Posts prototype and Vite/Playwright harness | `examples/web/` | Yes | Hosts the fixed Resume prototype without creating a new app or MoonBit package prematurely. |
| Post and engagement stores | `examples/web/src/post-{store,events}.ts` | No | Imported pi activity has different identity, provenance, privacy, and deletion semantics. |
| Cognition and Generative UI replay/identity precedents | `lib/cognition/` | No | Useful design precedents, but raw activity is a separate authority and the UX should be validated before a MoonBit abstraction is introduced. |
| Pi session v3 and extension events | pi 0.80.7 docs/types | Yes, in the plan | Ground stable import identity, branch/compaction handling, custom entries, and the later gated extension phase. |

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes — 124 existing warnings, 0 errors
- [x] `NEW_MOON_MOD=0 moon test` passes — 1921 JS and 70 native tests
- [x] `NEW_MOON_MOD=0 moon info` passes
- [x] `git diff -- '*.mbti'` reviewed — no interface changes
- [x] `git diff --check` passes
- [x] New PKE/pi documentation links and whitespace checks pass
- [x] Independent staged-diff review passes
- [x] Slopless reports no non-readability findings in the three new documents
- [x] JS rebuild not required; no web source or generated artifact changed

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
NEW_MOON_MOD=0 moon info
git diff -- '*.mbti'
git diff --check
```

`moon fmt --check` is not clean on the untouched base checkout because vendored submodule files under `alga` and `graphviz` differ from the current formatter output. This PR changes documentation only and includes no submodule or MoonBit source diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a human-centered product principles guide covering agency, accessibility, reversibility, privacy, and cognitive stability.
  * Reframed the product vision around user-controlled writing, provisional structure, relevant context, and local operation.
  * Added direction for a personal knowledge environment focused on resumable project memory.
  * Expanded architecture documentation and learning paths with updated vision and principles.
  * Added a plan for importing activity into a read-only Resume view with deterministic behavior and validation.
  * Defined acceptance criteria for generated UI, including legibility, accessibility, reversibility, and user control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->