### PR TITLE
fix(ci): target canvas deploy build output

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -56,7 +56,7 @@ jobs:
             type: pages
             # Build with workspace on. See #335 for target override caveat.
             moon-update: cd examples/canvas && "$GITHUB_WORKSPACE/scripts/moon-update.sh"
-            moon-build: cd examples/canvas && moon build --target js --release
+            moon-build: cd examples/canvas && moon build --target js --release --target-dir "$GITHUB_WORKSPACE/_build"
             npm-dir: examples/canvas/web
             deploy-dir: examples/canvas/web/dist
 


### PR DESCRIPTION
## Summary

- write the standalone Canvas MoonBit build into the repository-root `_build` directory during Cloudflare deploys
- align the deploy workflow with `scripts/build-js.sh` and the path expected by `vite-plugin-moonbit`
- prevent CI-mode Vite builds from failing because `@moonbit/canopy-canvas` is missing

## Reuse check

Not applicable: this is a CI configuration-only change and adds no functions, helpers, or types. It reuses the existing `--target-dir "$GITHUB_WORKSPACE/_build"` convention from `scripts/build-js.sh`.

## Test plan

- [x] `actionlint .github/workflows/deploy-cloudflare.yml`
- [x] `git diff --check`
- [x] Canvas release build with an isolated `--target-dir`; verified `js/release/build/dowdiness/canopy-canvas/main/main.js`
- [x] `CI=true CANOPY_SKIP_MOON_BUILD=1 npx vite build` in `examples/canvas/web`

## Validation

The Canvas MoonBit build completed with existing deprecation warnings and zero errors. The Vite production build found the pre-built module and completed successfully.
