### PR TITLE
feat(loomark): add typed Markdown foundations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@ examples/web/worker-configuration.d.ts whitespace=-blank-at-eol
 
 # MoonBit owns this empty generated interface and emits a final blank line.
 probe/diagnostic_portability/pkg.generated.mbti whitespace=-blank-at-eof
+
+# MoonBit owns these generated interfaces and emits a final blank line.
+editor/markdown/pkg.generated.mbti whitespace=-blank-at-eof
+loomark/core/pkg.generated.mbti whitespace=-blank-at-eof

--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -1,0 +1,211 @@
+///|
+/// A categorized failure at the headless Markdown editor boundary.
+pub(all) suberror MarkdownEditorError {
+  InvalidAgentId
+  InitializationFailed(detail~ : String)
+  ProjectionUnavailable
+  InvalidTextRange(start~ : Int, delete_len~ : Int, source_length~ : Int)
+  EditFailed(detail~ : String)
+}
+
+///|
+/// Opaque identity of a projected Markdown node.
+pub struct MarkdownNodeId {
+  priv value : @core.NodeId
+} derive(Eq, Debug)
+
+///|
+/// A caller-owned edit request lowered by the Markdown façade.
+pub(all) enum MarkdownEditRequest {
+  ReplaceSource(String)
+  ReplaceText(start~ : Int, delete_len~ : Int, inserted~ : String)
+  CommitEdit(node_id~ : MarkdownNodeId, new_text~ : String)
+  ChangeHeadingLevel(node_id~ : MarkdownNodeId, level~ : Int)
+  ToggleListItem(node_id~ : MarkdownNodeId)
+  Delete(node_id~ : MarkdownNodeId)
+  MergeWithPrevious(node_id~ : MarkdownNodeId)
+} derive(Eq, Debug)
+
+///|
+/// Immutable, façade-owned projection summary.
+pub struct MarkdownProjectionSnapshot {
+  priv root_id : MarkdownNodeId?
+  priv node_ids : @vector.Vector[MarkdownNodeId]
+} derive(Eq, Debug)
+
+///|
+pub fn MarkdownProjectionSnapshot::root_id(self : Self) -> MarkdownNodeId? {
+  self.root_id
+}
+
+///|
+pub fn MarkdownProjectionSnapshot::node_ids(
+  self : Self,
+) -> @vector.Vector[MarkdownNodeId] {
+  self.node_ids
+}
+
+///|
+/// An immutable source snapshot detached from the editor implementation.
+pub struct MarkdownDocumentSnapshot {
+  priv source : String
+  priv projection : MarkdownProjectionSnapshot
+} derive(Eq, Debug)
+
+///|
+pub fn MarkdownDocumentSnapshot::source(self : Self) -> String {
+  self.source
+}
+
+///|
+pub fn MarkdownDocumentSnapshot::projection(
+  self : Self,
+) -> MarkdownProjectionSnapshot {
+  self.projection
+}
+
+///|
+/// Result of one atomic editor commit.
+pub(all) enum MarkdownCommitResult {
+  Applied(MarkdownDocumentSnapshot)
+  Unchanged(MarkdownDocumentSnapshot)
+} derive(Eq, Debug)
+
+///|
+/// Opaque, headless Markdown editor façade.
+pub struct MarkdownEditor {
+  priv editor : @editor.SyncEditor[@md_markdown.Block]
+}
+
+///|
+/// Construct a Markdown editor and install its initial canonical source.
+pub fn MarkdownEditor::MarkdownEditor(
+  agent_id~ : String,
+  source~ : String,
+) -> MarkdownEditor raise MarkdownEditorError {
+  let editor = @md_companion.new_markdown_editor(agent_id) catch {
+    @text.TextError::EmptyReplicaId => raise MarkdownEditorError::InvalidAgentId
+    error =>
+      raise MarkdownEditorError::InitializationFailed(detail=error.message())
+  }
+  editor.set_text(source)
+  editor.refresh()
+  { editor, }
+}
+
+///|
+/// Read the last committed canonical source without exposing editor state.
+pub fn MarkdownEditor::snapshot(self : Self) -> MarkdownDocumentSnapshot {
+  {
+    source: self.editor.get_text(),
+    projection: projection_snapshot(self.editor),
+  }
+}
+
+///|
+/// Apply one façade-owned request atomically.
+pub fn MarkdownEditor::commit(
+  self : Self,
+  request : MarkdownEditRequest,
+) -> Result[MarkdownCommitResult, MarkdownEditorError] {
+  match request {
+    ReplaceSource(source) =>
+      if self.editor.get_text() == source {
+        Ok(MarkdownCommitResult::Unchanged(self.snapshot()))
+      } else {
+        self.editor.set_text(source)
+        self.editor.refresh()
+        Ok(MarkdownCommitResult::Applied(self.snapshot()))
+      }
+    ReplaceText(start~, delete_len~, inserted~) => {
+      let source = self.editor.get_text()
+      let source_length = source.length()
+      if start < 0 ||
+        delete_len < 0 ||
+        start > source_length ||
+        delete_len > source_length - start {
+        Err(
+          MarkdownEditorError::InvalidTextRange(
+            start~,
+            delete_len~,
+            source_length~,
+          ),
+        )
+      } else if self.editor.apply_text_edit_exact(
+          start, delete_len, inserted, 0,
+        ) {
+        self.editor.refresh()
+        let snapshot = self.snapshot()
+        if snapshot.source() == source {
+          Ok(MarkdownCommitResult::Unchanged(snapshot))
+        } else {
+          Ok(MarkdownCommitResult::Applied(snapshot))
+        }
+      } else {
+        Err(MarkdownEditorError::EditFailed(detail="text edit rejected"))
+      }
+    }
+    CommitEdit(node_id~, new_text~) =>
+      self.commit_structural(
+        @md_edits.MarkdownEditOp::CommitEdit(node_id=node_id.value, new_text~),
+      )
+    ChangeHeadingLevel(node_id~, level~) =>
+      self.commit_structural(
+        @md_edits.MarkdownEditOp::ChangeHeadingLevel(
+          node_id=node_id.value,
+          level~,
+        ),
+      )
+    ToggleListItem(node_id~) =>
+      self.commit_structural(
+        @md_edits.MarkdownEditOp::ToggleListItem(node_id=node_id.value),
+      )
+    Delete(node_id~) =>
+      self.commit_structural(
+        @md_edits.MarkdownEditOp::Delete(node_id=node_id.value),
+      )
+    MergeWithPrevious(node_id~) =>
+      self.commit_structural(
+        @md_edits.MarkdownEditOp::MergeWithPrevious(node_id=node_id.value),
+      )
+  }
+}
+
+///|
+/// Lower typed structural requests without exposing Tier-2 edit values.
+fn MarkdownEditor::commit_structural(
+  self : Self,
+  op : @md_edits.MarkdownEditOp,
+) -> Result[MarkdownCommitResult, MarkdownEditorError] {
+  let source = self.editor.get_text()
+  guard self.editor.get_proj_node() is Some(_) else {
+    return Err(MarkdownEditorError::ProjectionUnavailable)
+  }
+  match @md_companion.apply_markdown_edit(self.editor, op, 0) {
+    Err(detail) => Err(MarkdownEditorError::EditFailed(detail~))
+    Ok(_) => {
+      self.editor.refresh()
+      let snapshot = self.snapshot()
+      if snapshot.source() == source {
+        Ok(MarkdownCommitResult::Unchanged(snapshot))
+      } else {
+        Ok(MarkdownCommitResult::Applied(snapshot))
+      }
+    }
+  }
+}
+
+///|
+/// Copy only stable node identities into the façade snapshot.
+fn projection_snapshot(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+) -> MarkdownProjectionSnapshot {
+  match editor.get_proj_node() {
+    None => { root_id: None, node_ids: @vector.new() }
+    Some(root) => {
+      let ids : Array[MarkdownNodeId] = []
+      root.walk_preorder(node => ids.push({ value: node.id() }))
+      { root_id: Some({ value: root.id() }), node_ids: @vector.Vector(ids[:]) }
+    }
+  }
+}

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1,0 +1,154 @@
+///| The first public headless Markdown façade seam.
+
+///|
+test "headless facade commits exact source and exposes snapshot" {
+  let editor = try! MarkdownEditor(agent_id="red", source="before")
+  inspect(editor.snapshot().source(), content="before")
+
+  let result = editor.commit(
+    MarkdownEditRequest::ReplaceSource("# LF\n## CRLF\r\n### CR\rend"),
+  )
+
+  let after = editor.snapshot()
+  inspect(after.source(), content="# LF\n## CRLF\r\n### CR\rend")
+  match result {
+    Ok(MarkdownCommitResult::Applied(snapshot)) =>
+      assert_true(snapshot == after)
+    _ => fail("expected Applied")
+  }
+}
+
+///|
+test "headless facade reports unchanged source atomically" {
+  let editor = try! MarkdownEditor(agent_id="unchanged", source="before")
+  let before = editor.snapshot()
+  let result = editor.commit(MarkdownEditRequest::ReplaceSource("before"))
+
+  match result {
+    Ok(MarkdownCommitResult::Unchanged(snapshot)) =>
+      assert_true(snapshot == before)
+    _ => fail("expected Unchanged")
+  }
+  assert_true(editor.snapshot() == before)
+}
+
+///|
+test "headless facade preserves caller-owned ZWSP in exact source" {
+  let source = "Hello\u200Bworld\n"
+  let editor = try! MarkdownEditor(agent_id="zwsp", source~)
+
+  assert_eq(editor.snapshot().source(), source)
+  let result = editor.commit(MarkdownEditRequest::ReplaceSource(source))
+  match result {
+    Ok(MarkdownCommitResult::Unchanged(snapshot)) =>
+      assert_eq(snapshot.source(), source)
+    _ => fail("expected Unchanged")
+  }
+}
+
+///|
+test "headless facade applies UTF-16 exact text edits" {
+  let editor = try! MarkdownEditor(agent_id="utf16", source="A🤣B\r\n")
+
+  let result = editor.commit(
+    MarkdownEditRequest::ReplaceText(start=1, delete_len=2, inserted="é"),
+  )
+
+  let after = editor.snapshot()
+  inspect(after.source(), content="AéB\r\n")
+  match result {
+    Ok(MarkdownCommitResult::Applied(snapshot)) =>
+      assert_true(snapshot == after)
+    _ => fail("expected Applied")
+  }
+}
+
+///|
+test "invalid UTF-16 boundary leaves source unchanged" {
+  let editor = try! MarkdownEditor(
+    agent_id="invalid-range",
+    source="A🤣B\r\n",
+  )
+  let before = editor.snapshot()
+
+  let result = editor.commit(
+    MarkdownEditRequest::ReplaceText(start=2, delete_len=1, inserted="x"),
+  )
+
+  match result {
+    Err(MarkdownEditorError::EditFailed(_)) => ()
+    _ => fail("expected EditFailed")
+  }
+  assert_true(editor.snapshot() == before)
+}
+
+///|
+test "out of range text edit is categorized and preserves source" {
+  let editor = try! MarkdownEditor(agent_id="invalid-range", source="A\n")
+  let before = editor.snapshot()
+
+  let result = editor.commit(
+    MarkdownEditRequest::ReplaceText(start=3, delete_len=1, inserted="x"),
+  )
+
+  match result {
+    Err(MarkdownEditorError::InvalidTextRange(_)) => ()
+    _ => fail("expected InvalidTextRange")
+  }
+  assert_true(editor.snapshot() == before)
+}
+
+///|
+test "snapshot owns immutable projection identities" {
+  let editor = try! MarkdownEditor(
+    agent_id="projection",
+    source="# Heading\n\nBody\n",
+  )
+  let projection = editor.snapshot().projection()
+
+  assert_true(projection.root_id() is Some(_))
+  assert_true(projection.node_ids().length() >= 1)
+}
+
+///|
+test "unsupported typed edit preserves source and projection" {
+  let editor = try! MarkdownEditor(agent_id="unsupported", source="# Heading\n")
+  let stale_node_id = editor.snapshot().projection().node_ids().get(1).unwrap()
+  let replacement = editor.commit(MarkdownEditRequest::ReplaceSource(""))
+  assert_true(replacement is Ok(_))
+  let before = editor.snapshot()
+
+  let result = editor.commit(MarkdownEditRequest::Delete(node_id=stale_node_id))
+
+  match result {
+    Err(MarkdownEditorError::EditFailed(_)) => ()
+    _ => fail("expected EditFailed")
+  }
+  assert_true(editor.snapshot() == before)
+}
+
+///|
+test "supported typed delete lowers through the Markdown edit companion" {
+  let editor = try! MarkdownEditor(agent_id="delete", source="# Heading\n")
+  let ids = editor.snapshot().projection().node_ids()
+  let node_id = ids.get(1).unwrap()
+
+  let result = editor.commit(MarkdownEditRequest::Delete(node_id~))
+
+  assert_true(result is Ok(_))
+  inspect(editor.snapshot().source(), content="")
+}
+
+///|
+test "empty replica identity is a categorized construction failure" {
+  let result : Result[MarkdownEditor, MarkdownEditorError] = Ok(
+    MarkdownEditor(agent_id="", source=""),
+  ) catch {
+    error => Err(error)
+  }
+
+  match result {
+    Err(MarkdownEditorError::InvalidAgentId) => ()
+    _ => fail("expected InvalidAgentId")
+  }
+}

--- a/editor/markdown/moon.pkg
+++ b/editor/markdown/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "dowdiness/canopy/lang/markdown/companion" @md_companion,
+  "dowdiness/canopy/lang/markdown/edits" @md_edits,
+  "dowdiness/canopy/core",
+  "dowdiness/canopy/editor",
+  "dowdiness/markdown" @md_markdown,
+  "dowdiness/event-graph-walker/text",
+  "moonbitlang/core/immut/vector",
+}
+
+warnings = "-7-29"
+
+options(
+  is_main: false,
+)

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -1,0 +1,62 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/canopy/editor/markdown"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/immut/vector",
+}
+
+// Values
+
+// Errors
+pub(all) suberror MarkdownEditorError {
+  InvalidAgentId
+  InitializationFailed(detail~ : String)
+  ProjectionUnavailable
+  InvalidTextRange(start~ : Int, delete_len~ : Int, source_length~ : Int)
+  EditFailed(detail~ : String)
+}
+
+// Types and methods
+pub(all) enum MarkdownCommitResult {
+  Applied(MarkdownDocumentSnapshot)
+  Unchanged(MarkdownDocumentSnapshot)
+} derive(Eq, @debug.Debug)
+
+pub struct MarkdownDocumentSnapshot {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn MarkdownDocumentSnapshot::projection(Self) -> MarkdownProjectionSnapshot
+pub fn MarkdownDocumentSnapshot::source(Self) -> String
+
+pub(all) enum MarkdownEditRequest {
+  ReplaceSource(String)
+  ReplaceText(start~ : Int, delete_len~ : Int, inserted~ : String)
+  CommitEdit(node_id~ : MarkdownNodeId, new_text~ : String)
+  ChangeHeadingLevel(node_id~ : MarkdownNodeId, level~ : Int)
+  ToggleListItem(node_id~ : MarkdownNodeId)
+  Delete(node_id~ : MarkdownNodeId)
+  MergeWithPrevious(node_id~ : MarkdownNodeId)
+} derive(Eq, @debug.Debug)
+
+pub struct MarkdownEditor {
+  // private fields
+}
+pub fn MarkdownEditor::MarkdownEditor(agent_id~ : String, source~ : String) -> Self raise MarkdownEditorError
+pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError]
+pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
+
+pub struct MarkdownNodeId {
+  // private fields
+} derive(Eq, @debug.Debug)
+
+pub struct MarkdownProjectionSnapshot {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn MarkdownProjectionSnapshot::node_ids(Self) -> @vector.Vector[MarkdownNodeId]
+pub fn MarkdownProjectionSnapshot::root_id(Self) -> MarkdownNodeId?
+
+// Type aliases
+
+// Traits
+

--- a/loomark/core/application_core.mbt
+++ b/loomark/core/application_core.mbt
@@ -1,0 +1,153 @@
+///|
+/// Modes owned by the pure Loomark application core.
+pub(all) enum ApplicationMode {
+  Raw
+  Block
+  Preview
+} derive(Eq, Debug)
+
+///|
+/// Version of the application-owned snapshot value.
+pub const SNAPSHOT_VERSION : Int = 1
+
+///|
+/// Application state contains mode decisions only, never canonical source.
+pub struct ApplicationState {
+  priv mode : ApplicationMode
+} derive(Eq, Debug)
+
+///|
+pub fn ApplicationState::ApplicationState(
+  mode : ApplicationMode,
+) -> ApplicationState {
+  { mode, }
+}
+
+///|
+pub fn ApplicationState::mode(self : Self) -> ApplicationMode {
+  self.mode
+}
+
+///|
+/// The application-owned portion of a restorable session snapshot.
+pub struct ApplicationStateSnapshot {
+  priv version : Int
+  priv source : String
+  priv mode : ApplicationMode
+} derive(Eq, Debug)
+
+///|
+/// Construct a decoded snapshot for reducer validation.
+pub fn ApplicationStateSnapshot::ApplicationStateSnapshot(
+  version~ : Int,
+  source~ : String,
+  mode~ : ApplicationMode,
+) -> ApplicationStateSnapshot {
+  { version, source, mode }
+}
+
+///|
+pub fn ApplicationStateSnapshot::version(self : Self) -> Int {
+  self.version
+}
+
+///|
+pub fn ApplicationStateSnapshot::source(self : Self) -> String {
+  self.source
+}
+
+///|
+pub fn ApplicationStateSnapshot::mode(self : Self) -> ApplicationMode {
+  self.mode
+}
+
+///|
+pub fn ApplicationState::snapshot(
+  self : Self,
+  source : String,
+) -> ApplicationStateSnapshot {
+  { version: SNAPSHOT_VERSION, source, mode: self.mode }
+}
+
+///|
+/// Snapshot validation failures reported as immutable decisions.
+pub(all) enum SnapshotError {
+  UnsupportedSnapshotVersion(Int)
+} derive(Eq, Debug)
+
+///|
+/// Ordered decisions for the imperative editor/browser shell.
+pub(all) enum ApplicationDecision {
+  ReplaceCanonicalSource(String)
+  SnapshotRejected(SnapshotError)
+} derive(Eq, Debug)
+
+///|
+/// Events accepted by the pure reducer.
+pub(all) enum ApplicationEvent {
+  RequestCanonicalSource(source~ : String)
+  SelectMode(mode~ : ApplicationMode)
+  RestoreSnapshot(
+    snapshot~ : ApplicationStateSnapshot,
+    canonical_source~ : String
+  )
+} derive(Eq, Debug)
+
+///|
+/// Proposed next state and ordered shell decisions from one reduction.
+pub struct ProposedTransition {
+  priv state : ApplicationState
+  priv decisions : @vector.Vector[ApplicationDecision]
+}
+
+///|
+pub fn ProposedTransition::state(self : Self) -> ApplicationState {
+  self.state
+}
+
+///|
+pub fn ProposedTransition::decisions(
+  self : Self,
+) -> @vector.Vector[ApplicationDecision] {
+  self.decisions
+}
+
+///|
+/// Purely reduce an application event; no source/editor/runtime effect occurs.
+pub fn reduce(
+  state : ApplicationState,
+  event : ApplicationEvent,
+) -> ProposedTransition {
+  match event {
+    RequestCanonicalSource(source~) =>
+      {
+        state,
+        decisions: @vector.singleton(
+          ApplicationDecision::ReplaceCanonicalSource(source),
+        ),
+      }
+    SelectMode(mode~) => { state: { mode, }, decisions: @vector.new() }
+    RestoreSnapshot(snapshot~, canonical_source~) =>
+      if snapshot.version != SNAPSHOT_VERSION {
+        {
+          state,
+          decisions: @vector.singleton(
+            ApplicationDecision::SnapshotRejected(
+              SnapshotError::UnsupportedSnapshotVersion(snapshot.version),
+            ),
+          ),
+        }
+      } else {
+        {
+          state: { mode: snapshot.mode },
+          decisions: if snapshot.source != canonical_source {
+            @vector.singleton(
+              ApplicationDecision::ReplaceCanonicalSource(snapshot.source),
+            )
+          } else {
+            @vector.new()
+          },
+        }
+      }
+  }
+}

--- a/loomark/core/application_core_wbtest.mbt
+++ b/loomark/core/application_core_wbtest.mbt
@@ -1,0 +1,99 @@
+///| The pure core proposes source work without owning canonical source.
+
+///|
+test "source request yields an ordered replacement decision" {
+  let state = ApplicationState(Raw)
+  let transition = reduce(
+    state,
+    ApplicationEvent::RequestCanonicalSource(source="# New\r\n"),
+  )
+
+  assert_true(transition.state() == state)
+  assert_eq(transition.decisions().to_array(), [
+    ApplicationDecision::ReplaceCanonicalSource("# New\r\n"),
+  ])
+}
+
+///|
+test "mode selection changes only the proposed mode" {
+  let state = ApplicationState(Raw)
+  let transition = reduce(state, ApplicationEvent::SelectMode(mode=Preview))
+
+  assert_true(transition.state().mode() == Preview)
+  assert_true(transition.decisions().is_empty())
+
+  let repeated = reduce(
+    transition.state(),
+    ApplicationEvent::SelectMode(mode=Preview),
+  )
+  assert_true(repeated.state() == transition.state())
+  assert_true(repeated.decisions().is_empty())
+}
+
+///|
+test "snapshot restore proposes source replacement without storing source" {
+  let state = ApplicationState(Raw)
+  let snapshot = ApplicationStateSnapshot(
+    version=1,
+    source="# New\r\n",
+    mode=Preview,
+  )
+  let transition = reduce(
+    state,
+    ApplicationEvent::RestoreSnapshot(snapshot~, canonical_source="# Old\n"),
+  )
+
+  assert_true(transition.state().mode() == Preview)
+  assert_eq(transition.decisions().to_array(), [
+    ApplicationDecision::ReplaceCanonicalSource("# New\r\n"),
+  ])
+}
+
+///|
+test "snapshot restore with equal source emits no replacement" {
+  let state = ApplicationState(Raw)
+  let snapshot = ApplicationStateSnapshot(
+    version=1,
+    source="# Same\n",
+    mode=Preview,
+  )
+  let transition = reduce(
+    state,
+    ApplicationEvent::RestoreSnapshot(snapshot~, canonical_source="# Same\n"),
+  )
+
+  assert_true(transition.state().mode() == Preview)
+  assert_true(transition.decisions().is_empty())
+}
+
+///|
+test "unsupported snapshot version rejects without changing state" {
+  let state = ApplicationState(Raw)
+  let snapshot = ApplicationStateSnapshot(
+    version=99,
+    source="# New\n",
+    mode=Preview,
+  )
+  let transition = reduce(
+    state,
+    ApplicationEvent::RestoreSnapshot(snapshot~, canonical_source="# Old\n"),
+  )
+
+  assert_true(transition.state() == state)
+  assert_eq(transition.decisions().to_array(), [
+    ApplicationDecision::SnapshotRejected(
+      SnapshotError::UnsupportedSnapshotVersion(99),
+    ),
+  ])
+}
+
+///|
+test "state snapshot carries caller source separately from live state" {
+  let state = ApplicationState(Block)
+  let snapshot = state.snapshot("A🤣B\r\n")
+
+  assert_eq(snapshot.version(), SNAPSHOT_VERSION)
+  assert_eq(snapshot.source(), "A🤣B\r\n")
+  assert_true(snapshot.mode() == Block)
+  assert_true(state.mode() == Block)
+}

--- a/loomark/core/moon.pkg
+++ b/loomark/core/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/core/immut/vector",
+}
+
+warnings = "-7-29"
+
+options(
+  is_main: false,
+)

--- a/loomark/core/pkg.generated.mbti
+++ b/loomark/core/pkg.generated.mbti
@@ -1,0 +1,62 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/loomark/core"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/immut/vector",
+}
+
+// Values
+pub const SNAPSHOT_VERSION : Int = 1
+
+pub fn reduce(ApplicationState, ApplicationEvent) -> ProposedTransition
+
+// Errors
+
+// Types and methods
+pub(all) enum ApplicationDecision {
+  ReplaceCanonicalSource(String)
+  SnapshotRejected(SnapshotError)
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ApplicationEvent {
+  RequestCanonicalSource(source~ : String)
+  SelectMode(mode~ : ApplicationMode)
+  RestoreSnapshot(snapshot~ : ApplicationStateSnapshot, canonical_source~ : String)
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ApplicationMode {
+  Raw
+  Block
+  Preview
+} derive(Eq, @debug.Debug)
+
+pub struct ApplicationState {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn ApplicationState::ApplicationState(ApplicationMode) -> Self
+pub fn ApplicationState::mode(Self) -> ApplicationMode
+pub fn ApplicationState::snapshot(Self, String) -> ApplicationStateSnapshot
+
+pub struct ApplicationStateSnapshot {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn ApplicationStateSnapshot::ApplicationStateSnapshot(version~ : Int, source~ : String, mode~ : ApplicationMode) -> Self
+pub fn ApplicationStateSnapshot::mode(Self) -> ApplicationMode
+pub fn ApplicationStateSnapshot::source(Self) -> String
+pub fn ApplicationStateSnapshot::version(Self) -> Int
+
+pub struct ProposedTransition {
+  // private fields
+}
+pub fn ProposedTransition::decisions(Self) -> @vector.Vector[ApplicationDecision]
+pub fn ProposedTransition::state(Self) -> ApplicationState
+
+pub(all) enum SnapshotError {
+  UnsupportedSnapshotVersion(Int)
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/loomark/moon.mod
+++ b/loomark/moon.mod
@@ -1,0 +1,13 @@
+name = "dowdiness/loomark"
+
+version = "0.1.0"
+
+import {
+  "dowdiness/canopy@0.1.0",
+}
+
+license = "Apache-2.0"
+
+keywords = [ "markdown", "editor", "projectional" ]
+
+description = "Pure application core for the Loomark Markdown editor"

--- a/moon.work
+++ b/moon.work
@@ -1,5 +1,6 @@
 members = [
   ".",
+  "./loomark",
   "./rabbita/rabbita",
   "./graphviz",
   "./svg-dsl",

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -18,7 +18,8 @@
 #       canopy-internal imports must stay within {core/**, protocol/**},
 #       and no language grammar.
 #   [G] editor/** must not import dowdiness/canopy/lang/* or a language
-#       grammar in ANY scope, test/wbtest included.
+#       grammar in ANY scope, test/wbtest included, except exact imports
+#       registered for a canonical Tier 1 language façade below.
 #   [H] relay/** imports only protocol/wire, byte_codec, its own subtree,
 #       and moonbitlang/* — never editor.
 #   [I] lang/** must not import dowdiness/canopy/ffi/*; a language
@@ -229,6 +230,25 @@ GRAMMAR_MODULES = {
     "dowdiness/markdown": "markdown",
 }
 
+# Canonical Tier 1 editor façades are language-owned boundaries inside
+# editor/**, not language-neutral editor internals. Keep this allowlist exact
+# and scope-aware so adding a façade does not weaken Rule G for siblings.
+EDITOR_LANGUAGE_FACADE_IMPORTS = {
+    ("editor/markdown", "normal",
+     CANOPY + "/lang/markdown/companion"),
+    ("editor/markdown", "normal",
+     CANOPY + "/lang/markdown/edits"),
+    ("editor/markdown", "normal", "dowdiness/markdown"),
+}
+editor_language_facade_imports_used = set()
+
+def allowed_editor_language_facade_import(pkg, scope, sym):
+    key = (pkg, scope, sym)
+    if key in EDITOR_LANGUAGE_FACADE_IMPORTS:
+        editor_language_facade_imports_used.add(key)
+        return True
+    return False
+
 def grammar_lang(sym):
     """Owning language of an out-of-module grammar import, or None."""
     for root, lang in GRAMMAR_MODULES.items():
@@ -264,7 +284,9 @@ def check_canopy_layering(pkg, scope, sym):
     if under(pkg, ("editor",)):
         is_lang_import = (target is not None and under(target, ("lang",))) \
             or glang is not None
-        if is_lang_import and not waived("G", pkg, scope, sym):
+        if is_lang_import \
+                and not allowed_editor_language_facade_import(pkg, scope, sym) \
+                and not waived("G", pkg, scope, sym):
             yield (f"[G] {pkg} ({scope}) → {sym} "
                    f"(editor must not import lang/* or a language grammar)")
     if under(pkg, ("relay",)) \
@@ -333,6 +355,14 @@ for mmj in iter_manifests():
             violations.append(f"[E] submodule mod {name} has path-dep → {dep_name}")
 
 # --- Report ---
+for pkg, scope, sym in sorted(
+        EDITOR_LANGUAGE_FACADE_IMPORTS
+        - editor_language_facade_imports_used):
+    violations.append(
+        f"[G] STALE façade import: {pkg} ({scope}) → {sym} no longer "
+        f"matches any import — remove it from "
+        f"EDITOR_LANGUAGE_FACADE_IMPORTS")
+
 for key in sorted(EXCEPTIONS):
     rule, pkg, scope, sym = key
     if key in exceptions_used:


### PR DESCRIPTION
## Summary

- Add the typed, opaque `editor/markdown` façade with a labeled, raising MoonBit custom constructor over the canonical Markdown companion and exact text-edit APIs.
- Add the pure `dowdiness/loomark/core` reducer boundary for mode, snapshot restoration, and proposed canonical-source decisions.
- Keep Rule G fail-closed while permitting only the façade's three exact Markdown dependencies.

Closes #1102.

## UI and review evidence

N/A — this is a headless MoonBit foundation change with no rendered UI or interaction changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `new_markdown_editor`, `apply_markdown_edit` | `lang/markdown/companion` | Yes | Canonical Markdown editor construction and typed edit lowering |
| `SyncEditor::{set_text,get_text,apply_text_edit_exact,refresh,get_proj_node}` | `editor` | Yes | Canonical source mutation and projection access remain behind the façade |
| `MarkdownEditOp` | `lang/markdown/edits` | Yes | Reused internally without exposing the Tier-2 edit type publicly |
| `Option`, `Result`, `String` | MoonBit core | Yes | Categorized failures, optional roots, and owning source snapshots |
| `immut/vector::{Vector,new,singleton}` | MoonBit core | Yes | Immutable projection identities and ordered application decisions |
| `StringView`, `ArrayView` | MoonBit core | No | Public snapshots require detached owning values |
| `Map`, `Set` | MoonBit core | No | The public result is an ordered identity sequence, not keyed lookup or membership state |
| `Buffer`, `StringBuilder` | MoonBit core | No | No incremental string assembly is performed at this boundary |

New helpers added:

- `MarkdownEditor(...)`, `ApplicationState(...)`, and `ApplicationStateSnapshot(...)` are the sole custom construction paths; no pre-merge `::new` compatibility aliases are retained.
- `MarkdownEditor::commit_structural` lowers façade-owned requests through the existing Markdown companion and preserves atomic result classification.
- `projection_snapshot` copies only opaque stable identities into an immutable façade snapshot.

Remaining imperative code is limited to the `SyncEditor` façade shell (`set_text`, exact edit, refresh). `loomark/core` is a deterministic reducer and performs no editor, DOM, runtime, clock, filesystem, or network effect.

## Validation scope

Boundary matrix / first failing regression:

- The first RED was the absent `editor/markdown` and `loomark/core` package/API boundary.
- The constructor refactor RED compiled the existing black-box tests against `TypeName(...)` first and failed because no custom constructors existed; the same behavioral assertions then passed after the minimal API replacement.
- Façade tests cover applied/unchanged commits, caller-owned ZWSP, UTF-16 exact edits, invalid boundaries/ranges, immutable identity snapshots, supported lowering, rejected edits, and construction errors.
- Core tests cover Raw/Block/Preview mode transitions, ordered replacement decisions, equal-source restoration, unsupported snapshot versions, and separation of snapshot source from live state.
- A negative dependency probe added an unrelated JSON companion import and confirmed Rule G rejects it; the exact three Markdown façade imports remain green.

Target packages:

- `editor/markdown`
- `loomark/core`

Additional conditional gates:

- Native and JavaScript targeted checks/tests passed: editor 10/10 and core 6/6.
- Workspace `moon check` and `moon test` passed.
- JavaScript artifact build passed.
- Independent Terra review returned schema-validated PASS with zero findings.
- No submodule pointer or submodule source changes.

## PR-ready evidence

Validated HEAD: `9d6fb057cacbe27f03d25ff652f9cf898f93653d`

Validated base: `origin/main@a6e205e249d2263574e426221aa7d058cf60c6a1`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target editor/markdown
./scripts/validate-pr-ready.sh --target loomark/core
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened or updated.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit or pointer changed.
- [x] Validation was rerun after every commit, amend, manifest, and generated-interface change.
- [x] Independent review findings were resolved before the final validation.

## Deferred work

Block editing, Browser App/Session, Rabbita rendering and lifecycle, Vanilla bindings, and Waku/React/Vue integration remain in their dependent tickets. Sentinel-producing insertion and end-of-block split operations are intentionally not exposed by this façade.
