### PR TITLE
refactor(web): map ownership and enforce boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,18 @@ jobs:
       - name: Build web
         run: ./scripts/build-web.sh
 
+      - name: Type check web
+        working-directory: examples/web
+        run: npm run typecheck
+
+      - name: Check web dependency boundaries
+        working-directory: examples/web
+        run: npm run check:boundaries
+
+      - name: Test web dependency boundaries
+        working-directory: examples/web
+        run: npm run test:boundaries
+
       - name: Install prosemirror dependencies
         working-directory: examples/prosemirror
         run: npm ci

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -1,0 +1,72 @@
+# Web module map
+
+Implementation inventory for the current `examples/web` workspace. The source tree and Vite configuration are authoritative; this file records what exists today rather than prescribing a separate architecture.
+
+## Active HTML surfaces
+
+| Surface | HTML | Browser entry | Feature-owned source | Styles | Runtime and tests |
+|---|---|---|---|---|---|
+| Lambda | `index.html` | `src/main.ts` | `editor.ts`, `decoration-overlay.ts`, `ast-grep-runner.ts` | Inline in `index.html` | Browser + generated MoonBit Lambda/Graphviz; `tests/lambda-editor.spec.ts` |
+| JSON | `json.html` | `src/json-editor.ts` | `json-editor.ts` (uses shared decoration overlay) | Inline in `json.html` plus `src/json-editor.css` | Browser + generated MoonBit JSON; `tests/json-editor.spec.ts` |
+| Markdown | `markdown.html` | `src/markdown-editor.ts` | `markdown-editor.ts`, `markdown-sentinels.ts` | Inline in `markdown.html` plus editor-adapter CSS | Browser + generated MoonBit Markdown; `tests/markdown-editor.spec.ts` |
+| Memo | `memo.html` | `src/memo-editor.ts` | `memo-editor.ts` | Inline in `memo.html` | Browser + generated MoonBit Lambda; no dedicated test suite |
+| Posts | `posts.html` | `src/post-app.ts` | `post-app.ts`, `post-events.ts`, `post-retrieval.ts`, `post-store.ts` | Inline in `posts.html` | Browser persistence shell around deterministic retrieval logic; `tests/post-app.spec.ts` |
+| Resume/PKE | `resume.html` | `src/resume-app.tsx` | `resume-app.tsx`, `pi-resume-core.ts`, `pi-resume-chat-protocol.ts`, `components/ai-elements/*` | `src/resume.css` | Browser React + Vite chat relay; `tests/pi-resume.spec.ts` |
+| GenUI | `genui.html` | `src/genui.js` | `genui.js`, `genui-data.ts`, feasibility flow/fixtures/schema/provider/recorded/spike modules, `src/fixtures/*` | Inline in `genui.html` plus `src/tailwind.css` | Browser + generated MoonBit JSX, deterministic feasibility code, and a server-only provider; `tests/genui.spec.ts`, feasibility suites, colocated Node tests, study scripts |
+| GenUI Possibilities | `genui-possibilities.html` | `src/genui-possibilities.js` | `genui-possibilities.js`, `genui-journey-state.js` | `src/genui-possibilities.css` | Deterministic browser state; `tests/genui-possibilities.spec.ts`, `preview-tests/genui-preview.spec.ts` |
+
+`spike-block-input.html` is an inactive investigation surface and is not part of the eight Vite inputs.
+
+## Runtime and generated dependencies
+
+- Browser code is TypeScript/TSX/JS bundled by Vite. React and the AI SDK are used by Resume/PKE; GenUI is plain browser JavaScript plus the generated JSX FFI.
+- `vite-plugin-moonbit.ts` owns MoonBit builds, virtual-module loading, output watching, and HMR. It also currently owns the Lambda-only `/api/ast-grep` development relay.
+- `vite-plugin-pi-resume-chat.ts` owns the local Resume/PKE provider relay. `vite-plugin-genui-feasibility.ts` owns the local GenUI study relay and imports the server-only `src/genui-feasibility-provider.js`. These Vite adapters are not browser entry dependencies.
+- `signaling-server.js`, `signaling-worker.js`, `wrangler-signaling.toml`, and `wrangler.jsonc` are deployment/integration shells outside the eight browser entry graphs.
+
+| Virtual module | Owning package/output | Browser owner |
+|---|---|---|
+| `@moonbit/crdt-lambda` | `_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.{js,d.ts}` | Lambda, Memo |
+| `@moonbit/crdt-json` | `_build/js/release/build/dowdiness/canopy/ffi/json/json.{js,d.ts}` | JSON |
+| `@moonbit/crdt-markdown` | `_build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.{js,d.ts}` | Markdown |
+| `@moonbit/crdt-jsx` | `_build/js/release/build/dowdiness/canopy/ffi/jsx/jsx.{js,d.ts}` | GenUI |
+| `@moonbit/graphviz` | `_build/js/release/build/dowdiness/graphviz/browser/browser.{js,d.ts}` | Lambda |
+
+`vite.config.ts` defines the runtime mappings, `tsconfig.json` maps generated declarations, `scripts/build-js.sh` checks the expected artifacts, and CI uploads/downloads the same paths. Treat these four locations as one artifact contract.
+
+## Test and study ownership
+
+- `playwright.config.ts` runs the default browser suites under `tests/`; `playwright.preview.config.ts` owns the production-preview GenUI check.
+- `playwright.feasibility.config.ts` and `tests/genui-feasibility-live.spec.ts` own the live local-provider study path.
+- `playwright.minimal-provider.config.ts` and `tests/genui-minimal-provider.spec.ts` own the bounded minimal-provider path.
+- Deterministic GenUI tests are colocated as `src/genui-*.test.mjs`. Study orchestration tests are `scripts/*.test.mjs`; study evidence is retained under `studies/`.
+- `tests/fixtures/pi-session-v3.jsonl` belongs to Resume/PKE import and relay tests.
+- `spike-block-input.html`, `test-ast-bug.js`, and `test-ast-comprehensive.js` are not active Vite inputs or current test-runner inputs. Their removal or archival requires a separate reviewed slice.
+
+## Current structural exceptions and debt
+
+The source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. `decoration-overlay.ts` is shared by Lambda and JSON but lives at the source root. GenUI feasibility modules mix deterministic fixtures/flows with the server-only provider. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
+
+## Boundary vocabulary and allowed direction
+
+The target vocabulary is:
+
+- **entries**: one thin browser composition module per HTML surface;
+- **features**: browser-owned modules for one application only;
+- **shared**: reusable deterministic types, adapters, protocols, and core logic;
+- **server**: Node/Vite/provider capabilities and relays.
+
+Allowed direction is `entries -> corresponding feature -> shared`; server adapters may consume shared/core data but browser code must not consume server. Shared cannot consume features. A feature cannot consume another feature's internals. Declared `core/` and `protocol/` paths cannot import Node, Vite, React, or provider capabilities. The checker parses static imports with the TypeScript compiler and classifies the current flat tree explicitly; new target-shaped paths are checked by the same rules.
+
+## Validation
+
+```bash
+npm ci
+npm run check:boundaries
+npm run test:boundaries
+npm run typecheck   # generated MoonBit declarations must exist
+npm run build
+npm run preview
+```
+
+Playwright suites live in `tests/` and `preview-tests/`; deterministic unit/study tests are colocated under `src/` and `scripts/`. The repository-level JS build (`moon build --target js`, or `scripts/build-web.sh`) produces the generated dependencies before typecheck/build in CI.

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -1,79 +1,26 @@
-# Lambda Calculus CRDT Editor - Web Interface
+# Canopy web workspace
 
-A collaborative lambda calculus editor built with MoonBit CRDT and JavaScript.
+`examples/web` is a Vite workspace containing eight active browser applications:
+Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI Possibilities. Each HTML surface has its own entry module, while the applications share Canopy editor-adapter types and generated MoonBit JavaScript modules.
 
-Part of the [dowdiness/canopy](https://github.com/dowdiness/canopy) monorepo.
+The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Features
-
-- **Real-time syntax highlighting** for lambda calculus
-- **Error recovery** with inline error display
-- **CRDT-based** text editing for future collaboration
-- **Vite plugin** for automatic MoonBit builds and HMR
-
-## Getting Started
-
-### Prerequisites
-
-- Node.js 18+ and npm
-- MoonBit compiler (`curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash`)
-- The full monorepo cloned with submodules:
-  ```bash
-  git clone --recursive https://github.com/dowdiness/canopy.git
-  ```
-
-### Development
+## Development
 
 ```bash
 cd examples/web
-npm install
+npm ci
 npm run dev
-
-# Open http://localhost:5173
 ```
 
-The Vite plugin (`vite-plugin-moonbit`) automatically runs `moon build --target js` and watches for `.mbt` file changes during development.
-
-### Production Build
+The Vite configuration relays MoonBit modules from the repository build output and rebuilds them during development when needed. Build artifacts are namespaced under `_build/js/release/build/dowdiness/`.
 
 ```bash
+npm run typecheck
+npm run check:boundaries
+npm run test:boundaries
 npm run build
 npm run preview
 ```
 
-### Deploy Build (Cloudflare Pages)
-
-```bash
-npm run build:deploy
-```
-
-This installs the MoonBit CLI, fetches MoonBit package dependencies, then runs the Vite build. Use this as the build command on Cloudflare Pages or other CI environments that don't have `moon` pre-installed.
-
-## Architecture
-
-- **Frontend**: TypeScript + Vite
-- **Backend**: MoonBit CRDT compiled to JavaScript via `vite-plugin-moonbit`
-- **Parser**: Error-recovering lambda calculus parser
-- **Editor**: contenteditable-based with AST-driven highlighting
-
-### Vite Plugin
-
-The `vite-plugin-moonbit.ts` plugin handles the MoonBit integration:
-
-- Builds MoonBit modules at startup (`moon build --target js`)
-- Provides virtual modules (`@moonbit/crdt`, `@moonbit/graphviz`) importable in TypeScript
-- Watches `.mbt` files and triggers full reload on changes during development
-
-## Usage
-
-1. Open the editor in your browser
-2. Start typing lambda calculus expressions
-3. See real-time syntax highlighting and error detection
-
-### Example Expressions
-
-```
-((x) => x + 1) 5
-((f, x) => f (f x)) ((y) => y + y) 3
-if 1 then 2 else 3
-```
+For a deploy build, use `npm run build:deploy`; it installs MoonBit and builds the generated JavaScript before running Vite.

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -8,7 +8,10 @@
     "build:deploy": "sh scripts/build-deploy.sh",
     "preview": "vite preview",
     "signaling": "node signaling-server.js",
-    "genui:minimal-provider-e2e": "node scripts/run-genui-minimal-provider-e2e.mjs"
+    "genui:minimal-provider-e2e": "node scripts/run-genui-minimal-provider-e2e.mjs",
+    "typecheck": "tsc --noEmit",
+    "check:boundaries": "node scripts/check-boundaries.mjs",
+    "test:boundaries": "node --test scripts/check-boundaries.test.mjs"
   },
   "dependencies": {
     "@ai-sdk/deepseek": "^3.0.12",

--- a/examples/web/scripts/check-boundaries.mjs
+++ b/examples/web/scripts/check-boundaries.mjs
@@ -215,10 +215,17 @@ export function evaluateEdge(from, to, specifier = to) {
   }
   if (
     source.kind === 'feature' &&
-    (source.layer === 'core' || source.layer === 'protocol') &&
-    capabilityImport(specifier)
+    (source.layer === 'core' || source.layer === 'protocol')
   ) {
-    violations.push('core/protocol code cannot import Node/Vite/React/provider capabilities');
+    if (
+      (target.kind === 'feature' && target.layer === 'browser') ||
+      (target.kind === 'shared' && /(^|\/)shared\/browser\//.test(normalize(to)))
+    ) {
+      violations.push('core/protocol code cannot import browser layers');
+    }
+    if (capabilityImport(specifier)) {
+      violations.push('core/protocol code cannot import Node/Vite/React/provider capabilities');
+    }
   }
   return [...new Set(violations)];
 }
@@ -284,22 +291,43 @@ export function htmlEntryAccepted(script, feature, currentScript) {
     (target.kind === 'entry' && target.owner === feature);
 }
 
+export function evaluateHtmlEntryScripts(html, feature, scripts, currentScript) {
+  const violations = [];
+  let acceptedCount = 0;
+  for (const script of scripts) {
+    const relative = script.startsWith('/') ? script.slice(1) : script;
+    if (htmlEntryAccepted(script, feature, currentScript)) {
+      acceptedCount += 1;
+    } else {
+      violations.push({
+        from: html,
+        to: relative,
+        rule: 'HTML entry must load its corresponding browser entry module',
+      });
+    }
+  }
+  if (acceptedCount === 0) {
+    violations.push({
+      from: html,
+      to: '<missing>',
+      rule: 'HTML entry must load at least one corresponding browser entry module',
+    });
+  }
+  return violations;
+}
+
 export function checkHtmlEntries(root) {
   const violations = [];
   for (const [html, feature] of ENTRY_FEATURES) {
     const htmlText = fs.readFileSync(path.join(root, html), 'utf8');
     const scripts = [...htmlText.matchAll(/<script[^>]+src=["']([^"']+)["']/g)]
       .map(match => match[1]);
-    for (const script of scripts) {
-      const relative = script.startsWith('/') ? script.slice(1) : script;
-      if (!htmlEntryAccepted(script, feature, CURRENT_ENTRY_SCRIPTS.get(html))) {
-        violations.push({
-          from: html,
-          to: relative,
-          rule: 'HTML entry must load its corresponding browser entry module',
-        });
-      }
-    }
+    violations.push(...evaluateHtmlEntryScripts(
+      html,
+      feature,
+      scripts,
+      CURRENT_ENTRY_SCRIPTS.get(html),
+    ));
   }
   return violations;
 }

--- a/examples/web/scripts/check-boundaries.mjs
+++ b/examples/web/scripts/check-boundaries.mjs
@@ -1,0 +1,318 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+const FEATURE_NAMES = new Set([
+  'lambda',
+  'json',
+  'markdown',
+  'memo',
+  'posts',
+  'resume',
+  'genui',
+  'genui-possibilities',
+]);
+const ENTRY_FEATURES = new Map([
+  ['index.html', 'lambda'],
+  ['json.html', 'json'],
+  ['markdown.html', 'markdown'],
+  ['memo.html', 'memo'],
+  ['posts.html', 'posts'],
+  ['resume.html', 'resume'],
+  ['genui.html', 'genui'],
+  ['genui-possibilities.html', 'genui-possibilities'],
+]);
+const CURRENT_ENTRY_SCRIPTS = new Map([
+  ['index.html', 'src/main.ts'],
+  ['json.html', 'src/json-editor.ts'],
+  ['markdown.html', 'src/markdown-editor.ts'],
+  ['memo.html', 'src/memo-editor.ts'],
+  ['posts.html', 'src/post-app.ts'],
+  ['resume.html', 'src/resume-app.tsx'],
+  ['genui.html', 'src/genui.js'],
+  ['genui-possibilities.html', 'src/genui-possibilities.js'],
+]);
+const ROOT_SERVER_FILES = new Set([
+  'signaling-server.js',
+  'signaling-worker.js',
+  'vite.config.ts',
+  'vite-plugin-genui-feasibility.ts',
+  'vite-plugin-moonbit.ts',
+  'vite-plugin-pi-resume-chat.ts',
+]);
+
+function normalize(filePath) {
+  return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function capabilityImport(specifier) {
+  return specifier.startsWith('node:') ||
+    specifier === 'vite' ||
+    specifier.startsWith('@vitejs/') ||
+    specifier.startsWith('@tailwindcss/') ||
+    specifier === 'react' ||
+    specifier.startsWith('react/') ||
+    specifier === 'react-dom' ||
+    specifier.startsWith('react-dom/') ||
+    specifier === 'ai' ||
+    specifier.startsWith('ai/') ||
+    specifier.startsWith('@ai-sdk/');
+}
+
+export function describePath(filePath) {
+  const normalized = normalize(filePath);
+  const base = path.posix.basename(normalized);
+  if (/\.(test|spec)\./.test(base) || /^(tests|preview-tests)\//.test(normalized)) {
+    return { kind: 'test' };
+  }
+  if (
+    /(^|\/)server\//.test(normalized) ||
+    ROOT_SERVER_FILES.has(normalized) ||
+    base === 'genui-feasibility-provider.js'
+  ) {
+    return { kind: 'server' };
+  }
+
+  const entryMatch = normalized.match(/(^|\/)entries\/([^/]+)\.[^.]+$/);
+  if (entryMatch) return { kind: 'entry', owner: entryMatch[2] };
+
+  const featureMatch = normalized.match(/(^|\/)features\/([^/]+)(?:\/([^/]+))?/);
+  if (featureMatch) {
+    return {
+      kind: 'feature',
+      owner: featureMatch[2],
+      layer: featureMatch[3],
+    };
+  }
+
+  if (/(^|\/)shared\//.test(normalized) || base === 'decoration-overlay.ts' || base === 'vite-env.d.ts') {
+    return { kind: 'shared' };
+  }
+  if (/^(main|editor|ast-grep-runner)\./.test(base)) return { kind: 'feature', owner: 'lambda' };
+  if (base.startsWith('json-editor.')) return { kind: 'feature', owner: 'json' };
+  if (base === 'resume.css') return { kind: 'feature', owner: 'resume' };
+  if (base === 'tailwind.css') return { kind: 'feature', owner: 'genui' };
+  if (base === 'genui-possibilities.css') {
+    return { kind: 'feature', owner: 'genui-possibilities' };
+  }
+  if (/^(markdown-editor|markdown-sentinels)\./.test(base)) return { kind: 'feature', owner: 'markdown' };
+  if (base.startsWith('memo-editor.')) return { kind: 'feature', owner: 'memo' };
+  if (/^post-(app|events|retrieval|store)\./.test(base)) return { kind: 'feature', owner: 'posts' };
+  if (/^(resume-app|pi-resume-)/.test(base) || normalized.includes('components/ai-elements/')) {
+    return { kind: 'feature', owner: 'resume' };
+  }
+  if (/^genui-possibilities\./.test(base) || base.startsWith('genui-journey-state.')) {
+    return { kind: 'feature', owner: 'genui-possibilities' };
+  }
+  if (/^genui(?:-|\.)/.test(base) || normalized.includes('/fixtures/')) {
+    return { kind: 'feature', owner: 'genui' };
+  }
+  return { kind: 'unclassified' };
+}
+
+export function classifyPath(filePath) {
+  const description = describePath(filePath);
+  return description.owner ?? description.kind;
+}
+
+export function resolveLocalImport(from, specifier, files = new Set()) {
+  if (!specifier.startsWith('.') && !specifier.startsWith('/')) return null;
+  const fromDir = path.posix.dirname(normalize(from));
+  const requested = specifier.startsWith('/')
+    ? path.posix.normalize(specifier.slice(1))
+    : path.posix.normalize(path.posix.join(fromDir, specifier));
+  const requestedExtension = path.posix.extname(requested);
+  const candidates = requestedExtension
+    ? [
+        requested,
+        ...SOURCE_EXTENSIONS
+          .filter(extension => extension !== requestedExtension)
+          .map(extension => requested.slice(0, -requestedExtension.length) + extension),
+      ]
+    : SOURCE_EXTENSIONS.flatMap(extension => [
+        requested + extension,
+        path.posix.join(requested, 'index' + extension),
+      ]);
+  return candidates.find(candidate => files.has(candidate)) ?? requested;
+}
+
+export function staticImports(sourceText, fileName = 'file.ts') {
+  const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const imports = new Set();
+  function visit(node) {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      imports.add(node.moduleSpecifier.text);
+    } else if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      imports.add(node.moduleSpecifier.text);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      (
+        node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require')
+      )
+    ) {
+      imports.add(node.arguments[0].text);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteral(node.moduleReference.expression)
+    ) {
+      imports.add(node.moduleReference.expression.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  return [...imports];
+}
+
+export function evaluateEdge(from, to, specifier = to) {
+  const source = describePath(from);
+  const target = describePath(to);
+  const violations = [];
+
+  if (source.kind === 'unclassified') violations.push('source module has no declared owner');
+  if (target.kind === 'unclassified' && specifier.startsWith('.')) {
+    violations.push('local dependency has no declared owner');
+  }
+  if (source.kind !== 'server' && source.kind !== 'test' && target.kind === 'server') {
+    violations.push('browser code cannot import server code');
+  }
+  if (source.kind === 'shared' && target.kind === 'feature') {
+    violations.push('shared code cannot import feature code');
+  }
+  if (
+    source.kind === 'feature' &&
+    target.kind === 'feature' &&
+    source.owner !== target.owner
+  ) {
+    violations.push('a feature cannot import another feature internals');
+  }
+  if (source.kind === 'entry') {
+    if (
+      target.kind !== 'feature' ||
+      target.owner !== source.owner ||
+      target.layer !== 'browser'
+    ) {
+      violations.push('entry can only compose its corresponding feature browser surface');
+    }
+  }
+  if (
+    source.kind === 'server' &&
+    target.kind === 'feature' &&
+    target.layer !== undefined &&
+    target.layer !== 'core' &&
+    target.layer !== 'protocol'
+  ) {
+    violations.push('server code can only import explicit feature core/protocol surfaces');
+  }
+  if (
+    source.kind === 'feature' &&
+    (source.layer === 'core' || source.layer === 'protocol') &&
+    capabilityImport(specifier)
+  ) {
+    violations.push('core/protocol code cannot import Node/Vite/React/provider capabilities');
+  }
+  return [...new Set(violations)];
+}
+
+function filesBelow(root) {
+  if (!fs.existsSync(root)) return [];
+  const found = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) found.push(...filesBelow(full));
+    else if (SOURCE_EXTENSIONS.includes(path.extname(entry.name))) found.push(full);
+  }
+  return found;
+}
+
+export function discoverSourceFiles(projectRoot) {
+  return [
+    ...filesBelow(path.join(projectRoot, 'src')),
+    ...filesBelow(path.join(projectRoot, 'server')),
+    ...[...ROOT_SERVER_FILES]
+      .map(file => path.join(projectRoot, file))
+      .filter(file => fs.existsSync(file)),
+  ];
+}
+
+export function checkBoundaries({
+  root,
+  files = discoverSourceFiles(root),
+  readFile = file => fs.readFileSync(file, 'utf8'),
+}) {
+  const relativeFiles = new Set(files.map(file => normalize(path.relative(root, file))));
+  const violations = [];
+  for (const file of files) {
+    const relative = normalize(path.relative(root, file));
+    const source = describePath(relative);
+    if (source.kind === 'unclassified') {
+      violations.push({ from: relative, to: relative, rule: 'source module has no declared owner' });
+    }
+    for (const specifier of staticImports(readFile(file), relative)) {
+      const target = resolveLocalImport(relative, specifier, relativeFiles);
+      if (target !== null) {
+        violations.push(...evaluateEdge(relative, target, specifier).map(rule => ({
+          from: relative,
+          to: target,
+          rule,
+        })));
+      } else {
+        violations.push(...evaluateEdge(relative, specifier, specifier).map(rule => ({
+          from: relative,
+          to: specifier,
+          rule,
+        })));
+      }
+    }
+  }
+  return violations;
+}
+
+export function htmlEntryAccepted(script, feature, currentScript) {
+  const relative = script.startsWith('/') ? script.slice(1) : script;
+  const target = describePath(relative);
+  return relative === currentScript ||
+    (target.kind === 'entry' && target.owner === feature);
+}
+
+export function checkHtmlEntries(root) {
+  const violations = [];
+  for (const [html, feature] of ENTRY_FEATURES) {
+    const htmlText = fs.readFileSync(path.join(root, html), 'utf8');
+    const scripts = [...htmlText.matchAll(/<script[^>]+src=["']([^"']+)["']/g)]
+      .map(match => match[1]);
+    for (const script of scripts) {
+      const relative = script.startsWith('/') ? script.slice(1) : script;
+      if (!htmlEntryAccepted(script, feature, CURRENT_ENTRY_SCRIPTS.get(html))) {
+        violations.push({
+          from: html,
+          to: relative,
+          rule: 'HTML entry must load its corresponding browser entry module',
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const root = path.resolve(process.argv[2] ?? new URL('..', import.meta.url).pathname);
+  const violations = [...checkBoundaries({ root }), ...checkHtmlEntries(root)];
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      console.error(`${violation.from} -> ${violation.to}: ${violation.rule}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log('Web dependency boundaries: OK');
+  }
+}

--- a/examples/web/scripts/check-boundaries.test.mjs
+++ b/examples/web/scripts/check-boundaries.test.mjs
@@ -5,6 +5,7 @@ import {
   classifyPath,
   describePath,
   evaluateEdge,
+  evaluateHtmlEntryScripts,
   htmlEntryAccepted,
   resolveLocalImport,
   staticImports,
@@ -89,6 +90,23 @@ test('requires HTML to load a current entry or the target-shaped entry module', 
   assert.equal(htmlEntryAccepted('/src/entries/posts.ts', 'posts', 'src/post-app.ts'), true);
   assert.equal(htmlEntryAccepted('/src/features/posts/core/posts.ts', 'posts', 'src/post-app.ts'), false);
   assert.equal(htmlEntryAccepted('/src/entries/resume.tsx', 'posts', 'src/post-app.ts'), false);
+  assert.deepEqual(
+    evaluateHtmlEntryScripts('posts.html', 'posts', [], 'src/post-app.ts'),
+    [{
+      from: 'posts.html',
+      to: '<missing>',
+      rule: 'HTML entry must load at least one corresponding browser entry module',
+    }],
+  );
+  assert.deepEqual(
+    evaluateHtmlEntryScripts(
+      'posts.html',
+      'posts',
+      ['/src/entries/posts.ts'],
+      'src/post-app.ts',
+    ),
+    [],
+  );
 });
 
 test('limits future server adapters to feature core and protocol surfaces', () => {
@@ -99,6 +117,23 @@ test('limits future server adapters to feature core and protocol surfaces', () =
   assert.match(
     evaluateEdge('server/vite/resume-chat.ts', 'src/features/resume/browser/chat.ts')[0],
     /server code/,
+  );
+});
+
+test('rejects browser-layer imports from declared core and protocol paths', () => {
+  assert.match(
+    evaluateEdge(
+      'src/features/resume/core/session.ts',
+      'src/features/resume/browser/import-session.ts',
+    )[0],
+    /browser layers/,
+  );
+  assert.match(
+    evaluateEdge(
+      'src/features/resume/protocol/chat.ts',
+      'src/shared/browser/fetch-json.ts',
+    )[0],
+    /browser layers/,
   );
 });
 

--- a/examples/web/scripts/check-boundaries.test.mjs
+++ b/examples/web/scripts/check-boundaries.test.mjs
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  checkBoundaries,
+  classifyPath,
+  describePath,
+  evaluateEdge,
+  htmlEntryAccepted,
+  resolveLocalImport,
+  staticImports,
+} from './check-boundaries.mjs';
+
+test('parses static and literal dynamic imports with the TypeScript AST', () => {
+  assert.deepEqual(
+    staticImports([
+      "import { x } from './x.js'",
+      "export { y } from './y.js'",
+      "const z = import('./dynamic.js')",
+      "const legacy = require('./legacy.cjs')",
+      "const ignored = import(variable)",
+    ].join('\n')),
+    ['./x.js', './y.js', './dynamic.js', './legacy.cjs'],
+  );
+});
+
+test('accepts same-feature and feature-to-shared edges', () => {
+  assert.deepEqual(
+    evaluateEdge('src/features/posts/browser/app.ts', 'src/features/posts/core/posts.ts'),
+    [],
+  );
+  assert.deepEqual(
+    evaluateEdge('src/features/posts/browser/app.ts', 'src/shared/browser/date.ts'),
+    [],
+  );
+});
+
+test('rejects cross-feature, browser-to-server, and shared-to-feature edges', () => {
+  assert.match(
+    evaluateEdge('src/features/posts/browser/app.ts', 'src/features/resume/core/session.ts')[0],
+    /another feature/,
+  );
+  assert.match(
+    evaluateEdge('src/features/genui/browser/app.ts', 'server/vite/provider.ts')[0],
+    /server/,
+  );
+  assert.match(
+    evaluateEdge('src/shared/browser/overlay.ts', 'src/features/posts/browser/app.ts')[0],
+    /shared/,
+  );
+});
+
+test('resolves relative and Vite root-relative local imports', () => {
+  const files = new Set([
+    'src/features/posts/browser/mount.ts',
+    'server/vite/provider.ts',
+  ]);
+  assert.equal(
+    resolveLocalImport('src/entries/posts.ts', '../features/posts/browser/mount', files),
+    'src/features/posts/browser/mount.ts',
+  );
+  assert.equal(
+    resolveLocalImport('src/features/posts/browser/mount.ts', '/server/vite/provider.ts', files),
+    'server/vite/provider.ts',
+  );
+});
+
+test('requires entries to import the matching feature browser surface only', () => {
+  assert.deepEqual(
+    evaluateEdge('src/entries/posts.ts', 'src/features/posts/browser/mount.ts'),
+    [],
+  );
+  assert.match(
+    evaluateEdge('src/entries/posts.ts', 'src/features/posts/core/posts.ts')[0],
+    /entry/,
+  );
+  assert.match(
+    evaluateEdge('src/entries/posts.ts', 'src/shared/browser/date.ts')[0],
+    /entry/,
+  );
+  assert.match(
+    evaluateEdge('src/entries/posts.ts', 'react', 'react')[0],
+    /entry/,
+  );
+});
+
+test('requires HTML to load a current entry or the target-shaped entry module', () => {
+  assert.equal(htmlEntryAccepted('/src/post-app.ts', 'posts', 'src/post-app.ts'), true);
+  assert.equal(htmlEntryAccepted('/src/post-store.ts', 'posts', 'src/post-app.ts'), false);
+  assert.equal(htmlEntryAccepted('/src/entries/posts.ts', 'posts', 'src/post-app.ts'), true);
+  assert.equal(htmlEntryAccepted('/src/features/posts/core/posts.ts', 'posts', 'src/post-app.ts'), false);
+  assert.equal(htmlEntryAccepted('/src/entries/resume.tsx', 'posts', 'src/post-app.ts'), false);
+});
+
+test('limits future server adapters to feature core and protocol surfaces', () => {
+  assert.deepEqual(
+    evaluateEdge('server/vite/resume-chat.ts', 'src/features/resume/protocol/chat.ts'),
+    [],
+  );
+  assert.match(
+    evaluateEdge('server/vite/resume-chat.ts', 'src/features/resume/browser/chat.ts')[0],
+    /server code/,
+  );
+});
+
+test('rejects capabilities from declared core and protocol paths', () => {
+  assert.match(
+    evaluateEdge('src/features/resume/core/parser.ts', 'node:crypto', 'node:crypto')[0],
+    /core\/protocol/,
+  );
+  assert.match(
+    evaluateEdge('src/features/resume/protocol/chat.ts', 'react', 'react')[0],
+    /core\/protocol/,
+  );
+});
+
+test('recognizes current exceptions and future top-level runtime vocabulary', () => {
+  assert.equal(classifyPath('src/main.ts'), 'lambda');
+  assert.equal(classifyPath('src/components/ai-elements/message.tsx'), 'resume');
+  assert.equal(classifyPath('src/genui-feasibility-provider.js'), 'server');
+  assert.equal(classifyPath('server/vite/genui-provider.ts'), 'server');
+  assert.deepEqual(
+    describePath('src/features/json/browser/editor.ts'),
+    { kind: 'feature', owner: 'json', layer: 'browser' },
+  );
+});
+
+test('rejects newly added unclassified production modules', () => {
+  const root = '/repo/examples/web';
+  const files = [`${root}/src/mystery.ts`];
+  const violations = checkBoundaries({
+    root,
+    files,
+    readFile: () => 'export const mystery = true',
+  });
+  assert.deepEqual(violations, [{
+    from: 'src/mystery.ts',
+    to: 'src/mystery.ts',
+    rule: 'source module has no declared owner',
+  }]);
+});


### PR DESCRIPTION
## Summary

- document all eight active `examples/web` surfaces, runtime ownership, tests, relays, and generated MoonBit artifact contracts
- add a TypeScript-AST dependency checker for current ownership and the planned entries/features/shared/server boundaries
- run web typecheck, boundary validation, and boundary unit tests in CI

This is the first behavior-preserving slice of #917. It establishes the map and enforceable dependency direction before production files move. It does not close #917.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| TypeScript compiler AST (`createSourceFile`, node guards, traversal) | `typescript` dev dependency | Yes | Parses imports without a new parser dependency or source regexes |
| Node `fs` and `path` | Node core | Yes | Thin filesystem/CLI shell around deterministic rule evaluation |
| Existing Vite input and MoonBit virtual-module maps | `examples/web/vite.config.ts` | Yes | Source of truth for the committed module inventory |

New helpers added:

- path classification and edge-evaluation helpers keep ownership decisions deterministic and unit-testable
- import discovery and CLI helpers isolate filesystem traversal from rule evaluation
- no MoonBit helper, type, package, or generated interface was added

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (existing vendored/deprecation warnings only)
- [x] `NEW_MOON_MOD=0 moon test` passes (1,937 JS and 70 native tests)
- [x] `git diff *.mbti` reviewed; no interface drift
- [x] JS rebuild run (`cd examples/web && npm run build`)
- [x] `cd examples/web && npm run typecheck`
- [x] `cd examples/web && npm run check:boundaries`
- [x] `cd examples/web && npm run test:boundaries`
- [x] `./scripts/validate-ci-yaml.sh`
- [x] `git diff --check`

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/web
npm run typecheck
npm run check:boundaries
npm run test:boundaries
npm run build
```

Part of #917.
