### PR TITLE
fix(probe): align lone surrogate text contract

### DIFF
--- a/workspace/probe/test_grammar.mbt
+++ b/workspace/probe/test_grammar.mbt
@@ -5,13 +5,13 @@
 //         | IDENT '(' expr* ')'      -> Branch(tag, children)
 //   root := expr*                    -> Branch("", children)
 //
-// The lexer/parser/fold/projection are TOTAL over arbitrary input: any
-// byte run that is not an identifier or paren becomes a gap (Whitespace
-// trivia for blank gaps, an Error token otherwise), and unparseable spans
-// fold to an error Leaf. This matters because the editor unconditionally
-// converts the syntax tree to a ProjNode and assumes malformed/partial
-// input still yields an AST (e.g. sync_editor_text_wbtest inserts emoji /
-// ZWJ / surrogate halves).
+// The lexer/parser/fold/projection are TOTAL over valid Unicode input: any
+// run that is not an identifier or paren becomes a gap (Whitespace trivia for
+// blank gaps, an Error token otherwise), and unparseable spans fold to an error
+// Leaf. This matters because the editor unconditionally converts the syntax
+// tree to a ProjNode and assumes malformed/partial syntax still yields an AST
+// (e.g. sync_editor_text_wbtest inserts emoji / ZWJ). Malformed UTF-16 is
+// rejected by the text facade before reaching this grammar.
 
 // === Tokens ===
 

--- a/workspace/probe/test_grammar_contract_wbtest.mbt
+++ b/workspace/probe/test_grammar_contract_wbtest.mbt
@@ -1,6 +1,7 @@
 // Contract tests for the neutral TestExpr grammar / editor fixture.
 // Proves new_test_editor parses, round-trips text, and is TOTAL over
-// arbitrary input (garbage / non-BMP / surrogate halves) without aborting.
+// valid Unicode input (garbage / non-BMP) without aborting. Malformed UTF-16
+// is rejected at the text boundary before parsing.
 
 ///|
 test "new_test_editor parses a branch with leaf children" {
@@ -70,21 +71,21 @@ test "total over non-BMP and surrogate input — no abort" {
 }
 
 ///|
-/// A LONE (unpaired) surrogate half — distinct from the well-formed pairs
-/// above. MoonBit rejects lone surrogates as string literals, so at runtime
-/// they only arise from slicing a pair at a code-unit boundary (e.g. a CRDT
-/// merge or FFI input splitting an emoji). The lexer skips the undecodable
-/// code unit into a gap; from_located_tokens classifies the gap via
-/// `is_blank()`, which compares whitespace code units without a full scalar
-/// decode and so does NOT abort on the lone half. This pins the "surrogate
-/// halves" totality claim in the file header so it cannot regress silently.
-test "total over a lone surrogate half — no abort" {
-  let half = "😀".view(start_offset=0, end_offset=1).to_owned() // lone high surrogate
+/// A lone surrogate is malformed UTF-16. The text facade rejects it before
+/// CRDT allocation or parsing, leaving source, cursor, and parsed AST unchanged.
+test "rejects a lone surrogate before parsing without changing text" {
+  let half = "😀".view(start_offset=0, end_offset=1).to_owned()
   let ed = new_test_editor("agent")
-  ed.insert("a" + half + "b")
-  let _ = get_test_ast(ed)
-  // The surrounding idents survive; the lone half does not crash the pipeline.
-  inspect(ed.get_text().length() > 0, content="true")
+  try ed.insert("a" + half + "b") catch {
+    @text.TextError::InvalidText(detail~) =>
+      inspect(detail, content="malformed UTF-16")
+    _ => fail("expected malformed UTF-16 to be rejected")
+  } noraise {
+    _ => fail("lone surrogate insertion must fail")
+  }
+  inspect(ed.get_text(), content="")
+  inspect(ed.get_cursor(), content="0")
+  inspect(get_test_ast(ed), content="Branch(\"\", [])")
 }
 
 ///|
@@ -92,12 +93,13 @@ test "total over a lone surrogate half — no abort" {
 // against TestExpr's SINGLE structural error shape — an unclosed '('. This is
 // by design, not an oversight, and the limitation is documented here so it
 // cannot be mistaken for missing coverage. The grammar is deliberately TOTAL
-// (see test_grammar.mbt header): every other malformed input (stray
-// punctuation, garbage, non-BMP runs, lone surrogate halves) becomes a silent
-// lexer gap rather than a diagnostic. Adding a second error shape would require
-// a non-total parser path and risk the totality invariant the contract tests
-// above pin — so the single trigger is intentional. This test pins both sides:
-// exactly one diagnostic for the one trigger, and zero for silent-gap garbage.
+// over valid Unicode input (see test_grammar.mbt header): stray punctuation,
+// garbage, and non-BMP runs become silent lexer gaps rather than diagnostics.
+// Malformed UTF-16 is rejected by the text facade before reaching this grammar.
+// Adding a second parser error shape would require a non-total parser path and
+// risk the totality invariant the contract tests above pin — so the single
+// trigger is intentional. This test pins both sides: exactly one diagnostic for
+// the one trigger, and zero for silent-gap garbage.
 test "TestExpr reports exactly one structural diagnostic kind (unclosed '(')" {
   let ed = new_test_editor("agent")
   ed.insert("foo(")


### PR DESCRIPTION
## Summary

- align the TestExpr lone-surrogate contract with event-graph-walker's fail-fast `InvalidText` boundary introduced by #946
- assert malformed UTF-16 leaves source, cursor, and parsed AST unchanged
- narrow grammar totality documentation to valid Unicode input while retaining non-BMP coverage

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `TextError::InvalidText` | `event-graph-walker/text` | Yes | Matches the accepted malformed UTF-16 boundary exactly |
| `SyncEditor::{get_text,get_cursor}` and `get_test_ast` | `editor`, `workspace/probe` | Yes | Verify the existing visible-state contract without new helpers |
| `StringView::to_owned` | MoonBit core `string` | Yes | Preserves the existing JS lone-surrogate reproduction |
| `Result` | MoonBit core `result` | No | Direct typed `catch` is clearer because `SyncEditor::insert` exposes the general `Error` effect |

New helpers added: none.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `moon test` passes: wasm-gc 3932/3932, JS 1949/1949, native 70/70
- [x] `./scripts/check-test-baseline.sh 7 moon test --release` passes with 0 failures
- [x] `git diff *.mbti` reviewed; no interface changes
- [x] JS rebuild not required; web code is unaffected

## Validation

```bash
moon test workspace/probe/test_grammar_contract_wbtest.mbt \
  --target js --release --filter '*lone surrogate*' --frozen
NEW_MOON_MOD=0 moon check
moon test
./scripts/check-test-baseline.sh 7 moon test --release
```

Regression introduced when #946 advanced event-graph-walker to its explicit malformed-local-text contract without updating this Canopy-owned probe test.
