### PR TITLE
feat(web): migrate Mini-ML and Memo to Waku

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -662,7 +662,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
   Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#975 migrate Journey, Posts, JSON, and Markdown to `/journey`, `/posts`, `/json`, and `/markdown`. Vite remains the default, and no redirect or production deployment has migrated.
+  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#976 migrate Journey, Posts, JSON, Markdown, Mini-ML, and Memo to `/journey`, `/posts`, `/json`, `/markdown`, `/ml`, and `/memo`. Memo exposes its provider controls only in development, while production renders the explicit local-only state. Vite remains the default, and no redirect or production deployment has migrated.
   Exit: the plan's Stage 12 gate passes after production cutover is proven.
 
 ## 22. SDEG Lifecycle

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -121,10 +121,10 @@ Stage 6 remains pre-production. Vite and `markdown.html` remain the defaults and
 
 - `src/features/lambda/route/{lambda-route,lambda-client}.tsx` — server/client seam that reuses the legacy Mini-ML shell, loads Lambda and Graphviz from client-only dynamic imports, and mounts at `/ml` through the imperative host.
 - `src/features/lambda/browser/{editor,mount}.ts` — root-scoped Vite/Waku controller that snapshots source text only and idempotently releases the MoonBit handle, `HTMLAdapter`, `DecorationOverlay`, listeners, animation frame, analysis timer, and request.
-- `src/features/memo/route/{memo-route,memo-client}.tsx` — development route seam that shares the generated Lambda artifact specifier without a cross-feature import; production tree-shakes the client editor and renders a local-only state without credential/provider controls.
+- `src/features/memo/route/{memo-route,memo-client}.tsx` — development route seam that shares the generated Lambda artifact specifier without a cross-feature import; a production-first route gate never imports the development shell/client and renders a local-only state without credential/provider controls.
 - `src/features/memo/browser/{app,mount,view}.ts` — root-scoped controller that snapshots draft, instruction, and completed proposal only; API key and request timing remain ephemeral, listeners are aborted, and late provider responses are invalidated after disposal.
 - `tests/{lambda-editor,memo-editor}.spec.ts` — existing behavior and local-validation contracts, now run against both legacy Vite URLs and canonical Waku routes.
-- `waku-tests/{lambda-route,memo-route}.spec.ts` — inert SSR shells, runtime failures, allowlisted route memory, focus, reload reset, and live-resource disposal coverage. The production bundle/Worker checks prove Mini-ML has no AST endpoint request and Memo has no credential surface.
+- `waku-tests/{lambda-route,memo-route}.spec.ts` — inert SSR shells, runtime failures, allowlisted route memory, focus, reload reset, and live-resource disposal coverage. The production bundle/Worker checks prove Mini-ML has no AST endpoint request and Memo has no development shell, client module, or credential surface; provider fingerprints are permitted only inside the shared Lambda artifact required by Mini-ML.
 
 Stage 7 remains pre-production. Vite `/`/`index.html` and `/memo.html` remain the defaults and are retained. No compatibility redirect, provider proxy, MoonBit API change, or production deployment is active.
 

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -6,10 +6,10 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 | Surface | HTML | Browser entry | Feature-owned source | Styles | Runtime and tests |
 |---|---|---|---|---|---|
-| Lambda | `index.html` | `src/entries/lambda.ts` | `features/lambda/browser/{mount,editor,ast-grep-runner}.ts` (uses shared decoration overlay) | `features/lambda/browser/styles.css`, imported by `mount.ts` | Browser + generated MoonBit Lambda/Graphviz; `tests/lambda-editor.spec.ts` |
+| Lambda | `index.html` | `src/entries/lambda.ts` | `features/lambda/browser/{mount,editor,ast-grep-runner}.ts`, `features/lambda/route/{lambda-route,lambda-client}.tsx` (uses shared decoration overlay) | `features/lambda/browser/styles.css`, imported by Vite and Waku composition | Browser + generated MoonBit Lambda/Graphviz; `tests/lambda-editor.spec.ts`, `waku-tests/lambda-route.spec.ts` |
 | JSON | `json.html` | `src/entries/json.ts` | `features/json/browser/{editor,mount}.ts` (uses shared decoration overlay) | `features/json/browser/styles.css`, imported by `mount.ts` | Browser + generated MoonBit JSON; `tests/json-editor.spec.ts` |
 | Markdown | `markdown.html` | `src/entries/markdown.ts` | `features/markdown/browser/{app,mount,sentinels}.ts`; `features/markdown/route/{markdown-route,markdown-client}.tsx` | `features/markdown/browser/styles.css`, imported by Vite and Waku composition; adapter CSS remains adapter-owned | Browser + generated MoonBit Markdown; `tests/markdown-editor.spec.ts`, `waku-tests/markdown-route.spec.ts` |
-| Memo | `memo.html` | `src/entries/memo.ts` | `features/memo/core/edit-actions.ts`, `features/memo/browser/{app,mount,view}.ts` | `features/memo/browser/styles.css`, imported by `mount.ts` | Browser + generated MoonBit Lambda; `tests/memo-editor.spec.ts` |
+| Memo | `memo.html` | `src/entries/memo.ts` | `features/memo/core/edit-actions.ts`, `features/memo/browser/{app,mount,view}.ts`, `features/memo/route/{memo-route,memo-client}.tsx` | `features/memo/browser/styles.css`, imported by Vite and development Waku composition | Development browser + generated MoonBit Lambda; production local-only state; `tests/memo-editor.spec.ts`, `waku-tests/memo-route.spec.ts` |
 | Posts | `posts.html` | `src/entries/posts.ts` | `features/posts/core/{posts,post-events,post-retrieval}.ts`, `features/posts/browser/{app,mount,post-events,post-store,view}.ts` | `features/posts/browser/styles.css`, imported by `mount.ts` | Browser persistence shell around deterministic retrieval logic; `tests/post-app.spec.ts` |
 | Resume/PKE | `resume.html` | `src/entries/resume.ts` | `features/resume/browser/app.tsx`, `features/resume/browser/components/*`, `features/resume/core/session.ts`, `features/resume/protocol/chat.ts` | `features/resume/browser/styles.css`, imported by `app.tsx` | Browser React + `server/vite/resume-chat.ts` local chat relay; `tests/pi-resume.spec.ts` |
 | GenUI | `genui.html` | `src/entries/genui.js` | `features/genui/browser/mount.js`, deterministic `features/genui/core/*` (fixtures, schema, flow, recorded candidates, data, spikes), `server/genui/feasibility-provider.js`, and `server/vite/genui-feasibility.ts` | `features/genui/browser/styles.css`, imported by `mount.js`; `src/tailwind.css` remains the GenUI Tailwind input | Browser + generated MoonBit JSX, deterministic feasibility core, and a server-only study relay; `tests/genui.spec.ts`, feasibility suites, colocated core/server Node tests, study scripts |
@@ -20,7 +20,7 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 ## Runtime and generated dependencies
 
 - Browser code is TypeScript/TSX/JS bundled by Vite. React and the AI SDK are used by Resume/PKE; GenUI is plain browser JavaScript plus the generated JSX FFI.
-- `server/vite/ast-grep.ts` owns the Lambda-only `/api/ast-grep` development relay. `vite-plugin-moonbit.ts` owns MoonBit build, virtual-module, and HMR behavior only.
+- `server/vite/ast-grep.ts` owns the Lambda-only `/api/ast-grep` development relay for Vite and Waku. Its serve-only plugin is absent from production, where Mini-ML returns no analysis matches without a request. `vite-plugin-moonbit.ts` owns MoonBit build, virtual-module, and HMR behavior only.
 - `server/vite/resume-chat.ts` owns the local Resume/PKE provider relay and consumes the Resume protocol surface. `server/vite/genui-feasibility.ts` owns the local GenUI study relay and imports `server/genui/feasibility-provider.js`; it consumes only GenUI core fixtures and recorded candidates. These Vite adapters are not browser entry dependencies.
 - `signaling-server.js`, `signaling-worker.js`, `wrangler-signaling.toml`, and `wrangler.jsonc` are deployment/integration shells outside the eight browser entry graphs.
 
@@ -45,11 +45,11 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 ## Current structural exceptions and debt
 
-Most of the source tree is intentionally flat: feature ownership is inferred from filenames rather than represented by `src/entries`, `src/features`, and `src/shared` directories. Resume/PKE, Posts, Memo, JSON, Markdown, GenUI, and GenUI Possibilities use the target entry/feature layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime. Styles are partly per-surface and partly global/adapter-owned. These are inventory facts, not exemptions from the boundary checker.
+The active surfaces use the target `src/entries`, `src/features`, and `src/shared` ownership layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime without importing Lambda feature internals. Styles are partly per-surface and partly adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku migration (pre-production, #970–#975 Stages 0–6)
+## Waku migration (pre-production, #970–#976 Stages 0–7)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–6 migrate Journey, Posts, JSON, and Markdown while retaining every old HTML entry.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–7 migrate Journey, Posts, JSON, Markdown, Mini-ML, and Memo while retaining every old HTML entry.
 
 ### Stage 0–1 configuration and artifacts
 
@@ -65,7 +65,9 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 
 - `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
 - `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
-- `src/pages/{ml,memo,resume,genui}.tsx` — four canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/{resume,genui}.tsx` — two canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/ml.tsx` — canonical Mini-ML route; composes its feature-owned controller through the shared imperative host.
+- `src/pages/memo.tsx` — canonical Memo route; composes the local client editor in development and the explicit unavailable state in production.
 - `src/pages/journey.tsx` — canonical Journey route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/posts.tsx` — canonical Posts route; composes the feature-owned route surface through the shared imperative host.
 - `src/pages/json.tsx` — canonical JSON route; composes the feature-owned editor controller through the shared imperative host.
@@ -115,6 +117,17 @@ Stage 5 remains pre-production. Vite and `json.html` remain the defaults and are
 
 Stage 6 remains pre-production. Vite and `markdown.html` remain the defaults and are retained. No Markdown compatibility redirect is active, and no Markdown model, toolbar, mode semantics, or MoonBit API changed.
 
+### Stage 7 — Mini-ML and Memo
+
+- `src/features/lambda/route/{lambda-route,lambda-client}.tsx` — server/client seam that reuses the legacy Mini-ML shell, loads Lambda and Graphviz from client-only dynamic imports, and mounts at `/ml` through the imperative host.
+- `src/features/lambda/browser/{editor,mount}.ts` — root-scoped Vite/Waku controller that snapshots source text only and idempotently releases the MoonBit handle, `HTMLAdapter`, `DecorationOverlay`, listeners, animation frame, analysis timer, and request.
+- `src/features/memo/route/{memo-route,memo-client}.tsx` — development route seam that shares the generated Lambda artifact specifier without a cross-feature import; production tree-shakes the client editor and renders a local-only state without credential/provider controls.
+- `src/features/memo/browser/{app,mount,view}.ts` — root-scoped controller that snapshots draft, instruction, and completed proposal only; API key and request timing remain ephemeral, listeners are aborted, and late provider responses are invalidated after disposal.
+- `tests/{lambda-editor,memo-editor}.spec.ts` — existing behavior and local-validation contracts, now run against both legacy Vite URLs and canonical Waku routes.
+- `waku-tests/{lambda-route,memo-route}.spec.ts` — inert SSR shells, runtime failures, allowlisted route memory, focus, reload reset, and live-resource disposal coverage. The production bundle/Worker checks prove Mini-ML has no AST endpoint request and Memo has no credential surface.
+
+Stage 7 remains pre-production. Vite `/`/`index.html` and `/memo.html` remain the defaults and are retained. No compatibility redirect, provider proxy, MoonBit API change, or production deployment is active.
+
 Validation runs in parallel with the Vite pipeline:
 
 - `npm run build:waku` — Waku production build from prebuilt MoonBit artifacts.
@@ -125,7 +138,7 @@ Validation runs in parallel with the Vite pipeline:
 - `npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env preview` — preview Waku Worker bundle dry-run.
 - CI jobs `waku-build`, `waku-e2e`, and `waku-workerd` run alongside the existing Vite jobs until Stage 12 (Vite retirement).
 
-Both development modes reuse the same coordinator, which starts one root MoonBit watcher rather than one watcher per virtual module. `npm run dev:dual` runs Vite and Waku side by side behind that single watcher. Generated modules stay client-only on the Waku side; the probe loads all five, while the migrated JSON and Markdown routes load only their own runtime on demand.
+Both development modes reuse the same coordinator, which starts one root MoonBit watcher rather than one watcher per virtual module. `npm run dev:dual` runs Vite and Waku side by side behind that single watcher. Generated modules stay client-only on the Waku side; the probe loads all five, JSON and Markdown load their own runtimes on demand, and Mini-ML/Memo share the Lambda artifact specifier without sharing feature internals.
 
 ## Boundary vocabulary and allowed direction
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,9 +5,9 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Waku migration (in progress, #975)
+## Waku migration (in progress, #976)
 
-A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–6 migrate Journey Proposals, Posts, JSON, and Markdown to `/journey`, `/posts`, `/json`, and `/markdown`. JSON and Markdown snapshot source text only and rebuild their live MoonBit controller state after navigation; Markdown keeps its within-demo mode and selection behavior. All four use the imperative host and retain their legacy HTML entries; the other four canonical demo routes remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–7 migrate Journey Proposals, Posts, JSON, Markdown, Mini-ML, and Memo to `/journey`, `/posts`, `/json`, `/markdown`, `/ml`, and `/memo`. The editor routes restore only their allowlisted document state and rebuild generated-runtime internals after navigation. Memo keeps its browser credential flow in development only; the production Worker renders an explicit local-only state without provider controls. All six retain their legacy HTML entries, while Resume and GenUI remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
 
 ## Development
 

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -6,11 +6,13 @@
   <title>Mini-ML CRDT Editor</title>
 
 </head>
-<body>
+<body class="lambda-surface">
+  <!-- lambda-shell:start -->
   <div class="container">
-    <h1>Mini-ML CRDT Editor</h1>
+    <h1 data-route-heading tabindex="-1">Mini-ML CRDT Editor</h1>
     <p class="subtitle">Collaborative real-time editor with live evaluation</p>
 
+    <div class="lambda-app" inert data-lambda-ready="false">
     <div id="status" class="status">Loading JavaScript...</div>
 
     <div class="panel network-panel">
@@ -85,7 +87,7 @@ IfThenElse  ::= 'if' Expression 'then' Expression 'else' Expression</pre>
         <button class="example-btn" data-example="fn choose(x : Int) { if x then {&#10;  x + 1&#10;} else {&#10;  42&#10;} }&#10;let a = choose 0&#10;let b = choose 5&#10;a + b">Conditional</button>
         <button class="example-btn" data-example="fn compose(f : Int -> Int, g : Int -> Int, x : Int) {&#10;  f (g x)&#10;}&#10;fn double(x : Int) { x + x }&#10;fn inc(x : Int) { x + 1 }&#10;let f = compose inc double&#10;f 5">Pipeline</button>
       </div>
-      <div id="editor" contenteditable="plaintext-only" spellcheck="false"></div>
+      <div id="editor" contenteditable="plaintext-only" spellcheck="false" data-route-focus="editor"></div>
     </div>
 
     <div class="info-panel">
@@ -110,7 +112,9 @@ IfThenElse  ::= 'if' Expression 'then' Expression 'else' Expression</pre>
         </div>
       </div>
     </div>
+    </div>
   </div>
+  <!-- lambda-shell:end -->
 
   <script type="module" src="/src/entries/lambda.ts"></script>
 </body>

--- a/examples/web/memo.html
+++ b/examples/web/memo.html
@@ -6,10 +6,12 @@
   <title>Canopy Memo — AI Editor</title>
 
 </head>
-<body>
+<body class="memo-surface">
+  <!-- memo-shell:start -->
   <div class="container">
-    <h1>Canopy Memo</h1>
+    <h1 data-route-heading tabindex="-1">Canopy Memo</h1>
     <p class="subtitle">AI-powered text editor — typo correction &amp; structured edits</p>
+    <div class="memo-app" inert data-memo-ready="false">
     <div style="background:#2a1a1a;border:1px solid #ff537044;border-radius:6px;padding:10px 14px;margin-bottom:16px;font-size:12px;color:#ff8a80;">
       <strong>Local demo only.</strong> API key is sent directly from your browser to Google.
       Do not deploy this page publicly. Production use requires a server-side proxy.
@@ -19,12 +21,12 @@
       <input type="password" id="api-key" placeholder="Enter your API key (stored in memory only)">
     </div>
     <div class="editor-area">
-      <textarea id="memo" placeholder="Type or paste your text here..."></textarea>
+      <textarea id="memo" data-route-focus="memo" placeholder="Type or paste your text here..."></textarea>
       <div class="toolbar">
         <button id="fix-typos-btn" class="btn btn-primary">Fix Typos</button>
       </div>
       <div class="instruction-row">
-        <input type="text" id="instruction" placeholder="Edit instruction (e.g. 3行目をもっと丁寧にして)">
+        <input type="text" id="instruction" data-route-focus="instruction" placeholder="Edit instruction (e.g. 3行目をもっと丁寧にして)">
         <button id="edit-btn" class="btn btn-secondary">Edit</button>
       </div>
       <div class="status-bar" id="status"></div>
@@ -46,7 +48,9 @@
         <button id="reject-btn" class="btn btn-secondary">Reject</button>
       </div>
     </div>
+    </div>
   </div>
+  <!-- memo-shell:end -->
   <script type="module" src="/src/entries/memo.ts"></script>
 </body>
 </html>

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -7,6 +7,7 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 
 process.env.GENUI_POSSIBILITIES_URL = '/journey';
 process.env.POSTS_URL = '/posts';
+process.env.LAMBDA_EDITOR_URL = '/ml';
 process.env.JSON_EDITOR_URL = '/json';
 process.env.MARKDOWN_EDITOR_URL = '/markdown';
 
@@ -15,6 +16,7 @@ export default defineConfig({
   testMatch: [
     'waku-tests/**/*.spec.ts',
     'tests/genui-possibilities.spec.ts',
+    'tests/lambda-editor.spec.ts',
     'tests/json-editor.spec.ts',
     'tests/markdown-editor.spec.ts',
     'tests/post-app.spec.ts',

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -8,6 +8,7 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 process.env.GENUI_POSSIBILITIES_URL = '/journey';
 process.env.POSTS_URL = '/posts';
 process.env.LAMBDA_EDITOR_URL = '/ml';
+process.env.MEMO_EDITOR_URL = '/memo';
 process.env.JSON_EDITOR_URL = '/json';
 process.env.MARKDOWN_EDITOR_URL = '/markdown';
 
@@ -17,6 +18,7 @@ export default defineConfig({
     'waku-tests/**/*.spec.ts',
     'tests/genui-possibilities.spec.ts',
     'tests/lambda-editor.spec.ts',
+    'tests/memo-editor.spec.ts',
     'tests/json-editor.spec.ts',
     'tests/markdown-editor.spec.ts',
     'tests/post-app.spec.ts',

--- a/examples/web/scripts/check-waku-bundles.mjs
+++ b/examples/web/scripts/check-waku-bundles.mjs
@@ -10,8 +10,31 @@ const generatedModules = [
   { id: '@moonbit/graphviz', fingerprint: 'render_dot_to_svg' },
 ];
 
-const forbiddenProductionClientRequests = [
-  { capability: 'Mini-ML AST Grep', requestPath: '/api/ast-grep' },
+const forbiddenProductionClientArtifacts = [
+  { capability: 'Mini-ML AST Grep request', fingerprint: '/api/ast-grep' },
+  { capability: 'Memo development shell', fingerprint: 'data-memo-ready' },
+  {
+    capability: 'Memo client module',
+    fingerprint: 'The Memo runtime is unavailable on the client',
+  },
+  // Mini-ML intentionally reuses the monolithic Lambda artifact. Provider
+  // fingerprints are allowed only inside that generated bundle, never in
+  // route/client glue that would make the production Memo capability reachable.
+  {
+    capability: 'Memo provider URL',
+    fingerprint: 'https://generativelanguage.googleapis.com/v1beta/models/',
+    allowedBundleFingerprint: 'assemble_lambda_handle',
+  },
+  {
+    capability: 'Memo provider function',
+    fingerprint: 'canopy_llm_fix_typos',
+    allowedBundleFingerprint: 'assemble_lambda_handle',
+  },
+  {
+    capability: 'Memo provider function',
+    fingerprint: 'canopy_llm_edit',
+    allowedBundleFingerprint: 'assemble_lambda_handle',
+  },
 ];
 
 export function inspectWakuBundles({ serverBundles, clientBundles }) {
@@ -25,13 +48,17 @@ export function inspectWakuBundles({ serverBundles, clientBundles }) {
       !clientBundles.some(({ source }) => source.includes(fingerprint)),
     )
     .map(({ id }) => id);
-  const productionClientRequestLeaks = forbiddenProductionClientRequests.flatMap(({
+  const productionClientArtifactLeaks = forbiddenProductionClientArtifacts.flatMap(({
     capability,
-    requestPath,
+    fingerprint,
+    allowedBundleFingerprint,
   }) => clientBundles
-    .filter(({ source }) => source.includes(requestPath))
-    .map(({ name }) => ({ capability, requestPath, file: name })));
-  return { serverLeaks, missingClientModules, productionClientRequestLeaks };
+    .filter(({ source }) =>
+      source.includes(fingerprint) &&
+      !(allowedBundleFingerprint && source.includes(allowedBundleFingerprint))
+    )
+    .map(({ name }) => ({ capability, fingerprint, file: name })));
+  return { serverLeaks, missingClientModules, productionClientArtifactLeaks };
 }
 
 function javascriptBundlesBelow(root) {
@@ -55,13 +82,13 @@ function main() {
   for (const id of result.missingClientModules) {
     console.error(`Generated module is missing from Waku client bundles: ${id}`);
   }
-  for (const { capability, requestPath, file } of result.productionClientRequestLeaks) {
-    console.error(`${capability} production request ${requestPath} leaked into client bundle: ${file}`);
+  for (const { capability, fingerprint, file } of result.productionClientArtifactLeaks) {
+    console.error(`${capability} fingerprint ${fingerprint} leaked into production client bundle: ${file}`);
   }
   if (
     result.serverLeaks.length > 0 ||
     result.missingClientModules.length > 0 ||
-    result.productionClientRequestLeaks.length > 0
+    result.productionClientArtifactLeaks.length > 0
   ) {
     process.exitCode = 1;
   } else {

--- a/examples/web/scripts/check-waku-bundles.mjs
+++ b/examples/web/scripts/check-waku-bundles.mjs
@@ -10,6 +10,10 @@ const generatedModules = [
   { id: '@moonbit/graphviz', fingerprint: 'render_dot_to_svg' },
 ];
 
+const forbiddenProductionClientRequests = [
+  { capability: 'Mini-ML AST Grep', requestPath: '/api/ast-grep' },
+];
+
 export function inspectWakuBundles({ serverBundles, clientBundles }) {
   const serverLeaks = generatedModules.flatMap(({ id, fingerprint }) =>
     serverBundles
@@ -21,7 +25,13 @@ export function inspectWakuBundles({ serverBundles, clientBundles }) {
       !clientBundles.some(({ source }) => source.includes(fingerprint)),
     )
     .map(({ id }) => id);
-  return { serverLeaks, missingClientModules };
+  const productionClientRequestLeaks = forbiddenProductionClientRequests.flatMap(({
+    capability,
+    requestPath,
+  }) => clientBundles
+    .filter(({ source }) => source.includes(requestPath))
+    .map(({ name }) => ({ capability, requestPath, file: name })));
+  return { serverLeaks, missingClientModules, productionClientRequestLeaks };
 }
 
 function javascriptBundlesBelow(root) {
@@ -45,7 +55,14 @@ function main() {
   for (const id of result.missingClientModules) {
     console.error(`Generated module is missing from Waku client bundles: ${id}`);
   }
-  if (result.serverLeaks.length > 0 || result.missingClientModules.length > 0) {
+  for (const { capability, requestPath, file } of result.productionClientRequestLeaks) {
+    console.error(`${capability} production request ${requestPath} leaked into client bundle: ${file}`);
+  }
+  if (
+    result.serverLeaks.length > 0 ||
+    result.missingClientModules.length > 0 ||
+    result.productionClientRequestLeaks.length > 0
+  ) {
     process.exitCode = 1;
   } else {
     console.log('Waku generated-module bundle boundary: OK');

--- a/examples/web/scripts/smoke-waku-worker.sh
+++ b/examples/web/scripts/smoke-waku-worker.sh
@@ -31,10 +31,17 @@ for _ in $(seq 1 120); do
 done
 
 grep -q 'Canopy demos' "$BODY_FILE"
+curl -fsS "http://127.0.0.1:${PORT}/memo" >"$BODY_FILE"
+grep -q 'data-memo-production-unavailable' "$BODY_FILE"
+grep -q 'available only in local development' "$BODY_FILE"
+if grep -Eq 'id="api-key"|Fix Typos|data-imperative-demo-host="memo"' "$BODY_FILE"; then
+  echo 'Production Memo route exposed local provider controls' >&2
+  exit 1
+fi
 asset="$(find dist/public/assets -type f -name '*.js' -printf '%f\n' | sort | head -n 1)"
 test -n "$asset"
 curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/assets/${asset}"
 worker_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   "http://127.0.0.1:${PORT}/__canopy_worker_probe_missing")"
 test "$worker_status" = '404'
-echo 'Waku workerd Hub smoke: OK'
+echo 'Waku workerd Hub and production Memo smoke: OK'

--- a/examples/web/scripts/waku-foundation.test.mjs
+++ b/examples/web/scripts/waku-foundation.test.mjs
@@ -110,6 +110,21 @@ test('detects each generated runtime fingerprint in a server/RSC bundle', () => 
   assert.deepEqual(result.missingClientModules, []);
 });
 
+test('rejects the development-only Mini-ML AST Grep request in production bundles', () => {
+  const result = inspectWakuBundles({
+    serverBundles: [],
+    clientBundles: [{
+      name: 'dist/public/assets/ml-a.js',
+      source: 'fetch("/api/ast-grep")',
+    }],
+  });
+  assert.deepEqual(result.productionClientRequestLeaks, [{
+    capability: 'Mini-ML AST Grep',
+    requestPath: '/api/ast-grep',
+    file: 'dist/public/assets/ml-a.js',
+  }]);
+});
+
 test('keeps Vite defaults while exposing explicit dual-run commands', () => {
   const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
   assert.equal(pkg.scripts.dev, 'vite');

--- a/examples/web/scripts/waku-foundation.test.mjs
+++ b/examples/web/scripts/waku-foundation.test.mjs
@@ -214,4 +214,7 @@ test('isolates the non-deploying Waku foundation from the existing Vite deployme
 
   const smoke = fs.readFileSync(new URL('./smoke-waku-worker.sh', import.meta.url), 'utf8');
   assert.match(smoke, /wrangler dev --config wrangler\.waku\.jsonc --env preview/);
+  assert.match(smoke, /127\.0\.0\.1:\$\{PORT\}\/memo/);
+  assert.match(smoke, /data-memo-production-unavailable/);
+  assert.match(smoke, /id="api-key"\|Fix Typos\|data-imperative-demo-host="memo"/);
 });

--- a/examples/web/scripts/waku-foundation.test.mjs
+++ b/examples/web/scripts/waku-foundation.test.mjs
@@ -118,11 +118,60 @@ test('rejects the development-only Mini-ML AST Grep request in production bundle
       source: 'fetch("/api/ast-grep")',
     }],
   });
-  assert.deepEqual(result.productionClientRequestLeaks, [{
-    capability: 'Mini-ML AST Grep',
-    requestPath: '/api/ast-grep',
+  assert.deepEqual(result.productionClientArtifactLeaks, [{
+    capability: 'Mini-ML AST Grep request',
+    fingerprint: '/api/ast-grep',
     file: 'dist/public/assets/ml-a.js',
   }]);
+});
+
+test('rejects Memo development and provider capabilities outside the shared Lambda artifact', () => {
+  const providerFingerprints = [
+    'https://generativelanguage.googleapis.com/v1beta/models/',
+    'canopy_llm_fix_typos',
+    'canopy_llm_edit',
+  ];
+  const result = inspectWakuBundles({
+    serverBundles: [],
+    clientBundles: [{
+      name: 'dist/public/assets/memo-route-a.js',
+      source: [
+        'data-memo-ready',
+        'The Memo runtime is unavailable on the client',
+        ...providerFingerprints,
+      ].join('\n'),
+    }, {
+      name: 'dist/public/assets/crdt-lambda-a.js',
+      source: ['assemble_lambda_handle', ...providerFingerprints].join('\n'),
+    }],
+  });
+  assert.deepEqual(result.productionClientArtifactLeaks, [
+    {
+      capability: 'Memo development shell',
+      fingerprint: 'data-memo-ready',
+      file: 'dist/public/assets/memo-route-a.js',
+    },
+    {
+      capability: 'Memo client module',
+      fingerprint: 'The Memo runtime is unavailable on the client',
+      file: 'dist/public/assets/memo-route-a.js',
+    },
+    {
+      capability: 'Memo provider URL',
+      fingerprint: 'https://generativelanguage.googleapis.com/v1beta/models/',
+      file: 'dist/public/assets/memo-route-a.js',
+    },
+    {
+      capability: 'Memo provider function',
+      fingerprint: 'canopy_llm_fix_typos',
+      file: 'dist/public/assets/memo-route-a.js',
+    },
+    {
+      capability: 'Memo provider function',
+      fingerprint: 'canopy_llm_edit',
+      file: 'dist/public/assets/memo-route-a.js',
+    },
+  ]);
 });
 
 test('keeps Vite defaults while exposing explicit dual-run commands', () => {

--- a/examples/web/src/features/lambda/browser/ast-grep-runner.ts
+++ b/examples/web/src/features/lambda/browser/ast-grep-runner.ts
@@ -15,8 +15,7 @@ export async function runAnalysis(
 ): Promise<AstGrepMatch[]> {
   if (text.trim() === '') return [];
 
-  const importMeta = import.meta as ImportMeta & { env?: { DEV?: boolean } };
-  if (!importMeta.env?.DEV) return [];
+  if (!import.meta.env.DEV) return [];
 
   const response = await fetch('/api/ast-grep', {
     method: 'POST',

--- a/examples/web/src/features/lambda/browser/editor.ts
+++ b/examples/web/src/features/lambda/browser/editor.ts
@@ -1,159 +1,233 @@
 'use client';
 
-// Lambda Calculus Editor — thin DOM bridge over MoonBit CRDT backend
+// Mini-ML editor — imperative DOM shell over the MoonBit CRDT core.
 
-import * as crdt from '@moonbit/crdt-lambda';
-import * as graphviz from '@moonbit/graphviz';
 import { HTMLAdapter } from '@canopy/editor-adapter/html-adapter';
-import type { Decoration, ViewPatch } from '@canopy/editor-adapter/types';
-import { runAnalysis } from './ast-grep-runner';
+import type { ViewPatch } from '@canopy/editor-adapter/types';
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
 import { DecorationOverlay } from '../../../shared/decoration-overlay';
+import { runAnalysis } from './ast-grep-runner';
 
-export function createEditor(agentId: string) {
-  const handle = crdt.create_editor(agentId);
+export type LambdaEditorRuntime = typeof import('@moonbit/crdt-lambda');
+export type GraphvizRuntime = typeof import('@moonbit/graphviz');
 
-  const editorEl = document.getElementById('editor') as HTMLDivElement;
-  const astGraphEl = document.getElementById('ast-graph') as HTMLDivElement;
-  const astOutputEl = document.getElementById('ast-output') as HTMLElement;
-  const errorEl = document.getElementById('error-output') as HTMLUListElement;
+export function mountLambdaEditor(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot: unknown,
+  crdt: LambdaEditorRuntime,
+  graphviz: GraphvizRuntime,
+): MountedImperativeSession {
+  const document = root instanceof Document ? root : root.ownerDocument;
+  const window = document.defaultView ?? globalThis.window;
 
-  // Protocol-based pretty-print adapter
-  const prettyAdapter = new HTMLAdapter(astOutputEl);
-  const decorationOverlay = new DecorationOverlay(editorEl);
-  const analysisApi = crdt as typeof crdt & {
-    apply_ast_grep_results_json(handle: number, matchesJson: string): string;
-    compute_view_patches_json(handle: number): string;
-  };
+  function must<T extends HTMLElement>(selector: string): T {
+    const element = root.querySelector<HTMLElement>(selector);
+    if (element === null) throw new Error(`Missing Mini-ML editor element ${selector}`);
+    return element as T;
+  }
 
-  let lastText = '';
-  let scheduled = false;
+  const surfaceEl = must<HTMLElement>('[data-lambda-ready]');
+  const editorEl = must<HTMLDivElement>('#editor');
+  const astGraphEl = must<HTMLDivElement>('#ast-graph');
+  const astOutputEl = must<HTMLElement>('#ast-output');
+  const errorEl = must<HTMLUListElement>('#error-output');
+  const statusEl = must<HTMLElement>('#status');
+  const exampleButtons = Array.from(root.querySelectorAll<HTMLButtonElement>('.example-btn'));
+  const listenerAbort = new window.AbortController();
+  const agentId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  const restoredSource = typeof restoredSnapshot === 'string' ? restoredSnapshot : '';
+
+  let disposed = false;
+  let inputFrame: number | null = null;
   let analysisGeneration = 0;
   let analysisTimer: number | null = null;
   let analysisAbortController: AbortController | null = null;
+  let releaseHandle: (() => void) | null = null;
+  let releasePrettyAdapter: (() => void) | null = null;
+  let releaseDecorationOverlay: (() => void) | null = null;
 
-  function updateUI() {
-    const text = editorEl.textContent || '';
-    if (text !== lastText) {
-      crdt.set_text(handle, text);
-      lastText = text;
-      applyDecorationPatches(JSON.parse(analysisApi.compute_view_patches_json(handle)));
-      scheduleAnalysis(text);
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    surfaceEl.inert = true;
+    surfaceEl.dataset.lambdaReady = 'false';
+    listenerAbort.abort();
+    analysisGeneration += 1;
+    if (inputFrame !== null) {
+      window.cancelAnimationFrame(inputFrame);
+      inputFrame = null;
     }
-
-    // AST visualization (DOT → SVG via graphviz module)
-    try {
-      const dot = crdt.get_ast_dot_resolved(handle);
-      const svg = graphviz.render_dot_to_svg(dot);
-      astGraphEl.innerHTML = svg;
-
-      // Dark theme: remove white background from SVG
-      const polygon = astGraphEl.querySelector('g.graph polygon');
-      if (polygon) polygon.setAttribute('fill', 'transparent');
-    } catch (e) {
-      astGraphEl.innerHTML = `<p style="color:#f44">Error: ${e}</p>`;
-    }
-
-    // Pretty-printed AST with syntax highlighting (via protocol)
-    try {
-      const patches: ViewPatch[] = JSON.parse(
-        crdt.compute_pretty_patches_json(handle),
-      );
-      prettyAdapter.applyPatches(patches);
-    } catch (e) {
-      astOutputEl.textContent = `Pretty-print error: ${e}`;
-    }
-
-    // Diagnostics (parse errors + eval warnings). `def_name` is present
-    // on type errors inside a named binding so we can render a badge
-    // instead of string-prefixing the message.
-    const diags: { level: string; message: string; def_name?: string }[] = JSON.parse(
-      crdt.get_diagnostics_json(handle),
-    );
-    if (diags.length === 0) {
-      errorEl.innerHTML = '<li>No errors</li>';
-    } else {
-      errorEl.innerHTML = diags
-        .map(d => {
-          const badge = d.def_name
-            ? `<span class="diag-def-badge">${escapeHTML(d.def_name)}</span> `
-            : '';
-          return `<li class="diag-item diag-${d.level}">${badge}${escapeHTML(d.message)}</li>`;
-        })
-        .join('');
-    }
-  }
-
-  function scheduleAnalysis(text: string) {
-    const generation = ++analysisGeneration;
     if (analysisTimer !== null) {
       window.clearTimeout(analysisTimer);
-    }
-    if (analysisAbortController !== null) {
-      analysisAbortController.abort();
-      analysisAbortController = null;
-    }
-    analysisTimer = window.setTimeout(() => {
       analysisTimer = null;
-      void applyAnalysis(text, generation);
-    }, 150);
-  }
-
-  async function applyAnalysis(text: string, generation: number) {
-    const controller = new AbortController();
-    analysisAbortController = controller;
-    try {
-      const matches = await runAnalysis(text, { signal: controller.signal });
-      if (generation !== analysisGeneration) return;
-
-      const result = analysisApi.apply_ast_grep_results_json(handle, JSON.stringify(matches));
-      if (result !== 'ok') {
-        console.warn(`ast-grep analysis rejected: ${result}`);
-        return;
-      }
-
-      const patches: ViewPatch[] = JSON.parse(analysisApi.compute_view_patches_json(handle));
-      applyDecorationPatches(patches);
-    } catch (error) {
-      if (controller.signal.aborted || generation !== analysisGeneration) return;
-      console.warn('ast-grep analysis failed', error);
-    } finally {
-      if (analysisAbortController === controller) {
-        analysisAbortController = null;
-      }
     }
-  }
+    analysisAbortController?.abort();
+    analysisAbortController = null;
 
-  function applyDecorationPatches(patches: ViewPatch[]) {
-    let decorations: Decoration[] | null = null;
-    for (const patch of patches) {
-      if (patch.type === 'SetDecorations') {
-        decorations = patch.decorations;
+    const releases = [
+      ['decoration overlay', releaseDecorationOverlay],
+      ['pretty-print adapter', releasePrettyAdapter],
+      ['MoonBit handle', releaseHandle],
+    ] as const;
+    releaseDecorationOverlay = null;
+    releasePrettyAdapter = null;
+    releaseHandle = null;
+    releases.forEach(([resource, release]) => {
+      try {
+        release?.();
+      } catch (error) {
+        console.error(`Failed to dispose Mini-ML editor ${resource}`, error);
       }
-    }
-    if (decorations !== null) {
-      decorationOverlay.applyDecorations(decorations);
-    }
-  }
-
-  editorEl.addEventListener('input', () => {
-    if (scheduled) return;
-    scheduled = true;
-    requestAnimationFrame(() => {
-      scheduled = false;
-      updateUI();
     });
-  });
+  }
 
-  return {
-    handle,
-    agentId,
-    updateUI,
-    getText: () => crdt.get_text(handle),
-    setText: (text: string) => {
+  try {
+    const handle = crdt.create_editor(agentId);
+    releaseHandle = () => crdt.destroy_editor(handle);
+    const prettyAdapter = new HTMLAdapter(astOutputEl);
+    releasePrettyAdapter = () => prettyAdapter.destroy();
+    const decorationOverlay = new DecorationOverlay(editorEl);
+    releaseDecorationOverlay = () => decorationOverlay.dispose();
+    const analysisApi = crdt as LambdaEditorRuntime & {
+      apply_ast_grep_results_json(handle: number, matchesJson: string): string;
+      compute_view_patches_json(handle: number): string;
+    };
+    let lastText = '';
+
+    function applyDecorationPatches(patches: ViewPatch[]): void {
+      const decorationPatch = patches.reduce<
+        Extract<ViewPatch, { type: 'SetDecorations' }> | undefined
+      >(
+        (last, patch) => patch.type === 'SetDecorations' ? patch : last,
+        undefined,
+      );
+      if (decorationPatch !== undefined) {
+        decorationOverlay.applyDecorations(decorationPatch.decorations);
+      }
+    }
+
+    async function applyAnalysis(text: string, generation: number): Promise<void> {
+      const controller = new window.AbortController();
+      analysisAbortController = controller;
+      try {
+        const matches = await runAnalysis(text, { signal: controller.signal });
+        if (disposed || generation !== analysisGeneration) return;
+
+        const result = analysisApi.apply_ast_grep_results_json(
+          handle,
+          JSON.stringify(matches),
+        );
+        if (result !== 'ok') {
+          console.warn(`ast-grep analysis rejected: ${result}`);
+          return;
+        }
+        const patches: ViewPatch[] = JSON.parse(
+          analysisApi.compute_view_patches_json(handle),
+        );
+        applyDecorationPatches(patches);
+      } catch (error) {
+        if (controller.signal.aborted || disposed || generation !== analysisGeneration) return;
+        console.warn('ast-grep analysis failed', error);
+      } finally {
+        if (analysisAbortController === controller) analysisAbortController = null;
+      }
+    }
+
+    function scheduleAnalysis(text: string): void {
+      const generation = ++analysisGeneration;
+      if (analysisTimer !== null) window.clearTimeout(analysisTimer);
+      analysisAbortController?.abort();
+      analysisAbortController = null;
+      analysisTimer = window.setTimeout(() => {
+        analysisTimer = null;
+        void applyAnalysis(text, generation);
+      }, 150);
+    }
+
+    function updateUI(): void {
+      if (disposed) return;
+      const text = editorEl.textContent ?? '';
+      if (text !== lastText) {
+        crdt.set_text(handle, text);
+        lastText = text;
+        const patches: ViewPatch[] = JSON.parse(
+          analysisApi.compute_view_patches_json(handle),
+        );
+        applyDecorationPatches(patches);
+        scheduleAnalysis(text);
+      }
+
+      try {
+        const svg = graphviz.render_dot_to_svg(crdt.get_ast_dot_resolved(handle));
+        astGraphEl.innerHTML = svg;
+        astGraphEl.querySelector('g.graph polygon')?.setAttribute('fill', 'transparent');
+      } catch (error) {
+        astGraphEl.textContent = `AST visualization error: ${error}`;
+      }
+
+      try {
+        const patches: ViewPatch[] = JSON.parse(
+          crdt.compute_pretty_patches_json(handle),
+        );
+        prettyAdapter.applyPatches(patches);
+      } catch (error) {
+        astOutputEl.textContent = `Pretty-print error: ${error}`;
+      }
+
+      const diagnostics: { level: string; message: string; def_name?: string }[] = JSON.parse(
+        crdt.get_diagnostics_json(handle),
+      );
+      errorEl.innerHTML = diagnostics.length === 0
+        ? '<li>No errors</li>'
+        : diagnostics.map((diagnostic) => {
+            const badge = diagnostic.def_name
+              ? `<span class="diag-def-badge">${escapeHTML(diagnostic.def_name)}</span> `
+              : '';
+            return `<li class="diag-item diag-${diagnostic.level}">${badge}${escapeHTML(diagnostic.message)}</li>`;
+          }).join('');
+    }
+
+    function setText(text: string): void {
       editorEl.textContent = text;
-      editorEl.dispatchEvent(new Event('input', { bubbles: true }));
-    },
-  };
+      editorEl.dispatchEvent(new window.Event('input', { bubbles: true }));
+    }
+
+    editorEl.addEventListener('input', () => {
+      if (inputFrame !== null) return;
+      inputFrame = window.requestAnimationFrame(() => {
+        inputFrame = null;
+        updateUI();
+      });
+    }, { signal: listenerAbort.signal });
+    exampleButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const example = button.dataset.example;
+        if (example !== undefined) setText(example);
+      }, { signal: listenerAbort.signal });
+    });
+
+    if (restoredSource !== '') {
+      editorEl.textContent = restoredSource;
+      updateUI();
+    }
+    statusEl.textContent = `Ready! ID: ${agentId}`;
+    statusEl.className = 'status success';
+    surfaceEl.inert = false;
+    surfaceEl.dataset.lambdaReady = 'true';
+
+    return {
+      snapshot: () => editorEl.textContent ?? '',
+      restoreFocus(token: string): boolean {
+        if (disposed || token !== 'editor') return false;
+        editorEl.focus({ preventScroll: true });
+        return document.activeElement === editorEl;
+      },
+      dispose,
+    };
+  } catch (error) {
+    dispose();
+    throw error;
+  }
 }
 
 function escapeHTML(text: string): string {

--- a/examples/web/src/features/lambda/browser/mount.ts
+++ b/examples/web/src/features/lambda/browser/mount.ts
@@ -1,21 +1,12 @@
-// Main entry point for Lambda Calculus CRDT Editor
+'use client';
 
+// Legacy Vite entry point for the Mini-ML editor.
+
+import * as crdt from '@moonbit/crdt-lambda';
+import * as graphviz from '@moonbit/graphviz';
 import './styles.css';
-import { createEditor } from './editor';
+import { mountLambdaEditor } from './editor';
 
 export function mountLambda(): void {
-  const agentId = `user-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-  const editor = createEditor(agentId);
-
-  // Example buttons
-  document.querySelectorAll('.example-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const example = btn.getAttribute('data-example');
-      if (example) editor.setText(example);
-    });
-  });
-
-  const statusEl = document.getElementById('status')!;
-  statusEl.textContent = `Ready! ID: ${agentId}`;
-  statusEl.className = 'status success';
+  mountLambdaEditor(document, undefined, crdt, graphviz);
 }

--- a/examples/web/src/features/lambda/browser/styles.css
+++ b/examples/web/src/features/lambda/browser/styles.css
@@ -1,18 +1,16 @@
 .lambda-surface {
+    box-sizing: border-box;
+    margin: 0;
+    font-family: Consolas, Monaco, 'Courier New', monospace;
+    background: #1e1e1e;
+    color: #d4d4d4;
+    min-height: 100vh;
+    padding: 20px;
+
     * {
       box-sizing: border-box;
       margin: 0;
       padding: 0;
-    }
-
-    & {
-      box-sizing: border-box;
-      margin: 0;
-      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
-      background: #1e1e1e;
-      color: #d4d4d4;
-      min-height: 100vh;
-      padding: 20px;
     }
 
     .container {
@@ -62,7 +60,7 @@
       border-radius: 3px;
       cursor: pointer;
       font-size: 12px;
-      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      font-family: Consolas, Monaco, 'Courier New', monospace;
       transition: background 0.2s;
     }
 
@@ -344,9 +342,7 @@
 
     /* Mobile responsive styles */
     @media (max-width: 768px) {
-      & {
-        padding: 10px;
-      }
+      padding: 10px;
 
       h1 {
         font-size: 20px;
@@ -508,9 +504,7 @@
 
     /* Extra small screens (phones in portrait) */
     @media (max-width: 480px) {
-      & {
-        padding: 8px;
-      }
+      padding: 8px;
 
       h1 {
         font-size: 18px;

--- a/examples/web/src/features/lambda/browser/styles.css
+++ b/examples/web/src/features/lambda/browser/styles.css
@@ -1,13 +1,17 @@
+.lambda-surface {
     * {
       box-sizing: border-box;
       margin: 0;
       padding: 0;
     }
 
-    body {
+    & {
+      box-sizing: border-box;
+      margin: 0;
       font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
       background: #1e1e1e;
       color: #d4d4d4;
+      min-height: 100vh;
       padding: 20px;
     }
 
@@ -340,7 +344,7 @@
 
     /* Mobile responsive styles */
     @media (max-width: 768px) {
-      body {
+      & {
         padding: 10px;
       }
 
@@ -504,7 +508,7 @@
 
     /* Extra small screens (phones in portrait) */
     @media (max-width: 480px) {
-      body {
+      & {
         padding: 8px;
       }
 
@@ -537,3 +541,4 @@
         font-size: 12px;
       }
     }
+}

--- a/examples/web/src/features/lambda/route/lambda-client.tsx
+++ b/examples/web/src/features/lambda/route/lambda-client.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { type ReactNode, useCallback, useState } from 'react';
+import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
+import {
+  mountLambdaEditor,
+  type GraphvizRuntime,
+  type LambdaEditorRuntime,
+} from '../browser/editor';
+import '../browser/styles.css';
+
+const loadLambdaRuntime: (() => Promise<[
+  LambdaEditorRuntime,
+  GraphvizRuntime,
+]>) | null = import.meta.env.SSR
+  ? null
+  : () => Promise.all([
+      import('@moonbit/crdt-lambda'),
+      import('@moonbit/graphviz'),
+    ]);
+
+function mountLambdaRoute(
+  container: HTMLElement,
+  restoredSnapshot: unknown,
+  reportRuntimeError: (error: unknown) => void,
+) {
+  if (loadLambdaRuntime === null) {
+    throw new Error('The Mini-ML editor runtime is unavailable on the client');
+  }
+  let controller: ReturnType<typeof mountLambdaEditor> | null = null;
+  let disposed = false;
+  let pendingFocusToken: string | null = null;
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    controller?.dispose();
+    controller = null;
+  }
+
+  void loadLambdaRuntime()
+    .then(([crdt, graphviz]) => {
+      if (disposed) return;
+      controller = mountLambdaEditor(
+        container,
+        restoredSnapshot,
+        crdt,
+        graphviz,
+      );
+      if (
+        pendingFocusToken !== null &&
+        !controller.restoreFocus(pendingFocusToken)
+      ) {
+        container.querySelector<HTMLElement>('[data-route-heading]')
+          ?.focus({ preventScroll: true });
+      }
+    })
+    .catch((error: unknown) => {
+      if (disposed) return;
+      dispose();
+      reportRuntimeError(error);
+    });
+
+  return {
+    snapshot: () => controller?.snapshot() ?? (
+      typeof restoredSnapshot === 'string' ? restoredSnapshot : ''
+    ),
+    restoreFocus(token: string): boolean {
+      if (controller !== null) return controller.restoreFocus(token);
+      if (token !== 'editor') return false;
+      pendingFocusToken = token;
+      return true;
+    },
+    dispose,
+  };
+}
+
+export function LambdaClient({ children }: { readonly children: ReactNode }) {
+  const [runtimeError, setRuntimeError] = useState<Error | null>(null);
+  const mount = useCallback(
+    (container: HTMLElement, restoredSnapshot: unknown) => mountLambdaRoute(
+      container,
+      restoredSnapshot,
+      (error) => setRuntimeError(
+        error instanceof Error ? error : new Error(String(error)),
+      ),
+    ),
+    [],
+  );
+  if (runtimeError !== null) throw runtimeError;
+
+  return (
+    <ImperativeDemoHost
+      demoId="lambda"
+      mount={mount}
+      className="lambda-surface"
+    >
+      {children}
+    </ImperativeDemoHost>
+  );
+}

--- a/examples/web/src/features/lambda/route/lambda-route.tsx
+++ b/examples/web/src/features/lambda/route/lambda-route.tsx
@@ -1,0 +1,17 @@
+import lambdaDocument from '../../../../index.html?raw';
+import { LambdaClient } from './lambda-client';
+
+const LAMBDA_SHELL_PATTERN = /<!-- lambda-shell:start -->([\s\S]*?)<!-- lambda-shell:end -->/;
+
+export function LambdaRoute() {
+  const shellMatch = LAMBDA_SHELL_PATTERN.exec(lambdaDocument);
+  if (shellMatch === null) {
+    throw new Error('The canonical Mini-ML document shell is unavailable');
+  }
+
+  return (
+    <LambdaClient>
+      <div dangerouslySetInnerHTML={{ __html: shellMatch[1] }} />
+    </LambdaClient>
+  );
+}

--- a/examples/web/src/features/memo/browser/app.ts
+++ b/examples/web/src/features/memo/browser/app.ts
@@ -1,19 +1,56 @@
 'use client';
-import * as crdt from '@moonbit/crdt-lambda';
-import { applyActions, parseLlmResult } from '../core/edit-actions';
-import type { MemoView } from './view';
 
-const llm = crdt as unknown as {
+import type { MountedImperativeSession } from '../../../shared/route-lifecycle/browser/imperative-session';
+import { applyActions, parseLlmResult } from '../core/edit-actions';
+import { createMemoView } from './view';
+
+export interface MemoRuntime {
   canopy_llm_fix_typos(text: string, apiKey: string): Promise<string>;
   canopy_llm_edit(text: string, instruction: string, apiKey: string): Promise<string>;
-};
+}
+
+export interface MemoProposal {
+  readonly original: string;
+  readonly fixed: string;
+}
+
+export interface MemoSnapshot {
+  readonly draft: string;
+  readonly instruction: string;
+  readonly proposal: MemoProposal | null;
+}
 
 const RATE_LIMIT_MS = 5000;
 const MAX_INPUT_LENGTH = 5000;
 
-export function createMemoApp(view: MemoView) {
-  let pendingText: string | null = null;
+export function mountMemoApp(
+  root: Document | HTMLElement = globalThis.document,
+  restoredSnapshot: unknown,
+  llm: MemoRuntime,
+): MountedImperativeSession {
+  const document = root instanceof Document ? root : root.ownerDocument;
+  const window = document.defaultView ?? globalThis.window;
+  const surfaceCandidate = root.querySelector<HTMLElement>('[data-memo-ready]');
+  if (surfaceCandidate === null) throw new Error('Missing Memo editor surface');
+  const surfaceEl: HTMLElement = surfaceCandidate;
+  const view = createMemoView(root);
+  const listenerAbort = new window.AbortController();
+  const restored = normalizeMemoSnapshot(restoredSnapshot);
+
+  let disposed = false;
+  let proposal = restored.proposal;
   let lastRequestTime = 0;
+  let requestGeneration = 0;
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    requestGeneration += 1;
+    listenerAbort.abort();
+    view.clearApiKey();
+    surfaceEl.inert = true;
+    surfaceEl.dataset.memoReady = 'false';
+  }
 
   function getApiKey(): string | null {
     const key = view.apiKey().trim();
@@ -51,38 +88,47 @@ export function createMemoApp(view: MemoView) {
 
   function hideDiff(): void {
     view.hideDiff();
-    pendingText = null;
+    proposal = null;
   }
 
-  async function callLlm(fetchResult: () => Promise<string>, originalText: string): Promise<void> {
+  async function callLlm(
+    fetchResult: () => Promise<string>,
+    originalText: string,
+  ): Promise<void> {
+    const generation = ++requestGeneration;
     view.setLoading(true);
     try {
-      const result = parseLlmResult(await fetchResult());
-      if (!result.ok) {
-        view.setStatus(`Error: ${result.error}`, 'error');
+      const parsed = parseLlmResult(await fetchResult());
+      if (disposed || generation !== requestGeneration) return;
+      if (!parsed.ok) {
+        view.setStatus(`Error: ${parsed.error}`, 'error');
         return;
       }
-      if (!result.actions || result.actions.length === 0) {
+      if (!parsed.actions || parsed.actions.length === 0) {
         view.setStatus('No changes suggested.', 'success');
         return;
       }
-      const { result: fixed, warnings } = applyActions(originalText, result.actions);
+      const { result: fixed, warnings } = applyActions(originalText, parsed.actions);
       if (fixed === originalText) {
         view.setStatus('No changes detected.', 'success');
-      } else {
-        pendingText = fixed;
-        view.showDiff(originalText, fixed);
-        view.setStatus(
-          warnings.length > 0
-            ? `Review changes. Warnings: ${warnings.join('; ')}`
-            : 'Review the suggested changes below.',
-          warnings.length > 0 ? 'error' : 'success',
-        );
+        return;
       }
+      proposal = { original: originalText, fixed };
+      view.showDiff(originalText, fixed);
+      view.setStatus(
+        warnings.length > 0
+          ? `Review changes. Warnings: ${warnings.join('; ')}`
+          : 'Review the suggested changes below.',
+        warnings.length > 0 ? 'error' : 'success',
+      );
     } catch (error) {
-      view.setStatus(`Unexpected error: ${error instanceof Error ? error.message : error}`, 'error');
+      if (disposed || generation !== requestGeneration) return;
+      view.setStatus(
+        `Unexpected error: ${error instanceof Error ? error.message : error}`,
+        'error',
+      );
     } finally {
-      view.setLoading(false);
+      if (!disposed && generation === requestGeneration) view.setLoading(false);
     }
   }
 
@@ -109,24 +155,67 @@ export function createMemoApp(view: MemoView) {
     await callLlm(() => llm.canopy_llm_edit(text, instruction, apiKey), text);
   }
 
+  try {
+    view.setMemoText(restored.draft);
+    view.setInstruction(restored.instruction);
+    if (proposal !== null) view.showDiff(proposal.original, proposal.fixed);
+    view.bind({
+      fixTypos,
+      edit,
+      accept(): void {
+        if (proposal !== null) {
+          view.setMemoText(proposal.fixed);
+          view.setStatus('Changes applied.', 'success');
+        }
+        hideDiff();
+      },
+      reject(): void {
+        view.setStatus('Changes rejected.');
+        hideDiff();
+      },
+    }, listenerAbort.signal);
+    view.setStatus('Ready. Enter your API key and start typing.');
+    surfaceEl.inert = false;
+    surfaceEl.dataset.memoReady = 'true';
+
+    return {
+      snapshot: (): MemoSnapshot => ({
+        draft: view.memoText(),
+        instruction: view.instruction(),
+        proposal: proposal === null ? null : { ...proposal },
+      }),
+      restoreFocus(token: string): boolean {
+        if (disposed) return false;
+        if (token === 'memo') view.focusMemo();
+        else if (token === 'instruction') view.focusInstruction();
+        else return false;
+        return document.activeElement?.getAttribute('data-route-focus') === token;
+      },
+      dispose,
+    };
+  } catch (error) {
+    dispose();
+    throw error;
+  }
+}
+
+export function normalizeMemoSnapshot(value: unknown): MemoSnapshot {
+  if (typeof value !== 'object' || value === null) {
+    return { draft: '', instruction: '', proposal: null };
+  }
+  const snapshot = value as Record<string, unknown>;
+  const candidate = snapshot.proposal;
+  const proposal = typeof candidate === 'object' && candidate !== null &&
+    typeof (candidate as Record<string, unknown>).original === 'string' &&
+    typeof (candidate as Record<string, unknown>).fixed === 'string'
+    ? {
+        original: (candidate as Record<string, string>).original,
+        fixed: (candidate as Record<string, string>).fixed,
+      }
+    : null;
   return {
-    mount(): void {
-      view.bind({
-        fixTypos,
-        edit,
-        accept(): void {
-          if (pendingText !== null) {
-            view.setMemoText(pendingText);
-            view.setStatus('Changes applied.', 'success');
-          }
-          hideDiff();
-        },
-        reject(): void {
-          view.setStatus('Changes rejected.');
-          hideDiff();
-        },
-      });
-      view.setStatus('Ready. Enter your API key and start typing.');
-    },
+    draft: typeof snapshot.draft === 'string' ? snapshot.draft : '',
+    instruction: typeof snapshot.instruction === 'string' ? snapshot.instruction : '',
+    proposal,
   };
 }

--- a/examples/web/src/features/memo/browser/mount.ts
+++ b/examples/web/src/features/memo/browser/mount.ts
@@ -1,7 +1,9 @@
+'use client';
+
+import * as runtime from '@moonbit/crdt-lambda';
+import { mountMemoApp } from './app';
 import './styles.css';
-import { createMemoApp } from './app';
-import { createMemoView } from './view';
 
 export function mountMemo(): void {
-  createMemoApp(createMemoView(document)).mount();
+  mountMemoApp(document, undefined, runtime);
 }

--- a/examples/web/src/features/memo/browser/styles.css
+++ b/examples/web/src/features/memo/browser/styles.css
@@ -1,8 +1,12 @@
+.memo-surface {
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
+    & {
+      box-sizing: border-box;
+      margin: 0;
       font-family: 'Inter', 'Helvetica Neue', sans-serif;
       background: #1a1a2e;
       color: #e0e0e0;
+      min-height: 100vh;
       padding: 24px;
     }
     .container { max-width: 720px; margin: 0 auto; }
@@ -63,7 +67,8 @@
     }
     .diff-actions { margin-top: 12px; display: flex; gap: 8px; }
     @media (max-width: 640px) {
-      body { padding: 12px; }
+      & { padding: 12px; }
       .diff-content { grid-template-columns: 1fr; }
       .config-section { flex-direction: column; align-items: stretch; }
     }
+}

--- a/examples/web/src/features/memo/browser/styles.css
+++ b/examples/web/src/features/memo/browser/styles.css
@@ -1,14 +1,13 @@
 .memo-surface {
+    box-sizing: border-box;
+    margin: 0;
+    font-family: Inter, 'Helvetica Neue', sans-serif;
+    background: #1a1a2e;
+    color: #e0e0e0;
+    min-height: 100vh;
+    padding: 24px;
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    & {
-      box-sizing: border-box;
-      margin: 0;
-      font-family: 'Inter', 'Helvetica Neue', sans-serif;
-      background: #1a1a2e;
-      color: #e0e0e0;
-      min-height: 100vh;
-      padding: 24px;
-    }
     .container { max-width: 720px; margin: 0 auto; }
     h1 { color: #8250df; font-size: 20px; margin-bottom: 6px; }
     .subtitle { color: #666; font-size: 13px; margin-bottom: 20px; }
@@ -67,7 +66,7 @@
     }
     .diff-actions { margin-top: 12px; display: flex; gap: 8px; }
     @media (max-width: 640px) {
-      & { padding: 12px; }
+      padding: 12px;
       .diff-content { grid-template-columns: 1fr; }
       .config-section { flex-direction: column; align-items: stretch; }
     }

--- a/examples/web/src/features/memo/browser/view.ts
+++ b/examples/web/src/features/memo/browser/view.ts
@@ -11,36 +11,48 @@ export interface MemoView {
   memoText(): string;
   setMemoText(value: string): void;
   apiKey(): string;
+  clearApiKey(): void;
   instruction(): string;
+  setInstruction(value: string): void;
+  focusMemo(): void;
   focusApiKey(): void;
   focusInstruction(): void;
   setStatus(message: string, tone?: StatusTone): void;
   setLoading(loading: boolean): void;
   showDiff(original: string, fixed: string): void;
   hideDiff(): void;
-  bind(handlers: MemoViewHandlers): void;
+  bind(handlers: MemoViewHandlers, signal: AbortSignal): void;
 }
 
-export function createMemoView(document: Document): MemoView {
-  const memoEl = document.getElementById('memo') as HTMLTextAreaElement;
-  const apiKeyEl = document.getElementById('api-key') as HTMLInputElement;
-  const fixTyposBtn = document.getElementById('fix-typos-btn') as HTMLButtonElement;
-  const editBtn = document.getElementById('edit-btn') as HTMLButtonElement;
-  const instructionEl = document.getElementById('instruction') as HTMLInputElement;
-  const statusEl = document.getElementById('status') as HTMLDivElement;
-  const diffSection = document.getElementById('diff-section') as HTMLDivElement;
-  const diffOriginal = document.getElementById('diff-original') as HTMLPreElement;
-  const diffFixed = document.getElementById('diff-fixed') as HTMLPreElement;
-  const acceptBtn = document.getElementById('accept-btn') as HTMLButtonElement;
-  const rejectBtn = document.getElementById('reject-btn') as HTMLButtonElement;
+export function createMemoView(root: Document | HTMLElement): MemoView {
+  function must<T extends HTMLElement>(selector: string): T {
+    const element = root.querySelector<HTMLElement>(selector);
+    if (element === null) throw new Error(`Missing Memo editor element ${selector}`);
+    return element as T;
+  }
+
+  const memoEl = must<HTMLTextAreaElement>('#memo');
+  const apiKeyEl = must<HTMLInputElement>('#api-key');
+  const fixTyposBtn = must<HTMLButtonElement>('#fix-typos-btn');
+  const editBtn = must<HTMLButtonElement>('#edit-btn');
+  const instructionEl = must<HTMLInputElement>('#instruction');
+  const statusEl = must<HTMLDivElement>('#status');
+  const diffSection = must<HTMLDivElement>('#diff-section');
+  const diffOriginal = must<HTMLPreElement>('#diff-original');
+  const diffFixed = must<HTMLPreElement>('#diff-fixed');
+  const acceptBtn = must<HTMLButtonElement>('#accept-btn');
+  const rejectBtn = must<HTMLButtonElement>('#reject-btn');
 
   return {
     memoText: () => memoEl.value,
-    setMemoText: value => { memoEl.value = value; },
+    setMemoText: (value) => { memoEl.value = value; },
     apiKey: () => apiKeyEl.value,
+    clearApiKey: () => { apiKeyEl.value = ''; },
     instruction: () => instructionEl.value,
-    focusApiKey: () => apiKeyEl.focus(),
-    focusInstruction: () => instructionEl.focus(),
+    setInstruction: (value) => { instructionEl.value = value; },
+    focusMemo: () => memoEl.focus({ preventScroll: true }),
+    focusApiKey: () => apiKeyEl.focus({ preventScroll: true }),
+    focusInstruction: () => instructionEl.focus({ preventScroll: true }),
     setStatus(message: string, tone: StatusTone = ''): void {
       statusEl.textContent = message;
       statusEl.className = `status-bar ${tone}`;
@@ -60,12 +72,14 @@ export function createMemoView(document: Document): MemoView {
     },
     hideDiff(): void {
       diffSection.classList.remove('visible');
+      diffOriginal.textContent = '';
+      diffFixed.textContent = '';
     },
-    bind({ fixTypos, edit, accept, reject }): void {
-      fixTyposBtn.addEventListener('click', () => { void fixTypos(); });
-      editBtn.addEventListener('click', () => { void edit(); });
-      acceptBtn.addEventListener('click', accept);
-      rejectBtn.addEventListener('click', reject);
+    bind({ fixTypos, edit, accept, reject }, signal): void {
+      fixTyposBtn.addEventListener('click', () => { void fixTypos(); }, { signal });
+      editBtn.addEventListener('click', () => { void edit(); }, { signal });
+      acceptBtn.addEventListener('click', accept, { signal });
+      rejectBtn.addEventListener('click', reject, { signal });
     },
   };
 }

--- a/examples/web/src/features/memo/route/memo-client.tsx
+++ b/examples/web/src/features/memo/route/memo-client.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { type ReactNode, useCallback, useState } from 'react';
+import { ImperativeDemoHost } from '../../../shared/route-lifecycle/browser/imperative-host';
+import {
+  mountMemoApp,
+  normalizeMemoSnapshot,
+  type MemoRuntime,
+} from '../browser/app';
+import '../browser/styles.css';
+
+const loadMemoRuntime: (() => Promise<MemoRuntime>) | null = import.meta.env.SSR
+  ? null
+  : () => import('@moonbit/crdt-lambda');
+
+function mountMemoRoute(
+  container: HTMLElement,
+  restoredSnapshot: unknown,
+  reportRuntimeError: (error: unknown) => void,
+) {
+  if (loadMemoRuntime === null) {
+    throw new Error('The Memo runtime is unavailable on the client');
+  }
+  const pendingSnapshot = normalizeMemoSnapshot(restoredSnapshot);
+  let controller: ReturnType<typeof mountMemoApp> | null = null;
+  let disposed = false;
+  let pendingFocusToken: string | null = null;
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    controller?.dispose();
+    controller = null;
+  }
+
+  void loadMemoRuntime()
+    .then((runtime) => {
+      if (disposed) return;
+      controller = mountMemoApp(container, pendingSnapshot, runtime);
+      if (
+        pendingFocusToken !== null &&
+        !controller.restoreFocus(pendingFocusToken)
+      ) {
+        container.querySelector<HTMLElement>('[data-route-heading]')
+          ?.focus({ preventScroll: true });
+      }
+    })
+    .catch((error: unknown) => {
+      if (disposed) return;
+      dispose();
+      reportRuntimeError(error);
+    });
+
+  return {
+    snapshot: () => controller?.snapshot() ?? pendingSnapshot,
+    restoreFocus(token: string): boolean {
+      if (controller !== null) return controller.restoreFocus(token);
+      if (token !== 'memo' && token !== 'instruction') return false;
+      pendingFocusToken = token;
+      return true;
+    },
+    dispose,
+  };
+}
+
+export function MemoClient({ children }: { readonly children: ReactNode }) {
+  const [runtimeError, setRuntimeError] = useState<Error | null>(null);
+  const mount = useCallback(
+    (container: HTMLElement, restoredSnapshot: unknown) => mountMemoRoute(
+      container,
+      restoredSnapshot,
+      (error) => setRuntimeError(
+        error instanceof Error ? error : new Error(String(error)),
+      ),
+    ),
+    [],
+  );
+  if (runtimeError !== null) throw runtimeError;
+
+  return (
+    <ImperativeDemoHost
+      demoId="memo"
+      mount={mount}
+      className="memo-surface"
+    >
+      {children}
+    </ImperativeDemoHost>
+  );
+}

--- a/examples/web/src/features/memo/route/memo-route.tsx
+++ b/examples/web/src/features/memo/route/memo-route.tsx
@@ -1,10 +1,8 @@
-import memoDocument from '../../../../memo.html?raw';
 import { LifecycleLink } from '../../../shared/route-lifecycle/browser/lifecycle-link';
-import { MemoClient } from './memo-client';
 
 const MEMO_SHELL_PATTERN = /<!-- memo-shell:start -->([\s\S]*?)<!-- memo-shell:end -->/;
 
-export function MemoRoute() {
+export async function MemoRoute() {
   if (import.meta.env.PROD) {
     return (
       <main className="route-state" data-memo-production-unavailable>
@@ -22,6 +20,13 @@ export function MemoRoute() {
     );
   }
 
+  const [
+    { default: memoDocument },
+    { MemoClient },
+  ] = await Promise.all([
+    import('../../../../memo.html?raw'),
+    import('./memo-client'),
+  ]);
   const shellMatch = MEMO_SHELL_PATTERN.exec(memoDocument);
   if (shellMatch === null) {
     throw new Error('The canonical Memo document shell is unavailable');

--- a/examples/web/src/features/memo/route/memo-route.tsx
+++ b/examples/web/src/features/memo/route/memo-route.tsx
@@ -1,0 +1,34 @@
+import memoDocument from '../../../../memo.html?raw';
+import { LifecycleLink } from '../../../shared/route-lifecycle/browser/lifecycle-link';
+import { MemoClient } from './memo-client';
+
+const MEMO_SHELL_PATTERN = /<!-- memo-shell:start -->([\s\S]*?)<!-- memo-shell:end -->/;
+
+export function MemoRoute() {
+  if (import.meta.env.PROD) {
+    return (
+      <main className="route-state" data-memo-production-unavailable>
+        <p className="route-state__label">Local-only demo</p>
+        <h1 tabIndex={-1} data-route-heading>Canopy Memo</h1>
+        <p>
+          This demo is available only in local development because it sends
+          provider requests directly from the browser. Production requires a
+          server-side provider proxy.
+        </p>
+        <LifecycleLink className="route-state__action" to="/">
+          Back to demos
+        </LifecycleLink>
+      </main>
+    );
+  }
+
+  const shellMatch = MEMO_SHELL_PATTERN.exec(memoDocument);
+  if (shellMatch === null) {
+    throw new Error('The canonical Memo document shell is unavailable');
+  }
+  return (
+    <MemoClient>
+      <div dangerouslySetInnerHTML={{ __html: shellMatch[1] }} />
+    </MemoClient>
+  );
+}

--- a/examples/web/src/pages/memo.tsx
+++ b/examples/web/src/pages/memo.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { MemoRoute } from '../features/memo/route/memo-route';
 
 export default function Memo() {
-  return <DemoPlaceholder demoId="memo" />;
+  return <MemoRoute />;
 }

--- a/examples/web/src/pages/ml.tsx
+++ b/examples/web/src/pages/ml.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { LambdaRoute } from '../features/lambda/route/lambda-route';
 
 export default function Ml() {
-  return <DemoPlaceholder demoId="lambda" />;
+  return <LambdaRoute />;
 }

--- a/examples/web/tests/lambda-editor.spec.ts
+++ b/examples/web/tests/lambda-editor.spec.ts
@@ -23,7 +23,7 @@ let pageErrors: Error[];
 test.beforeEach(async ({ page }) => {
   pageErrors = [];
   page.on('pageerror', (error) => pageErrors.push(error));
-  await page.goto('/');
+  await page.goto(process.env.LAMBDA_EDITOR_URL ?? '/');
   await expect(page.locator('#status')).toContainText('Ready!');
 });
 

--- a/examples/web/tests/memo-editor.spec.ts
+++ b/examples/web/tests/memo-editor.spec.ts
@@ -5,7 +5,7 @@ test.describe('Memo editor', () => {
     const pageErrors: Error[] = [];
     page.on('pageerror', error => pageErrors.push(error));
 
-    await page.goto('/memo.html');
+    await page.goto(process.env.MEMO_EDITOR_URL ?? '/memo.html');
 
     await expect(page.getByRole('heading', { name: 'Canopy Memo' })).toBeVisible();
     await expect(page.locator('#status')).toHaveText('Ready. Enter your API key and start typing.');

--- a/examples/web/waku-tests/lambda-route.spec.ts
+++ b/examples/web/waku-tests/lambda-route.spec.ts
@@ -1,0 +1,224 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForLambdaMount(page: Page): Promise<void> {
+  await expect(page.locator('[data-lambda-ready]'))
+    .toHaveAttribute('data-lambda-ready', 'true');
+  await expect(page.locator('#status')).toContainText('Ready!');
+}
+
+async function replaceSource(page: Page, source: string): Promise<void> {
+  await page.locator('#editor').evaluate((editor, nextSource) => {
+    editor.textContent = nextSource;
+    editor.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      data: nextSource,
+      inputType: 'insertText',
+    }));
+  }, source);
+  await expect(page.locator('#ast-graph svg')).toBeVisible();
+}
+
+test('keeps the server-rendered Mini-ML controls inert without client JavaScript', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    const response = await page.goto('/ml');
+    expect(response?.ok()).toBe(true);
+    await expect(page.getByRole('heading', { name: 'Mini-ML CRDT Editor' })).toBeVisible();
+    await expect(page.locator('[data-lambda-ready]')).toHaveAttribute('inert', '');
+    await expect(page.locator('[data-lambda-ready]'))
+      .toHaveAttribute('data-lambda-ready', 'false');
+  } finally {
+    await context.close();
+  }
+});
+
+test('reports Mini-ML runtime load failures through the route error boundary', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  let failedRuntimeRequests = 0;
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.route(/crdt[-_]lambda|graphviz/, (route) => {
+    failedRuntimeRequests += 1;
+    return route.abort('failed');
+  });
+
+  await page.goto('/ml');
+
+  await expect(page.getByRole('heading', {
+    name: 'This demo could not be displayed',
+  })).toBeFocused();
+  expect(failedRuntimeRequests).toBeGreaterThan(0);
+  await expect(page.locator('[data-imperative-demo-host="lambda"]')).toHaveCount(0);
+  await expect(page.locator('.decoration-overlay')).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});
+
+test('restores only source and stable editor focus while rebuilding derived state', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Mini-ML Editor/ }).click();
+  await waitForLambdaMount(page);
+  await expect(page.getByRole('heading', { name: 'Mini-ML CRDT Editor' })).toBeFocused();
+
+  const firstAgent = await page.locator('#status').textContent();
+  const source = 'fn identity(x : Int) { x }\nidentity 42';
+  await replaceSource(page, source);
+  await page.locator('#editor').focus();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForLambdaMount(page);
+
+  await expect(page.locator('#editor')).toHaveText(source);
+  await expect(page.locator('#editor')).toBeFocused();
+  await expect(page.locator('#ast-graph svg')).toBeVisible();
+  await expect(page.locator('#ast-output')).not.toContainText('Waiting for input...');
+  expect(await page.locator('#status').textContent()).not.toBe(firstAgent);
+});
+
+test('reload clears Mini-ML route memory and creates a fresh editor', async ({ page }) => {
+  await page.goto('/ml');
+  await waitForLambdaMount(page);
+  const firstAgent = await page.locator('#status').textContent();
+  await replaceSource(page, '1 + 2');
+
+  await page.reload();
+  await waitForLambdaMount(page);
+
+  await expect(page.locator('#editor')).toHaveText('');
+  await expect(page.locator('#ast-output')).toContainText('Waiting for input...');
+  expect(await page.locator('#status').textContent()).not.toBe(firstAgent);
+});
+
+test('repeated route cycles release the surface, overlay, frame, and timer', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    await page.getByRole('link', { name: /Mini-ML Editor/ }).click();
+    await waitForLambdaMount(page);
+    await expect(page.locator('[data-imperative-demo-host="lambda"]')).toHaveCount(1);
+    await expect(page.locator('.lambda-surface .decoration-overlay')).toHaveCount(1);
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('[data-imperative-demo-host="lambda"]')).toHaveCount(0);
+    await expect(page.locator('.decoration-overlay')).toHaveCount(0);
+  }
+
+  await page.getByRole('link', { name: /Mini-ML Editor/ }).click();
+  await waitForLambdaMount(page);
+  await page.evaluate(() => {
+    const frameId = 2_147_480_100;
+    const originalRequest = window.requestAnimationFrame;
+    const originalCancel = window.cancelAnimationFrame;
+    const state = { cancelledFrames: [] as number[] };
+    (window as Window & { __lambdaReleaseState?: typeof state }).__lambdaReleaseState = state;
+    window.requestAnimationFrame = (() => frameId) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = ((candidate: number) => {
+      if (candidate === frameId) state.cancelledFrames.push(candidate);
+      else originalCancel(candidate);
+    }) as typeof window.cancelAnimationFrame;
+    const editor = document.querySelector<HTMLElement>('#editor');
+    editor?.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    window.requestAnimationFrame = originalRequest;
+    window.history.back();
+  });
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.evaluate(
+    () => (window as Window & { __lambdaReleaseState?: {
+      cancelledFrames: number[];
+    } }).__lambdaReleaseState,
+  )).toEqual({
+    cancelledFrames: [2_147_480_100],
+  });
+
+  await page.getByRole('link', { name: /Mini-ML Editor/ }).click();
+  await waitForLambdaMount(page);
+  await page.evaluate(() => {
+    const timerId = 2_147_480_101;
+    const originalSetTimeout = window.setTimeout;
+    const originalClearTimeout = window.clearTimeout;
+    const state = { scheduled: false, clearedTimers: [] as number[] };
+    (window as Window & { __lambdaTimerState?: typeof state }).__lambdaTimerState = state;
+    (window as Window & { __restoreLambdaTimers?: () => void }).__restoreLambdaTimers = () => {
+      window.setTimeout = originalSetTimeout;
+      window.clearTimeout = originalClearTimeout;
+    };
+    window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (timeout === 150) {
+        state.scheduled = true;
+        return timerId;
+      }
+      return originalSetTimeout(handler, timeout, ...args);
+    }) as typeof window.setTimeout;
+    window.clearTimeout = ((candidate: number) => {
+      if (candidate === timerId) state.clearedTimers.push(candidate);
+      else originalClearTimeout(candidate);
+    }) as typeof window.clearTimeout;
+    const editor = document.querySelector<HTMLElement>('#editor');
+    if (editor === null) throw new Error('Mini-ML editor is unavailable');
+    editor.textContent = '1';
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
+  });
+  await expect.poll(() => page.evaluate(
+    () => (window as Window & { __lambdaTimerState?: { scheduled: boolean } })
+      .__lambdaTimerState?.scheduled,
+  )).toBe(true);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.evaluate(
+    () => (window as Window & { __lambdaTimerState?: { clearedTimers: number[] } })
+      .__lambdaTimerState?.clearedTimers,
+  )).toEqual([2_147_480_101]);
+  await page.evaluate(() => {
+    (window as Window & { __restoreLambdaTimers?: () => void })
+      .__restoreLambdaTimers?.();
+  });
+
+  expect(pageErrors).toEqual([]);
+});
+
+test('aborts an in-flight development AST Grep request on route exit', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Mini-ML Editor/ }).click();
+  await waitForLambdaMount(page);
+  await page.evaluate(() => {
+    const originalFetch = window.fetch.bind(window);
+    const state = { started: false, aborted: false };
+    (window as Window & { __lambdaRequestState?: typeof state }).__lambdaRequestState = state;
+    window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (!url.endsWith('/api/ast-grep')) return originalFetch(input, init);
+      state.started = true;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          state.aborted = true;
+          reject(new DOMException('Aborted', 'AbortError'));
+        }, { once: true });
+      });
+    }) as typeof window.fetch;
+  });
+  await replaceSource(page, 'fn pending(x : Int) { x }');
+  await expect.poll(() => page.evaluate(
+    () => (window as Window & { __lambdaRequestState?: { started: boolean } })
+      .__lambdaRequestState?.started,
+  )).toBe(true);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  expect(await page.evaluate(
+    () => (window as Window & { __lambdaRequestState?: { aborted: boolean } })
+      .__lambdaRequestState?.aborted,
+  )).toBe(true);
+  expect(pageErrors).toEqual([]);
+});

--- a/examples/web/waku-tests/memo-route.spec.ts
+++ b/examples/web/waku-tests/memo-route.spec.ts
@@ -1,0 +1,256 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForMemoMount(page: Page): Promise<void> {
+  await expect(page.locator('[data-memo-ready]'))
+    .toHaveAttribute('data-memo-ready', 'true');
+  await expect(page.locator('#status'))
+    .toHaveText('Ready. Enter your API key and start typing.');
+}
+
+async function enterMemoFromHub(page: Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Canopy Memo/ }).click();
+  await waitForMemoMount(page);
+}
+
+async function installImmediateProvider(page: Page, fixed: string): Promise<void> {
+  await page.evaluate((fixedText) => {
+    const originalFetch = window.fetch.bind(window);
+    const state = { calls: 0 };
+    (window as Window & { __memoProviderState?: typeof state }).__memoProviderState = state;
+    window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (!url.includes('generativelanguage.googleapis.com')) {
+        return originalFetch(input, init);
+      }
+      state.calls += 1;
+      const actions = JSON.stringify([{
+        action: 'fix_typos',
+        original: 'teh',
+        fixed: fixedText,
+      }]);
+      return Promise.resolve(new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ text: actions }] } }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+    }) as typeof window.fetch;
+  }, fixed);
+}
+
+test('keeps the development Memo controls inert without client JavaScript', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    const response = await page.goto('/memo');
+    expect(response?.ok()).toBe(true);
+    await expect(page.getByRole('heading', { name: 'Canopy Memo' })).toBeVisible();
+    await expect(page.locator('[data-memo-ready]')).toHaveAttribute('inert', '');
+    await expect(page.locator('[data-memo-ready]'))
+      .toHaveAttribute('data-memo-ready', 'false');
+  } finally {
+    await context.close();
+  }
+});
+
+test('reports Memo runtime load failures through the route error boundary', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  let failedRuntimeRequests = 0;
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.route(/crdt[-_]lambda/, (route) => {
+    failedRuntimeRequests += 1;
+    return route.abort('failed');
+  });
+
+  await page.goto('/memo');
+
+  await expect(page.getByRole('heading', {
+    name: 'This demo could not be displayed',
+  })).toBeFocused();
+  expect(failedRuntimeRequests).toBeGreaterThan(0);
+  await expect(page.locator('[data-imperative-demo-host="memo"]')).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});
+
+test('restores draft, instruction, proposal, and stable focus without credentials or rate state', async ({ page }) => {
+  await enterMemoFromHub(page);
+  await installImmediateProvider(page, 'the memo');
+  await page.locator('#api-key').fill('not-snapshotted');
+  await page.locator('#memo').fill('teh memo');
+  await page.locator('#instruction').fill('Make it formal');
+  await page.getByRole('button', { name: 'Fix Typos' }).click();
+  await expect(page.locator('#diff-section')).toHaveClass(/visible/);
+  await expect(page.locator('#diff-original')).toHaveText('teh memo');
+  await expect(page.locator('#diff-fixed')).toHaveText('the memo');
+  await page.locator('#instruction').focus();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForMemoMount(page);
+
+  await expect(page.locator('#memo')).toHaveValue('teh memo');
+  await expect(page.locator('#instruction')).toHaveValue('Make it formal');
+  await expect(page.locator('#instruction')).toBeFocused();
+  await expect(page.locator('#api-key')).toHaveValue('');
+  await expect(page.locator('#diff-section')).toHaveClass(/visible/);
+  await expect(page.locator('#diff-original')).toHaveText('teh memo');
+  await expect(page.locator('#diff-fixed')).toHaveText('the memo');
+  await page.getByRole('button', { name: 'Accept' }).click();
+  await expect(page.locator('#memo')).toHaveValue('the memo');
+  await expect(page.locator('#diff-section')).not.toHaveClass(/visible/);
+
+  await page.locator('#api-key').fill('fresh-key');
+  await page.locator('#memo').fill('teh memo');
+  await page.getByRole('button', { name: 'Fix Typos' }).click();
+  await expect.poll(() => page.evaluate(
+    () => (window as Window & { __memoProviderState?: { calls: number } })
+      .__memoProviderState?.calls,
+  )).toBe(2);
+  await expect(page.locator('#status')).not.toContainText('Rate limited');
+});
+
+test('invalidates a pending provider result when the route exits', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await enterMemoFromHub(page);
+  await page.evaluate(() => {
+    const originalFetch = window.fetch.bind(window);
+    const state = { started: false, resolved: false };
+    (window as Window & { __memoPendingState?: typeof state }).__memoPendingState = state;
+    window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (!url.includes('generativelanguage.googleapis.com')) {
+        return originalFetch(input, init);
+      }
+      state.started = true;
+      return new Promise<Response>((resolve) => {
+        (window as Window & { __resolveMemoProvider?: () => void })
+          .__resolveMemoProvider = () => {
+            state.resolved = true;
+            const actions = JSON.stringify([{
+              action: 'fix_typos',
+              original: 'teh',
+              fixed: 'the pending draft',
+            }]);
+            resolve(new Response(JSON.stringify({
+              candidates: [{ content: { parts: [{ text: actions }] } }],
+            }), { status: 200, headers: { 'content-type': 'application/json' } }));
+          };
+      });
+    }) as typeof window.fetch;
+  });
+  await page.locator('#api-key').fill('temporary-key');
+  await page.locator('#memo').fill('teh pending draft');
+  await page.getByRole('button', { name: 'Fix Typos' }).click();
+  await expect(page.locator('#status')).toHaveText('Calling Gemini API...');
+  await expect.poll(() => page.evaluate(
+    () => (window as Window & { __memoPendingState?: { started: boolean } })
+      .__memoPendingState?.started,
+  )).toBe(true);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForMemoMount(page);
+  await expect(page.locator('#memo')).toHaveValue('teh pending draft');
+  await expect(page.locator('#api-key')).toHaveValue('');
+  await expect(page.locator('#diff-section')).not.toHaveClass(/visible/);
+
+  await page.evaluate(() => {
+    (window as Window & { __resolveMemoProvider?: () => void })
+      .__resolveMemoProvider?.();
+  });
+  await expect.poll(() => page.evaluate(
+    () => (window as Window & { __memoPendingState?: { resolved: boolean } })
+      .__memoPendingState?.resolved,
+  )).toBe(true);
+  await page.waitForTimeout(100);
+  await expect(page.locator('#status'))
+    .toHaveText('Ready. Enter your API key and start typing.');
+  await expect(page.locator('#diff-section')).not.toHaveClass(/visible/);
+  expect(pageErrors).toEqual([]);
+});
+
+test('reload clears draft, instruction, and completed proposal route memory', async ({ page }) => {
+  await page.goto('/memo');
+  await waitForMemoMount(page);
+  await installImmediateProvider(page, 'the transient draft');
+  await page.locator('#api-key').fill('temporary-key');
+  await page.locator('#memo').fill('teh transient draft');
+  await page.locator('#instruction').fill('Temporary instruction');
+  await page.getByRole('button', { name: 'Fix Typos' }).click();
+  await expect(page.locator('#diff-section')).toHaveClass(/visible/);
+
+  await page.reload();
+  await waitForMemoMount(page);
+
+  await expect(page.locator('#memo')).toHaveValue('');
+  await expect(page.locator('#instruction')).toHaveValue('');
+  await expect(page.locator('#api-key')).toHaveValue('');
+  await expect(page.locator('#diff-section')).not.toHaveClass(/visible/);
+});
+
+test('repeated route cycles release the surface and detached control listeners', async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await enterMemoFromHub(page);
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    await expect(page.locator('[data-imperative-demo-host="memo"]')).toHaveCount(1);
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('[data-imperative-demo-host="memo"]')).toHaveCount(0);
+    await page.goForward();
+    await waitForMemoMount(page);
+  }
+
+  await page.evaluate(() => {
+    const originalFetch = window.fetch.bind(window);
+    const state = { calls: 0 };
+    (window as Window & { __memoDetachedState?: typeof state }).__memoDetachedState = state;
+    window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes('generativelanguage.googleapis.com')) {
+        state.calls += 1;
+        return Promise.resolve(new Response('{"candidates":[]}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }));
+      }
+      return originalFetch(input, init);
+    }) as typeof window.fetch;
+    (window as Window & { __memoDetachedControls?: Record<string, HTMLElement> })
+      .__memoDetachedControls = {
+        key: document.querySelector<HTMLInputElement>('#api-key')!,
+        memo: document.querySelector<HTMLTextAreaElement>('#memo')!,
+        instruction: document.querySelector<HTMLInputElement>('#instruction')!,
+        fix: document.querySelector<HTMLButtonElement>('#fix-typos-btn')!,
+        edit: document.querySelector<HTMLButtonElement>('#edit-btn')!,
+      };
+  });
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.evaluate(() => {
+    const controls = (window as Window & {
+      __memoDetachedControls?: Record<string, HTMLElement>;
+    }).__memoDetachedControls;
+    if (controls === undefined) throw new Error('Detached Memo controls are unavailable');
+    (controls.key as HTMLInputElement).value = 'detached-key';
+    (controls.memo as HTMLTextAreaElement).value = 'detached draft';
+    (controls.instruction as HTMLInputElement).value = 'detached instruction';
+    controls.fix.click();
+    controls.edit.click();
+  });
+  await page.waitForTimeout(100);
+  expect(await page.evaluate(
+    () => (window as Window & { __memoDetachedState?: { calls: number } })
+      .__memoDetachedState?.calls,
+  )).toBe(0);
+  expect(pageErrors).toEqual([]);
+});

--- a/examples/web/waku.config.ts
+++ b/examples/web/waku.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'waku/config';
+import { astGrepPlugin } from './server/vite/ast-grep';
 import {
   createMoonbitArtifactsPlugin,
   moonbitImportIds,
@@ -7,7 +8,10 @@ import {
 export default defineConfig({
   unstable_adapter: 'waku/adapters/cloudflare',
   vite: {
-    plugins: [createMoonbitArtifactsPlugin({ watch: true })],
+    plugins: [
+      astGrepPlugin(),
+      createMoonbitArtifactsPlugin({ watch: true }),
+    ],
     server: {
       fs: {
         allow: ['../..'],


### PR DESCRIPTION
## Summary

- Migrate Mini-ML to the canonical Waku `/ml` route while retaining the legacy Vite mount and the existing generated Lambda artifact.
- Migrate Memo to `/memo` in development with a strict lifecycle snapshot allowlist, while rendering an explicit local-only unavailable state in production with no API-key control or provider client mount.
- Add route lifecycle, disposal, production bundle, workerd smoke, and inherited editor coverage; update Stage 7 documentation without enabling redirects or removing Vite.

Closes #976

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `ImperativeDemoHost` / `MountedImperativeSession` | `examples/web/src/shared/route-lifecycle` | Yes | Owns mount, snapshot, focus restoration, and deterministic disposal at the route boundary. |
| `HTMLAdapter.destroy`, `DecorationOverlay.dispose`, generated `destroy_editor` | Existing Mini-ML browser/generated APIs | Yes | Releases editor, adapter, overlay, and MoonBit handle resources without introducing feature-sharing internals. |
| `astGrepPlugin` | `examples/web/vite.config.ts` | Yes | Keeps development AST analysis on the existing adapter; production is statically disabled. |
| Existing Memo `applyActions` / `parseLlmResult` flow | `examples/web/src/features/memo/browser` | Yes | Preserves the local adapter and generated Lambda runtime. |
| JSON/Markdown canonical route pattern | Existing Waku feature routes | Yes | Reuses the established server shell plus client imperative-host boundary. |
| `DemoPlaceholder` | `examples/web/src/shared` | No | Represents pending migration, not the accepted production local-only/unavailable capability state. |
| MoonBit `Option` / `Result`, `String` / `StringView`, `Array` / `Iter`, `Map` / `Set` | MoonBit core | Checked; no new MoonBit code | Existing generated FFI and feature APIs already cover the required data shapes, so no MoonBit helper or API change was introduced. |

New helpers added:

- Route-local DOM `must` helpers validate ownership of canonical shell elements; they do not add domain behavior.
- `normalizeMemoSnapshot` is the strict snapshot allowlist for draft, instruction, and completed proposal only.
- Route-local mount seams adapt existing browser mounts to `ImperativeDemoHost`; imperative code remains limited to DOM, listeners, timers, fetch, and generated-runtime lifecycle wiring.

The existing Memo provider API does not expose physical request cancellation. Route disposal therefore invalidates the request generation and ignores late results; credentials and pending/rate state are never snapshotted. No MoonBit API redesign is included.

## Test plan

- [x] `moon check` passes (only pre-existing vendored Rabbita deprecation warnings)
- [x] `moon test` passes: wasm-gc 3932/3932, JS 1949/1949, native 70/70
- [x] `moon info` and `moon fmt` run; `git diff '*.mbti'` reviewed with no API drift
- [x] `npm run typecheck`
- [x] `npm run check:boundaries`
- [x] `npm run test:boundaries` (18 passed)
- [x] `npm run test:foundation` (30 passed)
- [x] `npm run test:waku:e2e` (103 passed)
- [x] Legacy Vite Playwright suite (103 passed, 2 skipped)
- [x] `npm run build:vite`
- [x] `npm run build:waku`
- [x] `npm run check:waku-bundles`
- [x] `npm run test:waku:workerd`

## Validation

```bash
moon check
moon test
cd examples/web
npm run test:waku:e2e
CI=1 npx playwright test --config=playwright.config.ts --workers=1
npm run build:waku
npm run check:waku-bundles
npm run test:waku:workerd
```
