### PR TITLE
chore: migrate Canopy to Incr v0.15.0

### DIFF
--- a/examples/canvas/moon.mod
+++ b/examples/canvas/moon.mod
@@ -8,7 +8,7 @@ import {
   "dowdiness/canopy-canvas-graph@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/rabbita_codemirror@0.0.1",
-  "dowdiness/incr@0.14.2",
+  "dowdiness/incr@0.15.0",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",
   "dowdiness/rabbita-menu@0.1.0",

--- a/lib/cognition/moon.mod
+++ b/lib/cognition/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/cognition"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.14.2",
+  "dowdiness/incr@0.15.0",
 }
 
 repository = "https://github.com/dowdiness/canopy"

--- a/lib/semantic/annotate_test.mbt
+++ b/lib/semantic/annotate_test.mbt
@@ -1,8 +1,8 @@
 ///|
 test "heading then paragraph → SectionIntro" {
-  let doc = @md.Document([
-    @md.Heading(1, [@md.Text("Title")]),
-    @md.Paragraph([@md.Text("Introduction")]),
+  let doc = @md.Block::Document([
+    @md.Block::Heading(1, [@md.Inline::Text("Title")]),
+    @md.Block::Paragraph([@md.Inline::Text("Introduction")]),
   ])
   let map = annotate_symbolic(doc)
   inspect(map[1], content="RuleBased(SectionIntro)")
@@ -11,9 +11,9 @@ test "heading then paragraph → SectionIntro" {
 
 ///|
 test "first paragraph → Abstract" {
-  let doc = @md.Document([
-    @md.Paragraph([@md.Text("Opening paragraph")]),
-    @md.Paragraph([@md.Text("Second paragraph")]),
+  let doc = @md.Block::Document([
+    @md.Block::Paragraph([@md.Inline::Text("Opening paragraph")]),
+    @md.Block::Paragraph([@md.Inline::Text("Second paragraph")]),
   ])
   let map = annotate_symbolic(doc)
   inspect(map[0], content="RuleBased(Abstract)")
@@ -22,11 +22,11 @@ test "first paragraph → Abstract" {
 
 ///|
 test "paragraph before code block → CodeExplanation" {
-  let doc = @md.Document([
-    @md.Heading(2, [@md.Text("Example")]),
-    @md.Paragraph([@md.Text("Section intro")]),
-    @md.Paragraph([@md.Text("Here is the code:")]),
-    @md.CodeBlock("moonbit", "let x = 1"),
+  let doc = @md.Block::Document([
+    @md.Block::Heading(2, [@md.Inline::Text("Example")]),
+    @md.Block::Paragraph([@md.Inline::Text("Section intro")]),
+    @md.Block::Paragraph([@md.Inline::Text("Here is the code:")]),
+    @md.Block::CodeBlock("moonbit", "let x = 1"),
   ])
   let map = annotate_symbolic(doc)
   inspect(map[1], content="RuleBased(SectionIntro)")
@@ -35,11 +35,11 @@ test "paragraph before code block → CodeExplanation" {
 
 ///|
 test "list after heading → KeyPoints" {
-  let doc = @md.Document([
-    @md.Heading(1, [@md.Text("Features")]),
-    @md.UnorderedList([
-      @md.UnorderedListItem([@md.Text("Fast")]),
-      @md.UnorderedListItem([@md.Text("Safe")]),
+  let doc = @md.Block::Document([
+    @md.Block::Heading(1, [@md.Inline::Text("Features")]),
+    @md.Block::UnorderedList([
+      @md.Block::UnorderedListItem([@md.Inline::Text("Fast")]),
+      @md.Block::UnorderedListItem([@md.Inline::Text("Safe")]),
     ]),
   ])
   let map = annotate_symbolic(doc)
@@ -48,12 +48,12 @@ test "list after heading → KeyPoints" {
 
 ///|
 test "ordered list after heading → KeyPoints" {
-  let doc = @md.Document([
-    @md.Heading(1, [@md.Text("Steps")]),
-    @md.OrderedList(
+  let doc = @md.Block::Document([
+    @md.Block::Heading(1, [@md.Inline::Text("Steps")]),
+    @md.Block::OrderedList(
       [
-        @md.OrderedListItem([@md.Text("First")], None),
-        @md.OrderedListItem([@md.Text("Second")], None),
+        @md.Block::OrderedListItem([@md.Inline::Text("First")], None),
+        @md.Block::OrderedListItem([@md.Inline::Text("Second")], None),
       ],
       None,
     ),
@@ -64,10 +64,10 @@ test "ordered list after heading → KeyPoints" {
 
 ///|
 test "SectionIntro takes priority over CodeExplanation" {
-  let doc = @md.Document([
-    @md.Heading(1, [@md.Text("Demo")]),
-    @md.Paragraph([@md.Text("After heading and before code")]),
-    @md.CodeBlock("", "x = 1"),
+  let doc = @md.Block::Document([
+    @md.Block::Heading(1, [@md.Inline::Text("Demo")]),
+    @md.Block::Paragraph([@md.Inline::Text("After heading and before code")]),
+    @md.Block::CodeBlock("", "x = 1"),
   ])
   let map = annotate_symbolic(doc)
   inspect(map[1], content="RuleBased(SectionIntro)")
@@ -75,23 +75,23 @@ test "SectionIntro takes priority over CodeExplanation" {
 
 ///|
 test "non-Document input → empty array" {
-  let block = @md.Paragraph([@md.Text("just a paragraph")])
+  let block = @md.Block::Paragraph([@md.Inline::Text("just a paragraph")])
   let map = annotate_symbolic(block)
   inspect(map.length(), content="0")
 }
 
 ///|
 test "empty document → empty array" {
-  let doc = @md.Document([])
+  let doc = @md.Block::Document([])
   let map = annotate_symbolic(doc)
   inspect(map.length(), content="0")
 }
 
 ///|
 test "heading first, paragraph later → no Abstract" {
-  let doc = @md.Document([
-    @md.Heading(1, [@md.Text("Title")]),
-    @md.Paragraph([@md.Text("This is not Abstract")]),
+  let doc = @md.Block::Document([
+    @md.Block::Heading(1, [@md.Inline::Text("Title")]),
+    @md.Block::Paragraph([@md.Inline::Text("This is not Abstract")]),
   ])
   let map = annotate_symbolic(doc)
   // Not index 0, so not Abstract. After heading, so SectionIntro.
@@ -101,17 +101,17 @@ test "heading first, paragraph later → no Abstract" {
 
 ///|
 test "mixed document — full annotation" {
-  let doc = @md.Document([
-    @md.Paragraph([@md.Text("Abstract paragraph")]),
-    @md.Heading(1, [@md.Text("Overview")]),
-    @md.Paragraph([@md.Text("Section intro")]),
-    @md.Heading(2, [@md.Text("Features")]),
-    @md.UnorderedList([
-      @md.UnorderedListItem([@md.Text("A")]),
-      @md.UnorderedListItem([@md.Text("B")]),
+  let doc = @md.Block::Document([
+    @md.Block::Paragraph([@md.Inline::Text("Abstract paragraph")]),
+    @md.Block::Heading(1, [@md.Inline::Text("Overview")]),
+    @md.Block::Paragraph([@md.Inline::Text("Section intro")]),
+    @md.Block::Heading(2, [@md.Inline::Text("Features")]),
+    @md.Block::UnorderedList([
+      @md.Block::UnorderedListItem([@md.Inline::Text("A")]),
+      @md.Block::UnorderedListItem([@md.Inline::Text("B")]),
     ]),
-    @md.Paragraph([@md.Text("Code explanation")]),
-    @md.CodeBlock("moonbit", "fn main {}"),
+    @md.Block::Paragraph([@md.Inline::Text("Code explanation")]),
+    @md.Block::CodeBlock("moonbit", "fn main {}"),
   ])
   let map = annotate_symbolic(doc)
   inspect(map[0], content="RuleBased(Abstract)")

--- a/lib/visualizer/moon.mod
+++ b/lib/visualizer/moon.mod
@@ -3,7 +3,7 @@ name = "dowdiness/visualizer"
 version = "0.1.0"
 
 import {
-  "dowdiness/incr@0.14.2",
+  "dowdiness/incr@0.15.0",
   "dowdiness/graphviz@0.1.0",
   "dowdiness/svg-dsl@0.1.0",
   "dowdiness/alga@0.3.0",

--- a/moon.mod
+++ b/moon.mod
@@ -6,7 +6,7 @@ import {
   "moonbitlang/quickcheck@0.14.0",
   "moonbitlang/x@0.4.38",
   "moonbitlang/async@0.20.1",
-  "dowdiness/incr@0.14.2",
+  "dowdiness/incr@0.15.0",
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/event-graph-walker@0.6.0",
   "dowdiness/byte_codec@0.1.0",

--- a/workspace/probe/gate1_runtime_safety_wbtest.mbt
+++ b/workspace/probe/gate1_runtime_safety_wbtest.mbt
@@ -140,10 +140,10 @@ test "P0a gate #1 §A control — single registered callback fires once per bump
 
 ///|
 // ============================================================
-// §B — gc() collects unrooted Memos; observer-rooted Memos survive.
+// §B — gc() collects unrooted Deriveds; watch-rooted Deriveds survive.
 //
 // Holding a MoonBit parser binding does NOT pin its Runtime-side cells —
-// gc_roots are explicit (`add_gc_root`, exposed via `Memo::observe`)
+// gc_roots are explicit (`add_gc_root`, exposed via `Derived::watch`)
 // plus implicit (gc_role = Root cells, i.e. Effects). Production canopy
 // creates zero Effects in the editor/parser stack, and Memos are
 // `gc_role = Interior` (memo_data.mbt:46-48). So a shared-runtime
@@ -151,7 +151,7 @@ test "P0a gate #1 §A control — single registered callback fires once per bump
 // surviving editor's.
 //
 // To attribute the collect to "parser A specifically" we root parser
-// B's source view through Observer (observer.mbt:64-79).
+// B's source view through Watch.
 //
 // Trick — calling rt.gc() requires `phase is Idle`. set_source ran
 // inside rt.batch internally; the batch closes before set_source
@@ -161,7 +161,7 @@ test "P0a gate #1 §A control — single registered callback fires once per bump
 // ============================================================
 
 ///|
-test "P0a gate #1 §B — gc collects unrooted Memos; observer-rooted Memos survive" {
+test "P0a gate #1 §B — gc collects unrooted Deriveds; watch-rooted Deriveds survive" {
   let shared_rt = @incr.Runtime()
   let parser_a = json_parser_on(shared_rt, "[1]")
   let parser_b = json_parser_on(shared_rt, "[2]")
@@ -176,9 +176,9 @@ test "P0a gate #1 §B — gc collects unrooted Memos; observer-rooted Memos surv
   inspect(shared_rt.cell_info(id_a) is Some(_), content="true")
   inspect(shared_rt.cell_info(id_b) is Some(_), content="true")
 
-  // Root parser B's source view through an Observer; leave parser A
+  // Root parser B's source view through a Watch; leave parser A
   // unobserved.
-  let observer_b = parser_b.source().observe()
+  let watch_b = parser_b.source().watch()
 
   // gc() twice (Codex finding (d) — second call drains any post-mark
   // broadcast queue).
@@ -188,7 +188,7 @@ test "P0a gate #1 §B — gc collects unrooted Memos; observer-rooted Memos surv
   // Verdict: parser A's source was collected; parser B's survived.
   inspect(shared_rt.cell_info(id_a) is None, content="true")
   inspect(shared_rt.cell_info(id_b) is Some(_), content="true")
-  observer_b.dispose()
+  watch_b.dispose()
 }
 
 ///|
@@ -197,7 +197,7 @@ test "P0a gate #1 §B — gc collects unrooted Memos; observer-rooted Memos surv
 /// (expected on a shared runtime with no explicit roots) from "gc only
 /// removed parser A" (which would require an attributable explanation
 /// the test does not provide).
-test "P0a gate #1 §B control — gc with no observers collects ALL Memos" {
+test "P0a gate #1 §B control — gc with no watches collects ALL Deriveds" {
   let shared_rt = @incr.Runtime()
   let parser_a = json_parser_on(shared_rt, "[1]")
   let parser_b = json_parser_on(shared_rt, "[2]")
@@ -215,9 +215,9 @@ test "P0a gate #1 §B control — gc with no observers collects ALL Memos" {
 // ============================================================
 // §C — Cross-editor Memo: rooted transitively pins both inputs.
 //
-// A workspace dependency-graph MemoMap or workspace-scoped Memo that
+// A workspace dependency-graph DerivedMap or workspace-scoped Derived that
 // reads multiple editors' Memos joins them into one reachability cone:
-// rooting the cross-Memo (via observer or further downstream reachable
+// rooting the cross-Derived (via Watch or further downstream reachable
 // roots) keeps both editors' input Memos alive via gc_dependencies BFS
 // (kernel/gc.mbt:63-87). This is the "self-rooting" property workspace
 // surfaces would rely on.
@@ -238,11 +238,11 @@ test "P0a gate #1 §C — rooting a cross-editor Memo transitively pins both inp
     .source()
     .map2(parser_b.source(), (a, b) => a.length() + b.length(), label="cross")
   // Force first computation via read_or_abort (outside-the-graph read) so
-  // cross's dependency list is populated before observe/gc.
+  // cross's dependency list is populated before watch/gc.
   let initial : Int = cross.read_or_abort()
   inspect(initial, content="6")
   let id_cross : @incr.CellId = cross.id()
-  let cross_observer = cross.observe()
+  let cross_watch = cross.watch()
   shared_rt.gc()
   shared_rt.gc()
   // cross is rooted → alive.
@@ -253,11 +253,11 @@ test "P0a gate #1 §C — rooting a cross-editor Memo transitively pins both inp
   // Live cross can still be read after gc.
   parser_a.set_source("[11]")
   inspect(cross.read_or_abort(), content="7")
-  cross_observer.dispose()
+  cross_watch.dispose()
 }
 
 ///|
-/// Negative control for §C: cross-editor Memo NOT observed → gc collects
+/// Negative control for §C: cross-editor Derived NOT watched → gc collects
 /// it AND, since cross was the only thing keeping the source views
 /// reachable through gc_dependencies, both source views collected too.
 test "P0a gate #1 §C control — unrooted cross-Memo + inputs all collected" {


### PR DESCRIPTION
## Summary

- Update Canopy-owned Incr registry pins from `0.14.2` to `0.15.0`.
- Advance the Loom submodule to #866, which pins its nested Egglog compatibility update.
- Update affected semantic and runtime-safety tests for Loom's explicit `Block`/`Inline` constructors and Incr's `watch` terminology.

## Dependency order

1. Graphviz #20 — merged (`546c0e6`)
2. Canopy #1147 — merged (`a461673`)
3. Egglog #21 — merged (`d5934f2`)
4. Loom #866 — merged (`6696be7`)
5. This integration PR

## Validation

`./scripts/validate-pr-ready.sh --base origin/main --no-target 'Submodule pointer and manifest update; full suite validates the Incr 0.15.0 migration.'`

Passed for HEAD `044f0b15624cda6e346d9eb1f7585d103cb2cfcb` against `origin/main@a461673e1b7858ff36fdda83cfecba85a38aab51`, including dependency checks, interface checks, full test baseline, JS build, whitespace check, and PR evidence verification.

## Documentation and ADR

- No Markdown files or plan lifecycle changed.
- No ADR needed: this is a mechanical dependency integration plus required compatibility-test updates; it introduces no architectural decision or public API.
