### PR TITLE
fix(sync): bind recovery responses to peer identity

### DIFF
--- a/sync_session/recovery.mbt
+++ b/sync_session/recovery.mbt
@@ -69,3 +69,13 @@ fn RecoveryContext::matches_request_id(
 ) -> Bool {
   self.request_id.to_string() == id
 }
+
+///|
+/// Match a relay-authenticated response to this peer-local recovery request.
+fn RecoveryContext::matches_response(
+  self : RecoveryContext,
+  sender : String,
+  request_id : String,
+) -> Bool {
+  self.peer_id == sender && self.matches_request_id(request_id)
+}

--- a/sync_session/recovery_wbtest.mbt
+++ b/sync_session/recovery_wbtest.mbt
@@ -69,3 +69,12 @@ test "RecoveryContext: matches_request_id" {
   inspect(ctx.matches_request_id("42"), content="true")
   inspect(ctx.matches_request_id("99"), content="false")
 }
+
+///|
+test "RecoveryContext: matches response sender and request ID" {
+  let msg = make_empty_sync_message()
+  let ctx = RecoveryContext::new("alice", msg, 42)
+  inspect(ctx.matches_response("alice", "42"), content="true")
+  inspect(ctx.matches_response("bob", "42"), content="false")
+  inspect(ctx.matches_response("alice", "99"), content="false")
+}

--- a/sync_session/session_wbtest.mbt
+++ b/sync_session/session_wbtest.mbt
@@ -140,6 +140,50 @@ test "SyncSession: SyncResponse with stale request_id is ignored" {
 }
 
 ///|
+test "SyncSession: SyncResponse from wrong sender is ignored" {
+  let session = SyncSession()
+  session.on_open()
+  let empty_msg = empty_msg_or_fail()
+  session.recovery_epoch = 1
+  session.recovery = Some(RecoveryContext::new("alice", empty_msg, 1))
+  session.set_status(Recovering(peer_id="alice", attempt=1))
+  let applied : Array[@text.SyncMessage] = []
+  let sent : Array[Bytes] = []
+  let host = SyncHost(
+    io=test_io(sent),
+    apply_sync=msg => applied.push(msg),
+    export_all=() => empty_msg_or_fail(),
+    export_since=_ => empty_msg_or_fail(),
+    apply_ephemeral=(_, _) => (),
+    encode_ephemeral=_ => Bytes::new(0),
+    on_peer_leave=_ => (),
+  )
+  // Relay delivery replaces the target with authenticated sender "bob".
+  // The request ID collides with the active request to "alice".
+  let wire = @wire.encode_sync_response(
+    target="bob",
+    request_id="1",
+    sync_json=empty_msg.to_json_string(),
+  )
+  session.on_message(wire, host)
+  inspect(applied.length(), content="0")
+  inspect(sent.length(), content="0")
+  inspect(session.recovery_epoch, content="1")
+  inspect(session.recovery is Some(_), content="true")
+  let recovery = session.recovery.unwrap()
+  inspect(recovery.peer_id, content="alice")
+  inspect(recovery.request_id, content="1")
+  inspect(recovery.retries, content="0")
+  inspect(recovery.deferred.length(), content="0")
+  inspect(
+    session.get_status(),
+    content=(
+      #|Recovering(peer_id="alice", attempt=1)
+    ),
+  )
+}
+
+///|
 test "SyncSession: SyncResponse with empty delta increments retries" {
   let session = SyncSession()
   let empty_msg = empty_msg_or_fail()

--- a/sync_session/sync_session.mbt
+++ b/sync_session/sync_session.mbt
@@ -250,16 +250,15 @@ pub fn SyncSession::on_message(
     }
     SyncResponse(payload) => {
       guard parse_sync_response_payload(payload)
-        is Ok((_sender, request_id, sync_json)) else {
+        is Ok((sender, request_id, sync_json)) else {
         return
       }
       guard self.recovery is Some(ctx) else { // Not recovering, ignore
         return
       }
-      // Stale response check
-      if !ctx.matches_request_id(request_id) {
-        return
-      }
+      // Request IDs are peer-local, so both authenticated sender and ID must
+      // match before this response can advance recovery.
+      guard ctx.matches_response(sender, request_id) else { return }
       // Empty response = responder can't help
       if sync_json == "" {
         self.handle_recovery_retry(host.io)


### PR DESCRIPTION
## Summary

- require both the relay-authenticated sender and the peer-local request ID to match the active recovery context before accepting a `SyncResponse`
- centralize that deterministic correlation in `RecoveryContext::matches_response`
- pin a colliding-request regression where recovery targets `alice` but a response from `bob` uses the same request ID

## Behavior preserved

- matching sender plus matching request ID continues through the existing response path
- stale request IDs from the correct sender remain ignored
- empty responses from the correct sender continue to advance bounded retry
- protocol v3 bytes and Tier 1 `protocol/wire` / `sync_session` signatures are unchanged
- EGW remains the sole owner of causal pending-operation storage and replay

## Reuse check

- reused `parse_sync_response_payload` for relay-authenticated sender and request ID decoding
- reused `RecoveryContext::matches_request_id` inside the new combined predicate
- reused MoonBit `String` equality, `Option`/`Result` guards, and `Array` test observations
- introduced one private pure helper whose sole responsibility is atomic sender-plus-request correlation
- no new loops, queues, wire fields, public types, or mutable production state

## Validation

- `NEW_MOON_MOD=0 moon check sync_session`
- `NEW_MOON_MOD=0 moon test sync_session` — 29/29
- `moon test --target js --release -p dowdiness/canopy/sync_session` — 29/29
- `./scripts/check-strict.sh`
- `./scripts/check-test-baseline.sh 7 moon test --release` — 0 failures
- `moon build --release`
- `NEW_MOON_MOD=0 moon info` — no `sync_session/pkg.generated.mbti` drift
- independent MoonBit review — PASS

Fixes #939
