### PR TITLE
feat(web): migrate Journey to /journey

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -662,7 +662,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
   Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970 establishes the dual Vite/Waku foundation; Vite remains the default and no demo, redirect, or deployment has migrated.
+  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972 migrates Journey to `/journey`. Vite remains the default, and no redirect or production deployment has migrated.
   Exit: the plan's Stage 12 gate passes after production cutover is proven.
 
 ## 22. SDEG Lifecycle

--- a/docs/plans/2026-07-25-waku-unified-web-migration.md
+++ b/docs/plans/2026-07-25-waku-unified-web-migration.md
@@ -689,3 +689,87 @@ production deployment or merge.
 - Add one brief `docs/TODO.md` entry linking this plan while implementation is
   active; do not copy execution detail there.
 - Archive this plan only after Stage 12 is complete and validated.
+
+## Post-Cutover Follow-Up: React Ownership Assessment (Non-Gating)
+
+This section is not a migration stage, not a Stage 12 exit criterion, and does
+not authorize any rewrite of the current Journey, JSON, Markdown, Mini-ML, Memo,
+Posts, Resume, or GenUI implementations. It records the agreed approach for
+future per-demo React ownership evaluation after the Waku cutover is complete
+and Vite is retired. Reactification must not block or delay Waku cutover or
+Vite retirement.
+
+### Principles
+
+- React ownership is assessed per demo, never mandated wholesale across all
+  demos in one effort.
+- Each candidate is tracked in a separate issue and delivered in a separate PR
+  after cutover.
+- Journey is the first candidate: it already has a pure reducer and
+  presentation-only DOM, and proved the imperative lifecycle seam in Stage 3.
+- For each candidate, use React as a thin imperative shell around the existing
+  functional core. The reducer remains the domain source of truth; React renders
+  its returned state and dispatches events into it.
+- Do not mirror into React state: editor or runtime handles, generated MoonBit
+  state, DOM selection, IME composition state, in-flight requests or streams,
+  provider sessions, or any other live imperative resource. These remain behind
+  the imperative adapter.
+- JSON, Markdown, Mini-ML, and GenUI editor/runtime internals remain behind
+  imperative adapters unless separate evidence in a follow-up issue justifies a
+  different ownership seam for a specific demo. Memo and Posts are assessed
+  only where their browser DOM is presentation-only and React would not
+  duplicate provider or persistence ownership. Resume remains React-owned
+  through its existing native route snapshot seam.
+
+### Preservation Requirements
+
+Every React ownership change must preserve:
+
+- Existing reducer semantics and determinism.
+- The verified demo workflow and visual design.
+- Focus, selection, and node identity contracts.
+- Legacy behavior contracts that remain relevant for the demo.
+- Idempotent lifecycle cleanup on unmount, navigation, and route exit.
+
+### Candidate Entry Criteria
+
+A demo is eligible for React ownership assessment only when all of the
+following hold:
+
+- The demo already exposes a pure deterministic transition (`State + Event →
+  State`, optionally with returned decisions) or can be factored into one
+  without changing verified behavior.
+- Route state is serializable and already captured by the route-lifecycle
+  snapshot.
+- The DOM surface is presentation-only — it renders reducer output and
+  dispatches user events, without owning live editor, runtime, or provider
+  handles in React state.
+
+### Candidate Validation and Exit Criteria
+
+Each React ownership PR must demonstrate:
+
+- All existing behavior contracts (Playwright suites, reducer unit tests,
+  boundary checks) still pass unchanged.
+- Route snapshot save and restore works through the new React shell.
+- Full page reload clears all transient state as before; no React-managed
+  cache survives reload.
+- Focus restoration (route heading and per-demo stable token) works after
+  navigation to and from the route.
+- Unmount, Strict Mode double-mount, and repeated navigation cycles dispose
+  all live resources: no leaked handle, adapter, overlay, request, timer,
+  listener, or React root.
+- There is exactly one render implementation — React does not duplicate the
+  imperative adapter's rendering logic. If the imperative adapter is still
+  needed for a portion of the DOM, React delegates to it rather than
+  re-rendering it.
+
+### Scope Boundaries
+
+This follow-up does not:
+
+- Change any Stage 3 exit criterion or the Journey implementation in this plan.
+- Add gating requirements to any stage in the migration sequence.
+- Authorize changes to the five public virtual import IDs, generated MoonBit
+  JavaScript, or the route-lifecycle Module interface.
+- Redesign the signaling, storage, or provider capability contracts.

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -47,9 +47,9 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 Most of the source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. Resume/PKE, Posts, Memo, JSON, Markdown, GenUI, and GenUI Possibilities use the target entry/feature layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku foundation (pre-production, #970 Stages 0–1; #971 Stage 2 in progress)
+## Waku migration (pre-production, #970–#972 Stages 0–3)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 foundation has landed alongside it. Stage 2 has added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; no demo behavior has been migrated and no old HTML entry has been removed.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stage 3 migrates Journey while retaining every old HTML entry.
 
 ### Stage 0–1 configuration and artifacts
 
@@ -65,7 +65,8 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 
 - `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
 - `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
-- `src/pages/{ml,json,markdown,memo,posts,resume,genui,journey}.tsx` — eight canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell. No demo behavior has been migrated.
+- `src/pages/{ml,json,markdown,memo,posts,resume,genui}.tsx` — seven canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/journey.tsx` — canonical Journey route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/_layout.tsx` — pass-through shared route layout; the provider stays at `_root.tsx` so its in-memory registry survives route render failures.
 - `src/shared/catalog/demo-catalog.ts` — framework-independent catalog data (eight demos, three groups, canonical `DemoPath` routes).
 - `src/shared/shell/` — `DemoHub` and `DemoPlaceholder` React components and shared shell styles.
@@ -74,7 +75,14 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 - `waku-tests/foundation.spec.ts` and `waku-tests/hub.spec.ts` — deterministic Waku page tests.
 - `scripts/waku-lifecycle-contract.test.mjs` — reducer/provider/focus/error/imperative-host contract tests.
 
-Stage 2 remains pre-production. Vite remains the default and is retained.
+### Stage 3 — Journey Proposals
+
+- `src/features/genui-possibilities/route/{journey-route,journey-client}.tsx` — server/client route seam that reuses the legacy HTML as canonical Journey markup, preserves content during RSC navigation, and routes the existing wordmark through the lifecycle provider.
+- `src/features/genui-possibilities/browser/mount.js` — shared Vite/Waku mount; scopes DOM ownership to the supplied container and returns the defensive snapshot, stable response-focus, and idempotent disposal session.
+- `tests/genui-possibilities.spec.ts` — unchanged Journey behavior and visual contract, now also run against Waku `/journey`.
+- `waku-tests/journey-route.spec.ts` — route-memory, reload-reset, browser-traversal focus, and repeated timer/listener disposal coverage.
+
+Stage 3 remains pre-production. Vite and `genui-possibilities.html` remain the defaults and are retained. No Journey compatibility redirect is active.
 
 Validation runs in parallel with the Vite pipeline:
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,9 +5,9 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Waku migration (in progress, #971)
+## Waku migration (in progress, #972)
 
-A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stage 2 adds the Demo Hub, route-lifecycle Module (reducer, provider, focus manager, imperative host, error boundary), shared shell, eight canonical placeholder routes, and accessible 404. No demo behavior has been migrated; the previous foundation probe moved to `/foundation`, and no old HTML entry has been removed.
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stage 3 migrates Journey Proposals to `/journey` through the imperative host while retaining `genui-possibilities.html`; the other seven canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
 
 ## Development
 

--- a/examples/web/genui-possibilities.html
+++ b/examples/web/genui-possibilities.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#f3f0e8" />
     <title>Naoshima journey</title>
   </head>
-  <body>
+  <body class="journey-surface">
     <a class="skip-link" href="#decision-workspace">Skip to decision</a>
     <header class="app-bar">
       <a class="wordmark" href="/" aria-label="Canopy home">CANOPY</a>
@@ -55,7 +55,7 @@
         <section class="decision-panel" aria-labelledby="decision-title">
           <header class="decision-heading">
             <p class="section-label">Decision</p>
-            <h1 id="decision-title">How should this journey change?</h1>
+            <h1 id="decision-title" data-route-heading tabindex="-1">How should this journey change?</h1>
             <p>Nothing changes until you apply a response.</p>
           </header>
 

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -5,8 +5,14 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
   throw new Error('CANOPY_WAKU_TEST_PORT must be a valid TCP port.');
 }
 
+process.env.GENUI_POSSIBILITIES_URL = '/journey';
+
 export default defineConfig({
-  testDir: './waku-tests',
+  testDir: '.',
+  testMatch: [
+    'waku-tests/**/*.spec.ts',
+    'tests/genui-possibilities.spec.ts',
+  ],
   timeout: 30_000,
   retries: 0,
   use: {

--- a/examples/web/scripts/check-boundaries.mjs
+++ b/examples/web/scripts/check-boundaries.mjs
@@ -55,7 +55,10 @@ const WAKU_PAGE_OWNERS = new Map([
 ]);
 
 function normalize(filePath) {
-  return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+  return filePath
+    .replaceAll('\\', '/')
+    .replace(/^\.\//, '')
+    .replace(/[?#].*$/, '');
 }
 
 function capabilityImport(specifier) {
@@ -80,6 +83,10 @@ export function describePath(filePath) {
   }
   if (normalized === 'src/pages.gen.ts') {
     return { kind: 'generated' };
+  }
+  const htmlOwner = ENTRY_FEATURES.get(normalized);
+  if (htmlOwner !== undefined) {
+    return { kind: 'feature', owner: htmlOwner, layer: 'browser' };
   }
   if (
     /(^|\/)server\//.test(normalized) ||

--- a/examples/web/scripts/check-boundaries.test.mjs
+++ b/examples/web/scripts/check-boundaries.test.mjs
@@ -66,6 +66,21 @@ test('resolves relative and Vite root-relative local imports', () => {
   );
 });
 
+test('classifies canonical HTML raw imports under their feature owner', () => {
+  assert.deepEqual(describePath('genui-possibilities.html?raw'), {
+    kind: 'feature',
+    owner: 'genui-possibilities',
+    layer: 'browser',
+  });
+  assert.deepEqual(
+    evaluateEdge(
+      'src/features/genui-possibilities/route/journey-route.tsx',
+      'genui-possibilities.html?raw',
+    ),
+    [],
+  );
+});
+
 test('requires entries to import the matching feature browser surface only', () => {
   assert.deepEqual(
     evaluateEdge('src/entries/genui-possibilities.js', 'src/features/genui-possibilities/browser/mount.js'),

--- a/examples/web/src/features/genui-possibilities/browser/mount.d.ts
+++ b/examples/web/src/features/genui-possibilities/browser/mount.d.ts
@@ -1,0 +1,6 @@
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
+
+export function mountGenuiPossibilities(
+  root?: Document | HTMLElement,
+  restoredSnapshot?: unknown,
+): MountedImperativeSession;

--- a/examples/web/src/features/genui-possibilities/browser/mount.js
+++ b/examples/web/src/features/genui-possibilities/browser/mount.js
@@ -52,20 +52,30 @@ const responses = [
   },
 ];
 
-export function mountGenuiPossibilities() {
-  const itineraryList = document.querySelector('#itinerary-list');
-  const responseList = document.querySelector('#response-list');
-  const selectionDetail = document.querySelector('#selection-detail');
-  const revisionLabel = document.querySelector('#revision-label');
-  const planStatus = document.querySelector('#plan-status');
-  const applyButton = document.querySelector('#apply-button');
-  const clearSelectionButton = document.querySelector('#clear-selection-button');
-  const undoButton = document.querySelector('#undo-button');
-  const toast = document.querySelector('#toast');
+export function mountGenuiPossibilities(
+  root = globalThis.document,
+  restoredSnapshot = undefined,
+) {
+  const document = root.ownerDocument ?? root;
+  const window = document.defaultView ?? globalThis.window;
+  const itineraryList = root.querySelector('#itinerary-list');
+  const responseList = root.querySelector('#response-list');
+  const selectionDetail = root.querySelector('#selection-detail');
+  const revisionLabel = root.querySelector('#revision-label');
+  const planStatus = root.querySelector('#plan-status');
+  const applyButton = root.querySelector('#apply-button');
+  const clearSelectionButton = root.querySelector('#clear-selection-button');
+  const undoButton = root.querySelector('#undo-button');
+  const toast = root.querySelector('#toast');
 
-  let state = createJourneyState();
+  itineraryList.replaceChildren();
+  responseList.replaceChildren();
+
+  let state = restoredSnapshot === undefined
+    ? createJourneyState()
+    : structuredClone(restoredSnapshot);
   let toastTimer;
-  let focusedResponseId = responses[0]?.id ?? null;
+  let focusedResponseId = state.selectedOption ?? responses[0]?.id ?? null;
 
   const itineraryRows = [];
   const responseRows = [];
@@ -161,6 +171,7 @@ export function mountGenuiPossibilities() {
     row.className = `response-row ${response.tone}`;
     row.role = 'radio';
     row.dataset.response = response.id;
+    row.dataset.routeFocus = `response:${response.id}`;
 
     const radioMark = document.createElement('span');
     radioMark.className = 'radio-mark';
@@ -334,13 +345,13 @@ export function mountGenuiPossibilities() {
     render();
   }
 
-  responseList.addEventListener('click', (event) => {
+  function handleResponseClick(event) {
     const response = event.target.closest('[data-response]');
     if (response === null) return;
     selectResponse(response.dataset.response, true);
-  });
+  }
 
-  responseList.addEventListener('keydown', (event) => {
+  function handleResponseKeydown(event) {
     const response = event.target.closest('[data-response]');
     if (response === null) return;
 
@@ -370,9 +381,9 @@ export function mountGenuiPossibilities() {
     const targetId = responses[nextIndex].id;
     focusedResponseId = targetId;
     selectResponse(targetId, true);
-  });
+  }
 
-  applyButton.addEventListener('click', () => {
+  function handleApply() {
     if (state.selectedOption === null) return;
     const chosen = selectedResponse();
     const previousFocus = focusedResponseId;
@@ -382,9 +393,9 @@ export function mountGenuiPossibilities() {
       focusResponse(previousFocus);
     }
     showToast(`${chosen.name} applied to the itinerary. No booking was changed.`);
-  });
+  }
 
-  clearSelectionButton.addEventListener('click', () => {
+  function handleClearSelection() {
     if (state.selectedOption === null) return;
     const previousFocus = focusedResponseId;
     state = transitionJourney(state, { type: 'select_option', option: null });
@@ -393,9 +404,9 @@ export function mountGenuiPossibilities() {
       focusResponse(previousFocus);
     }
     showToast('Selection cleared. Current itinerary unchanged.');
-  });
+  }
 
-  undoButton.addEventListener('click', () => {
+  function handleUndo() {
     const previousFocus = focusedResponseId;
     state = transitionJourney(state, { type: 'undo' });
     render();
@@ -403,7 +414,35 @@ export function mountGenuiPossibilities() {
       focusResponse(previousFocus);
     }
     showToast('Previous itinerary restored as a new revision.');
-  });
+  }
+
+  responseList.addEventListener('click', handleResponseClick);
+  responseList.addEventListener('keydown', handleResponseKeydown);
+  applyButton.addEventListener('click', handleApply);
+  clearSelectionButton.addEventListener('click', handleClearSelection);
+  undoButton.addEventListener('click', handleUndo);
 
   renderAll();
+
+  return {
+    snapshot: () => state,
+    restoreFocus: (token) => {
+      const response = responseRows.find(
+        ({ row }) => row.dataset.routeFocus === token,
+      );
+      if (response === undefined) return false;
+      focusedResponseId = response.id;
+      renderResponses();
+      response.row.focus({ preventScroll: true });
+      return document.activeElement === response.row;
+    },
+    dispose: () => {
+      window.clearTimeout(toastTimer);
+      responseList.removeEventListener('click', handleResponseClick);
+      responseList.removeEventListener('keydown', handleResponseKeydown);
+      applyButton.removeEventListener('click', handleApply);
+      clearSelectionButton.removeEventListener('click', handleClearSelection);
+      undoButton.removeEventListener('click', handleUndo);
+    },
+  };
 }

--- a/examples/web/src/features/genui-possibilities/browser/styles.css
+++ b/examples/web/src/features/genui-possibilities/browser/styles.css
@@ -1,4 +1,4 @@
-:root {
+.journey-surface {
   --paper: #f3f0e8;
   --surface: #fffdf8;
   --surface-support: #faf8f2;
@@ -40,16 +40,17 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-* {
+.journey-surface,
+.journey-surface * {
   box-sizing: border-box;
 }
 
-html {
+.journey-surface {
   min-width: 20rem;
   background: var(--paper);
 }
 
-body {
+.journey-surface {
   min-height: 100vh;
   margin: 0;
   color: var(--ink);
@@ -57,23 +58,23 @@ body {
   line-height: 1.5;
 }
 
-button,
-input {
+.journey-surface button,
+.journey-surface input {
   font: inherit;
 }
 
-button {
+.journey-surface button {
   color: inherit;
 }
 
-button:focus-visible,
-a:focus-visible,
-.response-row:focus-visible {
+.journey-surface button:focus-visible,
+.journey-surface a:focus-visible,
+.journey-surface .response-row:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 3px;
 }
 
-.visually-hidden {
+.journey-surface .visually-hidden {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -85,7 +86,7 @@ a:focus-visible,
   border: 0;
 }
 
-.skip-link {
+.journey-surface .skip-link {
   position: fixed;
   z-index: 20;
   top: var(--space-xs);
@@ -96,11 +97,11 @@ a:focus-visible,
   transform: translateY(-150%);
 }
 
-.skip-link:focus {
+.journey-surface .skip-link:focus {
   transform: translateY(0);
 }
 
-.app-bar {
+.journey-surface .app-bar {
   min-height: 4rem;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -111,7 +112,7 @@ a:focus-visible,
   background: color-mix(in srgb, var(--paper) 92%, transparent);
 }
 
-.wordmark {
+.journey-surface .wordmark {
   width: fit-content;
   color: var(--ink);
   font-size: 0.75rem;
@@ -120,12 +121,12 @@ a:focus-visible,
   text-decoration: none;
 }
 
-.journey-identity {
+.journey-surface .journey-identity {
   min-width: 0;
   font-weight: 650;
 }
 
-.revision-trace {
+.journey-surface .revision-trace {
   min-width: 0;
   display: flex;
   justify-self: end;
@@ -136,7 +137,7 @@ a:focus-visible,
   font-size: 0.75rem;
 }
 
-.quiet-action {
+.journey-surface .quiet-action {
   min-height: 2.75rem;
   padding: 0;
   border: 0;
@@ -147,19 +148,19 @@ a:focus-visible,
   cursor: pointer;
 }
 
-.quiet-action:disabled {
+.journey-surface .quiet-action:disabled {
   color: var(--disabled-ink);
   cursor: default;
   opacity: 0.72;
 }
 
-main {
+.journey-surface main {
   width: min(86.25rem, calc(100% - var(--space-2xl)));
   margin: 0 auto;
   padding-block: var(--space-xl) var(--space-2xl);
 }
 
-.disruption {
+.journey-surface .disruption {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
@@ -169,7 +170,7 @@ main {
   background: var(--amber-soft);
 }
 
-.disruption-mark {
+.journey-surface .disruption-mark {
   width: 2.75rem;
   height: 2.75rem;
   display: grid;
@@ -181,12 +182,12 @@ main {
   font-weight: 750;
 }
 
-.disruption-copy {
+.journey-surface .disruption-copy {
   display: grid;
   gap: var(--space-2xs);
 }
 
-.section-label {
+.journey-surface .section-label {
   margin: 0;
   color: var(--muted);
   font-size: 0.6875rem;
@@ -195,21 +196,21 @@ main {
   text-transform: uppercase;
 }
 
-.disruption h2 {
+.journey-surface .disruption h2 {
   margin: 0;
   font-size: clamp(1.125rem, 2vw, 1.5rem);
   line-height: 1.25;
   letter-spacing: -0.025em;
 }
 
-.disruption-copy > p:last-child {
+.journey-surface .disruption-copy > p:last-child {
   max-width: 72ch;
   margin: 0;
   color: var(--ink-secondary);
   font-size: 0.875rem;
 }
 
-.source-status {
+.journey-surface .source-status {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -217,13 +218,13 @@ main {
   margin: 0;
 }
 
-.source-status > div {
+.journey-surface .source-status > div {
   display: grid;
   justify-items: end;
   gap: var(--space-2xs);
 }
 
-.source-status dt {
+.journey-surface .source-status dt {
   color: var(--muted);
   font-size: 0.625rem;
   font-weight: 750;
@@ -231,13 +232,13 @@ main {
   text-transform: uppercase;
 }
 
-.source-status dd {
+.journey-surface .source-status dd {
   margin: 0;
   color: var(--ink-secondary);
   font-size: 0.75rem;
 }
 
-.certainty {
+.journey-surface .certainty {
   display: inline-flex;
   align-items: center;
   min-height: 1.75rem;
@@ -246,13 +247,13 @@ main {
   font-weight: 750;
 }
 
-.certainty.likely {
+.journey-surface .certainty.likely {
   color: var(--amber);
   background: color-mix(in srgb, var(--amber-soft) 72%, var(--surface));
   box-shadow: inset 0 0 0 1px var(--amber-line);
 }
 
-.workspace-grid {
+.journey-surface .workspace-grid {
   display: grid;
   grid-template-columns: minmax(19rem, 0.8fr) minmax(38rem, 1.7fr);
   min-height: 38rem;
@@ -261,36 +262,36 @@ main {
   background: var(--surface);
 }
 
-.itinerary-panel,
-.decision-panel {
+.journey-surface .itinerary-panel,
+.journey-surface .decision-panel {
   min-width: 0;
 }
 
-.itinerary-panel {
+.journey-surface .itinerary-panel {
   padding: var(--space-lg);
   border-right: 1px solid var(--line);
   background: var(--surface-support);
 }
 
-.decision-panel {
+.journey-surface .decision-panel {
   padding: var(--space-xl);
 }
 
-.panel-heading {
+.journey-surface .panel-heading {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-md);
 }
 
-.panel-heading > div {
+.journey-surface .panel-heading > div {
   display: grid;
   gap: var(--space-2xs);
 }
 
-.panel-heading h2,
-.decision-preview h2,
-.decision-action-region h2 {
+.journey-surface .panel-heading h2,
+.journey-surface .decision-preview h2,
+.journey-surface .decision-action-region h2 {
   margin: 0;
   color: var(--ink);
   font-size: 1rem;
@@ -298,11 +299,11 @@ main {
   letter-spacing: -0.015em;
 }
 
-.panel-heading h2 {
+.journey-surface .panel-heading h2 {
   font-size: 1.25rem;
 }
 
-.plan-status {
+.journey-surface .plan-status {
   display: inline-flex;
   align-items: center;
   min-height: 1.75rem;
@@ -313,22 +314,22 @@ main {
   white-space: nowrap;
 }
 
-.plan-status.at-risk {
+.journey-surface .plan-status.at-risk {
   color: var(--red);
   background: var(--red-soft);
 }
 
-.plan-status.updated {
+.journey-surface .plan-status.updated {
   color: var(--green);
   background: var(--green-soft);
 }
 
-.plan-status.restored {
+.journey-surface .plan-status.restored {
   color: var(--accent);
   background: var(--accent-soft);
 }
 
-.itinerary-list {
+.journey-surface .itinerary-list {
   display: grid;
   gap: 0;
   margin: var(--space-xl) 0 0;
@@ -336,7 +337,7 @@ main {
   list-style: none;
 }
 
-.itinerary-stop {
+.journey-surface .itinerary-stop {
   position: relative;
   display: grid;
   grid-template-columns: 1.125rem minmax(0, 1fr);
@@ -345,7 +346,7 @@ main {
   padding-block: var(--space-2xs) var(--space-lg);
 }
 
-.itinerary-stop:not(:last-child)::before {
+.journey-surface .itinerary-stop:not(:last-child)::before {
   content: "";
   position: absolute;
   top: 1.125rem;
@@ -355,7 +356,7 @@ main {
   background: var(--line);
 }
 
-.stop-marker {
+.journey-surface .stop-marker {
   z-index: 1;
   width: 0.875rem;
   height: 0.875rem;
@@ -366,27 +367,27 @@ main {
   box-shadow: 0 0 0 1px var(--line-strong);
 }
 
-.stop-version {
+.journey-surface .stop-version {
   display: grid;
   grid-column: 2;
   gap: var(--space-2xs);
   min-width: 0;
 }
 
-.stop-version[hidden] {
+.journey-surface .stop-version[hidden] {
   display: none;
 }
 
-.stop-version strong {
+.journey-surface .stop-version strong {
   font-size: 0.875rem;
 }
 
-.stop-version > span:not(.stop-version-label) {
+.journey-surface .stop-version > span:not(.stop-version-label) {
   color: var(--muted);
   font-size: 0.8125rem;
 }
 
-.stop-version-label {
+.journey-surface .stop-version-label {
   width: max-content;
   color: var(--muted);
   font-size: 0.625rem;
@@ -396,27 +397,27 @@ main {
   text-transform: uppercase;
 }
 
-.itinerary-stop.proposed {
+.journey-surface .itinerary-stop.proposed {
   margin-inline: calc(var(--space-xs) * -1);
   padding: var(--space-xs) var(--space-xs) var(--space-lg);
   background: var(--accent-soft);
 }
 
-.itinerary-stop.proposed .stop-marker {
+.journey-surface .itinerary-stop.proposed .stop-marker {
   background: var(--accent);
 }
 
-.proposed-stop {
+.journey-surface .proposed-stop {
   margin-top: var(--space-xs);
   padding-top: var(--space-sm);
   border-top: 1px solid var(--line);
 }
 
-.proposed-stop .stop-version-label {
+.journey-surface .proposed-stop .stop-version-label {
   color: var(--accent);
 }
 
-.change-note {
+.journey-surface .change-note {
   grid-column: 2;
   margin-top: var(--space-xs);
   color: var(--muted);
@@ -424,7 +425,7 @@ main {
   font-weight: 650;
 }
 
-.protected-badge {
+.journey-surface .protected-badge {
   display: inline-flex;
   align-items: center;
   min-height: 1.25rem;
@@ -441,17 +442,17 @@ main {
   vertical-align: 0.0625rem;
 }
 
-.protected-badge[hidden] {
+.journey-surface .protected-badge[hidden] {
   display: none;
 }
 
-.decision-heading {
+.journey-surface .decision-heading {
   display: grid;
   gap: var(--space-xs);
   max-width: 48rem;
 }
 
-.decision-heading h1 {
+.journey-surface .decision-heading h1 {
   max-width: 24ch;
   margin: 0;
   font-size: clamp(1.75rem, 2.5vw, 2.25rem);
@@ -459,43 +460,43 @@ main {
   letter-spacing: -0.04em;
 }
 
-.decision-heading > p:last-child {
+.journey-surface .decision-heading > p:last-child {
   max-width: 48ch;
   margin: 0;
   color: var(--muted);
   font-size: 0.8125rem;
 }
 
-.response-comparison {
+.journey-surface .response-comparison {
   margin-top: var(--space-xl);
 }
 
-.comparison-heading {
+.journey-surface .comparison-heading {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
   gap: var(--space-md);
 }
 
-.comparison-heading-copy {
+.journey-surface .comparison-heading-copy {
   display: grid;
   gap: var(--space-2xs);
 }
 
-.comparison-heading h2 {
+.journey-surface .comparison-heading h2 {
   margin: 0;
   font-size: 1rem;
   letter-spacing: -0.015em;
 }
 
-.comparison-heading p {
+.journey-surface .comparison-heading p {
   max-width: 64ch;
   margin: 0;
   color: var(--muted);
   font-size: 0.75rem;
 }
 
-.selection-reset {
+.journey-surface .selection-reset {
   min-height: 2.75rem;
   padding-inline: var(--space-sm);
   border: 1px solid var(--line-strong);
@@ -509,37 +510,37 @@ main {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .selection-reset:hover:not(:disabled) {
+  .journey-surface .selection-reset:hover:not(:disabled) {
     border-color: var(--ink-secondary);
     background: var(--surface-inset);
   }
 }
 
-.selection-reset:not(:disabled):active {
+.journey-surface .selection-reset:not(:disabled):active {
   transform: scale(0.98);
 }
 
-.selection-reset:disabled {
+.journey-surface .selection-reset:disabled {
   border-color: var(--line);
   color: var(--disabled-ink);
   background: var(--disabled-surface);
   cursor: default;
 }
 
-.comparison-table {
+.journey-surface .comparison-table {
   --selector-column: 1.25rem;
   --response-columns: minmax(11rem, 1.35fr) minmax(7rem, 0.75fr) minmax(5rem, 0.55fr) minmax(10rem, 1fr);
   margin-top: var(--space-md);
 }
 
-.comparison-labels,
-.response-row {
+.journey-surface .comparison-labels,
+.journey-surface .response-row {
   display: grid;
   grid-template-columns: var(--selector-column) var(--response-columns);
   gap: var(--space-sm);
 }
 
-.comparison-labels {
+.journey-surface .comparison-labels {
   padding: 0 var(--space-md) var(--space-xs);
   color: var(--muted);
   font-size: 0.625rem;
@@ -548,11 +549,11 @@ main {
   text-transform: uppercase;
 }
 
-.comparison-labels::before {
+.journey-surface .comparison-labels::before {
   content: "";
 }
 
-.response-row {
+.journey-surface .response-row {
   position: relative;
   width: 100%;
   min-height: 5.75rem;
@@ -566,76 +567,76 @@ main {
   transition: background-color var(--selection-transition), transform var(--press-transition);
 }
 
-.response-row:last-child {
+.journey-surface .response-row:last-child {
   border-bottom: 1px solid var(--line);
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .response-row:hover {
+  .journey-surface .response-row:hover {
     background: var(--surface-inset);
   }
 }
 
-.response-row:active {
+.journey-surface .response-row:active {
   transform: scale(0.99);
 }
 
-.response-row[aria-checked="true"] {
+.journey-surface .response-row[aria-checked="true"] {
   z-index: 1;
   outline: 2px solid var(--accent);
   outline-offset: -2px;
   background: var(--accent-soft);
 }
 
-.radio-mark {
+.journey-surface .radio-mark {
   width: 1.125rem;
   height: 1.125rem;
   border: 1.5px solid var(--line-strong);
   border-radius: 50%;
 }
 
-.response-row[aria-checked="true"] .radio-mark {
+.journey-surface .response-row[aria-checked="true"] .radio-mark {
   border: 5px solid var(--accent);
 }
 
-.response-name,
-.metric,
-.response-change {
+.journey-surface .response-name,
+.journey-surface .metric,
+.journey-surface .response-change {
   min-width: 0;
   display: grid;
   gap: var(--space-2xs);
 }
 
-.response-name strong,
-.metric strong,
-.response-change strong {
+.journey-surface .response-name strong,
+.journey-surface .metric strong,
+.journey-surface .response-change strong {
   font-size: 0.8125rem;
   overflow-wrap: anywhere;
 }
 
-.response-name small,
-.metric small,
-.response-change small {
+.journey-surface .response-name small,
+.journey-surface .metric small,
+.journey-surface .response-change small {
   color: var(--muted);
   font-size: 0.6875rem;
 }
 
-.response-row.risk .response-name small {
+.journey-surface .response-row.risk .response-name small {
   color: var(--red);
 }
 
-.decision-preview {
+.journey-surface .decision-preview {
   display: grid;
   gap: var(--space-sm);
   margin-top: var(--space-xl);
 }
 
-.decision-preview > header {
+.journey-surface .decision-preview > header {
   display: grid;
   gap: var(--space-2xs);
 }
 
-.selection-detail {
+.journey-surface .selection-detail {
   min-height: 5rem;
   display: grid;
   grid-template-columns: minmax(9rem, auto) minmax(0, 1fr);
@@ -646,23 +647,23 @@ main {
   background: var(--surface-inset);
 }
 
-.selection-detail > p {
+.journey-surface .selection-detail > p {
   grid-column: 1 / -1;
 }
 
-.selection-detail > div {
+.journey-surface .selection-detail > div {
   display: grid;
   gap: var(--space-2xs);
 }
 
-.selection-detail p {
+.journey-surface .selection-detail p {
   margin: 0;
   color: var(--ink-secondary);
   font-size: 0.8125rem;
   line-height: 1.5;
 }
 
-.detail-label {
+.journey-surface .detail-label {
   color: var(--accent);
   font-size: 0.625rem;
   font-weight: 750;
@@ -670,7 +671,7 @@ main {
   text-transform: uppercase;
 }
 
-.decision-action-region {
+.journey-surface .decision-action-region {
   display: flex;
   align-items: end;
   justify-content: space-between;
@@ -680,19 +681,19 @@ main {
   border-top: 1px solid var(--line-strong);
 }
 
-.decision-action-region > div:first-child {
+.journey-surface .decision-action-region > div:first-child {
   display: grid;
   gap: var(--space-2xs);
 }
 
-.decision-actions {
+.journey-surface .decision-actions {
   display: flex;
   justify-content: flex-end;
   gap: var(--space-xs);
 }
 
-.primary-action,
-.secondary-action {
+.journey-surface .primary-action,
+.journey-surface .secondary-action {
   min-height: 2.75rem;
   padding-inline: var(--space-md);
   border-radius: var(--control-radius);
@@ -701,42 +702,42 @@ main {
   transition: transform var(--press-transition), background-color var(--selection-transition), border-color var(--selection-transition);
 }
 
-.primary-action {
+.journey-surface .primary-action {
   border: 1px solid var(--accent);
   color: var(--surface);
   background: var(--accent);
 }
 
-.secondary-action {
+.journey-surface .secondary-action {
   border: 1px solid var(--line-strong);
   background: transparent;
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .primary-action:hover:not(:disabled) {
+  .journey-surface .primary-action:hover:not(:disabled) {
     border-color: var(--accent-hover);
     background: var(--accent-hover);
   }
 
-  .secondary-action:hover {
+  .journey-surface .secondary-action:hover {
     border-color: var(--ink-secondary);
     background: var(--surface-inset);
   }
 }
 
-.primary-action:not(:disabled):active,
-.secondary-action:active {
+.journey-surface .primary-action:not(:disabled):active,
+.journey-surface .secondary-action:active {
   transform: scale(0.98);
 }
 
-.primary-action:disabled {
+.journey-surface .primary-action:disabled {
   border-color: var(--line);
   color: var(--disabled-ink);
   background: var(--disabled-surface);
   cursor: default;
 }
 
-.toast {
+.journey-surface .toast {
   position: fixed;
   z-index: 10;
   top: calc(4rem + var(--space-sm));
@@ -752,135 +753,135 @@ main {
   transition: opacity 200ms ease-out, transform 200ms ease-out;
 }
 
-.toast.visible {
+.journey-surface .toast.visible {
   opacity: 1;
   transform: translateY(0);
 }
 
 @media (max-width: 65rem) {
-  .app-bar {
+  .journey-surface .app-bar {
     grid-template-columns: auto 1fr auto;
     padding-inline: var(--space-lg);
   }
 
-  main {
+  .journey-surface main {
     width: min(calc(100% - var(--space-xl)), 45rem);
   }
 
-  .disruption {
+  .journey-surface .disruption {
     grid-template-columns: auto minmax(0, 1fr);
   }
 
-  .source-status {
+  .journey-surface .source-status {
     grid-column: 2;
     justify-content: flex-start;
   }
 
-  .source-status > div {
+  .journey-surface .source-status > div {
     justify-items: start;
   }
 
-  .workspace-grid {
+  .journey-surface .workspace-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .itinerary-panel {
+  .journey-surface .itinerary-panel {
     border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 }
 
 @media (max-width: 40rem) {
-  .app-bar {
+  .journey-surface .app-bar {
     min-height: 4rem;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: var(--space-sm);
     padding-inline: var(--space-md);
   }
 
-  .wordmark {
+  .journey-surface .wordmark {
     display: none;
   }
 
-  .journey-identity {
+  .journey-surface .journey-identity {
     justify-self: start;
     font-size: 0.8125rem;
   }
 
-  .revision-trace {
+  .journey-surface .revision-trace {
     gap: var(--space-xs);
     font-size: 0.6875rem;
   }
 
-  .quiet-action {
+  .journey-surface .quiet-action {
     font-size: 0.75rem;
   }
 
-  main {
+  .journey-surface main {
     width: 100%;
     padding: 0 0 var(--space-xl);
   }
 
-  .disruption {
+  .journey-surface .disruption {
     gap: var(--space-sm);
     padding: var(--space-md);
     border-width: 0 0 1px;
   }
 
-  .disruption-mark {
+  .journey-surface .disruption-mark {
     width: 2.25rem;
     height: 2.25rem;
   }
 
-  .disruption h2 {
+  .journey-surface .disruption h2 {
     font-size: 1.125rem;
   }
 
-  .disruption-copy > p:last-child {
+  .journey-surface .disruption-copy > p:last-child {
     font-size: 0.8125rem;
   }
 
-  .source-status {
+  .journey-surface .source-status {
     grid-column: 1 / -1;
   }
 
-  .workspace-grid {
+  .journey-surface .workspace-grid {
     min-height: 0;
     margin: 0;
     border: 0;
   }
 
-  .itinerary-panel {
+  .journey-surface .itinerary-panel {
     padding: var(--space-lg) var(--space-md);
   }
 
-  .decision-panel {
+  .journey-surface .decision-panel {
     padding: var(--space-xl) var(--space-md);
   }
 
-  .panel-heading {
+  .journey-surface .panel-heading {
     gap: var(--space-sm);
   }
 
-  .itinerary-list {
+  .journey-surface .itinerary-list {
     margin-top: var(--space-lg);
   }
 
-  .itinerary-stop {
+  .journey-surface .itinerary-stop {
     min-height: 3.625rem;
     padding-bottom: var(--space-md);
   }
 
-  .decision-heading h1 {
+  .journey-surface .decision-heading h1 {
     font-size: 1.75rem;
   }
 
 
-  .comparison-labels {
+  .journey-surface .comparison-labels {
     display: none;
   }
 
-  .response-row {
+  .journey-surface .response-row {
     grid-template-columns: var(--selector-column) minmax(0, 1fr);
     gap: var(--space-sm);
     min-height: 0;
@@ -888,65 +889,65 @@ main {
     padding: var(--space-md) var(--space-sm);
   }
 
-  .radio-mark {
+  .journey-surface .radio-mark {
     grid-column: 1;
   }
 
-  .response-name,
-  .metric,
-  .response-change {
+  .journey-surface .response-name,
+  .journey-surface .metric,
+  .journey-surface .response-change {
     grid-column: 2;
   }
 
-  .response-name small {
+  .journey-surface .response-name small {
     display: grid;
     grid-template-columns: minmax(5.5rem, 0.65fr) minmax(0, 1fr);
     gap: var(--space-sm);
   }
 
-  .response-name small::before {
+  .journey-surface .response-name small::before {
     content: "Evidence";
     color: var(--muted);
     font-weight: 650;
   }
 
-  .metric,
-  .response-change {
+  .journey-surface .metric,
+  .journey-surface .response-change {
     grid-template-columns: minmax(5.5rem, 0.65fr) minmax(0, 1fr);
     align-items: baseline;
     gap: var(--space-sm);
   }
 
-  .metric small,
-  .response-change small {
+  .journey-surface .metric small,
+  .journey-surface .response-change small {
     font-weight: 650;
   }
 
-  .selection-detail {
+  .journey-surface .selection-detail {
     grid-template-columns: minmax(0, 1fr);
     gap: var(--space-xs);
   }
 
-  .selection-detail > p {
+  .journey-surface .selection-detail > p {
     grid-column: auto;
   }
 
-  .decision-action-region {
+  .journey-surface .decision-action-region {
     display: grid;
     align-items: start;
     gap: var(--space-md);
   }
 
-  .decision-actions {
+  .journey-surface .decision-actions {
     display: grid;
   }
 
-  .primary-action,
-  .secondary-action {
+  .journey-surface .primary-action,
+  .journey-surface .secondary-action {
     width: 100%;
   }
 
-  .toast {
+  .journey-surface .toast {
     top: calc(4rem + var(--space-xs));
     right: var(--space-md);
     max-width: calc(100% - var(--space-xl));
@@ -954,21 +955,21 @@ main {
 }
 
 @media (prefers-contrast: more) {
-  :root {
+  .journey-surface {
     --line: var(--line-strong);
   }
 
-  .response-row[aria-checked="true"],
-  .plan-status,
-  .certainty {
+  .journey-surface .response-row[aria-checked="true"],
+  .journey-surface .plan-status,
+  .journey-surface .certainty {
     box-shadow: inset 0 0 0 1px currentcolor;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
+  .journey-surface *,
+  .journey-surface *::before,
+  .journey-surface *::after {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }

--- a/examples/web/src/features/genui-possibilities/route/journey-client.tsx
+++ b/examples/web/src/features/genui-possibilities/route/journey-client.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { MouseEvent, ReactNode } from 'react';
+import { mountGenuiPossibilities } from '../browser/mount.js';
+import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
+import { useRouteLifecycle } from '../../../shared/route-lifecycle/browser/provider';
+
+export function JourneyClient({ children }: { readonly children: ReactNode }) {
+  const lifecycle = useRouteLifecycle();
+  const handleNavigation = (event: MouseEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const link = target.closest<HTMLAnchorElement>('a.wordmark[href="/"]');
+    if (
+      link === null ||
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    lifecycle.navigate('/');
+  };
+
+  return (
+    <ImperativeDemoHost
+      demoId="journey"
+      mount={mountGenuiPossibilities}
+      className="journey-surface"
+    >
+      <div onClick={handleNavigation}>{children}</div>
+    </ImperativeDemoHost>
+  );
+}

--- a/examples/web/src/features/genui-possibilities/route/journey-route.tsx
+++ b/examples/web/src/features/genui-possibilities/route/journey-route.tsx
@@ -1,0 +1,18 @@
+import journeyDocument from '../../../../genui-possibilities.html?raw';
+import { JourneyClient } from './journey-client';
+
+const shellMatch = journeyDocument.match(
+  /<body[^>]*>([\s\S]*?)\s*<script type="module" src="\/src\/entries\/genui-possibilities\.js"><\/script>\s*<\/body>/,
+);
+if (shellMatch === null) {
+  throw new Error('The canonical Journey document shell is unavailable');
+}
+const journeyShellMarkup = shellMatch[1];
+
+export function JourneyRoute() {
+  return (
+    <JourneyClient>
+      <div dangerouslySetInnerHTML={{ __html: journeyShellMarkup }} />
+    </JourneyClient>
+  );
+}

--- a/examples/web/src/pages/journey.tsx
+++ b/examples/web/src/pages/journey.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { JourneyRoute } from '../features/genui-possibilities/route/journey-route';
 
 export default function Journey() {
-  return <DemoPlaceholder demoId="journey" />;
+  return <JourneyRoute />;
 }

--- a/examples/web/src/shared/route-lifecycle/browser/imperative-host.ts
+++ b/examples/web/src/shared/route-lifecycle/browser/imperative-host.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { createElement, useLayoutEffect, useRef } from 'react';
+import { createElement, type ReactNode, useLayoutEffect, useRef } from 'react';
 import type { DemoId } from '../../catalog/demo-catalog';
 import {
   type MountedImperativeSession,
@@ -20,10 +20,12 @@ export function ImperativeDemoHost({
   demoId,
   mount,
   className,
+  children,
 }: {
   readonly demoId: DemoId;
   readonly mount: MountImperativeDemo;
   readonly className?: string;
+  readonly children?: ReactNode;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const lifecycle = useRouteLifecycle();
@@ -41,5 +43,5 @@ export function ImperativeDemoHost({
     ref: containerRef,
     className,
     'data-imperative-demo-host': demoId,
-  });
+  }, children);
 }

--- a/examples/web/waku-tests/journey-route.spec.ts
+++ b/examples/web/waku-tests/journey-route.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test';
+
+test('restores Journey reducer state after a same-document route cycle', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Journey Proposals/ }).click();
+  await expect(page).toHaveURL(/\/journey$/);
+  await expect(page.getByRole('heading', { name: 'How should this journey change?' }))
+    .toBeFocused();
+
+  await page.getByRole('radio', { name: 'Leave earlier' }).click();
+  await page.getByRole('button', { name: 'Apply to itinerary' }).click();
+  await expect(page.locator('#revision-label')).toHaveText('Revision 4');
+
+  await page.getByRole('link', { name: 'Canopy home' }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await page.getByRole('link', { name: /Journey Proposals/ }).click();
+
+  await expect(page.locator('#revision-label')).toHaveText('Revision 4');
+  await expect(page.locator('#plan-status')).toHaveText('Updated · booking unchanged');
+});
+
+test('resets Journey reducer state on full reload', async ({ page }) => {
+  await page.goto('/journey');
+  await page.getByRole('radio', { name: 'Leave earlier' }).click();
+  await page.getByRole('button', { name: 'Apply to itinerary' }).click();
+  await expect(page.locator('#revision-label')).toHaveText('Revision 4');
+
+  await page.reload();
+
+  await expect(page.locator('#revision-label')).toHaveText('Revision 3');
+  await expect(page.locator('#plan-status')).toHaveText('Needs attention');
+  await expect(page.getByRole('button', { name: 'Undo last change' })).toBeDisabled();
+});
+
+test('restores the focused Journey response on browser traversal', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Journey Proposals/ }).click();
+  const response = page.getByRole('radio', { name: 'Stay in Okayama' });
+  await response.click();
+  await expect(response).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await expect(page).toHaveURL(/\/journey$/);
+
+  await expect(page.getByRole('radio', { name: 'Stay in Okayama' })).toBeFocused();
+  await expect(page.getByRole('radio', { name: 'Stay in Okayama' }))
+    .toHaveAttribute('aria-checked', 'true');
+});
+
+test('repeated Journey route cycles release listeners and the toast timer', async ({ page }) => {
+  await page.addInitScript(() => {
+    const listenerRecords: Array<{
+      target: EventTarget;
+      type: string;
+      listener: EventListenerOrEventListenerObject;
+    }> = [];
+    const toastTimers = new Set<number>();
+    const originalAdd = EventTarget.prototype.addEventListener;
+    const originalRemove = EventTarget.prototype.removeEventListener;
+    const originalSetTimeout = window.setTimeout.bind(window);
+    const originalClearTimeout = window.clearTimeout.bind(window);
+    const isJourneyTarget = (target: EventTarget) =>
+      target instanceof Element &&
+      target.closest('[data-imperative-demo-host="journey"]') !== null;
+
+    EventTarget.prototype.addEventListener = function (type, listener, options) {
+      if (listener !== null && isJourneyTarget(this)) {
+        listenerRecords.push({ target: this, type, listener });
+      }
+      originalAdd.call(this, type, listener, options);
+    };
+    EventTarget.prototype.removeEventListener = function (type, listener, options) {
+      const index = listener === null ? -1 : listenerRecords.findIndex(
+        (record) => record.target === this && record.type === type && record.listener === listener,
+      );
+      if (index >= 0) listenerRecords.splice(index, 1);
+      originalRemove.call(this, type, listener, options);
+    };
+    window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      let timer = 0;
+      const wrapped = typeof handler === 'function'
+        ? (...callbackArgs: unknown[]) => {
+            toastTimers.delete(timer);
+            return handler(...callbackArgs);
+          }
+        : handler;
+      timer = originalSetTimeout(wrapped, timeout, ...args);
+      if (timeout === 2_800) toastTimers.add(timer);
+      return timer;
+    }) as typeof window.setTimeout;
+    window.clearTimeout = ((timer?: number) => {
+      if (timer !== undefined) toastTimers.delete(timer);
+      originalClearTimeout(timer);
+    }) as typeof window.clearTimeout;
+    Object.defineProperty(window, '__journeyResources', {
+      value: {
+        listenerCount: () => listenerRecords.length,
+        timerCount: () => toastTimers.size,
+      },
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    await page.getByRole('link', { name: /Journey Proposals/ }).click();
+    await expect(page.getByRole('radio')).toHaveCount(3);
+    expect(await page.evaluate(
+      () => (window as unknown as {
+        __journeyResources: { listenerCount(): number };
+      }).__journeyResources.listenerCount(),
+    )).toBeGreaterThan(0);
+
+    if (cycle === 0) {
+      await page.getByRole('radio', { name: 'Leave earlier' }).click();
+      await page.getByRole('button', { name: 'Apply to itinerary' }).click();
+      expect(await page.evaluate(
+        () => (window as unknown as {
+          __journeyResources: { timerCount(): number };
+        }).__journeyResources.timerCount(),
+      )).toBe(1);
+    }
+
+    await page.getByRole('link', { name: 'Canopy home' }).click();
+    await expect(page).toHaveURL(/\/$/);
+    expect(await page.evaluate(
+      () => {
+        const resources = (window as unknown as {
+          __journeyResources: { listenerCount(): number; timerCount(): number };
+        }).__journeyResources;
+        return [resources.listenerCount(), resources.timerCount()];
+      },
+    )).toEqual([0, 0]);
+  }
+});


### PR DESCRIPTION
## Summary

- expose the existing Journey reducer and DOM shell at the canonical Waku `/journey` route through the shared imperative lifecycle host
- preserve same-document reducer snapshots and response focus while resetting on reload, and release Journey listeners/toast timers across repeated route cycles
- retain `genui-possibilities.html` as the canonical visual markup and legacy Vite URL; scope its CSS so visiting Journey cannot affect the Hub

No compatibility redirect, production deployment, Vite removal, reducer semantic change, itinerary workflow change, or visual redesign is included.

Closes #972

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `createJourneyState` / `transitionJourney` | `examples/web/src/features/genui-possibilities/core/journey-state.js` | Yes | Existing Journey reducer remains unchanged and owns all state transitions. |
| `ImperativeDemoHost` / `ownImperativeSession` | `examples/web/src/shared/route-lifecycle/browser/` | Yes | Provides mount registration, defensive snapshots, focus restoration, and idempotent disposal. |
| `useRouteLifecycle` | `examples/web/src/shared/route-lifecycle/browser/provider.tsx` | Yes | Routes the existing wordmark through Waku without adding another router. |
| `genui-possibilities.html` | `examples/web/genui-possibilities.html` | Yes | Remains the single source of truth for Journey markup in Vite and Waku. |
| `structuredClone` | Browser core API | Yes | Defensively owns restored and captured reducer state. |
| `LifecycleLink` | `examples/web/src/shared/route-lifecycle/browser/lifecycle-link.tsx` | No | The canonical legacy markup owns the existing anchor; the client route preserves modified-click behavior and delegates unmodified navigation to `useRouteLifecycle`. |

No MoonBit source, helper, type, loop, or data transformation was added. MoonBit `Map`, `Set`, `String`/views, `Bytes`/views, `Buffer`, `Option`/`Result`, `Array`, and `Iter` APIs are therefore not applicable to this browser-only lifecycle slice.

New helpers added (if any):

- `JourneyRoute` is the server route surface that reuses the canonical legacy markup and keeps it present during RSC navigation.
- `JourneyClient` is the client lifecycle boundary around the existing imperative DOM shell.
- `mount.d.ts` describes the existing JavaScript mount as a `MountedImperativeSession`; it adds no runtime behavior.

Remaining imperative code is limited to the pre-existing DOM shell plus the required listener, timer, focus, and disposal adapter boundary.

## Test plan

- [x] `moon check` passes
- [x] `moon test` passes
- [x] `git diff *.mbti` reviewed — no interface changes
- [x] Vite and Waku JavaScript builds pass
- [x] legacy Journey Playwright contract passes at `genui-possibilities.html`
- [x] Waku Journey parity and route lifecycle contracts pass at `/journey`

## Validation

```bash
./scripts/build-js.sh
moon check
moon test

cd examples/web
npm run typecheck
npm run check:boundaries
npm run test:boundaries
npm run test:foundation
npm run build:vite
npm run build:waku
npm run check:waku-bundles
npm run check:waku-types
npm run test:waku:e2e
npx playwright test tests/genui-possibilities.spec.ts --project=chromium
CANOPY_WAKU_WORKER_PORT=8797 npm run test:waku:workerd
npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env preview
```

Waku E2E: 21 passed. Legacy Journey E2E: 8 passed. The workerd smoke used port 8797 because an unrelated local Worker already occupied 8787.
