### PR TITLE
fix(btree): balance arbitrary-cardinality callback splices

### DIFF
--- a/lib/btree/README.md
+++ b/lib/btree/README.md
@@ -56,9 +56,9 @@ tree.init_root({ text: "hello", len: 5 }, 5)
 | `BTree::new(min_degree?)` | Create empty tree (default min_degree=10) | O(1) |
 | `get_at(pos)` | Element at span position | O(log n) |
 | `find(pos)` | Element + offset within element | O(log n) |
-| `mutate_for_insert(pos, callback)` | Insert via leaf splice callback | O(log n) |
-| `mutate_for_delete(pos, callback)` | Delete via leaf splice callback | O(log n) |
-| `delete_range(start, end)` | Delete span range [start, end), with boundary repair/merge | O(log n) path planning/splice; O(n) current worst-case repair* |
+| `mutate_for_insert(pos, callback)` | Insert via leaf splice callback | O(k + log n) at fixed t |
+| `mutate_for_delete(pos, callback)` | Delete via leaf splice callback | O(k + log n) at fixed t |
+| `delete_range(start, end)` | Delete span range [start, end), with boundary repair/merge | O(log n) path planning/splice; O(n) repair worst case |
 | `from_sorted(items, min_degree?)` | Bulk-build from sorted `(elem, span)` pairs | O(n) |
 | `view(start?, end?)` | Slice elements in range | O(k + log n) |
 | `iter()` | Lazy cursor-based iterator | O(n) total |
@@ -67,7 +67,13 @@ tree.init_root({ text: "hello", len: 5 }, 5)
 | `span()` | Total span (cached) | O(1) |
 | `size()` | Number of leaves | O(1) |
 
-*Current worst-case repair can visit every child in the repaired subtree after range deletion.
+For callback splices, `k` is the number of replacement leaves and `t` is the
+minimum degree. More exactly, propagation is linear in the changed segment and
+logarithmic in unaffected height; current bulk underflow repair gives
+`O(k + t² log_t n)`.
+
+Current worst-case range-delete repair can visit every child in the repaired
+subtree.
 
 ## API Contracts
 
@@ -137,7 +143,11 @@ current leaf parent's child array. Callers must maintain
 `0 <= start_idx <= end_idx <= parent child count`; arbitrary invalid indices
 are not separately validated.
 
-`new_leaves` replace that interval in order.
+`new_leaves` replace that interval in order. It may contain any number of
+leaves representable in memory; propagation partitions the complete replacement
+into as many balanced nodes and root levels as required rather than imposing a
+cardinality limit.
+
 Every replacement span must be positive, or propagation aborts with
 `BTree splice: leaf spans must be positive`. Their prospective cumulative
 total must also satisfy the cumulative span range above.

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -156,19 +156,25 @@ pub fn[T : BTreeElem] BTree::delete_range(
       let propagated = propagate_node_splice(splice, self.min_degree)
       // Keep every range-delete phase on an unpublished candidate. A late
       // boundary-merge or repair rejection must leave the original tree intact.
-      let new_root = propagated.root_candidate(normalize_delete=false).unwrap()
-      let (merged_root, boundary_merged) = normalize_boundary_merge(
-        new_root,
-        start,
-        self.min_degree,
-      )
-      // Collapse unary root wrappers, fix underfull descendants, then
-      // collapse again (fix_merged_chain may create new unary roots via merge).
-      let final_root = match normalize_root_after_delete(merged_root) {
-        None => None
-        Some(collapsed) => {
-          let fixed = fix_merged_chain(collapsed, self.min_degree)
-          normalize_root_after_delete(fixed)
+      let (final_root, boundary_merged) = match
+        propagated.root_candidate(self.min_degree, normalize_delete=false) {
+        None => (None, false)
+        Some(new_root) => {
+          let (merged_root, boundary_merged) = normalize_boundary_merge(
+            new_root,
+            start,
+            self.min_degree,
+          )
+          // Collapse unary root wrappers, fix underfull descendants, then
+          // collapse again (fix_merged_chain may create new unary roots).
+          let final_root = match normalize_root_after_delete(merged_root) {
+            None => None
+            Some(collapsed) => {
+              let fixed = fix_merged_chain(collapsed, self.min_degree)
+              normalize_root_after_delete(fixed)
+            }
+          }
+          (final_root, boundary_merged)
         }
       }
       let final_size = self.size +
@@ -183,16 +189,19 @@ pub fn[T : BTreeElem] BTree::delete_range(
 ///|
 fn[T] PropagateResult::root_candidate(
   self : PropagateResult[T],
+  min_degree : Int,
   normalize_delete~ : Bool,
 ) -> BTreeNode[T]? {
-  match self.overflow {
-    None =>
-      if normalize_delete {
-        normalize_root_after_delete(self.node)
-      } else {
-        Some(self.node)
-      }
-    Some(sibling) => Some(make_internal([self.node, sibling]))
+  guard !self.segment.is_empty() else { return None }
+  let mut segment = self.segment
+  while segment.length() > 1 {
+    segment = pack_level(segment, min_degree)
+  }
+  let root = segment[0]
+  if normalize_delete {
+    normalize_root_after_delete(root)
+  } else {
+    Some(root)
   }
 }
 
@@ -202,7 +211,7 @@ fn[T] BTree::apply_propagated(
   propagated : PropagateResult[T],
   normalize_delete~ : Bool,
 ) -> Unit {
-  let next_root = propagated.root_candidate(normalize_delete~)
+  let next_root = propagated.root_candidate(self.min_degree, normalize_delete~)
   let next_size = self.size + propagated.leaf_delta
   self.root = next_root
   self.size = next_size
@@ -230,27 +239,7 @@ pub fn[T] BTree::from_sorted(
     Leaf(elem=pair.0, span=pair.1)
   })
   while nodes.length() > max_degree {
-    let next : Array[BTreeNode[T]] = []
-    let mut i = 0
-    while i < nodes.length() {
-      let remaining = nodes.length() - i
-      // Redistribute when the leftover would violate min_degree
-      let chunk_size = if remaining > max_degree &&
-        remaining - max_degree < min_degree {
-        remaining / 2
-      } else if remaining <= max_degree {
-        remaining
-      } else {
-        max_degree
-      }
-      let chunk : Array[BTreeNode[T]] = []
-      for j in i..<(i + chunk_size) {
-        chunk.push(nodes[j])
-      }
-      next.push(make_internal(chunk))
-      i = i + chunk_size
-    }
-    nodes = next
+    nodes = pack_level(nodes, min_degree)
   }
   let root = make_internal(nodes)
   { root: Some(root), min_degree, size: items.length() }

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -469,6 +469,119 @@ fn prop_from_sorted_exact_content(case_ : FromSortedCase) -> Bool {
 }
 
 ///|
+enum ArbitrarySpliceShape {
+  Overflow(Int)
+  Borrow
+  Merge
+} derive(Debug)
+
+///|
+struct ArbitrarySpliceCase {
+  min_degree : Int
+  shape : ArbitrarySpliceShape
+} derive(Debug)
+
+///|
+impl @quickcheck.Arbitrary for ArbitrarySpliceCase with fn arbitrary(_size, rs) {
+  let min_degree = match rs.split().next_positive_int() % 3 {
+    0 => 2
+    1 => 3
+    _ => DEFAULT_MIN_DEGREE
+  }
+  let max_degree = 2 * min_degree
+  let shape = match rs.split().next_positive_int() % 3 {
+    0 => {
+      let cardinalities = [
+        0,
+        1,
+        2,
+        max_degree,
+        max_degree + 1,
+        2 * max_degree,
+        2 * max_degree + 1,
+        max_degree * max_degree + 1,
+      ]
+      let idx = rs.split().next_positive_int() % cardinalities.length()
+      Overflow(cardinalities[idx])
+    }
+    1 => Borrow
+    _ => Merge
+  }
+  { min_degree, shape }
+}
+
+///|
+fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
+  let min_degree = case_.min_degree
+  match case_.shape {
+    Overflow(cardinality) => {
+      let t : BTree[TItem] = BTree::from_sorted(
+        [(make_item(0, 1), 1)],
+        min_degree~,
+      )
+      let expected = Array::makei(cardinality, i => make_item(i + 1, 1))
+      t.mutate_for_insert(0, ctx => {
+        start_idx: ctx.child_idx,
+        end_idx: ctx.child_idx + 1,
+        new_leaves: expected.map(item => (item, item.span)),
+      })
+      tree_matches_model(t, expected)
+    }
+    Borrow => {
+      let donor_count = 2 * min_degree
+      let target_count = min_degree
+      let donor = make_internal(
+        Array::makei(donor_count, i => Leaf(elem=make_item(i, 1), span=1)),
+      )
+      let target = make_internal(
+        Array::makei(target_count, i => {
+          Leaf(elem=make_item(donor_count + i, 1), span=1)
+        }),
+      )
+      let t : BTree[TItem] = {
+        root: Some(make_internal([donor, target])),
+        min_degree,
+        size: donor_count + target_count,
+      }
+      let replacement = make_item(donor_count + target_count, 1)
+      t.mutate_for_insert(donor_count + 1, _ctx => {
+        start_idx: 0,
+        end_idx: target_count,
+        new_leaves: [(replacement, 1)],
+      })
+      let expected = Array::makei(donor_count, i => make_item(i, 1))
+      expected.push(replacement)
+      tree_matches_model(t, expected)
+    }
+    Merge => {
+      let sibling_count = min_degree
+      let left = make_internal(
+        Array::makei(sibling_count, i => Leaf(elem=make_item(i, 1), span=1)),
+      )
+      let right = make_internal(
+        Array::makei(sibling_count, i => {
+          Leaf(elem=make_item(sibling_count + i, 1), span=1)
+        }),
+      )
+      let t : BTree[TItem] = {
+        root: Some(make_internal([left, right])),
+        min_degree,
+        size: 2 * sibling_count,
+      }
+      let replacement = make_item(2 * sibling_count, 1)
+      t.mutate_for_insert(sibling_count + 1, _ctx => {
+        start_idx: 0,
+        end_idx: sibling_count,
+        new_leaves: [(replacement, 1)],
+      })
+      let expected = Array::makei(sibling_count, i => make_item(i, 1))
+      expected.push(replacement)
+      tree_matches_model(t, expected)
+    }
+  }
+}
+
+///|
 enum ModelOp {
   Append(Int, Int)
   Insert(Int, Int, Int)
@@ -732,6 +845,95 @@ test "property: from_sorted exact content matches array model" {
 ///|
 test "property: operation sequences match array model" {
   @qc.quick_check_fn(prop_operation_sequence_matches_model)
+}
+
+///|
+test "arbitrary callback splice cardinality and repair boundary matrix" {
+  for min_degree in [2, 3, DEFAULT_MIN_DEGREE] {
+    let max_degree = 2 * min_degree
+    for
+      cardinality in [
+        0,
+        1,
+        2,
+        max_degree,
+        max_degree + 1,
+        2 * max_degree,
+        2 * max_degree + 1,
+        max_degree * max_degree + 1,
+      ] {
+      inspect(
+        arbitrary_splice_case_matches_model({
+          min_degree,
+          shape: Overflow(cardinality),
+        }),
+        content="true",
+      )
+    }
+    inspect(
+      arbitrary_splice_case_matches_model({ min_degree, shape: Borrow }),
+      content="true",
+    )
+    inspect(
+      arbitrary_splice_case_matches_model({ min_degree, shape: Merge }),
+      content="true",
+    )
+  }
+}
+
+///|
+test "quickcheck arbitrary callback splice generator reaches stress paths" {
+  let samples : Array[ArbitrarySpliceCase] = @quickcheck.samples(400)
+  let mut saw_multi_output = false
+  let mut saw_extra_root_level = false
+  let mut saw_multi_child_underflow_repair = false
+  let mut saw_borrow_degree_2 = false
+  let mut saw_borrow_degree_3 = false
+  let mut saw_borrow_default_degree = false
+  let mut saw_merge_degree_2 = false
+  let mut saw_merge_degree_3 = false
+  let mut saw_merge_default_degree = false
+  for case_ in samples {
+    guard arbitrary_splice_case_matches_model(case_) else {
+      fail("generated arbitrary splice diverged from model")
+    }
+    match case_.shape {
+      Overflow(cardinality) => {
+        let max_degree = 2 * case_.min_degree
+        if cardinality > 2 * max_degree {
+          saw_multi_output = true
+        }
+        if cardinality > max_degree * max_degree {
+          saw_extra_root_level = true
+        }
+      }
+      Borrow => {
+        if case_.min_degree > 2 {
+          saw_multi_child_underflow_repair = true
+        }
+        match case_.min_degree {
+          2 => saw_borrow_degree_2 = true
+          3 => saw_borrow_degree_3 = true
+          _ => saw_borrow_default_degree = true
+        }
+      }
+      Merge =>
+        match case_.min_degree {
+          2 => saw_merge_degree_2 = true
+          3 => saw_merge_degree_3 = true
+          _ => saw_merge_default_degree = true
+        }
+    }
+  }
+  inspect(saw_multi_output, content="true")
+  inspect(saw_extra_root_level, content="true")
+  inspect(saw_multi_child_underflow_repair, content="true")
+  inspect(saw_borrow_degree_2, content="true")
+  inspect(saw_borrow_degree_3, content="true")
+  inspect(saw_borrow_default_degree, content="true")
+  inspect(saw_merge_degree_2, content="true")
+  inspect(saw_merge_degree_3, content="true")
+  inspect(saw_merge_default_degree, content="true")
 }
 
 ///|

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -471,8 +471,9 @@ fn prop_from_sorted_exact_content(case_ : FromSortedCase) -> Bool {
 ///|
 enum ArbitrarySpliceShape {
   Overflow(Int)
-  Borrow
+  BulkBorrow
   Merge
+  RepeatedMerge
 } derive(Debug)
 
 ///|
@@ -489,7 +490,7 @@ impl @quickcheck.Arbitrary for ArbitrarySpliceCase with fn arbitrary(_size, rs) 
     _ => DEFAULT_MIN_DEGREE
   }
   let max_degree = 2 * min_degree
-  let shape = match rs.split().next_positive_int() % 3 {
+  let shape = match rs.split().next_positive_int() % 4 {
     0 => {
       let cardinalities = [
         0,
@@ -504,8 +505,9 @@ impl @quickcheck.Arbitrary for ArbitrarySpliceCase with fn arbitrary(_size, rs) 
       let idx = rs.split().next_positive_int() % cardinalities.length()
       Overflow(cardinalities[idx])
     }
-    1 => Borrow
-    _ => Merge
+    1 => BulkBorrow
+    2 => Merge
+    _ => RepeatedMerge
   }
   { min_degree, shape }
 }
@@ -527,7 +529,7 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
       })
       tree_matches_model(t, expected)
     }
-    Borrow => {
+    BulkBorrow => {
       let donor_count = 2 * min_degree
       let target_count = min_degree
       let donor = make_internal(
@@ -543,14 +545,12 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
         min_degree,
         size: donor_count + target_count,
       }
-      let replacement = make_item(donor_count + target_count, 1)
       t.mutate_for_insert(donor_count + 1, _ctx => {
         start_idx: 0,
         end_idx: target_count,
-        new_leaves: [(replacement, 1)],
+        new_leaves: [],
       })
       let expected = Array::makei(donor_count, i => make_item(i, 1))
-      expected.push(replacement)
       tree_matches_model(t, expected)
     }
     Merge => {
@@ -568,14 +568,52 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
         min_degree,
         size: 2 * sibling_count,
       }
-      let replacement = make_item(2 * sibling_count, 1)
       t.mutate_for_insert(sibling_count + 1, _ctx => {
         start_idx: 0,
         end_idx: sibling_count,
-        new_leaves: [(replacement, 1)],
+        new_leaves: [],
       })
       let expected = Array::makei(sibling_count, i => make_item(i, 1))
-      expected.push(replacement)
+      tree_matches_model(t, expected)
+    }
+    RepeatedMerge => {
+      let old = make_internal(
+        Array::makei(min_degree, i => Leaf(elem=make_item(1000 + i, 1), span=1)),
+      )
+      let underfull_count = min_degree + 1
+      let new_children : Array[BTreeNode[TItem]] = Array::makei(
+        underfull_count,
+        i => make_internal([Leaf(elem=make_item(i, 1), span=1)]),
+      )
+      new_children.push(
+        make_internal(
+          Array::makei(2 * min_degree, i => {
+            Leaf(elem=make_item(underfull_count + i, 1), span=1)
+          }),
+        ),
+      )
+      let new_leaf_count = underfull_count + 2 * min_degree
+      let result = propagate_node_splice(
+        {
+          prefix: [],
+          children: [old],
+          counts: [old.total()],
+          start_idx: 0,
+          end_idx: 1,
+          new_children,
+          leaf_delta: new_leaf_count - min_degree,
+        },
+        min_degree,
+      )
+      let root = result
+        .root_candidate(min_degree, normalize_delete=false)
+        .unwrap()
+      let t : BTree[TItem] = {
+        root: Some(root),
+        min_degree,
+        size: new_leaf_count,
+      }
+      let expected = Array::makei(new_leaf_count, i => make_item(i, 1))
       tree_matches_model(t, expected)
     }
   }
@@ -848,7 +886,7 @@ test "property: operation sequences match array model" {
 }
 
 ///|
-test "arbitrary callback splice cardinality and repair boundary matrix" {
+test "arbitrary splice propagation cardinality and repair boundary matrix" {
   for min_degree in [2, 3, DEFAULT_MIN_DEGREE] {
     let max_degree = 2 * min_degree
     for
@@ -871,28 +909,35 @@ test "arbitrary callback splice cardinality and repair boundary matrix" {
       )
     }
     inspect(
-      arbitrary_splice_case_matches_model({ min_degree, shape: Borrow }),
+      arbitrary_splice_case_matches_model({ min_degree, shape: BulkBorrow }),
       content="true",
     )
     inspect(
       arbitrary_splice_case_matches_model({ min_degree, shape: Merge }),
       content="true",
     )
+    inspect(
+      arbitrary_splice_case_matches_model({ min_degree, shape: RepeatedMerge }),
+      content="true",
+    )
   }
 }
 
 ///|
-test "quickcheck arbitrary callback splice generator reaches stress paths" {
+test "quickcheck arbitrary splice generator reaches stress paths" {
   let samples : Array[ArbitrarySpliceCase] = @quickcheck.samples(400)
   let mut saw_multi_output = false
   let mut saw_extra_root_level = false
   let mut saw_multi_child_underflow_repair = false
-  let mut saw_borrow_degree_2 = false
-  let mut saw_borrow_degree_3 = false
-  let mut saw_borrow_default_degree = false
+  let mut saw_bulk_borrow_degree_2 = false
+  let mut saw_bulk_borrow_degree_3 = false
+  let mut saw_bulk_borrow_default_degree = false
   let mut saw_merge_degree_2 = false
   let mut saw_merge_degree_3 = false
   let mut saw_merge_default_degree = false
+  let mut saw_repeated_merge_degree_2 = false
+  let mut saw_repeated_merge_degree_3 = false
+  let mut saw_repeated_merge_default_degree = false
   for case_ in samples {
     guard arbitrary_splice_case_matches_model(case_) else {
       fail("generated arbitrary splice diverged from model")
@@ -907,14 +952,12 @@ test "quickcheck arbitrary callback splice generator reaches stress paths" {
           saw_extra_root_level = true
         }
       }
-      Borrow => {
-        if case_.min_degree > 2 {
-          saw_multi_child_underflow_repair = true
-        }
+      BulkBorrow => {
+        saw_multi_child_underflow_repair = true
         match case_.min_degree {
-          2 => saw_borrow_degree_2 = true
-          3 => saw_borrow_degree_3 = true
-          _ => saw_borrow_default_degree = true
+          2 => saw_bulk_borrow_degree_2 = true
+          3 => saw_bulk_borrow_degree_3 = true
+          _ => saw_bulk_borrow_default_degree = true
         }
       }
       Merge =>
@@ -923,17 +966,26 @@ test "quickcheck arbitrary callback splice generator reaches stress paths" {
           3 => saw_merge_degree_3 = true
           _ => saw_merge_default_degree = true
         }
+      RepeatedMerge =>
+        match case_.min_degree {
+          2 => saw_repeated_merge_degree_2 = true
+          3 => saw_repeated_merge_degree_3 = true
+          _ => saw_repeated_merge_default_degree = true
+        }
     }
   }
   inspect(saw_multi_output, content="true")
   inspect(saw_extra_root_level, content="true")
   inspect(saw_multi_child_underflow_repair, content="true")
-  inspect(saw_borrow_degree_2, content="true")
-  inspect(saw_borrow_degree_3, content="true")
-  inspect(saw_borrow_default_degree, content="true")
+  inspect(saw_bulk_borrow_degree_2, content="true")
+  inspect(saw_bulk_borrow_degree_3, content="true")
+  inspect(saw_bulk_borrow_default_degree, content="true")
   inspect(saw_merge_degree_2, content="true")
   inspect(saw_merge_degree_3, content="true")
   inspect(saw_merge_default_degree, content="true")
+  inspect(saw_repeated_merge_degree_2, content="true")
+  inspect(saw_repeated_merge_degree_3, content="true")
+  inspect(saw_repeated_merge_default_degree, content="true")
 }
 
 ///|

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -139,9 +139,13 @@ fn query_matches_model(
 ///|
 fn all_queries_match_model(t : BTree[TItem], model : Array[TItem]) -> Bool {
   let total = model_span(model)
-  if t.view(start=-total - 2, end=total + 2) !=
-    model_view_range(model, -total - 2, total + 2) {
-    return false
+  let middle = total / 2
+  for
+    range in [(-total - 2, total + 2), (1, total - 1), (middle - 1, middle + 2)] {
+    let (start, end_) = range
+    if t.view(start~, end=end_) != model_view_range(model, start, end_) {
+      return false
+    }
   }
   for pos in -1..<(total + 2) {
     if !query_matches_model(t, model, pos, 0, total) {
@@ -546,12 +550,19 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
         size: donor_count + target_count,
       }
       t.mutate_for_insert(donor_count + 1, _ctx => {
-        start_idx: 0,
+        start_idx: 1,
         end_idx: target_count,
         new_leaves: [],
       })
-      let expected = Array::makei(donor_count, i => make_item(i, 1))
-      tree_matches_model(t, expected)
+      let expected = Array::makei(donor_count + 1, i => make_item(i, 1))
+      let borrowed_to_target = match t.root {
+        Some(Internal(children~, ..)) =>
+          children.length() == 2 &&
+          children[0].child_count() == min_degree + 1 &&
+          children[1].child_count() == min_degree
+        _ => false
+      }
+      borrowed_to_target && tree_matches_model(t, expected)
     }
     Merge => {
       let sibling_count = min_degree
@@ -569,12 +580,16 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
         size: 2 * sibling_count,
       }
       t.mutate_for_insert(sibling_count + 1, _ctx => {
-        start_idx: 0,
+        start_idx: 1,
         end_idx: sibling_count,
         new_leaves: [],
       })
-      let expected = Array::makei(sibling_count, i => make_item(i, 1))
-      tree_matches_model(t, expected)
+      let expected = Array::makei(sibling_count + 1, i => make_item(i, 1))
+      let merged_with_sibling = match t.root {
+        Some(root) => root.child_count() == min_degree + 1
+        None => false
+      }
+      merged_with_sibling && tree_matches_model(t, expected)
     }
     RepeatedMerge => {
       let old = make_internal(
@@ -608,13 +623,20 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
       let root = result
         .root_candidate(min_degree, normalize_delete=false)
         .unwrap()
+      let repeatedly_merged = match root {
+        Internal(children~, ..) =>
+          children.length() == 2 &&
+          children[0].child_count() == min_degree + 1 &&
+          children[1].child_count() == 2 * min_degree
+        _ => false
+      }
       let t : BTree[TItem] = {
         root: Some(root),
         min_degree,
         size: new_leaf_count,
       }
       let expected = Array::makei(new_leaf_count, i => make_item(i, 1))
-      tree_matches_model(t, expected)
+      repeatedly_merged && tree_matches_model(t, expected)
     }
   }
 }
@@ -925,7 +947,7 @@ test "arbitrary splice propagation cardinality and repair boundary matrix" {
 
 ///|
 test "quickcheck arbitrary splice generator reaches stress paths" {
-  let samples : Array[ArbitrarySpliceCase] = @quickcheck.samples(400)
+  let samples : Array[ArbitrarySpliceCase] = @quickcheck.samples(800)
   let mut saw_multi_output = false
   let mut saw_extra_root_level = false
   let mut saw_multi_child_underflow_repair = false
@@ -953,7 +975,9 @@ test "quickcheck arbitrary splice generator reaches stress paths" {
         }
       }
       BulkBorrow => {
-        saw_multi_child_underflow_repair = true
+        if case_.min_degree > 2 {
+          saw_multi_child_underflow_repair = true
+        }
         match case_.min_degree {
           2 => saw_bulk_borrow_degree_2 = true
           3 => saw_bulk_borrow_degree_3 = true

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -148,7 +148,10 @@ fn all_queries_match_model(t : BTree[TItem], model : Array[TItem]) -> Bool {
     }
   }
   for pos in -1..<(total + 2) {
-    if !query_matches_model(t, model, pos, 0, total) {
+    // Representative views are checked once above; keep the exhaustive
+    // positional pass linear in the model size.
+    if t.find(pos) != model_find(model, pos) ||
+      t.get_at(pos) != model_get_at(model, pos) {
       return false
     }
   }

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -491,6 +491,61 @@ test "boundary sweep successful mutations never expose negative span" {
 }
 
 ///|
+test "arbitrary insert splice partitions more than two output nodes" {
+  let t : BTree[TItem] = BTree::from_sorted(
+    [(make_item(0, 1), 1)],
+    min_degree=2,
+  )
+  let expected = Array::makei(10, fn(i) { make_item(i + 1, 1) })
+  t.mutate_for_insert(0, fn(ctx) {
+    {
+      start_idx: ctx.child_idx,
+      end_idx: ctx.child_idx + 1,
+      new_leaves: expected.map(item => (item, item.span)),
+    }
+  })
+  inspect(tree_matches_model(t, expected), content="true")
+}
+
+///|
+test "arbitrary insert splice propagates a complete segment through ancestors" {
+  let original = Array::makei(12, i => (make_item(i, 1), 1))
+  let t : BTree[TItem] = BTree::from_sorted(original, min_degree=2)
+  let replacement = Array::makei(9, i => make_item(100 + i, 1))
+  t.mutate_for_insert(0, ctx => {
+    start_idx: ctx.child_idx,
+    end_idx: ctx.child_idx + 1,
+    new_leaves: replacement.map(item => (item, item.span)),
+  })
+  let expected = replacement.copy()
+  let suffix = Array::makei(11, i => make_item(i + 1, 1))
+  expected.append(suffix[:])
+  inspect(tree_matches_model(t, expected), content="true")
+}
+
+///|
+test "arbitrary insert deletion repairs a multi-child underflow deficit" {
+  let left = make_internal(
+    Array::makei(6, fn(i) { Leaf(elem=make_item(i, 1), span=1) }),
+  )
+  let right = make_internal(
+    Array::makei(3, fn(i) { Leaf(elem=make_item(i + 6, 1), span=1) }),
+  )
+  let t : BTree[TItem] = {
+    root: Some(make_internal([left, right])),
+    min_degree: 3,
+    size: 9,
+  }
+  let replacement = make_item(9, 1)
+  t.mutate_for_insert(7, fn(_ctx) {
+    { start_idx: 0, end_idx: 3, new_leaves: [(replacement, 1)] }
+  })
+  let expected = Array::makei(6, fn(i) { make_item(i, 1) })
+  expected.push(replacement)
+  inspect(tree_matches_model(t, expected), content="true")
+}
+
+///|
 test "panic init_root rejects zero non-positive span" {
   let t : BTree[TItem] = BTree::new()
   t.init_root(make_item(1, 0), 0)
@@ -1401,9 +1456,10 @@ test "propagate_node_splice updates ancestor counts after removal" {
     leaf_delta: -1,
   }
   let result = propagate_node_splice(splice, 2)
+  let root = result.root_candidate(2, normalize_delete=false).unwrap()
   inspect(result.leaf_delta, content="-1")
   // Resulting node should have total = 2 + 4 = 6
-  inspect(result.node.total(), content="6")
+  inspect(root.total(), content="6")
 }
 
 // === Underfull propagation repair ===
@@ -1465,11 +1521,12 @@ test "propagate_node_splice repairs underfull node by borrowing from right" {
     leaf_delta: -2,
   }
   let result = propagate_node_splice(splice, 2)
+  let root = result.root_candidate(2, normalize_delete=false).unwrap()
   // After repair: underfull node borrowed from right sibling
   // Total span should be 6 - 2 = 4
-  inspect(result.node.total(), content="4")
+  inspect(root.total(), content="4")
   // Root should still have 2 children (no merge needed at root level)
-  match result.node {
+  match root {
     Internal(children~, ..) => {
       inspect(children.length(), content="2")
       // Each child should have >= 2 children
@@ -1536,12 +1593,40 @@ test "propagate_node_splice repairs underfull node by merging with sibling" {
     leaf_delta: -1,
   }
   let result = propagate_node_splice(splice, 2)
-  inspect(result.node.total(), content="3")
+  let root = result.root_candidate(2, normalize_delete=false).unwrap()
+  inspect(root.total(), content="3")
   // After merge: root has 1 child (will be collapsed by normalize)
-  match result.node {
+  match root {
     Internal(children~, ..) => inspect(children.length(), content="1")
     _ => abort("expected internal root")
   }
+}
+
+///|
+test "propagate_node_splice rechecks repeated adjacent underfull merges" {
+  let old = make_internal(
+    Array::makei(3, i => Leaf(elem=make_item(100 + i, 1), span=1)),
+  )
+  let first = make_internal([Leaf(elem=make_item(0, 1), span=1)])
+  let second = make_internal([Leaf(elem=make_item(1, 1), span=1)])
+  let third = make_internal([Leaf(elem=make_item(2, 1), span=1)])
+  let donor = make_internal(
+    Array::makei(6, i => Leaf(elem=make_item(i + 3, 1), span=1)),
+  )
+  let splice : NodeSplice[TItem] = {
+    prefix: [],
+    children: [old],
+    counts: [old.total()],
+    start_idx: 0,
+    end_idx: 1,
+    new_children: [first, second, third, donor],
+    leaf_delta: 6,
+  }
+  let result = propagate_node_splice(splice, 3)
+  let root = result.root_candidate(3, normalize_delete=false).unwrap()
+  let t : BTree[TItem] = { root: Some(root), min_degree: 3, size: 9 }
+  let expected = Array::makei(9, i => make_item(i, 1))
+  inspect(tree_matches_model(t, expected), content="true")
 }
 
 // === Post-splice boundary merge ===
@@ -1896,15 +1981,18 @@ fn[T] btree_invariants_hold(t : BTree[T]) -> Bool {
     Some(root) =>
       match root {
         Leaf(..) => false
-        Internal(..) => {
-          let (ok, _, leaf_count) = check_node_invariants(
-            root,
-            t.min_degree,
-            true,
-            0,
-          )
-          ok && leaf_count == t.size && root.total() == t.span()
-        }
+        Internal(children~, ..) =>
+          if children is [Internal(..)] {
+            false
+          } else {
+            let (ok, _, leaf_count) = check_node_invariants(
+              root,
+              t.min_degree,
+              true,
+              0,
+            )
+            ok && leaf_count == t.size && root.total() == t.span()
+          }
       }
   }
 }

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -1726,6 +1726,27 @@ test "BTree::delete_range merges boundary leaves" {
 }
 
 ///|
+test "delete_range repartitions an overfull merged boundary chain" {
+  let ids = [10, 11, 12, 7, 20, 21, 22, 23, 7, 31, 32, 33]
+  let items = ids.map(id => (make_item(id, 1), 1))
+  let t : BTree[TItem] = BTree::from_sorted(items, min_degree=2)
+  // The three leaf parents start at 4 | 4 | 4. Removing the middle parent
+  // merges the two id=7 boundary leaves; the rebuilt seven-child chain must
+  // be repartitioned instead of surviving above the maximum occupancy of four.
+  t.delete_range(4, 8)
+  let expected = [
+    make_item(10, 1),
+    make_item(11, 1),
+    make_item(12, 1),
+    make_item(7, 2),
+    make_item(31, 1),
+    make_item(32, 1),
+    make_item(33, 1),
+  ]
+  inspect(tree_matches_model(t, expected), content="true")
+}
+
+///|
 test "delete_range repair near Int max keeps cumulative span valid" {
   let items = Array::makei(16, fn(i) {
     let span = if i == 0 { @int.MAX_VALUE - 15 } else { 1 }

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -524,24 +524,24 @@ test "arbitrary insert splice propagates a complete segment through ancestors" {
 }
 
 ///|
-test "arbitrary insert deletion repairs a multi-child underflow deficit" {
+test "arbitrary delete-shaped insert repairs the zero-child underflow counterexample" {
+  // min_degree=3 and occupancies [3] | [4]. Removing the complete left
+  // parent used to borrow only one child and leave an invalid [1] | [3].
   let left = make_internal(
-    Array::makei(6, fn(i) { Leaf(elem=make_item(i, 1), span=1) }),
+    Array::makei(3, fn(i) { Leaf(elem=make_item(i, 1), span=1) }),
   )
   let right = make_internal(
-    Array::makei(3, fn(i) { Leaf(elem=make_item(i + 6, 1), span=1) }),
+    Array::makei(4, fn(i) { Leaf(elem=make_item(i + 3, 1), span=1) }),
   )
   let t : BTree[TItem] = {
     root: Some(make_internal([left, right])),
     min_degree: 3,
-    size: 9,
+    size: 7,
   }
-  let replacement = make_item(9, 1)
-  t.mutate_for_insert(7, fn(_ctx) {
-    { start_idx: 0, end_idx: 3, new_leaves: [(replacement, 1)] }
+  t.mutate_for_insert(0, fn(_ctx) {
+    { start_idx: 0, end_idx: 3, new_leaves: [] }
   })
-  let expected = Array::makei(6, fn(i) { make_item(i, 1) })
-  expected.push(replacement)
+  let expected = Array::makei(4, fn(i) { make_item(i + 3, 1) })
   inspect(tree_matches_model(t, expected), content="true")
 }
 
@@ -1603,30 +1603,46 @@ test "propagate_node_splice repairs underfull node by merging with sibling" {
 }
 
 ///|
-test "propagate_node_splice rechecks repeated adjacent underfull merges" {
-  let old = make_internal(
-    Array::makei(3, i => Leaf(elem=make_item(100 + i, 1), span=1)),
-  )
-  let first = make_internal([Leaf(elem=make_item(0, 1), span=1)])
-  let second = make_internal([Leaf(elem=make_item(1, 1), span=1)])
-  let third = make_internal([Leaf(elem=make_item(2, 1), span=1)])
-  let donor = make_internal(
-    Array::makei(6, i => Leaf(elem=make_item(i + 3, 1), span=1)),
-  )
-  let splice : NodeSplice[TItem] = {
-    prefix: [],
-    children: [old],
-    counts: [old.total()],
-    start_idx: 0,
-    end_idx: 1,
-    new_children: [first, second, third, donor],
-    leaf_delta: 6,
+test "propagate_node_splice rechecks repeated adjacent merges at every degree" {
+  for min_degree in [2, 3, DEFAULT_MIN_DEGREE] {
+    let old = make_internal(
+      Array::makei(min_degree, i => Leaf(elem=make_item(1000 + i, 1), span=1)),
+    )
+    // min_degree + 1 singleton internal nodes force at least two adjacent
+    // merges even when min_degree=2. The final full donor must remain valid.
+    let underfull_count = min_degree + 1
+    let new_children : Array[BTreeNode[TItem]] = Array::makei(underfull_count, i => {
+      make_internal([Leaf(elem=make_item(i, 1), span=1)])
+    })
+    new_children.push(
+      make_internal(
+        Array::makei(2 * min_degree, i => {
+          Leaf(elem=make_item(underfull_count + i, 1), span=1)
+        }),
+      ),
+    )
+    let new_leaf_count = underfull_count + 2 * min_degree
+    let splice : NodeSplice[TItem] = {
+      prefix: [],
+      children: [old],
+      counts: [old.total()],
+      start_idx: 0,
+      end_idx: 1,
+      new_children,
+      leaf_delta: new_leaf_count - min_degree,
+    }
+    let result = propagate_node_splice(splice, min_degree)
+    let root = result
+      .root_candidate(min_degree, normalize_delete=false)
+      .unwrap()
+    let t : BTree[TItem] = {
+      root: Some(root),
+      min_degree,
+      size: new_leaf_count,
+    }
+    let expected = Array::makei(new_leaf_count, i => make_item(i, 1))
+    inspect(tree_matches_model(t, expected), content="true")
   }
-  let result = propagate_node_splice(splice, 3)
-  let root = result.root_candidate(3, normalize_delete=false).unwrap()
-  let t : BTree[TItem] = { root: Some(root), min_degree: 3, size: 9 }
-  let expected = Array::makei(9, i => make_item(i, 1))
-  inspect(tree_matches_model(t, expected), content="true")
 }
 
 // === Post-splice boundary merge ===

--- a/lib/btree/walker_propagate.mbt
+++ b/lib/btree/walker_propagate.mbt
@@ -1,5 +1,5 @@
-// Propagation: after a leaf splice, rebuild ancestors bottom-up,
-// splitting any node that exceeds 2*min_degree children.
+// Propagation: after a splice, rebuild ancestors bottom-up as complete,
+// same-height segments and repair underfull children before packing each level.
 
 ///|
 /// Split a full internal node at its midpoint, producing two balanced halves.
@@ -38,21 +38,17 @@ fn[T] apply_splice(
   children : Array[BTreeNode[T]],
   counts : Array[Int],
   splice : Splice[T],
-) -> Unit {
-  let remove_count = splice.end_idx - splice.start_idx
-  for _ in 0..<remove_count {
-    let _ = children.remove(splice.start_idx)
-    let _ = counts.remove(splice.start_idx)
-  }
-  if splice.new_leaves.length() == 0 {
-    return
-  }
-  // Insert in reverse so each goes to start_idx in correct final order
-  for i in (splice.new_leaves.length() - 1)>=..0 {
-    let (elem, span) = splice.new_leaves[i]
-    children.insert(splice.start_idx, Leaf(elem~, span~))
-    counts.insert(splice.start_idx, span)
-  }
+) -> (Array[BTreeNode[T]], Array[Int]) {
+  let new_children : Array[BTreeNode[T]] = splice.new_leaves.map(pair => {
+    Leaf(elem=pair.0, span=pair.1)
+  })
+  apply_node_splice(
+    children,
+    counts,
+    splice.start_idx,
+    splice.end_idx,
+    new_children,
+  )
 }
 
 ///|
@@ -62,113 +58,88 @@ fn[T] apply_node_splice(
   start_idx : Int,
   end_idx : Int,
   new_children : Array[BTreeNode[T]],
-) -> Unit {
-  let remove_count = end_idx - start_idx
-  for _ in 0..<remove_count {
-    let _ = children.remove(start_idx)
-    let _ = counts.remove(start_idx)
-  }
-  if new_children.length() == 0 {
-    return
-  }
-  for i in (new_children.length() - 1)>=..0 {
-    let child = new_children[i]
-    children.insert(start_idx, child)
-    counts.insert(start_idx, child.total())
-  }
+) -> (Array[BTreeNode[T]], Array[Int]) {
+  let result : Array[BTreeNode[T]] = []
+  let result_counts : Array[Int] = []
+  result.append(children[:start_idx])
+  result_counts.append(counts[:start_idx])
+  result.append(new_children[:])
+  result_counts.append(new_children.map(child => child.total())[:])
+  result.append(children[end_idx:])
+  result_counts.append(counts[end_idx:])
+  (result, result_counts)
 }
 
 ///|
-fn[T] maybe_split(
+/// Return the existing bottom-up grouping policy as scalar chunk sizes.
+/// For `child_count >= min_degree`, every size is in
+/// `[min_degree, 2 * min_degree]` and the sizes sum to `child_count`.
+fn legal_chunk_sizes(child_count : Int, min_degree : Int) -> Array[Int] {
+  guard child_count >= min_degree else {
+    abort("legal_chunk_sizes: child count is underfull")
+  }
+  let max_degree = 2 * min_degree
+  let sizes : Array[Int] = []
+  let mut remaining = child_count
+  while remaining > max_degree {
+    let chunk_size = if remaining - max_degree < min_degree {
+      remaining / 2
+    } else {
+      max_degree
+    }
+    sizes.push(chunk_size)
+    remaining = remaining - chunk_size
+  }
+  sizes.push(remaining)
+  sizes
+}
+
+///|
+/// Pack one level into a complete ordered segment. An empty input stays empty;
+/// one underfull node is carried upward until its parent can repair it.
+fn[T] pack_level(
   children : Array[BTreeNode[T]],
-  counts : Array[Int],
   min_degree : Int,
-) -> (BTreeNode[T], BTreeNode[T]?) {
-  let total = counts.sum()
-  if children.length() > 2 * min_degree {
-    let (left, right) = split_internal(children, counts)
-    (left, Some(right))
-  } else {
-    (Internal(children~, counts~, total~), None)
+) -> Array[BTreeNode[T]] {
+  guard !children.is_empty() else { return [] }
+  if children.length() < min_degree {
+    return [make_internal(children)]
   }
+  let sizes = legal_chunk_sizes(children.length(), min_degree)
+  if sizes.length() == 1 {
+    return [make_internal(children)]
+  }
+  let nodes : Array[BTreeNode[T]] = []
+  let mut offset = 0
+  for size in sizes {
+    nodes.push(make_internal(children[offset:offset + size].to_owned()))
+    offset = offset + size
+  }
+  nodes
 }
 
 ///|
-/// Repair an underfull node after a range splice. Uses < min_degree threshold
-/// (reactive) unlike ensure_min_children which uses <= min_degree (proactive).
-fn[T] ensure_min_after_splice(
-  children : Array[BTreeNode[T]],
-  counts : Array[Int],
-  idx : Int,
-  min_degree : Int,
-) -> Unit {
-  guard children[idx].is_underfull(min_degree) else { return }
-  if idx > 0 && children[idx - 1].can_lend(min_degree) {
-    children[idx - 1] = children[idx - 1].shallow_copy()
-    children[idx] = children[idx].shallow_copy()
-    borrow_from_left(children, counts, idx)
-    return
-  }
-  if idx + 1 < children.length() && children[idx + 1].can_lend(min_degree) {
-    children[idx] = children[idx].shallow_copy()
-    children[idx + 1] = children[idx + 1].shallow_copy()
-    borrow_from_right(children, counts, idx)
-    return
-  }
-  if idx > 0 {
-    children[idx - 1] = children[idx - 1].shallow_copy()
-    children[idx] = children[idx].shallow_copy()
-    merge_children(children, counts, idx - 1)
-  } else if idx + 1 < children.length() {
-    children[idx] = children[idx].shallow_copy()
-    children[idx + 1] = children[idx + 1].shallow_copy()
-    merge_children(children, counts, idx)
-  }
-}
-
-///|
-/// Walk from a node upward through ancestor frames, updating each parent's
-/// child pointer and inserting any overflow sibling from a split below.
-/// Also repairs underfull nodes (< min_degree children) by borrowing or merging.
-/// Splits again if a parent exceeds capacity.
+/// Walk a complete same-height segment upward through ancestor frames.
 fn[T] walk_up_ancestors(
   path : Array[PathFrame[T]],
   start_from : Int,
-  initial_node : BTreeNode[T],
-  initial_overflow : BTreeNode[T]?,
+  initial_segment : Array[BTreeNode[T]],
   min_degree : Int,
-) -> (BTreeNode[T], BTreeNode[T]?) {
-  let mut current_node = initial_node
-  let mut overflow = initial_overflow
+) -> Array[BTreeNode[T]] {
+  let mut segment = initial_segment
   for i in start_from>=..0 {
     let frame = path[i]
-    frame.children[frame.child_idx] = current_node
-    frame.counts[frame.child_idx] = current_node.total()
-    match overflow {
-      Some(sibling) => {
-        frame.children.insert(frame.child_idx + 1, sibling)
-        frame.counts.insert(frame.child_idx + 1, sibling.total())
-      }
-      _ => ()
-    }
-    // Repair underfull child after splice (< min_degree children)
-    if current_node.is_underfull(min_degree) && frame.children.length() > 1 {
-      ensure_min_after_splice(
-        frame.children,
-        frame.counts,
-        frame.child_idx,
-        min_degree,
-      )
-    }
-    let (updated, next_overflow) = maybe_split(
+    let (children, counts) = apply_node_splice(
       frame.children,
       frame.counts,
-      min_degree,
+      frame.child_idx,
+      frame.child_idx + 1,
+      segment,
     )
-    current_node = updated
-    overflow = next_overflow
+    repair_underfull_children(children, counts, min_degree, min_degree)
+    segment = pack_level(children, min_degree)
   }
-  (current_node, overflow)
+  segment
 }
 
 ///|
@@ -185,20 +156,19 @@ fn[T] propagate(
   let leaf_delta = splice.new_leaves.length() -
     (splice.end_idx - splice.start_idx)
   let leaf_parent = path[path.length() - 1]
-  apply_splice(leaf_parent.children, leaf_parent.counts, splice)
-  let (initial_node, initial_overflow) = maybe_split(
+  let (children, _) = apply_splice(
     leaf_parent.children,
     leaf_parent.counts,
-    min_degree,
+    splice,
   )
-  let (node, overflow) = walk_up_ancestors(
+  let initial_segment = pack_level(children, min_degree)
+  let segment = walk_up_ancestors(
     path,
     path.length() - 2,
-    initial_node,
-    initial_overflow,
+    initial_segment,
     min_degree,
   )
-  { node, overflow, leaf_delta }
+  { segment, leaf_delta }
 }
 
 ///|
@@ -207,47 +177,22 @@ fn[T] propagate_node_splice(
   splice : NodeSplice[T],
   min_degree : Int,
 ) -> PropagateResult[T] {
-  let insert_count = splice.new_children.length()
-  let insert_start = splice.start_idx
-  apply_node_splice(
+  let (children, counts) = apply_node_splice(
     splice.children,
     splice.counts,
     splice.start_idx,
     splice.end_idx,
     splice.new_children,
   )
-  // Repair underfull boundary subtree roots at their insertion positions.
-  // Chain repair fixes internal underfull descendants, but the root itself
-  // may still be underfull and needs material from adjacent LCA children.
-  // Only triggers for range-delete boundary subtrees — leaves and valid
-  // internals pass the is_underfull check as no-ops.
-  let mut pos = insert_start
-  for _ in 0..<insert_count {
-    // Loop: one borrow isn't enough for min_degree > 2 when boundary
-    // root is heavily underfull. Keep repairing until valid or merged.
-    while pos < splice.children.length() &&
-          splice.children[pos].is_underfull(min_degree) &&
-          splice.children.length() > 1 {
-      let len_before = splice.children.length()
-      ensure_min_after_splice(splice.children, splice.counts, pos, min_degree)
-      if splice.children.length() < len_before {
-        // Merge removed a sibling — break inner loop, re-check in outer
-        break
-      }
-    }
-    pos += 1
-  }
-  let (initial_node, initial_overflow) = maybe_split(
-    splice.children,
-    splice.counts,
-    min_degree,
-  )
-  let (node, overflow) = walk_up_ancestors(
+  // Boundary-chain repair can leave more than one adjacent subtree root
+  // underfull. Repair the complete replacement before packing it upward.
+  repair_underfull_children(children, counts, min_degree, min_degree)
+  let initial_segment = pack_level(children, min_degree)
+  let segment = walk_up_ancestors(
     splice.prefix,
     splice.prefix.length() - 1,
-    initial_node,
-    initial_overflow,
+    initial_segment,
     min_degree,
   )
-  { node, overflow, leaf_delta: splice.leaf_delta }
+  { segment, leaf_delta: splice.leaf_delta }
 }

--- a/lib/btree/walker_range_delete.mbt
+++ b/lib/btree/walker_range_delete.mbt
@@ -546,10 +546,9 @@ fn[T : BTreeElem] normalize_boundary_merge(
         leaf_delta: merged_subtree.leaf_count() - removed_leaf_count,
       }
       let result = propagate_node_splice(splice, min_degree)
-      let new_root = match result.overflow {
-        None => result.node
-        Some(sibling) => make_internal([result.node, sibling])
-      }
+      let new_root = result
+        .root_candidate(min_degree, normalize_delete=false)
+        .unwrap()
       (new_root, true)
     }
     _ => (root, false)

--- a/lib/btree/walker_range_delete.mbt
+++ b/lib/btree/walker_range_delete.mbt
@@ -65,29 +65,31 @@ fn[T] merge_boundary_chain(
   left_path_suffix : Array[PathFrame[T]],
   right_path_suffix : Array[PathFrame[T]],
   leaf : BTreeNode[T],
-) -> BTreeNode[T] {
+  min_degree : Int,
+) -> Array[BTreeNode[T]] {
   if left_path_suffix.length() != right_path_suffix.length() {
     abort("merge_boundary_chain: mismatched suffix heights")
   }
-  let mut current = leaf
+  let mut current : Array[BTreeNode[T]] = [leaf]
   for i in (left_path_suffix.length() - 1)>=..0 {
     let left_frame = left_path_suffix[i]
     let right_frame = right_path_suffix[i]
     let children : Array[BTreeNode[T]] = []
     let counts : Array[Int] = []
-    for j in 0..<left_frame.child_idx {
-      children.push(left_frame.children[j])
-      counts.push(left_frame.counts[j])
-    }
-    children.push(current)
-    counts.push(current.total())
-    for j in (right_frame.child_idx + 1)..<right_frame.children.length() {
-      children.push(right_frame.children[j])
-      counts.push(right_frame.counts[j])
-    }
-    current = Internal(children~, counts~, total=counts.sum())
+    children.append(left_frame.children[:left_frame.child_idx])
+    counts.append(left_frame.counts[:left_frame.child_idx])
+    children.append(current[:])
+    counts.append(current.map(node => node.total())[:])
+    children.append(right_frame.children[right_frame.child_idx + 1:])
+    counts.append(right_frame.counts[right_frame.child_idx + 1:])
+    // The two boundary paths and a two-node carried segment can contribute up
+    // to 4t children. Repair an
+    // underfull carried node, then preserve every balanced output node as a
+    // segment for the next ancestor instead of hiding overfull descendants.
+    repair_underfull_children(children, counts, min_degree, min_degree)
+    current = pack_level(children, min_degree)
   }
-  current
+  current.map(node => fix_merged_chain(node, min_degree))
 }
 
 ///|
@@ -303,11 +305,13 @@ fn[T : BTreeElem] absorb_subtree_gap_merge(
   }
   let merged = @rle.Mergeable::merge(left_edge.elem, right_edge.elem)
   let merged_leaf = Leaf(elem=merged, span=@rle.Spanning::span(merged))
-  let merged_subtree = fix_merged_chain(
-    merge_boundary_chain(left_edge.path, right_edge.path, merged_leaf),
+  let merged_subtrees = merge_boundary_chain(
+    left_edge.path,
+    right_edge.path,
+    merged_leaf,
     min_degree,
   )
-  ([merged_subtree], start_idx - 1, end_idx + 1, true)
+  (merged_subtrees, start_idx - 1, end_idx + 1, true)
 }
 
 ///|
@@ -332,11 +336,12 @@ fn[T : BTreeElem] promote_empty_child_gap_merge(
   }
   let merged = @rle.Mergeable::merge(left_edge.elem, right_edge.elem)
   let merged_leaf = Leaf(elem=merged, span=@rle.Spanning::span(merged))
-  let merged_subtree = fix_merged_chain(
-    merge_boundary_chain(left_edge.path, right_edge.path, merged_leaf),
+  let new_children = merge_boundary_chain(
+    left_edge.path,
+    right_edge.path,
+    merged_leaf,
     min_degree,
   )
-  let new_children : Array[BTreeNode[T]] = [merged_subtree]
   let removed_leaf_count = leaf_count_of_children(
     parent.children,
     child_idx - 1,
@@ -527,9 +532,8 @@ fn[T : BTreeElem] normalize_boundary_merge(
         right.path,
         lca.prefix.length(),
       )
-      let merged_subtree = fix_merged_chain(
-        merge_boundary_chain(left_suffix, right_suffix, merged_leaf),
-        min_degree,
+      let merged_subtrees = merge_boundary_chain(
+        left_suffix, right_suffix, merged_leaf, min_degree,
       )
       let removed_leaf_count = leaf_count_of_children(
         lca.children,
@@ -542,8 +546,8 @@ fn[T : BTreeElem] normalize_boundary_merge(
         counts: lca.counts,
         start_idx: lca.start_idx,
         end_idx: lca.end_idx,
-        new_children: [merged_subtree],
-        leaf_delta: merged_subtree.leaf_count() - removed_leaf_count,
+        new_children: merged_subtrees,
+        leaf_delta: leaf_count_of_array(merged_subtrees) - removed_leaf_count,
       }
       let result = propagate_node_splice(splice, min_degree)
       let new_root = result

--- a/lib/btree/walker_repair.mbt
+++ b/lib/btree/walker_repair.mbt
@@ -167,13 +167,15 @@ fn[T] fix_left_border(node : BTreeNode[T], min_degree : Int) -> BTreeNode[T] {
 /// all children at each level. Used for merge_boundary_chain output
 /// where the underfull node can be at an interior position.
 ///
-/// Top-down: at each level, find any underfull child, stock it via
-/// merge-or-bulk-steal, then recurse into the result.
-/// Scan children for underfull nodes and fix via merge-or-bulk-steal.
+/// Top-down: at each level, find any underfull child, stock it to
+/// `target_child_count` via merge-or-bulk-steal, then recurse into the result.
+/// Callers that recurse through the repaired node request `min_degree + 1`;
+/// propagation only needs `min_degree`.
 fn[T] repair_underfull_children(
   children : Array[BTreeNode[T]],
   counts : Array[Int],
   min_degree : Int,
+  target_child_count : Int,
 ) -> Unit {
   let mut i = 0
   while i < children.length() {
@@ -183,12 +185,12 @@ fn[T] repair_underfull_children(
       children[i] = children[i].shallow_copy()
       let r = children[i].child_count()
       let s = children[sibling_idx].child_count()
-      if r + s <= 2 * min_degree {
+      let steal_count = target_child_count - r
+      if s - steal_count < min_degree {
         let merge_idx = if i > 0 { i - 1 } else { 0 }
         merge_children(children, counts, merge_idx)
         i = merge_idx
       } else {
-        let steal_count = min_degree + 1 - r
         if i > 0 {
           bulk_steal_from_left(children, counts, i, steal_count)
         } else {
@@ -210,7 +212,7 @@ fn[T] fix_merged_chain(node : BTreeNode[T], min_degree : Int) -> BTreeNode[T] {
       guard children.length() > 1 else { return node }
       let children = children.copy()
       let counts = counts.copy()
-      repair_underfull_children(children, counts, min_degree)
+      repair_underfull_children(children, counts, min_degree, min_degree + 1)
       // Recurse into all children to fix deeper levels.
       for j in 0..<children.length() {
         let fixed = fix_merged_chain(children[j], min_degree)
@@ -219,7 +221,7 @@ fn[T] fix_merged_chain(node : BTreeNode[T], min_degree : Int) -> BTreeNode[T] {
       }
       // Post-recursion repair: a child merge at depth D+1 can leave
       // a child at depth D with fewer than min_degree children.
-      repair_underfull_children(children, counts, min_degree)
+      repair_underfull_children(children, counts, min_degree, min_degree + 1)
       Internal(children~, counts~, total=counts.sum())
     }
   }

--- a/lib/btree/walker_types.mbt
+++ b/lib/btree/walker_types.mbt
@@ -84,8 +84,7 @@ pub(all) struct Splice[T] {
 
 ///|
 priv struct PropagateResult[T] {
-  node : BTreeNode[T]
-  overflow : BTreeNode[T]?
+  segment : Array[BTreeNode[T]]
   leaf_delta : Int
 }
 


### PR DESCRIPTION
## Summary

- Replace the private zero-or-one overflow result with complete same-height segments, repartitioning arbitrary callback output at every ancestor and building as many root levels as required.
- Repair arbitrary underflow deficits with bulk borrow or repeated merge, and carry range-delete boundary merges as balanced segments so overfull descendants cannot be hidden.
- Add exact static regressions, boundary-cardinality and repair matrices for degree 2, 3, and default, generator reachability assertions, stronger model queries, and the documented complexity/contract.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Existing balanced chunk redistribution | `BTree::from_sorted`, `lib/btree/btree.mbt` | Yes | Extracted into the shared scalar grouping policy used by both bulk construction and propagation. |
| `make_internal` and `apply_node_splice` | `lib/btree/utils.mbt`, `lib/btree/walker_propagate.mbt` | Yes | Recompute cached counts/totals and replace complete ordered segments. |
| `repair_underfull_children` | `lib/btree/walker_repair.mbt` | Yes | Generalized with an explicit target occupancy and reused by callback and range-delete propagation. |
| `split_internal` | `lib/btree/walker_propagate.mbt` | No | A binary split cannot represent arbitrary output cardinality; it remains the proactive-descent binary special case. |
| `Array::append`, `Array::map`, `ArrayView::to_owned`, `Array::sum` | MoonBit core array APIs | Yes | Used for ordered segment construction, owning slices, and aggregate recomputation. |
| `Int::clamp` | MoonBit core int API | No | Clamping cannot produce legal chunk sizes whose exact sum equals the child count. |

New helpers added:

- `legal_chunk_sizes`: pure scalar policy that returns legal group sizes for `(child_count, min_degree)`.
- `pack_level`: materializes one same-height balanced segment from those sizes.
- Test-only `ArbitrarySpliceShape` and `ArbitrarySpliceCase`: force overflow, bulk-borrow, merge, and repeated-merge paths with observable postconditions.

## Test plan

- [x] `moon check --deny-warn lib/btree` passes
- [x] `moon test --release lib/btree` passes: 123/123
- [x] `moon test --release` passes: 3969/3969
- [x] `moon check` passes; only the existing vendored Rabbita deprecation warnings remain
- [x] `moon info` and `moon fmt --check lib/btree` pass
- [x] `git diff origin/main...HEAD -- "*.mbti"` is empty
- [x] `moon bench --release lib/btree` passes: 10/10
- [x] JS rebuild not required; no web code or generated JS path changed

## Review evidence

Two independent read-only MoonBit reviews found and then re-verified fixes for:

- an overfull `delete_range` boundary chain produced by a 4|4|4 tree at `min_degree=2`;
- vacuous borrow/merge generator cases that removed an empty parent instead of exercising repair.

Both follow-up reviews report no remaining high-confidence findings.

Closes #1002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved B+ tree insertions, deletions, range deletions, and splice operations involving large or complex replacements.
  - Fixed boundary-chain merging and redistribution to maintain valid node sizes and tree structure.
  - Improved root normalization after deletions and repaired previously invalid unary internal-node cases.
  - Preserved accurate tree counts, ranges, and model-consistent results across edge cases.

- **Documentation**
  - Clarified mutation callback complexity and documented replacement sizing, propagation, and rebalancing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->