### PR TITLE
Prototype revision-bound diagnostic publication

### DIFF
--- a/docs/research/2026-08-01-diagnostic-publication-prototype.md
+++ b/docs/research/2026-08-01-diagnostic-publication-prototype.md
@@ -1,0 +1,72 @@
+# Revision-bound diagnostic publication prototype (#1089)
+
+## Behavioral boundary matrix
+
+| Situation | Declared input / event | Expected publication decision | Published result |
+| --- | --- | --- | --- |
+| Current single-source completion | Active ticket, matching source revision, dependency identities, config, and producer generation | Accept | Atomically replace its channel only. |
+| Source changes during work | Covered source revision differs | Reject | Preserve parser and every existing producer publication. |
+| A0 -> A1 -> A0 | Original ticket has revision 0; current source is newer revision 2 even if text is equal | Reject original; a newly issued ticket may accept | Never revive an older request from text equality. |
+| Out-of-order completions | A newer ticket supersedes the older ticket on one channel | Accept newer, reject older | Newer result remains authoritative. |
+| Dependency/configuration change | A declared dependency or configuration identity differs | Reject | Preserve previous publication. |
+| Unrelated source change | Changed source is outside declared coverage | Accept if every declared input matches | Precise invalidation only. |
+| Two-source coverage | Either declared source changes | Reject | No mixed-current multi-source diagnostic set. |
+| Cancellation / restart / duplicate | Ticket is inactive, generation differs, or ticket was consumed | Reject | No mutation. |
+| Display assembly | Current parser channel plus producer channels | Deterministic | Parser first, then producer/channel lexical order. |
+| Value preservation | Accepted neutral `DiagnosticSet` | Accept with copy | Messages, labels/styles/source/ranges and other Loom-owned values are retained; later producer mutation cannot escape. |
+
+## Existing-API reuse check
+
+* Reused: `@loom_core.DiagnosticSet::copy`, `items`, and `add_all` for
+  defensive ownership and parser-first display assembly. The current
+  `merge_current_diagnostics` in `editor/view_updater.mbt` is source-equality
+  prior art only; it cannot distinguish a revived A0 request from its later
+  identical text.
+* Checked: `Map`/`Set` for host state keyed by distinct identities,
+  `Array`/`Iter` for collection transformation/order, `Option`/`Result` for
+  absence/error alternatives, `String`/`StringView` for host identities,
+  `Buffer` for formatting, and `cmp`/`math` for ordering/numeric helpers.
+  The core uses copied `Map`/`Set` values and `Array::sort_by`; it does not need
+  `Buffer`, `Result`, or numeric helpers.
+* Checked: `SyncEditor::parser_snapshot` exposes a coherent parser source,
+  CST, AST, and diagnostics snapshot; `@analysis.SourceSnapshot` models a
+  document/version/text-hash tuple; cognition's
+  `ProviderSourceSnapshot`/request descriptors demonstrate explicit source and
+  dependency provenance plus a deterministic fake-time driver.
+
+## Coherent-snapshot verdict
+
+**Negative prototype verdict.** `SyncEditor::parser_snapshot`
+(`editor/sync_editor_parser.mbt:137-142`) is coherent for one parser's
+source/CST/AST/diagnostics and the Loom diagnostic API copies its collections,
+but it has no monotonic source revision suitable for a ticket. The current
+`Coordinator::read_protected` (`workspace/coordinator/methods.mbt:156-190`)
+validates and reads one `ProtectedCell[T]`; its registration owns an array of
+independent protected reads (`workspace/coordinator/types.mbt:134-151`). Direct
+current-host evidence therefore does not establish an atomic project-wide
+capture of all declared source revisions, dependency identities, and
+configuration identity.
+
+Production integration therefore needs one highest-host, read-only
+`DiagnosticPublicationInputSnapshot` seam that atomically returns: monotonic
+revision for every declared source, dependency fingerprints, configuration
+identity, and the relevant producer generation. It must be captured under one
+coordinator protection boundary and detached from mutable host state. This
+prototype deliberately does not add that production seam.
+
+## Scope verdict
+
+Tickets, revisions, dependency/configuration identities, cancellation, and
+producer generations remain private editor orchestration state. The payload is
+the existing neutral `@loom_core.DiagnosticSet`; no protocol, Loom diagnostic,
+`AnalysisProjection`, FFI, or producer integration change is proposed.
+
+## Validation and local mutation justification
+
+The targeted native and JS editor release suites exercise the same deterministic
+publication boundary. The core returns replacement state and command values;
+its only local mutations copy a `Map`/`Set` before replacing that returned
+state, build the returned command array, and sort a fresh array returned from
+`Map::to_array`. The whitebox fake shell mutates only its test-local state and
+recorded start/cancel arrays while executing those commands. Neither kind of
+mutation escapes the core result or published `DiagnosticSet` boundary.

--- a/editor/diagnostic_publication.mbt
+++ b/editor/diagnostic_publication.mbt
@@ -1,0 +1,360 @@
+///|
+/// Host-only identity for a diagnostic producer. It is intentionally distinct
+/// from both source and display-channel identity.
+priv struct DiagnosticProducerId(String) derive(Eq, Hash)
+
+///|
+#warnings("-unused_value")
+fn DiagnosticProducerId::new(value : String) -> DiagnosticProducerId {
+  DiagnosticProducerId(value)
+}
+
+///|
+fn DiagnosticProducerId::to_string(self : DiagnosticProducerId) -> String {
+  let DiagnosticProducerId(value) = self
+  value
+}
+
+///|
+priv struct DiagnosticSourceId(String) derive(Eq, Hash)
+
+///|
+#warnings("-unused_value")
+fn DiagnosticSourceId::new(value : String) -> DiagnosticSourceId {
+  DiagnosticSourceId(value)
+}
+
+///|
+priv struct DiagnosticDependencyId(String) derive(Eq, Hash)
+
+///|
+#warnings("-unused_value")
+fn DiagnosticDependencyId::new(value : String) -> DiagnosticDependencyId {
+  DiagnosticDependencyId(value)
+}
+
+///|
+priv struct DiagnosticConfigurationId(String) derive(Eq)
+
+///|
+#warnings("-unused_value")
+fn DiagnosticConfigurationId::new(value : String) -> DiagnosticConfigurationId {
+  DiagnosticConfigurationId(value)
+}
+
+///|
+priv struct DiagnosticPublicationChannel {
+  producer : DiagnosticProducerId
+  name : String
+} derive(Eq, Hash)
+
+///|
+#warnings("-unused_value")
+fn DiagnosticPublicationChannel::new(
+  producer : DiagnosticProducerId,
+  name : String,
+) -> DiagnosticPublicationChannel {
+  { producer, name }
+}
+
+///|
+fn DiagnosticPublicationChannel::compare(
+  self : DiagnosticPublicationChannel,
+  other : DiagnosticPublicationChannel,
+) -> Int {
+  let producer_order = self.producer
+    .to_string()
+    .compare(other.producer.to_string())
+  if producer_order == 0 {
+    self.name.compare(other.name)
+  } else {
+    producer_order
+  }
+}
+
+///|
+priv struct DiagnosticSourceRevision {
+  source : DiagnosticSourceId
+  revision : Int
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticSourceRevision::new(
+  source : DiagnosticSourceId,
+  revision : Int,
+) -> DiagnosticSourceRevision {
+  { source, revision }
+}
+
+///|
+priv struct DiagnosticDependencyRevision {
+  dependency : DiagnosticDependencyId
+  identity : String
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticDependencyRevision::new(
+  dependency : DiagnosticDependencyId,
+  identity : String,
+) -> DiagnosticDependencyRevision {
+  { dependency, identity }
+}
+
+///|
+/// Opaque host-issued capability. Producers only receive and return it.
+priv struct DiagnosticPublicationTicket(Int) derive(Eq, Hash)
+
+///|
+#warnings("-unused_constructor")
+priv enum DiagnosticPublicationDecision {
+  Accepted
+  Rejected
+}
+
+///|
+/// Commands are data from the functional core; the shell owns execution.
+#warnings("-unused_constructor")
+priv enum DiagnosticPublicationCommand {
+  Start(DiagnosticPublicationTicket)
+  Cancel(DiagnosticPublicationTicket)
+}
+
+///|
+priv struct DiagnosticPublicationRequest {
+  channel : DiagnosticPublicationChannel
+  generation : Int
+  sources : Array[DiagnosticSourceRevision]
+  dependencies : Array[DiagnosticDependencyRevision]
+  configuration : DiagnosticConfigurationId
+}
+
+///|
+/// Private functional-core state for publication provenance and accepted sets.
+priv struct DiagnosticPublicationState {
+  next_ticket : Int
+  sources : Map[DiagnosticSourceId, Int]
+  dependencies : Map[DiagnosticDependencyId, String]
+  configuration : DiagnosticConfigurationId
+  generations : Map[DiagnosticProducerId, Int]
+  active : Map[DiagnosticPublicationChannel, DiagnosticPublicationTicket]
+  requests : Map[DiagnosticPublicationTicket, DiagnosticPublicationRequest]
+  consumed : Set[DiagnosticPublicationTicket]
+  publications : Map[DiagnosticPublicationChannel, @loom_core.DiagnosticSet]
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticPublicationState::new(
+  configuration : DiagnosticConfigurationId,
+) -> DiagnosticPublicationState {
+  {
+    next_ticket: 0,
+    sources: Map::default(),
+    dependencies: Map::default(),
+    configuration,
+    generations: Map::default(),
+    active: Map::default(),
+    requests: Map::default(),
+    consumed: Set::default(),
+    publications: Map::default(),
+  }
+}
+
+///|
+fn DiagnosticPublicationState::replace(
+  self : DiagnosticPublicationState,
+  next_ticket? : Int = self.next_ticket,
+  sources? : Map[DiagnosticSourceId, Int] = self.sources,
+  dependencies? : Map[DiagnosticDependencyId, String] = self.dependencies,
+  configuration? : DiagnosticConfigurationId = self.configuration,
+  generations? : Map[DiagnosticProducerId, Int] = self.generations,
+  active? : Map[DiagnosticPublicationChannel, DiagnosticPublicationTicket] = self.active,
+  requests? : Map[DiagnosticPublicationTicket, DiagnosticPublicationRequest] = self.requests,
+  consumed? : Set[DiagnosticPublicationTicket] = self.consumed,
+  publications? : Map[DiagnosticPublicationChannel, @loom_core.DiagnosticSet] = self.publications,
+) -> DiagnosticPublicationState {
+  {
+    next_ticket,
+    sources,
+    dependencies,
+    configuration,
+    generations,
+    active,
+    requests,
+    consumed,
+    publications,
+  }
+}
+
+///|
+/// The shell supplies its current monotonic source revision through this event.
+#warnings("-unused_value")
+fn DiagnosticPublicationState::set_source_revision(
+  self : DiagnosticPublicationState,
+  source : DiagnosticSourceId,
+  revision : Int,
+) -> DiagnosticPublicationState {
+  let sources = self.sources.copy()
+  sources.set(source, revision)
+  self.replace(sources~)
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticPublicationState::set_dependency_identity(
+  self : DiagnosticPublicationState,
+  dependency : DiagnosticDependencyId,
+  identity : String,
+) -> DiagnosticPublicationState {
+  let dependencies = self.dependencies.copy()
+  dependencies.set(dependency, identity)
+  self.replace(dependencies~)
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticPublicationState::set_configuration(
+  self : DiagnosticPublicationState,
+  configuration : DiagnosticConfigurationId,
+) -> DiagnosticPublicationState {
+  self.replace(configuration~)
+}
+
+///|
+/// Restart invalidates every older request for this producer by generation.
+#warnings("-unused_value")
+fn DiagnosticPublicationState::restart_producer(
+  self : DiagnosticPublicationState,
+  producer : DiagnosticProducerId,
+) -> (DiagnosticPublicationState, Array[DiagnosticPublicationCommand]) {
+  let generations = self.generations.copy()
+  generations.set(producer, generations.get(producer).unwrap_or(0) + 1)
+  let active = self.active.copy()
+  let affected = self.active
+    .to_array()
+    .filter(entry => entry.0.producer == producer)
+  affected.sort_by((left, right) => left.0.compare(right.0))
+  let commands = affected.map(entry => {
+    active.remove(entry.0)
+    DiagnosticPublicationCommand::Cancel(entry.1)
+  })
+  (self.replace(generations~, active~), commands)
+}
+
+///|
+/// Issue a ticket from an already coherent host snapshot. Starting/cancelling
+/// work is deferred to the imperative shell through returned commands.
+#warnings("-unused_value")
+fn DiagnosticPublicationState::issue(
+  self : DiagnosticPublicationState,
+  channel : DiagnosticPublicationChannel,
+  sources : Array[DiagnosticSourceRevision],
+  dependencies : Array[DiagnosticDependencyRevision],
+) -> (
+  DiagnosticPublicationState,
+  DiagnosticPublicationTicket,
+  Array[DiagnosticPublicationCommand],
+) {
+  let ticket = DiagnosticPublicationTicket(self.next_ticket)
+  let request = {
+    channel,
+    generation: self.generations.get(channel.producer).unwrap_or(0),
+    sources: sources.copy(),
+    dependencies: dependencies.copy(),
+    configuration: self.configuration,
+  }
+  let active = self.active.copy()
+  let commands = match active.get(channel) {
+    Some(previous) => [DiagnosticPublicationCommand::Cancel(previous)]
+    None => []
+  }
+  active.set(channel, ticket)
+  let requests = self.requests.copy()
+  requests.set(ticket, request)
+  let next = self.replace(next_ticket=self.next_ticket + 1, active~, requests~)
+  commands.push(DiagnosticPublicationCommand::Start(ticket))
+  (next, ticket, commands)
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticPublicationState::cancel(
+  self : DiagnosticPublicationState,
+  ticket : DiagnosticPublicationTicket,
+) -> (DiagnosticPublicationState, Array[DiagnosticPublicationCommand]) {
+  match self.requests.get(ticket) {
+    Some(request) if self.active.get(request.channel) == Some(ticket) => {
+      let active = self.active.copy()
+      active.remove(request.channel)
+      (self.replace(active~), [DiagnosticPublicationCommand::Cancel(ticket)])
+    }
+    _ => (self, [])
+  }
+}
+
+///|
+fn DiagnosticPublicationState::request_is_current(
+  self : DiagnosticPublicationState,
+  ticket : DiagnosticPublicationTicket,
+  request : DiagnosticPublicationRequest,
+) -> Bool {
+  self.active.get(request.channel) == Some(ticket) &&
+  !self.consumed.contains(ticket) &&
+  self.generations.get(request.channel.producer).unwrap_or(0) ==
+  request.generation &&
+  self.configuration == request.configuration &&
+  request.sources.all(snapshot => {
+    self.sources.get(snapshot.source) == Some(snapshot.revision)
+  }) &&
+  request.dependencies.all(snapshot => {
+    self.dependencies.get(snapshot.dependency) == Some(snapshot.identity)
+  })
+}
+
+///|
+/// Single deterministic completion decision. Rejection has no published-state
+/// effect; acceptance copies and atomically replaces exactly one channel.
+#warnings("-unused_value")
+fn DiagnosticPublicationState::complete(
+  self : DiagnosticPublicationState,
+  ticket : DiagnosticPublicationTicket,
+  diagnostics : @loom_core.DiagnosticSet,
+) -> (DiagnosticPublicationState, DiagnosticPublicationDecision) {
+  match self.requests.get(ticket) {
+    Some(request) if self.request_is_current(ticket, request) => {
+      let active = self.active.copy()
+      active.remove(request.channel)
+      let consumed = self.consumed.copy()
+      consumed.add(ticket)
+      let publications = self.publications.copy()
+      publications.set(request.channel, diagnostics.copy())
+      (
+        self.replace(active~, consumed~, publications~),
+        DiagnosticPublicationDecision::Accepted,
+      )
+    }
+    _ => (self, DiagnosticPublicationDecision::Rejected)
+  }
+}
+
+///|
+/// Assemble a fresh diagnostic set: parser first, then stable producer/channel
+/// order. Local sorting mutates only a newly returned array.
+#warnings("-unused_value")
+fn DiagnosticPublicationState::display(
+  self : DiagnosticPublicationState,
+  parser_channel : DiagnosticPublicationChannel,
+) -> @loom_core.DiagnosticSet {
+  let merged = match self.publications.get(parser_channel) {
+    Some(parser) => parser.copy()
+    None => @loom_core.DiagnosticSet::empty()
+  }
+  let others = self.publications
+    .to_array()
+    .filter(entry => entry.0 != parser_channel)
+  others.sort_by((left, right) => left.0.compare(right.0))
+  others.each(entry => merged.add_all(entry.1))
+  merged
+}

--- a/editor/diagnostic_publication_wbtest.mbt
+++ b/editor/diagnostic_publication_wbtest.mbt
@@ -1,0 +1,547 @@
+///|
+fn publication_fixture(message : String) -> @loom_core.DiagnosticSet {
+  @loom_core.DiagnosticSet::single(
+    @loom_core.Diagnostic(
+      source=@loom_core.DiagnosticSource::parser(),
+      severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+      message~,
+    ),
+  )
+}
+
+///|
+fn publication_channel(
+  producer : String,
+  name? : String = "diagnostics",
+) -> DiagnosticPublicationChannel {
+  DiagnosticPublicationChannel::new(DiagnosticProducerId::new(producer), name)
+}
+
+///|
+fn publication_state() -> DiagnosticPublicationState {
+  DiagnosticPublicationState::new(DiagnosticConfigurationId::new("config-0"))
+}
+
+///|
+fn source_revision(source : String, revision : Int) -> DiagnosticSourceRevision {
+  DiagnosticSourceRevision::new(DiagnosticSourceId::new(source), revision)
+}
+
+///|
+fn with_source(
+  state : DiagnosticPublicationState,
+  source : String,
+  revision : Int,
+) -> DiagnosticPublicationState {
+  state.set_source_revision(DiagnosticSourceId::new(source), revision)
+}
+
+///|
+fn messages(diagnostics : @loom_core.DiagnosticSet) -> Array[String] {
+  diagnostics.items().map(diagnostic => diagnostic.message())
+}
+
+///|
+fn rich_publication_fixture() -> @loom_core.DiagnosticSet {
+  let source = @loom_core.SourceId("A")
+  @loom_core.DiagnosticSet::single(
+    @loom_core.Diagnostic(
+      source=@loom_core.DiagnosticSource::parser(),
+      severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+      code=Some(@loom_core.DiagnosticCode("fixture.rich")),
+      message="retained",
+      labels=[
+        @loom_core.DiagnosticLabel(
+          @loom_core.LabelStyle::Primary,
+          @loom_core.SourceSpan(
+            source,
+            try! @loom_core.TextRange::from_offsets(1, 3),
+          ),
+          Some("primary"),
+        ),
+        @loom_core.DiagnosticLabel(
+          @loom_core.LabelStyle::Secondary,
+          @loom_core.SourceSpan(
+            source,
+            try! @loom_core.TextRange::from_offsets(4, 5),
+          ),
+          Some("secondary"),
+        ),
+      ],
+    ),
+  )
+}
+
+///|
+test "publication rejects the original completion after A0 A1 A0" {
+  let source_a = DiagnosticSourceId::new("A")
+  let parser = publication_channel("parser")
+  let a0_text = "same source"
+  let state = with_source(
+    DiagnosticPublicationState::new(DiagnosticConfigurationId::new("config-0")),
+    "A",
+    0,
+  )
+  let a1_text = "changed source"
+  let (state, parser_ticket, _) = state.issue(
+    parser,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (state, _) = state.complete(
+    parser_ticket,
+    publication_fixture("parser-current"),
+  )
+  let (state, old_ticket, _) = state.issue(
+    DiagnosticPublicationChannel::new(
+      DiagnosticProducerId::new("semantic"),
+      "diagnostics",
+    ),
+    [DiagnosticSourceRevision::new(source_a, 0)],
+    [],
+  )
+  let state = state.set_source_revision(source_a, 1)
+  inspect(a1_text != a0_text, content="true")
+  let state = state.set_source_revision(source_a, 2)
+  let host_text_after_return = a0_text
+  inspect(host_text_after_return == a0_text, content="true")
+  let (state, decision) = state.complete(old_ticket, publication_fixture("old"))
+  inspect(decision is DiagnosticPublicationDecision::Rejected, content="true")
+  let (state, current_ticket, _) = state.issue(
+    publication_channel("semantic"),
+    [DiagnosticSourceRevision::new(source_a, 2)],
+    [],
+  )
+  let (state, current_decision) = state.complete(
+    current_ticket,
+    publication_fixture("semantic-current"),
+  )
+  inspect(
+    current_decision is DiagnosticPublicationDecision::Accepted,
+    content="true",
+  )
+  debug_inspect(
+    messages(state.display(parser)),
+    content="[\"parser-current\", \"semantic-current\"]",
+  )
+}
+
+///|
+test "current completion replaces one channel and preserves other publications" {
+  let parser = publication_channel("parser")
+  let semantic = publication_channel("semantic")
+  let lint = publication_channel("lint")
+  let state = with_source(publication_state(), "A", 0)
+  let (state, parser_ticket, _) = state.issue(
+    parser,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (state, _) = state.complete(parser_ticket, publication_fixture("parser"))
+  let (state, semantic_old, _) = state.issue(
+    semantic,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (state, _) = state.complete(
+    semantic_old,
+    publication_fixture("semantic-old"),
+  )
+  let (state, lint_ticket, _) = state.issue(lint, [source_revision("A", 0)], [])
+  let (state, _) = state.complete(lint_ticket, publication_fixture("lint"))
+  let (state, semantic_new, _) = state.issue(
+    semantic,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (state, decision) = state.complete(
+    semantic_new,
+    publication_fixture("semantic-new"),
+  )
+  inspect(decision is DiagnosticPublicationDecision::Accepted, content="true")
+  debug_inspect(
+    messages(state.display(parser)),
+    content="[\"parser\", \"lint\", \"semantic-new\"]",
+  )
+}
+
+///|
+test "display sorts producer and channel as a lexicographic pair" {
+  let parser = publication_channel("parser")
+  let first = publication_channel("a", name="b:c")
+  let second = publication_channel("a:b", name="c")
+  let state = with_source(publication_state(), "A", 0)
+  // Insert reverse pair order. Both concatenated colon keys would be "a:b:c".
+  let (state, second_ticket, _) = state.issue(
+    second,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (state, _) = state.complete(second_ticket, publication_fixture("second"))
+  let (state, first_ticket, _) = state.issue(first, [source_revision("A", 0)], [])
+  let (state, _) = state.complete(first_ticket, publication_fixture("first"))
+  debug_inspect(
+    messages(state.display(parser)),
+    content="[\"first\", \"second\"]",
+  )
+}
+
+///|
+test "producer restart cancels active channels in lexical pair order" {
+  let producer = DiagnosticProducerId::new("semantic")
+  let later = DiagnosticPublicationChannel::new(producer, "z-channel")
+  let earlier = DiagnosticPublicationChannel::new(producer, "a-channel")
+  let state = with_source(publication_state(), "A", 0)
+  // Reverse insertion must not determine cancellation command order.
+  let (state, later_ticket, _) = state.issue(later, [source_revision("A", 0)], [])
+  let (state, earlier_ticket, _) = state.issue(
+    earlier,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (_, commands) = state.restart_producer(producer)
+  guard commands
+    is [
+      DiagnosticPublicationCommand::Cancel(first),
+      DiagnosticPublicationCommand::Cancel(second),
+    ] else {
+    fail("expected ordered restart cancellations")
+  }
+  inspect(first == earlier_ticket, content="true")
+  inspect(second == later_ticket, content="true")
+}
+
+///|
+test "coverage invalidation is precise for source dependency configuration and two sources" {
+  let semantic = publication_channel("semantic")
+  let state = with_source(with_source(publication_state(), "A", 0), "B", 0)
+  let state = state.set_dependency_identity(
+    DiagnosticDependencyId::new("project"),
+    "dep-0",
+  )
+  let (state, unrelated, _) = state.issue(semantic, [source_revision("A", 0)], [])
+  let state = with_source(state, "unrelated", 1)
+  let (state, unrelated_decision) = state.complete(
+    unrelated,
+    publication_fixture("current"),
+  )
+  inspect(
+    unrelated_decision is DiagnosticPublicationDecision::Accepted,
+    content="true",
+  )
+  let (state, dependency_ticket, _) = state.issue(
+    semantic,
+    [source_revision("A", 0)],
+    [
+      DiagnosticDependencyRevision::new(
+        DiagnosticDependencyId::new("project"),
+        "dep-0",
+      ),
+    ],
+  )
+  let state = state.set_dependency_identity(
+    DiagnosticDependencyId::new("project"),
+    "dep-1",
+  )
+  let (state, dependency_decision) = state.complete(
+    dependency_ticket,
+    publication_fixture("stale-dependency"),
+  )
+  inspect(
+    dependency_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  let (state, config_ticket, _) = state.issue(
+    semantic,
+    [source_revision("A", 0)],
+    [],
+  )
+  let state = state.set_configuration(
+    DiagnosticConfigurationId::new("config-1"),
+  )
+  let (state, config_decision) = state.complete(
+    config_ticket,
+    publication_fixture("stale-config"),
+  )
+  inspect(
+    config_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  let (state, two_source_ticket, _) = state.issue(
+    semantic,
+    [source_revision("A", 0), source_revision("B", 0)],
+    [],
+  )
+  let state = with_source(state, "B", 1)
+  let (state, two_source_decision) = state.complete(
+    two_source_ticket,
+    publication_fixture("stale-B"),
+  )
+  inspect(
+    two_source_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  debug_inspect(
+    messages(state.display(publication_channel("parser"))),
+    content="[\"current\"]",
+  )
+}
+
+///|
+test "newer cancellation restart and duplicate completions never revive older work" {
+  let parser = publication_channel("parser")
+  let semantic = publication_channel("semantic")
+  let state = with_source(publication_state(), "A", 0)
+  let (state, old, _) = state.issue(semantic, [source_revision("A", 0)], [])
+  let (state, newer, commands) = state.issue(
+    semantic,
+    [source_revision("A", 0)],
+    [],
+  )
+  inspect(commands.length(), content="2")
+  let (state, newer_decision) = state.complete(
+    newer,
+    publication_fixture("newer"),
+  )
+  inspect(
+    newer_decision is DiagnosticPublicationDecision::Accepted,
+    content="true",
+  )
+  let (state, old_decision) = state.complete(old, publication_fixture("old"))
+  inspect(
+    old_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  let (state, duplicate) = state.complete(
+    newer,
+    publication_fixture("duplicate"),
+  )
+  inspect(duplicate is DiagnosticPublicationDecision::Rejected, content="true")
+  let (state, cancelled, _) = state.issue(semantic, [source_revision("A", 0)], [])
+  let (state, cancellation) = state.cancel(cancelled)
+  inspect(cancellation.length(), content="1")
+  let (state, cancelled_decision) = state.complete(
+    cancelled,
+    publication_fixture("cancelled"),
+  )
+  inspect(
+    cancelled_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  let (state, before_restart, _) = state.issue(
+    semantic,
+    [source_revision("A", 0)],
+    [],
+  )
+  let (state, restart_commands) = state.restart_producer(
+    DiagnosticProducerId::new("semantic"),
+  )
+  inspect(restart_commands.length(), content="1")
+  let (state, restart_decision) = state.complete(
+    before_restart,
+    publication_fixture("pre-restart"),
+  )
+  inspect(
+    restart_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  debug_inspect(messages(state.display(parser)), content="[\"newer\"]")
+}
+
+///|
+/// Thin deterministic fake shell: it records execution of core commands, then
+/// deliberately delivers the stale completion after the current one.
+priv struct FakePublicationShell {
+  mut state : DiagnosticPublicationState
+  started : Array[DiagnosticPublicationTicket]
+  cancelled : Array[DiagnosticPublicationTicket]
+}
+
+///|
+fn FakePublicationShell::FakePublicationShell(
+  state : DiagnosticPublicationState,
+) -> FakePublicationShell {
+  { state, started: [], cancelled: [] }
+}
+
+///|
+fn FakePublicationShell::execute(
+  self : FakePublicationShell,
+  commands : Array[DiagnosticPublicationCommand],
+) -> Unit {
+  commands.each(command => {
+    match command {
+      DiagnosticPublicationCommand::Start(ticket) => self.started.push(ticket)
+      DiagnosticPublicationCommand::Cancel(ticket) =>
+        self.cancelled.push(ticket)
+    }
+  })
+}
+
+///|
+fn FakePublicationShell::issue(
+  self : FakePublicationShell,
+  channel : DiagnosticPublicationChannel,
+) -> DiagnosticPublicationTicket {
+  let (state, ticket, commands) = self.state.issue(
+    channel,
+    [source_revision("A", 0)],
+    [],
+  )
+  self.state = state
+  self.execute(commands)
+  ticket
+}
+
+///|
+fn FakePublicationShell::cancel(
+  self : FakePublicationShell,
+  ticket : DiagnosticPublicationTicket,
+) -> Unit {
+  let (state, commands) = self.state.cancel(ticket)
+  self.state = state
+  self.execute(commands)
+}
+
+///|
+fn FakePublicationShell::restart(
+  self : FakePublicationShell,
+  producer : DiagnosticProducerId,
+) -> Unit {
+  let (state, commands) = self.state.restart_producer(producer)
+  self.state = state
+  self.execute(commands)
+}
+
+///|
+fn FakePublicationShell::complete(
+  self : FakePublicationShell,
+  ticket : DiagnosticPublicationTicket,
+  diagnostics : @loom_core.DiagnosticSet,
+) -> DiagnosticPublicationDecision {
+  let (state, decision) = self.state.complete(ticket, diagnostics)
+  self.state = state
+  decision
+}
+
+///|
+test "fake async shell executes issue cancellation restart and reordered completion commands" {
+  let semantic = publication_channel("semantic")
+  let shell = FakePublicationShell::FakePublicationShell(
+    with_source(publication_state(), "A", 0),
+  )
+  let old = shell.issue(semantic)
+  let current = shell.issue(semantic)
+  inspect(old != current, content="true")
+  guard shell.started is [first_started, second_started] else {
+    fail("expected two starts")
+  }
+  guard shell.cancelled is [superseded] else {
+    fail("expected old cancellation")
+  }
+  inspect(first_started == old, content="true")
+  inspect(second_started == current, content="true")
+  inspect(superseded == old, content="true")
+  let current_decision = shell.complete(current, publication_fixture("current"))
+  let late_decision = shell.complete(old, publication_fixture("late"))
+  inspect(
+    current_decision is DiagnosticPublicationDecision::Accepted,
+    content="true",
+  )
+  inspect(
+    late_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  let explicitly_cancelled = shell.issue(semantic)
+  shell.cancel(explicitly_cancelled)
+  let cancelled_decision = shell.complete(
+    explicitly_cancelled,
+    publication_fixture("cancelled"),
+  )
+  inspect(
+    cancelled_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  let previous_generation = shell.issue(semantic)
+  shell.restart(DiagnosticProducerId::new("semantic"))
+  let restart_decision = shell.complete(
+    previous_generation,
+    publication_fixture("pre-restart"),
+  )
+  inspect(
+    restart_decision is DiagnosticPublicationDecision::Rejected,
+    content="true",
+  )
+  inspect(shell.started.length(), content="4")
+  inspect(shell.cancelled.length(), content="3")
+  guard shell.cancelled is [_, explicit_cancel_command, restart_cancel_command] else {
+    fail("expected recorded cancellation commands")
+  }
+  inspect(explicit_cancel_command == explicitly_cancelled, content="true")
+  inspect(restart_cancel_command == previous_generation, content="true")
+  debug_inspect(
+    messages(shell.state.display(publication_channel("parser"))),
+    content="[\"current\"]",
+  )
+}
+
+///|
+test "producer and source identities remain independent across publications" {
+  let parser = publication_channel("parser")
+  let semantic = publication_channel("semantic")
+  let lint = publication_channel("lint")
+  let state = with_source(with_source(publication_state(), "A", 0), "B", 0)
+  let (state, semantic_ticket, _) = state.issue(
+    semantic,
+    [source_revision("A", 0), source_revision("B", 0)],
+    [],
+  )
+  let (state, _) = state.complete(
+    semantic_ticket,
+    publication_fixture("semantic-A-B"),
+  )
+  let (state, lint_ticket, _) = state.issue(lint, [source_revision("A", 0)], [])
+  let (state, lint_decision) = state.complete(
+    lint_ticket,
+    publication_fixture("lint-A"),
+  )
+  inspect(
+    lint_decision is DiagnosticPublicationDecision::Accepted,
+    content="true",
+  )
+  debug_inspect(
+    messages(state.display(parser)),
+    content="[\"lint-A\", \"semantic-A-B\"]",
+  )
+}
+
+///|
+test "accepted diagnostics retain Loom values and own a defensive copy" {
+  let parser = publication_channel("parser")
+  let semantic = publication_channel("semantic")
+  let state = with_source(publication_state(), "A", 0)
+  let produced = rich_publication_fixture()
+  let (state, ticket, _) = state.issue(semantic, [source_revision("A", 0)], [])
+  let (state, decision) = state.complete(ticket, produced)
+  inspect(decision is DiagnosticPublicationDecision::Accepted, content="true")
+  produced.push(@loom_core.Diagnostic::lexer_error("late producer mutation"))
+  let published = state.display(parser)
+  guard published.items() is [diagnostic] else {
+    fail("expected one copied diagnostic")
+  }
+  inspect(diagnostic.message(), content="retained")
+  guard diagnostic.labels() is [primary, secondary] else {
+    fail("expected both labels")
+  }
+  inspect(primary.style() is @loom_core.LabelStyle::Primary, content="true")
+  inspect(secondary.style() is @loom_core.LabelStyle::Secondary, content="true")
+  inspect(
+    primary.span().source_id() == @loom_core.SourceId("A"),
+    content="true",
+  )
+  inspect(primary.span().range().start().value(), content="1")
+  inspect(primary.span().range().end().value(), content="3")
+  inspect(published.length(), content="1")
+  published.push(@loom_core.Diagnostic::lexer_error("late display mutation"))
+  debug_inspect(messages(state.display(parser)), content="[\"retained\"]")
+}


### PR DESCRIPTION
## Summary

- add a private editor-local functional core for host-issued diagnostic publication tickets, precise declared-input coverage, stale completion rejection, and atomic per-channel replacement
- add a deterministic fake-async shell and whitebox matrix covering A0 → A1 → A0, source/dependency/configuration changes, multi-source coverage, cancellation, restart, duplicate/out-of-order completion, ordering, and defensive ownership
- record a negative coherent-snapshot verdict: current host seams do not atomically capture project-wide source revisions, dependencies, configuration, and producer generation; nonblocking follow-up #1096 owns that production seam

Refs #1089.

## UI and review evidence

N/A — private MoonBit prototype, whitebox tests, and research documentation only; no UI or visual behavior changed.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `DiagnosticSet::copy`, `items`, `add_all` | `loom/loom/core` | Yes | Defensive publication ownership and parser-first display assembly |
| `Map` / `Set` | MoonBit core | Yes | Copied host state keyed by distinct producer/channel/source/ticket identities |
| `Array` / `Iter` / `Option` | MoonBit core | Yes | Declared coverage checks, deterministic command/display ordering, and optional lookups |
| `String::compare` | MoonBit core | Yes | Collision-free producer/channel pair ordering |
| `Result`, `StringView`, `Bytes`/`BytesView`, `Buffer`, `cmp`/`math` | MoonBit core | No | No error transport, view/byte transform, builder, or numeric ordering helper is needed by the private value-state prototype |
| `SyncEditor::parser_snapshot` | `editor` | Evidence only | Coherent for one parser, but lacks a monotonic host source revision |
| `SourceSnapshot` | `lib/analysis` | No | Ast-grep fact validation owns that domain type; direct reuse would create false coupling |
| `GenerativeUiLifecycle` / provider driver | `lib/cognition` | No | Lifecycle/fake-driver prior art, but cognition owns a different candidate-generation domain |
| `merge_current_diagnostics` | `editor/view_updater.mbt` | No | Synchronous source-string equality cannot distinguish an older A0 request after A0 → A1 → A0 |

New private helpers/types added:

- distinct producer/source/dependency/configuration/channel/ticket/request identities and `DiagnosticPublicationState` — host-only provenance that must not enter Loom diagnostics or protocol
- `DiagnosticPublicationState::{issue,cancel,restart_producer,complete,display}` — deterministic state transitions and returned shell commands; they introduce no public `.mbti` API
- `FakePublicationShell` in whitebox tests — executes returned start/cancel commands without clocks, threads, network, or production producer integration

Remaining imperative code is test-local shell state/command recording. Core mutation only updates fresh `Map`/`Set` copies, builds returned command arrays, and sorts fresh arrays; no internal mutable collection escapes.

## Validation scope

Boundary matrix / first failing regression:

- The complete matrix is in `docs/research/2026-08-01-diagnostic-publication-prototype.md`.
- RED: the first A0 → A1 → A0 whitebox test failed because `DiagnosticPublicationState` did not exist.
- GREEN: 9 focused publication tests cover current replacement; equal-text revision revival rejection; source/dependency/configuration and two-source invalidation; unrelated source acceptance; supersession, cancellation, restart and duplicates; deterministic producer/channel and restart-command ordering; producer/source identity independence; and producer/consumer defensive-copy isolation.

Target packages:

- `editor`

Additional conditional gates:

- native editor release tests: 227/227 passed
- JS editor release tests: 227/227 passed
- independent structured review: 4 findings resolved; correctness and architecture/acceptance closure reviews PASS; every worker JSON passed strict parsing and the shared `ReviewFindings` BAML parser
- negative coherent-snapshot verdict persisted as follow-up #1096 without starting production integration

## PR-ready evidence

Validated HEAD: `44ee9959da570f63d9b03f94b8d92ff9dc862497`

Validated base: `origin/main@dd70498b02ac771b2f98d05e80f7a0cffd14293f`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target editor
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; this private prototype produces no interface drift.
- [x] No submodule pointer changed; every recorded submodule commit was fetched and verified reachable from its configured origin.
- [x] Validation was rerun after the candidate commit and every review correction.
- [x] Independent review findings were resolved before the final validation.
