### PR TITLE
Build the Waku Demo Hub and route lifecycle

### DIFF
--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -47,17 +47,34 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 Most of the source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. Resume/PKE, Posts, Memo, JSON, Markdown, GenUI, and GenUI Possibilities use the target entry/feature layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku foundation (pre-production, #970 Stages 0–1)
+## Waku foundation (pre-production, #970 Stages 0–1; #971 Stage 2 in progress)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 foundation has landed alongside it — configuration, a Cloudflare adapter, and a generated-artifact client probe only. No demo, route, deployment, or redirect has been migrated.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 foundation has landed alongside it. Stage 2 has added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; no demo behavior has been migrated and no old HTML entry has been removed.
+
+### Stage 0–1 configuration and artifacts
 
 - `waku.config.ts` — Waku configuration with the official Cloudflare adapter (`waku/adapters/cloudflare`) and the shared MoonBit artifact plugin.
 - `src/waku.server.tsx` — Waku server entry using `fsRouter` over `pages/**/*.{tsx,ts}`.
-- `src/pages/index.tsx` — foundation probe page that renders only a `MoonbitClientProbe` (generated-artifact boundary check, not a migrated demo).
-- `src/pages/_root.tsx` — Waku root document.
+- `src/pages/foundation.tsx` — foundation probe page (moved from `index.tsx`); renders only a `MoonbitClientProbe` (generated-artifact boundary check, not a migrated demo).
+- `src/pages/_root.tsx` — Waku root document; Stage 2 also anchors shared styles and the long-lived route-lifecycle provider here.
 - `moonbit-artifacts.mjs` — single source of truth for the five generated module records, consumed by both Vite and Waku build pipelines.
 - `wrangler.jsonc` — unchanged existing Vite deployment shell.
 - `wrangler.waku.jsonc` — isolated pre-production Waku preview and production Worker environments.
+
+### Stage 2 — Hub, lifecycle Module, shell, and common states
+
+- `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
+- `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
+- `src/pages/{ml,json,markdown,memo,posts,resume,genui,journey}.tsx` — eight canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell. No demo behavior has been migrated.
+- `src/pages/_layout.tsx` — pass-through shared route layout; the provider stays at `_root.tsx` so its in-memory registry survives route render failures.
+- `src/shared/catalog/demo-catalog.ts` — framework-independent catalog data (eight demos, three groups, canonical `DemoPath` routes).
+- `src/shared/shell/` — `DemoHub` and `DemoPlaceholder` React components and shared shell styles.
+- `src/shared/route-lifecycle/core/reducer.ts` — pure `State + Event -> (State, Decision)` reducer.
+- `src/shared/route-lifecycle/browser/` — React provider, imperative host, focus manager, imperative session, route render boundary, and common states.
+- `waku-tests/foundation.spec.ts` and `waku-tests/hub.spec.ts` — deterministic Waku page tests.
+- `scripts/waku-lifecycle-contract.test.mjs` — reducer/provider/focus/error/imperative-host contract tests.
+
+Stage 2 remains pre-production. Vite remains the default and is retained.
 
 Validation runs in parallel with the Vite pipeline:
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -22,6 +22,7 @@ npm run dev:dual     # both servers with one shared root MoonBit watcher
 `npm run dev` and `npm run build` remain Vite aliases until the final cutover. Both development modes reuse one root MoonBit build/watch coordinator; generated outputs remain namespaced under `_build/js/release/build/dowdiness/`.
 
 ```bash
+(cd ../.. && moon build --target js)
 npm run typecheck
 npm run check:boundaries
 npm run test:boundaries

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,6 +5,10 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
+## Waku migration (in progress, #971)
+
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stage 2 adds the Demo Hub, route-lifecycle Module (reducer, provider, focus manager, imperative host, error boundary), shared shell, eight canonical placeholder routes, and accessible 404. No demo behavior has been migrated; the previous foundation probe moved to `/foundation`, and no old HTML entry has been removed.
+
 ## Development
 
 ```bash

--- a/examples/web/scripts/check-boundaries.mjs
+++ b/examples/web/scripts/check-boundaries.mjs
@@ -110,6 +110,12 @@ export function describePath(filePath) {
     };
   }
 
+  const routeLifecycleMatch = normalized.match(
+    /(^|\/)shared\/route-lifecycle\/(core|browser)\//,
+  );
+  if (routeLifecycleMatch) {
+    return { kind: 'shared', layer: routeLifecycleMatch[2] };
+  }
   if (/(^|\/)shared\//.test(normalized) || base === 'vite-env.d.ts') {
     return { kind: 'shared' };
   }
@@ -214,6 +220,16 @@ export function evaluateEdge(from, to, specifier = to, clientModule = false) {
   }
   if (source.kind === 'shared' && target.kind === 'feature') {
     violations.push('shared code cannot import feature code');
+  }
+  if (
+    source.kind === 'shared' &&
+    source.layer === 'core' &&
+    (
+      (target.kind === 'shared' && target.layer === 'browser') ||
+      capabilityImport(specifier)
+    )
+  ) {
+    violations.push('route-lifecycle core cannot import browser or React capabilities');
   }
   if (
     source.kind === 'feature' &&

--- a/examples/web/scripts/check-boundaries.test.mjs
+++ b/examples/web/scripts/check-boundaries.test.mjs
@@ -287,6 +287,28 @@ test('allows Waku pages to compose shared and corresponding route surfaces only'
   );
 });
 
+test('keeps the shared route-lifecycle core free of React and browser effects', () => {
+  assert.deepEqual(
+    describePath('src/shared/route-lifecycle/core/reducer.ts'),
+    { kind: 'shared', layer: 'core' },
+  );
+  assert.deepEqual(
+    describePath('src/shared/route-lifecycle/browser/provider.tsx'),
+    { kind: 'shared', layer: 'browser' },
+  );
+  assert.match(
+    evaluateEdge('src/shared/route-lifecycle/core/reducer.ts', 'react', 'react')[0],
+    /route-lifecycle core/,
+  );
+  assert.match(
+    evaluateEdge(
+      'src/shared/route-lifecycle/core/reducer.ts',
+      'src/shared/route-lifecycle/browser/provider.tsx',
+    )[0],
+    /route-lifecycle core/,
+  );
+});
+
 test('recognizes use-client directives and confines generated modules below them', () => {
   assert.equal(isClientModule("'use client';\nimport '@moonbit/crdt-json';"), true);
   assert.equal(isClientModule('/* comment */\n"use client";\nexport {}'), true);

--- a/examples/web/scripts/smoke-waku-worker.sh
+++ b/examples/web/scripts/smoke-waku-worker.sh
@@ -30,11 +30,11 @@ for _ in $(seq 1 120); do
   sleep 1
 done
 
-grep -q 'Canopy Waku foundation' "$BODY_FILE"
+grep -q 'Canopy demos' "$BODY_FILE"
 asset="$(find dist/public/assets -type f -name '*.js' -printf '%f\n' | sort | head -n 1)"
 test -n "$asset"
 curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/assets/${asset}"
 worker_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   "http://127.0.0.1:${PORT}/__canopy_worker_probe_missing")"
 test "$worker_status" = '404'
-echo 'Waku workerd foundation smoke: OK'
+echo 'Waku workerd Hub smoke: OK'

--- a/examples/web/scripts/waku-lifecycle-contract.test.mjs
+++ b/examples/web/scripts/waku-lifecycle-contract.test.mjs
@@ -3,6 +3,18 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  createLifecycleState,
+  reduceLifecycle,
+} from '../src/shared/route-lifecycle/core/reducer.ts';
+import { applyFocusDecision } from '../src/shared/route-lifecycle/browser/focus-manager.ts';
+import { ownImperativeSession } from '../src/shared/route-lifecycle/browser/imperative-session.ts';
+import {
+  NavigationFailureAlert,
+  PostCommitRouteError,
+} from '../src/shared/route-lifecycle/browser/common-states.ts';
+import { recoverPreCommitNavigation } from '../src/shared/route-lifecycle/browser/navigation-recovery.ts';
 
 const require = createRequire(import.meta.url);
 const wakuPackage = require('waku/package.json');
@@ -49,4 +61,330 @@ test('routes popstate through Waku and leaves route disposal to React unmount cl
   assert.match(clientSource, /window\.addEventListener\('popstate', callback\)/);
   assert.match(clientSource, /changeRoute\(nextRoute, \{[\s\S]*?shouldScroll:/);
   assert.match(clientSource, /return \(\)=>\{[\s\S]*?window\.removeEventListener\('popstate', callback\)/);
+});
+
+test('saves before navigation and disposes the source only after route commit', () => {
+  const sourceSnapshot = { source: 'let answer = 42' };
+  const started = reduceLifecycle(
+    createLifecycleState('lambda'),
+    {
+      type: 'navigation-started',
+      mode: 'push',
+      to: '/json',
+      destination: 'json',
+      source: {
+        demoId: 'lambda',
+        snapshot: sourceSnapshot,
+        focusToken: 'editor',
+      },
+    },
+  );
+
+  sourceSnapshot.source = 'mutated after dispatch';
+  assert.deepEqual(started.state.snapshots.lambda, {
+    value: { source: 'let answer = 42' },
+    focusToken: 'editor',
+  });
+  assert.deepEqual(started.decisions, [
+    { type: 'save-snapshot', demoId: 'lambda' },
+  ]);
+
+  const committed = reduceLifecycle(started.state, {
+    type: 'navigation-committed',
+    destination: 'json',
+    fragment: null,
+  });
+  assert.deepEqual(committed.decisions.slice(0, 2), [
+    { type: 'dispose-surface', demoId: 'lambda' },
+    { type: 'mount-surface', demoId: 'json' },
+  ]);
+});
+
+test('forget immediately removes the requested route snapshot', () => {
+  const withSnapshot = reduceLifecycle(
+    createLifecycleState('resume'),
+    {
+      type: 'navigation-started',
+      mode: 'push',
+      to: '/',
+      destination: null,
+      source: {
+        demoId: 'resume',
+        snapshot: { session: 'normalized' },
+        focusToken: 'source-list',
+      },
+    },
+  ).state;
+
+  const result = reduceLifecycle(withSnapshot, { type: 'forget', demoId: 'resume' });
+
+  assert.equal(result.state.snapshots.resume, undefined);
+  assert.deepEqual(result.decisions, [{ type: 'forget-snapshot', demoId: 'resume' }]);
+});
+
+test('turns push and browser traversal requests into Waku navigation decisions', () => {
+  const state = createLifecycleState(null);
+
+  assert.deepEqual(
+    reduceLifecycle(state, { type: 'navigation-requested', mode: 'push', to: '/json' }),
+    {
+      state,
+      decisions: [{ type: 'navigate', mode: 'push', to: '/json' }],
+    },
+  );
+  assert.deepEqual(
+    reduceLifecycle(state, { type: 'navigation-requested', mode: 'back' }),
+    {
+      state,
+      decisions: [{ type: 'navigate', mode: 'back' }],
+    },
+  );
+  assert.deepEqual(
+    reduceLifecycle(state, { type: 'navigation-requested', mode: 'forward' }),
+    {
+      state,
+      decisions: [{ type: 'navigate', mode: 'forward' }],
+    },
+  );
+});
+
+test('pop mounts the latest snapshot and restores stable focus with a heading fallback', () => {
+  const saved = reduceLifecycle(
+    createLifecycleState('json'),
+    {
+      type: 'navigation-started',
+      mode: 'push',
+      to: '/',
+      destination: null,
+      source: {
+        demoId: 'json',
+        snapshot: { source: '{"answer":42}' },
+        focusToken: 'json-editor',
+      },
+    },
+  ).state;
+  const returning = reduceLifecycle(saved, {
+    type: 'navigation-started',
+    mode: 'pop',
+    to: '/json',
+    destination: 'json',
+  }).state;
+
+  const restored = reduceLifecycle(returning, {
+    type: 'navigation-committed',
+    destination: 'json',
+    fragment: null,
+  });
+  assert.deepEqual(restored.decisions, [
+    { type: 'mount-surface', demoId: 'json', snapshot: { source: '{"answer":42}' } },
+    {
+      type: 'focus-route',
+      preferred: { kind: 'adapter', token: 'json-editor' },
+      fallback: 'route-heading',
+      preventScroll: true,
+    },
+  ]);
+
+  const withoutToken = reduceLifecycle(
+    {
+      ...returning,
+      snapshots: { json: { value: { source: '{}' }, focusToken: null } },
+    },
+    { type: 'navigation-committed', destination: 'json', fragment: null },
+  );
+  assert.deepEqual(withoutToken.decisions.at(-1), {
+    type: 'focus-route',
+    preferred: null,
+    fallback: 'route-heading',
+    preventScroll: true,
+  });
+});
+
+test('push lets Waku scroll to fragments while focus moves to the route heading', () => {
+  const started = reduceLifecycle(createLifecycleState(null), {
+    type: 'navigation-started',
+    mode: 'push',
+    to: '/json',
+    destination: 'json',
+  }).state;
+
+  const committed = reduceLifecycle(started, {
+    type: 'navigation-committed',
+    destination: 'json',
+    fragment: 'editor',
+  });
+
+  assert.deepEqual(committed.decisions.at(-1), {
+    type: 'focus-route',
+    preferred: null,
+    fallback: 'route-heading',
+    preventScroll: true,
+  });
+});
+
+test('a pre-commit failure retains the source route and announces recovery actions', () => {
+  const started = reduceLifecycle(
+    createLifecycleState('lambda'),
+    {
+      type: 'navigation-started',
+      mode: 'push',
+      to: '/json',
+      destination: 'json',
+      source: {
+        demoId: 'lambda',
+        snapshot: { source: 'let answer = 42' },
+        focusToken: 'editor',
+      },
+    },
+  ).state;
+
+  const failed = reduceLifecycle(started, {
+    type: 'navigation-failed',
+    message: 'The demo could not be loaded.',
+    retryHref: '/json',
+  });
+
+  assert.equal(failed.state.activeDemo, 'lambda');
+  assert.equal(failed.state.pending, null);
+  assert.deepEqual(failed.state.snapshots.lambda?.value, { source: 'let answer = 42' });
+  assert.deepEqual(failed.state.error, {
+    phase: 'pre-commit',
+    message: 'The demo could not be loaded.',
+    retryHref: '/json',
+  });
+  assert.deepEqual(failed.decisions, [{
+    type: 'announce-navigation-error',
+    phase: 'pre-commit',
+    message: 'The demo could not be loaded.',
+    retryHref: '/json',
+  }]);
+});
+
+test('a post-commit failure keeps the destination and retries from its retained snapshot', () => {
+  const saved = reduceLifecycle(
+    createLifecycleState('json'),
+    {
+      type: 'navigation-started',
+      mode: 'push',
+      to: '/',
+      destination: null,
+      source: {
+        demoId: 'json',
+        snapshot: { source: '{"answer":42}' },
+        focusToken: 'json-editor',
+      },
+    },
+  ).state;
+  const returning = reduceLifecycle(saved, {
+    type: 'navigation-started',
+    mode: 'pop',
+    to: '/json',
+    destination: 'json',
+  }).state;
+  const committed = reduceLifecycle(returning, {
+    type: 'navigation-committed',
+    destination: 'json',
+    fragment: null,
+  }).state;
+
+  const failed = reduceLifecycle(committed, {
+    type: 'render-failed',
+    demoId: 'json',
+    message: 'This demo could not be displayed.',
+  });
+  assert.equal(failed.state.activeDemo, 'json');
+  assert.deepEqual(failed.state.error, {
+    phase: 'post-commit',
+    demoId: 'json',
+    message: 'This demo could not be displayed.',
+  });
+  assert.deepEqual(failed.decisions, [
+    { type: 'dispose-surface', demoId: 'json' },
+    {
+      type: 'show-route-error',
+      demoId: 'json',
+      message: 'This demo could not be displayed.',
+    },
+  ]);
+
+  const retried = reduceLifecycle(failed.state, { type: 'retry' });
+  assert.equal(retried.state.error, null);
+  assert.deepEqual(retried.decisions, [
+    { type: 'dispose-surface', demoId: 'json' },
+    { type: 'mount-surface', demoId: 'json', snapshot: { source: '{"answer":42}' } },
+  ]);
+});
+
+test('focus manager falls back to the route heading without changing scroll', () => {
+  const focusCalls = [];
+  const heading = { focus: (options) => focusCalls.push(['heading', options]) };
+  const document = {
+    getElementById: () => null,
+    querySelector: (selector) => selector === '[data-route-heading]' ? heading : null,
+  };
+  const session = { restoreFocus: () => false };
+
+  const outcome = applyFocusDecision(
+    {
+      type: 'focus-route',
+      preferred: { kind: 'adapter', token: 'missing-control' },
+      fallback: 'route-heading',
+      preventScroll: true,
+    },
+    { document, session },
+  );
+
+  assert.equal(outcome, 'route-heading');
+  assert.deepEqual(focusCalls, [['heading', { preventScroll: true }]]);
+});
+
+test('imperative sessions defensively own snapshots and dispose idempotently', () => {
+  const mutableSnapshot = { source: 'initial' };
+  let disposeCount = 0;
+  const session = ownImperativeSession({
+    snapshot: () => mutableSnapshot,
+    restoreFocus: (token) => token === 'editor',
+    dispose: () => { disposeCount += 1; },
+  });
+
+  const captured = session.snapshot();
+  const restoredBeforeDispose = session.restoreFocus('editor');
+  mutableSnapshot.source = 'changed later';
+  session.dispose();
+  session.dispose();
+
+  assert.deepEqual(captured, { source: 'initial' });
+  assert.equal(restoredBeforeDispose, true);
+  assert.equal(session.restoreFocus('editor'), false);
+  assert.equal(disposeCount, 1);
+});
+
+test('common failure states expose accessible recovery without leaking error details', () => {
+  const preCommit = renderToStaticMarkup(NavigationFailureAlert({
+    message: 'The demo could not be loaded.',
+    retryHref: '/json',
+    onRetry: () => {},
+  }));
+  assert.match(preCommit, /role="alert"/);
+  assert.match(preCommit, />Retry</);
+  assert.match(preCommit, /href="\/json"[^>]*>Open directly</);
+
+  const postCommit = renderToStaticMarkup(PostCommitRouteError({ onRetry: () => {} }));
+  assert.match(postCommit, /data-route-error-heading="true"/);
+  assert.match(postCommit, />Retry</);
+  assert.match(postCommit, /href="\/"[^>]*>Back to demos</);
+  assert.doesNotMatch(postCommit, /stack|payload|exception/i);
+});
+
+test('pre-commit recovery records the failure before traversing back', () => {
+  const calls = [];
+  recoverPreCommitNavigation(
+    { back: () => { calls.push(['back']); } },
+    () => { calls.push(['remember']); },
+  );
+
+  assert.deepEqual(calls, [
+    ['remember'],
+    ['back'],
+  ]);
 });

--- a/examples/web/scripts/waku-lifecycle-contract.test.mjs
+++ b/examples/web/scripts/waku-lifecycle-contract.test.mjs
@@ -21,6 +21,10 @@ const wakuPackage = require('waku/package.json');
 const clientSourceUrl = import.meta.resolve('waku/router/client');
 const clientSourcePath = fileURLToPath(clientSourceUrl);
 const clientSource = fs.readFileSync(clientSourcePath, 'utf8');
+const providerSource = fs.readFileSync(
+  fileURLToPath(new URL('../src/shared/route-lifecycle/browser/provider.tsx', import.meta.url)),
+  'utf8',
+);
 const clientTypes = fs.readFileSync(
   clientSourcePath.replace(/\.js$/, '.d.ts'),
   'utf8',
@@ -260,6 +264,19 @@ test('a pre-commit failure retains the source route and announces recovery actio
   }]);
 });
 
+test('a pre-commit retry clears the error and pushes the retained target', () => {
+  const failed = reduceLifecycle(createLifecycleState('lambda'), {
+    type: 'navigation-failed',
+    message: 'The demo could not be loaded.',
+    retryHref: '/json',
+  }).state;
+
+  const retried = reduceLifecycle(failed, { type: 'retry' });
+
+  assert.equal(retried.state.error, null);
+  assert.deepEqual(retried.decisions, [{ type: 'navigate', mode: 'push', to: '/json' }]);
+});
+
 test('a post-commit failure keeps the destination and retries from its retained snapshot', () => {
   const saved = reduceLifecycle(
     createLifecycleState('json'),
@@ -369,11 +386,22 @@ test('common failure states expose accessible recovery without leaking error det
   assert.match(preCommit, />Retry</);
   assert.match(preCommit, /href="\/json"[^>]*>Open directly</);
 
-  const postCommit = renderToStaticMarkup(PostCommitRouteError({ onRetry: () => {} }));
+  const postCommit = renderToStaticMarkup(PostCommitRouteError({
+    message: 'The restored editor state is unavailable.',
+    onRetry: () => {},
+  }));
   assert.match(postCommit, /data-route-error-heading="true"/);
+  assert.match(postCommit, /The restored editor state is unavailable\./);
   assert.match(postCommit, />Retry</);
   assert.match(postCommit, /href="\/"[^>]*>Back to demos</);
   assert.doesNotMatch(postCommit, /stack|payload|exception/i);
+});
+
+test('the provider shell handles the reducer post-commit error decision', () => {
+  assert.match(
+    providerSource,
+    /decision\.type === 'show-route-error'[\s\S]*?setRouteErrorMessage\(decision\.message\)/,
+  );
 });
 
 test('pre-commit recovery records the failure before traversing back', () => {

--- a/examples/web/src/pages/404.tsx
+++ b/examples/web/src/pages/404.tsx
@@ -1,0 +1,10 @@
+export default function NotFoundPage() {
+  return (
+    <main className="route-state" aria-labelledby="not-found-heading">
+      <p className="route-state__label">404</p>
+      <h1 id="not-found-heading" tabIndex={-1} data-route-heading>Demo not found</h1>
+      <p>The requested page is not part of the Canopy demo catalog.</p>
+      <a className="route-state__action" href="/">Back to demos</a>
+    </main>
+  );
+}

--- a/examples/web/src/pages/_layout.tsx
+++ b/examples/web/src/pages/_layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function Layout({ children }: { readonly children: ReactNode }) {
+  return children;
+}

--- a/examples/web/src/pages/_root.tsx
+++ b/examples/web/src/pages/_root.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import { RouteLifecycleProvider } from '../shared/route-lifecycle/browser/provider';
+import '../shared/shell/styles.css';
 
 export default function Root({ children }: { readonly children: ReactNode }) {
   return (
@@ -6,9 +8,9 @@ export default function Root({ children }: { readonly children: ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Canopy Waku Foundation</title>
+        <title>Canopy demos</title>
       </head>
-      <body>{children}</body>
+      <body><RouteLifecycleProvider>{children}</RouteLifecycleProvider></body>
     </html>
   );
 }

--- a/examples/web/src/pages/foundation.tsx
+++ b/examples/web/src/pages/foundation.tsx
@@ -1,0 +1,11 @@
+import { MoonbitClientProbe } from '../shared/browser/moonbit-client-probe';
+
+export default function WakuFoundationPage() {
+  return (
+    <main className="route-state">
+      <h1 tabIndex={-1} data-route-heading>Canopy Waku foundation</h1>
+      <p>This pre-production route verifies the generated client artifact boundary.</p>
+      <MoonbitClientProbe />
+    </main>
+  );
+}

--- a/examples/web/src/pages/genui.tsx
+++ b/examples/web/src/pages/genui.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Genui() {
+  return <DemoPlaceholder demoId="genui" />;
+}

--- a/examples/web/src/pages/index.tsx
+++ b/examples/web/src/pages/index.tsx
@@ -1,11 +1,5 @@
-import { MoonbitClientProbe } from '../shared/browser/moonbit-client-probe';
+import { DemoHub } from '../shared/shell/demo-hub';
 
-export default function WakuFoundationPage() {
-  return (
-    <main>
-      <h1>Canopy Waku foundation</h1>
-      <p>This pre-production route verifies the generated client artifact boundary.</p>
-      <MoonbitClientProbe />
-    </main>
-  );
-}
+export { DemoHub };
+
+export default DemoHub;

--- a/examples/web/src/pages/journey.tsx
+++ b/examples/web/src/pages/journey.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Journey() {
+  return <DemoPlaceholder demoId="journey" />;
+}

--- a/examples/web/src/pages/json.tsx
+++ b/examples/web/src/pages/json.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Json() {
+  return <DemoPlaceholder demoId="json" />;
+}

--- a/examples/web/src/pages/markdown.tsx
+++ b/examples/web/src/pages/markdown.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Markdown() {
+  return <DemoPlaceholder demoId="markdown" />;
+}

--- a/examples/web/src/pages/memo.tsx
+++ b/examples/web/src/pages/memo.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Memo() {
+  return <DemoPlaceholder demoId="memo" />;
+}

--- a/examples/web/src/pages/ml.tsx
+++ b/examples/web/src/pages/ml.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Ml() {
+  return <DemoPlaceholder demoId="lambda" />;
+}

--- a/examples/web/src/pages/posts.tsx
+++ b/examples/web/src/pages/posts.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Posts() {
+  return <DemoPlaceholder demoId="posts" />;
+}

--- a/examples/web/src/pages/resume.tsx
+++ b/examples/web/src/pages/resume.tsx
@@ -1,0 +1,5 @@
+import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+
+export default function Resume() {
+  return <DemoPlaceholder demoId="resume" />;
+}

--- a/examples/web/src/shared/catalog/demo-catalog.ts
+++ b/examples/web/src/shared/catalog/demo-catalog.ts
@@ -1,0 +1,104 @@
+export type DemoId =
+  | 'lambda'
+  | 'json'
+  | 'markdown'
+  | 'memo'
+  | 'posts'
+  | 'resume'
+  | 'genui'
+  | 'journey';
+
+export type DemoPath =
+  | '/ml'
+  | '/json'
+  | '/markdown'
+  | '/memo'
+  | '/posts'
+  | '/resume'
+  | '/genui'
+  | '/journey';
+
+export type DemoGroupId = 'editors' | 'memory' | 'generated-change';
+
+export interface DemoGroup {
+  readonly id: DemoGroupId;
+  readonly title: string;
+}
+
+export interface DemoDefinition {
+  readonly id: DemoId;
+  readonly title: string;
+  readonly description: string;
+  readonly href: DemoPath;
+  readonly group: DemoGroupId;
+}
+
+export const DEMO_GROUPS: readonly DemoGroup[] = [
+  { id: 'editors', title: 'Editors' },
+  { id: 'memory', title: 'Notes and history' },
+  { id: 'generated-change', title: 'Generated UI and proposals' },
+];
+
+/** Add one entry here to include another demo in the Hub. */
+export const DEMOS: readonly DemoDefinition[] = [
+  {
+    id: 'lambda',
+    title: 'Mini-ML Editor',
+    description: 'Edit Mini-ML code and inspect its AST, type errors, and evaluation results.',
+    href: '/ml',
+    group: 'editors',
+  },
+  {
+    id: 'json',
+    title: 'JSON Editor',
+    description: 'Edit JSON as text or a tree and review the edit history.',
+    href: '/json',
+    group: 'editors',
+  },
+  {
+    id: 'markdown',
+    title: 'Markdown Editor',
+    description: 'Edit Markdown in block, source, and preview views.',
+    href: '/markdown',
+    group: 'editors',
+  },
+  {
+    id: 'memo',
+    title: 'Canopy Memo',
+    description: 'Review spelling corrections and structured edits before applying them.',
+    href: '/memo',
+    group: 'memory',
+  },
+  {
+    id: 'posts',
+    title: 'Posts',
+    description: 'Save short notes locally and find earlier posts related to what you are writing.',
+    href: '/posts',
+    group: 'memory',
+  },
+  {
+    id: 'resume',
+    title: 'Session Resume',
+    description: 'Review an agent session by timeline, conversation, and source.',
+    href: '/resume',
+    group: 'memory',
+  },
+  {
+    id: 'genui',
+    title: 'Generative UI',
+    description: 'Edit JSX and inspect the parser output and generated interface.',
+    href: '/genui',
+    group: 'generated-change',
+  },
+  {
+    id: 'journey',
+    title: 'Journey Proposals',
+    description: 'Compare changes to a travel plan, apply them, and undo them.',
+    href: '/journey',
+    group: 'generated-change',
+  },
+];
+
+export function demoIdForPath(path: string): DemoId | null {
+  return DEMOS.find((demo) => demo.href === path)?.id ?? null;
+}

--- a/examples/web/src/shared/route-lifecycle/browser/common-states.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/common-states.ts
@@ -22,8 +22,10 @@ export function NavigationFailureAlert({
 }
 
 export function PostCommitRouteError({
+  message,
   onRetry,
 }: {
+  readonly message: string;
   readonly onRetry: () => void;
 }): ReactElement {
   return createElement('main', {
@@ -36,9 +38,10 @@ export function PostCommitRouteError({
       'data-route-error-heading': true,
       key: 'heading',
     }, 'This demo could not be displayed'),
+    createElement('p', { key: 'message' }, message),
     createElement(
       'p',
-      { key: 'message' },
+      { key: 'recovery' },
       'The destination remains selected. Retry the demo or return to the catalog.',
     ),
     createElement('div', { className: 'route-state__actions', key: 'actions' }, [

--- a/examples/web/src/shared/route-lifecycle/browser/common-states.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/common-states.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { createElement, type ReactElement } from 'react';
+import type { LifecycleHref } from '../core/reducer';
+
+export function NavigationFailureAlert({
+  message,
+  retryHref,
+  onRetry,
+}: {
+  readonly message: string;
+  readonly retryHref: LifecycleHref;
+  readonly onRetry: () => void;
+}): ReactElement {
+  return createElement('div', { className: 'navigation-alert', role: 'alert' }, [
+    createElement('p', { key: 'message' }, message),
+    createElement('div', { className: 'route-state__actions', key: 'actions' }, [
+      createElement('button', { type: 'button', onClick: onRetry, key: 'retry' }, 'Retry'),
+      createElement('a', { href: retryHref, key: 'fallback' }, 'Open directly'),
+    ]),
+  ]);
+}
+
+export function PostCommitRouteError({
+  onRetry,
+}: {
+  readonly onRetry: () => void;
+}): ReactElement {
+  return createElement('main', {
+    className: 'route-state route-state--error',
+    role: 'alert',
+  }, [
+    createElement('p', { className: 'route-state__label', key: 'label' }, 'Demo error'),
+    createElement('h1', {
+      tabIndex: -1,
+      'data-route-error-heading': true,
+      key: 'heading',
+    }, 'This demo could not be displayed'),
+    createElement(
+      'p',
+      { key: 'message' },
+      'The destination remains selected. Retry the demo or return to the catalog.',
+    ),
+    createElement('div', { className: 'route-state__actions', key: 'actions' }, [
+      createElement('button', { type: 'button', onClick: onRetry, key: 'retry' }, 'Retry'),
+      createElement('a', { href: '/', key: 'back' }, 'Back to demos'),
+    ]),
+  ]);
+}

--- a/examples/web/src/shared/route-lifecycle/browser/focus-manager.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/focus-manager.ts
@@ -1,0 +1,37 @@
+import type { LifecycleDecision } from '../core/reducer';
+
+type FocusDecision = Extract<LifecycleDecision, { readonly type: 'focus-route' }>;
+
+interface FocusTarget {
+  focus(options?: FocusOptions): void;
+}
+
+interface FocusDocument {
+  querySelector(selector: string): FocusTarget | null;
+}
+
+interface FocusSession {
+  restoreFocus(token: string): boolean;
+}
+
+export type FocusOutcome = 'preferred' | 'route-heading' | 'none';
+
+export function applyFocusDecision(
+  decision: FocusDecision,
+  dependencies: {
+    readonly document: FocusDocument;
+    readonly session?: FocusSession;
+  },
+): FocusOutcome {
+  const { preferred } = decision;
+  if (
+    preferred?.kind === 'adapter' &&
+    dependencies.session?.restoreFocus(preferred.token) === true
+  ) {
+    return 'preferred';
+  }
+  const heading = dependencies.document.querySelector('[data-route-heading]');
+  if (heading === null) return 'none';
+  heading.focus({ preventScroll: decision.preventScroll });
+  return 'route-heading';
+}

--- a/examples/web/src/shared/route-lifecycle/browser/imperative-host.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/imperative-host.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { createElement, useLayoutEffect, useRef } from 'react';
+import type { DemoId } from '../../catalog/demo-catalog';
+import {
+  type MountedImperativeSession,
+  ownImperativeSession,
+} from './imperative-session';
+import { useRouteLifecycle } from './provider';
+
+export type { MountedImperativeSession } from './imperative-session';
+
+export type MountImperativeDemo = (
+  container: HTMLElement,
+  restoredSnapshot: unknown,
+) => MountedImperativeSession;
+
+export function ImperativeDemoHost({
+  demoId,
+  mount,
+  className,
+}: {
+  readonly demoId: DemoId;
+  readonly mount: MountImperativeDemo;
+  readonly className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lifecycle = useRouteLifecycle();
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (container === null) throw new Error('Imperative demo host container is unavailable');
+    const session = ownImperativeSession(
+      mount(container, lifecycle.snapshotForMount(demoId)),
+    );
+    return lifecycle.registerSurface(demoId, { container, session });
+  }, [demoId, lifecycle.mountRevision, lifecycle.registerSurface, lifecycle.snapshotForMount, mount]);
+
+  return createElement('div', {
+    ref: containerRef,
+    className,
+    'data-imperative-demo-host': demoId,
+  });
+}

--- a/examples/web/src/shared/route-lifecycle/browser/imperative-host.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/imperative-host.ts
@@ -10,6 +10,7 @@ import { useRouteLifecycle } from './provider';
 
 export type { MountedImperativeSession } from './imperative-session';
 
+/** Keep this callback referentially stable; memoize inline implementations with `useCallback`. */
 export type MountImperativeDemo = (
   container: HTMLElement,
   restoredSnapshot: unknown,

--- a/examples/web/src/shared/route-lifecycle/browser/imperative-session.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/imperative-session.ts
@@ -1,0 +1,20 @@
+export interface MountedImperativeSession {
+  snapshot(): unknown;
+  restoreFocus(token: string): boolean;
+  dispose(): void;
+}
+
+export function ownImperativeSession(
+  session: MountedImperativeSession,
+): MountedImperativeSession {
+  let disposed = false;
+  return {
+    snapshot: () => structuredClone(session.snapshot()),
+    restoreFocus: (token) => !disposed && session.restoreFocus(token),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      session.dispose();
+    },
+  };
+}

--- a/examples/web/src/shared/route-lifecycle/browser/lifecycle-link.tsx
+++ b/examples/web/src/shared/route-lifecycle/browser/lifecycle-link.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from 'react';
+import { Link } from 'waku/router/client';
+import type { LifecycleHref } from '../core/reducer';
+import { useRouteLifecycle } from './provider';
+
+interface LifecycleLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  readonly to: LifecycleHref;
+  readonly children: ReactNode;
+}
+
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return event.button !== 0 || event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+}
+
+export function LifecycleLink({
+  to,
+  children,
+  onClick,
+  target,
+  download,
+  ...props
+}: LifecycleLinkProps) {
+  const lifecycle = useRouteLifecycle();
+  const downloads = download !== undefined && download !== null && download !== false;
+  if ((target !== undefined && target.toLowerCase() !== '_self') || downloads) {
+    return (
+      <a {...props} href={to} target={target} download={download} onClick={onClick}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      {...props}
+      to={to}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented || isModifiedClick(event)) return;
+        event.preventDefault();
+        lifecycle.navigate(to);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/examples/web/src/shared/route-lifecycle/browser/navigation-recovery.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/navigation-recovery.ts
@@ -1,0 +1,11 @@
+interface RecoveryRouter {
+  back(): void;
+}
+
+export function recoverPreCommitNavigation(
+  router: RecoveryRouter,
+  rememberFailure: () => void,
+): void {
+  rememberFailure();
+  router.back();
+}

--- a/examples/web/src/shared/route-lifecycle/browser/provider.tsx
+++ b/examples/web/src/shared/route-lifecycle/browser/provider.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useRouter } from 'waku/router/client';
+import { demoIdForPath, type DemoId } from '../../catalog/demo-catalog';
+import {
+  createLifecycleState,
+  type LifecycleDecision,
+  type LifecycleEvent,
+  type LifecycleHref,
+  reduceLifecycle,
+  type RouteFailure,
+} from '../core/reducer';
+import { NavigationFailureAlert } from './common-states';
+import { applyFocusDecision } from './focus-manager';
+import type { MountedImperativeSession } from './imperative-session';
+import { recoverPreCommitNavigation } from './navigation-recovery';
+import { RouteRenderBoundary } from './route-render-boundary';
+
+interface RegisteredSurface {
+  readonly container: HTMLElement;
+  readonly session: MountedImperativeSession;
+}
+
+interface RegisteredReactRoute {
+  snapshot(): unknown;
+  restoreFocus(token: string): boolean;
+}
+
+interface RouteLifecycleContextValue {
+  readonly registerSurface: (
+    demoId: DemoId,
+    surface: RegisteredSurface,
+  ) => () => void;
+  readonly snapshotForMount: (demoId: DemoId) => unknown;
+  readonly registerReactRoute: (
+    demoId: DemoId,
+    route: RegisteredReactRoute,
+  ) => () => void;
+  readonly mountRevision: number;
+  readonly forget: (demoId: DemoId) => void;
+  readonly navigate: (to: LifecycleHref) => void;
+  readonly back: () => void;
+  readonly forward: () => void;
+}
+
+const RouteLifecycleContext = createContext<RouteLifecycleContextValue | null>(null);
+
+function safeFocusToken(surface: RegisteredSurface | undefined): string | null {
+  if (surface === undefined) return null;
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement) || !surface.container.contains(active)) return null;
+  return active.closest<HTMLElement>('[data-route-focus]')?.dataset.routeFocus ?? null;
+}
+
+export function RouteLifecycleProvider({ children }: { readonly children: ReactNode }) {
+  const router = useRouter();
+  const lifecycle = useRef(createLifecycleState(demoIdForPath(router.path)));
+  const surfaces = useRef(new Map<DemoId, RegisteredSurface>());
+  const reactRoutes = useRef(new Map<DemoId, RegisteredReactRoute>());
+  const nextMode = useRef<'push' | 'pop'>('push');
+  const headingBeforeNavigation = useRef<HTMLElement | null>(null);
+  const pendingPreCommitFailure = useRef<LifecycleHref | null>(null);
+  const [preCommitError, setPreCommitError] = useState<RouteFailure | null>(null);
+  const [ready, setReady] = useState(false);
+  const [mountRevision, setMountRevision] = useState(0);
+  const [boundaryRevision, setBoundaryRevision] = useState(0);
+
+  const executeDecisions = useCallback((decisions: readonly LifecycleDecision[]) => {
+    for (const decision of decisions) {
+      if (decision.type === 'dispose-surface') {
+        surfaces.current.get(decision.demoId)?.session.dispose();
+      } else if (decision.type === 'navigate') {
+        if (decision.mode === 'push') {
+          void router.push(decision.to).catch(() => {
+            recoverPreCommitNavigation(router, () => {
+              pendingPreCommitFailure.current = decision.to;
+            });
+          });
+        } else if (decision.mode === 'back') {
+          router.back();
+        } else {
+          router.forward();
+        }
+      } else if (decision.type === 'focus-route') {
+        let attempts = 0;
+        const focusCommittedRoute = () => {
+          const heading = document.querySelector<HTMLElement>('[data-route-heading]');
+          if (
+            heading === headingBeforeNavigation.current &&
+            attempts < 60
+          ) {
+            attempts += 1;
+            requestAnimationFrame(focusCommittedRoute);
+            return;
+          }
+          const activeDemo = lifecycle.current.activeDemo;
+          const session = activeDemo === null
+            ? undefined
+            : surfaces.current.get(activeDemo)?.session ?? reactRoutes.current.get(activeDemo);
+          applyFocusDecision(decision, {
+            document,
+            ...(session === undefined ? {} : { session }),
+          });
+          headingBeforeNavigation.current = null;
+        };
+        requestAnimationFrame(focusCommittedRoute);
+      } else if (decision.type === 'announce-navigation-error') {
+        setPreCommitError({
+          phase: 'pre-commit',
+          message: decision.message,
+          retryHref: decision.retryHref,
+        });
+      } else if (decision.type === 'mount-surface') {
+        setMountRevision((revision) => revision + 1);
+      }
+    }
+  // `dispatch` reads only refs and this callback; the declaration is intentionally recursive.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]);
+
+  function dispatch(event: LifecycleEvent): void {
+    const result = reduceLifecycle(lifecycle.current, event);
+    lifecycle.current = result.state;
+    if (result.state.error?.phase !== 'pre-commit') setPreCommitError(null);
+    executeDecisions(result.decisions);
+  }
+
+  useLayoutEffect(() => {
+    const markPop = () => {
+      nextMode.current = 'pop';
+    };
+    const handleStart = (route: { readonly path: string }) => {
+      headingBeforeNavigation.current = document.querySelector<HTMLElement>('[data-route-heading]');
+      const sourceDemo = lifecycle.current.activeDemo;
+      const surface = sourceDemo === null ? undefined : surfaces.current.get(sourceDemo);
+      let source: Extract<LifecycleEvent, { type: 'navigation-started' }>['source'];
+      if (sourceDemo !== null && surface !== undefined) {
+        source = {
+          demoId: sourceDemo,
+          snapshot: surface.session.snapshot(),
+          focusToken: safeFocusToken(surface),
+        };
+      } else if (sourceDemo !== null) {
+        const reactRoute = reactRoutes.current.get(sourceDemo);
+        if (reactRoute !== undefined) {
+          const active = document.activeElement;
+          source = {
+            demoId: sourceDemo,
+            snapshot: reactRoute.snapshot(),
+            focusToken: active instanceof HTMLElement
+              ? active.closest<HTMLElement>('[data-route-focus]')?.dataset.routeFocus ?? null
+              : null,
+          };
+        }
+      }
+      dispatch({
+        type: 'navigation-started',
+        mode: nextMode.current,
+        to: route.path,
+        destination: demoIdForPath(route.path),
+        ...(source === undefined ? {} : { source }),
+      });
+      nextMode.current = 'push';
+    };
+    const handleComplete = (route: { readonly path: string; readonly hash: string }) => {
+      dispatch({
+        type: 'navigation-committed',
+        destination: demoIdForPath(route.path),
+        fragment: route.hash.startsWith('#') ? route.hash.slice(1) : null,
+      });
+      const failedTarget = pendingPreCommitFailure.current;
+      if (failedTarget !== null) {
+        pendingPreCommitFailure.current = null;
+        dispatch({
+          type: 'navigation-failed',
+          message: 'The demo could not be loaded.',
+          retryHref: failedTarget,
+        });
+        setBoundaryRevision((revision) => revision + 1);
+      }
+    };
+
+    window.addEventListener('popstate', markPop);
+    router.unstable_events.on('start', handleStart);
+    router.unstable_events.on('complete', handleComplete);
+    setReady(true);
+    return () => {
+      window.removeEventListener('popstate', markPop);
+      router.unstable_events.off('start', handleStart);
+      router.unstable_events.off('complete', handleComplete);
+      for (const surface of surfaces.current.values()) surface.session.dispose();
+      surfaces.current.clear();
+      reactRoutes.current.clear();
+    };
+  // The pinned Waku router event registry is stable for the provider lifetime.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.unstable_events]);
+
+  const registerSurface = useCallback((demoId: DemoId, surface: RegisteredSurface) => {
+    surfaces.current.get(demoId)?.session.dispose();
+    surfaces.current.set(demoId, surface);
+    return () => {
+      if (surfaces.current.get(demoId) !== surface) return;
+      surface.session.dispose();
+      surfaces.current.delete(demoId);
+    };
+  }, []);
+
+  const snapshotForMount = useCallback((demoId: DemoId) => {
+    const snapshot = lifecycle.current.snapshots[demoId];
+    return snapshot === undefined ? undefined : structuredClone(snapshot.value);
+  }, []);
+
+  const registerReactRoute = useCallback((demoId: DemoId, route: RegisteredReactRoute) => {
+    reactRoutes.current.set(demoId, route);
+    return () => {
+      if (reactRoutes.current.get(demoId) === route) reactRoutes.current.delete(demoId);
+    };
+  }, []);
+
+  const actions = useMemo<RouteLifecycleContextValue>(() => ({
+    registerSurface,
+    snapshotForMount,
+    registerReactRoute,
+    mountRevision,
+    forget: (demoId) => dispatch({ type: 'forget', demoId }),
+    navigate: (to) => dispatch({ type: 'navigation-requested', mode: 'push', to }),
+    back: () => dispatch({ type: 'navigation-requested', mode: 'back' }),
+    forward: () => dispatch({ type: 'navigation-requested', mode: 'forward' }),
+  // `dispatch` is a ref-backed command boundary and intentionally not memoized.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [mountRevision, registerReactRoute, registerSurface, snapshotForMount]);
+
+  const reportRenderFailure = useCallback(() => {
+    if (lifecycle.current.pending !== null) return;
+    const demoId = lifecycle.current.activeDemo;
+    if (demoId === null) return;
+    dispatch({
+      type: 'render-failed',
+      demoId,
+      message: 'This demo could not be displayed.',
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const retryRender = useCallback(() => {
+    dispatch({ type: 'retry' });
+    setBoundaryRevision((revision) => revision + 1);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <RouteLifecycleContext.Provider value={actions}>
+      <div data-route-lifecycle-ready={ready ? 'true' : 'false'}>
+        {preCommitError?.phase === 'pre-commit' ? (
+          <NavigationFailureAlert
+            message={preCommitError.message}
+            retryHref={preCommitError.retryHref}
+            onRetry={() => dispatch({ type: 'retry' })}
+          />
+        ) : null}
+        <RouteRenderBoundary
+          key={boundaryRevision}
+          onError={reportRenderFailure}
+          onRetry={retryRender}
+        >
+          {children}
+        </RouteRenderBoundary>
+      </div>
+    </RouteLifecycleContext.Provider>
+  );
+}
+
+export function useRouteLifecycle(): RouteLifecycleContextValue {
+  const value = useContext(RouteLifecycleContext);
+  if (value === null) throw new Error('Route lifecycle context is unavailable');
+  return value;
+}
+
+export function useRouteSnapshot<Snapshot>(
+  demoId: DemoId,
+  adapter: {
+    readonly snapshot: () => Snapshot;
+    readonly restoreFocus: (token: string) => boolean;
+  },
+): Snapshot | undefined {
+  const lifecycle = useRouteLifecycle();
+  const adapterRef = useRef(adapter);
+  adapterRef.current = adapter;
+  const restored = useRef<Snapshot | undefined>(
+    lifecycle.snapshotForMount(demoId) as Snapshot | undefined,
+  );
+
+  useLayoutEffect(
+    () => lifecycle.registerReactRoute(demoId, {
+      snapshot: () => adapterRef.current.snapshot(),
+      restoreFocus: (token) => adapterRef.current.restoreFocus(token),
+    }),
+    [demoId, lifecycle.registerReactRoute],
+  );
+  return restored.current;
+}

--- a/examples/web/src/shared/route-lifecycle/browser/provider.tsx
+++ b/examples/web/src/shared/route-lifecycle/browser/provider.tsx
@@ -54,6 +54,7 @@ interface RouteLifecycleContextValue {
 }
 
 const RouteLifecycleContext = createContext<RouteLifecycleContextValue | null>(null);
+const DEFAULT_ROUTE_ERROR_MESSAGE = 'This demo could not be displayed.';
 
 function safeFocusToken(surface: RegisteredSurface | undefined): string | null {
   if (surface === undefined) return null;
@@ -74,11 +75,14 @@ export function RouteLifecycleProvider({ children }: { readonly children: ReactN
   const [ready, setReady] = useState(false);
   const [mountRevision, setMountRevision] = useState(0);
   const [boundaryRevision, setBoundaryRevision] = useState(0);
+  const [routeErrorMessage, setRouteErrorMessage] = useState(DEFAULT_ROUTE_ERROR_MESSAGE);
 
   const executeDecisions = useCallback((decisions: readonly LifecycleDecision[]) => {
     for (const decision of decisions) {
       if (decision.type === 'dispose-surface') {
         surfaces.current.get(decision.demoId)?.session.dispose();
+      } else if (decision.type === 'show-route-error') {
+        setRouteErrorMessage(decision.message);
       } else if (decision.type === 'navigate') {
         if (decision.mode === 'push') {
           void router.push(decision.to).catch(() => {
@@ -248,13 +252,14 @@ export function RouteLifecycleProvider({ children }: { readonly children: ReactN
     dispatch({
       type: 'render-failed',
       demoId,
-      message: 'This demo could not be displayed.',
+      message: DEFAULT_ROUTE_ERROR_MESSAGE,
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const retryRender = useCallback(() => {
     dispatch({ type: 'retry' });
+    setRouteErrorMessage(DEFAULT_ROUTE_ERROR_MESSAGE);
     setBoundaryRevision((revision) => revision + 1);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -271,6 +276,7 @@ export function RouteLifecycleProvider({ children }: { readonly children: ReactN
         ) : null}
         <RouteRenderBoundary
           key={boundaryRevision}
+          message={routeErrorMessage}
           onError={reportRenderFailure}
           onRetry={retryRender}
         >

--- a/examples/web/src/shared/route-lifecycle/browser/route-render-boundary.tsx
+++ b/examples/web/src/shared/route-lifecycle/browser/route-render-boundary.tsx
@@ -5,6 +5,7 @@ import { PostCommitRouteError } from './common-states';
 
 interface RouteRenderBoundaryProps {
   readonly children: ReactNode;
+  readonly message: string;
   readonly onError: () => void;
   readonly onRetry: () => void;
 }
@@ -33,6 +34,8 @@ export class RouteRenderBoundary extends Component<
 
   render(): ReactNode {
     if (!this.state.failed) return this.props.children;
-    return <PostCommitRouteError onRetry={this.props.onRetry} />;
+    return (
+      <PostCommitRouteError message={this.props.message} onRetry={this.props.onRetry} />
+    );
   }
 }

--- a/examples/web/src/shared/route-lifecycle/browser/route-render-boundary.tsx
+++ b/examples/web/src/shared/route-lifecycle/browser/route-render-boundary.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { PostCommitRouteError } from './common-states';
+
+interface RouteRenderBoundaryProps {
+  readonly children: ReactNode;
+  readonly onError: () => void;
+  readonly onRetry: () => void;
+}
+
+interface RouteRenderBoundaryState {
+  readonly failed: boolean;
+}
+
+export class RouteRenderBoundary extends Component<
+  RouteRenderBoundaryProps,
+  RouteRenderBoundaryState
+> {
+  state: RouteRenderBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): RouteRenderBoundaryState {
+    return { failed: true };
+  }
+
+  componentDidCatch(_error: unknown, _errorInfo: ErrorInfo): void {
+    this.props.onError();
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLElement>('[data-route-error-heading]')
+        ?.focus({ preventScroll: true });
+    });
+  }
+
+  render(): ReactNode {
+    if (!this.state.failed) return this.props.children;
+    return <PostCommitRouteError onRetry={this.props.onRetry} />;
+  }
+}

--- a/examples/web/src/shared/route-lifecycle/core/reducer.ts
+++ b/examples/web/src/shared/route-lifecycle/core/reducer.ts
@@ -1,0 +1,261 @@
+import type { DemoId, DemoPath } from '../../catalog/demo-catalog';
+
+export type LifecycleHref = DemoPath | '/';
+
+export interface SnapshotRecord {
+  readonly value: unknown;
+  readonly focusToken: string | null;
+}
+
+export interface PendingNavigation {
+  readonly mode: 'push' | 'pop';
+  readonly to: string;
+  readonly destination: DemoId | null;
+  readonly source: DemoId | null;
+}
+
+export type RouteFailure =
+  | {
+      readonly phase: 'pre-commit';
+      readonly message: string;
+      readonly retryHref: LifecycleHref;
+    }
+  | {
+      readonly phase: 'post-commit';
+      readonly demoId: DemoId;
+      readonly message: string;
+    };
+
+export interface LifecycleState {
+  readonly activeDemo: DemoId | null;
+  readonly snapshots: Readonly<Partial<Record<DemoId, SnapshotRecord>>>;
+  readonly pending: PendingNavigation | null;
+  readonly error: RouteFailure | null;
+}
+
+export type LifecycleEvent =
+  | {
+      readonly type: 'navigation-started';
+      readonly mode: 'push' | 'pop';
+      readonly to: string;
+      readonly destination: DemoId | null;
+      readonly source?: {
+        readonly demoId: DemoId;
+        readonly snapshot: unknown;
+        readonly focusToken: string | null;
+      };
+    }
+  | { readonly type: 'forget'; readonly demoId: DemoId }
+  | {
+      readonly type: 'navigation-requested';
+      readonly mode: 'push';
+      readonly to: LifecycleHref;
+    }
+  | {
+      readonly type: 'navigation-requested';
+      readonly mode: 'back' | 'forward';
+    }
+  | {
+      readonly type: 'navigation-committed';
+      readonly destination: DemoId | null;
+      readonly fragment: string | null;
+    }
+  | {
+      readonly type: 'navigation-failed';
+      readonly message: string;
+      readonly retryHref: LifecycleHref;
+    }
+  | {
+      readonly type: 'render-failed';
+      readonly demoId: DemoId;
+      readonly message: string;
+    }
+  | { readonly type: 'retry' };
+
+export type LifecycleDecision =
+  | { readonly type: 'save-snapshot'; readonly demoId: DemoId }
+  | { readonly type: 'dispose-surface'; readonly demoId: DemoId }
+  | { readonly type: 'forget-snapshot'; readonly demoId: DemoId }
+  | { readonly type: 'navigate'; readonly mode: 'push'; readonly to: LifecycleHref }
+  | { readonly type: 'navigate'; readonly mode: 'back' | 'forward' }
+  | {
+      readonly type: 'mount-surface';
+      readonly demoId: DemoId;
+      readonly snapshot?: unknown;
+    }
+  | {
+      readonly type: 'focus-route';
+      readonly preferred:
+        | { readonly kind: 'adapter'; readonly token: string }
+        | null;
+      readonly fallback: 'route-heading';
+      readonly preventScroll: true;
+    }
+  | {
+      readonly type: 'announce-navigation-error';
+      readonly phase: 'pre-commit';
+      readonly message: string;
+      readonly retryHref: LifecycleHref;
+    }
+  | {
+      readonly type: 'show-route-error';
+      readonly demoId: DemoId;
+      readonly message: string;
+    };
+
+export interface LifecycleResult {
+  readonly state: LifecycleState;
+  readonly decisions: readonly LifecycleDecision[];
+}
+
+export function createLifecycleState(activeDemo: DemoId | null = null): LifecycleState {
+  return {
+    activeDemo,
+    snapshots: {},
+    pending: null,
+    error: null,
+  };
+}
+
+export function reduceLifecycle(
+  state: LifecycleState,
+  event: LifecycleEvent,
+): LifecycleResult {
+  if (event.type === 'forget') {
+    const { [event.demoId]: _forgotten, ...snapshots } = state.snapshots;
+    return {
+      state: { ...state, snapshots },
+      decisions: [{ type: 'forget-snapshot', demoId: event.demoId }],
+    };
+  }
+  if (event.type === 'navigation-requested') {
+    return {
+      state,
+      decisions: event.mode === 'push'
+        ? [{ type: 'navigate', mode: 'push', to: event.to }]
+        : [{ type: 'navigate', mode: event.mode }],
+    };
+  }
+  if (event.type === 'navigation-failed') {
+    const error: RouteFailure = {
+      phase: 'pre-commit',
+      message: event.message,
+      retryHref: event.retryHref,
+    };
+    return {
+      state: { ...state, pending: null, error },
+      decisions: [{ type: 'announce-navigation-error', ...error }],
+    };
+  }
+  if (event.type === 'render-failed') {
+    const error: RouteFailure = {
+      phase: 'post-commit',
+      demoId: event.demoId,
+      message: event.message,
+    };
+    return {
+      state: { ...state, pending: null, error },
+      decisions: [
+        { type: 'dispose-surface', demoId: event.demoId },
+        { type: 'show-route-error', demoId: event.demoId, message: event.message },
+      ],
+    };
+  }
+  if (event.type === 'retry') {
+    if (state.error === null) return { state, decisions: [] };
+    if (state.error.phase === 'pre-commit') {
+      return {
+        state: { ...state, error: null },
+        decisions: [{ type: 'navigate', mode: 'push', to: state.error.retryHref }],
+      };
+    }
+    const { demoId } = state.error;
+    const snapshot = state.snapshots[demoId];
+    return {
+      state: { ...state, error: null },
+      decisions: [
+        { type: 'dispose-surface', demoId },
+        {
+          type: 'mount-surface',
+          demoId,
+          ...(snapshot === undefined ? {} : { snapshot: structuredClone(snapshot.value) }),
+        },
+      ],
+    };
+  }
+  if (event.type === 'navigation-committed') {
+    const snapshot = event.destination === null
+      ? undefined
+      : state.snapshots[event.destination];
+    const preferred = state.pending?.mode === 'pop' && snapshot?.focusToken
+      ? { kind: 'adapter' as const, token: snapshot.focusToken }
+      : null;
+    const disposeDecision: LifecycleDecision[] =
+      state.pending?.source !== null &&
+      state.pending?.source !== undefined &&
+      state.pending.source !== event.destination
+        ? [{ type: 'dispose-surface', demoId: state.pending.source }]
+        : [];
+    const mountDecision: LifecycleDecision[] = event.destination === null
+      ? []
+      : [{
+          type: 'mount-surface',
+          demoId: event.destination,
+          ...(snapshot === undefined ? {} : { snapshot: structuredClone(snapshot.value) }),
+        }];
+    return {
+      state: {
+        ...state,
+        activeDemo: event.destination,
+        pending: null,
+        error: null,
+      },
+      decisions: [
+        ...disposeDecision,
+        ...mountDecision,
+        {
+          type: 'focus-route',
+          preferred,
+          fallback: 'route-heading',
+          preventScroll: true,
+        },
+      ],
+    };
+  }
+
+  const source = event.source;
+  if (source === undefined) {
+    return {
+      state: {
+        ...state,
+        error: null,
+        pending: {
+          mode: event.mode,
+          to: event.to,
+          destination: event.destination,
+          source: state.activeDemo,
+        },
+      },
+      decisions: [],
+    };
+  }
+
+  const snapshot: SnapshotRecord = {
+    value: structuredClone(source.snapshot),
+    focusToken: source.focusToken,
+  };
+  return {
+    state: {
+      ...state,
+      snapshots: { ...state.snapshots, [source.demoId]: snapshot },
+      error: null,
+      pending: {
+        mode: event.mode,
+        to: event.to,
+        destination: event.destination,
+        source: state.activeDemo,
+      },
+    },
+    decisions: [{ type: 'save-snapshot', demoId: source.demoId }],
+  };
+}

--- a/examples/web/src/shared/shell/demo-hub.tsx
+++ b/examples/web/src/shared/shell/demo-hub.tsx
@@ -1,0 +1,43 @@
+import { DEMOS, DEMO_GROUPS } from '../catalog/demo-catalog';
+import { LifecycleLink } from '../route-lifecycle/browser/lifecycle-link';
+
+export function DemoHub() {
+  return (
+    <div className="demo-hub">
+      <a className="skip-link" href="#demo-catalog">Skip to demos</a>
+
+      <main id="demo-catalog">
+        <header className="page-heading">
+          <h1 tabIndex={-1} data-route-heading>Canopy demos</h1>
+          <p>Choose a demo to open its interactive page.</p>
+        </header>
+
+        <div className="catalog-groups">
+          {DEMO_GROUPS.map((group) => {
+            const demos = DEMOS.filter((demo) => demo.group === group.id);
+            if (demos.length === 0) return null;
+
+            return (
+              <section key={group.id} className="catalog-group" aria-labelledby={`group-${group.id}`}>
+                <h2 id={`group-${group.id}`}>{group.title}</h2>
+                <ul className="demo-list">
+                  {demos.map((demo) => (
+                    <li key={demo.id}>
+                      <LifecycleLink to={demo.href} data-demo-id={demo.id}>
+                        <span className="demo-copy">
+                          <strong>{demo.title}</strong>
+                          <span>{demo.description}</span>
+                        </span>
+                        <span className="open-label" aria-hidden="true">Open →</span>
+                      </LifecycleLink>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/examples/web/src/shared/shell/demo-placeholder.tsx
+++ b/examples/web/src/shared/shell/demo-placeholder.tsx
@@ -1,0 +1,16 @@
+import { DEMOS, type DemoId } from '../catalog/demo-catalog';
+import { LifecycleLink } from '../route-lifecycle/browser/lifecycle-link';
+
+export function DemoPlaceholder({ demoId }: { readonly demoId: DemoId }) {
+  const demo = DEMOS.find((candidate) => candidate.id === demoId);
+  if (demo === undefined) throw new Error(`Unknown demo catalog entry: ${demoId}`);
+
+  return (
+    <main className="route-state" data-demo-placeholder={demo.id}>
+      <p className="route-state__label">Migration pending</p>
+      <h1 tabIndex={-1} data-route-heading>{demo.title}</h1>
+      <p>This demo still runs in the parallel Vite application during Stage 2.</p>
+      <LifecycleLink className="route-state__action" to="/">Back to demos</LifecycleLink>
+    </main>
+  );
+}

--- a/examples/web/src/shared/shell/styles.css
+++ b/examples/web/src/shared/shell/styles.css
@@ -9,6 +9,7 @@
   --error: oklch(0.48 0.15 28);
   --error-soft: oklch(0.94 0.035 28);
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+
   color-scheme: light;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }

--- a/examples/web/src/shared/shell/styles.css
+++ b/examples/web/src/shared/shell/styles.css
@@ -1,0 +1,263 @@
+:root {
+  --paper: oklch(0.97 0.007 88);
+  --ink: oklch(0.24 0.012 190);
+  --muted: oklch(0.48 0.012 180);
+  --line: oklch(0.84 0.01 88);
+  --accent: oklch(0.43 0.09 215);
+  --accent-soft: oklch(0.93 0.025 215);
+  --focus: oklch(0.55 0.13 215);
+  --error: oklch(0.48 0.15 28);
+  --error-soft: oklch(0.94 0.035 28);
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  color-scheme: light;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 20rem;
+  background: var(--paper);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+:where(a, button):focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 10;
+  top: 0.75rem;
+  left: 0.75rem;
+  min-height: 2.75rem;
+  display: inline-grid;
+  align-items: center;
+  padding-inline: 0.75rem;
+  color: var(--paper);
+  background: var(--ink);
+  transform: translateY(-180%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.demo-hub main {
+  width: min(52rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding-block: clamp(2.5rem, 7vw, 4rem);
+}
+
+.page-heading {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.page-heading h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 650;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+}
+
+.page-heading p {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.9375rem;
+}
+
+.catalog-group {
+  padding-top: 2rem;
+}
+
+.catalog-group h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.demo-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.demo-list li {
+  border-bottom: 1px solid var(--line);
+}
+
+.demo-list a {
+  min-height: 5.5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 0.75rem;
+  text-decoration: none;
+}
+
+.demo-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.demo-copy strong {
+  font-size: 0.9375rem;
+}
+
+.demo-copy > span {
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+.open-label {
+  min-width: max-content;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.route-state {
+  width: min(42rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding-block: clamp(3rem, 10vw, 6rem);
+}
+
+.route-state h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  line-height: 1.2;
+}
+
+.route-state > p:not(.route-state__label) {
+  max-width: 60ch;
+  color: var(--muted);
+}
+
+.route-state__label {
+  margin: 0 0 0.75rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.route-state__action,
+.route-state__actions :where(a, button) {
+  min-height: 2.75rem;
+  display: inline-grid;
+  place-items: center;
+  padding-inline: 0.875rem;
+  border: 1px solid var(--line);
+  color: var(--accent);
+  background: transparent;
+  font: inherit;
+  font-weight: 650;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.route-state__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.route-state--error,
+.navigation-alert {
+  border: 1px solid color-mix(in oklch, var(--error), var(--line) 65%);
+  background: var(--error-soft);
+}
+
+.navigation-alert {
+  width: min(52rem, calc(100% - 2rem));
+  margin: 1rem auto 0;
+  padding: 1rem;
+}
+
+.navigation-alert > p {
+  margin-block: 0 0.75rem;
+}
+
+@media (max-width: 34rem) {
+  .demo-list a {
+    min-height: 6.5rem;
+    grid-template-columns: 1fr;
+    align-content: center;
+    gap: 0.5rem;
+  }
+
+  .open-label {
+    justify-self: start;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .demo-list a {
+    transition: background-color 160ms ease;
+  }
+
+  .demo-list a:hover {
+    background-color: var(--accent-soft);
+  }
+
+  .open-label {
+    transition:
+      transform 120ms var(--ease-out),
+      opacity 120ms ease;
+  }
+
+  .demo-list a:hover:active .open-label {
+    opacity: 0.72;
+    transform: translateX(2px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) and (hover: hover) and (pointer: fine) {
+  .demo-list a {
+    transition: background-color 80ms ease;
+  }
+
+  .open-label {
+    transition: opacity 80ms ease;
+  }
+
+  .demo-list a:hover:active .open-label {
+    opacity: 0.82;
+    transform: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .demo-list a:hover {
+    outline: 2px solid CanvasText;
+    outline-offset: -3px;
+  }
+}

--- a/examples/web/waku-tests/foundation.spec.ts
+++ b/examples/web/waku-tests/foundation.spec.ts
@@ -9,7 +9,7 @@ const expectedModuleIds = [
 ];
 
 test('loads every generated module only through the Waku client probe', async ({ page }) => {
-  const response = await page.goto('/');
+  const response = await page.goto('/foundation');
   expect(response?.status()).toBe(200);
   await expect(page.getByRole('heading', { level: 1 })).toHaveText('Canopy Waku foundation');
 

--- a/examples/web/waku-tests/hub.spec.ts
+++ b/examples/web/waku-tests/hub.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test';
+
+const expectedDemos = [
+  ['Mini-ML Editor', '/ml'],
+  ['JSON Editor', '/json'],
+  ['Markdown Editor', '/markdown'],
+  ['Canopy Memo', '/memo'],
+  ['Posts', '/posts'],
+  ['Session Resume', '/resume'],
+  ['Generative UI', '/genui'],
+  ['Journey Proposals', '/journey'],
+] as const;
+
+test('server-renders the complete canonical demo catalog at the Waku root', async ({ request }) => {
+  const response = await request.get('/');
+  expect(response.status()).toBe(200);
+
+  const html = await response.text();
+  for (const [title, href] of expectedDemos) {
+    expect(html).toContain(title);
+    expect(html).toContain(`href="${href}"`);
+  }
+});
+
+test('/index.html renders the same Hub without redirecting', async ({ request }) => {
+  const root = await request.get('/');
+  const compatibility = await request.get('/index.html', { maxRedirects: 0 });
+  const rootHtml = await root.text();
+  const compatibilityHtml = await compatibility.text();
+
+  expect(compatibility.status()).toBe(200);
+  expect(compatibility.headers()).not.toHaveProperty('location');
+  for (const [title, href] of expectedDemos) {
+    expect(rootHtml).toContain(`${title}</strong>`);
+    expect(compatibilityHtml).toContain(`${title}</strong>`);
+    expect(compatibilityHtml).toContain(`href="${href}"`);
+  }
+});
+
+test('unknown routes return the accessible custom page with HTTP 404', async ({ page }) => {
+  const response = await page.goto('/missing-demo');
+
+  expect(response?.status()).toBe(404);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Demo not found');
+  await expect(page.getByRole('link', { name: 'Back to demos' })).toHaveAttribute('href', '/');
+});
+
+test('keeps all Hub choices usable without overflow at desktop and mobile widths', async ({ page }) => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/');
+
+    const links = page.locator('[data-demo-id]');
+    await expect(links).toHaveCount(expectedDemos.length);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
+      .toBe(true);
+    for (const link of await links.all()) {
+      const box = await link.boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+      expect(box?.width).toBeGreaterThanOrEqual(44);
+    }
+  }
+});
+
+test('pre-commit failure restores the source without an extra Back stop', async ({ page }) => {
+  await page.goto('/foundation');
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.route('**/RSC/R/json.txt?**', (route) => route.abort('failed'));
+
+  await page.getByRole('link', { name: /JSON Editor/ }).click();
+
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Canopy demos');
+  await expect(page.getByRole('alert')).toContainText('The demo could not be loaded.');
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Open directly' })).toHaveAttribute('href', '/json');
+
+  await page.unroute('**/RSC/R/json.txt?**');
+  await page.goBack();
+  await expect(page).toHaveURL(/\/foundation$/);
+});
+
+test('does not intercept modified Hub clicks', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.evaluate(() => {
+    (window as Window & { __modifiedClickPrevented?: boolean }).__modifiedClickPrevented = true;
+    document.addEventListener('click', (event) => {
+      (window as Window & { __modifiedClickPrevented?: boolean }).__modifiedClickPrevented =
+        event.defaultPrevented;
+    }, { once: true });
+  });
+
+  await page.getByRole('link', { name: /JSON Editor/ }).dispatchEvent('click', {
+    button: 0,
+    ctrlKey: true,
+  });
+
+  expect(await page.evaluate(
+    () => (window as Window & { __modifiedClickPrevented?: boolean }).__modifiedClickPrevented,
+  )).toBe(false);
+  await expect(page).toHaveURL(/\/$/);
+});
+
+test('Back restores the Hub history entry scroll position', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 500 });
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  const journeyLink = page.getByRole('link', { name: /Journey Proposals/ });
+  await journeyLink.scrollIntoViewIfNeeded();
+  const hubScroll = await page.evaluate(() => window.scrollY);
+  expect(hubScroll).toBeGreaterThan(0);
+
+  await journeyLink.click();
+  await expect(page).toHaveURL(/\/journey$/);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { level: 1 })).toBeFocused();
+  await page.waitForTimeout(250);
+  expect(await page.evaluate(() => window.scrollY)).toBe(hubScroll);
+});
+
+test('push, Back, and Forward keep one Waku history chain and focus each route heading', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+
+  await page.getByRole('link', { name: /JSON Editor/ }).click();
+  await expect(page).toHaveURL(/\/json$/);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('JSON Editor');
+  await expect(page.getByRole('heading', { level: 1 })).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Canopy demos');
+  await expect(page.getByRole('heading', { level: 1 })).toBeFocused();
+
+  await page.goForward();
+  await expect(page).toHaveURL(/\/json$/);
+  await expect(page.getByRole('heading', { level: 1 })).toBeFocused();
+});

--- a/examples/web/waku-tests/hub.spec.ts
+++ b/examples/web/waku-tests/hub.spec.ts
@@ -30,11 +30,12 @@ test('/index.html renders the same Hub without redirecting', async ({ request })
 
   expect(compatibility.status()).toBe(200);
   expect(compatibility.headers()).not.toHaveProperty('location');
-  for (const [title, href] of expectedDemos) {
-    expect(rootHtml).toContain(`${title}</strong>`);
-    expect(compatibilityHtml).toContain(`${title}</strong>`);
-    expect(compatibilityHtml).toContain(`href="${href}"`);
-  }
+  const rootCatalog = rootHtml.match(/<main id="demo-catalog">[\s\S]*?<\/main>/)?.[0];
+  const compatibilityCatalog = compatibilityHtml.match(
+    /<main id="demo-catalog">[\s\S]*?<\/main>/,
+  )?.[0];
+  expect(rootCatalog).toBeDefined();
+  expect(compatibilityCatalog).toBe(rootCatalog);
 });
 
 test('unknown routes return the accessible custom page with HTTP 404', async ({ page }) => {


### PR DESCRIPTION
## Summary

- add the SSR Waku Demo Hub, canonical Stage 2 route catalog, nonredirecting `/index.html` behavior, accessible HTTP 404, and migration-pending route placeholders
- add a functional route-lifecycle reducer with React/browser shells for snapshots, disposal, history traversal, focus, and pre/post-commit recovery
- add contract, boundary, responsive, history, focus, error, build, and workerd coverage while retaining the Vite deployment path and all legacy HTML entries

Closes #971

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `useRouter`, `Link`, and `unstable_events` | `waku/router/client` | Yes | Waku remains the sole router and owns navigation and scrolling. |
| `MoonbitClientProbe` | `examples/web/src/shared/browser/moonbit-client-probe.tsx` | Yes | The Stage 1 generated-module probe moved intact to `/foundation`. |
| `structuredClone` | Web platform | Yes | Snapshot ownership is defensive at reducer capture, imperative-session capture, and mount retrieval boundaries. |
| React component error boundary | React `Component` API | Yes | Waku's generic exported boundary was considered but does not provide Canopy's pre/post-commit recovery contract, retry action, or sanitized accessible state. |
| Existing Stage 1 Waku build/configuration | `examples/web/waku.config.ts`, `src/waku.server.tsx`, package scripts | Yes | Stage 2 extends the existing Waku lane rather than adding another router or deployment path. |

MoonBit core API check: not applicable to this change. No `.mbt`/`.mbti` function, helper, type, loop, or data-manipulation code was added. `Map`, `Set`, `String`/`StringView`, `Option`/`Result`, `Array`, and `Iter` therefore do not fit this TypeScript/React/browser-boundary change. Interface drift was checked and is empty.

New helpers added:

- `demoIdForPath` centralizes canonical route-to-demo lookup in the pure catalog.
- `createLifecycleState` / `reduceLifecycle` define the deterministic `State + Event -> State + Decisions` core.
- `createImperativeSession`, `applyFocusDecision`, and `recoverPreCommitNavigation` isolate browser adapter responsibilities and idempotent cleanup.
- `RouteLifecycleProvider`, `useRouteSnapshot`, `ImperativeHost`, and `LifecycleLink` expose the shared lifecycle seam without leaking mutable registries.
- `NavigationFailureAlert` and `RouteRenderBoundary` centralize sanitized, accessible recovery UI.

Remaining mutation is confined to the imperative shell: React refs hold mounted route/session registries, browser event subscriptions, and one-shot recovery state. The reducer and catalog remain deterministic, and snapshots are cloned before storage and before adapter restoration.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed for unintended API surface changes
- [x] JS rebuild run if web is affected (`cd examples/web && npm run build:vite`; Waku build also run)

Additional validation:

- [x] `npm run typecheck`
- [x] `npm run test:foundation` — 28 passed
- [x] `npm run test:boundaries` — 17 passed
- [x] `npm run check:boundaries`
- [x] `npm run test:waku:e2e` — 9 passed
- [x] Vite Playwright suite — 103 passed, 2 skipped
- [x] `CANOPY_SKIP_MOON_BUILD=1 npm run build:waku`
- [x] `npm run check:waku-bundles`
- [x] `npm run check:waku-types`
- [x] `npm run test:waku:workerd`
- [x] `npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env preview`

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
cd examples/web
npm run typecheck
npm run test:foundation
npm run test:boundaries
npm run check:boundaries
npm run test:waku:e2e
CANOPY_SKIP_MOON_BUILD=1 npm run build:waku
npm run check:waku-bundles
npm run check:waku-types
npm run test:waku:workerd
```

No demo workflow was migrated, no legacy redirect was activated, no production deployment was performed, and no existing HTML or Vite deployment path was removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Canopy demos hub with grouped demo listings and accessible navigation.
  * Added placeholder routes for eight demos and a custom accessible 404 page.
  * Added shared navigation handling with focus restoration, snapshot recovery, retry actions, and route error states.
  * Added responsive styling, skip links, and improved keyboard and reduced-motion support.
* **Documentation**
  * Documented the staged Waku migration and updated the foundation route.
* **Tests**
  * Added coverage for routing, accessibility, navigation recovery, boundaries, and worker smoke checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
