### PR TITLE
chore(deps): update Loom and diagnostic APIs

### DIFF
--- a/cmd/main/moon.pkg
+++ b/cmd/main/moon.pkg
@@ -7,4 +7,8 @@ import {
   "moonbitlang/core/debug",
 }
 
+import {
+  "dowdiness/diagnostic",
+} for "wbtest"
+
 pkgtype(kind: "executable")

--- a/editor/diagnostic_fix_wbtest.mbt
+++ b/editor/diagnostic_fix_wbtest.mbt
@@ -23,8 +23,8 @@ fn test_diagnostic(
   fixes : Array[@loom_core.DiagnosticFix],
 ) -> @loom_core.Diagnostic {
   @loom_core.Diagnostic(
-    source=@loom_core.DiagnosticSource::parser(),
-    severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+    origin=@diagnostic.DiagnosticOrigin("parser"),
+    severity=@diagnostic.DiagnosticSeverity::Error,
     code=Some(@loom_core.DiagnosticCode("test.fix")),
     message="replace source",
     labels=[

--- a/editor/diagnostic_publication_wbtest.mbt
+++ b/editor/diagnostic_publication_wbtest.mbt
@@ -2,8 +2,8 @@
 fn publication_fixture(message : String) -> @loom_core.DiagnosticSet {
   @loom_core.DiagnosticSet::single(
     @loom_core.Diagnostic(
-      source=@loom_core.DiagnosticSource::parser(),
-      severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+      origin=@diagnostic.DiagnosticOrigin("parser"),
+      severity=@diagnostic.DiagnosticSeverity::Error,
       message~,
     ),
   )
@@ -46,8 +46,8 @@ fn rich_publication_fixture() -> @loom_core.DiagnosticSet {
   let source = @loom_core.SourceId("A")
   @loom_core.DiagnosticSet::single(
     @loom_core.Diagnostic(
-      source=@loom_core.DiagnosticSource::parser(),
-      severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+      origin=@diagnostic.DiagnosticOrigin("parser"),
+      severity=@diagnostic.DiagnosticSeverity::Error,
       code=Some(@loom_core.DiagnosticCode("fixture.rich")),
       message="retained",
       labels=[
@@ -517,7 +517,13 @@ test "accepted diagnostics retain Loom values and own a defensive copy" {
   let (state, ticket, _) = state.issue(semantic, [source_revision("A", 0)], [])
   let (state, decision) = state.complete(ticket, produced)
   inspect(decision is DiagnosticPublicationDecision::Accepted, content="true")
-  produced.push(@loom_core.Diagnostic::lexer_error("late producer mutation"))
+  produced.push(
+    @diagnostic.Diagnostic(
+      origin=@diagnostic.DiagnosticOrigin("parser"),
+      severity=@diagnostic.DiagnosticSeverity::Error,
+      message="late producer mutation",
+    ),
+  )
   let published = state.display(parser)
   guard published.items() is [diagnostic] else {
     fail("expected one copied diagnostic")
@@ -535,6 +541,12 @@ test "accepted diagnostics retain Loom values and own a defensive copy" {
   inspect(primary.span().range().start().value(), content="1")
   inspect(primary.span().range().end().value(), content="3")
   inspect(published.length(), content="1")
-  published.push(@loom_core.Diagnostic::lexer_error("late display mutation"))
+  published.push(
+    @diagnostic.Diagnostic(
+      origin=@diagnostic.DiagnosticOrigin("parser"),
+      severity=@diagnostic.DiagnosticSeverity::Error,
+      message="late display mutation",
+    ),
+  )
   debug_inspect(messages(state.display(parser)), content="[\"retained\"]")
 }

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -152,3 +152,27 @@ test "empty replica identity is a categorized construction failure" {
     _ => fail("expected InvalidAgentId")
   }
 }
+
+///|
+test "reference definition insertion preserves facade block identities" {
+  let prefix = "[ref]: /target\n\n"
+  let source = "# Heading\n\nBody [link][ref].\n"
+  let editor = try! MarkdownEditor(agent_id="reference-definition", source~)
+  let before_ids = editor.snapshot().projection().node_ids()
+  assert_eq(before_ids.length(), 3)
+
+  let result = editor.commit(
+    MarkdownEditRequest::ReplaceText(start=0, delete_len=0, inserted=prefix),
+  )
+
+  match result {
+    Ok(MarkdownCommitResult::Applied(after)) => {
+      assert_eq(after.source(), prefix + source)
+      let after_ids = after.projection().node_ids()
+      assert_eq(after_ids.length(), 3)
+      assert_eq(after_ids.get(1), before_ids.get(1))
+      assert_eq(after_ids.get(2), before_ids.get(2))
+    }
+    _ => fail("expected reference definition insertion to apply")
+  }
+}

--- a/editor/moon.pkg
+++ b/editor/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/protocol/wire",
+  "dowdiness/diagnostic",
   "dowdiness/canopy/transport_ws",
   "dowdiness/canopy/sync_session",
   "dowdiness/text_change",

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "dowdiness/canopy/protocol/wire",
   "dowdiness/canopy/sync_session",
   "dowdiness/canopy/transport_ws",
+  "dowdiness/diagnostic",
   "dowdiness/event-graph-walker/history",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
@@ -27,12 +28,12 @@ pub fn[T : @pretty.Pretty] compute_pretty_patches(ViewUpdateState, SyncEditor[T]
 
 pub fn[T : @dowdiness/loom/core.Renderable] compute_view_patches(ViewUpdateState, SyncEditor[T]) -> Array[@protocol.ViewPatch]
 
-pub fn project_diagnostics_for_source(@dowdiness/loom/core.SourceId, @dowdiness/loom/core.DiagnosticSet) -> Array[@protocol.Diagnostic]
+pub fn project_diagnostics_for_source(@diagnostic.SourceId, @dowdiness/loom/core.DiagnosticSet) -> Array[@protocol.Diagnostic]
 
 // Errors
 pub(all) suberror DiagnosticPublicationInputError {
   NoCoveredSources
-  DuplicateSource(@dowdiness/loom/core.SourceId)
+  DuplicateSource(@diagnostic.SourceId)
   DuplicateDependency(DiagnosticDependencyId)
 } derive(Eq, @debug.Debug)
 pub impl Show for DiagnosticPublicationInputError
@@ -98,8 +99,8 @@ pub fn DiagnosticPublicationInputSnapshot::sources(Self) -> Array[DiagnosticPubl
 pub struct DiagnosticPublicationSourceRevision {
   // private fields
 } derive(Eq, @debug.Debug)
-pub fn DiagnosticPublicationSourceRevision::DiagnosticPublicationSourceRevision(@dowdiness/loom/core.SourceId, @text.Version) -> Self
-pub fn DiagnosticPublicationSourceRevision::source(Self) -> @dowdiness/loom/core.SourceId
+pub fn DiagnosticPublicationSourceRevision::DiagnosticPublicationSourceRevision(@diagnostic.SourceId, @text.Version) -> Self
+pub fn DiagnosticPublicationSourceRevision::source(Self) -> @diagnostic.SourceId
 pub fn DiagnosticPublicationSourceRevision::version(Self) -> @text.Version
 
 pub struct Editor {
@@ -181,7 +182,7 @@ pub fn[T] SyncEditor::move_cursor_left_word(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_grapheme(Self[T]) -> Unit
 pub fn[T] SyncEditor::move_cursor_right_word(Self[T]) -> Unit
 pub fn[T : Eq + @dowdiness/loom/core.Renderable] SyncEditor::move_node(Self[T], @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.DropPosition, Int) -> Result[Array[@dowdiness/canopy/core.SpanEdit], TreeEditError]
-pub fn[T] SyncEditor::new_generic(String, (@dowdiness/loom/core.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : LanguageCapabilities[T], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> Self[T] raise @text.TextError
+pub fn[T] SyncEditor::new_generic(String, (@diagnostic.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : LanguageCapabilities[T], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> Self[T] raise @text.TextError
 pub fn[T] SyncEditor::node_at_position(Self[T], Int) -> @dowdiness/canopy/core.NodeId?
 pub fn[T] SyncEditor::on_watchdog_fire(Self[T], Int) -> Unit
 pub fn[T] SyncEditor::parser_ast(Self[T]) -> @cells.Derived[T]
@@ -189,7 +190,7 @@ pub fn[T] SyncEditor::parser_diagnostics(Self[T]) -> @cells.Derived[@dowdiness/l
 pub fn[T] SyncEditor::parser_runtime(Self[T]) -> @cells.Runtime
 pub fn[T] SyncEditor::parser_snapshot(Self[T]) -> @cells.Derived[@incremental.ParseSnapshot[T]]
 pub fn[T] SyncEditor::parser_source(Self[T]) -> @cells.Derived[String]
-pub fn[T] SyncEditor::parser_source_id(Self[T]) -> @dowdiness/loom/core.SourceId
+pub fn[T] SyncEditor::parser_source_id(Self[T]) -> @diagnostic.SourceId
 pub fn[T] SyncEditor::parser_syntax_tree(Self[T]) -> @cells.Derived[@seam.SyntaxNode]
 pub fn[T : Eq] SyncEditor::redo(Self[T]) -> Bool
 pub fn[T : Eq] SyncEditor::redo_and_export(Self[T]) -> @text.SyncMessage?

--- a/editor/semantic_diagnostics_wbtest.mbt
+++ b/editor/semantic_diagnostics_wbtest.mbt
@@ -2,8 +2,8 @@
 fn semantic_merge_test_set(message : String) -> @loom_core.DiagnosticSet {
   @loom_core.DiagnosticSet::single(
     @loom_core.Diagnostic(
-      source=@loom_core.DiagnosticSource(message),
-      severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+      origin=@diagnostic.DiagnosticOrigin(message),
+      severity=@diagnostic.DiagnosticSeverity::Error,
       message~,
     ),
   )
@@ -60,7 +60,19 @@ test "diagnostic merge owns a defensive result" {
     parser,
     Some(("current", semantic)),
   )
-  parser.push(@loom_core.Diagnostic::lexer_error("late parser mutation"))
-  semantic.push(@loom_core.Diagnostic::lexer_error("late semantic mutation"))
+  parser.push(
+    @diagnostic.Diagnostic(
+      origin=@diagnostic.DiagnosticOrigin("parser"),
+      severity=@diagnostic.DiagnosticSeverity::Error,
+      message="late parser mutation",
+    ),
+  )
+  semantic.push(
+    @diagnostic.Diagnostic(
+      origin=@diagnostic.DiagnosticOrigin("semantic"),
+      severity=@diagnostic.DiagnosticSeverity::Error,
+      message="late semantic mutation",
+    ),
+  )
   inspect(merged.length(), content="2")
 }

--- a/editor/view_updater.mbt
+++ b/editor/view_updater.mbt
@@ -109,23 +109,36 @@ fn current_source_diagnostic_fixes(
 }
 
 ///|
-fn diagnostic_source_provider(
-  source_id : @loom_core.SourceId,
+priv struct CurrentSourceResolver {
+  source_id : @diagnostic.SourceId
+  snapshot : @diagnostic.SourceSnapshot
+}
+
+///|
+impl @diagnostic.SourceResolver for CurrentSourceResolver with fn resolve_source(
+  self,
+  requested_source_id,
+) {
+  if requested_source_id == self.source_id {
+    Some(self.snapshot)
+  } else {
+    None
+  }
+}
+
+///|
+fn diagnostic_source_resolver(
+  source_id : @diagnostic.SourceId,
   source : String,
-) -> @loom_core.SourceProvider {
-  @loom_core.SourceProvider(requested_source_id => {
-    if requested_source_id == source_id {
-      Some(
-        @loom_core.DiagnosticSourceFile(
-          "<input>",
-          source,
-          @loom_core.LineIndex::new(source),
-        ),
-      )
-    } else {
-      None
-    }
-  })
+) -> CurrentSourceResolver {
+  {
+    source_id,
+    snapshot: @diagnostic.SourceSnapshot(
+      "<input>",
+      source,
+      @diagnostic.LineIndex::new(source),
+    ),
+  }
 }
 
 ///|
@@ -200,11 +213,11 @@ fn[T] ViewUpdateState::publish_diagnostics(
   self.next_diagnostic_snapshot_id += 1
   let source_id = editor.parser_source_id()
   let source = editor.get_text()
-  let provider = diagnostic_source_provider(source_id, source)
+  let resolver = diagnostic_source_resolver(source_id, source)
   let published = diagnostics
     .items()
     .mapi((id, diagnostic) => {
-      let rendered_message : String? = Some(diagnostic.render_plain(provider)) catch {
+      let rendered_message : String? = Some(diagnostic.render_plain(resolver)) catch {
         _ => None
       }
       let fixes = match rendered_message {

--- a/editor/view_updater_test.mbt
+++ b/editor/view_updater_test.mbt
@@ -173,7 +173,7 @@ test "structural edit produces ReplaceNode" {
 test "diagnostic projection emits only current-source primary labels in order" {
   let current_source = @loom_core.SourceId("current")
   let other_source = @loom_core.SourceId("other")
-  let severity = @loom_core.Diagnostic::lexer_error("fixture").severity()
+  let severity = @diagnostic.DiagnosticSeverity::Error
   let current_primary = (start, end) => {
     @loom_core.DiagnosticLabel(
       @loom_core.LabelStyle::Primary,
@@ -185,7 +185,7 @@ test "diagnostic projection emits only current-source primary labels in order" {
     )
   }
   let diagnostic = @loom_core.Diagnostic(
-    source=@loom_core.DiagnosticSource::parser(),
+    origin=@diagnostic.DiagnosticOrigin("parser"),
     severity~,
     code=Some(@loom_core.DiagnosticCode("test.mixed-sources")),
     message="mixed source labels",
@@ -234,7 +234,12 @@ test "diagnostic projection keeps locationless compatibility at zero width" {
   let projected = @editor.project_diagnostics_for_source(
     source_id,
     @loom_core.DiagnosticSet::single(
-      @loom_core.Diagnostic::lexer_error("locationless"),
+      @diagnostic.Diagnostic(
+        origin=@diagnostic.DiagnosticOrigin("lexer"),
+        severity=@diagnostic.DiagnosticSeverity::Error,
+        code=Some(@diagnostic.DiagnosticCode("lex-error")),
+        message="locationless",
+      ),
     ),
   )
 
@@ -253,8 +258,8 @@ test "diagnostic projection omits foreign-only labeled diagnostics" {
   let current_source = @loom_core.SourceId("current")
   let other_source = @loom_core.SourceId("other")
   let diagnostic = @loom_core.Diagnostic(
-    source=@loom_core.DiagnosticSource::parser(),
-    severity=@loom_core.Diagnostic::lexer_error("fixture").severity(),
+    origin=@diagnostic.DiagnosticOrigin("parser"),
+    severity=@diagnostic.DiagnosticSeverity::Error,
     message="foreign location",
     labels=[
       @loom_core.DiagnosticLabel(

--- a/examples/canvas/main/moon.pkg
+++ b/examples/canvas/main/moon.pkg
@@ -16,6 +16,10 @@ import {
   "moonbit-community/rabbita/sub",
 }
 
+import {
+  "dowdiness/diagnostic",
+} for "wbtest"
+
 // Keep this package JS-only until `defer_sync` in `source_demo.mbt` has a
 // non-JS implementation with the same post-mutation defer ordering as browser
 // `queueMicrotask`; a synchronous fallback reintroduces stale source reads.

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -6,6 +6,10 @@
       "path": "../../loom/examples/graph-dsl",
       "version": "0.1.0"
     },
+    "dowdiness/diagnostic": {
+      "path": "../../loom/diagnostic",
+      "version": "0.1.0"
+    },
     "dowdiness/canopy-canvas-graph": {
       "path": "../../lib/canvas-graph",
       "version": "0.1.0"

--- a/examples/canvas/moon.work
+++ b/examples/canvas/moon.work
@@ -1,5 +1,6 @@
 members = [
   ".",
+  "../../loom/diagnostic",
   "../../loom/examples/graph-dsl",
   "../../lib/canvas-graph",
   "../../loom/loom",

--- a/ffi/jsx/moon.pkg
+++ b/ffi/jsx/moon.pkg
@@ -16,6 +16,7 @@ import {
 }
 
 import {
+  "dowdiness/diagnostic",
   "moonbitlang/async",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",

--- a/ffi/lambda/moon.pkg
+++ b/ffi/lambda/moon.pkg
@@ -31,6 +31,10 @@ import {
   "dowdiness/canopy/protocol/wire",
 } for "test"
 
+import {
+  "dowdiness/diagnostic",
+} for "wbtest"
+
 // `cells` field of LambdaHandle is read in production by Phase 1b accessors
 // (`get_diagnostics_json`, view/pretty/semantic projection accessors, and
 // `rename_semantic_node`) and by whitebox tests

--- a/lang/json/proj/moon.pkg
+++ b/lang/json/proj/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core",
+  "dowdiness/diagnostic",
   "dowdiness/incr",
   "dowdiness/json",
   "dowdiness/loom",

--- a/lang/json/proj/pkg.generated.mbti
+++ b/lang/json/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/json/proj"
 
 import {
+  "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/json",
   "dowdiness/loom/pipeline",
@@ -16,7 +17,7 @@ pub fn key_role(Int) -> String
 
 pub fn member_role(Int) -> String
 
-pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@json.JsonValue], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@json.JsonValue], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@json.JsonValue]) -> Unit
 

--- a/lang/jsx/proj/moon.pkg
+++ b/lang/jsx/proj/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core",
+  "dowdiness/diagnostic",
   "dowdiness/incr",
   "dowdiness/jsx",
   "dowdiness/jsx/syntax",

--- a/lang/jsx/proj/pkg.generated.mbti
+++ b/lang/jsx/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/jsx/proj"
 
 import {
+  "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/jsx",
   "dowdiness/loom/pipeline",
@@ -17,7 +18,7 @@ pub fn dom_patches_to_json(Array[DomPatch]) -> String
 
 pub fn normalize_dom_attribute_value(String, String) -> String
 
-pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@jsx.JsxNode], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@jsx.JsxNode]) -> Unit
 

--- a/lang/lambda/proj/moon.pkg
+++ b/lang/lambda/proj/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core",
+  "dowdiness/diagnostic",
   "dowdiness/incr",
   "dowdiness/lambda" @parser,
   "dowdiness/lambda/ast",

--- a/lang/lambda/proj/pkg.generated.mbti
+++ b/lang/lambda/proj/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "dowdiness/canopy/lang/lambda/proj"
 
 import {
+  "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/lambda/ast",
   "dowdiness/loom/pipeline",
@@ -28,7 +29,7 @@ pub fn build_lambda_projection_memos(@pipeline.Parser[@ast.Term], identity_hints
 
 pub fn module_name_role(Int) -> String
 
-pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@ast.Term], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@ast.Term]) -> Unit
 

--- a/lang/lambda/semantic/moon.pkg
+++ b/lang/lambda/semantic/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "dowdiness/canopy/core",
+  "dowdiness/diagnostic",
   "dowdiness/canopy/lang/lambda/proj" @lambda_proj,
   "dowdiness/canopy/lang/lambda/scope" @lambda_scope,
   "dowdiness/canopy/protocol",

--- a/lang/lambda/semantic/pkg.generated.mbti
+++ b/lang/lambda/semantic/pkg.generated.mbti
@@ -3,12 +3,13 @@ package "dowdiness/canopy/lang/lambda/semantic"
 
 import {
   "dowdiness/canopy/protocol",
+  "dowdiness/diagnostic",
   "dowdiness/lambda/ast",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn build_semantic_diagnostics(@dowdiness/loom/core.SourceId, String, @dowdiness/canopy/core.ProjNode[@ast.Term], @dowdiness/canopy/core.SourceMap) -> @dowdiness/loom/core.DiagnosticSet raise SemanticDiagnosticError
+pub fn build_semantic_diagnostics(@diagnostic.SourceId, String, @dowdiness/canopy/core.ProjNode[@ast.Term], @dowdiness/canopy/core.SourceMap) -> @dowdiness/loom/core.DiagnosticSet raise SemanticDiagnosticError
 
 pub fn build_semantic_projection(@dowdiness/canopy/core.ProjNode[@ast.Term], @dowdiness/canopy/core.SourceMap) -> SemanticProjection
 

--- a/lang/lambda/semantic/semantic_projection.mbt
+++ b/lang/lambda/semantic/semantic_projection.mbt
@@ -127,7 +127,7 @@ pub fn build_semantic_diagnostics(
     })
     diagnostics.push(
       @loomcore.Diagnostic::Diagnostic(
-        source=@loomcore.DiagnosticSource::DiagnosticSource("lambda.semantic"),
+        origin=@diagnostic.DiagnosticOrigin("lambda.semantic"),
         // Imported enum variants are read-only; `all()` is the public value factory.
         severity=@loomcore.DiagnosticSeverity::all()[1],
         message="Free variable '" + failure.name + "'",

--- a/lang/lambda/semantic/semantic_projection_test.mbt
+++ b/lang/lambda/semantic/semantic_projection_test.mbt
@@ -4,6 +4,24 @@ let lambda_semantic_projection_test_source : @loomcore.SourceId = @loomcore.Sour
 )
 
 ///|
+priv struct SemanticDiagnosticSourceResolver {
+  source_id : @diagnostic.SourceId
+  snapshot : @diagnostic.SourceSnapshot
+}
+
+///|
+impl @diagnostic.SourceResolver for SemanticDiagnosticSourceResolver with fn resolve_source(
+  self,
+  requested_source_id,
+) {
+  if requested_source_id == self.source_id {
+    Some(self.snapshot)
+  } else {
+    None
+  }
+}
+
+///|
 fn parse_fixture(
   text : String,
 ) -> (@core.ProjNode[@ast.Term], @core.SourceMap) raise {
@@ -204,9 +222,9 @@ test "semantic diagnostics preserve neutral warning labels and identities" {
     content="lambda.unresolved_reference",
   )
   inspect(diagnostic.message(), content="Free variable 'y'")
-  inspect(diagnostic.source().name(), content="lambda.semantic")
+  inspect(diagnostic.origin().name(), content="lambda.semantic")
   inspect(
-    diagnostic.source().name() == lambda_semantic_projection_test_source.value(),
+    diagnostic.origin().name() == lambda_semantic_projection_test_source.value(),
     content="false",
   )
   let labels = diagnostic.labels()
@@ -297,21 +315,16 @@ test "semantic diagnostics are defensive copies and render from one neutral valu
   inspect(diagnostics.length(), content="1")
   inspect(diagnostics.items()[0].labels().length() >= 2, content="true")
   inspect(diagnostics.items()[0].notes().contains("mutated"), content="false")
-  let provider = @loomcore.SourceProvider(requested => {
-    if requested == lambda_semantic_projection_test_source {
-      Some(
-        @loomcore.DiagnosticSourceFile(
-          "lambda.mbt",
-          text,
-          @loomcore.LineIndex::new(text),
-        ),
-      )
-    } else {
-      None
-    }
-  })
+  let resolver = SemanticDiagnosticSourceResolver::{
+    source_id: lambda_semantic_projection_test_source,
+    snapshot: @diagnostic.SourceSnapshot(
+      "lambda.mbt",
+      text,
+      @diagnostic.LineIndex::new(text),
+    ),
+  }
   inspect(
-    diagnostics.items()[0].render_plain(provider).contains("Free variable 'y'"),
+    diagnostics.items()[0].render_plain(resolver).contains("Free variable 'y'"),
     content="true",
   )
 }

--- a/lang/markdown/proj/moon.pkg
+++ b/lang/markdown/proj/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/core",
   "dowdiness/canopy/protocol",
+  "dowdiness/diagnostic",
   "dowdiness/incr",
   "dowdiness/markdown",
   "dowdiness/loom",

--- a/lang/markdown/proj/pkg.generated.mbti
+++ b/lang/markdown/proj/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "dowdiness/canopy/lang/markdown/proj"
 
 import {
   "dowdiness/canopy/protocol",
+  "dowdiness/diagnostic",
   "dowdiness/incr/cells",
   "dowdiness/loom/pipeline",
   "dowdiness/markdown",
@@ -13,7 +14,7 @@ import {
 // Values
 pub fn build_markdown_projection_memos(@pipeline.Parser[@markdown.Block], identity_hints? : @ref.Ref[Array[@dowdiness/canopy/core.IdentityTransform]]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[@markdown.Block]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[@markdown.Block]]], @cells.Derived[@dowdiness/canopy/core.SourceMap])
 
-pub fn parse_to_proj_node(@dowdiness/loom/core.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
+pub fn parse_to_proj_node(@diagnostic.SourceId, String) -> (@dowdiness/canopy/core.ProjNode[@markdown.Block], Array[String]) raise @dowdiness/loom/core.LexError
 
 pub fn populate_token_spans(@dowdiness/canopy/core.SourceMap, @seam.SyntaxNode, @dowdiness/canopy/core.ProjNode[@markdown.Block]) -> Unit
 

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -674,3 +674,54 @@ test "projection: incremental quote insertion keeps following heading identity" 
   assert_eq(incremental.children[1].end, fresh.children[1].end)
   assert_eq(incremental.children[1].node_id, heading_id)
 }
+
+///|
+test "projection: reference definition insertion preserves following blocks" {
+  let prefix = "[ref]: /target\n\n"
+  let source = "# Heading\n\nBody [link][ref].\n"
+  let edited_source = prefix + source
+  let parser = @loom.new_imperative_parser(
+    markdown_projection_test_source, source, @markdown.markdown_grammar,
+  )
+  // Keep one allocator across both projections and reconciliation so IDs stay deterministic.
+  let counter : Ref[Int] = Ref(0)
+  let _ = parser.parse()
+  let initial_syntax = parser.get_syntax_tree().unwrap()
+  let initial = syntax_to_proj_node(initial_syntax, counter)
+  assert_eq(initial.children.length(), 2)
+  let heading_id = initial.children[0].node_id
+  let paragraph_id = initial.children[1].node_id
+  let edit = @loomcore.Edit::new(0, 0, prefix.length())
+  let _ = parser.edit(edit, edited_source)
+  let edited_syntax = parser.get_syntax_tree().unwrap()
+  let raw = syntax_to_proj_node(edited_syntax, counter)
+  let incremental = @core.reconcile(initial, raw, counter)
+  let (fresh, errors) = parse_to_proj_node(
+    markdown_projection_test_source, edited_source,
+  )
+  assert_eq(errors.length(), 0)
+  assert_eq(incremental.children.length(), 2)
+  assert_eq(incremental.equal(fresh), true)
+  assert_eq(
+    source_map_for(edited_source, incremental).equal(
+      source_map_for(edited_source, fresh),
+    ),
+    true,
+  )
+  assert_eq(incremental.children[0].start, prefix.length())
+  assert_eq(incremental.children[0].node_id, heading_id)
+  assert_eq(incremental.children[1].node_id, paragraph_id)
+  match incremental.children {
+    [heading, paragraph] => {
+      match heading.kind {
+        Heading(1, [Text(text)]) => assert_eq(text, "Heading")
+        _ => fail("expected aligned heading after reference definition")
+      }
+      match paragraph.kind {
+        Paragraph(_) => ()
+        _ => fail("expected aligned paragraph after reference definition")
+      }
+    }
+    _ => fail("expected reference definition to stay outside projection")
+  }
+}

--- a/lang/runtime/pkg.generated.mbti
+++ b/lang/runtime/pkg.generated.mbti
@@ -2,7 +2,9 @@
 package "dowdiness/canopy/lang/runtime"
 
 import {
+  "dowdiness/canopy/core",
   "dowdiness/canopy/editor",
+  "dowdiness/diagnostic",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/loom/pipeline",
@@ -16,7 +18,7 @@ import {
 pub struct LanguageSpec[T, Op] {
   // private fields
 }
-pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (@dowdiness/loom/core.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@dowdiness/canopy/core.ProjNode[T]?], @cells.Derived[Map[@dowdiness/canopy/core.NodeId, @dowdiness/canopy/core.ProjNode[T]]], @cells.Derived[@dowdiness/canopy/core.SourceMap]), compute_edit~ : (Op, String, @dowdiness/canopy/core.ProjNode[T], @dowdiness/canopy/core.SourceMap) -> (Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint)? raise @dowdiness/canopy/core.EditError, on_no_edit~ : (Op) -> Unit raise @dowdiness/canopy/core.EditError) -> Self[T, Op]
+pub fn[T, Op] LanguageSpec::LanguageSpec(make_parser~ : (@diagnostic.SourceId, String, @cells.Runtime?) -> @pipeline.Parser[T], build_memos~ : (@pipeline.Parser[T]) -> (@cells.Derived[@core.ProjNode[T]?], @cells.Derived[Map[@core.NodeId, @core.ProjNode[T]]], @cells.Derived[@core.SourceMap]), compute_edit~ : (Op, String, @core.ProjNode[T], @core.SourceMap) -> (Array[@core.SpanEdit], @core.FocusHint)? raise @core.EditError, on_no_edit~ : (Op) -> Unit raise @core.EditError) -> Self[T, Op]
 pub fn[T : Eq, Op] LanguageSpec::apply_edit(Self[T, Op], @editor.SyncEditor[T], Op, Int) -> Result[Unit, String]
 pub fn[T, Op] LanguageSpec::new_editor(Self[T, Op], String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime, capabilities? : @editor.LanguageCapabilities[T]) -> @editor.SyncEditor[T] raise @text.TextError
 

--- a/moon.mod
+++ b/moon.mod
@@ -7,6 +7,7 @@ import {
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
   "dowdiness/incr@0.14.2",
+  "dowdiness/diagnostic@0.1.0",
   "dowdiness/event-graph-walker@0.6.0",
   "dowdiness/byte_codec@0.1.0",
   "dowdiness/text_change@0.1.0",

--- a/moon.work
+++ b/moon.work
@@ -7,6 +7,7 @@ members = [
   "./alga",
   "./event-graph-walker",
   "./order-tree",
+  "./loom/diagnostic",
   "./loom/examples/markdown",
   "./loom/examples/jsx",
   "./loom/examples/json",

--- a/probe/diagnostic_portability/moon.pkg
+++ b/probe/diagnostic_portability/moon.pkg
@@ -1,4 +1,4 @@
 import {
+  "dowdiness/diagnostic",
   "dowdiness/lambda",
-  "dowdiness/loom/core" @loomcore,
 }

--- a/probe/diagnostic_portability/top.mbt
+++ b/probe/diagnostic_portability/top.mbt
@@ -1,8 +1,26 @@
 ///|
+priv struct PortableSourceResolver {
+  source_id : @diagnostic.SourceId
+  snapshot : @diagnostic.SourceSnapshot
+}
+
+///|
+impl @diagnostic.SourceResolver for PortableSourceResolver with fn resolve_source(
+  self,
+  requested_source_id,
+) {
+  if requested_source_id == self.source_id {
+    Some(self.snapshot)
+  } else {
+    None
+  }
+}
+
+///|
 /// Deterministic portability boundary: consumes only Lambda's public parser and
-/// Loom's neutral diagnostic values, with source text supplied externally.
+/// standalone diagnostic values, with source text supplied externally.
 fn portable_missing_else_probe() -> (String, String, Bool) raise {
-  let source_id = @loomcore.SourceId::SourceId("standalone-source")
+  let source_id = @diagnostic.SourceId("standalone-source")
   let source = "if x then y"
   let (_, diagnostics) = @lambda.parse_cst(source_id, source) catch {
     _ => fail("unexpected lex error")
@@ -23,20 +41,15 @@ fn portable_missing_else_probe() -> (String, String, Bool) raise {
   guard fixes.length() == 1 else {
     fail("expected exactly one missing-else fix")
   }
-  let provider = @loomcore.SourceProvider(requested => {
-    if requested == source_id {
-      Some(
-        @loomcore.DiagnosticSourceFile(
-          "standalone.lambda",
-          source,
-          @loomcore.LineIndex::new(source),
-        ),
-      )
-    } else {
-      None
-    }
-  })
-  let rendered = diagnostic.render_plain(provider) catch {
+  let resolver = PortableSourceResolver::{
+    source_id,
+    snapshot: @diagnostic.SourceSnapshot(
+      "standalone.lambda",
+      source,
+      @diagnostic.LineIndex::new(source),
+    ),
+  }
+  let rendered = diagnostic.render_plain(resolver) catch {
     _ => fail("expected external source provider to render diagnostic")
   }
   let fixed = fixes[0].apply(source_id, source) catch {

--- a/workspace/probe/moon.pkg
+++ b/workspace/probe/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "dowdiness/canopy/editor",
   "dowdiness/canopy/core",
+  "dowdiness/diagnostic",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr",
   "dowdiness/loom",


### PR DESCRIPTION
## Summary

- Update the Loom submodule to `d9cac9b`, including the standalone diagnostic module extraction and the reference-definition boundary fix.
- Migrate Canopy diagnostics to `DiagnosticOrigin`, `SourceResolver`, and `SourceSnapshot`, preserving the existing pure rendering boundary.
- Add projection/editor regressions for reference-definition insertion and make the isolated Canvas workspace resolve the new local diagnostic module.

## UI and review evidence

N/A — this dependency and API migration does not change rendered UI behavior.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SourceResolver`, `SourceSnapshot`, `DiagnosticOrigin` | `dowdiness/diagnostic` | Yes | Canonical replacements for the APIs extracted from Loom core. |
| `MarkdownEditor::commit`, `MarkdownEditRequest::ReplaceText` | `editor/markdown` | Yes | Exercises the public editor facade without adding a parallel edit path. |
| `syntax_to_proj_node`, `source_map_for` | `lang/markdown/proj` | Yes | Reuses the existing projection and source-map boundaries in the regression. |
| `Option` | MoonBit core | Yes | Represents whether a requested source snapshot is available. |
| `Vector::length`, `Vector::get` | MoonBit core | Yes | Reads projected blocks without adding collection traversal helpers. |
| `Eq` for `SourceId` | `dowdiness/diagnostic` | Yes | Canvas wbtests import the defining package directly so the derived identity comparison remains available. |
| `SourceProvider`, `DiagnosticSourceFile` | previous Loom core API | No | Removed by the standalone diagnostic module extraction. |

New helpers added:

- `CurrentSourceResolver` and `diagnostic_source_resolver` adapt one immutable editor source snapshot to the new `SourceResolver` trait. They contain no I/O or mutable application state.
- Test-only resolver structs provide the same explicit boundary for semantic and portability tests.

Remaining imperative code is limited to the existing editor commit/render shell; the new resolver is a deterministic value adapter.

## Validation scope

Boundary matrix / first failing regression:

- Inserting a reference definition before a heading and paragraph must preserve the following projected blocks, source text, and block identities through both direct projection and the public Markdown editor facade.
- The first regression failed against the previous Loom pin with three projected blocks instead of two, then passed after the Loom update.
- The Canvas isolated workspace check reproduced both missing local module resolution and missing defining-package trait visibility before its workspace, module, and wbtest package dependencies were declared.

Target packages:

- `cmd/main`
- `editor`
- `editor/markdown`
- `ffi/jsx`
- `ffi/lambda`
- `lang/json/proj`
- `lang/jsx/proj`
- `lang/lambda/proj`
- `lang/lambda/semantic`
- `lang/markdown/proj`
- `lang/runtime`
- `probe/diagnostic_portability`
- `workspace/probe`

Additional conditional gates:

- Loom Markdown tests: 552 passed.
- Canvas's exact `ci-lenient` module command passed with 47 tests after reproducing the missing `SourceId` `Eq` visibility failure.
- Release JavaScript artifacts, including the isolated Canvas build, succeeded.
- Independent MoonBit review returned PASS with no findings.

## PR-ready evidence

Validated HEAD: `d1b46f9457cbdd5e167a06b1d045bc711191ff0d`

Validated base: `origin/main@b8fece6301a4147bcf9d9ebdf6461c370855e20c`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target cmd/main \
  --target editor \
  --target editor/markdown \
  --target ffi/jsx \
  --target ffi/lambda \
  --target lang/json/proj \
  --target lang/jsx/proj \
  --target lang/lambda/proj \
  --target lang/lambda/semantic \
  --target lang/markdown/proj \
  --target lang/runtime \
  --target probe/diagnostic_portability \
  --target workspace/probe
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
./scripts/check-test-baseline.sh 7 \
  ./scripts/run-moon-module.sh "ci-lenient" "examples/canvas"
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff was reviewed; ownership references intentionally move to `@diagnostic.SourceId`, with no unintended trait-bound drift.
- [x] The Loom commit is reachable from its configured upstream remote; no submodule source was modified.
- [x] Validation was rerun after the final amend, workspace-manifest change, submodule-pointer change, and generated-interface update.
- [x] Independent review findings were resolved before final validation.
