### PR TITLE
docs: define incremental generative UI document engine

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,9 @@ behavior** — check the code before relying on any specific detail.
 - [Stable Document Entity Graph](design/stable-document-entity-graph.md) —
   direction for growing a stable editing-entity layer from the existing
   projection identity pipeline.
+- [Incremental Generative UI document engine](design/incremental-generative-ui-document-engine.md) —
+  semantic authority, operation, identity, and recovery direction for generated
+  documents.
 - [Design Concerns](design/design-concerns.md) — open problems and future
   considerations.
 - [Decisions Needed](decisions-needed.md) — open architectural questions.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -159,6 +159,15 @@ maintenance and proving-ground mode.
   Already covered: click selection, keyboard navigation, and scroll-to-selection (`examples/ideal/web/e2e/outline-navigation.spec.ts`); tree roles, selection, active-descendant, and collapse ARIA (`examples/ideal/web/e2e/outline-aria.spec.ts`); resize-handle behavior while `.tree-rows` scrolls (`examples/ideal/web/e2e/outline-resizable.spec.ts`).
   Closed here: collapse/expand descendant visibility plus collapsed badges; light-DOM outline row drag/drop in `examples/ideal/web/e2e/outline-drag-drop.spec.ts`, verifying CRDT/CodeMirror text sync plus outline reorder. Shadow structure-mode drag/drop remains covered separately by `examples/ideal/web/e2e/drag-drop.spec.ts`.
 
+- [ ] Verify the incremental Generative UI semantic core.
+  Why: the document-engine authority, transaction, recovery, and identity
+  claims have no implementation or falsifiable evidence; adapter work before
+  the core gate would hide architectural failure.
+  Plan: `docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md`
+  Exit: the fixed invalid-draft, exactly-once, rewrite-conflict, outbox, and
+  restart transcript passes with every non-deferred evidence-matrix row;
+  deferred adapter and trust claims remain explicitly unclaimed.
+
 ---
 
 ## 7. Code Cleanup

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -244,6 +244,10 @@ This document's generative-UI-specific interpretation:
 
 These gates are product requirements, not technical implementation details.
 They sit above the commit and candidate contracts defined in this document.
+A private semantic-core experiment may falsify proposed invariants, but it does
+not replace this sequence, authorize product integration, or freeze a public
+renderer-neutral contract.
 
-Related: [JSX Incremental Parser for Generative UI](../plans/2026-07-09-jsx-incremental-parser-generative-ui.md)
-and [property-based correctness coverage issue #888](https://github.com/dowdiness/canopy/issues/888).
+Related: [JSX Incremental Parser for Generative UI](../plans/2026-07-09-jsx-incremental-parser-generative-ui.md),
+[property-based correctness coverage issue #888](https://github.com/dowdiness/canopy/issues/888),
+and the [Incremental Generative UI document engine](../design/incremental-generative-ui-document-engine.md).

--- a/docs/design/incremental-generative-ui-document-engine.md
+++ b/docs/design/incremental-generative-ui-document-engine.md
@@ -54,7 +54,7 @@ request lookup and bounds
 → final graph and schema validation
 → terminal outcome
    Applied          → atomically persist graph, revision, applied batch,
-                      request record, and outbox
+                      request record, exact effect manifest, and outbox entries
    NoSemanticChange → persist request record only
    Rejected         → persist request record only
 → respond; release post-commit effects only for Applied
@@ -65,10 +65,20 @@ ID, canonical content, digest, outcome, and resolved handle-to-ID mapping.
 Decode or bounds failures before canonical request construction remain boundary
 diagnostics.
 
-Only `Applied` advances `GraphRevision`. `NoSemanticChange` and `Rejected` are
-ledger-only outcomes: they add no applied history or outbox work. Rejection
-also exposes no partial batch and changes no graph, source, or renderer
-baseline.
+Only `Applied` advances `GraphRevision`. Its canonical delivery plan records
+the source effect kind/preconditions and the ordered renderer targets/baselines
+captured at commit. A pure function derives exactly one source effect and one
+render effect per captured target: `MarkSynchronized` for text, or
+`RewriteSource` for projection, agent, and undo origins. Each expected tuple
+contains `EffectId`, request, revision, kind, target, and baselines; `EffectId`
+derives deterministically from the plan position and tuple identity. The plan,
+its digest, derived manifest, and outbox entries persist atomically. There is no
+generic rewrite effect for text-origin commits.
+
+`NoSemanticChange` and `Rejected` are ledger-only outcomes: their delivery
+plans and effect manifests are empty, so they add no applied history or outbox
+work. Rejection also exposes no partial batch and changes no
+graph, source, or renderer baseline.
 
 The host owns the component registry, schema, authority facts, and approval
 evidence. Generated input can name only capabilities allowed by the pinned
@@ -79,9 +89,9 @@ approval evidence.
 ## Renderer separation
 
 Semantic commit does not depend on DOM or renderer success. A committed change
-emits durable source and renderer work through an outbox. Renderer failure
-leaves meaning unchanged, marks only that renderer dirty, and schedules repair
-from the committed graph.
+emits durable renderer work and its origin-specific source effect through an
+outbox. Renderer failure leaves meaning unchanged, marks only that renderer
+dirty, and schedules repair from the committed graph.
 
 The existing JSX session still follows its V1 rule that a candidate is not
 reported committed until DOM apply succeeds. That adapter/session contract does
@@ -153,7 +163,7 @@ AtStart | AtEnd | Before(sibling) | After(sibling)
 
 The parent and optional sibling must already resolve in the private working
 graph; the sibling must belong to that parent. Same-parent moves detach the
-moved node before resolving placement, and self anchors are invalid. Insert
+moved node before resolving placement, and self-anchors are invalid. Insert
 requires a fresh local handle and allowed component. Move and remove require an
 existing non-root node; a move cannot target its own subtree. `RemoveProperty`
 requires a present property. Assigning the current value or moving to the
@@ -237,8 +247,8 @@ provider I/O, then reports results as events.
 | Draft edit | Preserve exact bytes and advance `DraftRevision`; keep the graph unchanged until lowering succeeds. |
 | Text-derived semantic change | Commit only when origin draft, graph, and schema revisions match. |
 | No-delta text change | Preserve complement; sync without request, revision, history, or outbox. |
-| Matching text-origin commit | Mark the current draft synchronized without rewriting its bytes. |
-| Projection/agent commit | Rewrite only on matching draft and semantic baselines; otherwise enter `RewriteConflict`. |
+| Matching text-origin commit | Emit `MarkSynchronized`; never rewrite its bytes. |
+| Non-text semantic commit | Emit `RewriteSource` on matching baselines; otherwise enter `RewriteConflict`. |
 | Renderer success | Advance only that renderer's baseline. |
 | Renderer failure | Keep meaning, mark that renderer dirty, and repair from committed state. |
 
@@ -269,18 +279,30 @@ An applied commit atomically groups:
 - graph revision, schema revision, and schema descriptor digest;
 - validated batch, ID allocations, and provenance;
 - canonical request content, digest, and terminal outcome;
-- source and renderer outbox entries.
+- canonical delivery plan and digest;
+- the derived effect manifest and matching source/render outbox entries.
 
-Recovery loads the latest valid checkpoint and replays a contiguous history
-suffix. Every step must match base graph/schema revisions and the next recorded
-revision. Reconstructed graph, schema identity/digest, and checkpoint must
-agree. Gaps, request-content/digest mismatches, unavailable or changed schemas,
-and replay mismatches enter diagnostic read-only state.
+Recovery restores the latest valid checkpoint, complete request ledger, and
+all outbox statuses, then replays a contiguous applied-history suffix. It
+recomputes each ledger and delivery-plan digest, regenerates every expected
+effect tuple from the plan, and requires exact equality with the manifest and
+outbox statuses. `NoSemanticChange` and `Rejected` records must have no history,
+delivery plan, manifest entries, or effects. Omitted targets, duplicates,
+cross-links, or swapped effect IDs fail closed. Pending effects are redelivered;
+terminal source/render outcomes remain available for integrity checks.
 
-Outbox effects carry `EffectId`, target, base/target graph revisions, graph hash
-or snapshot reference, and optional expected draft state. Delivery is
-at-least-once and adapters are idempotent against effect IDs and baselines.
-Redelivery cannot create another semantic commit.
+Every replay step must match base graph/schema revisions and the next recorded
+revision. Reconstructed graph, schema identity/digest, request outcomes, outbox
+statuses, and checkpoint must agree. Corrupt ledger/outbox data, history gaps,
+unavailable or changed schemas, and replay mismatches enter diagnostic
+read-only state.
+
+Outbox effects carry `EffectId`, applied request/revision, target, base/target
+graph revisions, graph hash or snapshot reference, and optional expected draft
+state. Delivery is at-least-once and adapters are idempotent against effect IDs
+and baselines. An effect stays pending until its applied, stale, or blocked
+outcome is durable; a crash before that acknowledgment causes deterministic
+redelivery. Redelivery cannot create another semantic commit.
 
 Renderer ordering is explicit:
 
@@ -289,11 +311,14 @@ Renderer ordering is explicit:
 3. An effect whose base equals the baseline may apply.
 4. A gap rebuilds the latest snapshot; older deltas never apply.
 
-A text-origin source effect matching the current draft marks it synchronized
-without rewriting bytes. Projection/agent source effects require matching draft
-revision, valid/rewrite-eligible status, and source semantic baseline; otherwise
-they preserve source and enter `RewriteConflict`. Gaps coalesce to the latest graph and canonical source.
-Observed state never regresses.
+`MarkSynchronized` changes no bytes. A matching draft becomes synchronized; a
+newer draft produces a durable stale acknowledgment without changing draft or
+sync state. `RewriteSource` for projection, agent, or undo requires matching draft
+revision, valid/rewrite-eligible status, and source semantic baseline. A mismatch
+preserves source and durably records blocked `RewriteConflict`, consuming that
+effect rather than retrying forever. A later rewrite requires a new effect.
+Rewrite gaps coalesce to the latest graph and canonical source. Observed state
+never regresses.
 
 ## Concurrency
 

--- a/docs/design/incremental-generative-ui-document-engine.md
+++ b/docs/design/incremental-generative-ui-document-engine.md
@@ -69,10 +69,11 @@ Only `Applied` advances `GraphRevision`. Its canonical delivery plan records
 the source effect kind/preconditions and the ordered renderer targets/baselines
 captured at commit. A pure function derives exactly one source effect and one
 render effect per captured target: `MarkSynchronized` for text, or
-`RewriteSource` for projection, agent, and undo origins. Each expected tuple
-contains `EffectId`, request, revision, kind, target, and baselines; `EffectId`
-derives deterministically from the plan position and tuple identity. The plan,
-its digest, derived manifest, and outbox entries persist atomically. There is no
+`RewriteSource` for projection, agent, and undo origins. Each canonical effect
+payload contains request, revision, kind, target, and baselines. `EffectId`
+derives from `(DocumentId, plan position, payload)`; the expected tuple adds
+that ID to the payload. The plan, its digest, derived manifest, and outbox
+entries persist atomically. There is no
 generic rewrite effect for text-origin commits.
 
 `NoSemanticChange` and `Rejected` are ledger-only outcomes: their delivery
@@ -88,16 +89,25 @@ approval evidence.
 
 ## Renderer separation
 
-Semantic commit does not depend on DOM or renderer success. A committed change
-emits durable renderer work and its origin-specific source effect through an
-outbox. Renderer failure leaves meaning unchanged, marks only that renderer
-dirty, and schedules repair from the committed graph.
+A renderer can fail after the graph is durable. If that failure revoked the
+commit, document meaning would depend on which renderer happened to be
+available. Semantic commit therefore emits durable renderer work through the
+outbox but does not wait for DOM success. Failure marks only that renderer dirty
+and repairs it from the committed graph.
 
-The existing JSX session still follows its V1 rule that a candidate is not
-reported committed until DOM apply succeeds. That adapter/session contract does
-not define semantic authority for the new document engine.
+The existing JSX session appears stricter: it does not report a V1 candidate as
+committed until DOM apply succeeds. That remains the local adapter/session
+contract. It cannot decide semantic authority for a document with other
+renderers.
 
 ## Requests and idempotency
+
+A commit can succeed while its response is lost, so the caller retries the same
+`RequestId` and the graph must not advance twice. A repeated ID appears
+sufficient, but a caller can reuse it for different content. Replacing that
+content comparison with a digest only moves the ambiguity because collisions
+remain possible. Retry safety therefore rests on the validated canonical
+request itself.
 
 | Field | Rule |
 | --- | --- |
@@ -233,6 +243,12 @@ reversal path.
 
 ## Draft, source, and renderer transitions
 
+Text and non-text commits leave the source in different conditions. A text
+commit already exists in the current draft, so writing generated source back
+could destroy its lossless complement. Projection, agent, and undo commits have
+changed the graph without changing those bytes. Their source effect must first
+prove that the draft has not moved.
+
 The functional core follows:
 
 ```text
@@ -273,6 +289,13 @@ is private and collision-checked.
 
 ## Persistence and recovery
 
+A checkpoint can restore the right graph and still restore the wrong protocol.
+Without a ledger-only outcome, a retry may run again. Without acknowledged
+outbox state, delivery may resume from the wrong point. Even a manifest/outbox
+comparison is insufficient when both omit the same renderer target: the two
+corrupt records still agree. The durable commit therefore keeps an independent
+canonical delivery plan from which the expected effects can be regenerated.
+
 An applied commit atomically groups:
 
 - next graph or checkpoint/delta reference;
@@ -311,14 +334,14 @@ Renderer ordering is explicit:
 3. An effect whose base equals the baseline may apply.
 4. A gap rebuilds the latest snapshot; older deltas never apply.
 
-`MarkSynchronized` changes no bytes. A matching draft becomes synchronized; a
-newer draft produces a durable stale acknowledgment without changing draft or
-sync state. `RewriteSource` for projection, agent, or undo requires matching draft
-revision, valid/rewrite-eligible status, and source semantic baseline. A mismatch
-preserves source and durably records blocked `RewriteConflict`, consuming that
-effect rather than retrying forever. A later rewrite requires a new effect.
-Rewrite gaps coalesce to the latest graph and canonical source. Observed state
-never regresses.
+The source origin determines what delivery can safely do. `MarkSynchronized`
+changes no bytes: a matching text draft becomes synchronized, while a newer
+draft receives a durable stale acknowledgment and remains untouched.
+`RewriteSource` serves projection, agent, and undo commits only after draft,
+eligibility, and semantic-baseline checks pass. A mismatch preserves source and
+durably records blocked `RewriteConflict`, consuming that effect rather than
+retrying forever. A later rewrite requires a new effect. Rewrite gaps coalesce
+to the latest graph and canonical source. Observed state never regresses.
 
 ## Concurrency
 

--- a/docs/design/incremental-generative-ui-document-engine.md
+++ b/docs/design/incremental-generative-ui-document-engine.md
@@ -1,0 +1,682 @@
+# Incremental Generative UI document engine
+
+**Status:** Design direction; not implemented.
+
+**Related:** [Generative UI direction](../architecture/generative-ui-direction.md) · [Stable Document Entity Graph](stable-document-entity-graph.md) · [JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md) · [Input vertical slice](../plans/2026-07-12-generative-ui-input-vertical-slice.md) · [Responsibility Map](../architecture/responsibility-map.md) · [Human-centered product principles](../architecture/human-centered-product-principles.md)
+
+## Load-bearing question
+
+A Generative UI document receives text, projection, and agent inputs that may
+be incomplete, conflicting, duplicated, stale, or unapproved. The load-bearing
+question is not which syntax carries a proposal. It is which transition counts
+as committed document meaning.
+
+The answer is a validated, atomic semantic transaction. Text, projection, and
+agent adapters may propose transactions, but none of them is document
+authority.
+
+## Scope and non-goals
+
+This is a narrowly scoped operation/semantic-authoritative model for a new
+`GenerativeUiDocument`. Current Canopy remains text/CRDT authoritative for
+existing language editors; this document does not replace that responsibility
+map ([Responsibility Map](../architecture/responsibility-map.md)).
+
+Not included:
+
+- An implementation plan, task checklist, or file-by-file breakdown.
+- A global replacement of the text-first Canopy pipeline.
+- A public renderer-neutral API. The first implementation remains internal
+  until a real vertical slice and a materially different renderer validate the
+  shared invariants.
+- A change to the current product sequence. A private semantic core is bounded
+  falsification research, not permission to add generated behavior before the
+  fixed personal-knowledge baseline is accepted or to bypass the existing V1
+  adapter gates.
+- A claim that the operation history provides CRDT or causal-merge semantics.
+
+## First principles
+
+The design follows five rules:
+
+1. **Current meaning has one authority.** A valid committed UI graph at an
+   explicit revision is the current document meaning.
+2. **Proposals are not authority.** Draft text, projection gestures, agent
+   output, JavaScript callbacks, and renderer state cannot directly mutate the
+   committed graph.
+3. **Commit is atomic; effects are not commit.** Persistence of the next graph
+   and its applied transaction is one atomic decision. Source rewriting and
+   rendering are post-commit effects with explicit recovery state.
+4. **Identity names its stability scope.** Source handles, projection handles,
+   semantic node IDs, renderer IDs, and document IDs are distinct.
+5. **Generated input is data.** It crosses a bounded, schema-validated request
+   boundary and never carries executable callbacks or host objects.
+
+## State and authority model
+
+A Generative UI document has five first-class state classes:
+
+1. **Draft source state** — lossless source and CST at a `DraftRevision`,
+   possibly incomplete or unresolved.
+2. **Committed semantic state** — a valid UI graph identified by `DocumentId`,
+   `GraphRevision`, and `SchemaRevision`, plus the canonical digest of the
+   immutable schema descriptor named by that revision.
+3. **Commit history and request ledger** — applied batches plus request IDs,
+   actor, provenance, approval evidence, terminal outcomes, and schema
+   revisions. Applied history explains how meaning changed; the request ledger
+   provides retry safety and auditability.
+4. **Runtime state** — host-owned binding values, interaction and tool state,
+   and renderer/session-local working state.
+5. **Sync state** — the explicit relation among draft, committed graph, source
+   rewrite cursor, and each renderer baseline, including drafting,
+   rewrite-conflict, schema-unavailable, and dirty-renderer conditions.
+
+The committed graph is authoritative for current document meaning. Applied
+history is authoritative for accepted semantic changes. The request ledger is
+not document meaning, and runtime values never become document meaning merely
+because a renderer displays them.
+
+Draft source may intentionally differ from committed semantics. Parse or
+lowering failures update diagnostics and sync state while the last valid
+committed graph remains current. No path may silently promote draft, runtime,
+or renderer state into committed meaning.
+
+## The semantic commit boundary
+
+The semantic commit protocol is the only path that can advance committed
+meaning. Regular edits enter through `UiOperationRequested`, which carries a
+non-empty forward `OperationBatch`; the batch, not each primitive, is the
+transaction unit. A future schema migration uses the same atomic commit
+protocol through a separate host-only gate rather than a generated operation
+request.
+
+```text
+UiOperationRequested
+  → request-ID lookup and limit validation
+  → host policy / authority gate
+  → approval evidence check (if required)
+  → base graph + schema revision check
+  → pure ordered batch application on a private working graph
+  → final graph invariant + component schema validation
+  → classify terminal outcome
+     Applied          → atomically persist graph, revision,
+                        AppliedUiOperation, RequestRecord, and effect outbox
+     NoSemanticChange → persist RequestRecord only
+     Rejected         → persist RequestRecord only
+  → respond; run source-rewrite and renderer effects only after Applied
+```
+
+`AppliedUiOperation` names the committed envelope for the whole batch. Primitive
+operations are not independently committed. One committed batch advances
+`GraphRevision` exactly once.
+
+Every terminal outcome of a host-constructed request — `Applied`,
+`NoSemanticChange`, or `Rejected` — produces a conceptual `RequestRecord`
+containing the request ID, canonical request content (or an equality-preserving
+canonical representation), canonical digest, terminal outcome, and any resolved
+handle-to-ID mapping. The host persists this record before responding to the
+caller. Proposal decoding or limit failures that occur before the host
+constructs a canonical request are boundary diagnostics rather than
+request-ledger outcomes.
+
+An `Applied` outcome is atomic with the graph, applied history, and outbox
+entries. `NoSemanticChange` and `Rejected` records do not advance graph
+revision and do not append to applied history. A rejected batch leaves the
+graph, graph revision, applied history, source, and renderer baselines
+unchanged. If the final semantic state equals the initial semantic state, the
+result is `NoSemanticChange`: no semantic revision advances and no
+`AppliedUiOperation` is appended.
+
+The host owns the component registry and schema revision. Generated input may
+name only host-issued components and capabilities; it cannot register a
+component, choose another schema revision, or supply approval evidence on the
+host's behalf.
+
+## Semantic commit versus renderer apply
+
+Actual DOM or renderer mutation is not part of the semantic transaction. Only
+renderer-independent document schema and capability policy may reject a graph
+before semantic commit. An adapter may run a pure preflight before applying a
+committed graph, but its result changes that renderer's sync state rather than
+the semantic transaction. Semantic commit never depends on an actual DOM
+mutation succeeding.
+
+A committed transaction emits durable source-rewrite and render work through
+an outbox. Renderer success advances that renderer's baseline. Renderer failure
+leaves the committed graph unchanged, marks only that renderer dirty, and
+schedules repair from the committed graph.
+
+The existing JSX session keeps its accepted V1 rule that a candidate is not
+reported as committed until DOM application succeeds
+([JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md)).
+That is an adapter/session commit for the current candidate pipeline. It must
+not define the new document engine's semantic commit, because one renderer's
+availability cannot determine meaning for every renderer.
+
+## Request envelope and idempotency
+
+A request contains, conceptually:
+
+| Field | Rule |
+| --- | --- |
+| `RequestId` | Host-issued and unique within one document; reused IDs must carry the same canonical request content; the digest is an index and check, not an equality proxy. |
+| Actor and provenance | Host-attested origin such as text, projection, agent, or undo. |
+| Base graph revision | Must equal the current `GraphRevision`. |
+| Base schema revision | Must equal the committed `SchemaRevision`. |
+| Origin revision | Required for text-derived requests; identifies the exact `DraftRevision` that was lowered. |
+| Approval evidence | Host-issued evidence when required by the current user-authorized, revocable policy; generated input cannot mint it. |
+| `OperationBatch` | Non-empty ordered list of bounded primitive operations. |
+
+The canonical digest is computed from the validated typed request, not from
+raw transport bytes. It includes a version or domain tag, document and actor
+identity, provenance, base revisions, approval evidence identity, and the
+ordered canonical batch. It excludes `RequestId`, transport timestamps,
+whitespace, and object-key order. Boundary validation rejects duplicate object
+keys and non-finite numbers; canonical encoding orders map keys and gives
+`BindingRef` one stable representation before digest computation. Digest
+equality never establishes request equality.
+
+Two committed semantic states are equal only when they share the same schema
+revision, root identity, semantic node IDs, components, canonical properties,
+and ordered children. `GraphRevision`, history, draft complement, runtime,
+renderer, and diagnostics are excluded from semantic equality. Changing
+`SchemaRevision` is a semantic change even when the node graph is otherwise
+identical.
+
+A repeated `RequestId` with equal canonical request content returns the
+recorded terminal outcome only after the stored digest matches the canonical
+content. A mismatch fails closed as an integrity error. Neither path alters the
+existing record, committed graph, applied history, or effect outbox.
+
+A repeated `RequestId` with different canonical request content is always
+rejected without mutation. If the digest is equal despite differing content,
+classify it as a collision; if the digest differs, classify it as request-ID
+reuse. Neither case may alter the existing `RequestRecord`, committed graph,
+applied history, or effect outbox.
+
+The initial slice does not compact request records. A later retention design
+may remove canonical content only after it defines and tests an equality-
+preserving tombstone or a monotonic actor request sequence that still rejects
+ID reuse and digest collisions. A digest or unspecified actor watermark alone
+is insufficient.
+
+A text-derived request is rejected and re-lowered if its origin revision is no
+longer the current draft revision. Projection- and agent-derived requests use
+the committed graph revision for semantic conflict detection; source rewrite
+uses a separate compare-and-swap rule described below.
+
+## Forward operation algebra
+
+### Primitive vocabulary
+
+| Primitive | Meaning |
+| --- | --- |
+| `InsertNode` | Declare one request-local new-node handle with component, initial properties, parent, and placement. |
+| `MoveNode` | Move an addressed non-root node to a parent and placement. |
+| `SetProperty` | Add or replace one declarative property value. |
+| `RemoveProperty` | Remove one declarative property. This is distinct from assigning `null`. |
+| `RemoveNode` | Atomically remove the addressed node and its complete subtree. |
+
+Requests address committed nodes with `Existing(UiNodeId)` and nodes introduced
+in the same batch with `New(NewNodeHandle)`. A new-node handle is unique only
+inside its request and must be declared exactly once by `InsertNode`. Each
+`NewNodeHandle` is resolved to its declaration-order insertion ordinal before
+pure apply. The logical `UiNodeId` is an opaque deterministic derivation from
+`(DocumentId, RequestId, insertion ordinal)`. The resolution is pure, retries
+produce the same mapping, different request-ordinal pairs produce different
+IDs, and generated input cannot select durable IDs. Once ID resolution occurs,
+the terminal `RequestRecord` stores the handle-to-ID mapping, and an applied
+envelope stores the same resolved mapping; generated callers have no path to
+mint durable IDs.
+
+`InsertNode` inserts one node rather than an arbitrary subtree. A caller builds
+a subtree with an ordered batch whose parent insertions precede their children.
+Initial properties must satisfy node-local required-property rules at insertion;
+full child-cardinality and graph invariants are checked on the completed private
+working graph.
+
+`RemoveProperty` is a forward operation, not merely an undo detail. The
+separation from `SetProperty` preserves schemas where `null` is a valid value
+and makes deletion explicit in audit and approval policy.
+
+Primitive preconditions are strict. `InsertNode` requires an undeclared local
+handle, an allowed component, and an already resolvable parent. `MoveNode` and
+`RemoveNode` require an existing non-root target; a move beneath the target's
+own subtree is rejected before mutation. `RemoveProperty` requires the property
+to be present. `SetProperty` may assign the current value, and `MoveNode` may
+resolve to the current placement; the final no-semantic-change rule decides
+whether the batch commits.
+
+Changing a node's component kind is not an initial primitive. An adapter lowers
+that change to subtree removal and insertion with fresh semantic identity unless
+a later domain use case proves that cross-kind identity must survive.
+
+### Placement
+
+Tree insertion and movement use identity-relative placement rather than raw
+numeric indexes:
+
+- `AtStart`
+- `AtEnd`
+- `Before(sibling_ref)`
+- `After(sibling_ref)`
+
+A sibling reference may be an existing semantic ID or an earlier request-local
+new-node handle. The anchor must be a child of the target parent in the private
+working graph at that point in batch evaluation. For a move within one parent,
+the moved node is detached before placement is resolved. Missing, removed,
+self, forward, or wrong-parent anchors reject the whole batch.
+
+### Batch laws
+
+A forward `OperationBatch` obeys these laws:
+
+1. It is non-empty and evaluated in source order against one private working
+   graph.
+2. Structural preconditions are checked as each primitive is evaluated; final
+   tree and schema invariants are checked on the completed working graph.
+3. Later primitives may address nodes inserted or moved earlier in the same
+   batch.
+4. Any failure rejects the entire batch. No prefix becomes visible in the
+   graph, history, source, or renderer.
+5. A successful batch creates one applied-history record and advances graph
+   revision once, regardless of primitive count.
+6. A batch whose final graph equals its base graph is `NoSemanticChange` and
+   does not advance semantic revision.
+7. Limits apply to primitive count, inserted nodes, resulting graph growth,
+   property depth, string/collection size, and total decoded request size.
+
+These laws make a multi-node text edit, projection gesture, agent proposal, or
+undo one transaction without exposing partially valid meaning.
+
+### Graph invariants
+
+Pure apply and final validation preserve at least these invariants:
+
+- Semantic node IDs are host-derived, unique within the document, and never
+  reused.
+- The host-owned generated-surface root exists and cannot be inserted, moved,
+  or removed by a request.
+- Every non-root node has exactly one parent; the tree is connected and
+  acyclic.
+- Every placement resolves to one deterministic sibling order.
+- Every component and property is allowed by the pinned component schema.
+- Required properties, child kinds, child cardinality, and graph-size limits
+  hold in the final graph.
+- Runtime binding values, callbacks, JavaScript objects, DOM handles, and host
+  chrome identities are absent from the graph.
+- The first operation slice has no property-level references to arbitrary
+  `UiNodeId` values. A future reference algebra must define dangling-reference
+  and removal policy before such references are admitted.
+
+## Value and schema boundary
+
+Committed property values are immutable, bounded data. The initial value
+algebra is JSON-shaped literals plus host-issued symbolic `BindingRef` values
+when a component schema explicitly permits them. A `BindingRef` identifies a
+host capability; the resolved binding value stays in runtime state and is not
+serialized into the graph. An unavailable or revoked `BindingRef` produces a
+runtime `BindingUnavailable` diagnostic and yields no value; it does not
+mutate or invalidate the committed graph.
+
+The initial algebra excludes expressions, functions, action callbacks, raw
+HTML, URLs with ambient authority, provider objects, DOM nodes, and JavaScript
+host objects. Commands and side effects require a separate commands-as-data and
+approval design.
+
+Each `SchemaRevision` names one immutable canonical schema descriptor. Every
+committed graph and applied transaction pins both that revision and the
+canonical descriptor digest. Regular generated requests can only target that
+revision. On restore, the host must supply a descriptor whose identity and
+digest both match. A missing descriptor, a reused revision with different
+content, or a digest mismatch preserves the committed bytes and history but
+enters `SchemaUnavailable`: no reinterpretation, semantic commit, or rendering
+occurs under a different schema.
+
+A schema migration is a separate host-only command boundary, not a normal
+generated `OperationBatch`. It validates the complete migrated graph under the
+target schema, records both schema revisions and migration provenance
+atomically, and never runs merely because a new registry version is installed.
+The initial operation slice implements only fail-closed `SchemaUnavailable`;
+migration authoring remains deferred.
+
+## Inverse algebra and undo
+
+Pure batch application captures the before-images required to derive an
+internal inverse batch:
+
+| Forward primitive | Internal inverse |
+| --- | --- |
+| `InsertNode` | `RemoveNode` |
+| `MoveNode` | `MoveNode` to the previous parent and placement |
+| `SetProperty` on an existing property | `SetProperty` with the previous value |
+| `SetProperty` on an absent property | `RemoveProperty` |
+| `RemoveProperty` | `SetProperty` with the removed value |
+| `RemoveNode` | `RestoreSubtree` with the complete validated before-image |
+
+The inverse of a batch applies primitive inverses in reverse order.
+`RestoreSubtree` is internal because it carries trusted before-images and may
+resurrect semantic IDs that generated callers must never mint or reuse.
+
+Undo never rewinds graph revision or edits applied history. It submits the
+inverse as a new request at the current base revision, passes current policy
+and schema validation, and may be rejected if intervening changes invalidate
+its preconditions. The private core need not expose undo, but any product
+adapter that permits generated commits must provide a user-visible reversal
+path. The exact history retention and interaction design remain later choices.
+
+## Draft, rewrite, and renderer transitions
+
+State changes follow a reducer-shaped boundary:
+
+```text
+DocumentState + DocumentEvent → DocumentState + Decision
+```
+
+The functional core decides transitions and emits commands. The shell performs
+persistence, parsing, source rewriting, rendering, clocks, and provider I/O,
+then reports their results as new events.
+
+The required transition behavior is:
+
+1. **Draft edited:** preserve the exact source, advance `DraftRevision`, and
+   request parse/lowering. Committed meaning does not change.
+2. **Parse or lowering failed:** retain diagnostics and enter drafting state.
+   The last committed graph remains current.
+3. **Text lowering found no semantic delta:** retain the new lossless syntax
+   complement and mark it semantically synchronized without creating a request
+   or advancing graph revision.
+4. **Text lowering produced semantics:** resolve source-local handles to
+   existing semantic IDs or request-local new-node handles, then produce one
+   batch tied to the exact draft and graph revisions. If either base is stale
+   at commit time, reject and re-lower.
+5. **Semantic batch committed:** atomically advance the graph and enqueue
+   source-rewrite and render effects.
+6. **Text-origin commit:** if the committed batch describes the still-current
+   draft, mark the draft synchronized without rewriting it.
+7. **Projection- or agent-origin commit:** rewrite source only when the draft
+   revision, rewrite-eligible status, and source semantic baseline all match
+   the effect preconditions. Otherwise the draft is preserved byte-for-byte
+   and enters `RewriteConflict`; the committed graph is not rolled back.
+8. **Renderer applied:** advance only that renderer's baseline.
+9. **Renderer failed:** retain committed meaning, mark that renderer dirty, and
+   repair from the committed graph.
+
+A host policy may defer projection or agent commits while a draft is dirty, but
+the engine's safety rule is stronger: even when such a commit is allowed, it
+must never overwrite a diverged draft. Temporary disagreement is explicit
+state, not silent loss and not corruption.
+
+## Identity scopes
+
+The following identities must not be confused:
+
+| Scope | Owner | Stability |
+| --- | --- | --- |
+| Source-local handle | draft source / CST | One source instance; renameable and rewriteable. |
+| Request-local new-node handle | one `UiOperationRequested` | Exists only while validating one batch. |
+| Current Canopy projection `NodeId` | session projection ([ProjNode](../../core/proj_node.mbt), [ProjectionMemo](../../core/projection_memo.mbt)) | Session-local projection continuity. |
+| `UiNodeId` | Generative UI document | Stable within one logical document and its full-state restore. |
+| Renderer node ID | one renderer/session registry | Adapter-local. |
+| `DocumentId` | persistence/host boundary | Distinguishes restore from import, clone, or fork. |
+
+A semantic identity is the pair `(DocumentId, UiNodeId)`. The deterministic
+derivation of `UiNodeId` from `(DocumentId, RequestId, insertion ordinal)`
+means retries produce the same allocation without exposing the derivation to
+generated input. Derived IDs are recorded even if later operations in the same
+committed batch remove the new node, and IDs are never reused within one
+document history. A no-op request namespace remains reserved by its
+`RequestId`. The serialized and hash representation is private and
+collision-checked.
+
+Full-state restore preserves `DocumentId` and `UiNodeId`. Plain-text import
+creates a new `DocumentId` and fresh semantic IDs; it does not claim identity
+continuity. Clone or fork creates a new `DocumentId`, even if an implementation
+preserves local node labels for diagnostics.
+
+`UiNodeId` is internal to `GenerativeUiDocument`. It is not a new public stable
+entity ID for existing Canopy languages and must not be backed by projection
+`NodeId`. Its representation remains private so a future collaborative version
+can compose with `event-graph-walker` tree identity rather than maintain a
+second causal identity system.
+
+The existing `data-node-id` reservation
+([JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md))
+is separate evidence that renderer identity is adapter-owned; it does not
+establish semantic identity.
+
+## Persistence and recovery invariants
+
+A semantic commit durably groups:
+
+- the next graph or checkpoint/delta reference;
+- next graph revision, pinned schema revision, and canonical schema descriptor
+  digest;
+- the complete validated `AppliedUiOperation` batch, resolved new-node ID
+  allocations, and provenance;
+- the request ID, canonical request content (or an equality-preserving canonical
+  representation), canonical digest, and terminal outcome; replay compares
+  canonical content, not digest equality;
+- the source-rewrite and renderer outbox entries.
+
+After a crash, recovery loads the latest valid checkpoint and replays a
+contiguous applied-history suffix. Every replay step must match its base graph
+and schema revisions and produce the recorded next revision. The reconstructed
+graph must equal the stored checkpoint at the same revision. The restored
+schema descriptor must match the pinned revision and digest. A gap, canonical-
+content or digest mismatch, unavailable or changed schema, or replay mismatch fails closed
+into diagnostic read-only state; recovery must not guess a graph.
+
+Each outbox entry carries conceptual effect metadata: an `EffectId`, target,
+base graph revision, target graph revision, a graph hash or snapshot
+reference, and an optional expected draft revision or status. Delivery is
+at-least-once, so source and renderer adapters must be idempotent against
+their recorded effect IDs and baselines. Redelivery cannot create another
+semantic commit.
+
+Renderer rule: dirty state takes precedence over stale acknowledgment and
+rebuilds from the latest committed snapshot. When the renderer is clean, a
+target revision at or below its baseline is stale and treated as an
+acknowledgment; a base equal to the baseline may apply; a gap rebuilds from
+the latest committed snapshot and never applies an older delta. Source rewrite rule: a source effect requires a
+matching draft revision, valid and rewrite-eligible draft state, and a
+matching source semantic baseline; otherwise the source is preserved and the
+effect enters `RewriteConflict`. Gaps are coalesced to the latest committed
+snapshot and its canonical source rather than replaying stale intermediate
+patches. Observed state remains monotonic.
+
+Checkpoint cadence, compaction format, and storage backend remain
+implementation decisions. Their representations may vary; the atomicity,
+replay, and fail-closed rules may not.
+
+The initial applied history is a single-writer transaction/audit log. It must
+not acquire ad hoc causal merge semantics. If collaborative semantic editing is
+introduced, `event-graph-walker` owns causal history, tree CRDT semantics,
+sync, and undo; this layer must adapt to those APIs rather than compete with
+them ([Stable Document Entity Graph](stable-document-entity-graph.md)).
+
+## Concurrency policy
+
+The initial document engine serializes semantic requests. A request with a
+stale graph or schema revision is rejected; it is not automatically rebased.
+Text edits may continue in draft state, but only an exact draft revision can
+produce a text-derived commit.
+
+This is a strict optimistic-concurrency policy, not a semantic CRDT merge
+claim. Identity-relative placement reduces accidental index coupling but does
+not itself provide concurrent ordering semantics.
+
+## Existing implementation to reuse
+
+| Concern | Source |
+| --- | --- |
+| Request lifecycle and generation rules | [GenerativeUiLifecycle](../../lib/cognition/generative_ui.mbt) |
+| Fail-closed candidate and capability validation | [GenerativeUiCandidate](../../lib/cognition/generative_ui_candidate.mbt) |
+| JSX adapter preflight, DOM apply, dirty recovery | [JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md); [render_baseline](../../ffi/jsx/render_baseline.mbt) |
+| Lossless parser and CST | [Loom](../../loom/) |
+| Projection, ViewNode, ViewPatch adapters | [Responsibility Map](../architecture/responsibility-map.md); [ProjNode](../../core/proj_node.mbt) |
+| Future CRDT semantics | `event-graph-walker` (submodule) |
+
+## Existing implementation not to freeze into the core
+
+Current adapter behavior remains local to its adapter and must not become
+permanent core semantics:
+
+- Whole-candidate synthetic JSX lowering
+  ([generative_ui_adapter](../../ffi/jsx/generative_ui_adapter.mbt)).
+- Candidate-always-remount behavior
+  ([render_baseline](../../ffi/jsx/render_baseline.mbt)).
+- Session-local and synthetic node IDs.
+- `DomPatch` as renderer-neutral semantics. It is a JSX session boundary, not
+  a universal patch contract.
+- Normalized JSX `Renderable::unparse` output as a lossless or byte-faithful
+  writer ([JSX proj_traits](../../loom/examples/jsx/proj_traits.mbt)).
+- Table, filter, and summary candidate variants as generic core. They are
+  first-slice adapter content.
+
+## Execution and trust boundary
+
+The `js_engine` supports persistent interpreter state, JSON calls, explicit
+queues, and advanced host objects. Its stable embedding documentation states that it is
+not a security sandbox (js_engine `docs/EMBEDDING.md`,
+`docs/design/embedded-runtime-vision.md`).
+
+An agent adapter may submit only a decoded proposal body. Boundary decoding
+makes a bounded immutable copy; no callback, source handle, semantic graph
+reference, renderer registry, DOM object, or host object crosses with it. The
+host constructs `UiOperationRequested` and attaches its request ID, actor,
+schema, generation, authority, and approval facts rather than trusting
+agent-supplied claims.
+
+Arbitrary agent-generated orchestration code remains gated on deterministic
+execution budgets, interruption, re-entry rules, disposal/generation tokens,
+async-host completion lifetime, and a killable Wasm or process boundary if
+hostile code is claimed safe. The operation slice proves the structured request
+boundary without executing arbitrary agent-generated JavaScript.
+
+Trusted host chrome and approval UI use a separate root, component registry,
+and authority domain from the generated surface. The current JSX contract
+reserves `data-node-id` and keeps expression spans inert. Those controls
+constrain adapter injection, but they do not establish the full structural
+separation required by the document engine.
+
+## Text adapter
+
+A temporary text adapter is permitted: newline-committed, flat declarations
+with explicit parent and placement, plus a lossless per-record complement. It
+is not the final language. JSX remains an adapter and import surface; JSON
+Lines remains only a possible wire format.
+
+For snapshot-style text, a syntactically complete newline-terminated declaration
+prefix must retain the same lowered meaning when an incomplete suffix is
+appended. This snapshot-prefix rule does not apply to append-only operation
+streams whose later records intentionally move, update, or remove earlier
+nodes.
+
+## Staged direction
+
+1. Preserve the existing structured-candidate lifecycle and JSX session as the
+   validated V1 adapter baseline.
+2. Introduce the renderer-independent semantic graph, forward batch algebra,
+   reducer transitions, persistence boundary, and structured request envelope.
+3. Add the temporary text adapter and projection/agent request adapters; prove
+   rewrite-conflict behavior without arbitrary JavaScript execution.
+4. Add a materially different renderer and validate shared graph, identity,
+   state-preservation, and capability invariants.
+5. Only then consider a public renderer-neutral contract or collaborative
+   semantic editing.
+
+The private core may test step 2 as a discardable falsification experiment. It
+must not add product or adapter behavior before the personal-knowledge fixed
+baseline and existing V1 gates pass, and it cannot freeze a renderer-neutral
+contract before the use-case and second-adapter evidence above.
+
+## Proof obligations
+
+Deterministic unit, property, replay, and boundary tests must establish each
+obligation before the corresponding behavior is claimed safe:
+
+- Only the semantic transaction boundary advances committed meaning.
+- A failed primitive rejects the whole batch; no prefix is observable.
+- One successful batch advances graph revision once; a semantic no-op does not.
+- `RemoveProperty` is distinguishable from assigning `null`.
+- Duplicate request delivery with equal canonical content and a matching stored
+  digest cannot apply a batch twice; canonical-content/digest mismatch fails
+  closed.
+- Request-local handles resolve once to the recorded semantic IDs and cannot
+  mint or reuse durable IDs.
+- Derived inverse batches restore the prior graph when their preconditions
+  still hold.
+- Syntax-only edits preserve committed meaning and graph revision.
+- Invalid or concurrently changed draft text is never overwritten by a source
+  rewrite.
+- Renderer failure cannot roll back or advance semantic meaning.
+- Checkpoint replay reconstructs exactly the committed graph and fails closed
+  on gaps, mismatches, or an unavailable or changed schema descriptor.
+- Persisted `NoSemanticChange` and `Rejected` records survive restart and retry
+  without creating graph revisions, applied history, or outbox entries.
+- Projection and renderer IDs cannot be observed as durable semantic identity.
+- Stale graph, schema, and text-derived draft revisions are rejected.
+- Generated input cannot obtain host chrome, callbacks, runtime binding values,
+  DOM handles, or component-registration authority.
+- The host trust boundary is structural rather than policy-only.
+- Every host-constructed request persists its terminal `RequestRecord` before
+  the response is sent.
+- Canonical-equivalent transport inputs produce identical digests regardless of
+  key order, whitespace, or transport encoding.
+- An equal-digest, different-content collision is rejected without mutation and
+  does not alter the existing `RequestRecord`, committed graph, applied history,
+  or effect outbox.
+- A `SchemaRevision` change is semantic even when the node graph is otherwise
+  identical.
+- Arbitrary duplicated or out-of-order effect delivery converges monotonically;
+  dirty repair takes precedence over stale acknowledgment, and stale
+  intermediate patches are never applied.
+- Stale source rewrite effects never overwrite a diverged draft.
+- Deterministic node identity produces the same mapping on retry and different
+  mappings for distinct request-ordinal pairs.
+
+### Falsifiable validation gate
+
+Before production source, renderer, persistence, or JavaScript integration, a
+private semantic core must pass one deterministic transcript:
+
+1. Preserve an invalid human draft while keeping the last committed graph.
+2. Apply one duplicated host-constructed agent request exactly once.
+3. Reject its stale source rewrite as `RewriteConflict` without changing draft
+   bytes.
+4. Converge a failed renderer after duplicate, stale, and out-of-order effects
+   without regressing its baseline.
+5. Restart from checkpoint, history, request records, and outbox with the same
+   graph, schema revision, semantic IDs, draft bytes, and terminal outcome.
+
+The [Semantic-core validation plan](../plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md)
+defines the reference model, observation oracle, fault injection, generated
+traces, and evidence mapping. The gate covers only obligations observable in the
+private core and fake shell. It does not establish adapter isolation, host trust,
+hostile-JavaScript safety, collaboration, agency, accessibility, or product
+value. It cannot authorize PKE semantic candidates before that direction's
+fixed deterministic baseline is accepted. Product claims remain subject to the [Human-centered product principles](../architecture/human-centered-product-principles.md)
+gates for agency and contestability, inclusion and cognitive steady state, and
+net value against fixed alternatives; the other boundaries require their own
+validation.
+
+Collection, tree, replay, and state-machine laws require unit and property
+tests. `moon prove` is optional and limited to small scalar decision functions
+that compile under the documented prover constraints. Failure of the fixed
+transcript requires revising or rejecting this document-engine direction before
+adapter work begins.
+
+## Deferred decisions
+
+- Storage backend, checkpoint cadence, compaction, and retention sizing.
+- The approval and preview interaction layered over the required
+  user-authorized, revocable policy.
+- The host migration authoring API beyond the fail-closed schema rules above.
+- The user-visible reversal interaction and which historical transactions
+  remain undoable.
+- When or whether the text adapter becomes a first-class language.
+- When or whether to promote the operation vocabulary to a public API.
+- The exact mapping to `event-graph-walker` if collaborative semantic editing
+  is introduced.
+- The second-renderer conformance contract.

--- a/docs/design/incremental-generative-ui-document-engine.md
+++ b/docs/design/incremental-generative-ui-document-engine.md
@@ -2,681 +2,395 @@
 
 **Status:** Design direction; not implemented.
 
-**Related:** [Generative UI direction](../architecture/generative-ui-direction.md) · [Stable Document Entity Graph](stable-document-entity-graph.md) · [JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md) · [Input vertical slice](../plans/2026-07-12-generative-ui-input-vertical-slice.md) · [Responsibility Map](../architecture/responsibility-map.md) · [Human-centered product principles](../architecture/human-centered-product-principles.md)
+**Related:**
+
+- [Generative UI direction](../architecture/generative-ui-direction.md)
+- [Stable Document Entity Graph](stable-document-entity-graph.md)
+- [JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md)
+- [Input vertical slice](../plans/2026-07-12-generative-ui-input-vertical-slice.md)
+- [Responsibility Map](../architecture/responsibility-map.md)
+- [Human-centered product principles](../architecture/human-centered-product-principles.md)
 
 ## Load-bearing question
 
-A Generative UI document receives text, projection, and agent inputs that may
-be incomplete, conflicting, duplicated, stale, or unapproved. The load-bearing
-question is not which syntax carries a proposal. It is which transition counts
-as committed document meaning.
+Text, projections, and agents can produce incomplete, stale, duplicated, or
+unapproved proposals. Which transition becomes document meaning?
 
-The answer is a validated, atomic semantic transaction. Text, projection, and
-agent adapters may propose transactions, but none of them is document
-authority.
+For a new `GenerativeUiDocument`, the answer is one validated, atomic change to
+a committed `UiGraph`. Proposal sources never mutate that graph directly.
+Existing Canopy editors remain text/CRDT authoritative.
 
-## Scope and non-goals
+This design is bounded research. It does not authorize generated behavior
+before the personal-knowledge fixed baseline or existing Generative UI V1 gates
+pass. It also does not define a public renderer-neutral API, final source
+syntax, or CRDT/causal-merge semantics.
 
-This is a narrowly scoped operation/semantic-authoritative model for a new
-`GenerativeUiDocument`. Current Canopy remains text/CRDT authoritative for
-existing language editors; this document does not replace that responsibility
-map ([Responsibility Map](../architecture/responsibility-map.md)).
+## Authority and state
 
-Not included:
+The document keeps five state classes separate:
 
-- An implementation plan, task checklist, or file-by-file breakdown.
-- A global replacement of the text-first Canopy pipeline.
-- A public renderer-neutral API. The first implementation remains internal
-  until a real vertical slice and a materially different renderer validate the
-  shared invariants.
-- A change to the current product sequence. A private semantic core is bounded
-  falsification research, not permission to add generated behavior before the
-  fixed personal-knowledge baseline is accepted or to bypass the existing V1
-  adapter gates.
-- A claim that the operation history provides CRDT or causal-merge semantics.
+| State | Authority |
+| --- | --- |
+| Draft | Lossless source and CST at a `DraftRevision`; may be invalid or incomplete. |
+| Committed semantic | Valid `UiGraph`, document/graph/schema IDs, and immutable schema digest. |
+| History and request ledger | Applied batches plus terminal records for retry and audit. |
+| Runtime | Host bindings, interaction state, and renderer-local state; never document meaning. |
+| Sync | Draft/graph relation, rewrite cursor, renderer baselines, conflicts, and dirty state. |
 
-## First principles
+The committed graph is current meaning. Invalid draft updates diagnostics and
+sync state while the last valid graph remains current. No path silently
+promotes draft, runtime, or renderer state.
 
-The design follows five rules:
+## Semantic commit
 
-1. **Current meaning has one authority.** A valid committed UI graph at an
-   explicit revision is the current document meaning.
-2. **Proposals are not authority.** Draft text, projection gestures, agent
-   output, JavaScript callbacks, and renderer state cannot directly mutate the
-   committed graph.
-3. **Commit is atomic; effects are not commit.** Persistence of the next graph
-   and its applied transaction is one atomic decision. Source rewriting and
-   rendering are post-commit effects with explicit recovery state.
-4. **Identity names its stability scope.** Source handles, projection handles,
-   semantic node IDs, renderer IDs, and document IDs are distinct.
-5. **Generated input is data.** It crosses a bounded, schema-validated request
-   boundary and never carries executable callbacks or host objects.
-
-## State and authority model
-
-A Generative UI document has five first-class state classes:
-
-1. **Draft source state** — lossless source and CST at a `DraftRevision`,
-   possibly incomplete or unresolved.
-2. **Committed semantic state** — a valid UI graph identified by `DocumentId`,
-   `GraphRevision`, and `SchemaRevision`, plus the canonical digest of the
-   immutable schema descriptor named by that revision.
-3. **Commit history and request ledger** — applied batches plus request IDs,
-   actor, provenance, approval evidence, terminal outcomes, and schema
-   revisions. Applied history explains how meaning changed; the request ledger
-   provides retry safety and auditability.
-4. **Runtime state** — host-owned binding values, interaction and tool state,
-   and renderer/session-local working state.
-5. **Sync state** — the explicit relation among draft, committed graph, source
-   rewrite cursor, and each renderer baseline, including drafting,
-   rewrite-conflict, schema-unavailable, and dirty-renderer conditions.
-
-The committed graph is authoritative for current document meaning. Applied
-history is authoritative for accepted semantic changes. The request ledger is
-not document meaning, and runtime values never become document meaning merely
-because a renderer displays them.
-
-Draft source may intentionally differ from committed semantics. Parse or
-lowering failures update diagnostics and sync state while the last valid
-committed graph remains current. No path may silently promote draft, runtime,
-or renderer state into committed meaning.
-
-## The semantic commit boundary
-
-The semantic commit protocol is the only path that can advance committed
-meaning. Regular edits enter through `UiOperationRequested`, which carries a
-non-empty forward `OperationBatch`; the batch, not each primitive, is the
-transaction unit. A future schema migration uses the same atomic commit
-protocol through a separate host-only gate rather than a generated operation
-request.
+`UiOperationRequested` carries a non-empty ordered `OperationBatch`. The batch,
+not each primitive, is the transaction unit.
 
 ```text
-UiOperationRequested
-  → request-ID lookup and limit validation
-  → host policy / authority gate
-  → approval evidence check (if required)
-  → base graph + schema revision check
-  → pure ordered batch application on a private working graph
-  → final graph invariant + component schema validation
-  → classify terminal outcome
-     Applied          → atomically persist graph, revision,
-                        AppliedUiOperation, RequestRecord, and effect outbox
-     NoSemanticChange → persist RequestRecord only
-     Rejected         → persist RequestRecord only
-  → respond; run source-rewrite and renderer effects only after Applied
+request lookup and bounds
+→ host authority and approval policy
+→ graph and schema revision checks
+→ pure batch apply on a private graph
+→ final graph and schema validation
+→ terminal outcome
+   Applied          → atomically persist graph, revision, applied batch,
+                      request record, and outbox
+   NoSemanticChange → persist request record only
+   Rejected         → persist request record only
+→ respond; release post-commit effects only for Applied
 ```
 
-`AppliedUiOperation` names the committed envelope for the whole batch. Primitive
-operations are not independently committed. One committed batch advances
-`GraphRevision` exactly once.
+Before responding, the host persists a durable `RequestRecord` with the request
+ID, canonical content, digest, outcome, and resolved handle-to-ID mapping.
+Decode or bounds failures before canonical request construction remain boundary
+diagnostics.
 
-Every terminal outcome of a host-constructed request — `Applied`,
-`NoSemanticChange`, or `Rejected` — produces a conceptual `RequestRecord`
-containing the request ID, canonical request content (or an equality-preserving
-canonical representation), canonical digest, terminal outcome, and any resolved
-handle-to-ID mapping. The host persists this record before responding to the
-caller. Proposal decoding or limit failures that occur before the host
-constructs a canonical request are boundary diagnostics rather than
-request-ledger outcomes.
+Only `Applied` advances `GraphRevision`. `NoSemanticChange` and `Rejected` are
+ledger-only outcomes: they add no applied history or outbox work. Rejection
+also exposes no partial batch and changes no graph, source, or renderer
+baseline.
 
-An `Applied` outcome is atomic with the graph, applied history, and outbox
-entries. `NoSemanticChange` and `Rejected` records do not advance graph
-revision and do not append to applied history. A rejected batch leaves the
-graph, graph revision, applied history, source, and renderer baselines
-unchanged. If the final semantic state equals the initial semantic state, the
-result is `NoSemanticChange`: no semantic revision advances and no
-`AppliedUiOperation` is appended.
+The host owns the component registry, schema, authority facts, and approval
+evidence. Generated input can name only capabilities allowed by the pinned
+schema. A product adapter must enforce a person-authorized, revocable policy
+and require approval where that policy says; generated input cannot mint
+approval evidence.
 
-The host owns the component registry and schema revision. Generated input may
-name only host-issued components and capabilities; it cannot register a
-component, choose another schema revision, or supply approval evidence on the
-host's behalf.
+## Renderer separation
 
-## Semantic commit versus renderer apply
+Semantic commit does not depend on DOM or renderer success. A committed change
+emits durable source and renderer work through an outbox. Renderer failure
+leaves meaning unchanged, marks only that renderer dirty, and schedules repair
+from the committed graph.
 
-Actual DOM or renderer mutation is not part of the semantic transaction. Only
-renderer-independent document schema and capability policy may reject a graph
-before semantic commit. An adapter may run a pure preflight before applying a
-committed graph, but its result changes that renderer's sync state rather than
-the semantic transaction. Semantic commit never depends on an actual DOM
-mutation succeeding.
+The existing JSX session still follows its V1 rule that a candidate is not
+reported committed until DOM apply succeeds. That adapter/session contract does
+not define semantic authority for the new document engine.
 
-A committed transaction emits durable source-rewrite and render work through
-an outbox. Renderer success advances that renderer's baseline. Renderer failure
-leaves the committed graph unchanged, marks only that renderer dirty, and
-schedules repair from the committed graph.
-
-The existing JSX session keeps its accepted V1 rule that a candidate is not
-reported as committed until DOM application succeeds
-([JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md)).
-That is an adapter/session commit for the current candidate pipeline. It must
-not define the new document engine's semantic commit, because one renderer's
-availability cannot determine meaning for every renderer.
-
-## Request envelope and idempotency
-
-A request contains, conceptually:
+## Requests and idempotency
 
 | Field | Rule |
 | --- | --- |
-| `RequestId` | Host-issued and unique within one document; reused IDs must carry the same canonical request content; the digest is an index and check, not an equality proxy. |
-| Actor and provenance | Host-attested origin such as text, projection, agent, or undo. |
-| Base graph revision | Must equal the current `GraphRevision`. |
-| Base schema revision | Must equal the committed `SchemaRevision`. |
-| Origin revision | Required for text-derived requests; identifies the exact `DraftRevision` that was lowered. |
-| Approval evidence | Host-issued evidence when required by the current user-authorized, revocable policy; generated input cannot mint it. |
-| `OperationBatch` | Non-empty ordered list of bounded primitive operations. |
+| `RequestId` | Host-issued and unique within one document. |
+| Actor/provenance | Host-attested text, projection, agent, or undo origin. |
+| Base graph/schema | Must match the committed revisions. |
+| Origin revision | Required for text-derived requests; names the exact lowered draft. |
+| Approval evidence | Host-issued when the current policy requires it. |
+| Batch | Non-empty, ordered, and bounded. |
 
-The canonical digest is computed from the validated typed request, not from
-raw transport bytes. It includes a version or domain tag, document and actor
-identity, provenance, base revisions, approval evidence identity, and the
-ordered canonical batch. It excludes `RequestId`, transport timestamps,
-whitespace, and object-key order. Boundary validation rejects duplicate object
-keys and non-finite numbers; canonical encoding orders map keys and gives
-`BindingRef` one stable representation before digest computation. Digest
-equality never establishes request equality.
+Canonical content comes from the validated typed request, not transport bytes.
+It includes a version/domain tag, document and actor identity, provenance, base
+revisions, approval identity, and ordered batch. It excludes `RequestId`,
+timestamps, whitespace, and object-key order. Boundary decoding rejects
+duplicate keys and non-finite numbers; canonical encoding orders keys and gives
+`BindingRef` one stable representation.
 
-Two committed semantic states are equal only when they share the same schema
-revision, root identity, semantic node IDs, components, canonical properties,
-and ordered children. `GraphRevision`, history, draft complement, runtime,
-renderer, and diagnostics are excluded from semantic equality. Changing
-`SchemaRevision` is a semantic change even when the node graph is otherwise
-identical.
+The digest is only an index and integrity check. Canonical request content is
+the equality authority.
 
-A repeated `RequestId` with equal canonical request content returns the
-recorded terminal outcome only after the stored digest matches the canonical
-content. A mismatch fails closed as an integrity error. Neither path alters the
-existing record, committed graph, applied history, or effect outbox.
+- Same request ID and same canonical content returns the recorded outcome after
+  verifying the stored digest. It performs no new mutation.
+- Same ID with different content is request-ID reuse, or a digest collision when
+  the digest also matches. Both fail closed without changing the existing
+  record, graph, history, or outbox.
+- Stored content/digest disagreement is an integrity error and also fails
+  closed.
 
-A repeated `RequestId` with different canonical request content is always
-rejected without mutation. If the digest is equal despite differing content,
-classify it as a collision; if the digest differs, classify it as request-ID
-reuse. Neither case may alter the existing `RequestRecord`, committed graph,
-applied history, or effect outbox.
+The initial slice does not compact request records. A future retention design
+must first define and test an equality-preserving tombstone or monotonic actor
+sequence. A digest or unspecified watermark is insufficient.
 
-The initial slice does not compact request records. A later retention design
-may remove canonical content only after it defines and tests an equality-
-preserving tombstone or a monotonic actor request sequence that still rejects
-ID reuse and digest collisions. A digest or unspecified actor watermark alone
-is insufficient.
+Semantic graph equality includes schema revision, root and node identities,
+components, canonical properties, and ordered children. It excludes graph
+revision, history, draft, runtime, renderer, and diagnostics.
 
-A text-derived request is rejected and re-lowered if its origin revision is no
-longer the current draft revision. Projection- and agent-derived requests use
-the committed graph revision for semantic conflict detection; source rewrite
-uses a separate compare-and-swap rule described below.
+Text requests are rejected and re-lowered when their origin draft is stale.
+Projection and agent requests use the committed graph revision. The core does
+not automatically rebase semantic operations.
 
 ## Forward operation algebra
 
-### Primitive vocabulary
-
 | Primitive | Meaning |
 | --- | --- |
-| `InsertNode` | Declare one request-local new-node handle with component, initial properties, parent, and placement. |
-| `MoveNode` | Move an addressed non-root node to a parent and placement. |
-| `SetProperty` | Add or replace one declarative property value. |
-| `RemoveProperty` | Remove one declarative property. This is distinct from assigning `null`. |
-| `RemoveNode` | Atomically remove the addressed node and its complete subtree. |
+| `InsertNode(handle, component, properties, parent, placement)` | Insert a new node. |
+| `MoveNode(node, parent, placement)` | Reparent or reorder an existing node. |
+| `SetProperty(node, key, value)` | Assign a schema-valid declarative value. |
+| `RemoveProperty(node, key)` | Remove a property; distinct from assigning `null`. |
+| `RemoveNode(node)` | Remove a non-root subtree. |
 
-Requests address committed nodes with `Existing(UiNodeId)` and nodes introduced
-in the same batch with `New(NewNodeHandle)`. A new-node handle is unique only
-inside its request and must be declared exactly once by `InsertNode`. Each
-`NewNodeHandle` is resolved to its declaration-order insertion ordinal before
-pure apply. The logical `UiNodeId` is an opaque deterministic derivation from
-`(DocumentId, RequestId, insertion ordinal)`. The resolution is pure, retries
-produce the same mapping, different request-ordinal pairs produce different
-IDs, and generated input cannot select durable IDs. Once ID resolution occurs,
-the terminal `RequestRecord` stores the handle-to-ID mapping, and an applied
-envelope stores the same resolved mapping; generated callers have no path to
-mint durable IDs.
+Requests address committed nodes with `Existing(UiNodeId)` and same-batch nodes
+with `New(NewNodeHandle)`. A handle is request-local and declared exactly once
+by `InsertNode`. Before apply, declaration order assigns each handle an
+insertion ordinal. The host deterministically derives the opaque `UiNodeId`
+from `(DocumentId, RequestId, insertion ordinal)` and records the mapping in the
+terminal request record. Generated input never chooses durable IDs.
 
-`InsertNode` inserts one node rather than an arbitrary subtree. A caller builds
-a subtree with an ordered batch whose parent insertions precede their children.
-Initial properties must satisfy node-local required-property rules at insertion;
-full child-cardinality and graph invariants are checked on the completed private
-working graph.
+Placement is identity-relative:
 
-`RemoveProperty` is a forward operation, not merely an undo detail. The
-separation from `SetProperty` preserves schemas where `null` is a valid value
-and makes deletion explicit in audit and approval policy.
+```text
+AtStart | AtEnd | Before(sibling) | After(sibling)
+```
 
-Primitive preconditions are strict. `InsertNode` requires an undeclared local
-handle, an allowed component, and an already resolvable parent. `MoveNode` and
-`RemoveNode` require an existing non-root target; a move beneath the target's
-own subtree is rejected before mutation. `RemoveProperty` requires the property
-to be present. `SetProperty` may assign the current value, and `MoveNode` may
-resolve to the current placement; the final no-semantic-change rule decides
-whether the batch commits.
+The parent and optional sibling must already resolve in the private working
+graph; the sibling must belong to that parent. Same-parent moves detach the
+moved node before resolving placement, and self anchors are invalid. Insert
+requires a fresh local handle and allowed component. Move and remove require an
+existing non-root node; a move cannot target its own subtree. `RemoveProperty`
+requires a present property. Assigning the current value or moving to the
+current position is allowed and handled by final no-op classification. Index
+placement and fallback clamping are excluded.
 
-Changing a node's component kind is not an initial primitive. An adapter lowers
-that change to subtree removal and insertion with fresh semantic identity unless
-a later domain use case proves that cross-kind identity must survive.
+Changing component kind is not a primitive. Adapters lower it to remove and
+insert with fresh identity unless later evidence requires cross-kind identity.
 
-### Placement
+Batch laws:
 
-Tree insertion and movement use identity-relative placement rather than raw
-numeric indexes:
+1. The batch is non-empty and applied sequentially to a private graph.
+2. Each primitive reads the result of previous primitives.
+3. Any failed precondition rejects the whole batch.
+4. Final graph and schema validation occur before commit.
+5. A final graph semantically equal to the base is `NoSemanticChange`.
+6. Only `Applied` advances the graph revision.
 
-- `AtStart`
-- `AtEnd`
-- `Before(sibling_ref)`
-- `After(sibling_ref)`
+Every valid graph has one host-owned root that requests cannot insert, move, or
+remove. Node IDs are unique, each non-root node has one parent, and the tree is
+connected, acyclic, and deterministically ordered. Component schemas enforce
+required properties, child kinds/cardinality, and bounded values. Boundary and
+graph limits cover decoded bytes, nodes, depth, children, properties, recursive
+value depth and collection size, strings, value bytes, batch length, and
+cumulative inserted subtree size.
 
-A sibling reference may be an existing semantic ID or an earlier request-local
-new-node handle. The anchor must be a child of the target parent in the private
-working graph at that point in batch evaluation. For a move within one parent,
-the moved node is detached before placement is resolved. Missing, removed,
-self, forward, or wrong-parent anchors reject the whole batch.
+## Values and schemas
 
-### Batch laws
+Committed values are immutable bounded JSON-shaped literals plus host-issued
+`BindingRef` values where the component schema permits them. A binding names a
+host capability; its runtime value is never serialized. Missing or revoked
+bindings produce `BindingUnavailable` without changing the graph.
 
-A forward `OperationBatch` obeys these laws:
+The first slice excludes expressions, functions, action callbacks, raw HTML,
+ambient-authority URLs, provider objects, DOM nodes, and JavaScript host
+objects. Commands require a separate commands-as-data and approval design.
 
-1. It is non-empty and evaluated in source order against one private working
-   graph.
-2. Structural preconditions are checked as each primitive is evaluated; final
-   tree and schema invariants are checked on the completed working graph.
-3. Later primitives may address nodes inserted or moved earlier in the same
-   batch.
-4. Any failure rejects the entire batch. No prefix becomes visible in the
-   graph, history, source, or renderer.
-5. A successful batch creates one applied-history record and advances graph
-   revision once, regardless of primitive count.
-6. A batch whose final graph equals its base graph is `NoSemanticChange` and
-   does not advance semantic revision.
-7. Limits apply to primitive count, inserted nodes, resulting graph growth,
-   property depth, string/collection size, and total decoded request size.
+Each `SchemaRevision` names one immutable canonical schema descriptor. Commits
+and checkpoints persist its revision and digest. Restore requires both to
+match; missing or changed schema enters `SchemaUnavailable` while preserving
+bytes and history. No reinterpretation, commit, or rendering occurs under a
+different schema.
 
-These laws make a multi-node text edit, projection gesture, agent proposal, or
-undo one transaction without exposing partially valid meaning.
+Schema migration is a separate host-only command. It validates the full graph
+under the target schema and atomically records both revisions, the new digest,
+and migration provenance. Installing a new registry version never triggers
+migration automatically.
 
-### Graph invariants
+## Inverse batches and reversal
 
-Pure apply and final validation preserve at least these invariants:
+Pure apply captures before-images and derives an inverse in reverse order:
 
-- Semantic node IDs are host-derived, unique within the document, and never
-  reused.
-- The host-owned generated-surface root exists and cannot be inserted, moved,
-  or removed by a request.
-- Every non-root node has exactly one parent; the tree is connected and
-  acyclic.
-- Every placement resolves to one deterministic sibling order.
-- Every component and property is allowed by the pinned component schema.
-- Required properties, child kinds, child cardinality, and graph-size limits
-  hold in the final graph.
-- Runtime binding values, callbacks, JavaScript objects, DOM handles, and host
-  chrome identities are absent from the graph.
-- The first operation slice has no property-level references to arbitrary
-  `UiNodeId` values. A future reference algebra must define dangling-reference
-  and removal policy before such references are admitted.
-
-## Value and schema boundary
-
-Committed property values are immutable, bounded data. The initial value
-algebra is JSON-shaped literals plus host-issued symbolic `BindingRef` values
-when a component schema explicitly permits them. A `BindingRef` identifies a
-host capability; the resolved binding value stays in runtime state and is not
-serialized into the graph. An unavailable or revoked `BindingRef` produces a
-runtime `BindingUnavailable` diagnostic and yields no value; it does not
-mutate or invalidate the committed graph.
-
-The initial algebra excludes expressions, functions, action callbacks, raw
-HTML, URLs with ambient authority, provider objects, DOM nodes, and JavaScript
-host objects. Commands and side effects require a separate commands-as-data and
-approval design.
-
-Each `SchemaRevision` names one immutable canonical schema descriptor. Every
-committed graph and applied transaction pins both that revision and the
-canonical descriptor digest. Regular generated requests can only target that
-revision. On restore, the host must supply a descriptor whose identity and
-digest both match. A missing descriptor, a reused revision with different
-content, or a digest mismatch preserves the committed bytes and history but
-enters `SchemaUnavailable`: no reinterpretation, semantic commit, or rendering
-occurs under a different schema.
-
-A schema migration is a separate host-only command boundary, not a normal
-generated `OperationBatch`. It validates the complete migrated graph under the
-target schema, records both schema revisions and migration provenance
-atomically, and never runs merely because a new registry version is installed.
-The initial operation slice implements only fail-closed `SchemaUnavailable`;
-migration authoring remains deferred.
-
-## Inverse algebra and undo
-
-Pure batch application captures the before-images required to derive an
-internal inverse batch:
-
-| Forward primitive | Internal inverse |
+| Forward | Inverse |
 | --- | --- |
-| `InsertNode` | `RemoveNode` |
-| `MoveNode` | `MoveNode` to the previous parent and placement |
-| `SetProperty` on an existing property | `SetProperty` with the previous value |
-| `SetProperty` on an absent property | `RemoveProperty` |
-| `RemoveProperty` | `SetProperty` with the removed value |
-| `RemoveNode` | `RestoreSubtree` with the complete validated before-image |
+| Insert | Remove the inserted node. |
+| Move | Move to the previous parent and placement. |
+| Set existing property | Restore the previous value. |
+| Set absent property | Remove the property. |
+| Remove property | Restore the removed value. |
+| Remove subtree | Internal `RestoreSubtree` with the validated before-image. |
 
-The inverse of a batch applies primitive inverses in reverse order.
-`RestoreSubtree` is internal because it carries trusted before-images and may
-resurrect semantic IDs that generated callers must never mint or reuse.
+`RestoreSubtree` is host-internal because it can resurrect semantic IDs. Undo
+never rewinds revision or history; it submits the inverse as a new request at
+the current base and may fail current policy, schema, or conflict checks. Any
+product adapter that permits generated commits must expose a user-visible
+reversal path.
 
-Undo never rewinds graph revision or edits applied history. It submits the
-inverse as a new request at the current base revision, passes current policy
-and schema validation, and may be rejected if intervening changes invalidate
-its preconditions. The private core need not expose undo, but any product
-adapter that permits generated commits must provide a user-visible reversal
-path. The exact history retention and interaction design remain later choices.
+## Draft, source, and renderer transitions
 
-## Draft, rewrite, and renderer transitions
-
-State changes follow a reducer-shaped boundary:
+The functional core follows:
 
 ```text
 DocumentState + DocumentEvent → DocumentState + Decision
 ```
 
-The functional core decides transitions and emits commands. The shell performs
-persistence, parsing, source rewriting, rendering, clocks, and provider I/O,
-then reports their results as new events.
+The shell performs persistence, parsing, rewriting, rendering, clocks, and
+provider I/O, then reports results as events.
 
-The required transition behavior is:
+| Event | Required transition |
+| --- | --- |
+| Draft edit | Preserve exact bytes and advance `DraftRevision`; keep the graph unchanged until lowering succeeds. |
+| Text-derived semantic change | Commit only when origin draft, graph, and schema revisions match. |
+| No-delta text change | Preserve complement; sync without request, revision, history, or outbox. |
+| Matching text-origin commit | Mark the current draft synchronized without rewriting its bytes. |
+| Projection/agent commit | Rewrite only on matching draft and semantic baselines; otherwise enter `RewriteConflict`. |
+| Renderer success | Advance only that renderer's baseline. |
+| Renderer failure | Keep meaning, mark that renderer dirty, and repair from committed state. |
 
-1. **Draft edited:** preserve the exact source, advance `DraftRevision`, and
-   request parse/lowering. Committed meaning does not change.
-2. **Parse or lowering failed:** retain diagnostics and enter drafting state.
-   The last committed graph remains current.
-3. **Text lowering found no semantic delta:** retain the new lossless syntax
-   complement and mark it semantically synchronized without creating a request
-   or advancing graph revision.
-4. **Text lowering produced semantics:** resolve source-local handles to
-   existing semantic IDs or request-local new-node handles, then produce one
-   batch tied to the exact draft and graph revisions. If either base is stale
-   at commit time, reject and re-lower.
-5. **Semantic batch committed:** atomically advance the graph and enqueue
-   source-rewrite and render effects.
-6. **Text-origin commit:** if the committed batch describes the still-current
-   draft, mark the draft synchronized without rewriting it.
-7. **Projection- or agent-origin commit:** rewrite source only when the draft
-   revision, rewrite-eligible status, and source semantic baseline all match
-   the effect preconditions. Otherwise the draft is preserved byte-for-byte
-   and enters `RewriteConflict`; the committed graph is not rolled back.
-8. **Renderer applied:** advance only that renderer's baseline.
-9. **Renderer failed:** retain committed meaning, mark that renderer dirty, and
-   repair from the committed graph.
-
-A host policy may defer projection or agent commits while a draft is dirty, but
-the engine's safety rule is stronger: even when such a commit is allowed, it
-must never overwrite a diverged draft. Temporary disagreement is explicit
-state, not silent loss and not corruption.
+A host may defer agent/projection commits while draft is dirty. Even when it
+allows them, source rewrite never overwrites a diverged draft.
 
 ## Identity scopes
 
-The following identities must not be confused:
-
-| Scope | Owner | Stability |
-| --- | --- | --- |
-| Source-local handle | draft source / CST | One source instance; renameable and rewriteable. |
-| Request-local new-node handle | one `UiOperationRequested` | Exists only while validating one batch. |
-| Current Canopy projection `NodeId` | session projection ([ProjNode](../../core/proj_node.mbt), [ProjectionMemo](../../core/projection_memo.mbt)) | Session-local projection continuity. |
-| `UiNodeId` | Generative UI document | Stable within one logical document and its full-state restore. |
-| Renderer node ID | one renderer/session registry | Adapter-local. |
-| `DocumentId` | persistence/host boundary | Distinguishes restore from import, clone, or fork. |
-
-A semantic identity is the pair `(DocumentId, UiNodeId)`. The deterministic
-derivation of `UiNodeId` from `(DocumentId, RequestId, insertion ordinal)`
-means retries produce the same allocation without exposing the derivation to
-generated input. Derived IDs are recorded even if later operations in the same
-committed batch remove the new node, and IDs are never reused within one
-document history. A no-op request namespace remains reserved by its
-`RequestId`. The serialized and hash representation is private and
-collision-checked.
-
-Full-state restore preserves `DocumentId` and `UiNodeId`. Plain-text import
-creates a new `DocumentId` and fresh semantic IDs; it does not claim identity
-continuity. Clone or fork creates a new `DocumentId`, even if an implementation
-preserves local node labels for diagnostics.
-
-`UiNodeId` is internal to `GenerativeUiDocument`. It is not a new public stable
-entity ID for existing Canopy languages and must not be backed by projection
-`NodeId`. Its representation remains private so a future collaborative version
-can compose with `event-graph-walker` tree identity rather than maintain a
-second causal identity system.
-
-The existing `data-node-id` reservation
-([JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md))
-is separate evidence that renderer identity is adapter-owned; it does not
-establish semantic identity.
-
-## Persistence and recovery invariants
-
-A semantic commit durably groups:
-
-- the next graph or checkpoint/delta reference;
-- next graph revision, pinned schema revision, and canonical schema descriptor
-  digest;
-- the complete validated `AppliedUiOperation` batch, resolved new-node ID
-  allocations, and provenance;
-- the request ID, canonical request content (or an equality-preserving canonical
-  representation), canonical digest, and terminal outcome; replay compares
-  canonical content, not digest equality;
-- the source-rewrite and renderer outbox entries.
-
-After a crash, recovery loads the latest valid checkpoint and replays a
-contiguous applied-history suffix. Every replay step must match its base graph
-and schema revisions and produce the recorded next revision. The reconstructed
-graph must equal the stored checkpoint at the same revision. The restored
-schema descriptor must match the pinned revision and digest. A gap, canonical-
-content or digest mismatch, unavailable or changed schema, or replay mismatch fails closed
-into diagnostic read-only state; recovery must not guess a graph.
-
-Each outbox entry carries conceptual effect metadata: an `EffectId`, target,
-base graph revision, target graph revision, a graph hash or snapshot
-reference, and an optional expected draft revision or status. Delivery is
-at-least-once, so source and renderer adapters must be idempotent against
-their recorded effect IDs and baselines. Redelivery cannot create another
-semantic commit.
-
-Renderer rule: dirty state takes precedence over stale acknowledgment and
-rebuilds from the latest committed snapshot. When the renderer is clean, a
-target revision at or below its baseline is stale and treated as an
-acknowledgment; a base equal to the baseline may apply; a gap rebuilds from
-the latest committed snapshot and never applies an older delta. Source rewrite rule: a source effect requires a
-matching draft revision, valid and rewrite-eligible draft state, and a
-matching source semantic baseline; otherwise the source is preserved and the
-effect enters `RewriteConflict`. Gaps are coalesced to the latest committed
-snapshot and its canonical source rather than replaying stale intermediate
-patches. Observed state remains monotonic.
-
-Checkpoint cadence, compaction format, and storage backend remain
-implementation decisions. Their representations may vary; the atomicity,
-replay, and fail-closed rules may not.
-
-The initial applied history is a single-writer transaction/audit log. It must
-not acquire ad hoc causal merge semantics. If collaborative semantic editing is
-introduced, `event-graph-walker` owns causal history, tree CRDT semantics,
-sync, and undo; this layer must adapt to those APIs rather than compete with
-them ([Stable Document Entity Graph](stable-document-entity-graph.md)).
-
-## Concurrency policy
-
-The initial document engine serializes semantic requests. A request with a
-stale graph or schema revision is rejected; it is not automatically rebased.
-Text edits may continue in draft state, but only an exact draft revision can
-produce a text-derived commit.
-
-This is a strict optimistic-concurrency policy, not a semantic CRDT merge
-claim. Identity-relative placement reduces accidental index coupling but does
-not itself provide concurrent ordering semantics.
-
-## Existing implementation to reuse
-
-| Concern | Source |
+| Identity | Scope |
 | --- | --- |
-| Request lifecycle and generation rules | [GenerativeUiLifecycle](../../lib/cognition/generative_ui.mbt) |
-| Fail-closed candidate and capability validation | [GenerativeUiCandidate](../../lib/cognition/generative_ui_candidate.mbt) |
-| JSX adapter preflight, DOM apply, dirty recovery | [JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md); [render_baseline](../../ffi/jsx/render_baseline.mbt) |
-| Lossless parser and CST | [Loom](../../loom/) |
-| Projection, ViewNode, ViewPatch adapters | [Responsibility Map](../architecture/responsibility-map.md); [ProjNode](../../core/proj_node.mbt) |
-| Future CRDT semantics | `event-graph-walker` (submodule) |
+| Source/CST handle | One parse or draft revision. |
+| `NewNodeHandle` | One request. |
+| Projection `NodeId` | Existing projection reconciliation. |
+| `UiNodeId` | Durable semantic identity within one document history. |
+| Renderer ID | One adapter instance. |
+| `DocumentId` | Document/storage namespace. |
 
-## Existing implementation not to freeze into the core
+The stable semantic identity is `(DocumentId, UiNodeId)`. Derived IDs remain
+reserved even when a same-batch operation removes the new node, and they are
+never reused. A no-op request also reserves its request namespace. ID encoding
+is private and collision-checked.
 
-Current adapter behavior remains local to its adapter and must not become
-permanent core semantics:
+## Persistence and recovery
 
-- Whole-candidate synthetic JSX lowering
-  ([generative_ui_adapter](../../ffi/jsx/generative_ui_adapter.mbt)).
-- Candidate-always-remount behavior
-  ([render_baseline](../../ffi/jsx/render_baseline.mbt)).
-- Session-local and synthetic node IDs.
-- `DomPatch` as renderer-neutral semantics. It is a JSX session boundary, not
-  a universal patch contract.
-- Normalized JSX `Renderable::unparse` output as a lossless or byte-faithful
-  writer ([JSX proj_traits](../../loom/examples/jsx/proj_traits.mbt)).
-- Table, filter, and summary candidate variants as generic core. They are
-  first-slice adapter content.
+An applied commit atomically groups:
 
-## Execution and trust boundary
+- next graph or checkpoint/delta reference;
+- graph revision, schema revision, and schema descriptor digest;
+- validated batch, ID allocations, and provenance;
+- canonical request content, digest, and terminal outcome;
+- source and renderer outbox entries.
 
-The `js_engine` supports persistent interpreter state, JSON calls, explicit
-queues, and advanced host objects. Its stable embedding documentation states that it is
-not a security sandbox (js_engine `docs/EMBEDDING.md`,
-`docs/design/embedded-runtime-vision.md`).
+Recovery loads the latest valid checkpoint and replays a contiguous history
+suffix. Every step must match base graph/schema revisions and the next recorded
+revision. Reconstructed graph, schema identity/digest, and checkpoint must
+agree. Gaps, request-content/digest mismatches, unavailable or changed schemas,
+and replay mismatches enter diagnostic read-only state.
 
-An agent adapter may submit only a decoded proposal body. Boundary decoding
-makes a bounded immutable copy; no callback, source handle, semantic graph
-reference, renderer registry, DOM object, or host object crosses with it. The
-host constructs `UiOperationRequested` and attaches its request ID, actor,
-schema, generation, authority, and approval facts rather than trusting
-agent-supplied claims.
+Outbox effects carry `EffectId`, target, base/target graph revisions, graph hash
+or snapshot reference, and optional expected draft state. Delivery is
+at-least-once and adapters are idempotent against effect IDs and baselines.
+Redelivery cannot create another semantic commit.
 
-Arbitrary agent-generated orchestration code remains gated on deterministic
-execution budgets, interruption, re-entry rules, disposal/generation tokens,
-async-host completion lifetime, and a killable Wasm or process boundary if
-hostile code is claimed safe. The operation slice proves the structured request
-boundary without executing arbitrary agent-generated JavaScript.
+Renderer ordering is explicit:
 
-Trusted host chrome and approval UI use a separate root, component registry,
-and authority domain from the generated surface. The current JSX contract
-reserves `data-node-id` and keeps expression spans inert. Those controls
-constrain adapter injection, but they do not establish the full structural
-separation required by the document engine.
+1. Dirty state takes precedence and rebuilds the latest committed snapshot.
+2. When clean, a target at or below the baseline is a stale acknowledgment.
+3. An effect whose base equals the baseline may apply.
+4. A gap rebuilds the latest snapshot; older deltas never apply.
+
+A text-origin source effect matching the current draft marks it synchronized
+without rewriting bytes. Projection/agent source effects require matching draft
+revision, valid/rewrite-eligible status, and source semantic baseline; otherwise
+they preserve source and enter `RewriteConflict`. Gaps coalesce to the latest graph and canonical source.
+Observed state never regresses.
+
+## Concurrency
+
+The first engine serializes semantic requests. Stale graph or schema revisions
+are rejected. Draft editing may continue independently, but only an exact draft
+revision can produce a text-derived commit. No automatic rebase or semantic
+CRDT merge is claimed. Future collaboration must integrate with
+`event-graph-walker` rather than create a second causal identity system.
+
+## Existing precedents
+
+The design reuses principles, not dependencies:
+
+| Precedent | Reused principle |
+| --- | --- |
+| `GenerativeUiLifecycle` | Generation IDs, cancellation, stale rejection, terminal states. |
+| Candidate validation | Bounded capability checks before commit. |
+| Replay source | Deterministic fixed-event replay. |
+| JSX session | Draft preservation, base revision, dry-run, failed-apply recovery. |
+| Render baseline | Dirty recovery and monotonic renderer state. |
+| Stable entity work | Durable semantic identity distinct from projection IDs. |
+
+The generic core does not freeze synthetic JSX, normalized unparse output,
+candidate-always-remount behavior, session-local IDs, JSX `DomPatch`, or
+current table/filter/summary candidate types.
+
+## Trust boundary
+
+An agent adapter submits only a bounded decoded proposal body. The host adds
+request ID, actor, schema, generation, authority, and approval facts. No
+callback, source handle, graph reference, registry, DOM object, or host object
+crosses the boundary.
+
+`js_engine` supports persistent interpreter state and advanced host objects but
+is not a security sandbox. Arbitrary generated JavaScript remains gated on
+budgets, interruption, re-entry, disposal/generation tokens, async lifetime,
+and a killable Wasm or process boundary. The first slice executes no generated
+JavaScript.
+
+Trusted chrome and approval UI require a separate root, registry, and authority
+domain from generated content. Existing inert expression spans and reserved
+`data-node-id` constrain JSX injection but do not prove that separation.
 
 ## Text adapter
 
-A temporary text adapter is permitted: newline-committed, flat declarations
-with explicit parent and placement, plus a lossless per-record complement. It
-is not the final language. JSX remains an adapter and import surface; JSON
-Lines remains only a possible wire format.
+A temporary adapter may use newline-committed flat declarations with explicit
+parent/placement and lossless per-record complement. JSX remains an adapter and
+import surface; JSON Lines is only a possible wire format.
 
-For snapshot-style text, a syntactically complete newline-terminated declaration
-prefix must retain the same lowered meaning when an incomplete suffix is
-appended. This snapshot-prefix rule does not apply to append-only operation
-streams whose later records intentionally move, update, or remove earlier
+For snapshot text, appending an incomplete suffix must not change the lowered
+meaning of a complete newline-terminated prefix. This rule does not apply to
+append-only operation streams whose later records intentionally modify earlier
 nodes.
 
-## Staged direction
+## Sequence and validation gate
 
-1. Preserve the existing structured-candidate lifecycle and JSX session as the
-   validated V1 adapter baseline.
-2. Introduce the renderer-independent semantic graph, forward batch algebra,
-   reducer transitions, persistence boundary, and structured request envelope.
-3. Add the temporary text adapter and projection/agent request adapters; prove
-   rewrite-conflict behavior without arbitrary JavaScript execution.
-4. Add a materially different renderer and validate shared graph, identity,
-   state-preservation, and capability invariants.
-5. Only then consider a public renderer-neutral contract or collaborative
-   semantic editing.
+1. Preserve the existing structured-candidate and JSX V1 baseline.
+2. Test the private semantic graph, batch, reducer, persistence, and request
+   model as a discardable experiment.
+3. Add text and projection/agent adapters only after the core gate passes.
+4. Validate shared invariants with a materially different renderer.
+5. Only then consider a public contract or collaborative semantic editing.
 
-The private core may test step 2 as a discardable falsification experiment. It
-must not add product or adapter behavior before the personal-knowledge fixed
-baseline and existing V1 gates pass, and it cannot freeze a renderer-neutral
-contract before the use-case and second-adapter evidence above.
+Step 2 does not bypass the PKE fixed baseline, V1 gates, real use-case evidence,
+or second-adapter requirement.
 
-## Proof obligations
+Before adapter work, the private core must pass one deterministic transcript:
 
-Deterministic unit, property, replay, and boundary tests must establish each
-obligation before the corresponding behavior is claimed safe:
+1. Preserve an invalid draft while retaining the last committed graph.
+2. Commit one duplicated request exactly once after response loss.
+3. Reject stale source rewrite without changing draft bytes.
+4. Recover a dirty renderer under duplicate, stale, and gap delivery without
+   regressing its baseline.
+5. Restart with the same graph, schema identity, semantic IDs, request outcomes,
+   draft, and pending effects.
 
-- Only the semantic transaction boundary advances committed meaning.
-- A failed primitive rejects the whole batch; no prefix is observable.
-- One successful batch advances graph revision once; a semantic no-op does not.
-- `RemoveProperty` is distinguishable from assigning `null`.
-- Duplicate request delivery with equal canonical content and a matching stored
-  digest cannot apply a batch twice; canonical-content/digest mismatch fails
-  closed.
-- Request-local handles resolve once to the recorded semantic IDs and cannot
-  mint or reuse durable IDs.
-- Derived inverse batches restore the prior graph when their preconditions
-  still hold.
-- Syntax-only edits preserve committed meaning and graph revision.
-- Invalid or concurrently changed draft text is never overwritten by a source
-  rewrite.
-- Renderer failure cannot roll back or advance semantic meaning.
-- Checkpoint replay reconstructs exactly the committed graph and fails closed
-  on gaps, mismatches, or an unavailable or changed schema descriptor.
-- Persisted `NoSemanticChange` and `Rejected` records survive restart and retry
-  without creating graph revisions, applied history, or outbox entries.
-- Projection and renderer IDs cannot be observed as durable semantic identity.
-- Stale graph, schema, and text-derived draft revisions are rejected.
-- Generated input cannot obtain host chrome, callbacks, runtime binding values,
-  DOM handles, or component-registration authority.
-- The host trust boundary is structural rather than policy-only.
-- Every host-constructed request persists its terminal `RequestRecord` before
-  the response is sent.
-- Canonical-equivalent transport inputs produce identical digests regardless of
-  key order, whitespace, or transport encoding.
-- An equal-digest, different-content collision is rejected without mutation and
-  does not alter the existing `RequestRecord`, committed graph, applied history,
-  or effect outbox.
-- A `SchemaRevision` change is semantic even when the node graph is otherwise
-  identical.
-- Arbitrary duplicated or out-of-order effect delivery converges monotonically;
-  dirty repair takes precedence over stale acknowledgment, and stale
-  intermediate patches are never applied.
-- Stale source rewrite effects never overwrite a diverged draft.
-- Deterministic node identity produces the same mapping on retry and different
-  mappings for distinct request-ordinal pairs.
+The [semantic-core validation plan](../plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md)
+maps each invariant to focused, property, replay, or deferred evidence. It also
+requires restart coverage for `NoSemanticChange` and `Rejected`, forced digest
+collision tests, schema-descriptor corruption, inverse properties, and
+fail-closed replay.
 
-### Falsifiable validation gate
+Collection, tree, and state-machine laws remain executable tests. `moon prove`
+is optional and limited to small scalar decisions. Failure of the fixed
+transcript rejects or revises this direction before adapter work.
 
-Before production source, renderer, persistence, or JavaScript integration, a
-private semantic core must pass one deterministic transcript:
-
-1. Preserve an invalid human draft while keeping the last committed graph.
-2. Apply one duplicated host-constructed agent request exactly once.
-3. Reject its stale source rewrite as `RewriteConflict` without changing draft
-   bytes.
-4. Converge a failed renderer after duplicate, stale, and out-of-order effects
-   without regressing its baseline.
-5. Restart from checkpoint, history, request records, and outbox with the same
-   graph, schema revision, semantic IDs, draft bytes, and terminal outcome.
-
-The [Semantic-core validation plan](../plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md)
-defines the reference model, observation oracle, fault injection, generated
-traces, and evidence mapping. The gate covers only obligations observable in the
-private core and fake shell. It does not establish adapter isolation, host trust,
-hostile-JavaScript safety, collaboration, agency, accessibility, or product
-value. It cannot authorize PKE semantic candidates before that direction's
-fixed deterministic baseline is accepted. Product claims remain subject to the [Human-centered product principles](../architecture/human-centered-product-principles.md)
-gates for agency and contestability, inclusion and cognitive steady state, and
-net value against fixed alternatives; the other boundaries require their own
-validation.
-
-Collection, tree, replay, and state-machine laws require unit and property
-tests. `moon prove` is optional and limited to small scalar decision functions
-that compile under the documented prover constraints. Failure of the fixed
-transcript requires revising or rejecting this document-engine direction before
-adapter work begins.
+Passing the core gate proves none of adapter isolation, host trust, hostile
+JavaScript safety, collaboration, accessibility, agency, or product value.
+Those claims remain subject to the
+[human-centered product principles](../architecture/human-centered-product-principles.md)
+and their own evidence.
 
 ## Deferred decisions
 
-- Storage backend, checkpoint cadence, compaction, and retention sizing.
-- The approval and preview interaction layered over the required
-  user-authorized, revocable policy.
-- The host migration authoring API beyond the fail-closed schema rules above.
-- The user-visible reversal interaction and which historical transactions
-  remain undoable.
-- When or whether the text adapter becomes a first-class language.
-- When or whether to promote the operation vocabulary to a public API.
-- The exact mapping to `event-graph-walker` if collaborative semantic editing
-  is introduced.
-- The second-renderer conformance contract.
+- Storage backend, checkpoint cadence, retention, and request-ledger bounds.
+- Approval/preview interaction over the required revocable policy.
+- User-visible reversal interaction and undo retention.
+- Schema migration authoring API.
+- Final text language and public operation API.
+- Collaboration mapping to `event-graph-walker`.

--- a/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
+++ b/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
@@ -1,0 +1,578 @@
+# Incremental Generative UI semantic-core validation
+
+**Status:** ready for bounded validation; product integration gated
+
+## Why
+
+The [Incremental Generative UI document engine](../design/incremental-generative-ui-document-engine.md)
+defines authority, transaction, identity, recovery, and trust invariants that
+are not implemented. The first implementation must therefore be a falsifiable
+semantic-core experiment, not a syntax, DOM, persistence, or JavaScript
+integration. It is discardable architecture research: passing it cannot add
+semantic candidates or generated behavior to the personal knowledge
+environment before that direction's fixed deterministic baseline is accepted,
+and it cannot freeze a public renderer-neutral contract.
+
+This plan proves the central claim: an invalid human draft can coexist with one
+exactly-once agent commit while source rewriting conflicts, renderer effects
+fail or arrive out of order, and restart/replay still reconstructs the same
+committed graph and semantic IDs. If that transcript cannot pass through a
+small deterministic core and fake shell, the broader document-engine direction
+is not justified.
+
+This file is the sole implementation spec for that validation slice. The design
+document remains the source of principles and invariants.
+
+## Scope
+
+In:
+
+- `moon.work` — add the renderer- and agent-neutral core module.
+- `lib/generative-ui-document/moon.mod` — new standalone module with no Canopy,
+  cognition, renderer, DOM, or incremental-runtime dependency; pin
+  `moonbitlang/quickcheck` for tests.
+- `lib/generative-ui-document/moon.pkg` — core package plus
+  `core/quickcheck`, SplitMix, and `@qc` imports scoped to white-box tests.
+- `lib/generative-ui-document/types.mbt` — private document, revision,
+  identity, request, outcome, sync, and effect data.
+- `lib/generative-ui-document/graph.mbt` — private semantic graph invariants
+  and semantic equality.
+- `lib/generative-ui-document/operation.mbt` — private forward batch
+  application, canonical request content, deterministic ID resolution, and
+  inverse derivation.
+- `lib/generative-ui-document/transition.mbt` — pure document reducer and
+  persistence/effect decisions.
+- `lib/generative-ui-document/replay.mbt` — pure checkpoint/history recovery.
+- `lib/generative-ui-document/reference_model_wbtest.mbt` — deliberately small
+  immutable reference model and observation oracle.
+- `lib/generative-ui-document/fixed_scenario_wbtest.mbt` — the mandatory
+  falsifiable transcript and fake atomic store/source/renderer shell.
+- `lib/generative-ui-document/operation_properties_wbtest.mbt` — generated
+  graph/batch/identity/inverse properties.
+- `lib/generative-ui-document/transition_properties_wbtest.mbt` — generated
+  request, draft, outbox, and state-machine traces.
+- `lib/generative-ui-document/replay_wbtest.mbt` — checkpoint, corruption, and
+  crash-boundary recovery tests.
+- `lib/generative-ui-document-proof/` — optional standalone proof module for
+  scalar transition rules only, gated by an early proof-compilation spike.
+- `.github/workflows/ci.yml` — run the new core package on both JS and native;
+  if the proof spike lands, include its paths in change detection and run each
+  standalone proof module explicitly.
+- `docs/design/incremental-generative-ui-document-engine.md` and
+  `docs/TODO.md` — gate link and completion status only.
+
+Out:
+
+- Changes to `lib/cognition/`; its lifecycle and replay code are precedents,
+  not dependencies of the semantic core.
+- Production JSX adapter changes or new renderer-neutral public APIs.
+- Arbitrary JavaScript, `js_engine`, DOM, React, provider, or agent-framework
+  integration.
+- A real database, filesystem store, or production outbox implementation.
+- Final source syntax, parser, or projection-to-source lowering.
+- Collaboration, causal history, CRDT merge, or semantic undo integration with
+  `event-graph-walker`.
+- Schema-migration authoring, action/command execution, approval UI, a second
+  renderer, product-value experiments, or PKE semantic/generated views.
+- Performance optimization or benchmarks before correctness is established.
+
+## Current state
+
+- [`lib/cognition/generative_ui.mbt`](../../lib/cognition/generative_ui.mbt)
+  provides the current request/generation lifecycle, event vocabulary, and
+  terminal-state handling. It is a behavioral precedent; the new module must
+  not import cognition or its `incr` dependency.
+- [`lib/cognition/generative_ui_candidate.mbt`](../../lib/cognition/generative_ui_candidate.mbt)
+  demonstrates fail-closed capability validation. Its table/filter-specific
+  candidate types remain adapter content and are not generalized into the core.
+- [`lib/cognition/generative_ui_replay.mbt`](../../lib/cognition/generative_ui_replay.mbt)
+  demonstrates deterministic fixed-event replay with an explicit cursor.
+- [`lib/canvas-graph/graph_model/model.mbt`](../../lib/canvas-graph/graph_model/model.mbt)
+  and its operation tests demonstrate pure operation replay; they are examples,
+  not dependencies.
+- [`core/reconcile_properties_wbtest.mbt`](../../core/reconcile_properties_wbtest.mbt)
+  demonstrates bounded recursive `Arbitrary` generators, explicit shrinkers,
+  and `@qc.quick_check_fn`.
+- [`ffi/jsx/render_baseline_wbtest.mbt`](../../ffi/jsx/render_baseline_wbtest.mbt)
+  demonstrates folding generated renderer events through a lifecycle and
+  checking reachable invariants. Real JSX conformance remains a later plan
+  because its baseline and outcomes are adapter-private.
+- [`lib/semantic/proof/`](../../lib/semantic/proof/) and
+  [Formal Verification](../development/formal-verification.md) define the
+  standalone `moon prove` pattern and its Map/Array/state-machine limits.
+- [The JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md)
+  remains the V1 adapter/session contract. This plan does not change its
+  DOM-gated candidate commit semantics.
+
+## Desired state
+
+The slice is complete when a private, deterministic core and test-owned shell
+can execute the fixed transcript below and satisfy every core obligation mapped
+in this plan.
+
+The functional core owns:
+
+- semantic graph validation and equality;
+- ordered, atomic `OperationBatch` application;
+- deterministic request-local handle resolution;
+- request canonicalization and collision-aware idempotency decisions;
+- graph, draft, request-ledger, sync, and outbox transitions;
+- replay and fail-closed recovery;
+- decisions describing persistence, response, source rewrite, and rendering.
+
+The imperative shell remains test-only in this slice. It owns a fake atomic
+store, delivery order, injected failure, response loss, fake draft bytes, and
+fake renderer baselines. The reducer may emit a response or post-commit effect
+only after the shell reports that the corresponding terminal `RequestRecord`
+and, for `Applied`, graph/history/outbox transaction were persisted.
+
+No type from this module is public. `pkg.generated.mbti` should remain empty or
+contain only intentionally unavoidable module metadata. A later adapter plan
+must re-evaluate and validate any API promotion.
+
+## Decision locks
+
+- The core lives in `lib/generative-ui-document`, not `lib/cognition`, so its
+  dependency graph enforces renderer, agent, and reactive-runtime neutrality.
+- `UiNodeId` is logically derived from `(DocumentId, RequestId, insertion
+  ordinal)`. The core stores canonical request content alongside its digest;
+  digest equality alone never proves request equality or semantic identity. A
+  test-owned digest function must be injectable so collision handling is
+  falsifiable without weakening production canonical-content comparison.
+- `RequestRecord` is mandatory for every host-constructed terminal request.
+  The initial slice does not compact these records; retention bounds require a
+  later equality-preserving tombstone or monotonic request-sequence design.
+  Decoder failures before request construction remain boundary diagnostics.
+- The persistence protocol has an explicit intent/acknowledgment boundary.
+  “Persist before respond” is not modeled as an in-memory ledger mutation.
+- Every `SchemaRevision` names one immutable canonical descriptor. Commits and
+  checkpoints persist its digest; restore fails closed if either identity or
+  digest differs.
+- Effects carry base and target graph revisions. Dirty repair takes precedence
+  over stale acknowledgment. Clean consumers ignore stale targets, apply only
+  from the expected baseline, and rebuild from the latest committed snapshot
+  after a gap.
+- The plan verifies only the obligations reachable without production adapters.
+  Adapter/trust-boundary obligations stay unclaimed and are listed as deferred
+  in the evidence matrix.
+- `moon prove` is optional and subordinate to executable core evidence. It may
+  prove only scalar/enum decision functions that compile under the documented
+  prover constraints.
+
+## Reference model and observation oracle
+
+`reference_model_wbtest.mbt` owns a small immutable model that is intentionally
+simpler than production code. It uses the same public event meaning but does
+not call production transition or apply functions.
+
+Every generated or fixed trace compares this model with the implementation
+through one test-only observation containing:
+
+- semantic graph, schema revision, and canonical schema descriptor digest;
+- graph revision;
+- exact draft bytes, draft revision, and sync status;
+- canonical terminal request outcomes;
+- applied-history IDs and deterministic new-node mappings;
+- pending effect IDs with base/target revisions;
+- source and renderer baselines;
+- read-only/fail-closed recovery state.
+
+Implementation-only caches, collection iteration order, diagnostic formatting,
+and builder scratch state are excluded. A mismatch reports the minimized event
+trace and both observations.
+
+## Fixed falsifiable scenario
+
+`fixed_scenario_wbtest.mbt` is the first red test and the final integration gate.
+It executes this transcript through the reference model and production reducer:
+
+1. Start with draft bytes `D0 = "valid\n"`, a root-only committed graph `G0`,
+   graph revision 0, an immutable schema revision and descriptor digest, and a
+   renderer synchronized to revision 0. Retain a
+   redeliverable already-acknowledged renderer effect `E0` whose target is 0.
+2. Edit the draft to `D1 = "valid\n<unfinished"` and report it invalid; retain
+   those exact bytes and keep `G0` as current meaning. The strings are test
+   fixtures, not a proposed source grammar.
+3. Deliver host-constructed request `Q` at base revision 0. Its valid batch
+   declares two new-node handles, inserts both nodes, and sets one property so
+   deterministic ordinal IDs and multi-primitive commit are observable.
+4. Persist the resulting graph `G1`, request record, history, source/render
+   effects, and graph revision 1 atomically, then lose the response. Retry `Q`;
+   return the recorded outcome without another revision or history entry.
+5. Deliver the source-rewrite effect for target 1. Its draft validity/revision
+   precondition fails; preserve `D1` byte-for-byte and enter
+   `RewriteConflict`.
+6. Deliver renderer effect `E1` for target 1 and force failure. While the
+   renderer is dirty at baseline 0, deliver stale `E0`: dirty repair must take
+   precedence and rebuild from `G1`, not merely acknowledge `E0`. Duplicate
+   `E1` after recovery; it must be acknowledged without regression.
+7. Crash before every effect acknowledgment is durable. Recover from
+   checkpoint, applied history, request records, and pending outbox, then
+   redeliver remaining effects.
+8. Assert that recovered graph, schema revision, and schema descriptor digest
+   equal `G1`, graph revision is exactly 1, `Q` has one terminal/applied outcome,
+   IDs are unchanged, `D1` is unchanged, and the renderer baseline is 1.
+   Separate generated traces must create revisions 1 and 2 and deliver target 2
+   to baseline 0 to prove gap rebuild.
+
+Separate terminal-outcome fixtures must persist, crash, recover, and retry one
+`NoSemanticChange` request and one `Rejected` request. Each returns its recorded
+outcome without adding a graph revision, applied-history entry, or outbox entry.
+A batch-rejection fixture is required, but it is not a substitute for the full
+transcript or these request-ledger recovery fixtures.
+
+## Evidence matrix
+
+| Obligation from the design document | Evidence in this plan |
+| --- | --- |
+| Only semantic commit advances meaning | Fixed transcript; transition trace property; fake-store acknowledgment test |
+| Failed primitive exposes no batch prefix | Batch-rejection unit test; generated batch atomicity property |
+| Applied advances once; no-op does not | Request/revision unit tests; generated no-op property |
+| No-op and rejected outcomes survive restart/retry | Terminal-outcome crash/recovery fixtures |
+| `RemoveProperty` differs from `null` | Focused value/property unit test |
+| Duplicate request does not apply twice | Fixed transcript; retry and response-loss fault tests |
+| Request-local handles cannot mint/reuse IDs | Deterministic derivation and uniqueness properties |
+| Inverse restores when preconditions hold | Valid-batch/inverse property with explicit precondition generator |
+| Syntax-only edit preserves meaning | Reducer event test using a fake no-semantic-delta lowering result |
+| Invalid/concurrent draft is not overwritten | Fixed transcript; stale draft trace property |
+| Renderer failure cannot alter semantic meaning | Fixed transcript; generated renderer-failure traces |
+| Replay reconstructs or fails closed | Replay properties; gap/request-digest/schema-descriptor corruption tests |
+| Projection/renderer IDs are not durable semantic IDs | Deferred to adapter/API conformance; no such IDs exist in the private core |
+| Stale graph/schema/draft revisions reject | Generated stale-revision properties |
+| Generated input cannot obtain host/DOM/callback authority | Deferred to decoder and adapter conformance; not claimed by this core slice |
+| Host trust boundary is structural | Deferred to host/renderer integration; not claimed by this core slice |
+| Terminal request record precedes response | Fake atomic-store acknowledgment and crash-boundary tests |
+| Canonical-equivalent requests compare identically | Typed canonical-content and ordering properties; equal-digest/different-content collision fixture; raw transport whitespace/encoding remains deferred to decoder conformance |
+| Schema revision change is semantic | Focused semantic-equality unit/property test |
+| Duplicate/out-of-order effects converge monotonically | Fixed transcript including dirty-plus-stale precedence; generated effect permutation traces |
+| Stale source effect never overwrites draft | Fixed transcript; generated CAS mismatch traces |
+| Node identity repeats on retry and separates tuples | Deterministic ID properties and replay assertion |
+
+The plan is complete when every non-deferred row has passing evidence. Deferred
+rows remain explicit blockers on the corresponding future safety claim.
+
+## Existing API first — reuse check
+
+Project APIs and patterns reused:
+
+- `GenerativeUiLifecycle::dispatch` supplies the existing event/transition and
+  terminal-state precedent. The new core reuses the reducer shape, not the type
+  or module dependency.
+- `GenerativeUiReplaySource` supplies the fixed replay-log/cursor testing
+  precedent. Recovery state remains owned by the new core.
+- `@qc.quick_check_fn`, `@quickcheck.Arbitrary`, `@qc.Shrink`, and SplitMix
+  random-state splitting follow the patterns in
+  `core/reconcile_properties_wbtest.mbt` and
+  `ffi/jsx/render_baseline_wbtest.mbt`.
+- `@canvas_graph` operation replay is checked as an existing deterministic-log
+  precedent but is not reused because its workflow graph and action history
+  have different invariants.
+- `lib/semantic/proof` is reused as the standalone proof-package and CI pattern,
+  not as a dependency.
+
+MoonBit/core candidates to check before new definitions:
+
+- `Map` and `Set` for graph lookup, request records, uniqueness, and pending
+  effects; use owning collections privately and do not expose mutable values.
+- `Array` and `Iter` for ordered children, ordered batches, trace folds, and
+  local result construction.
+- `Option` and `Result` for lookup and validation outcomes.
+- `String`/`StringView` and `Bytes`/`BytesView` for exact draft observations and
+  canonical request input; avoid copies where a view suffices.
+- `Buffer`/`StringBuilder` for canonical encoding only if the actual core API is
+  preferable to structural canonical content comparison.
+- `cmp`/math helpers for revision and bound comparison instead of new numeric
+  helpers.
+- Core JSON APIs only at a future decoder boundary; the semantic core consumes
+  validated typed values.
+
+Checked but not reused:
+
+- `GenerativeUiCandidate::validate` is table/filter-specific. Reuse its
+  fail-closed principle, not its candidate types or validator.
+- `ProjNode`, `SourceMap`, JSX AST, DOM patches, `incr`, and
+  `event-graph-walker` are excluded from this private single-writer core.
+- `Map`, `Set`, `Array`, recursive graph functions, canonical encoders, and
+  state-machine traces are excluded from `moon prove` under current prover
+  limitations.
+
+New definitions are justified only for the semantic graph, operation algebra,
+request/identity vocabulary, reducer decisions, replay model, and observation
+oracle described above. Each new helper must stay within one of those
+responsibility boundaries.
+
+## Steps
+
+### Phase 0 — Package boundary and first red transcript
+
+1. Add `lib/generative-ui-document` to `moon.work`; create its `moon.mod` with
+   a pinned `moonbitlang/quickcheck` test dependency and its `moon.pkg` with
+   JS/native support plus core QuickCheck/SplitMix/`@qc` imports restricted to
+   white-box tests.
+2. Run `moon ide doc`/`outline` checks listed under Validation and record any
+   better existing API in the Reuse check before defining helpers.
+3. Add the observation vocabulary, fake-shell protocol, and full fixed
+   transcript as a failing white-box test. The initial failure must be missing
+   core behavior, not a parser, renderer, or persistence dependency.
+
+### Phase 1 — Semantic graph and forward batch
+
+4. Implement private typed values, graph state, semantic equality, revision
+   wrappers, immutable schema descriptor identity/digest, request-local handles,
+   and deterministic ordinal-based IDs.
+5. Implement structural precondition validation and ordered application for
+   `InsertNode`, `MoveNode`, `SetProperty`, `RemoveProperty`, and subtree
+   `RemoveNode` on a private working graph.
+6. Commit the working graph only after final graph/schema validation. Add the
+   batch-rejection fixture, no-op behavior, `RemoveProperty`/`null` distinction,
+   graph invariant tests, and inverse derivation tests.
+
+### Phase 2 — Request and persistence protocol
+
+7. Implement canonical typed request content, collision-aware request lookup,
+   and terminal outcomes. Store canonical content as the equality authority;
+   use a digest only as an index/check. Provide a white-box-only digest injection
+   seam so tests can force equal digests for different canonical requests.
+8. Implement reducer decisions for persistence intent, persistence success or
+   failure, response emission, and effect release. The reducer must not emit a
+   response or effect-delivery command before persisted acknowledgment.
+9. Add a fake atomic store that can fail before commit, commit then lose the
+   response, restart with committed records, and reject mismatched request
+   content under the same ID. Force one equal-digest/different-content case and
+   assert that the stored request record, graph, history, and outbox remain
+   unchanged. Persist, restart, and retry separate `NoSemanticChange` and
+   `Rejected` records without creating applied history or effects.
+
+### Phase 3 — Draft and outbox transitions
+
+10. Implement draft revision/validity/sync transitions and source-rewrite
+    compare-and-swap decisions without a real parser or writer.
+11. Implement renderer/source effect classification using base/target graph
+    revisions, consumer baselines, dirty state, stale acknowledgment, and
+    latest-snapshot rebuild decisions. Dirty repair must be evaluated before
+    stale-target acknowledgment.
+12. Add fake source and renderer consumers that can fail, duplicate, reorder,
+    and acknowledge effects. Make the full fixed transcript pass through the
+    persistence and restart boundary.
+
+### Phase 4 — Generated traces and shrinking
+
+13. Add separate bounded generators for valid graphs, valid batches, invalid
+    batches, request retries/collisions, draft events, and effect-delivery
+    permutations. Do not rely on filtering mostly invalid random data.
+14. Add shrinkers that shorten event/batch sequences, remove leaf subtrees,
+    simplify properties, and replace identity-relative placements with simpler
+    valid placements while preserving the failing precondition when required.
+15. Compare every generated trace with the reference model observation. Add
+    bounded exhaustive traces for the smallest graphs/events before relying on
+    randomized larger traces. Include a two-commit trace that delivers target
+    revision 2 to renderer baseline 0, then verifies latest-snapshot rebuild and
+    stale target-1 suppression.
+
+### Phase 5 — Replay and corruption
+
+16. Implement checkpoint plus contiguous applied-history replay. Validate base
+    graph/schema revisions and canonical request content at each step.
+17. Inject history gaps, mismatched request content/digests, unavailable schema,
+    stale outbox acknowledgments, schema descriptor identity/digest mismatches,
+    and crash boundaries. Recovery must reproduce
+    the live observation or enter explicit diagnostic read-only state.
+18. Complete the non-deferred rows in the evidence matrix and keep deferred
+    adapter/security rows visibly unclaimed.
+
+### Phase 6 — Optional scalar formal-proof spike
+
+19. Create `lib/generative-ui-document-proof` as a standalone module outside
+    `moon.work`. First prove that one small Int/Bool/enum mirror with an explicit
+    `proof_ensure` compiles and terminates.
+20. If the spike succeeds, prove only scalar decision laws such as revision
+    delta by terminal outcome, effect classification preconditions, and
+    non-regressing next-baseline projection. Keep tree equality, batch
+    atomicity, inverse correctness, hashing, canonical encoding, and traces in
+    unit/property tests.
+21. If the spike fails because of documented prover limitations, record the
+    reason in this plan, omit unsupported claims, and keep the executable test
+    evidence. Formal-proof failure does not weaken or block already passing
+    core properties.
+22. If the proof module lands, update `.github/workflows/ci.yml` path filters and
+    the Formal Verification job to run both standalone proof modules explicitly.
+
+### Phase 7 — Gate decision and cleanup
+
+23. Run all validation commands on both JS and native, inspect the new package
+    `.mbti` for accidental exports, and verify no forbidden dependency appears
+    in the new module. Add an explicit CI step for both package targets.
+24. Record the fixed transcript result and the evidence-matrix status. Do not
+    claim adapter, host-trust, or product-value safety from this core gate. Do
+    not begin PKE semantic/generated behavior until its fixed baseline is
+    independently accepted.
+25. If the gate passes, open a separate JSX conformance plan. If it fails,
+    revise or reject the document-engine direction before adapter work.
+26. On completion, move this plan to `docs/archive/completed-phases/` and mark
+    the linked TODO item done in the same change.
+
+## PR split
+
+1. **Core boundary and red gate:** Phase 0 only.
+2. **Graph and operation algebra:** Phase 1.
+3. **Request/persistence protocol:** Phase 2.
+4. **Draft/outbox and fixed transcript:** Phase 3.
+5. **Property/reference-model traces:** Phase 4.
+6. **Replay/fault recovery:** Phase 5.
+7. **Optional formal proof and CI:** Phase 6, only after the spike succeeds.
+8. **Gate report and archival:** Phase 7.
+
+Each PR starts with failing evidence for its phase and ends with affected-package
+`moon check`/`moon test`; no PR may introduce the next adapter layer early.
+
+## Acceptance criteria
+
+- [ ] `lib/generative-ui-document` is a `moon.work` member with no Canopy,
+      cognition, `incr`, JSX, DOM, provider, agent, or `event-graph-walker`
+      dependency.
+- [ ] The full invalid-draft/duplicate-request/rewrite-conflict/renderer-
+      failure/out-of-order/restart transcript passes against both reference and
+      production observations.
+- [ ] Applied persistence happens once; retry after response loss returns the
+      recorded result without another graph revision or history entry.
+- [ ] Failed batches expose no prefix; semantic no-ops do not advance revision;
+      explicit property removal remains distinct from `null`.
+- [ ] Draft bytes survive stale or invalid rewrite attempts exactly.
+- [ ] Renderer/source baselines never regress: the fixed transcript covers
+      dirty-plus-stale precedence, duplicate and failure delivery, and generated
+      two-commit traces cover revision gaps and latest-snapshot rebuild.
+- [ ] Persisted `NoSemanticChange` and `Rejected` records survive restart and
+      retry without adding graph revisions, applied history, or outbox entries.
+- [ ] Replay either reconstructs the exact live observation or fails closed on
+      corruption, schema absence, or changed schema descriptor content.
+- [ ] Deterministic IDs repeat for the same document/request/ordinal, differ for
+      distinct logical tuples, survive replay, and cannot be supplied by the
+      generated proposal body.
+- [ ] An equal-digest/different-canonical-content request collision is rejected
+      without changing the stored record, graph, history, or outbox; raw
+      transport equivalence remains deferred to decoder conformance.
+- [ ] Every non-deferred evidence-matrix row maps to at least one passing test;
+      deferred rows remain explicitly unclaimed.
+- [ ] Generated traces have useful shrinking and report a minimized event trace
+      on failure.
+- [ ] `moon info` shows no accidental public API or trait-bound widening in the
+      new core package.
+- [ ] If formal proofs land, every claim is attached to a compiling
+      `proof_ensure`, the standalone module has no project dependency, and CI
+      runs it. No proof is claimed for unsupported collection/stateful laws.
+- [ ] No source, JSX, DOM, JavaScript, persistence backend, collaboration, or
+      second-renderer implementation is added by this plan.
+
+## Validation
+
+Before adding definitions:
+
+```bash
+NEW_MOON_MOD=0 moon ide outline lib/cognition
+NEW_MOON_MOD=0 moon ide outline lib/canvas-graph/graph_model
+NEW_MOON_MOD=0 moon ide doc "Map::*"
+NEW_MOON_MOD=0 moon ide doc "Set::*"
+NEW_MOON_MOD=0 moon ide doc "Array::*"
+NEW_MOON_MOD=0 moon ide doc "String::*"
+NEW_MOON_MOD=0 moon ide doc "Bytes::*"
+NEW_MOON_MOD=0 moon ide doc "Buffer::*"
+NEW_MOON_MOD=0 moon ide doc "Option::*"
+NEW_MOON_MOD=0 moon ide doc "Result::*"
+NEW_MOON_MOD=0 moon ide doc "@cmp"
+NEW_MOON_MOD=0 moon ide doc "@quickcheck"
+```
+
+During each core PR:
+
+```bash
+NEW_MOON_MOD=0 moon check --target js lib/generative-ui-document
+NEW_MOON_MOD=0 moon check --target native lib/generative-ui-document
+NEW_MOON_MOD=0 moon test --target js lib/generative-ui-document
+NEW_MOON_MOD=0 moon test --target native lib/generative-ui-document
+```
+
+Before merge:
+
+```bash
+NEW_MOON_MOD=0 moon test
+NEW_MOON_MOD=0 moon fmt
+NEW_MOON_MOD=0 moon info
+git status --short -- '*.mbti'
+git diff -- '*.mbti'
+git diff --check
+```
+
+If the proof spike lands:
+
+```bash
+cd lib/generative-ui-document-proof
+moon check
+moon prove
+moon fmt
+moon info
+```
+
+Also inspect `moon.work` and `.github/workflows/ci.yml`, and open every new or
+changed `pkg.generated.mbti`; `git diff` alone does not display an untracked
+interface file. Verify that the core interface is empty apart from unavoidable
+module metadata and that the optional proof interface exposes nothing
+unexpected.
+
+No TypeScript, browser, JS artifact, proof-submodule, or vendored-submodule
+command is required locally unless the corresponding out-of-scope boundary
+changes. Once this plan edits `.github/workflows/ci.yml`, however, the pull
+request must wait for the full workflow-triggered CI fan-out, including proof
+and browser jobs selected by that workflow path.
+
+## Risks
+
+- The fake store proves protocol ordering and recovery decisions, not the
+  atomicity guarantees of a future production storage technology. Each real
+  store will need its own boundary tests.
+- A production-looking graph API may invite premature export. Keep all core
+  declarations private until a later adapter/public-contract decision.
+- Random graph generation can hide behind rejection-heavy samples. Separate
+  valid and invalid generators and report their coverage.
+- Shrinking a stateful failure can destroy the precondition that triggered it.
+  Shrink traces and graph fixtures together and re-check the intended failure
+  class.
+- Canonical digests are not injective. Persist canonical content and treat a
+  digest as an index/check, not as semantic identity.
+- The full fixed transcript verifies only the private architecture hypothesis.
+  It cannot authorize PKE semantic candidates before the fixed deterministic
+  baseline, and product value still requires a later real use case and decision
+  gate.
+- The optional proof mirror can drift from production behavior. Keep proof
+  targets scalar, name the corresponding production decision, and retain the
+  production property test as the integration oracle.
+- The 21-obligation list may evolve. Update the evidence matrix by obligation
+  meaning whenever it changes; the fixed count is only a diagnostic.
+- Raw JSON whitespace, key-order, and encoding equivalence cannot be proved by a
+  typed core that has no decoder. The core verifies canonical typed content;
+  the eventual decoder/adapter gate owns transport equivalence.
+
+## Open questions
+
+- Which private persistent collection representation gives the clearest graph
+  equality and replay implementation without exposing mutation? Resolve during
+  Phase 1 after the required MoonBit API checks; do not optimize before the
+  reference properties pass.
+- Should bounded exhaustive trace enumeration be a handwritten small alphabet
+  or generated from the same event grammar as QuickCheck? Choose the simpler
+  implementation that reports reproducible traces.
+- Which scalar transition rule, if any, gives enough value to justify the
+  standalone proof module and CI cost? Phase 6 begins with a compilation spike
+  precisely to answer this.
+
+## Notes
+
+- `event-graph-walker` remains the sole owner of future causal history, CRDT
+  tree semantics, sync, and collaborative undo. This private single-writer log
+  must not evolve into a competing causal oplog.
+- Real JSX conformance belongs to a follow-up plan under `ffi/jsx`, where the
+  adapter-private baseline and outcomes are visible without reversing
+  dependencies.
+- The design document's gate is satisfied only for the non-deferred core rows.
+  It must not be read as proof of adapter isolation, hostile JavaScript safety,
+  collaboration, product usefulness, or readiness to bypass the PKE baseline
+  and existing Generative UI V1 sequence.

--- a/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
+++ b/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
@@ -85,7 +85,12 @@ only when it cannot escape.
   separate equality-preserving tombstone or monotonic sequence design.
 - Each `SchemaRevision` names one immutable descriptor. Commits and checkpoints
   persist its digest; restore rejects identity/content disagreement.
-- Persistence intent and acknowledgment are separate reducer events.
+- Persistence intent and acknowledgment are separate reducer events. Each
+  `Applied` commit stores a canonical delivery plan and digest. A pure function
+  regenerates the exact effect tuples/IDs from its source kind, ordered renderer
+  targets, and baselines. Ledger-only outcomes store empty plans/manifests.
+  Every effect remains pending until an applied, stale, or blocked outcome is
+  durable.
 - Dirty renderer repair precedes stale acknowledgment. Clean renderers apply
   only from the expected baseline and rebuild the latest snapshot after gaps.
 - The core makes no adapter, host-trust, accessibility, collaboration, or
@@ -101,8 +106,9 @@ model with the implementation using one test-only observation:
 - graph, schema revision/digest, and graph revision;
 - exact draft bytes/revision and sync state;
 - canonical terminal request outcomes and handle mappings;
-- applied history and pending effects with base/target revisions, snapshot
-  references, and draft preconditions;
+- applied history, canonical delivery plans/digests, regenerated effect
+  manifests, and complete outbox status keyed by `EffectId`, including kind,
+  request/revision, target, baselines, routing preconditions, and outcome;
 - renderer/source baselines and dirty/conflict state;
 - explicit diagnostic read-only recovery state.
 
@@ -117,13 +123,14 @@ On mismatch, report the minimized event trace and both observations.
    schema identity/digest, renderer baseline 0, and acknowledged effect `E0`.
 2. Change the draft to exact invalid bytes `D1 = "valid\n<unfinished"`; retain
    `G0` as meaning. These bytes are fixtures, not proposed syntax.
-3. Submit host-built request `Q` at base 0. Its batch inserts two handles and
-   sets a property, making ordinal IDs and multi-step atomicity observable.
-4. Atomically persist `G1`, revision 1, request record, history, and source/render
-   effects, then lose the response. Retry `Q`; return its record without a
+3. Submit host-built agent request `Q` at base 0. Its batch inserts two handles
+   and sets a property, making ordinal IDs and multi-step atomicity observable.
+4. Atomically persist `G1`, revision 1, request record, history, exact effect
+   manifest, and source/render entries, then lose the response. Retry `Q`;
+   return its record without a
    second revision or history entry.
-5. Deliver the source effect. Its draft precondition fails, so preserve `D1`
-   byte-for-byte and enter `RewriteConflict`.
+5. Deliver its `RewriteSource` effect. The draft precondition fails, so
+   preserve `D1` byte-for-byte and durably record blocked `RewriteConflict`.
 6. Fail renderer effect `E1`. While dirty at baseline 0, deliver stale `E0`;
    dirty repair must rebuild `G1` rather than merely acknowledge `E0`. Duplicate
    `E1` after recovery without regression.
@@ -135,7 +142,15 @@ On mismatch, report the minimized event trace and both observations.
 Additional mandatory fixtures:
 
 - persist, restart, and retry one `NoSemanticChange` and one `Rejected` request;
-  neither creates graph revision, applied history, or outbox work;
+  neither creates graph revision, applied history, manifest, or outbox work;
+- edit the draft before delivering text-origin `MarkSynchronized`; record a
+  stale outcome without changing bytes, crash before that outcome is durable,
+  then redeliver to the same result;
+- assert that projection- and undo-origin commits emit exactly one
+  `RewriteSource` and no `MarkSynchronized`;
+- regenerate manifests from canonical delivery plans; reject omitted/duplicate
+  targets, cross-linked entries, swapped IDs across two commits, and corruption
+  of an acknowledged entry;
 - deliver revision 2 to renderer baseline 0 and rebuild the latest snapshot;
 - force equal digests for different canonical requests and preserve all state;
 - reject failed batch prefixes and distinguish `RemoveProperty` from `null`.
@@ -152,9 +167,12 @@ Additional mandatory fixtures:
 | Handles cannot mint/reuse IDs | Derivation, uniqueness, retry, and replay properties. |
 | Inverse restores under preconditions | Valid-batch/inverse property. |
 | No-delta lowering preserves meaning | Reducer fixture: synchronized draft; no request, revision, history, or outbox. |
+| Text-origin commit never rewrites source | Matching/stale `MarkSynchronized` fixtures with crash/redelivery. |
+| Non-text semantic commit uses rewrite | Projection/undo fixtures and agent transcript: `RewriteSource` only. |
 | Invalid or stale draft is preserved | Fixed transcript and generated CAS mismatch. |
 | Renderer state never regresses | Dirty-plus-stale transcript and delivery permutations. |
-| Replay reconstructs or fails closed | Gap, request, digest, schema, and checkpoint corruption. |
+| Commit/effect correlation is exact | Regenerated delivery-plan tuples; omitted/duplicate/swapped-ID fixtures. |
+| Replay reconstructs or fails closed | Full-ledger/all-status outbox restart plus corruption fixtures. |
 | Stale graph/schema/draft rejects | Generated revision properties. |
 | Schema change is semantic and immutable | Equality and descriptor mismatch properties. |
 | Transport canonicalization agrees | Typed canonical-content tests; raw decoder equivalence deferred. |
@@ -224,14 +242,18 @@ package checks/tests; no PR starts the next adapter layer.
 ### Phase 2 — Requests and persistence
 
 - Add typed canonical content, collision-aware lookup, and terminal outcomes.
-- Model persistence intent, success/failure, response release, and effect
-  release as reducer events.
+- Model persistence intent, canonical delivery plans/digests, derived manifests,
+  success/failure, response release, and effect release as reducer events.
 - Add fake-store failures before commit, response loss after commit, restart,
   request-ID misuse, forced digest collision, and no-op/rejected recovery.
 
 ### Phase 3 — Draft and outbox
 
 - Add draft validity/revision and source rewrite CAS without a real parser.
+- Emit `MarkSynchronized` for text-origin commits and `RewriteSource` only for
+  projection, agent, or undo origins; cover every origin explicitly.
+- Give source effects durable applied, stale, or blocked outcomes. Test draft
+  edits before delivery and crashes before outcome persistence.
 - Classify renderer/source effects with dirty precedence, stale acknowledgment,
   expected baseline, and latest-snapshot rebuild.
 - Make the fixed transcript pass through restart with duplicate, reordered, and
@@ -248,9 +270,13 @@ package checks/tests; no PR starts the next adapter layer.
 
 ### Phase 5 — Replay and corruption
 
-- Replay checkpoint plus contiguous applied history.
-- Inject history gaps, request/digest mismatches, schema identity/digest changes,
-  stale acknowledgments, and crash boundaries.
+- Restore the checkpoint, complete request ledger, effect manifests, and every
+  pending or terminal outbox status, then replay contiguous applied history.
+- Recompute ledger/delivery-plan digests, regenerate full effect tuples, and
+  require exact manifest/outbox equality; ledger-only outcomes have empty plans.
+- Redeliver pending effects, then inject omitted or duplicate targets, swapped
+  IDs across commits, cross-links, corrupt acknowledged entries, history gaps,
+  schema changes, stale acknowledgments, and crash boundaries.
 - Match the live observation or enter explicit diagnostic read-only state.
 
 ### Phase 6 — Optional scalar proof
@@ -283,8 +309,12 @@ package checks/tests; no PR starts the next adapter layer.
 - Syntax-only lowering synchronizes the draft without a request, graph revision,
   history, or outbox work.
 - Draft bytes and semantic meaning survive all tested conflict/failure paths.
-- Renderer/source baselines never regress, including dirty-plus-stale and gaps.
-- Replay reconstructs exactly or fails closed on every injected corruption.
+- Source effect kinds and durable outcomes preserve bytes under delayed delivery
+  and crash/redelivery; renderer/source baselines never regress.
+- Regeneration from the canonical delivery plan proves each applied commit has
+  exactly its expected effect tuples; ledger-only outcomes have empty plans.
+- Replay restores all request and outbox statuses exactly or fails closed on
+  every injected corruption.
 - Generated failures shrink to reproducible minimal traces.
 - Optional proofs claim only compiled scalar properties and run in CI.
 - No source, renderer, JavaScript, storage backend, collaboration, or product
@@ -321,6 +351,7 @@ NEW_MOON_MOD=0 moon test --target native lib/generative-ui-document
 Before merge:
 
 ```bash
+NEW_MOON_MOD=0 moon check
 NEW_MOON_MOD=0 moon test
 NEW_MOON_MOD=0 moon fmt
 NEW_MOON_MOD=0 moon info

--- a/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
+++ b/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
@@ -4,18 +4,21 @@
 
 ## Purpose
 
+A recovered graph can look correct while the same request has committed twice,
+a newer draft has been overwritten, or a renderer has resumed from an older
+baseline. Testing those failures separately would miss the state that connects
+them.
+
 The [document-engine design](../design/incremental-generative-ui-document-engine.md)
-defines unimplemented authority, identity, transaction, and recovery rules.
-This plan tests them in a private deterministic core before syntax, DOM,
-storage, or JavaScript integration.
+earns adapter work only if one private deterministic core can preserve an
+invalid human draft, commit exactly once, block a conflicting rewrite, recover
+a failed renderer, and restart with the same identities. If that combined trace
+fails, revise or reject the design before syntax, DOM, storage, or JavaScript
+integration.
 
-The gate is intentionally falsifiable: if an invalid human draft, exactly-once
-semantic commit, failed renderer, conflicting rewrite, and restart cannot
-coexist in a small core and fake shell, revise or reject the design.
-
-Passing does not authorize PKE semantic candidates before its fixed baseline,
-change the Generative UI V1 sequence, or establish a public renderer-neutral
-contract.
+A passing trace still does not authorize PKE semantic candidates before its
+fixed baseline, change the Generative UI V1 sequence, or establish a public
+renderer-neutral contract.
 
 ## Scope
 

--- a/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
+++ b/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
@@ -2,470 +2,297 @@
 
 **Status:** ready for bounded validation; product integration gated
 
-## Why
+## Purpose
 
-The [Incremental Generative UI document engine](../design/incremental-generative-ui-document-engine.md)
-defines authority, transaction, identity, recovery, and trust invariants that
-are not implemented. The first implementation must therefore be a falsifiable
-semantic-core experiment, not a syntax, DOM, persistence, or JavaScript
-integration. It is discardable architecture research: passing it cannot add
-semantic candidates or generated behavior to the personal knowledge
-environment before that direction's fixed deterministic baseline is accepted,
-and it cannot freeze a public renderer-neutral contract.
+The [document-engine design](../design/incremental-generative-ui-document-engine.md)
+defines unimplemented authority, identity, transaction, and recovery rules.
+This plan tests them in a private deterministic core before syntax, DOM,
+storage, or JavaScript integration.
 
-This plan proves the central claim: an invalid human draft can coexist with one
-exactly-once agent commit while source rewriting conflicts, renderer effects
-fail or arrive out of order, and restart/replay still reconstructs the same
-committed graph and semantic IDs. If that transcript cannot pass through a
-small deterministic core and fake shell, the broader document-engine direction
-is not justified.
+The gate is intentionally falsifiable: if an invalid human draft, exactly-once
+semantic commit, failed renderer, conflicting rewrite, and restart cannot
+coexist in a small core and fake shell, revise or reject the design.
 
-This file is the sole implementation spec for that validation slice. The design
-document remains the source of principles and invariants.
+Passing does not authorize PKE semantic candidates before its fixed baseline,
+change the Generative UI V1 sequence, or establish a public renderer-neutral
+contract.
 
 ## Scope
 
-In:
+Create one private module:
 
-- `moon.work` — add the renderer- and agent-neutral core module.
-- `lib/generative-ui-document/moon.mod` — new standalone module with no Canopy,
-  cognition, renderer, DOM, or incremental-runtime dependency; pin
-  `moonbitlang/quickcheck` for tests.
-- `lib/generative-ui-document/moon.pkg` — core package plus
-  `core/quickcheck`, SplitMix, and `@qc` imports scoped to white-box tests.
-- `lib/generative-ui-document/types.mbt` — private document, revision,
-  identity, request, outcome, sync, and effect data.
-- `lib/generative-ui-document/graph.mbt` — private semantic graph invariants
-  and semantic equality.
-- `lib/generative-ui-document/operation.mbt` — private forward batch
-  application, canonical request content, deterministic ID resolution, and
-  inverse derivation.
-- `lib/generative-ui-document/transition.mbt` — pure document reducer and
-  persistence/effect decisions.
-- `lib/generative-ui-document/replay.mbt` — pure checkpoint/history recovery.
-- `lib/generative-ui-document/reference_model_wbtest.mbt` — deliberately small
-  immutable reference model and observation oracle.
-- `lib/generative-ui-document/fixed_scenario_wbtest.mbt` — the mandatory
-  falsifiable transcript and fake atomic store/source/renderer shell.
-- `lib/generative-ui-document/operation_properties_wbtest.mbt` — generated
-  graph/batch/identity/inverse properties.
-- `lib/generative-ui-document/transition_properties_wbtest.mbt` — generated
-  request, draft, outbox, and state-machine traces.
-- `lib/generative-ui-document/replay_wbtest.mbt` — checkpoint, corruption, and
-  crash-boundary recovery tests.
-- `lib/generative-ui-document-proof/` — optional standalone proof module for
-  scalar transition rules only, gated by an early proof-compilation spike.
-- `.github/workflows/ci.yml` — run the new core package on both JS and native;
-  if the proof spike lands, include its paths in change detection and run each
-  standalone proof module explicitly.
-- `docs/design/incremental-generative-ui-document-engine.md` and
-  `docs/TODO.md` — gate link and completion status only.
+| Area | Planned files |
+| --- | --- |
+| Workspace/module | `moon.work`, `lib/generative-ui-document/moon.mod`, `moon.pkg` |
+| Core | `types.mbt`, `graph.mbt`, `operation.mbt`, `transition.mbt`, `replay.mbt` |
+| Test model | `reference_model_wbtest.mbt`, `fixed_scenario_wbtest.mbt` |
+| Properties | `operation_properties_wbtest.mbt`, `transition_properties_wbtest.mbt`, `replay_wbtest.mbt` |
+| Optional proof | standalone `lib/generative-ui-document-proof/` for scalar decisions only |
+| CI/docs | `.github/workflows/ci.yml`, design gate link, TODO completion |
 
-Out:
+The module supports JS and native and pins `moonbitlang/quickcheck` for
+white-box tests. It imports no Canopy, cognition, renderer, DOM, provider,
+agent framework, `incr`, or `event-graph-walker` package. No type is public;
+`pkg.generated.mbti` should contain no accidental API.
 
-- Changes to `lib/cognition/`; its lifecycle and replay code are precedents,
-  not dependencies of the semantic core.
-- Production JSX adapter changes or new renderer-neutral public APIs.
-- Arbitrary JavaScript, `js_engine`, DOM, React, provider, or agent-framework
-  integration.
-- A real database, filesystem store, or production outbox implementation.
-- Final source syntax, parser, or projection-to-source lowering.
-- Collaboration, causal history, CRDT merge, or semantic undo integration with
-  `event-graph-walker`.
-- Schema-migration authoring, action/command execution, approval UI, a second
-  renderer, product-value experiments, or PKE semantic/generated views.
-- Performance optimization or benchmarks before correctness is established.
+Out of scope:
 
-## Current state
+- production JSX, source, renderer, storage, or outbox adapters;
+- public renderer-neutral APIs;
+- arbitrary JavaScript, `js_engine`, DOM, React, or provider integration;
+- collaboration, CRDT merge, causal history, and collaborative undo;
+- schema migration, commands, approval UI, second renderer, PKE generated
+  views, and product-value experiments;
+- optimization or benchmarks before correctness.
 
-- [`lib/cognition/generative_ui.mbt`](../../lib/cognition/generative_ui.mbt)
-  provides the current request/generation lifecycle, event vocabulary, and
-  terminal-state handling. It is a behavioral precedent; the new module must
-  not import cognition or its `incr` dependency.
-- [`lib/cognition/generative_ui_candidate.mbt`](../../lib/cognition/generative_ui_candidate.mbt)
-  demonstrates fail-closed capability validation. Its table/filter-specific
-  candidate types remain adapter content and are not generalized into the core.
-- [`lib/cognition/generative_ui_replay.mbt`](../../lib/cognition/generative_ui_replay.mbt)
-  demonstrates deterministic fixed-event replay with an explicit cursor.
-- [`lib/canvas-graph/graph_model/model.mbt`](../../lib/canvas-graph/graph_model/model.mbt)
-  and its operation tests demonstrate pure operation replay; they are examples,
-  not dependencies.
-- [`core/reconcile_properties_wbtest.mbt`](../../core/reconcile_properties_wbtest.mbt)
-  demonstrates bounded recursive `Arbitrary` generators, explicit shrinkers,
-  and `@qc.quick_check_fn`.
-- [`ffi/jsx/render_baseline_wbtest.mbt`](../../ffi/jsx/render_baseline_wbtest.mbt)
-  demonstrates folding generated renderer events through a lifecycle and
-  checking reachable invariants. Real JSX conformance remains a later plan
-  because its baseline and outcomes are adapter-private.
-- [`lib/semantic/proof/`](../../lib/semantic/proof/) and
-  [Formal Verification](../development/formal-verification.md) define the
-  standalone `moon prove` pattern and its Map/Array/state-machine limits.
-- [The JSX DOM patch contract](../decisions/2026-07-13-jsx-dom-patch-contract.md)
-  remains the V1 adapter/session contract. This plan does not change its
-  DOM-gated candidate commit semantics.
+## Existing evidence
 
-## Desired state
+| Existing code | Use in this plan |
+| --- | --- |
+| `lib/cognition/generative_ui.mbt` | Reducer lifecycle and terminal-state precedent; no dependency. |
+| `generative_ui_candidate.mbt` | Fail-closed capability validation precedent; candidate types stay adapter-specific. |
+| `generative_ui_replay.mbt` | Fixed replay-log and cursor precedent. |
+| `lib/canvas-graph/graph_model/model.mbt` | Pure operation replay example; different domain invariants. |
+| `core/reconcile_properties_wbtest.mbt` | Bounded generators and explicit shrinkers. |
+| `ffi/jsx/render_baseline_wbtest.mbt` | Generated lifecycle traces and reachable invariants. |
+| `lib/semantic/proof/` | Standalone proof layout and documented collection/state limits. |
+| JSX DOM patch contract | Existing V1 session contract; unchanged by this plan. |
 
-The slice is complete when a private, deterministic core and test-owned shell
-can execute the fixed transcript below and satisfy every core obligation mapped
-in this plan.
+## Core and shell boundary
 
-The functional core owns:
+The functional core owns graph validation/equality, ordered batch apply,
+deterministic ID resolution, request canonicalization, idempotency decisions,
+draft/sync/outbox transitions, inverse derivation, and replay. It returns next
+state plus persistence, response, source, or renderer decisions.
 
-- semantic graph validation and equality;
-- ordered, atomic `OperationBatch` application;
-- deterministic request-local handle resolution;
-- request canonicalization and collision-aware idempotency decisions;
-- graph, draft, request-ledger, sync, and outbox transitions;
-- replay and fail-closed recovery;
-- decisions describing persistence, response, source rewrite, and rendering.
+The test-only imperative shell owns the fake atomic store, draft bytes,
+renderer baselines, delivery order, failure injection, response loss, and
+restart. It releases no response or effect until the terminal request record
+(and, for `Applied`, graph/history/outbox transaction) is persisted.
 
-The imperative shell remains test-only in this slice. It owns a fake atomic
-store, delivery order, injected failure, response loss, fake draft bytes, and
-fake renderer baselines. The reducer may emit a response or post-commit effect
-only after the shell reports that the corresponding terminal `RequestRecord`
-and, for `Applied`, graph/history/outbox transaction were persisted.
-
-No type from this module is public. `pkg.generated.mbti` should remain empty or
-contain only intentionally unavoidable module metadata. A later adapter plan
-must re-evaluate and validate any API promotion.
+Core results do not expose mutable internal collections. Use immutable views or
+defensive copies at adapter boundaries; local builder mutation is acceptable
+only when it cannot escape.
 
 ## Decision locks
 
-- The core lives in `lib/generative-ui-document`, not `lib/cognition`, so its
-  dependency graph enforces renderer, agent, and reactive-runtime neutrality.
-- `UiNodeId` is logically derived from `(DocumentId, RequestId, insertion
-  ordinal)`. The core stores canonical request content alongside its digest;
-  digest equality alone never proves request equality or semantic identity. A
-  test-owned digest function must be injectable so collision handling is
-  falsifiable without weakening production canonical-content comparison.
-- `RequestRecord` is mandatory for every host-constructed terminal request.
-  The initial slice does not compact these records; retention bounds require a
-  later equality-preserving tombstone or monotonic request-sequence design.
-  Decoder failures before request construction remain boundary diagnostics.
-- The persistence protocol has an explicit intent/acknowledgment boundary.
-  “Persist before respond” is not modeled as an in-memory ledger mutation.
-- Every `SchemaRevision` names one immutable canonical descriptor. Commits and
-  checkpoints persist its digest; restore fails closed if either identity or
-  digest differs.
-- Effects carry base and target graph revisions. Dirty repair takes precedence
-  over stale acknowledgment. Clean consumers ignore stale targets, apply only
-  from the expected baseline, and rebuild from the latest committed snapshot
-  after a gap.
-- The plan verifies only the obligations reachable without production adapters.
-  Adapter/trust-boundary obligations stay unclaimed and are listed as deferred
-  in the evidence matrix.
-- `moon prove` is optional and subordinate to executable core evidence. It may
-  prove only scalar/enum decision functions that compile under the documented
-  prover constraints.
+- `UiNodeId` derives from `(DocumentId, RequestId, insertion ordinal)`.
+- Canonical request content is equality authority; its digest is only an
+  index/integrity check. Tests can inject a colliding digest.
+- Every host-constructed terminal request has a durable `RequestRecord`.
+  Decoder failures before construction remain boundary diagnostics.
+- The initial slice does not compact request records. Retention requires a
+  separate equality-preserving tombstone or monotonic sequence design.
+- Each `SchemaRevision` names one immutable descriptor. Commits and checkpoints
+  persist its digest; restore rejects identity/content disagreement.
+- Persistence intent and acknowledgment are separate reducer events.
+- Dirty renderer repair precedes stale acknowledgment. Clean renderers apply
+  only from the expected baseline and rebuild the latest snapshot after gaps.
+- The core makes no adapter, host-trust, accessibility, collaboration, or
+  product-value claim.
+- `moon prove` is optional and subordinate to executable evidence.
 
-## Reference model and observation oracle
+## Reference model and observation
 
-`reference_model_wbtest.mbt` owns a small immutable model that is intentionally
-simpler than production code. It uses the same public event meaning but does
-not call production transition or apply functions.
+`reference_model_wbtest.mbt` implements a small model without calling production
+apply or transition functions. Every fixed or generated trace compares this
+model with the implementation using one test-only observation:
 
-Every generated or fixed trace compares this model with the implementation
-through one test-only observation containing:
+- graph, schema revision/digest, and graph revision;
+- exact draft bytes/revision and sync state;
+- canonical terminal request outcomes and handle mappings;
+- applied history and pending effects with base/target revisions, snapshot
+  references, and draft preconditions;
+- renderer/source baselines and dirty/conflict state;
+- explicit diagnostic read-only recovery state.
 
-- semantic graph, schema revision, and canonical schema descriptor digest;
-- graph revision;
-- exact draft bytes, draft revision, and sync status;
-- canonical terminal request outcomes;
-- applied-history IDs and deterministic new-node mappings;
-- pending effect IDs with base/target revisions;
-- source and renderer baselines;
-- read-only/fail-closed recovery state.
+Exclude caches, iteration order, diagnostic prose, and builder scratch state.
+On mismatch, report the minimized event trace and both observations.
 
-Implementation-only caches, collection iteration order, diagnostic formatting,
-and builder scratch state are excluded. A mismatch reports the minimized event
-trace and both observations.
+## Fixed transcript
 
-## Fixed falsifiable scenario
+`fixed_scenario_wbtest.mbt` is the first red test and final integration gate:
 
-`fixed_scenario_wbtest.mbt` is the first red test and the final integration gate.
-It executes this transcript through the reference model and production reducer:
+1. Start with valid draft `D0`, root-only graph `G0` at revision 0, immutable
+   schema identity/digest, renderer baseline 0, and acknowledged effect `E0`.
+2. Change the draft to exact invalid bytes `D1 = "valid\n<unfinished"`; retain
+   `G0` as meaning. These bytes are fixtures, not proposed syntax.
+3. Submit host-built request `Q` at base 0. Its batch inserts two handles and
+   sets a property, making ordinal IDs and multi-step atomicity observable.
+4. Atomically persist `G1`, revision 1, request record, history, and source/render
+   effects, then lose the response. Retry `Q`; return its record without a
+   second revision or history entry.
+5. Deliver the source effect. Its draft precondition fails, so preserve `D1`
+   byte-for-byte and enter `RewriteConflict`.
+6. Fail renderer effect `E1`. While dirty at baseline 0, deliver stale `E0`;
+   dirty repair must rebuild `G1` rather than merely acknowledge `E0`. Duplicate
+   `E1` after recovery without regression.
+7. Crash before each possible effect acknowledgment becomes durable. Recover
+   from checkpoint, history, request records, and outbox, then redeliver.
+8. Assert graph `G1`, schema identity/digest, revision 1, one terminal/applied
+   outcome for `Q`, stable IDs, unchanged `D1`, and renderer baseline 1.
 
-1. Start with draft bytes `D0 = "valid\n"`, a root-only committed graph `G0`,
-   graph revision 0, an immutable schema revision and descriptor digest, and a
-   renderer synchronized to revision 0. Retain a
-   redeliverable already-acknowledged renderer effect `E0` whose target is 0.
-2. Edit the draft to `D1 = "valid\n<unfinished"` and report it invalid; retain
-   those exact bytes and keep `G0` as current meaning. The strings are test
-   fixtures, not a proposed source grammar.
-3. Deliver host-constructed request `Q` at base revision 0. Its valid batch
-   declares two new-node handles, inserts both nodes, and sets one property so
-   deterministic ordinal IDs and multi-primitive commit are observable.
-4. Persist the resulting graph `G1`, request record, history, source/render
-   effects, and graph revision 1 atomically, then lose the response. Retry `Q`;
-   return the recorded outcome without another revision or history entry.
-5. Deliver the source-rewrite effect for target 1. Its draft validity/revision
-   precondition fails; preserve `D1` byte-for-byte and enter
-   `RewriteConflict`.
-6. Deliver renderer effect `E1` for target 1 and force failure. While the
-   renderer is dirty at baseline 0, deliver stale `E0`: dirty repair must take
-   precedence and rebuild from `G1`, not merely acknowledge `E0`. Duplicate
-   `E1` after recovery; it must be acknowledged without regression.
-7. Crash before every effect acknowledgment is durable. Recover from
-   checkpoint, applied history, request records, and pending outbox, then
-   redeliver remaining effects.
-8. Assert that recovered graph, schema revision, and schema descriptor digest
-   equal `G1`, graph revision is exactly 1, `Q` has one terminal/applied outcome,
-   IDs are unchanged, `D1` is unchanged, and the renderer baseline is 1.
-   Separate generated traces must create revisions 1 and 2 and deliver target 2
-   to baseline 0 to prove gap rebuild.
+Additional mandatory fixtures:
 
-Separate terminal-outcome fixtures must persist, crash, recover, and retry one
-`NoSemanticChange` request and one `Rejected` request. Each returns its recorded
-outcome without adding a graph revision, applied-history entry, or outbox entry.
-A batch-rejection fixture is required, but it is not a substitute for the full
-transcript or these request-ledger recovery fixtures.
+- persist, restart, and retry one `NoSemanticChange` and one `Rejected` request;
+  neither creates graph revision, applied history, or outbox work;
+- deliver revision 2 to renderer baseline 0 and rebuild the latest snapshot;
+- force equal digests for different canonical requests and preserve all state;
+- reject failed batch prefixes and distinguish `RemoveProperty` from `null`.
 
 ## Evidence matrix
 
-| Obligation from the design document | Evidence in this plan |
+| Claim | Required evidence |
 | --- | --- |
-| Only semantic commit advances meaning | Fixed transcript; transition trace property; fake-store acknowledgment test |
-| Failed primitive exposes no batch prefix | Batch-rejection unit test; generated batch atomicity property |
-| Applied advances once; no-op does not | Request/revision unit tests; generated no-op property |
-| No-op and rejected outcomes survive restart/retry | Terminal-outcome crash/recovery fixtures |
-| `RemoveProperty` differs from `null` | Focused value/property unit test |
-| Duplicate request does not apply twice | Fixed transcript; retry and response-loss fault tests |
-| Request-local handles cannot mint/reuse IDs | Deterministic derivation and uniqueness properties |
-| Inverse restores when preconditions hold | Valid-batch/inverse property with explicit precondition generator |
-| Syntax-only edit preserves meaning | Reducer event test using a fake no-semantic-delta lowering result |
-| Invalid/concurrent draft is not overwritten | Fixed transcript; stale draft trace property |
-| Renderer failure cannot alter semantic meaning | Fixed transcript; generated renderer-failure traces |
-| Replay reconstructs or fails closed | Replay properties; gap/request-digest/schema-descriptor corruption tests |
-| Projection/renderer IDs are not durable semantic IDs | Deferred to adapter/API conformance; no such IDs exist in the private core |
-| Stale graph/schema/draft revisions reject | Generated stale-revision properties |
-| Generated input cannot obtain host/DOM/callback authority | Deferred to decoder and adapter conformance; not claimed by this core slice |
-| Host trust boundary is structural | Deferred to host/renderer integration; not claimed by this core slice |
-| Terminal request record precedes response | Fake atomic-store acknowledgment and crash-boundary tests |
-| Canonical-equivalent requests compare identically | Typed canonical-content and ordering properties; equal-digest/different-content collision fixture; raw transport whitespace/encoding remains deferred to decoder conformance |
-| Schema revision change is semantic | Focused semantic-equality unit/property test |
-| Duplicate/out-of-order effects converge monotonically | Fixed transcript including dirty-plus-stale precedence; generated effect permutation traces |
-| Stale source effect never overwrites draft | Fixed transcript; generated CAS mismatch traces |
-| Node identity repeats on retry and separates tuples | Deterministic ID properties and replay assertion |
+| Only semantic commit advances meaning | Fixed transcript and transition traces. |
+| Batch is atomic; no-op does not advance | Rejection/no-op units and generated batches. |
+| Request retry applies at most once | Response-loss transcript and crash fixtures. |
+| Non-applied outcomes survive restart | No-op/rejected recovery fixtures. |
+| Canonical content defeats ID reuse/collision | Ordering properties and injected collision. |
+| Handles cannot mint/reuse IDs | Derivation, uniqueness, retry, and replay properties. |
+| Inverse restores under preconditions | Valid-batch/inverse property. |
+| No-delta lowering preserves meaning | Reducer fixture: synchronized draft; no request, revision, history, or outbox. |
+| Invalid or stale draft is preserved | Fixed transcript and generated CAS mismatch. |
+| Renderer state never regresses | Dirty-plus-stale transcript and delivery permutations. |
+| Replay reconstructs or fails closed | Gap, request, digest, schema, and checkpoint corruption. |
+| Stale graph/schema/draft rejects | Generated revision properties. |
+| Schema change is semantic and immutable | Equality and descriptor mismatch properties. |
+| Transport canonicalization agrees | Typed canonical-content tests; raw decoder equivalence deferred. |
+| Agent lacks host/DOM authority | Deferred to decoder/adapter conformance. |
+| Host isolation is structural | Deferred to host/renderer integration. |
 
-The plan is complete when every non-deferred row has passing evidence. Deferred
-rows remain explicit blockers on the corresponding future safety claim.
+Every non-deferred row must pass. Deferred rows block only their corresponding
+future safety claim.
 
-## Existing API first — reuse check
+## Reuse check
 
-Project APIs and patterns reused:
+Project precedents reused:
 
-- `GenerativeUiLifecycle::dispatch` supplies the existing event/transition and
-  terminal-state precedent. The new core reuses the reducer shape, not the type
-  or module dependency.
-- `GenerativeUiReplaySource` supplies the fixed replay-log/cursor testing
-  precedent. Recovery state remains owned by the new core.
+- `GenerativeUiLifecycle::dispatch` for reducer shape, not as a dependency;
+- `GenerativeUiReplaySource` for replay-log/cursor structure;
 - `@qc.quick_check_fn`, `@quickcheck.Arbitrary`, `@qc.Shrink`, and SplitMix
-  random-state splitting follow the patterns in
-  `core/reconcile_properties_wbtest.mbt` and
-  `ffi/jsx/render_baseline_wbtest.mbt`.
-- `@canvas_graph` operation replay is checked as an existing deterministic-log
-  precedent but is not reused because its workflow graph and action history
-  have different invariants.
-- `lib/semantic/proof` is reused as the standalone proof-package and CI pattern,
-  not as a dependency.
-
-MoonBit/core candidates to check before new definitions:
-
-- `Map` and `Set` for graph lookup, request records, uniqueness, and pending
-  effects; use owning collections privately and do not expose mutable values.
-- `Array` and `Iter` for ordered children, ordered batches, trace folds, and
-  local result construction.
-- `Option` and `Result` for lookup and validation outcomes.
-- `String`/`StringView` and `Bytes`/`BytesView` for exact draft observations and
-  canonical request input; avoid copies where a view suffices.
-- `Buffer`/`StringBuilder` for canonical encoding only if the actual core API is
-  preferable to structural canonical content comparison.
-- `cmp`/math helpers for revision and bound comparison instead of new numeric
-  helpers.
-- Core JSON APIs only at a future decoder boundary; the semantic core consumes
-  validated typed values.
+  patterns from existing property tests;
+- the standalone proof-module pattern from `lib/semantic/proof`.
 
 Checked but not reused:
 
-- `GenerativeUiCandidate::validate` is table/filter-specific. Reuse its
-  fail-closed principle, not its candidate types or validator.
-- `ProjNode`, `SourceMap`, JSX AST, DOM patches, `incr`, and
-  `event-graph-walker` are excluded from this private single-writer core.
-- `Map`, `Set`, `Array`, recursive graph functions, canonical encoders, and
-  state-machine traces are excluded from `moon prove` under current prover
-  limitations.
+- `@canvas_graph` replay: workflow graph and action-history invariants differ;
+- `@egwalker`: owns future causal history, not this private single-writer log;
+- JSX renderer baseline types: adapter-private and would reverse dependencies;
+- SDEG identity: useful precedent, but its projection mapping has a different
+  lifetime and authority boundary.
 
-New definitions are justified only for the semantic graph, operation algebra,
-request/identity vocabulary, reducer decisions, replay model, and observation
-oracle described above. Each new helper must stay within one of those
-responsibility boundaries.
+MoonBit/core candidates to inspect before definitions:
 
-## Steps
+- `Map`/`Set` for graph, ledger, uniqueness, and pending effects;
+- `Array`/`Iter` for ordered children, batches, folds, and trace generation;
+- `String`/`StringView` and `Bytes`/`BytesView` for bounded canonical inputs;
+- `Buffer`/`StringBuilder` for canonical encoding only if existing encoders do
+  not fit;
+- `Option`/`Result` for lookups and pure validation;
+- `cmp`/math helpers for revision and bounds checks;
+- QuickCheck `Arbitrary`, `Shrink`, combinators, and SplitMix.
 
-### Phase 0 — Package boundary and first red transcript
+Do not introduce a helper until `moon ide doc`, `outline`, `peek-def`, and
+`find-references` establish that these APIs do not cover its responsibility.
 
-1. Add `lib/generative-ui-document` to `moon.work`; create its `moon.mod` with
-   a pinned `moonbitlang/quickcheck` test dependency and its `moon.pkg` with
-   JS/native support plus core QuickCheck/SplitMix/`@qc` imports restricted to
-   white-box tests.
-2. Run `moon ide doc`/`outline` checks listed under Validation and record any
-   better existing API in the Reuse check before defining helpers.
-3. Add the observation vocabulary, fake-shell protocol, and full fixed
-   transcript as a failing white-box test. The initial failure must be missing
-   core behavior, not a parser, renderer, or persistence dependency.
+## Implementation phases
 
-### Phase 1 — Semantic graph and forward batch
+Each phase is a separate PR. It begins with failing evidence and ends with
+package checks/tests; no PR starts the next adapter layer.
 
-4. Implement private typed values, graph state, semantic equality, revision
-   wrappers, immutable schema descriptor identity/digest, request-local handles,
-   and deterministic ordinal-based IDs.
-5. Implement structural precondition validation and ordered application for
-   `InsertNode`, `MoveNode`, `SetProperty`, `RemoveProperty`, and subtree
-   `RemoveNode` on a private working graph.
-6. Commit the working graph only after final graph/schema validation. Add the
-   batch-rejection fixture, no-op behavior, `RemoveProperty`/`null` distinction,
-   graph invariant tests, and inverse derivation tests.
+### Phase 0 — Boundary and red gate
 
-### Phase 2 — Request and persistence protocol
+- Add the module to `moon.work`, with pinned `moonbitlang/quickcheck`, JS/native
+  support, and `core/quickcheck`, SplitMix, and `@qc` imports restricted to
+  white-box tests.
+- Record the Existing API First results.
+- Add observation types, fake-shell protocol, and the complete failing fixed
+  transcript. Its first failure must demonstrate missing core behavior while
+  the package remains free of adapter dependencies.
 
-7. Implement canonical typed request content, collision-aware request lookup,
-   and terminal outcomes. Store canonical content as the equality authority;
-   use a digest only as an index/check. Provide a white-box-only digest injection
-   seam so tests can force equal digests for different canonical requests.
-8. Implement reducer decisions for persistence intent, persistence success or
-   failure, response emission, and effect release. The reducer must not emit a
-   response or effect-delivery command before persisted acknowledgment.
-9. Add a fake atomic store that can fail before commit, commit then lose the
-   response, restart with committed records, and reject mismatched request
-   content under the same ID. Force one equal-digest/different-content case and
-   assert that the stored request record, graph, history, and outbox remain
-   unchanged. Persist, restart, and retry separate `NoSemanticChange` and
-   `Rejected` records without creating applied history or effects.
+### Phase 1 — Graph and operations
 
-### Phase 3 — Draft and outbox transitions
+- Add private values, graph, revisions, schema descriptor identity/digest,
+  request-local handles, and deterministic IDs.
+- Apply all five operations to a private working graph, checking each
+  primitive's structural preconditions as it runs and final graph/schema
+  invariants at the batch boundary.
+- Cover atomic rejection, no-op, property deletion versus `null`, graph
+  invariants, limits, and inverse derivation.
 
-10. Implement draft revision/validity/sync transitions and source-rewrite
-    compare-and-swap decisions without a real parser or writer.
-11. Implement renderer/source effect classification using base/target graph
-    revisions, consumer baselines, dirty state, stale acknowledgment, and
-    latest-snapshot rebuild decisions. Dirty repair must be evaluated before
-    stale-target acknowledgment.
-12. Add fake source and renderer consumers that can fail, duplicate, reorder,
-    and acknowledge effects. Make the full fixed transcript pass through the
-    persistence and restart boundary.
+### Phase 2 — Requests and persistence
 
-### Phase 4 — Generated traces and shrinking
+- Add typed canonical content, collision-aware lookup, and terminal outcomes.
+- Model persistence intent, success/failure, response release, and effect
+  release as reducer events.
+- Add fake-store failures before commit, response loss after commit, restart,
+  request-ID misuse, forced digest collision, and no-op/rejected recovery.
 
-13. Add separate bounded generators for valid graphs, valid batches, invalid
-    batches, request retries/collisions, draft events, and effect-delivery
-    permutations. Do not rely on filtering mostly invalid random data.
-14. Add shrinkers that shorten event/batch sequences, remove leaf subtrees,
-    simplify properties, and replace identity-relative placements with simpler
-    valid placements while preserving the failing precondition when required.
-15. Compare every generated trace with the reference model observation. Add
-    bounded exhaustive traces for the smallest graphs/events before relying on
-    randomized larger traces. Include a two-commit trace that delivers target
-    revision 2 to renderer baseline 0, then verifies latest-snapshot rebuild and
-    stale target-1 suppression.
+### Phase 3 — Draft and outbox
+
+- Add draft validity/revision and source rewrite CAS without a real parser.
+- Classify renderer/source effects with dirty precedence, stale acknowledgment,
+  expected baseline, and latest-snapshot rebuild.
+- Make the fixed transcript pass through restart with duplicate, reordered, and
+  failed delivery.
+
+### Phase 4 — Generated traces
+
+- Build separate bounded generators for valid/invalid graphs and batches,
+  request retries/collisions, draft events, and effect permutations.
+- Shrink sequences, leaf subtrees, properties, and placements while preserving
+  the failure precondition.
+- Compare all traces to the reference model. Include small exhaustive traces
+  and the revision-2-to-baseline-0 gap case.
 
 ### Phase 5 — Replay and corruption
 
-16. Implement checkpoint plus contiguous applied-history replay. Validate base
-    graph/schema revisions and canonical request content at each step.
-17. Inject history gaps, mismatched request content/digests, unavailable schema,
-    stale outbox acknowledgments, schema descriptor identity/digest mismatches,
-    and crash boundaries. Recovery must reproduce
-    the live observation or enter explicit diagnostic read-only state.
-18. Complete the non-deferred rows in the evidence matrix and keep deferred
-    adapter/security rows visibly unclaimed.
+- Replay checkpoint plus contiguous applied history.
+- Inject history gaps, request/digest mismatches, schema identity/digest changes,
+  stale acknowledgments, and crash boundaries.
+- Match the live observation or enter explicit diagnostic read-only state.
 
-### Phase 6 — Optional scalar formal-proof spike
+### Phase 6 — Optional scalar proof
 
-19. Create `lib/generative-ui-document-proof` as a standalone module outside
-    `moon.work`. First prove that one small Int/Bool/enum mirror with an explicit
-    `proof_ensure` compiles and terminates.
-20. If the spike succeeds, prove only scalar decision laws such as revision
-    delta by terminal outcome, effect classification preconditions, and
-    non-regressing next-baseline projection. Keep tree equality, batch
-    atomicity, inverse correctness, hashing, canonical encoding, and traces in
-    unit/property tests.
-21. If the spike fails because of documented prover limitations, record the
-    reason in this plan, omit unsupported claims, and keep the executable test
-    evidence. Formal-proof failure does not weaken or block already passing
-    core properties.
-22. If the proof module lands, update `.github/workflows/ci.yml` path filters and
-    the Formal Verification job to run both standalone proof modules explicitly.
+- Create `lib/generative-ui-document-proof` outside `moon.work` only after one
+  explicit `proof_ensure` compilation spike succeeds.
+- Limit proofs to scalar terminal-outcome or effect-classification decisions.
+  Keep trees, maps, arrays, canonical encoding, inverse laws, and stateful traces
+  in executable tests.
+- If it lands, add CI path detection and run every standalone proof module. If
+  it fails, record why and retain executable evidence without weaker claims.
 
-### Phase 7 — Gate decision and cleanup
+### Phase 7 — Gate decision
 
-23. Run all validation commands on both JS and native, inspect the new package
-    `.mbti` for accidental exports, and verify no forbidden dependency appears
-    in the new module. Add an explicit CI step for both package targets.
-24. Record the fixed transcript result and the evidence-matrix status. Do not
-    claim adapter, host-trust, or product-value safety from this core gate. Do
-    not begin PKE semantic/generated behavior until its fixed baseline is
-    independently accepted.
-25. If the gate passes, open a separate JSX conformance plan. If it fails,
-    revise or reject the document-engine direction before adapter work.
-26. On completion, move this plan to `docs/archive/completed-phases/` and mark
-    the linked TODO item done in the same change.
+- Run JS/native validation, inspect `.mbti` and dependency edges, and add CI
+  steps that check and test `lib/generative-ui-document` explicitly on both
+  targets.
+- Record the transcript and evidence-matrix result without claiming adapter,
+  host-trust, or product safety.
+- On pass, create a separate JSX conformance plan. On failure, revise or reject
+  the engine before adapter work.
+- Archive this plan and close its TODO only when all non-deferred rows pass.
 
-## PR split
+## Acceptance gate
 
-1. **Core boundary and red gate:** Phase 0 only.
-2. **Graph and operation algebra:** Phase 1.
-3. **Request/persistence protocol:** Phase 2.
-4. **Draft/outbox and fixed transcript:** Phase 3.
-5. **Property/reference-model traces:** Phase 4.
-6. **Replay/fault recovery:** Phase 5.
-7. **Optional formal proof and CI:** Phase 6, only after the spike succeeds.
-8. **Gate report and archival:** Phase 7.
-
-Each PR starts with failing evidence for its phase and ends with affected-package
-`moon check`/`moon test`; no PR may introduce the next adapter layer early.
-
-## Acceptance criteria
-
-- [ ] `lib/generative-ui-document` is a `moon.work` member with no Canopy,
-      cognition, `incr`, JSX, DOM, provider, agent, or `event-graph-walker`
-      dependency.
-- [ ] The full invalid-draft/duplicate-request/rewrite-conflict/renderer-
-      failure/out-of-order/restart transcript passes against both reference and
-      production observations.
-- [ ] Applied persistence happens once; retry after response loss returns the
-      recorded result without another graph revision or history entry.
-- [ ] Failed batches expose no prefix; semantic no-ops do not advance revision;
-      explicit property removal remains distinct from `null`.
-- [ ] Draft bytes survive stale or invalid rewrite attempts exactly.
-- [ ] Renderer/source baselines never regress: the fixed transcript covers
-      dirty-plus-stale precedence, duplicate and failure delivery, and generated
-      two-commit traces cover revision gaps and latest-snapshot rebuild.
-- [ ] Persisted `NoSemanticChange` and `Rejected` records survive restart and
-      retry without adding graph revisions, applied history, or outbox entries.
-- [ ] Replay either reconstructs the exact live observation or fails closed on
-      corruption, schema absence, or changed schema descriptor content.
-- [ ] Deterministic IDs repeat for the same document/request/ordinal, differ for
-      distinct logical tuples, survive replay, and cannot be supplied by the
-      generated proposal body.
-- [ ] An equal-digest/different-canonical-content request collision is rejected
-      without changing the stored record, graph, history, or outbox; raw
-      transport equivalence remains deferred to decoder conformance.
-- [ ] Every non-deferred evidence-matrix row maps to at least one passing test;
-      deferred rows remain explicitly unclaimed.
-- [ ] Generated traces have useful shrinking and report a minimized event trace
-      on failure.
-- [ ] `moon info` shows no accidental public API or trait-bound widening in the
-      new core package.
-- [ ] If formal proofs land, every claim is attached to a compiling
-      `proof_ensure`, the standalone module has no project dependency, and CI
-      runs it. No proof is claimed for unsupported collection/stateful laws.
-- [ ] No source, JSX, DOM, JavaScript, persistence backend, collaboration, or
-      second-renderer implementation is added by this plan.
+- The private module has no forbidden dependency or accidental public API.
+- Fixed and generated traces match the reference model on JS and native.
+- Applied, no-op, rejected, response-loss, and collision outcomes satisfy their
+  persistence and retry contracts.
+- Syntax-only lowering synchronizes the draft without a request, graph revision,
+  history, or outbox work.
+- Draft bytes and semantic meaning survive all tested conflict/failure paths.
+- Renderer/source baselines never regress, including dirty-plus-stale and gaps.
+- Replay reconstructs exactly or fails closed on every injected corruption.
+- Generated failures shrink to reproducible minimal traces.
+- Optional proofs claim only compiled scalar properties and run in CI.
+- No source, renderer, JavaScript, storage backend, collaboration, or product
+  integration enters this validation slice.
 
 ## Validation
 
-Before adding definitions:
+Before definitions:
 
 ```bash
 NEW_MOON_MOD=0 moon ide outline lib/cognition
@@ -502,77 +329,26 @@ git diff -- '*.mbti'
 git diff --check
 ```
 
-If the proof spike lands:
+Open every new or changed `pkg.generated.mbti`; `git diff` omits untracked
+files. If the proof spike lands, run `moon check`, `moon prove`, `moon fmt`, and
+`moon info` from its standalone module.
 
-```bash
-cd lib/generative-ui-document-proof
-moon check
-moon prove
-moon fmt
-moon info
-```
+No local browser or TypeScript command is required unless those boundaries
+change. Editing `.github/workflows/ci.yml` still triggers the full selected CI
+fan-out, so the PR must wait for those proof/browser jobs.
 
-Also inspect `moon.work` and `.github/workflows/ci.yml`, and open every new or
-changed `pkg.generated.mbti`; `git diff` alone does not display an untracked
-interface file. Verify that the core interface is empty apart from unavoidable
-module metadata and that the optional proof interface exposes nothing
-unexpected.
+## Risks and deferred evidence
 
-No TypeScript, browser, JS artifact, proof-submodule, or vendored-submodule
-command is required locally unless the corresponding out-of-scope boundary
-changes. Once this plan edits `.github/workflows/ci.yml`, however, the pull
-request must wait for the full workflow-triggered CI fan-out, including proof
-and browser jobs selected by that workflow path.
-
-## Risks
-
-- The fake store proves protocol ordering and recovery decisions, not the
-  atomicity guarantees of a future production storage technology. Each real
-  store will need its own boundary tests.
-- A production-looking graph API may invite premature export. Keep all core
-  declarations private until a later adapter/public-contract decision.
-- Random graph generation can hide behind rejection-heavy samples. Separate
-  valid and invalid generators and report their coverage.
-- Shrinking a stateful failure can destroy the precondition that triggered it.
-  Shrink traces and graph fixtures together and re-check the intended failure
-  class.
-- Canonical digests are not injective. Persist canonical content and treat a
-  digest as an index/check, not as semantic identity.
-- The full fixed transcript verifies only the private architecture hypothesis.
-  It cannot authorize PKE semantic candidates before the fixed deterministic
-  baseline, and product value still requires a later real use case and decision
-  gate.
-- The optional proof mirror can drift from production behavior. Keep proof
-  targets scalar, name the corresponding production decision, and retain the
-  production property test as the integration oracle.
-- The 21-obligation list may evolve. Update the evidence matrix by obligation
-  meaning whenever it changes; the fixed count is only a diagnostic.
-- Raw JSON whitespace, key-order, and encoding equivalence cannot be proved by a
-  typed core that has no decoder. The core verifies canonical typed content;
-  the eventual decoder/adapter gate owns transport equivalence.
-
-## Open questions
-
-- Which private persistent collection representation gives the clearest graph
-  equality and replay implementation without exposing mutation? Resolve during
-  Phase 1 after the required MoonBit API checks; do not optimize before the
-  reference properties pass.
-- Should bounded exhaustive trace enumeration be a handwritten small alphabet
-  or generated from the same event grammar as QuickCheck? Choose the simpler
-  implementation that reports reproducible traces.
-- Which scalar transition rule, if any, gives enough value to justify the
-  standalone proof module and CI cost? Phase 6 begins with a compilation spike
-  precisely to answer this.
-
-## Notes
-
-- `event-graph-walker` remains the sole owner of future causal history, CRDT
-  tree semantics, sync, and collaborative undo. This private single-writer log
-  must not evolve into a competing causal oplog.
-- Real JSX conformance belongs to a follow-up plan under `ffi/jsx`, where the
-  adapter-private baseline and outcomes are visible without reversing
-  dependencies.
-- The design document's gate is satisfied only for the non-deferred core rows.
-  It must not be read as proof of adapter isolation, hostile JavaScript safety,
-  collaboration, product usefulness, or readiness to bypass the PKE baseline
-  and existing Generative UI V1 sequence.
+- The fake store validates protocol decisions, not a production store's
+  atomicity; each real adapter needs boundary tests.
+- Canonical digests are not injective; canonical content must remain the
+  equality authority.
+- Typed-core tests cannot prove raw JSON encoding equivalence; the eventual
+  decoder owns that conformance gate.
+- Random generators and shrinkers can hide or destroy preconditions; use
+  separate valid/invalid generators, small exhaustive traces, and re-check the
+  intended failure class.
+- A proof mirror can drift; pair every scalar proof with a production property
+  test.
+- This gate proves no adapter isolation, hostile JavaScript safety,
+  collaboration, accessibility, or product usefulness.


### PR DESCRIPTION
## Summary

- Define committed `UiGraph` state as the semantic authority for a future `GenerativeUiDocument`, while text, projections, and agents remain proposal sources.
- Specify atomic operation batches, deterministic request-scoped identity, canonical-content idempotency, draft/rewrite conflicts, renderer recovery, immutable schema identity, and fail-closed replay.
- Add a bounded semantic-core validation plan with a reference model, fault-injected fixed transcript, generated traces, and explicit stop conditions before adapter or product integration.
- Keep the experiment subordinate to the existing Generative UI V1 sequence and the personal-knowledge fixed-baseline gate.
- Distill the two main documents from 8,989 to 5,639 words while preserving reviewed contracts, varying the reasoning flow around real failure states, and keeping every line at 120 characters or fewer.

## Reuse check

Pure documentation change; no functions, methods, helpers, or types were added.

The implementation plan records the required Existing API First checks for current Canopy lifecycle/replay/property-test/proof precedents and MoonBit `Map`, `Set`, `Array`, `Iter`, `String`, `Bytes`, `Buffer`, `Option`, `Result`, `cmp`, and QuickCheck APIs.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes — 0 errors, 124 existing warnings
- [x] `NEW_MOON_MOD=0 moon test` passes — 1,921 JS and 70 native tests
- [x] `NEW_MOON_MOD=0 moon fmt` and `NEW_MOON_MOD=0 moon info` run
- [x] `.mbti` changes and untracked interfaces reviewed — none
- [x] `git diff --check` passes
- [x] New-document Markdown links and fenced-code languages checked
- [x] Slopless reports no non-readability findings in the new design/plan or updated Generative UI direction
- [x] Independent MoonBit/package and semantic-contract re-reviews report no remaining findings
- [x] JS rebuild not required; no web files changed

## Validation

```bash
NEW_MOON_MOD=0 moon fmt
NEW_MOON_MOD=0 moon info
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
git status --short -- '*.mbti'
git diff -- '*.mbti'
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for an incremental Generative UI document engine, covering semantic commits, identity, recovery, delivery, rendering, and trust boundaries.
  * Added a validation plan for deterministic semantic-core behavior, including conflict handling, retries, persistence, recovery, and renderer repair.
  * Linked the new design document from the deep-design documentation.
  * Clarified that the semantic-core experiment does not authorize product integration or establish a public contract.
* **Planning**
  * Added testing backlog items and evidence requirements for validating the semantic core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->