### PR TITLE
feat(loomark): add responsive split preview

### DIFF
--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -718,8 +718,14 @@ test("Block delete focuses the adjacent survivor instead of a stale editor curso
     await selectBlock(host.page)
     const first = host.page.locator("#loomark-block-input")
     await first.fill("Changed")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(
+      "Changed\n\nSecond\n\nThird\n",
+    )
     const third = host.page.locator("#loomark-block-input-2")
     await third.focus()
+    await expect(
+      host.page.locator('[data-loomark-block-row]').filter({ has: third }),
+    ).toHaveAttribute("data-loomark-block-active", "true")
 
     await host.page.getByRole("button", { name: "Delete selected block" }).click()
 

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -11,6 +11,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
  * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
  * | semantic Preview | blocks, inline forms, recovery, unsafe URLs | RUI-aligned read-only semantic DOM from the committed MarkdownIR |
+ * | fixed split Preview | Raw/Block editor plus Preview | one editor and one semantic attachment stay live; accepted commits update both panes |
  * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
  * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
  * | Block formatting | focused paragraph/heading/list item | typed heading/list/delete requests update source and restore a valid target |
@@ -88,6 +89,10 @@ async function selectBlock(page: Page): Promise<void> {
 async function selectRaw(page: Page): Promise<void> {
   await page.evaluate(moduleUrl =>
     import(moduleUrl).then(module => module.dev_host_select_raw()), moduleUrl)
+}
+
+async function toggleSplitPreview(page: Page): Promise<void> {
+  await page.locator("#loomark-split-toggle").click()
 }
 
 async function restoreSnapshot(page: Page, version: number, source: string, mode: "raw" | "block" | "preview"): Promise<void> {
@@ -203,6 +208,134 @@ test("Raw input preserves canonical source and Preview follows a committed edit"
     await selectPreview(host.page)
     await expect(host.page.locator("#loomark-preview")).toHaveCount(1)
     await expectPreviewSource(host.page, "after\r\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Raw and Preview observe one accepted document in a fixed resizable split", async ({ browser }) => {
+  const host = await mountHost(browser, "# Before\n")
+  try {
+    await expect(host.page.locator("#loomark-input")).toHaveCount(1)
+    await expect(host.page.locator("#loomark-preview")).toHaveCount(0)
+
+    await toggleSplitPreview(host.page)
+    await expect(host.page.locator("#loomark-split-toggle")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    await expect(host.page.locator("#loomark-split")).toHaveAttribute(
+      "data-slot",
+      "resizable-panel-group",
+    )
+    await expect(host.page.locator("#loomark-input")).toHaveCount(1)
+    await expectPreviewSource(host.page, "# Before\n")
+    await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(1)
+
+    await selectPreview(host.page)
+    await expect(host.page.locator("#loomark-split")).toHaveCount(0)
+    await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(1)
+    await selectRaw(host.page)
+    await expect(host.page.locator("#loomark-split")).toHaveCount(1)
+    await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(1)
+
+    await host.page.locator("#loomark-input").fill("# After\n")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# After\n")
+    await expectPreviewSource(host.page, "# After\n")
+    await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(2)
+
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await host.page.locator("#loomark-input").evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.value = "# Rejected\n"
+      textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# After\n")
+    await expectPreviewSource(host.page, "# After\n")
+    await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(2)
+
+    await toggleSplitPreview(host.page)
+    await expect(host.page.locator("#loomark-preview")).toHaveCount(0)
+    await expect(host.page.locator("#loomark-input")).toHaveCount(1)
+    await expect.poll(async () => (await snapshot(host.page)).semantic_read_count).toBe(2)
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("split divider resizes by keyboard and exposes its current width", async ({ browser }) => {
+  const host = await mountHost(browser, "# Resize\n")
+  try {
+    await toggleSplitPreview(host.page)
+    const handle = host.page.locator("#loomark-split-handle")
+    await expect(handle).toHaveAttribute("aria-valuenow", "384")
+
+    await handle.focus()
+    await handle.press("ArrowRight")
+
+    await expect(handle).toHaveAttribute("aria-valuenow", "392")
+    await expect(host.page.locator('[data-panel="editor"]')).toHaveCSS(
+      "width",
+      "392px",
+    )
+
+    const bounds = await handle.boundingBox()
+    expect(bounds).not.toBeNull()
+    await host.page.mouse.move(bounds!.x, bounds!.y + bounds!.height / 2)
+    await host.page.mouse.down()
+    await host.page.mouse.move(bounds!.x + 40, bounds!.y + bounds!.height / 2)
+    await host.page.mouse.up()
+
+    await expect(handle).toHaveAttribute("aria-valuenow", "432")
+    await expect(host.page.locator('[data-panel="editor"]')).toHaveCSS(
+      "width",
+      "432px",
+    )
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("Block and Preview converge through the shared canonical document", async ({ browser }) => {
+  const host = await mountHost(browser, "# Before\n")
+  try {
+    await selectBlock(host.page)
+    await toggleSplitPreview(host.page)
+    await expectPreviewSource(host.page, "# Before\n")
+
+    await host.page.locator("#loomark-block-input").fill("After")
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("# After\n")
+    await expectPreviewSource(host.page, "# After\n")
+    await expect(
+      host.page.locator('#loomark-preview h1[data-slot="typography-h1"]'),
+    ).toHaveText("After")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("split view keeps both surfaces inside a narrow viewport", async ({ browser }) => {
+  const host = await mountHost(browser, "# Narrow\n")
+  try {
+    await host.page.setViewportSize({ width: 390, height: 844 })
+    await toggleSplitPreview(host.page)
+
+    await expect(host.page.locator('[data-panel="editor"]')).toBeVisible()
+    await expect(host.page.locator('[data-panel="preview"]')).toBeVisible()
+    const editorWidth = await host.page.locator('[data-panel="editor"]').evaluate(
+      element => Math.round(element.getBoundingClientRect().width),
+    )
+    await expect(host.page.locator("#loomark-split-handle")).toHaveAttribute(
+      "aria-valuenow",
+      editorWidth.toString(),
+    )
+    await expect.poll(() => host.page.evaluate(() => ({
+      viewport: window.innerWidth,
+      content: document.documentElement.scrollWidth,
+    }))).toEqual({ viewport: 390, content: 390 })
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -11,7 +11,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | unsupported containers | quote/thematic/list | reject atomically; neighbors/ranges/focus unchanged |
  * | tight list / fenced code | unordered, ordered `)`, tilde fence, mixed CRLF | typed payload controls preserve markers, delimiters, and line endings |
  * | semantic Preview | blocks, inline forms, recovery, unsafe URLs | RUI-aligned read-only semantic DOM from the committed MarkdownIR |
- * | fixed split Preview | Raw/Block editor plus Preview | one editor and one semantic attachment stay live; accepted commits update both panes |
+ * | fixed split Preview | Raw/Block editor plus Preview, wide/narrow viewport | one editor and one semantic attachment stay live; accepted commits update both panes; the divider axis follows the available width |
  * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
  * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
  * | Block formatting | focused paragraph/heading/list item | typed heading/list/delete requests update source and restore a valid target |
@@ -286,25 +286,38 @@ test("Raw keeps focus and accepts consecutive keystrokes while split Preview upd
     await expect(input).toHaveValue("startabc")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("startabc")
     await expectPreviewSource(host.page, "startabc")
+
+    await host.page.setViewportSize({ width: 390, height: 844 })
+    await expect(host.page.locator("#loomark-split")).toHaveAttribute(
+      "data-orientation",
+      "vertical",
+    )
+    await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+      "loomark-input",
+    )
+    await host.page.keyboard.type("d")
+    await expect(input).toHaveValue("startabcd")
   } finally {
     await host.context.close()
   }
 })
 
-test("split divider resizes by keyboard and exposes its current width", async ({ browser }) => {
+test("RUI split divider resizes by keyboard and pointer", async ({ browser }) => {
   const host = await mountHost(browser, "# Resize\n")
   try {
     await toggleSplitPreview(host.page)
-    const handle = host.page.locator("#loomark-split-handle")
-    await expect(handle).toHaveAttribute("aria-valuenow", "384")
+    const split = host.page.locator("#loomark-split")
+    const handle = split.locator('[data-slot="resizable-handle"]')
+    const control = host.page.locator("#loomark-split-handle")
+    await expect(handle).toHaveAttribute("aria-valuenow", "50")
 
-    await handle.focus()
-    await handle.press("ArrowRight")
+    await control.focus()
+    await control.press("ArrowRight")
 
-    await expect(handle).toHaveAttribute("aria-valuenow", "392")
-    await expect(host.page.locator('[data-panel="editor"]')).toHaveCSS(
-      "width",
-      "392px",
+    await expect(handle).toHaveAttribute("aria-valuenow", "51")
+    await expect(host.page.locator('[data-panel="editor"]')).toHaveAttribute(
+      "data-size",
+      "51",
     )
 
     const hitArea = host.page.locator('[data-slot="resizable-handle-hit-area"]')
@@ -316,11 +329,8 @@ test("split divider resizes by keyboard and exposes its current width", async ({
     await host.page.mouse.move(bounds!.x + 41, bounds!.y + bounds!.height / 2)
     await host.page.mouse.up()
 
-    await expect(handle).toHaveAttribute("aria-valuenow", "432")
-    await expect(host.page.locator('[data-panel="editor"]')).toHaveCSS(
-      "width",
-      "432px",
-    )
+    await expect.poll(async () => Number(await handle.getAttribute("aria-valuenow")))
+      .toBeGreaterThan(51)
   } finally {
     await host.context.close()
   }
@@ -345,21 +355,33 @@ test("Block and Preview converge through the shared canonical document", async (
   }
 })
 
-test("split view keeps both surfaces inside a narrow viewport", async ({ browser }) => {
-  const host = await mountHost(browser, "# Narrow\n")
+test("split view stacks its resizable panes in a narrow viewport", async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 } })
+  const host = { context, ...await mountPage(context, "# Narrow\n") }
   try {
-    await host.page.setViewportSize({ width: 390, height: 844 })
     await toggleSplitPreview(host.page)
 
-    await expect(host.page.locator('[data-panel="editor"]')).toBeVisible()
-    await expect(host.page.locator('[data-panel="preview"]')).toBeVisible()
-    const editorWidth = await host.page.locator('[data-panel="editor"]').evaluate(
-      element => Math.round(element.getBoundingClientRect().width),
-    )
-    await expect(host.page.locator("#loomark-split-handle")).toHaveAttribute(
-      "aria-valuenow",
-      editorWidth.toString(),
-    )
+    const split = host.page.locator("#loomark-split")
+    const handle = split.locator('[data-slot="resizable-handle"]')
+    await expect(split).toHaveAttribute("data-orientation", "vertical")
+    await expect(handle).toHaveAttribute("aria-orientation", "horizontal")
+
+    const editor = host.page.locator('[data-panel="editor"]')
+    const preview = host.page.locator('[data-panel="preview"]')
+    await expect(editor).toBeVisible()
+    await expect(preview).toBeVisible()
+    const positions = await Promise.all([editor, preview].map(async pane => {
+      const bounds = await pane.boundingBox()
+      expect(bounds).not.toBeNull()
+      return bounds!
+    }))
+    expect(positions[1].y).toBeGreaterThanOrEqual(positions[0].y + positions[0].height - 1)
+    expect(Math.abs(positions[0].height - positions[1].height)).toBeLessThanOrEqual(1)
+
+    const control = host.page.locator("#loomark-split-handle")
+    await control.focus()
+    await control.press("ArrowDown")
+    await expect(handle).toHaveAttribute("aria-valuenow", "51")
     await expect.poll(() => host.page.evaluate(() => ({
       viewport: window.innerWidth,
       content: document.documentElement.scrollWidth,

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -265,6 +265,32 @@ test("Raw and Preview observe one accepted document in a fixed resizable split",
   }
 })
 
+test("Raw keeps focus and accepts consecutive keystrokes while split Preview updates", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    await toggleSplitPreview(host.page)
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+    })
+
+    for (const character of ["a", "b", "c"]) {
+      await host.page.keyboard.type(character)
+      await expect.poll(() => host.page.evaluate(() => document.activeElement?.id)).toBe(
+        "loomark-input",
+      )
+    }
+
+    await expect(input).toHaveValue("startabc")
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startabc")
+    await expectPreviewSource(host.page, "startabc")
+  } finally {
+    await host.context.close()
+  }
+})
+
 test("split divider resizes by keyboard and exposes its current width", async ({ browser }) => {
   const host = await mountHost(browser, "# Resize\n")
   try {
@@ -1062,9 +1088,14 @@ test("Block input editor failure preserves its committed payload atomically", as
   const host = await mountHost(browser, "Stable\n")
   try {
     await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      Object.assign(element, { __loomarkIdentity: "preserved" })
+    })
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
-    await host.page.locator("#loomark-block-input").fill("Rejected")
+    await input.fill("Rejected")
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
     expect(await snapshot(host.page)).toMatchObject({
       source: "Stable\n",
@@ -1072,7 +1103,46 @@ test("Block input editor failure preserves its committed payload atomically", as
       committed_change_count: 0,
       editor_failure_armed: false,
     })
-    await expect(host.page.locator("#loomark-block-input")).toHaveValue("Stable")
+    await expect(input).toHaveValue("Stable")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(
+      element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
+    )).toBe("preserved")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected Block insertion restores a UTF-16 caret to its accepted position", async ({ browser }) => {
+  const host = await mountHost(browser, "A😀B\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(3, 3)
+      Object.assign(textarea, { __loomarkIdentity: "preserved" })
+    })
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(3, 3)
+    })
+    await host.page.keyboard.type("X")
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await expect(input).toHaveValue("A😀B")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("3:3")
+    await expect.poll(() => input.evaluate(
+      element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
+    )).toBe("preserved")
   } finally {
     await host.context.close()
   }
@@ -1429,14 +1499,20 @@ test("Raw textarea editor failure preserves committed state and consumes the arm
   const host = await mountHost(browser, "before\n")
   try {
     await selectRaw(host.page)
-    await expect(host.page.locator("#loomark-input")).toHaveValue("before\n")
+    const input = host.page.locator("#loomark-input")
+    await expect(input).toHaveValue("before\n")
+    await input.focus()
+    await input.evaluate(element => {
+      Object.assign(element, { __loomarkIdentity: "preserved" })
+    })
     await forceEditorFailure(host.page)
     await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
     const before = await snapshot(host.page)
 
-    await host.page.locator("#loomark-input").evaluate(element => {
+    await input.evaluate(element => {
       const textarea = element as HTMLTextAreaElement
       textarea.value = "failed edit\n"
+      textarea.setSelectionRange(3, 6, "backward")
       textarea.dispatchEvent(new Event("input", { bubbles: true }))
     })
     await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
@@ -1449,7 +1525,15 @@ test("Raw textarea editor failure preserves committed state and consumes the arm
       error_operation: "editor-dispatch",
       editor_failure_armed: false,
     })
-    await expect(host.page.locator("#loomark-input")).toHaveValue("before\n")
+    await expect(input).toHaveValue("before\n")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("0:0")
+    await expect.poll(() => input.evaluate(
+      element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
+    )).toBe("preserved")
   } finally {
     await host.context.close()
   }
@@ -1473,6 +1557,35 @@ test("Raw textarea editor failure can be retried and reflected in Preview", asyn
     await expect.poll(async () => (await snapshot(host.page)).source).toBe("retried edit\n")
     await selectPreview(host.page)
     await expectPreviewSource(host.page, "retried edit\n")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected Raw insertion restores a UTF-16 caret to its accepted position", async ({ browser }) => {
+  const host = await mountHost(browser, "A😀B")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(3, 3)
+      Object.assign(textarea, { __loomarkIdentity: "preserved" })
+    })
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await host.page.keyboard.type("X")
+
+    await expect.poll(async () => (await snapshot(host.page)).error_code).toBe("editor-commit-failed")
+    await expect(input).toHaveValue("A😀B")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("3:3")
+    await expect.poll(() => input.evaluate(
+      element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
+    )).toBe("preserved")
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -15,7 +15,7 @@ import { expect, test, type Browser, type BrowserContext, type Page } from "@pla
  * | production chrome | Raw/Block/Preview, desktop/narrow | one labelled region, tablist, selected panel, and keyboard navigation |
  * | example presets | Hello/Blog/List/Code from any mode | replace canonical source without changing the selected mode |
  * | Block formatting | focused paragraph/heading/list item | typed heading/list/delete requests update source and restore a valid target |
- * | Block keyboard editing | collapsed caret at start/middle/end | Enter splits, boundary arrows navigate, empty-start Backspace merges, and focus/caret follow the typed target |
+ * | Block keyboard editing | collapsed text cursor at start/middle/end | Enter splits, native direction keys preserve text cursor movement, boundary arrows navigate, empty-start Backspace merges, and focus/text cursor follow the typed target |
  * | interactive chrome | normal, focus, error | only application controls are visible; Preview owns focus; errors appear on demand |
  * | Raw <-> Block <-> Preview | new/same source | one canonical source, no marker leakage |
  * | ownership | fresh page/container | termination only; no cleanup claim |
@@ -1257,6 +1257,31 @@ test("boundary keys navigate between text blocks without changing source", async
 
     await second.press("Backspace")
     await expect(first).toBeFocused()
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe(source)
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("a direction key keeps native text cursor movement inside a Block editor", async ({ browser }) => {
+  const source = "ABCDE\n"
+  const host = await mountHost(browser, source)
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await expect(input).toHaveValue("ABCDE")
+    await input.focus()
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.setSelectionRange(3, 3)
+    })
+
+    await input.press("ArrowLeft")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("2:2")
     await expect.poll(async () => (await snapshot(host.page)).source).toBe(source)
   } finally {
     await host.context.close()

--- a/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
+++ b/apps/loomark/examples/vanilla/tests/dev-host.spec.ts
@@ -307,11 +307,13 @@ test("split divider resizes by keyboard and exposes its current width", async ({
       "392px",
     )
 
-    const bounds = await handle.boundingBox()
+    const hitArea = host.page.locator('[data-slot="resizable-handle-hit-area"]')
+    const bounds = await hitArea.boundingBox()
     expect(bounds).not.toBeNull()
-    await host.page.mouse.move(bounds!.x, bounds!.y + bounds!.height / 2)
+    expect(bounds!.width).toBeGreaterThanOrEqual(12)
+    await host.page.mouse.move(bounds!.x + 1, bounds!.y + bounds!.height / 2)
     await host.page.mouse.down()
-    await host.page.mouse.move(bounds!.x + 40, bounds!.y + bounds!.height / 2)
+    await host.page.mouse.move(bounds!.x + 41, bounds!.y + bounds!.height / 2)
     await host.page.mouse.up()
 
     await expect(handle).toHaveAttribute("aria-valuenow", "432")
@@ -1113,7 +1115,7 @@ test("Block input editor failure preserves its committed payload atomically", as
   }
 })
 
-test("rejected Block insertion restores a UTF-16 caret to its accepted position", async ({ browser }) => {
+test("rejected Block insertion restores a UTF-16 text cursor to its accepted position", async ({ browser }) => {
   const host = await mountHost(browser, "A😀B\n")
   try {
     await selectBlock(host.page)
@@ -1143,6 +1145,38 @@ test("rejected Block insertion restores a UTF-16 caret to its accepted position"
     await expect.poll(() => input.evaluate(
       element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
     )).toBe("preserved")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected Block repair yields to a newer same-frame input", async ({ browser }) => {
+  const host = await mountHost(browser, "start\n")
+  try {
+    await selectBlock(host.page)
+    const input = host.page.locator("#loomark-block-input")
+    await input.focus()
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      for (const value of ["startX", "startXY"]) {
+        textarea.value = value
+        textarea.setSelectionRange(value.length, value.length)
+        textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      }
+    })
+    await host.page.evaluate(() => new Promise<void>(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    }))
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY\n")
+    await expect(input).toHaveValue("startXY")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("7:7")
   } finally {
     await host.context.close()
   }
@@ -1587,7 +1621,7 @@ test("Raw textarea editor failure can be retried and reflected in Preview", asyn
   }
 })
 
-test("rejected Raw insertion restores a UTF-16 caret to its accepted position", async ({ browser }) => {
+test("rejected Raw insertion restores a UTF-16 text cursor to its accepted position", async ({ browser }) => {
   const host = await mountHost(browser, "A😀B")
   try {
     const input = host.page.locator("#loomark-input")
@@ -1611,6 +1645,37 @@ test("rejected Raw insertion restores a UTF-16 caret to its accepted position", 
     await expect.poll(() => input.evaluate(
       element => (element as HTMLTextAreaElement & { __loomarkIdentity?: string }).__loomarkIdentity,
     )).toBe("preserved")
+  } finally {
+    await host.context.close()
+  }
+})
+
+test("rejected Raw repair yields to a newer same-frame input", async ({ browser }) => {
+  const host = await mountHost(browser, "start")
+  try {
+    const input = host.page.locator("#loomark-input")
+    await input.focus()
+    await forceEditorFailure(host.page)
+    await expect.poll(async () => (await snapshot(host.page)).editor_failure_armed).toBe(true)
+    await input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      for (const value of ["startX", "startXY"]) {
+        textarea.value = value
+        textarea.setSelectionRange(value.length, value.length)
+        textarea.dispatchEvent(new Event("input", { bubbles: true }))
+      }
+    })
+    await host.page.evaluate(() => new Promise<void>(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    }))
+
+    await expect.poll(async () => (await snapshot(host.page)).source).toBe("startXY")
+    await expect(input).toHaveValue("startXY")
+    await expect(input).toBeFocused()
+    await expect.poll(() => input.evaluate(element => {
+      const textarea = element as HTMLTextAreaElement
+      return `${textarea.selectionStart}:${textarea.selectionEnd}`
+    })).toBe("7:7")
   } finally {
     await host.context.close()
   }

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -6,8 +6,6 @@ priv enum DriverEvent {
   SelectBlock
   SelectPreview
   ToggleSplitPreview
-  SplitResize(@resizable.Msg)
-  SplitMeasured(Int)
   BlockFocused(String)
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)
@@ -67,25 +65,13 @@ priv suberror DriverSubscription {
 }
 
 ///|
-/// The imported model hides drag origin/base/edge state that affects future
-/// updates, so every replacement remains observable to Rabbita.
-priv struct SplitResizeState {
-  model : @resizable.Model
-}
-
-///|
-impl Eq for SplitResizeState with fn equal(_, _) {
-  false
-}
-
-///|
 priv struct DriverModel {
   state : @core.ApplicationState
   document : @markdown.MarkdownDocumentSnapshot
   semantic_document : @md_markdown.MarkdownIR?
   semantic_read_count : Int
   split_preview_open : Bool
-  split_resize : SplitResizeState
+  compact_split : Bool
   active_block_key : String?
   replica_id : String
   source_revision : Int
@@ -523,7 +509,6 @@ fn publish(model : DriverModel) -> Unit {
     "version": @core.SNAPSHOT_VERSION.to_json(),
     "mode": mode_name(model.state.mode()).to_json(),
     "split_preview_open": model.split_preview_open.to_json(),
-    "split_preview_width": model.split_resize.model.width().to_json(),
     "source_revision": model.source_revision.to_json(),
     "semantic_read_count": model.semantic_read_count.to_json(),
     "fatal": model.fatal.to_json(),
@@ -617,6 +602,7 @@ fn editor_surface(
 fn preview_view(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
+  surface : @rabbita_runtime.Html,
 ) -> @rabbita_runtime.Html {
   let raw_selected = model.state.mode() == @core.Raw
   let block_selected = model.state.mode() == @core.Block
@@ -752,7 +738,7 @@ fn preview_view(
         id="loomark-editor-shell",
         style=[
           if model.split_preview_open && !preview_selected {
-            "width:min(100%,76rem);min-height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column"
+            "width:min(100%,76rem);height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column"
           } else {
             "width:min(100%,53.75rem);min-height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column"
           },
@@ -791,7 +777,7 @@ fn preview_view(
                   .role("tabpanel")
                   .aria_labelledby(panel_labelledby),
                 style=["min-width:0;flex:1;display:flex"],
-                application_surface(model, emit),
+                surface,
               ),
             ],
           ),
@@ -928,8 +914,6 @@ fn driver_event_name(event : DriverEvent) -> String {
     SelectBlock => "select-block"
     SelectPreview => "select-preview"
     ToggleSplitPreview => "toggle-split"
-    SplitResize(_) => "split-resize"
-    SplitMeasured(_) => "split-measured"
     BlockFocused(_) => "block-focused"
     BlockHeading(_, _) => "block-heading"
     BlockToggleList(_) => "block-toggle-list"
@@ -1653,12 +1637,7 @@ fn update_model(
         changed=source_changed,
       )
       publish(next)
-      let command = if split_visible(next) && !split_visible(model) {
-        split_measure_command(emit)
-      } else {
-        @rabbita_runtime.none
-      }
-      (next, command)
+      (next, @rabbita_runtime.none)
     }
     SelectRaw | SelectBlock | SelectPreview => {
       let mode = match event {
@@ -1679,12 +1658,7 @@ fn update_model(
         changed=false,
       )
       publish(next)
-      let command = if split_visible(next) && !split_visible(model) {
-        split_measure_command(emit)
-      } else {
-        @rabbita_runtime.none
-      }
-      (next, command)
+      (next, @rabbita_runtime.none)
     }
     ToggleSplitPreview => {
       let old_requested = preview_requested(model)
@@ -1695,23 +1669,6 @@ fn update_model(
         accepted=true,
         changed=false,
       )
-      publish(next)
-      let command = if split_visible(next) {
-        split_measure_command(emit)
-      } else {
-        @rabbita_runtime.none
-      }
-      (next, command)
-    }
-    SplitResize(message) => {
-      let split_resize = { model: model.split_resize.model.update(message) }
-      let next = { ..model, split_resize, }
-      publish(next)
-      (next, @rabbita_runtime.none)
-    }
-    SplitMeasured(group_width) => {
-      let split_resize = model.split_resize.fit_group(group_width)
-      let next = { ..model, split_resize, }
       publish(next)
       (next, @rabbita_runtime.none)
     }
@@ -1935,15 +1892,13 @@ fn update_model(
       (next, @rabbita_runtime.none)
     }
     Resize(viewport) => {
-      ignore(viewport)
-      let next = { ..model, resize_count: model.resize_count + 1 }
-      publish(next)
-      let command = if split_visible(next) {
-        split_measure_command(emit)
-      } else {
-        @rabbita_runtime.none
+      let next = {
+        ..model,
+        compact_split: compact_split_for_width(viewport.width),
+        resize_count: model.resize_count + 1,
       }
-      (next, command)
+      publish(next)
+      (next, @rabbita_runtime.none)
     }
   }
 }
@@ -2105,9 +2060,6 @@ fn subscriptions(
     @sub.batch([
       @sub.on_resize(emit.map(viewport => Resize(viewport))),
       driver_test_subscription(emit, model.document.source()),
-      model.split_resize.model.subscriptions(message => {
-        emit(SplitResize(message))
-      }),
       control,
     ])
   }
@@ -2127,20 +2079,18 @@ pub fn mount(host_id : String, source : String) -> String {
   ) catch {
     _ => return "{\"ok\":false,\"error\":\"editor-initialization-failed\"}"
   }
+  let host_width = @dom_boundary.measure_element_id(host_id)
+    .offset_width()
+    .to_int() catch {
+      _ => SPLIT_STACK_BREAKPOINT
+    }
   let initial : DriverModel = {
     state: @core.ApplicationState::ApplicationState(@core.Raw),
     document: editor.snapshot(),
     semantic_document: None,
     semantic_read_count: 0,
     split_preview_open: false,
-    split_resize: {
-      model: @resizable.Model::new(w=384, h=1, constraints={
-        min_w: 160,
-        max_w: 640,
-        min_h: 1,
-        max_h: 1,
-      }),
-    },
+    compact_split: compact_split_for_width(host_width),
     active_block_key: None,
     replica_id,
     source_revision: 0,
@@ -2175,7 +2125,8 @@ pub fn mount(host_id : String, source : String) -> String {
       update~,
       subscriptions~,
     )
-    model.map(model => preview_view(model, emit))
+    let surface = application_surface(model, emit)
+    model.view2(surface, (model, surface) => preview_view(model, emit, surface))
   })
   app.mount(host_id)
   mounted.val = true

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -12,9 +12,10 @@ priv enum DriverEvent {
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)
   BlockDelete
-  RawInput(String)
+  RawInput(String, @dom_boundary.TextSelection?)
   BlockInput(
     node_id~ : @markdown.MarkdownNodeId,
+    input_id~ : String,
     text~ : String,
     selection_offset~ : Int
   )
@@ -106,6 +107,50 @@ fn preview_document_decision(
 }
 
 ///|
+/// Map one live offset from a rejected contiguous edit back into the accepted
+/// text's UTF-16 coordinates.
+fn rejected_text_offset(
+  accepted_source : String,
+  rejected_source : String,
+  offset : Int,
+) -> Int {
+  let change = @text_change.compute_text_change(
+    accepted_source, rejected_source,
+  )
+  let inserted_len = change.inserted.length()
+  let inserted_end = change.start + inserted_len
+  let mapped = if offset <= change.start {
+    offset
+  } else if offset >= inserted_end {
+    offset - inserted_len + change.delete_len
+  } else {
+    change.start
+  }
+  mapped.clamp(min=0, max=accepted_source.length())
+}
+
+///|
+/// Map a live selection from one rejected contiguous edit back into the
+/// accepted source's UTF-16 coordinates.
+fn rejected_text_selection(
+  accepted_source : String,
+  rejected_source : String,
+  selection : @dom_boundary.TextSelection,
+) -> @dom_boundary.TextSelection {
+  let start = rejected_text_offset(
+    accepted_source,
+    rejected_source,
+    selection.start(),
+  )
+  let end = rejected_text_offset(
+    accepted_source,
+    rejected_source,
+    selection.end(),
+  ).clamp(min=start, max=accepted_source.length())
+  @dom_boundary.TextSelection(start, end, selection.direction())
+}
+
+///|
 priv struct DriverModel {
   state : @core.ApplicationState
   document : @markdown.MarkdownDocumentSnapshot
@@ -123,10 +168,6 @@ priv struct DriverModel {
   error_count : Int
   committed_change_count : Int
   fail_next_editor_commit : Bool
-  /// Rendering epoch used only to remount Raw after a rejected commit.
-  raw_surface_revision : Int
-  /// Rendering epoch used only to remount Block controls after rejection.
-  block_surface_revision : Int
   resize_count : Int
   selection : String?
   measurement : String?
@@ -397,11 +438,7 @@ fn commit_source(
         operation,
         "editor commit failed: " + editor_error_detail(error),
       )
-      (
-        { ..failed, raw_surface_revision: model.raw_surface_revision + 1 },
-        false,
-        false,
-      )
+      (failed, false, false)
     }
   }
 }
@@ -444,7 +481,7 @@ fn commit_block_request(
   model : DriverModel,
   request : @markdown.MarkdownEditRequest,
   operation : String,
-) -> (DriverModel, @markdown.MarkdownBlockSelection?) {
+) -> (DriverModel, @markdown.MarkdownBlockSelection?, Bool) {
   let fail_commit = model.fail_next_editor_commit
   let next = { ..model, fail_next_editor_commit: false }
   let request = if fail_commit {
@@ -473,6 +510,7 @@ fn commit_block_request(
           changed=true,
         ),
         selection,
+        true,
       )
     }
     Ok(@markdown.Unchanged(document)) =>
@@ -485,6 +523,7 @@ fn commit_block_request(
           changed=false,
         ),
         None,
+        true,
       )
     Err(error) => {
       let failed = record_error(
@@ -493,19 +532,16 @@ fn commit_block_request(
         operation,
         "editor commit failed: " + editor_error_detail(error),
       )
-      let committed = {
-        ..failed,
-        block_surface_revision: model.block_surface_revision + 1,
-      }
       (
         update_preview_document(
           attachment,
-          committed,
+          failed,
           preview_requested(model),
           accepted=false,
           changed=false,
         ),
         None,
+        false,
       )
     }
   }
@@ -523,7 +559,7 @@ fn commit_block_toolbar_request(
   control_id : String,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
-  let (committed, committed_selection) = commit_block_request(
+  let (committed, committed_selection, _) = commit_block_request(
     editor, attachment, model, request, "editor-dispatch",
   )
   let selection = committed_selection.bind(selection => {
@@ -607,7 +643,6 @@ fn publish(model : DriverModel) -> Unit {
     "error_count": model.error_count.to_json(),
     "committed_change_count": model.committed_change_count.to_json(),
     "editor_failure_armed": model.fail_next_editor_commit.to_json(),
-    "block_surface_revision": model.block_surface_revision.to_json(),
     "resize_count": model.resize_count.to_json(),
     "selection": match model.selection {
       Some(selection) => selection.to_json()
@@ -664,34 +699,41 @@ fn preview_document_surface(model : DriverModel) -> @rabbita_runtime.Html {
 fn editor_surface(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
-) -> Map[String, @rabbita_runtime.Html] {
+) -> @rabbita_runtime.Html {
   let source = model.document.source()
   match model.state.mode() {
     @core.Raw =>
-      Map([
-        (
-          "raw|" + model.raw_surface_revision.to_string(),
-          @rui.textarea(
-            id="loomark-input",
-            value=source,
-            rows=4,
-            attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
-            style=[
-              "min-height:clamp(24rem,70vh,36rem);flex:1;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-radius:0;background:transparent;padding:1rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
-            ],
-            on_input=emit.map(source => RawInput(source)),
-          ),
-        ),
-      ])
-    @core.Preview => { "preview": preview_document_surface(model) }
-    @core.Block =>
-      Map([
-        (
-          "block|" + model.block_surface_revision.to_string(),
-          block_surface(model, emit),
-        ),
-      ])
+      @rui.textarea(
+        id="loomark-input",
+        value=source,
+        rows=4,
+        attrs=@html.Attrs::build().aria_label("Raw Markdown source"),
+        style=[
+          "min-height:clamp(24rem,70vh,36rem);flex:1;field-sizing:fixed;resize:none;--rui-control-base-border:transparent;--rui-control-base-shadow:none;border-radius:0;background:transparent;padding:1rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.65",
+        ],
+        on_input=@cmd.Emit(source => raw_input_command(source, emit)),
+      )
+    @core.Preview => preview_document_surface(model)
+    @core.Block => block_surface(model, emit)
   }
+}
+
+///|
+/// Capture the live Raw selection before the accepted model may need to repair
+/// a rejected controlled value on the same textarea node.
+fn raw_input_command(
+  source : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    let selection = @dom_boundary.read_text_selection_id("loomark-input") catch {
+      error => {
+        scheduler.add(emit(EffectFailed(error.message())))
+        return
+      }
+    }
+    scheduler.add(emit(RawInput(source, Some(selection))))
+  })
 }
 
 ///|
@@ -713,6 +755,7 @@ fn block_input_command(
       emit(
         BlockInput(
           node_id=block.node_id(),
+          input_id~,
           text~,
           selection_offset=selection.end(),
         ),
@@ -1042,7 +1085,7 @@ fn driver_event_name(event : DriverEvent) -> String {
     BlockHeading(_, _) => "block-heading"
     BlockToggleList(_) => "block-toggle-list"
     BlockDelete => "block-delete"
-    RawInput(_) => "raw-input"
+    RawInput(_, _) => "raw-input"
     BlockInput(..) => "block-input"
     BlockSplit(..) => "block-split"
     BlockMerge(..) => "block-merge"
@@ -1107,7 +1150,7 @@ fn parse_driver_event(detail : String) -> DriverEvent {
   } else if detail.has_prefix("source|") {
     ReplaceSource(detail["source|".length():].to_owned())
   } else if detail.has_prefix("raw-input|") {
-    RawInput(detail["raw-input|".length():].to_owned())
+    RawInput(detail["raw-input|".length():].to_owned(), None)
   } else if detail == "editor-failure" {
     EditorFailure
   } else if detail.has_prefix("restore-focus|") {
@@ -1188,7 +1231,7 @@ fn update_model(
     publish(next)
     return (next, @rabbita_runtime.none)
   }
-  if model.state.mode() != @core.Raw && event is RawInput(_) {
+  if model.state.mode() != @core.Raw && event is RawInput(_, _) {
     let next = record_error(
       model, "mode-inapplicable", "editor-dispatch", "Raw input is unavailable outside Raw mode",
     )
@@ -1213,12 +1256,18 @@ fn update_model(
     return (next, @rabbita_runtime.none)
   }
   match event {
-    ReplaceSource(source) | RawInput(source) => {
+    ReplaceSource(source) | RawInput(source, _) => {
+      let raw_selection = match event {
+        RawInput(_, selection) => selection
+        _ => None
+      }
+      let raw_event = event is RawInput(_, _)
       let transition = @core.reduce(
         model.state,
         @core.ApplicationEvent::RequestCanonicalSource(source~),
       )
       let mut next = model
+      let mut restore_raw_value = false
       for decision in transition.decisions() {
         match decision {
           @core.ReplaceCanonicalSource(source) => {
@@ -1237,6 +1286,7 @@ fn update_model(
               accepted~,
               changed~,
             )
+            restore_raw_value = restore_raw_value || (raw_event && !accepted)
           }
           @core.SnapshotRejected(_) =>
             next = record_error(
@@ -1245,7 +1295,27 @@ fn update_model(
         }
       }
       publish(next)
-      (next, @rabbita_runtime.none)
+      let command = if restore_raw_value {
+        after_render(
+          scheduler => {
+            ignore(scheduler)
+            let accepted_source = next.document.source()
+            @dom_boundary.write_text_value_id("loomark-input", accepted_source)
+            match raw_selection {
+              Some(selection) =>
+                @dom_boundary.write_text_selection_id(
+                  "loomark-input",
+                  rejected_text_selection(accepted_source, source, selection),
+                )
+              None => ()
+            }
+          },
+          emit,
+        )
+      } else {
+        @rabbita_runtime.none
+      }
+      (next, command)
     }
     BlockFocused(key) =>
       if model.active_block_key == Some(key) {
@@ -1401,14 +1471,14 @@ fn update_model(
             emit,
           )
       }
-    BlockInput(node_id~, text~, selection_offset~) => {
-      let (next, committed_selection) = commit_block_request(
+    BlockInput(node_id~, input_id~, text=proposed_text, selection_offset~) => {
+      let (next, committed_selection, accepted) = commit_block_request(
         editor,
         attachment,
         model,
         @markdown.MarkdownEditRequest::CommitTextControlEdit(
           node_id~,
-          new_text=text,
+          new_text=proposed_text,
         ),
         "editor-dispatch",
       )
@@ -1444,11 +1514,55 @@ fn update_model(
               emit,
             ),
           )
-        None => (next, @rabbita_runtime.none)
+        None =>
+          if accepted {
+            (next, @rabbita_runtime.none)
+          } else {
+            let accepted_text = next.document
+              .blocks()
+              .fold(init=None, (found, block) => {
+                match found {
+                  Some(_) => found
+                  None =>
+                    if block.node_id() == node_id {
+                      Some(block.text())
+                    } else {
+                      None
+                    }
+                }
+              })
+            match accepted_text {
+              Some(text) => {
+                let offset = rejected_text_offset(
+                  text, proposed_text, selection_offset,
+                )
+                (
+                  next,
+                  after_render(
+                    scheduler => {
+                      ignore(scheduler)
+                      @dom_boundary.write_text_value_id(input_id, text)
+                      @dom_boundary.focus_id(input_id)
+                      @dom_boundary.write_text_selection_id(
+                        input_id,
+                        @dom_boundary.TextSelection(
+                          offset,
+                          offset,
+                          @dom_boundary.NoDirection,
+                        ),
+                      )
+                    },
+                    emit,
+                  ),
+                )
+              }
+              None => (next, @rabbita_runtime.none)
+            }
+          }
       }
     }
     BlockSplit(node_id~, offset~) => {
-      let (next, committed_selection) = commit_block_request(
+      let (next, committed_selection, _) = commit_block_request(
         editor,
         attachment,
         model,
@@ -1486,7 +1600,7 @@ fn update_model(
       }
     }
     BlockMerge(node_id~, selection=originating_selection) => {
-      let (next, committed_selection) = commit_block_request(
+      let (next, committed_selection, _) = commit_block_request(
         editor,
         attachment,
         model,
@@ -2161,8 +2275,6 @@ pub fn mount(host_id : String, source : String) -> String {
     error_count: 0,
     committed_change_count: 0,
     fail_next_editor_commit: false,
-    raw_surface_revision: 0,
-    block_surface_revision: 0,
     resize_count: 0,
     selection: None,
     measurement: None,

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -89,6 +89,7 @@ priv struct DriverModel {
   active_block_key : String?
   replica_id : String
   source_revision : Int
+  text_input_generation : Int
   fatal : Bool
   error : String?
   error_code : String?
@@ -1114,7 +1115,11 @@ fn update_model(
         model.state,
         @core.ApplicationEvent::RequestCanonicalSource(source~),
       )
-      let mut next = model
+      let mut next = if raw_event {
+        { ..model, text_input_generation: model.text_input_generation + 1 }
+      } else {
+        model
+      }
       let mut restore_raw_value = false
       for decision in transition.decisions() {
         match decision {
@@ -1144,18 +1149,31 @@ fn update_model(
       }
       publish(next)
       let command = if restore_raw_value {
+        let repair_generation = next.text_input_generation
+        let repair_source_revision = next.source_revision
         after_render(
           scheduler => {
             ignore(scheduler)
             let accepted_source = next.document.source()
-            @dom_boundary.write_text_value_id("loomark-input", accepted_source)
-            match raw_selection {
-              Some(selection) =>
-                @dom_boundary.write_text_selection_id(
-                  "loomark-input",
-                  rejected_text_selection(accepted_source, source, selection),
+            match detached_model.val {
+              Some(current) if current.state.mode() == @core.Raw &&
+                current.text_input_generation == repair_generation &&
+                current.source_revision == repair_source_revision => {
+                @dom_boundary.write_text_value_id(
+                  "loomark-input", accepted_source,
                 )
-              None => ()
+                match raw_selection {
+                  Some(selection) =>
+                    @dom_boundary.write_text_selection_id(
+                      "loomark-input",
+                      rejected_text_selection(
+                        accepted_source, source, selection,
+                      ),
+                    )
+                  None => ()
+                }
+              }
+              _ => ()
             }
           },
           emit,
@@ -1341,6 +1359,7 @@ fn update_model(
       }
       let next = {
         ..next,
+        text_input_generation: model.text_input_generation + 1,
         active_block_key: match selection {
           Some(selection) => Some(selection.key)
           None => model.active_block_key
@@ -1384,21 +1403,30 @@ fn update_model(
                 let offset = rejected_text_offset(
                   text, proposed_text, selection_offset,
                 )
+                let repair_generation = next.text_input_generation
+                let repair_source_revision = next.source_revision
                 (
                   next,
                   after_render(
                     scheduler => {
                       ignore(scheduler)
-                      @dom_boundary.write_text_value_id(input_id, text)
-                      @dom_boundary.focus_id(input_id)
-                      @dom_boundary.write_text_selection_id(
-                        input_id,
-                        @dom_boundary.TextSelection(
-                          offset,
-                          offset,
-                          @dom_boundary.NoDirection,
-                        ),
-                      )
+                      match detached_model.val {
+                        Some(current) if current.state.mode() == @core.Block &&
+                          current.text_input_generation == repair_generation &&
+                          current.source_revision == repair_source_revision => {
+                          @dom_boundary.write_text_value_id(input_id, text)
+                          @dom_boundary.focus_id(input_id)
+                          @dom_boundary.write_text_selection_id(
+                            input_id,
+                            @dom_boundary.TextSelection(
+                              offset,
+                              offset,
+                              @dom_boundary.NoDirection,
+                            ),
+                          )
+                        }
+                        _ => ()
+                      }
                     },
                     emit,
                   ),
@@ -2116,6 +2144,7 @@ pub fn mount(host_id : String, source : String) -> String {
     active_block_key: None,
     replica_id,
     source_revision: 0,
+    text_input_generation: 0,
     fatal: false,
     error: None,
     error_code: None,

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -5,6 +5,9 @@ priv enum DriverEvent {
   SelectRaw
   SelectBlock
   SelectPreview
+  ToggleSplitPreview
+  SplitResize(@resizable.Msg)
+  SplitMeasured(Int)
   BlockFocused(String)
   BlockHeading(Int, BlockSelection?)
   BlockToggleList(BlockSelection?)
@@ -73,17 +76,29 @@ priv enum PreviewDocumentDecision {
 } derive(Eq, Debug)
 
 ///|
+/// The imported model hides drag origin/base/edge state that affects future
+/// updates, so every replacement remains observable to Rabbita.
+priv struct SplitResizeState {
+  model : @resizable.Model
+}
+
+///|
+impl Eq for SplitResizeState with fn equal(_, _) {
+  false
+}
+
+///|
 fn preview_document_decision(
-  old_mode : @core.ApplicationMode,
-  next_mode : @core.ApplicationMode,
+  old_requested : Bool,
+  next_requested : Bool,
   accepted~ : Bool,
   changed~ : Bool,
 ) -> PreviewDocumentDecision {
   if !accepted {
     PreviewDocumentKeep
-  } else if next_mode != @core.Preview {
+  } else if !next_requested {
     PreviewDocumentClear
-  } else if old_mode != @core.Preview || changed {
+  } else if !old_requested || changed {
     PreviewDocumentRead
   } else {
     PreviewDocumentKeep
@@ -95,6 +110,9 @@ priv struct DriverModel {
   state : @core.ApplicationState
   document : @markdown.MarkdownDocumentSnapshot
   semantic_document : @md_markdown.MarkdownIR?
+  semantic_read_count : Int
+  split_preview_open : Bool
+  split_resize : SplitResizeState
   active_block_key : String?
   replica_id : String
   source_revision : Int
@@ -165,6 +183,12 @@ fn mode_name(mode : @core.ApplicationMode) -> String {
     @core.Block => "block"
     @core.Preview => "preview"
   }
+}
+
+///|
+/// Aggregate document-level Preview demand independently from the active mode.
+fn preview_requested(model : DriverModel) -> Bool {
+  model.state.mode() == @core.Preview || model.split_preview_open
 }
 
 ///|
@@ -388,14 +412,23 @@ fn commit_source(
 fn update_preview_document(
   attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
-  old_mode : @core.ApplicationMode,
+  old_requested : Bool,
   accepted~ : Bool,
   changed~ : Bool,
 ) -> DriverModel {
   match
-    preview_document_decision(old_mode, model.state.mode(), accepted~, changed~) {
+    preview_document_decision(
+      old_requested,
+      preview_requested(model),
+      accepted~,
+      changed~,
+    ) {
     PreviewDocumentRead =>
-      { ..model, semantic_document: Some(attachment.document()) }
+      {
+        ..model,
+        semantic_document: Some(attachment.document()),
+        semantic_read_count: model.semantic_read_count + 1,
+      }
     PreviewDocumentKeep => model
     PreviewDocumentClear => { ..model, semantic_document: None }
   }
@@ -407,6 +440,7 @@ fn update_preview_document(
 /// SyncEditor cursor state in this shell.
 fn commit_block_request(
   editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
   request : @markdown.MarkdownEditRequest,
   operation : String,
@@ -423,17 +457,35 @@ fn commit_block_request(
     request
   }
   match editor.commit(request) {
-    Ok(@markdown.Applied(document, selection)) =>
+    Ok(@markdown.Applied(document, selection)) => {
+      let committed = {
+        ..next,
+        document,
+        source_revision: model.source_revision + 1,
+        committed_change_count: model.committed_change_count + 1,
+      }
       (
-        {
-          ..next,
-          document,
-          source_revision: model.source_revision + 1,
-          committed_change_count: model.committed_change_count + 1,
-        },
+        update_preview_document(
+          attachment,
+          committed,
+          preview_requested(model),
+          accepted=true,
+          changed=true,
+        ),
         selection,
       )
-    Ok(@markdown.Unchanged(document)) => ({ ..next, document, }, None)
+    }
+    Ok(@markdown.Unchanged(document)) =>
+      (
+        update_preview_document(
+          attachment,
+          { ..next, document, },
+          preview_requested(model),
+          accepted=true,
+          changed=false,
+        ),
+        None,
+      )
     Err(error) => {
       let failed = record_error(
         next,
@@ -441,8 +493,18 @@ fn commit_block_request(
         operation,
         "editor commit failed: " + editor_error_detail(error),
       )
+      let committed = {
+        ..failed,
+        block_surface_revision: model.block_surface_revision + 1,
+      }
       (
-        { ..failed, block_surface_revision: model.block_surface_revision + 1 },
+        update_preview_document(
+          attachment,
+          committed,
+          preview_requested(model),
+          accepted=false,
+          changed=false,
+        ),
         None,
       )
     }
@@ -454,6 +516,7 @@ fn commit_block_request(
 /// the typed selection only after Rabbita renders that committed document.
 fn commit_block_toolbar_request(
   editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
   request : @markdown.MarkdownEditRequest,
   originating_selection : BlockSelection?,
@@ -461,7 +524,7 @@ fn commit_block_toolbar_request(
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
   let (committed, committed_selection) = commit_block_request(
-    editor, model, request, "editor-dispatch",
+    editor, attachment, model, request, "editor-dispatch",
   )
   let selection = committed_selection.bind(selection => {
     block_selection_from_commit(committed.document, selection)
@@ -528,7 +591,10 @@ fn publish(model : DriverModel) -> Unit {
     "replica_id": model.replica_id.to_json(),
     "version": @core.SNAPSHOT_VERSION.to_json(),
     "mode": mode_name(model.state.mode()).to_json(),
+    "split_preview_open": model.split_preview_open.to_json(),
+    "split_preview_width": model.split_resize.model.width().to_json(),
     "source_revision": model.source_revision.to_json(),
+    "semantic_read_count": model.semantic_read_count.to_json(),
     "fatal": model.fatal.to_json(),
     "error_code": match model.error_code {
       Some(code) => code.to_json()
@@ -574,6 +640,27 @@ fn publish(model : DriverModel) -> Unit {
 }
 
 ///|
+fn preview_document_surface(model : DriverModel) -> @rabbita_runtime.Html {
+  let source = model.document.source()
+  match model.semantic_document {
+    Some(document) => preview_surface(source, document)
+    None =>
+      @html.div(
+        id="loomark-preview",
+        attrs=@html.Attrs::build()
+          .data_set("loomark-preview-fallback", "unavailable")
+          .role("region")
+          .tabindex(0)
+          .aria_label("Markdown preview"),
+        style=["display:grid;gap:1rem"],
+        @rui.typography_muted(
+          "Preview is unavailable for the current accepted document.",
+        ),
+      )
+  }
+}
+
+///|
 fn editor_surface(
   model : DriverModel,
   emit : @cmd.Emit[DriverEvent],
@@ -596,25 +683,7 @@ fn editor_surface(
           ),
         ),
       ])
-    @core.Preview =>
-      match model.semantic_document {
-        Some(document) => { "preview": preview_surface(source, document) }
-        None =>
-          {
-            "preview": @html.div(
-              id="loomark-preview",
-              attrs=@html.Attrs::build()
-                .data_set("loomark-preview-fallback", "unavailable")
-                .role("region")
-                .tabindex(0)
-                .aria_label("Markdown preview"),
-              style=["display:grid;gap:1rem"],
-              @rui.typography_muted(
-                "Preview is unavailable for the current accepted document.",
-              ),
-            ),
-          }
-      }
+    @core.Preview => { "preview": preview_document_surface(model) }
     @core.Block =>
       Map([
         (
@@ -697,6 +766,30 @@ fn preview_view(
     @core.Block => ("loomark-panel-block", "loomark-mode-block")
     @core.Preview => ("loomark-panel-preview", "loomark-mode-preview")
   }
+  let split_toggle = if preview_selected {
+    @html.nothing
+  } else {
+    @rui.button(
+      id="loomark-split-toggle",
+      variant=@rui.Ghost,
+      size=@rui.Xs,
+      attrs=@html.Attrs::build()
+        .aria_label(
+          if model.split_preview_open {
+            "Close split Preview"
+          } else {
+            "Open split Preview"
+          },
+        )
+        .aria_pressed(model.split_preview_open.to_string()),
+      on_click=emit(ToggleSplitPreview),
+      if model.split_preview_open {
+        "Close split"
+      } else {
+        "Split"
+      },
+    )
+  }
   let examples = @html.div(
     attrs=@html.Attrs::build().role("toolbar").aria_label("Example documents"),
     style=[
@@ -766,7 +859,11 @@ fn preview_view(
       @html.div(
         id="loomark-editor-shell",
         style=[
-          "width:min(100%,53.75rem);min-height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column",
+          if model.split_preview_open && !preview_selected {
+            "width:min(100%,76rem);min-height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column"
+          } else {
+            "width:min(100%,53.75rem);min-height:calc(100dvh - clamp(1rem,4vw,3rem));margin-inline:auto;display:flex;flex-direction:column"
+          },
         ],
         [
           @rui.tabs_root(
@@ -788,7 +885,12 @@ fn preview_view(
                     style=["min-height:3.25rem;padding:0;overflow:visible"],
                     [block_button, raw_button, preview_button],
                   ),
-                  examples,
+                  @html.div(
+                    style=[
+                      "display:flex;align-items:center;justify-content:flex-end;gap:0.125rem;flex-wrap:wrap",
+                    ],
+                    [split_toggle, examples],
+                  ),
                 ],
               ),
               @html.div(
@@ -797,27 +899,7 @@ fn preview_view(
                   .role("tabpanel")
                   .aria_labelledby(panel_labelledby),
                 style=["min-width:0;flex:1;display:flex"],
-                if model.state.mode() == @core.Block {
-                  @html.div(
-                    style=[
-                      "width:100%;min-width:0;display:flex;flex-direction:column",
-                    ],
-                    [
-                      block_format_toolbar(model, emit),
-                      @html.div(
-                        id="loomark-surface",
-                        style=["width:100%;min-width:0;display:flex"],
-                        editor_surface(model, emit),
-                      ),
-                    ],
-                  )
-                } else {
-                  @html.div(
-                    id="loomark-surface",
-                    style=["width:100%;min-width:0;display:flex"],
-                    editor_surface(model, emit),
-                  )
-                },
+                application_surface(model, emit),
               ),
             ],
           ),
@@ -953,6 +1035,9 @@ fn driver_event_name(event : DriverEvent) -> String {
     SelectRaw => "select-raw"
     SelectBlock => "select-block"
     SelectPreview => "select-preview"
+    ToggleSplitPreview => "toggle-split"
+    SplitResize(_) => "split-resize"
+    SplitMeasured(_) => "split-measured"
     BlockFocused(_) => "block-focused"
     BlockHeading(_, _) => "block-heading"
     BlockToggleList(_) => "block-toggle-list"
@@ -999,6 +1084,8 @@ fn parse_driver_event(detail : String) -> DriverEvent {
     SelectBlock
   } else if detail == "select-preview" {
     SelectPreview
+  } else if detail == "toggle-split" {
+    ToggleSplitPreview
   } else if detail == "focus-preview" {
     FocusPreview
   } else if detail == "focus-block" {
@@ -1135,7 +1222,7 @@ fn update_model(
       for decision in transition.decisions() {
         match decision {
           @core.ReplaceCanonicalSource(source) => {
-            let old_mode = next.state.mode()
+            let old_requested = preview_requested(next)
             let (committed, accepted, changed) = commit_source(
               editor,
               next,
@@ -1146,7 +1233,7 @@ fn update_model(
             next = update_preview_document(
               attachment,
               committed,
-              old_mode,
+              old_requested,
               accepted~,
               changed~,
             )
@@ -1245,6 +1332,7 @@ fn update_model(
           }
           commit_block_toolbar_request(
             editor,
+            attachment,
             model,
             @markdown.MarkdownEditRequest::ChangeHeadingLevel(
               node_id=block.node_id(),
@@ -1282,6 +1370,7 @@ fn update_model(
           }
           commit_block_toolbar_request(
             editor,
+            attachment,
             model,
             @markdown.MarkdownEditRequest::ToggleListItem(
               node_id=block.node_id(),
@@ -1304,6 +1393,7 @@ fn update_model(
         Some(block) =>
           commit_block_toolbar_request(
             editor,
+            attachment,
             model,
             @markdown.MarkdownEditRequest::Delete(node_id=block.node_id()),
             None,
@@ -1314,6 +1404,7 @@ fn update_model(
     BlockInput(node_id~, text~, selection_offset~) => {
       let (next, committed_selection) = commit_block_request(
         editor,
+        attachment,
         model,
         @markdown.MarkdownEditRequest::CommitTextControlEdit(
           node_id~,
@@ -1359,6 +1450,7 @@ fn update_model(
     BlockSplit(node_id~, offset~) => {
       let (next, committed_selection) = commit_block_request(
         editor,
+        attachment,
         model,
         @markdown.MarkdownEditRequest::SplitBlock(node_id~, offset~),
         "editor-dispatch",
@@ -1396,6 +1488,7 @@ fn update_model(
     BlockMerge(node_id~, selection=originating_selection) => {
       let (next, committed_selection) = commit_block_request(
         editor,
+        attachment,
         model,
         @markdown.MarkdownEditRequest::MergeWithPrevious(node_id~),
         "editor-dispatch",
@@ -1491,7 +1584,7 @@ fn update_model(
         let next = update_preview_document(
           attachment,
           committed,
-          model.state.mode(),
+          preview_requested(model),
           accepted~,
           changed~,
         )
@@ -1565,12 +1658,17 @@ fn update_model(
       next = update_preview_document(
         attachment,
         next,
-        model.state.mode(),
+        preview_requested(model),
         accepted~,
         changed=source_changed,
       )
       publish(next)
-      (next, @rabbita_runtime.none)
+      let command = if split_visible(next) && !split_visible(model) {
+        split_measure_command(emit)
+      } else {
+        @rabbita_runtime.none
+      }
+      (next, command)
     }
     SelectRaw | SelectBlock | SelectPreview => {
       let mode = match event {
@@ -1586,10 +1684,44 @@ fn update_model(
       let next = update_preview_document(
         attachment,
         { ..model, state: transition.state() },
-        model.state.mode(),
+        preview_requested(model),
         accepted=true,
         changed=false,
       )
+      publish(next)
+      let command = if split_visible(next) && !split_visible(model) {
+        split_measure_command(emit)
+      } else {
+        @rabbita_runtime.none
+      }
+      (next, command)
+    }
+    ToggleSplitPreview => {
+      let old_requested = preview_requested(model)
+      let next = update_preview_document(
+        attachment,
+        { ..model, split_preview_open: !model.split_preview_open },
+        old_requested,
+        accepted=true,
+        changed=false,
+      )
+      publish(next)
+      let command = if split_visible(next) {
+        split_measure_command(emit)
+      } else {
+        @rabbita_runtime.none
+      }
+      (next, command)
+    }
+    SplitResize(message) => {
+      let split_resize = { model: model.split_resize.model.update(message) }
+      let next = { ..model, split_resize, }
+      publish(next)
+      (next, @rabbita_runtime.none)
+    }
+    SplitMeasured(group_width) => {
+      let split_resize = model.split_resize.fit_group(group_width)
+      let next = { ..model, split_resize, }
       publish(next)
       (next, @rabbita_runtime.none)
     }
@@ -1816,7 +1948,12 @@ fn update_model(
       ignore(viewport)
       let next = { ..model, resize_count: model.resize_count + 1 }
       publish(next)
-      (next, @rabbita_runtime.none)
+      let command = if split_visible(next) {
+        split_measure_command(emit)
+      } else {
+        @rabbita_runtime.none
+      }
+      (next, command)
     }
   }
 }
@@ -1976,8 +2113,11 @@ fn subscriptions(
     control
   } else {
     @sub.batch([
-      @sub.on_resize(emit.map(_ => Resize({ width: 0, height: 0 }))),
+      @sub.on_resize(emit.map(viewport => Resize(viewport))),
       driver_test_subscription(emit, model.document.source()),
+      model.split_resize.model.subscriptions(message => {
+        emit(SplitResize(message))
+      }),
       control,
     ])
   }
@@ -2001,6 +2141,16 @@ pub fn mount(host_id : String, source : String) -> String {
     state: @core.ApplicationState::ApplicationState(@core.Raw),
     document: editor.snapshot(),
     semantic_document: None,
+    semantic_read_count: 0,
+    split_preview_open: false,
+    split_resize: {
+      model: @resizable.Model::new(w=384, h=1, constraints={
+        min_w: 160,
+        max_w: 640,
+        min_h: 1,
+        max_h: 1,
+      }),
+    },
     active_block_key: None,
     replica_id,
     source_revision: 0,

--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -67,16 +67,6 @@ priv suberror DriverSubscription {
 }
 
 ///|
-/// Pure preview read-model decision. The shell reads the attachment only when
-/// this boundary returns `PreviewDocumentRead`.
-#warnings("-unused_value")
-priv enum PreviewDocumentDecision {
-  PreviewDocumentRead
-  PreviewDocumentKeep
-  PreviewDocumentClear
-} derive(Eq, Debug)
-
-///|
 /// The imported model hides drag origin/base/edge state that affects future
 /// updates, so every replacement remains observable to Rabbita.
 priv struct SplitResizeState {
@@ -86,68 +76,6 @@ priv struct SplitResizeState {
 ///|
 impl Eq for SplitResizeState with fn equal(_, _) {
   false
-}
-
-///|
-fn preview_document_decision(
-  old_requested : Bool,
-  next_requested : Bool,
-  accepted~ : Bool,
-  changed~ : Bool,
-) -> PreviewDocumentDecision {
-  if !accepted {
-    PreviewDocumentKeep
-  } else if !next_requested {
-    PreviewDocumentClear
-  } else if !old_requested || changed {
-    PreviewDocumentRead
-  } else {
-    PreviewDocumentKeep
-  }
-}
-
-///|
-/// Map one live offset from a rejected contiguous edit back into the accepted
-/// text's UTF-16 coordinates.
-fn rejected_text_offset(
-  accepted_source : String,
-  rejected_source : String,
-  offset : Int,
-) -> Int {
-  let change = @text_change.compute_text_change(
-    accepted_source, rejected_source,
-  )
-  let inserted_len = change.inserted.length()
-  let inserted_end = change.start + inserted_len
-  let mapped = if offset <= change.start {
-    offset
-  } else if offset >= inserted_end {
-    offset - inserted_len + change.delete_len
-  } else {
-    change.start
-  }
-  mapped.clamp(min=0, max=accepted_source.length())
-}
-
-///|
-/// Map a live selection from one rejected contiguous edit back into the
-/// accepted source's UTF-16 coordinates.
-fn rejected_text_selection(
-  accepted_source : String,
-  rejected_source : String,
-  selection : @dom_boundary.TextSelection,
-) -> @dom_boundary.TextSelection {
-  let start = rejected_text_offset(
-    accepted_source,
-    rejected_source,
-    selection.start(),
-  )
-  let end = rejected_text_offset(
-    accepted_source,
-    rejected_source,
-    selection.end(),
-  ).clamp(min=start, max=accepted_source.length())
-  @dom_boundary.TextSelection(start, end, selection.direction())
 }
 
 ///|
@@ -224,12 +152,6 @@ fn mode_name(mode : @core.ApplicationMode) -> String {
     @core.Block => "block"
     @core.Preview => "preview"
   }
-}
-
-///|
-/// Aggregate document-level Preview demand independently from the active mode.
-fn preview_requested(model : DriverModel) -> Bool {
-  model.state.mode() == @core.Preview || model.split_preview_open
 }
 
 ///|
@@ -440,34 +362,6 @@ fn commit_source(
       )
       (failed, false, false)
     }
-  }
-}
-
-///|
-/// Imperative shell around `preview_document_decision`; this is the sole
-/// application read site for the mount-owned semantic attachment.
-fn update_preview_document(
-  attachment : @md_markdown.MarkdownSemanticAttachment,
-  model : DriverModel,
-  old_requested : Bool,
-  accepted~ : Bool,
-  changed~ : Bool,
-) -> DriverModel {
-  match
-    preview_document_decision(
-      old_requested,
-      preview_requested(model),
-      accepted~,
-      changed~,
-    ) {
-    PreviewDocumentRead =>
-      {
-        ..model,
-        semantic_document: Some(attachment.document()),
-        semantic_read_count: model.semantic_read_count + 1,
-      }
-    PreviewDocumentKeep => model
-    PreviewDocumentClear => { ..model, semantic_document: None }
   }
 }
 
@@ -716,52 +610,6 @@ fn editor_surface(
     @core.Preview => preview_document_surface(model)
     @core.Block => block_surface(model, emit)
   }
-}
-
-///|
-/// Capture the live Raw selection before the accepted model may need to repair
-/// a rejected controlled value on the same textarea node.
-fn raw_input_command(
-  source : String,
-  emit : @cmd.Emit[DriverEvent],
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    let selection = @dom_boundary.read_text_selection_id("loomark-input") catch {
-      error => {
-        scheduler.add(emit(EffectFailed(error.message())))
-        return
-      }
-    }
-    scheduler.add(emit(RawInput(source, Some(selection))))
-  })
-}
-
-///|
-/// Capture the DOM caret before the controlled textarea is rendered again.
-fn block_input_command(
-  block : @markdown.MarkdownBlockSnapshot,
-  input_id : String,
-  text : String,
-  emit : @cmd.Emit[DriverEvent],
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    let selection = @dom_boundary.read_text_selection_id(input_id) catch {
-      error => {
-        scheduler.add(emit(EffectFailed(error.message())))
-        return
-      }
-    }
-    scheduler.add(
-      emit(
-        BlockInput(
-          node_id=block.node_id(),
-          input_id~,
-          text~,
-          selection_offset=selection.end(),
-        ),
-      ),
-    )
-  })
 }
 
 ///|

--- a/apps/loomark/internal/rabbita/application_preview_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/application_preview_wbtest.mbt
@@ -1,110 +1,68 @@
 ///|
+/// Preview-demand boundary matrix:
+///
+/// | old consumer | next consumer | accepted | changed | decision |
+/// | --- | --- | --- | --- | --- |
+/// | no | yes | yes | either | read |
+/// | yes | yes | yes | yes | read |
+/// | yes | yes | yes | no | keep |
+/// | either | either | no | either | keep |
+/// | either | no | yes | either | clear |
 test "preview document decision matrix preserves accepted preview reads" {
   assert_eq(
-    preview_document_decision(
-      @core.Raw,
-      @core.Preview,
-      accepted=true,
-      changed=false,
-    ),
+    preview_document_decision(false, true, accepted=true, changed=false),
     PreviewDocumentRead,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Preview,
-      @core.Preview,
-      accepted=true,
-      changed=true,
-    ),
+    preview_document_decision(true, true, accepted=true, changed=true),
     PreviewDocumentRead,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Preview,
-      @core.Preview,
-      accepted=true,
-      changed=false,
-    ),
+    preview_document_decision(true, true, accepted=true, changed=false),
     PreviewDocumentKeep,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Preview,
-      @core.Preview,
-      accepted=false,
-      changed=true,
-    ),
+    preview_document_decision(true, true, accepted=false, changed=true),
     PreviewDocumentKeep,
   )
 }
 
 ///|
-test "preview document decision matrix clears outside preview" {
+test "preview document decision matrix clears without consumers" {
   assert_eq(
-    preview_document_decision(
-      @core.Preview,
-      @core.Raw,
-      accepted=true,
-      changed=false,
-    ),
+    preview_document_decision(true, false, accepted=true, changed=false),
     PreviewDocumentClear,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Preview,
-      @core.Block,
-      accepted=true,
-      changed=true,
-    ),
+    preview_document_decision(true, false, accepted=true, changed=true),
     PreviewDocumentClear,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Raw,
-      @core.Block,
-      accepted=true,
-      changed=false,
-    ),
+    preview_document_decision(false, false, accepted=true, changed=false),
     PreviewDocumentClear,
   )
 }
 
 ///|
-test "preview document decision matrix restores and repeats deterministically" {
+test "preview document decision matrix restores and rejects deterministically" {
   assert_eq(
-    preview_document_decision(
-      @core.Block,
-      @core.Preview,
-      accepted=true,
-      changed=true,
-    ),
+    preview_document_decision(false, true, accepted=true, changed=true),
     PreviewDocumentRead,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Block,
-      @core.Preview,
-      accepted=true,
-      changed=false,
-    ),
+    preview_document_decision(false, true, accepted=true, changed=false),
     PreviewDocumentRead,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Preview,
-      @core.Preview,
-      accepted=true,
-      changed=false,
-    ),
+    preview_document_decision(true, true, accepted=true, changed=false),
     PreviewDocumentKeep,
   )
   assert_eq(
-    preview_document_decision(
-      @core.Raw,
-      @core.Preview,
-      accepted=false,
-      changed=true,
-    ),
+    preview_document_decision(false, true, accepted=false, changed=true),
+    PreviewDocumentKeep,
+  )
+  assert_eq(
+    preview_document_decision(true, false, accepted=false, changed=true),
     PreviewDocumentKeep,
   )
 }

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -3,7 +3,6 @@ import {
   "dowdiness/diagnostic",
   "dowdiness/dom_boundary",
   "dowdiness/markdown" @md_markdown,
-  "dowdiness/rabbita-resizable/resizable",
   "dowdiness/text_change",
   "dowdiness/loomark/core",
   "moonbit-community/rabbita" @rabbita_runtime,

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -3,6 +3,7 @@ import {
   "dowdiness/diagnostic",
   "dowdiness/dom_boundary",
   "dowdiness/markdown" @md_markdown,
+  "dowdiness/rabbita-resizable/resizable",
   "dowdiness/loomark/core",
   "moonbit-community/rabbita" @rabbita_runtime,
   "moonbit-community/rabbita/cmd",

--- a/apps/loomark/internal/rabbita/moon.pkg
+++ b/apps/loomark/internal/rabbita/moon.pkg
@@ -4,6 +4,7 @@ import {
   "dowdiness/dom_boundary",
   "dowdiness/markdown" @md_markdown,
   "dowdiness/rabbita-resizable/resizable",
+  "dowdiness/text_change",
   "dowdiness/loomark/core",
   "moonbit-community/rabbita" @rabbita_runtime,
   "moonbit-community/rabbita/cmd",

--- a/apps/loomark/internal/rabbita/preview_read_model.mbt
+++ b/apps/loomark/internal/rabbita/preview_read_model.mbt
@@ -1,0 +1,61 @@
+///|
+/// Pure preview read-model decision. The shell reads the attachment only when
+/// this boundary returns `PreviewDocumentRead`.
+#warnings("-unused_value")
+priv enum PreviewDocumentDecision {
+  PreviewDocumentRead
+  PreviewDocumentKeep
+  PreviewDocumentClear
+} derive(Eq, Debug)
+
+///|
+fn preview_document_decision(
+  old_requested : Bool,
+  next_requested : Bool,
+  accepted~ : Bool,
+  changed~ : Bool,
+) -> PreviewDocumentDecision {
+  if !accepted {
+    PreviewDocumentKeep
+  } else if !next_requested {
+    PreviewDocumentClear
+  } else if !old_requested || changed {
+    PreviewDocumentRead
+  } else {
+    PreviewDocumentKeep
+  }
+}
+
+///|
+/// Aggregate document-level Preview demand independently from the active mode.
+fn preview_requested(model : DriverModel) -> Bool {
+  model.state.mode() == @core.Preview || model.split_preview_open
+}
+
+///|
+/// Imperative shell around `preview_document_decision`; this is the sole
+/// application read site for the mount-owned semantic attachment.
+fn update_preview_document(
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  old_requested : Bool,
+  accepted~ : Bool,
+  changed~ : Bool,
+) -> DriverModel {
+  match
+    preview_document_decision(
+      old_requested,
+      preview_requested(model),
+      accepted~,
+      changed~,
+    ) {
+    PreviewDocumentRead =>
+      {
+        ..model,
+        semantic_document: Some(attachment.document()),
+        semantic_read_count: model.semantic_read_count + 1,
+      }
+    PreviewDocumentKeep => model
+    PreviewDocumentClear => { ..model, semantic_document: None }
+  }
+}

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -1,0 +1,116 @@
+///|
+fn split_visible(model : DriverModel) -> Bool {
+  model.split_preview_open && model.state.mode() != @core.Preview
+}
+
+///|
+/// Rebuild the opaque resizable model against the measured group width. The
+/// editor Pane may occupy at most half so its flexible Preview peer remains
+/// visible, and the ARIA value always equals rendered geometry.
+fn SplitResizeState::fit_group(
+  self : SplitResizeState,
+  group_width : Int,
+) -> SplitResizeState {
+  let max_width = (group_width / 2).clamp(min=1, max=640)
+  let min_width = if max_width < 160 { max_width } else { 160 }
+  {
+    model: @resizable.Model::new(w=self.model.width(), h=1, constraints={
+      min_w: min_width,
+      max_w: max_width,
+      min_h: 1,
+      max_h: 1,
+    }),
+  }
+}
+
+///|
+/// Measure only after Rabbita has rendered the group; DOM access remains in
+/// the imperative shell and returns the owning width as a typed event.
+fn split_measure_command(emit : @cmd.Emit[DriverEvent]) -> @cmd.Cmd {
+  after_render(
+    scheduler => {
+      let measurement = @dom_boundary.measure_element_id("loomark-split")
+      scheduler.add(emit(SplitMeasured(measurement.offset_width().to_int())))
+    },
+    emit,
+  )
+}
+
+///|
+/// Compose the active editing mode without owning document resources.
+fn mode_surface(
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Html {
+  if model.state.mode() == @core.Block {
+    @html.div(
+      style=["width:100%;min-width:0;display:flex;flex-direction:column"],
+      [
+        block_format_toolbar(model, emit),
+        @html.div(
+          id="loomark-surface",
+          style=["width:100%;min-width:0;display:flex"],
+          editor_surface(model, emit),
+        ),
+      ],
+    )
+  } else {
+    @html.div(
+      id="loomark-surface",
+      style=["width:100%;min-width:0;display:flex"],
+      editor_surface(model, emit),
+    )
+  }
+}
+
+///|
+/// Render the fixed two-surface workspace. Both surfaces observe the same
+/// accepted document held by `DriverModel`.
+fn application_surface(
+  model : DriverModel,
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Html {
+  if split_visible(model) {
+    let editor_width = model.split_resize.model.width()
+    let handle_attrs = model.split_resize.model
+      .handle_attrs(@resizable.East, message => emit(SplitResize(message)))
+      .aria_label("Resize editor and Preview")
+      .data_set("slot", "resizable-handle")
+      .data_set("orientation", "horizontal")
+    @html.div(
+      id="loomark-split",
+      attrs=@html.Attrs::build()
+        .data_set("slot", "resizable-panel-group")
+        .data_set("orientation", "horizontal"),
+      style=["width:100%;min-width:0;display:flex;overflow:hidden"],
+      [
+        @html.div(
+          attrs=@html.Attrs::build()
+            .data_set("slot", "resizable-panel")
+            .data_set("panel", "editor"),
+          style=[
+            "width:\{editor_width}px;min-width:0;display:flex;flex:0 0 auto",
+          ],
+          mode_surface(model, emit),
+        ),
+        @html.div(
+          id="loomark-split-handle",
+          attrs=handle_attrs,
+          style=[
+            "width:1px;flex:0 0 1px;background:var(--rui-border);outline-offset:3px;cursor:col-resize",
+          ],
+          @html.nothing,
+        ),
+        @html.div(
+          attrs=@html.Attrs::build()
+            .data_set("slot", "resizable-panel")
+            .data_set("panel", "preview"),
+          style=["min-width:0;flex:1;overflow:auto;padding:1rem;border-left:0"],
+          preview_document_surface(model),
+        ),
+      ],
+    )
+  } else {
+    mode_surface(model, emit)
+  }
+}

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -97,9 +97,17 @@ fn application_surface(
           id="loomark-split-handle",
           attrs=handle_attrs,
           style=[
-            "width:1px;flex:0 0 1px;background:var(--rui-border);outline-offset:3px;cursor:col-resize",
+            "position:relative;z-index:1;width:1px;flex:0 0 1px;background:var(--rui-border);outline-offset:6px;cursor:col-resize",
           ],
-          @html.nothing,
+          @html.span(
+            attrs=@html.Attrs::build()
+              .data_set("slot", "resizable-handle-hit-area")
+              .aria_hidden("true"),
+            style=[
+              "position:absolute;z-index:2;left:-6px;top:0;width:13px;height:100%;cursor:col-resize;background:transparent;touch-action:none;user-select:none",
+            ],
+            "",
+          ),
         ),
         @html.div(
           attrs=@html.Attrs::build()

--- a/apps/loomark/internal/rabbita/split_view.mbt
+++ b/apps/loomark/internal/rabbita/split_view.mbt
@@ -1,39 +1,41 @@
 ///|
+const SPLIT_STACK_BREAKPOINT : Int = 640
+
+///|
+priv enum SplitPresentation {
+  SingleSurface
+  SideBySide
+  Stacked
+} derive(Eq)
+
+///|
+impl @rabbita_runtime.Enumerate for SplitPresentation with fn tag(self) {
+  match self {
+    SingleSurface => "single"
+    SideBySide => "side-by-side"
+    Stacked => "stacked"
+  }
+}
+
+///|
 fn split_visible(model : DriverModel) -> Bool {
   model.split_preview_open && model.state.mode() != @core.Preview
 }
 
 ///|
-/// Rebuild the opaque resizable model against the measured group width. The
-/// editor Pane may occupy at most half so its flexible Preview peer remains
-/// visible, and the ARIA value always equals rendered geometry.
-fn SplitResizeState::fit_group(
-  self : SplitResizeState,
-  group_width : Int,
-) -> SplitResizeState {
-  let max_width = (group_width / 2).clamp(min=1, max=640)
-  let min_width = if max_width < 160 { max_width } else { 160 }
-  {
-    model: @resizable.Model::new(w=self.model.width(), h=1, constraints={
-      min_w: min_width,
-      max_w: max_width,
-      min_h: 1,
-      max_h: 1,
-    }),
-  }
+fn compact_split_for_width(width : Int) -> Bool {
+  width < SPLIT_STACK_BREAKPOINT
 }
 
 ///|
-/// Measure only after Rabbita has rendered the group; DOM access remains in
-/// the imperative shell and returns the owning width as a typed event.
-fn split_measure_command(emit : @cmd.Emit[DriverEvent]) -> @cmd.Cmd {
-  after_render(
-    scheduler => {
-      let measurement = @dom_boundary.measure_element_id("loomark-split")
-      scheduler.add(emit(SplitMeasured(measurement.offset_width().to_int())))
-    },
-    emit,
-  )
+fn split_presentation(model : DriverModel) -> SplitPresentation {
+  if !split_visible(model) {
+    SingleSurface
+  } else if model.compact_split {
+    Stacked
+  } else {
+    SideBySide
+  }
 }
 
 ///|
@@ -64,61 +66,83 @@ fn mode_surface(
 }
 
 ///|
-/// Render the fixed two-surface workspace. Both surfaces observe the same
-/// accepted document held by `DriverModel`.
-fn application_surface(
-  model : DriverModel,
+fn single_surface(
+  model : @rabbita_runtime.Val[DriverModel],
   emit : @cmd.Emit[DriverEvent],
-) -> @rabbita_runtime.Html {
-  if split_visible(model) {
-    let editor_width = model.split_resize.model.width()
-    let handle_attrs = model.split_resize.model
-      .handle_attrs(@resizable.East, message => emit(SplitResize(message)))
-      .aria_label("Resize editor and Preview")
-      .data_set("slot", "resizable-handle")
-      .data_set("orientation", "horizontal")
-    @html.div(
-      id="loomark-split",
-      attrs=@html.Attrs::build()
-        .data_set("slot", "resizable-panel-group")
-        .data_set("orientation", "horizontal"),
-      style=["width:100%;min-width:0;display:flex;overflow:hidden"],
-      [
-        @html.div(
-          attrs=@html.Attrs::build()
-            .data_set("slot", "resizable-panel")
-            .data_set("panel", "editor"),
-          style=[
-            "width:\{editor_width}px;min-width:0;display:flex;flex:0 0 auto",
-          ],
+) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
+  model.view(model => mode_surface(model, emit))
+}
+
+///|
+fn resizable_split_surface(
+  model : @rabbita_runtime.Val[DriverModel],
+  emit : @cmd.Emit[DriverEvent],
+  orientation : @rui.SeparatorOrientation,
+) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
+  @rui.resizable_panel_group_with_input(
+    id="loomark-split",
+    input=model,
+    default_size=50,
+    min=25,
+    max=75,
+    orientation~,
+    aria_label="Resize editor and Preview",
+    style=["flex:1;min-width:0;min-height:0"],
+    (scope, model) => {
+      @html.fragment([
+        @rui.resizable_panel(
+          scope~,
+          side=@rui.FirstPanel,
+          attrs=@html.Attrs::build().data_set("panel", "editor"),
+          style=["display:flex;overflow:auto"],
           mode_surface(model, emit),
         ),
-        @html.div(
-          id="loomark-split-handle",
-          attrs=handle_attrs,
-          style=[
-            "position:relative;z-index:1;width:1px;flex:0 0 1px;background:var(--rui-border);outline-offset:6px;cursor:col-resize",
-          ],
-          @html.span(
-            attrs=@html.Attrs::build()
-              .data_set("slot", "resizable-handle-hit-area")
-              .aria_hidden("true"),
-            style=[
-              "position:absolute;z-index:2;left:-6px;top:0;width:13px;height:100%;cursor:col-resize;background:transparent;touch-action:none;user-select:none",
-            ],
-            "",
-          ),
+        @rui.resizable_handle(
+          scope~,
+          with_handle=true,
+          aria_label="Resize editor and Preview",
         ),
-        @html.div(
-          attrs=@html.Attrs::build()
-            .data_set("slot", "resizable-panel")
-            .data_set("panel", "preview"),
-          style=["min-width:0;flex:1;overflow:auto;padding:1rem;border-left:0"],
+        @rui.resizable_panel(
+          scope~,
+          side=@rui.SecondPanel,
+          attrs=@html.Attrs::build().data_set("panel", "preview"),
+          style=["padding:1rem"],
           preview_document_surface(model),
         ),
-      ],
-    )
-  } else {
-    mode_surface(model, emit)
-  }
+      ])
+    },
+  )
+}
+
+///|
+fn side_by_side_surface(
+  model : @rabbita_runtime.Val[DriverModel],
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
+  resizable_split_surface(model, emit, @rui.Horizontal)
+}
+
+///|
+fn stacked_surface(
+  model : @rabbita_runtime.Val[DriverModel],
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
+  resizable_split_surface(model, emit, @rui.Vertical)
+}
+
+///|
+/// Select one bounded workspace component while the shared document model stays
+/// live as a separate incremental input to every branch.
+fn application_surface(
+  model : @rabbita_runtime.Val[DriverModel],
+  emit : @cmd.Emit[DriverEvent],
+) -> @rabbita_runtime.Val[@rabbita_runtime.Html] {
+  let presentation = model.map(split_presentation)
+  presentation.switch(presentation => {
+    match presentation {
+      SingleSurface => single_surface(model, emit)
+      SideBySide => side_by_side_surface(model, emit)
+      Stacked => stacked_surface(model, emit)
+    }
+  })
 }

--- a/apps/loomark/internal/rabbita/text_control_repair.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair.mbt
@@ -1,0 +1,89 @@
+///|
+/// Map one live offset from a rejected contiguous edit back into the accepted
+/// text's UTF-16 coordinates.
+fn rejected_text_offset(
+  accepted_source : String,
+  rejected_source : String,
+  offset : Int,
+) -> Int {
+  let change = @text_change.compute_text_change(
+    accepted_source, rejected_source,
+  )
+  let inserted_len = change.inserted.length()
+  let inserted_end = change.start + inserted_len
+  let mapped = if offset <= change.start {
+    offset
+  } else if offset >= inserted_end {
+    offset - inserted_len + change.delete_len
+  } else {
+    change.start
+  }
+  mapped.clamp(min=0, max=accepted_source.length())
+}
+
+///|
+/// Map a live selection from one rejected contiguous edit back into the
+/// accepted source's UTF-16 coordinates.
+fn rejected_text_selection(
+  accepted_source : String,
+  rejected_source : String,
+  selection : @dom_boundary.TextSelection,
+) -> @dom_boundary.TextSelection {
+  let start = rejected_text_offset(
+    accepted_source,
+    rejected_source,
+    selection.start(),
+  )
+  let end = rejected_text_offset(
+    accepted_source,
+    rejected_source,
+    selection.end(),
+  ).clamp(min=start, max=accepted_source.length())
+  @dom_boundary.TextSelection(start, end, selection.direction())
+}
+
+///|
+/// Capture the live Raw selection before the accepted model may need to repair
+/// a rejected controlled value on the same textarea node.
+fn raw_input_command(
+  source : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    let selection = @dom_boundary.read_text_selection_id("loomark-input") catch {
+      error => {
+        scheduler.add(emit(EffectFailed(error.message())))
+        return
+      }
+    }
+    scheduler.add(emit(RawInput(source, Some(selection))))
+  })
+}
+
+///|
+/// Capture the DOM text cursor before the controlled textarea is rendered again.
+fn block_input_command(
+  block : @markdown.MarkdownBlockSnapshot,
+  input_id : String,
+  text : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    let selection = @dom_boundary.read_text_selection_id(input_id) catch {
+      error => {
+        scheduler.add(emit(EffectFailed(error.message())))
+        return
+      }
+    }
+    scheduler.add(
+      emit(
+        BlockInput(
+          node_id=block.node_id(),
+          input_id~,
+          text~,
+          selection_offset=selection.end(),
+        ),
+      ),
+    )
+  })
+}

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -1,0 +1,24 @@
+///|
+test "rejected insertion maps a non-BMP UTF-16 caret back to accepted source" {
+  let selection = rejected_text_selection(
+    "A😀B",
+    "A😀XB",
+    @dom_boundary.TextSelection(4, 4, @dom_boundary.NoDirection),
+  )
+  inspect(selection.start(), content="3")
+  inspect(selection.end(), content="3")
+}
+
+///|
+test "rejected replacement maps a range around the accepted span" {
+  let selection = rejected_text_selection(
+    "abcdef",
+    "abXef",
+    @dom_boundary.TextSelection(2, 3, @dom_boundary.Backward),
+  )
+  inspect(selection.start(), content="2")
+  inspect(selection.end(), content="4")
+  guard selection.direction() is @dom_boundary.Backward else {
+    fail("expected selection direction to be preserved")
+  }
+}

--- a/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/text_control_repair_wbtest.mbt
@@ -1,5 +1,5 @@
 ///|
-test "rejected insertion maps a non-BMP UTF-16 caret back to accepted source" {
+test "rejected insertion maps a non-BMP UTF-16 text cursor back to accepted source" {
   let selection = rejected_text_selection(
     "A😀B",
     "A😀XB",

--- a/apps/loomark/moon.mod
+++ b/apps/loomark/moon.mod
@@ -7,7 +7,6 @@ import {
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/markdown@0.1.0",
-  "dowdiness/rabbita-resizable@0.1.0",
   "dowdiness/text_change@0.1.0",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",

--- a/apps/loomark/moon.mod
+++ b/apps/loomark/moon.mod
@@ -8,6 +8,7 @@ import {
   "dowdiness/loom@0.1.0",
   "dowdiness/markdown@0.1.0",
   "dowdiness/rabbita-resizable@0.1.0",
+  "dowdiness/text_change@0.1.0",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",
   "moonbit-community/rabbita@0.14.1",

--- a/apps/loomark/moon.mod
+++ b/apps/loomark/moon.mod
@@ -7,6 +7,7 @@ import {
   "dowdiness/diagnostic@0.1.0",
   "dowdiness/loom@0.1.0",
   "dowdiness/markdown@0.1.0",
+  "dowdiness/rabbita-resizable@0.1.0",
   "dowdiness/dom_boundary@0.1.0",
   "dowdiness/js_ffi@0.1.0",
   "moonbit-community/rabbita@0.14.1",

--- a/docs/plans/2026-08-01-loomark-application-handoff.md
+++ b/docs/plans/2026-08-01-loomark-application-handoff.md
@@ -197,7 +197,7 @@ Focus tokens are opaque logical locators, not DOM/session identity. Their privat
 | supported/rejected MoveBlock | lang/markdown/edits/compute_markdown_edit_wbtest.mbt | edit + approved Waku subset |
 | IME final commit, version/errors/reentrancy | absent | #1076 core + Vanilla contract |
 | mount ownership/full remount | absent | #1072 Vanilla contract; Waku cutover subset |
-| selection/measurement/listener | modules/dom-boundary additions | boundary; Rabbita wiring only |
+| text value/selection/measurement/listener | modules/dom-boundary additions | boundary; Rabbita wiring only |
 | React/Vue | absent | lifecycle tests plus real-binding smoke |
 
 ## Ordered graph
@@ -273,6 +273,13 @@ are deliberately absent from `MarkdownSnapshotV1`, focus tokens, and the future
 public Browser Session contract. Full Preview temporarily replaces the split
 layout without discarding the private split preference; returning to Raw or
 Block restores the two-surface view without another semantic read.
+
+Accepted Raw and Block input keeps each mounted textarea node stable across
+renders. A rejected controlled edit also keeps that node: after rendering the
+unchanged accepted model, the imperative shell restores the accepted value
+through `dom-boundary` and reapplies any required focus/caret. Rejection does
+not use a rendering epoch, keyed relocation, or remove/add remount to repair a
+live DOM value that diverged from the accepted document.
 
 The divider reuses `modules/rabbita-resizable` for its pure clamped model,
 mouse subscription, keyboard nudges, and separator ARIA values. Loomark owns

--- a/docs/plans/2026-08-01-loomark-application-handoff.md
+++ b/docs/plans/2026-08-01-loomark-application-handoff.md
@@ -277,13 +277,14 @@ Block restores the two-surface view without another semantic read.
 Accepted Raw and Block input keeps each mounted textarea node stable across
 renders. A rejected controlled edit also keeps that node: after rendering the
 unchanged accepted model, the imperative shell restores the accepted value
-through `dom-boundary` and reapplies any required focus/caret. Rejection does
-not use a rendering epoch, keyed relocation, or remove/add remount to repair a
-live DOM value that diverged from the accepted document.
+through `dom-boundary` and reapplies any required focus/text cursor. Rejection
+does not use a rendering epoch, keyed relocation, or remove/add remount to
+repair a live DOM value that diverged from the accepted document.
 
 The divider reuses `modules/rabbita-resizable` for its pure clamped model,
 mouse subscription, keyboard nudges, and separator ARIA values. Loomark owns
-only Pane composition and styling in `internal/rabbita/split_view.mbt`. The
+only Pane composition and styling in `internal/rabbita/split_view.mbt`,
+including a wider invisible hit area around the one-pixel divider line. The
 first increment keeps a horizontal two-Pane layout and caps the editing Pane at
 half of narrow containers so both surfaces remain within the viewport.
 

--- a/docs/plans/2026-08-01-loomark-application-handoff.md
+++ b/docs/plans/2026-08-01-loomark-application-handoff.md
@@ -231,7 +231,9 @@ Issue #1145 follows the completed private Application Train and does not wait fo
 Rabbita #141. It attaches one `MarkdownSemanticAttachment` to the exact parser
 created for the private Loomark editor and retains it for the existing
 page/process lifetime. Raw and Block keep the editable `Block` projection;
-Preview alone holds an owning `MarkdownIR` read model. The ordinary headless
+the document-level Preview consumer holds an owning `MarkdownIR` read model.
+The consumer may be the full Preview mode or the fixed split Preview described
+below. The ordinary headless
 `MarkdownEditor` constructor remains attachment-free. `SyncEditor` privately
 roots the three projection memos it already owns for the editor lifetime, so
 attachment collection cannot sweep the editable projection graph without
@@ -242,20 +244,49 @@ recorded in
 | Boundary | Accepted transition | Semantic read | Required observation |
 | --- | --- | --- | --- |
 | Private mount | construct editor and attachment over one parser | none while initial mode is Raw | one attachment; ordinary constructor unchanged |
-| Raw/Block → Preview | committed mode transition | once after transition acceptance | current complete MarkdownIR renders through typed Rabbita HTML |
-| Preview source/block edit | editor commit succeeds | once after commit | Raw, Block, and Preview reflect the same canonical source |
+| no Preview consumer → at least one consumer | committed mode or split transition | once after transition acceptance | current complete MarkdownIR renders through typed Rabbita HTML |
+| accepted source/block edit while a Preview consumer exists | editor commit succeeds | once after commit | Raw, Block, and Preview reflect the same canonical source |
 | Preview no-op or rejected edit | no committed source change | none | prior owning Preview document and focus remain visible |
 | Snapshot restore to Preview | source/mode transaction succeeds | once after acceptance | restored source and semantic document appear atomically |
-| Snapshot restore outside Preview | transaction succeeds | none; semantic model may be cleared | editable source/projection behavior is unchanged |
+| last Preview consumer disappears | committed mode or split transition | none; semantic model is cleared | editable source/projection behavior is unchanged |
 | Prepend, position shift, exact reversal | commit succeeds in Preview | once per committed edit | attached result matches fresh one-shot MarkdownIR lowering |
 | Malformed intermediate input | parser accepts recovered source | once per committed edit in Preview | `Raw`/`Recovered` are visible; no last-good substitution |
 | Valid inline/block HTML | semantic render | no extra read | literal content is escaped text, never injected DOM markup |
-| Repeated mode switches and mount rejection | accepted transition / rejected second mount | only non-Preview → Preview reads | attachment count stays one; existing single-mount contract stays green |
+| Repeated mode/split switches and mount rejection | accepted transition / rejected second mount | only zero-consumer → consumer reads | attachment count stays one; existing single-mount contract stays green |
 
 The deterministic renderer exhaustively matches `MarkdownIRView`. It consumes
 an already-owned document and performs no parser, attachment, DOM, clock,
 subscription, or `document()` effect. Reading the attachment and installing the
 owning document remain imperative-shell work at the committed boundaries above.
+
+### Fixed split Preview M0
+
+The first split-view increment is one editable Raw or Block surface beside one
+read-only Preview. Both surfaces observe the same mount-owned editor, parser,
+semantic attachment, canonical source, history, and accepted revision. Opening
+or closing the split never constructs or disposes a document resource. Block
+and Raw commits pass through their existing atomic editor boundary before the
+Preview read model advances.
+
+Split open state and divider width are private, ephemeral Rabbita state. They
+are deliberately absent from `MarkdownSnapshotV1`, focus tokens, and the future
+public Browser Session contract. Full Preview temporarily replaces the split
+layout without discarding the private split preference; returning to Raw or
+Block restores the two-surface view without another semantic read.
+
+The divider reuses `modules/rabbita-resizable` for its pure clamped model,
+mouse subscription, keyboard nudges, and separator ARIA values. Loomark owns
+only Pane composition and styling in `internal/rabbita/split_view.mbt`. The
+first increment keeps a horizontal two-Pane layout and caps the editing Pane at
+half of narrow containers so both surfaces remain within the viewport.
+
+Out of this increment are recursive Pane trees, a second editable Pane, layout
+persistence, scroll/selection synchronization, and public lifecycle changes.
+Warren remains Rabbita development-preview/build tooling; it does not own
+runtime Pane state or replace the private deterministic Vanilla/Playwright
+contract host. Adopting Warren as an additional interactive host is a separate
+tooling change after the vendored Warren CLI is compatible with the workspace
+MoonBit toolchain.
 
 ### Canonical Session, adapters, and Waku
 

--- a/docs/plans/2026-08-01-loomark-application-handoff.md
+++ b/docs/plans/2026-08-01-loomark-application-handoff.md
@@ -268,11 +268,12 @@ or closing the split never constructs or disposes a document resource. Block
 and Raw commits pass through their existing atomic editor boundary before the
 Preview read model advances.
 
-Split open state and divider width are private, ephemeral Rabbita state. They
-are deliberately absent from `MarkdownSnapshotV1`, focus tokens, and the future
-public Browser Session contract. Full Preview temporarily replaces the split
-layout without discarding the private split preference; returning to Raw or
-Block restores the two-surface view without another semantic read.
+Split open state is private application state, while the divider ratio is local
+ephemeral RUI state. Both are deliberately absent from `MarkdownSnapshotV1`,
+focus tokens, and the future public Browser Session contract. Full Preview
+temporarily replaces the split layout without discarding the private split
+preference; returning to Raw or Block restores the two-surface view without
+another semantic read.
 
 Accepted Raw and Block input keeps each mounted textarea node stable across
 renders. A rejected controlled edit also keeps that node: after rendering the
@@ -281,12 +282,15 @@ through `dom-boundary` and reapplies any required focus/text cursor. Rejection
 does not use a rendering epoch, keyed relocation, or remove/add remount to
 repair a live DOM value that diverged from the accepted document.
 
-The divider reuses `modules/rabbita-resizable` for its pure clamped model,
-mouse subscription, keyboard nudges, and separator ARIA values. Loomark owns
-only Pane composition and styling in `internal/rabbita/split_view.mbt`,
-including a wider invisible hit area around the one-pixel divider line. The
-first increment keeps a horizontal two-Pane layout and caps the editing Pane at
-half of narrow containers so both surfaces remain within the viewport.
+The divider uses RUI's `resizable_panel_group_with_input`, which keeps pointer
+capture, touch cancellation, keyboard nudges, clamped percentage sizes, and
+separator ARIA values inside RUI while allowing the panels to observe Loomark's
+incremental document model. Loomark owns only Pane composition and the pure
+viewport-width decision in `internal/rabbita/split_view.mbt`. At 640 CSS pixels
+and above the panes are side by side; below that breakpoint the same editor and
+Preview stack vertically. Crossing the breakpoint preserves the live text
+input node, focus, and text cursor. RUI supplies the one-pixel divider and its
+wider invisible hit area on both axes.
 
 Out of this increment are recursive Pane trees, a second editable Pane, layout
 persistence, scroll/selection synchronization, and public lifecycle changes.

--- a/modules/dom-boundary/dom_boundary.mbt
+++ b/modules/dom-boundary/dom_boundary.mbt
@@ -11,6 +11,7 @@ pub(all) enum DomAction {
   Click
   ScrollIntoView
   ReadTextSelection
+  WriteTextValue
   WriteTextSelection
   MeasureElement
   DispatchCustomEvent
@@ -213,6 +214,22 @@ pub fn read_text_selection_selector(
   selector : String,
 ) -> TextSelection raise DomBoundaryError {
   read_text_selection_target(LOOKUP_SELECTOR, selector, Selector(selector))
+}
+
+///|
+pub fn write_text_value_id(
+  id : String,
+  value : String,
+) -> Unit raise DomBoundaryError {
+  write_text_value_target(LOOKUP_ID, id, Id(id), value)
+}
+
+///|
+pub fn write_text_value_selector(
+  selector : String,
+  value : String,
+) -> Unit raise DomBoundaryError {
+  write_text_value_target(LOOKUP_SELECTOR, selector, Selector(selector), value)
 }
 
 ///|

--- a/modules/dom-boundary/dom_boundary_runtime.mbt
+++ b/modules/dom-boundary/dom_boundary_runtime.mbt
@@ -235,6 +235,26 @@ fn read_text_selection_target(
 }
 
 ///|
+fn write_text_value_target(
+  lookup_kind : String,
+  raw_target : String,
+  target : DomTarget,
+  value : String,
+) -> Unit raise DomBoundaryError {
+  let element = resolve_target(lookup_kind, raw_target, WriteTextValue, target)
+  let supported : Bool = run_dom_operation(WriteTextValue, target, () => {
+    @js.any(@js.any(element).get("value").type_of() == "string")
+  }).cast()
+  guard supported else {
+    raise UnsupportedAction(action=WriteTextValue, target~)
+  }
+  let _ = run_dom_operation(WriteTextValue, target, () => {
+    @js.any(element).set("value", @js.any(value))
+    @js.undefined()
+  })
+}
+
+///|
 fn decode_text_selection_direction(
   direction : String,
   target : DomTarget,
@@ -481,6 +501,7 @@ fn DomAction::describe(self : DomAction) -> String {
     Click => "click"
     ScrollIntoView => "scrollIntoView"
     ReadTextSelection => "readTextSelection"
+    WriteTextValue => "writeTextValue"
     WriteTextSelection => "writeTextSelection"
     MeasureElement => "measureElement"
     DispatchCustomEvent => "dispatchCustomEvent"

--- a/modules/dom-boundary/dom_boundary_wbtest.mbt
+++ b/modules/dom-boundary/dom_boundary_wbtest.mbt
@@ -235,6 +235,10 @@ extern "js" fn text_control_selection(id : String) -> String =
   #| }
 
 ///|
+extern "js" fn text_control_value(id : String) -> String =
+  #| (id) => globalThis.document.getElementById(id).value
+
+///|
 extern "js" fn text_selection_write_count() -> Int =
   #| () => globalThis.__canopyTextSelectionWrites
 
@@ -651,6 +655,24 @@ test "write_text_selection_id applies UTF-16 offsets and direction" {
 }
 
 ///|
+test "write_text_value_id updates an existing text control" {
+  install_text_control_document("editor", "rejected", 8, 8, "none")
+  write_text_value_id("editor", "accepted")
+  let value = text_control_value("editor")
+  clear_text_control_document()
+  inspect(value, content="accepted")
+}
+
+///|
+test "write_text_value_selector resolves an existing text control" {
+  install_text_control_document("editor", "before", 6, 6, "none")
+  write_text_value_selector("#editor", "after")
+  let value = text_control_value("editor")
+  clear_text_control_document()
+  inspect(value, content="after")
+}
+
+///|
 test "measure_element_id returns a detached immutable measurement" {
   install_text_control_document("editor", "text", 0, 0, "none")
   update_element_measurement("editor", 120.5, 48.25)
@@ -726,6 +748,12 @@ test "text selection and measurement reject unsupported elements" {
   } catch {
     error => Some(error)
   }
+  let value_error = try {
+    write_text_value_id("host", "value")
+    None
+  } catch {
+    error => Some(error)
+  }
   let measure_error = try {
     let _ = measure_element_id("host")
     None
@@ -740,6 +768,10 @@ test "text selection and measurement reject unsupported elements" {
   guard write_error
     is Some(UnsupportedAction(action=WriteTextSelection, target=Id("host"))) else {
     fail("expected unsupported text selection write")
+  }
+  guard value_error
+    is Some(UnsupportedAction(action=WriteTextValue, target=Id("host"))) else {
+    fail("expected unsupported text value write")
   }
   guard measure_error
     is Some(UnsupportedAction(action=MeasureElement, target=Id("host"))) else {

--- a/modules/dom-boundary/pkg.generated.mbti
+++ b/modules/dom-boundary/pkg.generated.mbti
@@ -42,6 +42,10 @@ pub fn write_text_selection_id(String, TextSelection) -> Unit raise DomBoundaryE
 
 pub fn write_text_selection_selector(String, TextSelection) -> Unit raise DomBoundaryError
 
+pub fn write_text_value_id(String, String) -> Unit raise DomBoundaryError
+
+pub fn write_text_value_selector(String, String) -> Unit raise DomBoundaryError
+
 // Errors
 pub(all) suberror DomBoundaryError {
   DocumentUnavailable
@@ -66,6 +70,7 @@ pub(all) enum DomAction {
   Click
   ScrollIntoView
   ReadTextSelection
+  WriteTextValue
   WriteTextSelection
   MeasureElement
   DispatchCustomEvent

--- a/scripts/test-pr-ready-validation.sh
+++ b/scripts/test-pr-ready-validation.sh
@@ -231,7 +231,7 @@ if PATH="$fake_bin:$PATH" \
     --target pkg >"$unpushed_output" 2>&1; then
   fail "unpushed submodule commit unexpectedly passed"
 fi
-grep -q "submodule commit is not reachable from origin" "$unpushed_output" ||
+grep -q "submodule commit is not fetchable from origin" "$unpushed_output" ||
   fail "unpushed submodule diagnostic was not actionable"
 if [ -s "$execution_log" ]; then
   fail "unpushed submodule failure ran dependency commands"
@@ -243,8 +243,23 @@ fi
 grep -q "evidence is missing" "$tmp_dir/unpushed-evidence-output" ||
   fail "unpushed submodule failure did not invalidate earlier evidence"
 
+git -C "$fixture/vendor/test-submodule" push --quiet \
+  origin HEAD:refs/pull/144/head
+: >"$execution_log"
+pull_ref_output="$tmp_dir/pull-ref-submodule-output"
+if ! PATH="$fake_bin:$PATH" \
+  PR_READY_TEST_LOG="$execution_log" \
+  "$fixture/scripts/validate-pr-ready.sh" \
+    --base fixture-base \
+    --target pkg >"$pull_ref_output" 2>&1; then
+  fail "submodule commit fetchable only by exact SHA was rejected"
+fi
+grep -q "PR-ready validation passed" "$pull_ref_output" ||
+  fail "exact-SHA-fetchable submodule did not complete validation"
+
 git -C "$fixture/vendor/test-submodule" push --quiet origin HEAD:main
 
+: >"$execution_log"
 PATH="$fake_bin:$PATH" \
   PR_READY_TEST_LOG="$execution_log" \
   "$fixture/scripts/validate-pr-ready.sh" \

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -318,9 +318,12 @@ run_phase() {
           exit 1
         fi
         if [ -z "$(git for-each-ref --format="%(refname)" --contains HEAD refs/remotes/origin)" ]; then
-          echo "error: submodule commit is not reachable from origin: $displaypath" >&2
-          echo "push its branch to the configured origin before the parent PR" >&2
-          exit 1
+          sha="$(git rev-parse HEAD)"
+          if ! git fetch --quiet --no-tags --refetch origin "$sha"; then
+            echo "error: submodule commit is not fetchable from origin: $displaypath" >&2
+            echo "push the commit to the configured origin before the parent PR" >&2
+            exit 1
+          fi
         fi
       ' || die "submodule remote reachability check failed"
       ;;


### PR DESCRIPTION
## Summary

- Add a fixed Raw/Block + semantic Preview split that keeps one mount-owned Markdown editor, parser, semantic attachment, canonical source, and history.
- Use RUI resizable panels with incremental parent input; render panes side by side at 640 CSS pixels and above, and stack them vertically below the breakpoint.
- Preserve text-input focus and the text cursor across accepted and rejected edits by avoiding no-op keyed DOM relocation and repairing rejected controlled values without remounting the textarea.

## UI and review evidence

- [x] No visible label was removed; the split toggle and resize control retain accessible names, visible focus, and keyboard operation.
- [x] Interactive bounds, pointer feedback, keyboard resize, desktop layout, mobile reflow, focus continuity, and text entry were checked in the rendered UI.
- [x] Canopy-specific ownership and lifecycle claims are recorded in `docs/plans/2026-08-01-loomark-application-handoff.md`; other UX observations are treated as review recommendations.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `resizable_panel_group`, panel, and handle | `deps/rabbita/rui/resizable.mbt` | Yes | The existing RUI sizing, pointer, keyboard, and ARIA implementation remains authoritative. A narrow `resizable_panel_group_with_input` variant was added because the original construction-time child closure could not observe a changing parent `Val`. |
| `Val::view2` and `Val::switch` | Rabbita incremental graph | Yes | They combine the live document model with local RUI state and give responsive presentation branches explicit lifetimes. |
| `on_resize` | `deps/rabbita/rabbita/sub` | Yes | Viewport changes enter the existing application update loop as typed events. |
| `compute_text_change` | `modules/text-change` | Yes | Rejected-edit cursor mapping reuses the shared contiguous-diff representation instead of implementing another diff. |
| text selection, focus, measurement, and custom-event operations | `modules/dom-boundary` | Yes | Browser effects remain behind the existing DOM boundary. The missing text-value write was added there rather than as Loomark-local JS FFI. |
| `Option` mapping/binding, `Result`, `String.length`, `Int.clamp`, and collection `fold` | MoonBit core | Yes | These cover optional effects, error boundaries, UTF-16 offsets, range clamping, and immutable snapshot lookup without new low-level loops. |

New helpers added (if any):

- Preview-demand helpers isolate the pure read/keep/clear decision from the semantic-attachment effect.
- Split presentation helpers own only visibility, breakpoint selection, and Pane composition.
- Text-control repair helpers map rejected UTF-16 selections and enqueue DOM-boundary effects with generation/revision guards.
- `INode::needs_relocation` answers only whether the requested keyed placement would change DOM order.
- `resizable_panel_group_with_input` is the two-panel RUI boundary for changing parent content plus component-local divider state.
- `write_text_value_id` and `write_text_value_selector` complete the existing DOM-boundary ID/selector pairs for controlled text repair.

Remaining imperative code is limited to editor commits, semantic attachment reads, Rabbita commands/subscriptions, DOM operations, and mount-owned lifecycle state.

## Validation scope

Boundary matrix / first failing regression:

- Preview demand: zero/one consumer x accepted/unchanged/rejected source transition x Raw/Block/Preview mode.
- Text input: accepted/rejected commit x Raw/Block x collapsed/range/non-BMP UTF-16 selection x same-frame newer input.
- Keyed reconciliation: retained child already at the anchor vs relocation required.
- Split layout: open/closed/full Preview x desktop/mobile viewport x pointer/keyboard divider input.
- Ownership: one editor and semantic attachment; accepted edits update both surfaces and rejected edits leave the accepted Preview unchanged.

Target packages:

- `deps/rabbita/rui`
- `apps/loomark/internal/rabbita`

Additional conditional gates:

- `npm run typecheck:dev-host` in `apps/loomark/examples/vanilla`: passed.
- `npm run test:dev-host` in `apps/loomark/examples/vanilla`: 70 passed.
- JS build and workspace check/build gates passed through the PR-ready validator.
- Rendered desktop and 390 x 844 mobile layouts were checked with no browser console or page errors.

## PR-ready evidence

Validated HEAD: `c737fd5c6b57d7b2931245707628705206c7a610`

Validated base: `origin/main@b1935696d88e5956a0874761319ec8a2ba871791`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target deps/rabbita/rui \
  --target apps/loomark/internal/rabbita
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff against the validated base was reviewed; the new DOM text-value API and RUI incremental-input API changes are intentional, with no unintended trait-bound widening.
- [x] The changed Rabbita submodule commit is pushed and fetchable from its configured remote by exact SHA.
- [x] Validation was rerun after the final commit and submodule-pointer change.
- [x] Independent MoonBit and browser reviews passed before final validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added split Preview layouts with side-by-side and stacked modes.
  - Added responsive behavior for smaller screens and draggable panel dividers.
  - Added Preview toggling while preserving synchronized editor state.

- **Bug Fixes**
  - Improved recovery after rejected or failed edits, preserving text, focus, selections, and cursor positions.
  - Maintained stable editor controls during accepted and rejected input.
  - Preserved native keyboard cursor navigation in Block editors.

- **Documentation**
  - Clarified Preview ownership, editor responsibilities, responsive behavior, and split-view requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
