### PR TITLE
Clear Canopy-owned mechanical MoonBit warnings

### DIFF
--- a/core/reconcile.mbt
+++ b/core/reconcile.mbt
@@ -83,7 +83,7 @@ pub fn[T : TreeNode + Renderable] reconcile_hinted(
     // to fresh ids rather than leaving the preserved id on the new wrapper.
     Unlocatable => assign_fresh_ids(new, counter)
     NoStructuralHint =>
-      if T::same_kind(old.kind, new.kind) {
+      if @loomcore.TreeNode::same_kind(old.kind, new.kind) {
         let reconciled_children = reconcile_children(
           old.children,
           new.children,
@@ -121,7 +121,7 @@ fn[T : TreeNode + Renderable] reconcile_children(
     Array::makei(old_len, oi => lcs_excluded(hints, old_children[oi].id()))
   }
   let lcs_match = fn(oi : Int, nj : Int) -> Bool {
-    T::same_kind(old_children[oi].kind, new_children[nj].kind) &&
+    @loomcore.TreeNode::same_kind(old_children[oi].kind, new_children[nj].kind) &&
     (excluded_old.length() == 0 || excluded_old[oi] == false)
   }
   // Each row must be a fresh array — use makei (called per row), not
@@ -186,7 +186,7 @@ fn[T : TreeNode + Renderable] reconcile_children(
             new_matched[k],
             k,
             reconciled.id(),
-            T::kind_tag(reconciled.kind),
+            @loomcore.Renderable::kind_tag(reconciled.kind),
           ),
         )
         reconciled
@@ -194,7 +194,12 @@ fn[T : TreeNode + Renderable] reconcile_children(
         let fresh = assign_fresh_ids(new_children[k], counter)
         emit_trace(
           trace_ref,
-          Inserted(parent_id, k, fresh.id(), T::kind_tag(fresh.kind)),
+          Inserted(
+            parent_id,
+            k,
+            fresh.id(),
+            @loomcore.Renderable::kind_tag(fresh.kind),
+          ),
         )
         fresh
       } else {
@@ -212,7 +217,13 @@ fn[T : TreeNode + Renderable] reconcile_children(
           Some(node) => {
             emit_trace(
               trace_ref,
-              Matched(parent_id, -1, k, node.id(), T::kind_tag(node.kind)),
+              Matched(
+                parent_id,
+                -1,
+                k,
+                node.id(),
+                @loomcore.Renderable::kind_tag(node.kind),
+              ),
             )
             node
           }
@@ -220,7 +231,12 @@ fn[T : TreeNode + Renderable] reconcile_children(
             let fresh = assign_fresh_ids(new_children[k], counter)
             emit_trace(
               trace_ref,
-              Inserted(parent_id, k, fresh.id(), T::kind_tag(fresh.kind)),
+              Inserted(
+                parent_id,
+                k,
+                fresh.id(),
+                @loomcore.Renderable::kind_tag(fresh.kind),
+              ),
             )
             fresh
           }
@@ -236,7 +252,7 @@ fn[T : TreeNode + Renderable] reconcile_children(
           parent_id,
           oi,
           old_children[oi].id(),
-          T::kind_tag(old_children[oi].kind),
+          @loomcore.Renderable::kind_tag(old_children[oi].kind),
         ),
       )
     }
@@ -297,7 +313,10 @@ fn[T : TreeNode + Renderable] reconcile_children_exact(
   let new_len = new_children.length()
   let match_base_score = old_len.min(new_len) + 1
   let match_score = fn(oi : Int, nj : Int) -> Int {
-    if !T::same_kind(old_children[oi].kind, new_children[nj].kind) {
+    if !@loomcore.TreeNode::same_kind(
+        old_children[oi].kind,
+        new_children[nj].kind,
+      ) {
       0
     } else if old_fingerprints[old_children[oi].id()] ==
       new_fingerprints[new_children[nj].id()] {
@@ -359,7 +378,7 @@ fn[T : TreeNode + Renderable] reconcile_children_exact(
             new_matched[k],
             k,
             reconciled.id(),
-            T::kind_tag(reconciled.kind),
+            @loomcore.Renderable::kind_tag(reconciled.kind),
           ),
         )
         reconciled
@@ -367,7 +386,12 @@ fn[T : TreeNode + Renderable] reconcile_children_exact(
         let fresh = assign_fresh_ids(new_children[k], counter)
         emit_trace(
           trace_ref,
-          Inserted(parent_id, k, fresh.id(), T::kind_tag(fresh.kind)),
+          Inserted(
+            parent_id,
+            k,
+            fresh.id(),
+            @loomcore.Renderable::kind_tag(fresh.kind),
+          ),
         )
         fresh
       }
@@ -381,7 +405,7 @@ fn[T : TreeNode + Renderable] reconcile_children_exact(
           parent_id,
           oi,
           old_children[oi].id(),
-          T::kind_tag(old_children[oi].kind),
+          @loomcore.Renderable::kind_tag(old_children[oi].kind),
         ),
       )
     }
@@ -398,7 +422,7 @@ fn[T : TreeNode + Renderable] reconcile_exact(
   new_fingerprints : Map[NodeId, Int],
   trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T] {
-  if T::same_kind(old.kind, new.kind) {
+  if @loomcore.TreeNode::same_kind(old.kind, new.kind) {
     let reconciled_children = reconcile_children_exact(
       old.children,
       new.children,
@@ -444,7 +468,11 @@ fn[T : TreeNode + Renderable] structural_pair(
         Some(node) => {
           emit_trace(
             trace_ref,
-            Wrapped(old.id(), node.id(), T::kind_tag(node.kind)),
+            Wrapped(
+              old.id(),
+              node.id(),
+              @loomcore.Renderable::kind_tag(node.kind),
+            ),
           )
           Applied(node)
         }
@@ -455,7 +483,11 @@ fn[T : TreeNode + Renderable] structural_pair(
         Some(node) => {
           emit_trace(
             trace_ref,
-            Unwrapped(old.id(), node.id(), T::kind_tag(old.kind)),
+            Unwrapped(
+              old.id(),
+              node.id(),
+              @loomcore.Renderable::kind_tag(old.kind),
+            ),
           )
           Applied(node)
         }
@@ -577,7 +609,10 @@ fn[T : TreeNode + Renderable] apply_wrap(
   trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
 ) -> ProjNode[T]? {
   let targets = [
-    for idx, c in wrapper.children if T::same_kind(c.kind, old.kind) => idx
+    for idx, c in wrapper.children if @loomcore.TreeNode::same_kind(
+      c.kind,
+      old.kind,
+    ) => idx
   ]
   match targets {
     [target] => {

--- a/examples/block-editor/main/block_init.mbt
+++ b/examples/block-editor/main/block_init.mbt
@@ -40,9 +40,7 @@ fn parse_block_id(s : String) -> @container.TreeNodeId {
     return @container.root_id
   }
   guard rest[agent_length] == ':' else { return @container.root_id }
-  let agent = rest[:agent_length].to_owned() catch {
-    _ => return @container.root_id
-  }
+  let agent = rest[:agent_length].to_owned()
   let sequence : Int = @strconv.from_str(rest[agent_length + 1:]) catch {
     _ => return @container.root_id
   }

--- a/ffi/jsx/generative_ui_async_driver.mbt
+++ b/ffi/jsx/generative_ui_async_driver.mbt
@@ -203,10 +203,10 @@ fn GenerativeUiAsyncDriver::GenerativeUiAsyncDriver(
 }
 
 ///|
-let async_driver_registry : Map[Int, GenerativeUiAsyncDriver] = {}
+let async_driver_registry : Map[Int, GenerativeUiAsyncDriver] = Map([])
 
 ///|
-let async_provider_registry : Map[Int, AsyncProviderPending] = {}
+let async_provider_registry : Map[Int, AsyncProviderPending] = Map([])
 
 ///|
 let next_async_driver_handle : Ref[Int] = Ref(1)
@@ -374,7 +374,7 @@ fn async_start_driver(
     @cognition.GenerativeUiTransition::Started(generation_id~) => generation_id
     _ => abort("async lifecycle did not start")
   }
-  let generation_ids : Map[Int, @cognition.GenerativeUiGenerationId] = {}
+  let generation_ids : Map[Int, @cognition.GenerativeUiGenerationId] = Map([])
   generation_ids[generation_id.to_int()] = generation_id
   let driver = GenerativeUiAsyncDriver(
     session_handle,

--- a/ffi/jsx/session.mbt
+++ b/ffi/jsx/session.mbt
@@ -56,7 +56,7 @@ priv struct JsxSessionResultJson {
 ///|
 impl ToJson for JsxSessionResultJson with fn to_json(self) {
   let error_json = match self.error {
-    Some(error) => error.to_json()
+    Some(error) => ToJson::to_json(error)
     None => Json::null()
   }
   Json::object({
@@ -84,16 +84,14 @@ fn render_result_json(
     Some((code, message)) => Some(JsxSessionErrorJson::{ code, message })
     None => None
   }
-  JsxSessionResultJson::{
+  ToJson::to_json(JsxSessionResultJson::{
     schema_version: 1,
     success,
     revision,
     mounted_ids: mounted_ids.map(id => id.to_string()),
     diagnostics,
     error: error_json,
-  }
-  .to_json()
-  .stringify()
+  }).stringify()
 }
 
 ///|

--- a/ffi/lambda/canopy_test.mbt
+++ b/ffi/lambda/canopy_test.mbt
@@ -15,7 +15,8 @@ test "editor creation rejects an empty agent identifier before registration" {
 test "sync JSON fallback is a valid empty v0.5 envelope" {
   let all = @text.SyncMessage::from_json_string(export_all_json(-1))
   let since = @text.SyncMessage::from_json_string(export_since_json(-1, ""))
-  inspect((all.op_count(), since.op_count()), content="(0, 0)")
+  inspect(all.op_count(), content="0")
+  inspect(since.op_count(), content="0")
 }
 
 ///|

--- a/lang/lambda/alpha/alpha_key.mbt
+++ b/lang/lambda/alpha/alpha_key.mbt
@@ -46,34 +46,34 @@ impl Hash for AlphaKeyRepr with fn hash_combine(self, hasher) {
     }
     KLam(body) => {
       hasher.combine_int(3)
-      body.hash_combine(hasher)
+      Hash::hash_combine(body, hasher)
     }
     KApp(fn_key, arg_key) => {
       hasher.combine_int(4)
-      fn_key.hash_combine(hasher)
-      arg_key.hash_combine(hasher)
+      Hash::hash_combine(fn_key, hasher)
+      Hash::hash_combine(arg_key, hasher)
     }
     KBop(op, lhs_key, rhs_key) => {
       hasher.combine_int(5)
       hasher.combine_int(key_bop_index(op))
-      lhs_key.hash_combine(hasher)
-      rhs_key.hash_combine(hasher)
+      Hash::hash_combine(lhs_key, hasher)
+      Hash::hash_combine(rhs_key, hasher)
     }
     KIf(cond_key, then_key, else_key) => {
       hasher.combine_int(6)
-      cond_key.hash_combine(hasher)
-      then_key.hash_combine(hasher)
-      else_key.hash_combine(hasher)
+      Hash::hash_combine(cond_key, hasher)
+      Hash::hash_combine(then_key, hasher)
+      Hash::hash_combine(else_key, hasher)
     }
     KLetDef(init_key) => {
       hasher.combine_int(7)
-      init_key.hash_combine(hasher)
+      Hash::hash_combine(init_key, hasher)
     }
     KModule(def_keys, body_key) => {
       hasher.combine_int(8)
       hasher.combine_int(def_keys.length())
-      def_keys.iter().each(fn(def_key) { def_key.hash_combine(hasher) })
-      body_key.hash_combine(hasher)
+      def_keys.iter().each(fn(def_key) { Hash::hash_combine(def_key, hasher) })
+      Hash::hash_combine(body_key, hasher)
     }
     KError(message) => {
       hasher.combine_int(9)
@@ -88,7 +88,7 @@ impl Hash for AlphaKeyRepr with fn hash_combine(self, hasher) {
 
 ///|
 pub impl Hash for AlphaKey with fn hash_combine(self, hasher) {
-  self.repr.hash_combine(hasher)
+  Hash::hash_combine(self.repr, hasher)
 }
 
 ///|

--- a/lang/lambda/edits/text_edit.mbt
+++ b/lang/lambda/edits/text_edit.mbt
@@ -37,7 +37,7 @@ pub fn compute_text_edit(
   op : TreeEditOp,
   ctx : EditContext[@ast.Term],
 ) -> EditResult raise EditError {
-  ValidateNodeExists::{  }.apply(core_dispatch, op, ctx)
+  EditMiddleware::apply(ValidateNodeExists::{  }, core_dispatch, op, ctx)
 }
 
 ///|

--- a/workspace/probe/test_grammar.mbt
+++ b/workspace/probe/test_grammar.mbt
@@ -196,7 +196,7 @@ fn parse_test_expr(ctx : @loomcore.ParserContext[TestToken, TestKind]) -> Unit {
 
 ///|
 fn test_node_ident(node : @seam.SyntaxNode) -> String {
-  match node.direct_token_of_kind(IdentToken.to_raw()) {
+  match node.direct_token_of_kind(@seam.ToRawKind::to_raw(IdentToken)) {
     Some(tok) => tok.text()
     None => ""
   }


### PR DESCRIPTION
## Summary
- qualify deprecated trait calls with their owning traits
- make typed empty maps explicit
- remove a redundant `try` and preserve test assertions without deprecated tuple Show

## Scope
Excludes submodule warnings and the three Rabbita state-API UI migrations, which require separate component/browser validation.

## Validation
- `moon fmt`
- `moon check` (0 errors; only excluded submodule/UI warnings remain)
- `moon test --package ffi/lambda` (56 tests)
- targeted affected-package tests (3,873 tests)
- `moon info`
- `moon build --target js`
- `git diff --check`
- `moonbit-reviewer`: PASS