### PR TITLE
fix(btree): harden invariants and reuse bulk construction

### DIFF
--- a/lib/btree/README.md
+++ b/lib/btree/README.md
@@ -69,6 +69,65 @@ tree.init_root({ text: "hello", len: 5 }, 5)
 
 *Current worst-case repair can visit every child in the repaired subtree after range deletion.
 
+## API Contracts
+
+### Construction
+
+Calling `new` creates an empty tree. Both `new` and `from_sorted` normalize
+`min_degree` to the inclusive interval `[2, @int.MAX_VALUE / 2]`.
+Use `init_root` to install the first element before calling
+`mutate_for_insert`; `from_sorted([])` is another empty construction.
+
+`init_root` and every `(element, span)` pair passed to `from_sorted` require a
+strictly positive span. Invalid spans abort with
+`BTree::init_root: leaf span must be positive` or
+`BTree::from_sorted: leaf spans must be positive`, respectively.
+
+`from_sorted` preserves input order but does not merge adjacent elements;
+callers own any no-adjacent-mergeable canonicalization policy.
+
+### Positions and ranges
+
+Positions are measured in the cumulative units supplied by leaf spans. Ranges
+are half-open `[start, end)`.
+
+| Operation | Accepted bounds | Other input |
+|-----------|-----------------|-------------|
+| `find(pos)`, `get_at(pos)` | `0 <= pos < span()` | Return `None` for an empty tree, a negative position, or `pos >= span()`. |
+| `mutate_for_insert(pos, callback)` | A non-empty tree and `0 <= pos <= span()`; the end position is valid. | Abort for an empty tree or a position outside the accepted bounds. Use `init_root` for the first element. |
+| `mutate_for_delete(pos, callback)` | `0 <= pos < span()` | Return `None` without calling the callback for an empty tree or an out-of-bounds position. |
+| `delete_range(start, end)` | `0 <= start < end`; `end` is clamped to `span()`. | No-op for an empty tree, a negative start, an empty or reversed range, or `start >= span()`. |
+| `view(start?, end?)` | Defaults to `[0, span())`; a negative start clamps to `0`, and an omitted or oversized end clamps to `span()`. | Return an empty array when the clamped range is empty or reversed, its end is negative, its start is at or beyond `span()`, or the tree is empty. |
+
+### Callback and splice contract
+
+`LeafContext` captures the current element, its span, the offset within it,
+its child index, and optional adjacent leaf values. `left_neighbor()` and
+`right_neighbor()` return the captured values; the context exposes no live
+tree collection.
+
+A callback computes and returns a `Splice` description. The
+engine applies that description after the callback returns and performs the
+required propagation and rebalancing.
+
+`Splice.start_idx` is inclusive and `Splice.end_idx` is exclusive in the
+current leaf parent's child array. Callers must maintain
+`0 <= start_idx <= end_idx <= parent child count`; arbitrary invalid indices
+are not separately validated.
+
+`new_leaves` replace that interval in order.
+Every replacement span must be positive, or propagation aborts with
+`BTree splice: leaf spans must be positive`.
+
+The canonical splice shapes are:
+
+| Shape | Replaced child interval | `new_leaves` |
+|-------|-------------------------|--------------|
+| Insert before child `i` | `[i, i)` | `[new]` |
+| Replace child `i` | `[i, i + 1)` | `[replacement]` |
+| Delete child `i` | `[i, i + 1)` | `[]` |
+| Split child `i` | `[i, i + 1)` | `[left, right, ...]` |
+
 ## Relationship to Other Libraries
 
 ```

--- a/lib/btree/README.md
+++ b/lib/btree/README.md
@@ -77,6 +77,9 @@ Calling `new` creates an empty tree. Both `new` and `from_sorted` normalize
 `min_degree` to the inclusive interval `[2, @int.MAX_VALUE / 2]`.
 Use `init_root` to install the first element before calling
 `mutate_for_insert`; `from_sorted([])` is another empty construction.
+Calling `init_root` on an already initialized tree aborts with
+`BTree::init_root: tree is already initialized` instead of replacing its
+contents.
 
 `init_root` and every `(element, span)` pair passed to `from_sorted` require a
 strictly positive span. Invalid spans abort with

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -238,10 +238,13 @@ pub fn[T] BTree::from_sorted(
 }
 
 ///|
-/// Initialize the tree with a single root element. `span` must be positive or
-/// the operation aborts.
+/// Initialize an empty tree with a single root element. `span` must be positive;
+/// a non-positive span or an already initialized tree aborts.
 pub fn[T] BTree::init_root(self : BTree[T], elem : T, span : Int) -> Unit {
   guard span > 0 else { abort("BTree::init_root: leaf span must be positive") }
+  guard self.is_empty() else {
+    abort("BTree::init_root: tree is already initialized")
+  }
   let leaf = Leaf(elem~, span~)
   self.root = Some(Internal(children=[leaf], counts=[span], total=span))
   self.size = 1

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -57,6 +57,11 @@ pub fn[T] BTree::mutate_for_insert(
     None =>
       abort("BTree::mutate_for_insert: tree is empty, use init_root first")
     Some(root) => {
+      // Bounds check before descend — prepare_split may mutate the tree, so
+      // reject invalid positions before any structural preparation begins.
+      guard pos >= 0 && pos <= root.total() else {
+        abort("BTree::mutate_for_insert: position out of bounds")
+      }
       let cursor = match
         descend(
           root,

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -1,4 +1,6 @@
 ///|
+/// Create an empty tree. `min_degree` is normalized to the inclusive interval
+/// `[2, @int.MAX_VALUE / 2]`.
 pub fn[T] BTree::new(min_degree? : Int = DEFAULT_MIN_DEGREE) -> BTree[T] {
   { root: None, min_degree: clamp_min_degree(min_degree), size: 0 }
 }
@@ -37,11 +39,13 @@ pub fn[T] BTree::find(self : BTree[T], pos : Int) -> FindResult[T]? {
 }
 
 ///|
-/// Descend for insert: splits full nodes during descent, uses inclusive slot
-/// finding, allows leaf-end positions. Tree must be non-empty (use init_root
-/// first). Aborts if pos is out of [0, span] or tree is empty.
-/// The callback receives a LeafContext and returns a Splice describing
-/// what to replace. The tree handles rebalancing and size tracking automatically.
+/// Mutate a non-empty tree at a span position in the inclusive interval
+/// `[0, span()]`; use `init_root` for the first element. An empty tree or a
+/// position outside that interval aborts.
+///
+/// The callback receives a `LeafContext` snapshot and returns a `Splice`
+/// description. The tree applies it, rebalances, and updates size. Every span
+/// in the returned splice must be positive or propagation aborts.
 pub fn[T] BTree::mutate_for_insert(
   self : BTree[T],
   pos : Int,
@@ -74,10 +78,10 @@ pub fn[T] BTree::mutate_for_insert(
 }
 
 ///|
-/// Descend for delete: ensures min children during descent, uses strict slot
-/// finding. Returns the callback's payload R, or None if pos is out of bounds
-/// or tree is empty. The callback returns (splice, payload) where payload is
-/// any caller-defined data (e.g., the deleted element).
+/// Mutate the leaf containing span position `pos`, where
+/// `0 <= pos < span()`. Returns the callback's payload, or `None` without
+/// calling the callback when the tree is empty or `pos` is out of bounds.
+/// Every span in the returned splice must be positive or propagation aborts.
 pub fn[T, R] BTree::mutate_for_delete(
   self : BTree[T],
   pos : Int,
@@ -112,9 +116,9 @@ pub fn[T, R] BTree::mutate_for_delete(
 }
 
 ///|
-/// Delete all elements in the span range [start, end_).
-/// Handles all cases: single-leaf splice, multi-child LCA splice,
-/// underfull node repair, and post-splice boundary merging.
+/// Delete the half-open span range `[start, end_)`, clamping an oversized end
+/// to `span()`. This is a no-op for an empty tree, a negative start, an empty
+/// or reversed range, or `start >= span()`.
 pub fn[T : BTreeElem] BTree::delete_range(
   self : BTree[T],
   start : Int,
@@ -182,9 +186,12 @@ fn[T] BTree::apply_propagated(
 }
 
 ///|
-/// Build a BTree bottom-up from a pre-sorted array of (element, span) pairs.
-/// O(n) instead of O(n log n) repeated inserts.
-/// Caller must ensure no adjacent items are mergeable (pre-merge if needed).
+/// Build a `BTree` bottom-up in input order from pre-sorted `(element, span)`
+/// pairs. `min_degree` is normalized to `[2, @int.MAX_VALUE / 2]`.
+///
+/// Every span must be positive or construction aborts. The caller must
+/// pre-merge adjacent mergeable elements when its canonicalization policy
+/// requires that invariant. Runs in O(n), rather than O(n log n) inserts.
 pub fn[T] BTree::from_sorted(
   items : Array[(T, Int)],
   min_degree? : Int = DEFAULT_MIN_DEGREE,
@@ -226,7 +233,8 @@ pub fn[T] BTree::from_sorted(
 }
 
 ///|
-/// Initialize root with a single leaf wrapped in an internal node.
+/// Initialize the tree with a single root element. `span` must be positive or
+/// the operation aborts.
 pub fn[T] BTree::init_root(self : BTree[T], elem : T, span : Int) -> Unit {
   guard span > 0 else { abort("BTree::init_root: leaf span must be positive") }
   let leaf = Leaf(elem~, span~)
@@ -258,7 +266,10 @@ fn[T] normalize_root_after_delete(root : BTreeNode[T]) -> BTreeNode[T]? {
 }
 
 ///|
-/// View elements in span range [start, end). Slices at boundaries.
+/// Return elements in the half-open span range `[start, end)`, slicing boundary
+/// elements. A negative start clamps to zero; an omitted or oversized end
+/// clamps to `span()`. An empty or reversed range, a negative end, or a start at
+/// or beyond `span()` returns an empty array.
 pub fn[T : BTreeElem] BTree::view(
   self : BTree[T],
   start? : Int = 0,

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -189,6 +189,7 @@ pub fn[T] BTree::from_sorted(
   items : Array[(T, Int)],
   min_degree? : Int = DEFAULT_MIN_DEGREE,
 ) -> BTree[T] {
+  validate_positive_spans(items, "BTree::from_sorted")
   let min_degree = clamp_min_degree(min_degree)
   let max_degree = 2 * min_degree
   if items.is_empty() {
@@ -227,6 +228,7 @@ pub fn[T] BTree::from_sorted(
 ///|
 /// Initialize root with a single leaf wrapped in an internal node.
 pub fn[T] BTree::init_root(self : BTree[T], elem : T, span : Int) -> Unit {
+  guard span > 0 else { abort("BTree::init_root: leaf span must be positive") }
   let leaf = Leaf(elem~, span~)
   self.root = Some(Internal(children=[leaf], counts=[span], total=span))
   self.size = 1

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -874,6 +874,20 @@ test "LeafContext neighbors return adjacent siblings" {
 }
 
 ///|
+test "LeafContext snapshot keeps original neighbors" {
+  let children : Array[BTreeNode[TItem]] = [
+    Leaf(elem=make_item(1, 3), span=3),
+    Leaf(elem=make_item(2, 2), span=2),
+    Leaf(elem=make_item(3, 4), span=4),
+  ]
+  let root : BTreeNode[TItem] = Internal(children~, counts=[3, 2, 4], total=9)
+  let cursor = descend(root, 3, 2, prepare_noop, find_slot, false).unwrap()
+  let ctx = LeafContext::from_cursor(cursor)
+  children[0] = Leaf(elem=make_item(9, 3), span=3)
+  @debug.debug_inspect(ctx.left_neighbor(), content="Some({ id: 1, span: 3 })")
+}
+
+///|
 test "LeafContext boundary neighbors are None" {
   let root : BTreeNode[TItem] = Internal(
     children=[

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -272,8 +272,8 @@ test "panic init_root rejects repeated initialization" {
 ///|
 test "panic insert splice rejects non-positive span" {
   let t = build_tree([(1, 1)])
-  // abort is uncatchable, so atomicity is verified by validation-before-splice
-  // source ordering rather than by observing state after the failure.
+  // abort is uncatchable, so this test verifies rejection only. In propagate,
+  // validation precedes apply_splice; descent may already have split nodes.
   t.mutate_for_insert(1, ctx => {
     start_idx: ctx.child_idx + 1,
     end_idx: ctx.child_idx + 1,
@@ -284,8 +284,8 @@ test "panic insert splice rejects non-positive span" {
 ///|
 test "panic delete splice rejects non-positive span" {
   let t = build_tree([(1, 2)])
-  // abort is uncatchable, so atomicity is verified by validation-before-splice
-  // source ordering rather than by observing state after the failure.
+  // abort is uncatchable, so this test verifies rejection only. In propagate,
+  // validation precedes apply_splice; descent may already have rebalanced nodes.
   let _ = t.mutate_for_delete(0, ctx => {
     (
       {

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -2263,6 +2263,21 @@ test "from_sorted clamps invalid min_degree" {
 }
 
 ///|
+test "from_sorted clamps oversized min_degree" {
+  let items : Array[(TItem, Int)] = [(make_item(1, 1), 1), (make_item(2, 1), 1)]
+  let oversized_min_degree = MAX_SAFE_MIN_DEGREE + 1
+  let t : BTree[TItem] = BTree::from_sorted(
+    items,
+    min_degree=oversized_min_degree,
+  )
+  inspect(t.size(), content="2")
+  inspect(t.span(), content="2")
+  inspect(btree_invariants_hold(t), content="true")
+  let empty : BTree[TItem] = BTree::new(min_degree=oversized_min_degree)
+  inspect(empty.min_degree, content=MAX_SAFE_MIN_DEGREE.to_string())
+}
+
+///|
 struct FromSortedCase {
   items : Array[(Int, Int)]
   min_degree : Int

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -263,6 +263,13 @@ test "panic init_root rejects negative non-positive span" {
 }
 
 ///|
+test "panic init_root rejects repeated initialization" {
+  let t : BTree[TItem] = BTree::new()
+  t.init_root(make_item(1, 1), 1)
+  t.init_root(make_item(2, 1), 1)
+}
+
+///|
 test "panic insert splice rejects non-positive span" {
   let t = build_tree([(1, 1)])
   // abort is uncatchable, so atomicity is verified by validation-before-splice

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -2366,6 +2366,7 @@ test "from_sorted clamps oversized min_degree" {
     items,
     min_degree=oversized_min_degree,
   )
+  inspect(t.min_degree, content=MAX_SAFE_MIN_DEGREE.to_string())
   inspect(t.size(), content="2")
   inspect(t.span(), content="2")
   inspect(btree_invariants_hold(t), content="true")

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -216,6 +216,57 @@ test "panic insert on empty tree aborts" {
   t.mutate_for_insert(0, fn(_ctx) { abort("should not reach callback") })
 }
 
+///|
+test "panic from_sorted rejects zero non-positive span" {
+  let _ : BTree[TItem] = BTree::from_sorted([(make_item(1, 0), 0)])
+}
+
+///|
+test "panic from_sorted rejects negative non-positive span" {
+  let _ : BTree[TItem] = BTree::from_sorted([(make_item(1, -1), -1)])
+}
+
+///|
+test "panic init_root rejects zero non-positive span" {
+  let t : BTree[TItem] = BTree::new()
+  t.init_root(make_item(1, 0), 0)
+}
+
+///|
+test "panic init_root rejects negative non-positive span" {
+  let t : BTree[TItem] = BTree::new()
+  t.init_root(make_item(1, -1), -1)
+}
+
+///|
+test "panic insert splice rejects non-positive span" {
+  let t = build_tree([(1, 1)])
+  // abort is uncatchable, so atomicity is verified by validation-before-splice
+  // source ordering rather than by observing state after the failure.
+  t.mutate_for_insert(1, ctx => {
+    start_idx: ctx.child_idx + 1,
+    end_idx: ctx.child_idx + 1,
+    new_leaves: [(make_item(2, 0), 0)],
+  })
+}
+
+///|
+test "panic delete splice rejects non-positive span" {
+  let t = build_tree([(1, 2)])
+  // abort is uncatchable, so atomicity is verified by validation-before-splice
+  // source ordering rather than by observing state after the failure.
+  let _ = t.mutate_for_delete(0, ctx => {
+    (
+      {
+        start_idx: ctx.child_idx,
+        end_idx: ctx.child_idx + 1,
+        new_leaves: [(make_item(2, -1), -1)],
+      },
+      ctx.elem,
+    )
+  })
+}
+
 // === Iteration ===
 
 ///|
@@ -1392,7 +1443,7 @@ fn[T] check_node_invariants(
   depth : Int,
 ) -> (Bool, Int, Int) {
   match node {
-    Leaf(..) => (true, depth, 1)
+    Leaf(span~, ..) => (span > 0, depth, 1)
     Internal(children~, counts~, total~) => {
       if children is [] {
         return (false, depth, 0)

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -217,6 +217,30 @@ test "panic insert on empty tree aborts" {
 }
 
 ///|
+test "panic insert rejects negative position" {
+  let t = build_tree([(1, 1)])
+  // abort is uncatchable, so mutation-free failure is also verified by the
+  // bounds-guard-before-descent source ordering in mutate_for_insert.
+  t.mutate_for_insert(-1, ctx => {
+    start_idx: ctx.child_idx,
+    end_idx: ctx.child_idx,
+    new_leaves: [(make_item(2, 1), 1)],
+  })
+}
+
+///|
+test "panic insert rejects position beyond span" {
+  let t = build_tree([(1, 1)])
+  // abort is uncatchable, so mutation-free failure is also verified by the
+  // bounds-guard-before-descent source ordering in mutate_for_insert.
+  t.mutate_for_insert(t.span() + 1, ctx => {
+    start_idx: ctx.child_idx + 1,
+    end_idx: ctx.child_idx + 1,
+    new_leaves: [(make_item(2, 1), 1)],
+  })
+}
+
+///|
 test "panic from_sorted rejects zero non-positive span" {
   let _ : BTree[TItem] = BTree::from_sorted([(make_item(1, 0), 0)])
 }

--- a/lib/btree/moon.pkg
+++ b/lib/btree/moon.pkg
@@ -2,6 +2,7 @@ import {
   "dowdiness/rle",
   "moonbitlang/core/bench",
   "moonbitlang/core/debug",
+  "moonbitlang/core/int",
 }
 
 import {

--- a/lib/btree/pkg.generated.mbti
+++ b/lib/btree/pkg.generated.mbti
@@ -51,8 +51,8 @@ pub(all) struct LeafContext[T] {
   elem : T
   span : Int
   offset : Int
-  children : Array[BTreeNode[T]]
   child_idx : Int
+  // private fields
 } derive(@debug.Debug)
 pub fn[T] LeafContext::left_neighbor(Self[T]) -> T?
 pub fn[T] LeafContext::right_neighbor(Self[T]) -> T?

--- a/lib/btree/pkg.generated.mbti
+++ b/lib/btree/pkg.generated.mbti
@@ -12,9 +12,7 @@ import {
 
 // Types and methods
 pub(all) struct BTree[T] {
-  mut root : BTreeNode[T]?
-  min_degree : Int
-  mut size : Int
+  // private fields
 } derive(Eq, @debug.Debug)
 pub fn[T : BTreeElem] BTree::delete_range(Self[T], Int, Int) -> Unit
 pub fn[T] BTree::each(Self[T], (T) -> Unit) -> Unit

--- a/lib/btree/types.mbt
+++ b/lib/btree/types.mbt
@@ -9,9 +9,9 @@ pub(all) enum BTreeNode[T] {
 
 ///|
 pub(all) struct BTree[T] {
-  mut root : BTreeNode[T]?
-  min_degree : Int
-  mut size : Int
+  priv mut root : BTreeNode[T]?
+  priv min_degree : Int
+  priv mut size : Int
 } derive(Debug, Eq)
 
 ///|

--- a/lib/btree/utils.mbt
+++ b/lib/btree/utils.mbt
@@ -13,6 +13,17 @@ fn clamp_min_degree(min_degree : Int) -> Int {
 }
 
 ///|
+/// Reject invalid leaf spans before a constructor or splice mutates tree state.
+fn[T] validate_positive_spans(
+  items : Array[(T, Int)],
+  operation : String,
+) -> Unit {
+  guard items.all(pair => pair.1 > 0) else {
+    abort("\{operation}: leaf spans must be positive")
+  }
+}
+
+///|
 /// Wrap an array of child nodes into an Internal node with computed counts/total.
 fn[T] make_internal(children : Array[BTreeNode[T]]) -> BTreeNode[T] {
   let counts : Array[Int] = children.map(fn(n) { n.total() })

--- a/lib/btree/utils.mbt
+++ b/lib/btree/utils.mbt
@@ -4,12 +4,12 @@ fn Array::sum(self : Array[Int]) -> Int {
 }
 
 ///|
+/// Largest minimum degree whose doubling remains within `Int`.
+const MAX_SAFE_MIN_DEGREE : Int = @int.MAX_VALUE / 2
+
+///|
 fn clamp_min_degree(min_degree : Int) -> Int {
-  if min_degree < 2 {
-    2
-  } else {
-    min_degree
-  }
+  min_degree.clamp(min=2, max=MAX_SAFE_MIN_DEGREE)
 }
 
 ///|

--- a/lib/btree/walker_propagate.mbt
+++ b/lib/btree/walker_propagate.mbt
@@ -173,6 +173,7 @@ fn[T] propagate(
   min_degree : Int,
 ) -> PropagateResult[T] {
   guard path.length() > 0 else { abort("propagate: empty path") }
+  validate_positive_spans(splice.new_leaves, "BTree splice")
   let leaf_delta = splice.new_leaves.length() -
     (splice.end_idx - splice.start_idx)
   let leaf_parent = path[path.length() - 1]

--- a/lib/btree/walker_types.mbt
+++ b/lib/btree/walker_types.mbt
@@ -57,8 +57,9 @@ pub(all) struct LeafContext[T] {
   elem : T
   span : Int
   offset : Int
-  children : Array[BTreeNode[T]]
   child_idx : Int
+  priv left_elem : T?
+  priv right_elem : T?
 } derive(Debug)
 
 ///|
@@ -77,20 +78,12 @@ priv struct PropagateResult[T] {
 
 ///|
 pub fn[T] LeafContext::left_neighbor(self : LeafContext[T]) -> T? {
-  guard self.child_idx > 0 else { return None }
-  match self.children[self.child_idx - 1] {
-    Leaf(elem~, ..) => Some(elem)
-    _ => None
-  }
+  self.left_elem
 }
 
 ///|
 pub fn[T] LeafContext::right_neighbor(self : LeafContext[T]) -> T? {
-  guard self.child_idx + 1 < self.children.length() else { return None }
-  match self.children[self.child_idx + 1] {
-    Leaf(elem~, ..) => Some(elem)
-    _ => None
-  }
+  self.right_elem
 }
 
 ///|
@@ -99,12 +92,21 @@ fn[T] LeafContext::from_cursor(cursor : Cursor[T]) -> LeafContext[T] {
     abort("LeafContext::from_cursor: cursor missing parent frame")
   }
   let frame = cursor.path[cursor.path.length() - 1]
+  let left_elem : T? = match frame.children.get(cursor.child_idx - 1) {
+    Some(Leaf(elem~, ..)) => Some(elem)
+    _ => None
+  }
+  let right_elem : T? = match frame.children.get(cursor.child_idx + 1) {
+    Some(Leaf(elem~, ..)) => Some(elem)
+    _ => None
+  }
   {
     elem: cursor.leaf_elem,
     span: cursor.leaf_span,
     offset: cursor.offset,
-    children: frame.children,
     child_idx: cursor.child_idx,
+    left_elem,
+    right_elem,
   }
 }
 

--- a/lib/btree/walker_types.mbt
+++ b/lib/btree/walker_types.mbt
@@ -52,20 +52,33 @@ priv struct NodeSplice[T] {
 }
 
 ///|
-/// Read-only context passed to pure leaf splice computations.
+/// Value snapshot passed to a leaf splice callback. It captures the current
+/// leaf and optional adjacent leaf values without exposing a live tree
+/// collection. See the README's API Contracts section.
 pub(all) struct LeafContext[T] {
+  /// Current leaf value.
   elem : T
+  /// Current leaf span.
   span : Int
+  /// Span offset addressed by the mutation.
   offset : Int
+  /// Current leaf index in its parent child array.
   child_idx : Int
   priv left_elem : T?
   priv right_elem : T?
 } derive(Debug)
 
 ///|
+/// Replacement description for a current leaf parent's child array.
+/// `start_idx` and `end_idx` must satisfy
+/// `0 <= start_idx <= end_idx <= parent child count`; invalid indices are not
+/// separately validated.
 pub(all) struct Splice[T] {
+  /// Inclusive child index where replacement begins.
   start_idx : Int
+  /// Exclusive child index where replacement ends.
   end_idx : Int
+  /// Replacement leaves, inserted in order. Every span must be positive.
   new_leaves : Array[(T, Int)]
 } derive(Debug)
 
@@ -77,11 +90,13 @@ priv struct PropagateResult[T] {
 }
 
 ///|
+/// Return the adjacent left leaf value captured in this snapshot, if present.
 pub fn[T] LeafContext::left_neighbor(self : LeafContext[T]) -> T? {
   self.left_elem
 }
 
 ///|
+/// Return the adjacent right leaf value captured in this snapshot, if present.
 pub fn[T] LeafContext::right_neighbor(self : LeafContext[T]) -> T? {
   self.right_elem
 }


### PR DESCRIPTION
## Summary

- Harden B-tree invariants at construction and mutation boundaries: multiplication-safe degree normalization, positive spans, pre-descent insert bounds, and one-shot `init_root`.
- Replace live callback aliases with `LeafContext` neighbor snapshots, make invariant-bearing B-tree state private, and document the complete construction/range/splice contract.
- Point `order-tree` at its already-merged bulk-builder reuse change, eliminating the duplicate structural builder before hiding B-tree state.
- Clean replacement for #999: this branch is based directly on current `main` (`4207c9f6`) and contains only B-tree plus the intended `order-tree` gitlink change.

## Plan status and commits

All five B-tree plans are **DONE** in this replacement branch, with one independent commit per plan.

| Plan | Commit | Result |
|---|---|---|
| 001 — bound min-degree arithmetic | `ef52e549` | Clamp to `[2, @int.MAX_VALUE / 2]`; oversized construction terminates. |
| 002 — positive leaf spans | `75062fde` | Reject non-positive constructor spans before construction and callback splice spans before `apply_splice`. |
| 003 — snapshot callback neighbors | `189f2c09` | Remove the live children-array alias from `LeafContext`. |
| 004 — reuse bulk construction / opaque state | `1c09150f` | Make B-tree state private and update the reachable `order-tree` gitlink. |
| 005 — document contracts | `9afa3500` | Define construction, position, range, callback, and splice behavior. |

Review follow-ups are separate commits:

| Commit | Result |
|---|---|
| `fafc0bdf` | Validate insert bounds before split preparation can mutate the tree. |
| `78626fde` | Reject repeated `init_root` calls and document the one-shot contract. |
| `2d11e813` | Directly assert the non-empty `from_sorted` degree clamp. |
| `a814d96` | Clarify that splice validation precedes callback replacement, without claiming full mutation rollback. |

The original B-tree plan index on #999 was marked `DONE`. It is intentionally not replayed here because current `main` now uses the same `plans/README.md` and numbered filenames for the unrelated Waku plans; replaying it would overwrite current plan state. This PR records the B-tree plan statuses without reintroducing that collision.

## order-tree prerequisite

`dowdiness/order-tree` PR [#10](https://github.com/dowdiness/order-tree/pull/10) had to merge first. That prerequisite is satisfied: it was merged normally, its work commit `6eb3702` is reachable from `origin/main`, and the Canopy gitlink now points at order-tree merge commit `731026f712af8b3bfe99703e15cf13e3402e9ef9`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|---|---|---|---|
| `BTree::from_sorted` | `lib/btree/btree.mbt` | Yes | order-tree delegates structural bulk construction to the owning package. |
| `BTree::is_empty` | `lib/btree/btree.mbt` | Yes | Enforces the one-shot `init_root` precondition. |
| `mutate_for_delete` pre-descent guard pattern | `lib/btree/btree.mbt` | Yes | Insert now rejects invalid positions before its mutating prepare hook too. |
| `Int::clamp`, `@int.MAX_VALUE` | MoonBit core `int` | Yes | Express the multiplication-safe degree interval without widening or a loop. |
| `Array::all` / `ArrayView::all` | MoonBit core `array` | Yes | Declarative batch span validation; no input mutation. |
| `Array::get` | MoonBit core `array` | Yes | Capture optional left/right neighbor values safely. |
| `Array::map`, `@rle.Spanning::span` | MoonBit core / rle, in order-tree #10 | Yes | Map canonicalized elements to the generic B-tree bulk-builder input. |
| `Option::is_none` / `Option::is_some` | MoonBit core `option` | No | Deprecated; the owning `BTree::is_empty` method and pattern matching are clearer. |
| `Int::compare` | MoonBit core `int` | No | Direct inclusive relational checks state the positional contract more clearly. |
| `Result` / typed errors | MoonBit core | No | Changing established low-level signatures is outside these plans; invalid invariant inputs retain the package's `abort` contract. |

New helpers added:

- `validate_positive_spans`: private functional-core boundary that validates constructor batches before node construction and callback replacement batches before `apply_splice`. Top-down descent may already have performed invariant-preserving split or rebalance preparation.
- `MAX_SAFE_MIN_DEGREE`: private derived constant, not a duplicated magic number.

No new low-level loops were added. Existing local mutation remains in the bottom-up B-tree builder and propagation/rebalancing state machines, where it builds or updates owned tree structures. Validation and snapshot decisions are deterministic: constructor validation precedes node construction, while callback replacement validation precedes `apply_splice`; descent preparation remains part of the existing state machine.

## `.mbti` review

Intentional public-surface changes only:

- `BTree.root`, `BTree.min_degree`, and `BTree.size` are no longer public fields.
- `LeafContext.children` is removed; captured neighbor storage is private.
- Existing B-tree methods, callback signatures, `BTreeNode`, `Splice`, and trait bounds are unchanged.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes (9 known vendored `rabbita` deprecation warnings, 0 errors).
- [x] `NEW_MOON_MOD=0 moon test` passes on all workspace targets.
- [x] Focused B-tree and order-tree contract tests pass.
- [x] B-tree and order-tree release benchmarks complete without a material bulk-build regression.
- [x] `git diff *.mbti` reviewed for unintended API or trait-bound drift.
- [x] JS rebuild not required; no web code or generated JS path changed.

## Validation

```text
moon check --deny-warn lib/btree order-tree                         PASS
NEW_MOON_MOD=0 moon check                                          PASS (9 vendored rabbita warnings, 0 errors)
moon test --release lib/btree -f '*min_degree*'                    6/6 PASS
moon test --release lib/btree -f '*non-positive span*'             6/6 PASS
moon test --release lib/btree -f '*LeafContext*'                   4/4 PASS
moon test --release lib/btree -f '*insert rejects*'                2/2 PASS
moon test --release lib/btree -f '*init_root*'                     4/4 PASS
moon test --release lib/btree -f '*oversized min_degree*'          1/1 PASS
moon test --release -p dowdiness/order-tree -f '*from_array*'      12/12 PASS
moon test --release lib/btree                                      98/98 PASS
moon test --release -p dowdiness/order-tree                        65/65 PASS
NEW_MOON_MOD=0 moon test                                           3944 wasm-gc + 1961 js + 70 native PASS
moon bench --release -p dowdiness/btree                            10/10 PASS
moon bench --release -p dowdiness/order-tree                       19/19 PASS
NEW_MOON_MOD=0 moon fmt/info lib/btree and order-tree              PASS
git diff --check origin/main...HEAD                                PASS
```

Final order-tree bulk-build samples were 31.11 µs for 1,000 elements and 469.58 µs for 10,000 elements; the comparable pre-follow-up run was 31.15 µs and 452.85 µs, respectively, with no material regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded B-tree API docs with precise bounds, clamping/no-op rules, and splice callback/engine invariants, including required error/abort behavior.

- **Bug Fixes**
  - Added stricter validation for out-of-range operations and non-positive leaf spans.
  - Prevented reinitialization of already-initialized trees.
  - Bounded and clamped oversized minimum-degree values.
  - Stabilized leaf-neighbor context during callbacks.

- **Tests**
  - Added failure-mode and regression coverage for validation, bounds handling, degree clamping, splice behavior, and snapshot semantics.

- **Chores**
  - Updated the `order-tree` submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
