### PR TITLE
refactor(web): compose Resume workbench state

### DIFF
--- a/examples/web/src/features/resume/browser/app.tsx
+++ b/examples/web/src/features/resume/browser/app.tsx
@@ -59,7 +59,7 @@ import {
 import {
   buildWorkbenchView,
 } from './workbench-view-model';
-import { useWorkbench, Workbench } from './workbench';
+import { useWorkbenchNavigation, Workbench } from './workbench';
 import './styles.css';
 
 
@@ -247,7 +247,7 @@ function PilotSourceChat({
   const {
     onToggleChatSource,
     selectChatSource,
-  } = useWorkbench();
+  } = useWorkbenchNavigation();
   const [contextScope, setContextScope] = useState<PkeChatContext['scope']>('none');
   const [showPayload, setShowPayload] = useState(false);
   const selectedSourceItems = useMemo(

--- a/examples/web/src/features/resume/browser/app.tsx
+++ b/examples/web/src/features/resume/browser/app.tsx
@@ -1,14 +1,9 @@
-import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport, type UIMessage } from 'ai';
 import {
   StrictMode,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type ChangeEvent,
-  type KeyboardEvent,
-  type MouseEvent,
 } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
@@ -38,7 +33,6 @@ import {
 import {
   activityTextForDisplay,
   isSensitiveText,
-  type ActivityItem,
   type NormalizedEntry,
   type ResumeDiagnostic,
   type ResumeProjection,
@@ -49,19 +43,23 @@ import {
   PKE_CHAT_MODEL,
   PKE_CHAT_REQUEST_MAX_BYTES,
   PKE_CHAT_SOURCE_LIMIT,
-  parsePkeChatStatus,
   pkeChatSourceFromActivity,
   pkeChatTextMessages,
   type PkeChatContext,
-  type PkeChatSource,
-  type PkeChatStatus,
 } from '../protocol/chat';
 import {
   type PilotSourceSelection,
   type ResumeState,
 } from './resume-state';
 import { useResumeSession } from './use-resume-session';
-import { useConversationSelectionScroll } from './use-conversation-selection-scroll';
+import {
+  type PkeChatTurnContext,
+  usePkeChat,
+} from './use-pke-chat';
+import {
+  buildWorkbenchView,
+} from './workbench-view-model';
+import { useWorkbench, Workbench } from './workbench';
 import './styles.css';
 
 
@@ -71,34 +69,14 @@ const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
   hour: '2-digit',
   minute: '2-digit',
 });
-const workbenchTimeFormat = new Intl.DateTimeFormat(undefined, {
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-});
 
 
 function formatTimestamp(value: string): string {
   return dateTimeFormat.format(new Date(value));
 }
 
-function formatWorkbenchTime(value: string): string {
-  return workbenchTimeFormat.format(new Date(value));
-}
 
 
-function activityKindLabel(item: ActivityItem): string {
-  switch (item.kind) {
-    case 'human': return 'human input';
-    case 'assistant-claim': return 'assistant claim';
-    case 'tool-evidence':
-      return item.evidenceStatus === 'observed-failure' ? 'tool failure' : 'tool evidence';
-    case 'checkpoint': return 'accepted anchor';
-    case 'compaction': return 'source summary';
-    case 'branch-summary': return 'branch context';
-    case 'omitted': return 'omitted';
-  }
-}
 
 function PilotSessionToolbar({
   state,
@@ -227,114 +205,12 @@ function PilotEmptyWorkspace({ state }: { readonly state: ResumeState }) {
   );
 }
 
-interface PilotTimelinePhase {
-  readonly id: string;
-  readonly index: number;
-  readonly items: readonly ActivityItem[];
-  readonly recordedKinds: readonly string[];
-}
-
-type PilotWorkbenchPane = 'timeline' | 'conversation' | 'evidence';
-type PilotEvidenceMode = 'readable' | 'normalized';
-type PilotInspectorMode = 'discuss' | 'evidence';
-
-function buildPilotTimelinePhases(
-  chronology: readonly ActivityItem[],
-): readonly PilotTimelinePhase[] {
-  const grouped: ActivityItem[][] = [];
-  let current: ActivityItem[] = [];
-  for (const item of chronology) {
-    if (item.kind === 'human' && current.length > 0) {
-      grouped.push(current);
-      current = [];
-    }
-    current.push(item);
-    if (item.kind === 'compaction') {
-      grouped.push(current);
-      current = [];
-    }
-  }
-  if (current.length > 0) grouped.push(current);
-  return grouped.map((items, index) => {
-    const first = items[0]!;
-    const last = items[items.length - 1]!;
-    const recordedKinds = [...new Set(items.map(activityKindLabel))];
-    return {
-      id: `${first.id}-${last.id}`,
-      index,
-      items: Object.freeze([...items]),
-      recordedKinds: Object.freeze(recordedKinds),
-    };
-  });
-}
-
-function normalizedEntryLabel(entry: NormalizedEntry | undefined): string {
-  if (entry === undefined) return 'withheld entry';
-  switch (entry.kind) {
-    case 'message':
-      if (entry.role === 'user') return 'user message';
-      if (entry.role === 'assistant') return 'assistant message';
-      return 'tool result';
-    case 'bashExecution': return 'bash execution';
-    case 'compaction': return 'conversation summary';
-    case 'branchSummary': return 'branch summary';
-    case 'checkpoint': return `${entry.anchorKind} checkpoint`;
-    case 'omitted': return `omitted ${entry.originalType}`;
-  }
-}
-
-type PilotChatRole = 'user' | 'assistant' | 'tool' | 'checkpoint' | 'system';
-
-function pilotChatRole(item: ActivityItem, entry: NormalizedEntry | undefined): PilotChatRole {
-  if (entry?.kind === 'message') {
-    if (entry.role === 'user') return 'user';
-    if (entry.role === 'assistant') return 'assistant';
-    return 'tool';
-  }
-  if (entry?.kind === 'bashExecution' || item.kind === 'tool-evidence') return 'tool';
-  if (entry?.kind === 'checkpoint' || item.kind === 'checkpoint') return 'checkpoint';
-  return 'system';
-}
-
-function conversationSpeaker(role: PilotChatRole): string {
-  switch (role) {
-    case 'user': return 'You';
-    case 'assistant': return 'Assistant';
-    case 'tool': return 'Tool';
-    case 'checkpoint': return 'Accepted checkpoint';
-    case 'system': return 'Session event';
-  }
-}
-
-function chatAuthorityLabel(item: ActivityItem, role: PilotChatRole): string {
-  switch (role) {
-    case 'user': return 'Recorded user message';
-    case 'assistant': return 'Unverified assistant text';
-    case 'tool': return item.evidenceStatus === 'observed-failure'
-      ? 'Observed failure'
-      : 'Observed result';
-    case 'checkpoint': return item.anchorKind === undefined
-      ? 'Accepted anchor'
-      : `Accepted ${item.anchorKind}`;
-    case 'system': return activityKindLabel(item);
-  }
-}
-
-interface PilotChatTurnContext {
-  readonly context: PkeChatContext;
-  readonly sources: readonly PkeChatSource[];
-}
-
-const NO_HISTORY_CHAT_CONTEXT: PilotChatTurnContext = Object.freeze({
-  context: Object.freeze({ scope: 'none' }),
-  sources: Object.freeze([]),
-});
 
 const PKE_CHAT_CITATION_HREF_PREFIX = '#canopy-source-';
 
 function sourceLinkedChatMarkdown(
   text: string,
-  turnContext: PilotChatTurnContext,
+  turnContext: PkeChatTurnContext,
 ): string {
   if (turnContext.context.scope === 'none') return text;
   const sourceEntryIds = new Set(turnContext.sources.map(source => source.source.entryId));
@@ -363,24 +239,17 @@ function PilotSourceChat({
   projection,
   selectedSource,
   sourceEntryIds,
-  onToggleSource,
-  onOpenSource,
 }: {
   readonly projection: ResumeProjection;
   readonly selectedSource: PilotSourceSelection;
   readonly sourceEntryIds: readonly string[];
-  readonly onToggleSource: (entryId: string) => void;
-  readonly onOpenSource: (entryId: string, leafId: string) => void;
 }) {
-  const [draft, setDraft] = useState('');
-  const [draftMessageId, setDraftMessageId] = useState(() => crypto.randomUUID());
+  const {
+    onToggleChatSource,
+    selectChatSource,
+  } = useWorkbench();
   const [contextScope, setContextScope] = useState<PkeChatContext['scope']>('none');
-  const [contextByMessageId, setContextByMessageId] = useState<
-    ReadonlyMap<string, PilotChatTurnContext>
-  >(() => new Map());
   const [showPayload, setShowPayload] = useState(false);
-  const [relayStatus, setRelayStatus] = useState<PkeChatStatus>();
-  const [relayStatusError, setRelayStatusError] = useState<string>();
   const selectedSourceItems = useMemo(
     () => sourceEntryIds.flatMap(entryId => {
       const item = projection.chronology.find(candidate => candidate.source.entryId === entryId);
@@ -416,106 +285,20 @@ function PilotSourceChat({
         }),
     [contextScope, projection.leafId, projection.sessionId],
   );
-  const outboundContextRef = useRef<PkeChatContext>(currentContext);
-  const outboundSourcesRef = useRef<readonly PkeChatSource[]>(sourcePayload);
-  const transport = useMemo(
-    () => new DefaultChatTransport<UIMessage>({
-      api: '/api/pi-resume-chat',
-      prepareSendMessagesRequest: ({ messages }) => ({
-        body: {
-          messages: pkeChatTextMessages(messages),
-          context: outboundContextRef.current,
-          sources: outboundSourcesRef.current,
-        },
-      }),
-    }),
-    [],
-  );
   const {
-    messages,
-    setMessages,
-    sendMessage,
-    status,
-    stop,
-    error,
     clearError,
-  } = useChat<UIMessage>({
-    id: `pke-chat:${projection.sessionId}`,
-    transport,
-  });
-  const restoreUnansweredUserMessage = (): void => {
-    const trailingMessage = messages[messages.length - 1];
-    if (trailingMessage?.role !== 'user') return;
-    const text = trailingMessage.parts
-      .filter(part => part.type === 'text')
-      .map(part => part.text)
-      .join('');
-    setMessages(messages.slice(0, -1));
-    setContextByMessageId(current => {
-      if (!current.has(trailingMessage.id)) return current;
-      const next = new Map(current);
-      next.delete(trailingMessage.id);
-      return next;
-    });
-    setDraft(current => current.trim().length === 0 ? text : current);
-  };
-  const stopRef = useRef(stop);
-  stopRef.current = stop;
-  useEffect(() => () => {
-    void stopRef.current();
-  }, []);
-  useEffect(() => {
-    if (error === undefined) return;
-    const trailingMessage = messages[messages.length - 1];
-    if (trailingMessage?.role !== 'user') return;
-    const text = trailingMessage.parts
-      .filter(part => part.type === 'text')
-      .map(part => part.text)
-      .join('');
-    setMessages(messages.slice(0, -1));
-    setContextByMessageId(current => {
-      if (!current.has(trailingMessage.id)) return current;
-      const next = new Map(current);
-      next.delete(trailingMessage.id);
-      return next;
-    });
-    setDraft(current => current.trim().length === 0 ? text : current);
-  }, [error, messages, setMessages]);
-  useEffect(() => {
-    const controller = new AbortController();
-    void fetch('/api/pi-resume-chat/status', { signal: controller.signal })
-      .then(async response => {
-        if (!response.ok) throw new Error('Chat relay status is unavailable.');
-        const value = parsePkeChatStatus(await response.json());
-        setRelayStatus(value);
-        setRelayStatusError(undefined);
-      })
-      .catch(cause => {
-        if (cause instanceof DOMException && cause.name === 'AbortError') return;
-        setRelayStatusError(cause instanceof Error ? cause.message : String(cause));
-      });
-    return () => controller.abort();
-  }, []);
-
-  const renderedMessages = useMemo(() => {
-    let turnContext = NO_HISTORY_CHAT_CONTEXT;
-    return messages.map(message => {
-      if (message.role === 'user') {
-        turnContext = contextByMessageId.get(message.id) ?? NO_HISTORY_CHAT_CONTEXT;
-      }
-      return Object.freeze({ message, turnContext });
-    });
-  }, [contextByMessageId, messages]);
-  const pendingMessage = useMemo<UIMessage | undefined>(() => {
-    const text = draft.trim();
-    return text.length === 0
-      ? undefined
-      : {
-          id: draftMessageId,
-          role: 'user',
-          parts: [{ type: 'text', text }],
-        };
-  }, [draft, draftMessageId]);
+    draft,
+    error,
+    messages,
+    pendingMessage,
+    relayStatus,
+    relayStatusError,
+    renderedMessages,
+    setDraft,
+    status,
+    stopAndRestoreDraft,
+    submit,
+  } = usePkeChat(projection.sessionId);
   const outboundPreview = pendingMessage === undefined
     ? undefined
     : {
@@ -579,7 +362,7 @@ function PilotSourceChat({
         aria-pressed={selectedSourceIncluded}
         disabled={!selectedSourceIncluded && sourceLimitReached}
         onClick={() => {
-          onToggleSource(selectedSource.entryId);
+          onToggleChatSource(selectedSource.entryId);
           if (!selectedSourceIncluded) setContextScope('selected');
         }}
       >
@@ -599,14 +382,14 @@ function PilotSourceChat({
             {sourceItems.slice(0, 12).map(item => (
               <article key={item.source.entryId}>
                 <div className="pilot-chat-context-heading">
-                  <Source onClick={() => onOpenSource(item.source.entryId, projection.leafId)}>
+                  <Source onClick={() => selectChatSource(item.source.entryId, projection.leafId)}>
                     source {item.source.entryId} · {item.title}
                   </Source>
                   {contextScope !== 'selected' ? null : (
                     <button
                       type="button"
                       aria-label={`Remove ${item.title} from chat context`}
-                      onClick={() => onToggleSource(item.source.entryId)}
+                      onClick={() => onToggleChatSource(item.source.entryId)}
                     >
                       Remove
                     </button>
@@ -693,7 +476,7 @@ function PilotSourceChat({
                               <Source
                                 aria-label={`Open cited source ${entryId}`}
                                 className="ai-inline-citation"
-                                onClick={() => onOpenSource(entryId, citationLeafId)}
+                                onClick={() => selectChatSource(entryId, citationLeafId)}
                               >
                                 {children}
                               </Source>
@@ -729,7 +512,7 @@ function PilotSourceChat({
                         <Source
                           aria-label={`Open chat source ${source.source.entryId}`}
                           key={source.source.entryId}
-                          onClick={() => onOpenSource(
+                          onClick={() => selectChatSource(
                             source.source.entryId,
                             turnContext.context.scope === 'none'
                               ? projection.leafId
@@ -780,26 +563,12 @@ function PilotSourceChat({
         onSubmit={event => {
           event.preventDefault();
           if (running) {
-            void stop();
-            restoreUnansweredUserMessage();
+            stopAndRestoreDraft();
             return;
           }
-          if (!canSend || pendingMessage === undefined) return;
-          const turnContext: PilotChatTurnContext = Object.freeze({
-            context: currentContext,
-            sources: sourcePayload,
-          });
-          outboundContextRef.current = currentContext;
-          outboundSourcesRef.current = sourcePayload;
-          setContextByMessageId(current => {
-            const next = new Map(current);
-            next.set(pendingMessage.id, turnContext);
-            return next;
-          });
-          setDraft('');
-          setDraftMessageId(crypto.randomUUID());
+          if (!canSend) return;
           setShowPayload(false);
-          void sendMessage(pendingMessage);
+          submit(currentContext, sourcePayload);
         }}
       >
         <PromptInputBody>
@@ -853,448 +622,35 @@ function PilotUnderstandingWorkbench({
   readonly onSelectChatSource: (entryId: string, leafId: string) => void;
   readonly onToggleChatSource: (entryId: string) => void;
 }) {
-  const phases = useMemo(
-    () => buildPilotTimelinePhases(projection.chronology),
-    [projection.chronology],
+  const viewModel = useMemo(
+    () => buildWorkbenchView(projection, entries, selectedSource.entryId),
+    [entries, projection, selectedSource.entryId],
   );
-  const entriesById = useMemo(
-    () => new Map(entries.map(entry => [entry.id, entry])),
-    [entries],
-  );
-  const operationIndex = useMemo(() => {
-    const calls = new Map<string, { readonly entryId: string; readonly name: string }>();
-    const results = new Map<string, { readonly entryId: string; readonly name: string }>();
-    for (const entry of entries) {
-      if (entry.kind === 'message' && entry.role === 'assistant') {
-        for (const call of entry.toolCalls) {
-          calls.set(call.id, { entryId: entry.id, name: call.name });
-        }
-      }
-      if (
-        entry.kind === 'message' &&
-        entry.role === 'toolResult' &&
-        entry.toolCallId !== undefined
-      ) {
-        results.set(entry.toolCallId, {
-          entryId: entry.id,
-          name: entry.toolName ?? 'tool',
-        });
-      }
-    }
-    return { calls, results };
-  }, [entries]);
-  const selectedPhaseId = phases.find(phase =>
-    phase.items.some(item => item.source.entryId === selectedSource.entryId),
-  )?.id;
-  const [expandedPhaseIds, setExpandedPhaseIds] = useState<ReadonlySet<string>>(
-    () => new Set(selectedPhaseId === undefined ? [] : [selectedPhaseId]),
-  );
-  useEffect(() => {
-    if (selectedPhaseId === undefined) return;
-    setExpandedPhaseIds(current =>
-      current.has(selectedPhaseId) ? current : new Set([...current, selectedPhaseId]),
-    );
-  }, [selectedPhaseId]);
-  const [activePane, setActivePane] = useState<PilotWorkbenchPane>('conversation');
-  const {
-    conversationPanelRef,
-    revealConversationSelection,
-    selectedConversationRef,
-  } = useConversationSelectionScroll(activePane === 'conversation', selectedSource.entryId);
-  const [inspectorMode, setInspectorMode] = useState<PilotInspectorMode>('discuss');
-  const [evidenceMode, setEvidenceMode] = useState<PilotEvidenceMode>('readable');
-  const selectedItemIndex = Math.max(
-    0,
-    projection.chronology.findIndex(item => item.source.entryId === selectedSource.entryId),
-  );
-  const selectedItem = projection.chronology[selectedItemIndex];
-  const selectedRecord = selectedItem === undefined
-    ? undefined
-    : entriesById.get(selectedItem.source.entryId);
-  const selectedPhase = phases.find(phase => phase.id === selectedPhaseId);
-  const conversationItems = projection.chronology;
-  const normalizedRecord = selectedRecord === undefined
-    ? 'This entry was withheld by the bounded import policy.'
-    : JSON.stringify(selectedRecord, null, 2);
-  let operationRelationship: string | undefined;
-  if (selectedRecord?.kind === 'message' && selectedRecord.role === 'assistant') {
-    const linkedResults = selectedRecord.toolCalls
-      .map(call => operationIndex.results.get(call.id))
-      .filter((result): result is { readonly entryId: string; readonly name: string } =>
-        result !== undefined,
-      );
-    if (selectedRecord.toolCalls.length > 0) {
-      operationRelationship = `${selectedRecord.toolCalls.map(call => call.name).join(', ')} requested · ${linkedResults.length} matching result${linkedResults.length === 1 ? '' : 's'} recorded`;
-    }
-  } else if (
-    selectedRecord?.kind === 'message' &&
-    selectedRecord.role === 'toolResult' &&
-    selectedRecord.toolCallId !== undefined
-  ) {
-    const request = operationIndex.calls.get(selectedRecord.toolCallId);
-    operationRelationship = request === undefined
-      ? 'Tool result recorded; its request is outside the selected path.'
-      : `Result for ${request.name} requested by source entry ${request.entryId}`;
-  }
-
-
-  const selectFromTimeline = (entryId: string): void => {
-    revealConversationSelection();
-    onSelectEntry(entryId);
-    setActivePane('conversation');
-  };
-
-  const selectConversationAt = (index: number, focus: boolean): void => {
-    const item = conversationItems[index];
-    if (item === undefined) return;
-    onSelectEntry(item.source.entryId);
-    if (!focus) return;
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        const options = conversationPanelRef.current
-          ?.querySelectorAll<HTMLElement>('[data-entry-id]');
-        [...(options ?? [])]
-          .find(option => option.dataset.entryId === item.source.entryId)
-          ?.focus({ preventScroll: true });
-      });
-    });
-  };
-
-  const handleConversationKeyDown = (
-    event: KeyboardEvent<HTMLLIElement>,
-    index: number,
-  ): void => {
-    let nextIndex: number | undefined;
-    switch (event.key) {
-      case 'Enter':
-      case ' ':
-        nextIndex = index;
-        break;
-      case 'ArrowDown':
-        nextIndex = Math.min(conversationItems.length - 1, index + 1);
-        break;
-      case 'ArrowUp':
-        nextIndex = Math.max(0, index - 1);
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = conversationItems.length - 1;
-        break;
-      default:
-        return;
-    }
-    event.preventDefault();
-    selectConversationAt(nextIndex, true);
-  };
 
   return (
-    <section className="pilot-workbench" aria-labelledby="pilot-workbench-title">
+    <Workbench.Root
+      viewModel={viewModel}
+      selectedEntryId={selectedSource.entryId}
+      terminalPathId={projection.leafId}
+      onSelectEntry={onSelectEntry}
+      onSelectChatSource={onSelectChatSource}
+      onToggleChatSource={onToggleChatSource}
+    >
       <h2 className="visually-hidden" id="pilot-workbench-title">Session understanding</h2>
-      <nav className="pilot-workbench-tabs" aria-label="Session understanding views">
-        {(['timeline', 'conversation', 'evidence'] as const).map(pane => (
-          <button
-            type="button"
-            data-pane={pane}
-            aria-pressed={activePane === pane}
-            key={pane}
-            onClick={() => setActivePane(pane)}
-          >
-            {pane === 'timeline' ? 'Timeline' : pane === 'conversation' ? 'Conversation' : 'Evidence'}
-          </button>
-        ))}
-      </nav>
-      <div className="pilot-workbench-grid" data-active-pane={activePane}>
-        <section
-          className="pilot-workbench-panel pilot-timeline"
-          data-pane="timeline"
-          aria-labelledby="pilot-timeline-title"
-        >
-          <header className="pilot-panel-heading">
-            <div>
-              <h3 id="pilot-timeline-title">Timeline</h3>
-            </div>
-            <p>{phases.length} phases · {projection.chronology.length} recorded events</p>
-          </header>
-          <ol className="pilot-phase-list">
-            {phases.map(phase => {
-              const containsSelection = phase === selectedPhase;
-              const expanded = expandedPhaseIds.has(phase.id);
-              const first = phase.items[0]!;
-              const last = phase.items[phase.items.length - 1]!;
-              return (
-                <li className="pilot-phase" data-selected={containsSelection} key={phase.id}>
-                  <button
-                    className="pilot-phase-toggle"
-                    type="button"
-                    aria-expanded={expanded}
-                    onClick={() => {
-                      setExpandedPhaseIds(current => {
-                        const next = new Set(current);
-                        if (next.has(phase.id)) next.delete(phase.id);
-                        else next.add(phase.id);
-                        return next;
-                      });
-                    }}
-                  >
-                    <span>Phase {String(phase.index + 1).padStart(2, '0')}</span>
-                    <time dateTime={first.timestamp}>
-                      {formatWorkbenchTime(first.timestamp)}–{formatWorkbenchTime(last.timestamp)}
-                    </time>
-                    <strong>{phase.recordedKinds.join(' · ')}</strong>
-                    <i aria-hidden="true">{expanded ? '−' : '+'}</i>
-                  </button>
-                  {expanded ? (
-                    <ol className="pilot-event-list">
-                      {phase.items.map(item => {
-                        const selected = item.source.entryId === selectedSource.entryId;
-                        return (
-                          <li
-                            id={`source-${item.source.entryId}`}
-                            data-selected={selected}
-                            aria-current={selected ? 'true' : undefined}
-                            key={item.id}
-                          >
-                            <button type="button" onClick={() => selectFromTimeline(item.source.entryId)}>
-                              <span>{activityKindLabel(item)}</span>
-                              <time dateTime={item.timestamp}>{formatWorkbenchTime(item.timestamp)}</time>
-                              <strong>{item.title}</strong>
-                              <small>{activityTextForDisplay(item)}</small>
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ol>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ol>
-        </section>
-
-        <section
-          className="pilot-workbench-panel pilot-conversation"
-          data-pane="conversation"
-          aria-labelledby="pilot-conversation-title"
-          ref={conversationPanelRef}
-        >
-          <header className="pilot-panel-heading">
-            <div>
-              <h3 id="pilot-conversation-title">Conversation</h3>
-            </div>
-            <p>
-              Full selected path · {projection.chronology.length} events · selected {selectedItemIndex + 1}
-            </p>
-          </header>
-          <ol
-            className="pilot-conversation-list"
-            role="listbox"
-            aria-label="Recorded conversation"
-          >
-            {conversationItems.map((item, index) => {
-              const selected = item.source.entryId === selectedSource.entryId;
-              const record = entriesById.get(item.source.entryId);
-              const role = pilotChatRole(item, record);
-              const assistantRecord = record?.kind === 'message' && record.role === 'assistant'
-                ? record
-                : undefined;
-              const toolResultRecord = record?.kind === 'message' && record.role === 'toolResult'
-                ? record
-                : undefined;
-              const linkedRequest = toolResultRecord?.toolCallId === undefined
-                ? undefined
-                : operationIndex.calls.get(toolResultRecord.toolCallId);
-              return (
-                <li
-                  data-role={role}
-                  data-entry-id={item.source.entryId}
-                  data-anchor={item.anchorKind}
-                  data-selected={selected}
-                  data-status={item.evidenceStatus}
-                  role="option"
-                  aria-label={`${conversationSpeaker(role)}: ${item.title}, ${formatWorkbenchTime(item.timestamp)}`}
-                  aria-current={selected ? 'true' : undefined}
-                  aria-selected={selected}
-                  aria-keyshortcuts="ArrowUp ArrowDown Home End Enter Space"
-                  tabIndex={selected ? 0 : -1}
-                  key={item.id}
-                  ref={selected ? selectedConversationRef : undefined}
-                  onClick={event => {
-                    const selection = window.getSelection();
-                    const selectedTextIsInside = selection?.isCollapsed === false &&
-                      ((selection.anchorNode !== null && event.currentTarget.contains(selection.anchorNode)) ||
-                        (selection.focusNode !== null && event.currentTarget.contains(selection.focusNode)));
-                    if (selectedTextIsInside) return;
-                    event.currentTarget.focus({ preventScroll: true });
-                    selectConversationAt(index, false);
-                  }}
-                  onKeyDown={event => handleConversationKeyDown(event, index)}
-                >
-                  <article className="pilot-chat-turn">
-                    <header className="pilot-chat-meta">
-                      <div>
-                        <span className="pilot-chat-author">
-                          {conversationSpeaker(role)}
-                        </span>
-                        <span>{chatAuthorityLabel(item, role)}</span>
-                        {selected ? <strong>Selected source</strong> : null}
-                      </div>
-                      <time dateTime={item.timestamp}>{formatWorkbenchTime(item.timestamp)}</time>
-                    </header>
-                    <div className="pilot-chat-bubble">
-                      {role === 'checkpoint' || role === 'system' || role === 'tool' ? (
-                        <strong className="pilot-chat-event-title">{item.title}</strong>
-                      ) : null}
-                      <p>{activityTextForDisplay(item)}</p>
-                      {assistantRecord === undefined || assistantRecord.toolCalls.length === 0 ? null : (
-                        <div className="pilot-chat-tool-calls" aria-label="Tool calls in this assistant message">
-                          {assistantRecord.toolCalls.map(call => {
-                            const result = operationIndex.results.get(call.id);
-                            return (
-                              <div className="pilot-chat-tool-call" key={call.id}>
-                                <div>
-                                  <span>Tool call</span>
-                                  <strong>{call.name}</strong>
-                                  <em>{result === undefined ? 'No result on path' : 'Result recorded'}</em>
-                                </div>
-                                <dl>
-                                  <div><dt>Call</dt><dd>{call.id}</dd></div>
-                                  {call.path === undefined ? null : <div><dt>Path</dt><dd>{call.path}</dd></div>}
-                                  {call.editCount === undefined ? null : <div><dt>Edits</dt><dd>{call.editCount}</dd></div>}
-                                  {call.bashClassification === undefined ? null : (
-                                    <div><dt>Kind</dt><dd>{call.bashClassification}</dd></div>
-                                  )}
-                                  {result === undefined ? null : <div><dt>Result source</dt><dd>{result.entryId}</dd></div>}
-                                </dl>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      )}
-                      {linkedRequest === undefined ? null : (
-                        <p className="pilot-chat-operation-link">
-                          Result for <strong>{linkedRequest.name}</strong> requested in source {linkedRequest.entryId}
-                        </p>
-                      )}
-                      {record?.kind === 'bashExecution' ? (
-                        <dl className="pilot-chat-command-meta">
-                          <div><dt>Command kind</dt><dd>{record.classification}</dd></div>
-                          <div><dt>Exit</dt><dd>{record.exitCode ?? 'unknown'}</dd></div>
-                          <div><dt>Cancelled</dt><dd>{record.cancelled ? 'yes' : 'no'}</dd></div>
-                        </dl>
-                      ) : null}
-                      <footer>
-                        <span>{normalizedEntryLabel(record)}</span>
-                        <span>source {item.source.entryId}</span>
-                      </footer>
-                    </div>
-                  </article>
-                </li>
-              );
-            })}
-          </ol>
-        </section>
-
-        <section
-          className="pilot-workbench-panel pilot-evidence"
-          data-pane="evidence"
-          id="pilot-inspector"
-          aria-labelledby="pilot-inspector-title"
-        >
-          <header className="pilot-panel-heading">
-            <div>
-              <h3 id="pilot-inspector-title" tabIndex={-1}>Evidence</h3>
-            </div>
-            <p>Selected {selectedItemIndex + 1} of {projection.chronology.length}</p>
-          </header>
-          <div className="pilot-inspector-tabs" role="tablist" aria-label="Evidence panel mode">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={inspectorMode === 'discuss'}
-              onClick={() => setInspectorMode('discuss')}
-            >
-              Discuss
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={inspectorMode === 'evidence'}
-              onClick={() => setInspectorMode('evidence')}
-            >
-              Evidence
-            </button>
-          </div>
-          <div hidden={inspectorMode !== 'discuss'} role="tabpanel">
-            <PilotSourceChat
-              key={chatInstanceId}
-              projection={projection}
-              selectedSource={selectedSource}
-              sourceEntryIds={chatSourceEntryIds}
-              onToggleSource={onToggleChatSource}
-              onOpenSource={(entryId, leafId) => {
-                onSelectChatSource(entryId, leafId);
-                setActivePane('evidence');
-              }}
-            />
-          </div>
-          {inspectorMode !== 'evidence' ? null : (
-            <>
-              <div className="pilot-evidence-tabs" role="tablist" aria-label="Evidence representation">
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={evidenceMode === 'readable'}
-                  onClick={() => setEvidenceMode('readable')}
-                >
-                  Readable
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={evidenceMode === 'normalized'}
-                  onClick={() => setEvidenceMode('normalized')}
-                >
-                  Normalized record
-                </button>
-              </div>
-              {evidenceMode === 'readable' ? (
-                <div className="pilot-evidence-readable" role="tabpanel">
-                  <section className="pilot-evidence-copy" aria-labelledby="pilot-evidence-copy-title">
-                    <span className="kicker">Selected recorded entry</span>
-                    <h4 id="pilot-evidence-copy-title">{selectedItem?.title ?? 'Unavailable entry'}</h4>
-                    <p>{selectedItem === undefined
-                      ? 'No recorded entry is selected.'
-                      : activityTextForDisplay(selectedItem)}</p>
-                  </section>
-                  <dl className="pilot-evidence-metadata">
-                    <div><dt>Recorded type</dt><dd>{normalizedEntryLabel(selectedRecord)}</dd></div>
-                    <div><dt>Time</dt><dd>{selectedItem === undefined ? 'Unknown' : formatWorkbenchTime(selectedItem.timestamp)}</dd></div>
-                    <div><dt>Path position</dt><dd>{selectedItemIndex + 1} of {projection.chronology.length}</dd></div>
-                    <div><dt>Terminal path</dt><dd>{projection.leafId}</dd></div>
-                    <div><dt>Source entry</dt><dd>{selectedSource.entryId}</dd></div>
-                  </dl>
-                  {operationRelationship === undefined ? null : (
-                    <div className="pilot-operation-relation">
-                      <strong>Recorded operation relationship</strong>
-                      <p>{operationRelationship}</p>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className="pilot-evidence-normalized" role="tabpanel">
-                  <p>
-                    This is the bounded normalized import used by this view, not the unfiltered JSONL line.
-                  </p>
-                  <pre>{normalizedRecord}</pre>
-                </div>
-              )}
-            </>
-          )}
-        </section>
-      </div>
-    </section>
+      <Workbench.Tabs />
+      <Workbench.Grid>
+        <Workbench.Timeline />
+        <Workbench.Conversation />
+        <Workbench.Evidence>
+          <PilotSourceChat
+            key={chatInstanceId}
+            projection={projection}
+            selectedSource={selectedSource}
+            sourceEntryIds={chatSourceEntryIds}
+          />
+        </Workbench.Evidence>
+      </Workbench.Grid>
+    </Workbench.Root>
   );
 }
 

--- a/examples/web/src/features/resume/browser/app.tsx
+++ b/examples/web/src/features/resume/browser/app.tsx
@@ -4,7 +4,6 @@ import {
   StrictMode,
   useEffect,
   useMemo,
-  useReducer,
   useRef,
   useState,
   type ChangeEvent,
@@ -12,7 +11,6 @@ import {
   type MouseEvent,
 } from 'react';
 import { createRoot } from 'react-dom/client';
-import fixtureSource from '../../../../tests/fixtures/pi-session-v3.jsonl?raw';
 import {
   Conversation,
   ConversationContent,
@@ -38,16 +36,10 @@ import {
   SourcesTrigger,
 } from './components/sources';
 import {
-  DEFAULT_LIMITS,
   activityTextForDisplay,
   isSensitiveText,
-  parsePiSessionJsonl,
-  projectResume,
-  reducePiSession,
-  PiSessionFormatError,
   type ActivityItem,
   type NormalizedEntry,
-  type ReducedPiSession,
   type ResumeDiagnostic,
   type ResumeProjection,
 } from '../core/session';
@@ -64,9 +56,14 @@ import {
   type PkeChatSource,
   type PkeChatStatus,
 } from '../protocol/chat';
+import {
+  type PilotSourceSelection,
+  type ResumeState,
+} from './resume-state';
+import { useResumeSession } from './use-resume-session';
+import { useConversationSelectionScroll } from './use-conversation-selection-scroll';
 import './styles.css';
 
-const demoSession = reducePiSession(parsePiSessionJsonl(fixtureSource));
 
 const dateTimeFormat = new Intl.DateTimeFormat(undefined, {
   month: 'short',
@@ -80,141 +77,6 @@ const workbenchTimeFormat = new Intl.DateTimeFormat(undefined, {
   second: '2-digit',
 });
 
-type SourceMode = 'demo' | 'imported';
-type StatusTone = 'idle' | 'success' | 'error';
-
-interface ImportStatus {
-  readonly message: string;
-  readonly tone: StatusTone;
-}
-
-export interface ResumeState {
-  readonly session: ReducedPiSession;
-  readonly sourceMode: SourceMode;
-  readonly importedFileName?: string;
-  readonly selectedLeafId: string | null;
-  readonly isImporting: boolean;
-  readonly importStatus: ImportStatus;
-  readonly diagnosticOverride?: readonly ResumeDiagnostic[];
-  readonly fileInputGeneration: number;
-}
-
-export type ResumeEvent =
-  | { readonly type: 'import-reading'; readonly fileName: string }
-  | {
-      readonly type: 'import-succeeded';
-      readonly session: ReducedPiSession;
-      readonly fileName: string;
-      readonly status: ImportStatus;
-    }
-  | { readonly type: 'import-failed'; readonly diagnostic: ResumeDiagnostic; readonly status: ImportStatus }
-  | { readonly type: 'select-leaf'; readonly leafId: string | null }
-  | { readonly type: 'forget' };
-
-export const initialResumeState: ResumeState = {
-  session: demoSession,
-  sourceMode: 'demo',
-  selectedLeafId: null,
-  isImporting: false,
-  importStatus: { message: '', tone: 'idle' },
-  fileInputGeneration: 0,
-};
-
-export function reduceResumeState(state: ResumeState, event: ResumeEvent): ResumeState {
-  switch (event.type) {
-    case 'import-reading':
-      return {
-        ...state,
-        selectedLeafId: null,
-        isImporting: true,
-        importStatus: { message: `Reading ${event.fileName} in this tab…`, tone: 'idle' },
-        fileInputGeneration: state.fileInputGeneration + 1,
-      };
-    case 'import-succeeded': {
-      return {
-        session: event.session,
-        sourceMode: 'imported',
-        importedFileName: event.fileName,
-        selectedLeafId: null,
-        isImporting: false,
-        importStatus: event.status,
-        fileInputGeneration: state.fileInputGeneration,
-      };
-    }
-    case 'import-failed':
-      return {
-        ...initialResumeState,
-        importStatus: event.status,
-        diagnosticOverride: [event.diagnostic],
-        fileInputGeneration: state.fileInputGeneration + 1,
-      };
-    case 'select-leaf':
-      return {
-        ...state,
-        selectedLeafId: event.leafId,
-        diagnosticOverride: undefined,
-      };
-    case 'forget':
-      return {
-        ...initialResumeState,
-        importStatus: {
-          message: 'Imported session forgotten. The demo transcript is active again.',
-          tone: 'idle',
-        },
-        fileInputGeneration: state.fileInputGeneration + 1,
-      };
-  }
-}
-
-interface PilotSourceSelection {
-  readonly entryId: string;
-}
-
-interface PilotViewState {
-  readonly selectedSource?: PilotSourceSelection;
-  readonly chatSourceEntryIds: readonly string[];
-}
-
-type PilotViewEvent =
-  | {
-      readonly type: 'open-source';
-      readonly entryId: string;
-    }
-  | { readonly type: 'toggle-chat-source'; readonly entryId: string }
-  | { readonly type: 'reset' };
-
-const initialPilotViewState: PilotViewState = {
-  chatSourceEntryIds: Object.freeze([]),
-};
-
-function reducePilotViewState(
-  state: PilotViewState,
-  event: PilotViewEvent,
-): PilotViewState {
-  switch (event.type) {
-    case 'open-source':
-      return {
-        ...state,
-        selectedSource: {
-          entryId: event.entryId,
-        },
-      };
-    case 'toggle-chat-source': {
-      const includesSource = state.chatSourceEntryIds.includes(event.entryId);
-      if (!includesSource && state.chatSourceEntryIds.length >= PKE_CHAT_SOURCE_LIMIT) return state;
-      return {
-        ...state,
-        chatSourceEntryIds: Object.freeze(
-          includesSource
-            ? state.chatSourceEntryIds.filter(entryId => entryId !== event.entryId)
-            : [...state.chatSourceEntryIds, event.entryId],
-        ),
-      };
-    }
-    case 'reset':
-      return initialPilotViewState;
-  }
-}
 
 function formatTimestamp(value: string): string {
   return dateTimeFormat.format(new Date(value));
@@ -224,49 +86,6 @@ function formatWorkbenchTime(value: string): string {
   return workbenchTimeFormat.format(new Date(value));
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} bytes`;
-  const units = ['KiB', 'MiB', 'GiB'];
-  let value = bytes;
-  let unitIndex = -1;
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-  return `${value.toFixed(1)} ${units[unitIndex]}`;
-}
-
-function formatImportError(error: unknown, file: File): ResumeDiagnostic {
-  if (error instanceof PiSessionFormatError) {
-    const message = (() => {
-      switch (error.code) {
-        case 'file_too_large':
-          return `This session is ${formatBytes(file.size)} (${file.size.toLocaleString()} bytes), above the ${formatBytes(DEFAULT_LIMITS.maxFileBytes)} limit (${DEFAULT_LIMITS.maxFileBytes.toLocaleString()} bytes). Choose a shorter or newer pi session and try again. Nothing was uploaded or saved.`;
-        case 'line_too_large':
-          return 'One entry in this session is too large to import safely. Choose a shorter session or a session with less captured tool output. Nothing was uploaded or saved.';
-        case 'too_many_entries':
-          return `This session has more than ${DEFAULT_LIMITS.maxEntries.toLocaleString()} entries. Choose a shorter session and try again. Nothing was uploaded or saved.`;
-        case 'unsupported_version':
-          return 'This is not a supported pi session v3 file. Choose a v3 .jsonl session snapshot.';
-        case 'invalid_json':
-          return 'This file is not valid JSONL. Choose a pi session .jsonl snapshot rather than a folder or export in another format.';
-        case 'invalid_entry_identity':
-        case 'missing_parent':
-        case 'missing_reference':
-        case 'cycle':
-          return 'This session appears incomplete or malformed. Choose another .jsonl snapshot; the file was not modified.';
-        default:
-          return error.message;
-      }
-    })();
-    return { severity: 'error', code: error.code, message };
-  }
-  return {
-    severity: 'error',
-    code: 'import_failed',
-    message: error instanceof Error ? error.message : String(error),
-  };
-}
 
 function activityKindLabel(item: ActivityItem): string {
   switch (item.kind) {
@@ -1077,14 +896,11 @@ function PilotUnderstandingWorkbench({
     );
   }, [selectedPhaseId]);
   const [activePane, setActivePane] = useState<PilotWorkbenchPane>('conversation');
-  const previousSelectedSourceRef = useRef(selectedSource.entryId);
-  useEffect(() => {
-    const sourceChanged = previousSelectedSourceRef.current !== selectedSource.entryId;
-    previousSelectedSourceRef.current = selectedSource.entryId;
-  }, [selectedSource.entryId]);
-  const conversationPanelRef = useRef<HTMLElement | null>(null);
-  const selectedConversationRef = useRef<HTMLLIElement | null>(null);
-  const revealConversationSelectionRef = useRef(false);
+  const {
+    conversationPanelRef,
+    revealConversationSelection,
+    selectedConversationRef,
+  } = useConversationSelectionScroll(activePane === 'conversation', selectedSource.entryId);
   const [inspectorMode, setInspectorMode] = useState<PilotInspectorMode>('discuss');
   const [evidenceMode, setEvidenceMode] = useState<PilotEvidenceMode>('readable');
   const selectedItemIndex = Math.max(
@@ -1121,35 +937,9 @@ function PilotUnderstandingWorkbench({
       : `Result for ${request.name} requested by source entry ${request.entryId}`;
   }
 
-  useEffect(() => {
-    if (activePane !== 'conversation') return;
-    const frame = window.requestAnimationFrame(() => {
-      const panel = conversationPanelRef.current;
-      const target = selectedConversationRef.current;
-      if (panel === null || target === null) return;
-      const usesInternalScroll = window.getComputedStyle(panel).overflowY !== 'visible';
-      if (usesInternalScroll) {
-        const panelBox = panel.getBoundingClientRect();
-        const targetBox = target.getBoundingClientRect();
-        const headingHeight = panel.querySelector<HTMLElement>('.pilot-panel-heading')
-          ?.getBoundingClientRect().height ?? 0;
-        panel.scrollTo({
-          top: Math.max(
-            0,
-            panel.scrollTop + targetBox.top - panelBox.top - headingHeight - 4,
-          ),
-          behavior: 'auto',
-        });
-      } else if (revealConversationSelectionRef.current) {
-        target.scrollIntoView({ block: 'center', behavior: 'auto' });
-      }
-      revealConversationSelectionRef.current = false;
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [activePane, selectedSource.entryId]);
 
   const selectFromTimeline = (entryId: string): void => {
-    revealConversationSelectionRef.current = true;
+    revealConversationSelection();
     onSelectEntry(entryId);
     setActivePane('conversation');
   };
@@ -1558,63 +1348,26 @@ function Diagnostics({ items }: { readonly items: readonly ResumeDiagnostic[] })
 }
 
 export function ResumeApp() {
-  const [state, dispatch] = useReducer(reduceResumeState, initialResumeState);
-  const [pilotState, dispatchPilot] = useReducer(reducePilotViewState, initialPilotViewState);
-  const effectiveLeafId = state.selectedLeafId ?? (
-    state.sourceMode === 'demo' ? state.session.terminalPaths[0]?.leafId ?? null : null
-  );
-  const projection = useMemo(
-    () => effectiveLeafId === null ? undefined : projectResume(state.session, effectiveLeafId),
-    [effectiveLeafId, state.session],
-  );
-  const defaultItem = projection?.chronology[0];
-  const effectivePilotSource: PilotSourceSelection | undefined = pilotState.selectedSource ??
-    (defaultItem === undefined ? undefined : { entryId: defaultItem.source.entryId });
-  const diagnostics = state.diagnosticOverride ?? projection?.diagnostics ?? state.session.diagnostics;
-  const importSessionFile = async (file: File): Promise<void> => {
-    dispatchPilot({ type: 'reset' });
-    dispatch({ type: 'import-reading', fileName: file.name });
-    try {
-      if (file.size > DEFAULT_LIMITS.maxFileBytes) {
-        throw new PiSessionFormatError('file_too_large', 'The selected file exceeds the file limit.');
-      }
-      const session = reducePiSession(parsePiSessionJsonl(await file.text()));
-      const count = session.diagnostics.length;
-      dispatch({
-        type: 'import-succeeded', session, fileName: file.name,
-        status: { tone: 'success', message: count === 0
-          ? `Imported ${file.name}. Select a terminal path to inspect it.`
-          : `Imported ${file.name} with ${count} import note${count === 1 ? '' : 's'}.` },
-      });
-    } catch (error) {
-      const diagnostic = formatImportError(error, file);
-      dispatch({ type: 'import-failed', diagnostic,
-        status: { tone: 'error', message: `Could not import ${file.name}. ${diagnostic.message} The demo transcript remains active.` } });
-    }
-  };
-  const revealSource = (entryId: string): void => {
-    if (projection?.chronology.some(item => item.source.entryId === entryId) !== true) return;
-    dispatchPilot({ type: 'open-source', entryId });
-    window.history.replaceState(null, '', `#source-${entryId}`);
-  };
-  const revealChatSource = (entryId: string, leafId: string): void => {
-    if (projection?.leafId === leafId) { revealSource(entryId); return; }
-    if (!state.session.entries.some(entry => entry.id === leafId) ||
-        !state.session.entries.some(entry => entry.id === entryId)) return;
-    dispatchPilot({ type: 'open-source', entryId });
-    dispatch({ type: 'select-leaf', leafId });
-    window.history.replaceState(null, '', `#source-${entryId}`);
-  };
-  const forgetSession = (): void => {
-    dispatchPilot({ type: 'reset' });
-    dispatch({ type: 'forget' });
-  };
+  const {
+    diagnostics,
+    effectiveLeafId,
+    effectivePilotSource,
+    forgetSession,
+    importSessionFile,
+    pilotState,
+    projection,
+    revealChatSource,
+    revealSource,
+    selectPath,
+    state,
+    toggleChatSource,
+  } = useResumeSession();
   return (
     <main className="pilot-shell">
       <PilotSessionToolbar
         state={state} pathLength={projection?.path.length ?? 0} selectedLeafId={effectiveLeafId}
         onFile={file => void importSessionFile(file)}
-        onSelectPath={leafId => { dispatchPilot({ type: 'reset' }); dispatch({ type: 'select-leaf', leafId }); }}
+        onSelectPath={selectPath}
         onForget={forgetSession}
       />
       <section className="pilot-workspace" data-layout="resume">
@@ -1624,7 +1377,7 @@ export function ResumeApp() {
             chatInstanceId={`${state.sourceMode}:${state.fileInputGeneration}:${state.session.header.sessionId}`}
             chatSourceEntryIds={pilotState.chatSourceEntryIds}
             onSelectEntry={revealSource} onSelectChatSource={revealChatSource}
-            onToggleChatSource={entryId => dispatchPilot({ type: 'toggle-chat-source', entryId })}
+            onToggleChatSource={toggleChatSource}
           />
         )}
       </section>

--- a/examples/web/src/features/resume/browser/conversation-pane.tsx
+++ b/examples/web/src/features/resume/browser/conversation-pane.tsx
@@ -1,0 +1,269 @@
+import {
+  forwardRef,
+  useImperativeHandle,
+  type KeyboardEvent,
+} from 'react';
+import {
+  activityTextForDisplay,
+  type ActivityItem,
+  type NormalizedEntry,
+} from '../core/session';
+import {
+  activityKindLabel,
+  normalizedEntryLabel,
+} from './workbench-view-model';
+import { useConversationSelectionScroll } from './use-conversation-selection-scroll';
+
+
+type PilotChatRole = 'user' | 'assistant' | 'tool' | 'checkpoint' | 'system';
+
+function pilotChatRole(item: ActivityItem, entry: NormalizedEntry | undefined): PilotChatRole {
+  if (entry?.kind === 'message') {
+    if (entry.role === 'user') return 'user';
+    if (entry.role === 'assistant') return 'assistant';
+    return 'tool';
+  }
+  if (entry?.kind === 'bashExecution' || item.kind === 'tool-evidence') return 'tool';
+  if (entry?.kind === 'checkpoint' || item.kind === 'checkpoint') return 'checkpoint';
+  return 'system';
+}
+
+function conversationSpeaker(role: PilotChatRole): string {
+  switch (role) {
+    case 'user': return 'You';
+    case 'assistant': return 'Assistant';
+    case 'tool': return 'Tool';
+    case 'checkpoint': return 'Accepted checkpoint';
+    case 'system': return 'Session event';
+  }
+}
+
+function chatAuthorityLabel(item: ActivityItem, role: PilotChatRole): string {
+  switch (role) {
+    case 'user': return 'Recorded user message';
+    case 'assistant': return 'Unverified assistant text';
+    case 'tool': return item.evidenceStatus === 'observed-failure'
+      ? 'Observed failure'
+      : 'Observed result';
+    case 'checkpoint': return item.anchorKind === undefined
+      ? 'Accepted anchor'
+      : `Accepted ${item.anchorKind}`;
+    case 'system': return activityKindLabel(item);
+  }
+}
+
+
+export interface ConversationPaneHandle {
+  revealConversationSelection: () => void;
+}
+
+export interface ConversationPaneProps {
+  readonly active: boolean;
+  readonly conversationItems: readonly ActivityItem[];
+  readonly entriesById: ReadonlyMap<string, NormalizedEntry>;
+  readonly operationIndex: Readonly<{
+    readonly calls: ReadonlyMap<string, { readonly entryId: string; readonly name: string }>;
+    readonly results: ReadonlyMap<string, { readonly entryId: string; readonly name: string }>;
+  }>;
+  readonly selectedEntryId: string;
+  readonly selectedItemIndex: number;
+  readonly totalEvents: number;
+  readonly formatTime: (value: string) => string;
+  readonly onSelectEntry: (entryId: string) => void;
+}
+
+export const ConversationPane = forwardRef<ConversationPaneHandle, ConversationPaneProps>(
+  function ConversationPane(props, ref) {
+    const {
+      active,
+      conversationItems,
+      entriesById,
+      operationIndex,
+      selectedEntryId,
+      selectedItemIndex,
+      totalEvents,
+      formatTime,
+      onSelectEntry,
+    } = props;
+
+    const {
+      conversationPanelRef,
+      revealConversationSelection,
+      selectedConversationRef,
+    } = useConversationSelectionScroll(active, selectedEntryId);
+
+    useImperativeHandle(ref, () => ({
+      revealConversationSelection,
+    }));
+
+    const selectConversationAt = (index: number, focus: boolean): void => {
+      const item = conversationItems[index];
+      if (item === undefined) return;
+      onSelectEntry(item.source.entryId);
+      if (!focus) return;
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          const options = conversationPanelRef.current
+            ?.querySelectorAll<HTMLElement>('[data-entry-id]');
+          [...(options ?? [])]
+            .find(option => option.dataset.entryId === item.source.entryId)
+            ?.focus({ preventScroll: true });
+        });
+      });
+    };
+
+    const handleConversationKeyDown = (
+      event: KeyboardEvent<HTMLLIElement>,
+      index: number,
+    ): void => {
+      let nextIndex: number | undefined;
+      switch (event.key) {
+        case 'Enter':
+        case ' ':
+          nextIndex = index;
+          break;
+        case 'ArrowDown':
+          nextIndex = Math.min(conversationItems.length - 1, index + 1);
+          break;
+        case 'ArrowUp':
+          nextIndex = Math.max(0, index - 1);
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = conversationItems.length - 1;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      selectConversationAt(nextIndex, true);
+    };
+
+    return (
+      <section
+        className="pilot-workbench-panel pilot-conversation"
+        data-pane="conversation"
+        aria-labelledby="pilot-conversation-title"
+        ref={conversationPanelRef}
+      >
+        <header className="pilot-panel-heading">
+          <div>
+            <h3 id="pilot-conversation-title">Conversation</h3>
+          </div>
+          <p>
+            Full selected path · {totalEvents} events · selected {selectedItemIndex + 1}
+          </p>
+        </header>
+        <ol
+          className="pilot-conversation-list"
+          role="listbox"
+          aria-label="Recorded conversation"
+        >
+          {conversationItems.map((item, index) => {
+            const selected = item.source.entryId === selectedEntryId;
+            const record = entriesById.get(item.source.entryId);
+            const role = pilotChatRole(item, record);
+            const assistantRecord = record?.kind === 'message' && record.role === 'assistant'
+              ? record
+              : undefined;
+            const toolResultRecord = record?.kind === 'message' && record.role === 'toolResult'
+              ? record
+              : undefined;
+            const linkedRequest = toolResultRecord?.toolCallId === undefined
+              ? undefined
+              : operationIndex.calls.get(toolResultRecord.toolCallId);
+            return (
+              <li
+                data-role={role}
+                data-entry-id={item.source.entryId}
+                data-anchor={item.anchorKind}
+                data-selected={selected}
+                data-status={item.evidenceStatus}
+                role="option"
+                aria-label={`${conversationSpeaker(role)}: ${item.title}, ${formatTime(item.timestamp)}`}
+                aria-current={selected ? 'true' : undefined}
+                aria-selected={selected}
+                aria-keyshortcuts="ArrowUp ArrowDown Home End Enter Space"
+                tabIndex={selected ? 0 : -1}
+                key={item.id}
+                ref={selected ? selectedConversationRef : undefined}
+                onClick={event => {
+                  const selection = window.getSelection();
+                  const selectedTextIsInside = selection?.isCollapsed === false &&
+                    ((selection.anchorNode !== null && event.currentTarget.contains(selection.anchorNode)) ||
+                      (selection.focusNode !== null && event.currentTarget.contains(selection.focusNode)));
+                  if (selectedTextIsInside) return;
+                  event.currentTarget.focus({ preventScroll: true });
+                  selectConversationAt(index, false);
+                }}
+                onKeyDown={event => handleConversationKeyDown(event, index)}
+              >
+                <article className="pilot-chat-turn">
+                  <header className="pilot-chat-meta">
+                    <div>
+                      <span className="pilot-chat-author">
+                        {conversationSpeaker(role)}
+                      </span>
+                      <span>{chatAuthorityLabel(item, role)}</span>
+                      {selected ? <strong>Selected source</strong> : null}
+                    </div>
+                    <time dateTime={item.timestamp}>{formatTime(item.timestamp)}</time>
+                  </header>
+                  <div className="pilot-chat-bubble">
+                    {role === 'checkpoint' || role === 'system' || role === 'tool' ? (
+                      <strong className="pilot-chat-event-title">{item.title}</strong>
+                    ) : null}
+                    <p>{activityTextForDisplay(item)}</p>
+                    {assistantRecord === undefined || assistantRecord.toolCalls.length === 0 ? null : (
+                      <div className="pilot-chat-tool-calls" aria-label="Tool calls in this assistant message">
+                        {assistantRecord.toolCalls.map(call => {
+                          const result = operationIndex.results.get(call.id);
+                          return (
+                            <div className="pilot-chat-tool-call" key={call.id}>
+                              <div>
+                                <span>Tool call</span>
+                                <strong>{call.name}</strong>
+                                <em>{result === undefined ? 'No result on path' : 'Result recorded'}</em>
+                              </div>
+                              <dl>
+                                <div><dt>Call</dt><dd>{call.id}</dd></div>
+                                {call.path === undefined ? null : <div><dt>Path</dt><dd>{call.path}</dd></div>}
+                                {call.editCount === undefined ? null : <div><dt>Edits</dt><dd>{call.editCount}</dd></div>}
+                                {call.bashClassification === undefined ? null : (
+                                  <div><dt>Kind</dt><dd>{call.bashClassification}</dd></div>
+                                )}
+                                {result === undefined ? null : <div><dt>Result source</dt><dd>{result.entryId}</dd></div>}
+                              </dl>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                    {linkedRequest === undefined ? null : (
+                      <p className="pilot-chat-operation-link">
+                        Result for <strong>{linkedRequest.name}</strong> requested in source {linkedRequest.entryId}
+                      </p>
+                    )}
+                    {record?.kind === 'bashExecution' ? (
+                      <dl className="pilot-chat-command-meta">
+                        <div><dt>Command kind</dt><dd>{record.classification}</dd></div>
+                        <div><dt>Exit</dt><dd>{record.exitCode ?? 'unknown'}</dd></div>
+                        <div><dt>Cancelled</dt><dd>{record.cancelled ? 'yes' : 'no'}</dd></div>
+                      </dl>
+                    ) : null}
+                    <footer>
+                      <span>{normalizedEntryLabel(record)}</span>
+                      <span>source {item.source.entryId}</span>
+                    </footer>
+                  </div>
+                </article>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+    );
+  },
+);

--- a/examples/web/src/features/resume/browser/evidence-pane.tsx
+++ b/examples/web/src/features/resume/browser/evidence-pane.tsx
@@ -1,0 +1,77 @@
+import { useState, type ReactNode } from 'react';
+import { activityTextForDisplay, type ActivityItem, type NormalizedEntry } from '../core/session';
+
+export interface EvidencePaneProps {
+  readonly chat: ReactNode;
+  readonly normalizedRecord: string;
+  readonly operationRelationship: string | undefined;
+  readonly selectedEntryId: string;
+  readonly selectedItem: ActivityItem | undefined;
+  readonly selectedItemIndex: number;
+  readonly selectedRecord: NormalizedEntry | undefined;
+  readonly terminalPathId: string;
+  readonly totalItems: number;
+  readonly formatTime: (timestamp: string) => string;
+  readonly normalizedEntryLabel: (entry: NormalizedEntry | undefined) => string;
+}
+
+export function EvidencePane({
+  chat,
+  normalizedRecord,
+  operationRelationship,
+  selectedEntryId,
+  selectedItem,
+  selectedItemIndex,
+  selectedRecord,
+  terminalPathId,
+  totalItems,
+  formatTime,
+  normalizedEntryLabel,
+}: EvidencePaneProps) {
+  const [inspectorMode, setInspectorMode] = useState<'discuss' | 'evidence'>('discuss');
+  const [evidenceMode, setEvidenceMode] = useState<'readable' | 'normalized'>('readable');
+
+  return (
+    <section className="pilot-workbench-panel pilot-evidence" data-pane="evidence" id="pilot-inspector" aria-labelledby="pilot-inspector-title">
+      <header className="pilot-panel-heading">
+        <div><h3 id="pilot-inspector-title" tabIndex={-1}>Evidence</h3></div>
+        <p>Selected {selectedItemIndex + 1} of {totalItems}</p>
+      </header>
+      <div className="pilot-inspector-tabs" role="tablist" aria-label="Evidence panel mode">
+        <button type="button" role="tab" aria-selected={inspectorMode === 'discuss'} onClick={() => setInspectorMode('discuss')}>Discuss</button>
+        <button type="button" role="tab" aria-selected={inspectorMode === 'evidence'} onClick={() => setInspectorMode('evidence')}>Evidence</button>
+      </div>
+      <div hidden={inspectorMode !== 'discuss'} role="tabpanel">{chat}</div>
+      {inspectorMode !== 'evidence' ? null : (
+        <>
+          <div className="pilot-evidence-tabs" role="tablist" aria-label="Evidence representation">
+            <button type="button" role="tab" aria-selected={evidenceMode === 'readable'} onClick={() => setEvidenceMode('readable')}>Readable</button>
+            <button type="button" role="tab" aria-selected={evidenceMode === 'normalized'} onClick={() => setEvidenceMode('normalized')}>Normalized record</button>
+          </div>
+          {evidenceMode === 'readable' ? (
+            <div className="pilot-evidence-readable" role="tabpanel">
+              <section className="pilot-evidence-copy" aria-labelledby="pilot-evidence-copy-title">
+                <span className="kicker">Selected recorded entry</span>
+                <h4 id="pilot-evidence-copy-title">{selectedItem?.title ?? 'Unavailable entry'}</h4>
+                <p>{selectedItem === undefined ? 'No recorded entry is selected.' : activityTextForDisplay(selectedItem)}</p>
+              </section>
+              <dl className="pilot-evidence-metadata">
+                <div><dt>Recorded type</dt><dd>{normalizedEntryLabel(selectedRecord)}</dd></div>
+                <div><dt>Time</dt><dd>{selectedItem === undefined ? 'Unknown' : formatTime(selectedItem.timestamp)}</dd></div>
+                <div><dt>Path position</dt><dd>{selectedItemIndex + 1} of {totalItems}</dd></div>
+                <div><dt>Terminal path</dt><dd>{terminalPathId}</dd></div>
+                <div><dt>Source entry</dt><dd>{selectedEntryId}</dd></div>
+              </dl>
+              {operationRelationship === undefined ? null : <div className="pilot-operation-relation"><strong>Recorded operation relationship</strong><p>{operationRelationship}</p></div>}
+            </div>
+          ) : (
+            <div className="pilot-evidence-normalized" role="tabpanel">
+              <p>This is the bounded normalized import used by this view, not the unfiltered JSONL line.</p>
+              <pre>{normalizedRecord}</pre>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/examples/web/src/features/resume/browser/resume-reducer.ts
+++ b/examples/web/src/features/resume/browser/resume-reducer.ts
@@ -1,0 +1,139 @@
+import { type ReducedPiSession, type ResumeDiagnostic } from '../core/session';
+import { PKE_CHAT_SOURCE_LIMIT } from '../protocol/chat';
+
+type SourceMode = 'demo' | 'imported';
+type StatusTone = 'idle' | 'success' | 'error';
+
+export interface ImportStatus {
+  readonly message: string;
+  readonly tone: StatusTone;
+}
+
+export interface ResumeState {
+  readonly session: ReducedPiSession;
+  readonly sourceMode: SourceMode;
+  readonly importedFileName?: string;
+  readonly selectedLeafId: string | null;
+  readonly isImporting: boolean;
+  readonly importStatus: ImportStatus;
+  readonly diagnosticOverride?: readonly ResumeDiagnostic[];
+  readonly fileInputGeneration: number;
+}
+
+export type ResumeEvent =
+  | { readonly type: 'import-reading'; readonly fileName: string }
+  | {
+      readonly type: 'import-succeeded';
+      readonly session: ReducedPiSession;
+      readonly fileName: string;
+      readonly status: ImportStatus;
+    }
+  | { readonly type: 'import-failed'; readonly diagnostic: ResumeDiagnostic; readonly status: ImportStatus }
+  | { readonly type: 'select-leaf'; readonly leafId: string | null }
+  | { readonly type: 'forget' };
+
+export function createResumeState(session: ReducedPiSession): ResumeState {
+  return {
+    session,
+    sourceMode: 'demo',
+    selectedLeafId: null,
+    isImporting: false,
+    importStatus: { message: '', tone: 'idle' },
+    fileInputGeneration: 0,
+  };
+}
+
+export function createResumeReducer(
+  baseline: ResumeState,
+): (state: ResumeState, event: ResumeEvent) => ResumeState {
+  return function reduceResumeState(state: ResumeState, event: ResumeEvent): ResumeState {
+    switch (event.type) {
+      case 'import-reading':
+        return {
+          ...state,
+          selectedLeafId: null,
+          isImporting: true,
+          importStatus: { message: `Reading ${event.fileName} in this tab\u2026`, tone: 'idle' },
+          fileInputGeneration: state.fileInputGeneration + 1,
+        };
+      case 'import-succeeded': {
+        return {
+          session: event.session,
+          sourceMode: 'imported',
+          importedFileName: event.fileName,
+          selectedLeafId: null,
+          isImporting: false,
+          importStatus: event.status,
+          fileInputGeneration: state.fileInputGeneration,
+        };
+      }
+      case 'import-failed':
+        return {
+          ...baseline,
+          importStatus: event.status,
+          diagnosticOverride: [event.diagnostic],
+          fileInputGeneration: state.fileInputGeneration + 1,
+        };
+      case 'select-leaf':
+        return {
+          ...state,
+          selectedLeafId: event.leafId,
+          diagnosticOverride: undefined,
+        };
+      case 'forget':
+        return {
+          ...baseline,
+          importStatus: {
+            message: 'Imported session forgotten. The demo transcript is active again.',
+            tone: 'idle',
+          },
+          fileInputGeneration: state.fileInputGeneration + 1,
+        };
+    }
+  };
+}
+
+export interface PilotSourceSelection {
+  readonly entryId: string;
+}
+
+export interface PilotViewState {
+  readonly selectedSource?: PilotSourceSelection;
+  readonly chatSourceEntryIds: readonly string[];
+}
+
+export type PilotViewEvent =
+  | { readonly type: 'open-source'; readonly entryId: string }
+  | { readonly type: 'toggle-chat-source'; readonly entryId: string }
+  | { readonly type: 'reset' };
+
+export const initialPilotViewState: PilotViewState = {
+  chatSourceEntryIds: Object.freeze([]),
+};
+
+export function reducePilotViewState(
+  state: PilotViewState,
+  event: PilotViewEvent,
+): PilotViewState {
+  switch (event.type) {
+    case 'open-source':
+      return {
+        ...state,
+        selectedSource: { entryId: event.entryId },
+      };
+    case 'toggle-chat-source': {
+      const includesSource = state.chatSourceEntryIds.includes(event.entryId);
+      if (!includesSource && state.chatSourceEntryIds.length >= PKE_CHAT_SOURCE_LIMIT) return state;
+      return {
+        ...state,
+        chatSourceEntryIds: Object.freeze(
+          includesSource
+            ? state.chatSourceEntryIds.filter(entryId => entryId !== event.entryId)
+            : [...state.chatSourceEntryIds, event.entryId],
+        ),
+      };
+    }
+    case 'reset':
+      return initialPilotViewState;
+  }
+}

--- a/examples/web/src/features/resume/browser/resume-reducer.ts
+++ b/examples/web/src/features/resume/browser/resume-reducer.ts
@@ -52,6 +52,7 @@ export function createResumeReducer(
         return {
           ...state,
           selectedLeafId: null,
+          diagnosticOverride: undefined,
           isImporting: true,
           importStatus: { message: `Reading ${event.fileName} in this tab\u2026`, tone: 'idle' },
           fileInputGeneration: state.fileInputGeneration + 1,

--- a/examples/web/src/features/resume/browser/resume-state.ts
+++ b/examples/web/src/features/resume/browser/resume-state.ts
@@ -1,0 +1,141 @@
+import fixtureSource from '../../../../tests/fixtures/pi-session-v3.jsonl?raw';
+import {
+  parsePiSessionJsonl,
+  reducePiSession,
+  type ReducedPiSession,
+  type ResumeDiagnostic,
+} from '../core/session';
+import { PKE_CHAT_SOURCE_LIMIT } from '../protocol/chat';
+
+const demoSession = reducePiSession(parsePiSessionJsonl(fixtureSource));
+
+type SourceMode = 'demo' | 'imported';
+type StatusTone = 'idle' | 'success' | 'error';
+
+export interface ImportStatus {
+  readonly message: string;
+  readonly tone: StatusTone;
+}
+
+export interface ResumeState {
+  readonly session: ReducedPiSession;
+  readonly sourceMode: SourceMode;
+  readonly importedFileName?: string;
+  readonly selectedLeafId: string | null;
+  readonly isImporting: boolean;
+  readonly importStatus: ImportStatus;
+  readonly diagnosticOverride?: readonly ResumeDiagnostic[];
+  readonly fileInputGeneration: number;
+}
+
+export type ResumeEvent =
+  | { readonly type: 'import-reading'; readonly fileName: string }
+  | {
+      readonly type: 'import-succeeded';
+      readonly session: ReducedPiSession;
+      readonly fileName: string;
+      readonly status: ImportStatus;
+    }
+  | { readonly type: 'import-failed'; readonly diagnostic: ResumeDiagnostic; readonly status: ImportStatus }
+  | { readonly type: 'select-leaf'; readonly leafId: string | null }
+  | { readonly type: 'forget' };
+
+export const initialResumeState: ResumeState = {
+  session: demoSession,
+  sourceMode: 'demo',
+  selectedLeafId: null,
+  isImporting: false,
+  importStatus: { message: '', tone: 'idle' },
+  fileInputGeneration: 0,
+};
+
+export function reduceResumeState(state: ResumeState, event: ResumeEvent): ResumeState {
+  switch (event.type) {
+    case 'import-reading':
+      return {
+        ...state,
+        selectedLeafId: null,
+        isImporting: true,
+        importStatus: { message: `Reading ${event.fileName} in this tab…`, tone: 'idle' },
+        fileInputGeneration: state.fileInputGeneration + 1,
+      };
+    case 'import-succeeded': {
+      return {
+        session: event.session,
+        sourceMode: 'imported',
+        importedFileName: event.fileName,
+        selectedLeafId: null,
+        isImporting: false,
+        importStatus: event.status,
+        fileInputGeneration: state.fileInputGeneration,
+      };
+    }
+    case 'import-failed':
+      return {
+        ...initialResumeState,
+        importStatus: event.status,
+        diagnosticOverride: [event.diagnostic],
+        fileInputGeneration: state.fileInputGeneration + 1,
+      };
+    case 'select-leaf':
+      return {
+        ...state,
+        selectedLeafId: event.leafId,
+        diagnosticOverride: undefined,
+      };
+    case 'forget':
+      return {
+        ...initialResumeState,
+        importStatus: {
+          message: 'Imported session forgotten. The demo transcript is active again.',
+          tone: 'idle',
+        },
+        fileInputGeneration: state.fileInputGeneration + 1,
+      };
+  }
+}
+
+export interface PilotSourceSelection {
+  readonly entryId: string;
+}
+
+export interface PilotViewState {
+  readonly selectedSource?: PilotSourceSelection;
+  readonly chatSourceEntryIds: readonly string[];
+}
+
+export type PilotViewEvent =
+  | { readonly type: 'open-source'; readonly entryId: string }
+  | { readonly type: 'toggle-chat-source'; readonly entryId: string }
+  | { readonly type: 'reset' };
+
+export const initialPilotViewState: PilotViewState = {
+  chatSourceEntryIds: Object.freeze([]),
+};
+
+export function reducePilotViewState(
+  state: PilotViewState,
+  event: PilotViewEvent,
+): PilotViewState {
+  switch (event.type) {
+    case 'open-source':
+      return {
+        ...state,
+        selectedSource: { entryId: event.entryId },
+      };
+    case 'toggle-chat-source': {
+      const includesSource = state.chatSourceEntryIds.includes(event.entryId);
+      if (!includesSource && state.chatSourceEntryIds.length >= PKE_CHAT_SOURCE_LIMIT) return state;
+      return {
+        ...state,
+        chatSourceEntryIds: Object.freeze(
+          includesSource
+            ? state.chatSourceEntryIds.filter(entryId => entryId !== event.entryId)
+            : [...state.chatSourceEntryIds, event.entryId],
+        ),
+      };
+    }
+    case 'reset':
+      return initialPilotViewState;
+  }
+}

--- a/examples/web/src/features/resume/browser/resume-state.ts
+++ b/examples/web/src/features/resume/browser/resume-state.ts
@@ -2,140 +2,36 @@ import fixtureSource from '../../../../tests/fixtures/pi-session-v3.jsonl?raw';
 import {
   parsePiSessionJsonl,
   reducePiSession,
-  type ReducedPiSession,
-  type ResumeDiagnostic,
 } from '../core/session';
-import { PKE_CHAT_SOURCE_LIMIT } from '../protocol/chat';
+import {
+  createResumeReducer,
+  createResumeState,
+  reducePilotViewState,
+  initialPilotViewState,
+  type ImportStatus,
+  type PilotSourceSelection,
+  type PilotViewEvent,
+  type PilotViewState,
+  type ResumeEvent,
+  type ResumeState,
+} from './resume-reducer';
+
+export type {
+  ImportStatus,
+  PilotSourceSelection,
+  PilotViewEvent,
+  PilotViewState,
+  ResumeEvent,
+  ResumeState,
+};
 
 const demoSession = reducePiSession(parsePiSessionJsonl(fixtureSource));
+const demoBaseline = createResumeState(demoSession);
 
-type SourceMode = 'demo' | 'imported';
-type StatusTone = 'idle' | 'success' | 'error';
+export const initialResumeState: ResumeState = demoBaseline;
+export const reduceResumeState = createResumeReducer(demoBaseline);
 
-export interface ImportStatus {
-  readonly message: string;
-  readonly tone: StatusTone;
-}
-
-export interface ResumeState {
-  readonly session: ReducedPiSession;
-  readonly sourceMode: SourceMode;
-  readonly importedFileName?: string;
-  readonly selectedLeafId: string | null;
-  readonly isImporting: boolean;
-  readonly importStatus: ImportStatus;
-  readonly diagnosticOverride?: readonly ResumeDiagnostic[];
-  readonly fileInputGeneration: number;
-}
-
-export type ResumeEvent =
-  | { readonly type: 'import-reading'; readonly fileName: string }
-  | {
-      readonly type: 'import-succeeded';
-      readonly session: ReducedPiSession;
-      readonly fileName: string;
-      readonly status: ImportStatus;
-    }
-  | { readonly type: 'import-failed'; readonly diagnostic: ResumeDiagnostic; readonly status: ImportStatus }
-  | { readonly type: 'select-leaf'; readonly leafId: string | null }
-  | { readonly type: 'forget' };
-
-export const initialResumeState: ResumeState = {
-  session: demoSession,
-  sourceMode: 'demo',
-  selectedLeafId: null,
-  isImporting: false,
-  importStatus: { message: '', tone: 'idle' },
-  fileInputGeneration: 0,
+export {
+  initialPilotViewState,
+  reducePilotViewState,
 };
-
-export function reduceResumeState(state: ResumeState, event: ResumeEvent): ResumeState {
-  switch (event.type) {
-    case 'import-reading':
-      return {
-        ...state,
-        selectedLeafId: null,
-        isImporting: true,
-        importStatus: { message: `Reading ${event.fileName} in this tab…`, tone: 'idle' },
-        fileInputGeneration: state.fileInputGeneration + 1,
-      };
-    case 'import-succeeded': {
-      return {
-        session: event.session,
-        sourceMode: 'imported',
-        importedFileName: event.fileName,
-        selectedLeafId: null,
-        isImporting: false,
-        importStatus: event.status,
-        fileInputGeneration: state.fileInputGeneration,
-      };
-    }
-    case 'import-failed':
-      return {
-        ...initialResumeState,
-        importStatus: event.status,
-        diagnosticOverride: [event.diagnostic],
-        fileInputGeneration: state.fileInputGeneration + 1,
-      };
-    case 'select-leaf':
-      return {
-        ...state,
-        selectedLeafId: event.leafId,
-        diagnosticOverride: undefined,
-      };
-    case 'forget':
-      return {
-        ...initialResumeState,
-        importStatus: {
-          message: 'Imported session forgotten. The demo transcript is active again.',
-          tone: 'idle',
-        },
-        fileInputGeneration: state.fileInputGeneration + 1,
-      };
-  }
-}
-
-export interface PilotSourceSelection {
-  readonly entryId: string;
-}
-
-export interface PilotViewState {
-  readonly selectedSource?: PilotSourceSelection;
-  readonly chatSourceEntryIds: readonly string[];
-}
-
-export type PilotViewEvent =
-  | { readonly type: 'open-source'; readonly entryId: string }
-  | { readonly type: 'toggle-chat-source'; readonly entryId: string }
-  | { readonly type: 'reset' };
-
-export const initialPilotViewState: PilotViewState = {
-  chatSourceEntryIds: Object.freeze([]),
-};
-
-export function reducePilotViewState(
-  state: PilotViewState,
-  event: PilotViewEvent,
-): PilotViewState {
-  switch (event.type) {
-    case 'open-source':
-      return {
-        ...state,
-        selectedSource: { entryId: event.entryId },
-      };
-    case 'toggle-chat-source': {
-      const includesSource = state.chatSourceEntryIds.includes(event.entryId);
-      if (!includesSource && state.chatSourceEntryIds.length >= PKE_CHAT_SOURCE_LIMIT) return state;
-      return {
-        ...state,
-        chatSourceEntryIds: Object.freeze(
-          includesSource
-            ? state.chatSourceEntryIds.filter(entryId => entryId !== event.entryId)
-            : [...state.chatSourceEntryIds, event.entryId],
-        ),
-      };
-    }
-    case 'reset':
-      return initialPilotViewState;
-  }
-}

--- a/examples/web/src/features/resume/browser/timeline-pane.tsx
+++ b/examples/web/src/features/resume/browser/timeline-pane.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { activityTextForDisplay } from '../core/session';
+import {
+  activityKindLabel,
+  type PilotTimelinePhase,
+} from './workbench-view-model';
+
+export interface TimelinePaneProps {
+  readonly phases: readonly PilotTimelinePhase[];
+  readonly selectedEntryId: string;
+  readonly selectedPhase: PilotTimelinePhase | undefined;
+  readonly selectedPhaseId: string | undefined;
+  readonly formatTime: (timestamp: string) => string;
+  readonly onSelectEntry: (entryId: string) => void;
+}
+
+export function TimelinePane({
+  phases,
+  selectedEntryId,
+  selectedPhase,
+  selectedPhaseId,
+  formatTime,
+  onSelectEntry,
+}: TimelinePaneProps) {
+  const [expandedPhaseIds, setExpandedPhaseIds] = useState<ReadonlySet<string>>(
+    () => new Set(selectedPhaseId === undefined ? [] : [selectedPhaseId]),
+  );
+  useEffect(() => {
+    if (selectedPhaseId === undefined) return;
+    setExpandedPhaseIds(current =>
+      current.has(selectedPhaseId) ? current : new Set([...current, selectedPhaseId]),
+    );
+  }, [selectedPhaseId]);
+
+  return (
+    <section
+      className="pilot-workbench-panel pilot-timeline"
+      data-pane="timeline"
+      aria-labelledby="pilot-timeline-title"
+    >
+      <header className="pilot-panel-heading">
+        <div>
+          <h3 id="pilot-timeline-title">Timeline</h3>
+        </div>
+        <p>{phases.length} phases · {phases.flatMap(phase => phase.items).length} recorded events</p>
+      </header>
+      <ol className="pilot-phase-list">
+        {phases.map(phase => {
+          const containsSelection = phase === selectedPhase;
+          const expanded = expandedPhaseIds.has(phase.id);
+          const first = phase.items[0]!;
+          const last = phase.items[phase.items.length - 1]!;
+          return (
+            <li className="pilot-phase" data-selected={containsSelection} key={phase.id}>
+              <button
+                className="pilot-phase-toggle"
+                type="button"
+                aria-expanded={expanded}
+                onClick={() => {
+                  setExpandedPhaseIds(current => {
+                    const next = new Set(current);
+                    if (next.has(phase.id)) next.delete(phase.id);
+                    else next.add(phase.id);
+                    return next;
+                  });
+                }}
+              >
+                <span>Phase {String(phase.index + 1).padStart(2, '0')}</span>
+                <time dateTime={first.timestamp}>
+                  {formatTime(first.timestamp)}–{formatTime(last.timestamp)}
+                </time>
+                <strong>{phase.recordedKinds.join(' · ')}</strong>
+                <i aria-hidden="true">{expanded ? '−' : '+'}</i>
+              </button>
+              {expanded ? (
+                <ol className="pilot-event-list">
+                  {phase.items.map(item => {
+                    const selected = item.source.entryId === selectedEntryId;
+                    return (
+                      <li
+                        id={`source-${item.source.entryId}`}
+                        data-selected={selected}
+                        aria-current={selected ? 'true' : undefined}
+                        key={item.id}
+                      >
+                        <button type="button" onClick={() => onSelectEntry(item.source.entryId)}>
+                          <span>{activityKindLabel(item)}</span>
+                          <time dateTime={item.timestamp}>{formatTime(item.timestamp)}</time>
+                          <strong>{item.title}</strong>
+                          <small>{activityTextForDisplay(item)}</small>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ol>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/examples/web/src/features/resume/browser/use-conversation-selection-scroll.ts
+++ b/examples/web/src/features/resume/browser/use-conversation-selection-scroll.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+
+export function useConversationSelectionScroll(
+  isConversationVisible: boolean,
+  selectedEntryId: string,
+) {
+  const conversationPanelRef = useRef<HTMLElement | null>(null);
+  const selectedConversationRef = useRef<HTMLLIElement | null>(null);
+  const revealConversationSelectionRef = useRef(false);
+
+  useEffect(() => {
+    if (!isConversationVisible) return;
+    const frame = window.requestAnimationFrame(() => {
+      const panel = conversationPanelRef.current;
+      const target = selectedConversationRef.current;
+      if (panel === null || target === null) return;
+      const usesInternalScroll = window.getComputedStyle(panel).overflowY !== 'visible';
+      if (usesInternalScroll) {
+        const panelBox = panel.getBoundingClientRect();
+        const targetBox = target.getBoundingClientRect();
+        const headingHeight = panel.querySelector<HTMLElement>('.pilot-panel-heading')
+          ?.getBoundingClientRect().height ?? 0;
+        panel.scrollTo({
+          top: Math.max(
+            0,
+            panel.scrollTop + targetBox.top - panelBox.top - headingHeight - 4,
+          ),
+          behavior: 'auto',
+        });
+      } else if (revealConversationSelectionRef.current) {
+        target.scrollIntoView({ block: 'center', behavior: 'auto' });
+      }
+      revealConversationSelectionRef.current = false;
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isConversationVisible, selectedEntryId]);
+
+  const revealConversationSelection = (): void => {
+    revealConversationSelectionRef.current = true;
+  };
+
+  return {
+    conversationPanelRef,
+    revealConversationSelection,
+    selectedConversationRef,
+  };
+}

--- a/examples/web/src/features/resume/browser/use-pke-chat.ts
+++ b/examples/web/src/features/resume/browser/use-pke-chat.ts
@@ -1,0 +1,174 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, type ChatStatus, type UIMessage } from 'ai';
+import {
+  parsePkeChatStatus,
+  pkeChatTextMessages,
+  type PkeChatContext,
+  type PkeChatSource,
+  type PkeChatStatus,
+} from '../protocol/chat';
+
+export interface PkeChatTurnContext {
+  readonly context: PkeChatContext;
+  readonly sources: readonly PkeChatSource[];
+}
+
+export interface PkeChatTurn {
+  readonly message: UIMessage;
+  readonly turnContext: PkeChatTurnContext;
+}
+
+const NO_HISTORY_CHAT_CONTEXT: PkeChatTurnContext = Object.freeze({
+  context: Object.freeze({ scope: 'none' }),
+  sources: Object.freeze([]),
+});
+
+export interface PkeChatController {
+  readonly draft: string;
+  readonly error: Error | undefined;
+  readonly messages: readonly UIMessage[];
+  readonly pendingMessage: UIMessage | undefined;
+  readonly relayStatus: PkeChatStatus | undefined;
+  readonly relayStatusError: string | undefined;
+  readonly renderedMessages: readonly PkeChatTurn[];
+  readonly status: ChatStatus;
+  clearError(): void;
+  setDraft(draft: string): void;
+  stopAndRestoreDraft(): void;
+  submit(context: PkeChatContext, sources: readonly PkeChatSource[]): void;
+}
+
+export function usePkeChat(sessionId: string): PkeChatController {
+  const [draft, setDraft] = useState('');
+  const [draftMessageId, setDraftMessageId] = useState(() => crypto.randomUUID());
+  const [contextByMessageId, setContextByMessageId] = useState<
+    ReadonlyMap<string, PkeChatTurnContext>
+  >(() => new Map());
+  const [relayStatus, setRelayStatus] = useState<PkeChatStatus>();
+  const [relayStatusError, setRelayStatusError] = useState<string>();
+  const outboundContextRef = useRef<PkeChatContext>(NO_HISTORY_CHAT_CONTEXT.context);
+  const outboundSourcesRef = useRef<readonly PkeChatSource[]>(NO_HISTORY_CHAT_CONTEXT.sources);
+  const transport = useMemo(
+    () => new DefaultChatTransport<UIMessage>({
+      api: '/api/pi-resume-chat',
+      prepareSendMessagesRequest: ({ messages }) => ({
+        body: {
+          messages: pkeChatTextMessages(messages),
+          context: outboundContextRef.current,
+          sources: outboundSourcesRef.current,
+        },
+      }),
+    }),
+    [],
+  );
+  const {
+    messages,
+    setMessages,
+    sendMessage,
+    status,
+    stop,
+    error,
+    clearError,
+  } = useChat<UIMessage>({
+    id: `pke-chat:${sessionId}`,
+    transport,
+  });
+
+  const restoreUnansweredUserMessage = (): void => {
+    const trailingMessage = messages[messages.length - 1];
+    if (trailingMessage?.role !== 'user') return;
+    const text = trailingMessage.parts
+      .filter(part => part.type === 'text')
+      .map(part => part.text)
+      .join('');
+    setMessages(messages.slice(0, -1));
+    setContextByMessageId(current => {
+      if (!current.has(trailingMessage.id)) return current;
+      const next = new Map(current);
+      next.delete(trailingMessage.id);
+      return next;
+    });
+    setDraft(current => current.trim().length === 0 ? text : current);
+  };
+
+  const stopRef = useRef(stop);
+  stopRef.current = stop;
+  useEffect(() => () => {
+    void stopRef.current();
+  }, []);
+  useEffect(() => {
+    if (error === undefined) return;
+    restoreUnansweredUserMessage();
+  }, [error, messages, setMessages]);
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch('/api/pi-resume-chat/status', { signal: controller.signal })
+      .then(async response => {
+        if (!response.ok) throw new Error('Chat relay status is unavailable.');
+        const value = parsePkeChatStatus(await response.json());
+        setRelayStatus(value);
+        setRelayStatusError(undefined);
+      })
+      .catch(cause => {
+        if (cause instanceof DOMException && cause.name === 'AbortError') return;
+        setRelayStatusError(cause instanceof Error ? cause.message : String(cause));
+      });
+    return () => controller.abort();
+  }, []);
+
+  const renderedMessages = useMemo(() => {
+    let turnContext = NO_HISTORY_CHAT_CONTEXT;
+    return messages.map(message => {
+      if (message.role === 'user') {
+        turnContext = contextByMessageId.get(message.id) ?? NO_HISTORY_CHAT_CONTEXT;
+      }
+      return Object.freeze({ message, turnContext });
+    });
+  }, [contextByMessageId, messages]);
+  const pendingMessage = useMemo<UIMessage | undefined>(() => {
+    const text = draft.trim();
+    return text.length === 0
+      ? undefined
+      : {
+          id: draftMessageId,
+          role: 'user',
+          parts: [{ type: 'text', text }],
+        };
+  }, [draft, draftMessageId]);
+
+  const submit = (context: PkeChatContext, sources: readonly PkeChatSource[]): void => {
+    if (pendingMessage === undefined) return;
+    const turnContext: PkeChatTurnContext = Object.freeze({ context, sources });
+    outboundContextRef.current = context;
+    outboundSourcesRef.current = sources;
+    setContextByMessageId(current => {
+      const next = new Map(current);
+      next.set(pendingMessage.id, turnContext);
+      return next;
+    });
+    setDraft('');
+    setDraftMessageId(crypto.randomUUID());
+    void sendMessage(pendingMessage);
+  };
+
+  const stopAndRestoreDraft = (): void => {
+    void stop();
+    restoreUnansweredUserMessage();
+  };
+
+  return {
+    draft,
+    error,
+    messages,
+    pendingMessage,
+    relayStatus,
+    relayStatusError,
+    renderedMessages,
+    status,
+    clearError,
+    setDraft,
+    stopAndRestoreDraft,
+    submit,
+  };
+}

--- a/examples/web/src/features/resume/browser/use-resume-session.ts
+++ b/examples/web/src/features/resume/browser/use-resume-session.ts
@@ -1,0 +1,160 @@
+import { useMemo, useReducer } from 'react';
+import {
+  DEFAULT_LIMITS,
+  parsePiSessionJsonl,
+  PiSessionFormatError,
+  projectResume,
+  reducePiSession,
+  type ResumeDiagnostic,
+  type ResumeProjection,
+} from '../core/session';
+import {
+  initialPilotViewState,
+  initialResumeState,
+  reducePilotViewState,
+  reduceResumeState,
+  type PilotSourceSelection,
+  type PilotViewState,
+  type ResumeState,
+} from './resume-state';
+
+export interface ResumeSessionController {
+  readonly state: ResumeState;
+  readonly pilotState: PilotViewState;
+  readonly effectiveLeafId: string | null;
+  readonly projection: ResumeProjection | undefined;
+  readonly effectivePilotSource: PilotSourceSelection | undefined;
+  readonly diagnostics: readonly ResumeDiagnostic[];
+  importSessionFile(file: File): Promise<void>;
+  revealSource(entryId: string): void;
+  revealChatSource(entryId: string, leafId: string): void;
+  selectPath(leafId: string | null): void;
+  toggleChatSource(entryId: string): void;
+  forgetSession(): void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} bytes`;
+  const units = ['KiB', 'MiB', 'GiB'];
+  let value = bytes;
+  let unitIndex = -1;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function formatImportError(error: unknown, file: File): ResumeDiagnostic {
+  if (error instanceof PiSessionFormatError) {
+    const message = (() => {
+      switch (error.code) {
+        case 'file_too_large':
+          return `This session is ${formatBytes(file.size)} (${file.size.toLocaleString()} bytes), above the ${formatBytes(DEFAULT_LIMITS.maxFileBytes)} limit (${DEFAULT_LIMITS.maxFileBytes.toLocaleString()} bytes). Choose a shorter or newer pi session and try again. Nothing was uploaded or saved.`;
+        case 'line_too_large':
+          return 'One entry in this session is too large to import safely. Choose a shorter session or a session with less captured tool output. Nothing was uploaded or saved.';
+        case 'too_many_entries':
+          return `This session has more than ${DEFAULT_LIMITS.maxEntries.toLocaleString()} entries. Choose a shorter session and try again. Nothing was uploaded or saved.`;
+        case 'unsupported_version':
+          return 'This is not a supported pi session v3 file. Choose a v3 .jsonl session snapshot.';
+        case 'invalid_json':
+          return 'This file is not valid JSONL. Choose a pi session .jsonl snapshot rather than a folder or export in another format.';
+        case 'invalid_entry_identity':
+        case 'missing_parent':
+        case 'missing_reference':
+        case 'cycle':
+          return 'This session appears incomplete or malformed. Choose another .jsonl snapshot; the file was not modified.';
+        default:
+          return error.message;
+      }
+    })();
+    return { severity: 'error', code: error.code, message };
+  }
+  return {
+    severity: 'error',
+    code: 'import_failed',
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export function useResumeSession(): ResumeSessionController {
+  const [state, dispatch] = useReducer(reduceResumeState, initialResumeState);
+  const [pilotState, dispatchPilot] = useReducer(reducePilotViewState, initialPilotViewState);
+  const effectiveLeafId = state.selectedLeafId ?? (
+    state.sourceMode === 'demo' ? state.session.terminalPaths[0]?.leafId ?? null : null
+  );
+  const projection = useMemo(
+    () => effectiveLeafId === null ? undefined : projectResume(state.session, effectiveLeafId),
+    [effectiveLeafId, state.session],
+  );
+  const defaultItem = projection?.chronology[0];
+  const effectivePilotSource: PilotSourceSelection | undefined = pilotState.selectedSource ??
+    (defaultItem === undefined ? undefined : { entryId: defaultItem.source.entryId });
+  const diagnostics = state.diagnosticOverride ?? projection?.diagnostics ?? state.session.diagnostics;
+
+  const importSessionFile = async (file: File): Promise<void> => {
+    dispatchPilot({ type: 'reset' });
+    dispatch({ type: 'import-reading', fileName: file.name });
+    try {
+      if (file.size > DEFAULT_LIMITS.maxFileBytes) {
+        throw new PiSessionFormatError('file_too_large', 'The selected file exceeds the file limit.');
+      }
+      const session = reducePiSession(parsePiSessionJsonl(await file.text()));
+      const count = session.diagnostics.length;
+      dispatch({
+        type: 'import-succeeded', session, fileName: file.name,
+        status: { tone: 'success', message: count === 0
+          ? `Imported ${file.name}. Select a terminal path to inspect it.`
+          : `Imported ${file.name} with ${count} import note${count === 1 ? '' : 's'}.` },
+      });
+    } catch (error) {
+      const diagnostic = formatImportError(error, file);
+      dispatch({ type: 'import-failed', diagnostic,
+        status: { tone: 'error', message: `Could not import ${file.name}. ${diagnostic.message} The demo transcript remains active.` } });
+    }
+  };
+
+  const revealSource = (entryId: string): void => {
+    if (projection?.chronology.some(item => item.source.entryId === entryId) !== true) return;
+    dispatchPilot({ type: 'open-source', entryId });
+    window.history.replaceState(null, '', `#source-${entryId}`);
+  };
+
+  const revealChatSource = (entryId: string, leafId: string): void => {
+    if (projection?.leafId === leafId) { revealSource(entryId); return; }
+    if (!state.session.entries.some(entry => entry.id === leafId) ||
+        !state.session.entries.some(entry => entry.id === entryId)) return;
+    dispatchPilot({ type: 'open-source', entryId });
+    dispatch({ type: 'select-leaf', leafId });
+    window.history.replaceState(null, '', `#source-${entryId}`);
+  };
+
+  const selectPath = (leafId: string | null): void => {
+    dispatchPilot({ type: 'reset' });
+    dispatch({ type: 'select-leaf', leafId });
+  };
+
+  const toggleChatSource = (entryId: string): void => {
+    dispatchPilot({ type: 'toggle-chat-source', entryId });
+  };
+
+  const forgetSession = (): void => {
+    dispatchPilot({ type: 'reset' });
+    dispatch({ type: 'forget' });
+  };
+
+  return {
+    state,
+    pilotState,
+    effectiveLeafId,
+    projection,
+    effectivePilotSource,
+    diagnostics,
+    importSessionFile,
+    revealSource,
+    revealChatSource,
+    selectPath,
+    toggleChatSource,
+    forgetSession,
+  };
+}

--- a/examples/web/src/features/resume/browser/workbench-view-model.ts
+++ b/examples/web/src/features/resume/browser/workbench-view-model.ts
@@ -1,0 +1,174 @@
+import type {
+  ActivityItem,
+  NormalizedEntry,
+  ResumeProjection,
+} from '../core/session';
+
+export interface PilotTimelinePhase {
+  readonly id: string;
+  readonly index: number;
+  readonly items: readonly ActivityItem[];
+  readonly recordedKinds: readonly string[];
+}
+
+interface OperationReference {
+  readonly entryId: string;
+  readonly name: string;
+}
+
+export interface WorkbenchViewModel {
+  readonly conversationItems: readonly ActivityItem[];
+  readonly entriesById: ReadonlyMap<string, NormalizedEntry>;
+  readonly normalizedRecord: string;
+  readonly operationIndex: Readonly<{
+    readonly calls: ReadonlyMap<string, OperationReference>;
+    readonly results: ReadonlyMap<string, OperationReference>;
+  }>;
+  readonly operationRelationship: string | undefined;
+  readonly phases: readonly PilotTimelinePhase[];
+  readonly selectedItem: ActivityItem | undefined;
+  readonly selectedItemIndex: number;
+  readonly selectedPhase: PilotTimelinePhase | undefined;
+  readonly selectedPhaseId: string | undefined;
+  readonly selectedRecord: NormalizedEntry | undefined;
+}
+
+export function activityKindLabel(item: ActivityItem): string {
+  switch (item.kind) {
+    case 'human': return 'human input';
+    case 'assistant-claim': return 'assistant claim';
+    case 'tool-evidence':
+      return item.evidenceStatus === 'observed-failure' ? 'tool failure' : 'tool evidence';
+    case 'checkpoint': return 'accepted anchor';
+    case 'compaction': return 'source summary';
+    case 'branch-summary': return 'branch context';
+    case 'omitted': return 'omitted';
+  }
+}
+
+export function normalizedEntryLabel(entry: NormalizedEntry | undefined): string {
+  if (entry === undefined) return 'withheld entry';
+  switch (entry.kind) {
+    case 'message':
+      if (entry.role === 'user') return 'user message';
+      if (entry.role === 'assistant') return 'assistant message';
+      return 'tool result';
+    case 'bashExecution': return 'bash execution';
+    case 'compaction': return 'conversation summary';
+    case 'branchSummary': return 'branch summary';
+    case 'checkpoint': return `${entry.anchorKind} checkpoint`;
+    case 'omitted': return `omitted ${entry.originalType}`;
+  }
+}
+
+function buildTimelinePhases(chronology: readonly ActivityItem[]): readonly PilotTimelinePhase[] {
+  const grouped: ActivityItem[][] = [];
+  let current: ActivityItem[] = [];
+  for (const item of chronology) {
+    if (item.kind === 'human' && current.length > 0) {
+      grouped.push(current);
+      current = [];
+    }
+    current.push(item);
+    if (item.kind === 'compaction') {
+      grouped.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) grouped.push(current);
+  return grouped.map((items, index) => {
+    const first = items[0]!;
+    const last = items[items.length - 1]!;
+    const recordedKinds = [...new Set(items.map(activityKindLabel))];
+    return {
+      id: `${first.id}-${last.id}`,
+      index,
+      items: Object.freeze([...items]),
+      recordedKinds: Object.freeze(recordedKinds),
+    };
+  });
+}
+
+function buildOperationIndex(entries: readonly NormalizedEntry[]) {
+  const calls = new Map<string, OperationReference>();
+  const results = new Map<string, OperationReference>();
+  for (const entry of entries) {
+    if (entry.kind === 'message' && entry.role === 'assistant') {
+      for (const call of entry.toolCalls) {
+        calls.set(call.id, { entryId: entry.id, name: call.name });
+      }
+    }
+    if (
+      entry.kind === 'message' &&
+      entry.role === 'toolResult' &&
+      entry.toolCallId !== undefined
+    ) {
+      results.set(entry.toolCallId, {
+        entryId: entry.id,
+        name: entry.toolName ?? 'tool',
+      });
+    }
+  }
+  return Object.freeze({ calls, results });
+}
+
+function operationRelationship(
+  selectedRecord: NormalizedEntry | undefined,
+  operationIndex: WorkbenchViewModel['operationIndex'],
+): string | undefined {
+  if (selectedRecord?.kind === 'message' && selectedRecord.role === 'assistant') {
+    const linkedResults = selectedRecord.toolCalls
+      .map(call => operationIndex.results.get(call.id))
+      .filter((result): result is OperationReference => result !== undefined);
+    if (selectedRecord.toolCalls.length > 0) {
+      return `${selectedRecord.toolCalls.map(call => call.name).join(', ')} requested · ${linkedResults.length} matching result${linkedResults.length === 1 ? '' : 's'} recorded`;
+    }
+  }
+  if (
+    selectedRecord?.kind === 'message' &&
+    selectedRecord.role === 'toolResult' &&
+    selectedRecord.toolCallId !== undefined
+  ) {
+    const request = operationIndex.calls.get(selectedRecord.toolCallId);
+    return request === undefined
+      ? 'Tool result recorded; its request is outside the selected path.'
+      : `Result for ${request.name} requested by source entry ${request.entryId}`;
+  }
+  return undefined;
+}
+
+export function buildWorkbenchView(
+  projection: ResumeProjection,
+  entries: readonly NormalizedEntry[],
+  selectedEntryId: string,
+): WorkbenchViewModel {
+  const phases = buildTimelinePhases(projection.chronology);
+  const entriesById = new Map(entries.map(entry => [entry.id, entry]));
+  const operationIndex = buildOperationIndex(entries);
+  const selectedPhaseId = phases.find(phase =>
+    phase.items.some(item => item.source.entryId === selectedEntryId),
+  )?.id;
+  const selectedItemIndex = Math.max(
+    0,
+    projection.chronology.findIndex(item => item.source.entryId === selectedEntryId),
+  );
+  const selectedItem = projection.chronology[selectedItemIndex];
+  const selectedRecord = selectedItem === undefined
+    ? undefined
+    : entriesById.get(selectedItem.source.entryId);
+  return {
+    conversationItems: projection.chronology,
+    entriesById,
+    normalizedRecord: selectedRecord === undefined
+      ? 'This entry was withheld by the bounded import policy.'
+      : JSON.stringify(selectedRecord, null, 2),
+    operationIndex,
+    operationRelationship: operationRelationship(selectedRecord, operationIndex),
+    phases,
+    selectedItem,
+    selectedItemIndex,
+    selectedPhase: phases.find(phase => phase.id === selectedPhaseId),
+    selectedPhaseId,
+    selectedRecord,
+  };
+}

--- a/examples/web/src/features/resume/browser/workbench.tsx
+++ b/examples/web/src/features/resume/browser/workbench.tsx
@@ -1,0 +1,224 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import {
+  ConversationPane,
+  type ConversationPaneHandle,
+} from './conversation-pane';
+import { EvidencePane } from './evidence-pane';
+import { TimelinePane } from './timeline-pane';
+import {
+  normalizedEntryLabel,
+  type WorkbenchViewModel,
+} from './workbench-view-model';
+
+export type WorkbenchPane = 'timeline' | 'conversation' | 'evidence';
+
+export interface WorkbenchRootProps {
+  readonly viewModel: WorkbenchViewModel;
+  readonly selectedEntryId: string;
+  readonly terminalPathId: string;
+  readonly onSelectEntry: (entryId: string) => void;
+  readonly onSelectChatSource: (entryId: string, leafId: string) => void;
+  readonly onToggleChatSource: (entryId: string) => void;
+  readonly children: ReactNode;
+}
+
+interface WorkbenchContextValue {
+  readonly viewModel: WorkbenchViewModel;
+  readonly selectedEntryId: string;
+  readonly terminalPathId: string;
+  readonly activePane: WorkbenchPane;
+  readonly setActivePane: (pane: WorkbenchPane) => void;
+  readonly selectFromTimeline: (entryId: string) => void;
+  readonly selectChatSource: (entryId: string, leafId: string) => void;
+  readonly onSelectEntry: (entryId: string) => void;
+  readonly onToggleChatSource: (entryId: string) => void;
+  readonly conversationPaneRef: RefObject<ConversationPaneHandle | null>;
+}
+
+const WorkbenchContext = createContext<WorkbenchContextValue | null>(null);
+
+function useWorkbench(): WorkbenchContextValue {
+  const context = useContext(WorkbenchContext);
+  if (context === null) throw new Error('Workbench compound children must be inside Workbench.Root.');
+  return context;
+}
+
+export function Root({
+  viewModel,
+  selectedEntryId,
+  terminalPathId,
+  onSelectEntry,
+  onSelectChatSource,
+  onToggleChatSource,
+  children,
+}: WorkbenchRootProps) {
+  const [activePane, setActivePane] = useState<WorkbenchPane>('conversation');
+  const conversationPaneRef = useRef<ConversationPaneHandle>(null);
+  const context = useMemo<WorkbenchContextValue>(() => ({
+    viewModel,
+    selectedEntryId,
+    terminalPathId,
+    activePane,
+    setActivePane,
+    selectFromTimeline: entryId => {
+      conversationPaneRef.current?.revealConversationSelection();
+      onSelectEntry(entryId);
+      setActivePane('conversation');
+    },
+    selectChatSource: (entryId, leafId) => {
+      onSelectChatSource(entryId, leafId);
+      setActivePane('evidence');
+    },
+    onSelectEntry,
+    onToggleChatSource,
+    conversationPaneRef,
+  }), [
+    activePane,
+    onSelectChatSource,
+    onSelectEntry,
+    onToggleChatSource,
+    selectedEntryId,
+    terminalPathId,
+    viewModel,
+  ]);
+  return (
+    <WorkbenchContext.Provider value={context}>
+      <section className="pilot-workbench" aria-labelledby="pilot-workbench-title">
+        {children}
+      </section>
+    </WorkbenchContext.Provider>
+  );
+}
+
+export function Tabs() {
+  const { activePane, setActivePane } = useWorkbench();
+  return (
+    <nav className="pilot-workbench-tabs" aria-label="Session understanding views">
+      {(['timeline', 'conversation', 'evidence'] as const).map(pane => (
+        <button
+          type="button"
+          data-pane={pane}
+          aria-pressed={activePane === pane}
+          key={pane}
+          onClick={() => setActivePane(pane)}
+        >
+          {pane === 'timeline' ? 'Timeline' : pane === 'conversation' ? 'Conversation' : 'Evidence'}
+        </button>
+      ))}
+    </nav>
+  );
+}
+export function Grid({ children }: { readonly children: ReactNode }) {
+  const { activePane } = useWorkbench();
+  return (
+    <div className="pilot-workbench-grid" data-active-pane={activePane}>
+      {children}
+    </div>
+  );
+}
+
+export function Timeline() {
+  const {
+    viewModel: { phases, selectedPhase, selectedPhaseId },
+    selectedEntryId,
+    selectFromTimeline,
+  } = useWorkbench();
+  return (
+    <TimelinePane
+      phases={phases}
+      selectedEntryId={selectedEntryId}
+      selectedPhase={selectedPhase}
+      selectedPhaseId={selectedPhaseId}
+      formatTime={formatWorkbenchTime}
+      onSelectEntry={selectFromTimeline}
+    />
+  );
+}
+
+export function Conversation() {
+  const {
+    viewModel: {
+      conversationItems,
+      entriesById,
+      operationIndex,
+      selectedItemIndex,
+    },
+    selectedEntryId,
+    activePane,
+    conversationPaneRef,
+    onSelectEntry,
+  } = useWorkbench();
+  return (
+    <ConversationPane
+      ref={conversationPaneRef}
+      active={activePane === 'conversation'}
+      conversationItems={conversationItems}
+      entriesById={entriesById}
+      operationIndex={operationIndex}
+      selectedEntryId={selectedEntryId}
+      selectedItemIndex={selectedItemIndex}
+      totalEvents={conversationItems.length}
+      formatTime={formatWorkbenchTime}
+      onSelectEntry={onSelectEntry}
+    />
+  );
+}
+
+export function Evidence({ children }: { readonly children: ReactNode }) {
+  const {
+    viewModel: {
+      normalizedRecord,
+      operationRelationship,
+      selectedItem,
+      selectedItemIndex,
+      selectedRecord,
+      conversationItems,
+    },
+    selectedEntryId,
+    terminalPathId,
+  } = useWorkbench();
+  return (
+    <EvidencePane
+      chat={children}
+      normalizedRecord={normalizedRecord}
+      operationRelationship={operationRelationship}
+      selectedEntryId={selectedEntryId}
+      selectedItem={selectedItem}
+      selectedItemIndex={selectedItemIndex}
+      selectedRecord={selectedRecord}
+      terminalPathId={terminalPathId}
+      totalItems={conversationItems.length}
+      formatTime={formatWorkbenchTime}
+      normalizedEntryLabel={normalizedEntryLabel}
+    />
+  );
+}
+
+const workbenchTimeFormat = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+function formatWorkbenchTime(value: string): string {
+  return workbenchTimeFormat.format(new Date(value));
+}
+
+export const Workbench = {
+  Root,
+  Tabs,
+  Grid,
+  Timeline,
+  Conversation,
+  Evidence,
+} as const;
+
+export { useWorkbench };

--- a/examples/web/src/features/resume/browser/workbench.tsx
+++ b/examples/web/src/features/resume/browser/workbench.tsx
@@ -30,10 +30,13 @@ export interface WorkbenchRootProps {
   readonly children: ReactNode;
 }
 
-interface WorkbenchContextValue {
+interface WorkbenchViewContextValue {
   readonly viewModel: WorkbenchViewModel;
   readonly selectedEntryId: string;
   readonly terminalPathId: string;
+}
+
+interface WorkbenchNavigationContextValue {
   readonly activePane: WorkbenchPane;
   readonly setActivePane: (pane: WorkbenchPane) => void;
   readonly selectFromTimeline: (entryId: string) => void;
@@ -43,10 +46,17 @@ interface WorkbenchContextValue {
   readonly conversationPaneRef: RefObject<ConversationPaneHandle | null>;
 }
 
-const WorkbenchContext = createContext<WorkbenchContextValue | null>(null);
+const WorkbenchViewContext = createContext<WorkbenchViewContextValue | null>(null);
+const WorkbenchNavigationContext = createContext<WorkbenchNavigationContextValue | null>(null);
 
-function useWorkbench(): WorkbenchContextValue {
-  const context = useContext(WorkbenchContext);
+function useWorkbenchView(): WorkbenchViewContextValue {
+  const context = useContext(WorkbenchViewContext);
+  if (context === null) throw new Error('Workbench compound children must be inside Workbench.Root.');
+  return context;
+}
+
+function useWorkbenchNavigation(): WorkbenchNavigationContextValue {
+  const context = useContext(WorkbenchNavigationContext);
   if (context === null) throw new Error('Workbench compound children must be inside Workbench.Root.');
   return context;
 }
@@ -62,10 +72,12 @@ export function Root({
 }: WorkbenchRootProps) {
   const [activePane, setActivePane] = useState<WorkbenchPane>('conversation');
   const conversationPaneRef = useRef<ConversationPaneHandle>(null);
-  const context = useMemo<WorkbenchContextValue>(() => ({
+  const viewContext = useMemo<WorkbenchViewContextValue>(() => ({
     viewModel,
     selectedEntryId,
     terminalPathId,
+  }), [selectedEntryId, terminalPathId, viewModel]);
+  const navigationContext = useMemo<WorkbenchNavigationContextValue>(() => ({
     activePane,
     setActivePane,
     selectFromTimeline: entryId => {
@@ -80,26 +92,20 @@ export function Root({
     onSelectEntry,
     onToggleChatSource,
     conversationPaneRef,
-  }), [
-    activePane,
-    onSelectChatSource,
-    onSelectEntry,
-    onToggleChatSource,
-    selectedEntryId,
-    terminalPathId,
-    viewModel,
-  ]);
+  }), [activePane, onSelectChatSource, onSelectEntry, onToggleChatSource]);
   return (
-    <WorkbenchContext.Provider value={context}>
-      <section className="pilot-workbench" aria-labelledby="pilot-workbench-title">
-        {children}
-      </section>
-    </WorkbenchContext.Provider>
+    <WorkbenchViewContext.Provider value={viewContext}>
+      <WorkbenchNavigationContext.Provider value={navigationContext}>
+        <section className="pilot-workbench" aria-labelledby="pilot-workbench-title">
+          {children}
+        </section>
+      </WorkbenchNavigationContext.Provider>
+    </WorkbenchViewContext.Provider>
   );
 }
 
 export function Tabs() {
-  const { activePane, setActivePane } = useWorkbench();
+  const { activePane, setActivePane } = useWorkbenchNavigation();
   return (
     <nav className="pilot-workbench-tabs" aria-label="Session understanding views">
       {(['timeline', 'conversation', 'evidence'] as const).map(pane => (
@@ -117,7 +123,7 @@ export function Tabs() {
   );
 }
 export function Grid({ children }: { readonly children: ReactNode }) {
-  const { activePane } = useWorkbench();
+  const { activePane } = useWorkbenchNavigation();
   return (
     <div className="pilot-workbench-grid" data-active-pane={activePane}>
       {children}
@@ -129,8 +135,8 @@ export function Timeline() {
   const {
     viewModel: { phases, selectedPhase, selectedPhaseId },
     selectedEntryId,
-    selectFromTimeline,
-  } = useWorkbench();
+  } = useWorkbenchView();
+  const { selectFromTimeline } = useWorkbenchNavigation();
   return (
     <TimelinePane
       phases={phases}
@@ -152,10 +158,12 @@ export function Conversation() {
       selectedItemIndex,
     },
     selectedEntryId,
+  } = useWorkbenchView();
+  const {
     activePane,
     conversationPaneRef,
     onSelectEntry,
-  } = useWorkbench();
+  } = useWorkbenchNavigation();
   return (
     <ConversationPane
       ref={conversationPaneRef}
@@ -184,7 +192,7 @@ export function Evidence({ children }: { readonly children: ReactNode }) {
     },
     selectedEntryId,
     terminalPathId,
-  } = useWorkbench();
+  } = useWorkbenchView();
   return (
     <EvidencePane
       chat={children}
@@ -221,4 +229,4 @@ export const Workbench = {
   Evidence,
 } as const;
 
-export { useWorkbench };
+export { useWorkbenchNavigation };

--- a/examples/web/tests/resume-state.spec.ts
+++ b/examples/web/tests/resume-state.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+import {
+  createResumeReducer,
+  createResumeState,
+  reducePilotViewState,
+  initialPilotViewState,
+  type PilotViewState,
+  type ResumeState,
+} from '../src/features/resume/browser/resume-reducer';
+import { type ReducedPiSession, type ResumeDiagnostic } from '../src/features/resume/core/session';
+import { PKE_CHAT_SOURCE_LIMIT } from '../src/features/resume/protocol/chat';
+
+const dummySession: ReducedPiSession = {
+  header: { sessionId: 'test', version: 3, timestamp: '2024-01-01T00:00:00Z', cwd: '/' },
+  entries: Object.freeze([]),
+  terminalPaths: Object.freeze([]),
+  diagnostics: Object.freeze([]),
+};
+
+const baseline = createResumeState(dummySession);
+const reduceResumeState = createResumeReducer(baseline);
+
+test('import-reading sets isImporting and clears selectedLeafId', () => {
+  const initial = createResumeState(dummySession);
+  const withSelection: ResumeState = { ...initial, selectedLeafId: 'leaf-1' };
+  const result = reduceResumeState(withSelection, {
+    type: 'import-reading',
+    fileName: 'session.jsonl',
+  });
+
+  expect(result.selectedLeafId).toBeNull();
+  expect(result.isImporting).toBe(true);
+  expect(result.importStatus.message).toBe('Reading session.jsonl in this tab\u2026');
+  expect(result.importStatus.tone).toBe('idle');
+  expect(result.fileInputGeneration).toBe(1);
+});
+
+test('select-leaf clears diagnosticOverride', () => {
+  const initial = createResumeState(dummySession);
+  const withDiagnostic: ResumeState = {
+    ...initial,
+    diagnosticOverride: [{ severity: 'error', code: 'test', message: 'test error' }],
+  };
+  const result = reduceResumeState(withDiagnostic, {
+    type: 'select-leaf',
+    leafId: 'leaf-2',
+  });
+
+  expect(result.selectedLeafId).toBe('leaf-2');
+  expect(result.diagnosticOverride).toBeUndefined();
+});
+
+test('select-leaf with null clears selection and diagnostics', () => {
+  const initial = createResumeState(dummySession);
+  const withSelection: ResumeState = {
+    ...initial,
+    selectedLeafId: 'leaf-1',
+    diagnosticOverride: [{ severity: 'warning', code: 'warn', message: 'warn msg' }],
+  };
+  const result = reduceResumeState(withSelection, { type: 'select-leaf', leafId: null });
+
+  expect(result.selectedLeafId).toBeNull();
+  expect(result.diagnosticOverride).toBeUndefined();
+});
+
+test('forget restores baseline session', () => {
+  const initial = createResumeState(dummySession);
+  const importedSession: ReducedPiSession = {
+    header: { sessionId: 'imported', version: 3, timestamp: '2024-02-01T00:00:00Z', cwd: '/other' },
+    entries: Object.freeze([]),
+    terminalPaths: Object.freeze([]),
+    diagnostics: Object.freeze([]),
+  };
+  const withImport: ResumeState = {
+    ...initial,
+    session: importedSession,
+    sourceMode: 'imported',
+    importedFileName: 'session.jsonl',
+    selectedLeafId: 'leaf-1',
+    isImporting: false,
+    importStatus: { message: 'Imported.', tone: 'success' },
+  };
+  const result = reduceResumeState(withImport, { type: 'forget' });
+
+  expect(result.session).toBe(dummySession);
+  expect(result.session.header.sessionId).toBe('test');
+  expect(result.sourceMode).toBe('demo');
+  expect(result.importedFileName).toBeUndefined();
+  expect(result.selectedLeafId).toBeNull();
+  expect(result.isImporting).toBe(false);
+  expect(result.importStatus.message).toContain('forgotten');
+  expect(result.fileInputGeneration).toBe(1);
+});
+
+test('import-failed restores baseline session with diagnostic', () => {
+  const initial = createResumeState(dummySession);
+  const importedSession: ReducedPiSession = {
+    header: { sessionId: 'imported', version: 3, timestamp: '2024-02-01T00:00:00Z', cwd: '/other' },
+    entries: Object.freeze([]),
+    terminalPaths: Object.freeze([]),
+    diagnostics: Object.freeze([]),
+  };
+  const withImport: ResumeState = {
+    ...initial,
+    session: importedSession,
+    sourceMode: 'imported',
+    importedFileName: 'session.jsonl',
+    diagnosticOverride: undefined,
+  };
+  const diagnostic: ResumeDiagnostic = { severity: 'error', code: 'parse_failed', message: 'Bad format' };
+  const result = reduceResumeState(withImport, {
+    type: 'import-failed',
+    diagnostic,
+    status: { message: 'Import failed. Demo active.', tone: 'error' },
+  });
+
+  expect(result.session).toBe(dummySession);
+  expect(result.session.header.sessionId).toBe('test');
+  expect(result.sourceMode).toBe('demo');
+  expect(result.importedFileName).toBeUndefined();
+  expect(result.isImporting).toBe(false);
+  expect(result.diagnosticOverride).toEqual([diagnostic]);
+  expect(result.importStatus.tone).toBe('error');
+  expect(result.fileInputGeneration).toBe(1);
+});
+
+test('toggle-chat-source caps at PKE_CHAT_SOURCE_LIMIT', () => {
+  const limit = PKE_CHAT_SOURCE_LIMIT;
+  let state: PilotViewState = initialPilotViewState;
+
+  for (let i = 0; i < limit; i++) {
+    state = reducePilotViewState(state, {
+      type: 'toggle-chat-source',
+      entryId: `entry-${i}`,
+    });
+    expect(state.chatSourceEntryIds.length).toBe(i + 1);
+  }
+
+  // Exceeding the limit is a no-op
+  state = reducePilotViewState(state, {
+    type: 'toggle-chat-source',
+    entryId: 'overflow',
+  });
+  expect(state.chatSourceEntryIds.length).toBe(limit);
+});
+
+test('toggle-chat-source preserves insertion order', () => {
+  let state: PilotViewState = initialPilotViewState;
+
+  state = reducePilotViewState(state, { type: 'toggle-chat-source', entryId: 'a' });
+  state = reducePilotViewState(state, { type: 'toggle-chat-source', entryId: 'b' });
+  state = reducePilotViewState(state, { type: 'toggle-chat-source', entryId: 'c' });
+  expect(state.chatSourceEntryIds).toEqual(['a', 'b', 'c']);
+
+  // Toggling an existing entry removes it
+  state = reducePilotViewState(state, { type: 'toggle-chat-source', entryId: 'b' });
+  expect(state.chatSourceEntryIds).toEqual(['a', 'c']);
+
+  // Re-toggling appends at the end
+  state = reducePilotViewState(state, { type: 'toggle-chat-source', entryId: 'b' });
+  expect(state.chatSourceEntryIds).toEqual(['a', 'c', 'b']);
+});
+
+test('reset clears pilot view state', () => {
+  let state: PilotViewState = {
+    selectedSource: { entryId: 'src-1' },
+    chatSourceEntryIds: Object.freeze(['a', 'b']),
+  };
+  state = reducePilotViewState(state, { type: 'reset' });
+  expect(state.chatSourceEntryIds).toEqual([]);
+  expect(state.selectedSource).toBeUndefined();
+});

--- a/examples/web/tests/resume-state.spec.ts
+++ b/examples/web/tests/resume-state.spec.ts
@@ -20,15 +20,20 @@ const dummySession: ReducedPiSession = {
 const baseline = createResumeState(dummySession);
 const reduceResumeState = createResumeReducer(baseline);
 
-test('import-reading sets isImporting and clears selectedLeafId', () => {
+test('import-reading clears selection and stale diagnostics', () => {
   const initial = createResumeState(dummySession);
-  const withSelection: ResumeState = { ...initial, selectedLeafId: 'leaf-1' };
+  const withSelection: ResumeState = {
+    ...initial,
+    selectedLeafId: 'leaf-1',
+    diagnosticOverride: [{ severity: 'error', code: 'old', message: 'old failure' }],
+  };
   const result = reduceResumeState(withSelection, {
     type: 'import-reading',
     fileName: 'session.jsonl',
   });
 
   expect(result.selectedLeafId).toBeNull();
+  expect(result.diagnosticOverride).toBeUndefined();
   expect(result.isImporting).toBe(true);
   expect(result.importStatus.message).toBe('Reading session.jsonl in this tab\u2026');
   expect(result.importStatus.tone).toBe('idle');

--- a/examples/web/tests/workbench-view-model.spec.ts
+++ b/examples/web/tests/workbench-view-model.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import {
+  parsePiSessionJsonl,
+  projectResume,
+  reducePiSession,
+} from '../src/features/resume/core/session';
+import { buildWorkbenchView } from '../src/features/resume/browser/workbench-view-model';
+const fixtureSource = readFileSync(
+  new URL('./fixtures/pi-session-v3.jsonl', import.meta.url),
+  'utf8',
+);
+
+const session = reducePiSession(parsePiSessionJsonl(fixtureSource));
+const projection = projectResume(session, session.terminalPaths[0]!.leafId);
+
+test('partitions chronology at human inputs and compactions', () => {
+  const view = buildWorkbenchView(projection, session.entries, projection.chronology[0]!.source.entryId);
+  const flattened = view.phases.flatMap(phase => phase.items);
+
+  expect(flattened).toEqual(projection.chronology);
+  for (const phase of view.phases.slice(1)) {
+    const firstIndex = projection.chronology.indexOf(phase.items[0]!);
+    const previous = projection.chronology[firstIndex - 1]!;
+    expect(
+      phase.items[0]!.kind === 'human' || previous.kind === 'compaction',
+    ).toBe(true);
+  }
+});
+
+test('links selected assistant operations to recorded results', () => {
+  const assistant = session.entries.find(entry =>
+    entry.kind === 'message' && entry.role === 'assistant' && entry.toolCalls.length > 0,
+  );
+  expect(assistant).toBeDefined();
+  if (assistant === undefined) return;
+
+  const view = buildWorkbenchView(projection, session.entries, assistant.id);
+  expect(view.operationRelationship).toContain('requested');
+  expect(view.operationRelationship).toContain(assistant.toolCalls[0]!.name);
+});
+
+test('falls back to the first chronology item for an absent selection', () => {
+  const view = buildWorkbenchView(projection, session.entries, 'missing-entry');
+
+  expect(view.selectedItemIndex).toBe(0);
+  expect(view.selectedItem).toEqual(projection.chronology[0]);
+});


### PR DESCRIPTION
## Summary
- Extract Resume browser state, PKE lifecycle, and pure workbench derivation from the main Resume view.
- Compose Timeline, Conversation, and Evidence through a typed Workbench.Root compound boundary.
- Split immutable view data from navigation context and add fixture-free reducer transition tests.
- Clear stale diagnostics when a new import begins.

## Validation
- `npm run typecheck`
- `npx playwright test tests/pi-resume.spec.ts tests/workbench-view-model.spec.ts tests/resume-state.spec.ts` — 26 passed
- `npm run check:boundaries`
- `npm run build`

## Design
- Root owns active-pane and cross-pane routing; panes retain local interaction state and DOM capabilities.
- `createResumeReducer(baseline)` is shared by the Vite-facing app and Node-side transition tests.

## Reuse check
- Reused React useReducer, useMemo, useRef, Context, and useImperativeHandle at existing ownership boundaries.
- Reused existing Resume session projection, PKE protocol limits, and Playwright conventions.
- No generic collection helper or container was introduced.