### PR TITLE
Build the Loomark block editor prototype

### DIFF
--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -745,7 +745,11 @@ fn MarkdownEditor::commit_structural_recording_transforms(
         // A no-op never authorizes a new caret move for the caller.
         MarkdownCommitResult::Unchanged(snapshot)
       } else {
-        let selection = selection_for_cursor(snapshot, self.editor.get_cursor())
+        let selection = selection_for_cursor(
+          snapshot,
+          self.editor.get_cursor(),
+          allow_nearest=op is @md_edits.Delete(_),
+        )
         MarkdownCommitResult::Applied(snapshot, selection)
       }
       Ok((result, sequential_text_transforms(edits)))
@@ -864,14 +868,36 @@ fn reconcile_text_control_edit(
 fn selection_for_cursor(
   snapshot : MarkdownDocumentSnapshot,
   cursor : Int,
+  allow_nearest~ : Bool,
 ) -> MarkdownBlockSelection? {
-  for block in snapshot.blocks().to_array() {
-    let (start, end) = block.text_range()
-    if cursor >= start && cursor <= end {
-      return Some({ node_id: block.node_id(), offset: cursor - start })
-    }
-  }
-  None
+  let closest : (Int, MarkdownBlockSelection)? = snapshot
+    .blocks()
+    .fold(init=None, (closest, block) => {
+      let (start, end) = block.text_range()
+      let (distance, offset) = if cursor < start {
+        (start - cursor, 0)
+      } else if cursor > end {
+        (cursor - end, end - start)
+      } else {
+        (0, cursor - start)
+      }
+      let candidate = MarkdownBlockSelection::{
+        node_id: block.node_id(),
+        offset,
+      }
+      if distance != 0 && !allow_nearest {
+        closest
+      } else {
+        match closest {
+          Some((closest_distance, _)) if closest_distance <= distance => closest
+          _ => Some((distance, candidate))
+        }
+      }
+    })
+  closest.map(pair => {
+    let (_, selection) = pair
+    selection
+  })
 }
 
 ///|

--- a/editor/markdown/editor.mbt
+++ b/editor/markdown/editor.mbt
@@ -721,6 +721,15 @@ fn MarkdownEditor::commit_structural_recording_transforms(
   guard self.editor.get_proj_node() is Some(proj) else {
     return Err(MarkdownEditorError::ProjectionUnavailable)
   }
+  let deleted_block_index = match op {
+    @md_edits.Delete(node_id~) =>
+      self
+      .snapshot()
+      .blocks()
+      .to_array()
+      .search_by(block => block.node_id().value == node_id)
+    _ => None
+  }
   let computed = Ok(
     @md_edits.compute_markdown_edit(
       op,
@@ -745,11 +754,25 @@ fn MarkdownEditor::commit_structural_recording_transforms(
         // A no-op never authorizes a new caret move for the caller.
         MarkdownCommitResult::Unchanged(snapshot)
       } else {
-        let selection = selection_for_cursor(
-          snapshot,
-          self.editor.get_cursor(),
-          allow_nearest=op is @md_edits.Delete(_),
-        )
+        let selection = match deleted_block_index {
+          Some(index) => {
+            let blocks = snapshot.blocks().to_array()
+            let survivor = match blocks.get(index) {
+              Some(block) => Some(block)
+              None => blocks.get(index - 1)
+            }
+            survivor.map(block => MarkdownBlockSelection::{
+              node_id: block.node_id(),
+              offset: block.text().length(),
+            })
+          }
+          None =>
+            selection_for_cursor(
+              snapshot,
+              self.editor.get_cursor(),
+              allow_nearest=false,
+            )
+        }
         MarkdownCommitResult::Applied(snapshot, selection)
       }
       Ok((result, sequential_text_transforms(edits)))

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1161,6 +1161,45 @@ test "typed delete selects the next surviving block" {
 }
 
 ///|
+test "typed delete selects the adjacent survivor instead of a stale cursor" {
+  let editor = try! MarkdownEditor(
+    agent_id="delete-adjacent-survivor-selection",
+    source="First\n\nSecond\n\nThird\n",
+  )
+  let first = editor.snapshot().blocks().get(0).unwrap()
+  ignore(
+    editor.commit(
+      MarkdownEditRequest::CommitEdit(
+        node_id=first.node_id(),
+        new_text="Changed",
+      ),
+    ),
+  )
+  let third = editor.snapshot().blocks().get(2).unwrap()
+
+  let receipt = match
+    (try! editor.commit_with_receipt(
+      MarkdownEditRequest::Delete(node_id=third.node_id()),
+    )) {
+    Ok(receipt) => receipt
+    Err(_) => fail("expected the adjacent survivor receipt")
+  }
+  match receipt.result() {
+    MarkdownCommitResult::Applied(snapshot, Some(selection)) => {
+      let survivor = snapshot.blocks().get(1).unwrap()
+      assert_eq(selection.node_id(), survivor.node_id())
+      assert_eq(selection.offset(), survivor.text().length())
+    }
+    _ => fail("expected the adjacent survivor selection")
+  }
+  let transforms = receipt.transforms().to_array()
+  assert_eq(transforms.length(), 1)
+  assert_eq(transforms[0].start(), 17)
+  assert_eq(transforms[0].delete_len(), 6)
+  assert_eq(transforms[0].inserted(), "")
+}
+
+///|
 test "empty replica identity is a categorized construction failure" {
   let result : Result[MarkdownEditor, MarkdownEditorError] = Ok(
     MarkdownEditor(agent_id="", source=""),

--- a/editor/markdown/markdown_editor_wbtest.mbt
+++ b/editor/markdown/markdown_editor_wbtest.mbt
@@ -1143,6 +1143,24 @@ test "supported typed delete lowers through the Markdown edit companion" {
 }
 
 ///|
+test "typed delete selects the next surviving block" {
+  let editor = try! MarkdownEditor(
+    agent_id="delete-survivor-selection",
+    source="First\n\nSecond\n",
+  )
+  let first = editor.snapshot().blocks().get(0).unwrap()
+
+  match editor.commit(MarkdownEditRequest::Delete(node_id=first.node_id())) {
+    Ok(MarkdownCommitResult::Applied(snapshot, Some(selection))) => {
+      let survivor = snapshot.blocks().get(0).unwrap()
+      assert_eq(selection.node_id(), survivor.node_id())
+      assert_eq(selection.offset(), survivor.text().length())
+    }
+    _ => fail("expected a typed selection for the surviving block")
+  }
+}
+
+///|
 test "empty replica identity is a categorized construction failure" {
   let result : Result[MarkdownEditor, MarkdownEditorError] = Ok(
     MarkdownEditor(agent_id="", source=""),

--- a/lang/markdown/edits/compute_markdown_edit.mbt
+++ b/lang/markdown/edits/compute_markdown_edit.mbt
@@ -135,7 +135,7 @@ fn normalize_atx_heading_content(content : String) -> String {
 }
 
 ///|
-fn heading_replacement_terminator(
+fn block_replacement_terminator(
   source : String,
   range_start : Int,
   range_end : Int,
@@ -200,7 +200,7 @@ fn compute_change_heading_level(
   }
   let new_block = new_prefix +
     rendered_content +
-    heading_replacement_terminator(source, range.start, range.end)
+    block_replacement_terminator(source, range.start, range.end)
   Some(
     (
       [
@@ -266,12 +266,13 @@ fn compute_toggle_list_item(
     Some(node) => is_markdown_list_item(node.kind)
     None => false
   }
+  let terminator = block_replacement_terminator(source, range.start, range.end)
   let (new_text, prefix_len) = if is_list_item {
     // List item -> paragraph: just content
-    (content + "\n", 0)
+    (content + terminator, 0)
   } else {
     // Paragraph -> list item: add "- " prefix
-    ("- " + content + "\n", 2)
+    ("- " + content + terminator, 2)
   }
   Some(
     (

--- a/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
+++ b/lang/markdown/edits/compute_markdown_edit_wbtest.mbt
@@ -314,6 +314,26 @@ test "toggle_list_item: paragraph to list item" {
 }
 
 ///|
+test "toggle_list_item: round trip preserves the following block separator" {
+  let source = "Item\n\nTail\n"
+  let (paragraph_proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, source,
+  )
+  let list_source = apply_edit(
+    source,
+    ToggleListItem(node_id=paragraph_proj.children[0].id()),
+  )
+  let (list_proj, _) = @md_proj.parse_to_proj_node(
+    markdown_edit_test_source, list_source,
+  )
+  let restored = apply_edit(
+    list_source,
+    ToggleListItem(node_id=list_proj.children[0].children[0].id()),
+  )
+  inspect(restored, content="Item\n\nTail\n")
+}
+
+///|
 test "delete: remove a block" {
   let source = "# Title\n\nParagraph\n"
   let (proj, _) = @md_proj.parse_to_proj_node(

--- a/loomark/examples/vanilla/index.html
+++ b/loomark/examples/vanilla/index.html
@@ -2,7 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Loomark private host</title>
+    <style>
+      html,
+      body {
+        min-height: 100%;
+        margin: 0;
+      }
+    </style>
   </head>
   <body>
     <main id="app"></main>

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -13,6 +13,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | semantic Preview | heading, paragraph, fenced code, list fallback | RUI-aligned read-only semantic DOM without invented list containers |
  * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
  * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
+ * | Block formatting | focused paragraph/heading/list item | typed heading/list/delete requests update source and restore a valid target |
  * | interactive chrome | normal, focus, error | only application controls are visible; Preview owns focus; errors appear on demand |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
@@ -346,6 +347,125 @@ test("application status stays quiet until an error needs attention", async ({ b
     await expect(error).toHaveText("error: fatal test")
     await expect(error).toHaveAttribute("role", "alert")
     await expect(error).toHaveAttribute("data-slot", "alert")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block toolbar toggles a focused paragraph and heading through typed edits", async ({ browser }) => {
+  const host = await mountHost(browser, "Title\n\nBody\n")
+  try {
+    await selectBlock(host.page)
+    const toolbar = host.page.getByRole("toolbar", { name: "Block formatting" })
+    const heading2 = toolbar.getByRole("button", { name: "Heading 2, Ctrl+2" })
+    await expect(heading2).toBeDisabled()
+
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await expect(heading2).toBeEnabled()
+    await expect(heading2).toHaveAttribute("aria-pressed", "false")
+    await heading2.click()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("## Title\n\nBody\n")
+    await expect(heading2).toHaveAttribute("aria-pressed", "true")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-block-input",
+    )
+
+    await heading2.click()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n\nBody\n")
+    await expect(heading2).toHaveAttribute("aria-pressed", "false")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block toolbar toggles a focused paragraph and list item through typed edits", async ({ browser }) => {
+  const host = await mountHost(browser, "Item\n\nTail\n")
+  try {
+    await selectBlock(host.page)
+    const toolbar = host.page.getByRole("toolbar", { name: "Block formatting" })
+    const toggleList = toolbar.getByRole("button", { name: "Toggle list, Ctrl+Shift+L" })
+    await expect(toggleList).toBeDisabled()
+
+    await host.page.locator("#loomark-block-input").focus()
+    await expect(toggleList).toBeEnabled()
+    await expect(toggleList).toHaveAttribute("aria-pressed", "false")
+    await toggleList.click()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("- Item\n\nTail\n")
+    await expect(toggleList).toHaveAttribute("aria-pressed", "true")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-block-input",
+    )
+
+    await toggleList.click()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Item\n\nTail\n")
+    await expect(toggleList).toHaveAttribute("aria-pressed", "false")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block toolbar deletes the active block and focuses the surviving typed target", async ({ browser }) => {
+  const host = await mountHost(browser, "First\n\nSecond\n")
+  try {
+    await selectBlock(host.page)
+    const toolbar = host.page.getByRole("toolbar", { name: "Block formatting" })
+    const deleteBlock = toolbar.getByRole("button", { name: "Delete selected block" })
+    await expect(deleteBlock).toBeDisabled()
+
+    await host.page.locator("#loomark-block-input").focus()
+    await expect(deleteBlock).toBeEnabled()
+    await deleteBlock.click()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("\nSecond\n")
+    await expect(host.page.locator("#loomark-block-input")).toHaveValue("Second")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-block-input",
+    )
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block toolbar enables only edits accepted for the active typed block", async ({ browser }) => {
+  const host = await mountHost(browser, "```moonbit\nvalue\n```\n")
+  try {
+    await selectBlock(host.page)
+    const toolbar = host.page.getByRole("toolbar", { name: "Block formatting" })
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+
+    await expect(toolbar.getByRole("button", { name: "Heading 2, Ctrl+2" })).toBeDisabled()
+    await expect(toolbar.getByRole("button", { name: "Toggle list, Ctrl+Shift+L" })).toBeDisabled()
+    await expect(toolbar.getByRole("button", { name: "Delete selected block" })).toBeEnabled()
+    await input.press("Control+2")
+    await input.press("Control+Shift+L")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("```moonbit\nvalue\n```\n")
+    await expect.poll(async () => (await snapshot(host.page)).error_count).toBe(0)
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block formatting shortcuts dispatch the same typed edits", async ({ browser }) => {
+  const host = await mountHost(browser, "Title\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+
+    await input.press("Control+2")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("## Title\n")
+    await input.press("Control+2")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
+    await input.press("Control+Shift+L")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("- Title\n")
+
+    await input.dispatchEvent("keydown", {
+      key: "2",
+      ctrlKey: true,
+      isComposing: true,
+    })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("- Title\n")
   } finally {
     await host.context.close()
   }

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -276,7 +276,7 @@ test("example presets replace canonical source without changing the selected mod
         source: "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nThis editor has three modes: raw, block, and preview.\n",
       },
       {
-        name: "Apply Blog example",
+        name: "Guide: Apply Blog example",
         source: "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nThe editor supports real-time collaboration via CRDT.\n\nEvery keystroke is incrementally parsed and projected into a structured view.",
       },
       {
@@ -350,6 +350,7 @@ test("interactive chrome hides driver controls and focuses the Preview surface",
     const preview = host.page.locator("#loomark-preview")
     await expect(preview).toHaveAttribute("tabindex", "0")
     await expect(preview).toHaveAttribute("aria-label", "Markdown preview")
+    await expect(host.page.getByRole("region", { name: "Markdown preview" })).toBeVisible()
     await host.page.locator("#loomark-mode-preview").focus()
     await focusPreview(host.page)
     await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
@@ -379,7 +380,7 @@ test("Block toolbar toggles a focused paragraph and heading through typed edits"
   try {
     await selectBlock(host.page)
     const toolbar = host.page.getByRole("toolbar", { name: "Block formatting" })
-    const heading2 = toolbar.getByRole("button", { name: "Heading 2, Ctrl+2" })
+    const heading2 = toolbar.getByRole("button", { name: "H2: Heading 2, Ctrl+2" })
     await expect(heading2).toBeDisabled()
 
     const input = host.page.locator("#loomark-block-input")
@@ -456,7 +457,7 @@ test("Block toolbar enables only edits accepted for the active typed block", asy
     const input = host.page.locator("#loomark-block-input")
     await input.focus()
 
-    await expect(toolbar.getByRole("button", { name: "Heading 2, Ctrl+2" })).toBeDisabled()
+    await expect(toolbar.getByRole("button", { name: "H2: Heading 2, Ctrl+2" })).toBeDisabled()
     await expect(toolbar.getByRole("button", { name: "Toggle list, Ctrl+Shift+L" })).toBeDisabled()
     await expect(toolbar.getByRole("button", { name: "Delete selected block" })).toBeEnabled()
     await input.dispatchEvent("keydown", { key: "2", ctrlKey: true })
@@ -514,6 +515,49 @@ test("Block formatting shortcuts dispatch the same typed edits", async ({ browse
       isComposing: true,
     })
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("- Title\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("failed Block formatting shortcut restores its originating selection", async ({ browser }) => {
+  const host = await mountHost(browser, "Title\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(2, 2)
+    })
+    await forceEditorFailure(host.page)
+    await input.dispatchEvent("keydown", { key: "2", ctrlKey: true })
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("2:2")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("failed Block toolbar edit returns focus to its invoked control", async ({ browser }) => {
+  const host = await mountHost(browser, "Title\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    const heading2 = host.page.getByRole("button", { name: "H2: Heading 2, Ctrl+2" })
+    await forceEditorFailure(host.page)
+    await heading2.click()
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
+    await expect(heading2).toBeFocused()
   } finally {
     await host.context.close()
   }

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -10,6 +10,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | projection | full/incremental/fresh | payload, SourceMap ranges, and identity stay attached |
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
  * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
+ * | semantic Preview | heading, paragraph, fenced code, list fallback | RUI-aligned read-only semantic DOM without invented list containers |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
  */
@@ -68,6 +69,10 @@ async function rawInput(page: Page, source: string): Promise<void> {
 async function selectPreview(page: Page): Promise<void> {
   await page.evaluate(moduleUrl =>
     import(moduleUrl).then(module => module.dev_host_select_preview()), moduleUrl)
+}
+
+async function expectPreviewSource(page: Page, source: string): Promise<void> {
+  await expect(page.locator("#loomark-preview")).toHaveAttribute("data-loomark-source", source)
 }
 
 async function selectBlock(page: Page): Promise<void> {
@@ -189,7 +194,38 @@ test("Raw input preserves canonical source and Preview follows a committed edit"
     await expect(host.page.locator("#loomark-input")).toHaveValue("after\n")
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("after\r\n")
+    await expectPreviewSource(host.page, "after\r\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Preview renders supported blocks as RUI-aligned semantic HTML", async ({ browser }) => {
+  const source = "# Semantic title\n\nReadable body.\n\n~~~moonbit\nlet answer = 42\n~~~\n\n- one\n- two\n"
+  const host = await mountHost(browser, source)
+  try {
+    await expect(host.page.locator("#loomark-root")).toHaveAttribute("data-rui-theme", "")
+    await expect(host.page.locator('#loomark-toolbar button[data-slot="button"]')).toHaveCount(3)
+    await expect(host.page.locator("#loomark-mode-raw")).toHaveAttribute("aria-pressed", "true")
+    await selectPreview(host.page)
+    await expect(host.page.locator("#loomark-mode-raw")).toHaveAttribute("aria-pressed", "false")
+    await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute("aria-pressed", "true")
+    const preview = host.page.locator("#loomark-preview")
+    await expect(preview).toHaveAttribute("data-loomark-source", source)
+    await expect(preview.locator("[data-loomark-preview-notice]")).toContainText(
+      "supported top-level blocks",
+    )
+    await expect(preview.locator('h1[data-slot="typography-h1"]')).toHaveText("Semantic title")
+    await expect(preview.locator('p[data-slot="typography-p"]')).toHaveText("Readable body.")
+    await expect(preview.locator('pre code[data-loomark-code-info="moonbit"]')).toHaveText(
+      "let answer = 42",
+    )
+    await expect(preview.locator("ul, ol")).toHaveCount(0)
+    const rawListItems = preview.locator('[data-loomark-preview-raw-list-item="unordered"]')
+    await expect(rawListItems).toHaveCount(2)
+    await expect(rawListItems.nth(0)).toContainText("- one")
+    await expect(rawListItems.nth(1)).toContainText("- two")
+    await expect(preview.locator("textarea, input, button")).toHaveCount(0)
   } finally {
     await host.context.close()
   }
@@ -207,7 +243,7 @@ test("Block mode edits a heading payload without leaking its marker", async ({ b
     await host.page.locator("#loomark-block-input").fill("Retitled")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Retitled\n")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("# Retitled\n")
+    await expectPreviewSource(host.page, "# Retitled\n")
   } finally {
     await host.context.close()
   }
@@ -225,7 +261,7 @@ test("Block mode edits a paragraph payload while preserving CRLF source", async 
     await host.page.locator("#loomark-block-input").fill("Changed")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Changed\r\n")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("Changed\r\n")
+    await expectPreviewSource(host.page, "Changed\r\n")
   } finally {
     await host.context.close()
   }
@@ -258,7 +294,7 @@ test("Block mode edits ordered/unordered lists and fenced code in one mixed docu
     await selectRaw(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveValue(committed.replaceAll("\r\n", "\n"))
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText(committed)
+    await expectPreviewSource(host.page, committed)
     await selectBlock(host.page)
     await expect(host.page.locator("#loomark-block")).toHaveAttribute("data-loomark-source", committed)
   } finally {
@@ -293,7 +329,7 @@ test("Block mode edits a Setext heading payload without replacing its underline"
     await host.page.locator("#loomark-block-input").fill("Renamed")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Renamed\n---\n")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("Renamed\n---\n")
+    await expectPreviewSource(host.page, "Renamed\n---\n")
   } finally {
     await host.context.close()
   }
@@ -311,7 +347,7 @@ test("Block mode preserves CR Setext equals markers and multiline payloads", asy
     await host.page.locator("#loomark-block-input").fill("Renamed")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Renamed\r=\r")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("Renamed\r=\r")
+    await expectPreviewSource(host.page, "Renamed\r=\r")
   } finally {
     await host.context.close()
   }
@@ -397,7 +433,7 @@ test("Block mode preserves an ATX marker at EOF", async ({ browser }) => {
     await host.page.locator("#loomark-block-input").fill("Retitled")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("# Retitled")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("# Retitled")
+    await expectPreviewSource(host.page, "# Retitled")
   } finally {
     await host.context.close()
   }
@@ -588,7 +624,7 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
     await expect(host.page.locator("#loomark-mode")).toHaveText("mode: preview")
-    await expect(host.page.locator("#loomark-preview")).toHaveText("edited\nsource")
+    await expectPreviewSource(host.page, "edited\nsource")
     await rawInput(host.page, "must-not-commit\n")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("mode-inapplicable")
     expect(await snapshot(host.page)).toMatchObject({
@@ -647,7 +683,7 @@ test("Raw textarea editor failure can be retried and reflected in Preview", asyn
     await host.page.locator("#loomark-input").fill("retried edit\n")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("retried edit\n")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("retried edit\n")
+    await expectPreviewSource(host.page, "retried edit\n")
   } finally {
     await host.context.close()
   }
@@ -692,7 +728,7 @@ test("valid snapshot restore commits source and mode atomically while unknown ve
     await expect.poll(async () => (await snapshot(host.page)).mode).toBe("preview")
     await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("new\r\n")
+    await expectPreviewSource(host.page, "new\r\n")
     const committed = await snapshot(host.page)
 
     await restoreSnapshot(host.page, 99, "must-not-commit\n", "raw")
@@ -788,7 +824,8 @@ test("mounts one fresh connected container and exposes a detached snapshot", asy
     expect(host.mountResult).toBe('{"ok":true}')
     expect(await snapshot(host.page)).toMatchObject({ source: "# Loomark\n", mode: "raw" })
     await selectPreview(host.page)
-    await expect(host.page.locator("#app")).toContainText("# Loomark")
+    await expectPreviewSource(host.page, "# Loomark\n")
+    await expect(host.page.locator('#loomark-preview h1[data-slot="typography-h1"]')).toHaveText("Loomark")
     await expect.poll(() => host.page.evaluate(() => document.getElementById("app")?.isConnected)).toBe(true)
   } finally {
     await host.context.close()
@@ -820,7 +857,7 @@ test("rejects a second mount without clearing or reusing the first host", async 
     expect(secondMount).toBe('{"ok":false,"error":"host-already-mounted"}')
     await expect(host.page.locator("#loomark-root")).toHaveCount(1)
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("first\n")
+    await expectPreviewSource(host.page, "first\n")
   } finally {
     await host.context.close()
   }
@@ -832,7 +869,7 @@ test("keeps source and mode state separate from after-render focus and DOM effec
     await requestSource(host.page, "# Updated\n")
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-mode")).toHaveText("mode: preview")
-    await expect(host.page.locator("#loomark-preview")).toHaveText("# Updated\n")
+    await expectPreviewSource(host.page, "# Updated\n")
 
     await focusPreview(host.page)
     await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-focus-target")
@@ -871,7 +908,7 @@ test("installs one custom listener, refreshes its tagger, and cleans up repeated
 
     await requestSource(host.page, "events-updated\n")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-preview")).toHaveText("events-updated\n")
+    await expectPreviewSource(host.page, "events-updated\n")
     await dispatchDriverEvent(host.page, "new")
     await expect.poll(async () => (await snapshot(host.page)).event_count).toBe(2)
     expect(await snapshot(host.page)).toMatchObject({

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -14,6 +14,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
  * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
  * | Block formatting | focused paragraph/heading/list item | typed heading/list/delete requests update source and restore a valid target |
+ * | Block keyboard editing | collapsed caret at start/middle/end | Enter splits, boundary arrows navigate, empty-start Backspace merges, and focus/caret follow the typed target |
  * | interactive chrome | normal, focus, error | only application controls are visible; Preview owns focus; errors appear on demand |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
@@ -316,6 +317,27 @@ test("production chrome keeps its controls inside a narrow viewport", async ({ b
   }
 })
 
+test("Block surface presents typed blocks as compact RUI editing rows", async ({ browser }) => {
+  const source = "# Title\n\nBody\n\n3) Third\n\n```moonbit\nlet x = 1\n```\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectBlock(host.page)
+    const block = host.page.locator("#loomark-block")
+    await expect(block.locator('[data-slot="block-editor-input"]')).toHaveCount(4)
+    await expect(block.getByRole("textbox", { name: "Heading 1 block 1" })).toHaveValue("Title")
+    await expect(block.getByRole("textbox", { name: "Paragraph block 2" })).toHaveValue("Body")
+    await expect(block.locator('[data-loomark-block-marker="ordered"]')).toHaveText("3)")
+    await expect(block.getByRole("textbox", { name: "Ordered list item 3" })).toHaveValue("Third")
+    await expect(block.getByRole("textbox", { name: "moonbit code block 4" })).toHaveValue(
+      "let x = 1",
+    )
+    await expect(block.getByRole("button", { name: "Split" })).toHaveCount(0)
+    await expect(block.getByRole("button", { name: "Merge" })).toHaveCount(0)
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("interactive chrome hides driver controls and focuses the Preview surface", async ({ browser }) => {
   const host = await mountHost(browser, "# Focusable preview\n")
   try {
@@ -437,7 +459,7 @@ test("Block toolbar enables only edits accepted for the active typed block", asy
     await expect(toolbar.getByRole("button", { name: "Heading 2, Ctrl+2" })).toBeDisabled()
     await expect(toolbar.getByRole("button", { name: "Toggle list, Ctrl+Shift+L" })).toBeDisabled()
     await expect(toolbar.getByRole("button", { name: "Delete selected block" })).toBeEnabled()
-    await input.press("Control+2")
+    await input.dispatchEvent("keydown", { key: "2", ctrlKey: true })
     await input.press("Control+Shift+L")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("```moonbit\nvalue\n```\n")
     await expect.poll(async () => (await snapshot(host.page)).error_count).toBe(0)
@@ -453,11 +475,37 @@ test("Block formatting shortcuts dispatch the same typed edits", async ({ browse
     const input = host.page.locator("#loomark-block-input")
     await input.focus()
 
-    await input.press("Control+2")
+    await input.dispatchEvent("keydown", { key: "2", ctrlKey: true })
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("## Title\n")
-    await input.press("Control+2")
+    await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
+    await expect(input).toHaveAttribute("aria-label", "Heading 2 block 1")
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "2", ctrlKey: true })
+    await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(2)
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
-    await input.press("Control+Shift+L")
+    await expect(input).toHaveAttribute("aria-label", "Paragraph block 1")
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "4", ctrlKey: true })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("#### Title\n")
+    await expect(input).toHaveAttribute("aria-label", "Heading 4 block 1")
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "5", ctrlKey: true })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("##### Title\n")
+    await expect(input).toHaveAttribute("aria-label", "Heading 5 block 1")
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "6", ctrlKey: true })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("###### Title\n")
+    await expect(input).toHaveAttribute("aria-label", "Heading 6 block 1")
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "0", ctrlKey: true })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
+    await expect(input).toHaveAttribute("aria-label", "Paragraph block 1")
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "0", ctrlKey: true })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
+    await expect.poll(async () => (await snapshot(host.page)).error_count).toBe(0)
+    await expect(input).toBeFocused()
+    await input.dispatchEvent("keydown", { key: "L", ctrlKey: true, shiftKey: true })
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("- Title\n")
 
     await input.dispatchEvent("keydown", {
@@ -466,6 +514,25 @@ test("Block formatting shortcuts dispatch the same typed edits", async ({ browse
       isComposing: true,
     })
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("- Title\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("same-frame formatting callbacks reduce against the latest model", async ({ browser }) => {
+  const host = await mountHost(browser, "Title\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      element.dispatchEvent(new KeyboardEvent("keydown", { key: "2", ctrlKey: true, bubbles: true }))
+      element.dispatchEvent(new KeyboardEvent("keydown", { key: "2", ctrlKey: true, bubbles: true }))
+    })
+
+    await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(2)
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Title\n")
+    await expect.poll(async () => (await snapshot(host.page)).error_count).toBe(0)
   } finally {
     await host.context.close()
   }
@@ -731,6 +798,172 @@ test("Block input editor failure preserves its committed payload atomically", as
   }
 })
 
+test("Enter splits the active text block at the caret and focuses the new block", async ({ browser }) => {
+  const host = await mountHost(browser, "Hello\n\nWorld\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(2, 2)
+    })
+
+    await input.press("Enter")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("He\n\nllo\n\nWorld\n")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-block-input-1",
+    )
+    await expect.poll(() => host.page.evaluate(() => {
+      const textarea = document.activeElement as HTMLTextAreaElement | null
+      return textarea === null ? "missing" : `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("0:0")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Backspace at the start of an empty text block merges into the previous block", async ({ browser }) => {
+  const host = await mountHost(browser, "First\n\nSecond\n")
+  try {
+    await selectBlock(host.page)
+    const first = host.page.locator("#loomark-block-input")
+    await first.focus()
+    await first.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+    })
+    await first.press("Enter")
+    const empty = host.page.locator("#loomark-block-input-1")
+    await expect(empty).toBeFocused()
+    await expect(empty).toHaveValue("")
+
+    await empty.press("Backspace")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("First\n\nSecond\n")
+    await expect(host.page.locator("[data-loomark-block-id]")).toHaveCount(2)
+    await expect(first).toBeFocused()
+    await expect.poll(() => first.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("5:5")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Backspace preserves focus when an unsupported predecessor rejects merge", async ({ browser }) => {
+  const host = await mountHost(browser, "First\n\n---\n\nBody\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input-1")
+    await input.fill("")
+    await expect(input).toHaveValue("")
+    const source = (await snapshot(host.page)).source
+
+    await input.press("Backspace")
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe(
+      "editor-commit-failed",
+    )
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(source)
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("0:0")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("boundary keys navigate between text blocks without changing source", async ({ browser }) => {
+  const source = "First\n\nSecond\n\nThird\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectBlock(host.page)
+    const first = host.page.locator("#loomark-block-input")
+    const second = host.page.locator("#loomark-block-input-1")
+    await second.focus()
+    await second.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(0, 0)
+    })
+
+    await second.press("ArrowLeft")
+    await expect(first).toBeFocused()
+    await expect.poll(() => first.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("5:5")
+
+    await first.press("ArrowDown")
+    await expect(second).toBeFocused()
+    await expect.poll(() => second.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("0:0")
+
+    await second.press("Backspace")
+    await expect(first).toBeFocused()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(source)
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Enter rejects unsupported list structure changes without mutating source", async ({ browser }) => {
+  const source = "- Item\n\nTail\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectBlock(host.page)
+    const item = host.page.locator("#loomark-block-input")
+    await item.focus()
+    await item.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+    })
+
+    await item.press("Enter")
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe(
+      "block-selection-rejected",
+    )
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(source)
+    await expect(item).toBeFocused()
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Enter edits fenced code payload without splitting its typed block", async ({ browser }) => {
+  const host = await mountHost(browser, "```moonbit\nab\n```\n")
+  try {
+    await selectBlock(host.page)
+    const code = host.page.locator("#loomark-block-input")
+    await code.focus()
+    await code.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(1, 1)
+    })
+
+    await code.press("Enter")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(
+      "```moonbit\na\nb\n```\n",
+    )
+    await expect(host.page.locator('[data-loomark-block-kind="code"]')).toHaveCount(1)
+    await expect(code).toBeFocused()
+    await expect.poll(() => code.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("2:2")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Block split rejects a non-collapsed selection without changing source", async ({ browser }) => {
   const host = await mountHost(browser, "Hello\n")
   try {
@@ -741,10 +974,15 @@ test("Block split rejects a non-collapsed selection without changing source", as
       const textarea = element as HTMLTextAreaElement
       textarea.setSelectionRange(0, 2)
     })
-    await host.page.locator("[data-loomark-block-split]").first().click()
+    await input.press("Enter")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("block-selection-rejected")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("Hello\n")
     await expect(host.page.locator("#loomark-block-input")).toHaveValue("Hello")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("0:2")
   } finally {
     await host.context.close()
   }
@@ -760,7 +998,7 @@ test("Block split at the start creates and focuses an empty previous block", asy
       const textarea = element as HTMLTextAreaElement
       textarea.setSelectionRange(0, 0)
     })
-    await host.page.locator("[data-loomark-block-split]").click()
+    await input.press("Enter")
     await expect(host.page.locator("[data-loomark-block-id]")).toHaveCount(2)
     await expect(host.page.locator("#loomark-block-input")).toHaveValue("")
     await expect(host.page.locator("#loomark-block-input-1")).toHaveValue("Hello")
@@ -776,7 +1014,7 @@ test("Block split at the start creates and focuses an empty previous block", asy
   }
 })
 
-test("Block split and merge use typed structural edits and deterministic selection", async ({ browser }) => {
+test("Block split uses a typed structural edit and deterministic selection", async ({ browser }) => {
   const host = await mountHost(browser, "Hello\n\nWorld\n")
   try {
     await selectBlock(host.page)
@@ -786,7 +1024,7 @@ test("Block split and merge use typed structural edits and deterministic selecti
       const textarea = element as HTMLTextAreaElement
       textarea.setSelectionRange(2, 2)
     })
-    await host.page.locator("[data-loomark-block-split]").first().click()
+    await firstInput.press("Enter")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("He\n\nllo\n\nWorld\n")
     await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-block-input-1")
     await expect.poll(() => host.page.evaluate(() => {
@@ -799,15 +1037,6 @@ test("Block split and merge use typed structural edits and deterministic selecti
     await expect.poll(async () => (await snapshot(host.page)).selection).toBe(`block|${secondKey}|0`)
     await expect(host.page.locator('[data-loomark-block-kind="paragraph"]')).toHaveCount(3)
 
-    await host.page.locator("[data-loomark-block-merge]").nth(1).click()
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Hello\n\nWorld\n")
-    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-block-input")
-    await expect.poll(() => host.page.evaluate(() => {
-      const textarea = document.activeElement as HTMLTextAreaElement | null
-      return textarea === null ? "missing" : `${textarea.selectionStart}:${textarea.selectionEnd}`
-    })).toBe("2:2")
-    const mergedKey = await host.page.locator("#loomark-block-input").getAttribute("data-loomark-block-id")
-    await expect.poll(async () => (await snapshot(host.page)).selection).toBe(`block|${mergedKey}|2`)
   } finally {
     await host.context.close()
   }
@@ -823,7 +1052,7 @@ test("typing after an end split does not leak the empty-block placeholder", asyn
       const textarea = element as HTMLTextAreaElement
       textarea.setSelectionRange(textarea.value.length, textarea.value.length)
     })
-    await host.page.locator("[data-loomark-block-split]").click()
+    await input.press("Enter")
     await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-block-input-1")
     await expect(host.page.locator("#loomark-block-input-1")).toHaveValue("")
     await host.page.keyboard.type("X")

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -449,6 +449,29 @@ test("Block toolbar deletes the active block and focuses the surviving typed tar
   }
 })
 
+test("Block delete focuses the adjacent survivor instead of a stale editor cursor", async ({ browser }) => {
+  const host = await mountHost(browser, "First\n\nSecond\n\nThird\n")
+  try {
+    await selectBlock(host.page)
+    const first = host.page.locator("#loomark-block-input")
+    await first.fill("Changed")
+    const third = host.page.locator("#loomark-block-input-2")
+    await third.focus()
+
+    await host.page.getByRole("button", { name: "Delete selected block" }).click()
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("Changed\n\nSecond\n\n")
+    const second = host.page.locator("#loomark-block-input-1")
+    await expect(second).toBeFocused()
+    await expect.poll(() => second.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("6:6")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Block toolbar enables only edits accepted for the active typed block", async ({ browser }) => {
   const host = await mountHost(browser, "```moonbit\nvalue\n```\n")
   try {

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -11,7 +11,9 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
  * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
  * | semantic Preview | heading, paragraph, fenced code, list fallback | RUI-aligned read-only semantic DOM without invented list containers |
- * | interactive chrome | normal, focus, error | only mode controls are visible; Preview owns focus; errors appear on demand |
+ * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
+ * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
+ * | interactive chrome | normal, focus, error | only application controls are visible; Preview owns focus; errors appear on demand |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
  */
@@ -206,11 +208,11 @@ test("Preview renders supported blocks as RUI-aligned semantic HTML", async ({ b
   const host = await mountHost(browser, source)
   try {
     await expect(host.page.locator("#loomark-root")).toHaveAttribute("data-rui-theme", "")
-    await expect(host.page.locator('#loomark-toolbar button[data-slot="button"]')).toHaveCount(3)
-    await expect(host.page.locator("#loomark-mode-raw")).toHaveAttribute("aria-pressed", "true")
+    await expect(host.page.locator('#loomark-toolbar button[role="tab"]')).toHaveCount(3)
+    await expect(host.page.locator("#loomark-mode-raw")).toHaveAttribute("aria-selected", "true")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-mode-raw")).toHaveAttribute("aria-pressed", "false")
-    await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute("aria-pressed", "true")
+    await expect(host.page.locator("#loomark-mode-raw")).toHaveAttribute("aria-selected", "false")
+    await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute("aria-selected", "true")
     const preview = host.page.locator("#loomark-preview")
     await expect(preview).toHaveAttribute("data-loomark-source", source)
     await expect(preview.locator("[data-loomark-preview-notice]")).toContainText(
@@ -232,14 +234,92 @@ test("Preview renders supported blocks as RUI-aligned semantic HTML", async ({ b
   }
 })
 
+test("production chrome exposes one accessible editor view at a time", async ({ browser }) => {
+  const host = await mountHost(browser, "# Accessible editor\n")
+  try {
+    const region = host.page.getByRole("region", { name: "Loomark Markdown Editor" })
+    await expect(region).toBeVisible()
+    const tabs = region.getByRole("tablist", { name: "Editor view" })
+    await expect(tabs.getByRole("tab")).toHaveCount(3)
+    await expect(tabs.locator("svg")).toHaveCount(3)
+    const blockTab = tabs.getByRole("tab", { name: "Block view" })
+    const rawTab = tabs.getByRole("tab", { name: "Raw Markdown" })
+    const previewTab = tabs.getByRole("tab", { name: "Preview" })
+    await expect(rawTab).toHaveAttribute("aria-selected", "true")
+    await expect(rawTab).not.toHaveAttribute("aria-controls")
+    await expect(blockTab).not.toHaveAttribute("aria-controls")
+    await expect(previewTab).not.toHaveAttribute("aria-controls")
+    await expect(region.getByRole("tabpanel", { name: "Raw Markdown" })).toBeVisible()
+
+    await rawTab.focus()
+    await rawTab.press("ArrowRight")
+    await expect(previewTab).toBeFocused()
+    await expect(previewTab).toHaveAttribute("aria-selected", "true")
+    await expect(region.getByRole("tabpanel", { name: "Preview" })).toBeVisible()
+    await expect.poll(async () => (await snapshot(host.page)).mode).toBe("preview")
+    await expect(blockTab).toHaveAttribute("aria-selected", "false")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("example presets replace canonical source without changing the selected mode", async ({ browser }) => {
+  const host = await mountHost(browser, "initial\n")
+  try {
+    await selectPreview(host.page)
+    const examples = host.page.getByRole("toolbar", { name: "Example documents" })
+    const presets = [
+      {
+        name: "Apply Hello example",
+        source: "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nThis editor has three modes: raw, block, and preview.\n",
+      },
+      {
+        name: "Apply Blog example",
+        source: "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nThe editor supports real-time collaboration via CRDT.\n\nEvery keystroke is incrementally parsed and projected into a structured view.",
+      },
+      {
+        name: "Apply List example",
+        source: "# Shopping List\n\nThings to pick up:\n\n- Apples\n- Bread\n- Coffee\n- Dark chocolate",
+      },
+      {
+        name: "Apply Code example",
+        source: "# README\n\nA minimal example project.\n\n## Install\n\n```bash\nnpm install\n```\n\n## Usage\n\n- Run the dev server\n- Open the browser\n- Start editing",
+      },
+    ]
+
+    for (const preset of presets) {
+      await examples.getByRole("button", { name: preset.name }).click()
+      await expect.poll(async () => (await snapshot(host.page)).source).toBe(preset.source)
+      await expect.poll(async () => (await snapshot(host.page)).mode).toBe("preview")
+      await expectPreviewSource(host.page, preset.source)
+    }
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("production chrome keeps its controls inside a narrow viewport", async ({ browser }) => {
+  const host = await mountHost(browser, "# Narrow editor\n")
+  try {
+    await host.page.setViewportSize({ width: 360, height: 720 })
+    const region = host.page.getByRole("region", { name: "Loomark Markdown Editor" })
+    await expect(region.getByRole("toolbar", { name: "Example documents" })).toBeVisible()
+    await expect(region.getByRole("tablist", { name: "Editor view" })).toBeVisible()
+    expect(await host.page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(360)
+    const frame = await host.page.locator("#loomark-editor-frame").boundingBox()
+    expect(frame).not.toBeNull()
+    expect(frame!.x).toBeGreaterThanOrEqual(0)
+    expect(frame!.x + frame!.width).toBeLessThanOrEqual(360)
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("interactive chrome hides driver controls and focuses the Preview surface", async ({ browser }) => {
   const host = await mountHost(browser, "# Focusable preview\n")
   try {
-    await expect(host.page.locator("#loomark-root button:visible")).toHaveText([
-      "Raw",
-      "Block",
-      "Preview",
-    ])
+    await expect(host.page.getByRole("toolbar", { name: "Example documents" }).getByRole("button")).toHaveCount(4)
+    await expect(host.page.getByRole("tablist", { name: "Editor view" }).getByRole("tab")).toHaveCount(3)
     await expect(host.page.locator("#loomark-event-target")).toBeHidden()
     await expect(host.page.locator("#loomark-focus-target")).toHaveCount(0)
     await expect(host.page.locator("#loomark-mode")).toHaveCount(0)
@@ -247,11 +327,6 @@ test("interactive chrome hides driver controls and focuses the Preview surface",
     const preview = host.page.locator("#loomark-preview")
     await expect(preview).toHaveAttribute("tabindex", "0")
     await expect(preview).toHaveAttribute("aria-label", "Markdown preview")
-    await host.page.locator("#loomark-mode-preview").focus()
-    await host.page.keyboard.press("Tab")
-    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
-      "loomark-preview",
-    )
     await host.page.locator("#loomark-mode-preview").focus()
     await focusPreview(host.page)
     await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
@@ -695,13 +770,18 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
   try {
     await selectRaw(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(1)
+    await expect(host.page.locator("#loomark-input")).toHaveAttribute("data-slot", "textarea")
+    await expect(host.page.locator("#loomark-input")).toHaveAttribute(
+      "aria-label",
+      "Raw Markdown source",
+    )
     await host.page.locator("#loomark-input").fill("edited\nsource")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("edited\nsource")
     await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
     await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute(
-      "aria-pressed",
+      "aria-selected",
       "true",
     )
     await expectPreviewSource(host.page, "edited\nsource")
@@ -949,7 +1029,7 @@ test("keeps source and mode state separate from after-render focus and DOM effec
     await requestSource(host.page, "# Updated\n")
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute(
-      "aria-pressed",
+      "aria-selected",
       "true",
     )
     await expectPreviewSource(host.page, "# Updated\n")

--- a/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -11,6 +11,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
  * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
  * | semantic Preview | heading, paragraph, fenced code, list fallback | RUI-aligned read-only semantic DOM without invented list containers |
+ * | interactive chrome | normal, focus, error | only mode controls are visible; Preview owns focus; errors appear on demand |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
  */
@@ -231,6 +232,50 @@ test("Preview renders supported blocks as RUI-aligned semantic HTML", async ({ b
   }
 })
 
+test("interactive chrome hides driver controls and focuses the Preview surface", async ({ browser }) => {
+  const host = await mountHost(browser, "# Focusable preview\n")
+  try {
+    await expect(host.page.locator("#loomark-root button:visible")).toHaveText([
+      "Raw",
+      "Block",
+      "Preview",
+    ])
+    await expect(host.page.locator("#loomark-event-target")).toBeHidden()
+    await expect(host.page.locator("#loomark-focus-target")).toHaveCount(0)
+    await expect(host.page.locator("#loomark-mode")).toHaveCount(0)
+    await selectPreview(host.page)
+    const preview = host.page.locator("#loomark-preview")
+    await expect(preview).toHaveAttribute("tabindex", "0")
+    await expect(preview).toHaveAttribute("aria-label", "Markdown preview")
+    await host.page.locator("#loomark-mode-preview").focus()
+    await host.page.keyboard.press("Tab")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-preview",
+    )
+    await host.page.locator("#loomark-mode-preview").focus()
+    await focusPreview(host.page)
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-preview",
+    )
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("application status stays quiet until an error needs attention", async ({ browser }) => {
+  const host = await mountHost(browser, "stable\n")
+  try {
+    await expect(host.page.locator("#loomark-error")).toHaveCount(0)
+    await failHost(host.page, "fatal test")
+    const error = host.page.locator("#loomark-error")
+    await expect(error).toHaveText("error: fatal test")
+    await expect(error).toHaveAttribute("role", "alert")
+    await expect(error).toHaveAttribute("data-slot", "alert")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("Block mode edits a heading payload without leaking its marker", async ({ browser }) => {
   const host = await mountHost(browser, "# Title\n")
   try {
@@ -420,6 +465,38 @@ test("Rapid Block typing preserves a mid-text UTF-16 caret across CRLF normaliza
       error_code: null,
       error_count: 0,
     })
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a superseded Block caret restore yields to a same-frame deletion", async ({ browser }) => {
+  const host = await mountHost(browser, "A")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "AB"
+      textarea.setSelectionRange(2, 2)
+      textarea.dispatchEvent(new InputEvent("input", { bubbles: true, data: "B" }))
+      textarea.value = "A"
+      textarea.setSelectionRange(1, 1)
+      textarea.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        inputType: "deleteContentBackward",
+      }))
+    })
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("A")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-block-input",
+    )
+    await expect.poll(() => host.page.evaluate(() => {
+      const textarea = document.activeElement as HTMLTextAreaElement | null
+      return textarea === null ? "missing" : `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("1:1")
+    await expect.poll(async () => (await snapshot(host.page)).error).toBeNull()
   } finally {
     await host.context.close()
   }
@@ -623,7 +700,10 @@ test("Raw textarea input uses the atomic editor transaction and mode toolbar", a
     await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
-    await expect(host.page.locator("#loomark-mode")).toHaveText("mode: preview")
+    await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
     await expectPreviewSource(host.page, "edited\nsource")
     await rawInput(host.page, "must-not-commit\n")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("mode-inapplicable")
@@ -868,11 +948,16 @@ test("keeps source and mode state separate from after-render focus and DOM effec
   try {
     await requestSource(host.page, "# Updated\n")
     await selectPreview(host.page)
-    await expect(host.page.locator("#loomark-mode")).toHaveText("mode: preview")
+    await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
     await expectPreviewSource(host.page, "# Updated\n")
 
     await focusPreview(host.page)
-    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe("loomark-focus-target")
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-preview",
+    )
 
     await selectRaw(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(1)

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -107,6 +107,18 @@ let detached_focus_token : @ref.Ref[String] = { val: "" }
 const FOCUS_TOKEN_VERSION : Int = 1
 
 ///|
+const HELLO_EXAMPLE_SOURCE : String = "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nThis editor has three modes: raw, block, and preview.\n"
+
+///|
+const BLOG_EXAMPLE_SOURCE : String = "# Getting Started\n\nCanopy is an incremental projectional editor.\n\n## Features\n\nThe editor supports real-time collaboration via CRDT.\n\nEvery keystroke is incrementally parsed and projected into a structured view."
+
+///|
+const LIST_EXAMPLE_SOURCE : String = "# Shopping List\n\nThings to pick up:\n\n- Apples\n- Bread\n- Coffee\n- Dark chocolate"
+
+///|
+const CODE_EXAMPLE_SOURCE : String = "# README\n\nA minimal example project.\n\n## Install\n\n```bash\nnpm install\n```\n\n## Usage\n\n- Run the dev server\n- Open the browser\n- Start editing"
+
+///|
 /// Allocate one globally unique CRDT replica identity per mount.
 extern "js" fn js_replica_uuid() -> String =
   #| () => globalThis.crypto.randomUUID()
@@ -118,6 +130,35 @@ fn mode_name(mode : @core.ApplicationMode) -> String {
     @core.Block => "block"
     @core.Preview => "preview"
   }
+}
+
+///|
+/// Render one decorative mode glyph; the owning tab supplies its accessible
+/// name and interaction semantics.
+fn mode_icon(path : String) -> @html.Html {
+  @html.span(
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    style=[
+      "display:inline-flex;width:1.125rem;height:1.125rem;align-items:center;justify-content:center;pointer-events:none",
+    ],
+    @svg.svg(
+      width=18,
+      height=18,
+      view_box="0 0 24 24",
+      style=["display:block;width:100%;height:100%"],
+      [
+        @svg.path(
+          d=path,
+          fill="none",
+          stroke="currentColor",
+          stroke_width=2,
+          attrs=@svg.Attrs::build()
+            .stroke_linecap("round")
+            .stroke_linejoin("round"),
+        ),
+      ],
+    ),
+  )
 }
 
 ///|
@@ -414,12 +455,15 @@ fn editor_surface(
       Map([
         (
           "raw|" + model.raw_surface_revision.to_string(),
-          @html.textarea(
+          @rui.textarea(
             id="loomark-input",
             value=source,
             rows=4,
+            attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
+            style=[
+              "min-height:clamp(24rem,70vh,36rem);flex:1;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-radius:0;background:transparent;padding:1rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
+            ],
             on_input=emit.map(source => RawInput(source)),
-            "",
           ),
         ),
       ])
@@ -496,26 +540,78 @@ fn preview_view(
   let raw_selected = model.state.mode() == @core.Raw
   let block_selected = model.state.mode() == @core.Block
   let preview_selected = model.state.mode() == @core.Preview
-  let raw_button = @rui.button(
+  let raw_button = @rui.tabs_trigger(
+    value="raw",
     id="loomark-mode-raw",
-    variant=if raw_selected { @rui.Secondary } else { @rui.Ghost },
-    attrs=@html.Attrs::build().aria_pressed(raw_selected.to_string()),
-    on_click=emit(SelectRaw),
-    "Raw",
+    selected=raw_selected,
+    attrs=@html.Attrs::build()
+      .aria_label("Raw Markdown")
+      .on_click(_ => emit(SelectRaw)),
+    style=["min-height:2.75rem;flex:0 0 3.25rem;padding:0"],
+    mode_icon("m8 9-3 3 3 3m8-6 3 3-3 3m-2-8-4 16"),
   )
-  let preview_button = @rui.button(
+  let preview_button = @rui.tabs_trigger(
+    value="preview",
     id="loomark-mode-preview",
-    variant=if preview_selected { @rui.Secondary } else { @rui.Ghost },
-    attrs=@html.Attrs::build().aria_pressed(preview_selected.to_string()),
-    on_click=emit(SelectPreview),
-    "Preview",
+    selected=preview_selected,
+    attrs=@html.Attrs::build()
+      .aria_label("Preview")
+      .on_click(_ => emit(SelectPreview)),
+    style=["min-height:2.75rem;flex:0 0 3.25rem;padding:0"],
+    mode_icon(
+      "M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Zm10 3a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
+    ),
   )
-  let block_button = @rui.button(
+  let block_button = @rui.tabs_trigger(
+    value="block",
     id="loomark-mode-block",
-    variant=if block_selected { @rui.Secondary } else { @rui.Ghost },
-    attrs=@html.Attrs::build().aria_pressed(block_selected.to_string()),
-    on_click=emit(SelectBlock),
-    "Block",
+    selected=block_selected,
+    attrs=@html.Attrs::build()
+      .aria_label("Block view")
+      .on_click(_ => emit(SelectBlock)),
+    style=["min-height:2.75rem;flex:0 0 3.25rem;padding:0"],
+    mode_icon("M4 4h6v6H4V4Zm10 0h6v6h-6V4ZM4 14h6v6H4v-6Zm10 0h6v6h-6v-6Z"),
+  )
+  let (panel_id, panel_labelledby) = match model.state.mode() {
+    @core.Raw => ("loomark-panel-raw", "loomark-mode-raw")
+    @core.Block => ("loomark-panel-block", "loomark-mode-block")
+    @core.Preview => ("loomark-panel-preview", "loomark-mode-preview")
+  }
+  let examples = @html.div(
+    attrs=@html.Attrs::build().role("toolbar").aria_label("Example documents"),
+    style=[
+      "display:flex;min-height:2.5rem;align-items:center;justify-content:flex-end;gap:0.125rem;flex-wrap:wrap;padding-inline:0.25rem",
+    ],
+    [
+      @rui.button(
+        variant=@rui.Ghost,
+        size=@rui.Xs,
+        attrs=@html.Attrs::build().aria_label("Apply Hello example"),
+        on_click=emit(ReplaceSource(HELLO_EXAMPLE_SOURCE)),
+        "Hello",
+      ),
+      @rui.button(
+        variant=@rui.Ghost,
+        size=@rui.Xs,
+        attrs=@html.Attrs::build().aria_label("Apply Blog example"),
+        on_click=emit(ReplaceSource(BLOG_EXAMPLE_SOURCE)),
+        "Guide",
+      ),
+      @rui.button(
+        variant=@rui.Ghost,
+        size=@rui.Xs,
+        attrs=@html.Attrs::build().aria_label("Apply List example"),
+        on_click=emit(ReplaceSource(LIST_EXAMPLE_SOURCE)),
+        "List",
+      ),
+      @rui.button(
+        variant=@rui.Ghost,
+        size=@rui.Xs,
+        attrs=@html.Attrs::build().aria_label("Apply Code example"),
+        on_click=emit(ReplaceSource(CODE_EXAMPLE_SOURCE)),
+        "Code",
+      ),
+    ],
   )
   let event_button = @html.button(
     id="loomark-event-target",
@@ -540,20 +636,56 @@ fn preview_view(
   }
   @rui.theme(
     id="loomark-root",
+    attrs=@html.Attrs::build()
+      .role("region")
+      .aria_label("Loomark Markdown Editor"),
     style=[
-      "min-height:100vh;max-width:64rem;margin-inline:auto;padding:clamp(1rem,4vw,3rem)",
+      "min-height:100vh;min-height:100dvh;box-sizing:border-box;background:oklch(0.968 0.008 85);color:oklch(0.24 0.018 265);padding:clamp(0.5rem,2vw,1.5rem);--rui-background:oklch(0.991 0.004 85);--rui-foreground:oklch(0.24 0.018 265);--rui-muted:oklch(0.94 0.01 85);--rui-muted-foreground:oklch(0.5 0.02 265);--rui-border:oklch(0.86 0.012 85);--rui-primary:oklch(0.48 0.12 276);--rui-radius:0.5rem",
     ],
     [
-      @rui.typography_h1(style=["text-align:start"], "Loomark"),
-      @html.nav(
-        id="loomark-toolbar",
-        style=["display:flex;gap:0.25rem;margin-block:1.5rem"],
-        [raw_button, block_button, preview_button],
-      ),
       @html.div(
-        id="loomark-surface",
-        style=["margin-block:1.5rem"],
-        editor_surface(model, emit),
+        id="loomark-editor-shell",
+        style=[
+          "width:min(100%,53.75rem);min-height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column",
+        ],
+        [
+          @rui.tabs_root(
+            value=mode_name(model.state.mode()),
+            id="loomark-editor-frame",
+            style=[
+              "flex:1;gap:0;overflow:hidden;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-background);box-shadow:0 1px 2px rgb(31 35 48 / 0.06),0 10px 30px rgb(31 35 48 / 0.05)",
+            ],
+            [
+              @html.div(
+                style=[
+                  "display:flex;min-width:0;align-items:center;justify-content:space-between;gap:0.25rem;flex-wrap:wrap;padding-inline:0.5rem;border-bottom:1px solid var(--rui-border)",
+                ],
+                [
+                  @rui.tabs_list(
+                    variant=@rui.TabsLine,
+                    aria_label="Editor view",
+                    id="loomark-toolbar",
+                    style=["min-height:3.25rem;padding:0;overflow:visible"],
+                    [block_button, raw_button, preview_button],
+                  ),
+                  examples,
+                ],
+              ),
+              @html.div(
+                id=panel_id,
+                attrs=@html.Attrs::build()
+                  .role("tabpanel")
+                  .aria_labelledby(panel_labelledby),
+                style=["min-width:0;flex:1;display:flex"],
+                @html.div(
+                  id="loomark-surface",
+                  style=["width:100%;min-width:0;display:flex"],
+                  editor_surface(model, emit),
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
       event_button,
       driver_button,

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -423,14 +423,7 @@ fn editor_surface(
           ),
         ),
       ])
-    @core.Preview =>
-      {
-        "preview": @html.pre(
-          id="loomark-preview",
-          attrs=@html.Attrs::build().data_set("loomark-source", source),
-          source,
-        ),
-      }
+    @core.Preview => { "preview": preview_surface(model.document) }
     @core.Block =>
       Map([
         (
@@ -500,37 +493,43 @@ fn preview_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
 ) -> @rabbita_runtime.Html {
-  let raw_button = @html.button(
+  let raw_selected = model.state.mode() == @core.Raw
+  let block_selected = model.state.mode() == @core.Block
+  let preview_selected = model.state.mode() == @core.Preview
+  let raw_button = @rui.button(
     id="loomark-mode-raw",
-    type_="button",
+    variant=if raw_selected { @rui.Secondary } else { @rui.Ghost },
+    attrs=@html.Attrs::build().aria_pressed(raw_selected.to_string()),
     on_click=emit(SelectRaw),
     "Raw",
   )
-  let preview_button = @html.button(
+  let preview_button = @rui.button(
     id="loomark-mode-preview",
-    type_="button",
+    variant=if preview_selected { @rui.Secondary } else { @rui.Ghost },
+    attrs=@html.Attrs::build().aria_pressed(preview_selected.to_string()),
     on_click=emit(SelectPreview),
     "Preview",
   )
-  let block_button = @html.button(
+  let block_button = @rui.button(
     id="loomark-mode-block",
-    type_="button",
+    variant=if block_selected { @rui.Secondary } else { @rui.Ghost },
+    attrs=@html.Attrs::build().aria_pressed(block_selected.to_string()),
     on_click=emit(SelectBlock),
     "Block",
   )
-  let focus_button = @html.button(
+  let focus_button = @rui.button(
     id="loomark-focus-target",
-    type_="button",
+    variant=@rui.Outline,
     on_click=emit(FocusPreview),
     "Focus preview",
   )
-  let mode = @html.p(
+  let mode = @rui.typography_muted(
     id="loomark-mode",
     "mode: " + mode_name(model.state.mode()),
   )
-  let event_button = @html.button(
+  let event_button = @rui.button(
     id="loomark-event-target",
-    type_="button",
+    variant=@rui.Outline,
     "Dispatch event",
   )
   let driver_button = @html.button(
@@ -543,16 +542,30 @@ fn preview_view(
     Some(error) => "error: " + error
     None => "ready"
   }
-  @html.div(id="loomark-root", [
-    @html.h1("Loomark"),
-    @html.nav(id="loomark-toolbar", [raw_button, block_button, preview_button]),
-    mode,
-    @html.div(id="loomark-surface", editor_surface(model, emit)),
-    event_button,
-    driver_button,
-    focus_button,
-    @html.p(id="loomark-error", error_text),
-  ])
+  @rui.theme(
+    id="loomark-root",
+    style=[
+      "min-height:100vh;max-width:64rem;margin-inline:auto;padding:clamp(1rem,4vw,3rem)",
+    ],
+    [
+      @rui.typography_h1(style=["text-align:start"], "Loomark"),
+      @html.nav(
+        id="loomark-toolbar",
+        style=["display:flex;gap:0.25rem;margin-block:1.5rem"],
+        [raw_button, block_button, preview_button],
+      ),
+      mode,
+      @html.div(
+        id="loomark-surface",
+        style=["margin-block:1.5rem"],
+        editor_surface(model, emit),
+      ),
+      event_button,
+      driver_button,
+      focus_button,
+      @rui.typography_muted(id="loomark-error", error_text),
+    ],
+  )
 }
 
 ///|

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -6,8 +6,8 @@ priv enum DriverEvent {
   SelectBlock
   SelectPreview
   BlockFocused(String)
-  BlockHeading(Int)
-  BlockToggleList
+  BlockHeading(Int, BlockSelection?)
+  BlockToggleList(BlockSelection?)
   BlockDelete
   RawInput(String)
   BlockInput(
@@ -16,8 +16,9 @@ priv enum DriverEvent {
     selection_offset~ : Int
   )
   BlockSplit(node_id~ : @markdown.MarkdownNodeId, offset~ : Int)
-  BlockMerge(node_id~ : @markdown.MarkdownNodeId)
-  BlockSelectionRejected(String)
+  BlockMerge(node_id~ : @markdown.MarkdownNodeId, selection~ : BlockSelection)
+  BlockNavigate(key~ : String, direction~ : Int)
+  BlockSelectionRejected(String, BlockSelection?)
   ProbeBlockSelection(String)
   EditorFailure
   RestoreSnapshot(
@@ -430,7 +431,12 @@ fn commit_block_toolbar_request(
     Some(selection) =>
       (
         next,
-        block_selection_after_render(selection, next.source_revision, emit),
+        block_selection_after_render(
+          selection,
+          next.source_revision,
+          skip_stale_revision=true,
+          emit,
+        ),
       )
     None =>
       if applied {
@@ -534,33 +540,6 @@ fn editor_surface(
         ),
       ])
   }
-}
-
-///|
-fn block_split_command(
-  block : @markdown.MarkdownBlockSnapshot,
-  input_id : String,
-  emit : @cmd.Emit[DriverEvent],
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    let selection = @dom_boundary.read_text_selection_id(input_id) catch {
-      error => {
-        scheduler.add(emit(EffectFailed(error.message())))
-        return
-      }
-    }
-    if selection.start() != selection.end() {
-      scheduler.add(
-        emit(
-          BlockSelectionRejected("block split requires a collapsed selection"),
-        ),
-      )
-    } else {
-      scheduler.add(
-        emit(BlockSplit(node_id=block.node_id(), offset=selection.start())),
-      )
-    }
-  })
 }
 
 ///|
@@ -800,7 +779,9 @@ fn block_selection_after_render(
         Some(model) =>
           if model.state.mode() != @core.Block {
             scheduler.add(
-              emit(BlockSelectionRejected("block selection mode is stale")),
+              emit(
+                BlockSelectionRejected("block selection mode is stale", None),
+              ),
             )
           } else if model.source_revision != source_revision {
             // Rapid input can queue several post-render selections in one
@@ -809,7 +790,7 @@ fn block_selection_after_render(
             // second render after the newest selection restored the caret.
             if report_superseded {
               scheduler.add(
-                emit(BlockSelectionRejected("block selection is stale")),
+                emit(BlockSelectionRejected("block selection is stale", None)),
               )
             }
           } else {
@@ -820,8 +801,8 @@ fn block_selection_after_render(
                 @dom_boundary.write_text_selection_id(
                   id,
                   @dom_boundary.TextSelection(
-                    selection.offset,
-                    selection.offset,
+                    selection.start,
+                    selection.end,
                     @dom_boundary.NoDirection,
                   ),
                 )
@@ -831,6 +812,7 @@ fn block_selection_after_render(
                   emit(
                     BlockSelectionRejected(
                       "block selection target is unavailable",
+                      None,
                     ),
                   ),
                 )
@@ -838,7 +820,9 @@ fn block_selection_after_render(
           }
         None =>
           scheduler.add(
-            emit(BlockSelectionRejected("block selection model unavailable")),
+            emit(
+              BlockSelectionRejected("block selection model unavailable", None),
+            ),
           )
       }
     },
@@ -887,14 +871,15 @@ fn driver_event_name(event : DriverEvent) -> String {
     SelectBlock => "select-block"
     SelectPreview => "select-preview"
     BlockFocused(_) => "block-focused"
-    BlockHeading(_) => "block-heading"
-    BlockToggleList => "block-toggle-list"
+    BlockHeading(_, _) => "block-heading"
+    BlockToggleList(_) => "block-toggle-list"
     BlockDelete => "block-delete"
     RawInput(_) => "raw-input"
     BlockInput(..) => "block-input"
     BlockSplit(..) => "block-split"
     BlockMerge(..) => "block-merge"
-    BlockSelectionRejected(_) => "block-selection-rejected"
+    BlockNavigate(..) => "block-navigate"
+    BlockSelectionRejected(_, _) => "block-selection-rejected"
     ProbeBlockSelection(_) => "probe-block-selection"
     EditorFailure => "editor-failure"
     RestoreSnapshot(..) => "restore-snapshot"
@@ -1044,9 +1029,10 @@ fn update_model(
       event is BlockInput(..) ||
       event is BlockSplit(..) ||
       event is BlockMerge(..) ||
+      event is BlockNavigate(..) ||
       event is BlockFocused(_) ||
-      event is BlockHeading(_) ||
-      event is BlockToggleList ||
+      event is BlockHeading(_, _) ||
+      event is BlockToggleList(_) ||
       event is BlockDelete
     ) {
     let next = record_error(
@@ -1124,8 +1110,8 @@ fn update_model(
           }
         }
       }
-    BlockHeading(requested_level) =>
-      match active_block(model) {
+    BlockHeading(requested_level, originating_selection) =>
+      match block_format_target(model, originating_selection) {
         None => {
           let next = record_error(
             model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
@@ -1134,6 +1120,32 @@ fn update_model(
           (next, @rabbita_runtime.none)
         }
         Some(block) => {
+          guard block_allows_heading(block.kind()) else {
+            publish(model)
+            let command = originating_selection
+              .map(selection => {
+                block_selection_after_render(
+                  selection,
+                  model.source_revision,
+                  emit,
+                )
+              })
+              .unwrap_or(@rabbita_runtime.none)
+            return (model, command)
+          }
+          if requested_level == 0 && block.kind() is @markdown.Paragraph {
+            publish(model)
+            let command = originating_selection
+              .map(selection => {
+                block_selection_after_render(
+                  selection,
+                  model.source_revision,
+                  emit,
+                )
+              })
+              .unwrap_or(@rabbita_runtime.none)
+            return (model, command)
+          }
           let target_level = match block.kind() {
             @markdown.Heading(level~) if level == requested_level => 0
             _ => requested_level
@@ -1150,8 +1162,8 @@ fn update_model(
           )
         }
       }
-    BlockToggleList =>
-      match active_block(model) {
+    BlockToggleList(originating_selection) =>
+      match block_format_target(model, originating_selection) {
         None => {
           let next = record_error(
             model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
@@ -1159,7 +1171,20 @@ fn update_model(
           publish(next)
           (next, @rabbita_runtime.none)
         }
-        Some(block) =>
+        Some(block) => {
+          guard block_allows_list(block.kind()) else {
+            publish(model)
+            let command = originating_selection
+              .map(selection => {
+                block_selection_after_render(
+                  selection,
+                  model.source_revision,
+                  emit,
+                )
+              })
+              .unwrap_or(@rabbita_runtime.none)
+            return (model, command)
+          }
           commit_block_toolbar_request(
             editor,
             model,
@@ -1169,6 +1194,7 @@ fn update_model(
             "loomark-toggle-list",
             emit,
           )
+        }
       }
     BlockDelete =>
       match active_block(model) {
@@ -1270,30 +1296,30 @@ fn update_model(
         None => (next, @rabbita_runtime.none)
       }
     }
-    BlockMerge(node_id~) => {
+    BlockMerge(node_id~, selection=originating_selection) => {
       let (next, committed_selection) = commit_block_request(
         editor,
         model,
         @markdown.MarkdownEditRequest::MergeWithPrevious(node_id~),
         "editor-dispatch",
       )
-      let selection = match committed_selection {
+      let resolved_selection = match committed_selection {
         Some(selection) => block_selection_from_commit(next.document, selection)
         None => None
       }
       let next = {
         ..next,
-        active_block_key: match selection {
+        active_block_key: match resolved_selection {
           Some(selection) => Some(selection.key)
           None => model.active_block_key
         },
-        selection: match selection {
+        selection: match resolved_selection {
           Some(selection) => Some(block_selection_label(selection))
           None => None
         },
       }
       publish(next)
-      match selection {
+      match resolved_selection {
         Some(selection) =>
           (
             next,
@@ -1304,9 +1330,36 @@ fn update_model(
               emit,
             ),
           )
-        None => (next, @rabbita_runtime.none)
+        None =>
+          (
+            next,
+            block_selection_after_render(
+              originating_selection,
+              next.source_revision,
+              emit,
+            ),
+          )
       }
     }
+    BlockNavigate(key~, direction~) =>
+      match block_navigation_selection(model.document, key, direction) {
+        None => {
+          publish(model)
+          (model, @rabbita_runtime.none)
+        }
+        Some(selection) => {
+          let next = {
+            ..model,
+            active_block_key: Some(selection.key),
+            selection: Some(block_selection_label(selection)),
+          }
+          publish(next)
+          (
+            next,
+            block_selection_after_render(selection, next.source_revision, emit),
+          )
+        }
+      }
     ProbeBlockSelection(kind) => {
       let blocks = model.document.blocks().to_array()
       if blocks.is_empty() {
@@ -1320,7 +1373,8 @@ fn update_model(
         let selection = BlockSelection::{
           key: block.key(),
           index: 0,
-          offset: 0,
+          start: 0,
+          end: 0,
         }
         let previous_revision = model.source_revision
         let source = if kind == "deleted" { "" } else { "replacement\n" }
@@ -1567,12 +1621,17 @@ fn update_model(
       publish(next)
       (next, @rabbita_runtime.none)
     }
-    BlockSelectionRejected(message) => {
+    BlockSelectionRejected(message, selection) => {
       let next = record_error(
         model, "block-selection-rejected", "browser-effect", message,
       )
       publish(next)
-      (next, @rabbita_runtime.none)
+      let command = match selection {
+        Some(selection) =>
+          block_selection_after_render(selection, next.source_revision, emit)
+        None => @rabbita_runtime.none
+      }
+      (next, command)
     }
     CustomEvent(detail) => {
       let next = {

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -405,6 +405,7 @@ fn commit_block_toolbar_request(
   editor : @markdown.MarkdownEditor,
   model : DriverModel,
   request : @markdown.MarkdownEditRequest,
+  originating_selection : BlockSelection?,
   control_id : String,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
@@ -434,7 +435,7 @@ fn commit_block_toolbar_request(
         block_selection_after_render(
           selection,
           next.source_revision,
-          skip_stale_revision=true,
+          report_superseded=false,
           emit,
         ),
       )
@@ -442,16 +443,29 @@ fn commit_block_toolbar_request(
       if applied {
         (next, @rabbita_runtime.none)
       } else {
-        (
-          next,
-          after_render(
-            scheduler => {
-              ignore(scheduler)
-              @dom_boundary.focus_id(control_id)
-            },
-            emit,
-          ),
-        )
+        match originating_selection {
+          Some(selection) =>
+            (
+              next,
+              block_selection_after_render(
+                selection,
+                next.source_revision,
+                report_superseded=true,
+                emit,
+              ),
+            )
+          None =>
+            (
+              next,
+              after_render(
+                scheduler => {
+                  ignore(scheduler)
+                  @dom_boundary.focus_id(control_id)
+                },
+                emit,
+              ),
+            )
+        }
       }
   }
 }
@@ -630,7 +644,7 @@ fn preview_view(
       @rui.button(
         variant=@rui.Ghost,
         size=@rui.Xs,
-        attrs=@html.Attrs::build().aria_label("Apply Blog example"),
+        attrs=@html.Attrs::build().aria_label("Guide: Apply Blog example"),
         on_click=emit(ReplaceSource(BLOG_EXAMPLE_SOURCE)),
         "Guide",
       ),
@@ -1127,6 +1141,7 @@ fn update_model(
                 block_selection_after_render(
                   selection,
                   model.source_revision,
+                  report_superseded=true,
                   emit,
                 )
               })
@@ -1140,6 +1155,7 @@ fn update_model(
                 block_selection_after_render(
                   selection,
                   model.source_revision,
+                  report_superseded=true,
                   emit,
                 )
               })
@@ -1157,6 +1173,7 @@ fn update_model(
               node_id=block.node_id(),
               level=target_level,
             ),
+            originating_selection,
             "loomark-heading-" + requested_level.to_string(),
             emit,
           )
@@ -1179,6 +1196,7 @@ fn update_model(
                 block_selection_after_render(
                   selection,
                   model.source_revision,
+                  report_superseded=true,
                   emit,
                 )
               })
@@ -1191,6 +1209,7 @@ fn update_model(
             @markdown.MarkdownEditRequest::ToggleListItem(
               node_id=block.node_id(),
             ),
+            originating_selection,
             "loomark-toggle-list",
             emit,
           )
@@ -1210,6 +1229,7 @@ fn update_model(
             editor,
             model,
             @markdown.MarkdownEditRequest::Delete(node_id=block.node_id()),
+            None,
             "loomark-delete-block",
             emit,
           )
@@ -1336,6 +1356,7 @@ fn update_model(
             block_selection_after_render(
               originating_selection,
               next.source_revision,
+              report_superseded=true,
               emit,
             ),
           )
@@ -1356,7 +1377,12 @@ fn update_model(
           publish(next)
           (
             next,
-            block_selection_after_render(selection, next.source_revision, emit),
+            block_selection_after_render(
+              selection,
+              next.source_revision,
+              report_superseded=true,
+              emit,
+            ),
           )
         }
       }
@@ -1628,7 +1654,12 @@ fn update_model(
       publish(next)
       let command = match selection {
         Some(selection) =>
-          block_selection_after_render(selection, next.source_revision, emit)
+          block_selection_after_render(
+            selection,
+            next.source_revision,
+            report_superseded=true,
+            emit,
+          )
         None => @rabbita_runtime.none
       }
       (next, command)

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -5,6 +5,10 @@ priv enum DriverEvent {
   SelectRaw
   SelectBlock
   SelectPreview
+  BlockFocused(String)
+  BlockHeading(Int)
+  BlockToggleList
+  BlockDelete
   RawInput(String)
   BlockInput(
     node_id~ : @markdown.MarkdownNodeId,
@@ -61,6 +65,7 @@ priv suberror DriverSubscription {
 priv struct DriverModel {
   state : @core.ApplicationState
   document : @markdown.MarkdownDocumentSnapshot
+  active_block_key : String?
   replica_id : String
   source_revision : Int
   fatal : Bool
@@ -393,6 +398,59 @@ fn commit_block_request(
 }
 
 ///|
+/// Reconcile one toolbar commit with the immutable block view and schedule
+/// the typed selection only after Rabbita renders that committed document.
+fn commit_block_toolbar_request(
+  editor : @markdown.MarkdownEditor,
+  model : DriverModel,
+  request : @markdown.MarkdownEditRequest,
+  control_id : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @cmd.Cmd) {
+  let (committed, committed_selection) = commit_block_request(
+    editor, model, request, "editor-dispatch",
+  )
+  let selection = committed_selection.bind(selection => {
+    block_selection_from_commit(committed.document, selection)
+  })
+  let applied = committed.source_revision != model.source_revision
+  let next = {
+    ..committed,
+    active_block_key: match selection {
+      Some(selection) => Some(selection.key)
+      None => if applied { None } else { model.active_block_key }
+    },
+    selection: match selection {
+      Some(selection) => Some(block_selection_label(selection))
+      None => if applied { None } else { committed.selection }
+    },
+  }
+  publish(next)
+  match selection {
+    Some(selection) =>
+      (
+        next,
+        block_selection_after_render(selection, next.source_revision, emit),
+      )
+    None =>
+      if applied {
+        (next, @rabbita_runtime.none)
+      } else {
+        (
+          next,
+          after_render(
+            scheduler => {
+              ignore(scheduler)
+              @dom_boundary.focus_id(control_id)
+            },
+            emit,
+          ),
+        )
+      }
+  }
+}
+
+///|
 fn publish(model : DriverModel) -> Unit {
   let fields : Map[String, Json] = {
     "source": model.document.source().to_json(),
@@ -677,11 +735,27 @@ fn preview_view(
                   .role("tabpanel")
                   .aria_labelledby(panel_labelledby),
                 style=["min-width:0;flex:1;display:flex"],
-                @html.div(
-                  id="loomark-surface",
-                  style=["width:100%;min-width:0;display:flex"],
-                  editor_surface(model, emit),
-                ),
+                if model.state.mode() == @core.Block {
+                  @html.div(
+                    style=[
+                      "width:100%;min-width:0;display:flex;flex-direction:column",
+                    ],
+                    [
+                      block_format_toolbar(model, emit),
+                      @html.div(
+                        id="loomark-surface",
+                        style=["width:100%;min-width:0;display:flex"],
+                        editor_surface(model, emit),
+                      ),
+                    ],
+                  )
+                } else {
+                  @html.div(
+                    id="loomark-surface",
+                    style=["width:100%;min-width:0;display:flex"],
+                    editor_surface(model, emit),
+                  )
+                },
               ),
             ],
           ),
@@ -812,6 +886,10 @@ fn driver_event_name(event : DriverEvent) -> String {
     SelectRaw => "select-raw"
     SelectBlock => "select-block"
     SelectPreview => "select-preview"
+    BlockFocused(_) => "block-focused"
+    BlockHeading(_) => "block-heading"
+    BlockToggleList => "block-toggle-list"
+    BlockDelete => "block-delete"
     RawInput(_) => "raw-input"
     BlockInput(..) => "block-input"
     BlockSplit(..) => "block-split"
@@ -965,7 +1043,11 @@ fn update_model(
     (
       event is BlockInput(..) ||
       event is BlockSplit(..) ||
-      event is BlockMerge(..)
+      event is BlockMerge(..) ||
+      event is BlockFocused(_) ||
+      event is BlockHeading(_) ||
+      event is BlockToggleList ||
+      event is BlockDelete
     ) {
     let next = record_error(
       model, "mode-inapplicable", "editor-dispatch", "Block editing is unavailable outside Block mode",
@@ -1001,6 +1083,111 @@ fn update_model(
       publish(next)
       (next, @rabbita_runtime.none)
     }
+    BlockFocused(key) =>
+      if model.active_block_key == Some(key) {
+        publish(model)
+        (model, @rabbita_runtime.none)
+      } else {
+        let (_, selected_index) = model.document
+          .blocks()
+          .fold(init=(0, None), (state, block) => {
+            let (index, found) = state
+            (
+              index + 1,
+              match found {
+                Some(_) => found
+                None => if block.key() == key { Some(index) } else { None }
+              },
+            )
+          })
+        match selected_index {
+          None => {
+            let next = record_error(
+              model, "block-selection-rejected", "editor-dispatch", "focused block is unavailable",
+            )
+            publish(next)
+            (next, @rabbita_runtime.none)
+          }
+          Some(index) => {
+            let next = { ..model, active_block_key: Some(key) }
+            publish(next)
+            (
+              next,
+              after_render(
+                scheduler => {
+                  ignore(scheduler)
+                  @dom_boundary.focus_id(block_input_id(index))
+                },
+                emit,
+              ),
+            )
+          }
+        }
+      }
+    BlockHeading(requested_level) =>
+      match active_block(model) {
+        None => {
+          let next = record_error(
+            model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
+          )
+          publish(next)
+          (next, @rabbita_runtime.none)
+        }
+        Some(block) => {
+          let target_level = match block.kind() {
+            @markdown.Heading(level~) if level == requested_level => 0
+            _ => requested_level
+          }
+          commit_block_toolbar_request(
+            editor,
+            model,
+            @markdown.MarkdownEditRequest::ChangeHeadingLevel(
+              node_id=block.node_id(),
+              level=target_level,
+            ),
+            "loomark-heading-" + requested_level.to_string(),
+            emit,
+          )
+        }
+      }
+    BlockToggleList =>
+      match active_block(model) {
+        None => {
+          let next = record_error(
+            model, "block-selection-rejected", "editor-dispatch", "formatting requires an active block",
+          )
+          publish(next)
+          (next, @rabbita_runtime.none)
+        }
+        Some(block) =>
+          commit_block_toolbar_request(
+            editor,
+            model,
+            @markdown.MarkdownEditRequest::ToggleListItem(
+              node_id=block.node_id(),
+            ),
+            "loomark-toggle-list",
+            emit,
+          )
+      }
+    BlockDelete =>
+      match active_block(model) {
+        None => {
+          let next = record_error(
+            model, "block-selection-rejected", "editor-dispatch", "deletion requires an active block",
+          )
+          publish(next)
+          (next, @rabbita_runtime.none)
+        }
+        Some(block) =>
+          commit_block_toolbar_request(
+            editor,
+            model,
+            @markdown.MarkdownEditRequest::Delete(node_id=block.node_id()),
+            "loomark-delete-block",
+            emit,
+          )
+      }
     BlockInput(node_id~, text~, selection_offset~) => {
       let (next, committed_selection) = commit_block_request(
         editor,
@@ -1022,6 +1209,10 @@ fn update_model(
       }
       let next = {
         ..next,
+        active_block_key: match selection {
+          Some(selection) => Some(selection.key)
+          None => model.active_block_key
+        },
         selection: match selection {
           Some(selection) => Some(block_selection_label(selection))
           None => None
@@ -1055,6 +1246,10 @@ fn update_model(
       }
       let next = {
         ..next,
+        active_block_key: match selection {
+          Some(selection) => Some(selection.key)
+          None => model.active_block_key
+        },
         selection: match selection {
           Some(selection) => Some(block_selection_label(selection))
           None => None
@@ -1088,6 +1283,10 @@ fn update_model(
       }
       let next = {
         ..next,
+        active_block_key: match selection {
+          Some(selection) => Some(selection.key)
+          None => model.active_block_key
+        },
         selection: match selection {
           Some(selection) => Some(block_selection_label(selection))
           None => None
@@ -1229,8 +1428,18 @@ fn update_model(
       let token = encode_focus_token(target, model.source_revision)
       match @core.decide_focus(model.state, model.source_revision, locator) {
         @core.Compatible(_) => {
-          publish(model)
-          (model, focus_latest_after_render(locator, token, emit))
+          let next = match target {
+            @core.BlockEditor => {
+              let active_block_key = model.document
+                .blocks()
+                .get(0)
+                .map(block => block.key())
+              { ..model, active_block_key, }
+            }
+            _ => model
+          }
+          publish(next)
+          (next, focus_latest_after_render(locator, token, emit))
         }
         @core.Rejected(error) => reject_focus(model, error)
       }
@@ -1241,9 +1450,19 @@ fn update_model(
         Ok(locator) =>
           match
             @core.decide_focus(model.state, model.source_revision, locator) {
-            @core.Compatible(_) => {
-              publish(model)
-              (model, focus_latest_after_render(locator, token, emit))
+            @core.Compatible(target) => {
+              let next = match target {
+                @core.BlockEditor => {
+                  let active_block_key = model.document
+                    .blocks()
+                    .get(0)
+                    .map(block => block.key())
+                  { ..model, active_block_key, }
+                }
+                _ => model
+              }
+              publish(next)
+              (next, focus_latest_after_render(locator, token, emit))
             }
             @core.Rejected(error) => reject_focus(model, error)
           }
@@ -1589,6 +1808,7 @@ pub fn mount(host_id : String, source : String) -> String {
   let initial : DriverModel = {
     state: @core.ApplicationState::ApplicationState(@core.Raw),
     document: editor.snapshot(),
+    active_block_key: None,
     replica_id,
     source_revision: 0,
     fatal: false,

--- a/loomark/internal/rabbita/application.mbt
+++ b/loomark/internal/rabbita/application.mbt
@@ -126,7 +126,7 @@ fn focus_target_id(target : @core.FocusTarget) -> String {
   match target {
     @core.RawEditor => "loomark-input"
     @core.BlockEditor => "loomark-block-input"
-    @core.PreviewControl => "loomark-focus-target"
+    @core.PreviewControl => "loomark-preview"
   }
 }
 
@@ -517,20 +517,11 @@ fn preview_view(
     on_click=emit(SelectBlock),
     "Block",
   )
-  let focus_button = @rui.button(
-    id="loomark-focus-target",
-    variant=@rui.Outline,
-    on_click=emit(FocusPreview),
-    "Focus preview",
-  )
-  let mode = @rui.typography_muted(
-    id="loomark-mode",
-    "mode: " + mode_name(model.state.mode()),
-  )
-  let event_button = @rui.button(
+  let event_button = @html.button(
     id="loomark-event-target",
-    variant=@rui.Outline,
-    "Dispatch event",
+    type_="button",
+    hidden=true,
+    "Driver event",
   )
   let driver_button = @html.button(
     id="loomark-driver-target",
@@ -538,9 +529,14 @@ fn preview_view(
     hidden=true,
     "Driver",
   )
-  let error_text = match model.error {
-    Some(error) => "error: " + error
-    None => "ready"
+  let error_view = match model.error {
+    Some(error) =>
+      @rui.alert(
+        id="loomark-error",
+        variant=@rui.Destructive,
+        @rui.alert_description("error: " + error),
+      )
+    None => @html.nothing
   }
   @rui.theme(
     id="loomark-root",
@@ -554,7 +550,6 @@ fn preview_view(
         style=["display:flex;gap:0.25rem;margin-block:1.5rem"],
         [raw_button, block_button, preview_button],
       ),
-      mode,
       @html.div(
         id="loomark-surface",
         style=["margin-block:1.5rem"],
@@ -562,8 +557,7 @@ fn preview_view(
       ),
       event_button,
       driver_button,
-      focus_button,
-      @rui.typography_muted(id="loomark-error", error_text),
+      error_view,
     ],
   )
 }
@@ -586,6 +580,8 @@ fn after_render(
 ///|
 /// Revalidate a structural selection after the edited blocks are rendered,
 /// then focus the exact block and restore its relative UTF-16 caret.
+/// Routine input may follow a newer render when keystrokes overtake one frame;
+/// its superseded callback yields while structural edits report stale revisions.
 fn block_selection_after_render(
   selection : BlockSelection,
   source_revision : Int,

--- a/loomark/internal/rabbita/block_surface.mbt
+++ b/loomark/internal/rabbita/block_surface.mbt
@@ -3,7 +3,8 @@
 priv struct BlockSelection {
   key : String
   index : Int
-  offset : Int
+  start : Int
+  end : Int
 }
 
 ///|
@@ -39,9 +40,98 @@ fn block_allows_list(kind : @markdown.MarkdownBlockKind) -> Bool {
 }
 
 ///|
+/// Decode structural keys without reading the DOM or reconstructing Markdown.
+fn block_structural_key_event(
+  kind : @markdown.MarkdownBlockKind,
+  node_id : @markdown.MarkdownNodeId,
+  key : String,
+  ctrl : Bool,
+  shift : Bool,
+  alt : Bool,
+  meta : Bool,
+  composing : Bool,
+  repeated : Bool,
+  selection : @dom_boundary.TextSelection,
+  text_length : Int,
+  has_previous : Bool,
+  has_next : Bool,
+  block_key : String,
+  block_index : Int,
+) -> DriverEvent? {
+  guard !ctrl && !shift && !alt && !meta && !composing && !repeated else {
+    return None
+  }
+  if key == "Enter" {
+    if block_allows_heading(kind) {
+      if selection.start() == selection.end() {
+        return Some(BlockSplit(node_id~, offset=selection.start()))
+      }
+      return Some(
+        BlockSelectionRejected(
+          "block split requires a collapsed selection",
+          Some({
+            key: block_key,
+            index: block_index,
+            start: selection.start(),
+            end: selection.end(),
+          }),
+        ),
+      )
+    }
+    if block_allows_list(kind) {
+      return Some(
+        BlockSelectionRejected(
+          "list structural editing is unavailable",
+          Some({
+            key: block_key,
+            index: block_index,
+            start: selection.start(),
+            end: selection.end(),
+          }),
+        ),
+      )
+    }
+  }
+  guard selection.start() == selection.end() else { return None }
+  match key {
+    "Backspace" if block_allows_heading(kind) &&
+      has_previous &&
+      text_length == 0 &&
+      selection.start() == 0 =>
+      Some(
+        BlockMerge(node_id~, selection={
+          key: block_key,
+          index: block_index,
+          start: selection.start(),
+          end: selection.end(),
+        }),
+      )
+    "Backspace" if has_previous && selection.start() == 0 =>
+      Some(BlockNavigate(key=block_key, direction=-1))
+    "ArrowLeft" | "ArrowUp" if has_previous && selection.start() == 0 =>
+      Some(BlockNavigate(key=block_key, direction=-1))
+    "ArrowRight" | "ArrowDown" if has_next && selection.start() == text_length =>
+      Some(BlockNavigate(key=block_key, direction=1))
+    _ => None
+  }
+}
+
+///|
+fn block_key_uses_selection(key : String) -> Bool {
+  match key {
+    "Enter"
+    | "Backspace"
+    | "ArrowLeft"
+    | "ArrowUp"
+    | "ArrowRight"
+    | "ArrowDown" => true
+    _ => false
+  }
+}
+
+///|
 /// Decode a keyboard value without reading or mutating the DOM.
 fn block_shortcut_event(
-  kind : @markdown.MarkdownBlockKind,
   key : String,
   ctrl : Bool,
   shift : Bool,
@@ -52,26 +142,28 @@ fn block_shortcut_event(
 ) -> DriverEvent? {
   guard ctrl && !alt && !meta && !composing && !repeated else { return None }
   if shift {
-    if block_allows_list(kind) && (key == "l" || key == "L") {
-      Some(BlockToggleList)
+    if key == "l" || key == "L" {
+      Some(BlockToggleList(None))
     } else {
       None
     }
-  } else if block_allows_heading(kind) {
+  } else {
     match key {
-      "1" => Some(BlockHeading(1))
-      "2" => Some(BlockHeading(2))
-      "3" => Some(BlockHeading(3))
+      "0" => Some(BlockHeading(0, None))
+      "1" => Some(BlockHeading(1, None))
+      "2" => Some(BlockHeading(2, None))
+      "3" => Some(BlockHeading(3, None))
+      "4" => Some(BlockHeading(4, None))
+      "5" => Some(BlockHeading(5, None))
+      "6" => Some(BlockHeading(6, None))
       _ => None
     }
-  } else {
-    None
   }
 }
 
 ///|
 fn block_selection_label(selection : BlockSelection) -> String {
-  "block|" + selection.key + "|" + selection.offset.to_string()
+  "block|" + selection.key + "|" + selection.start.to_string()
 }
 
 ///|
@@ -85,7 +177,7 @@ fn block_selection_from_commit(
     if block.node_id() == selection.node_id() {
       let (start, end) = block.text_range()
       if offset >= 0 && offset <= end - start {
-        return Some({ key: block.key(), index, offset })
+        return Some({ key: block.key(), index, start: offset, end: offset })
       }
     }
   }
@@ -102,7 +194,9 @@ fn block_selection_target(
     let block = blocks[selection.index]
     if block.key() == selection.key {
       let (start, end) = block.text_range()
-      if selection.offset >= 0 && selection.offset <= end - start {
+      if selection.start >= 0 &&
+        selection.start <= selection.end &&
+        selection.end <= end - start {
         return Some(selection.index)
       }
     }
@@ -111,9 +205,115 @@ fn block_selection_target(
 }
 
 ///|
+/// Resolve adjacent keyboard navigation against one immutable block snapshot.
+fn block_navigation_selection(
+  document : @markdown.MarkdownDocumentSnapshot,
+  key : String,
+  direction : Int,
+) -> BlockSelection? {
+  let blocks = document.blocks().to_array()
+  let current = blocks.search_by(block => block.key() == key)
+  guard current is Some(current) else { return None }
+  let target_index = current + direction
+  guard blocks.get(target_index) is Some(target) else { return None }
+  let offset = if direction < 0 { target.text().length() } else { 0 }
+  Some({ key: target.key(), index: target_index, start: offset, end: offset })
+}
+
+///|
+fn block_input_label(kind : @markdown.MarkdownBlockKind, index : Int) -> String {
+  let position = (index + 1).to_string()
+  match kind {
+    @markdown.Paragraph => "Paragraph block " + position
+    @markdown.Heading(level~) =>
+      "Heading " + level.to_string() + " block " + position
+    @markdown.UnorderedListItem => "Unordered list item " + position
+    @markdown.OrderedListItem(..) => "Ordered list item " + position
+    @markdown.CodeBlock(info~) =>
+      if info == "" {
+        "Code block " + position
+      } else {
+        info + " code block " + position
+      }
+  }
+}
+
+///|
+fn block_marker(kind : @markdown.MarkdownBlockKind) -> @html.Html {
+  match kind {
+    @markdown.UnorderedListItem =>
+      @html.span(
+        attrs=@html.Attrs::build()
+          .aria_hidden("true")
+          .data_set("loomark-block-marker", "unordered"),
+        style=[
+          "width:1.5rem;flex:0 0 1.5rem;padding-top:0.375rem;color:var(--rui-primary);font-weight:650;text-align:center;line-height:1.5rem",
+        ],
+        "•",
+      )
+    @markdown.OrderedListItem(start~, delimiter~) =>
+      @html.span(
+        attrs=@html.Attrs::build()
+          .aria_hidden("true")
+          .data_set("loomark-block-marker", "ordered"),
+        style=[
+          "width:1.5rem;flex:0 0 1.5rem;padding-top:0.375rem;color:var(--rui-primary);font-variant-numeric:tabular-nums;font-weight:650;text-align:right;line-height:1.5rem",
+        ],
+        start.to_string() + delimiter,
+      )
+    _ => @html.nothing
+  }
+}
+
+///|
+fn block_row_style(
+  kind : @markdown.MarkdownBlockKind,
+  active : Bool,
+) -> Array[String] {
+  let surface = match kind {
+    @markdown.CodeBlock(_) if active =>
+      "border-color:color-mix(in oklch,var(--rui-primary) 32%,var(--rui-border));background:var(--rui-muted)"
+    @markdown.CodeBlock(_) =>
+      "border-color:var(--rui-border);background:var(--rui-muted)"
+    _ if active =>
+      "border-color:color-mix(in oklch,var(--rui-primary) 24%,transparent);background:color-mix(in oklch,var(--rui-primary) 5%,transparent)"
+    _ => "border-color:transparent;background:transparent"
+  }
+  [
+    "display:flex;min-width:0;align-items:flex-start;gap:0.25rem;border:1px solid transparent;border-radius:calc(var(--rui-radius) - 0.125rem);padding:0.125rem 0.375rem;transition:background 120ms ease,border-color 120ms ease",
+    surface,
+  ]
+}
+
+///|
+fn block_input_style(kind : @markdown.MarkdownBlockKind) -> Array[String] {
+  let typography = match kind {
+    @markdown.Heading(level~) =>
+      match level {
+        1 =>
+          "font-size:2rem;font-weight:700;line-height:1.3;letter-spacing:-0.025em"
+        2 =>
+          "font-size:1.5rem;font-weight:650;line-height:1.35;letter-spacing:-0.018em"
+        3 =>
+          "font-size:1.25rem;font-weight:650;line-height:1.4;letter-spacing:-0.012em"
+        4 => "font-size:1.125rem;font-weight:650;line-height:1.45"
+        _ => "font-size:1rem;font-weight:650;line-height:1.5"
+      }
+    @markdown.CodeBlock(_) =>
+      "font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.6;tab-size:2;white-space:pre;overflow-x:auto"
+    _ => "font-size:1rem;font-weight:400;line-height:1.65"
+  }
+  [
+    "min-height:2.25rem;field-sizing:content;resize:none;overflow:hidden;--rui-control-base-border:transparent;--rui-control-base-shadow:none;--rui-control-base-bg:transparent;border-radius:0;background:transparent;padding:0.25rem 0.5rem",
+    typography,
+  ]
+}
+
+///|
 fn block_input(
   block : @markdown.MarkdownBlockSnapshot,
   index : Int,
+  count : Int,
   active : Bool,
   emit : @cmd.Emit[DriverEvent],
 ) -> @rabbita_runtime.Html {
@@ -121,9 +321,9 @@ fn block_input(
   let attrs = @html.Attrs::build()
     .data_set("loomark-block-id", block.key())
     .data_set("loomark-block-kind", block_kind_name(block.kind()))
+    .aria_label(block_input_label(block.kind(), index))
     .on_keydown(event => {
       let shortcut = block_shortcut_event(
-        block.kind(),
         event.key(),
         event.ctrl_key(),
         event.shift_key(),
@@ -134,8 +334,51 @@ fn block_input(
       )
       match shortcut {
         Some(shortcut) => {
+          let selection = @dom_boundary.read_text_selection_id(input_id) catch {
+            error => return emit(EffectFailed(error.message()))
+          }
+          let selection = Some({
+            key: block.key(),
+            index,
+            start: selection.start(),
+            end: selection.end(),
+          })
+          let shortcut = match shortcut {
+            BlockHeading(level, _) => BlockHeading(level, selection)
+            BlockToggleList(_) => BlockToggleList(selection)
+            shortcut => shortcut
+          }
           event.prevent_default()
           emit(shortcut)
+        }
+        None if block_key_uses_selection(event.key()) => {
+          let selection = @dom_boundary.read_text_selection_id(input_id) catch {
+            error => return emit(EffectFailed(error.message()))
+          }
+          match
+            block_structural_key_event(
+              block.kind(),
+              block.node_id(),
+              event.key(),
+              event.ctrl_key(),
+              event.shift_key(),
+              event.alt_key(),
+              event.meta_key(),
+              event.is_composing(),
+              event.repeat(),
+              selection,
+              block.text().length(),
+              index > 0,
+              index + 1 < count,
+              block.key(),
+              index,
+            ) {
+            Some(structural) => {
+              event.prevent_default()
+              emit(structural)
+            }
+            None => @rabbita_runtime.none
+          }
         }
         None => @rabbita_runtime.none
       }
@@ -145,31 +388,22 @@ fn block_input(
   } else {
     attrs.on_focus(_ => emit(BlockFocused(block.key())))
   }
-  let input = @html.textarea(
+  let input = @rui.textarea(
     id=input_id,
     value=block.text(),
-    rows=2,
+    rows=1,
+    slot="block-editor-input",
+    style=block_input_style(block.kind()),
     attrs~,
     on_input=@cmd.Emit(text => block_input_command(block, input_id, text, emit)),
-    "",
   )
-  let structure_controls = match block.kind() {
-    @markdown.Paragraph | @markdown.Heading(_) => {
-      let split = @html.button(
-        attrs=@html.Attrs::build().data_set("loomark-block-split", block.key()),
-        on_click=block_split_command(block, input_id, emit),
-        "Split",
-      )
-      let merge = @html.button(
-        attrs=@html.Attrs::build().data_set("loomark-block-merge", block.key()),
-        on_click=emit(BlockMerge(node_id=block.node_id())),
-        "Merge",
-      )
-      [split, merge]
-    }
-    _ => []
-  }
-  @html.div([input, ..structure_controls])
+  @html.div(
+    attrs=@html.Attrs::build()
+      .data_set("loomark-block-row", block.key())
+      .data_set("loomark-block-active", active.to_string()),
+    style=block_row_style(block.kind(), active),
+    [block_marker(block.kind()), input],
+  )
 }
 
 ///|
@@ -178,10 +412,12 @@ fn block_surface(
   emit : @cmd.Emit[DriverEvent],
 ) -> @rabbita_runtime.Html {
   let controls : Map[String, @rabbita_runtime.Html] = Map([])
-  for index, block in model.document.blocks().to_array() {
+  let blocks = model.document.blocks().to_array()
+  for index, block in blocks {
     controls[block.key()] = block_input(
       block,
       index,
+      blocks.length(),
       model.active_block_key == Some(block.key()),
       emit,
     )
@@ -192,6 +428,9 @@ fn block_surface(
       "loomark-source",
       model.document.source(),
     ),
+    style=[
+      "width:100%;min-width:0;display:flex;flex-direction:column;gap:0.25rem;padding:clamp(0.75rem,2vw,1rem)",
+    ],
     controls,
   )
 }

--- a/loomark/internal/rabbita/block_surface.mbt
+++ b/loomark/internal/rabbita/block_surface.mbt
@@ -27,6 +27,49 @@ fn block_kind_name(kind : @markdown.MarkdownBlockKind) -> String {
 }
 
 ///|
+fn block_allows_heading(kind : @markdown.MarkdownBlockKind) -> Bool {
+  kind is @markdown.Paragraph || kind is @markdown.Heading(_)
+}
+
+///|
+fn block_allows_list(kind : @markdown.MarkdownBlockKind) -> Bool {
+  kind is @markdown.Paragraph ||
+  kind is @markdown.UnorderedListItem ||
+  kind is @markdown.OrderedListItem(..)
+}
+
+///|
+/// Decode a keyboard value without reading or mutating the DOM.
+fn block_shortcut_event(
+  kind : @markdown.MarkdownBlockKind,
+  key : String,
+  ctrl : Bool,
+  shift : Bool,
+  alt : Bool,
+  meta : Bool,
+  composing : Bool,
+  repeated : Bool,
+) -> DriverEvent? {
+  guard ctrl && !alt && !meta && !composing && !repeated else { return None }
+  if shift {
+    if block_allows_list(kind) && (key == "l" || key == "L") {
+      Some(BlockToggleList)
+    } else {
+      None
+    }
+  } else if block_allows_heading(kind) {
+    match key {
+      "1" => Some(BlockHeading(1))
+      "2" => Some(BlockHeading(2))
+      "3" => Some(BlockHeading(3))
+      _ => None
+    }
+  } else {
+    None
+  }
+}
+
+///|
 fn block_selection_label(selection : BlockSelection) -> String {
   "block|" + selection.key + "|" + selection.offset.to_string()
 }
@@ -71,12 +114,37 @@ fn block_selection_target(
 fn block_input(
   block : @markdown.MarkdownBlockSnapshot,
   index : Int,
+  active : Bool,
   emit : @cmd.Emit[DriverEvent],
 ) -> @rabbita_runtime.Html {
   let input_id = block_input_id(index)
   let attrs = @html.Attrs::build()
     .data_set("loomark-block-id", block.key())
     .data_set("loomark-block-kind", block_kind_name(block.kind()))
+    .on_keydown(event => {
+      let shortcut = block_shortcut_event(
+        block.kind(),
+        event.key(),
+        event.ctrl_key(),
+        event.shift_key(),
+        event.alt_key(),
+        event.meta_key(),
+        event.is_composing(),
+        event.repeat(),
+      )
+      match shortcut {
+        Some(shortcut) => {
+          event.prevent_default()
+          emit(shortcut)
+        }
+        None => @rabbita_runtime.none
+      }
+    })
+  let attrs = if active {
+    attrs
+  } else {
+    attrs.on_focus(_ => emit(BlockFocused(block.key())))
+  }
   let input = @html.textarea(
     id=input_id,
     value=block.text(),
@@ -111,7 +179,12 @@ fn block_surface(
 ) -> @rabbita_runtime.Html {
   let controls : Map[String, @rabbita_runtime.Html] = Map([])
   for index, block in model.document.blocks().to_array() {
-    controls[block.key()] = block_input(block, index, emit)
+    controls[block.key()] = block_input(
+      block,
+      index,
+      model.active_block_key == Some(block.key()),
+      emit,
+    )
   }
   @html.div(
     id="loomark-block",

--- a/loomark/internal/rabbita/block_toolbar.mbt
+++ b/loomark/internal/rabbita/block_toolbar.mbt
@@ -16,6 +16,37 @@ fn active_block(model : DriverModel) -> @markdown.MarkdownBlockSnapshot? {
 }
 
 ///|
+/// Resolve a keyboard event's stable typed target before falling back to the
+/// toolbar selection, whose focus event may still be queued.
+fn block_format_target(
+  model : DriverModel,
+  selection : BlockSelection?,
+) -> @markdown.MarkdownBlockSnapshot? {
+  match selection {
+    None => active_block(model)
+    Some(selection) => {
+      let exact = model.document
+        .blocks()
+        .fold(init=None, (selected, block) => {
+          match selected {
+            Some(_) => selected
+            None =>
+              if block.key() == selection.key {
+                Some(block)
+              } else {
+                None
+              }
+          }
+        })
+      match exact {
+        Some(_) => exact
+        None => active_block(model)
+      }
+    }
+  }
+}
+
+///|
 fn heading_toolbar_button(
   level : Int,
   selected_level : Int?,
@@ -34,7 +65,7 @@ fn heading_toolbar_button(
       .aria_label(label)
       .aria_keyshortcuts(shortcut)
       .aria_pressed((selected_level == Some(level)).to_string()),
-    on_click=emit(BlockHeading(level)),
+    on_click=emit(BlockHeading(level, None)),
     "H" + level.to_string(),
   )
 }
@@ -56,7 +87,7 @@ fn list_toolbar_button(
       .aria_label(label)
       .aria_keyshortcuts("Control+Shift+L")
       .aria_pressed(selected.to_string()),
-    on_click=emit(BlockToggleList),
+    on_click=emit(BlockToggleList(None)),
     mode_icon("M6 6h11M6 10h11M6 14h11M3 6h.01M3 10h.01M3 14h.01"),
   )
 }
@@ -68,7 +99,7 @@ fn delete_toolbar_button(
 ) -> @html.Html {
   @rui.button(
     id="loomark-delete-block",
-    variant=@rui.Destructive,
+    variant=@rui.Ghost,
     size=@rui.IconSm,
     disabled~,
     title="Delete block",

--- a/loomark/internal/rabbita/block_toolbar.mbt
+++ b/loomark/internal/rabbita/block_toolbar.mbt
@@ -54,7 +54,12 @@ fn heading_toolbar_button(
   emit : @cmd.Emit[DriverEvent],
 ) -> @html.Html {
   let shortcut = "Control+" + level.to_string()
-  let label = "Heading " + level.to_string() + ", Ctrl+" + level.to_string()
+  let visible_label = "H" + level.to_string()
+  let label = visible_label +
+    ": Heading " +
+    level.to_string() +
+    ", Ctrl+" +
+    level.to_string()
   @rui.button(
     id="loomark-heading-" + level.to_string(),
     variant=@rui.Ghost,
@@ -66,7 +71,7 @@ fn heading_toolbar_button(
       .aria_keyshortcuts(shortcut)
       .aria_pressed((selected_level == Some(level)).to_string()),
     on_click=emit(BlockHeading(level, None)),
-    "H" + level.to_string(),
+    visible_label,
   )
 }
 

--- a/loomark/internal/rabbita/block_toolbar.mbt
+++ b/loomark/internal/rabbita/block_toolbar.mbt
@@ -1,0 +1,126 @@
+///|
+/// Resolve transient application selection only through the typed snapshot.
+fn active_block(model : DriverModel) -> @markdown.MarkdownBlockSnapshot? {
+  match model.active_block_key {
+    None => None
+    Some(key) =>
+      model.document
+      .blocks()
+      .fold(init=None, (selected, block) => {
+        match selected {
+          Some(_) => selected
+          None => if block.key() == key { Some(block) } else { None }
+        }
+      })
+  }
+}
+
+///|
+fn heading_toolbar_button(
+  level : Int,
+  selected_level : Int?,
+  disabled : Bool,
+  emit : @cmd.Emit[DriverEvent],
+) -> @html.Html {
+  let shortcut = "Control+" + level.to_string()
+  let label = "Heading " + level.to_string() + ", Ctrl+" + level.to_string()
+  @rui.button(
+    id="loomark-heading-" + level.to_string(),
+    variant=@rui.Ghost,
+    size=@rui.Sm,
+    disabled~,
+    title=label,
+    attrs=@html.Attrs::build()
+      .aria_label(label)
+      .aria_keyshortcuts(shortcut)
+      .aria_pressed((selected_level == Some(level)).to_string()),
+    on_click=emit(BlockHeading(level)),
+    "H" + level.to_string(),
+  )
+}
+
+///|
+fn list_toolbar_button(
+  selected : Bool,
+  disabled : Bool,
+  emit : @cmd.Emit[DriverEvent],
+) -> @html.Html {
+  let label = "Toggle list, Ctrl+Shift+L"
+  @rui.button(
+    id="loomark-toggle-list",
+    variant=@rui.Ghost,
+    size=@rui.Sm,
+    disabled~,
+    title=label,
+    attrs=@html.Attrs::build()
+      .aria_label(label)
+      .aria_keyshortcuts("Control+Shift+L")
+      .aria_pressed(selected.to_string()),
+    on_click=emit(BlockToggleList),
+    mode_icon("M6 6h11M6 10h11M6 14h11M3 6h.01M3 10h.01M3 14h.01"),
+  )
+}
+
+///|
+fn delete_toolbar_button(
+  disabled : Bool,
+  emit : @cmd.Emit[DriverEvent],
+) -> @html.Html {
+  @rui.button(
+    id="loomark-delete-block",
+    variant=@rui.Destructive,
+    size=@rui.IconSm,
+    disabled~,
+    title="Delete block",
+    attrs=@html.Attrs::build().aria_label("Delete selected block"),
+    on_click=emit(BlockDelete),
+    mode_icon("M4 6h12M8 3h4l1 3H7l1-3M6 6l.7 11h6.6L14 6M8.5 9v5M11.5 9v5"),
+  )
+}
+
+///|
+fn block_format_toolbar(
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @html.Html {
+  let selected = active_block(model)
+  let selected_level = selected.bind(block => {
+    match block.kind() {
+      @markdown.Heading(level~) => Some(level)
+      _ => None
+    }
+  })
+  let heading_allowed = selected
+    .map(block => block_allows_heading(block.kind()))
+    .unwrap_or(false)
+  let selected_list = selected
+    .map(block => {
+      match block.kind() {
+        @markdown.UnorderedListItem | @markdown.OrderedListItem(..) => true
+        _ => false
+      }
+    })
+    .unwrap_or(false)
+  let list_allowed = selected
+    .map(block => block_allows_list(block.kind()))
+    .unwrap_or(false)
+  let delete_disabled = selected is None
+  @html.div(
+    attrs=@html.Attrs::build().role("toolbar").aria_label("Block formatting"),
+    style=[
+      "display:flex;min-height:3.75rem;box-sizing:border-box;align-items:center;justify-content:space-between;padding:0.75rem 1rem;border-bottom:1px solid var(--rui-border)",
+    ],
+    [
+      @rui.button_group(aria_label="Block style", [
+        heading_toolbar_button(1, selected_level, !heading_allowed, emit),
+        heading_toolbar_button(2, selected_level, !heading_allowed, emit),
+        heading_toolbar_button(3, selected_level, !heading_allowed, emit),
+        @rui.button_group_separator(),
+        list_toolbar_button(selected_list, !list_allowed, emit),
+      ]),
+      @rui.button_group(aria_label="Block actions", [
+        delete_toolbar_button(delete_disabled, emit),
+      ]),
+    ],
+  )
+}

--- a/loomark/internal/rabbita/moon.pkg
+++ b/loomark/internal/rabbita/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbit-community/rabbita/common",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
+  "Yoorkin/rui",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/ref",

--- a/loomark/internal/rabbita/moon.pkg
+++ b/loomark/internal/rabbita/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbit-community/rabbita/common",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/svg",
   "Yoorkin/rui",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",

--- a/loomark/internal/rabbita/preview_surface.mbt
+++ b/loomark/internal/rabbita/preview_surface.mbt
@@ -101,6 +101,7 @@ fn preview_surface(
     id="loomark-preview",
     attrs=@html.Attrs::build()
       .data_set("loomark-source", source)
+      .role("region")
       .tabindex(0)
       .aria_label("Markdown preview"),
     style=["display:grid;gap:1rem"],

--- a/loomark/internal/rabbita/preview_surface.mbt
+++ b/loomark/internal/rabbita/preview_surface.mbt
@@ -1,0 +1,106 @@
+///|
+fn preview_block_attrs(block : @markdown.MarkdownBlockSnapshot) -> @html.Attrs {
+  @html.Attrs::build()
+  .data_set("loomark-block-id", block.key())
+  .data_set("loomark-block-kind", block_kind_name(block.kind()))
+}
+
+///|
+fn preview_heading(
+  level : Int,
+  block : @markdown.MarkdownBlockSnapshot,
+) -> @rabbita_runtime.Html {
+  let attrs = preview_block_attrs(block)
+  let text = block.text()
+  match level {
+    1 => @rui.typography_h1(style=["text-align:start"], attrs~, text)
+    2 => @rui.typography_h2(attrs~, text)
+    3 => @rui.typography_h3(attrs~, text)
+    4 => @rui.typography_h4(attrs~, text)
+    5 =>
+      @html.h5(
+        style=["margin:0;font-size:1rem;line-height:1.5rem;font-weight:600"],
+        attrs~,
+        text,
+      )
+    _ =>
+      @html.h6(
+        style=[
+          "margin:0;font-size:0.875rem;line-height:1.25rem;font-weight:600",
+        ],
+        attrs~,
+        text,
+      )
+  }
+}
+
+///|
+fn preview_raw_list_item(
+  source : String,
+  kind : String,
+  block : @markdown.MarkdownBlockSnapshot,
+) -> @rabbita_runtime.Html {
+  let (start, end) = block.source_range()
+  @html.pre(
+    style=[
+      "margin:0;overflow:auto;border-radius:var(--rui-radius,0.625rem);background:var(--rui-muted,oklch(0.97 0 0));padding:0.75rem 1rem",
+    ],
+    attrs=preview_block_attrs(block).data_set(
+      "loomark-preview-raw-list-item", kind,
+    ),
+    source[start:end].to_owned(),
+  )
+}
+
+///|
+fn preview_block(
+  source : String,
+  block : @markdown.MarkdownBlockSnapshot,
+) -> @rabbita_runtime.Html {
+  let attrs = preview_block_attrs(block)
+  match block.kind() {
+    @markdown.Paragraph => @rui.typography_p(attrs~, block.text())
+    @markdown.Heading(level~) => preview_heading(level, block)
+    @markdown.UnorderedListItem =>
+      preview_raw_list_item(source, "unordered", block)
+    @markdown.OrderedListItem(..) =>
+      preview_raw_list_item(source, "ordered", block)
+    @markdown.CodeBlock(info~) => {
+      let code_attrs = @html.Attrs::build().data_set("loomark-code-info", info)
+      @html.pre(
+        style=[
+          "margin:0;overflow:auto;border-radius:var(--rui-radius,0.625rem);background:var(--rui-muted,oklch(0.97 0 0));padding:1rem",
+        ],
+        attrs~,
+        @html.code(
+          style=[
+            "font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.5rem",
+          ],
+          attrs=code_attrs,
+          block.text(),
+        ),
+      )
+    }
+  }
+}
+
+///|
+fn preview_surface(
+  document : @markdown.MarkdownDocumentSnapshot,
+) -> @rabbita_runtime.Html {
+  let source = document.source()
+  let blocks : Map[String, @rabbita_runtime.Html] = Map([])
+  blocks["preview-scope-notice"] = @rui.typography_muted(
+    attrs=@html.Attrs::build().data_set("loomark-preview-notice", ""),
+    "Prototype preview shows supported top-level blocks. Use Raw for the complete source.",
+  )
+  for block in document.blocks().to_array() {
+    blocks[block.key()] = preview_block(source, block)
+  }
+  @html.div(
+    id="loomark-preview",
+    attrs=@html.Attrs::build().data_set("loomark-source", source),
+    style=["display:grid;gap:1rem"],
+    blocks,
+  )
+}

--- a/loomark/internal/rabbita/preview_surface.mbt
+++ b/loomark/internal/rabbita/preview_surface.mbt
@@ -99,7 +99,10 @@ fn preview_surface(
   }
   @html.div(
     id="loomark-preview",
-    attrs=@html.Attrs::build().data_set("loomark-source", source),
+    attrs=@html.Attrs::build()
+      .data_set("loomark-source", source)
+      .tabindex(0)
+      .aria_label("Markdown preview"),
     style=["display:grid;gap:1rem"],
     blocks,
   )

--- a/loomark/moon.mod
+++ b/loomark/moon.mod
@@ -7,6 +7,7 @@ import {
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",
   "moonbit-community/rabbita@0.14.1",
+  "Yoorkin/rui@0.1.1",
 }
 
 license = "Apache-2.0"

--- a/moon.work
+++ b/moon.work
@@ -2,6 +2,7 @@ members = [
   ".",
   "./loomark",
   "./rabbita/rabbita",
+  "./rabbita/rui",
   "./graphviz",
   "./svg-dsl",
   "./alga",


### PR DESCRIPTION
## Summary

- render the private Loomark Raw, Block, and Preview surfaces with Rabbita RUI components and production-aligned chrome
- add typed Block formatting, keyboard split/merge/navigation, stable focus and UTF-16 selection restoration
- edit paragraphs, headings, tight list items, and fenced code while preserving canonical Markdown markers and line endings
- reject unsupported list/container structure changes without mutating source or losing the active selection

## Reuse check

Reuses the existing `editor/markdown` façade requests and immutable snapshots, Rabbita RUI textarea/button components, `Cmd` AfterRender effects, and `lib/dom-boundary` focus/selection operations. MoonBit `Option`, `Array::search_by`/`get`, `String::length`, and immutable snapshot views cover the new decisions. No Markdown parser, handwritten Markdown JavaScript, or public mutable collection was added.

Checked but not used: raw `@html.textarea` was replaced by the controlled RUI textarea; `Map`/`Set`, `StringView`, and builders were unnecessary because this change neither parses nor reconstructs Markdown; `Array::find` is unavailable, so the existing search/fold APIs are used.

New private helpers are limited to pure keyboard decoding, adjacent-block resolution, typed block labels/markers/styles, and keyboard target resolution. Remaining imperative code only reads or restores DOM focus and selection after Rabbita renders.

## Validation

- clean-HEAD `./scripts/validate-pr-ready.sh --target editor/markdown`
- clean-HEAD `./scripts/validate-pr-ready.sh --target loomark/internal/rabbita`
- Markdown editor tests: 57 passed
- JavaScript artifact build
- Vanilla host TypeScript check
- Chromium dev-host suite: 57 passed
- independent MoonBit/Rabbita review: no remaining blockers
- generated `.mbti` changes: none

Validated HEAD: `3f70bdfadf0ca773a515903d7e63ef9fd1db4818`

Validated base: `ace0cd5f988ad79ba59580ca75780bb37b34ca13`

## Deferred

MoveBlock, rich inline editing, nested or loose-list structural editing, public Session/unmount, Waku cutover, and React/Vue adapters remain outside this prototype.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added block-based Markdown editing with headings, lists, deletion, keyboard navigation, and formatting controls.
  * Added accessible Preview rendering for headings, paragraphs, lists, and code blocks.
  * Added example documents, responsive layout, focus handling, and clearer error feedback.
* **Bug Fixes**
  * Improved cursor placement after deletions and structural edits.
  * Preserved line endings and blank-line spacing when toggling list items.
* **Tests**
  * Expanded coverage for editing, accessibility, preview behavior, navigation, focus restoration, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->