### PR TITLE
fix(web): bound Waku preload recovery reloads

### DIFF
--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -23,7 +23,7 @@
     "create:waku-release-manifest": "node scripts/create-waku-release-manifest.mjs",
     "check:waku-bundles": "node scripts/check-waku-bundles.mjs",
     "test:waku:e2e": "playwright test --config=playwright.waku.config.ts",
-    "test:waku:preview": "playwright test --config=playwright.waku-preview.config.ts",
+    "test:waku:preview": "playwright test --config=playwright.waku-preview.config.ts && playwright test --config=playwright.waku-preload.config.ts",
     "dev:dual": "bash scripts/dev-dual.sh",
     "test:waku:workerd": "bash scripts/smoke-waku-worker.sh"
   },

--- a/examples/web/playwright.preview.config.ts
+++ b/examples/web/playwright.preview.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './preview-tests',
+  testMatch: 'genui-preview.spec.ts',
   timeout: 30_000,
   retries: 0,
   use: {

--- a/examples/web/playwright.waku-preload.config.ts
+++ b/examples/web/playwright.waku-preload.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+const port = Number(process.env.CANOPY_WAKU_PRELOAD_PORT ?? '4194');
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new Error('CANOPY_WAKU_PRELOAD_PORT must be a valid TCP port.');
+}
+
+export default defineConfig({
+  testDir: './preview-tests',
+  testMatch: 'preload-recovery.spec.ts',
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+  },
+  webServer: {
+    command: `CANOPY_SKIP_WAKU_BUILD=1 CANOPY_WAKU_PREVIEW_PORT=${port} bash scripts/serve-waku-preview.sh`,
+    url: `http://127.0.0.1:${port}/ml`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/examples/web/preview-tests/genui-preview.spec.ts
+++ b/examples/web/preview-tests/genui-preview.spec.ts
@@ -12,7 +12,7 @@ const FORBIDDEN_PROVIDER_MARKERS = [
   '__canopyGenUiTest',
 ] as const;
 
-test('replays the recorded control without exposing the local study runner', async ({ page, request }) => {
+test('replays the recorded control without exposing local production capabilities', async ({ page, request }) => {
   await page.goto(GENUI_PREVIEW_URL);
   await expect(page.locator('[data-genui-ready]'))
     .toHaveAttribute('data-genui-ready', 'true');
@@ -31,18 +31,6 @@ test('replays the recorded control without exposing the local study runner', asy
     }).__canopyGenUiTest,
   }))).toEqual({ feasibility: 'undefined', browser: 'undefined' });
 
-  const response = await request.post('/api/genui-feasibility', {
-    data: {
-      studyId: 'genui-local-v1',
-      runCapability: 'not-available-in-production',
-      caseId: 'orders-pending-attention',
-      slotId: 0,
-    },
-  });
-  expect(response.status()).toBe(404);
-});
-
-test('production JavaScript assets omit every local provider marker', async ({ request }) => {
   const developmentSource = await readFile(new URL('../src/features/genui/browser/mount.js', import.meta.url), 'utf8');
   expect(developmentSource).toContain('/api/genui-feasibility');
 
@@ -67,4 +55,14 @@ test('production JavaScript assets omit every local provider marker', async ({ r
       expect(source, `${assetPath} contains ${marker}`).not.toContain(marker);
     }
   }
+
+  const response = await request.post('/api/genui-feasibility', {
+    data: {
+      studyId: 'genui-local-v1',
+      runCapability: 'not-available-in-production',
+      caseId: 'orders-pending-attention',
+      slotId: 0,
+    },
+  });
+  expect(response.status()).toBe(404);
 });

--- a/examples/web/preview-tests/preload-recovery.spec.ts
+++ b/examples/web/preview-tests/preload-recovery.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+const recoveryKey = 'canopy.preload-recovery.v1';
+
+test('allows one preload recovery per route and leaves stable route errors', async ({ page }) => {
+  const documentRequests = new Map<string, number>();
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (request.isNavigationRequest()) {
+      documentRequests.set(
+        url.pathname,
+        (documentRequests.get(url.pathname) ?? 0) + 1,
+      );
+    }
+  });
+  await page.route(/\/assets\/(?:crdt-(?:json|lambda)|graphviz)-/, (route) =>
+    route.abort('failed'));
+
+  await page.goto('/ml');
+
+  const errorHeading = page.getByRole('heading', {
+    name: 'This demo could not be displayed',
+  });
+  await expect(errorHeading).toBeFocused({ timeout: 15_000 });
+  expect(documentRequests.get('/ml')).toBe(2);
+  await page.waitForTimeout(11_000);
+  expect(documentRequests.get('/ml')).toBe(2);
+  await expect(errorHeading).toBeFocused();
+  await expect(page.locator('[data-imperative-demo-host="lambda"]')).toHaveCount(0);
+
+  await page.goto('/json');
+  await expect(errorHeading).toBeFocused({ timeout: 15_000 });
+  expect(documentRequests.get('/json')).toBe(2);
+  await expect(page.locator('[data-imperative-demo-host="json"]')).toHaveCount(0);
+
+  const mlRequestsBeforeReturn = documentRequests.get('/ml') ?? 0;
+  await page.goto('/ml');
+  await expect(errorHeading).toBeFocused({ timeout: 15_000 });
+  await page.waitForTimeout(500);
+  expect(documentRequests.get('/ml')).toBe(mlRequestsBeforeReturn + 1);
+  expect(await page.evaluate((key) =>
+    JSON.parse(sessionStorage.getItem(key) ?? '[]'), recoveryKey))
+    .toEqual(['/ml', '/json']);
+});

--- a/examples/web/scripts/waku-foundation.test.mjs
+++ b/examples/web/scripts/waku-foundation.test.mjs
@@ -247,7 +247,7 @@ test('keeps Vite defaults while exposing explicit dual-run commands', () => {
   );
   assert.equal(
     pkg.scripts['test:waku:preview'],
-    'playwright test --config=playwright.waku-preview.config.ts',
+    'playwright test --config=playwright.waku-preview.config.ts && playwright test --config=playwright.waku-preload.config.ts',
   );
   assert.equal(
     pkg.scripts['generate:waku-types'],

--- a/examples/web/src/pages/_root.tsx
+++ b/examples/web/src/pages/_root.tsx
@@ -2,6 +2,40 @@ import type { ReactNode } from 'react';
 import { RouteLifecycleProvider } from '../shared/route-lifecycle/browser/provider';
 import '../shared/shell/styles.css';
 
+const boundedPreloadRecovery = String.raw`
+(() => {
+  const recoveryKey = 'canopy.preload-recovery.v1';
+  const pageKey = location.pathname + location.search;
+  const recoveredPages = new Set();
+  try {
+    const storedPages = JSON.parse(sessionStorage.getItem(recoveryKey) || '[]');
+    if (Array.isArray(storedPages)) {
+      for (const storedPage of storedPages) {
+        if (typeof storedPage === 'string') recoveredPages.add(storedPage);
+      }
+    }
+  } catch {
+    recoveredPages.add(pageKey);
+  }
+  let reloadAttempted = recoveredPages.has(pageKey);
+  addEventListener('vite:preloadError', (event) => {
+    if (reloadAttempted) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    reloadAttempted = true;
+    recoveredPages.add(pageKey);
+    try {
+      sessionStorage.setItem(recoveryKey, JSON.stringify([...recoveredPages]));
+    } catch {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }, { capture: true });
+})();
+`;
+
 export default function Root({ children }: { readonly children: ReactNode }) {
   return (
     <html lang="en">
@@ -9,6 +43,7 @@ export default function Root({ children }: { readonly children: ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Canopy demos</title>
+        <script dangerouslySetInnerHTML={{ __html: boundedPreloadRecovery }} />
       </head>
       <body><RouteLifecycleProvider>{children}</RouteLifecycleProvider></body>
     </html>


### PR DESCRIPTION
## Summary

- bound Waku's production `vite:preloadError` recovery to one automatic reload per pathname/query and browser session, then leave the existing route error boundary stable
- add an isolated production-preview fault-injection test covering persistent failures, multiple routes, marker retention, focus, and the absence of partially mounted demo hosts
- keep the legacy Vite preview suite scoped to its GenUI test, and keep production-capability assertions ordered ahead of the intentional Wrangler 404 so pinned Wrangler 4.114 does not terminate before they run

Prerequisite for the Stage 12 retirement work in #979. This PR does not close that issue; production acceptance must be repeated after deployment before legacy delivery files are removed.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `vite:preloadError` | pinned Waku/Vite generated client runtime | Yes | preserves Waku's first automatic retry while intercepting subsequent failures before its unconditional reload listener |
| `RouteRenderBoundary` | `examples/web/src/shared/route-lifecycle/browser/route-render-boundary.tsx` | Yes | provides the stable accessible fallback after the bounded retry |
| `sessionStorage`, `Set`, `JSON` | browser platform APIs | Yes | persist and validate route recovery attempts without adding application state machinery |

MoonBit core candidates such as `Map`, `Set`, `String`, `Option`, `Result`, `Array`, and `Iter` are not applicable: this change introduces no MoonBit definitions or data manipulation and must run as a pre-hydration browser shell before Waku's generated listener.

New helpers added (if any):

- `boundedPreloadRecovery`: a static pre-hydration script, not a general application helper. It must execute in `<head>` before Waku registers its generated unconditional reload listener.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes (5,951 tests)
- [x] `git diff *.mbti` reviewed; no interface changes
- [x] Waku JS rebuild run (`cd examples/web && npm run build:waku`)
- [x] TypeScript, route-boundary, foundation, bundle, and client/server checks pass
- [x] Waku Playwright E2E passes (156 tests)
- [x] production preview and persistent-preload-failure tests pass
- [x] workerd route/asset/signaling smoke passes
- [x] preview and production Wrangler dry-run/startup checks pass

## Validation

```bash
NEW_MOON_MOD=0 moon check
NEW_MOON_MOD=0 moon test
cd examples/web
npm run typecheck
npm run build:waku
npm run test:waku:e2e
CANOPY_SKIP_WAKU_BUILD=1 npm run test:waku:preview
npm run test:waku:workerd
npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env preview
npx wrangler check startup --config wrangler.waku.jsonc --env preview
npx wrangler deploy --config wrangler.waku.jsonc --dry-run --env production
npx wrangler check startup --config wrangler.waku.jsonc --env production
```
