### PR TITLE
feat(btree): normalize cross-parent boundaries

### DIFF
--- a/lib/btree/CHANGELOG.md
+++ b/lib/btree/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `dowdiness/btree` are documented in this file.
+
+## [0.2.0] - Unreleased
+
+### Added
+
+- Add `BTree::normalize_boundary_at`, a path-local operation that merges the
+  complete mergeable closure around one exact logical leaf boundary, including
+  boundaries whose leaves have different immediate parents.
+- Add deterministic, model-based property, distribution, and benchmark
+  coverage for boundary normalization across tree heights and minimum degrees.
+
+### Fixed
+
+- Reject cumulative span overflow before publishing a mutated tree.
+- Preserve B+ tree occupancy for arbitrary-cardinality callback splices.
+- Restore the empty-tree lifecycle after a delete-shaped
+  `mutate_for_insert` splice removes the final leaf.
+
+### Documentation
+
+- Clarify that `LeafContext` neighbor values are immediate-parent snapshots,
+  not logical predecessor or successor lookups across parent boundaries.
+
+Package publication remains pending explicit maintainer approval after the
+corresponding changes merge.

--- a/lib/btree/README.md
+++ b/lib/btree/README.md
@@ -21,7 +21,7 @@ Internal(counts=[5, 3, 4], total=12)
 
 Navigation uses the `counts` array as a cumulative index. To find position 6: `counts[0]=5` (skip), `6-5=1` into child 1 → `Leaf(b)` at offset 1.
 
-Elements implement `BTreeElem` (requires `Spanning` + `Mergeable` + `Sliceable` from `dowdiness/rle`) for slice-aware range operations. `delete_range` merges newly adjacent boundary leaves when their elements are mergeable; insertion callbacks and `from_sorted` callers remain responsible for any broader canonicalization policy.
+Elements implement `BTreeElem` (requires `Spanning` + `Mergeable` + `Sliceable` from `dowdiness/rle`) for slice-aware range operations. `delete_range` normalizes the mergeable closure at its newly exposed boundary. `normalize_boundary_at` needs only `Spanning` + `Mergeable` and closes the mergeable run around one exact leaf boundary. Insertion callbacks and `from_sorted` callers remain responsible for any broader canonicalization policy.
 
 ## Quick Start
 
@@ -59,6 +59,7 @@ tree.init_root({ text: "hello", len: 5 }, 5)
 | `mutate_for_insert(pos, callback)` | Insert via leaf splice callback | O(k + log n) at fixed t |
 | `mutate_for_delete(pos, callback)` | Delete via leaf splice callback | O(k + log n) at fixed t |
 | `delete_range(start, end)` | Delete span range [start, end), with boundary repair/merge | O(log n) path planning/splice; O(n) repair worst case |
+| `normalize_boundary_at(pos)` | Merge the complete mergeable closure around one exact leaf boundary | O((m + 1) log n) at fixed t |
 | `from_sorted(items, min_degree?)` | Bulk-build from sorted `(elem, span)` pairs | O(n) |
 | `view(start?, end?)` | Slice elements in range | O(k + log n) |
 | `iter()` | Lazy cursor-based iterator | O(n) total |
@@ -71,6 +72,10 @@ For callback splices, `k` is the number of replacement leaves and `t` is the
 minimum degree. More exactly, propagation is linear in the changed segment and
 logarithmic in unaffected height; current bulk underflow repair gives
 `O(k + t² log_t n)`.
+
+For boundary normalization, `m` is the number of successful adjacent-leaf
+merges. A stable or invalid boundary still needs at most one pair of tree
+descents.
 
 Current worst-case range-delete repair can visit every child in the repaired
 subtree.
@@ -125,14 +130,26 @@ are half-open `[start, end)`.
 | `mutate_for_insert(pos, callback)` | A non-empty tree and `0 <= pos <= span()`; the end position is valid. | Abort for an empty tree or a position outside the accepted bounds. Use `init_root` for the first element. |
 | `mutate_for_delete(pos, callback)` | `0 <= pos < span()` | Return `None` without calling the callback for an empty tree or an out-of-bounds position. |
 | `delete_range(start, end)` | `0 <= start < end`; `end` is clamped to `span()`. | No-op for an empty tree, a negative start, an empty or reversed range, or `start >= span()`. |
+| `normalize_boundary_at(pos)` | `0 < pos < span()`, where `pos` is an exact leaf boundary. | No-op for an empty tree, an outer or out-of-bounds position, a position inside a leaf, or a stable boundary. |
 | `view(start?, end?)` | Defaults to `[0, span())`; a negative start clamps to `0`, and an omitted or oversized end clamps to `span()`. | Return an empty array when the clamped range is empty or reversed, its end is negative, its start is at or beyond `span()`, or the tree is empty. |
+
+### Boundary normalization
+
+When the two logical leaves at `pos` are mergeable,
+`normalize_boundary_at(pos)` merges them and then continues across both sides
+of the merged result until neither adjacent logical leaf can merge with it.
+The operation can cross leaf-parent and higher subtree boundaries. It preserves
+the total span and element order, decreases `size()` exactly once per merge,
+and restores the B+ tree occupancy and root invariants before publishing the
+result. Calling it again at the same stable boundary is a no-op.
 
 ### Callback and splice contract
 
 `LeafContext` captures the current element, its span, the offset within it,
-its child index, and optional adjacent leaf values. `left_neighbor()` and
-`right_neighbor()` return the captured values; the context exposes no live
-tree collection.
+its child index, and optional adjacent values from the same immediate parent.
+`left_neighbor()` and `right_neighbor()` return those snapshots; they are not
+logical predecessor or successor lookups across a parent boundary. The context
+exposes no live tree collection.
 
 A callback computes and returns a `Splice` description. The
 engine applies that description after the callback returns and performs the
@@ -188,11 +205,11 @@ This is a **counted B+ tree**, also known as an order-statistic tree:
 
 - **B+ tree**: data only in leaves, internal nodes are navigational
 - **Counted**: `counts` array replaces keys — navigation by span position, not key comparison
-- **RLE-aware where requested**: slice-aware range operations can merge newly adjacent boundary leaves
+- **RLE-aware where requested**: range deletion and explicit boundary normalization close affected mergeable runs
 
 The tree maintains these structural invariants:
 - All leaves at the same depth
 - Internal nodes have between `min_degree` and `2 * min_degree` children (root excepted)
 - `counts[i] == children[i].total()` and `total == sum(counts)`
 
-Canonical no-adjacent-mergeable-leaf policy is enforced by higher-level callers (for example `order-tree`) or by insertion/bulk-build callbacks that choose to pre-merge input.
+Canonical no-adjacent-mergeable-leaf policy is enforced by higher-level callers (for example `order-tree`), by calling `normalize_boundary_at` at affected boundaries, or by insertion/bulk-build callbacks that choose to pre-merge input.

--- a/lib/btree/btree.mbt
+++ b/lib/btree/btree.mbt
@@ -137,6 +137,27 @@ pub fn[T, R] BTree::mutate_for_delete(
 }
 
 ///|
+/// Merge the canonical closure at logical span boundary `pos`. This is a no-op
+/// for an empty tree, an outer boundary, a position inside a leaf, or stable
+/// non-mergeable neighbors. For `m` merged boundaries, runs in
+/// `O((m + 1) log n)` time for a fixed minimum degree.
+pub fn[T : @rle.Spanning + @rle.Mergeable] BTree::normalize_boundary_at(
+  self : BTree[T],
+  pos : Int,
+) -> Unit {
+  guard self.root is Some(root) else { return }
+  let (next_root, leaf_delta) = normalize_boundary_chain(
+    root,
+    pos,
+    self.min_degree,
+  )
+  guard leaf_delta != 0 else { return }
+  let next_size = self.size + leaf_delta
+  self.root = Some(next_root)
+  self.size = next_size
+}
+
+///|
 /// Delete the half-open span range `[start, end_)`, clamping an oversized end
 /// to `span()`. This is a no-op for an empty tree, a negative start, an empty
 /// or reversed range, or `start >= span()`. Splice, boundary merge, and repair
@@ -156,11 +177,11 @@ pub fn[T : BTreeElem] BTree::delete_range(
       let propagated = propagate_node_splice(splice, self.min_degree)
       // Keep every range-delete phase on an unpublished candidate. A late
       // boundary-merge or repair rejection must leave the original tree intact.
-      let (final_root, boundary_merged) = match
+      let (final_root, boundary_leaf_delta) = match
         propagated.root_candidate(self.min_degree, normalize_delete=false) {
-        None => (None, false)
+        None => (None, 0)
         Some(new_root) => {
-          let (merged_root, boundary_merged) = normalize_boundary_merge(
+          let (merged_root, boundary_leaf_delta) = normalize_boundary_chain(
             new_root,
             start,
             self.min_degree,
@@ -174,12 +195,10 @@ pub fn[T : BTreeElem] BTree::delete_range(
               normalize_root_after_delete(fixed)
             }
           }
-          (final_root, boundary_merged)
+          (final_root, boundary_leaf_delta)
         }
       }
-      let final_size = self.size +
-        propagated.leaf_delta -
-        (if boundary_merged { 1 } else { 0 })
+      let final_size = self.size + propagated.leaf_delta + boundary_leaf_delta
       self.root = final_root
       self.size = final_size
     }

--- a/lib/btree/btree_benchmark.mbt
+++ b/lib/btree/btree_benchmark.mbt
@@ -152,7 +152,10 @@ fn bench_boundary_merge(
       10,
     )
     variant = (variant + 1) % roots.length()
-    b.keep(if leaf_delta < 0 { root.total() } else { -1 })
+    guard leaf_delta == -1 else {
+      abort("boundary merge benchmark stopped merging")
+    }
+    b.keep(root.total())
   })
 }
 

--- a/lib/btree/btree_benchmark.mbt
+++ b/lib/btree/btree_benchmark.mbt
@@ -39,6 +39,32 @@ impl @rle.Sliceable for BItem with fn slice(self, start~ : Int, end~ : Int) -> R
 impl BTreeElem for BItem
 
 ///|
+priv struct MergeBenchItem {
+  value : Int
+  span : Int
+}
+
+///|
+impl @rle.HasLength for MergeBenchItem with fn length(self) -> Int {
+  self.span
+}
+
+///|
+impl @rle.Spanning for MergeBenchItem with fn span(self) -> Int {
+  self.span
+}
+
+///|
+impl @rle.Mergeable for MergeBenchItem with fn can_merge(self, other) -> Bool {
+  self.value == other.value
+}
+
+///|
+impl @rle.Mergeable for MergeBenchItem with fn merge(self, other) -> MergeBenchItem {
+  { value: self.value, span: self.span + other.span }
+}
+
+///|
 fn bi(v : Int) -> BItem {
   { value: v }
 }
@@ -71,6 +97,63 @@ fn build_via_from_sorted(n : Int, min_degree : Int) -> BTree[BItem] {
     items.push((bi(i), 1))
   }
   BTree::from_sorted(items, min_degree~)
+}
+
+///|
+fn build_boundary_merge_root(
+  n : Int,
+  boundary : Int,
+  variant : Int,
+  expect_cross_parent : Bool,
+) -> BTreeNode[MergeBenchItem] {
+  let merge_value = -variant - 1
+  let items = Array::makei(n, i => {
+    let value = if i == boundary - 1 || i == boundary {
+      merge_value
+    } else {
+      variant * n + i + 1
+    }
+    let item : MergeBenchItem = { value, span: 1 }
+    (item, 1)
+  })
+  let t : BTree[MergeBenchItem] = BTree::from_sorted(items, min_degree=10)
+  let root = t.root.unwrap()
+  let left = descend_leaf_at_end_boundary(
+    root,
+    boundary,
+    10,
+    copy_on_write=false,
+  ).unwrap()
+  let right = descend_leaf_at(root, boundary, 10, copy_on_write=false).unwrap()
+  let is_cross_parent = left.path.length() == right.path.length() &&
+    left.path.length() > 0 &&
+    shared_prefix_length(left.path, right.path) < left.path.length() - 1
+  guard is_cross_parent == expect_cross_parent else {
+    abort("boundary merge benchmark topology drifted")
+  }
+  root
+}
+
+///|
+fn bench_boundary_merge(
+  b : @bench.T,
+  n : Int,
+  boundary : Int,
+  expect_cross_parent : Bool,
+) -> Unit {
+  let roots = Array::makei(8, variant => {
+    build_boundary_merge_root(n, boundary, variant, expect_cross_parent)
+  })
+  let mut variant = 0
+  b.bench(fn() {
+    let (root, leaf_delta) = normalize_boundary_chain(
+      roots[variant],
+      boundary,
+      10,
+    )
+    variant = (variant + 1) % roots.length()
+    b.keep(if leaf_delta < 0 { root.total() } else { -1 })
+  })
 }
 
 // === 100 elements ===
@@ -145,4 +228,26 @@ test "bench: delete_range middle 50% (10000)" (b : @bench.T) {
     t.delete_range(2500, 7500)
     b.keep(t.span())
   })
+}
+
+// === isolated boundary merge ===
+
+///|
+test "bench: boundary merge cross-parent (401)" (b : @bench.T) {
+  bench_boundary_merge(b, 401, 200, true)
+}
+
+///|
+test "bench: boundary merge same-parent (401)" (b : @bench.T) {
+  bench_boundary_merge(b, 401, 201, false)
+}
+
+///|
+test "bench: boundary merge cross-parent (8001)" (b : @bench.T) {
+  bench_boundary_merge(b, 8001, 4000, true)
+}
+
+///|
+test "bench: boundary merge same-parent (8001)" (b : @bench.T) {
+  bench_boundary_merge(b, 8001, 4001, false)
 }

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -810,6 +810,8 @@ fn model_normalize_boundary(items : Array[TItem], pos : Int) -> Array[TItem] {
   result[left_idx] = @rle.Mergeable::merge(result[left_idx], result[right_idx])
   let _ = result.remove(right_idx)
   let mut merged_idx = left_idx
+  // This targeted fixpoint must not merge unrelated runs outside the closure
+  // containing `pos`, as a global declarative grouping fold would.
   let mut changed = true
   while changed {
     changed = false

--- a/lib/btree/btree_property_wbtest.mbt
+++ b/lib/btree/btree_property_wbtest.mbt
@@ -645,6 +645,255 @@ fn arbitrary_splice_case_matches_model(case_ : ArbitrarySpliceCase) -> Bool {
 }
 
 ///|
+enum NormalizeBoundaryShape {
+  SameParent
+  CrossParent
+  Cascade
+  EmptyNoOp
+  OuterNoOp
+  InteriorNoOp
+  StableNoOp
+} derive(Debug, Eq)
+
+///|
+struct NormalizeBoundaryCase {
+  min_degree : Int
+  shape : NormalizeBoundaryShape
+  seed : Int
+} derive(Debug)
+
+///|
+impl @quickcheck.Arbitrary for NormalizeBoundaryCase with fn arbitrary(
+  _size,
+  rs,
+) {
+  let min_degree = match rs.split().next_positive_int() % 3 {
+    0 => 2
+    1 => 3
+    _ => DEFAULT_MIN_DEGREE
+  }
+  let shape = match rs.split().next_positive_int() % 7 {
+    0 => SameParent
+    1 => CrossParent
+    2 => Cascade
+    3 => EmptyNoOp
+    4 => OuterNoOp
+    5 => InteriorNoOp
+    _ => StableNoOp
+  }
+  { min_degree, shape, seed: rs.split().next_positive_int() % 1_000 }
+}
+
+///|
+impl @qc.Shrink for NormalizeBoundaryCase with fn shrink(case_) {
+  let results : Array[NormalizeBoundaryCase] = []
+  if case_.seed != 0 {
+    results.push({ ..case_, seed: 0 })
+  }
+  if case_.min_degree == DEFAULT_MIN_DEGREE {
+    results.push({ ..case_, min_degree: 3 })
+    results.push({ ..case_, min_degree: 2 })
+  } else if case_.min_degree > 2 {
+    results.push({ ..case_, min_degree: 2 })
+  }
+  results.iter()
+}
+
+///|
+fn normalization_items(
+  count : Int,
+  run_start : Int,
+  run_end : Int,
+  seed : Int,
+) -> Array[TItem] {
+  Array::makei(count, i => {
+    let id = if i >= run_start && i <= run_end {
+      -1
+    } else {
+      seed * (count + 1) + i + 1
+    }
+    make_item(id, 1 + (seed + i) % 3)
+  })
+}
+
+///|
+fn normalization_boundary_position(
+  items : Array[TItem],
+  right_idx : Int,
+) -> Int {
+  items[:right_idx].fold(init=0, (total, item) => total + item.span)
+}
+
+///|
+fn normalization_case_input(
+  case_ : NormalizeBoundaryCase,
+) -> (Array[TItem], Int) {
+  let max_degree = 2 * case_.min_degree
+  match case_.shape {
+    SameParent => {
+      let items = normalization_items(4, 1, 2, case_.seed)
+      (items, normalization_boundary_position(items, 2))
+    }
+    CrossParent => {
+      let right_idx = max_degree
+      let items = normalization_items(
+        2 * max_degree,
+        right_idx - 1,
+        right_idx,
+        case_.seed,
+      )
+      (items, normalization_boundary_position(items, right_idx))
+    }
+    Cascade => {
+      let right_idx = case_.min_degree * max_degree
+      let items = normalization_items(
+        max_degree * max_degree + 1,
+        right_idx - 2,
+        right_idx + 1,
+        case_.seed,
+      )
+      (items, normalization_boundary_position(items, right_idx))
+    }
+    EmptyNoOp => ([], case_.seed % 3 - 1)
+    OuterNoOp => {
+      let items = normalization_items(4, 0, -1, case_.seed)
+      let total = model_span(items)
+      let pos = match case_.seed % 4 {
+        0 => -1
+        1 => 0
+        2 => total
+        _ => total + 1
+      }
+      (items, pos)
+    }
+    InteriorNoOp => {
+      let items = normalization_items(4, 0, -1, case_.seed)
+      items[0] = { ..items[0], span: 3 }
+      (items, 1)
+    }
+    StableNoOp => {
+      let items = normalization_items(4, 0, -1, case_.seed)
+      (items, normalization_boundary_position(items, 2))
+    }
+  }
+}
+
+///|
+fn model_exact_boundary_index(items : Array[TItem], pos : Int) -> Int? {
+  guard pos > 0 && pos < model_span(items) else { return None }
+  let mut offset = 0
+  for i in 0..<items.length() {
+    offset = offset + items[i].span
+    if offset == pos {
+      return Some(i + 1)
+    }
+    if offset > pos {
+      return None
+    }
+  }
+  None
+}
+
+///|
+/// Independent flat-array oracle for the mergeable closure around one exact
+/// boundary. Mutation is confined to constructing the returned model value.
+fn model_normalize_boundary(items : Array[TItem], pos : Int) -> Array[TItem] {
+  let result = model_copy(items)
+  guard model_exact_boundary_index(result, pos) is Some(right_idx) else {
+    return result
+  }
+  guard right_idx < result.length() else { return result }
+  let left_idx = right_idx - 1
+  guard @rle.Mergeable::can_merge(result[left_idx], result[right_idx]) else {
+    return result
+  }
+  result[left_idx] = @rle.Mergeable::merge(result[left_idx], result[right_idx])
+  let _ = result.remove(right_idx)
+  let mut merged_idx = left_idx
+  let mut changed = true
+  while changed {
+    changed = false
+    if merged_idx > 0 &&
+      @rle.Mergeable::can_merge(result[merged_idx - 1], result[merged_idx]) {
+      result[merged_idx - 1] = @rle.Mergeable::merge(
+        result[merged_idx - 1],
+        result[merged_idx],
+      )
+      let _ = result.remove(merged_idx)
+      merged_idx = merged_idx - 1
+      changed = true
+    }
+    if merged_idx + 1 < result.length() &&
+      @rle.Mergeable::can_merge(result[merged_idx], result[merged_idx + 1]) {
+      result[merged_idx] = @rle.Mergeable::merge(
+        result[merged_idx],
+        result[merged_idx + 1],
+      )
+      let _ = result.remove(merged_idx + 1)
+      changed = true
+    }
+  }
+  result
+}
+
+///|
+fn normalization_boundary_path_shape(
+  t : BTree[TItem],
+  pos : Int,
+) -> (Int, Int)? {
+  guard t.root is Some(root) else { return None }
+  guard descend_leaf_at_end_boundary(
+      root,
+      pos,
+      t.min_degree,
+      copy_on_write=false,
+    )
+    is Some(left) else {
+    return None
+  }
+  guard descend_leaf_at(root, pos, t.min_degree, copy_on_write=false)
+    is Some(right) else {
+    return None
+  }
+  guard left.offset == left.span && right.offset == 0 else { return None }
+  Some((left.path.length(), shared_prefix_length(left.path, right.path)))
+}
+
+///|
+fn normalization_case_topology_matches(
+  case_ : NormalizeBoundaryCase,
+  t : BTree[TItem],
+  pos : Int,
+) -> Bool {
+  match case_.shape {
+    SameParent => normalization_boundary_path_shape(t, pos) == Some((1, 0))
+    CrossParent => normalization_boundary_path_shape(t, pos) == Some((2, 0))
+    Cascade => normalization_boundary_path_shape(t, pos) == Some((3, 0))
+    _ => true
+  }
+}
+
+///|
+fn prop_normalize_boundary_matches_model(case_ : NormalizeBoundaryCase) -> Bool {
+  let (items, pos) = normalization_case_input(case_)
+  let expected = model_normalize_boundary(items, pos)
+  let t : BTree[TItem] = BTree::from_sorted(
+    items.map(item => (item, item.span)),
+    min_degree=case_.min_degree,
+  )
+  if !normalization_case_topology_matches(case_, t, pos) {
+    abort("normalize_boundary_at generated topology drifted")
+  }
+  t.normalize_boundary_at(pos)
+  if !tree_matches_model(t, expected) {
+    return false
+  }
+  let stable = @debug.to_string(t)
+  t.normalize_boundary_at(pos)
+  @debug.to_string(t) == stable && tree_matches_model(t, expected)
+}
+
+///|
 enum ModelOp {
   Append(Int, Int)
   Insert(Int, Int, Int)
@@ -906,8 +1155,78 @@ test "property: from_sorted exact content matches array model" {
 }
 
 ///|
+test "property: normalize_boundary_at matches closure model and is idempotent" {
+  @qc.quick_check_fn(prop_normalize_boundary_matches_model)
+}
+
+///|
 test "property: operation sequences match array model" {
   @qc.quick_check_fn(prop_operation_sequence_matches_model)
+}
+
+///|
+test "normalize_boundary_at degree and topology matrix matches closure model" {
+  for min_degree in [2, 3, DEFAULT_MIN_DEGREE] {
+    for
+      shape in [
+        SameParent,
+        CrossParent,
+        Cascade,
+        EmptyNoOp,
+        OuterNoOp,
+        InteriorNoOp,
+        StableNoOp,
+      ] {
+      inspect(
+        prop_normalize_boundary_matches_model({ min_degree, shape, seed: 7 }),
+        content="true",
+      )
+    }
+  }
+}
+
+///|
+test "quickcheck normalize_boundary_at generator covers topology and no-op shapes" {
+  let samples : Array[NormalizeBoundaryCase] = @quickcheck.samples(400)
+  let mut saw_degree_2 = false
+  let mut saw_degree_3 = false
+  let mut saw_default_degree = false
+  let mut saw_same_parent = false
+  let mut saw_cross_parent = false
+  let mut saw_cascade = false
+  let mut saw_empty_noop = false
+  let mut saw_outer_noop = false
+  let mut saw_interior_noop = false
+  let mut saw_stable_noop = false
+  for case_ in samples {
+    guard prop_normalize_boundary_matches_model(case_) else {
+      fail("generated normalize_boundary_at case diverged from model")
+    }
+    match case_.min_degree {
+      2 => saw_degree_2 = true
+      3 => saw_degree_3 = true
+      _ => saw_default_degree = true
+    }
+    match case_.shape {
+      SameParent => saw_same_parent = true
+      CrossParent => saw_cross_parent = true
+      Cascade => saw_cascade = true
+      EmptyNoOp => saw_empty_noop = true
+      OuterNoOp => saw_outer_noop = true
+      InteriorNoOp => saw_interior_noop = true
+      StableNoOp => saw_stable_noop = true
+    }
+  }
+  inspect(saw_degree_2, content="true")
+  inspect(saw_degree_3, content="true")
+  inspect(saw_default_degree, content="true")
+  inspect(saw_same_parent, content="true")
+  inspect(saw_cross_parent, content="true")
+  inspect(saw_cascade, content="true")
+  inspect(saw_empty_noop, content="true")
+  inspect(saw_outer_noop, content="true")
+  inspect(saw_interior_noop, content="true")
+  inspect(saw_stable_noop, content="true")
 }
 
 ///|

--- a/lib/btree/btree_wbtest.mbt
+++ b/lib/btree/btree_wbtest.mbt
@@ -51,6 +51,32 @@ impl @rle.Sliceable for TItem with fn slice(
 impl BTreeElem for TItem
 
 ///|
+struct MergeOnlyItem {
+  id : Int
+  span : Int
+} derive(Debug, Eq)
+
+///|
+impl @rle.HasLength for MergeOnlyItem with fn length(self) -> Int {
+  self.span
+}
+
+///|
+impl @rle.Spanning for MergeOnlyItem with fn span(self) -> Int {
+  self.span
+}
+
+///|
+impl @rle.Mergeable for MergeOnlyItem with fn can_merge(self, other) -> Bool {
+  self.id == other.id
+}
+
+///|
+impl @rle.Mergeable for MergeOnlyItem with fn merge(self, other) -> MergeOnlyItem {
+  { id: self.id, span: self.span + other.span }
+}
+
+///|
 fn make_item(id : Int, span : Int) -> TItem {
   { id, span }
 }
@@ -1648,7 +1674,7 @@ test "propagate_node_splice rechecks repeated adjacent merges at every degree" {
 // === Post-splice boundary merge ===
 
 ///|
-test "normalize_boundary_merge merges adjacent leaves across subtrees" {
+test "normalize_boundary_chain merges adjacent leaves across subtrees" {
   // After splice already removed middle, tree is: [[a(3)]] [[a(3)]]
   let left : BTreeNode[TItem] = Internal(
     children=[Leaf(elem=make_item(1, 3), span=3)],
@@ -1665,8 +1691,8 @@ test "normalize_boundary_merge merges adjacent leaves across subtrees" {
     counts=[3, 3],
     total=6,
   )
-  let (result, merged) = normalize_boundary_merge(root, 3, 2)
-  inspect(merged, content="true")
+  let (result, leaf_delta) = normalize_boundary_chain(root, 3, 2)
+  inspect(leaf_delta, content="-1")
   inspect(result.total(), content="6")
   let items : Array[TItem] = []
   result.each(fn(item) { items.push(item) })
@@ -1675,7 +1701,7 @@ test "normalize_boundary_merge merges adjacent leaves across subtrees" {
 }
 
 ///|
-test "normalize_boundary_merge is no-op when boundaries not mergeable" {
+test "normalize_boundary_chain is no-op when boundaries not mergeable" {
   let left : BTreeNode[TItem] = Internal(
     children=[Leaf(elem=make_item(1, 3), span=3)],
     counts=[3],
@@ -1691,12 +1717,115 @@ test "normalize_boundary_merge is no-op when boundaries not mergeable" {
     counts=[3, 3],
     total=6,
   )
-  let (result, merged) = normalize_boundary_merge(root, 3, 2)
-  inspect(merged, content="false")
+  let (result, leaf_delta) = normalize_boundary_chain(root, 3, 2)
+  inspect(leaf_delta, content="0")
   inspect(result.total(), content="6")
   let items : Array[TItem] = []
   result.each(fn(item) { items.push(item) })
   inspect(items.length(), content="2")
+}
+
+///|
+test "normalize_boundary_at merges logical neighbors across parents" {
+  let items = [
+    make_item(1, 1),
+    make_item(2, 1),
+    make_item(2, 1),
+    make_item(3, 1),
+    make_item(4, 1),
+  ]
+  let t : BTree[TItem] = BTree::from_sorted(
+    items.map(item => (item, item.span)),
+    min_degree=2,
+  )
+  t.normalize_boundary_at(2)
+  let expected = [
+    make_item(1, 1),
+    make_item(2, 2),
+    make_item(3, 1),
+    make_item(4, 1),
+  ]
+  inspect(tree_matches_model(t, expected), content="true")
+}
+
+///|
+test "normalize_boundary_at repartitions a full cross-parent seam" {
+  let items = Array::makei(8, i => {
+    let id = if i == 3 || i == 4 { 100 } else { i }
+    let item = make_item(id, 1)
+    (item, item.span)
+  })
+  let t : BTree[TItem] = BTree::from_sorted(items, min_degree=2)
+  t.normalize_boundary_at(4)
+  let expected = Array::makei(3, i => make_item(i, 1))
+  expected.push(make_item(100, 2))
+  expected.append(Array::makei(3, i => make_item(i + 5, 1)))
+  inspect(tree_matches_model(t, expected), content="true")
+}
+
+///|
+test "normalize_boundary_at closes both sides across a root boundary" {
+  let items = Array::makei(17, i => {
+    let id = if i >= 6 && i <= 9 { 100 } else { i }
+    let item = make_item(id, 1)
+    (item, item.span)
+  })
+  let t : BTree[TItem] = BTree::from_sorted(items, min_degree=2)
+  t.normalize_boundary_at(8)
+  let expected = Array::makei(6, i => make_item(i, 1))
+  expected.push(make_item(100, 4))
+  expected.append(Array::makei(7, i => make_item(i + 10, 1)))
+  inspect(tree_matches_model(t, expected), content="true")
+  let stable = @debug.to_string(t)
+  t.normalize_boundary_at(8)
+  inspect(@debug.to_string(t) == stable, content="true")
+}
+
+///|
+test "normalize_boundary_at ordinary no-op positions preserve the tree" {
+  let empty : BTree[TItem] = BTree::new(min_degree=2)
+  empty.normalize_boundary_at(0)
+  inspect(tree_matches_model(empty, []), content="true")
+  let original = [make_item(1, 3), make_item(2, 2)]
+  let t : BTree[TItem] = BTree::from_sorted(
+    original.map(item => (item, item.span)),
+    min_degree=2,
+  )
+  let stable = @debug.to_string(t)
+  for pos in [-1, 0, 1, 3, 5, 6] {
+    t.normalize_boundary_at(pos)
+    inspect(@debug.to_string(t) == stable, content="true")
+    inspect(tree_matches_model(t, original), content="true")
+  }
+}
+
+///|
+test "normalize_boundary_at requires only spanning and mergeable" {
+  let t : BTree[MergeOnlyItem] = BTree::from_sorted([
+    ({ id: 1, span: 1 }, 1),
+    ({ id: 1, span: 1 }, 1),
+    ({ id: 2, span: 1 }, 1),
+  ])
+  t.normalize_boundary_at(1)
+  inspect(t.size(), content="2")
+  inspect(t.span(), content="3")
+  inspect(
+    t.to_array() == [{ id: 1, span: 2 }, { id: 2, span: 1 }],
+    content="true",
+  )
+}
+
+///|
+test "normalize_boundary_at preserves cached spans independent of element span" {
+  let t : BTree[MergeOnlyItem] = BTree::from_sorted([
+    ({ id: 1, span: 1 }, 2),
+    ({ id: 1, span: 1 }, 3),
+  ])
+  t.normalize_boundary_at(2)
+  inspect(t.size(), content="1")
+  inspect(t.span(), content="5")
+  inspect(t.find(4) is Some(_), content="true")
+  @debug.debug_inspect(t.to_array(), content="[{ id: 1, span: 2 }]")
 }
 
 // === BTree::delete_range ===

--- a/lib/btree/moon.mod
+++ b/lib/btree/moon.mod
@@ -1,6 +1,6 @@
 name = "dowdiness/btree"
 
-version = "0.1.0"
+version = "0.2.0"
 
 import {
   "dowdiness/rle@0.2.2",

--- a/lib/btree/pkg.generated.mbti
+++ b/lib/btree/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub fn[T] BTree::iter(Self[T]) -> Iter[T]
 pub fn[T, R] BTree::mutate_for_delete(Self[T], Int, (LeafContext[T]) -> (Splice[T], R)) -> R?
 pub fn[T] BTree::mutate_for_insert(Self[T], Int, (LeafContext[T]) -> Splice[T]) -> Unit
 pub fn[T] BTree::new(min_degree? : Int) -> Self[T]
+pub fn[T : @rle.Spanning + @rle.Mergeable] BTree::normalize_boundary_at(Self[T], Int) -> Unit
 pub fn[T] BTree::size(Self[T]) -> Int
 pub fn[T] BTree::span(Self[T]) -> Int
 pub fn[T] BTree::to_array(Self[T]) -> Array[T]

--- a/lib/btree/walker_range_delete.mbt
+++ b/lib/btree/walker_range_delete.mbt
@@ -520,6 +520,8 @@ fn[T : @rle.Spanning + @rle.Mergeable] merge_boundary_once(
       guard @rle.Spanning::span(merged) > 0 else {
         abort("BTree boundary merge: merged span must be positive")
       }
+      // A leaf's cached BTree span is independent of its element-reported span,
+      // so preserve the replaced interval instead of changing tree coordinates.
       let merged_leaf : BTreeNode[T] = Leaf(
         elem=merged,
         span=merged_end - merged_start,

--- a/lib/btree/walker_range_delete.mbt
+++ b/lib/btree/walker_range_delete.mbt
@@ -61,16 +61,18 @@ fn[T : BTreeElem] right_boundary_keep(end_ : LeafCursor[T]) -> T? {
 }
 
 ///|
-fn[T] merge_boundary_chain(
+/// Rebuild a merged seam as a complete same-height segment. Each fresh level
+/// repairs underflow and packs overflow before the segment moves upward.
+fn[T] merge_boundary_segment(
   left_path_suffix : Array[PathFrame[T]],
   right_path_suffix : Array[PathFrame[T]],
   leaf : BTreeNode[T],
   min_degree : Int,
 ) -> Array[BTreeNode[T]] {
   if left_path_suffix.length() != right_path_suffix.length() {
-    abort("merge_boundary_chain: mismatched suffix heights")
+    abort("merge_boundary_segment: mismatched suffix heights")
   }
-  let mut current : Array[BTreeNode[T]] = [leaf]
+  let mut segment : Array[BTreeNode[T]] = [leaf]
   for i in (left_path_suffix.length() - 1)>=..0 {
     let left_frame = left_path_suffix[i]
     let right_frame = right_path_suffix[i]
@@ -78,18 +80,17 @@ fn[T] merge_boundary_chain(
     let counts : Array[Int] = []
     children.append(left_frame.children[:left_frame.child_idx])
     counts.append(left_frame.counts[:left_frame.child_idx])
-    children.append(current[:])
-    counts.append(current.map(node => node.total())[:])
+    children.append(segment[:])
+    counts.append(segment.map(node => node.total())[:])
     children.append(right_frame.children[right_frame.child_idx + 1:])
     counts.append(right_frame.counts[right_frame.child_idx + 1:])
-    // The two boundary paths and a two-node carried segment can contribute up
-    // to 4t children. Repair an
-    // underfull carried node, then preserve every balanced output node as a
-    // segment for the next ancestor instead of hiding overfull descendants.
+    // The two boundary paths and a carried segment can contribute up to 4t
+    // children. Repair underflow and preserve every balanced output node for
+    // the next ancestor rather than hiding an overfull descendant.
     repair_underfull_children(children, counts, min_degree, min_degree)
-    current = pack_level(children, min_degree)
+    segment = pack_level(children, min_degree)
   }
-  current.map(node => fix_merged_chain(node, min_degree))
+  segment
 }
 
 ///|
@@ -305,7 +306,7 @@ fn[T : BTreeElem] absorb_subtree_gap_merge(
   }
   let merged = @rle.Mergeable::merge(left_edge.elem, right_edge.elem)
   let merged_leaf = Leaf(elem=merged, span=@rle.Spanning::span(merged))
-  let merged_subtrees = merge_boundary_chain(
+  let merged_subtrees = merge_boundary_segment(
     left_edge.path,
     right_edge.path,
     merged_leaf,
@@ -336,7 +337,7 @@ fn[T : BTreeElem] promote_empty_child_gap_merge(
   }
   let merged = @rle.Mergeable::merge(left_edge.elem, right_edge.elem)
   let merged_leaf = Leaf(elem=merged, span=@rle.Spanning::span(merged))
-  let new_children = merge_boundary_chain(
+  let new_children = merge_boundary_segment(
     left_edge.path,
     right_edge.path,
     merged_leaf,
@@ -478,28 +479,23 @@ fn[T : BTreeElem] plan_delete_range(
 }
 
 ///|
-/// Post-splice boundary normalization: if the leaves at the splice boundary
-/// are mergeable, merge them and propagate the structural change.
-/// `boundary_pos` is the position where the deleted range started (after deletion,
-/// the left boundary's last leaf ends here and the right boundary's first leaf starts here).
-/// Returns the updated root node and whether a merge occurred (for leaf_delta tracking).
-fn[T : BTreeElem] normalize_boundary_merge(
+/// Merge the two logical leaves at one exact boundary on an unpublished root.
+/// Returns the updated root and the merged leaf's `[start, end)` interval, or
+/// the original root and `None` when the position is not mergeable.
+fn[T : @rle.Spanning + @rle.Mergeable] merge_boundary_once(
   root : BTreeNode[T],
   boundary_pos : Int,
   min_degree : Int,
-) -> (BTreeNode[T], Bool) {
-  // Nothing to merge at boundaries
+) -> (BTreeNode[T], (Int, Int)?) {
   guard boundary_pos > 0 && boundary_pos < root.total() else {
-    return (root, false)
+    return (root, None)
   }
-  // Descend to the leaf just before the boundary (end-boundary semantics)
   let left_cursor = descend_leaf_at_end_boundary(
     root,
     boundary_pos,
     min_degree,
     copy_on_write=true,
   )
-  // Descend to the leaf at the boundary (start semantics)
   let right_cursor = descend_leaf_at(
     root,
     boundary_pos,
@@ -508,37 +504,34 @@ fn[T : BTreeElem] normalize_boundary_merge(
   )
   match (left_cursor, right_cursor) {
     (Some(left), Some(right)) => {
-      // Check if these are different leaves
       if left.path.length() == right.path.length() &&
         shared_prefix_length(left.path, right.path) == left.path.length() {
-        // Same leaf — no boundary merge needed
-        return (root, false)
+        return (root, None)
       }
-      // Not at leaf boundaries — can't merge whole leaves
       guard left.offset == left.span && right.offset == 0 else {
-        return (root, false)
+        return (root, None)
       }
-      // Check if mergeable
       guard @rle.Mergeable::can_merge(left.elem, right.elem) else {
-        return (root, false)
+        return (root, None)
       }
-      // Merge: delete the right leaf, expand the left leaf to absorb it
+      let merged_start = boundary_pos - left.span
+      let merged_end = add_spans_or_abort(boundary_pos, right.span)
       let merged = @rle.Mergeable::merge(left.elem, right.elem)
-      let merged_span = @rle.Spanning::span(merged)
-      let merged_leaf : BTreeNode[T] = Leaf(elem=merged, span=merged_span)
+      guard @rle.Spanning::span(merged) > 0 else {
+        abort("BTree boundary merge: merged span must be positive")
+      }
+      let merged_leaf : BTreeNode[T] = Leaf(
+        elem=merged,
+        span=merged_end - merged_start,
+      )
       let lca = lowest_common_ancestor_range(left, right)
       let left_suffix = path_suffix_after_target(left.path, lca.prefix.length())
       let right_suffix = path_suffix_after_target(
         right.path,
         lca.prefix.length(),
       )
-      let merged_subtrees = merge_boundary_chain(
+      let merged_segment = merge_boundary_segment(
         left_suffix, right_suffix, merged_leaf, min_degree,
-      )
-      let removed_leaf_count = leaf_count_of_children(
-        lca.children,
-        lca.start_idx,
-        lca.end_idx,
       )
       let splice : NodeSplice[T] = {
         prefix: lca.prefix,
@@ -546,15 +539,64 @@ fn[T : BTreeElem] normalize_boundary_merge(
         counts: lca.counts,
         start_idx: lca.start_idx,
         end_idx: lca.end_idx,
-        new_children: merged_subtrees,
-        leaf_delta: leaf_count_of_array(merged_subtrees) - removed_leaf_count,
+        new_children: merged_segment,
+        leaf_delta: -1,
       }
       let result = propagate_node_splice(splice, min_degree)
       let new_root = result
         .root_candidate(min_degree, normalize_delete=false)
         .unwrap()
-      (new_root, true)
+      (new_root, Some((merged_start, merged_end)))
     }
-    _ => (root, false)
+    _ => (root, None)
   }
+}
+
+///|
+/// Normalize only the mergeable closure containing one logical boundary.
+/// Each successful merge rebuilds one pair of boundary paths, so `m` merges
+/// take `O((m + 1) log n)` work for a fixed minimum degree.
+fn[T : @rle.Spanning + @rle.Mergeable] normalize_boundary_chain(
+  root : BTreeNode[T],
+  boundary_pos : Int,
+  min_degree : Int,
+) -> (BTreeNode[T], Int) {
+  let (first_root, first_interval) = merge_boundary_once(
+    root, boundary_pos, min_degree,
+  )
+  guard first_interval is Some((first_start, first_end)) else {
+    return (root, 0)
+  }
+  let mut current = first_root
+  let mut merged_start = first_start
+  let mut merged_end = first_end
+  let mut leaf_delta = -1
+  for ;; {
+    let (left_root, left_interval) = merge_boundary_once(
+      current, merged_start, min_degree,
+    )
+    match left_interval {
+      Some((next_start, next_end)) => {
+        current = left_root
+        merged_start = next_start
+        merged_end = next_end
+        leaf_delta = leaf_delta - 1
+        continue
+      }
+      None => ()
+    }
+    let (right_root, right_interval) = merge_boundary_once(
+      current, merged_end, min_degree,
+    )
+    match right_interval {
+      Some((next_start, next_end)) => {
+        current = right_root
+        merged_start = next_start
+        merged_end = next_end
+        leaf_delta = leaf_delta - 1
+      }
+      None => break
+    }
+  }
+  (normalize_root_after_delete(current).unwrap(), leaf_delta)
 }

--- a/lib/btree/walker_repair.mbt
+++ b/lib/btree/walker_repair.mbt
@@ -162,10 +162,10 @@ fn[T] fix_left_border(node : BTreeNode[T], min_degree : Int) -> BTreeNode[T] {
 }
 
 ///|
-/// Fix any underfull child in a merged boundary chain subtree.
+/// Fix any underfull child in a merged boundary segment.
 /// Unlike fix_left/right_border which only walk one edge, this scans
-/// all children at each level. Used for merge_boundary_chain output
-/// where the underfull node can be at an interior position.
+/// all children at each level. Used for merged-segment output where the
+/// underfull node can be at an interior position.
 ///
 /// Top-down: at each level, find any underfull child, stock it to
 /// `target_child_count` via merge-or-bulk-steal, then recurse into the result.

--- a/lib/btree/walker_types.mbt
+++ b/lib/btree/walker_types.mbt
@@ -53,8 +53,9 @@ priv struct NodeSplice[T] {
 
 ///|
 /// Value snapshot passed to a leaf splice callback. It captures the current
-/// leaf and optional adjacent leaf values without exposing a live tree
-/// collection. See the README's API Contracts section.
+/// leaf and optional adjacent values from the same immediate parent without
+/// exposing a live tree collection. These values are not guaranteed logical
+/// neighbors across parent boundaries. See the README's API Contracts section.
 pub(all) struct LeafContext[T] {
   /// Current leaf value.
   elem : T
@@ -89,13 +90,15 @@ priv struct PropagateResult[T] {
 }
 
 ///|
-/// Return the adjacent left leaf value captured in this snapshot, if present.
+/// Return the left sibling leaf value captured from the immediate parent, if
+/// present. This is not a cross-parent logical predecessor lookup.
 pub fn[T] LeafContext::left_neighbor(self : LeafContext[T]) -> T? {
   self.left_elem
 }
 
 ///|
-/// Return the adjacent right leaf value captured in this snapshot, if present.
+/// Return the right sibling leaf value captured from the immediate parent, if
+/// present. This is not a cross-parent logical successor lookup.
 pub fn[T] LeafContext::right_neighbor(self : LeafContext[T]) -> T? {
   self.right_elem
 }


### PR DESCRIPTION
## Summary

- Add `BTree::normalize_boundary_at` with the decided `Spanning + Mergeable` bounds, merging same- or cross-parent logical neighbors and closing only the mergeable run around the requested boundary.
- Reuse the range-delete descent/LCA/segment-propagation machinery through one private boundary core, with exact leaf-delta accounting and path-local `O((m + 1) log n)` work.
- Add deterministic, model-based, distribution, and benchmark coverage; document parent-local `LeafContext` neighbors and prepare the unreleased BTree 0.2.0 metadata.

Closes #1008

## Reuse check

| API | Location | Reused? | Notes |
|---|---|---:|---|
| `descend_leaf_at` / `descend_leaf_at_end_boundary` | `lib/btree/walker_descend.mbt` | Yes | Locate the exact logical leaves on both sides of a span boundary. |
| `lowest_common_ancestor_range` | `lib/btree/walker_range.mbt` | Yes | Owns same- and cross-parent LCA coordinates. |
| Existing `normalize_boundary_merge` flow | `lib/btree/walker_range_delete.mbt` | Yes, refactored | Split into one-merge and closure operations rather than adding a second implementation. |
| `propagate_node_splice`, `pack_level`, `repair_underfull_children` | `lib/btree` propagation/repair files | Yes | Reuses the arbitrary-cardinality segment infrastructure merged in #1026. |
| `fix_merged_chain` | `lib/btree/walker_repair.mbt` | No for point normalization | It recursively visits a whole repaired subtree and would violate the point-operation complexity bound; range deletion retains its existing final repair. |
| `Array::append/map/remove/fold/makei`, array views | MoonBit core | Yes | Segment construction, independent flat-array oracle, and generated topology cases. |
| `Option::unwrap` | MoonBit core | Yes | Used only after structural preconditions establish a present root. |
| `Int::min` | MoonBit core | No | Boundary coordinates already provide the exact merge interval; clamping would weaken exact-boundary semantics. |

New private responsibilities:

- `merge_boundary_once`: prepare one COW logical-boundary merge and return its resulting interval.
- `normalize_boundary_chain`: deterministic closure state machine returning the unpublished root and complete leaf delta.

Remaining mutation is limited to local segment builders, BTree rebalancing, the closure state machine, and final root/size publication. The public method is a thin shell around the deterministic private result.

## Test plan

- [x] RED regression first for a `min_degree = 2` cross-parent boundary
- [x] Same-parent, cross-parent, full-seam repartition, multi-level cascade, no-op, and idempotence coverage
- [x] Exact content/span/size/query/iteration/occupancy/cache/equal-depth/root checks through `tree_matches_model`
- [x] Degree 2, 3, and default topology matrix across multiple heights
- [x] Non-vacuous QuickCheck distribution assertions for every topology/no-op class
- [x] Regression where cached BTree spans differ from element `Spanning::span`
- [x] Existing `delete_range` regressions remain green through the shared core

## Validation

- `moon check --deny-warn lib/btree` — pass
- `moon test --release lib/btree` — 132/132 pass
- `moon test --release` — wasm-gc 3978/3978, JS 1968/1968, native 70/70
- `moon bench --release lib/btree` — 14/14 pass
  - cross-parent: 401 leaves ~4.67 µs; 8001 leaves ~7.51 µs
  - same-parent: 401 leaves ~3.10 µs; 8001 leaves ~4.59 µs
- `moon fmt --check lib/btree` and `git diff --check` — pass
- `moon info lib/btree` — only the intentional `normalize_boundary_at` line changed in `pkg.generated.mbti`
- workspace `moon check` — pass with only the existing vendored Rabbita implicit-trait-method warnings
- two independent read-only reviews — final PASS; one review found the cached-span preservation regression, which was fixed and re-reviewed

## API and release notes

- Raw `mutate_for_insert` / `mutate_for_delete` signatures, semantics, and trait bounds are unchanged.
- The only generated interface change is:
  `pub fn[T : @rle.Spanning + @rle.Mergeable] BTree::normalize_boundary_at(Self[T], Int) -> Unit`.
- `lib/btree/CHANGELOG.md` and version `0.2.0` are prepared as **Unreleased**.
- This PR does not publish the package. Merge and package publication remain separate explicit approval gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added boundary normalization to merge adjacent compatible leaves and maintain canonical tree structure.
  - Updated range deletion to automatically repair and normalize affected boundaries.
  - Released version 0.2.0.

- **Bug Fixes**
  - Improved tree integrity during boundary merges, including cross-parent merges, underfull nodes, and empty-tree restoration.
  - Prevented invalid overflowed trees from being published.

- **Documentation**
  - Documented the new boundary-normalization API, behavior, complexity, edge cases, and leaf-neighbor semantics.

- **Tests**
  - Added comprehensive property, topology, idempotence, and benchmark coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->