### PR TITLE
feat(markdown): add history-aware commit receipts

### DIFF
--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -277,6 +277,98 @@ pub(all) enum MarkdownCommitResult {
 } derive(Eq, Debug)
 
 ///|
+/// Origin of a committed Markdown change.
+///
+/// This ticket reports only edits produced by this writing instance. Keeping
+/// origin explicit prevents a future remote admission from entering a local
+/// persistence outbox by accident.
+pub(all) enum MarkdownCommitOrigin {
+  Local
+} derive(Eq, Debug)
+
+///|
+/// One source transform for downstream presence coordinates.
+///
+/// `start` and `delete_len` are UTF-16 code-unit coordinates, and
+/// `inserted.length()` is the inserted UTF-16 length. The first transform is
+/// relative to the source immediately before the commit; each later transform
+/// is relative to the source produced by every preceding transform. Applying
+/// the ordered sequence yields the receipt's post-commit snapshot source.
+pub struct MarkdownTextTransform {
+  priv change : @text_change.TextChange
+} derive(Eq, Debug)
+
+///|
+pub fn MarkdownTextTransform::start(self : Self) -> Int {
+  self.change.start
+}
+
+///|
+pub fn MarkdownTextTransform::delete_len(self : Self) -> Int {
+  self.change.delete_len
+}
+
+///|
+pub fn MarkdownTextTransform::inserted(self : Self) -> String {
+  self.change.inserted
+}
+
+///|
+/// Causal receipt for one successful local commit attempt.
+///
+/// The legacy result remains source-oriented for compatibility. Advancement is
+/// reported independently through the before/after versions: when they differ,
+/// `history` is exactly the opaque increment since `before_version`; when they
+/// are equal, `history` is absent and `transforms` is empty.
+pub struct MarkdownCommitReceipt {
+  priv result : MarkdownCommitResult
+  priv before_version : MarkdownDocumentVersion
+  priv after_version : MarkdownDocumentVersion
+  priv origin : MarkdownCommitOrigin
+  priv history : MarkdownDocumentHistory?
+  priv transforms : @vector.Vector[MarkdownTextTransform]
+}
+
+///|
+pub fn MarkdownCommitReceipt::result(self : Self) -> MarkdownCommitResult {
+  self.result
+}
+
+///|
+pub fn MarkdownCommitReceipt::before_version(
+  self : Self,
+) -> MarkdownDocumentVersion {
+  self.before_version
+}
+
+///|
+pub fn MarkdownCommitReceipt::after_version(
+  self : Self,
+) -> MarkdownDocumentVersion {
+  self.after_version
+}
+
+///|
+pub fn MarkdownCommitReceipt::origin(self : Self) -> MarkdownCommitOrigin {
+  self.origin
+}
+
+///|
+/// Opaque history increment cut at `before_version`, present only when the
+/// document version advanced.
+pub fn MarkdownCommitReceipt::history(self : Self) -> MarkdownDocumentHistory? {
+  self.history
+}
+
+///|
+/// Ordered UTF-16 transforms for downstream presence updates.
+pub fn MarkdownCommitReceipt::transforms(
+  self : Self,
+) -> @vector.Vector[MarkdownTextTransform] {
+  self.transforms
+}
+
+///|
 /// Opaque, headless Markdown editor façade.
 pub struct MarkdownEditor {
   priv editor : @editor.SyncEditor[@md_markdown.Block]
@@ -415,19 +507,83 @@ pub fn MarkdownEditor::history_since(
 
 ///|
 /// Apply one façade-owned request atomically.
+///
+/// This compatibility method intentionally returns only the existing
+/// source-oriented result. Call `commit_with_receipt` when causal advancement
+/// and presence transforms are needed.
 pub fn MarkdownEditor::commit(
   self : Self,
   request : MarkdownEditRequest,
 ) -> Result[MarkdownCommitResult, MarkdownEditorError] {
-  match request {
-    ReplaceSource(source) =>
-      if self.editor.get_text() == source {
-        Ok(MarkdownCommitResult::Unchanged(self.snapshot()))
+  self.commit_recording_transforms(request).map(pair => pair.0)
+}
+
+///|
+/// Apply one request and report causal advancement without changing `commit`.
+///
+/// History export can fail independently after the local edit has committed,
+/// so archive failures remain raised while edit failures keep the legacy
+/// `Result` channel.
+pub fn MarkdownEditor::commit_with_receipt(
+  self : Self,
+  request : MarkdownEditRequest,
+) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError {
+  let before_version = self.version()
+  match self.commit_recording_transforms(request) {
+    Err(error) => Err(error)
+    Ok((result, transforms)) => {
+      let after_version = self.version()
+      if after_version == before_version {
+        Ok({
+          result,
+          before_version,
+          after_version,
+          origin: MarkdownCommitOrigin::Local,
+          history: None,
+          transforms: @vector.new(),
+        })
       } else {
+        Ok({
+          result,
+          before_version,
+          after_version,
+          origin: MarkdownCommitOrigin::Local,
+          history: Some(self.history_since(version=before_version)),
+          transforms,
+        })
+      }
+    }
+  }
+}
+
+///|
+/// Keep the mutation shell shared by legacy commits and causal receipts.
+fn MarkdownEditor::commit_recording_transforms(
+  self : Self,
+  request : MarkdownEditRequest,
+) -> Result[
+  (MarkdownCommitResult, @vector.Vector[MarkdownTextTransform]),
+  MarkdownEditorError,
+] {
+  match request {
+    ReplaceSource(source) => {
+      let before = self.editor.get_text()
+      if before == source {
+        Ok((MarkdownCommitResult::Unchanged(self.snapshot()), @vector.new()))
+      } else {
+        // set_text uses this same shared splice contract. Computing it here is
+        // the only path without caller- or lowering-supplied edit information.
+        let change = @text_change.compute_text_change(before, source)
         self.editor.set_text(source)
         self.editor.refresh()
-        Ok(MarkdownCommitResult::Applied(self.snapshot(), None))
+        Ok(
+          (
+            MarkdownCommitResult::Applied(self.snapshot(), None),
+            @vector.Vector::singleton(MarkdownTextTransform::{ change, }),
+          ),
+        )
       }
+    }
     ReplaceText(start~, delete_len~, inserted~) => {
       let source = self.editor.get_text()
       let source_length = source.length()
@@ -447,11 +603,19 @@ pub fn MarkdownEditor::commit(
         ) {
         self.editor.refresh()
         let snapshot = self.snapshot()
-        if snapshot.source() == source {
-          Ok(MarkdownCommitResult::Unchanged(snapshot))
+        let result = if snapshot.source() == source {
+          MarkdownCommitResult::Unchanged(snapshot)
         } else {
-          Ok(MarkdownCommitResult::Applied(snapshot, None))
+          MarkdownCommitResult::Applied(snapshot, None)
         }
+        Ok(
+          (
+            result,
+            @vector.Vector::singleton(MarkdownTextTransform::{
+              change: @text_change.TextChange::{ start, delete_len, inserted },
+            }),
+          ),
+        )
       } else {
         Err(MarkdownEditorError::EditFailed(detail="text edit rejected"))
       }
@@ -459,7 +623,7 @@ pub fn MarkdownEditor::commit(
     CommitEdit(node_id~, new_text~) =>
       match self.editable_block_text(node_id) {
         Some(_) =>
-          self.commit_structural(
+          self.commit_structural_recording_transforms(
             @md_edits.MarkdownEditOp::CommitEdit(
               node_id=node_id.value,
               new_text~,
@@ -487,7 +651,7 @@ pub fn MarkdownEditor::commit(
           } else {
             reconciled
           }
-          self.commit_structural(
+          self.commit_structural_recording_transforms(
             @md_edits.MarkdownEditOp::CommitEdit(
               node_id=node_id.value,
               new_text~,
@@ -503,7 +667,7 @@ pub fn MarkdownEditor::commit(
       }
     SplitBlock(node_id~, offset~) =>
       if self.editable_block_target(node_id) {
-        self.commit_structural(
+        self.commit_structural_recording_transforms(
           @md_edits.MarkdownEditOp::SplitBlock(node_id=node_id.value, offset~),
         )
       } else {
@@ -514,23 +678,23 @@ pub fn MarkdownEditor::commit(
         )
       }
     ChangeHeadingLevel(node_id~, level~) =>
-      self.commit_structural(
+      self.commit_structural_recording_transforms(
         @md_edits.MarkdownEditOp::ChangeHeadingLevel(
           node_id=node_id.value,
           level~,
         ),
       )
     ToggleListItem(node_id~) =>
-      self.commit_structural(
+      self.commit_structural_recording_transforms(
         @md_edits.MarkdownEditOp::ToggleListItem(node_id=node_id.value),
       )
     Delete(node_id~) =>
-      self.commit_structural(
+      self.commit_structural_recording_transforms(
         @md_edits.MarkdownEditOp::Delete(node_id=node_id.value),
       )
     MergeWithPrevious(node_id~) =>
       if self.editable_block_target(node_id) {
-        self.commit_structural(
+        self.commit_structural_recording_transforms(
           @md_edits.MarkdownEditOp::MergeWithPrevious(node_id=node_id.value),
         )
       } else {
@@ -544,29 +708,68 @@ pub fn MarkdownEditor::commit(
 }
 
 ///|
-/// Lower typed structural requests without exposing Tier-2 edit values.
-fn MarkdownEditor::commit_structural(
+/// Lower one typed request once, apply the same spans, and retain their exact
+/// order for the receipt without re-diffing the resulting source.
+fn MarkdownEditor::commit_structural_recording_transforms(
   self : Self,
   op : @md_edits.MarkdownEditOp,
-) -> Result[MarkdownCommitResult, MarkdownEditorError] {
+) -> Result[
+  (MarkdownCommitResult, @vector.Vector[MarkdownTextTransform]),
+  MarkdownEditorError,
+] {
   let source = self.editor.get_text()
-  guard self.editor.get_proj_node() is Some(_) else {
+  guard self.editor.get_proj_node() is Some(proj) else {
     return Err(MarkdownEditorError::ProjectionUnavailable)
   }
-  match @md_companion.apply_markdown_edit(self.editor, op, 0) {
+  let computed = Ok(
+    @md_edits.compute_markdown_edit(
+      op,
+      source,
+      proj,
+      self.editor.get_source_map(),
+    ),
+  ) catch {
+    error => Err(error.message())
+  }
+  match computed {
     Err(detail) => Err(MarkdownEditorError::EditFailed(detail~))
-    Ok(_) => {
+    Ok(lowered) => {
+      let (edits, focus_hint) = match lowered {
+        Some(pair) => pair
+        None => ([], @core.FocusHint::RestoreCursor)
+      }
+      self.editor.apply_span_edits(edits, focus_hint, 0)
       self.editor.refresh()
       let snapshot = self.snapshot()
-      if snapshot.source() == source {
+      let result = if snapshot.source() == source {
         // A no-op never authorizes a new caret move for the caller.
-        Ok(MarkdownCommitResult::Unchanged(snapshot))
+        MarkdownCommitResult::Unchanged(snapshot)
       } else {
         let selection = selection_for_cursor(snapshot, self.editor.get_cursor())
-        Ok(MarkdownCommitResult::Applied(snapshot, selection))
+        MarkdownCommitResult::Applied(snapshot, selection)
       }
+      Ok((result, sequential_text_transforms(edits)))
     }
   }
+}
+
+///|
+/// Mirror SyncEditor's reverse-document-order application as a sequential,
+/// immutable façade value. Local mutation only sorts a private copy used to
+/// build the returned vector.
+fn sequential_text_transforms(
+  edits : Array[@core.SpanEdit],
+) -> @vector.Vector[MarkdownTextTransform] {
+  let ordered = edits.copy()
+  ordered.sort_by((a, b) => b.start.compare(a.start))
+  let transforms = ordered.map(edit => MarkdownTextTransform::{
+    change: @text_change.TextChange::{
+      start: edit.start,
+      delete_len: edit.delete_len,
+      inserted: edit.inserted,
+    },
+  })
+  @vector.Vector(transforms[:])
 }
 
 ///|

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -145,6 +145,42 @@ test "headless facade commits exact source and exposes snapshot" {
 }
 
 ///|
+test "source-changing receipt carries history and a UTF-16 transform" {
+  let editor = try! MarkdownEditor(
+    agent_id="receipt-source-change",
+    source="A🤣B\r\n",
+  )
+  let before_version = editor.version()
+
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceSource("AéB\r\n"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected receipt commit to succeed")
+  }
+
+  match receipt.result() {
+    MarkdownCommitResult::Applied(snapshot, None) =>
+      assert_eq(snapshot.source(), "AéB\r\n")
+    _ => fail("expected legacy Applied result")
+  }
+  assert_false(receipt.after_version() == before_version)
+  match receipt.history() {
+    Some(history) => {
+      let expected = try! editor.history_since(version=before_version)
+      assert_true(history == expected)
+    }
+    None => fail("expected incremental history")
+  }
+  let transforms = receipt.transforms().to_array()
+  assert_eq(transforms.length(), 1)
+  assert_eq(transforms[0].start(), 1)
+  assert_eq(transforms[0].delete_len(), 2)
+  assert_eq(transforms[0].inserted(), "é")
+}
+
+///|
 test "headless facade reports unchanged source atomically" {
   let editor = try! MarkdownEditor(agent_id="unchanged", source="before")
   let before = editor.snapshot()
@@ -156,6 +192,30 @@ test "headless facade reports unchanged source atomically" {
     _ => fail("expected Unchanged")
   }
   assert_true(editor.snapshot() == before)
+}
+
+///|
+test "true no-op receipt has unchanged version and no history" {
+  let editor = try! MarkdownEditor(agent_id="receipt-no-op", source="before")
+  let before_version = editor.version()
+
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceSource("before"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected no-op receipt commit to succeed")
+  }
+
+  match receipt.result() {
+    MarkdownCommitResult::Unchanged(snapshot) =>
+      assert_eq(snapshot.source(), "before")
+    _ => fail("expected legacy Unchanged result")
+  }
+  assert_true(receipt.before_version() == before_version)
+  assert_true(receipt.after_version() == before_version)
+  assert_true(receipt.history() is None)
+  assert_true(receipt.transforms().is_empty())
 }
 
 ///|
@@ -492,6 +552,128 @@ test "headless facade rejects CommitEdit for loose list items atomically" {
     _ => fail("expected loose list CommitEdit to fail")
   }
   assert_true(editor.snapshot() == before)
+}
+
+///|
+test "typed block receipt carries the lowered transform and selection" {
+  let editor = try! MarkdownEditor(
+    agent_id="receipt-typed-block",
+    source="# Title\n",
+  )
+  let block = editor.snapshot().blocks().to_array()[0]
+  let before_version = editor.version()
+
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::CommitEdit(
+        node_id=block.node_id(),
+        new_text="Renamed",
+      ),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected typed block receipt")
+  }
+
+  match receipt.result() {
+    MarkdownCommitResult::Applied(snapshot, Some(selection)) => {
+      assert_eq(snapshot.source(), "# Renamed\n")
+      assert_eq(selection.node_id(), snapshot.blocks().to_array()[0].node_id())
+      assert_eq(selection.offset(), 7)
+    }
+    _ => fail("expected typed block commit to apply with a selection")
+  }
+  let typed_history = try! editor.history_since(version=before_version)
+  match receipt.history() {
+    Some(history) => assert_true(history == typed_history)
+    None => fail("expected typed block history increment")
+  }
+  let transforms = receipt.transforms().to_array()
+  assert_eq(transforms.length(), 1)
+  assert_eq(transforms[0].start(), 2)
+  assert_eq(transforms[0].delete_len(), 5)
+  assert_eq(transforms[0].inserted(), "Renamed")
+}
+
+///|
+test "split and merge receipts retain exact sequential lowering transforms" {
+  let editor = try! MarkdownEditor(
+    agent_id="receipt-block-structure",
+    source="Hello\n\nWorld\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0].node_id()
+  let before_split = editor.version()
+
+  let split = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::SplitBlock(node_id=first, offset=2),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected split receipt")
+  }
+  match split.result() {
+    MarkdownCommitResult::Applied(snapshot, Some(selection)) => {
+      assert_eq(snapshot.source(), "He\n\nllo\n\nWorld\n")
+      assert_eq(selection.node_id(), snapshot.blocks().to_array()[1].node_id())
+      assert_eq(selection.offset(), 0)
+    }
+    _ => fail("expected split to apply with a selection")
+  }
+  let split_history = try! editor.history_since(version=before_split)
+  assert_true(split.history().unwrap() == split_history)
+  let split_transforms = split.transforms().to_array()
+  assert_eq(split_transforms.length(), 1)
+  assert_eq(split_transforms[0].start(), 2)
+  assert_eq(split_transforms[0].delete_len(), 4)
+  assert_eq(split_transforms[0].inserted(), "\n\nllo\n")
+
+  let before_merge = editor.version()
+  let second = editor.snapshot().blocks().to_array()[1].node_id()
+  let merge = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::MergeWithPrevious(node_id=second),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected merge receipt")
+  }
+  match merge.result() {
+    MarkdownCommitResult::Applied(snapshot, Some(selection)) => {
+      assert_eq(snapshot.source(), "Hello\n\nWorld\n")
+      assert_eq(selection.node_id(), snapshot.blocks().to_array()[0].node_id())
+      assert_eq(selection.offset(), 2)
+    }
+    _ => fail("expected merge to apply with a selection")
+  }
+  let merge_history = try! editor.history_since(version=before_merge)
+  assert_true(merge.history().unwrap() == merge_history)
+  let merge_transforms = merge.transforms().to_array()
+  assert_eq(merge_transforms.length(), 1)
+  assert_eq(merge_transforms[0].start(), 2)
+  assert_eq(merge_transforms[0].delete_len(), 6)
+  assert_eq(merge_transforms[0].inserted(), "llo\n")
+}
+
+///|
+test "receipt transforms use sequential reverse-document order" {
+  let transforms = sequential_text_transforms([
+    @core.SpanEdit::{ start: 1, delete_len: 1, inserted: "X" },
+    @core.SpanEdit::{ start: 4, delete_len: 0, inserted: "!" },
+  ]).to_array()
+
+  assert_eq(transforms.length(), 2)
+  assert_eq(transforms[0].start(), 4)
+  assert_eq(transforms[0].delete_len(), 0)
+  assert_eq(transforms[0].inserted(), "!")
+  assert_eq(transforms[1].start(), 1)
+  assert_eq(transforms[1].delete_len(), 1)
+  assert_eq(transforms[1].inserted(), "X")
+
+  // Every coordinate is read against the source left by the prior transform.
+  let source = "abcde"
+  let after_first = source[:4].to_owned() + "!" + source[4:].to_owned()
+  let after_second = after_first[:1].to_owned() +
+    "X" +
+    after_first[2:].to_owned()
+  assert_eq(after_second, "aXcd!e")
 }
 
 ///|
@@ -1169,25 +1351,44 @@ test "equal source and version do not imply equal history" {
 }
 
 ///|
-/// A commit reported as Unchanged still advanced the document.
+/// A source-preserving commit still carries the history it advanced.
 ///
-/// The façade classifies a commit by comparing source, so it says Unchanged
-/// here. The version says otherwise, and the version is what persistence must
-/// trigger on: saving on the façade's own verdict would skip this.
-test "text-preserving commit reports Unchanged while the version advances" {
+/// Replacing one character with itself emits a real CRDT operation even though
+/// the detached source is equal. The receipt must follow the version frontier,
+/// not the legacy result's source-based `Unchanged` classification.
+test "text-preserving commit receipt carries advanced history" {
   let editor = try! MarkdownEditor(agent_id="advance", source="hello")
   let before_version = editor.version()
 
-  let result = editor.commit(
-    MarkdownEditRequest::ReplaceText(start=0, delete_len=1, inserted="h"),
-  )
-
-  match result {
-    Ok(MarkdownCommitResult::Unchanged(snapshot)) =>
-      assert_eq(snapshot.source(), "hello")
-    _ => fail("expected Unchanged")
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::ReplaceText(start=0, delete_len=1, inserted="h"),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected receipt commit to succeed")
   }
-  assert_false(editor.version() == before_version)
+
+  match receipt.result() {
+    MarkdownCommitResult::Unchanged(snapshot) =>
+      assert_eq(snapshot.source(), "hello")
+    _ => fail("expected legacy Unchanged result")
+  }
+  assert_true(receipt.origin() is MarkdownCommitOrigin::Local)
+  assert_true(receipt.before_version() == before_version)
+  assert_false(receipt.after_version() == before_version)
+  assert_true(receipt.after_version() == editor.version())
+  match receipt.history() {
+    Some(history) => {
+      let expected = try! editor.history_since(version=before_version)
+      assert_true(history == expected)
+    }
+    None => fail("expected incremental history from the before-version")
+  }
+  let transforms = receipt.transforms().to_array()
+  assert_eq(transforms.length(), 1)
+  assert_eq(transforms[0].start(), 0)
+  assert_eq(transforms[0].delete_len(), 1)
+  assert_eq(transforms[0].inserted(), "h")
 }
 
 ///|

--- a/editor/markdown/pkg.generated.mbti
+++ b/editor/markdown/pkg.generated.mbti
@@ -58,6 +58,20 @@ pub fn MarkdownBlockSnapshot::source_range(Self) -> (Int, Int)
 pub fn MarkdownBlockSnapshot::text(Self) -> String
 pub fn MarkdownBlockSnapshot::text_range(Self) -> (Int, Int)
 
+pub(all) enum MarkdownCommitOrigin {
+  Local
+} derive(Eq, @debug.Debug)
+
+pub struct MarkdownCommitReceipt {
+  // private fields
+}
+pub fn MarkdownCommitReceipt::after_version(Self) -> MarkdownDocumentVersion
+pub fn MarkdownCommitReceipt::before_version(Self) -> MarkdownDocumentVersion
+pub fn MarkdownCommitReceipt::history(Self) -> MarkdownDocumentHistory?
+pub fn MarkdownCommitReceipt::origin(Self) -> MarkdownCommitOrigin
+pub fn MarkdownCommitReceipt::result(Self) -> MarkdownCommitResult
+pub fn MarkdownCommitReceipt::transforms(Self) -> @vector.Vector[MarkdownTextTransform]
+
 pub(all) enum MarkdownCommitResult {
   Applied(MarkdownDocumentSnapshot, MarkdownBlockSelection?)
   Unchanged(MarkdownDocumentSnapshot)
@@ -97,6 +111,7 @@ pub struct MarkdownEditor {
 pub fn MarkdownEditor::MarkdownEditor(agent_id~ : String, source~ : String) -> Self raise MarkdownEditorError
 pub fn MarkdownEditor::admit(Self, MarkdownDocumentHistory) -> MarkdownAdmitReport raise MarkdownArchiveError
 pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError]
+pub fn MarkdownEditor::commit_with_receipt(Self, MarkdownEditRequest) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError
 pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -> MarkdownDocumentHistory raise MarkdownArchiveError
 pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory) -> Self raise MarkdownArchiveError
 pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
@@ -112,6 +127,13 @@ pub struct MarkdownProjectionSnapshot {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownProjectionSnapshot::node_ids(Self) -> @vector.Vector[MarkdownNodeId]
 pub fn MarkdownProjectionSnapshot::root_id(Self) -> MarkdownNodeId?
+
+pub struct MarkdownTextTransform {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn MarkdownTextTransform::delete_len(Self) -> Int
+pub fn MarkdownTextTransform::inserted(Self) -> String
+pub fn MarkdownTextTransform::start(Self) -> Int
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

- Add an additive `MarkdownEditor::commit_with_receipt` surface while preserving the existing `commit` signature and source-oriented result semantics.
- Report causal advancement through before/after `MarkdownDocumentVersion` values and the exact opaque `history_since(before_version)` increment, including source-preserving CRDT commits.
- Expose façade-owned, ordered UTF-16 transforms for downstream presence updates without leaking `SyncEditor`, `SyncMessage`, or `SpanEdit`.

Closes #1130.

## UI and review evidence

N/A — headless Markdown façade only; no UI or visual changes.

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path — N/A
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI — N/A
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

Two independent `moonbit-reviewer` passes were completed. The final review returned PASS with no critical findings or warnings.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `MarkdownEditor::version` / `MarkdownDocumentVersion` | `editor/markdown` | Yes | Before/after causal frontier; no second checkpoint type. |
| `MarkdownEditor::history_since` / `MarkdownDocumentHistory` | `editor/markdown` | Yes | Exact opaque increment from the before-version; no second history/wire abstraction. |
| `MarkdownCommitResult` | `editor/markdown` | Yes | Receipt retains the legacy source-oriented result unchanged. |
| `TextChange` / `compute_text_change` | `loom/text-change` | Yes | Façade-owned transform storage and the `ReplaceSource` path, where no exact caller edit exists. |
| `compute_markdown_edit` | `lang/markdown/edits` | Yes | Typed Block, split, and merge receipts retain the exact lowered spans instead of re-diffing final source. |
| `SyncEditor::apply_span_edits` | `editor` | Yes | Applies the same lowered spans whose ordered façade copies enter the receipt. |
| `@vector.Vector`, `Array::copy` / `sort_by` / `map` | MoonBit core | Yes | Immutable public sequence plus deterministic local construction in application order. |
| `Option`, `Result` | MoonBit core | Yes | Optional history and existing commit failure channel. |
| `String` / `StringView` | MoonBit core | Yes | UTF-16 `String::length` coordinates and existing source slices; no new string loop. |
| `@md_companion.apply_markdown_edit` | `lang/markdown/companion` | No | It intentionally returns `Unit` and discards the exact lowered `SpanEdit` values needed by the receipt. |
| `@editor.compute_edit` / `@loom_core.Edit` | `editor`, `loom` | No | Parser delta shape does not preserve the public presence transform payload; exact request/lowering information is preferred. |
| `Map`, `Set`, `Bytes`/`BytesView`, `Buffer`/`StringBuilder`, `cmp`/`math`, `Iter` | MoonBit core | No | No lookup, byte serialization, string building, numeric algorithm, or iterator pipeline was introduced. |

New helpers added:

- `commit_recording_transforms`: shared imperative shell for legacy commits and receipt commits, preserving one mutation path.
- `commit_structural_recording_transforms`: lowers one typed request once, applies those exact spans, and returns façade transforms.
- `sequential_text_transforms`: translates a private `SpanEdit` array into an immutable façade vector in the same reverse-document application order. Its only mutation sorts a private copy used to build the returned value.
- `MarkdownCommitReceipt`, `MarkdownCommitOrigin`, and `MarkdownTextTransform`: façade-owned values that keep low-level editor and CRDT types out of the generated interface.

## Validation scope

Boundary matrix / first failing regression:

| Boundary | Coverage |
|---|---|
| Source equal, history advances | `ReplaceText(start=0, delete_len=1, inserted="h")` returns legacy `Unchanged`, differing versions, incremental history, and the exact transform. This was the first RED test. |
| Source changes | `ReplaceSource` over non-BMP text verifies history and UTF-16 `(start=1, delete_len=2)` coordinates. |
| True no-op | Equal `ReplaceSource` keeps the version equal and returns no history or transforms. |
| Typed Block | `CommitEdit` verifies exact lowering, detached snapshot, and logical selection. |
| Structural split/merge | Both verify exact lowering spans rather than equivalent final-source diffs, plus selection and history increments. |
| Ordered sequence | A two-transform test pins reverse-document order and sequential coordinates. |
| Existing regressions | Existing Raw, CR/LF/CRLF, non-BMP, range, marker, identity, projection, split/merge, and selection tests remain green. |

Target packages:

- `editor/markdown`

Additional conditional gates:

- No proof, documentation, UI, or TypeScript package changed.
- The standard validator completed workspace checks/tests/builds and the JavaScript artifact build.

## PR-ready evidence

Validated HEAD: `f79e6e8901c0d8e07eb007b674f1abf99205da1e`

Validated base: `origin/main@0d999d7665cd4b717aaf157dc8debc1be365494b`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target editor/markdown
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] Any changed submodule commit is pushed and reachable from its remote — no submodule pointers changed.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commit receipts containing version information, commit origin, optional history, and ordered text transformations.
  * Added UTF-16 text-change reporting for replacements and structural markdown edits.
  * Receipts now distinguish document changes from no-op commits and preserve selection information where applicable.

* **Bug Fixes**
  * Improved consistency of change tracking across typed edits, splits, merges, and source-preserving operations.
  * Existing commit behavior and result classifications remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
