### PR TITLE
Add atomic diagnostic publication input snapshots

### DIFF
--- a/editor/diagnostic_publication.mbt
+++ b/editor/diagnostic_publication.mbt
@@ -1,18 +1,20 @@
 ///|
 /// Host-only identity for a diagnostic producer. It is intentionally distinct
 /// from both source and display-channel identity.
-priv struct DiagnosticProducerId(String) derive(Eq, Hash)
+pub struct DiagnosticProducerId {
+  priv value : String
+} derive(Eq, Hash, @debug.Debug)
 
 ///|
-#warnings("-unused_value")
-fn DiagnosticProducerId::new(value : String) -> DiagnosticProducerId {
-  DiagnosticProducerId(value)
+pub fn DiagnosticProducerId::DiagnosticProducerId(
+  value : String,
+) -> DiagnosticProducerId {
+  { value, }
 }
 
 ///|
-fn DiagnosticProducerId::to_string(self : DiagnosticProducerId) -> String {
-  let DiagnosticProducerId(value) = self
-  value
+pub fn DiagnosticProducerId::to_string(self : DiagnosticProducerId) -> String {
+  self.value
 }
 
 ///|
@@ -25,21 +27,60 @@ fn DiagnosticSourceId::new(value : String) -> DiagnosticSourceId {
 }
 
 ///|
-priv struct DiagnosticDependencyId(String) derive(Eq, Hash)
+pub struct DiagnosticDependencyId {
+  priv value : String
+} derive(Eq, Hash, @debug.Debug)
 
 ///|
-#warnings("-unused_value")
-fn DiagnosticDependencyId::new(value : String) -> DiagnosticDependencyId {
-  DiagnosticDependencyId(value)
+pub fn DiagnosticDependencyId::DiagnosticDependencyId(
+  value : String,
+) -> DiagnosticDependencyId {
+  { value, }
 }
 
 ///|
-priv struct DiagnosticConfigurationId(String) derive(Eq)
+pub fn DiagnosticDependencyId::to_string(
+  self : DiagnosticDependencyId,
+) -> String {
+  self.value
+}
 
 ///|
-#warnings("-unused_value")
-fn DiagnosticConfigurationId::new(value : String) -> DiagnosticConfigurationId {
-  DiagnosticConfigurationId(value)
+pub struct DiagnosticConfigurationId {
+  priv value : String
+} derive(Eq, @debug.Debug)
+
+///|
+pub fn DiagnosticConfigurationId::DiagnosticConfigurationId(
+  value : String,
+) -> DiagnosticConfigurationId {
+  { value, }
+}
+
+///|
+pub fn DiagnosticConfigurationId::to_string(
+  self : DiagnosticConfigurationId,
+) -> String {
+  self.value
+}
+
+///|
+pub struct DiagnosticProducerGeneration {
+  priv value : Int
+} derive(Eq, @debug.Debug)
+
+///|
+pub fn DiagnosticProducerGeneration::DiagnosticProducerGeneration(
+  value : Int,
+) -> DiagnosticProducerGeneration {
+  { value, }
+}
+
+///|
+pub fn DiagnosticProducerGeneration::to_int(
+  self : DiagnosticProducerGeneration,
+) -> Int {
+  self.value
 }
 
 ///|
@@ -88,18 +129,31 @@ fn DiagnosticSourceRevision::new(
 }
 
 ///|
-priv struct DiagnosticDependencyRevision {
-  dependency : DiagnosticDependencyId
-  identity : String
-}
+pub struct DiagnosticDependencyRevision {
+  priv dependency : DiagnosticDependencyId
+  priv identity : String
+} derive(Eq, @debug.Debug)
 
 ///|
-#warnings("-unused_value")
-fn DiagnosticDependencyRevision::new(
+pub fn DiagnosticDependencyRevision::DiagnosticDependencyRevision(
   dependency : DiagnosticDependencyId,
   identity : String,
 ) -> DiagnosticDependencyRevision {
   { dependency, identity }
+}
+
+///|
+pub fn DiagnosticDependencyRevision::dependency(
+  self : DiagnosticDependencyRevision,
+) -> DiagnosticDependencyId {
+  self.dependency
+}
+
+///|
+pub fn DiagnosticDependencyRevision::identity(
+  self : DiagnosticDependencyRevision,
+) -> String {
+  self.identity
 }
 
 ///|

--- a/editor/diagnostic_publication_input.mbt
+++ b/editor/diagnostic_publication_input.mbt
@@ -1,0 +1,144 @@
+///|
+/// A covered source's stable parser identity paired with its CRDT causal
+/// document version. No source text or parser value crosses this boundary.
+pub struct DiagnosticPublicationSourceRevision {
+  priv source : @loom_core.SourceId
+  priv version : @text.Version
+} derive(Eq, @debug.Debug)
+
+///|
+pub fn DiagnosticPublicationSourceRevision::DiagnosticPublicationSourceRevision(
+  source : @loom_core.SourceId,
+  version : @text.Version,
+) -> DiagnosticPublicationSourceRevision {
+  { source, version }
+}
+
+///|
+pub fn DiagnosticPublicationSourceRevision::source(
+  self : DiagnosticPublicationSourceRevision,
+) -> @loom_core.SourceId {
+  self.source
+}
+
+///|
+pub fn DiagnosticPublicationSourceRevision::version(
+  self : DiagnosticPublicationSourceRevision,
+) -> @text.Version {
+  self.version
+}
+
+///|
+pub(all) suberror DiagnosticPublicationInputError {
+  NoCoveredSources
+  DuplicateSource(@loom_core.SourceId)
+  DuplicateDependency(DiagnosticDependencyId)
+} derive(Eq, @debug.Debug)
+
+///|
+pub impl Show for DiagnosticPublicationInputError with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+pub struct DiagnosticPublicationInputSnapshot {
+  priv producer : DiagnosticProducerId
+  priv generation : DiagnosticProducerGeneration
+  priv sources : Array[DiagnosticPublicationSourceRevision]
+  priv dependencies : Array[DiagnosticDependencyRevision]
+  priv configuration : DiagnosticConfigurationId
+} derive(Eq, @debug.Debug)
+
+///|
+/// Pure validation and normalization boundary. The returned value owns fresh,
+/// deterministically ordered arrays; no caller-owned collection escapes.
+pub fn DiagnosticPublicationInputSnapshot::DiagnosticPublicationInputSnapshot(
+  producer : DiagnosticProducerId,
+  generation : DiagnosticProducerGeneration,
+  sources : Array[DiagnosticPublicationSourceRevision],
+  dependencies : Array[DiagnosticDependencyRevision],
+  configuration : DiagnosticConfigurationId,
+) -> DiagnosticPublicationInputSnapshot raise DiagnosticPublicationInputError {
+  guard !sources.is_empty() else { raise NoCoveredSources }
+  let normalized_sources = sources.copy()
+  let source_ids : Set[@loom_core.SourceId] = Set([])
+  for source_revision in normalized_sources {
+    guard source_ids.add_and_check(source_revision.source) else {
+      raise DuplicateSource(source_revision.source)
+    }
+  }
+  normalized_sources.sort_by((left, right) => {
+    left.source.value().compare(right.source.value())
+  })
+  let normalized_dependencies = dependencies.copy()
+  let dependency_ids : Set[DiagnosticDependencyId] = Set([])
+  for dependency_revision in normalized_dependencies {
+    guard dependency_ids.add_and_check(dependency_revision.dependency) else {
+      raise DuplicateDependency(dependency_revision.dependency)
+    }
+  }
+  normalized_dependencies.sort_by((left, right) => {
+    left.dependency.to_string().compare(right.dependency.to_string())
+  })
+  {
+    producer,
+    generation,
+    sources: normalized_sources,
+    dependencies: normalized_dependencies,
+    configuration,
+  }
+}
+
+///|
+pub fn DiagnosticPublicationInputSnapshot::producer(
+  self : DiagnosticPublicationInputSnapshot,
+) -> DiagnosticProducerId {
+  self.producer
+}
+
+///|
+pub fn DiagnosticPublicationInputSnapshot::generation(
+  self : DiagnosticPublicationInputSnapshot,
+) -> DiagnosticProducerGeneration {
+  self.generation
+}
+
+///|
+pub fn DiagnosticPublicationInputSnapshot::sources(
+  self : DiagnosticPublicationInputSnapshot,
+) -> Array[DiagnosticPublicationSourceRevision] {
+  self.sources.copy()
+}
+
+///|
+pub fn DiagnosticPublicationInputSnapshot::dependencies(
+  self : DiagnosticPublicationInputSnapshot,
+) -> Array[DiagnosticDependencyRevision] {
+  self.dependencies.copy()
+}
+
+///|
+pub fn DiagnosticPublicationInputSnapshot::configuration(
+  self : DiagnosticPublicationInputSnapshot,
+) -> DiagnosticConfigurationId {
+  self.configuration
+}
+
+///|
+/// Reactive editor view used by host protected surfaces. Parser source is read
+/// only to establish invalidation; the returned value carries no source text.
+pub fn[T] SyncEditor::diagnostic_publication_source_revision(
+  self : SyncEditor[T],
+) -> @incr.Derived[DiagnosticPublicationSourceRevision] {
+  let source_id = self.parser_source_id()
+  @incr.Derived::Derived(
+    self.parser_runtime(),
+    () => {
+      DiagnosticPublicationSourceRevision(
+        source_id,
+        self.document_version.get(),
+      )
+    },
+    label="diagnostic_publication_source_revision",
+  )
+}

--- a/editor/diagnostic_publication_input_wbtest.mbt
+++ b/editor/diagnostic_publication_input_wbtest.mbt
@@ -1,0 +1,130 @@
+///|
+test "diagnostic publication input rejects duplicate declared identities" {
+  let producer = DiagnosticProducerId("producer")
+  let generation = DiagnosticProducerGeneration(0)
+  let configuration = DiagnosticConfigurationId("configuration")
+  let source = @loom_core.SourceId("source")
+  let source_revision = DiagnosticPublicationSourceRevision(
+    source,
+    @text.Version::empty(),
+  )
+  let duplicate_source = try {
+    let _ = DiagnosticPublicationInputSnapshot(
+      producer,
+      generation,
+      [source_revision, source_revision],
+      [],
+      configuration,
+    )
+    None
+  } catch {
+    error => Some(error)
+  }
+  guard duplicate_source is Some(DuplicateSource(duplicate)) else {
+    fail("expected DuplicateSource")
+  }
+  assert_eq(duplicate, source)
+  let dependency_id = DiagnosticDependencyId("dependency")
+  let dependency = DiagnosticDependencyRevision(dependency_id, "identity")
+  let duplicate_dependency = try {
+    let _ = DiagnosticPublicationInputSnapshot(
+      producer,
+      generation,
+      [source_revision],
+      [dependency, dependency],
+      configuration,
+    )
+    None
+  } catch {
+    error => Some(error)
+  }
+  guard duplicate_dependency is Some(DuplicateDependency(duplicate)) else {
+    fail("expected DuplicateDependency")
+  }
+  assert_eq(duplicate, dependency_id)
+}
+
+///|
+test "diagnostic publication input normalizes order and owns its arrays" {
+  let source_z = DiagnosticPublicationSourceRevision(
+    @loom_core.SourceId("z-source"),
+    @text.Version::empty(),
+  )
+  let source_a = DiagnosticPublicationSourceRevision(
+    @loom_core.SourceId("a-source"),
+    @text.Version::empty(),
+  )
+  let dependency_z = DiagnosticDependencyRevision(
+    DiagnosticDependencyId("z-dependency"),
+    "z-identity",
+  )
+  let dependency_a = DiagnosticDependencyRevision(
+    DiagnosticDependencyId("a-dependency"),
+    "a-identity",
+  )
+  let constructor_sources = [source_z, source_a]
+  let constructor_dependencies = [dependency_z, dependency_a]
+  let snapshot = DiagnosticPublicationInputSnapshot(
+    DiagnosticProducerId("producer"),
+    DiagnosticProducerGeneration(0),
+    constructor_sources,
+    constructor_dependencies,
+    DiagnosticConfigurationId("configuration"),
+  )
+  assert_eq(snapshot.sources()[0].source().value(), "a-source")
+  assert_eq(snapshot.dependencies()[0].dependency().to_string(), "a-dependency")
+  constructor_sources.clear()
+  constructor_dependencies.clear()
+  assert_eq(snapshot.sources().length(), 2)
+  assert_eq(snapshot.dependencies().length(), 2)
+  let returned_sources = snapshot.sources()
+  let returned_dependencies = snapshot.dependencies()
+  returned_sources.clear()
+  returned_dependencies.clear()
+  assert_eq(snapshot.sources().length(), 2)
+  assert_eq(snapshot.dependencies().length(), 2)
+}
+
+///|
+test "diagnostic source revision follows local structural undo redo and remote edits" {
+  let primary = try! @probe.new_test_editor("diagnostic-source-local")
+  let local_watch = primary.diagnostic_publication_source_revision().watch()
+  let initial = local_watch.read().unwrap()
+  primary.set_text("a")
+  let after_local = local_watch.read().unwrap()
+  assert_true(after_local.version() != initial.version())
+  let root = primary.get_proj_node().unwrap()
+  primary.commit_edit(root.id(), "b", 0).unwrap()
+  let after_structural = local_watch.read().unwrap()
+  assert_true(after_structural.version() != after_local.version())
+  assert_true(primary.undo())
+  let after_undo = local_watch.read().unwrap()
+  assert_true(after_undo.version() != after_structural.version())
+  assert_true(primary.redo())
+  let after_redo = local_watch.read().unwrap()
+  assert_true(after_redo.version() != after_undo.version())
+  let remote = try! @probe.new_test_editor("diagnostic-source-remote")
+  let remote_watch = remote.diagnostic_publication_source_revision().watch()
+  let before_remote = remote_watch.read().unwrap()
+  try! remote.apply_sync(try! primary.export_all())
+  let after_remote = remote_watch.read().unwrap()
+  assert_true(after_remote.version() != before_remote.version())
+  local_watch.dispose()
+  remote_watch.dispose()
+}
+
+///|
+test "diagnostic source revision follows causal changes with identical text" {
+  let receiver = try! @probe.new_test_editor("diagnostic-causal-receiver")
+  let watch = receiver.diagnostic_publication_source_revision().watch()
+  let before = watch.read().unwrap()
+  let sender = try! @probe.new_test_editor("diagnostic-causal-sender")
+  sender.set_text("transient")
+  sender.set_text("")
+  assert_eq(receiver.get_text(), sender.get_text())
+  try! receiver.apply_sync(try! sender.export_all())
+  let after = watch.read().unwrap()
+  assert_true(after.version() != before.version())
+  assert_eq(receiver.get_text(), "")
+  watch.dispose()
+}

--- a/editor/diagnostic_publication_wbtest.mbt
+++ b/editor/diagnostic_publication_wbtest.mbt
@@ -14,12 +14,12 @@ fn publication_channel(
   producer : String,
   name? : String = "diagnostics",
 ) -> DiagnosticPublicationChannel {
-  DiagnosticPublicationChannel::new(DiagnosticProducerId::new(producer), name)
+  DiagnosticPublicationChannel::new(DiagnosticProducerId(producer), name)
 }
 
 ///|
 fn publication_state() -> DiagnosticPublicationState {
-  DiagnosticPublicationState::new(DiagnosticConfigurationId::new("config-0"))
+  DiagnosticPublicationState::new(DiagnosticConfigurationId("config-0"))
 }
 
 ///|
@@ -78,7 +78,7 @@ test "publication rejects the original completion after A0 A1 A0" {
   let parser = publication_channel("parser")
   let a0_text = "same source"
   let state = with_source(
-    DiagnosticPublicationState::new(DiagnosticConfigurationId::new("config-0")),
+    DiagnosticPublicationState::new(DiagnosticConfigurationId("config-0")),
     "A",
     0,
   )
@@ -94,7 +94,7 @@ test "publication rejects the original completion after A0 A1 A0" {
   )
   let (state, old_ticket, _) = state.issue(
     DiagnosticPublicationChannel::new(
-      DiagnosticProducerId::new("semantic"),
+      DiagnosticProducerId("semantic"),
       "diagnostics",
     ),
     [DiagnosticSourceRevision::new(source_a, 0)],
@@ -188,7 +188,7 @@ test "display sorts producer and channel as a lexicographic pair" {
 
 ///|
 test "producer restart cancels active channels in lexical pair order" {
-  let producer = DiagnosticProducerId::new("semantic")
+  let producer = DiagnosticProducerId("semantic")
   let later = DiagnosticPublicationChannel::new(producer, "z-channel")
   let earlier = DiagnosticPublicationChannel::new(producer, "a-channel")
   let state = with_source(publication_state(), "A", 0)
@@ -216,7 +216,7 @@ test "coverage invalidation is precise for source dependency configuration and t
   let semantic = publication_channel("semantic")
   let state = with_source(with_source(publication_state(), "A", 0), "B", 0)
   let state = state.set_dependency_identity(
-    DiagnosticDependencyId::new("project"),
+    DiagnosticDependencyId("project"),
     "dep-0",
   )
   let (state, unrelated, _) = state.issue(semantic, [source_revision("A", 0)], [])
@@ -232,15 +232,10 @@ test "coverage invalidation is precise for source dependency configuration and t
   let (state, dependency_ticket, _) = state.issue(
     semantic,
     [source_revision("A", 0)],
-    [
-      DiagnosticDependencyRevision::new(
-        DiagnosticDependencyId::new("project"),
-        "dep-0",
-      ),
-    ],
+    [DiagnosticDependencyRevision(DiagnosticDependencyId("project"), "dep-0")],
   )
   let state = state.set_dependency_identity(
-    DiagnosticDependencyId::new("project"),
+    DiagnosticDependencyId("project"),
     "dep-1",
   )
   let (state, dependency_decision) = state.complete(
@@ -256,9 +251,7 @@ test "coverage invalidation is precise for source dependency configuration and t
     [source_revision("A", 0)],
     [],
   )
-  let state = state.set_configuration(
-    DiagnosticConfigurationId::new("config-1"),
-  )
+  let state = state.set_configuration(DiagnosticConfigurationId("config-1"))
   let (state, config_decision) = state.complete(
     config_ticket,
     publication_fixture("stale-config"),
@@ -334,7 +327,7 @@ test "newer cancellation restart and duplicate completions never revive older wo
     [],
   )
   let (state, restart_commands) = state.restart_producer(
-    DiagnosticProducerId::new("semantic"),
+    DiagnosticProducerId("semantic"),
   )
   inspect(restart_commands.length(), content="1")
   let (state, restart_decision) = state.complete(
@@ -463,7 +456,7 @@ test "fake async shell executes issue cancellation restart and reordered complet
     content="true",
   )
   let previous_generation = shell.issue(semantic)
-  shell.restart(DiagnosticProducerId::new("semantic"))
+  shell.restart(DiagnosticProducerId("semantic"))
   let restart_decision = shell.complete(
     previous_generation,
     publication_fixture("pre-restart"),

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -30,6 +30,13 @@ pub fn[T : @dowdiness/loom/core.Renderable] compute_view_patches(ViewUpdateState
 pub fn project_diagnostics_for_source(@dowdiness/loom/core.SourceId, @dowdiness/loom/core.DiagnosticSet) -> Array[@protocol.Diagnostic]
 
 // Errors
+pub(all) suberror DiagnosticPublicationInputError {
+  NoCoveredSources
+  DuplicateSource(@dowdiness/loom/core.SourceId)
+  DuplicateDependency(DiagnosticDependencyId)
+} derive(Eq, @debug.Debug)
+pub impl Show for DiagnosticPublicationInputError
+
 pub(all) suberror TreeEditError {
   ExpectedJsonObject
   MissingField(field~ : String)
@@ -47,6 +54,54 @@ pub(all) suberror TreeEditError {
 pub fn TreeEditError::message(Self) -> String
 
 // Types and methods
+pub struct DiagnosticConfigurationId {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn DiagnosticConfigurationId::DiagnosticConfigurationId(String) -> Self
+pub fn DiagnosticConfigurationId::to_string(Self) -> String
+
+pub struct DiagnosticDependencyId {
+  // private fields
+} derive(Eq, Hash, @debug.Debug)
+pub fn DiagnosticDependencyId::DiagnosticDependencyId(String) -> Self
+pub fn DiagnosticDependencyId::to_string(Self) -> String
+
+pub struct DiagnosticDependencyRevision {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn DiagnosticDependencyRevision::DiagnosticDependencyRevision(DiagnosticDependencyId, String) -> Self
+pub fn DiagnosticDependencyRevision::dependency(Self) -> DiagnosticDependencyId
+pub fn DiagnosticDependencyRevision::identity(Self) -> String
+
+pub struct DiagnosticProducerGeneration {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn DiagnosticProducerGeneration::DiagnosticProducerGeneration(Int) -> Self
+pub fn DiagnosticProducerGeneration::to_int(Self) -> Int
+
+pub struct DiagnosticProducerId {
+  // private fields
+} derive(Eq, Hash, @debug.Debug)
+pub fn DiagnosticProducerId::DiagnosticProducerId(String) -> Self
+pub fn DiagnosticProducerId::to_string(Self) -> String
+
+pub struct DiagnosticPublicationInputSnapshot {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn DiagnosticPublicationInputSnapshot::DiagnosticPublicationInputSnapshot(DiagnosticProducerId, DiagnosticProducerGeneration, Array[DiagnosticPublicationSourceRevision], Array[DiagnosticDependencyRevision], DiagnosticConfigurationId) -> Self raise DiagnosticPublicationInputError
+pub fn DiagnosticPublicationInputSnapshot::configuration(Self) -> DiagnosticConfigurationId
+pub fn DiagnosticPublicationInputSnapshot::dependencies(Self) -> Array[DiagnosticDependencyRevision]
+pub fn DiagnosticPublicationInputSnapshot::generation(Self) -> DiagnosticProducerGeneration
+pub fn DiagnosticPublicationInputSnapshot::producer(Self) -> DiagnosticProducerId
+pub fn DiagnosticPublicationInputSnapshot::sources(Self) -> Array[DiagnosticPublicationSourceRevision]
+
+pub struct DiagnosticPublicationSourceRevision {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn DiagnosticPublicationSourceRevision::DiagnosticPublicationSourceRevision(@dowdiness/loom/core.SourceId, @text.Version) -> Self
+pub fn DiagnosticPublicationSourceRevision::source(Self) -> @dowdiness/loom/core.SourceId
+pub fn DiagnosticPublicationSourceRevision::version(Self) -> @text.Version
+
 pub struct Editor {
   doc : @text.TextState
   mut cursor : Int
@@ -93,6 +148,7 @@ pub fn[T : Eq] SyncEditor::delete_and_record(Self[T], Int) -> Bool
 pub fn[T : Eq] SyncEditor::delete_at(Self[T], Int, Int) -> Bool
 pub fn[T] SyncEditor::delete_local_presence(Self[T]) -> Unit
 pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::delete_node(Self[T], @dowdiness/canopy/core.NodeId, Int) -> Result[Unit, TreeEditError]
+pub fn[T] SyncEditor::diagnostic_publication_source_revision(Self[T]) -> @cells.Derived[DiagnosticPublicationSourceRevision]
 pub fn[T] SyncEditor::encode_ephemeral_all(Self[T]) -> Bytes
 pub fn[T] SyncEditor::export_all(Self[T]) -> @text.SyncMessage raise
 pub fn[T] SyncEditor::export_since(Self[T], @text.Version) -> @text.SyncMessage raise

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -6,6 +6,10 @@ pub struct SyncEditor[T] {
   priv doc : @text.TextState
   priv undo : @undo.UndoManager
   priv parser : @loom.Parser[T]
+  // Reactive causal authority for host-owned snapshots. This is separate
+  // from parser source because CRDT history can advance without changing the
+  // rendered text.
+  priv document_version : @incr.Input[@text.Version]
   priv mut cursor : Int
   priv cached_proj_node : @incr.Derived[@core.ProjNode[T]?]
   priv registry_memo : @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]]
@@ -65,12 +69,18 @@ pub fn[T] SyncEditor::new_generic(
     "canopy-sync-editor:" + identity.to_string(),
   )
   let parser = make_parser(source_id, "", parent_runtime)
+  let document_version = @incr.Input(
+    parser.runtime(),
+    doc.version(),
+    label="sync_editor_document_version",
+  )
   let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
   {
     doc,
     undo: @undo.UndoManager::new(agent_id, capture_timeout_ms~),
     parser,
+    document_version,
     cursor: 0,
     cached_proj_node,
     registry_memo,

--- a/editor/sync_editor_parser.mbt
+++ b/editor/sync_editor_parser.mbt
@@ -17,6 +17,7 @@ fn[T : Eq] SyncEditor::sync_parser_after_text_change(
   new_source : String,
   known_edit : @loom_core.Edit?,
 ) -> Unit {
+  self.document_version.set(self.doc.version())
   // Short-circuits mark_projection_dirty; Parser does its own identity check.
   guard old_source != new_source else { return }
   if new_source == "" {
@@ -99,6 +100,7 @@ fn[T : Eq] SyncEditor::apply_local_text_change(
 
 ///|
 pub fn[T : Eq] SyncEditor::mark_dirty(self : SyncEditor[T]) -> Unit {
+  self.document_version.set(self.doc.version())
   self.parser.set_source(self.doc.text())
   self.mark_projection_dirty()
 }

--- a/ffi/lambda/diagnostic_publication_input.mbt
+++ b/ffi/lambda/diagnostic_publication_input.mbt
@@ -1,0 +1,126 @@
+///|
+/// Host-owned reactive identity for one declared dependency. The dependency
+/// id is fixed for the registration lifetime; only its safe fingerprint is an
+/// incremental input.
+priv struct DiagnosticPublicationDependencyInput {
+  dependency : @editor.DiagnosticDependencyId
+  identity : @incr.Input[String]
+}
+
+///|
+#warnings("-unused_value")
+fn DiagnosticPublicationDependencyInput::DiagnosticPublicationDependencyInput(
+  dependency : @editor.DiagnosticDependencyId,
+  identity : @incr.Input[String],
+) -> DiagnosticPublicationDependencyInput {
+  { dependency, identity }
+}
+
+///|
+priv enum DiagnosticPublicationInputCaptureError {
+  InvalidInput(@editor.DiagnosticPublicationInputError)
+  Coordinator(@workspace.AbortReport)
+} derive(@debug.Debug)
+
+///|
+#warnings("-unused_value")
+impl Show for DiagnosticPublicationInputCaptureError with fn output(
+  self,
+  logger,
+) {
+  logger.write_string(@debug.to_string(self))
+}
+
+///|
+/// Lambda-host assembly shell for #1096. Coverage is validated before the
+/// coordinator is mutated. The returned workspace-cell handle is the only
+/// supported capture operation and owns registration/disposal symmetry.
+#warnings("-unused_value")
+fn register_diagnostic_publication_input_snapshot(
+  source_handles : Array[LambdaHandle],
+  dependency_inputs : Array[DiagnosticPublicationDependencyInput],
+  configuration : @incr.Input[@editor.DiagnosticConfigurationId],
+  producer : @editor.DiagnosticProducerId,
+  generation : @incr.Input[@editor.DiagnosticProducerGeneration],
+) -> Result[
+  @workspace.WorkspaceCellHandle[@editor.DiagnosticPublicationInputSnapshot],
+  DiagnosticPublicationInputCaptureError,
+] {
+  let captured_sources = source_handles.copy()
+  let captured_dependencies = dependency_inputs.copy()
+  // Imperative-shell preflight only: these eager reads validate lifecycle and
+  // declared identity before registration. Their values are discarded after
+  // validation and never become a captured request snapshot.
+  let validation_sources : Array[@editor.DiagnosticPublicationSourceRevision] = []
+  for handle in captured_sources {
+    match
+      coordinator.read_protected(
+        handle.editor_id,
+        handle.cells.diagnostic_source_revision,
+      ) {
+      Ok(source) => validation_sources.push(source)
+      Err(report) => return Err(Coordinator(report))
+    }
+  }
+  let validation_dependencies = captured_dependencies.map(input => {
+    @editor.DiagnosticDependencyRevision(input.dependency, "validation")
+  })
+  try
+    @editor.DiagnosticPublicationInputSnapshot(
+      producer,
+      generation.peek(),
+      validation_sources,
+      validation_dependencies,
+      configuration.peek(),
+    )
+  catch {
+    error => return Err(InvalidInput(error))
+  } noraise {
+    _ => ()
+  }
+  let snapshot_cell : @incr.Derived[@editor.DiagnosticPublicationInputSnapshot] = @incr.Derived::Derived(
+    coordinator.runtime(),
+    () => {
+      let sources = captured_sources.map(handle => {
+        match
+          coordinator.read_protected(
+            handle.editor_id,
+            handle.cells.diagnostic_source_revision,
+          ) {
+          Ok(source) => source
+          Err(report) =>
+            abort("diagnostic publication source read failed: \{report}")
+        }
+      })
+      let dependencies = captured_dependencies.map(input => {
+        @editor.DiagnosticDependencyRevision(
+          input.dependency,
+          input.identity.get(),
+        )
+      })
+      try
+        @editor.DiagnosticPublicationInputSnapshot(
+          producer,
+          generation.get(),
+          sources,
+          dependencies,
+          configuration.get(),
+        )
+      catch {
+        error =>
+          abort("validated diagnostic publication coverage changed: \{error}")
+      } noraise {
+        snapshot => snapshot
+      }
+    },
+    label="diagnostic_publication_input_snapshot",
+  )
+  let editor_dependencies = captured_sources.map(handle => {
+    (handle.editor_id, handle.cells.diagnostic_source_revision.cell_id())
+  })
+  match
+    coordinator.register_workspace_cell(snapshot_cell, editor_dependencies) {
+    Ok(handle) => Ok(handle)
+    Err(report) => Err(Coordinator(report))
+  }
+}

--- a/ffi/lambda/diagnostic_publication_input_wbtest.mbt
+++ b/ffi/lambda/diagnostic_publication_input_wbtest.mbt
@@ -1,0 +1,447 @@
+// Behavioral boundary matrix for #1096.
+//
+// | Coverage / event | Observable boundary |
+// | --- | --- |
+// | One real editor | One WorkspaceCellHandle read returns its stable source id and causal version. |
+// | A0 -> A1 -> A0 | Equal restored text still has a newer captured causal version. |
+// | Two sources + host inputs in one batch | A read returns the complete pre-batch or post-batch tuple, never a mix. |
+// | One covered input changes | A later read changes; an earlier returned snapshot stays detached. |
+// | Uncovered editor changes | The declared snapshot remains equal. |
+// | Duplicate source/dependency declarations | Registration is rejected before coordinator state changes. |
+// | Live/disposed handle | Destroy is refused while live, then succeeds after idempotent disposal. |
+
+///|
+test "diagnostic input snapshot captures one real Lambda editor" {
+  reset_coordinator_for_phase1_tests()
+  let raw_handle = create_editor("diagnostic_snapshot_single")
+  let editor_handle = lambda_registry.get(raw_handle).unwrap()
+  editor_handle.editor.set_text("let answer = 42")
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+    label="diagnostic_configuration",
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+    label="diagnostic_generation",
+  )
+  let producer = @editor.DiagnosticProducerId("lambda-typecheck")
+  let snapshot_handle = match
+    register_diagnostic_publication_input_snapshot(
+      [editor_handle],
+      [],
+      configuration,
+      producer,
+      generation,
+    ) {
+    Ok(handle) => handle
+    Err(error) => fail("register diagnostic snapshot: \{error}")
+  }
+  let snapshot = snapshot_handle.read().unwrap()
+  let sources = snapshot.sources()
+  assert_eq(sources.length(), 1)
+  assert_eq(sources[0].source(), editor_handle.editor.parser_source_id())
+  assert_eq(sources[0].version(), editor_handle.editor.get_version())
+  assert_eq(snapshot.producer(), producer)
+  assert_eq(snapshot.configuration(), configuration.peek())
+  assert_eq(snapshot.generation(), generation.peek())
+  snapshot_handle.dispose()
+  destroy_editor(raw_handle)
+}
+
+///|
+test "diagnostic input snapshot keeps A0 A1 A0 causally distinct" {
+  reset_coordinator_for_phase1_tests()
+  let raw_handle = create_editor("diagnostic_snapshot_aba")
+  let editor_handle = lambda_registry.get(raw_handle).unwrap()
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let producer = @editor.DiagnosticProducerId("lambda-typecheck")
+  let snapshot_handle = register_diagnostic_publication_input_snapshot(
+    [editor_handle],
+    [],
+    configuration,
+    producer,
+    generation,
+  ).unwrap()
+  editor_handle.editor.set_text("A0")
+  let first = snapshot_handle.read().unwrap()
+  editor_handle.editor.set_text("A1")
+  let middle = snapshot_handle.read().unwrap()
+  editor_handle.editor.set_text("A0")
+  let restored = snapshot_handle.read().unwrap()
+  assert_eq(editor_handle.editor.get_text(), "A0")
+  assert_true(first.sources()[0].version() != middle.sources()[0].version())
+  assert_true(first.sources()[0].version() != restored.sources()[0].version())
+  assert_true(middle.sources()[0].version() != restored.sources()[0].version())
+  snapshot_handle.dispose()
+  destroy_editor(raw_handle)
+}
+
+///|
+test "diagnostic input snapshot observes one batched multi-source host tuple" {
+  reset_coordinator_for_phase1_tests()
+  let raw_a = create_editor("diagnostic_snapshot_batch_a")
+  let raw_b = create_editor("diagnostic_snapshot_batch_b")
+  let handle_a = lambda_registry.get(raw_a).unwrap()
+  let handle_b = lambda_registry.get(raw_b).unwrap()
+  handle_a.editor.set_text("A0")
+  handle_b.editor.set_text("B0")
+  let dependency_identity = @incr.Input(coordinator.runtime(), "dependency-0")
+  let dependency = DiagnosticPublicationDependencyInput(
+    @editor.DiagnosticDependencyId("workspace"),
+    dependency_identity,
+  )
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let producer = @editor.DiagnosticProducerId("lambda-typecheck")
+  let snapshot_handle = register_diagnostic_publication_input_snapshot(
+    [handle_b, handle_a],
+    [dependency],
+    configuration,
+    producer,
+    generation,
+  ).unwrap()
+  let before = snapshot_handle.read().unwrap()
+  coordinator
+  .runtime()
+  .batch(() => {
+    handle_a.editor.set_text("A1")
+    handle_b.editor.set_text("B1")
+    dependency_identity.set("dependency-1")
+    configuration.set(@editor.DiagnosticConfigurationId("config-1"))
+    generation.set(@editor.DiagnosticProducerGeneration(1))
+  })
+  let after = snapshot_handle.read().unwrap()
+  let after_sources = after.sources()
+  assert_true(
+    after_sources.any(source => {
+      source.source() == handle_a.editor.parser_source_id() &&
+      source.version() == handle_a.editor.get_version()
+    }),
+  )
+  assert_true(
+    after_sources.any(source => {
+      source.source() == handle_b.editor.parser_source_id() &&
+      source.version() == handle_b.editor.get_version()
+    }),
+  )
+  assert_eq(after.dependencies()[0].identity(), "dependency-1")
+  assert_eq(
+    after.configuration(),
+    @editor.DiagnosticConfigurationId("config-1"),
+  )
+  assert_eq(after.generation(), @editor.DiagnosticProducerGeneration(1))
+  assert_eq(before.dependencies()[0].identity(), "dependency-0")
+  assert_eq(
+    before.configuration(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  assert_eq(before.generation(), @editor.DiagnosticProducerGeneration(0))
+  snapshot_handle.dispose()
+  destroy_editor(raw_a)
+  destroy_editor(raw_b)
+}
+
+///|
+test "diagnostic input snapshot invalidates only for declared inputs" {
+  reset_coordinator_for_phase1_tests()
+  let raw_covered = create_editor("diagnostic_snapshot_covered")
+  let raw_uncovered = create_editor("diagnostic_snapshot_uncovered")
+  let covered = lambda_registry.get(raw_covered).unwrap()
+  let uncovered = lambda_registry.get(raw_uncovered).unwrap()
+  let dependency_identity = @incr.Input(coordinator.runtime(), "dependency-0")
+  let dependency = DiagnosticPublicationDependencyInput(
+    @editor.DiagnosticDependencyId("workspace"),
+    dependency_identity,
+  )
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let snapshot_handle = register_diagnostic_publication_input_snapshot(
+    [covered],
+    [dependency],
+    configuration,
+    @editor.DiagnosticProducerId("lambda-typecheck"),
+    generation,
+  ).unwrap()
+  let initial = snapshot_handle.read().unwrap()
+  uncovered.editor.set_text("unrelated")
+  assert_eq(snapshot_handle.read().unwrap(), initial)
+  covered.editor.set_text("covered")
+  let after_source = snapshot_handle.read().unwrap()
+  assert_true(after_source != initial)
+  dependency_identity.set("dependency-1")
+  let after_dependency = snapshot_handle.read().unwrap()
+  assert_true(after_dependency != after_source)
+  configuration.set(@editor.DiagnosticConfigurationId("config-1"))
+  let after_configuration = snapshot_handle.read().unwrap()
+  assert_true(after_configuration != after_dependency)
+  generation.set(@editor.DiagnosticProducerGeneration(1))
+  let after_generation = snapshot_handle.read().unwrap()
+  assert_true(after_generation != after_configuration)
+  assert_eq(initial.dependencies()[0].identity(), "dependency-0")
+  assert_eq(
+    initial.configuration(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  assert_eq(initial.generation(), @editor.DiagnosticProducerGeneration(0))
+  snapshot_handle.dispose()
+  destroy_editor(raw_covered)
+  destroy_editor(raw_uncovered)
+}
+
+///|
+test "duplicate source coverage is rejected before coordinator mutation" {
+  reset_coordinator_for_phase1_tests()
+  let raw_handle = create_editor("diagnostic_snapshot_duplicate_source")
+  let editor_handle = lambda_registry.get(raw_handle).unwrap()
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  match
+    register_diagnostic_publication_input_snapshot(
+      [editor_handle, editor_handle],
+      [],
+      configuration,
+      @editor.DiagnosticProducerId("lambda-typecheck"),
+      generation,
+    ) {
+    Err(InvalidInput(@editor.DuplicateSource(_))) => ()
+    Err(error) => fail("expected duplicate source, got \{error}")
+    Ok(_) => fail("expected duplicate source rejection")
+  }
+  match coordinator.destroy_editor(editor_handle.editor_id) {
+    Ok(_) => ()
+    Err(report) =>
+      fail("duplicate validation leaked coordinator state: \{report}")
+  }
+  drain_lambda_handle_after_direct_coordinator_destroy(
+    raw_handle, editor_handle,
+  )
+}
+
+///|
+test "duplicate dependency coverage is rejected before coordinator mutation" {
+  reset_coordinator_for_phase1_tests()
+  let raw_handle = create_editor("diagnostic_snapshot_duplicate_dependency")
+  let editor_handle = lambda_registry.get(raw_handle).unwrap()
+  let dependency = DiagnosticPublicationDependencyInput(
+    @editor.DiagnosticDependencyId("workspace"),
+    @incr.Input(coordinator.runtime(), "dependency-0"),
+  )
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  match
+    register_diagnostic_publication_input_snapshot(
+      [editor_handle],
+      [dependency, dependency],
+      configuration,
+      @editor.DiagnosticProducerId("lambda-typecheck"),
+      generation,
+    ) {
+    Err(InvalidInput(@editor.DuplicateDependency(_))) => ()
+    Err(error) => fail("expected duplicate dependency, got \{error}")
+    Ok(_) => fail("expected duplicate dependency rejection")
+  }
+  match coordinator.destroy_editor(editor_handle.editor_id) {
+    Ok(_) => ()
+    Err(report) =>
+      fail("duplicate validation leaked coordinator state: \{report}")
+  }
+  drain_lambda_handle_after_direct_coordinator_destroy(
+    raw_handle, editor_handle,
+  )
+}
+
+///|
+test "diagnostic snapshot handle owns symmetric idempotent lifecycle" {
+  reset_coordinator_for_phase1_tests()
+  let raw_handle = create_editor("diagnostic_snapshot_lifecycle")
+  let editor_handle = lambda_registry.get(raw_handle).unwrap()
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let snapshot_handle = register_diagnostic_publication_input_snapshot(
+    [editor_handle],
+    [],
+    configuration,
+    @editor.DiagnosticProducerId("lambda-typecheck"),
+    generation,
+  ).unwrap()
+  match coordinator.destroy_editor(editor_handle.editor_id) {
+    Err(report) => {
+      assert_eq(report.kind, @workspace.DestroyWhileDependedUpon)
+      @debug.assert_eq(report.cell_id, Some(snapshot_handle.id()))
+    }
+    Ok(_) => fail("expected live snapshot handle to protect editor")
+  }
+  let before = snapshot_handle.read().unwrap()
+  editor_handle.editor.set_text("still alive")
+  assert_true(snapshot_handle.read().unwrap() != before)
+  snapshot_handle.dispose()
+  snapshot_handle.dispose()
+  match coordinator.destroy_editor(editor_handle.editor_id) {
+    Ok(_) => ()
+    Err(report) => fail("expected destroy after snapshot disposal: \{report}")
+  }
+  drain_lambda_handle_after_direct_coordinator_destroy(
+    raw_handle, editor_handle,
+  )
+}
+
+///|
+test "diagnostic snapshot registration preserves typed coordinator failures" {
+  reset_coordinator_for_phase1_tests()
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let producer = @editor.DiagnosticProducerId("lambda-typecheck")
+  let raw_dead = create_editor("diagnostic_snapshot_dead")
+  let dead = lambda_registry.get(raw_dead).unwrap()
+  coordinator.destroy_editor(dead.editor_id).unwrap()
+  match
+    register_diagnostic_publication_input_snapshot(
+      [dead],
+      [],
+      configuration,
+      producer,
+      generation,
+    ) {
+    Err(Coordinator(report)) =>
+      assert_eq(report.kind, @workspace.EditorDestroyed)
+    Err(error) => fail("expected EditorDestroyed, got \{error}")
+    Ok(handle) => {
+      handle.dispose()
+      fail("expected destroyed editor rejection")
+    }
+  }
+  drain_lambda_handle_after_direct_coordinator_destroy(raw_dead, dead)
+  let raw_a = create_editor("diagnostic_snapshot_foreign_a")
+  let raw_b = create_editor("diagnostic_snapshot_foreign_b")
+  let handle_a = lambda_registry.get(raw_a).unwrap()
+  let handle_b = lambda_registry.get(raw_b).unwrap()
+  let foreign : LambdaHandle = {
+    editor: handle_a.editor,
+    companion: handle_a.companion,
+    editor_id: handle_a.editor_id,
+    cells: handle_b.cells,
+  }
+  match
+    register_diagnostic_publication_input_snapshot(
+      [foreign],
+      [],
+      configuration,
+      producer,
+      generation,
+    ) {
+    Err(Coordinator(report)) =>
+      assert_eq(report.kind, @workspace.CellNotInProtectedSurface)
+    Err(error) => fail("expected CellNotInProtectedSurface, got \{error}")
+    Ok(handle) => {
+      handle.dispose()
+      fail("expected foreign cell rejection")
+    }
+  }
+  destroy_editor(raw_a)
+  destroy_editor(raw_b)
+  let raw_disposed = create_editor("diagnostic_snapshot_disposed")
+  let disposed = lambda_registry.get(raw_disposed).unwrap()
+  (disposed.cells.diagnostic_source_revision.dispose)()
+  match
+    register_diagnostic_publication_input_snapshot(
+      [disposed],
+      [],
+      configuration,
+      producer,
+      generation,
+    ) {
+    Err(Coordinator(report)) =>
+      assert_eq(report.kind, @workspace.ProtectedCellDisposed)
+    Err(error) => fail("expected ProtectedCellDisposed, got \{error}")
+    Ok(handle) => {
+      handle.dispose()
+      fail("expected disposed protected cell rejection")
+    }
+  }
+  destroy_editor(raw_disposed)
+}
+
+///|
+test "two producers capture one source without sharing producer identity" {
+  reset_coordinator_for_phase1_tests()
+  let raw_handle = create_editor("diagnostic_snapshot_two_producers")
+  let editor_handle = lambda_registry.get(raw_handle).unwrap()
+  let configuration = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticConfigurationId("config-0"),
+  )
+  let generation_a = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let generation_b = @incr.Input(
+    coordinator.runtime(),
+    @editor.DiagnosticProducerGeneration(0),
+  )
+  let handle_a = register_diagnostic_publication_input_snapshot(
+    [editor_handle],
+    [],
+    configuration,
+    @editor.DiagnosticProducerId("producer-a"),
+    generation_a,
+  ).unwrap()
+  let handle_b = register_diagnostic_publication_input_snapshot(
+    [editor_handle],
+    [],
+    configuration,
+    @editor.DiagnosticProducerId("producer-b"),
+    generation_b,
+  ).unwrap()
+  let snapshot_a = handle_a.read().unwrap()
+  let snapshot_b = handle_b.read().unwrap()
+  assert_true(snapshot_a.producer() != snapshot_b.producer())
+  assert_eq(snapshot_a.sources(), snapshot_b.sources())
+  handle_a.dispose()
+  handle_b.dispose()
+  destroy_editor(raw_handle)
+}

--- a/ffi/lambda/lifecycle_phase1_wbtest.mbt
+++ b/ffi/lambda/lifecycle_phase1_wbtest.mbt
@@ -44,8 +44,15 @@ test "spec §12 #1: each protected cell reads through read_protected" {
   let id = h.editor_id
   // Spec compliance: every cell wired into the bundle must reach
   // `read_protected` with Ok(_) on a freshly-created editor. Reading
-  // all 9 (not a spot-check) guarantees a wiring defect on any single
+  // all 10 (not a spot-check) guarantees a wiring defect on any single
   // cell fails this test instead of slipping past.
+  match coordinator.read_protected(id, h.cells.diagnostic_source_revision) {
+    Ok(source_revision) => {
+      assert_eq(source_revision.source(), h.editor.parser_source_id())
+      assert_eq(source_revision.version(), h.editor.get_version())
+    }
+    Err(report) => fail("diagnostic_source_revision: \{report}")
+  }
   match coordinator.read_protected(id, h.cells.parser_syntax_tree) {
     Ok(_) => ()
     Err(report) => fail("parser_syntax_tree: \{report}")

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -18,8 +18,10 @@ import {
   "dowdiness/seam",
   "dowdiness/event-graph-walker/text",
   "dowdiness/analysis" @facts,
+  "dowdiness/incr",
   "moonbitlang/async/js_async",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
 }
@@ -27,11 +29,6 @@ import {
 import {
   "dowdiness/canopy/protocol/wire",
 } for "test"
-
-import {
-  "dowdiness/incr",
-  "moonbitlang/core/debug",
-} for "wbtest"
 
 // `cells` field of LambdaHandle is read in production by Phase 1b accessors
 // (`get_diagnostics_json`, view/pretty/semantic projection accessors, and

--- a/ffi/lambda/protected_cells.mbt
+++ b/ffi/lambda/protected_cells.mbt
@@ -16,6 +16,9 @@
 /// cross-package consumer (e.g., a separate workspace introspection
 /// crate) needs the bundle, promote to `pub` then.
 priv struct LambdaProtectedCells {
+  diagnostic_source_revision : @workspace.ProtectedCell[
+    @editor.DiagnosticPublicationSourceRevision,
+  ]
   parser_syntax_tree : @workspace.ProtectedCell[@seam.SyntaxNode]
   parser_ast : @workspace.ProtectedCell[@ast.Term]
   parser_source : @workspace.ProtectedCell[String]
@@ -35,6 +38,10 @@ fn LambdaProtectedCells::LambdaProtectedCells(
   companion : @lang_lambda.LambdaCompanion,
 ) -> LambdaProtectedCells {
   {
+    diagnostic_source_revision: @workspace.ProtectedCell::from_derived(
+      "diagnostic_publication_source_revision",
+      editor.diagnostic_publication_source_revision(),
+    ),
     parser_syntax_tree: @workspace.ProtectedCell::from_derived(
       "parser_syntax_view",
       editor.parser_syntax_tree(),
@@ -81,6 +88,7 @@ fn LambdaProtectedCells::to_protected_reads(
   self : LambdaProtectedCells,
 ) -> Array[@workspace.ProtectedRead] {
   [
+    self.diagnostic_source_revision.erase(),
     self.parser_syntax_tree.erase(),
     self.parser_ast.erase(),
     self.parser_source.erase(),


### PR DESCRIPTION
## Summary

- add a host-owned `DiagnosticPublicationInputSnapshot` that atomically captures declared source causal versions, dependency fingerprints, configuration identity, producer identity, and producer generation
- expose a reactive CRDT-version authority from `SyncEditor`, including causally newer states whose visible text is unchanged, and register it through Lambda's existing protected workspace-cell lifecycle
- validate and deterministically normalize coverage in a pure constructor, retain no source text or parser/protocol values, and return defensive copies of owned arrays

Closes #1096

## UI and review evidence

N/A — host/editor MoonBit boundary only; no UI or visual changes.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyncEditor::parser_source_id`, `TextState::version` | `editor`, `event-graph-walker/text` | Yes | stable source identity plus causal revision authority |
| `Coordinator::register_workspace_cell`, `WorkspaceCellHandle` | `lib/workspace` | Yes | single-read capture and symmetric protected-cell lifecycle |
| `Runtime::batch`, `Input::get`, `Input::set` | `lib/incr` | Yes | coherent coupled updates and reactive causal-version invalidation |
| `Array::copy`, `Array::sort_by`, `Set::add_and_check` | MoonBit core | Yes | detached deterministic collections and duplicate validation |
| `Result`, `Option` | MoonBit core | Yes | typed host/domain failure flow and lookups |
| `String`/comparison | MoonBit core | Yes | stable lexical ordering of safe identities |
| `StringView`, `Bytes`/`BytesView`, `Buffer`/`StringBuilder`, numeric helpers | MoonBit core | No | snapshot carries typed identities and causal versions, not encoded text/bytes or arithmetic |
| `analysis::SourceSnapshot` | `lib/analysis` | No | hash/length fact-validation semantics do not provide causal document identity |
| cognition provider snapshots/revisions | `lib/cognition` | No | wrong domain owner and would create a false dependency |
| separate eager `Coordinator::read_protected` values | `lib/workspace` | Preflight only | lifecycle validation is reused, but eager values are never snapshot authority because they cannot prove one coherent tuple |

New helpers added (if any):

- typed custom constructors/accessors for producer, dependency, configuration, generation, source revision, and the snapshot: required to preserve distinct identities while keeping fields private
- `register_diagnostic_publication_input_snapshot`: Lambda host shell that validates declared coverage before registration and returns exactly one existing `WorkspaceCellHandle`
- no new low-level collection loop or diagnostic-specific transaction/read operation; remaining mutation is limited to incremental inputs, coordinator lifecycle, and local builders returning detached values

## Validation scope

Boundary matrix / first failing regression:

- one real editor captures stable source ID plus causal version
- A0 → A1 → A0 remains causally distinct
- causally newer remote sync with identical visible text invalidates the revision view
- two sources plus dependency/configuration/generation update as one runtime batch
- covered source/dependency/configuration/generation each invalidate; uncovered source does not
- duplicate source/dependency coverage fails before coordinator mutation
- normalized ordering and constructor/accessor ownership are deterministic and detached
- live/idempotently disposed handles protect and release editor lifecycle
- destroyed, foreign, and disposed protected cells preserve typed coordinator failures
- local text, structural edit, undo, redo, and remote sync mutation paths invalidate
- two producer identities can independently cover one source

The first failing tests were added at the source-revision and real Lambda workspace-cell seams. Independent reviews found and drove fixes for private array ownership and version-only CRDT invalidation; correctness, MoonBit ownership/idioms, MoonBit API semantics, and exported boundary reviews all passed afterward.

Target packages:

- `editor`
- `ffi/lambda`

Additional conditional gates:

- `moon test editor/diagnostic_publication_input_wbtest.mbt --target native --release`
- generated `editor/pkg.generated.mbti` reviewed: private fields, no source text, parser/CST/AST/node/scheduler/protocol types, or unintended trait-bound widening

## PR-ready evidence

Validated HEAD: `bb86cd48c8b381725f03e9677e627d6fd9f75c34`

Validated base: `origin/main@9ff805e884c226b4541c5101819b7abf764d3a82`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target editor \
  --target ffi/lambda
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote. (No submodule pointer changed.)
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured diagnostic publication inputs for sources, dependencies, producers, generations, and configurations.
  * Added validation that rejects missing sources and duplicate source or dependency identities.
  * Added deterministic ordering and safe access to diagnostic publication data.
  * Diagnostic source revisions now update automatically after edits, undo/redo, remote synchronization, and meaningful document changes.
  * Added support for tracking diagnostic publication state through protected editor data.

* **Bug Fixes**
  * Improved consistency of diagnostic updates across synchronized editing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->