### PR TITLE
docs: record external coding-agent boundary

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -49,6 +49,8 @@ the files inside `docs/architecture/`.
 - **[Human-centered product principles](human-centered-product-principles.md)**
   — canonical behavior invariants for authority, negotiable structure,
   orientation, accessible equivalence, and product gates.
+- **[Coding Agent Direction](coding-agent-direction.md)** — deferred boundary
+  for external agent engines, revision-bound proposals, and host-owned effects.
 - **[The Projectional Bridge](vision-projectional-bridge.md)** — bridging
   syntax → semantics → intent → mental model.
 - **[Structure-Format Research](structure-format-research.md)** — PL research

--- a/docs/architecture/coding-agent-direction.md
+++ b/docs/architecture/coding-agent-direction.md
@@ -1,0 +1,231 @@
+# Coding Agent Direction
+
+**Status:** deferred target architecture. This document defines a safe
+integration boundary; it is not a near-term implementation commitment. Canopy's
+current priority remains the [Personal Knowledge Environment](personal-knowledge-environment-direction.md).
+
+The source-backed investigation behind this direction is recorded in
+[OpenSeek–Canopy integration research](../research/2026-07-16-openseek-canopy-integration.md).
+
+## Decision
+
+Canopy should reuse an external coding-agent engine rather than implement its
+own agent loop. The engine may own model interaction, conversation state, tool
+orchestration, and retries. Canopy must retain authority over projections,
+validation, user approval, live document state, and collaborative commit.
+
+The integration is worthwhile only when it serves a demonstrated product need.
+Until then, this document preserves the boundary future work must respect.
+
+## Boundary
+
+```text
+external agent engine
+  → structured requests and proposals
+  → replaceable adapter
+  → Canopy semantic and projection APIs
+  → validation and speculative preview
+  → host-issued approval where authority changes
+  → revision-checked collaborative commit
+```
+
+The adapter translates transport and protocol data. It must not become a second
+owner of document semantics or workspace state.
+
+## Responsibility split
+
+### External agent engine
+
+The engine owns:
+
+- model and provider interaction;
+- prompt and conversation state;
+- generic tool-call orchestration;
+- retry and model-call recovery policy;
+- its session persistence;
+- transport and credentials.
+
+The engine does not own Canopy document revisions, projection identity,
+semantic validation, approval, or collaborative-operation provenance.
+
+### Canopy
+
+Canopy owns:
+
+- authoritative live documents and their revisions;
+- incremental parsing, projections, and semantic context;
+- proposal validation and speculative preview;
+- user-facing approval decisions;
+- CRDT commit and peer convergence;
+- capability policy for effects that reach Canopy state;
+- proposal, approval, and commit provenance.
+
+Canopy does not own the coding-agent engine's model loop, concrete provider
+client, conversation manager, or coding-tool retry system. Canopy's existing
+provider-neutral request and result boundaries remain available to its own
+cognition features.
+
+### Adapter
+
+The adapter owns:
+
+- translation between an agent protocol and Canopy domain operations;
+- correlation between external requests and Canopy revisions;
+- process, stream, cancellation, and lifecycle handling;
+- conversion of agent tool requests into context queries or proposals.
+
+The adapter is replaceable. Canopy domain APIs must not depend on one engine's
+wire format.
+
+## Authority invariants
+
+### No direct live writes
+
+An agent cannot write directly to a Canopy-authoritative document, committed
+workspace state, or DOM. Document changes enter as proposals and are applied
+only by Canopy's commit boundary.
+
+An isolated workspace may allow shell, build, test, or file effects under an
+explicit host policy. Authority in an isolated workspace does not grant
+permission to mutate a live Canopy document.
+
+### Host-owned capabilities
+
+The host chooses which tools and effects are available before a prompt is sent.
+The agent cannot add to its own authority. If the host cannot verify the active
+tool set, the integration fails closed.
+
+Extra or third-party tools remain part of the host's policy; disabling
+OpenSeek's built-ins alone cannot establish a general sandbox guarantee.
+
+### Revision-bound proposals
+
+A proposal identifies the exact document revision it was prepared from.
+Validation and preview do not mutate the live document. Commit checks the
+revision again so a concurrent edit cannot silently change the meaning of an
+approved proposal.
+
+### Host-issued approval
+
+Approval belongs to the host and binds one exact proposal, base revision, and
+preview. The agent cannot mint approval. Changing proposal content or its base
+revision creates a new proposal and repeats validation and preview.
+
+Read-only context requests and effect-free generated views do not require a
+user approval step merely because an agent produced them. They still pass their
+existing validation and capability boundaries.
+
+### Idempotent effects
+
+Any path that supports cancellation, retry, reconnect, or replay must identify
+effect-bearing work strongly enough to prevent duplicate commit. Late or
+cancelled results cannot acquire authority after their request has closed.
+
+A narrow, ordered, single-process read-only bridge need not introduce a general
+distributed-event protocol before it has an effect to deduplicate. Broader
+correlation requirements should be justified by the transport and effects an
+implementation actually supports.
+
+## Functional core and imperative shell
+
+Proposal validation, revision checks, capability decisions, and lifecycle
+transitions belong in a deterministic functional core. The core receives
+explicit inputs and returns decisions without transport or document mutation.
+
+The imperative shell owns process I/O, scheduling, cancellation, provider and
+protocol adapters, scratch editors, and the final live commit. Tests should pin
+the functional core with deterministic inputs and keep shell tests focused on
+effect wiring.
+
+## Projection-aware proposals
+
+Agents should request language-owned operations, not reproduce Canopy's
+projection internals. For example, an agent may ask to rename a selected
+binding. Canopy resolves scope, computes the text changes, previews the
+projected result, and decides whether the proposal is valid.
+
+The conceptual mutation flow is:
+
+1. capture the authoritative base revision;
+2. validate the structured proposal against Canopy semantics;
+3. compute and preview the result without mutating the live document;
+4. present the exact proposal and preview for host approval;
+5. recheck the base revision and proposal identity;
+6. commit through the CRDT editor and record provenance.
+
+Rendering patches are outputs of the projection pipeline, never agent-authored
+mutation inputs.
+
+## Generative UI
+
+The existing capability validation, dry-run, and session commit path remains
+available to effect-free candidates; see the
+[Generative UI direction](generative-ui-direction.md). A generated action that
+changes a document or performs another host effect requires the same host-owned
+authority boundary as other agent proposals.
+
+Generated output cannot add event handlers, network access, persistence, or
+direct DOM authority merely by requesting it.
+
+## Session and audit separation
+
+The external engine owns conversation history, model responses, tool calls, and
+its own compaction or replay. Canopy owns the record of proposal identity, base
+revision, approval, commit, and collaborative provenance.
+
+The records answer different questions:
+
+- the agent session explains what was requested and generated;
+- the Canopy record explains what was authorized and changed authoritative
+  state.
+
+They may be correlated without sharing ownership. Loss or compaction of the
+agent session cannot erase Canopy's commit provenance.
+
+## Activation gates
+
+Implementation should begin only when all of the following hold:
+
+1. A named product experiment shows why an external coding agent is better than
+   a simpler fixed workflow.
+2. The selected engine can run without built-in paths that write around
+   Canopy's document boundary.
+3. The host can inspect the tools available to the model before sending a
+   prompt.
+4. An executable plan defines proposal identity, revision checks, approval,
+   cancellation, idempotency, and CRDT convergence for one narrow slice.
+5. The first slice uses one active editor and one language-owned operation; it
+   does not introduce multi-document identity prematurely.
+
+These gates protect the current Personal Knowledge Environment priority from an
+unbounded agent-framework project while preserving a route to a later
+integration.
+
+## Deferred work
+
+- stable multi-document identity and a document registry;
+- cross-session proposal identity;
+- concurrent semantic merge of agent proposals;
+- effectful Generative UI actions;
+- cryptographic approval evidence;
+- general reconnect and replay semantics beyond a concrete transport need;
+- a second provider abstraction for the external coding-agent engine.
+
+## Non-goals
+
+- reimplementing an agent loop in Canopy;
+- making Canopy a general-purpose agent framework;
+- allowing agents to bypass validation, approval, or collaborative commit;
+- treating model output as authoritative state;
+- coupling Canopy's domain API to OpenSeek or another agent protocol;
+- changing the near-term product priority through this document alone.
+
+## Related documentation
+
+- [Personal Knowledge Environment Direction](personal-knowledge-environment-direction.md)
+- [Human-centered product principles](human-centered-product-principles.md)
+- [Generative UI Direction](generative-ui-direction.md)
+- [Cognition Runtime](cognition-runtime.md)
+- [OpenSeek–Canopy integration research](../research/2026-07-16-openseek-canopy-integration.md)
+- [Codex App-Server Lowering](../research/2026-06-13-canopy-codex-app-server-lowering.md)
+- [Responsibility Map](responsibility-map.md)

--- a/docs/architecture/coding-agent-direction.md
+++ b/docs/architecture/coding-agent-direction.md
@@ -7,15 +7,22 @@ Canopy's near-term priority remains the
 See [OpenSeek–Canopy integration research](../research/2026-07-16-openseek-canopy-integration.md)
 for the source-backed investigation.
 
-## Decision
+## The boundary to preserve
 
-Canopy should reuse an external coding-agent engine instead of implementing its
-own agent loop. The engine may run models and tools, but Canopy must retain
-authority over projections, validation, approval, live documents, and
-collaborative commit.
+A coding-agent engine already knows how to call models, run tools, keep a
+conversation, and recover from model failures. Rebuilding those capabilities in
+Canopy would create a second agent framework without improving the part Canopy
+is designed to own.
 
-Implementation should begin only when a product experiment shows that an agent
-works better than a simpler fixed workflow.
+Reusing an engine looks simple until the first edit. Its normal shell and file
+tools can change the same source that Canopy parses, projects, and shares with
+peers. If those tools write directly, Canopy may display a change it never
+validated, approved, or recorded as a collaborative operation.
+
+The safe boundary is therefore narrower: the engine may decide what to request,
+but Canopy decides what a request means and whether it changes authoritative
+state. This direction should be implemented only when a product experiment
+shows that an agent works better than a simpler fixed workflow.
 
 ## Ownership
 
@@ -43,18 +50,20 @@ document.
 
 ### The host chooses capabilities
 
-The host chooses which tools are available before sending a prompt. The agent
-cannot expand that set. If the host cannot verify the active tools, the
-integration stops.
+Removing direct editor writes is not enough if another enabled tool can reach
+the same files. The host therefore chooses which tools are available before
+sending a prompt, and the agent cannot expand that set. If the host cannot
+verify the active tools, the integration stops.
 
 Third-party tools remain the host's responsibility. Disabling an engine's
 built-ins is not a general sandbox guarantee.
 
-### Proposals bind revision and approval
+### Preview does not authorize a later document
 
 A proposal identifies the document revision it was prepared from. Validation
-and preview do not mutate the live document. Commit checks the revision again
-so concurrent edits cannot change an approved proposal's meaning.
+and preview do not mutate the live document. Even after approval, commit checks
+the revision again; otherwise a concurrent edit could change the meaning of the
+proposal between preview and application.
 
 Approval is issued by the host and binds one proposal, base revision, and
 preview. Any content or revision change creates a new proposal and repeats
@@ -63,14 +72,15 @@ validation.
 Read-only queries and effect-free generated views do not need user approval,
 but they still pass their existing validation and capability checks.
 
-### Effects are idempotent
+### One authorized effect happens once
 
-Any path with cancellation, retry, reconnect, or replay must prevent duplicate
-commit. Late and cancelled results cannot gain authority after their request
-closes.
+A correct commit can still become incorrect when cancellation, retry, reconnect,
+or replay delivers the same result twice. Any effect-bearing path must prevent a
+duplicate commit. Late and cancelled results cannot gain authority after their
+request closes.
 
-A single-process read-only bridge does not need a general replay protocol before
-it has effects to deduplicate. Correlation requirements should match the
+A single-process read-only bridge has no effect to deduplicate and does not need
+a general replay protocol. Correlation requirements should grow with the
 transport and effects actually supported.
 
 ## Integration boundary
@@ -85,8 +95,9 @@ external engine
 ```
 
 Agents should request language-owned operations instead of reproducing Canopy's
-projection internals. For a rename, Canopy resolves scope, computes the text
-changes, previews the projection, and decides whether the proposal is valid.
+projection internals. For a rename, the agent can name the desired operation
+while Canopy resolves scope, computes the text changes, and previews the
+resulting projection.
 
 The mutation flow is:
 
@@ -105,14 +116,17 @@ decisions, and lifecycle transitions. It receives explicit inputs and returns
 decisions without I/O or document mutation.
 
 A thin shell owns process I/O, scheduling, cancellation, scratch editors, and
-the final live commit.
+the final live commit. This keeps proposal decisions testable without turning a
+transport mock into the source of truth.
 
 ## Generated UI and audit
 
+Not every agent result carries the same authority.
+
 Effect-free candidates may keep using the validation, dry-run, and commit path
-in the [Generative UI direction](generative-ui-direction.md). Generated actions
-that change documents or perform host effects use the same host-owned authority
-boundary as other proposals.
+in the [Generative UI direction](generative-ui-direction.md). A generated
+action that changes a document or performs a host effect crosses the proposal
+boundary above.
 
 The external engine owns conversation history and tool-call records. Canopy
 owns proposal identity, base revision, approval, commit, and collaborative

--- a/docs/architecture/coding-agent-direction.md
+++ b/docs/architecture/coding-agent-direction.md
@@ -137,9 +137,9 @@ session cannot erase Canopy's commit record.
 
 Implementation requires all of the following:
 
-1. A product experiment justifies an agent over a fixed workflow.
-2. Any experiment using PKE or session data passes the PKE fixed-baseline and
-   data-egress gates first.
+1. A read-only agent condition beats the fixed workflow on a named user task.
+2. Any use of PKE or session data passes the fixed-baseline and data-egress
+   gates.
 3. The engine can run without built-in write paths around Canopy.
 4. The host can inspect available tools before sending a prompt.
 5. An executable plan covers identity, revision checks, approval, cancellation,

--- a/docs/architecture/coding-agent-direction.md
+++ b/docs/architecture/coding-agent-direction.md
@@ -1,224 +1,155 @@
 # Coding Agent Direction
 
-**Status:** deferred target architecture. This document defines a safe
-integration boundary; it is not a near-term implementation commitment. Canopy's
-current priority remains the [Personal Knowledge Environment](personal-knowledge-environment-direction.md).
+**Status:** deferred target architecture that defines a safety boundary while
+Canopy's near-term priority remains the
+[Personal Knowledge Environment](personal-knowledge-environment-direction.md).
 
-The source-backed investigation behind this direction is recorded in
-[OpenSeek–Canopy integration research](../research/2026-07-16-openseek-canopy-integration.md).
+See [OpenSeek–Canopy integration research](../research/2026-07-16-openseek-canopy-integration.md)
+for the source-backed investigation.
 
 ## Decision
 
-Canopy should reuse an external coding-agent engine rather than implement its
-own agent loop. The engine may own model interaction, conversation state, tool
-orchestration, and retries. Canopy must retain authority over projections,
-validation, user approval, live document state, and collaborative commit.
+Canopy should reuse an external coding-agent engine instead of implementing its
+own agent loop. The engine may run models and tools, but Canopy must retain
+authority over projections, validation, approval, live documents, and
+collaborative commit.
 
-The integration is worthwhile only when it serves a demonstrated product need.
-Until then, this document preserves the boundary future work must respect.
+Implementation should begin only when a product experiment shows that an agent
+works better than a simpler fixed workflow.
 
-## Boundary
+## Ownership
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| External engine | Models, prompts, conversation state, generic tool orchestration, retries, credentials, and its session | Canopy revisions, semantics, approval, or commit provenance |
+| Canopy | Live documents, revisions, projections, semantic context, validation, approval, CRDT commit, and proposal provenance | The coding-agent loop, concrete provider client, conversation manager, or generic tool retries |
+| Adapter | Protocol translation, request correlation, process I/O, cancellation, and conversion to Canopy queries or proposals | Document semantics or authoritative state |
+
+The adapter is replaceable. Canopy's domain APIs must not depend on one engine's
+wire format. Existing provider-neutral request and result boundaries remain
+available to Canopy's own cognition features.
+
+## Authority rules
+
+### The agent cannot write live state
+
+An agent cannot write directly to a Canopy document, committed workspace state,
+or DOM. Document changes enter as proposals and are applied only by Canopy's
+commit boundary.
+
+A separate workspace may allow shell, build, test, or file effects under an
+explicit host policy. Access there does not grant access to a live Canopy
+document.
+
+### The host chooses capabilities
+
+The host chooses which tools are available before sending a prompt. The agent
+cannot expand that set. If the host cannot verify the active tools, the
+integration stops.
+
+Third-party tools remain the host's responsibility. Disabling an engine's
+built-ins is not a general sandbox guarantee.
+
+### Proposals bind revision and approval
+
+A proposal identifies the document revision it was prepared from. Validation
+and preview do not mutate the live document. Commit checks the revision again
+so concurrent edits cannot change an approved proposal's meaning.
+
+Approval is issued by the host and binds one proposal, base revision, and
+preview. Any content or revision change creates a new proposal and repeats
+validation.
+
+Read-only queries and effect-free generated views do not need user approval,
+but they still pass their existing validation and capability checks.
+
+### Effects are idempotent
+
+Any path with cancellation, retry, reconnect, or replay must prevent duplicate
+commit. Late and cancelled results cannot gain authority after their request
+closes.
+
+A single-process read-only bridge does not need a general replay protocol before
+it has effects to deduplicate. Correlation requirements should match the
+transport and effects actually supported.
+
+## Integration boundary
 
 ```text
-external agent engine
-  → structured requests and proposals
+external engine
   → replaceable adapter
-  → Canopy semantic and projection APIs
-  → validation and speculative preview
-  → host-issued approval where authority changes
-  → revision-checked collaborative commit
+  → Canopy semantic query or proposal
+  → validation and preview
+  → host approval when authority changes
+  → revision-checked CRDT commit
 ```
 
-The adapter translates transport and protocol data. It must not become a second
-owner of document semantics or workspace state.
+Agents should request language-owned operations instead of reproducing Canopy's
+projection internals. For a rename, Canopy resolves scope, computes the text
+changes, previews the projection, and decides whether the proposal is valid.
 
-## Responsibility split
+The mutation flow is:
 
-### External agent engine
+1. capture the base revision;
+2. validate and compute the proposal without live mutation;
+3. show the exact preview for host approval;
+4. recheck revision and identity;
+5. commit through the CRDT editor and record provenance.
 
-The engine owns:
-
-- model and provider interaction;
-- prompt and conversation state;
-- generic tool-call orchestration;
-- retry and model-call recovery policy;
-- its session persistence;
-- transport and credentials.
-
-The engine does not own Canopy document revisions, projection identity,
-semantic validation, approval, or collaborative-operation provenance.
-
-### Canopy
-
-Canopy owns:
-
-- authoritative live documents and their revisions;
-- incremental parsing, projections, and semantic context;
-- proposal validation and speculative preview;
-- user-facing approval decisions;
-- CRDT commit and peer convergence;
-- capability policy for effects that reach Canopy state;
-- proposal, approval, and commit provenance.
-
-Canopy does not own the coding-agent engine's model loop, concrete provider
-client, conversation manager, or coding-tool retry system. Canopy's existing
-provider-neutral request and result boundaries remain available to its own
-cognition features.
-
-### Adapter
-
-The adapter owns:
-
-- translation between an agent protocol and Canopy domain operations;
-- correlation between external requests and Canopy revisions;
-- process, stream, cancellation, and lifecycle handling;
-- conversion of agent tool requests into context queries or proposals.
-
-The adapter is replaceable. Canopy domain APIs must not depend on one engine's
-wire format.
-
-## Authority invariants
-
-### No direct live writes
-
-An agent cannot write directly to a Canopy-authoritative document, committed
-workspace state, or DOM. Document changes enter as proposals and are applied
-only by Canopy's commit boundary.
-
-An isolated workspace may allow shell, build, test, or file effects under an
-explicit host policy. Authority in an isolated workspace does not grant
-permission to mutate a live Canopy document.
-
-### Host-owned capabilities
-
-The host chooses which tools and effects are available before a prompt is sent.
-The agent cannot add to its own authority. If the host cannot verify the active
-tool set, the integration fails closed.
-
-Extra or third-party tools remain part of the host's policy; disabling
-OpenSeek's built-ins alone cannot establish a general sandbox guarantee.
-
-### Revision-bound proposals
-
-A proposal identifies the exact document revision it was prepared from.
-Validation and preview do not mutate the live document. Commit checks the
-revision again so a concurrent edit cannot silently change the meaning of an
-approved proposal.
-
-### Host-issued approval
-
-Approval belongs to the host and binds one exact proposal, base revision, and
-preview. The agent cannot mint approval. Changing proposal content or its base
-revision creates a new proposal and repeats validation and preview.
-
-Read-only context requests and effect-free generated views do not require a
-user approval step merely because an agent produced them. They still pass their
-existing validation and capability boundaries.
-
-### Idempotent effects
-
-Any path that supports cancellation, retry, reconnect, or replay must identify
-effect-bearing work strongly enough to prevent duplicate commit. Late or
-cancelled results cannot acquire authority after their request has closed.
-
-A narrow, ordered, single-process read-only bridge need not introduce a general
-distributed-event protocol before it has an effect to deduplicate. Broader
-correlation requirements should be justified by the transport and effects an
-implementation actually supports.
+Rendering patches are projection outputs, never agent-authored mutation inputs.
 
 ## Functional core and imperative shell
 
-Proposal validation, revision checks, capability decisions, and lifecycle
-transitions belong in a deterministic functional core. The core receives
-explicit inputs and returns decisions without transport or document mutation.
+A deterministic core owns proposal validation, revision checks, capability
+decisions, and lifecycle transitions. It receives explicit inputs and returns
+decisions without I/O or document mutation.
 
-The imperative shell owns process I/O, scheduling, cancellation, provider and
-protocol adapters, scratch editors, and the final live commit. Tests should pin
-the functional core with deterministic inputs and keep shell tests focused on
-effect wiring.
+A thin shell owns process I/O, scheduling, cancellation, scratch editors, and
+the final live commit.
 
-## Projection-aware proposals
+## Generated UI and audit
 
-Agents should request language-owned operations, not reproduce Canopy's
-projection internals. For example, an agent may ask to rename a selected
-binding. Canopy resolves scope, computes the text changes, previews the
-projected result, and decides whether the proposal is valid.
+Effect-free candidates may keep using the validation, dry-run, and commit path
+in the [Generative UI direction](generative-ui-direction.md). Generated actions
+that change documents or perform host effects use the same host-owned authority
+boundary as other proposals.
 
-The conceptual mutation flow is:
-
-1. capture the authoritative base revision;
-2. validate the structured proposal against Canopy semantics;
-3. compute and preview the result without mutating the live document;
-4. present the exact proposal and preview for host approval;
-5. recheck the base revision and proposal identity;
-6. commit through the CRDT editor and record provenance.
-
-Rendering patches are outputs of the projection pipeline, never agent-authored
-mutation inputs.
-
-## Generative UI
-
-The existing capability validation, dry-run, and session commit path remains
-available to effect-free candidates; see the
-[Generative UI direction](generative-ui-direction.md). A generated action that
-changes a document or performs another host effect requires the same host-owned
-authority boundary as other agent proposals.
-
-Generated output cannot add event handlers, network access, persistence, or
-direct DOM authority merely by requesting it.
-
-## Session and audit separation
-
-The external engine owns conversation history, model responses, tool calls, and
-its own compaction or replay. Canopy owns the record of proposal identity, base
-revision, approval, commit, and collaborative provenance.
-
-The records answer different questions:
-
-- the agent session explains what was requested and generated;
-- the Canopy record explains what was authorized and changed authoritative
-  state.
-
-They may be correlated without sharing ownership. Loss or compaction of the
-agent session cannot erase Canopy's commit provenance.
+The external engine owns conversation history and tool-call records. Canopy
+owns proposal identity, base revision, approval, commit, and collaborative
+provenance. The records may be correlated, but losing or compacting the agent
+session cannot erase Canopy's commit record.
 
 ## Activation gates
 
-Implementation should begin only when all of the following hold:
+Implementation requires all of the following:
 
-1. A named product experiment shows why an external coding agent is better than
-   a simpler fixed workflow.
-2. The selected engine can run without built-in paths that write around
-   Canopy's document boundary.
-3. The host can inspect the tools available to the model before sending a
-   prompt.
-4. An executable plan defines proposal identity, revision checks, approval,
-   cancellation, idempotency, and CRDT convergence for one narrow slice.
-5. The first slice uses one active editor and one language-owned operation; it
-   does not introduce multi-document identity prematurely.
+1. A product experiment justifies an agent over a fixed workflow.
+2. Any experiment using PKE or session data passes the PKE fixed-baseline and
+   data-egress gates first.
+3. The engine can run without built-in write paths around Canopy.
+4. The host can inspect available tools before sending a prompt.
+5. An executable plan covers identity, revision checks, approval, cancellation,
+   idempotency, and peer convergence.
+6. The first slice uses one active editor and one language-owned operation.
 
-These gates protect the current Personal Knowledge Environment priority from an
-unbounded agent-framework project while preserving a route to a later
-integration.
+## Deferred
 
-## Deferred work
-
-- stable multi-document identity and a document registry;
+- multi-document identity and registry;
 - cross-session proposal identity;
-- concurrent semantic merge of agent proposals;
+- concurrent semantic merge;
 - effectful Generative UI actions;
 - cryptographic approval evidence;
-- general reconnect and replay semantics beyond a concrete transport need;
-- a second provider abstraction for the external coding-agent engine.
+- general reconnect and replay semantics;
+- a second provider abstraction for the external engine.
 
 ## Non-goals
 
-- reimplementing an agent loop in Canopy;
-- making Canopy a general-purpose agent framework;
-- allowing agents to bypass validation, approval, or collaborative commit;
+- implementing an agent loop in Canopy;
+- making Canopy a general agent framework;
+- bypassing validation, approval, or collaborative commit;
 - treating model output as authoritative state;
-- coupling Canopy's domain API to OpenSeek or another agent protocol;
-- changing the near-term product priority through this document alone.
+- coupling Canopy's domain API to OpenSeek;
+- changing the near-term product priority through this document.
 
 ## Related documentation
 
@@ -228,4 +159,3 @@ integration.
 - [Cognition Runtime](cognition-runtime.md)
 - [OpenSeek–Canopy integration research](../research/2026-07-16-openseek-canopy-integration.md)
 - [Codex App-Server Lowering](../research/2026-06-13-canopy-codex-app-server-lowering.md)
-- [Responsibility Map](responsibility-map.md)

--- a/docs/research/2026-07-16-openseek-canopy-integration.md
+++ b/docs/research/2026-07-16-openseek-canopy-integration.md
@@ -12,11 +12,21 @@ paths live here rather than in architecture documentation.
 See [Coding Agent Direction](../architecture/coding-agent-direction.md) for the
 deferred architecture and activation gates.
 
-## External engine findings
+## What the investigation needed to establish
 
-### OpenSeek
+OpenSeek already supplies the expensive outer machinery of a coding agent: a
+model loop, tools, conversations, and sessions. The unresolved part was whether
+Canopy could reuse that machinery without creating a second writer for the same
+document.
 
-The inspected OpenSeek revision provides:
+The answer split in two. OpenSeek has a suitable process and protocol boundary,
+and Canopy already has several validation seams. But OpenSeek's default tools
+can write around those seams, while Canopy has no proposal and approval gateway
+to receive the result safely.
+
+## OpenSeek has the right outer shape
+
+The inspected revision provides:
 
 - a MoonBit agent loop, tool registry, conversation state, and session store;
 - a native `serve` command that reads JSONL commands from stdin and emits typed
@@ -30,126 +40,128 @@ The inspected OpenSeek revision provides:
 - concrete DeepSeek and Kimi model support, with credentials owned by OpenSeek;
 - Apache-2.0 licensing.
 
-OpenSeek is therefore a plausible external engine, but its native process and
-filesystem tools still need a host boundary for browser and editor use.
+The portable decoder initially suggests a direct browser integration. That
+portability stops at the wire: the engine and its filesystem tools remain a
+native process. A browser still needs a native host or server bridge.
 
-### Tau
+Tau reaches a similar boundary from Python. Its reusable harness separates
+provider events from agent events and excludes terminal and rendering concerns.
+Its append-only sessions derive replay, branching, and compaction views without
+rewriting history. Tau is useful here as a design comparison, not a dependency.
 
-Tau is a small Python reference, not a dependency candidate. Its useful lessons
-are architectural:
+## Canopy already has validation seams
 
-- provider events feed a separate agent event contract;
-- its reusable harness excludes terminal and rendering concerns;
-- append-only sessions derive replay, branching, and compaction views without
-  rewriting history.
+Canopy is not starting from an untyped model response. It already validates
+revisioned context, generated UI candidates, editor intents, and one narrow
+external diff. None of those seams, however, combines proposal identity, user
+approval, and collaborative commit.
 
-## Current Canopy seams
-
-### Cognition
+### Cognition tracks requests without running an agent
 
 The cognition store (`lib/cognition/store.mbt`) keeps revisioned context,
 dependencies, dirty state, and request records deterministic. Provider-neutral
-values are defined in `lib/cognition/provider_boundary.mbt`. Their store
+values are defined in `lib/cognition/provider_boundary.mbt`; their store
 operations live in `lib/cognition/provider_boundary_store.mbt`.
 
 The reactive next-action machinery and `ProviderDriverAction` remain private in
-`lib/cognition/provider_boundary_reactive.mbt`. Canopy has no public external
-driver contract for a coding-agent process.
+`lib/cognition/provider_boundary_reactive.mbt`. This is a planning seam, not a
+public driver contract for a coding-agent process.
 
-### Generative UI
+### Generative UI distrusts generated data
 
-`lib/cognition/generative_ui.mbt` already models generation identity, revision,
-cancellation, chunk order, validation, dry-run, and stale-result rejection.
+`lib/cognition/generative_ui.mbt` already tracks generation identity, revision,
+cancellation, chunk order, validation, dry-run, and stale results.
 `lib/cognition/generative_ui_candidate.mbt` validates untrusted candidate data.
-This lifecycle has no user approval step.
 
-`ffi/jsx/generative_ui_adapter.mbt` lowers validated data into typed JSX, while
-`ffi/jsx/session.mbt` commits only after dry-run and DOM application succeed.
-Generated values do not become event handlers, URLs, expressions, or direct DOM
-operations.
+The JSX path goes further. `ffi/jsx/generative_ui_adapter.mbt` lowers validated
+data into typed JSX, and `ffi/jsx/session.mbt` commits only after dry-run and DOM
+application succeed. Generated values do not become event handlers, URLs,
+expressions, or direct DOM operations.
 
-This path is suitable for effect-free views. Document changes and other host
-effects still need a separate approval boundary.
+That is enough for effect-free views. It does not answer who may approve a
+document change, because the current lifecycle has no user approval step.
 
-### Intent and view protocol
+### Intent and view types point in opposite directions
 
-- `protocol/user_intent.mbt` carries editor-originated text, structural,
-  selection, cursor, undo/redo, and value-commit intents.
-- `protocol/view_node.mbt` is the renderer-facing tree.
-- `protocol/view_patch.mbt` carries editor output such as node, text,
-  decoration, diagnostic, and selection updates.
+`protocol/user_intent.mbt` carries editor-originated edits and navigation into
+Canopy. `protocol/view_node.mbt` and `protocol/view_patch.mbt` carry projected
+state back to renderers.
 
-`ViewPatch` is output, not an authoring format. `UserIntent` also does not yet
-model a revision-bound agent proposal with host approval.
+A tempting shortcut would be to accept a `ViewPatch` from the agent. That would
+reverse the boundary: patches describe what Canopy decided to render, not what
+an external participant may author. `UserIntent` is closer, but it still lacks
+a base revision, proposal identity, and host approval.
 
-### Existing external lowering probe
+### One external edit is already lowered safely
 
-`codex/lowering.mbt` converts one narrowly constrained unified-diff update into
+`codex/lowering.mbt` converts one constrained unified-diff update into
 `UserIntent.TextEdit`.
 
 It accepts one changed line in one hunk only when the old line still matches and
 grapheme boundaries are valid. Tests pin stale-diff and UTF-16 boundary
 rejection.
 
-This proves that an external change can be lowered through a guarded Canopy
-boundary. It is not a generic proposal or commit gateway.
+The probe shows that an external change can pass through a guarded Canopy
+boundary. Its narrowness also exposes what is missing: it is neither a generic
+proposal nor a revision-checked commit gateway.
 
-### Workspace coordinator
+### Workspace and rename cover different halves
 
 `workspace/coordinator` manages editor registration, protected reads,
-dependencies, and disposal on a shared incremental runtime. It has no stable
-`DocumentId`, document registry, proposal revision gateway, or workspace
-persistence.
+dependencies, and disposal on a shared incremental runtime. It does not provide
+stable document identity, a document registry, or proposal revisions.
 
-### Lambda rename
+`lang/lambda/edits/text_edit_rename.mbt` supplies the semantic half of one useful
+operation. It resolves declarations and references through the scope graph and
+rejects sibling-name capture. The operation is Lambda-specific, with no
+language-neutral action facade.
 
-`lang/lambda/edits/text_edit_rename.mbt` performs scope-aware rename. It resolves
-declarations and references through the scope graph and rejects sibling-name
-capture. The operation is Lambda-specific; no language-neutral action facade
-currently exposes it.
+## The stock `serve` boundary fails in two concrete places
 
-## OpenSeek integration constraints
-
-### Native engine, portable decoder
-
-The browser can decode OpenSeek events, but it cannot run the native engine and
-filesystem tools directly. A browser integration needs a native host or server
-bridge.
-
-### Built-ins cannot be restricted
+### More tools can be added, but built-ins cannot be removed
 
 `agent/tool_definition.mbt::build_tools` always adds `shell`, `read`, `edit`,
 `multi_edit`, `write`, `remove`, `plan`, `goal`, and `finish`, plus
 `shell_output` and `shell_stop` where supported. `extra_tools` only appends.
-`serve` has no setting that removes the file-changing built-ins.
 
-### The final registry is not reported
+An embedded caller can instead pass a custom `Tools` registry to
+`run_turn_in_scope`. A separate `serve` client cannot inject that registry, which
+is the boundary evaluated here. Its model would still have `shell`, `edit`, and
+`write` paths around Canopy's validation flow.
+
+### MCP reporting is not a final tool inventory
 
 `serve` resolves MCP tools, builds the final registry, and then starts its stdin
-reader. It emits no complete list of tools available to the model.
-`mcp_tools_registered` reports only MCP discovery and is absent without an MCP
-configuration.
+reader. `mcp_tools_registered` reports only MCP discovery and is absent without
+an MCP configuration. No event reports every tool available to the model.
 
-Registry reporting can describe today's standard engine before configurable
-built-ins exist. Once restrictions exist, the same startup report can verify
-them before a prompt is sent.
+The distinction matters before the first prompt. Once a turn starts, the model
+may call an unexpected write-capable tool immediately. A host that intends to
+fail closed must inspect the final registry first.
 
-### Initial correlation can stay narrow
+These two changes can land independently. Registry reporting can describe the
+current engine before configurable built-ins exist; later it can verify that a
+restricted registry was actually built.
 
-The current `serve` scheduler uses one ordered queue and one active work item.
-A single-process, read-only bridge can keep request state in its adapter without
-a general replay protocol.
+### Correlation is narrower than it first appears
 
-Reconnect, replay, concurrent effects, or commit-capable results would require
-stable correlation so duplicate delivery cannot duplicate an effect.
+The protocol has no general request identity for reconnect and replay. That
+sounds like the next blocker, but the current `serve` scheduler uses one ordered
+queue and one active work item. A single-process, read-only bridge can keep its
+request state in the adapter because it has no effect to replay.
 
-## Candidate first mutation slice
+The requirement changes as soon as results can commit. Reconnect, replay,
+concurrent effects, or duplicate delivery then need stable identity so one
+approval cannot become two commits.
 
-The existing Lambda rename is a plausible first operation because its semantic
-checks already live in Canopy. A future plan could use a selected-node rename or
-first build a language-owned action facade; this research does not choose.
+## A Lambda rename could test the missing half
 
-Either mutation slice still needs infrastructure that Canopy lacks:
+Lambda rename is a plausible first mutation because Canopy already owns its
+scope and capture checks. The agent could request the operation without
+reimplementing those semantics.
+
+The remaining gap is not rename logic. Before the operation can reach a live
+document, Canopy still needs:
 
 - proposal identity and base revision;
 - host-issued approval;
@@ -158,30 +170,34 @@ Either mutation slice still needs infrastructure that Canopy lacks:
 - duplicate and cancellation handling;
 - CRDT peer-convergence tests.
 
-Stable document identity is not required for one active editor, but it is
-required before multi-document proposals.
+A future plan may choose selected-node rename or build a language-owned action
+facade first. Stable document identity can wait for multi-document work, but the
+items above cannot be skipped for one active editor.
 
-## Risks and open questions
+## Risks that remain open
 
 - **Product priority:** agent integration is deferred while the Personal
   Knowledge Environment is the near-term direction.
-- **Retrieval:** the current default cognition ranker is path-oriented;
-  projection-aware semantic retrieval remains future work.
+- **Retrieval:** the default cognition ranker is path-oriented; projection-aware
+  semantic retrieval remains future work.
 - **Structural parameters:** string-valued edit parameters cover rename but not
   every refactoring.
 - **Protocol evolution:** additive event decoding is tolerant, but a safe host
   still needs the actual startup tool inventory. General version negotiation
   should wait for a concrete compatibility need.
-- **Generative UI:** an agent connection does not bypass the existing product,
-  provider, validation, or effect-authority gates.
+- **Generative UI:** an agent connection does not bypass product, provider,
+  validation, or effect-authority gates.
 
 ## Conclusion
 
-OpenSeek can supply the agent loop and session, while Canopy can supply semantic
-queries and authoritative commit. The immediate upstream gaps are the inability
-to remove file-changing built-ins and the absence of a final tool inventory.
-Canopy's larger proposal, approval, and audit boundary remains unimplemented.
+OpenSeek can supply the agent loop and session. Canopy can supply semantic
+queries and authoritative commit.
 
-Any implementation should first pass the activation gates in
+The stock `serve` path is not safe for this integration yet: it cannot omit its
+file-changing built-ins or report its final registry, and Canopy cannot turn an
+approved proposal into an idempotent collaborative commit.
+
+Those gaps define a bounded future experiment rather than a new product
+priority. Any implementation should first pass the activation gates in
 [Coding Agent Direction](../architecture/coding-agent-direction.md) and use an
 executable plan with explicit acceptance criteria.

--- a/docs/research/2026-07-16-openseek-canopy-integration.md
+++ b/docs/research/2026-07-16-openseek-canopy-integration.md
@@ -160,6 +160,9 @@ Lambda rename is a plausible first mutation because Canopy already owns its
 scope and capture checks. The agent could request the operation without
 reimplementing those semantics.
 
+This is a technical mutation probe, not the next product experiment. It becomes
+relevant only after a read-only agent condition beats the fixed PKE baseline.
+
 The remaining gap is not rename logic. Before the operation can reach a live
 document, Canopy still needs:
 

--- a/docs/research/2026-07-16-openseek-canopy-integration.md
+++ b/docs/research/2026-07-16-openseek-canopy-integration.md
@@ -1,0 +1,293 @@
+# OpenSeek–Canopy integration research (2026-07-16)
+
+**Status:** research note — records what was verified and why, not what to build.
+This is a "what was verified" record, kept separate from an implementation plan.
+It deliberately cites concrete types, fields, and file paths; that is precisely
+why it lives in `docs/research/` and not under architecture docs (which are
+principles-only).
+
+**Inspected revisions:**
+- Canopy: `43f16244`
+- OpenSeek: `b72389a`
+- Tau: `6c14f83`
+
+**Companion references:**
+- [Coding Agent Direction](../architecture/coding-agent-direction.md) — the
+  principles-only target architecture and activation gates this research
+  informs.
+
+## OpenSeek identity and capabilities
+
+OpenSeek is a MoonBit-native coding agent. The inspected revision (`b72389a`)
+reveals:
+
+- **Native engine:** the agent loop, tools, conversation state, and session
+  persistence are implemented in MoonBit.
+- **Portable protocol decoder:** `openseek_protocol` parses the wire contract
+  without depending on the engine and supports browser and native targets.
+- **JSONL command/event protocol:** `serve` reads commands from stdin and emits
+  typed events on stdout. Durable replay belongs to the separate session store.
+- **Typed tool registry:** tools advertise JSON input schemas and return typed
+  response or control actions. Built-ins cover file access, shell execution,
+  plans, goals, and turn completion.
+- **MCP support:** MCP servers can contribute namespaced tools over stdio or
+  Streamable HTTP.
+- **Append-only sessions:** a header and typed events form the durable log.
+  Compaction appends a summary that changes model-context projection while
+  preserving covered history.
+- **Provider coupling:** the current loop targets DeepSeek and Kimi models.
+  OpenSeek owns its concrete model selection and API credentials. A
+  provider-neutral abstraction remains future work.
+- **License:** Apache-2.0.
+
+## Tau lessons as reference
+
+Tau is a small Python coding agent and teaching project. The inspected revision
+(`6c14f83`) demonstrates:
+
+- **Provider and agent event layers:** provider adapters feed one event stream
+  into a separate agent event contract.
+- **Portable harness:** the reusable harness excludes terminal, rendering, and
+  coding-session resource concerns. Frontends consume its event stream.
+- **Append-only sessions:** replay, branching, and compaction derive active
+  context without rewriting history.
+- **Reference only:** Tau is implemented in Python. Canopy should reuse these
+  boundaries rather than depend on Tau's implementation.
+
+## Current Canopy seams
+
+### Cognition context and provider boundary
+
+The cognition runtime models an incremental context graph for AI coding
+context. The provider boundary separates deterministic graph recomputation from
+external provider interaction.
+
+- `lib/cognition/store.mbt` — `CognitionStore` owns revision, dirty state,
+  dependencies, and artifact lifetime. It may plan provider requests and keep
+  request/status/result records, but it must not own HTTP clients, credentials,
+  retry loops, timers, or background tasks.
+- `lib/cognition/provider_boundary.mbt` defines provider-neutral request,
+  result, status, provenance, and error descriptors.
+- `lib/cognition/provider_boundary_store.mbt` exposes planning
+  (`plan_provider_request`), cancellation (`cancel_provider_request`),
+  completion (`complete_provider_request`), and request/status/result queries
+  on `CognitionStore`.
+- `lib/cognition/provider_boundary_reactive.mbt` contains the private reactive
+  planning graph and `ProviderDriverAction`. Next-action polling is internal,
+  not a public driver contract. A real external driver shell remains future
+  work.
+- `lib/cognition/types.mbt` — context item types with provenance (source key,
+  source revision, payload, inclusion reason).
+
+### Generative UI lifecycle and candidate validation
+
+The Generative UI lifecycle manages revision-bound candidate generation,
+validation, and commit. The LLM is an untrusted candidate generator; its output
+must never mutate the committed UI directly.
+
+- `lib/cognition/generative_ui.mbt` — lifecycle state machine: generation ID,
+  revision, cancellation, chunk sequencing, finalization, stale-completion
+  rejection. Every candidate is evaluated against an explicit base revision.
+  The lifecycle progresses through validation, dry-run, and commit phases
+  deterministically; it does not include a user-visible approval step.
+- `lib/cognition/generative_ui_candidate.mbt` — syntax, schema, size, and
+  host-capability validation for untrusted candidate data. Revision checks,
+  dry-run, and commit remain separate lifecycle and session responsibilities.
+
+The current Generative UI path supports internal validation, internal dry-run,
+and session commit. A user-visible approval preview is deferred. Effectful
+actions and document mutations require the future host-approval boundary.
+
+### JSX candidate projection and session commit
+
+The JSX boundary lowers validated candidates into a typed synthetic projection,
+then commits that projection through the existing session dry-run and DOM-apply
+path.
+
+- `ffi/jsx/session.mbt` — JSX session state, revision tracking, render planning,
+  dry-run, DOM application, recovery, and commit. A candidate is not reported as
+  committed unless the session commit succeeds.
+- `ffi/jsx/generative_ui_adapter.mbt` — lowering from validated candidate nodes
+  to a typed JSX projection. Generated values never become event handlers,
+  URLs, expressions, or direct DOM operations.
+- `lang/jsx/proj/reconcile.mbt` — reconciliation logic that computes patches
+  between projected JSX states.
+- `lang/jsx/proj/dry_run.mbt` — pure modeled application of DOM patches before
+  the imperative DOM boundary runs.
+
+### UserIntent, ViewNode, and ViewPatch
+
+The protocol layer defines the boundary between Canopy's domain and external
+adapters.
+
+- `protocol/user_intent.mbt` — `UserIntent` enum: text edit, structural edit,
+  node selection, cursor movement, undo/redo, and node-value commit. These are
+  editor-adapter-originated actions: they represent the intent path from a
+  frontend or adapter into the editor. Direct FFI paths and language-specific
+  edit paths exist alongside this intent enum.
+- `protocol/view_node.mbt` — `ViewNode` struct: the UI boundary. New renderers
+  should consume protocol output instead of inventing a parallel view tree.
+- `protocol/view_patch.mbt` — `ViewPatch` enum: text changes, node replacement
+  and child updates, decorations, diagnostics, selection, and full-tree output.
+  It is editor output consumed by render adapters, not an authoring input.
+
+### Codex lowering prototype
+
+The Codex lowering prototype demonstrates how an external agent's file changes
+can be lowered into `UserIntent` operations and driven into a `SyncEditor`
+under the exact (grapheme-boundary-checked) policy.
+
+- `codex/lowering.mbt` — lowers a Codex `FileChange.update` unified diff into
+  `UserIntent.TextEdit` operations. The prototype scope is narrow: exactly one
+  changed line inside a single hunk, applied only when the document line still
+  matches the patch's old text. Multi-hunk diffs, multi-line hunks, and
+  concurrent/stale apply are rejected with a clear error.
+- `codex/lowering_test.mbt` — tests for grapheme-boundary alignment,
+  stale-diff rejection, and exact-boundary policy, including adjacent emoji
+  whose UTF-16 encodings share a high surrogate. The earlier Codex research
+  note records the separate UTF-8 byte-to-UTF-16 probe.
+
+### Workspace coordinator
+
+The workspace coordinator manages multiple editors on a shared runtime,
+enforcing observer discipline and atomic disposal boundaries.
+
+- `workspace/coordinator/types.mbt` — coordinator types: `EditorId`,
+  `ProtectedCell`, lifecycle abort kinds and reports, and the coordinator-owned
+  registration state.
+- `workspace/coordinator/pkg.generated.mbti` — public API: `Coordinator::new`,
+  `register_editor`, `destroy_editor`, `read_protected`,
+  `register_workspace_cell`, `register_dep`, `unregister_dep`, `runtime`.
+- `ffi/json/json_ffi.mbt` — JSON FFI bundle uses the workspace coordinator to
+  manage multiple JSON editors on a shared runtime.
+
+The coordinator provides shared incremental-runtime access, protected-cell
+lifecycle, and disposal safety. It has no `DocumentId`, document registry,
+workspace persistence, multi-document identity, or proposal revision gateway.
+
+### Lambda rename: scope-aware, Lambda-specific
+
+- `lang/lambda/edits/text_edit_rename.mbt` — rename operations are
+  scope-graph-aware: they resolve through `@scope.Decl`, use
+  `@scope.references(g, decl.id)`, thread the block-local `Decl` straight
+  through without round-tripping a root-relative `def_index`, and enforce a
+  capture guard against sibling bindings in the same scope. This is
+  Lambda-specific; no language-owned action facade generalizes it yet.
+
+### Current explicit gaps
+
+The following infrastructure does not exist today:
+
+- No generic proposal session for agent-authored edits.
+- No host-issued approval evidence mechanism.
+- No audit ledger recording proposal, approval, and commit provenance.
+- No revision-bound commit API for inbound proposals.
+- No document workspace with stable `DocumentId` or document registry.
+
+## Observed integration constraints
+
+These constraints follow from the inspected source. They are facts about the
+current codebase, not design recommendations.
+
+- **`serve` is native JSONL over stdio.** The serve loop reads JSONL commands
+  from stdin and writes JSONL events to stdout (`serve.mbt`). This is a
+  native-process contract.
+- **Protocol decoder is portable.** `openseek_protocol` parses the wire
+  contract without engine dependencies and supports browser targets.
+- **Browser needs native or server bridge.** The engine and its process and
+  filesystem tools remain native. Browser deployments need a local native host
+  or server bridge even though the decoder itself is portable.
+- **Standard serve always registers mutation-capable built-ins.** The default
+  registry includes workspace-mutating `shell`, `edit`, `multi_edit`, `write`,
+  and `remove` tools alongside `read` and the session/control tools `plan`,
+  `goal`, and `finish` (`tool_definition.mbt`). No built-in profile or
+  host-policy switch disables the workspace-mutating subset for an
+  external-editor integration.
+- **Protocol and domain separation.** OpenSeek's protocol layer
+  (`openseek_protocol`) is independent of its engine, but the engine's tool
+  semantics (file writes, shell execution) are not mediated by any Canopy
+  domain concept today. An adapter must translate between OpenSeek's tool
+  actions and Canopy's proposal and intent contracts.
+
+## Candidate integration blockers
+
+The inspected `serve` path exposes two concrete blockers for a safe subprocess
+integration:
+
+- **Built-in write paths cannot be omitted.** A controller cannot currently
+  remove `shell`, `edit`, `multi_edit`, `write`, and `remove` while retaining
+  the model loop and selected read/control tools.
+- **The final registry is not reported.** `serve` resolves MCP tools, builds the
+  final registry, and then starts its stdin reader without emitting the names
+  available to the model. `mcp_tools_registered` reports only MCP discovery and
+  is absent when no MCP configuration is supplied.
+
+Registry reporting can describe the current standard engine before
+configurable built-ins exist. Once a restricted registry exists, the same
+startup report can verify it before a prompt is sent.
+
+The current `serve` scheduler funnels commands through one ordered queue and
+runs one active work item at a time. An initial single-process, read-only bridge
+can keep request state in its adapter without a general replay protocol.
+
+Stable cross-process correlation becomes necessary when an implementation adds
+reconnect, replay, concurrent effects, or any path whose duplicate result could
+commit state.
+
+A later mutation slice also depends on Canopy infrastructure that does not yet
+exist: proposal identity, revision checks, host-issued approval, and a commit
+gateway. Abstracting OpenSeek's concrete model providers is a separate engine
+concern and is not required to test this host boundary.
+
+## Feasibility finding: first vertical slice
+
+The current Lambda rename implementation is scope-graph-aware and
+capture-safe, but it is Lambda-specific. No language-owned action facade
+generalizes rename across languages.
+
+A first vertical slice could therefore use a **Lambda selected-node rename
+proposal**, or it must build a language-owned action facade first. Choosing
+between those scopes belongs in a future implementation decision and plan.
+
+Either mutation slice would require infrastructure that does not exist today:
+
+- A generic proposal model that carries proposal identity, base revision, and
+  structured edit intent.
+- A host-issued approval step that the agent cannot mint itself.
+- A revision-checked commit gateway that re-checks the base revision at commit
+  time.
+- An audit trail recording proposal, approval, and commit provenance.
+
+None of this infrastructure exists today.
+
+The responsibility split and activation gates for this slice are defined in the
+[Coding Agent Direction](../architecture/coding-agent-direction.md). This
+research note does not authorize implementation.
+
+## Risks and open questions
+
+- **Retrieval gap:** OpenSeek supplies an agent and tools, while Canopy currently
+  supplies deterministic context packing with a path-oriented default ranker.
+  Projection-derived and semantic retrieval remain future work.
+- **Narrow structural parameters:** string-valued structural parameters cover
+  rename but not every refactoring shape.
+- **Document-qualified identity:** multi-document proposals need stable document
+  identity in addition to projection identity. No `DocumentId` exists today.
+- **Protocol skew:** the portable decoder tolerates additive events, but a safe
+  adapter still needs a startup inventory of the tools actually available to
+  the model. General version negotiation should be added only when a concrete
+  compatibility boundary requires it.
+- **Generative UI value gate:** agent integration does not authorize a live
+  provider. A later OpenSeek-driven experiment must retain effect-free host
+  capabilities and pass the separate product-value and provider gates;
+  effectful actions also need future host approval evidence.
+
+## Disclaimer
+
+This is not an implementation plan. It does not authorize live-provider
+production work. It records what was verified and why, and it informs the
+principles-only target architecture direction in
+[Coding Agent Direction](../architecture/coding-agent-direction.md).
+
+Implementation work should pass the activation gates in the direction document
+and should be scoped through an executable plan with clear acceptance criteria.

--- a/docs/research/2026-07-16-openseek-canopy-integration.md
+++ b/docs/research/2026-07-16-openseek-canopy-integration.md
@@ -1,293 +1,187 @@
 # OpenSeek–Canopy integration research (2026-07-16)
 
-**Status:** research note — records what was verified and why, not what to build.
-This is a "what was verified" record, kept separate from an implementation plan.
-It deliberately cites concrete types, fields, and file paths; that is precisely
-why it lives in `docs/research/` and not under architecture docs (which are
-principles-only).
+**Status:** verified research, not an implementation plan. Concrete APIs and
+paths live here rather than in architecture documentation.
 
 **Inspected revisions:**
+
 - Canopy: `43f16244`
 - OpenSeek: `b72389a`
 - Tau: `6c14f83`
 
-**Companion references:**
-- [Coding Agent Direction](../architecture/coding-agent-direction.md) — the
-  principles-only target architecture and activation gates this research
-  informs.
+See [Coding Agent Direction](../architecture/coding-agent-direction.md) for the
+deferred architecture and activation gates.
 
-## OpenSeek identity and capabilities
+## External engine findings
 
-OpenSeek is a MoonBit-native coding agent. The inspected revision (`b72389a`)
-reveals:
+### OpenSeek
 
-- **Native engine:** the agent loop, tools, conversation state, and session
-  persistence are implemented in MoonBit.
-- **Portable protocol decoder:** `openseek_protocol` parses the wire contract
-  without depending on the engine and supports browser and native targets.
-- **JSONL command/event protocol:** `serve` reads commands from stdin and emits
-  typed events on stdout. Durable replay belongs to the separate session store.
-- **Typed tool registry:** tools advertise JSON input schemas and return typed
-  response or control actions. Built-ins cover file access, shell execution,
-  plans, goals, and turn completion.
-- **MCP support:** MCP servers can contribute namespaced tools over stdio or
-  Streamable HTTP.
-- **Append-only sessions:** a header and typed events form the durable log.
-  Compaction appends a summary that changes model-context projection while
-  preserving covered history.
-- **Provider coupling:** the current loop targets DeepSeek and Kimi models.
-  OpenSeek owns its concrete model selection and API credentials. A
-  provider-neutral abstraction remains future work.
-- **License:** Apache-2.0.
+The inspected OpenSeek revision provides:
 
-## Tau lessons as reference
+- a MoonBit agent loop, tool registry, conversation state, and session store;
+- a native `serve` command that reads JSONL commands from stdin and emits typed
+  events on stdout;
+- a portable `openseek_protocol` decoder for native, JavaScript, and WebAssembly
+  clients;
+- built-in file, shell, plan, goal, and completion tools;
+- MCP tools over stdio or Streamable HTTP;
+- append-only sessions whose compaction changes model-context projection without
+  deleting covered history;
+- concrete DeepSeek and Kimi model support, with credentials owned by OpenSeek;
+- Apache-2.0 licensing.
 
-Tau is a small Python coding agent and teaching project. The inspected revision
-(`6c14f83`) demonstrates:
+OpenSeek is therefore a plausible external engine, but its native process and
+filesystem tools still need a host boundary for browser and editor use.
 
-- **Provider and agent event layers:** provider adapters feed one event stream
-  into a separate agent event contract.
-- **Portable harness:** the reusable harness excludes terminal, rendering, and
-  coding-session resource concerns. Frontends consume its event stream.
-- **Append-only sessions:** replay, branching, and compaction derive active
-  context without rewriting history.
-- **Reference only:** Tau is implemented in Python. Canopy should reuse these
-  boundaries rather than depend on Tau's implementation.
+### Tau
+
+Tau is a small Python reference, not a dependency candidate. Its useful lessons
+are architectural:
+
+- provider events feed a separate agent event contract;
+- its reusable harness excludes terminal and rendering concerns;
+- append-only sessions derive replay, branching, and compaction views without
+  rewriting history.
 
 ## Current Canopy seams
 
-### Cognition context and provider boundary
+### Cognition
 
-The cognition runtime models an incremental context graph for AI coding
-context. The provider boundary separates deterministic graph recomputation from
-external provider interaction.
+The cognition store (`lib/cognition/store.mbt`) keeps revisioned context,
+dependencies, dirty state, and request records deterministic. Provider-neutral
+values are defined in `lib/cognition/provider_boundary.mbt`. Their store
+operations live in `lib/cognition/provider_boundary_store.mbt`.
 
-- `lib/cognition/store.mbt` — `CognitionStore` owns revision, dirty state,
-  dependencies, and artifact lifetime. It may plan provider requests and keep
-  request/status/result records, but it must not own HTTP clients, credentials,
-  retry loops, timers, or background tasks.
-- `lib/cognition/provider_boundary.mbt` defines provider-neutral request,
-  result, status, provenance, and error descriptors.
-- `lib/cognition/provider_boundary_store.mbt` exposes planning
-  (`plan_provider_request`), cancellation (`cancel_provider_request`),
-  completion (`complete_provider_request`), and request/status/result queries
-  on `CognitionStore`.
-- `lib/cognition/provider_boundary_reactive.mbt` contains the private reactive
-  planning graph and `ProviderDriverAction`. Next-action polling is internal,
-  not a public driver contract. A real external driver shell remains future
-  work.
-- `lib/cognition/types.mbt` — context item types with provenance (source key,
-  source revision, payload, inclusion reason).
+The reactive next-action machinery and `ProviderDriverAction` remain private in
+`lib/cognition/provider_boundary_reactive.mbt`. Canopy has no public external
+driver contract for a coding-agent process.
 
-### Generative UI lifecycle and candidate validation
+### Generative UI
 
-The Generative UI lifecycle manages revision-bound candidate generation,
-validation, and commit. The LLM is an untrusted candidate generator; its output
-must never mutate the committed UI directly.
+`lib/cognition/generative_ui.mbt` already models generation identity, revision,
+cancellation, chunk order, validation, dry-run, and stale-result rejection.
+`lib/cognition/generative_ui_candidate.mbt` validates untrusted candidate data.
+This lifecycle has no user approval step.
 
-- `lib/cognition/generative_ui.mbt` — lifecycle state machine: generation ID,
-  revision, cancellation, chunk sequencing, finalization, stale-completion
-  rejection. Every candidate is evaluated against an explicit base revision.
-  The lifecycle progresses through validation, dry-run, and commit phases
-  deterministically; it does not include a user-visible approval step.
-- `lib/cognition/generative_ui_candidate.mbt` — syntax, schema, size, and
-  host-capability validation for untrusted candidate data. Revision checks,
-  dry-run, and commit remain separate lifecycle and session responsibilities.
+`ffi/jsx/generative_ui_adapter.mbt` lowers validated data into typed JSX, while
+`ffi/jsx/session.mbt` commits only after dry-run and DOM application succeed.
+Generated values do not become event handlers, URLs, expressions, or direct DOM
+operations.
 
-The current Generative UI path supports internal validation, internal dry-run,
-and session commit. A user-visible approval preview is deferred. Effectful
-actions and document mutations require the future host-approval boundary.
+This path is suitable for effect-free views. Document changes and other host
+effects still need a separate approval boundary.
 
-### JSX candidate projection and session commit
+### Intent and view protocol
 
-The JSX boundary lowers validated candidates into a typed synthetic projection,
-then commits that projection through the existing session dry-run and DOM-apply
-path.
+- `protocol/user_intent.mbt` carries editor-originated text, structural,
+  selection, cursor, undo/redo, and value-commit intents.
+- `protocol/view_node.mbt` is the renderer-facing tree.
+- `protocol/view_patch.mbt` carries editor output such as node, text,
+  decoration, diagnostic, and selection updates.
 
-- `ffi/jsx/session.mbt` — JSX session state, revision tracking, render planning,
-  dry-run, DOM application, recovery, and commit. A candidate is not reported as
-  committed unless the session commit succeeds.
-- `ffi/jsx/generative_ui_adapter.mbt` — lowering from validated candidate nodes
-  to a typed JSX projection. Generated values never become event handlers,
-  URLs, expressions, or direct DOM operations.
-- `lang/jsx/proj/reconcile.mbt` — reconciliation logic that computes patches
-  between projected JSX states.
-- `lang/jsx/proj/dry_run.mbt` — pure modeled application of DOM patches before
-  the imperative DOM boundary runs.
+`ViewPatch` is output, not an authoring format. `UserIntent` also does not yet
+model a revision-bound agent proposal with host approval.
 
-### UserIntent, ViewNode, and ViewPatch
+### Existing external lowering probe
 
-The protocol layer defines the boundary between Canopy's domain and external
-adapters.
+`codex/lowering.mbt` converts one narrowly constrained unified-diff update into
+`UserIntent.TextEdit`.
 
-- `protocol/user_intent.mbt` — `UserIntent` enum: text edit, structural edit,
-  node selection, cursor movement, undo/redo, and node-value commit. These are
-  editor-adapter-originated actions: they represent the intent path from a
-  frontend or adapter into the editor. Direct FFI paths and language-specific
-  edit paths exist alongside this intent enum.
-- `protocol/view_node.mbt` — `ViewNode` struct: the UI boundary. New renderers
-  should consume protocol output instead of inventing a parallel view tree.
-- `protocol/view_patch.mbt` — `ViewPatch` enum: text changes, node replacement
-  and child updates, decorations, diagnostics, selection, and full-tree output.
-  It is editor output consumed by render adapters, not an authoring input.
+It accepts one changed line in one hunk only when the old line still matches and
+grapheme boundaries are valid. Tests pin stale-diff and UTF-16 boundary
+rejection.
 
-### Codex lowering prototype
-
-The Codex lowering prototype demonstrates how an external agent's file changes
-can be lowered into `UserIntent` operations and driven into a `SyncEditor`
-under the exact (grapheme-boundary-checked) policy.
-
-- `codex/lowering.mbt` — lowers a Codex `FileChange.update` unified diff into
-  `UserIntent.TextEdit` operations. The prototype scope is narrow: exactly one
-  changed line inside a single hunk, applied only when the document line still
-  matches the patch's old text. Multi-hunk diffs, multi-line hunks, and
-  concurrent/stale apply are rejected with a clear error.
-- `codex/lowering_test.mbt` — tests for grapheme-boundary alignment,
-  stale-diff rejection, and exact-boundary policy, including adjacent emoji
-  whose UTF-16 encodings share a high surrogate. The earlier Codex research
-  note records the separate UTF-8 byte-to-UTF-16 probe.
+This proves that an external change can be lowered through a guarded Canopy
+boundary. It is not a generic proposal or commit gateway.
 
 ### Workspace coordinator
 
-The workspace coordinator manages multiple editors on a shared runtime,
-enforcing observer discipline and atomic disposal boundaries.
+`workspace/coordinator` manages editor registration, protected reads,
+dependencies, and disposal on a shared incremental runtime. It has no stable
+`DocumentId`, document registry, proposal revision gateway, or workspace
+persistence.
 
-- `workspace/coordinator/types.mbt` — coordinator types: `EditorId`,
-  `ProtectedCell`, lifecycle abort kinds and reports, and the coordinator-owned
-  registration state.
-- `workspace/coordinator/pkg.generated.mbti` — public API: `Coordinator::new`,
-  `register_editor`, `destroy_editor`, `read_protected`,
-  `register_workspace_cell`, `register_dep`, `unregister_dep`, `runtime`.
-- `ffi/json/json_ffi.mbt` — JSON FFI bundle uses the workspace coordinator to
-  manage multiple JSON editors on a shared runtime.
+### Lambda rename
 
-The coordinator provides shared incremental-runtime access, protected-cell
-lifecycle, and disposal safety. It has no `DocumentId`, document registry,
-workspace persistence, multi-document identity, or proposal revision gateway.
+`lang/lambda/edits/text_edit_rename.mbt` performs scope-aware rename. It resolves
+declarations and references through the scope graph and rejects sibling-name
+capture. The operation is Lambda-specific; no language-neutral action facade
+currently exposes it.
 
-### Lambda rename: scope-aware, Lambda-specific
+## OpenSeek integration constraints
 
-- `lang/lambda/edits/text_edit_rename.mbt` — rename operations are
-  scope-graph-aware: they resolve through `@scope.Decl`, use
-  `@scope.references(g, decl.id)`, thread the block-local `Decl` straight
-  through without round-tripping a root-relative `def_index`, and enforce a
-  capture guard against sibling bindings in the same scope. This is
-  Lambda-specific; no language-owned action facade generalizes it yet.
+### Native engine, portable decoder
 
-### Current explicit gaps
+The browser can decode OpenSeek events, but it cannot run the native engine and
+filesystem tools directly. A browser integration needs a native host or server
+bridge.
 
-The following infrastructure does not exist today:
+### Built-ins cannot be restricted
 
-- No generic proposal session for agent-authored edits.
-- No host-issued approval evidence mechanism.
-- No audit ledger recording proposal, approval, and commit provenance.
-- No revision-bound commit API for inbound proposals.
-- No document workspace with stable `DocumentId` or document registry.
+`agent/tool_definition.mbt::build_tools` always adds `shell`, `read`, `edit`,
+`multi_edit`, `write`, `remove`, `plan`, `goal`, and `finish`, plus
+`shell_output` and `shell_stop` where supported. `extra_tools` only appends.
+`serve` has no setting that removes the file-changing built-ins.
 
-## Observed integration constraints
+### The final registry is not reported
 
-These constraints follow from the inspected source. They are facts about the
-current codebase, not design recommendations.
+`serve` resolves MCP tools, builds the final registry, and then starts its stdin
+reader. It emits no complete list of tools available to the model.
+`mcp_tools_registered` reports only MCP discovery and is absent without an MCP
+configuration.
 
-- **`serve` is native JSONL over stdio.** The serve loop reads JSONL commands
-  from stdin and writes JSONL events to stdout (`serve.mbt`). This is a
-  native-process contract.
-- **Protocol decoder is portable.** `openseek_protocol` parses the wire
-  contract without engine dependencies and supports browser targets.
-- **Browser needs native or server bridge.** The engine and its process and
-  filesystem tools remain native. Browser deployments need a local native host
-  or server bridge even though the decoder itself is portable.
-- **Standard serve always registers mutation-capable built-ins.** The default
-  registry includes workspace-mutating `shell`, `edit`, `multi_edit`, `write`,
-  and `remove` tools alongside `read` and the session/control tools `plan`,
-  `goal`, and `finish` (`tool_definition.mbt`). No built-in profile or
-  host-policy switch disables the workspace-mutating subset for an
-  external-editor integration.
-- **Protocol and domain separation.** OpenSeek's protocol layer
-  (`openseek_protocol`) is independent of its engine, but the engine's tool
-  semantics (file writes, shell execution) are not mediated by any Canopy
-  domain concept today. An adapter must translate between OpenSeek's tool
-  actions and Canopy's proposal and intent contracts.
+Registry reporting can describe today's standard engine before configurable
+built-ins exist. Once restrictions exist, the same startup report can verify
+them before a prompt is sent.
 
-## Candidate integration blockers
+### Initial correlation can stay narrow
 
-The inspected `serve` path exposes two concrete blockers for a safe subprocess
-integration:
+The current `serve` scheduler uses one ordered queue and one active work item.
+A single-process, read-only bridge can keep request state in its adapter without
+a general replay protocol.
 
-- **Built-in write paths cannot be omitted.** A controller cannot currently
-  remove `shell`, `edit`, `multi_edit`, `write`, and `remove` while retaining
-  the model loop and selected read/control tools.
-- **The final registry is not reported.** `serve` resolves MCP tools, builds the
-  final registry, and then starts its stdin reader without emitting the names
-  available to the model. `mcp_tools_registered` reports only MCP discovery and
-  is absent when no MCP configuration is supplied.
+Reconnect, replay, concurrent effects, or commit-capable results would require
+stable correlation so duplicate delivery cannot duplicate an effect.
 
-Registry reporting can describe the current standard engine before
-configurable built-ins exist. Once a restricted registry exists, the same
-startup report can verify it before a prompt is sent.
+## Candidate first mutation slice
 
-The current `serve` scheduler funnels commands through one ordered queue and
-runs one active work item at a time. An initial single-process, read-only bridge
-can keep request state in its adapter without a general replay protocol.
+The existing Lambda rename is a plausible first operation because its semantic
+checks already live in Canopy. A future plan could use a selected-node rename or
+first build a language-owned action facade; this research does not choose.
 
-Stable cross-process correlation becomes necessary when an implementation adds
-reconnect, replay, concurrent effects, or any path whose duplicate result could
-commit state.
+Either mutation slice still needs infrastructure that Canopy lacks:
 
-A later mutation slice also depends on Canopy infrastructure that does not yet
-exist: proposal identity, revision checks, host-issued approval, and a commit
-gateway. Abstracting OpenSeek's concrete model providers is a separate engine
-concern and is not required to test this host boundary.
+- proposal identity and base revision;
+- host-issued approval;
+- revision recheck at commit;
+- proposal, approval, and commit provenance;
+- duplicate and cancellation handling;
+- CRDT peer-convergence tests.
 
-## Feasibility finding: first vertical slice
-
-The current Lambda rename implementation is scope-graph-aware and
-capture-safe, but it is Lambda-specific. No language-owned action facade
-generalizes rename across languages.
-
-A first vertical slice could therefore use a **Lambda selected-node rename
-proposal**, or it must build a language-owned action facade first. Choosing
-between those scopes belongs in a future implementation decision and plan.
-
-Either mutation slice would require infrastructure that does not exist today:
-
-- A generic proposal model that carries proposal identity, base revision, and
-  structured edit intent.
-- A host-issued approval step that the agent cannot mint itself.
-- A revision-checked commit gateway that re-checks the base revision at commit
-  time.
-- An audit trail recording proposal, approval, and commit provenance.
-
-None of this infrastructure exists today.
-
-The responsibility split and activation gates for this slice are defined in the
-[Coding Agent Direction](../architecture/coding-agent-direction.md). This
-research note does not authorize implementation.
+Stable document identity is not required for one active editor, but it is
+required before multi-document proposals.
 
 ## Risks and open questions
 
-- **Retrieval gap:** OpenSeek supplies an agent and tools, while Canopy currently
-  supplies deterministic context packing with a path-oriented default ranker.
-  Projection-derived and semantic retrieval remain future work.
-- **Narrow structural parameters:** string-valued structural parameters cover
-  rename but not every refactoring shape.
-- **Document-qualified identity:** multi-document proposals need stable document
-  identity in addition to projection identity. No `DocumentId` exists today.
-- **Protocol skew:** the portable decoder tolerates additive events, but a safe
-  adapter still needs a startup inventory of the tools actually available to
-  the model. General version negotiation should be added only when a concrete
-  compatibility boundary requires it.
-- **Generative UI value gate:** agent integration does not authorize a live
-  provider. A later OpenSeek-driven experiment must retain effect-free host
-  capabilities and pass the separate product-value and provider gates;
-  effectful actions also need future host approval evidence.
+- **Product priority:** agent integration is deferred while the Personal
+  Knowledge Environment is the near-term direction.
+- **Retrieval:** the current default cognition ranker is path-oriented;
+  projection-aware semantic retrieval remains future work.
+- **Structural parameters:** string-valued edit parameters cover rename but not
+  every refactoring.
+- **Protocol evolution:** additive event decoding is tolerant, but a safe host
+  still needs the actual startup tool inventory. General version negotiation
+  should wait for a concrete compatibility need.
+- **Generative UI:** an agent connection does not bypass the existing product,
+  provider, validation, or effect-authority gates.
 
-## Disclaimer
+## Conclusion
 
-This is not an implementation plan. It does not authorize live-provider
-production work. It records what was verified and why, and it informs the
-principles-only target architecture direction in
-[Coding Agent Direction](../architecture/coding-agent-direction.md).
+OpenSeek can supply the agent loop and session, while Canopy can supply semantic
+queries and authoritative commit. The immediate upstream gaps are the inability
+to remove file-changing built-ins and the absence of a final tool inventory.
+Canopy's larger proposal, approval, and audit boundary remains unimplemented.
 
-Implementation work should pass the activation gates in the direction document
-and should be scoped through an executable plan with clear acceptance criteria.
+Any implementation should first pass the activation gates in
+[Coding Agent Direction](../architecture/coding-agent-direction.md) and use an
+executable plan with explicit acceptance criteria.


### PR DESCRIPTION
## Summary

- define a deferred boundary between an external coding-agent engine and Canopy-owned document authority;
- record the source-backed OpenSeek, Tau, and Canopy integration findings at the inspected revisions;
- index the new direction without changing the near-term Personal Knowledge Environment priority.

The direction keeps model loops, conversations, and generic tool orchestration outside Canopy while reserving projection semantics, validation, approval, CRDT commit, and provenance for Canopy. It adds no implementation commitment or live mutation path.

## Reuse check

Pure documentation change. No functions, methods, helpers, types, dependencies, or public APIs are added.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (existing workspace and vendored warnings only)
- [x] `NEW_MOON_MOD=0 moon test` passes — 1,937 JS and 70 native tests
- [x] `git diff -- '*.mbti'` reviewed; no interface files changed
- [x] local links in both new documents resolve
- [x] `git diff --check` passes
- [x] `scripts/check-agent-doc-links.sh` passes
- [x] Slopless actionable findings resolved; only document-wide technical readability scores remain
- [x] independent MoonBit boundary review found no blockers
- [x] JS rebuild not required; no source or web files changed

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
git diff --check
bash scripts/check-agent-doc-links.sh
```

`moon fmt && moon info` were also run. No submodule pointer or generated interface change is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture guidance for integrating external coding-agent engines while preserving host-controlled safety and approval boundaries.
  * Documented revision-aware proposals, validation, previews, CRDT commits, provenance, and cancellation handling.
  * Added research findings on OpenSeek and related integration constraints, capabilities, risks, and adoption requirements.
  * Updated the architecture vision to include the new coding-agent direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->