### PR TITLE
docs(genui): design minimal provider E2E

### DIFF
--- a/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md
+++ b/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md
@@ -1,6 +1,6 @@
 # Generative UI minimal provider E2E design
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Issue:** #896
 
@@ -69,8 +69,7 @@ The minimal command reuses rather than duplicates:
 
 - `GENUI_CANDIDATE_SCHEMA` from
   `examples/web/src/genui-candidate-schema.js`.
-- `buildFeasibilityPrompt`, `GENUI_PROVIDER_SETTINGS.maxCandidateBytes`, and
-  canonical JSON utilities from
+- `buildFeasibilityPrompt` and `GENUI_PROVIDER_SETTINGS.maxCandidateBytes` from
   `examples/web/src/genui-feasibility-provider.js`.
 - Existing fixture lookup and normalized capability/dataset JSON from
   `examples/web/src/genui-feasibility-fixtures.js`.
@@ -78,7 +77,8 @@ The minimal command reuses rather than duplicates:
   `examples/web/src/genui-feasibility-flow.js`.
 - The existing browser-loaded MoonBit evaluator and session commit path in
   `examples/web/src/genui.js`.
-- The existing Playwright web-server configuration and Chromium dependency.
+- The existing Playwright Chromium dependency and the dev-server command pattern
+  in `examples/web/playwright.feasibility.config.ts`.
 
 No general provider interface is introduced. A second live provider is required
 before a shared provider abstraction can be justified.
@@ -90,16 +90,21 @@ The developer command accepts only:
 - `--fixture <case-id>`
 - `--model <model-slug>`
 - `--output-dir <absolute-path-outside-repository>`
-- `--timeout-ms <positive-integer>` with a conservative default
+- optional `--timeout-ms <positive-integer>`, defaulting to the existing
+  `GENUI_PROVIDER_SETTINGS.timeoutMs`
 
-The output directory must not already exist. The command creates it with mode
-`0700`; retained files use mode `0600`. The command rejects paths inside the
-repository so private model output cannot be committed accidentally.
+The output directory must not already exist, and its parent must already exist.
+The command resolves the parent canonically, rejects parents inside the
+repository (including symlink aliases), then creates the directory exclusively
+with mode `0700`; retained files use mode `0600`. This prevents private model
+output from landing in the checkout accidentally.
 
-The process exits `0` only when the provider succeeds and the existing MoonBit
-path returns classification `success`, `rubric.passed == true`, and
-`session.success == true`. Every other terminal outcome exits nonzero after
-writing `result.json`.
+Fixture, model, timeout, and output-parent validation happen
+before the run directory is created. A failure in that pre-run phase writes one
+diagnostic to stderr and creates no artifact. Once the run directory exists,
+every terminal outcome writes `result.json`. The process exits `0` only when the
+provider succeeds and the existing MoonBit path returns classification
+`success`, `rubric.passed == true`, and `session.success == true`.
 
 ## Provider invocation
 
@@ -122,12 +127,19 @@ runner supplies the complete feasibility prompt on stdin and starts Codex in an
 empty directory below the private run directory. The prompt contains the fixture
 question, capabilities, and normalized dataset but no rubric or expected answer.
 
-At startup the command verifies that the installed `codex exec --help` exposes
-the required flags. It does not compare display strings such as
-`codex-cli 0.144.4` with semantic versions such as `0.144.4`.
+This is not a confidentiality sandbox. Codex `read-only` prevents writes but can
+read host files available to an ordinary local Codex invocation, and tool output
+can be sent to the configured model provider. The command is limited to trusted
+synthetic fixtures and machines where that ordinary Codex access is acceptable.
+Stronger host-read isolation would require the deliberately excluded external
+sandbox.
 
-The parent process enforces the timeout. Timeout or interruption terminates the
-single child and records the terminal outcome; it never retries.
+
+The parent process enforces the timeout over the complete provider process tree,
+not only the direct `codex` child. It sends a graceful tree termination, waits a
+small bounded interval, then force-terminates survivors. Timeout or interruption
+records one terminal outcome and never retries. POSIX process groups and the
+Windows process-tree facility provide the platform-specific mechanism.
 
 ## Data flow
 
@@ -138,18 +150,21 @@ developer command
   -> write private request.json and temporary schema
   -> codex exec once in private empty cwd
   -> provider-events.jsonl + candidate.json
-  -> reject missing, invalid, or >64 KiB candidate
+  -> reject missing, syntactically invalid, or >64 KiB candidate
   -> local Playwright Chromium page
-  -> existing DEV-only commitCandidate hook
+  -> new minimal DEV-only injected-candidate commit hook
   -> existing MoonBit decode/materialize/rubric/replay/session commit
   -> private result.json
   -> exit 0 or nonzero
 ```
 
-The Playwright step uses the existing web-server lifecycle rather than adding a
-custom Vite readiness loop or browser process manager. A local-only Playwright
-entry reads `candidate.json`, calls the DEV-only browser hook, writes the returned
-MoonBit result, and asserts the command success contract.
+The Playwright step follows the existing feasibility dev-server command pattern
+but uses dedicated local-only wiring. It binds to loopback, uses a strict port,
+never reuses an already-running server, disables trace retention, and directs
+all temporary Playwright output below the private run directory. A local-only
+Playwright entry reads `candidate.json`, calls the DEV-only browser hook, and
+writes the returned MoonBit result without reclassifying it. The runner alone
+applies the command success contract so MoonBit failure classifications survive.
 
 ## Private run directory
 
@@ -167,6 +182,10 @@ at the end of the run. Stderr may be included in `result.json` only after a
 small fixed byte cap; inherited environment variables and credential paths are
 never serialized.
 
+Playwright traces, reports, screenshots, and `test-results` must not be written
+inside the repository. Temporary Playwright output is deleted before the final
+four-file contract is checked.
+
 No digest graph, manifest, journal, redacted transcript, or aggregate evidence
 is required for a single developer-run E2E check.
 
@@ -175,14 +194,19 @@ is required for a single developer-run E2E check.
 The command needs only boundary-level classifications that change the next
 engineering action:
 
-- `configuration_error`: invalid CLI input, fixture, output path, or unsupported
-  Codex CLI surface.
-- `provider_timeout`: the one provider process exceeded its deadline.
-- `provider_failed`: Codex exited nonzero or without a final message.
+- `configuration_error`: a pre-run invalid CLI input, fixture, or output parent.
+  It is reported on stderr because no safe run directory exists yet.
+- `provider_timeout`: the sole provider generation process exceeded its deadline.
+- `provider_failed`: Codex could not start, rejected its options, was interrupted,
+  exited nonzero, or produced no final message.
 - `candidate_oversize`: final output exceeded the existing 64 KiB limit.
-- `candidate_invalid`: final output was not a JSON value accepted by the
-  candidate boundary.
-- `materialization_error`, `rubric_failure`, `replay_mismatch`, and
+- `candidate_invalid`: final output was not syntactically valid JSON. The runner
+  does not duplicate MoonBit semantic candidate validation.
+- `browser_failed`: the dedicated Playwright process could not return one
+  parseable MoonBit result.
+- `candidate_decode_error`, `capability_decode_error`,
+  `candidate_validation_error`, `dataset_decode_error`,
+  `materialization_error`, `rubric_failure`, `replay_mismatch`, and
   `commit_failure`: preserved unchanged from the existing MoonBit result.
 - `success`: rubric and session commit both succeeded.
 
@@ -192,19 +216,23 @@ There is no global-stop taxonomy because one invocation owns one attempt.
 
 Tests defend only observable behavior needed by the command:
 
-1. CLI parsing rejects missing/invalid fixture, model, timeout, and unsafe
-   output paths before provider invocation.
-2. Provider arguments use the required supported Codex flags, existing prompt,
-   generated schema, selected model, and exactly one process invocation.
-3. Timeout terminates the child and writes a non-success `result.json` without a
-   retry.
-4. Missing, malformed, and oversized final output never reaches the browser.
+1. CLI parsing rejects missing/invalid fixture, model, or output parent and
+   invalid timeout values, non-canonical paths, repository-internal parents,
+   and symlink aliases before provider invocation or artifact creation; omitted
+   timeout uses the existing default.
+2. The sole provider generation process receives the required Codex flags,
+   existing prompt, generated schema, and selected model.
+3. Timeout terminates an orphan-prone fake provider's complete process tree and
+   writes a non-success `result.json` without a retry.
+4. Missing, malformed, and oversized final output never reaches the browser;
+   syntactically valid schema failures remain owned by MoonBit.
 5. A fake provider candidate traverses the real browser/MoonBit path and commits
    successfully.
-6. Each existing MoonBit failure classification produces nonzero exit and is
+6. Every existing MoonBit failure classification produces nonzero exit and is
    retained unchanged.
-7. The run directory contains only the four documented durable files, with
-   `candidate.json` absent when no candidate exists.
+7. The completed run directory contains only the four documented durable files,
+   with `candidate.json` absent when no candidate exists and no Playwright output
+   retained in the repository.
 8. A local opt-in smoke proves one real `codex exec` invocation can produce and
    commit a candidate. It is never part of CI.
 
@@ -245,8 +273,9 @@ not a runtime dependency and may not be imported or vendored.
 - A successful provider output reaches the real MoonBit materialization, rubric,
   replay, and session-commit path.
 - The command exits zero only for a passing rubric and successful commit.
-- A failed boundary writes one private `result.json` and exits nonzero without
-  retry.
+- After safe run-directory creation, a failed boundary writes one private
+  `result.json` and exits nonzero without retry. Pre-run validation failures
+  create no artifact.
 - The private run directory follows the four-file contract and remains outside
   the repository.
 - No provider comparison, App Server client, bubblewrap contract, scheduler,

--- a/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md
+++ b/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md
@@ -1,0 +1,255 @@
+# Generative UI minimal provider E2E design
+
+**Status:** Proposed
+
+**Issue:** #896
+
+## Purpose
+
+Provide one reusable local developer command that asks one configured provider
+to generate one Generative UI candidate, sends that candidate through the
+existing MoonBit materialization, rubric, replay, and session-commit path, and
+retains enough private evidence to diagnose the run.
+
+The command answers one technical question:
+
+> Can this provider produce a candidate that the existing Canopy pipeline
+> accepts and commits for this fixture?
+
+It does not compare providers, establish reliability rates, or measure user
+value.
+
+## Value gate
+
+- **Consumer:** a Canopy maintainer deciding whether a provider can traverse the
+  existing candidate pipeline at all.
+- **Success signal:** one invocation ends with a MoonBit result classified as
+  `success`, a passing rubric, and a successful session commit.
+- **Lifecycle:** a reusable, local-only developer command. It is not a CI gate,
+  production API, or permanent provider abstraction.
+- **Decision:** a successful run permits another technical iteration. A failed
+  run identifies the first provider, decode, materialization, rubric, replay, or
+  commit boundary that rejected the candidate. Neither outcome establishes
+  Generative UI usefulness.
+
+## Scope
+
+### In
+
+- Codex as the first provider, invoked through the supported non-interactive
+  `codex exec` command.
+- One existing synthetic feasibility fixture per invocation.
+- Configurable model.
+- Exactly one `codex exec` turn per invocation; the runner performs no retry. A
+  developer may start a new run explicitly.
+- Existing prompt construction, candidate schema, fixture data, MoonBit
+  materialization, rubric, replay, and session commit.
+- A private run directory containing the request, provider event stream,
+  candidate when produced, and final result.
+- A bounded provider timeout and process termination.
+
+### Out
+
+- Codex App Server protocol implementation or thread reuse.
+- Ollama diagnosis or any second provider.
+- Provider comparison, randomized schedules, repeated slots, Stage 1/2, or
+  aggregate statistics.
+- Immutable manifests, journals, finalizers, qualification thresholds, or
+  recommendation generation.
+- Exact CLI display-version or model-catalog identity freezing.
+- Bubblewrap or a benchmark-specific external sandbox.
+- Automatic retry, replacement request, or resume.
+- Production/public provider endpoints, browser credentials, CI credentials, or
+  deployment.
+- Target-user recruitment, fixed-UI comparison, or product-value claims.
+
+## Existing boundaries reused
+
+The minimal command reuses rather than duplicates:
+
+- `GENUI_CANDIDATE_SCHEMA` from
+  `examples/web/src/genui-candidate-schema.js`.
+- `buildFeasibilityPrompt`, `GENUI_PROVIDER_SETTINGS.maxCandidateBytes`, and
+  canonical JSON utilities from
+  `examples/web/src/genui-feasibility-provider.js`.
+- Existing fixture lookup and normalized capability/dataset JSON from
+  `examples/web/src/genui-feasibility-fixtures.js`.
+- `runFeasibilityCandidate` from
+  `examples/web/src/genui-feasibility-flow.js`.
+- The existing browser-loaded MoonBit evaluator and session commit path in
+  `examples/web/src/genui.js`.
+- The existing Playwright web-server configuration and Chromium dependency.
+
+No general provider interface is introduced. A second live provider is required
+before a shared provider abstraction can be justified.
+
+## Command contract
+
+The developer command accepts only:
+
+- `--fixture <case-id>`
+- `--model <model-slug>`
+- `--output-dir <absolute-path-outside-repository>`
+- `--timeout-ms <positive-integer>` with a conservative default
+
+The output directory must not already exist. The command creates it with mode
+`0700`; retained files use mode `0600`. The command rejects paths inside the
+repository so private model output cannot be committed accidentally.
+
+The process exits `0` only when the provider succeeds and the existing MoonBit
+path returns classification `success`, `rubric.passed == true`, and
+`session.success == true`. Every other terminal outcome exits nonzero after
+writing `result.json`.
+
+## Provider invocation
+
+Use the supported `codex exec` surface instead of implementing App Server JSONL:
+
+- `--ephemeral` avoids persisted Codex session files.
+- `--ignore-user-config` and `--ignore-rules` remove mutable execution policy
+  from the experiment. Authentication remains available through `CODEX_HOME`.
+- `--skip-git-repo-check` allows execution in an isolated empty working
+  directory.
+- `--sandbox read-only` prevents model-generated commands from writing.
+- `--model` selects the requested model.
+- `--output-schema` points to a temporary JSON file generated from the existing
+  `GENUI_CANDIDATE_SCHEMA`; no duplicate schema is committed.
+- `--output-last-message` writes the final candidate JSON.
+- `--json` emits the provider event stream for private diagnosis.
+
+`codex exec` is headless and therefore uses no interactive approval prompts. The
+runner supplies the complete feasibility prompt on stdin and starts Codex in an
+empty directory below the private run directory. The prompt contains the fixture
+question, capabilities, and normalized dataset but no rubric or expected answer.
+
+At startup the command verifies that the installed `codex exec --help` exposes
+the required flags. It does not compare display strings such as
+`codex-cli 0.144.4` with semantic versions such as `0.144.4`.
+
+The parent process enforces the timeout. Timeout or interruption terminates the
+single child and records the terminal outcome; it never retries.
+
+## Data flow
+
+```text
+developer command
+  -> resolve existing fixture
+  -> build existing feasibility prompt
+  -> write private request.json and temporary schema
+  -> codex exec once in private empty cwd
+  -> provider-events.jsonl + candidate.json
+  -> reject missing, invalid, or >64 KiB candidate
+  -> local Playwright Chromium page
+  -> existing DEV-only commitCandidate hook
+  -> existing MoonBit decode/materialize/rubric/replay/session commit
+  -> private result.json
+  -> exit 0 or nonzero
+```
+
+The Playwright step uses the existing web-server lifecycle rather than adding a
+custom Vite readiness loop or browser process manager. A local-only Playwright
+entry reads `candidate.json`, calls the DEV-only browser hook, writes the returned
+MoonBit result, and asserts the command success contract.
+
+## Private run directory
+
+A completed or failed run retains at most these durable files:
+
+- `request.json`: fixture ID, model, timeout, invocation timestamp, and the
+  exact prompt. It contains no credential or environment dump.
+- `provider-events.jsonl`: exact stdout events emitted by `codex exec --json`.
+- `candidate.json`: the final message, only when Codex produced one.
+- `result.json`: duration, provider exit/signal, terminal classification, and the
+  returned MoonBit evaluation/commit result when reached.
+
+The temporary output-schema file and empty Codex working directory are deleted
+at the end of the run. Stderr may be included in `result.json` only after a
+small fixed byte cap; inherited environment variables and credential paths are
+never serialized.
+
+No digest graph, manifest, journal, redacted transcript, or aggregate evidence
+is required for a single developer-run E2E check.
+
+## Failure classifications
+
+The command needs only boundary-level classifications that change the next
+engineering action:
+
+- `configuration_error`: invalid CLI input, fixture, output path, or unsupported
+  Codex CLI surface.
+- `provider_timeout`: the one provider process exceeded its deadline.
+- `provider_failed`: Codex exited nonzero or without a final message.
+- `candidate_oversize`: final output exceeded the existing 64 KiB limit.
+- `candidate_invalid`: final output was not a JSON value accepted by the
+  candidate boundary.
+- `materialization_error`, `rubric_failure`, `replay_mismatch`, and
+  `commit_failure`: preserved unchanged from the existing MoonBit result.
+- `success`: rubric and session commit both succeeded.
+
+There is no global-stop taxonomy because one invocation owns one attempt.
+
+## Required tests
+
+Tests defend only observable behavior needed by the command:
+
+1. CLI parsing rejects missing/invalid fixture, model, timeout, and unsafe
+   output paths before provider invocation.
+2. Provider arguments use the required supported Codex flags, existing prompt,
+   generated schema, selected model, and exactly one process invocation.
+3. Timeout terminates the child and writes a non-success `result.json` without a
+   retry.
+4. Missing, malformed, and oversized final output never reaches the browser.
+5. A fake provider candidate traverses the real browser/MoonBit path and commits
+   successfully.
+6. Each existing MoonBit failure classification produces nonzero exit and is
+   retained unchanged.
+7. The run directory contains only the four documented durable files, with
+   `candidate.json` absent when no candidate exists.
+8. A local opt-in smoke proves one real `codex exec` invocation can produce and
+   commit a candidate. It is never part of CI.
+
+Existing MoonBit package tests, TypeScript checks, development browser tests, and
+production build remain the verification gates for the unchanged product path.
+
+## Expected implementation surface
+
+The design should require approximately four to six changed files:
+
+- one minimal CLI runner;
+- one focused runner test;
+- one local-only Playwright E2E entry or extension;
+- the smallest DEV-only browser hook needed to commit an injected candidate;
+- optional package script/config wiring;
+- this design and its later implementation plan.
+
+The target is roughly 250–450 production lines and 200–350 test lines. This is a
+planning constraint, not a reason to omit a required failure path. If the design
+requires a protocol client, scheduler, manifest builder, or finalizer, stop and
+re-evaluate the boundary instead of recreating PR #906.
+
+## Preservation and migration
+
+PR #906 is closed without merge. Its complete implementation remains on remote
+branch `feat/genui-provider-comparison-implementation` at
+`fb28b9812385e5a999e3a688b96f86d93a177916` as historical reference.
+
+The minimal implementation starts from `main`. It may copy a small reviewed
+function only when the same responsibility is required by this design; it does
+not cherry-pick comparison commits wholesale. The remote historical branch is
+not a runtime dependency and may not be imported or vendored.
+
+## Acceptance criteria
+
+- One documented local command performs exactly one Codex request for one
+  existing fixture.
+- A successful provider output reaches the real MoonBit materialization, rubric,
+  replay, and session-commit path.
+- The command exits zero only for a passing rubric and successful commit.
+- A failed boundary writes one private `result.json` and exits nonzero without
+  retry.
+- The private run directory follows the four-file contract and remains outside
+  the repository.
+- No provider comparison, App Server client, bubblewrap contract, scheduler,
+  manifest, journal, finalizer, or aggregate evidence implementation is added.
+- No production provider API, CI credential, user-value claim, or `Closes #896`
+  relationship is introduced.

--- a/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-implementation.md
+++ b/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-implementation.md
@@ -416,6 +416,7 @@ Select one literal model slug from the locally authenticated Codex catalog befor
 ```bash
 : "${XDG_STATE_HOME:?XDG_STATE_HOME must be set}"
 : "${MODEL_SLUG:?MODEL_SLUG must be selected before the smoke}"
+mkdir -p "$XDG_STATE_HOME/canopy/genui-minimal-provider-e2e"
 RUN_DIR="$XDG_STATE_HOME/canopy/genui-minimal-provider-e2e/$(date -u +%Y%m%dT%H%M%SZ)"
 test ! -e "$RUN_DIR"
 cd examples/web

--- a/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-implementation.md
+++ b/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-implementation.md
@@ -1,0 +1,446 @@
+# Generative UI minimal provider E2E implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task. Protocol and process-lifecycle algorithms remain in the main context. Use `test-driven-development` and `verification-before-completion` throughout.
+
+**Status:** Proposed
+
+**Goal:** Add one reusable local command that makes exactly one Codex generation request for one existing synthetic fixture and accepts it only after the existing MoonBit materialization, rubric, replay, and session-commit path succeeds.
+
+**Architecture:** One Node command validates its four inputs, creates one private run directory, executes one ephemeral `codex exec` generation process, then passes the opaque candidate to a dedicated Playwright adapter. The adapter calls a minimal DEV-only hook around the existing `commitFeasibilityCandidate`; it does not reproduce candidate validation or MoonBit result semantics. All terminal outcomes after run-directory creation converge on one `result.json` write and cleanup removes temporary schema, working-directory, browser-result, and Playwright files.
+
+**Tech stack:** Node.js ESM and `node:test`, Codex CLI `exec`, Playwright Chromium, Vite DEV hook, existing MoonBit JavaScript build.
+
+## Global constraints
+
+- Implement `docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md` without broadening its claim boundary.
+- One invocation owns one fixture, one model, one provider generation process, no retry, and no provider comparison.
+- The command accepts only `--fixture`, `--model`, `--output-dir`, and optional `--timeout-ms`; omission reuses `GENUI_PROVIDER_SETTINGS.timeoutMs`.
+- The output directory is new, mode `0700`, canonically outside the repository; durable files are mode `0600`.
+- Durable files are only `request.json`, `provider-events.jsonl`, optional `candidate.json`, and `result.json`.
+- Use the existing `GENUI_CANDIDATE_SCHEMA`, `buildFeasibilityPrompt`, `GENUI_PROVIDER_SETTINGS.maxCandidateBytes`, `getFeasibilityFixture`, `recordedDemoInput`, `runFeasibilityCandidate`, and `commitFeasibilityCandidate` paths. Do not add a second validator.
+- `codex exec` uses `--ephemeral`, `--ignore-user-config`, `--ignore-rules`, `--skip-git-repo-check`, `--sandbox read-only`, `--model`, `--output-schema`, `--output-last-message`, and `--json`; no `--help` preflight is allowed.
+- Timeout and interruption terminate the complete child process tree with bounded graceful-then-force escalation and never start another provider process.
+- The runner exits `0` only for `classification === 'success'`, `rubric.passed === true`, and `session.success === true`.
+- The runner never retains Playwright output in the repository.
+- The real credentialed smoke is exactly one provider request, only after deterministic tests and independent different-model review pass. A failed smoke is retained and is not retried.
+- One file per edit call. Run `NEW_MOON_MOD=0 moon check` after every project-file edit.
+- Do not modify, rerun, or replace PR #902 evidence, PR #906 comparison code, the permanent request-lifecycle/replay design, or Gate A target-user work.
+
+## File responsibility map
+
+- `examples/web/src/genui.js`: expose only the DEV-only injected-candidate commit hook; existing commit semantics remain private and authoritative.
+- `examples/web/playwright.minimal-provider.config.ts`: isolate the dedicated browser process, fixed private output root, no trace, no reuse of an existing server.
+- `examples/web/tests/genui-minimal-provider.spec.ts`: bridge one candidate file to the DEV hook and write one browser result file; contain no provider logic.
+- `examples/web/scripts/run-genui-minimal-provider-e2e.mjs`: own CLI validation, private artifacts, exact Codex process lifecycle, candidate byte/JSON checks, Playwright lifecycle, terminal classification, and final cleanup.
+- `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`: defend runner boundaries with fake processes and temporary directories.
+- `examples/web/package.json`: expose the local developer command only.
+
+---
+
+### Task 1: Minimal browser commit adapter
+
+**Files:**
+- Modify: `examples/web/src/genui.js:366-394`
+- Create: `examples/web/playwright.minimal-provider.config.ts`
+- Create: `examples/web/tests/genui-minimal-provider.spec.ts`
+
+**Interfaces:**
+- Consumes: `recordedDemoInput(caseId)`, `resetSlotSession()`, and `commitFeasibilityCandidate(candidateJson, input)` already in `genui.js`.
+- Produces: `window.__canopyGenUiFeasibilityTest.commitSavedCandidate({ caseId, candidateJson }) -> Promise<MoonBitResult>` and a Playwright process contract using `GENUI_MINIMAL_PROVIDER_RUN_DIR`, `GENUI_MINIMAL_PROVIDER_CANDIDATE`, `GENUI_MINIMAL_PROVIDER_FIXTURE`, and `GENUI_MINIMAL_PROVIDER_BROWSER_RESULT`.
+
+- [ ] **Step 1: Write the failing Playwright adapter test**
+
+Create `tests/genui-minimal-provider.spec.ts`. Require all four environment variables before the test starts. The test must:
+
+1. load `/genui.html`;
+2. wait until `window.__canopyGenUiFeasibilityTest` exists;
+3. read candidate bytes from `GENUI_MINIMAL_PROVIDER_CANDIDATE` without parsing or modifying them in Node;
+4. call `commitSavedCandidate({ caseId, candidateJson })` in the page;
+5. exclusively create `GENUI_MINIMAL_PROVIDER_BROWSER_RESULT` with mode `0600` and the exact returned JSON;
+6. assert only that the returned value has a string `classification`, leaving success/failure interpretation to the runner.
+
+Declare the browser-side type locally in the test; do not change a production public type.
+
+- [ ] **Step 2: Run the test and observe the missing hook**
+
+Run from `examples/web` with a temporary external run directory and an existing recorded candidate copied into it:
+
+```bash
+GENUI_MINIMAL_PROVIDER_RUN_DIR="$RUN_DIR" \
+GENUI_MINIMAL_PROVIDER_CANDIDATE="$RUN_DIR/candidate.json" \
+GENUI_MINIMAL_PROVIDER_FIXTURE=orders-pending-attention \
+GENUI_MINIMAL_PROVIDER_BROWSER_RESULT="$RUN_DIR/browser-result.json" \
+npx playwright test --config=playwright.minimal-provider.config.ts --project=chromium
+```
+
+Expected: FAIL because `commitSavedCandidate` is absent.
+
+- [ ] **Step 3: Add the smallest DEV-only hook**
+
+Inside the existing frozen `window.__canopyGenUiFeasibilityTest` object add exactly this responsibility:
+
+```js
+async commitSavedCandidate({ caseId, candidateJson }) {
+  await resetSlotSession()
+  return commitFeasibilityCandidate(candidateJson, recordedDemoInput(caseId))
+},
+```
+
+Do not add provider calls, result reinterpretation, rendering, or production exports.
+
+- [ ] **Step 4: Add the dedicated Playwright config**
+
+The config must use `tests/genui-minimal-provider.spec.ts`, `retries: 0`, `fullyParallel: false`, one Chromium project, and `trace: 'off'`. Resolve `GENUI_MINIMAL_PROVIDER_RUN_DIR` canonically and set `outputDir` below it. Start `moon build --target js && npx vite --host 127.0.0.1 --port 4176 --strictPort`, use `http://127.0.0.1:4176`, and set `reuseExistingServer: false`. Throw during config load if the run root is absent or not absolute.
+
+- [ ] **Step 5: Verify the real MoonBit commit path**
+
+Re-run Step 2.
+
+Expected: PASS; `browser-result.json` contains `classification: "success"`, `rubric.passed: true`, and `session.success: true` for the recorded candidate.
+
+Then run:
+
+```bash
+cd ../..
+NEW_MOON_MOD=0 moon check
+```
+
+Expected: 0 errors; existing vendored warnings are allowed.
+
+- [ ] **Step 6: Commit the browser adapter**
+
+```bash
+git add examples/web/src/genui.js examples/web/playwright.minimal-provider.config.ts examples/web/tests/genui-minimal-provider.spec.ts
+git commit -m "feat(genui): expose minimal provider commit adapter"
+```
+
+---
+
+### Task 2: CLI and private artifact boundary
+
+**Files:**
+- Create: `examples/web/scripts/run-genui-minimal-provider-e2e.mjs`
+- Create: `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`
+
+**Interfaces:**
+- Produces: `parseMinimalProviderArgs(argv, { repositoryRoot }) -> { fixtureId, fixture, model, outputDir, timeoutMs }`.
+- Produces: `createPrivateRun(options, deps) -> { paths, request }`, where `paths` names the four durable paths plus private temporary paths.
+- Produces: `writeTerminalResult(run, terminal) -> Promise<void>` using exclusive creation of `result.json`.
+- Later tasks extend `runMinimalProviderE2E(options, deps) -> Promise<{ exitCode, result }>` without changing these contracts.
+
+- [ ] **Step 1: Write failing CLI and path-safety tests**
+
+Use `node:test`, `mkdtemp`, `realpath`, and temporary symlinks. Cover:
+
+- missing fixture/model/output flags, duplicate or unknown flags, empty model, unknown fixture, zero/negative/non-integer timeout, and omitted timeout resolving to `GENUI_PROVIDER_SETTINGS.timeoutMs`;
+- relative output path, existing output path, missing parent, repository descendant, `..` alias, and symlink alias into the repository;
+- a canonical absolute external child whose parent exists;
+- failure before run creation creates no directory and calls no provider dependency.
+
+Each rejection must assert the stable `configuration_error` code and one diagnostic, not incidental Node error text.
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+```bash
+cd examples/web
+node --test --test-name-pattern='CLI|output path|pre-run' scripts/run-genui-minimal-provider-e2e.test.mjs
+```
+
+Expected: FAIL because the runner module does not exist.
+
+- [ ] **Step 3: Implement deterministic pre-run validation**
+
+Use `path.resolve`, `path.isAbsolute`, `fs.realpath`, `fs.stat`, and `path.relative`. Preserve these invariants:
+
+- parse alternating flag/value pairs; fixture, model, and output appear exactly once, timeout appears at most once, and omission uses `GENUI_PROVIDER_SETTINGS.timeoutMs`;
+- compare the supplied absolute output path with `join(realpath(parent), basename(outputDir))`; inequality rejects `..` and symlink aliases;
+- repository containment is true only when `relative(repositoryRoot, candidate)` is empty or is neither absolute nor prefixed by `..${sep}`;
+- call `getFeasibilityFixture` only after lexical CLI shape is valid;
+- create the run directory with `mkdir(outputDir, { recursive: false, mode: 0o700 })` only after every pre-run check succeeds.
+
+Do not probe Codex with `--help` or any other process.
+
+- [ ] **Step 4: Write failing artifact-contract tests**
+
+Assert:
+
+- run directory mode is `0700` and every durable file mode is `0600` after masking to permission bits;
+- `request.json` contains schema version, fixture ID, model slug, timeout, invocation timestamp, expected provider invocation count `1`, the exact prompt, prompt SHA-256, and schema SHA-256; it contains no credential, environment dump, or candidate bytes;
+- a terminal write is exclusive and exactly once;
+- cleanup leaves exactly `request.json`, `provider-events.jsonl`, optional `candidate.json`, and `result.json`;
+- no artifact path is inside the repository.
+
+- [ ] **Step 5: Implement private paths and convergent finalization**
+
+Use `crypto.createHash`, `fs.open(..., 'wx', 0o600)`, `FileHandle.writeFile`, and `fs.rm`. `request.json` and `provider-events.jsonl` are created before provider execution. Temporary schema, empty working directory, Playwright output, and browser-result paths live below the run directory but are always removed in `finally` before the exclusive `result.json` write. If cleanup itself fails, replace the pending terminal result with `browser_failed` and include only a bounded safe message.
+
+- [ ] **Step 6: Verify and commit the boundary**
+
+```bash
+node --test --test-name-pattern='CLI|output path|pre-run|artifact|final' scripts/run-genui-minimal-provider-e2e.test.mjs
+cd ../..
+NEW_MOON_MOD=0 moon check
+git add examples/web/scripts/run-genui-minimal-provider-e2e.mjs examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+git commit -m "feat(genui): add private minimal E2E boundary"
+```
+
+Expected: focused Node tests pass; MoonBit check reports 0 errors.
+
+---
+
+### Task 3: Single provider process lifecycle
+
+**Files:**
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.mjs`
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`
+
+**Interfaces:**
+- Produces: `runProviderAttempt(run, options, deps) -> Promise<{ classification, exitCode, signal, timedOut, interrupted, invocationCount }>`; every `result.json` records the observed `invocationCount`.
+- Dependency seams: `deps.spawnProcess(command, args, options)` defaults to `node:child_process.spawn`; `deps.providerInvocation` defaults to `{ command: 'codex', prefixArgs: [] }`; `deps.platform` defaults to `process.platform`; `deps.kill` defaults to `process.kill`. Tests may replace these values, but the CLI exposes no executable override.
+
+- [ ] **Step 1: Write the exact-invocation failing test**
+
+Capture the one provider spawn and assert:
+
+- command is `codex`;
+- arguments contain one `exec`, the prompt is supplied on stdin, and the required flags from Global Constraints each appear exactly once;
+- `--output-schema` and `--output-last-message` point below the run directory;
+- `cwd` is the empty private working directory;
+- environment preserves `CODEX_HOME` but sets no repository path or inherited prompt/rule override;
+- stdout is the already-open `provider-events.jsonl` descriptor;
+- the spawn count remains exactly one on nonzero exit and malformed output.
+
+- [ ] **Step 2: Write the process-tree timeout failing test**
+
+Use a temporary Node fake provider that spawns a grandchild heartbeat process and never exits. Assert that after a short timeout:
+
+- the provider and grandchild are both gone using a positive liveness probe before timeout and a negative probe after escalation;
+- classification is `provider_timeout`;
+- `result.json` is non-success;
+- provider spawn count is one;
+- no candidate or browser invocation exists.
+
+Add a separate injected interruption test that expects `provider_failed`, one process-tree termination, and no retry.
+
+- [ ] **Step 3: Implement the process state machine**
+
+Maintain one monotonic state: `not_started -> running -> terminating -> exited`. Only the `not_started -> running` edge may call `spawnProcess`.
+
+On POSIX, spawn the provider detached and signal the negative process-group PID. On Windows, use the native `taskkill /PID <pid> /T` tree facility and add `/F` only after the bounded grace interval. In either platform:
+
+1. request graceful termination once;
+2. race child exit against the grace timer;
+3. force-terminate only surviving trees;
+4. await the direct child exit before finalization;
+5. ignore only `ESRCH` after an observed exit; propagate all other termination errors as `provider_failed`.
+
+Provider timeout starts immediately after successful spawn and is cleared exactly once on exit. CLI `SIGINT`/`SIGTERM` handlers call the same termination path and are removed in `finally`.
+
+- [ ] **Step 4: Verify no orphan and no retry**
+
+```bash
+cd examples/web
+node --test --test-name-pattern='provider|timeout|interrupt|process tree|retry' scripts/run-genui-minimal-provider-e2e.test.mjs
+cd ../..
+NEW_MOON_MOD=0 moon check
+```
+
+Expected: all focused tests pass; the fake grandchild liveness assertion proves the detector before proving termination; MoonBit check reports 0 errors.
+
+- [ ] **Step 5: Commit the provider lifecycle**
+
+```bash
+git add examples/web/scripts/run-genui-minimal-provider-e2e.mjs examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+git commit -m "feat(genui): enforce one provider process tree"
+```
+
+---
+
+### Task 4: Candidate and MoonBit result orchestration
+
+**Files:**
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.mjs`
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`
+
+**Interfaces:**
+- Produces: `classifyCandidate(candidatePath, maxBytes) -> Promise<{ classification } | { candidateJson, bytes }>`.
+- Produces: `evaluateInBrowser(run, options, deps) -> Promise<MoonBitResult>` by invoking the dedicated Playwright config once.
+- Completes: `runMinimalProviderE2E(options, deps) -> Promise<{ exitCode, result }>`.
+
+- [ ] **Step 1: Write the failing candidate-boundary table**
+
+Table-drive absent output, empty output, malformed JSON, invalid UTF-8, exactly 64 KiB, and 64 KiB plus one byte. Assert:
+
+- absent/empty becomes `provider_failed`;
+- malformed or invalid UTF-8 becomes `candidate_invalid`;
+- oversize becomes `candidate_oversize`;
+- none invokes the browser;
+- syntactically valid schema-invalid JSON does invoke the browser and preserves MoonBit `candidate_validation_error`.
+
+Do not assert a Node-side schema decision.
+
+- [ ] **Step 2: Write the failing MoonBit-result table**
+
+Feed each existing classification named in the design through an injected browser evaluator. Assert byte-for-byte classification preservation and nonzero exit. Add malformed/absent browser result cases expecting `browser_failed`. Assert success exits zero only for the triple condition; `success` with failed rubric or session is nonzero and retains the returned result fields.
+
+- [ ] **Step 3: Implement candidate checks and Playwright invocation**
+
+Use `stat.size` before reading, `TextDecoder('utf-8', { fatal: true })`, then `JSON.parse` only to establish syntactic JSON. Pass the original decoded string unchanged to Playwright.
+
+Spawn exactly one dedicated Playwright process with the four environment variables from Task 1. Capture its stdout/stderr only in bounded memory for a safe failure message. Await process exit, exclusively read and parse the browser-result file, and then delete browser-result and Playwright output in final cleanup. Never write trace, screenshots, reports, or results under `examples/web`.
+
+- [ ] **Step 4: Complete terminal orchestration**
+
+Implement this ordered decision table without fallthrough or retry:
+
+1. pre-run rejection: stderr only, no directory;
+2. provider timeout/failure: finalize immediately;
+3. missing/malformed/oversized candidate: finalize immediately;
+4. browser process/result failure: `browser_failed`;
+5. MoonBit result: preserve classification and fields;
+6. compute `exitCode = 0` only from the success triple;
+7. cleanup temporary entries;
+8. write exactly one `result.json`.
+
+- [ ] **Step 5: Run the complete deterministic Node suite**
+
+```bash
+cd examples/web
+node --test scripts/run-genui-minimal-provider-e2e.test.mjs
+cd ../..
+NEW_MOON_MOD=0 moon check
+```
+
+Expected: all tests pass; MoonBit check reports 0 errors.
+
+- [ ] **Step 6: Commit orchestration**
+
+```bash
+git add examples/web/scripts/run-genui-minimal-provider-e2e.mjs examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+git commit -m "feat(genui): commit provider candidates through MoonBit"
+```
+
+---
+
+### Task 5: End-to-end fake provider and developer command
+
+**Files:**
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`
+- Modify: `examples/web/package.json:5-11`
+
+**Interfaces:**
+- Produces: `npm run genui:minimal-provider-e2e -- --fixture "$FIXTURE_ID" --model "$MODEL_SLUG" --output-dir "$ABSOLUTE_OUTPUT_DIR" --timeout-ms "$TIMEOUT_MS"`.
+
+- [ ] **Step 1: Write the failing real-browser integration test**
+
+The test creates a temporary Node fake provider that accepts the production Codex argument shape, copies the existing recorded `orders-pending-attention` candidate to the `--output-last-message` path, and emits one valid JSONL event. Invoke `runMinimalProviderE2E` with `providerInvocation: { command: process.execPath, prefixArgs: [fakeProviderPath] }`; use the real dedicated Playwright evaluator.
+
+Assert:
+
+- one provider process;
+- the real browser hook returns `classification: "success"`, `rubric.passed: true`, and `session.success: true`;
+- exit code is zero;
+- the completed directory contains exactly the four durable files;
+- no `examples/web/test-results` or other repository Playwright output exists.
+
+Name the test `fake provider traverses real browser and MoonBit commit path` so it can run alone.
+
+- [ ] **Step 2: Run the integration test and confirm its initial failure**
+
+```bash
+cd examples/web
+node --test --test-name-pattern='fake provider traverses real browser' scripts/run-genui-minimal-provider-e2e.test.mjs
+```
+
+Expected: FAIL until default browser evaluation and command wiring are complete.
+
+- [ ] **Step 3: Add the package command**
+
+Add exactly:
+
+```json
+"genui:minimal-provider-e2e": "node scripts/run-genui-minimal-provider-e2e.mjs"
+```
+
+Do not add CI credentials or an automatic real-provider test.
+
+- [ ] **Step 4: Verify the uncredentialed end-to-end path**
+
+Run the Task 5 integration test again, then:
+
+```bash
+node --test scripts/run-genui-minimal-provider-e2e.test.mjs
+npx tsc --noEmit
+npm run build
+npx playwright test --config=playwright.preview.config.ts --project=chromium --grep 'local study runner|local provider marker'
+cd ../..
+NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/jsx
+NEW_MOON_MOD=0 moon check
+NEW_MOON_MOD=0 moon info
+NEW_MOON_MOD=0 moon fmt
+```
+
+Expected: deterministic runner, TypeScript, production build, existing browser contracts, affected MoonBit tests, and check all pass; no root `.mbti` drift.
+
+- [ ] **Step 5: Commit the developer command**
+
+```bash
+git add examples/web/package.json examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+git commit -m "test(genui): prove minimal provider E2E"
+```
+
+---
+
+### Task 6: Independent review and one credentialed smoke
+
+**Files:**
+- No repository files for the smoke output.
+- Raw run: `$XDG_STATE_HOME/canopy/genui-minimal-provider-e2e/<fresh-run-id>/`
+
+**Interfaces:**
+- Consumes the reviewed commit SHA from Tasks 1-5.
+- Produces one retained local run directory and a pass/fail report; it does not produce benchmark evidence or a provider recommendation.
+
+- [ ] **Step 1: Verify clean reviewed state**
+
+Record `git rev-parse HEAD`, require a clean superproject and clean initialized submodules, and confirm no output directory for the fresh run ID exists. Do not use `stash`.
+
+- [ ] **Step 2: Run independent different-model review**
+
+Require exact file:line findings for CLI/path safety, one-process lifecycle, timeout tree termination, artifact convergence, candidate opacity, browser/MoonBit result preservation, and credential isolation. Fix every validated blocker in its own commit, rerun the narrow failing test, then rerun the complete deterministic suite. Record the final reviewed SHA; no credentialed request may use an unreviewed later commit.
+
+- [ ] **Step 3: Execute exactly one real Codex request**
+
+Select one literal model slug from the locally authenticated Codex catalog before entering this gate, then set `MODEL_SLUG` without starting a model turn. Set a fresh absolute output directory below `$XDG_STATE_HOME/canopy/genui-minimal-provider-e2e/` and run one command:
+
+```bash
+: "${XDG_STATE_HOME:?XDG_STATE_HOME must be set}"
+: "${MODEL_SLUG:?MODEL_SLUG must be selected before the smoke}"
+RUN_DIR="$XDG_STATE_HOME/canopy/genui-minimal-provider-e2e/$(date -u +%Y%m%dT%H%M%SZ)"
+test ! -e "$RUN_DIR"
+cd examples/web
+npm run genui:minimal-provider-e2e -- \
+  --fixture orders-pending-attention \
+  --model "$MODEL_SLUG" \
+  --output-dir "$RUN_DIR" \
+  --timeout-ms 120000
+```
+
+Recording the selected slug does not authorize a second request. Never rerun after any failure.
+
+- [ ] **Step 4: Inspect the terminal artifact without changing it**
+
+Check directory/file modes, exact durable filenames, `request.json`, and `result.json`. Report the observed classification, success triple, model slug, observed provider `invocationCount`, and artifact path. Do not infer reliability, provider superiority, or user value from this one run.
+
+- [ ] **Step 5: Final verification and handoff**
+
+Run `git diff --check`, the complete deterministic runner suite, affected MoonBit tests, TypeScript check, production build, and dedicated fake-provider browser test again. Confirm the repository contains no private smoke bytes and report any remaining diff/unpushed commit explicitly.
+
+## Reuse check
+
+- Reused project APIs: `GENUI_CANDIDATE_SCHEMA` for structured output; `buildFeasibilityPrompt` and `GENUI_PROVIDER_SETTINGS.maxCandidateBytes` for the frozen provider boundary; `getFeasibilityFixture` and `recordedDemoInput` for fixture identity/data; `commitFeasibilityCandidate` and `runFeasibilityCandidate` for the unchanged MoonBit preparation/materialization/rubric/replay/session path.
+- Checked but not reused: PR #906 App Server client, bubblewrap sandbox, scheduler, manifest, journal, finalizer, and aggregate evidence. They solve comparison, stronger isolation, or repeated-run lifecycle requirements excluded by this specification.
+- Node core reused: `node:child_process`, `node:crypto`, `node:fs/promises`, `node:path`, `node:process`, `node:test`, and `TextDecoder`; no new runtime package is needed.
+- MoonBit core: no new MoonBit code or data manipulation is introduced. Existing `String`/`StringView`, `Bytes`/`BytesView`, `Array`, `Iter`, `Option`/`Result`, `Map`/`Set`, and buffer APIs remain behind the existing compiled evaluator and are not duplicated in JavaScript.
+- New helpers are private to the runner and limited to CLI/path validation, exclusive private-file writes, process-tree lifecycle, candidate byte/JSON boundary, browser adapter invocation, and convergent finalization.
+- Remaining imperative code is required for filesystem ownership/modes, child-process signaling, timers, signal handlers, and Playwright I/O; all classification decisions are deterministic pure values over observed outcomes.


### PR DESCRIPTION
## Summary

- replace the superseded provider-comparison implementation with one local-only, single-provider Codex E2E experiment design
- preserve the existing MoonBit materialization, rubric, replay, and session-commit path while limiting each invocation to one fixture, one model, one provider process, and no retry
- add a five-task TDD implementation plan with private artifact, process-tree termination, fake-provider browser, and one-shot credentialed smoke gates

## Reuse check

Pure documentation change. The design explicitly reuses `GENUI_CANDIDATE_SCHEMA`, `buildFeasibilityPrompt`, `GENUI_PROVIDER_SETTINGS.maxCandidateBytes`, `getFeasibilityFixture`, `recordedDemoInput`, `runFeasibilityCandidate`, and `commitFeasibilityCandidate`; it introduces no production helper or type.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (existing vendored warnings only)
- [ ] `NEW_MOON_MOD=0 moon test` — not run; documentation-only change
- [x] `.mbti` surface unchanged
- [ ] JS rebuild — not required; no web source changed
- [x] independent different-model review passed after correcting the Playwright preview config

## Validation

```bash
NEW_MOON_MOD=0 moon check
git diff --check
```

Supersedes the implementation direction in #906 without deleting its branch or worktree reference. No provider request was sent.