### PR TITLE
probe(crdt): pin concurrent-intent semantics of the text CRDT and the operation layer

### DIFF
--- a/probe/algebra_merge/algebra_merge_wbtest.mbt
+++ b/probe/algebra_merge/algebra_merge_wbtest.mbt
@@ -1,0 +1,215 @@
+///|
+/// Base document shared by both replicas before they diverge.
+///
+/// Offsets referenced by the operations below (`fn send(msg, kind) { msg + kind }`):
+///
+/// ```text
+///   0         1         2         3
+///   0123456789012345678901234567890123
+///   fn send(msg, kind) { msg + kind }
+///           ^^^  ^^^^     ^^^   ^^^^
+///           8-11 13-17    21-24 27-31
+/// ```
+const BASE : String =
+  #|fn send(msg, kind) { msg + kind }
+  #|send 1 2
+
+///|
+/// The result a *semantic* merge of Rename and MoveParam must produce.
+const INTENDED_RENAME_X_MOVE : String =
+  #|fn send(kind, message) { message + kind }
+  #|send 1 2
+
+///|
+/// The result a semantic merge of the two disjoint renames must produce.
+const INTENDED_RENAME_X_RENAME : String =
+  #|fn send(message, level) { message + level }
+  #|send 1 2
+
+///|
+/// Two replicas sharing `BASE` with a common causal history.
+fn make_replicas() -> (@text.TextState, @text.TextState) raise {
+  let alice = @text.TextState::new("alice")
+  let bob = @text.TextState::new("bob")
+  alice.insert(@text.Pos::at(0), BASE)
+  let _ = bob.sync().apply(alice.sync().export_all())
+  (alice, bob)
+}
+
+///|
+/// `Rename(msg -> message)`: the declaration site plus every use site.
+/// Applied right-to-left so the earlier offsets stay valid.
+fn op_rename_msg(doc : @text.TextState) -> Unit raise {
+  doc.replace_range(@text.Range::from_ints(21, 24), "message")
+  doc.replace_range(@text.Range::from_ints(8, 11), "message")
+}
+
+///|
+/// `Rename(kind -> level)`: the disjoint-region control.
+fn op_rename_kind(doc : @text.TextState) -> Unit raise {
+  doc.replace_range(@text.Range::from_ints(27, 31), "level")
+  doc.replace_range(@text.Range::from_ints(13, 17), "level")
+}
+
+///|
+/// `MoveParam(msg, +1)` lowered as a single region rewrite — what a
+/// naive structural editor emits when it re-prints the parameter list.
+fn op_move_param_as_rewrite(doc : @text.TextState) -> Unit raise {
+  doc.replace_range(@text.Range::from_ints(8, 17), "kind, msg")
+}
+
+///|
+/// `MoveParam(msg, +1)` lowered as an actual move: cut `msg, `, paste `, msg`
+/// after `kind`. Same resulting text, different operation shape.
+fn op_move_param_as_cut_paste(doc : @text.TextState) -> Unit raise {
+  doc.delete_range(@text.Range::from_ints(8, 13))
+  doc.insert(@text.Pos::at(12), ", msg")
+}
+
+///|
+/// Exchange every operation between the replicas. `alice_first` only controls
+/// the order in which each side *applies* the other's message.
+fn merge(
+  alice : @text.TextState,
+  bob : @text.TextState,
+  alice_first~ : Bool,
+) -> Unit raise {
+  let from_alice = alice.sync().export_all()
+  let from_bob = bob.sync().export_all()
+  if alice_first {
+    let _ = bob.sync().apply(from_alice)
+    let _ = alice.sync().apply(from_bob)
+  } else {
+    let _ = alice.sync().apply(from_bob)
+    let _ = bob.sync().apply(from_alice)
+  }
+}
+
+///|
+/// Number of unbound variable references, or `None` if the text no longer
+/// parses. This is the semantic judge: a merge can converge and still leave
+/// the program referring to a binder that no longer exists.
+fn free_vars(source : String) -> String {
+  let term = @lambda.parse(source) catch { _ => return "does not parse" }
+  let (_, resolution) = @lambda.resolve(term)
+  let free = resolution.vars
+    .values()
+    .filter(status => status is @lambda.VarStatus::Free)
+    .count()
+  free.to_string()
+}
+
+///|
+/// Run one scenario in both merge orders and report a single verdict string.
+fn run_scenario(
+  op_alice : (@text.TextState) -> Unit raise,
+  op_bob : (@text.TextState) -> Unit raise,
+  intended : String,
+) -> String raise {
+  let orders = [true, false]
+  let results = orders.map(alice_first => {
+    let (alice, bob) = make_replicas()
+    op_alice(alice)
+    op_bob(bob)
+    merge(alice, bob, alice_first~)
+    (alice.text(), bob.text())
+  })
+  let (a0, b0) = results[0]
+  let (a1, b1) = results[1]
+  let converged = a0 == b0 && a1 == b1
+  let order_independent = a0 == a1
+  let merged = a0
+  let verdict =
+    $|converged (both replicas agree): \{converged}
+    $|order-independent: \{order_independent}
+    $|merged text:
+    $|\{merged}
+    $|matches intended semantic merge: \{merged == intended}
+    $|intended text:
+    $|\{intended}
+    $|free variables after merge: \{free_vars(merged)}
+    $|free variables in intended: \{free_vars(intended)}
+  verdict
+}
+
+///|
+/// CONTROL — two renames over disjoint regions. If the harness cannot merge
+/// even this, any failure in the real scenario says nothing about the paper's
+/// claim.
+test "control: disjoint renames merge to the intended program" {
+  let report = run_scenario(
+    op_rename_msg,
+    op_rename_kind,
+    INTENDED_RENAME_X_RENAME,
+  )
+  inspect(
+    report,
+    content=(
+      #|converged (both replicas agree): true
+      #|order-independent: true
+      #|merged text:
+      #|fn send(message, level) { message + level }
+      #|send 1 2
+      #|matches intended semantic merge: true
+      #|intended text:
+      #|fn send(message, level) { message + level }
+      #|send 1 2
+      #|free variables after merge: 0
+      #|free variables in intended: 0
+    ),
+  )
+}
+
+///|
+/// SCENARIO A — Fig. 3, with MoveParam lowered as a region rewrite.
+test "rename x move-param (region rewrite lowering)" {
+  let report = run_scenario(
+    op_rename_msg,
+    op_move_param_as_rewrite,
+    INTENDED_RENAME_X_MOVE,
+  )
+  inspect(
+    report,
+    content=(
+      #|converged (both replicas agree): true
+      #|order-independent: true
+      #|merged text:
+      #|fn send(messagekind, msg) { message + kind }
+      #|send 1 2
+      #|matches intended semantic merge: false
+      #|intended text:
+      #|fn send(kind, message) { message + kind }
+      #|send 1 2
+      #|free variables after merge: 2
+      #|free variables in intended: 0
+    ),
+  )
+}
+
+///|
+/// SCENARIO B — same semantic pair, MoveParam lowered as cut/paste. Included
+/// because a failure under one lowering only is a property of the lowering,
+/// not of the text CRDT.
+test "rename x move-param (cut/paste lowering)" {
+  let report = run_scenario(
+    op_rename_msg,
+    op_move_param_as_cut_paste,
+    INTENDED_RENAME_X_MOVE,
+  )
+  inspect(
+    report,
+    content=(
+      #|converged (both replicas agree): true
+      #|order-independent: true
+      #|merged text:
+      #|fn send(messagekind, msg) { message + kind }
+      #|send 1 2
+      #|matches intended semantic merge: false
+      #|intended text:
+      #|fn send(kind, message) { message + kind }
+      #|send 1 2
+      #|free variables after merge: 2
+      #|free variables in intended: 0
+    ),
+  )
+}

--- a/probe/algebra_merge/moon.pkg
+++ b/probe/algebra_merge/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "dowdiness/event-graph-walker/text",
+  "dowdiness/lambda",
+  "moonbitlang/core/debug",
+} for "wbtest"

--- a/probe/algebra_merge/moon.pkg
+++ b/probe/algebra_merge/moon.pkg
@@ -1,5 +1,10 @@
 import {
   "dowdiness/event-graph-walker/text",
   "dowdiness/lambda",
+  "dowdiness/lambda/ast",
+  "dowdiness/seam",
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/canopy/lang/lambda/edits",
   "moonbitlang/core/debug",
 } for "wbtest"

--- a/probe/algebra_merge/operation_replay_wbtest.mbt
+++ b/probe/algebra_merge/operation_replay_wbtest.mbt
@@ -1,0 +1,236 @@
+///| Operation-layer counterpart to `algebra_merge_wbtest.mbt`.
+///
+/// The text-CRDT probe established the baseline: concurrent Rename x MoveParam
+/// converges on `fn send(messagekind, msg)` — a parseable program with two
+/// unbound variables. This file tests the paper's remedy using Canopy's
+/// SHIPPED operation layer (`@edits.TreeEditOp` + `compute_text_edit`, which
+/// resolves targets through the scope graph and enforces capture checks),
+/// not a toy written for the occasion.
+///
+/// Pinned predictions (written before first run):
+///   1. Replaying Rename as an operation on the post-move state yields the
+///      intended merge, free variables 0.
+///   2. Rename and SwapChildren applied as operations commute: both orders
+///      produce the same intended text.
+///   3. The same pair pushed through the text CRDT does not.
+///   4. The operation layer REFUSES a capture-inducing rename that the text
+///      layer would happily apply.
+
+///|
+/// Parse `text` and assemble the EditContext the shipped lowering needs.
+fn build_ctx(text : String) -> @edits.EditContext[@ast.Term] raise {
+  let (cst, _) = @lambda.parse_cst(text)
+  let syntax = @seam.SyntaxNode::from_cst(cst)
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
+  let source_map = @core.SourceMap::from_ast(proj)
+  @lambda_proj.populate_token_spans(source_map, syntax, proj)
+  let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = Map([])
+  @core.collect_registry(proj, registry)
+  {
+    source_text: text,
+    source_map,
+    registry,
+    definition_index: @lambda_proj.DefinitionIndex::from_proj_node(proj),
+  }
+}
+
+///|
+/// Locate the Lam node binding `param`. Operations target semantic entities;
+/// after a text-level change the entity is re-located structurally (the probe
+/// stand-in for projection identity tracking).
+fn find_lam_param(
+  ctx : @edits.EditContext[@ast.Term],
+  param : String,
+) -> @core.NodeId raise {
+  for id, node in ctx.registry {
+    match node.kind {
+      @ast.Term::Lam(p, _) => if p == param { return id }
+      _ => ()
+    }
+  }
+  fail("no lambda binding '" + param + "'")
+}
+
+///|
+/// Locate the unique Bop node.
+fn find_bop(ctx : @edits.EditContext[@ast.Term]) -> @core.NodeId raise {
+  for id, node in ctx.registry {
+    match node.kind {
+      @ast.Term::Bop(_, _, _) => return id
+      _ => ()
+    }
+  }
+  fail("no Bop node")
+}
+
+///|
+/// Lower `op` through the shipped pipeline and apply the resulting span
+/// edits (reverse document order, same as the editor shell).
+fn apply_op(
+  text : String,
+  op : @edits.TreeEditOp,
+  ctx : @edits.EditContext[@ast.Term],
+) -> String raise {
+  guard @edits.compute_text_edit(op, ctx) is Some((edits, _)) else {
+    fail("operation produced no edits")
+  }
+  let sorted = edits.copy()
+  sorted.sort_by((a, b) => b.start.compare(a.start))
+  let mut result = text
+  for e in sorted {
+    result = result[:e.start].to_owned() +
+      e.inserted +
+      result[e.start + e.delete_len:].to_owned()
+  }
+  result
+}
+
+///|
+/// `Rename(binder of `old` -> new)` as a fresh lowering against `text`.
+fn op_rename(text : String, old : String, new : String) -> String raise {
+  let ctx = build_ctx(text)
+  let lam = find_lam_param(ctx, old)
+  apply_op(text, @edits.TreeEditOp::Rename(node_id=lam, new_name=new), ctx)
+}
+
+///|
+/// `SwapChildren` on the unique Bop as a fresh lowering against `text`.
+fn op_swap_operands(text : String) -> String raise {
+  let ctx = build_ctx(text)
+  let bop = find_bop(ctx)
+  apply_op(text, @edits.TreeEditOp::SwapChildren(node_id=bop), ctx)
+}
+
+///|
+/// PREDICTION 1 — bob's post-move text (identical under both MoveParam
+/// lowerings measured in the CRDT probe) plus alice's Rename replayed as an
+/// operation must equal the intended merge that the text CRDT missed.
+test "operation replay heals the rename x move merge" {
+  let moved =
+    #|fn send(kind, msg) { msg + kind }
+    #|send 1 2
+  let healed = op_rename(moved, "msg", "message")
+  let report =
+    $|healed text:
+    $|\{healed}
+    $|matches intended semantic merge: \{healed == INTENDED_RENAME_X_MOVE}
+    $|free variables: \{free_vars(healed)}
+    $|(text-CRDT baseline for the same pair: free variables 2)
+  inspect(
+    report,
+    content=(
+      #|healed text:
+      #|fn send(kind, message) { message + kind }
+      #|send 1 2
+      #|matches intended semantic merge: true
+      #|free variables: 0
+      #|(text-CRDT baseline for the same pair: free variables 2)
+    ),
+  )
+}
+
+///|
+/// Base for the two-operation commutativity pair. Both directions exist as
+/// shipped operations, so this is the paper's Fig. 4 in executable form.
+const SMALL : String = "(x, y) => x + y"
+
+///|
+/// What Rename(x->a) and SwapChildren must jointly produce in either order.
+const SMALL_INTENDED : String = "(a, y) => y + a"
+
+///|
+/// PREDICTION 2 — operation composition is symmetric for this pair.
+test "operation-layer commutativity: rename x swap-operands" {
+  let path_a = op_swap_operands(op_rename(SMALL, "x", "a"))
+  let path_b = op_rename(op_swap_operands(SMALL), "x", "a")
+  // The exact-text comparison exposed a trivia defect in the shipped
+  // SwapChildren lowering (it drops the space after `=>`), so the report
+  // separates semantic agreement from whitespace fidelity.
+  let normalize = (s : String) => s.replace_all(old=" ", new="")
+  let report =
+    $|rename-then-swap: \{path_a}
+    $|swap-then-rename: \{path_b}
+    $|paths agree: \{path_a == path_b}
+    $|matches intended exactly: \{path_a == SMALL_INTENDED}
+    $|matches intended up to whitespace: \{normalize(path_a) == normalize(SMALL_INTENDED)}
+    $|free variables: \{free_vars(path_a)}
+  inspect(
+    report,
+    content=(
+      #|rename-then-swap: (a, y) =>y + a
+      #|swap-then-rename: (a, y) =>y + a
+      #|paths agree: true
+      #|matches intended exactly: false
+      #|matches intended up to whitespace: true
+      #|free variables: 0
+    ),
+  )
+}
+
+///|
+/// PREDICTION 3 — the same operation pair through the text CRDT. Offsets in
+/// `(x, y) => x + y`: param x = 1-2, body `x + y` = 10-15, body x = 10-11.
+test "text CRDT on the same pair does not commute semantically" {
+  let alice = @text.TextState::new("alice")
+  let bob = @text.TextState::new("bob")
+  alice.insert(@text.Pos::at(0), SMALL)
+  let _ = bob.sync().apply(alice.sync().export_all())
+  // alice: Rename(x -> a), declaration + use site, right-to-left
+  alice.replace_range(@text.Range::from_ints(10, 11), "a")
+  alice.replace_range(@text.Range::from_ints(1, 2), "a")
+  // bob: SwapChildren lowered as the region rewrite `x + y` -> `y + x`
+  bob.replace_range(@text.Range::from_ints(10, 15), "y + x")
+  merge(alice, bob, alice_first=true)
+  let report =
+    $|converged: \{alice.text() == bob.text()}
+    $|merged text: \{alice.text()}
+    $|matches intended: \{alice.text() == SMALL_INTENDED}
+    $|free variables: \{free_vars(alice.text())}
+  inspect(
+    report,
+    content=(
+      #|converged: true
+      #|merged text: (a, y) => ay + x
+      #|matches intended: false
+      #|free variables: 2
+    ),
+  )
+}
+
+///|
+/// PREDICTION 4 — the operation layer refuses `Rename(x -> y)` because `y`
+/// is bound in the body: the "verified" half of the claim. The text layer
+/// applies the same change without complaint.
+test "capture check refuses what the text layer accepts" {
+  let ctx = build_ctx(SMALL)
+  let lam = find_lam_param(ctx, "x")
+  let verdict = try {
+    let _ = @edits.compute_text_edit(
+      @edits.TreeEditOp::Rename(node_id=lam, new_name="y"),
+      ctx,
+    )
+    "accepted"
+  } catch {
+    @core.EditError::CaptureViolation(detail~) => "refused: " + detail
+    e => "refused (other): " + e.message()
+  }
+  let text_layer = {
+    let doc = @text.TextState::new("alice")
+    doc.insert(@text.Pos::at(0), SMALL)
+    doc.replace_range(@text.Range::from_ints(10, 11), "y")
+    doc.replace_range(@text.Range::from_ints(1, 2), "y")
+    doc.text()
+  }
+  let report =
+    $|operation layer: \{verdict}
+    $|text layer result: \{text_layer}
+    $|text layer free variables: \{free_vars(text_layer)}
+  inspect(
+    report,
+    content=(
+      #|operation layer: refused: Cannot rename: 'y' is bound by an inner scope at a usage site
+      #|text layer result: (y, y) => y + y
+      #|text layer free variables: 0
+    ),
+  )
+}

--- a/probe/algebra_merge/pkg.generated.mbti
+++ b/probe/algebra_merge/pkg.generated.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/probe/algebra_merge"
+
+// Values
+pub const PROBE_SUBJECT : String = "text-crdt intent preservation"
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/probe/algebra_merge/top.mbt
+++ b/probe/algebra_merge/top.mbt
@@ -1,0 +1,12 @@
+///|
+/// Probe package: does Canopy's text CRDT preserve *intent* when two
+/// semantically independent operations touch the same text region?
+///
+/// Scenario reproduces Fig. 3 of "Beyond Text Editing: Algebraic Manipulation
+/// of Source Code" (Pulo, ICSME 2026) in Canopy's lambda language: one replica
+/// renames a parameter (a change that cascades to every use site), the other
+/// reorders the parameter list. Text patches conflict; the paper claims the
+/// operations commute when represented algebraically.
+///
+/// The probe has no runtime surface — see `algebra_merge_wbtest.mbt`.
+pub const PROBE_SUBJECT : String = "text-crdt intent preservation"


### PR DESCRIPTION
## Summary

- Adds `probe/algebra_merge`: 7 pinned regression tests measuring what Canopy's layers do to concurrent structural intents, motivated by "Beyond Text Editing: Algebraic Manipulation of Source Code" (Pulo, ICSME 2026, arXiv:2607.18742).
- **Text-CRDT layer (baseline):** concurrent Rename x MoveParam converges silently on `fn send(messagekind, msg)` — parseable, 2 unbound variables, both merge orders, both MoveParam lowerings; a disjoint-rename control merges correctly. A text-layer capture (`Rename x->y`) yields `(y, y) => y + y` with ZERO free variables — undetectable after the fact.
- **Shipped operation layer (`lang/lambda/edits`):** replaying Rename via `compute_text_edit` on the post-move state heals to the intended merge (0 free vars); Rename x SwapChildren commute byte-identically; the capture case is refused with `CaptureViolation` at operation time. All predictions were pinned in doc comments before first run.
- Found one shipped defect: SwapChildren drops the space after `=>` — filed as #1024; the affected snapshot documents it with a whitespace-normalized comparison line to tighten on fix.

These pins are the measured foundation for the Gate 0–3 roadmap (milestones 10–13, #1012–#1023, #1027).

## Reuse check

Existing APIs considered and reused:

- `@text.TextState` / `SyncSession` / `Range::from_ints` (event-graph-walker/text) — the replica/merge harness; no new sync helpers.
- `@lambda.parse` / `parse_cst` / `resolve` / `VarStatus` — semantic judge (free-variable count); considered `@scope.failures` but `resolve` suffices for whole-program fixtures without a registry.
- `@edits.TreeEditOp` / `compute_text_edit` (+ `@core.EditError::CaptureViolation`) — the system under test; deliberately NOT reimplemented as a toy.
- `@lambda_proj.to_proj_node` / `populate_token_spans` / `DefinitionIndex::from_proj_node`, `@core.SourceMap::from_ast` / `collect_registry` — EditContext assembly, mirroring the shipped `edits` wbtest harness.
- Core APIs: `String` view slicing + `to_owned` (edit application), `String::replace_all` (whitespace-normalized compare), `Array::sort_by/map/copy`, `Iter::filter/count`, `Map` iteration, `Ref`. No new types; new helpers are wbtest-local (`build_ctx`, `apply_op`, locator fns) and package-private by construction.

## Validation

```bash
NEW_MOON_MOD=0 moon check probe/algebra_merge   # clean
NEW_MOON_MOD=0 moon test -p dowdiness/canopy/probe/algebra_merge   # 7/7
```

Rebased on current `main` (post #1010); full run repeated after rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
