### PR TITLE
Apply Lambda missing-else fixes through the editor protocol (#1038)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,7 +721,7 @@ jobs:
 
   cm6-adapter-e2e:
     name: CM6 Adapter E2E
-    needs: changes
+    needs: [build-js, changes]
     if: needs.changes.outputs.run_cm6_adapter_e2e == 'true'
     runs-on: ubuntu-latest
     container:
@@ -732,6 +732,15 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+
+      - name: Download MoonBit JS artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: moonbit-js-build
+          path: _build/js/release/build/dowdiness
+
+      - name: Verify Lambda diagnostic-fix runtime
+        run: test -f _build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/adapters/editor-adapter/cm6-adapter.ts
+++ b/adapters/editor-adapter/cm6-adapter.ts
@@ -248,12 +248,27 @@ export class CM6Adapter implements EditorAdapter {
         const diagnostics: CmDiagnostic[] = patch.diagnostics.map((diagnostic) => {
           const from = Math.min(Math.max(0, diagnostic.from), docLength);
           const to = Math.min(Math.max(from, diagnostic.to), docLength);
+          const actions =
+            diagnostic.snapshot_id != null && diagnostic.diagnostic_id != null
+              ? (diagnostic.fixes ?? []).map((fix) => ({
+                  name: fix.title,
+                  apply: () => {
+                    this.intentCallback?.({
+                      type: "ApplyDiagnosticFix",
+                      snapshot_id: diagnostic.snapshot_id!,
+                      diagnostic_id: diagnostic.diagnostic_id!,
+                      fix_id: fix.id,
+                    });
+                  },
+                }))
+              : [];
           return {
             from,
             to,
             severity: diagnostic.severity,
             message: diagnostic.message,
             source: diagnostic.code ?? undefined,
+            actions: actions.length > 0 ? actions : undefined,
           };
         });
         this.view.dispatch(setDiagnostics(this.view.state, diagnostics));

--- a/adapters/editor-adapter/index.ts
+++ b/adapters/editor-adapter/index.ts
@@ -6,6 +6,7 @@ export type {
   UserIntent,
   Decoration,
   Diagnostic,
+  DiagnosticFixSummary,
 } from './types';
 
 export type { EditorAdapter } from './adapter';

--- a/adapters/editor-adapter/test/cm6-diagnostics.spec.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.spec.ts
@@ -11,6 +11,37 @@ test("renders range and point diagnostics, then clears both", async ({ page }) =
   await expect(page.locator(".cm-lintRange-warning")).toHaveCount(1);
   await expect(page.locator(".cm-lintPoint-error")).toHaveCount(1);
 
+  await page.locator(".cm-lintPoint-error").click({ force: true });
+  const fixButton = page.getByRole("button", {
+    name: "Insert missing else branch",
+  });
+  await expect(fixButton).toBeVisible();
+  await fixButton.click();
+  const fixResult = await page.evaluate(() => {
+    const harnessWindow = window as typeof window & {
+      diagnosticFixResult: () => {
+        intents: unknown[];
+        text: string;
+        crdtText: string;
+        replayAccepted: boolean | null;
+      };
+    };
+    return harnessWindow.diagnosticFixResult();
+  });
+  expect(fixResult).toEqual({
+    intents: [
+      {
+        type: "ApplyDiagnosticFix",
+        snapshot_id: 0,
+        diagnostic_id: 0,
+        fix_id: 0,
+      },
+    ],
+    text: "if x then y else _",
+    crdtText: "if x then y else _",
+    replayAccepted: false,
+  });
+
   await page.evaluate(async () => {
     const harnessWindow = window as typeof window & {
       clearCm6Diagnostics: () => Promise<void>;

--- a/adapters/editor-adapter/test/cm6-diagnostics.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.ts
@@ -1,6 +1,8 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
+import * as crdt from "../../../_build/js/release/build/dowdiness/canopy/ffi/lambda/lambda.js";
 import { CM6Adapter } from "../cm6-adapter";
+import type { UserIntent, ViewPatch } from "../types";
 
 async function main(): Promise<void> {
   const parent = document.querySelector<HTMLElement>("#editor");
@@ -9,34 +11,66 @@ async function main(): Promise<void> {
     throw new Error("diagnostic harness DOM is incomplete");
   }
 
+  const initialSource = "if x then y";
+  const handle = crdt.create_editor("cm6-diagnostic-fix-e2e");
+  crdt.set_text(handle, initialSource);
   const state = EditorState.create({
-    doc: "if x then y",
+    doc: initialSource,
     extensions: CM6Adapter.extensions(),
   });
   const view = new EditorView({ state, parent });
   const adapter = new CM6Adapter(view);
+  const intents: UserIntent[] = [];
+  let replayAccepted: boolean | null = null;
+  adapter.onIntent((intent) => {
+    intents.push(intent);
+    if (intent.type !== "ApplyDiagnosticFix") return;
+    const before = crdt.get_text(handle);
+    const applied = crdt.handle_diagnostic_fix_intent(
+      handle,
+      intent.snapshot_id,
+      intent.diagnostic_id,
+      intent.fix_id,
+      101,
+    );
+    if (!applied) return;
+    const after = crdt.get_text(handle);
+    const patches = JSON.parse(crdt.compute_view_patches_json(handle)) as ViewPatch[];
+    adapter.applyPatches([
+      { type: "TextChange", from: 0, to: before.length, insert: after },
+      ...patches,
+    ]);
+    replayAccepted = crdt.handle_diagnostic_fix_intent(
+      handle,
+      intent.snapshot_id,
+      intent.diagnostic_id,
+      intent.fix_id,
+      102,
+    );
+  });
 
-  adapter.applyPatches([
-    {
-      type: "SetDiagnostics",
-      diagnostics: [
+  const published = JSON.parse(crdt.compute_view_patches_json(handle)) as ViewPatch[];
+  adapter.applyPatches(
+    published.map((patch): ViewPatch => {
+      if (patch.type !== "SetDiagnostics") return patch;
+      return {
+        ...patch,
+        diagnostics: [
         {
           from: 3,
           to: 4,
           severity: "warning",
           message: "range warning",
           code: "test.range",
+          snapshot_id: null,
+          diagnostic_id: null,
+          fixes: [],
         },
-        {
-          from: 11,
-          to: 11,
-          severity: "error",
-          message: "missing else",
-          code: null,
-        },
-      ],
-    },
-  ]);
+          ...patch.diagnostics,
+        ],
+      };
+    }),
+  );
 
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
   const rangeVisible = parent.querySelector(".cm-lintRange-warning") !== null;
@@ -46,7 +80,19 @@ async function main(): Promise<void> {
 
   const harnessWindow = window as typeof window & {
     clearCm6Diagnostics: () => Promise<void>;
+    diagnosticFixResult: () => {
+      intents: UserIntent[];
+      text: string;
+      crdtText: string;
+      replayAccepted: boolean | null;
+    };
   };
+  harnessWindow.diagnosticFixResult = () => ({
+    intents: [...intents],
+    text: view.state.doc.toString(),
+    crdtText: crdt.get_text(handle),
+    replayAccepted,
+  });
   harnessWindow.clearCm6Diagnostics = async () => {
     adapter.applyPatches([{ type: "SetDiagnostics", diagnostics: [] }]);
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
@@ -58,6 +104,9 @@ async function main(): Promise<void> {
     result.textContent = JSON.stringify({ rangeVisible, pointVisible, cleared });
     if (!passed) throw new Error(result.textContent);
   };
+  window.addEventListener("pagehide", () => crdt.destroy_editor(handle), {
+    once: true,
+  });
 }
 
 void main().catch((error: unknown) => {

--- a/adapters/editor-adapter/types.ts
+++ b/adapters/editor-adapter/types.ts
@@ -22,12 +22,21 @@ export type Decoration = {
   widget: boolean;
 };
 
+export type DiagnosticFixSummary = {
+  id: number;
+  title: string;
+  applicability: string;
+};
+
 export type Diagnostic = {
   from: number;
   to: number;
   severity: "error" | "warning" | "info" | "hint";
   message: string;
   code: string | null;
+  snapshot_id?: number | null;
+  diagnostic_id?: number | null;
+  fixes?: DiagnosticFixSummary[];
 };
 
 export type ViewPatch =
@@ -50,4 +59,5 @@ export type UserIntent =
   | { type: "SetDocCursor"; doc_code_unit_offset: number }
   | { type: "Undo" }
   | { type: "Redo" }
-  | { type: "CommitEdit"; node_id: number; value: string };
+  | { type: "CommitEdit"; node_id: number; value: string }
+  | { type: "ApplyDiagnosticFix"; snapshot_id: number; diagnostic_id: number; fix_id: number };

--- a/docs/plans/2026-07-31-lambda-diagnostic-fix-editor.md
+++ b/docs/plans/2026-07-31-lambda-diagnostic-fix-editor.md
@@ -1,0 +1,293 @@
+# Lambda diagnostic fix through the editor protocol
+
+Status: approved design contract for issue #1038. Implementation and merge
+evidence will be appended only after the exact reviewed commits pass their
+gates.
+
+## Scope
+
+Complete one vertical slice for Lambda input `if x then y`:
+
+```text
+Lambda parser diagnostic and fix
+  -> Loom source-backed plain rendering
+  -> Canopy revision-bound diagnostic snapshot
+  -> producer-neutral SetDiagnostics metadata
+  -> CodeMirror lint action
+  -> typed ApplyDiagnosticFix intent
+  -> current-snapshot validation
+  -> CRDT/undo mutation and one parser synchronization
+  -> cleared missing-else diagnostic
+```
+
+This issue does not add semantic diagnostics, generic fix extraction, or a
+second diagnostic model. Diagnostics remain outside `AnalysisProjection`.
+Loom retains parser diagnostic lifecycle and authoritative evidence; Canopy
+owns only the editor publication snapshot and application registry. Source
+text remains external to diagnostics and fixes.
+
+## Existing API First
+
+### Reused project APIs
+
+- Loom `SourceId`, `SourceSpan`, `TextRange`, and `TextOffset` remain the only
+  source and half-open UTF-16 location model. `DiagnosticSource` remains
+  producer identity and is never used as source identity.
+- Loom `Diagnostic`, `DiagnosticLabel`, `DiagnosticCode`, `DiagnosticFix`,
+  `TextReplacement`, and `FixApplicability` remain the producer-native model.
+  No Canopy replacement or fix value duplicates them.
+- `DiagnosticFix::apply(source_id, source)` revalidates source identity, bounds,
+  UTF-16 boundaries, normalized ordering, and non-overlap against the untouched
+  source before the imperative editor shell mutates anything.
+- `Diagnostic::render_plain(SourceProvider)` supplies the displayed message.
+  The current editor source is supplied atomically as a
+  `DiagnosticSourceFile`; source text is not stored in a diagnostic snapshot.
+- `ViewUpdateState` already owns per-handle publication state and is therefore
+  the owner of the current diagnostic snapshot. The registry is not placed in
+  `AnalysisProjection`, a parser, a protocol DTO, or a global map.
+- `SyncEditor::get_version()` returns an owning `@text.Version` value derived
+  from the CRDT operation set. Equality exactly detects whether the editor is
+  still at the registered operation snapshot. The value stays inside Canopy
+  and is never encoded on the wire.
+- `SyncEditor`'s existing CRDT/undo splice boundary is reused for commit.
+  Existing peer-cursor and parser synchronization functions run once after all
+  validated replacements have been committed.
+- `UndoManager`'s existing time-window grouping remains the mechanism that
+  combines the replacement operations themselves. The currently exposed API
+  has no non-destructive way to separate that batch from adjacent user input,
+  so event-graph-walker receives one additive `stop_capturing()` boundary.
+- The existing `UserIntent` enum remains the sole inbound protocol and the
+  existing adapter intent callback remains the sole CM6 action exit.
+
+### Reused MoonBit core APIs
+
+- `Array` preserves producer, label, diagnostic, and fix order. Constructor and
+  accessor copies from Loom remain the defensive ownership boundary.
+- `Array::mapi`, `filter_map`, `search_by`, and reverse traversal express
+  snapshot-local ID assignment, lookup, and end-to-start commit.
+- `Option` models optional wire metadata and the absence of a current snapshot.
+  `Result`/typed catches remain at JSON, renderer, and Loom fix validation
+  boundaries.
+- `String::length` and `String::get_view` remain the canonical UTF-16 bounds and
+  surrogate-boundary checks through Loom's fix application.
+
+### Checked but not selected
+
+- `Map` and `Set` are unnecessary. IDs are snapshot-local array positions, the
+  expected counts are small, and array lookup preserves explicit ordering.
+- `ArrayView` and `Iter` do not improve registry ownership because registered
+  fixes must outlive the projection call and Loom accessors already return
+  defensive owning copies.
+- `StringBuilder` is owned by the plain renderer; the registry does not format
+  diagnostic text itself.
+- `cmp`, new overlap helpers, and new sorting helpers are unnecessary because
+  `DiagnosticFix` already normalizes and validates replacements.
+- `@incr.Revision`, parser tokens, CST nodes, entity IDs, diagnostic messages,
+  source names, and list positions are not revision or location identities.
+- `SyncEditor::apply_span_edits` is not the final commit boundary because it
+  synchronizes the parser after every edit. `apply_text_edit_exact` is also not
+  reused directly because its public policy requires grapheme boundaries,
+  while diagnostic replacements are defined on valid UTF-16 boundaries.
+- `SyncEditor::set_text` is not used for fixes: it does not record undo and can
+  replace untouched CRDT content inside the combined span.
+- `UndoManager::clear()` is not a capture boundary because it destroys prior
+  undo and redo history. Toggling `set_tracking(false)` is also unsuitable
+  because it would omit the diagnostic fix from undo history altogether.
+
+### New responsibility boundaries
+
+- Three opaque protocol IDs identify a publication snapshot, one underlying
+  diagnostic within that snapshot, and one candidate within that diagnostic.
+  Their wire representation is an integer token; consumers may only echo it.
+- Private snapshot state inside `ViewUpdateState` owns its ID, source ID, CRDT
+  version, and registered diagnostic/fix entries. It stores Loom fix values but
+  no source text and exposes no mutable collection. Its representation uses
+  only public component types because MoonBit forbids a public struct's private
+  field from depending on a private type; no registry representation is added
+  to the public API.
+- A deterministic snapshot builder renders protocol rows and registers only
+  fixes whose source equals the current editor source.
+- One editor-private commit helper applies an already revalidated Loom fix
+  from end to start through CRDT/undo, then synchronizes peer cursors and the
+  parser exactly once. It does not perform publication or protocol work.
+- event-graph-walker's `UndoManager::stop_capturing()` marks only the next
+  recorded operation as the start of a new group. It neither clears history
+  nor disables tracking. Calling it before and after the replacement batch
+  isolates the batch on both sides while preserving normal time grouping for
+  every replacement inside the batch.
+
+## Approved invariants
+
+### Parser diagnostic and help
+
+Only the missing-`else` recovery point receives stable code
+`loom.lambda.expected_else`. The diagnostic has one zero-width primary label at
+EOF, a help note explaining that an `if` expression requires an else branch,
+and one `Always` candidate titled for inserting the missing branch.
+
+The existing ordered `Diagnostic.notes` channel is the help channel for this
+slice. Adding a second structured help model would exceed #1038 and would not
+be rendered by the already-merged #1036 contract. The note is rendered as
+`= note: ...` by the existing source-backed renderer.
+
+The first failing parser test obtains the candidate from the diagnostic,
+applies it with `DiagnosticFix::apply`, and reparses the exact output. That test
+defines the replacement only when the real Lambda grammar accepts it and the
+`loom.lambda.expected_else` diagnostic disappears. No implementation or plan
+text alone establishes the replacement.
+
+### Snapshot identity and lifetime
+
+Snapshot IDs are monotonically allocated within one `ViewUpdateState` lifetime.
+Diagnostic IDs are the underlying `DiagnosticSet` encounter indices. When one
+Loom diagnostic projects to multiple current-source primary rows, every row
+echoes the same diagnostic ID. Fix IDs are candidate encounter indices within
+that diagnostic. They are opaque tokens, not stable cross-snapshot identities.
+
+Every publication of nonempty diagnostics creates and installs a new snapshot,
+even when its values compare equal to the previous publication. Publishing an
+empty diagnostic set clears the registry. A source edit may leave the old
+registry object present until the next view update, but version mismatch makes
+all its actions immediately invalid.
+
+The stored `@text.Version` is compared only for equality with the current
+editor version. Any local, remote, undo, redo, or causally visible operation
+invalidates the action, including a conservative invalidation whose visible
+text happens to compare equal. `@incr.Revision` is neither stored nor exposed.
+
+### Source and rendering
+
+The snapshot source ID must equal `SyncEditor::parser_source_id()`. A fix is
+registered only when its first replacement source equals that ID; Loom's
+constructor guarantees the rest of the candidate has the same source. Foreign
+source candidates are not sent to the frontend.
+
+For parser diagnostics, the message sent to the editor is the #1036 plain
+rendering over the exact current source, using the stable provider name
+`<input>`. The renderer remains atomic and strictly validates every label. For
+compatibility, a diagnostic that cannot be rendered because it references a
+source outside this single-document provider keeps its neutral message and has
+no registered actions. Location is still taken only from explicit current
+source primary labels; it is never inferred from text, code, order, or token
+evidence.
+
+Offsets remain half-open UTF-16 code-unit offsets. Zero-width EOF labels remain
+`from == to == source.length()`.
+
+### Protocol compatibility
+
+The existing diagnostic DTO gains nullable `snapshot_id` and `diagnostic_id`
+plus an ordered `fixes` array. Each summary contains only opaque ID, title, and
+producer-neutral applicability. Replacement text, source text, CRDT version,
+Loom token/CST/entity evidence, and parser-native types are absent.
+
+Existing diagnostic constructors default the new fields to no IDs and no
+fixes. Existing adapters may ignore them. JSON always emits the fields so the
+wire shape is deterministic; legacy TypeScript producers may omit them and the
+CM6 adapter treats omission as no action.
+
+`UserIntent::ApplyDiagnosticFix(snapshot_id, diagnostic_id, fix_id)` is a
+dedicated typed variant. JSON decoding requires all three integer fields and
+rejects missing, wrong-typed, or negative values. No replacement, range,
+source, or structural-operation string is accepted inbound.
+
+### Action and application
+
+CM6 creates an action only when a diagnostic has both IDs and a fix summary.
+The action title is the fix title. Its callback ignores CM6's current `from`
+and `to` values and invokes the existing intent callback with the three captured
+IDs. It never dispatches a document change.
+
+After MoonBit accepts and commits the intent, the host reads the authoritative
+source and applies that result through `TextChange`, then applies the newly
+computed diagnostic patches. The browser integration uses the real Lambda FFI
+artifact, so the action itself still cannot bypass CRDT, undo, or revalidation.
+
+MoonBit accepts an action only when all of these hold in order:
+
+1. a current registry exists;
+2. the snapshot ID equals the current registry ID;
+3. the stored CRDT version equals `SyncEditor::get_version()`;
+4. the stored and current parser source IDs are equal;
+5. the diagnostic ID exists;
+6. the fix ID exists under that diagnostic;
+7. `DiagnosticFix::apply` succeeds against the current source ID and text.
+
+Any failure returns rejection without mutation. The frontend-supplied action
+contains no content that can influence the replacement.
+
+After successful pure validation, the imperative shell records all replacement
+operations in one undo group, committing them from end to start. It calls
+`stop_capturing()` immediately before the first operation and immediately after
+the last operation. Thus an ordinary edit inside the capture timeout before or
+after the fix is a distinct undo step, while every operation in a multi-edit
+fix remains one step. Because all ranges were validated against the untouched
+source and later offsets are committed first, each original offset remains
+valid. Peer cursors and the parser observe only the final source. The current
+registry is cleared on success, so replaying the action rejects before the next
+publication as well as after it.
+
+## Behavioral boundary matrix
+
+| Case | Required observation |
+| --- | --- |
+| Lambda `if x then y` | EOF primary label, stable code, help note, one named fix |
+| Candidate replacement | Applying it yields grammar-valid exact source and clears missing-else code |
+| Plain rendering | Published message contains header, `<input>` source block, EOF marker, and help note |
+| Metadata JSON | Nullable IDs and ordered fix summaries encode deterministically |
+| Typed intent JSON | Three IDs round-trip; missing/wrong/negative fields reject |
+| Current snapshot | Selected fix applies through CRDT/undo and parser |
+| Stale snapshot ID | Rejects without source mutation |
+| Stale CRDT version | Rejects without source mutation |
+| Unknown diagnostic/fix ID | Rejects without source mutation |
+| Two candidates | Only the selected candidate is resolved and applied |
+| Multiple replacements | Final source is exact; parser exposes no intermediate state |
+| Undo capture boundary | Prior input, the whole fix batch, and subsequent input are three undo steps even inside the capture timeout |
+| Source mismatch | Candidate is not registered or application rejects |
+| Bounds/UTF-16/non-overlap | Loom revalidation rejects before mutation |
+| Replay | A successfully used action rejects immediately |
+| CM6 zero-width diagnostic | Point marker exposes action; click emits IDs only |
+| Existing non-fix diagnostic | Renders as before and has no CM6 action |
+| Defensive ownership | Mutating caller/accessor arrays cannot alter registered fixes |
+
+## Tests-first and publication sequence
+
+1. In event-graph-walker, first add a failing undo-manager test in which prior
+   input, a multi-operation fix batch, and subsequent input all occur inside
+   the capture timeout. Add `stop_capturing()` so undo observes three groups,
+   with the entire fix batch in the middle group. Validate and independently
+   review it, then push, open its PR, wait for required CI, and squash merge.
+2. In Loom, add the missing-else parser test first. It must fail before the
+   diagnostic carries the stable code/help/fix, then prove the candidate output
+   reparses cleanly.
+3. Implement only the Lambda producer using existing Loom diagnostic values and
+   `ParserContext::report`; no Loom core API is added unless the test proves the
+   existing public context accessors are insufficient.
+4. Validate and independently review Loom, push its branch, open the Loom PR,
+   wait for required CI, squash merge, and record the public merge commit.
+5. Update the Canopy worktree's event-graph-walker and Loom pointers only to
+   their public merge commits.
+6. Add failing protocol JSON tests, snapshot/application tests, Lambda FFI
+   round-trip tests, and CM6 action/E2E tests before their corresponding
+   implementations.
+7. Implement the protocol IDs/metadata/intent, snapshot registry, atomic editor
+   commit shell, Lambda FFI intent endpoint, and adapter action in narrow
+   red-green slices.
+8. Run affected default/JS/native release tests, workspace check/test, JS build,
+   TypeScript checks, and the CM6 Playwright test. Inspect every generated
+   `.mbti` change and execute concrete current/stale/multi-edit scenarios.
+9. Obtain independent implementation review, resolve findings, refresh from
+   `origin/main`, run the exact-head PR validator, then create and merge the
+   Canopy PR only after raw required CI and mergeability gates pass.
+
+## Compatibility and ownership cutover
+
+The Loom parser diagnostic changes producer output additively. The Canopy
+diagnostic DTO and `UserIntent` change additively; there is no obsolete fix API
+or compatibility shim. Existing non-fix producers keep constructor defaults.
+The TypeScript adapter accepts old diagnostic objects without metadata.
+
+The event-graph-walker and Loom PRs must merge first. The Canopy parent PR may
+reference only their public squash merge commits. Issue #1039 does not begin
+until #1038's Canopy PR is merged, the issue is closed, and all #1038
+branches/worktrees are cleaned.

--- a/editor/diagnostic_fix_wbtest.mbt
+++ b/editor/diagnostic_fix_wbtest.mbt
@@ -1,0 +1,261 @@
+///|
+fn test_diagnostic_fix(
+  source_id : @loom_core.SourceId,
+  title : String,
+  start : Int,
+  end : Int,
+  replacement : String,
+) -> @loom_core.DiagnosticFix {
+  try! @loom_core.DiagnosticFix(title, @loom_core.FixApplicability::Always, [
+    @loom_core.TextReplacement(
+      @loom_core.SourceSpan(
+        source_id,
+        try! @loom_core.TextRange::from_offsets(start, end),
+      ),
+      replacement,
+    ),
+  ])
+}
+
+///|
+fn test_diagnostic(
+  source_id : @loom_core.SourceId,
+  fixes : Array[@loom_core.DiagnosticFix],
+) -> @loom_core.Diagnostic {
+  @loom_core.Diagnostic(
+    source=@loom_core.DiagnosticSource::parser(),
+    severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+    code=Some(@loom_core.DiagnosticCode("test.fix")),
+    message="replace source",
+    labels=[
+      @loom_core.DiagnosticLabel(
+        @loom_core.LabelStyle::Primary,
+        @loom_core.SourceSpan(
+          source_id,
+          try! @loom_core.TextRange::from_offsets(1, 2),
+        ),
+        Some("replace this range"),
+      ),
+    ],
+    notes=["apply the suggested edit"],
+    fixes~,
+  )
+}
+
+///|
+test "diagnostic fix publication renders source and applies exactly once" {
+  let editor = try! @probe.new_test_editor("diagnostic-fix-current")
+  editor.set_text_and_record("abcd", 100)
+  let source_id = editor.parser_source_id()
+  let state = ViewUpdateState::ViewUpdateState()
+  let rows = state.publish_diagnostics(
+    editor,
+    @loom_core.DiagnosticSet::single(
+      test_diagnostic(source_id, [
+        test_diagnostic_fix(source_id, "replace bc", 1, 3, "X"),
+      ]),
+    ),
+  )
+  guard rows is [row] else { fail("expected one diagnostic row") }
+  inspect(row.message.contains("<input>"), content="true")
+  guard (row.snapshot_id, row.diagnostic_id, row.fixes)
+    is (Some(snapshot_id), Some(diagnostic_id), [fix]) else {
+    fail("expected one registered fix")
+  }
+  inspect(fix.id, content="0")
+  inspect(fix.title, content="replace bc")
+  inspect(fix.applicability, content="always")
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id~,
+      diagnostic_id~,
+      fix_id=fix.id,
+      timestamp_ms=101,
+    ),
+    content="true",
+  )
+  inspect(editor.get_text(), content="aXd")
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id~,
+      diagnostic_id~,
+      fix_id=fix.id,
+      timestamp_ms=102,
+    ),
+    content="false",
+  )
+  inspect(editor.get_text(), content="aXd")
+}
+
+///|
+test "diagnostic fix registry rejects stale version and unknown opaque ids" {
+  let editor = try! @probe.new_test_editor("diagnostic-fix-stale")
+  editor.set_text_and_record("abcd", 100)
+  let source_id = editor.parser_source_id()
+  let state = ViewUpdateState::ViewUpdateState()
+  let rows = state.publish_diagnostics(
+    editor,
+    @loom_core.DiagnosticSet::single(
+      test_diagnostic(source_id, [
+        test_diagnostic_fix(source_id, "replace b", 1, 2, "X"),
+      ]),
+    ),
+  )
+  guard rows is [row] else { fail("expected one diagnostic row") }
+  let snapshot_id = row.snapshot_id.unwrap()
+  let diagnostic_id = row.diagnostic_id.unwrap()
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id=snapshot_id + 1,
+      diagnostic_id~,
+      fix_id=0,
+      timestamp_ms=101,
+    ),
+    content="false",
+  )
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id~,
+      diagnostic_id=diagnostic_id + 1,
+      fix_id=0,
+      timestamp_ms=101,
+    ),
+    content="false",
+  )
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id~,
+      diagnostic_id~,
+      fix_id=1,
+      timestamp_ms=101,
+    ),
+    content="false",
+  )
+  editor.insert_at(0, "!", 102)
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id~,
+      diagnostic_id~,
+      fix_id=0,
+      timestamp_ms=103,
+    ),
+    content="false",
+  )
+  inspect(editor.get_text(), content="!abcd")
+}
+
+///|
+test "diagnostic fix selection preserves candidate order" {
+  let editor = try! @probe.new_test_editor("diagnostic-fix-candidates")
+  editor.set_text_and_record("abcd", 100)
+  let source_id = editor.parser_source_id()
+  let state = ViewUpdateState::ViewUpdateState()
+  let rows = state.publish_diagnostics(
+    editor,
+    @loom_core.DiagnosticSet::single(
+      test_diagnostic(source_id, [
+        test_diagnostic_fix(source_id, "choose X", 1, 2, "X"),
+        test_diagnostic_fix(source_id, "choose Y", 1, 2, "Y"),
+      ]),
+    ),
+  )
+  guard rows is [row] else { fail("expected one diagnostic row") }
+  guard row.fixes is [first, second] else { fail("expected two fixes") }
+  inspect(first.id, content="0")
+  inspect(first.title, content="choose X")
+  inspect(second.id, content="1")
+  inspect(second.title, content="choose Y")
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id=row.snapshot_id.unwrap(),
+      diagnostic_id=row.diagnostic_id.unwrap(),
+      fix_id=second.id,
+      timestamp_ms=101,
+    ),
+    content="true",
+  )
+  inspect(editor.get_text(), content="aYcd")
+}
+
+///|
+test "multi-edit diagnostic fix is one isolated undo group" {
+  let editor = try! @probe.new_test_editor(
+    "diagnostic-fix-undo",
+    capture_timeout_ms=500,
+  )
+  editor.set_text_and_record("abcd", 100)
+  let source_id = editor.parser_source_id()
+  let fix = try! @loom_core.DiagnosticFix(
+    "replace endpoints",
+    @loom_core.FixApplicability::Always,
+    [
+      @loom_core.TextReplacement(
+        @loom_core.SourceSpan(
+          source_id,
+          try! @loom_core.TextRange::from_offsets(0, 1),
+        ),
+        "X",
+      ),
+      @loom_core.TextReplacement(
+        @loom_core.SourceSpan(
+          source_id,
+          try! @loom_core.TextRange::from_offsets(3, 4),
+        ),
+        "Z",
+      ),
+    ],
+  )
+  let state = ViewUpdateState::ViewUpdateState()
+  let rows = state.publish_diagnostics(
+    editor,
+    @loom_core.DiagnosticSet::single(test_diagnostic(source_id, [fix])),
+  )
+  guard rows is [row] else { fail("expected one diagnostic row") }
+  inspect(
+    state.apply_diagnostic_fix(
+      editor,
+      snapshot_id=row.snapshot_id.unwrap(),
+      diagnostic_id=row.diagnostic_id.unwrap(),
+      fix_id=0,
+      timestamp_ms=101,
+    ),
+    content="true",
+  )
+  inspect(editor.get_text(), content="XbcZ")
+  editor.insert_at(4, "!", 102)
+  inspect(editor.get_text(), content="XbcZ!")
+  inspect(editor.undo(), content="true")
+  inspect(editor.get_text(), content="XbcZ")
+  inspect(editor.undo(), content="true")
+  inspect(editor.get_text(), content="abcd")
+  inspect(editor.undo(), content="true")
+  inspect(editor.get_text(), content="")
+}
+
+///|
+test "foreign-source fixes are not registered as current-source actions" {
+  let editor = try! @probe.new_test_editor("diagnostic-fix-foreign")
+  editor.set_text("abcd")
+  let source_id = editor.parser_source_id()
+  let other_source = @loom_core.SourceId("other-source")
+  let state = ViewUpdateState::ViewUpdateState()
+  let rows = state.publish_diagnostics(
+    editor,
+    @loom_core.DiagnosticSet::single(
+      test_diagnostic(source_id, [
+        test_diagnostic_fix(other_source, "foreign", 1, 2, "X"),
+      ]),
+    ),
+  )
+  guard rows is [row] else { fail("expected one diagnostic row") }
+  @debug.assert_eq(row.snapshot_id, None)
+  @debug.assert_eq(row.diagnostic_id, None)
+  inspect(row.fixes.length(), content="0")
+}

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -160,8 +160,10 @@ pub struct ViewUpdateState {
   mut previous : @protocol.ViewNode?
   mut previous_decorations : Array[@protocol.Decoration]?
   mut had_errors : Bool
+  // private fields
 } derive(@debug.Debug)
 pub fn ViewUpdateState::ViewUpdateState() -> Self
+pub fn[T : Eq] ViewUpdateState::apply_diagnostic_fix(Self, SyncEditor[T], snapshot_id~ : Int, diagnostic_id~ : Int, fix_id~ : Int, timestamp_ms~ : Int) -> Bool
 pub fn ViewUpdateState::set_had_errors(Self, Bool) -> Unit
 pub fn ViewUpdateState::set_previous(Self, @protocol.ViewNode?) -> Unit
 

--- a/editor/sync_editor_text.mbt
+++ b/editor/sync_editor_text.mbt
@@ -205,6 +205,48 @@ fn[T] SyncEditor::apply_replace_span(
 }
 
 ///|
+/// Commit one prevalidated Loom fix as a single externally observable source
+/// transition. The fix owns source/range validation; this shell records its
+/// replacements end-to-start, then reconciles cursors and the parser once.
+fn[T : Eq] SyncEditor::apply_diagnostic_fix_candidate(
+  self : SyncEditor[T],
+  source_id : @loom_core.SourceId,
+  fix : @loom_core.DiagnosticFix,
+  timestamp_ms : Int,
+) -> Bool {
+  let old_source = self.doc.text()
+  let expected_source = fix.apply(source_id, old_source) catch {
+    _ => return false
+  }
+  let edits = fix.edits()
+  self.taint_pending_transforms()
+  self.undo.stop_capturing()
+  let mut applied = true
+  edits.rev_each(edit => {
+    if applied {
+      let range = edit.span().range()
+      applied = self.apply_replace_span(
+        self.doc.text(),
+        range.start().value(),
+        range.length(),
+        edit.replacement(),
+        timestamp_ms,
+        true,
+      )
+    }
+  })
+  self.undo.stop_capturing()
+  let new_source = self.doc.text()
+  self.cursor = @moji.next_grapheme_boundary(
+    new_source,
+    clamp_utf16_offset(new_source, self.cursor),
+  )
+  self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
+  self.sync_parser_after_text_change(old_source, new_source, None)
+  applied && new_source == expected_source
+}
+
+///|
 fn[T : Eq] SyncEditor::apply_text_edit_with_policy(
   self : SyncEditor[T],
   start : Int,

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -1,15 +1,60 @@
 // ViewUpdater: Computes incremental view patches by diffing ViewNode trees.
 
 ///|
+priv struct RegisteredDiagnosticFix {
+  id : Int
+  fix : @loom_core.DiagnosticFix
+}
+
+///|
+fn RegisteredDiagnosticFix::RegisteredDiagnosticFix(
+  id : Int,
+  fix : @loom_core.DiagnosticFix,
+) -> RegisteredDiagnosticFix {
+  { id, fix }
+}
+
+///|
+priv struct PublishedDiagnostic {
+  id : Int
+  diagnostic : @loom_core.Diagnostic
+  rendered_message : String?
+  fixes : Array[RegisteredDiagnosticFix]
+}
+
+///|
+fn PublishedDiagnostic::PublishedDiagnostic(
+  id : Int,
+  diagnostic : @loom_core.Diagnostic,
+  rendered_message : String?,
+  fixes : Array[RegisteredDiagnosticFix],
+) -> PublishedDiagnostic {
+  { id, diagnostic, rendered_message, fixes: fixes.copy() }
+}
+
+///|
 pub struct ViewUpdateState {
   mut previous : @protocol.ViewNode?
   mut previous_decorations : Array[@protocol.Decoration]?
   mut had_errors : Bool
+  priv mut next_diagnostic_snapshot_id : Int
+  priv mut diagnostic_snapshot : (
+    Int,
+    @loom_core.SourceId,
+    @text.Version,
+    Array[(Int, Array[(Int, @loom_core.DiagnosticFix)])],
+  )?
 } derive(Debug)
 
 ///|
 pub fn ViewUpdateState::ViewUpdateState() -> ViewUpdateState {
-  { previous: None, previous_decorations: None, had_errors: false }
+  {
+    previous: None,
+    previous_decorations: None,
+    had_errors: false,
+    next_diagnostic_snapshot_id: 0,
+    diagnostic_snapshot: None,
+  }
 }
 
 ///|
@@ -26,6 +71,208 @@ pub fn ViewUpdateState::set_had_errors(
   value : Bool,
 ) -> Unit {
   self.had_errors = value
+}
+
+///|
+fn diagnostic_protocol_severity(
+  severity : @loom_core.DiagnosticSeverity,
+) -> @protocol.Severity {
+  match severity {
+    @loom_core.DiagnosticSeverity::Error => @protocol.SevError
+    @loom_core.DiagnosticSeverity::Warning => @protocol.SevWarning
+    @loom_core.DiagnosticSeverity::Info => @protocol.SevInfo
+    @loom_core.DiagnosticSeverity::Hint => @protocol.SevHint
+  }
+}
+
+///|
+fn diagnostic_fix_applicability(
+  applicability : @loom_core.FixApplicability,
+) -> String {
+  match applicability {
+    @loom_core.FixApplicability::Always => "always"
+    @loom_core.FixApplicability::MaybeIncorrect => "maybe_incorrect"
+  }
+}
+
+///|
+fn current_source_diagnostic_fixes(
+  source_id : @loom_core.SourceId,
+  diagnostic : @loom_core.Diagnostic,
+) -> Array[RegisteredDiagnosticFix] {
+  diagnostic
+  .fixes()
+  .mapi((id, fix) => RegisteredDiagnosticFix(id, fix))
+  .filter(registered => {
+    registered.fix.edits()[0].span().source_id() == source_id
+  })
+}
+
+///|
+fn diagnostic_source_provider(
+  source_id : @loom_core.SourceId,
+  source : String,
+) -> @loom_core.SourceProvider {
+  @loom_core.SourceProvider(requested_source_id => {
+    if requested_source_id == source_id {
+      Some(
+        @loom_core.DiagnosticSourceFile(
+          "<input>",
+          source,
+          @loom_core.LineIndex::new(source),
+        ),
+      )
+    } else {
+      None
+    }
+  })
+}
+
+///|
+fn protocol_diagnostic_rows(
+  source_id : @loom_core.SourceId,
+  snapshot_id : Int,
+  published : PublishedDiagnostic,
+) -> Iter[@protocol.Diagnostic] {
+  let diagnostic = published.diagnostic
+  let severity = diagnostic_protocol_severity(diagnostic.severity())
+  let code = diagnostic.code().map(code => code.value())
+  let summaries = published.fixes.map(registered => {
+    @protocol.DiagnosticFixSummary(
+      id=registered.id,
+      title=registered.fix.title(),
+      applicability=diagnostic_fix_applicability(registered.fix.applicability()),
+    )
+  })
+  let has_actions = published.rendered_message is Some(_) &&
+    !summaries.is_empty()
+  let message = published.rendered_message.unwrap_or(diagnostic.message())
+  let protocol_diagnostic = (from, to) => {
+    let protocol_snapshot_id : Int? = if has_actions {
+      Some(snapshot_id)
+    } else {
+      None
+    }
+    let protocol_diagnostic_id : Int? = if has_actions {
+      Some(published.id)
+    } else {
+      None
+    }
+    @protocol.Diagnostic(
+      from~,
+      to~,
+      severity~,
+      message~,
+      code?,
+      snapshot_id?=protocol_snapshot_id,
+      diagnostic_id?=protocol_diagnostic_id,
+      fixes=if has_actions { summaries.copy() } else { [] },
+    )
+  }
+  let labels = diagnostic.labels()
+  if labels.is_empty() {
+    Iter::singleton(protocol_diagnostic(0, 0))
+  } else {
+    labels
+    .iter()
+    .filter(label => {
+      label.style() == @loom_core.LabelStyle::Primary &&
+      label.span().source_id() == source_id
+    })
+    .map(label => {
+      let range = label.span().range()
+      protocol_diagnostic(range.start().value(), range.end().value())
+    })
+  }
+}
+
+///|
+fn[T] ViewUpdateState::publish_diagnostics(
+  self : ViewUpdateState,
+  editor : SyncEditor[T],
+  diagnostics : @loom_core.DiagnosticSet,
+) -> Array[@protocol.Diagnostic] {
+  if diagnostics.is_empty() {
+    self.diagnostic_snapshot = None
+    return []
+  }
+  let snapshot_id = self.next_diagnostic_snapshot_id
+  self.next_diagnostic_snapshot_id += 1
+  let source_id = editor.parser_source_id()
+  let source = editor.get_text()
+  let provider = diagnostic_source_provider(source_id, source)
+  let published = diagnostics
+    .items()
+    .mapi((id, diagnostic) => {
+      let rendered_message : String? = Some(diagnostic.render_plain(provider)) catch {
+        _ => None
+      }
+      let fixes = match rendered_message {
+        Some(_) => current_source_diagnostic_fixes(source_id, diagnostic)
+        None => []
+      }
+      PublishedDiagnostic(id, diagnostic, rendered_message, fixes)
+    })
+  let registered = published
+    .iter()
+    .filter(item => !item.fixes.is_empty())
+    .map(item => {
+      (item.id, item.fixes.map(registered => (registered.id, registered.fix)))
+    })
+    .to_array()
+  self.diagnostic_snapshot = Some(
+    (snapshot_id, source_id, editor.get_version(), registered),
+  )
+  published
+  .iter()
+  .flat_map(item => protocol_diagnostic_rows(source_id, snapshot_id, item))
+  .to_array()
+}
+
+///|
+pub fn[T : Eq] ViewUpdateState::apply_diagnostic_fix(
+  self : ViewUpdateState,
+  editor : SyncEditor[T],
+  snapshot_id~ : Int,
+  diagnostic_id~ : Int,
+  fix_id~ : Int,
+  timestamp_ms~ : Int,
+) -> Bool {
+  guard snapshot_id >= 0 && diagnostic_id >= 0 && fix_id >= 0 else {
+    return false
+  }
+  guard self.diagnostic_snapshot
+    is Some((current_snapshot_id, source_id, version, diagnostics)) else {
+    return false
+  }
+  guard current_snapshot_id == snapshot_id &&
+    source_id == editor.parser_source_id() &&
+    version == editor.get_version() else {
+    return false
+  }
+  guard diagnostics.search_by(item => {
+      match item {
+        (id, _) => id == diagnostic_id
+      }
+    })
+    is Some(diagnostic_index) else {
+    return false
+  }
+  let (_, fixes) = diagnostics[diagnostic_index]
+  guard fixes.search_by(item => {
+      match item {
+        (id, _) => id == fix_id
+      }
+    })
+    is Some(fix_index) else {
+    return false
+  }
+  let (_, fix) = fixes[fix_index]
+  guard editor.apply_diagnostic_fix_candidate(source_id, fix, timestamp_ms) else {
+    return false
+  }
+  self.diagnostic_snapshot = None
+  true
 }
 
 ///|
@@ -71,12 +318,7 @@ pub fn project_diagnostics_for_source(
   .items()
   .iter()
   .flat_map(diagnostic => {
-    let severity = match diagnostic.severity() {
-      @loom_core.DiagnosticSeverity::Error => @protocol.SevError
-      @loom_core.DiagnosticSeverity::Warning => @protocol.SevWarning
-      @loom_core.DiagnosticSeverity::Info => @protocol.SevInfo
-      @loom_core.DiagnosticSeverity::Hint => @protocol.SevHint
-    }
+    let severity = diagnostic_protocol_severity(diagnostic.severity())
     let code = diagnostic.code().map(code => code.value())
     let protocol_diagnostic = (from, to) => {
       @protocol.Diagnostic(
@@ -135,8 +377,8 @@ pub fn[T : @loom_core.Renderable] compute_view_patches(
       }
   }
   state.previous_decorations = Some(current_decorations)
-  let diagnostics = project_diagnostics_for_source(
-    editor.parser.source_id(),
+  let diagnostics = state.publish_diagnostics(
+    editor,
     editor.parser_diagnostics().read_or_abort(),
   )
   if !diagnostics.is_empty() {

--- a/editor/view_updater_test.mbt
+++ b/editor/view_updater_test.mbt
@@ -297,7 +297,9 @@ test "parser diagnostic preserves EOF range severity message and code" {
   inspect(diagnostic.from, content="4")
   inspect(diagnostic.to, content="4")
   @debug.assert_eq(diagnostic.severity, @protocol.SevError)
-  inspect(diagnostic.message, content="unclosed '('")
+  inspect(diagnostic.message.contains("error: unclosed '('"), content="true")
+  inspect(diagnostic.message.contains("--> <input>"), content="true")
+  inspect(diagnostic.message.contains("primary 1:5-1:5"), content="true")
   @debug.assert_eq(diagnostic.code, None)
 }
 
@@ -320,7 +322,12 @@ test "empty document does not suppress structured parser diagnostics" {
   }
   inspect(diagnostic.from, content="0")
   inspect(diagnostic.to, content="0")
-  inspect(diagnostic.message, content="empty source")
+  inspect(
+    diagnostic.message.contains("error[test.empty-source]: empty source"),
+    content="true",
+  )
+  inspect(diagnostic.message.contains("--> <input>"), content="true")
+  inspect(diagnostic.message.contains("primary 1:1-1:1"), content="true")
   @debug.assert_eq(diagnostic.code, Some("test.empty-source"))
 }
 

--- a/examples/ideal/export-manifest.json
+++ b/examples/ideal/export-manifest.json
@@ -71,6 +71,7 @@
     "apply_ast_grep_results_json",
     "handle_text_intent",
     "handle_text_intent_checked",
+    "handle_diagnostic_fix_intent",
     "handle_undo",
     "handle_redo",
     "handle_structural_intent",

--- a/ffi/lambda/diagnostic_fix_wbtest.mbt
+++ b/ffi/lambda/diagnostic_fix_wbtest.mbt
@@ -1,0 +1,46 @@
+///|
+fn reset_diagnostic_fix_handles() -> Unit {
+  lambda_registry.clear()
+  pretty_view_states.clear()
+  last_created_handle.val = None
+}
+
+///|
+test "Lambda missing-else fix applies through revision-bound FFI and clears" {
+  reset_diagnostic_fix_handles()
+  let handle = create_editor("lambda-diagnostic-fix")
+  set_text(handle, "if x then y")
+  let published = compute_view_patches_json(handle)
+  inspect(
+    published.contains("\"code\":\"loom.lambda.expected_else\""),
+    content="true",
+  )
+  inspect(published.contains("\"snapshot_id\":0"), content="true")
+  inspect(published.contains("\"diagnostic_id\":0"), content="true")
+  inspect(
+    published.contains("\"title\":\"Insert missing else branch\""),
+    content="true",
+  )
+  inspect(handle_diagnostic_fix_intent(handle, 0, 0, 0, 101), content="true")
+  inspect(get_text(handle), content="if x then y else _")
+  inspect(handle_diagnostic_fix_intent(handle, 0, 0, 0, 102), content="false")
+  let cleared = compute_view_patches_json(handle)
+  inspect(
+    cleared.contains("\"type\":\"SetDiagnostics\",\"diagnostics\":[]"),
+    content="true",
+  )
+  destroy_editor(handle)
+}
+
+///|
+test "Lambda diagnostic fix FFI rejects stale publication after source edit" {
+  reset_diagnostic_fix_handles()
+  let handle = create_editor("lambda-diagnostic-fix-stale")
+  set_text(handle, "if x then y")
+  let published = compute_view_patches_json(handle)
+  inspect(published.contains("\"snapshot_id\":0"), content="true")
+  handle_text_intent(handle, 0, 0, " ", 101)
+  inspect(handle_diagnostic_fix_intent(handle, 0, 0, 0, 102), content="false")
+  inspect(get_text(handle), content=" if x then y")
+  destroy_editor(handle)
+}

--- a/ffi/lambda/intent.mbt
+++ b/ffi/lambda/intent.mbt
@@ -97,6 +97,32 @@ pub fn handle_text_intent_checked(
 }
 
 ///|
+/// Apply one opaque diagnostic-fix selection against the exact publication
+/// snapshot that produced it. Stale, unknown, or cross-editor IDs are rejected
+/// without changing source text.
+pub fn handle_diagnostic_fix_intent(
+  handle : Int,
+  snapshot_id : Int,
+  diagnostic_id : Int,
+  fix_id : Int,
+  timestamp_ms : Int,
+) -> Bool {
+  match lambda_registry.get(handle) {
+    Some(h) =>
+      lambda_registry
+      .view_state(handle)
+      .apply_diagnostic_fix(
+        h.editor,
+        snapshot_id~,
+        diagnostic_id~,
+        fix_id~,
+        timestamp_ms~,
+      )
+    None => false
+  }
+}
+
+///|
 pub fn handle_undo(handle : Int) -> Bool {
   undo_manager_undo(handle)
 }

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -107,6 +107,7 @@ options(
         "apply_ast_grep_results_json",
         "handle_text_intent",
         "handle_text_intent_checked",
+        "handle_diagnostic_fix_intent",
         "handle_undo",
         "handle_redo",
         "handle_structural_intent",

--- a/ffi/lambda/pkg.generated.mbti
+++ b/ffi/lambda/pkg.generated.mbti
@@ -81,6 +81,8 @@ pub fn get_version_json(Int) -> String
 
 pub fn get_view_tree_json(Int) -> String
 
+pub fn handle_diagnostic_fix_intent(Int, Int, Int, Int, Int) -> Bool
+
 pub fn handle_redo(Int) -> Bool
 
 pub fn handle_structural_intent(Int, String, String, Int, String) -> String

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -31,9 +31,20 @@ pub(all) struct Diagnostic {
   severity : Severity
   message : String
   code : String?
+  snapshot_id : Int?
+  diagnostic_id : Int?
+  fixes : Array[DiagnosticFixSummary]
 } derive(Eq, @debug.Debug)
-pub fn Diagnostic::Diagnostic(from~ : Int, to~ : Int, severity~ : Severity, message~ : String, code? : String) -> Self
+pub fn Diagnostic::Diagnostic(from~ : Int, to~ : Int, severity~ : Severity, message~ : String, code? : String, snapshot_id? : Int, diagnostic_id? : Int, fixes? : Array[DiagnosticFixSummary]) -> Self
 pub impl ToJson for Diagnostic
+
+pub(all) struct DiagnosticFixSummary {
+  id : Int
+  title : String
+  applicability : String
+} derive(Eq, @debug.Debug)
+pub fn DiagnosticFixSummary::DiagnosticFixSummary(id~ : Int, title~ : String, applicability~ : String) -> Self
+pub impl ToJson for DiagnosticFixSummary
 
 pub(all) enum Severity {
   SevError
@@ -60,6 +71,7 @@ pub(all) enum UserIntent {
   Undo
   Redo
   CommitEdit(node_id~ : @dowdiness/canopy/core.NodeId, value~ : String)
+  ApplyDiagnosticFix(snapshot_id~ : Int, diagnostic_id~ : Int, fix_id~ : Int)
 } derive(Eq, @debug.Debug)
 pub impl Show for UserIntent
 pub impl ToJson for UserIntent

--- a/protocol/user_intent.mbt
+++ b/protocol/user_intent.mbt
@@ -21,6 +21,7 @@ pub(all) enum UserIntent {
   Undo
   Redo
   CommitEdit(node_id~ : @core.NodeId, value~ : String)
+  ApplyDiagnosticFix(snapshot_id~ : Int, diagnostic_id~ : Int, fix_id~ : Int)
 } derive(Debug, Eq)
 
 ///|
@@ -56,6 +57,34 @@ fn user_intent_string_field(
     _ =>
       raise @json.JsonDecodeError(
         (path.add_key(key), "\{owner}: '\{key}' must be a string"),
+      )
+  }
+}
+
+///|
+fn user_intent_nonnegative_id_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+  owner : String,
+) -> Int raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(Json::Number(number, ..)) => {
+      let value = number.to_int()
+      if value >= 0 && number == Double::from_int(value) {
+        value
+      } else {
+        raise @json.JsonDecodeError(
+          (
+            path.add_key(key),
+            "\{owner}: '\{key}' must be a non-negative integer",
+          ),
+        )
+      }
+    }
+    _ =>
+      raise @json.JsonDecodeError(
+        (path.add_key(key), "\{owner}: '\{key}' must be a non-negative integer"),
       )
   }
 }
@@ -98,6 +127,12 @@ pub impl ToJson for UserIntent with fn to_json(self) {
       m["type"] = "CommitEdit".to_json()
       m["node_id"] = node_id.to_json()
       m["value"] = value.to_json()
+    }
+    ApplyDiagnosticFix(snapshot_id~, diagnostic_id~, fix_id~) => {
+      m["type"] = "ApplyDiagnosticFix".to_json()
+      m["snapshot_id"] = snapshot_id.to_json()
+      m["diagnostic_id"] = diagnostic_id.to_json()
+      m["fix_id"] = fix_id.to_json()
     }
   }
   Json::object(m)
@@ -180,6 +215,18 @@ pub impl @json.FromJson for UserIntent with fn from_json(json, path) {
       )
       let value = user_intent_string_field(m, path, "value", "CommitEdit")
       UserIntent::CommitEdit(node_id~, value~)
+    }
+    "ApplyDiagnosticFix" => {
+      let snapshot_id = user_intent_nonnegative_id_field(
+        m, path, "snapshot_id", "ApplyDiagnosticFix",
+      )
+      let diagnostic_id = user_intent_nonnegative_id_field(
+        m, path, "diagnostic_id", "ApplyDiagnosticFix",
+      )
+      let fix_id = user_intent_nonnegative_id_field(
+        m, path, "fix_id", "ApplyDiagnosticFix",
+      )
+      UserIntent::ApplyDiagnosticFix(snapshot_id~, diagnostic_id~, fix_id~)
     }
     _ =>
       raise @json.JsonDecodeError(

--- a/protocol/user_intent_test.mbt
+++ b/protocol/user_intent_test.mbt
@@ -135,6 +135,40 @@ test "UserIntent::CommitEdit round-trip" {
 }
 
 ///|
+test "UserIntent::ApplyDiagnosticFix round-trip" {
+  let intent = @protocol.UserIntent::ApplyDiagnosticFix(
+    snapshot_id=7,
+    diagnostic_id=2,
+    fix_id=1,
+  )
+  inspect(
+    intent.to_json().stringify(),
+    content="{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":7,\"diagnostic_id\":2,\"fix_id\":1}",
+  )
+  let decoded : @protocol.UserIntent = @json.from_json(intent.to_json())
+  assert_eq(intent, decoded)
+}
+
+///|
+test "UserIntent::ApplyDiagnosticFix rejects malformed IDs" {
+  let malformed = [
+    "{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":7,\"diagnostic_id\":2}", "{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":7,\"diagnostic_id\":\"2\",\"fix_id\":1}",
+    "{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":7.5,\"diagnostic_id\":2,\"fix_id\":1}",
+    "{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":-1,\"diagnostic_id\":2,\"fix_id\":1}",
+    "{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":7,\"diagnostic_id\":-2,\"fix_id\":1}",
+    "{\"type\":\"ApplyDiagnosticFix\",\"snapshot_id\":7,\"diagnostic_id\":2,\"fix_id\":-1}",
+  ]
+  malformed.each(encoded => {
+    let result : Result[@protocol.UserIntent, _] = Ok(
+      @json.from_json(@json.parse(encoded)),
+    ) catch {
+      error => Err(error)
+    }
+    assert_true(result is Err(_))
+  })
+}
+
+///|
 test "UserIntent from_json rejects unknown type" {
   let json = @json.parse("{\"type\": \"Unknown\"}")
   let result : Result[@protocol.UserIntent, _] = Ok(@json.from_json(json)) catch {

--- a/protocol/view_patch.mbt
+++ b/protocol/view_patch.mbt
@@ -49,6 +49,24 @@ pub impl ToJson for Severity with fn to_json(self) {
 }
 
 ///|
+/// Producer-neutral metadata for one registered diagnostic fix. The opaque
+/// integer `id` is meaningful only with its diagnostic and snapshot IDs.
+pub(all) struct DiagnosticFixSummary {
+  id : Int
+  title : String
+  applicability : String
+} derive(Debug, Eq)
+
+///|
+pub fn DiagnosticFixSummary::DiagnosticFixSummary(
+  id~ : Int,
+  title~ : String,
+  applicability~ : String,
+) -> DiagnosticFixSummary {
+  { id, title, applicability }
+}
+
+///|
 /// A diagnostic message associated with a half-open UTF-16 document code-unit
 /// range `[from, to)`. Used to surface compiler/linter findings to the editor
 /// frontend.
@@ -58,6 +76,9 @@ pub(all) struct Diagnostic {
   severity : Severity
   message : String
   code : String?
+  snapshot_id : Int?
+  diagnostic_id : Int?
+  fixes : Array[DiagnosticFixSummary]
 } derive(Debug, Eq)
 
 ///|
@@ -67,8 +88,20 @@ pub fn Diagnostic::Diagnostic(
   severity~ : Severity,
   message~ : String,
   code? : String,
+  snapshot_id? : Int,
+  diagnostic_id? : Int,
+  fixes? : Array[DiagnosticFixSummary] = [],
 ) -> Diagnostic {
-  { from, to, severity, message, code }
+  {
+    from,
+    to,
+    severity,
+    message,
+    code,
+    snapshot_id,
+    diagnostic_id,
+    fixes: fixes.copy(),
+  }
 }
 
 ///|
@@ -124,6 +157,24 @@ pub impl ToJson for Diagnostic with fn to_json(self) {
     Some(code) => code.to_json()
     None => Json::null()
   }
+  m["snapshot_id"] = match self.snapshot_id {
+    Some(id) => id.to_json()
+    None => Json::null()
+  }
+  m["diagnostic_id"] = match self.diagnostic_id {
+    Some(id) => id.to_json()
+    None => Json::null()
+  }
+  m["fixes"] = Json::array(self.fixes.map(fix => fix.to_json()))
+  Json::object(m)
+}
+
+///|
+pub impl ToJson for DiagnosticFixSummary with fn to_json(self) {
+  let m : Map[String, Json] = Map([])
+  m["id"] = self.id.to_json()
+  m["title"] = self.title.to_json()
+  m["applicability"] = self.applicability.to_json()
   Json::object(m)
 }
 

--- a/protocol/view_patch_test.mbt
+++ b/protocol/view_patch_test.mbt
@@ -35,7 +35,7 @@ test "Diagnostic to_json always includes nullable code" {
   )
   inspect(
     without_code.to_json().stringify(),
-    content="{\"from\":0,\"to\":3,\"severity\":\"error\",\"message\":\"unbound var\",\"code\":null}",
+    content="{\"from\":0,\"to\":3,\"severity\":\"error\",\"message\":\"unbound var\",\"code\":null,\"snapshot_id\":null,\"diagnostic_id\":null,\"fixes\":[]}",
   )
   let with_code = @protocol.Diagnostic(
     from=3,
@@ -46,8 +46,59 @@ test "Diagnostic to_json always includes nullable code" {
   )
   inspect(
     with_code.to_json().stringify(),
-    content="{\"from\":3,\"to\":3,\"severity\":\"hint\",\"message\":\"expected else\",\"code\":\"parse.expected-else\"}",
+    content="{\"from\":3,\"to\":3,\"severity\":\"hint\",\"message\":\"expected else\",\"code\":\"parse.expected-else\",\"snapshot_id\":null,\"diagnostic_id\":null,\"fixes\":[]}",
   )
+}
+
+///|
+test "Diagnostic to_json includes opaque IDs and ordered fix summaries" {
+  let diagnostic = @protocol.Diagnostic(
+    from=11,
+    to=11,
+    severity=@protocol.SevError,
+    message="missing else",
+    code="loom.lambda.expected_else",
+    snapshot_id=7,
+    diagnostic_id=2,
+    fixes=[
+      @protocol.DiagnosticFixSummary(
+        id=0,
+        title="Insert missing else branch",
+        applicability="always",
+      ),
+      @protocol.DiagnosticFixSummary(
+        id=1,
+        title="Insert explicit fallback",
+        applicability="maybe-incorrect",
+      ),
+    ],
+  )
+  inspect(
+    diagnostic.to_json().stringify(),
+    content="{\"from\":11,\"to\":11,\"severity\":\"error\",\"message\":\"missing else\",\"code\":\"loom.lambda.expected_else\",\"snapshot_id\":7,\"diagnostic_id\":2,\"fixes\":[{\"id\":0,\"title\":\"Insert missing else branch\",\"applicability\":\"always\"},{\"id\":1,\"title\":\"Insert explicit fallback\",\"applicability\":\"maybe-incorrect\"}]}",
+  )
+}
+
+///|
+test "Diagnostic constructor defensively copies fix summaries" {
+  let fixes = [
+    @protocol.DiagnosticFixSummary(
+      id=0,
+      title="Insert missing else branch",
+      applicability="always",
+    ),
+  ]
+  let diagnostic = @protocol.Diagnostic(
+    from=0,
+    to=0,
+    severity=@protocol.SevError,
+    message="missing else",
+    snapshot_id=1,
+    diagnostic_id=0,
+    fixes~,
+  )
+  fixes.clear()
+  inspect(diagnostic.fixes.length(), content="1")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- carry Loom's Lambda missing-else fix through producer-neutral diagnostic metadata and opaque snapshot/diagnostic/fix IDs
- keep the revision-bound fix registry private, reject stale/unknown/cross-source selections, and apply validated edits as one CRDT/undo transition
- wire CM6 actions through the typed Lambda FFI, then refresh authoritative source and diagnostics
- update the CM6 E2E job to consume the built Lambda artifact

Closes #1038

## Submodule prerequisites

- event-graph-walker PR #99, merge commit fadc41b1e99753129be816c37393afee2175e23f
- Loom PR #806, squash merge commit c87a5dd63560a00e6a598d6239634f3fefe411d2

## Reuse check

- reused Loom DiagnosticFix validation/application, SourceId, SourceProvider, DiagnosticRenderer, and text Version instead of introducing a second fix or revision model
- reused SyncEditor replace-span, parser synchronization, cursor reconciliation, UndoManager, existing UserIntent JSON boundaries, and the CM6 lint action callback
- checked MoonBit Option/Result, Array/Iter, Map, String/UTF-16 APIs, cmp/overlap/sorting needs; no Map/Set, new sorting, or low-level replacement loop was needed
- remaining mutation is confined to the editor/FFI imperative shell and the private current-snapshot registry; protocol collections are defensively copied

## Validation

- ./scripts/validate-pr-ready.sh --target protocol: pass; 46/46 focused tests
- ./scripts/validate-pr-ready.sh --target editor: pass; 214/214 focused tests
- ./scripts/validate-pr-ready.sh --target ffi/lambda: pass; 58/58 focused tests
- full workspace test baseline: 0 failures, 0 non-vendored failures; 4271 wasm-gc tests passed during independent review
- JavaScript build: pass
- CM6 typecheck/build: pass
- real CM6 to Lambda FFI Playwright E2E: 1/1 pass
- generated .mbti reviewed: protocol fix metadata/UserIntent, editor public apply capability with private registry fields, Lambda FFI handler; no unintended trait-bound widening
- known baseline only: nine Rabbita Warning [0020] implicit-promotion deprecations

Validated HEAD: 1563f68dc432c957bf797303502bdf67082b7ead
Validated base: ba20c7052cff8f839f532b2c00517b9adcd59681

## Independent review

- reviewer: gpt-5.6-terra
- final verdict: PASS
- initial finding that snapshot registry fields leaked through editor/pkg.generated.mbti was fixed; closure review confirmed only private fields plus the public apply capability remain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for applying suggested diagnostic fixes directly in the editor.
  - Diagnostics now display available fix actions with structured metadata.
  - Fixes are validated against the current source version and automatically clear after successful application.
  - Multi-edit fixes preserve a single undo operation.

- **Bug Fixes**
  - Prevented stale, unknown, or cross-source fixes from modifying editor content.

- **Tests**
  - Added coverage for fix application, rejection scenarios, serialization, undo/redo behavior, and editor integration.

- **Documentation**
  - Added the approved design contract for diagnostic fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->