### PR TITLE
docs: add durable zone navigation guides

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,0 +1,13 @@
+# Adapters
+
+Non-MoonBit runtime and interface integrations live here. Adapters translate
+between stable Canopy interfaces and host-specific concerns without owning the
+editor's domain behavior.
+
+Placement decisions are defined by the
+[module and package placement rules](../docs/development/module-package-map.md).
+
+Do not maintain an adapter inventory in this file. Read each adapter's local
+package and build configuration for its current entry points. Inspect the
+owning MoonBit package with `moon ide outline <path>` before changing the
+interface it consumes.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,13 @@
+# Applications
+
+Runnable or deployable Canopy products live here. An application may combine
+MoonBit modules, generated JavaScript artifacts, frontend code, deployment
+configuration, and end-to-end tests as one vertical slice.
+
+Placement decisions are defined by the
+[module and package placement rules](../docs/development/module-package-map.md).
+
+Do not maintain an application inventory in this file. Read each application's
+own manifests and package scripts. Root MoonBit workspace coverage is declared
+by [`../moon.work`](../moon.work); CI and deployment coverage is declared by
+[`../.github/workflows/`](../.github/workflows/).

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,0 +1,20 @@
+# Dependencies
+
+Separately owned Git repositories are checked out here as submodules. A
+dependency may also be a MoonBit workspace member; repository ownership and
+workspace membership are independent.
+
+## Working here
+
+- Use [`.gitmodules`](../.gitmodules) for the authoritative submodule paths and
+  remotes.
+- Follow the dependency repository's own guidance and manifests.
+- Commit and push changes in the submodule repository before updating the
+  parent pointer in Canopy.
+
+Do not maintain a dependency inventory in this file. Use
+`git submodule status --recursive` for the checked-out revisions and
+[`../moon.work`](../moon.work) for root-workspace membership.
+
+See the [submodule workflow](../docs/development/workflow.md) and the
+[module and package placement rules](../docs/development/module-package-map.md).

--- a/docs/development/module-package-map.md
+++ b/docs/development/module-package-map.md
@@ -125,17 +125,13 @@ own MoonBit module and workspace:
 
 Examples under `examples/` fall into two broad groups:
 
-- **MoonBit workspace example modules**: listed in the root `moon.work`, checked
-  by root workspace commands, and covered by CI's MoonBit example matrix.
-  Examples include `examples/codemirror/`, `examples/resizable/`, and
-  `examples/disclosure/`.
-- **Frontend/TypeScript/browser examples**: npm/Vite/Playwright projects that
-  require built MoonBit JS artifacts before TypeScript typechecks or browser
-  tests run. Examples include `examples/prosemirror/` and
-  `examples/demo-react/`.
+- **MoonBit workspace example modules**: declared by the root `moon.work` and
+  their nearest MoonBit manifests.
+- **Frontend/TypeScript/browser examples**: declared by their local package and
+  build configuration, with CI coverage defined in `.github/workflows/ci.yml`.
 
-See [`examples/README.md`](../../examples/README.md) for the example-by-example
-classification and commands.
+See [`examples/README.md`](../../examples/README.md) for the two workflow
+categories and their generic commands.
 
 ## Experimental and compatibility surfaces
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,20 +6,14 @@ JavaScript artifacts.
 
 ## MoonBit workspace example modules
 
-These directories have their own MoonBit module manifest and are listed in the
-root `moon.work`, so root-level `moon check` / `moon test` covers them as
-workspace members:
-
-| Example | Purpose | CI mechanism |
-| --- | --- | --- |
-| `examples/codemirror/` | CodeMirror binding demo module. | `scripts/run-moon-module.sh ci examples/codemirror`; browser wrapper is in the same directory. |
-| `examples/resizable/` | Rabbita resizable example module. | Covered by root workspace commands. |
-| `examples/disclosure/` | Rabbita disclosure example module. | Covered by root workspace commands. |
+MoonBit examples have their own module manifests. Root commands cover only the
+members declared by [`../moon.work`](../moon.work); read the nearest `moon.mod`
+and `moon.pkg` for module and package dependencies.
 
 Run a single MoonBit example directly with:
 
 ```sh
-cd examples/<name>
+cd examples/NAME
 moon check
 moon test
 ```
@@ -33,21 +27,18 @@ from the repository root when they import Canopy-generated output:
 moon build --target js
 ```
 
-| Frontend | Tooling | Notes |
-| --- | --- | --- |
-| `examples/demo-react/` | React/Vite + TypeScript + Vitest + Playwright | React integration demo plus local WebSocket helpers. |
-| `examples/prosemirror/` | Vite + TypeScript | ProseMirror integration example. |
-
 Typical frontend workflow:
 
 ```sh
-cd examples/demo-react
+cd examples/NAME
 npm ci
 npm run dev
 ```
 
-CI is the source of truth for the exact frontend fan-out and pinned Playwright
-container versions. See `.github/workflows/ci.yml` for the current matrices.
+CI is the source of truth for the exact frontend fan-out and pinned browser
+test environment. See
+[`../.github/workflows/ci.yml`](../.github/workflows/ci.yml) for the current
+matrices.
 
 ## Relationship to module/package map
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,14 @@
+# Modules
+
+Reusable, publishable MoonBit modules owned by this repository live here. The
+primary `dowdiness/canopy` module is `canopy/`; each sibling directory is an
+independently owned module.
+
+Placement decisions are defined by the
+[module and package placement rules](../docs/development/module-package-map.md).
+
+Do not maintain a module or package inventory in this file. Read
+[`../moon.work`](../moon.work) for root-workspace membership, the nearest
+`moon.mod` for module identity and dependencies, and the nearest `moon.pkg` for
+package dependencies. Use `moon ide outline <path>` to inspect a package's
+public interface.

--- a/modules/canopy/README.mbt.md
+++ b/modules/canopy/README.mbt.md
@@ -107,24 +107,25 @@ The repository is organised into seven zones:
 
 | Zone | Path | Purpose |
 |------|------|---------|
-| Modules | `modules/` | Reusable, publishable MoonBit modules; includes the primary `modules/canopy` |
-| Applications | `apps/` | Runnable or deployable vertical slices |
-| Examples | `examples/` | Removable learning and integration examples |
-| Adapters | `adapters/` | Non-MoonBit runtime and interface adapters |
-| Dependencies | `deps/` | Separately owned Git submodules |
-| Rules | `rules/` | Policy definitions |
-| Scripts | `scripts/` | Operations and tooling |
+| [Modules](../../modules/) | `modules/` | Reusable, publishable MoonBit modules; includes the primary `modules/canopy` |
+| [Applications](../../apps/) | `apps/` | Runnable or deployable vertical slices |
+| [Examples](../../examples/) | `examples/` | Removable learning and integration examples |
+| [Adapters](../../adapters/) | `adapters/` | Non-MoonBit runtime and interface adapters |
+| [Dependencies](../../deps/) | `deps/` | Separately owned Git submodules |
+| [Rules](../../rules/) | `rules/` | Policy definitions |
+| [Scripts](../../scripts/) | `scripts/` | Operations and tooling |
 
 Workspace membership is declared by [`moon.work`](../../moon.work); Git
 submodule ownership by [`.gitmodules`](../../.gitmodules). The two axes
 intentionally overlap: a submodule under `deps/` can also be a root-workspace
 member.
 
-For the exact package inventory, inspect the `moon.pkg` manifests under
-`modules/canopy/` and use `moon ide outline <path>` for a package's public
-interface. The [Module / Package Map](../../docs/development/module-package-map.md)
-explains placement rules; the [API Map](../../docs/api-map.md) is the task-first
-index for calling Canopy from MoonBit or JavaScript.
+Each zone README explains what belongs there without copying its current
+inventory. For concrete ownership, read `moon.work`, `.gitmodules`, and the
+nearest `moon.mod` and `moon.pkg`; use `moon ide outline <path>` to inspect a
+package's public interface. The
+[Module / Package Map](../../docs/development/module-package-map.md) explains
+the placement rules and how these sources overlap.
 
 The FFI stability surface is intentionally narrow: JS frontends should consume
 the editor through [`adapters/editor`](../../adapters/editor/) where

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,12 @@
+# Rules
+
+Machine-readable repository policy definitions live here. Rules should express
+general invariants that remain valid as individual packages and files change.
+
+Placement decisions are defined by the
+[module and package placement rules](../docs/development/module-package-map.md).
+
+Do not maintain a rule inventory in this file. The files in this directory and
+the configuration of the tool that loads them are authoritative.
+
+See the [development documentation](../docs/development/).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,15 @@
+# Scripts
+
+Repository operations and tooling live here. Scripts automate durable build,
+check, test, dependency, release, and maintenance workflows.
+
+Placement decisions are defined by the
+[module and package placement rules](../docs/development/module-package-map.md).
+Prefer standard `moon` workspace commands over wrappers that copy membership
+from [`../moon.work`](../moon.work).
+
+Do not maintain a script inventory or copied command reference in this file.
+Use the scripts themselves, the root [`Makefile`](../Makefile), and
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml) as the authoritative
+operational sources. Development guidance belongs under
+[`../docs/development/`](../docs/development/).


### PR DESCRIPTION
## Summary

- Add concise README guides for the `modules`, `apps`, `adapters`, `deps`, `rules`, and `scripts` zones.
- Link the root repository structure table to each zone guide.
- Remove hard-coded example inventories and delegate live membership to `moon.work`, local manifests/package configuration, and CI.
- Keep cross-zone placement rules centralized in `docs/development/module-package-map.md`.
- Avoid making root navigation depend on the handwritten task-to-interface API map.

## Drift-resistance contract

Zone READMEs contain only their stable local purpose, authoritative discovery sources, and generic commands. They do not copy child-directory inventories or cross-zone placement matrices.

## Reuse check

N/A — documentation-only. Reuses `moon.work`, `.gitmodules`, nearest `moon.mod`/`moon.pkg`, local package configuration, `.github/workflows/ci.yml`, and `moon ide outline <path>` as authoritative sources.

## Verification

- Relative-link validation: 9 files checked, 0 broken links
- `moon check`
- `scripts/check-agent-doc-links.sh`
- `scripts/test-documentation-lifecycle.sh`
- `moon info && moon fmt`
- `git diff --check`
- Independent review: PASS after resolving the stale examples-inventory claim (`opencode-zen/deepseek-v4-flash-free`)
- `./scripts/validate-pr-ready.sh --no-target "documentation-only zone navigation; no MoonBit package behavior changed"`
- `./scripts/validate-pr-ready.sh --verify-evidence`

Validated HEAD: `e9780fe2e33a98f443004b07721850f0dbd77d86`
Validated base: `275228287f7d9307286c114fcd15c2e24010e848`
Validated base ref: `origin/main`