### PR TITLE
feat(btree): prove scalar invariants

### DIFF
--- a/docs/development/formal-verification.md
+++ b/docs/development/formal-verification.md
@@ -13,7 +13,7 @@ moon prove  →  moonc (WhyML codegen)  →  Why3  →  z3 (SMT solver)
 ```
 
 **Tested versions:**
-- MoonBit moon 0.1.20260409
+- MoonBit 0.10.4+ade96c819 (repository-pinned toolchain)
 - Why3 1.7.2 (install via `opam install why3.1.7.2`)
 - Z3 4.13.x (install via `pip3 install z3-solver==4.13.4.0` or `opam install z3`)
 
@@ -24,11 +24,11 @@ moon prove  →  moonc (WhyML codegen)  →  Why3  →  z3 (SMT solver)
 ### File structure
 
 ```
-lib/semantic/proof/
-├── moon.mod.json          # Standalone module (no canopy deps)
+lib/{semantic,btree}/proof/
+├── moon.mod               # Standalone module (no Canopy dependencies)
 ├── moon.pkg               # options("proof-enabled": true)
-├── confidence.mbt          # Code + proof_ensure contracts
-├── confidence.mbtp         # Logical predicates (spec-only)
+├── *.mbt                  # Code + proof_ensure contracts
+├── *.mbtp                 # Logical predicates (spec-only)
 └── pkg.generated.mbti
 ```
 
@@ -65,8 +65,8 @@ predicate conflict_is_top(a : T, b : T, result : T) {
 ### Running
 
 ```bash
-cd lib/semantic/proof
-moon prove          # verify all proof_ensure contracts
+cd lib/semantic/proof  # or lib/btree/proof
+moon prove             # verify all proof_ensure contracts
 ```
 
 ## Prover Limitations
@@ -78,6 +78,7 @@ These constraints determine what `moon prove` can and cannot verify:
 | Unbounded integers only | No Float, no overflow modeling | Use Int-specialized mirror types |
 | No `==` on custom enums | Can't write `result == expected` for enum types | Project to Int via `#proof_pure` functions |
 | No method calls in predicates | Only `#proof_pure` functions and primitives | Write pure projection functions |
+| `#proof_pure` functions cannot carry contracts | A projection cannot prove its own postcondition | Put the arithmetic directly in a contracted side-effect-free function; reserve `#proof_pure` for logic-side projections |
 | No Map/Array[T]/closure reasoning | Can't model stateful data structures | Use @qc for these properties |
 | Wildcard `_` codegen bug | `IRuleBased(_) => 2` emits broken WhyML | Use named bindings: `IRuleBased(_v) => 2` |
 | `proof-enabled` cascades to deps | Enabling on a package proves all transitive deps | Isolate proof packages in standalone modules |
@@ -124,6 +125,24 @@ For `Confidence::join`: we proved the lattice laws on `IntConfidence` (the algor
 | `disagreement_yields_conflict` | Different payloads from non-trivial inputs → Conflict |
 | `guessed_max_score` | Guessed+Guessed same payload → Guessed with exact max score, payload preserved |
 
+### Formally verified (lib/btree/proof/)
+
+Nine scalar contracts mirror production decisions without importing the BTree package:
+
+| Function | What it proves |
+|---|---|
+| `splice_leaf_delta` | Leaf delta equals inserted leaves minus the replaced range |
+| `splice_new_count` | Splice cardinality is non-negative and equals `old_count + leaf_delta` under valid indices |
+| `planned_group_size` | Every scalar grouping step emits a value in `[t, 2t]`; nonterminal steps preserve a legal remainder and make progress |
+| `planned_group_total` | The recursive scalar grouping model terminates and its emitted sizes sum to the input count |
+| `advance_group_sum` | The emitted-plus-remaining invariant is preserved and the terminal sum equals the input count |
+| `repaired_node_count` | Merge/steal arithmetic preserves participating child counts; steal and sufficiently large merge restore occupancy, while smaller merges remain conserved intermediate states |
+| `repair_total_with_unaffected` | One repair step preserves the global child total when counts outside the selected sibling pair are held fixed |
+| `span_add_accepted` | Checked-add acceptance exactly matches the supported non-negative mathematical range |
+| `project_root_present` | The scalar publication policy maps zero leaves to no root and requires a present root to have a positive leaf count |
+
+See [`lib/btree/proof/README.md`](../../lib/btree/proof/README.md) for the exact production mapping, preconditions, composition argument, and limitations. Production Array materialization, final repeated-repair occupancy, root-state linkage, recursive tree integration, and MoonBit machine-`Int` behavior remain executable/property-test coverage.
+
 ### Property-tested (@qc)
 
 | Package | File | Properties |
@@ -131,6 +150,7 @@ For `Confidence::join`: we proved the lattice laws on `IntConfidence` (the algor
 | core/ | reconcile_properties_wbtest.mbt | ID uniqueness, ID preservation, kind propagation, idempotency, insert/delete stability |
 | core/ | source_map_properties_wbtest.mbt | Node coverage, range sorting, rebuild consistency, parent enclosure, innermost node minimality |
 | lib/semantic/ | confidence_properties_wbtest.mbt | Commutativity, associativity, idempotency, identity, absorbing top (on real `Confidence[Role]`) |
+| lib/btree/ | btree_property_wbtest.mbt | Cached spans, splice cardinality, occupancy repair, root normalization, and range-delete integration |
 | lib/zipper/ | zipper_properties_wbtest.mbt | Zipper navigation laws |
 | event-graph-walker/ | Various *_properties_test.mbt | CRDT convergence, version vector properties, FractionalIndex ordering |
 
@@ -142,7 +162,6 @@ Candidates ordered by value and feasibility:
 
 | Target | Package | Properties | Why provable |
 |---|---|---|---|
-| B+ tree scalar invariants (#1006, planned) | lib/btree/proof (planned) | Non-root child-group occupancy [t, 2t]; splice and grouping cardinality sums/progress; repair, root-lifecycle, and checked-add laws. Recursive mutable B+ tree integration remains executable/property-test coverage. | Pure Int/Bool arithmetic on child counts and cumulative spans; not yet implemented |
 | delete_range boundaries | lib/btree | Index parameters stay valid through descent | Index math — exactly what z3 excels at |
 | SourceMap range sorting | core/ | Ranges array sorted after rebuild | Int comparisons on array indices |
 | FractionalIndex ordering | event-graph-walker/ | midpoint(a, b) is strictly between a and b | Byte-array arithmetic |
@@ -178,20 +197,20 @@ pip3 install --user z3-solver==4.13.4.0
 # Register z3 with Why3
 why3 config detect
 
-# Run proofs
-cd lib/semantic/proof
+# Run either standalone proof module
+cd lib/semantic/proof  # or lib/btree/proof
 moon prove
 ```
 
 ### CI
 
-The `prove` job in `.github/workflows/ci.yml` uses `ocaml/setup-ocaml@v3` to install OCaml/opam, then installs Why3 1.7.2 and z3. The opam switch is cached across runs.
+The `prove` job in `.github/workflows/ci.yml` installs Why3 1.7.2 and z3 through opam. The opam switch is cached across runs. It currently executes `lib/semantic/proof`; adding `lib/btree/proof` to the gating matrix remains tracked by #1007.
 
 ### Adding a new proof package
 
-1. Create a standalone module with its own `moon.mod.json` (avoids cascading `proof-enabled` to the entire dependency graph)
+1. Create a standalone module with its own `moon.mod` (avoids cascading `proof-enabled` to the entire dependency graph)
 2. Add `options("proof-enabled": true)` to `moon.pkg`
-3. Write `#proof_pure` projection functions for any custom types
+3. Write `#proof_pure` projection functions only when logic predicates must inspect custom types
 4. Write predicates in `.mbtp`
 5. Add `proof_ensure` contracts to the function under verification
 6. Run `moon prove` and iterate

--- a/lib/btree/proof/README.md
+++ b/lib/btree/proof/README.md
@@ -1,0 +1,64 @@
+# BTree scalar proofs
+
+This standalone module proves the integer decisions behind BTree splice cardinality, non-root grouping, underfull-child repair, checked span addition, and root publication. It intentionally does not depend on `dowdiness/btree`: the production package remains executable while this package mirrors only pure `Int`/`Bool` formulas that Why3 can model accurately.
+
+## Production mapping
+
+| Proof-model function | Production source | Mirrored decision and preconditions | Proved postcondition |
+|---|---|---|---|
+| `splice_leaf_delta` | `lib/btree/walker_propagate.mbt`, `propagate` | `inserted_count - (end_idx - start_idx)` | The returned delta equals the replacement formula. |
+| `splice_new_count` | `lib/btree/walker_propagate.mbt`, `propagate`; callers publishing `size` | `0 <= start <= end <= old_count`, `inserted_count >= 0` | `new_count = old_count - (end - start) + inserted_count = old_count + leaf_delta`, and the result is non-negative. |
+| `planned_group_size` | `lib/btree/walker_propagate.mbt`, `legal_chunk_sizes` | `min_degree >= 2`, `remaining >= min_degree`; terminal push or the loop's next chunk | Every emitted group is in `[min_degree, 2 * min_degree]`; a non-terminal remainder stays at least `min_degree` and strictly decreases. |
+| `planned_group_total` | `lib/btree/walker_propagate.mbt`, repeated `legal_chunk_sizes` steps | The same grouping preconditions and the strictly decreasing remainder | The recursive scalar planner terminates and all emitted group sizes sum exactly to the input child count. |
+| `advance_group_sum` | `lib/btree/walker_propagate.mbt`, `legal_chunk_sizes` | `original_count = emitted_count + remaining` and the grouping preconditions | One step preserves `emitted + remaining = original_count`; a terminal step emits exactly `original_count`. |
+| `repaired_node_count` | `lib/btree/walker_repair.mbt`, `repair_underfull_children`, `bulk_steal_from_left`, and `bulk_steal_from_right` | Reactive underfull count in `[0, t)`, sibling in `[0, 2t]`, target in `[t, t + 1]` | Every merge or steal preserves the participating child total and keeps the result in `[0, 2t]`. A steal restores both occupancies. A merge at or above `t` restores occupancy; a smaller adjacent-underfull merge remains a conserved candidate for another repair step. |
+| `repair_total_with_unaffected` | One iteration of `lib/btree/walker_repair.mbt`, `repair_underfull_children` | A non-negative count outside the selected pair and the same reactive repair preconditions | `unaffected + participating pair` is unchanged by either branch, so each new loop decomposition preserves the global child total. |
+| `span_add_accepted` | `lib/btree/utils.mbt`, `checked_span_add` | The exact non-negative guard against the mathematical constant `2147483647` (`@int.MAX_VALUE`) | Acceptance implies a sum in `[0, MAX]`; every non-negative sum in range is accepted; rejection of non-negative inputs is equivalent to a sum above `MAX`; negative inputs are rejected. |
+| `project_root_present` | Leaf-count policy abstracted from `lib/btree/btree.mbt`, `PropagateResult::root_candidate` and `normalize_root_after_delete` | `leaf_count >= 0`; executable properties establish that production segment/root state corresponds to this count | In the scalar policy, zero leaves project to no root and every present root has a positive leaf count. |
+
+## Why the grouping proof is scalar
+
+`legal_chunk_sizes` returns an `Array[Int]`, which `moon prove` cannot model. The proof instead verifies its exact one-step transition:
+
+1. each chosen chunk has legal occupancy;
+2. `chunk + next_remaining = remaining`;
+3. a non-terminal `next_remaining` is legal and strictly smaller;
+4. `advance_group_sum` preserves `emitted + remaining = original_count`;
+5. `planned_group_total` uses the decreasing remainder as its termination measure and proves that the recursive sum equals `child_count`;
+6. the terminal transition sets `remaining` to zero and `emitted` to `original_count`.
+
+Starting from `(emitted, remaining) = (0, child_count)`, the verified scalar recurrence establishes legal scalar steps and an exact scalar total. It does not prove that the production `Array[Int]` contains those values; executable `legal_chunk_sizes` and `pack_level` properties cover that linkage. No sequence axiom or bounded sample is assumed by the scalar proof.
+
+## Why the repeated-repair proof is scalar
+
+`repair_underfull_children` may process several adjacent underfull nodes. `repaired_node_count` proves pair conservation and the selected postcondition for each reactive step: steal restores both occupancies; merge yields a node in `[0, 2t]`, which is occupied when its combined count reaches `t` and otherwise remains the one conserved candidate for the next iteration. `repair_total_with_unaffected` lifts pair conservation to a whole-segment accumulator, so repeated iterations preserve the complete child total by induction.
+
+Why3 cannot model the production `Array[BTreeNode]`, sibling selection, or the loop's final array shape. Final occupancy after traversing an adjacent-underfull sequence therefore remains explicitly excluded from the scalar proof and retained in BTree deterministic/property tests. This model also excludes proactive `ensure_min_children`, whose trigger includes `child_count == t`; it covers the reactive `child_count < t` policy only.
+
+## Guarantee boundary
+
+Why3 integers are unbounded mathematical integers. These proofs establish the scalar model only. They do **not** establish:
+
+- recursive BTree shape or path correctness;
+- production `Array` materialization or sibling selection;
+- final array occupancy after traversing a sequence of adjacent underfull siblings (covered by executable BTree repair properties);
+- proactive descent repair for a child with exactly `min_degree` children;
+- callback behavior or failure atomicity;
+- the correspondence between root segments and the leaf-count projection;
+- MoonBit machine-`Int` overflow semantics;
+- cross-parent OrderTree canonicalization.
+
+Production deterministic/property tests cover those integration boundaries, including adjacent-underfull repair and grouping arrays. In particular, `lib/btree/btree_wbtest.mbt` retains exact `@int.MAX_VALUE` acceptance and `@int.MAX_VALUE + 1` rejection regressions.
+
+## Run
+
+The repository pins MoonBit `0.10.4+ade96c819`; the proof toolchain uses Why3 1.7.2 and Z3 4.13.x.
+
+```bash
+cd lib/btree/proof
+NEW_MOON_MOD=0 moon check --deny-warn
+NEW_MOON_MOD=0 moon test --release
+NEW_MOON_MOD=0 moon info
+NEW_MOON_MOD=0 moon fmt
+NEW_MOON_MOD=0 moon prove
+```

--- a/lib/btree/proof/moon.mod
+++ b/lib/btree/proof/moon.mod
@@ -1,0 +1,11 @@
+name = "dowdiness/btree-proof"
+
+version = "0.1.0"
+
+repository = "https://github.com/dowdiness/canopy"
+
+license = "Apache-2.0"
+
+keywords = [ "btree", "verification", "proof" ]
+
+description = "Formal verification of BTree scalar arithmetic laws"

--- a/lib/btree/proof/moon.pkg
+++ b/lib/btree/proof/moon.pkg
@@ -1,0 +1,3 @@
+options(
+  "proof-enabled": true,
+)

--- a/lib/btree/proof/pkg.generated.mbti
+++ b/lib/btree/proof/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/btree-proof"
+
+// Values
+pub fn advance_group_sum(Int, Int, Int, Int) -> Int
+
+pub fn planned_group_size(Int, Int) -> Int
+
+pub fn planned_group_total(Int, Int) -> Int
+
+pub fn project_root_present(Int) -> Bool
+
+pub fn repair_total_with_unaffected(Int, Int, Int, Int, Int) -> Int
+
+pub fn repaired_node_count(Int, Int, Int, Int) -> Int
+
+pub fn span_add_accepted(Int, Int) -> Bool
+
+pub fn splice_leaf_delta(Int, Int, Int) -> Int
+
+pub fn splice_new_count(Int, Int, Int, Int) -> Int
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/lib/btree/proof/scalar.mbt
+++ b/lib/btree/proof/scalar.mbt
@@ -1,0 +1,192 @@
+///|
+/// Scalar model for the leaf-count change published by `propagate`.
+pub fn splice_leaf_delta(
+  start : Int,
+  end_ : Int,
+  inserted_count : Int,
+) -> Int where {
+  proof_ensure: result => leaf_delta_law(start, end_, inserted_count, result),
+} {
+  inserted_count - (end_ - start)
+}
+
+///|
+/// Scalar model for the leaf count after replacing `[start, end_)`.
+pub fn splice_new_count(
+  old_count : Int,
+  start : Int,
+  end_ : Int,
+  inserted_count : Int,
+) -> Int where {
+  proof_require: valid_splice(old_count, start, end_, inserted_count),
+  proof_ensure: result => {
+    splice_cardinality_law(old_count, start, end_, inserted_count, result)
+  },
+} {
+  old_count - (end_ - start) + inserted_count
+}
+
+///|
+/// One scalar step of `legal_chunk_sizes`.
+///
+/// `remaining <= 2 * min_degree` is the terminal push. Otherwise this mirrors
+/// the loop's split decision and leaves another legal non-root remainder.
+pub fn planned_group_size(
+  remaining : Int,
+  min_degree : Int,
+) -> Int where {
+  proof_require: valid_group_state(remaining, min_degree),
+  proof_ensure: result => grouping_step_law(remaining, min_degree, result),
+} {
+  let max_degree = 2 * min_degree
+  if remaining <= max_degree {
+    remaining
+  } else if remaining - max_degree < min_degree {
+    remaining / 2
+  } else {
+    max_degree
+  }
+}
+
+///|
+/// Sum every scalar group emitted by repeated planner steps.
+///
+/// Strict remainder decrease proves termination; the postcondition proves that
+/// all emitted group sizes sum exactly to the input child count.
+pub fn planned_group_total(
+  remaining : Int,
+  min_degree : Int,
+) -> Int where {
+  proof_decrease: remaining,
+  proof_require: valid_group_state(remaining, min_degree),
+  proof_ensure: result => grouping_total_law(remaining, result),
+} {
+  if remaining <= 2 * min_degree {
+    remaining
+  } else {
+    let group_size = planned_group_size(remaining, min_degree)
+    let rest = remaining - group_size
+    group_size + planned_group_total(rest, min_degree)
+  }
+}
+
+///|
+/// Advance the emitted-child accumulator by one planned group.
+///
+/// The postcondition is the induction step used to compose local grouping
+/// decisions: emitted children plus remaining children stays equal to the
+/// original input count, and a terminal step emits the exact total.
+pub fn advance_group_sum(
+  original_count : Int,
+  emitted_count : Int,
+  remaining : Int,
+  min_degree : Int,
+) -> Int where {
+  proof_require: valid_group_accumulator(
+    original_count, emitted_count, remaining, min_degree,
+  ),
+  proof_ensure: result => {
+    grouping_accumulator_law(
+      original_count, emitted_count, remaining, min_degree, result,
+    )
+  },
+} {
+  emitted_count + planned_group_size(remaining, min_degree)
+}
+
+///|
+/// Child count of an underfull node after the range-repair merge-or-steal
+/// decision. The sibling's remaining count is modeled in the postcondition.
+pub fn repaired_node_count(
+  underfull_count : Int,
+  sibling_count : Int,
+  min_degree : Int,
+  target_count : Int,
+) -> Int where {
+  proof_require: valid_repair_state(
+    underfull_count, sibling_count, min_degree, target_count,
+  ),
+  proof_ensure: result => {
+    repair_conservation_law(
+      underfull_count, sibling_count, min_degree, target_count, result,
+    )
+  },
+  proof_ensure: result => {
+    repair_occupancy_law(
+      underfull_count, sibling_count, min_degree, target_count, result,
+    )
+  },
+  proof_ensure: result => {
+    repair_donor_law(
+      underfull_count, sibling_count, min_degree, target_count, result,
+    )
+  },
+} {
+  let transfer = target_count - underfull_count
+  if sibling_count - transfer < min_degree {
+    proof_assert 0 <= underfull_count + sibling_count
+    proof_assert underfull_count + sibling_count <= 2 * min_degree
+    underfull_count + sibling_count
+  } else {
+    proof_assert sibling_count - transfer >= min_degree
+    proof_assert min_degree <= target_count
+    proof_assert target_count <= 2 * min_degree
+    target_count
+  }
+}
+
+///|
+/// Preserve the full child total around one reactive repair step.
+///
+/// `unaffected_count` is the count outside the participating sibling pair.
+/// Repeated loop steps may choose a new pair and decomposition, while each step
+/// preserves the same global total independently of merge versus steal.
+pub fn repair_total_with_unaffected(
+  unaffected_count : Int,
+  underfull_count : Int,
+  sibling_count : Int,
+  min_degree : Int,
+  target_count : Int,
+) -> Int where {
+  proof_require: unaffected_count >= 0,
+  proof_require: valid_repair_state(
+    underfull_count, sibling_count, min_degree, target_count,
+  ),
+  proof_ensure: result => {
+    repair_total_with_unaffected_law(
+      unaffected_count, underfull_count, sibling_count, result,
+    )
+  },
+} {
+  let transfer = target_count - underfull_count
+  if sibling_count - transfer < min_degree {
+    unaffected_count + underfull_count + sibling_count
+  } else {
+    unaffected_count + target_count + (sibling_count - transfer)
+  }
+}
+
+///|
+/// Exact acceptance predicate used by `checked_span_add` before addition.
+/// The literal is the mathematical model of `@int.MAX_VALUE` (2^31 - 1).
+pub fn span_add_accepted(
+  total : Int,
+  span : Int,
+) -> Bool where {
+  proof_ensure: result => checked_add_law(total, span, result),
+} {
+  total >= 0 && span >= 0 && total <= 2147483647 - span
+}
+
+///|
+/// Scalar root-publication projection. Recursive root collapse remains covered
+/// by executable BTree properties; this proves only the published leaf-count
+/// contract.
+pub fn project_root_present(
+  leaf_count : Int,
+) -> Bool where {
+  proof_require: leaf_count >= 0,
+  proof_ensure: result => root_lifecycle_law(leaf_count, result),
+} {
+  leaf_count > 0
+}

--- a/lib/btree/proof/scalar.mbtp
+++ b/lib/btree/proof/scalar.mbtp
@@ -1,0 +1,164 @@
+// Pure scalar specifications for BTree splice, grouping, repair, checked-add,
+// and root-publication decisions. Why3 interprets Int as an unbounded
+// mathematical integer; machine-Int integration remains executable-test scope.
+
+predicate leaf_delta_law(
+  start : Int,
+  end_ : Int,
+  inserted_count : Int,
+  result : Int,
+) {
+  result == inserted_count - (end_ - start)
+}
+
+predicate valid_splice(
+  old_count : Int,
+  start : Int,
+  end_ : Int,
+  inserted_count : Int,
+) {
+  0 <= start && start <= end_ && end_ <= old_count && inserted_count >= 0
+}
+
+predicate splice_cardinality_law(
+  old_count : Int,
+  start : Int,
+  end_ : Int,
+  inserted_count : Int,
+  result : Int,
+) {
+  result == old_count - (end_ - start) + inserted_count &&
+  result == old_count + (inserted_count - (end_ - start)) &&
+  result >= 0
+}
+
+predicate valid_group_state(remaining : Int, min_degree : Int) {
+  min_degree >= 2 && remaining >= min_degree
+}
+
+predicate grouping_step_law(
+  remaining : Int,
+  min_degree : Int,
+  group_size : Int,
+) {
+  min_degree <= group_size && group_size <= 2 * min_degree &&
+  group_size + (remaining - group_size) == remaining &&
+  remaining - group_size >= 0 &&
+  (remaining <= 2 * min_degree → remaining - group_size == 0) &&
+  (remaining > 2 * min_degree →
+    (remaining - group_size >= min_degree &&
+     remaining - group_size < remaining))
+}
+
+predicate grouping_total_law(remaining : Int, result : Int) {
+  result == remaining
+}
+
+predicate valid_group_accumulator(
+  original_count : Int,
+  emitted_count : Int,
+  remaining : Int,
+  min_degree : Int,
+) {
+  valid_group_state(remaining, min_degree) &&
+  emitted_count >= 0 &&
+  original_count == emitted_count + remaining
+}
+
+predicate grouping_accumulator_law(
+  original_count : Int,
+  emitted_count : Int,
+  remaining : Int,
+  min_degree : Int,
+  result : Int,
+) {
+  min_degree <= result - emitted_count &&
+  result - emitted_count <= 2 * min_degree &&
+  result + (remaining - (result - emitted_count)) == original_count &&
+  (remaining <= 2 * min_degree → result == original_count) &&
+  (remaining > 2 * min_degree →
+    (remaining - (result - emitted_count) >= min_degree &&
+     remaining - (result - emitted_count) < remaining))
+}
+
+predicate valid_repair_state(
+  underfull_count : Int,
+  sibling_count : Int,
+  min_degree : Int,
+  target_count : Int,
+) {
+  min_degree >= 2 &&
+  0 <= underfull_count && underfull_count < min_degree &&
+  0 <= sibling_count && sibling_count <= 2 * min_degree &&
+  min_degree <= target_count && target_count <= min_degree + 1
+}
+
+predicate repair_conservation_law(
+  underfull_count : Int,
+  sibling_count : Int,
+  min_degree : Int,
+  target_count : Int,
+  result : Int,
+) {
+  (sibling_count - (target_count - underfull_count) < min_degree →
+    result == underfull_count + sibling_count) &&
+  (sibling_count - (target_count - underfull_count) >= min_degree →
+    result + (sibling_count - (target_count - underfull_count)) ==
+      underfull_count + sibling_count)
+}
+
+predicate repair_occupancy_law(
+  underfull_count : Int,
+  sibling_count : Int,
+  min_degree : Int,
+  target_count : Int,
+  result : Int,
+) {
+  0 <= result && result <= 2 * min_degree &&
+  ((sibling_count - (target_count - underfull_count) < min_degree &&
+    underfull_count + sibling_count >= min_degree) →
+    result >= min_degree) &&
+  (sibling_count - (target_count - underfull_count) >= min_degree →
+    result >= min_degree) &&
+  (result < min_degree →
+    (sibling_count - (target_count - underfull_count) < min_degree &&
+     result == underfull_count + sibling_count))
+}
+
+predicate repair_donor_law(
+  underfull_count : Int,
+  sibling_count : Int,
+  min_degree : Int,
+  target_count : Int,
+  result : Int,
+) {
+  (sibling_count - (target_count - underfull_count) < min_degree →
+    result == underfull_count + sibling_count) &&
+  (sibling_count - (target_count - underfull_count) >= min_degree →
+    (result == target_count &&
+     sibling_count - (target_count - underfull_count) >= min_degree))
+}
+
+predicate repair_total_with_unaffected_law(
+  unaffected_count : Int,
+  underfull_count : Int,
+  sibling_count : Int,
+  result : Int,
+) {
+  result == unaffected_count + underfull_count + sibling_count
+}
+
+predicate checked_add_law(total : Int, span : Int, accepted : Bool) {
+  (accepted →
+    (total >= 0 && span >= 0 &&
+     total + span >= 0 && total + span <= 2147483647)) &&
+  ((total >= 0 && span >= 0 && total + span <= 2147483647) → accepted) &&
+  ((total >= 0 && span >= 0 && !accepted) → total + span > 2147483647) &&
+  ((total < 0 || span < 0) → !accepted)
+}
+
+predicate root_lifecycle_law(leaf_count : Int, present : Bool) {
+  (leaf_count == 0 → !present) &&
+  (present → leaf_count > 0) &&
+  (leaf_count > 0 → present)
+}

--- a/lib/btree/proof/scalar_test.mbt
+++ b/lib/btree/proof/scalar_test.mbt
@@ -1,0 +1,35 @@
+///|
+test "splice cardinality model" {
+  inspect(splice_leaf_delta(2, 5, 4), content="1")
+  inspect(splice_new_count(8, 2, 5, 4), content="9")
+}
+
+///|
+test "grouping model covers terminal, balanced split, and max chunk" {
+  inspect(planned_group_size(4, 2), content="4")
+  inspect(planned_group_size(5, 2), content="2")
+  inspect(planned_group_size(8, 2), content="4")
+  inspect(planned_group_total(5, 2), content="5")
+  inspect(planned_group_total(70, 3), content="70")
+  inspect(advance_group_sum(5, 0, 5, 2), content="2")
+  inspect(advance_group_sum(5, 2, 3, 2), content="5")
+}
+
+///|
+test "repair model preserves merge and steal totals" {
+  inspect(repaired_node_count(1, 1, 2, 2), content="2")
+  inspect(repaired_node_count(1, 1, 4, 4), content="2")
+  inspect(repaired_node_count(2, 2, 4, 4), content="4")
+  inspect(repaired_node_count(1, 4, 2, 3), content="3")
+  inspect(repair_total_with_unaffected(7, 1, 1, 4, 4), content="9")
+  inspect(repair_total_with_unaffected(7, 1, 4, 2, 3), content="12")
+}
+
+///|
+test "checked-add and root lifecycle boundaries" {
+  inspect(span_add_accepted(2147483646, 1), content="true")
+  inspect(span_add_accepted(2147483647, 1), content="false")
+  inspect(span_add_accepted(-1, 1), content="false")
+  inspect(project_root_present(0), content="false")
+  inspect(project_root_present(1), content="true")
+}


### PR DESCRIPTION
## Summary

Add a standalone, proof-enabled `lib/btree/proof` module for the pure scalar decisions behind BTree splice cardinality, grouping, reactive occupancy repair, checked aggregate addition, and root publication.

The package proves nine contracts:

- splice leaf delta and new leaf count
- legal group size, strict remainder progress, recursive termination, and exact scalar total
- grouping accumulator preservation
- merge/steal conservation, conditional occupancy restoration, adjacent-underfull intermediate states, and global total preservation with unaffected counts held fixed
- checked-add acceptance/rejection around the mathematical model of `@int.MAX_VALUE`
- zero-leaf/positive-root scalar publication policy

The proof package has no BTree or Canopy dependency. Its README maps every model function to the production formula and preconditions it mirrors.

## Guarantee boundary

The proofs use Why3 unbounded integers and intentionally do not claim:

- production `Array` materialization or sibling selection
- final occupancy after traversing adjacent underfull siblings
- recursive BTree shape, callback behavior, or mutation atomicity
- production root-segment linkage to the leaf-count projection
- MoonBit machine-`Int` overflow semantics
- OrderTree canonicalization

Existing deterministic/property tests retain those integration responsibilities, including exact `@int.MAX_VALUE` acceptance/`+1` rejection and adjacent-underfull repair cases.

Closes #1006.
Part of #1005.

## Validation

### Standalone BTree proof module

From `lib/btree/proof`:

- `NEW_MOON_MOD=0 moon check --deny-warn`: pass
- `NEW_MOON_MOD=0 moon test --release --target all`: 4/4 on wasm, wasm-gc, JS, and native
- `NEW_MOON_MOD=0 moon prove`: **9/9 goals proved**
- `NEW_MOON_MOD=0 moon fmt && moon info`: pass
- generated `pkg.generated.mbti`: reviewed; nine scalar functions only
- Why3 1.7.2 / Z3 4.13.4

### Existing proof and BTree integration

- `lib/semantic/proof`: 1/1 existing goal proved
- `moon test lib/btree --release --target all`: 132/132 on wasm, wasm-gc, JS, and native
- `moon bench lib/btree --release`: 14/14
- no `lib/btree/pkg.generated.mbti` drift

### Canopy workspace

- `./scripts/check-strict.sh`: pass; 9 existing Rabbita deprecation diagnostics suppressed by the vendored filter
- `./scripts/check-test-baseline.sh 7 moon test --release`: 0 failures
- `moon build --release`: pass
- `scripts/check-agent-doc-links.sh`: pass
- `scripts/check-moonbit-pkg-compat.sh`: pass

`moon info` emits the same canonical trailing blank line in the new generated interface as the existing `lib/semantic/proof/pkg.generated.mbti`; all non-generated changed files pass `git diff --check`.

Slopless reported only document-level readability metrics for the technical proof documentation and no concrete prose-rule findings.

## Reuse check

### Project APIs and patterns reused

- `lib/semantic/proof` standalone module, `.mbt`/`.mbtp`, contract, and generated-interface pattern
- production formulas from `checked_span_add`, `legal_chunk_sizes`, `propagate`, `repair_underfull_children`, bulk steal/merge, `root_candidate`, and `normalize_root_after_delete`

### MoonBit core APIs checked

- `Int` arithmetic/comparison and `@int.MAX_VALUE`: the proof model uses primitive Int/Bool arithmetic; `2147483647` is documented as the mathematical mirror because `@int.MAX_VALUE` is unsupported in a proof-pure expression
- `Int::clamp`: checked but not used; min-degree normalization is outside the scalar laws
- `Array`/`ArrayView::fold`: checked but not used because `moon prove` cannot model production arrays
- `Option`, `Result`, `Map`, `Set`, `StringView`, `BytesView`, `Buffer`, `Iter`, and `cmp`/`math`: not applicable to the Int/Bool-only proof shape

### New definitions and imperative code

All new functions belong to the standalone proof model and each has one documented production-formula boundary. No production helper, public BTree API, mutable collection, or imperative I/O path is added.
