### PR TITLE
feat(web): migrate Posts to /posts

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -662,7 +662,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
   Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972 migrates Journey to `/journey`. Vite remains the default, and no redirect or production deployment has migrated.
+  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#973 migrate Journey and Posts to `/journey` and `/posts`. Vite remains the default, and no redirect or production deployment has migrated.
   Exit: the plan's Stage 12 gate passes after production cutover is proven.
 
 ## 22. SDEG Lifecycle

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -47,9 +47,9 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 Most of the source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. Resume/PKE, Posts, Memo, JSON, Markdown, GenUI, and GenUI Possibilities use the target entry/feature layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku migration (pre-production, #970–#972 Stages 0–3)
+## Waku migration (pre-production, #970–#973 Stages 0–4)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stage 3 migrates Journey while retaining every old HTML entry.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–4 migrate Journey and Posts while retaining every old HTML entry.
 
 ### Stage 0–1 configuration and artifacts
 
@@ -65,8 +65,9 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 
 - `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
 - `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
-- `src/pages/{ml,json,markdown,memo,posts,resume,genui}.tsx` — seven canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/{ml,json,markdown,memo,resume,genui}.tsx` — six canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
 - `src/pages/journey.tsx` — canonical Journey route; composes the feature-owned route surface through the shared imperative host.
+- `src/pages/posts.tsx` — canonical Posts route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/_layout.tsx` — pass-through shared route layout; the provider stays at `_root.tsx` so its in-memory registry survives route render failures.
 - `src/shared/catalog/demo-catalog.ts` — framework-independent catalog data (eight demos, three groups, canonical `DemoPath` routes).
 - `src/shared/shell/` — `DemoHub` and `DemoPlaceholder` React components and shared shell styles.
@@ -83,6 +84,15 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 - `waku-tests/journey-route.spec.ts` — route-memory, reload-reset, browser-traversal focus, and repeated timer/listener disposal coverage.
 
 Stage 3 remains pre-production. Vite and `genui-possibilities.html` remain the defaults and are retained. No Journey compatibility redirect is active.
+
+### Stage 4 — Posts
+
+- `src/features/posts/route/{posts-route,posts-client}.tsx` — server/client route seam that reuses the legacy Posts markup at `/posts` and mounts the existing browser persistence shell inside the shared imperative host.
+- `src/features/posts/browser/{app,mount,view}.ts` — shared Vite/Waku mount with an allowlisted route snapshot (draft, related mode, highlighted post ID), host-scoped DOM ownership, stable focus restoration, and idempotent listener/scheduled-focus cleanup.
+- `tests/post-app.spec.ts` — existing Posts behavior and storage contract, now run against both legacy Vite `/posts.html` and Waku `/posts`.
+- `waku-tests/posts-route.spec.ts` — same-document route-memory, full-reload storage boundary, focus restoration, and repeated listener/scheduled-focus disposal coverage.
+
+Stage 4 remains pre-production. Vite and `posts.html` remain the defaults and are retained. No Posts compatibility redirect is active, and the existing `canopy.posts.v1` and `canopy.post-events.v1` schemas remain unchanged.
 
 Validation runs in parallel with the Vite pipeline:
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,9 +5,9 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Waku migration (in progress, #972)
+## Waku migration (in progress, #973)
 
-A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stage 3 migrates Journey Proposals to `/journey` through the imperative host while retaining `genui-possibilities.html`; the other seven canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stage 3 migrates Journey Proposals to `/journey`; Stage 4 migrates Posts to `/posts` while preserving its two local-storage contracts and route-local draft state. Both use the imperative host and retain their legacy HTML entries; the other six canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
 
 ## Development
 

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -6,12 +6,14 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 }
 
 process.env.GENUI_POSSIBILITIES_URL = '/journey';
+process.env.POSTS_URL = '/posts';
 
 export default defineConfig({
   testDir: '.',
   testMatch: [
     'waku-tests/**/*.spec.ts',
     'tests/genui-possibilities.spec.ts',
+    'tests/post-app.spec.ts',
   ],
   timeout: 30_000,
   retries: 0,

--- a/examples/web/posts.html
+++ b/examples/web/posts.html
@@ -6,18 +6,18 @@
   <title>Canopy Posts</title>
 
 </head>
-<body>
+<body class="posts-surface">
   <main class="shell">
     <header>
       <p class="eyebrow">Local-first prototype</p>
-      <h1>Post to yourself.</h1>
+      <h1 data-route-heading tabindex="-1">Post to yourself.</h1>
       <p class="lede">One field, no folders, no API key. As you write, a few old posts return quietly underneath; the stream stays newest-first when you just want chronology.</p>
     </header>
 
-    <form class="composer" id="post-form">
+    <form class="composer" id="post-form" inert data-posts-ready="false">
       <label for="post-input">
         Write
-        <textarea id="post-input" name="post" placeholder="A thought, reminder, note, or question for future you…" autocomplete="off"></textarea>
+        <textarea id="post-input" name="post" placeholder="A thought, reminder, note, or question for future you…" autocomplete="off" data-route-focus="draft"></textarea>
       </label>
 
       <div class="composer-actions">

--- a/examples/web/src/features/posts/browser/app.ts
+++ b/examples/web/src/features/posts/browser/app.ts
@@ -10,11 +10,33 @@ interface PostsAppDependencies {
   readonly view: PostsView;
 }
 
+export interface PostsSnapshot {
+  readonly draft: string;
+  readonly relatedMode: RelatedPanelMode;
+  readonly highlightedPostId: string | null;
+}
+
+function readPostsSnapshot(snapshot: unknown): PostsSnapshot | undefined {
+  if (snapshot === undefined) return undefined;
+  if (typeof snapshot !== 'object' || snapshot === null) {
+    return { draft: '', relatedMode: 'writing', highlightedPostId: null };
+  }
+  const candidate = snapshot as Record<string, unknown>;
+  return {
+    draft: typeof candidate.draft === 'string' ? candidate.draft : '',
+    relatedMode: candidate.relatedMode === 'ask' ? 'ask' : 'writing',
+    highlightedPostId: typeof candidate.highlightedPostId === 'string'
+      ? candidate.highlightedPostId
+      : null,
+  };
+}
+
 export function createPostsApp({ store, eventStore, view }: PostsAppDependencies) {
   let posts: LocalPost[] = [];
   let highlightedPostId: string | null = null;
   let relatedMode: RelatedPanelMode = 'writing';
   let retrievalIndex = new PostRetrievalIndex(posts, eventStore.engagementByPost());
+  let disposeView: (() => void) | null = null;
 
   function pluralizePosts(count: number): string {
     return count === 1 ? '1 post' : `${count} posts`;
@@ -128,8 +150,12 @@ export function createPostsApp({ store, eventStore, view }: PostsAppDependencies
   }
 
   return {
-    mount(): void {
-      view.bind({
+    mount(restoredSnapshot?: unknown, focusDraft = true): void {
+      const restored = readPostsSnapshot(restoredSnapshot);
+      highlightedPostId = restored?.highlightedPostId ?? null;
+      relatedMode = restored?.relatedMode ?? 'writing';
+      if (restored !== undefined) view.setDraftText(restored.draft);
+      disposeView = view.bind({
         submitDraft,
         askDraft,
         updateDraft(): void {
@@ -140,7 +166,17 @@ export function createPostsApp({ store, eventStore, view }: PostsAppDependencies
       });
       loadPosts();
       view.syncSubmitState();
-      view.focusDraft();
+      if (focusDraft) view.focusDraft();
+    },
+    snapshot: (): PostsSnapshot => ({
+      draft: view.draftText(),
+      relatedMode,
+      highlightedPostId,
+    }),
+    restoreFocus: (token: string) => view.restoreFocus(token),
+    dispose(): void {
+      disposeView?.();
+      disposeView = null;
     },
   };
 }

--- a/examples/web/src/features/posts/browser/mount.ts
+++ b/examples/web/src/features/posts/browser/mount.ts
@@ -3,11 +3,19 @@ import { createPostsApp } from './app';
 import { LocalPostEventStore } from './post-events';
 import { LocalPostStore } from './post-store';
 import { createPostsView } from './view';
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
 
-export function mountPosts(): void {
-  createPostsApp({
+export function mountPosts(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot?: unknown,
+): MountedImperativeSession {
+  const document = root instanceof Document ? root : root.ownerDocument;
+  const window = document.defaultView ?? globalThis.window;
+  const app = createPostsApp({
     store: new LocalPostStore(window.localStorage),
     eventStore: new LocalPostEventStore(window.localStorage),
-    view: createPostsView(document, window),
-  }).mount();
+    view: createPostsView(root, window),
+  });
+  app.mount(restoredSnapshot, root instanceof Document);
+  return app;
 }

--- a/examples/web/src/features/posts/browser/styles.css
+++ b/examples/web/src/features/posts/browser/styles.css
@@ -1,4 +1,4 @@
-    :root {
+    .posts-surface {
       --bg: #1a1a2e;
       --panel: #1e1e36;
       --surface: #252540;
@@ -20,11 +20,11 @@
       --space-3xl: 48px;
     }
 
-    * {
+    .posts-surface, .posts-surface * {
       box-sizing: border-box;
     }
 
-    body {
+    .posts-surface {
       margin: 0;
       min-height: 100vh;
       background:
@@ -35,24 +35,24 @@
       line-height: 1.6;
     }
 
-    button,
-    textarea {
+    .posts-surface button,
+    .posts-surface textarea {
       font: inherit;
     }
 
-    .shell {
+    .posts-surface .shell {
       width: min(920px, calc(100% - 32px));
       margin: 0 auto;
       padding: clamp(32px, 7vw, 72px) 0;
     }
 
-    header {
+    .posts-surface header {
       display: grid;
       gap: var(--space-sm);
       margin-bottom: var(--space-2xl);
     }
 
-    .eyebrow {
+    .posts-surface .eyebrow {
       color: var(--muted);
       font-size: 0.78rem;
       font-weight: 700;
@@ -60,7 +60,7 @@
       text-transform: uppercase;
     }
 
-    h1 {
+    .posts-surface h1 {
       margin: 0;
       max-width: 12ch;
       color: var(--text);
@@ -69,14 +69,14 @@
       letter-spacing: -0.065em;
     }
 
-    .lede {
+    .posts-surface .lede {
       max-width: 58ch;
       margin: var(--space-md) 0 0;
       color: var(--secondary);
       font-size: 1rem;
     }
 
-    .composer {
+    .posts-surface .composer {
       display: grid;
       gap: var(--space-lg);
       padding: var(--space-xl);
@@ -85,7 +85,7 @@
       border-radius: 18px;
     }
 
-    label {
+    .posts-surface label {
       display: grid;
       gap: var(--space-sm);
       color: var(--secondary);
@@ -93,7 +93,7 @@
       font-weight: 700;
     }
 
-    textarea {
+    .posts-surface textarea {
       width: 100%;
       min-height: 168px;
       resize: vertical;
@@ -108,16 +108,16 @@
       line-height: 1.7;
     }
 
-    textarea::placeholder {
+    .posts-surface textarea::placeholder {
       color: var(--muted);
     }
 
-    textarea:focus {
+    .posts-surface textarea:focus {
       border-color: color-mix(in oklab, var(--accent), var(--border) 25%);
       box-shadow: 0 0 0 3px var(--accent-soft);
     }
 
-    .composer-actions {
+    .posts-surface .composer-actions {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-md);
@@ -125,13 +125,13 @@
       justify-content: space-between;
     }
 
-    .hint {
+    .posts-surface .hint {
       margin: 0;
       color: var(--muted);
       font-size: 0.86rem;
     }
 
-    kbd {
+    .posts-surface kbd {
       padding: 1px 6px;
       background: var(--surface);
       color: var(--secondary);
@@ -141,15 +141,15 @@
       font-size: 0.78rem;
     }
 
-    .composer-buttons {
+    .posts-surface .composer-buttons {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-sm);
       align-items: center;
     }
 
-    .post-button,
-    .ask-button {
+    .posts-surface .post-button,
+    .posts-surface .ask-button {
       min-width: 116px;
       padding: 10px 18px;
       border-radius: 999px;
@@ -159,36 +159,36 @@
       transition: transform 120ms ease, background 120ms ease, border-color 120ms ease, opacity 120ms ease;
     }
 
-    .post-button {
+    .posts-surface .post-button {
       background: var(--accent);
       color: var(--text);
       border: 1px solid color-mix(in oklab, var(--accent), white 10%);
     }
 
-    .ask-button {
+    .posts-surface .ask-button {
       background: color-mix(in oklab, var(--surface), var(--accent) 10%);
       color: var(--secondary);
       border: 1px solid color-mix(in oklab, var(--border), var(--accent) 26%);
     }
 
-    .post-button:hover:not(:disabled) {
+    .posts-surface .post-button:hover:not(:disabled) {
       background: color-mix(in oklab, var(--accent), white 8%);
       transform: translateY(-1px);
     }
 
-    .ask-button:hover:not(:disabled) {
+    .posts-surface .ask-button:hover:not(:disabled) {
       color: var(--text);
       border-color: color-mix(in oklab, var(--accent), var(--border) 30%);
       transform: translateY(-1px);
     }
 
-    .post-button:disabled,
-    .ask-button:disabled {
+    .posts-surface .post-button:disabled,
+    .posts-surface .ask-button:disabled {
       cursor: not-allowed;
       opacity: 0.46;
     }
 
-    .status-row {
+    .posts-surface .status-row {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-md);
@@ -197,27 +197,27 @@
       min-height: 24px;
     }
 
-    #post-status {
+    .posts-surface #post-status {
       margin: 0;
       color: var(--muted);
       font-size: 0.9rem;
     }
 
-    #post-status[data-tone="success"] {
+    .posts-surface #post-status[data-tone="success"] {
       color: color-mix(in oklab, var(--success), var(--text) 18%);
     }
 
-    #post-status[data-tone="error"] {
+    .posts-surface #post-status[data-tone="error"] {
       color: var(--error);
     }
 
-    #post-count {
+    .posts-surface #post-count {
       color: var(--secondary);
       font-size: 0.86rem;
       font-weight: 700;
     }
 
-    .related-panel {
+    .posts-surface .related-panel {
       display: grid;
       gap: var(--space-md);
       margin-top: var(--space-xl);
@@ -227,11 +227,11 @@
       border-radius: 16px;
     }
 
-    .related-panel[hidden] {
+    .posts-surface .related-panel[hidden] {
       display: none;
     }
 
-    .related-heading {
+    .posts-surface .related-heading {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-sm) var(--space-lg);
@@ -239,7 +239,7 @@
       justify-content: space-between;
     }
 
-    .related-kicker {
+    .posts-surface .related-kicker {
       margin: 0;
       color: var(--muted);
       font-size: 0.72rem;
@@ -248,20 +248,20 @@
       text-transform: uppercase;
     }
 
-    .related-heading h2 {
+    .posts-surface .related-heading h2 {
       margin: var(--space-xs) 0 0;
       color: var(--text);
       font-size: 1rem;
       letter-spacing: -0.01em;
     }
 
-    #related-count {
+    .posts-surface #related-count {
       color: var(--secondary);
       font-size: 0.82rem;
       font-weight: 700;
     }
 
-    .related-list {
+    .posts-surface .related-list {
       display: grid;
       gap: 0;
       margin: 0;
@@ -269,42 +269,42 @@
       list-style: none;
     }
 
-    .related-empty {
+    .posts-surface .related-empty {
       margin: 0;
       padding-top: var(--space-sm);
       color: var(--muted);
       font-size: 0.9rem;
     }
 
-    .related-empty[hidden] {
+    .posts-surface .related-empty[hidden] {
       display: none;
     }
 
-    .related-item article {
+    .posts-surface .related-item article {
       display: grid;
       gap: var(--space-xs);
       padding: var(--space-md) 0;
       border-top: 1px solid var(--border);
     }
 
-    .related-item:first-child article {
+    .posts-surface .related-item:first-child article {
       padding-top: 0;
       border-top: 0;
     }
 
-    .related-item:last-child article {
+    .posts-surface .related-item:last-child article {
       padding-bottom: 0;
     }
 
-    .related-meta {
+    .posts-surface .related-meta {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-sm);
       align-items: center;
     }
 
-    .related-meta time,
-    .related-reason {
+    .posts-surface .related-meta time,
+    .posts-surface .related-reason {
       color: var(--muted);
       font-size: 0.72rem;
       font-weight: 700;
@@ -312,29 +312,29 @@
       text-transform: uppercase;
     }
 
-    .related-reasons {
+    .posts-surface .related-reasons {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-sm);
       align-items: center;
     }
 
-    .related-reason[data-kind="match"] {
+    .posts-surface .related-reason[data-kind="match"] {
       color: color-mix(in oklab, var(--secondary), var(--accent) 20%);
     }
 
-    .related-reason[data-kind="resurfacing"] {
+    .posts-surface .related-reason[data-kind="resurfacing"] {
       color: color-mix(in oklab, var(--success), var(--text) 18%);
     }
 
-    .related-text {
+    .posts-surface .related-text {
       margin: 0;
       color: var(--secondary);
       white-space: pre-wrap;
       overflow-wrap: anywhere;
     }
 
-    .related-open {
+    .posts-surface .related-open {
       justify-self: start;
       margin-top: var(--space-xs);
       padding: 4px 10px;
@@ -349,20 +349,20 @@
       text-transform: uppercase;
     }
 
-    .related-open:hover,
-    .related-open:focus-visible {
+    .posts-surface .related-open:hover,
+    .posts-surface .related-open:focus-visible {
       color: var(--text);
       border-color: color-mix(in oklab, var(--accent), var(--border) 30%);
       outline: none;
     }
 
-    .timeline {
+    .posts-surface .timeline {
       display: grid;
       gap: var(--space-lg);
       margin-top: var(--space-2xl);
     }
 
-    .timeline h2 {
+    .posts-surface .timeline h2 {
       margin: 0;
       color: var(--secondary);
       font-size: 0.88rem;
@@ -370,7 +370,7 @@
       text-transform: uppercase;
     }
 
-    .post-list {
+    .posts-surface .post-list {
       display: grid;
       gap: var(--space-md);
       margin: 0;
@@ -378,7 +378,7 @@
       list-style: none;
     }
 
-    .post-item article {
+    .posts-surface .post-item article {
       display: grid;
       gap: var(--space-sm);
       padding: var(--space-lg);
@@ -387,12 +387,12 @@
       border-radius: 16px;
     }
 
-    .post-item[data-highlighted="true"] article {
+    .posts-surface .post-item[data-highlighted="true"] article {
       border-color: color-mix(in oklab, var(--accent), var(--border) 25%);
       box-shadow: 0 0 0 3px var(--accent-soft);
     }
 
-    .post-item time {
+    .posts-surface .post-item time {
       color: var(--muted);
       font-size: 0.78rem;
       font-weight: 700;
@@ -400,14 +400,14 @@
       text-transform: uppercase;
     }
 
-    .post-item p {
+    .posts-surface .post-item p {
       margin: 0;
       color: var(--text);
       white-space: pre-wrap;
       overflow-wrap: anywhere;
     }
 
-    .empty-state {
+    .posts-surface .empty-state {
       padding: var(--space-2xl);
       background: color-mix(in oklab, var(--panel), transparent 20%);
       border: 1px dashed color-mix(in oklab, var(--border), var(--secondary) 12%);
@@ -415,32 +415,32 @@
       color: var(--muted);
     }
 
-    .empty-state p {
+    .posts-surface .empty-state p {
       max-width: 46ch;
       margin: 0;
     }
 
     @media (max-width: 640px) {
-      .shell {
+      .posts-surface .shell {
         width: min(100% - 24px, 920px);
         padding: var(--space-2xl) 0;
       }
 
-      .composer {
+      .posts-surface .composer {
         padding: var(--space-lg);
         border-radius: 14px;
       }
 
-      .composer-actions,
-      .related-heading,
-      .status-row {
+      .posts-surface .composer-actions,
+      .posts-surface .related-heading,
+      .posts-surface .status-row {
         align-items: stretch;
         flex-direction: column;
       }
 
-      .composer-buttons,
-      .post-button,
-      .ask-button {
+      .posts-surface .composer-buttons,
+      .posts-surface .post-button,
+      .posts-surface .ask-button {
         width: 100%;
       }
     }

--- a/examples/web/src/features/posts/browser/view.ts
+++ b/examples/web/src/features/posts/browser/view.ts
@@ -20,8 +20,10 @@ interface PostsViewHandlers {
 
 export interface PostsView {
   draftText(): string;
+  setDraftText(text: string): void;
   clearDraft(): void;
   focusDraft(): void;
+  restoreFocus(token: string): boolean;
   syncSubmitState(): void;
   setStatus(message: string, tone?: StatusTone): void;
   renderTimeline(posts: readonly LocalPost[], highlightedPostId: string | null): void;
@@ -31,7 +33,7 @@ export interface PostsView {
     openRelatedPost: (result: RelatedPost) => void,
   ): number;
   focusTimelinePost(postId: string): void;
-  bind(handlers: PostsViewHandlers): void;
+  bind(handlers: PostsViewHandlers): () => void;
 }
 
 const RELATED_PANEL_COPY: Record<RelatedPanelMode, RelatedPanelCopy> = {
@@ -51,27 +53,31 @@ const RELATED_PANEL_COPY: Record<RelatedPanelMode, RelatedPanelCopy> = {
   },
 };
 
-export function createPostsView(document: Document, window: Window): PostsView {
-  const form = document.getElementById('post-form') as HTMLFormElement;
-  const draft = document.getElementById('post-input') as HTMLTextAreaElement;
-  const askButton = document.getElementById('post-ask') as HTMLButtonElement;
-  const submitButton = document.getElementById('post-submit') as HTMLButtonElement;
-  const statusEl = document.getElementById('post-status') as HTMLParagraphElement;
-  const countEl = document.getElementById('post-count') as HTMLSpanElement;
-  const listEl = document.getElementById('post-list') as HTMLUListElement;
-  const emptyEl = document.getElementById('empty-state') as HTMLDivElement;
-  const relatedPanelEl = document.getElementById('related-panel') as HTMLElement;
-  const relatedKickerEl = document.getElementById('related-kicker') as HTMLParagraphElement;
-  const relatedTitleEl = document.getElementById('related-title') as HTMLHeadingElement;
-  const relatedCountEl = document.getElementById('related-count') as HTMLSpanElement;
-  const relatedEmptyEl = document.getElementById('related-empty') as HTMLParagraphElement;
-  const relatedListEl = document.getElementById('related-list') as HTMLUListElement;
+export function createPostsView(root: Document | HTMLElement, window: Window): PostsView {
+  const document = root instanceof Document ? root : root.ownerDocument;
+  const form = root.querySelector<HTMLFormElement>('#post-form')!;
+  const draft = root.querySelector<HTMLTextAreaElement>('#post-input')!;
+  const askButton = root.querySelector<HTMLButtonElement>('#post-ask')!;
+  const submitButton = root.querySelector<HTMLButtonElement>('#post-submit')!;
+  const statusEl = root.querySelector<HTMLParagraphElement>('#post-status')!;
+  const countEl = root.querySelector<HTMLSpanElement>('#post-count')!;
+  const listEl = root.querySelector<HTMLUListElement>('#post-list')!;
+  const emptyEl = root.querySelector<HTMLDivElement>('#empty-state')!;
+  const relatedPanelEl = root.querySelector<HTMLElement>('#related-panel')!;
+  const relatedKickerEl = root.querySelector<HTMLParagraphElement>('#related-kicker')!;
+  const relatedTitleEl = root.querySelector<HTMLHeadingElement>('#related-title')!;
+  const relatedCountEl = root.querySelector<HTMLSpanElement>('#related-count')!;
+  const relatedEmptyEl = root.querySelector<HTMLParagraphElement>('#related-empty')!;
+  const relatedListEl = root.querySelector<HTMLUListElement>('#related-list')!;
   const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
   });
+  let focusFrame: number | null = null;
+  let renderedRelatedPosts: readonly RelatedPost[] = [];
+  let openRenderedRelatedPost: ((result: RelatedPost) => void) | null = null;
 
   function formatTimestamp(value: string): string {
     return dateTimeFormat.format(new Date(value));
@@ -83,6 +89,7 @@ export function createPostsView(document: Document, window: Window): PostsView {
     item.dataset.postId = post.id;
     item.tabIndex = -1;
     item.dataset.highlighted = post.id === highlightedPostId ? 'true' : 'false';
+    item.dataset.routeFocus = `timeline:${post.id}`;
 
     const article = document.createElement('article');
     const time = document.createElement('time');
@@ -107,7 +114,6 @@ export function createPostsView(document: Document, window: Window): PostsView {
   function renderRelatedPost(
     result: RelatedPost,
     mode: RelatedPanelMode,
-    openRelatedPost: (result: RelatedPost) => void,
   ): HTMLLIElement {
     const copy = RELATED_PANEL_COPY[mode];
     const item = document.createElement('li');
@@ -128,9 +134,9 @@ export function createPostsView(document: Document, window: Window): PostsView {
     const openButton = document.createElement('button');
     openButton.type = 'button';
     openButton.className = 'related-open';
+    openButton.dataset.postId = result.post.id;
     openButton.textContent = copy.openButtonText;
     openButton.setAttribute('aria-label', `${copy.openLabelPrefix}: ${result.post.text.slice(0, 80)}`);
-    openButton.addEventListener('click', () => openRelatedPost(result));
 
     meta.append(time, reasons);
     article.append(meta, text, openButton);
@@ -140,8 +146,19 @@ export function createPostsView(document: Document, window: Window): PostsView {
 
   return {
     draftText: () => draft.value,
+    setDraftText: (text) => { draft.value = text; },
     clearDraft: () => { draft.value = ''; },
     focusDraft: () => draft.focus(),
+    restoreFocus(token): boolean {
+      const target = token === 'draft'
+        ? draft
+        : Array.from(listEl.querySelectorAll<HTMLLIElement>('.post-item')).find(
+          candidate => candidate.dataset.routeFocus === token,
+        );
+      if (target === undefined) return false;
+      target.focus({ preventScroll: true });
+      return document.activeElement === target;
+    },
     syncSubmitState(): void {
       const isEmpty = draft.value.trim().length === 0;
       askButton.disabled = isEmpty;
@@ -158,6 +175,8 @@ export function createPostsView(document: Document, window: Window): PostsView {
       emptyEl.hidden = posts.length !== 0;
     },
     renderRelated(relatedPosts, mode, openRelatedPost): number {
+      renderedRelatedPosts = relatedPosts;
+      openRenderedRelatedPost = openRelatedPost;
       const copy = RELATED_PANEL_COPY[mode];
       const isAskMode = mode === 'ask';
       const hasResults = relatedPosts.length > 0;
@@ -165,14 +184,16 @@ export function createPostsView(document: Document, window: Window): PostsView {
       relatedTitleEl.textContent = copy.title;
       relatedCountEl.textContent = copy.formatCount(relatedPosts.length);
       relatedListEl.replaceChildren(
-        ...relatedPosts.map(result => renderRelatedPost(result, mode, openRelatedPost)),
+        ...relatedPosts.map(result => renderRelatedPost(result, mode)),
       );
       relatedEmptyEl.hidden = !(isAskMode && !hasResults);
       relatedPanelEl.hidden = !isAskMode && !hasResults;
       return relatedPosts.length;
     },
     focusTimelinePost(postId): void {
-      window.requestAnimationFrame(() => {
+      if (focusFrame !== null) window.cancelAnimationFrame(focusFrame);
+      focusFrame = window.requestAnimationFrame(() => {
+        focusFrame = null;
         const item = Array.from(listEl.querySelectorAll<HTMLLIElement>('.post-item')).find(
           candidate => candidate.dataset.postId === postId,
         );
@@ -180,19 +201,55 @@ export function createPostsView(document: Document, window: Window): PostsView {
         item?.scrollIntoView({ block: 'center', behavior: 'smooth' });
       });
     },
-    bind({ submitDraft, askDraft, updateDraft }): void {
-      form.addEventListener('submit', event => {
+    bind({ submitDraft, askDraft, updateDraft }): () => void {
+      const handleSubmit = (event: SubmitEvent) => {
         event.preventDefault();
         submitDraft();
-      });
-      draft.addEventListener('keydown', event => {
+      };
+      const handleDraftKeydown = (event: KeyboardEvent) => {
         if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
           event.preventDefault();
           submitDraft();
         }
-      });
-      askButton.addEventListener('click', askDraft);
-      draft.addEventListener('input', updateDraft);
+      };
+      const handleAsk = () => askDraft();
+      const handleDraftInput = () => updateDraft();
+      const handleRelatedOpen = (event: MouseEvent) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+        const button = target.closest<HTMLButtonElement>('.related-open');
+        const postId = button?.dataset.postId;
+        if (postId === undefined) return;
+        const result = renderedRelatedPosts.find(candidate => candidate.post.id === postId);
+        if (result !== undefined) openRenderedRelatedPost?.(result);
+      };
+
+      form.addEventListener('submit', handleSubmit);
+      draft.addEventListener('keydown', handleDraftKeydown);
+      askButton.addEventListener('click', handleAsk);
+      draft.addEventListener('input', handleDraftInput);
+      relatedListEl.addEventListener('click', handleRelatedOpen);
+      form.inert = false;
+      form.dataset.postsReady = 'true';
+
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        form.inert = true;
+        form.dataset.postsReady = 'false';
+        if (focusFrame !== null) {
+          window.cancelAnimationFrame(focusFrame);
+          focusFrame = null;
+        }
+        form.removeEventListener('submit', handleSubmit);
+        draft.removeEventListener('keydown', handleDraftKeydown);
+        askButton.removeEventListener('click', handleAsk);
+        draft.removeEventListener('input', handleDraftInput);
+        relatedListEl.removeEventListener('click', handleRelatedOpen);
+        renderedRelatedPosts = [];
+        openRenderedRelatedPost = null;
+      };
     },
   };
 }

--- a/examples/web/src/features/posts/route/posts-client.tsx
+++ b/examples/web/src/features/posts/route/posts-client.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
+import { mountPosts } from '../browser/mount';
+
+export function PostsClient({ children }: { readonly children: ReactNode }) {
+  return (
+    <ImperativeDemoHost
+      demoId="posts"
+      mount={mountPosts}
+      className="posts-surface"
+    >
+      {children}
+    </ImperativeDemoHost>
+  );
+}

--- a/examples/web/src/features/posts/route/posts-route.tsx
+++ b/examples/web/src/features/posts/route/posts-route.tsx
@@ -1,0 +1,18 @@
+import postsDocument from '../../../../posts.html?raw';
+import { PostsClient } from './posts-client';
+
+const shellMatch = postsDocument.match(
+  /<body[^>]*>([\s\S]*?)\s*<script type="module" src="\/src\/entries\/posts\.ts"><\/script>\s*<\/body>/,
+);
+if (shellMatch === null) {
+  throw new Error('The canonical Posts document shell is unavailable');
+}
+const postsShellMarkup = shellMatch[1];
+
+export function PostsRoute() {
+  return (
+    <PostsClient>
+      <div dangerouslySetInnerHTML={{ __html: postsShellMarkup }} />
+    </PostsClient>
+  );
+}

--- a/examples/web/src/pages/posts.tsx
+++ b/examples/web/src/pages/posts.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { PostsRoute } from '../features/posts/route/posts-route';
 
 export default function Posts() {
-  return <DemoPlaceholder demoId="posts" />;
+  return <PostsRoute />;
 }

--- a/examples/web/tests/post-app.spec.ts
+++ b/examples/web/tests/post-app.spec.ts
@@ -1,11 +1,22 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const POST_STORAGE_KEY = 'canopy.posts.v1';
 const POST_EVENT_STORAGE_KEY = 'canopy.post-events.v1';
+const postsUrl = process.env.POSTS_URL ?? '/posts.html';
+
+async function waitForPostsReady(page: Page): Promise<void> {
+  await expect(page.getByRole('heading', { name: 'Post to yourself.' })).toBeVisible();
+  await expect(page.locator('#post-form'))
+    .toHaveAttribute('data-posts-ready', 'true');
+  if (postsUrl === '/posts') {
+    await expect(page.locator('[data-route-lifecycle-ready]'))
+      .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  }
+}
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/posts.html');
-  await expect(page.getByRole('heading', { name: 'Post to yourself.' })).toBeVisible();
+  await page.goto(postsUrl);
+  await waitForPostsReady(page);
 });
 
 test.describe('local-first post app', () => {
@@ -30,6 +41,7 @@ test.describe('local-first post app', () => {
     );
 
     await page.reload();
+    await waitForPostsReady(page);
 
     await expect(page.locator('.post-item p')).toHaveText([
       'Remember the product wedge: post exists before retrieval.',
@@ -102,6 +114,7 @@ test.describe('local-first post app', () => {
       },
     );
     await page.reload();
+    await waitForPostsReady(page);
 
     const input = page.getByLabel('Write');
     const relatedPanel = page.locator('#related-panel');
@@ -153,6 +166,7 @@ test.describe('local-first post app', () => {
       },
     );
     await page.reload();
+    await waitForPostsReady(page);
 
     const input = page.getByLabel('Write');
 
@@ -203,6 +217,7 @@ test.describe('local-first post app', () => {
       },
     );
     await page.reload();
+    await waitForPostsReady(page);
 
     const input = page.getByLabel('Write');
     const relatedTexts = page.locator('.related-text');
@@ -217,7 +232,9 @@ test.describe('local-first post app', () => {
       .getByRole('button', { name: /Open related post/ })
       .click();
 
-    await expect(page.locator('.post-item[data-highlighted="true"] p')).toHaveText(olderText);
+    const openedPost = page.locator('.post-item[data-highlighted="true"]');
+    await expect(openedPost.locator('p')).toHaveText(olderText);
+    await expect(openedPost).toBeFocused();
     await expect(relatedTexts).toHaveText([olderText, newerText]);
     await expect(page.locator('.related-item').first().locator('.related-reason')).toContainText([
       'Echoes sync · recovery · policy',

--- a/examples/web/waku-tests/posts-route.spec.ts
+++ b/examples/web/waku-tests/posts-route.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const POST_STORAGE_KEY = 'canopy.posts.v1';
+const POST_EVENT_STORAGE_KEY = 'canopy.post-events.v1';
+
+const storedPosts = [
+  {
+    id: 'post-sync-recovery',
+    text: 'For sync recovery we decided to retry locally before merging remote commits.',
+    createdAt: '2026-06-10T09:00:00.000Z',
+  },
+  {
+    id: 'post-basil-window',
+    text: 'Basil seedlings recovered on the kitchen window shelf after I stopped overwatering.',
+    createdAt: '2026-06-09T09:00:00.000Z',
+  },
+] as const;
+
+async function seedPosts(page: Page) {
+  await page.evaluate(
+    ({ key, posts }) => window.localStorage.setItem(key, JSON.stringify(posts)),
+    { key: POST_STORAGE_KEY, posts: storedPosts },
+  );
+}
+
+async function waitForPostsMount(page: Page) {
+  await expect(page.locator('#post-form'))
+    .toHaveAttribute('data-posts-ready', 'true');
+}
+
+test('keeps the server-rendered Posts form inert without client JavaScript', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    const response = await page.goto('/posts');
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('#post-form')).toHaveAttribute('inert', '');
+    await expect(page.locator('#post-form'))
+      .toHaveAttribute('data-posts-ready', 'false');
+  } finally {
+    await context.close();
+  }
+});
+
+test('restores the Posts draft, Ask mode, highlighted post, and focus after traversal', async ({ page }) => {
+  await page.goto('/');
+  await seedPosts(page);
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: 'Posts' }).click();
+  await waitForPostsMount(page);
+  await expect(page).toHaveURL(/\/posts$/);
+  await expect(page.getByRole('heading', { name: 'Post to yourself.' })).toBeFocused();
+
+  const question = 'what did I decide about sync recovery?';
+  await page.getByLabel('Write').fill(question);
+  await page.getByRole('button', { name: 'Ask' }).click();
+  await page.getByRole('button', { name: /Open source post/ }).click();
+  const openedPost = page.locator('.post-item[data-highlighted="true"]');
+  await expect(openedPost).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForPostsMount(page);
+  await expect(page).toHaveURL(/\/posts$/);
+
+  await expect(page.getByLabel('Write')).toHaveValue(question);
+  await expect(page.locator('#related-kicker')).toHaveText('Asked from your posts');
+  await expect(page.locator('#related-title')).toHaveText('Source posts');
+  await expect(openedPost).toBeFocused();
+});
+
+test('reload keeps only the existing Posts stores and clears route-memory state', async ({ page }) => {
+  await page.goto('/');
+  await seedPosts(page);
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: 'Posts' }).click();
+  await waitForPostsMount(page);
+
+  await page.getByLabel('Write').fill('A durable post written before a route-only draft.');
+  await page.getByRole('button', { name: 'Post' }).click();
+  await page.getByLabel('Write').fill('route-only draft');
+  await page.reload();
+  await waitForPostsMount(page);
+
+  await expect(page.getByLabel('Write')).toHaveValue('');
+  await expect(page.locator('.post-item p')).toHaveText([
+    'A durable post written before a route-only draft.',
+    ...storedPosts.map(({ text }) => text),
+  ]);
+  await expect(page.locator('#related-panel')).toBeHidden();
+  await expect(page.locator('.post-item[data-highlighted="true"]')).toHaveCount(0);
+
+  const storage = await page.evaluate(
+    ({ postKey, eventKey }) => ({
+      posts: JSON.parse(window.localStorage.getItem(postKey) ?? '[]') as unknown[],
+      events: JSON.parse(window.localStorage.getItem(eventKey) ?? '[]') as unknown[],
+      keys: Object.keys(window.localStorage).sort(),
+    }),
+    { postKey: POST_STORAGE_KEY, eventKey: POST_EVENT_STORAGE_KEY },
+  );
+  expect(storage.posts).toHaveLength(3);
+  expect(storage.events).toEqual([
+    expect.objectContaining({ type: 'post_created' }),
+  ]);
+  expect(storage.keys).toEqual([POST_EVENT_STORAGE_KEY, POST_STORAGE_KEY].sort());
+});
+
+test('repeated Posts route cycles release listeners and pending focus work', async ({ page }) => {
+  await page.addInitScript(() => {
+    const listenerRecords: Array<{
+      target: EventTarget;
+      type: string;
+      listener: EventListenerOrEventListenerObject;
+    }> = [];
+    const originalAdd = EventTarget.prototype.addEventListener;
+    const originalRemove = EventTarget.prototype.removeEventListener;
+    const isPostsTarget = (target: EventTarget) =>
+      target instanceof Element &&
+      target.closest('[data-imperative-demo-host="posts"]') !== null;
+
+    EventTarget.prototype.addEventListener = function (type, listener, options) {
+      if (listener !== null && isPostsTarget(this)) {
+        listenerRecords.push({ target: this, type, listener });
+      }
+      originalAdd.call(this, type, listener, options);
+    };
+    EventTarget.prototype.removeEventListener = function (type, listener, options) {
+      const index = listener === null ? -1 : listenerRecords.findIndex(
+        (record) => record.target === this && record.type === type && record.listener === listener,
+      );
+      if (index >= 0) listenerRecords.splice(index, 1);
+      originalRemove.call(this, type, listener, options);
+    };
+    Object.defineProperty(window, '__postsResources', {
+      value: { listenerCount: () => listenerRecords.length },
+    });
+  });
+
+  await page.goto('/');
+  await seedPosts(page);
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  const mountedListenerCounts: number[] = [];
+
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    await page.getByRole('link', { name: 'Posts' }).click();
+    await waitForPostsMount(page);
+    await expect(page.getByLabel('Write')).toBeVisible();
+    mountedListenerCounts.push(await page.evaluate(
+      () => (window as unknown as {
+        __postsResources: { listenerCount(): number };
+      }).__postsResources.listenerCount(),
+    ));
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    expect(await page.evaluate(
+      () => (window as unknown as {
+        __postsResources: { listenerCount(): number };
+      }).__postsResources.listenerCount(),
+    )).toBe(0);
+  }
+
+  expect(mountedListenerCounts[0]).toBeGreaterThan(0);
+  expect(mountedListenerCounts[1]).toBe(mountedListenerCounts[0]);
+
+  await page.getByRole('link', { name: 'Posts' }).click();
+  await waitForPostsMount(page);
+  await page.getByLabel('Write').fill('sync recovery');
+  await page.evaluate(() => {
+    const frameId = 2_147_483_000;
+    const originalRequest = window.requestAnimationFrame;
+    const originalCancel = window.cancelAnimationFrame;
+    let intercepted = false;
+    (window as Window & { __postsFocusFrameCancelled?: boolean }).__postsFocusFrameCancelled = false;
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      if (intercepted) return originalRequest(callback);
+      intercepted = true;
+      window.requestAnimationFrame = originalRequest;
+      return frameId;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = ((requestedId: number) => {
+      if (requestedId === frameId) {
+        (window as Window & { __postsFocusFrameCancelled?: boolean })
+          .__postsFocusFrameCancelled = true;
+        return;
+      }
+      originalCancel(requestedId);
+    }) as typeof window.cancelAnimationFrame;
+    document.querySelector<HTMLButtonElement>('.related-open')?.click();
+    window.history.back();
+  });
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.evaluate(
+    () => (window as Window & { __postsFocusFrameCancelled?: boolean })
+      .__postsFocusFrameCancelled,
+  )).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Expose the existing local-first Posts app at canonical Waku `/posts` through the shared imperative route host while retaining `/posts.html`.
- Preserve `canopy.posts.v1` and `canopy.post-events.v1`; keep only draft, related mode, and highlighted post ID in same-document route memory.
- Scope DOM ownership and CSS to the mounted host, restore related-item focus, dispose listeners/pending focus work, and keep the SSR form inert until hydration completes.
- Run the existing Posts contract against both Vite and Waku, with added traversal, reload-boundary, disposal, and no-JavaScript SSR coverage.

Closes #973

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ImperativeDemoHost` / `MountedImperativeSession` | `examples/web/src/shared/route-lifecycle/browser/` | Yes | Owns Waku route snapshots, focus restoration, and idempotent disposal. |
| `createPostsApp`, `LocalPostStore`, `LocalPostEventStore`, `createPostsView` | `examples/web/src/features/posts/browser/` | Yes | Keeps the existing browser persistence shell and storage formats unchanged. |
| `PostRetrievalIndex` and Posts core types | `examples/web/src/features/posts/core/` | Yes | Keeps deterministic retrieval, ordering, and Ask behavior unchanged. |
| `useRouteSnapshot` | `examples/web/src/shared/route-lifecycle/browser/provider.tsx` | No | It is the native React-state seam; Posts remains an imperative surface behind `ImperativeDemoHost`. |
| MoonBit `Map`/`Set`/`String`/`Option`/`Result` and collection APIs | MoonBit core | N/A | This slice changes no MoonBit source or data transformation; the existing TypeScript Posts core is reused unchanged. |

New helpers added:

- `readPostsSnapshot` validates the deliberately narrow `unknown` route-memory boundary; it does not persist or duplicate posts/events.
- `waitForPostsReady`, `waitForPostsMount`, and `seedPosts` are test-only synchronization/fixture helpers for the hydration boundary.

Remaining imperative code is limited to the existing browser shell: DOM listener wiring, localStorage adapters, and scheduled focus. The deterministic Posts retrieval core remains unchanged.

## Test plan

- [x] `moon check` passes (only the existing vendored Rabbita deprecation warnings)
- [x] `moon test` passes: 3,932 wasm-gc + 1,949 JS + 70 native
- [x] `git diff -- '*.mbti'` reviewed: no changes
- [x] JS rebuilt with both `npm run build:vite` and `npm run build:waku`
- [x] Existing Posts suite passes at `/posts.html` and `/posts`

## Validation

```text
npm run typecheck
npm run check:boundaries
npm run test:boundaries                 # 18 passed
npm run test:foundation                 # 28 passed
npm run build:vite
npm run build:waku
npm run check:waku-bundles
npm run check:waku-types
npm run test:waku:e2e                   # 31 passed
npm run test:waku:workerd               # smoke OK
npx playwright test                     # 103 passed, 2 expected provider-only skips
npx playwright test tests/post-app.spec.ts  # 6 passed
moon check
moon test
```

Manual browser validation covered desktop and 390px mobile `/posts`; the related panel remained usable with no horizontal overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Posts experience at `/posts` with routed rendering.
  - Preserved draft content, related-post mode, and highlighted-post state during navigation.
  - Added focus restoration for drafts and timeline posts.
  - Added responsive, scoped styling for the Posts interface.

- **Bug Fixes**
  - Improved readiness and inert-state handling before client initialization.
  - Ensured navigation and reload behavior correctly preserve or reset state.

- **Documentation**
  - Updated migration plans and route documentation to include the Posts experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->