### PR TITLE
feat(markdown): give the Markdown façade the archive surface

### DIFF
--- a/docs/design/local-first-document-surface.md
+++ b/docs/design/local-first-document-surface.md
@@ -1,0 +1,248 @@
+# The surface a locally-owned document presents
+
+What the application programs against, once a document is something the user
+owns rather than something an editing session holds.
+
+[Local-first document ownership](local-first-document-ownership.md) settles what
+must be preserved and why. This document settles what shape presents it. Treat
+it as direction: it names invariants and boundaries, carries no source
+citations, and does not describe what any package does today.
+
+## The noun is the document, not the editor
+
+An editor is a session. It has a cursor, a view mode, an undo stack, a person
+in front of it. A document has none of those and outlives all of them.
+
+Making the editor the top-level object forces every document-level concern to
+enter through a session that may not exist. Persisting an increment, admitting
+a peer's operations, answering how large the history has grown, reporting what
+is durable — none of these need a cursor, and a surface that demands one has
+made the session a prerequisite for owning a document.
+
+The inversion also hides the case the design exists for. Two windows on one
+document are two writing instances, and if the editor is the document, then two
+windows are two documents that must be reconciled with each other. The
+reconciliation is real, but calling both sides separate documents is what makes
+a shared identity look like a reasonable thing to hand them.
+
+So: **a document is the object; a writing session is a capability opened on
+it.** Sessions are created and discarded against a document that persists
+across all of them.
+
+## What belongs to which
+
+| | Document | Session |
+| --- | --- | --- |
+| Operation history | ✓ | |
+| Current text, as a view of the history | ✓ | |
+| Version frontier | ✓ | |
+| Durability watermarks | ✓ | |
+| Writer identity | | ✓ |
+| Cursor, selection, focus | | ✓ |
+| Undo and redo stacks | | ✓ |
+| View mode, projection focus | | ✓ |
+
+The line is not "what is mutable" or "what is expensive". It is: **would this
+still be true if everyone closed their window?** Everything in the right column
+is an appearance to reproduce; everything in the left column is an object to
+resume. The ownership document says these must stay separately named and
+separately versioned. Making them separate types is how that stops depending on
+anyone remembering it.
+
+Derived caches — syntax tree, semantic IR, projection, view patches — belong to
+neither. They are rebuilt from the text and are never authoritative, so they are
+not state to place but state to discard.
+
+## Admission is one operation
+
+Operations enter a document from exactly three places: a session's edits, a
+peer's history, and an archive being opened. The last two are the same
+operation. Opening an archive is admitting a history into a document that holds
+nothing yet; merging is admitting one into a document that holds something.
+Nothing distinguishes them but the receiver.
+
+A surface that exposes only the empty-receiver case cannot express the general
+one, and loses more than a feature: **the only honest way to check that a
+restored document was restored is to merge with it.** Equal history bytes show
+that two documents have the same past. Only an exchange of subsequent
+operations shows they share a future, and sharing a future is the thing that is
+lost when a document is reopened as a new object.
+
+So the document admits a history, and opening is composed from admission rather
+than standing beside it.
+
+## Openings are named for what they cost
+
+Two ways a document comes into existence:
+
+- **Opening** an archive continues a document that already exists. Identity,
+  history, and causal past all carry.
+- **Importing** text creates a new document. It has no past, and no future in
+  common with whatever produced the text.
+
+These are the same code until the envelope exists, and they must still be named
+apart from the beginning, because the moment identity lives in an envelope one
+of them reads an identity and the other mints one. Splitting a name later is a
+breaking change; reserving the distinction now costs nothing.
+
+Naming also sets the default. Importing is the lossy path — the ownership
+document is explicit that a `.md` touched by an outside tool re-enters as an
+import and never as a merge between two truths. A surface where constructing
+from text is the obvious call and continuing a document is the exceptional one
+has its defaults inverted, and every caller that reaches for the obvious call
+silently creates a new document.
+
+## Identity is minted, never supplied
+
+The invariant is one writer identity per writing instance. A caller-supplied
+identity cannot enforce it: nothing stops two instances receiving the same
+value, and the resulting history is indistinguishable from a legitimate one, so
+no later repair can separate them.
+
+An identity supplied as an argument is therefore not a parameter but a defect
+waiting for a second window. **Opening a session mints the identity; the caller
+never names it.** Determinism for tests is a seam on the session, not a
+parameter on the public path.
+
+This matters more than it appears, because the identity is not only the CRDT
+replica. It is simultaneously the undo owner, the ephemeral presence identity,
+and the peer identity. One supplied string decides four things at once, and the
+places it is wrong are not the same places it is noticed.
+
+## Export is a cut, not a dump
+
+Persistence triggers on the history advancing. If the only export is the whole
+history, then every save rewrites everything the document has ever been, and
+the cost of saving grows with the age of the document rather than the size of
+the change.
+
+The primitive is therefore **the history since a version**, with the whole
+history as the degenerate case of cutting at nothing. This is also the base and
+increments the ownership document names as the eventual answer to scale, which
+means the shape that answers scale is the same shape that answers routine
+saving — it does not need to be built later or separately.
+
+A version is what makes the cut. That it can also be compared to detect that
+the document advanced is a consequence of being a frontier, not its purpose. A
+surface that offers comparison and withholds the cut has kept the smaller half.
+
+## Durability is a set of watermarks
+
+Applied, durable locally, replicated, backed up. Each is the same kind of
+statement about a different destination: *everything up to here has arrived*.
+So each is a version, and the ladder is a set of watermarks over one type,
+ordered and monotone.
+
+Stating it this way makes the design's rule structural rather than remembered.
+"Sent is not saved" is not a discipline to follow but two different watermarks
+that cannot be substituted for one another. Adding replication later adds a
+watermark, not a redesign.
+
+One caveat the frontier itself imposes: a version summarizes what a writer has
+seen, not what a document contains, so a watermark is a claim about one
+document's own progress and never a comparison between two documents.
+
+A watermark advances only when a replacement completes. A partially written
+archive is not partial durability — it is a document whose text may have
+survived while its history did not, which is the loss the whole direction
+exists to prevent.
+
+## Admission states its policy at the call
+
+Resource limits are a consumer's policy. Two consumers admit histories for
+opposite reasons: the network defends against a sender it does not trust, and
+opening an archive defends against exhausting this device on data it wrote
+itself. The first is a question about an adversary; the second is a question
+about capacity. One number cannot be both, and a shared number means whichever
+was written first silently governs the other.
+
+Policy therefore belongs to the admission, not to the document. A document does
+not have a maximum size; a caller admits under a stated policy, and different
+callers state different ones.
+
+A ceiling nobody can see is a ceiling discovered in the field. The document must
+be able to answer how much room remains under a given policy, so that a limit
+can be surfaced before it is reached rather than reported as a failure at the
+moment a document stops opening.
+
+## Withheld operations are a state, not a failure
+
+Operations can arrive whose causal prerequisites have not. This is ordinary in
+any system where more than two replicas exchange history, and the ownership
+document already treats such operations as real state an archive must
+eventually retain.
+
+An admission that can only succeed or raise cannot report that it took some
+operations and is holding others. The state the design reserves room for then
+has no way to reach the application, and a caller cannot distinguish a document
+that is waiting from one that is broken.
+
+Admission therefore reports what it took and what it is holding. Whether
+withheld operations are acceptable is the caller's judgment: for a peer
+exchange they are expected, and for an archive that claims to be complete they
+are evidence that it is not. **This is where restore states its own policy** —
+not by owning a separate mechanism, but by making a different judgment about the
+same report.
+
+## Three layers, not two
+
+- **Document** — knows operations, versions, and views. Knows nothing about
+  files, formats, or destinations.
+- **Archive** — the envelope: application-owned metadata wrapping a payload it
+  does not interpret, plus the portable text. Owns document identity, its own
+  format version, and room reserved for what is not carried yet.
+- **Store** — atomic replacement, locations, and the reporting of durability.
+
+The middle layer is the one most easily skipped, and skipping it is how document
+identity ends up somewhere that cannot hold it: the payload's serialization is a
+closed contract belonging to the CRDT, admitting exactly its own fields. There
+is no seam in it for what a document is called.
+
+## What this design does not settle
+
+**Undo across a restart conflicts with per-instance identity.** The ownership
+document counts undo across a restart among the losses it exists to prevent, and
+undo state is a session's, discarded with the window. Recovering it after a
+restart requires either promoting undo into the archive, or letting a new
+session claim a previous instance's operations as its own — and the second
+contradicts one identity per writing instance. This design does not choose. It
+records that the choice exists, and that the envelope is where the first option
+would land.
+
+**Whether importing text should be able to adopt an existing identity.** A
+document reconstructed from its portable artifact after its history is lost is
+a new document by this design. Whether it should be allowed to claim the old
+identity — and what that would mean for replicas that still hold the history —
+is not settled here.
+
+**Semantic merge.** Convergence of text is not convergence of meaning. Nothing
+in this surface makes a structurally incoherent merge detectable; that is
+separate work.
+
+## Verification
+
+Two assumptions this design rests on are measurable without building it, and
+were measured rather than argued: that admitting a history into a populated
+document and into an empty one is the same operation, and that a history whose
+prerequisites are absent is reported today as an error rather than as a
+withheld count. Observations are recorded in
+[`docs/evidence/2026-08-03-markdown-facade-history-transport.json`](../evidence/2026-08-03-markdown-facade-history-transport.json).
+
+The rest is not yet expressible and should stop living in this document as it
+becomes so: the document and session split when they are separate types, the
+minted identity when opening a session generates it, the watermarks when
+durability is reported as versions, and the admission policy when it is an
+argument rather than a property fixed at construction.
+
+A prediction that would falsify the document and session split: some piece of
+state that must survive a restart but belongs to no document — if one exists,
+the line drawn here is in the wrong place. Undo is the candidate, and the
+unsettled question above is where it would show.
+
+## Related
+
+- [Local-first document ownership](local-first-document-ownership.md) — what
+  must be preserved, and why
+- [Grand Design](GRAND_DESIGN.md) — vision, principles, implementation order
+- [Stable Document Entity Graph](stable-document-entity-graph.md) — stable
+  editing-entity identity above projection

--- a/docs/evidence/2026-08-03-local-first-document-ownership-claims.json
+++ b/docs/evidence/2026-08-03-local-first-document-ownership-claims.json
@@ -180,7 +180,7 @@
     },
     {
       "claim": "The archive shape is implementable through the Markdown facade as stated.",
-      "status": "partially demonstrated. The round-trip is confirmed at the editor layer (E1/E2). It is not confirmed through the facade, which today exposes neither version nor history transport.",
+      "status": "confirmed 2026-08-03 by docs/evidence/2026-08-03-markdown-facade-history-transport.json (F1), which surfaced version and history transport on the facade and repeated E1 through it. Was: partially demonstrated at the editor layer only.",
       "wouldRequire": "surfacing version and history transport on the facade, then repeating E1 through it"
     },
     {

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -39,8 +39,8 @@
         "question": "Can one surface treat missing prerequisites as an ordinary state for a peer exchange and as a defect for an archive?",
         "procedure": "Cut a history at a version, hand the increment to a document that never saw the operations before that cut, and observe both admitting it directly and opening a document from it.",
         "result": "confirmed",
-        "observed": "Admission returned Withheld without raising. Opening the same increment raised IncompleteArchive.",
-        "bearingOn": "The distinction the design asks for is a judgment about one report rather than two mechanisms. It also shows the façade no longer propagates the substrate's shape, where the same situation arrives as an error carrying no count (F6)."
+        "observed": "Admission returned Withheld with exact counts -- nothing applied, one operation held -- without raising. Opening the same increment raised IncompleteArchive.",
+        "bearingOn": "The distinction the design asks for is a judgment about one report rather than two mechanisms. The counts are asserted exactly rather than as a mere distinction, which is what shows the report is carried through rather than reconstructed from the presence of an error (F6)."
       },
       {
         "id": "F4-payload-closed-to-outsiders",
@@ -71,8 +71,9 @@
         "question": "How does the substrate report a history whose causal prerequisites are absent?",
         "procedure": "Export an increment since a version, then apply it to a replica that never saw the operations before that version.",
         "result": "confirmed",
-        "observed": "apply_sync raised TextError::VersionNotFound. No count of admitted versus withheld operations is available to the caller through that channel.",
-        "bearingOn": "The design treats received-but-not-yet-applicable operations as real state the envelope must eventually retain. An admission that raises cannot report a partial take, so the state the design reserves room for has no way to reach the application."
+        "observed": "apply_sync raised TextError::VersionNotFound. The report carrying the counts existed one layer down and was discarded before the raise.",
+        "bearingOn": "The design treats received-but-not-yet-applicable operations as real state the envelope must eventually retain. An admission that raises cannot report a partial take, so the state the design reserves room for had no way to reach the application.",
+        "resolution": "Addressed 2026-08-03 by making admission the primitive in editor/ and apply_sync a completeness policy over it, so the report is no longer discarded. The counts now reach the façade (F9). apply_sync keeps its raising behaviour and every existing call site is untouched; what remains is that its name does not say which policy it applies, a rename reaching 81 call sites."
       },
       {
         "id": "F7-single-consumer-coupling",

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -19,6 +19,8 @@
     "findings": [
       {
         "id": "F1-facade-roundtrip",
+        "surfacedBy": "self",
+        "verifiedBy": "executed test",
         "question": "Does the editor-layer checkpoint round-trip (E1) hold through the Markdown façade?",
         "procedure": "Construct a façade document, commit a text edit, read version, cut the whole history, reopen it into a second façade document under a different writer identity, then compare source, version, and history.",
         "result": "confirmed",
@@ -28,6 +30,8 @@
       },
       {
         "id": "F8-reopened-document-converges",
+        "surfacedBy": "codex-review-2026-08-03",
+        "verifiedBy": "executed test",
         "question": "Does a reopened document share a future with the one it came from, or only a past?",
         "procedure": "Seed a second façade document by reopening the first one's history, let each commit a text edit at a different offset, confirm their sources have diverged, then have each admit the other's history and compare source and canonical history.",
         "result": "confirmed",
@@ -37,6 +41,8 @@
       },
       {
         "id": "F10-admission-is-idempotent",
+        "surfacedBy": "self, while reviewing this slice after it was written",
+        "verifiedBy": "executed test",
         "question": "Does taking back a history the document already holds change it?",
         "procedure": "Build and edit a document, cut its whole history, admit that history back into the same document, and compare source, version, and history against the values before.",
         "result": "confirmed",
@@ -45,6 +51,8 @@
       },
       {
         "id": "F9-withheld-reported-and-refused",
+        "surfacedBy": "self",
+        "verifiedBy": "executed test",
         "question": "Can one surface treat missing prerequisites as an ordinary state for a peer exchange and as a defect for an archive?",
         "procedure": "Cut a history at a version, hand the increment to a document that never saw the operations before that cut, and observe both admitting it directly and opening a document from it.",
         "result": "confirmed",
@@ -53,6 +61,8 @@
       },
       {
         "id": "F4-payload-closed-to-outsiders",
+        "surfacedBy": "codex-review-2026-08-03, which reported the property unverified",
+        "verifiedBy": "compile-failure probe, since removed",
         "question": "Is the history payload actually unreadable and unconstructible from another package, or does the interface merely look closed?",
         "procedure": "Known-positive control rather than an interface diff: a temporary probe in workspace/probe imported the façade and attempted both forbidden operations -- reading the payload field and constructing the type from a SyncMessage obtained at the editor layer. The probe was compiled, its rejection observed, then removed.",
         "result": "confirmed",
@@ -61,6 +71,8 @@
       },
       {
         "id": "F2-weak-oracle-at-facade",
+        "surfacedBy": "self",
+        "verifiedBy": "executed test",
         "question": "Does the weak-oracle result (E3) reproduce at the façade, where a caller would be tempted to check a restore by source and version?",
         "procedure": "Two façade editors sharing a writer identity each insert a different character through ReplaceText, then delete it.",
         "result": "confirmed",
@@ -69,6 +81,8 @@
       },
       {
         "id": "F5-restore-is-admission-into-empty",
+        "surfacedBy": "self",
+        "verifiedBy": "disposable probe, since removed",
         "question": "Is restoring an archive a different operation from merging a peer's history, or the same operation with a different receiver?",
         "procedure": "Disposable probe at the editor layer, since the façade has no merge. Seed a second replica from a full export, let both diverge with one insert each, exchange full histories in both directions, and compare.",
         "result": "confirmed",
@@ -77,6 +91,8 @@
       },
       {
         "id": "F6-pending-arrives-as-an-error",
+        "surfacedBy": "self",
+        "verifiedBy": "disposable probe, since removed",
         "question": "How does the substrate report a history whose causal prerequisites are absent?",
         "procedure": "Export an increment since a version, then apply it to a replica that never saw the operations before that version.",
         "result": "confirmed",
@@ -86,6 +102,8 @@
       },
       {
         "id": "F7-single-consumer-coupling",
+        "surfacedBy": "self",
+        "verifiedBy": "grep over the consumer",
         "question": "How tightly is the application coupled to the current façade shape?",
         "procedure": "Grep loomark for façade construction and result matching.",
         "result": "confirmed",
@@ -94,6 +112,8 @@
       },
       {
         "id": "F3-unchanged-verdict-hides-an-advance",
+        "surfacedBy": "self",
+        "verifiedBy": "executed test",
         "question": "What does the façade report for a text-preserving edit, and does the version agree?",
         "procedure": "Replace the first character of \"hello\" with itself and read the commit result and the version.",
         "result": "confirmed",

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -10,21 +10,37 @@
   },
   "executedProbes": {
     "command": "NEW_MOON_MOD=0 moon test -p dowdiness/canopy/editor/markdown",
-    "result": "Total tests: 14, passed: 14, failed: 0",
+    "result": "Total tests: 16, passed: 16, failed: 0",
     "instrumentControl": {
       "why": "The new assertions are the whole point of the slice; a green suite proves nothing unless they ran.",
-      "observed": "Falsifying the canonical-history oracle (assert_true -> assert_false on the restored-equals-exported comparison) produced 14 tests, 13 passed, 1 failed, naming markdown_editor_wbtest.mbt:182 and its test. Restoring it returned the suite to 14/14.",
-      "conclusion": "The façade oracle executes; the green run is not vacuous."
+      "observed": "Falsifying the canonical-history oracle produced 13 of 14 passing, naming its assertion line. After the surface was reshaped, falsifying both of the added assertions -- convergence, and the withheld report -- produced 14 of 16 passing, naming markdown_editor_wbtest.mbt:219 ('true is not false') and :242 ('Withheld != Complete'). Restoring each returned the suite to green.",
+      "conclusion": "Every assertion these findings rest on executes; the green runs are not vacuous. The second control also shows the admit report really is Withheld rather than defaulting."
     },
     "findings": [
       {
         "id": "F1-facade-roundtrip",
         "question": "Does the editor-layer checkpoint round-trip (E1) hold through the Markdown façade?",
-        "procedure": "Construct a façade editor, commit a text edit, read version, export history, restore into a second façade editor under a different writer identity, then compare source, version, and exported history.",
+        "procedure": "Construct a façade document, commit a text edit, read version, cut the whole history, reopen it into a second façade document under a different writer identity, then compare source, version, and history.",
         "result": "confirmed",
-        "observed": "Restored source and version equal the exported ones, and the restored document's exported history is equal to the exported history under canonical-history equality.",
+        "observed": "Reopened source and version equal the exported ones, and the reopened document's history is equal to the exported history under canonical-history equality.",
         "bearingOn": "Closes the prior record's notVerified entry 'The archive shape is implementable through the Markdown facade as stated.' Its stated wouldRequire -- surfacing version and history transport on the façade, then repeating E1 through it -- is what this slice did.",
-        "limitation": "This is one of the two checks the design names, not both. See openQuestions/restore-merge-not-expressible."
+        "limitation": "This is one of the two checks the design names. The other is F8."
+      },
+      {
+        "id": "F8-reopened-document-converges",
+        "question": "Does a reopened document share a future with the one it came from, or only a past?",
+        "procedure": "Seed a second façade document by reopening the first one's history, let each commit a text edit at a different offset, confirm their sources have diverged, then have each admit the other's history and compare source and canonical history.",
+        "result": "confirmed",
+        "observed": "Both admissions reported Complete. Sources diverged before the exchange and were equal after it, and the two histories were equal under canonical-history equality.",
+        "bearingOn": "Closes the second half of the design's oracle, which equality alone cannot reach: equal history shows agreement about the past, and only an exchange of subsequent operations shows the reopened document is a replica rather than a copy that happens to match. The pre-exchange divergence assertion is what keeps this from passing vacuously."
+      },
+      {
+        "id": "F9-withheld-reported-and-refused",
+        "question": "Can one surface treat missing prerequisites as an ordinary state for a peer exchange and as a defect for an archive?",
+        "procedure": "Cut a history at a version, hand the increment to a document that never saw the operations before that cut, and observe both admitting it directly and opening a document from it.",
+        "result": "confirmed",
+        "observed": "Admission returned Withheld without raising. Opening the same increment raised IncompleteArchive.",
+        "bearingOn": "The distinction the design asks for is a judgment about one report rather than two mechanisms. It also shows the façade no longer propagates the substrate's shape, where the same situation arrives as an error carrying no count (F6)."
       },
       {
         "id": "F4-payload-closed-to-outsiders",
@@ -87,14 +103,14 @@
         "docs/evidence/2026-08-03-local-first-document-ownership-claims.json (version-is-high-water-mark, consequence)",
         "editor/markdown/markdown_editor_wbtest.mbt:157-183 (round-trip test ends at history equality)"
       ],
-      "bearingOn": "Canonical-history equality shows the restored document has the same past. Only a merge shows it can share a future, which is the loss the design exists to prevent. Until the façade can admit a history into an existing document, the stronger half of the oracle is asserted nowhere above the editor layer. Not closed in this slice: it requires a fourth façade operation beyond the three this slice was scoped to.",
-      "status": "open"
+      "bearingOn": "Canonical-history equality shows the restored document has the same past. Only a merge shows it can share a future, which is the loss the design exists to prevent.",
+      "status": "resolved 2026-08-03. The surface was reshaped so that admission is the general operation and opening is its empty-receiver case; the merge check is F8. The finding stands as the reason the reshape happened."
     },
     {
       "id": "restore-inherits-receiver-policy",
-      "raisedBy": "implementing MarkdownEditor::restore",
-      "question": "What ceiling does restore state, given that the only available replay path applies the receiver's sync limits?",
-      "observation": "Restore replays through SyncEditor::apply_sync -> SyncSession::apply, which calls prepare_sync with the document's sync_limits and raises LimitExceeded on encoded bytes and decoded operation count. Those limits are fixed per TextState at construction (TextState::new_with_sync_limits) and cannot be varied per call, so a restore-specific ceiling is not separable from the ceiling applied to remote traffic for the rest of the session.",
+      "raisedBy": "implementing the façade's admission path",
+      "question": "What policy does admission state, given that the only available path applies the receiver's sync limits?",
+      "observation": "Admission goes through SyncEditor::apply_sync -> SyncSession::apply, which calls prepare_sync with the document's sync_limits and raises LimitExceeded on encoded bytes and decoded operation count. Those limits are fixed per TextState at construction (TextState::new_with_sync_limits) and cannot be varied per call, so opening an archive and admitting remote traffic cannot state different policies. The completeness half of the policy is now stated at the call -- opening refuses withheld operations, admission reports them -- but the resource half is not.",
       "sites": [
         "event-graph-walker/text/sync.mbt:1213-1224 (SyncSession::apply passes self.doc.sync_limits)",
         "event-graph-walker/text/sync.mbt:1099-1116 (prepare_sync limit checks)",
@@ -105,9 +121,9 @@
     },
     {
       "id": "archive-failure-taxonomy-placement",
-      "raisedBy": "implementing MarkdownEditor::export_history and ::restore",
+      "raisedBy": "implementing the façade's archive operations",
       "question": "Where do archive failures belong relative to editing failures?",
-      "observation": "Adding ExportFailed/RestoreFailed to MarkdownEditorError breaks loomark/internal/rabbita/application.mbt:226, which matches that suberror exhaustively and without a wildcard in order to keep failures categorized. This slice instead introduced a separate MarkdownArchiveError, so the editing taxonomy and its one consumer are untouched.",
+      "observation": "Adding archive failures to MarkdownEditorError breaks loomark/internal/rabbita/application.mbt:226, which matches that suberror exhaustively and without a wildcard in order to keep failures categorized. This slice instead introduced a separate MarkdownArchiveError, so the editing taxonomy and its one consumer are untouched.",
       "bearingOn": "Consistent with the design's separation of the archive from the editing session, but the consumer-facing categorization of a restore failure -- in particular the design's requirement that a reader distinguish 'written by a newer release' from 'damaged' -- is not decided here and belongs with the envelope.",
       "status": "open"
     }

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -1,0 +1,115 @@
+{
+  "evidenceVersion": 1,
+  "subject": "docs/design/local-first-document-ownership.md",
+  "purpose": "Observations from the first implementation slice: version and history transport on the Markdown façade. Extends 2026-08-03-local-first-document-ownership-claims.json, which recorded the same round-trip one layer lower and listed the façade version as not yet demonstrated.",
+  "recordedAt": "2026-08-03",
+  "observedAt": {
+    "canopy": "e97f7e3aa1261610e1edac90d7e0eb61f0753cfe plus the uncommitted editor/markdown slice these observations were taken from",
+    "event-graph-walker": "fadc41b1e99753129be816c37393afee2175e23f",
+    "loom": "d9cac9b29568595d1717f05e0ee0b530db064e24"
+  },
+  "executedProbes": {
+    "command": "NEW_MOON_MOD=0 moon test -p dowdiness/canopy/editor/markdown",
+    "result": "Total tests: 14, passed: 14, failed: 0",
+    "instrumentControl": {
+      "why": "The new assertions are the whole point of the slice; a green suite proves nothing unless they ran.",
+      "observed": "Falsifying the canonical-history oracle (assert_true -> assert_false on the restored-equals-exported comparison) produced 14 tests, 13 passed, 1 failed, naming markdown_editor_wbtest.mbt:182 and its test. Restoring it returned the suite to 14/14.",
+      "conclusion": "The façade oracle executes; the green run is not vacuous."
+    },
+    "findings": [
+      {
+        "id": "F1-facade-roundtrip",
+        "question": "Does the editor-layer checkpoint round-trip (E1) hold through the Markdown façade?",
+        "procedure": "Construct a façade editor, commit a text edit, read version, export history, restore into a second façade editor under a different writer identity, then compare source, version, and exported history.",
+        "result": "confirmed",
+        "observed": "Restored source and version equal the exported ones, and the restored document's exported history is equal to the exported history under canonical-history equality.",
+        "bearingOn": "Closes the prior record's notVerified entry 'The archive shape is implementable through the Markdown facade as stated.' Its stated wouldRequire -- surfacing version and history transport on the façade, then repeating E1 through it -- is what this slice did.",
+        "limitation": "This is one of the two checks the design names, not both. See openQuestions/restore-merge-not-expressible."
+      },
+      {
+        "id": "F4-payload-closed-to-outsiders",
+        "question": "Is the history payload actually unreadable and unconstructible from another package, or does the interface merely look closed?",
+        "procedure": "Known-positive control rather than an interface diff: a temporary probe in workspace/probe imported the façade and attempted both forbidden operations -- reading the payload field and constructing the type from a SyncMessage obtained at the editor layer. The probe was compiled, its rejection observed, then removed.",
+        "result": "confirmed",
+        "observed": "NEW_MOON_MOD=0 moon check workspace/probe reported [4091] 'The type ...MarkdownDocumentHistory has no field message' for the read and [4036] plus [4033] for the construction. Three errors, no warnings.",
+        "bearingOn": "Closes the gap a .mbti diff cannot show: a pub struct can hide construction while leaving fields readable. Here the field is priv, so both doors are shut and the caller is left with equality alone."
+      },
+      {
+        "id": "F2-weak-oracle-at-facade",
+        "question": "Does the weak-oracle result (E3) reproduce at the façade, where a caller would be tempted to check a restore by source and version?",
+        "procedure": "Two façade editors sharing a writer identity each insert a different character through ReplaceText, then delete it.",
+        "result": "confirmed",
+        "observed": "Sources are equal and versions are equal while the exported histories are not.",
+        "bearingOn": "The façade's own acceptance check must compare history. This is why MarkdownDocumentHistory defines equality as canonical-history equality and exposes nothing else."
+      },
+      {
+        "id": "F5-restore-is-admission-into-empty",
+        "question": "Is restoring an archive a different operation from merging a peer's history, or the same operation with a different receiver?",
+        "procedure": "Disposable probe at the editor layer, since the façade has no merge. Seed a second replica from a full export, let both diverge with one insert each, exchange full histories in both directions, and compare.",
+        "result": "confirmed",
+        "observed": "Both replicas reached the same text and the same canonical history bytes. The same call that restores an empty replica merges a divergent one.",
+        "bearingOn": "The distinction between restore and merge is not in the operation but in what the receiver already holds. A surface that exposes only the empty-receiver case makes the general case inexpressible, which is why the merge half of the design's oracle could not be asserted."
+      },
+      {
+        "id": "F6-pending-arrives-as-an-error",
+        "question": "How does the substrate report a history whose causal prerequisites are absent?",
+        "procedure": "Export an increment since a version, then apply it to a replica that never saw the operations before that version.",
+        "result": "confirmed",
+        "observed": "apply_sync raised TextError::VersionNotFound. No count of admitted versus withheld operations is available to the caller through that channel.",
+        "bearingOn": "The design treats received-but-not-yet-applicable operations as real state the envelope must eventually retain. An admission that raises cannot report a partial take, so the state the design reserves room for has no way to reach the application."
+      },
+      {
+        "id": "F7-single-consumer-coupling",
+        "question": "How tightly is the application coupled to the current façade shape?",
+        "procedure": "Grep loomark for façade construction and result matching.",
+        "result": "confirmed",
+        "observed": "One construction site, passing the fixed literal agent identity \"loomark-dev-host\". MarkdownCommitResult is matched nowhere in loomark; MarkdownEditorError is matched at exactly one site.",
+        "bearingOn": "The writer identity the design requires to be unique per writing instance is in practice a constant supplied by the caller. The coupling is small enough that the surface is not what constrains a redesign."
+      },
+      {
+        "id": "F3-unchanged-verdict-hides-an-advance",
+        "question": "What does the façade report for a text-preserving edit, and does the version agree?",
+        "procedure": "Replace the first character of \"hello\" with itself and read the commit result and the version.",
+        "result": "confirmed",
+        "observed": "The façade reports MarkdownCommitResult::Unchanged while the version advances.",
+        "bearingOn": "Sharpens the design's 'persistence triggers on history, not on text' from a requirement about text comparison into a concrete hazard about this façade's own verdict: a writer that saves when commit reports Applied would skip this operation. The façade's Unchanged classification is a source-level statement and is not a durability signal."
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "restore-merge-not-expressible",
+      "raisedBy": "independent review (Codex, GPT-5), 2026-08-03; confirmed by direct read",
+      "question": "How is the design's second acceptance check -- a merge performed after restore -- asserted through the façade?",
+      "observation": "The design names two honest checks, a canonical comparison of the history and a merge after restore; the prior evidence record repeats both as the consequence of the high-water-mark finding. This slice asserts only the first. A merge check needs an entry point that combines two divergent histories, and the façade has none: it gained a version reader, a history export, and a restore into a fresh editor, and restore is the only consumer of a history value.",
+      "sites": [
+        "docs/design/local-first-document-ownership.md:112-118",
+        "docs/evidence/2026-08-03-local-first-document-ownership-claims.json (version-is-high-water-mark, consequence)",
+        "editor/markdown/markdown_editor_wbtest.mbt:157-183 (round-trip test ends at history equality)"
+      ],
+      "bearingOn": "Canonical-history equality shows the restored document has the same past. Only a merge shows it can share a future, which is the loss the design exists to prevent. Until the façade can admit a history into an existing document, the stronger half of the oracle is asserted nowhere above the editor layer. Not closed in this slice: it requires a fourth façade operation beyond the three this slice was scoped to.",
+      "status": "open"
+    },
+    {
+      "id": "restore-inherits-receiver-policy",
+      "raisedBy": "implementing MarkdownEditor::restore",
+      "question": "What ceiling does restore state, given that the only available replay path applies the receiver's sync limits?",
+      "observation": "Restore replays through SyncEditor::apply_sync -> SyncSession::apply, which calls prepare_sync with the document's sync_limits and raises LimitExceeded on encoded bytes and decoded operation count. Those limits are fixed per TextState at construction (TextState::new_with_sync_limits) and cannot be varied per call, so a restore-specific ceiling is not separable from the ceiling applied to remote traffic for the rest of the session.",
+      "sites": [
+        "event-graph-walker/text/sync.mbt:1213-1224 (SyncSession::apply passes self.doc.sync_limits)",
+        "event-graph-walker/text/sync.mbt:1099-1116 (prepare_sync limit checks)",
+        "editor/sync_editor.mbt:457-465 (apply_sync delegates to sync().apply)"
+      ],
+      "bearingOn": "The design's 'Scale limits are a choice restore must make deliberately' states that restore must not inherit a policy written for a different threat, and its Verification section expects the restore ceiling to become a parameter with no default. Neither is expressible without a change under event-graph-walker, and no measurement exists to choose a ceiling from. Recorded rather than resolved: no default was chosen in this slice.",
+      "status": "open"
+    },
+    {
+      "id": "archive-failure-taxonomy-placement",
+      "raisedBy": "implementing MarkdownEditor::export_history and ::restore",
+      "question": "Where do archive failures belong relative to editing failures?",
+      "observation": "Adding ExportFailed/RestoreFailed to MarkdownEditorError breaks loomark/internal/rabbita/application.mbt:226, which matches that suberror exhaustively and without a wildcard in order to keep failures categorized. This slice instead introduced a separate MarkdownArchiveError, so the editing taxonomy and its one consumer are untouched.",
+      "bearingOn": "Consistent with the design's separation of the archive from the editing session, but the consumer-facing categorization of a restore failure -- in particular the design's requirement that a reader distinguish 'written by a newer release' from 'damaged' -- is not decided here and belongs with the envelope.",
+      "status": "open"
+    }
+  ]
+}

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -4,17 +4,17 @@
   "purpose": "Observations from the first implementation slice: version and history transport on the Markdown façade. Extends 2026-08-03-local-first-document-ownership-claims.json, which recorded the same round-trip one layer lower and listed the façade version as not yet demonstrated.",
   "recordedAt": "2026-08-03",
   "observedAt": {
-    "canopy": "e97f7e3aa1261610e1edac90d7e0eb61f0753cfe plus the uncommitted editor/markdown slice these observations were taken from",
+    "canopy": "the editor/markdown and editor changes committed on top of e97f7e3aa1261610e1edac90d7e0eb61f0753cfe; observations were taken as each landed, and the counts here are from the final state",
     "event-graph-walker": "fadc41b1e99753129be816c37393afee2175e23f",
     "loom": "d9cac9b29568595d1717f05e0ee0b530db064e24"
   },
   "executedProbes": {
     "command": "NEW_MOON_MOD=0 moon test -p dowdiness/canopy/editor/markdown",
-    "result": "Total tests: 16, passed: 16, failed: 0",
+    "result": "Total tests: 17, passed: 17, failed: 0",
     "instrumentControl": {
       "why": "The new assertions are the whole point of the slice; a green suite proves nothing unless they ran.",
-      "observed": "Falsifying the canonical-history oracle produced 13 of 14 passing, naming its assertion line. After the surface was reshaped, falsifying both of the added assertions -- convergence, and the withheld report -- produced 14 of 16 passing, naming markdown_editor_wbtest.mbt:219 ('true is not false') and :242 ('Withheld != Complete'). Restoring each returned the suite to green.",
-      "conclusion": "Every assertion these findings rest on executes; the green runs are not vacuous. The second control also shows the admit report really is Withheld rather than defaulting."
+      "observed": "Falsified once per added assertion, each time restoring the suite to green afterwards. The canonical-history oracle: 13 of 14 passing, naming its line. Convergence and the withheld report: 14 of 16 passing, the second reporting 'Withheld != Complete'. Idempotence, falsified one assertion at a time because the first failure ends the test: 16 of 17 passing for the version claim, then again for the history claim. The probe's direct pending count: 41 of 42.",
+      "conclusion": "Every assertion these findings rest on executes; the green runs are not vacuous. The withheld control also shows the report really is Withheld with those counts rather than a default."
     },
     "findings": [
       {
@@ -32,7 +32,16 @@
         "procedure": "Seed a second façade document by reopening the first one's history, let each commit a text edit at a different offset, confirm their sources have diverged, then have each admit the other's history and compare source and canonical history.",
         "result": "confirmed",
         "observed": "Both admissions reported Complete. Sources diverged before the exchange and were equal after it, and the two histories were equal under canonical-history equality.",
-        "bearingOn": "Closes the second half of the design's oracle, which equality alone cannot reach: equal history shows agreement about the past, and only an exchange of subsequent operations shows the reopened document is a replica rather than a copy that happens to match. The pre-exchange divergence assertion is what keeps this from passing vacuously."
+        "bearingOn": "Closes the second half of the design's oracle, which equality alone cannot reach: equal history shows agreement about the past, and only an exchange of subsequent operations shows the reopened document is a replica rather than a copy that happens to match. The pre-exchange divergence assertion is what keeps this from passing vacuously.",
+        "note": "Each side is handed the other's whole history, so this traverses the already-held path without pinning it; a document that re-applied operations it already had would converge here anyway. F10 pins it separately."
+      },
+      {
+        "id": "F10-admission-is-idempotent",
+        "question": "Does taking back a history the document already holds change it?",
+        "procedure": "Build and edit a document, cut its whole history, admit that history back into the same document, and compare source, version, and history against the values before.",
+        "result": "confirmed",
+        "observed": "Admission reported Complete, and source, version, and canonical history were all unchanged.",
+        "bearingOn": "This was traversed but unasserted by F8, and was the case that made an earlier report shape misleading: Complete once carried a count of newly applied operations, which reads as 'everything in the history was applied' and is false whenever the sender includes operations the receiver already holds. The count is no longer carried on that variant. Non-vacuous only in suite context -- an admission that applied nothing at all would also pass here, and F8 and F9 are what rule that out."
       },
       {
         "id": "F9-withheld-reported-and-refused",

--- a/editor/editor.mbt
+++ b/editor/editor.mbt
@@ -139,8 +139,18 @@ pub fn Editor::export_since(
 }
 
 ///|
-/// Sync: Apply a SyncMessage from a peer
-pub fn Editor::apply_sync(self : Editor, msg : @text.SyncMessage) -> Unit raise {
+/// Sync: take a peer's operations into this document, reporting what landed.
+///
+/// Operations whose causal prerequisites are absent are retained rather than
+/// rejected, and counted in the returned report. That is a state, not a
+/// failure: a caller that cannot tell a document waiting for prerequisites
+/// from a broken one cannot decide what to do next. Callers that require a
+/// message to be complete apply that policy themselves — `apply_sync` is the
+/// one that does.
+pub fn Editor::admit(
+  self : Editor,
+  msg : @text.SyncMessage,
+) -> @text.SyncReport raise {
   let report_result : Result[@text.SyncReport, @text.TextError] = Ok(
     self.doc.sync().apply(msg),
   ) catch {
@@ -149,11 +159,20 @@ pub fn Editor::apply_sync(self : Editor, msg : @text.SyncMessage) -> Unit raise 
   // EGW may apply ready operations before reporting an error or retaining
   // causal orphans, so repair shell state before propagating either outcome.
   self.adjust_cursor()
-  let report = match report_result {
+  match report_result {
     Ok(report) => report
     Err(error) => raise error
   }
-  if report.pending_operations() > 0 {
+}
+
+///|
+/// Sync: apply a SyncMessage from a peer, requiring it to be complete.
+///
+/// This is `admit` plus a completeness policy. The name does not say so; it
+/// predates the distinction and is kept because its callers depend on the
+/// raise.
+pub fn Editor::apply_sync(self : Editor, msg : @text.SyncMessage) -> Unit raise {
+  if self.admit(msg).pending_operations() > 0 {
     raise @text.TextError::VersionNotFound
   }
 }

--- a/editor/editor.mbt
+++ b/editor/editor.mbt
@@ -150,7 +150,7 @@ pub fn Editor::export_since(
 pub fn Editor::admit(
   self : Editor,
   msg : @text.SyncMessage,
-) -> @text.SyncReport raise {
+) -> @text.SyncReport raise @text.TextError {
   let report_result : Result[@text.SyncReport, @text.TextError] = Ok(
     self.doc.sync().apply(msg),
   ) catch {

--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -111,6 +111,10 @@ pub fn MarkdownBlockSnapshot::fence_close_range(self : Self) -> (Int, Int)? {
 /// taxonomy is how document recovery quietly becomes a session concern.
 pub(all) suberror MarkdownArchiveError {
   InvalidAgentId
+  /// No writing instance could be created, so nothing was attempted. Distinct
+  /// from `AdmitFailed`, which means a history was taken in and the taking
+  /// failed.
+  WriterUnavailable(detail~ : String)
   ExportFailed(detail~ : String)
   AdmitFailed(detail~ : String)
   IncompleteArchive
@@ -330,7 +334,8 @@ pub fn MarkdownEditor::open(
   let editor = @md_companion.new_markdown_editor(agent_id) catch {
     @text.TextError::EmptyReplicaId =>
       raise MarkdownArchiveError::InvalidAgentId
-    error => raise MarkdownArchiveError::AdmitFailed(detail=error.message())
+    error =>
+      raise MarkdownArchiveError::WriterUnavailable(detail=error.message())
   }
   let document = { editor, }
   match document.admit(history) {
@@ -353,7 +358,7 @@ pub fn MarkdownEditor::admit(
   history : MarkdownDocumentHistory,
 ) -> MarkdownAdmitReport raise MarkdownArchiveError {
   let report = self.editor.admit(history.message) catch {
-    error => raise MarkdownArchiveError::AdmitFailed(detail="\{error}")
+    error => raise MarkdownArchiveError::AdmitFailed(detail=error.message())
   }
   // Applicable operations are committed before the withheld ones are counted,
   // so the projection is rebuilt on both paths.
@@ -401,6 +406,8 @@ pub fn MarkdownEditor::history_since(
       Some(cut) => self.editor.export_since(cut.value)
     }
   } catch {
+    // The export methods widen to the supertype, so the binder has no
+    // `message()` here as it does at the admission and construction sites.
     error => raise MarkdownArchiveError::ExportFailed(detail="\{error}")
   }
   { message, }

--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -125,11 +125,10 @@ pub(all) suberror MarkdownArchiveError {
 /// it, and an archive that claims to be complete is contradicted by it.
 pub(all) enum MarkdownAdmitReport {
   /// Every operation in the history was applied.
-  Complete
+  Complete(applied~ : Int)
   /// Some operations were applied; others await prerequisites that did not
-  /// arrive. The count of each exists one layer down and is discarded before
-  /// it reaches here, so this reports the distinction and not the sizes.
-  Withheld
+  /// arrive and are held until they do.
+  Withheld(applied~ : Int, withheld~ : Int)
 } derive(Eq, Debug)
 
 ///|
@@ -325,8 +324,8 @@ pub fn MarkdownEditor::open(
   }
   let document = { editor, }
   match document.admit(history) {
-    MarkdownAdmitReport::Complete => document
-    MarkdownAdmitReport::Withheld =>
+    MarkdownAdmitReport::Complete(_) => document
+    MarkdownAdmitReport::Withheld(..) =>
       raise MarkdownArchiveError::IncompleteArchive
   }
 }
@@ -343,17 +342,17 @@ pub fn MarkdownEditor::admit(
   self : Self,
   history : MarkdownDocumentHistory,
 ) -> MarkdownAdmitReport raise MarkdownArchiveError {
-  let report = try {
-    self.editor.apply_sync(history.message)
-    MarkdownAdmitReport::Complete
-  } catch {
-    @text.TextError::VersionNotFound => MarkdownAdmitReport::Withheld
+  let report = self.editor.admit(history.message) catch {
     error => raise MarkdownArchiveError::AdmitFailed(detail="\{error}")
   }
   // Applicable operations are committed before the withheld ones are counted,
   // so the projection is rebuilt on both paths.
   self.editor.refresh()
-  report
+  let applied = report.applied_operations()
+  match report.pending_operations() {
+    0 => MarkdownAdmitReport::Complete(applied~)
+    withheld => MarkdownAdmitReport::Withheld(applied~, withheld~)
+  }
 }
 
 ///|

--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -103,6 +103,36 @@ pub fn MarkdownBlockSnapshot::fence_close_range(self : Self) -> (Int, Int)? {
 }
 
 ///|
+/// A categorized failure at the archive boundary.
+///
+/// Kept separate from `MarkdownEditorError` because an archive is a different
+/// authority from an editing session: a failure to reopen a document is not an
+/// editing failure, and the two are acted on at different moments. Sharing one
+/// taxonomy is how document recovery quietly becomes a session concern.
+pub(all) suberror MarkdownArchiveError {
+  InvalidAgentId
+  ExportFailed(detail~ : String)
+  AdmitFailed(detail~ : String)
+  IncompleteArchive
+}
+
+///|
+/// What an admission took, and what it is still holding.
+///
+/// Operations can arrive whose causal prerequisites have not. That is ordinary
+/// between replicas and is not a failure, so it is reported rather than raised.
+/// Whether it is acceptable is the caller's judgment: a peer exchange expects
+/// it, and an archive that claims to be complete is contradicted by it.
+pub(all) enum MarkdownAdmitReport {
+  /// Every operation in the history was applied.
+  Complete
+  /// Some operations were applied; others await prerequisites that did not
+  /// arrive. The count of each exists one layer down and is discarded before
+  /// it reaches here, so this reports the distinction and not the sizes.
+  Withheld
+} derive(Eq, Debug)
+
+///|
 /// Opaque identity of a projected Markdown node.
 pub struct MarkdownNodeId {
   priv value : @core.NodeId
@@ -192,6 +222,41 @@ pub fn MarkdownDocumentSnapshot::blocks(
 }
 
 ///|
+/// The document's version frontier, as a façade-owned value.
+///
+/// This is the signal persistence triggers on: an operation that leaves the
+/// source unchanged still moves it. Equality here means "has not advanced",
+/// never "is the same document" — two different histories can share a
+/// frontier, so continuation is decided by `MarkdownDocumentHistory` instead.
+pub struct MarkdownDocumentVersion {
+  priv value : @text.Version
+} derive(Eq, Debug)
+
+///|
+/// One document's operation history, carried as a value the caller cannot
+/// interpret.
+///
+/// The payload's own serialization is a closed CRDT contract that admits no
+/// application metadata, so document identity and archive versioning cannot
+/// be carried here — they belong to an outer envelope this façade does not
+/// define. Keeping the payload opaque is what stops that envelope from being
+/// skipped once one exists.
+pub struct MarkdownDocumentHistory {
+  priv message : @text.SyncMessage
+}
+
+///|
+/// Equality is canonical-history equality: the honest check that one document
+/// continues another. Comparing source and version instead would accept a
+/// document that merely looks the same.
+pub impl Eq for MarkdownDocumentHistory with fn equal(
+  self : MarkdownDocumentHistory,
+  other : MarkdownDocumentHistory,
+) -> Bool {
+  self.message.to_canonical_bytes() == other.message.to_canonical_bytes()
+}
+
+///|
 /// Result of one atomic editor commit.
 pub(all) enum MarkdownCommitResult {
   Applied(MarkdownDocumentSnapshot, MarkdownBlockSelection?)
@@ -205,7 +270,15 @@ pub struct MarkdownEditor {
 }
 
 ///|
-/// Construct a Markdown editor and install its initial canonical source.
+/// Create a new document from text.
+///
+/// This is the importing path, and it is the lossy one: the result has no past
+/// and shares no future with whatever produced the source. Continuing a
+/// document you already own is `open`.
+///
+/// The name does not yet say so. Renaming it to `import`, and letting the
+/// document mint its own writer identity instead of accepting one, both reach
+/// the single application call site and are deferred with it.
 pub fn MarkdownEditor::MarkdownEditor(
   agent_id~ : String,
   source~ : String,
@@ -221,9 +294,104 @@ pub fn MarkdownEditor::MarkdownEditor(
 }
 
 ///|
+/// Continue a document you already own, from its history.
+///
+/// This is admission into a document that holds nothing yet. It composes the
+/// general operation rather than standing beside it, because opening and
+/// merging differ only in what the receiver already holds — a surface that
+/// exposed only this case would make merging inexpressible, and merging is the
+/// only way to show a reopened document still shares a future.
+///
+/// Opening is where the completeness policy is stated. An archive presenting
+/// itself as whole is contradicted by operations it cannot satisfy, so withheld
+/// operations are refused here — while the same report is an expected outcome
+/// for a peer exchange. Nothing separates the two but this judgment.
+///
+/// The writer identity is supplied rather than carried by the history: a
+/// reopened document is a new writing instance, and reusing the exporter's
+/// identity would make the two indistinguishable in what they go on to write.
+///
+/// Not yet stated here: the admission policy. This passes through the path
+/// that admits remote traffic and inherits the resource limits written for it,
+/// which the design requires it not to. See the evidence record.
+pub fn MarkdownEditor::open(
+  agent_id~ : String,
+  history~ : MarkdownDocumentHistory,
+) -> MarkdownEditor raise MarkdownArchiveError {
+  let editor = @md_companion.new_markdown_editor(agent_id) catch {
+    @text.TextError::EmptyReplicaId =>
+      raise MarkdownArchiveError::InvalidAgentId
+    error => raise MarkdownArchiveError::AdmitFailed(detail=error.message())
+  }
+  let document = { editor, }
+  match document.admit(history) {
+    MarkdownAdmitReport::Complete => document
+    MarkdownAdmitReport::Withheld =>
+      raise MarkdownArchiveError::IncompleteArchive
+  }
+}
+
+///|
+/// Take a history into this document, whatever it already holds.
+///
+/// One operation covers restoring and merging; the receiver's prior contents
+/// are the only difference. Withheld operations are reported rather than
+/// raised, because a document waiting for prerequisites is in a state, not in
+/// a failure, and a caller that cannot tell those apart cannot decide what to
+/// do next.
+pub fn MarkdownEditor::admit(
+  self : Self,
+  history : MarkdownDocumentHistory,
+) -> MarkdownAdmitReport raise MarkdownArchiveError {
+  let report = try {
+    self.editor.apply_sync(history.message)
+    MarkdownAdmitReport::Complete
+  } catch {
+    @text.TextError::VersionNotFound => MarkdownAdmitReport::Withheld
+    error => raise MarkdownArchiveError::AdmitFailed(detail="\{error}")
+  }
+  // Applicable operations are committed before the withheld ones are counted,
+  // so the projection is rebuilt on both paths.
+  self.editor.refresh()
+  report
+}
+
+///|
 /// Read the last committed canonical source without exposing editor state.
 pub fn MarkdownEditor::snapshot(self : Self) -> MarkdownDocumentSnapshot {
   document_snapshot(self.editor)
+}
+
+///|
+/// Read the current version frontier without exposing editor state.
+pub fn MarkdownEditor::version(self : Self) -> MarkdownDocumentVersion {
+  { value: self.editor.get_version() }
+}
+
+///|
+/// Cut the history at a version and hand back everything after it.
+///
+/// The increment is the primitive and the whole history is the degenerate case
+/// of cutting at nothing. Saving triggers on the document advancing, so an
+/// export that could only produce everything would make the cost of saving
+/// grow with the age of the document rather than the size of the change — and
+/// the base-plus-increment shape that answers scale is the same shape that
+/// answers routine saving, not a later addition.
+///
+/// What comes back is a value the caller keeps but cannot read.
+pub fn MarkdownEditor::history_since(
+  self : Self,
+  version? : MarkdownDocumentVersion,
+) -> MarkdownDocumentHistory raise MarkdownArchiveError {
+  let message = try {
+    match version {
+      None => self.editor.export_all()
+      Some(cut) => self.editor.export_since(cut.value)
+    }
+  } catch {
+    error => raise MarkdownArchiveError::ExportFailed(detail="\{error}")
+  }
+  { message, }
 }
 
 ///|

--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -124,10 +124,20 @@ pub(all) suberror MarkdownArchiveError {
 /// Whether it is acceptable is the caller's judgment: a peer exchange expects
 /// it, and an archive that claims to be complete is contradicted by it.
 pub(all) enum MarkdownAdmitReport {
-  /// Every operation in the history was applied.
-  Complete(applied~ : Int)
-  /// Some operations were applied; others await prerequisites that did not
-  /// arrive and are held until they do.
+  /// Nothing is held: every operation in the history is now in this document.
+  ///
+  /// This carries no count. How many operations were new rather than already
+  /// present depends on what the sender chose to include, which says nothing
+  /// about this document, and whether the document advanced is answered by its
+  /// version — a signal that does not need a count to be read.
+  Complete
+  /// Some operations await prerequisites that did not arrive, and are held
+  /// until they do.
+  ///
+  /// Both counts are carried because the partial and total cases call for
+  /// different responses: `applied` is how many operations were new to this
+  /// document, so zero means nothing landed at all, and that reading holds
+  /// whatever else the message contained.
   Withheld(applied~ : Int, withheld~ : Int)
 } derive(Eq, Debug)
 
@@ -324,7 +334,7 @@ pub fn MarkdownEditor::open(
   }
   let document = { editor, }
   match document.admit(history) {
-    MarkdownAdmitReport::Complete(_) => document
+    MarkdownAdmitReport::Complete => document
     MarkdownAdmitReport::Withheld(..) =>
       raise MarkdownArchiveError::IncompleteArchive
   }
@@ -348,10 +358,13 @@ pub fn MarkdownEditor::admit(
   // Applicable operations are committed before the withheld ones are counted,
   // so the projection is rebuilt on both paths.
   self.editor.refresh()
-  let applied = report.applied_operations()
   match report.pending_operations() {
-    0 => MarkdownAdmitReport::Complete(applied~)
-    withheld => MarkdownAdmitReport::Withheld(applied~, withheld~)
+    0 => MarkdownAdmitReport::Complete
+    withheld =>
+      MarkdownAdmitReport::Withheld(
+        applied=report.applied_operations(),
+        withheld~,
+      )
   }
 }
 

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -975,6 +975,162 @@ test "empty replica identity is a categorized construction failure" {
 }
 
 ///|
+/// Repeats the probe's checkpoint round-trip through the façade.
+///
+/// workspace/probe pinned this at the editor layer because the façade exposed
+/// neither version nor history transport. It now does, so the same claim is
+/// asserted where the application actually stands.
+test "facade history round-trips into a reopened document" {
+  let original = try! MarkdownEditor(
+    agent_id="owner-1",
+    source="# Title\n\nbody text\n",
+  )
+  let edited = original.commit(
+    MarkdownEditRequest::ReplaceText(start=8, delete_len=0, inserted="!"),
+  )
+  assert_true(edited is Ok(MarkdownCommitResult::Applied(_)))
+  let want_source = original.snapshot().source()
+  let want_version = original.version()
+  let history = try! original.history_since()
+
+  let reopened = try! MarkdownEditor::open(agent_id="owner-2", history~)
+
+  assert_eq(reopened.snapshot().source(), want_source)
+  assert_true(reopened.version() == want_version)
+  // Same past. Source and version are asserted above as consequences, and
+  // would not on their own distinguish a continuation from a document that
+  // merely looks alike -- see the next test. Sharing a future is a separate
+  // claim, asserted by the convergence test below.
+  let reopened_history = try! reopened.history_since()
+  assert_true(reopened_history == history)
+}
+
+///|
+/// A reopened document still shares a future with the one it came from.
+///
+/// This is the half of the design's oracle that equality cannot reach. Equal
+/// history shows the two agree about the past; only an exchange of subsequent
+/// operations shows the reopened document is a replica rather than a copy that
+/// happens to match.
+test "reopened and original converge after divergent edits" {
+  let a = try! MarkdownEditor(agent_id="peer-a", source="hello world")
+  let seed = try! a.history_since()
+  let b = try! MarkdownEditor::open(agent_id="peer-b", history=seed)
+
+  assert_true(
+    a.commit(
+      MarkdownEditRequest::ReplaceText(start=0, delete_len=0, inserted="A"),
+    )
+    is Ok(_),
+  )
+  assert_true(
+    b.commit(
+      MarkdownEditRequest::ReplaceText(start=11, delete_len=0, inserted="B"),
+    )
+    is Ok(_),
+  )
+  assert_false(a.snapshot().source() == b.snapshot().source())
+
+  let from_b = try! b.history_since()
+  let from_a = try! a.history_since()
+  assert_eq(try! a.admit(from_b), MarkdownAdmitReport::Complete)
+  assert_eq(try! b.admit(from_a), MarkdownAdmitReport::Complete)
+
+  assert_eq(a.snapshot().source(), b.snapshot().source())
+  let history_a = try! a.history_since()
+  let history_b = try! b.history_since()
+  assert_true(history_a == history_b)
+}
+
+///|
+/// A history missing its prerequisites is a state, not a failure -- and an
+/// archive claiming to be whole is contradicted by it.
+///
+/// The same increment produces both outcomes. Admission reports what it could
+/// not place; opening refuses it. Nothing separates the two but the judgment
+/// each makes about the same report.
+test "withheld operations are reported by admit and refused by open" {
+  let source = try! MarkdownEditor(agent_id="gap-source", source="x")
+  let cut = source.version()
+  assert_true(
+    source.commit(
+      MarkdownEditRequest::ReplaceText(start=1, delete_len=0, inserted="y"),
+    )
+    is Ok(_),
+  )
+  // Everything after the cut, whose parents the receiver never saw.
+  let gapped = try! source.history_since(version=cut)
+
+  let receiver = try! MarkdownEditor(agent_id="gap-receiver", source="")
+  assert_eq(try! receiver.admit(gapped), MarkdownAdmitReport::Withheld)
+
+  let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+    MarkdownEditor::open(agent_id="gap-open", history=gapped),
+  ) catch {
+    error => Err(error)
+  }
+  match refused {
+    Err(MarkdownArchiveError::IncompleteArchive) => ()
+    _ => fail("expected IncompleteArchive")
+  }
+}
+
+///|
+/// Equal source and equal version do not make one document a continuation.
+///
+/// Two façade editors sharing a writer identity reach the same source and the
+/// same frontier while holding different histories. This is why restore is
+/// checked by comparing history, and it fails first if that ever stops being
+/// true.
+test "equal source and version do not imply equal history" {
+  let one = try! MarkdownEditor(agent_id="same-identity", source="")
+  let two = try! MarkdownEditor(agent_id="same-identity", source="")
+  for writer in [(one, "A"), (two, "B")] {
+    let (editor, inserted) = writer
+    assert_true(
+      editor.commit(
+        MarkdownEditRequest::ReplaceText(start=0, delete_len=0, inserted~),
+      )
+      is Ok(_),
+    )
+    assert_true(
+      editor.commit(
+        MarkdownEditRequest::ReplaceText(start=0, delete_len=1, inserted=""),
+      )
+      is Ok(_),
+    )
+  }
+
+  assert_eq(one.snapshot().source(), two.snapshot().source())
+  assert_true(one.version() == two.version())
+  let history_one = try! one.history_since()
+  let history_two = try! two.history_since()
+  assert_false(history_one == history_two)
+}
+
+///|
+/// A commit reported as Unchanged still advanced the document.
+///
+/// The façade classifies a commit by comparing source, so it says Unchanged
+/// here. The version says otherwise, and the version is what persistence must
+/// trigger on: saving on the façade's own verdict would skip this.
+test "text-preserving commit reports Unchanged while the version advances" {
+  let editor = try! MarkdownEditor(agent_id="advance", source="hello")
+  let before_version = editor.version()
+
+  let result = editor.commit(
+    MarkdownEditRequest::ReplaceText(start=0, delete_len=1, inserted="h"),
+  )
+
+  match result {
+    Ok(MarkdownCommitResult::Unchanged(snapshot)) =>
+      assert_eq(snapshot.source(), "hello")
+    _ => fail("expected Unchanged")
+  }
+  assert_false(editor.version() == before_version)
+}
+
+///|
 test "reference definition insertion preserves facade block identities" {
   let prefix = "[ref]: /target\n\n"
   let source = "# Heading\n\nBody [link][ref].\n"

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1045,6 +1045,31 @@ test "reopened and original converge after divergent edits" {
 }
 
 ///|
+/// Opening blames the writer it could not create, not the history.
+///
+/// The two failures are reported at the same moment and read alike from the
+/// outside, so the categories are easy to collapse -- and this one did, until
+/// the mapping was corrected. An admission failure means a history was taken
+/// in and the taking failed; here nothing was ever attempted.
+test "open categorizes a bad writer identity as such" {
+  let document = try! MarkdownEditor(agent_id="identity-source", source="# T\n")
+  let history = try! document.history_since()
+
+  let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+    MarkdownEditor::open(agent_id="", history~),
+  ) catch {
+    error => Err(error)
+  }
+
+  match refused {
+    Err(MarkdownArchiveError::InvalidAgentId) => ()
+    Err(MarkdownArchiveError::AdmitFailed(detail~)) =>
+      fail("blamed admission for a writer that was never created: \{detail}")
+    _ => fail("expected InvalidAgentId")
+  }
+}
+
+///|
 /// Taking back a history the document already holds changes nothing.
 ///
 /// The convergence test above traverses this path -- each side is sent the

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1033,8 +1033,8 @@ test "reopened and original converge after divergent edits" {
 
   let from_b = try! b.history_since()
   let from_a = try! a.history_since()
-  assert_eq(try! a.admit(from_b), MarkdownAdmitReport::Complete)
-  assert_eq(try! b.admit(from_a), MarkdownAdmitReport::Complete)
+  assert_true(try! (a.admit(from_b) is MarkdownAdmitReport::Complete(_)))
+  assert_true(try! (b.admit(from_a) is MarkdownAdmitReport::Complete(_)))
 
   assert_eq(a.snapshot().source(), b.snapshot().source())
   let history_a = try! a.history_since()
@@ -1062,7 +1062,12 @@ test "withheld operations are reported by admit and refused by open" {
   let gapped = try! source.history_since(version=cut)
 
   let receiver = try! MarkdownEditor(agent_id="gap-receiver", source="")
-  assert_eq(try! receiver.admit(gapped), MarkdownAdmitReport::Withheld)
+  // Exact counts, not merely the distinction: the increment carries one
+  // operation, whose parent is absent, so nothing lands and one is held.
+  assert_eq(
+    try! receiver.admit(gapped),
+    MarkdownAdmitReport::Withheld(applied=0, withheld=1),
+  )
 
   let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
     MarkdownEditor::open(agent_id="gap-open", history=gapped),

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1033,13 +1033,43 @@ test "reopened and original converge after divergent edits" {
 
   let from_b = try! b.history_since()
   let from_a = try! a.history_since()
-  assert_true(try! (a.admit(from_b) is MarkdownAdmitReport::Complete(_)))
-  assert_true(try! (b.admit(from_a) is MarkdownAdmitReport::Complete(_)))
+  // Each side is handed the other's whole history, most of which it already
+  // holds. Operations already present are neither applied again nor withheld.
+  assert_eq(try! a.admit(from_b), MarkdownAdmitReport::Complete)
+  assert_eq(try! b.admit(from_a), MarkdownAdmitReport::Complete)
 
   assert_eq(a.snapshot().source(), b.snapshot().source())
   let history_a = try! a.history_since()
   let history_b = try! b.history_since()
   assert_true(history_a == history_b)
+}
+
+///|
+/// Taking back a history the document already holds changes nothing.
+///
+/// The convergence test above traverses this path -- each side is sent the
+/// other's whole history -- without ever pinning it, so a document that
+/// re-applied operations it already had would have converged anyway and gone
+/// unnoticed. Admission is idempotent, and that is asserted here rather than
+/// relied on there.
+test "re-admitting a held history advances nothing" {
+  let document = try! MarkdownEditor(agent_id="idempotent", source="# Title\n")
+  assert_true(
+    document.commit(
+      MarkdownEditRequest::ReplaceText(start=8, delete_len=0, inserted="body\n"),
+    )
+    is Ok(_),
+  )
+  let before_source = document.snapshot().source()
+  let before_version = document.version()
+  let held = try! document.history_since()
+
+  assert_eq(try! document.admit(held), MarkdownAdmitReport::Complete)
+
+  assert_eq(document.snapshot().source(), before_source)
+  assert_true(document.version() == before_version)
+  let after = try! document.history_since()
+  assert_true(after == held)
 }
 
 ///|

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -9,6 +9,13 @@ import {
 // Values
 
 // Errors
+pub(all) suberror MarkdownArchiveError {
+  InvalidAgentId
+  ExportFailed(detail~ : String)
+  AdmitFailed(detail~ : String)
+  IncompleteArchive
+}
+
 pub(all) suberror MarkdownEditorError {
   InvalidAgentId
   InitializationFailed(detail~ : String)
@@ -18,6 +25,11 @@ pub(all) suberror MarkdownEditorError {
 }
 
 // Types and methods
+pub(all) enum MarkdownAdmitReport {
+  Complete
+  Withheld
+} derive(Eq, @debug.Debug)
+
 pub(all) enum MarkdownBlockKind {
   Paragraph
   Heading(level~ : Int)
@@ -50,12 +62,21 @@ pub(all) enum MarkdownCommitResult {
   Unchanged(MarkdownDocumentSnapshot)
 } derive(Eq, @debug.Debug)
 
+pub struct MarkdownDocumentHistory {
+  // private fields
+}
+pub impl Eq for MarkdownDocumentHistory
+
 pub struct MarkdownDocumentSnapshot {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn MarkdownDocumentSnapshot::blocks(Self) -> @vector.Vector[MarkdownBlockSnapshot]
 pub fn MarkdownDocumentSnapshot::projection(Self) -> MarkdownProjectionSnapshot
 pub fn MarkdownDocumentSnapshot::source(Self) -> String
+
+pub struct MarkdownDocumentVersion {
+  // private fields
+} derive(Eq, @debug.Debug)
 
 pub(all) enum MarkdownEditRequest {
   ReplaceSource(String)
@@ -73,8 +94,12 @@ pub struct MarkdownEditor {
   // private fields
 }
 pub fn MarkdownEditor::MarkdownEditor(agent_id~ : String, source~ : String) -> Self raise MarkdownEditorError
+pub fn MarkdownEditor::admit(Self, MarkdownDocumentHistory) -> MarkdownAdmitReport raise MarkdownArchiveError
 pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError]
+pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -> MarkdownDocumentHistory raise MarkdownArchiveError
+pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory) -> Self raise MarkdownArchiveError
 pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
+pub fn MarkdownEditor::version(Self) -> MarkdownDocumentVersion
 
 pub struct MarkdownNodeId {
   // private fields

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -26,7 +26,7 @@ pub(all) suberror MarkdownEditorError {
 
 // Types and methods
 pub(all) enum MarkdownAdmitReport {
-  Complete(applied~ : Int)
+  Complete
   Withheld(applied~ : Int, withheld~ : Int)
 } derive(Eq, @debug.Debug)
 

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -26,8 +26,8 @@ pub(all) suberror MarkdownEditorError {
 
 // Types and methods
 pub(all) enum MarkdownAdmitReport {
-  Complete
-  Withheld
+  Complete(applied~ : Int)
+  Withheld(applied~ : Int, withheld~ : Int)
 } derive(Eq, @debug.Debug)
 
 pub(all) enum MarkdownBlockKind {

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -11,6 +11,7 @@ import {
 // Errors
 pub(all) suberror MarkdownArchiveError {
   InvalidAgentId
+  WriterUnavailable(detail~ : String)
   ExportFailed(detail~ : String)
   AdmitFailed(detail~ : String)
   IncompleteArchive

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -107,7 +107,7 @@ pub struct Editor {
   doc : @text.TextState
   mut cursor : Int
 } derive(@debug.Debug)
-pub fn Editor::admit(Self, @text.SyncMessage) -> @text.SyncReport raise
+pub fn Editor::admit(Self, @text.SyncMessage) -> @text.SyncReport raise @text.TextError
 pub fn Editor::apply_sync(Self, @text.SyncMessage) -> Unit raise
 pub fn Editor::backspace(Self) -> Bool
 pub fn Editor::delete(Self) -> Bool
@@ -131,7 +131,7 @@ pub fn[T] LanguageCapabilities::with_to_view_node(Self[T], (@dowdiness/canopy/co
 pub struct SyncEditor[T] {
   // private fields
 }
-pub fn[T : Eq] SyncEditor::admit(Self[T], @text.SyncMessage) -> @text.SyncReport raise
+pub fn[T : Eq] SyncEditor::admit(Self[T], @text.SyncMessage) -> @text.SyncReport raise @text.TextError
 pub fn[T] SyncEditor::apply_ephemeral(Self[T], Bytes) -> Unit
 pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int, hint? : @dowdiness/canopy/core.IdentityTransform) -> Unit
 pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise

--- a/editor/pkg.generated.mbti
+++ b/editor/pkg.generated.mbti
@@ -107,6 +107,7 @@ pub struct Editor {
   doc : @text.TextState
   mut cursor : Int
 } derive(@debug.Debug)
+pub fn Editor::admit(Self, @text.SyncMessage) -> @text.SyncReport raise
 pub fn Editor::apply_sync(Self, @text.SyncMessage) -> Unit raise
 pub fn Editor::backspace(Self) -> Bool
 pub fn Editor::delete(Self) -> Bool
@@ -130,6 +131,7 @@ pub fn[T] LanguageCapabilities::with_to_view_node(Self[T], (@dowdiness/canopy/co
 pub struct SyncEditor[T] {
   // private fields
 }
+pub fn[T : Eq] SyncEditor::admit(Self[T], @text.SyncMessage) -> @text.SyncReport raise
 pub fn[T] SyncEditor::apply_ephemeral(Self[T], Bytes) -> Unit
 pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int, hint? : @dowdiness/canopy/core.IdentityTransform) -> Unit
 pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -454,10 +454,16 @@ fn[T] SyncEditor::adjust_cursor(self : SyncEditor[T]) -> Unit {
 }
 
 ///|
-pub fn[T : Eq] SyncEditor::apply_sync(
+/// Take a peer's operations into this document, reporting what landed.
+///
+/// Operations whose causal prerequisites are absent are retained rather than
+/// rejected, and counted in the returned report. That is a state, not a
+/// failure. Callers that require a message to be complete apply that policy
+/// themselves — `apply_sync` is the one that does.
+pub fn[T : Eq] SyncEditor::admit(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
-) -> Unit raise {
+) -> @text.SyncReport raise {
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.undo.set_tracking(false)
@@ -473,18 +479,32 @@ pub fn[T : Eq] SyncEditor::apply_sync(
   self.adjust_cursor()
   self.adjust_peer_cursors_after_text_change(old_source, new_source, None)
   self.sync_parser_after_text_change(old_source, new_source, None)
-  // Keep the legacy Unit-raising SyncHost seam while EGW remains the sole
-  // owner of causally pending operations.
   let report = match report_result {
     Ok(report) => report
     Err(error) => raise error
   }
-  if report.pending_operations() > 0 {
+  if report.pending_operations() == 0 {
+    // Clear a prior Error status once any sync applies — another peer
+    // (via RelayedCrdtOps) having filled the causal gap counts as recovery.
+    // A message that still leaves a gap is not recovery, so the status stands.
+    self.session.note_sync_applied()
+  }
+  report
+}
+
+///|
+/// Apply a SyncMessage from a peer, requiring it to be complete.
+///
+/// This is `admit` plus a completeness policy. The name does not say so; it
+/// predates the distinction and is kept because its callers depend on the
+/// raise.
+pub fn[T : Eq] SyncEditor::apply_sync(
+  self : SyncEditor[T],
+  msg : @text.SyncMessage,
+) -> Unit raise {
+  if self.admit(msg).pending_operations() > 0 {
     raise @text.TextError::VersionNotFound
   }
-  // Clear a prior Error status once any sync applies — another peer
-  // (via RelayedCrdtOps) having filled the causal gap counts as recovery.
-  self.session.note_sync_applied()
 }
 
 ///|

--- a/editor/sync_editor.mbt
+++ b/editor/sync_editor.mbt
@@ -463,7 +463,7 @@ fn[T] SyncEditor::adjust_cursor(self : SyncEditor[T]) -> Unit {
 pub fn[T : Eq] SyncEditor::admit(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
-) -> @text.SyncReport raise {
+) -> @text.SyncReport raise @text.TextError {
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.undo.set_tracking(false)

--- a/workspace/probe/document_ownership_assumptions_wbtest.mbt
+++ b/workspace/probe/document_ownership_assumptions_wbtest.mbt
@@ -15,8 +15,9 @@
 /// cannot be built the way the design describes.
 ///
 /// This also pins that restoring an intact checkpoint leaves no causally
-/// pending operations: apply_sync raises when pending remain, so a clean
-/// return is the observation.
+/// pending operations. That was once observed indirectly, through a call that
+/// raised when any remained; admission now reports the count, so the assertion
+/// is the count itself.
 test "ownership: checkpoint round-trips into a fresh editor" {
   let original = @editor.Editor::new("assumption-writer-1")
   original.insert_at(0, "# Title\n\nbody text\n")
@@ -26,13 +27,8 @@ test "ownership: checkpoint round-trips into a fresh editor" {
   let checkpoint_json = original.export_all().to_json_string()
   let restored = @editor.Editor::new("assumption-writer-2")
   let decoded = @text.SyncMessage::from_json_string(checkpoint_json)
-  let applied = try {
-    restored.apply_sync(decoded)
-    true
-  } catch {
-    _ => false
-  }
-  inspect(applied, content="true")
+  let report = restored.admit(decoded)
+  inspect(report.pending_operations(), content="0")
   inspect(restored.get_text() == want_text, content="true")
   inspect(
     restored.get_version().to_json_string() == want_version.to_json_string(),


### PR DESCRIPTION
## Summary

Gives the Markdown façade the surface a locally-owned document needs: report a
version, cut history at one, take a history in, and reopen a document from one.
Adds the design this shape comes from, and the observations behind it.

Follows the direction merged in #1123, which settles *what* must be preserved.
This settles *what shape presents it* — a gap that showed up as soon as a façade
tried: restoring was expressible and merging was not, so only half of that
design's own acceptance oracle could be asserted.

**Admission is one operation.** Opening an archive is admitting a history into a
document that holds nothing yet; merging is admitting into one that holds
something. Nothing distinguishes them but the receiver, and that was measured
before it was designed on. Exposing only the first is what made the second
inexpressible.

**Withheld operations are reported, not raised.** `editor/` built a report
naming how many operations landed and how many await prerequisites, then
discarded it one line before raising. `admit` now returns it and `apply_sync` is
that plus the completeness policy its callers depend on — one implementation,
not two. Opening refuses withheld operations, since an archive claiming to be
whole is contradicted by them; admission reports them as the ordinary outcome
they are between replicas. One report, two judgments.

**Export is a cut, not a dump.** Saving triggers on the document advancing, so
an export that could only produce everything would grow the cost of saving with
the age of the document.

**The payload is closed.** `MarkdownDocumentHistory` holds a private field, so
the compiler refuses both reading it and constructing one; equality is
canonical-history equality, the only affordance callers get and the honest one.
No `@text` type appears in the generated interface.

### Both halves of the oracle are asserted

The design names two honest checks and this asserts both. Equal canonical
history shows the reopened document agrees about the past. Convergence after
divergent edits shows it can still share a future — which equality cannot reach,
and which is the loss the direction exists to prevent.

### Deliberately not done

- **Writer identity is still supplied, not minted.** The invariant is one
  identity per writing instance, and an argument cannot enforce it. The sole
  application call site passes a fixed literal. Reaches `editor/` and `loomark/`.
- **The resource half of the admission policy is still inherited.** Limits are
  fixed per document at construction, so opening an archive cannot state a
  different policy from admitting remote traffic. Reaches `event-graph-walker`.
- **`apply_sync` does not say which policy it applies.** Correcting the name is a
  rename across 81 call sites, separable from this.
- **No envelope, no file I/O, no network.**

Each is recorded as an open question in the evidence file rather than guessed at.
`docs/design/local-first-document-surface.md` also names one conflict it does not
resolve: undo across a restart and one identity per writing instance cannot both
hold as stated.

## UI and review evidence

No UI. Independent review by Codex (GPT-5) on the pre-rebase tree returned FAIL
on one finding — the missing post-restore merge check — which is what the
convergence test now closes. Its other conclusions (canonical-bytes equality is
genuinely order-independent; restore cannot return a half-applied document; the
separate archive error type is justified on its merits) were checked against the
sources it cited. It could not execute tests in its sandbox, so every dynamic
result here is from local runs.

Every added assertion was falsified once and restored, after the rebase as well
as before, so none of them passes vacuously:

| Falsified assertion | Result |
| --- | --- |
| round-trip: reopened history equals exported | 48/49, names its line |
| convergence: histories equal after exchange | 48/49, names its line |
| idempotence: history unchanged after re-admit | 48/49, names its line |
| withheld: `Withheld(applied=0, withheld=1)` | 48/49, `Withheld(...) != Complete` |
| probe: pending count is 0 | 41/42 |

Opacity was checked with a known-positive control rather than by reading the
generated interface, which cannot show the hole: a temporary probe in another
package attempted both forbidden operations and the compiler rejected the field
read (`[4091]`) and the construction (`[4036]`, `[4033]`). Probe removed.

## Reuse check

Existing project APIs reused rather than reimplemented:

- `@editor.SyncEditor::export_since` — the increment primitive already existed;
  `history_since` cuts with it and falls back to `export_all` for the whole
  history. No new increment mechanism.
- `@text.SyncReport` — `editor/` returns it as-is rather than defining a parallel
  report type at that layer. `editor/` already exposes `@text` types throughout
  its interface, so this adds no new coupling; the façade is where opacity starts.
- `@text.Version`, `@text.SyncMessage` — wrapped, not re-modelled. The façade
  types are private-field newtypes over them.
- `@md_companion.new_markdown_editor` — reused by the reopening path.

MoonBit core APIs considered: `Eq` (used — `MarkdownDocumentHistory` implements
it manually over `Bytes` equality, since `SyncMessage` derives no `Eq`);
`Bytes`/`BytesView` (used via `to_canonical_bytes`, no view slicing needed);
`Option` (used for the optional cut in `history_since`); `Result` (not used —
these operations raise a categorized suberror, matching the façade's existing
convention); `Map`/`Set`, `Array`/`Iter`, `Buffer`/`StringBuilder` (not
applicable — no collection building or iteration was introduced).

New definitions and why: `MarkdownDocumentVersion`, `MarkdownDocumentHistory`,
`MarkdownAdmitReport`, `MarkdownArchiveError`. The first two exist to keep
`@text` types out of the interface, which is the point of the change rather than
incidental to it. `MarkdownAdmitReport` has no existing equivalent at the façade.
`MarkdownArchiveError` is separate from `MarkdownEditorError` because a document
that will not reopen has not suffered an editing failure; that also leaves the
one existing exhaustive match over the editing taxonomy untouched.

Honestly: the two-candidate search was performed for the substrate operations
above but not written down for each new façade type at the time it was defined.

## Validation scope

Workspace `moon check` clean. Test packages run locally: `editor` 231/231,
`editor/markdown` 49/49, `workspace/probe` 42/42, `lang/lambda/companion`
112/112, `lang/markdown/edits` 61/61, `ffi/lambda` 69/69, `sync_session` 29/29.

`editor/` has 42 consumer files across four languages, FFI, examples, and
Playwright suites; only the packages above were exercised locally. The interface
diff for `editor/` is two added methods and no signature change, so no call site
was touched.

Two corrections to claims made while this was open, in the order I got them
wrong. First I wrote that CI verifies the Playwright suites; then, seeing them
skip, I wrote that all E2E jobs skip. Neither is right.

What actually runs: **Loomark Dev Host E2E passed (1m20s)**. Its filter lists
`editor/markdown/**` alongside `loomark/**`, `lib/dom-boundary/**`,
`lib/js-ffi/**`, and `rabbita/**` — it names its dependencies, not just its own
directory, so a change to the façade triggers it. That is browser-level
verification of the surface this PR adds.

What does not: the four `run_e2e` suites (Waku, Ideal, Demo React, Canvas). That
filter lists only `examples/web|ideal|demo-react|canvas/**`, `build-js.sh`, and
`test-*.sh`, so a change to `editor/` never triggers them even though `editor/`
compiles into the artifacts they run against. The observation is about that one
filter, not about the repository's E2E gating generally — the Loomark filter
does it correctly.

So the JS-facing evidence is: the target builds, the web example builds, and the
one browser suite that consumes this façade passes. Unverified is runtime
behaviour in the four suites above, bounded by the `editor/` change being
behaviour-preserving — `apply_sync` raises on the same condition after the same
reconciliation, and `editor`'s own 231 tests pass unchanged.

### Review

CodeRabbit raised three points. Two are valid and unfixed as of this writing:
`open` maps an editor-construction failure to `AdmitFailed` when no admission
happened, and one error detail uses string interpolation where the neighbouring
sites use `error.message()`. The third, that the `Applied(_)` pattern does not
match the variant's two fields, is a false positive: a single wildcard matches
the constructor regardless of arity and does not match a sibling variant,
confirmed by probe.

### Packaging

This bundles a design direction with an implementation, where the precedent set
by #1123 a few days earlier was to ship the direction alone. A reviewer is asked
to judge both at once, and the design names a target this PR deliberately does
not reach. Splitting now would cost three rebases and a full CI cycle; recording
the deviation seemed the better trade, but it is a deviation.

## PR-ready evidence

```
validated-head=eb0294109a57ecb60b61b3cbe5e3a2de595bb1e2
validated-base=7e3a38eab65a9872aa0f27f08d0d7e6f8d0c830e
validated-base-ref=origin/main
validated-target=editor
validated-target=editor/markdown
validated-target=workspace/probe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
