### PR TITLE
docs(agents): add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,3 +290,31 @@ UI/visual work; do not duplicate token values here (they drift).
 - [eg-walker paper](https://arxiv.org/abs/2409.14252)
 - [MoonBit docs](https://docs.moonbitlang.com)
 - [Full documentation](docs/)
+
+## Cursor Cloud specific instructions
+
+The Cloud VM snapshot already has the toolchain installed and dependencies
+refreshed by the startup update script (`git submodule update --init
+--recursive`, `scripts/moon-update.sh`, `npm --prefix examples/web ci`). Do not
+re-run the MoonBit installer; it is pinned in the snapshot.
+
+Non-obvious caveats for this environment:
+
+- **`NEW_MOON_MOD=0` is exported in `~/.bashrc`** (matches
+  `.github/actions/setup-moonbit`). Every `moon` command relies on it — without
+  it the `rr_moon_mod` TOML migration drops path fields from cross-repo deps.
+  Login shells already have it; a bare non-login shell may not.
+- **Two `node` versions exist.** Login shells resolve nvm's `v22.22.2` (needed —
+  `examples/web` requires `node ^22.15.0`). A non-login/daemon shell may fall
+  back to `v22.14.0`, which is below the web `engines` floor. Run web commands in
+  a login shell (`bash -l`) or `nvm use 22.22.2`.
+- **Web dev server:** standard commands are in `examples/web/package.json`
+  (`npm run dev` → Waku on `http://localhost:3000`) and the root `Makefile`
+  (`make build-js`, `make web-dev`). The Waku dev server runs its own MoonBit
+  watcher and rebuilds the FFI (`ffi/{lambda,json,markdown,jsx}`) JS on change;
+  a separate `make build-js` is only needed for non-dev consumers.
+- `moon check` / `moon test` / `moon build` auto-download registry deps on first
+  run, so the pre-warm in the update script is an optimization, not a hard
+  prerequisite.
+- Verified working: `moon check`, `moon test` (1968 js + 70 native pass),
+  `make build-js`, and the `/ml` Mini-ML live editor at `localhost:3000`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Set up the Cloud dev environment for Canopy (pinned MoonBit `0.10.4+ade96c819`, recursive submodules, `moon` deps, `examples/web` npm deps) and verified lint/test/build/run end to end.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` (mirrored to `CLAUDE.md` via the existing symlink) capturing the non-obvious startup caveats future agents need.

The only code change in this PR is the `AGENTS.md` documentation addition. Toolchain install and dependency refresh are handled by the snapshot + startup update script, not by repo edits.

## Reuse check

Pure docs change — no new functions, methods, helpers, or types. Reuse table not applicable.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes (1968 js + 70 native)
- [x] `git diff *.mbti` reviewed — no `.mbti` changes
- [x] `make build-js` succeeds; Waku dev server serves `/` and `/ml` (HTTP 200) and the Mini-ML live editor evaluates (`5 + 5 → 10`)

## Validation

```bash
NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2406b4d7-cb38-4771-891d-e1c6031b8b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2406b4d7-cb38-4771-891d-e1c6031b8b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development environment instructions, including required tooling, configuration, setup behavior, and web development commands.
  * Documented verified commands and their expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->