### PR TITLE
feat(web): migrate Session Resume to native Waku route

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -662,7 +662,7 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
 - [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
   Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#976 migrate Journey, Posts, JSON, Markdown, Mini-ML, and Memo to `/journey`, `/posts`, `/json`, `/markdown`, `/ml`, and `/memo`. Memo exposes its provider controls only in development, while production renders the explicit local-only state. Vite remains the default, and no redirect or production deployment has migrated.
+  Status: #970–#971 establish the dual-run foundation and Hub lifecycle; #972–#977 migrate Journey, Posts, JSON, Markdown, Mini-ML, Memo, and Resume to `/journey`, `/posts`, `/json`, `/markdown`, `/ml`, `/memo`, and `/resume`. Memo and Resume expose provider-backed controls only in development; production keeps their usable local inspection states without provider capabilities. Vite remains the default, and no redirect or production deployment has migrated.
   Exit: the plan's Stage 12 gate passes after production cutover is proven.
 
 ## 22. SDEG Lifecycle

--- a/examples/web/MODULE_MAP.md
+++ b/examples/web/MODULE_MAP.md
@@ -11,7 +11,7 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 | Markdown | `markdown.html` | `src/entries/markdown.ts` | `features/markdown/browser/{app,mount,sentinels}.ts`; `features/markdown/route/{markdown-route,markdown-client}.tsx` | `features/markdown/browser/styles.css`, imported by Vite and Waku composition; adapter CSS remains adapter-owned | Browser + generated MoonBit Markdown; `tests/markdown-editor.spec.ts`, `waku-tests/markdown-route.spec.ts` |
 | Memo | `memo.html` | `src/entries/memo.ts` | `features/memo/core/edit-actions.ts`, `features/memo/browser/{app,mount,view}.ts`, `features/memo/route/{memo-route,memo-client}.tsx` | `features/memo/browser/styles.css`, imported by Vite and development Waku composition | Development browser + generated MoonBit Lambda; production local-only state; `tests/memo-editor.spec.ts`, `waku-tests/memo-route.spec.ts` |
 | Posts | `posts.html` | `src/entries/posts.ts` | `features/posts/core/{posts,post-events,post-retrieval}.ts`, `features/posts/browser/{app,mount,post-events,post-store,view}.ts` | `features/posts/browser/styles.css`, imported by `mount.ts` | Browser persistence shell around deterministic retrieval logic; `tests/post-app.spec.ts` |
-| Resume/PKE | `resume.html` | `src/entries/resume.ts` | `features/resume/browser/app.tsx`, `features/resume/browser/components/*`, `features/resume/core/session.ts`, `features/resume/protocol/chat.ts` | `features/resume/browser/styles.css`, imported by `app.tsx` | Browser React + `server/vite/resume-chat.ts` local chat relay; `tests/pi-resume.spec.ts` |
+| Resume/PKE | `resume.html` | `src/entries/resume.ts` | `features/resume/browser/app.tsx`, `features/resume/browser/components/*`, `features/resume/core/session.ts`, `features/resume/protocol/chat.ts`, `features/resume/route/resume-route.tsx` | scoped `features/resume/browser/styles.css`, imported by `app.tsx` | Browser React + development-only `server/vite/resume-chat.ts` relay; `tests/pi-resume.spec.ts`, `waku-tests/resume-route.spec.ts` |
 | GenUI | `genui.html` | `src/entries/genui.js` | `features/genui/browser/mount.js`, deterministic `features/genui/core/*` (fixtures, schema, flow, recorded candidates, data, spikes), `server/genui/feasibility-provider.js`, and `server/vite/genui-feasibility.ts` | `features/genui/browser/styles.css`, imported by `mount.js`; `src/tailwind.css` remains the GenUI Tailwind input | Browser + generated MoonBit JSX, deterministic feasibility core, and a server-only study relay; `tests/genui.spec.ts`, feasibility suites, colocated core/server Node tests, study scripts |
 | GenUI Possibilities | `genui-possibilities.html` | `src/entries/genui-possibilities.js` | `features/genui-possibilities/core/journey-state.js`, `features/genui-possibilities/browser/mount.js` | `features/genui-possibilities/browser/styles.css`, imported by `mount.js` | Deterministic browser state; `tests/genui-possibilities.spec.ts`, `preview-tests/genui-preview.spec.ts` |
 
@@ -47,13 +47,13 @@ Implementation inventory for the current `examples/web` workspace. The source tr
 
 The active surfaces use the target `src/entries`, `src/features`, and `src/shared` ownership layout. `shared/decoration-overlay.ts` is shared by Lambda and JSON. GenUI keeps deterministic fixtures/flows/schema/recorded candidates in its core, browser DOM/effect code in its browser surface, and Node/provider/Vite capabilities under `server/`. Memo reuses the Lambda generated runtime without importing Lambda feature internals. Styles are partly per-surface and partly adapter-owned. These are inventory facts, not exemptions from the boundary checker.
 
-## Waku migration (pre-production, #970–#976 Stages 0–7)
+## Waku migration (pre-production, #970–#977 Stages 0–8)
 
-Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–7 migrate Journey, Posts, JSON, Markdown, Mini-ML, and Memo while retaining every old HTML entry.
+Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.0-beta.8 + Wrangler 4.114.0 application has landed alongside it. Stage 2 added the Hub, route-lifecycle Module, shell, placeholder routes, and 404; Stages 3–8 migrate Journey, Posts, JSON, Markdown, Mini-ML, Memo, and Resume while retaining every old HTML entry.
 
 ### Stage 0–1 configuration and artifacts
 
-- `waku.config.ts` — Waku configuration with the official Cloudflare adapter (`waku/adapters/cloudflare`) and the shared MoonBit artifact plugin.
+- `waku.config.ts` — Waku configuration with the official Cloudflare adapter (`waku/adapters/cloudflare`), shared MoonBit artifact plugin, and serve-only AST/Resume relays used in development.
 - `src/waku.server.tsx` — Waku server entry using `fsRouter` over `pages/**/*.{tsx,ts}`.
 - `src/pages/foundation.tsx` — foundation probe page (moved from `index.tsx`); renders only a `MoonbitClientProbe` (generated-artifact boundary check, not a migrated demo).
 - `src/pages/_root.tsx` — Waku root document; Stage 2 also anchors shared styles and the long-lived route-lifecycle provider here.
@@ -65,7 +65,8 @@ Vite remains the default build for all eight HTML surfaces. A parallel Waku 1.0.
 
 - `src/pages/index.tsx` — Demo Hub. `/index.html` renders the same Hub without redirect (not a `308`).
 - `src/pages/404.tsx` — accessible true 404 with `aria-labelledby`, `tabIndex={-1}`, semantic heading.
-- `src/pages/{resume,genui}.tsx` — two canonical placeholder routes; each renders `DemoPlaceholder` from the shared shell.
+- `src/pages/genui.tsx` — the remaining canonical placeholder route; it renders `DemoPlaceholder` from the shared shell.
+- `src/pages/resume.tsx` — canonical native React Resume route using its feature-owned route surface directly.
 - `src/pages/ml.tsx` — canonical Mini-ML route; composes its feature-owned controller through the shared imperative host.
 - `src/pages/memo.tsx` — canonical Memo route; composes the local client editor in development and the explicit unavailable state in production.
 - `src/pages/journey.tsx` — canonical Journey route; composes the feature-owned route surface through the shared imperative host.
@@ -127,6 +128,16 @@ Stage 6 remains pre-production. Vite and `markdown.html` remain the defaults and
 - `waku-tests/{lambda-route,memo-route}.spec.ts` — inert SSR shells, runtime failures, allowlisted route memory, focus, reload reset, and live-resource disposal coverage. The production bundle/Worker checks prove Mini-ML has no AST endpoint request and Memo has no development shell, client module, or credential surface; provider fingerprints are permitted only inside the shared Lambda artifact required by Mini-ML.
 
 Stage 7 remains pre-production. Vite `/`/`index.html` and `/memo.html` remain the defaults and are retained. No compatibility redirect, provider proxy, MoonBit API change, or production deployment is active.
+
+### Stage 8 — Session Resume
+
+- `src/features/resume/route/resume-route.tsx` — native React route seam that registers directly with the shared snapshot provider, restores stable allowlisted focus tokens, and purges same-document memory through the shared Forget action without using the imperative host.
+- `src/features/resume/browser/app.tsx` — shared Vite/Waku UI that snapshots only the normalized loaded session, selected path/source, and successful atomic chat turns with their frozen source context. Drafts, attachment choices for the next turn, relay state, partial responses, files, DOM, and controllers remain ephemeral.
+- `server/vite/resume-chat.ts` — existing local relay reused by Vite and Waku development through its serve-only plugin. Production keeps the inspection UI, renders chat as explicitly unavailable, and emits no relay endpoint, secret, or middleware fingerprint.
+- `tests/pi-resume.spec.ts` — existing import, synchronized-view, request-preview, stop/continue, focus, responsive, protocol, and persistence contract, now run against both legacy Vite `/resume.html` and Waku `/resume`.
+- `waku-tests/resume-route.spec.ts` — inert SSR inspection, route-memory/Forget, fragment/focus restoration, pending status/chat abort, reload reset, and zero-persistence coverage.
+
+Stage 8 remains pre-production. Vite `/resume.html` remains the default and is retained. No compatibility redirect, production relay/provider, deployment, or Vite removal is active.
 
 Validation runs in parallel with the Vite pipeline:
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -5,9 +5,9 @@ Lambda (`index.html`), JSON, Markdown, Memo, Posts, Resume/PKE, GenUI, and GenUI
 
 The implementation inventory, source clusters, runtime ownership, tests, Vite relays, generated artifacts, and current boundary debt are documented in [`MODULE_MAP.md`](./MODULE_MAP.md).
 
-## Waku migration (in progress, #976)
+## Waku migration (in progress, #977)
 
-A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–7 migrate Journey Proposals, Posts, JSON, Markdown, Mini-ML, and Memo to `/journey`, `/posts`, `/json`, `/markdown`, `/ml`, and `/memo`. The editor routes restore only their allowlisted document state and rebuild generated-runtime internals after navigation. Memo keeps its browser credential flow in development only; the production Worker renders an explicit local-only state without provider controls. All six retain their legacy HTML entries, while Resume and GenUI remain placeholders. No compatibility redirect, production deployment, or Vite removal is active.
+A parallel Waku application is being built alongside the existing Vite workspace. Vite remains the default and production deploy path until final cutover. Stages 0–2 provide the foundation, Demo Hub, route-lifecycle Module, shared shell, canonical routes, and accessible 404. Stages 3–8 migrate Journey Proposals, Posts, JSON, Markdown, Mini-ML, Memo, and Session Resume to `/journey`, `/posts`, `/json`, `/markdown`, `/ml`, `/memo`, and `/resume`. The editor routes restore only their allowlisted document state and rebuild generated-runtime internals after navigation. Resume retains its normalized session, path/source selection, and completed chat turns in same-document memory while cancelling pending relay work; production keeps inspection available and removes the local chat capability. All seven retain their legacy HTML entries, while GenUI remains a placeholder. No compatibility redirect, production deployment, or Vite removal is active.
 
 ## Development
 

--- a/examples/web/playwright.waku.config.ts
+++ b/examples/web/playwright.waku.config.ts
@@ -11,6 +11,7 @@ process.env.LAMBDA_EDITOR_URL = '/ml';
 process.env.MEMO_EDITOR_URL = '/memo';
 process.env.JSON_EDITOR_URL = '/json';
 process.env.MARKDOWN_EDITOR_URL = '/markdown';
+process.env.PI_RESUME_URL = '/resume';
 
 export default defineConfig({
   testDir: '.',
@@ -22,6 +23,7 @@ export default defineConfig({
     'tests/json-editor.spec.ts',
     'tests/markdown-editor.spec.ts',
     'tests/post-app.spec.ts',
+    'tests/pi-resume.spec.ts',
   ],
   timeout: 30_000,
   retries: 0,
@@ -29,7 +31,7 @@ export default defineConfig({
     baseURL: `http://localhost:${port}`,
   },
   webServer: {
-    command: `CANOPY_SKIP_MOON_BUILD=1 npm run dev:waku -- --port ${port}`,
+    command: `PI_RESUME_CHAT_FAKE=1 PI_RESUME_CHAT_FAKE_DELAY_MS=400 CANOPY_SKIP_MOON_BUILD=1 npm run dev:waku -- --port ${port}`,
     port,
     reuseExistingServer: false,
     timeout: 120_000,

--- a/examples/web/resume.html
+++ b/examples/web/resume.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#ffffff" />
     <title>Canopy · Resume</title>
   </head>
-  <body>
+  <body class="resume-document">
     <div id="root"></div>
     <script type="module" src="/src/entries/resume.ts"></script>
   </body>

--- a/examples/web/scripts/check-waku-bundles.mjs
+++ b/examples/web/scripts/check-waku-bundles.mjs
@@ -10,6 +10,12 @@ const generatedModules = [
   { id: '@moonbit/graphviz', fingerprint: 'render_dot_to_svg' },
 ];
 
+const forbiddenProductionResumeArtifacts = [
+  { capability: 'Resume chat request', fingerprint: '/api/pi-resume-chat' },
+  { capability: 'Resume chat secret', fingerprint: 'DEEPSEEK_API_KEY' },
+  { capability: 'Resume chat relay', fingerprint: 'pi-resume-chat-relay' },
+];
+
 const forbiddenProductionClientArtifacts = [
   { capability: 'Mini-ML AST Grep request', fingerprint: '/api/ast-grep' },
   { capability: 'Memo development shell', fingerprint: 'data-memo-ready' },
@@ -35,6 +41,7 @@ const forbiddenProductionClientArtifacts = [
     fingerprint: 'canopy_llm_edit',
     allowedBundleFingerprint: 'assemble_lambda_handle',
   },
+  ...forbiddenProductionResumeArtifacts,
 ];
 
 export function inspectWakuBundles({ serverBundles, clientBundles }) {
@@ -58,7 +65,18 @@ export function inspectWakuBundles({ serverBundles, clientBundles }) {
       !(allowedBundleFingerprint && source.includes(allowedBundleFingerprint))
     )
     .map(({ name }) => ({ capability, fingerprint, file: name })));
-  return { serverLeaks, missingClientModules, productionClientArtifactLeaks };
+  const productionServerArtifactLeaks = forbiddenProductionResumeArtifacts.flatMap(({
+    capability,
+    fingerprint,
+  }) => serverBundles
+    .filter(({ source }) => source.includes(fingerprint))
+    .map(({ name }) => ({ capability, fingerprint, file: name })));
+  return {
+    serverLeaks,
+    missingClientModules,
+    productionClientArtifactLeaks,
+    productionServerArtifactLeaks,
+  };
 }
 
 function javascriptBundlesBelow(root) {
@@ -85,10 +103,14 @@ function main() {
   for (const { capability, fingerprint, file } of result.productionClientArtifactLeaks) {
     console.error(`${capability} fingerprint ${fingerprint} leaked into production client bundle: ${file}`);
   }
+  for (const { capability, fingerprint, file } of result.productionServerArtifactLeaks) {
+    console.error(`${capability} fingerprint ${fingerprint} leaked into production server bundle: ${file}`);
+  }
   if (
     result.serverLeaks.length > 0 ||
     result.missingClientModules.length > 0 ||
-    result.productionClientArtifactLeaks.length > 0
+    result.productionClientArtifactLeaks.length > 0 ||
+    result.productionServerArtifactLeaks.length > 0
   ) {
     process.exitCode = 1;
   } else {

--- a/examples/web/scripts/smoke-waku-worker.sh
+++ b/examples/web/scripts/smoke-waku-worker.sh
@@ -38,10 +38,21 @@ if grep -Eq 'id="api-key"|Fix Typos|data-imperative-demo-host="memo"' "$BODY_FIL
   echo 'Production Memo route exposed local provider controls' >&2
   exit 1
 fi
+curl -fsS "http://127.0.0.1:${PORT}/resume" >"$BODY_FILE"
+grep -q 'class="pilot-workbench"' "$BODY_FILE"
+grep -q 'data-resume-production-chat-unavailable' "$BODY_FILE"
+grep -q 'Chat is available only in local development' "$BODY_FILE"
+if grep -Eq 'aria-label="Chat message"|/api/pi-resume-chat|DEEPSEEK_API_KEY' "$BODY_FILE"; then
+  echo 'Production Resume route exposed local chat controls or capability' >&2
+  exit 1
+fi
+resume_chat_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+  "http://127.0.0.1:${PORT}/api/pi-resume-chat/status")"
+test "$resume_chat_status" = '404'
 asset="$(find dist/public/assets -type f -name '*.js' -printf '%f\n' | sort | head -n 1)"
 test -n "$asset"
 curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/assets/${asset}"
 worker_status="$(curl -sS -o /dev/null -w '%{http_code}' \
   "http://127.0.0.1:${PORT}/__canopy_worker_probe_missing")"
 test "$worker_status" = '404'
-echo 'Waku workerd Hub and production Memo smoke: OK'
+echo 'Waku workerd Hub, production Memo, and production Resume smoke: OK'

--- a/examples/web/scripts/waku-foundation.test.mjs
+++ b/examples/web/scripts/waku-foundation.test.mjs
@@ -125,6 +125,35 @@ test('rejects the development-only Mini-ML AST Grep request in production bundle
   }]);
 });
 
+test('rejects Resume relay requests, secrets, and middleware in production bundles', () => {
+  const fingerprints = [
+    ['Resume chat request', '/api/pi-resume-chat'],
+    ['Resume chat secret', 'DEEPSEEK_API_KEY'],
+    ['Resume chat relay', 'pi-resume-chat-relay'],
+  ];
+  const source = fingerprints.map(([, fingerprint]) => fingerprint).join('\n');
+  const result = inspectWakuBundles({
+    serverBundles: [{ name: 'dist/server/worker.js', source }],
+    clientBundles: [{ name: 'dist/public/assets/resume-a.js', source }],
+  });
+  assert.deepEqual(result.productionClientArtifactLeaks, fingerprints.map(([
+    capability,
+    fingerprint,
+  ]) => ({
+    capability,
+    fingerprint,
+    file: 'dist/public/assets/resume-a.js',
+  })));
+  assert.deepEqual(result.productionServerArtifactLeaks, fingerprints.map(([
+    capability,
+    fingerprint,
+  ]) => ({
+    capability,
+    fingerprint,
+    file: 'dist/server/worker.js',
+  })));
+});
+
 test('rejects Memo development and provider capabilities outside the shared Lambda artifact', () => {
   const providerFingerprints = [
     'https://generativelanguage.googleapis.com/v1beta/models/',

--- a/examples/web/server/vite/resume-chat.ts
+++ b/examples/web/server/vite/resume-chat.ts
@@ -1,4 +1,5 @@
 import { createDeepSeek } from '@ai-sdk/deepseek';
+import type { ServerResponse } from 'node:http';
 import {
   convertToModelMessages,
   createUIMessageStream,
@@ -71,7 +72,12 @@ function createPkeChatProvider(env: NodeJS.ProcessEnv): PkeChatProvider {
         model: PKE_CHAT_FAKE_MODEL,
         localRelay: true,
       }),
-      respond: async (messages, context, sources, signal) =>
+      respond: async (
+        messages: UIMessage[],
+        context: PkeChatContext,
+        sources: readonly PkeChatSource[],
+        signal: AbortSignal,
+      ) =>
         fakeChatResponse(messages, context, sources, signal, delayMilliseconds),
     });
   }
@@ -96,7 +102,12 @@ function createPkeChatProvider(env: NodeJS.ProcessEnv): PkeChatProvider {
   const deepSeek = createDeepSeek({ apiKey });
   return Object.freeze({
     status,
-    respond: async (messages, context, sources, signal) => {
+    respond: async (
+      messages: UIMessage[],
+      context: PkeChatContext,
+      sources: readonly PkeChatSource[],
+      signal: AbortSignal,
+    ) => {
       const result = streamText({
         model: deepSeek(PKE_CHAT_MODEL),
         system: buildPkeChatSystemPrompt(context, sources),
@@ -114,7 +125,7 @@ function createPkeChatProvider(env: NodeJS.ProcessEnv): PkeChatProvider {
 
 async function statusHandler(
   request: Connect.IncomingMessage,
-  response: Connect.ServerResponse,
+  response: ServerResponse,
   status: PkeChatStatus,
 ): Promise<void> {
   if (request.method !== 'GET') {
@@ -127,7 +138,7 @@ async function statusHandler(
 
 async function chatHandler(
   request: Connect.IncomingMessage,
-  response: Connect.ServerResponse,
+  response: ServerResponse,
   provider: PkeChatProvider,
 ): Promise<void> {
   if (request.method !== 'POST') {
@@ -248,7 +259,7 @@ function fakeChatResponse(
 
 function guardLocalRequest(
   request: Connect.IncomingMessage,
-  response: Connect.ServerResponse,
+  response: ServerResponse,
   requireOrigin: boolean,
 ): boolean {
   const host = request.headers.host;
@@ -268,7 +279,7 @@ function guardLocalRequest(
 
 async function pipeWebResponse(
   source: Response,
-  target: Connect.ServerResponse,
+  target: ServerResponse,
   signal: AbortSignal,
 ): Promise<void> {
   target.statusCode = source.status;
@@ -333,7 +344,7 @@ function isAbortError(error: unknown): boolean {
 }
 
 function sendJson(
-  response: Connect.ServerResponse,
+  response: ServerResponse,
   status: number,
   body: unknown,
 ): void {

--- a/examples/web/src/features/resume/browser/app.tsx
+++ b/examples/web/src/features/resume/browser/app.tsx
@@ -1,8 +1,9 @@
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport, type UIMessage } from 'ai';
+import { DefaultChatTransport, type ChatTransport, type UIMessage } from 'ai';
 import {
   StrictMode,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useRef,
@@ -10,6 +11,7 @@ import {
   type ChangeEvent,
   type KeyboardEvent,
   type MouseEvent,
+  type Ref,
 } from 'react';
 import { createRoot } from 'react-dom/client';
 import fixtureSource from '../../../../tests/fixtures/pi-session-v3.jsonl?raw';
@@ -68,13 +70,22 @@ import './styles.css';
 
 const demoSession = reducePiSession(parsePiSessionJsonl(fixtureSource));
 
-const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
+const productionUnavailableChatTransport: ChatTransport<UIMessage> = Object.freeze({
+  sendMessages: async () => {
+    throw new Error('Resume chat is available only in local development.');
+  },
+  reconnectToStream: async () => null,
+});
+
+const dateTimeFormat = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'UTC',
   month: 'short',
   day: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
 });
-const workbenchTimeFormat = new Intl.DateTimeFormat(undefined, {
+const workbenchTimeFormat = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'UTC',
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
@@ -120,6 +131,11 @@ export const initialResumeState: ResumeState = {
   fileInputGeneration: 0,
 };
 
+const forgottenImportStatus: ImportStatus = Object.freeze({
+  message: 'Imported session forgotten. The demo transcript is active again.',
+  tone: 'idle',
+});
+
 export function reduceResumeState(state: ResumeState, event: ResumeEvent): ResumeState {
   switch (event.type) {
     case 'import-reading':
@@ -157,10 +173,7 @@ export function reduceResumeState(state: ResumeState, event: ResumeEvent): Resum
     case 'forget':
       return {
         ...initialResumeState,
-        importStatus: {
-          message: 'Imported session forgotten. The demo transcript is active again.',
-          tone: 'idle',
-        },
+        importStatus: forgottenImportStatus,
         fileInputGeneration: state.fileInputGeneration + 1,
       };
   }
@@ -317,7 +330,14 @@ function PilotSessionToolbar({
           : 'Example restored';
   return (
     <header className="pilot-session-toolbar" aria-label="Session controls">
-      <h1 id="pilot-view-title" className="visually-hidden">{projectName} session</h1>
+      <h1
+        id="pilot-view-title"
+        className="visually-hidden"
+        tabIndex={-1}
+        data-route-heading
+      >
+        {projectName} session
+      </h1>
       <div className="pilot-file-control">
         <label htmlFor="session-file">Open session</label>
         <input
@@ -325,6 +345,7 @@ function PilotSessionToolbar({
           className="file-input"
           id="session-file"
           type="file"
+          data-route-focus="session-file"
           aria-label="Open session file"
           accept=".jsonl,application/json,text/plain"
           disabled={state.isImporting}
@@ -335,6 +356,7 @@ function PilotSessionToolbar({
         <label className="visually-hidden" htmlFor="branch-select">Session path</label>
         <select
           id="branch-select"
+          data-route-focus="branch-select"
           aria-label="Session path"
           disabled={state.isImporting}
           value={selectedLeafId ?? ''}
@@ -371,6 +393,7 @@ function PilotSessionToolbar({
           className="pilot-forget-session"
           type="button"
           disabled={state.isImporting}
+          data-route-focus="forget-session"
           aria-label="Forget session"
           onClick={onForget}
         >
@@ -506,12 +529,84 @@ interface PilotChatTurnContext {
   readonly sources: readonly PkeChatSource[];
 }
 
+interface PkeCompletedChatTextMessage {
+  readonly id: string;
+  readonly role: 'user' | 'assistant';
+  readonly parts: readonly {
+    readonly type: 'text';
+    readonly text: string;
+  }[];
+}
+
+export interface PkeCompletedChatTurn {
+  readonly user: PkeCompletedChatTextMessage & { readonly role: 'user' };
+  readonly assistant: PkeCompletedChatTextMessage & { readonly role: 'assistant' };
+  readonly context: PkeChatContext;
+  readonly sources: readonly PkeChatSource[];
+}
+
+export interface ResumeRouteSnapshot {
+  readonly version: 1;
+  readonly loaded: {
+    readonly session: ReducedPiSession;
+    readonly sourceMode: 'demo' | 'imported';
+    readonly importedFileName?: string;
+  };
+  readonly selectedLeafId: string | null;
+  readonly selectedSourceEntryId: string | null;
+  readonly completedChat: readonly PkeCompletedChatTurn[];
+}
+
+const EMPTY_COMPLETED_CHAT: readonly PkeCompletedChatTurn[] = Object.freeze([]);
+
 const NO_HISTORY_CHAT_CONTEXT: PilotChatTurnContext = Object.freeze({
   context: Object.freeze({ scope: 'none' }),
   sources: Object.freeze([]),
 });
 
 const PKE_CHAT_CITATION_HREF_PREFIX = '#canopy-source-';
+
+function completedChatHistory(
+  messages: readonly UIMessage[],
+  contextByMessageId: ReadonlyMap<string, PilotChatTurnContext>,
+): readonly PkeCompletedChatTurn[] {
+  const textMessages = pkeChatTextMessages(messages);
+  return Object.freeze(textMessages.flatMap((user, index) => {
+    if (index % 2 !== 0 || user.role !== 'user') return [];
+    const assistant = textMessages[index + 1];
+    const turnContext = contextByMessageId.get(user.id);
+    if (
+      assistant?.role !== 'assistant' ||
+      turnContext === undefined ||
+      user.parts.length === 0 ||
+      assistant.parts.length === 0 ||
+      user.parts.some(part => typeof part.text !== 'string') ||
+      assistant.parts.some(part => typeof part.text !== 'string')
+    ) {
+      return [];
+    }
+    return [Object.freeze({
+      user: Object.freeze({
+        id: user.id,
+        role: 'user' as const,
+        parts: Object.freeze(user.parts.map(part => Object.freeze({
+          type: 'text' as const,
+          text: part.text!,
+        }))),
+      }),
+      assistant: Object.freeze({
+        id: assistant.id,
+        role: 'assistant' as const,
+        parts: Object.freeze(assistant.parts.map(part => Object.freeze({
+          type: 'text' as const,
+          text: part.text!,
+        }))),
+      }),
+      context: turnContext.context,
+      sources: turnContext.sources,
+    })];
+  }));
+}
 
 function sourceLinkedChatMarkdown(
   text: string,
@@ -544,21 +639,28 @@ function PilotSourceChat({
   projection,
   selectedSource,
   sourceEntryIds,
+  initialCompletedChat,
   onToggleSource,
   onOpenSource,
+  onCompletedChatChange,
 }: {
   readonly projection: ResumeProjection;
   readonly selectedSource: PilotSourceSelection;
   readonly sourceEntryIds: readonly string[];
+  readonly initialCompletedChat: readonly PkeCompletedChatTurn[];
   readonly onToggleSource: (entryId: string) => void;
   readonly onOpenSource: (entryId: string, leafId: string) => void;
+  readonly onCompletedChatChange: (history: readonly PkeCompletedChatTurn[]) => void;
 }) {
   const [draft, setDraft] = useState('');
   const [draftMessageId, setDraftMessageId] = useState(() => crypto.randomUUID());
   const [contextScope, setContextScope] = useState<PkeChatContext['scope']>('none');
   const [contextByMessageId, setContextByMessageId] = useState<
     ReadonlyMap<string, PilotChatTurnContext>
-  >(() => new Map());
+  >(() => new Map(initialCompletedChat.map(turn => [
+    turn.user.id,
+    Object.freeze({ context: turn.context, sources: turn.sources }),
+  ])));
   const [showPayload, setShowPayload] = useState(false);
   const [relayStatus, setRelayStatus] = useState<PkeChatStatus>();
   const [relayStatusError, setRelayStatusError] = useState<string>();
@@ -599,17 +701,19 @@ function PilotSourceChat({
   );
   const outboundContextRef = useRef<PkeChatContext>(currentContext);
   const outboundSourcesRef = useRef<readonly PkeChatSource[]>(sourcePayload);
-  const transport = useMemo(
-    () => new DefaultChatTransport<UIMessage>({
-      api: '/api/pi-resume-chat',
-      prepareSendMessagesRequest: ({ messages }) => ({
-        body: {
-          messages: pkeChatTextMessages(messages),
-          context: outboundContextRef.current,
-          sources: outboundSourcesRef.current,
-        },
-      }),
-    }),
+  const transport = useMemo<ChatTransport<UIMessage>>(
+    () => import.meta.env.DEV
+      ? new DefaultChatTransport<UIMessage>({
+          api: '/api/pi-resume-chat',
+          prepareSendMessagesRequest: ({ messages }) => ({
+            body: {
+              messages: pkeChatTextMessages(messages),
+              context: outboundContextRef.current,
+              sources: outboundSourcesRef.current,
+            },
+          }),
+        })
+      : productionUnavailableChatTransport,
     [],
   );
   const {
@@ -623,6 +727,15 @@ function PilotSourceChat({
   } = useChat<UIMessage>({
     id: `pke-chat:${projection.sessionId}`,
     transport,
+    messages: initialCompletedChat.flatMap(turn => [turn.user, turn.assistant].map(message => ({
+      id: message.id,
+      role: message.role,
+      parts: message.parts.map(part => ({ type: part.type, text: part.text })),
+    }))),
+    onFinish: ({ messages: completedMessages, isAbort, isDisconnect, isError }) => {
+      if (isAbort || isDisconnect || isError) return;
+      onCompletedChatChange(completedChatHistory(completedMessages, contextByMessageId));
+    },
   });
   const restoreUnansweredUserMessage = (): void => {
     const trailingMessage = messages[messages.length - 1];
@@ -663,6 +776,7 @@ function PilotSourceChat({
     setDraft(current => current.trim().length === 0 ? text : current);
   }, [error, messages, setMessages]);
   useEffect(() => {
+    if (!import.meta.env.DEV) return;
     const controller = new AbortController();
     void fetch('/api/pi-resume-chat/status', { signal: controller.signal })
       .then(async response => {
@@ -710,16 +824,18 @@ function PilotSourceChat({
   const selectedSourceIncluded = sourceEntryIds.includes(selectedSource.entryId);
   const sourceLimitReached = sourceEntryIds.length >= PKE_CHAT_SOURCE_LIMIT;
   const running = status === 'submitted' || status === 'streaming';
-  const relayAvailable = relayStatus?.available === true;
+  const relayAvailable = import.meta.env.DEV && relayStatus?.available === true;
   const requestTooLarge = outboundBytes > PKE_CHAT_REQUEST_MAX_BYTES;
   const messageLimitReached = messages.length >= PKE_CHAT_MESSAGE_LIMIT;
   const canSend = relayAvailable && pendingMessage !== undefined &&
     !requestTooLarge && !messageLimitReached;
-  const providerLabel = relayStatus === undefined
-    ? 'Checking local relay…'
-    : relayStatus.provider === 'fake'
-      ? 'Test model · local relay'
-      : 'DeepSeek V4 Flash · local relay';
+  const providerLabel = !import.meta.env.DEV
+    ? 'Chat unavailable · production'
+    : relayStatus === undefined
+      ? 'Checking local relay…'
+      : relayStatus.provider === 'fake'
+        ? 'Test model · local relay'
+        : 'DeepSeek V4 Flash · local relay';
 
   return (
     <section className="pilot-source-chat" aria-labelledby="pilot-source-chat-title">
@@ -932,12 +1048,20 @@ function PilotSourceChat({
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
-      {relayStatus?.available === false ? (
+      {!import.meta.env.DEV ? (
+        <p
+          className="pilot-chat-unavailable"
+          data-resume-production-chat-unavailable
+          role="status"
+        >
+          Chat is available only in local development. Session inspection remains fully available.
+        </p>
+      ) : relayStatus?.available === false ? (
         <p className="pilot-chat-unavailable" role="status">
           Set DEEPSEEK_API_KEY and restart the local server to send messages.
         </p>
       ) : null}
-      {relayStatusError === undefined ? null : (
+      {!import.meta.env.DEV || relayStatusError === undefined ? null : (
         <p className="pilot-chat-error" role="alert">{relayStatusError}</p>
       )}
       {requestTooLarge ? (
@@ -957,7 +1081,7 @@ function PilotSourceChat({
           <button type="button" onClick={clearError}>Dismiss</button>
         </p>
       )}
-      <PromptInput
+      {!import.meta.env.DEV ? null : <PromptInput
         onSubmit={event => {
           event.preventDefault();
           if (running) {
@@ -986,6 +1110,7 @@ function PilotSourceChat({
         <PromptInputBody>
           <PromptInputTextarea
             aria-label="Chat message"
+            data-route-focus="chat-message"
             disabled={!relayAvailable || running || messageLimitReached}
             maxLength={PKE_CHAT_MESSAGE_TEXT_LIMIT}
             placeholder="Ask anything…"
@@ -1010,7 +1135,7 @@ function PilotSourceChat({
             status={status}
           />
         </PromptInputFooter>
-      </PromptInput>
+      </PromptInput>}
     </section>
   );
 }
@@ -1021,18 +1146,22 @@ function PilotUnderstandingWorkbench({
   selectedSource,
   chatInstanceId,
   chatSourceEntryIds,
+  initialCompletedChat,
   onSelectEntry,
   onSelectChatSource,
   onToggleChatSource,
+  onCompletedChatChange,
 }: {
   readonly projection: ResumeProjection;
   readonly entries: readonly NormalizedEntry[];
   readonly selectedSource: PilotSourceSelection;
   readonly chatInstanceId: string;
   readonly chatSourceEntryIds: readonly string[];
+  readonly initialCompletedChat: readonly PkeCompletedChatTurn[];
   readonly onSelectEntry: (entryId: string) => void;
   readonly onSelectChatSource: (entryId: string, leafId: string) => void;
   readonly onToggleChatSource: (entryId: string) => void;
+  readonly onCompletedChatChange: (history: readonly PkeCompletedChatTurn[]) => void;
 }) {
   const phases = useMemo(
     () => buildPilotTimelinePhases(projection.chronology),
@@ -1085,6 +1214,7 @@ function PilotUnderstandingWorkbench({
   const conversationPanelRef = useRef<HTMLElement | null>(null);
   const selectedConversationRef = useRef<HTMLLIElement | null>(null);
   const revealConversationSelectionRef = useRef(false);
+  const focusConversationSelectionRef = useRef(false);
   const [inspectorMode, setInspectorMode] = useState<PilotInspectorMode>('discuss');
   const [evidenceMode, setEvidenceMode] = useState<PilotEvidenceMode>('readable');
   const selectedItemIndex = Math.max(
@@ -1143,7 +1273,11 @@ function PilotUnderstandingWorkbench({
       } else if (revealConversationSelectionRef.current) {
         target.scrollIntoView({ block: 'center', behavior: 'auto' });
       }
+      if (focusConversationSelectionRef.current) {
+        target.focus({ preventScroll: true });
+      }
       revealConversationSelectionRef.current = false;
+      focusConversationSelectionRef.current = false;
     });
     return () => window.cancelAnimationFrame(frame);
   }, [activePane, selectedSource.entryId]);
@@ -1157,17 +1291,8 @@ function PilotUnderstandingWorkbench({
   const selectConversationAt = (index: number, focus: boolean): void => {
     const item = conversationItems[index];
     if (item === undefined) return;
+    focusConversationSelectionRef.current = focus;
     onSelectEntry(item.source.entryId);
-    if (!focus) return;
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        const options = conversationPanelRef.current
-          ?.querySelectorAll<HTMLElement>('[data-entry-id]');
-        [...(options ?? [])]
-          .find(option => option.dataset.entryId === item.source.entryId)
-          ?.focus({ preventScroll: true });
-      });
-    });
   };
 
   const handleConversationKeyDown = (
@@ -1319,6 +1444,7 @@ function PilotUnderstandingWorkbench({
                 <li
                   data-role={role}
                   data-entry-id={item.source.entryId}
+                  data-route-focus={`conversation:${item.source.entryId}`}
                   data-anchor={item.anchorKind}
                   data-selected={selected}
                   data-status={item.evidenceStatus}
@@ -1442,7 +1568,9 @@ function PilotUnderstandingWorkbench({
               projection={projection}
               selectedSource={selectedSource}
               sourceEntryIds={chatSourceEntryIds}
+              initialCompletedChat={initialCompletedChat}
               onToggleSource={onToggleChatSource}
+              onCompletedChatChange={onCompletedChatChange}
               onOpenSource={(entryId, leafId) => {
                 onSelectChatSource(entryId, leafId);
                 setActivePane('evidence');
@@ -1557,9 +1685,63 @@ function Diagnostics({ items }: { readonly items: readonly ResumeDiagnostic[] })
   );
 }
 
-export function ResumeApp() {
-  const [state, dispatch] = useReducer(reduceResumeState, initialResumeState);
-  const [pilotState, dispatchPilot] = useReducer(reducePilotViewState, initialPilotViewState);
+interface ResumeAppProps {
+  readonly initialSnapshot?: ResumeRouteSnapshot;
+  readonly initialDemoRestored?: boolean;
+  readonly onSnapshotChange?: (snapshot: ResumeRouteSnapshot) => void;
+  readonly onForgetSnapshot?: () => void;
+  readonly surfaceRef?: Ref<HTMLDivElement>;
+}
+
+export function ResumeApp({
+  initialSnapshot,
+  initialDemoRestored = false,
+  onSnapshotChange,
+  onForgetSnapshot,
+  surfaceRef,
+}: ResumeAppProps = {}) {
+  const restoredState: ResumeState = initialSnapshot === undefined
+    ? initialDemoRestored
+      ? { ...initialResumeState, importStatus: forgottenImportStatus }
+      : initialResumeState
+    : {
+        session: initialSnapshot.loaded.session,
+        sourceMode: initialSnapshot.loaded.sourceMode,
+        ...(initialSnapshot.loaded.importedFileName === undefined
+          ? {}
+          : { importedFileName: initialSnapshot.loaded.importedFileName }),
+        selectedLeafId: initialSnapshot.selectedLeafId,
+        isImporting: false,
+        importStatus: {
+          message: initialSnapshot.loaded.sourceMode === 'imported'
+            ? 'Imported session restored from same-tab memory.'
+            : '',
+          tone: 'idle',
+        },
+        fileInputGeneration: 0,
+      };
+  const restoredPilotState: PilotViewState = initialSnapshot?.selectedSourceEntryId == null
+    ? initialPilotViewState
+    : {
+        selectedSource: { entryId: initialSnapshot.selectedSourceEntryId },
+        chatSourceEntryIds: Object.freeze([]),
+      };
+  const [state, dispatch] = useReducer(reduceResumeState, restoredState);
+  const [pilotState, dispatchPilot] = useReducer(reducePilotViewState, restoredPilotState);
+  const [ready, setReady] = useState(false);
+  useLayoutEffect(() => setReady(true), []);
+  const restoredChatInstanceId = initialSnapshot === undefined
+    ? undefined
+    : `${restoredState.sourceMode}:${restoredState.fileInputGeneration}:${restoredState.session.header.sessionId}`;
+  const [completedChatMemory, setCompletedChatMemory] = useState<{
+    readonly instanceId: string;
+    readonly history: readonly PkeCompletedChatTurn[];
+  } | undefined>(() => restoredChatInstanceId === undefined
+    ? undefined
+    : {
+        instanceId: restoredChatInstanceId,
+        history: initialSnapshot?.completedChat ?? EMPTY_COMPLETED_CHAT,
+      });
   const effectiveLeafId = state.selectedLeafId ?? (
     state.sourceMode === 'demo' ? state.session.terminalPaths[0]?.leafId ?? null : null
   );
@@ -1571,6 +1753,27 @@ export function ResumeApp() {
   const effectivePilotSource: PilotSourceSelection | undefined = pilotState.selectedSource ??
     (defaultItem === undefined ? undefined : { entryId: defaultItem.source.entryId });
   const diagnostics = state.diagnosticOverride ?? projection?.diagnostics ?? state.session.diagnostics;
+  const chatInstanceId = `${state.sourceMode}:${state.fileInputGeneration}:${state.session.header.sessionId}`;
+  const completedChat = completedChatMemory?.instanceId === chatInstanceId
+    ? completedChatMemory.history
+    : EMPTY_COMPLETED_CHAT;
+  const routeSnapshot = useMemo<ResumeRouteSnapshot>(() => Object.freeze({
+    version: 1,
+    loaded: Object.freeze({
+      session: state.session,
+      sourceMode: state.sourceMode,
+      ...(state.importedFileName === undefined
+        ? {}
+        : { importedFileName: state.importedFileName }),
+    }),
+    selectedLeafId: state.selectedLeafId,
+    selectedSourceEntryId: effectivePilotSource?.entryId ?? null,
+    completedChat,
+  }), [completedChat, effectivePilotSource?.entryId, state.importedFileName,
+    state.selectedLeafId, state.session, state.sourceMode]);
+  useLayoutEffect(() => {
+    onSnapshotChange?.(routeSnapshot);
+  }, [onSnapshotChange, routeSnapshot]);
   const importSessionFile = async (file: File): Promise<void> => {
     dispatchPilot({ type: 'reset' });
     dispatch({ type: 'import-reading', fileName: file.name });
@@ -1595,7 +1798,7 @@ export function ResumeApp() {
   const revealSource = (entryId: string): void => {
     if (projection?.chronology.some(item => item.source.entryId === entryId) !== true) return;
     dispatchPilot({ type: 'open-source', entryId });
-    window.history.replaceState(null, '', `#source-${entryId}`);
+    window.history.replaceState(window.history.state, '', `#source-${entryId}`);
   };
   const revealChatSource = (entryId: string, leafId: string): void => {
     if (projection?.leafId === leafId) { revealSource(entryId); return; }
@@ -1603,33 +1806,47 @@ export function ResumeApp() {
         !state.session.entries.some(entry => entry.id === entryId)) return;
     dispatchPilot({ type: 'open-source', entryId });
     dispatch({ type: 'select-leaf', leafId });
-    window.history.replaceState(null, '', `#source-${entryId}`);
+    window.history.replaceState(window.history.state, '', `#source-${entryId}`);
   };
   const forgetSession = (): void => {
+    onForgetSnapshot?.();
+    setCompletedChatMemory(undefined);
     dispatchPilot({ type: 'reset' });
     dispatch({ type: 'forget' });
   };
   return (
-    <main className="pilot-shell">
-      <PilotSessionToolbar
-        state={state} pathLength={projection?.path.length ?? 0} selectedLeafId={effectiveLeafId}
-        onFile={file => void importSessionFile(file)}
-        onSelectPath={leafId => { dispatchPilot({ type: 'reset' }); dispatch({ type: 'select-leaf', leafId }); }}
-        onForget={forgetSession}
-      />
-      <section className="pilot-workspace" data-layout="resume">
-        {state.isImporting || projection === undefined || effectivePilotSource === undefined ? <PilotEmptyWorkspace state={state} /> : (
-          <PilotUnderstandingWorkbench
-            projection={projection} entries={state.session.entries} selectedSource={effectivePilotSource}
-            chatInstanceId={`${state.sourceMode}:${state.fileInputGeneration}:${state.session.header.sessionId}`}
-            chatSourceEntryIds={pilotState.chatSourceEntryIds}
-            onSelectEntry={revealSource} onSelectChatSource={revealChatSource}
-            onToggleChatSource={entryId => dispatchPilot({ type: 'toggle-chat-source', entryId })}
-          />
-        )}
-      </section>
-      <Diagnostics items={diagnostics} />
-    </main>
+    <div
+      className="resume-surface"
+      data-resume-ready={ready ? 'true' : 'false'}
+      inert={ready ? undefined : true}
+      ref={surfaceRef}
+    >
+      <main className="pilot-shell">
+        <PilotSessionToolbar
+          state={state} pathLength={projection?.path.length ?? 0} selectedLeafId={effectiveLeafId}
+          onFile={file => void importSessionFile(file)}
+          onSelectPath={leafId => { dispatchPilot({ type: 'reset' }); dispatch({ type: 'select-leaf', leafId }); }}
+          onForget={forgetSession}
+        />
+        <section className="pilot-workspace" data-layout="resume">
+          {state.isImporting || projection === undefined || effectivePilotSource === undefined ? <PilotEmptyWorkspace state={state} /> : (
+            <PilotUnderstandingWorkbench
+              projection={projection} entries={state.session.entries} selectedSource={effectivePilotSource}
+              chatInstanceId={chatInstanceId}
+              chatSourceEntryIds={pilotState.chatSourceEntryIds}
+              initialCompletedChat={completedChat}
+              onSelectEntry={revealSource} onSelectChatSource={revealChatSource}
+              onToggleChatSource={entryId => dispatchPilot({ type: 'toggle-chat-source', entryId })}
+              onCompletedChatChange={history => setCompletedChatMemory({
+                instanceId: chatInstanceId,
+                history,
+              })}
+            />
+          )}
+        </section>
+        <Diagnostics items={diagnostics} />
+      </main>
+    </div>
   );
 }
 

--- a/examples/web/src/features/resume/browser/app.tsx
+++ b/examples/web/src/features/resume/browser/app.tsx
@@ -1291,6 +1291,11 @@ function PilotUnderstandingWorkbench({
   const selectConversationAt = (index: number, focus: boolean): void => {
     const item = conversationItems[index];
     if (item === undefined) return;
+    if (item.source.entryId === selectedSource.entryId) {
+      focusConversationSelectionRef.current = false;
+      if (focus) selectedConversationRef.current?.focus({ preventScroll: true });
+      return;
+    }
     focusConversationSelectionRef.current = focus;
     onSelectEntry(item.source.entryId);
   };

--- a/examples/web/src/features/resume/browser/styles.css
+++ b/examples/web/src/features/resume/browser/styles.css
@@ -1,4 +1,10 @@
-:root {
+body.resume-document {
+  min-width: 320px;
+  margin: 0;
+  background: #ffffff;
+}
+
+.resume-surface {
   --bg: #ffffff;
   --panel: #f6f6f6;
   --surface: #f6f6f6;
@@ -39,10 +45,21 @@
   --space-3xl: 48px;
   --space-4xl: 64px;
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  min-width: 320px;
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--text);
   color-scheme: light;
+  font-family: "Noto Sans", "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
+  font-feature-settings: normal;
+  letter-spacing: 0.05em;
+  line-height: 1.9;
 }
 
-* { box-sizing: border-box; }
+.resume-surface,
+.resume-surface * { box-sizing: border-box; }
+
+@scope (.resume-surface) {
 
 .visually-hidden {
   position: absolute;
@@ -52,19 +69,6 @@
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   white-space: nowrap;
-}
-
-html { scroll-behavior: smooth; }
-
-body {
-  margin: 0;
-  min-width: 320px;
-  background: var(--bg);
-  color: var(--text);
-  font-family: "Noto Sans", "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
-  font-feature-settings: normal;
-  letter-spacing: 0.05em;
-  line-height: 1.9;
 }
 
 button, select { font: inherit; }
@@ -1956,4 +1960,6 @@ select {
   .pilot-evidence-metadata {
     grid-template-columns: 1fr;
   }
+}
+
 }

--- a/examples/web/src/features/resume/browser/styles.css
+++ b/examples/web/src/features/resume/browser/styles.css
@@ -45,6 +45,7 @@ body.resume-document {
   --space-3xl: 48px;
   --space-4xl: 64px;
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+
   min-width: 320px;
   min-height: 100dvh;
   background: var(--bg);

--- a/examples/web/src/features/resume/route/resume-route.tsx
+++ b/examples/web/src/features/resume/route/resume-route.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  useRouteLifecycle,
+  useRouteSnapshot,
+} from '../../../shared/route-lifecycle/browser/provider';
+import {
+  ResumeApp,
+  type ResumeRouteSnapshot,
+} from '../browser/app';
+
+const resumeControlFocusTokens = Object.freeze([
+  'session-file',
+  'branch-select',
+  'forget-session',
+  'chat-message',
+]);
+
+export function ResumeRoute() {
+  const [lifetime, setLifetime] = useState(0);
+  const remountAfterForget = useCallback(() => {
+    setLifetime(current => current + 1);
+  }, []);
+
+  return (
+    <ResumeRouteLifetime
+      key={lifetime}
+      initialDemoRestored={lifetime > 0}
+      onForget={remountAfterForget}
+    />
+  );
+}
+
+function ResumeRouteLifetime({
+  initialDemoRestored,
+  onForget,
+}: {
+  readonly initialDemoRestored: boolean;
+  readonly onForget: () => void;
+}) {
+  const lifecycle = useRouteLifecycle();
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const snapshotRef = useRef<ResumeRouteSnapshot | undefined>(undefined);
+  const restoredSnapshot = useRouteSnapshot<ResumeRouteSnapshot | undefined>('resume', {
+    snapshot: () => snapshotRef.current,
+    restoreFocus(token) {
+      const accepted = resumeControlFocusTokens.includes(token) ||
+        token.startsWith('conversation:');
+      if (!accepted) return false;
+      const target = [...(surfaceRef.current
+        ?.querySelectorAll<HTMLElement>('[data-route-focus]') ?? [])]
+        .find(candidate => candidate.dataset.routeFocus === token);
+      if (target === undefined) return false;
+      target.focus({ preventScroll: true });
+      return document.activeElement === target;
+    },
+  });
+  const captureSnapshot = useCallback((snapshot: ResumeRouteSnapshot) => {
+    snapshotRef.current = snapshot;
+  }, []);
+  const forgetSnapshot = useCallback(() => {
+    lifecycle.forget('resume');
+    onForget();
+  }, [lifecycle, onForget]);
+
+  return (
+    <ResumeApp
+      initialSnapshot={restoredSnapshot}
+      initialDemoRestored={initialDemoRestored}
+      onSnapshotChange={captureSnapshot}
+      onForgetSnapshot={forgetSnapshot}
+      surfaceRef={surfaceRef}
+    />
+  );
+}

--- a/examples/web/src/pages/resume.tsx
+++ b/examples/web/src/pages/resume.tsx
@@ -1,5 +1,5 @@
-import { DemoPlaceholder } from '../shared/shell/demo-placeholder';
+import { ResumeRoute } from '../features/resume/route/resume-route';
 
 export default function Resume() {
-  return <DemoPlaceholder demoId="resume" />;
+  return <ResumeRoute />;
 }

--- a/examples/web/tests/pi-resume.spec.ts
+++ b/examples/web/tests/pi-resume.spec.ts
@@ -1,6 +1,13 @@
 import path from 'node:path';
 import { test, expect } from '@playwright/test';
 
+const resumeUrl = process.env.PI_RESUME_URL ?? '/resume.html';
+
+async function gotoResume(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto(resumeUrl);
+  await expect(page.locator('[data-resume-ready="true"]')).toBeVisible();
+}
+
 async function loadFixture(page: import('@playwright/test').Page): Promise<string> {
   const result = await page.evaluate(async () => {
     const response = await fetch('/tests/fixtures/pi-session-v3.jsonl');
@@ -11,13 +18,13 @@ async function loadFixture(page: import('@playwright/test').Page): Promise<strin
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/resume.html');
+  await gotoResume(page);
   await expect(page.locator('.pilot-workbench')).toBeVisible();
 });
 
 test.describe('PKE workbench', () => {
   test('synchronizes Timeline, Conversation, and Evidence without provider or storage access', async ({ page }) => {
-    await page.goto('/resume.html');
+    await gotoResume(page);
 
     await expect(page.locator('.pilot-condition-gate')).toHaveCount(0);
     await expect(page.locator('.pilot-wordmark, .pilot-topbar, .pilot-session-header')).toHaveCount(0);
@@ -164,7 +171,7 @@ test.describe('PKE workbench', () => {
       if (new URL(request.url()).pathname !== '/api/pi-resume-chat' || request.method() !== 'POST') return;
       postedRequests.push(request.postDataJSON());
     });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     const prompt = chat.getByLabel('Chat message');
     await expect(prompt).toBeEnabled();
@@ -208,7 +215,7 @@ test.describe('PKE workbench', () => {
 
   test('retains sensitive-pattern excerpts and warns before explicit egress', async ({ page }) => {
     const fixture = await loadFixture(page);
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const retainedText = 'api_key: fixture-only-value for the retained product direction';
     await page.getByLabel('Open session file').setInputFiles({
       name: 'sensitive-warning-session.jsonl',
@@ -243,7 +250,7 @@ test.describe('PKE workbench', () => {
       if (new URL(request.url()).pathname !== '/api/pi-resume-chat' || request.method() !== 'POST') return;
       postedRequests.push(request.postDataJSON());
     });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     const prompt = chat.getByLabel('Chat message');
     const question = 'What changed across these exact moments?';
@@ -366,7 +373,7 @@ test.describe('PKE workbench', () => {
       if (new URL(request.url()).pathname !== '/api/pi-resume-chat' || request.method() !== 'POST') return;
       postedRequests.push(request.postDataJSON());
     });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     await chat.getByRole('button', { name: /Current path/ }).click();
     await chat.getByLabel('Chat message').fill('Look across the whole current path.');
@@ -389,7 +396,7 @@ test.describe('PKE workbench', () => {
       if (new URL(request.url()).pathname !== '/api/pi-resume-chat' || request.method() !== 'POST') return;
       postedRequests.push(request.postDataJSON());
     });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     await chat.getByRole('button', { name: 'Add current moment' }).click();
     await chat.getByLabel('Chat message').fill('Finish with the context attached to this turn.');
@@ -414,7 +421,7 @@ test.describe('PKE workbench', () => {
       if (new URL(request.url()).pathname !== '/api/pi-resume-chat' || request.method() !== 'POST') return;
       postedRequests.push(request.postDataJSON());
     });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     const prompt = chat.getByLabel('Chat message');
     await chat.getByRole('button', { name: 'Add current moment' }).click();
@@ -452,7 +459,7 @@ test.describe('PKE workbench', () => {
         body: JSON.stringify({ message: 'Fixture relay failure.' }),
       });
     });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     const prompt = chat.getByLabel('Chat message');
     await prompt.fill('Restore this failed message.');
@@ -468,7 +475,7 @@ test.describe('PKE workbench', () => {
   });
 
   test('clears and aborts chat as soon as a new import starts', async ({ page }) => {
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const chat = page.locator('.pilot-source-chat');
     await chat.getByLabel('Chat message').fill('Do not survive a new import.');
     await chat.getByRole('button', { name: 'Send' }).click();
@@ -484,7 +491,7 @@ test.describe('PKE workbench', () => {
   });
 
   test('fails closed at the local source-chat relay boundary', async ({ page }) => {
-    await page.goto('/resume.html');
+    await gotoResume(page);
     const status = await page.request.get('/api/pi-resume-chat/status');
     expect(status.status()).toBe(200);
     await expect(status.json()).resolves.toMatchObject({
@@ -511,7 +518,7 @@ test.describe('PKE workbench', () => {
 
   test('adapts the synchronized workbench to mobile view tabs without losing context', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('/resume.html');
+    await gotoResume(page);
     await page.getByLabel('Open session file').setInputFiles(
       path.resolve('tests/fixtures/pi-session-v3.jsonl'),
     );
@@ -543,7 +550,7 @@ test.describe('PKE workbench', () => {
 
   test('fully frames desktop scrollers and removes nested scrolling on narrow screens', async ({ page }) => {
     await page.setViewportSize({ width: 1024, height: 768 });
-    await page.goto('/resume.html');
+    await gotoResume(page);
 
     const desktopShell = await page.locator('.pilot-shell').boundingBox();
     const desktopToolbar = await page.locator('.pilot-session-toolbar').boundingBox();
@@ -601,7 +608,7 @@ test.describe('PKE workbench', () => {
       { width: 320, height: 700 },
     ]) {
       await page.setViewportSize(viewport);
-      await page.goto('/resume.html');
+      await gotoResume(page);
       await expect(page.evaluate(() => {
         const panel = document.querySelector<HTMLElement>('.pilot-conversation');
         const heading = panel?.querySelector<HTMLElement>('.pilot-panel-heading');

--- a/examples/web/tests/pi-resume.spec.ts
+++ b/examples/web/tests/pi-resume.spec.ts
@@ -135,12 +135,16 @@ test.describe('PKE workbench', () => {
     await expect(nextAssistantOption).toBeFocused();
     await expect(nextAssistantOption).toHaveAttribute('aria-selected', 'true');
     await nextAssistantOption.press('Home');
-    await expect(conversation.locator('[data-entry-id="00000001"]')).toBeFocused();
+    const firstConversationOption = conversation.locator('[data-entry-id="00000001"]');
+    await expect(firstConversationOption).toBeFocused();
+    await firstConversationOption.press('Enter');
     await page.getByRole('tab', { name: 'Normalized record' }).click();
     await expect(page.locator('.pilot-evidence-normalized')).toContainText('"id": "00000001"');
     await page.getByRole('tab', { name: 'Readable' }).click();
     await page.getByRole('button', { name: /Phase 02/ }).click();
-    await page.locator('#source-0000000b button').click();
+    const failedTimelineButton = page.locator('#source-0000000b button');
+    await failedTimelineButton.click();
+    await expect(failedTimelineButton).toBeFocused();
     await expect(page.locator('#source-0000000b')).toHaveAttribute('aria-current', 'true');
     await expect(page.locator('.pilot-evidence-copy')).toContainText('test failed');
     await expect(page.locator('.pilot-operation-relation')).toContainText(

--- a/examples/web/waku-tests/resume-route.spec.ts
+++ b/examples/web/waku-tests/resume-route.spec.ts
@@ -1,0 +1,254 @@
+import path from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForResume(page: Page): Promise<void> {
+  await expect(page.locator('[data-resume-ready]'))
+    .toHaveAttribute('data-resume-ready', 'true');
+}
+
+async function enterResumeFromHub(page: Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.locator('[data-route-lifecycle-ready]'))
+    .toHaveAttribute('data-route-lifecycle-ready', 'true');
+  await page.getByRole('link', { name: /Session Resume/ }).click();
+  await waitForResume(page);
+  await expect(page).toHaveURL(/\/resume$/);
+}
+
+async function importFixture(page: Page): Promise<void> {
+  await page.getByLabel('Open session file').setInputFiles(
+    path.resolve('tests/fixtures/pi-session-v3.jsonl'),
+  );
+  await expect(page.locator('.pilot-session-status')).toContainText('pi-session-v3.jsonl');
+  await page.locator('#branch-select').selectOption('0000000f');
+}
+
+test('keeps the server-rendered Resume inspection inert without client JavaScript', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  try {
+    const page = await context.newPage();
+    const response = await page.goto('/resume');
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('[data-resume-ready]')).toHaveAttribute('inert', '');
+    await expect(page.locator('[data-resume-ready]'))
+      .toHaveAttribute('data-resume-ready', 'false');
+    await expect(page.locator('.pilot-workbench')).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});
+
+test('hydrates the server-rendered timestamps in a different client time zone', async ({ browser }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (typeof baseURL !== 'string') throw new Error('Waku test baseURL is unavailable');
+  const serverContext = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  const clientContext = await browser.newContext({ baseURL, timezoneId: 'America/New_York' });
+  try {
+    const serverPage = await serverContext.newPage();
+    await serverPage.goto('/resume');
+    const serverTimestamps = await serverPage.locator('time').allTextContents();
+    expect(serverTimestamps.length).toBeGreaterThan(0);
+
+    const hydrationErrors: string[] = [];
+    const clientPage = await clientContext.newPage();
+    clientPage.on('console', message => {
+      if (
+        message.type() === 'error' &&
+        /hydration|server rendered html|didn't match/i.test(message.text())
+      ) {
+        hydrationErrors.push(message.text());
+      }
+    });
+    await clientPage.goto('/resume');
+    await waitForResume(clientPage);
+
+    expect(await clientPage.locator('time').allTextContents()).toEqual(serverTimestamps);
+    expect(hydrationErrors).toEqual([]);
+  } finally {
+    await serverContext.close();
+    await clientContext.close();
+  }
+});
+
+test('restores imported state, completed chat, source fragment, and listbox focus, then Forget purges them', async ({ page }) => {
+  await enterResumeFromHub(page);
+  await importFixture(page);
+
+  const historyLength = await page.evaluate(() => window.history.length);
+  const selectedOption = page.locator('.pilot-conversation-list [data-entry-id="00000004"]');
+  await selectedOption.click();
+  await expect(page).toHaveURL(/\/resume#source-00000004$/);
+  await page.locator('.pilot-conversation-list [data-entry-id="00000003"]').click();
+  await expect(page).toHaveURL(/\/resume#source-00000003$/);
+  expect(await page.evaluate(() => window.history.length)).toBe(historyLength);
+
+  const chat = page.locator('.pilot-source-chat');
+  await chat.getByLabel('Chat message').fill('Keep this completed turn in route memory.');
+  await chat.getByRole('button', { name: 'Send' }).click();
+  await expect(chat.locator('.ai-message[data-role="assistant"]')).toContainText(
+    'without attached activity history',
+  );
+  await selectedOption.click();
+  await expect(selectedOption).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForResume(page);
+
+  await expect(page.locator('.pilot-session-status')).toContainText('pi-session-v3.jsonl');
+  await expect(page.locator('#branch-select')).toHaveValue('0000000f');
+  await expect(selectedOption).toHaveAttribute('aria-selected', 'true');
+  await expect(chat.locator('.ai-message')).toHaveCount(2);
+  await expect(chat).toContainText('Keep this completed turn in route memory.');
+  await expect(selectedOption).toBeFocused();
+
+  await page.getByRole('button', { name: 'Forget session' }).click();
+  await expect(page.getByRole('button', { name: 'Forget session' })).toHaveCount(0);
+  await expect(chat.locator('.ai-message')).toHaveCount(0);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await page.goForward();
+  await waitForResume(page);
+
+  await expect(page.locator('.pilot-session-status')).toContainText('Example');
+  await expect(page.getByRole('button', { name: 'Forget session' })).toHaveCount(0);
+  await expect(chat.locator('.ai-message')).toHaveCount(0);
+});
+
+test('aborts status and pending chat work on route exit without snapshotting the partial turn', async ({ page }) => {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    const state = {
+      statusMode: 'pending' as 'pending' | 'available',
+      statusPendingCount: 0,
+      statusAbortCount: 0,
+      chatStarted: false,
+      chatSignalAborted: false,
+    };
+    (window as Window & { __resumeFetchState?: typeof state }).__resumeFetchState = state;
+    window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const pathname = new URL(request.url).pathname;
+      const signal = input instanceof Request ? input.signal : init?.signal;
+      if (pathname === '/api/pi-resume-chat/status') {
+        if (state.statusMode === 'pending') {
+          state.statusPendingCount += 1;
+          return new Promise<Response>((_resolve, reject) => {
+            const abort = () => {
+              state.statusPendingCount -= 1;
+              state.statusAbortCount += 1;
+              reject(new DOMException('The request was aborted.', 'AbortError'));
+            };
+            if (signal?.aborted) abort();
+            else signal?.addEventListener('abort', abort, { once: true });
+          });
+        }
+        return Promise.resolve(new Response(JSON.stringify({
+          available: true,
+          provider: 'fake',
+          model: 'pke-chat-fake-v1',
+          localRelay: true,
+        }), {
+          headers: { 'content-type': 'application/json' },
+        }));
+      }
+      if (pathname === '/api/pi-resume-chat' && request.method === 'POST') {
+        state.chatStarted = true;
+        return new Promise<Response>((_resolve, reject) => {
+          const abort = () => {
+            state.chatSignalAborted = true;
+            reject(new DOMException('The request was aborted.', 'AbortError'));
+          };
+          if (signal?.aborted) abort();
+          else signal?.addEventListener('abort', abort, { once: true });
+        });
+      }
+      return originalFetch(input, init);
+    }) as typeof window.fetch;
+  });
+  await enterResumeFromHub(page);
+
+  await expect.poll(() => page.evaluate(() => {
+    const state = (window as Window & {
+      __resumeFetchState?: { statusPendingCount: number };
+    }).__resumeFetchState;
+    return state?.statusPendingCount ?? 0;
+  })).toBeGreaterThan(0);
+  const abortCountBeforeExit = await page.evaluate(() =>
+    (window as Window & { __resumeFetchState?: { statusAbortCount: number } })
+      .__resumeFetchState?.statusAbortCount ?? 0,
+  );
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect.poll(() => page.evaluate(() => {
+    const state = (window as Window & {
+      __resumeFetchState?: {
+        statusPendingCount: number;
+      };
+    }).__resumeFetchState;
+    return state?.statusPendingCount;
+  })).toBe(0);
+  await expect.poll(() => page.evaluate((previous) => {
+    const state = (window as Window & {
+      __resumeFetchState?: { statusAbortCount: number };
+    }).__resumeFetchState;
+    return (state?.statusAbortCount ?? 0) > previous;
+  }, abortCountBeforeExit)).toBe(true);
+  await page.evaluate(() => {
+    const state = (window as Window & {
+      __resumeFetchState?: { statusMode: 'pending' | 'available' };
+    }).__resumeFetchState;
+    if (state !== undefined) state.statusMode = 'available';
+  });
+
+  await page.goForward();
+  await waitForResume(page);
+
+  const prompt = page.getByLabel('Chat message');
+  await expect(prompt).toBeEnabled();
+  await prompt.fill('This pending turn must not be restored.');
+  await page.locator('.pilot-source-chat').getByRole('button', { name: 'Send' }).click();
+  await expect.poll(() => page.evaluate(() =>
+    (window as Window & { __resumeFetchState?: { chatStarted: boolean } })
+      .__resumeFetchState?.chatStarted,
+  )).toBe(true);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect.poll(() => page.evaluate(() => {
+    const state = (window as Window & {
+      __resumeFetchState?: {
+        chatSignalAborted: boolean;
+      };
+    }).__resumeFetchState;
+    return state === undefined
+      ? undefined
+      : state.chatSignalAborted;
+  })).toBe(true);
+
+  await page.goForward();
+  await waitForResume(page);
+  await expect(page.locator('.pilot-source-chat .ai-message')).toHaveCount(0);
+  await expect(page.getByLabel('Chat message')).toHaveValue('');
+});
+
+test('clears route-only Resume state on reload without creating browser persistence', async ({ page }) => {
+  await enterResumeFromHub(page);
+  await importFixture(page);
+  await expect(page.getByRole('button', { name: 'Forget session' })).toBeVisible();
+
+  await page.reload();
+  await waitForResume(page);
+
+  await expect(page.locator('.pilot-session-status')).toContainText('Example');
+  await expect(page.getByRole('button', { name: 'Forget session' })).toHaveCount(0);
+  await expect(page.locator('#branch-select')).toHaveValue('0000000f');
+  await expect(page.evaluate(async () => ({
+    local: Object.keys(localStorage),
+    session: Object.keys(sessionStorage),
+    databases: (await indexedDB.databases()).map(database => database.name),
+  }))).resolves.toEqual({ local: [], session: [], databases: [] });
+});

--- a/examples/web/waku.config.ts
+++ b/examples/web/waku.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'waku/config';
 import { astGrepPlugin } from './server/vite/ast-grep';
+import { piResumeChatPlugin } from './server/vite/resume-chat';
 import {
   createMoonbitArtifactsPlugin,
   moonbitImportIds,
@@ -9,6 +10,7 @@ export default defineConfig({
   unstable_adapter: 'waku/adapters/cloudflare',
   vite: {
     plugins: [
+      piResumeChatPlugin(),
       astGrepPlugin(),
       createMoonbitArtifactsPlugin({ watch: true }),
     ],


### PR DESCRIPTION
## Summary

- Expose Session Resume as a native React route at `/resume`, wired directly to the shared Waku route snapshot lifecycle.
- Retain only normalized loaded state, selection, and atomic completed chat turns in same-document memory; Forget releases the snapshot lifetime and pending status/chat work aborts on exit.
- Keep the relay development-only, render production inspection with chat unavailable, and preserve the legacy Vite `/resume.html` path.

Closes #977

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `useRouteSnapshot` / `useRouteLifecycle` | `examples/web/src/shared/route-lifecycle/browser/provider.tsx` | Yes | Own same-document snapshots, Forget, focus restoration, and route disposal. |
| `reduceResumeState` / `reducePilotViewState` | `examples/web/src/features/resume/browser/app.tsx` | Yes | Keep session and synchronized-view transitions deterministic. |
| `parsePiSessionJsonl` / `reducePiSession` / `projectResume` | `examples/web/src/features/resume/core/session.ts` | Yes | Reuse the bounded import and projection core without duplicating normalization. |
| `pkeChatTextMessages` and chat protocol limits | `examples/web/src/features/resume/protocol/chat.ts` | Yes | Normalize outbound/restored chat and retain existing validation limits. |
| `useChat` / `DefaultChatTransport` | AI SDK | Yes | Reuse the existing streaming, stop, and transport contract. |
| `piResumeChatPlugin` | `examples/web/server/vite/resume-chat.ts` | Yes | Serve the existing loopback/same-origin relay in Waku development only. |
| `ImperativeDemoHost` | `examples/web/src/shared/route-lifecycle/browser/imperative-host.ts` | No | The issue requires a native React route using the snapshot provider directly. |
| JavaScript `ReadonlyMap`/`Map`, `Set`, and `Array` combinators | Platform APIs | Yes | Build immutable completed-turn snapshots and bounded lookup views. |
| MoonBit core collection APIs | MoonBit core | N/A | No MoonBit source, package, interface, or generated `.mbti` surface changed. |

New helpers and types:

- `completedChatHistory` owns the narrow boundary from AI SDK messages to immutable, fully completed user/assistant turns.
- `ResumeRouteLifetime` owns the snapshot adapter lifetime so Forget releases the restored imported object graph immediately.
- `ResumeRouteSnapshot` and `PkeCompletedChatTurn` describe only the route-memory data allowed by the migration contract.
- Waku E2E helpers only centralize route readiness and fixture import setup.

Remaining imperative code is limited to the browser/Waku shell: file reads, focus, history fragment replacement, fetch/abort, and React lifecycle wiring. Parsing, reduction, projection, validation, and state-transition decisions remain deterministic.

## Test plan

- [x] `moon check` passes (only the existing vendored Rabbita deprecation warnings)
- [x] `moon test` passes (3,932 wasm-gc, 1,949 JS, and 70 native tests)
- [x] `.mbti` diff reviewed; none changed
- [x] Vite and Waku production builds pass
- [x] Native Waku Resume plus inherited Resume E2E: 20 passed
- [x] Legacy Vite Resume E2E: 15 passed
- [x] Production bundle boundary and Workerd smoke pass

## Validation

```bash
moon check
moon test
cd examples/web
npm run typecheck
npm run check:boundaries
npm run test:boundaries
npm run test:foundation
npm run check:waku-types
npm run build:vite
npm run build:waku
npm run check:waku-bundles
npx playwright test waku-tests/resume-route.spec.ts tests/pi-resume.spec.ts --config=playwright.waku.config.ts
npx playwright test tests/pi-resume.spec.ts --config=playwright.config.ts
npm run test:waku:workerd
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native Resume route with session snapshot and restoration support.
  * Resume sessions now retain completed chat turns during navigation and can be forgotten on demand.
  * Production Resume provides local inspection while disabling provider-backed chat capabilities.
  * Added development-only chat support and improved focus restoration.

* **Bug Fixes**
  * Pending Resume requests are cancelled when leaving the route.
  * Resume state no longer persists unintentionally across reloads.

* **Tests**
  * Expanded end-to-end and production checks for Resume rendering, navigation, restoration, and capability boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->