### PR TITLE
Edit lists and fenced code in Loomark Block mode

### DIFF
--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -13,6 +13,9 @@ pub(all) suberror MarkdownEditorError {
 pub(all) enum MarkdownBlockKind {
   Paragraph
   Heading(level~ : Int)
+  UnorderedListItem
+  OrderedListItem(start~ : Int, delimiter~ : String)
+  CodeBlock(info~ : String)
 } derive(Eq, Debug)
 
 ///|
@@ -27,6 +30,10 @@ pub struct MarkdownBlockSnapshot {
   priv text_end : Int
   priv marker_start : Int?
   priv marker_end : Int?
+  priv fence_open_start : Int?
+  priv fence_open_end : Int?
+  priv fence_close_start : Int?
+  priv fence_close_end : Int?
 } derive(Eq, Debug)
 
 ///|
@@ -72,6 +79,24 @@ pub fn MarkdownBlockSnapshot::text_range(self : Self) -> (Int, Int) {
 ///|
 pub fn MarkdownBlockSnapshot::marker_range(self : Self) -> (Int, Int)? {
   match (self.marker_start, self.marker_end) {
+    (Some(start), Some(end)) => Some((start, end))
+    _ => None
+  }
+}
+
+///|
+/// Exact opening-fence span for a fenced code block, including its info string.
+pub fn MarkdownBlockSnapshot::fence_open_range(self : Self) -> (Int, Int)? {
+  match (self.fence_open_start, self.fence_open_end) {
+    (Some(start), Some(end)) => Some((start, end))
+    _ => None
+  }
+}
+
+///|
+/// Exact closing-fence span for a fenced code block.
+pub fn MarkdownBlockSnapshot::fence_close_range(self : Self) -> (Int, Int)? {
+  match (self.fence_close_start, self.fence_close_end) {
     (Some(start), Some(end)) => Some((start, end))
     _ => None
   }
@@ -245,9 +270,21 @@ pub fn MarkdownEditor::commit(
       }
     }
     CommitEdit(node_id~, new_text~) =>
-      self.commit_structural(
-        @md_edits.MarkdownEditOp::CommitEdit(node_id=node_id.value, new_text~),
-      )
+      match self.editable_block_text(node_id) {
+        Some(_) =>
+          self.commit_structural(
+            @md_edits.MarkdownEditOp::CommitEdit(
+              node_id=node_id.value,
+              new_text~,
+            ),
+          )
+        None =>
+          Err(
+            MarkdownEditorError::EditFailed(
+              detail="no editable span for Markdown block target",
+            ),
+          )
+      }
     CommitTextControlEdit(node_id~, new_text~) =>
       match self.editable_block_text(node_id) {
         Some(canonical_text) => {
@@ -353,7 +390,15 @@ fn MarkdownEditor::editable_block_target(
   self : Self,
   node_id : MarkdownNodeId,
 ) -> Bool {
-  self.editable_block_text(node_id) is Some(_)
+  for block in self.snapshot().blocks().to_array() {
+    if block.node_id() == node_id {
+      return match block.kind() {
+        MarkdownBlockKind::Paragraph | MarkdownBlockKind::Heading(_) => true
+        _ => false
+      }
+    }
+  }
+  false
 }
 
 ///|
@@ -480,49 +525,166 @@ fn editable_block_snapshots(
       let source_map = editor.get_source_map()
       let blocks : Array[MarkdownBlockSnapshot] = []
       for node in root.children {
-        let kind = match node.kind {
-          @md_markdown.Paragraph(_) => Some(MarkdownBlockKind::Paragraph)
+        match node.kind {
+          @md_markdown.UnorderedList(_) | @md_markdown.OrderedList(_, _) =>
+            if tight_top_level_list(source, node, source_map) {
+              for item in node.children {
+                match item.kind {
+                  @md_markdown.UnorderedListItem(_) =>
+                    append_editable_block_snapshot(
+                      blocks,
+                      item,
+                      MarkdownBlockKind::UnorderedListItem,
+                      source,
+                      source_map,
+                    )
+                  @md_markdown.OrderedListItem(_, marker) => {
+                    guard marker is Some(_) else { continue }
+                    let marker = match marker {
+                      Some(marker) => marker
+                      None => continue
+                    }
+                    append_editable_block_snapshot(
+                      blocks,
+                      item,
+                      MarkdownBlockKind::OrderedListItem(
+                        start=marker.start(),
+                        delimiter=ordered_marker_delimiter(marker),
+                      ),
+                      source,
+                      source_map,
+                    )
+                  }
+                  _ => ()
+                }
+              }
+            }
+          @md_markdown.Paragraph(_) =>
+            append_editable_block_snapshot(
+              blocks,
+              node,
+              MarkdownBlockKind::Paragraph,
+              source,
+              source_map,
+            )
           @md_markdown.Heading(level, _) =>
-            Some(MarkdownBlockKind::Heading(level~))
-          _ => None
-        }
-        match kind {
-          None => ()
-          Some(kind) => {
-            guard source_map.get_range(node.id()) is Some(source_range) else {
-              continue
-            }
-            guard source_map.get_token_span(node.id(), "text")
-              is Some(text_span) else {
-              continue
-            }
-            let text_range = (text_span.start, text_span.end)
-            let marker_range = match
-              source_map.get_token_span(node.id(), "marker") {
-              Some(range) => Some((range.start, range.end))
-              None => None
-            }
-            blocks.push({
-              node_id: { value: node.id() },
-              kind,
-              text: source[text_range.0:text_range.1].to_owned(),
-              source_start: source_range.start,
-              source_end: source_range.end,
-              text_start: text_range.0,
-              text_end: text_range.1,
-              marker_start: match marker_range {
-                Some(range) => Some(range.0)
-                None => None
-              },
-              marker_end: match marker_range {
-                Some(range) => Some(range.1)
-                None => None
-              },
-            })
-          }
+            append_editable_block_snapshot(
+              blocks,
+              node,
+              MarkdownBlockKind::Heading(level~),
+              source,
+              source_map,
+            )
+          @md_markdown.CodeBlock(info, _) =>
+            append_editable_block_snapshot(
+              blocks,
+              node,
+              MarkdownBlockKind::CodeBlock(info~),
+              source,
+              source_map,
+            )
+          _ => ()
         }
       }
       @vector.Vector(blocks[:])
     }
+  }
+}
+
+///|
+/// Append one block whose SourceMap roles satisfy the typed façade contract.
+fn append_editable_block_snapshot(
+  blocks : Array[MarkdownBlockSnapshot],
+  node : @core.ProjNode[@md_markdown.Block],
+  kind : MarkdownBlockKind,
+  source : String,
+  source_map : @core.SourceMap,
+) -> Unit {
+  guard source_map.get_range(node.id()) is Some(source_range) else { return }
+  let text_span = match source_map.get_token_span(node.id(), "text") {
+    Some(span) => span
+    None =>
+      match source_map.get_token_span(node.id(), "code") {
+        Some(span) => span
+        None => return
+      }
+  }
+  let marker_range = source_map.get_token_span(node.id(), "marker")
+  let fence_open_range = source_map.get_token_span(node.id(), "fence_open")
+  let fence_close_range = source_map.get_token_span(node.id(), "fence_close")
+  if kind is MarkdownBlockKind::CodeBlock(_) &&
+    (fence_open_range is None || fence_close_range is None) {
+    return
+  }
+  blocks.push({
+    node_id: { value: node.id() },
+    kind,
+    text: source[text_span.start:text_span.end].to_owned(),
+    source_start: source_range.start,
+    source_end: source_range.end,
+    text_start: text_span.start,
+    text_end: text_span.end,
+    marker_start: marker_range.map(r => r.start),
+    marker_end: marker_range.map(r => r.end),
+    fence_open_start: fence_open_range.map(r => r.start),
+    fence_open_end: fence_open_range.map(r => r.end),
+    fence_close_start: fence_close_range.map(r => r.start),
+    fence_close_end: fence_close_range.map(r => r.end),
+  })
+}
+
+///|
+/// A list is editable only when every direct item is a simple, tight item.
+fn tight_top_level_list(
+  source : String,
+  list : @core.ProjNode[@md_markdown.Block],
+  source_map : @core.SourceMap,
+) -> Bool {
+  for item in list.children {
+    if !(item.kind is @md_markdown.Block::UnorderedListItem(_) ||
+      item.kind is @md_markdown.Block::OrderedListItem(_, _)) {
+      return false
+    }
+    if item.children.length() != 0 ||
+      source_map.get_token_span(item.id(), "text") is None ||
+      source_map.get_token_span(item.id(), "marker") is None {
+      return false
+    }
+    let text_span = match source_map.get_token_span(item.id(), "text") {
+      Some(span) => span
+      None => return false
+    }
+    let payload = source[text_span.start:text_span.end]
+    if payload.contains("\n".view()) || payload.contains("\r".view()) {
+      return false
+    }
+  }
+  for i in 0..<(list.children.length() - 1) {
+    let current = list.children[i]
+    let next = list.children[i + 1]
+    let current_range = match source_map.get_range(current.id()) {
+      Some(range) => range
+      None => return false
+    }
+    let next_range = match source_map.get_range(next.id()) {
+      Some(range) => range
+      None => return false
+    }
+    let gap = source[current_range.end:next_range.start].to_owned()
+    let normalized = gap
+      .replace_all(old="\r\n", new="\n")
+      .replace_all(old="\r", new="\n")
+    if normalized.contains("\n\n".view()) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn ordered_marker_delimiter(marker : @md_markdown.OrderedListMarker) -> String {
+  match marker.delimiter() {
+    @md_markdown.Period => "."
+    @md_markdown.Paren => ")"
   }
 }

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1,5 +1,131 @@
 ///| The first public headless Markdown façade seam.
 
+/// #1075 behavioral boundary matrix
+/// Syntax: tight top-level unordered and ordered (`.`/`)`, non-1) list items,
+/// fenced backtick/tilde code; terminators: LF/CRLF/CR/EOF; operations:
+/// full/incremental projection and typed payload commits; modes: Raw/Block/
+/// Preview; ownership: direct top-level supported nodes only, with nested,
+/// loose, indented-code, and unsupported containers rejected atomically.
+/// Every accepted snapshot carries stable identity plus exact source, payload,
+/// marker, and fence spans; focus/selection success or rejection and fresh /
+/// incremental parity are checked here or at the private disposable seam.
+
+///|
+test "1075 RED: mixed list and fenced-code snapshots expose typed ranges" {
+  let source = "- one\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n"
+  let editor = try! MarkdownEditor(agent_id="1075-red", source~)
+  let blocks = editor.snapshot().blocks().to_array()
+
+  assert_eq(blocks.length(), 3)
+  match blocks[0].kind() {
+    MarkdownBlockKind::UnorderedListItem => ()
+    _ => fail("expected an unordered list item snapshot")
+  }
+  match blocks[1].kind() {
+    MarkdownBlockKind::OrderedListItem(start~, delimiter~) => {
+      assert_eq(start, 7)
+      assert_eq(delimiter, ")")
+    }
+    _ => fail("expected a non-1 ordered list item snapshot")
+  }
+  match blocks[2].kind() {
+    MarkdownBlockKind::CodeBlock(info~) => assert_eq(info, "moonbit")
+    _ => fail("expected a fenced-code snapshot")
+  }
+  assert_eq(blocks[0].text(), "one")
+  assert_eq(blocks[1].text(), "two")
+  assert_eq(blocks[2].text(), "old")
+  assert_eq(blocks[0].marker_range(), Some((0, 2)))
+  assert_eq(blocks[1].marker_range(), Some((9, 12)))
+  assert_eq(blocks[2].fence_open_range(), Some((17, 27)))
+  assert_eq(blocks[2].text_range(), (29, 32))
+  assert_eq(blocks[2].fence_close_range(), Some((34, 39)))
+
+  let unordered = blocks[0].node_id()
+  let ordered = blocks[1].node_id()
+  let code = blocks[2].node_id()
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=unordered, new_text="ONE"),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, _)) =>
+      assert_eq(
+        snapshot.source(),
+        "- ONE\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n",
+      )
+    _ => fail("expected unordered payload commit")
+  }
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=ordered, new_text="TWO"),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, _)) =>
+      assert_eq(
+        snapshot.source(),
+        "- ONE\r\n\r\n7) TWO\r\n~~~moonbit\r\nold\r\n~~~\r\n",
+      )
+    _ => fail("expected ordered payload commit")
+  }
+  match
+    editor.commit(MarkdownEditRequest::CommitEdit(node_id=code, new_text="new")) {
+    Ok(MarkdownCommitResult::Applied(snapshot, _)) =>
+      assert_eq(
+        snapshot.source(),
+        "- ONE\r\n\r\n7) TWO\r\n~~~moonbit\r\nnew\r\n~~~\r\n",
+      )
+    _ => fail("expected fenced-code payload commit")
+  }
+}
+
+///|
+test "mixed list and fenced-code projection keeps identity and fresh parity" {
+  let source = "- one\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n"
+  let editor = try! MarkdownEditor(agent_id="1075-identity", source~)
+  let before = editor.snapshot().blocks().to_array()
+  let unordered = before[0].node_id()
+  let ordered = before[1].node_id()
+  let code = before[2].node_id()
+
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=unordered, new_text="ONE"),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, _)) => {
+      let after = snapshot.blocks().to_array()
+      assert_eq(after.length(), 3)
+      assert_eq(after[1].node_id(), ordered)
+      assert_eq(after[2].node_id(), code)
+    }
+    _ => fail("expected list payload edit")
+  }
+
+  match
+    editor.commit(MarkdownEditRequest::CommitEdit(node_id=code, new_text="new")) {
+    Ok(MarkdownCommitResult::Applied(snapshot, _)) => {
+      let fresh = try! MarkdownEditor(
+        agent_id="1075-identity-fresh",
+        source=snapshot.source(),
+      )
+      let actual = snapshot.blocks().to_array()
+      let expected = fresh.snapshot().blocks().to_array()
+      assert_eq(actual.length(), expected.length())
+      for i in 0..<actual.length() {
+        assert_eq(actual[i].kind(), expected[i].kind())
+        assert_eq(actual[i].text(), expected[i].text())
+        assert_eq(actual[i].source_range(), expected[i].source_range())
+        assert_eq(actual[i].text_range(), expected[i].text_range())
+        assert_eq(actual[i].marker_range(), expected[i].marker_range())
+        assert_eq(actual[i].fence_open_range(), expected[i].fence_open_range())
+        assert_eq(
+          actual[i].fence_close_range(),
+          expected[i].fence_close_range(),
+        )
+      }
+    }
+    _ => fail("expected fenced-code payload edit")
+  }
+}
+
 ///|
 test "headless facade commits exact source and exposes snapshot" {
   let editor = try! MarkdownEditor(agent_id="red", source="before")
@@ -248,6 +374,124 @@ test "snapshot omits unsupported container payloads" {
     MarkdownBlockKind::Heading(level~) => assert_eq(level, 1)
     _ => fail("expected direct heading block")
   }
+}
+
+///|
+test "snapshot rejects nested and loose lists and indented code" {
+  let nested = try! MarkdownEditor(
+    agent_id="nested-list-unsupported",
+    source="- parent\n  - child\n\n# Direct\n",
+  )
+  let nested_blocks = nested.snapshot().blocks().to_array()
+  assert_eq(nested_blocks.length(), 1)
+  assert_eq(nested_blocks[0].text(), "Direct")
+
+  let loose = try! MarkdownEditor(
+    agent_id="loose-list-unsupported",
+    source="- one\n\n- two\n\n# Direct\n",
+  )
+  let loose_blocks = loose.snapshot().blocks().to_array()
+  assert_eq(loose_blocks.length(), 1)
+  assert_eq(loose_blocks[0].text(), "Direct")
+
+  let indented = try! MarkdownEditor(
+    agent_id="indented-code-unsupported",
+    source="    code\n\n# Direct\n",
+  )
+  let indented_blocks = indented.snapshot().blocks().to_array()
+  assert_eq(indented_blocks.length(), 1)
+  assert_eq(indented_blocks[0].text(), "Direct")
+}
+
+///|
+test "empty fenced code exposes a zero-length payload and preserves delimiters" {
+  let source = "~~~\r\n~~~\r\n"
+  let editor = try! MarkdownEditor(agent_id="empty-fenced-code", source~)
+  let blocks = editor.snapshot().blocks().to_array()
+  assert_eq(blocks.length(), 1)
+  match blocks[0].kind() {
+    MarkdownBlockKind::CodeBlock(info~) => assert_eq(info, "")
+    _ => fail("expected an empty fenced-code snapshot")
+  }
+  assert_eq(blocks[0].text(), "")
+  assert_eq(blocks[0].text_range(), (5, 5))
+  assert_eq(blocks[0].fence_open_range(), Some((0, 3)))
+  assert_eq(blocks[0].fence_close_range(), Some((5, 10)))
+
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(
+        node_id=blocks[0].node_id(),
+        new_text="filled",
+      ),
+    ) {
+    Ok(MarkdownCommitResult::Applied(snapshot, _)) =>
+      assert_eq(snapshot.source(), "~~~\r\nfilled\r\n~~~\r\n")
+    _ => fail("expected empty fenced-code payload commit")
+  }
+}
+
+///|
+test "empty fenced code preserves terminal payload newlines and boundaries" {
+  let cases : Array[(String, String, String)] = [
+    ("~~~\n~~~\n", "x\n", "~~~\nx\n\n~~~\n"),
+    ("~~~\r\n~~~\r\n", "x\r\n", "~~~\r\nx\r\n\r\n~~~\r\n"),
+    ("~~~\r~~~\r", "x\r", "~~~\rx\r\r~~~\r"),
+  ]
+  for case in cases {
+    let editor = try! MarkdownEditor(
+      agent_id="empty-fenced-terminal-newline",
+      source=case.0,
+    )
+    let block = editor.snapshot().blocks().to_array()[0]
+    match
+      editor.commit(
+        MarkdownEditRequest::CommitEdit(
+          node_id=block.node_id(),
+          new_text=case.1,
+        ),
+      ) {
+      Ok(MarkdownCommitResult::Applied(snapshot, _)) => {
+        assert_eq(snapshot.source(), case.2)
+        assert_eq(snapshot.blocks().to_array()[0].text(), case.1)
+      }
+      _ => fail("expected terminal-newline fenced payload commit")
+    }
+  }
+}
+
+///|
+test "headless facade rejects CommitEdit for nested list items atomically" {
+  let source = "- parent\n  - child\n\n# Direct\n"
+  let editor = try! MarkdownEditor(agent_id="nested-list-commit-edit", source~)
+  let nested_id = editor.snapshot().projection().node_ids().get(2).unwrap()
+  let before = editor.snapshot()
+
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=nested_id, new_text="changed"),
+    ) {
+    Err(MarkdownEditorError::EditFailed(_)) => ()
+    _ => fail("expected nested list CommitEdit to fail")
+  }
+  assert_true(editor.snapshot() == before)
+}
+
+///|
+test "headless facade rejects CommitEdit for loose list items atomically" {
+  let source = "- one\n\n- two\n\n# Direct\n"
+  let editor = try! MarkdownEditor(agent_id="loose-list-commit-edit", source~)
+  let loose_id = editor.snapshot().projection().node_ids().get(2).unwrap()
+  let before = editor.snapshot()
+
+  match
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(node_id=loose_id, new_text="changed"),
+    ) {
+    Err(MarkdownEditorError::EditFailed(_)) => ()
+    _ => fail("expected loose list CommitEdit to fail")
+  }
+  assert_true(editor.snapshot() == before)
 }
 
 ///|

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -21,6 +21,9 @@ pub(all) suberror MarkdownEditorError {
 pub(all) enum MarkdownBlockKind {
   Paragraph
   Heading(level~ : Int)
+  UnorderedListItem
+  OrderedListItem(start~ : Int, delimiter~ : String)
+  CodeBlock(info~ : String)
 } derive(Eq, @debug.Debug)
 
 pub struct MarkdownBlockSelection {
@@ -32,6 +35,8 @@ pub fn MarkdownBlockSelection::offset(Self) -> Int
 pub struct MarkdownBlockSnapshot {
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn MarkdownBlockSnapshot::fence_close_range(Self) -> (Int, Int)?
+pub fn MarkdownBlockSnapshot::fence_open_range(Self) -> (Int, Int)?
 pub fn MarkdownBlockSnapshot::key(Self) -> String
 pub fn MarkdownBlockSnapshot::kind(Self) -> MarkdownBlockKind
 pub fn MarkdownBlockSnapshot::marker_range(Self) -> (Int, Int)?

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -9,7 +9,7 @@ pub fn compute_markdown_edit(
 ) -> (Array[SpanEdit], FocusHint)? raise @core.EditError {
   match op {
     CommitEdit(node_id~, new_text~) =>
-      compute_commit_edit(source_map, node_id, new_text)
+      compute_commit_edit(source, source_map, node_id, new_text)
     ChangeHeadingLevel(node_id~, level~) =>
       compute_change_heading_level(source, proj, source_map, node_id, level)
     ToggleListItem(node_id~) =>
@@ -31,22 +31,28 @@ pub fn compute_markdown_edit(
 ///|
 /// Replace the editable "text" span of a block with new content.
 fn compute_commit_edit(
+  source : String,
   source_map : SourceMap,
   node_id : NodeId,
   new_text : String,
 ) -> (Array[SpanEdit], FocusHint)? raise @core.EditError {
   ensure_editable_target(source_map, node_id)
-  // Try "text" role first, fall back to "code" for code blocks
-  let range = match source_map.get_token_span(node_id, "text") {
-    Some(r) => r
+  // Try "text" role first, fall back to "code" for code blocks.
+  let (range, is_code) = match source_map.get_token_span(node_id, "text") {
+    Some(r) => (r, false)
     None =>
       match source_map.get_token_span(node_id, "code") {
-        Some(r) => r
+        Some(r) => (r, true)
         None =>
           raise @core.EditError::SourceSpanMissing(
             detail="no editable span for node " + node_id.to_string(),
           )
       }
+  }
+  let inserted = if is_code {
+    code_payload_for_commit(source, range.start, range.end, new_text)
+  } else {
+    new_text
   }
   Some(
     (
@@ -54,12 +60,35 @@ fn compute_commit_edit(
         SpanEdit::{
           start: range.start,
           delete_len: range.end - range.start,
-          inserted: new_text,
+          inserted,
         },
       ],
-      FocusHint::MoveCursor(position=range.start + new_text.length()),
+      FocusHint::MoveCursor(position=range.start + inserted.length()),
     ),
   )
+}
+
+///|
+/// Add the opening fence's line terminator when filling an empty code span.
+fn code_payload_for_commit(
+  source : String,
+  range_start : Int,
+  range_end : Int,
+  new_text : String,
+) -> String {
+  if range_start != range_end || new_text.is_empty() || range_start == 0 {
+    return new_text
+  }
+  let terminator = if range_start >= 2 &&
+    source[range_start - 2] == '\r' &&
+    source[range_start - 1] == '\n' {
+    "\r\n"
+  } else if source[range_start - 1] == '\r' {
+    "\r"
+  } else {
+    "\n"
+  }
+  new_text + terminator
 }
 
 ///|

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -89,6 +89,50 @@ test "commit_edit: change paragraph text" {
 }
 
 ///|
+test "commit_edit: list payloads and fenced code retain source delimiters" {
+  let source = "- old\r\n\r\n7) next\r\n\r\n~~~js\r\ncode\r\n~~~\r\n"
+  let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)
+  let unordered = proj.children[0].children[0].id()
+  let ordered = proj.children[1].children[0].id()
+  let code = proj.children[2].id()
+
+  assert_eq(
+    apply_edit(source, CommitEdit(node_id=unordered, new_text="OLD")),
+    "- OLD\r\n\r\n7) next\r\n\r\n~~~js\r\ncode\r\n~~~\r\n",
+  )
+  assert_eq(
+    apply_edit(source, CommitEdit(node_id=ordered, new_text="NEXT")),
+    "- old\r\n\r\n7) NEXT\r\n\r\n~~~js\r\ncode\r\n~~~\r\n",
+  )
+  assert_eq(
+    apply_edit(source, CommitEdit(node_id=code, new_text="new")),
+    "- old\r\n\r\n7) next\r\n\r\n~~~js\r\nnew\r\n~~~\r\n",
+  )
+}
+
+///|
+test "commit_edit: empty fenced payload newlines keep a separate fence boundary" {
+  let cases : Array[(String, String, String)] = [
+    ("~~~\n~~~\n", "x\n", "~~~\nx\n\n~~~\n"),
+    ("~~~\r\n~~~\r\n", "x\r\n", "~~~\r\nx\r\n\r\n~~~\r\n"),
+    ("~~~\r~~~\r", "x\r", "~~~\rx\r\r~~~\r"),
+  ]
+  for case in cases {
+    let (proj, _) = @md_proj.parse_to_proj_node(
+      markdown_edit_test_source,
+      case.0,
+    )
+    assert_eq(
+      apply_edit(
+        case.0,
+        CommitEdit(node_id=proj.children[0].id(), new_text=case.1),
+      ),
+      case.2,
+    )
+  }
+}
+
+///|
 test "commit_edit: unsupported block quote is rejected atomically" {
   let source = "> quoted\n\n# Heading\n"
   let (proj, _) = @md_proj.parse_to_proj_node(markdown_edit_test_source, source)

--- a/lang/markdown/proj/populate_token_spans.mbt
+++ b/lang/markdown/proj/populate_token_spans.mbt
@@ -162,13 +162,19 @@ fn populate_block(
       // Full inline content after this item's own marker. Compare marker
       // positions so a nested sublist marker never wins over the outer item
       // marker when both token kinds are present in the item CST.
-      set_content_span(
-        source_map,
-        syntax_node,
-        id,
-        "text",
-        list_item_marker_kind(syntax_node),
-      )
+      match list_item_marker_kind(syntax_node) {
+        Some(marker_kind) => {
+          set_token_span(source_map, syntax_node, id, "marker", marker_kind)
+          set_content_span(
+            source_map,
+            syntax_node,
+            id,
+            "text",
+            Some(marker_kind),
+          )
+        }
+        None => ()
+      }
     UnorderedList(_) | OrderedList(_, _) => {
       let syntax_children = collect_syntax_children(
         syntax_node,
@@ -187,10 +193,9 @@ fn populate_block(
         "fence_open",
         CodeFenceOpenToken,
       )
-      // Code content between fences, excluding the mandatory newlines
-      // after the opening fence and before the closing fence.
-      // set_content_span can't handle this because find_token returns
-      // the first NewlineToken (after fence open), not the last one.
+      // Code content between fences, excluding the exact line terminators
+      // after the opening fence and before the closing fence. Newline tokens
+      // carry one- or two-code-unit spans, so CR/LF/CRLF are preserved.
       let fence_open_end = match
         syntax_node.find_token(
           @markdown.SyntaxKind::CodeFenceOpenToken.to_raw(),
@@ -205,12 +210,27 @@ fn populate_block(
         Some(tok) => tok.start()
         None => syntax_node.end()
       }
-      // Skip newline after opening fence, skip newline before closing fence
-      let code_start = fence_open_end + 1
-      let code_end = if fence_close_start > code_start && fence_close_start > 0 {
-        fence_close_start - 1
-      } else {
-        fence_close_start
+      let mut opening_newline : @seam.SyntaxToken? = None
+      for
+        newline in syntax_node.tokens_of_kind(
+          @markdown.SyntaxKind::NewlineToken.to_raw(),
+        ) {
+        if opening_newline is None && newline.start() >= fence_open_end {
+          opening_newline = Some(newline)
+        }
+      }
+      let code_start = match opening_newline {
+        Some(newline) => newline.end()
+        None => fence_open_end
+      }
+      let mut code_end = fence_close_start
+      for
+        newline in syntax_node.tokens_of_kind(
+          @markdown.SyntaxKind::NewlineToken.to_raw(),
+        ) {
+        if newline.start() >= code_start && newline.end() <= fence_close_start {
+          code_end = newline.start()
+        }
       }
       if code_start <= code_end {
         source_map.set_token_span(

--- a/lang/markdown/proj/proj_node_wbtest.mbt
+++ b/lang/markdown/proj/proj_node_wbtest.mbt
@@ -336,6 +336,111 @@ test "source map: ATX heading separates marker and text" {
 }
 
 ///|
+test "source map: top-level list items separate marker and payload" {
+  let source = "- one\n\n7) two\n"
+  let (proj, errors) = parse_to_proj_node(
+    markdown_projection_test_source, source,
+  )
+  inspect(errors.length(), content="0")
+  let source_map = @core.SourceMap::from_ast(proj)
+  let (cst, diagnostics) = @markdown.parse_cst(
+    markdown_projection_test_source, source,
+  )
+  inspect(diagnostics.length(), content="0")
+  populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
+  let unordered = proj.children[0].children[0]
+  let ordered = proj.children[1].children[0]
+  match source_map.get_token_span(unordered.id(), "marker") {
+    Some(span) => assert_eq(source[span.start:span.end].to_owned(), "- ")
+    None => fail("expected unordered marker span")
+  }
+  match source_map.get_token_span(unordered.id(), "text") {
+    Some(span) => assert_eq(source[span.start:span.end].to_owned(), "one")
+    None => fail("expected unordered text span")
+  }
+  match source_map.get_token_span(ordered.id(), "marker") {
+    Some(span) => assert_eq(source[span.start:span.end].to_owned(), "7) ")
+    None => fail("expected ordered marker span")
+  }
+  match source_map.get_token_span(ordered.id(), "text") {
+    Some(span) => assert_eq(source[span.start:span.end].to_owned(), "two")
+    None => fail("expected ordered text span")
+  }
+}
+
+///|
+test "source map: fenced code spans preserve all line terminators" {
+  let cases : Array[(String, (Int, Int), (Int, Int), (Int, Int))] = [
+    ("```js\nline\n```\n", (6, 10), (11, 15), (0, 5)),
+    ("```js\r\nline\r\n```\r\n", (7, 11), (13, 18), (0, 5)),
+    ("```js\rline\r```\r", (6, 10), (11, 15), (0, 5)),
+    ("```js\nline\n```", (6, 10), (11, 14), (0, 5)),
+  ]
+  for case in cases {
+    let source = case.0
+    let (proj, errors) = parse_to_proj_node(
+      markdown_projection_test_source, source,
+    )
+    inspect(errors.length(), content="0")
+    let source_map = @core.SourceMap::from_ast(proj)
+    let (cst, diagnostics) = @markdown.parse_cst(
+      markdown_projection_test_source, source,
+    )
+    inspect(diagnostics.length(), content="0")
+    populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
+    let code = proj.children[0]
+    match source_map.get_token_span(code.id(), "code") {
+      Some(span) => assert_eq((span.start, span.end), case.1)
+      None => fail("expected fenced code span")
+    }
+    match source_map.get_token_span(code.id(), "fence_close") {
+      Some(span) => assert_eq((span.start, span.end), case.2)
+      None => fail("expected closing fence span")
+    }
+    match source_map.get_token_span(code.id(), "fence_open") {
+      Some(span) => assert_eq((span.start, span.end), case.3)
+      None => fail("expected opening fence span")
+    }
+  }
+}
+
+///|
+test "source map: empty fenced code spans retain zero-length payloads" {
+  let cases : Array[(String, (Int, Int), (Int, Int), (Int, Int))] = [
+    ("```\n```\n", (4, 4), (4, 8), (0, 3)),
+    ("~~~\r\n~~~\r\n", (5, 5), (5, 10), (0, 3)),
+    ("```\r```\r", (4, 4), (4, 8), (0, 3)),
+    ("~~~\n~~~", (4, 4), (4, 7), (0, 3)),
+  ]
+  for case in cases {
+    let source = case.0
+    let (proj, errors) = parse_to_proj_node(
+      markdown_projection_test_source, source,
+    )
+    inspect(errors.length(), content="0")
+    let source_map = @core.SourceMap::from_ast(proj)
+    let (cst, diagnostics) = @markdown.parse_cst(
+      markdown_projection_test_source, source,
+    )
+    inspect(diagnostics.length(), content="0")
+    populate_token_spans(source_map, @seam.SyntaxNode::from_cst(cst), proj)
+    let code = proj.children[0]
+    match source_map.get_token_span(code.id(), "code") {
+      Some(span) => assert_eq((span.start, span.end), case.1)
+      None => fail("expected zero-length fenced code span")
+    }
+    match source_map.get_token_span(code.id(), "fence_close") {
+      Some(span) => assert_eq((span.start, span.end), case.2)
+      None => fail("expected closing fence span")
+    }
+    match source_map.get_token_span(code.id(), "fence_open") {
+      Some(span) => assert_eq((span.start, span.end), case.3)
+      None => fail("expected opening fence span")
+    }
+  }
+}
+
+///|
 test "source map: aligned block quote and heading keep matching ranges" {
   let source = "> quote\n\n# Heading\n"
   let (proj, errors) = parse_to_proj_node(

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Browser, type BrowserContext, type Page } from "@playwright/test"
 
 /**
- * #1074 behavioral boundary matrix (each row gets a fresh BrowserContext,
+ * #1075 behavioral boundary matrix (each row gets a fresh BrowserContext,
  * page, and connected mount container; no case clears/reuses/remounts it):
  *
  * | syntax/operation | source shape | result |
@@ -9,6 +9,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | exact text / split / merge | supported top-level blocks | atomic commit + deterministic focus/selection |
  * | projection | full/incremental/fresh | payload, SourceMap ranges, and identity stay attached |
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
+ * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
  */
@@ -225,6 +226,41 @@ test("Block mode edits a paragraph payload while preserving CRLF source", async 
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Changed\r\n")
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-preview")).toHaveText("Changed\r\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block mode edits ordered/unordered lists and fenced code in one mixed document", async ({ browser }) => {
+  const source = "- one\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectBlock(host.page)
+    await expect(host.page.locator('[data-loomark-block-kind="unordered-list-item"]')).toHaveCount(1)
+    await expect(host.page.locator('[data-loomark-block-kind="ordered-list-item"]')).toHaveCount(1)
+    await expect(host.page.locator('[data-loomark-block-kind="code"]')).toHaveCount(1)
+    await expect(host.page.locator('[data-loomark-block-kind="unordered-list-item"]')).toHaveValue("one")
+    await expect(host.page.locator('[data-loomark-block-kind="ordered-list-item"]')).toHaveValue("two")
+    await expect(host.page.locator('[data-loomark-block-kind="code"]')).toHaveValue("old")
+
+    await host.page.locator('[data-loomark-block-kind="unordered-list-item"]').fill("ONE")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(
+      "- ONE\r\n\r\n7) two\r\n~~~moonbit\r\nold\r\n~~~\r\n",
+    )
+    await host.page.locator('[data-loomark-block-kind="ordered-list-item"]').fill("TWO")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(
+      "- ONE\r\n\r\n7) TWO\r\n~~~moonbit\r\nold\r\n~~~\r\n",
+    )
+    await host.page.locator('[data-loomark-block-kind="code"]').fill("new")
+    const committed = "- ONE\r\n\r\n7) TWO\r\n~~~moonbit\r\nnew\r\n~~~\r\n"
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(committed)
+
+    await selectRaw(host.page)
+    await expect(host.page.locator("#loomark-input")).toHaveValue(committed.replaceAll("\r\n", "\n"))
+    await selectPreview(host.page)
+    await expect(host.page.locator("#loomark-preview")).toHaveText(committed)
+    await selectBlock(host.page)
+    await expect(host.page.locator("#loomark-block")).toHaveAttribute("data-loomark-source", committed)
   } finally {
     await host.context.close()
   }
@@ -501,14 +537,14 @@ test("Block focus targets the typed first block and rejects stale mode restores"
 })
 
 test("Block mode omits unsupported containers without shifting direct block neighbors", async ({ browser }) => {
-  const host = await mountHost(browser, "- listed\n\n> quoted\n\n---\n\n# Direct\n")
+  const host = await mountHost(browser, "- listed\n  - nested\n\n> quoted\n\n---\n\n# Direct\n")
   try {
     await selectBlock(host.page)
     await expect(host.page.locator("[data-loomark-block-kind]")).toHaveCount(1)
     await expect(host.page.locator("#loomark-block-input")).toHaveValue("Direct")
     await expect(host.page.locator("#loomark-block")).toHaveAttribute(
       "data-loomark-source",
-      "- listed\n\n> quoted\n\n---\n\n# Direct\n",
+      "- listed\n  - nested\n\n> quoted\n\n---\n\n# Direct\n",
     )
   } finally {
     await host.context.close()

--- a/loomark/internal/rabbita/block_surface.mbt
+++ b/loomark/internal/rabbita/block_surface.mbt
@@ -20,6 +20,9 @@ fn block_kind_name(kind : @markdown.MarkdownBlockKind) -> String {
   match kind {
     @markdown.Paragraph => "paragraph"
     @markdown.Heading(_) => "heading"
+    @markdown.UnorderedListItem => "unordered-list-item"
+    @markdown.OrderedListItem(..) => "ordered-list-item"
+    @markdown.CodeBlock(_) => "code"
   }
 }
 
@@ -82,17 +85,23 @@ fn block_input(
     on_input=@cmd.Emit(text => block_input_command(block, input_id, text, emit)),
     "",
   )
-  let split = @html.button(
-    attrs=@html.Attrs::build().data_set("loomark-block-split", block.key()),
-    on_click=block_split_command(block, input_id, emit),
-    "Split",
-  )
-  let merge = @html.button(
-    attrs=@html.Attrs::build().data_set("loomark-block-merge", block.key()),
-    on_click=emit(BlockMerge(node_id=block.node_id())),
-    "Merge",
-  )
-  @html.div([input, split, merge])
+  let structure_controls = match block.kind() {
+    @markdown.Paragraph | @markdown.Heading(_) => {
+      let split = @html.button(
+        attrs=@html.Attrs::build().data_set("loomark-block-split", block.key()),
+        on_click=block_split_command(block, input_id, emit),
+        "Split",
+      )
+      let merge = @html.button(
+        attrs=@html.Attrs::build().data_set("loomark-block-merge", block.key()),
+        on_click=emit(BlockMerge(node_id=block.node_id())),
+        "Merge",
+      )
+      [split, merge]
+    }
+    _ => []
+  }
+  @html.div([input, ..structure_controls])
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Add Rabbita-owned Block controls for tight ordered and unordered list items and top-level fenced code.
- Preserve markers, delimiters, fence information, UTF-16 source ranges, line endings, and projection identity through typed Canopy edits.
- Reject nested, loose, and otherwise unsupported container edits atomically at the public Markdown editor boundary.

Closes #1075.

## UI and review evidence

N/A for visual styling: this changes typed Block behavior without removing labels or changing design tokens. Disposable browser tests exercise the rendered controls, mode transitions, focus path, and isolated mount lifecycle.

- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| Typed Markdown `Block` list/code variants | `loom/examples/markdown` | Yes | Loom remains the parser and Markdown-semantics owner. |
| Projection tree and reconciliation | `lang/markdown/proj` | Yes | Existing nodes and identities are retained. |
| `SourceMap` range and token-span APIs | `core/source_map.mbt` | Yes | Marker, payload, and fence ranges come from typed projection data. |
| `compute_markdown_edit` / `CommitEdit` | `lang/markdown/edits` | Yes | Existing typed lowering is extended only for empty fenced payload boundaries. |
| `Option`, `Result`, `String`/`StringView`, `ArrayView`, `Iter` | MoonBit core | Yes | Used for typed lookup, range handling, detached views, and traversal. |
| `Map`, `Set`, `Buffer`/`StringBuilder` | MoonBit core | No | No keyed aggregation, uniqueness tracking, or multi-part builder is needed for these bounded ordered snapshots. |

New helpers added:

- `append_editable_block_snapshot`: builds one detached public snapshot from validated SourceMap roles.
- `tight_top_level_list`: contains the pure supported-list eligibility policy.
- `ordered_marker_delimiter`: maps Loom's typed delimiter without reparsing source text.
- `code_payload_for_commit`: preserves the source-derived closing-fence boundary when filling a zero-length code span.

Remaining mutation is limited to SourceMap construction, detached snapshot assembly, and the existing thin Rabbita DOM/focus shell.

## Validation scope

Boundary matrix / first failing regression:

- Ordered `.`/`)` and non-1 starts; unordered markers; backtick/tilde fences; empty and multiline content.
- LF, CRLF, CR, and closing fence at EOF.
- Full/incremental/fresh projection identity and exact marker, payload, and fence ranges.
- Raw/Block/Preview convergence, typed commits, focus decisions, and atomic unsupported-container rejection.
- Fresh disposable browser context and single mount per case.

The first public-seam regression failed because list/code kinds and fence ranges were absent. Review-driven RED tests also reproduced missing zero-length code spans, unsupported direct list commits, and lost terminal payload newlines.

Target packages:

- `editor/markdown`
- `lang/markdown/proj`
- `lang/markdown/edits`
- `loomark/internal/rabbita`

Additional conditional gates:

- Workspace debug and release tests: wasm-gc 4352/4352, JS 2166/2166, native 70/70.
- Vanilla dev-host TypeScript typecheck and JavaScript release build passed.
- `./scripts/test-loomark-dev-host-e2e.sh`: 34/34 passed.
- Independent Terra review completed with no remaining findings.

## PR-ready evidence

Validated HEAD: `e285825dc824ca6a8facd18cf9db4a90058e0f44`

Validated base: `origin/main@0263aa798d25fe79e22d9a128cb5055c46335c1a`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target editor/markdown
./scripts/validate-pr-ready.sh --target lang/markdown/proj
./scripts/validate-pr-ready.sh --target lang/markdown/edits
./scripts/validate-pr-ready.sh --target loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule commit changed.
- [x] Validation was rerun after every amend and generated-interface change.
- [x] Independent review findings were resolved before the final validation.
