### PR TITLE
Add reachable failure review for Lambda agent edits

### DIFF
--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -344,6 +344,41 @@ pub fn apply_lambda_tree_edit(
 }
 
 ///|
+/// Apply one Lambda edit and return an opt-in, detached scope-failure review
+/// for the agent host. Ordinary editor and protocol paths remain on
+/// `apply_lambda_tree_edit` and do not pay the two scope snapshots.
+pub fn apply_lambda_tree_edit_with_reachable_failure_review(
+  editor : @editor.SyncEditor[@ast.Term],
+  companion : LambdaCompanion,
+  op : @lambda_edits.TreeEditOp,
+  timestamp_ms : Int,
+  attribution : ReachableFailureAttribution,
+) -> Result[ReachableFailureReview, @editor.TreeEditError] {
+  let before = snapshot_reachable_failures(editor)
+  match apply_lambda_tree_edit(editor, companion, op, timestamp_ms) {
+    Err(error) => Err(error)
+    Ok(edits) => {
+      editor.refresh()
+      let after = snapshot_reachable_failures(editor)
+      Ok(build_reachable_failure_review(attribution, edits, before, after))
+    }
+  }
+}
+
+///|
+/// The imperative shell reads the current projection capabilities; scope
+/// construction and failure collection themselves remain deterministic.
+fn snapshot_reachable_failures(
+  editor : @editor.SyncEditor[@ast.Term],
+) -> Array[@lambda_scope.ReachableFailure] {
+  let source_map = editor.get_source_map()
+  @lambda_scope.failures(
+    @lambda_scope.build(editor.get_registry(), source_map),
+    source_map,
+  )
+}
+
+///|
 /// Map a language edit error to the editor-level error type.
 fn map_edit_error(e : @core.EditError) -> @editor.TreeEditError {
   match e {

--- a/lang/lambda/companion/moon.pkg
+++ b/lang/lambda/companion/moon.pkg
@@ -6,6 +6,7 @@ import {
   "dowdiness/canopy/lang/lambda/eval" @lambda_eval,
   "dowdiness/canopy/lang/lambda/edits" @lambda_edits,
   "dowdiness/canopy/lang/lambda/semantic" @lambda_semantic,
+  "dowdiness/canopy/lang/lambda/scope" @lambda_scope,
   "dowdiness/canopy/editor",
   "dowdiness/canopy/protocol",
   "dowdiness/event-graph-walker/text",

--- a/lang/lambda/companion/pkg.generated.mbti
+++ b/lang/lambda/companion/pkg.generated.mbti
@@ -7,16 +7,20 @@ import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/edits",
   "dowdiness/canopy/lang/lambda/eval",
+  "dowdiness/canopy/lang/lambda/scope",
   "dowdiness/canopy/protocol",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/lambda",
   "dowdiness/lambda/ast",
   "dowdiness/lambda/typecheck",
+  "moonbitlang/core/debug",
 }
 
 // Values
 pub fn apply_lambda_tree_edit(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int) -> Result[Array[@core.SpanEdit], @editor.TreeEditError]
+
+pub fn apply_lambda_tree_edit_with_reachable_failure_review(@editor.SyncEditor[@ast.Term], LambdaCompanion, @edits.TreeEditOp, Int, ReachableFailureAttribution) -> Result[ReachableFailureReview, @editor.TreeEditError]
 
 pub fn detect_action_context(@editor.SyncEditor[@ast.Term], @core.NodeId) -> @edits.ActionContext?
 
@@ -50,6 +54,19 @@ pub fn LambdaCompanion::get_eval_results(Self) -> Array[@eval.EvalResult]
 pub fn LambdaCompanion::get_structured_changes(Self) -> Array[@core.StructuredChange]
 pub fn LambdaCompanion::set_pattern_analysis(Self, Array[@analysis.PatternMatchFact], @analysis.SourceSnapshot) -> Unit
 pub fn LambdaCompanion::typecheck_output(Self) -> @cells.Derived[@typecheck.ModuleTypeResult]
+
+pub(all) struct ReachableFailureAttribution {
+  producer : String
+  edit_id : String
+  summary : String
+} derive(@debug.Debug)
+
+pub struct ReachableFailureReview {
+  // private fields
+}
+pub fn ReachableFailureReview::attribution(Self) -> ReachableFailureAttribution
+pub fn ReachableFailureReview::diff(Self) -> @scope.FailureDiff
+pub fn ReachableFailureReview::edits(Self) -> Array[@core.SpanEdit]
 
 // Type aliases
 

--- a/lang/lambda/companion/reachable_failure_review.mbt
+++ b/lang/lambda/companion/reachable_failure_review.mbt
@@ -1,0 +1,82 @@
+///|
+/// Producer-neutral metadata supplied by the agent host for one reviewed edit.
+/// `summary` describes this edit for a human; it is not a durable identity or
+/// graph/revision reference.
+pub(all) struct ReachableFailureAttribution {
+  producer : String
+  edit_id : String
+  summary : String
+} derive(Debug)
+
+///|
+/// A detached before/after scope-failure review for one applied Lambda edit.
+/// The agent host is the consumer; this is deliberately not an audit schema.
+pub struct ReachableFailureReview {
+  priv attribution_value : ReachableFailureAttribution
+  priv edits_value : Array[@core.SpanEdit]
+  priv diff_value : @lambda_scope.FailureDiff
+}
+
+///|
+pub fn ReachableFailureReview::attribution(
+  self : ReachableFailureReview,
+) -> ReachableFailureAttribution {
+  self.attribution_value
+}
+
+///|
+pub fn ReachableFailureReview::edits(
+  self : ReachableFailureReview,
+) -> Array[@core.SpanEdit] {
+  self.edits_value.copy()
+}
+
+///|
+pub fn ReachableFailureReview::diff(
+  self : ReachableFailureReview,
+) -> @lambda_scope.FailureDiff {
+  detach_failure_diff(self.diff_value)
+}
+
+///|
+/// Deterministic functional core for the review shell. It composes the scope
+/// package's remapping and semantic diff exactly once, then owns detached data.
+fn build_reachable_failure_review(
+  attribution : ReachableFailureAttribution,
+  applied_edits : Array[@core.SpanEdit],
+  before : Array[@lambda_scope.ReachableFailure],
+  after : Array[@lambda_scope.ReachableFailure],
+) -> ReachableFailureReview {
+  let failure_diff = @lambda_scope.diff(
+    @lambda_scope.remap_failures(before, applied_edits),
+    after,
+  )
+  {
+    attribution_value: attribution,
+    edits_value: applied_edits.copy(),
+    diff_value: detach_failure_diff(failure_diff),
+  }
+}
+
+///|
+/// `ReachableFailure.witness` is documented upstream as shared, so report
+/// ownership requires copying it even when remapping returned input values.
+fn detach_failure(
+  failure : @lambda_scope.ReachableFailure,
+) -> @lambda_scope.ReachableFailure {
+  {
+    name: failure.name,
+    location: failure.location,
+    witness: failure.witness.copy(),
+  }
+}
+
+///|
+fn detach_failure_diff(
+  diff : @lambda_scope.FailureDiff,
+) -> @lambda_scope.FailureDiff {
+  {
+    newly_reachable: diff.newly_reachable.map(detach_failure),
+    resolved: diff.resolved.map(detach_failure),
+  }
+}

--- a/lang/lambda/companion/reachable_failure_review_wbtest.mbt
+++ b/lang/lambda/companion/reachable_failure_review_wbtest.mbt
@@ -1,0 +1,188 @@
+// Behavioral boundary matrix:
+// syntax: lambda binder/reference rename; terminator: in-memory SpanEdit;
+// operation: pure report and delegated editor edit; ownership: agent-host report.
+// Cases: introduced (binder rename), resolved (reference rename), position-only
+// shift, identical rebuild, and detached output/input collections.
+
+///|
+fn review_attribution() -> ReachableFailureAttribution {
+  { producer: "agent", edit_id: "edit-42", summary: "rename a reference" }
+}
+
+///|
+fn failure(name : String, start : Int) -> @lambda_scope.ReachableFailure {
+  {
+    name,
+    location: Some({ start, end: start + 1 }),
+    witness: [@lambda_scope.ScopeId(0)],
+  }
+}
+
+///|
+test "reachable failure review introduces a failure when a binder rename frees its reference" {
+  let report = build_reachable_failure_review(
+    review_attribution(),
+    [{ start: 1, delete_len: 1, inserted: "z" }],
+    [],
+    [failure("x", 7)],
+  )
+  let diff = report.diff()
+  inspect(diff.newly_reachable.length(), content="1")
+  inspect(diff.newly_reachable[0].name, content="x")
+  inspect(diff.newly_reachable[0].location is Some(_), content="true")
+  inspect(diff.newly_reachable[0].witness.is_empty(), content="false")
+  inspect(report.attribution().producer, content="agent")
+  inspect(report.edits()[0].inserted, content="z")
+}
+
+///|
+test "reachable failure review resolves a renamed reference" {
+  let report = build_reachable_failure_review(
+    review_attribution(),
+    [{ start: 7, delete_len: 1, inserted: "x" }],
+    [failure("y", 7)],
+    [],
+  )
+  let diff = report.diff()
+  inspect(diff.newly_reachable.length(), content="0")
+  inspect(diff.resolved.length(), content="1")
+  inspect(diff.resolved[0].name, content="y")
+}
+
+///|
+test "reachable failure review remaps a position-only shift to an empty diff" {
+  let report = build_reachable_failure_review(
+    review_attribution(),
+    [{ start: 0, delete_len: 0, inserted: "let w = 0\n" }],
+    [failure("y", 3)],
+    [failure("y", 13)],
+  )
+  let diff = report.diff()
+  inspect(diff.newly_reachable.length(), content="0")
+  inspect(diff.resolved.length(), content="0")
+}
+
+///|
+test "reachable failure review is empty for an identical rebuild" {
+  let report = build_reachable_failure_review(
+    review_attribution(),
+    [],
+    [failure("x", 3)],
+    [failure("x", 3)],
+  )
+  let diff = report.diff()
+  inspect(diff.newly_reachable.length(), content="0")
+  inspect(diff.resolved.length(), content="0")
+}
+
+///|
+test "reachable failure review detaches input and accessor collections" {
+  let edits : Array[@core.SpanEdit] = [
+    { start: 0, delete_len: 0, inserted: "a" },
+  ]
+  let witness = [@lambda_scope.ScopeId(1)]
+  let scoped_failure : @lambda_scope.ReachableFailure = {
+    name: "x",
+    location: Some({ start: 2, end: 3 }),
+    witness,
+  }
+  let after = [scoped_failure]
+  let report = build_reachable_failure_review(
+    review_attribution(),
+    edits,
+    [],
+    after,
+  )
+  edits.push({ start: 1, delete_len: 0, inserted: "b" })
+  witness.push(@lambda_scope.ScopeId(2))
+  let first_edits = report.edits()
+  first_edits.push({ start: 2, delete_len: 0, inserted: "c" })
+  let first_diff = report.diff()
+  first_diff.newly_reachable[0].witness.push(@lambda_scope.ScopeId(3))
+  inspect(report.edits().length(), content="1")
+  inspect(report.diff().newly_reachable[0].witness.length(), content="1")
+}
+
+///|
+test "reviewing CommitEdit recomputes scope failures after the delegated edit" {
+  let (editor, companion) = try! new_lambda_editor("reachable-review")
+  editor.set_text("(x) => x")
+  let reference_id = match editor.get_proj_node() {
+    Some(root) => root.children[0].id()
+    None => fail("expected lambda projection")
+  }
+  let report = apply_lambda_tree_edit_with_reachable_failure_review(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::CommitEdit(node_id=reference_id, new_value="y"),
+    1,
+    review_attribution(),
+  ).unwrap()
+  inspect(editor.get_text(), content="(x) =>y")
+  inspect(report.attribution().edit_id, content="edit-42")
+  let diff = report.diff()
+  inspect(diff.resolved.length(), content="0")
+  inspect(diff.newly_reachable.length(), content="1")
+  inspect(diff.newly_reachable[0].name, content="y")
+  inspect(diff.newly_reachable[0].location is Some(_), content="true")
+  inspect(diff.newly_reachable[0].witness.is_empty(), content="false")
+  inspect(report.edits().length() > 0, content="true")
+}
+
+///|
+test "review wrapper retains the exact SpanEdit batch from the ordinary edit boundary" {
+  let (control, control_companion) = try! new_lambda_editor("reachable-control")
+  control.set_text("(x) => x")
+  let control_reference = match control.get_proj_node() {
+    Some(root) => root.children[0].id()
+    None => fail("expected control lambda projection")
+  }
+  let expected = apply_lambda_tree_edit(
+    control,
+    control_companion,
+    @lambda_edits.TreeEditOp::CommitEdit(
+      node_id=control_reference,
+      new_value="y",
+    ),
+    1,
+  ).unwrap()
+  let (reviewed, reviewed_companion) = try! new_lambda_editor(
+    "reachable-reviewed",
+  )
+  reviewed.set_text("(x) => x")
+  let reviewed_reference = match reviewed.get_proj_node() {
+    Some(root) => root.children[0].id()
+    None => fail("expected reviewed lambda projection")
+  }
+  let actual = apply_lambda_tree_edit_with_reachable_failure_review(
+      reviewed,
+      reviewed_companion,
+      @lambda_edits.TreeEditOp::CommitEdit(
+        node_id=reviewed_reference,
+        new_value="y",
+      ),
+      1,
+      review_attribution(),
+    )
+    .unwrap()
+    .edits()
+  assert_eq(actual, expected)
+}
+
+///|
+test "review wrapper returns the delegated error without mutating the editor" {
+  let (editor, companion) = try! new_lambda_editor("reachable-error")
+  editor.set_text("(x) => x")
+  let result = apply_lambda_tree_edit_with_reachable_failure_review(
+    editor,
+    companion,
+    @lambda_edits.TreeEditOp::CommitEdit(
+      node_id=@core.NodeId::from_int(999),
+      new_value="y",
+    ),
+    1,
+    review_attribution(),
+  )
+  inspect(result is Err(_), content="true")
+  inspect(editor.get_text(), content="(x) => x")
+}


### PR DESCRIPTION
## Summary

- add an opt-in `apply_lambda_tree_edit_with_reachable_failure_review` wrapper beside the existing Lambda tree-edit entry point
- snapshot reachable failures before and after the exact existing edit operation, then compose the existing semantic remap and diff operations
- return a detached review report containing attribution, the exact applied `SpanEdit` sequence, and `FailureDiff`, without exposing `NodeId` or `DeclId`

Refs #618

## Boundary and behavior

- The existing `apply_lambda_tree_edit`, generic editor, projection, FFI, and protocol surfaces are unchanged.
- The companion wrapper refreshes only after a successful edit and preserves the original `TreeEditError` on failure.
- The deterministic review core is `diff(remap_failures(before, applied_edits), after)`.
- Report construction and accessors defensively detach arrays and witness paths from mutable producer state.
- The Lambda facade does not re-export this opt-in API until a live production consumer requires it.

## Tests

- binder rename introduces a reachable failure
- resolving a reference removes a reachable failure
- source-position shifts remap without a false diff
- identical rebuilds produce an empty diff
- report inputs and accessor results are mutation-isolated
- an actual committed Lambda tree edit returns the expected newly reachable failure and witness
- the wrapper preserves the exact `SpanEdit` array emitted by the existing edit path
- edit errors preserve the original document and error

The first failing integration test exposed the existing printer's compact arrow spacing (`(x) =>y` rather than the test's `(x) => y` expectation); the assertion was corrected to the established output while retaining the behavioral boundary.

## Reuse check

### Existing project APIs reused

- `@lambda_scope.build`, `failures`, `remap_failures`, and `diff` provide the established semantic identity, source remapping, and failure classification.
- `SyncEditor::refresh`, `get_registry`, and `get_source_map` provide the existing snapshot boundary.
- `apply_lambda_tree_edit` remains the sole edit implementation; the wrapper delegates to it directly.

### MoonBit core APIs checked

- Reused `Result`, `Option`, `Array::copy`, `Array::map`, and structural array equality.
- Checked `Map`/`Set`, `StringView`, `Bytes`/`BytesView`, `Buffer`/`StringBuilder`, and `cmp`/`math` helpers; none fit the report composition or defensive-copy boundary better than the existing scope APIs and array operations.

### New definitions and imperative code

- `ReachableFailureAttribution` and `ReachableFailureReview` define only the report boundary required by #618.
- Private snapshot, detach, and builder functions isolate mutable editor state and keep the semantic diff composition deterministic.
- The wrapper is the thin imperative shell around the existing edit and refresh operations. Remaining local allocation/mutation only builds detached return values and has no observable external effect.

## Validation

- `moon info lang/lambda/companion`
- `moon check --deny-warn lang/lambda/companion`
- native release companion tests: 112/112
- JavaScript release companion tests: 112/112
- `./scripts/validate-pr-ready.sh --target lang/lambda/companion`
- independent correctness and acceptance reviews: PASS after removing an unsupported facade re-export; structured findings passed strict JSON and `ReviewFindings` schema validation

Validated clean candidate:

- HEAD: `6b231b3bbd1bea8ea96a672cc084aad4cdf16ef7`
- base: `ead1e51a0d0e6ceaad3df43d80cac59768c6a442`
- target: `lang/lambda/companion`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in review workflow for Lambda edits that reports reachable failures before and after changes.
  * Reviews include edit details, failure differences, attribution metadata, and preserved source locations.
  * Added accessors for retrieving review attribution, applied edits, and failure differences.

* **Bug Fixes**
  * Prevented editor state changes when delegated edit processing fails.

* **Tests**
  * Added coverage for renames, position changes, unchanged rebuilds, edit preservation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->