### PR TITLE
fix(btree): normalize delete-shaped insert splices

### DIFF
--- a/lib/btree/README.md
+++ b/lib/btree/README.md
@@ -81,6 +81,9 @@ Calling `init_root` on an already initialized tree aborts with
 `BTree::init_root: tree is already initialized` instead of replacing its
 contents.
 
+Every successful mutation preserves the empty-tree lifecycle invariant:
+`size() == 0` if and only if the root is absent and `is_empty() == true`.
+
 `init_root` and every `(element, span)` pair passed to `from_sorted` require a
 strictly positive span. Invalid spans abort with
 `BTree::init_root: leaf span must be positive` or
@@ -130,6 +133,11 @@ The canonical splice shapes are:
 | Replace child `i` | `[i, i + 1)` | `[replacement]` |
 | Delete child `i` | `[i, i + 1)` | `[]` |
 | Split child `i` | `[i, i + 1)` | `[left, right, ...]` |
+
+Both mutation entry points support every structurally valid splice shape in
+this table. Their `insert` and `delete` names describe descent and return-value
+behavior; they do not restrict the callback to cardinality-increasing or
+cardinality-decreasing replacements.
 
 ## Relationship to Other Libraries
 

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -77,7 +77,7 @@ pub fn[T] BTree::mutate_for_insert(
       let leaf_ctx = LeafContext::from_cursor(cursor)
       let splice = f(leaf_ctx)
       let propagated = propagate(cursor.path, splice, self.min_degree)
-      self.apply_propagated(propagated, normalize_delete=false)
+      self.apply_propagated(propagated, normalize_delete=true)
     }
   }
 }

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -165,6 +165,9 @@ fn tree_matches_model(t : BTree[TItem], model : Array[TItem]) -> Bool {
   if !btree_invariants_hold(t) {
     return false
   }
+  if t.is_empty() != (t.size() == 0) {
+    return false
+  }
   if t.size() != model.length() {
     return false
   }

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -202,6 +202,26 @@ test "delete single element empties tree" {
 }
 
 ///|
+test "delete-shaped insert splice empties and can reinitialize tree" {
+  let t = build_tree([(1, 3)])
+  t.mutate_for_insert(0, ctx => {
+    start_idx: ctx.child_idx,
+    end_idx: ctx.child_idx + 1,
+    new_leaves: [],
+  })
+  inspect(t.is_empty(), content="true")
+  inspect(t.size(), content="0")
+  inspect(t.span(), content="0")
+  inspect(t.view().is_empty(), content="true")
+  inspect(t.iter().count(), content="0")
+  t.init_root(make_item(2, 2), 2)
+  inspect(t.is_empty(), content="false")
+  inspect(t.size(), content="1")
+  inspect(t.span(), content="2")
+  inspect(t.get_at(0) == Some(make_item(2, 2)), content="true")
+}
+
+///|
 test "delete on empty returns None" {
   let t : BTree[TItem] = BTree::new()
   let result : Unit? = t.mutate_for_delete(0, fn(_ctx) {


### PR DESCRIPTION
## Summary

- normalize the propagated root even when a delete-shaped splice is returned from `mutate_for_insert`
- pin the empty-tree lifecycle through the public query/iteration seam and the stateful model invariant
- document that both mutation entry points accept every structurally valid splice shape

Closes #1003.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `BTree::apply_propagated` | `lib/btree/btree.mbt` | Yes | Keeps root and size publication in the existing common mutation path. |
| `normalize_root_after_delete` | `lib/btree/btree.mbt` | Yes | Canonicalizes empty and unary roots without a second lifecycle implementation. |
| `Option::map` / pattern matching | `moonbitlang/core/option` | Existing match retained | The normalizer already owns the `None`/`Some` projection; another mapping layer would duplicate it. |
| `Array::is_empty` | `moonbitlang/core/array` | Yes | Observes the empty public `view`. |
| `Iter::count` | MoonBit prelude | Yes | Observes that public iteration yields no leaves. |

New helpers added: none.

Remaining imperative code is the existing `apply_propagated` publication shell, which must update mutable root and cached size together after deterministic propagation.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check --deny-warn lib/btree` passes
- [x] `NEW_MOON_MOD=0 moon test --release lib/btree` passes (99/99)
- [x] `NEW_MOON_MOD=0 moon test --release order-tree` passes (65/65)
- [x] `NEW_MOON_MOD=0 moon test --release` passes (3,945/3,945)
- [x] `NEW_MOON_MOD=0 moon info` run; `lib/btree/pkg.generated.mbti` has no change
- [x] `NEW_MOON_MOD=0 moon fmt --check lib/btree` passes
- [x] `git diff --check` passes
- [x] JS rebuild not required; no web code changed

## Validation

The focused regression failed before the production change with `is_empty()` returning `false`, then passed after root normalization was enabled for the shared publication path.

Full-workspace `moon fmt --check` continues to report pre-existing formatter drift in the pinned `graphviz` and `svg-dsl` submodules; the affected `lib/btree` module passes its scoped format check and neither submodule is changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved B-tree mutation handling so empty trees remain correctly normalized after insert and delete operations.
  * Ensured tree size and empty-state indicators remain consistent.

* **Tests**
  * Added coverage for operations that remove the only item during an insert-shaped mutation.
  * Expanded consistency checks for tree size, emptiness, spans, views, iteration, and item access.

* **Documentation**
  * Clarified B-tree mutation behavior and empty-tree lifecycle requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->