### PR TITLE
Audit diagnostic portability with a standalone parser probe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Wrangler owns this generated file and currently emits a few blank-at-EOL lines.
 examples/web/worker-configuration.d.ts whitespace=-blank-at-eol
+
+# MoonBit owns this empty generated interface and emits a final blank line.
+probe/diagnostic_portability/pkg.generated.mbti whitespace=-blank-at-eof

--- a/docs/research/2026-08-01-diagnostic-portability-audit.md
+++ b/docs/research/2026-08-01-diagnostic-portability-audit.md
@@ -1,0 +1,59 @@
+# Diagnostic portability audit (#1040)
+
+## Decision
+
+**NARROW.** The portable named subset is `SourceId`, `TextOffset`, `TextRange`,
+`SourceSpan`, severity/source/code, labels/notes, neutral single-source fixes,
+external-source plain rendering, defensive-copy value boundaries, and
+source-scoped transforms. The executable boundary is
+`probe/diagnostic_portability/top.mbt:4-76`: its source identity is
+`standalone-source`; its provider-owned display name is `standalone.lambda`.
+
+The full `Diagnostic` record is not token-erased: it has one optional,
+parser-specific `TokenEvidence` field. That field owns `@seam.RawKind`
+(`loom/loom/core/diagnostics.mbt:513-543`), so the full model is not the
+portable public subset. The second failed gate is label coverage: semantic
+production and generic rendering preserve both styles, but the audited parser
+path and standalone probe establish only `Primary`. These two failures keep the
+verdict narrow.
+
+## Behavioral boundary matrix
+
+| Gate / target | Direct evidence | Verdict |
+| --- | --- | --- |
+| Core dependency direction | `loom/loom/core/moon.pkg:1-14` imports Loom-adjacent/core packages and no `dowdiness/canopy/*`. | Core has no Canopy dependency. |
+| Neutral record shape | `Diagnostic` contains source, severity, code, message, labels, notes, fixes, and optional token (`loom/loom/core/diagnostics.mbt:592-624`); it contains no `NodeId`, entity, `SyntaxNode`, scope graph, or editor view field. | The named fields are portable values; optional `TokenEvidence` is the explicit non-portable exception. |
+| Generated-interface audit | Loom core's generated public interface exposes `Diagnostic` construction with `token? : TokenEvidence?` and `Diagnostic::token` (`loom/loom/core/pkg.generated.mbti:94-112`); it also publicly exposes `TokenEvidence`, whose constructor/accessor use `@seam.RawKind` (`:529-534`). | The `.mbti` confirms the parser-specific type crosses the public package seam; the whole record fails extraction. |
+| Parser and semantic producers | Lambda parser constructs the named error/fix (`loom/examples/lambda/cst_parser.mbt:132-167`); semantic lowering constructs `Diagnostic` values (`lang/lambda/semantic/semantic_projection.mbt:91-144`). | Both producer classes use one model, but parser token evidence prevents whole-record extraction. |
+| Label survival | Semantic production and its test preserve `Primary` and `Secondary` (`lang/lambda/semantic/semantic_projection.mbt:103-141`; `semantic_projection_test.mbt:197-231`), and the generic renderer prints both (`loom/loom/core/diagnostic_renderer_wbtest.mbt:92-130`). The audited Lambda parser diagnostic has only `Primary` (`loom/examples/lambda/cst_parser.mbt:157-165`), and the probe asserts only that output (`probe/diagnostic_portability/top.mbt:61-76`). | Failed full gate: both styles survive the semantic producer and renderer, but both producers/renderers are not established. This independently supports `NARROW`. |
+| Renderer isolation | Renderer receives only `SourceProvider`; its implementation references diagnostic/source types and no parser, CST, or editor APIs (`loom/loom/core/diagnostic_renderer.mbt:19-35,295-339`). Package dependency direction is covered by `moon.pkg` above. | External-source renderer is portable. |
+| Multi-source diagnostics | A renderer test resolves two source IDs and renders two source groups for one diagnostic (`loom/loom/core/diagnostic_renderer_wbtest.mbt:480-528`). | One diagnostic may span multiple sources; this probe intentionally covers one source only. |
+| Source locations | `TextOffset` rejects negatives and `TextRange` rejects reversed order; their documentation defines half-open UTF-16 code-unit positions (`loom/loom/core/diagnostics.mbt:269-339`). `SourceSpan` qualifies the range by source (`:446-467`). Bounds and actual UTF-16 boundaries are checked only when rendering (`diagnostic_renderer_wbtest.mbt:251-318`) or applying a fix (`diagnostic_fixes_wbtest.mbt:231-260`). | Portable source-scoped coordinates with validation deferred until source text is available. |
+| Mutable-array closure | Diagnostic construction and access copy labels, notes, and fixes (`loom/loom/core/diagnostics.mbt:620-660`); set access copies items (`:826-848`); mutation regression is `diagnostics_wbtest.mbt:692-711`. | No mutable-array escape across the value seam. |
+| Neutral, non-transactional fixes | `TextReplacement` is a source span plus replacement text and `DiagnosticFix` is named normalized replacements (`loom/loom/core/diagnostic_fixes.mbt:8-92`). | No editor transaction, CRDT, undo, or command is carried by a fix. |
+| Multi-file fix rejection | Constructor raises `MultiSourceDiagnosticFix` (`loom/loom/core/diagnostic_fixes.mbt:54-69`); regression asserts rejection (`loom/loom/core/diagnostic_fixes_wbtest.mbt:128-145`). | Portable candidates are single-source. |
+| Deterministic application | `apply` checks source, bounds, and UTF-16 boundaries before reverse application (`loom/loom/core/diagnostic_fixes.mbt:110-139`). | Source-scoped pure transform; host mutation stays outside. |
+| Source-scoped transforms | Two-source shift changes only the edited source label (`loom/loom/core/diagnostics_wbtest.mbt:512-534`); 2–4 source property coverage is `:791-839`. | Labels, rather than unrelated source evidence, drive shifts; validated by the core release test below. |
+| Replay and dedup | Parser replay equality intentionally omits token evidence while retaining source/code/labels/fixes (`loom/loom/core/diagnostics.mbt:815-887`); relex tests preserve foreign-source labels (`diagnostics_wbtest.mbt:562-620`). | Remains Loom parser lifecycle machinery, not extracted API. |
+| Public parser seam and standalone probe | `@lambda.parse_cst` returns `DiagnosticSet` (`loom/examples/lambda/pkg.generated.mbti:50`); the probe selects exact code, renders, applies, and reparses (`probe/diagnostic_portability/top.mbt:4-76`). | Probe proves the narrow consumer path without CST/seam/editor imports. |
+| Probe result | `moon test --release probe/diagnostic_portability` passed: 1/1. The exact expected rendering, fixed text, and absent code are asserted at `probe/diagnostic_portability/top.mbt:61-76`. | Concrete evidence for `if x then y`. |
+| Host revision/fix registry | `ViewUpdateState` owns snapshot ID, source ID, `@text.Version`, and registered Loom fixes (`editor/view_updater.mbt:36-57,190-270`); stale-version tests reject (`editor/diagnostic_fix_wbtest.mbt:93-150`). | Host-only publication lifetime and fix registry; not portable diagnostic data. |
+| Protocol DTO separation | Protocol diagnostic exposes offsets, message, IDs, and summaries (`protocol/view_patch.mbt:70-104`); inbound intent carries opaque IDs only (`protocol/user_intent.mbt:11-25`). | DTO is host protocol, not the Loom model. |
+| Async/project safety | No ticket, cancellation, dependency, configuration, or generation state appears in this probe. | #1089 owns those host-side concerns; this audit proves none of them. |
+
+## Ownership and reconsideration
+
+Loom owns validation, rendering, token evidence, parser replay, and dedup.
+Lambda owns grammar-specific production and acceptance. Canopy owns editor/CRDT
+mutation, undo, revision-bound publication, registry lifetime, and protocol
+mapping. Reconsider widening only for a second independent consumer, a
+multi-source/project snapshot contract, a source-provider lifetime interface,
+or token evidence that must cross the seam without `@seam`.
+
+## Validation
+
+Ran `moon check --deny-warn probe/diagnostic_portability`,
+`moon test --release probe/diagnostic_portability`, scoped `moon fmt` and
+`moon info` for that package, plus `git diff --check`; all passed. The
+source-transform property also passed in `moon test --release loom/loom/core`:
+379/379 tests.

--- a/probe/diagnostic_portability/moon.pkg
+++ b/probe/diagnostic_portability/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "dowdiness/lambda",
+  "dowdiness/loom/core" @loomcore,
+}

--- a/probe/diagnostic_portability/pkg.generated.mbti
+++ b/probe/diagnostic_portability/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/probe/diagnostic_portability"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/probe/diagnostic_portability/top.mbt
+++ b/probe/diagnostic_portability/top.mbt
@@ -1,0 +1,76 @@
+///|
+/// Deterministic portability boundary: consumes only Lambda's public parser and
+/// Loom's neutral diagnostic values, with source text supplied externally.
+fn portable_missing_else_probe() -> (String, String, Bool) raise {
+  let source_id = @loomcore.SourceId::SourceId("standalone-source")
+  let source = "if x then y"
+  let (_, diagnostics) = @lambda.parse_cst(source_id, source) catch {
+    _ => fail("unexpected lex error")
+  }
+  guard diagnostics
+    .items()
+    .iter()
+    .find_first(diagnostic => {
+      match diagnostic.code() {
+        Some(code) => code.value() == "loom.lambda.expected_else"
+        None => false
+      }
+    })
+    is Some(diagnostic) else {
+    fail("expected loom.lambda.expected_else diagnostic")
+  }
+  let fixes = diagnostic.fixes()
+  guard fixes.length() == 1 else {
+    fail("expected exactly one missing-else fix")
+  }
+  let provider = @loomcore.SourceProvider(requested => {
+    if requested == source_id {
+      Some(
+        @loomcore.DiagnosticSourceFile(
+          "standalone.lambda",
+          source,
+          @loomcore.LineIndex::new(source),
+        ),
+      )
+    } else {
+      None
+    }
+  })
+  let rendered = diagnostic.render_plain(provider) catch {
+    _ => fail("expected external source provider to render diagnostic")
+  }
+  let fixed = fixes[0].apply(source_id, source) catch {
+    _ => fail("expected validated missing-else fix to apply")
+  }
+  let (_, reparsed) = @lambda.parse_cst(source_id, fixed) catch {
+    _ => fail("unexpected lex error after fix")
+  }
+  let code_is_gone = !reparsed
+    .items()
+    .iter()
+    .any(diagnostic => {
+      match diagnostic.code() {
+        Some(code) => code.value() == "loom.lambda.expected_else"
+        None => false
+      }
+    })
+  (rendered, fixed, code_is_gone)
+}
+
+///|
+test "portable named missing-else diagnostic renders, fixes, and clears" {
+  let (rendered, fixed, code_is_gone) = portable_missing_else_probe()
+  inspect(
+    rendered,
+    content=(
+      #|error[loom.lambda.expected_else]: Expected else
+      #|--> standalone.lambda
+      #|primary 1:12-1:12
+      #|  1 | if x then y
+      #|    |            ^
+      #|= note: An if expression requires an else branch
+    ),
+  )
+  inspect(fixed, content="if x then y else _")
+  inspect(code_is_gone, content="true")
+}


### PR DESCRIPTION
## Summary

- add an adapter-free Lambda parser probe for `source -> diagnostic -> plain renderer -> validated text fix -> reparse`
- record an evidence-backed `NARROW` portability verdict with every #1040 gate and ownership boundary
- keep parser-specific `TokenEvidence`/`@seam.RawKind`, replay/dedup, host revision state, and protocol DTOs outside the named portable subset

Refs #1040.

## UI and review evidence

N/A — MoonBit probe and audit documentation only; no UI or visual behavior changed.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@lambda.parse_cst` | `loom/examples/lambda` | Yes | Public non-Canopy parser seam |
| `DiagnosticSet::items` | `loom/loom/core` | Yes | Defensive-copy diagnostic access |
| `Diagnostic::render_plain` / `SourceProvider` | `loom/loom/core` | Yes | External source-backed rendering |
| `DiagnosticFix::apply` | `loom/loom/core` | Yes | Validated deterministic text replacement |
| `Array` / `Iter` / `Option` / `String` | MoonBit core | Yes | Selection, absence handling, exact code matching, and post-fix absence check |
| `Map` / `Set` / `StringView` / `Bytes` / `Buffer` / `cmp` / `math` | MoonBit core | No | The probe needs no keyed collection, byte/view transform, builder, ordering helper, or arithmetic helper |

New helpers added:

- `portable_missing_else_probe` — one private deterministic orchestration boundary for the standalone probe; it introduces no public API and delegates parsing, rendering, validation, and application to existing APIs.

Remaining imperative code: none; the probe has no mutable state, manual loop, I/O, editor adapter, or host lifecycle mutation.

## Validation scope

Boundary matrix / first failing regression:

- The complete gate matrix and `NARROW` evidence are in `docs/research/2026-08-01-diagnostic-portability-audit.md`.
- RED: the focused package test initially failed to compile because `portable_missing_else_probe` was intentionally absent.
- GREEN: the probe asserts the stable parser code, exact provider-backed rendering, exact fixed text, and absence of that code after reparse.

Target packages:

- `probe/diagnostic_portability`

Additional conditional gates:

- focused release test: 1/1 passed on the default JS target and 1/1 on native
- Loom core release tests: 379/379 passed
- parallel read-only review: API/probe PASS; three audit findings corrected and closure re-review PASS; generated-interface whitespace exception review PASS
- structured reviewer outputs passed strict JSON parsing and the shared `ReviewFindings` BAML parser

## PR-ready evidence

Validated HEAD: `d703a8f65a4046adf39d1b71c7e9d893901c71ee`

Validated base: `origin/main@87a16cbac3a35ba0b4de10c4746c8a6d760bd876`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target probe/diagnostic_portability
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; the new package exposes no public API.
- [x] No submodule pointer changed; every recorded submodule commit was fetched and verified reachable from its configured origin.
- [x] Validation was rerun after the candidate amend and generated-interface attribute change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an audit describing diagnostic portability boundaries, behavior, ownership, and validation coverage.

* **Tests**
  * Added coverage for missing-`else` diagnostics, including rendering, source fixes, reparsing, and confirmation that the issue is resolved.

* **Chores**
  * Updated generated-file handling to accommodate MoonBit interface output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->