### PR TITLE
fix(btree): reject cumulative span overflow atomically

### DIFF
--- a/lib/btree/README.md
+++ b/lib/btree/README.md
@@ -92,6 +92,22 @@ strictly positive span. Invalid spans abort with
 `from_sorted` preserves input order but does not merge adjacent elements;
 callers own any no-adjacent-mergeable canonicalization policy.
 
+### Cumulative span range
+
+A valid tree's cumulative span is always in `0..=@int.MAX_VALUE`; zero is the
+empty-tree value, and `@int.MAX_VALUE` itself is supported. Construction or a
+callback splice whose prospective total exceeds that range aborts with
+`BTree: cumulative span must be in 0..=@int.MAX_VALUE` before an invalid root
+can be observed.
+
+Point mutations prepare and propagate through copy-on-write path arrays.
+Range deletion completes its splice, boundary merge, and repair on the same
+unpublished candidate. The tree publishes the candidate only after all
+checked totals succeed, so an overflow rejection leaves its root, size, and
+contents unchanged. A splice callback has already run by the time its returned
+spans can be checked; external side effects performed by that callback are not
+part of the tree-state rollback guarantee.
+
 ### Positions and ranges
 
 Positions are measured in the cumulative units supplied by leaf spans. Ranges
@@ -123,7 +139,8 @@ are not separately validated.
 
 `new_leaves` replace that interval in order.
 Every replacement span must be positive, or propagation aborts with
-`BTree splice: leaf spans must be positive`.
+`BTree splice: leaf spans must be positive`. Their prospective cumulative
+total must also satisfy the cumulative span range above.
 
 The canonical splice shapes are:
 

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -45,7 +45,8 @@ pub fn[T] BTree::find(self : BTree[T], pos : Int) -> FindResult[T]? {
 ///
 /// The callback receives a `LeafContext` snapshot and returns a `Splice`
 /// description. The tree applies it, rebalances, and updates size. Every span
-/// in the returned splice must be positive or propagation aborts.
+/// in the returned splice must be positive. A prospective cumulative span
+/// above `@int.MAX_VALUE` aborts before the copy-on-write candidate is published.
 pub fn[T] BTree::mutate_for_insert(
   self : BTree[T],
   pos : Int,
@@ -70,12 +71,19 @@ pub fn[T] BTree::mutate_for_insert(
           prepare_split,
           find_slot_inclusive,
           true,
+          copy_on_write=true,
         ) {
         Some(c) => c
         None => abort("BTree::mutate_for_insert: descent failed")
       }
       let leaf_ctx = LeafContext::from_cursor(cursor)
       let splice = f(leaf_ctx)
+      validate_positive_spans(splice.new_leaves, "BTree splice")
+      let leaf_parent = cursor.path[cursor.path.length() - 1]
+      guard checked_splice_total(root.total(), leaf_parent.counts, splice)
+        is Some(_) else {
+        abort("BTree: cumulative span must be in 0..=@int.MAX_VALUE")
+      }
       let propagated = propagate(cursor.path, splice, self.min_degree)
       self.apply_propagated(propagated, normalize_delete=true)
     }
@@ -86,7 +94,8 @@ pub fn[T] BTree::mutate_for_insert(
 /// Mutate the leaf containing span position `pos`, where
 /// `0 <= pos < span()`. Returns the callback's payload, or `None` without
 /// calling the callback when the tree is empty or `pos` is out of bounds.
-/// Every span in the returned splice must be positive or propagation aborts.
+/// Every span in the returned splice must be positive. A prospective cumulative
+/// span above `@int.MAX_VALUE` aborts without publishing the candidate tree.
 pub fn[T, R] BTree::mutate_for_delete(
   self : BTree[T],
   pos : Int,
@@ -106,11 +115,18 @@ pub fn[T, R] BTree::mutate_for_delete(
           prepare_ensure_min,
           find_slot,
           false,
+          copy_on_write=true,
         ) {
         None => None
         Some(cursor) => {
           let leaf_ctx = LeafContext::from_cursor(cursor)
           let (splice, payload) = f(leaf_ctx)
+          validate_positive_spans(splice.new_leaves, "BTree splice")
+          let leaf_parent = cursor.path[cursor.path.length() - 1]
+          guard checked_splice_total(root.total(), leaf_parent.counts, splice)
+            is Some(_) else {
+            abort("BTree: cumulative span must be in 0..=@int.MAX_VALUE")
+          }
           let propagated = propagate(cursor.path, splice, self.min_degree)
           self.apply_propagated(propagated, normalize_delete=true)
           Some(payload)
@@ -123,7 +139,8 @@ pub fn[T, R] BTree::mutate_for_delete(
 ///|
 /// Delete the half-open span range `[start, end_)`, clamping an oversized end
 /// to `span()`. This is a no-op for an empty tree, a negative start, an empty
-/// or reversed range, or `start >= span()`.
+/// or reversed range, or `start >= span()`. Splice, boundary merge, and repair
+/// complete on an unpublished copy-on-write candidate before one final update.
 pub fn[T : BTreeElem] BTree::delete_range(
   self : BTree[T],
   start : Int,
@@ -137,9 +154,9 @@ pub fn[T : BTreeElem] BTree::delete_range(
     None => ()
     Some(splice) => {
       let propagated = propagate_node_splice(splice, self.min_degree)
-      // Skip root normalization here — we normalize after boundary merge
-      self.apply_propagated(propagated, normalize_delete=false)
-      guard self.root is Some(new_root) else { return }
+      // Keep every range-delete phase on an unpublished candidate. A late
+      // boundary-merge or repair rejection must leave the original tree intact.
+      let new_root = propagated.root_candidate(normalize_delete=false).unwrap()
       let (merged_root, boundary_merged) = normalize_boundary_merge(
         new_root,
         start,
@@ -154,11 +171,28 @@ pub fn[T : BTreeElem] BTree::delete_range(
           normalize_root_after_delete(fixed)
         }
       }
+      let final_size = self.size +
+        propagated.leaf_delta -
+        (if boundary_merged { 1 } else { 0 })
       self.root = final_root
-      if boundary_merged {
-        self.size = self.size - 1
-      }
+      self.size = final_size
     }
+  }
+}
+
+///|
+fn[T] PropagateResult::root_candidate(
+  self : PropagateResult[T],
+  normalize_delete~ : Bool,
+) -> BTreeNode[T]? {
+  match self.overflow {
+    None =>
+      if normalize_delete {
+        normalize_root_after_delete(self.node)
+      } else {
+        Some(self.node)
+      }
+    Some(sibling) => Some(make_internal([self.node, sibling]))
   }
 }
 
@@ -168,34 +202,19 @@ fn[T] BTree::apply_propagated(
   propagated : PropagateResult[T],
   normalize_delete~ : Bool,
 ) -> Unit {
-  match propagated.overflow {
-    None =>
-      if normalize_delete {
-        self.root = normalize_root_after_delete(propagated.node)
-      } else {
-        self.root = Some(propagated.node)
-      }
-    Some(sibling) => {
-      let left_total = propagated.node.total()
-      let right_total = sibling.total()
-      self.root = Some(
-        Internal(
-          children=[propagated.node, sibling],
-          counts=[left_total, right_total],
-          total=left_total + right_total,
-        ),
-      )
-    }
-  }
-  self.size = self.size + propagated.leaf_delta
+  let next_root = propagated.root_candidate(normalize_delete~)
+  let next_size = self.size + propagated.leaf_delta
+  self.root = next_root
+  self.size = next_size
 }
 
 ///|
 /// Build a `BTree` bottom-up in input order from pre-sorted `(element, span)`
 /// pairs. `min_degree` is normalized to `[2, @int.MAX_VALUE / 2]`.
 ///
-/// Every span must be positive or construction aborts. The caller must
-/// pre-merge adjacent mergeable elements when its canonicalization policy
+/// Every span must be positive and the cumulative total must be at most
+/// `@int.MAX_VALUE`, or construction aborts before publishing a tree. The caller
+/// must pre-merge adjacent mergeable elements when its canonicalization policy
 /// requires that invariant. Runs in O(n), rather than O(n log n) inserts.
 pub fn[T] BTree::from_sorted(
   items : Array[(T, Int)],

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -271,6 +271,226 @@ test "panic from_sorted rejects negative non-positive span" {
 }
 
 ///|
+test "panic from_sorted rejects cumulative span overflow" {
+  let _ : BTree[Int] = BTree::from_sorted([(1, @int.MAX_VALUE), (2, 1)])
+}
+
+///|
+test "panic from_sorted rejects multi-level cumulative span overflow" {
+  let items = Array::makei(8, fn(i) {
+    (i, if i == 0 { @int.MAX_VALUE - 3 } else { 1 })
+  })
+  let _ : BTree[Int] = BTree::from_sorted(items, min_degree=2)
+}
+
+///|
+test "from_sorted accepts cumulative span at Int max" {
+  let t : BTree[Int] = BTree::from_sorted([(1, @int.MAX_VALUE - 1), (2, 1)])
+  inspect(t.span(), content="2147483647")
+  @debug.debug_inspect(
+    t.get_at(@int.MAX_VALUE - 1),
+    content=(
+      #|Some(2)
+    ),
+  )
+}
+
+///|
+test "overflow preflight keeps split candidate isolated from original tree" {
+  let items = Array::makei(8, fn(i) {
+    (i, if i == 0 { @int.MAX_VALUE - 7 } else { 1 })
+  })
+  let t : BTree[Int] = BTree::from_sorted(items, min_degree=2)
+  let before_items = t.to_array()
+  let before_debug = @debug.to_string(t)
+  let before_span = t.span()
+  let before_size = t.size()
+  let root = t.root.unwrap()
+  let cursor = descend(
+    root,
+    0,
+    t.min_degree,
+    prepare_split,
+    find_slot_inclusive,
+    true,
+    copy_on_write=true,
+  ).unwrap()
+  let splice : Splice[Int] = {
+    start_idx: cursor.child_idx,
+    end_idx: cursor.child_idx,
+    new_leaves: [(8, 1)],
+  }
+  let leaf_parent = cursor.path[cursor.path.length() - 1]
+  inspect(
+    checked_splice_total(root.total(), leaf_parent.counts, splice) is None,
+    content="true",
+  )
+  inspect(t.span(), content=before_span.to_string())
+  inspect(t.size(), content=before_size.to_string())
+  inspect(t.to_array() == before_items, content="true")
+  inspect(@debug.to_string(t) == before_debug, content="true")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "overflow preflight keeps borrow candidate isolated from original tree" {
+  let items = Array::makei(5, fn(i) {
+    (i, if i == 0 { @int.MAX_VALUE - 4 } else { 1 })
+  })
+  let t : BTree[Int] = BTree::from_sorted(items, min_degree=2)
+  let before_debug = @debug.to_string(t)
+  let root = t.root.unwrap()
+  let cursor = descend(
+    root,
+    0,
+    t.min_degree,
+    prepare_ensure_min,
+    find_slot,
+    false,
+    copy_on_write=true,
+  ).unwrap()
+  let splice : Splice[Int] = {
+    start_idx: cursor.child_idx,
+    end_idx: cursor.child_idx + 1,
+    new_leaves: [(cursor.leaf_elem, cursor.leaf_span + 1)],
+  }
+  let leaf_parent = cursor.path[cursor.path.length() - 1]
+  inspect(
+    checked_splice_total(root.total(), leaf_parent.counts, splice) is None,
+    content="true",
+  )
+  inspect(@debug.to_string(t) == before_debug, content="true")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "reactive merge candidate stays isolated until publish" {
+  let left : BTreeNode[Int] = Internal(
+    children=[Leaf(elem=0, span=@int.MAX_VALUE - 3), Leaf(elem=1, span=1)],
+    counts=[@int.MAX_VALUE - 3, 1],
+    total=@int.MAX_VALUE - 2,
+  )
+  let right : BTreeNode[Int] = Internal(
+    children=[Leaf(elem=2, span=1), Leaf(elem=3, span=1)],
+    counts=[1, 1],
+    total=2,
+  )
+  let root : BTreeNode[Int] = Internal(
+    children=[left, right],
+    counts=[@int.MAX_VALUE - 2, 2],
+    total=@int.MAX_VALUE,
+  )
+  let t : BTree[Int] = { root: Some(root), min_degree: 2, size: 4 }
+  let before_debug = @debug.to_string(t)
+  let cursor = descend(
+    root,
+    @int.MAX_VALUE - 2,
+    t.min_degree,
+    prepare_noop,
+    find_slot,
+    false,
+    copy_on_write=true,
+  ).unwrap()
+  let splice : Splice[Int] = {
+    start_idx: cursor.child_idx,
+    end_idx: cursor.child_idx + 1,
+    new_leaves: [],
+  }
+  let _candidate = propagate(cursor.path, splice, t.min_degree)
+  inspect(@debug.to_string(t) == before_debug, content="true")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "range delete candidate stays isolated until publish" {
+  let t = build_tree([(1, 2), (2, 2), (3, 2)])
+  let before_debug = @debug.to_string(t)
+  let root = t.root.unwrap()
+  let splice = plan_delete_range(root, 1, 3, t.min_degree).unwrap()
+  let _candidate = propagate_node_splice(splice, t.min_degree)
+  inspect(@debug.to_string(t) == before_debug, content="true")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "panic insert rejects cumulative span overflow" {
+  let t : BTree[Int] = BTree::from_sorted([(1, @int.MAX_VALUE)])
+  t.mutate_for_insert(@int.MAX_VALUE, fn(ctx) {
+    {
+      start_idx: ctx.child_idx + 1,
+      end_idx: ctx.child_idx + 1,
+      new_leaves: [(2, 1)],
+    }
+  })
+}
+
+///|
+test "insert accepts cumulative span at Int max" {
+  let t : BTree[Int] = BTree::from_sorted([(1, @int.MAX_VALUE - 1)])
+  t.mutate_for_insert(@int.MAX_VALUE - 1, fn(ctx) {
+    {
+      start_idx: ctx.child_idx + 1,
+      end_idx: ctx.child_idx + 1,
+      new_leaves: [(2, 1)],
+    }
+  })
+  inspect(t.span(), content="2147483647")
+  inspect(t.to_array() == [1, 2], content="true")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "insert split and root growth accept cumulative span at Int max" {
+  let items = Array::makei(16, fn(i) {
+    (i, if i == 0 { @int.MAX_VALUE - 16 } else { 1 })
+  })
+  let t : BTree[Int] = BTree::from_sorted(items, min_degree=2)
+  t.mutate_for_insert(0, fn(ctx) {
+    { start_idx: ctx.child_idx, end_idx: ctx.child_idx, new_leaves: [(16, 1)] }
+  })
+  inspect(t.span(), content="2147483647")
+  inspect(t.size(), content="17")
+  inspect(t.root.unwrap().height(), content="3")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "boundary sweep successful mutations never expose negative span" {
+  for reserve in 1..<33 {
+    let t : BTree[Int] = BTree::from_sorted(
+      [(0, @int.MAX_VALUE - reserve)],
+      min_degree=2,
+    )
+    for i in 0..<reserve {
+      t.mutate_for_insert(t.span(), fn(ctx) {
+        {
+          start_idx: ctx.child_idx + 1,
+          end_idx: ctx.child_idx + 1,
+          new_leaves: [(i + 1, 1)],
+        }
+      })
+      guard t.span() >= 0 && btree_invariants_hold(t) else { fail("insert") }
+    }
+    guard t.span() == @int.MAX_VALUE else { fail("boundary") }
+    for _ in 0..<reserve {
+      let deleted = t.mutate_for_delete(t.span() - 1, fn(ctx) {
+        (
+          {
+            start_idx: ctx.child_idx,
+            end_idx: ctx.child_idx + 1,
+            new_leaves: [],
+          },
+          ctx.elem,
+        )
+      })
+      guard deleted is Some(_) && t.span() >= 0 && btree_invariants_hold(t) else {
+        fail("delete")
+      }
+    }
+  }
+}
+
+///|
 test "panic init_root rejects zero non-positive span" {
   let t : BTree[TItem] = BTree::new()
   t.init_root(make_item(1, 0), 0)
@@ -280,6 +500,15 @@ test "panic init_root rejects zero non-positive span" {
 test "panic init_root rejects negative non-positive span" {
   let t : BTree[TItem] = BTree::new()
   t.init_root(make_item(1, -1), -1)
+}
+
+///|
+test "init_root accepts span at Int max" {
+  let t : BTree[Int] = BTree::new()
+  t.init_root(1, @int.MAX_VALUE)
+  inspect(t.span(), content="2147483647")
+  inspect(t.size(), content="1")
+  inspect(btree_invariants_hold(t), content="true")
 }
 
 ///|
@@ -316,6 +545,98 @@ test "panic delete splice rejects non-positive span" {
       ctx.elem,
     )
   })
+}
+
+///|
+test "panic delete splice rejects cumulative span overflow" {
+  let t : BTree[Int] = BTree::from_sorted([(1, @int.MAX_VALUE - 1), (2, 1)])
+  let _ = t.mutate_for_delete(@int.MAX_VALUE - 1, fn(ctx) {
+    (
+      {
+        start_idx: ctx.child_idx,
+        end_idx: ctx.child_idx + 1,
+        new_leaves: [(ctx.elem, 2)],
+      },
+      (),
+    )
+  })
+}
+
+///|
+test "delete splice update accepts cumulative span at Int max" {
+  let t : BTree[Int] = BTree::from_sorted([(1, @int.MAX_VALUE - 2), (2, 1)])
+  let updated = t.mutate_for_delete(@int.MAX_VALUE - 2, fn(ctx) {
+    (
+      {
+        start_idx: ctx.child_idx,
+        end_idx: ctx.child_idx + 1,
+        new_leaves: [(ctx.elem, 2)],
+      },
+      ctx.elem,
+    )
+  })
+  inspect(updated == Some(2), content="true")
+  inspect(t.span(), content="2147483647")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "delete preparation borrow accepts cumulative span at Int max" {
+  let items = Array::makei(5, fn(i) {
+    (i, if i == 0 { @int.MAX_VALUE - 4 } else { 1 })
+  })
+  let t : BTree[Int] = BTree::from_sorted(items, min_degree=2)
+  let before_items = t.to_array()
+  let updated = t.mutate_for_delete(0, fn(ctx) {
+    (
+      {
+        start_idx: ctx.child_idx,
+        end_idx: ctx.child_idx + 1,
+        new_leaves: [(ctx.elem, ctx.span)],
+      },
+      ctx.elem,
+    )
+  })
+  inspect(updated == Some(0), content="true")
+  inspect(t.span(), content="2147483647")
+  inspect(t.to_array() == before_items, content="true")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
+test "delete preparation merge accepts cumulative span at Int max" {
+  let left : BTreeNode[Int] = Internal(
+    children=[Leaf(elem=0, span=@int.MAX_VALUE - 3), Leaf(elem=1, span=1)],
+    counts=[@int.MAX_VALUE - 3, 1],
+    total=@int.MAX_VALUE - 2,
+  )
+  let right : BTreeNode[Int] = Internal(
+    children=[Leaf(elem=2, span=1), Leaf(elem=3, span=1)],
+    counts=[1, 1],
+    total=2,
+  )
+  let root : BTreeNode[Int] = Internal(
+    children=[left, right],
+    counts=[@int.MAX_VALUE - 2, 2],
+    total=@int.MAX_VALUE,
+  )
+  let t : BTree[Int] = { root: Some(root), min_degree: 2, size: 4 }
+  let before_items = t.to_array()
+  let updated = t.mutate_for_delete(0, fn(ctx) {
+    (
+      {
+        start_idx: ctx.child_idx,
+        end_idx: ctx.child_idx + 1,
+        new_leaves: [(ctx.elem, ctx.span)],
+      },
+      ctx.elem,
+    )
+  })
+  inspect(updated == Some(0), content="true")
+  inspect(t.span(), content="2147483647")
+  inspect(t.to_array() == before_items, content="true")
+  inspect(t.root.unwrap().height(), content="1")
+  inspect(btree_invariants_hold(t), content="true")
 }
 
 // === Iteration ===
@@ -1304,6 +1625,20 @@ test "BTree::delete_range merges boundary leaves" {
 }
 
 ///|
+test "delete_range repair near Int max keeps cumulative span valid" {
+  let items = Array::makei(16, fn(i) {
+    let span = if i == 0 { @int.MAX_VALUE - 15 } else { 1 }
+    (make_item(i, span), span)
+  })
+  let t : BTree[TItem] = BTree::from_sorted(items, min_degree=2)
+  t.delete_range(@int.MAX_VALUE - 12, @int.MAX_VALUE - 4)
+  inspect(t.span(), content="2147483639")
+  inspect(t.span() >= 0, content="true")
+  inspect(t.size(), content="8")
+  inspect(btree_invariants_hold(t), content="true")
+}
+
+///|
 test "BTree::delete_range empty range is no-op" {
   let t = build_tree([(1, 2), (2, 3)])
   t.delete_range(2, 2)
@@ -1524,7 +1859,7 @@ fn[T] check_node_invariants(
       }
       let mut expected_leaf_depth = -1
       let mut leaf_count = 0
-      let mut sum = 0
+      let mut sum : Int64 = 0L
       for i in 0..<children.length() {
         if counts[i] != children[i].total() {
           return (false, depth, 0)
@@ -1544,9 +1879,9 @@ fn[T] check_node_invariants(
           return (false, depth, 0)
         }
         leaf_count = leaf_count + child_leaf_count
-        sum = sum + counts[i]
+        sum = sum + counts[i].to_int64()
       }
-      if sum != total {
+      if sum != total.to_int64() {
         return (false, depth, 0)
       }
       (true, expected_leaf_depth, leaf_count)

--- a/lib/btree/utils.mbt
+++ b/lib/btree/utils.mbt
@@ -1,6 +1,70 @@
 ///|
+/// Add one non-negative span without allowing `Int` wraparound.
+/// MoonBit core has no checked-add API, so this package keeps the range
+/// decision in a small deterministic helper instead of widening then
+/// truncating through `Int64`.
+fn checked_span_add(total : Int, span : Int) -> Int? {
+  guard total >= 0 && span >= 0 else { return None }
+  guard total <= @int.MAX_VALUE - span else { return None }
+  Some(total + span)
+}
+
+///|
+/// Convert an internal checked-add decision to the package's established
+/// deterministic abort contract without changing any public error signature.
+fn add_spans_or_abort(total : Int, span : Int) -> Int {
+  match checked_span_add(total, span) {
+    Some(result) => result
+    None => abort("BTree: cumulative span must be in 0..=@int.MAX_VALUE")
+  }
+}
+
+///|
+/// Reuse core `ArrayView::fold` to validate and sum cached child spans.
+fn ArrayView::checked_span_sum(self : ArrayView[Int]) -> Int? {
+  self.fold(init=Some(0), fn(total, span) {
+    match total {
+      Some(acc) => checked_span_add(acc, span)
+      None => None
+    }
+  })
+}
+
+///|
+/// Sum cached child spans or reject an invalid cumulative range.
 fn Array::sum(self : Array[Int]) -> Int {
-  self.iter().fold(init=0, fn(acc, x) { acc + x })
+  match self[:].checked_span_sum() {
+    Some(total) => total
+    None => abort("BTree: cumulative span must be in 0..=@int.MAX_VALUE")
+  }
+}
+
+///|
+/// Compute the prospective tree total for a leaf-parent splice without
+/// mutating either the current tree or its copy-on-write candidate path.
+fn[T] checked_splice_total(
+  tree_total : Int,
+  parent_counts : Array[Int],
+  splice : Splice[T],
+) -> Int? {
+  guard splice.start_idx >= 0 &&
+    splice.start_idx <= splice.end_idx &&
+    splice.end_idx <= parent_counts.length() else {
+    return None
+  }
+  let removed = parent_counts[splice.start_idx:splice.end_idx].checked_span_sum()
+  let added = splice.new_leaves.fold(init=Some(0), fn(total, pair) {
+    guard pair.1 > 0 else { return None }
+    match total {
+      Some(acc) => checked_span_add(acc, pair.1)
+      None => None
+    }
+  })
+  match (removed, added) {
+    (Some(removed), Some(added)) if removed <= tree_total =>
+      checked_span_add(tree_total - removed, added)
+    _ => None
+  }
 }
 
 ///|

--- a/lib/btree/walker_descend.mbt
+++ b/lib/btree/walker_descend.mbt
@@ -69,7 +69,7 @@ fn[T] borrow_from_left(
       target_ch.insert(0, borrowed_child)
       target_cn.insert(0, borrowed_count)
       let new_left_total = left_total - borrowed_count
-      let new_target_total = target_total + borrowed_count
+      let new_target_total = add_spans_or_abort(target_total, borrowed_count)
       children[idx - 1] = Internal(
         children=left_ch,
         counts=left_cn,
@@ -104,7 +104,7 @@ fn[T] borrow_from_right(
       let borrowed_count = right_cn.remove(0)
       target_ch.push(borrowed_child)
       target_cn.push(borrowed_count)
-      let new_target_total = target_total + borrowed_count
+      let new_target_total = add_spans_or_abort(target_total, borrowed_count)
       let new_right_total = right_total - borrowed_count
       children[idx] = Internal(
         children=target_ch,
@@ -143,7 +143,7 @@ fn[T] merge_children(
       let merged = Internal(
         children=left_ch,
         counts=left_cn,
-        total=left_total + right_total,
+        total=add_spans_or_abort(left_total, right_total),
       )
       children[idx] = merged
       counts[idx] = merged.total()
@@ -191,16 +191,24 @@ fn[T] ensure_min_children(
     return
   }
   if idx > 0 && children[idx - 1].can_lend(min_degree) {
+    children[idx - 1] = children[idx - 1].shallow_copy()
+    children[idx] = children[idx].shallow_copy()
     borrow_from_left(children, counts, idx)
     return
   }
   if idx + 1 < children.length() && children[idx + 1].can_lend(min_degree) {
+    children[idx] = children[idx].shallow_copy()
+    children[idx + 1] = children[idx + 1].shallow_copy()
     borrow_from_right(children, counts, idx)
     return
   }
   if idx > 0 {
+    children[idx - 1] = children[idx - 1].shallow_copy()
+    children[idx] = children[idx].shallow_copy()
     merge_children(children, counts, idx - 1)
   } else {
+    children[idx] = children[idx].shallow_copy()
+    children[idx + 1] = children[idx + 1].shallow_copy()
     merge_children(children, counts, idx)
   }
 }
@@ -257,6 +265,7 @@ fn[T] descend(
   prepare : (Array[BTreeNode[T]], Array[Int], Int, Int) -> Unit,
   find_slot_fn : (Array[Int], Int, Int) -> (Int, Int),
   allow_leaf_end : Bool,
+  copy_on_write? : Bool = false,
 ) -> Cursor[T]? {
   let path : Array[PathFrame[T]] = []
   fn step(current : BTreeNode[T], current_pos : Int) -> Cursor[T]? {
@@ -279,7 +288,17 @@ fn[T] descend(
         } else {
           None
         }
-      Internal(children~, counts~, total~) => {
+      Internal(children=source_children, counts=source_counts, total~) => {
+        let children = if copy_on_write {
+          source_children.copy()
+        } else {
+          source_children
+        }
+        let counts = if copy_on_write {
+          source_counts.copy()
+        } else {
+          source_counts
+        }
         // First pass: find slot to prepare (may be invalidated by prepare)
         let (pre_idx, _) = find_slot_fn(counts, current_pos, total)
         prepare(children, counts, pre_idx, min_degree)
@@ -381,8 +400,18 @@ fn[T] descend_leaf_at(
   node : BTreeNode[T],
   pos : Int,
   min_degree : Int,
+  copy_on_write? : Bool = false,
 ) -> LeafCursor[T]? {
-  match descend(node, pos, min_degree, prepare_noop, find_slot, false) {
+  match
+    descend(
+      node,
+      pos,
+      min_degree,
+      prepare_noop,
+      find_slot,
+      false,
+      copy_on_write~,
+    ) {
     None => None
     Some(cursor) => Some(LeafCursor::from_cursor(cursor))
   }
@@ -393,12 +422,21 @@ fn[T] descend_leaf_at_end_boundary(
   node : BTreeNode[T],
   end_ : Int,
   min_degree : Int,
+  copy_on_write? : Bool = false,
 ) -> LeafCursor[T]? {
   if end_ == 0 {
     return None
   }
   match
-    descend(node, end_, min_degree, prepare_noop, find_slot_inclusive, true) {
+    descend(
+      node,
+      end_,
+      min_degree,
+      prepare_noop,
+      find_slot_inclusive,
+      true,
+      copy_on_write~,
+    ) {
     None => None
     Some(cursor) => Some(LeafCursor::from_cursor(cursor))
   }

--- a/lib/btree/walker_propagate.mbt
+++ b/lib/btree/walker_propagate.mbt
@@ -15,7 +15,7 @@ fn[T] split_internal(
   for i in 0..<mid {
     left_children.push(children[i])
     left_counts.push(counts[i])
-    left_total = left_total + counts[i]
+    left_total = add_spans_or_abort(left_total, counts[i])
   }
   let right_children : Array[BTreeNode[T]] = Array::new(
     capacity=children.length() - mid,
@@ -25,7 +25,7 @@ fn[T] split_internal(
   for i in mid..<children.length() {
     right_children.push(children[i])
     right_counts.push(counts[i])
-    right_total = right_total + counts[i]
+    right_total = add_spans_or_abort(right_total, counts[i])
   }
   (
     Internal(children=left_children, counts=left_counts, total=left_total),
@@ -104,16 +104,24 @@ fn[T] ensure_min_after_splice(
 ) -> Unit {
   guard children[idx].is_underfull(min_degree) else { return }
   if idx > 0 && children[idx - 1].can_lend(min_degree) {
+    children[idx - 1] = children[idx - 1].shallow_copy()
+    children[idx] = children[idx].shallow_copy()
     borrow_from_left(children, counts, idx)
     return
   }
   if idx + 1 < children.length() && children[idx + 1].can_lend(min_degree) {
+    children[idx] = children[idx].shallow_copy()
+    children[idx + 1] = children[idx + 1].shallow_copy()
     borrow_from_right(children, counts, idx)
     return
   }
   if idx > 0 {
+    children[idx - 1] = children[idx - 1].shallow_copy()
+    children[idx] = children[idx].shallow_copy()
     merge_children(children, counts, idx - 1)
   } else if idx + 1 < children.length() {
+    children[idx] = children[idx].shallow_copy()
+    children[idx + 1] = children[idx + 1].shallow_copy()
     merge_children(children, counts, idx)
   }
 }

--- a/lib/btree/walker_range_delete.mbt
+++ b/lib/btree/walker_range_delete.mbt
@@ -369,8 +369,18 @@ fn[T : BTreeElem] plan_delete_range(
     return None
   }
   let clamped_end = if end_ > total { total } else { end_ }
-  let start_cursor = descend_leaf_at(root, start, min_degree)
-  let end_cursor = descend_leaf_at_end_boundary(root, clamped_end, min_degree)
+  let start_cursor = descend_leaf_at(
+    root,
+    start,
+    min_degree,
+    copy_on_write=true,
+  )
+  let end_cursor = descend_leaf_at_end_boundary(
+    root,
+    clamped_end,
+    min_degree,
+    copy_on_write=true,
+  )
   match (start_cursor, end_cursor) {
     (Some(start_leaf), Some(end_leaf)) => {
       let lca = lowest_common_ancestor_range(start_leaf, end_leaf)
@@ -478,9 +488,19 @@ fn[T : BTreeElem] normalize_boundary_merge(
     return (root, false)
   }
   // Descend to the leaf just before the boundary (end-boundary semantics)
-  let left_cursor = descend_leaf_at_end_boundary(root, boundary_pos, min_degree)
+  let left_cursor = descend_leaf_at_end_boundary(
+    root,
+    boundary_pos,
+    min_degree,
+    copy_on_write=true,
+  )
   // Descend to the leaf at the boundary (start semantics)
-  let right_cursor = descend_leaf_at(root, boundary_pos, min_degree)
+  let right_cursor = descend_leaf_at(
+    root,
+    boundary_pos,
+    min_degree,
+    copy_on_write=true,
+  )
   match (left_cursor, right_cursor) {
     (Some(left), Some(right)) => {
       // Check if these are different leaves
@@ -528,15 +548,7 @@ fn[T : BTreeElem] normalize_boundary_merge(
       let result = propagate_node_splice(splice, min_degree)
       let new_root = match result.overflow {
         None => result.node
-        Some(sibling) => {
-          let left_total = result.node.total()
-          let right_total = sibling.total()
-          Internal(
-            children=[result.node, sibling],
-            counts=[left_total, right_total],
-            total=left_total + right_total,
-          )
-        }
+        Some(sibling) => make_internal([result.node, sibling])
       }
       (new_root, true)
     }

--- a/lib/btree/walker_repair.mbt
+++ b/lib/btree/walker_repair.mbt
@@ -53,8 +53,9 @@ fn[T] bulk_steal_from_left(
         let count = left_cn.remove(last)
         target_ch.insert(0, child)
         target_cn.insert(0, count)
-        transferred += count
+        transferred = add_spans_or_abort(transferred, count)
       }
+      let new_target_total = add_spans_or_abort(target_total, transferred)
       children[idx - 1] = Internal(
         children=left_ch,
         counts=left_cn,
@@ -63,10 +64,10 @@ fn[T] bulk_steal_from_left(
       children[idx] = Internal(
         children=target_ch,
         counts=target_cn,
-        total=target_total + transferred,
+        total=new_target_total,
       )
       counts[idx - 1] = left_total - transferred
-      counts[idx] = target_total + transferred
+      counts[idx] = new_target_total
     }
     _ => abort("bulk_steal_from_left: expected internal nodes")
   }
@@ -92,19 +93,20 @@ fn[T] bulk_steal_from_right(
         let count = right_cn.remove(0)
         target_ch.push(child)
         target_cn.push(count)
-        transferred += count
+        transferred = add_spans_or_abort(transferred, count)
       }
+      let new_target_total = add_spans_or_abort(target_total, transferred)
       children[idx] = Internal(
         children=target_ch,
         counts=target_cn,
-        total=target_total + transferred,
+        total=new_target_total,
       )
       children[idx + 1] = Internal(
         children=right_ch,
         counts=right_cn,
         total=right_total - transferred,
       )
-      counts[idx] = target_total + transferred
+      counts[idx] = new_target_total
       counts[idx + 1] = right_total - transferred
     }
     _ => abort("bulk_steal_from_right: expected internal nodes")

--- a/lib/btree/walker_types.mbt
+++ b/lib/btree/walker_types.mbt
@@ -1,7 +1,7 @@
 // Walker contract:
-// - descent owns navigation and may mutate internal nodes via prepare hooks
+// - mutation descent copies path arrays before prepare hooks mutate them
 // - leaf actions read LeafContext and return pure Splice descriptions
-// - propagation is the only phase that rewrites ancestors and handles splits
+// - propagation rewrites only the unpublished candidate path and handles splits
 
 ///|
 priv struct PathFrame[T] {


### PR DESCRIPTION
## Summary

- Define the supported cumulative span range as 0..=@int.MAX_VALUE and reject overflow before an invalid tree can be observed.
- Prepare point and range mutations on copy-on-write candidates, including split, borrow, merge, boundary normalization, and repair paths, then publish root and size once.
- Add exact-boundary, overflow, structural-isolation, and near-boundary regression coverage. No public MoonBit interface changes.

Fixes #1001

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Array::sum | lib/btree/utils.mbt | Yes | Strengthened the existing package aggregation boundary instead of adding parallel unchecked summation. |
| make_internal | lib/btree/utils.mbt | Yes | Reused for root growth and range boundary reconstruction. |
| validate_positive_spans | lib/btree/utils.mbt | Yes | Reused before point-splice overflow preflight. |
| BTreeNode::total and BTreeNode::shallow_copy | lib/btree | Yes | Reused cached totals and existing node-level COW support. |
| ArrayView::fold and Option | MoonBit core | Yes | Implement deterministic checked aggregation without observable mutation. |
| Int::to_int64 and Int64::from_int | MoonBit core | No | A widened sum still needs a checked down-conversion; a pre-add Int guard states the supported range directly. |
| Int checked-add / overflowing-add | MoonBit core | No | The current core exposes no such API. |
| Result / typed raise | MoonBit core | No | Public BTree mutation APIs are non-raising; changing them would drift the generated interface. |

New helpers added:

- checked_span_add: pure non-negative Int addition within the documented range.
- add_spans_or_abort: thin shell preserving the package deterministic-abort contract.
- ArrayView::checked_span_sum: checked child-count aggregation through core fold.
- checked_splice_total: pure prospective point-splice total validation.
- PropagateResult::root_candidate: finish root normalization or growth before publication.

Remaining imperative code is limited to existing array builders and BTree rebalancing, copy-on-write candidate preparation, and the final root/size assignments. The range decision and prospective-total validation remain deterministic.

## Test plan

- [x] NEW_MOON_MOD=0 moon check passes
- [x] NEW_MOON_MOD=0 moon test passes
- [x] git diff *.mbti reviewed; no public API surface change
- [x] JS rebuild is not required; no web code or generated JS surface changed

## Validation

- moon fmt --check lib/btree
- moon check --deny-warn lib/btree order-tree
- moon test lib/btree: 115/115
- moon test order-tree: 65/65
- full workspace moon test: wasm-gc 3961/3961, JS 1961/1961, native 70/70
- BTree benchmark suite: 10/10 completed with no material regression
- two independent read-only correctness reviews: pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented integer overflow when calculating cumulative B-tree spans.
  * Added validation for positive leaf spans and maximum supported totals.
  * Improved range deletion and tree mutation safety, preserving the original tree until changes are committed.
  * Strengthened balancing and repair operations near maximum span limits.

* **Documentation**
  * Documented cumulative span limits, overflow behavior, rollback guarantees, and construction requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->