### PR TITLE
refactor(web): compose Resume workbench panes

### DIFF
--- a/examples/web/src/features/resume/browser/app.tsx
+++ b/examples/web/src/features/resume/browser/app.tsx
@@ -9,8 +9,6 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type KeyboardEvent,
-  type MouseEvent,
   type Ref,
 } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -47,12 +45,14 @@ import {
   projectResume,
   reducePiSession,
   PiSessionFormatError,
-  type ActivityItem,
   type NormalizedEntry,
   type ReducedPiSession,
   type ResumeDiagnostic,
   type ResumeProjection,
 } from '../core/session';
+import { buildWorkbenchView } from './workbench-view-model';
+import { useWorkbenchNavigation, Workbench } from './workbench';
+import './styles.css';
 import {
   PKE_CHAT_MESSAGE_LIMIT,
   PKE_CHAT_MESSAGE_TEXT_LIMIT,
@@ -66,7 +66,6 @@ import {
   type PkeChatSource,
   type PkeChatStatus,
 } from '../protocol/chat';
-import './styles.css';
 
 const demoSession = reducePiSession(parsePiSessionJsonl(fixtureSource));
 
@@ -83,12 +82,6 @@ const dateTimeFormat = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
-});
-const workbenchTimeFormat = new Intl.DateTimeFormat('en-US', {
-  timeZone: 'UTC',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
 });
 
 type SourceMode = 'demo' | 'imported';
@@ -233,9 +226,6 @@ function formatTimestamp(value: string): string {
   return dateTimeFormat.format(new Date(value));
 }
 
-function formatWorkbenchTime(value: string): string {
-  return workbenchTimeFormat.format(new Date(value));
-}
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} bytes`;
@@ -281,18 +271,6 @@ function formatImportError(error: unknown, file: File): ResumeDiagnostic {
   };
 }
 
-function activityKindLabel(item: ActivityItem): string {
-  switch (item.kind) {
-    case 'human': return 'human input';
-    case 'assistant-claim': return 'assistant claim';
-    case 'tool-evidence':
-      return item.evidenceStatus === 'observed-failure' ? 'tool failure' : 'tool evidence';
-    case 'checkpoint': return 'accepted anchor';
-    case 'compaction': return 'source summary';
-    case 'branch-summary': return 'branch context';
-    case 'omitted': return 'omitted';
-  }
-}
 
 function PilotSessionToolbar({
   state,
@@ -431,98 +409,6 @@ function PilotEmptyWorkspace({ state }: { readonly state: ResumeState }) {
   );
 }
 
-interface PilotTimelinePhase {
-  readonly id: string;
-  readonly index: number;
-  readonly items: readonly ActivityItem[];
-  readonly recordedKinds: readonly string[];
-}
-
-type PilotWorkbenchPane = 'timeline' | 'conversation' | 'evidence';
-type PilotEvidenceMode = 'readable' | 'normalized';
-type PilotInspectorMode = 'discuss' | 'evidence';
-
-function buildPilotTimelinePhases(
-  chronology: readonly ActivityItem[],
-): readonly PilotTimelinePhase[] {
-  const grouped: ActivityItem[][] = [];
-  let current: ActivityItem[] = [];
-  for (const item of chronology) {
-    if (item.kind === 'human' && current.length > 0) {
-      grouped.push(current);
-      current = [];
-    }
-    current.push(item);
-    if (item.kind === 'compaction') {
-      grouped.push(current);
-      current = [];
-    }
-  }
-  if (current.length > 0) grouped.push(current);
-  return grouped.map((items, index) => {
-    const first = items[0]!;
-    const last = items[items.length - 1]!;
-    const recordedKinds = [...new Set(items.map(activityKindLabel))];
-    return {
-      id: `${first.id}-${last.id}`,
-      index,
-      items: Object.freeze([...items]),
-      recordedKinds: Object.freeze(recordedKinds),
-    };
-  });
-}
-
-function normalizedEntryLabel(entry: NormalizedEntry | undefined): string {
-  if (entry === undefined) return 'withheld entry';
-  switch (entry.kind) {
-    case 'message':
-      if (entry.role === 'user') return 'user message';
-      if (entry.role === 'assistant') return 'assistant message';
-      return 'tool result';
-    case 'bashExecution': return 'bash execution';
-    case 'compaction': return 'conversation summary';
-    case 'branchSummary': return 'branch summary';
-    case 'checkpoint': return `${entry.anchorKind} checkpoint`;
-    case 'omitted': return `omitted ${entry.originalType}`;
-  }
-}
-
-type PilotChatRole = 'user' | 'assistant' | 'tool' | 'checkpoint' | 'system';
-
-function pilotChatRole(item: ActivityItem, entry: NormalizedEntry | undefined): PilotChatRole {
-  if (entry?.kind === 'message') {
-    if (entry.role === 'user') return 'user';
-    if (entry.role === 'assistant') return 'assistant';
-    return 'tool';
-  }
-  if (entry?.kind === 'bashExecution' || item.kind === 'tool-evidence') return 'tool';
-  if (entry?.kind === 'checkpoint' || item.kind === 'checkpoint') return 'checkpoint';
-  return 'system';
-}
-
-function conversationSpeaker(role: PilotChatRole): string {
-  switch (role) {
-    case 'user': return 'You';
-    case 'assistant': return 'Assistant';
-    case 'tool': return 'Tool';
-    case 'checkpoint': return 'Accepted checkpoint';
-    case 'system': return 'Session event';
-  }
-}
-
-function chatAuthorityLabel(item: ActivityItem, role: PilotChatRole): string {
-  switch (role) {
-    case 'user': return 'Recorded user message';
-    case 'assistant': return 'Unverified assistant text';
-    case 'tool': return item.evidenceStatus === 'observed-failure'
-      ? 'Observed failure'
-      : 'Observed result';
-    case 'checkpoint': return item.anchorKind === undefined
-      ? 'Accepted anchor'
-      : `Accepted ${item.anchorKind}`;
-    case 'system': return activityKindLabel(item);
-  }
-}
 
 interface PilotChatTurnContext {
   readonly context: PkeChatContext;
@@ -635,6 +521,16 @@ function chatCitationEntryId(
   }
 }
 
+interface PilotSourceChatProps {
+  readonly projection: ResumeProjection;
+  readonly selectedSource: PilotSourceSelection;
+  readonly sourceEntryIds: readonly string[];
+  readonly initialCompletedChat: readonly PkeCompletedChatTurn[];
+  readonly onToggleSource: (entryId: string) => void;
+  readonly onOpenSource: (entryId: string, leafId: string) => void;
+  readonly onCompletedChatChange: (history: readonly PkeCompletedChatTurn[]) => void;
+}
+
 function PilotSourceChat({
   projection,
   selectedSource,
@@ -643,15 +539,7 @@ function PilotSourceChat({
   onToggleSource,
   onOpenSource,
   onCompletedChatChange,
-}: {
-  readonly projection: ResumeProjection;
-  readonly selectedSource: PilotSourceSelection;
-  readonly sourceEntryIds: readonly string[];
-  readonly initialCompletedChat: readonly PkeCompletedChatTurn[];
-  readonly onToggleSource: (entryId: string) => void;
-  readonly onOpenSource: (entryId: string, leafId: string) => void;
-  readonly onCompletedChatChange: (history: readonly PkeCompletedChatTurn[]) => void;
-}) {
+}: PilotSourceChatProps) {
   const [draft, setDraft] = useState('');
   const [draftMessageId, setDraftMessageId] = useState(() => crypto.randomUUID());
   const [contextScope, setContextScope] = useState<PkeChatContext['scope']>('none');
@@ -1140,6 +1028,28 @@ function PilotSourceChat({
   );
 }
 
+function PilotWorkbenchChat({
+  projection,
+  selectedSource,
+  sourceEntryIds,
+  initialCompletedChat,
+  onToggleSource,
+  onCompletedChatChange,
+}: Omit<PilotSourceChatProps, 'onOpenSource'>) {
+  const { selectChatSource } = useWorkbenchNavigation();
+  return (
+    <PilotSourceChat
+      projection={projection}
+      selectedSource={selectedSource}
+      sourceEntryIds={sourceEntryIds}
+      initialCompletedChat={initialCompletedChat}
+      onToggleSource={onToggleSource}
+      onCompletedChatChange={onCompletedChatChange}
+      onOpenSource={selectChatSource}
+    />
+  );
+}
+
 function PilotUnderstandingWorkbench({
   projection,
   entries,
@@ -1163,481 +1073,37 @@ function PilotUnderstandingWorkbench({
   readonly onToggleChatSource: (entryId: string) => void;
   readonly onCompletedChatChange: (history: readonly PkeCompletedChatTurn[]) => void;
 }) {
-  const phases = useMemo(
-    () => buildPilotTimelinePhases(projection.chronology),
-    [projection.chronology],
+  const viewModel = useMemo(
+    () => buildWorkbenchView(projection, entries, selectedSource.entryId),
+    [entries, projection, selectedSource.entryId],
   );
-  const entriesById = useMemo(
-    () => new Map(entries.map(entry => [entry.id, entry])),
-    [entries],
-  );
-  const operationIndex = useMemo(() => {
-    const calls = new Map<string, { readonly entryId: string; readonly name: string }>();
-    const results = new Map<string, { readonly entryId: string; readonly name: string }>();
-    for (const entry of entries) {
-      if (entry.kind === 'message' && entry.role === 'assistant') {
-        for (const call of entry.toolCalls) {
-          calls.set(call.id, { entryId: entry.id, name: call.name });
-        }
-      }
-      if (
-        entry.kind === 'message' &&
-        entry.role === 'toolResult' &&
-        entry.toolCallId !== undefined
-      ) {
-        results.set(entry.toolCallId, {
-          entryId: entry.id,
-          name: entry.toolName ?? 'tool',
-        });
-      }
-    }
-    return { calls, results };
-  }, [entries]);
-  const selectedPhaseId = phases.find(phase =>
-    phase.items.some(item => item.source.entryId === selectedSource.entryId),
-  )?.id;
-  const [expandedPhaseIds, setExpandedPhaseIds] = useState<ReadonlySet<string>>(
-    () => new Set(selectedPhaseId === undefined ? [] : [selectedPhaseId]),
-  );
-  useEffect(() => {
-    if (selectedPhaseId === undefined) return;
-    setExpandedPhaseIds(current =>
-      current.has(selectedPhaseId) ? current : new Set([...current, selectedPhaseId]),
-    );
-  }, [selectedPhaseId]);
-  const [activePane, setActivePane] = useState<PilotWorkbenchPane>('conversation');
-  const previousSelectedSourceRef = useRef(selectedSource.entryId);
-  useEffect(() => {
-    const sourceChanged = previousSelectedSourceRef.current !== selectedSource.entryId;
-    previousSelectedSourceRef.current = selectedSource.entryId;
-  }, [selectedSource.entryId]);
-  const conversationPanelRef = useRef<HTMLElement | null>(null);
-  const selectedConversationRef = useRef<HTMLLIElement | null>(null);
-  const revealConversationSelectionRef = useRef(false);
-  const focusConversationSelectionRef = useRef(false);
-  const [inspectorMode, setInspectorMode] = useState<PilotInspectorMode>('discuss');
-  const [evidenceMode, setEvidenceMode] = useState<PilotEvidenceMode>('readable');
-  const selectedItemIndex = Math.max(
-    0,
-    projection.chronology.findIndex(item => item.source.entryId === selectedSource.entryId),
-  );
-  const selectedItem = projection.chronology[selectedItemIndex];
-  const selectedRecord = selectedItem === undefined
-    ? undefined
-    : entriesById.get(selectedItem.source.entryId);
-  const selectedPhase = phases.find(phase => phase.id === selectedPhaseId);
-  const conversationItems = projection.chronology;
-  const normalizedRecord = selectedRecord === undefined
-    ? 'This entry was withheld by the bounded import policy.'
-    : JSON.stringify(selectedRecord, null, 2);
-  let operationRelationship: string | undefined;
-  if (selectedRecord?.kind === 'message' && selectedRecord.role === 'assistant') {
-    const linkedResults = selectedRecord.toolCalls
-      .map(call => operationIndex.results.get(call.id))
-      .filter((result): result is { readonly entryId: string; readonly name: string } =>
-        result !== undefined,
-      );
-    if (selectedRecord.toolCalls.length > 0) {
-      operationRelationship = `${selectedRecord.toolCalls.map(call => call.name).join(', ')} requested · ${linkedResults.length} matching result${linkedResults.length === 1 ? '' : 's'} recorded`;
-    }
-  } else if (
-    selectedRecord?.kind === 'message' &&
-    selectedRecord.role === 'toolResult' &&
-    selectedRecord.toolCallId !== undefined
-  ) {
-    const request = operationIndex.calls.get(selectedRecord.toolCallId);
-    operationRelationship = request === undefined
-      ? 'Tool result recorded; its request is outside the selected path.'
-      : `Result for ${request.name} requested by source entry ${request.entryId}`;
-  }
-
-  useEffect(() => {
-    if (activePane !== 'conversation') return;
-    const frame = window.requestAnimationFrame(() => {
-      const panel = conversationPanelRef.current;
-      const target = selectedConversationRef.current;
-      if (panel === null || target === null) return;
-      const usesInternalScroll = window.getComputedStyle(panel).overflowY !== 'visible';
-      if (usesInternalScroll) {
-        const panelBox = panel.getBoundingClientRect();
-        const targetBox = target.getBoundingClientRect();
-        const headingHeight = panel.querySelector<HTMLElement>('.pilot-panel-heading')
-          ?.getBoundingClientRect().height ?? 0;
-        panel.scrollTo({
-          top: Math.max(
-            0,
-            panel.scrollTop + targetBox.top - panelBox.top - headingHeight - 4,
-          ),
-          behavior: 'auto',
-        });
-      } else if (revealConversationSelectionRef.current) {
-        target.scrollIntoView({ block: 'center', behavior: 'auto' });
-      }
-      if (focusConversationSelectionRef.current) {
-        target.focus({ preventScroll: true });
-      }
-      revealConversationSelectionRef.current = false;
-      focusConversationSelectionRef.current = false;
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [activePane, selectedSource.entryId]);
-
-  const selectFromTimeline = (entryId: string): void => {
-    revealConversationSelectionRef.current = true;
-    onSelectEntry(entryId);
-    setActivePane('conversation');
-  };
-
-  const selectConversationAt = (index: number, focus: boolean): void => {
-    const item = conversationItems[index];
-    if (item === undefined) return;
-    if (item.source.entryId === selectedSource.entryId) {
-      focusConversationSelectionRef.current = false;
-      if (focus) selectedConversationRef.current?.focus({ preventScroll: true });
-      return;
-    }
-    focusConversationSelectionRef.current = focus;
-    onSelectEntry(item.source.entryId);
-  };
-
-  const handleConversationKeyDown = (
-    event: KeyboardEvent<HTMLLIElement>,
-    index: number,
-  ): void => {
-    let nextIndex: number | undefined;
-    switch (event.key) {
-      case 'Enter':
-      case ' ':
-        nextIndex = index;
-        break;
-      case 'ArrowDown':
-        nextIndex = Math.min(conversationItems.length - 1, index + 1);
-        break;
-      case 'ArrowUp':
-        nextIndex = Math.max(0, index - 1);
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = conversationItems.length - 1;
-        break;
-      default:
-        return;
-    }
-    event.preventDefault();
-    selectConversationAt(nextIndex, true);
-  };
-
   return (
-    <section className="pilot-workbench" aria-labelledby="pilot-workbench-title">
+    <Workbench.Root
+      viewModel={viewModel}
+      selectedEntryId={selectedSource.entryId}
+      terminalPathId={projection.leafId}
+      onSelectEntry={onSelectEntry}
+      onSelectChatSource={onSelectChatSource}
+      onToggleChatSource={onToggleChatSource}
+    >
       <h2 className="visually-hidden" id="pilot-workbench-title">Session understanding</h2>
-      <nav className="pilot-workbench-tabs" aria-label="Session understanding views">
-        {(['timeline', 'conversation', 'evidence'] as const).map(pane => (
-          <button
-            type="button"
-            data-pane={pane}
-            aria-pressed={activePane === pane}
-            key={pane}
-            onClick={() => setActivePane(pane)}
-          >
-            {pane === 'timeline' ? 'Timeline' : pane === 'conversation' ? 'Conversation' : 'Evidence'}
-          </button>
-        ))}
-      </nav>
-      <div className="pilot-workbench-grid" data-active-pane={activePane}>
-        <section
-          className="pilot-workbench-panel pilot-timeline"
-          data-pane="timeline"
-          aria-labelledby="pilot-timeline-title"
-        >
-          <header className="pilot-panel-heading">
-            <div>
-              <h3 id="pilot-timeline-title">Timeline</h3>
-            </div>
-            <p>{phases.length} phases · {projection.chronology.length} recorded events</p>
-          </header>
-          <ol className="pilot-phase-list">
-            {phases.map(phase => {
-              const containsSelection = phase === selectedPhase;
-              const expanded = expandedPhaseIds.has(phase.id);
-              const first = phase.items[0]!;
-              const last = phase.items[phase.items.length - 1]!;
-              return (
-                <li className="pilot-phase" data-selected={containsSelection} key={phase.id}>
-                  <button
-                    className="pilot-phase-toggle"
-                    type="button"
-                    aria-expanded={expanded}
-                    onClick={() => {
-                      setExpandedPhaseIds(current => {
-                        const next = new Set(current);
-                        if (next.has(phase.id)) next.delete(phase.id);
-                        else next.add(phase.id);
-                        return next;
-                      });
-                    }}
-                  >
-                    <span>Phase {String(phase.index + 1).padStart(2, '0')}</span>
-                    <time dateTime={first.timestamp}>
-                      {formatWorkbenchTime(first.timestamp)}–{formatWorkbenchTime(last.timestamp)}
-                    </time>
-                    <strong>{phase.recordedKinds.join(' · ')}</strong>
-                    <i aria-hidden="true">{expanded ? '−' : '+'}</i>
-                  </button>
-                  {expanded ? (
-                    <ol className="pilot-event-list">
-                      {phase.items.map(item => {
-                        const selected = item.source.entryId === selectedSource.entryId;
-                        return (
-                          <li
-                            id={`source-${item.source.entryId}`}
-                            data-selected={selected}
-                            aria-current={selected ? 'true' : undefined}
-                            key={item.id}
-                          >
-                            <button type="button" onClick={() => selectFromTimeline(item.source.entryId)}>
-                              <span>{activityKindLabel(item)}</span>
-                              <time dateTime={item.timestamp}>{formatWorkbenchTime(item.timestamp)}</time>
-                              <strong>{item.title}</strong>
-                              <small>{activityTextForDisplay(item)}</small>
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ol>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ol>
-        </section>
-
-        <section
-          className="pilot-workbench-panel pilot-conversation"
-          data-pane="conversation"
-          aria-labelledby="pilot-conversation-title"
-          ref={conversationPanelRef}
-        >
-          <header className="pilot-panel-heading">
-            <div>
-              <h3 id="pilot-conversation-title">Conversation</h3>
-            </div>
-            <p>
-              Full selected path · {projection.chronology.length} events · selected {selectedItemIndex + 1}
-            </p>
-          </header>
-          <ol
-            className="pilot-conversation-list"
-            role="listbox"
-            aria-label="Recorded conversation"
-          >
-            {conversationItems.map((item, index) => {
-              const selected = item.source.entryId === selectedSource.entryId;
-              const record = entriesById.get(item.source.entryId);
-              const role = pilotChatRole(item, record);
-              const assistantRecord = record?.kind === 'message' && record.role === 'assistant'
-                ? record
-                : undefined;
-              const toolResultRecord = record?.kind === 'message' && record.role === 'toolResult'
-                ? record
-                : undefined;
-              const linkedRequest = toolResultRecord?.toolCallId === undefined
-                ? undefined
-                : operationIndex.calls.get(toolResultRecord.toolCallId);
-              return (
-                <li
-                  data-role={role}
-                  data-entry-id={item.source.entryId}
-                  data-route-focus={`conversation:${item.source.entryId}`}
-                  data-anchor={item.anchorKind}
-                  data-selected={selected}
-                  data-status={item.evidenceStatus}
-                  role="option"
-                  aria-label={`${conversationSpeaker(role)}: ${item.title}, ${formatWorkbenchTime(item.timestamp)}`}
-                  aria-current={selected ? 'true' : undefined}
-                  aria-selected={selected}
-                  aria-keyshortcuts="ArrowUp ArrowDown Home End Enter Space"
-                  tabIndex={selected ? 0 : -1}
-                  key={item.id}
-                  ref={selected ? selectedConversationRef : undefined}
-                  onClick={event => {
-                    const selection = window.getSelection();
-                    const selectedTextIsInside = selection?.isCollapsed === false &&
-                      ((selection.anchorNode !== null && event.currentTarget.contains(selection.anchorNode)) ||
-                        (selection.focusNode !== null && event.currentTarget.contains(selection.focusNode)));
-                    if (selectedTextIsInside) return;
-                    event.currentTarget.focus({ preventScroll: true });
-                    selectConversationAt(index, false);
-                  }}
-                  onKeyDown={event => handleConversationKeyDown(event, index)}
-                >
-                  <article className="pilot-chat-turn">
-                    <header className="pilot-chat-meta">
-                      <div>
-                        <span className="pilot-chat-author">
-                          {conversationSpeaker(role)}
-                        </span>
-                        <span>{chatAuthorityLabel(item, role)}</span>
-                        {selected ? <strong>Selected source</strong> : null}
-                      </div>
-                      <time dateTime={item.timestamp}>{formatWorkbenchTime(item.timestamp)}</time>
-                    </header>
-                    <div className="pilot-chat-bubble">
-                      {role === 'checkpoint' || role === 'system' || role === 'tool' ? (
-                        <strong className="pilot-chat-event-title">{item.title}</strong>
-                      ) : null}
-                      <p>{activityTextForDisplay(item)}</p>
-                      {assistantRecord === undefined || assistantRecord.toolCalls.length === 0 ? null : (
-                        <div className="pilot-chat-tool-calls" aria-label="Tool calls in this assistant message">
-                          {assistantRecord.toolCalls.map(call => {
-                            const result = operationIndex.results.get(call.id);
-                            return (
-                              <div className="pilot-chat-tool-call" key={call.id}>
-                                <div>
-                                  <span>Tool call</span>
-                                  <strong>{call.name}</strong>
-                                  <em>{result === undefined ? 'No result on path' : 'Result recorded'}</em>
-                                </div>
-                                <dl>
-                                  <div><dt>Call</dt><dd>{call.id}</dd></div>
-                                  {call.path === undefined ? null : <div><dt>Path</dt><dd>{call.path}</dd></div>}
-                                  {call.editCount === undefined ? null : <div><dt>Edits</dt><dd>{call.editCount}</dd></div>}
-                                  {call.bashClassification === undefined ? null : (
-                                    <div><dt>Kind</dt><dd>{call.bashClassification}</dd></div>
-                                  )}
-                                  {result === undefined ? null : <div><dt>Result source</dt><dd>{result.entryId}</dd></div>}
-                                </dl>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      )}
-                      {linkedRequest === undefined ? null : (
-                        <p className="pilot-chat-operation-link">
-                          Result for <strong>{linkedRequest.name}</strong> requested in source {linkedRequest.entryId}
-                        </p>
-                      )}
-                      {record?.kind === 'bashExecution' ? (
-                        <dl className="pilot-chat-command-meta">
-                          <div><dt>Command kind</dt><dd>{record.classification}</dd></div>
-                          <div><dt>Exit</dt><dd>{record.exitCode ?? 'unknown'}</dd></div>
-                          <div><dt>Cancelled</dt><dd>{record.cancelled ? 'yes' : 'no'}</dd></div>
-                        </dl>
-                      ) : null}
-                      <footer>
-                        <span>{normalizedEntryLabel(record)}</span>
-                        <span>source {item.source.entryId}</span>
-                      </footer>
-                    </div>
-                  </article>
-                </li>
-              );
-            })}
-          </ol>
-        </section>
-
-        <section
-          className="pilot-workbench-panel pilot-evidence"
-          data-pane="evidence"
-          id="pilot-inspector"
-          aria-labelledby="pilot-inspector-title"
-        >
-          <header className="pilot-panel-heading">
-            <div>
-              <h3 id="pilot-inspector-title" tabIndex={-1}>Evidence</h3>
-            </div>
-            <p>Selected {selectedItemIndex + 1} of {projection.chronology.length}</p>
-          </header>
-          <div className="pilot-inspector-tabs" role="tablist" aria-label="Evidence panel mode">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={inspectorMode === 'discuss'}
-              onClick={() => setInspectorMode('discuss')}
-            >
-              Discuss
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={inspectorMode === 'evidence'}
-              onClick={() => setInspectorMode('evidence')}
-            >
-              Evidence
-            </button>
-          </div>
-          <div hidden={inspectorMode !== 'discuss'} role="tabpanel">
-            <PilotSourceChat
-              key={chatInstanceId}
-              projection={projection}
-              selectedSource={selectedSource}
-              sourceEntryIds={chatSourceEntryIds}
-              initialCompletedChat={initialCompletedChat}
-              onToggleSource={onToggleChatSource}
-              onCompletedChatChange={onCompletedChatChange}
-              onOpenSource={(entryId, leafId) => {
-                onSelectChatSource(entryId, leafId);
-                setActivePane('evidence');
-              }}
-            />
-          </div>
-          {inspectorMode !== 'evidence' ? null : (
-            <>
-              <div className="pilot-evidence-tabs" role="tablist" aria-label="Evidence representation">
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={evidenceMode === 'readable'}
-                  onClick={() => setEvidenceMode('readable')}
-                >
-                  Readable
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={evidenceMode === 'normalized'}
-                  onClick={() => setEvidenceMode('normalized')}
-                >
-                  Normalized record
-                </button>
-              </div>
-              {evidenceMode === 'readable' ? (
-                <div className="pilot-evidence-readable" role="tabpanel">
-                  <section className="pilot-evidence-copy" aria-labelledby="pilot-evidence-copy-title">
-                    <span className="kicker">Selected recorded entry</span>
-                    <h4 id="pilot-evidence-copy-title">{selectedItem?.title ?? 'Unavailable entry'}</h4>
-                    <p>{selectedItem === undefined
-                      ? 'No recorded entry is selected.'
-                      : activityTextForDisplay(selectedItem)}</p>
-                  </section>
-                  <dl className="pilot-evidence-metadata">
-                    <div><dt>Recorded type</dt><dd>{normalizedEntryLabel(selectedRecord)}</dd></div>
-                    <div><dt>Time</dt><dd>{selectedItem === undefined ? 'Unknown' : formatWorkbenchTime(selectedItem.timestamp)}</dd></div>
-                    <div><dt>Path position</dt><dd>{selectedItemIndex + 1} of {projection.chronology.length}</dd></div>
-                    <div><dt>Terminal path</dt><dd>{projection.leafId}</dd></div>
-                    <div><dt>Source entry</dt><dd>{selectedSource.entryId}</dd></div>
-                  </dl>
-                  {operationRelationship === undefined ? null : (
-                    <div className="pilot-operation-relation">
-                      <strong>Recorded operation relationship</strong>
-                      <p>{operationRelationship}</p>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className="pilot-evidence-normalized" role="tabpanel">
-                  <p>
-                    This is the bounded normalized import used by this view, not the unfiltered JSONL line.
-                  </p>
-                  <pre>{normalizedRecord}</pre>
-                </div>
-              )}
-            </>
-          )}
-        </section>
-      </div>
-    </section>
+      <Workbench.Tabs />
+      <Workbench.Grid>
+        <Workbench.Timeline />
+        <Workbench.Conversation />
+        <Workbench.Evidence>
+          <PilotWorkbenchChat
+            key={chatInstanceId}
+            projection={projection}
+            selectedSource={selectedSource}
+            sourceEntryIds={chatSourceEntryIds}
+            initialCompletedChat={initialCompletedChat}
+            onToggleSource={onToggleChatSource}
+            onCompletedChatChange={onCompletedChatChange}
+          />
+        </Workbench.Evidence>
+      </Workbench.Grid>
+    </Workbench.Root>
   );
 }
 

--- a/examples/web/src/features/resume/browser/conversation-pane.tsx
+++ b/examples/web/src/features/resume/browser/conversation-pane.tsx
@@ -1,0 +1,264 @@
+import {
+  forwardRef,
+  useImperativeHandle,
+  type KeyboardEvent,
+} from 'react';
+import {
+  activityTextForDisplay,
+  type ActivityItem,
+  type NormalizedEntry,
+} from '../core/session';
+import {
+  activityKindLabel,
+  normalizedEntryLabel,
+} from './workbench-view-model';
+import { useConversationSelectionScroll } from './use-conversation-selection-scroll';
+
+type PilotChatRole = 'user' | 'assistant' | 'tool' | 'checkpoint' | 'system';
+
+function pilotChatRole(item: ActivityItem, entry: NormalizedEntry | undefined): PilotChatRole {
+  if (entry?.kind === 'message') {
+    if (entry.role === 'user') return 'user';
+    if (entry.role === 'assistant') return 'assistant';
+    return 'tool';
+  }
+  if (entry?.kind === 'bashExecution' || item.kind === 'tool-evidence') return 'tool';
+  if (entry?.kind === 'checkpoint' || item.kind === 'checkpoint') return 'checkpoint';
+  return 'system';
+}
+
+function conversationSpeaker(role: PilotChatRole): string {
+  switch (role) {
+    case 'user': return 'You';
+    case 'assistant': return 'Assistant';
+    case 'tool': return 'Tool';
+    case 'checkpoint': return 'Accepted checkpoint';
+    case 'system': return 'Session event';
+  }
+}
+
+function chatAuthorityLabel(item: ActivityItem, role: PilotChatRole): string {
+  switch (role) {
+    case 'user': return 'Recorded user message';
+    case 'assistant': return 'Unverified assistant text';
+    case 'tool': return item.evidenceStatus === 'observed-failure'
+      ? 'Observed failure'
+      : 'Observed result';
+    case 'checkpoint': return item.anchorKind === undefined
+      ? 'Accepted anchor'
+      : `Accepted ${item.anchorKind}`;
+    case 'system': return activityKindLabel(item);
+  }
+}
+
+export interface ConversationPaneHandle {
+  revealConversationSelection: () => void;
+}
+
+export interface ConversationPaneProps {
+  readonly active: boolean;
+  readonly conversationItems: readonly ActivityItem[];
+  readonly entriesById: ReadonlyMap<string, NormalizedEntry>;
+  readonly operationIndex: Readonly<{
+    readonly calls: ReadonlyMap<string, { readonly entryId: string; readonly name: string }>;
+    readonly results: ReadonlyMap<string, { readonly entryId: string; readonly name: string }>;
+  }>;
+  readonly selectedEntryId: string;
+  readonly selectedItemIndex: number;
+  readonly totalEvents: number;
+  readonly formatTime: (value: string) => string;
+  readonly onSelectEntry: (entryId: string) => void;
+}
+
+export const ConversationPane = forwardRef<ConversationPaneHandle, ConversationPaneProps>(
+  function ConversationPane(props, ref) {
+    const {
+      active,
+      conversationItems,
+      entriesById,
+      operationIndex,
+      selectedEntryId,
+      selectedItemIndex,
+      totalEvents,
+      formatTime,
+      onSelectEntry,
+    } = props;
+
+    const {
+      conversationPanelRef,
+      revealConversationSelection,
+      focusConversationSelection,
+      selectedConversationRef,
+    } = useConversationSelectionScroll(active, selectedEntryId);
+
+    useImperativeHandle(ref, () => ({
+      revealConversationSelection,
+    }));
+
+    const selectConversationAt = (index: number, focus: boolean): void => {
+      const item = conversationItems[index];
+      if (item === undefined) return;
+      if (item.source.entryId === selectedEntryId) {
+        if (focus) selectedConversationRef.current?.focus({ preventScroll: true });
+        return;
+      }
+      if (focus) focusConversationSelection();
+      onSelectEntry(item.source.entryId);
+    };
+
+    const handleConversationKeyDown = (
+      event: KeyboardEvent<HTMLLIElement>,
+      index: number,
+    ): void => {
+      let nextIndex: number | undefined;
+      switch (event.key) {
+        case 'Enter':
+        case ' ':
+          nextIndex = index;
+          break;
+        case 'ArrowDown':
+          nextIndex = Math.min(conversationItems.length - 1, index + 1);
+          break;
+        case 'ArrowUp':
+          nextIndex = Math.max(0, index - 1);
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = conversationItems.length - 1;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      selectConversationAt(nextIndex, true);
+    };
+
+    return (
+      <section
+        className="pilot-workbench-panel pilot-conversation"
+        data-pane="conversation"
+        aria-labelledby="pilot-conversation-title"
+        ref={conversationPanelRef}
+      >
+        <header className="pilot-panel-heading">
+          <div>
+            <h3 id="pilot-conversation-title">Conversation</h3>
+          </div>
+          <p>
+            Full selected path · {totalEvents} events · selected {selectedItemIndex + 1}
+          </p>
+        </header>
+        <ol
+          className="pilot-conversation-list"
+          role="listbox"
+          aria-label="Recorded conversation"
+        >
+          {conversationItems.map((item, index) => {
+            const selected = item.source.entryId === selectedEntryId;
+            const record = entriesById.get(item.source.entryId);
+            const role = pilotChatRole(item, record);
+            const assistantRecord = record?.kind === 'message' && record.role === 'assistant'
+              ? record
+              : undefined;
+            const toolResultRecord = record?.kind === 'message' && record.role === 'toolResult'
+              ? record
+              : undefined;
+            const linkedRequest = toolResultRecord?.toolCallId === undefined
+              ? undefined
+              : operationIndex.calls.get(toolResultRecord.toolCallId);
+            return (
+              <li
+                data-role={role}
+                data-entry-id={item.source.entryId}
+                data-route-focus={`conversation:${item.source.entryId}`}
+                data-anchor={item.anchorKind}
+                data-selected={selected}
+                data-status={item.evidenceStatus}
+                role="option"
+                aria-label={`${conversationSpeaker(role)}: ${item.title}, ${formatTime(item.timestamp)}`}
+                aria-current={selected ? 'true' : undefined}
+                aria-selected={selected}
+                aria-keyshortcuts="ArrowUp ArrowDown Home End Enter Space"
+                tabIndex={selected ? 0 : -1}
+                key={item.id}
+                ref={selected ? selectedConversationRef : undefined}
+                onClick={event => {
+                  const selection = window.getSelection();
+                  const selectedTextIsInside = selection?.isCollapsed === false &&
+                    ((selection.anchorNode !== null && event.currentTarget.contains(selection.anchorNode)) ||
+                      (selection.focusNode !== null && event.currentTarget.contains(selection.focusNode)));
+                  if (selectedTextIsInside) return;
+                  event.currentTarget.focus({ preventScroll: true });
+                  selectConversationAt(index, false);
+                }}
+                onKeyDown={event => handleConversationKeyDown(event, index)}
+              >
+                <article className="pilot-chat-turn">
+                  <header className="pilot-chat-meta">
+                    <div>
+                      <span className="pilot-chat-author">
+                        {conversationSpeaker(role)}
+                      </span>
+                      <span>{chatAuthorityLabel(item, role)}</span>
+                      {selected ? <strong>Selected source</strong> : null}
+                    </div>
+                    <time dateTime={item.timestamp}>{formatTime(item.timestamp)}</time>
+                  </header>
+                  <div className="pilot-chat-bubble">
+                    {role === 'checkpoint' || role === 'system' || role === 'tool' ? (
+                      <strong className="pilot-chat-event-title">{item.title}</strong>
+                    ) : null}
+                    <p>{activityTextForDisplay(item)}</p>
+                    {assistantRecord === undefined || assistantRecord.toolCalls.length === 0 ? null : (
+                      <div className="pilot-chat-tool-calls" aria-label="Tool calls in this assistant message">
+                        {assistantRecord.toolCalls.map(call => {
+                          const result = operationIndex.results.get(call.id);
+                          return (
+                            <div className="pilot-chat-tool-call" key={call.id}>
+                              <div>
+                                <span>Tool call</span>
+                                <strong>{call.name}</strong>
+                                <em>{result === undefined ? 'No result on path' : 'Result recorded'}</em>
+                              </div>
+                              <dl>
+                                <div><dt>Call</dt><dd>{call.id}</dd></div>
+                                {call.path === undefined ? null : <div><dt>Path</dt><dd>{call.path}</dd></div>}
+                                {call.editCount === undefined ? null : <div><dt>Edits</dt><dd>{call.editCount}</dd></div>}
+                                {call.bashClassification === undefined ? null : (
+                                  <div><dt>Kind</dt><dd>{call.bashClassification}</dd></div>
+                                )}
+                                {result === undefined ? null : <div><dt>Result source</dt><dd>{result.entryId}</dd></div>}
+                              </dl>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                    {linkedRequest === undefined ? null : (
+                      <p className="pilot-chat-operation-link">
+                        Result for <strong>{linkedRequest.name}</strong> requested in source {linkedRequest.entryId}
+                      </p>
+                    )}
+                    {record?.kind === 'bashExecution' ? (
+                      <dl className="pilot-chat-command-meta">
+                        <div><dt>Command kind</dt><dd>{record.classification}</dd></div>
+                        <div><dt>Exit</dt><dd>{record.exitCode ?? 'unknown'}</dd></div>
+                        <div><dt>Cancelled</dt><dd>{record.cancelled ? 'yes' : 'no'}</dd></div>
+                      </dl>
+                    ) : null}
+                    <footer>
+                      <span>{normalizedEntryLabel(record)}</span>
+                      <span>source {item.source.entryId}</span>
+                    </footer>
+                  </div>
+                </article>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+    );
+  },
+);

--- a/examples/web/src/features/resume/browser/evidence-pane.tsx
+++ b/examples/web/src/features/resume/browser/evidence-pane.tsx
@@ -1,0 +1,77 @@
+import { useState, type ReactNode } from 'react';
+import { activityTextForDisplay, type ActivityItem, type NormalizedEntry } from '../core/session';
+
+export interface EvidencePaneProps {
+  readonly chat: ReactNode;
+  readonly normalizedRecord: string;
+  readonly operationRelationship: string | undefined;
+  readonly selectedEntryId: string;
+  readonly selectedItem: ActivityItem | undefined;
+  readonly selectedItemIndex: number;
+  readonly selectedRecord: NormalizedEntry | undefined;
+  readonly terminalPathId: string;
+  readonly totalItems: number;
+  readonly formatTime: (timestamp: string) => string;
+  readonly normalizedEntryLabel: (entry: NormalizedEntry | undefined) => string;
+}
+
+export function EvidencePane({
+  chat,
+  normalizedRecord,
+  operationRelationship,
+  selectedEntryId,
+  selectedItem,
+  selectedItemIndex,
+  selectedRecord,
+  terminalPathId,
+  totalItems,
+  formatTime,
+  normalizedEntryLabel,
+}: EvidencePaneProps) {
+  const [inspectorMode, setInspectorMode] = useState<'discuss' | 'evidence'>('discuss');
+  const [evidenceMode, setEvidenceMode] = useState<'readable' | 'normalized'>('readable');
+
+  return (
+    <section className="pilot-workbench-panel pilot-evidence" data-pane="evidence" id="pilot-inspector" aria-labelledby="pilot-inspector-title">
+      <header className="pilot-panel-heading">
+        <div><h3 id="pilot-inspector-title" tabIndex={-1}>Evidence</h3></div>
+        <p>Selected {selectedItemIndex + 1} of {totalItems}</p>
+      </header>
+      <div className="pilot-inspector-tabs" role="tablist" aria-label="Evidence panel mode">
+        <button type="button" role="tab" aria-selected={inspectorMode === 'discuss'} onClick={() => setInspectorMode('discuss')}>Discuss</button>
+        <button type="button" role="tab" aria-selected={inspectorMode === 'evidence'} onClick={() => setInspectorMode('evidence')}>Evidence</button>
+      </div>
+      <div hidden={inspectorMode !== 'discuss'} role="tabpanel">{chat}</div>
+      {inspectorMode !== 'evidence' ? null : (
+        <>
+          <div className="pilot-evidence-tabs" role="tablist" aria-label="Evidence representation">
+            <button type="button" role="tab" aria-selected={evidenceMode === 'readable'} onClick={() => setEvidenceMode('readable')}>Readable</button>
+            <button type="button" role="tab" aria-selected={evidenceMode === 'normalized'} onClick={() => setEvidenceMode('normalized')}>Normalized record</button>
+          </div>
+          {evidenceMode === 'readable' ? (
+            <div className="pilot-evidence-readable" role="tabpanel">
+              <section className="pilot-evidence-copy" aria-labelledby="pilot-evidence-copy-title">
+                <span className="kicker">Selected recorded entry</span>
+                <h4 id="pilot-evidence-copy-title">{selectedItem?.title ?? 'Unavailable entry'}</h4>
+                <p>{selectedItem === undefined ? 'No recorded entry is selected.' : activityTextForDisplay(selectedItem)}</p>
+              </section>
+              <dl className="pilot-evidence-metadata">
+                <div><dt>Recorded type</dt><dd>{normalizedEntryLabel(selectedRecord)}</dd></div>
+                <div><dt>Time</dt><dd>{selectedItem === undefined ? 'Unknown' : formatTime(selectedItem.timestamp)}</dd></div>
+                <div><dt>Path position</dt><dd>{selectedItemIndex + 1} of {totalItems}</dd></div>
+                <div><dt>Terminal path</dt><dd>{terminalPathId}</dd></div>
+                <div><dt>Source entry</dt><dd>{selectedEntryId}</dd></div>
+              </dl>
+              {operationRelationship === undefined ? null : <div className="pilot-operation-relation"><strong>Recorded operation relationship</strong><p>{operationRelationship}</p></div>}
+            </div>
+          ) : (
+            <div className="pilot-evidence-normalized" role="tabpanel">
+              <p>This is the bounded normalized import used by this view, not the unfiltered JSONL line.</p>
+              <pre>{normalizedRecord}</pre>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/examples/web/src/features/resume/browser/timeline-pane.tsx
+++ b/examples/web/src/features/resume/browser/timeline-pane.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { activityTextForDisplay } from '../core/session';
+import {
+  activityKindLabel,
+  type PilotTimelinePhase,
+} from './workbench-view-model';
+
+export interface TimelinePaneProps {
+  readonly phases: readonly PilotTimelinePhase[];
+  readonly selectedEntryId: string;
+  readonly selectedPhase: PilotTimelinePhase | undefined;
+  readonly selectedPhaseId: string | undefined;
+  readonly formatTime: (timestamp: string) => string;
+  readonly onSelectEntry: (entryId: string) => void;
+}
+
+export function TimelinePane({
+  phases,
+  selectedEntryId,
+  selectedPhase,
+  selectedPhaseId,
+  formatTime,
+  onSelectEntry,
+}: TimelinePaneProps) {
+  const [expandedPhaseIds, setExpandedPhaseIds] = useState<ReadonlySet<string>>(
+    () => new Set(selectedPhaseId === undefined ? [] : [selectedPhaseId]),
+  );
+  useEffect(() => {
+    if (selectedPhaseId === undefined) return;
+    setExpandedPhaseIds(current =>
+      current.has(selectedPhaseId) ? current : new Set([...current, selectedPhaseId]),
+    );
+  }, [selectedPhaseId]);
+
+  return (
+    <section
+      className="pilot-workbench-panel pilot-timeline"
+      data-pane="timeline"
+      aria-labelledby="pilot-timeline-title"
+    >
+      <header className="pilot-panel-heading">
+        <div>
+          <h3 id="pilot-timeline-title">Timeline</h3>
+        </div>
+        <p>{phases.length} phases · {phases.flatMap(phase => phase.items).length} recorded events</p>
+      </header>
+      <ol className="pilot-phase-list">
+        {phases.map(phase => {
+          const containsSelection = phase === selectedPhase;
+          const expanded = expandedPhaseIds.has(phase.id);
+          const first = phase.items[0]!;
+          const last = phase.items[phase.items.length - 1]!;
+          return (
+            <li className="pilot-phase" data-selected={containsSelection} key={phase.id}>
+              <button
+                className="pilot-phase-toggle"
+                type="button"
+                aria-expanded={expanded}
+                onClick={() => {
+                  setExpandedPhaseIds(current => {
+                    const next = new Set(current);
+                    if (next.has(phase.id)) next.delete(phase.id);
+                    else next.add(phase.id);
+                    return next;
+                  });
+                }}
+              >
+                <span>Phase {String(phase.index + 1).padStart(2, '0')}</span>
+                <time dateTime={first.timestamp}>
+                  {formatTime(first.timestamp)}–{formatTime(last.timestamp)}
+                </time>
+                <strong>{phase.recordedKinds.join(' · ')}</strong>
+                <i aria-hidden="true">{expanded ? '−' : '+'}</i>
+              </button>
+              {expanded ? (
+                <ol className="pilot-event-list">
+                  {phase.items.map(item => {
+                    const selected = item.source.entryId === selectedEntryId;
+                    return (
+                      <li
+                        id={`source-${item.source.entryId}`}
+                        data-selected={selected}
+                        aria-current={selected ? 'true' : undefined}
+                        key={item.id}
+                      >
+                        <button type="button" onClick={() => onSelectEntry(item.source.entryId)}>
+                          <span>{activityKindLabel(item)}</span>
+                          <time dateTime={item.timestamp}>{formatTime(item.timestamp)}</time>
+                          <strong>{item.title}</strong>
+                          <small>{activityTextForDisplay(item)}</small>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ol>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/examples/web/src/features/resume/browser/use-conversation-selection-scroll.ts
+++ b/examples/web/src/features/resume/browser/use-conversation-selection-scroll.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+
+export function useConversationSelectionScroll(
+  isConversationVisible: boolean,
+  selectedEntryId: string,
+) {
+  const conversationPanelRef = useRef<HTMLElement | null>(null);
+  const selectedConversationRef = useRef<HTMLLIElement | null>(null);
+  const revealConversationSelectionRef = useRef(false);
+  const focusConversationSelectionRef = useRef(false);
+
+  useEffect(() => {
+    if (!isConversationVisible) return;
+    const frame = window.requestAnimationFrame(() => {
+      const panel = conversationPanelRef.current;
+      const target = selectedConversationRef.current;
+      if (panel === null || target === null) {
+        revealConversationSelectionRef.current = false;
+        focusConversationSelectionRef.current = false;
+        return;
+      }
+      const usesInternalScroll = window.getComputedStyle(panel).overflowY !== 'visible';
+      if (usesInternalScroll) {
+        const panelBox = panel.getBoundingClientRect();
+        const targetBox = target.getBoundingClientRect();
+        const headingHeight = panel.querySelector<HTMLElement>('.pilot-panel-heading')
+          ?.getBoundingClientRect().height ?? 0;
+        panel.scrollTo({
+          top: Math.max(
+            0,
+            panel.scrollTop + targetBox.top - panelBox.top - headingHeight - 4,
+          ),
+          behavior: 'auto',
+        });
+      } else if (revealConversationSelectionRef.current) {
+        target.scrollIntoView({ block: 'center', behavior: 'auto' });
+      }
+      if (focusConversationSelectionRef.current) {
+        target.focus({ preventScroll: true });
+      }
+      revealConversationSelectionRef.current = false;
+      focusConversationSelectionRef.current = false;
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isConversationVisible, selectedEntryId]);
+
+  const revealConversationSelection = (): void => {
+    revealConversationSelectionRef.current = true;
+  };
+
+  const focusConversationSelection = (): void => {
+    focusConversationSelectionRef.current = true;
+  };
+
+  return {
+    conversationPanelRef,
+    revealConversationSelection,
+    focusConversationSelection,
+    selectedConversationRef,
+  };
+}

--- a/examples/web/src/features/resume/browser/workbench-view-model.ts
+++ b/examples/web/src/features/resume/browser/workbench-view-model.ts
@@ -1,0 +1,174 @@
+import type {
+  ActivityItem,
+  NormalizedEntry,
+  ResumeProjection,
+} from '../core/session';
+
+export interface PilotTimelinePhase {
+  readonly id: string;
+  readonly index: number;
+  readonly items: readonly ActivityItem[];
+  readonly recordedKinds: readonly string[];
+}
+
+interface OperationReference {
+  readonly entryId: string;
+  readonly name: string;
+}
+
+export interface WorkbenchViewModel {
+  readonly conversationItems: readonly ActivityItem[];
+  readonly entriesById: ReadonlyMap<string, NormalizedEntry>;
+  readonly normalizedRecord: string;
+  readonly operationIndex: Readonly<{
+    readonly calls: ReadonlyMap<string, OperationReference>;
+    readonly results: ReadonlyMap<string, OperationReference>;
+  }>;
+  readonly operationRelationship: string | undefined;
+  readonly phases: readonly PilotTimelinePhase[];
+  readonly selectedItem: ActivityItem | undefined;
+  readonly selectedItemIndex: number;
+  readonly selectedPhase: PilotTimelinePhase | undefined;
+  readonly selectedPhaseId: string | undefined;
+  readonly selectedRecord: NormalizedEntry | undefined;
+}
+
+export function activityKindLabel(item: ActivityItem): string {
+  switch (item.kind) {
+    case 'human': return 'human input';
+    case 'assistant-claim': return 'assistant claim';
+    case 'tool-evidence':
+      return item.evidenceStatus === 'observed-failure' ? 'tool failure' : 'tool evidence';
+    case 'checkpoint': return 'accepted anchor';
+    case 'compaction': return 'source summary';
+    case 'branch-summary': return 'branch context';
+    case 'omitted': return 'omitted';
+  }
+}
+
+export function normalizedEntryLabel(entry: NormalizedEntry | undefined): string {
+  if (entry === undefined) return 'withheld entry';
+  switch (entry.kind) {
+    case 'message':
+      if (entry.role === 'user') return 'user message';
+      if (entry.role === 'assistant') return 'assistant message';
+      return 'tool result';
+    case 'bashExecution': return 'bash execution';
+    case 'compaction': return 'conversation summary';
+    case 'branchSummary': return 'branch summary';
+    case 'checkpoint': return `${entry.anchorKind} checkpoint`;
+    case 'omitted': return `omitted ${entry.originalType}`;
+  }
+}
+
+function buildTimelinePhases(chronology: readonly ActivityItem[]): readonly PilotTimelinePhase[] {
+  const grouped: ActivityItem[][] = [];
+  let current: ActivityItem[] = [];
+  for (const item of chronology) {
+    if (item.kind === 'human' && current.length > 0) {
+      grouped.push(current);
+      current = [];
+    }
+    current.push(item);
+    if (item.kind === 'compaction') {
+      grouped.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) grouped.push(current);
+  return grouped.map((items, index) => {
+    const first = items[0]!;
+    const last = items[items.length - 1]!;
+    const recordedKinds = [...new Set(items.map(activityKindLabel))];
+    return {
+      id: `${first.id}-${last.id}`,
+      index,
+      items: Object.freeze([...items]),
+      recordedKinds: Object.freeze(recordedKinds),
+    };
+  });
+}
+
+function buildOperationIndex(entries: readonly NormalizedEntry[]) {
+  const calls = new Map<string, OperationReference>();
+  const results = new Map<string, OperationReference>();
+  for (const entry of entries) {
+    if (entry.kind === 'message' && entry.role === 'assistant') {
+      for (const call of entry.toolCalls) {
+        calls.set(call.id, { entryId: entry.id, name: call.name });
+      }
+    }
+    if (
+      entry.kind === 'message' &&
+      entry.role === 'toolResult' &&
+      entry.toolCallId !== undefined
+    ) {
+      results.set(entry.toolCallId, {
+        entryId: entry.id,
+        name: entry.toolName ?? 'tool',
+      });
+    }
+  }
+  return Object.freeze({ calls, results });
+}
+
+function operationRelationship(
+  selectedRecord: NormalizedEntry | undefined,
+  operationIndex: WorkbenchViewModel['operationIndex'],
+): string | undefined {
+  if (selectedRecord?.kind === 'message' && selectedRecord.role === 'assistant') {
+    const linkedResults = selectedRecord.toolCalls
+      .map(call => operationIndex.results.get(call.id))
+      .filter((result): result is OperationReference => result !== undefined);
+    if (selectedRecord.toolCalls.length > 0) {
+      return `${selectedRecord.toolCalls.map(call => call.name).join(', ')} requested · ${linkedResults.length} matching result${linkedResults.length === 1 ? '' : 's'} recorded`;
+    }
+  }
+  if (
+    selectedRecord?.kind === 'message' &&
+    selectedRecord.role === 'toolResult' &&
+    selectedRecord.toolCallId !== undefined
+  ) {
+    const request = operationIndex.calls.get(selectedRecord.toolCallId);
+    return request === undefined
+      ? 'Tool result recorded; its request is outside the selected path.'
+      : `Result for ${request.name} requested by source entry ${request.entryId}`;
+  }
+  return undefined;
+}
+
+export function buildWorkbenchView(
+  projection: ResumeProjection,
+  entries: readonly NormalizedEntry[],
+  selectedEntryId: string,
+): WorkbenchViewModel {
+  const phases = buildTimelinePhases(projection.chronology);
+  const entriesById = new Map(entries.map(entry => [entry.id, entry]));
+  const operationIndex = buildOperationIndex(entries);
+  const selectedPhaseId = phases.find(phase =>
+    phase.items.some(item => item.source.entryId === selectedEntryId),
+  )?.id;
+  const selectedItemIndex = Math.max(
+    0,
+    projection.chronology.findIndex(item => item.source.entryId === selectedEntryId),
+  );
+  const selectedItem = projection.chronology[selectedItemIndex];
+  const selectedRecord = selectedItem === undefined
+    ? undefined
+    : entriesById.get(selectedItem.source.entryId);
+  return {
+    conversationItems: projection.chronology,
+    entriesById,
+    normalizedRecord: selectedRecord === undefined
+      ? 'This entry was withheld by the bounded import policy.'
+      : JSON.stringify(selectedRecord, null, 2),
+    operationIndex,
+    operationRelationship: operationRelationship(selectedRecord, operationIndex),
+    phases,
+    selectedItem,
+    selectedItemIndex,
+    selectedPhase: phases.find(phase => phase.id === selectedPhaseId),
+    selectedPhaseId,
+    selectedRecord,
+  };
+}

--- a/examples/web/src/features/resume/browser/workbench.tsx
+++ b/examples/web/src/features/resume/browser/workbench.tsx
@@ -1,0 +1,234 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import {
+  ConversationPane,
+  type ConversationPaneHandle,
+} from './conversation-pane';
+import { EvidencePane } from './evidence-pane';
+import { TimelinePane } from './timeline-pane';
+import {
+  normalizedEntryLabel,
+  type WorkbenchViewModel,
+} from './workbench-view-model';
+
+export type WorkbenchPane = 'timeline' | 'conversation' | 'evidence';
+
+export interface WorkbenchRootProps {
+  readonly viewModel: WorkbenchViewModel;
+  readonly selectedEntryId: string;
+  readonly terminalPathId: string;
+  readonly onSelectEntry: (entryId: string) => void;
+  readonly onSelectChatSource: (entryId: string, leafId: string) => void;
+  readonly onToggleChatSource: (entryId: string) => void;
+  readonly children: ReactNode;
+}
+
+interface WorkbenchViewContextValue {
+  readonly viewModel: WorkbenchViewModel;
+  readonly selectedEntryId: string;
+  readonly terminalPathId: string;
+}
+
+interface WorkbenchNavigationContextValue {
+  readonly activePane: WorkbenchPane;
+  readonly setActivePane: (pane: WorkbenchPane) => void;
+  readonly selectFromTimeline: (entryId: string) => void;
+  readonly selectChatSource: (entryId: string, leafId: string) => void;
+  readonly onSelectEntry: (entryId: string) => void;
+  readonly onToggleChatSource: (entryId: string) => void;
+  readonly conversationPaneRef: RefObject<ConversationPaneHandle | null>;
+}
+
+const WorkbenchViewContext = createContext<WorkbenchViewContextValue | null>(null);
+const WorkbenchNavigationContext = createContext<WorkbenchNavigationContextValue | null>(null);
+
+function useWorkbenchView(): WorkbenchViewContextValue {
+  const context = useContext(WorkbenchViewContext);
+  if (context === null) throw new Error('Workbench compound children must be inside Workbench.Root.');
+  return context;
+}
+
+function useWorkbenchNavigation(): WorkbenchNavigationContextValue {
+  const context = useContext(WorkbenchNavigationContext);
+  if (context === null) throw new Error('Workbench compound children must be inside Workbench.Root.');
+  return context;
+}
+
+function Root({
+  viewModel,
+  selectedEntryId,
+  terminalPathId,
+  onSelectEntry,
+  onSelectChatSource,
+  onToggleChatSource,
+  children,
+}: WorkbenchRootProps) {
+  const [activePane, setActivePane] = useState<WorkbenchPane>('conversation');
+  const conversationPaneRef = useRef<ConversationPaneHandle>(null);
+  const viewContext = useMemo<WorkbenchViewContextValue>(() => ({
+    viewModel,
+    selectedEntryId,
+    terminalPathId,
+  }), [selectedEntryId, terminalPathId, viewModel]);
+  const navigationContext = useMemo<WorkbenchNavigationContextValue>(() => ({
+    activePane,
+    setActivePane,
+    selectFromTimeline: entryId => {
+      conversationPaneRef.current?.revealConversationSelection();
+      onSelectEntry(entryId);
+      setActivePane('conversation');
+    },
+    selectChatSource: (entryId, leafId) => {
+      onSelectChatSource(entryId, leafId);
+      setActivePane('evidence');
+    },
+    onSelectEntry,
+    onToggleChatSource,
+    conversationPaneRef,
+  }), [activePane, onSelectChatSource, onSelectEntry, onToggleChatSource]);
+  return (
+    <WorkbenchViewContext.Provider value={viewContext}>
+      <WorkbenchNavigationContext.Provider value={navigationContext}>
+        <section className="pilot-workbench" aria-labelledby="pilot-workbench-title">
+          {children}
+        </section>
+      </WorkbenchNavigationContext.Provider>
+    </WorkbenchViewContext.Provider>
+  );
+}
+
+function Tabs() {
+  const { activePane, setActivePane } = useWorkbenchNavigation();
+  return (
+    <nav className="pilot-workbench-tabs" aria-label="Session understanding views">
+      {(['timeline', 'conversation', 'evidence'] as const).map(pane => (
+        <button
+          type="button"
+          data-pane={pane}
+          aria-pressed={activePane === pane}
+          key={pane}
+          onClick={() => setActivePane(pane)}
+        >
+          {pane === 'timeline' ? 'Timeline' : pane === 'conversation' ? 'Conversation' : 'Evidence'}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+function Grid({ children }: { readonly children: ReactNode }) {
+  const { activePane } = useWorkbenchNavigation();
+  return (
+    <div className="pilot-workbench-grid" data-active-pane={activePane}>
+      {children}
+    </div>
+  );
+}
+
+function Timeline() {
+  const {
+    viewModel: { phases, selectedPhase, selectedPhaseId },
+    selectedEntryId,
+  } = useWorkbenchView();
+  const { selectFromTimeline } = useWorkbenchNavigation();
+  return (
+    <TimelinePane
+      phases={phases}
+      selectedEntryId={selectedEntryId}
+      selectedPhase={selectedPhase}
+      selectedPhaseId={selectedPhaseId}
+      formatTime={formatWorkbenchTime}
+      onSelectEntry={selectFromTimeline}
+    />
+  );
+}
+
+function Conversation() {
+  const {
+    viewModel: {
+      conversationItems,
+      entriesById,
+      operationIndex,
+      selectedItemIndex,
+    },
+    selectedEntryId,
+  } = useWorkbenchView();
+  const {
+    activePane,
+    conversationPaneRef,
+    onSelectEntry,
+  } = useWorkbenchNavigation();
+  return (
+    <ConversationPane
+      ref={conversationPaneRef}
+      active={activePane === 'conversation'}
+      conversationItems={conversationItems}
+      entriesById={entriesById}
+      operationIndex={operationIndex}
+      selectedEntryId={selectedEntryId}
+      selectedItemIndex={selectedItemIndex}
+      totalEvents={conversationItems.length}
+      formatTime={formatWorkbenchTime}
+      onSelectEntry={onSelectEntry}
+    />
+  );
+}
+
+function Evidence({ children }: { readonly children: ReactNode }) {
+  const {
+    viewModel: {
+      normalizedRecord,
+      operationRelationship,
+      selectedItem,
+      selectedItemIndex,
+      selectedRecord,
+      conversationItems,
+    },
+    selectedEntryId,
+    terminalPathId,
+  } = useWorkbenchView();
+  return (
+    <EvidencePane
+      chat={children}
+      normalizedRecord={normalizedRecord}
+      operationRelationship={operationRelationship}
+      selectedEntryId={selectedEntryId}
+      selectedItem={selectedItem}
+      selectedItemIndex={selectedItemIndex}
+      selectedRecord={selectedRecord}
+      terminalPathId={terminalPathId}
+      totalItems={conversationItems.length}
+      formatTime={formatWorkbenchTime}
+      normalizedEntryLabel={normalizedEntryLabel}
+    />
+  );
+}
+
+const workbenchTimeFormat = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'UTC',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+function formatWorkbenchTime(value: string): string {
+  return workbenchTimeFormat.format(new Date(value));
+}
+
+export const Workbench = {
+  Root,
+  Tabs,
+  Grid,
+  Timeline,
+  Conversation,
+  Evidence,
+} as const;
+
+export { useWorkbenchNavigation };


### PR DESCRIPTION
## Summary
- Extract Timeline, Conversation, and Evidence panes from the Resume workbench.
- Add a typed Workbench.Root compound boundary with separate immutable-view and navigation contexts.
- Preserve current Resume route snapshots, completed chat history, transport behavior, and route focus contracts.

## Validation
- `npx playwright test -c playwright.waku.config.ts tests/pi-resume.spec.ts` — 15 passed
- `npm run check:boundaries`
- `npm run build:waku`

## Review
- Independent review passed for the main-adapted port: route snapshot/history, citation routing, pane reveal, and ARIA route focus.

## Reuse check
- Reused existing Resume session projection, current PKE chat lifecycle, React Context/ref primitives, and existing Playwright Waku configuration.
- No generic collection helper or new container was introduced.