### PR TITLE
feat(lambda): add Signal Lab preset

### DIFF
--- a/examples/web/src/features/lambda/route/lambda-route.tsx
+++ b/examples/web/src/features/lambda/route/lambda-route.tsx
@@ -1,5 +1,52 @@
 import { LambdaClient } from './lambda-client';
 
+const SIGNAL_LAB_EXAMPLE = `fn increment(x : Int) {
+  x + 1
+}
+
+fn decrement(x : Int) {
+  x - 1
+}
+
+fn double(x : Int) {
+  x + x
+}
+
+fn triple(x : Int) {
+  x + x + x
+}
+
+fn compose(f : Int -> Int, g : Int -> Int, x : Int) {
+  f (g x)
+}
+
+fn twice(f : Int -> Int, x : Int) {
+  f (f x)
+}
+
+fn fourTimes(f : Int -> Int, x : Int) {
+  twice f (twice f x)
+}
+
+fn choose(flag : Int, yes : Int, no : Int) {
+  if flag then {
+    yes
+  } else {
+    no
+  }
+}
+
+let calibrate = compose increment double
+let amplify = compose triple calibrate
+let stabilize = fourTimes increment
+
+let rawSignal = 4
+let stableSignal = stabilize rawSignal
+let amplifiedSignal = amplify stableSignal
+let output = choose 1 amplifiedSignal (decrement amplifiedSignal)
+
+output`;
+
 export function LambdaRoute() {
   return (
     <LambdaClient>
@@ -82,6 +129,7 @@ IfThenElse  ::= 'if' Expression 'then' Expression 'else' Expression</pre>
                 <button className="example-btn" data-example="fn add(x : Int, y : Int) { x + y }&#10;let add5 = add 5&#10;let sum = add5 10&#10;sum">Currying</button>
                 <button className="example-btn" data-example="fn choose(x : Int) { if x then {&#10;  x + 1&#10;} else {&#10;  42&#10;} }&#10;let a = choose 0&#10;let b = choose 5&#10;a + b">Conditional</button>
                 <button className="example-btn" data-example="fn compose(f : Int -> Int, g : Int -> Int, x : Int) {&#10;  f (g x)&#10;}&#10;fn double(x : Int) { x + x }&#10;fn inc(x : Int) { x + 1 }&#10;let f = compose inc double&#10;f 5">Pipeline</button>
+                <button className="example-btn" data-example={SIGNAL_LAB_EXAMPLE}>Signal Lab</button>
               </div>
               <div id="editor" contentEditable="plaintext-only" spellCheck={false} data-route-focus="editor"></div>
               <section className="structural-search" aria-labelledby="structural-search-heading">

--- a/examples/web/tests/lambda-editor.spec.ts
+++ b/examples/web/tests/lambda-editor.spec.ts
@@ -52,7 +52,14 @@ test.describe('Lambda Editor — Foundation', () => {
   });
 
   test('example buttons populate editor', async ({ page }) => {
-    const examples = ['Basics', 'Composition', 'Currying', 'Conditional', 'Pipeline'];
+    const examples = [
+      'Basics',
+      'Composition',
+      'Currying',
+      'Conditional',
+      'Pipeline',
+      'Signal Lab',
+    ];
     for (const name of examples) {
       await page.locator(`.example-btn:has-text("${name}")`).click();
       const text = await page.locator('#editor').textContent();
@@ -73,10 +80,17 @@ test.describe('Lambda Editor — Foundation', () => {
   });
 
   test('every example preset typechecks clean', async ({ page }) => {
-    // All five presets now carry `: Type` annotations on every lambda
+    // All presets carry the annotations required by their parameter forms.
     // Loading each route example must produce a clean
     // typecheck — no diagnostic error items.
-    const examples = ['Basics', 'Composition', 'Currying', 'Conditional', 'Pipeline'];
+    const examples = [
+      'Basics',
+      'Composition',
+      'Currying',
+      'Conditional',
+      'Pipeline',
+      'Signal Lab',
+    ];
     for (const name of examples) {
       await loadExample(page, name);
       await expect(page.locator('#error-output')).toContainText('No errors');

--- a/examples/web/waku-tests/lambda-route.spec.ts
+++ b/examples/web/waku-tests/lambda-route.spec.ts
@@ -94,6 +94,32 @@ test('reload clears Mini-ML route memory and creates a fresh editor', async ({ p
   expect(await page.locator('#status').textContent()).not.toBe(firstAgent);
 });
 
+test('loads the Signal Lab preset and exposes its function matches', async ({ page }) => {
+  await page.route('**/api/ast-grep', async (route) => {
+    const payload = route.request().postDataJSON() as { text?: unknown };
+    const text = typeof payload.text === 'string' ? payload.text : '';
+    const matches = Array.from(text.matchAll(/^fn .+$/gm), (match) => ({
+      byte_start: match.index,
+      byte_end: match.index + match[0].length,
+      pattern_id: 'moonbit-fn-def',
+    }));
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ matches }),
+    });
+  });
+  await page.goto('/ml');
+  await waitForLambdaMount(page);
+
+  await page.getByRole('button', { name: 'Signal Lab' }).click();
+
+  await expect(page.locator('#editor')).toContainText('fn fourTimes');
+  await expect(page.locator('#editor')).toContainText('let output = choose');
+  await expect(page.locator('#structural-search-results button')).toHaveCount(8);
+  await expect(page.locator('#structural-search-status')).toHaveText('8 structural matches');
+  await expect(page.locator('#error-output')).toHaveText('No errors');
+});
+
 test('repeated route cycles release the surface, overlay, frame, and timer', async ({ page }) => {
   const pageErrors: Error[] = [];
   page.on('pageerror', (error) => pageErrors.push(error));


### PR DESCRIPTION
## Summary

- Add a longer `Signal Lab` Mini-ML preset that demonstrates named functions, higher-order composition, repeated application, conditional selection, and a multi-stage signal pipeline.
- Extend both foundation and Waku route coverage so the preset populates the editor, typechecks without diagnostics, and exposes eight function matches.
- Keep Waku E2E deterministic on clean checkouts by stubbing the development-only ast-grep provider at the browser boundary.

## UI and review evidence

- N/A: no visible label was removed; the new control keeps its visible `Signal Lab` accessible name and reuses the existing keyboard-focusable button implementation.
- [x] The preset was rendered and activated in the real Waku UI; its existing `.example-btn` bounds, pointer behavior, and wrapping layout were preserved.
- [x] Repository claims in this PR refer to `AGENTS.md`; no external design standard is claimed.
- Independent correctness, UI-idiom, and CI-boundary reviews passed after the clean-checkout finding was resolved.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Existing `data-example` preset binding | `examples/web/src/features/lambda/route/lambda-route.tsx` and Lambda browser shell | Yes | Loads the preset through the same route as every existing example. |
| Existing `.example-btn` UI contract | `examples/web/src/features/lambda/browser/styles.css` | Yes | Preserves the current styling, focus, pointer, and reflow behavior. |
| Playwright `page.route` provider seam | `examples/web/waku-tests/lambda-route.spec.ts` | Yes | Makes the development-only structural-search result deterministic without requiring a gitignored grammar artifact. |

MoonBit core APIs checked: N/A — this change does not add or modify MoonBit code or data manipulation.

New helpers added: none. The preset is a route-local constant and the deterministic response stays inline in its single test.

## Validation scope

Boundary matrix / first failing regression:

- First RED: the browser test timed out while locating the absent `Signal Lab` button.
- Preset selection: clicking `Signal Lab` loads the expected `fourTimes` function and final `choose` pipeline.
- Language behavior: all six example presets populate the editor and typecheck without diagnostic errors.
- Structural analysis: the Waku route consumes eight deterministic, valid function ranges and renders eight results.
- Clean checkout: the Waku regression does not depend on `.ast-grep/tree-sitter-moonbit.so`.

Target packages:

- `--no-target "web-only Signal Lab preset and Playwright coverage"`

Additional conditional gates:

- `npm run typecheck`
- `npm run check:boundaries`
- `npm run test:boundaries` — 14 passed
- `npm run test:foundation` — 55 passed
- targeted Playwright regression — 2 passed
- independent correctness, UI-idiom, and CI-boundary review — pass

## PR-ready evidence

Validated HEAD: `e0faeeb5720a8919154952d9fd9f1bf40739bf69`

Validated base: `origin/main@35b01e16c99c9f15db468949704f17ceb44ac611`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --no-target "web-only Signal Lab preset and Playwright coverage"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] No `.mbti` file changed; the committed diff was checked for generated-interface drift.
- [x] No submodule pointer changed.
- [x] Validation was run after the final commit; no amend, rebase, cherry-pick, manifest, submodule, or generated-interface change followed.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Signal Lab** example showcasing arithmetic, composition, repeated application, conditionals, and signal-processing operations.
  * Added a Signal Lab preset button to quickly load the example into the editor.

* **Tests**
  * Added coverage confirming the preset loads correctly, produces expected structural matches, and executes without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->