### PR TITLE
chore: enforce PR-ready validation order

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,12 +52,15 @@ Validated HEAD: `<40-character SHA>`
 Validated base: `origin/main@<40-character SHA>`
 
 ```bash
+git fetch origin main
 ./scripts/validate-pr-ready.sh --target <package-path>
+git fetch origin main
 ./scripts/validate-pr-ready.sh --verify-evidence
 ```
 
 - [ ] The full validator passed for the exact HEAD and base above.
-- [ ] `--verify-evidence` passed immediately before this PR was opened or updated.
+- [ ] The base was fetched again and `--verify-evidence` passed immediately
+      before this PR was opened, updated, or merged.
 - [ ] The committed `.mbti` diff against the validated base was reviewed for
       unintended API or trait-bound changes.
 - [ ] Any changed submodule commit is pushed and reachable from its remote.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,7 +53,12 @@ Validated base: `origin/main@<40-character SHA>`
 
 ```bash
 git fetch origin main
-./scripts/validate-pr-ready.sh --target <package-path>
+# Repeat --target for every affected MoonBit package:
+./scripts/validate-pr-ready.sh \
+  --target <package-path> \
+  --target <another-package-path>
+# Use instead when no MoonBit package is affected:
+# ./scripts/validate-pr-ready.sh --no-target "<reason>"
 git fetch origin main
 ./scripts/validate-pr-ready.sh --verify-evidence
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,17 +29,38 @@ New helpers added (if any):
 
 <!-- list any new helper names here and explain why each doesn't duplicate an existing API -->
 
-## Test plan
+## Validation scope
 
 <!-- Prefer behavior, state, and explicit readiness signals. Avoid fixed waits and brittle pixel assertions unless the exact value is an intended contract. -->
 
-- [ ] `NEW_MOON_MOD=0 moon check` passes
-- [ ] `NEW_MOON_MOD=0 moon test` passes
-- [ ] `git diff *.mbti` reviewed for unintended API surface changes
-- [ ] JS rebuild run if web is affected (`cd examples/web && npm run build`)
+Boundary matrix / first failing regression:
 
-## Validation
+<!-- List the behavior boundaries covered, or explain why no matrix applies. -->
+
+Target packages:
+
+<!-- List each --target path, or the exact --no-target reason. -->
+
+Additional conditional gates:
+
+<!-- Proof, browser E2E, or other checks not covered by the standard gate. -->
+
+## PR-ready evidence
+
+Validated HEAD: `<40-character SHA>`
+
+Validated base: `origin/main@<40-character SHA>`
 
 ```bash
-NEW_MOON_MOD=0 moon check && NEW_MOON_MOD=0 moon test
+./scripts/validate-pr-ready.sh --target <package-path>
+./scripts/validate-pr-ready.sh --verify-evidence
 ```
+
+- [ ] The full validator passed for the exact HEAD and base above.
+- [ ] `--verify-evidence` passed immediately before this PR was opened or updated.
+- [ ] The committed `.mbti` diff against the validated base was reviewed for
+      unintended API or trait-bound changes.
+- [ ] Any changed submodule commit is pushed and reachable from its remote.
+- [ ] Validation was rerun after every commit, amend, rebase, cherry-pick,
+      submodule-pointer, manifest, or generated-interface change.
+- [ ] Independent review findings were resolved before the final validation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Test moon update retry wrapper
         run: ./scripts/test-moon-update-wrapper.sh
 
+      - name: Test PR-ready validation contract
+        run: ./scripts/test-pr-ready-validation.sh
+
   changes:
     name: Change Detection
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       run_prove: ${{ steps.filter.outputs.run_prove }}
       run_e2e: ${{ steps.filter.outputs.run_e2e }}
       run_cm6_adapter_e2e: ${{ steps.filter.outputs.run_cm6_adapter_e2e }}
+      run_pr_ready_bash3: ${{ steps.filter.outputs.run_pr_ready_bash3 }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -82,6 +83,45 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'scripts/build-js.sh'
               - 'scripts/test-*.sh'
+            run_pr_ready_bash3:
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+
+  pr-ready-bash3:
+    name: PR-ready Bash 3.2 Contract
+    needs: changes
+    if: needs.changes.outputs.run_pr_ready_bash3 == 'true'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Test the system Bash 3.2 contract
+        shell: /bin/bash --noprofile --norc -eo pipefail {0}
+        run: |
+          if [ "${BASH_VERSINFO[0]}" -ne 3 ] || \
+             [ "${BASH_VERSINFO[1]}" -ne 2 ]; then
+            echo "error: expected /bin/bash 3.2, got ${BASH_VERSION}" >&2
+            exit 1
+          fi
+
+          bash32_bin="${RUNNER_TEMP}/canopy-bash32-bin"
+          mkdir -p "$bash32_bin"
+          ln -s /bin/bash "$bash32_bin/bash"
+
+          PATH="$bash32_bin:$PATH" \
+            /bin/bash ./scripts/check-moon-update-wrapped.sh
+          PATH="$bash32_bin:$PATH" \
+            /bin/bash ./scripts/test-pr-ready-validation.sh
+          PATH="$bash32_bin:$PATH" \
+            /bin/bash ./scripts/test-pr-ready-bash32.sh
 
   test-main:
     name: Test Main Module
@@ -714,6 +754,7 @@ jobs:
     needs:
       - dep-check
       - changes
+      - pr-ready-bash3
       - test-main
       - test-submodules
       - test-examples
@@ -735,6 +776,7 @@ jobs:
           ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
           if ! ok "${{ needs.dep-check.result }}" || \
              ! ok "${{ needs.changes.result }}" || \
+             ! ok "${{ needs.pr-ready-bash3.result }}" || \
              ! ok "${{ needs.test-main.result }}" || \
              ! ok "${{ needs.test-submodules.result }}" || \
              ! ok "${{ needs.test-examples.result }}" || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_pr_ready_bash3 == 'true'
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           submodules: recursive
           fetch-depth: 0
 
@@ -775,9 +778,15 @@ jobs:
       - name: Check all job statuses
         run: |
           ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
+          path_filtered_ok() {
+            [[ "$1" == "success" ]] ||
+              [[ "$1" == "skipped" && "$2" == "false" ]]
+          }
           if ! ok "${{ needs.dep-check.result }}" || \
              ! ok "${{ needs.changes.result }}" || \
-             ! ok "${{ needs.pr-ready-bash3.result }}" || \
+             ! path_filtered_ok \
+               "${{ needs.pr-ready-bash3.result }}" \
+               "${{ needs.changes.outputs.run_pr_ready_bash3 }}" || \
              ! ok "${{ needs.test-main.result }}" || \
              ! ok "${{ needs.test-submodules.result }}" || \
              ! ok "${{ needs.test-examples.result }}" || \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,38 @@ Hooks enforce `moon check` after every edit and `moon fmt && moon info` before c
 
 <!-- textlint-enable slopless/word-repetition -->
 
+### Required Implementation Order
+
+For implementation PRs, use this order so validation evidence belongs to the
+exact commit that is reviewed:
+
+1. `git fetch origin main`, then create or update a dedicated worktree so its
+   HEAD contains the current `origin/main`.
+2. Initialize submodules recursively and verify their recorded commits,
+   configured-origin reachability, and dependency/version identity before
+   changing behavior. Push changed submodule commits before the parent PR.
+3. Write the behavioral boundary matrix, then add the first failing test. For
+   Markdown stabilization, cover syntax form (ATX, Setext, multiline,
+   indented), terminator (LF, CRLF, CR, EOF), operation (span projection,
+   commit, conversion), and ownership context (top level, container,
+   explicitly unsupported).
+4. Keep the edit loop scoped to affected packages: failing test, implementation,
+   targeted check, targeted release test.
+5. Run independent review in parallel after the targeted loop is green; resolve
+   findings before final validation.
+6. Commit the candidate result, then run the final gate on that clean HEAD:
+   `./scripts/validate-pr-ready.sh --target <package-path>`. Repeat `--target`
+   for each affected MoonBit package. For changes with no MoonBit package,
+   provide `--no-target "<reason>"` instead.
+7. Immediately before opening or updating the PR, run
+   `./scripts/validate-pr-ready.sh --verify-evidence` and copy its HEAD/base
+   evidence into the PR description.
+
+Do not open a PR until the final gate succeeds on the current HEAD. A commit,
+amend, rebase, cherry-pick, submodule-pointer change, manifest change, or
+generated-interface change invalidates earlier evidence; rerun the full gate.
+The validator is a local preflight and does not replace required GitHub CI.
+
 ### Existing API First Rule
 
 Before defining any new function, method, helper, or type in this repository:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,18 +151,22 @@ exact commit that is reviewed:
    targeted check, targeted release test.
 5. Run independent review in parallel after the targeted loop is green; resolve
    findings before final validation.
-6. Commit the candidate result, then run the final gate on that clean HEAD:
+6. Fetch `origin/main` again. If HEAD no longer contains it, sync the branch and
+   repeat the affected targeted checks and review. Commit the candidate result,
+   then run the final gate on that clean HEAD:
    `./scripts/validate-pr-ready.sh --target <package-path>`. Repeat `--target`
    for each affected MoonBit package. For changes with no MoonBit package,
    provide `--no-target "<reason>"` instead.
-7. Immediately before opening or updating the PR, run
-   `./scripts/validate-pr-ready.sh --verify-evidence` and copy its HEAD/base
-   evidence into the PR description.
+7. Immediately before opening, updating, or merging the PR, fetch `origin/main`
+   once more and run `./scripts/validate-pr-ready.sh --verify-evidence`. If the
+   base moved, repeat step 6; otherwise copy the HEAD/base evidence into the PR
+   description.
 
 Do not open a PR until the final gate succeeds on the current HEAD. A commit,
 amend, rebase, cherry-pick, submodule-pointer change, manifest change, or
-generated-interface change invalidates earlier evidence; rerun the full gate.
-The validator is a local preflight and does not replace required GitHub CI.
+generated-interface change, or fetched base-ref movement invalidates earlier
+evidence; rerun the full gate. The validator is a local preflight and does not
+replace required GitHub CI.
 
 ### Existing API First Rule
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -23,6 +23,7 @@ The main gating workflow. Job names match the file:
 | Job | What it runs |
 |-----|--------------|
 | `dep-check` | `./scripts/check-deps.sh` (module-scope rules [A]–[E] + canopy package-layering rules [F]–[I]; the rules table lives in the script header), `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh`, `./scripts/test-pr-ready-validation.sh` |
+| `pr-ready-bash3` | Path-filtered macOS check that asserts `/bin/bash` 3.2, exercises local submodule failures, and runs the real PR-ready shell graph with only compiler work faked |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check .`, `./scripts/run-moon-module.sh test .`, `moon build --release` |
 | `test-submodules` | Matrix over `event-graph-walker`, `loom/loom`, `svg-dsl`, `graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `examples/ideal`, `examples/block-editor`, `examples/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |
@@ -148,9 +149,16 @@ and records the validated HEAD, base, and target policy in an ignored,
 worktree-local `_build` file.
 
 Any commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated
-interface change makes that evidence stale. Rerun the full validator before
-opening or updating the PR. This local gate deliberately does not replace the
-required CI matrix.
+interface change, or movement of the fetched base ref makes that evidence stale.
+Fetch the base again immediately before `--verify-evidence`; if it moved, sync
+the branch and rerun the full validator before opening, updating, or merging the
+PR. This local gate deliberately does not replace the required CI matrix.
+
+When `scripts/**` or `ci.yml` changes, the path-filtered `pr-ready-bash3` job
+asserts that the macOS system `/bin/bash` is 3.2, runs the CLI fixture contract,
+and executes the real downstream shell graph with a fake `moon` compiler. It
+verifies orchestration portability only; it does not claim macOS parity for
+MoonBit, JavaScript, proof, or browser gates.
 
 ## Pre-commit hook
 
@@ -162,10 +170,10 @@ on push.
 
 ## Adding new gating checks
 
-Add the job to `ci.yml`, then add its name to the `needs:` list under
-`all-checks-passed`. The aggregation gate verifies each named job's
-`.result == "success"`, so a missing entry there silently lets failures
-through.
+Add the job to `ci.yml`, then add its name to the `needs:` list and status
+predicate under `all-checks-passed`. The aggregation gate accepts `success` or
+an intentional path-filtered `skipped`; a missing entry there silently lets
+failures through.
 
 ## Troubleshooting
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -136,6 +136,7 @@ candidate result and run the ordered local gate on that clean HEAD:
 ```sh
 git fetch origin main
 ./scripts/validate-pr-ready.sh --target lang/markdown/proj --target lang/markdown/edits
+git fetch origin main
 ./scripts/validate-pr-ready.sh --verify-evidence
 ```
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -172,8 +172,9 @@ on push.
 ## Adding new gating checks
 
 Add the job to `ci.yml`, then add its name to the `needs:` list and status
-predicate under `all-checks-passed`. The aggregation gate accepts `success` or
-an intentional path-filtered `skipped`; a missing entry there silently lets
+predicate under `all-checks-passed`. For `pr-ready-bash3`, the aggregate accepts
+`success`, or `skipped` only when `run_pr_ready_bash3` is exactly `false`;
+unexpected skips fail the aggregate. A missing entry there silently lets
 failures through.
 
 ## Troubleshooting

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -22,7 +22,7 @@ The main gating workflow. Job names match the file:
 
 | Job | What it runs |
 |-----|--------------|
-| `dep-check` | `./scripts/check-deps.sh` (module-scope rules [A]–[E] + canopy package-layering rules [F]–[I]; the rules table lives in the script header), `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh` |
+| `dep-check` | `./scripts/check-deps.sh` (module-scope rules [A]–[E] + canopy package-layering rules [F]–[I]; the rules table lives in the script header), `./scripts/check-shared-substrate.sh`, `./scripts/check-egw-resolver-identity.sh`, `./scripts/check-moon-update-wrapped.sh`, `node ./scripts/check-export-manifest.mjs`, `./scripts/test-moon-update-wrapper.sh`, `./scripts/test-pr-ready-validation.sh` |
 | `test-main` | `./scripts/update-moon-deps.sh`, `./scripts/check-agent-doc-links.sh`, `./scripts/run-moon-module.sh check .`, `./scripts/run-moon-module.sh test .`, `moon build --release` |
 | `test-submodules` | Matrix over `event-graph-walker`, `loom/loom`, `svg-dsl`, `graphviz` — each runs `./scripts/run-moon-module.sh ci <path>` |
 | `test-examples` | Matrix over `examples/ideal`, `examples/block-editor`, `examples/canvas` — each runs `./scripts/run-moon-module.sh ci <path>` |
@@ -126,6 +126,31 @@ make update                # moon update across root + maintained submodules
 The shared module helper is `./scripts/run-moon-module.sh <subcommand> <path>`
 where `<subcommand>` is `check`, `test`, `ci`, `fmt-check`, or `bench`. It
 validates that `<path>` is a real MoonBit module before invoking `moon`.
+
+### PR-ready validation
+
+After the targeted edit loop and independent review are complete, commit the
+candidate result and run the ordered local gate on that clean HEAD:
+
+```sh
+git fetch origin main
+./scripts/validate-pr-ready.sh --target lang/markdown/proj --target lang/markdown/edits
+./scripts/validate-pr-ready.sh --verify-evidence
+```
+
+Use `--no-target "<reason>"` instead of `--target` only when no MoonBit package
+is affected. `--list` takes the same target policy and prints the stable phase
+order without executing it. The validator checks that HEAD contains the fetched
+base, fetches and prunes each submodule origin before checking gitlink
+reachability, verifies dependency identity, checks Canopy-owned formatting and
+generated interfaces, runs targeted and full release gates, builds JavaScript,
+and records the validated HEAD, base, and target policy in an ignored,
+worktree-local `_build` file.
+
+Any commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated
+interface change makes that evidence stale. Rerun the full validator before
+opening or updating the PR. This local gate deliberately does not replace the
+required CI matrix.
 
 ## Pre-commit hook
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,9 @@ behavior** — check the code before relying on any specific detail.
 - [Completed EGW companion and Canopy compatibility migration](archive/2026-07-22-egw-companion-canopy-migration.md)
   — records EGW v0.5 publication, dependency convergence, Tier 1 preservation,
   and the protocol v3 hard cut; runtime extraction remains active follow-up.
+- [Completed agent PR-ready validation order](archive/2026-07-30-agent-pr-ready-validation.md)
+  — fixes the implementation sequence, fail-fast local gate, and current-HEAD
+  evidence contract used before opening or updating a PR.
 - [Investigation Index](archive/INVESTIGATION_INDEX.md) — earlier investigations.
 - [Branch Variance Investigations](archive/investigations/branch-variance/) —
   historical perf investigations.

--- a/docs/archive/2026-07-30-agent-pr-ready-validation.md
+++ b/docs/archive/2026-07-30-agent-pr-ready-validation.md
@@ -45,9 +45,13 @@ change makes the local evidence fail closed.
    mode.
 4. Tested the public CLI through a temporary Git repository, including invalid
    targets, dirty and behind-base state, dependency failure, tracked interface
-   mutation, listed/executed order identity, failed-run invalidation, and stale
-   HEAD/base evidence.
-5. Added the contract test to the dependency CI job and exposed the evidence in
+   mutation, listed/executed order identity, failed-run invalidation, stale
+   HEAD/base evidence, and real local submodule origins for reachable, unpushed,
+   and fetch-failure cases.
+5. Removed the final gate's remaining Bash 4-only dependency and added a
+   path-filtered macOS job that runs the CLI fixture and real downstream shell
+   graph with system Bash 3.2 while faking compiler work only.
+6. Added the contract test to the dependency CI job and exposed the evidence in
    the pull-request template.
 
 ## Acceptance Criteria
@@ -59,14 +63,17 @@ change makes the local evidence fail closed.
 - [x] Submodule origins are fetched/pruned, and commits match gitlinks and remain
       reachable from the configured origin.
 - [x] Evidence becomes stale after HEAD or base-ref movement.
+- [x] The shell orchestration contract runs with macOS system Bash 3.2.
 - [x] The documented order, executable order, PR template, and CI self-test agree.
 
 ## Validation
 
 ```bash
 ./scripts/test-pr-ready-validation.sh
-shellcheck scripts/validate-pr-ready.sh scripts/test-pr-ready-validation.sh
+./scripts/check-moon-update-wrapped.sh
+shellcheck scripts/check-moon-update-wrapped.sh scripts/validate-pr-ready.sh scripts/test-pr-ready-validation.sh scripts/test-pr-ready-bash32.sh
 ./scripts/validate-ci-yaml.sh
+# macOS CI: /bin/bash ./scripts/test-pr-ready-bash32.sh
 ./scripts/validate-pr-ready.sh --no-target "shell and documentation workflow only"
 ./scripts/validate-pr-ready.sh --verify-evidence
 ```
@@ -76,7 +83,10 @@ shellcheck scripts/validate-pr-ready.sh scripts/test-pr-ready-validation.sh
 - The local full gate is intentionally expensive; the targeted loop remains the
   fast feedback path.
 - Network freshness cannot be proven without a fetch, so `AGENTS.md` requires
-  `git fetch origin main` before validation.
+  `git fetch origin main` before validation and evidence verification.
+- The macOS job proves the real shell graph under Bash 3.2 with compiler work
+  faked; it does not claim macOS parity for MoonBit, JavaScript, proof, or
+  browser gates.
 - The gate mirrors the local core of CI but does not replace isolated matrices,
   browser E2E, proof, or the aggregate required check.
 

--- a/docs/archive/2026-07-30-agent-pr-ready-validation.md
+++ b/docs/archive/2026-07-30-agent-pr-ready-validation.md
@@ -1,0 +1,86 @@
+# Agent PR-ready Validation Order
+
+Status: completed
+
+Tracking: [GitHub issue #1047](https://github.com/dowdiness/canopy/issues/1047)
+
+## Why
+
+Long implementation trains had the right checks available but no durable rule
+for their order. Validation could therefore be reused after HEAD changed, or a
+PR could be opened before dependency identity and generated interfaces were
+checked on the reviewed commit.
+
+## Scope
+
+In:
+
+- the normative implementation order in `AGENTS.md`
+- an executable final gate in `scripts/validate-pr-ready.sh`
+- public CLI contract tests
+- PR evidence fields and CI wiring
+
+Out:
+
+- Markdown parser or editor behavior
+- replacement of the GitHub CI matrix
+- automatic commits, pushes, PR creation, or merging
+
+## Desired State
+
+Agents fetch and sync the base, establish a boundary matrix and failing test,
+use a targeted edit loop, obtain independent review, and then validate one clean
+candidate HEAD. The PR records that HEAD and base. Any later HEAD or fetched-base
+change makes the local evidence fail closed.
+
+## Implemented Steps
+
+1. Added one stable phase table for both plan listing and execution, covering
+   preflight, dependency, formatting/interface, targeted, full-suite,
+   JavaScript, diff, and evidence phases.
+2. Kept plan construction deterministic and effect-free; the shell performs
+   repository and compiler effects in fail-fast order.
+3. Stored successful HEAD/base/target-policy evidence in the ignored
+   worktree-local `_build` directory and added a fast evidence verification
+   mode.
+4. Tested the public CLI through a temporary Git repository, including invalid
+   targets, dirty and behind-base state, dependency failure, tracked interface
+   mutation, listed/executed order identity, failed-run invalidation, and stale
+   HEAD/base evidence.
+5. Added the contract test to the dependency CI job and exposed the evidence in
+   the pull-request template.
+
+## Acceptance Criteria
+
+- [x] Dependency identity runs before generated-interface and compiler gates.
+- [x] Affected packages are explicit, or the caller supplies a no-target reason.
+- [x] The first failed phase prevents all later commands.
+- [x] Full validation requires a clean HEAD containing the configured base.
+- [x] Submodule origins are fetched/pruned, and commits match gitlinks and remain
+      reachable from the configured origin.
+- [x] Evidence becomes stale after HEAD or base-ref movement.
+- [x] The documented order, executable order, PR template, and CI self-test agree.
+
+## Validation
+
+```bash
+./scripts/test-pr-ready-validation.sh
+shellcheck scripts/validate-pr-ready.sh scripts/test-pr-ready-validation.sh
+./scripts/validate-ci-yaml.sh
+./scripts/validate-pr-ready.sh --no-target "shell and documentation workflow only"
+./scripts/validate-pr-ready.sh --verify-evidence
+```
+
+## Risks
+
+- The local full gate is intentionally expensive; the targeted loop remains the
+  fast feedback path.
+- Network freshness cannot be proven without a fetch, so `AGENTS.md` requires
+  `git fetch origin main` before validation.
+- The gate mirrors the local core of CI but does not replace isolated matrices,
+  browser E2E, proof, or the aggregate required check.
+
+## ADR Decision
+
+No ADR needed: this is execution-policy enforcement for an existing development
+workflow, not a product or library architecture decision.

--- a/scripts/check-moon-update-wrapped.sh
+++ b/scripts/check-moon-update-wrapped.sh
@@ -19,11 +19,23 @@ cd "$root_dir"
 # build-deploy.sh ran bare `moon update` undetected. Markdown/source/config are
 # excluded by the allowlist (they only mention the command in prose). The wrapper
 # itself is the one legitimate `moon update` caller, so exclude it.
-mapfile -t files < <(
+# Seed the array because Bash 3.2 treats a declared-but-empty array as unbound
+# under `set -u`. Each discovered path overwrites or extends the seed.
+files=("")
+file_count=0
+while IFS= read -r file; do
+  files[file_count]="$file"
+  file_count=$((file_count + 1))
+done < <(
   git ls-files |
     grep -E '(\.(ya?ml|sh|bash|zsh|mk)$)|(^|/)(Makefile|justfile|Taskfile[^/]*)$' |
     grep -vx 'scripts/moon-update.sh'
 )
+
+if [ "$file_count" -eq 0 ]; then
+  echo "error: no command-bearing tracked files found" >&2
+  exit 1
+fi
 
 # `moon-update.sh` (hyphen) never matches `moon update` (space), so the wrapper's
 # own call is ignored for free. Match only command-position `moon update` so that

--- a/scripts/test-pr-ready-bash32.sh
+++ b/scripts/test-pr-ready-bash32.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Run the real PR-ready shell graph with compiler work replaced by a fake moon
+# executable. This belongs on a macOS runner whose system /bin/bash is 3.2.
+
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -ne 3 ] || [ "${BASH_VERSINFO[1]}" -ne 2 ]; then
+  echo "error: expected Bash 3.2, got ${BASH_VERSION}" >&2
+  exit 1
+fi
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+created_artifacts="$tmp_dir/created-artifacts"
+evidence_path="$root_dir/_build/.canopy-pr-ready"
+evidence_backup="$tmp_dir/pr-ready-evidence"
+had_evidence=0
+: >"$created_artifacts"
+
+if [ -f "$evidence_path" ]; then
+  cp -p "$evidence_path" "$evidence_backup"
+  had_evidence=1
+fi
+
+cleanup() {
+  local created_artifact
+
+  while IFS= read -r created_artifact; do
+    [ -n "$created_artifact" ] || continue
+    rm -f "$created_artifact"
+  done <"$created_artifacts"
+
+  if [ "$had_evidence" -eq 1 ]; then
+    mkdir -p "${evidence_path%/*}"
+    cp -p "$evidence_backup" "$evidence_path"
+  else
+    rm -f "$evidence_path"
+  fi
+
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/moon" <<'FAKE_MOON'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The compatibility smoke exercises the real shell orchestration, not MoonBit.
+# Every moon invocation succeeds without changing tracked files.
+exit 0
+FAKE_MOON
+chmod +x "$fake_bin/moon"
+
+cd "$root_dir"
+
+# build-js.sh verifies these outputs after invoking the fake compiler. Keep this
+# literal list independent from its implementation so artifact-contract drift
+# fails the public validator instead of being reproduced dynamically.
+while IFS= read -r artifact; do
+  artifact_path="$root_dir/$artifact"
+  [ -n "$artifact" ] || continue
+  if [ -e "$artifact_path" ] || [ -L "$artifact_path" ]; then
+    continue
+  fi
+  printf '%s\n' "$artifact_path" >>"$created_artifacts"
+  mkdir -p "${artifact_path%/*}"
+  : >"$artifact_path"
+done <<'ARTIFACTS'
+_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js
+_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/lambda/moonbit.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/json/json.js
+_build/js/release/build/dowdiness/canopy/ffi/json/json.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/json/moonbit.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.js
+_build/js/release/build/dowdiness/canopy/ffi/markdown/markdown.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/markdown/moonbit.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/jsx/jsx.js
+_build/js/release/build/dowdiness/canopy/ffi/jsx/jsx.d.ts
+_build/js/release/build/dowdiness/canopy/ffi/jsx/moonbit.d.ts
+_build/js/release/build/dowdiness/graphviz/browser/browser.js
+_build/js/release/build/dowdiness/graphviz/browser/browser.d.ts
+_build/js/release/build/dowdiness/canopy-canvas/main/main.js
+_build/js/release/build/dowdiness/canopy-canvas/main/main.d.ts
+_build/js/release/build/dowdiness/canopy-canvas/main/moonbit.d.ts
+ARTIFACTS
+
+PATH="$fake_bin:$PATH" \
+  ./scripts/validate-pr-ready.sh \
+    --base HEAD \
+    --no-target "Bash 3.2 real shell graph compatibility"
+
+PATH="$fake_bin:$PATH" ./scripts/validate-pr-ready.sh --verify-evidence
+
+echo "ok: real PR-ready shell graph runs with Bash 3.2"

--- a/scripts/test-pr-ready-bash32.sh
+++ b/scripts/test-pr-ready-bash32.sh
@@ -60,8 +60,8 @@ cd "$root_dir"
 # literal list independent from its implementation so artifact-contract drift
 # fails the public validator instead of being reproduced dynamically.
 while IFS= read -r artifact; do
-  artifact_path="$root_dir/$artifact"
   [ -n "$artifact" ] || continue
+  artifact_path="$root_dir/$artifact"
   if [ -e "$artifact_path" ] || [ -L "$artifact_path" ]; then
     continue
   fi

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -155,11 +155,92 @@ printf '_build/\n' >"$fixture/.gitignore"
 git -C "$fixture" init --quiet --initial-branch=main
 git -C "$fixture" config user.email "pr-ready-test@example.invalid"
 git -C "$fixture" config user.name "PR Ready Test"
+
+submodule_origin="$tmp_dir/submodule-origin.git"
+submodule_seed="$tmp_dir/submodule-seed"
+git init --quiet --bare --initial-branch=main "$submodule_origin"
+git init --quiet --initial-branch=main "$submodule_seed"
+git -C "$submodule_seed" config user.email "pr-ready-test@example.invalid"
+git -C "$submodule_seed" config user.name "PR Ready Test"
+printf 'reachable\n' >"$submodule_seed/state.txt"
+git -C "$submodule_seed" add state.txt
+git -C "$submodule_seed" commit --quiet -m "reachable submodule commit"
+git -C "$submodule_seed" remote add origin "$submodule_origin"
+git -C "$submodule_seed" push --quiet --set-upstream origin main
+git -c protocol.file.allow=always -C "$fixture" submodule add --quiet \
+  "$submodule_origin" vendor/test-submodule
+git -C "$fixture/vendor/test-submodule" config protocol.file.allow always
+git -C "$fixture/vendor/test-submodule" config \
+  user.email "pr-ready-test@example.invalid"
+git -C "$fixture/vendor/test-submodule" config user.name "PR Ready Test"
+
 git -C "$fixture" add .
 git -C "$fixture" commit --quiet -m "fixture base"
 git -C "$fixture" tag fixture-base
 git -C "$fixture" switch --quiet -c feature
 git -C "$fixture" commit --quiet --allow-empty -m "fixture feature"
+
+fake_moon_update_guard="$tmp_dir/fake-check-moon-update-wrapped.sh"
+cp "$fixture/scripts/check-moon-update-wrapped.sh" "$fake_moon_update_guard"
+cp "$root_dir/scripts/check-moon-update-wrapped.sh" \
+  "$fixture/scripts/check-moon-update-wrapped.sh"
+git -C "$fixture" add scripts/check-moon-update-wrapped.sh
+git -C "$fixture" commit --quiet -m "exercise the real moon update guard"
+
+bash32_output="$tmp_dir/bash32-output"
+if ! (
+  # Bash 3.2 has no mapfile builtin. Exporting a failing function with that name
+  # gives newer Bash versions the same observable command boundary. The
+  # validator's child Bash process invokes this exported function.
+  # shellcheck disable=SC2329
+  mapfile() { return 127; }
+  export -f mapfile
+  PATH="$fake_bin:$PATH" \
+    PR_READY_TEST_LOG="$execution_log" \
+    "$fixture/scripts/validate-pr-ready.sh" \
+      --base fixture-base \
+      --no-target "Bash 3.2 compatibility probe"
+) >"$bash32_output" 2>&1; then
+  fail "public validator did not complete without the Bash 4 mapfile builtin"
+fi
+grep -q "PR-ready validation passed" "$bash32_output" ||
+  fail "Bash 3.2 compatibility probe did not complete the public CLI"
+grep -q "validated-no-target=Bash 3.2 compatibility probe" "$bash32_output" ||
+  fail "Bash 3.2 compatibility probe did not record its scope"
+
+cp "$fake_moon_update_guard" "$fixture/scripts/check-moon-update-wrapped.sh"
+git -C "$fixture" add scripts/check-moon-update-wrapped.sh
+git -C "$fixture" commit --quiet -m "restore the fake moon update guard"
+
+printf 'not pushed\n' >"$fixture/vendor/test-submodule/state.txt"
+git -C "$fixture/vendor/test-submodule" add state.txt
+git -C "$fixture/vendor/test-submodule" commit --quiet \
+  -m "unpushed submodule commit"
+git -C "$fixture" add vendor/test-submodule
+git -C "$fixture" commit --quiet -m "record the unpushed submodule commit"
+
+: >"$execution_log"
+unpushed_output="$tmp_dir/unpushed-submodule-output"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$unpushed_output" 2>&1; then
+  fail "unpushed submodule commit unexpectedly passed"
+fi
+grep -q "submodule commit is not reachable from origin" "$unpushed_output" ||
+  fail "unpushed submodule diagnostic was not actionable"
+if [ -s "$execution_log" ]; then
+  fail "unpushed submodule failure ran dependency commands"
+fi
+if "$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/unpushed-evidence-output" 2>&1; then
+  fail "unpushed submodule failure unexpectedly preserved evidence"
+fi
+grep -q "evidence is missing" "$tmp_dir/unpushed-evidence-output" ||
+  fail "unpushed submodule failure did not invalidate earlier evidence"
+
+git -C "$fixture/vendor/test-submodule" push --quiet origin HEAD:main
 
 PATH="$fake_bin:$PATH" \
   PR_READY_TEST_LOG="$execution_log" \
@@ -212,6 +293,43 @@ grep -q "validated-head=$validated_head" "$tmp_dir/verified-output" ||
   fail "evidence verification did not report the validated HEAD"
 grep -q "validated-target=pkg" "$tmp_dir/verified-output" ||
   fail "evidence verification did not report the validated target"
+
+submodule_origin_url="$(
+  git -C "$fixture/vendor/test-submodule" remote get-url origin
+)"
+git -C "$fixture/vendor/test-submodule" remote set-url origin \
+  "$tmp_dir/missing-submodule-origin.git"
+: >"$execution_log"
+fetch_failure_output="$tmp_dir/submodule-fetch-failure-output"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$fetch_failure_output" 2>&1; then
+  fail "submodule fetch failure unexpectedly passed"
+fi
+grep -q "could not fetch submodule origin" "$fetch_failure_output" ||
+  fail "submodule fetch failure diagnostic was not actionable"
+if [ -s "$execution_log" ]; then
+  fail "submodule fetch failure ran dependency commands"
+fi
+if "$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/fetch-failure-evidence-output" 2>&1; then
+  fail "submodule fetch failure unexpectedly preserved evidence"
+fi
+grep -q "evidence is missing" "$tmp_dir/fetch-failure-evidence-output" ||
+  fail "submodule fetch failure did not invalidate earlier evidence"
+
+git -C "$fixture/vendor/test-submodule" remote set-url origin \
+  "$submodule_origin_url"
+: >"$execution_log"
+PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$tmp_dir/restored-submodule-success-output"
+"$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/restored-submodule-evidence-output"
 
 if "$fixture/scripts/validate-pr-ready.sh" \
   --verify-evidence \

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+validator="$root_dir/scripts/validate-pr-ready.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+assert_files_equal() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if ! diff -u "$expected" "$actual"; then
+    fail "$label"
+  fi
+}
+
+if [ ! -x "$validator" ]; then
+  fail "expected executable validator at $validator"
+fi
+
+list_output="$tmp_dir/list-output"
+"$validator" \
+  --list \
+  --base origin/main \
+  --target lang/markdown/proj \
+  --target lang/markdown/edits >"$list_output"
+
+expected_list="$tmp_dir/expected-list"
+cat >"$expected_list" <<'EXPECTED_LIST'
+01 preflight.clean
+02 preflight.base origin/main
+03 preflight.submodules
+04 dependencies.check-deps
+05 dependencies.shared-substrate
+06 dependencies.egw-resolver-identity
+07 dependencies.moon-update-wrapper
+08 dependencies.agent-doc-links
+09 dependencies.export-manifest
+10 dependencies.update-wrapper-test
+11 dependencies.sync
+12 format.canopy
+13 interfaces.canopy
+14 target.check lang/markdown/proj
+15 target.test lang/markdown/proj
+16 target.check lang/markdown/edits
+17 target.test lang/markdown/edits
+18 suite.check
+19 suite.manifest-compat
+20 suite.test
+21 suite.build
+22 build.js
+23 diff.whitespace origin/main...HEAD
+24 evidence.record
+EXPECTED_LIST
+assert_files_equal "$expected_list" "$list_output" "--list order changed"
+
+missing_target_output="$tmp_dir/missing-target-output"
+if "$validator" --list --base origin/main >"$missing_target_output" 2>&1; then
+  fail "--list unexpectedly accepted a missing target policy"
+fi
+grep -q -- "--target or --no-target" "$missing_target_output" ||
+  fail "missing-target diagnostic was not actionable"
+
+invalid_target_output="$tmp_dir/invalid-target-output"
+if "$validator" --list --target docs >"$invalid_target_output" 2>&1; then
+  fail "--list unexpectedly accepted a non-package target"
+fi
+grep -q "not a MoonBit package directory" "$invalid_target_output" ||
+  fail "non-package target diagnostic was not actionable"
+
+duplicate_target_output="$tmp_dir/duplicate-target-output"
+if "$validator" --list --target lang/markdown/proj --target lang/markdown/proj \
+  >"$duplicate_target_output" 2>&1; then
+  fail "--list unexpectedly accepted a duplicate target"
+fi
+grep -q "duplicate target" "$duplicate_target_output" ||
+  fail "duplicate-target diagnostic was not actionable"
+
+fixture="$tmp_dir/repo"
+fake_bin="$tmp_dir/bin"
+execution_log="$tmp_dir/execution.log"
+mkdir -p "$fixture/scripts" "$fixture/pkg" "$fake_bin"
+cp "$validator" "$fixture/scripts/validate-pr-ready.sh"
+
+cat >"$fake_bin/moon" <<'FAKE_MOON'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'moon' >>"$PR_READY_TEST_LOG"
+if [ "$#" -gt 0 ]; then
+  printf ' %s' "$@" >>"$PR_READY_TEST_LOG"
+fi
+printf '\n' >>"$PR_READY_TEST_LOG"
+
+if [ "${PR_READY_MUTATE_MOON_COMMAND:-}" = "${1:-}" ]; then
+  printf '// changed by fake moon\n' >>"${PR_READY_MUTATE_FILE:?}"
+fi
+FAKE_MOON
+
+cat >"$fake_bin/node" <<'FAKE_NODE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'node' >>"$PR_READY_TEST_LOG"
+if [ "$#" -gt 0 ]; then
+  printf ' %s' "$@" >>"$PR_READY_TEST_LOG"
+fi
+printf '\n' >>"$PR_READY_TEST_LOG"
+FAKE_NODE
+chmod +x "$fake_bin/moon" "$fake_bin/node"
+
+for script_name in \
+  check-deps.sh \
+  check-shared-substrate.sh \
+  check-egw-resolver-identity.sh \
+  check-moon-update-wrapped.sh \
+  check-agent-doc-links.sh \
+  test-moon-update-wrapper.sh \
+  update-moon-deps.sh \
+  check-strict.sh \
+  check-moonbit-pkg-compat.sh \
+  check-test-baseline.sh \
+  build-js.sh; do
+  cat >"$fixture/scripts/$script_name" <<'FAKE_SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+step_name="$(basename "$0")"
+printf '%s' "$step_name" >>"$PR_READY_TEST_LOG"
+if [ "$#" -gt 0 ]; then
+  printf ' %s' "$@" >>"$PR_READY_TEST_LOG"
+fi
+printf '\n' >>"$PR_READY_TEST_LOG"
+
+if [ "${PR_READY_FAIL_STEP:-}" = "$step_name" ]; then
+  exit 23
+fi
+FAKE_SCRIPT
+  chmod +x "$fixture/scripts/$script_name"
+done
+
+printf 'pub fn answer() -> Int { 42 }\n' >"$fixture/pkg/main.mbt"
+printf 'package "fixture/pkg"\n' >"$fixture/pkg/moon.pkg"
+printf 'pub fn answer() -> Int\n' >"$fixture/pkg/pkg.generated.mbti"
+printf '_build/\n' >"$fixture/.gitignore"
+
+git -C "$fixture" init --quiet --initial-branch=main
+git -C "$fixture" config user.email "pr-ready-test@example.invalid"
+git -C "$fixture" config user.name "PR Ready Test"
+git -C "$fixture" add .
+git -C "$fixture" commit --quiet -m "fixture base"
+git -C "$fixture" tag fixture-base
+git -C "$fixture" switch --quiet -c feature
+git -C "$fixture" commit --quiet --allow-empty -m "fixture feature"
+
+PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$tmp_dir/success-output"
+
+fixture_plan="$tmp_dir/fixture-plan"
+execution_plan="$tmp_dir/execution-plan"
+"$fixture/scripts/validate-pr-ready.sh" \
+  --list \
+  --base fixture-base \
+  --target pkg >"$fixture_plan"
+sed -n 's/^==> //p' "$tmp_dir/success-output" >"$execution_plan"
+assert_files_equal "$fixture_plan" "$execution_plan" "listed and executed phases diverged"
+
+expected_execution="$tmp_dir/expected-execution"
+cat >"$expected_execution" <<'EXPECTED_EXECUTION'
+check-deps.sh
+check-shared-substrate.sh
+check-egw-resolver-identity.sh
+check-moon-update-wrapped.sh
+check-agent-doc-links.sh
+node ./scripts/check-export-manifest.mjs
+test-moon-update-wrapper.sh
+update-moon-deps.sh
+moon fmt --check pkg/main.mbt
+moon info --frozen pkg
+check-strict.sh pkg
+moon test --release pkg
+check-strict.sh
+check-moonbit-pkg-compat.sh
+check-test-baseline.sh 7 moon test --release
+moon build --release
+build-js.sh
+EXPECTED_EXECUTION
+assert_files_equal "$expected_execution" "$execution_log" "validation command order changed"
+
+validated_head="$(git -C "$fixture" rev-parse HEAD)"
+grep -q "validated-head=$validated_head" "$tmp_dir/success-output" ||
+  fail "success output did not identify the validated HEAD"
+grep -q "validated-target=pkg" "$tmp_dir/success-output" ||
+  fail "success output did not identify the validated target"
+
+PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --verify-evidence >"$tmp_dir/verified-output"
+grep -q "validated-head=$validated_head" "$tmp_dir/verified-output" ||
+  fail "evidence verification did not report the validated HEAD"
+grep -q "validated-target=pkg" "$tmp_dir/verified-output" ||
+  fail "evidence verification did not report the validated target"
+
+if "$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence \
+  --target pkg >"$tmp_dir/incompatible-mode-output" 2>&1; then
+  fail "--verify-evidence unexpectedly accepted target options"
+fi
+grep -q "does not accept" "$tmp_dir/incompatible-mode-output" ||
+  fail "incompatible-mode diagnostic was not actionable"
+
+: >"$execution_log"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  PR_READY_FAIL_STEP="check-shared-substrate.sh" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$tmp_dir/fail-fast-output" 2>&1; then
+  fail "dependency failure unexpectedly passed"
+fi
+expected_fail_fast="$tmp_dir/expected-fail-fast"
+cat >"$expected_fail_fast" <<'EXPECTED_FAIL_FAST'
+check-deps.sh
+check-shared-substrate.sh
+EXPECTED_FAIL_FAST
+assert_files_equal "$expected_fail_fast" "$execution_log" "dependency failure did not stop later steps"
+if "$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/failed-run-evidence-output" 2>&1; then
+  fail "a failed rerun unexpectedly preserved earlier evidence"
+fi
+grep -q "evidence is missing" "$tmp_dir/failed-run-evidence-output" ||
+  fail "failed rerun did not invalidate earlier evidence"
+
+: >"$execution_log"
+PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$tmp_dir/restored-success-output"
+
+: >"$execution_log"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  PR_READY_MUTATE_MOON_COMMAND="info" \
+  PR_READY_MUTATE_FILE="$fixture/pkg/pkg.generated.mbti" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$tmp_dir/mutation-output" 2>&1; then
+  fail "tracked interface mutation unexpectedly passed"
+fi
+grep -q "worktree is not clean" "$tmp_dir/mutation-output" ||
+  fail "tracked mutation diagnostic was not actionable"
+if grep -q "check-strict.sh" "$execution_log"; then
+  fail "tracked interface mutation did not stop before targeted checks"
+fi
+git -C "$fixture" restore pkg/pkg.generated.mbti
+if "$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/mutation-evidence-output" 2>&1; then
+  fail "a mutating rerun unexpectedly preserved earlier evidence"
+fi
+grep -q "evidence is missing" "$tmp_dir/mutation-evidence-output" ||
+  fail "mutating rerun did not invalidate earlier evidence"
+
+: >"$execution_log"
+PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --no-target "shell-only fixture" >"$tmp_dir/no-target-success-output"
+grep -q "validated-no-target=shell-only fixture" "$tmp_dir/no-target-success-output" ||
+  fail "success output did not identify the no-target reason"
+
+fixture_base_sha="$(git -C "$fixture" rev-parse fixture-base)"
+git -C "$fixture" tag --force fixture-base HEAD >/dev/null
+if "$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/base-stale-output" 2>&1; then
+  fail "evidence unexpectedly survived base-ref movement"
+fi
+grep -q "fixture-base changed" "$tmp_dir/base-stale-output" ||
+  fail "base-ref movement diagnostic was not actionable"
+git -C "$fixture" tag --force fixture-base "$fixture_base_sha" >/dev/null
+
+"$fixture/scripts/validate-pr-ready.sh" \
+  --verify-evidence >"$tmp_dir/restored-base-output"
+grep -q "validated-no-target=shell-only fixture" "$tmp_dir/restored-base-output" ||
+  fail "restored base did not restore matching evidence"
+
+git -C "$fixture" commit --quiet --allow-empty -m "advance HEAD"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --verify-evidence >"$tmp_dir/stale-output" 2>&1; then
+  fail "evidence unexpectedly survived a HEAD change"
+fi
+grep -q "stale" "$tmp_dir/stale-output" ||
+  fail "stale evidence diagnostic was not actionable"
+
+: >"$execution_log"
+printf 'dirty\n' >"$fixture/untracked.txt"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$tmp_dir/dirty-output" 2>&1; then
+  fail "dirty worktree unexpectedly passed"
+fi
+grep -q "worktree is not clean" "$tmp_dir/dirty-output" ||
+  fail "dirty-worktree diagnostic was not actionable"
+if [ -s "$execution_log" ]; then
+  fail "dirty-worktree failure ran validation commands"
+fi
+rm "$fixture/untracked.txt"
+
+git -C "$fixture" switch --quiet main
+git -C "$fixture" commit --quiet --allow-empty -m "advance base"
+git -C "$fixture" switch --quiet feature
+: >"$execution_log"
+if PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base main \
+    --target pkg >"$tmp_dir/behind-output" 2>&1; then
+  fail "branch behind the configured base unexpectedly passed"
+fi
+grep -q "does not contain base" "$tmp_dir/behind-output" ||
+  fail "behind-base diagnostic was not actionable"
+if [ -s "$execution_log" ]; then
+  fail "behind-base failure ran validation commands"
+fi
+
+echo "ok: PR-ready validation order and HEAD evidence are enforced"

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -150,6 +150,7 @@ done
 printf 'pub fn answer() -> Int { 42 }\n' >"$fixture/pkg/main.mbt"
 printf 'package "fixture/pkg"\n' >"$fixture/pkg/moon.pkg"
 printf 'pub fn answer() -> Int\n' >"$fixture/pkg/pkg.generated.mbti"
+printf '{"name":"fixture"}\n' >"$fixture/moon.pkg.json"
 printf '_build/\n' >"$fixture/.gitignore"
 
 git -C "$fixture" init --quiet --initial-branch=main
@@ -268,7 +269,7 @@ node ./scripts/check-export-manifest.mjs
 test-moon-update-wrapper.sh
 update-moon-deps.sh
 moon fmt --check pkg/main.mbt
-moon info --frozen pkg
+moon info --frozen . pkg
 check-strict.sh pkg
 moon test --release pkg
 check-strict.sh

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+
+# Bash 3.2 treats declared-but-empty arrays as unbound under `set -u`.
+# Keep the CLI usable with the macOS system Bash while retaining fail-fast and
+# pipeline error propagation.
+set -eo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(dirname "$script_dir")"
+base_ref="origin/main"
+base_was_set=0
+mode="validate"
+no_target_reason=""
+targets=()
+target_policy_was_set=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./scripts/validate-pr-ready.sh [--base REF] --target PATH [--target PATH ...]
+  ./scripts/validate-pr-ready.sh [--base REF] --no-target REASON
+  ./scripts/validate-pr-ready.sh --list [--base REF] (--target PATH [...] | --no-target REASON)
+  ./scripts/validate-pr-ready.sh --verify-evidence
+
+Options:
+  --base REF          Local base ref that must be contained in HEAD
+                      (default: origin/main; fetch it before validation).
+  --target PATH       Affected MoonBit package path. Repeatable.
+  --no-target REASON  Explain why no targeted MoonBit loop applies.
+  --list              Print the deterministic validation plan without running it.
+                      The same target policy as a real run is required.
+  --verify-evidence   Verify that the last successful validation still matches
+                      the current clean HEAD, base ref, and recorded target scope.
+  -h, --help          Show this help.
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "$value" ]; then
+    die "$option requires a non-empty value"
+  fi
+  case "$value" in
+    *$'\n'*) die "$option values must fit on one line" ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      require_value "$1" "${2:-}"
+      base_ref="$2"
+      base_was_set=1
+      shift 2
+      ;;
+    --target)
+      require_value "$1" "${2:-}"
+      targets+=("$2")
+      target_policy_was_set=1
+      shift 2
+      ;;
+    --no-target)
+      require_value "$1" "${2:-}"
+      no_target_reason="$2"
+      target_policy_was_set=1
+      shift 2
+      ;;
+    --list)
+      [ "$mode" = "validate" ] || die "choose only one operating mode"
+      mode="list"
+      shift
+      ;;
+    --verify-evidence)
+      [ "$mode" = "validate" ] || die "choose only one operating mode"
+      mode="verify"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+cd "$project_root"
+
+assert_target_policy() {
+  if [ "${#targets[@]}" -gt 0 ] && [ -n "$no_target_reason" ]; then
+    die "use --target or --no-target, not both"
+  fi
+  if [ "${#targets[@]}" -eq 0 ] && [ -z "$no_target_reason" ]; then
+    die "provide --target or --no-target; the latter requires an explicit reason"
+  fi
+}
+
+assert_targets_are_packages() {
+  local target
+  local previous
+  local seen_targets=()
+
+  for target in "${targets[@]}"; do
+    [ -d "$target" ] || die "target path does not exist: $target"
+    if [ ! -f "$target/moon.pkg" ] && [ ! -f "$target/moon.pkg.json" ]; then
+      die "target is not a MoonBit package directory: $target"
+    fi
+    for previous in "${seen_targets[@]}"; do
+      if [ "$previous" = "$target" ]; then
+        die "duplicate target: $target"
+      fi
+    done
+    seen_targets+=("$target")
+  done
+}
+
+evidence_path() {
+  printf '%s\n' "$project_root/_build/.canopy-pr-ready"
+}
+
+assert_clean_worktree() {
+  local status
+  status="$(git status --porcelain=v1 --untracked-files=all --ignore-submodules=none)"
+  if [ -n "$status" ]; then
+    echo "error: worktree is not clean; commit or remove these changes before validation:" >&2
+    echo "$status" >&2
+    exit 1
+  fi
+}
+
+verify_evidence() {
+  local path
+  local recorded_head=""
+  local recorded_base_ref=""
+  local recorded_base=""
+  local recorded_no_target=""
+  local recorded_targets=()
+  local key
+  local value
+
+  assert_clean_worktree
+  path="$(evidence_path)"
+  [ -f "$path" ] || die "PR-ready evidence is missing; run full validation first"
+
+  while IFS='=' read -r key value; do
+    case "$key" in
+      head) recorded_head="$value" ;;
+      base-ref) recorded_base_ref="$value" ;;
+      base) recorded_base="$value" ;;
+      target) recorded_targets+=("$value") ;;
+      no-target) recorded_no_target="$value" ;;
+    esac
+  done <"$path"
+
+  [ -n "$recorded_head" ] || die "PR-ready evidence is malformed"
+  [ -n "$recorded_base_ref" ] || die "PR-ready evidence is malformed"
+  [ -n "$recorded_base" ] || die "PR-ready evidence is malformed"
+  if [ "${#recorded_targets[@]}" -gt 0 ] && [ -n "$recorded_no_target" ]; then
+    die "PR-ready evidence is malformed"
+  fi
+  if [ "${#recorded_targets[@]}" -eq 0 ] && [ -z "$recorded_no_target" ]; then
+    die "PR-ready evidence is malformed"
+  fi
+
+  local current_head
+  current_head="$(git rev-parse HEAD)"
+  if [ "$current_head" != "$recorded_head" ]; then
+    die "PR-ready evidence is stale: HEAD changed from $recorded_head to $current_head"
+  fi
+
+  local current_base
+  current_base="$(git rev-parse --verify --quiet "$recorded_base_ref^{commit}")" ||
+    die "PR-ready evidence is stale: base ref $recorded_base_ref no longer resolves"
+  if [ "$current_base" != "$recorded_base" ]; then
+    die "PR-ready evidence is stale: $recorded_base_ref changed from $recorded_base to $current_base"
+  fi
+
+  git merge-base --is-ancestor "$recorded_base" HEAD ||
+    die "PR-ready evidence is stale: HEAD does not contain recorded base $recorded_base"
+
+  echo "validated-head=$recorded_head"
+  echo "validated-base=$recorded_base"
+  echo "validated-base-ref=$recorded_base_ref"
+  if [ "${#recorded_targets[@]}" -gt 0 ]; then
+    local recorded_target
+    for recorded_target in "${recorded_targets[@]}"; do
+      echo "validated-target=$recorded_target"
+    done
+  else
+    echo "validated-no-target=$recorded_no_target"
+  fi
+}
+
+if [ "$mode" = "verify" ]; then
+  if [ "$base_was_set" -eq 1 ] || [ "$target_policy_was_set" -eq 1 ]; then
+    die "--verify-evidence does not accept --base, --target, or --no-target"
+  fi
+  verify_evidence
+  exit 0
+fi
+
+assert_target_policy
+assert_targets_are_packages
+
+phase_ids=()
+phase_args=()
+
+add_phase() {
+  phase_ids+=("$1")
+  phase_args+=("${2:-}")
+}
+
+build_plan() {
+  add_phase "preflight.clean"
+  add_phase "preflight.base" "$base_ref"
+  add_phase "preflight.submodules"
+  add_phase "dependencies.check-deps"
+  add_phase "dependencies.shared-substrate"
+  add_phase "dependencies.egw-resolver-identity"
+  add_phase "dependencies.moon-update-wrapper"
+  add_phase "dependencies.agent-doc-links"
+  add_phase "dependencies.export-manifest"
+  add_phase "dependencies.update-wrapper-test"
+  add_phase "dependencies.sync"
+  add_phase "format.canopy"
+  add_phase "interfaces.canopy"
+
+  if [ "${#targets[@]}" -gt 0 ]; then
+    local target
+    for target in "${targets[@]}"; do
+      add_phase "target.check" "$target"
+      add_phase "target.test" "$target"
+    done
+  else
+    add_phase "target.skipped" "$no_target_reason"
+  fi
+
+  add_phase "suite.check"
+  add_phase "suite.manifest-compat"
+  add_phase "suite.test"
+  add_phase "suite.build"
+  add_phase "build.js"
+  add_phase "diff.whitespace" "$base_ref...HEAD"
+  add_phase "evidence.record"
+}
+
+format_phase() {
+  local index="$1"
+  local id="${phase_ids[$index]}"
+  local argument="${phase_args[$index]}"
+
+  if [ -n "$argument" ]; then
+    printf '%02d %s %s\n' "$((index + 1))" "$id" "$argument"
+  else
+    printf '%02d %s\n' "$((index + 1))" "$id"
+  fi
+}
+
+print_plan() {
+  local index
+  for ((index = 0; index < ${#phase_ids[@]}; index += 1)); do
+    format_phase "$index"
+  done
+}
+
+build_plan
+
+if [ "$mode" = "list" ]; then
+  print_plan
+  exit 0
+fi
+
+start_head=""
+start_base=""
+
+run_phase() {
+  local id="$1"
+  local argument="$2"
+
+  case "$id" in
+    preflight.clean)
+      assert_clean_worktree
+      rm -f "$(evidence_path)"
+      ;;
+    preflight.base)
+      start_head="$(git rev-parse HEAD)"
+      start_base="$(git rev-parse --verify --quiet "$base_ref^{commit}")" ||
+        die "base ref $base_ref does not resolve; fetch it before validation"
+      git merge-base --is-ancestor "$start_base" "$start_head" ||
+        die "HEAD does not contain base $base_ref ($start_base); sync or rebase first"
+      ;;
+    preflight.submodules)
+      local submodule_status
+      local line
+      submodule_status="$(git submodule status --recursive)"
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        case "${line:0:1}" in
+          -) die "submodule is not initialized: $line" ;;
+          +) die "submodule does not match its recorded gitlink: $line" ;;
+          U) die "submodule has a merge conflict: $line" ;;
+        esac
+      done <<<"$submodule_status"
+      # Variables in this body are intentionally expanded inside each submodule.
+      # shellcheck disable=SC2016
+      git submodule foreach --quiet --recursive '
+        if ! git fetch --quiet --prune origin; then
+          echo "error: could not fetch submodule origin: $displaypath" >&2
+          exit 1
+        fi
+        if [ -z "$(git for-each-ref --format="%(refname)" --contains HEAD refs/remotes/origin)" ]; then
+          echo "error: submodule commit is not reachable from origin: $displaypath" >&2
+          echo "push its branch to the configured origin before the parent PR" >&2
+          exit 1
+        fi
+      ' || die "submodule remote reachability check failed"
+      ;;
+    dependencies.check-deps)
+      ./scripts/check-deps.sh
+      ;;
+    dependencies.shared-substrate)
+      ./scripts/check-shared-substrate.sh
+      ;;
+    dependencies.egw-resolver-identity)
+      ./scripts/check-egw-resolver-identity.sh
+      ;;
+    dependencies.moon-update-wrapper)
+      ./scripts/check-moon-update-wrapped.sh
+      ;;
+    dependencies.agent-doc-links)
+      bash ./scripts/check-agent-doc-links.sh
+      ;;
+    dependencies.export-manifest)
+      node ./scripts/check-export-manifest.mjs
+      ;;
+    dependencies.update-wrapper-test)
+      ./scripts/test-moon-update-wrapper.sh
+      ;;
+    dependencies.sync)
+      ./scripts/update-moon-deps.sh
+      assert_clean_worktree
+      ;;
+    format.canopy)
+      local moon_sources=()
+      local source_file
+      while IFS= read -r -d '' source_file; do
+        moon_sources+=("$source_file")
+      done < <(git ls-files -z -- '*.mbt' '*.mbt.md')
+      if [ "${#moon_sources[@]}" -gt 0 ]; then
+        NEW_MOON_MOD=0 moon fmt --check "${moon_sources[@]}"
+      fi
+      ;;
+    interfaces.canopy)
+      local package_dirs=()
+      local package_file
+      local package_dir
+      local existing_dir
+      local already_seen
+      while IFS= read -r -d '' package_file; do
+        if [[ "$package_file" == */* ]]; then
+          package_dir="${package_file%/*}"
+        else
+          package_dir="."
+        fi
+        already_seen=0
+        for existing_dir in "${package_dirs[@]}"; do
+          if [ "$existing_dir" = "$package_dir" ]; then
+            already_seen=1
+            break
+          fi
+        done
+        if [ "$already_seen" -eq 0 ]; then
+          package_dirs+=("$package_dir")
+        fi
+      done < <(git ls-files -z -- 'moon.pkg' '*/moon.pkg' '*/moon.pkg.json')
+      if [ "${#package_dirs[@]}" -gt 0 ]; then
+        NEW_MOON_MOD=0 moon info --frozen "${package_dirs[@]}"
+      fi
+      assert_clean_worktree
+      ;;
+    target.check)
+      ./scripts/check-strict.sh "$argument"
+      ;;
+    target.test)
+      NEW_MOON_MOD=0 moon test --release "$argument"
+      ;;
+    target.skipped)
+      :
+      ;;
+    suite.check)
+      ./scripts/check-strict.sh
+      ;;
+    suite.manifest-compat)
+      ./scripts/check-moonbit-pkg-compat.sh
+      ;;
+    suite.test)
+      ./scripts/check-test-baseline.sh 7 moon test --release
+      ;;
+    suite.build)
+      NEW_MOON_MOD=0 moon build --release
+      ;;
+    build.js)
+      ./scripts/build-js.sh
+      ;;
+    diff.whitespace)
+      git diff --check "$base_ref...HEAD"
+      ;;
+    evidence.record)
+      assert_clean_worktree
+      local end_head
+      local end_base
+      end_head="$(git rev-parse HEAD)"
+      end_base="$(git rev-parse --verify --quiet "$base_ref^{commit}")" ||
+        die "base ref $base_ref stopped resolving during validation"
+      if [ "$end_head" != "$start_head" ]; then
+        die "HEAD changed during validation from $start_head to $end_head; rerun the full gate"
+      fi
+      if [ "$end_base" != "$start_base" ]; then
+        die "$base_ref changed during validation from $start_base to $end_base; rerun the full gate"
+      fi
+
+      local evidence_file
+      evidence_file="$(evidence_path)"
+      mkdir -p "$(dirname "$evidence_file")"
+      {
+        printf 'head=%s\n' "$start_head"
+        printf 'base-ref=%s\n' "$base_ref"
+        printf 'base=%s\n' "$start_base"
+        if [ "${#targets[@]}" -gt 0 ]; then
+          local target
+          for target in "${targets[@]}"; do
+            printf 'target=%s\n' "$target"
+          done
+        else
+          printf 'no-target=%s\n' "$no_target_reason"
+        fi
+      } >"$evidence_file"
+      ;;
+    *)
+      die "unknown validation phase: $id"
+      ;;
+  esac
+}
+
+for ((phase_index = 0; phase_index < ${#phase_ids[@]}; phase_index += 1)); do
+  phase_line="$(format_phase "$phase_index")"
+  echo
+  echo "==> $phase_line"
+  run_phase "${phase_ids[$phase_index]}" "${phase_args[$phase_index]}"
+done
+
+echo
+echo "PR-ready validation passed."
+verify_evidence

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -380,7 +380,10 @@ run_phase() {
         if [ "$already_seen" -eq 0 ]; then
           package_dirs+=("$package_dir")
         fi
-      done < <(git ls-files -z -- 'moon.pkg' '*/moon.pkg' '*/moon.pkg.json')
+      done < <(
+        git ls-files -z -- \
+          'moon.pkg' 'moon.pkg.json' '*/moon.pkg' '*/moon.pkg.json'
+      )
       if [ "${#package_dirs[@]}" -gt 0 ]; then
         NEW_MOON_MOD=0 moon info --frozen "${package_dirs[@]}"
       fi


### PR DESCRIPTION
## Summary

- codify the required implementation sequence in `AGENTS.md`, including a fresh base fetch before final validation, evidence verification, and merge
- add a fail-fast `scripts/validate-pr-ready.sh` gate with one shared phase plan and worktree-local HEAD/base/target evidence
- test the public CLI contract with real local submodule remotes and a path-filtered macOS Bash 3.2 real-shell-graph smoke
- require exact evidence in the PR template and document the completed local/CI boundary

Closes #1047

## UI and review evidence

N/A — this PR changes shell workflow enforcement, tests, CI, and documentation; it does not change rendered UI behavior.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| dependency and identity gates | `scripts/check-{deps,shared-substrate,egw-resolver-identity,moon-update-wrapped}.sh` | yes | canonical CI entrypoints |
| strict check and baseline runner | `scripts/check-strict.sh`, `scripts/check-test-baseline.sh` | yes | preserve vendored filtering and failure baseline |
| JS build gate | `scripts/build-js.sh` | yes | canonical artifact validation |
| Git clean/base/submodule primitives | Git CLI | yes | public repository state boundary |

New helpers added:

- shell-only phase planning, evidence, assertion, and Bash 3.2 compatibility helpers; these form or test the public workflow CLI and do not duplicate a project API

## Validation scope

Boundary matrix / first failing regression:

- clean vs dirty worktree
- contained vs behind or moved base
- valid, invalid, duplicate, and explicit no-target scope
- dependency success vs fail-fast failure
- reachable vs unpushed submodule commit and fetch success vs failure
- stable vs tracked interface mutation
- listed vs executed phase order
- successful vs failed rerun evidence
- stable vs changed HEAD and base ref
- Bash 3.2 orchestration with the real downstream shell graph and compiler work faked

Target packages:

- `--no-target "shell and documentation workflow only"`

Additional conditional gates:

- no proof, browser E2E, or product behavior gate applies
- `PR-ready Bash 3.2 Contract` runs on macOS because shell and CI files changed

## PR-ready evidence

Validated HEAD: `b21735037db403d76ef955472b6d8f0c27b676a3`

Validated base: `origin/main@4e481aeaf521f007dabd8d81bd59012062b3f9e5`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --no-target "shell and documentation workflow only"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was updated.
- [x] The committed `.mbti` diff against the validated base was reviewed; there is no `.mbti` diff.
- [x] Submodule pointers are unchanged; configured-origin reachability passed in the validator.
- [x] Validation was rerun after the final rebase and current HEAD change.
- [x] Independent review findings were resolved before final validation.

## Additional checks

- `./scripts/test-pr-ready-validation.sh`
- `./scripts/check-moon-update-wrapped.sh`
- `shellcheck scripts/check-moon-update-wrapped.sh scripts/validate-pr-ready.sh scripts/test-pr-ready-validation.sh scripts/test-pr-ready-bash32.sh`
- `actionlint -ignore SC2046 .github/workflows/ci.yml` (the ignored SC2046 findings predate this PR)
- all workflow YAML parsed by `scripts/validate-ci-yaml.sh`
- the macOS contract job checks out full submodule history before validating remote-branch ancestry
- full release test baseline: 0 failures, 0 non-vendored failures
- full release build and JS artifact build passed

## ADR decision

No ADR needed: this enforces an existing development workflow and does not change product or library architecture.
