### PR TITLE
chore(deps): migrate Canopy to EGW v0.5.0

### DIFF
--- a/cmd/main/demo.mbt
+++ b/cmd/main/demo.mbt
@@ -20,18 +20,14 @@ fn show_editor(agent_name : String, editor : @editor.Editor) -> Unit {
 
 ///|
 /// Show sync info (op count via SyncMessage)
-fn show_sync_info(editor : @editor.Editor) -> Unit {
-  try {
-    let msg = editor.export_all()
-    println("Operations (\{msg.op_count()} total in sync message)")
-  } catch {
-    _ => ()
-  }
+fn show_sync_info(editor : @editor.Editor) -> Unit raise {
+  let msg = editor.export_all()
+  println("Operations (\{msg.op_count()} total in sync message)")
 }
 
 ///|
 /// Run CRDT editor demo
-pub fn run_convergence_demo() -> Unit {
+pub fn run_convergence_demo() -> Unit raise {
   println("Eg-walker CRDT Editor - Feature Demo")
   print_separator()
   println("")
@@ -42,16 +38,16 @@ pub fn run_convergence_demo() -> Unit {
   println("")
   let alice = @editor.Editor::new("alice")
   println("1. Alice types 'Hello'")
-  try! alice.insert("Hello")
+  alice.insert("Hello")
   show_editor("Alice", alice)
   println("")
   println("2. Alice types ' World'")
-  try! alice.insert(" World")
+  alice.insert(" World")
   show_editor("Alice", alice)
   println("")
   println("3. Alice moves cursor to position 6 and inserts 'CRDT '")
   alice.move_cursor(6)
-  try! alice.insert("CRDT ")
+  alice.insert("CRDT ")
   show_editor("Alice", alice)
   println("")
   println("4. View operation log:")
@@ -59,7 +55,7 @@ pub fn run_convergence_demo() -> Unit {
   println("")
   println("5. Alice moves cursor to position 0 and inserts 'Hey! '")
   alice.move_cursor(0)
-  try! alice.insert("Hey! ")
+  alice.insert("Hey! ")
   show_editor("Alice", alice)
   println("")
   println("6. Final operation log:")

--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -4,10 +4,14 @@
 /// Runs demos of the CRDT editor
 fn main {
   // First run the convergence demo
-  run_convergence_demo()
+  run_convergence_demo() catch {
+    error => println("Convergence demo failed: \{error.to_string()}")
+  }
   println("")
   println("")
 
   // Then run the interactive REPL demo
-  run_repl("alice")
+  run_repl("alice") catch {
+    error => println("REPL failed: \{error.message()}")
+  }
 }

--- a/cmd/main/repl.mbt
+++ b/cmd/main/repl.mbt
@@ -12,7 +12,7 @@ struct ReplState {
 
 ///|
 /// Create a new REPL state
-fn ReplState::new(agent_id : String) -> ReplState {
+fn ReplState::new(agent_id : String) -> ReplState raise @text.TextError {
   { editor: @editor.Editor::new(agent_id) }
 }
 
@@ -128,7 +128,12 @@ fn execute_command(state : ReplState, line : String) -> Bool {
       for i = 2; i < parts.length(); i = i + 1 {
         text = text + " " + parts[i]
       }
-      try! state.editor.insert(text)
+      state.editor.insert(text) catch {
+        error => {
+          println("Insert failed: \{error.to_string()}")
+          return true
+        }
+      }
       println("Inserted: \"\{text}\"")
     }
     return true
@@ -185,7 +190,9 @@ fn execute_command(state : ReplState, line : String) -> Bool {
     return true
   }
   if command == "ops" || command == "o" {
-    show_sync_info(state.editor)
+    show_sync_info(state.editor) catch {
+      error => println("Operation log export failed: \{error.to_string()}")
+    }
     return true
   }
   println("Unknown command: '\{command}'")
@@ -195,7 +202,7 @@ fn execute_command(state : ReplState, line : String) -> Bool {
 
 ///|
 /// Run the REPL - simple demo mode (non-interactive for now)
-pub fn run_repl(agent_id : String) -> Unit {
+pub fn run_repl(agent_id : String) -> Unit raise @text.TextError {
   println("Eg-walker CRDT Editor v0.1.0")
   println("Agent: \{agent_id}")
   println("")

--- a/codex/lowering_test.mbt
+++ b/codex/lowering_test.mbt
@@ -14,7 +14,7 @@
 /// a single-line `update` diff. Only a grapheme-correct converter both is
 /// accepted by EXACT and reproduces the intended document.
 test "codex lowering: update diff deletes first of two adjacent emoji" {
-  let se = @probe.new_test_editor("codex-agent")
+  let se = try! @probe.new_test_editor("codex-agent")
   se.apply_text_edit(0, 0, "🧑🧒", 0)
   assert_eq(se.get_text(), "🧑🧒")
   let diff =
@@ -38,7 +38,7 @@ test "codex lowering: update diff deletes first of two adjacent emoji" {
 /// `----`; the old "skip any `---` prefix" parser dropped it. With hunk-state
 /// gating the marker is stripped to content `---`, replaced by `***`.
 test "codex lowering: content line starting with dashes is not a file header" {
-  let se = @probe.new_test_editor("codex-agent")
+  let se = try! @probe.new_test_editor("codex-agent")
   se.apply_text_edit(0, 0, "---", 0)
   let diff =
     #|@@ -1 +1 @@
@@ -59,7 +59,7 @@ test "codex lowering: content line starting with dashes is not a file header" {
 /// document unchanged — proving the guard is load-bearing independent of the
 /// converter. Offset 1 is the low surrogate of the first emoji.
 test "codex lowering: EXACT rejects a hand-fed mid-grapheme offset" {
-  let se = @probe.new_test_editor("codex-agent")
+  let se = try! @probe.new_test_editor("codex-agent")
   se.apply_text_edit(0, 0, "🧑🧒", 0)
   let accepted = se.apply_text_edit_exact(1, 2, "", 1)
   assert_false(accepted)
@@ -73,7 +73,7 @@ test "codex lowering: EXACT rejects a hand-fed mid-grapheme offset" {
 /// (line 1) would corrupt line 1 (`c\nb`); tracking the old-side line yields
 /// `a\nc`.
 test "codex lowering: leading context selects the correct old line" {
-  let se = @probe.new_test_editor("codex-agent")
+  let se = try! @probe.new_test_editor("codex-agent")
   se.apply_text_edit(0, 0, "a\nb", 0)
   let diff =
     #|@@ -1,2 +1,2 @@

--- a/editor/editor.mbt
+++ b/editor/editor.mbt
@@ -10,9 +10,10 @@ pub struct Editor {
 } derive(Debug)
 
 ///|
-/// Create a new editor for an agent
-pub fn Editor::new(agent_id : String) -> Editor {
-  { doc: try! @text.TextState::new(agent_id), cursor: 0 }
+/// Create a new editor for a non-empty agent identifier.
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
+pub fn Editor::new(agent_id : String) -> Editor raise @text.TextError {
+  { doc: @text.TextState::new(agent_id), cursor: 0 }
 }
 
 ///|

--- a/editor/editor.mbt
+++ b/editor/editor.mbt
@@ -12,7 +12,7 @@ pub struct Editor {
 ///|
 /// Create a new editor for an agent
 pub fn Editor::new(agent_id : String) -> Editor {
-  { doc: @text.TextState::new(agent_id), cursor: 0 }
+  { doc: try! @text.TextState::new(agent_id), cursor: 0 }
 }
 
 ///|
@@ -140,6 +140,9 @@ pub fn Editor::export_since(
 ///|
 /// Sync: Apply a SyncMessage from a peer
 pub fn Editor::apply_sync(self : Editor, msg : @text.SyncMessage) -> Unit raise {
-  self.doc.sync().apply(msg)
+  let report = self.doc.sync().apply(msg)
+  if report.pending_operations() > 0 {
+    raise @text.TextError::VersionNotFound
+  }
   self.adjust_cursor()
 }

--- a/editor/editor_properties_test.mbt
+++ b/editor/editor_properties_test.mbt
@@ -6,7 +6,7 @@
 ///|
 /// Property: New editor is always empty
 test "property: new editor is empty" {
-  let editor = Editor::new("test-agent")
+  let editor = try! Editor::new("test-agent")
   assert_eq(editor.get_text(), "")
   assert_eq(editor.get_cursor(), 0)
 }
@@ -16,7 +16,7 @@ test "property: new editor is empty" {
 test "property: insert updates length correctly" {
   let texts : Array[String] = @quickcheck.samples(20)
   for text in texts {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
     assert_eq(editor.get_text().length(), text.length())
   }
@@ -27,7 +27,7 @@ test "property: insert updates length correctly" {
 test "property: cursor bounds after insert" {
   let texts : Array[String] = @quickcheck.samples(20)
   for text in texts {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
     let cursor = editor.get_cursor()
     let len = editor.get_text().length()
@@ -39,7 +39,7 @@ test "property: cursor bounds after insert" {
 ///|
 /// Property: Inserting empty string doesn't change state
 test "property: inserting empty string is no-op" {
-  let editor = Editor::new("test-agent")
+  let editor = try! Editor::new("test-agent")
   let before_text = editor.get_text()
   let before_cursor = editor.get_cursor()
   try! editor.insert("")
@@ -50,7 +50,7 @@ test "property: inserting empty string is no-op" {
 ///|
 /// Property: Delete on empty editor is safe
 test "property: delete on empty editor is safe" {
-  let editor = Editor::new("test-agent")
+  let editor = try! Editor::new("test-agent")
   let result = editor.delete()
   assert_eq(result, false)
   assert_eq(editor.get_text(), "")
@@ -59,7 +59,7 @@ test "property: delete on empty editor is safe" {
 ///|
 /// Property: Backspace on empty editor is safe
 test "property: backspace on empty editor is safe" {
-  let editor = Editor::new("test-agent")
+  let editor = try! Editor::new("test-agent")
   let result = editor.backspace()
   assert_eq(result, false)
   assert_eq(editor.get_text(), "")
@@ -73,7 +73,7 @@ test "property: insert then delete all gives empty" {
     if text.is_empty() {
       continue
     }
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
 
     // Delete all characters one by one
@@ -90,7 +90,7 @@ test "property: insert then delete all gives empty" {
 test "property: text length is never negative" {
   let ops_arrays : Array[Array[Bool]] = @quickcheck.samples(10)
   for ops in ops_arrays {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     for is_insert in ops {
       if is_insert {
         try! editor.insert("x")
@@ -109,7 +109,7 @@ test "property: text length is never negative" {
 test "property: cursor move clamps to bounds" {
   let positions : Array[Int] = @quickcheck.samples(20)
   for position in positions {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert("hello")
     editor.move_cursor(position)
     let cursor = editor.get_cursor()
@@ -127,7 +127,7 @@ test "property: insert at start position" {
     if text.is_empty() {
       continue
     }
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert("world")
     let original_len = editor.get_text().length()
     editor.move_cursor(0)
@@ -143,7 +143,7 @@ test "property: insert at start position" {
 test "property: multiple inserts accumulate length" {
   let text_arrays : Array[Array[String]] = @quickcheck.samples(10)
   for texts in text_arrays {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     let mut expected_len = 0
     for text in texts {
       try! editor.insert(text)
@@ -158,7 +158,7 @@ test "property: multiple inserts accumulate length" {
 test "property: cursor advances after insert" {
   let texts : Array[String] = @quickcheck.samples(15)
   for text in texts {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     let start_pos = editor.get_cursor()
     try! editor.insert(text)
     let end_pos = editor.get_cursor()
@@ -176,7 +176,7 @@ test "property: delete reduces length by at most 1" {
     if text.is_empty() {
       continue
     }
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
     let before_len = editor.get_text().length()
     editor.move_cursor(0)
@@ -195,7 +195,7 @@ test "property: delete reduces length by at most 1" {
 test "property: backspace at start is no-op" {
   let texts : Array[String] = @quickcheck.samples(15)
   for text in texts {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     try! editor.insert(text)
     editor.move_cursor(0)
     let before_text = editor.get_text()
@@ -211,7 +211,7 @@ test "property: backspace at start is no-op" {
 test "property: sequential operations maintain invariants" {
   let ops_arrays : Array[Array[Int]] = @quickcheck.samples(10)
   for ops in ops_arrays {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     for op in ops {
       // Positive: insert, negative: delete, zero: move cursor
       if op > 0 {
@@ -237,7 +237,7 @@ test "property: sequential operations maintain invariants" {
 test "property: cursor invariant holds after operations" {
   let op_sequences : Array[Array[Bool]] = @quickcheck.samples(10)
   for ops in op_sequences {
-    let editor = Editor::new("test-agent")
+    let editor = try! Editor::new("test-agent")
     for is_insert in ops {
       if is_insert {
         try! editor.insert("x")

--- a/editor/editor_test.mbt
+++ b/editor/editor_test.mbt
@@ -1,14 +1,22 @@
 ///|
 /// Tests for Editor
 test "create new editor" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   inspect(editor.get_text(), content="")
   inspect(editor.get_cursor(), content="0")
 }
 
 ///|
+test "create editor rejects an empty agent identifier" {
+  let result : Result[Editor, @text.TextError] = Ok(Editor::new("")) catch {
+    error => Err(error)
+  }
+  inspect(result is Err(@text.TextError::EmptyReplicaId), content="true")
+}
+
+///|
 test "insert at cursor" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hello")
   inspect(editor.get_text(), content="Hello")
   inspect(editor.get_cursor(), content="5")
@@ -16,7 +24,7 @@ test "insert at cursor" {
 
 ///|
 test "multiple inserts" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hello")
   try! editor.insert(" ")
   try! editor.insert("World")
@@ -26,7 +34,7 @@ test "multiple inserts" {
 
 ///|
 test "insert at specific position" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Heo")
   editor.move_cursor(2)
   try! editor.insert("ll")
@@ -35,7 +43,7 @@ test "insert at specific position" {
 
 ///|
 test "move cursor" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hello")
   editor.move_cursor(0)
   inspect(editor.get_cursor(), content="0")
@@ -50,7 +58,7 @@ test "move cursor" {
 
 ///|
 test "delete at cursor" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hello")
   editor.move_cursor(1)
   let success = editor.delete()
@@ -60,7 +68,7 @@ test "delete at cursor" {
 
 ///|
 test "backspace" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hello")
   let success = editor.backspace()
   inspect(success, content="true")
@@ -70,7 +78,7 @@ test "backspace" {
 
 ///|
 test "backspace at start" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("H")
   editor.move_cursor(0)
   let success = editor.backspace()
@@ -80,7 +88,7 @@ test "backspace at start" {
 
 ///|
 test "delete beyond end" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hi")
   editor.move_cursor(10) // Move beyond end
   let success = editor.delete()
@@ -90,7 +98,7 @@ test "delete beyond end" {
 
 ///|
 test "cursor bounds checking" {
-  let editor = Editor::new("alice")
+  let editor = try! Editor::new("alice")
   try! editor.insert("Hello")
   editor.move_cursor(-5) // Should clamp to 0
   inspect(editor.get_cursor(), content="0")
@@ -101,8 +109,8 @@ test "cursor bounds checking" {
 ///|
 test "concurrent edits from two editors" {
   // Create two editors
-  let alice = Editor::new("alice")
-  let bob = Editor::new("bob")
+  let alice = try! Editor::new("alice")
+  let bob = try! Editor::new("bob")
 
   // Alice types "Hello"
   try! alice.insert("Hello")
@@ -135,8 +143,8 @@ test "concurrent edits from two editors" {
 ///|
 test "concurrent inserts at same position" {
   // Create two editors with initial text "AC"
-  let alice = Editor::new("alice")
-  let bob = Editor::new("bob")
+  let alice = try! Editor::new("alice")
+  let bob = try! Editor::new("bob")
 
   // Both start with "AC"
   try! alice.insert("A")

--- a/editor/error_path_wbtest.mbt
+++ b/editor/error_path_wbtest.mbt
@@ -195,11 +195,9 @@ test "ws_on_message: malformed message after valid sync preserves text" {
 test "apply_sync: empty SyncMessage is safe" {
   let editor = @probe.new_test_editor("alice")
   editor.set_text("hello")
-  let empty_msg = @text.SyncMessage::from_json_string(
-    "{\"runs\":[],\"heads\":[]}",
-  ) catch {
+  let empty_msg = @probe.new_test_editor("empty-message").export_all() catch {
     _ => {
-      fail("from_json_string failed")
+      fail("export_all failed")
       return
     }
   }
@@ -241,8 +239,7 @@ test "export_since: empty version exports all" {
   try {
     let msg = editor.export_since(fresh_version)
     // Should contain ops (alice's edits)
-    let json = msg.to_json_string()
-    inspect(json.contains("runs"), content="true")
+    inspect(msg.op_count() > 0, content="true")
   } catch {
     _ => () // VersionNotFound is acceptable
   }

--- a/editor/error_path_wbtest.mbt
+++ b/editor/error_path_wbtest.mbt
@@ -96,7 +96,7 @@ test "decode_message: roundtrip preserves all message types" {
 
 ///|
 test "ws_on_message: empty bytes does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.ws_on_message(Bytes::new(0))
   // Editor should be in default state
   inspect(editor.get_text(), content="")
@@ -104,21 +104,21 @@ test "ws_on_message: empty bytes does not panic" {
 
 ///|
 test "ws_on_message: truncated wire does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.ws_on_message(b"\x02")
   inspect(editor.get_text(), content="")
 }
 
 ///|
 test "ws_on_message: wrong protocol version ignored" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.ws_on_message(b"\xFF\x01\x00some payload")
   inspect(editor.get_text(), content="")
 }
 
 ///|
 test "ws_on_message: CrdtOps with invalid JSON does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let buf = Buffer()
   buf.write_string_utf16le("this is not valid json {{{".view())
   let wire = @wire.encode_message(CrdtOps(buf.to_bytes()))
@@ -129,7 +129,7 @@ test "ws_on_message: CrdtOps with invalid JSON does not panic" {
 
 ///|
 test "ws_on_message: CrdtOps with wrong JSON schema does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let buf = Buffer()
   buf.write_string_utf16le("{\"wrong\": \"schema\"}".view())
   let wire = @wire.encode_message(CrdtOps(buf.to_bytes()))
@@ -139,7 +139,7 @@ test "ws_on_message: CrdtOps with wrong JSON schema does not panic" {
 
 ///|
 test "ws_on_message: CrdtOps with empty JSON object does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let buf = Buffer()
   buf.write_string_utf16le("{}".view())
   let wire = @wire.encode_message(CrdtOps(buf.to_bytes()))
@@ -149,7 +149,7 @@ test "ws_on_message: CrdtOps with empty JSON object does not panic" {
 
 ///|
 test "ws_on_message: CrdtOps with empty payload does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let wire = @wire.encode_message(CrdtOps(Bytes::new(0)))
   editor.ws_on_message(wire)
   inspect(editor.get_text(), content="")
@@ -157,7 +157,7 @@ test "ws_on_message: CrdtOps with empty payload does not panic" {
 
 ///|
 test "ws_on_message: PeerLeft for unknown peer does not panic" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let wire = @wire.encode_message(PeerLeft("nonexistent_peer"))
   editor.ws_on_message(wire)
   inspect(editor.get_text(), content="")
@@ -165,8 +165,8 @@ test "ws_on_message: PeerLeft for unknown peer does not panic" {
 
 ///|
 test "ws_on_message: malformed message after valid sync preserves text" {
-  let editor_a = @probe.new_test_editor("alice")
-  let editor_b = @probe.new_test_editor("bob")
+  let editor_a = try! @probe.new_test_editor("alice")
+  let editor_b = try! @probe.new_test_editor("bob")
   // Valid sync: alice types, bob receives
   editor_a.set_text("hello")
   let crdt_msg = editor_a.export_all() catch {
@@ -193,9 +193,9 @@ test "ws_on_message: malformed message after valid sync preserves text" {
 
 ///|
 test "apply_sync: empty SyncMessage is safe" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.set_text("hello")
-  let empty_msg = @probe.new_test_editor("empty-message").export_all() catch {
+  let empty_msg = try! @probe.new_test_editor("empty-message").export_all() catch {
     _ => {
       fail("export_all failed")
       return
@@ -210,7 +210,7 @@ test "apply_sync: empty SyncMessage is safe" {
 
 ///|
 test "apply_sync: error does not corrupt editor state" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.set_text("hello world")
   let original_text = editor.get_text()
   // Try to apply a message with invalid JSON — should raise
@@ -230,11 +230,11 @@ test "apply_sync: error does not corrupt editor state" {
 
 ///|
 test "export_since: empty version exports all" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.set_text("hello")
   let empty_version = editor.get_version()
   // Create a fresh editor to get an empty version
-  let fresh = @probe.new_test_editor("bob")
+  let fresh = try! @probe.new_test_editor("bob")
   let fresh_version = fresh.get_version()
   try {
     let msg = editor.export_since(fresh_version)
@@ -252,7 +252,7 @@ test "export_since: empty version exports all" {
 
 ///|
 test "ws_broadcast_edit: no-op when disconnected" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.set_text("hello")
   // Should not panic when ws is None
   editor.ws_broadcast_edit()
@@ -261,7 +261,7 @@ test "ws_broadcast_edit: no-op when disconnected" {
 
 ///|
 test "ws_broadcast_cursor: no-op when disconnected" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   editor.hub.set_cursor(5)
   // Should not panic when ws is None
   editor.ws_broadcast_cursor()

--- a/editor/error_recovery_test.mbt
+++ b/editor/error_recovery_test.mbt
@@ -6,7 +6,7 @@
 
 ///|
 test "SyncEditor: error recovery - invalid to valid syntax" {
-  let editor = @probe.new_test_editor("agent1")
+  let editor = try! @probe.new_test_editor("agent1")
 
   // Start with valid syntax
   try! editor.insert("foo")
@@ -26,7 +26,7 @@ test "SyncEditor: error recovery - invalid to valid syntax" {
 
 ///|
 test "SyncEditor: error recovery - multiple edits" {
-  let editor = @probe.new_test_editor("agent2")
+  let editor = try! @probe.new_test_editor("agent2")
 
   // Valid nested expression
   try! editor.insert("a(b)")
@@ -46,7 +46,7 @@ test "SyncEditor: error recovery - multiple edits" {
 
 ///|
 test "SyncEditor: incremental parser is used" {
-  let editor = @probe.new_test_editor("agent3")
+  let editor = try! @probe.new_test_editor("agent3")
 
   // Insert some text
   try! editor.insert("f(x g(y))")

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -61,7 +61,7 @@ pub fn[T] SyncEditor::new_generic(
   let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
   {
-    doc: @text.TextState::new(agent_id),
+    doc: try! @text.TextState::new(agent_id),
     undo: @undo.UndoManager::new(agent_id, capture_timeout_ms~),
     parser,
     cursor: 0,
@@ -444,22 +444,27 @@ pub fn[T : Eq] SyncEditor::apply_sync(
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.undo.set_tracking(false)
-  self.doc.sync().apply(msg) catch {
-    e => {
-      self.undo.set_tracking(true)
-      // Reconcile derived state in case apply partially mutated the doc
-      let new_source = self.doc.text()
-      self.adjust_cursor()
-      self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
-      self.sync_parser_after_text_change(old_source, new_source, None)
-      raise e
-    }
+  let report_result : Result[@text.SyncReport, @text.TextError] = Ok(
+    self.doc.sync().apply(msg),
+  ) catch {
+    error => Err(error)
   }
   self.undo.set_tracking(true)
+  // Reconcile derived state even when apply reports an error, because the
+  // document may have been partially mutated before the failure surfaced.
   let new_source = self.doc.text()
   self.adjust_cursor()
   self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
   self.sync_parser_after_text_change(old_source, new_source, None)
+  // Keep the legacy Unit-raising SyncHost seam while EGW remains the sole
+  // owner of causally pending operations.
+  let report = match report_result {
+    Ok(report) => report
+    Err(error) => raise error
+  }
+  if report.pending_operations() > 0 {
+    raise @text.TextError::VersionNotFound
+  }
   // Clear a prior Error status once any sync applies — another peer
   // (via RelayedCrdtOps) having filled the causal gap counts as recovery.
   self.session.note_sync_applied()

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -33,6 +33,7 @@ pub struct SyncEditor[T] {
 
 ///|
 /// Generic constructor for all languages.
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
 /// `make_parser` builds a `@loom.Parser[T]` from an initial source string.
 /// `build_memos` receives the parser handle and returns the 3 projection memos
 /// (ProjNode, registry, SourceMap) it wants SyncEditor to own.
@@ -52,7 +53,8 @@ pub fn[T] SyncEditor::new_generic(
   // build_memos so the reconcile_node closure can consume+clear it. Callers
   // that don't use hints omit this; they get an isolated Ref that is never read.
   identity_hints? : Ref[Array[@core.IdentityTransform]],
-) -> SyncEditor[T] {
+) -> SyncEditor[T] raise @text.TextError {
+  let doc = @text.TextState::new(agent_id)
   let pending_transforms = match identity_hints {
     Some(r) => r
     None => Ref([])
@@ -61,7 +63,7 @@ pub fn[T] SyncEditor::new_generic(
   let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
   {
-    doc: try! @text.TextState::new(agent_id),
+    doc,
     undo: @undo.UndoManager::new(agent_id, capture_timeout_ms~),
     parser,
     cursor: 0,

--- a/editor/sync_editor_accessors_test.mbt
+++ b/editor/sync_editor_accessors_test.mbt
@@ -10,7 +10,7 @@ test "SyncEditor exposes typed accessors for protected cells" {
   // The `let typed : T = ...` lines pin the return types; the
   // `.read_or_abort()` calls exercise the cells so a regression that
   // makes any of them abort at construction time would fail the test.
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   let source_cell : @incr.Derived[String] = editor.parser_source()
   let _ = source_cell.read_or_abort()
   let ast_cell : @incr.Derived[@probe.TestExpr] = editor.parser_ast()

--- a/editor/sync_editor_hints_wbtest.mbt
+++ b/editor/sync_editor_hints_wbtest.mbt
@@ -6,13 +6,13 @@
 
 ///|
 test "pending_transforms starts empty" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   inspect(editor.pending_transforms.val.is_empty(), content="true")
 }
 
 ///|
 test "apply_span_edits with Wrap hint pushes hint" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let inner_id = @core.NodeId::from_int(42)
   let edits : Array[@core.SpanEdit] = [
@@ -37,7 +37,7 @@ test "apply_span_edits with Wrap hint pushes hint" {
 
 ///|
 test "apply_span_edits without hint leaves pending_transforms unchanged" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let edits : Array[@core.SpanEdit] = [
     { start: 0, delete_len: 0, inserted: "x" },
@@ -48,7 +48,7 @@ test "apply_span_edits without hint leaves pending_transforms unchanged" {
 
 ///|
 test "apply_span_edits with empty edits does not push hint (T4)" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   let fake_id = @core.NodeId::from_int(7)
   let edits : Array[@core.SpanEdit] = []
   editor.apply_span_edits(
@@ -66,7 +66,7 @@ test "apply_span_edits with net-no-op edits does not push hint (T4)" {
   // change, so sync_parser_after_text_change returns early without triggering
   // a reparse. The hint must not be queued — otherwise it becomes stale and
   // corrupts the next structural op's hint map.
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("x")
   let replace_id = @core.NodeId::from_int(5)
   let edits : Array[@core.SpanEdit] = [
@@ -83,7 +83,7 @@ test "apply_span_edits with net-no-op edits does not push hint (T4)" {
 
 ///|
 test "T2: set_text taints if pending_transforms non-empty" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   let fake_id = @core.NodeId::from_int(1)
   editor.pending_transforms.val.push(
     @core.IdentityTransform::Wrap(inner=fake_id),
@@ -98,14 +98,14 @@ test "T2: set_text taints if pending_transforms non-empty" {
 
 ///|
 test "T2: set_text does NOT taint when pending_transforms empty" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("hello")
   inspect(editor.pending_transforms.val.is_empty(), content="true")
 }
 
 ///|
 test "T2: insert taints if pending_transforms non-empty" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   let fake_id = @core.NodeId::from_int(2)
   editor.pending_transforms.val.push(
     @core.IdentityTransform::Wrap(inner=fake_id),
@@ -122,7 +122,7 @@ test "T2: insert taints if pending_transforms non-empty" {
 
 ///|
 test "multiple structural hints accumulate in order" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("ab")
   let id1 = @core.NodeId::from_int(10)
   let id2 = @core.NodeId::from_int(20)
@@ -159,7 +159,7 @@ test "multiple structural hints accumulate in order" {
 
 ///|
 test "move_node taints pending_transforms (Finding 3: Move is not identity-preserving)" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x) y")
   let _ = editor.get_proj_node() // force first parse
   let fake_id = @core.NodeId::from_int(5)

--- a/editor/sync_editor_history_test.mbt
+++ b/editor/sync_editor_history_test.mbt
@@ -2,7 +2,7 @@
 
 ///|
 test "fresh SyncEditor produces empty causal snapshot" {
-  let se = @probe.new_test_editor("alice")
+  let se = try! @probe.new_test_editor("alice")
   let snap = se.causal_snapshot()
   inspect(snap.op_count(), content="0")
   @debug.debug_inspect(snap.frontier(), content="[]")
@@ -10,8 +10,8 @@ test "fresh SyncEditor produces empty causal snapshot" {
 
 ///|
 test "two SyncEditors have distinct construction identities" {
-  let a = @probe.new_test_editor("alice")
-  let b = @probe.new_test_editor("bob")
+  let a = try! @probe.new_test_editor("alice")
+  let b = try! @probe.new_test_editor("bob")
   // Same instance always returns the same identity.
   inspect(a.identity() == a.identity(), content="true")
   // Distinct instances have distinct identities.

--- a/editor/sync_editor_parser_test.mbt
+++ b/editor/sync_editor_parser_test.mbt
@@ -6,7 +6,7 @@
 
 ///|
 test "parser: initial parse produces AST" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("foo")
   inspect(
     @probe.get_test_ast(se),
@@ -18,7 +18,7 @@ test "parser: initial parse produces AST" {
 
 ///|
 test "parser: edit updates AST" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("foo")
   inspect(
     @probe.get_test_ast(se),
@@ -37,7 +37,7 @@ test "parser: edit updates AST" {
 
 ///|
 test "parser: empty source clears AST" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("foo")
   inspect(
     @probe.get_test_ast(se),
@@ -56,7 +56,7 @@ test "parser: empty source clears AST" {
 
 ///|
 test "parser: parse errors reported" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("foo(") // unclosed '('
   let errors = se.get_errors()
   inspect(errors.is_empty(), content="false")
@@ -64,7 +64,7 @@ test "parser: parse errors reported" {
 
 ///|
 test "parser: valid source has no errors" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("f(x)")
   inspect(se.is_parse_valid(), content="true")
   inspect(se.get_errors().is_empty(), content="true")
@@ -72,7 +72,7 @@ test "parser: valid source has no errors" {
 
 ///|
 test "parser: mark_dirty forces reparse" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("foo")
   let ast1 = @probe.get_test_ast(se)
   inspect(
@@ -88,14 +88,14 @@ test "parser: mark_dirty forces reparse" {
 
 ///|
 test "parser: empty source has no errors" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("")
   inspect(se.get_errors().is_empty(), content="true")
 }
 
 ///|
 test "parser: successive edits maintain consistency" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("a")
   inspect(
     @probe.get_test_ast(se),
@@ -121,8 +121,8 @@ test "parser: successive edits maintain consistency" {
 
 ///|
 test "sync: export and apply roundtrip" {
-  let a = @probe.new_test_editor("agent-a")
-  let b = @probe.new_test_editor("agent-b")
+  let a = try! @probe.new_test_editor("agent-a")
+  let b = try! @probe.new_test_editor("agent-b")
   try! a.insert("h")
   try! a.insert("e")
   try! a.insert("l")
@@ -135,8 +135,8 @@ test "sync: export and apply roundtrip" {
 
 ///|
 test "sync: export_since for incremental sync" {
-  let a = @probe.new_test_editor("agent-a")
-  let b = @probe.new_test_editor("agent-b")
+  let a = try! @probe.new_test_editor("agent-a")
+  let b = try! @probe.new_test_editor("agent-b")
   // Initial content
   try! a.insert("x")
   try! b.apply_sync(try! a.export_all())
@@ -155,8 +155,8 @@ test "sync: export_since for incremental sync" {
 
 ///|
 test "sync: bidirectional sync converges" {
-  let a = @probe.new_test_editor("agent-a")
-  let b = @probe.new_test_editor("agent-b")
+  let a = try! @probe.new_test_editor("agent-a")
+  let b = try! @probe.new_test_editor("agent-b")
   try! a.insert("a")
   try! b.insert("b")
   // Sync both ways
@@ -168,8 +168,8 @@ test "sync: bidirectional sync converges" {
 
 ///|
 test "sync: AST consistent after sync" {
-  let a = @probe.new_test_editor("agent-a")
-  let b = @probe.new_test_editor("agent-b")
+  let a = try! @probe.new_test_editor("agent-a")
+  let b = try! @probe.new_test_editor("agent-b")
   a.set_text("f(x)")
   try! b.apply_sync(try! a.export_all())
   // Both editors should parse to the same AST
@@ -178,14 +178,14 @@ test "sync: AST consistent after sync" {
 
 ///|
 test "sync: empty export_all for empty editor" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   let msg = try! se.export_all()
   inspect(msg.op_count() == 0, content="true")
 }
 
 ///|
 test "sync: version advances after insert" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   let v1 = se.get_version()
   try! se.insert("x")
   let v2 = se.get_version()

--- a/editor/sync_editor_runtime_threading_test.mbt
+++ b/editor/sync_editor_runtime_threading_test.mbt
@@ -9,7 +9,7 @@
 // runtime_id; cells from different runtimes have distinct runtime_id values.
 test "SyncEditor::new_generic threads parent_runtime through to Parser" {
   let shared = @incr.Runtime()
-  let editor = @probe.new_test_editor("test", parent_runtime=shared)
+  let editor = try! @probe.new_test_editor("test", parent_runtime=shared)
   let parser_rt = editor.parser_runtime()
   // Allocate an Input on each runtime to read their CellId.runtime_id.
   let sig_shared = @incr.Input(shared, 0, label="probe_shared")
@@ -20,8 +20,8 @@ test "SyncEditor::new_generic threads parent_runtime through to Parser" {
 ///|
 // Regression guard: without parent_runtime, each editor gets its own runtime.
 test "SyncEditor::new_generic without parent_runtime allocates private runtime" {
-  let editor_a = @probe.new_test_editor("a")
-  let editor_b = @probe.new_test_editor("b")
+  let editor_a = try! @probe.new_test_editor("a")
+  let editor_b = try! @probe.new_test_editor("b")
   let rt_a = editor_a.parser_runtime()
   let rt_b = editor_b.parser_runtime()
   let sig_a = @incr.Input(rt_a, 0, label="probe_a")

--- a/editor/sync_editor_test.mbt
+++ b/editor/sync_editor_test.mbt
@@ -19,7 +19,7 @@ fn insert_each_and_record(
 
 ///|
 test "SyncEditor: create and insert text" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert("x")
   inspect(se.get_text(), content="x")
   inspect(
@@ -32,7 +32,7 @@ test "SyncEditor: create and insert text" {
 
 ///|
 test "SyncEditor: sequential inserts update AST" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert("f")
   inspect(
     @probe.get_test_ast(se),
@@ -51,7 +51,7 @@ test "SyncEditor: sequential inserts update AST" {
 
 ///|
 test "SyncEditor: delete updates AST" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each(se, "123")
   inspect(se.get_text(), content="123")
   let deleted = se.backspace()
@@ -61,7 +61,7 @@ test "SyncEditor: delete updates AST" {
 
 ///|
 test "SyncEditor: parse error handling" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each(se, "f(") // unclosed '('
   let _ast = @probe.get_test_ast(se)
   inspect(se.is_parse_valid(), content="false")
@@ -69,7 +69,7 @@ test "SyncEditor: parse error handling" {
 
 ///|
 test "SyncEditor: cursor tracking" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   inspect(se.get_cursor(), content="0")
   try! insert_each(se, "abc")
   inspect(se.get_cursor(), content="3")
@@ -79,8 +79,8 @@ test "SyncEditor: cursor tracking" {
 
 ///|
 test "SyncEditor: concurrent edits converge" {
-  let se1 = @probe.new_test_editor("agent1")
-  let se2 = @probe.new_test_editor("agent2")
+  let se1 = try! @probe.new_test_editor("agent1")
+  let se2 = try! @probe.new_test_editor("agent2")
   try! se1.insert("x")
   try! se2.apply_sync(try! se1.export_all())
   inspect(se1.get_text(), content="x")
@@ -97,8 +97,8 @@ test "SyncEditor: concurrent edits converge" {
 
 ///|
 test "SyncEditor: collaborative editing converges" {
-  let se1 = @probe.new_test_editor("agent1")
-  let se2 = @probe.new_test_editor("agent2")
+  let se1 = try! @probe.new_test_editor("agent1")
+  let se2 = try! @probe.new_test_editor("agent2")
   try! insert_each(se1, "f(")
   try! se2.apply_sync(try! se1.export_all())
   inspect(se1.get_text(), content="f(")
@@ -113,7 +113,7 @@ test "SyncEditor: collaborative editing converges" {
 
 ///|
 test "SyncEditor: incremental parsing vs full reparse" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each(se, "foo(bar)")
   let _ast1 = @probe.get_test_ast(se)
   se.move_cursor(7) // just after 'r'
@@ -129,14 +129,14 @@ test "SyncEditor: incremental parsing vs full reparse" {
 
 ///|
 test "SyncEditor: empty document" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   inspect(se.get_text(), content="")
   let _ast = @probe.get_test_ast(se)
 }
 
 ///|
 test "SyncEditor: backspace at start returns false" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each(se, "abc")
   se.move_cursor(0)
   inspect(se.backspace(), content="false")
@@ -145,7 +145,7 @@ test "SyncEditor: backspace at start returns false" {
 
 ///|
 test "SyncEditor: delete at end returns false" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each(se, "abc")
   se.move_cursor(3)
   inspect(se.delete(), content="false")
@@ -154,7 +154,7 @@ test "SyncEditor: delete at end returns false" {
 
 ///|
 test "SyncEditor: export_all produces non-empty message" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert("x")
   let msg = try! se.export_all()
   inspect(msg.op_count() > 0, content="true")
@@ -162,7 +162,7 @@ test "SyncEditor: export_all produces non-empty message" {
 
 ///|
 test "SyncEditor: lazy AST evaluation" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert("x")
   let _ast1 = @probe.get_test_ast(se)
   inspect(
@@ -175,8 +175,8 @@ test "SyncEditor: lazy AST evaluation" {
 
 ///|
 test "SyncEditor: merge invalidates AST cache" {
-  let se1 = @probe.new_test_editor("agent1")
-  let se2 = @probe.new_test_editor("agent2")
+  let se1 = try! @probe.new_test_editor("agent1")
+  let se2 = try! @probe.new_test_editor("agent2")
   try! se1.insert("x")
   try! se2.apply_sync(try! se1.export_all())
   let _ast1 = @probe.get_test_ast(se1)
@@ -193,7 +193,7 @@ test "SyncEditor: merge invalidates AST cache" {
 
 ///|
 test "SyncEditor: insert_and_record + undo roundtrip" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each_and_record(se, "hello", 1000)
   inspect(se.get_text(), content="hello")
   inspect(se.can_undo(), content="true")
@@ -213,7 +213,7 @@ test "SyncEditor: insert_and_record + undo roundtrip" {
 
 ///|
 test "SyncEditor: backspace_and_record + undo" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each_and_record(se, "abc", 1000)
   let deleted = se.backspace_and_record(2000)
   inspect(deleted, content="true")
@@ -228,7 +228,7 @@ test "SyncEditor: backspace_and_record + undo" {
 
 ///|
 test "SyncEditor: apply_text_edit replaces middle range and updates cursor" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("abc")
   se.move_cursor(0)
   se.apply_text_edit(1, 1, "XYZ", 1000)
@@ -238,7 +238,7 @@ test "SyncEditor: apply_text_edit replaces middle range and updates cursor" {
 
 ///|
 test "SyncEditor: apply_text_edit records undo" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each_and_record(se, "abc", 1000)
   se.apply_text_edit(1, 1, "XYZ", 2000)
   inspect(se.get_text(), content="aXYZc")
@@ -249,7 +249,7 @@ test "SyncEditor: apply_text_edit records undo" {
 
 ///|
 test "SyncEditor: apply_text_edit records multi-character range undo" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! insert_each_and_record(se, "abcdef", 1000)
   se.apply_text_edit(1, 3, "XYZ", 2000)
   inspect(se.get_text(), content="aXYZef")
@@ -260,7 +260,7 @@ test "SyncEditor: apply_text_edit records multi-character range undo" {
 
 ///|
 test "SyncEditor: apply_text_edit reuses parser structure on local edit" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_text("foo(bar)")
   ignore(@probe.get_test_ast(se))
   se.apply_text_edit(6, 1, "z", 1000) // replace 'r' with 'z'
@@ -275,7 +275,7 @@ test "SyncEditor: apply_text_edit reuses parser structure on local edit" {
 
 ///|
 test "SyncEditor: clear_undo empties stacks" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("x", 1000)
   inspect(se.can_undo(), content="true")
   se.clear_undo()
@@ -288,8 +288,8 @@ test "SyncEditor: clear_undo empties stacks" {
 
 ///|
 test "SyncEditor: non-numeric agent IDs encode and delete presence" {
-  let alice = @probe.new_test_editor("web-user")
-  let bob = @probe.new_test_editor("local-user")
+  let alice = try! @probe.new_test_editor("web-user")
+  let bob = try! @probe.new_test_editor("local-user")
   alice.set_text("abcd")
   alice.move_cursor(2)
   alice.set_local_presence("Alice", "#ff0000")
@@ -307,8 +307,8 @@ test "SyncEditor: non-numeric agent IDs encode and delete presence" {
 
 ///|
 test "SyncEditor: local edits and undo keep peer cursors in sync" {
-  let local_editor = @probe.new_test_editor("local-user")
-  let remote = @probe.new_test_editor("remote-user")
+  let local_editor = try! @probe.new_test_editor("local-user")
+  let remote = try! @probe.new_test_editor("remote-user")
   local_editor.set_text("abcd")
   try! remote.apply_sync(try! local_editor.export_all())
   remote.move_cursor(3)
@@ -344,8 +344,8 @@ test "SyncEditor: local edits and undo keep peer cursors in sync" {
 
 ///|
 test "SyncEditor: remote sync tracks actual merged text positions" {
-  let viewer = @probe.new_test_editor("viewer")
-  let remote = @probe.new_test_editor("peer-b")
+  let viewer = try! @probe.new_test_editor("viewer")
+  let remote = try! @probe.new_test_editor("peer-b")
   viewer.set_text("abcd")
   try! remote.apply_sync(try! viewer.export_all())
   remote.move_cursor(1)
@@ -373,8 +373,8 @@ test "SyncEditor: remote sync tracks actual merged text positions" {
 
 ///|
 test "SyncEditor: apply_sync does not pollute undo stack" {
-  let se1 = @probe.new_test_editor("alice", capture_timeout_ms=500)
-  let se2 = @probe.new_test_editor("bob", capture_timeout_ms=500)
+  let se1 = try! @probe.new_test_editor("alice", capture_timeout_ms=500)
+  let se2 = try! @probe.new_test_editor("bob", capture_timeout_ms=500)
 
   // Alice types
   try! se1.insert_and_record("hello", 1000)
@@ -388,7 +388,7 @@ test "SyncEditor: apply_sync does not pollute undo stack" {
 
 ///|
 test "SyncEditor: undo returns sync message for peer broadcast" {
-  let se = @probe.new_test_editor("alice", capture_timeout_ms=500)
+  let se = try! @probe.new_test_editor("alice", capture_timeout_ms=500)
 
   // Type some text
   try! se.insert_and_record("hello", 1000)
@@ -406,8 +406,8 @@ test "SyncEditor: undo returns sync message for peer broadcast" {
 
 ///|
 test "SyncEditor: undo sync ops can be applied to peer" {
-  let se1 = @probe.new_test_editor("alice", capture_timeout_ms=500)
-  let se2 = @probe.new_test_editor("bob", capture_timeout_ms=500)
+  let se1 = try! @probe.new_test_editor("alice", capture_timeout_ms=500)
+  let se2 = try! @probe.new_test_editor("bob", capture_timeout_ms=500)
 
   // Alice types
   try! se1.insert_and_record("hello", 1000)

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -189,7 +189,9 @@ fn[T] SyncEditor::apply_replace_span(
 ) -> Bool {
   let item_start = utf16_offset_to_item_pos(old_source, start)
   let item_end = utf16_offset_to_item_pos(old_source, start + deleted_len)
-  let range = @text.Range::from_ints(item_start, item_end)
+  let range = @text.Range::from_ints(item_start, item_end) catch {
+    _ => return false
+  }
   if record_undo {
     self.doc.replace_range_and_record(range, inserted, self.undo, timestamp_ms~) catch {
       _ => return false

--- a/editor/sync_editor_text_wbtest.mbt
+++ b/editor/sync_editor_text_wbtest.mbt
@@ -2,7 +2,7 @@
 
 ///|
 test "insert_at inserts at specified position without moving cursor" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("hello")
   editor.move_cursor(0) // cursor at start
   editor.insert_at(5, "!", 0) // insert at end
@@ -12,7 +12,7 @@ test "insert_at inserts at specified position without moving cursor" {
 
 ///|
 test "delete_at deletes at specified position without moving cursor" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("hello!")
   editor.move_cursor(0)
   let deleted = editor.delete_at(5, 0) // delete '!' at position 5
@@ -23,7 +23,7 @@ test "delete_at deletes at specified position without moving cursor" {
 
 ///|
 test "insert_at in middle does not move cursor" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("abcd")
   editor.move_cursor(2) // cursor in middle
   editor.insert_at(2, "X", 0) // insert at cursor position
@@ -34,7 +34,7 @@ test "insert_at in middle does not move cursor" {
 
 ///|
 test "delete_at before cursor clamps cursor to text length" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   // Use per-character inserts to avoid FugueMax batch-insert caveat
   editor.insert("a") catch {
     _ => ()
@@ -61,7 +61,7 @@ test "delete_at before cursor clamps cursor to text length" {
 
 ///|
 test "insert_at records undo" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("abc")
   editor.move_cursor(0)
   editor.insert_at(3, "d", 1000)
@@ -73,7 +73,7 @@ test "insert_at records undo" {
 
 ///|
 test "delete_at records undo" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("abcd")
   editor.move_cursor(0)
   let deleted = editor.delete_at(3, 1000) // delete 'd' at position 3
@@ -86,7 +86,7 @@ test "delete_at records undo" {
 
 ///|
 test "delete_at at end of text returns false" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("abc")
   editor.move_cursor(0)
   let result = editor.delete_at(3, 0) // position == length, nothing to delete
@@ -96,7 +96,7 @@ test "delete_at at end of text returns false" {
 
 ///|
 test "insert_at with multi-char text" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("ac")
   editor.move_cursor(0)
   editor.insert_at(1, "b", 0)
@@ -119,7 +119,7 @@ test "insert_at with multi-char text" {
 ///|
 /// BMP single-code-unit char (Japanese Hiragana). Sanity baseline.
 test "insert: BMP single-code-unit char advances cursor by 1 (baseline)" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("あ") catch {
     _ => ()
   }
@@ -131,7 +131,7 @@ test "insert: BMP single-code-unit char advances cursor by 1 (baseline)" {
 /// #216: backspace after a combining acute accent (NFD form of "é")
 /// removes the whole grapheme cluster.
 test "#216: backspace removes combining grapheme" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("e") catch {
     _ => ()
   }
@@ -145,7 +145,7 @@ test "#216: backspace removes combining grapheme" {
 
 ///|
 test "insert combining mark leaves cursor on grapheme boundary" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("e") catch {
     _ => ()
   }
@@ -158,7 +158,7 @@ test "insert combining mark leaves cursor on grapheme boundary" {
 
 ///|
 test "move_cursor snaps interior grapheme offset backward" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("e") catch {
     _ => ()
   }
@@ -171,7 +171,7 @@ test "move_cursor snaps interior grapheme offset backward" {
 
 ///|
 test "move_cursor_left_grapheme skips combining mark" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("e") catch {
     _ => ()
   }
@@ -184,7 +184,7 @@ test "move_cursor_left_grapheme skips combining mark" {
 
 ///|
 test "move_cursor_right_grapheme skips combining mark" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("e") catch {
     _ => ()
   }
@@ -201,7 +201,7 @@ test "move_cursor_right_grapheme skips combining mark" {
 
 ///|
 test "apply_text_edit pure insert snaps mid-cluster to previous boundary" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.insert("e") catch {
     _ => ()
   }
@@ -215,7 +215,7 @@ test "apply_text_edit pure insert snaps mid-cluster to previous boundary" {
 
 ///|
 test "apply_text_edit_exact rejects mid-cluster start" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("e\u{0301}")
   editor.move_cursor(0)
   let accepted = editor.apply_text_edit_exact(1, 0, "X", 0)
@@ -226,7 +226,7 @@ test "apply_text_edit_exact rejects mid-cluster start" {
 
 ///|
 test "apply_text_edit_exact accepts on-boundary splice" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("e\u{0301}")
   let accepted = editor.apply_text_edit_exact(2, 0, "X", 0)
   inspect(accepted, content="true")
@@ -239,7 +239,7 @@ test "apply_text_edit_exact accepts on-boundary splice" {
 
 ///|
 test "insert_at preserves cursor when BMP splice fuses cluster" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("a")
   editor.move_cursor(0)
   editor.insert_at(1, "\u{0301}", 0)
@@ -249,7 +249,7 @@ test "insert_at preserves cursor when BMP splice fuses cluster" {
 
 ///|
 test "RI re-pairing snaps cursor to next grapheme boundary" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("🇯🇵🇺🇸")
   editor.apply_text_edit(4, 0, "🇮", 0)
   inspect(editor.get_text(), content="🇯🇵🇮🇺🇸")
@@ -258,7 +258,7 @@ test "RI re-pairing snaps cursor to next grapheme boundary" {
 
 ///|
 test "ZWJ profession join snaps preserved cursor to grapheme boundary" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("👩💻")
   editor.move_cursor(2)
   editor.insert_at(2, "\u{200D}", 0)
@@ -270,7 +270,7 @@ test "ZWJ profession join snaps preserved cursor to grapheme boundary" {
 /// #216: insert of a surrogate-pair emoji stores the full non-BMP codepoint
 /// and leaves the cursor after the grapheme.
 test "#216: insert non-BMP emoji stores full emoji" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   try! editor.insert("😀")
   inspect(editor.get_text(), content="😀")
   inspect(editor.get_cursor(), content="2")
@@ -280,7 +280,7 @@ test "#216: insert non-BMP emoji stores full emoji" {
 /// #216: ZWJ-family components are non-BMP; inserting one must not produce a
 /// mid-surrogate parser recovery token.
 test "#216: insert ZWJ family member stores full emoji" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   try! editor.insert("👨")
   inspect(editor.get_text(), content="👨")
   inspect(editor.get_cursor(), content="2")
@@ -290,7 +290,7 @@ test "#216: insert ZWJ family member stores full emoji" {
 /// #216: regional indicators are non-BMP and must stay atomic through parser
 /// recovery.
 test "#216: insert regional indicator stores flag half" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   try! editor.insert("🇯")
   inspect(editor.get_text(), content="🇯")
   inspect(editor.get_cursor(), content="2")
@@ -300,7 +300,7 @@ test "#216: insert regional indicator stores flag half" {
 /// #216: `set_text` of a string containing a surrogate pair routes through
 /// the same bulk text mutation path used by external bridge updates.
 test "#216: set_text with non-BMP content stores full emoji" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("😀")
   inspect(editor.get_text(), content="😀")
   inspect(editor.get_cursor(), content="2")
@@ -310,7 +310,7 @@ test "#216: set_text with non-BMP content stores full emoji" {
 /// Word navigation applies the policy layer (word_nav.mbt), not raw UAX
 /// boundaries: whitespace is skipped, right lands at word end.
 test "word navigation: policy semantics through SyncEditor" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("foo bar")
   editor.move_cursor(0)
   editor.move_cursor_right_word()
@@ -329,7 +329,7 @@ test "word navigation: policy semantics through SyncEditor" {
 /// Word navigation post-snaps to grapheme boundaries even where a raw UAX
 /// word boundary falls inside a cluster (U+0600 is Prepend/Numeric).
 test "word navigation: landing snapped to grapheme boundary" {
-  let editor = @probe.new_test_editor("test-agent")
+  let editor = try! @probe.new_test_editor("test-agent")
   editor.set_text("\u{600}!")
   editor.move_cursor(0)
   editor.move_cursor_right_word()

--- a/editor/sync_editor_tree_edit_wbtest.mbt
+++ b/editor/sync_editor_tree_edit_wbtest.mbt
@@ -9,7 +9,7 @@
 
 ///|
 test "delete_node replaces span with placeholder" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x)")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -21,7 +21,7 @@ test "delete_node replaces span with placeholder" {
 
 ///|
 test "commit_edit replaces span with new text" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -34,7 +34,7 @@ test "commit_edit replaces span with new text" {
 
 ///|
 test "apply_text_transform wraps node" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -51,7 +51,7 @@ test "apply_text_transform wraps node" {
 
 ///|
 test "delete_node returns error for unknown node_id" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let _ = editor.get_proj_node()
   let bad_id = @core.NodeId::from_int(99999)
@@ -61,7 +61,7 @@ test "delete_node returns error for unknown node_id" {
 
 ///|
 test "commit_edit returns error for unknown node_id" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let _ = editor.get_proj_node()
   let bad_id = @core.NodeId::from_int(99999)
@@ -71,14 +71,14 @@ test "commit_edit returns error for unknown node_id" {
 
 ///|
 test "is_dirty set after set_text" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   inspect(editor.is_dirty(), content="true")
 }
 
 ///|
 test "is_dirty set after insert/backspace" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   // Consume initial dirty from construction
   editor.refresh()
   inspect(editor.is_dirty(), content="false")
@@ -97,7 +97,7 @@ test "is_dirty set after insert/backspace" {
 
 ///|
 test "refresh clears dirty flag and further edits are accepted" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   inspect(editor.is_dirty(), content="true")
   editor.refresh()
@@ -119,7 +119,7 @@ test "move_node moves source before target and adjusts text" {
   // Move Leaf("b") Before Leaf("a"):
   //   step 1: replace b's span with placeholder("?")
   //   step 2: insert "b " at the target start
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a b")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -149,7 +149,7 @@ test "move_node moves source before target and adjusts text" {
 ///|
 test "move_node exchange (Inside) swaps two leaves" {
   // "a b" -> root Branch("", [Leaf("a"), Leaf("b")])
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a b")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -170,7 +170,7 @@ test "move_node exchange (Inside) swaps two leaves" {
 ///|
 test "move_node exchange moves whole branches" {
   // "f(a) g(b)" -> root with two Branch children
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(a) g(b)")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -191,7 +191,7 @@ test "move_node exchange moves whole branches" {
 ///|
 test "move_node exchange: short and long leaf" {
   // "p qrs" -> root Branch("", [Leaf("p"), Leaf("qrs")])
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("p qrs")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -212,7 +212,7 @@ test "move_node exchange: short and long leaf" {
 ///|
 test "move_node exchange: branch and leaf" {
   // "f(x) y" -> root Branch("", [Branch("f", [Leaf("x")]), Leaf("y")])
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x) y")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")
@@ -234,7 +234,7 @@ test "move_node exchange: branch and leaf" {
 test "move_node exchange: nested siblings" {
   // "h(p q)" -> root Branch("", [Branch("h", [Leaf("p"), Leaf("q")])])
   // Exchange the two leaves inside the branch.
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("h(p q)")
   let root = match editor.get_proj_node() {
     None => fail("no proj node")

--- a/editor/sync_editor_undo_test.mbt
+++ b/editor/sync_editor_undo_test.mbt
@@ -2,14 +2,14 @@
 
 ///|
 test "undo: empty stack reports not undoable" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   inspect(se.can_undo(), content="false")
   inspect(se.can_redo(), content="false")
 }
 
 ///|
 test "undo: insert then undo restores" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("hello", 1000)
   inspect(se.get_text(), content="hello")
   inspect(se.can_undo(), content="true")
@@ -20,7 +20,7 @@ test "undo: insert then undo restores" {
 
 ///|
 test "undo: redo after undo" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("hello", 1000)
   inspect(se.undo(), content="true")
   inspect(se.get_text(), content="")
@@ -31,7 +31,7 @@ test "undo: redo after undo" {
 
 ///|
 test "undo: redo cleared on new edit" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("a", 1000)
   inspect(se.undo(), content="true")
   inspect(se.get_text(), content="")
@@ -43,7 +43,7 @@ test "undo: redo cleared on new edit" {
 
 ///|
 test "undo: tracking suppression" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   se.set_tracking(false)
   try! se.insert_and_record("x", 1000)
   se.set_tracking(true)
@@ -54,7 +54,7 @@ test "undo: tracking suppression" {
 
 ///|
 test "undo: backspace and record" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("ab", 1000)
   inspect(se.get_text(), content="ab")
   // Cursor is at 2 after insert, backspace deletes "b"
@@ -68,7 +68,7 @@ test "undo: backspace and record" {
 
 ///|
 test "undo: delete and record" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("ab", 1000)
   inspect(se.get_text(), content="ab")
   // Move cursor to position 0, then delete forward removes "a"
@@ -83,7 +83,7 @@ test "undo: delete and record" {
 
 ///|
 test "undo: multiple undos in sequence" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("a", 1000)
   try! se.insert_and_record("b", 2000)
   try! se.insert_and_record("c", 3000)
@@ -100,7 +100,7 @@ test "undo: multiple undos in sequence" {
 
 ///|
 test "undo: clear stacks" {
-  let se = @probe.new_test_editor("agent1")
+  let se = try! @probe.new_test_editor("agent1")
   try! se.insert_and_record("hello", 1000)
   inspect(se.can_undo(), content="true")
   se.clear_undo()

--- a/editor/sync_editor_ws_wbtest.mbt
+++ b/editor/sync_editor_ws_wbtest.mbt
@@ -2,7 +2,7 @@
 
 ///|
 test "ws_on_close: clears ws reference" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let ws = make_test_ws()
   editor.ws_on_open(ws)
   inspect(editor.ws is None, content="false")
@@ -12,7 +12,7 @@ test "ws_on_close: clears ws reference" {
 
 ///|
 test "ws_send: does nothing when disconnected" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   // ws is None by default — should not panic
   editor.ws_send(Bytes::new(0))
   inspect(editor.ws is None, content="true")
@@ -20,7 +20,7 @@ test "ws_send: does nothing when disconnected" {
 
 ///|
 test "ws_on_message: PeerLeft removes peer from hub" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   // Inject remote cursor presence for "bob" the way it arrives over the wire:
   // encode it from bob's own hub and apply to alice's editor hub.
   let bob_hub = EphemeralHub::new("bob")
@@ -37,8 +37,8 @@ test "ws_on_message: PeerLeft removes peer from hub" {
 
 ///|
 test "ws_on_message: CrdtOps applies remote edits" {
-  let editor_a = @probe.new_test_editor("alice")
-  let editor_b = @probe.new_test_editor("bob")
+  let editor_a = try! @probe.new_test_editor("alice")
+  let editor_b = try! @probe.new_test_editor("bob")
   // Alice types some text
   editor_a.set_text("hello")
   // Export alice's state as JSON bytes
@@ -59,7 +59,7 @@ test "ws_on_message: CrdtOps applies remote edits" {
 
 ///|
 test "ws_on_message: EphemeralUpdate applies to hub" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   // Create some ephemeral data from a different hub
   let other_hub = EphemeralHub::new("bob")
   other_hub.set_cursor(42)
@@ -74,8 +74,8 @@ test "ws_on_message: EphemeralUpdate applies to hub" {
 
 ///|
 test "ws_on_message: RelayedCrdtOps applies remote edits with sender" {
-  let editor_a = @probe.new_test_editor("alice")
-  let editor_b = @probe.new_test_editor("bob")
+  let editor_a = try! @probe.new_test_editor("alice")
+  let editor_b = try! @probe.new_test_editor("bob")
   editor_a.set_text("hello")
   let crdt_msg = editor_a.export_all() catch {
     _ => {

--- a/editor/sync_status_wbtest.mbt
+++ b/editor/sync_status_wbtest.mbt
@@ -155,16 +155,14 @@ test "SyncStatus: failed apply_sync leaves Error status intact" {
       return
     }
   }
-  // Apply the orphan delta — must raise TextError::SyncFailed with
-  // SyncFailure::MissingDependency specifically. Any other exception
-  // (or no exception) would mean the test isn't exercising what it claims.
-  let mut raised_missing_dep = false
+  // EGW owns and reports the pending operation. The editor normalizes that
+  // report to the legacy retryable VersionNotFound error for SyncHost.
+  let mut raised_pending = false
   editor_b.apply_sync(orphan_delta) catch {
-    @text.TextError::SyncFailed(@text.SyncFailure::MissingDependency(..)) =>
-      raised_missing_dep = true
-    other => fail("expected MissingDependency, got: \{other}")
+    @text.TextError::VersionNotFound => raised_pending = true
+    other => fail("expected pending dependency, got: \{other}")
   }
-  inspect(raised_missing_dep, content="true")
+  inspect(raised_pending, content="true")
   // Error must persist — the catch branch in apply_sync must not hit the
   // auto-clear tail.
   inspect(

--- a/editor/sync_status_wbtest.mbt
+++ b/editor/sync_status_wbtest.mbt
@@ -35,13 +35,13 @@ fn[T : Eq] force_error_exhausted(
 
 ///|
 test "SyncStatus: initial status is Disconnected" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   inspect(editor.get_sync_status(), content="Disconnected")
 }
 
 ///|
 test "SyncStatus: ws_on_open transitions to Idle" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let ws = make_test_ws()
   editor.ws_on_open(ws)
   inspect(editor.get_sync_status(), content="Idle")
@@ -49,7 +49,7 @@ test "SyncStatus: ws_on_open transitions to Idle" {
 
 ///|
 test "SyncStatus: ws_on_close transitions to Disconnected" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let ws = make_test_ws()
   editor.ws_on_open(ws)
   editor.ws_on_close()
@@ -60,7 +60,7 @@ test "SyncStatus: ws_on_close transitions to Disconnected" {
 
 ///|
 test "SyncStatus: callback fires on transition" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let fired : Array[SyncStatus] = []
   editor.set_on_status_change(Some(fn(s) { fired.push(s) }))
   let ws = make_test_ws()
@@ -74,7 +74,7 @@ test "SyncStatus: callback fires on transition" {
 
 ///|
 test "SyncStatus: equality guard suppresses no-op transitions" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let fired : Array[SyncStatus] = []
   editor.set_on_status_change(Some(fn(s) { fired.push(s) }))
   // ws_on_close when already Disconnected → no emission
@@ -91,7 +91,7 @@ test "SyncStatus: equality guard suppresses no-op transitions" {
 
 ///|
 test "SyncStatus: removing callback disables notifications" {
-  let editor = @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("alice")
   let fired : Array[SyncStatus] = []
   editor.set_on_status_change(Some(fn(s) { fired.push(s) }))
   let ws = make_test_ws()
@@ -107,8 +107,8 @@ test "SyncStatus: removing callback disables notifications" {
 
 ///|
 test "SyncStatus: Error → Idle on successful apply_sync" {
-  let editor_a = @probe.new_test_editor("alice")
-  let editor_b = @probe.new_test_editor("bob")
+  let editor_a = try! @probe.new_test_editor("alice")
+  let editor_b = try! @probe.new_test_editor("bob")
   let ws = make_test_ws()
   editor_b.ws_on_open(ws)
   // Drive editor_b into Error state through the public surface.
@@ -139,8 +139,8 @@ test "SyncStatus: failed apply_sync leaves Error status intact" {
   // receiving editor: apply_sync raises
   // TextError::SyncFailed(MissingDependency) and the Error → Idle
   // auto-clear must NOT fire.
-  let editor_a = @probe.new_test_editor("alice")
-  let editor_b = @probe.new_test_editor("bob")
+  let editor_a = try! @probe.new_test_editor("alice")
+  let editor_b = try! @probe.new_test_editor("bob")
   let ws = make_test_ws()
   editor_b.ws_on_open(ws)
   // Drive editor_b into Error state through the public surface.
@@ -177,8 +177,8 @@ test "SyncStatus: failed apply_sync leaves Error status intact" {
 
 ///|
 test "SyncStatus: watchdog scheduler receives request_id and timeout on send" {
-  let editor_a = @probe.new_test_editor("alice")
-  let editor = @probe.new_test_editor("bob")
+  let editor_a = try! @probe.new_test_editor("alice")
+  let editor = try! @probe.new_test_editor("bob")
   let ws = make_test_ws()
   editor.ws_on_open(ws)
   let scheduled : Array[(Int, Int)] = []

--- a/editor/view_updater_benchmark_wbtest.mbt
+++ b/editor/view_updater_benchmark_wbtest.mbt
@@ -21,7 +21,7 @@ fn bench_source(def_count : Int) -> String {
 
 ///|
 fn bench_setup(let_count : Int) -> @protocol.ViewNode {
-  let editor = @probe.new_test_editor("bench")
+  let editor = try! @probe.new_test_editor("bench")
   editor.set_text(bench_source(let_count))
   let proj_node = editor.get_proj_node().unwrap()
   let source_map = editor.get_source_map()
@@ -63,7 +63,7 @@ test "viewnode serialization (500 defs)" (b : @bench.T) {
 
 ///|
 test "compute_view_patches (100 defs, single edit)" (b : @bench.T) {
-  let editor = @probe.new_test_editor("bench")
+  let editor = try! @probe.new_test_editor("bench")
   editor.set_text(bench_source(100))
   let state = ViewUpdateState::ViewUpdateState()
   // Initial full tree

--- a/editor/view_updater_test.mbt
+++ b/editor/view_updater_test.mbt
@@ -5,7 +5,7 @@
 
 ///|
 test "get_view_tree returns ViewNode for non-empty editor" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x)")
   let tree = editor.get_view_tree()
   assert_true(tree is Some(_))
@@ -22,7 +22,7 @@ test "get_view_tree returns ViewNode for non-empty editor" {
 // pins the generic empty-document behavior, which the moved lambda companion
 // test (`editor_view_decorations_test.mbt`) does not cover.
 test "empty generic editor yields an empty-document view and a FullTree patch" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   // No text inserted.
   let tree = editor.get_view_tree()
   assert_true(tree is Some(_))
@@ -51,7 +51,7 @@ test "empty generic editor yields an empty-document view and a FullTree patch" {
 // lambda companion test asserts this only against lambda's Module/def-index
 // projection; this pins it for the generic pipeline.
 test "NodeId stable across an unrelated sibling edit" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x y)")
   // root Branch("") -> child Branch("f") -> [Leaf("x"), Leaf("y")]
   let root = editor.get_proj_node().unwrap()
@@ -67,7 +67,7 @@ test "NodeId stable across an unrelated sibling edit" {
 
 ///|
 test "initial state produces FullTree patch" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x)")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let patches = @editor.compute_view_patches(state, editor)
@@ -85,7 +85,7 @@ test "initial state produces FullTree patch" {
 
 ///|
 test "unchanged tree produces no tree patches" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x)")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   // First call: FullTree
@@ -118,7 +118,7 @@ test "unchanged tree produces no tree patches" {
 // eval-annotation diffs, which the generic pipeline does not produce. Assert
 // the tight shape so diff minimality is actually verified.
 test "single character leaf edit produces a minimal UpdateNode (not ReplaceNode)" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("a")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, editor)
@@ -150,7 +150,7 @@ test "single character leaf edit produces a minimal UpdateNode (not ReplaceNode)
 
 ///|
 test "structural edit produces ReplaceNode" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("x")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, editor)
@@ -171,7 +171,7 @@ test "structural edit produces ReplaceNode" {
 
 ///|
 test "diagnostics are emitted for parse errors" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("foo(") // unclosed '('
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let patches = @editor.compute_view_patches(state, editor)
@@ -190,7 +190,7 @@ test "diagnostics are emitted for parse errors" {
 
 ///|
 test "diagnostics are cleared when parse succeeds" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("foo(") // unclosed '('
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, editor)
@@ -212,7 +212,7 @@ test "diagnostics are cleared when parse succeeds" {
 
 ///|
 test "child insertion detected" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(a)")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, editor)
@@ -234,7 +234,7 @@ test "child insertion detected" {
 
 ///|
 test "child removal detected" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(a b)")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, editor)
@@ -256,7 +256,7 @@ test "child removal detected" {
 
 ///|
 test "proj_to_view_node converts a simple ProjNode tree" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   editor.set_text("f(x)")
   let proj_node = editor.get_proj_node().unwrap()
   let source_map = editor.get_source_map()
@@ -272,7 +272,7 @@ test "proj_to_view_node converts a simple ProjNode tree" {
 
 ///|
 test "proj_to_view_node node_count for 10 branches" {
-  let editor = @probe.new_test_editor("test")
+  let editor = try! @probe.new_test_editor("test")
   let segments : Array[String] = []
   for i = 0; i < 10; i = i + 1 {
     segments.push("f\{i}(x)")

--- a/examples/block-editor/main/block_doc.mbt
+++ b/examples/block-editor/main/block_doc.mbt
@@ -67,10 +67,10 @@ pub fn BlockDoc::move_block(
   position : @canopy_core.DropPosition,
 ) -> Unit raise @container.DocumentError {
   // Legality: self-drop and root-move are rejected at the model boundary.
-  if @container.tree_node_id_eq(id, ref_id) {
+  if id == ref_id {
     return
   }
-  if @container.tree_node_id_eq(id, root_block_id) {
+  if id == root_block_id {
     raise @container.DocumentError::Internal(detail="cannot move root block")
   }
   match position {

--- a/examples/block-editor/main/block_doc_wbtest.mbt
+++ b/examples/block-editor/main/block_doc_wbtest.mbt
@@ -23,8 +23,8 @@ test "children order is insertion order" {
   let b = doc.create_block(Paragraph)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="2")
-  inspect(@container.tree_node_id_eq(children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(children[1], b), content="true")
+  inspect(children[0] == a, content="true")
+  inspect(children[1] == b, content="true")
 }
 
 ///|
@@ -35,7 +35,7 @@ test "delete block removes from children" {
   doc.delete_block(a)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="1")
-  inspect(@container.tree_node_id_eq(children[0], b), content="true")
+  inspect(children[0] == b, content="true")
   inspect(doc.is_alive(a), content="false")
 }
 
@@ -67,9 +67,9 @@ test "create_block_after inserts at correct position" {
   let c = doc.create_block_after(a, Paragraph)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="3")
-  inspect(@container.tree_node_id_eq(children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(children[1], c), content="true")
-  inspect(@container.tree_node_id_eq(children[2], b), content="true")
+  inspect(children[0] == a, content="true")
+  inspect(children[1] == c, content="true")
+  inspect(children[2] == b, content="true")
 }
 
 ///|
@@ -80,9 +80,9 @@ test "create_block_after appends when after_id is last" {
   let c = doc.create_block_after(b, Paragraph)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="3")
-  inspect(@container.tree_node_id_eq(children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(children[1], b), content="true")
-  inspect(@container.tree_node_id_eq(children[2], c), content="true")
+  inspect(children[0] == a, content="true")
+  inspect(children[1] == b, content="true")
+  inspect(children[2] == c, content="true")
 }
 
 // ── Markdown export tests ─────────────────────────────────────────────────
@@ -483,9 +483,9 @@ test "move_block After: move first block after second" {
   doc.move_block(a, b, @canopy_core.DropPosition::After)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="3")
-  inspect(@container.tree_node_id_eq(children[0], b), content="true")
-  inspect(@container.tree_node_id_eq(children[1], a), content="true")
-  inspect(@container.tree_node_id_eq(children[2], c), content="true")
+  inspect(children[0] == b, content="true")
+  inspect(children[1] == a, content="true")
+  inspect(children[2] == c, content="true")
 }
 
 ///|
@@ -501,9 +501,9 @@ test "move_block Before: move last block before first" {
   doc.move_block(c, a, @canopy_core.DropPosition::Before)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="3")
-  inspect(@container.tree_node_id_eq(children[0], c), content="true")
-  inspect(@container.tree_node_id_eq(children[1], a), content="true")
-  inspect(@container.tree_node_id_eq(children[2], b), content="true")
+  inspect(children[0] == c, content="true")
+  inspect(children[1] == a, content="true")
+  inspect(children[2] == b, content="true")
 }
 
 ///|
@@ -516,9 +516,9 @@ test "move_block Before: move to before middle" {
   doc.move_block(c, b, @canopy_core.DropPosition::Before)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="3")
-  inspect(@container.tree_node_id_eq(children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(children[1], c), content="true")
-  inspect(@container.tree_node_id_eq(children[2], b), content="true")
+  inspect(children[0] == a, content="true")
+  inspect(children[1] == c, content="true")
+  inspect(children[2] == b, content="true")
 }
 
 ///|
@@ -531,9 +531,9 @@ test "move_block After: move to after last" {
   doc.move_block(a, c, @canopy_core.DropPosition::After)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="3")
-  inspect(@container.tree_node_id_eq(children[0], b), content="true")
-  inspect(@container.tree_node_id_eq(children[1], c), content="true")
-  inspect(@container.tree_node_id_eq(children[2], a), content="true")
+  inspect(children[0] == b, content="true")
+  inspect(children[1] == c, content="true")
+  inspect(children[2] == a, content="true")
 }
 
 ///|
@@ -547,8 +547,8 @@ test "move_block preserves text after reorder" {
   inspect(doc.get_text(a), content="alpha")
   inspect(doc.get_text(b), content="beta")
   let children = doc.children(root_block_id)
-  inspect(@container.tree_node_id_eq(children[0], b), content="true")
-  inspect(@container.tree_node_id_eq(children[1], a), content="true")
+  inspect(children[0] == b, content="true")
+  inspect(children[1] == a, content="true")
 }
 
 // ── Legality tests ───────────────────────────────────────────────────
@@ -563,8 +563,8 @@ test "move_block: self-drop is a silent no-op" {
   doc.move_block(a, a, @canopy_core.DropPosition::After)
   let children = doc.children(root_block_id)
   inspect(children.length(), content="2")
-  inspect(@container.tree_node_id_eq(children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(children[1], b), content="true")
+  inspect(children[0] == a, content="true")
+  inspect(children[1] == b, content="true")
 }
 
 ///|
@@ -605,13 +605,13 @@ test "move_block Before: cross-parent reparents nested block to ref's parent" {
   let root_children = doc.children(root_block_id)
   // Root should have: A, child-1, B (child-1 inserted before B)
   inspect(root_children.length(), content="3")
-  inspect(@container.tree_node_id_eq(root_children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(root_children[1], child1), content="true")
-  inspect(@container.tree_node_id_eq(root_children[2], b), content="true")
+  inspect(root_children[0] == a, content="true")
+  inspect(root_children[1] == child1, content="true")
+  inspect(root_children[2] == b, content="true")
   // A should still have child-2 only
   let a_children = doc.children(a)
   inspect(a_children.length(), content="1")
-  inspect(@container.tree_node_id_eq(a_children[0], child2), content="true")
+  inspect(a_children[0] == child2, content="true")
   // Text preserved
   inspect(doc.get_text(child1), content="child-1")
   inspect(doc.get_text(b), content="B")
@@ -632,9 +632,9 @@ test "move_block After: cross-parent reparents nested block to ref's parent" {
   let root_children = doc.children(root_block_id)
   // Root should have: A, B, child-1 (child-1 now under root after B)
   inspect(root_children.length(), content="3")
-  inspect(@container.tree_node_id_eq(root_children[0], a), content="true")
-  inspect(@container.tree_node_id_eq(root_children[1], b), content="true")
-  inspect(@container.tree_node_id_eq(root_children[2], child1), content="true")
+  inspect(root_children[0] == a, content="true")
+  inspect(root_children[1] == b, content="true")
+  inspect(root_children[2] == child1, content="true")
   // A should have no children
   let a_children = doc.children(a)
   inspect(a_children.length(), content="0")

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -28,28 +28,26 @@ fn get_replica_id(handle : Int) -> String {
 }
 
 ///|
-/// Parse "agent:counter" string into a TreeNodeId.
-/// Splits on last ':' so agent IDs without ':' are safe.
+/// Parse the length-prefixed TreeNodeId key produced by `TreeNodeId::key`.
 fn parse_block_id(s : String) -> @container.TreeNodeId {
-  match s.rev_split_once(":") {
-    None => @container.root_id
-    Some((agent, counter_view)) => {
-      // Parse integer directly from StringView — no intermediate String allocation
-      let mut counter = 0
-      let mut neg = false
-      let mut start = 0
-      if counter_view.length() > 0 && counter_view[0] == '-' {
-        neg = true
-        start = 1
-      }
-      for i in start..<counter_view.length() {
-        counter = counter * 10 + (counter_view[i].to_int() - 48)
-      }
-      if neg {
-        counter = -counter
-      }
-      @container.tree_node_id_new(agent.to_owned(), counter)
-    }
+  guard s.split_once(":") is Some((length_view, rest)) else {
+    return @container.root_id
+  }
+  let agent_length : Int = @strconv.from_str(length_view) catch {
+    _ => return @container.root_id
+  }
+  guard agent_length > 0 && rest.length() > agent_length else {
+    return @container.root_id
+  }
+  guard rest[agent_length] == ':' else { return @container.root_id }
+  let agent = rest[:agent_length].to_owned() catch {
+    _ => return @container.root_id
+  }
+  let sequence : Int = @strconv.from_str(rest[agent_length + 1:]) catch {
+    _ => return @container.root_id
+  }
+  @container.TreeNodeId::TreeNodeId(agent, sequence) catch {
+    _ => @container.root_id
   }
 }
 
@@ -75,7 +73,7 @@ fn emit_block_json(
   let bt = doc.get_type(id)
   buf
   ..write_string("{\"id\":\"")
-  ..write_json_escaped(@container.tree_node_id_key(id))
+  ..write_json_escaped(id.key())
   ..write_string("\",\"block_type\":\"")
   ..write_json_escaped(block_type_name(bt))
   .write_string("\",\"level\":\"")
@@ -120,7 +118,7 @@ fn emit_blocks(
   is_first : Ref[Bool],
 ) -> Unit {
   let children = doc.children(parent_id)
-  let parent_key = @container.tree_node_id_key(parent_id)
+  let parent_key = parent_id.key()
   // Indexed loop: i is the sibling index passed to emit_block_json.
   for i in 0..<children.length() {
     let id = children[i]
@@ -221,7 +219,7 @@ pub fn editor_insert_block_after(
       let after_id = parse_block_id(after_id_str)
       let bt = block_type_from_props(block_type_str, fn(_k) { None })
       let new_id = doc.create_block_after(after_id, bt) catch { _ => return "" }
-      @container.tree_node_id_key(new_id)
+      new_id.key()
     }
     None => ""
   }

--- a/examples/block-editor/main/block_init_wbtest.mbt
+++ b/examples/block-editor/main/block_init_wbtest.mbt
@@ -9,53 +9,42 @@ test "create_editor returns incrementing handles" {
 test "parse_block_id round-trips with id_key" {
   let doc = BlockDoc::new("alice")
   let id = doc.create_block(Paragraph)
-  let key = @container.tree_node_id_key(id)
+  let key = id.key()
   let parsed = parse_block_id(key)
-  inspect(@container.tree_node_id_agent(parsed), content="alice")
-  inspect(
-    @container.tree_node_id_counter(parsed) ==
-    @container.tree_node_id_counter(id),
-    content="true",
-  )
+  inspect(parsed.replica_id(), content="alice")
+  inspect(parsed.sequence() == id.sequence(), content="true")
 }
 
 ///|
 test "parse_block_id: empty string falls back to root" {
   let parsed = parse_block_id("")
-  inspect(
-    @container.tree_node_id_eq(parsed, @container.root_id),
-    content="true",
-  )
+  inspect(parsed == @container.root_id, content="true")
 }
 
 ///|
 test "parse_block_id: no colon falls back to root" {
   let parsed = parse_block_id("no-colon-here")
-  inspect(
-    @container.tree_node_id_eq(parsed, @container.root_id),
-    content="true",
-  )
+  inspect(parsed == @container.root_id, content="true")
 }
 
 ///|
-test "parse_block_id: multiple colons splits on last" {
-  let parsed = parse_block_id("agent:with:colons:42")
-  inspect(@container.tree_node_id_agent(parsed), content="agent:with:colons")
-  inspect(@container.tree_node_id_counter(parsed), content="42")
+test "parse_block_id: length prefix preserves colons" {
+  let parsed = parse_block_id("17:agent:with:colons:42")
+  inspect(parsed.replica_id(), content="agent:with:colons")
+  inspect(parsed.sequence(), content="42")
 }
 
 ///|
-test "parse_block_id: negative counter" {
-  let parsed = parse_block_id("root:-1")
-  inspect(@container.tree_node_id_agent(parsed), content="root")
-  inspect(@container.tree_node_id_counter(parsed), content="-1")
+test "parse_block_id: virtual root key falls back to root" {
+  let parsed = parse_block_id(@container.root_id.key())
+  inspect(parsed == @container.root_id, content="true")
 }
 
 ///|
 test "parse_block_id: zero counter" {
-  let parsed = parse_block_id("alice:0")
-  inspect(@container.tree_node_id_agent(parsed), content="alice")
-  inspect(@container.tree_node_id_counter(parsed), content="0")
+  let parsed = parse_block_id("5:alice:0")
+  inspect(parsed.replica_id(), content="alice")
+  inspect(parsed.sequence(), content="0")
 }
 
 ///|
@@ -112,7 +101,7 @@ test "editor_insert_block_after creates block" {
   inspect(String::contains(json1, "heading"), content="true")
   // Get the first block's id to insert after
   let doc = docs.get(h).unwrap()
-  let first_id = @container.tree_node_id_key(doc.children(root_block_id)[0])
+  let first_id = doc.children(root_block_id)[0].key()
   let new_id = editor_insert_block_after(h, first_id, "paragraph")
   inspect(new_id.length() > 0, content="true")
   let json2 = get_render_state(h)
@@ -128,7 +117,7 @@ test "editor_set_block_type changes type" {
   inspect(String::contains(json1, "paragraph"), content="true")
   // Change to heading via bridge
   let doc = docs.get(h).unwrap()
-  let block_id = @container.tree_node_id_key(doc.children(root_block_id)[0])
+  let block_id = doc.children(root_block_id)[0].key()
   editor_set_block_type(h, block_id, "heading", 2, "")
   let json2 = get_render_state(h)
   inspect(String::contains(json2, "heading"), content="true")
@@ -148,7 +137,7 @@ test "get_render_state includes depth and child_count" {
   inspect(String::contains(json, "\"depth\":1"), content="true")
   inspect(String::contains(json, "\"child_count\":1"), content="true")
   inspect(String::contains(json, "\"is_alive\":true"), content="true")
-  let parent_key = @container.tree_node_id_key(parent)
+  let parent_key = parent.key()
   inspect(
     String::contains(json, "\"parent_id\":\"\{parent_key}\""),
     content="true",

--- a/examples/block-editor/main/moon.pkg
+++ b/examples/block-editor/main/moon.pkg
@@ -2,6 +2,7 @@ import {
   "dowdiness/canopy/core" @canopy_core,
   "dowdiness/event-graph-walker/container",
   "moonbitlang/core/debug",
+  "moonbitlang/core/strconv",
 }
 
 pkgtype(kind: "executable")

--- a/examples/block-editor/moon.mod
+++ b/examples/block-editor/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "dowdiness/canopy@0.1.0",
-  "dowdiness/event-graph-walker@0.3.0",
+  "dowdiness/event-graph-walker@0.5.0",
 }
 
 preferred_target = "js"

--- a/examples/ideal/main/internal/history_render/history_render_wbtest.mbt
+++ b/examples/ideal/main/internal/history_render/history_render_wbtest.mbt
@@ -8,7 +8,7 @@
 /// Helper: build a fresh single-editor scenario with `n` sequential
 /// inserts of "a" by `agent`. LVs run 0..<n in append order.
 fn build_linear(agent : String, n : Int) -> @editor.SyncEditor[@ast.Term] {
-  let (editor, _) = @lambda.new_lambda_editor(agent)
+  let (editor, _) = try! @lambda.new_lambda_editor(agent)
   for i in 0..<n {
     editor.insert_at(i, "a", 0)
   }
@@ -17,7 +17,7 @@ fn build_linear(agent : String, n : Int) -> @editor.SyncEditor[@ast.Term] {
 
 ///|
 test "render_history empty" {
-  let (editor, _) = @lambda.new_lambda_editor("local")
+  let (editor, _) = try! @lambda.new_lambda_editor("local")
   match render_history(editor.causal_snapshot(), "local") {
     Empty => ()
     _ => fail("expected Empty")
@@ -145,9 +145,9 @@ test "render_history 10-op chain terminating at frontier — 9 compressed + 1 si
 
 ///|
 test "render_history two-agent divergence — 3 nodes, 2 edges, two fills, two frontier tips" {
-  let (alice, _) = @lambda.new_lambda_editor("alice")
+  let (alice, _) = try! @lambda.new_lambda_editor("alice")
   alice.insert_at(0, "a", 0) // LV0 by alice → shared root
-  let (bob, _) = @lambda.new_lambda_editor("bob")
+  let (bob, _) = try! @lambda.new_lambda_editor("bob")
   bob.apply_sync(alice.export_all())
   // Now both have alice's LV0 with op_count 1, frontier {0}.
   alice.insert_at(1, "x", 0) // LV1_alice on top of root
@@ -188,9 +188,9 @@ test "render_history two-agent divergence — 3 nodes, 2 edges, two fills, two f
 test "render_history merge — diamond, single frontier" {
   // Build divergence then have alice insert a third op AFTER syncing bob.
   // Result: alice's new op has parents = [alice_tip, bob_tip] ⇒ a merge node.
-  let (alice, _) = @lambda.new_lambda_editor("alice")
+  let (alice, _) = try! @lambda.new_lambda_editor("alice")
   alice.insert_at(0, "a", 0)
-  let (bob, _) = @lambda.new_lambda_editor("bob")
+  let (bob, _) = try! @lambda.new_lambda_editor("bob")
   bob.apply_sync(alice.export_all())
   alice.insert_at(1, "x", 0)
   bob.insert_at(1, "y", 0)
@@ -239,9 +239,9 @@ test "render_history produces parseable DOT for adversarial agent IDs" {
   // the emitted DOT round-trips through `@gv_parser.parse_dot`.
   let me = "me"
   let weird = "evil-\\\"x"
-  let (alice, _) = @lambda.new_lambda_editor(me)
+  let (alice, _) = try! @lambda.new_lambda_editor(me)
   alice.insert_at(0, "a", 0)
-  let (bob, _) = @lambda.new_lambda_editor(weird)
+  let (bob, _) = try! @lambda.new_lambda_editor(weird)
   bob.apply_sync(alice.export_all())
   bob.insert_at(1, "b", 0)
   alice.apply_sync(bob.export_all())
@@ -283,12 +283,12 @@ test "escape_dot_string normalizes newlines and escapes specials" {
 test "collect_history_data reserves index 0 for local agent past 8 collaborators" {
   // 9 distinct non-local agents (a01..a09) collide with index 0 under a
   // naïve `idx % 8` wrap; the 1..7 wrap rule keeps index 0 reserved.
-  let (me, _) = @lambda.new_lambda_editor("me")
+  let (me, _) = try! @lambda.new_lambda_editor("me")
   me.insert_at(0, "a", 0)
   let mut pos = 1
   for i in 1..<=9 {
     let agent = "a0" + i.to_string()
-    let (peer, _) = @lambda.new_lambda_editor(agent)
+    let (peer, _) = try! @lambda.new_lambda_editor(agent)
     peer.apply_sync(me.export_all())
     peer.insert_at(pos, "x", 0)
     me.apply_sync(peer.export_all())

--- a/examples/ideal/moon.mod
+++ b/examples/ideal/moon.mod
@@ -16,7 +16,7 @@ import {
   "dowdiness/text_change@0.1.0",
   "dowdiness/graphviz@0.1.0",
   "dowdiness/lambda@0.1.0",
-  "dowdiness/event-graph-walker@0.3.0",
+  "dowdiness/event-graph-walker@0.5.0",
   "dowdiness/visualizer@0.1.0",
 }
 

--- a/examples/ideal/web/src/sync.ts
+++ b/examples/ideal/web/src/sync.ts
@@ -239,6 +239,7 @@ export class SyncClient {
       if (!delta) return;
       const parsed = JSON.parse(delta);
       const hasOps =
+        (Array.isArray(parsed.operations) && parsed.operations.length > 0) ||
         (Array.isArray(parsed.ops) && parsed.ops.length > 0) ||
         (Array.isArray(parsed.runs) && parsed.runs.length > 0) ||
         (Array.isArray(parsed.tree_ops) && parsed.tree_ops.length > 0) ||

--- a/ffi/json/json_ffi.mbt
+++ b/ffi/json/json_ffi.mbt
@@ -29,13 +29,19 @@ let json_registry : @host.HostRegistry[JsonHandle] = @host.HostRegistry::HostReg
 ///|
 /// Build a JSON editor on the shared runtime, then atomically register its
 /// protected cells with the coordinator. Returns the freshly-allocated
-/// `EditorId`. Aborting at any step leaves `json_registry` untouched
+/// `EditorId`, or `EditorId(-1)` when construction fails. A failed
+/// construction leaves `json_registry` untouched
 /// (atomic-boundary observation, spec §3.6).
 fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
   let editor = @json_companion.new_json_editor(
     agent_id,
     parent_runtime=coordinator.runtime(),
-  )
+  ) catch {
+    error => {
+      println("assemble_json_handle failed: \{error.message()}")
+      return @workspace.EditorId(-1)
+    }
+  }
   let cells = JsonProtectedCells::JsonProtectedCells(editor)
   let editor_id = coordinator.register_editor(
     agent_id,
@@ -51,7 +57,8 @@ fn assemble_json_handle(agent_id : String) -> @workspace.EditorId {
 }
 
 ///|
-/// Create a new JSON SyncEditor instance. Returns a unique handle.
+/// Create a new JSON SyncEditor instance.
+/// Returns a unique handle, or `-1` when `agent_id` is invalid.
 pub fn create_json_editor(agent_id : String) -> Int {
   assemble_json_handle(agent_id).0
 }

--- a/ffi/json/lifecycle_phase1_wbtest.mbt
+++ b/ffi/json/lifecycle_phase1_wbtest.mbt
@@ -18,6 +18,18 @@ fn drain_json_handle_after_direct_coordinator_destroy(handle : Int) -> Unit {
 }
 
 ///|
+test "json creation rejects an empty agent identifier before registration" {
+  reset_json_coordinator_for_phase1_tests()
+  let before = create_json_editor("json-creation-boundary-before")
+  inspect(create_json_editor(""), content="-1")
+  inspect(json_registry.get(-1) is None, content="true")
+  let after = create_json_editor("json-creation-boundary-after")
+  inspect(after == before + 1, content="true")
+  destroy_json_editor(before)
+  destroy_json_editor(after)
+}
+
+///|
 test "spec §12 #1 (json): each protected cell reads through read_protected" {
   reset_json_coordinator_for_phase1_tests()
   let handle = create_json_editor("json_test_agent_one")

--- a/ffi/json/moon.pkg
+++ b/ffi/json/moon.pkg
@@ -5,6 +5,7 @@ import {
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/companion" @json_companion,
   "dowdiness/canopy/workspace/coordinator" @workspace,
+  "dowdiness/event-graph-walker/text",
   "dowdiness/json" @djson,
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",

--- a/ffi/lambda/canopy_test.mbt
+++ b/ffi/lambda/canopy_test.mbt
@@ -1,6 +1,13 @@
 // Test simulating the exact web editor scenario
 
 ///|
+test "sync JSON fallback is a valid empty v0.5 envelope" {
+  let all = @text.SyncMessage::from_json_string(export_all_json(-1))
+  let since = @text.SyncMessage::from_json_string(export_since_json(-1, ""))
+  inspect((all.op_count(), since.op_count()), content="(0, 0)")
+}
+
+///|
 test "Web scenario: error persistence bug" {
   // Simulate web editor usage
   let editor_ref : Ref[@editor.SyncEditor[@ast.Term]?] = { val: None }

--- a/ffi/lambda/canopy_test.mbt
+++ b/ffi/lambda/canopy_test.mbt
@@ -1,6 +1,17 @@
 // Test simulating the exact web editor scenario
 
 ///|
+test "editor creation rejects an empty agent identifier before registration" {
+  let before = create_editor("creation-boundary-before")
+  inspect(create_editor(""), content="-1")
+  inspect(create_editor_with_undo("", 500), content="-1")
+  let after = create_editor("creation-boundary-after")
+  inspect(after == before + 1, content="true")
+  destroy_editor(before)
+  destroy_editor(after)
+}
+
+///|
 test "sync JSON fallback is a valid empty v0.5 envelope" {
   let all = @text.SyncMessage::from_json_string(export_all_json(-1))
   let since = @text.SyncMessage::from_json_string(export_since_json(-1, ""))

--- a/ffi/lambda/diagnostics.mbt
+++ b/ffi/lambda/diagnostics.mbt
@@ -118,14 +118,17 @@ pub fn get_diagnostics_json(handle : Int) -> String {
 }
 
 ///|
+const EMPTY_SYNC_JSON : String = "{\"schema\":1,\"format\":\"event-graph-walker/text-sync\",\"operations\":[],\"heads\":[]}"
+
+///|
 /// Export all operations as a SyncMessage JSON string.
 pub fn export_all_json(handle : Int) -> String {
   match lambda_registry.get(handle) {
     Some(h) =>
       h.editor.export_all().to_json_string() catch {
-        _ => "{\"ops\":[],\"heads\":[]}"
+        _ => EMPTY_SYNC_JSON
       }
-    None => "{\"ops\":[],\"heads\":[]}"
+    None => EMPTY_SYNC_JSON
   }
 }
 
@@ -138,9 +141,9 @@ pub fn export_since_json(handle : Int, peer_version_json : String) -> String {
         let ver = @text.Version::from_json_string(peer_version_json)
         h.editor.export_since(ver).to_json_string()
       } catch {
-        _ => "{\"ops\":[],\"heads\":[]}"
+        _ => EMPTY_SYNC_JSON
       }
-    None => "{\"ops\":[],\"heads\":[]}"
+    None => EMPTY_SYNC_JSON
   }
 }
 

--- a/ffi/lambda/lifecycle.mbt
+++ b/ffi/lambda/lifecycle.mbt
@@ -33,8 +33,9 @@ let last_created_handle : Ref[Int?] = { val: None }
 ///|
 /// Build a Lambda editor + companion on the shared runtime, then
 /// atomically register them with the coordinator. Returns
-/// the freshly-allocated `EditorId`. Aborting at any step leaves
-/// `lambda_registry` untouched (atomic-boundary observation, spec §8.3).
+/// the freshly-allocated `EditorId`, or `EditorId(-1)` when construction
+/// fails. A failed construction leaves `lambda_registry` untouched
+/// (atomic-boundary observation, spec §8.3).
 fn assemble_lambda_handle(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
@@ -43,7 +44,12 @@ fn assemble_lambda_handle(
     agent_id,
     capture_timeout_ms~,
     parent_runtime=coordinator.runtime(),
-  )
+  ) catch {
+    error => {
+      println("assemble_lambda_handle failed: \{error.message()}")
+      return @workspace.EditorId(-1)
+    }
+  }
   let cells = LambdaProtectedCells::LambdaProtectedCells(editor, companion)
   let editor_id = coordinator.register_editor(
     agent_id,
@@ -81,7 +87,8 @@ pub fn get_lambda_companion() -> @lang_lambda.LambdaCompanion? {
 }
 
 ///|
-/// Create a new SyncEditor instance. Returns a unique handle.
+/// Create a new SyncEditor instance.
+/// Returns a unique handle, or `-1` when `agent_id` is invalid.
 pub fn create_editor(agent_id : String) -> Int {
   assemble_lambda_handle(agent_id).0
 }

--- a/ffi/lambda/undo.mbt
+++ b/ffi/lambda/undo.mbt
@@ -3,7 +3,7 @@
 
 ///|
 /// Create a new SyncEditor with undo support.
-/// Returns a unique handle for this editor.
+/// Returns a unique handle for this editor, or `-1` when `agent_id` is invalid.
 pub fn create_editor_with_undo(
   agent_id : String,
   capture_timeout_ms : Int,
@@ -19,7 +19,10 @@ pub fn insert_and_record(
   timestamp_ms : Int,
 ) -> Unit {
   match lambda_registry.get(handle) {
-    Some(h) => try! h.editor.insert_and_record(text, timestamp_ms)
+    Some(h) =>
+      h.editor.insert_and_record(text, timestamp_ms) catch {
+        error => println("insert_and_record failed: \{error.to_string()}")
+      }
     None => ()
   }
 }

--- a/ffi/markdown/lifecycle_phase1_wbtest.mbt
+++ b/ffi/markdown/lifecycle_phase1_wbtest.mbt
@@ -26,6 +26,18 @@ fn drain_markdown_handle_after_direct_coordinator_destroy(handle : Int) -> Unit 
 }
 
 ///|
+test "markdown creation rejects an empty agent identifier before registration" {
+  reset_markdown_coordinator_for_phase1_tests()
+  let before = create_markdown_editor("markdown-creation-boundary-before")
+  inspect(create_markdown_editor(""), content="-1")
+  inspect(markdown_registry.get(-1) is None, content="true")
+  let after = create_markdown_editor("markdown-creation-boundary-after")
+  inspect(after == before + 1, content="true")
+  destroy_markdown_editor(before)
+  destroy_markdown_editor(after)
+}
+
+///|
 test "spec §12 #1 (md): each protected cell reads through read_protected" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_test_agent_one")

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -28,13 +28,19 @@ let markdown_registry : @host.HostRegistry[MarkdownHandle] = @host.HostRegistry:
 ///|
 /// Build a Markdown editor on the shared runtime, then atomically register
 /// its protected cells with the coordinator. Returns the freshly-allocated
-/// `EditorId`. Aborting at any step leaves `markdown_registry` untouched
+/// `EditorId`, or `EditorId(-1)` when construction fails. A failed
+/// construction leaves `markdown_registry` untouched
 /// (atomic-boundary observation, spec §3.6).
 fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId {
   let editor = @md_companion.new_markdown_editor(
     agent_id,
     parent_runtime=coordinator.runtime(),
-  )
+  ) catch {
+    error => {
+      println("assemble_markdown_handle failed: \{error.message()}")
+      return @workspace.EditorId(-1)
+    }
+  }
   let cells = MarkdownProtectedCells::MarkdownProtectedCells(editor)
   let editor_id = coordinator.register_editor(
     agent_id,
@@ -45,6 +51,7 @@ fn assemble_markdown_handle(agent_id : String) -> @workspace.EditorId {
 }
 
 ///|
+/// Returns a unique handle, or `-1` when `agent_id` is invalid.
 pub fn create_markdown_editor(agent_id : String) -> Int {
   assemble_markdown_handle(agent_id).0
 }

--- a/ffi/markdown/moon.pkg
+++ b/ffi/markdown/moon.pkg
@@ -8,6 +8,7 @@ import {
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
   "dowdiness/canopy/protocol",
   "dowdiness/canopy/workspace/coordinator" @workspace,
+  "dowdiness/event-graph-walker/text",
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",
   "dowdiness/markdown" @md,

--- a/lang/json/companion/dispatch_benchmark.mbt
+++ b/lang/json/companion/dispatch_benchmark.mbt
@@ -48,7 +48,9 @@ fn run_text_intent_dispatch_bench(
   mode : DispatchMode,
 ) -> Unit {
   let source = json_bench_object(member_count)
-  let editor = new_json_editor("bench")
+  let editor = new_json_editor("bench") catch {
+    error => abort("benchmark editor construction failed: \{error.message()}")
+  }
   editor.set_text(source)
   ignore(editor.get_proj_node())
   ignore(editor.get_source_map())

--- a/lang/json/companion/edit_messages_wbtest.mbt
+++ b/lang/json/companion/edit_messages_wbtest.mbt
@@ -11,7 +11,7 @@
 
 ///|
 test "apply_json_edit message pin: unwrap root scalar -> compute error" {
-  let editor = new_json_editor("target")
+  let editor = try! new_json_editor("target")
   editor.set_text("42")
   let root_id = match editor.get_proj_node() {
     Some(p) => p.id()
@@ -36,7 +36,7 @@ test "apply_json_edit message pin: unwrap root scalar -> compute error" {
 test "apply_json_edit message pin: absent node id -> compute error" {
   // Take a high child id from a donor with many nodes, then apply against a
   // single-scalar editor whose id space cannot contain it.
-  let donor = new_json_editor("donor")
+  let donor = try! new_json_editor("donor")
   donor.set_text("{\"a\": 1, \"b\": 2, \"c\": 3}")
   let absent_id = match donor.get_proj_node() {
     Some(p) => p.children[p.children.length() - 1].id()
@@ -45,7 +45,7 @@ test "apply_json_edit message pin: absent node id -> compute error" {
       return
     }
   }
-  let editor = new_json_editor("target")
+  let editor = try! new_json_editor("target")
   editor.set_text("42")
   match apply_json_edit(editor, JsonEditOp::Delete(node_id=absent_id), 0) {
     Err(msg) =>

--- a/lang/json/companion/integration_wbtest.mbt
+++ b/lang/json/companion/integration_wbtest.mbt
@@ -5,14 +5,14 @@ using @json_edits {type JsonEditOp, type JsonType}
 
 ///|
 test "new_json_editor — create and get text" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1}")
   inspect(editor.get_text(), content="{\"a\": 1}")
 }
 
 ///|
 test "new_json_editor — projection pipeline works" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1, \"b\": true}")
   let proj = editor.get_proj_node()
   inspect(proj is Some(_), content="true")
@@ -27,7 +27,7 @@ test "new_json_editor — projection pipeline works" {
 
 ///|
 test "new_json_editor — source map positions" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("[1, 2, 3]")
   let sm = editor.get_source_map()
   let proj = editor.get_proj_node()
@@ -39,7 +39,7 @@ test "new_json_editor — source map positions" {
 
 ///|
 test "new_json_editor — reconcile preserves IDs" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1, \"b\": 2}")
   let id1 = match editor.get_proj_node() {
     Some(p) => p.node_id
@@ -61,7 +61,7 @@ test "new_json_editor — reconcile preserves IDs" {
 
 ///|
 test "apply WrapInArray" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("42")
   match editor.get_proj_node() {
     Some(p) => {
@@ -79,7 +79,7 @@ test "apply WrapInArray" {
 
 ///|
 test "apply WrapInObject" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("42")
   match editor.get_proj_node() {
     Some(p) => {
@@ -97,7 +97,7 @@ test "apply WrapInObject" {
 
 ///|
 test "apply AddMember to empty object" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -117,7 +117,7 @@ test "apply AddMember to empty object" {
 
 ///|
 test "apply AddMember to non-empty object" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -137,7 +137,7 @@ test "apply AddMember to non-empty object" {
 
 ///|
 test "apply AddElement to empty array" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("[]")
   match editor.get_proj_node() {
     Some(p) => {
@@ -155,7 +155,7 @@ test "apply AddElement to empty array" {
 
 ///|
 test "apply AddElement to non-empty array" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("[1]")
   match editor.get_proj_node() {
     Some(p) => {
@@ -173,7 +173,7 @@ test "apply AddElement to non-empty array" {
 
 ///|
 test "apply ChangeType" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("null")
   match editor.get_proj_node() {
     Some(p) => {
@@ -191,7 +191,7 @@ test "apply ChangeType" {
 
 ///|
 test "apply ChangeType to object" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("123")
   match editor.get_proj_node() {
     Some(p) => {
@@ -209,7 +209,7 @@ test "apply ChangeType to object" {
 
 ///|
 test "apply CommitEdit" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("42")
   match editor.get_proj_node() {
     Some(p) => {
@@ -227,14 +227,14 @@ test "apply CommitEdit" {
 
 ///|
 test "error recovery — malformed JSON still produces projection" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": }")
   inspect(editor.get_proj_node() is Some(_), content="true")
 }
 
 ///|
 test "CommitEdit on value inside object preserves key" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -259,7 +259,7 @@ test "CommitEdit on value inside object preserves key" {
 
 ///|
 test "ChangeType on value inside object preserves key" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -286,7 +286,7 @@ test "ChangeType on value inside object preserves key" {
 
 ///|
 test "WrapInArray on value inside object preserves key" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -310,7 +310,7 @@ test "WrapInArray on value inside object preserves key" {
 
 ///|
 test "WrapInObject on value inside object preserves key" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -334,7 +334,7 @@ test "WrapInObject on value inside object preserves key" {
 
 ///|
 test "Delete member from object with two members" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1, \"b\": 2}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -354,7 +354,7 @@ test "Delete member from object with two members" {
 
 ///|
 test "Delete second member from object" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"a\": 1, \"b\": 2}")
   match editor.get_proj_node() {
     Some(p) => {
@@ -374,7 +374,7 @@ test "Delete second member from object" {
 
 ///|
 test "RenameKey on object" {
-  let editor = new_json_editor("test")
+  let editor = try! new_json_editor("test")
   editor.set_text("{\"old\": 1}")
   match editor.get_proj_node() {
     Some(p) => {

--- a/lang/json/companion/json_benchmark.mbt
+++ b/lang/json/companion/json_benchmark.mbt
@@ -47,7 +47,9 @@ fn json_bench_array(element_count : Int) -> String {
 /// ProjNode + SourceMap.
 fn run_json_object_bench(b : @bench.T, member_count : Int) -> Unit {
   let source = json_bench_object(member_count)
-  let editor = new_json_editor("bench")
+  let editor = new_json_editor("bench") catch {
+    error => abort("benchmark editor construction failed: \{error.message()}")
+  }
   editor.set_text(source)
   ignore(editor.get_proj_node())
   ignore(editor.get_source_map())
@@ -73,7 +75,9 @@ fn run_json_object_bench(b : @bench.T, member_count : Int) -> Unit {
 /// Benchmark: incremental edit on JSON array.
 fn run_json_array_bench(b : @bench.T, element_count : Int) -> Unit {
   let source = json_bench_array(element_count)
-  let editor = new_json_editor("bench")
+  let editor = new_json_editor("bench") catch {
+    error => abort("benchmark editor construction failed: \{error.message()}")
+  }
   editor.set_text(source)
   ignore(editor.get_proj_node())
   ignore(editor.get_source_map())

--- a/lang/json/companion/json_companion.mbt
+++ b/lang/json/companion/json_companion.mbt
@@ -22,12 +22,13 @@ let json_spec : @lang_runtime.LanguageSpec[
 
 ///|
 /// Create a new SyncEditor for JSON documents.
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
 /// Uses the generic 3-memo projection pipeline.
 pub fn new_json_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> @editor.SyncEditor[@json.JsonValue] {
+) -> @editor.SyncEditor[@json.JsonValue] raise @text.TextError {
   json_spec.new_editor(agent_id, capture_timeout_ms~, parent_runtime?)
 }
 

--- a/lang/json/companion/moon.pkg
+++ b/lang/json/companion/moon.pkg
@@ -4,6 +4,7 @@ import {
   "dowdiness/canopy/lang/json/edits" @json_edits,
   "dowdiness/canopy/lang/json/proj" @json_proj,
   "dowdiness/canopy/lang/runtime" @lang_runtime,
+  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/json",
   "dowdiness/loom",

--- a/lang/lambda/companion/editor_parser_integration_test.mbt
+++ b/lang/lambda/companion/editor_parser_integration_test.mbt
@@ -6,7 +6,7 @@
 
 ///|
 test "parser: get_ast_pretty contains expression" {
-  let se = new_lambda_editor("agent1").0
+  let se = (try! new_lambda_editor("agent1")).0
   se.set_text("42")
   let pretty = get_lambda_ast_pretty(se)
   inspect(pretty.contains("42"), content="true")
@@ -15,7 +15,7 @@ test "parser: get_ast_pretty contains expression" {
 
 ///|
 test "parser: complex expression parses correctly" {
-  let se = new_lambda_editor("agent1").0
+  let se = (try! new_lambda_editor("agent1")).0
   se.set_text("(f, x) => f x")
   inspect(
     @ast.print_term(get_lambda_ast(se)),
@@ -27,7 +27,7 @@ test "parser: complex expression parses correctly" {
 
 ///|
 test "parser: let binding with body" {
-  let se = new_lambda_editor("agent1").0
+  let se = (try! new_lambda_editor("agent1")).0
   se.set_text("let x = 1\nx + 2")
   let ast = get_lambda_ast(se)
   inspect(
@@ -41,14 +41,14 @@ test "parser: let binding with body" {
 
 ///|
 test "parser: if-then-else expression" {
-  let se = new_lambda_editor("agent1").0
+  let se = (try! new_lambda_editor("agent1")).0
   se.set_text("if x then 1 else 2")
   inspect(@ast.print_term(get_lambda_ast(se)), content="if x then 1 else 2")
 }
 
 ///|
 test "parser: arithmetic addition" {
-  let se = new_lambda_editor("agent1").0
+  let se = (try! new_lambda_editor("agent1")).0
   se.set_text("1 + 2 + 3")
   let ast = get_lambda_ast(se)
   inspect(
@@ -61,7 +61,7 @@ test "parser: arithmetic addition" {
 
 ///|
 test "parser: resolution tracks bound and free variables" {
-  let se = new_lambda_editor("agent1").0
+  let se = (try! new_lambda_editor("agent1")).0
   se.set_text("(x) => x + y")
   let res = get_lambda_resolution(se)
   // Verify resolution is populated (bound x, free y)

--- a/lang/lambda/companion/editor_view_decorations_test.mbt
+++ b/lang/lambda/companion/editor_view_decorations_test.mbt
@@ -8,7 +8,7 @@
 
 ///|
 test "get_view_tree returns Unit for empty editor" {
-  let editor = new_lambda_editor("test").0
+  let editor = (try! new_lambda_editor("test")).0
   let tree = editor.get_view_tree()
   guard tree is Some(node) else { fail("expected Unit projection") }
   inspect(node.kind_tag, content="Unit")
@@ -16,7 +16,7 @@ test "get_view_tree returns Unit for empty editor" {
 
 ///|
 test "FullTree emitted for empty editor then updated after text" {
-  let editor = new_lambda_editor("test").0
+  let editor = (try! new_lambda_editor("test")).0
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let patches1 = @editor.compute_view_patches(state, editor)
   let full_tree_unit = patches1
@@ -45,7 +45,7 @@ test "FullTree emitted for empty editor then updated after text" {
 
 ///|
 test "semantic decorations are emitted and stable" {
-  let editor = new_lambda_editor("test-semantic-decorations").0
+  let editor = (try! new_lambda_editor("test-semantic-decorations")).0
   editor.set_text("(x) => x")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let patches = @editor.compute_view_patches(state, editor)
@@ -77,7 +77,7 @@ test "semantic decorations are emitted and stable" {
 
 ///|
 test "analysis projection combines semantic and pattern decorations" {
-  let (editor, companion) = new_lambda_editor("test-analysis-projection")
+  let (editor, companion) = try! new_lambda_editor("test-analysis-projection")
   editor.set_text("(x) => x")
   let source = editor.get_text()
   let snapshot = @facts.SourceSnapshot::SourceSnapshot(
@@ -118,7 +118,7 @@ test "analysis projection combines semantic and pattern decorations" {
 
 ///|
 test "analysis projection drops stale pattern decorations but keeps semantic decorations" {
-  let (editor, companion) = new_lambda_editor(
+  let (editor, companion) = try! new_lambda_editor(
     "test-analysis-stale-keeps-semantic",
   )
   editor.set_text("(x) => x")

--- a/lang/lambda/companion/eval_memo_test.mbt
+++ b/lang/lambda/companion/eval_memo_test.mbt
@@ -1,6 +1,6 @@
 ///|
 test "pretty_view: eval annotations appear after edit" {
-  let editor = new_lambda_editor("test-eval-pretty").0
+  let editor = (try! new_lambda_editor("test-eval-pretty")).0
   editor.set_text("let x = 5\nx")
   let view = editor.get_pretty_view()
   let lines = view.children
@@ -14,7 +14,7 @@ test "pretty_view: eval annotations appear after edit" {
 
 ///|
 test "get_eval_annotations: module defs have annotations" {
-  let (editor, companion) = new_lambda_editor("test-struct-ann")
+  let (editor, companion) = try! new_lambda_editor("test-struct-ann")
   editor.set_text("let x = 5\nx")
   let annotations = companion.get_eval_annotations(editor.get_proj_node())
   inspect(annotations.length() > 0, content="true")
@@ -22,14 +22,14 @@ test "get_eval_annotations: module defs have annotations" {
 
 ///|
 test "get_eval_annotations: empty for no text" {
-  let (editor, companion) = new_lambda_editor("test-struct-ann-empty")
+  let (editor, companion) = try! new_lambda_editor("test-struct-ann-empty")
   let annotations = companion.get_eval_annotations(editor.get_proj_node())
   inspect(annotations.length(), content="0")
 }
 
 ///|
 test "get_view_tree: annotations attached to view nodes" {
-  let editor = new_lambda_editor("test-view-eval").0
+  let editor = (try! new_lambda_editor("test-view-eval")).0
   editor.set_text("let x = 5\nx")
   let view = editor.get_view_tree()
   guard view is Some(root)

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -142,11 +142,12 @@ fn build_eval_annotations(
 
 ///|
 /// Create a lambda editor with its companion.
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
 pub fn new_lambda_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
+) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) raise @text.TextError {
   let analysis_projection = AnalysisProjection::new()
   // Reconciliation trace accumulator. Populated on every reconcile pass;
   // the caller reads `trace_ref.val` after projection changes.

--- a/lang/lambda/companion/moon.pkg
+++ b/lang/lambda/companion/moon.pkg
@@ -8,6 +8,7 @@ import {
   "dowdiness/canopy/lang/lambda/semantic" @lambda_semantic,
   "dowdiness/canopy/editor",
   "dowdiness/canopy/protocol",
+  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/lambda" @parser,
   "dowdiness/lambda/ast",

--- a/lang/lambda/companion/semantic_overlay_wbtest.mbt
+++ b/lang/lambda/companion/semantic_overlay_wbtest.mbt
@@ -1,6 +1,6 @@
 ///|
 test "semantic overlay annotations appear in lambda view tree" {
-  let editor = new_lambda_editor("semantic-overlay-view").0
+  let editor = (try! new_lambda_editor("semantic-overlay-view")).0
   editor.set_text("(x) => x")
   let view = editor.get_view_tree()
   guard view is Some(root)

--- a/lang/lambda/companion/tree_edit_bridge_test.mbt
+++ b/lang/lambda/companion/tree_edit_bridge_test.mbt
@@ -5,7 +5,7 @@
 fn setup_bridge(
   text : String,
 ) -> (@editor.SyncEditor[@ast.Term], LambdaCompanion) {
-  let (editor, companion) = new_lambda_editor("test")
+  let (editor, companion) = try! new_lambda_editor("test")
   editor.set_text(text)
   (editor, companion)
 }

--- a/lang/markdown/companion/edit_messages_wbtest.mbt
+++ b/lang/markdown/companion/edit_messages_wbtest.mbt
@@ -8,7 +8,7 @@ test "apply_markdown_edit pin: merge on first block -> silent no-op" {
   // compute_markdown_edit returns Ok(None) for MergeWithPrevious on the
   // first sibling; markdown's on_no_edit maps that to Ok(()) with the
   // document untouched (unlike JSON, which reports an unhandled-op error).
-  let ed = new_markdown_editor("pin")
+  let ed = try! new_markdown_editor("pin")
   ed.set_text("Hello\n\nWorld\n")
   guard ed.get_proj_node() is Some(p) && p.children is [first, ..] else {
     fail("expected projection with children")
@@ -34,12 +34,12 @@ test "apply_markdown_edit pin: merge on first block -> silent no-op" {
 ///|
 test "apply_markdown_edit pin: absent node id -> compute error" {
   // High child id from a donor doc with more blocks than the target has.
-  let donor = new_markdown_editor("donor")
+  let donor = try! new_markdown_editor("donor")
   donor.set_text("A\n\nB\n\nC\n\nD\n")
   guard donor.get_proj_node() is Some(p) && p.children is [.., last] else {
     fail("donor: expected projection with children")
   }
-  let ed = new_markdown_editor("target")
+  let ed = try! new_markdown_editor("target")
   ed.set_text("Hello\n")
   match
     apply_markdown_edit(

--- a/lang/markdown/companion/integration_wbtest.mbt
+++ b/lang/markdown/companion/integration_wbtest.mbt
@@ -5,7 +5,7 @@ using @md_edits {type MarkdownEditOp}
 
 ///|
 test "round-trip: new_markdown_editor + apply_markdown_edit" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("# Hello\n\nWorld\n")
   // Force a reparse/projection cycle
   let state = @editor.ViewUpdateState::ViewUpdateState()
@@ -24,7 +24,7 @@ test "round-trip: new_markdown_editor + apply_markdown_edit" {
 
 ///|
 test "generic view path preserves ordered list kind" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("1. one\n2. two\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let patches = @editor.compute_view_patches(state, ed)
@@ -37,7 +37,7 @@ test "generic view path preserves ordered list kind" {
 
 ///|
 test "move_block: unordered list item move preserves identity" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("- A\n- B\n- C\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)
@@ -61,7 +61,7 @@ test "move_block: unordered list item move preserves identity" {
 
 ///|
 test "move_block: ordered list item move preserves identity across renumbering" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("1. A\n2. B\n3. C\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)
@@ -85,7 +85,7 @@ test "move_block: ordered list item move preserves identity across renumbering" 
 
 ///|
 test "split_block: middle of paragraph" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("Hello World\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)
@@ -105,7 +105,7 @@ test "split_block: middle of paragraph" {
 
 ///|
 test "split_block: offset 0 inserts before" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("# Title\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)
@@ -123,7 +123,7 @@ test "split_block: offset 0 inserts before" {
 
 ///|
 test "split_block: end of block inserts after" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("Hello\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)
@@ -140,7 +140,7 @@ test "split_block: end of block inserts after" {
 
 ///|
 test "insert_block_after: ZWSP present in raw text, absent in export" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("Hello\n")
   // Force projection cycle
   let state = @editor.ViewUpdateState::ViewUpdateState()
@@ -163,7 +163,7 @@ test "insert_block_after: ZWSP present in raw text, absent in export" {
 
 ///|
 test "export preserves legitimate ZWSP in user content" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   // Simulate user content with ZWSP inside text (e.g., pasted from another tool)
   ed.set_text("Hello\u200Bworld\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
@@ -178,7 +178,7 @@ test "export preserves legitimate ZWSP in user content" {
 /// must round-trip unchanged. The previous blind `replace_all("\n\u200B\n",
 /// "\n\n")` mangled this case.
 test "export preserves ZWSP-only line inside a code block" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("```\nfoo\n\u200B\nbar\n```\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)
@@ -191,7 +191,7 @@ test "export preserves ZWSP-only line inside a code block" {
 
 ///|
 test "merge cleans up ZWSP from empty block" {
-  let ed = new_markdown_editor("test")
+  let ed = try! new_markdown_editor("test")
   ed.set_text("Hello\n")
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let _ = @editor.compute_view_patches(state, ed)

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -4,11 +4,12 @@
 
 ///|
 /// Construct a SyncEditor[@markdown.Block] using the standard 3-memo pipeline.
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
 pub fn new_markdown_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> @editor.SyncEditor[@markdown.Block] {
+) -> @editor.SyncEditor[@markdown.Block] raise @text.TextError {
   let hints_ref : Ref[Array[@core.IdentityTransform]] = Ref([])
   @editor.SyncEditor::new_generic(
     agent_id,

--- a/lang/markdown/companion/moon.pkg
+++ b/lang/markdown/companion/moon.pkg
@@ -4,6 +4,7 @@ import {
   "dowdiness/canopy/lang/markdown/edits" @md_edits,
   "dowdiness/canopy/lang/markdown/proj" @md_proj,
   "dowdiness/canopy/lang/markdown/sentinel" @md_sentinel,
+  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/markdown",
   "dowdiness/loom",

--- a/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
+++ b/lang/markdown/companion/sdeg_edit_path_wbtest.mbt
@@ -55,7 +55,7 @@ fn first_heading_edit_path_observation(
 
 ///|
 test "sdeg phase0: heading rename goes through Markdown edit path" {
-  let editor = new_markdown_editor("sdeg-edit-path")
+  let editor = try! new_markdown_editor("sdeg-edit-path")
   editor.set_text("# Alpha\n\nBody\n")
   editor.refresh()
   let before = first_heading_edit_path_observation(editor)
@@ -80,7 +80,7 @@ test "sdeg phase0: heading rename goes through Markdown edit path" {
 
 ///|
 test "sdeg phase0: markdown edit path swap is replacement, not reorder provenance" {
-  let editor = new_markdown_editor("sdeg-edit-path-reorder")
+  let editor = try! new_markdown_editor("sdeg-edit-path-reorder")
   editor.set_text("# A\n# B\n")
   editor.refresh()
   let before = heading_edit_path_observations(editor)
@@ -120,7 +120,7 @@ test "sdeg phase0: markdown edit path swap is replacement, not reorder provenanc
 
 ///|
 test "sdeg spike: explicit markdown block move preserves moved heading identity" {
-  let editor = new_markdown_editor("sdeg-edit-path-explicit-move")
+  let editor = try! new_markdown_editor("sdeg-edit-path-explicit-move")
   editor.set_text("# A\n# B\n")
   editor.refresh()
   let before = heading_edit_path_observations(editor)
@@ -149,7 +149,7 @@ test "sdeg spike: explicit markdown block move preserves moved heading identity"
 
 ///|
 test "sdeg phase0: heading level change through edit path has fresh NodeId" {
-  let editor = new_markdown_editor("sdeg-edit-path-level")
+  let editor = try! new_markdown_editor("sdeg-edit-path-level")
   editor.set_text("# Alpha\n\nBody\n")
   editor.refresh()
   let before = first_heading_edit_path_observation(editor)

--- a/lang/runtime/language_spec.mbt
+++ b/lang/runtime/language_spec.mbt
@@ -51,6 +51,7 @@ pub fn[T, Op] LanguageSpec::LanguageSpec(
 
 ///|
 /// Construct a SyncEditor from this spec (standard 3-memo pipeline).
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
 /// Per-instance capabilities (e.g. lambda's eval/semantic closures capturing
 /// instance memos) are passed here, not stored in the spec.
 pub fn[T, Op] LanguageSpec::new_editor(
@@ -59,7 +60,7 @@ pub fn[T, Op] LanguageSpec::new_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
   capabilities? : @editor.LanguageCapabilities[T] = @editor.LanguageCapabilities::default(),
-) -> @editor.SyncEditor[T] {
+) -> @editor.SyncEditor[T] raise @text.TextError {
   @editor.SyncEditor::new_generic(
     agent_id,
     self.make_parser,

--- a/lang/runtime/moon.pkg
+++ b/lang/runtime/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
+  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/loom",
 }

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -400,7 +400,7 @@ fn QueryCase::to_stable_witness(self : QueryCase) -> QueryCase {
     let current_score = current.shrink_score()
     let mut next_case : QueryCase? = None
     let mut next_score = current_score
-    for candidate in QueryCase::shrink(current) {
+    for candidate in @qc.Shrink::shrink(current) {
       if candidate.is_minimal_witness() {
         return candidate
       }

--- a/moon.mod
+++ b/moon.mod
@@ -7,7 +7,7 @@ import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
   "dowdiness/incr@0.14.2",
-  "dowdiness/event-graph-walker@0.3.0",
+  "dowdiness/event-graph-walker@0.5.0",
   "dowdiness/byte_codec@0.1.0",
   "dowdiness/text_change@0.1.0",
   "dowdiness/moji@0.1.0",

--- a/sync_session/moon.pkg
+++ b/sync_session/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/protocol/wire",
   "dowdiness/event-graph-walker/text",
+  "dowdiness/event-graph-walker/sync",
   "dowdiness/byte_codec",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",

--- a/sync_session/payloads.mbt
+++ b/sync_session/payloads.mbt
@@ -57,9 +57,7 @@ fn parse_sync_response_payload(
 ///|
 fn should_retry_sync_error(err : Error) -> Bool {
   match err {
-    @text.TextError::SyncFailed(@text.SyncFailure::MissingDependency(..)) =>
-      true
-    @text.TextError::SyncFailed(@text.SyncFailure::Timeout(..)) => true
+    @text.TextError::SyncFailed(@sync.Failure::MissingDependency(..)) => true
     @text.TextError::VersionNotFound => true
     _ => false
   }

--- a/sync_session/recovery_wbtest.mbt
+++ b/sync_session/recovery_wbtest.mbt
@@ -2,7 +2,8 @@
 
 ///|
 fn make_empty_sync_message() -> @text.SyncMessage raise {
-  @text.SyncMessage::from_json_string("{\"runs\":[],\"heads\":[]}")
+  let doc = @text.TextState::new("recovery-message-fixture")
+  doc.sync().export_all()
 }
 
 ///|

--- a/sync_session/session_wbtest.mbt
+++ b/sync_session/session_wbtest.mbt
@@ -8,16 +8,15 @@
 ///|
 /// Test helper: construct an empty SyncMessage or fail the current test.
 fn empty_msg_or_fail() -> @text.SyncMessage raise {
-  @text.SyncMessage::from_json_string("{\"runs\":[],\"heads\":[]}") catch {
-    _ => fail("failed to construct empty SyncMessage fixture")
-  }
+  let doc = @text.TextState::new("empty-message-fixture")
+  doc.sync().export_all()
 }
 
 ///|
 /// Fake IO: records sent frames, serves a fresh empty version.
 fn test_io(sent : Array[Bytes]) -> SyncIo {
   SyncIo(send=data => sent.push(data), current_version=() => {
-    @text.TextState::new("io-peer").version()
+    try! @text.TextState::new("io-peer").version()
   })
 }
 
@@ -34,6 +33,47 @@ fn test_host(sent : Array[Bytes], left : Array[String]) -> SyncHost {
     apply_ephemeral=(_, _) => (),
     encode_ephemeral=_ => Bytes::new(0),
     on_peer_leave=peer_id => left.push(peer_id),
+  )
+}
+
+// Retry classification
+
+///|
+test "SyncSession: retries only causal dependency failures" {
+  debug_inspect(
+    [
+      should_retry_sync_error(
+        @text.TextError::SyncFailed(
+          @sync.Failure::MissingDependency(replica_id="peer", sequence=1),
+        ),
+      ),
+      should_retry_sync_error(@text.TextError::VersionNotFound),
+      should_retry_sync_error(
+        @text.TextError::SyncFailed(
+          @sync.Failure::MalformedMessage(detail="bad envelope"),
+        ),
+      ),
+      should_retry_sync_error(
+        @text.TextError::SyncFailed(
+          @sync.Failure::InvalidContent(detail="bad content"),
+        ),
+      ),
+      should_retry_sync_error(
+        @text.TextError::SyncFailed(
+          @sync.Failure::ConflictingIdentity(replica_id="peer", sequence=1),
+        ),
+      ),
+      should_retry_sync_error(
+        @text.TextError::SyncFailed(
+          @sync.Failure::LimitExceeded(
+            kind=@sync.LimitKind::PendingOperations,
+            limit=1,
+            actual=2,
+          ),
+        ),
+      ),
+    ],
+    content="[true, true, false, false, false, false]",
   )
 }
 
@@ -74,7 +114,7 @@ test "SyncSession: RelayedCrdtOps buffers during recovery" {
   session.recovery = Some(RecoveryContext::new("alice", empty_msg, 1))
   // Send RelayedCrdtOps from "alice" — should be buffered, not applied
   let buf = Buffer()
-  buf.write_string_utf16le("{\"runs\":[],\"heads\":[]}".view())
+  buf.write_string_utf16le(empty_msg.to_json_string().view())
   let wire = @wire.encode_relayed_crdt_ops("alice", buf.to_bytes())
   session.on_message(wire, test_host([], []))
   // Message should be buffered

--- a/workspace/probe/identity_probe_wbtest.mbt
+++ b/workspace/probe/identity_probe_wbtest.mbt
@@ -31,21 +31,32 @@ test "A1: shared peer_id — broadcast is skipped" {
 }
 
 ///|
-/// A2 (CRDT op-ID dedup): When two editors share agent_id and both create
-/// local ops at (shared_agent, seq=0), feeding A's export into B causes
-/// the duplicate RawVersion to be silently dropped (oplog.mbt:327-330).
-/// B's snapshot therefore still reflects only its own first op.
-test "A2: shared agent_id — duplicate RawVersion is silently dropped" {
+/// A2 (CRDT identity conflict): When two editors share agent_id and create
+/// different payloads for overlapping operation identities, feeding A's export
+/// into B is rejected. B's snapshot remains unchanged.
+test "A2: shared agent_id — conflicting RawVersion is rejected" {
   let editor_a = @json_companion.new_json_editor("shared_agent")
   let editor_b = @json_companion.new_json_editor("shared_agent")
   // B gets a local op at (shared_agent, seq 0) first
   try! editor_b.insert("[1]")
-  // A also gets a local op at (shared_agent, seq 0)
+  // A also gets a different local op at (shared_agent, seq 0)
   try! editor_a.insert("[9]")
   // Bypass the transport: directly feed A's entire history to B
-  try! editor_b.apply_sync(try! editor_a.export_all())
-  // Inspect B's snapshot: op_count must remain 3 — A's seq 0 was dropped.
-  // (Each character in "[1]" is one CRDT op: 3 ops total for the 3-char string.)
+  let conflict_detected = try {
+    editor_b.apply_sync(try! editor_a.export_all())
+    false
+  } catch {
+    @text.TextError::SyncFailed(
+      @sync.Failure::ConflictingIdentity(replica_id~, sequence~)
+    ) => {
+      inspect(replica_id, content="shared_agent")
+      inspect(sequence, content="1")
+      true
+    }
+    _ => false
+  }
+  inspect(conflict_detected, content="true")
+  // The rejected message does not alter B's three local character operations.
   let snap = editor_b.causal_snapshot()
   inspect(snap.op_count(), content="3")
   let entry = snap.entry(0).unwrap()

--- a/workspace/probe/moon.pkg
+++ b/workspace/probe/moon.pkg
@@ -14,6 +14,8 @@ import {
   "dowdiness/canopy/protocol",
   "dowdiness/canopy/lang/json/companion" @json_companion,
   "dowdiness/canopy/lang/lambda/edits" @lambda_edits,
+  "dowdiness/event-graph-walker/text",
+  "dowdiness/event-graph-walker/sync",
   "dowdiness/incr",
   "dowdiness/json" @_json_lang,
   "dowdiness/lambda/ast",

--- a/workspace/probe/moon.pkg
+++ b/workspace/probe/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/core",
+  "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/loom",
   "dowdiness/loom/core" @loomcore,

--- a/workspace/probe/test_grammar.mbt
+++ b/workspace/probe/test_grammar.mbt
@@ -292,11 +292,12 @@ fn build_test_projection_memos(
 ///|
 /// Construct a language-agnostic editor over the neutral TestExpr grammar,
 /// with all-None capabilities (no eval / decorations / annotations).
+/// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
 pub fn new_test_editor(
   agent_id : String,
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
-) -> @editor.SyncEditor[TestExpr] {
+) -> @editor.SyncEditor[TestExpr] raise @text.TextError {
   @editor.SyncEditor::new_generic(
     agent_id,
     fn(s, rt) { @loom.new_parser(s, test_grammar, runtime?=rt) },


### PR DESCRIPTION
## Summary

- align Canopy, the ideal and block-editor examples, and the Loom submodule on the published `dowdiness/event-graph-walker@0.5.0` release
- adapt the existing editor and `sync_session` boundaries to v0.5 construction, `SyncReport`, shared failure, `Range`, and length-prefixed `TreeNodeId` APIs without changing Tier 1 public interfaces
- propagate constructor `TextError` values through library APIs and handle them explicitly at CLI/FFI boundaries; production `try!` usage is eliminated
- update canonical sync fixtures and browser delta detection, preserving EGW ownership of causal pending operations and Canopy ownership of watchdog/retry envelopes

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `TextState::sync`, `SyncSession::apply`, `export_all`, `export_since` | EGW `text` | Yes | Keeps EGW as the sole document and causal-pending authority. |
| `SyncReport::pending_operations` | EGW `text` | Yes | Normalizes pending causal work at the legacy `SyncHost.apply_sync : Unit raise` seam. |
| `@sync.Failure` | EGW `sync` | Yes | Classifies missing/version failures as retryable and malformed/invalid/conflicting/limit failures as terminal. |
| `TreeNodeId::TreeNodeId`, `key`, `replica_id`, `sequence` | EGW `container` | Yes | Replaces removed free helpers and preserves the v0.5 length-prefixed key format. |
| `@text.TextError` | EGW `text` | Yes | Propagates invalid replica identifiers through editor/language constructors without a fallback identity or new error type. |
| `Result` plus `Ok(raising_expression) catch { ... }` | MoonBit core | Yes | Shares post-apply reconciliation while preserving the concrete `TextError`. |
| `StringView::split_once`, slicing, and `@strconv.from_str` | MoonBit core | Yes | Parses v0.5 tree-node keys without a manual digit loop or intermediate array. |

New helpers added (if any):

None. The migration updates existing boundaries and uses owning-type/core APIs.

## Test plan

- [x] `moon check` / strict check passes
- [x] workspace and release tests pass
- [x] `git diff *.mbti` reviewed; no generated or Tier 1 API drift
- [x] JS artifacts rebuilt
- [x] ideal and block-editor standalone module checks pass
- [x] ideal two-browser collaboration E2E passes
- [x] committed resolver identity check passes
- [x] all 330 tracked Canopy-owned production MoonBit files contain zero `try!` occurrences

## Validation

```bash
./scripts/check-strict.sh
./scripts/check-moonbit-pkg-compat.sh
./scripts/check-test-baseline.sh 7 moon test --release
moon build --release
moon info -p dowdiness/canopy
./scripts/build-js.sh

./scripts/check-test-baseline.sh 7 ./scripts/run-moon-module.sh ci-lenient event-graph-walker
./scripts/check-test-baseline.sh 7 ./scripts/run-moon-module.sh ci-lenient loom/loom
./scripts/check-test-baseline.sh 7 ./scripts/run-moon-module.sh ci-lenient examples/ideal
./scripts/check-test-baseline.sh 7 ./scripts/run-moon-module.sh ci-lenient examples/block-editor

cd examples/ideal/web
CANOPY_SKIP_MOON_BUILD=1 npx playwright test e2e/collaboration.spec.ts --reporter=line

cd ../../..
./scripts/check-egw-resolver-identity.sh
```

Results:

- workspace tests: 3,873 wasm-gc; 1,945 JS; 70 native
- targeted tests: editor 203, ffi/lambda 56, ffi/json 13, ffi/markdown 11, language companions 143
- previously verified targeted JS suites: protocol/wire 20, sync_session 27, relay 46, ephemeral 81
- ideal collaboration E2E: 5/5
- release baseline: 0 failures, 0 non-vendored failures
- generated `.mbti` drift: none
- resolver identity: all five manifests and the EGW/Loom pins agree on 0.5.0

## Notes

- `peer_sync` consumption and payload-opaque runtime extraction remain deferred to the next collaboration slice.
- Editor and language constructors now propagate the concrete `TextError`; exported FFI constructors preserve their `Int` signatures, log invalid identifiers, and return `-1` before coordinator registration.
