### PR TITLE
refactor(web): isolate Lambda ast-grep relay

### DIFF
--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -20,7 +20,7 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 ## Runtime and generated dependencies
 
 - Browser code is TypeScript/TSX/JS bundled by Vite. React and the AI SDK are used by Resume/PKE; GenUI is plain browser JavaScript plus the generated JSX FFI.
-- `vite-plugin-moonbit.ts` owns MoonBit builds, virtual-module loading, output watching, and HMR. It also currently owns the Lambda-only `/api/ast-grep` development relay.
+- `server/vite/ast-grep.ts` owns the Lambda-only `/api/ast-grep` development relay. `vite-plugin-moonbit.ts` owns MoonBit build, virtual-module, and HMR behavior only.
 - `server/vite/resume-chat.ts` owns the local Resume/PKE provider relay and consumes the Resume protocol surface. `vite-plugin-genui-feasibility.ts` owns the local GenUI study relay and imports the server-only `src/genui-feasibility-provider.js`. These Vite adapters are not browser entry dependencies.
 - `signaling-server.js`, `signaling-worker.js`, `wrangler-signaling.toml`, and `wrangler.jsonc` are deployment/integration shells outside the eight browser entry graphs.
 

--- a/examples/web/scripts/check-boundaries.test.mjs
+++ b/examples/web/scripts/check-boundaries.test.mjs
@@ -267,6 +267,7 @@ test('recognizes current exceptions and future top-level runtime vocabulary', ()
   assert.equal(classifyPath('src/resume.css'), 'unclassified');
   assert.equal(classifyPath('src/genui-feasibility-provider.js'), 'server');
   assert.equal(classifyPath('server/vite/genui-provider.ts'), 'server');
+  assert.equal(classifyPath('server/vite/ast-grep.ts'), 'server');
   assert.equal(classifyPath('src/shared/decoration-overlay.ts'), 'shared');
   assert.deepEqual(
     describePath('src/entries/lambda.ts'),

--- a/examples/web/server/vite/ast-grep.ts
+++ b/examples/web/server/vite/ast-grep.ts
@@ -1,0 +1,149 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { Plugin, ViteDevServer } from 'vite';
+
+type AstGrepJsonMatch = {
+  ruleId?: string;
+  range?: { byteOffset?: { start?: number; end?: number } };
+};
+
+export function astGrepPlugin(): Plugin {
+  return {
+    name: 'ast-grep',
+    apply: 'serve',
+
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use('/api/ast-grep', async (req, res) => {
+        if (req.method !== 'POST') {
+          res.statusCode = 405;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ error: 'method not allowed' }));
+          return;
+        }
+
+        try {
+          const body = JSON.parse(await readRequestBody(req, 1_000_000)) as { text?: unknown };
+          const text = typeof body.text === 'string' ? body.text : '';
+          const matches = await runAstGrep(text);
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ matches }));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          res.statusCode = message.includes('request body too large') ? 413 : 500;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ error: message }));
+        }
+      });
+    },
+  };
+}
+
+async function readRequestBody(
+  req: import('node:http').IncomingMessage,
+  maxBytes: number,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    totalBytes += buffer.byteLength;
+    if (totalBytes > maxBytes) {
+      throw new Error('request body too large for ast-grep analysis');
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function runAstGrep(text: string): Promise<Array<{ byte_start: number; byte_end: number; pattern_id: string }>> {
+  if (text.trim() === '') return [];
+
+  const repoRoot = path.resolve(process.cwd(), '../..');
+  const astGrepBin = process.env.AST_GREP_BIN ?? path.resolve(process.cwd(), 'node_modules/.bin/sg');
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'canopy-ast-grep-'));
+  const tempFile = path.join(tempDir, 'input.mbt');
+
+  try {
+    await writeFile(tempFile, text, 'utf8');
+    const { stdout, stderr, code } = await runProcess(
+      astGrepBin,
+      [
+        'scan',
+        '-c', 'sgconfig.yml',
+        '--filter', '^moonbit-fn-def$',
+        tempFile,
+        '--json=stream',
+      ],
+      '',
+      repoRoot,
+      5_000,
+    );
+
+    if (code !== 0) {
+      throw new Error(stderr || `ast-grep exited with code ${code}`);
+    }
+
+    return stdout
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => JSON.parse(line) as AstGrepJsonMatch)
+      .map(match => {
+        const start = match.range?.byteOffset?.start;
+        const end = match.range?.byteOffset?.end;
+        if (typeof start !== 'number' || typeof end !== 'number') {
+          throw new Error('ast-grep result missing byte offsets');
+        }
+        return {
+          byte_start: start,
+          byte_end: end,
+          pattern_id: match.ruleId ?? 'moonbit-fn-def',
+        };
+      });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function runProcess(
+  command: string,
+  args: string[],
+  input: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    child.stdout?.on('data', data => { stdout += data.toString(); });
+    child.stderr?.on('data', data => { stderr += data.toString(); });
+    child.on('error', error => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('close', code => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        stdout,
+        stderr: timedOut ? `ast-grep timed out after ${timeoutMs}ms` : stderr,
+        code,
+      });
+    });
+    child.stdin?.end(input);
+  });
+}

--- a/examples/web/tests/lambda-editor.spec.ts
+++ b/examples/web/tests/lambda-editor.spec.ts
@@ -33,6 +33,18 @@ test.describe('Lambda Editor — Foundation', () => {
     expect(pageErrors).toEqual([]);
   });
 
+  test('ast-grep endpoint preserves its method and empty-input contract', async ({ page }) => {
+    const getResponse = await page.request.get('/api/ast-grep');
+    expect(getResponse.status()).toBe(405);
+
+    const postResponse = await page.request.post('/api/ast-grep', {
+      headers: { 'content-type': 'application/json' },
+      data: { text: '' },
+    });
+    expect(postResponse.status()).toBe(200);
+    expect(await postResponse.json()).toEqual({ matches: [] });
+  });
+
   test('editor is visible and focusable', async ({ page }) => {
     const editor = page.locator('#editor');
     await expect(editor).toBeVisible();

--- a/examples/web/vite-plugin-moonbit.ts
+++ b/examples/web/vite-plugin-moonbit.ts
@@ -1,7 +1,6 @@
 import { exec, spawn, type ChildProcess } from 'node:child_process';
 import { promisify } from 'node:util';
-import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { access, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
 
@@ -136,28 +135,6 @@ export function moonbitPlugin(options: MoonBitPluginOptions): Plugin {
     },
 
     configureServer(server: ViteDevServer) {
-      server.middlewares.use('/api/ast-grep', async (req, res) => {
-        if (req.method !== 'POST') {
-          res.statusCode = 405;
-          res.setHeader('content-type', 'application/json');
-          res.end(JSON.stringify({ error: 'method not allowed' }));
-          return;
-        }
-
-        try {
-          const body = JSON.parse(await readRequestBody(req, 1_000_000)) as { text?: unknown };
-          const text = typeof body.text === 'string' ? body.text : '';
-          const matches = await runAstGrep(text);
-          res.setHeader('content-type', 'application/json');
-          res.end(JSON.stringify({ matches }));
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          res.statusCode = message.includes('request body too large') ? 413 : 500;
-          res.setHeader('content-type', 'application/json');
-          res.end(JSON.stringify({ error: message }));
-        }
-      });
-
       if (watch && shouldSkipBuild) {
         console.log('[MoonBit] Skipping watch mode (CI / CANOPY_SKIP_MOON_BUILD=1), using pre-built modules');
       } else if (watch) {
@@ -281,119 +258,6 @@ async function buildAllModules(
 /**
  * Build a single MoonBit module
  */
-type AstGrepJsonMatch = {
-  ruleId?: string;
-  range?: { byteOffset?: { start?: number; end?: number } };
-};
-
-async function readRequestBody(
-  req: import('node:http').IncomingMessage,
-  maxBytes: number,
-): Promise<string> {
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
-  for await (const chunk of req) {
-    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
-    totalBytes += buffer.byteLength;
-    if (totalBytes > maxBytes) {
-      throw new Error('request body too large for ast-grep analysis');
-    }
-    chunks.push(buffer);
-  }
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-async function runAstGrep(text: string): Promise<Array<{ byte_start: number; byte_end: number; pattern_id: string }>> {
-  if (text.trim() === '') return [];
-
-  const repoRoot = path.resolve(process.cwd(), '../..');
-  const astGrepBin = process.env.AST_GREP_BIN ?? path.resolve(process.cwd(), 'node_modules/.bin/sg');
-  const tempDir = await mkdtemp(path.join(tmpdir(), 'canopy-ast-grep-'));
-  const tempFile = path.join(tempDir, 'input.mbt');
-
-  try {
-    await writeFile(tempFile, text, 'utf8');
-    const { stdout, stderr, code } = await runProcess(
-      astGrepBin,
-      [
-        'scan',
-        '-c', 'sgconfig.yml',
-        '--filter', '^moonbit-fn-def$',
-        tempFile,
-        '--json=stream',
-      ],
-      '',
-      repoRoot,
-      5_000,
-    );
-
-    if (code !== 0) {
-      throw new Error(stderr || `ast-grep exited with code ${code}`);
-    }
-
-    return stdout
-      .split('\n')
-      .map(line => line.trim())
-      .filter(Boolean)
-      .map(line => JSON.parse(line) as AstGrepJsonMatch)
-      .map(match => {
-        const start = match.range?.byteOffset?.start;
-        const end = match.range?.byteOffset?.end;
-        if (typeof start !== 'number' || typeof end !== 'number') {
-          throw new Error('ast-grep result missing byte offsets');
-        }
-        return {
-          byte_start: start,
-          byte_end: end,
-          pattern_id: match.ruleId ?? 'moonbit-fn-def',
-        };
-      });
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-}
-
-function runProcess(
-  command: string,
-  args: string[],
-  input: string,
-  cwd: string,
-  timeoutMs: number,
-): Promise<{ stdout: string; stderr: string; code: number | null }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
-    let stdout = '';
-    let stderr = '';
-    let settled = false;
-    let timedOut = false;
-
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGKILL');
-    }, timeoutMs);
-
-    child.stdout?.on('data', data => { stdout += data.toString(); });
-    child.stderr?.on('data', data => { stderr += data.toString(); });
-    child.on('error', error => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      reject(error);
-    });
-    child.on('close', code => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      resolve({
-        stdout,
-        stderr: timedOut ? `ast-grep timed out after ${timeoutMs}ms` : stderr,
-        code,
-      });
-    });
-    child.stdin?.end(input);
-  });
-}
-
 async function buildModule(
   mod: MoonBitModule & { absolutePath: string },
   target: string,

--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -5,6 +5,7 @@ import { moonbitPlugin } from './vite-plugin-moonbit';
 import tailwindcss from '@tailwindcss/vite';
 import { genUiFeasibilityPlugin } from './vite-plugin-genui-feasibility';
 import { piResumeChatPlugin } from './server/vite/resume-chat';
+import { astGrepPlugin } from './server/vite/ast-grep';
 
 const analyze = process.env.ANALYZE === '1';
 
@@ -14,6 +15,7 @@ export default defineConfig({
     tailwindcss(),
     genUiFeasibilityPlugin(),
     piResumeChatPlugin(),
+    astGrepPlugin(),
     moonbitPlugin({
       modules: [
         {


### PR DESCRIPTION
## Summary

- Move the Lambda-only `/api/ast-grep` Vite middleware into `server/vite/ast-grep.ts`.
- Keep MoonBit build, virtual-module, watch, and HMR behavior inside `vite-plugin-moonbit.ts`.
- Preserve the relay contract and add focused endpoint coverage.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Server Vite plugin pattern | `examples/web/server/vite/resume-chat.ts` | Yes | Applied the existing `apply: 'serve'` middleware plugin structure. |
| Lambda browser endpoint runner | `examples/web/src/features/lambda/browser/ast-grep-runner.ts` | Yes | Preserved its endpoint contract without adding server imports. |

New helpers added (if any):

- `astGrepPlugin`: server-shell Vite plugin owning the existing middleware and Node subprocess helpers; it replaces the relay responsibility formerly embedded in the MoonBit plugin.

## Test plan

- [ ] `NEW_MOON_MOD=0 moon check` passes (not run; no MoonBit source changed)
- [ ] `NEW_MOON_MOD=0 moon test` passes (not run; no MoonBit source changed)
- [x] `git diff *.mbti` reviewed for unintended API surface changes (no MoonBit interfaces changed)
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build`)

## Validation

```bash
cd examples/web
npm run check:boundaries
npm run test:boundaries
npm run typecheck
npx playwright test tests/lambda-editor.spec.ts
npm run build
npx playwright test
```

Full Web E2E: 100 passed, 2 skipped.
