### PR TITLE
test(editor-adapter): isolate CM6 diagnostic fixture

### DIFF
--- a/adapters/editor-adapter/test/cm6-diagnostics.spec.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.spec.ts
@@ -37,8 +37,8 @@ test("renders range and point diagnostics, then clears both", async ({ page }) =
         fix_id: 0,
       },
     ],
-    text: "if x then y else _",
-    crdtText: "if x then y else _",
+    text: "if 1 then 2 else _",
+    crdtText: "if 1 then 2 else _",
     replayAccepted: false,
   });
 

--- a/adapters/editor-adapter/test/cm6-diagnostics.ts
+++ b/adapters/editor-adapter/test/cm6-diagnostics.ts
@@ -11,7 +11,7 @@ async function main(): Promise<void> {
     throw new Error("diagnostic harness DOM is incomplete");
   }
 
-  const initialSource = "if x then y";
+  const initialSource = "if 1 then 2";
   const handle = crdt.create_editor("cm6-diagnostic-fix-e2e");
   crdt.set_text(handle, initialSource);
   const state = EditorState.create({


### PR DESCRIPTION
## Summary

- Keep the CM6 diagnostics E2E fixture focused on one range warning and one actionable EOF point diagnostic.
- Replace the open `if x then y` expression with the closed `if 1 then 2` expression so current unresolved-reference diagnostics do not leak into adapter-owned marker-count assertions.
- Preserve the diagnostic-fix intent, CRDT update, replay rejection, and clearing coverage.

## UI and review evidence

N/A. This changes only a private browser-test fixture; no production UI or adapter behavior changes.

## Reuse check

N/A. No helper, type, function, binding, or production API was added.

## Validation scope

Boundary matrix / first failing regression:

- RED: `npm run test:e2e:cm6` consistently found two `.cm-lintRange-warning` elements because `if x then y` now publishes unresolved-reference warnings for both variables; the EOF point marker was also obscured by the warning ending at EOF.
- GREEN: the closed fixture produces only the manually supplied range warning and the intended actionable EOF point diagnostic.

Target packages:

- No MoonBit package target: TypeScript-only CM6 diagnostic fixture correction.

Additional conditional gates:

- `npm run typecheck:cm6`
- `npm run build:test:cm6`
- `npm run test:e2e:cm6` — 1/1 passed

## PR-ready evidence

Validated HEAD: `36e635aa663e9579462252aca7bef0ec8da979a9`

Validated base: `origin/main@65699bab2f24b3055102ca4a786c60e5662d6139`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --no-target "TypeScript-only CM6 diagnostic fixture correction"
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] No `.mbti` or public interface changed.
- [x] No submodule gitlink changed.
- [x] Validation was run on the committed clean HEAD.
- [x] The fix was confirmed against the original Playwright failure.
