### PR TITLE
feat(markdown): adopt responsive minimal editor chrome

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -138,7 +138,6 @@ Composition laws:
 - **Focus behavior:** keyboard focus appears immediately, remains visible, and
   stays at the causal interaction point after an update unless the task
   explicitly moves to a new object.
-- **Touch targets:** interactive targets are at least 44 CSS pixels.
 - **Interaction personality:** calm, precise, immediate. Motion explains a causal
   change or confirms an action; it does not decorate routine work.
 - **Motion gate order:** evaluate frequency, purpose, input modality, motion

--- a/examples/web/src/features/markdown/browser/app.ts
+++ b/examples/web/src/features/markdown/browser/app.ts
@@ -277,7 +277,10 @@ function setMode(mode: Mode): void {
 
   // Update tab styles
   modeTabs.forEach(tab => {
-    tab.classList.toggle('active', tab.dataset.mode === mode);
+    const isActive = tab.dataset.mode === mode;
+    tab.classList.toggle('active', isActive);
+    tab.setAttribute('aria-selected', String(isActive));
+    tab.tabIndex = isActive ? 0 : -1;
   });
 
   updateToolbar();
@@ -287,6 +290,17 @@ modeTabs.forEach(tab => {
   tab.addEventListener('click', () => {
     setMode(tab.dataset.mode as Mode);
   }, { signal: listenerAbort.signal });
+
+  tab.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    const offset = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (modeTabs.indexOf(tab) + offset + modeTabs.length) % modeTabs.length;
+    const nextTab = modeTabs[nextIndex];
+    if (nextTab === undefined) return;
+    setMode(nextTab.dataset.mode as Mode);
+    nextTab.focus();
+  }, { signal: listenerAbort.signal });
 });
 
 // ---------------------------------------------------------------------------
@@ -295,11 +309,19 @@ modeTabs.forEach(tab => {
 
 function updateToolbar(): void {
   const hasSelection = activeNodeId !== null && activeMode === 'block';
+  const info = hasSelection ? getActiveBlockInfo() : null;
   h1Btn.disabled = !hasSelection;
   h2Btn.disabled = !hasSelection;
   h3Btn.disabled = !hasSelection;
   listBtn.disabled = !hasSelection;
   deleteBtn.disabled = !hasSelection;
+  h1Btn.setAttribute('aria-pressed', String(info?.level === 1));
+  h2Btn.setAttribute('aria-pressed', String(info?.level === 2));
+  h3Btn.setAttribute('aria-pressed', String(info?.level === 3));
+  listBtn.setAttribute(
+    'aria-pressed',
+    String(info?.kind === 'ListItem' || info?.kind === 'OrderedListItem'),
+  );
 }
 
 /** Toggle heading level: clicking the same level reverts to paragraph (level 0). */
@@ -396,7 +418,10 @@ blockPane.hidden = false;
 previewPane.hidden = true;
 toolbarEl.hidden = false;
 modeTabs.forEach((tab) => {
-  tab.classList.toggle('active', tab.dataset.mode === 'block');
+  const isActive = tab.dataset.mode === 'block';
+  tab.classList.toggle('active', isActive);
+  tab.setAttribute('aria-selected', String(isActive));
+  tab.tabIndex = isActive ? 0 : -1;
 });
 
 const initialText = typeof restoredSnapshot === 'string'

--- a/examples/web/src/features/markdown/browser/styles.css
+++ b/examples/web/src/features/markdown/browser/styles.css
@@ -5,17 +5,56 @@
     }
 
     .markdown-surface {
-      font-family: Inter, system-ui, -apple-system, sans-serif;
-      background: #1a1a2e;
-      color: #e0e0e8;
-      padding: 24px;
+      color-scheme: light;
+      --canvas: oklch(96.8% 0.008 85);
+      --surface: oklch(99.1% 0.004 85);
+      --surface-raised: oklch(100% 0 0);
+      --ink: oklch(24% 0.018 265);
+      --ink-soft: oklch(46% 0.018 265);
+      --ink-faint: oklch(59% 0.015 265);
+      --rule: oklch(86% 0.012 265);
+      --rule-strong: oklch(78% 0.018 265);
+      --accent: oklch(48% 0.12 276);
+      --accent-soft: oklch(94% 0.025 276);
+      --danger: oklch(48% 0.13 25);
+      --danger-soft: oklch(95% 0.025 25);
+      --space-xs: 4px;
+      --space-sm: 8px;
+      --space-md: 12px;
+      --space-lg: 16px;
+      --space-xl: 24px;
+    }
+
+    .markdown-surface {
       min-height: 100vh;
+      min-height: 100dvh;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--canvas);
+      color: var(--ink);
+      padding: 8px 24px;
       line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
     }
 
     .markdown-surface .container {
+      display: flex;
+      height: calc(100vh - 16px);
+      height: calc(100dvh - 16px);
       max-width: 860px;
       margin: 0 auto;
+      flex-direction: column;
+    }
+
+    .markdown-surface .container:focus {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .markdown-surface .markdown-app {
+      display: flex;
+      min-height: 0;
+      flex: 1;
+      flex-direction: column;
     }
 
     /* --- Header ----------------------------------------------------------- */
@@ -26,17 +65,17 @@
 
     .markdown-surface header h1 {
       font-size: 28px;
-      font-weight: 700;
-      color: #f0f0f8;
-      letter-spacing: -0.02em;
+      font-weight: 640;
+      color: var(--ink);
+      letter-spacing: -0.025em;
     }
 
     .markdown-surface header h1 span {
-      color: #8250df;
+      color: var(--accent);
     }
 
     .markdown-surface .subtitle {
-      color: #8888a0;
+      color: var(--ink-soft);
       font-size: 14px;
       margin-top: 4px;
     }
@@ -45,173 +84,322 @@
 
     .markdown-surface .examples-bar {
       display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-bottom: 16px;
+      gap: var(--space-xs);
+      margin-bottom: var(--space-sm);
       align-items: center;
+      justify-content: flex-end;
     }
 
-    .markdown-surface .examples-label {
-      color: #8888a0;
-      font-size: 13px;
-      margin-right: 4px;
+    .markdown-surface .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
 
     .markdown-surface .example-btn {
-      padding: 6px 14px;
-      background: rgba(130, 80, 223, 0.08);
-      color: #c0b8d8;
-      border: 1px solid rgba(130, 80, 223, 0.2);
-      border-radius: 6px;
+      display: inline-flex;
+      width: auto;
+      min-width: 52px;
+      height: 40px;
+      padding: 0 10px;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      color: var(--ink-faint);
+      border: 1px solid transparent;
+      border-radius: 5px;
       cursor: pointer;
-      font-size: 13px;
       font-family: inherit;
-      transition: background 0.15s, border-color 0.15s;
+      line-height: 1.2;
+      transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+    }
+
+    .markdown-surface .example-btn svg {
+      width: 20px;
+      height: 20px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .markdown-surface .example-btn svg circle {
+      fill: currentColor;
+      stroke: none;
     }
 
     .markdown-surface .example-btn:hover {
-      background: rgba(130, 80, 223, 0.16);
-      border-color: rgba(130, 80, 223, 0.4);
-      color: #e0d8f0;
+      color: var(--ink);
+      background: color-mix(in oklch, var(--surface) 72%, transparent);
+      border-color: var(--rule);
+    }
+
+    .markdown-surface button:focus-visible,
+    .markdown-surface textarea:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
 
     /* --- Mode tabs -------------------------------------------------------- */
 
     .markdown-surface .mode-tabs {
       display: flex;
-      gap: 2px;
+      gap: var(--space-xs);
       margin-bottom: 0;
-      background: rgba(130, 80, 223, 0.06);
-      border-radius: 8px 8px 0 0;
-      padding: 4px 4px 0 4px;
+      background: var(--canvas);
+      border: 1px solid var(--rule);
+      border-bottom: none;
+      border-radius: 7px 7px 0 0;
+      padding: var(--space-xs) var(--space-sm) 0;
+      align-items: center;
     }
 
     .markdown-surface .mode-tab {
-      padding: 8px 20px;
+      display: inline-grid;
+      place-items: center;
+      width: 44px;
+      min-height: 44px;
+      padding: 0;
       background: transparent;
-      color: #8888a0;
+      color: var(--ink-soft);
       border: none;
-      border-radius: 6px 6px 0 0;
+      border-radius: 4px 4px 0 0;
       cursor: pointer;
-      font-size: 13px;
-      font-family: inherit;
-      font-weight: 500;
-      transition: background 0.15s, color 0.15s;
+      transition: background 120ms ease, color 120ms ease;
+    }
+
+    .markdown-surface .mode-tab svg {
+      width: 18px;
+      height: 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.45;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .markdown-surface .mode-tab[data-mode="block"] rect {
+      fill: currentColor;
+      stroke: none;
     }
 
     .markdown-surface .mode-tab:hover {
-      color: #c0b8d8;
-      background: rgba(130, 80, 223, 0.08);
+      color: var(--ink);
+      background: color-mix(in oklch, var(--surface) 72%, transparent);
     }
 
     .markdown-surface .mode-tab.active {
-      background: #22223a;
-      color: #f0f0f8;
+      position: relative;
+      background: var(--surface);
+      color: var(--ink);
+    }
+
+    .markdown-surface .mode-tab.active::after {
+      position: absolute;
+      right: 8px;
+      bottom: 0;
+      left: 8px;
+      height: 2px;
+      background: var(--accent);
+      content: "";
     }
 
     /* --- Editor panel ----------------------------------------------------- */
 
     .markdown-surface .editor-panel {
-      background: #22223a;
-      border: 1px solid rgba(130, 80, 223, 0.15);
-      border-top: none;
-      border-radius: 0 0 8px 8px;
+      display: flex;
+      min-height: 0;
+      background: var(--surface);
+      border: 1px solid var(--rule);
+      border-radius: 0 0 7px 7px;
       overflow: hidden;
+      box-shadow: 0 12px 32px oklch(28% 0.02 265 / 0.055);
+      flex: 1;
+      flex-direction: column;
     }
 
     /* --- Toolbar ---------------------------------------------------------- */
 
     .markdown-surface .toolbar {
       display: flex;
-      flex-wrap: wrap;
-      gap: 4px;
-      padding: 8px 12px;
-      border-bottom: 1px solid rgba(130, 80, 223, 0.1);
+      gap: var(--space-sm);
+      min-height: 60px;
+      padding: var(--space-sm) var(--space-md);
+      border-bottom: 1px solid var(--rule);
       align-items: center;
+      background: color-mix(in oklch, var(--canvas) 44%, var(--surface));
+    }
+
+    .markdown-surface .toolbar[hidden] {
+      display: none;
     }
 
     .markdown-surface .toolbar-group {
       display: flex;
-      gap: 2px;
+      gap: var(--space-xs);
       align-items: center;
     }
 
     .markdown-surface .toolbar-divider {
       width: 1px;
-      height: 20px;
-      background: rgba(130, 80, 223, 0.15);
-      margin: 0 6px;
+      height: 24px;
+      background: var(--rule);
+      margin: 0 var(--space-xs);
+    }
+
+    .markdown-surface .toolbar-spacer {
+      flex: 1;
+      min-width: var(--space-sm);
     }
 
     .markdown-surface .toolbar-btn {
-      padding: 4px 10px;
+      display: inline-flex;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 7px 10px;
       background: transparent;
-      color: #a0a0b8;
+      color: var(--ink-soft);
       border: 1px solid transparent;
-      border-radius: 4px;
+      border-radius: 5px;
       cursor: pointer;
-      font-size: 13px;
+      font-size: 12px;
       font-family: inherit;
-      font-weight: 500;
-      transition: background 0.12s, color 0.12s, border-color 0.12s;
-      line-height: 1.4;
+      font-weight: 600;
+      line-height: 1;
+      align-items: center;
+      justify-content: center;
+      gap: 7px;
+      transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+    }
+
+    .markdown-surface .toolbar-btn > svg {
+      width: 18px;
+      height: 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.45;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .markdown-surface .toolbar-btn-heading {
+      font-family: ui-serif, Georgia, serif;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .markdown-surface #h1-btn { font-size: 15px; }
+    .markdown-surface #h2-btn { font-size: 13px; }
+    .markdown-surface #h3-btn { font-size: 12px; }
+
+    .markdown-surface .list-glyph {
+      display: grid;
+      width: 13px;
+      gap: 3px;
+    }
+
+    .markdown-surface .list-glyph i {
+      display: block;
+      height: 1px;
+      background: currentColor;
+      box-shadow: -4px 0 0 currentColor;
     }
 
     .markdown-surface .toolbar-btn:hover:not(:disabled) {
-      background: rgba(130, 80, 223, 0.1);
-      color: #e0d8f0;
-      border-color: rgba(130, 80, 223, 0.2);
+      background: var(--surface-raised);
+      color: var(--ink);
+      border-color: var(--rule-strong);
+    }
+
+    .markdown-surface .toolbar-btn[aria-pressed="true"] {
+      background: var(--accent-soft);
+      color: var(--accent);
+      border-color: color-mix(in oklch, var(--accent) 30%, var(--rule));
+    }
+
+    .markdown-surface .toolbar-btn-delete:not(:disabled) {
+      color: var(--ink-soft);
+    }
+
+    .markdown-surface .toolbar-btn-delete:hover:not(:disabled) {
+      background: var(--danger-soft);
+      color: var(--danger);
+      border-color: color-mix(in oklch, var(--danger) 28%, var(--rule));
     }
 
     .markdown-surface .toolbar-btn:disabled {
       cursor: not-allowed;
-      opacity: 0.35;
+      opacity: 0.38;
     }
 
     .markdown-surface .toolbar-btn .shortcut {
       font-size: 11px;
-      color: #666680;
+      color: var(--ink-faint);
       margin-left: 4px;
     }
 
     /* --- Editor panes ----------------------------------------------------- */
 
     .markdown-surface .editor-pane {
-      min-height: 400px;
+      display: flex;
+      min-height: 0;
+      overflow: auto;
+      flex: 1;
+      flex-direction: column;
+    }
+
+    .markdown-surface .editor-pane[hidden] {
+      display: none;
     }
 
     /* Raw mode */
     .markdown-surface #raw-editor {
       width: 100%;
-      min-height: 400px;
+      height: auto;
+      min-height: 0;
       padding: 16px;
       background: transparent;
-      color: #e0e0e8;
+      color: var(--ink);
       border: none;
       outline: none;
-      resize: vertical;
-      font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+      resize: none;
+      font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
       font-size: 14px;
       line-height: 1.6;
       tab-size: 2;
       white-space: pre-wrap;
       overflow-wrap: break-word;
+      flex: 1;
     }
 
     .markdown-surface #raw-editor::placeholder {
-      color: #555568;
+      color: var(--ink-faint);
+    }
+
+    .markdown-surface #raw-editor:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
     }
 
     /* Block mode container */
     .markdown-surface #block-container {
       padding: 16px;
-      min-height: 400px;
+      min-height: 0;
+      flex: 1;
     }
 
     /* Preview mode container */
     .markdown-surface #preview-container {
       padding: 24px 20px;
-      min-height: 400px;
+      min-height: 0;
+      flex: 1;
     }
 
     /* --- Preview styles --------------------------------------------------- */
@@ -222,18 +410,18 @@
     .markdown-surface #preview-container h4,
     .markdown-surface #preview-container h5,
     .markdown-surface #preview-container h6 {
-      color: #f0f0f8;
+      color: var(--ink);
       margin-bottom: 0.5em;
       line-height: 1.3;
     }
 
     .markdown-surface #preview-container h1 { font-size: 2em; font-weight: 700; }
-    .markdown-surface #preview-container h2 { font-size: 1.5em; font-weight: 600; border-bottom: 1px solid rgba(130,80,223,0.15); padding-bottom: 0.3em; }
+    .markdown-surface #preview-container h2 { font-size: 1.5em; font-weight: 600; border-bottom: 1px solid var(--rule); padding-bottom: 0.3em; }
     .markdown-surface #preview-container h3 { font-size: 1.25em; font-weight: 600; }
 
     .markdown-surface #preview-container p {
       margin-bottom: 1em;
-      color: #c8c8d8;
+      color: var(--ink-soft);
     }
 
     .markdown-surface #preview-container ul {
@@ -242,17 +430,17 @@
     }
 
     .markdown-surface #preview-container li {
-      color: #c8c8d8;
+      color: var(--ink-soft);
       margin-bottom: 0.25em;
     }
 
     .markdown-surface #preview-container li::marker {
-      color: #8250df;
+      color: var(--accent);
     }
 
     .markdown-surface #preview-container pre {
-      background: rgba(130, 80, 223, 0.06);
-      border: 1px solid rgba(130, 80, 223, 0.12);
+      background: var(--canvas);
+      border: 1px solid var(--rule);
       border-radius: 6px;
       padding: 12px 16px;
       margin-bottom: 1em;
@@ -260,16 +448,16 @@
     }
 
     .markdown-surface #preview-container code {
-      font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+      font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
       font-size: 0.9em;
-      color: #c3e88d;
+      color: oklch(39% 0.1 145);
     }
 
     /* --- Responsive ------------------------------------------------------- */
 
     @media (max-width: 640px) {
       .markdown-surface {
-        padding: 12px;
+        padding: 8px 12px;
       }
 
       .markdown-surface header h1 {
@@ -277,18 +465,51 @@
       }
 
       .markdown-surface .mode-tab {
-        padding: 6px 14px;
-        font-size: 12px;
+        min-height: 44px;
+        padding: 0;
+      }
+
+      .markdown-surface .toolbar {
+        overflow-x: auto;
+        overscroll-behavior-inline: contain;
+        scrollbar-width: thin;
       }
 
       .markdown-surface .toolbar-btn .shortcut {
         display: none;
       }
 
+      .markdown-surface .toolbar-group {
+        flex: none;
+      }
+
+      .markdown-surface .toolbar-spacer {
+        min-width: 0;
+      }
+
       .markdown-surface #raw-editor,
       .markdown-surface #block-container,
       .markdown-surface #preview-container {
-        min-height: 300px;
         padding: 12px;
+      }
+    }
+
+    @media (max-width: 380px) {
+      .markdown-surface .mode-tabs {
+        justify-content: space-between;
+      }
+
+      .markdown-surface .mode-tab {
+        flex: 1;
+        padding-inline: 8px;
+      }
+
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .markdown-surface .example-btn,
+      .markdown-surface .mode-tab,
+      .markdown-surface .toolbar-btn {
+        transition: none;
       }
     }

--- a/examples/web/src/features/markdown/route/markdown-route.tsx
+++ b/examples/web/src/features/markdown/route/markdown-route.tsx
@@ -4,53 +4,61 @@ export function MarkdownRoute() {
   return (
     <MarkdownClient>
       <div>
-        <div className="container">
-          <header>
-            <h1 data-route-heading tabIndex={-1}><span>&#9649;</span> Markdown Editor</h1>
-            <p className="subtitle">Block-based Markdown editing with three view modes</p>
+        <div className="container" role="region" aria-labelledby="markdown-route-title" data-route-heading tabIndex={-1}>
+          <header className="visually-hidden">
+            <h1 id="markdown-route-title"><span>&#9649;</span> Markdown Editor</h1>
           </header>
 
           <div className="markdown-app" inert data-markdown-ready="false">
-            <div className="examples-bar">
-              <span className="examples-label">Examples:</span>
-              <button className="example-btn" data-example="# Hello World&#10;&#10;Welcome to the Canopy Markdown editor.&#10;&#10;This editor has three modes: raw, block, and preview.">Hello</button>
-              <button className="example-btn" data-example="# Getting Started&#10;&#10;Canopy is an incremental projectional editor.&#10;&#10;## Features&#10;&#10;The editor supports real-time collaboration via CRDT.&#10;&#10;Every keystroke is incrementally parsed and projected into a structured view.">Blog</button>
-              <button className="example-btn" data-example="# Shopping List&#10;&#10;Things to pick up:&#10;&#10;- Apples&#10;- Bread&#10;- Coffee&#10;- Dark chocolate">List</button>
-              <button className="example-btn" data-example="# README&#10;&#10;A minimal example project.&#10;&#10;## Install&#10;&#10;```bash&#10;npm install&#10;```&#10;&#10;## Usage&#10;&#10;- Run the dev server&#10;- Open the browser&#10;- Start editing">Code</button>
+            <div className="examples-bar" role="toolbar" aria-label="Markdown examples">
+              <button className="example-btn" type="button" title="Apply Hello example" aria-label="Apply Hello example" data-example="# Hello World&#10;&#10;Welcome to the Canopy Markdown editor.&#10;&#10;This editor has three modes: raw, block, and preview.">Hello</button>
+              <button className="example-btn" type="button" title="Apply Blog example" aria-label="Apply Blog example" data-example="# Getting Started&#10;&#10;Canopy is an incremental projectional editor.&#10;&#10;## Features&#10;&#10;The editor supports real-time collaboration via CRDT.&#10;&#10;Every keystroke is incrementally parsed and projected into a structured view.">Guide</button>
+              <button className="example-btn" type="button" title="Apply List example" aria-label="Apply List example" data-example="# Shopping List&#10;&#10;Things to pick up:&#10;&#10;- Apples&#10;- Bread&#10;- Coffee&#10;- Dark chocolate">List</button>
+              <button className="example-btn" type="button" title="Apply Code example" aria-label="Apply Code example" data-example="# README&#10;&#10;A minimal example project.&#10;&#10;## Install&#10;&#10;```bash&#10;npm install&#10;```&#10;&#10;## Usage&#10;&#10;- Run the dev server&#10;- Open the browser&#10;- Start editing">Code</button>
             </div>
 
-            <div className="mode-tabs">
-              <button className="mode-tab active" data-mode="block" data-route-focus="mode-block">Block</button>
-              <button className="mode-tab" data-mode="raw" data-route-focus="mode-raw">Raw</button>
-              <button className="mode-tab" data-mode="preview" data-route-focus="mode-preview">Preview</button>
+            <div className="mode-tabs" role="tablist" aria-label="Editor view">
+              <button id="block-tab" className="mode-tab active" type="button" role="tab" title="Block view" aria-label="Block view" aria-selected="true" aria-controls="block-pane" data-mode="block" data-route-focus="mode-block">
+                <svg viewBox="0 0 20 20" aria-hidden="true"><rect x="3" y="3" width="5" height="5" rx="1"/><rect x="12" y="3" width="5" height="5" rx="1"/><rect x="3" y="12" width="5" height="5" rx="1"/><rect x="12" y="12" width="5" height="5" rx="1"/></svg>
+              </button>
+              <button id="raw-tab" className="mode-tab" type="button" role="tab" title="Raw Markdown" aria-label="Raw Markdown" aria-selected="false" aria-controls="raw-pane" tabIndex={-1} data-mode="raw" data-route-focus="mode-raw">
+                <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M7.5 5 3 10l4.5 5M12.5 5l4.5 5-4.5 5"/><path d="m11 3-2 14"/></svg>
+              </button>
+              <button id="preview-tab" className="mode-tab" type="button" role="tab" title="Preview" aria-label="Preview" aria-selected="false" aria-controls="preview-pane" tabIndex={-1} data-mode="preview" data-route-focus="mode-preview">
+                <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M2.5 10s2.8-5 7.5-5 7.5 5 7.5 5-2.8 5-7.5 5-7.5-5-7.5-5Z"/><circle cx="10" cy="10" r="2"/></svg>
+              </button>
             </div>
 
             <div className="editor-panel">
-              <div className="toolbar" id="toolbar" data-no-blur>
-                <div className="toolbar-group">
-                  <button id="h1-btn" className="toolbar-btn" type="button" title="Heading 1 (Ctrl+1)" disabled>H1</button>
-                  <button id="h2-btn" className="toolbar-btn" type="button" title="Heading 2 (Ctrl+2)" disabled>H2</button>
-                  <button id="h3-btn" className="toolbar-btn" type="button" title="Heading 3 (Ctrl+3)" disabled>H3</button>
+              <div className="toolbar" id="toolbar" role="toolbar" aria-label="Block formatting" aria-controls="block-container" data-no-blur>
+                <div className="toolbar-group" role="group" aria-label="Text style">
+                  <button id="h1-btn" className="toolbar-btn toolbar-btn-heading" type="button" title="Heading 1 (Ctrl+1)" aria-label="Heading 1, Ctrl+1" aria-pressed="false" disabled>H1</button>
+                  <button id="h2-btn" className="toolbar-btn toolbar-btn-heading" type="button" title="Heading 2 (Ctrl+2)" aria-label="Heading 2, Ctrl+2" aria-pressed="false" disabled>H2</button>
+                  <button id="h3-btn" className="toolbar-btn toolbar-btn-heading" type="button" title="Heading 3 (Ctrl+3)" aria-label="Heading 3, Ctrl+3" aria-pressed="false" disabled>H3</button>
                 </div>
-                <div className="toolbar-divider"></div>
-                <div className="toolbar-group">
-                  <button id="list-btn" className="toolbar-btn" type="button" title="Toggle list (Ctrl+Shift+L)" disabled>List</button>
+                <div className="toolbar-divider" aria-hidden="true"></div>
+                <div className="toolbar-group" role="group" aria-label="Block structure">
+                  <button id="list-btn" className="toolbar-btn" type="button" title="Toggle list (Ctrl+Shift+L)" aria-label="Toggle list, Ctrl+Shift+L" aria-pressed="false" disabled>
+                    <span className="list-glyph" aria-hidden="true"><i></i><i></i><i></i></span>
+                  </button>
                 </div>
-                <div className="toolbar-divider"></div>
-                <div className="toolbar-group">
-                  <button id="delete-btn" className="toolbar-btn" type="button" title="Delete block" disabled>Delete</button>
+                <div className="toolbar-spacer" aria-hidden="true"></div>
+                <div className="toolbar-group toolbar-group-danger" role="group" aria-label="Block actions">
+                  <button id="delete-btn" className="toolbar-btn toolbar-btn-delete" type="button" title="Delete block" aria-label="Delete selected block" disabled>
+                    <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 6h12M8 3h4l1 3H7l1-3ZM6 6l.7 11h6.6L14 6M8.5 9v5M11.5 9v5"/></svg>
+                  </button>
                 </div>
               </div>
 
-              <div className="editor-pane" id="raw-pane" hidden>
+              <div className="editor-pane" id="raw-pane" role="tabpanel" aria-labelledby="raw-tab" hidden>
                 <textarea id="raw-editor" data-route-focus="raw-editor" placeholder="Type Markdown here..." spellCheck={false}></textarea>
               </div>
 
-              <div className="editor-pane" id="block-pane">
+              <div className="editor-pane" id="block-pane" role="tabpanel" aria-labelledby="block-tab">
                 <div id="block-container"></div>
               </div>
 
-              <div className="editor-pane" id="preview-pane" hidden>
+              <div className="editor-pane" id="preview-pane" role="tabpanel" aria-labelledby="preview-tab" hidden>
                 <div id="preview-container"></div>
               </div>
             </div>

--- a/examples/web/tests/markdown-editor.spec.ts
+++ b/examples/web/tests/markdown-editor.spec.ts
@@ -17,7 +17,12 @@ async function blockTexts(page: Page): Promise<string[]> {
 
 /** Switch to a mode tab and wait for the pane to appear. */
 async function switchMode(page: Page, mode: 'Block' | 'Raw' | 'Preview') {
-  await page.locator(`button.mode-tab:has-text("${mode}")`).click();
+  const accessibleName = {
+    Block: 'Block view',
+    Raw: 'Raw Markdown',
+    Preview: 'Preview',
+  }[mode];
+  await page.getByRole('tab', { name: accessibleName, exact: true }).click();
   const paneId =
     mode === 'Block' ? '#block-pane' :
     mode === 'Raw' ? '#raw-pane' :
@@ -27,7 +32,7 @@ async function switchMode(page: Page, mode: 'Block' | 'Raw' | 'Preview') {
 
 /** Load an example preset and wait for blocks to render. */
 async function loadExample(page: Page, name: 'Hello' | 'Blog' | 'List' | 'Code') {
-  await page.locator(`button.example-btn:has-text("${name}")`).click();
+  await page.getByRole('button', { name: `Apply ${name} example`, exact: true }).click();
   await expect(page.locator('#block-container .block-text').first()).toBeVisible();
 }
 
@@ -37,16 +42,33 @@ async function loadExample(page: Page, name: 'Hello' | 'Blog' | 'List' | 'Code')
 
 test.beforeEach(async ({ page }) => {
   await page.goto(markdownEditorUrl);
-  await expect(page.locator('#block-container .block-text').first()).toBeVisible();
   if (markdownEditorUrl === '/markdown') {
     await expect(page.locator('[data-markdown-ready]'))
       .toHaveAttribute('data-markdown-ready', 'true');
     await expect(page.locator('[data-route-lifecycle-ready]'))
       .toHaveAttribute('data-route-lifecycle-ready', 'true');
   }
+  await expect(page.locator('#block-container .block-text').first()).toBeVisible();
 });
 
 test.describe('Markdown Block Editor', () => {
+
+  test('mode tabs support arrow-key navigation', async ({ page }) => {
+    const blockTab = page.getByRole('tab', { name: 'Block view' });
+    const rawTab = page.getByRole('tab', { name: 'Raw Markdown' });
+    const previewTab = page.getByRole('tab', { name: 'Preview' });
+
+    await blockTab.focus();
+    await blockTab.press('ArrowRight');
+    await expect(rawTab).toBeFocused();
+    await expect(rawTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('#raw-pane')).toBeVisible();
+
+    await rawTab.press('ArrowRight');
+    await expect(previewTab).toBeFocused();
+    await expect(previewTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('#preview-pane')).toBeVisible();
+  });
 
   test('blocks render from Markdown source', async ({ page }) => {
     // Default text loads blocks with content
@@ -129,7 +151,7 @@ test.describe('Markdown Block Editor', () => {
     await textarea.evaluate((element: HTMLTextAreaElement) => element.setSelectionRange(1, 3));
 
     await switchMode(page, 'Preview');
-    await page.locator('button.example-btn:has-text("List")').click();
+    await page.getByRole('button', { name: 'Apply List example', exact: true }).click();
     await switchMode(page, 'Block');
 
     await expect(textarea).toHaveCount(0);

--- a/examples/web/waku-tests/markdown-route.spec.ts
+++ b/examples/web/waku-tests/markdown-route.spec.ts
@@ -12,7 +12,12 @@ async function switchMode(
   page: Page,
   mode: 'Block' | 'Raw' | 'Preview',
 ): Promise<void> {
-  await page.getByRole('button', { name: mode, exact: true }).click();
+  const accessibleName = {
+    Block: 'Block view',
+    Raw: 'Raw Markdown',
+    Preview: 'Preview',
+  }[mode];
+  await page.getByRole('tab', { name: accessibleName, exact: true }).click();
   const pane = mode === 'Block'
     ? '#block-pane'
     : mode === 'Raw'
@@ -29,7 +34,7 @@ test('keeps the server-rendered Markdown controls inert without client JavaScrip
     const page = await context.newPage();
     const response = await page.goto('/markdown');
     expect(response?.ok()).toBe(true);
-    await expect(page.getByRole('heading', { name: '▱ Markdown Editor' })).toBeVisible();
+    await expect(page.locator('[data-route-heading]')).toBeAttached();
     await expect(page.locator('[data-markdown-ready]')).toHaveAttribute('inert', '');
     await expect(page.locator('[data-markdown-ready]'))
       .toHaveAttribute('data-markdown-ready', 'false');
@@ -64,7 +69,8 @@ test('restores document text and stable control focus while rebuilding mode stat
   await page.getByRole('link', { name: /Markdown Editor/ }).click();
   await waitForMarkdownMount(page);
   await expect(page).toHaveURL(/\/markdown$/);
-  await expect(page.getByRole('heading', { name: '▱ Markdown Editor' })).toBeFocused();
+  await expect(page.locator('[data-route-heading]')).toBeFocused();
+  await expect(page.locator('[data-route-heading]')).toHaveCSS('outline-style', 'solid');
 
   const source = '# Route memory\n\nOnly document text returns.\n';
   await switchMode(page, 'Raw');
@@ -80,14 +86,15 @@ test('restores document text and stable control focus while rebuilding mode stat
 
   await expect(page.locator('#block-pane')).toBeVisible();
   await expect(page.locator('#raw-pane')).toBeHidden();
-  await expect(page.locator('.mode-tab.active')).toHaveText('Block');
+  await expect(page.getByRole('tab', { name: 'Block view' }))
+    .toHaveAttribute('aria-selected', 'true');
   await expect(page.locator('.block-textarea')).toHaveCount(0);
   await expect(previewTab).toBeFocused();
   await switchMode(page, 'Raw');
   await expect(page.locator('#raw-editor')).toHaveValue(source);
 });
 
-test('falls back to the heading when the prior pane is rebuilt', async ({ page }) => {
+test('falls back to the route container when the prior pane is rebuilt', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('[data-route-lifecycle-ready]'))
     .toHaveAttribute('data-route-lifecycle-ready', 'true');
@@ -115,7 +122,8 @@ test('falls back to the heading when the prior pane is rebuilt', async ({ page }
   await page.goForward();
   await waitForMarkdownMount(page);
 
-  await expect(page.getByRole('heading', { name: '▱ Markdown Editor' })).toBeFocused();
+  await expect(page.locator('[data-route-heading]')).toBeFocused();
+  await expect(page.locator('[data-route-heading]')).toHaveCSS('outline-style', 'solid');
   await expect(page.locator('#block-pane')).toBeVisible();
   await switchMode(page, 'Raw');
   await expect(rawEditor).toHaveValue(source);
@@ -132,7 +140,8 @@ test('reload clears route memory and reconstructs Markdown internals', async ({ 
   await waitForMarkdownMount(page);
 
   await expect(page.locator('#block-pane')).toBeVisible();
-  await expect(page.locator('.mode-tab.active')).toHaveText('Block');
+  await expect(page.getByRole('tab', { name: 'Block view' }))
+    .toHaveAttribute('aria-selected', 'true');
   await expect(page.locator('.block-textarea')).toHaveCount(0);
   await switchMode(page, 'Raw');
   await expect(page.locator('#raw-editor')).toHaveValue(new RegExp(DEFAULT_HEADING));


### PR DESCRIPTION
## Summary

- Replaces the Markdown route chrome with the selected quiet, title-free visual direction while preserving an accessible route heading.
- Adds compact Examples controls, icon tabs, semantic toolbar/tab roles, synchronized ARIA state, and arrow-key tab navigation.
- Fits the editor to the dynamic viewport with 8px vertical breathing room and scrollable, flexible Block, Raw, and Preview panes.
- Removes the project-wide 44px minimum-target rule and keeps the selected 40px Examples controls.
- Moves route focus from the visually hidden heading to the visible editor region and renders a clear focus outline.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `setMode` | `examples/web/src/features/markdown/browser/app.ts` | Yes | Keeps pane visibility, tab styling, ARIA selection, and focus in one existing transition boundary. |
| `getActiveBlockInfo` | `examples/web/src/features/markdown/browser/app.ts` | Yes | Derives heading/list pressed state from the existing rendered block metadata. |
| `AbortController.signal` | existing Markdown browser lifecycle | Yes | Owns the new keyboard listener with the existing teardown path. |
| Route focus manager | `examples/web/src/shared/route-lifecycle/browser/focus-manager.ts` | Yes | Reuses the existing `data-route-heading` focus contract with a visible region target. |
| MoonBit core APIs | N/A | N/A | No MoonBit code, helpers, types, or APIs changed. |

New helpers added: none.

## Test plan

- [x] `NEW_MOON_MOD=0 moon check` passes
- [x] `NEW_MOON_MOD=0 moon test` passes
- [x] `git diff *.mbti` reviewed; no `.mbti` changes
- [x] JS release rebuild and Waku production build pass

## Validation

```bash
moon build --target js --release
moon check
moon test
cd examples/web
npm run typecheck
npm run check:boundaries
npm run build
CHOKIDAR_USEPOLLING=true CANOPY_WAKU_TEST_PORT=5284 npx playwright test waku-tests/markdown-route.spec.ts tests/markdown-editor.spec.ts --config=playwright.waku.config.ts
CHOKIDAR_USEPOLLING=true CANOPY_WAKU_TEST_PORT=5285 npx playwright test waku-tests/markdown-route.spec.ts --config=playwright.waku.config.ts
```

Results:

- MoonBit: 4,214 wasm-gc + 1,978 JS + 70 native tests passed.
- Markdown Playwright: 23/23 passed.
- Updated route-focus suite: 6/6 passed, including visible-outline assertions.
- The ready-state test setup was ordered before rendered-block assertions and the two initialization-sensitive cases also passed 3 repeated parallel runs each.
- Browser checks confirmed 40px Example buttons, 8px top/bottom viewport gaps, dynamic pane height, and no console errors at desktop and 390px mobile widths.