### PR TITLE
feat(lambda): add structural search results UI

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -657,7 +657,13 @@ The [moji API spec](plans/2026-05-10-moji-api-spec.md) is now
   Shipped: PR #699 added `SourceSnapshot::matches`; PR #704 clears stale lambda pattern facts before view patches are computed.
 
 - [x] Add structural-search match list projection (#695).
-  Shipped: PR #699 — `facts_to_match_list` supplies `from`/`to`/`pattern_id` for future host list/jump rendering. Host-side list UI remains a follow-up.
+  Shipped: PR #699 — `facts_to_match_list` supplies normalized
+  `from`/`to`/`pattern_id` entries for host rendering.
+
+- [x] Add structural-search host match list and jump-to-range UI (#818).
+  The Lambda host renders current facts with source-line context, clears stale
+  results while analysis is pending, and selects the normalized UTF-16 range
+  without adding a protocol variant.
 
 - [ ] Consolidate Lambda name resolution on `lang/lambda/scope` (#129).
   Why: edit free-variable guards and module-end lookup still carry local name-resolution walks that can drift from the canonical scope graph.

--- a/docs/design/analysis-query-layer.md
+++ b/docs/design/analysis-query-layer.md
@@ -378,6 +378,5 @@ intent-level operations.
 - Stale provider results are rejected deterministically. ✅
 - Byte offsets are converted to UTF-16 ranges before entering analysis state. ✅
 - Non-ASCII test cases prove range conversion correctness. ✅
-- The UI can list matches and jump to a normalized range. *(Data projection is
-  available; host-side list/jump rendering remains a follow-up.)*
+- The UI can list matches and jump to a normalized range. ✅
 - No changes are required to the public protocol. ✅

--- a/docs/research/2026-07-25-waku-demo-behavior-contracts.md
+++ b/docs/research/2026-07-25-waku-demo-behavior-contracts.md
@@ -69,9 +69,11 @@ semantics ([tests](../../examples/web/tests/lambda-editor.spec.ts#L44-L52)).
 ### Existing verification
 
 The Playwright suite covers page errors, presets, AST rendering, formatted
-output, clean and failing type checks, parse-error suppression, and the AST
-Grep HTTP method/empty-input contract
-([tests](../../examples/web/tests/lambda-editor.spec.ts#L29-L163)).
+output, clean and failing type checks, parse-error suppression, the AST Grep
+HTTP method/empty-input contract, and current/stale structural-match list and
+jump behavior
+([tests](../../examples/web/tests/lambda-editor.spec.ts),
+[route tests](../../examples/web/waku-tests/lambda-route.spec.ts)).
 
 ### Development/production split
 
@@ -79,9 +81,9 @@ The server adapter is `apply: 'serve'`
 ([adapter](../../examples/web/server/vite/ast-grep.ts#L13-L20)), and the browser
 runner returns an empty match list when `import.meta.env.DEV` is false
 ([runner](../../examples/web/src/features/lambda/browser/ast-grep-runner.ts#L16-L21)).
-The collaboration panel exists in the route-owned shell, but the current Lambda
-mount binds only the editor and preset buttons. Signaling files remain separate integration
-shells outside the browser graph
+The collaboration panel exists in the route-owned shell. The current Lambda
+mount binds the editor, preset buttons, and structural-match result list.
+Signaling files remain separate integration shells outside the browser graph
 ([route](../../examples/web/src/pages/ml.tsx),
 [client mount](../../examples/web/src/features/lambda/route/lambda-client.tsx#L20-L53),
 [map](../../examples/web/MODULE_MAP.md)).

--- a/examples/ideal/export-manifest.json
+++ b/examples/ideal/export-manifest.json
@@ -69,6 +69,7 @@
     "get_view_tree_json",
     "compute_view_patches_json",
     "apply_ast_grep_results_json",
+    "get_pattern_matches_json",
     "handle_text_intent",
     "handle_text_intent_checked",
     "handle_diagnostic_fix_intent",

--- a/examples/web/src/features/lambda/browser/editor.ts
+++ b/examples/web/src/features/lambda/browser/editor.ts
@@ -163,6 +163,7 @@ export function mountLambdaEditor(
         );
         if (result !== 'ok') {
           console.warn(`ast-grep analysis rejected: ${result}`);
+          renderStructuralSearchState('Structural search unavailable');
           return;
         }
         const patches: ViewPatch[] = JSON.parse(

--- a/examples/web/src/features/lambda/browser/editor.ts
+++ b/examples/web/src/features/lambda/browser/editor.ts
@@ -11,6 +11,17 @@ import { runAnalysis } from './ast-grep-runner';
 export type LambdaEditorRuntime = typeof import('@moonbit/crdt-lambda');
 export type GraphvizRuntime = typeof import('@moonbit/graphviz');
 
+type PatternMatchEntry = {
+  from: number;
+  to: number;
+  pattern_id: string;
+};
+
+type StructuralSearchResult = PatternMatchEntry & {
+  line: number;
+  snippet: string;
+};
+
 export function mountLambdaEditor(
   root: Document | HTMLElement = globalThis.document,
   restoredSnapshot: unknown,
@@ -32,6 +43,8 @@ export function mountLambdaEditor(
   const astOutputEl = must<HTMLElement>('#ast-output');
   const errorEl = must<HTMLUListElement>('#error-output');
   const statusEl = must<HTMLElement>('#status');
+  const structuralSearchStatusEl = must<HTMLElement>('#structural-search-status');
+  const structuralSearchResultsEl = must<HTMLOListElement>('#structural-search-results');
   const exampleButtons = Array.from(root.querySelectorAll<HTMLButtonElement>('.example-btn'));
   const listenerAbort = new window.AbortController();
   const agentId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
@@ -91,8 +104,39 @@ export function mountLambdaEditor(
     const analysisApi = crdt as LambdaEditorRuntime & {
       apply_ast_grep_results_json(handle: number, matchesJson: string): string;
       compute_view_patches_json(handle: number): string;
+      get_pattern_matches_json(handle: number): string;
     };
     let lastText = '';
+
+    function renderStructuralSearchState(message: string): void {
+      structuralSearchResultsEl.replaceChildren();
+      structuralSearchStatusEl.textContent = message;
+    }
+
+    function renderStructuralMatches(source: string): void {
+      const entries = JSON.parse(
+        analysisApi.get_pattern_matches_json(handle),
+      ) as PatternMatchEntry[];
+      const results = toStructuralSearchResults(source, entries);
+      structuralSearchResultsEl.replaceChildren(...results.map((result) => {
+        const item = document.createElement('li');
+        const button = document.createElement('button');
+        const meta = document.createElement('span');
+        const snippet = document.createElement('code');
+        button.type = 'button';
+        button.dataset.from = String(result.from);
+        button.dataset.to = String(result.to);
+        meta.className = 'structural-match-meta';
+        meta.textContent = `${result.pattern_id} · L${result.line}`;
+        snippet.textContent = result.snippet;
+        button.append(meta, snippet);
+        item.append(button);
+        return item;
+      }));
+      structuralSearchStatusEl.textContent = results.length === 0
+        ? 'No structural matches'
+        : `${results.length} structural ${results.length === 1 ? 'match' : 'matches'}`;
+    }
 
     function applyDecorationPatches(patches: ViewPatch[]): void {
       const decorationPatch = patches.reduce<
@@ -125,8 +169,10 @@ export function mountLambdaEditor(
           analysisApi.compute_view_patches_json(handle),
         );
         applyDecorationPatches(patches);
+        renderStructuralMatches(text);
       } catch (error) {
         if (controller.signal.aborted || disposed || generation !== analysisGeneration) return;
+        renderStructuralSearchState('Structural search unavailable');
         console.warn('ast-grep analysis failed', error);
       } finally {
         if (analysisAbortController === controller) analysisAbortController = null;
@@ -154,6 +200,7 @@ export function mountLambdaEditor(
           analysisApi.compute_view_patches_json(handle),
         );
         applyDecorationPatches(patches);
+        renderStructuralSearchState('Searching…');
         scheduleAnalysis(text);
       }
 
@@ -199,6 +246,17 @@ export function mountLambdaEditor(
         updateUI();
       });
     }, { signal: listenerAbort.signal });
+    structuralSearchResultsEl.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof window.Element)) return;
+      const button = target.closest<HTMLButtonElement>('button[data-from][data-to]');
+      if (button === null) return;
+      const from = Number(button.dataset.from);
+      const to = Number(button.dataset.to);
+      if (selectUtf16Range(editorEl, from, to)) {
+        editorEl.scrollIntoView({ block: 'nearest' });
+      }
+    }, { signal: listenerAbort.signal });
     exampleButtons.forEach((button) => {
       button.addEventListener('click', () => {
         const example = button.dataset.example;
@@ -235,4 +293,72 @@ function escapeHTML(text: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+}
+
+function toStructuralSearchResults(
+  source: string,
+  entries: PatternMatchEntry[],
+): StructuralSearchResult[] {
+  return entries.flatMap((entry) => {
+    if (
+      !Number.isInteger(entry.from) ||
+      !Number.isInteger(entry.to) ||
+      entry.from < 0 ||
+      entry.to < entry.from ||
+      entry.to > source.length
+    ) return [];
+    const lineStart = source.lastIndexOf('\n', entry.from - 1) + 1;
+    const followingBreak = source.indexOf('\n', entry.from);
+    const lineEnd = followingBreak === -1 ? source.length : followingBreak;
+    return [{
+      ...entry,
+      line: source.slice(0, entry.from).split('\n').length,
+      snippet: source.slice(lineStart, lineEnd).trim(),
+    }];
+  });
+}
+
+function selectUtf16Range(
+  editor: HTMLElement,
+  from: number,
+  to: number,
+): boolean {
+  const document = editor.ownerDocument;
+  const window = document.defaultView;
+  if (
+    window === null ||
+    !Number.isInteger(from) ||
+    !Number.isInteger(to) ||
+    from < 0 ||
+    to < from ||
+    to > (editor.textContent ?? '').length
+  ) return false;
+  const walker = document.createTreeWalker(editor, window.NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  let position = 0;
+  let start: { node: Text; offset: number } | null = null;
+  let end: { node: Text; offset: number } | null = null;
+  while (node !== null) {
+    const text = node as Text;
+    const nextPosition = position + text.data.length;
+    if (start === null && from <= nextPosition) {
+      start = { node: text, offset: from - position };
+    }
+    if (to <= nextPosition) {
+      end = { node: text, offset: to - position };
+      break;
+    }
+    position = nextPosition;
+    node = walker.nextNode();
+  }
+  if (start === null || end === null) return false;
+  const range = document.createRange();
+  range.setStart(start.node, start.offset);
+  range.setEnd(end.node, end.offset);
+  const selection = window.getSelection();
+  if (selection === null) return false;
+  editor.focus({ preventScroll: true });
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
 }

--- a/examples/web/src/features/lambda/browser/styles.css
+++ b/examples/web/src/features/lambda/browser/styles.css
@@ -112,6 +112,80 @@
       color: #6a6a6a;
     }
 
+    .structural-search {
+      display: grid;
+      gap: 8px;
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid #3c3c3c;
+    }
+
+    .structural-search-heading-row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .structural-search h2 {
+      color: #d4d4d4;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    #structural-search-status {
+      color: #858585;
+      font-size: 12px;
+    }
+
+    #structural-search-results {
+      display: grid;
+      gap: 4px;
+      max-height: 220px;
+      overflow-y: auto;
+      list-style: none;
+    }
+
+    #structural-search-results button {
+      display: grid;
+      grid-template-columns: minmax(150px, 0.4fr) minmax(0, 1fr);
+      align-items: baseline;
+      gap: 12px;
+      width: 100%;
+      padding: 7px 8px;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      background: transparent;
+      color: #d4d4d4;
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+    }
+
+    #structural-search-results button:hover {
+      background: #2d2d30;
+      border-color: #3c3c3c;
+    }
+
+    #structural-search-results button:focus-visible {
+      outline: 2px solid #82aaff;
+      outline-offset: -2px;
+    }
+
+    .structural-match-meta {
+      color: #82aaff;
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    #structural-search-results code {
+      overflow: hidden;
+      color: #c8c8c8;
+      font: inherit;
+      text-overflow: ellipsis;
+      white-space: pre;
+    }
+
     /* Syntax highlighting */
     .lambda { color: #c586c0; font-weight: bold; }
     .variable { color: #9cdcfe; }
@@ -354,6 +428,11 @@
 
       .editor-container {
         padding: 10px;
+      }
+
+      #structural-search-results button {
+        grid-template-columns: 1fr;
+        gap: 3px;
       }
 
       .examples-bar {

--- a/examples/web/src/features/lambda/route/lambda-route.tsx
+++ b/examples/web/src/features/lambda/route/lambda-route.tsx
@@ -84,6 +84,15 @@ IfThenElse  ::= 'if' Expression 'then' Expression 'else' Expression</pre>
                 <button className="example-btn" data-example="fn compose(f : Int -> Int, g : Int -> Int, x : Int) {&#10;  f (g x)&#10;}&#10;fn double(x : Int) { x + x }&#10;fn inc(x : Int) { x + 1 }&#10;let f = compose inc double&#10;f 5">Pipeline</button>
               </div>
               <div id="editor" contentEditable="plaintext-only" spellCheck={false} data-route-focus="editor"></div>
+              <section className="structural-search" aria-labelledby="structural-search-heading">
+                <div className="structural-search-heading-row">
+                  <h2 id="structural-search-heading">Structural matches</h2>
+                  <span id="structural-search-status" role="status" aria-live="polite">
+                    No structural matches
+                  </span>
+                </div>
+                <ol id="structural-search-results"></ol>
+              </section>
             </div>
 
             <div className="info-panel">

--- a/examples/web/waku-tests/lambda-route.spec.ts
+++ b/examples/web/waku-tests/lambda-route.spec.ts
@@ -222,3 +222,47 @@ test('aborts an in-flight development AST Grep request on route exit', async ({ 
   )).toBe(true);
   expect(pageErrors).toEqual([]);
 });
+
+test('lists structural matches, jumps to utf16 ranges, and removes stale results', async ({ page }) => {
+  const source = '😀\nfn alpha(x : Int) {\n  x\n}\nfn beta(y : Int) { y }';
+  let requestCount = 0;
+  let releaseSecondResponse: (() => void) | undefined;
+  const secondResponseGate = new Promise<void>((resolve) => {
+    releaseSecondResponse = resolve;
+  });
+  await page.route('**/api/ast-grep', async (route) => {
+    requestCount += 1;
+    if (requestCount > 1) await secondResponseGate;
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        matches: requestCount === 1
+          ? [
+              { byte_start: 5, byte_end: 30, pattern_id: 'moonbit-fn-def' },
+              { byte_start: 31, byte_end: 53, pattern_id: 'moonbit-fn-def' },
+            ]
+          : [],
+      }),
+    });
+  });
+
+  await page.goto('/ml');
+  await waitForLambdaMount(page);
+  await replaceSource(page, source);
+
+  const results = page.locator('#structural-search-results button');
+  await expect(results).toHaveCount(2);
+  await expect(results.first()).toContainText('L2');
+  await expect(results.first().locator('code')).toHaveText('fn alpha(x : Int) {');
+  await results.nth(1).click();
+  await expect(page.locator('#editor')).toBeFocused();
+  await expect.poll(() => page.evaluate(
+    () => window.getSelection()?.toString(),
+  )).toBe('fn beta(y : Int) { y }');
+
+  await replaceSource(page, `${source} `);
+  await expect(results).toHaveCount(0);
+  await expect(page.locator('#structural-search-status')).toHaveText('Searching…');
+  releaseSecondResponse?.();
+  await expect(page.locator('#structural-search-status')).toHaveText('No structural matches');
+});

--- a/examples/web/waku-tests/lambda-route.spec.ts
+++ b/examples/web/waku-tests/lambda-route.spec.ts
@@ -227,12 +227,19 @@ test('lists structural matches, jumps to utf16 ranges, and removes stale results
   const source = '😀\nfn alpha(x : Int) {\n  x\n}\nfn beta(y : Int) { y }';
   let requestCount = 0;
   let releaseSecondResponse: (() => void) | undefined;
+  let markSecondRequestStarted: (() => void) | undefined;
   const secondResponseGate = new Promise<void>((resolve) => {
     releaseSecondResponse = resolve;
   });
+  const secondRequestStarted = new Promise<void>((resolve) => {
+    markSecondRequestStarted = resolve;
+  });
   await page.route('**/api/ast-grep', async (route) => {
     requestCount += 1;
-    if (requestCount > 1) await secondResponseGate;
+    if (requestCount > 1) {
+      markSecondRequestStarted?.();
+      await secondResponseGate;
+    }
     await route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify({
@@ -263,6 +270,24 @@ test('lists structural matches, jumps to utf16 ranges, and removes stale results
   await replaceSource(page, `${source} `);
   await expect(results).toHaveCount(0);
   await expect(page.locator('#structural-search-status')).toHaveText('Searching…');
+  await secondRequestStarted;
   releaseSecondResponse?.();
   await expect(page.locator('#structural-search-status')).toHaveText('No structural matches');
+});
+
+test('reports structural-search provider rejections', async ({ page }) => {
+  await page.route('**/api/ast-grep', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        matches: [{ byte_start: 0, byte_end: 100_000, pattern_id: 'invalid' }],
+      }),
+    });
+  });
+
+  await page.goto('/ml');
+  await waitForLambdaMount(page);
+  await replaceSource(page, 'fn rejected(x : Int) { x }');
+  await expect(page.locator('#structural-search-status'))
+    .toHaveText('Structural search unavailable');
 });

--- a/ffi/lambda/analysis.mbt
+++ b/ffi/lambda/analysis.mbt
@@ -80,6 +80,16 @@ fn LambdaHandle::pattern_source_snapshot(
 }
 
 ///|
+fn is_utf8_byte_boundary(bytes : Bytes, offset : Int) -> Bool {
+  guard offset >= 0 && offset <= bytes.length() else { return false }
+  try @utf8.decode(bytes.view(end=offset)) catch {
+    _ => false
+  } noraise {
+    _ => true
+  }
+}
+
+///|
 /// Apply JSON-encoded ast-grep results for a lambda editor handle.
 ///
 /// The JSON shape is:
@@ -102,13 +112,15 @@ pub fn apply_ast_grep_results_json(
     Err(e) => return "parse error: " + e
   }
   let source = h.editor.get_text()
-  let source_byte_length = @utf8.encode(source).length()
+  let source_bytes = @utf8.encode(source)
   guard matches
     .iter()
     .all(entry => {
       entry.byte_start >= 0 &&
       entry.byte_start <= entry.byte_end &&
-      entry.byte_end <= source_byte_length
+      entry.byte_end <= source_bytes.length() &&
+      is_utf8_byte_boundary(source_bytes, entry.byte_start) &&
+      is_utf8_byte_boundary(source_bytes, entry.byte_end)
     }) else {
     return "parse error: match byte range is out of bounds"
   }

--- a/ffi/lambda/analysis.mbt
+++ b/ffi/lambda/analysis.mbt
@@ -68,6 +68,18 @@ fn parse_ast_grep_matches(
 }
 
 ///|
+fn LambdaHandle::pattern_source_snapshot(
+  self : LambdaHandle,
+  source : String,
+) -> @facts.SourceSnapshot {
+  @facts.SourceSnapshot::SourceSnapshot(
+    doc_id=self.editor_id.0.to_string(),
+    version=self.editor.get_version().to_json_string().hash(),
+    source~,
+  )
+}
+
+///|
 /// Apply JSON-encoded ast-grep results for a lambda editor handle.
 ///
 /// The JSON shape is:
@@ -90,14 +102,44 @@ pub fn apply_ast_grep_results_json(
     Err(e) => return "parse error: " + e
   }
   let source = h.editor.get_text()
-  let snapshot = @facts.SourceSnapshot::SourceSnapshot(
-    doc_id=h.editor_id.0.to_string(),
-    version=0,
-    source~,
-  )
+  let source_byte_length = @utf8.encode(source).length()
+  guard matches
+    .iter()
+    .all(entry => {
+      entry.byte_start >= 0 &&
+      entry.byte_start <= entry.byte_end &&
+      entry.byte_end <= source_byte_length
+    }) else {
+    return "parse error: match byte range is out of bounds"
+  }
+  let snapshot = h.pattern_source_snapshot(source)
   h.companion.set_pattern_analysis(
     @analysis.from_ast_grep_matches(matches, source, snapshot),
     snapshot,
   )
   "ok"
+}
+
+///|
+/// Return current structural-search matches as normalized UTF-16 ranges.
+/// Stale provider facts collapse to an empty array.
+pub fn get_pattern_matches_json(handle : Int) -> String {
+  match lambda_registry.get(handle) {
+    Some(h) => {
+      let source = h.editor.get_text()
+      let snapshot = h.pattern_source_snapshot(source)
+      Json::array(
+        h.companion
+        .get_pattern_matches(snapshot)
+        .map(entry => {
+          Json::object({
+            "from": entry.from.to_json(),
+            "to": entry.to.to_json(),
+            "pattern_id": entry.pattern_id.to_json(),
+          })
+        }),
+      ).stringify()
+    }
+    None => "[]"
+  }
 }

--- a/ffi/lambda/analysis_wbtest.mbt
+++ b/ffi/lambda/analysis_wbtest.mbt
@@ -69,7 +69,7 @@ test "ast-grep input rejects invalid byte ranges" {
   for
     matches_json in [
       "[{\"byte_start\":-1,\"byte_end\":1,\"pattern_id\":\"negative\"}]", "[{\"byte_start\":2,\"byte_end\":1,\"pattern_id\":\"reversed\"}]",
-      "[{\"byte_start\":0,\"byte_end\":4,\"pattern_id\":\"past-end\"}]",
+      "[{\"byte_start\":0,\"byte_end\":4,\"pattern_id\":\"past-end\"}]", "[{\"byte_start\":1,\"byte_end\":2,\"pattern_id\":\"split-codepoint\"}]",
     ] {
     inspect(
       apply_ast_grep_results_json(handle, matches_json),

--- a/ffi/lambda/analysis_wbtest.mbt
+++ b/ffi/lambda/analysis_wbtest.mbt
@@ -42,3 +42,39 @@ test "apply_ast_grep_results_json sanitizes pattern ids for css classes" {
   assert_true(patches.contains("\"data\":\"fn/def:α\""))
   destroy_editor(handle)
 }
+
+///|
+test "pattern match list exposes current utf16 ranges and drops stale facts" {
+  let handle = create_editor("analysis-match-list")
+  set_text(handle, "😀\nfn alpha(x : Int) { x }")
+  let result = apply_ast_grep_results_json(
+    handle, "[{\"byte_start\":5,\"byte_end\":13,\"pattern_id\":\"moonbit-fn-def\"}]",
+  )
+  inspect(result, content="ok")
+  let current = get_pattern_matches_json(handle)
+  assert_true(current.contains("\"from\":3"))
+  assert_true(current.contains("\"to\":11"))
+  assert_true(current.contains("\"pattern_id\":\"moonbit-fn-def\""))
+  set_text(handle, "😀\nfn alpha(x : Int) { x } ")
+  inspect(get_pattern_matches_json(handle), content="[]")
+  set_text(handle, "😀\nfn alpha(x : Int) { x }")
+  inspect(get_pattern_matches_json(handle), content="[]")
+  destroy_editor(handle)
+}
+
+///|
+test "ast-grep input rejects invalid byte ranges" {
+  let handle = create_editor("analysis-invalid-byte-ranges")
+  set_text(handle, "éx")
+  for
+    matches_json in [
+      "[{\"byte_start\":-1,\"byte_end\":1,\"pattern_id\":\"negative\"}]", "[{\"byte_start\":2,\"byte_end\":1,\"pattern_id\":\"reversed\"}]",
+      "[{\"byte_start\":0,\"byte_end\":4,\"pattern_id\":\"past-end\"}]",
+    ] {
+    inspect(
+      apply_ast_grep_results_json(handle, matches_json),
+      content="parse error: match byte range is out of bounds",
+    )
+  }
+  destroy_editor(handle)
+}

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -22,6 +22,7 @@ import {
   "moonbitlang/async/js_async",
   "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
 }
@@ -103,6 +104,7 @@ options(
         "get_view_tree_json",
         "compute_view_patches_json",
         "apply_ast_grep_results_json",
+        "get_pattern_matches_json",
         "handle_text_intent",
         "handle_text_intent_checked",
         "handle_diagnostic_fix_intent",

--- a/ffi/lambda/pkg.generated.mbti
+++ b/ffi/lambda/pkg.generated.mbti
@@ -65,6 +65,8 @@ pub fn get_errors_json(Int) -> String
 
 pub fn get_lambda_companion() -> @companion.LambdaCompanion?
 
+pub fn get_pattern_matches_json(Int) -> String
+
 pub fn get_pretty_view_json(Int) -> String
 
 pub fn get_proj_node_json(Int) -> String

--- a/ffi/lambda/view.mbt
+++ b/ffi/lambda/view.mbt
@@ -95,11 +95,7 @@ pub fn compute_view_patches_json(handle : Int) -> String {
         }
       }
       let source = h.editor.get_text()
-      let snapshot = @facts.SourceSnapshot::SourceSnapshot(
-        doc_id=h.editor_id.0.to_string(),
-        version=0,
-        source~,
-      )
+      let snapshot = h.pattern_source_snapshot(source)
       h.companion.clear_stale_pattern_analysis(snapshot)
       let state = lambda_registry.view_state(handle)
       let patches = @editor.compute_view_patches(state, h.editor)

--- a/lang/lambda/companion/analysis_projection.mbt
+++ b/lang/lambda/companion/analysis_projection.mbt
@@ -41,6 +41,17 @@ fn AnalysisProjection::clear_stale_pattern_analysis(
 }
 
 ///|
+fn AnalysisProjection::match_list(
+  self : AnalysisProjection,
+  current : @facts.SourceSnapshot,
+) -> Array[@analysis.MatchListEntry] {
+  match self.pattern_analysis_ref.val {
+    Some(analysis) => @analysis.facts_to_match_list(analysis.facts, current)
+    None => []
+  }
+}
+
+///|
 fn AnalysisProjection::decorations(
   self : AnalysisProjection,
   semantic_decorations : Array[@protocol.Decoration],

--- a/lang/lambda/companion/lambda_editor.mbt
+++ b/lang/lambda/companion/lambda_editor.mbt
@@ -71,6 +71,15 @@ pub fn LambdaCompanion::clear_stale_pattern_analysis(
 }
 
 ///|
+/// Project host-provided pattern facts that still match the current source.
+pub fn LambdaCompanion::get_pattern_matches(
+  self : LambdaCompanion,
+  current : @facts.SourceSnapshot,
+) -> Array[@analysis.MatchListEntry] {
+  self.analysis_projection.match_list(current)
+}
+
+///|
 pub fn LambdaCompanion::get_eval_results(
   self : LambdaCompanion,
 ) -> Array[@lambda_eval.EvalResult] {

--- a/lang/lambda/companion/pkg.generated.mbti
+++ b/lang/lambda/companion/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "dowdiness/canopy/lang/lambda/companion"
 
 import {
   "dowdiness/analysis",
+  "dowdiness/canopy/analysis_bridge",
   "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
   "dowdiness/canopy/lang/lambda/edits",
@@ -51,6 +52,7 @@ pub fn LambdaCompanion::dispose_analysis_attachment(Self) -> Unit
 pub fn LambdaCompanion::escalation_memo(Self) -> @cells.Derived[Array[@eval.EvalResult]]
 pub fn LambdaCompanion::get_eval_annotations(Self, @core.ProjNode[@ast.Term]?) -> Map[@core.NodeId, Array[@protocol.ViewAnnotation]]
 pub fn LambdaCompanion::get_eval_results(Self) -> Array[@eval.EvalResult]
+pub fn LambdaCompanion::get_pattern_matches(Self, @analysis.SourceSnapshot) -> Array[@analysis_bridge.MatchListEntry]
 pub fn LambdaCompanion::get_structured_changes(Self) -> Array[@core.StructuredChange]
 pub fn LambdaCompanion::set_pattern_analysis(Self, Array[@analysis.PatternMatchFact], @analysis.SourceSnapshot) -> Unit
 pub fn LambdaCompanion::typecheck_output(Self) -> @cells.Derived[@typecheck.ModuleTypeResult]


### PR DESCRIPTION
## Summary

- Render current structural-search facts as a compact, source-aware result list below the Lambda editor.
- Jump to each match's normalized UTF-16 range while clearing stale results during provider refreshes.
- Expose the existing `facts_to_match_list` projection through the Lambda companion/FFI, with stale-snapshot and invalid-byte-range regressions.

Closes #818

## UI and review evidence

- [x] No visible label was removed; result buttons have descriptive accessible names, visible focus, and a keyboard activation path.
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI at desktop and mobile widths.
- [x] Canopy UI and implementation rules were checked against `.impeccable.md` and `AGENTS.md`; no external recommendation is presented as a repository requirement.

The list stays visually subordinate to the editor, shows pattern id, source line, and a one-line snippet, and uses the full provider range for selection. Browser checks covered the real development endpoint, focus/selection behavior, the accessibility tree, and mobile reflow.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `facts_to_match_list` | `analysis_bridge/render.mbt` | Yes | Canonical filtering and normalized match-list projection. |
| `SourceSnapshot::matches` / `SourceSnapshot` | `lib/analysis/source_snapshot.mbt` | Yes | Preserves the existing current-versus-stale fact contract. |
| Editor generation/abort flow | `examples/web/src/features/lambda/browser/editor.ts` | Yes | Prevents late provider responses from repopulating stale UI. |
| Decoration payload parsing | Lambda FFI/view path | No | The list needs structured facts and should not reverse-engineer rendered decorations. |
| New protocol variant | Public protocol | No | Existing analysis facts and FFI projection are sufficient. |

MoonBit core APIs checked and reused: `@utf8.encode` for byte-length validation, `Array::iter`/`Iter::all` for provider-range validation, and existing `Json` builders/stringification for the FFI result. `StringView`/`BytesView` were considered but not used because the FFI only validates byte bounds and the browser already owns UTF-16 display slicing.

New helpers added:

- `AnalysisProjection::match_list` and `LambdaCompanion::get_pattern_matches`: thin ownership-boundary projections over `facts_to_match_list`.
- `LambdaHandle::pattern_source_snapshot`: binds editor id, canonical editor version, and source so an A→B→A edit cannot revive old facts.
- `toStructuralSearchResults`: pure browser-side validation and source-line derivation.
- `selectUtf16Range`: imperative DOM adapter that maps UTF-16 offsets across text nodes; its `TreeWalker` loop is necessary at the contenteditable boundary.

## Validation scope

Boundary matrix / first failing regression:

- current, stale, empty, non-ASCII, click-to-select, and disposed/late-result behavior
- first RED: missing match-list FFI; follow-up REDs covered multiline snippets, A→B→A stale revival, and invalid provider byte ranges

Target packages:

- `lang/lambda/companion`
- `ffi/lambda`

Additional conditional gates:

- full workspace `moon test` and `moon check`
- `npm run typecheck`
- `npm run check:boundaries`
- `npm run test:boundaries` (14 passed)
- `npm run test:foundation` (55 passed)
- Lambda Playwright suites (22 passed)
- export-manifest consistency check
- independent correctness, MoonBit/API, and idiom reviews; all initial and post-review closure reviews passed
- Slopless scan of changed English Markdown; no finding intersects changed lines

## PR-ready evidence

Validated HEAD: `e10dc9e5e0f2669f91dad6086a624842cd866d81`

Validated base: `origin/main@b806202cabb975b5e8aa29d45c95f8394f97abb0`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target lang/lambda/companion
./scripts/validate-pr-ready.sh --target ffi/lambda
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; it only adds the intended imports/signatures and does not widen trait bounds.
- [x] Submodule pointers are unchanged; all recorded commits were initialized and remote-reachable.
- [x] Validation was rerun after the candidate commit; no amend, rebase, cherry-pick, pointer, manifest, or generated-interface change followed it.
- [x] Independent review findings were resolved before final validation.
