### PR TITLE
feat(diagnostics): add source-aware spans and styled labels

### DIFF
--- a/cmd/main/moon.pkg
+++ b/cmd/main/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/event-graph-walker/text",
+  "dowdiness/loom/core" @loomcore,
   "dowdiness/lambda" @parser,
   "dowdiness/pretty",
   "moonbitlang/core/debug",

--- a/cmd/main/repl.mbt
+++ b/cmd/main/repl.mbt
@@ -5,15 +5,25 @@
 ///| Provides interactive commands for editing and testing
 
 ///|
+let next_repl_source_identity : Ref[Int] = { val: 0 }
+
+///|
 /// REPL state holding the editor
 struct ReplState {
   editor : @editor.Editor
+  source_id : @loomcore.SourceId
 }
 
 ///|
 /// Create a new REPL state
 fn ReplState::new(agent_id : String) -> ReplState raise @text.TextError {
-  { editor: @editor.Editor::new(agent_id) }
+  let editor = @editor.Editor::new(agent_id)
+  let identity = next_repl_source_identity.val
+  next_repl_source_identity.val = identity + 1
+  {
+    editor,
+    source_id: @loomcore.SourceId("canopy-repl:" + identity.to_string()),
+  }
 }
 
 ///|
@@ -68,7 +78,7 @@ fn with_parsed_ast(state : ReplState, f : (@parser.Term) -> Unit) -> Unit {
     println("(empty)")
   } else {
     try {
-      let ast = @parser.parse(text)
+      let ast = @parser.parse(state.source_id, text)
       f(ast)
     } catch {
       err => println("Parse error: \{err}")

--- a/cmd/main/repl_wbtest.mbt
+++ b/cmd/main/repl_wbtest.mbt
@@ -1,0 +1,6 @@
+///|
+test "REPL source identity is construction-scoped" {
+  let repl_a = ReplState::new("same-agent")
+  let repl_b = ReplState::new("same-agent")
+  inspect(repl_a.source_id == repl_b.source_id, content="false")
+}

--- a/docs/plans/2026-07-31-source-aware-diagnostics.md
+++ b/docs/plans/2026-07-31-source-aware-diagnostics.md
@@ -1,0 +1,295 @@
+# Source-aware Loom diagnostics
+
+Status: Design reviewed; Canopy projection approved by the user on 2026-07-31
+
+Canonical issue: [#1035](https://github.com/dowdiness/canopy/issues/1035)
+
+## Goal
+
+Replace Loom's source-less primary range and unstyled related ranges with one
+neutral label model whose locations remain correct when a diagnostic relates to
+more than one source. Preserve the existing parser-owned diagnostic lifecycle,
+UTF-16 offset convention, and Canopy protocol boundary.
+
+This plan does not add source text, fixes, a renderer, semantic diagnostics, or
+an analysis-projection diagnostic fact. Those remain sequenced through #1036,
+#1037, #1038, and #1039.
+
+## Current boundary
+
+Loom currently validates non-negative `TextOffset` values and half-open
+`TextRange` values, but `Diagnostic.primary`, `DiagnosticLabel.range`, and
+token evidence have no source identity. All offset/relex transforms therefore
+treat every range as if it belonged to the edited source. Parser replay and its
+logical deduplication key likewise compare numeric ranges without a source.
+
+Canopy's current editor projection has a narrower contract: one source-less
+`from`/`to` range per protocol diagnostic. It consumes only parser diagnostics,
+and the normal parser producer currently supplies zero or one primary range.
+The protocol deliberately contains no Loom token, CST, entity, or parser
+evidence.
+
+## Model and invariants
+
+### Source identity
+
+`SourceId` is an opaque string key with exact value equality and hashing. It is
+not a `DiagnosticSource`: producer identity and source identity remain distinct
+types and fields. The value is neither normalized nor derived from a diagnostic
+message, producer name, label order, or presentation artifact.
+
+The proposed identity scope is a diagnostic/source-provider snapshot rather
+than a globally unique file registry. A caller must keep one key stable for the
+same logical source throughout construction, shifting, replay, and rendering.
+Different keys are always different sources even when their text or numeric
+ranges are equal. A parser stores an explicit source ID for its current source;
+the generic model does not store source text.
+
+The ID is passed explicitly through the complete parser ownership chain. The
+public high-level parser factories, low-level `Parser`/`SyntaxParser` and
+`ImperativeParser` constructors, parser entry points and contexts, standalone
+`TokenBuffer` constructors, and block-reparse entry point all receive a
+`SourceId`; no source-less overload remains. `ImperativeParser` owns the ID for
+the lifetime of one logical source and supplies it to full and incremental
+language callbacks. `TokenBuffer` stores the same ID and uses it whenever it
+qualifies relex damage. Standalone `LexResult` adapters that create ranged
+diagnostics also require the caller's ID. Resetting or editing source text does
+not change the stored ID.
+
+### Valid spans
+
+`SourceSpan` contains one `SourceId` and one existing `TextRange`. Its fields are
+private and its named constructor can only receive an already validated range.
+Consequently negative offsets and `end < start` continue to fail through
+`TextOffset`/`TextRange`; zero-width spans remain valid. Bounds, missing-provider
+sources, and surrogate-interior boundaries require source text and therefore
+remain provider/adapter validation for #1036.
+
+All offsets remain half-open UTF-16 code-unit offsets. No byte, scalar-value,
+line/column, or grapheme conversion enters this model.
+
+### Styled labels and primary locations
+
+`DiagnosticLabel` contains private `style`, `span`, and optional `message`
+fields. `LabelStyle` has exactly `Primary` and `Secondary`. Its constructor and
+accessors preserve all three values unchanged.
+
+`Diagnostic` removes the source-less `primary` field. Its only public source
+locations are styled labels. Zero, one, or multiple primary labels are valid;
+array position does not confer primary status. Token evidence remains
+producer-native, but its range becomes a source-aware span so a source-scoped
+transform cannot corrupt it.
+
+The parser producer creates a primary label and token evidence with the same
+explicit parser source ID. Locationless parser/lexer infrastructure failures
+remain representable with no labels.
+
+### Private storage and defensive copies
+
+`Diagnostic`, `DiagnosticLabel`, `SourceSpan`, `SourceEdit`, and token evidence
+use private fields with named constructors and accessors. The `Diagnostic`
+constructor copies incoming label and note arrays. Its label/note accessors
+return copies. `DiagnosticSet::items()` and `copy()` retain their existing outer
+array copy boundary. No accessor exposes an internally stored mutable array.
+
+### Source-qualified edits
+
+`SourceEdit` contains private `source_id` and existing parser `Edit` values. It
+does not duplicate damage arithmetic or replacement text. Public diagnostic
+offset/relex operations take either the edited `SourceId` explicitly or a
+`SourceEdit`; the old source-less forms are removed without shims.
+
+For an edit to source A, disposition is classified from labels whose source ID
+equals A:
+
+- labels in another source are ignored by disposition and preserved exactly;
+- A labels before the damage are preserved;
+- A labels after the damage are shifted by the existing delta rule;
+- any overlapping A label drops the complete diagnostic;
+- a diagnostic with no A label is preserved unchanged.
+
+Token evidence does not independently cause a drop: the issue defines
+preserve/shift/drop from labels. When A labels select `Shift`, same-source token
+evidence shifts with them; when the diagnostic is preserved because it has no A
+label, all token evidence is preserved unchanged. Parser-produced token
+evidence shares its explicit source with its primary label, so its normal
+lifecycle remains coherent without inventing a second invalidation policy.
+
+Existing insertion-boundary behavior remains: zero-width evidence at the
+insertion point and evidence crossing it shift, while evidence ending at the
+insertion point remains before the edit. Source IDs, label styles, label
+messages, notes, severity, code, and producer identity never change during a
+transform.
+
+Block-reparse offsetting and TokenBuffer relexing construct source-qualified
+damage values. Parser replay examines primary labels for the parser's stored
+source ID, and its deduplication key includes styled source spans while still
+allowing refreshed token evidence.
+
+### Formatting compatibility
+
+Legacy `format()` and `format_with_line_col()` remain compact compatibility
+surfaces, not the new multi-source renderer. For the existing parser shape of
+exactly one primary label, they preserve the current `message [start,end]` and
+line/column output. A diagnostic with no primary remains message-only. The
+source-backed, all-label rendering contract belongs exclusively to #1036.
+
+## Caller cutover
+
+Loom constructors, parser recovery, replay, block reparse, token-buffer relex,
+Lambda rename diagnostics, Markdown diagnostics, Graph DSL attachment and
+one-shot projection entry points, tests, and facade re-exports migrate
+together. Accessors replace direct field reads. There is no public source-less
+diagnostic shift/drop/relex API after the cutover.
+
+Canopy's `view_updater` migrates from the removed public fields to accessors and
+explicit styled source spans. The independent Markdown FFI `SetDiagnostics`
+producer migrates under the same approved current-source projection policy and
+gains equivalent range/severity/code/clearing coverage; it must not keep
+flattening every result to a `0..0` formatted string. `SyncEditor::get_errors()`
+continues to use the legacy compact formatter. Diagnostics remain outside
+`AnalysisProjection`, and the independent semantic protocol producer remains
+untouched until #1039.
+
+The separately rooted Canvas Graph DSL shell allocates one namespaced source ID
+from its append-only handle at construction, passes it to the attachment, and
+reuses it across source edits. The ID is neither the mutable Graph DSL source
+text nor a producer identity. JS-target Canvas compilation and focused tests
+are part of the caller-cutover gate because the root workspace does not include
+that module.
+
+## Approved Canopy projection
+
+The issue requires multiple primary labels and multiple sources to be
+representable, but the existing Canopy protocol can carry only one source-less
+range per diagnostic. The issue does not define how that richer Loom value is
+projected to this narrower current-document wire type. Selecting a label merely
+because it is first would violate the no-list-position inference rule.
+
+The narrow proposed policy is:
+
+- use a stable, provider-snapshot-scoped parser ID for the current document;
+- emit one existing protocol diagnostic for every `Primary` label whose source
+  equals the current parser source;
+- preserve the existing single item for the normal one-primary parser case;
+- emit one `0..0` item only for a truly locationless diagnostic;
+- do not project labels belonging only to another source into the current
+  editor;
+- retain all labels in Loom for the source-backed renderer introduced by #1036;
+- do not change the protocol wire shape in #1035.
+
+This policy preserves every current-source primary without inferring a location
+from array order. Because it is a material adapter behavior not stated in
+#1035, it was explicitly approved by the user before implementation.
+
+### Canopy boundary matrix
+
+| Loom labels | Current-source primary labels | Protocol result |
+| --- | ---: | --- |
+| none | 0 | one compatibility item at `0..0` |
+| one current primary | 1 | one item with that range |
+| multiple current primaries | multiple | one ordered item per primary |
+| current secondary only | 0 | no item |
+| other-source labels only | 0 | no item |
+| current and other-source labels | current primary count | only the current primaries |
+
+Every emitted item preserves the diagnostic message, severity, and optional
+code. Secondary labels and other-source labels remain in Loom for later
+source-backed rendering; neither list position nor presentation text supplies a
+wire location. The editor and Markdown FFI share one deterministic projection
+helper. A `SyncEditor` allocates its source identity once at construction and
+reuses it for parser creation and every snapshot; direct one-shot language
+entry points require an explicit caller-owned identity. No protocol field or
+TypeScript adapter shape changes in this issue.
+
+## Existing API First
+
+Reused:
+
+- `TextOffset` and `TextRange` for validation, UTF-16 units, half-open ranges,
+  and checked offsetting;
+- `Edit` for parser damage and delta arithmetic;
+- `Option` mapping/pattern matching for optional code, messages, and evidence;
+- `Array::copy`, `Array::map`, `Array::filter`, and search/fold operations for
+  defensive copies and declarative label selection;
+- Canopy's existing process-local editor construction counter as the allocation
+  seed for a separately typed and namespaced parser `SourceId`; the value is
+  allocated once before parser construction and is never derived from the CRDT
+  agent, producer, text, projection, entity, or presentation state;
+- `DiagnosticSet::items()` and `Diagnostic::labels()` defensive copies plus
+  `Iter::flat_map`, `Iter::filter`, `Iter::map`, and `Iter::to_array` for the
+  ordered current-source protocol projection;
+- existing relex disposition, parser replay, and `DiagnosticSet` ordering and
+  deduplication structure;
+- the Canvas source registry's append-only handle as the construction identity
+  seed for the separately rooted Graph DSL attachment; no second mutable
+  counter or lookup collection is needed.
+
+Checked but not reused:
+
+- generic `Range` has public unvalidated `Int` fields and no source identity;
+- the Graph DSL example's private-package `SourceSpan` has raw offsets and no
+  source identity or validation;
+- projection IDs, interning IDs, CRDT peer IDs, and `DiagnosticSource` identify
+  different domains and must not become source IDs;
+- `Map` and `Set` are unnecessary because transforms operate independently over
+  the existing ordered label array;
+- `ArrayView` and `Iter` are available, but owning defensive copies are required
+  at the public boundary;
+- `cmp` helpers and sorting are unnecessary because #1035 neither normalizes nor
+  orders labels and does not compute unions;
+- generic overlap helpers are unnecessary because the existing half-open relex
+  disposition already defines insertion and deletion boundary behavior.
+
+The existing generic editor and Markdown FFI conversions are inline, divergent
+adapter code rather than reusable APIs. One new pure
+`project_diagnostics_for_source(SourceId, DiagnosticSet)` helper therefore owns
+only the Loom-to-existing-protocol narrowing policy. `Parser::source_id()`
+remains the authoritative identity store; `SyncEditor` exposes it without
+duplicating mutable state.
+
+The private pure `source_graph_source_id(Int)` helper owns only the Canvas
+handle namespace conversion. It is necessary because the separate JS-only
+module must pass the same construction identity to `GraphAttachment` and its
+focused lifecycle test without adding a second mutable counter, retaining a
+duplicate field, or deriving identity from source text.
+
+New type responsibility boundaries:
+
+- `SourceId`: opaque equality-stable source key only;
+- `SourceSpan`: pair an existing validated range with its source key;
+- `DiagnosticLabel`: preserve presentation-neutral style, span, and message;
+- `SourceEdit`: qualify existing parser damage with the edited source.
+
+No new generic location, source registry, renderer, fix, map, sorting helper, or
+source-text owner is introduced.
+
+## Test-first acceptance map
+
+Focused failing tests precede production edits and cover:
+
+1. an A edit never shifts a B label;
+2. an A edit never drops a diagnostic for a B overlap;
+3. same-source shift/drop/replay retains existing boundary semantics;
+4. primary/secondary style and label messages survive construction and shifts;
+5. half-open insertion/deletion boundaries, including zero-width EOF;
+6. negative and reversed ranges fail at the validated constructors;
+7. caller mutation of input/output arrays cannot mutate a diagnostic or set;
+8. existing compact formatting remains unchanged for zero/one primary;
+9. multiple labels and 2–4 sources preserve all non-edited sources;
+10. source identity is independent of producer identity;
+11. same numeric ranges in different sources do not deduplicate;
+12. parser replay shifts only parser-source evidence.
+
+Property tests generate 2–4 source IDs and compare the transformed result with
+a reference classification that changes only the selected source.
+
+## Validation
+
+Each MoonBit file edit is followed immediately by the narrowest applicable
+`NEW_MOON_MOD=0 moon check`. Final Loom validation runs focused core/parser
+tests, the full Loom suite, `moon info`, `moon fmt`, and interface-diff review.
+After the Loom PR merges, Canopy updates only to the published Loom merge commit
+and runs its focused editor tests plus the full workspace checks. Concrete A/B
+shift, drop, deduplication, replay, and defensive-copy scenarios are retained as
+execution evidence.

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -26,6 +26,8 @@ pub fn[T : @pretty.Pretty] compute_pretty_patches(ViewUpdateState, SyncEditor[T]
 
 pub fn[T : @dowdiness/loom/core.Renderable] compute_view_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch]
 
+pub fn project_diagnostics_for_source(@dowdiness/loom/core.SourceId, @dowdiness/loom/core.DiagnosticSet) -> Array[@protocol.Diagnostic]
+
 // Errors
 pub(all) suberror TreeEditError {
   ExpectedJsonObject
@@ -122,13 +124,14 @@ pub fn[T] SyncEditor::move_cursor_left_word(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_word(Self[T]) -> Unit
 pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], TreeEditError]
-pub fn[T] SyncEditor::new_generic(String, (String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : LanguageCapabilities[T], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> Self[T] raise @text.TextError
+pub fn[T] SyncEditor::new_generic(String, (@dowdiness/loom/core.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : LanguageCapabilities[T], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> Self[T] raise @text.TextError
 pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId?
 pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T]
 pub fn[T] SyncEditor::parser_diagnostics(Self[T]) -> @cells.Derived[@dowdiness/loom/core.DiagnosticSet]
 pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime
 pub fn[T] SyncEditor::parser_source(Self[T]) -> @cells.Derived[String]
+pub fn[T] SyncEditor::parser_source_id(Self[T]) -> @dowdiness/loom/core.SourceId
 pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Derived[@seam.SyntaxNode]
 pub fn[T : Eq] SyncEditor::redo(Self[T]) -> Bool
 pub fn[T : Eq] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage?

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -34,12 +34,13 @@ pub struct SyncEditor[T] {
 ///|
 /// Generic constructor for all languages.
 /// Raises `TextError::EmptyReplicaId` when `agent_id` is empty.
-/// `make_parser` builds a `@loom.Parser[T]` from an initial source string.
+/// `make_parser` builds a `@loom.Parser[T]` from the editor's stable source ID
+/// and initial source string.
 /// `build_memos` receives the parser handle and returns the 3 projection memos
 /// (ProjNode, registry, SourceMap) it wants SyncEditor to own.
 pub fn[T] SyncEditor::new_generic(
   agent_id : String,
-  make_parser : (String, @incr.Runtime?) -> @loom.Parser[T],
+  make_parser : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[T],
   build_memos : (@loom.Parser[T]) -> (
     @incr.Derived[@core.ProjNode[T]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
@@ -59,7 +60,11 @@ pub fn[T] SyncEditor::new_generic(
     Some(r) => r
     None => Ref([])
   }
-  let parser = make_parser("", parent_runtime)
+  let identity = next_editor_identity()
+  let source_id = @loom_core.SourceId(
+    "canopy-sync-editor:" + identity.to_string(),
+  )
+  let parser = make_parser(source_id, "", parent_runtime)
   let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
   {
@@ -78,7 +83,7 @@ pub fn[T] SyncEditor::new_generic(
     session: @sync_session.SyncSession::SyncSession(),
     projection_dirty: false,
     pending_transforms,
-    identity: next_editor_identity(),
+    identity,
   }
 }
 

--- a/editor/sync_editor_accessors_test.mbt
+++ b/editor/sync_editor_accessors_test.mbt
@@ -26,3 +26,16 @@ test "SyncEditor exposes typed accessors for protected cells" {
   let source_map_cell : @incr.Derived[@core.SourceMap] = editor.source_map_memo()
   let _ = source_map_cell.read_or_abort()
 }
+
+///|
+test "SyncEditor source identity is construction-scoped and stable across edits" {
+  let first = try! @probe.new_test_editor("shared-agent")
+  let second = try! @probe.new_test_editor("shared-agent")
+  let initial : @loom_core.SourceId = first.parser_source_id()
+
+  inspect(initial == second.parser_source_id(), content="false")
+  first.set_text("x")
+  inspect(first.parser_source_id() == initial, content="true")
+  first.apply_text_edit(1, 0, "y", 1)
+  inspect(first.parser_source_id() == initial, content="true")
+}

--- a/editor/sync_editor_parser.mbt
+++ b/editor/sync_editor_parser.mbt
@@ -125,6 +125,14 @@ pub fn[T] SyncEditor::parser_runtime(self : SyncEditor[T]) -> @incr.Runtime {
 }
 
 ///|
+/// Stable source identity owned by this editor's parser.
+pub fn[T] SyncEditor::parser_source_id(
+  self : SyncEditor[T],
+) -> @loom_core.SourceId {
+  self.parser.source_id()
+}
+
+///|
 /// Reactive view of the parser's recovered CST. Tracked when `.get_or_abort()`
 /// inside a memo closure.
 pub fn[T] SyncEditor::parser_syntax_tree(

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -59,6 +59,54 @@ pub fn[T : @loom_core.Renderable] SyncEditor::get_view_tree(
 }
 
 ///|
+/// Narrow Loom diagnostics to the existing current-document protocol shape.
+/// Label and diagnostic order are preserved. A truly locationless diagnostic
+/// keeps the compatibility `0..0` range; labeled diagnostics emit only primary
+/// labels belonging to `source_id`.
+pub fn project_diagnostics_for_source(
+  source_id : @loom_core.SourceId,
+  diagnostics : @loom_core.DiagnosticSet,
+) -> Array[@protocol.Diagnostic] {
+  diagnostics
+  .items()
+  .iter()
+  .flat_map(diagnostic => {
+    let severity = match diagnostic.severity() {
+      @loom_core.DiagnosticSeverity::Error => @protocol.SevError
+      @loom_core.DiagnosticSeverity::Warning => @protocol.SevWarning
+      @loom_core.DiagnosticSeverity::Info => @protocol.SevInfo
+      @loom_core.DiagnosticSeverity::Hint => @protocol.SevHint
+    }
+    let code = diagnostic.code().map(code => code.value())
+    let protocol_diagnostic = (from, to) => {
+      @protocol.Diagnostic(
+        from~,
+        to~,
+        severity~,
+        message=diagnostic.message(),
+        code?,
+      )
+    }
+    let labels = diagnostic.labels()
+    if labels.is_empty() {
+      Iter::singleton(protocol_diagnostic(0, 0))
+    } else {
+      labels
+      .iter()
+      .filter(label => {
+        label.style() == @loom_core.LabelStyle::Primary &&
+        label.span().source_id() == source_id
+      })
+      .map(label => {
+        let range = label.span().range()
+        protocol_diagnostic(range.start().value(), range.end().value())
+      })
+    }
+  })
+  .to_array()
+}
+
+///|
 pub fn[T : @loom_core.Renderable] compute_view_patches(
   state : ViewUpdateState,
   editor : SyncEditor[T],
@@ -87,28 +135,11 @@ pub fn[T : @loom_core.Renderable] compute_view_patches(
       }
   }
   state.previous_decorations = Some(current_decorations)
-  let parser_diagnostics = editor.parser_diagnostics().read_or_abort().items()
-  if !parser_diagnostics.is_empty() {
-    let diagnostics = parser_diagnostics.map(diagnostic => {
-      let (from, to) = match diagnostic.primary {
-        Some(range) => (range.start().value(), range.end().value())
-        None => (0, 0)
-      }
-      let severity = match diagnostic.severity {
-        @loom_core.DiagnosticSeverity::Error => @protocol.SevError
-        @loom_core.DiagnosticSeverity::Warning => @protocol.SevWarning
-        @loom_core.DiagnosticSeverity::Info => @protocol.SevInfo
-        @loom_core.DiagnosticSeverity::Hint => @protocol.SevHint
-      }
-      let code = diagnostic.code.map(code => code.value())
-      @protocol.Diagnostic(
-        from~,
-        to~,
-        severity~,
-        message=diagnostic.message,
-        code?,
-      )
-    })
+  let diagnostics = project_diagnostics_for_source(
+    editor.parser.source_id(),
+    editor.parser_diagnostics().read_or_abort(),
+  )
+  if !diagnostics.is_empty() {
     patches.push(@protocol.ViewPatch::SetDiagnostics(diagnostics~))
     state.had_errors = true
   } else if state.had_errors {

--- a/editor/view_updater_test.mbt
+++ b/editor/view_updater_test.mbt
@@ -170,6 +170,115 @@ test "structural edit produces ReplaceNode" {
 }
 
 ///|
+test "diagnostic projection emits only current-source primary labels in order" {
+  let current_source = @loom_core.SourceId("current")
+  let other_source = @loom_core.SourceId("other")
+  let severity = @loom_core.Diagnostic::lexer_error("fixture").severity()
+  let current_primary = (start, end) => {
+    @loom_core.DiagnosticLabel(
+      @loom_core.LabelStyle::Primary,
+      @loom_core.SourceSpan(
+        current_source,
+        try! @loom_core.TextRange::from_offsets(start, end),
+      ),
+      None,
+    )
+  }
+  let diagnostic = @loom_core.Diagnostic(
+    source=@loom_core.DiagnosticSource::parser(),
+    severity~,
+    code=Some(@loom_core.DiagnosticCode("test.mixed-sources")),
+    message="mixed source labels",
+    labels=[
+      current_primary(1, 2),
+      @loom_core.DiagnosticLabel(
+        @loom_core.LabelStyle::Primary,
+        @loom_core.SourceSpan(
+          other_source,
+          try! @loom_core.TextRange::from_offsets(3, 4),
+        ),
+        None,
+      ),
+      @loom_core.DiagnosticLabel(
+        @loom_core.LabelStyle::Secondary,
+        @loom_core.SourceSpan(
+          current_source,
+          try! @loom_core.TextRange::from_offsets(5, 6),
+        ),
+        Some("related"),
+      ),
+      current_primary(7, 9),
+    ],
+  )
+
+  let projected = @editor.project_diagnostics_for_source(
+    current_source,
+    @loom_core.DiagnosticSet::single(diagnostic),
+  )
+
+  guard projected is [first, second] else {
+    fail("expected two current-source primary diagnostics")
+  }
+  inspect(first.from, content="1")
+  inspect(first.to, content="2")
+  inspect(second.from, content="7")
+  inspect(second.to, content="9")
+  @debug.assert_eq(first.severity, @protocol.SevError)
+  inspect(first.message, content="mixed source labels")
+  @debug.assert_eq(first.code, Some("test.mixed-sources"))
+}
+
+///|
+test "diagnostic projection keeps locationless compatibility at zero width" {
+  let source_id = @loom_core.SourceId("current")
+  let projected = @editor.project_diagnostics_for_source(
+    source_id,
+    @loom_core.DiagnosticSet::single(
+      @loom_core.Diagnostic::lexer_error("locationless"),
+    ),
+  )
+
+  guard projected is [diagnostic] else {
+    fail("expected one locationless diagnostic")
+  }
+  inspect(diagnostic.from, content="0")
+  inspect(diagnostic.to, content="0")
+  @debug.assert_eq(diagnostic.severity, @protocol.SevError)
+  inspect(diagnostic.message, content="locationless")
+  @debug.assert_eq(diagnostic.code, Some("lex-error"))
+}
+
+///|
+test "diagnostic projection omits foreign-only labeled diagnostics" {
+  let current_source = @loom_core.SourceId("current")
+  let other_source = @loom_core.SourceId("other")
+  let diagnostic = @loom_core.Diagnostic(
+    source=@loom_core.DiagnosticSource::parser(),
+    severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+    message="foreign location",
+    labels=[
+      @loom_core.DiagnosticLabel(
+        @loom_core.LabelStyle::Primary,
+        @loom_core.SourceSpan(
+          other_source,
+          try! @loom_core.TextRange::from_offsets(3, 4),
+        ),
+        None,
+      ),
+    ],
+  )
+
+  let projected = @editor.project_diagnostics_for_source(
+    current_source,
+    @loom_core.DiagnosticSet::single(diagnostic),
+  )
+
+  guard projected is [] else {
+    fail("foreign-only labels must not be projected into the current source")
+  }
+}
+
+///|
 test "parser diagnostic preserves EOF range severity message and code" {
   let editor = try! @probe.new_test_editor("test")
   editor.set_text("foo(") // unclosed '(' at UTF-16 EOF offset 4

--- a/examples/canvas/main/graph_dsl_adapter.mbt
+++ b/examples/canvas/main/graph_dsl_adapter.mbt
@@ -26,9 +26,17 @@ struct SourceBackedGraph {
 }
 
 ///|
-fn SourceBackedGraph::SourceBackedGraph(source : String) -> SourceBackedGraph {
+fn source_graph_source_id(handle : Int) -> @core.SourceId {
+  @core.SourceId("canopy-canvas-source-graph:" + handle.to_string())
+}
+
+///|
+fn SourceBackedGraph::SourceBackedGraph(
+  source_id : @core.SourceId,
+  source : String,
+) -> SourceBackedGraph {
   {
-    attachment: @graph_dsl.GraphAttachment::GraphAttachment(source),
+    attachment: @graph_dsl.GraphAttachment::GraphAttachment(source_id, source),
     source,
     viewport: default_source_graph_viewport(),
     interaction: @graph_model.empty_interaction(),
@@ -1001,8 +1009,10 @@ pub fn sample_graph_dsl_source() -> String {
 
 ///|
 pub fn create_source_graph(source : String) -> Int {
-  _source_registry.push(Some(SourceBackedGraph(source)))
-  _source_registry.length() - 1
+  let handle = _source_registry.length()
+  let source_id = source_graph_source_id(handle)
+  _source_registry.push(Some(SourceBackedGraph(source_id, source)))
+  handle
 }
 
 ///|

--- a/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
+++ b/examples/canvas/main/graph_dsl_adapter_wbtest.mbt
@@ -2,6 +2,11 @@
 const GRAPH_DSL_SAMPLE = "osc = sine(freq: 440Hz, wave: \"saw\") -> audio\nfilter = lowpass(input: osc, cutoff: 1200Hz, mode: warm)"
 
 ///|
+let graph_dsl_adapter_test_source : @core.SourceId = @core.SourceId(
+  "canopy-test:canvas:graph-dsl-adapter",
+)
+
+///|
 fn ok_graph_doc(
   result : Result[@graph_dsl.GraphDoc, Array[String]],
 ) -> @graph_dsl.GraphDoc {
@@ -142,7 +147,12 @@ fn required_canvas_id_for_binding(
 
 ///|
 test "graph-dsl projection maps into the canvas graph view model" {
-  let doc = ok_graph_doc(@graph_dsl.project_graph_source(GRAPH_DSL_SAMPLE))
+  let doc = ok_graph_doc(
+    @graph_dsl.project_graph_source(
+      graph_dsl_adapter_test_source,
+      GRAPH_DSL_SAMPLE,
+    ),
+  )
   let canvas = canvas_from_graph_doc(doc)
   match canvas.nodes {
     [osc, filter] => {
@@ -235,8 +245,23 @@ test "source-backed compatibility export rejects invalid current source" {
 }
 
 ///|
+test "source-backed graphs own stable distinct source identities" {
+  let handle_a = create_source_graph("osc = sine(freq: 440Hz)")
+  let handle_b = create_source_graph("meter = scope()")
+  let source_a = source_graph_source_id(handle_a)
+  inspect(source_a == source_graph_source_id(handle_b), content="false")
+  set_source_graph_source(handle_a, "osc = sine(freq: 880Hz)")
+  inspect(source_graph_source_id(handle_a) == source_a, content="true")
+  destroy_source_graph(handle_a)
+  destroy_source_graph(handle_b)
+}
+
+///|
 test "SetParam lowers to an exact source edit and preserves graph ids" {
-  let attachment = @graph_dsl.GraphAttachment::GraphAttachment(GRAPH_DSL_SAMPLE)
+  let attachment = @graph_dsl.GraphAttachment::GraphAttachment(
+    @core.SourceId("canopy-test:canvas:set-param"),
+    GRAPH_DSL_SAMPLE,
+  )
   let before = ok_current_graph_doc(attachment.current_result())
   let osc_id = graph_node_id(before, "osc")
   let filter_id = graph_node_id(before, "filter")
@@ -265,14 +290,19 @@ test "SetParam lowers to an exact source edit and preserves graph ids" {
 ///|
 test "ConnectPorts and AddNode lower through source and reparse to canvas graph" {
   let source = "osc = sine(freq: 440Hz)\nmeter = scope()"
-  let doc = ok_graph_doc(@graph_dsl.project_graph_source(source))
+  let doc = ok_graph_doc(
+    @graph_dsl.project_graph_source(graph_dsl_adapter_test_source, source),
+  )
   let connect = ok_lowered(doc.lower_add_connection("meter", "osc"))
   inspect(
     connect.new_source(),
     content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)",
   )
   let connected = ok_graph_doc(
-    @graph_dsl.project_graph_source(connect.new_source()),
+    @graph_dsl.project_graph_source(
+      graph_dsl_adapter_test_source,
+      connect.new_source(),
+    ),
   )
   let connected_canvas = canvas_from_graph_doc(connected)
   match connected_canvas.edges {
@@ -297,7 +327,10 @@ test "ConnectPorts and AddNode lower through source and reparse to canvas graph"
     content="osc = sine(freq: 440Hz)\nmeter = scope(input: osc)\nreverb = plate()",
   )
   let inserted = ok_graph_doc(
-    @graph_dsl.project_graph_source(insert.new_source()),
+    @graph_dsl.project_graph_source(
+      graph_dsl_adapter_test_source,
+      insert.new_source(),
+    ),
   )
   let inserted_canvas = canvas_from_graph_doc(inserted)
   match inserted_canvas.nodes {
@@ -1048,7 +1081,10 @@ test "source-backed CodeMirror edit reparses editor text when source diverged" {
 
 ///|
 test "invalid source keeps last-good canvas graph available" {
-  let attachment = @graph_dsl.GraphAttachment::GraphAttachment(GRAPH_DSL_SAMPLE)
+  let attachment = @graph_dsl.GraphAttachment::GraphAttachment(
+    @core.SourceId("canopy-test:canvas:last-good"),
+    GRAPH_DSL_SAMPLE,
+  )
   let good = ok_current_graph_doc(attachment.current_result())
   let good_canvas = canvas_from_graph_doc(good)
 

--- a/ffi/jsx/jsx_ffi.mbt
+++ b/ffi/jsx/jsx_ffi.mbt
@@ -74,7 +74,10 @@ fn proj_node_to_json(node : @canopy_core.ProjNode[@jsx_ast.JsxNode]) -> Json {
 /// The JSON includes node_ids, kind tags, and structural info so the demo
 /// page can highlight stable-vs-new NodeIds across streaming re-parses.
 pub fn jsx_parse_to_json(text : String) -> String {
-  let (proj, errors) = @jsx_proj.parse_to_proj_node(text) catch {
+  let (proj, errors) = @jsx_proj.parse_to_proj_node(
+    allocate_jsx_source_id(),
+    text,
+  ) catch {
     _ =>
       return Json::object({
         "success": Json::boolean(false),
@@ -103,14 +106,15 @@ pub fn jsx_streaming_to_json(prefixes_input : String) -> String {
   if parts.is_empty() {
     return Json::array([]).stringify()
   }
-  let parser = @loom.new_parser(parts[0], @jsx_ast.jsx_grammar)
+  let source_id = allocate_jsx_source_id()
+  let parser = @loom.new_parser(source_id, parts[0], @jsx_ast.jsx_grammar)
   let (proj_memo, _, _) = @jsx_proj.build_jsx_projection_memos(parser)
   let results : Array[Json] = for i in 0..<parts.length(); acc = [] {
     let prefix = parts[i]
     if i > 0 {
       parser.set_source(prefix)
     }
-    let errors : Array[String] = get_or_empty_errors(prefix)
+    let errors : Array[String] = get_or_empty_errors(source_id, prefix)
     let step = match proj_memo.read_or_abort() {
       Some(proj) =>
         Json::object({
@@ -137,9 +141,12 @@ pub fn jsx_streaming_to_json(prefixes_input : String) -> String {
 ///|
 /// Parse text just to extract diagnostic errors (side-channel from the shared
 /// parser's stream). Returns empty array on LexError.
-fn get_or_empty_errors(text : String) -> Array[String] {
+fn get_or_empty_errors(
+  source_id : @loomcore.SourceId,
+  text : String,
+) -> Array[String] {
   try {
-    let (_, errors) = @jsx_proj.parse_to_proj_node(text)
+    let (_, errors) = @jsx_proj.parse_to_proj_node(source_id, text)
     errors
   } catch {
     _ => []
@@ -152,7 +159,7 @@ fn get_or_empty_errors(text : String) -> Array[String] {
 /// independently on every call and keeps no parser or DOM ownership state.
 pub fn jsx_parse_and_render(text : String, existing_json : String) -> String {
   let parsed : (@canopy_core.ProjNode[@jsx_ast.JsxNode], Array[String])? = Some(
-    @jsx_proj.parse_to_proj_node(text),
+    @jsx_proj.parse_to_proj_node(allocate_jsx_source_id(), text),
   ) catch {
     _ => None
   }

--- a/ffi/jsx/moon.pkg
+++ b/ffi/jsx/moon.pkg
@@ -6,6 +6,7 @@ import {
   "dowdiness/canopy/lang/jsx/proj" @jsx_proj,
   "dowdiness/jsx" @jsx_ast,
   "dowdiness/loom",
+  "dowdiness/loom/core" @loomcore,
   "moonbitlang/async/js_async",
   "moonbitlang/core/json",
   "moonbitlang/core/encoding/utf8",

--- a/ffi/jsx/session.mbt
+++ b/ffi/jsx/session.mbt
@@ -110,7 +110,11 @@ fn session_envelope_json(handle : Int?, result_json : String) -> String {
 
 ///|
 fn new_jsx_session(source : String, root_id : String) -> JsxSession {
-  let parser = @loom.new_parser(source, @jsx_ast.jsx_grammar)
+  let parser = @loom.new_parser(
+    allocate_jsx_source_id(),
+    source,
+    @jsx_ast.jsx_grammar,
+  )
   let (proj_memo, registry_memo, source_map_memo) = @jsx_proj.build_jsx_projection_memos(
     parser,
   )
@@ -310,7 +314,7 @@ fn render_jsx_session_with_projection_read(
       if update_source {
         session.parser.set_source(source)
       }
-      let diagnostics = get_or_empty_errors(source)
+      let diagnostics = get_or_empty_errors(session.parser.source_id(), source)
       let projection_read = match projection_read_override {
         Some(value) => value
         None => read_source_projection(session)

--- a/ffi/jsx/session_contract_wbtest.mbt
+++ b/ffi/jsx/session_contract_wbtest.mbt
@@ -112,6 +112,18 @@ fn session_test_handle(result : @js.Any) -> Int {
 }
 
 ///|
+test "JSX sessions own distinct stable source identities" {
+  let session_a = new_jsx_session("<div />", "same-root")
+  let session_b = new_jsx_session("<div />", "same-root")
+  let source_a = session_a.parser.source_id()
+  inspect(source_a == session_b.parser.source_id(), content="false")
+  session_a.parser.set_source("<span />")
+  inspect(session_a.parser.source_id() == source_a, content="true")
+  dispose_jsx_session(session_a)
+  dispose_jsx_session(session_b)
+}
+
+///|
 test "render result uses the versioned envelope and string mounted ids" {
   let result = render_result_json(
     true,

--- a/ffi/jsx/source_identity.mbt
+++ b/ffi/jsx/source_identity.mbt
@@ -1,0 +1,9 @@
+///|
+let next_jsx_source_identity : Ref[Int] = { val: 0 }
+
+///|
+fn allocate_jsx_source_id() -> @loomcore.SourceId {
+  let identity = next_jsx_source_identity.val
+  next_jsx_source_identity.val = identity + 1
+  @loomcore.SourceId("canopy-jsx-ffi:" + identity.to_string())
+}

--- a/ffi/jsx/source_identity_wbtest.mbt
+++ b/ffi/jsx/source_identity_wbtest.mbt
@@ -1,0 +1,6 @@
+///|
+test "JSX source identity allocator returns distinct construction IDs" {
+  let source_a = allocate_jsx_source_id()
+  let source_b = allocate_jsx_source_id()
+  inspect(source_a == source_b, content="false")
+}

--- a/ffi/markdown/markdown_ffi.mbt
+++ b/ffi/markdown/markdown_ffi.mbt
@@ -242,19 +242,18 @@ pub fn markdown_compute_view_patches_json(handle : Int) -> String {
       return "[]"
     }
   }
-  let parse_errors : Array[String] = if h.editor.get_text() == "" {
-    []
-  } else {
-    match coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
-      Ok(d) => d.format()
-      Err(report) => {
-        println(
-          "markdown_compute_view_patches_json diagnostics read: \{report}",
-        )
-        return "[]"
-      }
+  let parser_diagnostics = match
+    coordinator.read_protected(h.editor_id, h.cells.parser_diagnostics) {
+    Ok(diagnostics) => diagnostics
+    Err(report) => {
+      println("markdown_compute_view_patches_json diagnostics read: \{report}")
+      return "[]"
     }
   }
+  let diagnostics = @editor.project_diagnostics_for_source(
+    h.editor.parser_source_id(),
+    parser_diagnostics,
+  )
   let source_text = h.editor.get_text()
   let current : @protocol.ViewNode? = match proj_opt {
     Some(proj) =>
@@ -276,18 +275,7 @@ pub fn markdown_compute_view_patches_json(handle : Int) -> String {
     (Some(_), None) => patches.push(@protocol.ViewPatch::FullTree(root=None))
     (Some(prev), Some(curr)) => diff_view_nodes(prev, curr, patches)
   }
-  if parse_errors.length() > 0 {
-    let diagnostics : Array[@protocol.Diagnostic] = []
-    for error in parse_errors {
-      diagnostics.push(
-        @protocol.Diagnostic(
-          from=0,
-          to=0,
-          severity=@protocol.SevError,
-          message=error,
-        ),
-      )
-    }
+  if diagnostics.length() > 0 {
     patches.push(@protocol.ViewPatch::SetDiagnostics(diagnostics~))
     state.set_had_errors(true)
   } else if state.had_errors {

--- a/lang/json/companion/json_companion.mbt
+++ b/lang/json/companion/json_companion.mbt
@@ -10,7 +10,9 @@ let json_spec : @lang_runtime.LanguageSpec[
   @json.JsonValue,
   @json_edits.JsonEditOp,
 ] = @lang_runtime.LanguageSpec::LanguageSpec(
-  make_parser=fn(s, rt) { @loom.new_parser(s, @json.json_grammar, runtime?=rt) },
+  make_parser=(source_id, source, runtime) => {
+    @loom.new_parser(source_id, source, @json.json_grammar, runtime?)
+  },
   build_memos=@json_proj.build_json_projection_memos,
   compute_edit=@json_edits.compute_json_edit,
   on_no_edit=op => {

--- a/lang/json/proj/pkg.generated.mbti
+++ b/lang/json/proj/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub fn key_role(Int) -> String
 
 pub fn member_role(Int) -> String
 
-pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@json.JsonValue], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@json.JsonValue], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@json.JsonValue]) -> Unit
 

--- a/lang/json/proj/proj_node.mbt
+++ b/lang/json/proj/proj_node.mbt
@@ -151,11 +151,12 @@ fn extract_member(
 ///|
 /// Parse text and return a ProjNode tree with any diagnostic errors.
 pub fn parse_to_proj_node(
+  source_id : @loomcore.SourceId,
   text : String,
 ) -> (ProjNode[@json.JsonValue], Array[String]) raise @loomcore.LexError {
-  let (cst, diagnostics) = @json.parse_cst(text)
+  let (cst, diagnostics) = @json.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
-  let errors = diagnostics.map(fn(d) { d.message })
+  let errors = diagnostics.map(diagnostic => diagnostic.message())
   let root = syntax_to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }

--- a/lang/json/proj/proj_node_wbtest.mbt
+++ b/lang/json/proj/proj_node_wbtest.mbt
@@ -1,8 +1,13 @@
 // Whitebox tests for JSON projection builder.
 
 ///|
+let json_projection_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:json-projection",
+)
+
+///|
 test "parse null → ProjNode with kind Null, 0 children" {
-  let (proj, errors) = parse_to_proj_node("null")
+  let (proj, errors) = parse_to_proj_node(json_projection_test_source, "null")
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Null")
   inspect(proj.children.length(), content="0")
@@ -12,7 +17,7 @@ test "parse null → ProjNode with kind Null, 0 children" {
 
 ///|
 test "parse number → ProjNode with kind Number" {
-  let (proj, errors) = parse_to_proj_node("42")
+  let (proj, errors) = parse_to_proj_node(json_projection_test_source, "42")
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Number(42)")
   inspect(proj.children.length(), content="0")
@@ -20,7 +25,9 @@ test "parse number → ProjNode with kind Number" {
 
 ///|
 test "parse string → ProjNode with kind String (unescaped)" {
-  let (proj, errors) = parse_to_proj_node("\"hello\"")
+  let (proj, errors) = parse_to_proj_node(
+    json_projection_test_source, "\"hello\"",
+  )
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="String(\"hello\")")
   inspect(proj.children.length(), content="0")
@@ -28,13 +35,17 @@ test "parse string → ProjNode with kind String (unescaped)" {
 
 ///|
 test "parse string with escapes → properly unescaped" {
-  let (proj, _errors) = parse_to_proj_node("\"hello\\nworld\"")
+  let (proj, _errors) = parse_to_proj_node(
+    json_projection_test_source, "\"hello\\nworld\"",
+  )
   inspect(proj.kind, content="String(\"hello\\nworld\")")
 }
 
 ///|
 test "parse array [1, 2, 3] → Array with 3 children" {
-  let (proj, errors) = parse_to_proj_node("[1, 2, 3]")
+  let (proj, errors) = parse_to_proj_node(
+    json_projection_test_source, "[1, 2, 3]",
+  )
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Array([Number(1), Number(2), Number(3)])")
   inspect(proj.children.length(), content="3")
@@ -45,7 +56,9 @@ test "parse array [1, 2, 3] → Array with 3 children" {
 
 ///|
 test "parse object {\"a\": 1, \"b\": true} → Object with 2 children" {
-  let (proj, errors) = parse_to_proj_node("{\"a\": 1, \"b\": true}")
+  let (proj, errors) = parse_to_proj_node(
+    json_projection_test_source, "{\"a\": 1, \"b\": true}",
+  )
   inspect(errors.length(), content="0")
   inspect(proj.children.length(), content="2")
   // First child: key "a", value Number(1)
@@ -61,7 +74,9 @@ test "parse object {\"a\": 1, \"b\": true} → Object with 2 children" {
 
 ///|
 test "parse nested {\"data\": [1, 2]} → correct nesting" {
-  let (proj, errors) = parse_to_proj_node("{\"data\": [1, 2]}")
+  let (proj, errors) = parse_to_proj_node(
+    json_projection_test_source, "{\"data\": [1, 2]}",
+  )
   inspect(errors.length(), content="0")
   inspect(proj.children.length(), content="1")
   // The child is a member with Array value
@@ -74,7 +89,7 @@ test "parse nested {\"data\": [1, 2]} → correct nesting" {
 
 ///|
 test "parse empty object {} → 0 children" {
-  let (proj, errors) = parse_to_proj_node("{}")
+  let (proj, errors) = parse_to_proj_node(json_projection_test_source, "{}")
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Object([])")
   inspect(proj.children.length(), content="0")
@@ -82,7 +97,7 @@ test "parse empty object {} → 0 children" {
 
 ///|
 test "parse empty array [] → 0 children" {
-  let (proj, errors) = parse_to_proj_node("[]")
+  let (proj, errors) = parse_to_proj_node(json_projection_test_source, "[]")
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Array([])")
   inspect(proj.children.length(), content="0")
@@ -90,15 +105,17 @@ test "parse empty array [] → 0 children" {
 
 ///|
 test "parse true / false → Bool" {
-  let (t, _) = parse_to_proj_node("true")
+  let (t, _) = parse_to_proj_node(json_projection_test_source, "true")
   inspect(t.kind, content="Bool(true)")
-  let (f, _) = parse_to_proj_node("false")
+  let (f, _) = parse_to_proj_node(json_projection_test_source, "false")
   inspect(f.kind, content="Bool(false)")
 }
 
 ///|
 test "parse error recovery {\"a\": } → Object with Error child" {
-  let (proj, errors) = parse_to_proj_node("{\"a\": }")
+  let (proj, errors) = parse_to_proj_node(
+    json_projection_test_source, "{\"a\": }",
+  )
   // Should have parse errors
   inspect(errors.length() > 0, content="true")
   // But still produces an Object node
@@ -109,7 +126,9 @@ test "parse error recovery {\"a\": } → Object with Error child" {
 test "object child ProjNode uses value span (not member span)" {
   // "{\"a\": 1}" — the NumberValue node includes leading trivia (space)
   // so it spans [5, 7), not [1, 7) which would be the MemberNode span
-  let (proj, _errors) = parse_to_proj_node("{\"a\": 1}")
+  let (proj, _errors) = parse_to_proj_node(
+    json_projection_test_source, "{\"a\": 1}",
+  )
   let child = proj.children[0]
   // Object starts at 0, ends at 8
   inspect(proj.start, content="0")
@@ -122,7 +141,9 @@ test "object child ProjNode uses value span (not member span)" {
 
 ///|
 test "SourceMap from_ast produces correct ranges" {
-  let (proj, _errors) = parse_to_proj_node("{\"a\": 1, \"b\": 2}")
+  let (proj, _errors) = parse_to_proj_node(
+    json_projection_test_source, "{\"a\": 1, \"b\": 2}",
+  )
   let sm = @core.SourceMap::from_ast(proj)
   // Root + 2 children = 3 nodes
   inspect(sm.node_count(), content="3")
@@ -136,7 +157,9 @@ test "SourceMap from_ast produces correct ranges" {
 ///|
 test "token spans for object keys stored on Object node" {
   let text = "{\"a\": 1, \"b\": 2}"
-  let (cst, _) = @json.parse_cst(text) catch { _ => abort("parse failed") }
+  let (cst, _) = @json.parse_cst(json_projection_test_source, text) catch {
+    _ => abort("parse failed")
+  }
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
   let proj = syntax_to_proj_node(syntax_node, counter)
@@ -156,8 +179,12 @@ test "token spans for object keys stored on Object node" {
 
 ///|
 test "reconcile preserves IDs on value edit" {
-  let (old_proj, _) = parse_to_proj_node("{\"a\": 1, \"b\": 2}")
-  let (new_proj, _) = parse_to_proj_node("{\"a\": 99, \"b\": 2}")
+  let (old_proj, _) = parse_to_proj_node(
+    json_projection_test_source, "{\"a\": 1, \"b\": 2}",
+  )
+  let (new_proj, _) = parse_to_proj_node(
+    json_projection_test_source, "{\"a\": 99, \"b\": 2}",
+  )
   let counter = Ref(100)
   let reconciled = @core.reconcile(old_proj, new_proj, counter)
   // Object kind matches → old root ID preserved
@@ -171,14 +198,14 @@ test "reconcile preserves IDs on value edit" {
 
 ///|
 test "parse floating point number" {
-  let (proj, errors) = parse_to_proj_node("3.14")
+  let (proj, errors) = parse_to_proj_node(json_projection_test_source, "3.14")
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Number(3.14)")
 }
 
 ///|
 test "parse negative number" {
-  let (proj, errors) = parse_to_proj_node("-42")
+  let (proj, errors) = parse_to_proj_node(json_projection_test_source, "-42")
   inspect(errors.length(), content="0")
   inspect(proj.kind, content="Number(-42)")
 }

--- a/lang/jsx/proj/pkg.generated.mbti
+++ b/lang/jsx/proj/pkg.generated.mbti
@@ -17,7 +17,7 @@ pub fn dom_patches_to_json(Array[DomPatch]) -> String
 
 pub fn normalize_dom_attribute_value(String, String) -> String
 
-pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]) -> Unit
 

--- a/lang/jsx/proj/populate_token_spans_wbtest.mbt
+++ b/lang/jsx/proj/populate_token_spans_wbtest.mbt
@@ -1,13 +1,19 @@
-///| Regression tests for populate_token_spans (Task 2.3), including a
+///|
+/// Regression tests for populate_token_spans (Task 2.3), including a
 /// Codex-review-caught bug (2026-07-11): an unclosed element's lone
 /// open-tag `>` was being recorded as its `close_bracket`, and nested
 /// same-tag elements' `close_bracket` disambiguation was unverified.
+let jsx_token_span_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:jsx-token-spans",
+)
 
 ///|
 fn source_map_for(
   text : String,
 ) -> (@core.ProjNode[@jsx.JsxNode], @core.SourceMap) {
-  let parser = @loom.new_parser(text, @jsx.jsx_grammar)
+  let parser = @loom.new_parser(
+    jsx_token_span_test_source, text, @jsx.jsx_grammar,
+  )
   let (proj_memo, _, source_map_memo) = build_jsx_projection_memos(parser)
   let root = proj_memo.read_or_abort().unwrap()
   let source_map = source_map_memo.read_or_abort()

--- a/lang/jsx/proj/proj_node.mbt
+++ b/lang/jsx/proj/proj_node.mbt
@@ -9,11 +9,12 @@
 ///|
 /// Convenience: parse source and project in one call (for tests and REPL).
 pub fn parse_to_proj_node(
+  source_id : @loomcore.SourceId,
   text : String,
 ) -> (@core.ProjNode[@jsx.JsxNode], Array[String]) raise @loomcore.LexError {
-  let (cst, diagnostics) = @jsx.parse_cst(text)
+  let (cst, diagnostics) = @jsx.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
-  let errors = diagnostics.map(fn(d) { d.message })
+  let errors = diagnostics.map(diagnostic => diagnostic.message())
   let root = syntax_to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }

--- a/lang/jsx/proj/proj_node_wbtest.mbt
+++ b/lang/jsx/proj/proj_node_wbtest.mbt
@@ -1,4 +1,8 @@
-///| Whitebox tests for JSX projection (Task 2.2 Step 4 checkpoint).
+///|
+/// Whitebox tests for JSX projection (Task 2.2 Step 4 checkpoint).
+let jsx_projection_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:jsx-projection",
+)
 
 ///|
 test "parse and project basic element" {
@@ -6,7 +10,9 @@ test "parse and project basic element" {
   // prefix can legally have several roots) — the plan's original snippet
   // predates that AST divergence and asserted "Element" directly at the
   // top; check the wrapped element instead.
-  let (root, errors) = parse_to_proj_node("<div>hello</div>")
+  let (root, errors) = parse_to_proj_node(
+    jsx_projection_test_source, "<div>hello</div>",
+  )
   inspect(errors.length(), content="0")
   inspect(root.kind.kind_tag(), content="Root")
   inspect(root.children[0].kind.kind_tag(), content="Element")
@@ -14,14 +20,16 @@ test "parse and project basic element" {
 
 ///|
 test "projection: root wraps top-level nodes" {
-  let (root, _) = parse_to_proj_node("<div/>")
+  let (root, _) = parse_to_proj_node(jsx_projection_test_source, "<div/>")
   inspect(root.kind.kind_tag(), content="Root")
   inspect(root.children.length(), content="1")
 }
 
 ///|
 test "projection: element with text child" {
-  let (root, errors) = parse_to_proj_node("<p>hello world</p>")
+  let (root, errors) = parse_to_proj_node(
+    jsx_projection_test_source, "<p>hello world</p>",
+  )
   inspect(errors.length(), content="0")
   let el = root.children[0]
   inspect(el.children.length(), content="1")
@@ -31,7 +39,7 @@ test "projection: element with text child" {
 ///|
 test "projection: nested elements" {
   let (root, errors) = parse_to_proj_node(
-    "<div><h1>title</h1><p>body</p></div>",
+    jsx_projection_test_source, "<div><h1>title</h1><p>body</p></div>",
   )
   inspect(errors.length(), content="0")
   let div = root.children[0]
@@ -42,7 +50,9 @@ test "projection: nested elements" {
 
 ///|
 test "projection: attrs are excluded from proj children" {
-  let (root, errors) = parse_to_proj_node("<div class=\"a\" id=\"b\">x</div>")
+  let (root, errors) = parse_to_proj_node(
+    jsx_projection_test_source, "<div class=\"a\" id=\"b\">x</div>",
+  )
   inspect(errors.length(), content="0")
   let div = root.children[0]
   // Only the Text child appears — the two attrs must not be counted.
@@ -52,7 +62,9 @@ test "projection: attrs are excluded from proj children" {
 
 ///|
 test "projection: expression span child" {
-  let (root, errors) = parse_to_proj_node("<p>{title}</p>")
+  let (root, errors) = parse_to_proj_node(
+    jsx_projection_test_source, "<p>{title}</p>",
+  )
   inspect(errors.length(), content="0")
   let p = root.children[0]
   inspect(p.children[0].kind.kind_tag(), content="ExprSpan")
@@ -60,7 +72,9 @@ test "projection: expression span child" {
 
 ///|
 test "projection: fragment" {
-  let (root, errors) = parse_to_proj_node("<><span/><span/></>")
+  let (root, errors) = parse_to_proj_node(
+    jsx_projection_test_source, "<><span/><span/></>",
+  )
   inspect(errors.length(), content="0")
   let fragment = root.children[0]
   inspect(fragment.kind.kind_tag(), content="Fragment")
@@ -69,7 +83,9 @@ test "projection: fragment" {
 
 ///|
 test "projection: unclosed element still exposes parsed children" {
-  let (root, errors) = parse_to_proj_node("<div><span>text")
+  let (root, errors) = parse_to_proj_node(
+    jsx_projection_test_source, "<div><span>text",
+  )
   // Design B case 2: diagnostics are pushed, but children are not
   // discarded.
   inspect(errors.length() > 0, content="true")

--- a/lang/jsx/proj/reconcile_wbtest.mbt
+++ b/lang/jsx/proj/reconcile_wbtest.mbt
@@ -1,9 +1,13 @@
-///| Whitebox tests for reconcile — pure DomPatch generation.
+///|
+/// Whitebox tests for reconcile — pure DomPatch generation.
+let jsx_reconcile_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:jsx-reconcile",
+)
 
 ///|
 /// First render produces patches.
 test "reconcile: first render produces patches" {
-  let (root, _) = parse_to_proj_node("<p>hello</p>")
+  let (root, _) = parse_to_proj_node(jsx_reconcile_test_source, "<p>hello</p>")
   let (patches, reached) = reconcile(root, [])
   inspect(patches.length() > 0, content="true")
   inspect(reached.length() > 0, content="true")
@@ -12,7 +16,9 @@ test "reconcile: first render produces patches" {
 ///|
 /// Empty existing set → all nodes new → all Make patches.
 test "reconcile: empty existing produces Make" {
-  let (root, _) = parse_to_proj_node("<span>text</span>")
+  let (root, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<span>text</span>",
+  )
   let (patches, _) = reconcile(root, [])
   for p in patches {
     match p {
@@ -94,7 +100,7 @@ fn count_make_text(patches : Array[DomPatch], expected : String) -> Int {
 ///|
 /// Second render with same text → SetText.
 test "reconcile: existing text produces SetText" {
-  let (root, _) = parse_to_proj_node("<p>hello</p>")
+  let (root, _) = parse_to_proj_node(jsx_reconcile_test_source, "<p>hello</p>")
   let (_, reached) = reconcile(root, [])
   let (patches, _) = reconcile(root, reached)
   inspect(has_patch(patches, "SetText"), content="true")
@@ -104,9 +110,9 @@ test "reconcile: existing text produces SetText" {
 ///|
 /// Text content change → SetText with updated value.
 test "reconcile: text change produces SetText with new value" {
-  let (root, _) = parse_to_proj_node("<p>hello</p>")
+  let (root, _) = parse_to_proj_node(jsx_reconcile_test_source, "<p>hello</p>")
   let (_, reached) = reconcile(root, [])
-  let (root2, _) = parse_to_proj_node("<p>world</p>")
+  let (root2, _) = parse_to_proj_node(jsx_reconcile_test_source, "<p>world</p>")
   let (patches, _) = reconcile(root2, reached)
   inspect(find_text(patches, "world"), content="true")
 }
@@ -114,10 +120,14 @@ test "reconcile: text change produces SetText with new value" {
 ///|
 /// Element with attributes.
 test "reconcile: element attributes" {
-  let (root, _) = parse_to_proj_node("<div class=\"foo\">x</div>")
+  let (root, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<div class=\"foo\">x</div>",
+  )
   let (p1, reached) = reconcile(root, [])
   inspect(has_patch(p1, "MakeElement"), content="true")
-  let (root2, _) = parse_to_proj_node("<div class=\"foo\">x</div>")
+  let (root2, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<div class=\"foo\">x</div>",
+  )
   let (p2, _) = reconcile(root2, reached)
   inspect(has_patch(p2, "SetAttrs"), content="true")
 }
@@ -125,9 +135,9 @@ test "reconcile: element attributes" {
 ///|
 /// Node removed → Release.
 test "reconcile: removed node produces Release" {
-  let (root, _) = parse_to_proj_node("<p>hello</p>")
+  let (root, _) = parse_to_proj_node(jsx_reconcile_test_source, "<p>hello</p>")
   let (_, reached) = reconcile(root, [])
-  let (root2, _) = parse_to_proj_node("<div></div>")
+  let (root2, _) = parse_to_proj_node(jsx_reconcile_test_source, "<div></div>")
   let (patches, _) = reconcile(root2, reached)
   inspect(has_patch(patches, "Release"), content="true")
 }
@@ -135,7 +145,9 @@ test "reconcile: removed node produces Release" {
 ///|
 /// Nested elements produce the mounted DOM node count.
 test "reconcile: nested elements" {
-  let (root, _) = parse_to_proj_node("<div><h1>title</h1><p>body</p></div>")
+  let (root, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<div><h1>title</h1><p>body</p></div>",
+  )
   let (_, reached) = reconcile(root, [])
   inspect(reached.length(), content="5")
 }
@@ -143,7 +155,9 @@ test "reconcile: nested elements" {
 ///|
 /// A trailing `<` is a recoverable parser state, not a valid DOM element.
 test "reconcile: incomplete tag does not produce empty MakeElement" {
-  let (root, _) = parse_to_proj_node("<div><p>text</p>\n<")
+  let (root, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<div><p>text</p>\n<",
+  )
   let (patches, _) = reconcile(root, [])
   for patch in patches {
     match patch {
@@ -185,12 +199,12 @@ test "reconcile: empty-tag recovery is transparent and preserves children" {
 /// cross the DOM mount boundary on the second render.
 test "reconcile: append equal-kind sibling mounts only the tail" {
   let (old_root, _) = parse_to_proj_node(
-    "<div><span>a</span><span>b</span></div>",
+    jsx_reconcile_test_source, "<div><span>a</span><span>b</span></div>",
   )
   let (first_patches, _) = reconcile(old_root, [])
   let existing = patch_ids(first_patches)
   let (new_raw, _) = parse_to_proj_node(
-    "<div><span>a</span><span>b</span><span>c</span></div>",
+    jsx_reconcile_test_source, "<div><span>a</span><span>b</span><span>c</span></div>",
   )
   let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
   let (patches, _) = reconcile(new_root, existing)
@@ -206,11 +220,11 @@ test "reconcile: append equal-kind sibling mounts only the tail" {
 /// Exact duplicate sibling keys preserve existing IDs positionally.
 test "reconcile: duplicate exact siblings preserve identity order" {
   let (old_root, _) = parse_to_proj_node(
-    "<div><span>a</span><span>a</span></div>",
+    jsx_reconcile_test_source, "<div><span>a</span><span>a</span></div>",
   )
   let old_div = old_root.children[0]
   let (new_raw, _) = parse_to_proj_node(
-    "<div><span>a</span><span>a</span><span>a</span></div>",
+    jsx_reconcile_test_source, "<div><span>a</span><span>a</span><span>a</span></div>",
   )
   let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
   let new_div = new_root.children[0]
@@ -228,11 +242,11 @@ test "reconcile: duplicate exact siblings preserve identity order" {
 /// Removing an exact duplicate preserves the earliest existing identities.
 test "reconcile: duplicate exact siblings preserve prefix on deletion" {
   let (old_root, _) = parse_to_proj_node(
-    "<div><span>a</span><span>a</span><span>a</span></div>",
+    jsx_reconcile_test_source, "<div><span>a</span><span>a</span><span>a</span></div>",
   )
   let old_div = old_root.children[0]
   let (new_raw, _) = parse_to_proj_node(
-    "<div><span>a</span><span>a</span></div>",
+    jsx_reconcile_test_source, "<div><span>a</span><span>a</span></div>",
   )
   let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
   let new_div = new_root.children[0]
@@ -245,11 +259,11 @@ test "reconcile: duplicate exact siblings preserve prefix on deletion" {
 /// middle insertion does not retarget either existing sibling.
 test "reconcile: attribute-distinct siblings preserve exact identities" {
   let (old_root, _) = parse_to_proj_node(
-    "<div><span class=\"a\"/><span class=\"b\"/></div>",
+    jsx_reconcile_test_source, "<div><span class=\"a\"/><span class=\"b\"/></div>",
   )
   let old_div = old_root.children[0]
   let (new_raw, _) = parse_to_proj_node(
-    "<div><span class=\"a\"/><span class=\"x\"/><span class=\"b\"/></div>",
+    jsx_reconcile_test_source, "<div><span class=\"a\"/><span class=\"x\"/><span class=\"b\"/></div>",
   )
   let new_root = reconcile_jsx_projection(old_root, new_raw, Ref(1000), None)
   let new_div = new_root.children[0]
@@ -351,9 +365,13 @@ test "reconcile: empty-tag recovery removal releases child" {
 ///|
 /// Second render of nested tree produces Update patches.
 test "reconcile: nested second render" {
-  let (root, _) = parse_to_proj_node("<div><h1>title</h1></div>")
+  let (root, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<div><h1>title</h1></div>",
+  )
   let (_, reached) = reconcile(root, [])
-  let (root2, _) = parse_to_proj_node("<div><h1>changed</h1></div>")
+  let (root2, _) = parse_to_proj_node(
+    jsx_reconcile_test_source, "<div><h1>changed</h1></div>",
+  )
   let (patches, _) = reconcile(root2, reached)
   inspect(find_text(patches, "changed"), content="true")
 }

--- a/lang/jsx/proj/streaming_reconcile_wbtest.mbt
+++ b/lang/jsx/proj/streaming_reconcile_wbtest.mbt
@@ -24,7 +24,11 @@ let streaming_prefixes : Array[String] = [
 
 ///|
 test "streaming: element identity stable from first complete-tag-name appearance" {
-  let parser = @loom.new_parser(streaming_prefixes[0], @jsx.jsx_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:jsx-streaming-elements"),
+    streaming_prefixes[0],
+    @jsx.jsx_grammar,
+  )
   let (proj_memo, _, _) = build_jsx_projection_memos(parser)
 
   // Prefix 0 ("<di"): the outer element's tag is truncated mid-word — a
@@ -74,7 +78,11 @@ test "streaming: element identity stable from first complete-tag-name appearance
 /// stability across an unclosed prefix growing into a closed one.
 test "streaming: ExprSpan identity stable across unclosed-to-closed growth" {
   let prefixes : Array[String] = ["<h1>{titl", "<h1>{title", "<h1>{title}"]
-  let parser = @loom.new_parser(prefixes[0], @jsx.jsx_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:jsx-streaming-unclosed-expression"),
+    prefixes[0],
+    @jsx.jsx_grammar,
+  )
   let (proj_memo, _, _) = build_jsx_projection_memos(parser)
   let root0 = proj_memo.read_or_abort().unwrap()
   let expr0 = root0.children[0].children[0]
@@ -97,7 +105,11 @@ test "streaming: ExprSpan identity stable across unclosed-to-closed growth" {
 /// never passes through an unclosed intermediate state).
 test "streaming: ExprSpan identity stable across closed-content growth" {
   let prefixes : Array[String] = ["<h1>{a}", "<h1>{ab}", "<h1>{abc}"]
-  let parser = @loom.new_parser(prefixes[0], @jsx.jsx_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:jsx-streaming-closed-expression"),
+    prefixes[0],
+    @jsx.jsx_grammar,
+  )
   let (proj_memo, _, _) = build_jsx_projection_memos(parser)
   let root0 = proj_memo.read_or_abort().unwrap()
   let expr_id = root0.children[0].children[0].id()
@@ -114,7 +126,9 @@ test "streaming: ExprSpan identity stable across closed-content growth" {
 /// another equal-kind sibling must not retarget the existing two.
 test "streaming: duplicate siblings keep distinct identities" {
   let parser = @loom.new_parser(
-    "<div><span>a</span><span>b</span></div>", @jsx.jsx_grammar,
+    @loomcore.SourceId("canopy-test:jsx-streaming-duplicate-siblings"),
+    "<div><span>a</span><span>b</span></div>",
+    @jsx.jsx_grammar,
   )
   let (proj_memo, _, _) = build_jsx_projection_memos(parser)
   let root0 = proj_memo.read_or_abort().unwrap()

--- a/lang/lambda/alpha/fixtures_wbtest.mbt
+++ b/lang/lambda/alpha/fixtures_wbtest.mbt
@@ -25,7 +25,10 @@ fn graph_for_root(root : @core.ProjNode[@ast.Term]) -> @scope.ScopeGraph {
 fn alpha_parse_fixture(
   text : String,
 ) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph) raise {
-  let (proj, errors) = @lambda_proj.parse_to_proj_node(text)
+  let (proj, errors) = @lambda_proj.parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-alpha-fixture"),
+    text,
+  )
   if errors.length() > 0 {
     fail("parse diagnostics in alpha fixture")
   }

--- a/lang/lambda/alpha/moon.pkg
+++ b/lang/lambda/alpha/moon.pkg
@@ -6,4 +6,5 @@ import {
 
 import {
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/loom/core" @loomcore,
 } for "wbtest"

--- a/lang/lambda/alpha_egraph_adapter/moon.pkg
+++ b/lang/lambda/alpha_egraph_adapter/moon.pkg
@@ -9,4 +9,5 @@ import {
 
 import {
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
+  "dowdiness/loom/core" @loomcore,
 } for "wbtest"

--- a/lang/lambda/alpha_egraph_adapter/optimize_wbtest.mbt
+++ b/lang/lambda/alpha_egraph_adapter/optimize_wbtest.mbt
@@ -10,7 +10,10 @@ fn graph_for_root(root : @core.ProjNode[@ast.Term]) -> @scope.ScopeGraph {
 fn parse_fixture(
   text : String,
 ) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph) raise {
-  let (proj, errors) = @lambda_proj.parse_to_proj_node(text)
+  let (proj, errors) = @lambda_proj.parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-alpha-egraph-fixture"),
+    text,
+  )
   if errors.length() > 0 {
     fail("parse diagnostics in alpha-egraph fixture")
   }

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -169,7 +169,9 @@ pub fn new_lambda_editor(
   let hints_ref : Ref[Array[@core.IdentityTransform]] = Ref([])
   let editor = @editor.SyncEditor::new_generic(
     agent_id,
-    fn(s, rt) { @loom.new_parser(s, @parser.lambda_grammar, runtime?=rt) },
+    (source_id, source, runtime) => {
+      @loom.new_parser(source_id, source, @parser.lambda_grammar, runtime?)
+    },
     fn(parser) {
       let (cached_proj_node, registry_memo, source_map_memo) = @lambda_proj.build_lambda_projection_memos(
         parser,

--- a/lang/lambda/edits/action_context_wbtest.mbt
+++ b/lang/lambda/edits/action_context_wbtest.mbt
@@ -140,7 +140,10 @@ test "to_node_context: binding context produces new_binding" {
 
 ///|
 test "build_action_context: non-binding node" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("1")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-action-context-non-binding"),
+    "1",
+  )
   let di = @lambda_proj.DefinitionIndex::from_proj_node(proj)
   let ctx = build_action_context(
     node_id=proj.id(),
@@ -154,7 +157,10 @@ test "build_action_context: non-binding node" {
 
 ///|
 test "build_action_context: let-binding node via parse" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("let x = 1\nx")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-action-context-binding"),
+    "let x = 1\nx",
+  )
   let di = @lambda_proj.DefinitionIndex::from_proj_node(proj)
   // The first child (index 0) is the LetDef init: Int(1)
   let init_child = proj.children[0]

--- a/lang/lambda/edits/scope_equivalence_wbtest.mbt
+++ b/lang/lambda/edits/scope_equivalence_wbtest.mbt
@@ -47,7 +47,10 @@ fn graph_of(
 fn graph_and_sm_of(
   text : String,
 ) -> (@core.ProjNode[@ast.Term], @scope.ScopeGraph, SourceMap) raise {
-  let (cst, _errs) = @parser.parse_cst(text)
+  let (cst, _errs) = @parser.parse_cst(
+    @loomcore.SourceId("canopy-test:lambda-scope-equivalence"),
+    text,
+  )
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = to_proj_node(syntax, Ref(0))
   let sm = SourceMap::from_ast(proj)

--- a/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
+++ b/lang/lambda/edits/scope_memo_stack_differential_wbtest.mbt
@@ -34,8 +34,11 @@ struct LevelBStack {
 }
 
 ///|
-fn LevelBStack::LevelBStack(source : String) -> LevelBStack {
-  let parser = @loom.new_parser(source, @parser.lambda_grammar)
+fn LevelBStack::LevelBStack(
+  source_id : @loomcore.SourceId,
+  source : String,
+) -> LevelBStack {
+  let parser = @loom.new_parser(source_id, source, @parser.lambda_grammar)
   let (cached_proj_node, registry_memo, source_map_memo) = @lambda_proj.build_lambda_projection_memos(
     parser,
   )
@@ -88,6 +91,7 @@ fn lb_minimal_edit(old : String, new : String) -> @loomcore.Edit {
 ///|
 /// Fresh generic projection rebuild used as the oracle for the live memo stack.
 fn fresh_generic_graph_of(
+  source_id : @loomcore.SourceId,
   text : String,
 ) -> (
   @core.ProjNode[@ast.Term],
@@ -95,7 +99,7 @@ fn fresh_generic_graph_of(
   @scope.ScopeGraph,
   @core.SourceMap,
 ) raise {
-  let (cst, _diags) = @parser.parse_cst(text)
+  let (cst, _diags) = @parser.parse_cst(source_id, text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
   let proj = @lambda_proj.to_proj_node(syntax, counter)
@@ -128,7 +132,10 @@ fn assert_level_b_agrees(
   }
   let g_i = @scope.build(reg_i, sm_i)
   let ranges_i = def_binding_ranges(root)
-  let (proj_f, reg_f, g_f, sm_f) = fresh_generic_graph_of(src)
+  let (proj_f, reg_f, g_f, sm_f) = fresh_generic_graph_of(
+    stack.parser.source_id(),
+    src,
+  )
   let ranges_f = def_binding_ranges(proj_f)
   assert_resolution_agrees(
     ResolutionSide(
@@ -157,7 +164,10 @@ fn assert_level_b_agrees(
 /// agreement after every step.
 fn lb_run_sequence(sources : Array[String]) -> Unit raise {
   guard sources.length() >= 1 else { fail("lb_run_sequence needs >=1 source") }
-  let stack = LevelBStack(sources[0])
+  let stack = LevelBStack(
+    @loomcore.SourceId("canopy-test:lambda-level-b-sequence"),
+    sources[0],
+  )
   assert_level_b_agrees(stack, sources[0], "init:\{sources[0]}")
   for i in 1..<sources.length() {
     stack.apply(sources[i - 1], sources[i])
@@ -169,7 +179,10 @@ fn lb_run_sequence(sources : Array[String]) -> Unit raise {
 ///|
 test "level-B generic: resolution-visible def-init edit agrees with fresh rebuild" {
   let s0 = "let x = 1\nlet y = 2\nx"
-  let stack = LevelBStack(s0)
+  let stack = LevelBStack(
+    @loomcore.SourceId("canopy-test:lambda-level-b-resolution-edit"),
+    s0,
+  )
   assert_level_b_agrees(stack, s0, "init")
   let s1 = "let x = 1\nlet y = x\nx"
   stack.apply(s0, s1)
@@ -180,7 +193,10 @@ test "level-B generic: resolution-visible def-init edit agrees with fresh rebuil
 ///|
 test "level-B generic: skipped registry reads still agree after later edits" {
   let s0 = "let a = 1\nlet b = 2\nb"
-  let stack = LevelBStack(s0)
+  let stack = LevelBStack(
+    @loomcore.SourceId("canopy-test:lambda-level-b-skipped-reads"),
+    s0,
+  )
   ignore(stack.registry_memo.read_or_abort())
   ignore(stack.source_map_memo.read_or_abort())
   assert_level_b_agrees(stack, s0, "init")

--- a/lang/lambda/edits/scope_resolution_differential_wbtest.mbt
+++ b/lang/lambda/edits/scope_resolution_differential_wbtest.mbt
@@ -60,7 +60,10 @@ fn build_oracle(
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @scope.ScopeGraph,
 ) raise {
-  let (cst, _errs) = @parser.parse_cst(text)
+  let (cst, _errs) = @parser.parse_cst(
+    @loomcore.SourceId("canopy-test:lambda-scope-resolution-oracle"),
+    text,
+  )
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
   let proj = to_proj_node(syntax, counter)

--- a/lang/lambda/edits/scope_wbtest.mbt
+++ b/lang/lambda/edits/scope_wbtest.mbt
@@ -1,4 +1,9 @@
 ///|
+let lambda_scope_edit_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:lambda-scope-edits",
+)
+
+///|
 fn scope_test_registry(
   root : ProjNode[@ast.Term],
 ) -> Map[NodeId, ProjNode[@ast.Term]] {
@@ -34,7 +39,7 @@ fn def_cutoff_at_node_for_test(
 ///|
 test "module_def_references: finds Var references in Module body" {
   let text = "let x = 0\nx + x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_scope_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(registry, source_map)
@@ -47,7 +52,7 @@ test "module_def_references: finds Var references in Module body" {
 ///|
 test "module_def_references: respects shadowing by inner Lam" {
   let text = "let x = 0\n(x) => x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_scope_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(registry, source_map)
@@ -60,7 +65,7 @@ test "module_def_references: respects shadowing by inner Lam" {
 ///|
 test "module_def_references: later duplicate shadows body only" {
   let text = "let x = 0\nlet x = x\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_scope_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = scope_test_registry(proj)
   let g = @scope.build(registry, source_map)
@@ -80,7 +85,7 @@ test "module_def_references: later duplicate shadows body only" {
 ///|
 test "def_cutoff_at_node: duplicate defs use init-range cutoff" {
   let text = "let x = 0\nlet x = x\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_scope_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let body = proj.children.last().unwrap()
   let index = DefinitionIndex::from_proj_node(proj)

--- a/lang/lambda/edits/text_edit_wbtest.mbt
+++ b/lang/lambda/edits/text_edit_wbtest.mbt
@@ -1,6 +1,11 @@
 // Whitebox tests for compute_text_edit
 
 ///|
+let lambda_text_edit_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:lambda-text-edits",
+)
+
+///|
 /// Test adapter: converts compute_text_edit's raise EditError model to
 /// Result[...String] so existing test patterns continue to work unchanged.
 /// Same pattern as the FFI-layer adapters (apply_json_edit, apply_markdown_edit,
@@ -20,7 +25,9 @@ fn test_edit(
 fn parse_with_token_spans(
   text : String,
 ) -> (ProjNode[@ast.Term], SourceMap, Map[NodeId, ProjNode[@ast.Term]]) raise {
-  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  let (cst, _) = @parser.parse_cst(lambda_text_edit_test_source, text) catch {
+    _ => fail("parse failed")
+  }
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let counter = Ref(0)
   let proj = to_proj_node(syntax, counter)
@@ -72,7 +79,7 @@ fn make_edit_ctx(
 ///|
 test "compute_text_edit: CommitEdit replaces single expression" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -94,7 +101,7 @@ test "compute_text_edit: CommitEdit replaces single expression" {
 ///|
 test "compute_text_edit: CommitEdit replaces left operand in binary expr" {
   let text = "x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // children[0] is the left operand (Var("x")), span [0, 1)
@@ -117,7 +124,7 @@ test "compute_text_edit: CommitEdit replaces left operand in binary expr" {
 ///|
 test "compute_text_edit: CommitEdit inside fn body preserves braces" {
   let text = "fn id(x : Int) { x }\nid 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let body = proj.children[0].children[0].children[0]
@@ -135,7 +142,7 @@ test "compute_text_edit: CommitEdit inside fn body preserves braces" {
 ///|
 test "compute_text_edit: no-op ops return empty array" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -148,7 +155,7 @@ test "compute_text_edit: no-op ops return empty array" {
 ///|
 test "compute_text_edit: Delete replaces node with placeholder" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -169,7 +176,7 @@ test "compute_text_edit: Delete replaces node with placeholder" {
 ///|
 test "compute_text_edit: Delete replaces Var with placeholder" {
   let text = "x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // children[0] is the left operand Var("x"), span [0, 1)
@@ -196,7 +203,7 @@ test "compute_text_edit: Delete replaces Var with placeholder" {
 ///|
 test "compute_text_edit: Delete inside fn body preserves braces" {
   let text = "fn id(x : Int) { x }\nid 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let body = proj.children[0].children[0].children[0]
@@ -214,7 +221,7 @@ test "compute_text_edit: Delete inside fn body preserves braces" {
 ///|
 test "compute_text_edit: WrapInLambda wraps node in lambda abstraction" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -234,7 +241,7 @@ test "compute_text_edit: WrapInLambda wraps node in lambda abstraction" {
 ///|
 test "compute_text_edit: WrapInLambda parenthesizes subexpression" {
   let text = "f 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let func = proj.children[0]
@@ -252,7 +259,7 @@ test "compute_text_edit: WrapInLambda parenthesizes subexpression" {
 ///|
 test "compute_text_edit: WrapInApp wraps node in application" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -277,7 +284,7 @@ test "compute_text_edit: WrapInApp wraps node in application" {
 ///|
 test "compute_text_edit: InsertChild into Module inserts def text" {
   let text = "let y = 1\ny"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -300,7 +307,7 @@ test "compute_text_edit: InsertChild into Module inserts def text" {
 ///|
 test "compute_text_edit: InsertChild into non-Module re-renders parent" {
   let text = "x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -329,7 +336,7 @@ test "compute_text_edit: InsertChild into non-Module re-renders parent" {
 ///|
 test "compute_text_edit: Drop produces two edits" {
   let text = "x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // source = children[0] (Var "x"), target = children[1] (Int 1)
@@ -410,7 +417,7 @@ test "compute_text_edit: Drop LetDef Before moves the whole binding row before t
 ///|
 test "compute_text_edit: Drop with unknown source returns error" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -423,7 +430,7 @@ test "compute_text_edit: Drop with unknown source returns error" {
 ///|
 test "compute_text_edit: Drop synthetic multi-param lambda source is rejected" {
   let text = "(x, y) => x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let inner_lam = proj.children[0]
@@ -438,7 +445,7 @@ test "compute_text_edit: Drop synthetic multi-param lambda source is rejected" {
 ///|
 test "compute_text_edit: Drop synthetic multi-param lambda target is rejected" {
   let text = "(x, y) => x + z"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let inner_lam = proj.children[0]
@@ -454,7 +461,7 @@ test "compute_text_edit: Drop synthetic multi-param lambda target is rejected" {
 ///|
 test "compute_text_edit: WrapInLambda with unknown node returns error" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -467,7 +474,7 @@ test "compute_text_edit: WrapInLambda with unknown node returns error" {
 ///|
 test "compute_text_edit: CommitEdit with unknown node returns error" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -480,7 +487,7 @@ test "compute_text_edit: CommitEdit with unknown node returns error" {
 ///|
 test "compute_text_edit: Unwrap Lam keeps body" {
   let text = "(x) => 42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let lam_id = proj.id()
@@ -502,7 +509,7 @@ test "compute_text_edit: Unwrap Lam keeps body" {
 ///|
 test "compute_text_edit: Unwrap synthetic fn lambda is rejected" {
   let text = "fn id(x : Int) { x }\nid 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let lam = proj.children[0].children[0]
@@ -516,7 +523,7 @@ test "compute_text_edit: Unwrap synthetic fn lambda is rejected" {
 ///|
 test "compute_text_edit: Unwrap synthetic multi-param lambda is rejected" {
   let text = "(x, y) => x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let inner_lam = proj.children[0]
@@ -530,7 +537,7 @@ test "compute_text_edit: Unwrap synthetic multi-param lambda is rejected" {
 ///|
 test "compute_text_edit: Unwrap Bop keeps left" {
   let text = "1 + 2"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let bop_id = proj.id()
@@ -547,7 +554,7 @@ test "compute_text_edit: Unwrap Bop keeps left" {
 ///|
 test "compute_text_edit: Unwrap Bop keeps right" {
   let text = "1 + 2"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let bop_id = proj.id()
@@ -564,7 +571,7 @@ test "compute_text_edit: Unwrap Bop keeps right" {
 ///|
 test "compute_text_edit: WrapInIf wraps node in if-then-else" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -585,7 +592,7 @@ test "compute_text_edit: WrapInIf wraps node in if-then-else" {
 ///|
 test "compute_text_edit: WrapInBop wraps node in binary operation" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -617,7 +624,7 @@ test "compute_text_edit: WrapInBop wraps node in binary operation" {
 ///|
 test "compute_text_edit: ChangeOperator changes Bop operator" {
   let text = "1 + 2"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -642,7 +649,7 @@ test "compute_text_edit: ChangeOperator changes Bop operator" {
 ///|
 test "compute_text_edit: SwapChildren swaps Bop operands" {
   let text = "1 + 2"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let root_id = proj.id()
@@ -667,7 +674,7 @@ test "compute_text_edit: SwapChildren swaps Bop operands" {
 ///|
 test "compute_text_edit: DeleteBinding removes first let line" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Delete first binding
@@ -688,7 +695,7 @@ test "compute_text_edit: DeleteBinding removes first let line" {
 ///|
 test "compute_text_edit: DeleteBinding removes second let line" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Delete second binding
@@ -709,7 +716,7 @@ test "compute_text_edit: DeleteBinding removes second let line" {
 ///|
 test "compute_text_edit: DeleteBinding removes second fn line" {
   let text = "fn id(x) { x }\nfn apply(f, x) { f x }\napply id 42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -728,7 +735,7 @@ test "compute_text_edit: DeleteBinding removes second fn line" {
 ///|
 test "compute_text_edit: DeleteBinding removes only binding" {
   let text = "let x = 42\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -748,7 +755,7 @@ test "compute_text_edit: DeleteBinding removes only binding" {
 ///|
 test "compute_text_edit: DeleteBinding with unknown id returns error" {
   let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -761,7 +768,7 @@ test "compute_text_edit: DeleteBinding with unknown id returns error" {
 ///|
 test "compute_text_edit: DeleteBinding with init id returns error" {
   let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let init_id = proj.children[0].children[0].id()
@@ -775,7 +782,7 @@ test "compute_text_edit: DeleteBinding with init id returns error" {
 ///|
 test "compute_text_edit: DuplicateBinding copies binding with fresh numeric suffix" {
   let text = "let x = 42\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -795,7 +802,7 @@ test "compute_text_edit: DuplicateBinding copies binding with fresh numeric suff
 ///|
 test "compute_text_edit: DuplicateBinding on last binding" {
   let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -835,7 +842,7 @@ test "compute_text_edit: DuplicateBinding preserves typed fn syntax" {
 ///|
 test "compute_text_edit: DuplicateBinding produces lexable name and reparses (root)" {
   let text = "let x = 42\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -846,7 +853,7 @@ test "compute_text_edit: DuplicateBinding produces lexable name and reparses (ro
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (_, _) = parse_to_proj_node(new_text) catch {
+      let (_, _) = parse_to_proj_node(lambda_text_edit_test_source, new_text) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(root_def_names(new_text), content="x,x1,y")
@@ -858,7 +865,7 @@ test "compute_text_edit: DuplicateBinding produces lexable name and reparses (ro
 ///|
 test "compute_text_edit: DuplicateBinding skips existing numeric suffix (root)" {
   let text = "let x = 42\nlet x1 = 1\nx + x1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -869,7 +876,7 @@ test "compute_text_edit: DuplicateBinding skips existing numeric suffix (root)" 
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (_, _) = parse_to_proj_node(new_text) catch {
+      let (_, _) = parse_to_proj_node(lambda_text_edit_test_source, new_text) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(root_def_names(new_text), content="x,x2,x1")
@@ -881,7 +888,7 @@ test "compute_text_edit: DuplicateBinding skips existing numeric suffix (root)" 
 ///|
 test "compute_text_edit: DuplicateBinding skips suffix that would capture later free reference (root)" {
   let text = "let x = 42\nlet y = x1\ny"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -892,7 +899,7 @@ test "compute_text_edit: DuplicateBinding skips suffix that would capture later 
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (_, _) = parse_to_proj_node(new_text) catch {
+      let (_, _) = parse_to_proj_node(lambda_text_edit_test_source, new_text) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(root_def_names(new_text), content="x,x2,y")
@@ -904,7 +911,7 @@ test "compute_text_edit: DuplicateBinding skips suffix that would capture later 
 ///|
 test "compute_text_edit: MoveBindingDown swaps two bindings" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -925,7 +932,7 @@ test "compute_text_edit: MoveBindingDown swaps two bindings" {
 test "compute_text_edit: MoveBindingDown rejects when scoping violated" {
   // y uses x, so moving x down past y would break scoping
   let text = "let x = 0\nlet y = x\ny"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -939,7 +946,7 @@ test "compute_text_edit: MoveBindingDown rejects when scoping violated" {
 ///|
 test "compute_text_edit: MoveBindingDown rejects last binding" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[1].id()
@@ -953,7 +960,7 @@ test "compute_text_edit: MoveBindingDown rejects last binding" {
 ///|
 test "compute_text_edit: MoveBindingUp swaps two bindings" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[1].id()
@@ -973,7 +980,7 @@ test "compute_text_edit: MoveBindingUp swaps two bindings" {
 ///|
 test "compute_text_edit: MoveBindingUp swaps fn bindings" {
   let text = "fn id(x) { x }\nfn apply(f, x) { f x }\napply id 42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -1000,7 +1007,7 @@ test "compute_text_edit: MoveBindingUp swaps fn bindings" {
 /// botched swap can string-match an expectation while reparsing to a different
 /// structure (see the #649/#650 reparse-gate lesson).
 fn nested_block_def_names(def_index : Int, text : String) -> String raise {
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   match proj.children[def_index].children[0].kind {
     @ast.Term::Module(defs, _) => defs.map(fn(d) { d.0 }).join(",")
     other =>
@@ -1016,7 +1023,7 @@ fn nested_block_def_names(def_index : Int, text : String) -> String raise {
 /// nested_block_def_names for shadowing cases where both root and block scopes
 /// must survive a block-local edit.
 fn root_def_names(text : String) -> String raise {
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   match proj.kind {
     @ast.Term::Module(defs, _) => defs.map(fn(d) { d.0 }).join(",")
     other =>
@@ -1034,7 +1041,7 @@ fn block_local_edit_ctx(
   text : String,
   def_index : Int,
 ) -> (EditContext[@ast.Term], ProjNode[@ast.Term]) raise {
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[def_index].children[0]
@@ -1059,7 +1066,7 @@ test "compute_text_edit: DeleteBinding removes block-local binding" {
   // it. The block-aware op deletes it and the result reparses to a block with
   // only `a`.
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1139,7 +1146,7 @@ test "compute_text_edit: MoveBindingUp swaps block-local bindings" {
 ///|
 test "compute_text_edit: MoveBindingUp rejects first block-local binding" {
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1157,7 +1164,7 @@ test "compute_text_edit: DuplicateBinding on block-local binding" {
   // Block-local duplicate is reachable, produces a lexable fresh name, and keeps
   // the inserted binding aligned with the enclosing block.
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1182,7 +1189,7 @@ test "compute_text_edit: DuplicateBinding on block-local binding" {
 ///|
 test "compute_text_edit: DuplicateBinding on block-local binding produces lexable name and reparses with correct indentation" {
   let text = "let x = 0\nlet z = { let a = 1\n  let b = 2\n  a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1194,7 +1201,7 @@ test "compute_text_edit: DuplicateBinding on block-local binding produces lexabl
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (_, _) = parse_to_proj_node(new_text) catch {
+      let (_, _) = parse_to_proj_node(lambda_text_edit_test_source, new_text) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(
@@ -1210,7 +1217,7 @@ test "compute_text_edit: DuplicateBinding on block-local binding produces lexabl
 ///|
 test "compute_text_edit: DuplicateBinding skips existing numeric suffix (block-local)" {
   let text = "let z = { let a = 1\n  let a1 = 2\n  a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[0].children[0]
@@ -1222,7 +1229,7 @@ test "compute_text_edit: DuplicateBinding skips existing numeric suffix (block-l
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (_, _) = parse_to_proj_node(new_text) catch {
+      let (_, _) = parse_to_proj_node(lambda_text_edit_test_source, new_text) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(
@@ -1238,7 +1245,7 @@ test "compute_text_edit: DuplicateBinding skips existing numeric suffix (block-l
 ///|
 test "compute_text_edit: DuplicateBinding skips suffix that would capture later free reference (block-local)" {
   let text = "let z = { let a = 1\n  let b = a1\n  b }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[0].children[0]
@@ -1250,7 +1257,7 @@ test "compute_text_edit: DuplicateBinding skips suffix that would capture later 
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (_, _) = parse_to_proj_node(new_text) catch {
+      let (_, _) = parse_to_proj_node(lambda_text_edit_test_source, new_text) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(
@@ -1368,7 +1375,7 @@ test "compute_text_edit: MoveBindingUp swaps block-local binding that shadows ro
 /// def after `a`, and block body becomes `y`.
 test "compute_text_edit: ExtractToLet handles block body with block-local free var" {
   let text = "let z = { let a = 1\n  a + 1 }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[0].children[0]
@@ -1380,7 +1387,9 @@ test "compute_text_edit: ExtractToLet handles block body with block-local free v
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed")
       }
       match result_proj.kind {
@@ -1412,7 +1421,7 @@ test "compute_text_edit: ExtractToLet handles block body with block-local free v
 /// instead of the original `let a = 1`.
 test "compute_text_edit: ExtractToLet refuses block-body extraction when var_name would capture suffix" {
   let text = "let z = { let a = 1\n  (a + 1) + a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Extract `(a + 1)` from the body: block→body→Add(Add(Var(a),Int(1)), Var(a))
@@ -1436,7 +1445,7 @@ test "compute_text_edit: ExtractToLet refuses block-body extraction when var_nam
 /// produce `let y = a + 1\ny + y` where `y` is now bound.
 test "compute_text_edit: ExtractToLet refuses block-body extraction when var_name would bind free suffix ref" {
   let text = "let z = { let a = 1\n  (a + 1) + y }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[0].children[0]
@@ -1457,7 +1466,7 @@ test "compute_text_edit: ExtractToLet refuses block-body extraction when var_nam
 /// unbound `y` now resolves.
 test "compute_text_edit: ExtractToLet refuses block-def extraction when var_name would bind free block ref" {
   let text = "let z = { let a = 1\n  y + a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[0].children[0]
@@ -1480,7 +1489,7 @@ test "compute_text_edit: ExtractToLet refuses block-def extraction when var_name
 /// `y` to 1 instead of the outer binding.
 test "compute_text_edit: ExtractToLet refuses block-def extraction when var_name would capture block ref" {
   let text = "let y = 5\nlet z = { let a = 1\n  y + a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // z is proj.children[1] (second root def); block is z's init
@@ -1502,7 +1511,7 @@ test "compute_text_edit: ExtractToLet refuses block-def extraction when var_name
 /// `a` unbound. The root-relative capture guard catches this case.
 test "compute_text_edit: ExtractToLet refuses block-def extraction with block-local free var" {
   let text = "let z = { let a = 1\n  let b = a + 1\n  b }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Extract `a + 1` (the init of `let b`): block→LetDef("b")→Add(Var("a"), Int(1))
@@ -1524,7 +1533,7 @@ test "compute_text_edit: ExtractToLet refuses block-def extraction with block-lo
 /// Module([("", Lam("x",…))], Unit). Navigation must go through that wrapper.
 test "compute_text_edit: ExtractToLet allows block-def extraction when lambda param is from outside the block" {
   let text = "fn(x) { let y = x\ny }"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // proj = Module([("", Lam("x", …))], Unit)
@@ -1544,7 +1553,9 @@ test "compute_text_edit: ExtractToLet allows block-def extraction when lambda pa
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed: " + new_text)
       }
       // Root still has 1 def (the unnamed lambda binding); lambda body block
@@ -1580,7 +1591,7 @@ test "compute_text_edit: ExtractToLet allows block-def extraction when lambda pa
 /// as its first def.
 test "compute_text_edit: ExtractToLet inserts inside block for block-internal def" {
   let text = "let z = { let a = 1\n  a + 1 }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Int(1) is: proj→LetDef("z")→block→LetDef("a")→Int(1)
@@ -1593,7 +1604,9 @@ test "compute_text_edit: ExtractToLet inserts inside block for block-internal de
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed")
       }
       // The let binding must be inside the block, so root still has exactly 1 def.
@@ -1623,7 +1636,7 @@ test "compute_text_edit: ExtractToLet inserts inside block for block-internal de
 /// the first binding still inserts let y before all block defs (at block start).
 test "compute_text_edit: ExtractToLet inserts before all block defs for non-first def" {
   let text = "let z = { let a = 1\n  let b = 2\n  a + b }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Extract Int(2) from `let b = 2`: proj→LetDef("z")→block→LetDef("b")→Int(2)
@@ -1636,7 +1649,9 @@ test "compute_text_edit: ExtractToLet inserts before all block defs for non-firs
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed")
       }
       match result_proj.kind {
@@ -1669,7 +1684,7 @@ test "compute_text_edit: ExtractToLet inserts before all block defs for non-firs
 /// Verified by reparsing: root keeps 1 def, block gains a new def `y`.
 test "compute_text_edit: ExtractToLet finds block via ancestor scope for lambda-in-block" {
   let text = "let z = { let a = 1\n(x) => a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // proj→LetDef("z")→block→[LetDef("a"), Lam("x", Var("a"))]; extract Var("a")
@@ -1682,7 +1697,9 @@ test "compute_text_edit: ExtractToLet finds block via ancestor scope for lambda-
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed")
       }
       match result_proj.kind {
@@ -1712,7 +1729,7 @@ test "compute_text_edit: ExtractToLet finds block via ancestor scope for lambda-
 /// making the param references unbound.
 test "compute_text_edit: ExtractToLet refuses lambda-param rebind in lambda-in-block" {
   let text = "let z = { let a = 1\n(x) => x + a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // proj→LetDef("z")→block→[LetDef("a"), Lam("x", Add(Var("x"), Var("a")))]; extract body
@@ -1734,7 +1751,7 @@ test "compute_text_edit: ExtractToLet refuses lambda-param rebind in lambda-in-b
 /// Verified by reparsing: root still has 1 def (z), block gains def `y`.
 test "compute_text_edit: ExtractToLet inserts inside empty-def block body" {
   let text = "let z = { 1 + 2 }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // After Option B: proj→LetDef("z")→Module([], Add)→[Add→[Int(1), Int(2)]]
@@ -1747,7 +1764,9 @@ test "compute_text_edit: ExtractToLet inserts inside empty-def block body" {
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed: " + new_text)
       }
       match result_proj.kind {
@@ -1802,7 +1821,7 @@ fn expect_var_resolves_to(
 ///|
 test "compute_text_edit: ExtractToLet block-body preserves resolution when block-local def shadows outer var [#659]" {
   let text = "let a = 0\nlet z = { let a = 1\n  a + 1 }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1814,7 +1833,9 @@ test "compute_text_edit: ExtractToLet block-body preserves resolution when block
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(root_def_names(new_text), content="a,z")
@@ -1837,7 +1858,7 @@ test "compute_text_edit: ExtractToLet block-body preserves resolution when block
 ///|
 test "compute_text_edit: ExtractToLet block-body sub-expr preserves block-local free var resolution [#659]" {
   let text = "let a = 0\nlet z = { let a = 1\n  (a + 2) + a }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1850,7 +1871,9 @@ test "compute_text_edit: ExtractToLet block-body sub-expr preserves block-local 
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed: " + new_text)
       }
       let g = scope_graph_for_proj(result_proj)
@@ -1871,7 +1894,7 @@ test "compute_text_edit: ExtractToLet block-body sub-expr preserves block-local 
 ///|
 test "compute_text_edit: ExtractToLet block-body preserves mixed inner/outer free var resolution [#659]" {
   let text = "let x = 10\nlet z = { let a = 1\n  a + x }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -1883,7 +1906,9 @@ test "compute_text_edit: ExtractToLet block-body preserves mixed inner/outer fre
   match result {
     Ok(Some((edits, _))) => {
       let new_text = apply_edits(text, edits)
-      let (result_proj, _) = parse_to_proj_node(new_text) catch {
+      let (result_proj, _) = parse_to_proj_node(
+        lambda_text_edit_test_source, new_text,
+      ) catch {
         _ => fail("reparse failed: " + new_text)
       }
       inspect(root_def_names(new_text), content="x,z")
@@ -1913,7 +1938,7 @@ test "compute_text_edit: ExtractToLet block-body preserves mixed inner/outer fre
 ///|
 test "compute_text_edit: AddBinding adds new let line" {
   let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let module_id = proj.id()
@@ -1933,7 +1958,7 @@ test "compute_text_edit: AddBinding adds new let line" {
 ///|
 test "compute_text_edit: ExtractToLet from body" {
   let text = "let x = 0\nx + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Body is Bop(+, Var(x), Int(1)). Extract the whole body expression.
@@ -1961,7 +1986,7 @@ test "compute_text_edit: ExtractToLet from body" {
 ///|
 test "compute_text_edit: ExtractToLet sub-expression from body" {
   let text = "let x = 0\nx + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Extract Var("x") from the body (left operand of +)
@@ -1984,7 +2009,7 @@ test "compute_text_edit: ExtractToLet sub-expression from body" {
 test "compute_text_edit: ExtractToLet rejects lambda-captured var" {
   // Inside (x) => (x + 1), trying to extract the body which captures x
   let text = "(x) => x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // The body of lambda is Bop(+, Var(x), Int(1)) — child[0] of Lam
@@ -2029,7 +2054,7 @@ test "compute_text_edit: ExtractToLet rejects later module-def shadow capture" {
 ///|
 test "compute_text_edit: ExtractToLet bare expression" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -2079,7 +2104,7 @@ test "compute_text_edit: ExtractToLet defs-empty does not reject block-shadowed 
 ///|
 test "compute_text_edit: InlineDefinition sole usage removes binding" {
   let text = "let x = 42\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Body is the last child of Module — Var("x")
@@ -2100,7 +2125,7 @@ test "compute_text_edit: InlineDefinition sole usage removes binding" {
 ///|
 test "compute_text_edit: InlineDefinition nested block uses resolved declaration" {
   let text = "let x = 0\nlet z = { let x = 1\n  x }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -2121,7 +2146,7 @@ test "compute_text_edit: InlineDefinition nested block uses resolved declaration
 ///|
 test "compute_text_edit: InlineDefinition multiple usages keeps binding" {
   let text = "let x = 42\nx + x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Body is Bop(+, Var(x), Var(x)). Get the left Var.
@@ -2145,7 +2170,7 @@ test "compute_text_edit: InlineAllUsages replaces all refs and removes binding" 
   // Note: right operand range in BinaryExpr may include leading whitespace
   // from the CST, so "x + x" -> "42 +42" — reparsing normalizes spacing.
   let text = "let x = 42\nx + x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -2167,7 +2192,7 @@ test "compute_text_edit: InlineAllUsages replaces all refs and removes binding" 
 ///|
 test "compute_text_edit: InlineAllUsages nested block uses binding declaration" {
   let text = "let x = 0\nlet z = { let x = 1\n  x }\nz"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let block = proj.children[1].children[0]
@@ -2188,7 +2213,7 @@ test "compute_text_edit: InlineAllUsages nested block uses binding declaration" 
 ///|
 test "compute_text_edit: InlineDefinition on non-Var returns error" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -2201,7 +2226,7 @@ test "compute_text_edit: InlineDefinition on non-Var returns error" {
 ///|
 test "compute_text_edit: InlineAllUsages with unknown binding returns error" {
   let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -2303,7 +2328,7 @@ test "compute_text_edit: InlineDefinition zero-param fn with lambda body uses bl
 ///|
 test "compute_text_edit: InlineDefinition typed fn rejects missing keyword span" {
   let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let body = proj.children[proj.children.length() - 1]
@@ -2321,7 +2346,7 @@ test "compute_text_edit: InlineDefinition typed fn rejects missing keyword span"
 ///|
 test "compute_text_edit: InlineDefinition typed fn rejects missing parameter span" {
   let text = "fn twice(f : Int -> Int, x : Int) { f x }\ntwice"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   source_map.set_token_span(
     proj.children[0].id(),
@@ -2366,7 +2391,7 @@ test "compute_text_edit: InlineAllUsages first duplicate preserves shadowed body
 ///|
 test "compute_text_edit: InlineDefinition on lambda-bound var returns error" {
   let text = "(x) => x"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // Body is Var("x") — child[0] of Lam
@@ -2381,7 +2406,7 @@ test "compute_text_edit: InlineDefinition on lambda-bound var returns error" {
 ///|
 test "compute_text_edit: InlineAllUsages no usages just removes binding" {
   let text = "let x = 42\n0"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let binding_id = proj.children[0].id()
@@ -2401,7 +2426,7 @@ test "compute_text_edit: InlineAllUsages no usages just removes binding" {
 ///|
 test "compute_text_edit: InlineAllUsages removes unused second fn binding" {
   let text = "fn id(x) { x }\nfn unused(x) { x }\nid 42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(
@@ -3075,7 +3100,7 @@ test "compute_text_edit: Unwrap cursor at replacement start" {
   // Unwrap Bop keeps right child — cursor should be at range.start (0),
   // not the original position of the right child
   let text = "1 + 2"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let bop_id = proj.id()
@@ -3123,7 +3148,7 @@ test "compute_text_edit: AddBinding rejects non-Module target" {
 ///|
 test "compute_text_edit: Drop self-drop returns error" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let id = proj.id()
@@ -3139,7 +3164,7 @@ test "compute_text_edit: Drop descendant-drop returns error" {
   // "x + 1" parses as Bop(Var(x), Int(1))
   // Dropping the root Bop onto its child Var(x) is a descendant-drop
   let text = "x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let child = proj.children[0] // Var(x), inside the Bop
@@ -3156,7 +3181,7 @@ test "compute_text_edit: Drop descendant-drop returns error" {
 ///|
 test "compute_text_edit: Drop with Before position inserts at target start" {
   let text = "x + 1"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   // source = Int(1) at children[1], target = Var(x) at children[0]
@@ -3184,7 +3209,7 @@ test "compute_text_edit: Drop with Before position inserts at target start" {
 ///|
 test "compute_text_edit: Drop with unknown target returns error" {
   let text = "42"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(lambda_text_edit_test_source, text)
   let source_map = SourceMap::from_ast(proj)
   let registry = text_edit_test_registry(proj)
   let result = test_edit(

--- a/lang/lambda/edits/text_lens_regression_wbtest.mbt
+++ b/lang/lambda/edits/text_lens_regression_wbtest.mbt
@@ -2,8 +2,9 @@
 // Regression: ProjNode.kind must be rebuilt from reconciled children so that
 // rendering reflects the updated tree after a same-shape edit.
 test "reconcile_ast rebuilds rendered text after same-shape edit" {
-  let (old_root, _) = parse_to_proj_node("x + 1")
-  let (new_root, _) = parse_to_proj_node("x + 2")
+  let source_id = @loomcore.SourceId("canopy-test:lambda-text-lens-revision")
+  let (old_root, _) = parse_to_proj_node(source_id, "x + 1")
+  let (new_root, _) = parse_to_proj_node(source_id, "x + 2")
   let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(
     @ast.print_term(reconciled.kind),

--- a/lang/lambda/proj/definition_index_wbtest.mbt
+++ b/lang/lambda/proj/definition_index_wbtest.mbt
@@ -1,7 +1,10 @@
 ///|
 test "DefinitionIndex::binding_for_node: maps LetDef id to binding index" {
   let text = "let x = 0\nlet y = 1\nx + y"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-definition-index-binding"),
+    text,
+  )
   let index = DefinitionIndex::from_proj_node(proj)
   let binding_node_id = proj.children[0].id()
   match index.binding_for_node(binding_node_id) {
@@ -16,7 +19,10 @@ test "DefinitionIndex::binding_for_node: maps LetDef id to binding index" {
 ///|
 test "DefinitionIndex::binding_for_node: init id is not a binding id" {
   let text = "let x = 0\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-definition-index-init"),
+    text,
+  )
   let index = DefinitionIndex::from_proj_node(proj)
   let init_id = proj.children[0].children[0].id()
   inspect(index.binding_for_node(init_id) is None, content="true")
@@ -25,7 +31,10 @@ test "DefinitionIndex::binding_for_node: init id is not a binding id" {
 ///|
 test "DefinitionIndex::binding_for_node: duplicate defs return binding order" {
   let text = "let x = 0\nlet x = x\nx"
-  let (proj, _) = parse_to_proj_node(text)
+  let (proj, _) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-definition-index-duplicates"),
+    text,
+  )
   let index = DefinitionIndex::from_proj_node(proj)
   match index.binding_for_node(proj.children[0].id()) {
     Some((binding_id, def_index)) => {

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -26,7 +26,7 @@ pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints
 
 pub fn module_name_role(Int) -> String
 
-pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@ast.Term]) -> Unit
 

--- a/lang/lambda/proj/populate_token_spans_wbtest.mbt
+++ b/lang/lambda/proj/populate_token_spans_wbtest.mbt
@@ -2,7 +2,12 @@
 fn parse_proj_with_token_spans(
   text : String,
 ) -> (ProjNode[@ast.Term], SourceMap) raise {
-  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  let (cst, _) = @parser.parse_cst(
+    @loomcore.SourceId("canopy-test:lambda-token-spans"),
+    text,
+  ) catch {
+    _ => fail("parse failed")
+  }
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = to_proj_node(syntax, Ref(0))
   let source_map = SourceMap::from_ast(proj)

--- a/lang/lambda/proj/proj_node.mbt
+++ b/lang/lambda/proj/proj_node.mbt
@@ -484,11 +484,12 @@ pub fn rebuild_kind(
 /// Uses the unified source-file grammar for both single expressions and
 /// multi-definition files.
 pub fn parse_to_proj_node(
+  source_id : @loomcore.SourceId,
   text : String,
 ) -> (ProjNode[@ast.Term], Array[String]) raise @loomcore.LexError {
-  let (cst, diagnostics) = @parser.parse_cst(text)
+  let (cst, diagnostics) = @parser.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
-  let errors = diagnostics.map(fn(d) { d.message })
+  let errors = diagnostics.map(diagnostic => diagnostic.message())
   let root = to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }

--- a/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_cstfold_wbtest.mbt
@@ -1,12 +1,17 @@
 ///|
+let lambda_cstfold_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:lambda-cstfold-parity",
+)
+
+///|
 fn cstfold_term(source : String) -> @ast.Term raise {
-  let (cst, _) = @parser.parse_cst(source)
+  let (cst, _) = @parser.parse_cst(lambda_cstfold_test_source, source)
   @parser.syntax_node_to_term(@seam.SyntaxNode::from_cst(cst))
 }
 
 ///|
 fn cstfold_shallow_first_child(source : String) -> @ast.Term raise {
-  let (cst, _) = @parser.parse_cst(source)
+  let (cst, _) = @parser.parse_cst(lambda_cstfold_test_source, source)
   let root = @seam.SyntaxNode::from_cst(cst)
   match root.children() {
     [expr, ..] => cstfold_projection_compatible_shallow_kind(expr)
@@ -29,7 +34,7 @@ fn assert_term_equal(
 
 ///|
 fn assert_clean_projection_kind_matches_fold(source : String) -> Unit raise {
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if !errors.is_empty() {
     fail(
       "expected clean parse for " + source + ", got " + @debug.to_string(errors),
@@ -49,7 +54,7 @@ fn assert_projection_fold_classification(
   expected_projection : @ast.Term,
   expected_fold : @ast.Term,
 ) -> Unit raise {
-  let (proj, _errors) = parse_to_proj_node(source)
+  let (proj, _errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   let folded = cstfold_term(source)
   assert_term_equal(
     "projection classification for " + source,
@@ -65,7 +70,7 @@ fn assert_projection_fold_classification(
 
 ///|
 fn assert_projection_matches_compatible_fold(source : String) -> Unit raise {
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if !errors.is_empty() {
     fail(
       "expected clean parse for " + source + ", got " + @debug.to_string(errors),
@@ -115,7 +120,7 @@ fn assert_leaf_projection_metadata(
   expected_start : Int,
   expected_end : Int,
 ) -> Unit raise {
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if !errors.is_empty() {
     fail(
       "expected clean parse for " + source + ", got " + @debug.to_string(errors),
@@ -185,7 +190,7 @@ test "cstfold-backed branch shape does not fold nested if children" {
 ///|
 test "cstfold-backed if projection preserves branch metadata" {
   let source = "if x then 1 else 2"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if !errors.is_empty() {
     fail(
       "expected clean parse for " + source + ", got " + @debug.to_string(errors),
@@ -214,7 +219,7 @@ test "cstfold-backed if projection preserves branch metadata" {
 ///|
 test "cstfold-backed if projection preserves recovered child kind" {
   let source = "if 1 + then 2 else 3"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if errors.is_empty() {
     fail("expected recovery diagnostics for " + source)
   }
@@ -272,7 +277,7 @@ test "cstfold-backed flat app and bop shallow shapes do not fold nested children
 ///|
 test "app projection preserves left-nested spine metadata" {
   let source = "f x y"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if !errors.is_empty() {
     fail(
       "expected clean parse for " + source + ", got " + @debug.to_string(errors),
@@ -311,7 +316,7 @@ test "app projection preserves left-nested spine metadata" {
 ///|
 test "app projection preserves recovered argument child" {
   let source = "f ("
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if errors.is_empty() {
     fail("expected recovery diagnostics for " + source)
   }
@@ -343,7 +348,7 @@ test "app projection preserves recovered argument child" {
 ///|
 test "bop projection preserves left-nested spine metadata" {
   let source = "1 + 2 - 3"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if !errors.is_empty() {
     fail(
       "expected clean parse for " + source + ", got " + @debug.to_string(errors),
@@ -382,7 +387,7 @@ test "bop projection preserves left-nested spine metadata" {
 ///|
 test "bop projection preserves recovered rhs child metadata" {
   let source = "1 +"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if errors.is_empty() {
     fail("expected recovery diagnostics for " + source)
   }
@@ -465,7 +470,7 @@ test "cstfold parity: block projection agrees with cstfold; empty-block divergen
 ///|
 test "cstfold parity: recovery divergence is classified separately" {
   let source = "1 +"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(lambda_cstfold_test_source, source)
   if errors.is_empty() {
     fail("expected recovery diagnostics for " + source)
   }

--- a/lang/lambda/proj/proj_node_recovery_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_recovery_wbtest.mbt
@@ -5,7 +5,10 @@
 test "recovery: int literal overflow yields Error node" {
   // parse_int overflows on 20+ digit integers, so IntLiteralView::value
   // returns None. Recovery should emit an Error node, not Int(0).
-  let (proj, _) = parse_to_proj_node("99999999999999999999")
+  let (proj, _) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-proj-overflow"),
+    "99999999999999999999",
+  )
   match proj.kind {
     Error(msg) => inspect(msg, content="invalid integer literal")
     other => fail("expected Error node, got \{other}")
@@ -14,6 +17,9 @@ test "recovery: int literal overflow yields Error node" {
 
 ///|
 test "recovery: valid int literal still produces Int" {
-  let (proj, _) = parse_to_proj_node("42")
+  let (proj, _) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-proj-valid-int"),
+    "42",
+  )
   inspect(proj.kind, content="Int(42)")
 }

--- a/lang/lambda/proj/proj_node_wbtest.mbt
+++ b/lang/lambda/proj/proj_node_wbtest.mbt
@@ -1,6 +1,9 @@
 ///|
 test "syntax_to_proj_node: block expression with def and body" {
-  let (proj, errors) = parse_to_proj_node("{ let x = 1; x }")
+  let (proj, errors) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-proj-block"),
+    "{ let x = 1; x }",
+  )
   inspect(errors.is_empty(), content="true")
   inspect(
     proj.kind,
@@ -16,7 +19,10 @@ test "syntax_to_proj_node: block expression with def and body" {
 
 ///|
 test "syntax_to_proj_node: hole literal" {
-  let (proj, errors) = parse_to_proj_node("_")
+  let (proj, errors) = parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-proj-hole"),
+    "_",
+  )
   inspect(errors.is_empty(), content="true")
   inspect(proj.kind, content="Hole(0)")
 }

--- a/lang/lambda/proj/projection_memo_wbtest.mbt
+++ b/lang/lambda/proj/projection_memo_wbtest.mbt
@@ -19,7 +19,9 @@ fn module_binding_ids(
 ///|
 test "build_lambda_projection_memos: reordered defs preserve binding ids" {
   let parser = @loom.new_parser(
-    "let x = 1\nlet y = 2\nx", @parser.lambda_grammar,
+    @loomcore.SourceId("canopy-test:lambda-projection-memo-reordered"),
+    "let x = 1\nlet y = 2\nx",
+    @parser.lambda_grammar,
   )
   let (proj_memo, _, _) = build_lambda_projection_memos(parser)
   let before = module_binding_ids(proj_memo.read_or_abort().unwrap())
@@ -50,7 +52,9 @@ fn module_binding_ids_in_order(
 ///|
 test "build_lambda_projection_memos: duplicate defs preserve occurrence binding ids" {
   let parser = @loom.new_parser(
-    "let x = 1\nlet x = 2\nx", @parser.lambda_grammar,
+    @loomcore.SourceId("canopy-test:lambda-projection-memo-duplicates"),
+    "let x = 1\nlet x = 2\nx",
+    @parser.lambda_grammar,
   )
   let (proj_memo, _, _) = build_lambda_projection_memos(parser)
   let before = module_binding_ids_in_order(proj_memo.read_or_abort().unwrap())
@@ -64,7 +68,9 @@ test "build_lambda_projection_memos: duplicate defs preserve occurrence binding 
 ///|
 test "build_lambda_projection_memos: inserted def gets fresh id while neighbors stay stable" {
   let parser = @loom.new_parser(
-    "let x = 1\nlet z = 3\nz", @parser.lambda_grammar,
+    @loomcore.SourceId("canopy-test:lambda-projection-memo-inserted"),
+    "let x = 1\nlet z = 3\nz",
+    @parser.lambda_grammar,
   )
   let (proj_memo, _, _) = build_lambda_projection_memos(parser)
   let before = module_binding_ids_in_order(proj_memo.read_or_abort().unwrap())
@@ -77,7 +83,11 @@ test "build_lambda_projection_memos: inserted def gets fresh id while neighbors 
 
 ///|
 test "build_lambda_projection_memos: root module id stays stable across rebuild" {
-  let parser = @loom.new_parser("let x = 1\nx", @parser.lambda_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:lambda-projection-memo-root"),
+    "let x = 1\nx",
+    @parser.lambda_grammar,
+  )
   let (proj_memo, _, _) = build_lambda_projection_memos(parser)
   let before = proj_memo.read_or_abort().unwrap().id()
   parser.set_source("let x = 2\nx")
@@ -87,7 +97,11 @@ test "build_lambda_projection_memos: root module id stays stable across rebuild"
 
 ///|
 test "build_lambda_projection_memos: root block module keeps outer span" {
-  let parser = @loom.new_parser("{ let x = 1\n  x }", @parser.lambda_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:lambda-projection-memo-block"),
+    "{ let x = 1\n  x }",
+    @parser.lambda_grammar,
+  )
   let (proj_memo, _, _) = build_lambda_projection_memos(parser)
   ignore(proj_memo.read_or_abort())
   parser.set_source("{ let x = 2\n  x }")
@@ -98,7 +112,11 @@ test "build_lambda_projection_memos: root block module keeps outer span" {
 
 ///|
 test "build_lambda_projection_memos: explicit Unit body keeps span" {
-  let parser = @loom.new_parser("let x = 1\n{}", @parser.lambda_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:lambda-projection-memo-unit"),
+    "let x = 1\n{}",
+    @parser.lambda_grammar,
+  )
   let (proj_memo, _, _) = build_lambda_projection_memos(parser)
   ignore(proj_memo.read_or_abort())
   parser.set_source("let x = 2\n{}")

--- a/lang/lambda/scope/go_to_definition_wbtest.mbt
+++ b/lang/lambda/scope/go_to_definition_wbtest.mbt
@@ -10,7 +10,12 @@
 fn build_fixture_with_spans(
   text : String,
 ) -> (ScopeGraph, @core.SourceMap) raise {
-  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  let (cst, _) = @parser.parse_cst(
+    @loomcore.SourceId("canopy-test:lambda-go-to-definition"),
+    text,
+  ) catch {
+    _ => fail("parse failed")
+  }
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   let source_map = @core.SourceMap::from_ast(proj)
@@ -97,7 +102,10 @@ test "go_to_definition: free variable — no jump" {
 test "binder_span: None when token spans were not populated" {
   // A SourceMap built via from_ast without populate_token_spans has no token
   // spans — binder_span must degrade to None, never a wrong location.
-  let (proj, _errs) = @lambda_proj.parse_to_proj_node("let x = 1\nx")
+  let (proj, _errs) = @lambda_proj.parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-binder-span-no-tokens"),
+    "let x = 1\nx",
+  )
   let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = Map([])
   @core.collect_registry(proj, registry)

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -7,7 +7,10 @@ fn build_fixture(
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @core.SourceMap,
 ) raise {
-  let (proj, _errs) = @lambda_proj.parse_to_proj_node(text)
+  let (proj, _errs) = @lambda_proj.parse_to_proj_node(
+    @loomcore.SourceId("canopy-test:lambda-scope-graph"),
+    text,
+  )
   let source_map = @core.SourceMap::from_ast(proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = Map([])
   @core.collect_registry(proj, registry)

--- a/lang/lambda/semantic/moon.pkg
+++ b/lang/lambda/semantic/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
   "dowdiness/canopy/lang/lambda/scope" @lambda_scope,
   "dowdiness/canopy/protocol",
+  "dowdiness/loom/core" @loomcore,
   "dowdiness/lambda/ast",
   "moonbitlang/core/json",
 }

--- a/lang/lambda/semantic/semantic_projection_test.mbt
+++ b/lang/lambda/semantic/semantic_projection_test.mbt
@@ -1,8 +1,13 @@
 ///|
+let lambda_semantic_projection_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:lambda-semantic-projection",
+)
+
+///|
 fn parse_fixture(
   text : String,
 ) -> (@core.ProjNode[@ast.Term], @core.SourceMap) raise {
-  let (cst, _) = @parser.parse_cst(text)
+  let (cst, _) = @parser.parse_cst(lambda_semantic_projection_test_source, text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let root = @lambda_proj.to_proj_node(syntax, Ref(0))
   let source_map = @core.SourceMap::from_ast(root)

--- a/lang/markdown/companion/markdown_companion.mbt
+++ b/lang/markdown/companion/markdown_companion.mbt
@@ -13,7 +13,9 @@ pub fn new_markdown_editor(
   let hints_ref : Ref[Array[@core.IdentityTransform]] = Ref([])
   @editor.SyncEditor::new_generic(
     agent_id,
-    (s, rt) => @loom.new_parser(s, @markdown.markdown_grammar, runtime?=rt),
+    (source_id, source, runtime) => {
+      @loom.new_parser(source_id, source, @markdown.markdown_grammar, runtime?)
+    },
     parser => {
       @md_proj.build_markdown_projection_memos(parser, identity_hints=hints_ref)
     },

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -1,16 +1,21 @@
 ///| Whitebox tests for Markdown edit ops (pure compute, no SyncEditor).
 
 ///|
+let markdown_edit_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:markdown-edits",
+)
+
+///|
 fn compute_edit_result(
   source : String,
   op : MarkdownEditOp,
 ) -> (Array[SpanEdit], FocusHint)? raise @core.EditError {
-  let (proj, _) = @md_proj.parse_to_proj_node(source) catch {
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source) catch {
     @loomcore.LexError(msg) => raise @core.EditError::ParseFailed(detail=msg)
   }
   let source_map = @core.SourceMap::from_ast(proj)
   // Re-parse to get the SyntaxNode for populate_token_spans
-  let (cst, _) = @markdown.parse_cst(source) catch {
+  let (cst, _) = @markdown.parse_cst(markdown_edit_test_source, source) catch {
     @loomcore.LexError(msg) => raise @core.EditError::ParseFailed(detail=msg)
   }
   let syntax_root = @seam.SyntaxNode::from_cst(cst)
@@ -72,7 +77,9 @@ fn inspect_edit_error_contains(
 ///|
 test "commit_edit: change paragraph text" {
   let source = "Hello world\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("Hello world\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "Hello world\n",
+  )
   let para_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -84,7 +91,9 @@ test "commit_edit: change paragraph text" {
 ///|
 test "change_heading_level: paragraph to h2" {
   let source = "Hello\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "Hello\n",
+  )
   let para_id = proj.children[0].id()
   let result = apply_edit(source, ChangeHeadingLevel(node_id=para_id, level=2))
   inspect(result.contains("## Hello"), content="true")
@@ -93,7 +102,9 @@ test "change_heading_level: paragraph to h2" {
 ///|
 test "change_heading_level: h1 to h3" {
   let source = "# Title\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("# Title\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "# Title\n",
+  )
   let heading_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -105,7 +116,7 @@ test "change_heading_level: h1 to h3" {
 ///|
 test "change_heading_level: setext h2 to ATX h3" {
   let source = "Title\n---\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -117,7 +128,7 @@ test "change_heading_level: setext h2 to ATX h3" {
 ///|
 test "change_heading_level: multiline setext becomes one ATX line" {
   let source = "Foo\nbar\n---\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -129,7 +140,7 @@ test "change_heading_level: multiline setext becomes one ATX line" {
 ///|
 test "change_heading_level: CRLF setext preserves line ending" {
   let source = "Title\r\n---\r\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -141,7 +152,7 @@ test "change_heading_level: CRLF setext preserves line ending" {
 ///|
 test "change_heading_level: indented setext drops underline indentation" {
   let source = "Title\n   ---\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -153,7 +164,7 @@ test "change_heading_level: indented setext drops underline indentation" {
 ///|
 test "commit_edit: indented setext preserves underline structure" {
   let source = "Title\n   ---\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let result = apply_edit(
     source,
@@ -165,7 +176,9 @@ test "commit_edit: indented setext preserves underline structure" {
 ///|
 test "toggle_list_item: paragraph to list item" {
   let source = "Hello\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "Hello\n",
+  )
   let para_id = proj.children[0].id()
   let result = apply_edit(source, ToggleListItem(node_id=para_id))
   inspect(result.contains("- Hello"), content="true")
@@ -174,7 +187,9 @@ test "toggle_list_item: paragraph to list item" {
 ///|
 test "delete: remove a block" {
   let source = "# Title\n\nParagraph\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("# Title\n\nParagraph\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "# Title\n\nParagraph\n",
+  )
   let para_id = proj.children[1].id()
   let result = apply_edit(source, Delete(node_id=para_id))
   inspect(result.contains("Paragraph"), content="false")
@@ -183,7 +198,9 @@ test "delete: remove a block" {
 ///|
 test "insert_block_after: adds newline" {
   let source = "Hello\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "Hello\n",
+  )
   let para_id = proj.children[0].id()
   let result = apply_edit(source, InsertBlockAfter(node_id=para_id))
   // Should have extra newline (new block separator)
@@ -193,7 +210,7 @@ test "insert_block_after: adds newline" {
 ///|
 test "split_block: mid-cluster offset snaps to next grapheme boundary" {
   let source = "e\u{0301}x\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let para_id = proj.children[0].id()
   let result = apply_edit(source, SplitBlock(node_id=para_id, offset=1))
   inspect(result, content="é\n\nx\n")
@@ -202,7 +219,7 @@ test "split_block: mid-cluster offset snaps to next grapheme boundary" {
 ///|
 test "split_block: ordered list item keeps ordered marker" {
   let source = "1. first\n2. second\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let item_id = proj.children[0].children[0].id()
   let result = apply_edit(source, SplitBlock(node_id=item_id, offset=2))
   inspect(result, content="1. fi\n2. rst\n2. second\n")
@@ -211,7 +228,9 @@ test "split_block: ordered list item keeps ordered marker" {
 ///|
 test "merge_with_previous: first block is no-op" {
   let source = "Hello\n"
-  let (proj, _) = @md_proj.parse_to_proj_node("Hello\n")
+  let (proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, "Hello\n",
+  )
   let para_id = proj.children[0].id()
   let result = apply_edit(source, MergeWithPrevious(node_id=para_id))
   inspect(result, content="Hello\n")
@@ -220,7 +239,7 @@ test "merge_with_previous: first block is no-op" {
 ///|
 test "move_block: moves sibling before target" {
   let source = "# A\n# B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   let result = apply_edit(
@@ -233,7 +252,7 @@ test "move_block: moves sibling before target" {
 ///|
 test "move_block: adjacent after move is no-op" {
   let source = "# A\n# B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   let result = apply_edit(
@@ -246,7 +265,7 @@ test "move_block: adjacent after move is no-op" {
 ///|
 test "move_block: adjacent duplicate before move is no-op" {
   let source = "# X\n# X\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let first_id = proj.children[0].id()
   let second_id = proj.children[1].id()
   let result = compute_edit_result(
@@ -263,7 +282,7 @@ test "move_block: adjacent duplicate before move is no-op" {
 ///|
 test "move_block: preserves paragraph blank-line separator before target" {
   let source = "A\n\nB\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   let result = apply_edit(
@@ -276,7 +295,7 @@ test "move_block: preserves paragraph blank-line separator before target" {
 ///|
 test "move_block: preserves paragraph blank-line separator after target" {
   let source = "A\n\nB\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   let result = apply_edit(
@@ -289,7 +308,7 @@ test "move_block: preserves paragraph blank-line separator after target" {
 ///|
 test "move_block: preserves separator when moving final block without trailing newline" {
   let source = "# A\n# B"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   let result = apply_edit(
@@ -302,7 +321,7 @@ test "move_block: preserves separator when moving final block without trailing n
 ///|
 test "move_block: preserves separator when moving first block after EOF block" {
   let source = "# A\n# B"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   let result = apply_edit(
@@ -315,7 +334,7 @@ test "move_block: preserves separator when moving first block after EOF block" {
 ///|
 test "move_block: preserves paragraph break left behind by moved heading" {
   let source = "A\n\n# B\nC\n\nD\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[1].id()
   let d_id = proj.children[3].id()
   let result = apply_edit(
@@ -332,7 +351,7 @@ test "move_block: preserves paragraph break left behind by moved heading" {
 ///|
 test "move_block: preserves paragraph break at target insertion" {
   let source = "# H\nP\n\nQ\n\nR\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let p_id = proj.children[1].id()
   let r_id = proj.children[3].id()
   let result = apply_edit(
@@ -345,7 +364,7 @@ test "move_block: preserves paragraph break at target insertion" {
 ///|
 test "move_block: preserves root paragraph after list target" {
   let source = "A\n\n- B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let paragraph_id = proj.children[0].id()
   let list_id = proj.children[1].id()
   let result = apply_edit(
@@ -362,7 +381,7 @@ test "move_block: preserves root paragraph after list target" {
 ///|
 test "move_block: rejects unclosed fenced code before following sibling" {
   let source = "# A\n```\ncode\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let code_id = proj.children[1].id()
   try {
@@ -383,7 +402,7 @@ test "move_block: rejects unclosed fenced code before following sibling" {
 ///|
 test "move_block: preserves unrelated adjacent sibling separator" {
   let source = "# A\n\n\n# B\n# C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let c_id = proj.children[2].id()
   let result = apply_edit(
@@ -396,7 +415,7 @@ test "move_block: preserves unrelated adjacent sibling separator" {
 ///|
 test "move_block: rejects inside position" {
   let source = "# A\n# B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let a_id = proj.children[0].id()
   let b_id = proj.children[1].id()
   inspect_edit_error(
@@ -408,7 +427,7 @@ test "move_block: rejects inside position" {
 ///|
 test "move_block: unordered list item before sibling" {
   let source = "- A\n- B\n- C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -424,7 +443,7 @@ test "move_block: unordered list item before sibling" {
 ///|
 test "move_block: unordered list item after sibling" {
   let source = "- A\n- B\n- C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -440,7 +459,7 @@ test "move_block: unordered list item after sibling" {
 ///|
 test "move_block: ordered list item before sibling" {
   let source = "1. A\n2. B\n3. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -456,7 +475,7 @@ test "move_block: ordered list item before sibling" {
 ///|
 test "move_block: ordered list item after sibling" {
   let source = "1. A\n2. B\n3. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -472,7 +491,7 @@ test "move_block: ordered list item after sibling" {
 ///|
 test "move_block: rejects duplicate list item payloads" {
   let source = "- X\n- X\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   try {
     let _ = compute_edit_result(
@@ -492,7 +511,7 @@ test "move_block: rejects duplicate list item payloads" {
 ///|
 test "move_block: rejects duplicate ordered list item payloads" {
   let source = "1. X\n2. X\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   try {
     let _ = compute_edit_result(
@@ -512,7 +531,7 @@ test "move_block: rejects duplicate ordered list item payloads" {
 ///|
 test "move_block: renumbers ordered list markers consecutively from 1" {
   let source = "1. A\n2. B\n3. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -528,7 +547,7 @@ test "move_block: renumbers ordered list markers consecutively from 1" {
 ///|
 test "move_block: renumbers ordered list when first item is empty" {
   let source = "1. \n2. B\n3. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -544,7 +563,7 @@ test "move_block: renumbers ordered list when first item is empty" {
 ///|
 test "move_block: moves empty ordered list item with renumbering" {
   let source = "1. A\n2. \n3. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -560,7 +579,7 @@ test "move_block: moves empty ordered list item with renumbering" {
 ///|
 test "move_block: preserves ordered list delimiter paren" {
   let source = "1) A\n2) B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -585,7 +604,7 @@ test "move_block: inserts padding after empty ordered seed marker" {
 test "move_block: preserves ordered list start value" {
   inspect(next_ordered_marker("-1. ").unwrap(), content="0. ")
   let source = "4. A\n5. B\n6. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -611,7 +630,7 @@ test "move_block: reindents ordered item continuations after renumbering" {
 ///|
 test "move_block: no-op for adjacent ordered items" {
   let source = "1. A\n2. B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = compute_edit_result(
     source,
@@ -627,7 +646,7 @@ test "move_block: no-op for adjacent ordered items" {
 ///|
 test "move_block: uses single newline separator between list items" {
   let source = "- A\n- B\n- C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   let result = apply_edit(
     source,
@@ -643,7 +662,7 @@ test "move_block: uses single newline separator between list items" {
 ///|
 test "move_block: rejects loose list item move" {
   let source = "- A\n\n- B\n- C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   inspect_edit_error_contains(
     source,
@@ -659,7 +678,7 @@ test "move_block: rejects loose list item move" {
 ///|
 test "move_block: rejects whitespace-blank loose list item move" {
   let source = "1. A\n  \n2. B\n3. C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   inspect_edit_error_contains(
     source,
@@ -675,7 +694,7 @@ test "move_block: rejects whitespace-blank loose list item move" {
 ///|
 test "move_block: rejects cross-list item move" {
   let source = "- A\n- B\n\nbetween\n\n- C\n- D\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let list1_items = proj.children[0].children
   let list2_items = proj.children[2].children
   inspect_edit_error(
@@ -691,7 +710,7 @@ test "move_block: rejects cross-list item move" {
 ///|
 test "move_block: rejects ordered-to-unordered list item move" {
   let source = "1. A\n2. B\n\n- C\n- D\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let ordered_items = proj.children[0].children
   let unordered_items = proj.children[1].children
   inspect_edit_error(
@@ -707,7 +726,7 @@ test "move_block: rejects ordered-to-unordered list item move" {
 ///|
 test "move_block: rejects list container sources" {
   let source = "# A\n- B\n- C\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let list_id = proj.children[1].id()
   inspect_edit_error_contains(
@@ -724,7 +743,7 @@ test "move_block: rejects list container sources" {
 ///|
 test "move_block: rejects ordered list container source" {
   let source = "# H\n1. A\n2. B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let heading_id = proj.children[0].id()
   let ordered_list_id = proj.children[1].id()
   inspect_edit_error(
@@ -740,7 +759,7 @@ test "move_block: rejects ordered list container source" {
 ///|
 test "move_block: rejects root target for list item source" {
   let source = "- A\n# B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let item_id = proj.children[0].children[0].id()
   let heading_id = proj.children[1].id()
   inspect_edit_error_contains(
@@ -757,7 +776,7 @@ test "move_block: rejects root target for list item source" {
 ///|
 test "move_block: inside position rejected before list-item checks" {
   let source = "- A\n- B\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let items = proj.children[0].children
   inspect_edit_error(
     source,
@@ -772,7 +791,7 @@ test "move_block: inside position rejected before list-item checks" {
 ///|
 test "move_block: rejects duplicate source payloads" {
   let source = "# X\n# X\n"
-  let (proj, _) = @md_proj.parse_to_proj_node(source)
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
   let first_id = proj.children[0].id()
   let second_id = proj.children[1].id()
   try {

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -13,7 +13,7 @@ import {
 // Values
 pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
 
-pub fn parse_to_proj_node(String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@markdown.Block]) -> Unit
 

--- a/lang/markdown/proj/proj_node.mbt
+++ b/lang/markdown/proj/proj_node.mbt
@@ -7,11 +7,12 @@
 ///|
 /// Convenience: parse source and project in one call (for tests and REPL).
 pub fn parse_to_proj_node(
+  source_id : @loomcore.SourceId,
   text : String,
 ) -> (@core.ProjNode[@markdown.Block], Array[String]) raise @loomcore.LexError {
-  let (cst, diagnostics) = @markdown.parse_cst(text)
+  let (cst, diagnostics) = @markdown.parse_cst(source_id, text)
   let syntax_node = @seam.SyntaxNode::from_cst(cst)
-  let errors = diagnostics.map(fn(d) { d.message })
+  let errors = diagnostics.map(d => d.message())
   let root = syntax_to_proj_node(syntax_node, Ref(0))
   (root, errors)
 }

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -1,31 +1,44 @@
 ///| Whitebox tests for Markdown projection.
 
 ///|
+let markdown_projection_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:markdown-projection",
+)
+
+///|
 test "projection: empty document" {
-  let (proj, errors) = parse_to_proj_node("")
+  let (proj, errors) = parse_to_proj_node(markdown_projection_test_source, "")
   inspect(errors.length(), content="0")
   inspect(proj.children.length(), content="0")
 }
 
 ///|
 test "projection: single paragraph" {
-  let (proj, _) = parse_to_proj_node("Hello world")
+  let (proj, _) = parse_to_proj_node(
+    markdown_projection_test_source, "Hello world",
+  )
   inspect(proj.children.length(), content="1")
 }
 
 ///|
 test "projection: heading levels" {
-  let (proj, _) = parse_to_proj_node("# H1\n\n## H2\n\n### H3")
+  let (proj, _) = parse_to_proj_node(
+    markdown_projection_test_source, "# H1\n\n## H2\n\n### H3",
+  )
   inspect(proj.children.length(), content="3")
 }
 
 ///|
 test "source map: ATX heading separates marker and text" {
   let source = "## Title\n"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(
+    markdown_projection_test_source, source,
+  )
   inspect(errors.length(), content="0")
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, diagnostics) = @markdown.parse_cst(source)
+  let (cst, diagnostics) = @markdown.parse_cst(
+    markdown_projection_test_source, source,
+  )
   inspect(diagnostics.length(), content="0")
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let heading = proj.children[0]
@@ -43,10 +56,14 @@ test "source map: ATX heading separates marker and text" {
 ///|
 test "source map: setext heading separates underline and text" {
   let source = "Title\n---\n"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(
+    markdown_projection_test_source, source,
+  )
   inspect(errors.length(), content="0")
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, diagnostics) = @markdown.parse_cst(source)
+  let (cst, diagnostics) = @markdown.parse_cst(
+    markdown_projection_test_source, source,
+  )
   inspect(diagnostics.length(), content="0")
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let heading = proj.children[0]
@@ -64,10 +81,14 @@ test "source map: setext heading separates underline and text" {
 ///|
 test "source map: multiline setext text excludes underline separator" {
   let source = "Foo\nbar\n---\n"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(
+    markdown_projection_test_source, source,
+  )
   inspect(errors.length(), content="0")
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, diagnostics) = @markdown.parse_cst(source)
+  let (cst, diagnostics) = @markdown.parse_cst(
+    markdown_projection_test_source, source,
+  )
   inspect(diagnostics.length(), content="0")
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let heading = proj.children[0]
@@ -81,10 +102,14 @@ test "source map: multiline setext text excludes underline separator" {
 ///|
 test "source map: indented setext text excludes separator indentation" {
   let source = "Title\n   ---\n"
-  let (proj, errors) = parse_to_proj_node(source)
+  let (proj, errors) = parse_to_proj_node(
+    markdown_projection_test_source, source,
+  )
   inspect(errors.length(), content="0")
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, diagnostics) = @markdown.parse_cst(source)
+  let (cst, diagnostics) = @markdown.parse_cst(
+    markdown_projection_test_source, source,
+  )
   inspect(diagnostics.length(), content="0")
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let heading = proj.children[0]
@@ -97,7 +122,9 @@ test "source map: indented setext text excludes separator indentation" {
 
 ///|
 test "projection: delimiter resolver preserves italic and bold payloads" {
-  let (proj, errors) = parse_to_proj_node("_em_ and **strong**\n")
+  let (proj, errors) = parse_to_proj_node(
+    markdown_projection_test_source, "_em_ and **strong**\n",
+  )
   inspect(errors.length(), content="0")
   match proj.children[0].kind {
     Paragraph([Italic([Text(em)]), Text(separator), Bold([Text(strong)])]) => {
@@ -111,7 +138,9 @@ test "projection: delimiter resolver preserves italic and bold payloads" {
 
 ///|
 test "projection: unordered list" {
-  let (proj, _) = parse_to_proj_node("- first\n- second\n- third")
+  let (proj, _) = parse_to_proj_node(
+    markdown_projection_test_source, "- first\n- second\n- third",
+  )
   inspect(proj.children.length(), content="1")
   let list = proj.children[0]
   inspect(list.children.length(), content="3")
@@ -119,7 +148,9 @@ test "projection: unordered list" {
 
 ///|
 test "projection: ordered list" {
-  let (proj, _) = parse_to_proj_node("1. first\n2. second\n")
+  let (proj, _) = parse_to_proj_node(
+    markdown_projection_test_source, "1. first\n2. second\n",
+  )
   inspect(proj.children.length(), content="1")
   let list = proj.children[0]
   match list.kind {
@@ -132,9 +163,9 @@ test "projection: ordered list" {
 ///|
 test "source map: ordered list item text excludes marker" {
   let source = "1. first\n2. second\n"
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_projection_test_source, source)
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, _) = @markdown.parse_cst(source)
+  let (cst, _) = @markdown.parse_cst(markdown_projection_test_source, source)
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let item = proj.children[0].children[0]
   match source_map.get_token_span(item.id(), "text") {
@@ -147,7 +178,7 @@ test "source map: ordered list item text excludes marker" {
 ///|
 test "view: ordered list keeps ordered kind tag from payload" {
   let source = "1. first\n2. second\n"
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_projection_test_source, source)
   let source_map = @core.SourceMap::from_ast(proj)
   let view = proj_to_view_node(proj, source_map, source_text=Some(source))
   inspect(view.children[0].kind_tag, content="OrderedList")
@@ -156,9 +187,9 @@ test "view: ordered list keeps ordered kind tag from payload" {
 ///|
 test "source map: outer ordered item marker wins over nested bullet" {
   let source = "1. parent\n   - child\n"
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_projection_test_source, source)
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, _) = @markdown.parse_cst(source)
+  let (cst, _) = @markdown.parse_cst(markdown_projection_test_source, source)
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   let item = proj.children[0].children[0]
   match source_map.get_token_span(item.id(), "text") {
@@ -170,21 +201,23 @@ test "source map: outer ordered item marker wins over nested bullet" {
 
 ///|
 test "projection: code block" {
-  let (proj, _) = parse_to_proj_node("```js\nconsole.log(42)\n```")
+  let (proj, _) = parse_to_proj_node(
+    markdown_projection_test_source, "```js\nconsole.log(42)\n```",
+  )
   inspect(proj.children.length(), content="1")
 }
 
 ///|
 test "projection: html block" {
   let source = "# Before\n\n<div>\nraw\n</div>\n\nAfter"
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_projection_test_source, source)
   inspect(proj.children.length(), content="3")
   match proj.children[1].kind {
     HtmlBlock(value) => inspect(value, content="<div>\nraw\n</div>\n")
     _ => fail("expected html block payload")
   }
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, _) = @markdown.parse_cst(source)
+  let (cst, _) = @markdown.parse_cst(markdown_projection_test_source, source)
   populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
   // Verify the "text" span covers the raw HTML content
   match source_map.get_token_span(proj.children[1].id(), "text") {
@@ -197,21 +230,23 @@ test "projection: html block" {
 ///|
 test "projection: mixed blocks" {
   let source = "# Title\n\nSome text.\n\n- item one\n- item two\n\nMore text."
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_projection_test_source, source)
   inspect(proj.children.length(), content="4")
 }
 
 ///|
 test "projection: node positions span source text" {
   let source = "# Hello\n\nWorld"
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_projection_test_source, source)
   inspect(proj.start, content="0")
   inspect(proj.children[0].start, content="0")
 }
 
 ///|
 test "projection: IDs are unique" {
-  let (proj, _) = parse_to_proj_node("# H1\n\n- a\n- b")
+  let (proj, _) = parse_to_proj_node(
+    markdown_projection_test_source, "# H1\n\n- a\n- b",
+  )
   let ids : Array[Int] = []
   fn collect(node : @core.ProjNode[@markdown.Block]) {
     ids.push(node.node_id)
@@ -234,7 +269,9 @@ test "projection: IDs are unique" {
 ///|
 test "projection: incremental reparse preserves IDs" {
   let source = "# Hello\n\nWorld"
-  let parser = @loom.new_imperative_parser(source, @markdown.markdown_grammar)
+  let parser = @loom.new_imperative_parser(
+    markdown_projection_test_source, source, @markdown.markdown_grammar,
+  )
   let counter : Ref[Int] = Ref(0)
   // Initial parse
   let _ = parser.parse()

--- a/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_side_table_wbtest.mbt
@@ -1,6 +1,11 @@
 ///| Whitebox side-table tests for the Stable Document Entity Graph Phase 0 idea.
 
 ///|
+let markdown_side_table_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:markdown-heading-side-table",
+)
+
+///|
 /// These tests exercise the package-private side-table model and validate the
 /// internal lifecycle sketch in `docs/design/sdeg-nodeid-side-table.md`.
 
@@ -202,7 +207,9 @@ test "sdeg phase0: NodeId side table preserves same-node matches before semantic
   let counter : Ref[Int] = Ref(0)
   let source = "# A\n# B\n"
   let next_source = "# C\n# A\n"
-  let (initial_cst, _) = @markdown.parse_cst(source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_side_table_test_source, source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -241,7 +248,9 @@ test "sdeg phase0: NodeId side table records semantic drift on same-node reorder
   let counter : Ref[Int] = Ref(0)
   let source = "# A\n# B\n"
   let next_source = "# B\n# A\n"
-  let (initial_cst, _) = @markdown.parse_cst(source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_side_table_test_source, source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -287,7 +296,9 @@ test "sdeg phase0: NodeId side table tombstone recovers delete-restore" {
   let initial_source = "# A\n# B\n"
   let deleted_source = "# B\n"
   let restored_source = "# A\n# B\n"
-  let (initial_cst, _) = @markdown.parse_cst(initial_source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_side_table_test_source, initial_source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -359,7 +370,9 @@ test "sdeg phase0: NodeId side table keeps duplicate restore ambiguous" {
   let initial_source = "# A\n# B\n"
   let deleted_source = "# B\n"
   let restored_source = "# A\n# A\n# B\n"
-  let (initial_cst, _) = @markdown.parse_cst(initial_source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_side_table_test_source, initial_source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -524,7 +537,9 @@ test "sdeg phase0: NodeId side table invariants hold across lifecycle states" {
   let source = "# A\n# B\n"
   let deleted_source = "# B\n"
   let restored_source = "# A\n# B\n"
-  let (initial_cst, _) = @markdown.parse_cst(source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_side_table_test_source, source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -851,7 +866,11 @@ fn completed_cell_label(
 
 ///|
 test "sdeg phase1: public projection memos force heading side table through source map" {
-  let parser = @loom.new_parser("# A\n", @markdown.markdown_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:markdown-heading-side-table:invalid-gap"),
+    "# A\n",
+    @markdown.markdown_grammar,
+  )
   let runtime = parser.runtime()
   let completed_labels : Array[String] = []
   try! runtime.on_derived_event(event => {
@@ -880,7 +899,11 @@ test "sdeg phase1: public projection memos force heading side table through sour
 
 ///|
 test "sdeg phase1: production side table memo treats valid delete as absence evidence" {
-  let parser = @loom.new_parser("# A\n", @markdown.markdown_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:markdown-heading-side-table:recovery"),
+    "# A\n",
+    @markdown.markdown_grammar,
+  )
   let bundle = build_markdown_projection_memos_with_heading_side_table(parser)
   let source_map = bundle.source_map_memo
   let side_table = bundle.heading_side_table_memo
@@ -904,7 +927,11 @@ test "sdeg phase1: production side table memo treats valid delete as absence evi
 
 ///|
 test "sdeg phase1: production side table memo holds malformed snapshots" {
-  let parser = @loom.new_parser("# A\n", @markdown.markdown_grammar)
+  let parser = @loom.new_parser(
+    @loomcore.SourceId("canopy-test:markdown-heading-side-table:error-node"),
+    "# A\n",
+    @markdown.markdown_grammar,
+  )
   let bundle = build_markdown_projection_memos_with_heading_side_table(parser)
   let source_map = bundle.source_map_memo
   let side_table = bundle.heading_side_table_memo

--- a/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
+++ b/lang/markdown/proj/sdeg_heading_spike_wbtest.mbt
@@ -1,6 +1,11 @@
 ///| Whitebox spike tests for the Stable Document Entity Graph Phase 0 idea.
 
 ///|
+let markdown_heading_spike_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:markdown-heading-spike",
+)
+
+///|
 /// These tests intentionally do not add a public SDEG API. They treat Markdown
 /// headings as session-local entities backed by existing `NodeId`, `ProjNode`,
 /// and `SourceMap` data, then pin what the current projection identity pipeline
@@ -46,7 +51,7 @@ fn source_map_for(
   proj : @core.ProjNode[@markdown.Block],
 ) -> @core.SourceMap raise @loomcore.LexError {
   let source_map = @core.SourceMap::from_ast(proj)
-  let (cst, _) = @markdown.parse_cst(source)
+  let (cst, _) = @markdown.parse_cst(markdown_heading_spike_test_source, source)
   let syntax_root = @seam.SyntaxNode::from_cst(cst)
   populate_token_spans(source_map, syntax_root, proj)
   source_map
@@ -56,7 +61,7 @@ fn source_map_for(
 fn project_source(
   source : String,
 ) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise @loomcore.LexError {
-  let (proj, _) = parse_to_proj_node(source)
+  let (proj, _) = parse_to_proj_node(markdown_heading_spike_test_source, source)
   (proj, source_map_for(source, proj))
 }
 
@@ -66,7 +71,9 @@ fn project_after_reconcile(
   next_source : String,
   counter : Ref[Int],
 ) -> (@core.ProjNode[@markdown.Block], @core.SourceMap) raise @loomcore.LexError {
-  let (cst, _) = @markdown.parse_cst(next_source)
+  let (cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, next_source,
+  )
   let syntax_root = @seam.SyntaxNode::from_cst(cst)
   let raw = syntax_to_proj_node(syntax_root, counter)
   let reconciled = @core.reconcile(old, raw, counter)
@@ -231,7 +238,9 @@ test "sdeg phase0: heading observation is backed by SourceMap ranges" {
 ///|
 test "sdeg phase0: heading rename preserves session-local NodeId" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# Alpha\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# Alpha\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -251,7 +260,9 @@ test "sdeg phase0: heading rename preserves session-local NodeId" {
 ///|
 test "sdeg phase0: heading reorder is currently position-stable, not semantic-stable" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -292,7 +303,9 @@ test "sdeg phase0: ProjectionIdentityTracker does not solve heading reorder" {
   let counter : Ref[Int] = Ref(0)
   let source = "# A\n# B\n"
   let next_source = "# B\n# A\n"
-  let (initial_cst, _) = @markdown.parse_cst(source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -324,7 +337,9 @@ test "sdeg phase0: ProjectionIdentityTracker does not solve heading reorder" {
 ///|
 test "sdeg phase0: matching evidence detects semantic reorder mismatch" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -360,7 +375,9 @@ test "sdeg phase0: matching evidence detects semantic reorder mismatch" {
 ///|
 test "sdeg phase0: semantic side-table matcher follows simple heading reorder" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -441,7 +458,9 @@ test "sdeg phase0: retained duplicate headings stay ambiguous after one remains"
 ///|
 test "sdeg phase0: delete and restore currently cannot recover the retired heading id" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -472,7 +491,9 @@ test "sdeg phase0: ProjectionIdentityTracker does not recover after committed de
   let initial_source = "# A\n# B\n"
   let deleted_source = "# B\n"
   let restored_source = "# A\n# B\n"
-  let (initial_cst, _) = @markdown.parse_cst(initial_source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, initial_source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -507,7 +528,9 @@ test "sdeg phase0: ProjectionIdentityTracker does not recover after committed de
 ///|
 test "sdeg phase0: matching evidence detects delete-restore recovery candidate" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -536,7 +559,9 @@ test "sdeg phase0: matching evidence detects delete-restore recovery candidate" 
 ///|
 test "sdeg phase0: semantic side-table matcher finds delete-restore candidate" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -570,7 +595,9 @@ test "sdeg phase0: semantic side-table matcher finds delete-restore candidate" {
 test "sdeg phase0: inline malformed-to-recovered heading preserves heading NodeId" {
   let counter : Ref[Int] = Ref(0)
   let malformed_source = "# **unclosed\n"
-  let (initial_cst, _) = @markdown.parse_cst(malformed_source)
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, malformed_source,
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,
@@ -591,7 +618,9 @@ test "sdeg phase0: inline malformed-to-recovered heading preserves heading NodeI
 ///|
 test "sdeg phase0: format-like whitespace rewrite preserves heading NodeIds" {
   let counter : Ref[Int] = Ref(0)
-  let (initial_cst, _) = @markdown.parse_cst("# A\n\n# B\n")
+  let (initial_cst, _) = @markdown.parse_cst(
+    markdown_heading_spike_test_source, "# A\n\n# B\n",
+  )
   let initial = syntax_to_proj_node(
     @seam.SyntaxNode::from_cst(initial_cst),
     counter,

--- a/lang/runtime/language_spec.mbt
+++ b/lang/runtime/language_spec.mbt
@@ -19,7 +19,9 @@
 /// message rendering it needs) stays language-owned and the record stays
 /// unbounded.
 pub struct LanguageSpec[T, Op] {
-  priv make_parser : (String, @incr.Runtime?) -> @loom.Parser[T]
+  priv make_parser : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[
+    T,
+  ]
   priv build_memos : (@loom.Parser[T]) -> (
     @incr.Derived[@core.ProjNode[T]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],
@@ -34,7 +36,9 @@ pub struct LanguageSpec[T, Op] {
 
 ///|
 pub fn[T, Op] LanguageSpec::LanguageSpec(
-  make_parser~ : (String, @incr.Runtime?) -> @loom.Parser[T],
+  make_parser~ : (@loom_core.SourceId, String, @incr.Runtime?) -> @loom.Parser[
+    T,
+  ],
   build_memos~ : (@loom.Parser[T]) -> (
     @incr.Derived[@core.ProjNode[T]?],
     @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]],

--- a/lang/runtime/language_spec_test.mbt
+++ b/lang/runtime/language_spec_test.mbt
@@ -24,8 +24,8 @@ fn stub_spec(
   ) = @json_proj.build_json_projection_memos,
 ) -> @runtime.LanguageSpec[@djson.JsonValue, String] {
   @runtime.LanguageSpec::LanguageSpec(
-    make_parser=fn(s, rt) {
-      @loom.new_parser(s, @djson.json_grammar, runtime?=rt)
+    make_parser=(source_id, source, runtime) => {
+      @loom.new_parser(source_id, source, @djson.json_grammar, runtime?)
     },
     build_memos~,
     compute_edit~,

--- a/lang/runtime/moon.pkg
+++ b/lang/runtime/moon.pkg
@@ -4,6 +4,7 @@ import {
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/loom",
+  "dowdiness/loom/core" @loom_core,
 }
 
 import {

--- a/lang/runtime/pkg.generated.mbti
+++ b/lang/runtime/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "dowdiness/canopy/lang/runtime"
 
 import {
-  "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
@@ -17,7 +16,7 @@ import {
 pub struct LanguageSpec[T, Op] {
   // private fields
 }
-pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@core.ProjNode[T]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[T]]], @cells.Derived[@core.SourceMap]), compute_edit~ : (Op, String, @core.ProjNode[T], @core.SourceMap) -> (Array[@core.SpanEdit], @core.FocusHint)? raise @core.EditError, on_no_edit~ : (Op) -> Unit raise @core.EditError) -> Self[T, Op]
+pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (@dowdiness/loom/core.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), compute_edit~ : (Op, String, @dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap) -> (Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint)? raise @dowdiness/canopy/core.EditError, on_no_edit~ : (Op) -> Unit raise @dowdiness/canopy/core.EditError) -> Self[T, Op]
 pub fn[T : Eq, Op] LanguageSpec::apply_edit(Self[T, Op], @editor.SyncEditor[T], Op, Int) -> Result[Unit, String]
 pub fn[T, Op] LanguageSpec::new_editor(Self[T, Op], String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : @editor.LanguageCapabilities[T]) -> @editor.SyncEditor[T] raise @text.TextError
 

--- a/probe/algebra_merge/algebra_merge_wbtest.mbt
+++ b/probe/algebra_merge/algebra_merge_wbtest.mbt
@@ -1,4 +1,9 @@
 ///|
+let algebra_merge_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:algebra-merge",
+)
+
+///|
 /// Base document shared by both replicas before they diverge.
 ///
 /// Offsets referenced by the operations below (`fn send(msg, kind) { msg + kind }`):
@@ -90,7 +95,9 @@ fn merge(
 /// parses. This is the semantic judge: a merge can converge and still leave
 /// the program referring to a binder that no longer exists.
 fn free_vars(source : String) -> String {
-  let term = @lambda.parse(source) catch { _ => return "does not parse" }
+  let term = @lambda.parse(algebra_merge_test_source, source) catch {
+    _ => return "does not parse"
+  }
   let (_, resolution) = @lambda.resolve(term)
   let free = resolution.vars
     .values()

--- a/probe/algebra_merge/moon.pkg
+++ b/probe/algebra_merge/moon.pkg
@@ -2,6 +2,7 @@ import {
   "dowdiness/event-graph-walker/text",
   "dowdiness/lambda",
   "dowdiness/lambda/ast",
+  "dowdiness/loom/core" @loomcore,
   "dowdiness/seam",
   "dowdiness/canopy/core",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,

--- a/probe/algebra_merge/operation_replay_wbtest.mbt
+++ b/probe/algebra_merge/operation_replay_wbtest.mbt
@@ -17,9 +17,14 @@
 ///      layer would happily apply.
 
 ///|
+let operation_replay_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:algebra-merge-operation-replay",
+)
+
+///|
 /// Parse `text` and assemble the EditContext the shipped lowering needs.
 fn build_ctx(text : String) -> @edits.EditContext[@ast.Term] raise {
-  let (cst, _) = @lambda.parse_cst(text)
+  let (cst, _) = @lambda.parse_cst(operation_replay_test_source, text)
   let syntax = @seam.SyntaxNode::from_cst(cst)
   let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   let source_map = @core.SourceMap::from_ast(proj)

--- a/projection/lens_test.mbt
+++ b/projection/lens_test.mbt
@@ -1,15 +1,24 @@
 // Tests for the projection infrastructure after CanonicalModel removal.
 
 ///|
+let projection_lens_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-lens",
+)
+
+///|
 test "SourceMap from_ast" {
-  let (root, _) = @lambda_proj.parse_to_proj_node("42")
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "42",
+  )
   let source_map = @core.SourceMap::from_ast(root)
   inspect(source_map.node_count() >= 1, content="true")
 }
 
 ///|
 test "parse_to_proj_node preserves child-specific ranges" {
-  let (root, _) = @lambda_proj.parse_to_proj_node("x + 1")
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x + 1",
+  )
   inspect(root.children.length(), content="2")
   inspect(root.children[0].start < root.children[1].start, content="true")
   inspect(root.children[0].end <= root.children[1].start, content="true")
@@ -17,7 +26,9 @@ test "parse_to_proj_node preserves child-specific ranges" {
 
 ///|
 test "SourceMap innermost_node_at distinguishes operands" {
-  let (root, _) = @lambda_proj.parse_to_proj_node("x + 1")
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x + 1",
+  )
   let source_map = @core.SourceMap::from_ast(root)
   let left_pos = root.children[0].start
   let right_pos = if root.children[1].end > root.children[1].start {
@@ -37,7 +48,9 @@ test "SourceMap innermost_node_at distinguishes operands" {
 
 ///|
 test "TreeEditorState from_projection" {
-  let (root, _) = @lambda_proj.parse_to_proj_node("x + 1")
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x + 1",
+  )
   let state = TreeEditorState::from_projection(
     Some(root),
     @core.SourceMap::from_ast(root),
@@ -47,7 +60,9 @@ test "TreeEditorState from_projection" {
 
 ///|
 test "InteractiveTreeNode from AstNode" {
-  let (root, _) = @lambda_proj.parse_to_proj_node("(x) => x")
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "(x) => x",
+  )
   let tree = InteractiveTreeNode::from_term_node(
     root,
     @core.SourceMap::from_ast(root),
@@ -57,8 +72,12 @@ test "InteractiveTreeNode from AstNode" {
 
 ///|
 test "reconcile_ast preserves IDs for matching nodes" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("x + 1")
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("x + 2")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x + 1",
+  )
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x + 2",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(reconciled.node_id, content=old_root.node_id.to_string())
   inspect(
@@ -75,8 +94,12 @@ test "reconcile_ast preserves IDs for matching nodes" {
 
 ///|
 test "reconcile_ast preserves IDs across operator-only edits" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("x + 1")
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("x - 1")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x + 1",
+  )
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "x - 1",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(reconciled.node_id, content=old_root.node_id.to_string())
   inspect(
@@ -97,8 +120,12 @@ test "reconcile_ast preserves IDs across operator-only edits" {
 
 ///|
 test "reconcile_ast shrinks rebuilt source map when children disappear" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("1 + 2 + 3")
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("1 + 2")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "1 + 2 + 3",
+  )
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "1 + 2",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(100))
   inspect(
     @core.SourceMap::from_ast(reconciled).node_count() <
@@ -109,7 +136,9 @@ test "reconcile_ast shrinks rebuilt source map when children disappear" {
 
 ///|
 test "node_at_position covers parenthesis positions" {
-  let (root, _) = @lambda_proj.parse_to_proj_node("(x)")
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    projection_lens_test_source, "(x)",
+  )
   let source_map = @core.SourceMap::from_ast(root)
   inspect(source_map.innermost_node_at(0) is None, content="false")
   inspect(source_map.innermost_node_at(2) is None, content="false")

--- a/projection/proj_node_json_test.mbt
+++ b/projection/proj_node_json_test.mbt
@@ -1,6 +1,13 @@
 ///|
+let projection_json_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-json",
+)
+
+///|
 test "ProjNode JSON export for simple expression" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("42")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    projection_json_test_source, "42",
+  )
   inspect(
     proj.to_json().stringify(),
     content=(
@@ -11,7 +18,9 @@ test "ProjNode JSON export for simple expression" {
 
 ///|
 test "ProjNode JSON export for lambda" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("(x) => x")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    projection_json_test_source, "(x) => x",
+  )
   inspect(
     proj.to_json().stringify(),
     content=(
@@ -22,7 +31,9 @@ test "ProjNode JSON export for lambda" {
 
 ///|
 test "ProjNode JSON export for application" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("f x")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    projection_json_test_source, "f x",
+  )
   inspect(
     proj.to_json().stringify(),
     content=(
@@ -33,7 +44,9 @@ test "ProjNode JSON export for application" {
 
 ///|
 test "ProjNode JSON export for binary op" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("1 + 2")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    projection_json_test_source, "1 + 2",
+  )
   inspect(
     proj.to_json().stringify(),
     content=(
@@ -44,7 +57,9 @@ test "ProjNode JSON export for binary op" {
 
 ///|
 test "ProjNode JSON export for module" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("let x = 1\nx")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    projection_json_test_source, "let x = 1\nx",
+  )
   inspect(
     proj.to_json().stringify(),
     content=(
@@ -55,7 +70,9 @@ test "ProjNode JSON export for module" {
 
 ///|
 test "SourceMap JSON export" {
-  let (proj, _) = @lambda_proj.parse_to_proj_node("1 + 2")
+  let (proj, _) = @lambda_proj.parse_to_proj_node(
+    projection_json_test_source, "1 + 2",
+  )
   let sm = @core.SourceMap::from_ast(proj)
   inspect(
     sm.to_json().stringify(),

--- a/projection/proj_node_test.mbt
+++ b/projection/proj_node_test.mbt
@@ -1,6 +1,13 @@
 ///|
+let projection_proj_node_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-proj-node",
+)
+
+///|
 fn parse_syntax(text : String) -> @seam.SyntaxNode raise {
-  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  let (cst, _) = @parser.parse_cst(projection_proj_node_test_source, text) catch {
+    _ => fail("parse failed")
+  }
   @seam.SyntaxNode::from_cst(cst)
 }
 

--- a/projection/reconcile_lcs_benchmark_wbtest.mbt
+++ b/projection/reconcile_lcs_benchmark_wbtest.mbt
@@ -20,11 +20,18 @@
 // def + the trailing body), giving a wide sibling list for the LCS DP.
 
 ///|
+let reconcile_lcs_benchmark_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-reconcile-lcs-benchmark",
+)
+
+///|
 fn lcs_setup(n : Int) -> (ProjNode[@ast.Term], ProjNode[@ast.Term]) raise {
   let (root_a, _) = @lambda_proj.parse_to_proj_node(
+    reconcile_lcs_benchmark_source,
     tree_refresh_bench_source(n, "0"),
   )
   let (root_b, _) = @lambda_proj.parse_to_proj_node(
+    reconcile_lcs_benchmark_source,
     tree_refresh_bench_source(n, "1"),
   )
   (root_a, root_b)

--- a/projection/source_map_token_spans_wbtest.mbt
+++ b/projection/source_map_token_spans_wbtest.mbt
@@ -1,8 +1,15 @@
 // Whitebox tests for SourceMap token-level spans
 
 ///|
+let source_map_token_spans_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-source-map-token-spans",
+)
+
+///|
 fn parse_syntax_for_token_test(text : String) -> @seam.SyntaxNode raise {
-  let (cst, _) = @parser.parse_cst(text) catch { _ => fail("parse failed") }
+  let (cst, _) = @parser.parse_cst(source_map_token_spans_test_source, text) catch {
+    _ => fail("parse failed")
+  }
   @seam.SyntaxNode::from_cst(cst)
 }
 

--- a/projection/tree_editor_wbtest.mbt
+++ b/projection/tree_editor_wbtest.mbt
@@ -1,10 +1,17 @@
 // Whitebox tests for TreeEditorState using ProjNode + SourceMap directly.
 
 ///|
+let tree_editor_test_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-tree-editor",
+)
+
+///|
 fn tree_editor_test_state(
   source : String,
 ) -> (ProjNode[@ast.Term], SourceMap, TreeEditorState[@ast.Term]) raise {
-  let (root, _) = @lambda_proj.parse_to_proj_node(source)
+  let (root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, source,
+  )
   let source_map = SourceMap::from_ast(root)
   (root, source_map, TreeEditorState::from_projection(Some(root), source_map))
 }
@@ -71,10 +78,14 @@ fn tree_editor_test_refresh_minimal(
 
 ///|
 test "refresh_node_minimal skips unchanged subtrees" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 4)")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 4)",
+  )
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 5)",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let ui_state : TreeUIState = {
@@ -493,10 +504,14 @@ test "from_projection builds structural indexes" {
 
 ///|
 test "refresh rebuilds structural indexes for updated projection" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 4)")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 4)",
+  )
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 5)",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let refreshed = state.refresh(Some(reconciled), source_map)
@@ -523,10 +538,14 @@ test "refresh rebuilds structural indexes for updated projection" {
 
 ///|
 test "refresh builder reuses unchanged sibling subtree after unrelated leaf change" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 4)")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 4)",
+  )
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 5)",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let ui_state : TreeUIState = {
@@ -667,7 +686,9 @@ test "build_preorder_from_tree matches eagerly-built indexes" {
 
 ///|
 test "TreeEditorState::refresh preserves unchanged sibling subtree through public API" {
-  let (old_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 4)")
+  let (old_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 4)",
+  )
   let old_source_map = SourceMap::from_ast(old_root)
   let state = TreeEditorState::from_projection(Some(old_root), old_source_map)
   let old_tree = match state.tree {
@@ -678,7 +699,9 @@ test "TreeEditorState::refresh preserves unchanged sibling subtree through publi
   let old_left = old_root_children[0]
   let old_right = old_root_children[1]
 
-  let (new_root, _) = @lambda_proj.parse_to_proj_node("(1 + 2) + (3 + 5)")
+  let (new_root, _) = @lambda_proj.parse_to_proj_node(
+    tree_editor_test_source, "(1 + 2) + (3 + 5)",
+  )
   let reconciled = @core.reconcile(old_root, new_root, Ref(1000))
   let source_map = SourceMap::from_ast(reconciled)
   let refreshed = state.refresh(Some(reconciled), source_map)

--- a/projection/tree_refresh_benchmark_wbtest.mbt
+++ b/projection/tree_refresh_benchmark_wbtest.mbt
@@ -1,6 +1,11 @@
 // Benchmark for TreeEditorState::refresh — measures the tree refresh hot path.
 
 ///|
+let tree_refresh_benchmark_source : @loomcore.SourceId = @loomcore.SourceId(
+  "canopy-test:projection-tree-refresh-benchmark",
+)
+
+///|
 fn tree_refresh_bench_source(let_count : Int, tail_literal : String) -> String {
   let segments : Array[String] = []
   for i = 0; i < let_count - 1; i = i + 1 {
@@ -23,10 +28,14 @@ fn tree_refresh_bench_setup(
 ) raise {
   let source_a = tree_refresh_bench_source(let_count, "0")
   let source_b = tree_refresh_bench_source(let_count, "1")
-  let (root_a, _) = @lambda_proj.parse_to_proj_node(source_a)
+  let (root_a, _) = @lambda_proj.parse_to_proj_node(
+    tree_refresh_benchmark_source, source_a,
+  )
   let sm_a = SourceMap::from_ast(root_a)
   let state = TreeEditorState::from_projection(Some(root_a), sm_a)
-  let (root_b, _) = @lambda_proj.parse_to_proj_node(source_b)
+  let (root_b, _) = @lambda_proj.parse_to_proj_node(
+    tree_refresh_benchmark_source, source_b,
+  )
   let reconciled = @core.reconcile(root_a, root_b, Ref(1000))
   let sm_b = SourceMap::from_ast(reconciled)
   (state, root_a, sm_a, reconciled, sm_b)

--- a/workspace/probe/gate1_runtime_safety_wbtest.mbt
+++ b/workspace/probe/gate1_runtime_safety_wbtest.mbt
@@ -56,11 +56,32 @@
 // recommendation update).
 
 ///|
+let next_probe_source_identity : Ref[Int] = { val: 0 }
+
+///|
 fn json_parser_on(
   rt : @incr.Runtime,
   source : String,
 ) -> @loom.Parser[@_json_lang.JsonValue] {
-  @loom.new_parser(source, @_json_lang.json_grammar, runtime=rt)
+  let identity = next_probe_source_identity.val
+  next_probe_source_identity.val = identity + 1
+  @loom.new_parser(
+    @loomcore.SourceId("canopy-test:workspace-probe:" + identity.to_string()),
+    source,
+    @_json_lang.json_grammar,
+    runtime=rt,
+  )
+}
+
+///|
+test "P0a gate #1 source identity is construction-scoped and stable" {
+  let shared_rt = @incr.Runtime()
+  let parser_a = json_parser_on(shared_rt, "[1]")
+  let parser_b = json_parser_on(shared_rt, "[1]")
+  let source_a = parser_a.source_id()
+  inspect(source_a == parser_b.source_id(), content="false")
+  parser_a.set_source("[2]")
+  inspect(parser_a.source_id() == source_a, content="true")
 }
 
 ///|

--- a/workspace/probe/test_grammar.mbt
+++ b/workspace/probe/test_grammar.mbt
@@ -107,7 +107,10 @@ fn is_ident_char(c : Char) -> Bool {
 }
 
 ///|
-fn lex_test_expr(source : String) -> @loomcore.LexResult[TestToken] {
+fn lex_test_expr(
+  source_id : @loomcore.SourceId,
+  source : String,
+) -> @loomcore.LexResult[TestToken] {
   let located : Array[@loomcore.LocatedToken[TestToken]] = []
   let n = source.length()
   let mut i = 0
@@ -143,6 +146,7 @@ fn lex_test_expr(source : String) -> @loomcore.LexResult[TestToken] {
     }
   }
   @loomcore.LexResult::from_located_tokens(
+    source_id,
     source,
     located,
     gap_token=fn(_text, _start, _end) { Whitespace },
@@ -332,7 +336,9 @@ pub fn new_test_editor(
 ) -> @editor.SyncEditor[TestExpr] raise @text.TextError {
   @editor.SyncEditor::new_generic(
     agent_id,
-    fn(s, rt) { @loom.new_parser(s, test_grammar, runtime?=rt) },
+    (source_id, source, runtime) => {
+      @loom.new_parser(source_id, source, test_grammar, runtime?)
+    },
     build_test_projection_memos,
     capture_timeout_ms~,
     parent_runtime?,
@@ -348,8 +354,13 @@ pub fn new_empty_diagnostic_test_editor(
 ) -> @editor.SyncEditor[TestExpr] raise @text.TextError {
   @editor.SyncEditor::new_generic(
     agent_id,
-    (source, runtime) => {
-      @loom.new_parser(source, empty_diagnostic_test_grammar, runtime?)
+    (source_id, source, runtime) => {
+      @loom.new_parser(
+        source_id,
+        source,
+        empty_diagnostic_test_grammar,
+        runtime?,
+      )
     },
     build_test_projection_memos,
   )


### PR DESCRIPTION
## Summary

- Advance the Loom submodule to [Loom PR #795](https://github.com/dowdiness/loom/pull/795), merge commit `5f34e395cc62c59e4ca391e5bbef86d12063d7e6`, adding opaque source IDs, validated source spans, styled labels, private fields, defensive copies, and source-scoped transforms.
- Thread construction-scoped `SourceId` values through Canopy editors, language projections, REPL, JSX and Markdown FFI shells, workspace probes, and the separately rooted Canvas Graph DSL adapter without deriving identity from producer names or mutable source text.
- Project only current-source `Primary` labels into the unchanged producer-neutral protocol while preserving range, severity, message, code, locationless compatibility, and diagnostic clearing.

## UI and review evidence

N/A — no visual design or protocol wire-shape change.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceId`, `SourceSpan`, `TextRange`, `TextOffset` | `loom/loom/core` | Yes | Preserve validated half-open UTF-16 ranges and source identity in the existing Loom model. |
| `DiagnosticSet::items`, diagnostic and label accessors | `loom/loom/core` | Yes | Preserve defensive-copy boundaries and avoid exposing mutable arrays. |
| `Option`, `Result`, `Array`, `Iter` | MoonBit core | Yes | Declarative optional fields, filtering, mapping, and owned boundary arrays. |
| `Map`, `Set`, `cmp`, sorting and overlap helpers | MoonBit core / project APIs | No | Projection and transforms operate independently over ordered labels and require no grouping, normalization, or new overlap rule. |
| Existing editor identity and Canvas append-only handle | Canopy editor / Canvas registry | Yes | Supply stable construction identity without a source registry or text-derived key. |

New helpers added:

- `project_diagnostics_for_source` owns only the Loom-to-existing-protocol narrowing policy.
- `allocate_jsx_source_id` owns the JSX FFI construction counter shared by one-shot and session paths.
- `source_graph_source_id` owns only the Canvas handle namespace conversion.

## Validation scope

Boundary matrix / first failing regression:

- source A edits do not shift or drop source B labels;
- same-source shift, drop, and replay preserve half-open UTF-16 boundaries, including zero-width EOF;
- primary and secondary style, label message, multiple labels, and multiple sources survive transforms;
- invalid ranges are rejected and all array boundaries remain defensive copies;
- source identity remains distinct from diagnostic producer identity;
- current-source primary projection preserves severity, message, code, locationless compatibility, foreign-source omission, and clearing;
- Canvas Graph DSL construction owns one stable ID per handle and distinct handles receive distinct IDs.

Target packages:

`loom/loom/core`, `editor`, `lang/runtime`, `cmd/main`, `ffi/jsx`, `ffi/markdown`, `lang/json/companion`, `lang/json/proj`, `lang/jsx/proj`, `lang/lambda/companion`, `lang/lambda/proj`, `lang/markdown/companion`, `lang/markdown/proj`, `workspace/probe`, `lang/lambda/alpha`, `lang/lambda/alpha_egraph_adapter`, `lang/lambda/edits`, `lang/lambda/scope`, `lang/lambda/semantic`, `lang/markdown/edits`, `probe/algebra_merge`, `projection`.

`examples/canvas/main` is a separate MoonBit module not addressable by the root validator target resolver. It was validated with its standalone strict CI wrapper, focused debug and release tests, the validator JS build, and Canvas E2E.

Additional conditional gates:

- `rtk moon test --release` — 4240/4240 pass.
- `./scripts/check-test-baseline.sh 7 ./scripts/run-moon-module.sh ci-lenient examples/canvas` — 0 failures.
- Canvas `main` debug and release tests — 47/47 pass in each mode.
- `./scripts/build-js.sh` and `./scripts/build-web.sh` — pass.
- Web typecheck and boundary checks, plus ProseMirror TypeScript check — pass.
- Canvas Playwright — 19/19 pass.
- Generated interface diff reviewed: six intended API cutovers only; no unintended trait-bound widening.
- Independent implementation review: two `gpt-5.6-terra` reviewers, PASS with no remaining findings.

## PR-ready evidence

Validated HEAD: `98934084490d6b365a4ecce94fe02578fa1cc2f3`

Validated base: `origin/main@649491fdf9644639cb0b86a5d233ed889bc2e5fa`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target loom/loom/core \
  --target editor \
  --target lang/runtime \
  --target cmd/main \
  --target ffi/jsx \
  --target ffi/markdown \
  --target lang/json/companion \
  --target lang/json/proj \
  --target lang/jsx/proj \
  --target lang/lambda/companion \
  --target lang/lambda/proj \
  --target lang/markdown/companion \
  --target lang/markdown/proj \
  --target workspace/probe \
  --target lang/lambda/alpha \
  --target lang/lambda/alpha_egraph_adapter \
  --target lang/lambda/edits \
  --target lang/lambda/scope \
  --target lang/lambda/semantic \
  --target lang/markdown/edits \
  --target probe/algebra_merge \
  --target projection
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff was reviewed for unintended API or trait-bound changes.
- [x] The changed Loom commit is pushed, merged, and reachable from its remote.
- [x] Validation was rerun after the final commit and submodule pointer.
- [x] Independent review findings were resolved before final validation.

Closes #1035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable source identification across editors, REPL sessions, JSX, JSON, Markdown, Lambda, and graph workflows.
  * Improved diagnostics to associate messages with their originating source and preserve ordering, severity, codes, and location details.
  * Added consistent handling for locationless diagnostics and diagnostics from other sources.

* **Bug Fixes**
  * Markdown and JSX views now reliably display parser diagnostics, including for empty or updated content.

* **Documentation**
  * Added a design plan for source-aware diagnostics and editing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->