### PR TITLE
Preserve setext headings in the Markdown block editor

### DIFF
--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -93,7 +93,7 @@ test.describe('Markdown Block Editor', () => {
 
   test('surface-only heading rewrite preserves the same block handle', async ({ page }) => {
     await switchMode(page, 'Raw');
-    await page.locator('#raw-editor').fill('# Title\n\n## Other\n');
+    await page.locator('#raw-editor').fill('  # Title\n\n## Other\n');
     await switchMode(page, 'Block');
 
     const titleBefore = page.locator('#block-container .block').filter({ hasText: 'Title' });

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -91,6 +91,37 @@ test.describe('Markdown Block Editor', () => {
     expect(afterCycle).toEqual(originalTexts);
   });
 
+  test('surface-only heading rewrite preserves the same block handle', async ({ page }) => {
+    await switchMode(page, 'Raw');
+    await page.locator('#raw-editor').fill('# Title\n\n## Other\n');
+    await switchMode(page, 'Block');
+
+    const titleBefore = page.locator('#block-container .block').filter({ hasText: 'Title' });
+    const otherBefore = page.locator('#block-container .block').filter({ hasText: 'Other' });
+    await expect(titleBefore).toHaveCount(1);
+    await expect(otherBefore).toHaveCount(1);
+    const titleId = await titleBefore.getAttribute('data-node-id');
+    const otherId = await otherBefore.getAttribute('data-node-id');
+    expect(titleId).not.toBeNull();
+    expect(otherId).not.toBeNull();
+
+    await switchMode(page, 'Raw');
+    await page.locator('#raw-editor').fill('Title\n=====\n\n## Other\n');
+    await switchMode(page, 'Block');
+
+    await switchMode(page, 'Preview');
+    await expect(page.locator('#preview-container h1', { hasText: 'Title' })).toHaveCount(1);
+    await expect(page.locator('#preview-container h2', { hasText: 'Other' })).toHaveCount(1);
+    await switchMode(page, 'Block');
+
+    const titleAfter = page.locator('#block-container .block').filter({ hasText: 'Title' });
+    const otherAfter = page.locator('#block-container .block').filter({ hasText: 'Other' });
+    await expect(titleAfter).toHaveCount(1);
+    await expect(otherAfter).toHaveCount(1);
+    await expect(titleAfter).toHaveAttribute('data-node-id', titleId!);
+    await expect(otherAfter).toHaveAttribute('data-node-id', otherId!);
+  });
+
   test('block mode preserves ordered list markers', async ({ page }) => {
     await switchMode(page, 'Raw');
     await page.locator('#raw-editor').fill('3. three\n4. four\n');

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -108,6 +108,8 @@ test.describe('Markdown Block Editor', () => {
     await switchMode(page, 'Raw');
     await page.locator('#raw-editor').fill('Title\n=====\n\n## Other\n');
     await switchMode(page, 'Block');
+    await switchMode(page, 'Raw');
+    await expect(page.locator('#raw-editor')).toHaveValue('Title\n=====\n\n## Other\n');
 
     await switchMode(page, 'Preview');
     await expect(page.locator('#preview-container h1', { hasText: 'Title' })).toHaveCount(1);

--- a/ffi/markdown/lifecycle_phase1_wbtest.mbt
+++ b/ffi/markdown/lifecycle_phase1_wbtest.mbt
@@ -157,6 +157,32 @@ test "workstream 2 (md): compute_view_patches initial render emits FullTree with
 }
 
 ///|
+test "markdown set_text keeps setext heading in view patches" {
+  reset_markdown_coordinator_for_phase1_tests()
+  let handle = create_markdown_editor("md_setext_heading_agent")
+  markdown_set_text(handle, "# Title\n\n## Other\n")
+  let _ = markdown_compute_view_patches_json(handle)
+  let target = "Title\n=====\n\n## Other\n"
+  markdown_set_text(handle, target)
+  assert_eq(markdown_get_text(handle), target)
+  let h = markdown_registry.get(handle).unwrap()
+  let projection = h.editor.get_proj_node().unwrap()
+  let projection_text = @debug.to_string(projection)
+  if !projection_text.contains("Title") || !projection_text.contains("Other") {
+    fail(
+      "expected current projection to retain both headings, got \{projection_text}",
+    )
+  }
+  let patches = markdown_compute_view_patches_json(handle)
+  if !patches.contains("Title") || !patches.contains("Other") {
+    fail(
+      "expected setext heading view patch to retain both headings, got \{patches}",
+    )
+  }
+  destroy_markdown_editor(handle)
+}
+
+///|
 test "workstream 2 (md): compute_view_patches preserves ordered list kind" {
   reset_markdown_coordinator_for_phase1_tests()
   let handle = create_markdown_editor("md_view_ordered_list_agent")

--- a/ffi/markdown/moon.pkg
+++ b/ffi/markdown/moon.pkg
@@ -12,6 +12,7 @@ import {
   "dowdiness/loom/core" @loom,
   "dowdiness/seam",
   "dowdiness/markdown" @md,
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -83,14 +83,30 @@ fn populate_block(
     }
     Heading(_, _) => {
       set_token_span(source_map, syntax_node, id, "marker", HeadingMarkerToken)
-      // Full inline content after the heading marker
-      set_content_span(
-        source_map,
-        syntax_node,
-        id,
-        "text",
-        Some(HeadingMarkerToken),
-      )
+      match
+        syntax_node.find_token(
+          @markdown.SyntaxKind::HeadingMarkerToken.to_raw(),
+        ) {
+        // ATX marker prefixes its inline content; setext underline follows it.
+        Some(marker) if marker.start() == syntax_node.start() =>
+          set_content_span(
+            source_map,
+            syntax_node,
+            id,
+            "text",
+            Some(HeadingMarkerToken),
+          )
+        Some(_) =>
+          set_content_span(
+            source_map,
+            syntax_node,
+            id,
+            "text",
+            None,
+            suffix_kind=Some(@markdown.SyntaxKind::HeadingMarkerToken),
+          )
+        None => ()
+      }
     }
     Paragraph(_) =>
       // Full inline content (no prefix to skip)

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -88,7 +88,9 @@ fn populate_block(
           @markdown.SyntaxKind::HeadingMarkerToken.to_raw(),
         ) {
         // ATX marker prefixes its inline content; setext underline follows it.
-        Some(marker) if marker.start() == syntax_node.start() =>
+        // Inspect the marker itself because an IndentationToken may precede an
+        // ATX marker inside the same HeadingNode.
+        Some(marker) if marker.text().trim_start().has_prefix("#") =>
           set_content_span(
             source_map,
             syntax_node,


### PR DESCRIPTION
## Summary
- derive setext heading text spans before their trailing underline marker
- keep setext headings editable in the Markdown ViewNode projection
- add FFI and browser regressions for ATX-to-setext rewrites

## Root cause
The projection treated every `HeadingMarkerToken` as an ATX prefix. For setext headings the marker is the trailing underline, so the text span became empty and BlockInput excluded the resulting non-editable node.

## Validation
- `moon check lang/markdown/proj`
- `moon test ffi/markdown --filter "markdown set_text keeps setext heading in view patches"`
- `npx tsc --noEmit`
- `npx playwright test tests/markdown-editor.spec.ts --grep "surface-only heading rewrite" --project=chromium`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Markdown headings when switching between Raw, Block, and Preview modes.
  - Preserved existing heading blocks and their content during heading-style rewrites.
  - Fixed setext-style headings so their text and formatting remain correctly represented in the editor and previews.

- **Tests**
  - Added coverage for heading preservation across editing-mode transitions.
  - Added validation for setext heading rendering and view updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->