### PR TITLE
Project reachable failures through shared diagnostics

### DIFF
--- a/docs/plans/2026-07-31-reachable-failure-shared-diagnostics.md
+++ b/docs/plans/2026-07-31-reachable-failure-shared-diagnostics.md
@@ -1,0 +1,172 @@
+# ReachableFailure shared diagnostics design
+
+Issue: #1039
+
+## Scope
+
+Project the existing Lambda `ReachableFailure` output through Loom's neutral
+diagnostic model. The scope graph remains the resolver of record. This change
+does not reimplement #617, does not move diagnostics into `AnalysisProjection`,
+and does not introduce entity-backed diagnostic remapping.
+
+## Behavioral boundary matrix
+
+| Input state | Parser diagnostics | Semantic snapshot | Published result |
+| --- | --- | --- | --- |
+| Valid source, all references bound | empty | current, empty | empty |
+| Valid source, unresolved reference | empty | current, warning | semantic warning |
+| Recoverable syntax error with unresolved references | current | current | parser then semantic diagnostics |
+| Semantic source differs from the coherent parser snapshot source | current | stale | parser diagnostics only |
+| Parser snapshot source differs from editor text | stale | any | no diagnostics |
+| Unresolved reference is corrected or bound | current | recomputed empty | prior warning is cleared |
+
+## Accepted contract and invariants
+
+1. `ReachableFailure` and `failures(graph, source_map)` remain producer-native
+   data and the only unresolved-reference query. No second name resolver is
+   added.
+2. Lambda exposes a separate neutral diagnostic builder. Diagnostics are
+   removed from `SemanticProjection`; annotations and decorations remain its
+   presentation responsibility. `AnalysisProjection` never stores diagnostics.
+3. The producer receives the editor parser's opaque `SourceId`. It constructs a
+   `DiagnosticSource("lambda.semantic")` independently; producer identity and
+   source-file identity are never interchangeable.
+4. Each finding is a warning with stable code `lambda.unresolved_reference` and
+   preserves the existing main message `Free variable '<name>'`.
+5. The unresolved identifier's exact token range becomes the single primary
+   `SourceSpan`. Lambda projection records the identifier token under a
+   dedicated `REFERENCE_NAME_ROLE` on the reference's existing NodeId. This is
+   required because parenthesized expressions reuse the inner NodeId while the
+   ordinary node range includes the parentheses. `failures` resolves the
+   reference NodeId through that token role in the current `SourceMap`; it does
+   not fall back to a wider node range. Scope witnesses are likewise resolved
+   before neutral construction: each scope records its structural owner node
+   during graph construction, and the current `SourceMap` supplies that owner's
+   range. A resolved owner range is a secondary label with message `searched
+   lexical scope`; a witness without an authoritative range becomes a note. No
+   location is inferred from a name, message, diagnostic position, scope-array
+   position, or presentation DTO.
+6. The neutral builder accepts the current source text as an external
+   validation input but never stores it in a diagnostic. A typed
+   `SemanticDiagnosticError` boundary rejects a range unless its offsets are
+   non-negative and ordered, its end is at most `source.length()`, and
+   `String::get_view(start~, end~)` confirms both offsets are
+   valid UTF-16 code-point boundaries. Only then does the builder call
+   `TextRange::from_offsets`. Invalid ranges are neither clamped nor emitted to
+   the editor after a renderer failure.
+7. All ranges remain half-open UTF-16 code-unit offsets. A label ending at the
+   source length is valid, as is Loom's existing zero-width representation.
+8. Loom constructors and accessors preserve label style/message and defensive
+   copies. The producer never exposes a mutable internal diagnostic array.
+9. Parser diagnostics are read from one coherent `Parser::snapshot()`. The
+   Lambda diagnostic callback returns the exact parser source text alongside
+   its neutral set. A private deterministic merge accepts semantic diagnostics
+   only when editor text, parser snapshot source, and semantic source are equal;
+   otherwise it publishes no mixed snapshot. Equal-source edits recompute from
+   the current projection and scope graph; generic NodeId/entity remapping is
+   not used.
+10. Parser diagnostics retain order and semantic diagnostics append in scope
+    graph order via `DiagnosticSet::copy` plus `add_all`.
+11. The existing semantic-projection JSON shape remains compatible, but its
+    `diagnostics` member is assembled at the FFI shell by the existing editor
+    protocol adapter. The semantic producer does not construct protocol DTOs.
+12. Plain text uses Loom's existing source-backed renderer. Editor patches use
+    the existing editor publisher. Both consume the same neutral diagnostic.
+
+## Existing API First
+
+### Reused project and Loom APIs
+
+- `ReachableFailure`, `failures`, and `visited_scopes`: authoritative semantic
+  failure and witness; reused unchanged as the query.
+- `SourceMap::get_token_span`, `SourceMap::get_range`, and existing UTF-16
+  `Range`: authoritative identity-to-span conversion. A new reference-name role
+  is necessary because no current role distinguishes a `VarRef` identifier from
+  a parenthesized node range. A scope-owner query is added only because no
+  existing scope-to-node/span API exists.
+- Loom `SourceId`, `TextRange::from_offsets`, `SourceSpan`, `DiagnosticLabel`,
+  `LabelStyle`, `Diagnostic`, `DiagnosticCode`, and `DiagnosticSource`: reused as
+  the sole neutral model and validation boundary.
+- `DiagnosticSet::empty`, `single`, `copy`, `push`, `items`, and `add_all`:
+  collection construction, merging, deduplication, and defensive copying.
+- `Diagnostic::render_plain` / `DiagnosticSet::render_plain` and the editor's
+  existing current-source projection/publisher: reused without a second
+  renderer or wire model.
+- `Parser::snapshot`: reused because source, CST, AST, and parser diagnostics are
+  updated atomically in one parse snapshot.
+
+### MoonBit core APIs checked
+
+- `Option.map/bind` and pattern matching: used for missing locations and optional
+  semantic snapshots.
+- `String::length` and `String::get_view`: reused to validate source bounds and
+  UTF-16 code-point boundaries without slicing or storing source text.
+- `Array.map`, `filter`, `filter_map`, `copy`, and `Iter` traversal: used for
+  labels, notes, and protocol projection. Local mutable arrays remain only as
+  builders returned from deterministic functions.
+- `Map` and `Set`: checked but no new collection is needed. The existing scope
+  graph and `DiagnosticSet` already own lookup/deduplication.
+- `Result`: checked; Loom's raising range constructor is the existing typed
+  validation contract, so a parallel result wrapper would add no value.
+- comparison helpers, overlap checks, and sorting: checked and not needed. The
+  scope graph already defines witness order, and no diagnostic correctness rule
+  depends on label overlap or sorted spans.
+- `ArrayView`: checked but not used because Loom's public diagnostic accessors
+  intentionally return owning defensive copies.
+
+### New responsibility boundaries
+
+- A scope-owner field/query records the node that structurally opened a scope
+  and resolves that producer-native identity through the current `SourceMap`.
+  Existing APIs expose declaration binders and node-to-scope lookup, but no
+  authoritative scope-to-source direction.
+- `REFERENCE_NAME_ROLE` is the smallest producer/consumer contract that gives a
+  `VarRef` an exact identifier span even when syntax wrappers reuse its NodeId;
+  existing parameter and binding-name roles describe different tokens.
+- `SemanticDiagnosticError` belongs to the Lambda-to-neutral conversion
+  boundary. Loom's `DiagnosticBuildError` validates ordering but has no source
+  text with which to reject out-of-bounds or surrogate-interior offsets.
+- A private source-consistency merge in the editor is a pure functional core:
+  `(editor source, parser snapshot, optional semantic snapshot) -> DiagnosticSet`.
+  It is the only new combination policy and performs no I/O or mutation.
+
+## Caller migration
+
+- Lambda semantic tests consume the neutral diagnostic builder instead of a
+  protocol array on `SemanticProjection`.
+- Lambda capabilities expose a content-tagged semantic diagnostic snapshot built
+  from the same reactive parser/projection inputs used by the current editor.
+- The generic editor merges the current producer set with parser diagnostics and
+  passes the combined neutral set to the existing publisher once.
+- The semantic FFI composes its compatibility JSON through the editor adapter.
+- Markdown and generic editors keep `LanguageCapabilities::default`; the new
+  callback is optional and defaults to no semantic producer.
+
+## Focused tests
+
+1. Valid unresolved input produces one warning with the stable semantic code.
+2. The exact identifier range is the primary half-open UTF-16 span, including an
+   end boundary equal to source length. A parenthesized unresolved reference
+   labels only the inner identifier, never the parentheses.
+3. Primary/secondary styles and messages survive; multiple witnessed scopes
+   become multiple labels, and missing scope ranges become notes.
+4. Negative, reversed, out-of-bounds, and surrogate-interior producer ranges
+   are rejected by the source-aware semantic conversion boundary and never
+   reach the editor publisher.
+5. Diagnostic/label/note access remains defensive-copy safe.
+6. Diagnostic source identity is distinct from source-file identity.
+7. A recoverable parser diagnostic and semantic warnings coexist in one editor
+   patch.
+8. Plain and editor adapters consume the same neutral diagnostic.
+9. Correcting the reference clears the semantic warning.
+10. A semantic source mismatch cannot join current parser diagnostics.
+11. Generated interfaces and source inspection show no NodeId, SyntaxNode,
+    ScopeId, or protocol DTO inside the neutral diagnostic.
+
+## Validation
+
+Run focused tests for `lang/lambda/scope`, `lang/lambda/semantic`, `editor`,
+`lang/lambda/companion`, and `ffi/lambda`, followed by workspace `moon check`,
+`moon test`, `moon info`, and `moon fmt`. Inspect every generated `.mbti` diff,
+then validate the committed clean HEAD with `validate-pr-ready.sh` for every
+affected MoonBit package.

--- a/editor/capabilities.mbt
+++ b/editor/capabilities.mbt
@@ -10,6 +10,7 @@ pub struct LanguageCapabilities[T] {
     Array[@protocol.ViewAnnotation],
   ])?
   priv get_decorations : (() -> Array[@protocol.Decoration])?
+  priv get_diagnostics : (() -> (String, @loom_core.DiagnosticSet)?)?
   priv to_view_node : ((
     @core.ProjNode[T],
     @core.SourceMap,
@@ -26,6 +27,7 @@ pub struct LanguageCapabilities[T] {
 pub fn[T] LanguageCapabilities::new(
   get_annotations? : (() -> Map[@core.NodeId, Array[@protocol.ViewAnnotation]])? = None,
   get_decorations? : (() -> Array[@protocol.Decoration])? = None,
+  get_diagnostics? : (() -> (String, @loom_core.DiagnosticSet)?)? = None,
   pretty_post_process? : ((@pretty.Layout[@pretty.SyntaxCategory]) -> @pretty.Layout[
     @pretty.SyntaxCategory,
   ])? = None,
@@ -33,6 +35,7 @@ pub fn[T] LanguageCapabilities::new(
   {
     get_annotations,
     get_decorations,
+    get_diagnostics,
     to_view_node: None,
     pretty_post_process,
     phantom: None,
@@ -52,6 +55,7 @@ pub fn[T] LanguageCapabilities::with_to_view_node(
   {
     get_annotations: self.get_annotations,
     get_decorations: self.get_decorations,
+    get_diagnostics: self.get_diagnostics,
     to_view_node: Some(to_view_node),
     pretty_post_process: self.pretty_post_process,
     phantom: None,
@@ -64,6 +68,7 @@ pub fn[T] LanguageCapabilities::default() -> LanguageCapabilities[T] {
   {
     get_annotations: None,
     get_decorations: None,
+    get_diagnostics: None,
     to_view_node: None,
     pretty_post_process: None,
     phantom: None,

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -10,6 +10,7 @@ import {
   "dowdiness/event-graph-walker/history",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
+  "dowdiness/loom/incremental",
   "dowdiness/loom/pipeline",
   "dowdiness/pretty",
   "dowdiness/seam",
@@ -67,7 +68,7 @@ pub struct LanguageCapabilities[T] {
   // private fields
 }
 pub fn[T] LanguageCapabilities::default() -> Self[T]
-pub fn[T] LanguageCapabilities::new(get_annotations? : (() -> Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]])?, get_decorations? : (() -> Array[@protocol.Decoration])?, pretty_post_process? : ((@pretty.Layout[@pretty.SyntaxCategory]) -> @pretty.Layout[@pretty.SyntaxCategory])?) -> Self[T]
+pub fn[T] LanguageCapabilities::new(get_annotations? : (() -> Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]])?, get_decorations? : (() -> Array[@protocol.Decoration])?, get_diagnostics? : (() -> (String, @dowdiness/loom/core.DiagnosticSet)?)?, pretty_post_process? : ((@pretty.Layout[@pretty.SyntaxCategory]) -> @pretty.Layout[@pretty.SyntaxCategory])?) -> Self[T]
 pub fn[T] LanguageCapabilities::with_to_view_node(Self[T], (@dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap, Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]], String?) -> @protocol.ViewNode) -> Self[T]
 
 pub struct SyncEditor[T] {
@@ -130,6 +131,7 @@ pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T]
 pub fn[T] SyncEditor::parser_diagnostics(Self[T]) -> @cells.Derived[@dowdiness/loom/core.DiagnosticSet]
 pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime
+pub fn[T] SyncEditor::parser_snapshot(Self[T]) -> @cells.Derived[@incremental.ParseSnapshot[T]]
 pub fn[T] SyncEditor::parser_source(Self[T]) -> @cells.Derived[String]
 pub fn[T] SyncEditor::parser_source_id(Self[T]) -> @dowdiness/loom/core.SourceId
 pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Derived[@seam.SyntaxNode]

--- a/editor/semantic_diagnostics_wbtest.mbt
+++ b/editor/semantic_diagnostics_wbtest.mbt
@@ -1,0 +1,66 @@
+///|
+fn semantic_merge_test_set(message : String) -> @loom_core.DiagnosticSet {
+  @loom_core.DiagnosticSet::single(
+    @loom_core.Diagnostic(
+      source=@loom_core.DiagnosticSource(message),
+      severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+      message~,
+    ),
+  )
+}
+
+///|
+test "semantic diagnostics merge only equal source snapshots in producer order" {
+  let parser = semantic_merge_test_set("parser")
+  let semantic = semantic_merge_test_set("semantic")
+  let merged = merge_current_diagnostics(
+    "current",
+    "current",
+    parser,
+    Some(("current", semantic)),
+  )
+  debug_inspect(
+    merged.items().map(diagnostic => diagnostic.message()),
+    content="[\"parser\", \"semantic\"]",
+  )
+}
+
+///|
+test "semantic diagnostics source mismatch keeps only current parser diagnostics" {
+  let merged = merge_current_diagnostics(
+    "current",
+    "current",
+    semantic_merge_test_set("parser"),
+    Some(("stale", semantic_merge_test_set("semantic"))),
+  )
+  debug_inspect(
+    merged.items().map(diagnostic => diagnostic.message()),
+    content="[\"parser\"]",
+  )
+}
+
+///|
+test "stale parser snapshot publishes no diagnostics" {
+  let merged = merge_current_diagnostics(
+    "current",
+    "stale",
+    semantic_merge_test_set("parser"),
+    Some(("current", semantic_merge_test_set("semantic"))),
+  )
+  inspect(merged.length(), content="0")
+}
+
+///|
+test "diagnostic merge owns a defensive result" {
+  let parser = semantic_merge_test_set("parser")
+  let semantic = semantic_merge_test_set("semantic")
+  let merged = merge_current_diagnostics(
+    "current",
+    "current",
+    parser,
+    Some(("current", semantic)),
+  )
+  parser.push(@loom_core.Diagnostic::lexer_error("late parser mutation"))
+  semantic.push(@loom_core.Diagnostic::lexer_error("late semantic mutation"))
+  inspect(merged.length(), content="2")
+}

--- a/editor/sync_editor_parser.mbt
+++ b/editor/sync_editor_parser.mbt
@@ -133,6 +133,14 @@ pub fn[T] SyncEditor::parser_source_id(
 }
 
 ///|
+/// Reactive view of the parser's complete coherent snapshot.
+pub fn[T] SyncEditor::parser_snapshot(
+  self : SyncEditor[T],
+) -> @incr.Derived[@loom.ParseSnapshot[T]] {
+  self.parser.snapshot()
+}
+
+///|
 /// Reactive view of the parser's recovered CST. Tracked when `.get_or_abort()`
 /// inside a memo closure.
 pub fn[T] SyncEditor::parser_syntax_tree(

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -349,6 +349,28 @@ pub fn project_diagnostics_for_source(
 }
 
 ///|
+/// Combine diagnostics only when every input belongs to the current source
+/// snapshot. The returned set owns its collection and preserves parser-first
+/// producer order.
+fn merge_current_diagnostics(
+  editor_source : String,
+  parser_source : String,
+  parser_diagnostics : @loom_core.DiagnosticSet,
+  semantic_snapshot : (String, @loom_core.DiagnosticSet)?,
+) -> @loom_core.DiagnosticSet {
+  if editor_source != parser_source {
+    return @loom_core.DiagnosticSet::empty()
+  }
+  let merged = parser_diagnostics.copy()
+  match semantic_snapshot {
+    Some((semantic_source, semantic_diagnostics)) if semantic_source ==
+      parser_source => merged.add_all(semantic_diagnostics)
+    _ => ()
+  }
+  merged
+}
+
+///|
 pub fn[T : @loom_core.Renderable] compute_view_patches(
   state : ViewUpdateState,
   editor : SyncEditor[T],
@@ -377,10 +399,18 @@ pub fn[T : @loom_core.Renderable] compute_view_patches(
       }
   }
   state.previous_decorations = Some(current_decorations)
-  let diagnostics = state.publish_diagnostics(
-    editor,
-    editor.parser_diagnostics().read_or_abort(),
+  let parser_snapshot = editor.parser_snapshot().read_or_abort()
+  let semantic_snapshot = match editor.capabilities.get_diagnostics {
+    Some(get_diagnostics) => get_diagnostics()
+    None => None
+  }
+  let current_diagnostics = merge_current_diagnostics(
+    editor.get_text(),
+    parser_snapshot.source,
+    parser_snapshot.diagnostics,
+    semantic_snapshot,
   )
+  let diagnostics = state.publish_diagnostics(editor, current_diagnostics)
   if !diagnostics.is_empty() {
     patches.push(@protocol.ViewPatch::SetDiagnostics(diagnostics~))
     state.had_errors = true

--- a/ffi/lambda/diagnostic_fix_wbtest.mbt
+++ b/ffi/lambda/diagnostic_fix_wbtest.mbt
@@ -26,7 +26,11 @@ test "Lambda missing-else fix applies through revision-bound FFI and clears" {
   inspect(handle_diagnostic_fix_intent(handle, 0, 0, 0, 102), content="false")
   let cleared = compute_view_patches_json(handle)
   inspect(
-    cleared.contains("\"type\":\"SetDiagnostics\",\"diagnostics\":[]"),
+    cleared.contains("\"code\":\"loom.lambda.expected_else\""),
+    content="false",
+  )
+  inspect(
+    cleared.contains("\"code\":\"lambda.unresolved_reference\""),
     content="true",
   )
   destroy_editor(handle)

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -163,7 +163,7 @@ test "workstream 3: get_semantic_projection_json collapses to empty after coordi
   reset_coordinator_for_phase1_tests()
   let handle = create_editor("semantic_projection_coord_destroy_agent")
   set_text(handle, "let x = 1\nx")
-  let empty = @lambda_semantic.SemanticProjection::empty().to_json().stringify()
+  let empty = empty_semantic_projection_json()
   let alive_json = get_semantic_projection_json(handle)
   if alive_json == empty {
     fail("expected live semantic projection JSON before coordinator destroy")

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -8,6 +8,7 @@ import {
   "dowdiness/canopy/lang/lambda/eval" @lambda_eval,
   "dowdiness/canopy/lang/lambda/semantic" @lambda_semantic,
   "dowdiness/canopy/llm",
+  "dowdiness/canopy/protocol",
   "dowdiness/canopy/relay",
   "dowdiness/canopy/core",
   "dowdiness/canopy/workspace/coordinator" @workspace,

--- a/ffi/lambda/semantic.mbt
+++ b/ffi/lambda/semantic.mbt
@@ -18,8 +18,22 @@ fn semantic_node_allows_rename(
 }
 
 ///|
+fn semantic_projection_json(
+  projection : @lambda_semantic.SemanticProjection,
+  diagnostics : Array[@protocol.Diagnostic],
+) -> String {
+  guard projection.to_json() is Json::Object(fields) else {
+    abort("SemanticProjection must serialize to an object")
+  }
+  fields["diagnostics"] = Json::array(
+    diagnostics.map(diagnostic => diagnostic.to_json()),
+  )
+  Json::object(fields).stringify()
+}
+
+///|
 fn empty_semantic_projection_json() -> String {
-  @lambda_semantic.SemanticProjection::empty().to_json().stringify()
+  semantic_projection_json(@lambda_semantic.SemanticProjection::empty(), [])
 }
 
 ///|
@@ -47,9 +61,32 @@ pub fn get_semantic_projection_json(handle : Int) -> String {
           return empty_semantic_projection_json()
         }
       }
-      @lambda_semantic.build_semantic_projection(root, source_map)
-      .to_json()
-      .stringify()
+      let source = match
+        coordinator.read_protected(h.editor_id, h.cells.parser_source) {
+        Ok(source) => source
+        Err(report) => {
+          println("get_semantic_projection_json source read: \{report}")
+          return empty_semantic_projection_json()
+        }
+      }
+      let projection = @lambda_semantic.build_semantic_projection(
+        root, source_map,
+      )
+      let diagnostics = @lambda_semantic.build_semantic_diagnostics(
+        h.editor.parser_source_id(),
+        source,
+        root,
+        source_map,
+      ) catch {
+        _ => @loom.DiagnosticSet::empty()
+      }
+      semantic_projection_json(
+        projection,
+        @editor.project_diagnostics_for_source(
+          h.editor.parser_source_id(),
+          diagnostics,
+        ),
+      )
     }
     None => empty_semantic_projection_json()
   }

--- a/lang/lambda/companion/editor_view_decorations_test.mbt
+++ b/lang/lambda/companion/editor_view_decorations_test.mbt
@@ -215,3 +215,80 @@ test "coded lexer diagnostic preserves its source range and code" {
   assert_true(diagnostic.from < diagnostic.to)
   assert_true(diagnostic.code.unwrap().length() > 0)
 }
+
+///|
+test "unresolved reference publishes the neutral semantic warning" {
+  let editor = (try! new_lambda_editor("test-semantic-diagnostic")).0
+  editor.set_text("(x) => y")
+  let patches = @editor.compute_view_patches(
+    @editor.ViewUpdateState::ViewUpdateState(),
+    editor,
+  )
+  let patch = patches
+    .iter()
+    .find_first(patch => patch is @protocol.ViewPatch::SetDiagnostics(_))
+    .unwrap()
+  guard patch is @protocol.ViewPatch::SetDiagnostics(diagnostics~) else {
+    fail("expected SetDiagnostics")
+  }
+  let semantic = diagnostics
+    .iter()
+    .find_first(diagnostic => {
+      diagnostic.code == Some("lambda.unresolved_reference")
+    })
+    .unwrap()
+  inspect(semantic.from, content="7")
+  inspect(semantic.to, content="8")
+  @debug.assert_eq(semantic.severity, @protocol.SevWarning)
+  inspect(semantic.message.contains("Free variable 'y'"), content="true")
+  inspect(semantic.message.contains("searched lexical scope"), content="true")
+}
+
+///|
+test "parser and semantic diagnostics coexist in one current-source patch" {
+  let editor = (try! new_lambda_editor("test-parser-semantic-coexist")).0
+  editor.set_text("if x then y")
+  let patches = @editor.compute_view_patches(
+    @editor.ViewUpdateState::ViewUpdateState(),
+    editor,
+  )
+  let patch = patches
+    .iter()
+    .find_first(patch => patch is @protocol.ViewPatch::SetDiagnostics(_))
+    .unwrap()
+  guard patch is @protocol.ViewPatch::SetDiagnostics(diagnostics~) else {
+    fail("expected SetDiagnostics")
+  }
+  inspect(
+    diagnostics.iter().any(diagnostic => diagnostic.message.contains("else")),
+    content="true",
+  )
+  inspect(
+    diagnostics
+    .iter()
+    .any(diagnostic => diagnostic.code == Some("lambda.unresolved_reference")),
+    content="true",
+  )
+}
+
+///|
+test "binding an unresolved reference clears its semantic warning" {
+  let editor = (try! new_lambda_editor("test-semantic-diagnostic-clear")).0
+  let state = @editor.ViewUpdateState::ViewUpdateState()
+  editor.set_text("(x) => y")
+  let _ = @editor.compute_view_patches(state, editor)
+  editor.set_text("(x) => x")
+  let patches = @editor.compute_view_patches(state, editor)
+  inspect(
+    patches
+    .iter()
+    .any(patch => {
+      match patch {
+        @protocol.ViewPatch::SetDiagnostics(diagnostics~) =>
+          diagnostics.is_empty()
+        _ => false
+      }
+    }),
+    content="true",
+  )
+}

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -163,6 +163,7 @@ pub fn new_lambda_editor(
     None,
   )
   let source_map_memo_ref : Ref[@incr.Derived[@core.SourceMap]?] = Ref(None)
+  let parser_ref : Ref[@loom.Parser[@ast.Term]?] = Ref(None)
   // Shared structural-edit hint channel: apply_lambda_tree_edit pushes hints
   // here via apply_span_edits; the reconcile closure in build_lambda_projection_memos
   // consumes+clears it once per reparse (T4).
@@ -173,6 +174,7 @@ pub fn new_lambda_editor(
       @loom.new_parser(source_id, source, @parser.lambda_grammar, runtime?)
     },
     fn(parser) {
+      parser_ref.val = Some(parser)
       let (cached_proj_node, registry_memo, source_map_memo) = @lambda_proj.build_lambda_projection_memos(
         parser,
         identity_hints=hints_ref,
@@ -192,7 +194,8 @@ pub fn new_lambda_editor(
     capture_timeout_ms~,
     parent_runtime?,
     capabilities=build_lambda_capabilities(
-      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref, analysis_projection,
+      cached_proj_node_ref, source_map_memo_ref, escalation_memo_ref, parser_ref,
+      analysis_projection,
     ),
     identity_hints=hints_ref,
   )
@@ -211,6 +214,7 @@ fn build_lambda_capabilities(
   cached_proj_node_ref : Ref[@incr.Derived[@core.ProjNode[@ast.Term]?]?],
   source_map_memo_ref : Ref[@incr.Derived[@core.SourceMap]?],
   escalation_memo_ref : Ref[@incr.Derived[Array[@lambda_eval.EvalResult]]?],
+  parser_ref : Ref[@loom.Parser[@ast.Term]?],
   analysis_projection : AnalysisProjection,
 ) -> @editor.LanguageCapabilities[@ast.Term] {
   @editor.LanguageCapabilities::new(
@@ -251,6 +255,30 @@ fn build_lambda_capabilities(
         _ => []
       }
       analysis_projection.decorations(semantic_decorations)
+    }),
+    get_diagnostics=Some(fn() {
+      guard parser_ref.val is Some(parser) else { return None }
+      let snapshot = parser.snapshot().read_or_abort()
+      guard cached_proj_node_ref.val is Some(cached_proj_memo) else {
+        return None
+      }
+      guard cached_proj_memo.read_or_abort() is Some(root) else { return None }
+      guard source_map_memo_ref.val is Some(source_map_memo) else {
+        return None
+      }
+      Some(
+        (
+          snapshot.source,
+          @lambda_semantic.build_semantic_diagnostics(
+            parser.source_id(),
+            snapshot.source,
+            root,
+            source_map_memo.read_or_abort(),
+          ),
+        ),
+      ) catch {
+        _ => None
+      }
     }),
     pretty_post_process=Some(fn(layout) {
       let eval_results = match escalation_memo_ref.val {

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -22,6 +22,8 @@ pub const LET_DEF_NAME_ROLE : String = "name"
 
 pub const PARAM_ROLE : String = "param"
 
+pub const REFERENCE_NAME_ROLE : String = "reference:name"
+
 pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]], trace_ref? : @ref.Ref[Array[@dowdiness/canopy/core.ReconcileTraceEvent]]?) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@ast.Term]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@ast.Term]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
 
 pub fn module_name_role(Int) -> String

--- a/lang/lambda/proj/populate_token_spans.mbt
+++ b/lang/lambda/proj/populate_token_spans.mbt
@@ -415,6 +415,13 @@ fn collect_token_spans_expr(
           collect_token_spans_expr(source_map, body_syn, proj_node)
         }
     }
+  } else if @parser.VarRefView::cast(syntax_node) is Some(_) {
+    source_map.set_span_from_token(
+      proj_node.id(),
+      REFERENCE_NAME_ROLE,
+      syntax_node,
+      @syntax.IdentToken.to_raw(),
+    )
   }
-  // IntLiteral, VarRef: leaf nodes, no token spans to extract
+  // IntLiteral: leaf node with no token spans to extract
 }

--- a/lang/lambda/proj/populate_token_spans_wbtest.mbt
+++ b/lang/lambda/proj/populate_token_spans_wbtest.mbt
@@ -171,3 +171,10 @@ test "populate_token_spans: binary left spine reaches every lambda operand" {
   expect_param_span(source_map, inner_bop.children[1], 15, 16)
   expect_param_span(source_map, proj.children[1], 28, 29)
 }
+
+///|
+test "populate_token_spans: parenthesized VarRef keeps exact identifier span" {
+  let text = "((free))"
+  let (proj, source_map) = parse_proj_with_token_spans(text)
+  expect_role_span(source_map, proj, REFERENCE_NAME_ROLE, 2, 6)
+}

--- a/lang/lambda/proj/token_roles.mbt
+++ b/lang/lambda/proj/token_roles.mbt
@@ -13,6 +13,10 @@ pub const PARAM_ROLE : String = "param"
 pub const LET_DEF_NAME_ROLE : String = "name"
 
 ///|
+/// Role key for a variable reference's exact identifier token.
+pub const REFERENCE_NAME_ROLE : String = "reference:name"
+
+///|
 /// Role key for a typed `fn` binding's keyword token (stored on the `LetDef`).
 pub const FN_BINDING_KEYWORD_ROLE : String = "fn:keyword"
 

--- a/lang/lambda/scope/builder.mbt
+++ b/lang/lambda/scope/builder.mbt
@@ -46,9 +46,13 @@ fn Builder::new() -> Builder {
 }
 
 ///|
-fn Builder::add_scope(self : Builder, parent : ScopeId?) -> ScopeId {
+fn Builder::add_scope(
+  self : Builder,
+  parent : ScopeId?,
+  owner_node_id : @core.NodeId,
+) -> ScopeId {
   let id = ScopeId(self.scopes.length())
-  self.scopes.push({ id, parent, decl_ids: [], ref_ids: [] })
+  self.scopes.push({ id, parent, decl_ids: [], ref_ids: [], owner_node_id })
   id
 }
 
@@ -94,7 +98,7 @@ fn root_node(
 /// cutoff is recorded against the scope in `node_cutoffs`, accumulating the
 /// cutoffs of all enclosing module scopes so each gates visibility independently.
 fn Builder::pass2(self : Builder, root : @core.ProjNode[@ast.Term]) -> Unit {
-  let root_scope = self.add_scope(None)
+  let root_scope = self.add_scope(None, root.id())
   match root.kind {
     // Root is the top-level module. Its scope (parent None) and decls are
     // installed above from the root `Module` children — that pre-installation
@@ -166,7 +170,7 @@ fn Builder::walk(
   self.node_cutoffs[node.id()] = cutoffs
   match node.kind {
     @ast.Term::Lam(param, _) => {
-      let lam_scope = self.add_scope(Some(current))
+      let lam_scope = self.add_scope(Some(current), node.id())
       let _ = self.add_decl(
         lam_scope,
         node.id(),
@@ -178,7 +182,7 @@ fn Builder::walk(
       }
     }
     @ast.Term::Module(defs, _) => {
-      let mod_scope = self.add_scope(Some(current))
+      let mod_scope = self.add_scope(Some(current), node.id())
       for i, def in defs {
         let _ = self.add_decl(
           mod_scope,

--- a/lang/lambda/scope/failures.mbt
+++ b/lang/lambda/scope/failures.mbt
@@ -8,8 +8,8 @@
 /// shared word — see the note's naming-discipline aside (§5).
 ///
 /// - `name`: the unresolved reference's identifier.
-/// - `location`: the reference's source span when recorded; `None` when the
-///   `SourceMap` holds no range for the node (nothing to draw). Diagnostic
+/// - `location`: the reference identifier's exact token span when recorded;
+///   `None` when the `SourceMap` holds no reference-name token span (nothing to draw). Diagnostic
 ///   consumers filter on `location is Some(_)`; impact-query consumers want the
 ///   whole set.
 /// - `witness`: the scopes searched and found NOT to contain `name`
@@ -34,7 +34,7 @@ fn ReachableFailure::ReachableFailure(
 /// Derived view over the scope graph: every unresolved (free) reference,
 /// surfaced as a witnessed `ReachableFailure`. The failure predicate is
 /// `resolution.decl is None`; the witness is `resolution.visited_scopes`; the
-/// location is the reference node's recorded source span.
+/// location is the reference identifier's recorded token span.
 ///
 /// Total over the graph's refs: this is the failure SET that feeds both the
 /// free-variable diagnostic (research note §6 Step 1, which it now sources) and
@@ -49,7 +49,10 @@ pub fn failures(
     for r in g.refs if r.resolution.decl is None => {
       ReachableFailure(
         name=r.name,
-        location=source_map.get_range(r.node_id),
+        location=source_map.get_token_span(
+          r.node_id,
+          @lambda_proj.REFERENCE_NAME_ROLE,
+        ),
         witness=r.resolution.visited_scopes,
       )
     }

--- a/lang/lambda/scope/failures_wbtest.mbt
+++ b/lang/lambda/scope/failures_wbtest.mbt
@@ -15,6 +15,33 @@ test "failures: free variable is surfaced with a populated witness" {
 }
 
 ///|
+test "failures: parenthesized free variable uses exact identifier token" {
+  let (_proj, registry, source_map) = build_fixture("((free))")
+  let g = build(registry, source_map)
+  let fs = failures(g, source_map)
+  guard fs[0].location is Some(location) else {
+    fail("expected exact reference location")
+  }
+  inspect(location.start, content="2")
+  inspect(location.end, content="6")
+}
+
+///|
+test "scope_span: every unresolved witness resolves through its owner node" {
+  let (_proj, registry, source_map) = build_fixture("(x) => { let y = 1; z }")
+  let g = build(registry, source_map)
+  let fs = failures(g, source_map)
+  inspect(fs.length(), content="1")
+  inspect(fs[0].witness.length() >= 2, content="true")
+  inspect(
+    fs[0].witness
+    .iter()
+    .all(scope => scope_span(g, scope, source_map) is Some(_)),
+    content="true",
+  )
+}
+
+///|
 test "failures: a fully-resolved program has no failures" {
   let (_proj, registry, source_map) = build_fixture(
     "let x = 1\nlet y = x\nx + y",

--- a/lang/lambda/scope/graph.mbt
+++ b/lang/lambda/scope/graph.mbt
@@ -25,6 +25,7 @@ pub(all) struct Scope {
   parent : ScopeId?
   decl_ids : Array[DeclId]
   ref_ids : Array[RefId]
+  priv owner_node_id : @core.NodeId
 } derive(Debug)
 
 ///|

--- a/lang/lambda/scope/graph_wbtest.mbt
+++ b/lang/lambda/scope/graph_wbtest.mbt
@@ -7,11 +7,14 @@ fn build_fixture(
   Map[@core.NodeId, @core.ProjNode[@ast.Term]],
   @core.SourceMap,
 ) raise {
-  let (proj, _errs) = @lambda_proj.parse_to_proj_node(
+  let (cst, _) = @parser.parse_cst(
     @loomcore.SourceId("canopy-test:lambda-scope-graph"),
     text,
   )
+  let syntax = @seam.SyntaxNode::from_cst(cst)
+  let proj = @lambda_proj.to_proj_node(syntax, Ref(0))
   let source_map = @core.SourceMap::from_ast(proj)
+  @lambda_proj.populate_token_spans(source_map, syntax, proj)
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = Map([])
   @core.collect_registry(proj, registry)
   (proj, registry, source_map)

--- a/lang/lambda/scope/pkg.generated.mbti
+++ b/lang/lambda/scope/pkg.generated.mbti
@@ -50,6 +50,8 @@ pub fn scope_binder_ui_key(Decl) -> @dowdiness/canopy/core.NodeId
 
 pub fn scope_for_node(ScopeGraph, @dowdiness/canopy/core.NodeId) -> ScopeId?
 
+pub fn scope_span(ScopeGraph, ScopeId, @dowdiness/canopy/core.SourceMap) -> @dowdiness/loom/core.Range?
+
 // Errors
 
 // Types and methods
@@ -99,6 +101,7 @@ pub(all) struct Scope {
   parent : ScopeId?
   decl_ids : Array[DeclId]
   ref_ids : Array[RefId]
+  // private fields
 } derive(@debug.Debug)
 
 pub struct ScopeAnnotation {

--- a/lang/lambda/scope/query.mbt
+++ b/lang/lambda/scope/query.mbt
@@ -60,6 +60,19 @@ pub fn scope_for_node(g : ScopeGraph, node_id : @core.NodeId) -> ScopeId? {
 }
 
 ///|
+/// The source range of the structural node that opened `scope`.
+/// Returns `None` for an invalid graph-local id or when the current SourceMap
+/// has no authoritative range for the owner node.
+pub fn scope_span(
+  g : ScopeGraph,
+  scope : ScopeId,
+  source_map : @core.SourceMap,
+) -> @loomcore.Range? {
+  let ScopeId(index) = scope
+  g.scopes.get(index).bind(owner => source_map.get_range(owner.owner_node_id))
+}
+
+///|
 /// All reference NodeIds whose resolution points at the declaration `decl`.
 /// Identity-based (keyed on `DeclId`, NOT a name match), so shadowing is
 /// respected. Keying on `DeclId` rather than `Decl.node_id` is deliberate:

--- a/lang/lambda/semantic/pkg.generated.mbti
+++ b/lang/lambda/semantic/pkg.generated.mbti
@@ -2,22 +2,26 @@
 package "dowdiness/canopy/lang/lambda/semantic"
 
 import {
-  "dowdiness/canopy/core",
   "dowdiness/canopy/protocol",
   "dowdiness/lambda/ast",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn build_semantic_projection(@core.ProjNode[@ast.Term], @core.SourceMap) -> SemanticProjection
+pub fn build_semantic_diagnostics(@dowdiness/loom/core.SourceId, String, @dowdiness/canopy/core.ProjNode[@ast.Term], @dowdiness/canopy/core.SourceMap) -> @dowdiness/loom/core.DiagnosticSet raise SemanticDiagnosticError
+
+pub fn build_semantic_projection(@dowdiness/canopy/core.ProjNode[@ast.Term], @dowdiness/canopy/core.SourceMap) -> SemanticProjection
 
 // Errors
+pub(all) suberror SemanticDiagnosticError {
+  InvalidSourceRange(Int, Int, Int)
+  InvalidUtf16Boundary(Int, Int)
+} derive(Eq, @debug.Debug)
 
 // Types and methods
 pub struct SemanticProjection {
-  annotations : Map[@core.NodeId, Array[@protocol.ViewAnnotation]]
+  annotations : Map[@dowdiness/canopy/core.NodeId, Array[@protocol.ViewAnnotation]]
   decorations : Array[@protocol.Decoration]
-  diagnostics : Array[@protocol.Diagnostic]
 } derive(@debug.Debug)
 pub fn SemanticProjection::empty() -> Self
 pub impl ToJson for SemanticProjection

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -8,12 +8,11 @@
 pub struct SemanticProjection {
   annotations : Map[@core.NodeId, Array[@protocol.ViewAnnotation]]
   decorations : Array[@protocol.Decoration]
-  diagnostics : Array[@protocol.Diagnostic]
 } derive(Debug)
 
 ///|
 pub fn SemanticProjection::empty() -> SemanticProjection {
-  { annotations: Map([]), decorations: [], diagnostics: [] }
+  { annotations: Map([]), decorations: [] }
 }
 
 ///|
@@ -28,9 +27,15 @@ pub impl ToJson for SemanticProjection with fn to_json(self) {
   let m : Map[String, Json] = Map([])
   m["annotations"] = Json::array(annotation_entries)
   m["decorations"] = Json::array(self.decorations.map(fn(d) { d.to_json() }))
-  m["diagnostics"] = Json::array(self.diagnostics.map(fn(d) { d.to_json() }))
   Json::object(m)
 }
+
+///|
+/// Failures at the Lambda-to-neutral diagnostic conversion boundary.
+pub(all) suberror SemanticDiagnosticError {
+  InvalidSourceRange(Int, Int, Int)
+  InvalidUtf16Boundary(Int, Int)
+} derive(Eq, Debug)
 
 ///|
 pub fn build_semantic_projection(
@@ -39,41 +44,104 @@ pub fn build_semantic_projection(
 ) -> SemanticProjection {
   let projection = SemanticProjection::empty()
   analyze_node(root, source_map, [], projection)
-  push_scope_failures(root, source_map, projection)
   projection
 }
 
 ///|
-/// Source the free-variable diagnostics from the lambda scope graph rather than
-/// the projection's own environment walk (research note 2026-06-13 §6 Step 1).
-/// Each unresolved reference (`resolution.decl == None`) is a witnessed
-/// `ReachableFailure`; for today's lexical lambda language that failure is
-/// genuinely reachable, so the squiggle now rests on the resolver of record
-/// instead of a parallel `env.contains` check.
-///
-/// The scope graph is reconstructed from `root`. Both the registry and the
-/// diagnostic ranges derive from that same tree, so resolution stays consistent
-/// with the spans where squiggles land. Incremental maintenance (avoiding this
-/// rebuild) is §6 Step 3, benchmark-gated.
-fn push_scope_failures(
+/// Convert one producer-native range after validating it against the exact
+/// source snapshot. The returned range is half-open UTF-16.
+fn semantic_text_range(
+  source : String,
+  range : @loomcore.Range,
+) -> @loomcore.TextRange raise SemanticDiagnosticError {
+  let source_length = source.length()
+  if range.start < 0 || range.end < range.start || range.end > source_length {
+    raise InvalidSourceRange(range.start, range.end, source_length)
+  }
+  guard source.get_view(start=range.start, end=range.end) is Some(_) else {
+    raise InvalidUtf16Boundary(range.start, range.end)
+  }
+  @loomcore.TextRange::from_offsets(range.start, range.end) catch {
+    _ => raise InvalidSourceRange(range.start, range.end, source_length)
+  }
+}
+
+///|
+fn semantic_label(
+  source_id : @loomcore.SourceId,
+  source : String,
+  range : @loomcore.Range,
+  style : @loomcore.LabelStyle,
+  message : String,
+) -> @loomcore.DiagnosticLabel raise SemanticDiagnosticError {
+  @loomcore.DiagnosticLabel::DiagnosticLabel(
+    style,
+    @loomcore.SourceSpan::SourceSpan(
+      source_id,
+      semantic_text_range(source, range),
+    ),
+    Some(message),
+  )
+}
+
+///|
+/// Project the existing witnessed scope failures into Loom's neutral model.
+/// Source text is used only for boundary validation and is never stored in the
+/// returned diagnostics.
+pub fn build_semantic_diagnostics(
+  source_id : @loomcore.SourceId,
+  source : String,
   root : @core.ProjNode[@ast.Term],
   source_map : @core.SourceMap,
-  projection : SemanticProjection,
-) -> Unit {
+) -> @loomcore.DiagnosticSet raise SemanticDiagnosticError {
   let registry : Map[@core.NodeId, @core.ProjNode[@ast.Term]] = Map([])
   @core.collect_registry(root, registry)
   let graph = @lambda_scope.build(registry, source_map)
+  let diagnostics = @loomcore.DiagnosticSet::empty()
   for failure in @lambda_scope.failures(graph, source_map) {
     guard failure.location is Some(range) else { continue }
-    projection.diagnostics.push(
-      @protocol.Diagnostic(
-        from=range.start,
-        to=range.end,
-        severity=@protocol.SevWarning,
+    let labels = [
+      semantic_label(
+        source_id,
+        source,
+        range,
+        @loomcore.LabelStyle::Primary,
+        "unresolved identifier",
+      ),
+    ]
+    let notes : Array[String] = []
+    failure.witness.each(scope => {
+      match @lambda_scope.scope_span(graph, scope, source_map) {
+        Some(scope_range) =>
+          labels.push(
+            semantic_label(
+              source_id,
+              source,
+              scope_range,
+              @loomcore.LabelStyle::Secondary,
+              "searched lexical scope",
+            ),
+          )
+        None => notes.push("searched lexical scope without source span")
+      }
+    })
+    diagnostics.push(
+      @loomcore.Diagnostic::Diagnostic(
+        source=@loomcore.DiagnosticSource::DiagnosticSource("lambda.semantic"),
+        // Imported enum variants are read-only; `all()` is the public value factory.
+        severity=@loomcore.DiagnosticSeverity::all()[1],
         message="Free variable '" + failure.name + "'",
+        code=Some(
+          @loomcore.DiagnosticCode::DiagnosticCode(
+            "lambda.unresolved_reference",
+          ),
+        ),
+        labels~,
+        notes~,
       ),
     )
   }
+  diagnostics
 }
 
 ///|

--- a/lang/lambda/semantic/semantic_projection_test.mbt
+++ b/lang/lambda/semantic/semantic_projection_test.mbt
@@ -16,6 +16,14 @@ fn parse_fixture(
 }
 
 ///|
+fn semantic_diagnostics_fixture(text : String) -> @loomcore.DiagnosticSet raise {
+  let (root, source_map) = parse_fixture(text)
+  build_semantic_diagnostics(
+    lambda_semantic_projection_test_source, text, root, source_map,
+  )
+}
+
+///|
 fn has_annotation(
   projection : SemanticProjection,
   node_id : @core.NodeId,
@@ -33,7 +41,7 @@ test "semantic projection annotates lambda binder and bound use" {
   let projection = build_semantic_projection(root, source_map)
   assert_true(has_annotation(projection, root.id(), "(x) =>"))
   assert_true(has_annotation(projection, root.children[0].id(), "bound x"))
-  inspect(projection.diagnostics.length(), content="0")
+  inspect(semantic_diagnostics_fixture("(x) => x").length(), content="0")
   assert_true(
     projection.decorations
     .iter()
@@ -46,11 +54,17 @@ test "semantic projection annotates lambda binder and bound use" {
 
 ///|
 test "semantic projection reports free variable" {
-  let (root, source_map) = parse_fixture("(x) => y")
+  let text = "(x) => y"
+  let (root, source_map) = parse_fixture(text)
   let projection = build_semantic_projection(root, source_map)
   let body = root.children[0]
   assert_true(has_annotation(projection, body.id(), "free y"))
-  inspect(projection.diagnostics.length(), content="1")
+  inspect(
+    build_semantic_diagnostics(
+      lambda_semantic_projection_test_source, text, root, source_map,
+    ).length(),
+    content="1",
+  )
   assert_true(
     projection.decorations.iter().any(fn(d) { d.css_class == "semantic-free" }),
   )
@@ -63,9 +77,11 @@ test "free-variable diagnostic in a module def is scope-sourced" {
   // lambda route), proving `push_scope_failures` reconstructs and resolves the
   // module-def graph rather than the diagnostic still coming from stale env logic.
   let (root, source_map) = parse_fixture("let a = z\na")
-  let projection = build_semantic_projection(root, source_map)
-  inspect(projection.diagnostics.length(), content="1")
-  inspect(projection.diagnostics[0].message, content="Free variable 'z'")
+  let diagnostics = build_semantic_diagnostics(
+    lambda_semantic_projection_test_source, "let a = z\na", root, source_map,
+  )
+  inspect(diagnostics.length(), content="1")
+  inspect(diagnostics.items()[0].message(), content="Free variable 'z'")
 }
 
 ///|
@@ -171,5 +187,131 @@ test "semantic projection respects sequential module bindings" {
   assert_true(has_annotation(projection, root.children[1].id(), "let y"))
   assert_false(has_annotation(projection, root.id(), "let x"))
   assert_false(has_annotation(projection, root.id(), "let y"))
-  inspect(projection.diagnostics.length(), content="0")
+  inspect(
+    semantic_diagnostics_fixture("let x = 1\nlet y = x\nx + y").length(),
+    content="0",
+  )
+}
+
+///|
+test "semantic diagnostics preserve neutral warning labels and identities" {
+  let text = "(x) => y"
+  let diagnostics = semantic_diagnostics_fixture(text)
+  let diagnostic = diagnostics.items()[0]
+  debug_inspect(diagnostic.severity(), content="Warning")
+  inspect(
+    diagnostic.code().unwrap().value(),
+    content="lambda.unresolved_reference",
+  )
+  inspect(diagnostic.message(), content="Free variable 'y'")
+  inspect(diagnostic.source().name(), content="lambda.semantic")
+  inspect(
+    diagnostic.source().name() == lambda_semantic_projection_test_source.value(),
+    content="false",
+  )
+  let labels = diagnostic.labels()
+  inspect(labels.length() >= 2, content="true")
+  debug_inspect(labels[0].style(), content="Primary")
+  debug_inspect(labels[0].message(), content="Some(\"unresolved identifier\")")
+  inspect(
+    labels[0].span().source_id().value(),
+    content="canopy-test:lambda-semantic-projection",
+  )
+  inspect(labels[0].span().range().start().value(), content="7")
+  inspect(labels[0].span().range().end().value(), content="8")
+  inspect(
+    labels
+    .get_view(start=1)
+    .unwrap()
+    .all(label => {
+      label.style() == @loomcore.LabelStyle::Secondary &&
+      label.message() == Some("searched lexical scope")
+    }),
+    content="true",
+  )
+}
+
+///|
+test "semantic diagnostics keep missing witness locations as notes" {
+  let text = "(x) => y"
+  let (root, populated_source_map) = parse_fixture(text)
+  let sparse_source_map = @core.SourceMap::new()
+  let body = root.children[0]
+  let reference_span = populated_source_map
+    .get_token_span(body.id(), @lambda_proj.REFERENCE_NAME_ROLE)
+    .unwrap()
+  sparse_source_map.set_token_span(
+    body.id(),
+    @lambda_proj.REFERENCE_NAME_ROLE,
+    reference_span,
+  )
+  let diagnostic = build_semantic_diagnostics(
+      lambda_semantic_projection_test_source, text, root, sparse_source_map,
+    ).items()[0]
+  inspect(diagnostic.labels().length(), content="1")
+  inspect(diagnostic.notes().length() >= 1, content="true")
+  inspect(
+    diagnostic
+    .notes()
+    .all(note => note == "searched lexical scope without source span"),
+    content="true",
+  )
+}
+
+///|
+test "semantic diagnostic boundary rejects invalid source ranges" {
+  let text = "(x) => y"
+  let (root, source_map) = parse_fixture(text)
+  let body = root.children[0]
+  let rejected = (range, validation_source) => {
+    source_map.set_token_span(
+      body.id(),
+      @lambda_proj.REFERENCE_NAME_ROLE,
+      range,
+    )
+    try {
+      let _ = build_semantic_diagnostics(
+        lambda_semantic_projection_test_source, validation_source, root, source_map,
+      )
+      false
+    } catch {
+      _ => true
+    }
+  }
+  inspect(rejected(@loomcore.Range::new(-1, 1), text), content="true")
+  inspect(rejected(@loomcore.Range::new(2, 1), text), content="true")
+  inspect(rejected(@loomcore.Range::new(7, 9), text), content="true")
+  inspect(rejected(@loomcore.Range::new(7, 8), "123456😀"), content="true")
+}
+
+///|
+test "semantic diagnostics are defensive copies and render from one neutral value" {
+  let text = "(x) => y"
+  let diagnostics = semantic_diagnostics_fixture(text)
+  let exposed = diagnostics.items()
+  let exposed_labels = exposed[0].labels()
+  let exposed_notes = exposed[0].notes()
+  exposed.clear()
+  exposed_labels.clear()
+  exposed_notes.push("mutated")
+  inspect(diagnostics.length(), content="1")
+  inspect(diagnostics.items()[0].labels().length() >= 2, content="true")
+  inspect(diagnostics.items()[0].notes().contains("mutated"), content="false")
+  let provider = @loomcore.SourceProvider(requested => {
+    if requested == lambda_semantic_projection_test_source {
+      Some(
+        @loomcore.DiagnosticSourceFile(
+          "lambda.mbt",
+          text,
+          @loomcore.LineIndex::new(text),
+        ),
+      )
+    } else {
+      None
+    }
+  })
+  inspect(
+    diagnostics.items()[0].render_plain(provider).contains("Free variable 'y'"),
+    content="true",
+  )
 }


### PR DESCRIPTION
## Summary

- project existing ReachableFailure scope-graph evidence into Loom neutral diagnostics
- preserve the exact unresolved identifier as the primary source span and searched scopes as secondary labels or notes
- merge parser and semantic diagnostics only for the same current source snapshot
- keep the semantic producer free of protocol Diagnostic construction while preserving editor and FFI compatibility

## Reuse check

Reused:
- ReachableFailure, failures, visited scopes, and current SourceMap evidence
- existing SourceMap token-role and range APIs
- Loom SourceId, SourceSpan, styled labels, Diagnostic, DiagnosticSet, defensive-copy APIs, and plain renderer
- existing editor diagnostic projection and publication path
- MoonBit String.get_view, Option, Array, and Iter APIs for validation and collection transforms

Checked but not needed:
- Map and Set for diagnostic grouping
- sorting, overlap, generic span remapping, or a second resolver
- new Loom diagnostic types or source-text ownership

New boundaries are limited to the exact variable-reference token role, scope-owner span query, typed semantic range validation, and source-consistent host merge.

## Validation

- PR-ready validator passed on HEAD acc7e22cd412134fe71db3957650cb92a7ec0200 against origin/main 1d6eb636fe9dbf6a8404b612e66d181cbe86ca0f
- targeted release tests: proj 52/52; scope 60/60; semantic 10/10; editor 218/218; companion 104/104; Lambda FFI 58/58
- full workspace release tests: 4271/4271
- JS artifact build passed
- moon check passed with the existing nine vendored Rabbita Warning [0020] diagnostics
- generated interface diff reviewed; no neutral diagnostic leaks NodeId, SyntaxNode, ScopeId, or protocol DTOs
- independent implementation review: Claude Sonnet 5 PASS, no remaining findings
- independent Codex review: PASS, no findings

Closes #1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic diagnostics for unresolved references, including precise identifier and scope locations.
  * Combined parser and semantic diagnostics when they apply to the same source version.
  * Added optional diagnostic retrieval to editor capabilities.
  * Improved diagnostic output for editor and JavaScript integrations.

* **Bug Fixes**
  * Prevented stale or mismatched diagnostics from appearing.
  * Ensured diagnostic fixes remove only the resolved issue while retaining others.
  * Corrected locations for parenthesized references and invalid source ranges.

* **Tests**
  * Added coverage for diagnostic merging, clearing, source validation, severity, labels, and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->