### PR TITLE
fix(core): make a hint with no applicable target inert

### DIFF
--- a/core/reconcile.mbt
+++ b/core/reconcile.mbt
@@ -110,15 +110,24 @@ fn[T : TreeNode + Renderable] reconcile_children(
 ) -> Array[ProjNode[T]] {
   let old_len = old_children.length()
   let new_len = new_children.length()
-  // Old children carrying a wrap/unwrap/replace/move hint are excluded from
-  // ordinary LCS matching: their identity is decided by the hint logic, so they
-  // must not be consumed by a same-kind match against the wrong new sibling
-  // first. Rename / insert / delete / opaque hints stay matchable (LCS already
-  // preserves those). Computed only when hints are present.
+  // Old children whose hint will decide their identity are excluded from
+  // ordinary LCS matching, so they are not consumed by a same-kind match
+  // against the wrong new sibling first. Exclusion is decided from hint
+  // APPLICABILITY, not hint presence: a Wrap/Unwrap hint that can land nowhere
+  // in `new_children` must not cost its node the match plain LCS would have
+  // given it. Computed only when hints are present.
+  //
+  // Cost: this scans every new sibling per hinted old sibling, and each
+  // `hint_pairs` scans that sibling's children. The DP below is already
+  // Θ(old_len × new_len), so this adds a child-count factor to a term that is
+  // there anyway — not a new order of growth. The per-keystroke path takes the
+  // empty-hints branch and pays none of it.
   let excluded_old : Array[Bool] = if hints.is_empty() {
     []
   } else {
-    Array::makei(old_len, oi => lcs_excluded(hints, old_children[oi].id()))
+    Array::makei(old_len, oi => {
+      lcs_excluded(old_children[oi], new_children, hints)
+    })
   }
   let lcs_match = fn(oi : Int, nj : Int) -> Bool {
     @loomcore.TreeNode::same_kind(old_children[oi].kind, new_children[nj].kind) &&
@@ -451,10 +460,15 @@ priv enum HintResult[T] {
 }
 
 ///|
-/// Consult the structural hint keyed by `old.id()`. A `Wrap`/`Unwrap` hint is
-/// authoritative: it either applies or forces a degrade-to-fresh. It never
-/// silently falls through to same-kind reconciliation (which would leave the
-/// preserved id on the new wrapper).
+/// Consult the structural hint keyed by `old.id()`. A `Wrap`/`Unwrap` hint that
+/// the new tree bears a trace of is authoritative: it either applies or forces a
+/// degrade-to-fresh, and does not fall through to same-kind reconciliation
+/// (which would leave the preserved id on the new wrapper).
+///
+/// A hint the new tree bears NO trace of is a different case, and falls through:
+/// it is evidence about an edit that this position does not show, so letting it
+/// veto ordinary matching would destroy identity plain LCS preserves. See
+/// `apply_wrap` for why "no trace" and "ambiguous" must not share an outcome.
 fn[T : TreeNode + Renderable] structural_pair(
   old : ProjNode[T],
   new : ProjNode[T],
@@ -465,7 +479,7 @@ fn[T : TreeNode + Renderable] structural_pair(
   match hints.get(old.id()) {
     Some(Wrap(_)) =>
       match apply_wrap(old, new, counter, hints, trace_ref~) {
-        Some(node) => {
+        Applied(node) => {
           emit_trace(
             trace_ref,
             Wrapped(
@@ -476,11 +490,11 @@ fn[T : TreeNode + Renderable] structural_pair(
           )
           Applied(node)
         }
-        None => Unlocatable
+        other => other
       }
     Some(Unwrap(keep~, ..)) =>
       match apply_unwrap(old, new, counter, hints, keep, trace_ref~) {
-        Some(node) => {
+        Applied(node) => {
           emit_trace(
             trace_ref,
             Unwrapped(
@@ -491,7 +505,7 @@ fn[T : TreeNode + Renderable] structural_pair(
           )
           Applied(node)
         }
-        None => Unlocatable
+        other => other
       }
     // Replace retires the old identity; Move's identity is editor-owned
     // (move_node) and not reconcilable here. Both freshen the node at this
@@ -503,17 +517,34 @@ fn[T : TreeNode + Renderable] structural_pair(
 
 ///|
 /// Whether an old child's hint means "do not let ordinary LCS assign this
-/// identity". Wrap/Unwrap/Replace/Move are handled by the hint logic; rename /
-/// insert / delete / opaque (and no hint) are left to LCS, which already honors
-/// them.
-fn lcs_excluded(hints : Map[NodeId, IdentityTransform], id : NodeId) -> Bool {
-  match hints.get(id) {
+/// identity".
+///
+/// `Replace` / `Move` are authoritative at any position — `structural_pair`
+/// retires or re-owns the identity whichever new sibling they meet — so they are
+/// withheld from LCS unconditionally, which also leaves match room for the other
+/// old children.
+///
+/// `Wrap` / `Unwrap` are withheld only when the hint can actually land in some
+/// new sibling. A hint whose transform the completed batch left no trace of says
+/// nothing about this position, and withholding on its say-so would cost the
+/// node the match plain LCS would have given it — the stale-hint defect.
+///
+/// Rename / insert / delete / opaque (and no hint) are left to LCS, which
+/// already honors them.
+fn[T : TreeNode] lcs_excluded(
+  old_child : ProjNode[T],
+  new_children : Array[ProjNode[T]],
+  hints : Map[NodeId, IdentityTransform],
+) -> Bool {
+  match hints.get(old_child.id()) {
+    Some(Replace(_)) | Some(Move(_)) => true
+    Some(Wrap(_)) | Some(Unwrap(..)) =>
+      new_children.iter().any(n => hint_pairs(old_child, n, hints))
     Some(RenameLeaf(_))
     | Some(InsertSubtree(..))
     | Some(DeleteSubtree(_))
     | Some(Opaque)
     | None => false
-    Some(_) => true
   }
 }
 
@@ -601,13 +632,27 @@ fn[T : TreeNode] hint_pairs(
 ///|
 /// Wrap: `wrapper` introduces a level over the prev subtree `old`. Carry `old`'s
 /// identity into the unique same-kind child; the wrapper itself is fresh.
+///
+/// The target count is the three-way answer, and the two failures are NOT the
+/// same failure:
+///
+/// - none: `wrapper` has no same-kind child, so it is not a wrapper OF `old` and
+///   the tree carries no trace of the wrap this hint describes. The hint is
+///   inert here and ordinary matching decides (`NoStructuralHint`).
+/// - one: the wrapped subtree is located; carry the identity (`Applied`).
+/// - several: `wrapper` may well be a wrapper of `old`, but which child holds it
+///   is not decidable. Degrading to fresh ids is required here (invariant T3) —
+///   falling through instead would leave `old`'s id on the wrapper itself.
+///
+/// That asymmetry is why inertness holds only for the none case; the scoped
+/// property and its counterexamples are pinned in reconcile_hints_wbtest.mbt.
 fn[T : TreeNode + Renderable] apply_wrap(
   old : ProjNode[T],
   wrapper : ProjNode[T],
   counter : Ref[Int],
   hints : Map[NodeId, IdentityTransform],
   trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
-) -> ProjNode[T]? {
+) -> HintResult[T] {
   let targets = [
     for idx, c in wrapper.children if @loomcore.TreeNode::same_kind(
       c.kind,
@@ -642,7 +687,7 @@ fn[T : TreeNode + Renderable] apply_wrap(
           }
         }
       ]
-      Some(
+      Applied(
         ProjNode(
           wrapper.kind,
           wrapper.start,
@@ -652,13 +697,25 @@ fn[T : TreeNode + Renderable] apply_wrap(
         ),
       )
     }
-    _ => None
+    [] => NoStructuralHint
+    _ => Unlocatable
   }
 }
 
 ///|
 /// Unwrap: the prev `wrapper` is removed and its child `keep` promoted to `new`.
 /// Carry `keep`'s identity into `new`; the wrapper id retires.
+///
+/// A `keep` this wrapper does not have is a hint about a subtree that is not
+/// here: it is inert, and ordinary matching decides. That absence is Unwrap's
+/// ONLY inapplicable case. In particular a `keep` whose kind differs from `new`
+/// is still applied, because the recursion is what interprets the difference —
+/// a nested hint on `keep` may legitimately consume it, which is how an
+/// unwrap-then-wrap batch retires the old wrapper id instead of preserving it.
+/// Requiring same-kind here would defeat that composition.
+///
+/// Unwrap has no ambiguous case — `find_child` resolves a single id — so it
+/// never yields `Unlocatable`.
 fn[T : TreeNode + Renderable] apply_unwrap(
   wrapper : ProjNode[T],
   new : ProjNode[T],
@@ -666,10 +723,10 @@ fn[T : TreeNode + Renderable] apply_unwrap(
   hints : Map[NodeId, IdentityTransform],
   keep : NodeId,
   trace_ref? : Ref[Array[ReconcileTraceEvent]]? = None,
-) -> ProjNode[T]? {
+) -> HintResult[T] {
   match find_child(wrapper, keep) {
-    Some(k) => Some(reconcile_hinted(k, new, counter, hints, trace_ref~))
-    None => None
+    Some(k) => Applied(reconcile_hinted(k, new, counter, hints, trace_ref~))
+    None => NoStructuralHint
   }
 }
 

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -484,3 +484,147 @@ test "composed unwrap-then-wrap retires the old wrapper id" {
   // and #5 rode the wrap into it
   inspect(result.children[0].node_id, content="5")
 }
+
+// ── Still violated: hints that ARE applicable somewhere ───────────────────
+//
+// The three pins below are NOT covered by the property above, and are recorded
+// so the remaining surface is visible rather than implied by its absence. Each
+// names its own cause. The first is a design decision (T3); the other two are
+// open defects of the same family as the one just fixed — a hint's presence
+// costing identity that plain LCS would have kept.
+
+///|
+/// Cause: T3, deliberately — but note the mechanism, which is NOT `apply_wrap`.
+/// Two candidate wrappers make `hint_pair_counts` return 2, so
+/// `try_unmatched_hint_pair` rejects the candidate and `structural_pair` is
+/// never reached. `apply_wrap`'s own ambiguity branch guards the same principle
+/// one level in (see the same-kind ambiguous-wrap test above, which does reach
+/// it). Making either inert would require leaving #5's id on a node that may
+/// really be its wrapper.
+test "STILL VIOLATED (by design, T3): an ambiguous Wrap hint is not inert" {
+  let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
+  // Unhinted, LCS carries #5 into the standalone Leaf. Hinted, #5 is withheld
+  // from LCS for two candidate wrappers and then paired with neither.
+  let plain = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let wa_leaf = ProjNode(Leaf("x"), 2, 3, 91, [])
+  let wa = ProjNode(Branch("w", [Leaf("x")]), 2, 4, 92, [wa_leaf])
+  let wb_leaf = ProjNode(Leaf("x"), 4, 5, 93, [])
+  let wb = ProjNode(Branch("w", [Leaf("x")]), 4, 6, 94, [wb_leaf])
+  let new_ = ProjNode(
+    Branch("root", [
+      Leaf("x"),
+      Branch("w", [Leaf("x")]),
+      Branch("w", [Leaf("x")]),
+    ]),
+    0,
+    7,
+    95,
+    [plain, wa, wb],
+  )
+  let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
+  inspect(hinted_result_is_inert(old, new_, hints), content="false")
+}
+
+///|
+/// Cause: domain mismatch across the LCS step. Exclusion asks "does this hint
+/// pair with ANY new child"; pairing afterwards asks "does it pair with an
+/// LCS-UNMATCHED new child". LCS runs in between and can consume the sole
+/// wrapper, leaving the withheld old child with nothing.
+///
+/// Fixing this means reserving hint partners globally BEFORE LCS, so that
+/// exclusion and pairing agree on one domain — a strictly larger change than
+/// the applicability gate, because the reservation must be unique in both
+/// directions and must then also remove the reserved NEW child from LCS.
+test "STILL VIOLATED: LCS can consume the sole wrapper a hint needed" {
+  let l5 = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let b6 = ProjNode(Branch("b", [Leaf("y")]), 1, 3, 6, [
+    ProjNode(Leaf("y"), 1, 2, 7, []),
+  ])
+  let old = ProjNode(
+    Branch("root", [Leaf("x"), Branch("b", [Leaf("y")])]),
+    0,
+    4,
+    1,
+    [l5, b6],
+  )
+  // The wrapper is same_kind as #6, so LCS pairs it with #6 first; #5 was
+  // withheld on that wrapper's account and now has no partner left.
+  let plain = ProjNode(Leaf("x"), 0, 1, 90, [])
+  let w_leaf = ProjNode(Leaf("x"), 2, 3, 91, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 2, 4, 92, [w_leaf])
+  let new_ = ProjNode(
+    Branch("root", [Leaf("x"), Branch("w", [Leaf("x")])]),
+    0,
+    5,
+    93,
+    [plain, wrapper],
+  )
+  let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
+  inspect(hinted_result_is_inert(old, new_, hints), content="false")
+}
+
+///|
+/// Cause: the same domain mismatch, stated as the caller hazard it actually is.
+/// This one is not measured against the unhinted path but against a SMALLER
+/// hint map: adding a second hint that cannot be satisfied destroys the
+/// identity the first hint was successfully carrying. So hints do not compose,
+/// and "attach every hint you have" remains unsafe even after exit 1.
+test "STILL VIOLATED: an extra unsatisfiable hint destroys a live hint's work" {
+  let l5 = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let l6 = ProjNode(Leaf("x"), 1, 2, 6, [])
+  let old = ProjNode(Branch("root", [Leaf("x"), Leaf("x")]), 0, 3, 1, [l5, l6])
+  let plain = ProjNode(Leaf("x"), 0, 1, 90, [])
+  let w_leaf = ProjNode(Leaf("x"), 2, 3, 91, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 2, 4, 92, [w_leaf])
+  let new_ = ProjNode(
+    Branch("root", [Leaf("x"), Branch("w", [Leaf("x")])]),
+    0,
+    5,
+    93,
+    [plain, wrapper],
+  )
+  // With only #6 hinted, #6 rides the hint into the wrapper.
+  let one = mk_hints([(6, Wrap(inner=NodeId::from_int(6)))])
+  let with_one = reconcile_hinted(old, new_, Ref(1000), one)
+  inspect(with_one.children[1].children[0].node_id, content="6")
+  // Adding #5's hint — which cannot be satisfied, both claim the one wrapper —
+  // costs #6 the identity it had.
+  let two = mk_hints([
+    (5, Wrap(inner=NodeId::from_int(5))),
+    (6, Wrap(inner=NodeId::from_int(6))),
+  ])
+  let with_two = reconcile_hinted(old, new_, Ref(1000), two)
+  inspect(with_two.children[1].children[0].node_id >= 1000, content="true")
+}
+
+///|
+/// Cause: `reconcile_hinted` consults `structural_pair` at the ROOT before any
+/// child LCS runs, so the applicability gate — which lives in
+/// `reconcile_children` — never sees this hint. Exit 1 fixes the zero-target
+/// root case (via `apply_wrap`), but an ambiguous root Wrap still freshens the
+/// whole tree where the unhinted path preserves the root id.
+test "STILL VIOLATED: an ambiguous Wrap on the ROOT freshens the whole tree" {
+  let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
+  let c1 = ProjNode(Branch("a", [Leaf("x")]), 1, 3, 90, [
+    ProjNode(Leaf("x"), 1, 2, 91, []),
+  ])
+  let c2 = ProjNode(Branch("b", [Leaf("y")]), 3, 5, 92, [
+    ProjNode(Leaf("y"), 3, 4, 93, []),
+  ])
+  let new_ = ProjNode(
+    Branch("root", [Branch("a", [Leaf("x")]), Branch("b", [Leaf("y")])]),
+    0,
+    6,
+    94,
+    [c1, c2],
+  )
+  let hints = mk_hints([(1, Wrap(inner=NodeId::from_int(1)))])
+  // Unhinted the root keeps #1; hinted it does not.
+  inspect(reconcile(old, new_, Ref(1000)).node_id, content="1")
+  inspect(
+    reconcile_hinted(old, new_, Ref(1000), hints).node_id >= 1000,
+    content="true",
+  )
+}

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -299,10 +299,25 @@ test "a batch of two independent Wrap hints preserves both ids" {
 ///
 /// The two tests below pin CURRENT behaviour, and together they say: supplying
 /// a stale hint is worse than supplying none. That makes "attach a hint
-/// whenever one is available" unsafe as a caller contract. Whether to fix this
-/// in reconcile (reject a hint whose topology does not match) or to require
-/// freshness of callers is an open choice; these tests exist so that either
-/// decision shows up here as a diff.
+/// whenever one is available" unsafe as a caller contract.
+///
+/// Three ways out, at different costs. These tests exist so that whichever is
+/// taken shows up here as a diff.
+///
+/// 1. Consumer side — reconcile refuses a hint whose topology does not match
+///    the new tree and leaves the node to ordinary matching.
+/// 2. Caller contract — hints are required to be fresh, so producing a stale
+///    one is a caller bug rather than something reconcile absorbs.
+/// 3. Producer side — compose the pending transforms before emitting anything,
+///    so a batch whose net effect cancels emits NO hint instead of a stale one.
+///    This also recovers the identity that the current all-or-nothing degrade
+///    discards when a batch carries several perfectly describable transforms,
+///    so it answers both failures at once. Its cost is that the transform
+///    vocabulary is a flat set of named topology changes and so is not closed
+///    under composition — the opaque fallback is the honest bottom element of
+///    that. Buying composition means giving the vocabulary a compositional
+///    shape, which is a much larger change than 1 or 2 and should wait for a
+///    consumer that needs it.
 test "without hints, an edit whose net effect is nil preserves identity" {
   let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
   let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -244,3 +244,85 @@ test "Replace hint retires the old id (node is fresh, not preserved)" {
   // same-kind would normally preserve #5; Replace retires it → the node is fresh
   inspect(result.children[0].node_id >= 1000, content="true")
 }
+
+///|
+/// Sequencing: two wraps at different depths, both hints supplied to ONE
+/// reconcile. Neither wrap makes the other's target an ambiguous sibling, so
+/// this isolates "can a batch carry more than one hint" from the ambiguity
+/// degrade tested above.
+test "a batch of two independent Wrap hints preserves both ids" {
+  // old: root#1 -> a#4 -> Leaf#5 ; root#1 -> b#6 -> Leaf#7
+  let x = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let a = ProjNode(Branch("a", [Leaf("x")]), 1, 3, 4, [x])
+  let y = ProjNode(Leaf("y"), 4, 5, 7, [])
+  let b = ProjNode(Branch("b", [Leaf("y")]), 4, 6, 6, [y])
+  let old = ProjNode(
+    Branch("root", [Branch("a", [Leaf("x")]), Branch("b", [Leaf("y")])]),
+    0,
+    7,
+    1,
+    [a, b],
+  )
+  // new: each leaf gained a wrapper; every id is fresh (as after a reparse)
+  let nx = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let wx = ProjNode(Branch("w", [Leaf("x")]), 1, 3, 91, [nx])
+  let na = ProjNode(Branch("a", [Branch("w", [Leaf("x")])]), 1, 4, 92, [wx])
+  let ny = ProjNode(Leaf("y"), 4, 5, 93, [])
+  let wy = ProjNode(Branch("w", [Leaf("y")]), 4, 6, 94, [ny])
+  let nb = ProjNode(Branch("b", [Branch("w", [Leaf("y")])]), 4, 7, 95, [wy])
+  let new_ = ProjNode(
+    Branch("root", [
+      Branch("a", [Branch("w", [Leaf("x")])]),
+      Branch("b", [Branch("w", [Leaf("y")])]),
+    ]),
+    0,
+    8,
+    96,
+    [na, nb],
+  )
+  let hints = mk_hints([
+    (5, Wrap(inner=NodeId::from_int(5))),
+    (7, Wrap(inner=NodeId::from_int(7))),
+  ])
+  let result = reconcile_hinted(old, new_, Ref(1000), hints)
+  // both wrapped leaves keep their ids from the one batched reconcile
+  inspect(result.children[0].children[0].children[0].node_id, content="5")
+  inspect(result.children[1].children[0].children[0].node_id, content="7")
+}
+
+///|
+/// Monotonicity: a hint whose topology no longer matches the new tree.
+///
+/// This arises whenever a batch's net effect cancels the edit the hint
+/// describes — wrap then unwrap the same node leaves the tree shaped exactly
+/// as it started, while the wrap hint computed at the first step survives.
+///
+/// The two tests below pin CURRENT behaviour, and together they say: supplying
+/// a stale hint is worse than supplying none. That makes "attach a hint
+/// whenever one is available" unsafe as a caller contract. Whether to fix this
+/// in reconcile (reject a hint whose topology does not match) or to require
+/// freshness of callers is an open choice; these tests exist so that either
+/// decision shows up here as a diff.
+test "without hints, an edit whose net effect is nil preserves identity" {
+  let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
+  // same shape, all ids fresh (a reparse after wrap-then-unwrap)
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
+  let result = reconcile(old, new_, Ref(1000))
+  inspect(result.node_id, content="1")
+  inspect(result.children[0].node_id, content="5")
+}
+
+///|
+test "a stale Wrap hint loses identity that the unhinted path keeps" {
+  let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
+  // The wrap this hint describes was undone later in the same batch: there is
+  // no wrapper in `new_` for #5 to be found inside.
+  let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
+  let result = reconcile_hinted(old, new_, Ref(1000), hints)
+  inspect(result.children[0].node_id >= 1000, content="true")
+}

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -296,28 +296,31 @@ test "a batch of two independent Wrap hints preserves both ids" {
 /// This arises whenever a batch's net effect cancels the edit the hint
 /// describes — wrap then unwrap the same node leaves the tree shaped exactly
 /// as it started, while the wrap hint computed at the first step survives.
+/// It is reachable: hints are cleared exactly once per reparse
+/// (lang/lambda/proj/projection_memo.mbt), the projection is a pull-based
+/// `@incr.Derived`, and the editor's T4 guard drops only a hint whose OWN span
+/// batch produced no text change (editor/sync_editor.mbt) — it cannot see a
+/// later op cancelling an earlier one.
 ///
-/// The two tests below pin CURRENT behaviour, and together they say: supplying
-/// a stale hint is worse than supplying none. That makes "attach a hint
-/// whenever one is available" unsafe as a caller contract.
+/// Exit 1 of the three recorded here has been taken: exclusion from LCS is
+/// decided from hint APPLICABILITY, and `apply_wrap` distinguishes "no trace of
+/// this wrap here" (inert, fall through) from "ambiguous" (degrade, T3).
 ///
-/// Three ways out, at different costs. These tests exist so that whichever is
-/// taken shows up here as a diff.
+/// The two exits NOT taken:
 ///
-/// 1. Consumer side — reconcile refuses a hint whose topology does not match
-///    the new tree and leaves the node to ordinary matching.
 /// 2. Caller contract — hints are required to be fresh, so producing a stale
 ///    one is a caller bug rather than something reconcile absorbs.
 /// 3. Producer side — compose the pending transforms before emitting anything,
 ///    so a batch whose net effect cancels emits NO hint instead of a stale one.
-///    This also recovers the identity that the current all-or-nothing degrade
-///    discards when a batch carries several perfectly describable transforms,
-///    so it answers both failures at once. Its cost is that the transform
-///    vocabulary is a flat set of named topology changes and so is not closed
-///    under composition — the opaque fallback is the honest bottom element of
-///    that. Buying composition means giving the vocabulary a compositional
-///    shape, which is a much larger change than 1 or 2 and should wait for a
-///    consumer that needs it.
+///    This is the generalisation of the editor's existing T4 guard from one
+///    span batch to the whole reparse window. It also recovers the identity
+///    that the all-or-nothing degrade discards when a batch carries several
+///    perfectly describable transforms, so it answers both failures at once.
+///    Its cost is that the transform vocabulary is a flat set of named topology
+///    changes and so is not closed under composition — the opaque fallback is
+///    the honest bottom element of that. Buying composition means giving the
+///    vocabulary a compositional shape, which is a much larger change than 2
+///    and should wait for a consumer that needs it.
 test "without hints, an edit whose net effect is nil preserves identity" {
   let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
   let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
@@ -330,57 +333,72 @@ test "without hints, an edit whose net effect is nil preserves identity" {
 }
 
 ///|
-test "a stale Wrap hint loses identity that the unhinted path keeps" {
+test "a stale Wrap hint is inert: identity survives it" {
   let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
   let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
   let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
   let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
   // The wrap this hint describes was undone later in the same batch: there is
-  // no wrapper in `new_` for #5 to be found inside.
+  // no wrapper in `new_` for #5 to be found inside. Neither the LCS exclusion
+  // nor `structural_pair` may act on it.
   let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
   let result = reconcile_hinted(old, new_, Ref(1000), hints)
-  inspect(result.children[0].node_id >= 1000, content="true")
+  inspect(result.children[0].node_id, content="5")
 }
 
 ///|
-/// Weak monotonicity for hints, as a named predicate.
+/// Does supplying `hints` change the identities reconcile assigns, relative to
+/// supplying `base` instead?
+///
+/// Deliberately named for what it computes, not for a property it is claimed to
+/// witness: the claims live in the test names below, which pin it both ways.
+///
+/// The `base` parameter is what makes the property statable. Inertness is a
+/// MARGINAL claim — "this entry changes nothing" — and comparing a whole map
+/// against the empty map cannot express it: any other entry in the map is
+/// entitled to change the result, so the comparison would fail for reasons that
+/// have nothing to do with the entry under test.
+fn hinted_result_is_inert(
+  old : ProjNode[TestExpr],
+  new_ : ProjNode[TestExpr],
+  hints : Map[NodeId, IdentityTransform],
+  base~ : Map[NodeId, IdentityTransform] = Map([]),
+) -> Bool {
+  let without = collect_ids(reconcile_hinted(old, new_, Ref(1000), base))
+  let with_ = collect_ids(reconcile_hinted(old, new_, Ref(1000), hints))
+  without == with_
+}
+
+///|
+/// Weak monotonicity for hints, at the scope that is actually achievable.
 ///
 /// Strong monotonicity — "a hint never makes any node worse off" — is neither
 /// achievable nor wanted: a hint that DOES apply is authoritative and is meant
 /// to override a coincidental LCS match, which can cost some other node the
-/// match it would otherwise have had. The property worth holding is the weaker
-/// one:
+/// match it would otherwise have had.
 ///
-///   **A hint that cannot be applied has no effect.**
+/// The obvious next weakening, "a hint that cannot be APPLIED has no effect",
+/// is also not achievable, and not because of an unfixed defect. An ambiguous
+/// Wrap — two or more same-kind children — cannot be applied, yet the new node
+/// may genuinely be a wrapper, and invariant T3 requires degrading to fresh ids
+/// rather than leaving the preserved id on that wrapper. Inertness would demand
+/// the opposite. The two invariants are in direct conflict for that case, and
+/// T3 wins by design.
 ///
-/// Caller must supply a `hints` map whose entries cannot land in `new_`;
-/// for an applicable hint the two results are expected to differ.
+/// What holds is the properly scoped, MARGINAL statement:
 ///
-/// Returns whether the property HOLDS.
-fn prop_unapplicable_hint_is_inert(
-  old : ProjNode[TestExpr],
-  new_ : ProjNode[TestExpr],
-  hints : Map[NodeId, IdentityTransform],
-) -> Bool {
-  let unhinted = collect_ids(reconcile(old, new_, Ref(1000)))
-  let hinted = collect_ids(reconcile_hinted(old, new_, Ref(1000), hints))
-  unhinted == hinted
-}
-
-///|
-/// The property above does NOT hold today, and this pins that.
+///   **Adding a hint with no applicable target to a hint map changes nothing.**
 ///
-/// The cause is an ordering choice in `reconcile_children`: an old child
-/// carrying a Wrap/Unwrap/Replace/Move hint is removed from LCS by
-/// `lcs_excluded` BEFORE anything checks whether the hint can land, and a hint
-/// that then fails to pair has no route back into ordinary matching.
+/// "No applicable target" is decidable locally and carries no T3 tension: for
+/// `Wrap`, zero same-kind children means the new node is not a wrapper of this
+/// node at all, so ordinary matching is exactly the right decision. For
+/// `Unwrap` it means the kept child is absent from the old wrapper — a mismatch
+/// of KIND is not inapplicability, because the recursion is what interprets it.
 ///
-/// If reconcile is changed so that exclusion is decided from hint
-/// applicability — `hint_pair_counts` already computes very nearly that
-/// predicate, though today it counts only among LCS-unmatched new children —
-/// this flips to "true". When it does: update the pin here, and drop the
-/// stale-hint caveat from the two tests above.
-test "PROPERTY, currently violated: an unapplicable hint is inert" {
+/// Marginal, not absolute: the map may hold other entries that are entitled to
+/// change the result. The second test below is the one that would have caught a
+/// property stated over the whole map instead of the added entry.
+test "PROPERTY: adding a hint with no applicable target is inert" {
   let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
   let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
   // Net effect of the batch was nil, so `new_` has the shape of `old`.
@@ -388,18 +406,81 @@ test "PROPERTY, currently violated: an unapplicable hint is inert" {
   let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
   // Describes a wrapper that the completed batch left no trace of.
   let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
-  inspect(prop_unapplicable_hint_is_inert(old, new_, hints), content="false")
+  inspect(hinted_result_is_inert(old, new_, hints), content="true")
 }
 
 ///|
-/// Known-positive control for the pin above: with no hints at all the two
-/// reconciles are the same call, so the predicate must report "holds". Without
-/// this, a predicate that had become stuck at `false` would let the pin pass
-/// vacuously and the violation above would stop meaning anything.
+/// The property holds against a NON-EMPTY base too: a coexisting `Replace` is
+/// entitled to freshen its own node, and the zero-target `Wrap` added alongside
+/// it must still change nothing. Stated over the whole map against no hints at
+/// all, this comparison would fail — on the `Replace`'s account, not the
+/// `Wrap`'s — and the property would look violated when it is not.
+test "PROPERTY: still inert when the map already carries an applicable hint" {
+  let l5 = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let l6 = ProjNode(Leaf("y"), 2, 3, 6, [])
+  let old = ProjNode(Branch("root", [Leaf("x"), Leaf("y")]), 0, 4, 1, [l5, l6])
+  let n5 = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let n6 = ProjNode(Leaf("y"), 2, 3, 91, [])
+  let new_ = ProjNode(Branch("root", [Leaf("x"), Leaf("y")]), 0, 4, 92, [n5, n6])
+  let base = mk_hints([(6, Replace(old=NodeId::from_int(6)))])
+  let with_stale = mk_hints([
+    (6, Replace(old=NodeId::from_int(6))),
+    (5, Wrap(inner=NodeId::from_int(5))),
+  ])
+  inspect(hinted_result_is_inert(old, new_, with_stale, base~), content="true")
+}
+
+///|
+/// Known-negative control for the pin above. A predicate stuck at `true` would
+/// let the property pass vacuously, so one input on which it MUST report "not
+/// inert" is pinned here: an applicable Wrap changes the result by design.
+test "control: the inertness predicate does report NOT holding when it should" {
+  let inner = ProjNode(Leaf("x"), 0, 1, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 5, 1, [inner])
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let wrapper = ProjNode(Branch("w", [Leaf("x")]), 1, 3, 91, [new_inner])
+  let new_ = ProjNode(Branch("root", [Branch("w", [Leaf("x")])]), 0, 5, 92, [
+    wrapper,
+  ])
+  let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
+  inspect(hinted_result_is_inert(old, new_, hints), content="false")
+}
+
+///|
+/// Known-positive control: with no hints at all the two reconciles are the same
+/// call, so the predicate must report "inert".
 test "control: the inertness predicate does report holding when it should" {
   let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
   let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
   let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
   let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
-  inspect(prop_unapplicable_hint_is_inert(old, new_, Map([])), content="true")
+  inspect(hinted_result_is_inert(old, new_, Map([])), content="true")
+}
+
+///|
+/// Regression pin for an over-tightening that an independent review caught
+/// before it shipped: gating `apply_unwrap` on `same_kind(new, keep)` would
+/// make this batch preserve #10, which is wrong.
+///
+/// The batch is unwrap-then-wrap: #10 is removed and #5 promoted, then #5 is
+/// wrapped in a NEW node. The shape ends up identical to where it started, but
+/// the outer node of the new tree is not #10 — #10 was destroyed and a fresh
+/// wrapper built. Only the recursion can see this: `apply_unwrap` descends to
+/// #5, and #5's own `Wrap` hint consumes the new outer node, retiring #10.
+///
+/// A kind mismatch between `keep` and `new` is therefore NOT inapplicability.
+test "composed unwrap-then-wrap retires the old wrapper id" {
+  let kept = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("w", [Leaf("x")]), 0, 3, 10, [kept])
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_ = ProjNode(Branch("w2", [Leaf("x")]), 0, 3, 91, [new_inner])
+  let hints = mk_hints([
+    (10, Unwrap(wrapper=NodeId::from_int(10), keep=NodeId::from_int(5))),
+    (5, Wrap(inner=NodeId::from_int(5))),
+  ])
+  let result = reconcile_hinted(old, new_, Ref(1000), hints)
+  // the new outer node is fresh — #10 did not survive its own unwrap
+  inspect(result.node_id >= 1000, content="true")
+  // and #5 rode the wrap into it
+  inspect(result.children[0].node_id, content="5")
 }

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -362,7 +362,7 @@ fn hinted_result_is_inert(
   old : ProjNode[TestExpr],
   new_ : ProjNode[TestExpr],
   hints : Map[NodeId, IdentityTransform],
-  base~ : Map[NodeId, IdentityTransform] = Map([]),
+  base? : Map[NodeId, IdentityTransform] = Map([]),
 ) -> Bool {
   let without = collect_ids(reconcile_hinted(old, new_, Ref(1000), base))
   let with_ = collect_ids(reconcile_hinted(old, new_, Ref(1000), hints))

--- a/core/reconcile_hints_wbtest.mbt
+++ b/core/reconcile_hints_wbtest.mbt
@@ -326,3 +326,65 @@ test "a stale Wrap hint loses identity that the unhinted path keeps" {
   let result = reconcile_hinted(old, new_, Ref(1000), hints)
   inspect(result.children[0].node_id >= 1000, content="true")
 }
+
+///|
+/// Weak monotonicity for hints, as a named predicate.
+///
+/// Strong monotonicity — "a hint never makes any node worse off" — is neither
+/// achievable nor wanted: a hint that DOES apply is authoritative and is meant
+/// to override a coincidental LCS match, which can cost some other node the
+/// match it would otherwise have had. The property worth holding is the weaker
+/// one:
+///
+///   **A hint that cannot be applied has no effect.**
+///
+/// Caller must supply a `hints` map whose entries cannot land in `new_`;
+/// for an applicable hint the two results are expected to differ.
+///
+/// Returns whether the property HOLDS.
+fn prop_unapplicable_hint_is_inert(
+  old : ProjNode[TestExpr],
+  new_ : ProjNode[TestExpr],
+  hints : Map[NodeId, IdentityTransform],
+) -> Bool {
+  let unhinted = collect_ids(reconcile(old, new_, Ref(1000)))
+  let hinted = collect_ids(reconcile_hinted(old, new_, Ref(1000), hints))
+  unhinted == hinted
+}
+
+///|
+/// The property above does NOT hold today, and this pins that.
+///
+/// The cause is an ordering choice in `reconcile_children`: an old child
+/// carrying a Wrap/Unwrap/Replace/Move hint is removed from LCS by
+/// `lcs_excluded` BEFORE anything checks whether the hint can land, and a hint
+/// that then fails to pair has no route back into ordinary matching.
+///
+/// If reconcile is changed so that exclusion is decided from hint
+/// applicability — `hint_pair_counts` already computes very nearly that
+/// predicate, though today it counts only among LCS-unmatched new children —
+/// this flips to "true". When it does: update the pin here, and drop the
+/// stale-hint caveat from the two tests above.
+test "PROPERTY, currently violated: an unapplicable hint is inert" {
+  let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
+  // Net effect of the batch was nil, so `new_` has the shape of `old`.
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
+  // Describes a wrapper that the completed batch left no trace of.
+  let hints = mk_hints([(5, Wrap(inner=NodeId::from_int(5)))])
+  inspect(prop_unapplicable_hint_is_inert(old, new_, hints), content="false")
+}
+
+///|
+/// Known-positive control for the pin above: with no hints at all the two
+/// reconciles are the same call, so the predicate must report "holds". Without
+/// this, a predicate that had become stuck at `false` would let the pin pass
+/// vacuously and the violation above would stop meaning anything.
+test "control: the inertness predicate does report holding when it should" {
+  let inner = ProjNode(Leaf("x"), 1, 2, 5, [])
+  let old = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 1, [inner])
+  let new_inner = ProjNode(Leaf("x"), 1, 2, 90, [])
+  let new_ = ProjNode(Branch("root", [Leaf("x")]), 0, 3, 91, [new_inner])
+  inspect(prop_unapplicable_hint_is_inert(old, new_, Map([])), content="true")
+}


### PR DESCRIPTION
## Summary

- A stale structural hint destroyed identity that the unhinted path preserved. When a batch's net effect cancels the edit a hint describes (wrap then unwrap the same node), the tree ends up shaped as it started, but the wrap hint computed at the first step survives and costs the node its id. Supplying a stale hint was strictly worse than supplying none, which made "attach a hint whenever one is available" unsafe as a caller contract.
- The hint cost identity at **two independent points**, and either alone was enough to lose it: `lcs_excluded` withheld an old child from LCS on hint *presence* with no route back after the hint failed to pair, and `apply_wrap` collapsed "no same-kind child" and ">=2 same-kind children" into one failure that degraded to fresh ids.
- Exclusion is now decided from hint **applicability**, and `apply_wrap` / `apply_unwrap` return `HintResult` so that "no trace of this wrap here" falls through to ordinary matching while genuine ambiguity still degrades.

### What this does *not* claim

The property established is deliberately narrower than "an unapplicable hint is inert":

> **Adding a hint with no applicable target to a hint map changes nothing.**

An **ambiguous** Wrap also cannot be applied, yet the new node may really be a wrapper, and invariant T3 requires degrading to fresh rather than leaving the preserved id on it. Inertness and T3 are in direct conflict for that case and **T3 wins by design**. The statement is also *marginal*, not absolute — compared against the empty map, a coexisting `Replace` is entitled to change the result, so the test predicate takes a base map.

Four cases where a hint still costs identity are **not** closed, and are pinned as `STILL VIOLATED` tests naming their causes rather than left implied by absence. They were verified **pre-existing**: running the new test file against the pre-change `reconcile.mbt` leaves all four passing and fails only the two this PR closes. Two of them share one cause (exclusion asks "pairs with ANY new child", pairing asks "with an LCS-*unmatched* one", and LCS runs in between) and would both close if hint partners were reserved globally before LCS — a strictly larger change with no named consumer yet.

Related, not closed by this PR: #831 and #725 consume these hints, and #886 concerns where identity comes from. All three depend on the scoping above.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `hint_pairs` | `core/reconcile.mbt` | Yes | Already the pure pairing predicate; became the applicability test for LCS exclusion. No new predicate needed. |
| `HintResult[T]` | `core/reconcile.mbt` | Yes | Already modelled the three outcomes; absorbed `apply_wrap`/`apply_unwrap`'s `Option`, removing the lossy collapse. |
| `hint_pair_counts` | `core/reconcile.mbt` | No (deliberately) | Computes nearly the right predicate, but only over LCS-*unmatched* new children. Moving it before LCS would widen its domain and change the 0/>1 ambiguity rules. Left exactly where it is. |
| `count_same_kind_children` | `core/reconcile.mbt` | Yes (indirectly) | Target selection stays owned by `apply_wrap` alone; `structural_pair` does not re-count, so the two cannot drift. |
| `Iter::any` | MoonBit core | Yes | Existence check over new siblings. No hand-written loop. |
| `Array`, `Map`, `Option` | MoonBit core | Yes | Unchanged usage; no new container introduced. |
| `@cmp` / `String` / `Buffer` | MoonBit core | N/A | No comparison, string, or buffer work in this change. |

New helpers added: **none**. `lcs_excluded` changed signature (now takes the old child and the new siblings instead of a bare id) but is the same function with the same responsibility.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes — core 151/151; workspace wasm-gc 3932/3932, native 70/70, js 1960/1961
- [x] `git diff *.mbti` reviewed — **no change**; all three touched functions are private
- [x] JS rebuild not needed — no web-facing surface touched

The single js failure is `workspace/probe/test_grammar_contract_wbtest.mbt:81` (a lone-surrogate `TextError`), present identically on the untouched baseline with submodules at their pinned pointers, and unrelated to reconciliation.

### Beyond the checklist

- The two `STILL VIOLATED` claims and the pre-existing status of all four were verified by **running the new tests against the old `reconcile.mbt`**, not by argument.
- The regression pin `composed unwrap-then-wrap retires the old wrapper id` was **calibrated**: re-introducing the guard it guards against makes that pin, and only that pin, fail.

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
