### PR TITLE
fix(editor): preserve structured parser diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     outputs:
       run_prove: ${{ steps.filter.outputs.run_prove }}
       run_e2e: ${{ steps.filter.outputs.run_e2e }}
+      run_cm6_adapter_e2e: ${{ steps.filter.outputs.run_cm6_adapter_e2e }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -62,6 +63,9 @@ jobs:
         id: filter
         with:
           filters: |
+            run_cm6_adapter_e2e:
+              - 'adapters/editor-adapter/**'
+              - '.github/workflows/ci.yml'
             run_prove:
               - 'lib/semantic/proof/**'
               - '.github/actions/setup-moonbit/**'
@@ -668,6 +672,39 @@ jobs:
       - name: Run canvas Playwright suite
         run: ./scripts/test-canvas-e2e.sh
 
+  cm6-adapter-e2e:
+    name: CM6 Adapter E2E
+    needs: changes
+    if: needs.changes.outputs.run_cm6_adapter_e2e == 'true'
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      options: --ipc=host
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: adapters/editor-adapter/package-lock.json
+
+      - name: Install editor adapter dependencies
+        working-directory: adapters/editor-adapter
+        run: npm ci
+
+      - name: Type check CM6 adapter and harness
+        working-directory: adapters/editor-adapter
+        run: npm run typecheck:cm6
+
+      - name: Run CM6 adapter Playwright suite
+        working-directory: adapters/editor-adapter
+        run: npm run test:e2e:cm6
+
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
@@ -687,6 +724,7 @@ jobs:
       - ideal-web-e2e
       - demo-react-e2e
       - canvas-e2e
+      - cm6-adapter-e2e
     if: always()
     steps:
       - name: Check all job statuses
@@ -706,7 +744,8 @@ jobs:
              ! ok "${{ needs.waku-workerd.result }}" || \
              ! ok "${{ needs.ideal-web-e2e.result }}" || \
              ! ok "${{ needs.demo-react-e2e.result }}" || \
-             ! ok "${{ needs.canvas-e2e.result }}"; then
+             ! ok "${{ needs.canvas-e2e.result }}" || \
+             ! ok "${{ needs.cm6-adapter-e2e.result }}"; then
             echo "❌ One or more required checks failed"
             exit 1
           fi

--- a/adapters/editor-adapter/CHANGELOG.md
+++ b/adapters/editor-adapter/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `CM6Adapter` now applies `SetDiagnostics` patches as inline `cm-diagnostic cm-diagnostic-${severity}` marks with native-tooltip `title` and `data-severity` attributes. `static extensions()` returns the new diagnostic field + plugin alongside the decoration pair. (#227)
+- `CM6Adapter` now applies `SetDiagnostics` patches through `@codemirror/lint`, preserving range diagnostics and adding zero-width point diagnostics. Non-null protocol codes become CodeMirror diagnostic sources. (#227, #1034)
 
 ### Changed
 - `UserIntent` cursor intents are now unit-specific: `SetPmCursor(pm_tree_position)` for ProseMirror tree positions and `SetDocCursor(doc_code_unit_offset)` for document code-unit offsets replace the ambiguous `SetCursor(position)` shape.
+- `Diagnostic` now always carries nullable `code`; producers and consumers must send `code: null` when no stable code exists. (#1034)
 - `cm6-adapter.ts`: `DecorationSet` and `ViewUpdate` are now imported with `import type`, fixing the build for downstream TypeScript projects with `verbatimModuleSyntax: true` (a Vite/SvelteKit default).
 - `cm6-adapter.ts`: `PeerCursorWidget.{eq, toDOM, ignoreEvent}` now carry the `override` modifier, fixing the build for downstream projects with `noImplicitOverride: true`.
 

--- a/adapters/editor-adapter/README.md
+++ b/adapters/editor-adapter/README.md
@@ -19,7 +19,7 @@ Peer dependencies are optional — install only what you use:
 | Adapter        | Required peers                                                                 |
 |----------------|--------------------------------------------------------------------------------|
 | `HTMLAdapter`  | none                                                                           |
-| `CM6Adapter`   | `@codemirror/state`, `@codemirror/view`, `@codemirror/language`, `@codemirror/commands` |
+| `CM6Adapter`   | `@codemirror/state`, `@codemirror/view`, `@codemirror/language`, `@codemirror/commands`, `@codemirror/lint` |
 | `PMAdapter`    | `prosemirror-state`, `prosemirror-view`, `prosemirror-model`, `prosemirror-transform`, `prosemirror-keymap`, `prosemirror-commands` |
 
 ## Quick start
@@ -95,7 +95,7 @@ mirrors them. Coordinate units and breaking-change rules live in
 
 **Bring your own engine.** Implement `EditorAdapter` directly, or use a built-in adapter and feed it `ViewPatch[]` from any source — a parser, an evaluator, a remote server, a wasm audio engine. The adapter does not know or care where patches come from.
 
-**Diagnostics.** Send `{ type: "SetDiagnostics", diagnostics: [...] }`. Severity is `"error" | "warning" | "info" | "hint"`; the adapter renders them as inline marks plus a hover panel. Parse errors, type errors, runtime errors all use the same path.
+**Diagnostics.** Send `{ type: "SetDiagnostics", diagnostics: [...] }`. Severity is `"error" | "warning" | "info" | "hint"`, and `code` is always `string | null`. The adapter passes diagnostics to `@codemirror/lint`, including zero-width point diagnostics; a non-null code becomes CodeMirror's diagnostic `source`. Parse errors, type errors, and runtime errors all use the same path.
 
 **Custom decorations.** Send `{ type: "SetDecorations", decorations: [...] }` with a `css_class` namespaced to your project (e.g. `moondsp-pattern-cursor`). Style it in your host CSS. Use the `widget` flag for inline DOM widgets.
 

--- a/adapters/editor-adapter/cm6-adapter.ts
+++ b/adapters/editor-adapter/cm6-adapter.ts
@@ -8,8 +8,10 @@ import {
 } from "@codemirror/view";
 import type { DecorationSet, ViewUpdate } from "@codemirror/view";
 import { StateField, StateEffect, RangeSetBuilder } from "@codemirror/state";
+import { setDiagnostics } from "@codemirror/lint";
+import type { Diagnostic as CmDiagnostic } from "@codemirror/lint";
 import type { EditorAdapter } from './adapter';
-import type { ViewPatch, UserIntent, Decoration, Diagnostic } from './types';
+import type { ViewPatch, UserIntent, Decoration } from './types';
 
 // ── Decoration state ────────────────────────────────────────
 
@@ -147,76 +149,6 @@ const decorationPlugin = ViewPlugin.fromClass(
   },
 );
 
-// ── Diagnostic state ────────────────────────────────────────
-
-const setDiagnostics = StateEffect.define<Diagnostic[]>();
-
-function buildDiagnosticSet(
-  diagnostics: Diagnostic[],
-  docLength: number,
-): DecorationSet {
-  const sorted = diagnostics
-    .map((d) => {
-      const from = Math.min(Math.max(0, d.from), docLength);
-      const to = Math.min(Math.max(from, d.to), docLength);
-      return { ...d, from, to };
-    })
-    .filter((d) => d.from < d.to)
-    .sort((a, b) => a.from - b.from || a.to - b.to);
-
-  const builder = new RangeSetBuilder<CmDecoration>();
-  for (const d of sorted) {
-    builder.add(
-      d.from,
-      d.to,
-      CmDecoration.mark({
-        class: `cm-diagnostic cm-diagnostic-${d.severity}`,
-        // Native browser tooltip — no extra @codemirror/lint dep.
-        // Consumers can override by replacing this StateField.
-        attributes: { title: d.message, "data-severity": d.severity },
-      }),
-    );
-  }
-  return builder.finish();
-}
-
-const diagnosticField = StateField.define<Diagnostic[]>({
-  create() {
-    return [];
-  },
-  update(value, tr) {
-    for (const effect of tr.effects) {
-      if (effect.is(setDiagnostics)) {
-        return effect.value;
-      }
-    }
-    return value;
-  },
-});
-
-const diagnosticPlugin = ViewPlugin.fromClass(
-  class {
-    decorations: DecorationSet;
-
-    constructor(view: EditorView) {
-      const diags = view.state.field(diagnosticField);
-      this.decorations = buildDiagnosticSet(diags, view.state.doc.length);
-    }
-
-    update(update: ViewUpdate) {
-      const oldDiags = update.startState.field(diagnosticField);
-      const newDiags = update.state.field(diagnosticField);
-      if (oldDiags !== newDiags) {
-        this.decorations = buildDiagnosticSet(newDiags, update.state.doc.length);
-      } else if (update.docChanged) {
-        this.decorations = this.decorations.map(update.changes);
-      }
-    }
-  },
-  {
-    decorations: (v) => v.decorations,
-  },
-);
 
 // ── CM6Adapter ──────────────────────────────────────────────
 
@@ -235,10 +167,8 @@ export class CM6Adapter implements EditorAdapter {
   static extensions(): [
     typeof decorationField,
     typeof decorationPlugin,
-    typeof diagnosticField,
-    typeof diagnosticPlugin,
   ] {
-    return [decorationField, decorationPlugin, diagnosticField, diagnosticPlugin];
+    return [decorationField, decorationPlugin];
   }
 
   /**
@@ -314,9 +244,19 @@ export class CM6Adapter implements EditorAdapter {
       }
 
       case "SetDiagnostics": {
-        this.view.dispatch({
-          effects: setDiagnostics.of(patch.diagnostics),
+        const docLength = this.view.state.doc.length;
+        const diagnostics: CmDiagnostic[] = patch.diagnostics.map((diagnostic) => {
+          const from = Math.min(Math.max(0, diagnostic.from), docLength);
+          const to = Math.min(Math.max(from, diagnostic.to), docLength);
+          return {
+            from,
+            to,
+            severity: diagnostic.severity,
+            message: diagnostic.message,
+            source: diagnostic.code ?? undefined,
+          };
         });
+        this.view.dispatch(setDiagnostics(this.view.state, diagnostics));
         break;
       }
 

--- a/adapters/editor-adapter/package-lock.json
+++ b/adapters/editor-adapter/package-lock.json
@@ -1,0 +1,1273 @@
+{
+  "name": "@canopy/editor-adapter",
+  "version": "0.1.0-alpha.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@canopy/editor-adapter",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "typescript": "^6.0.3",
+        "vite": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/commands": "^6.10.0",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.0",
+        "prosemirror-commands": "^1.6.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.24.0",
+        "prosemirror-state": "^1.4.0",
+        "prosemirror-transform": "^1.10.0",
+        "prosemirror-view": "^1.37.0"
+      },
+      "peerDependenciesMeta": {
+        "@codemirror/commands": {
+          "optional": true
+        },
+        "@codemirror/language": {
+          "optional": true
+        },
+        "@codemirror/lint": {
+          "optional": true
+        },
+        "@codemirror/state": {
+          "optional": true
+        },
+        "@codemirror/view": {
+          "optional": true
+        },
+        "prosemirror-commands": {
+          "optional": true
+        },
+        "prosemirror-keymap": {
+          "optional": true
+        },
+        "prosemirror-model": {
+          "optional": true
+        },
+        "prosemirror-state": {
+          "optional": true
+        },
+        "prosemirror-transform": {
+          "optional": true
+        },
+        "prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
+      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/adapters/editor-adapter/package-lock.json
+++ b/adapters/editor-adapter/package-lock.json
@@ -12,6 +12,8 @@
         "@codemirror/lint": "^6.9.7",
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.35.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "^24.13.3",
         "typescript": "^6.0.3",
         "vite": "^6.0.0"
       },
@@ -548,6 +550,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
@@ -944,6 +962,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
@@ -1063,6 +1091,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -1186,6 +1261,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.3",

--- a/adapters/editor-adapter/package.json
+++ b/adapters/editor-adapter/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "typecheck:cm6": "tsc -p tsconfig.cm6-test.json --noEmit",
     "build:test:cm6": "vite build --config vite.config.cm6-test.ts",
-    "dev:test:cm6": "vite --config vite.config.cm6-test.ts"
+    "dev:test:cm6": "vite --config vite.config.cm6-test.ts",
+    "test:e2e:cm6": "playwright test --config test/playwright.config.ts"
   },
   "description": "UI adapters bridging Canopy's ViewPatch protocol to DOM/CodeMirror/ProseMirror renderers.",
   "license": "Apache-2.0",
@@ -75,6 +76,8 @@
     "@codemirror/lint": "^6.9.7",
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.35.0",
+    "@playwright/test": "1.61.1",
+    "@types/node": "^24.13.3",
     "typescript": "^6.0.3",
     "vite": "^6.0.0"
   }

--- a/adapters/editor-adapter/package.json
+++ b/adapters/editor-adapter/package.json
@@ -2,6 +2,11 @@
   "name": "@canopy/editor-adapter",
   "version": "0.1.0-alpha.0",
   "type": "module",
+  "scripts": {
+    "typecheck:cm6": "tsc -p tsconfig.cm6-test.json --noEmit",
+    "build:test:cm6": "vite build --config vite.config.cm6-test.ts",
+    "dev:test:cm6": "vite --config vite.config.cm6-test.ts"
+  },
   "description": "UI adapters bridging Canopy's ViewPatch protocol to DOM/CodeMirror/ProseMirror renderers.",
   "license": "Apache-2.0",
   "repository": {
@@ -43,6 +48,7 @@
   "peerDependencies": {
     "@codemirror/commands": "^6.10.0",
     "@codemirror/language": "^6.10.0",
+    "@codemirror/lint": "^6.9.7",
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.35.0",
     "prosemirror-commands": "^1.6.0",
@@ -55,6 +61,7 @@
   "peerDependenciesMeta": {
     "@codemirror/commands": { "optional": true },
     "@codemirror/language": { "optional": true },
+    "@codemirror/lint": { "optional": true },
     "@codemirror/state": { "optional": true },
     "@codemirror/view": { "optional": true },
     "prosemirror-commands": { "optional": true },
@@ -63,5 +70,12 @@
     "prosemirror-state": { "optional": true },
     "prosemirror-transform": { "optional": true },
     "prosemirror-view": { "optional": true }
+  },
+  "devDependencies": {
+    "@codemirror/lint": "^6.9.7",
+    "@codemirror/state": "^6.5.0",
+    "@codemirror/view": "^6.35.0",
+    "typescript": "^6.0.3",
+    "vite": "^6.0.0"
   }
 }

--- a/adapters/editor-adapter/test/cm6-diagnostics.html
+++ b/adapters/editor-adapter/test/cm6-diagnostics.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CM6 diagnostic adapter harness</title>
+  </head>
+  <body>
+    <main>
+      <div id="editor"></div>
+      <output id="result" data-result="pending">pending</output>
+    </main>
+    <script type="module" src="./cm6-diagnostics.ts"></script>
+  </body>
+</html>

--- a/adapters/editor-adapter/test/cm6-diagnostics.spec.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+test("renders range and point diagnostics, then clears both", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await page.goto("/test/cm6-diagnostics.html");
+
+  const result = page.locator("#result");
+  await expect(result).toHaveAttribute("data-result", "markers-ready");
+  await expect(page.locator(".cm-lintRange-warning")).toHaveCount(1);
+  await expect(page.locator(".cm-lintPoint-error")).toHaveCount(1);
+
+  await page.evaluate(async () => {
+    const harnessWindow = window as typeof window & {
+      clearCm6Diagnostics: () => Promise<void>;
+    };
+    await harnessWindow.clearCm6Diagnostics();
+  });
+
+  await expect(result).toHaveAttribute("data-result", "pass");
+  await expect(page.locator(".cm-lintRange-warning")).toHaveCount(0);
+  await expect(page.locator(".cm-lintPoint-error")).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});

--- a/adapters/editor-adapter/test/cm6-diagnostics.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.ts
@@ -1,0 +1,63 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { CM6Adapter } from "../cm6-adapter";
+
+async function main(): Promise<void> {
+  const parent = document.querySelector<HTMLElement>("#editor");
+  const result = document.querySelector<HTMLOutputElement>("#result");
+  if (!parent || !result) {
+    throw new Error("diagnostic harness DOM is incomplete");
+  }
+
+  const state = EditorState.create({
+    doc: "if x then y",
+    extensions: CM6Adapter.extensions(),
+  });
+  const view = new EditorView({ state, parent });
+  const adapter = new CM6Adapter(view);
+
+  adapter.applyPatches([
+    {
+      type: "SetDiagnostics",
+      diagnostics: [
+        {
+          from: 3,
+          to: 4,
+          severity: "warning",
+          message: "range warning",
+          code: "test.range",
+        },
+        {
+          from: 11,
+          to: 11,
+          severity: "error",
+          message: "missing else",
+          code: null,
+        },
+      ],
+    },
+  ]);
+
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  const rangeVisible = parent.querySelector(".cm-lintRange-warning") !== null;
+  const pointVisible = parent.querySelector(".cm-lintPoint-error") !== null;
+  result.dataset.result = "markers-ready";
+  result.textContent = JSON.stringify({ rangeVisible, pointVisible });
+
+  const harnessWindow = window as typeof window & {
+    clearCm6Diagnostics: () => Promise<void>;
+  };
+  harnessWindow.clearCm6Diagnostics = async () => {
+    adapter.applyPatches([{ type: "SetDiagnostics", diagnostics: [] }]);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const cleared =
+      parent.querySelector(".cm-lintRange-warning") === null &&
+      parent.querySelector(".cm-lintPoint-error") === null;
+    const passed = rangeVisible && pointVisible && cleared;
+    result.dataset.result = passed ? "pass" : "fail";
+    result.textContent = JSON.stringify({ rangeVisible, pointVisible, cleared });
+    if (!passed) throw new Error(result.textContent);
+  };
+}
+
+void main();

--- a/adapters/editor-adapter/test/cm6-diagnostics.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.ts
@@ -60,4 +60,11 @@ async function main(): Promise<void> {
   };
 }
 
-void main();
+void main().catch((error: unknown) => {
+  const result = document.querySelector<HTMLOutputElement>("#result");
+  if (result) {
+    result.dataset.result = "fail";
+    result.textContent = error instanceof Error ? error.message : String(error);
+  }
+  console.error(error);
+});

--- a/adapters/editor-adapter/test/playwright.config.ts
+++ b/adapters/editor-adapter/test/playwright.config.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const adapterDir = fileURLToPath(new URL("..", import.meta.url));
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "cm6-diagnostics.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "line" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5197",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    cwd: adapterDir,
+    command: "node ./node_modules/vite/bin/vite.js --config vite.config.cm6-test.ts --host 127.0.0.1 --port 5197 --strictPort",
+    url: "http://127.0.0.1:5197/test/cm6-diagnostics.html",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/adapters/editor-adapter/tsconfig.cm6-test.json
+++ b/adapters/editor-adapter/tsconfig.cm6-test.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+  },
+  "include": [
+    "adapter.ts",
+    "cm6-adapter.ts",
+    "types.ts",
+    "test/cm6-diagnostics.ts",
+    "vite.config.cm6-test.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/adapters/editor-adapter/tsconfig.cm6-test.json
+++ b/adapters/editor-adapter/tsconfig.cm6-test.json
@@ -6,13 +6,14 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node"]
   },
   "include": [
     "adapter.ts",
     "cm6-adapter.ts",
     "types.ts",
-    "test/cm6-diagnostics.ts",
+    "test/*.ts",
     "vite.config.cm6-test.ts"
   ],
   "exclude": ["node_modules", "dist"]

--- a/adapters/editor-adapter/types.ts
+++ b/adapters/editor-adapter/types.ts
@@ -27,6 +27,7 @@ export type Diagnostic = {
   to: number;
   severity: "error" | "warning" | "info" | "hint";
   message: string;
+  code: string | null;
 };
 
 export type ViewPatch =

--- a/adapters/editor-adapter/vite.config.cm6-test.ts
+++ b/adapters/editor-adapter/vite.config.cm6-test.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    outDir: "dist/cm6-test",
+    emptyOutDir: true,
+    rollupOptions: {
+      input: new URL("./test/cm6-diagnostics.html", import.meta.url).pathname,
+    },
+  },
+});

--- a/adapters/editor-adapter/vite.config.cm6-test.ts
+++ b/adapters/editor-adapter/vite.config.cm6-test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -5,7 +7,9 @@ export default defineConfig({
     outDir: "dist/cm6-test",
     emptyOutDir: true,
     rollupOptions: {
-      input: new URL("./test/cm6-diagnostics.html", import.meta.url).pathname,
+      input: fileURLToPath(
+        new URL("./test/cm6-diagnostics.html", import.meta.url),
+      ),
     },
   },
 });

--- a/docs/plans/2026-07-30-structured-parser-diagnostics-editor.md
+++ b/docs/plans/2026-07-30-structured-parser-diagnostics-editor.md
@@ -1,6 +1,6 @@
 # Structured Parser Diagnostics in the CodeMirror Editor
 
-Status: ready
+Status: Executed
 
 Canonical issue: [#1034](https://github.com/dowdiness/canopy/issues/1034)
 
@@ -94,17 +94,17 @@ No new MoonBit core helper or type is required.
 
 ## Acceptance Criteria
 
-- [ ] Editor display reads structured `parser_diagnostics()`; it does not call `get_errors()`.
-- [ ] Loom primary UTF-16 range, all four severities, message, and optional code survive conversion.
-- [ ] Only a locationless diagnostic falls back to `0..0`.
-- [ ] `if x then y` renders a visible EOF point marker.
-- [ ] A nonzero diagnostic renders as a lint range.
-- [ ] Correcting input emits `SetDiagnostics([])` and removes markers.
-- [ ] The custom CM6 diagnostic field/plugin and `from < to` filter are gone.
-- [ ] Protocol JSON always contains `code`, covered with both a string and `null`; TypeScript declares `code: string | null`.
-- [ ] `@codemirror/lint` is an optional peer; no nonconsumer manifest is changed.
-- [ ] The adapter-owned browser harness passes without Canopy parser, CST, or editor internals.
-- [ ] No fix, source-ID, semantic, or standalone-renderer API enters this change.
+- [x] Editor display reads structured `parser_diagnostics()`; it does not call `get_errors()`.
+- [x] Loom primary UTF-16 range, all four severities, message, and optional code survive conversion.
+- [x] Only a locationless diagnostic falls back to `0..0`.
+- [x] `if x then y` renders a visible EOF point marker.
+- [x] A nonzero diagnostic renders as a lint range.
+- [x] Correcting input emits `SetDiagnostics([])` and removes markers.
+- [x] The custom CM6 diagnostic field/plugin and `from < to` filter are gone.
+- [x] Protocol JSON always contains `code`, covered with both a string and `null`; TypeScript declares `code: string | null`.
+- [x] `@codemirror/lint` is an optional peer; no nonconsumer manifest is changed.
+- [x] The adapter-owned browser harness passes without Canopy parser, CST, or editor internals.
+- [x] No fix, source-ID, semantic, or standalone-renderer API enters this change.
 
 ## Validation
 
@@ -139,6 +139,17 @@ npm run dev:test:cm6
 ```
 
 Drive the last command in a real browser. Require the harness pass signal, inspect `.cm-lintRange-warning` and `.cm-lintPoint-error`, verify clearing, and capture a screenshot.
+
+## Execution Evidence
+
+Executed 2026-07-30 on branch `fix/1034-preserve-parser-diagnostics`.
+
+- Focused MoonBit tests: protocol 42/42, editor 205/205, Lambda companion 101/101.
+- Adapter clean install and build: `npm ci`, `npm run typecheck:cm6`, and `npm run build:test:cm6` passed.
+- Browser harness: one `.cm-lintRange-warning` and one `.cm-lintPoint-error` were present together; after `clearCm6Diagnostics()`, both counts were zero. A 1024×200 screenshot was captured.
+- Workspace validation: `moon check`, `moon test`, and `moon build --target js --release` passed. The only diagnostics were nine pre-existing vendored Rabbita deprecation warnings.
+- Interface/format validation: `NEW_MOON_MOD=0 moon info && NEW_MOON_MOD=0 moon fmt` passed. The intended protocol interface change is nullable `Diagnostic.code`; the test-only probe interface adds `new_empty_diagnostic_test_editor`.
+- Independent review: MoonBit/protocol/editor PASS with no findings (`openai-codex/gpt-5.5`); TypeScript adapter PASS (`mimo-v2.5-free`) after correcting one stale changelog entry.
 
 ## Risks
 

--- a/docs/plans/2026-07-30-structured-parser-diagnostics-editor.md
+++ b/docs/plans/2026-07-30-structured-parser-diagnostics-editor.md
@@ -135,10 +135,11 @@ cd adapters/editor-adapter
 npm ci
 npm run typecheck:cm6
 npm run build:test:cm6
+npm run test:e2e:cm6
 npm run dev:test:cm6
 ```
 
-Drive the last command in a real browser. Require the harness pass signal, inspect `.cm-lintRange-warning` and `.cm-lintPoint-error`, verify clearing, and capture a screenshot.
+`test:e2e:cm6` must automatically assert the range marker, EOF point marker, clearing, and final pass signal. For manual visual inspection, drive `dev:test:cm6` in a real browser and capture a screenshot.
 
 ## Execution Evidence
 
@@ -146,7 +147,8 @@ Executed 2026-07-30 on branch `fix/1034-preserve-parser-diagnostics`.
 
 - Focused MoonBit tests: protocol 42/42, editor 205/205, Lambda companion 101/101.
 - Adapter clean install and build: `npm ci`, `npm run typecheck:cm6`, and `npm run build:test:cm6` passed.
-- Browser harness: one `.cm-lintRange-warning` and one `.cm-lintPoint-error` were present together; after `clearCm6Diagnostics()`, both counts were zero. A 1024×200 screenshot was captured.
+- Automated browser regression: `npm run test:e2e:cm6` passed, asserting one `.cm-lintRange-warning`, one `.cm-lintPoint-error`, clearing both, no page errors, and the final pass signal. The dedicated `CM6 Adapter E2E` job is required by `All Checks Passed`.
+- Manual browser inspection captured both marker forms and their clearing in a 1024×200 screenshot.
 - Workspace validation: `moon check`, `moon test`, and `moon build --target js --release` passed. The only diagnostics were nine pre-existing vendored Rabbita deprecation warnings.
 - Interface/format validation: `NEW_MOON_MOD=0 moon info && NEW_MOON_MOD=0 moon fmt` passed. The intended protocol interface change is nullable `Diagnostic.code`; the test-only probe interface adds `new_empty_diagnostic_test_editor`.
 - Independent review: MoonBit/protocol/editor PASS with no findings (`openai-codex/gpt-5.5`); TypeScript adapter PASS (`mimo-v2.5-free`) after correcting one stale changelog entry.

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -87,19 +87,28 @@ pub fn[T : @loom_core.Renderable] compute_view_patches(
       }
   }
   state.previous_decorations = Some(current_decorations)
-  let errors = editor.get_errors()
-  if errors.length() > 0 {
-    let diagnostics : Array[@protocol.Diagnostic] = []
-    for error in errors {
-      diagnostics.push(
-        @protocol.Diagnostic(
-          from=0,
-          to=0,
-          severity=@protocol.SevError,
-          message=error,
-        ),
+  let parser_diagnostics = editor.parser_diagnostics().read_or_abort().items()
+  if !parser_diagnostics.is_empty() {
+    let diagnostics = parser_diagnostics.map(diagnostic => {
+      let (from, to) = match diagnostic.primary {
+        Some(range) => (range.start().value(), range.end().value())
+        None => (0, 0)
+      }
+      let severity = match diagnostic.severity {
+        @loom_core.DiagnosticSeverity::Error => @protocol.SevError
+        @loom_core.DiagnosticSeverity::Warning => @protocol.SevWarning
+        @loom_core.DiagnosticSeverity::Info => @protocol.SevInfo
+        @loom_core.DiagnosticSeverity::Hint => @protocol.SevHint
+      }
+      let code = diagnostic.code.map(code => code.value())
+      @protocol.Diagnostic(
+        from~,
+        to~,
+        severity~,
+        message=diagnostic.message,
+        code?,
       )
-    }
+    })
     patches.push(@protocol.ViewPatch::SetDiagnostics(diagnostics~))
     state.had_errors = true
   } else if state.had_errors {

--- a/editor/view_updater_test.mbt
+++ b/editor/view_updater_test.mbt
@@ -170,22 +170,49 @@ test "structural edit produces ReplaceNode" {
 }
 
 ///|
-test "diagnostics are emitted for parse errors" {
+test "parser diagnostic preserves EOF range severity message and code" {
   let editor = try! @probe.new_test_editor("test")
-  editor.set_text("foo(") // unclosed '('
+  editor.set_text("foo(") // unclosed '(' at UTF-16 EOF offset 4
   let state = @editor.ViewUpdateState::ViewUpdateState()
   let patches = @editor.compute_view_patches(state, editor)
-  // Should contain SetDiagnostics with errors
-  let has_diagnostics = patches
+  let patch = patches
     .iter()
-    .any(fn(p) {
-      match p {
-        @protocol.ViewPatch::SetDiagnostics(diagnostics~) =>
-          diagnostics.length() > 0
-        _ => false
-      }
-    })
-  assert_true(has_diagnostics)
+    .find_first(patch => patch is @protocol.ViewPatch::SetDiagnostics(_))
+    .unwrap()
+  guard patch is @protocol.ViewPatch::SetDiagnostics(diagnostics~) else {
+    fail("expected SetDiagnostics")
+  }
+  guard diagnostics is [diagnostic] else {
+    fail("expected exactly one parser diagnostic")
+  }
+  inspect(diagnostic.from, content="4")
+  inspect(diagnostic.to, content="4")
+  @debug.assert_eq(diagnostic.severity, @protocol.SevError)
+  inspect(diagnostic.message, content="unclosed '('")
+  @debug.assert_eq(diagnostic.code, None)
+}
+
+///|
+test "empty document does not suppress structured parser diagnostics" {
+  let editor = try! @probe.new_empty_diagnostic_test_editor("test")
+  let patches = @editor.compute_view_patches(
+    @editor.ViewUpdateState::ViewUpdateState(),
+    editor,
+  )
+  let patch = patches
+    .iter()
+    .find_first(patch => patch is @protocol.ViewPatch::SetDiagnostics(_))
+    .unwrap()
+  guard patch is @protocol.ViewPatch::SetDiagnostics(diagnostics~) else {
+    fail("expected SetDiagnostics")
+  }
+  guard diagnostics is [diagnostic] else {
+    fail("expected exactly one empty-document diagnostic")
+  }
+  inspect(diagnostic.from, content="0")
+  inspect(diagnostic.to, content="0")
+  inspect(diagnostic.message, content="empty source")
+  @debug.assert_eq(diagnostic.code, Some("test.empty-source"))
 }
 
 ///|

--- a/examples/prosemirror/src/keymap.ts
+++ b/examples/prosemirror/src/keymap.ts
@@ -1,6 +1,6 @@
 import { keymap } from "prosemirror-keymap";
 import { NodeSelection } from "prosemirror-state";
-import type { UserIntent } from "@canopy/editor-adapter";
+import type { UserIntent } from "@canopy/editor-adapter/types";
 
 /**
  * ProseMirror keymap plugin for structural operations on AST nodes.

--- a/examples/prosemirror/src/main.ts
+++ b/examples/prosemirror/src/main.ts
@@ -2,8 +2,8 @@
 
 import * as crdt from "@moonbit/canopy";
 import { EditorState as PmState } from "prosemirror-state";
-import { PMAdapter } from "@canopy/editor-adapter";
-import type { ViewPatch, ViewNode, UserIntent } from "@canopy/editor-adapter";
+import { PMAdapter } from "@canopy/editor-adapter/pm-adapter";
+import type { ViewPatch, ViewNode, UserIntent } from "@canopy/editor-adapter/types";
 import { connectWebSocket } from "./ws-glue";
 import { structuralKeymap } from "./keymap";
 

--- a/lang/lambda/companion/editor_view_decorations_test.mbt
+++ b/lang/lambda/companion/editor_view_decorations_test.mbt
@@ -168,3 +168,50 @@ test "analysis projection drops stale pattern decorations but keeps semantic dec
     })
   assert_true(has_semantic_without_pattern)
 }
+
+///|
+test "missing else projects an EOF point diagnostic" {
+  let editor = (try! new_lambda_editor("test-missing-else-diagnostic")).0
+  editor.set_text("if x then y")
+  let patches = @editor.compute_view_patches(
+    @editor.ViewUpdateState::ViewUpdateState(),
+    editor,
+  )
+  let patch = patches
+    .iter()
+    .find_first(patch => patch is @protocol.ViewPatch::SetDiagnostics(_))
+    .unwrap()
+  guard patch is @protocol.ViewPatch::SetDiagnostics(diagnostics~) else {
+    fail("expected SetDiagnostics")
+  }
+  let diagnostic = diagnostics
+    .iter()
+    .find_first(diagnostic => diagnostic.message.contains("else"))
+    .unwrap()
+  inspect(diagnostic.from, content="11")
+  inspect(diagnostic.to, content="11")
+  @debug.assert_eq(diagnostic.severity, @protocol.SevError)
+}
+
+///|
+test "coded lexer diagnostic preserves its source range and code" {
+  let editor = (try! new_lambda_editor("test-coded-lexer-diagnostic")).0
+  editor.set_text("@")
+  let patches = @editor.compute_view_patches(
+    @editor.ViewUpdateState::ViewUpdateState(),
+    editor,
+  )
+  let patch = patches
+    .iter()
+    .find_first(patch => patch is @protocol.ViewPatch::SetDiagnostics(_))
+    .unwrap()
+  guard patch is @protocol.ViewPatch::SetDiagnostics(diagnostics~) else {
+    fail("expected SetDiagnostics")
+  }
+  let diagnostic = diagnostics
+    .iter()
+    .find_first(diagnostic => diagnostic.code is Some(_))
+    .unwrap()
+  assert_true(diagnostic.from < diagnostic.to)
+  assert_true(diagnostic.code.unwrap().length() > 0)
+}

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -48,6 +48,7 @@ so these units stay separate.
 | `ViewPatch.SetSelection.anchor` / `.head` | MoonBit → JS | UTF-16 document code-unit offset | Text selection endpoints. |
 | `Decoration.from` / `.to` | MoonBit → JS | UTF-16 document code-unit offset | Half-open source range for marks or widgets. |
 | `Diagnostic.from` / `.to` | MoonBit → JS | UTF-16 document code-unit offset | Half-open source range for annotations. |
+| `Diagnostic.code` | MoonBit → JS | Nullable string | Stable producer-defined diagnostic identifier; always serialized as `null` or a string. |
 | `SetPmCursor.pm_tree_position` | JS → MoonBit | ProseMirror tree position | Cursor in the PM tree. Convert before using text APIs. |
 | `SetDocCursor.doc_code_unit_offset` | JS → MoonBit | UTF-16 document code-unit offset | Cursor in source text. |
 

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -30,8 +30,9 @@ pub(all) struct Diagnostic {
   to : Int
   severity : Severity
   message : String
+  code : String?
 } derive(Eq, @debug.Debug)
-pub fn Diagnostic::Diagnostic(from~ : Int, to~ : Int, severity~ : Severity, message~ : String) -> Self
+pub fn Diagnostic::Diagnostic(from~ : Int, to~ : Int, severity~ : Severity, message~ : String, code? : String) -> Self
 pub impl ToJson for Diagnostic
 
 pub(all) enum Severity {

--- a/protocol/view_patch.mbt
+++ b/protocol/view_patch.mbt
@@ -57,6 +57,7 @@ pub(all) struct Diagnostic {
   to : Int
   severity : Severity
   message : String
+  code : String?
 } derive(Debug, Eq)
 
 ///|
@@ -65,8 +66,9 @@ pub fn Diagnostic::Diagnostic(
   to~ : Int,
   severity~ : Severity,
   message~ : String,
+  code? : String,
 ) -> Diagnostic {
-  { from, to, severity, message }
+  { from, to, severity, message, code }
 }
 
 ///|
@@ -118,6 +120,10 @@ pub impl ToJson for Diagnostic with fn to_json(self) {
   m["to"] = self.to.to_json()
   m["severity"] = self.severity.to_json()
   m["message"] = self.message.to_json()
+  m["code"] = match self.code {
+    Some(code) => code.to_json()
+    None => Json::null()
+  }
   Json::object(m)
 }
 

--- a/protocol/view_patch_test.mbt
+++ b/protocol/view_patch_test.mbt
@@ -26,17 +26,27 @@ test "Decoration with data and widget to_json" {
 }
 
 ///|
-test "Diagnostic to_json produces object-based JSON" {
-  let diag = @protocol.Diagnostic(
+test "Diagnostic to_json always includes nullable code" {
+  let without_code = @protocol.Diagnostic(
     from=0,
     to=3,
     severity=@protocol.SevError,
     message="unbound var",
   )
-  let s = diag.to_json().stringify()
   inspect(
-    s,
-    content="{\"from\":0,\"to\":3,\"severity\":\"error\",\"message\":\"unbound var\"}",
+    without_code.to_json().stringify(),
+    content="{\"from\":0,\"to\":3,\"severity\":\"error\",\"message\":\"unbound var\",\"code\":null}",
+  )
+  let with_code = @protocol.Diagnostic(
+    from=3,
+    to=3,
+    severity=@protocol.SevHint,
+    message="expected else",
+    code="parse.expected-else",
+  )
+  inspect(
+    with_code.to_json().stringify(),
+    content="{\"from\":3,\"to\":3,\"severity\":\"hint\",\"message\":\"expected else\",\"code\":\"parse.expected-else\"}",
   )
 }
 

--- a/workspace/probe/pkg.generated.mbti
+++ b/workspace/probe/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Values
 pub fn get_test_ast(@editor.SyncEditor[TestExpr]) -> TestExpr
 
+pub fn new_empty_diagnostic_test_editor(String) -> @editor.SyncEditor[TestExpr] raise @text.TextError
+
 pub fn new_test_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[TestExpr] raise @text.TextError
 
 // Errors

--- a/workspace/probe/test_grammar.mbt
+++ b/workspace/probe/test_grammar.mbt
@@ -165,6 +165,20 @@ fn test_parse_root(ctx : @loomcore.ParserContext[TestToken, TestKind]) -> Unit {
 }
 
 ///|
+fn test_parse_empty_diagnostic_root(
+  ctx : @loomcore.ParserContext[TestToken, TestKind],
+) -> Unit {
+  if ctx.at_eof() {
+    ctx.report_at_current(
+      message="empty source",
+      code=Some(@loomcore.DiagnosticCode::DiagnosticCode("test.empty-source")),
+    )
+  } else {
+    test_parse_root(ctx)
+  }
+}
+
+///|
 fn parse_test_expr(ctx : @loomcore.ParserContext[TestToken, TestKind]) -> Unit {
   if ctx.peek_nth(1) is LParen {
     ctx.node(BranchNode, fn() {
@@ -237,6 +251,24 @@ let test_grammar : @loom.Grammar[TestToken, TestKind, TestExpr] = @loom.Grammar:
   incremental_relex_enabled=false,
 )
 
+///|
+let empty_diagnostic_test_spec : @loomcore.LanguageSpec[TestToken, TestKind] = @loomcore.LanguageSpec::new(
+  WhitespaceToken,
+  ErrorNode,
+  RootNode,
+  Eof,
+  parse_root=test_parse_empty_diagnostic_root,
+  reuse_size_threshold=0,
+)
+
+///|
+let empty_diagnostic_test_grammar : @loom.Grammar[TestToken, TestKind, TestExpr] = @loom.Grammar::new(
+  spec=empty_diagnostic_test_spec,
+  lex=lex_test_expr,
+  fold_node=test_fold_node,
+  incremental_relex_enabled=false,
+)
+
 // === Projection (SyntaxNode -> ProjNode[TestExpr]) ===
 
 ///|
@@ -304,6 +336,22 @@ pub fn new_test_editor(
     build_test_projection_memos,
     capture_timeout_ms~,
     parent_runtime?,
+  )
+}
+
+///|
+/// Construct a test-only editor whose empty source emits one structured
+/// diagnostic. This keeps the default neutral grammar unchanged while allowing
+/// consumers to verify that they do not suppress diagnostics by source length.
+pub fn new_empty_diagnostic_test_editor(
+  agent_id : String,
+) -> @editor.SyncEditor[TestExpr] raise @text.TextError {
+  @editor.SyncEditor::new_generic(
+    agent_id,
+    (source, runtime) => {
+      @loom.new_parser(source, empty_diagnostic_test_grammar, runtime?)
+    },
+    build_test_projection_memos,
   )
 }
 


### PR DESCRIPTION
## Summary
- project Loom parser diagnostics into the editor protocol without flattening ranges, severity, or stable codes
- replace the custom CodeMirror diagnostic field with @codemirror/lint, including zero-width point markers
- add protocol, editor, Lambda, and adapter-browser regression coverage

## Reuse check
- reused Loom DiagnosticSet, Diagnostic, TextRange/TextOffset, and parser_diagnostics() rather than adding a second model
- reused CodeMirror setDiagnostics rather than maintaining the custom field/plugin
- no new MoonBit helper or domain type introduced

## Validation
- NEW_MOON_MOD=0 moon test -p dowdiness/canopy/protocol
- NEW_MOON_MOD=0 moon test -p dowdiness/canopy/editor
- NEW_MOON_MOD=0 moon test -p dowdiness/canopy/lang/lambda/companion
- moon check && moon test && moon build --target js --release
- npm ci && npm run typecheck:cm6 && npm run build:test:cm6
- browser harness: range marker, EOF point marker, and clearing all verified
- independent MoonBit and TypeScript reviews: PASS

Closes #1034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nullable diagnostic `code` to the editor protocol/adapter, surfaced in CodeMirror diagnostics via diagnostic source mapping.
  * Cursor intents now more clearly distinguish document offsets vs tree positions (unit-specific).
* **Bug Fixes**
  * Diagnostics now preserve correct ranges, severities, messages, and point markers across supported editors; empty-document diagnostics are handled consistently.
* **Tests**
  * Added/extended browser-based E2E coverage for displaying and clearing CodeMirror 6 diagnostics.
* **Documentation**
  * Updated adapter and protocol docs to reflect the revised diagnostics flow and the new `code` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->