### PR TITLE
fix(loomark): ignore superseded block focus effects

### DIFF
--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -341,7 +341,7 @@ test("Block mode preserves untouched CRLF separators during a partial multiline 
   }
 })
 
-test("Block typing preserves a mid-text UTF-16 caret across CRLF normalization", async ({ browser }) => {
+test("Rapid Block typing preserves a mid-text UTF-16 caret across CRLF normalization", async ({ browser }) => {
   const host = await mountHost(browser, "A😀B\r\nC")
   try {
     await selectBlock(host.page)
@@ -351,13 +351,39 @@ test("Block typing preserves a mid-text UTF-16 caret across CRLF normalization",
       const textarea = element as HTMLTextAreaElement
       textarea.setSelectionRange(3, 3)
     })
-    await host.page.keyboard.type("XY")
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "A😀XB\nC"
+      textarea.setSelectionRange(4, 4)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "X",
+        inputType: "insertText",
+      }))
+      textarea.value = "A😀XYB\nC"
+      textarea.setSelectionRange(5, 5)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "Y",
+        inputType: "insertText",
+      }))
+    })
+    // The first frame drains the LIFO AfterRender selection callbacks. A stale
+    // callback used to enqueue a rejection render, so the second frame exposes
+    // the focus loss instead of letting pre-render focus satisfy the assertion.
+    await host.page.evaluate(() => new Promise<void>(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    }))
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("A😀XYB\r\nC")
     await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-block-input")
     await expect.poll(() => host.page.evaluate(() => {
       const textarea = document.activeElement as HTMLTextAreaElement | null
       return textarea === null ? "missing" : `${textarea.selectionStart}:${textarea.selectionEnd}`
     })).toBe("5:5")
+    expect(await snapshot(host.page)).toMatchObject({
+      error_code: null,
+      error_count: 0,
+    })
   } finally {
     await host.context.close()
   }

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -576,6 +576,7 @@ fn after_render(
 fn block_selection_after_render(
   selection : BlockSelection,
   source_revision : Int,
+  report_superseded~ : Bool,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   after_render(
@@ -587,9 +588,15 @@ fn block_selection_after_render(
               emit(BlockSelectionRejected("block selection mode is stale")),
             )
           } else if model.source_revision != source_revision {
-            scheduler.add(
-              emit(BlockSelectionRejected("block selection is stale")),
-            )
+            // Rapid input can queue several post-render selections in one
+            // frame. Rabbita runs AfterRender effects newest-first, so an older
+            // superseded selection must not emit a message that schedules a
+            // second render after the newest selection restored the caret.
+            if report_superseded {
+              scheduler.add(
+                emit(BlockSelectionRejected("block selection is stale")),
+              )
+            }
           } else {
             match block_selection_target(model.document, selection) {
               Some(index) => {
@@ -884,7 +891,12 @@ fn update_model(
         Some(selection) =>
           (
             next,
-            block_selection_after_render(selection, next.source_revision, emit),
+            block_selection_after_render(
+              selection,
+              next.source_revision,
+              report_superseded=false,
+              emit,
+            ),
           )
         None => (next, @rabbita_runtime.none)
       }
@@ -912,7 +924,12 @@ fn update_model(
         Some(selection) =>
           (
             next,
-            block_selection_after_render(selection, next.source_revision, emit),
+            block_selection_after_render(
+              selection,
+              next.source_revision,
+              report_superseded=false,
+              emit,
+            ),
           )
         None => (next, @rabbita_runtime.none)
       }
@@ -940,7 +957,12 @@ fn update_model(
         Some(selection) =>
           (
             next,
-            block_selection_after_render(selection, next.source_revision, emit),
+            block_selection_after_render(
+              selection,
+              next.source_revision,
+              report_superseded=false,
+              emit,
+            ),
           )
         None => (next, @rabbita_runtime.none)
       }
@@ -975,7 +997,15 @@ fn update_model(
         } else {
           next.source_revision
         }
-        (next, block_selection_after_render(selection, expected_revision, emit))
+        (
+          next,
+          block_selection_after_render(
+            selection,
+            expected_revision,
+            report_superseded=true,
+            emit,
+          ),
+        )
       }
     }
     EditorFailure => {


### PR DESCRIPTION
## Summary

- Fix rapid Block typing losing focus after CRLF-normalized commits when multiple selection-restoration effects queue in one frame.
- Silently discard only superseded normal Block input/split/merge selection callbacks, while preserving explicit stale/deleted probe and mode/target failure reporting.
- Make the browser regression deterministic by dispatching two input events before a frame and observing both the AfterRender drain and any follow-up render.

This is split from #1142 because the race reproduces unchanged on `origin/main` and is not caused by the Markdown commit-receipt change.

## UI and review evidence

No visual design change. This restores existing focus/caret behavior.

- [x] Visible-label removal preserves accessible names, visible focus, and the keyboard path — N/A; no labels removed
- [x] Interactive bounds, pointer feedback, and viewport reflow were checked in the rendered UI — N/A; no layout change
- [x] Any claimed Canopy rule cites its repository source; external guidance, recommendations, and preferences are labeled as such

Rabbita sources used to verify the effect model:

- `rabbita/doc/004_using_command/readme.mbt.md` — managed command lifecycle
- `rabbita/rabbita/cmd/commands.mbt` — `AfterRender` contract
- `rabbita/rabbita/internal/runtime/sandbox.mbt` — AfterRender callbacks are stored in an array and drained with `pop()`, so the newest queued callback runs first

Two independent `moonbit-reviewer` passes were completed. The final review returned PASS with no findings.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@cmd.AfterRender` / `@cmd.custom_cmd` | `rabbita/rabbita/cmd` | Yes | Existing render-relative DOM effect boundary remains unchanged. |
| `detached_model` / `source_revision` | `loomark/internal/rabbita` | Yes | Revalidates whether a queued selection was superseded; no second generation counter. |
| `BlockSelectionRejected` | `loomark/internal/rabbita` | Yes | Explicit stale/deleted probes and real mode/target/model failures keep the existing reporting path. |
| `@dom_boundary.focus_id` / `write_text_selection_id` | `lib/dom-boundary` | Yes | Existing typed focus and UTF-16 selection writes remain the browser shell. |
| `Bool` | MoonBit core | Yes | A labeled private policy argument distinguishes superseded interactive effects from explicit probes without adding a public type. |
| `Option`, `Result`, `Map`, `Set`, `String`/`StringView`, `Bytes`/`BytesView`, `Buffer`/`StringBuilder`, `Array`, `Iter` | MoonBit core | No new use | The fix introduces no new collection, transformation, parsing, or serialization logic. |

New helpers added:

- None. `block_selection_after_render` gains one labeled private policy argument.

Remaining imperative code is the existing DOM-effect shell. The new branch only decides whether an obsolete callback should enqueue another state transition.

## Validation scope

Boundary matrix / first failing regression:

| Boundary | Coverage |
|---|---|
| Two Block inputs before one frame | Deterministic E2E dispatches `X` and `Y` input events before rendering. Before the fix: 5/5 failed. After the fix: 20/20 passed. |
| Deferred render observation | Two `requestAnimationFrame` turns expose both the initial LIFO AfterRender drain and the extra render formerly scheduled by stale rejection. |
| Canonical source | `A😀XYB\r\nC` remains exact after LF-normalized textarea input. |
| Focus and selection | The Block textarea remains active at UTF-16 caret `5:5`. |
| Error reporting | Superseded normal input leaves `error_code=null` and `error_count=0`; explicit stale/deleted probes remain covered by the existing E2E. |
| Existing browser behavior | Standard Loomark dev-host suite passed 34/34. |

Target packages:

- `loomark/internal/rabbita`

Additional conditional gates:

- `npm run typecheck:dev-host`
- `./scripts/test-loomark-dev-host-e2e.sh`
- Targeted Playwright regression repeated 20 times with two workers
- No generated `.mbti` change

## PR-ready evidence

Validated HEAD: `6906e1910043a8fb856df59e8cde4b82338787cf`

Validated base: `origin/main@1e333bad370b3deccd57c72a26121767ddb5dad0`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh --target loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened, updated, or merged.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes — no `.mbti` changed.
- [x] Any changed submodule commit is pushed and reachable from its remote — no submodule pointers changed.
- [x] Validation was rerun after every commit, amend, rebase, cherry-pick, submodule-pointer, manifest, or generated-interface change.
- [x] Independent review findings were resolved before the final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection handling after rapid edits and rendered updates.
  * Prevented stale selections from being incorrectly retained during normal block edits.
  * Added clearer rejection handling for deleted or superseded selections.

* **Tests**
  * Expanded coverage for rapid text insertion, line-ending normalization, caret preservation, focus retention, and error-free updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->