### PR TITLE
feat(loomark): add private single-mount development host

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@ probe/diagnostic_portability/pkg.generated.mbti whitespace=-blank-at-eof
 # MoonBit owns these generated interfaces and emits a final blank line.
 editor/markdown/pkg.generated.mbti whitespace=-blank-at-eof
 loomark/core/pkg.generated.mbti whitespace=-blank-at-eof
+loomark/internal/dev_host/pkg.generated.mbti whitespace=-blank-at-eof
+loomark/internal/rabbita/pkg.generated.mbti whitespace=-blank-at-eof

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       run_prove: ${{ steps.filter.outputs.run_prove }}
       run_e2e: ${{ steps.filter.outputs.run_e2e }}
       run_cm6_adapter_e2e: ${{ steps.filter.outputs.run_cm6_adapter_e2e }}
+      run_loomark_dev_host_e2e: ${{ steps.filter.outputs.run_loomark_dev_host_e2e }}
       run_pr_ready_bash3: ${{ steps.filter.outputs.run_pr_ready_bash3 }}
     steps:
       - uses: actions/checkout@v7
@@ -70,6 +71,14 @@ jobs:
             run_cm6_adapter_e2e:
               - 'adapters/editor-adapter/**'
               - '.github/workflows/ci.yml'
+            run_loomark_dev_host_e2e:
+              - 'loomark/**'
+              - 'editor/markdown/**'
+              - 'lib/dom-boundary/**'
+              - 'lib/js-ffi/**'
+              - 'rabbita/**'
+              - '.github/workflows/ci.yml'
+              - 'scripts/test-loomark-dev-host-e2e.sh'
             run_prove:
               - 'lib/semantic/proof/**'
               - '.github/actions/setup-moonbit/**'
@@ -761,6 +770,32 @@ jobs:
         working-directory: adapters/editor-adapter
         run: npm run test:e2e:cm6
 
+  loomark-dev-host-e2e:
+    name: Loomark Dev Host E2E
+    needs: [changes]
+    if: needs.changes.outputs.run_loomark_dev_host_e2e == 'true'
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      options: --ipc=host
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up MoonBit
+        uses: ./.github/actions/setup-moonbit
+
+      - name: Verify MoonBit installation
+        run: moon version --all
+
+      - name: Update MoonBit dependencies
+        run: ./scripts/update-moon-deps.sh
+
+      - name: Run Loomark dev-host browser suite
+        run: ./scripts/test-loomark-dev-host-e2e.sh
+
   all-checks-passed:
     name: All Checks Passed
     runs-on: ubuntu-latest
@@ -782,6 +817,7 @@ jobs:
       - demo-react-e2e
       - canvas-e2e
       - cm6-adapter-e2e
+      - loomark-dev-host-e2e
     if: always()
     steps:
       - name: Check all job statuses
@@ -809,7 +845,10 @@ jobs:
              ! ok "${{ needs.ideal-web-e2e.result }}" || \
              ! ok "${{ needs.demo-react-e2e.result }}" || \
              ! ok "${{ needs.canvas-e2e.result }}" || \
-             ! ok "${{ needs.cm6-adapter-e2e.result }}"; then
+             ! ok "${{ needs.cm6-adapter-e2e.result }}" || \
+             ! path_filtered_ok \
+               "${{ needs.loomark-dev-host-e2e.result }}" \
+               "${{ needs.changes.outputs.run_loomark_dev_host_e2e }}"; then
             echo "❌ One or more required checks failed"
             exit 1
           fi

--- a/loomark/examples/vanilla/README.md
+++ b/loomark/examples/vanilla/README.md
@@ -1,0 +1,35 @@
+# Loomark private development host
+
+This directory is a disposable browser harness for the pre-`MountedApp`
+Loomark application. It owns one fresh connected mount per BrowserContext and
+lets the browser suite observe detached snapshots, typed event effects, and
+Rabbita timing. It is not a public Browser App/Session contract.
+
+## Behavioral and lifetime test inventory
+
+| Boundary | Harness assertion | Lifetime claim |
+| --- | --- | --- |
+| Fresh connected host | one application mounts once into one connected container | mount ownership starts only after the fresh host is validated |
+| Second mount | a second mount attempt is rejected by the private driver | no host reuse or remount |
+| Page/process termination | the isolated page/context closes to end the run | termination is the only lifetime end; runtime cleanup is unclaimed |
+| Source/mode/event/error/focus | typed source, mode, editor, error, and focus operations remain independent of host lifetime | application behavior is testable without teardown |
+| Immediate reads / after-render writes | snapshots read committed state immediately; focus, selection, and measurement write/read after the corresponding render command | no synchronous read-after-write assumption |
+| Selection / measurement | supported capabilities succeed; unsupported or failed capabilities report typed boundary errors | DOM capability semantics belong to `dom-boundary` |
+| Listener load / tagger refresh / unload | one retained-key test listener is installed, its source-dependent tagger refreshes through `RunningSub.update_tagger`, unload removes it exactly once, and repeated cleanup stops delivery | control transport remains available while the test listener is stopped |
+| Fatal driver state | fatal application errors reject later private driver operations with an operation/reason snapshot | the control listener remains reachable so rejection is observable; no teardown claim is made |
+| Forbidden paths | no clear, reuse, remount, transfer, or cleanup approximation appears in a case | a new page/process is used for every isolated case |
+
+The one mount-ownership site in the private adapter is the migration point that
+#1072 will replace with Rabbita `MountedApp::unmount`. That migration must add
+disposal, repeated-unmount, fatal-cleanup, reentrancy, remount, and host-reuse
+tests before deleting this adapter and harness.
+
+## Driver seam
+
+The generated JavaScript for `internal/dev_host` is private test infrastructure.
+Its exports accept `String`/`Int` arguments and return `Unit` or serialized
+status/snapshot `String`s. Each request is encoded in MoonBit, dispatched
+through typed `dom-boundary` custom-event APIs (the DOM `CustomEvent.detail` is
+a `String`), and decoded into a typed `DriverEvent`; there is no live enqueue
+closure or global handle registry. Raw DOM/Rabbita values, `MarkdownApp`,
+`MarkdownSession`, and `unmount` are deliberately absent.

--- a/loomark/examples/vanilla/index.html
+++ b/loomark/examples/vanilla/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Loomark private host</title>
+  </head>
+  <body>
+    <main id="app"></main>
+  </body>
+</html>

--- a/loomark/examples/vanilla/package-lock.json
+++ b/loomark/examples/vanilla/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "loomark-private-vanilla-host",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loomark-private-vanilla-host",
+      "devDependencies": {
+        "@playwright/test": "1.61.1",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyTjsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": ["darwin"],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/loomark/examples/vanilla/package.json
+++ b/loomark/examples/vanilla/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "loomark-private-vanilla-host",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck:dev-host": "tsc --noEmit -p tsconfig.dev-host.json",
+    "test:dev-host": "playwright test --config=playwright.dev-host.config.ts"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/loomark/examples/vanilla/playwright.dev-host.config.ts
+++ b/loomark/examples/vanilla/playwright.dev-host.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  fullyParallel: true,
+  reporter: [["list"]],
+  use: {
+    launchOptions: {
+      args: ["--allow-file-access-from-files"],
+    },
+  },
+})

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1,0 +1,208 @@
+import { expect, test, type Browser, type BrowserContext, type Page } from "@playwright/test"
+
+const moduleUrl = new URL(
+  "../../../../_build/js/release/build/dowdiness/loomark/internal/dev_host/dev_host.js",
+  import.meta.url,
+).href
+const pageUrl = new URL("../index.html", import.meta.url).href
+
+type Host = {
+  context: BrowserContext
+  page: Page
+  mountResult: string
+}
+
+async function mountHost(browser: Browser, source: string): Promise<Host> {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto(pageUrl)
+  const mountResult = await page.evaluate(
+    ({ moduleUrl, source }) =>
+      import(moduleUrl).then(module => module.mount_dev_host("app", source)),
+    { moduleUrl, source },
+  )
+  await expect(page.locator("#loomark-root")).toBeVisible()
+  await expect.poll(async () => (await snapshot(page)).control_ready).toBe(true)
+  return { context, page, mountResult }
+}
+
+async function snapshot(page: Page): Promise<Record<string, unknown>> {
+  const raw = await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_snapshot()), moduleUrl)
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+async function requestSource(page: Page, source: string): Promise<void> {
+  await page.evaluate(
+    ({ moduleUrl, source }) =>
+      import(moduleUrl).then(module => module.dev_host_request_source(source)),
+    { moduleUrl, source },
+  )
+}
+
+async function selectPreview(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_select_preview()), moduleUrl)
+}
+
+async function focusPreview(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_focus_preview()), moduleUrl)
+}
+
+async function writeSelection(page: Page, start: number, end: number): Promise<void> {
+  await page.evaluate(
+    ({ moduleUrl, start, end }) =>
+      import(moduleUrl).then(module => module.dev_host_write_selection(start, end)),
+    { moduleUrl, start, end },
+  )
+}
+
+async function writeSelectionFailure(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_write_selection_failure()), moduleUrl)
+}
+
+async function measurePreview(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_measure_preview()), moduleUrl)
+}
+
+async function measureFailure(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_measure_failure()), moduleUrl)
+}
+
+async function stopListening(page: Page): Promise<void> {
+  await page.evaluate(moduleUrl =>
+    import(moduleUrl).then(module => module.dev_host_stop_listening()), moduleUrl)
+}
+
+async function failHost(page: Page, message: string): Promise<void> {
+  await page.evaluate(
+    ({ moduleUrl, message }) =>
+      import(moduleUrl).then(module => module.dev_host_fail(message)),
+    { moduleUrl, message },
+  )
+}
+
+async function dispatchDriverEvent(page: Page, detail: string): Promise<void> {
+  await page.evaluate(detail => {
+    const target = document.getElementById("loomark-event-target")
+    target?.dispatchEvent(new CustomEvent("loomark-test", { detail }))
+  }, detail)
+}
+
+test("mounts one fresh connected container and exposes a detached snapshot", async ({ browser }) => {
+  const host = await mountHost(browser, "# Loomark\n")
+  try {
+    expect(host.mountResult).toBe('{"ok":true}')
+    await expect(host.page.locator("#app")).toContainText("# Loomark")
+    await expect.poll(() => host.page.evaluate(() => document.getElementById("app")?.isConnected)).toBe(true)
+    expect(await snapshot(host.page)).toMatchObject({ source: "# Loomark\n", mode: "raw" })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejects a second mount without clearing or reusing the first host", async ({ browser }) => {
+  const host = await mountHost(browser, "first\n")
+  try {
+    const secondMount = await host.page.evaluate(
+      ({ moduleUrl }) => import(moduleUrl).then(module => module.mount_dev_host("app", "second\n")),
+      { moduleUrl },
+    )
+    expect(secondMount).toBe('{"ok":false,"error":"host-already-mounted"}')
+    await expect(host.page.locator("#loomark-root")).toHaveCount(1)
+    await expect(host.page.locator("#loomark-preview")).toHaveText("first\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("keeps source and mode state separate from after-render focus and DOM effects", async ({ browser }) => {
+  const host = await mountHost(browser, "# Effects\n")
+  try {
+    await requestSource(host.page, "# Updated\n")
+    await expect(host.page.locator("#loomark-preview")).toHaveText("# Updated\n")
+    await selectPreview(host.page)
+    await expect(host.page.locator("#loomark-mode")).toHaveText("mode: preview")
+
+    await focusPreview(host.page)
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-focus-target")
+
+    await writeSelection(host.page, 1, 3)
+    await expect.poll(async () => (await snapshot(host.page)).selection).toBe("1:3")
+    await writeSelectionFailure(host.page)
+    await expect.poll(async () => String((await snapshot(host.page)).error)).toContain("DOM element not found")
+
+    await measurePreview(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).measurement).toEqual(expect.stringMatching(/^[0-9]/))
+    await measureFailure(host.page)
+    await expect.poll(async () => String((await snapshot(host.page)).error)).toContain("DOM element not found")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("installs one custom listener, refreshes its tagger, and cleans up repeatedly", async ({ browser }) => {
+  const host = await mountHost(browser, "events\n")
+  try {
+    await expect.poll(async () => (await snapshot(host.page)).event_install_count).toBe(1)
+    await dispatchDriverEvent(host.page, "old")
+    await expect.poll(async () => (await snapshot(host.page)).event_count).toBe(1)
+    await expect.poll(async () => (await snapshot(host.page)).event_install_count).toBe(1)
+    expect(await snapshot(host.page)).toMatchObject({
+      event_detail: "old|events\n",
+      event_install_count: 1,
+      event_unload_count: 0,
+      listening: true,
+    })
+
+    await requestSource(host.page, "events-updated\n")
+    await expect(host.page.locator("#loomark-preview")).toHaveText("events-updated\n")
+    await dispatchDriverEvent(host.page, "new")
+    await expect.poll(async () => (await snapshot(host.page)).event_count).toBe(2)
+    expect(await snapshot(host.page)).toMatchObject({
+      event_detail: "new|events-updated\n",
+      event_install_count: 1,
+      event_unload_count: 0,
+      listening: true,
+    })
+
+    await stopListening(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).listening).toBe(false)
+    await expect.poll(async () => (await snapshot(host.page)).event_unload_count).toBe(1)
+    await stopListening(host.page)
+    await dispatchDriverEvent(host.page, "after-cleanup")
+    await expect.poll(async () => (await snapshot(host.page)).event_count).toBe(2)
+    expect(await snapshot(host.page)).toMatchObject({
+      listening: false,
+      event_detail: "new|events-updated\n",
+      event_install_count: 1,
+      event_unload_count: 1,
+    })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("enters a fatal state and rejects later driver operations", async ({ browser }) => {
+  const host = await mountHost(browser, "stable\n")
+  try {
+    await failHost(host.page, "fatal test")
+    await expect.poll(async () => (await snapshot(host.page)).fatal).toBe(true)
+    await requestSource(host.page, "must not commit\n")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("stable\n")
+    await expect.poll(async () => (await snapshot(host.page)).rejection).toBe(
+      "operation=source;reason=fatal-state",
+    )
+    expect(await snapshot(host.page)).toMatchObject({
+      fatal: true,
+      error: "fatal test",
+      rejection: "operation=source;reason=fatal-state",
+    })
+  } finally {
+    await host.context.close()
+  }
+})

--- a/loomark/examples/vanilla/tsconfig.dev-host.json
+++ b/loomark/examples/vanilla/tsconfig.dev-host.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowJs": false
+  },
+  "include": ["tests/**/*.ts"]
+}

--- a/loomark/internal/dev_host/dev_host.mbt
+++ b/loomark/internal/dev_host/dev_host.mbt
@@ -1,0 +1,55 @@
+///|
+/// Private JavaScript link root for the disposable Vanilla harness.
+pub fn mount_dev_host(host_id : String, source : String) -> String {
+  @app.mount(host_id, source)
+}
+
+///|
+pub fn dev_host_snapshot() -> String {
+  @app.snapshot()
+}
+
+///|
+pub fn dev_host_request_source(source : String) -> Unit {
+  @app.request_source(source)
+}
+
+///|
+pub fn dev_host_select_preview() -> Unit {
+  @app.select_preview()
+}
+
+///|
+pub fn dev_host_focus_preview() -> Unit {
+  @app.focus_preview()
+}
+
+///|
+pub fn dev_host_write_selection(start : Int, end : Int) -> Unit {
+  @app.write_selection(start, end)
+}
+
+///|
+pub fn dev_host_write_selection_failure() -> Unit {
+  @app.write_selection_failure()
+}
+
+///|
+pub fn dev_host_measure_preview() -> Unit {
+  @app.measure_preview()
+}
+
+///|
+pub fn dev_host_measure_failure() -> Unit {
+  @app.measure_failure()
+}
+
+///|
+pub fn dev_host_stop_listening() -> Unit {
+  @app.stop_listening()
+}
+
+///|
+pub fn dev_host_fail(message : String) -> Unit {
+  @app.fail(message)
+}

--- a/loomark/internal/dev_host/moon.pkg
+++ b/loomark/internal/dev_host/moon.pkg
@@ -1,0 +1,25 @@
+import {
+  "dowdiness/loomark/internal/rabbita" @app,
+}
+
+supported_targets = "js"
+
+options(
+  link: {
+    "js": {
+      "exports": [
+        "mount_dev_host",
+        "dev_host_snapshot",
+        "dev_host_request_source",
+        "dev_host_select_preview",
+        "dev_host_focus_preview",
+        "dev_host_write_selection",
+        "dev_host_write_selection_failure",
+        "dev_host_measure_preview",
+        "dev_host_measure_failure",
+        "dev_host_stop_listening",
+        "dev_host_fail",
+      ],
+    },
+  },
+)

--- a/loomark/internal/dev_host/pkg.generated.mbti
+++ b/loomark/internal/dev_host/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/loomark/internal/dev_host"
+
+// Values
+pub fn dev_host_fail(String) -> Unit
+
+pub fn dev_host_focus_preview() -> Unit
+
+pub fn dev_host_measure_failure() -> Unit
+
+pub fn dev_host_measure_preview() -> Unit
+
+pub fn dev_host_request_source(String) -> Unit
+
+pub fn dev_host_select_preview() -> Unit
+
+pub fn dev_host_snapshot() -> String
+
+pub fn dev_host_stop_listening() -> Unit
+
+pub fn dev_host_write_selection(Int, Int) -> Unit
+
+pub fn dev_host_write_selection_failure() -> Unit
+
+pub fn mount_dev_host(String, String) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -1,0 +1,725 @@
+///|
+/// Private pre-`MountedApp` application and test-driver seam.
+priv enum DriverEvent {
+  ReplaceSource(String)
+  SelectPreview
+  FocusPreview
+  WriteSelection(start~ : Int, end~ : Int)
+  WriteSelectionFailure
+  MeasurePreview
+  MeasureFailure
+  SelectionRead(start~ : Int, end~ : Int)
+  Measured(width~ : Double, height~ : Double)
+  EffectFailed(String)
+  CustomEvent(String)
+  ControlInstalled
+  SubscriptionInstalled
+  SubscriptionUnloaded
+  InvalidRequest(String)
+  StopListening
+  Fatal(String)
+  Resize(@common.Viewport)
+}
+
+///|
+priv suberror DriverSubscription {
+  Control(@cmd.Emit[DriverEvent])
+  Test(@cmd.Emit[String], @cmd.Emit[DriverEvent])
+}
+
+///|
+priv struct DriverModel {
+  state : @core.ApplicationState
+  document : @markdown.MarkdownDocumentSnapshot
+  fatal : Bool
+  error : String?
+  resize_count : Int
+  selection : String?
+  measurement : String?
+  event_detail : String?
+  event_count : Int
+  control_ready : Bool
+  event_install_count : Int
+  event_unload_count : Int
+  listening : Bool
+  rejection : String?
+} derive(Eq)
+
+///|
+/// The private harness has exactly one mount per page/process. This is a
+/// bounded test seam, not a reusable handle registry or lifecycle API.
+let mounted : @ref.Ref[Bool] = { val: false }
+
+///|
+let detached_snapshot : @ref.Ref[String] = { val: "{}" }
+
+///|
+fn mode_name(mode : @core.ApplicationMode) -> String {
+  match mode {
+    @core.Raw => "raw"
+    @core.Block => "block"
+    @core.Preview => "preview"
+  }
+}
+
+///|
+fn publish(model : DriverModel) -> Unit {
+  let fields : Map[String, Json] = {
+    "source": model.document.source().to_json(),
+    "mode": mode_name(model.state.mode()).to_json(),
+    "fatal": model.fatal.to_json(),
+    "resize_count": model.resize_count.to_json(),
+    "selection": match model.selection {
+      Some(selection) => selection.to_json()
+      None => Json::null()
+    },
+    "measurement": match model.measurement {
+      Some(measurement) => measurement.to_json()
+      None => Json::null()
+    },
+    "event_detail": match model.event_detail {
+      Some(detail) => detail.to_json()
+      None => Json::null()
+    },
+    "event_count": model.event_count.to_json(),
+    "control_ready": model.control_ready.to_json(),
+    "event_install_count": model.event_install_count.to_json(),
+    "event_unload_count": model.event_unload_count.to_json(),
+    "listening": model.listening.to_json(),
+    "rejection": match model.rejection {
+      Some(rejection) => rejection.to_json()
+      None => Json::null()
+    },
+    "error": match model.error {
+      Some(error) => error.to_json()
+      None => Json::null()
+    },
+  }
+  detached_snapshot.val = Json::object(fields).stringify()
+}
+
+///|
+fn preview_view(
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Html {
+  let focus_button = @html.button(
+    id="loomark-focus-target",
+    type_="button",
+    on_click=emit(FocusPreview),
+    "Focus preview",
+  )
+  let mode = @html.p(
+    id="loomark-mode",
+    "mode: " + mode_name(model.state.mode()),
+  )
+  let preview = @html.pre(
+    id="loomark-preview",
+    attrs=@html.Attrs::build().data_set(
+      "loomark-source",
+      model.document.source(),
+    ),
+    model.document.source(),
+  )
+  let input = @html.textarea(
+    id="loomark-input",
+    value=model.document.source(),
+    rows=4,
+    read_only=true,
+    "",
+  )
+  let event_button = @html.button(
+    id="loomark-event-target",
+    type_="button",
+    "Dispatch event",
+  )
+  let driver_button = @html.button(
+    id="loomark-driver-target",
+    type_="button",
+    hidden=true,
+    "Driver",
+  )
+  let error_text = match model.error {
+    Some(error) => "error: " + error
+    None => "ready"
+  }
+  @html.div(id="loomark-root", [
+    @html.h1("Loomark"),
+    mode,
+    preview,
+    input,
+    event_button,
+    driver_button,
+    focus_button,
+    @html.p(id="loomark-error", error_text),
+  ])
+}
+
+///|
+fn after_render(
+  action : (&@cmd.Scheduler) -> Unit raise @dom_boundary.DomBoundaryError,
+  failed : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    scheduler => {
+      action(scheduler) catch {
+        error => scheduler.add(failed(EffectFailed(error.message())))
+      }
+    },
+    kind=@cmd.AfterRender,
+  )
+}
+
+///|
+fn driver_event_name(event : DriverEvent) -> String {
+  match event {
+    ReplaceSource(_) => "source"
+    SelectPreview => "select-preview"
+    FocusPreview => "focus-preview"
+    WriteSelection(..) => "write-selection"
+    WriteSelectionFailure => "write-selection-failure"
+    MeasurePreview => "measure-preview"
+    MeasureFailure => "measure-failure"
+    SelectionRead(..) => "selection-read"
+    Measured(..) => "measured"
+    EffectFailed(_) => "effect-failed"
+    CustomEvent(_) => "custom-event"
+    ControlInstalled => "control-installed"
+    SubscriptionInstalled => "subscription-installed"
+    SubscriptionUnloaded => "subscription-unloaded"
+    InvalidRequest(_) => "invalid-request"
+    StopListening => "stop-listening"
+    Fatal(_) => "fatal"
+    Resize(_) => "resize"
+  }
+}
+
+///|
+/// Decode the private DOM transport without exposing a mutable application
+/// handle to the generated JavaScript boundary.
+fn parse_driver_event(detail : String) -> DriverEvent {
+  if detail == "select-preview" {
+    SelectPreview
+  } else if detail == "focus-preview" {
+    FocusPreview
+  } else if detail == "write-selection-failure" {
+    WriteSelectionFailure
+  } else if detail == "measure-preview" {
+    MeasurePreview
+  } else if detail == "measure-failure" {
+    MeasureFailure
+  } else if detail == "stop-listening" {
+    StopListening
+  } else if detail.has_prefix("source|") {
+    ReplaceSource(detail["source|".length():].to_owned())
+  } else if detail.has_prefix("write-selection|") {
+    let parts = detail["write-selection|".length():].split("|").to_array()
+    guard parts.length() == 2 else { return InvalidRequest("write-selection") }
+    let start = @string.parse_int(parts[0], base=10) catch {
+      _ => return InvalidRequest("write-selection")
+    }
+    let end = @string.parse_int(parts[1], base=10) catch {
+      _ => return InvalidRequest("write-selection")
+    }
+    WriteSelection(start~, end~)
+  } else if detail.has_prefix("fatal|") {
+    Fatal(detail["fatal|".length():].to_owned())
+  } else {
+    InvalidRequest("unknown")
+  }
+}
+
+///|
+/// Dispatch one request through the mount-owned DOM event target.
+fn dispatch_driver(detail : String) -> Unit {
+  @dom_boundary.dispatch_custom_event_id(
+    "loomark-driver-target",
+    "loomark-driver",
+    detail~,
+  ) catch {
+    _ => ()
+  }
+}
+
+///|
+fn update_model(
+  editor : @markdown.MarkdownEditor,
+  model : DriverModel,
+  event : DriverEvent,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  if model.fatal {
+    let next = {
+      ..model,
+      rejection: Some(
+        "operation=" + driver_event_name(event) + ";reason=fatal-state",
+      ),
+    }
+    publish(next)
+    return (next, @rabbita_runtime.none)
+  }
+  match event {
+    ReplaceSource(source) => {
+      let transition = @core.reduce(
+        model.state,
+        @core.ApplicationEvent::RequestCanonicalSource(source~),
+      )
+      let mut next = model
+      let mut command = @rabbita_runtime.none
+      for decision in transition.decisions() {
+        match decision {
+          @core.ReplaceCanonicalSource(source) =>
+            match
+              editor.commit(
+                @markdown.MarkdownEditRequest::ReplaceSource(source),
+              ) {
+              Ok(result) => {
+                let snapshot = match result {
+                  @markdown.Applied(snapshot) | @markdown.Unchanged(snapshot) =>
+                    snapshot
+                }
+                next = { ..next, state: transition.state(), document: snapshot }
+              }
+              Err(_) => {
+                next = { ..next, error: Some("editor commit failed") }
+                command = @rabbita_runtime.none
+              }
+            }
+          @core.SnapshotRejected(_) =>
+            next = { ..next, error: Some("snapshot rejected") }
+        }
+      }
+      publish(next)
+      (next, command)
+    }
+    SelectPreview => {
+      let transition = @core.reduce(
+        model.state,
+        @core.ApplicationEvent::SelectMode(mode=@core.Preview),
+      )
+      let next = { ..model, state: transition.state() }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    FocusPreview => {
+      publish(model)
+      (
+        model,
+        after_render(
+          scheduler => {
+            ignore(scheduler)
+            @dom_boundary.focus_id("loomark-focus-target")
+          },
+          emit,
+        ),
+      )
+    }
+    WriteSelection(start~, end~) => {
+      publish(model)
+      (
+        model,
+        after_render(
+          scheduler => {
+            let selection = @dom_boundary.TextSelection(
+              start,
+              end,
+              @dom_boundary.NoDirection,
+            )
+            @dom_boundary.write_text_selection_id("loomark-input", selection)
+            let read = @dom_boundary.read_text_selection_id("loomark-input")
+            scheduler.add(
+              emit(SelectionRead(start=read.start(), end=read.end())),
+            )
+          },
+          emit,
+        ),
+      )
+    }
+    WriteSelectionFailure => {
+      publish(model)
+      (
+        model,
+        after_render(
+          scheduler => {
+            ignore(scheduler)
+            let selection = @dom_boundary.TextSelection(
+              0,
+              1,
+              @dom_boundary.NoDirection,
+            )
+            @dom_boundary.write_text_selection_id(
+              "loomark-missing-input", selection,
+            )
+          },
+          emit,
+        ),
+      )
+    }
+    MeasurePreview => {
+      publish(model)
+      (
+        model,
+        after_render(
+          scheduler => {
+            let measurement = @dom_boundary.measure_element_id(
+              "loomark-preview",
+            )
+            scheduler.add(
+              emit(
+                Measured(
+                  width=measurement.offset_width(),
+                  height=measurement.offset_height(),
+                ),
+              ),
+            )
+          },
+          emit,
+        ),
+      )
+    }
+    MeasureFailure => {
+      publish(model)
+      (
+        model,
+        after_render(
+          scheduler => {
+            ignore(scheduler)
+            ignore(@dom_boundary.measure_element_id("loomark-missing-preview"))
+          },
+          emit,
+        ),
+      )
+    }
+    SelectionRead(start~, end~) => {
+      let next = {
+        ..model,
+        selection: Some(start.to_string() + ":" + end.to_string()),
+      }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    Measured(width~, height~) => {
+      let next = {
+        ..model,
+        measurement: Some(width.to_string() + ":" + height.to_string()),
+      }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    EffectFailed(message) => {
+      let next = { ..model, error: Some(message) }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    CustomEvent(detail) => {
+      let next = {
+        ..model,
+        event_detail: Some(detail),
+        event_count: model.event_count + 1,
+      }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    ControlInstalled => {
+      let next = { ..model, control_ready: true }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    SubscriptionInstalled => {
+      let next = { ..model, event_install_count: model.event_install_count + 1 }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    SubscriptionUnloaded => {
+      let next = { ..model, event_unload_count: model.event_unload_count + 1 }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    InvalidRequest(message) => {
+      let next = { ..model, error: Some("invalid driver request: " + message) }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    StopListening => {
+      let next = { ..model, listening: false }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    Fatal(message) => {
+      let next = { ..model, fatal: true, error: Some(message), rejection: None }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    Resize(viewport) => {
+      ignore(viewport)
+      let next = { ..model, resize_count: model.resize_count + 1 }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+  }
+}
+
+///|
+fn driver_control_subscription_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    DriverSubscription::Control(emit) => {
+      let mut tagger = emit
+      let mut disposed = false
+      let mut subscription : @dom_boundary.CustomEventSubscription? = None
+      let install = _ => {
+        guard !disposed && subscription is None else { return }
+        subscription = Some(
+          @dom_boundary.listen_custom_event_id(
+            "loomark-driver-target",
+            "loomark-driver",
+            detail => {
+              guard !disposed else { return }
+              scheduler.add(tagger(parse_driver_event(detail)))
+            },
+          ),
+        ) catch {
+          _ => None
+        }
+        match subscription {
+          Some(_) => scheduler.add(tagger(ControlInstalled))
+          None => ()
+        }
+      }
+      scheduler.run_effect(@cmd.AfterRender, install)
+      Some({
+        unload: _ => {
+          if !disposed {
+            disposed = true
+            match subscription {
+              Some(running) => running.dispose() catch { _ => () }
+              None => ()
+            }
+          }
+        },
+        update_tagger: payload => {
+          guard payload is DriverSubscription::Control(new_emit) else { return }
+          guard !disposed else { return }
+          tagger = new_emit
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+fn driver_test_subscription_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    DriverSubscription::Test(emit, lifecycle) => {
+      let mut tagger = emit
+      let mut lifecycle_tagger = lifecycle
+      let mut disposed = false
+      let mut installed = false
+      let mut subscription : @dom_boundary.CustomEventSubscription? = None
+      let install = _ => {
+        guard !disposed && subscription is None else { return }
+        subscription = Some(
+          @dom_boundary.listen_custom_event_id(
+            "loomark-event-target",
+            "loomark-test",
+            detail => {
+              guard !disposed else { return }
+              scheduler.add(tagger(detail))
+            },
+          ),
+        ) catch {
+          _ => None
+        }
+        match subscription {
+          Some(_) => {
+            installed = true
+            scheduler.add(lifecycle_tagger(SubscriptionInstalled))
+          }
+          None => ()
+        }
+      }
+      scheduler.run_effect(@cmd.AfterRender, install)
+      Some({
+        unload: scheduler => {
+          if !disposed {
+            disposed = true
+            match subscription {
+              Some(running) => {
+                running.dispose() catch {
+                  _ => ()
+                }
+                subscription = None
+              }
+              None => ()
+            }
+            if installed {
+              installed = false
+              scheduler.add(lifecycle_tagger(SubscriptionUnloaded))
+            }
+          }
+        },
+        update_tagger: payload => {
+          guard payload is DriverSubscription::Test(new_emit, new_lifecycle) else {
+            return
+          }
+          guard !disposed else { return }
+          tagger = new_emit
+          lifecycle_tagger = new_lifecycle
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+fn driver_control_subscription(emit : @cmd.Emit[DriverEvent]) -> @sub.Sub {
+  @sub.custom_sub(
+    "loomark.driver-control",
+    @sub.Local,
+    DriverSubscription::Control(emit),
+    driver_control_subscription_loader,
+  )
+}
+
+///|
+fn driver_test_subscription(
+  emit : @cmd.Emit[DriverEvent],
+  source : String,
+) -> @sub.Sub {
+  @sub.custom_sub(
+    "loomark.driver-event",
+    @sub.Local,
+    DriverSubscription::Test(
+      emit.map(detail => CustomEvent(detail + "|" + source)),
+      emit,
+    ),
+    driver_test_subscription_loader,
+  )
+}
+
+///|
+fn subscriptions(
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @sub.Sub {
+  let control = driver_control_subscription(emit)
+  if !model.listening || model.fatal {
+    control
+  } else {
+    @sub.batch([
+      @sub.on_resize(emit.map(_ => Resize({ width: 0, height: 0 }))),
+      driver_test_subscription(emit, model.document.source()),
+      control,
+    ])
+  }
+}
+
+///|
+/// Mount the private application exactly once into a fresh connected element.
+#warnings("-alert_unstable")
+pub fn mount(host_id : String, source : String) -> String {
+  if mounted.val {
+    return "{\"ok\":false,\"error\":\"host-already-mounted\"}"
+  }
+  let editor = @markdown.MarkdownEditor(agent_id="loomark-dev-host", source~) catch {
+    _ => return "{\"ok\":false,\"error\":\"editor-initialization-failed\"}"
+  }
+  let initial : DriverModel = {
+    state: @core.ApplicationState::ApplicationState(@core.Raw),
+    document: editor.snapshot(),
+    fatal: false,
+    error: None,
+    resize_count: 0,
+    selection: None,
+    measurement: None,
+    event_detail: None,
+    event_count: 0,
+    control_ready: false,
+    event_install_count: 0,
+    event_unload_count: 0,
+    listening: true,
+    rejection: None,
+  }
+  publish(initial)
+  let update = (model, event, emit) => update_model(editor, model, event, emit)
+  let app = @rabbita_runtime.new(() => {
+    let (model, emit) = @rabbita_runtime.create_state(
+      initial,
+      update~,
+      subscriptions~,
+    )
+    model.map(model => preview_view(model, emit))
+  })
+  app.mount(host_id)
+  mounted.val = true
+  "{\"ok\":true}"
+}
+
+///|
+/// Return an immutable detached snapshot for private browser assertions.
+pub fn snapshot() -> String {
+  detached_snapshot.val
+}
+
+///|
+/// Queue a typed source transaction through the Rabbita update loop.
+pub fn request_source(source : String) -> Unit {
+  dispatch_driver("source|" + source)
+}
+
+///|
+/// Queue the read-only Preview mode transition.
+pub fn select_preview() -> Unit {
+  dispatch_driver("select-preview")
+}
+
+///|
+/// Queue the focus operation; the DOM write is AfterRender.
+pub fn focus_preview() -> Unit {
+  dispatch_driver("focus-preview")
+}
+
+///|
+/// Queue a selection write followed by a read through the DOM boundary.
+pub fn write_selection(start : Int, end : Int) -> Unit {
+  dispatch_driver(
+    "write-selection|" + start.to_string() + "|" + end.to_string(),
+  )
+}
+
+///|
+/// Queue a selection write against a missing element.
+pub fn write_selection_failure() -> Unit {
+  dispatch_driver("write-selection-failure")
+}
+
+///|
+/// Queue a detached preview measurement.
+pub fn measure_preview() -> Unit {
+  dispatch_driver("measure-preview")
+}
+
+///|
+/// Queue a measurement against a missing element.
+pub fn measure_failure() -> Unit {
+  dispatch_driver("measure-failure")
+}
+
+///|
+/// Dispose the custom event subscription through the update loop.
+pub fn stop_listening() -> Unit {
+  dispatch_driver("stop-listening")
+}
+
+///|
+/// Queue a fatal driver state for negative-path assertions.
+pub fn fail(message : String) -> Unit {
+  dispatch_driver("fatal|" + message)
+}

--- a/loomark/internal/rabbita/moon.pkg
+++ b/loomark/internal/rabbita/moon.pkg
@@ -1,0 +1,20 @@
+import {
+  "dowdiness/canopy/editor/markdown",
+  "dowdiness/dom_boundary",
+  "dowdiness/loomark/core",
+  "moonbit-community/rabbita" @rabbita_runtime,
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/common",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+  "moonbitlang/core/ref",
+  "moonbitlang/core/string",
+}
+
+supported_targets = "js"
+
+options(
+  targets: { "*.mbt": [ "js" ] },
+)

--- a/loomark/internal/rabbita/pkg.generated.mbti
+++ b/loomark/internal/rabbita/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/loomark/internal/rabbita"
+
+// Values
+pub fn fail(String) -> Unit
+
+pub fn focus_preview() -> Unit
+
+pub fn measure_failure() -> Unit
+
+pub fn measure_preview() -> Unit
+
+pub fn mount(String, String) -> String
+
+pub fn request_source(String) -> Unit
+
+pub fn select_preview() -> Unit
+
+pub fn snapshot() -> String
+
+pub fn stop_listening() -> Unit
+
+pub fn write_selection(Int, Int) -> Unit
+
+pub fn write_selection_failure() -> Unit
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/loomark/moon.mod
+++ b/loomark/moon.mod
@@ -4,6 +4,9 @@ version = "0.1.0"
 
 import {
   "dowdiness/canopy@0.1.0",
+  "dowdiness/dom_boundary@0.1.0",
+  "dowdiness/js_ffi@0.1.0",
+  "moonbit-community/rabbita@0.14.1",
 }
 
 license = "Apache-2.0"
@@ -11,3 +14,5 @@ license = "Apache-2.0"
 keywords = [ "markdown", "editor", "projectional" ]
 
 description = "Pure application core for the Loomark Markdown editor"
+
+preferred_target = "js"

--- a/scripts/test-loomark-dev-host-e2e.sh
+++ b/scripts/test-loomark-dev-host-e2e.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+NEW_MOON_MOD=0 moon build --target js --release loomark/internal/dev_host
+cd loomark/examples/vanilla
+npm ci
+npm run typecheck:dev-host
+npm run test:dev-host -- "$@"


### PR DESCRIPTION
## Summary

- Closes #1103 by adding the private single-mount Loomark Rabbita development host and disposable Vanilla browser harness.
- Exercises canonical source updates, read-only Preview, after-render DOM effects, retained subscription callback replacement, deterministic listener unload, and fatal-state rejection without exposing a provisional public Session or `unmount` API.
- Adds one path-filtered CI job using the same build, typecheck, and Playwright wrapper as local validation.

## UI and review evidence

N/A for production UI. This change adds only a private disposable test host. Browser assertions cover a fresh connected container, rendered source/mode, focus, selection, measurement, and per-test BrowserContext isolation.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `reduce`, `ApplicationEvent`, `ApplicationState` | `loomark/core` | Yes | Keeps source/mode decisions in the pure application core. |
| `MarkdownEditor::commit` / `snapshot` | `editor/markdown` | Yes | Uses the canonical typed editor transaction boundary. |
| focus, selection, measurement, custom-event dispatch/listen/dispose | `lib/dom-boundary` | Yes | Keeps raw DOM handles behind the typed capability boundary. |
| `custom_cmd(AfterRender)`, `custom_sub`, `RunningSub.update_tagger`, `on_resize` | Rabbita `cmd` / `sub` | Yes | Reuses the canonical Cmd/Sub lifecycle and callback replacement contracts. |
| `Map`, `Json`, `Option`, `String` slicing/splitting, `parse_int` | MoonBit core | Yes | Builds detached snapshots and decodes the narrow private driver transport. |
| Rabbita `MountedApp::unmount` | Rabbita lifecycle API | No | Not available yet; #1072 owns migration after Rabbita #141. |
| Markdown companion low-level edit functions | `lang/markdown/companion` | No | The existing `MarkdownEditor` facade already owns the required transaction boundary. |

New helpers added:

- Snapshot/mode helpers expose immutable private browser evidence only.
- The after-render wrapper translates typed DOM failures into application events.
- Driver encode/decode helpers are limited to the disposable DOM custom-event transport and retain no live application handle.
- Subscription loaders own only listener/tagger/disposal wiring required by Rabbita `RunningSub`.

Remaining mutation is confined to the imperative shell: the mount-once guard, detached snapshot copy, and Rabbita subscription tagger/disposal state.

## Validation scope

Boundary matrix / first failing regression:

- Covers fresh/second mount, page termination, source/mode state, immediate snapshot versus after-render focus/selection/measurement, boundary failures, retained-key callback replacement, exactly-one listener install/unload, repeated cleanup, and fatal rejection.
- Before implementation, the focused browser test failed because `event_install_count` and the fatal `rejection` were absent.

Target packages:

- `loomark/internal/rabbita`
- `loomark/internal/dev_host`

Additional conditional gates:

- `./scripts/test-loomark-dev-host-e2e.sh`: release JS build, `npm ci`, TypeScript typecheck, Playwright 5/5.
- Direct Rabbita runtime regressions: 10/10.
- CM6 fixture prerequisite #1119 was squash-merged, then this branch was rebased onto its merge commit.
- Independent Terra review: PASS after all findings were resolved; post-rebase exact-HEAD audit also PASS.

## PR-ready evidence

Validated HEAD: `019195fedfa670d8b661650f290d5d0238c8dfbd`

Validated base: `origin/main@578eb7a828e4f2264cd5f954af2857e3beffa928`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target loomark/internal/rabbita \
  --target loomark/internal/dev_host
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was updated.
- [x] The committed `.mbti` diff was reviewed; only the intended private internal interfaces were added.
- [x] No submodule gitlink changed; recorded dependency commits remain reachable from their configured remotes.
- [x] Validation was rerun after every amend and generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone browser development host for the vanilla example.
  * Supports preview mounting, source updates, focus and selection interactions, measurements, event handling, and failure states.

* **Documentation**
  * Added guidance covering development-host behavior, testing, lifecycle, migration considerations, and supported boundaries.

* **Tests**
  * Added comprehensive browser-based end-to-end coverage for mounting, updates, interactions, cleanup, and fatal-state handling.
  * Integrated development-host checks into continuous integration with path-based execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->