### PR TITLE
chore: adopt Rabbita 0.14.1 model-first callbacks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/dowdiness/alga.git
 [submodule "rabbita"]
 	path = rabbita
-	url = https://github.com/dowdiness/rabbita.git
+	url = https://github.com/moonbit-community/rabbita.git

--- a/examples/canvas/moon.mod.json
+++ b/examples/canvas/moon.mod.json
@@ -48,7 +48,7 @@
     },
     "moonbit-community/rabbita": {
       "path": "../../rabbita/rabbita",
-      "version": "0.12.4"
+      "version": "0.14.1"
     }
   },
   "source": ".",

--- a/examples/codemirror_demo/main/client.mbt
+++ b/examples/codemirror_demo/main/client.mbt
@@ -107,7 +107,7 @@ fn mount_cmd(emit : Emit[Msg], model : Model) -> Cmd {
 }
 
 ///|
-fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
+fn update(model : Model, msg : Msg, emit : Emit[Msg]) -> (Cmd, Model) {
   match msg {
     Mounted =>
       (@rabbita.none, with_status({ ..model, mounted: true }, "mounted editor"))
@@ -175,7 +175,7 @@ fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
 }
 
 ///|
-fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
+fn subscriptions(model : Model, emit : Emit[Msg]) -> Sub {
   guard model.mounted else { return @sub.none }
   let doc_tagger : Emit[String] = if model.use_variant_b {
     emit.map(text => DocChangedB(text))
@@ -295,8 +295,8 @@ fn main {
   fn app() {
     let (model, emit) = @rabbita.create_state_with_init(
       init=emit => (initial_model, mount_cmd(emit, initial_model)),
-      update=(emit, msg, model) => {
-        let (cmd, model) = update(emit, msg, model)
+      update=(model, msg, emit) => {
+        let (cmd, model) = update(model, msg, emit)
         (model, cmd)
       },
       subscriptions~,

--- a/examples/codemirror_demo/moon.mod
+++ b/examples/codemirror_demo/moon.mod
@@ -3,7 +3,7 @@ name = "example/codemirror_demo"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
   "dowdiness/rabbita_codemirror@0.0.1",
 }
 

--- a/examples/disclosure/README.md
+++ b/examples/disclosure/README.md
@@ -1,7 +1,7 @@
 # Disclosure example
 
 Smallest working PoC of the **headless behavior + local styling** pattern on
-rabbita 0.12.4, mirroring `examples/resizable`.
+rabbita 0.14.1, mirroring `examples/resizable`.
 
 - `DisclosureModel` (in `main/client.mbt`) owns state (`open`) and emits ARIA
   via `trigger_attrs` / `content_attrs` returning `@html.Attrs` — no styling.

--- a/examples/disclosure/main/client.mbt
+++ b/examples/disclosure/main/client.mbt
@@ -119,7 +119,7 @@ let initial_model : Model = {
 }
 
 ///|
-fn update(msg : Msg, model : Model) -> Model {
+fn update(model : Model, msg : Msg) -> Model {
   match msg {
     Toggle(i) =>
       {
@@ -136,7 +136,7 @@ fn update(msg : Msg, model : Model) -> Model {
 
 ///|
 test "toggle updates selected section only" {
-  let toggled = update(Toggle(0), initial_model)
+  let toggled = update(initial_model, Toggle(0))
   match toggled.sections {
     [first, second, third] => {
       assert_eq(first.disclosure.open, true)
@@ -166,7 +166,7 @@ fn section_view(emit : Emit[Msg], index : Int, section : Section) -> Html {
 fn view(emit : Emit[Msg], model : Model) -> Html {
   div(class="page", [
     div(class="hero", [
-      p(class="eyebrow", "Headless UI · rabbita 0.12.4"),
+      p(class="eyebrow", "Headless UI · rabbita 0.14.1"),
       h1("Disclosure"),
       p(
         class="subtitle",

--- a/examples/disclosure/moon.mod
+++ b/examples/disclosure/moon.mod
@@ -3,7 +3,7 @@ name = "example/disclosure"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"

--- a/examples/ideal/main/init.mbt
+++ b/examples/ideal/main/init.mbt
@@ -71,7 +71,7 @@ fn init_model() -> Model raise {
 }
 
 ///|
-fn subscriptions(emit : Emit[Msg], model : Model) -> Sub {
+fn subscriptions(model : Model, emit : Emit[Msg]) -> Sub {
   let editor_events = editor_dom_event_subscriptions(emit)
   let cm_events = if model.mounted {
     @cm.listen(
@@ -98,17 +98,17 @@ fn root_init(emit : Emit[Msg]) -> (RootState, Cmd) {
 
 ///|
 fn root_update(
-  emit : Emit[Msg],
-  msg : Msg,
   state : RootState,
+  msg : Msg,
+  emit : Emit[Msg],
 ) -> (RootState, Cmd) {
   let (cmd, model) = update(emit, msg, state.0)
   (RootState(model, next_root_revision(state.1)), cmd)
 }
 
 ///|
-fn root_subscriptions(emit : Emit[Msg], state : RootState) -> Sub {
-  subscriptions(emit, state.0)
+fn root_subscriptions(state : RootState, emit : Emit[Msg]) -> Sub {
+  subscriptions(state.0, emit)
 }
 
 ///|
@@ -117,7 +117,7 @@ fn main {
     let (model, emit) = @rabbita.create_state_with_init(
       init=root_init,
       update=root_update,
-      subscriptions=(emit, state) => root_subscriptions(emit, state),
+      subscriptions=root_subscriptions,
     )
     model.map(state => view(emit, state.0))
   })

--- a/examples/ideal/main/main_wbtest.mbt
+++ b/examples/ideal/main/main_wbtest.mbt
@@ -218,9 +218,9 @@ test "root reactive wrapper distinguishes adjacent updates" {
   let state = RootState(model, 0)
   inspect(state == state, content="true")
   let (next, _) = root_update(
-    test_parent_emit(),
-    OutlineNavigate("not-a-node-id"),
     state,
+    OutlineNavigate("not-a-node-id"),
+    test_parent_emit(),
   )
   inspect(state == next, content="false")
   inspect(next.1, content="1")

--- a/examples/ideal/moon.mod
+++ b/examples/ideal/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/ideal-editor"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
   "dowdiness/rabbita_codemirror@0.0.1",
   "dowdiness/rabbita-menu@0.1.0",
   "dowdiness/rabbita-tabs@0.1.0",

--- a/examples/resizable/main/client.mbt
+++ b/examples/resizable/main/client.mbt
@@ -40,7 +40,7 @@ let initial_model : Model = {
 }
 
 ///|
-fn update(_emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
+fn update(model : Model, msg : Msg, _emit : Emit[Msg]) -> (Cmd, Model) {
   match msg {
     Corner(resize_msg) => {
       let corner = model.corner.update(resize_msg)
@@ -54,7 +54,7 @@ fn update(_emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
 }
 
 ///|
-fn subscriptions(emit : Emit[Msg], model : Model) -> @sub.Sub {
+fn subscriptions(model : Model, emit : Emit[Msg]) -> @sub.Sub {
   @sub.batch([
     model.corner.subscriptions(msg => emit(Corner(msg))),
     model.split.subscriptions(msg => emit(Split(msg))),
@@ -142,8 +142,8 @@ fn main {
   fn app() {
     let (model, emit) = @rabbita.create_state(
       initial_model,
-      update=(emit, msg, model) => {
-        let (cmd, model) = update(emit, msg, model)
+      update=(model, msg, emit) => {
+        let (cmd, model) = update(model, msg, emit)
         (model, cmd)
       },
       subscriptions~,

--- a/examples/resizable/moon.mod
+++ b/examples/resizable/moon.mod
@@ -3,7 +3,7 @@ name = "example/resizable"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
   "dowdiness/rabbita-resizable@0.1.0",
 }
 

--- a/lib/context-menu/moon.mod
+++ b/lib/context-menu/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "dowdiness/rabbita-menu@0.1.0",
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"

--- a/lib/menu/moon.mod
+++ b/lib/menu/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/rabbita-menu"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
   "dowdiness/dom_boundary@0.1.0",
 }
 

--- a/lib/rabbita_codemirror/moon.mod
+++ b/lib/rabbita_codemirror/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/rabbita_codemirror"
 version = "0.0.1"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"

--- a/lib/resizable/moon.mod
+++ b/lib/resizable/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/rabbita-resizable"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"

--- a/lib/status/moon.mod
+++ b/lib/status/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/rabbita-status"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"

--- a/lib/tabs/moon.mod
+++ b/lib/tabs/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/rabbita-tabs"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"

--- a/lib/treeview/moon.mod
+++ b/lib/treeview/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/rabbita-treeview"
 version = "0.1.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Adopt canonical Rabbita 0.14.1, which includes the merged retained-subscription tagger fix from moonbit-community/rabbita#142.
- Migrate Canopy's `create_pure_state`, `create_state`, `create_state_with_init`, and subscription callbacks to the Model-first API without changing their state transitions or effects.
- Repoint the Rabbita submodule from the temporary fork to canonical upstream and align all Canopy-owned dependency declarations and Disclosure version labels with 0.14.1.

Closes #1110.

## UI and review evidence

- N/A for interaction and layout: the only rendered change is the static Disclosure dependency label from 0.12.4 to 0.14.1.
- Accessible names, focus behavior, keyboard paths, and DOM ownership are unchanged.
- The dependency and callback requirements come from #1110 and `docs/plans/2026-08-01-loomark-application-handoff.md`.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Rabbita `create_pure_state` / `create_state` / `create_state_with_init` | `rabbita/rabbita/pkg.generated.mbti` | Yes | Used with the 0.14.1 Model-first callback contracts. |
| Existing application `update` / `subscriptions` functions | Four affected example applications | Yes | Their argument order was migrated directly; no compatibility adapter was added. |
| MoonBit `Option` / `Result` | Core | No | No optional or fallible data transformation was introduced. |
| MoonBit `Array` / `Iter` | Core | No | No collection transformation or new loop was introduced. |

New helpers added: none.

Remaining imperative code is limited to the existing Rabbita application shells; this change adds no effects, lifecycle state, DOM access, or mutable collection.

## Validation scope

Boundary matrix / first failing regression:

- `create_pure_state`: `(Model, Msg) -> Model`
- state update: `(Model, Msg, Emit) -> (Model, Cmd)`
- subscriptions: `(Model, Emit) -> Sub`
- deprecated `cell*` callback order remains unchanged
- initial model, command, subscription keys, rendering, and mount behavior remain unchanged
- with only the 0.14.1 gitlink selected, workspace check failed with 10 callback-order errors across the four affected applications; the committed migration resolves them
- Rabbita `diff_subs`, `every`, and `on_resize` retained-callback regressions pass 10/10

Target packages:

- `examples/codemirror_demo/main`
- `examples/disclosure/main`
- `examples/ideal/main`
- `examples/resizable/main`
- `lib/context-menu/context_menu`
- `lib/menu/menu`
- `lib/rabbita_codemirror`
- `lib/rabbita_codemirror/js`
- `lib/resizable/resizable`
- `lib/status/status`
- `lib/tabs/tabs`
- `lib/treeview/treeview`

Additional conditional gates:

- Rabbita runtime JS tests: 10/10
- workspace tests: JS 2107/2107 and native 70/70
- Disclosure: 1/1
- isolated Canvas main JS tests: 47/47
- `moon fmt`, `moon info`, generated `.mbti` audit, and `scripts/build-js.sh`: passed
- Terra independent review: no blocker

Canvas has an independent legacy `moon.work`, so the root validator cannot target `examples/canvas/main`; it was checked and tested from `examples/canvas` instead. Its full JS workspace retains one Context Menu focus expectation failure that reproduces identically on the validated base and is not introduced here.

## PR-ready evidence

Validated HEAD: `c85ea87d03400034d6f00fcb8b13af97359dc573`

Validated base: `origin/main@8214760437ef0233f649bef42923dfaee971bc67`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target examples/codemirror_demo/main \
  --target examples/disclosure/main \
  --target examples/ideal/main \
  --target examples/resizable/main \
  --target lib/context-menu/context_menu \
  --target lib/menu/menu \
  --target lib/rabbita_codemirror \
  --target lib/rabbita_codemirror/js \
  --target lib/resizable/resizable \
  --target lib/status/status \
  --target lib/tabs/tabs \
  --target lib/treeview/treeview
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; there is no generated interface change.
- [x] The changed Rabbita commit is reachable from canonical upstream `main` through the configured submodule URL.
- [x] Validation was rerun after every amend, submodule-pointer, manifest, and documentation change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Rabbita integration to version 0.14.1 across examples and libraries.
  * Standardized callback argument ordering across demos and application setup.
* **Bug Fixes**
  * Updated examples and tests to remain compatible with the current callback APIs.
  * Preserved existing editor, subscription, and UI behavior while improving compatibility.
* **Documentation**
  * Updated displayed version references in example documentation and interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->