### PR TITLE
docs(web): archive completed Waku migration

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -660,16 +660,6 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Plan: `docs/plans/2026-07-02-lambda-name-resolution-consolidation.md`
   Exit: production edit guards, alpha lowering, and free-variable diagnostics all read scope-graph facts; duplicate edit-layer resolvers are removed or test-only; #652's module-end cutoff drift is closed.
 
-- [x] Migrate the eight Vite HTML surfaces to one routed Waku application.
-  Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
-  Plan: `docs/archive/2026-07-25-waku-unified-web-migration.md`
-  Shipped: PR #997 (merge `e47aee6`, 2026-07-28). Native Cloudflare
-  deployment `9453ae99-b0a8-47d9-8976-00fa320a06e1` serves Worker version
-  `37b75d02-124a-468f-abc4-75d673eb5ac5` at 100% traffic. Production
-  acceptance passed all canonical routes, aliases, 404, availability boundaries,
-  and signaling.
-  Exit: met.
-
 ## 22. SDEG Lifecycle
 
 - [x] Distinguish delete from malformed transient absence (#748).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -660,11 +660,15 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Plan: `docs/plans/2026-07-02-lambda-name-resolution-consolidation.md`
   Exit: production edit guards, alpha lowering, and free-variable diagnostics all read scope-graph facts; duplicate edit-layer resolvers are removed or test-only; #652's module-end cutoff drift is closed.
 
-- [ ] Migrate the eight Vite HTML surfaces to one routed Waku application.
+- [x] Migrate the eight Vite HTML surfaces to one routed Waku application.
   Why: unify delivery without losing verified demo behavior or generated MoonBit contracts.
-  Plan: `docs/plans/2026-07-25-waku-unified-web-migration.md`
-  Status: #970–#978 established the Waku foundation, Hub lifecycle, and eight canonical demo routes. #979 added compatibility redirects, static assets, same-origin Signaling, privacy-safe logs, exact-green CI artifacts, and multi-worker workerd smoke. Stage 12 now makes Waku the default, retires the eight legacy HTML/entry graphs and Vite-only delivery, and preserves the Vite plugins Waku still uses. Local build, browser, preview, workerd, Wrangler, and workspace validation pass. The item remains open for final repository CI and post-merge verification of the automatic 100% Cloudflare Workers Build deployment.
-  Exit: the plan's Stage 12 gate passes after production cutover is proven.
+  Plan: `docs/archive/2026-07-25-waku-unified-web-migration.md`
+  Shipped: PR #997 (merge `e47aee6`, 2026-07-28). Native Cloudflare
+  deployment `9453ae99-b0a8-47d9-8976-00fa320a06e1` serves Worker version
+  `37b75d02-124a-468f-abc4-75d673eb5ac5` at 100% traffic. Production
+  acceptance passed all canonical routes, aliases, 404, availability boundaries,
+  and signaling.
+  Exit: met.
 
 ## 22. SDEG Lifecycle
 

--- a/docs/archive/2026-07-25-waku-unified-web-migration.md
+++ b/docs/archive/2026-07-25-waku-unified-web-migration.md
@@ -12,7 +12,7 @@
 
 - **PR:** [#997](https://github.com/dowdiness/canopy/pull/997) squash-merged at 2026-07-28T16:00:20Z.
 - **Merge commit:** `e47aee68677b91cd433b0a0d5253ced715cac62c`.
-- **CI:** repository `All Checks Passed` passed on the final PR head; CodeRabbit's final rerun was pass with reason `Review rate limited`, after its five earlier actionable findings were fixed and local/CI validation reran.
+- **CI:** repository `All Checks Passed` passed on the final PR head; CodeRabbit's final rerun passed with reason `Review rate limited`, after its five earlier actionable findings were fixed and local/CI validation reran.
 - **Deployment:** native Cloudflare Workers Builds produced Worker version `37b75d02-124a-468f-abc4-75d673eb5ac5`, deployment `9453ae99-b0a8-47d9-8976-00fa320a06e1` at 2026-07-28T16:02:06Z, 100% traffic. Previous rollback version: `8fc4338a-b425-430b-a05b-8b91f1b85679`.
 - **Production acceptance:** all nine canonical routes plus `/index.html` returned 200; seven document aliases and their RSC aliases returned 308 with query preservation; unknown route returned 404; Memo production-unavailable boundary, Resume production-chat-unavailable boundary, GenUI recorded replay and production hook exclusion, Waku history/focus, Signaling WebSocket, and error-only live tail all passed. No error invocation appeared for the new version.
 

--- a/docs/archive/2026-07-25-waku-unified-web-migration.md
+++ b/docs/archive/2026-07-25-waku-unified-web-migration.md
@@ -1,6 +1,6 @@
 # Unified Waku Web Migration
 
-**Status:** final verification
+**Status:** completed
 
 **Map:** [#947](https://github.com/dowdiness/canopy/issues/947)
 
@@ -8,13 +8,21 @@
 
 **Behavior baseline:** [`c82368c5`](https://github.com/dowdiness/canopy/commit/c82368c5)
 
+## Completion Evidence
+
+- **PR:** [#997](https://github.com/dowdiness/canopy/pull/997) squash-merged at 2026-07-28T16:00:20Z.
+- **Merge commit:** `e47aee68677b91cd433b0a0d5253ced715cac62c`.
+- **CI:** repository `All Checks Passed` passed on the final PR head; CodeRabbit's final rerun was pass with reason `Review rate limited`, after its five earlier actionable findings were fixed and local/CI validation reran.
+- **Deployment:** native Cloudflare Workers Builds produced Worker version `37b75d02-124a-468f-abc4-75d673eb5ac5`, deployment `9453ae99-b0a8-47d9-8976-00fa320a06e1` at 2026-07-28T16:02:06Z, 100% traffic. Previous rollback version: `8fc4338a-b425-430b-a05b-8b91f1b85679`.
+- **Production acceptance:** all nine canonical routes plus `/index.html` returned 200; seven document aliases and their RSC aliases returned 308 with query preservation; unknown route returned 404; Memo production-unavailable boundary, Resume production-chat-unavailable boundary, GenUI recorded replay and production hook exclusion, Waku history/focus, Signaling WebSocket, and error-only live tail all passed. No error invocation appeared for the new version.
+
 ## Why
 
-`examples/web` currently builds eight independent HTML inputs with Vite. The
-migration must replace those inputs with one routed Waku application without
+`examples/web` originally built eight independent HTML inputs with Vite. The
+migration replaced those inputs with one routed Waku application without
 losing the verified demo workflows, the five generated MoonBit JavaScript
 contracts, the local-development capability split, existing Posts data, or the
-ability to fall back to the current deployment.
+ability to fall back to the prior deployment.
 
 The route decision in #952 adds a stronger requirement than changing URLs:
 navigation must behave as a reversible context switch. User work may survive a
@@ -75,8 +83,9 @@ Issues track execution status and link here rather than duplicating this detail.
   core/protocol, and server capabilities separated.
 - `.github/workflows/ci.yml` builds MoonBit JavaScript, builds and typechecks the
   web example, runs boundary checks, and runs the Playwright suite.
-- `.github/workflows/deploy-cloudflare.yml` currently deploys `examples/web/dist`
-  to the `canopy-lambda-editor` Cloudflare Pages project on pushes to `main`.
+- `.github/workflows/deploy-cloudflare.yml` deployed `examples/web/dist`
+  to the `canopy-lambda-editor` Cloudflare Pages project on pushes to `main`
+  (superseded by the Waku Worker deployment in Stage 12).
 - `examples/web/wrangler-signaling.toml` deploys the separate
   `crdt-signaling-server` Worker and its `SIGNALING_ROOM` Durable Object.
 
@@ -428,13 +437,13 @@ mismatch, or failed signaling handshake.
 
 ### Stage 12 — Vite retirement
 
-**Status (2026-07-28):** Implementation and local validation complete. Waku
-is now the default dev/build/preview path; legacy Vite HTML inputs,
-`src/entries/`, and dual-build scripts are removed. `wrangler.jsonc` now owns
-the Worker configuration; `wrangler.waku.jsonc` and `build:deploy:waku` remain
-as compatibility aliases for Cloudflare Workers Builds external settings.
-**Remaining gate:** final repository CI and post-merge production verification
-on Cloudflare; issue #979 stays open until both complete.
+**Status (2026-07-28):** Complete. Waku is the default dev/build/preview path;
+legacy Vite HTML inputs, `src/entries/`, and dual-build scripts are removed.
+`wrangler.jsonc` owns the Worker configuration; `wrangler.waku.jsonc` and
+`build:deploy:waku` remain as compatibility aliases for Cloudflare Workers
+Builds external settings. Final repository CI passed and post-merge production
+verification on Cloudflare succeeded (see Completion Evidence above). No
+remaining gate.
 
 - Make Waku the default development/build path.
 - Remove old HTML inputs, Vite multi-page configuration, throwaway Hub files,
@@ -555,30 +564,30 @@ copy the whole plan.
 
 ## Acceptance Criteria
 
-- [ ] `/` and `/index.html` server-render equivalent data-driven Hub content and
+- [x] `/` and `/index.html` server-render equivalent data-driven Hub content and
       `/index.html` does not redirect.
-- [ ] All eight canonical demo routes pass their inherited behavior contract.
-- [ ] All seven active legacy HTML URLs return `308`, preserve query/fragment,
+- [x] All eight canonical demo routes pass their inherited behavior contract.
+- [x] All seven active legacy HTML URLs return `308`, preserve query/fragment,
       and lead to the correct canonical route without an extra usable Back stop.
-- [ ] Waku owns navigation; modified clicks and new-tab behavior remain native.
-- [ ] Same-document snapshots restore exactly the allowed per-demo fields and
+- [x] Waku owns navigation; modified clicks and new-tab behavior remain native.
+- [x] Same-document snapshots restore exactly the allowed per-demo fields and
       clear on reload/new tab, except Posts' two unchanged stores.
-- [ ] Every route exit disposes its live resources idempotently; repeated
+- [x] Every route exit disposes its live resources idempotently; repeated
       Strict Mode/navigation cycles leak no handle, adapter, overlay, request,
       timer, listener, React root, or development hook.
-- [ ] Push, pop, fragment, fallback, and route-error focus behavior matches #952.
-- [ ] Unknown routes return HTTP 404; pre-commit and post-commit failures retain
+- [x] Push, pop, fragment, fallback, and route-error focus behavior matches #952.
+- [x] Unknown routes return HTTP 404; pre-commit and post-commit failures retain
       the correct URL/state and provide accessible recovery.
-- [ ] Production exposes no Memo credential flow, AST Grep request, Resume
+- [x] Production exposes no Memo credential flow, AST Grep request, Resume
       provider call, GenUI live endpoint, provider secret, stack, or user content
       in errors/logs.
-- [ ] The five virtual IDs and artifact paths remain unchanged, are absent from
+- [x] The five virtual IDs and artifact paths remain unchanged, are absent from
       server/RSC bundles, and trigger output-driven full reload in development.
-- [ ] The separate Signaling Worker remains independently deployable and a real
+- [x] The separate Signaling Worker remains independently deployable and a real
       same-origin handshake passes through the service binding.
-- [ ] Vite remains green until cutover; the final Waku CI jobs join
+- [x] Vite remains green until cutover; the final Waku CI jobs join
       `All Checks Passed` before Vite is retired.
-- [ ] Production deployment records version IDs, passes production smoke gates,
+- [x] Production deployment records version IDs, passes production smoke gates,
       and has a verified previous-Worker-version rollback procedure.
 
 ## Validation

--- a/docs/research/2026-07-25-waku-demo-behavior-contracts.md
+++ b/docs/research/2026-07-25-waku-demo-behavior-contracts.md
@@ -385,8 +385,10 @@ outbound request preview, and zero browser persistence
 
 ### Known gaps
 
-Production chat availability is unverified by the current preview suites
-([map](../../examples/web/MODULE_MAP.md)).
+Post-merge production acceptance (2026-07-28) verified that Resume renders the
+intentional production-unavailable chat state while session inspection remains
+fully available. A server-side production chat proxy remains out of scope for
+this migration.
 
 ## GenUI
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -2,8 +2,10 @@
 
 `examples/web` is a Waku 1.0.0-beta.8 application deployed as the
 `canopy-examples` Cloudflare Worker. Cloudflare Workers Builds is configured to
-build and deploy `main` directly at 100%. This PR's post-merge deployment remains
-unverified.
+build and deploy `main` directly at 100%. Native Cloudflare deployment is
+configured and the Stage 12 production cutover was verified; see the
+[archived migration plan](../../docs/archive/2026-07-25-waku-unified-web-migration.md)
+for the acceptance evidence.
 
 ## Canonical routes
 


### PR DESCRIPTION
## Summary

- Archive the completed unified Waku migration plan with PR, merge, Worker version, deployment, rollback, and production-acceptance evidence.
- Mark the Waku migration TODO complete and update active README/research wording after the verified native Cloudflare deployment.

Closes #979

## Reuse check

Pure documentation close-out; no functions, methods, helpers, types, or MoonBit code were added.

## Test plan

- [x] `git diff --check`
- [x] Changed Markdown local links verified
- [x] `scripts/check-agent-doc-links.sh`
- [x] `NEW_MOON_MOD=0 moon fmt`
- [x] `NEW_MOON_MOD=0 moon info`; no `.mbti` drift

## Production evidence

- PR #997 merge: `e47aee68677b91cd433b0a0d5253ced715cac62c`
- Worker version: `37b75d02-124a-468f-abc4-75d673eb5ac5`
- Deployment: `9453ae99-b0a8-47d9-8976-00fa320a06e1`, 100% traffic
- Production acceptance: canonical routes, aliases/RSC redirects, 404, Memo/Resume production boundaries, GenUI recorded replay, history/focus, Signaling WebSocket, and error-only live tail passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project planning records to mark the Stage 12 Waku migration and Vite retirement as complete.
  * Recorded successful production deployment, traffic rollout, CI validation, and post-release verification.
  * Completed the migration acceptance checklist, including rendering, routing, error handling, security, signaling, and cutover criteria.
  * Clarified production chat behavior: chat remains intentionally unavailable while session inspection continues to function.
  * Updated web example deployment documentation and linked the archived migration evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->