### PR TITLE
test(genui): establish semantic core Phase 0 fixture

### DIFF
--- a/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
+++ b/docs/plans/2026-07-16-incremental-generative-ui-semantic-core-validation.md
@@ -120,7 +120,7 @@ On mismatch, report the minimized event trace and both observations.
 
 ## Fixed transcript
 
-`fixed_scenario_wbtest.mbt` is the first red test and final integration gate:
+`fixed_scenario_wbtest.mbt` defines the shared fixture and final integration gate:
 
 1. Start with valid draft `D0`, root-only graph `G0` at revision 0, immutable
    schema identity/digest, renderer baseline 0, and acknowledged effect `E0`.
@@ -219,39 +219,58 @@ Do not introduce a helper until `moon ide doc`, `outline`, `peek-def`, and
 
 ## Implementation phases
 
-Each phase is a separate PR. It begins with failing evidence and ends with
-package checks/tests; no PR starts the next adapter layer.
+Each phase is a separate mergeable PR. It begins by running a newly registered
+bounded test and observing the expected failure, then ends with that test and
+the package checks passing. The complete transcript is represented once as
+shared fixture data in Phase 0, but it is not registered as an end-to-end test
+until Phase 3 implements every behavior needed for it to pass. Earlier phases
+execute successively longer prefixes of that same fixture. No phase lands a
+skipped, ignored, placeholder, or knowingly failing test, and no PR starts the
+next adapter layer.
 
-### Phase 0 — Boundary and red gate
+### Phase 0 — Boundary and executable fixture
 
 - Add the module to `moon.work`, with pinned `moonbitlang/quickcheck`, JS/native
   support, and `core/quickcheck`, SplitMix, and `@qc` imports restricted to
   white-box tests.
 - Record the Existing API First results.
-- Add observation types, fake-shell protocol, and the complete failing fixed
-  transcript. Its first failure must demonstrate missing core behavior while
-  the package remains free of adapter dependencies.
+- Add private observation types, the fake-shell event protocol, and the complete
+  fixed transcript as immutable fixture data with named checkpoints.
+- Register only boundary and fixture-contract tests: the package has no forbidden
+  dependency or public API, event/checkpoint ordering is complete and
+  deterministic, exact draft bytes are retained in the fixture, and later
+  phases can select a prefix without copying or rewriting the transcript.
+- Do not register the complete transcript as a test and do not add production
+  transition behavior in this phase.
 
-### Phase 1 — Graph and operations
+### Phase 1 — Graph and operations prefix
 
+- Register and first observe failure for the graph/operation prefix ending after
+  the request batch has produced `G1`.
 - Add private values, graph, revisions, schema descriptor identity/digest,
   request-local handles, and deterministic IDs.
 - Apply all five operations to a private working graph, checking each
   primitive's structural preconditions as it runs and final graph/schema
   invariants at the batch boundary.
 - Cover atomic rejection, no-op, property deletion versus `null`, graph
-  invariants, limits, and inverse derivation.
+  invariants, limits, and inverse derivation; end the PR with this prefix green.
 
-### Phase 2 — Requests and persistence
+### Phase 2 — Requests and persistence prefix
 
+- Extend the registered prefix through atomic persistence, response loss, retry,
+  and durable ledger-only outcomes; first observe its expected failure.
 - Add typed canonical content, collision-aware lookup, and terminal outcomes.
 - Model persistence intent, canonical delivery plans/digests, derived manifests,
   success/failure, response release, and effect release as reducer events.
 - Add fake-store failures before commit, response loss after commit, restart,
-  request-ID misuse, forced digest collision, and no-op/rejected recovery.
+  request-ID misuse, forced digest collision, and no-op/rejected recovery; end
+  the PR with this prefix green.
 
-### Phase 3 — Draft and outbox
+### Phase 3 — Draft, outbox, and complete transcript
 
+- Extend the registered prefix through draft/source and renderer delivery, first
+  observe its expected failure, and then register the complete fixed transcript
+  as the end-to-end test.
 - Add draft validity/revision and source rewrite CAS without a real parser.
 - Emit `MarkSynchronized` for text-origin commits and `RewriteSource` only for
   projection, agent, or undo origins; cover every origin explicitly.
@@ -259,8 +278,8 @@ package checks/tests; no PR starts the next adapter layer.
   edits before delivery and crashes before outcome persistence.
 - Classify renderer/source effects with dirty precedence, stale acknowledgment,
   expected baseline, and latest-snapshot rebuild.
-- Make the fixed transcript pass through restart with duplicate, reordered, and
-  failed delivery.
+- End the PR with the complete fixed transcript passing through restart with
+  duplicate, reordered, and failed delivery.
 
 ### Phase 4 — Generated traces
 
@@ -306,6 +325,10 @@ package checks/tests; no PR starts the next adapter layer.
 ## Acceptance gate
 
 - The private module has no forbidden dependency or accidental public API.
+- Phase 0 registers only bounded fixture-contract tests; Phases 1 and 2 register
+  only their executable prefixes; Phase 3 registers the complete transcript.
+  Every phase lands with no skipped, ignored, placeholder, or knowingly failing
+  test.
 - Fixed and generated traces match the reference model on JS and native.
 - Applied, no-op, rejected, response-loss, and collision outcomes satisfy their
   persistence and retry contracts.

--- a/lib/generative-ui-document/fixed_scenario_fixture_wbtest.mbt
+++ b/lib/generative-ui-document/fixed_scenario_fixture_wbtest.mbt
@@ -1,0 +1,531 @@
+///|
+priv enum ScenarioCheckpoint {
+  GraphOperations
+  RequestPersistence
+  CompleteTranscript
+} derive(Debug)
+
+///|
+impl @quickcheck.Arbitrary for ScenarioCheckpoint with fn arbitrary(_size, rs) {
+  match rs.split().next_positive_int() % 3 {
+    0 => GraphOperations
+    1 => RequestPersistence
+    _ => CompleteTranscript
+  }
+}
+
+///|
+impl @qc.Shrink for ScenarioCheckpoint with fn shrink(checkpoint) {
+  match checkpoint {
+    GraphOperations => [].iter()
+    RequestPersistence => [GraphOperations].iter()
+    CompleteTranscript => [RequestPersistence].iter()
+  }
+}
+
+///|
+priv enum ScenarioNodeRef {
+  Existing(String)
+  New(String)
+} derive(Eq)
+
+///|
+fn ScenarioNodeRef::label(self : ScenarioNodeRef) -> String {
+  match self {
+    Existing(id) | New(id) => id
+  }
+}
+
+///|
+priv enum ScenarioPlacement {
+  AtEnd
+} derive(Eq)
+
+///|
+fn ScenarioPlacement::label(self : ScenarioPlacement) -> String {
+  let AtEnd = self
+  "end"
+}
+
+///|
+priv enum ScenarioValue {
+  Null
+} derive(Eq)
+
+///|
+fn ScenarioValue::label(self : ScenarioValue) -> String {
+  let Null = self
+  "null"
+}
+
+///|
+priv enum ScenarioOperation {
+  InsertNode(
+    handle~ : String,
+    component~ : String,
+    properties~ : Array[(String, ScenarioValue)],
+    parent~ : ScenarioNodeRef,
+    placement~ : ScenarioPlacement
+  )
+  MoveNode(
+    node~ : ScenarioNodeRef,
+    parent~ : ScenarioNodeRef,
+    placement~ : ScenarioPlacement
+  )
+  SetProperty(node~ : ScenarioNodeRef, key~ : String, value~ : ScenarioValue)
+  RemoveProperty(node~ : ScenarioNodeRef, key~ : String)
+  RemoveNode(ScenarioNodeRef)
+} derive(Eq)
+
+///|
+fn ScenarioOperation::label(self : ScenarioOperation) -> String {
+  match self {
+    InsertNode(handle~, component~, properties=_, parent~, placement~) =>
+      "insert \{handle} \{component} at \{parent.label()} \{placement.label()}"
+    MoveNode(node~, parent~, placement~) =>
+      "move \{node.label()} into \{parent.label()} \{placement.label()}"
+    SetProperty(node~, key~, value~) =>
+      "set \{node.label()}.\{key} to \{value.label()}"
+    RemoveProperty(node~, key~) => "remove \{node.label()}.\{key}"
+    RemoveNode(node) => "remove \{node.label()}"
+  }
+}
+
+///|
+priv enum FakeShellEvent {
+  OpenDocument
+  EditDraft(bytes~ : Bytes, revision~ : Int, valid~ : Bool)
+  SubmitAgentRequest(request_id~ : String, base_revision~ : Int)
+  StoreCommit(request_id~ : String)
+  LoseResponse(request_id~ : String)
+  RetryRequest(request_id~ : String)
+  DeliverSourceEffect(effect_id~ : String)
+  CrashBeforeSourceOutcome(effect_id~ : String)
+  RecoverDocument
+  RedeliverSourceEffect(effect_id~ : String)
+  StoreBlockedSourceOutcome(effect_id~ : String)
+  DeliverRendererEffect(effect_id~ : String)
+  RendererDeliveryFailed(effect_id~ : String)
+  StoreRendererDirtyOutcome(effect_id~ : String)
+  DeliverStaleRendererEffect(effect_id~ : String)
+  RendererRebuildSucceeded(effect_id~ : String)
+  CrashBeforeRendererOutcome(effect_id~ : String)
+  RedeliverStaleRendererEffect(effect_id~ : String)
+  StoreRebuiltRendererOutcome(effect_id~ : String)
+  DeliverDuplicateRendererEffect(effect_id~ : String)
+  StoreDuplicateRendererOutcome(effect_id~ : String)
+} derive(Eq)
+
+///|
+fn FakeShellEvent::label(self : FakeShellEvent) -> String {
+  match self {
+    OpenDocument => "open document"
+    EditDraft(..) => "edit draft to invalid bytes"
+    SubmitAgentRequest(request_id~, ..) => "submit agent request \{request_id}"
+    StoreCommit(request_id~) => "store commit \{request_id}"
+    LoseResponse(request_id~) => "lose response \{request_id}"
+    RetryRequest(request_id~) => "retry request \{request_id}"
+    DeliverSourceEffect(effect_id~) => "deliver source effect \{effect_id}"
+    CrashBeforeSourceOutcome(_) => "crash before source outcome"
+    RecoverDocument => "recover document"
+    RedeliverSourceEffect(effect_id~) => "redeliver source effect \{effect_id}"
+    StoreBlockedSourceOutcome(_) => "store blocked source outcome"
+    DeliverRendererEffect(effect_id~) => "deliver renderer effect \{effect_id}"
+    RendererDeliveryFailed(effect_id~) => "renderer delivery \{effect_id} fails"
+    StoreRendererDirtyOutcome(_) => "store renderer dirty outcome"
+    DeliverStaleRendererEffect(effect_id~) =>
+      "deliver stale renderer effect \{effect_id}"
+    RendererRebuildSucceeded(_) => "renderer rebuild succeeds"
+    CrashBeforeRendererOutcome(_) => "crash before renderer outcome"
+    RedeliverStaleRendererEffect(effect_id~) =>
+      "redeliver stale renderer effect \{effect_id}"
+    StoreRebuiltRendererOutcome(_) => "store rebuilt renderer outcome"
+    DeliverDuplicateRendererEffect(effect_id~) =>
+      "deliver duplicate renderer effect \{effect_id}"
+    StoreDuplicateRendererOutcome(_) => "store duplicate renderer outcome"
+  }
+}
+
+///|
+priv enum ScenarioObservation {
+  DocumentOpened(
+    draft_revision~ : Int,
+    draft_bytes~ : Bytes,
+    graph_digest~ : String,
+    graph_revision~ : Int,
+    schema_identity~ : String,
+    schema_digest~ : String,
+    renderer_baseline~ : Int,
+    acknowledged_effect~ : String
+  )
+  DraftChanged(
+    draft_revision~ : Int,
+    draft_bytes~ : Bytes,
+    valid~ : Bool,
+    retained_graph_digest~ : String
+  )
+  CommitPlanned(
+    request_id~ : String,
+    graph_digest~ : String,
+    inserted_node_ids~ : Array[String],
+    source_effect_id~ : String,
+    renderer_effect_id~ : String
+  )
+  CommitPersisted(
+    request_id~ : String,
+    graph_revision~ : Int,
+    history_length~ : Int,
+    outbox_length~ : Int
+  )
+  ResponseSuppressed(request_id~ : String)
+  RecordedOutcomeReturned(
+    request_id~ : String,
+    graph_revision~ : Int,
+    history_length~ : Int
+  )
+  PersistSourceBlocked(
+    effect_id~ : String,
+    reason~ : String,
+    preserved_bytes~ : Bytes
+  )
+  CrashObserved(effect_id~ : String)
+  Recovered(
+    graph_revision~ : Int,
+    pending_effects~ : Array[String],
+    renderer_baseline~ : Int,
+    renderer_dirty~ : Bool
+  )
+  SourceBlockedPersisted(effect_id~ : String, preserved_bytes~ : Bytes)
+  RendererApplyRequested(effect_id~ : String, graph_revision~ : Int)
+  PersistRendererDirty(
+    effect_id~ : String,
+    renderer_baseline~ : Int,
+    graph_revision~ : Int
+  )
+  RendererDirtyPersisted(renderer_baseline~ : Int, graph_revision~ : Int)
+  RebuildLatestRequested(
+    delivered_effect_id~ : String,
+    graph_digest~ : String,
+    graph_revision~ : Int
+  )
+  PersistRendererRebuilt(
+    delivered_effect_id~ : String,
+    renderer_baseline~ : Int
+  )
+  RendererRebuiltPersisted(renderer_baseline~ : Int, renderer_dirty~ : Bool)
+  PersistDuplicateRenderer(effect_id~ : String, renderer_baseline~ : Int)
+  DuplicateRendererPersisted(renderer_baseline~ : Int, renderer_dirty~ : Bool)
+} derive(Eq)
+
+///|
+priv struct ScenarioStep {
+  event : FakeShellEvent
+  expectations : Array[ScenarioObservation]
+} derive(Eq)
+
+///|
+fn ScenarioStep::ScenarioStep(
+  event~ : FakeShellEvent,
+  expectations~ : Array[ScenarioObservation],
+) -> ScenarioStep {
+  { event, expectations }
+}
+
+///|
+fn ScenarioStep::event(self : ScenarioStep) -> FakeShellEvent {
+  self.event
+}
+
+///|
+fn ScenarioStep::expectations(
+  self : ScenarioStep,
+) -> ArrayView[ScenarioObservation] {
+  self.expectations.view()
+}
+
+///|
+priv struct ScenarioFinalExpectation {
+  graph_digest : String
+  graph_revision : Int
+  schema_identity : String
+  schema_digest : String
+  applied_history_length : Int
+  terminal_request_count : Int
+  inserted_node_ids : Array[String]
+  draft_bytes : Bytes
+  renderer_baseline : Int
+  renderer_dirty : Bool
+} derive(Eq)
+
+///|
+fn ScenarioFinalExpectation::ScenarioFinalExpectation(
+  graph_digest~ : String,
+  graph_revision~ : Int,
+  schema_identity~ : String,
+  schema_digest~ : String,
+  applied_history_length~ : Int,
+  terminal_request_count~ : Int,
+  inserted_node_ids~ : Array[String],
+  draft_bytes~ : Bytes,
+  renderer_baseline~ : Int,
+  renderer_dirty~ : Bool,
+) -> ScenarioFinalExpectation {
+  {
+    graph_digest,
+    graph_revision,
+    schema_identity,
+    schema_digest,
+    applied_history_length,
+    terminal_request_count,
+    inserted_node_ids,
+    draft_bytes,
+    renderer_baseline,
+    renderer_dirty,
+  }
+}
+
+///|
+priv struct FixedScenario {
+  invalid_draft_bytes : Bytes
+  request_batch : Array[ScenarioOperation]
+  steps : Array[ScenarioStep]
+  final_expectation : ScenarioFinalExpectation
+}
+
+///|
+fn FixedScenario::FixedScenario(
+  invalid_draft_bytes~ : Bytes,
+  request_batch~ : Array[ScenarioOperation],
+  steps~ : Array[ScenarioStep],
+  final_expectation~ : ScenarioFinalExpectation,
+) -> FixedScenario {
+  { invalid_draft_bytes, request_batch, steps, final_expectation }
+}
+
+///|
+fn FixedScenario::invalid_draft_bytes(self : FixedScenario) -> BytesView {
+  self.invalid_draft_bytes.view()
+}
+
+///|
+fn FixedScenario::request_batch(
+  self : FixedScenario,
+) -> ArrayView[ScenarioOperation] {
+  self.request_batch.view()
+}
+
+///|
+fn FixedScenario::steps(self : FixedScenario) -> ArrayView[ScenarioStep] {
+  self.steps.view()
+}
+
+///|
+fn FixedScenario::prefix(
+  self : FixedScenario,
+  checkpoint : ScenarioCheckpoint,
+) -> ArrayView[ScenarioStep] {
+  match checkpoint {
+    GraphOperations => self.steps.view(end=3)
+    RequestPersistence => self.steps.view(end=6)
+    CompleteTranscript => self.steps.view()
+  }
+}
+
+///|
+fn FixedScenario::final_expectation(
+  self : FixedScenario,
+) -> ScenarioFinalExpectation {
+  self.final_expectation
+}
+
+///|
+fn fixed_request_batch() -> Array[ScenarioOperation] {
+  [
+    InsertNode(
+      handle="h0",
+      component="panel",
+      properties=[],
+      parent=Existing("root"),
+      placement=AtEnd,
+    ),
+    InsertNode(
+      handle="h1",
+      component="text",
+      properties=[],
+      parent=Existing("root"),
+      placement=AtEnd,
+    ),
+    SetProperty(node=New("h0"), key="note", value=Null),
+    MoveNode(node=New("h1"), parent=New("h0"), placement=AtEnd),
+    RemoveProperty(node=New("h0"), key="note"),
+    RemoveNode(New("h1")),
+  ]
+}
+
+///|
+fn fixed_transcript_steps(invalid_draft_bytes : Bytes) -> Array[ScenarioStep] {
+  [
+    ScenarioStep(event=OpenDocument, expectations=[
+      DocumentOpened(
+        draft_revision=0,
+        draft_bytes=b"valid",
+        graph_digest="graph:G0",
+        graph_revision=0,
+        schema_identity="schema:ui-v1",
+        schema_digest="schema-digest:ui-v1",
+        renderer_baseline=0,
+        acknowledged_effect="E-render-0",
+      ),
+    ]),
+    ScenarioStep(
+      event=EditDraft(bytes=invalid_draft_bytes, revision=1, valid=false),
+      expectations=[
+        DraftChanged(
+          draft_revision=1,
+          draft_bytes=invalid_draft_bytes,
+          valid=false,
+          retained_graph_digest="graph:G0",
+        ),
+      ],
+    ),
+    ScenarioStep(event=SubmitAgentRequest(request_id="Q", base_revision=0), expectations=[
+      CommitPlanned(
+        request_id="Q",
+        graph_digest="graph:G1",
+        inserted_node_ids=["node:Q:0", "node:Q:1"],
+        source_effect_id="E-source-1",
+        renderer_effect_id="E-render-1",
+      ),
+    ]),
+    ScenarioStep(event=StoreCommit(request_id="Q"), expectations=[
+      CommitPersisted(
+        request_id="Q",
+        graph_revision=1,
+        history_length=1,
+        outbox_length=2,
+      ),
+    ]),
+    ScenarioStep(event=LoseResponse(request_id="Q"), expectations=[
+      ResponseSuppressed(request_id="Q"),
+    ]),
+    ScenarioStep(event=RetryRequest(request_id="Q"), expectations=[
+      RecordedOutcomeReturned(
+        request_id="Q",
+        graph_revision=1,
+        history_length=1,
+      ),
+    ]),
+    ScenarioStep(event=DeliverSourceEffect(effect_id="E-source-1"), expectations=[
+      PersistSourceBlocked(
+        effect_id="E-source-1",
+        reason="RewriteConflict",
+        preserved_bytes=invalid_draft_bytes,
+      ),
+    ]),
+    ScenarioStep(event=CrashBeforeSourceOutcome(effect_id="E-source-1"), expectations=[
+      CrashObserved(effect_id="E-source-1"),
+    ]),
+    ScenarioStep(event=RecoverDocument, expectations=[
+      Recovered(
+        graph_revision=1,
+        pending_effects=["E-source-1", "E-render-1"],
+        renderer_baseline=0,
+        renderer_dirty=false,
+      ),
+    ]),
+    ScenarioStep(event=RedeliverSourceEffect(effect_id="E-source-1"), expectations=[
+      PersistSourceBlocked(
+        effect_id="E-source-1",
+        reason="RewriteConflict",
+        preserved_bytes=invalid_draft_bytes,
+      ),
+    ]),
+    ScenarioStep(event=StoreBlockedSourceOutcome(effect_id="E-source-1"), expectations=[
+      SourceBlockedPersisted(
+        effect_id="E-source-1",
+        preserved_bytes=invalid_draft_bytes,
+      ),
+    ]),
+    ScenarioStep(event=DeliverRendererEffect(effect_id="E-render-1"), expectations=[
+      RendererApplyRequested(effect_id="E-render-1", graph_revision=1),
+    ]),
+    ScenarioStep(event=RendererDeliveryFailed(effect_id="E-render-1"), expectations=[
+      PersistRendererDirty(
+        effect_id="E-render-1",
+        renderer_baseline=0,
+        graph_revision=1,
+      ),
+    ]),
+    ScenarioStep(event=StoreRendererDirtyOutcome(effect_id="E-render-1"), expectations=[
+      RendererDirtyPersisted(renderer_baseline=0, graph_revision=1),
+    ]),
+    ScenarioStep(event=DeliverStaleRendererEffect(effect_id="E-render-0"), expectations=[
+      RebuildLatestRequested(
+        delivered_effect_id="E-render-0",
+        graph_digest="graph:G1",
+        graph_revision=1,
+      ),
+    ]),
+    ScenarioStep(event=RendererRebuildSucceeded(effect_id="E-render-0"), expectations=[
+      PersistRendererRebuilt(
+        delivered_effect_id="E-render-0",
+        renderer_baseline=1,
+      ),
+    ]),
+    ScenarioStep(event=CrashBeforeRendererOutcome(effect_id="E-render-0"), expectations=[
+      CrashObserved(effect_id="E-render-0"),
+    ]),
+    ScenarioStep(event=RecoverDocument, expectations=[
+      Recovered(
+        graph_revision=1,
+        pending_effects=["E-render-0", "E-render-1"],
+        renderer_baseline=0,
+        renderer_dirty=true,
+      ),
+    ]),
+    ScenarioStep(event=RedeliverStaleRendererEffect(effect_id="E-render-0"), expectations=[
+      RebuildLatestRequested(
+        delivered_effect_id="E-render-0",
+        graph_digest="graph:G1",
+        graph_revision=1,
+      ),
+    ]),
+    ScenarioStep(event=RendererRebuildSucceeded(effect_id="E-render-0"), expectations=[
+      PersistRendererRebuilt(
+        delivered_effect_id="E-render-0",
+        renderer_baseline=1,
+      ),
+    ]),
+    ScenarioStep(event=StoreRebuiltRendererOutcome(effect_id="E-render-0"), expectations=[
+      RendererRebuiltPersisted(renderer_baseline=1, renderer_dirty=false),
+    ]),
+    ScenarioStep(event=DeliverDuplicateRendererEffect(effect_id="E-render-1"), expectations=[
+      PersistDuplicateRenderer(effect_id="E-render-1", renderer_baseline=1),
+    ]),
+    ScenarioStep(event=StoreDuplicateRendererOutcome(effect_id="E-render-1"), expectations=[
+      DuplicateRendererPersisted(renderer_baseline=1, renderer_dirty=false),
+    ]),
+  ]
+}
+
+///|
+fn fixed_scenario() -> FixedScenario {
+  let invalid_draft_bytes = b"valid\n<unfinished"
+  FixedScenario(
+    invalid_draft_bytes~,
+    request_batch=fixed_request_batch(),
+    steps=fixed_transcript_steps(invalid_draft_bytes),
+    final_expectation=ScenarioFinalExpectation(
+      graph_digest="graph:G1",
+      graph_revision=1,
+      schema_identity="schema:ui-v1",
+      schema_digest="schema-digest:ui-v1",
+      applied_history_length=1,
+      terminal_request_count=1,
+      inserted_node_ids=["node:Q:0", "node:Q:1"],
+      draft_bytes=invalid_draft_bytes,
+      renderer_baseline=1,
+      renderer_dirty=false,
+    ),
+  )
+}

--- a/lib/generative-ui-document/fixed_scenario_wbtest.mbt
+++ b/lib/generative-ui-document/fixed_scenario_wbtest.mbt
@@ -1,0 +1,113 @@
+///|
+test "fixed transcript preserves exact order and named prefixes" {
+  let scenario = fixed_scenario()
+  let steps = scenario.steps()
+  inspect(steps.length(), content="23")
+  inspect(
+    steps.map(step => step.event().label()).join("\n"),
+    content=(
+      #|open document
+      #|edit draft to invalid bytes
+      #|submit agent request Q
+      #|store commit Q
+      #|lose response Q
+      #|retry request Q
+      #|deliver source effect E-source-1
+      #|crash before source outcome
+      #|recover document
+      #|redeliver source effect E-source-1
+      #|store blocked source outcome
+      #|deliver renderer effect E-render-1
+      #|renderer delivery E-render-1 fails
+      #|store renderer dirty outcome
+      #|deliver stale renderer effect E-render-0
+      #|renderer rebuild succeeds
+      #|crash before renderer outcome
+      #|recover document
+      #|redeliver stale renderer effect E-render-0
+      #|renderer rebuild succeeds
+      #|store rebuilt renderer outcome
+      #|deliver duplicate renderer effect E-render-1
+      #|store duplicate renderer outcome
+    ),
+  )
+
+  let graph_prefix = scenario.prefix(GraphOperations)
+  let persistence_prefix = scenario.prefix(RequestPersistence)
+  let complete_prefix = scenario.prefix(CompleteTranscript)
+  inspect(graph_prefix.length(), content="3")
+  inspect(persistence_prefix.length(), content="6")
+  inspect(complete_prefix.length(), content="23")
+  inspect(graph_prefix.equal(steps.view(end=3)), content="true")
+  inspect(persistence_prefix.equal(steps.view(end=6)), content="true")
+  inspect(complete_prefix.equal(steps), content="true")
+}
+
+///|
+test "fixed transcript retains exact draft bytes and operation algebra" {
+  let scenario = fixed_scenario()
+  inspect(
+    scenario.invalid_draft_bytes().equal_to_bytes(b"valid\n<unfinished"),
+    content="true",
+  )
+  inspect(
+    scenario.request_batch().map(operation => operation.label()).join("\n"),
+    content=(
+      #|insert h0 panel at root end
+      #|insert h1 text at root end
+      #|set h0.note to null
+      #|move h1 into h0 end
+      #|remove h0.note
+      #|remove h1
+    ),
+  )
+
+  let expected = scenario.final_expectation()
+  inspect(expected.graph_digest, content="graph:G1")
+  inspect(expected.graph_revision, content="1")
+  inspect(expected.schema_identity, content="schema:ui-v1")
+  inspect(expected.schema_digest, content="schema-digest:ui-v1")
+  inspect(expected.applied_history_length, content="1")
+  inspect(expected.terminal_request_count, content="1")
+  inspect(expected.inserted_node_ids.join(","), content="node:Q:0,node:Q:1")
+  inspect(
+    expected.draft_bytes.view().equal_to_bytes(b"valid\n<unfinished"),
+    content="true",
+  )
+  inspect(expected.renderer_baseline, content="1")
+  inspect(expected.renderer_dirty, content="false")
+}
+
+///|
+test "fixed transcript event expectations are deterministic" {
+  let first = fixed_scenario()
+  let second = fixed_scenario()
+  inspect(first.steps().equal(second.steps()), content="true")
+  inspect(
+    first.steps().all(step => !step.expectations().is_empty()),
+    content="true",
+  )
+  inspect(first.request_batch().equal(second.request_batch()), content="true")
+  inspect(
+    first.final_expectation() == second.final_expectation(),
+    content="true",
+  )
+}
+
+///|
+fn prop_named_prefix_selects_exact_transcript_view(
+  checkpoint : ScenarioCheckpoint,
+) -> Bool {
+  let scenario = fixed_scenario()
+  let end = match checkpoint {
+    GraphOperations => 3
+    RequestPersistence => 6
+    CompleteTranscript => 23
+  }
+  scenario.prefix(checkpoint).equal(scenario.steps().view(end~))
+}
+
+///|
+test "property: named prefixes select exact transcript views" {
+  @qc.quick_check_fn(prop_named_prefix_selects_exact_transcript_view)
+}

--- a/lib/generative-ui-document/moon.mod
+++ b/lib/generative-ui-document/moon.mod
@@ -1,0 +1,15 @@
+name = "dowdiness/generative-ui-document"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/quickcheck@0.14.0",
+}
+
+repository = "https://github.com/dowdiness/canopy"
+
+license = "Apache-2.0"
+
+keywords = [ "generative-ui", "semantic-graph", "document-engine" ]
+
+description = "Private deterministic semantic-core validation for Generative UI documents"

--- a/lib/generative-ui-document/moon.pkg
+++ b/lib/generative-ui-document/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/splitmix",
+  "moonbitlang/quickcheck" @qc,
+} for "wbtest"

--- a/lib/generative-ui-document/pkg.generated.mbti
+++ b/lib/generative-ui-document/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/generative-ui-document"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/moon.work
+++ b/moon.work
@@ -35,6 +35,7 @@ members = [
   "./lib/analysis",
   "./lib/semantic",
   "./lib/cognition",
+  "./lib/generative-ui-document",
   "./examples/ideal",
   "./examples/block-editor",
   "./examples/codemirror_demo",


### PR DESCRIPTION
## Summary

- clarify the Phase 0–3 prefix-registration contract so every PR remains mergeable and green
- add a separate `dowdiness/generative-ui-document` module containing only private white-box protocol fixtures
- pin the 23-step fixed transcript, exact invalid draft bytes, operation batch, named 3/6/23 prefixes, and final expectation without implementing production transitions

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ArrayView::view` / `ArrayView::equal` / `ArrayView::map` / `ArrayView::all` | MoonBit core `array` | Yes | Named checkpoints are zero-copy views; fixture tests compare and summarize them declaratively. |
| `Bytes` / `BytesView::view` / `BytesView::equal_to_bytes` | MoonBit core `bytes` | Yes | Retains and verifies `valid\n<unfinished` byte-for-byte without string reinterpretation. |
| `@quickcheck.Arbitrary`, `@qc.Shrink`, `@qc.quick_check_fn` | MoonBit core/quickcheck and moonbitlang/quickcheck | Yes | Exhausts the bounded three-checkpoint selection contract. |
| `GenerativeUiReplaySource` | `lib/cognition/generative_ui_replay.mbt` | No | Owns a mutable replay cursor and provider lifecycle inputs; Phase 0 needs immutable semantic-document fixture prefixes and cannot depend on cognition. |
| `WorkflowAction` and graph model types | `lib/canvas-graph/graph_model/model.mbt` | No | Canvas-specific public actions and adapter state violate the private renderer-neutral validation boundary. |
| `Map`, `Set`, `Option`, `Result`, `Buffer`, `cmp` | MoonBit core | No | The fixed fixture is ordered static data with no lookup, fallibility, string-builder, or comparison policy. |

New helpers added:

- `fixed_request_batch`: owns the single ordered fixture batch.
- `fixed_transcript_steps`: owns the one complete protocol transcript used by all future prefixes.
- `fixed_scenario`: assembles fixture data and the final expectation.
- private `label` methods: stable, human-readable fixture-contract snapshots only.

All helpers and types live in `*_wbtest.mbt`; `pkg.generated.mbti` exposes no values, types, aliases, traits, or errors.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (0 errors; existing vendored warnings)
- [x] `NEW_MOON_MOD=0 moon test` passes (1,937 JS + 70 native)
- [x] `git diff *.mbti` reviewed for unintended API surface changes (`generative-ui-document/pkg.generated.mbti` is empty)
- [x] JS rebuild not applicable; no web boundary changed

## Validation

```bash
NEW_MOON_MOD=0 moon check --target js lib/generative-ui-document
NEW_MOON_MOD=0 moon check --target native lib/generative-ui-document
NEW_MOON_MOD=0 moon test --target js lib/generative-ui-document
NEW_MOON_MOD=0 moon test --target native lib/generative-ui-document
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
```

Independent MoonBit review: PASS, no findings (`openai-codex/gpt-5.5`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added deterministic end-to-end scenario coverage for document generation workflows, including persistence, conflicts, crash recovery, stale rendering, duplicate updates, and final state validation.
  - Added incremental transcript checks to verify each workflow stage independently before validating the complete scenario.
  - Added property-based checks to confirm scenario prefixes and full transcripts remain consistent and reproducible.

- **Documentation**
  - Updated implementation guidance with stricter phased validation and acceptance criteria for workflow testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->