### PR TITLE
feat(dom-boundary): add typed text controls

### DIFF
--- a/lib/dom-boundary/dom_boundary.mbt
+++ b/lib/dom-boundary/dom_boundary.mbt
@@ -10,9 +10,34 @@ pub(all) enum DomAction {
   Focus
   Click
   ScrollIntoView
+  ReadTextSelection
+  WriteTextSelection
+  MeasureElement
   DispatchCustomEvent
   ListenCustomEvent
   RemoveCustomEventListener
+} derive(Debug, Eq)
+
+///|
+pub(all) enum TextSelectionDirection {
+  NoDirection
+  Forward
+  Backward
+} derive(Debug, Eq)
+
+///|
+/// An immutable half-open text selection measured in UTF-16 code units.
+pub struct TextSelection {
+  priv start : Int
+  priv end : Int
+  priv direction : TextSelectionDirection
+} derive(Debug, Eq)
+
+///|
+/// A detached element measurement in CSS pixels.
+pub struct ElementMeasurement {
+  priv offset_width : Double
+  priv offset_height : Double
 } derive(Debug, Eq)
 
 ///|
@@ -36,6 +61,11 @@ pub(all) suberror DomBoundaryError {
   InvalidSelector(selector~ : String, detail~ : String)
   ElementNotFound(target~ : DomTarget)
   UnsupportedAction(action~ : DomAction, target~ : DomTarget)
+  InvalidTextSelection(
+    selection~ : TextSelection,
+    value_length~ : Int,
+    target~ : DomTarget
+  )
   ActionFailed(action~ : DomAction, target~ : DomTarget, detail~ : String)
   UnknownStatus(
     status~ : Int,
@@ -63,6 +93,48 @@ pub struct CustomEventSubscription {
 }
 
 ///|
+pub fn TextSelection::TextSelection(
+  start : Int,
+  end : Int,
+  direction : TextSelectionDirection,
+) -> TextSelection {
+  { start, end, direction }
+}
+
+///|
+pub fn TextSelection::start(self : TextSelection) -> Int {
+  self.start
+}
+
+///|
+pub fn TextSelection::end(self : TextSelection) -> Int {
+  self.end
+}
+
+///|
+pub fn TextSelection::direction(self : TextSelection) -> TextSelectionDirection {
+  self.direction
+}
+
+///|
+fn ElementMeasurement::ElementMeasurement(
+  offset_width : Double,
+  offset_height : Double,
+) -> ElementMeasurement {
+  { offset_width, offset_height }
+}
+
+///|
+pub fn ElementMeasurement::offset_width(self : ElementMeasurement) -> Double {
+  self.offset_width
+}
+
+///|
+pub fn ElementMeasurement::offset_height(self : ElementMeasurement) -> Double {
+  self.offset_height
+}
+
+///|
 pub impl Show for DomBoundaryError with fn output(self, logger) {
   logger.write_string(@debug.to_string(self))
 }
@@ -76,6 +148,8 @@ pub fn DomBoundaryError::message(self : DomBoundaryError) -> String {
     ElementNotFound(target~) => "DOM element not found: \{target.describe()}"
     UnsupportedAction(action~, target~) =>
       "DOM element does not support \{action.describe()}: \{target.describe()}"
+    InvalidTextSelection(selection~, value_length~, target~) =>
+      "invalid text selection [\{selection.start()}, \{selection.end()}) for UTF-16 length \{value_length}: \{target.describe()}"
     ActionFailed(action~, target~, detail~) =>
       with_detail(
         "DOM \{action.describe()} failed: \{target.describe()}",
@@ -125,6 +199,55 @@ pub fn scroll_selector(
   block? : ScrollBlock = Nearest,
 ) -> Unit raise DomBoundaryError {
   scroll_target(LOOKUP_SELECTOR, selector, Selector(selector), behavior, block)
+}
+
+///|
+pub fn read_text_selection_id(
+  id : String,
+) -> TextSelection raise DomBoundaryError {
+  read_text_selection_target(LOOKUP_ID, id, Id(id))
+}
+
+///|
+pub fn read_text_selection_selector(
+  selector : String,
+) -> TextSelection raise DomBoundaryError {
+  read_text_selection_target(LOOKUP_SELECTOR, selector, Selector(selector))
+}
+
+///|
+pub fn write_text_selection_id(
+  id : String,
+  selection : TextSelection,
+) -> Unit raise DomBoundaryError {
+  write_text_selection_target(LOOKUP_ID, id, Id(id), selection)
+}
+
+///|
+pub fn write_text_selection_selector(
+  selector : String,
+  selection : TextSelection,
+) -> Unit raise DomBoundaryError {
+  write_text_selection_target(
+    LOOKUP_SELECTOR,
+    selector,
+    Selector(selector),
+    selection,
+  )
+}
+
+///|
+pub fn measure_element_id(
+  id : String,
+) -> ElementMeasurement raise DomBoundaryError {
+  measure_element_target(LOOKUP_ID, id, Id(id))
+}
+
+///|
+pub fn measure_element_selector(
+  selector : String,
+) -> ElementMeasurement raise DomBoundaryError {
+  measure_element_target(LOOKUP_SELECTOR, selector, Selector(selector))
 }
 
 ///|

--- a/lib/dom-boundary/dom_boundary_runtime.mbt
+++ b/lib/dom-boundary/dom_boundary_runtime.mbt
@@ -23,6 +23,14 @@ const LOOKUP_ID : String = "id"
 const LOOKUP_SELECTOR : String = "selector"
 
 ///|
+#external
+priv type DomTextSelection
+
+///|
+#external
+priv type DomElementMeasurement
+
+///|
 /// Resolve an element ID using the host's native lookup when available.
 /// Shadow-root-like scopes lack `getElementById`, so child traversal is the
 /// fallback for those scopes.
@@ -199,6 +207,121 @@ fn scroll_target(
 }
 
 ///|
+fn read_text_selection_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+) -> TextSelection raise DomBoundaryError {
+  let element = resolve_target(
+    lookup_kind,
+    raw_target,
+    ReadTextSelection,
+    target,
+  )
+  let supported : Bool = run_dom_operation(ReadTextSelection, target, () => {
+    @js.any(js_text_selection_supported(element))
+  }).cast()
+  guard supported else {
+    raise UnsupportedAction(action=ReadTextSelection, target~)
+  }
+  let raw : DomTextSelection = run_dom_operation(ReadTextSelection, target, () => {
+    @js.any(js_read_text_selection(element))
+  }).cast()
+  TextSelection(
+    dom_text_selection_start(raw),
+    dom_text_selection_end(raw),
+    decode_text_selection_direction(dom_text_selection_direction(raw), target),
+  )
+}
+
+///|
+fn decode_text_selection_direction(
+  direction : String,
+  target : DomTarget,
+) -> TextSelectionDirection raise DomBoundaryError {
+  match direction {
+    "none" => NoDirection
+    "forward" => Forward
+    "backward" => Backward
+    _ =>
+      raise ActionFailed(
+        action=ReadTextSelection,
+        target~,
+        detail="unknown text selection direction: \{direction}",
+      )
+  }
+}
+
+///|
+fn validate_text_selection_range(
+  selection : TextSelection,
+  value_length : Int,
+  target : DomTarget,
+) -> Unit raise DomBoundaryError {
+  guard selection.start() >= 0 &&
+    selection.start() <= selection.end() &&
+    selection.end() <= value_length else {
+    raise InvalidTextSelection(selection~, value_length~, target~)
+  }
+}
+
+///|
+fn write_text_selection_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+  selection : TextSelection,
+) -> Unit raise DomBoundaryError {
+  let element = resolve_target(
+    lookup_kind,
+    raw_target,
+    WriteTextSelection,
+    target,
+  )
+  let supported : Bool = run_dom_operation(WriteTextSelection, target, () => {
+    @js.any(js_text_selection_writable(element))
+  }).cast()
+  guard supported else {
+    raise UnsupportedAction(action=WriteTextSelection, target~)
+  }
+  let value_length : Int = run_dom_operation(WriteTextSelection, target, () => {
+    @js.any(js_text_value_utf16_length(element))
+  }).cast()
+  validate_text_selection_range(selection, value_length, target)
+  let _ = run_dom_operation(WriteTextSelection, target, () => {
+    js_write_text_selection(
+      element,
+      selection.start(),
+      selection.end(),
+      selection.direction().to_dom_string(),
+    )
+    @js.undefined()
+  })
+}
+
+///|
+fn measure_element_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+) -> ElementMeasurement raise DomBoundaryError {
+  let element = resolve_target(lookup_kind, raw_target, MeasureElement, target)
+  let supported : Bool = run_dom_operation(MeasureElement, target, () => {
+    @js.any(js_element_measurement_supported(element))
+  }).cast()
+  guard supported else {
+    raise UnsupportedAction(action=MeasureElement, target~)
+  }
+  let raw : DomElementMeasurement = run_dom_operation(MeasureElement, target, () => {
+    @js.any(js_measure_element(element))
+  }).cast()
+  ElementMeasurement(
+    dom_element_offset_width(raw),
+    dom_element_offset_height(raw),
+  )
+}
+
+///|
 fn dispatch_custom_event_target(
   lookup_kind : String,
   raw_target : String,
@@ -357,6 +480,9 @@ fn DomAction::describe(self : DomAction) -> String {
     Focus => "focus"
     Click => "click"
     ScrollIntoView => "scrollIntoView"
+    ReadTextSelection => "readTextSelection"
+    WriteTextSelection => "writeTextSelection"
+    MeasureElement => "measureElement"
     DispatchCustomEvent => "dispatchCustomEvent"
     ListenCustomEvent => "listenCustomEvent"
     RemoveCustomEventListener => "removeCustomEventListener"
@@ -379,6 +505,17 @@ fn ScrollBlock::to_dom_string(self : ScrollBlock) -> String {
     Center => "center"
     End => "end"
     Nearest => "nearest"
+  }
+}
+
+///|
+fn TextSelectionDirection::to_dom_string(
+  self : TextSelectionDirection,
+) -> String {
+  match self {
+    NoDirection => "none"
+    Forward => "forward"
+    Backward => "backward"
   }
 }
 
@@ -454,6 +591,84 @@ extern "js" fn js_scroll_into_view(
   #| (element, behavior, block) => {
   #|   element.scrollIntoView({ behavior, block });
   #| }
+
+///|
+extern "js" fn js_text_selection_supported(element : DomElement) -> Bool =
+  #| (element) => typeof element.value === "string" &&
+  #|   typeof element.selectionStart === "number" &&
+  #|   typeof element.selectionEnd === "number" &&
+  #|   typeof element.selectionDirection === "string"
+
+///|
+extern "js" fn js_read_text_selection(element : DomElement) -> DomTextSelection =
+  #| (element) => ({
+  #|   start: element.selectionStart,
+  #|   end: element.selectionEnd,
+  #|   direction: element.selectionDirection,
+  #| })
+
+///|
+extern "js" fn js_text_selection_writable(element : DomElement) -> Bool =
+  #| (element) => typeof element.value === "string" &&
+  #|   typeof element.selectionStart === "number" &&
+  #|   typeof element.selectionEnd === "number" &&
+  #|   typeof element.selectionDirection === "string" &&
+  #|   typeof element.setSelectionRange === "function"
+
+///|
+extern "js" fn js_text_value_utf16_length(element : DomElement) -> Int =
+  #| (element) => element.value.length
+
+///|
+extern "js" fn js_write_text_selection(
+  element : DomElement,
+  start : Int,
+  end : Int,
+  direction : String,
+) -> Unit =
+  #| (element, start, end, direction) => {
+  #|   element.setSelectionRange(start, end, direction);
+  #| }
+
+///|
+extern "js" fn dom_text_selection_start(selection : DomTextSelection) -> Int =
+  #| (selection) => selection.start
+
+///|
+extern "js" fn dom_text_selection_end(selection : DomTextSelection) -> Int =
+  #| (selection) => selection.end
+
+///|
+extern "js" fn dom_text_selection_direction(
+  selection : DomTextSelection,
+) -> String =
+  #| (selection) => selection.direction
+
+///|
+extern "js" fn js_element_measurement_supported(element : DomElement) -> Bool =
+  #| (element) => typeof element.offsetWidth === "number" &&
+  #|   typeof element.offsetHeight === "number"
+
+///|
+extern "js" fn js_measure_element(
+  element : DomElement,
+) -> DomElementMeasurement =
+  #| (element) => ({
+  #|   offsetWidth: element.offsetWidth,
+  #|   offsetHeight: element.offsetHeight,
+  #| })
+
+///|
+extern "js" fn dom_element_offset_width(
+  measurement : DomElementMeasurement,
+) -> Double =
+  #| (measurement) => measurement.offsetWidth
+
+///|
+extern "js" fn dom_element_offset_height(
+  measurement : DomElementMeasurement,
+) -> Double =
+  #| (measurement) => measurement.offsetHeight
 
 ///|
 extern "js" fn js_dispatch_custom_event(

--- a/lib/dom-boundary/dom_boundary_wbtest.mbt
+++ b/lib/dom-boundary/dom_boundary_wbtest.mbt
@@ -146,6 +146,128 @@ extern "js" fn clear_descendant_document() -> Unit =
   #| }
 
 ///|
+extern "js" fn install_text_control_document(
+  id : String,
+  value : String,
+  start : Int,
+  end : Int,
+  direction : String,
+) -> Unit =
+  #| (id, value, start, end, direction) => {
+  #|   const control = {
+  #|     id,
+  #|     value,
+  #|     selectionStart: start,
+  #|     selectionEnd: end,
+  #|     selectionDirection: direction,
+  #|     setSelectionRange(nextStart, nextEnd, nextDirection) {
+  #|       globalThis.__canopyTextSelectionWrites += 1;
+  #|       this.selectionStart = nextStart;
+  #|       this.selectionEnd = nextEnd;
+  #|       this.selectionDirection = nextDirection;
+  #|     },
+  #|   };
+  #|   globalThis.__canopyTextSelectionWrites = 0;
+  #|   globalThis.document = {
+  #|     getElementById: target => target === id ? control : null,
+  #|     querySelector: selector => selector === `#${id}` ? control : null,
+  #|   };
+  #| }
+
+///|
+extern "js" fn install_throwing_capability_document(
+  id : String,
+  message : String,
+) -> Unit =
+  #| (id, message) => {
+  #|   const element = new Proxy({ id }, {
+  #|     get(target, property) {
+  #|       if (property === "id") return target.id;
+  #|       throw new Error(message);
+  #|     },
+  #|   });
+  #|   globalThis.document = {
+  #|     getElementById: target => target === id ? element : null,
+  #|     querySelector: selector => selector === `#${id}` ? element : null,
+  #|   };
+  #| }
+
+///|
+extern "js" fn install_unsupported_text_input_document(id : String) -> Unit =
+  #| (id) => {
+  #|   const input = {
+  #|     id,
+  #|     value: "123",
+  #|     selectionStart: null,
+  #|     selectionEnd: null,
+  #|     selectionDirection: null,
+  #|     setSelectionRange() {
+  #|       throw new Error("selection unsupported");
+  #|     },
+  #|   };
+  #|   globalThis.document = {
+  #|     getElementById: target => target === id ? input : null,
+  #|     querySelector: selector => selector === `#${id}` ? input : null,
+  #|   };
+  #| }
+
+///|
+extern "js" fn update_text_control_selection(
+  id : String,
+  start : Int,
+  end : Int,
+  direction : String,
+) -> Unit =
+  #| (id, start, end, direction) => {
+  #|   const control = globalThis.document.getElementById(id);
+  #|   control.setSelectionRange(start, end, direction);
+  #| }
+
+///|
+extern "js" fn text_control_selection(id : String) -> String =
+  #| (id) => {
+  #|   const control = globalThis.document.getElementById(id);
+  #|   return [
+  #|     control.selectionStart,
+  #|     control.selectionEnd,
+  #|     control.selectionDirection,
+  #|   ].join(":");
+  #| }
+
+///|
+extern "js" fn text_selection_write_count() -> Int =
+  #| () => globalThis.__canopyTextSelectionWrites
+
+///|
+extern "js" fn make_text_selection_write_throw(
+  id : String,
+  message : String,
+) -> Unit =
+  #| (id, message) => {
+  #|   const element = globalThis.document.getElementById(id);
+  #|   element.setSelectionRange = () => { throw new Error(message); };
+  #| }
+
+///|
+extern "js" fn update_element_measurement(
+  id : String,
+  width : Double,
+  height : Double,
+) -> Unit =
+  #| (id, width, height) => {
+  #|   const element = globalThis.document.getElementById(id);
+  #|   element.offsetWidth = width;
+  #|   element.offsetHeight = height;
+  #| }
+
+///|
+extern "js" fn clear_text_control_document() -> Unit =
+  #| () => {
+  #|   delete globalThis.document;
+  #|   delete globalThis.__canopyTextSelectionWrites;
+  #| }
+
+///|
 test "decode_status maps invalid selectors to typed errors" {
   let captured = try {
     decode_status_parts(
@@ -504,4 +626,286 @@ test "action failures preserve action context" {
     ) => ()
     _ => fail("expected dispatch failure")
   }
+}
+
+///|
+test "read_text_selection_id returns a detached UTF-16 selection" {
+  install_text_control_document("editor", "A😀B", 1, 3, "backward")
+  let selection = read_text_selection_id("editor")
+  update_text_control_selection("editor", 0, 0, "none")
+  clear_text_control_document()
+  inspect(selection.start(), content="1")
+  inspect(selection.end(), content="3")
+  guard selection.direction() is Backward else {
+    fail("expected backward selection direction")
+  }
+}
+
+///|
+test "write_text_selection_id applies UTF-16 offsets and direction" {
+  install_text_control_document("editor", "A😀B", 0, 0, "none")
+  write_text_selection_id("editor", TextSelection(1, 3, Backward))
+  let selection = text_control_selection("editor")
+  clear_text_control_document()
+  inspect(selection, content="1:3:backward")
+}
+
+///|
+test "measure_element_id returns a detached immutable measurement" {
+  install_text_control_document("editor", "text", 0, 0, "none")
+  update_element_measurement("editor", 120.5, 48.25)
+  let measurement = measure_element_id("editor")
+  update_element_measurement("editor", 0.0, 0.0)
+  clear_text_control_document()
+  inspect(measurement.offset_width(), content="120.5")
+  inspect(measurement.offset_height(), content="48.25")
+}
+
+///|
+test "selector text controls preserve collapsed forward selections" {
+  install_text_control_document("editor", "A😀B", 1, 3, "backward")
+  write_text_selection_selector("#editor", TextSelection(3, 3, Forward))
+  let selection = read_text_selection_selector("#editor")
+  clear_text_control_document()
+  inspect(selection.start(), content="3")
+  inspect(selection.end(), content="3")
+  guard selection.direction() is Forward else {
+    fail("expected forward selection direction")
+  }
+}
+
+///|
+test "invalid text selection ranges reject atomically" {
+  install_text_control_document("editor", "A😀B", 1, 3, "backward")
+  let negative = try {
+    write_text_selection_id("editor", TextSelection(-1, 1, Forward))
+    None
+  } catch {
+    error => Some(error)
+  }
+  let reversed = try {
+    write_text_selection_id("editor", TextSelection(3, 2, Forward))
+    None
+  } catch {
+    error => Some(error)
+  }
+  let too_long = try {
+    write_text_selection_id("editor", TextSelection(0, 5, Forward))
+    None
+  } catch {
+    error => Some(error)
+  }
+  let selection = text_control_selection("editor")
+  let writes = text_selection_write_count()
+  clear_text_control_document()
+  guard negative is Some(InvalidTextSelection(value_length=4, ..)) else {
+    fail("expected negative selection to be rejected")
+  }
+  guard reversed is Some(InvalidTextSelection(value_length=4, ..)) else {
+    fail("expected reversed selection to be rejected")
+  }
+  guard too_long is Some(InvalidTextSelection(value_length=4, ..)) else {
+    fail("expected overlong selection to be rejected")
+  }
+  inspect(selection, content="1:3:backward")
+  inspect(writes, content="0")
+}
+
+///|
+test "text selection and measurement reject unsupported elements" {
+  install_descendant_document("host", "menu", "item", false, false)
+  let read_error = try {
+    let _ = read_text_selection_id("host")
+    None
+  } catch {
+    error => Some(error)
+  }
+  let write_error = try {
+    write_text_selection_id("host", TextSelection(0, 0, NoDirection))
+    None
+  } catch {
+    error => Some(error)
+  }
+  let measure_error = try {
+    let _ = measure_element_id("host")
+    None
+  } catch {
+    error => Some(error)
+  }
+  clear_descendant_document()
+  guard read_error
+    is Some(UnsupportedAction(action=ReadTextSelection, target=Id("host"))) else {
+    fail("expected unsupported text selection read")
+  }
+  guard write_error
+    is Some(UnsupportedAction(action=WriteTextSelection, target=Id("host"))) else {
+    fail("expected unsupported text selection write")
+  }
+  guard measure_error
+    is Some(UnsupportedAction(action=MeasureElement, target=Id("host"))) else {
+    fail("expected unsupported element measurement")
+  }
+}
+
+///|
+test "write rejects input types without text selection support" {
+  install_unsupported_text_input_document("number-input")
+  let captured = try {
+    write_text_selection_id("number-input", TextSelection(0, 1, NoDirection))
+    None
+  } catch {
+    error => Some(error)
+  }
+  clear_fake_document()
+  guard captured
+    is Some(
+      UnsupportedAction(action=WriteTextSelection, target=Id("number-input"))
+    ) else {
+    fail("expected unsupported input type")
+  }
+}
+
+///|
+test "capability getter exceptions retain action context" {
+  install_throwing_capability_document("editor", "getter failed")
+  let selection_error = try {
+    let _ = read_text_selection_id("editor")
+    None
+  } catch {
+    error => Some(error)
+  }
+  let measurement_error = try {
+    let _ = measure_element_selector("#editor")
+    None
+  } catch {
+    error => Some(error)
+  }
+  clear_fake_document()
+  guard selection_error
+    is Some(
+      ActionFailed(
+        action=ReadTextSelection,
+        target=Id("editor"),
+        detail="getter failed"
+      )
+    ) else {
+    fail("expected selection getter failure")
+  }
+  guard measurement_error
+    is Some(
+      ActionFailed(
+        action=MeasureElement,
+        target=Selector("#editor"),
+        detail="getter failed"
+      )
+    ) else {
+    fail("expected measurement getter failure")
+  }
+}
+
+///|
+test "measure_element_selector resolves selector targets" {
+  install_text_control_document("editor", "text", 0, 0, "none")
+  update_element_measurement("editor", 80.0, 32.0)
+  let measurement = measure_element_selector("#editor")
+  clear_text_control_document()
+  inspect(measurement.offset_width(), content="80")
+  inspect(measurement.offset_height(), content="32")
+}
+
+///|
+test "new DOM actions retain missing and invalid target errors" {
+  install_text_control_document("editor", "text", 0, 0, "none")
+  let missing = try {
+    let _ = read_text_selection_id("missing")
+    None
+  } catch {
+    error => Some(error)
+  }
+  clear_text_control_document()
+  install_throwing_query_document("bad selector")
+  let invalid = try {
+    let _ = measure_element_selector("[")
+    None
+  } catch {
+    error => Some(error)
+  }
+  clear_fake_document()
+  guard missing is Some(ElementNotFound(target=Id("missing"))) else {
+    fail("expected missing text control")
+  }
+  guard invalid is Some(InvalidSelector(selector="[", detail="bad selector")) else {
+    fail("expected invalid measurement selector")
+  }
+}
+
+///|
+test "text selection write exceptions retain action context" {
+  install_text_control_document("editor", "text", 1, 2, "forward")
+  make_text_selection_write_throw("editor", "write failed")
+  let captured = try {
+    write_text_selection_id("editor", TextSelection(0, 2, NoDirection))
+    None
+  } catch {
+    error => Some(error)
+  }
+  let selection = text_control_selection("editor")
+  clear_text_control_document()
+  guard captured
+    is Some(
+      ActionFailed(
+        action=WriteTextSelection,
+        target=Id("editor"),
+        detail="write failed"
+      )
+    ) else {
+    fail("expected text selection write failure")
+  }
+  inspect(selection, content="1:2:forward")
+}
+
+///|
+test "no-direction text selection round-trips" {
+  install_text_control_document("editor", "text", 1, 2, "forward")
+  write_text_selection_id("editor", TextSelection(2, 2, NoDirection))
+  let selection = read_text_selection_id("editor")
+  clear_text_control_document()
+  guard selection.direction() is NoDirection else {
+    fail("expected no-direction selection")
+  }
+}
+
+///|
+test "unknown text selection directions retain action context" {
+  install_text_control_document("editor", "text", 1, 2, "sideways")
+  let captured = try {
+    let _ = read_text_selection_id("editor")
+    None
+  } catch {
+    error => Some(error)
+  }
+  clear_text_control_document()
+  guard captured
+    is Some(
+      ActionFailed(
+        action=ReadTextSelection,
+        target=Id("editor"),
+        detail="unknown text selection direction: sideways"
+      )
+    ) else {
+    fail("expected unknown selection direction failure")
+  }
+}
+
+///|
+test "invalid text selection error message includes UTF-16 context" {
+  let error = InvalidTextSelection(
+    selection=TextSelection(-1, 5, NoDirection),
+    value_length=4,
+    target=Selector("#editor"),
+  )
+  inspect(
+    error.message(),
+    content="invalid text selection [-1, 5) for UTF-16 length 4: #editor",
+  )
 }

--- a/lib/dom-boundary/pkg.generated.mbti
+++ b/lib/dom-boundary/pkg.generated.mbti
@@ -26,9 +26,21 @@ pub fn listen_custom_event_id(String, String, (String) -> Unit) -> CustomEventSu
 
 pub fn listen_custom_event_selector(String, String, (String) -> Unit) -> CustomEventSubscription raise DomBoundaryError
 
+pub fn measure_element_id(String) -> ElementMeasurement raise DomBoundaryError
+
+pub fn measure_element_selector(String) -> ElementMeasurement raise DomBoundaryError
+
+pub fn read_text_selection_id(String) -> TextSelection raise DomBoundaryError
+
+pub fn read_text_selection_selector(String) -> TextSelection raise DomBoundaryError
+
 pub fn scroll_id(String, behavior? : ScrollBehavior, block? : ScrollBlock) -> Unit raise DomBoundaryError
 
 pub fn scroll_selector(String, behavior? : ScrollBehavior, block? : ScrollBlock) -> Unit raise DomBoundaryError
+
+pub fn write_text_selection_id(String, TextSelection) -> Unit raise DomBoundaryError
+
+pub fn write_text_selection_selector(String, TextSelection) -> Unit raise DomBoundaryError
 
 // Errors
 pub(all) suberror DomBoundaryError {
@@ -36,6 +48,7 @@ pub(all) suberror DomBoundaryError {
   InvalidSelector(selector~ : String, detail~ : String)
   ElementNotFound(target~ : DomTarget)
   UnsupportedAction(action~ : DomAction, target~ : DomTarget)
+  InvalidTextSelection(selection~ : TextSelection, value_length~ : Int, target~ : DomTarget)
   ActionFailed(action~ : DomAction, target~ : DomTarget, detail~ : String)
   UnknownStatus(status~ : Int, action~ : DomAction, target~ : DomTarget, detail~ : String)
 } derive(Eq, @debug.Debug)
@@ -52,6 +65,9 @@ pub(all) enum DomAction {
   Focus
   Click
   ScrollIntoView
+  ReadTextSelection
+  WriteTextSelection
+  MeasureElement
   DispatchCustomEvent
   ListenCustomEvent
   RemoveCustomEventListener
@@ -62,6 +78,12 @@ pub(all) enum DomTarget {
   Selector(String)
   EventSubscription
 } derive(Eq, @debug.Debug)
+
+pub struct ElementMeasurement {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn ElementMeasurement::offset_height(Self) -> Double
+pub fn ElementMeasurement::offset_width(Self) -> Double
 
 pub(all) enum ScrollBehavior {
   Auto
@@ -74,6 +96,20 @@ pub(all) enum ScrollBlock {
   Center
   End
   Nearest
+} derive(Eq, @debug.Debug)
+
+pub struct TextSelection {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn TextSelection::TextSelection(Int, Int, TextSelectionDirection) -> Self
+pub fn TextSelection::direction(Self) -> TextSelectionDirection
+pub fn TextSelection::end(Self) -> Int
+pub fn TextSelection::start(Self) -> Int
+
+pub(all) enum TextSelectionDirection {
+  NoDirection
+  Forward
+  Backward
 } derive(Eq, @debug.Debug)
 
 // Type aliases


### PR DESCRIPTION
## Summary

- Add typed, immutable UTF-16 text-selection read/write capabilities for ID and selector targets.
- Add detached `offsetWidth`/`offsetHeight` measurement without exposing DOM handles or mutable state.
- Preserve categorized DOM boundary errors and reject invalid selection ranges before mutation.

Closes #1071.

## UI and review evidence

N/A — this change adds a generic typed DOM boundary and boundary tests; Rabbita/browser rendering integration belongs to #1103.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `DomTarget`, `DomAction`, `DomBoundaryError` | `lib/dom-boundary` | Yes | Extended the existing target, action, and categorized-error model. |
| `resolve_target`, `run_dom_operation` | `lib/dom-boundary/dom_boundary_runtime.mbt` | Yes | Reused target lookup and JavaScript exception quarantine. |
| `@js.try_sync`, `dowdiness/js_ffi` | MoonBit JS boundary / project dependency | Yes | Preserves the existing typed FFI boundary. |
| `Option` / `Result` error-handling patterns | MoonBit core | Yes | Used the package's existing raised-error and optional lookup patterns. |
| `String` / `StringView` | MoonBit core | Checked | DOM `String.length` is required because the contract is explicitly JavaScript UTF-16 code units; no MoonBit slicing or copy is needed. |
| `Map`, `Set`, `ArrayView` | MoonBit core | Checked | The boundary returns one detached value and owns no collection. |
| Rabbita DOM measurement helpers | `rabbita/rabbita/dom` | No | They require raw typed element handles and do not preserve the ID/selector capability boundary. |
| CodeMirror `set_selection` | `lib/rabbita_codemirror` | No | Editor-specific and unsuitable for generic textarea/input controls. |

New helpers added:

- Private selection capability/snapshot helpers adapt a resolved element to detached `TextSelection` values.
- Private write helpers validate the range against the current UTF-16 value length before invoking `setSelectionRange`.
- Private measurement helpers snapshot numeric offsets into `ElementMeasurement`.

The remaining imperative code is limited to DOM property/method access and JavaScript exception quarantine.

## Validation scope

Boundary matrix / first failing regression:

- ID and selector lookup; textarea/input support and unsupported elements.
- UTF-16 non-BMP, collapsed, forward, backward, and no-direction selections.
- Negative, reversed, and overlong ranges with atomic preservation and zero setter calls.
- Missing targets, invalid selectors, unsupported input types, getter/setter exceptions, and detached measurements.
- The first RED test failed because `read_text_selection_id` was not yet defined; write and measurement APIs were introduced through equivalent RED steps.

Target packages:

- `lib/dom-boundary`

Additional conditional gates:

- Workspace check/test and JavaScript artifact build passed.
- Independent MoonBit review found no high-confidence findings.

## PR-ready evidence

Validated HEAD: `220f55bf61692e16ed9493b899a94604e357850f`

Validated base: `origin/main@3863e72742560f7e90d9b12f3b69587e7448cf0d`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target lib/dom-boundary
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; only the intended types, actions, error, and functions changed.
- [x] No submodule commit changed.
- [x] Validation was rerun after the final commit and generated-interface update.
- [x] Independent review found no unresolved findings before final validation.
