### PR TITLE
docs(genui): define opportunity discovery protocol

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -159,6 +159,17 @@ maintenance and proving-ground mode.
   Already covered: click selection, keyboard navigation, and scroll-to-selection (`examples/ideal/web/e2e/outline-navigation.spec.ts`); tree roles, selection, active-descendant, and collapse ARIA (`examples/ideal/web/e2e/outline-aria.spec.ts`); resize-handle behavior while `.tree-rows` scrolls (`examples/ideal/web/e2e/outline-resizable.spec.ts`).
   Closed here: collapse/expand descendant visibility plus collapsed badges; light-DOM outline row drag/drop in `examples/ideal/web/e2e/outline-drag-drop.spec.ts`, verifying CRDT/CodeMirror text sync plus outline reorder. Shadow structure-mode drag/drop remains covered separately by `examples/ideal/web/e2e/drag-drop.spec.ts`.
 
+- [ ] Discover where Generative UI creates user value.
+  Why: current engineering evidence covers a bounded Declarative/Projectional
+  path, but no research has established which people, jobs, value sources,
+  lifecycles, or generation modes deserve product investment.
+  Plan: `docs/plans/2026-07-17-generative-ui-opportunity-discovery-design.md`
+  Exit: a reviewed opportunity map samples the bounded initial tranche across
+  Static, Declarative, Open-Ended, Dynamic, Projectional, and Hybrid modes with
+  lifecycle recorded separately; ranked hypotheses name their strongest
+  alternatives, useful moments, capability and authority bundles, and
+  confirmatory exit criteria.
+
 - [ ] Verify the incremental Generative UI semantic core.
   Why: the document-engine authority, transaction, recovery, and identity
   claims have no implementation or falsifiable evidence; adapter work before

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -164,11 +164,12 @@ maintenance and proving-ground mode.
   path, but no research has established which people, jobs, value sources,
   lifecycles, or generation modes deserve product investment.
   Plan: `docs/plans/2026-07-17-generative-ui-opportunity-discovery-design.md`
-  Exit: a reviewed opportunity map samples the bounded initial tranche across
-  Static, Declarative, Open-Ended, Dynamic, Projectional, and Hybrid modes with
-  lifecycle recorded separately; ranked hypotheses name their strongest
-  alternatives, useful moments, capability and authority bundles, and
-  confirmatory exit criteria.
+  Exit: the bounded initial tranche yields a reviewed opportunity map and
+  ranked hypotheses; Stage 3 compares the smallest eligible modes for each
+  surviving hypothesis, with lifecycle recorded separately. Closure requires
+  the redacted evidence corpus, representation comparison, confirmatory
+  proposal or stop recommendation, and canonical direction updates defined by
+  the plan.
 
 - [ ] Verify the incremental Generative UI semantic core.
   Why: the document-engine authority, transaction, recovery, and identity

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -1,16 +1,30 @@
 # Generative UI direction
 
-## Thesis
+## Research purpose
 
-Canopy should treat Generative UI as incremental editing of a stateful UI
-program, not as repeated generation of disposable HTML or JSX.
+Canopy's top-level Generative UI question is not tied to one data format, user
+job, output representation, or provider:
 
-The important property is that an AI-generated view remains editable,
-state-preserving, incrementally updateable, and safe to reconcile with human
-edits. JSX is one projection surface for this idea, not the definition of the
-whole system.
+> For which people, intents, contexts, and lifecycles does a generated
+> interface create useful capability, and what generation authority is
+> necessary to create that value?
 
-The existing architecture is a good fit:
+The research program must discover those conditions before choosing a preferred
+representation. A successful experiment in one job does not establish a global
+architecture, and a failed experiment does not reject Generative UI outside
+that experiment's frozen scope.
+
+## Current architecture hypothesis
+
+Canopy's current hypothesis is that treating generated UI as incremental editing
+of a stateful UI program can make the result editable, state-preserving,
+incrementally updateable, and safe to reconcile with human edits. This is one
+candidate answer to the research question, not the definition of Generative UI
+or a conclusion that disposable documents and executable generated interfaces
+are unhelpful.
+
+JSX is one projection surface for this hypothesis, not the definition of the
+whole system. The existing architecture is a good fit:
 
 ```text
 source / semantic UI program
@@ -37,6 +51,40 @@ Canopy does not yet define how concurrent semantic UI edits map to projection
 identity, conflict resolution, or user-visible state. The CRDT source-edit path
 and the future semantic-edit path must not be treated as having the same
 guarantees.
+
+## Candidate spectrum
+
+Opportunity discovery evaluates these modes as parallel candidates:
+
+| Mode | Generated result | Native strength |
+| --- | --- | --- |
+| Static | Content, parameters, or tool choices inside a host-authored UI | Predictability, speed, and host control |
+| Declarative | A component tree, bindings, and allowlisted actions | Flexible composition with structural validation |
+| Open-Ended | A document such as HTML and CSS | Visual freedom and portable presentation |
+| Dynamic | Executable UI code | Novel stateful behavior, computation, and integration |
+| Projectional | A semantic UI artifact and structured edits | Direct editing, identity, replay, and collaboration |
+| Hybrid | Explicitly bounded combinations of the other modes | Authority matched to each part of the interface |
+
+These modes are not a maturity ladder and do not form a single strength axis.
+Declarative generation is not preferred because its first implementation
+already exists, Dynamic generation is not a last resort, and Projectional
+generation is not the winner merely because it matches Canopy's architecture.
+Open-Ended presentation, Dynamic execution, and Projectional identity are
+incomparable capabilities. A job may require one mode, several incomparable
+minimum modes, or a Hybrid.
+
+Lifecycle is a separate axis. Static, Declarative, Open-Ended, Dynamic,
+Projectional, and Hybrid results may each be ephemeral, session-scoped,
+personally persistent, shared, or productized. Persistence increases identity,
+migration, provenance, replay, ownership, and maintenance obligations; it is
+not intrinsic to Projectional representation.
+
+Expressiveness, execution authority, persistence, and inspectability are also
+separate axes. Dynamic generation remains eligible where custom behavior,
+local state, computation, or integration produces value unavailable to a fixed
+component vocabulary. Its sandbox, dependency, interruption, lifecycle,
+latency, and maintenance costs are evidence to measure against that value, not
+reasons to exclude it before discovery.
 
 ## Direction
 
@@ -74,12 +122,17 @@ Expressiveness and authority are separate axes. Capability boundaries should
 constrain ambient authority and effects without treating the first prototype's
 component allowlist as the permanent ceiling on composition.
 
-Generated UI must not imply unrestricted authority. Components, actions, data
-access, expressions, and side effects should be constrained by explicit
-capabilities and schemas. The first prototype should use an allowlisted,
-declarative component model with no model-controlled network access, raw HTML,
-navigation, or arbitrary code/expression execution. Structural edits should be
-auditable and, where needed, require approval before effects occur.
+Generated UI must not imply unrestricted authority. Every mode needs a boundary
+appropriate to what it can execute: schemas and allowlists for declarative
+programs; document isolation for open-ended output; and sandboxing, budgets,
+interruption, dependency policy, re-entry control, and disposal for Dynamic
+code. Projectional artifacts additionally need explicit edit, identity, and
+commit authority.
+
+The first engineering prototype uses an allowlisted declarative component model
+with no model-controlled network access, raw HTML, navigation, or arbitrary
+code/expression execution. That is a contract for one validated slice, not a
+research conclusion or a permanent ceiling on later experiments.
 
 ### LLM input boundary
 
@@ -137,15 +190,29 @@ DOM application is required before committing a candidate. A user-visible
 approval preview is a separate product feature and is deferred beyond the
 first vertical slice.
 
-## High-value applications
+## Opportunity hypotheses
+
+Potential value is broader than one data-exploration task. Discovery should
+sample materially different jobs rather than treat any item below as an
+established consumer:
 
 - Adaptive data-exploration workspaces that add filters, charts, and detail
   views without losing the current query state.
-- Forms that reveal and validate fields based on the user's answers.
-- Educational surfaces that generate exercises, hints, visualizations, and
-  explanations around the learner's current state.
-- Collaborative workspaces where people and AI edit the same structured view.
-- Temporary debugging interfaces assembled from live program state.
+- Forms and workflows that reveal, validate, and act on information according
+  to the person's changing intent.
+- Educational surfaces that generate exercises, hints, simulations,
+  visualizations, and explanations around the learner's current state.
+- Monitoring and debugging interfaces assembled from live system state.
+- Personal or domain-specific applications whose useful interaction was not
+  known when the host was authored.
+- Creative authoring surfaces in which the generated interface is itself
+  inspected, edited, and reused.
+- Collaborative workspaces where people and AI evolve a shared artifact.
+
+The value source may be information selection, composition, visual adaptation,
+novel behavior, computation, integration, editability, persistence, reuse, or
+collaboration. An experiment must name which source it tests instead of using
+"Generative UI" as an undifferentiated treatment.
 
 ## Risks to measure
 
@@ -156,7 +223,12 @@ first vertical slice.
 - Versioning and migration of generated UI structures.
 - Latency, token cost, and bundle/runtime overhead.
 
-## Recommended sequence
+## Current bounded implementation sequence
+
+The following sequence validates Canopy's incremental, capability-bounded
+architecture hypothesis. It is not the ordering for opportunity discovery and
+does not make its JSON/CSV job, Declarative representation, or projectional
+direction the default for later product experiments.
 
 1. Finish V1 correctness gates: CI, browser validation, and property-based
    coverage for patch ordering, sibling indexes, nested updates, disposal,
@@ -218,10 +290,15 @@ renderer-neutral contract.
 
 ## Non-goals
 
-This direction does not require making JSX a universal UI language, allowing
-arbitrary model-generated code, or replacing conventional hand-authored UI.
-The initial goal is a safe incremental bridge between structured generation,
-human editing, and multiple UI projections.
+This direction does not require making JSX a universal UI language, replacing
+conventional hand-authored UI, or treating unrestricted execution as a
+prerequisite for every experiment. It also does not exclude open-ended
+documents, Dynamic generated code, or hybrids from opportunity discovery.
+
+The current engineering goal is narrower: establish a safe incremental bridge
+between structured generation, human editing, and multiple UI projections.
+Other modes must earn their own value and safety claims through evidence suited
+to what they generate and execute.
 
 ## Human outcome gate
 
@@ -238,9 +315,11 @@ This document's generative-UI-specific interpretation:
 - **Apply/recovery preserves focus, selection, and orientation.** Generated
   changes preserve user-entered values, focus, selection, and local
   customizations whenever the structure permits.
-- **Generated outcomes are compared with fixed/rules alternatives.** The
-  generated outcome must produce a measurably better result on a named task
-  than a fixed, rules-based alternative. Novelty alone is not justification.
+- **Generated outcomes are compared with the strongest realistic alternative.**
+  The comparator may be a fixed UI, rules-based system, hand-authored
+  application, manual coding, conversational answer, or the workflow without
+  an interface. The generated outcome must create measurably better value on a
+  named task; novelty alone is not justification.
 
 These gates are product requirements, not technical implementation details.
 They sit above the commit and candidate contracts defined in this document.

--- a/docs/architecture/generative-ui-direction.md
+++ b/docs/architecture/generative-ui-direction.md
@@ -1,332 +1,169 @@
 # Generative UI direction
 
-## Research purpose
+## Purpose and authority
 
-Canopy's top-level Generative UI question is not tied to one data format, user
-job, output representation, or provider:
+Canopy's top-level Generative UI question is not tied to one user job, output
+representation, or generation system:
 
 > For which people, intents, contexts, and lifecycles does a generated
 > interface create useful capability, and what generation authority is
 > necessary to create that value?
 
-The research program must discover those conditions before choosing a preferred
-representation. A successful experiment in one job does not establish a global
-architecture, and a failed experiment does not reject Generative UI outside
-that experiment's frozen scope.
+This document is the source of truth for durable Generative UI principles,
+taxonomy, and architectural claim boundaries.
 
-## Current architecture hypothesis
-
-Canopy's current hypothesis is that treating generated UI as incremental editing
-of a stateful UI program can make the result editable, state-preserving,
-incrementally updateable, and safe to reconcile with human edits. This is one
-candidate answer to the research question, not the definition of Generative UI
-or a conclusion that disposable documents and executable generated interfaces
-are unhelpful.
-
-JSX is one projection surface for this hypothesis, not the definition of the
-whole system. The existing architecture is a good fit:
-
-```text
-source / semantic UI program
-  → incremental parse and projection
-  → session-scoped identity preservation
-  → patch adapter
-  → UI surface
-```
-
-## Why this matters
-
-Whole-view regeneration causes lost input, remounted components, broken focus,
-unnecessary work, and conflicts between AI and human edits. Incremental
-projection makes the generated result behave more like a shared, editable
-artifact.
-
-The differentiator is therefore not that a model can write JSX. It is that a
-model can safely edit a structured UI while preserving user state and making
-the change inspectable and reversible. Semantic merging is a later capability,
-not a V1 guarantee.
-
-For V1, supported edits are limited to sequential or single-writer edits.
-Canopy does not yet define how concurrent semantic UI edits map to projection
-identity, conflict resolution, or user-visible state. The CRDT source-edit path
-and the future semantic-edit path must not be treated as having the same
-guarantees.
+Research and implementation plans own concrete jobs, representations, execution
+mechanisms, staged sequences, and acceptance criteria. Evidence from one bounded
+plan may revise this direction, but it must not silently become a general
+architectural conclusion.
 
 ## Candidate spectrum
 
-Opportunity discovery evaluates these modes as parallel candidates:
+Opportunity discovery evaluates six representation modes as parallel candidates:
 
-| Mode | Generated result | Native strength |
+| Mode | Architectural definition | Native strength |
 | --- | --- | --- |
-| Static | Content, parameters, or tool choices inside a host-authored UI | Predictability, speed, and host control |
-| Declarative | A component tree, bindings, and allowlisted actions | Flexible composition with structural validation |
-| Open-Ended | A document such as HTML and CSS | Visual freedom and portable presentation |
-| Dynamic | Executable UI code | Novel stateful behavior, computation, and integration |
-| Projectional | A semantic UI artifact and structured edits | Direct editing, identity, replay, and collaboration |
-| Hybrid | Explicitly bounded combinations of the other modes | Authority matched to each part of the interface |
+| Static | Generated content or choices within a host-owned interaction | Predictability and host control |
+| Declarative | Generated structure composed within declared capabilities | Inspectability and structural validation |
+| Open-Ended | Generated presentation outside a fixed structural catalog | Expressive presentation |
+| Dynamic | Generated executable behavior | Novel state, computation, and integration |
+| Projectional | Generated semantic operations over an identity-bearing artifact | Editing, replay, provenance, and collaboration |
+| Hybrid | Explicitly bounded combinations of other modes | Authority matched to each part of an interface |
 
 These modes are not a maturity ladder and do not form a single strength axis.
-Declarative generation is not preferred because its first implementation
-already exists, Dynamic generation is not a last resort, and Projectional
-generation is not the winner merely because it matches Canopy's architecture.
 Open-Ended presentation, Dynamic execution, and Projectional identity are
 incomparable capabilities. A job may require one mode, several incomparable
 minimum modes, or a Hybrid.
 
-Lifecycle is a separate axis. Static, Declarative, Open-Ended, Dynamic,
-Projectional, and Hybrid results may each be ephemeral, session-scoped,
-personally persistent, shared, or productized. Persistence increases identity,
-migration, provenance, replay, ownership, and maintenance obligations; it is
-not intrinsic to Projectional representation.
+Lifecycle is a separate axis. Every representation mode may be ephemeral,
+session-scoped, personally persistent, shared, or productized. Persistence
+increases identity, migration, provenance, replay, ownership, and maintenance
+obligations; it is not intrinsic to Projectional representation.
 
 Expressiveness, execution authority, persistence, and inspectability are also
-separate axes. Dynamic generation remains eligible where custom behavior,
-local state, computation, or integration produces value unavailable to a fixed
-component vocabulary. Its sandbox, dependency, interruption, lifecycle,
-latency, and maintenance costs are evidence to measure against that value, not
-reasons to exclude it before discovery.
+separate axes. Each experiment must identify the minimum sufficient capability
+and authority bundle instead of assuming that a more expressive mode is better.
 
-## Direction
+## Durable principles
 
-### Structured edits instead of whole-view generation
+### Discover value before choosing architecture
 
-Natural-language requests should eventually lower to semantic UI edits such
-as adding a field, changing a layout, or showing a detail panel. The system
-should validate, preview, reject, undo, and merge these edits at a structural
-boundary.
+A Generative UI proposal must name the person, job, context, value source,
+strongest realistic alternative, expected lifecycle, and required authority.
+Generation is justified only by a useful outcome that the strongest alternative
+cannot provide as effectively. Novelty and technical feasibility are not product
+value.
 
-### Human and AI co-editing
+### Keep generated output subordinate to human authority
 
-AI changes must preserve user-entered values, focus, selection, and local
-customizations wherever the structure permits. Human edits and AI edits should
-eventually be represented in the same incremental and collaborative model. The
-V1 implementation should first establish these preservation rules for
-sequential edits before claiming concurrent co-editing semantics.
+People must be able to understand what the system proposes, what it may affect,
+and which decisions remain theirs. Consequential changes require explicit
+acceptance or a narrow, revocable policy chosen by the person. Generated output
+must not acquire authority merely because it was successfully produced.
 
-### Streaming and interruption
+### Preserve continuity when continuity creates value
 
-The UI should be useful while generation is incomplete. This requires
-well-defined partial states, placeholders, transaction boundaries, cancellation,
-and resumption rather than treating incomplete output as a fatal parse error.
+When a job depends on ongoing interaction or editing, generated changes should
+preserve the person's values, focus, selection, orientation, and local
+customizations wherever the structure permits. Whole replacement remains a
+valid mode where continuity is unnecessary; it is not the default for an
+identity-bearing artifact.
 
-### Semantic UI with multiple projections
+### Separate proposals from committed state
 
-The long-term abstraction should be a semantic UI model that can project to
-JSX/DOM, native UI, canvas, accessibility-oriented views, voice interfaces,
-and other surfaces. Renderer adapters must share one patch and identity
-contract while remaining free to implement platform-specific behavior.
+Generation produces untrusted proposals, not authoritative state. A proposal
+must cross explicit validation and commitment boundaries before it can change a
+canonical artifact. Rejection or failed application must not be reported as a
+successful commit.
 
-### Capability-bounded generation
+Generation, validation, state ownership, and commitment policy remain distinct
+responsibilities. No generation mechanism owns artifact identity or decides by
+itself that an output is accepted, useful, or committed.
 
-Expressiveness and authority are separate axes. Capability boundaries should
-constrain ambient authority and effects without treating the first prototype's
-component allowlist as the permanent ceiling on composition.
+### Make change inspectable and reversible
 
-Generated UI must not imply unrestricted authority. Every mode needs a boundary
-appropriate to what it can execute: schemas and allowlists for declarative
-programs; document isolation for open-ended output; and sandboxing, budgets,
-interruption, dependency policy, re-entry control, and disposal for Dynamic
-code. Projectional artifacts additionally need explicit edit, identity, and
-commit authority.
+Generated changes should retain enough identity, rationale, and provenance for a
+person to inspect what changed and why. Reversal must preserve prior work rather
+than reconstructing an approximation of it. Persistence and collaboration raise
+these obligations but do not define the representation mode.
 
-The first engineering prototype uses an allowlisted declarative component model
-with no model-controlled network access, raw HTML, navigation, or arbitrary
-code/expression execution. That is a contract for one validated slice, not a
-research conclusion or a permanent ceiling on later experiments.
+### Treat incompleteness and interruption as normal states
 
-### LLM input boundary
+Generation may be partial, cancelled, superseded, or resumed. Those states need
+explicit semantics so incomplete work does not corrupt the last accepted
+artifact or overwrite newer intent.
 
-An LLM is an untrusted, asynchronous candidate generator, not the source of
-truth for UI state. Its output must never mutate the committed UI directly.
-The input path is:
+### Scope identity and collaboration claims precisely
 
-```text
-LLM/provider
-  → untrusted candidate
-  → syntax and schema validation
-  → capability validation
-  → base-revision check
-  → candidate projection and internal dry-run
-  → committed UI update
-```
+Sequential editing, concurrent editing, cross-session identity, and shared
+collaboration are different guarantees. Evidence for one does not establish the
+others. Canopy must not claim semantic co-editing until conflict, identity, and
+recovery behavior are defined for that scope.
 
-The provider transport, request lifecycle, UI-program validation, and renderer
-must remain separate responsibilities. Provider-specific code may fetch and
-decode model responses, but it must not own UI identity, DOM state, or commit
-policy. The request lifecycle owns request identity, observed revision,
-cancellation, chunk sequencing and assembly, finalization, stale-completion
-rejection, terminal-state idempotency, and typed failure classification.
-The UI input adapter owns the constrained UI-program schema and candidate
-validation. The renderer only applies validated candidates through the session
-commit boundary.
+### Separate technical correctness from product evidence
 
-The first implementation should use a replayable fixed-chunk source before
-connecting a live model. This makes incomplete output, duplicate chunks,
-revision conflicts, cancellation, late responses, and deterministic replay
-testable without depending on model behavior.
+Deterministic validation can establish lifecycle, state, and projection
+invariants. It cannot establish that a generated interface is useful.
 
-Deterministic replay establishes lifecycle and projection correctness; it does
-not establish product value. Product experiments must compare generated outcomes
-with an appropriate hand-authored baseline.
+Product claims require comparison with the strongest realistic alternative on a
+named job. Architecture claims require evidence across materially different
+contexts.
 
-The output representation should evolve in stages:
+## Current architecture hypothesis
 
-1. constrained JSX-like source;
-2. semantic edits such as adding a table or filter;
-3. a renderer-neutral semantic UI program, only after a real use case and a
-   second adapter establish the shared invariants.
+Canopy's current hypothesis is that incremental editing of an identity-bearing
+semantic artifact can create value when people need generated changes to remain
+editable, state-preserving, inspectable, and reversible. This hypothesis aligns
+with Canopy's projectional architecture, but it is neither the definition of
+Generative UI nor the preferred answer before opportunity discovery.
 
-Every candidate is evaluated against an explicit base revision. Cancelled or
-stale candidates are rejected, and only a validated candidate can advance the
-committed revision. A candidate is not committed until DOM application succeeds
-and the session state, registry, mounted IDs, and revision remain consistent.
-If application fails partway through, the existing session recovery and
-dirty-state contract determines whether the previous state is restored or the
-affected UI is rebuilt; the candidate must not be reported as committed. This
-boundary is more important than any particular model provider or transport API.
+Where semantic editing is justified, natural-language intent should lower to
+structured operations over a canonical model rather than bypassing that model.
+Multiple projections may share semantic intent and identity without requiring a
+single universal representation or premature renderer-neutral contract.
 
-The input path has two distinct kinds of preview. An internal dry-run or fake
-DOM application is required before committing a candidate. A user-visible
-approval preview is a separate product feature and is deferred beyond the
-first vertical slice.
-
-## Opportunity hypotheses
-
-Potential value is broader than one data-exploration task. Discovery should
-sample materially different jobs rather than treat any item below as an
-established consumer:
-
-- Adaptive data-exploration workspaces that add filters, charts, and detail
-  views without losing the current query state.
-- Forms and workflows that reveal, validate, and act on information according
-  to the person's changing intent.
-- Educational surfaces that generate exercises, hints, simulations,
-  visualizations, and explanations around the learner's current state.
-- Monitoring and debugging interfaces assembled from live system state.
-- Personal or domain-specific applications whose useful interaction was not
-  known when the host was authored.
-- Creative authoring surfaces in which the generated interface is itself
-  inspected, edited, and reused.
-- Collaborative workspaces where people and AI evolve a shared artifact.
-
-The value source may be information selection, composition, visual adaptation,
-novel behavior, computation, integration, editability, persistence, reuse, or
-collaboration. An experiment must name which source it tests instead of using
-"Generative UI" as an undifferentiated treatment.
-
-## Risks to measure
-
-- Non-deterministic or surprising model edits.
-- State loss during identity changes or reconciliation.
-- Accessibility and responsive-layout regressions.
-- Unsafe actions hidden behind generated controls.
-- Versioning and migration of generated UI structures.
-- Latency, token cost, and bundle/runtime overhead.
-
-## Current bounded implementation sequence
-
-The following sequence validates Canopy's incremental, capability-bounded
-architecture hypothesis. It is not the ordering for opportunity discovery and
-does not make its JSON/CSV job, Declarative representation, or projectional
-direction the default for later product experiments.
-
-1. Finish V1 correctness gates: CI, browser validation, and property-based
-   coverage for patch ordering, sibling indexes, nested updates, disposal,
-   isolation, and failed-apply recovery. See issue #888.
-2. Demonstrate one read-only end-to-end use case: an AI-assisted JSON/CSV data
-   exploration surface that incrementally produces a table, filters, and a
-   detail/summary panel while preserving user state. Keep generated actions
-   side-effect-free and place the minimal component, action, and data
-   capability boundary before expanding the scope.
-3. Extract provisional patch, identity, state-preservation, capability, and
-   candidate-commit invariants from that use case. Require internal dry-run
-   validation; defer user-visible approval preview.
-4. Validate those provisional invariants with a second materially different
-   adapter, then freeze the renderer-neutral conformance suite and contract.
-5. Add semantic edits, preview/undo, and auditability. Define concurrent
-   semantic-edit and conflict behavior before describing co-editing as a
-   supported guarantee, then generalize from JSX to multiple projections.
-
-## First vertical-slice acceptance criteria
-
-The first Generative UI prototype is successful only if it demonstrates all of
-the following:
-
-- Existing input, filter, and selection state survives incremental generation
-  whenever the structure permits.
-- Incomplete or invalid generated input does not destroy the last valid UI.
-- Reapplying the same update produces the same modeled UI result.
-- A failed patch application leaves the candidate uncommitted and follows the
-  session recovery/dirty-state contract without falsely advancing revision.
-- The generated surface uses only allowlisted declarative components: no
-  model-controlled network access, persistence, navigation, raw HTML, or
-  arbitrary code/expression execution is reachable through generated controls.
-- Cancelling generation invalidates its generation revision; late chunks from
-  that revision are rejected and cannot overwrite newer committed UI.
-- Resumption starts only from an explicitly selected committed revision.
-- Chunk sequencing, duplicate handling, finalization, and terminal-state
-  idempotency are deterministic and owned by the request lifecycle.
-- Internal dry-run validation succeeds before any candidate commit; a
-  user-visible approval preview is not required for this first slice.
-- The prototype records enough patch/revision information to inspect what the
-  model changed and to measure update latency.
-
-The prototype should be treated as a sequential or single-writer experiment.
-It does not claim concurrent semantic merging, cross-session identity, or a
-renderer-neutral contract.
-
-## Explicitly deferred
-
-- Concurrent semantic-edit conflict resolution.
-- Persistent or cross-session view identity.
-- General-purpose renderer-neutral APIs.
-- Additional language projections beyond the first validated use case.
-- Typed pure-expression and local state-transition models, pending a concrete
-  use case and validation by a materially different adapter.
-- Commands-as-data, effect approval, and undo/audit semantics for generated
-  actions.
-- Formal proof of the JavaScript/DOM boundary; prove pure reconciliation
-  invariants only after they are isolated from the adapter.
-
-## Non-goals
-
-This direction does not require making JSX a universal UI language, replacing
-conventional hand-authored UI, or treating unrestricted execution as a
-prerequisite for every experiment. It also does not exclude open-ended
-documents, Dynamic generated code, or hybrids from opportunity discovery.
-
-The current engineering goal is narrower: establish a safe incremental bridge
-between structured generation, human editing, and multiple UI projections.
-Other modes must earn their own value and safety claims through evidence suited
-to what they generate and execute.
+The hypothesis remains bounded. A successful Projectional experiment does not
+exclude Static, Declarative, Open-Ended, Dynamic, or Hybrid approaches. A failed
+experiment rejects only its frozen person, job, representation, comparator, and
+evidence contract.
 
 ## Human outcome gate
 
-Generated UI changes are meaningful only when they meet the product-level
-gates defined in [Human-centered product principles](human-centered-product-principles.md).
-This document's generative-UI-specific interpretation:
+Generated UI changes are meaningful only when they meet the product-level gates
+defined in [Human-centered product principles](human-centered-product-principles.md):
 
-- **Candidate rationale/provenance tied to the exact candidate/revision.**
-  Every generated change carries a reason the person can read, linked to the
-  specific candidate and base revision that produced it.
-- **Preview/rejection cannot mutate committed state.** Internal dry-run must
-  validate a candidate before it reaches the session commit boundary; rejected
-  candidates change no committed state.
-- **Apply/recovery preserves focus, selection, and orientation.** Generated
-  changes preserve user-entered values, focus, selection, and local
-  customizations whenever the structure permits.
-- **Generated outcomes are compared with the strongest realistic alternative.**
-  The comparator may be a fixed UI, rules-based system, hand-authored
-  application, manual coding, conversational answer, or the workflow without
-  an interface. The generated outcome must create measurably better value on a
-  named task; novelty alone is not justification.
+- **Legibility and governance:** people can understand generated changes and
+  retain authority over consequential effects.
+- **Orientation:** changes preserve the person's place and attention.
+- **Accessible equivalence:** generated capability has an equivalent accessible
+  path.
+- **Rationale and reversal:** changes carry understandable provenance and can be
+  undone without losing prior work.
+- **Net value:** the outcome improves a named job over its strongest realistic
+  alternative.
 
-These gates are product requirements, not technical implementation details.
-They sit above the commit and candidate contracts defined in this document.
-A private semantic-core experiment may falsify proposed invariants, but it does
-not replace this sequence, authorize product integration, or freeze a public
-renderer-neutral contract.
+These gates govern every representation mode. No architecture, model, or
+implementation path is exempt.
 
-Related: [JSX Incremental Parser for Generative UI](../plans/2026-07-09-jsx-incremental-parser-generative-ui.md),
-[property-based correctness coverage issue #888](https://github.com/dowdiness/canopy/issues/888),
-and the [Incremental Generative UI document engine](../design/incremental-generative-ui-document-engine.md).
+## Non-goals
+
+This direction does not prescribe one universal UI language, require generated
+execution, replace conventional hand-authored interfaces, or rank representation
+modes before evidence exists. It also does not authorize production integration,
+participant recruitment, or a public contract.
+
+## Detailed work
+
+Concrete research and execution details live in their bounded documents:
+
+- [Generative UI opportunity discovery](../plans/2026-07-17-generative-ui-opportunity-discovery-design.md)
+  defines sampling, evidence, comparison, and stop rules.
+- [Generative UI input vertical slice](../plans/2026-07-12-generative-ui-input-vertical-slice.md)
+  records the completed bounded implementation sequence and its technical
+  acceptance criteria.
+- [Structured-data bounded-provider experiment](../plans/2026-07-15-generative-ui-live-provider-experiment-design.md)
+  preserves one deferred confirmatory protocol without generalizing its job or
+  representation.
+- [Incremental Generative UI semantic-core validation](../plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md)
+  defines the evidence required for the current semantic architecture
+  hypothesis.

--- a/docs/plans/2026-07-15-generative-ui-live-provider-experiment-design.md
+++ b/docs/plans/2026-07-15-generative-ui-live-provider-experiment-design.md
@@ -1,4 +1,4 @@
-# Generative UI live-provider experiment design
+# Structured-data bounded-provider experiment design
 
 - **Date:** 2026-07-15
 - **Status:** Deferred before campaign freeze; no manifest was frozen and no gate was executed
@@ -16,6 +16,27 @@ The active engineering question is defined separately in
 [Generative UI local-LLM technical feasibility](2026-07-15-generative-ui-local-llm-technical-feasibility.md).
 That work tests implementation feasibility only. It neither depends on this
 value protocol nor supplies evidence for its gates.
+
+## Experiment-local claim
+
+This is one confirmatory experiment over one job family: answering specified
+questions about unfamiliar, read-only JSON/CSV data. It compares the existing
+fixed explorer, a task-specific hand-authored oracle, deterministic rules, and
+an eligible model-generated candidate on a capability-bounded
+Declarative/Projectional surface.
+
+It does not compare Static, Declarative, Open-Ended, Dynamic, Projectional, and
+Hybrid generation as general approaches, nor does it compare their possible
+lifecycles. It cannot show that this job is Canopy's best Generative UI
+opportunity, that bounded declarative output is the preferred representation
+elsewhere, or that generated code and open-ended documents lack value. Its
+`FIXED`, `RULES`, and `GENERATE` labels are experiment-local retention decisions
+for this job and apparatus, not architecture-wide verdicts.
+
+Arbitrary model-generated HTML, JavaScript, network calls, calculations, and
+effects remain outside this experiment. A later opportunity hypothesis that
+needs Dynamic or Open-Ended generation requires its own execution boundary,
+comparator, evidence contract, and review.
 
 ## Why
 

--- a/docs/plans/2026-07-15-generative-ui-live-provider-experiment-design.md
+++ b/docs/plans/2026-07-15-generative-ui-live-provider-experiment-design.md
@@ -19,11 +19,16 @@ value protocol nor supplies evidence for its gates.
 
 ## Experiment-local claim
 
-This is one confirmatory experiment over one job family: answering specified
-questions about unfamiliar, read-only JSON/CSV data. It compares the existing
-fixed explorer, a task-specific hand-authored oracle, deterministic rules, and
-an eligible model-generated candidate on a capability-bounded
-Declarative/Projectional surface.
+This is one confirmatory experiment in the **Information understanding** job
+family: answering specified questions about unfamiliar, read-only JSON/CSV
+data. It tests one required value source from the opportunity taxonomy:
+**composing known controls around a new intent**.
+
+The experiment asks whether a task-specific composition of the bounded table,
+filter, and summary capabilities improves task completion over the fixed
+explorer. It compares the existing fixed explorer, a task-specific hand-authored
+oracle, deterministic rules, and an eligible model-generated candidate on the
+same capability-bounded Declarative/Projectional surface.
 
 It does not compare Static, Declarative, Open-Ended, Dynamic, Projectional, and
 Hybrid generation as general approaches, nor does it compare their possible
@@ -68,10 +73,18 @@ remain prohibited until the rules-capture gate makes Gemini eligible.
 - **Target-user hypothesis:** a developer or analyst answering a specified
   question over an unfamiliar read-only JSON/CSV schema. This is a hypothesis
   to test, not an established Canopy consumer.
-- **Primary signal:** correct task completion within a fixed time limit on
-  held-out schema-by-question cases.
-- **Secondary signals:** completion time, interaction count, blinded usefulness,
-  safety, latency, token use, provider cost, retries, and rejection reasons.
+- **Required value source:** composing known controls around a new intent.
+- **Primary signal:** the preregistered difference in correct task-completion
+  rate within a fixed time limit on held-out schema-by-question cases. Gate A
+  measures whether task-specific composition improves on the fixed explorer;
+  Gate B measures whether the capability-bounded surface preserves that uplift;
+  Gate C, when eligible, measures whether a model recovers additional uplift.
+- **Evidence:** each decisive observation binds the question, frozen capability
+  composition, answer correctness, completion time, interaction trace, and
+  reported useful moment. Aggregate success is attributed to this value source
+  only through the frozen arm comparisons.
+- **Secondary signals:** interaction count, blinded usefulness, safety, latency,
+  token use, provider cost, retries, and rejection reasons.
 - **Comparators:** the existing fixed explorer, a task-specific hand-authored
   oracle, deterministic rules, and Gemini only if the earlier gates pass.
 - **Lifecycle:** a removable experiment. It does not establish a public library

--- a/docs/plans/2026-07-17-generative-ui-opportunity-discovery-design.md
+++ b/docs/plans/2026-07-17-generative-ui-opportunity-discovery-design.md
@@ -246,9 +246,13 @@ For each sampled job family, investigate:
 - what failure would make the interface unsafe or untrustworthy;
 - which existing alternative is strongest.
 
-Evidence consists of redacted notes, workflow diagrams, observed artifacts,
-and coded opportunity statements. Interview counts are not a success metric;
-new evidence must stop changing the opportunity map before sampling ends.
+Evidence consists of redacted notes, workflow diagrams, coded opportunity
+statements, and artifacts retained under the rules below. An artifact may be
+retained only when it is synthetic, redacted, or covered by explicit participant
+consent. Stage 1 retains no sensitive source data.
+
+Interview counts are not a success metric. Sampling ends only after new evidence
+stops changing the opportunity map.
 
 ### Stage 2: Representation-neutral concept tests
 
@@ -274,10 +278,10 @@ Declarative; another may compare Declarative with Dynamic; a persistent
 collaboration hypothesis may compare a Projectional artifact with a persistent
 Dynamic artifact.
 
-Prototype source and behavior are fixed before each session. Provider calls are
-not required: deterministic fixtures, hand-authored alternatives, and
-facilitator-driven behavior isolate the representation question from model
-reliability.
+Prototype source and behavior are fixed before each session. Provider calls,
+credentials, and networked model execution are prohibited during sessions.
+Deterministic fixtures, hand-authored alternatives, and facilitator-driven
+behavior isolate the representation question from model reliability.
 
 ### Stage 4: Useful moments and terminal limits
 

--- a/docs/plans/2026-07-17-generative-ui-opportunity-discovery-design.md
+++ b/docs/plans/2026-07-17-generative-ui-opportunity-discovery-design.md
@@ -1,0 +1,462 @@
+# Generative UI opportunity discovery design
+
+- **Date:** 2026-07-17
+- **Status:** Proposed formative research; no participant recruitment or product experiment is authorized
+- **Decision owner:** Canopy maintainers
+
+## Purpose
+
+Canopy needs to discover where Generative UI creates user value before it
+selects a job, representation, provider, or production architecture.
+
+The question is:
+
+> For which people, intents, contexts, and lifecycles does a generated
+> interface create useful capability, and what capability and authority bundle
+> is necessary to create that value?
+
+The existing structured-data experiment covers only one part of this research.
+JSON/CSV exploration, an allowlisted component tree, provider integration, and
+Dynamic generated code remain hypotheses whose value must be tested.
+
+The output is an opportunity map and a ranked set of testable hypotheses. It is
+not a production roadmap, renderer contract, provider selection, or permission
+to send credentialed requests.
+
+## Relationship to existing work
+
+The [Generative UI direction](../architecture/generative-ui-direction.md)
+defines the broad research purpose and Canopy's current incremental-editing
+architecture hypothesis.
+
+The [Human-centered product principles](../architecture/human-centered-product-principles.md)
+define the non-negotiable authority, legibility, reversibility, cognitive
+stability, accessibility, and contestability gates used below.
+
+The [structured-data bounded-provider experiment](2026-07-15-generative-ui-live-provider-experiment-design.md)
+is one deferred confirmatory protocol for one job family.
+
+It combines a bounded Declarative surface with Projectional editing, but does
+not establish that either capability creates value. Its `FIXED`, `RULES`, and
+`GENERATE` labels apply only to that experiment.
+
+The local-LLM feasibility study, provider comparison, and minimal provider E2E
+work establish engineering facts about the existing candidate pipeline. They do
+not establish user value or rank generation modes.
+
+This design precedes any new product-value experiment. Discovery evidence may
+revise or reject the structured-data hypothesis without invalidating its
+engineering evidence.
+
+## Research boundaries
+
+### In scope
+
+- Identify recurring moments where a person's needed interface cannot be fully
+  anticipated by the host application.
+- Compare job families with different sources of value, lifecycles, and
+  authority needs.
+- Compare representation modes by what they enable and what they cost.
+- Observe existing workarounds, including manual coding, spreadsheets,
+  dashboards, prompt-only assistants, fixed applications, and abandoned tasks.
+- Build disposable, non-provider stimuli only when interviews cannot answer a
+  concrete uncertainty.
+- Rank hypotheses for later confirmatory experiments.
+
+### Out of scope
+
+- Selecting a provider or model.
+- Adding credentials, network transport, retries, or production lifecycle code.
+- Freezing a public candidate schema, renderer-neutral API, or execution runtime.
+- Treating novelty, visual polish, or model output quality as proof of value.
+- Generalizing from one job family to Generative UI as a whole.
+- Claiming that a representation is safe merely because its prototype is
+  sandboxed.
+
+## Opportunity model
+
+Each opportunity is recorded as a tuple:
+
+```text
+person × job × context × strongest alternative × value source × lifecycle
+× required capability and authority bundle
+```
+
+A hypothesis is incomplete if any element is unspecified. "Generate a UI for
+this prompt" is not a hypothesis because it names neither the person, job,
+existing alternative, nor useful outcome.
+
+### People and contexts
+
+Discovery must sample concrete contexts rather than demographic abstractions:
+
+- domain specialists working with unfamiliar or changing information;
+- developers and analysts building one-off internal tools;
+- operators responding to time-sensitive events;
+- creators shaping interactive artifacts;
+- people completing infrequent, high-friction workflows;
+- collaborators maintaining a shared artifact over time;
+- people with accessibility or device constraints unmet by a fixed interface.
+
+The listed contexts are recruitment hypotheses. A reviewed study protocol must
+establish that they include real Canopy users and define consent, privacy,
+compensation, access, and retention before recruitment.
+
+### Job families
+
+The initial sampling frame deliberately spans jobs whose value could come from
+different mechanisms:
+
+1. **Information understanding** — explore, compare, explain, and monitor data.
+2. **Planning and decision support** — assemble constraints, scenarios, and
+   tradeoffs into a manipulable workspace.
+3. **Workflow generation** — create task-specific forms, checklists, and action
+   sequences around an existing process.
+4. **Education and explanation** — adapt an interactive explanation or
+   simulation to a learner's question and progress.
+5. **Developer and domain tools** — construct small calculators, inspectors,
+   transformations, or debugging surfaces.
+6. **Creative authoring** — generate an interface or interactive artifact that
+   the person can inspect, edit, and reuse.
+7. **Personal applications** — support a narrow recurring need that was not
+   anticipated by an installed application.
+8. **Collaborative workspaces** — let people and AI evolve a persistent shared
+   artifact with provenance and conflict awareness.
+
+Discovery should seek disconfirming cases: tasks where a fixed interface,
+conversation, or direct manual action is clearly better.
+
+### Sources of value
+
+A generated interface may help through one or more distinct mechanisms:
+
+- selecting and organizing relevant information;
+- composing known controls around a new intent;
+- adapting presentation to content, device, or accessibility needs;
+- creating behavior that the host did not anticipate;
+- performing domain-specific computation;
+- integrating external capabilities;
+- making an output inspectable, editable, and reversible;
+- preserving an artifact for reuse or collaboration.
+
+The study must name the proposed mechanism. A visually different layout is not
+itself a value source.
+
+### Lifecycle
+
+The same representation can have different value and risk depending on how long
+it lives:
+
+- **Ephemeral:** used once and discarded.
+- **Session:** evolves during one task but is not retained.
+- **Personal persistent:** saved, reopened, and adapted by one person.
+- **Shared persistent:** edited, reviewed, and reused by multiple people.
+- **Productized:** becomes maintained software with compatibility and support
+  obligations.
+
+Persistence increases the importance of identity, migration, provenance,
+replay, ownership, and dependency control. Discovery records those needs; it
+does not presume that every useful interface must be persistent.
+
+## Representation spectrum
+
+Representation modes are compared as affordance-and-cost bundles, not as a
+maturity ladder.
+
+| Mode | Generated authority | Native strength | Principal cost or limit |
+|---|---|---|---|
+| **Static** | Text, image, or fixed rendered output | Explanation, preview, low execution risk | Little or no interaction |
+| **Declarative** | Allowlisted components, properties, and bindings | Inspectability, validation, host control | Cannot express behavior outside the catalog |
+| **Open-Ended** | HTML/CSS or document structures beyond a fixed component catalog | Broad presentation and document composition | Harder validation, accessibility, and sanitization |
+| **Dynamic** | Executable code or behavior | New stateful behavior, computation, and integration | Strong sandbox, interruption, dependency, and lifecycle requirements |
+| **Projectional** | Semantic operations over an identity-bearing model | Editability, replay, provenance, and collaboration | Semantic-model and migration complexity |
+| **Hybrid** | Deliberate combination of modes | Can separate durable intent from bounded or executable presentation | Cross-boundary ownership and failure semantics |
+
+Persistence is a lifecycle property, not a representation mode. Static,
+Declarative, Open-Ended, Dynamic, Projectional, and Hybrid artifacts may each be
+ephemeral, session-scoped, personally persistent, shared, or productized.
+
+The modes form a partial order of capabilities rather than a single strength
+axis. Open-Ended presentation, Dynamic execution, and Projectional identity are
+incomparable capabilities. Dynamic is neither the final stage nor the default,
+and Declarative is neither inherently sufficient nor merely a stepping stone.
+
+A prototype identifies the minimum sufficient capability and authority bundle
+for the hypothesized value source, then records every eligible mode that can
+provide it.
+
+Multiple incomparable minima remain eligible. If Static or Declarative output
+reproduces the useful moment without executable behavior, a Dynamic prototype
+cannot claim that execution created the value.
+
+## Discovery sequence
+
+### Initial bounded tranche
+
+The first tranche samples three deliberately contrasting job families:
+
+1. **Information understanding**, because the existing structured-data work
+   provides a known comparator while unfamiliar and changing information tests
+   selection, explanation, and presentation adaptation.
+2. **Workflow generation**, because infrequent and time-sensitive processes
+   test whether composed controls and action sequences outperform fixed forms,
+   checklists, or conversation.
+3. **Collaborative workspaces**, because a shared artifact tests editability,
+   identity, provenance, and persistence without presuming that Projectional
+   representation is the answer.
+
+Each family samples two context strata:
+
+- Information understanding: domain specialists, and developers or analysts
+  building one-off tools.
+- Workflow generation: people completing infrequent high-friction processes,
+  and operators responding to time-sensitive events.
+- Collaborative workspaces: collaborators maintaining a shared artifact, and
+  creators shaping an interactive artifact with others.
+
+Each stratum receives at least three and at most six sessions.
+
+After the third session, a stratum reaches saturation when two consecutive
+sessions add no new job, value-source, or human-control research code. A
+human-control code is a qualitative label for an action or decision that
+participants require to remain under their authority.
+
+Sampling stops at six even without saturation; the stratum is then recorded as
+`UNCERTAIN`, not silently extended. The tranche therefore contains 18–36
+sessions.
+
+The other five job families remain `UNSAMPLED`.
+
+A separately reviewed tranche may add job families when the first tranche
+reaches its cap without saturation, or when it exposes a distinct value
+mechanism or capability requirement that none of the three families can test
+and for which a concrete recruitment stratum exists. Otherwise the study
+proceeds to Stage 2 with the bounded map.
+
+### Stage 1: Formative interviews and workflow observation
+
+For each sampled job family, investigate:
+
+- the triggering situation and desired outcome;
+- why the current workflow is insufficient;
+- which steps are repetitive, unpredictable, or impossible;
+- what people create manually to bridge the gap;
+- what must remain under human control;
+- what needs to be saved, revised, shared, or audited;
+- what failure would make the interface unsafe or untrustworthy;
+- which existing alternative is strongest.
+
+Evidence consists of redacted notes, workflow diagrams, observed artifacts,
+and coded opportunity statements. Interview counts are not a success metric;
+new evidence must stop changing the opportunity map before sampling ends.
+
+### Stage 2: Representation-neutral concept tests
+
+Test the job and value mechanism without implying a generation architecture.
+Use storyboards, paper sketches, or hand-operated prototypes to compare:
+
+- the existing workflow;
+- the strongest realistic alternative;
+- an interface that adapts to the participant's intent.
+
+The facilitator may simulate adaptation, but must not imply that a model,
+component schema, or executable runtime exists. Record whether participants can
+identify a useful moment, complete the job, understand control boundaries, and
+state what they would keep or discard.
+
+### Stage 3: Flat-spectrum prototypes
+
+Only hypotheses surviving Stage 2 receive prototypes.
+
+Compare the smallest credible eligible modes side by side rather than
+implementing them in a presumed order. A hypothesis may compare Static with
+Declarative; another may compare Declarative with Dynamic; a persistent
+collaboration hypothesis may compare a Projectional artifact with a persistent
+Dynamic artifact.
+
+Prototype source and behavior are fixed before each session. Provider calls are
+not required: deterministic fixtures, hand-authored alternatives, and
+facilitator-driven behavior isolate the representation question from model
+reliability.
+
+### Stage 4: Useful moments and terminal limits
+
+For each job-mode pair, record:
+
+- the useful moment that changes the person's outcome;
+- the value mechanism responsible for that change;
+- the minimum sufficient capability and authority bundle;
+- every eligible mode that can provide that bundle;
+- the missing capability that excludes each otherwise plausible mode;
+- failure, latency, control, editability, and trust costs;
+- retention or collaboration needs;
+- the condition under which the hypothesis should be rejected.
+
+This stage separates "a model can emit it" from "this representation creates
+value."
+
+### Stage 5: Rank hypotheses for confirmatory experiments
+
+Rank surviving hypotheses using evidence, not architectural fit:
+
+- frequency and severity of the unmet job;
+- magnitude of improvement over the strongest alternative;
+- whether the value survives outside a facilitated session;
+- breadth of people and contexts benefiting;
+- minimum sufficient capability and authority bundle;
+- safety, privacy, latency, and maintenance burden;
+- fit with Canopy's editable, incremental, and collaborative strengths;
+- existence of a measurable primary outcome.
+
+Architectural fit is one criterion, not a veto. A high-value Dynamic opportunity
+may justify execution-boundary research. A low-value Projectional opportunity
+should not be selected merely because Canopy can implement it elegantly.
+
+## Evidence model
+
+### Opportunity record
+
+Every candidate opportunity records:
+
+- concrete person and triggering context;
+- job, desired outcome, and strongest realistic alternative;
+- current workflow and observed friction or impossible action;
+- proposed value source;
+- expected lifecycle;
+- minimum sufficient capability and authority bundle;
+- every eligible representation mode, including incomparable minima;
+- legibility, contestability, reversibility, pacing, and accessible-equivalence
+  requirements;
+- preview, confirmation, ownership, privacy, and safety boundaries;
+- supporting and contradicting evidence;
+- next uncertainty and cheapest falsification method.
+
+### Cross-opportunity map
+
+The final map is a matrix of:
+
+```text
+job family × value source × required capability bundle
+× eligible representation × lifecycle
+```
+
+Each cell links to evidence and receives one disposition:
+
+- `SUPPORTED`: repeated evidence justifies a confirmatory experiment;
+- `UNCERTAIN`: evidence conflicts or the useful moment is not isolated;
+- `REJECTED`: the strongest alternative is preferable or the value disappears;
+- `UNSAMPLED`: no evidence was collected.
+
+`UNSAMPLED` must remain visible. Absence of evidence is not rejection.
+
+### Signals
+
+Formative signals include:
+
+- previously impossible or abandoned actions made possible;
+- successful task completion;
+- time to a useful result;
+- desired corrections and adaptation requests;
+- willingness to keep, reuse, or share the artifact;
+- ability to understand and constrain effects;
+- reduction in manual authoring or coordination cost;
+- representation-specific terminal failures;
+- latency, lifecycle, privacy, and maintenance concerns.
+
+No single aggregate score selects a winner during discovery. The purpose is to
+explain where value comes from and what authority it requires.
+
+## Bias controls
+
+- Recruit around a job and context, not interest in AI.
+- Describe the capability without naming a provider or claiming intelligence.
+- Randomize concept and mode presentation order where comparison is involved.
+- Separate the facilitator from the person coding the evidence when practical.
+- Record negative cases and participant confusion, not only requested features.
+- Keep visual polish comparable across modes.
+- Do not reveal implementation cost estimates until value judgments are
+  recorded.
+- Distinguish willingness to try from willingness to retain and rely on the
+  result.
+- Treat researcher-authored opportunity categories as revisable codes.
+
+## Human-centered product gates, safety, and authority
+
+Discovery prototypes must not execute participant-provided or model-generated
+arbitrary code, use participant credentials, mutate external systems, or retain
+sensitive source data. A concept requiring those capabilities can be evaluated
+through bounded simulation until a separate execution and privacy protocol is
+reviewed.
+
+Human-control questions determine product value and belong in the initial
+evaluation. Every hypothesis must state:
+
+- what the generator may observe, propose, and execute;
+- why a person can understand each generated result or change;
+- how the person can inspect, correct, reject, contest, and reverse it;
+- what requires preview or explicit confirmation, including every irreversible
+  external effect;
+- how update pace and spatial change preserve orientation and cognitive
+  stability;
+- how keyboard and screen-reader users can complete the same job with
+  equivalent authority and information;
+- who owns persistent artifacts and dependencies.
+
+Early prototypes need not implement production accessibility or every recovery
+path. Advancement does require a credible design path for every gate above;
+visual success without that path is disqualifying evidence.
+
+## Stop and continuation rules
+
+Stop investigating a hypothesis when any of these holds:
+
+- the strongest existing alternative already satisfies the job;
+- participants value the information but not an interface;
+- the useful moment depends on facilitator knowledge unavailable to a system;
+- the proposed value disappears under the minimum safety boundary;
+- the job is too rare or low-impact to justify the lifecycle burden;
+- no measurable outcome can distinguish the hypothesis from novelty.
+
+Advance a hypothesis to a confirmatory design only when:
+
+1. a concrete person, job, context, and strongest alternative are named;
+2. repeated evidence identifies one useful moment and value mechanism;
+3. the minimum sufficient capability and authority bundle is explicit;
+4. every eligible mode is listed, including incomparable minima, and exclusions
+   name the missing capability;
+5. terminal limitations and lifecycle needs are explicit;
+6. the human-centered product gates have a credible design path;
+7. safety, privacy, ownership, and confirmation boundaries are plausible;
+8. a primary outcome and keep/delete decision can be preregistered;
+9. contradictory evidence and unsampled contexts remain visible.
+
+A confirmatory experiment freezes only its selected job, representation,
+comparator, and evidence contract. Its result must not be generalized to
+unsampled jobs or generation modes.
+
+## Deliverables
+
+Discovery concludes with:
+
+1. a redacted evidence corpus and coding guide;
+2. the cross-opportunity map with supported, uncertain, rejected, and unsampled
+   cells;
+3. a ranked hypothesis list with explicit value sources and authority needs;
+4. a representation comparison showing useful moments and terminal limits;
+5. one or more confirmatory experiment design proposals, or a recommendation
+   not to continue;
+6. updates to the canonical Generative UI direction where evidence changes its
+   hypotheses.
+
+No production code or provider integration is a required deliverable.
+
+## Decision boundary
+
+The maintainers decide which hypotheses, if any, deserve confirmatory work.
+Discovery success means reducing uncertainty and rejecting weak opportunities,
+not producing a provider-backed demo.
+
+A later experiment may select a bounded Declarative path, an open-ended
+document, Dynamic generated software, a Projectional artifact under an
+evidence-backed lifecycle, a Hybrid, or no generated interface. The evidence
+decides; this design does not.


### PR DESCRIPTION
## Summary

- Broaden the canonical Generative UI direction from one bounded provider experiment to six parallel representation modes with lifecycle kept as a separate axis.
- Define a staged, human-centered opportunity-discovery protocol with bounded sampling, saturation rules, evidence dispositions, human-control gates, and terminal decision criteria.
- Re-scope the deferred structured-data provider experiment and link the new discovery plan from the active backlog without authorizing recruitment or provider execution.

## Reuse check

Pure documentation change; no functions, methods, helpers, or types added.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (152 pre-existing workspace warnings, 0 errors; incremental rerun 9 warnings, 0 errors)
- [x] Markdown local links, heading jumps, duplicate headings, and trailing whitespace validated for all four changed files
- [x] Slopless reviewed; zero actionable findings after edits
- [x] `git diff --check` passes
- [x] Independent different-model review passes with zero findings
- [x] `moon test` not run: documentation-only change
- [x] `.mbti` review not applicable: no MoonBit API changes
- [x] JS rebuild not applicable: no web code changes

## Validation

```bash
NEW_MOON_MOD=0 moon check
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Generative UI direction with a broader capability spectrum, opportunity hypotheses, lifecycle considerations, and human-outcome evaluation criteria.
  * Added a research plan for discovering where generated interfaces create user value and defining appropriate capability and authority boundaries.
  * Refined the structured-data provider experiment to clarify its scope and evaluation criteria.
  * Added a testing-gap backlog item for validating Generative UI opportunities across multiple modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->