### PR TITLE
feat(genui): add minimal provider E2E command

### DIFF
--- a/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md
+++ b/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-design.md
@@ -255,6 +255,32 @@ planning constraint, not a reason to omit a required failure path. If the design
 requires a protocol client, scheduler, manifest builder, or finalizer, stop and
 re-evaluate the boundary instead of recreating PR #906.
 
+## Implementation structure refinement
+
+The implementation keeps orchestration in the command runner but extracts the
+provider child-process lifecycle into one private support module. That module
+owns the single spawn, fixed Codex arguments, timeout and interrupt handling,
+whole-process-tree termination, and bounded pipe settlement. The runner retains
+CLI validation, private artifact ownership, candidate classification, browser
+evaluation, and terminal result policy.
+
+This split is organizational, not a provider abstraction. It introduces no
+provider interface, scheduler, retry policy, or second execution path. Existing
+runner exports remain stable for focused tests and the package command remains
+the only user-facing entry point.
+
+The lifecycle module keeps production timing defaults fixed while permitting
+tests to shorten grace periods. At least one real descendant-process test must
+still exercise operating-system process-tree cleanup rather than a fake child.
+The fake-provider browser test continues to pin the unchanged MoonBit
+materialization, rubric, replay, and session-commit boundary.
+
+Implementation verification and live feature validation are reported
+separately. Deterministic tests may establish that the command and unchanged
+pipeline work, but Required test 8 remains unmet until a post-fix credentialed
+run ends with classification `success`, a passing rubric, and a successful
+session commit. No deterministic substitute may be reported as that evidence.
+
 ## Preservation and migration
 
 PR #906 is closed without merge. Its complete implementation remains on remote

--- a/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-refactor-implementation.md
+++ b/docs/plans/2026-07-17-generative-ui-minimal-provider-e2e-refactor-implementation.md
@@ -1,0 +1,132 @@
+# Generative UI minimal provider E2E refactor implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task. The provider process lifecycle remains in the main context because timeout, signal, and process-tree ordering are load-bearing algorithms.
+
+**Goal:** Separate provider child-process lifecycle from command orchestration, shorten deterministic lifecycle tests without weakening the real descendant-process check, and report live validation status accurately.
+
+**Architecture:** The existing command runner remains the only executable entry point and continues to own CLI validation, private artifact creation, candidate classification, browser evaluation, and terminal result policy. One private support module owns the fixed Codex spawn contract, timeout and interrupt state, whole-process-tree termination, and bounded stdout/stderr settlement. Production timing remains unchanged; tests may inject shorter grace periods.
+
+**Tech Stack:** Node.js ESM, `node:test`, Playwright Chromium, existing JavaScript browser adapter, existing MoonBit JSX evaluator.
+
+## Global Constraints
+
+- Send no credentialed provider request during this refactor.
+- Preserve exactly one provider spawn and no retry.
+- Preserve every Codex argument, working-directory, sandbox, and output path.
+- Preserve output directory mode `0700`, durable file mode `0600`, and exclusive writes.
+- Preserve candidate bytes until the existing MoonBit path owns semantic validation.
+- Preserve every MoonBit classification, rubric result, replay result, and session-commit result.
+- Keep the package command and current runner exports stable.
+- Add no provider interface, scheduler, manifest, journal, or production API.
+- Use one file per edit call and run `NEW_MOON_MOD=0 moon check` after every project-file edit.
+- Keep the real Unix descendant-process test; injected fake timers cannot replace it.
+- Report deterministic implementation verification separately from the unmet post-fix credentialed success signal.
+
+---
+
+### Task 1: Pin injectable lifecycle timing
+
+**Files:**
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`
+
+**Interfaces:**
+- Consumes: existing `runProviderAttempt(run, options, deps)` test seam.
+- Produces: a failing contract that `deps.terminationGraceMs` and `deps.outputSettleMs` bound fake-process termination without changing production defaults.
+
+- [ ] **Step 1: Strengthen the fake timeout test before structural changes**
+
+Record elapsed wall time around the existing timeout test. Pass short positive `terminationGraceMs` and `outputSettleMs` dependency values, retain the exact expected `SIGTERM` then `SIGKILL` sequence, and assert completion well below the current five-second production grace. The assertion must fail against the current implementation because it ignores both injected values.
+
+- [ ] **Step 2: Confirm the safety test fails for the intended reason**
+
+Run only `provider timeout kills the process group and settles inherited output`. Expected: the signal assertions still pass, but the new elapsed-time bound fails after the current production grace expires.
+
+- [ ] **Step 3: Re-run the existing structural safety net unchanged**
+
+Run the remaining lifecycle tests individually: exact one invocation, live descendant cleanup, and interrupt without retry. Expected: all pass before extraction. This establishes that the branch starts from the known behavior being moved.
+
+---
+
+### Task 2: Extract the provider process lifecycle
+
+**Files:**
+- Create: `examples/web/scripts/genui-minimal-provider-process.mjs`
+- Modify: `examples/web/scripts/run-genui-minimal-provider-e2e.mjs`
+- Test: `examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs`
+
+**Interfaces:**
+- Consumes: run paths, selected model, timeout, fixed provider invocation descriptor, and injectable process capabilities.
+- Produces: `runProviderProcess(run, options, deps)`, returning the same observed process result and `invocationCount: 1` used by `runProviderAttempt`.
+- Preserves: `runProviderAttempt` as the runner-level export responsible for mapping provider process results to existing terminal classifications.
+
+- [ ] **Step 1: Move process-only behavior verbatim into the support module**
+
+Move the child spawn, fixed Codex arguments, process observation, Unix process-group termination, Windows tree termination, and pipe settlement. Do not move CLI parsing, run-directory ownership, candidate classification, browser invocation, or terminal-result policy. Keep argument order and observable return fields unchanged.
+
+- [ ] **Step 2: Add bounded timing dependencies at the lifecycle boundary**
+
+Use positive internal defaults of 5,000 milliseconds for termination grace and pipe settlement. Accept test-only dependency overrides through the existing dependency object. These values control only waiting; they must not change timeout classification, signal order, invocation count, or production behavior.
+
+- [ ] **Step 3: Delegate from the runner without changing its public contract**
+
+Import the process function and call it from `runProviderAttempt`. Keep `runProviderAttempt` responsible for schema/work preparation, provider terminal classification, candidate presence, and safe messages. Re-export no new package command and introduce no provider-generic interface.
+
+- [ ] **Step 4: Make the red timing contract pass**
+
+Run the focused fake timeout test. Expected: pass quickly with the exact `SIGTERM` and `SIGKILL` sequence.
+
+- [ ] **Step 5: Prove real process-tree cleanup remains effective**
+
+Run the live descendant-process test with a shortened but nonzero injected termination grace. Expected: one spawn, `provider_timeout`, heartbeat observed before termination, and `ESRCH` when probing the grandchild after cleanup.
+
+- [ ] **Step 6: Run the complete deterministic runner suite**
+
+Run `node --test scripts/run-genui-minimal-provider-e2e.test.mjs`. Expected: 18 tests pass, zero failures, with materially lower wall time than the previous approximately 153-second full run when browser build state is warm.
+
+- [ ] **Step 7: Commit the implementation separately from the design**
+
+Commit the support module, runner delegation, and lifecycle test changes as one refactor commit. Do not amend the preceding design commit.
+
+---
+
+### Task 3: Verify unchanged product and evidence boundaries
+
+**Files:**
+- Verify: `examples/web/scripts/genui-minimal-provider-process.mjs`
+- Verify: `examples/web/scripts/run-genui-minimal-provider-e2e.mjs`
+- Verify: `examples/web/tests/genui-minimal-provider.spec.ts`
+- Update remotely: PR #908 description only if its validation wording is ambiguous.
+
+**Interfaces:**
+- Consumes: Task 2 implementation.
+- Produces: deterministic verification evidence and an explicit live-validation status; no credentialed artifact.
+
+- [ ] **Step 1: Run focused and full local verification**
+
+Run the provider unit suite, JSX MoonBit package tests, workspace `moon check`, TypeScript check, production web build, default Web Playwright suite, dedicated fake-provider browser/MoonBit path, and `git diff --check`. Each command must report its own exit status; do not infer success from a piped or wrapped status.
+
+- [ ] **Step 2: Audit the structural boundary**
+
+Confirm the support module imports only Node process/stream primitives and does not import fixtures, candidate schema, browser code, rubric code, or MoonBit adapters. Confirm the runner remains the sole owner of filesystem artifact and browser orchestration policy.
+
+- [ ] **Step 3: Obtain an independent different-model review**
+
+Require exact file-and-line evidence for process ordering, timeout/interrupt terminality, exactly-one invocation, unchanged Codex flags, and the distinction between deterministic verification and live feature validation. Fix every validated blocker and rerun its narrow reproducer.
+
+- [ ] **Step 4: State the unmet live success criterion explicitly**
+
+Ensure PR #908 says the only credentialed invocation failed before generation, the schema was corrected deterministically afterward, no second credentialed request was sent, and Required test 8/design success remains unmet. Do not describe the feature as live-validated or recommend merge on the basis of fake-provider success alone.
+
+- [ ] **Step 5: Push and require green aggregate CI**
+
+Push the refactor commits, run raw `gh pr checks 908`, and require `All Checks Passed` to be `pass`. If any job fails, inspect the failing job output, fix the source problem, and repeat focused verification before pushing.
+
+## Acceptance criteria
+
+- Provider process lifecycle has one focused private module and no generalized provider abstraction.
+- Current CLI, runner exports, Codex arguments, artifact layout, classifications, and exit semantics remain unchanged.
+- Fake timeout and interruption tests finish with injected bounded waits while retaining exact signal and no-retry assertions.
+- A real descendant process is terminated and independently probed as absent.
+- Complete Node, MoonBit, TypeScript, build, browser, and CI checks pass.
+- No credentialed provider request is sent.
+- PR #908 explicitly marks post-fix credentialed success and Required test 8 as unmet.

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "build:deploy": "sh scripts/build-deploy.sh",
     "preview": "vite preview",
-    "signaling": "node signaling-server.js"
+    "signaling": "node signaling-server.js",
+    "genui:minimal-provider-e2e": "node scripts/run-genui-minimal-provider-e2e.mjs"
   },
   "dependencies": {
     "@canopy/editor-adapter": "file:../../adapters/editor-adapter",

--- a/examples/web/playwright.minimal-provider.config.ts
+++ b/examples/web/playwright.minimal-provider.config.ts
@@ -1,0 +1,23 @@
+import { realpathSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import { defineConfig } from '@playwright/test';
+
+const suppliedRoot = process.env.GENUI_MINIMAL_PROVIDER_RUN_DIR;
+if (!suppliedRoot || !isAbsolute(suppliedRoot)) throw new Error('GENUI_MINIMAL_PROVIDER_RUN_DIR must be absolute');
+const runRoot = realpathSync(suppliedRoot);
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: 'genui-minimal-provider.spec.ts',
+  retries: 0,
+  fullyParallel: false,
+  outputDir: join(runRoot, '.playwright'),
+  use: { baseURL: 'http://127.0.0.1:4176', trace: 'off' },
+  webServer: {
+    command: 'moon build --target js && npx vite --host 127.0.0.1 --port 4176 --strictPort',
+    port: 4176,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});

--- a/examples/web/scripts/genui-minimal-provider-process.mjs
+++ b/examples/web/scripts/genui-minimal-provider-process.mjs
@@ -1,0 +1,115 @@
+import { spawn } from 'node:child_process';
+import { finished } from 'node:stream/promises';
+
+const DEFAULT_TERMINATION_GRACE_MS = 5_000;
+const DEFAULT_OUTPUT_SETTLE_MS = 5_000;
+
+export function waitForProcess(child, {
+  timeoutMs,
+  kill,
+  platform,
+  terminateWindowsTree,
+  terminationGraceMs = DEFAULT_TERMINATION_GRACE_MS,
+}) {
+  return new Promise(resolveResult => {
+    let timedOut = false;
+    let interrupted = false;
+    let forceTimer;
+    let settled = false;
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearTimeout(forceTimer);
+      process.off('SIGINT', interrupt);
+      process.off('SIGTERM', interrupt);
+      resolveResult(result);
+    };
+    const signal = name => {
+      if (platform === 'win32') terminateWindowsTree(child.pid, name === 'SIGKILL');
+      else {
+        try { kill(-child.pid, name); } catch { child.kill(name); }
+      }
+    };
+    const terminate = () => {
+      signal('SIGTERM');
+      forceTimer = setTimeout(() => {
+        signal('SIGKILL');
+        finish({ exitCode: null, signal: 'SIGKILL', timedOut, interrupted, error: null });
+      }, terminationGraceMs);
+    };
+    const interrupt = () => {
+      interrupted = true;
+      terminate();
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, timeoutMs);
+    process.once('SIGINT', interrupt);
+    process.once('SIGTERM', interrupt);
+    child.once('error', error => finish({ exitCode: null, signal: null, timedOut, interrupted, error }));
+    child.once('exit', (exitCode, signalName) => {
+      finish({ exitCode, signal: signalName, timedOut, interrupted, error: null });
+    });
+  });
+}
+
+async function settlePipedOutput(child, stream, completion, outputSettleMs) {
+  let timer;
+  const bounded = new Promise(resolveDone => {
+    timer = setTimeout(() => {
+      child.stdout.destroy();
+      stream.destroy();
+      resolveDone();
+    }, outputSettleMs);
+  });
+  await Promise.race([completion.catch(() => undefined), bounded]);
+  clearTimeout(timer);
+}
+
+export async function runProviderProcess(run, options, deps = {}) {
+  const spawnProcess = deps.spawnProcess ?? spawn;
+  const providerInvocation = deps.providerInvocation ?? { command: 'codex', prefixArgs: [] };
+  const platform = deps.platform ?? process.platform;
+  const kill = deps.kill ?? process.kill;
+  const terminationGraceMs = deps.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+  const outputSettleMs = deps.outputSettleMs ?? DEFAULT_OUTPUT_SETTLE_MS;
+  const args = [
+    ...providerInvocation.prefixArgs,
+    'exec',
+    '--json',
+    '--ephemeral',
+    '--ignore-user-config',
+    '--ignore-rules',
+    '--skip-git-repo-check',
+    '--sandbox', 'read-only',
+    '--model', options.model,
+    '--output-schema', run.paths.schema,
+    '--output-last-message', run.paths.candidate,
+    '-',
+  ];
+  const child = spawnProcess(providerInvocation.command, args, {
+    cwd: run.paths.work,
+    detached: platform !== 'win32',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const terminateWindowsTree = deps.terminateWindowsTree ?? ((pid, force) => {
+    const killer = spawn('taskkill', ['/PID', String(pid), '/T', ...(force ? ['/F'] : [])], { stdio: 'ignore' });
+    killer.unref();
+  });
+  const processResult = waitForProcess(child, {
+    timeoutMs: options.timeoutMs,
+    kill,
+    platform,
+    terminateWindowsTree,
+    terminationGraceMs,
+  });
+  const eventsDone = finished(child.stdout.pipe(deps.eventsStream));
+  let stderr = '';
+  child.stderr.on('data', chunk => { stderr += chunk; });
+  child.stdin.end(run.request.prompt);
+  const observed = await processResult;
+  await settlePipedOutput(child, deps.eventsStream, eventsDone, outputSettleMs);
+  return { ...observed, stderr, invocationCount: 1 };
+}

--- a/examples/web/scripts/genui-minimal-provider-process.mjs
+++ b/examples/web/scripts/genui-minimal-provider-process.mjs
@@ -1,8 +1,44 @@
 import { spawn } from 'node:child_process';
-import { finished } from 'node:stream/promises';
+import { performance } from 'node:perf_hooks';
+import { finished, pipeline } from 'node:stream/promises';
 
 const DEFAULT_TERMINATION_GRACE_MS = 5_000;
 const DEFAULT_OUTPUT_SETTLE_MS = 5_000;
+const STDERR_RETAIN_BYTES = 16_384;
+
+function waitWithin(promise, timeoutMs) {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = value => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    Promise.resolve(promise).then(() => finish(true), () => finish(false));
+  });
+}
+
+function terminateWindowsProcessTree(pid, force, timeoutMs) {
+  return new Promise(resolve => {
+    const killer = spawn('taskkill', ['/PID', String(pid), '/T', ...(force ? ['/F'] : [])], { stdio: 'ignore' });
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      killer.kill('SIGKILL');
+      killer.unref();
+      finish();
+    }, timeoutMs);
+    killer.once('error', finish);
+    killer.once('exit', finish);
+  });
+}
 
 export function waitForProcess(child, {
   timeoutMs,
@@ -10,10 +46,11 @@ export function waitForProcess(child, {
   platform,
   terminateWindowsTree,
   terminationGraceMs = DEFAULT_TERMINATION_GRACE_MS,
+  forceTerminationMs = DEFAULT_TERMINATION_GRACE_MS,
 }) {
   return new Promise(resolveResult => {
-    let timedOut = false;
-    let interrupted = false;
+    let terminationReason = null;
+    let childOutcome = null;
     let forceTimer;
     let settled = false;
     const finish = result => {
@@ -26,46 +63,123 @@ export function waitForProcess(child, {
       resolveResult(result);
     };
     const signal = name => {
-      if (platform === 'win32') terminateWindowsTree(child.pid, name === 'SIGKILL');
-      else {
-        try { kill(-child.pid, name); } catch { child.kill(name); }
+      if (platform === 'win32') {
+        return Promise.resolve()
+          .then(() => terminateWindowsTree(child.pid, name === 'SIGKILL'))
+          .catch(() => undefined);
       }
+      try {
+        kill(-child.pid, name);
+      } catch {
+        try { child.kill(name); } catch {}
+      }
+      return Promise.resolve();
     };
-    const terminate = () => {
-      signal('SIGTERM');
+    const terminate = reason => {
+      if (terminationReason !== null) return;
+      terminationReason = reason;
       forceTimer = setTimeout(() => {
-        signal('SIGKILL');
-        finish({ exitCode: null, signal: 'SIGKILL', timedOut, interrupted, error: null });
+        void (async () => {
+          await waitWithin(signal('SIGKILL'), forceTerminationMs);
+          finish({
+            exitCode: null,
+            signal: 'SIGKILL',
+            timedOut: terminationReason === 'timeout',
+            interrupted: terminationReason === 'interrupt',
+            error: childOutcome?.error ?? null,
+          });
+        })();
       }, terminationGraceMs);
+      void signal('SIGTERM');
     };
-    const interrupt = () => {
-      interrupted = true;
-      terminate();
-    };
-    const timer = setTimeout(() => {
-      timedOut = true;
-      terminate();
-    }, timeoutMs);
+    const interrupt = () => terminate('interrupt');
+    const timer = setTimeout(() => terminate('timeout'), timeoutMs);
     process.once('SIGINT', interrupt);
     process.once('SIGTERM', interrupt);
-    child.once('error', error => finish({ exitCode: null, signal: null, timedOut, interrupted, error }));
+    child.once('error', error => {
+      childOutcome = { exitCode: null, signal: null, error };
+      if (terminationReason === null) {
+        finish({ ...childOutcome, timedOut: false, interrupted: false });
+      }
+    });
     child.once('exit', (exitCode, signalName) => {
-      finish({ exitCode, signal: signalName, timedOut, interrupted, error: null });
+      childOutcome = { exitCode, signal: signalName, error: null };
+      if (terminationReason === null) {
+        finish({ ...childOutcome, timedOut: false, interrupted: false });
+      }
     });
   });
 }
 
-async function settlePipedOutput(child, stream, completion, outputSettleMs) {
+function completeUtf8PrefixLength(bytes) {
+  if (bytes.length === 0) return 0;
+  let lead = bytes.length - 1;
+  while (lead >= 0 && (bytes[lead] & 0xc0) === 0x80) lead -= 1;
+  if (lead < 0) return 0;
+  const first = bytes[lead];
+  const expected = first <= 0x7f
+    ? 1
+    : first >= 0xc2 && first <= 0xdf
+      ? 2
+      : first >= 0xe0 && first <= 0xef
+        ? 3
+        : first >= 0xf0 && first <= 0xf4
+          ? 4
+          : 1;
+  return bytes.length - lead < expected ? lead : bytes.length;
+}
+
+function decodeUtf8WithinByteCap(chunks, retainedBytes, maxBytes) {
+  const text = Buffer.concat(chunks, retainedBytes).toString('utf8');
+  const encoded = Buffer.from(text);
+  if (encoded.length <= maxBytes) return text;
+  const capped = encoded.subarray(0, maxBytes);
+  return capped.subarray(0, completeUtf8PrefixLength(capped)).toString('utf8');
+}
+
+function collectBoundedStderr(stream, maxBytes, ignoreError) {
+  const chunks = [];
+  let retainedBytes = 0;
+  let truncated = false;
+  let streamError = null;
+  const onData = chunk => {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const remaining = maxBytes - retainedBytes;
+    if (remaining > 0) {
+      const retained = bytes.subarray(0, remaining);
+      chunks.push(retained);
+      retainedBytes += retained.length;
+    }
+    if (bytes.length > remaining) truncated = true;
+  };
+  stream.on('data', onData);
+  const completion = finished(stream).catch(error => {
+    if (!ignoreError()) streamError = error;
+  });
+  return {
+    completion,
+    finish(incomplete) {
+      stream.off('data', onData);
+      const stderr = decodeUtf8WithinByteCap(chunks, retainedBytes, maxBytes);
+      return { stderr, stderrTruncated: truncated || incomplete, streamError };
+    },
+  };
+}
+
+async function settlePipedOutput(streams, completions, outputSettleMs, onTimeout) {
   let timer;
+  let timedOut = false;
   const bounded = new Promise(resolveDone => {
     timer = setTimeout(() => {
-      child.stdout.destroy();
-      stream.destroy();
+      timedOut = true;
+      onTimeout();
+      for (const stream of streams) stream.destroy();
       resolveDone();
     }, outputSettleMs);
   });
-  await Promise.race([completion.catch(() => undefined), bounded]);
+  await Promise.race([Promise.all(completions), bounded]);
   clearTimeout(timer);
+  return timedOut;
 }
 
 export async function runProviderProcess(run, options, deps = {}) {
@@ -75,6 +189,7 @@ export async function runProviderProcess(run, options, deps = {}) {
   const kill = deps.kill ?? process.kill;
   const terminationGraceMs = deps.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
   const outputSettleMs = deps.outputSettleMs ?? DEFAULT_OUTPUT_SETTLE_MS;
+  const monotonicNow = deps.monotonicNow ?? (() => performance.now());
   const args = [
     ...providerInvocation.prefixArgs,
     'exec',
@@ -89,27 +204,60 @@ export async function runProviderProcess(run, options, deps = {}) {
     '--output-last-message', run.paths.candidate,
     '-',
   ];
+  const startedAt = monotonicNow();
   const child = spawnProcess(providerInvocation.command, args, {
     cwd: run.paths.work,
     detached: platform !== 'win32',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  const terminateWindowsTree = deps.terminateWindowsTree ?? ((pid, force) => {
-    const killer = spawn('taskkill', ['/PID', String(pid), '/T', ...(force ? ['/F'] : [])], { stdio: 'ignore' });
-    killer.unref();
-  });
+  const terminateWindowsTree = deps.terminateWindowsTree ?? ((pid, force) => (
+    terminateWindowsProcessTree(pid, force, terminationGraceMs)
+  ));
   const processResult = waitForProcess(child, {
     timeoutMs: options.timeoutMs,
     kill,
     platform,
     terminateWindowsTree,
     terminationGraceMs,
+    forceTerminationMs: deps.forceTerminationMs ?? DEFAULT_TERMINATION_GRACE_MS,
   });
-  const eventsDone = finished(child.stdout.pipe(deps.eventsStream));
-  let stderr = '';
-  child.stderr.on('data', chunk => { stderr += chunk; });
-  child.stdin.end(run.request.prompt);
+  let suppressOutputErrors = false;
+  let eventsError = null;
+  const eventsDone = pipeline(child.stdout, deps.eventsStream).catch(error => {
+    if (!suppressOutputErrors) eventsError = error;
+  });
+  const stderrOutput = collectBoundedStderr(
+    child.stderr,
+    STDERR_RETAIN_BYTES,
+    () => suppressOutputErrors,
+  );
+  let stdinError = null;
+  const stdinDone = finished(child.stdin, { readable: false }).catch(error => { stdinError ??= error; });
+  try {
+    child.stdin.end(run.request.prompt);
+  } catch (error) {
+    stdinError = error;
+    child.stdin.destroy();
+  }
   const observed = await processResult;
-  await settlePipedOutput(child, deps.eventsStream, eventsDone, outputSettleMs);
-  return { ...observed, stderr, invocationCount: 1 };
+  const outputSettlementTimedOut = await settlePipedOutput(
+    [child.stdin, child.stdout, child.stderr, deps.eventsStream],
+    [stdinDone, eventsDone, stderrOutput.completion],
+    outputSettleMs,
+    () => { suppressOutputErrors = true; },
+  );
+  const { streamError: stderrError, ...stderrResult } = stderrOutput.finish(outputSettlementTimedOut);
+  if (eventsError) throw eventsError;
+  if (stderrError) throw stderrError;
+  const elapsed = monotonicNow() - startedAt;
+  const providerDurationMs = Number.isFinite(elapsed) ? Math.max(0, Math.round(elapsed)) : 0;
+  const error = observed.error ?? (observed.exitCode === 0 ? stdinError : null);
+  return {
+    ...observed,
+    ...stderrResult,
+    error,
+    outputSettlementTimedOut,
+    providerDurationMs,
+    invocationCount: 1,
+  };
 }

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
-import { mkdir, open, realpath, rm, stat } from 'node:fs/promises';
-import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { chmod, mkdir, open, readFile, realpath, rm, stat } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { finished } from 'node:stream/promises';
 
 import { GENUI_CANDIDATE_SCHEMA } from '../src/genui-candidate-schema.js';
 import { getFeasibilityFixture } from '../src/genui-feasibility-fixtures.js';
@@ -74,7 +76,7 @@ export async function createPrivateRun(options, deps = {}) {
     schema: join(canonicalOutput, '.candidate-schema.json'),
     work: join(canonicalOutput, '.codex-work'),
     playwright: join(canonicalOutput, '.playwright'),
-    browserResult: join(canonicalOutput, '.browser-result.json'),
+    browserResult: join(canonicalOutput, 'browser-result.json'),
   };
   const prompt = buildFeasibilityPrompt(options.fixture);
   const schemaJson = JSON.stringify(GENUI_CANDIDATE_SCHEMA);
@@ -100,3 +102,175 @@ export async function writeTerminalResult(run, terminal) {
   }
   await writeExclusive(run.paths.result, `${JSON.stringify(terminal, null, 2)}\n`);
 }
+
+function waitForProcess(child, { timeoutMs, kill, platform }) {
+  return new Promise((resolveResult) => {
+    let timedOut = false;
+    let interrupted = false;
+    let forceTimer;
+    let settled = false;
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearTimeout(forceTimer);
+      process.off('SIGINT', interrupt);
+      process.off('SIGTERM', interrupt);
+      resolveResult(result);
+    };
+    const signal = name => {
+      if (platform === 'win32') child.kill(name);
+      else {
+        try { kill(-child.pid, name); } catch { child.kill(name); }
+      }
+    };
+    const terminate = () => {
+      signal('SIGTERM');
+      forceTimer = setTimeout(() => {
+        signal('SIGKILL');
+        finish({ exitCode: null, signal: 'SIGKILL', timedOut, interrupted, error: null });
+      }, 5_000);
+    };
+    const interrupt = () => {
+      interrupted = true;
+      terminate();
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, timeoutMs);
+    process.once('SIGINT', interrupt);
+    process.once('SIGTERM', interrupt);
+    child.once('error', error => finish({ exitCode: null, signal: null, timedOut, interrupted, error }));
+    child.once('exit', (exitCode, signalName) => {
+      finish({ exitCode, signal: signalName, timedOut, interrupted, error: null });
+    });
+  });
+}
+
+export async function runProviderAttempt(run, options, deps = {}) {
+  const spawnProcess = deps.spawnProcess ?? spawn;
+  const providerInvocation = deps.providerInvocation ?? { command: 'codex', prefixArgs: [] };
+  const platform = deps.platform ?? process.platform;
+  const kill = deps.kill ?? process.kill;
+  await writeExclusive(run.paths.schema, `${JSON.stringify(GENUI_CANDIDATE_SCHEMA)}\n`);
+  await mkdir(run.paths.work, { mode: 0o700 });
+  const args = [
+    ...providerInvocation.prefixArgs,
+    'exec',
+    '--json',
+    '--ephemeral',
+    '--ignore-git-repo-check',
+    '--skip-rules',
+    '--sandbox', 'read-only',
+    '--model', options.model,
+    '--output-schema', run.paths.schema,
+    '--output-last-message', run.paths.candidate,
+    '-',
+  ];
+  const eventsHandle = await open(run.paths.providerEvents, 'a', 0o600);
+  const eventsStream = eventsHandle.createWriteStream();
+  const child = spawnProcess(providerInvocation.command, args, {
+    cwd: run.paths.work,
+    detached: platform !== 'win32',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const processResult = waitForProcess(child, { timeoutMs: options.timeoutMs, kill, platform });
+  const eventsDone = finished(child.stdout.pipe(eventsStream));
+  let stderr = '';
+  child.stderr.on('data', chunk => { stderr += chunk; });
+  child.stdin.end(run.request.prompt);
+  const observed = await processResult;
+  await eventsDone;
+  const base = { ...observed, invocationCount: 1 };
+  if (observed.timedOut) return { ...base, classification: 'provider_timeout', safeMessage: 'Provider deadline exceeded.' };
+  if (observed.interrupted) return { ...base, classification: 'provider_failed', safeMessage: 'Provider interrupted.' };
+  if (observed.error || observed.exitCode !== 0) return { ...base, classification: 'provider_failed', safeMessage: 'Provider process failed.' };
+  return { ...base, classification: 'success', safeMessage: null, stderr };
+}
+
+async function readCandidate(run) {
+  let bytes;
+  try { bytes = await readFile(run.paths.candidate); }
+  catch { return { classification: 'provider_failed', safeMessage: 'Provider produced no final message.' }; }
+  if (bytes.length > GENUI_PROVIDER_SETTINGS.maxCandidateBytes) {
+    return { classification: 'candidate_oversize', safeMessage: 'Provider final output exceeded the size limit.' };
+  }
+  let value;
+  try { value = JSON.parse(bytes.toString('utf8')); }
+  catch { return { classification: 'candidate_invalid', safeMessage: 'Provider final output was not valid JSON.' }; }
+  await chmod(run.paths.candidate, 0o600);
+  return { classification: 'success', value };
+}
+
+async function runBrowser(run, deps = {}) {
+  const spawnProcess = deps.spawnProcess ?? spawn;
+  const child = spawnProcess(
+    'npx',
+    ['playwright', 'test', '--config=playwright.minimal-provider.config.ts', '--project=chromium'],
+    {
+      cwd: resolve(import.meta.dirname, '..'),
+      env: { ...process.env, GENUI_MINIMAL_PROVIDER_RUN_DIR: run.paths.root },
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const observed = await waitForProcess(child, {
+    timeoutMs: run.options.timeoutMs,
+    kill: deps.kill ?? process.kill,
+    platform: deps.platform ?? process.platform,
+  });
+  if (observed.exitCode !== 0) return { classification: 'browser_failed', safeMessage: 'Browser validation failed.' };
+  try {
+    const result = JSON.parse(await readFile(run.paths.browserResult, 'utf8'));
+    return result.classification === 'success' && result.rubric?.passed === true && result.session?.success === true
+      ? result
+      : { classification: result.classification ?? 'browser_failed', safeMessage: 'Browser validation failed.' };
+  } catch {
+    return { classification: 'browser_failed', safeMessage: 'Browser result was unavailable.' };
+  }
+}
+
+export async function runMinimalProviderE2E(options, deps = {}) {
+  let run;
+  try {
+    run = await createPrivateRun(options, deps);
+    const provider = await runProviderAttempt(run, options, deps);
+    if (provider.classification !== 'success') {
+      const result = { ...provider, invocationCount: provider.invocationCount };
+      await writeTerminalResult(run, result);
+      return { exitCode: 1, result };
+    }
+    const candidate = await readCandidate(run);
+    if (candidate.classification !== 'success') {
+      const result = { ...candidate, invocationCount: provider.invocationCount };
+      await writeTerminalResult(run, result);
+      return { exitCode: 1, result };
+    }
+    const browser = await (deps.runBrowser?.(run) ?? runBrowser(run, deps));
+    const result = { ...browser, invocationCount: provider.invocationCount };
+    await writeTerminalResult(run, result);
+    return { exitCode: result.classification === 'success' ? 0 : 1, result };
+  } finally {
+    if (run) {
+      for (const path of [run.paths.schema, run.paths.work, run.paths.playwright, run.paths.browserResult]) {
+        await rm(path, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+async function main() {
+  try {
+    const options = parseMinimalProviderArgs(process.argv.slice(2), {
+      repositoryRoot: resolve(import.meta.dirname, '../../..'),
+    });
+    const { exitCode } = await runMinimalProviderE2E(options);
+    process.exitCode = exitCode;
+  } catch (error) {
+    console.error(error.code === CONFIGURATION_ERROR ? error.message : 'Minimal provider E2E failed.');
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === new URL(process.argv[1], 'file:').href) await main();

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
@@ -148,6 +148,19 @@ function waitForProcess(child, { timeoutMs, kill, platform }) {
   });
 }
 
+async function settlePipedOutput(child, stream, completion) {
+  let timer;
+  const bounded = new Promise(resolveDone => {
+    timer = setTimeout(() => {
+      child.stdout.destroy();
+      stream.destroy();
+      resolveDone();
+    }, 5_000);
+  });
+  await Promise.race([completion.catch(() => undefined), bounded]);
+  clearTimeout(timer);
+}
+
 export async function runProviderAttempt(run, options, deps = {}) {
   const spawnProcess = deps.spawnProcess ?? spawn;
   const providerInvocation = deps.providerInvocation ?? { command: 'codex', prefixArgs: [] };
@@ -181,7 +194,7 @@ export async function runProviderAttempt(run, options, deps = {}) {
   child.stderr.on('data', chunk => { stderr += chunk; });
   child.stdin.end(run.request.prompt);
   const observed = await processResult;
-  await eventsDone;
+  await settlePipedOutput(child, eventsStream, eventsDone);
   const base = { ...observed, invocationCount: 1 };
   if (observed.timedOut) return { ...base, classification: 'provider_timeout', safeMessage: 'Provider deadline exceeded.' };
   if (observed.interrupted) return { ...base, classification: 'provider_failed', safeMessage: 'Provider interrupted.' };
@@ -189,22 +202,32 @@ export async function runProviderAttempt(run, options, deps = {}) {
   return { ...base, classification: 'success', safeMessage: null, stderr };
 }
 
-async function readCandidate(run) {
-  let bytes;
-  try { bytes = await readFile(run.paths.candidate); }
+export async function classifyCandidate(candidatePath, maxBytes) {
+  let candidateStat;
+  try { candidateStat = await stat(candidatePath); }
   catch { return { classification: 'provider_failed', safeMessage: 'Provider produced no final message.' }; }
-  if (bytes.length > GENUI_PROVIDER_SETTINGS.maxCandidateBytes) {
+  if (candidateStat.size === 0) {
+    return { classification: 'provider_failed', safeMessage: 'Provider produced no final message.' };
+  }
+  if (candidateStat.size > maxBytes) {
     return { classification: 'candidate_oversize', safeMessage: 'Provider final output exceeded the size limit.' };
   }
-  let value;
-  try { value = JSON.parse(bytes.toString('utf8')); }
-  catch { return { classification: 'candidate_invalid', safeMessage: 'Provider final output was not valid JSON.' }; }
-  await chmod(run.paths.candidate, 0o600);
-  return { classification: 'success', value };
+  let bytes;
+  try { bytes = await readFile(candidatePath); }
+  catch { return { classification: 'provider_failed', safeMessage: 'Provider produced no final message.' }; }
+  let candidateJson;
+  try {
+    candidateJson = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    JSON.parse(candidateJson);
+  } catch {
+    return { classification: 'candidate_invalid', safeMessage: 'Provider final output was not valid JSON.' };
+  }
+  await chmod(candidatePath, 0o600);
+  return { candidateJson, bytes };
 }
 
-async function runBrowser(run, deps = {}) {
-  const spawnProcess = deps.spawnProcess ?? spawn;
+export async function evaluateInBrowser(run, options, deps = {}) {
+  const spawnProcess = deps.spawnBrowserProcess ?? spawn;
   const child = spawnProcess(
     'npx',
     ['playwright', 'test', '--config=playwright.minimal-provider.config.ts', '--project=chromium'],
@@ -212,20 +235,17 @@ async function runBrowser(run, deps = {}) {
       cwd: resolve(import.meta.dirname, '..'),
       env: { ...process.env, GENUI_MINIMAL_PROVIDER_RUN_DIR: run.paths.root },
       detached: process.platform !== 'win32',
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', 'ignore', 'ignore'],
     },
   );
   const observed = await waitForProcess(child, {
-    timeoutMs: run.options.timeoutMs,
+    timeoutMs: options.timeoutMs,
     kill: deps.kill ?? process.kill,
     platform: deps.platform ?? process.platform,
   });
   if (observed.exitCode !== 0) return { classification: 'browser_failed', safeMessage: 'Browser validation failed.' };
   try {
-    const result = JSON.parse(await readFile(run.paths.browserResult, 'utf8'));
-    return result.classification === 'success' && result.rubric?.passed === true && result.session?.success === true
-      ? result
-      : { classification: result.classification ?? 'browser_failed', safeMessage: 'Browser validation failed.' };
+    return JSON.parse(await readFile(run.paths.browserResult, 'utf8'));
   } catch {
     return { classification: 'browser_failed', safeMessage: 'Browser result was unavailable.' };
   }
@@ -241,13 +261,13 @@ export async function runMinimalProviderE2E(options, deps = {}) {
       await writeTerminalResult(run, result);
       return { exitCode: 1, result };
     }
-    const candidate = await readCandidate(run);
-    if (candidate.classification !== 'success') {
+    const candidate = await classifyCandidate(run.paths.candidate, GENUI_PROVIDER_SETTINGS.maxCandidateBytes);
+    if (candidate.classification) {
       const result = { ...candidate, invocationCount: provider.invocationCount };
       await writeTerminalResult(run, result);
       return { exitCode: 1, result };
     }
-    const browser = await (deps.runBrowser?.(run) ?? runBrowser(run, deps));
+    const browser = await (deps.runBrowser?.(run) ?? evaluateInBrowser(run, options, deps));
     const result = { ...browser, invocationCount: provider.invocationCount };
     await writeTerminalResult(run, result);
     return { exitCode: result.classification === 'success' ? 0 : 1, result };

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto';
+import { mkdir, open, realpath, rm, stat } from 'node:fs/promises';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+import { GENUI_CANDIDATE_SCHEMA } from '../src/genui-candidate-schema.js';
+import { getFeasibilityFixture } from '../src/genui-feasibility-fixtures.js';
+import { buildFeasibilityPrompt, GENUI_PROVIDER_SETTINGS } from '../src/genui-feasibility-provider.js';
+
+const CONFIGURATION_ERROR = 'configuration_error';
+
+function configurationError(message) {
+  return Object.assign(new Error(message), { code: CONFIGURATION_ERROR });
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function writeExclusive(path, value) {
+  const handle = await open(path, 'wx', 0o600);
+  try { await handle.writeFile(value); } finally { await handle.close(); }
+}
+
+export function parseMinimalProviderArgs(argv, { repositoryRoot }) {
+  if (argv.length % 2 !== 0) throw configurationError('Every flag requires one value.');
+  const allowed = new Set(['--fixture', '--model', '--output-dir', '--timeout-ms']);
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(flag) || values.has(flag)) throw configurationError('Unknown or duplicate CLI flag.');
+    values.set(flag, value);
+  }
+  for (const flag of ['--fixture', '--model', '--output-dir']) {
+    if (!values.has(flag) || values.get(flag) === '') throw configurationError(`Missing ${flag}.`);
+  }
+  const timeoutText = values.get('--timeout-ms');
+  const timeoutMs = timeoutText === undefined ? GENUI_PROVIDER_SETTINGS.timeoutMs : Number(timeoutText);
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) throw configurationError('Timeout must be a positive integer.');
+  let fixture;
+  try { fixture = getFeasibilityFixture(values.get('--fixture')); }
+  catch { throw configurationError('Unknown fixture.'); }
+  return {
+    fixtureId: values.get('--fixture'), fixture, model: values.get('--model'),
+    outputDir: values.get('--output-dir'), timeoutMs, repositoryRoot: resolve(repositoryRoot),
+  };
+}
+
+export async function createPrivateRun(options, deps = {}) {
+  const repositoryRoot = await realpath(deps.repositoryRoot ?? options.repositoryRoot);
+  const outputDir = options.outputDir;
+  if (!isAbsolute(outputDir)) throw configurationError('Output path must be absolute.');
+  const parent = resolve(outputDir, '..');
+  let canonicalParent;
+  try {
+    canonicalParent = await realpath(parent);
+    await stat(canonicalParent);
+  } catch { throw configurationError('Output parent must exist.'); }
+  const canonicalOutput = join(canonicalParent, basename(outputDir));
+  if (canonicalOutput !== outputDir) throw configurationError('Output path must be canonical.');
+  const rel = relative(repositoryRoot, canonicalOutput);
+  if (rel === '' || (!isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${sep}`))) {
+    throw configurationError('Output path must be outside the repository.');
+  }
+  try { await stat(canonicalOutput); throw configurationError('Output path must not exist.'); }
+  catch (error) { if (error.code !== 'ENOENT') throw error; }
+  await mkdir(canonicalOutput, { recursive: false, mode: 0o700 });
+  const paths = {
+    root: canonicalOutput,
+    request: join(canonicalOutput, 'request.json'),
+    providerEvents: join(canonicalOutput, 'provider-events.jsonl'),
+    candidate: join(canonicalOutput, 'candidate.json'),
+    result: join(canonicalOutput, 'result.json'),
+    schema: join(canonicalOutput, '.candidate-schema.json'),
+    work: join(canonicalOutput, '.codex-work'),
+    playwright: join(canonicalOutput, '.playwright'),
+    browserResult: join(canonicalOutput, '.browser-result.json'),
+  };
+  const prompt = buildFeasibilityPrompt(options.fixture);
+  const schemaJson = JSON.stringify(GENUI_CANDIDATE_SCHEMA);
+  const request = {
+    schemaVersion: 1,
+    fixtureId: options.fixtureId,
+    model: options.model,
+    timeoutMs: options.timeoutMs,
+    invocationTimestamp: (deps.now?.() ?? new Date().toISOString()),
+    expectedProviderInvocationCount: 1,
+    prompt,
+    promptSha256: sha256(prompt),
+    schemaSha256: sha256(schemaJson),
+  };
+  await writeExclusive(paths.request, `${JSON.stringify(request, null, 2)}\n`);
+  await writeExclusive(paths.providerEvents, '');
+  return { paths, request, options };
+}
+
+export async function writeTerminalResult(run, terminal) {
+  for (const path of [run.paths.schema, run.paths.work, run.paths.playwright, run.paths.browserResult]) {
+    await rm(path, { recursive: true, force: true });
+  }
+  await writeExclusive(run.paths.result, `${JSON.stringify(terminal, null, 2)}\n`);
+}

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
@@ -1,12 +1,12 @@
 import { createHash } from 'node:crypto';
-import { chmod, mkdir, open, readFile, realpath, rm, stat } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
+import { chmod, mkdir, open, readFile, realpath, rm, stat } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
-import { finished } from 'node:stream/promises';
 
 import { GENUI_CANDIDATE_SCHEMA } from '../src/genui-candidate-schema.js';
 import { getFeasibilityFixture } from '../src/genui-feasibility-fixtures.js';
 import { buildFeasibilityPrompt, GENUI_PROVIDER_SETTINGS } from '../src/genui-feasibility-provider.js';
+import { runProviderProcess, waitForProcess } from './genui-minimal-provider-process.mjs';
 
 const CONFIGURATION_ERROR = 'configuration_error';
 
@@ -102,108 +102,17 @@ export async function writeTerminalResult(run, terminal) {
   }
   await writeExclusive(run.paths.result, `${JSON.stringify(terminal, null, 2)}\n`);
 }
-function waitForProcess(child, { timeoutMs, kill, platform, terminateWindowsTree }) {
-  return new Promise((resolveResult) => {
-    let timedOut = false;
-    let interrupted = false;
-    let forceTimer;
-    let settled = false;
-    const finish = result => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      clearTimeout(forceTimer);
-      process.off('SIGINT', interrupt);
-      process.off('SIGTERM', interrupt);
-      resolveResult(result);
-    };
-    const signal = name => {
-    if (platform === 'win32') terminateWindowsTree(child.pid, name === 'SIGKILL');
-    else {
-      try { kill(-child.pid, name); } catch { child.kill(name); }
-    }
-    };
-    const terminate = () => {
-      signal('SIGTERM');
-      forceTimer = setTimeout(() => {
-        signal('SIGKILL');
-        finish({ exitCode: null, signal: 'SIGKILL', timedOut, interrupted, error: null });
-      }, 5_000);
-    };
-    const interrupt = () => {
-      interrupted = true;
-      terminate();
-    };
-    const timer = setTimeout(() => {
-      timedOut = true;
-      terminate();
-    }, timeoutMs);
-    process.once('SIGINT', interrupt);
-    process.once('SIGTERM', interrupt);
-    child.once('error', error => finish({ exitCode: null, signal: null, timedOut, interrupted, error }));
-    child.once('exit', (exitCode, signalName) => {
-      finish({ exitCode, signal: signalName, timedOut, interrupted, error: null });
-    });
-  });
-}
-
-async function settlePipedOutput(child, stream, completion) {
-  let timer;
-  const bounded = new Promise(resolveDone => {
-    timer = setTimeout(() => {
-      child.stdout.destroy();
-      stream.destroy();
-      resolveDone();
-    }, 5_000);
-  });
-  await Promise.race([completion.catch(() => undefined), bounded]);
-  clearTimeout(timer);
-}
 
 export async function runProviderAttempt(run, options, deps = {}) {
-  const spawnProcess = deps.spawnProcess ?? spawn;
-  const providerInvocation = deps.providerInvocation ?? { command: 'codex', prefixArgs: [] };
-  const platform = deps.platform ?? process.platform;
-  const kill = deps.kill ?? process.kill;
   await writeExclusive(run.paths.schema, `${JSON.stringify(GENUI_CANDIDATE_SCHEMA)}\n`);
   await mkdir(run.paths.work, { mode: 0o700 });
-  const args = [
-    ...providerInvocation.prefixArgs,
-    'exec',
-    '--json',
-    '--ephemeral',
-    '--ignore-user-config',
-    '--ignore-rules',
-    '--skip-git-repo-check',
-    '--sandbox', 'read-only',
-    '--model', options.model,
-    '--output-schema', run.paths.schema,
-    '--output-last-message', run.paths.candidate,
-    '-',
-  ];
   const eventsHandle = await open(run.paths.providerEvents, 'a', 0o600);
   const eventsStream = eventsHandle.createWriteStream();
-  const child = spawnProcess(providerInvocation.command, args, {
-    cwd: run.paths.work,
-    detached: platform !== 'win32',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  const terminateWindowsTree = deps.terminateWindowsTree ?? ((pid, force) => {
-    const killer = spawn('taskkill', ['/PID', String(pid), '/T', ...(force ? ['/F'] : [])], { stdio: 'ignore' });
-    killer.unref();
-  });
-  const processResult = waitForProcess(child, { timeoutMs: options.timeoutMs, kill, platform, terminateWindowsTree });
-  const eventsDone = finished(child.stdout.pipe(eventsStream));
-  let stderr = '';
-  child.stderr.on('data', chunk => { stderr += chunk; });
-  child.stdin.end(run.request.prompt);
-  const observed = await processResult;
-  await settlePipedOutput(child, eventsStream, eventsDone);
-  const base = { ...observed, invocationCount: 1 };
-  if (observed.timedOut) return { ...base, classification: 'provider_timeout', safeMessage: 'Provider deadline exceeded.' };
-  if (observed.interrupted) return { ...base, classification: 'provider_failed', safeMessage: 'Provider interrupted.' };
-  if (observed.error || observed.exitCode !== 0) return { ...base, classification: 'provider_failed', safeMessage: 'Provider process failed.' };
-  return { ...base, classification: 'success', safeMessage: null, stderr };
+  const observed = await runProviderProcess(run, options, { ...deps, eventsStream });
+  if (observed.timedOut) return { ...observed, classification: 'provider_timeout', safeMessage: 'Provider deadline exceeded.' };
+  if (observed.interrupted) return { ...observed, classification: 'provider_failed', safeMessage: 'Provider interrupted.' };
+  if (observed.error || observed.exitCode !== 0) return { ...observed, classification: 'provider_failed', safeMessage: 'Provider process failed.' };
+  return { ...observed, classification: 'success', safeMessage: null };
 }
 
 export async function classifyCandidate(candidatePath, maxBytes) {

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
@@ -270,7 +270,8 @@ export async function runMinimalProviderE2E(options, deps = {}) {
     const browser = await (deps.runBrowser?.(run) ?? evaluateInBrowser(run, options, deps));
     const result = { ...browser, invocationCount: provider.invocationCount };
     await writeTerminalResult(run, result);
-    return { exitCode: result.classification === 'success' ? 0 : 1, result };
+    const passed = result.classification === 'success' && result.rubric?.passed === true && result.session?.success === true;
+    return { exitCode: passed ? 0 : 1, result };
   } finally {
     if (run) {
       for (const path of [run.paths.schema, run.paths.work, run.paths.playwright, run.paths.browserResult]) {

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.mjs
@@ -102,8 +102,7 @@ export async function writeTerminalResult(run, terminal) {
   }
   await writeExclusive(run.paths.result, `${JSON.stringify(terminal, null, 2)}\n`);
 }
-
-function waitForProcess(child, { timeoutMs, kill, platform }) {
+function waitForProcess(child, { timeoutMs, kill, platform, terminateWindowsTree }) {
   return new Promise((resolveResult) => {
     let timedOut = false;
     let interrupted = false;
@@ -119,10 +118,10 @@ function waitForProcess(child, { timeoutMs, kill, platform }) {
       resolveResult(result);
     };
     const signal = name => {
-      if (platform === 'win32') child.kill(name);
-      else {
-        try { kill(-child.pid, name); } catch { child.kill(name); }
-      }
+    if (platform === 'win32') terminateWindowsTree(child.pid, name === 'SIGKILL');
+    else {
+      try { kill(-child.pid, name); } catch { child.kill(name); }
+    }
     };
     const terminate = () => {
       signal('SIGTERM');
@@ -173,8 +172,9 @@ export async function runProviderAttempt(run, options, deps = {}) {
     'exec',
     '--json',
     '--ephemeral',
-    '--ignore-git-repo-check',
-    '--skip-rules',
+    '--ignore-user-config',
+    '--ignore-rules',
+    '--skip-git-repo-check',
     '--sandbox', 'read-only',
     '--model', options.model,
     '--output-schema', run.paths.schema,
@@ -188,7 +188,11 @@ export async function runProviderAttempt(run, options, deps = {}) {
     detached: platform !== 'win32',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  const processResult = waitForProcess(child, { timeoutMs: options.timeoutMs, kill, platform });
+  const terminateWindowsTree = deps.terminateWindowsTree ?? ((pid, force) => {
+    const killer = spawn('taskkill', ['/PID', String(pid), '/T', ...(force ? ['/F'] : [])], { stdio: 'ignore' });
+    killer.unref();
+  });
+  const processResult = waitForProcess(child, { timeoutMs: options.timeoutMs, kill, platform, terminateWindowsTree });
   const eventsDone = finished(child.stdout.pipe(eventsStream));
   let stderr = '';
   child.stderr.on('data', chunk => { stderr += chunk; });
@@ -238,10 +242,15 @@ export async function evaluateInBrowser(run, options, deps = {}) {
       stdio: ['ignore', 'ignore', 'ignore'],
     },
   );
+  const terminateWindowsTree = deps.terminateWindowsTree ?? ((pid, force) => {
+    const killer = spawn('taskkill', ['/PID', String(pid), '/T', ...(force ? ['/F'] : [])], { stdio: 'ignore' });
+    killer.unref();
+  });
   const observed = await waitForProcess(child, {
     timeoutMs: options.timeoutMs,
     kill: deps.kill ?? process.kill,
     platform: deps.platform ?? process.platform,
+    terminateWindowsTree,
   });
   if (observed.exitCode !== 0) return { classification: 'browser_failed', safeMessage: 'Browser validation failed.' };
   try {

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
@@ -129,10 +129,13 @@ test('provider timeout kills the process group and settles inherited output', { 
   child.stderr = new PassThrough();
   child.kill = () => true;
   const signals = [];
+  const startedAt = Date.now();
   const observed = await runProviderAttempt(run, options, {
     spawnProcess: () => child,
     providerInvocation: { command: 'codex', prefixArgs: [] },
     platform: 'linux',
+    terminationGraceMs: 10,
+    outputSettleMs: 10,
     kill(pid, signal) {
       signals.push([pid, signal]);
       if (signal === 'SIGKILL') child.emit('exit', null, signal);
@@ -140,6 +143,7 @@ test('provider timeout kills the process group and settles inherited output', { 
   });
   assert.equal(observed.classification, 'provider_timeout');
   assert.deepEqual(signals, [[-24680, 'SIGTERM'], [-24680, 'SIGKILL']]);
+  assert.ok(Date.now() - startedAt < 1_000, 'injected lifecycle bounds must avoid the production grace period');
 });
 test('timeout kills a live provider grandchild after bounded escalation', { timeout: 15_000 }, async () => {
   if (process.platform === 'win32') return;
@@ -170,6 +174,7 @@ test('timeout kills a live provider grandchild after bounded escalation', { time
       return spawn(process.execPath, [scriptPath, heartbeatPath, pidPath], spawnOptions);
     },
     providerInvocation: { command: 'codex', prefixArgs: [] },
+    terminationGraceMs: 100,
   });
   assert.equal(observed.classification, 'provider_timeout');
   assert.equal(spawnCount, 1);

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
@@ -15,6 +15,7 @@ import {
   runProviderAttempt,
   writeTerminalResult,
 } from './run-genui-minimal-provider-e2e.mjs';
+import { runProviderProcess } from './genui-minimal-provider-process.mjs';
 import { GENUI_PROVIDER_SETTINGS } from '../src/genui-feasibility-provider.js';
 import { recordedFeasibilityCandidateJson } from '../src/genui-recorded-candidates.js';
 
@@ -87,6 +88,7 @@ test('provider lifecycle performs exactly one fixed Codex invocation', async () 
   const options = parseMinimalProviderArgs(argv(join(root, 'run')), { repositoryRoot });
   const run = await createPrivateRun(options, { repositoryRoot });
   const calls = [];
+  const monotonicTimes = [100, 125];
   const child = new EventEmitter();
   child.pid = 12345;
   child.stdin = new PassThrough();
@@ -104,10 +106,12 @@ test('provider lifecycle performs exactly one fixed Codex invocation', async () 
       return child;
     },
     providerInvocation: { command: 'codex', prefixArgs: [] },
+    monotonicNow: () => monotonicTimes.shift(),
   });
   const result = await resultPromise;
   assert.equal(result.classification, 'success');
   assert.equal(result.invocationCount, 1);
+  assert.equal(result.providerDurationMs, 25);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].command, 'codex');
   assert.equal(calls[0].args.filter(value => value === 'exec').length, 1);
@@ -116,6 +120,32 @@ test('provider lifecycle performs exactly one fixed Codex invocation', async () 
   }
   assert.equal(calls[0].args.at(-1), '-');
   assert.equal(calls[0].spawnOptions.cwd, run.paths.work);
+});
+
+test('provider event artifact write failures remain terminal', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run')), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 24680;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const eventsStream = new PassThrough();
+  await assert.rejects(runProviderProcess(run, options, {
+    spawnProcess() {
+      queueMicrotask(() => {
+        eventsStream.destroy(new Error('artifact write failed'));
+        child.stdout.end('{}\n');
+        child.emit('exit', 0, null);
+      });
+      return child;
+    },
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+    eventsStream,
+    outputSettleMs: 5,
+  }), /artifact write failed/);
 });
 
 test('provider timeout kills the process group and settles inherited output', { timeout: 15_000 }, async () => {
@@ -184,6 +214,46 @@ test('timeout kills a live provider grandchild after bounded escalation', { time
   assert.throws(() => process.kill(grandchildPid, 0), error => error.code === 'ESRCH');
 });
 
+test('timeout force-kills descendants after the provider parent exits', { timeout: 15_000 }, async () => {
+  if (process.platform === 'win32') return;
+  const { root, repositoryRoot } = await sandbox();
+  const scriptPath = join(root, 'provider-parent-exits.mjs');
+  const heartbeatPath = join(root, 'parent-exits-heartbeat');
+  const pidPath = join(root, 'parent-exits-grandchild-pid');
+  await writeFile(scriptPath, `
+    import { spawn } from 'node:child_process';
+    import { writeFileSync } from 'node:fs';
+    const heartbeat = process.argv[2];
+    const pidFile = process.argv[3];
+    const grandchild = spawn(process.execPath, ['-e', \`
+      const { appendFileSync } = require('node:fs');
+      process.on('SIGTERM', () => {});
+      setInterval(() => appendFileSync(process.argv[1], '.'), 20);
+    \`, heartbeat], { stdio: 'ignore' });
+    writeFileSync(pidFile, String(grandchild.pid));
+    process.on('SIGTERM', () => process.exit(0));
+    setInterval(() => {}, 1000);
+  `);
+  const options = parseMinimalProviderArgs(argv(join(root, 'run'), ['--timeout-ms', '250']), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const observed = await runProviderAttempt(run, options, {
+    spawnProcess(_command, _args, spawnOptions) {
+      return spawn(process.execPath, [scriptPath, heartbeatPath, pidPath], spawnOptions);
+    },
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+    terminationGraceMs: 100,
+  });
+  assert.equal(observed.classification, 'provider_timeout');
+  assert.ok((await readFile(heartbeatPath, 'utf8')).length > 0);
+  const grandchildPid = Number(await readFile(pidPath, 'utf8'));
+  await new Promise(resolve => setTimeout(resolve, 100));
+  try {
+    assert.throws(() => process.kill(grandchildPid, 0), error => error.code === 'ESRCH');
+  } finally {
+    try { process.kill(grandchildPid, 'SIGKILL'); } catch {}
+  }
+});
+
 
 test('provider interruption terminates without retry', async () => {
   const { root, repositoryRoot } = await sandbox();
@@ -210,6 +280,126 @@ test('provider interruption terminates without retry', async () => {
   assert.equal(observed.classification, 'provider_failed');
   assert.equal(observed.interrupted, true);
   assert.equal(observed.invocationCount, 1);
+});
+
+test('Windows timeout awaits forced tree termination after the child exits', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run'), ['--timeout-ms', '1']), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 97531;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  let resolveForcedTermination;
+  const forcedTermination = new Promise(resolve => { resolveForcedTermination = resolve; });
+  let completed = false;
+  const attempt = runProviderAttempt(run, options, {
+    spawnProcess: () => child,
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+    platform: 'win32',
+    terminationGraceMs: 5,
+    outputSettleMs: 5,
+    terminateWindowsTree(_pid, force) {
+      if (!force) {
+        child.stdout.end();
+        child.stderr.end();
+        queueMicrotask(() => child.emit('exit', 0, null));
+        return Promise.resolve();
+      }
+      return forcedTermination;
+    },
+  }).then(result => {
+    completed = true;
+    return result;
+  });
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(completed, false);
+  resolveForcedTermination();
+  const observed = await attempt;
+  assert.equal(observed.classification, 'provider_timeout');
+});
+
+test('Windows forced tree termination has a bounded wait', { timeout: 15_000 }, async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run'), ['--timeout-ms', '1']), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 13579;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const startedAt = Date.now();
+  const observed = await runProviderAttempt(run, options, {
+    spawnProcess: () => child,
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+    platform: 'win32',
+    terminationGraceMs: 5,
+    forceTerminationMs: 5,
+    outputSettleMs: 5,
+    terminateWindowsTree(_pid, force) {
+      if (!force) {
+        child.stdout.end();
+        child.stderr.end();
+        queueMicrotask(() => child.emit('exit', 0, null));
+        return Promise.resolve();
+      }
+      return new Promise(() => {});
+    },
+  });
+  assert.equal(observed.classification, 'provider_timeout');
+  assert.ok(Date.now() - startedAt < 1_000);
+});
+
+test('provider early stdin close is classified without an uncaught EPIPE', { timeout: 15_000 }, async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const providerPath = join(root, 'provider-closes-stdin.mjs');
+  await writeFile(providerPath, 'process.stdin.destroy(); process.exit(2);');
+  const options = parseMinimalProviderArgs(argv(join(root, 'run')), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  run.request.prompt = 'x'.repeat(1_048_576);
+  const observed = await runProviderAttempt(run, options, {
+    providerInvocation: { command: process.execPath, prefixArgs: [providerPath] },
+  });
+  assert.equal(observed.classification, 'provider_failed');
+  assert.equal(observed.exitCode, 2);
+  assert.equal(observed.invocationCount, 1);
+});
+
+test('provider stderr is UTF-8 safe and bounded by retained bytes', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run')), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 86420;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const euro = Buffer.from('€');
+  const observed = await runProviderAttempt(run, options, {
+    spawnProcess() {
+      queueMicrotask(() => {
+        child.stderr.write(euro.subarray(0, 1));
+        child.stderr.write(euro.subarray(1));
+        child.stderr.write('x'.repeat(16_380));
+        child.stderr.write(euro.subarray(0, 1));
+        child.stderr.write(euro.subarray(1));
+        child.stdout.end();
+        child.stderr.end();
+        child.emit('exit', 2, null);
+      });
+      return child;
+    },
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+  });
+  assert.equal(observed.classification, 'provider_failed');
+  assert.equal(observed.stderr.startsWith('€'), true);
+  assert.ok(Buffer.byteLength(observed.stderr) <= 16_384);
+  assert.equal(observed.stderr.includes('\uFFFD'), false);
+  assert.equal(observed.stderrTruncated, true);
 });
 
 test('candidate boundaries distinguish missing, invalid UTF-8, malformed, and oversize output', async () => {

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
@@ -3,10 +3,12 @@ import { mkdtemp, mkdir, readFile, readdir, realpath, stat, symlink, writeFile }
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { EventEmitter } from 'node:events';
+import { spawn } from 'node:child_process';
 import { PassThrough } from 'node:stream';
 import test from 'node:test';
 
 import {
+  classifyCandidate,
   createPrivateRun,
   parseMinimalProviderArgs,
   runMinimalProviderE2E,
@@ -109,11 +111,155 @@ test('provider lifecycle performs exactly one fixed Codex invocation', async () 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].command, 'codex');
   assert.equal(calls[0].args.filter(value => value === 'exec').length, 1);
-  for (const flag of ['--json', '--ephemeral', '--ignore-git-repo-check', '--skip-rules', '--sandbox', '--model', '--output-schema', '--output-last-message']) {
+  for (const flag of ['--json', '--ephemeral', '--ignore-user-config', '--ignore-rules', '--skip-git-repo-check', '--sandbox', '--model', '--output-schema', '--output-last-message']) {
     assert.equal(calls[0].args.filter(value => value === flag).length, 1);
   }
   assert.equal(calls[0].args.at(-1), '-');
   assert.equal(calls[0].spawnOptions.cwd, run.paths.work);
+});
+
+test('provider timeout kills the process group and settles inherited output', { timeout: 15_000 }, async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run'), ['--timeout-ms', '1']), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 24680;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const signals = [];
+  const observed = await runProviderAttempt(run, options, {
+    spawnProcess: () => child,
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+    platform: 'linux',
+    kill(pid, signal) {
+      signals.push([pid, signal]);
+      if (signal === 'SIGKILL') child.emit('exit', null, signal);
+    },
+  });
+  assert.equal(observed.classification, 'provider_timeout');
+  assert.deepEqual(signals, [[-24680, 'SIGTERM'], [-24680, 'SIGKILL']]);
+});
+test('timeout kills a live provider grandchild after bounded escalation', { timeout: 15_000 }, async () => {
+  if (process.platform === 'win32') return;
+  const { root, repositoryRoot } = await sandbox();
+  const scriptPath = join(root, 'provider-tree.mjs');
+  const heartbeatPath = join(root, 'heartbeat');
+  const pidPath = join(root, 'grandchild-pid');
+  await writeFile(scriptPath, `
+    import { spawn } from 'node:child_process';
+    import { writeFileSync } from 'node:fs';
+    const heartbeat = process.argv[2];
+    const pidFile = process.argv[3];
+    const grandchild = spawn(process.execPath, ['-e', \`
+      const { appendFileSync } = require('node:fs');
+      process.on('SIGTERM', () => {});
+      setInterval(() => appendFileSync(process.argv[1], '.'), 20);
+    \`, heartbeat], { stdio: 'ignore' });
+    writeFileSync(pidFile, String(grandchild.pid));
+    process.on('SIGTERM', () => {});
+    setInterval(() => {}, 1000);
+  `);
+  const options = parseMinimalProviderArgs(argv(join(root, 'run'), ['--timeout-ms', '250']), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  let spawnCount = 0;
+  const observed = await runProviderAttempt(run, options, {
+    spawnProcess(_command, _args, spawnOptions) {
+      spawnCount += 1;
+      return spawn(process.execPath, [scriptPath, heartbeatPath, pidPath], spawnOptions);
+    },
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+  });
+  assert.equal(observed.classification, 'provider_timeout');
+  assert.equal(spawnCount, 1);
+  assert.ok((await readFile(heartbeatPath, 'utf8')).length > 0);
+  const grandchildPid = Number(await readFile(pidPath, 'utf8'));
+  await new Promise(resolve => setTimeout(resolve, 100));
+  assert.throws(() => process.kill(grandchildPid, 0), error => error.code === 'ESRCH');
+});
+
+
+test('provider interruption terminates without retry', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run')), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 13579;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const attempt = runProviderAttempt(run, options, {
+    spawnProcess: () => child,
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+    platform: 'linux',
+    kill(_pid, signal) {
+      child.stdout.end();
+      child.stderr.end();
+      child.emit('exit', null, signal);
+    },
+  });
+  setTimeout(() => process.emit('SIGINT'), 10);
+  const observed = await attempt;
+  assert.equal(observed.classification, 'provider_failed');
+  assert.equal(observed.interrupted, true);
+  assert.equal(observed.invocationCount, 1);
+});
+
+test('candidate boundaries distinguish missing, invalid UTF-8, malformed, and oversize output', async () => {
+  const { root } = await sandbox();
+  const candidatePath = join(root, 'candidate.json');
+  assert.equal((await classifyCandidate(candidatePath, 65_536)).classification, 'provider_failed');
+  await writeFile(candidatePath, Buffer.from([0xff]));
+  assert.equal((await classifyCandidate(candidatePath, 65_536)).classification, 'candidate_invalid');
+  await writeFile(candidatePath, '{');
+  assert.equal((await classifyCandidate(candidatePath, 65_536)).classification, 'candidate_invalid');
+  await writeFile(candidatePath, ' '.repeat(65_535) + '0');
+  assert.equal((await classifyCandidate(candidatePath, 65_536)).bytes.length, 65_536);
+  await writeFile(candidatePath, ' '.repeat(65_536) + '0');
+  assert.equal((await classifyCandidate(candidatePath, 65_536)).classification, 'candidate_oversize');
+});
+
+async function runWithBrowserOutcome(outcome) {
+  const { root, repositoryRoot } = await sandbox();
+  const outputDir = join(root, 'run');
+  const options = parseMinimalProviderArgs(argv(outputDir), { repositoryRoot });
+  const child = new EventEmitter();
+  child.pid = 12345;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const observed = await runMinimalProviderE2E(options, {
+    repositoryRoot,
+    runBrowser: async () => outcome,
+    spawnProcess(_command, args) {
+      queueMicrotask(async () => {
+        const outputFlag = args.indexOf('--output-last-message');
+        await writeFile(args[outputFlag + 1], '{}');
+        child.stdout.end();
+        child.stderr.end();
+        child.emit('exit', 0, null);
+      });
+      return child;
+    },
+  });
+  return observed;
+}
+
+test('MoonBit classifications and failed success predicates remain terminal failures', async () => {
+  const schemaInvalid = { classification: 'candidate_validation_error', diagnostics: ['schema'] };
+  assert.deepEqual((await runWithBrowserOutcome(schemaInvalid)).result.diagnostics, ['schema']);
+  for (const outcome of [
+    { classification: 'success', rubric: { passed: false }, session: { success: true } },
+    { classification: 'success', rubric: { passed: true }, session: { success: false } },
+  ]) {
+    const observed = await runWithBrowserOutcome(outcome);
+    assert.equal(observed.exitCode, 1);
+    assert.deepEqual(observed.result.rubric, outcome.rubric);
+    assert.deepEqual(observed.result.session, outcome.session);
+  }
 });
 
 test('fake provider traverses real browser and MoonBit commit path', { timeout: 360_000 }, async () => {

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, realpath, stat, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import test from 'node:test';
+
+import {
+  createPrivateRun,
+  parseMinimalProviderArgs,
+  writeTerminalResult,
+} from './run-genui-minimal-provider-e2e.mjs';
+import { GENUI_PROVIDER_SETTINGS } from '../src/genui-feasibility-provider.js';
+
+const fixtureId = 'orders-pending-attention';
+
+async function sandbox() {
+  const root = await mkdtemp(join(tmpdir(), 'canopy-minimal-e2e-'));
+  const repositoryRoot = await realpath(join(import.meta.dirname, '../../..'));
+  return { root, repositoryRoot };
+}
+
+function argv(outputDir, extra = []) {
+  return ['--fixture', fixtureId, '--model', 'test-model', '--output-dir', outputDir, ...extra];
+}
+
+function configurationError(fn) {
+  assert.throws(fn, error => error.code === 'configuration_error' && error.message.length > 0);
+}
+
+for (const bad of [
+  [], ['--fixture', fixtureId],
+  ['--fixture', fixtureId, '--model', ''],
+  ['--fixture', 'missing', '--model', 'm', '--output-dir', '/tmp/x'],
+  ['--fixture', fixtureId, '--fixture', fixtureId, '--model', 'm', '--output-dir', '/tmp/x'],
+  ['--fixture', fixtureId, '--model', 'm', '--output-dir', '/tmp/x', '--wat', 'x'],
+  ['--fixture', fixtureId, '--model', 'm', '--output-dir', '/tmp/x', '--timeout-ms', '0'],
+  ['--fixture', fixtureId, '--model', 'm', '--output-dir', '/tmp/x', '--timeout-ms', '1.5'],
+]) {
+  test(`CLI rejects ${JSON.stringify(bad)}`, () => configurationError(() => parseMinimalProviderArgs(bad, { repositoryRoot: '/repo' })));
+}
+
+test('CLI applies default timeout', () => {
+  const parsed = parseMinimalProviderArgs(argv('/tmp/new-run'), { repositoryRoot: '/repo' });
+  assert.equal(parsed.timeoutMs, GENUI_PROVIDER_SETTINGS.timeoutMs);
+});
+
+test('output path accepts one canonical external child and creates private artifacts', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const outputDir = join(root, 'run');
+  const options = parseMinimalProviderArgs(argv(outputDir), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot, now: () => '2026-07-17T00:00:00.000Z' });
+  assert.equal((await stat(outputDir)).mode & 0o777, 0o700);
+  for (const path of [run.paths.request, run.paths.providerEvents]) assert.equal((await stat(path)).mode & 0o777, 0o600);
+  const request = JSON.parse(await readFile(run.paths.request, 'utf8'));
+  assert.equal(request.fixtureId, fixtureId);
+  assert.equal(request.model, 'test-model');
+  assert.equal(request.expectedProviderInvocationCount, 1);
+  assert.equal(typeof request.promptSha256, 'string');
+  assert.equal(typeof request.schemaSha256, 'string');
+  assert.equal(Object.hasOwn(request, 'candidateJson'), false);
+  await writeTerminalResult(run, { classification: 'provider_failed', safeMessage: 'test' });
+  assert.equal((await stat(run.paths.result)).mode & 0o777, 0o600);
+  await assert.rejects(() => writeTerminalResult(run, { classification: 'provider_failed' }));
+});
+
+test('output path rejects aliases and unsafe parents before run creation', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const existing = join(root, 'existing');
+  await mkdir(existing);
+  const alias = join(root, 'repo-link');
+  await symlink(repositoryRoot, alias);
+  for (const outputDir of ['relative', existing, join(root, 'missing', 'run'), join(repositoryRoot, 'run'), `${root}/../${basename(root)}/alias`, join(alias, 'run')]) {
+    const options = parseMinimalProviderArgs(argv(outputDir), { repositoryRoot });
+    await assert.rejects(() => createPrivateRun(options, { repositoryRoot }), error => error.code === 'configuration_error');
+  }
+});

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
@@ -2,11 +2,14 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, readFile, realpath, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import test from 'node:test';
 
 import {
   createPrivateRun,
   parseMinimalProviderArgs,
+  runProviderAttempt,
   writeTerminalResult,
 } from './run-genui-minimal-provider-e2e.mjs';
 import { GENUI_PROVIDER_SETTINGS } from '../src/genui-feasibility-provider.js';
@@ -73,4 +76,40 @@ test('output path rejects aliases and unsafe parents before run creation', async
     const options = parseMinimalProviderArgs(argv(outputDir), { repositoryRoot });
     await assert.rejects(() => createPrivateRun(options, { repositoryRoot }), error => error.code === 'configuration_error');
   }
+});
+
+test('provider lifecycle performs exactly one fixed Codex invocation', async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const options = parseMinimalProviderArgs(argv(join(root, 'run')), { repositoryRoot });
+  const run = await createPrivateRun(options, { repositoryRoot });
+  const calls = [];
+  const child = new EventEmitter();
+  child.pid = 12345;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  const resultPromise = runProviderAttempt(run, options, {
+    spawnProcess(command, args, spawnOptions) {
+      calls.push({ command, args, spawnOptions });
+      queueMicrotask(() => {
+        child.stdout.end();
+        child.stderr.end();
+        child.emit('exit', 0, null);
+      });
+      return child;
+    },
+    providerInvocation: { command: 'codex', prefixArgs: [] },
+  });
+  const result = await resultPromise;
+  assert.equal(result.classification, 'success');
+  assert.equal(result.invocationCount, 1);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'codex');
+  assert.equal(calls[0].args.filter(value => value === 'exec').length, 1);
+  for (const flag of ['--json', '--ephemeral', '--ignore-git-repo-check', '--skip-rules', '--sandbox', '--model', '--output-schema', '--output-last-message']) {
+    assert.equal(calls[0].args.filter(value => value === flag).length, 1);
+  }
+  assert.equal(calls[0].args.at(-1), '-');
+  assert.equal(calls[0].spawnOptions.cwd, run.paths.work);
 });

--- a/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
+++ b/examples/web/scripts/run-genui-minimal-provider-e2e.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, realpath, stat, symlink } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, realpath, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -9,10 +9,12 @@ import test from 'node:test';
 import {
   createPrivateRun,
   parseMinimalProviderArgs,
+  runMinimalProviderE2E,
   runProviderAttempt,
   writeTerminalResult,
 } from './run-genui-minimal-provider-e2e.mjs';
 import { GENUI_PROVIDER_SETTINGS } from '../src/genui-feasibility-provider.js';
+import { recordedFeasibilityCandidateJson } from '../src/genui-recorded-candidates.js';
 
 const fixtureId = 'orders-pending-attention';
 
@@ -112,4 +114,28 @@ test('provider lifecycle performs exactly one fixed Codex invocation', async () 
   }
   assert.equal(calls[0].args.at(-1), '-');
   assert.equal(calls[0].spawnOptions.cwd, run.paths.work);
+});
+
+test('fake provider traverses real browser and MoonBit commit path', { timeout: 360_000 }, async () => {
+  const { root, repositoryRoot } = await sandbox();
+  const fakeProvider = join(root, 'fake-provider.mjs');
+  const candidateJson = recordedFeasibilityCandidateJson(fixtureId);
+  await writeFile(fakeProvider, [
+    "import { writeFile } from 'node:fs/promises';",
+    "const outputFlag = process.argv.indexOf('--output-last-message');",
+    "if (outputFlag < 0) process.exit(2);",
+    `await writeFile(process.argv[outputFlag + 1], ${JSON.stringify(candidateJson)});`,
+    "process.stdout.write(JSON.stringify({ type: 'turn.completed' }) + '\\n');",
+  ].join('\n'));
+  const outputDir = join(root, 'run');
+  const options = parseMinimalProviderArgs(argv(outputDir, ['--timeout-ms', '300000']), { repositoryRoot });
+  const observed = await runMinimalProviderE2E(options, {
+    repositoryRoot,
+    providerInvocation: { command: process.execPath, prefixArgs: [fakeProvider] },
+  });
+  assert.equal(observed.exitCode, 0);
+  assert.equal(observed.result.classification, 'success');
+  assert.equal(observed.result.rubric.passed, true);
+  assert.equal(observed.result.session.success, true);
+  assert.deepEqual((await readdir(outputDir)).sort(), ['candidate.json', 'provider-events.jsonl', 'request.json', 'result.json']);
 });

--- a/examples/web/src/genui-candidate-schema.js
+++ b/examples/web/src/genui-candidate-schema.js
@@ -18,11 +18,9 @@ function componentSchema(name, attributes, children) {
     properties: {
       type: { const: 'component' },
       name: { const: name },
-      attributes: {
-        type: 'array',
-        prefixItems: attributes,
-        items: false,
-      },
+      attributes: attributes.length === 0
+        ? { type: 'array', maxItems: 0 }
+        : { type: 'array', prefixItems: attributes, items: false },
       children,
     },
   };

--- a/examples/web/src/genui-feasibility-provider.test.mjs
+++ b/examples/web/src/genui-feasibility-provider.test.mjs
@@ -110,6 +110,7 @@ test('provider schema accepts recorded controls and embeds no case authority', (
     assert.equal(validateSchema(getRecordedFeasibilityCandidate(fixture.caseId), GENUI_CANDIDATE_SCHEMA), true);
   }
   const schemaText = JSON.stringify(GENUI_CANDIDATE_SCHEMA);
+  assert.equal(schemaText.includes('"prefixItems":[]'), false, 'provider schema cannot contain empty prefixItems');
   for (const forbidden of [
     'orders', 'inventory', 'incidents', 'status', 'amount', 'on_hand', 'severity',
     'resolution_minutes', 'pending', 'critical', 'ord-1002', 'sku-001', 'inc-001',

--- a/examples/web/src/genui.js
+++ b/examples/web/src/genui.js
@@ -386,6 +386,10 @@ if (import.meta.env.DEV) {
         provider,
       }
     },
+    async commitSavedCandidate({ caseId, candidateJson }) {
+      await resetSlotSession()
+      return commitFeasibilityCandidate(candidateJson, recordedDemoInput(caseId))
+    },
     async evaluateSavedCandidate({ caseId, candidateJson }) {
       return evaluateFeasibilityCandidate(candidateJson, recordedDemoInput(caseId))
     },

--- a/examples/web/tests/genui-minimal-provider.spec.ts
+++ b/examples/web/tests/genui-minimal-provider.spec.ts
@@ -15,7 +15,5 @@ test('minimal provider candidate reaches unchanged commit path', async ({ page }
   );
 
   await writeFile(join(runRoot, 'browser-result.json'), `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600, flag: 'wx' });
-  expect(result.classification).toBe('success');
-  expect(result.rubric?.passed).toBe(true);
-  expect(result.session?.success).toBe(true);
+  expect(typeof result.classification).toBe('string');
 });

--- a/examples/web/tests/genui-minimal-provider.spec.ts
+++ b/examples/web/tests/genui-minimal-provider.spec.ts
@@ -1,0 +1,21 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test } from '@playwright/test';
+
+test('minimal provider candidate reaches unchanged commit path', async ({ page }) => {
+  const runRoot = process.env.GENUI_MINIMAL_PROVIDER_RUN_DIR;
+  if (!runRoot) throw new Error('GENUI_MINIMAL_PROVIDER_RUN_DIR is required');
+  const request = JSON.parse(await readFile(join(runRoot, 'request.json'), 'utf8'));
+  const candidateJson = await readFile(join(runRoot, 'candidate.json'), 'utf8');
+
+  await page.goto('/genui.html');
+  const result = await page.evaluate(
+    ({ caseId, candidateJson }) => window.__canopyGenUiFeasibilityTest.commitSavedCandidate({ caseId, candidateJson }),
+    { caseId: request.fixtureId, candidateJson },
+  );
+
+  await writeFile(join(runRoot, 'browser-result.json'), `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600, flag: 'wx' });
+  expect(result.classification).toBe('success');
+  expect(result.rubric?.passed).toBe(true);
+  expect(result.session?.success).toBe(true);
+});

--- a/examples/web/tests/genui-minimal-provider.spec.ts
+++ b/examples/web/tests/genui-minimal-provider.spec.ts
@@ -2,9 +2,11 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 
+const runRoot = process.env.GENUI_MINIMAL_PROVIDER_RUN_DIR;
+test.skip(!runRoot, 'GENUI_MINIMAL_PROVIDER_RUN_DIR is required for the dedicated runner');
+
 test('minimal provider candidate reaches unchanged commit path', async ({ page }) => {
-  const runRoot = process.env.GENUI_MINIMAL_PROVIDER_RUN_DIR;
-  if (!runRoot) throw new Error('GENUI_MINIMAL_PROVIDER_RUN_DIR is required');
+  if (!runRoot) throw new Error('unreachable: dedicated runner directory is missing');
   const request = JSON.parse(await readFile(join(runRoot, 'request.json'), 'utf8'));
   const candidateJson = await readFile(join(runRoot, 'candidate.json'), 'utf8');
 


### PR DESCRIPTION
## Summary
- add a private local-only Codex-to-MoonBit E2E runner with strict path, process-tree, and artifact boundaries
- reuse the existing browser commit path and preserve MoonBit terminal classifications
- add deterministic CLI, lifecycle, candidate-boundary, schema-compatibility, and real-browser coverage
- isolate the fixed Codex child-process lifecycle in one private support module without introducing a provider abstraction

## Credentialed smoke
- exactly one Codex request was sent with model `gpt-5.6-luna`
- immutable result: `provider_failed`, invocationCount 1
- provider rejected the pre-fix schema with HTTP 400 `invalid_json_schema`; no retry was sent
- commit 77972f9b removes the incompatible empty `prefixItems` form and is deterministically tested and independently reviewed
- no post-fix credentialed request was sent; post-fix credentialed success and design Required test 8 remain unmet
- deterministic fake-provider success is not live feature validation and is not evidence of provider reliability

## Verification
- `NEW_MOON_MOD=0 moon test -p dowdiness/canopy/ffi/jsx`: 68/68 pass
- `NEW_MOON_MOD=0 moon check`: pass
- complete runner suite: 18/18 pass
- `npx tsc --noEmit`: pass
- `npm run build`: pass
- default Web Playwright suite: 75 pass, 2 expected skips
- dedicated fake-provider browser/MoonBit path: 1/1 pass
- real descendant cleanup: grandchild absent after bounded escalation

## Reuse check
- reused `GENUI_CANDIDATE_SCHEMA`, `buildFeasibilityPrompt`, fixture lookup, recorded inputs, and existing MoonBit commit/evaluation path
- checked but did not reuse comparison App Server, sandbox, scheduler, journal, and aggregate evidence because this command is single-provider and local-only
- Node core `child_process.spawn` and `stream/promises.finished` remain the process lifecycle primitives; no new runtime dependency
- no new MoonBit helper or runtime dependency

## Experimental retention contract

This PR is a private experimental maintainer diagnostic, not an accepted runtime, production API, provider abstraction, CI gate, or evidence that Generative UI has user value.

**Review date:** 2026-08-31. The pre-merge credentialed smoke does not count as reuse. This contract does not authorize another credentialed request; each future request still requires a separately approved maintenance need.

**Decision owner:** Canopy maintainers. By the review date, record one final `KEEP` or `DELETE` comment on PR #908 with links to the secret-safe eligible-event summaries. A missing decision or incomplete evidence means `DELETE`.

An eligible maintenance event must be an independently arising investigation of a Codex CLI/model/schema change, provider invocation failure, or candidate decode/materialization/rubric/replay/session-commit failure. It must state its maintenance question before execution, use exactly one provider invocation with no runner retry, and must not be created only to justify retaining this command. Repeating the existing smoke or exercising the fake provider does not count.

For each eligible event, record only a secret-safe summary: date, maintenance question, trigger, commit/model/CLI identity, terminal classification, first rejecting boundary, artifact completeness, any ad-hoc code or manual workaround, resulting action, invocation count, and whether any secret/private-path/raw-output leak occurred. Raw provider output remains only in the private run directory.

**KEEP only if, by 2026-08-31:**

- the command is used for at least two independent eligible events with different triggers;
- both runs answer the recorded maintenance question without an ad-hoc script or repository code change;
- both produce one terminal classification, identify the first rejecting boundary, and retain complete private artifacts;
- at least one reaches the candidate or MoonBit pipeline rather than ending at provider invocation;
- the maintainer can name a concrete action selected from each result; and
- there is no retry ambiguity, process leak, artifact leak, secret leak, or private-path leak.

**DELETE if any KEEP condition is unmet.** Delete the npm command, minimal-provider runner, private process support module, dedicated Playwright config/spec, DEV-only saved-candidate hook, and harness-only tests. Keep the provider-schema compatibility fix and its regression test only if they remain independently required.

A KEEP decision establishes only recurring value as a private maintainer diagnostic. It does not authorize promotion to production or a provider-neutral interface.

## Product-value separation

The harness-retention decision and the Generative UI product-value decision are independent. PR #908 usage, terminal success, diagnostic speed, and invocation count provide no target-user evidence and must not be included in a `FIXED`, `RULES`, or `GENERATE` decision.

The canonical live-provider experiment remains deferred: no manifest is frozen, no gate has run, and its former 2026-07-29 decision date is inactive. If product discovery resumes, a reviewed amendment must freeze a new decision date, manifest, target-user population, and evidence controls. Gate A remains provider-free fixed explorer versus hand-authored oracle; only its prescribed Gate A, Gate B, and conditional Gate C sequence may establish product value. PR #908 is not used to bypass those gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “minimal provider” end-to-end workflow covering provider execution, browser verification, and terminal reporting.
  - Added a runnable CLI command for minimal provider checks.
  - Added a development-only method to commit a saved candidate for browser validation.
- **Bug Fixes**
  - Improved component candidate schema validation when no attributes are provided.
- **Tests**
  - Added Playwright configuration and spec for minimal provider runs.
  - Added comprehensive Node.js end-to-end tests covering timeouts, interruption, and output classification.
- **Documentation**
  - Added an end-to-end refactor plan for the minimal provider workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Wall time: 0.89 seconds


Wall time: 1.08 seconds