### PR TITLE
feat(web): migrate Markdown editor to /markdown

### DIFF
--- a/adapters/editor-adapter/block-input.css
+++ b/adapters/editor-adapter/block-input.css
@@ -15,7 +15,7 @@
   margin: 0;
 }
 
-.block {
+.block-editor .block {
   position: relative;
   padding: 4px 8px;
   border-radius: 4px;
@@ -24,11 +24,11 @@
   transition: background 0.1s ease;
 }
 
-.block:hover {
+.block-editor .block:hover {
   background: rgba(130, 80, 223, 0.04);
 }
 
-.block.active {
+.block-editor .block.active {
   outline: 2px solid #8250df;
   outline-offset: -1px;
 }
@@ -36,45 +36,45 @@
 /* --- Block kinds -------------------------------------------------------- */
 
 /* Headings: kind_tag is "H1"–"H6" */
-.block[data-kind^="H"] {
+.block-editor .block[data-kind^="H"] {
   font-weight: 700;
   line-height: 1.3;
 }
 
-.block[data-kind="H1"] { font-size: 2em; }
-.block[data-kind="H2"] { font-size: 1.5em; font-weight: 600; }
-.block[data-kind="H3"] { font-size: 1.25em; font-weight: 600; }
-.block[data-kind="H4"] { font-size: 1.1em; font-weight: 600; }
-.block[data-kind="H5"],
-.block[data-kind="H6"] { font-size: 1em; font-weight: 600; }
+.block-editor .block[data-kind="H1"] { font-size: 2em; }
+.block-editor .block[data-kind="H2"] { font-size: 1.5em; font-weight: 600; }
+.block-editor .block[data-kind="H3"] { font-size: 1.25em; font-weight: 600; }
+.block-editor .block[data-kind="H4"] { font-size: 1.1em; font-weight: 600; }
+.block-editor .block[data-kind="H5"],
+.block-editor .block[data-kind="H6"] { font-size: 1em; font-weight: 600; }
 
-.block[data-kind="ListItem"],
-.block[data-kind="UnorderedListItem"],
-.block[data-kind="OrderedListItem"] {
+.block-editor .block[data-kind="ListItem"],
+.block-editor .block[data-kind="UnorderedListItem"],
+.block-editor .block[data-kind="OrderedListItem"] {
   padding-left: 24px;
 }
 
-.block[data-kind="ListItem"]::before,
-.block[data-kind="UnorderedListItem"]::before,
-.block[data-kind="OrderedListItem"]::before {
+.block-editor .block[data-kind="ListItem"]::before,
+.block-editor .block[data-kind="UnorderedListItem"]::before,
+.block-editor .block[data-kind="OrderedListItem"]::before {
   content: "\2022 ";
   position: absolute;
   left: 8px;
   color: #666;
 }
 
-.block[data-kind="ListItem"][data-list-kind="ordered"],
-.block[data-kind="OrderedListItem"] {
+.block-editor .block[data-kind="ListItem"][data-list-kind="ordered"],
+.block-editor .block[data-kind="OrderedListItem"] {
   padding-left: 32px;
 }
 
-.block[data-kind="ListItem"][data-list-kind="ordered"]::before,
-.block[data-kind="OrderedListItem"]::before {
+.block-editor .block[data-kind="ListItem"][data-list-kind="ordered"]::before,
+.block-editor .block[data-kind="OrderedListItem"]::before {
   content: attr(data-list-marker) " ";
 }
 
 /* Code blocks: kind_tag is "Code" or "Code(lang)" */
-.block[data-kind^="Code"] {
+.block-editor .block[data-kind^="Code"] {
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   font-size: 0.9em;
   background: rgba(130, 80, 223, 0.04);
@@ -83,7 +83,7 @@
 
 /* --- Textarea overlay --------------------------------------------------- */
 
-.block-textarea {
+.block-editor .block-textarea {
   position: absolute;
   top: 0;
   left: 0;
@@ -106,7 +106,7 @@
 
 /* --- Text span ---------------------------------------------------------- */
 
-.block-text {
+.block-editor .block-text {
   white-space: pre-wrap;
   overflow-wrap: break-word;
 }

--- a/adapters/editor-adapter/block-input.ts
+++ b/adapters/editor-adapter/block-input.ts
@@ -60,6 +60,7 @@ export class BlockInput implements EditorAdapter {
   private intentCb: ((intent: UserIntent) => void) | null = null;
   private stripParagraphSentinels: (s: string) => string;
   private getSourceText: (() => string) | null;
+  private pointerUpAbort: AbortController | null = null;
 
   constructor(container: HTMLElement, opts: BlockInputOptions = {}) {
     this.container = container;
@@ -138,10 +139,14 @@ export class BlockInput implements EditorAdapter {
   }
 
   destroy(): void {
+    this.pointerUpAbort?.abort();
+    this.pointerUpAbort = null;
     this.deactivate();
     this.container.removeEventListener('click', this.onContainerClick);
     this.container.innerHTML = '';
     this.currentTree = null;
+    this.intentCb = null;
+    this.getSourceText = null;
     if (this.textarea) {
       this.textarea.remove();
       this.textarea = null;
@@ -374,17 +379,27 @@ export class BlockInput implements EditorAdapter {
 
     // Deferred blur: bind onblur only after pointerup, skip if target is toolbar
     if (!this.blurBound) {
+      this.pointerUpAbort?.abort();
+      const view = this.container.ownerDocument.defaultView ?? window;
+      const pointerUpAbort = new view.AbortController();
+      this.pointerUpAbort = pointerUpAbort;
       const handler = (e: PointerEvent) => {
+        if (this.pointerUpAbort === pointerUpAbort) this.pointerUpAbort = null;
         // Don't bind blur if click was on toolbar/menu — keeps textarea active
         if ((e.target as Element)?.closest?.('[data-no-blur]')) return;
         if (ta) ta.onblur = () => this.deactivate();
         this.blurBound = true;
       };
-      document.addEventListener('pointerup', handler as EventListener, { once: true });
+      this.container.ownerDocument.addEventListener('pointerup', handler, {
+        once: true,
+        signal: pointerUpAbort.signal,
+      });
     }
   }
 
   private deactivate(): void {
+    this.pointerUpAbort?.abort();
+    this.pointerUpAbort = null;
     if (this.activeBlockId === null) return;
     this.activeBlockId = null;
     this.blurBound = false;

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -662,7 +662,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
   Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#974 migrate Journey, Posts, and JSON to `/journey`, `/posts`, and `/json`. Vite remains the default, and no redirect or production deployment has migrated.
+  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#975 migrate Journey, Posts, JSON, and Markdown to `/journey`, `/posts`, `/json`, and `/markdown`. Vite remains the default, and no redirect or production deployment has migrated.
   Exit: the plan's Stage 12 gate passes after production cutover is proven.
 
 ## 22. SDEG Lifecycle

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -8,7 +8,7 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 |---|---|---|---|---|---|
 | Lambda | `index.html` | `src/entries/lambda.ts` | `features/lambda/browser/{mount,editor,ast-grep-runner}.ts` (uses shared decoration overlay) | `features/lambda/browser/styles.css`, imported by `mount.ts` | Browser + generated MoonBit Lambda/Graphviz; `tests/lambda-editor.spec.ts` |
 | JSON | `json.html` | `src/entries/json.ts` | `features/json/browser/{editor,mount}.ts` (uses shared decoration overlay) | `features/json/browser/styles.css`, imported by `mount.ts` | Browser + generated MoonBit JSON; `tests/json-editor.spec.ts` |
-| Markdown | `markdown.html` | `src/entries/markdown.ts` | `features/markdown/browser/{app,mount,sentinels}.ts` | `features/markdown/browser/styles.css`, imported by `mount.ts`; adapter CSS remains adapter-owned | Browser + generated MoonBit Markdown; `tests/markdown-editor.spec.ts` |
+| Markdown | `markdown.html` | `src/entries/markdown.ts` | `features/markdown/browser/{app,mount,sentinels}.ts`; `features/markdown/route/{markdown-route,markdown-client}.tsx` | `features/markdown/browser/styles.css`, imported by Vite and Waku composition; adapter CSS remains adapter-owned | Browser + generated MoonBit Markdown; `tests/markdown-editor.spec.ts`, `waku-tests/markdown-route.spec.ts` |
 | Memo | `memo.html` | `src/entries/memo.ts` | `features/memo/core/edit-actions.ts`, `features/memo/browser/{app,mount,view}.ts` | `features/memo/browser/styles.css`, imported by `mount.ts` | Browser + generated MoonBit Lambda; `tests/memo-editor.spec.ts` |
 | Posts | `posts.html` | `src/entries/posts.ts` | `features/posts/core/{posts,post-events,post-retrieval}.ts`, `features/posts/browser/{app,mount,post-events,post-store,view}.ts` | `features/posts/browser/styles.css`, imported by `mount.ts` | Browser persistence shell around deterministic retrieval logic; `tests/post-app.spec.ts` |
 | Resume/PKE | `resume.html` | `src/entries/resume.ts` | `features/resume/browser/app.tsx`, `features/resume/browser/components/*`, `features/resume/core/session.ts`, `features/resume/protocol/chat.ts` | `features/resume/browser/styles.css`, imported by `app.tsx` | Browser React + `server/vite/resume-chat.ts` local chat relay; `tests/pi-resume.spec.ts` |
@@ -47,9 +47,9 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 Most of the source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. Resume/PKE, Posts, Memo, JSON, Markdown, GenUI, and GenUI Possibilities use the target entry/feature layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku migration (pre-production, #970–#974 Stages 0–5)
+## Waku migration (pre-production, #970–#975 Stages 0–6)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–5 migrate Journey, Posts, and JSON while retaining every old HTML entry.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–6 migrate Journey, Posts, JSON, and Markdown while retaining every old HTML entry.
 
 ### Stage 0–1 configuration and artifacts
 
@@ -65,10 +65,11 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 
 - `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
 - `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
-- `src/pages/{ml,markdown,memo,resume,genui}.tsx` — five canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/{ml,memo,resume,genui}.tsx` — four canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
 - `src/pages/journey.tsx` — canonical Journey route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/posts.tsx` — canonical Posts route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/json.tsx` — canonical JSON route; composes the feature-owned editor controller through the shared imperative host.
+- `src/pages/markdown.tsx` — canonical Markdown route; composes the feature-owned three-mode editor through the shared imperative host.
 - `src/pages/_layout.tsx` — pass-through shared route layout; the provider stays at `_root.tsx` so its in-memory registry survives route render failures.
 - `src/shared/catalog/demo-catalog.ts` — framework-independent catalog data (eight demos, three groups, canonical `DemoPath` routes).
 - `src/shared/shell/` — `DemoHub` and `DemoPlaceholder` React components and shared shell styles.
@@ -104,6 +105,16 @@ Stage 4 remains pre-production. Vite and `posts.html` remain the defaults and ar
 
 Stage 5 remains pre-production. Vite and `json.html` remain the defaults and are retained. No JSON compatibility redirect is active, and no MoonBit editor API or workflow changed.
 
+### Stage 6 — Markdown editor
+
+- `src/features/markdown/route/{markdown-route,markdown-client}.tsx` — server/client route seam that reuses the legacy Markdown markup, keeps the generated MoonBit runtime client-only, and mounts through the shared imperative host.
+- `src/features/markdown/browser/{app,mount,sentinels}.ts` — root-scoped controller shared by Waku and Vite; snapshots document text only while rebuilding mode, active block, raw-dirty, and DOM-selection state after route return. It owns the MoonBit handle, `BlockInput`, `MarkdownPreview`, pending frame, listeners, and focus until idempotent disposal.
+- `adapters/editor-adapter/block-input.ts` — explicitly owns and cancels its deferred `pointerup` listener and clears callbacks during disposal.
+- `tests/markdown-editor.spec.ts` — existing Markdown mode, selection, edit, and preview contract, now run against both legacy Vite `/markdown.html` and Waku `/markdown`.
+- `waku-tests/markdown-route.spec.ts` — no-JavaScript inertness, runtime-failure boundary, document-only route memory, rebuilt-mode focus fallback, reload reset, and repeated listener/frame disposal coverage.
+
+Stage 6 remains pre-production. Vite and `markdown.html` remain the defaults and are retained. No Markdown compatibility redirect is active, and no Markdown model, toolbar, mode semantics, or MoonBit API changed.
+
 Validation runs in parallel with the Vite pipeline:
 
 - `npm run build:waku` — Waku production build from prebuilt MoonBit artifacts.
@@ -114,7 +125,7 @@ Validation runs in parallel with the Vite pipeline:
 - `npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env preview` — preview Waku Worker bundle dry-run.
 - CI jobs `waku-build`, `waku-e2e`, and `waku-workerd` run alongside the existing Vite jobs until Stage 12 (Vite retirement).
 
-Both development modes reuse the same coordinator, which starts one root MoonBit watcher rather than one watcher per virtual module. `npm run dev:dual` runs Vite and Waku side by side behind that single watcher. Generated modules stay client-only on the Waku side; the probe loads all five and the migrated JSON route loads its JSON runtime on demand.
+Both development modes reuse the same coordinator, which starts one root MoonBit watcher rather than one watcher per virtual module. `npm run dev:dual` runs Vite and Waku side by side behind that single watcher. Generated modules stay client-only on the Waku side; the probe loads all five, while the migrated JSON and Markdown routes load only their own runtime on demand.
 
 ## Boundary vocabulary and allowed direction
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,9 +5,9 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Waku migration (in progress, #974)
+## Waku migration (in progress, #975)
 
-A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–5 migrate Journey Proposals, Posts, and the JSON editor to `/journey`, `/posts`, and `/json`. JSON snapshots source text only and rebuilds its live MoonBit controller state after navigation. All three use the imperative host and retain their legacy HTML entries; the other five canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–6 migrate Journey Proposals, Posts, JSON, and Markdown to `/journey`, `/posts`, `/json`, and `/markdown`. JSON and Markdown snapshot source text only and rebuild their live MoonBit controller state after navigation; Markdown keeps its within-demo mode and selection behavior. All four use the imperative host and retain their legacy HTML entries; the other four canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
 
 ## Development
 

--- a/examples/web/markdown.html
+++ b/examples/web/markdown.html
@@ -6,13 +6,15 @@
   <title>Canopy Markdown Editor</title>
 
 </head>
-<body>
+<body class="markdown-surface">
+  <!-- markdown-shell:start -->
   <div class="container">
     <header>
-      <h1><span>&#9649;</span> Markdown Editor</h1>
+      <h1 data-route-heading tabindex="-1"><span>&#9649;</span> Markdown Editor</h1>
       <p class="subtitle">Block-based Markdown editing with three view modes</p>
     </header>
 
+    <div class="markdown-app" inert data-markdown-ready="false">
     <div class="examples-bar">
       <span class="examples-label">Examples:</span>
       <button class="example-btn" data-example="# Hello World&#10;&#10;Welcome to the Canopy Markdown editor.&#10;&#10;This editor has three modes: raw, block, and preview.">Hello</button>
@@ -22,9 +24,9 @@
     </div>
 
     <div class="mode-tabs">
-      <button class="mode-tab active" data-mode="block">Block</button>
-      <button class="mode-tab" data-mode="raw">Raw</button>
-      <button class="mode-tab" data-mode="preview">Preview</button>
+      <button class="mode-tab active" data-mode="block" data-route-focus="mode-block">Block</button>
+      <button class="mode-tab" data-mode="raw" data-route-focus="mode-raw">Raw</button>
+      <button class="mode-tab" data-mode="preview" data-route-focus="mode-preview">Preview</button>
     </div>
 
     <div class="editor-panel">
@@ -45,7 +47,7 @@
       </div>
 
       <div class="editor-pane" id="raw-pane" hidden>
-        <textarea id="raw-editor" placeholder="Type Markdown here..." spellcheck="false"></textarea>
+        <textarea id="raw-editor" data-route-focus="raw-editor" placeholder="Type Markdown here..." spellcheck="false"></textarea>
       </div>
 
       <div class="editor-pane" id="block-pane">
@@ -56,7 +58,9 @@
         <div id="preview-container"></div>
       </div>
     </div>
+    </div>
   </div>
+  <!-- markdown-shell:end -->
 
   <script type="module" src="/src/entries/markdown.ts"></script>
 </body>

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -8,6 +8,7 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 process.env.GENUI_POSSIBILITIES_URL = '/journey';
 process.env.POSTS_URL = '/posts';
 process.env.JSON_EDITOR_URL = '/json';
+process.env.MARKDOWN_EDITOR_URL = '/markdown';
 
 export default defineConfig({
   testDir: '.',
@@ -15,6 +16,7 @@ export default defineConfig({
     'waku-tests/**/*.spec.ts',
     'tests/genui-possibilities.spec.ts',
     'tests/json-editor.spec.ts',
+    'tests/markdown-editor.spec.ts',
     'tests/post-app.spec.ts',
   ],
   timeout: 30_000,

--- a/examples/web/src/features/markdown/browser/app.ts
+++ b/examples/web/src/features/markdown/browser/app.ts
@@ -2,14 +2,20 @@
 
 // Markdown Block Editor — three-mode page wiring FFI → adapters.
 
-import * as crdt from '@moonbit/crdt-markdown';
 import { BlockInput, type BlockSelection } from '@canopy/editor-adapter/block-input';
 import { MarkdownPreview } from '@canopy/editor-adapter/markdown-preview';
 import '@canopy/editor-adapter/block-input.css';
 import type { ViewPatch, UserIntent } from '@canopy/editor-adapter/types';
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
 import { stripParagraphSentinels } from './sentinels';
 
-export function mountMarkdownApp(): void {
+export type MarkdownEditorRuntime = typeof import('@moonbit/crdt-markdown');
+
+export function mountMarkdownApp(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot: unknown,
+  crdt: MarkdownEditorRuntime,
+): MountedImperativeSession {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -24,24 +30,14 @@ This editor has three modes: raw, block, and preview.
 type Mode = 'raw' | 'block' | 'preview';
 
 // ---------------------------------------------------------------------------
-// State
+// DOM and lifecycle ownership
 // ---------------------------------------------------------------------------
 
-const agentId = `md-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-const handle = crdt.create_markdown_editor(agentId);
-
-let activeMode: Mode = 'block';
-let activeNodeId: number | null = null;
-let savedBlockSelection: BlockSelection | null = null;
-let rawSyncScheduled = false;
-let rawDirty = false;
-
-// ---------------------------------------------------------------------------
-// DOM helpers
-// ---------------------------------------------------------------------------
+const document = root instanceof Document ? root : root.ownerDocument;
+const window = document.defaultView ?? globalThis.window;
 
 function must<T extends HTMLElement>(id: string): T {
-  const el = document.getElementById(id);
+  const el = root.querySelector<HTMLElement>(`#${id}`);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
 }
@@ -60,17 +56,67 @@ const h3Btn = must<HTMLButtonElement>('h3-btn');
 const listBtn = must<HTMLButtonElement>('list-btn');
 const deleteBtn = must<HTMLButtonElement>('delete-btn');
 
-const modeTabs = document.querySelectorAll<HTMLButtonElement>('.mode-tab');
+const modeTabs = Array.from(root.querySelectorAll<HTMLButtonElement>('.mode-tab'));
+const exampleButtons = Array.from(root.querySelectorAll<HTMLButtonElement>('.example-btn'));
+const surfaceCandidate = root.querySelector<HTMLElement>('[data-markdown-ready]');
+if (surfaceCandidate === null) throw new Error('Missing Markdown editor surface');
+const surfaceEl: HTMLElement = surfaceCandidate;
+const listenerAbort = new window.AbortController();
+let disposed = false;
+let rawSyncFrame: number | null = null;
+let releaseHandle: (() => void) | null = null;
+let releaseBlockInput: (() => void) | null = null;
+let releasePreview: (() => void) | null = null;
+
+function dispose(): void {
+  if (disposed) return;
+  disposed = true;
+  surfaceEl.inert = true;
+  surfaceEl.dataset.markdownReady = 'false';
+  listenerAbort.abort();
+  if (rawSyncFrame !== null) {
+    window.cancelAnimationFrame(rawSyncFrame);
+    rawSyncFrame = null;
+  }
+  const releases = [
+    ['preview adapter', releasePreview],
+    ['BlockInput adapter', releaseBlockInput],
+    ['MoonBit handle', releaseHandle],
+  ] as const;
+  releasePreview = null;
+  releaseBlockInput = null;
+  releaseHandle = null;
+  releases.forEach(([resource, release]) => {
+    try {
+      release?.();
+    } catch (error) {
+      console.error(`Failed to dispose Markdown editor ${resource}`, error);
+    }
+  });
+}
+
+try {
+const agentId = `md-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const handle = crdt.create_markdown_editor(agentId);
+releaseHandle = () => crdt.destroy_markdown_editor(handle);
+
+let activeMode: Mode = 'block';
+let activeNodeId: number | null = null;
+let savedBlockSelection: BlockSelection | null = null;
+let rawDirty = false;
 
 // ---------------------------------------------------------------------------
 // Adapters
 // ---------------------------------------------------------------------------
 
+const paragraphSentinel = crdt.markdown_empty_paragraph_sentinel();
 const blockInput = new BlockInput(blockContainer, {
-  stripParagraphSentinels,
+  stripParagraphSentinels: (text) => stripParagraphSentinels(text, paragraphSentinel),
   getSourceText: () => crdt.markdown_export_text(handle),
 });
+releaseBlockInput = () => blockInput.destroy();
 const preview = new MarkdownPreview(previewContainer);
+releasePreview = () => preview.destroy();
 
 // ---------------------------------------------------------------------------
 // Core functions
@@ -174,14 +220,15 @@ blockInput.onIntent((intent: UserIntent) => {
 
 rawEditor.addEventListener('input', () => {
   rawDirty = true;
-  if (rawSyncScheduled) return;
-  rawSyncScheduled = true;
-  requestAnimationFrame(() => {
-    rawSyncScheduled = false;
+  if (rawSyncFrame !== null) return;
+  rawSyncFrame = window.requestAnimationFrame(() => {
+    rawSyncFrame = null;
+    if (disposed) return;
     crdt.markdown_set_text(handle, rawEditor.value);
     refresh();
+    rawDirty = false;
   });
-});
+}, { signal: listenerAbort.signal });
 
 // ---------------------------------------------------------------------------
 // Mode switching
@@ -199,6 +246,10 @@ function setMode(mode: Mode): void {
   // If they just viewed raw mode without editing, don't write back the
   // ZWSP-stripped display text (which would destroy empty block placeholders).
   if (activeMode === 'raw' && rawDirty) {
+    if (rawSyncFrame !== null) {
+      window.cancelAnimationFrame(rawSyncFrame);
+      rawSyncFrame = null;
+    }
     crdt.markdown_set_text(handle, rawEditor.value);
     refresh();
     rawDirty = false;
@@ -235,7 +286,7 @@ function setMode(mode: Mode): void {
 modeTabs.forEach(tab => {
   tab.addEventListener('click', () => {
     setMode(tab.dataset.mode as Mode);
-  });
+  }, { signal: listenerAbort.signal });
 });
 
 // ---------------------------------------------------------------------------
@@ -259,13 +310,13 @@ function toggleHeading(level: number): void {
   applyEdit('change_heading_level', activeNodeId, '', targetLevel);
 }
 
-h1Btn.addEventListener('click', () => toggleHeading(1));
-h2Btn.addEventListener('click', () => toggleHeading(2));
-h3Btn.addEventListener('click', () => toggleHeading(3));
+h1Btn.addEventListener('click', () => toggleHeading(1), { signal: listenerAbort.signal });
+h2Btn.addEventListener('click', () => toggleHeading(2), { signal: listenerAbort.signal });
+h3Btn.addEventListener('click', () => toggleHeading(3), { signal: listenerAbort.signal });
 
 listBtn.addEventListener('click', () => {
   if (activeNodeId != null) applyEdit('toggle_list_item', activeNodeId, '', 0);
-});
+}, { signal: listenerAbort.signal });
 
 deleteBtn.addEventListener('click', () => {
   if (activeNodeId == null) return;
@@ -281,13 +332,13 @@ deleteBtn.addEventListener('click', () => {
     activeNodeId = null;
     updateToolbar();
   }
-});
+}, { signal: listenerAbort.signal });
 
 // ---------------------------------------------------------------------------
 // Keyboard shortcuts (block mode)
 // ---------------------------------------------------------------------------
 
-document.addEventListener('keydown', (e) => {
+document.addEventListener('keydown', (e: KeyboardEvent) => {
   if (activeMode !== 'block' || activeNodeId === null) return;
   if (e.isComposing) return;
 
@@ -311,13 +362,13 @@ document.addEventListener('keydown', (e) => {
     applyEdit('toggle_list_item', activeNodeId, '', 0);
     return;
   }
-});
+}, { signal: listenerAbort.signal });
 
 // ---------------------------------------------------------------------------
 // Examples
 // ---------------------------------------------------------------------------
 
-document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach(btn => {
+exampleButtons.forEach(btn => {
   btn.addEventListener('click', () => {
     const text = btn.dataset.example ?? DEFAULT_TEXT;
     blockInput.clearSelection();
@@ -327,25 +378,55 @@ document.querySelectorAll<HTMLButtonElement>('.example-btn').forEach(btn => {
     savedBlockSelection = null;
     refresh();
     updateToolbar();
-  });
+  }, { signal: listenerAbort.signal });
 });
 
 // ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------
 
-window.addEventListener('beforeunload', () => {
-  blockInput.destroy();
-  preview.destroy();
-  crdt.destroy_markdown_editor(handle);
-});
+window.addEventListener('beforeunload', dispose, { signal: listenerAbort.signal });
 
 // ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------
 
-crdt.markdown_set_text(handle, DEFAULT_TEXT);
+rawPane.hidden = true;
+blockPane.hidden = false;
+previewPane.hidden = true;
+toolbarEl.hidden = false;
+modeTabs.forEach((tab) => {
+  tab.classList.toggle('active', tab.dataset.mode === 'block');
+});
+
+const initialText = typeof restoredSnapshot === 'string'
+  ? restoredSnapshot
+  : DEFAULT_TEXT;
+crdt.markdown_set_text(handle, initialText);
 syncRawFromModel();
 refresh();
 updateToolbar();
+surfaceEl.inert = false;
+surfaceEl.dataset.markdownReady = 'true';
+
+return {
+  snapshot: () => rawDirty || rawSyncFrame !== null
+    ? rawEditor.value
+    : crdt.markdown_export_text(handle),
+  restoreFocus(token): boolean {
+    if (disposed) return false;
+    const modeTarget = modeTabs.find((tab) => tab.dataset.routeFocus === token);
+    const target = modeTarget ?? (
+      token === 'raw-editor' && !rawPane.hidden ? rawEditor : null
+    );
+    if (target === null) return false;
+    target.focus({ preventScroll: true });
+    return document.activeElement === target;
+  },
+  dispose,
+};
+} catch (error) {
+  dispose();
+  throw error;
+}
 }

--- a/examples/web/src/features/markdown/browser/mount.ts
+++ b/examples/web/src/features/markdown/browser/mount.ts
@@ -1,6 +1,13 @@
-import './styles.css';
-import { mountMarkdownApp } from './app';
+'use client';
 
-export function mountMarkdown(): void {
-  mountMarkdownApp();
+import './styles.css';
+import * as crdt from '@moonbit/crdt-markdown';
+import { mountMarkdownApp } from './app';
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
+
+export function mountMarkdown(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot?: unknown,
+): MountedImperativeSession {
+  return mountMarkdownApp(root, restoredSnapshot, crdt);
 }

--- a/examples/web/src/features/markdown/browser/sentinels.ts
+++ b/examples/web/src/features/markdown/browser/sentinels.ts
@@ -2,22 +2,19 @@
 
 // Empty-paragraph sentinel wiring for the markdown editor.
 //
-// Sources the sentinel codepoint from the MoonBit FFI bundle so this file
-// and `lang/markdown/sentinel/` + `loom/moji/codepoints.mbt` agree by
-// construction. The build graph routes:
+// The caller supplies the sentinel sourced from the MoonBit FFI bundle so this
+// pure display transformation and `lang/markdown/sentinel/` +
+// `loom/moji/codepoints.mbt` agree by construction. The build graph routes:
 //
 //   loom/moji/codepoints.mbt          (canonical const: ZERO_WIDTH_SPACE)
 //     → lang/markdown/sentinel/       (role-name layer: EMPTY_PARAGRAPH_SENTINEL)
 //       → ffi/markdown/markdown_ffi   (JS export: markdown_empty_paragraph_sentinel)
-//         → @moonbit/crdt-markdown    (Vite virtual module)
-//           → this file               (captures the value once)
-//             → BlockInput option     (per-instance strip behavior)
-
-import { markdown_empty_paragraph_sentinel } from '@moonbit/crdt-markdown';
-
-const SENTINEL = markdown_empty_paragraph_sentinel();
+//         → @moonbit/crdt-markdown    (client-only generated module)
+//           → app runtime injection   (captures the value once)
+//             → this pure function
+//               → BlockInput option   (per-instance strip behavior)
 
 /** Strip every occurrence of the empty-paragraph sentinel from a display string. */
-export function stripParagraphSentinels(s: string): string {
-  return s.split(SENTINEL).join('');
+export function stripParagraphSentinels(s: string, sentinel: string): string {
+  return s.split(sentinel).join('');
 }

--- a/examples/web/src/features/markdown/browser/styles.css
+++ b/examples/web/src/features/markdown/browser/styles.css
@@ -1,40 +1,41 @@
-    * {
+    .markdown-surface, .markdown-surface * {
       box-sizing: border-box;
       margin: 0;
       padding: 0;
     }
 
-    body {
+    .markdown-surface {
       font-family: Inter, system-ui, -apple-system, sans-serif;
       background: #1a1a2e;
       color: #e0e0e8;
       padding: 24px;
+      min-height: 100vh;
       line-height: 1.6;
     }
 
-    .container {
+    .markdown-surface .container {
       max-width: 860px;
       margin: 0 auto;
     }
 
     /* --- Header ----------------------------------------------------------- */
 
-    header {
+    .markdown-surface header {
       margin-bottom: 24px;
     }
 
-    header h1 {
+    .markdown-surface header h1 {
       font-size: 28px;
       font-weight: 700;
       color: #f0f0f8;
       letter-spacing: -0.02em;
     }
 
-    header h1 span {
+    .markdown-surface header h1 span {
       color: #8250df;
     }
 
-    .subtitle {
+    .markdown-surface .subtitle {
       color: #8888a0;
       font-size: 14px;
       margin-top: 4px;
@@ -42,7 +43,7 @@
 
     /* --- Examples bar ----------------------------------------------------- */
 
-    .examples-bar {
+    .markdown-surface .examples-bar {
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
@@ -50,13 +51,13 @@
       align-items: center;
     }
 
-    .examples-label {
+    .markdown-surface .examples-label {
       color: #8888a0;
       font-size: 13px;
       margin-right: 4px;
     }
 
-    .example-btn {
+    .markdown-surface .example-btn {
       padding: 6px 14px;
       background: rgba(130, 80, 223, 0.08);
       color: #c0b8d8;
@@ -68,7 +69,7 @@
       transition: background 0.15s, border-color 0.15s;
     }
 
-    .example-btn:hover {
+    .markdown-surface .example-btn:hover {
       background: rgba(130, 80, 223, 0.16);
       border-color: rgba(130, 80, 223, 0.4);
       color: #e0d8f0;
@@ -76,7 +77,7 @@
 
     /* --- Mode tabs -------------------------------------------------------- */
 
-    .mode-tabs {
+    .markdown-surface .mode-tabs {
       display: flex;
       gap: 2px;
       margin-bottom: 0;
@@ -85,7 +86,7 @@
       padding: 4px 4px 0 4px;
     }
 
-    .mode-tab {
+    .markdown-surface .mode-tab {
       padding: 8px 20px;
       background: transparent;
       color: #8888a0;
@@ -98,19 +99,19 @@
       transition: background 0.15s, color 0.15s;
     }
 
-    .mode-tab:hover {
+    .markdown-surface .mode-tab:hover {
       color: #c0b8d8;
       background: rgba(130, 80, 223, 0.08);
     }
 
-    .mode-tab.active {
+    .markdown-surface .mode-tab.active {
       background: #22223a;
       color: #f0f0f8;
     }
 
     /* --- Editor panel ----------------------------------------------------- */
 
-    .editor-panel {
+    .markdown-surface .editor-panel {
       background: #22223a;
       border: 1px solid rgba(130, 80, 223, 0.15);
       border-top: none;
@@ -120,7 +121,7 @@
 
     /* --- Toolbar ---------------------------------------------------------- */
 
-    .toolbar {
+    .markdown-surface .toolbar {
       display: flex;
       flex-wrap: wrap;
       gap: 4px;
@@ -129,20 +130,20 @@
       align-items: center;
     }
 
-    .toolbar-group {
+    .markdown-surface .toolbar-group {
       display: flex;
       gap: 2px;
       align-items: center;
     }
 
-    .toolbar-divider {
+    .markdown-surface .toolbar-divider {
       width: 1px;
       height: 20px;
       background: rgba(130, 80, 223, 0.15);
       margin: 0 6px;
     }
 
-    .toolbar-btn {
+    .markdown-surface .toolbar-btn {
       padding: 4px 10px;
       background: transparent;
       color: #a0a0b8;
@@ -156,18 +157,18 @@
       line-height: 1.4;
     }
 
-    .toolbar-btn:hover:not(:disabled) {
+    .markdown-surface .toolbar-btn:hover:not(:disabled) {
       background: rgba(130, 80, 223, 0.1);
       color: #e0d8f0;
       border-color: rgba(130, 80, 223, 0.2);
     }
 
-    .toolbar-btn:disabled {
+    .markdown-surface .toolbar-btn:disabled {
       cursor: not-allowed;
       opacity: 0.35;
     }
 
-    .toolbar-btn .shortcut {
+    .markdown-surface .toolbar-btn .shortcut {
       font-size: 11px;
       color: #666680;
       margin-left: 4px;
@@ -175,12 +176,12 @@
 
     /* --- Editor panes ----------------------------------------------------- */
 
-    .editor-pane {
+    .markdown-surface .editor-pane {
       min-height: 400px;
     }
 
     /* Raw mode */
-    #raw-editor {
+    .markdown-surface #raw-editor {
       width: 100%;
       min-height: 400px;
       padding: 16px;
@@ -189,7 +190,7 @@
       border: none;
       outline: none;
       resize: vertical;
-      font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+      font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
       font-size: 14px;
       line-height: 1.6;
       tab-size: 2;
@@ -197,59 +198,59 @@
       overflow-wrap: break-word;
     }
 
-    #raw-editor::placeholder {
+    .markdown-surface #raw-editor::placeholder {
       color: #555568;
     }
 
     /* Block mode container */
-    #block-container {
+    .markdown-surface #block-container {
       padding: 16px;
       min-height: 400px;
     }
 
     /* Preview mode container */
-    #preview-container {
+    .markdown-surface #preview-container {
       padding: 24px 20px;
       min-height: 400px;
     }
 
     /* --- Preview styles --------------------------------------------------- */
 
-    #preview-container h1,
-    #preview-container h2,
-    #preview-container h3,
-    #preview-container h4,
-    #preview-container h5,
-    #preview-container h6 {
+    .markdown-surface #preview-container h1,
+    .markdown-surface #preview-container h2,
+    .markdown-surface #preview-container h3,
+    .markdown-surface #preview-container h4,
+    .markdown-surface #preview-container h5,
+    .markdown-surface #preview-container h6 {
       color: #f0f0f8;
       margin-bottom: 0.5em;
       line-height: 1.3;
     }
 
-    #preview-container h1 { font-size: 2em; font-weight: 700; }
-    #preview-container h2 { font-size: 1.5em; font-weight: 600; border-bottom: 1px solid rgba(130,80,223,0.15); padding-bottom: 0.3em; }
-    #preview-container h3 { font-size: 1.25em; font-weight: 600; }
+    .markdown-surface #preview-container h1 { font-size: 2em; font-weight: 700; }
+    .markdown-surface #preview-container h2 { font-size: 1.5em; font-weight: 600; border-bottom: 1px solid rgba(130,80,223,0.15); padding-bottom: 0.3em; }
+    .markdown-surface #preview-container h3 { font-size: 1.25em; font-weight: 600; }
 
-    #preview-container p {
+    .markdown-surface #preview-container p {
       margin-bottom: 1em;
       color: #c8c8d8;
     }
 
-    #preview-container ul {
+    .markdown-surface #preview-container ul {
       margin-bottom: 1em;
       padding-left: 1.5em;
     }
 
-    #preview-container li {
+    .markdown-surface #preview-container li {
       color: #c8c8d8;
       margin-bottom: 0.25em;
     }
 
-    #preview-container li::marker {
+    .markdown-surface #preview-container li::marker {
       color: #8250df;
     }
 
-    #preview-container pre {
+    .markdown-surface #preview-container pre {
       background: rgba(130, 80, 223, 0.06);
       border: 1px solid rgba(130, 80, 223, 0.12);
       border-radius: 6px;
@@ -258,8 +259,8 @@
       overflow-x: auto;
     }
 
-    #preview-container code {
-      font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+    .markdown-surface #preview-container code {
+      font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
       font-size: 0.9em;
       color: #c3e88d;
     }
@@ -267,26 +268,26 @@
     /* --- Responsive ------------------------------------------------------- */
 
     @media (max-width: 640px) {
-      body {
+      .markdown-surface {
         padding: 12px;
       }
 
-      header h1 {
+      .markdown-surface header h1 {
         font-size: 22px;
       }
 
-      .mode-tab {
+      .markdown-surface .mode-tab {
         padding: 6px 14px;
         font-size: 12px;
       }
 
-      .toolbar-btn .shortcut {
+      .markdown-surface .toolbar-btn .shortcut {
         display: none;
       }
 
-      #raw-editor,
-      #block-container,
-      #preview-container {
+      .markdown-surface #raw-editor,
+      .markdown-surface #block-container,
+      .markdown-surface #preview-container {
         min-height: 300px;
         padding: 12px;
       }

--- a/examples/web/src/features/markdown/route/markdown-client.tsx
+++ b/examples/web/src/features/markdown/route/markdown-client.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { type ReactNode, useCallback, useState } from 'react';
+import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
+import {
+  mountMarkdownApp,
+  type MarkdownEditorRuntime,
+} from '../browser/app';
+import '../browser/styles.css';
+
+const loadMarkdownRuntime: (() => Promise<MarkdownEditorRuntime>) | null = import.meta.env.SSR
+  ? null
+  : () => import('@moonbit/crdt-markdown');
+
+function mountMarkdownRoute(
+  container: HTMLElement,
+  restoredSnapshot: unknown,
+  reportRuntimeError: (error: unknown) => void,
+) {
+  if (loadMarkdownRuntime === null) {
+    throw new Error('The Markdown editor runtime is unavailable on the client');
+  }
+  let controller: ReturnType<typeof mountMarkdownApp> | null = null;
+  let disposed = false;
+  let pendingFocusToken: string | null = null;
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    controller?.dispose();
+    controller = null;
+  }
+
+  void loadMarkdownRuntime()
+    .then((runtime) => {
+      if (disposed) return;
+      controller = mountMarkdownApp(container, restoredSnapshot, runtime);
+      if (
+        pendingFocusToken !== null &&
+        !controller.restoreFocus(pendingFocusToken)
+      ) {
+        container.querySelector<HTMLElement>('[data-route-heading]')
+          ?.focus({ preventScroll: true });
+      }
+    })
+    .catch((error: unknown) => {
+      if (disposed) return;
+      dispose();
+      reportRuntimeError(error);
+    });
+
+  return {
+    snapshot: () => controller?.snapshot() ?? restoredSnapshot,
+    restoreFocus(token: string): boolean {
+      if (controller !== null) return controller.restoreFocus(token);
+      if (!['mode-block', 'mode-raw', 'mode-preview', 'raw-editor'].includes(token)) {
+        return false;
+      }
+      pendingFocusToken = token;
+      return true;
+    },
+    dispose,
+  };
+}
+
+export function MarkdownClient({ children }: { readonly children: ReactNode }) {
+  const [runtimeError, setRuntimeError] = useState<Error | null>(null);
+  const mount = useCallback(
+    (container: HTMLElement, restoredSnapshot: unknown) => mountMarkdownRoute(
+      container,
+      restoredSnapshot,
+      (error) => setRuntimeError(
+        error instanceof Error ? error : new Error(String(error)),
+      ),
+    ),
+    [],
+  );
+  if (runtimeError !== null) throw runtimeError;
+
+  return (
+    <ImperativeDemoHost
+      demoId="markdown"
+      mount={mount}
+      className="markdown-surface"
+    >
+      {children}
+    </ImperativeDemoHost>
+  );
+}

--- a/examples/web/src/features/markdown/route/markdown-route.tsx
+++ b/examples/web/src/features/markdown/route/markdown-route.tsx
@@ -1,0 +1,17 @@
+import markdownDocument from '../../../../markdown.html?raw';
+import { MarkdownClient } from './markdown-client';
+
+const MARKDOWN_SHELL_PATTERN = /<!-- markdown-shell:start -->([\s\S]*?)<!-- markdown-shell:end -->/;
+
+export function MarkdownRoute() {
+  const shellMatch = MARKDOWN_SHELL_PATTERN.exec(markdownDocument);
+  if (shellMatch === null) {
+    throw new Error('The canonical Markdown document shell is unavailable');
+  }
+
+  return (
+    <MarkdownClient>
+      <div dangerouslySetInnerHTML={{ __html: shellMatch[1] }} />
+    </MarkdownClient>
+  );
+}

--- a/examples/web/src/pages/markdown.tsx
+++ b/examples/web/src/pages/markdown.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { MarkdownRoute } from '../features/markdown/route/markdown-route';
 
 export default function Markdown() {
-  return <DemoPlaceholder demoId="markdown" />;
+  return <MarkdownRoute />;
 }

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -4,6 +4,8 @@
 
 import { test, expect, type Page } from '@playwright/test';
 
+const markdownEditorUrl = process.env.MARKDOWN_EDITOR_URL ?? '/markdown.html';
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -34,8 +36,14 @@ async function loadExample(page: Page, name: 'Hello' | 'Blog' | 'List' | 'Code')
 // ---------------------------------------------------------------------------
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/markdown.html');
+  await page.goto(markdownEditorUrl);
   await expect(page.locator('#block-container .block-text').first()).toBeVisible();
+  if (markdownEditorUrl === '/markdown') {
+    await expect(page.locator('[data-markdown-ready]'))
+      .toHaveAttribute('data-markdown-ready', 'true');
+    await expect(page.locator('[data-route-lifecycle-ready]'))
+      .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  }
 });
 
 test.describe('Markdown Block Editor', () => {

--- a/examples/web/waku-tests/markdown-route.spec.ts
+++ b/examples/web/waku-tests/markdown-route.spec.ts
@@ -1,0 +1,229 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const DEFAULT_HEADING = '# Hello World';
+
+async function waitForMarkdownMount(page: Page): Promise<void> {
+  await expect(page.locator('[data-markdown-ready]'))
+    .toHaveAttribute('data-markdown-ready', 'true');
+  await expect(page.locator('#block-container .block-text').first()).toBeVisible();
+}
+
+async function switchMode(
+  page: Page,
+  mode: 'Block' | 'Raw' | 'Preview',
+): Promise<void> {
+  await page.getByRole('button', { name: mode, exact: true }).click();
+  const pane = mode === 'Block'
+    ? '#block-pane'
+    : mode === 'Raw'
+      ? '#raw-pane'
+      : '#preview-pane';
+  await expect(page.locator(pane)).toBeVisible();
+}
+
+test('keeps the server-rendered Markdown controls inert without client JavaScript', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    const response = await page.goto('/markdown');
+    expect(response?.ok()).toBe(true);
+    await expect(page.getByRole('heading', { name: '▱ Markdown Editor' })).toBeVisible();
+    await expect(page.locator('[data-markdown-ready]')).toHaveAttribute('inert', '');
+    await expect(page.locator('[data-markdown-ready]'))
+      .toHaveAttribute('data-markdown-ready', 'false');
+  } finally {
+    await context.close();
+  }
+});
+
+test('reports Markdown runtime load failures through the route error boundary', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  let failedRuntimeRequests = 0;
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.route(/crdt[-_]markdown/, (route) => {
+    failedRuntimeRequests += 1;
+    return route.abort('failed');
+  });
+
+  await page.goto('/markdown');
+
+  await expect(page.getByRole('heading', {
+    name: 'This demo could not be displayed',
+  })).toBeFocused();
+  expect(failedRuntimeRequests).toBeGreaterThan(0);
+  await expect(page.locator('[data-imperative-demo-host="markdown"]')).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});
+
+test('restores document text and stable control focus while rebuilding mode state', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Markdown Editor/ }).click();
+  await waitForMarkdownMount(page);
+  await expect(page).toHaveURL(/\/markdown$/);
+  await expect(page.getByRole('heading', { name: '▱ Markdown Editor' })).toBeFocused();
+
+  const source = '# Route memory\n\nOnly document text returns.\n';
+  await switchMode(page, 'Raw');
+  await page.locator('#raw-editor').fill(source);
+  await switchMode(page, 'Block');
+  const previewTab = page.locator('[data-route-focus="mode-preview"]');
+  await previewTab.focus();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForMarkdownMount(page);
+
+  await expect(page.locator('#block-pane')).toBeVisible();
+  await expect(page.locator('#raw-pane')).toBeHidden();
+  await expect(page.locator('.mode-tab.active')).toHaveText('Block');
+  await expect(page.locator('.block-textarea')).toHaveCount(0);
+  await expect(previewTab).toBeFocused();
+  await switchMode(page, 'Raw');
+  await expect(page.locator('#raw-editor')).toHaveValue(source);
+});
+
+test('falls back to the heading when the prior pane is rebuilt', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Markdown Editor/ }).click();
+  await waitForMarkdownMount(page);
+  await switchMode(page, 'Raw');
+  const rawEditor = page.locator('#raw-editor');
+  const source = '# Pending route snapshot\n\nCaptured before the frame.\n';
+  await rawEditor.evaluate((editor: HTMLTextAreaElement, nextSource) => {
+    const pendingFrameId = 2_147_481_999;
+    const originalRequest = window.requestAnimationFrame;
+    window.requestAnimationFrame = (() => pendingFrameId) as typeof window.requestAnimationFrame;
+    editor.value = nextSource;
+    editor.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      data: nextSource,
+      inputType: 'insertText',
+    }));
+    window.requestAnimationFrame = originalRequest;
+  }, source);
+  await expect(rawEditor).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForMarkdownMount(page);
+
+  await expect(page.getByRole('heading', { name: '▱ Markdown Editor' })).toBeFocused();
+  await expect(page.locator('#block-pane')).toBeVisible();
+  await switchMode(page, 'Raw');
+  await expect(rawEditor).toHaveValue(source);
+});
+
+test('reload clears route memory and reconstructs Markdown internals', async ({ page }) => {
+  await page.goto('/markdown');
+  await waitForMarkdownMount(page);
+  await switchMode(page, 'Raw');
+  await page.locator('#raw-editor').fill('# Transient\n');
+  await switchMode(page, 'Preview');
+
+  await page.reload();
+  await waitForMarkdownMount(page);
+
+  await expect(page.locator('#block-pane')).toBeVisible();
+  await expect(page.locator('.mode-tab.active')).toHaveText('Block');
+  await expect(page.locator('.block-textarea')).toHaveCount(0);
+  await switchMode(page, 'Raw');
+  await expect(page.locator('#raw-editor')).toHaveValue(new RegExp(DEFAULT_HEADING));
+  await expect(page.locator('#raw-editor')).not.toHaveValue(/# Transient/);
+});
+
+test('repeated route cycles release listeners and pending frames', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.evaluate(() => {
+    const tracked = { keydown: 0, pointerup: 0 };
+    const originalAdd = document.addEventListener.bind(document);
+    document.addEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      if ((type !== 'keydown' && type !== 'pointerup') || listener === null) {
+        originalAdd(type, listener, options);
+        return;
+      }
+      const wrapped = (event: Event) => {
+        tracked[type] += 1;
+        if (typeof listener === 'function') listener.call(document, event);
+        else listener.handleEvent(event);
+      };
+      originalAdd(type, wrapped, options);
+    }) as typeof document.addEventListener;
+    (window as Window & { __markdownListenerCalls?: typeof tracked })
+      .__markdownListenerCalls = tracked;
+  });
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    await page.getByRole('link', { name: /Markdown Editor/ }).click();
+    await waitForMarkdownMount(page);
+    await expect(page.locator('[data-imperative-demo-host="markdown"]')).toHaveCount(1);
+    await expect(page.locator('.block-editor')).toHaveCount(1);
+    await page.locator('#block-container .block').first().click();
+    await expect(page.locator('.block-textarea')).toBeVisible();
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('[data-imperative-demo-host="markdown"]')).toHaveCount(0);
+    const callsBefore = await page.evaluate(
+      () => ({ ...(window as Window & {
+        __markdownListenerCalls?: { keydown: number; pointerup: number };
+      }).__markdownListenerCalls! }),
+    );
+    await page.evaluate(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '1', ctrlKey: true }));
+      document.dispatchEvent(new PointerEvent('pointerup'));
+    });
+    expect(await page.evaluate(
+      () => (window as Window & {
+        __markdownListenerCalls?: { keydown: number; pointerup: number };
+      }).__markdownListenerCalls,
+    )).toEqual(callsBefore);
+  }
+
+  await page.getByRole('link', { name: /Markdown Editor/ }).click();
+  await waitForMarkdownMount(page);
+  await switchMode(page, 'Raw');
+  await page.evaluate(() => {
+    const frameId = 2_147_482_000;
+    const originalRequest = window.requestAnimationFrame;
+    const originalCancel = window.cancelAnimationFrame;
+    (window as Window & { __markdownCancelledFrames?: number[] })
+      .__markdownCancelledFrames = [];
+    window.requestAnimationFrame = (() => frameId) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = ((candidate: number) => {
+      if (candidate === frameId) {
+        (window as Window & { __markdownCancelledFrames?: number[] })
+          .__markdownCancelledFrames?.push(candidate);
+        return;
+      }
+      originalCancel(candidate);
+    }) as typeof window.cancelAnimationFrame;
+    const editor = document.querySelector<HTMLTextAreaElement>('#raw-editor');
+    if (editor === null) throw new Error('Raw editor is unavailable');
+    editor.value = '# Pending frame';
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    window.requestAnimationFrame = originalRequest;
+    window.history.back();
+  });
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.evaluate(
+    () => (window as Window & { __markdownCancelledFrames?: number[] })
+      .__markdownCancelledFrames,
+  )).toEqual([2_147_482_000]);
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes #975

## Summary

- serve the existing Markdown Block/Raw/Preview editor at `/markdown` through the shared imperative route host while retaining `/markdown.html`
- make the browser controller root-scoped and session-owned, with document-text-only route snapshots, stable focus restoration, and deterministic teardown of the MoonBit handle, adapters, listeners, and pending animation frames
- keep the generated Markdown runtime client-only, scope shared editor CSS to its owning surface, and add dual-run lifecycle/error/no-JS coverage plus migration docs

## Validation

- `npm run build:waku`
- `npm run check:waku-bundles`
- `npm run check:waku-types`
- `npm run test:waku:workerd`
- `npm run typecheck`
- `npm run check:boundaries`
- `npm run test:boundaries` (18 passed)
- `npm run test:foundation` (28 passed)
- `CI=1 npm run test:waku:e2e` (76 passed)
- `CI=1 npx playwright test --config=playwright.waku.config.ts waku-tests/markdown-route.spec.ts --workers=1` (6 passed)
- `CI=1 npx playwright test --config=playwright.config.ts --workers=1` (103 passed, 2 expected skipped)
- `moon check`
- `moon test` (3,932 wasm-gc, 1,949 JS, 70 native passed)
- `moon info`
- `moon fmt`
- `git diff --check`

## Reuse check

- Reused project APIs: `ImperativeDemoHost`, `MountedImperativeSession`, `BlockInput`, `MarkdownPreview`, the existing Markdown FFI surface, and the established JSON route/client composition pattern.
- MoonBit core APIs checked: no MoonBit code, helper, type, or generated interface changed in this stage, so no MoonBit core API was needed.
- Existing APIs checked but not used: `useRouteSnapshot` is React-owned and does not fit the imperative controller boundary; `HTMLAdapter` and `DecorationOverlay` do not model the Markdown block/preview lifecycle.
- New private helper: `mountMarkdownRoute` owns only asynchronous client runtime loading and adapts it to the synchronous imperative-session contract.
- Remaining imperative code is limited to DOM wiring, event/listener ownership, animation-frame scheduling, focus, and external handle/adapter disposal; document transformation and snapshot choice remain deterministic and capability-explicit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a routed Markdown editor at `/markdown` with Block, Raw, and Preview modes.
  * Preserves editor content and focus during navigation, reloads, and mode changes.
  * Added runtime error handling with a user-facing error state.

* **Bug Fixes**
  * Improved editor cleanup and prevented stale interactions or pending updates after switching modes or leaving the page.
  * Scoped Markdown and block editor styles to prevent unintended page-wide effects.

* **Tests & Documentation**
  * Added coverage for routing, restoration, failures, cleanup, and runtime readiness.
  * Updated migration documentation for the Markdown route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->