### PR TITLE
feat(loomark): render source-aware Markdown preview

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -10,7 +10,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | projection | full/incremental/fresh | payload, SourceMap ranges, and identity stay attached |
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
  * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
- * | semantic Preview | heading, paragraph, fenced code, list fallback | RUI-aligned read-only semantic DOM without invented list containers |
+ * | semantic Preview | blocks, inline forms, recovery, unsafe URLs | RUI-aligned read-only semantic DOM from the committed MarkdownIR |
  * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
  * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
  * | Block formatting | focused paragraph/heading/list item | typed heading/list/delete requests update source and restore a valid target |
@@ -200,13 +200,16 @@ test("Raw input preserves canonical source and Preview follows a committed edit"
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
     await expectPreviewSource(host.page, "after\r\n")
+    await selectPreview(host.page)
+    await expect(host.page.locator("#loomark-preview")).toHaveCount(1)
+    await expectPreviewSource(host.page, "after\r\n")
   } finally {
     await host.context.close()
   }
 })
 
-test("Preview renders supported blocks as RUI-aligned semantic HTML", async ({ browser }) => {
-  const source = "# Semantic title\n\nReadable body.\n\n~~~moonbit\nlet answer = 42\n~~~\n\n- one\n- two\n"
+test("Preview renders committed MarkdownIR as semantic HTML with source-aware forms", async ({ browser }) => {
+  const source = "# Semantic title\n\nReadable body with a [reference][docs].  \nnext line\n\n~~~moonbit\nlet answer = 42\n~~~\n\n- one\n- two\n\n3. three\n4. four\n\n> quoted\n\n---\n\n[docs]: https://example.test/docs \"Documentation\"\n"
   const host = await mountHost(browser, source)
   try {
     await expect(host.page.locator("#loomark-root")).toHaveAttribute("data-rui-theme", "")
@@ -217,20 +220,97 @@ test("Preview renders supported blocks as RUI-aligned semantic HTML", async ({ b
     await expect(host.page.locator("#loomark-mode-preview")).toHaveAttribute("aria-selected", "true")
     const preview = host.page.locator("#loomark-preview")
     await expect(preview).toHaveAttribute("data-loomark-source", source)
-    await expect(preview.locator("[data-loomark-preview-notice]")).toContainText(
-      "supported top-level blocks",
-    )
     await expect(preview.locator('h1[data-slot="typography-h1"]')).toHaveText("Semantic title")
-    await expect(preview.locator('p[data-slot="typography-p"]')).toHaveText("Readable body.")
+    await expect(preview.locator('p[data-slot="typography-p"]').first()).toContainText(
+      "Readable body with a reference.",
+    )
     await expect(preview.locator('pre code[data-loomark-code-info="moonbit"]')).toHaveText(
       "let answer = 42",
     )
-    await expect(preview.locator("ul, ol")).toHaveCount(0)
-    const rawListItems = preview.locator('[data-loomark-preview-raw-list-item="unordered"]')
-    await expect(rawListItems).toHaveCount(2)
-    await expect(rawListItems.nth(0)).toContainText("- one")
-    await expect(rawListItems.nth(1)).toContainText("- two")
+    await expect(preview.locator('ul[data-loomark-list-marker="-"] > li')).toHaveText(["one", "two"])
+    await expect(preview.locator('ol[data-loomark-list-marker="3."]')).toHaveAttribute("start", "3")
+    await expect(preview.locator('ol[data-loomark-list-marker="3."] > li')).toHaveText(["three", "four"])
+    await expect(preview.locator("blockquote")).toHaveText("quoted")
+    await expect(preview.locator("hr")).toHaveCount(1)
+    await expect(preview.locator('a[data-loomark-link-reference-form="full-reference"]')).toHaveAttribute(
+      "href",
+      "https://example.test/docs",
+    )
+    await expect(preview.locator('a[data-loomark-link-reference-form="full-reference"]')).toHaveAttribute(
+      "title",
+      "Documentation",
+    )
+    await expect(preview.locator('[data-loomark-hard-break-surface="trailing-spaces"]')).toHaveCount(1)
     await expect(preview.locator("textarea, input, button")).toHaveCount(0)
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Preview refreshes semantic DOM and source metadata after a committed source shift", async ({ browser }) => {
+  const initial = "[Docs][docs]\n\n[docs]: https://old.example.test \"Old title\"\n"
+  const shifted = "# Prepended\n\n[Docs][docs]\n\n[docs]: https://new.example.test/path \"New title\"\n"
+  const host = await mountHost(browser, initial)
+  try {
+    await selectPreview(host.page)
+    const preview = host.page.locator("#loomark-preview")
+    const link = preview.locator('a[data-loomark-link-reference-form="full-reference"]')
+    await expect(link).toHaveAttribute("href", "https://old.example.test")
+    await requestSource(host.page, shifted)
+    await expectPreviewSource(host.page, shifted)
+    await expect(preview.locator('h1[data-slot="typography-h1"]')).toHaveText("Prepended")
+    await expect(link).toHaveAttribute("href", "https://new.example.test/path")
+    await expect(link).toHaveAttribute("title", "New title")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Preview replaces stale semantic DOM with recovered diagnostics and restores it on exact reversal", async ({ browser }) => {
+  const source = "# Good\n\n- one\n- two\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectPreview(host.page)
+    const preview = host.page.locator("#loomark-preview")
+    await expect(preview.locator("ul > li")).toHaveText(["one", "two"])
+    await requestSource(host.page, "[unclosed\n")
+    await expectPreviewSource(host.page, "[unclosed\n")
+    await expect(preview.locator('[data-loomark-preview-fallback="recovered"]')).toContainText(
+      "Recovered Markdown:",
+    )
+    await expect(preview.locator("[data-loomark-preview-diagnostic]")).toContainText("Diagnostic:")
+    await expect(preview.locator('h1[data-slot="typography-h1"], ul[data-loomark-list-marker] > li')).toHaveCount(0)
+    await requestSource(host.page, source)
+    await expectPreviewSource(host.page, source)
+    await expect(preview.locator('h1[data-slot="typography-h1"]')).toHaveText("Good")
+    await expect(preview.locator("ul > li")).toHaveText(["one", "two"])
+    await expect(preview.locator('[data-loomark-preview-fallback="recovered"]')).toHaveCount(0)
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Preview escapes HTML and rejects dangerous link, image, and autolink destinations", async ({ browser }) => {
+  const source = "<script>window.loomarkScriptExecuted = true</script>\n\ninline <i>markup</i>\n\n[link](javascript:alert(1)) ![image](javascript:alert(1)) <javascript:alert(1)>\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectPreview(host.page)
+    const preview = host.page.locator("#loomark-preview")
+    await expect(preview.locator("script")).toHaveCount(0)
+    await expect(preview).toContainText("<script>window.loomarkScriptExecuted = true</script>")
+    await expect(preview.locator('[data-loomark-preview-html="block"]')).toHaveText(
+      "<script>window.loomarkScriptExecuted = true</script>",
+    )
+    await expect(preview.locator('[data-loomark-preview-html="inline"]')).toHaveText(["<i>", "</i>"])
+    expect(await host.page.evaluate(() => (
+      window as Window & { loomarkScriptExecuted?: boolean }
+    ).loomarkScriptExecuted)).toBeUndefined()
+    await expect(preview.locator('[data-loomark-preview-url-rejected="link"]')).toHaveText("link")
+    await expect(preview.locator('[data-loomark-preview-url-rejected="image"]')).toContainText("image")
+    await expect(preview.locator('[data-loomark-preview-url-rejected="autolink"]')).toHaveText(
+      "javascript:alert(1)",
+    )
+    await expect(preview.locator('a[href^="javascript:"], img[src^="javascript:"]')).toHaveCount(0)
   } finally {
     await host.context.close()
   }
@@ -1299,12 +1379,15 @@ test("canonical source keeps LF, CRLF, CR, and EOF bytes and collapses same-sour
 test("valid snapshot restore commits source and mode atomically while unknown versions do nothing", async ({ browser }) => {
   const host = await mountHost(browser, "old\r\n")
   try {
-    await restoreSnapshot(host.page, 1, "new\r\n", "preview")
-    await expect.poll(async () => (await snapshot(host.page)).source).toBe("new\r\n")
+    const restored = "# Restored\n\n> semantic quote\n"
+    await restoreSnapshot(host.page, 1, restored, "preview")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(restored)
     await expect.poll(async () => (await snapshot(host.page)).mode).toBe("preview")
     await expect.poll(async () => (await snapshot(host.page)).committed_change_count).toBe(1)
     await expect(host.page.locator("#loomark-input")).toHaveCount(0)
-    await expectPreviewSource(host.page, "new\r\n")
+    await expectPreviewSource(host.page, restored)
+    await expect(host.page.locator('#loomark-preview h1[data-slot="typography-h1"]')).toHaveText("Restored")
+    await expect(host.page.locator("#loomark-preview blockquote")).toHaveText("semantic quote")
     const committed = await snapshot(host.page)
 
     await restoreSnapshot(host.page, 99, "must-not-commit\n", "raw")

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -63,9 +63,38 @@ priv suberror DriverSubscription {
 }
 
 ///|
+/// Pure preview read-model decision. The shell reads the attachment only when
+/// this boundary returns `PreviewDocumentRead`.
+#warnings("-unused_value")
+priv enum PreviewDocumentDecision {
+  PreviewDocumentRead
+  PreviewDocumentKeep
+  PreviewDocumentClear
+} derive(Eq, Debug)
+
+///|
+fn preview_document_decision(
+  old_mode : @core.ApplicationMode,
+  next_mode : @core.ApplicationMode,
+  accepted~ : Bool,
+  changed~ : Bool,
+) -> PreviewDocumentDecision {
+  if !accepted {
+    PreviewDocumentKeep
+  } else if next_mode != @core.Preview {
+    PreviewDocumentClear
+  } else if old_mode != @core.Preview || changed {
+    PreviewDocumentRead
+  } else {
+    PreviewDocumentKeep
+  }
+}
+
+///|
 priv struct DriverModel {
   state : @core.ApplicationState
   document : @markdown.MarkdownDocumentSnapshot
+  semantic_document : @md_markdown.MarkdownIR?
   active_block_key : String?
   replica_id : String
   source_revision : Int
@@ -310,7 +339,7 @@ fn commit_source(
   state : @core.ApplicationState,
   source : String,
   operation : String,
-) -> (DriverModel, Bool) {
+) -> (DriverModel, Bool, Bool) {
   let fail_commit = model.fail_next_editor_commit
   let next = { ..model, fail_next_editor_commit: false }
   let request = if fail_commit {
@@ -333,8 +362,10 @@ fn commit_source(
           committed_change_count: model.committed_change_count + 1,
         },
         true,
+        true,
       )
-    Ok(@markdown.Unchanged(document)) => ({ ..next, state, document }, true)
+    Ok(@markdown.Unchanged(document)) =>
+      ({ ..next, state, document }, true, false)
     Err(error) => {
       let failed = record_error(
         next,
@@ -345,8 +376,28 @@ fn commit_source(
       (
         { ..failed, raw_surface_revision: model.raw_surface_revision + 1 },
         false,
+        false,
       )
     }
+  }
+}
+
+///|
+/// Imperative shell around `preview_document_decision`; this is the sole
+/// application read site for the mount-owned semantic attachment.
+fn update_preview_document(
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  old_mode : @core.ApplicationMode,
+  accepted~ : Bool,
+  changed~ : Bool,
+) -> DriverModel {
+  match
+    preview_document_decision(old_mode, model.state.mode(), accepted~, changed~) {
+    PreviewDocumentRead =>
+      { ..model, semantic_document: Some(attachment.document()) }
+    PreviewDocumentKeep => model
+    PreviewDocumentClear => { ..model, semantic_document: None }
   }
 }
 
@@ -545,7 +596,25 @@ fn editor_surface(
           ),
         ),
       ])
-    @core.Preview => { "preview": preview_surface(model.document) }
+    @core.Preview =>
+      match model.semantic_document {
+        Some(document) => { "preview": preview_surface(source, document) }
+        None =>
+          {
+            "preview": @html.div(
+              id="loomark-preview",
+              attrs=@html.Attrs::build()
+                .data_set("loomark-preview-fallback", "unavailable")
+                .role("region")
+                .tabindex(0)
+                .aria_label("Markdown preview"),
+              style=["display:grid;gap:1rem"],
+              @rui.typography_muted(
+                "Preview is unavailable for the current accepted document.",
+              ),
+            ),
+          }
+      }
     @core.Block =>
       Map([
         (
@@ -1017,6 +1086,7 @@ fn dispatch_driver(detail : String) -> Unit {
 ///|
 fn update_model(
   editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
   event : DriverEvent,
   emit : @cmd.Emit[DriverEvent],
@@ -1065,14 +1135,21 @@ fn update_model(
       for decision in transition.decisions() {
         match decision {
           @core.ReplaceCanonicalSource(source) => {
-            let (committed, _) = commit_source(
+            let old_mode = next.state.mode()
+            let (committed, accepted, changed) = commit_source(
               editor,
               next,
               transition.state(),
               source,
               "editor-dispatch",
             )
-            next = committed
+            next = update_preview_document(
+              attachment,
+              committed,
+              old_mode,
+              accepted~,
+              changed~,
+            )
           }
           @core.SnapshotRejected(_) =>
             next = record_error(
@@ -1404,12 +1481,19 @@ fn update_model(
         }
         let previous_revision = model.source_revision
         let source = if kind == "deleted" { "" } else { "replacement\n" }
-        let (next, _) = commit_source(
+        let (committed, accepted, changed) = commit_source(
           editor,
           model,
           model.state,
           source,
           "editor-dispatch",
+        )
+        let next = update_preview_document(
+          attachment,
+          committed,
+          model.state.mode(),
+          accepted~,
+          changed~,
         )
         publish(next)
         let expected_revision = if kind == "stale" {
@@ -1448,10 +1532,11 @@ fn update_model(
       )
       let mut next = model
       let mut accepted = true
+      let mut source_changed = false
       for decision in transition.decisions() {
         match decision {
           @core.ReplaceCanonicalSource(source) => {
-            let (committed, commit_accepted) = commit_source(
+            let (committed, commit_accepted, changed) = commit_source(
               editor,
               next,
               transition.state(),
@@ -1460,6 +1545,7 @@ fn update_model(
             )
             next = committed
             accepted = accepted && commit_accepted
+            source_changed = source_changed || changed
           }
           @core.SnapshotRejected(error) => {
             accepted = false
@@ -1476,6 +1562,13 @@ fn update_model(
       if accepted {
         next = { ..next, state: transition.state() }
       }
+      next = update_preview_document(
+        attachment,
+        next,
+        model.state.mode(),
+        accepted~,
+        changed=source_changed,
+      )
       publish(next)
       (next, @rabbita_runtime.none)
     }
@@ -1490,7 +1583,13 @@ fn update_model(
         model.state,
         @core.ApplicationEvent::SelectMode(mode~),
       )
-      let next = { ..model, state: transition.state() }
+      let next = update_preview_document(
+        attachment,
+        { ..model, state: transition.state() },
+        model.state.mode(),
+        accepted=true,
+        changed=false,
+      )
       publish(next)
       (next, @rabbita_runtime.none)
     }
@@ -1892,12 +1991,16 @@ pub fn mount(host_id : String, source : String) -> String {
     return "{\"ok\":false,\"error\":\"host-already-mounted\"}"
   }
   let replica_id = "loomark-dev-host-" + js_replica_uuid()
-  let editor = @markdown.MarkdownEditor(agent_id=replica_id, source~) catch {
+  let (editor, attachment) = @markdown.MarkdownEditor::with_semantic_attachment(
+    agent_id=replica_id,
+    source~,
+  ) catch {
     _ => return "{\"ok\":false,\"error\":\"editor-initialization-failed\"}"
   }
   let initial : DriverModel = {
     state: @core.ApplicationState::ApplicationState(@core.Raw),
     document: editor.snapshot(),
+    semantic_document: None,
     active_block_key: None,
     replica_id,
     source_revision: 0,
@@ -1924,7 +2027,9 @@ pub fn mount(host_id : String, source : String) -> String {
   detached_model.val = None
   detached_focus_token.val = ""
   publish(initial)
-  let update = (model, event, emit) => update_model(editor, model, event, emit)
+  let update = (model, event, emit) => {
+    update_model(editor, attachment, model, event, emit)
+  }
   let app = @rabbita_runtime.new(() => {
     let (model, emit) = @rabbita_runtime.create_state(
       initial,

--- a/apps/loomark/internal/rabbita/application_preview_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/application_preview_wbtest.mbt
@@ -1,0 +1,110 @@
+///|
+test "preview document decision matrix preserves accepted preview reads" {
+  assert_eq(
+    preview_document_decision(
+      @core.Raw,
+      @core.Preview,
+      accepted=true,
+      changed=false,
+    ),
+    PreviewDocumentRead,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Preview,
+      @core.Preview,
+      accepted=true,
+      changed=true,
+    ),
+    PreviewDocumentRead,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Preview,
+      @core.Preview,
+      accepted=true,
+      changed=false,
+    ),
+    PreviewDocumentKeep,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Preview,
+      @core.Preview,
+      accepted=false,
+      changed=true,
+    ),
+    PreviewDocumentKeep,
+  )
+}
+
+///|
+test "preview document decision matrix clears outside preview" {
+  assert_eq(
+    preview_document_decision(
+      @core.Preview,
+      @core.Raw,
+      accepted=true,
+      changed=false,
+    ),
+    PreviewDocumentClear,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Preview,
+      @core.Block,
+      accepted=true,
+      changed=true,
+    ),
+    PreviewDocumentClear,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Raw,
+      @core.Block,
+      accepted=true,
+      changed=false,
+    ),
+    PreviewDocumentClear,
+  )
+}
+
+///|
+test "preview document decision matrix restores and repeats deterministically" {
+  assert_eq(
+    preview_document_decision(
+      @core.Block,
+      @core.Preview,
+      accepted=true,
+      changed=true,
+    ),
+    PreviewDocumentRead,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Block,
+      @core.Preview,
+      accepted=true,
+      changed=false,
+    ),
+    PreviewDocumentRead,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Preview,
+      @core.Preview,
+      accepted=true,
+      changed=false,
+    ),
+    PreviewDocumentKeep,
+  )
+  assert_eq(
+    preview_document_decision(
+      @core.Raw,
+      @core.Preview,
+      accepted=false,
+      changed=true,
+    ),
+    PreviewDocumentKeep,
+  )
+}

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -11,7 +11,6 @@ import {
   "moonbit-community/rabbita/sub",
   "moonbit-community/rabbita/svg",
   "Yoorkin/rui",
-  "moonbitlang/core/bench",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/ref",
@@ -20,6 +19,7 @@ import {
 
 import {
   "dowdiness/loom",
+  "moonbitlang/core/bench",
 } for "wbtest"
 
 supported_targets = "js"

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "dowdiness/canopy/editor/markdown",
+  "dowdiness/diagnostic",
   "dowdiness/dom_boundary",
+  "dowdiness/markdown" @md_markdown,
   "dowdiness/loomark/core",
   "moonbit-community/rabbita" @rabbita_runtime,
   "moonbit-community/rabbita/cmd",
@@ -9,11 +11,16 @@ import {
   "moonbit-community/rabbita/sub",
   "moonbit-community/rabbita/svg",
   "Yoorkin/rui",
+  "moonbitlang/core/bench",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/ref",
   "moonbitlang/core/string",
 }
+
+import {
+  "dowdiness/loom",
+} for "wbtest"
 
 supported_targets = "js"
 

--- a/apps/loomark/internal/rabbita/preview_surface.mbt
+++ b/apps/loomark/internal/rabbita/preview_surface.mbt
@@ -1,102 +1,410 @@
 ///|
-fn preview_block_attrs(block : @markdown.MarkdownBlockSnapshot) -> @html.Attrs {
-  @html.Attrs::build()
-  .data_set("loomark-block-id", block.key())
-  .data_set("loomark-block-kind", block_kind_name(block.kind()))
+/// Collect image alternative text without depending on Loom's private helper.
+/// This narrow renderer-local traversal keeps an image's semantic inline text
+/// available to the typed HTML image constructor.
+fn semantic_preview_plain_text(node : @md_markdown.MarkdownIR) -> String {
+  match node.text_value() {
+    Some(value) => return value
+    None => ()
+  }
+  match node.view() {
+    @md_markdown.Text(value~)
+    | @md_markdown.InlineHtml(value~)
+    | @md_markdown.Raw(value~) => value
+    @md_markdown.Autolink(display~, ..) => display
+    @md_markdown.InlineCode(value~) | @md_markdown.HtmlBlock(value~) => value
+    @md_markdown.HardBreak(..) | @md_markdown.SoftBreak => "\n"
+    @md_markdown.Unsupported(message~) | @md_markdown.Recovered(message~) =>
+      message
+    @md_markdown.ThematicBreak => ""
+    @md_markdown.CodeBlock(value~, ..) => value
+    @md_markdown.Document
+    | @md_markdown.Heading(..)
+    | @md_markdown.Paragraph
+    | @md_markdown.BlockQuote
+    | @md_markdown.UnorderedList(..)
+    | @md_markdown.OrderedList(..)
+    | @md_markdown.ListItem(..)
+    | @md_markdown.OrderedListItem(..)
+    | @md_markdown.Bold
+    | @md_markdown.Italic
+    | @md_markdown.Link(..)
+    | @md_markdown.Image(..) =>
+      node.children().map(semantic_preview_plain_text).join("")
+  }
 }
 
 ///|
-fn preview_heading(
-  level : Int,
-  block : @markdown.MarkdownBlockSnapshot,
+fn semantic_preview_link_form(
+  form : @md_markdown.MarkdownIRLinkReferenceForm,
+) -> String {
+  match form {
+    @md_markdown.InlineLinkForm => "inline"
+    @md_markdown.FullReferenceLinkForm => "full-reference"
+    @md_markdown.CollapsedReferenceLinkForm => "collapsed-reference"
+    @md_markdown.ShortcutReferenceLinkForm => "shortcut-reference"
+  }
+}
+
+///|
+fn semantic_preview_unordered_marker(
+  marker : @md_markdown.UnorderedListMarker?,
+) -> String {
+  match marker {
+    Some(@md_markdown.Dash) => "-"
+    Some(@md_markdown.Star) => "*"
+    Some(@md_markdown.Plus) => "+"
+    None => ""
+  }
+}
+
+///|
+fn semantic_preview_ordered_marker(
+  marker : @md_markdown.OrderedListMarker?,
+) -> String {
+  match marker {
+    Some(marker) => marker.text()
+    None => ""
+  }
+}
+
+///|
+/// Keep destinations deterministic and inert before passing them to typed
+/// href/src attributes. Links allow http, https, and mailto; images exclude
+/// mailto because it cannot identify a renderable image resource.
+const SEMANTIC_PREVIEW_FORBIDDEN_URL_CHARS = "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F"
+
+///|
+fn semantic_preview_safe_destination(
+  destination : String,
+  image~ : Bool,
+) -> String? {
+  let trimmed = destination.trim().to_owned()
+  if trimmed != destination ||
+    destination.contains_any(chars=SEMANTIC_PREVIEW_FORBIDDEN_URL_CHARS) {
+    return None
+  }
+  let lowercase = destination.to_lower()
+  if lowercase.has_prefix("//") ||
+    lowercase.has_prefix("/") ||
+    lowercase.has_prefix("#") ||
+    lowercase.has_prefix("?") {
+    return Some(destination)
+  }
+  match lowercase.find(":") {
+    None => Some(destination)
+    Some(scheme_end) => {
+      if (lowercase.find("/") is Some(separator) && separator < scheme_end) ||
+        (lowercase.find("?") is Some(separator) && separator < scheme_end) ||
+        (lowercase.find("#") is Some(separator) && separator < scheme_end) {
+        return Some(destination)
+      }
+      let scheme = lowercase[:scheme_end].to_owned()
+      match scheme {
+        "http" | "https" => Some(destination)
+        "mailto" if !image => Some(destination)
+        _ => None
+      }
+    }
+  }
+}
+
+///|
+fn semantic_preview_diagnostics(
+  node : @md_markdown.MarkdownIR,
+) -> Array[@rabbita_runtime.Html] {
+  node
+  .diagnostics()
+  .map(diagnostic => {
+    @html.li(
+      attrs=@html.Attrs::build().data_set("loomark-preview-diagnostic", ""),
+      "Diagnostic: " + diagnostic.format(),
+    )
+  })
+}
+
+///|
+fn semantic_preview_children(
+  node : @md_markdown.MarkdownIR,
+) -> Array[@rabbita_runtime.Html] {
+  node.children().map(child => semantic_preview_node(child))
+}
+
+///|
+/// Render direct list-item children with their parent's spread decision.
+fn semantic_preview_list_children(
+  node : @md_markdown.MarkdownIR,
+  parent_list_spread : Bool,
+) -> Array[@rabbita_runtime.Html] {
+  node
+  .children()
+  .map(child => {
+    match child.view() {
+      @md_markdown.ListItem(..) | @md_markdown.OrderedListItem(..) =>
+        semantic_preview_node(child, list_parent_spread=parent_list_spread)
+      _ => semantic_preview_node(child)
+    }
+  })
+}
+
+///|
+/// Unwrap only direct Paragraph children of a tight list item.
+fn semantic_preview_list_item_children(
+  node : @md_markdown.MarkdownIR,
+  render_paragraphs : Bool,
+) -> Array[@rabbita_runtime.Html] {
+  node
+  .children()
+  .map(child => {
+    match child.view() {
+      @md_markdown.Paragraph =>
+        semantic_preview_node(
+          child,
+          unwrap_list_item_paragraph=!render_paragraphs,
+        )
+      _ => semantic_preview_node(child)
+    }
+  })
+}
+
+///|
+fn semantic_preview_heading(
+  depth : Int,
+  children : Array[@rabbita_runtime.Html],
 ) -> @rabbita_runtime.Html {
-  let attrs = preview_block_attrs(block)
-  let text = block.text()
-  match level {
-    1 => @rui.typography_h1(style=["text-align:start"], attrs~, text)
-    2 => @rui.typography_h2(attrs~, text)
-    3 => @rui.typography_h3(attrs~, text)
-    4 => @rui.typography_h4(attrs~, text)
+  match depth {
+    1 => @rui.typography_h1(style=["text-align:start"], children)
+    2 => @rui.typography_h2(children)
+    3 => @rui.typography_h3(children)
+    4 => @rui.typography_h4(children)
     5 =>
       @html.h5(
         style=["margin:0;font-size:1rem;line-height:1.5rem;font-weight:600"],
-        attrs~,
-        text,
+        children,
       )
     _ =>
       @html.h6(
         style=[
           "margin:0;font-size:0.875rem;line-height:1.25rem;font-weight:600",
         ],
-        attrs~,
-        text,
+        children,
       )
   }
 }
 
 ///|
-fn preview_raw_list_item(
-  source : String,
-  kind : String,
-  block : @markdown.MarkdownBlockSnapshot,
+/// Render all 24 current public MarkdownIR views without reparsing or
+/// source-offset keys.
+fn semantic_preview_node(
+  node : @md_markdown.MarkdownIR,
+  list_parent_spread? : Bool = false,
+  unwrap_list_item_paragraph? : Bool = false,
 ) -> @rabbita_runtime.Html {
-  let (start, end) = block.source_range()
-  @html.pre(
-    style=[
-      "margin:0;overflow:auto;border-radius:var(--rui-radius,0.625rem);background:var(--rui-muted,oklch(0.97 0 0));padding:0.75rem 1rem",
-    ],
-    attrs=preview_block_attrs(block).data_set(
-      "loomark-preview-raw-list-item", kind,
-    ),
-    source[start:end].to_owned(),
-  )
-}
-
-///|
-fn preview_block(
-  source : String,
-  block : @markdown.MarkdownBlockSnapshot,
-) -> @rabbita_runtime.Html {
-  let attrs = preview_block_attrs(block)
-  match block.kind() {
-    @markdown.Paragraph => @rui.typography_p(attrs~, block.text())
-    @markdown.Heading(level~) => preview_heading(level, block)
-    @markdown.UnorderedListItem =>
-      preview_raw_list_item(source, "unordered", block)
-    @markdown.OrderedListItem(..) =>
-      preview_raw_list_item(source, "ordered", block)
-    @markdown.CodeBlock(info~) => {
-      let code_attrs = @html.Attrs::build().data_set("loomark-code-info", info)
+  let view = node.view()
+  let children = match view {
+    @md_markdown.UnorderedList(spread~, ..)
+    | @md_markdown.OrderedList(spread~, ..) =>
+      semantic_preview_list_children(node, spread)
+    @md_markdown.ListItem(spread~, ..)
+    | @md_markdown.OrderedListItem(spread~, ..) =>
+      semantic_preview_list_item_children(node, spread || list_parent_spread)
+    _ => semantic_preview_children(node)
+  }
+  match view {
+    @md_markdown.Document => @html.fragment(children)
+    @md_markdown.Heading(depth~) => semantic_preview_heading(depth, children)
+    @md_markdown.Paragraph =>
+      if unwrap_list_item_paragraph {
+        @html.fragment(children)
+      } else {
+        @rui.typography_p(children)
+      }
+    @md_markdown.BlockQuote => @rui.typography_blockquote(children)
+    @md_markdown.UnorderedList(spread~, marker~) =>
+      @html.ul(
+        attrs=@html.Attrs::build()
+          .data_set("loomark-list-spread", spread.to_string())
+          .data_set(
+            "loomark-list-marker",
+            semantic_preview_unordered_marker(marker),
+          ),
+        children,
+      )
+    @md_markdown.OrderedList(spread~, marker~) => {
+      let attrs = @html.Attrs::build()
+        .data_set("loomark-list-spread", spread.to_string())
+        .data_set(
+          "loomark-list-marker",
+          semantic_preview_ordered_marker(marker),
+        )
+      match marker {
+        Some(marker) => @html.ol(start=marker.start(), attrs~, children)
+        None => @html.ol(attrs~, children)
+      }
+    }
+    @md_markdown.ListItem(spread~, marker~) =>
+      @html.li(
+        attrs=@html.Attrs::build()
+          .data_set(
+            "loomark-list-item-spread",
+            (spread || list_parent_spread).to_string(),
+          )
+          .data_set(
+            "loomark-list-marker",
+            semantic_preview_unordered_marker(marker),
+          ),
+        children,
+      )
+    @md_markdown.OrderedListItem(spread~, marker~) =>
+      @html.li(
+        attrs=@html.Attrs::build()
+          .data_set(
+            "loomark-list-item-spread",
+            (spread || list_parent_spread).to_string(),
+          )
+          .data_set(
+            "loomark-list-marker",
+            semantic_preview_ordered_marker(marker),
+          ),
+        children,
+      )
+    @md_markdown.CodeBlock(info~, value~) =>
       @html.pre(
         style=[
           "margin:0;overflow:auto;border-radius:var(--rui-radius,0.625rem);background:var(--rui-muted,oklch(0.97 0 0));padding:1rem",
         ],
-        attrs~,
         @html.code(
           style=[
             "font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.5rem",
           ],
-          attrs=code_attrs,
-          block.text(),
+          attrs=@html.Attrs::build().data_set("loomark-code-info", info),
+          value,
         ),
       )
+    @md_markdown.HtmlBlock(value~) =>
+      @html.pre(
+        attrs=@html.Attrs::build().data_set("loomark-preview-html", "block"),
+        value,
+      )
+    @md_markdown.ThematicBreak => @html.hr()
+    @md_markdown.Text(value~) => @html.text(value)
+    @md_markdown.Bold => @html.strong(children)
+    @md_markdown.Italic => @html.em(children)
+    @md_markdown.InlineCode(value~) => @html.code(value)
+    @md_markdown.Link(destination~, title~, surface~) =>
+      match semantic_preview_safe_destination(destination, image=false) {
+        Some(destination) =>
+          @html.a(
+            href=destination,
+            title?,
+            attrs=@html.Attrs::build().data_set(
+              "loomark-link-reference-form",
+              semantic_preview_link_form(surface.form),
+            ),
+            children,
+          )
+        None =>
+          @html.span(
+            attrs=@html.Attrs::build().data_set(
+              "loomark-preview-url-rejected", "link",
+            ),
+            children,
+          )
+      }
+    @md_markdown.Image(destination~, title~, surface~) => {
+      let alt = semantic_preview_plain_text(node)
+      match semantic_preview_safe_destination(destination, image=true) {
+        Some(destination) =>
+          @html.img(
+            src=destination,
+            alt~,
+            title?,
+            attrs=@html.Attrs::build().data_set(
+              "loomark-image-reference-form",
+              semantic_preview_link_form(surface.form),
+            ),
+          )
+        None =>
+          @html.span(
+            attrs=@html.Attrs::build().data_set(
+              "loomark-preview-url-rejected", "image",
+            ),
+            "Image URL rejected: " + alt,
+          )
+      }
     }
+    @md_markdown.Autolink(kind~, display~, destination~, ..) =>
+      match semantic_preview_safe_destination(destination, image=false) {
+        Some(destination) =>
+          @html.a(
+            href=destination,
+            attrs=@html.Attrs::build().data_set(
+              "loomark-autolink-kind",
+              match kind {
+                @md_markdown.UriAutolink => "uri"
+                @md_markdown.EmailAutolink => "email"
+              },
+            ),
+            display,
+          )
+        None =>
+          @html.span(
+            attrs=@html.Attrs::build().data_set(
+              "loomark-preview-url-rejected", "autolink",
+            ),
+            display,
+          )
+      }
+    @md_markdown.InlineHtml(value~) =>
+      @html.span(
+        attrs=@html.Attrs::build().data_set("loomark-preview-html", "inline"),
+        value,
+      )
+    @md_markdown.SoftBreak => @html.text("\n")
+    @md_markdown.HardBreak(surface~) =>
+      @html.br(
+        attrs=@html.Attrs::build().data_set(
+          "loomark-hard-break-surface",
+          match surface {
+            @md_markdown.TrailingSpaces(_) => "trailing-spaces"
+            @md_markdown.Backslash => "backslash"
+          },
+        ),
+      )
+    @md_markdown.Unsupported(message~) =>
+      @html.div(
+        attrs=@html.Attrs::build().data_set(
+          "loomark-preview-fallback", "unsupported",
+        ),
+        "Unsupported Markdown: " + message,
+      )
+    @md_markdown.Raw(value~) =>
+      @html.div(
+        attrs=@html.Attrs::build().data_set("loomark-preview-fallback", "raw"),
+        [
+          @html.strong("Raw Markdown:"),
+          @html.pre(value),
+          @html.ul(semantic_preview_diagnostics(node)),
+        ],
+      )
+    @md_markdown.Recovered(message~) =>
+      @html.div(
+        attrs=@html.Attrs::build().data_set(
+          "loomark-preview-fallback", "recovered",
+        ),
+        [
+          @html.strong("Recovered Markdown: " + message),
+          @html.ul(semantic_preview_diagnostics(node)),
+        ],
+      )
   }
 }
 
 ///|
 fn preview_surface(
-  document : @markdown.MarkdownDocumentSnapshot,
+  source : String,
+  semantic_document : @md_markdown.MarkdownIR,
 ) -> @rabbita_runtime.Html {
-  let source = document.source()
-  let blocks : Map[String, @rabbita_runtime.Html] = Map([])
-  blocks["preview-scope-notice"] = @rui.typography_muted(
-    attrs=@html.Attrs::build().data_set("loomark-preview-notice", ""),
-    "Prototype preview shows supported top-level blocks. Use Raw for the complete source.",
-  )
-  for block in document.blocks().to_array() {
-    blocks[block.key()] = preview_block(source, block)
-  }
   @html.div(
     id="loomark-preview",
     attrs=@html.Attrs::build()
@@ -105,6 +413,6 @@ fn preview_surface(
       .tabindex(0)
       .aria_label("Markdown preview"),
     style=["display:grid;gap:1rem"],
-    blocks,
+    semantic_preview_node(semantic_document),
   )
 }

--- a/apps/loomark/internal/rabbita/preview_surface_benchmark_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/preview_surface_benchmark_wbtest.mbt
@@ -24,7 +24,7 @@ fn preview_surface_benchmark_replace_middle(source : String) -> String {
 }
 
 ///|
-fn preview_surface_benchmark_ir(
+fn wbtest_markdown_ir(
   source_id : @loom.SourceId,
   source : String,
 ) -> @md_markdown.MarkdownIR {
@@ -54,11 +54,11 @@ fn preview_surface_benchmark_input() -> PreviewSurfaceBenchmarkInput {
   {
     source,
     edited,
-    source_ir: preview_surface_benchmark_ir(
+    source_ir: wbtest_markdown_ir(
       @loom.SourceId("loomark-preview-materialize"),
       source,
     ),
-    edited_ir: preview_surface_benchmark_ir(
+    edited_ir: wbtest_markdown_ir(
       @loom.SourceId("loomark-preview-materialize"),
       edited,
     ),
@@ -75,12 +75,6 @@ test "loomark Preview materialization: initial 2500 blocks" (b : @bench.T) {
 test "loomark Preview materialization: edited IR 2500 blocks" (b : @bench.T) {
   let input = preview_surface_benchmark_input()
   b.bench(() => b.keep(preview_surface(input.edited, input.edited_ir)))
-}
-
-///|
-test "loomark Preview materialization: reversal IR 2500 blocks" (b : @bench.T) {
-  let input = preview_surface_benchmark_input()
-  b.bench(() => b.keep(preview_surface(input.source, input.source_ir)))
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/preview_surface_benchmark_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/preview_surface_benchmark_wbtest.mbt
@@ -1,0 +1,113 @@
+///|
+/// Build the 2,500-block workload once. Parsing belongs to Loom's semantic
+/// attachment benchmarks; this file isolates the pure Preview materializer.
+fn preview_surface_benchmark_source(block_count : Int) -> String {
+  let out = StringBuilder::StringBuilder()
+  for index = 0; index < block_count; index = index + 1 {
+    out.write_string(
+      "Paragraph \{index} contains *emphasis*, **strong text**, a [link](https://example.test/\{index}), and `code`.\n\n",
+    )
+  }
+  out.to_string()
+}
+
+///|
+fn preview_surface_benchmark_replace_middle(source : String) -> String {
+  let target = "Paragraph 1250"
+  match source.find(target) {
+    Some(position) =>
+      source[:position].to_owned() +
+      "Edited paragraph 1250" +
+      source[position + target.length():].to_owned()
+    None => abort("preview surface benchmark middle paragraph not found")
+  }
+}
+
+///|
+fn preview_surface_benchmark_ir(
+  source_id : @loom.SourceId,
+  source : String,
+) -> @md_markdown.MarkdownIR {
+  let parser = @loom.new_parser(
+    source_id, source, @md_markdown.markdown_grammar,
+  )
+  let snapshot = parser.snapshot().read_or_abort()
+  @md_markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
+    parser.source_id(),
+    snapshot.syntax,
+    snapshot.diagnostics,
+  )
+}
+
+///|
+priv struct PreviewSurfaceBenchmarkInput {
+  source : String
+  edited : String
+  source_ir : @md_markdown.MarkdownIR
+  edited_ir : @md_markdown.MarkdownIR
+}
+
+///|
+fn preview_surface_benchmark_input() -> PreviewSurfaceBenchmarkInput {
+  let source = preview_surface_benchmark_source(2500)
+  let edited = preview_surface_benchmark_replace_middle(source)
+  {
+    source,
+    edited,
+    source_ir: preview_surface_benchmark_ir(
+      @loom.SourceId("loomark-preview-materialize"),
+      source,
+    ),
+    edited_ir: preview_surface_benchmark_ir(
+      @loom.SourceId("loomark-preview-materialize"),
+      edited,
+    ),
+  }
+}
+
+///|
+test "loomark Preview materialization: initial 2500 blocks" (b : @bench.T) {
+  let input = preview_surface_benchmark_input()
+  b.bench(() => b.keep(preview_surface(input.source, input.source_ir)))
+}
+
+///|
+test "loomark Preview materialization: edited IR 2500 blocks" (b : @bench.T) {
+  let input = preview_surface_benchmark_input()
+  b.bench(() => b.keep(preview_surface(input.edited, input.edited_ir)))
+}
+
+///|
+test "loomark Preview materialization: reversal IR 2500 blocks" (b : @bench.T) {
+  let input = preview_surface_benchmark_input()
+  b.bench(() => b.keep(preview_surface(input.source, input.source_ir)))
+}
+
+///|
+/// Measure the requested edit-and-exact-reversal materialization as one cycle.
+test "loomark Preview materialization: edit and reversal cycle 2500 blocks" (
+  b : @bench.T,
+) {
+  let input = preview_surface_benchmark_input()
+  b.bench(() => {
+    b.keep(preview_surface(input.edited, input.edited_ir))
+    b.keep(preview_surface(input.source, input.source_ir))
+  })
+}
+
+///|
+/// Isolate the semantic-document component of DriverModel's structural Eq on
+/// a Preview no-op; the complete model also compares its other fields.
+test "loomark Preview MarkdownIR Eq: same 2500 blocks" (b : @bench.T) {
+  let input = preview_surface_benchmark_input()
+  b.bench(() => b.keep(input.source_ir == input.source_ir))
+}
+
+///|
+/// A middle edit gives a conservative isolated cost for comparing two owning
+/// semantic documents; the complete model may short-circuit on an earlier
+/// changed field.
+test "loomark Preview MarkdownIR Eq: middle edit 2500 blocks" (b : @bench.T) {
+  let input = preview_surface_benchmark_input()
+  b.bench(() => b.keep(input.source_ir == input.edited_ir))
+}

--- a/apps/loomark/internal/rabbita/preview_surface_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/preview_surface_wbtest.mbt
@@ -1,22 +1,10 @@
 ///|
-fn fresh_preview_ir(source : String) -> @md_markdown.MarkdownIR {
-  let parser = @loom.new_parser(
-    @loom.SourceId("loomark-preview-ssr"),
-    source,
-    @md_markdown.markdown_grammar,
-  )
-  let snapshot = parser.snapshot().read_or_abort()
-  @md_markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
-    parser.source_id(),
-    snapshot.syntax,
-    snapshot.diagnostics,
-  )
-}
-
-///|
 #warnings("-alert_unstable")
 fn render_preview(source : String) -> String {
-  let preview = preview_surface(source, fresh_preview_ir(source))
+  let preview = preview_surface(
+    source,
+    wbtest_markdown_ir(@loom.SourceId("loomark-preview-ssr"), source),
+  )
   @rabbita_runtime.render_to_string(() => {
     @rabbita_runtime.Val::constant(preview)
   })
@@ -159,7 +147,9 @@ test "semantic preview SSR distinguishes tight and loose list paragraphs" {
   let tight = render_preview("- one\n- two\n")
   let loose = render_preview("- one\n\n- two\n")
   let nested = render_preview("- outer\n  - inner\n")
-  assert_true(!tight.contains("<li data-loomark-list-item-spread=\"false\"><p"))
+  assert_true(!tight.contains("<p"))
+  assert_preview_contains(tight, "data-loomark-list-item-spread=\"false\"")
+  assert_preview_contains(tight, ">one</li>")
   assert_preview_contains(loose, "data-loomark-list-item-spread=\"true\"")
   assert_preview_contains(loose, "<p")
   assert_preview_contains(nested, "<ul")

--- a/apps/loomark/internal/rabbita/preview_surface_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/preview_surface_wbtest.mbt
@@ -1,0 +1,168 @@
+///|
+fn fresh_preview_ir(source : String) -> @md_markdown.MarkdownIR {
+  let parser = @loom.new_parser(
+    @loom.SourceId("loomark-preview-ssr"),
+    source,
+    @md_markdown.markdown_grammar,
+  )
+  let snapshot = parser.snapshot().read_or_abort()
+  @md_markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
+    parser.source_id(),
+    snapshot.syntax,
+    snapshot.diagnostics,
+  )
+}
+
+///|
+#warnings("-alert_unstable")
+fn render_preview(source : String) -> String {
+  let preview = preview_surface(source, fresh_preview_ir(source))
+  @rabbita_runtime.render_to_string(() => {
+    @rabbita_runtime.Val::constant(preview)
+  })
+}
+
+///|
+test "semantic preview SSR renders an ATX heading" {
+  let rendered = render_preview("# Hello\n")
+  assert_true(rendered.contains("id=\"loomark-preview\""))
+  assert_true(rendered.contains("<h1"))
+  assert_true(rendered.contains(">Hello</h1>"))
+}
+
+///|
+fn assert_preview_contains(rendered : String, expected : String) -> Unit {
+  if !rendered.contains(expected) {
+    abort("missing `\{expected}` in `\{rendered}`")
+  }
+}
+
+///|
+test "semantic preview SSR renders headings containers and code" {
+  let rendered = render_preview(
+    "# ATX\n\nSetext\r\n======\r\n\n> quote\n\n- outer\n  3. inner\n\n```moonbit\nlet value = 1\n```\n\n---\n",
+  )
+  assert_preview_contains(rendered, ">ATX</h1>")
+  assert_preview_contains(rendered, ">Setext</h1>")
+  assert_preview_contains(rendered, "<blockquote")
+  assert_preview_contains(rendered, "<ul")
+  assert_preview_contains(rendered, "<ol")
+  assert_preview_contains(rendered, "start=\"3\"")
+  assert_preview_contains(rendered, "data-loomark-code-info=\"moonbit\"")
+  assert_preview_contains(rendered, "<hr")
+}
+
+///|
+test "semantic preview SSR renders inline links images and reference metadata" {
+  let rendered = render_preview(
+    "**bold** *italic* `code` [inline](/to \"tip\") [full][ref] ![image *alt*](/img \"caption\")\n\n[ref]: /ref \"reference title\"\n",
+  )
+  assert_preview_contains(rendered, "<strong>bold</strong>")
+  assert_preview_contains(rendered, "<em>italic</em>")
+  assert_preview_contains(rendered, "<code>code</code>")
+  assert_preview_contains(rendered, "href=\"/to\"")
+  assert_preview_contains(rendered, "title=\"tip\"")
+  assert_preview_contains(
+    rendered, "data-loomark-link-reference-form=\"inline\"",
+  )
+  assert_preview_contains(
+    rendered, "data-loomark-link-reference-form=\"full-reference\"",
+  )
+  assert_preview_contains(rendered, "src=\"/img\"")
+  assert_preview_contains(rendered, "alt=\"image alt\"")
+  assert_preview_contains(rendered, "title=\"caption\"")
+  assert_preview_contains(
+    rendered, "data-loomark-image-reference-form=\"inline\"",
+  )
+}
+
+///|
+test "semantic preview SSR preserves autolink break and HTML surfaces" {
+  let rendered = render_preview(
+    "<https://example.test> <mail@example.test>\rsoft\nspace  \nslash\\\nnext\n\n<div>block</div>\n\ninline <i>tag</i>\n",
+  )
+  assert_preview_contains(rendered, "data-loomark-autolink-kind=\"uri\"")
+  assert_preview_contains(rendered, "data-loomark-autolink-kind=\"email\"")
+  assert_preview_contains(
+    rendered, "data-loomark-hard-break-surface=\"trailing-spaces\"",
+  )
+  assert_preview_contains(
+    rendered, "data-loomark-hard-break-surface=\"backslash\"",
+  )
+  assert_preview_contains(rendered, "data-loomark-preview-html=\"block\"")
+  assert_preview_contains(rendered, "data-loomark-preview-html=\"inline\"")
+  assert_preview_contains(rendered, "&lt;div&gt;block&lt;/div&gt;")
+  assert_preview_contains(rendered, "&lt;i&gt;")
+}
+
+///|
+test "semantic preview SSR labels raw recovered and literal fallback forms" {
+  let raw = render_preview("[text](url\n")
+  let recovered = render_preview("[unclosed\n")
+  let literal = render_preview("~~strike~~")
+  assert_preview_contains(raw, "data-loomark-preview-fallback=\"raw\"")
+  assert_preview_contains(
+    recovered, "data-loomark-preview-fallback=\"recovered\"",
+  )
+  assert_preview_contains(recovered, "Diagnostic:")
+  assert_preview_contains(literal, "~~strike~~")
+}
+
+///|
+test "semantic preview SSR rejects unsafe link destinations" {
+  let rejected = render_preview(
+    "[link](javascript:alert(1)) <javascript:alert(1)> ![image](javascript:alert(1))",
+  )
+  let safe = render_preview(
+    "[relative](docs/page) [space](<docs/my page>) [colon](docs/page:part) [web](HTTP://example.test) [mail](mailto:me@example.test) ![image](/image.png)",
+  )
+  assert_true(!rejected.contains("href=\"javascript:"))
+  assert_true(!rejected.contains("src=\"javascript:"))
+  assert_preview_contains(rejected, "data-loomark-preview-url-rejected")
+  assert_preview_contains(safe, "href=\"docs/page\"")
+  assert_preview_contains(safe, "href=\"docs/my page\"")
+  assert_preview_contains(safe, "href=\"docs/page:part\"")
+  assert_preview_contains(safe, "href=\"HTTP://example.test\"")
+  assert_preview_contains(safe, "href=\"mailto:me@example.test\"")
+  assert_preview_contains(safe, "src=\"/image.png\"")
+  assert_eq(
+    semantic_preview_safe_destination("java script:alert(1)", image=false),
+    None,
+  )
+  assert_eq(
+    semantic_preview_safe_destination("java\u0000script:alert(1)", image=false),
+    None,
+  )
+  assert_eq(
+    semantic_preview_safe_destination("java\tscript:alert(1)", image=false),
+    None,
+  )
+  assert_eq(
+    semantic_preview_safe_destination("java\nscript:alert(1)", image=false),
+    None,
+  )
+  assert_eq(
+    semantic_preview_safe_destination("java\rscript:alert(1)", image=false),
+    None,
+  )
+}
+
+///|
+test "semantic preview SSR keeps ordinary paragraphs semantic" {
+  let rendered = render_preview("ordinary paragraph\n")
+  assert_preview_contains(rendered, "<p")
+  assert_preview_contains(rendered, ">ordinary paragraph</p>")
+}
+
+///|
+test "semantic preview SSR distinguishes tight and loose list paragraphs" {
+  let tight = render_preview("- one\n- two\n")
+  let loose = render_preview("- one\n\n- two\n")
+  let nested = render_preview("- outer\n  - inner\n")
+  assert_true(!tight.contains("<li data-loomark-list-item-spread=\"false\"><p"))
+  assert_preview_contains(loose, "data-loomark-list-item-spread=\"true\"")
+  assert_preview_contains(loose, "<p")
+  assert_preview_contains(nested, "<ul")
+  assert_preview_contains(nested, "outer")
+  assert_preview_contains(nested, "inner")
+}

--- a/apps/loomark/moon.mod
+++ b/apps/loomark/moon.mod
@@ -4,6 +4,9 @@ version = "0.1.0"
 
 import {
   "dowdiness/canopy@0.1.0",
+  "dowdiness/diagnostic@0.1.0",
+  "dowdiness/loom@0.1.0",
+  "dowdiness/markdown@0.1.0",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",
   "moonbit-community/rabbita@0.14.1",

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,6 +181,9 @@ behavior** — check the code before relying on any specific detail.
 - [Protocol v3 hard cutover](decisions/2026-07-22-protocol-v3-hard-cutover.md)
   — rejects v2 frames at endpoints and the relay rather than bridging the
   incompatible EGW 0.3 and 0.4 identity schemas.
+- [Markdown semantic Preview ownership](decisions/2026-08-04-markdown-semantic-preview-ownership.md)
+  — keeps the ordinary Markdown editor attachment-free while the private
+  single-mount Loomark host retains one same-parser semantic Preview read model.
 
 ## Historical / Archive
 

--- a/docs/decisions/2026-08-04-markdown-semantic-preview-ownership.md
+++ b/docs/decisions/2026-08-04-markdown-semantic-preview-ownership.md
@@ -1,0 +1,102 @@
+# Markdown semantic Preview ownership
+
+**Date:** 2026-08-04
+
+**Status:** Accepted for the private single-mount Loomark host.
+
+**Related:**
+
+- [Loomark application handoff](../plans/2026-08-01-loomark-application-handoff.md)
+- [Loom Markdown semantic attachment boundary](../../deps/loom/docs/decisions/2026-08-04-markdown-semantic-attachment-boundary.md)
+- [Issue #1145](https://github.com/dowdiness/canopy/issues/1145)
+
+**Decision:** The Markdown editor offers an explicit construction path that
+returns its existing editing facade together with one semantic attachment over
+the exact parser created for that facade. The ordinary constructor remains
+attachment-free. The private Loomark host retains the editor and attachment for
+its existing page/process lifetime and installs owning semantic documents only
+at accepted Preview transition points.
+
+**Keep until:** A reusable Browser Session with explicit teardown supersedes
+the private single-mount host.
+
+## Context
+
+Loomark's Raw and Block modes already share one canonical source, parser,
+projection, edit-lowering path, identity model, and SourceMap. Its earlier
+Preview read the editable Block snapshot, which intentionally cannot represent
+the complete source-aware Markdown semantic model.
+
+Constructing a second parser for Preview would allow the three modes to observe
+different commits and would duplicate incremental work. Exposing a generic
+parser or reactive accessor would weaken the editor facade. Attaching semantic
+observation to every ordinary Markdown editor would retain work for consumers
+that never request Preview.
+
+The current private host rejects a second mount and has no early-unmount or
+reuse contract. Its editor resources therefore already have page/process
+lifetime.
+
+## Decision
+
+### Construction and ownership
+
+The existing Markdown editor constructor keeps its behavior and owns no
+semantic attachment. A separate Markdown-specific constructor returns the same
+facade plus one Loom semantic attachment created inside the companion boundary
+where the live parser is already available. The two paths share one private
+initialization implementation so source seeding and initial projection cannot
+drift.
+
+The companion handoff carries only the typed semantic attachment. It does not
+expose the parser, runtime, Watch, Scope, cache, or a generic callback.
+
+The generic editor privately roots each projection memo it already owns for the
+editor's lifetime. This makes runtime-wide collection by a co-located semantic
+attachment safe without adding a new public lifecycle API. Because the current
+editor has no destructor, these roots deliberately follow the host's
+page/process lifetime.
+
+### Functional core and imperative shell
+
+The private Loomark model holds an optional owning semantic document. Its
+imperative update shell reads the attachment only when an accepted transaction:
+
+- enters Preview;
+- changes canonical source while Preview is active; or
+- restores a snapshot whose resulting mode is Preview.
+
+Rejected and unchanged transactions retain the prior accepted document.
+Leaving Preview clears or ignores the read model. Rabbita view evaluation never
+reads the attachment.
+
+Rendering is a deterministic `source + MarkdownIR -> typed Rabbita Html`
+transformation. Every public semantic view has an explicit decision. Raw HTML
+nodes render as text, and rejected URL destinations remain visible without an
+active `href` or `src`.
+
+## Consequences
+
+- Raw, Block, and Preview observe one parser and one accepted mutation path.
+- Ordinary and headless Markdown editors pay no semantic attachment cost.
+- Repeated Preview selection and edits create no additional attachments.
+- Preview can represent lists, quotations, reference metadata, breaks,
+  autolinks, HTML nodes, recovery, and diagnostics without converting back to
+  the legacy editable Block model.
+- The generic editor's existing projection memos remain rooted for the editor's
+  lifetime. Short-lived editors on a shared runtime are not given a new teardown
+  claim by this decision.
+- A future reusable Session must introduce and test explicit teardown for the
+  editor-owned roots and semantic attachment together. It may supersede the
+  lifetime portion of this ADR without changing the semantic renderer or read
+  model.
+
+## Non-goals
+
+- Public Browser Session, early unmount, remount, or host reuse.
+- Generic parser or reactive accessors.
+- A second parser, DOM owner, HTML-string injection, or semantic identity
+  protocol.
+- Replacement of the editable Block projection, structural editing, SourceMap,
+  or reconciliation paths.
+- Trusted raw-HTML passthrough or new Markdown syntax.

--- a/docs/decisions/2026-08-04-markdown-semantic-preview-ownership.md
+++ b/docs/decisions/2026-08-04-markdown-semantic-preview-ownership.md
@@ -9,23 +9,23 @@
 - [Loomark application handoff](../plans/2026-08-01-loomark-application-handoff.md)
 - [Loom Markdown semantic attachment boundary](../../deps/loom/docs/decisions/2026-08-04-markdown-semantic-attachment-boundary.md)
 - [Issue #1145](https://github.com/dowdiness/canopy/issues/1145)
+- [Lifecycle follow-up #1159](https://github.com/dowdiness/canopy/issues/1159)
 
-**Decision:** The Markdown editor offers an explicit construction path that
-returns its existing editing facade together with one semantic attachment over
-the exact parser created for that facade. The ordinary constructor remains
-attachment-free. The private Loomark host retains the editor and attachment for
-its existing page/process lifetime and installs owning semantic documents only
-at accepted Preview transition points.
+**Decision:** The Markdown editor offers an explicit, opt-in construction path
+that returns its existing editing facade together with one semantic observer
+over the same parser. Ordinary construction remains observer-free. The private
+Loomark host retains both resources for its existing page/process lifetime and
+installs owning semantic documents only at accepted Preview transition points.
 
 **Keep until:** A reusable Browser Session with explicit teardown supersedes
 the private single-mount host.
 
 ## Context
 
-Loomark's Raw and Block modes already share one canonical source, parser,
-projection, edit-lowering path, identity model, and SourceMap. Its earlier
-Preview read the editable Block snapshot, which intentionally cannot represent
-the complete source-aware Markdown semantic model.
+Loomark's editing modes already share one canonical source, parser, projection,
+edit-lowering path, identity model, and source mapping. Its earlier Preview read
+the editable projection, which intentionally cannot represent the complete
+source-aware Markdown semantic model.
 
 Constructing a second parser for Preview would allow the three modes to observe
 different commits and would duplicate incremental work. Exposing a generic
@@ -41,53 +41,53 @@ lifetime.
 
 ### Construction and ownership
 
-The existing Markdown editor constructor keeps its behavior and owns no
-semantic attachment. A separate Markdown-specific constructor returns the same
-facade plus one Loom semantic attachment created inside the companion boundary
-where the live parser is already available. The two paths share one private
-initialization implementation so source seeding and initial projection cannot
-drift.
+The existing Markdown editor construction path keeps its behavior and owns no
+semantic observer. A separate opt-in path returns the same facade plus one
+observer created inside the companion seam where the live parser is already
+available. The two paths share one private initialization implementation so
+source seeding and initial projection cannot drift.
 
-The companion handoff carries only the typed semantic attachment. It does not
-expose the parser, runtime, Watch, Scope, cache, or a generic callback.
+The companion handoff carries only the typed semantic observer. It does not
+expose parser or runtime internals, reactive ownership handles, caches, or a
+generic callback.
 
-The generic editor privately roots each projection memo it already owns for the
-editor's lifetime. This makes runtime-wide collection by a co-located semantic
-attachment safe without adding a new public lifecycle API. Because the current
-editor has no destructor, these roots deliberately follow the host's
+The generic editor privately roots the projection state it already owns for the
+editor's lifetime. This makes runtime-wide collection by a co-located observer
+safe without adding a new public lifecycle interface. Because the current
+editor has no teardown contract, these roots deliberately follow the host's
 page/process lifetime.
 
 ### Functional core and imperative shell
 
 The private Loomark model holds an optional owning semantic document. Its
-imperative update shell reads the attachment only when an accepted transaction:
+imperative update shell reads the observer only when an accepted transaction:
 
 - enters Preview;
 - changes canonical source while Preview is active; or
 - restores a snapshot whose resulting mode is Preview.
 
 Rejected and unchanged transactions retain the prior accepted document.
-Leaving Preview clears or ignores the read model. Rabbita view evaluation never
-reads the attachment.
+Leaving Preview clears or ignores the read model. View evaluation never performs
+effectful semantic reads.
 
-Rendering is a deterministic `source + MarkdownIR -> typed Rabbita Html`
-transformation. Every public semantic view has an explicit decision. Raw HTML
-nodes render as text, and rejected URL destinations remain visible without an
-active `href` or `src`.
+Rendering is a deterministic transformation from canonical source and an owning
+semantic document to an inert typed view tree. Every public semantic form has
+an explicit rendering decision. Raw HTML renders as text, and rejected URL
+destinations remain visible without becoming active links or media sources.
 
 ## Consequences
 
 - Raw, Block, and Preview observe one parser and one accepted mutation path.
-- Ordinary and headless Markdown editors pay no semantic attachment cost.
-- Repeated Preview selection and edits create no additional attachments.
+- Ordinary and headless Markdown editors pay no semantic-observer cost.
+- Repeated Preview selection and edits create no additional observers.
 - Preview can represent lists, quotations, reference metadata, breaks,
   autolinks, HTML nodes, recovery, and diagnostics without converting back to
-  the legacy editable Block model.
-- The generic editor's existing projection memos remain rooted for the editor's
+  the legacy editable projection.
+- The generic editor's existing projection state remains rooted for the editor's
   lifetime. Short-lived editors on a shared runtime are not given a new teardown
   claim by this decision.
 - A future reusable Session must introduce and test explicit teardown for the
-  editor-owned roots and semantic attachment together. It may supersede the
+  editor-owned roots and semantic observer together. It may supersede the
   lifetime portion of this ADR without changing the semantic renderer or read
   model.
 
@@ -97,6 +97,6 @@ active `href` or `src`.
 - Generic parser or reactive accessors.
 - A second parser, DOM owner, HTML-string injection, or semantic identity
   protocol.
-- Replacement of the editable Block projection, structural editing, SourceMap,
+- Replacement of the editable projection, structural editing, source mapping,
   or reconciliation paths.
 - Trusted raw-HTML passthrough or new Markdown syntax.

--- a/docs/plans/2026-08-01-loomark-application-handoff.md
+++ b/docs/plans/2026-08-01-loomark-application-handoff.md
@@ -1,6 +1,6 @@
 # Loomark application handoff
 
-Status: staged handoff — application behavior is gated by adoption of merged Rabbita #142, Canopy #1045, and the Foundation through #1103. The canonical public Browser App/Session, teardown/remount claims, production adapters, and Waku cutover remain additionally gated by Rabbita #141. This is the sole implementation plan for the accepted #1060, #1062–#1067, and #1070 decisions; the pure core prototype is evidence only.
+Status: staged handoff — the Foundation and private Application Train through #1075 are complete. #1145 is the current pre-#141 semantic Preview slice. The canonical public Browser App/Session, teardown/remount claims, production adapters, and Waku cutover remain gated by Rabbita #141. This is the sole implementation plan for the accepted #1060, #1062–#1067, #1070, and #1145 decisions; the pure core prototype is evidence only.
 
 ## Why
 
@@ -224,6 +224,38 @@ Rabbita #141 is intentionally not an Application Train gate. It remains the nati
 3. #1075 only after green committed #1074: ordered/unordered lists and fenced code. Defer unsupported moves/containers, rich inline, diagnostics UI, adapters, Waku.
 
 Each ticket begins with behavioral matrix and first RED test, makes one logical commit, and reruns affected evidence after commit/amend/rebase, manifest/generated-interface change, or base movement.
+
+### Source-aware semantic Preview
+
+#1145 follows the completed private Application Train and does not wait for
+Rabbita #141. It attaches one `MarkdownSemanticAttachment` to the exact parser
+created for the private Loomark editor and retains it for the existing
+page/process lifetime. Raw and Block keep the editable `Block` projection;
+Preview alone holds an owning `MarkdownIR` read model. The ordinary headless
+`MarkdownEditor` constructor remains attachment-free. `SyncEditor` privately
+roots the three projection memos it already owns for the editor lifetime, so
+attachment collection cannot sweep the editable projection graph without
+adding a public disposal or reactive interface. The ownership decision is
+recorded in
+[Markdown semantic Preview ownership](../decisions/2026-08-04-markdown-semantic-preview-ownership.md).
+
+| Boundary | Accepted transition | Semantic read | Required observation |
+| --- | --- | --- | --- |
+| Private mount | construct editor and attachment over one parser | none while initial mode is Raw | one attachment; ordinary constructor unchanged |
+| Raw/Block → Preview | committed mode transition | once after transition acceptance | current complete MarkdownIR renders through typed Rabbita HTML |
+| Preview source/block edit | editor commit succeeds | once after commit | Raw, Block, and Preview reflect the same canonical source |
+| Preview no-op or rejected edit | no committed source change | none | prior owning Preview document and focus remain visible |
+| Snapshot restore to Preview | source/mode transaction succeeds | once after acceptance | restored source and semantic document appear atomically |
+| Snapshot restore outside Preview | transaction succeeds | none; semantic model may be cleared | editable source/projection behavior is unchanged |
+| Prepend, position shift, exact reversal | commit succeeds in Preview | once per committed edit | attached result matches fresh one-shot MarkdownIR lowering |
+| Malformed intermediate input | parser accepts recovered source | once per committed edit in Preview | `Raw`/`Recovered` are visible; no last-good substitution |
+| Valid inline/block HTML | semantic render | no extra read | literal content is escaped text, never injected DOM markup |
+| Repeated mode switches and mount rejection | accepted transition / rejected second mount | only non-Preview → Preview reads | attachment count stays one; existing single-mount contract stays green |
+
+The deterministic renderer exhaustively matches `MarkdownIRView`. It consumes
+an already-owned document and performs no parser, attachment, DOM, clock,
+subscription, or `document()` effect. Reading the attachment and installing the
+owning document remain imperative-shell work at the committed boundaries above.
 
 ### Canonical Session, adapters, and Waku
 

--- a/docs/plans/2026-08-01-loomark-application-handoff.md
+++ b/docs/plans/2026-08-01-loomark-application-handoff.md
@@ -227,7 +227,7 @@ Each ticket begins with behavioral matrix and first RED test, makes one logical 
 
 ### Source-aware semantic Preview
 
-#1145 follows the completed private Application Train and does not wait for
+Issue #1145 follows the completed private Application Train and does not wait for
 Rabbita #141. It attaches one `MarkdownSemanticAttachment` to the exact parser
 created for the private Loomark editor and retains it for the existing
 page/process lifetime. Raw and Block keep the editable `Block` projection;

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -393,6 +393,32 @@ pub fn MarkdownEditor::MarkdownEditor(
     error =>
       raise MarkdownEditorError::InitializationFailed(detail=error.message())
   }
+  initialize_markdown_editor(editor, source)
+}
+
+///|
+/// Create a Markdown façade and a semantic attachment over the same live
+/// parser. The ordinary constructor remains attachment-free.
+pub fn MarkdownEditor::with_semantic_attachment(
+  agent_id~ : String,
+  source~ : String,
+) -> (MarkdownEditor, @md_markdown.MarkdownSemanticAttachment) raise MarkdownEditorError {
+  let (editor, attachment) = @md_companion.new_markdown_editor_with_semantic_attachment(
+    agent_id,
+  ) catch {
+    @text.TextError::EmptyReplicaId => raise MarkdownEditorError::InvalidAgentId
+    error =>
+      raise MarkdownEditorError::InitializationFailed(detail=error.message())
+  }
+  (initialize_markdown_editor(editor, source), attachment)
+}
+
+///|
+/// Seed source and projection identically for every façade construction path.
+fn initialize_markdown_editor(
+  editor : @editor.SyncEditor[@md_markdown.Block],
+  source : String,
+) -> MarkdownEditor {
   editor.set_text(source)
   editor.refresh()
   { editor, }

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -1,5 +1,44 @@
 ///| The first public headless Markdown façade seam.
 
+///|
+fn fresh_markdown_ir(source : String) -> @md_markdown.MarkdownIR {
+  let parser = @loom.new_parser(
+    @loom.SourceId("markdown-editor-semantic-fresh"),
+    source,
+    @md_markdown.markdown_grammar,
+  )
+  let snapshot = parser.snapshot().read_or_abort()
+  @md_markdown.experimental_markdown_ir_from_syntax_with_diagnostics(
+    parser.source_id(),
+    snapshot.syntax,
+    snapshot.diagnostics,
+  )
+}
+
+///|
+test "semantic attachment follows MarkdownEditor source commits" {
+  let source = "# Heading [ref]\n\nBefore\n\n[ref]: /one \"title\"\n"
+  let (editor, attachment) = try! MarkdownEditor::with_semantic_attachment(
+    agent_id="markdown-semantic-facade",
+    source~,
+  )
+
+  assert_eq(attachment.document(), fresh_markdown_ir(source))
+
+  let updated = "# Heading [ref]\n\nAfter\n\n[ref]: /two \"changed\"\n"
+  match editor.commit(MarkdownEditRequest::ReplaceSource(updated)) {
+    Ok(MarkdownCommitResult::Applied(_, None)) => ()
+    _ => fail("expected source replacement to commit")
+  }
+  // snapshot observes both the projection and its SourceMap after attachment
+  // collection has run on the shared parser runtime.
+  let snapshot = editor.snapshot()
+  assert_eq(snapshot.source(), updated)
+  assert_eq(snapshot.blocks().to_array()[1].text(), "After")
+  assert_eq(attachment.document(), fresh_markdown_ir(updated))
+  attachment.dispose()
+}
+
 /// #1075 behavioral boundary matrix
 /// Syntax: tight top-level unordered and ordered (`.`/`)`, non-1) list items,
 /// fenced backtick/tilde code; terminators: LF/CRLF/CR/EOF; operations:

--- a/modules/canopy/editor/markdown/moon.pkg
+++ b/modules/canopy/editor/markdown/moon.pkg
@@ -10,6 +10,10 @@ import {
   "moonbitlang/core/immut/vector",
 }
 
+import {
+  "dowdiness/loom",
+} for "wbtest"
+
 warnings = "-7-29"
 
 options(

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -116,6 +116,7 @@ pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -
 pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory) -> Self raise MarkdownArchiveError
 pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
 pub fn MarkdownEditor::version(Self) -> MarkdownDocumentVersion
+pub fn MarkdownEditor::with_semantic_attachment(agent_id~ : String, source~ : String) -> (Self, @dowdiness/markdown.MarkdownSemanticAttachment) raise MarkdownEditorError
 
 pub struct MarkdownNodeId {
   // private fields

--- a/modules/canopy/editor/sync_editor.mbt
+++ b/modules/canopy/editor/sync_editor.mbt
@@ -14,6 +14,12 @@ pub struct SyncEditor[T] {
   priv cached_proj_node : @incr.Derived[@core.ProjNode[T]?]
   priv registry_memo : @incr.Derived[Map[@core.NodeId, @core.ProjNode[T]]]
   priv source_map_memo : @incr.Derived[@core.SourceMap]
+  // These private roots give the projection graph the same page/process
+  // lifetime as its owning editor. A shared-runtime attachment may run
+  // runtime-wide collection without sweeping editor-owned memos.
+  priv projection_anchor : @incr.Watch[@core.ProjNode[T]?]
+  priv registry_anchor : @incr.Watch[Map[@core.NodeId, @core.ProjNode[T]]]
+  priv source_map_anchor : @incr.Watch[@core.SourceMap]
   priv capabilities : LanguageCapabilities[T]
   priv hub : EphemeralHub
   priv cursor_view : PeerCursorView
@@ -75,6 +81,9 @@ pub fn[T] SyncEditor::new_generic(
     label="sync_editor_document_version",
   )
   let (cached_proj_node, registry_memo, source_map_memo) = build_memos(parser)
+  let projection_anchor = cached_proj_node.watch()
+  let registry_anchor = registry_memo.watch()
+  let source_map_anchor = source_map_memo.watch()
   let (hub, cursor_view) = setup_hub_and_cursor(agent_id)
   {
     doc,
@@ -85,6 +94,9 @@ pub fn[T] SyncEditor::new_generic(
     cached_proj_node,
     registry_memo,
     source_map_memo,
+    projection_anchor,
+    registry_anchor,
+    source_map_anchor,
     capabilities,
     hub,
     cursor_view,

--- a/modules/canopy/editor/sync_editor_accessors_test.mbt
+++ b/modules/canopy/editor/sync_editor_accessors_test.mbt
@@ -28,6 +28,23 @@ test "SyncEditor exposes typed accessors for protected cells" {
 }
 
 ///|
+test "SyncEditor keeps its projection graph rooted across runtime collection" {
+  let editor = try! @probe.new_test_editor("projection-root-owner")
+  editor.set_text("x")
+  editor.refresh()
+  let projection = editor.cached_proj_node()
+  let registry = editor.registry_memo()
+  let source_map = editor.source_map_memo()
+
+  editor.parser_runtime().gc()
+  editor.parser_runtime().gc()
+
+  let _ = projection.read_or_abort()
+  let _ = registry.read_or_abort()
+  let _ = source_map.read_or_abort()
+}
+
+///|
 test "SyncEditor source identity is construction-scoped and stable across edits" {
   let first = try! @probe.new_test_editor("shared-agent")
   let second = try! @probe.new_test_editor("shared-agent")

--- a/modules/canopy/lang/json/companion/edit_messages_wbtest.mbt
+++ b/modules/canopy/lang/json/companion/edit_messages_wbtest.mbt
@@ -1,7 +1,7 @@
 // Message-contract pins for apply_json_edit error paths (S3 lang/runtime
 // migration safety net — docs/plans/2026-06-11-s3-lang-runtime-extraction.md
-// Step 2). Expectations are frozen string literals; do not regenerate them
-// by calling the migrated path.
+// Step 2). Message templates are frozen; runtime-owned NodeId values are
+// interpolated from the request target rather than global construction order.
 
 // Note: the bridge's "no projection available" guard and the
 // "unhandled edit op" policy branch are unreachable through the JSON surface
@@ -49,12 +49,7 @@ test "apply_json_edit message pin: absent node id -> compute error" {
   editor.set_text("42")
   match apply_json_edit(editor, JsonEditOp::Delete(node_id=absent_id), 0) {
     Err(msg) =>
-      inspect(
-        msg,
-        content=(
-          #|compute_json_edit: node NodeId(5) not in source map
-        ),
-      )
+      assert_eq(msg, "compute_json_edit: node \{absent_id} not in source map")
     Ok(_) => fail("expected Err for absent node id")
   }
 }

--- a/modules/canopy/lang/markdown/companion/edit_messages_wbtest.mbt
+++ b/modules/canopy/lang/markdown/companion/edit_messages_wbtest.mbt
@@ -1,7 +1,7 @@
 // Message/no-op contract pins for apply_markdown_edit error paths (S3
 // lang/runtime migration safety net —
-// docs/plans/2026-06-11-s3-lang-runtime-extraction.md Step 3). Expectations
-// are frozen; do not regenerate them by calling the migrated path.
+// docs/plans/2026-06-11-s3-lang-runtime-extraction.md Step 3). Message
+// templates are frozen; runtime-owned NodeId values come from the request.
 
 ///|
 test "apply_markdown_edit pin: merge on first block -> silent no-op" {
@@ -48,12 +48,7 @@ test "apply_markdown_edit pin: absent node id -> compute error" {
       0,
     ) {
     Err(msg) =>
-      inspect(
-        msg,
-        content=(
-          #|compute_markdown_edit: node NodeId(3) not found
-        ),
-      )
+      assert_eq(msg, "compute_markdown_edit: node \{last.id()} not found")
     Ok(_) => fail("expected Err for absent node id")
   }
 }

--- a/modules/canopy/lang/markdown/companion/integration_wbtest.mbt
+++ b/modules/canopy/lang/markdown/companion/integration_wbtest.mbt
@@ -4,6 +4,23 @@
 using @md_edits {type MarkdownEditOp}
 
 ///|
+test "semantic companion factory follows its editor parser" {
+  let (editor, attachment) = try! new_markdown_editor_with_semantic_attachment(
+    "semantic-companion",
+  )
+  editor.set_text("# Before\n")
+  let before = attachment.document()
+  editor.set_text("# After\n")
+  let after = attachment.document()
+
+  assert_eq(before.kind_tag(), "Document")
+  assert_true(before != after)
+  assert_true(editor.get_proj_node() is Some(_))
+  let _ = editor.get_source_map()
+  attachment.dispose()
+}
+
+///|
 test "round-trip: new_markdown_editor + apply_markdown_edit" {
   let ed = try! new_markdown_editor("test")
   ed.set_text("# Hello\n\nWorld\n")

--- a/modules/canopy/lang/markdown/companion/markdown_companion.mbt
+++ b/modules/canopy/lang/markdown/companion/markdown_companion.mbt
@@ -10,6 +10,36 @@ pub fn new_markdown_editor(
   capture_timeout_ms? : Int = 500,
   parent_runtime? : @incr.Runtime,
 ) -> @editor.SyncEditor[@markdown.Block] raise @text.TextError {
+  new_markdown_editor_impl(agent_id, capture_timeout_ms~, parent_runtime?)
+}
+
+///|
+/// Construct the standard Markdown editor and one semantic attachment over
+/// the exact parser created for it. No parser or reactive handle escapes this
+/// Markdown-specific companion boundary.
+pub fn new_markdown_editor_with_semantic_attachment(
+  agent_id : String,
+  capture_timeout_ms? : Int = 500,
+  parent_runtime? : @incr.Runtime,
+) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise @text.TextError {
+  let attachment : Ref[@markdown.MarkdownSemanticAttachment?] = Ref(None)
+  let editor = new_markdown_editor_impl(
+    agent_id,
+    capture_timeout_ms~,
+    parent_runtime?,
+    semantic_attachment=attachment,
+  )
+  (editor, attachment.val.unwrap())
+}
+
+///|
+/// Shared construction implementation for the ordinary and semantic paths.
+fn new_markdown_editor_impl(
+  agent_id : String,
+  capture_timeout_ms? : Int = 500,
+  parent_runtime? : @incr.Runtime,
+  semantic_attachment? : Ref[@markdown.MarkdownSemanticAttachment?],
+) -> @editor.SyncEditor[@markdown.Block] raise @text.TextError {
   let hints_ref : Ref[Array[@core.IdentityTransform]] = Ref([])
   @editor.SyncEditor::new_generic(
     agent_id,
@@ -17,7 +47,20 @@ pub fn new_markdown_editor(
       @loom.new_parser(source_id, source, @markdown.markdown_grammar, runtime?)
     },
     parser => {
-      @md_proj.build_markdown_projection_memos(parser, identity_hints=hints_ref)
+      let memos = @md_proj.build_markdown_projection_memos(
+        parser,
+        identity_hints=hints_ref,
+      )
+      match semantic_attachment {
+        Some(sink) =>
+          sink.val = Some(
+            @markdown.MarkdownSemanticAttachment::MarkdownSemanticAttachment(
+              parser,
+            ),
+          )
+        None => ()
+      }
+      memos
     },
     capture_timeout_ms~,
     parent_runtime?,

--- a/modules/canopy/lang/markdown/companion/pkg.generated.mbti
+++ b/modules/canopy/lang/markdown/companion/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn export_markdown_text(@editor.SyncEditor[@markdown.Block]) -> String
 
 pub fn new_markdown_editor(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> @editor.SyncEditor[@markdown.Block] raise @text.TextError
 
+pub fn new_markdown_editor_with_semantic_attachment(String, capture_timeout_ms? : Int, parent_runtime? : @cells.Runtime) -> (@editor.SyncEditor[@markdown.Block], @markdown.MarkdownSemanticAttachment) raise @text.TextError
+
 // Errors
 
 // Types and methods


### PR DESCRIPTION
## Summary

- Add a Markdown-specific construction path that returns the existing editor facade and one semantic observer over the exact same live parser.
- Replace the legacy Block-snapshot Preview with a committed MarkdownIR read model and an exhaustive typed Rabbita renderer, including recovery, diagnostics, escaped HTML, and URL safety.
- Add focused MoonBit/browser coverage, a 2,500-block JavaScript release benchmark, and the ownership decision record.

Closes #1145.

Non-gating follow-ups: Preview materialization profiling #1156; reusable lifecycle ownership #1159.

## UI and review evidence

- [x] N/A — no visible label was removed; Preview remains a labelled region with keyboard focus and the existing Raw/Block/Preview accessible names.
- [x] Interactive bounds, keyboard focus, narrow-viewport reflow, mode switching, source commits, recovery, and snapshot restoration were checked in the rendered Vanilla host; Playwright passed 60/60 on the validated HEAD.
- [x] Repository requirements are tied to #1145, AGENTS.md, the canonical Loomark plan, and the ownership decision record. CodeRabbit review findings were resolved; independent post-sync review passed.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| MarkdownSemanticAttachment and MarkdownIR read/view operations | deps/loom/examples/markdown | Yes | Same-parser owning semantic read and exhaustive renderer input. |
| Markdown companion parser/projection construction closure | modules/canopy/lang/markdown/companion | Yes | Captures the exact live parser without a parser accessor or second parser. |
| MarkdownEditor construction and initialization | modules/canopy/editor/markdown | Yes | Ordinary construction stays observer-free and both paths share initialization. |
| Rabbita typed HTML/RUI builders | deps/rabbita | Yes | Produces inert typed views rather than injected HTML strings. |
| MoonBit Option, Result, Array, String, and StringBuilder | moonbitlang/core | Yes | Used for read decisions, tree traversal, URL policy, and benchmark fixtures. |
| MoonBit Map, Set, StringView, and ArrayView | moonbitlang/core | No | Ordered owning tree rendering does not need keyed membership or borrowed-view state. |
| Loom safe HTML adapter | deps/loom/examples/markdown | No | Policy oracle only; its HTML string is not passed to the DOM. |
| Generic SyncEditor parser/reactive accessors | modules/canopy/editor | No | Would expose parser/runtime internals and weaken the editor seam. |

New helpers added:

- Markdown-specific editor/observer construction and shared initialization helpers keep the ordinary interface observer-free.
- Preview document decisions keep committed read decisions pure and effectful reads in the imperative shell.
- Renderer-local helpers exhaustively lower semantic Markdown forms into typed inert views.
- One shared white-box MarkdownIR fixture helper serves SSR tests and benchmarks without duplicate parsing code.

The private host intentionally keeps editor projection roots and its semantic observer for the current page/process lifetime. Explicit reusable teardown is tracked in #1159 and must land before remount, host reuse, or short-lived editors on a shared runtime become supported.

## Validation scope

Boundary matrix / first failing regression:

- Same-parser fresh-versus-attached semantic parity and ordinary-construction separation.
- Initial Preview, Raw/Block entry, accepted source changes, rejected/no-op commits, restore, mode switches, source shifts, malformed recovery, and exact reversal.
- Headings, paragraphs, tight/loose and nested lists, code, quotations, thematic breaks, inline forms, links/images/references, autolinks, line breaks, escaped HTML, Raw/Recovered nodes, diagnostics, and dangerous URL rejection.
- Runtime-wide collection followed by readable editor projection, registry, and source mapping.

Target packages:

- modules/canopy/editor
- modules/canopy/editor/markdown
- modules/canopy/lang/markdown/companion
- apps/loomark/internal/rabbita
- modules/canopy/lang/json/companion

Additional conditional gates:

- Target JavaScript release tests: 232/232, 58/58, 18/18, 11/11, and 23/23.
- Workspace tests: 4473/4473; zero non-vendored baseline failures.
- Vanilla TypeScript check and Playwright: 60/60.
- Documentation lifecycle and agent-document link checks passed.
- Generated interface review found only the two intended Markdown construction functions and no trait-bound drift.
- Preview release benchmarks: initial 26.95 ms; edited 25.88 ms; edit/reversal cycle 52.91 ms; same-document structural equality 0.94 ms; middle-edit equality 2.53 ms.
- No submodule pointer changed; recorded commits were checked against configured origins and dependency identities.

## PR-ready evidence

Validated HEAD: `108968a1cdd9444a7f3f1870325035f63c477ff8`

Validated base: `origin/main@2c9fc0d939617e5057ab90a8d536e67a7303e079`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor \
  --target modules/canopy/editor/markdown \
  --target modules/canopy/lang/markdown/companion \
  --target apps/loomark/internal/rabbita \
  --target modules/canopy/lang/json/companion
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR update.
- [x] The committed `.mbti` diff against the validated base was reviewed for unintended API or trait-bound changes.
- [x] No submodule pointer changed; every recorded commit is reachable from its configured origin.
- [x] Validation was rerun after the rebase, review-fix commit, manifest change, and generated-interface check.
- [x] Independent review findings were resolved before final validation.
