### PR TITLE
Restore Markdown block selection across mode switches

### DIFF
--- a/adapters/editor-adapter/block-input.ts
+++ b/adapters/editor-adapter/block-input.ts
@@ -132,6 +132,11 @@ export class BlockInput implements EditorAdapter {
     return true;
   }
 
+  /** Clear transient block selection before replacing the document. */
+  clearSelection(): void {
+    this.deactivate();
+  }
+
   destroy(): void {
     this.deactivate();
     this.container.removeEventListener('click', this.onContainerClick);

--- a/adapters/editor-adapter/block-input.ts
+++ b/adapters/editor-adapter/block-input.ts
@@ -39,6 +39,13 @@ type FlattenedBlock = {
   listContext?: ListContext;
 };
 
+/** Ephemeral caret state for restoring a selected block after a mode switch. */
+export type BlockSelection = {
+  nodeId: number;
+  start: number;
+  end: number;
+};
+
 // ---------------------------------------------------------------------------
 // BlockInput
 // ---------------------------------------------------------------------------
@@ -99,6 +106,30 @@ export class BlockInput implements EditorAdapter {
 
   onIntent(callback: (intent: UserIntent) => void): void {
     this.intentCb = callback;
+  }
+
+  /** Return the active block and its textarea selection, if any. */
+  getSelection(): BlockSelection | null {
+    if (this.activeBlockId === null || this.textarea === null) return null;
+    return {
+      nodeId: this.activeBlockId,
+      start: this.textarea.selectionStart,
+      end: this.textarea.selectionEnd,
+    };
+  }
+
+  /** Restore a saved selection when its editable block still exists. */
+  restoreSelection(selection: BlockSelection): boolean {
+    const node = this.findNode(selection.nodeId);
+    if (!node?.editable) return false;
+
+    this.activateBlock(selection.nodeId);
+    const textarea = this.textarea;
+    if (!textarea) return false;
+    const start = Math.min(selection.start, textarea.value.length);
+    const end = Math.max(start, Math.min(selection.end, textarea.value.length));
+    textarea.setSelectionRange(start, end);
+    return true;
   }
 
   destroy(): void {

--- a/examples/web/src/features/markdown/browser/app.ts
+++ b/examples/web/src/features/markdown/browser/app.ts
@@ -1,7 +1,7 @@
 // Markdown Block Editor — three-mode page wiring FFI → adapters.
 
 import * as crdt from '@moonbit/crdt-markdown';
-import { BlockInput } from '@canopy/editor-adapter/block-input';
+import { BlockInput, type BlockSelection } from '@canopy/editor-adapter/block-input';
 import { MarkdownPreview } from '@canopy/editor-adapter/markdown-preview';
 import '@canopy/editor-adapter/block-input.css';
 import type { ViewPatch, UserIntent } from '@canopy/editor-adapter/types';
@@ -30,6 +30,7 @@ const handle = crdt.create_markdown_editor(agentId);
 
 let activeMode: Mode = 'block';
 let activeNodeId: number | null = null;
+let savedBlockSelection: BlockSelection | null = null;
 let rawSyncScheduled = false;
 let rawDirty = false;
 
@@ -187,6 +188,11 @@ rawEditor.addEventListener('input', () => {
 function setMode(mode: Mode): void {
   if (mode === activeMode) return;
 
+  if (activeMode === 'block') {
+    savedBlockSelection = blockInput.getSelection();
+    if (savedBlockSelection === null) activeNodeId = null;
+  }
+
   // Sync from current mode before switching — only if user edited in raw mode.
   // If they just viewed raw mode without editing, don't write back the
   // ZWSP-stripped display text (which would destroy empty block placeholders).
@@ -209,6 +215,11 @@ function setMode(mode: Mode): void {
     syncRawFromModel();
     rawDirty = false;
     rawEditor.focus();
+  } else if (mode === 'block' && savedBlockSelection !== null) {
+    if (!blockInput.restoreSelection(savedBlockSelection)) {
+      savedBlockSelection = null;
+      activeNodeId = null;
+    }
   }
 
   // Update tab styles

--- a/examples/web/src/features/markdown/browser/app.ts
+++ b/examples/web/src/features/markdown/browser/app.ts
@@ -318,9 +318,11 @@ document.addEventListener('keydown', (e) => {
 document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach(btn => {
   btn.addEventListener('click', () => {
     const text = btn.dataset.example ?? DEFAULT_TEXT;
+    blockInput.clearSelection();
     crdt.markdown_set_text(handle, text);
     syncRawFromModel();
     activeNodeId = null;
+    savedBlockSelection = null;
     refresh();
     updateToolbar();
   });

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -91,6 +91,29 @@ test.describe('Markdown Block Editor', () => {
     expect(afterCycle).toEqual(originalTexts);
   });
 
+  test('mode switching restores the selected block and caret range', async ({ page }) => {
+    await switchMode(page, 'Raw');
+    await page.locator('#raw-editor').fill('# Title\n\nParagraph\n');
+    await switchMode(page, 'Block');
+
+    await page.locator('#block-container .block').filter({ hasText: 'Title' }).click();
+    const textarea = page.locator('.block-textarea');
+    await expect(textarea).toHaveValue('Title');
+    await textarea.evaluate((element: HTMLTextAreaElement) => element.setSelectionRange(1, 4));
+
+    await switchMode(page, 'Raw');
+    await switchMode(page, 'Block');
+    await expect(textarea).toHaveValue('Title');
+    await expect(textarea).toHaveJSProperty('selectionStart', 1);
+    await expect(textarea).toHaveJSProperty('selectionEnd', 4);
+
+    await switchMode(page, 'Preview');
+    await switchMode(page, 'Block');
+    await expect(textarea).toHaveValue('Title');
+    await expect(textarea).toHaveJSProperty('selectionStart', 1);
+    await expect(textarea).toHaveJSProperty('selectionEnd', 4);
+  });
+
   test('surface-only heading rewrite preserves the same block handle', async ({ page }) => {
     await switchMode(page, 'Raw');
     await page.locator('#raw-editor').fill('  # Title\n\n## Other\n');
@@ -104,6 +127,10 @@ test.describe('Markdown Block Editor', () => {
     const otherId = await otherBefore.getAttribute('data-node-id');
     expect(titleId).not.toBeNull();
     expect(otherId).not.toBeNull();
+    await titleBefore.click();
+    const textarea = page.locator('.block-textarea');
+    await expect(textarea).toHaveValue('Title');
+    await textarea.evaluate((element: HTMLTextAreaElement) => element.setSelectionRange(1, 4));
 
     await switchMode(page, 'Raw');
     await page.locator('#raw-editor').fill('Title\n=====\n\n## Other\n');
@@ -122,6 +149,9 @@ test.describe('Markdown Block Editor', () => {
     await expect(otherAfter).toHaveCount(1);
     await expect(titleAfter).toHaveAttribute('data-node-id', titleId!);
     await expect(otherAfter).toHaveAttribute('data-node-id', otherId!);
+    await expect(textarea).toHaveValue('Title');
+    await expect(textarea).toHaveJSProperty('selectionStart', 1);
+    await expect(textarea).toHaveJSProperty('selectionEnd', 4);
   });
 
   test('block mode preserves ordered list markers', async ({ page }) => {

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -114,6 +114,20 @@ test.describe('Markdown Block Editor', () => {
     await expect(textarea).toHaveJSProperty('selectionEnd', 4);
   });
 
+  test('example replacement discards a saved block selection', async ({ page }) => {
+    await page.locator('#block-container .block').first().click();
+    const textarea = page.locator('.block-textarea');
+    await expect(textarea).toBeVisible();
+    await textarea.evaluate((element: HTMLTextAreaElement) => element.setSelectionRange(1, 3));
+
+    await switchMode(page, 'Preview');
+    await page.locator('button.example-btn:has-text("List")').click();
+    await switchMode(page, 'Block');
+
+    await expect(textarea).toHaveCount(0);
+    await expect(page.locator('#h1-btn')).toBeDisabled();
+  });
+
   test('surface-only heading rewrite preserves the same block handle', async ({ page }) => {
     await switchMode(page, 'Raw');
     await page.locator('#raw-editor').fill('  # Title\n\n## Other\n');


### PR DESCRIPTION
## Summary
- retain selected Markdown block and textarea range while Raw or Preview mode is active
- restore the selection when the current projected block still exists
- clear stale selection when the block no longer exists
- verify both ordinary mode cycles and ATX-to-setext rewrites

## Scope
This is browser-shell state only. It does not add semantic identity, modify CRDT/wire APIs, or change Loom. Current `NodeId` reconciliation is sufficient for the verified rewrite path.

## Validation
- `npx tsc --noEmit`
- `npx playwright test tests/markdown-editor.spec.ts --grep "mode switching restores the selected block|surface-only heading rewrite" --project=chromium`
- Full Markdown browser suite passed locally: `15 passed`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserves the active block and text selection when switching between Block, Raw, and Preview modes.
  * Restores caret positions safely when returning to Block mode.

* **Bug Fixes**
  * Clears stale selection state when replacing an example.
  * Maintains text selection during heading edits and mode transitions.

* **Tests**
  * Added coverage for selection restoration, clearing, and caret preservation across editor workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->