### PR TITLE
feat(web): migrate JSON editor to /json

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -662,7 +662,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
   Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#973 migrate Journey and Posts to `/journey` and `/posts`. Vite remains the default, and no redirect or production deployment has migrated.
+  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#974 migrate Journey, Posts, and JSON to `/journey`, `/posts`, and `/json`. Vite remains the default, and no redirect or production deployment has migrated.
   Exit: the plan's Stage 12 gate passes after production cutover is proven.
 
 ## 22. SDEG Lifecycle

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -47,9 +47,9 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 Most of the source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. Resume/PKE, Posts, Memo, JSON, Markdown, GenUI, and GenUI Possibilities use the target entry/feature layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku migration (pre-production, #970–#973 Stages 0–4)
+## Waku migration (pre-production, #970–#974 Stages 0–5)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–4 migrate Journey and Posts while retaining every old HTML entry.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–5 migrate Journey, Posts, and JSON while retaining every old HTML entry.
 
 ### Stage 0–1 configuration and artifacts
 
@@ -65,9 +65,10 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 
 - `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
 - `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
-- `src/pages/{ml,json,markdown,memo,resume,genui}.tsx` — six canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/{ml,markdown,memo,resume,genui}.tsx` — five canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
 - `src/pages/journey.tsx` — canonical Journey route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/posts.tsx` — canonical Posts route; composes the feature-owned route surface through the shared imperative host.
+- `src/pages/json.tsx` — canonical JSON route; composes the feature-owned editor controller through the shared imperative host.
 - `src/pages/_layout.tsx` — pass-through shared route layout; the provider stays at `_root.tsx` so its in-memory registry survives route render failures.
 - `src/shared/catalog/demo-catalog.ts` — framework-independent catalog data (eight demos, three groups, canonical `DemoPath` routes).
 - `src/shared/shell/` — `DemoHub` and `DemoPlaceholder` React components and shared shell styles.
@@ -94,6 +95,15 @@ Stage 3 remains pre-production. Vite and `genui-possibilities.html` remain the d
 
 Stage 4 remains pre-production. Vite and `posts.html` remain the defaults and are retained. No Posts compatibility redirect is active, and the existing `canopy.posts.v1` and `canopy.post-events.v1` schemas remain unchanged.
 
+### Stage 5 — JSON editor
+
+- `src/features/json/route/{json-route,json-client}.tsx` — server/client route seam that reuses the legacy JSON markup, loads the generated MoonBit runtime only in the client bundle, and mounts through the shared imperative host.
+- `src/features/json/browser/{editor,mount}.ts` — root-scoped controller shared by Waku and Vite; snapshots source text only and owns the MoonBit handle, adapter, overlay, frames, listeners, focus, and global test hook until idempotent disposal.
+- `tests/json-editor.spec.ts` — existing JSON behavior contract, now run against both legacy Vite `/json.html` and Waku `/json`.
+- `waku-tests/json-route.spec.ts` — no-JavaScript inertness, route-memory/reload boundaries, reconstructed mode/collapse/edit-log state, focus restoration, and repeated resource-disposal coverage.
+
+Stage 5 remains pre-production. Vite and `json.html` remain the defaults and are retained. No JSON compatibility redirect is active, and no MoonBit editor API or workflow changed.
+
 Validation runs in parallel with the Vite pipeline:
 
 - `npm run build:waku` — Waku production build from prebuilt MoonBit artifacts.
@@ -104,7 +114,7 @@ Validation runs in parallel with the Vite pipeline:
 - `npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env preview` — preview Waku Worker bundle dry-run.
 - CI jobs `waku-build`, `waku-e2e`, and `waku-workerd` run alongside the existing Vite jobs until Stage 12 (Vite retirement).
 
-Both development modes reuse the same coordinator, which starts one root MoonBit watcher rather than one watcher per virtual module. `npm run dev:dual` runs Vite and Waku side by side behind that single watcher. The five generated modules are loaded only by the client probe on the Waku side.
+Both development modes reuse the same coordinator, which starts one root MoonBit watcher rather than one watcher per virtual module. `npm run dev:dual` runs Vite and Waku side by side behind that single watcher. Generated modules stay client-only on the Waku side; the probe loads all five and the migrated JSON route loads its JSON runtime on demand.
 
 ## Boundary vocabulary and allowed direction
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,9 +5,9 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Waku migration (in progress, #973)
+## Waku migration (in progress, #974)
 
-A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stage 3 migrates Journey Proposals to `/journey`; Stage 4 migrates Posts to `/posts` while preserving its two local-storage contracts and route-local draft state. Both use the imperative host and retain their legacy HTML entries; the other six canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–5 migrate Journey Proposals, Posts, and the JSON editor to `/journey`, `/posts`, and `/json`. JSON snapshots source text only and rebuilds its live MoonBit controller state after navigation. All three use the imperative host and retain their legacy HTML entries; the other five canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
 
 ## Development
 

--- a/examples/web/json.html
+++ b/examples/web/json.html
@@ -6,11 +6,12 @@
   <title>{} JSON CRDT Editor</title>
 
 </head>
-<body>
+<body class="json-surface">
   <div class="container">
-    <h1>{} JSON CRDT Editor</h1>
+    <h1 data-route-heading tabindex="-1">{} JSON CRDT Editor</h1>
     <p class="subtitle">Structural JSON editing with CRDT collaboration</p>
 
+    <div class="json-app" inert data-json-ready="false">
     <div class="examples-bar">
       <span class="examples-label">Examples:</span>
       <button class="example-btn" data-example='{"hello": "world"}'>Simple</button>
@@ -24,12 +25,12 @@
         <div class="panel-header" style="display:flex;align-items:center;gap:10px">
           <h2>JSON Text</h2>
           <button id="format-btn" class="toolbar-btn" type="button">Format</button>
-          <button id="struct-toggle-btn" class="toolbar-btn" type="button" style="margin-left:auto">▦ Structured</button>
+          <button id="struct-toggle-btn" class="toolbar-btn" type="button" style="margin-left:auto" data-route-focus="structure-toggle">▦ Structured</button>
         </div>
         <div class="editor-shell">
           <div class="editor-wrapper">
             <div id="json-gutter" class="editor-gutter"></div>
-            <div id="json-input" contenteditable="plaintext-only" spellcheck="false" class="json-editor-raw"></div>
+            <div id="json-input" contenteditable="plaintext-only" spellcheck="false" class="json-editor-raw" data-route-focus="editor"></div>
             <div id="json-editor-view" class="json-editor-view" style="display:none"></div>
           </div>
 
@@ -49,6 +50,8 @@
         </section>
       </section>
         <div id="tree-view" style="display:none"></div>
+
+    </div>
 
     </div>
 

--- a/examples/web/json.html
+++ b/examples/web/json.html
@@ -7,6 +7,7 @@
 
 </head>
 <body class="json-surface">
+  <!-- json-shell:start -->
   <div class="container">
     <h1 data-route-heading tabindex="-1">{} JSON CRDT Editor</h1>
     <p class="subtitle">Structural JSON editing with CRDT collaboration</p>
@@ -56,6 +57,7 @@
     </div>
 
   </div>
+  <!-- json-shell:end -->
 
   <script type="module" src="/src/entries/json.ts"></script>
 </body>

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -7,12 +7,14 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 
 process.env.GENUI_POSSIBILITIES_URL = '/journey';
 process.env.POSTS_URL = '/posts';
+process.env.JSON_EDITOR_URL = '/json';
 
 export default defineConfig({
   testDir: '.',
   testMatch: [
     'waku-tests/**/*.spec.ts',
     'tests/genui-possibilities.spec.ts',
+    'tests/json-editor.spec.ts',
     'tests/post-app.spec.ts',
   ],
   timeout: 30_000,

--- a/examples/web/src/features/json/browser/editor.ts
+++ b/examples/web/src/features/json/browser/editor.ts
@@ -73,12 +73,21 @@ function dispose() {
     Reflect.deleteProperty(window, 'getJsonRoleSpans');
   }
   ownedRoleHook = null;
-  releaseOverlay?.();
+  const releases = [
+    ['decoration overlay', releaseOverlay],
+    ['HTML adapter', releaseAdapter],
+    ['MoonBit handle', releaseHandle],
+  ] as const;
   releaseOverlay = null;
-  releaseAdapter?.();
   releaseAdapter = null;
-  releaseHandle?.();
   releaseHandle = null;
+  releases.forEach(([resource, release]) => {
+    try {
+      release?.();
+    } catch (error) {
+      console.error(`Failed to dispose JSON editor ${resource}`, error);
+    }
+  });
 }
 
 function must<T extends HTMLElement>(id: string): T {

--- a/examples/web/src/features/json/browser/editor.ts
+++ b/examples/web/src/features/json/browser/editor.ts
@@ -1,9 +1,9 @@
 'use client';
-import * as crdt from '@moonbit/crdt-json';
 import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
 import { DecorationOverlay } from '../../../shared/decoration-overlay';
 import type { Decoration } from '@canopy/editor-adapter/types';
 import type { ViewPatch, ViewNode } from '@canopy/editor-adapter/types';
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
 
 interface JsonRoleSpanData { start: number; end: number; role: string }
 
@@ -11,18 +11,25 @@ declare global {
   interface Window { getJsonRoleSpans: () => JsonRoleSpanData[]; }
 }
 
-export function mountJsonEditor(): void {
+export type JsonEditorRuntime = typeof import('@moonbit/crdt-json');
+
+export function mountJsonEditor(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot: unknown,
+  crdt: JsonEditorRuntime,
+): MountedImperativeSession {
 const EXAMPLE_FALLBACK = '{"hello": "world"}';
 
-const agentId = `json-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-const handle = crdt.create_json_editor(agentId);
+const document = root instanceof Document ? root : root.ownerDocument;
+const window = document.defaultView ?? globalThis.window;
 
 const editorEl = must<HTMLDivElement>('json-input');
+const errorsPanelEl = must<HTMLDivElement>('errors-panel');
 const errorsEl = must<HTMLUListElement>('parse-errors');
 const treeEl = must<HTMLDivElement>('tree-view');
 const formatBtn = must<HTMLButtonElement>('format-btn');
-const viewEl = document.getElementById('json-editor-view')!;
-const gutterEl = document.getElementById('json-gutter');
+const viewEl = must<HTMLDivElement>('json-editor-view');
+const gutterEl = must<HTMLDivElement>('json-gutter');
 
 const patchLogEl = must<HTMLDivElement>('patch-log-body');
 const patchLogHeaderEl = must<HTMLDivElement>('patch-log-header');
@@ -30,19 +37,69 @@ const patchLogToggleEl = must<HTMLSpanElement>('patch-log-toggle');
 const patchLogCountEl = must<HTMLSpanElement>('patch-log-count');
 const patchLogEmptyEl = must<HTMLDivElement>('patch-log-empty');
 const structToggleBtn = must<HTMLButtonElement>('struct-toggle-btn');
+const surfaceCandidate = root.querySelector<HTMLElement>('[data-json-ready]');
+if (surfaceCandidate === null) throw new Error('Missing JSON editor surface');
+const surfaceEl: HTMLElement = surfaceCandidate;
+const exampleButtons = Array.from(root.querySelectorAll<HTMLButtonElement>('.example-btn'));
+const listenerAbort = new window.AbortController();
+let disposed = false;
+let syncFrame: number | null = null;
+let gutterScrollFrame: number | null = null;
+let ownedRoleHook: (() => JsonRoleSpanData[]) | null = null;
+let releaseHandle: (() => void) | null = null;
+let releaseAdapter: (() => void) | null = null;
+let releaseOverlay: (() => void) | null = null;
 
-// Protocol-based tree adapter
-const adapter = new HTMLAdapter(treeEl, errorsEl, true);
-const decorationOverlay = new DecorationOverlay(editorEl);
-
-const collapsedNodes = new Set<number>();
-let structMode = false;
+function dispose() {
+  if (disposed) return;
+  disposed = true;
+  surfaceEl.inert = true;
+  surfaceEl.dataset.jsonReady = 'false';
+  listenerAbort.abort();
+  if (syncFrame !== null) {
+    window.cancelAnimationFrame(syncFrame);
+    syncFrame = null;
+  }
+  if (gutterScrollFrame !== null) {
+    window.cancelAnimationFrame(gutterScrollFrame);
+    gutterScrollFrame = null;
+  }
+  gutterEl.replaceChildren();
+  viewEl.replaceChildren();
+  if (
+    ownedRoleHook !== null &&
+    window.getJsonRoleSpans === ownedRoleHook
+  ) {
+    Reflect.deleteProperty(window, 'getJsonRoleSpans');
+  }
+  ownedRoleHook = null;
+  releaseOverlay?.();
+  releaseOverlay = null;
+  releaseAdapter?.();
+  releaseAdapter = null;
+  releaseHandle?.();
+  releaseHandle = null;
+}
 
 function must<T extends HTMLElement>(id: string): T {
-  const element = document.getElementById(id);
+  const element = root.querySelector<HTMLElement>(`#${id}`);
   if (!element) throw new Error(`Missing element #${id}`);
   return element as T;
 }
+
+try {
+const agentId = `json-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+const handle = crdt.create_json_editor(agentId);
+releaseHandle = () => crdt.destroy_json_editor(handle);
+
+// Protocol-based tree adapter
+const adapter = new HTMLAdapter(treeEl, errorsEl, true);
+releaseAdapter = () => adapter.destroy();
+const decorationOverlay = new DecorationOverlay(editorEl);
+releaseOverlay = () => decorationOverlay.dispose();
+
+const collapsedNodes = new Set<number>();
+let structMode = false;
 
 // ── Role spans ──────────────────────────────────────
 
@@ -57,11 +114,13 @@ const ROLE_TO_CSS_CLASS: Record<string, string> = {
 };
 
 function getJsonRoleSpans(): JsonRoleSpanData[] {
+  if (disposed) return [];
   const raw = crdt.json_get_role_spans_json(handle);
   try { return JSON.parse(raw) as JsonRoleSpanData[]; }
   catch { return []; }
 }
 
+ownedRoleHook = getJsonRoleSpans;
 window.getJsonRoleSpans = getJsonRoleSpans;
 
 function roleSpansToDecorations(spans: JsonRoleSpanData[]): Decoration[] {
@@ -134,7 +193,7 @@ function fetchEditLog(): void {
 // ── Gutter ───────────────────────────────────────────
 
 function findTextPosition(offset: number): { node: Text; offset: number } | null {
-  const walker = document.createTreeWalker(editorEl, NodeFilter.SHOW_TEXT);
+  const walker = document.createTreeWalker(editorEl, window.NodeFilter.SHOW_TEXT);
   let remaining = offset;
   let lastText: Text | null = null;
   for (let node = walker.nextNode() as Text | null; node; node = walker.nextNode() as Text | null) {
@@ -148,7 +207,6 @@ function findTextPosition(offset: number): { node: Text; offset: number } | null
 }
 
 function renderGutter() {
-  if (!gutterEl) return;
   gutterEl.replaceChildren();
   const root = adapter.getTree();
   if (!root) return;
@@ -179,7 +237,7 @@ function renderGutter() {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       applyEdit(w.action === 'add-member' ? { op: 'AddMember', object_id: w.nodeId, key: 'key' } : { op: 'AddElement', array_id: w.nodeId });
-    });
+    }, { signal: listenerAbort.signal });
     gutterEl.appendChild(btn);
   }
 }
@@ -216,8 +274,8 @@ function renderTreeNode(node: ViewNode, isRoot: boolean): HTMLElement {
       if (collapsedNodes.has(node.id)) { collapsedNodes.delete(node.id); toggle.textContent = '▼'; if (body) body.style.display = ''; }
       else { collapsedNodes.add(node.id); toggle.textContent = '▶'; if (body) body.style.display = 'none'; }
     };
-    toggle.addEventListener('click', (e) => { e.stopPropagation(); doToggle(); });
-    toggle.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); doToggle(); } });
+    toggle.addEventListener('click', (e) => { e.stopPropagation(); doToggle(); }, { signal: listenerAbort.signal });
+    toggle.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); doToggle(); } }, { signal: listenerAbort.signal });
     row.appendChild(toggle);
 
     const tag = document.createElement('span');
@@ -240,35 +298,35 @@ function renderTreeNode(node: ViewNode, isRoot: boolean): HTMLElement {
     addBtn.textContent = '+';
     addBtn.title = node.kind_tag === 'Array' ? 'Add element' : 'Add member';
     addBtn.dataset.action = node.kind_tag === 'Array' ? 'add-element' : 'add-member';
-    addBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit(node.kind_tag === 'Array' ? { op: 'AddElement', array_id: node.id } : { op: 'AddMember', object_id: node.id, key: 'key' }); });
+    addBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit(node.kind_tag === 'Array' ? { op: 'AddElement', array_id: node.id } : { op: 'AddMember', object_id: node.id, key: 'key' }); }, { signal: listenerAbort.signal });
     actions.appendChild(addBtn);
     const delBtn = document.createElement('button');
     delBtn.className = 'node-action-btn';
     delBtn.textContent = '×';
     delBtn.title = 'Delete';
     delBtn.dataset.action = 'delete';
-    delBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'Delete', node_id: node.id }); });
+    delBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'Delete', node_id: node.id }); }, { signal: listenerAbort.signal });
     actions.appendChild(delBtn);
     const wrapArrBtn = document.createElement('button');
     wrapArrBtn.className = 'node-action-btn';
     wrapArrBtn.textContent = '[]';
     wrapArrBtn.title = 'Wrap in array';
     wrapArrBtn.dataset.action = 'wrap-array';
-    wrapArrBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'WrapInArray', node_id: node.id }); });
+    wrapArrBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'WrapInArray', node_id: node.id }); }, { signal: listenerAbort.signal });
     actions.appendChild(wrapArrBtn);
     const wrapObjBtn = document.createElement('button');
     wrapObjBtn.className = 'node-action-btn';
     wrapObjBtn.textContent = '{}';
     wrapObjBtn.title = 'Wrap in object';
     wrapObjBtn.dataset.action = 'wrap-object';
-    wrapObjBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'WrapInObject', node_id: node.id, key: 'key' }); });
+    wrapObjBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'WrapInObject', node_id: node.id, key: 'key' }); }, { signal: listenerAbort.signal });
     actions.appendChild(wrapObjBtn);
     if (node.children.length > 0) {
       const unwrapBtn = document.createElement('button');
       unwrapBtn.className = 'node-action-btn';
       unwrapBtn.textContent = '⇔';
       unwrapBtn.title = 'Unwrap';
-      unwrapBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'Unwrap', node_id: node.id }); });
+      unwrapBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'Unwrap', node_id: node.id }); }, { signal: listenerAbort.signal });
       actions.appendChild(unwrapBtn);
     }
     row.appendChild(actions);
@@ -287,7 +345,7 @@ function renderTreeNode(node: ViewNode, isRoot: boolean): HTMLElement {
     tag.dataset.nodeId = String(node.id);
     tag.dataset.kind = node.kind_tag;
     tag.style.cursor = 'text';
-    tag.addEventListener('click', (e) => { e.stopPropagation(); startInlineEdit(tag, node); });
+    tag.addEventListener('click', (e) => { e.stopPropagation(); startInlineEdit(tag, node); }, { signal: listenerAbort.signal });
     row.appendChild(tag);
 
     // Type switch
@@ -298,7 +356,7 @@ function renderTreeNode(node: ViewNode, isRoot: boolean): HTMLElement {
       opt.value = t; opt.textContent = t; if (t === kind) opt.selected = true;
       select.appendChild(opt);
     }
-    select.addEventListener('change', () => applyEdit({ op: 'ChangeType', node_id: node.id, new_type: select.value }));
+    select.addEventListener('change', () => applyEdit({ op: 'ChangeType', node_id: node.id, new_type: select.value }), { signal: listenerAbort.signal });
     row.appendChild(select);
 
     const delBtn = document.createElement('button');
@@ -306,7 +364,7 @@ function renderTreeNode(node: ViewNode, isRoot: boolean): HTMLElement {
     delBtn.textContent = '×';
     delBtn.title = 'Delete';
     delBtn.dataset.action = 'delete';
-    delBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'Delete', node_id: node.id }); });
+    delBtn.addEventListener('click', (e) => { e.stopPropagation(); applyEdit({ op: 'Delete', node_id: node.id }); }, { signal: listenerAbort.signal });
     row.appendChild(delBtn);
     const idSpan = document.createElement('span');
     idSpan.className = 'node-id';
@@ -352,12 +410,12 @@ function renderTreeNode(node: ViewNode, isRoot: boolean): HTMLElement {
             }
             keyEl.textContent = '"' + keyName + '":';
           };
-          input.addEventListener('blur', () => finish(true));
+          input.addEventListener('blur', () => finish(true), { signal: listenerAbort.signal });
           input.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') { e.preventDefault(); finish(true); }
             else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
-          });
-        });
+          }, { signal: listenerAbort.signal });
+        }, { signal: listenerAbort.signal });
         const toggle = childRowEl.querySelector('.node-toggle');
         if (toggle) toggle.after(keyEl);
         else childRowEl.insertBefore(keyEl, childRowEl.firstChild);
@@ -394,11 +452,11 @@ function startInlineEdit(span: HTMLElement, node: ViewNode) {
     if (!display) { span.setAttribute('data-empty', 'true'); span.textContent = ''; }
     else { span.textContent = rawVal; }
   };
-  input.addEventListener('blur', () => finish(true));
+  input.addEventListener('blur', () => finish(true), { signal: listenerAbort.signal });
   input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') { e.preventDefault(); finish(true); }
     else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
-  });
+  }, { signal: listenerAbort.signal });
 }
 
 // ── Refresh ──────────────────────────────────────────
@@ -420,10 +478,7 @@ function refresh() {
   renderGutter();
   if (structMode) renderStructuredView();
   // Show errors panel only when there are actual errors
-  const errorsPanel = document.getElementById('errors-panel');
-  if (errorsPanel) {
-    errorsPanel.style.display = errorsEl.querySelector('.error-item') ? '' : 'none';
-  }
+  errorsPanelEl.style.display = errorsEl.querySelector('.error-item') ? '' : 'none';
 }
 
 // ── Edit & format ────────────────────────────────────
@@ -463,10 +518,9 @@ function syncTextFromModel() {
   if ((editorEl.textContent ?? '') !== text) editorEl.textContent = text;
 }
 
-let syncFrame: number | null = null;
-editorEl.addEventListener('input', () => {
+function handleEditorInput() {
   if (syncFrame !== null) return;
-  syncFrame = requestAnimationFrame(() => {
+  syncFrame = window.requestAnimationFrame(() => {
     syncFrame = null;
     if (!structMode) {
       const text = editorEl.textContent ?? '';
@@ -476,44 +530,46 @@ editorEl.addEventListener('input', () => {
       }
     }
   });
-});
+}
+editorEl.addEventListener('input', handleEditorInput, { signal: listenerAbort.signal });
 
 // ── Mode toggle ──────────────────────────────────────
 
-structToggleBtn.addEventListener('click', () => {
+function toggleStructureMode() {
   structMode = !structMode;
   structToggleBtn.textContent = structMode ? '📝 Raw' : '▦ Structured';
   structToggleBtn.classList.toggle('active', structMode);
   viewEl.style.display = structMode ? '' : 'none';
   editorEl.style.display = structMode ? 'none' : '';
-  if (gutterEl) gutterEl.style.display = structMode ? 'none' : '';
+  gutterEl.style.display = structMode ? 'none' : '';
   formatBtn.disabled = structMode;
   if (structMode) renderStructuredView();
   else { syncTextFromModel(); refresh(); }
-});
+}
+structToggleBtn.addEventListener('click', toggleStructureMode, { signal: listenerAbort.signal });
 
 // ── Event listeners ──────────────────────────────────
 
-let gutterScrollFrame: number | null = null;
-editorEl.addEventListener('scroll', () => {
+function handleEditorScroll() {
   if (gutterScrollFrame !== null) return;
-  gutterScrollFrame = requestAnimationFrame(() => {
+  gutterScrollFrame = window.requestAnimationFrame(() => {
     gutterScrollFrame = null;
     if (!structMode) renderGutter();
   });
-});
+}
+editorEl.addEventListener('scroll', handleEditorScroll, { signal: listenerAbort.signal });
 
-formatBtn.addEventListener('click', formatJson);
+formatBtn.addEventListener('click', formatJson, { signal: listenerAbort.signal });
 
-document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach((button) => {
+for (const button of exampleButtons) {
   button.addEventListener('click', () => {
     const example = button.dataset.example ?? EXAMPLE_FALLBACK;
     crdt.json_set_text(handle, example);
     editorEl.textContent = example;
     adapter.resetCollapseState();
     refresh();
-  });
-});
+  }, { signal: listenerAbort.signal });
+}
 
 // Patch log collapse toggle
 patchLogHeaderEl.setAttribute('role', 'button');
@@ -525,25 +581,67 @@ function togglePatchLog() {
   patchLogToggleEl.classList.toggle('collapsed');
   patchLogHeaderEl.setAttribute('aria-expanded', String(!isHidden));
 }
-patchLogHeaderEl.addEventListener('click', togglePatchLog);
+patchLogHeaderEl.addEventListener('click', togglePatchLog, { signal: listenerAbort.signal });
 patchLogHeaderEl.addEventListener('keydown', (event) => {
   if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); togglePatchLog(); }
-});
+}, { signal: listenerAbort.signal });
 
-window.addEventListener('beforeunload', () => {
-  adapter.destroy();
-  crdt.destroy_json_editor(handle);
-});
+window.addEventListener('beforeunload', dispose, { signal: listenerAbort.signal });
 
 // ── Init ──────────────────────────────────────────────
 
-const initialText = crdt.json_get_text(handle);
-if (initialText.trim()) editorEl.textContent = initialText;
-else {
-  crdt.json_set_text(handle, EXAMPLE_FALLBACK);
-  editorEl.textContent = EXAMPLE_FALLBACK;
+try {
+  structToggleBtn.textContent = '▦ Structured';
+  structToggleBtn.classList.remove('active');
+  viewEl.style.display = 'none';
+  viewEl.replaceChildren();
+  editorEl.style.display = '';
+  gutterEl.style.display = '';
+  formatBtn.disabled = false;
+  patchLogEl.classList.remove('hidden');
+  patchLogToggleEl.classList.remove('collapsed');
+  patchLogHeaderEl.setAttribute('aria-expanded', 'true');
+
+  const restoredText = typeof restoredSnapshot === 'string'
+    ? restoredSnapshot
+    : undefined;
+  if (restoredText !== undefined) {
+    crdt.json_set_text(handle, restoredText);
+    editorEl.textContent = restoredText;
+  } else {
+    const initialText = crdt.json_get_text(handle);
+    if (initialText.trim()) editorEl.textContent = initialText;
+    else {
+      crdt.json_set_text(handle, EXAMPLE_FALLBACK);
+      editorEl.textContent = EXAMPLE_FALLBACK;
+    }
+  }
+  adapter.resetCollapseState();
+  refresh();
+  fetchEditLog();
+  surfaceEl.inert = false;
+  surfaceEl.dataset.jsonReady = 'true';
+} catch (error) {
+  dispose();
+  throw error;
 }
-adapter.resetCollapseState();
-refresh();
-fetchEditLog();
+
+return {
+  snapshot: () => editorEl.textContent ?? '',
+  restoreFocus(token): boolean {
+    const target = token === 'editor'
+      ? editorEl
+      : token === 'structure-toggle'
+        ? structToggleBtn
+        : null;
+    if (target === null) return false;
+    target.focus({ preventScroll: true });
+    return document.activeElement === target;
+  },
+  dispose,
+};
+} catch (error) {
+  dispose();
+  throw error;
+}
 }

--- a/examples/web/src/features/json/browser/mount.ts
+++ b/examples/web/src/features/json/browser/mount.ts
@@ -1,6 +1,13 @@
-import './styles.css';
-import { mountJsonEditor } from './editor';
+'use client';
 
-export function mountJson(): void {
-  mountJsonEditor();
+import './styles.css';
+import * as crdt from '@moonbit/crdt-json';
+import { mountJsonEditor } from './editor';
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
+
+export function mountJson(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot?: unknown,
+): MountedImperativeSession {
+  return mountJsonEditor(root, restoredSnapshot, crdt);
 }

--- a/examples/web/src/features/json/browser/styles.css
+++ b/examples/web/src/features/json/browser/styles.css
@@ -5,7 +5,7 @@
     }
 
     .json-surface {
-      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      font-family: Consolas, Monaco, 'Courier New', monospace;
       background: #1e1e1e;
       color: #d4d4d4;
       padding: 20px;
@@ -127,7 +127,7 @@
   border-radius: 0 4px 4px 0;
   position: relative;
   outline: none;
-  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-family: Consolas, Monaco, 'Courier New', monospace;
   font-size: 15px;
   line-height: 1.6;
   overflow: auto;

--- a/examples/web/src/features/json/browser/styles.css
+++ b/examples/web/src/features/json/browser/styles.css
@@ -1,33 +1,33 @@
-    * {
+    .json-surface, .json-surface * {
       box-sizing: border-box;
       margin: 0;
       padding: 0;
     }
 
-    body {
+    .json-surface {
       font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
       background: #1e1e1e;
       color: #d4d4d4;
       padding: 20px;
     }
 
-    .container {
+    .json-surface .container {
       max-width: 1280px;
       margin: 0 auto;
     }
 
-    h1 {
+    .json-surface h1 {
       color: #4ec9b0;
       margin-bottom: 10px;
       font-size: 32px;
     }
 
-    .subtitle {
+    .json-surface .subtitle {
       color: #858585;
       margin-bottom: 20px;
     }
 
-    .examples-bar {
+    .json-surface .examples-bar {
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
@@ -39,17 +39,17 @@
       align-items: center;
     }
 
-    .examples-label,
-    .toolbar-label {
+    .json-surface .examples-label,
+    .json-surface .toolbar-label {
       color: #858585;
       font-size: 13px;
       margin-right: 4px;
     }
 
-    .example-btn,
-    .toolbar-btn,
-    .inline-submit,
-    .inline-cancel {
+    .json-surface .example-btn,
+    .json-surface .toolbar-btn,
+    .json-surface .inline-submit,
+    .json-surface .inline-cancel {
       padding: 7px 12px;
       background: #3c3c3c;
       color: #d4d4d4;
@@ -61,55 +61,55 @@
       transition: background 0.2s, border-color 0.2s;
     }
 
-    .example-btn:hover,
-    .toolbar-btn:hover,
-    .inline-submit:hover,
-    .inline-cancel:hover {
+    .json-surface .example-btn:hover,
+    .json-surface .toolbar-btn:hover,
+    .json-surface .inline-submit:hover,
+    .json-surface .inline-cancel:hover {
       background: #4c4c4c;
       border-color: #666;
     }
 
-    .toolbar-btn:disabled,
-    .inline-submit:disabled {
+    .json-surface .toolbar-btn:disabled,
+    .json-surface .inline-submit:disabled {
       cursor: not-allowed;
       opacity: 0.45;
     }
 
-    .layout {
+    .json-surface .layout {
       display: flex;
       flex-direction: column;
       gap: 20px;
     }
 
-    .panel {
+    .json-surface .panel {
       background: #252526;
       border: 1px solid #3c3c3c;
       border-radius: 4px;
       overflow: hidden;
     }
 
-    .panel-header {
+    .json-surface .panel-header {
       padding: 14px 16px;
       border-bottom: 1px solid #3c3c3c;
     }
 
-    .panel-header h2 {
+    .json-surface .panel-header h2 {
       color: #4ec9b0;
       font-size: 14px;
       text-transform: uppercase;
       letter-spacing: 0.04em;
     }
 
-    .editor-shell {
+    .json-surface .editor-shell {
       padding: 16px;
     }
 
-.editor-wrapper {
+.json-surface .editor-wrapper {
   display: flex;
   position: relative;
 }
 
-.editor-gutter {
+.json-surface .editor-gutter {
   width: 28px;
   flex-shrink: 0;
   background: #1e1e1e;
@@ -117,7 +117,7 @@
   position: relative;
 }
 
-.json-editor-view {
+.json-surface .json-editor-view {
   flex: 1;
   min-width: 0;
   min-height: 360px;
@@ -134,15 +134,15 @@
   white-space: pre;
 }
 
-.json-editor-view:focus {
+.json-surface .json-editor-view:focus {
   border-color: #4ec9b0;
 }
 
-.editor-empty {
+.json-surface .editor-empty {
   color: #6a6a6a;
 }
 
-.gutter-btn {
+.json-surface .gutter-btn {
   position: absolute;
   left: 3px;
   display: inline-flex;
@@ -162,12 +162,12 @@
   transition: color 0.15s, background 0.15s;
 }
 
-.gutter-btn:hover {
+.json-surface .gutter-btn:hover {
   background: #252540;
   color: #82aaff;
 }
 
-#json-input.json-editor-raw {
+.json-surface #json-input.json-editor-raw {
   flex: 1;
   min-width: 0;
   min-height: 360px;
@@ -183,39 +183,39 @@
   word-break: break-word;
 }
 
-#json-input.json-editor-raw:focus {
+.json-surface #json-input.json-editor-raw:focus {
   border-color: #4ec9b0;
 }
 
-#json-input.json-editor-raw:empty::before {
+.json-surface #json-input.json-editor-raw:empty::before {
   content: 'Type JSON here...';
   color: #6a6a6a;
 }
 
-.toolbar-btn.active {
+.json-surface .toolbar-btn.active {
   background: #8250df;
   border-color: #8250df;
   color: #fff;
 }
 
-.toolbar-btn.active:hover {
+.json-surface .toolbar-btn.active:hover {
   background: #6f3fbf;
   border-color: #6f3fbf;
 }
 
 /* ── Structured JSON view ────────────────────────── */
 
-.json-container {
+.json-surface .json-container {
   margin-left: 0;
 }
 
-.json-container .json-container {
+.json-surface .json-container .json-container {
   margin-left: 20px;
   border-left: 1px solid #2a2a48;
   padding-left: 12px;
 }
 
-.json-row {
+.json-surface .json-row {
   display: flex;
   align-items: center;
   gap: 4px;
@@ -224,11 +224,11 @@
   white-space: nowrap;
 }
 
-.json-row:hover {
+.json-surface .json-row:hover {
   background: #252540;
 }
 
-.json-toggle {
+.json-surface .json-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -241,64 +241,64 @@
   user-select: none;
 }
 
-.json-toggle:hover {
+.json-surface .json-toggle:hover {
   color: #c8c8e0;
 }
 
-.json-brace {
+.json-surface .json-brace {
   color: #858585;
   font-weight: 500;
 }
 
-.json-summary {
+.json-surface .json-summary {
   color: #5a5a7a;
   font-size: 13px;
   font-style: italic;
 }
 
-.json-key {
+.json-surface .json-key {
   color: #82aaff;
 }
 
-.json-colon {
+.json-surface .json-colon {
   color: #858585;
   margin-right: 4px;
 }
 
-.json-value {
+.json-surface .json-value {
   cursor: text;
   padding: 1px 4px;
   border-radius: 2px;
   min-width: 20px;
 }
 
-.json-value:hover {
+.json-surface .json-value:hover {
   background: #1e1e3e;
 }
 
-.json-value.json-string {
+.json-surface .json-value.json-string {
   color: #c3e88d;
 }
 
-.json-value.json-number {
+.json-surface .json-value.json-number {
   color: #f78c6c;
 }
 
-.json-value.json-bool {
+.json-surface .json-value.json-bool {
   color: #c792ea;
 }
 
-.json-value.json-null {
+.json-surface .json-value.json-null {
   color: #c792ea;
   font-style: italic;
 }
 
-.json-value.json-error {
+.json-surface .json-value.json-error {
   color: #f48771;
   border-bottom: 1px wavy #f48771;
 }
 
-.json-value input {
+.json-surface .json-value input {
   background: #1e1e1e;
   border: 1px solid #5a5a7a;
   color: #d4d4d4;
@@ -310,11 +310,11 @@
   min-width: 40px;
 }
 
-.json-value input:focus {
+.json-surface .json-value input:focus {
   border-color: #8250df;
 }
 
-.json-btn {
+.json-surface .json-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -333,32 +333,32 @@
   transition: opacity 0.15s, color 0.15s, background 0.15s;
 }
 
-.json-row:hover .json-btn {
+.json-surface .json-row:hover .json-btn {
   opacity: 1;
 }
 
-.json-btn:hover {
+.json-surface .json-btn:hover {
   background: #2a2a4a;
 }
 
-.json-btn-add {
+.json-surface .json-btn-add {
   color: #4ec9b0;
 }
 
-.json-btn-del {
+.json-surface .json-btn-del {
   color: #f48771;
 }
 
-.json-btn-add:hover {
+.json-surface .json-btn-add:hover {
   color: #6fdfc0;
 }
 
-.json-btn-del:hover {
+.json-surface .json-btn-del:hover {
   color: #f7a08e;
 }
 
 
-    .errors-header {
+    .json-surface .errors-header {
       padding: 10px 14px;
       color: #4ec9b0;
       font-size: 13px;
@@ -366,27 +366,27 @@
       border-bottom: 1px solid #3c3c3c;
     }
 
-    .error-list {
+    .json-surface .error-list {
       list-style: none;
       padding: 12px 14px;
       min-height: 48px;
     }
 
-    .error-item {
+    .json-surface .error-item {
       color: #f48771;
       border-left: 3px solid #f48771;
       padding-left: 10px;
     }
 
-    .error-item + .error-item {
+    .json-surface .error-item + .error-item {
       margin-top: 8px;
     }
 
-    .error-empty {
+    .json-surface .error-empty {
       color: #6a6a6a;
     }
 
-    .toolbar {
+    .json-surface .toolbar {
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
@@ -395,7 +395,7 @@
       align-items: center;
     }
 
-    .inline-form {
+    .json-surface .inline-form {
       display: none;
       gap: 8px;
       align-items: center;
@@ -404,11 +404,11 @@
       padding-top: 8px;
     }
 
-    .inline-form.visible {
+    .json-surface .inline-form.visible {
       display: flex;
     }
 
-    .inline-input {
+    .json-surface .inline-input {
       min-width: 160px;
       padding: 7px 10px;
       background: #1e1e1e;
@@ -420,11 +420,11 @@
       outline: none;
     }
 
-    .inline-input:focus {
+    .json-surface .inline-input:focus {
       border-color: #4ec9b0;
     }
 
-    .tree-view {
+    .json-surface .tree-view {
       padding: 16px;
       min-height: 420px;
       max-height: 70vh;
@@ -432,29 +432,29 @@
       background: #1e1e1e;
     }
 
-    .tree-empty {
+    .json-surface .tree-empty {
       color: #6a6a6a;
     }
 
-    .tree-node {
+    .json-surface .tree-node {
       margin-left: 14px;
       border-left: 1px solid #2a2a48;
       padding-left: 12px;
     }
 
-    .tree-node.root {
+    .json-surface .tree-node.root {
       margin-left: 0;
       padding-left: 0;
       border-left: none;
     }
 
-    .tree-node.collapsed > .node-children {
+    .json-surface .tree-node.collapsed > .node-children {
       display: none;
     }
 
     /* ── Toggle ───────────────────────────────────── */
 
-    .node-toggle {
+    .json-surface .node-toggle {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -472,19 +472,19 @@
       transition: color 0.15s, background 0.15s;
     }
 
-    .node-toggle:hover {
+    .json-surface .node-toggle:hover {
       color: #c8c8e0;
       background: #252540;
     }
 
-    .node-toggle:focus-visible {
+    .json-surface .node-toggle:focus-visible {
       outline: 2px solid #8250df;
       outline-offset: 1px;
     }
 
     /* ── Row ──────────────────────────────────────── */
 
-    .node-row {
+    .json-surface .node-row {
       display: flex;
       align-items: center;
       gap: 6px;
@@ -495,27 +495,27 @@
       user-select: none;
     }
 
-    .node-row:hover {
+    .json-surface .node-row:hover {
       background: #252540;
     }
 
-    .node-row.selected {
+    .json-surface .node-row.selected {
       background: rgba(130, 80, 223, 0.12);
       outline: 1px solid #8250df;
     }
 
     /* ── Key labels ───────────────────────────────── */
 
-    .node-key {
+    .json-surface .node-key {
       color: #82aaff;
     }
 
-    .node-id {
+    .json-surface .node-id {
       color: #5a5a7a;
       font-size: 11px;
     }
 
-    .node-count {
+    .json-surface .node-count {
       background: #252540;
       color: #5a5a7a;
       font-size: 10px;
@@ -527,43 +527,43 @@
 
     /* ── Type tags ────────────────────────────────── */
 
-    .node-tag.object,
-    .node-tag.array {
+    .json-surface .node-tag.object,
+    .json-surface .node-tag.array {
       color: #82aaff;
       font-weight: 600;
     }
 
-    .node-tag.string {
+    .json-surface .node-tag.string {
       color: #c3e88d;
     }
 
-    .node-tag.number {
+    .json-surface .node-tag.number {
       color: #f78c6c;
     }
 
-    .node-tag.bool,
-    .node-tag.null {
+    .json-surface .node-tag.bool,
+    .json-surface .node-tag.null {
       color: #c792ea;
     }
 
-    .node-tag.error {
+    .json-surface .node-tag.error {
       color: #cf222e;
     }
 
-    .node-tag {
+    .json-surface .node-tag {
       display: inline-block;
       min-width: 24px;
       min-height: 1.4em;
     }
 
-    .node-tag[data-empty="true"]::after {
+    .json-surface .node-tag[data-empty="true"]::after {
       content: '""';
       color: #5a5a7a;
       font-style: italic;
     }
 
-    .node-tag input,
-    .node-key input {
+    .json-surface .node-tag input,
+    .json-surface .node-key input {
       background: #1e1e1e;
       border: 1px solid #5a5a7a;
       color: #d4d4d4;
@@ -575,51 +575,51 @@
       min-width: 40px;
     }
 
-    .node-tag input:focus,
-    .node-key input:focus {
+    .json-surface .node-tag input:focus,
+    .json-surface .node-key input:focus {
       border-color: #8250df;
     }
 
     /* ── Value nodes (scalars) ────────────────────── */
 
-    .node-row.value-node {
+    .json-surface .node-row.value-node {
       padding-left: 24px;
     }
 
-    .node-row.value-node .node-id {
+    .json-surface .node-row.value-node .node-id {
       opacity: 0.5;
     }
 
-    .node-row.value-node:hover .node-id {
+    .json-surface .node-row.value-node:hover .node-id {
       opacity: 1;
     }
 
 
     /* ── Inline controls (action buttons, type dropdown) ──────── */
 
-    .node-actions {
+    .json-surface .node-actions {
       display: none;
       margin-left: auto;
       gap: 2px;
       flex-shrink: 0;
     }
 
-    .node-row:hover .node-actions,
-    .node-row.selected .node-actions {
+    .json-surface .node-row:hover .node-actions,
+    .json-surface .node-row.selected .node-actions {
       display: inline-flex;
     }
 
     /* Structured view: always show action buttons (no hover needed) */
-    #json-editor-view .node-actions {
+    .json-surface #json-editor-view .node-actions {
       display: inline-flex;
     }
 
     /* Structured view: always show type select (no row selection needed) */
-    #json-editor-view .node-type-select {
+    .json-surface #json-editor-view .node-type-select {
       display: inline-block;
     }
 
-    .node-action-btn {
+    .json-surface .node-action-btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -637,18 +637,18 @@
       transition: background 0.15s, color 0.15s, border-color 0.15s;
     }
 
-    .node-action-btn:hover {
+    .json-surface .node-action-btn:hover {
       background: #3a3a5a;
       color: #c8c8e0;
       border-color: #5a5a7a;
     }
 
-    .node-action-btn:focus-visible {
+    .json-surface .node-action-btn:focus-visible {
       outline: 2px solid #8250df;
       outline-offset: 1px;
     }
 
-    .node-type-select {
+    .json-surface .node-type-select {
       display: none;
       font-size: 10px;
       padding: 1px 2px;
@@ -661,21 +661,21 @@
       max-width: 70px;
     }
 
-    .node-row.selected .node-type-select {
+    .json-surface .node-row.selected .node-type-select {
       display: inline-block;
     }
-    .decoration-overlay {
+    .json-surface .decoration-overlay {
       position: absolute;
       pointer-events: none;
       z-index: 1;
       overflow: hidden;
     }
 
-    .decoration-overlay .widget-btn {
+    .json-surface .decoration-overlay .widget-btn {
       pointer-events: auto;
     }
 
-    .widget-btn {
+    .json-surface .widget-btn {
       position: absolute;
       display: inline-flex;
       align-items: center;
@@ -694,65 +694,65 @@
       transition: background 0.15s, color 0.15s, border-color 0.15s;
     }
 
-    .widget-btn:hover {
+    .json-surface .widget-btn:hover {
       background: #3a3a5a;
       color: #c8c8e0;
       border-color: #5a5a7a;
     }
 
 
-    .decoration-mark {
+    .json-surface .decoration-mark {
       position: absolute;
       pointer-events: none;
       border-radius: 2px;
     }
 
-    .json-role-property-key {
+    .json-surface .json-role-property-key {
       background-color: rgba(156, 220, 254, 0.12);
     }
 
-    .json-role-string-value {
+    .json-surface .json-role-string-value {
       background-color: rgba(206, 145, 120, 0.15);
     }
 
-    .json-role-number-literal {
+    .json-surface .json-role-number-literal {
       background-color: rgba(181, 206, 168, 0.13);
     }
 
-    .json-role-boolean-literal {
+    .json-surface .json-role-boolean-literal {
       background-color: rgba(86, 156, 214, 0.13);
     }
 
-    .json-role-null-literal {
+    .json-surface .json-role-null-literal {
       background-color: rgba(86, 156, 214, 0.13);
     }
 
-    .json-role-punctuation {
+    .json-surface .json-role-punctuation {
       background-color: rgba(128, 128, 128, 0.10);
     }
 
-    .json-role-error {
+    .json-surface .json-role-error {
       background-color: rgba(244, 135, 113, 0.18);
       border-bottom: 1px wavy #f48771;
     }
 
     @media (max-width: 900px) {
-      .layout {
+      .json-surface .layout {
         grid-template-columns: 1fr;
       }
 
-      .tree-view {
+      .json-surface .tree-view {
         max-height: none;
       }
     }
 
     /* ── Patch log panel ───────────────────────────── */
 
-    .patch-log-panel {
+    .json-surface .patch-log-panel {
       margin-top: 20px;
     }
 
-    .patch-log-header {
+    .json-surface .patch-log-header {
       display: flex;
       align-items: center;
       gap: 10px;
@@ -761,11 +761,11 @@
       user-select: none;
     }
 
-    .patch-log-header:hover {
+    .json-surface .patch-log-header:hover {
       background: #2a2a2a;
     }
 
-    .patch-log-count {
+    .json-surface .patch-log-count {
       background: #252540;
       color: #7a7a9a;
       font-size: 11px;
@@ -775,35 +775,35 @@
       text-align: center;
     }
 
-    .patch-log-toggle {
+    .json-surface .patch-log-toggle {
       font-size: 11px;
       color: #5a5a7a;
       margin-left: auto;
       transition: transform 0.2s;
     }
 
-    .patch-log-toggle.collapsed {
+    .json-surface .patch-log-toggle.collapsed {
       transform: rotate(-90deg);
     }
 
-    .patch-log-body {
+    .json-surface .patch-log-body {
       max-height: 480px;
       overflow-y: auto;
       padding: 0 16px 16px;
     }
 
-    .patch-log-body.hidden {
+    .json-surface .patch-log-body.hidden {
       display: none;
     }
 
-    .patch-log-empty {
+    .json-surface .patch-log-empty {
       color: #6a6a6a;
       font-size: 13px;
       padding: 16px 0;
       text-align: center;
     }
 
-    .patch-entry {
+    .json-surface .patch-entry {
       display: flex;
       align-items: center;
       gap: 10px;
@@ -816,38 +816,38 @@
       line-height: 1.5;
     }
 
-    .patch-entry:hover {
+    .json-surface .patch-entry:hover {
       border-color: #3a3a5a;
     }
 
-    .patch-entry + .patch-entry {
+    .json-surface .patch-entry + .patch-entry {
       margin-top: 4px;
     }
 
-    .patch-entry-time {
+    .json-surface .patch-entry-time {
       color: #5a5a7a;
       white-space: nowrap;
       flex-shrink: 0;
       font-variant-numeric: tabular-nums;
     }
 
-    .patch-entry-op {
+    .json-surface .patch-entry-op {
       font-weight: 600;
       white-space: nowrap;
       flex-shrink: 0;
     }
 
-    .patch-entry-op.Delete { color: #f48771; }
-    .patch-entry-op.AddMember,
-    .patch-entry-op.AddElement { color: #c3e88d; }
-    .patch-entry-op.WrapInArray,
-    .patch-entry-op.WrapInObject { color: #82aaff; }
-    .patch-entry-op.Unwrap { color: #c792ea; }
-    .patch-entry-op.ChangeType { color: #ffcb6b; }
-    .patch-entry-op.RenameKey { color: #89ddff; }
-    .patch-entry-op.CommitEdit { color: #a0a0a0; }
+    .json-surface .patch-entry-op.Delete { color: #f48771; }
+    .json-surface .patch-entry-op.AddMember,
+    .json-surface .patch-entry-op.AddElement { color: #c3e88d; }
+    .json-surface .patch-entry-op.WrapInArray,
+    .json-surface .patch-entry-op.WrapInObject { color: #82aaff; }
+    .json-surface .patch-entry-op.Unwrap { color: #c792ea; }
+    .json-surface .patch-entry-op.ChangeType { color: #ffcb6b; }
+    .json-surface .patch-entry-op.RenameKey { color: #89ddff; }
+    .json-surface .patch-entry-op.CommitEdit { color: #a0a0a0; }
 
-    .patch-entry-params {
+    .json-surface .patch-entry-params {
       color: #858585;
       flex: 1;
       min-width: 0;
@@ -856,12 +856,12 @@
       white-space: nowrap;
     }
 
-    .patch-entry-ok {
+    .json-surface .patch-entry-ok {
       color: #4ec9b0;
       flex-shrink: 0;
     }
 
-    .patch-entry-err {
+    .json-surface .patch-entry-err {
       color: #f48771;
       flex-shrink: 0;
     }

--- a/examples/web/src/features/json/route/json-client.tsx
+++ b/examples/web/src/features/json/route/json-client.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { type ReactNode, useCallback, useState } from 'react';
+import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
+import {
+  mountJsonEditor,
+  type JsonEditorRuntime,
+} from '../browser/editor';
+import '../browser/styles.css';
+
+const loadJsonRuntime: (() => Promise<JsonEditorRuntime>) | null = import.meta.env.SSR
+  ? null
+  : () => import('@moonbit/crdt-json');
+
+function mountJsonRoute(
+  container: HTMLElement,
+  restoredSnapshot: unknown,
+  reportRuntimeError: (error: unknown) => void,
+) {
+  if (loadJsonRuntime === null) {
+    throw new Error('The JSON editor runtime is unavailable on the client');
+  }
+  let controller: ReturnType<typeof mountJsonEditor> | null = null;
+  let disposed = false;
+  let pendingFocusToken: string | null = null;
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    controller?.dispose();
+    controller = null;
+  }
+
+  void loadJsonRuntime()
+    .then((runtime) => {
+      if (disposed) return;
+      controller = mountJsonEditor(container, restoredSnapshot, runtime);
+      if (
+        pendingFocusToken !== null &&
+        !controller.restoreFocus(pendingFocusToken)
+      ) {
+        container.querySelector<HTMLElement>('[data-route-heading]')
+          ?.focus({ preventScroll: true });
+      }
+    })
+    .catch((error: unknown) => {
+      if (disposed) return;
+      dispose();
+      reportRuntimeError(error);
+    });
+
+  return {
+    snapshot: () => controller?.snapshot() ?? restoredSnapshot,
+    restoreFocus(token: string): boolean {
+      if (controller !== null) return controller.restoreFocus(token);
+      if (token !== 'editor' && token !== 'structure-toggle') return false;
+      pendingFocusToken = token;
+      return true;
+    },
+    dispose,
+  };
+}
+
+export function JsonClient({ children }: { readonly children: ReactNode }) {
+  const [runtimeError, setRuntimeError] = useState<Error | null>(null);
+  const mount = useCallback(
+    (container: HTMLElement, restoredSnapshot: unknown) => mountJsonRoute(
+      container,
+      restoredSnapshot,
+      (error) => setRuntimeError(
+        error instanceof Error ? error : new Error(String(error)),
+      ),
+    ),
+    [],
+  );
+  if (runtimeError !== null) throw runtimeError;
+
+  return (
+    <ImperativeDemoHost
+      demoId="json"
+      mount={mount}
+      className="json-surface"
+    >
+      {children}
+    </ImperativeDemoHost>
+  );
+}

--- a/examples/web/src/features/json/route/json-route.tsx
+++ b/examples/web/src/features/json/route/json-route.tsx
@@ -1,0 +1,18 @@
+import jsonDocument from '../../../../json.html?raw';
+import { JsonClient } from './json-client';
+
+const shellMatch = jsonDocument.match(
+  /<body[^>]*>([\s\S]*?)\s*<script type="module" src="\/src\/entries\/json\.ts"><\/script>\s*<\/body>/,
+);
+if (shellMatch === null) {
+  throw new Error('The canonical JSON document shell is unavailable');
+}
+const jsonShellMarkup = shellMatch[1];
+
+export function JsonRoute() {
+  return (
+    <JsonClient>
+      <div dangerouslySetInnerHTML={{ __html: jsonShellMarkup }} />
+    </JsonClient>
+  );
+}

--- a/examples/web/src/features/json/route/json-route.tsx
+++ b/examples/web/src/features/json/route/json-route.tsx
@@ -1,18 +1,17 @@
 import jsonDocument from '../../../../json.html?raw';
 import { JsonClient } from './json-client';
 
-const shellMatch = jsonDocument.match(
-  /<body[^>]*>([\s\S]*?)\s*<script type="module" src="\/src\/entries\/json\.ts"><\/script>\s*<\/body>/,
-);
-if (shellMatch === null) {
-  throw new Error('The canonical JSON document shell is unavailable');
-}
-const jsonShellMarkup = shellMatch[1];
+const JSON_SHELL_PATTERN = /<!-- json-shell:start -->([\s\S]*?)<!-- json-shell:end -->/;
 
 export function JsonRoute() {
+  const shellMatch = JSON_SHELL_PATTERN.exec(jsonDocument);
+  if (shellMatch === null) {
+    throw new Error('The canonical JSON document shell is unavailable');
+  }
+
   return (
     <JsonClient>
-      <div dangerouslySetInnerHTML={{ __html: jsonShellMarkup }} />
+      <div dangerouslySetInnerHTML={{ __html: shellMatch[1] }} />
     </JsonClient>
   );
 }

--- a/examples/web/src/pages/json.tsx
+++ b/examples/web/src/pages/json.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { JsonRoute } from '../features/json/route/json-route';
 
 export default function Json() {
-  return <DemoPlaceholder demoId="json" />;
+  return <JsonRoute />;
 }

--- a/examples/web/src/shared/decoration-overlay.ts
+++ b/examples/web/src/shared/decoration-overlay.ts
@@ -17,18 +17,26 @@ export class DecorationOverlay {
     this.onWidgetClick = onWidgetClick;
     const host = editorEl.parentElement ?? editorEl;
     const hostStyle = window.getComputedStyle(host);
-    if (hostStyle.position === 'static') {
-      host.style.position = 'relative';
-    }
+    const previousHostPosition = host.style.position;
 
     this.overlay = document.createElement('div');
     this.overlay.className = 'decoration-overlay';
     this.overlay.setAttribute('aria-hidden', 'true');
-    host.appendChild(this.overlay);
-
     this.resizeObserver = new ResizeObserver(() => this.scheduleRender());
-    this.resizeObserver.observe(editorEl);
-    window.addEventListener('scroll', this.handleScroll, true);
+    try {
+      if (hostStyle.position === 'static') {
+        host.style.position = 'relative';
+      }
+      host.appendChild(this.overlay);
+      this.resizeObserver.observe(editorEl);
+      window.addEventListener('scroll', this.handleScroll, true);
+    } catch (error) {
+      this.resizeObserver.disconnect();
+      window.removeEventListener('scroll', this.handleScroll, true);
+      this.overlay.remove();
+      host.style.position = previousHostPosition;
+      throw error;
+    }
   }
 
   applyDecorations(decorations: Decoration[]) {

--- a/examples/web/tests/json-editor.spec.ts
+++ b/examples/web/tests/json-editor.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
+const jsonEditorUrl = process.env.JSON_EDITOR_URL ?? '/json.html';
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -32,10 +34,21 @@ function editorArea(page: Page) {
 
 let pageErrors: Error[];
 
+async function waitForJsonReady(page: Page): Promise<void> {
+  await expect(page.getByRole('heading', { name: '{} JSON CRDT Editor' })).toBeVisible();
+  await expect(page.locator('[data-json-ready]'))
+    .toHaveAttribute('data-json-ready', 'true');
+  if (jsonEditorUrl === '/json') {
+    await expect(page.locator('[data-route-lifecycle-ready]'))
+      .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  }
+}
+
 test.beforeEach(async ({ page }) => {
   pageErrors = [];
   page.on('pageerror', (error) => pageErrors.push(error));
-  await page.goto('/json.html');
+  await page.goto(jsonEditorUrl);
+  await waitForJsonReady(page);
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/web/waku-tests/hub.spec.ts
+++ b/examples/web/waku-tests/hub.spec.ts
@@ -135,7 +135,7 @@ test('push, Back, and Forward keep one Waku history chain and focus each route h
 
   await page.getByRole('link', { name: /JSON Editor/ }).click();
   await expect(page).toHaveURL(/\/json$/);
-  await expect(page.getByRole('heading', { level: 1 })).toHaveText('JSON Editor');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('{} JSON CRDT Editor');
   await expect(page.getByRole('heading', { level: 1 })).toBeFocused();
 
   await page.goBack();

--- a/examples/web/waku-tests/json-route.spec.ts
+++ b/examples/web/waku-tests/json-route.spec.ts
@@ -1,0 +1,166 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const DEFAULT_SOURCE = '{"hello": "world"}';
+
+async function waitForJsonMount(page: Page): Promise<void> {
+  await expect(page.locator('[data-json-ready]'))
+    .toHaveAttribute('data-json-ready', 'true');
+}
+
+async function replaceSource(page: Page, source: string): Promise<void> {
+  await page.locator('#json-input').evaluate((editor, nextSource) => {
+    editor.textContent = nextSource;
+    editor.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      data: nextSource,
+      inputType: 'insertText',
+    }));
+  }, source);
+  await expect.poll(
+    () => page.evaluate(() => window.getJsonRoleSpans().length),
+  ).toBeGreaterThan(0);
+}
+
+test('keeps the server-rendered JSON controls inert without client JavaScript', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    const response = await page.goto('/json');
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('[data-json-ready]')).toHaveAttribute('inert', '');
+    await expect(page.locator('[data-json-ready]'))
+      .toHaveAttribute('data-json-ready', 'false');
+  } finally {
+    await context.close();
+  }
+});
+
+test('reports runtime load failures through the route error boundary', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  let failedRuntimeRequests = 0;
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.route(/crdt[-_]json/, (route) => {
+    failedRuntimeRequests += 1;
+    return route.abort('failed');
+  });
+
+  await page.goto('/json');
+
+  await expect(page.getByRole('heading', {
+    name: 'This demo could not be displayed',
+  })).toBeFocused();
+  expect(failedRuntimeRequests).toBeGreaterThan(0);
+  await expect(page.locator('[data-imperative-demo-host="json"]')).toHaveCount(0);
+  expect(await page.evaluate(() => typeof window.getJsonRoleSpans)).toBe('undefined');
+  expect(pageErrors).toEqual([]);
+});
+
+test('restores source and stable focus while rebuilding structure state', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /JSON Editor/ }).click();
+  await waitForJsonMount(page);
+  await expect(page).toHaveURL(/\/json$/);
+  await expect(page.getByRole('heading', { name: '{} JSON CRDT Editor' })).toBeFocused();
+
+  const source = '{"nested":{"value":42}}';
+  await replaceSource(page, source);
+  const structureToggle = page.locator('#struct-toggle-btn');
+  await structureToggle.click();
+  const rootToggle = page.locator('#json-editor-view .node-toggle').first();
+  await expect(rootToggle).toHaveText('▼');
+  await rootToggle.click();
+  await expect(rootToggle).toHaveText('▶');
+  await structureToggle.focus();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForJsonMount(page);
+
+  await expect(page.locator('#json-input')).toHaveText(source);
+  await expect(structureToggle).toHaveText('▦ Structured');
+  await expect(structureToggle).toBeFocused();
+  await expect(page.locator('#patch-log-count')).toHaveText('0');
+  await structureToggle.click();
+  await expect(rootToggle).toHaveText('▼');
+});
+
+test('reload clears route memory and reconstructs controller internals', async ({ page }) => {
+  await page.goto('/json');
+  await waitForJsonMount(page);
+  await replaceSource(page, '{"transient":true}');
+  await page.locator('#struct-toggle-btn').click();
+  await page.locator('#json-editor-view .node-action-btn[data-action="add-member"]')
+    .first()
+    .click();
+  await expect(page.locator('#patch-log-count')).not.toHaveText('0');
+
+  await page.reload();
+  await waitForJsonMount(page);
+
+  await expect(page.locator('#json-input')).toHaveText(DEFAULT_SOURCE);
+  await expect(page.locator('#json-input')).toBeVisible();
+  await expect(page.locator('#struct-toggle-btn')).toHaveText('▦ Structured');
+  await expect(page.locator('#patch-log-count')).toHaveText('0');
+  await expect(page.locator('#json-editor-view')).toBeHidden();
+});
+
+test('repeated route cycles leave one surface and release hooks, overlays, and frames', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    await page.getByRole('link', { name: /JSON Editor/ }).click();
+    await waitForJsonMount(page);
+    await expect(page.locator('[data-imperative-demo-host="json"]')).toHaveCount(1);
+    await expect(page.locator('.json-surface .decoration-overlay')).toHaveCount(1);
+    expect(await page.evaluate(() => typeof window.getJsonRoleSpans)).toBe('function');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('[data-imperative-demo-host="json"]')).toHaveCount(0);
+    await expect(page.locator('.decoration-overlay')).toHaveCount(0);
+    expect(await page.evaluate(() => typeof window.getJsonRoleSpans)).toBe('undefined');
+  }
+
+  await page.getByRole('link', { name: /JSON Editor/ }).click();
+  await waitForJsonMount(page);
+  await page.evaluate(() => {
+    const frameIds = [2_147_483_000, 2_147_483_001];
+    const originalRequest = window.requestAnimationFrame;
+    const originalCancel = window.cancelAnimationFrame;
+    let requestIndex = 0;
+    (window as Window & { __jsonCancelledFrames?: number[] }).__jsonCancelledFrames = [];
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      if (requestIndex >= frameIds.length) return originalRequest(callback);
+      const frameId = frameIds[requestIndex];
+      requestIndex += 1;
+      return frameId;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = ((frameId: number) => {
+      if (frameIds.includes(frameId)) {
+        (window as Window & { __jsonCancelledFrames?: number[] })
+          .__jsonCancelledFrames?.push(frameId);
+        return;
+      }
+      originalCancel(frameId);
+    }) as typeof window.cancelAnimationFrame;
+    const editor = document.querySelector<HTMLElement>('#json-input');
+    editor?.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    editor?.dispatchEvent(new Event('scroll'));
+    window.history.back();
+  });
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.evaluate(
+    () => (window as Window & { __jsonCancelledFrames?: number[] })
+      .__jsonCancelledFrames,
+  )).toEqual([2_147_483_000, 2_147_483_001]);
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- make /json the canonical Waku route while retaining /json.html for the dual-run migration
- adapt the JSON editor to the shared imperative lifecycle contract with source-only snapshots, stable focus restoration, and idempotent resource disposal
- load the generated JSON MoonBit runtime only on the client, keep the server-rendered controls inert until mount, and surface runtime failures through the route error boundary
- run the existing JSON behavior suite against Waku and add route-memory, reload, no-JavaScript, failure, and repeated-cleanup coverage

## Reuse check

- Reused ImperativeDemoHost and MountedImperativeSession for the established snapshot, focus, and disposal boundary.
- Reused the accepted Issue #950 React/controller seam as primary-source behavior, without merging its prototype delivery code.
- Reused HTMLAdapter.destroy, DecorationOverlay.dispose, AbortController, requestAnimationFrame cancellation, and the existing generated JSON editor create/get/set/edit/destroy APIs.
- Checked static generated-module loading and rejected it for the Waku route because it enters the server graph; the existing Waku client-only dynamic import boundary is used instead.
- No MoonBit source or API changed, so MoonBit core API candidates are not applicable.
- New route/client definitions only extract the retained legacy shell and bridge asynchronous runtime loading into the existing imperative host. Remaining mutation is confined to the browser shell for DOM, listeners, frames, and owned resource teardown.

## Validation

- npm run typecheck
- npm run check:boundaries
- npm run test:boundaries
- npm run test:foundation
- npm run build:waku
- npm run check:waku-bundles
- npm run check:waku-types
- npm run test:waku:e2e — 54 passed
- npm run test:waku:workerd
- npm run build:vite
- npx playwright test — 103 passed, 2 expected provider-only skips
- moon check — 0 errors; 9 pre-existing vendored Rabbita deprecation warnings
- moon test — wasm-gc 3932, JS 1949, native 70 passed
- moon info and moon fmt; no mbti drift
- desktop and 390px browser checks; no horizontal overflow or page errors

Closes #974

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the JSON CRDT editor to the `/json` route with client-side loading, navigation-aware state restoration, focus recovery, and structured editing.
  * Improved editor lifecycle handling when navigating between routes or reloading the page.
  * Updated the interface styling and accessibility-related controls.

* **Bug Fixes**
  * Improved cleanup after editor or overlay initialization failures.
  * Prevented stale editor instances and event handlers from persisting after navigation.

* **Documentation**
  * Updated migration documentation and progress tracking for the JSON editor.

* **Tests**
  * Added end-to-end coverage for loading, navigation, failures, restoration, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->