### PR TITLE
feat(loomark): add versioned document archive envelope

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@ modules/canopy/probe/diagnostic_portability/pkg.generated.mbti whitespace=-blank
 
 # MoonBit owns these generated interfaces and emits a final blank line.
 modules/canopy/editor/markdown/pkg.generated.mbti whitespace=-blank-at-eof
+apps/loomark/archive/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/core/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/internal/dev_host/pkg.generated.mbti whitespace=-blank-at-eof
 apps/loomark/internal/rabbita/pkg.generated.mbti whitespace=-blank-at-eof

--- a/apps/loomark/archive/archive.mbt
+++ b/apps/loomark/archive/archive.mbt
@@ -33,10 +33,7 @@ pub fn LoomarkDocumentId::value(self : Self) -> String {
 ///|
 /// The capture-side failures for an application-owned archive.
 pub(all) suberror LoomarkArchiveCaptureError {
-  InvalidValidationAgentId
   HistoryUnavailable(detail~ : String)
-  CorruptHistory(detail~ : String)
-  PortableTextHistoryMismatch
 }
 
 ///|
@@ -76,15 +73,14 @@ pub fn LoomarkDocumentArchive::history(
 }
 
 ///|
-/// Capture portable text and the complete opaque history from an editor.
+/// Capture portable text and the complete opaque history from a valid editor.
+///
+/// The editor already owns the source/history invariant. Persisted input is
+/// reopened and checked only at the decode boundary below.
 pub fn LoomarkDocumentArchive::capture(
   document_id~ : LoomarkDocumentId,
   editor~ : @markdown.MarkdownEditor,
-  validation_agent_id~ : String,
 ) -> LoomarkDocumentArchive raise LoomarkArchiveCaptureError {
-  if validation_agent_id.is_empty() {
-    raise LoomarkArchiveCaptureError::InvalidValidationAgentId
-  }
   let portable_markdown = editor.portable_markdown()
   let history = editor.history_since() catch {
     _ =>
@@ -92,7 +88,6 @@ pub fn LoomarkDocumentArchive::capture(
         detail="history export failed",
       )
   }
-  validate_capture(portable_markdown, history, validation_agent_id)
   { document_id, portable_markdown, history }
 }
 
@@ -184,8 +179,9 @@ fn archive_schema_version(
     Some(Json::String(version)) =>
       if version == LOOMARK_ARCHIVE_SCHEMA_VERSION.to_string() {
         LOOMARK_ARCHIVE_SCHEMA_VERSION
-      } else if version.all(c => c.is_ascii_digit()) &&
-        version.any(c => c != '0') {
+      } else if !version.is_empty() &&
+        !version.has_prefix("0") &&
+        version.all(c => c.is_ascii_digit()) {
         raise LoomarkArchiveDecodeError::UnsupportedNewerVersion(version~)
       } else {
         raise LoomarkArchiveDecodeError::MalformedEnvelope(
@@ -219,28 +215,6 @@ fn validate_archive_fields(
       raise LoomarkArchiveDecodeError::MalformedEnvelope(
         detail="extensions must be an empty object in schema version 1",
       )
-  }
-}
-
-///|
-fn validate_capture(
-  portable_markdown : String,
-  history : @markdown.MarkdownDocumentHistory,
-  validation_agent_id : String,
-) -> Unit raise LoomarkArchiveCaptureError {
-  let reopened = @markdown.MarkdownEditor::open(
-    agent_id=validation_agent_id,
-    history~,
-  ) catch {
-    @markdown.MarkdownArchiveError::InvalidAgentId =>
-      raise LoomarkArchiveCaptureError::InvalidValidationAgentId
-    _ =>
-      raise LoomarkArchiveCaptureError::CorruptHistory(
-        detail="history could not be reopened",
-      )
-  }
-  if reopened.portable_markdown() != portable_markdown {
-    raise LoomarkArchiveCaptureError::PortableTextHistoryMismatch
   }
 }
 

--- a/apps/loomark/archive/archive.mbt
+++ b/apps/loomark/archive/archive.mbt
@@ -1,0 +1,267 @@
+///|
+/// The only supported application archive schema version.
+pub const LOOMARK_ARCHIVE_SCHEMA_VERSION : Int = 1
+
+///|
+/// An opaque logical identity for one Loomark document.
+pub struct LoomarkDocumentId {
+  priv value : String
+} derive(Eq, Debug)
+
+///|
+pub(all) suberror LoomarkDocumentIdError {
+  Empty
+}
+
+///|
+/// Construct a non-empty logical document identity.
+pub fn LoomarkDocumentId::from_string(
+  value : String,
+) -> LoomarkDocumentId raise LoomarkDocumentIdError {
+  if value.is_empty() {
+    raise LoomarkDocumentIdError::Empty
+  }
+  { value, }
+}
+
+///|
+/// Return the validated identity for repository keying.
+pub fn LoomarkDocumentId::value(self : Self) -> String {
+  self.value
+}
+
+///|
+/// The capture-side failures for an application-owned archive.
+pub(all) suberror LoomarkArchiveCaptureError {
+  InvalidValidationAgentId
+  HistoryUnavailable(detail~ : String)
+  CorruptHistory(detail~ : String)
+  PortableTextHistoryMismatch
+}
+
+///|
+/// The decode-side failures for an application-owned archive.
+pub(all) suberror LoomarkArchiveDecodeError {
+  UnsupportedNewerVersion(version~ : String)
+  MalformedEnvelope(detail~ : String)
+  EmptyDocumentId
+  CorruptHistory(detail~ : String)
+  PortableTextHistoryMismatch
+  InvalidValidationAgentId
+}
+
+///|
+/// A versioned Loomark document archive with an opaque history payload.
+pub struct LoomarkDocumentArchive {
+  priv document_id : LoomarkDocumentId
+  priv portable_markdown : String
+  priv history : @markdown.MarkdownDocumentHistory
+}
+
+///|
+pub fn LoomarkDocumentArchive::document_id(self : Self) -> LoomarkDocumentId {
+  self.document_id
+}
+
+///|
+pub fn LoomarkDocumentArchive::portable_markdown(self : Self) -> String {
+  self.portable_markdown
+}
+
+///|
+pub fn LoomarkDocumentArchive::history(
+  self : Self,
+) -> @markdown.MarkdownDocumentHistory {
+  self.history
+}
+
+///|
+/// Capture portable text and the complete opaque history from an editor.
+pub fn LoomarkDocumentArchive::capture(
+  document_id~ : LoomarkDocumentId,
+  editor~ : @markdown.MarkdownEditor,
+  validation_agent_id~ : String,
+) -> LoomarkDocumentArchive raise LoomarkArchiveCaptureError {
+  if validation_agent_id.is_empty() {
+    raise LoomarkArchiveCaptureError::InvalidValidationAgentId
+  }
+  let portable_markdown = editor.portable_markdown()
+  let history = editor.history_since() catch {
+    _ =>
+      raise LoomarkArchiveCaptureError::HistoryUnavailable(
+        detail="history export failed",
+      )
+  }
+  validate_capture(portable_markdown, history, validation_agent_id)
+  { document_id, portable_markdown, history }
+}
+
+///|
+/// Encode the exact v1 envelope deterministically.
+pub fn LoomarkDocumentArchive::to_json_string(self : Self) -> String {
+  Json::object({
+    "schema_version": Json::string(LOOMARK_ARCHIVE_SCHEMA_VERSION.to_string()),
+    "document_id": Json::string(self.document_id.value()),
+    "portable_markdown": Json::string(self.portable_markdown),
+    "history": Json::string(self.history.to_json_string()),
+    "extensions": Json::empty_object(),
+  }).stringify()
+}
+
+///|
+/// Decode and validate a v1 archive with a caller-owned fresh validation ID.
+///
+/// Field uniqueness follows core JSON's semantic-object `Map` behavior: a
+/// duplicate member overwrites the earlier value. Canonical Loomark encoding
+/// emits each field once, and strict validation below is over that semantic
+/// object rather than lexical JSON member occurrences.
+pub fn LoomarkDocumentArchive::from_json_string(
+  json : String,
+  validation_agent_id~ : String,
+) -> LoomarkDocumentArchive raise LoomarkArchiveDecodeError {
+  let value = @json.parse(json) catch {
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(detail="invalid JSON")
+  }
+  let fields = match value {
+    Json::Object(fields) => fields
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(
+        detail="archive must be a JSON object",
+      )
+  }
+  let version = archive_schema_version(fields)
+  if version != LOOMARK_ARCHIVE_SCHEMA_VERSION {
+    raise LoomarkArchiveDecodeError::MalformedEnvelope(
+      detail="unsupported archive schema version",
+    )
+  }
+  validate_archive_fields(fields)
+  let document_id = match fields.get("document_id") {
+    Some(Json::String(value)) =>
+      LoomarkDocumentId::from_string(value) catch {
+        _ => raise LoomarkArchiveDecodeError::EmptyDocumentId
+      }
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(
+        detail="document_id must be a non-empty string",
+      )
+  }
+  let portable_markdown = match fields.get("portable_markdown") {
+    Some(Json::String(value)) => value
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(
+        detail="portable_markdown must be a string",
+      )
+  }
+  let history_json = match fields.get("history") {
+    Some(Json::String(value)) => value
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(
+        detail="history must be a string",
+      )
+  }
+  let history = @markdown.MarkdownDocumentHistory::from_json_string(
+    history_json,
+  ) catch {
+    _ =>
+      raise LoomarkArchiveDecodeError::CorruptHistory(
+        detail="history codec rejected payload",
+      )
+  }
+  if validation_agent_id.is_empty() {
+    raise LoomarkArchiveDecodeError::InvalidValidationAgentId
+  }
+  validate_decoded(portable_markdown, history, validation_agent_id)
+  { document_id, portable_markdown, history }
+}
+
+///|
+fn archive_schema_version(
+  fields : Map[String, Json],
+) -> Int raise LoomarkArchiveDecodeError {
+  match fields.get("schema_version") {
+    Some(Json::String(version)) =>
+      if version == LOOMARK_ARCHIVE_SCHEMA_VERSION.to_string() {
+        LOOMARK_ARCHIVE_SCHEMA_VERSION
+      } else if version.all(c => c.is_ascii_digit()) &&
+        version.any(c => c != '0') {
+        raise LoomarkArchiveDecodeError::UnsupportedNewerVersion(version~)
+      } else {
+        raise LoomarkArchiveDecodeError::MalformedEnvelope(
+          detail="schema_version must be the exact string \"1\"",
+        )
+      }
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(
+        detail="schema_version must be a string",
+      )
+  }
+}
+
+///|
+fn validate_archive_fields(
+  fields : Map[String, Json],
+) -> Unit raise LoomarkArchiveDecodeError {
+  if fields.length() != 5 ||
+    !fields.contains("schema_version") ||
+    !fields.contains("document_id") ||
+    !fields.contains("portable_markdown") ||
+    !fields.contains("history") ||
+    !fields.contains("extensions") {
+    raise LoomarkArchiveDecodeError::MalformedEnvelope(
+      detail="archive has missing or unknown top-level fields",
+    )
+  }
+  match fields.get("extensions") {
+    Some(Json::Object(extensions)) if extensions.is_empty() => ()
+    _ =>
+      raise LoomarkArchiveDecodeError::MalformedEnvelope(
+        detail="extensions must be an empty object in schema version 1",
+      )
+  }
+}
+
+///|
+fn validate_capture(
+  portable_markdown : String,
+  history : @markdown.MarkdownDocumentHistory,
+  validation_agent_id : String,
+) -> Unit raise LoomarkArchiveCaptureError {
+  let reopened = @markdown.MarkdownEditor::open(
+    agent_id=validation_agent_id,
+    history~,
+  ) catch {
+    @markdown.MarkdownArchiveError::InvalidAgentId =>
+      raise LoomarkArchiveCaptureError::InvalidValidationAgentId
+    _ =>
+      raise LoomarkArchiveCaptureError::CorruptHistory(
+        detail="history could not be reopened",
+      )
+  }
+  if reopened.portable_markdown() != portable_markdown {
+    raise LoomarkArchiveCaptureError::PortableTextHistoryMismatch
+  }
+}
+
+///|
+fn validate_decoded(
+  portable_markdown : String,
+  history : @markdown.MarkdownDocumentHistory,
+  validation_agent_id : String,
+) -> Unit raise LoomarkArchiveDecodeError {
+  let reopened = @markdown.MarkdownEditor::open(
+    agent_id=validation_agent_id,
+    history~,
+  ) catch {
+    @markdown.MarkdownArchiveError::InvalidAgentId =>
+      raise LoomarkArchiveDecodeError::InvalidValidationAgentId
+    _ =>
+      raise LoomarkArchiveDecodeError::CorruptHistory(
+        detail="history could not be reopened",
+      )
+  }
+  if reopened.portable_markdown() != portable_markdown {
+    raise LoomarkArchiveDecodeError::PortableTextHistoryMismatch
+  }
+}

--- a/apps/loomark/archive/archive_wbtest.mbt
+++ b/apps/loomark/archive/archive_wbtest.mbt
@@ -1,0 +1,259 @@
+///|
+test "archive capture and round-trip tracer" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="archive-capture-red",
+    source="# Title\n\nbody\n",
+  )
+  ignore(
+    editor.commit(
+      @markdown.MarkdownEditRequest::ReplaceText(
+        start=2,
+        delete_len=0,
+        inserted="New ",
+      ),
+    ),
+  )
+  let document_id = try! LoomarkDocumentId::from_string("doc-1")
+  let archive = try! LoomarkDocumentArchive::capture(
+    document_id~,
+    editor~,
+    validation_agent_id="archive-validation-red",
+  )
+  let encoded = archive.to_json_string()
+  assert_true(encoded.contains("\"schema_version\":\"1\""))
+  let decoded = try! LoomarkDocumentArchive::from_json_string(
+    encoded,
+    validation_agent_id="archive-roundtrip-red",
+  )
+  assert_true(decoded.document_id() == archive.document_id())
+  assert_eq(decoded.portable_markdown(), editor.portable_markdown())
+  assert_true(decoded.history() == archive.history())
+}
+
+///|
+test "archive capture rejects invalid validation agent id" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="archive-invalid-validation-source",
+    source="# Title\n",
+  )
+  let document_id = try! LoomarkDocumentId::from_string(
+    "doc-invalid-validation",
+  )
+  let captured : Result[LoomarkDocumentArchive, LoomarkArchiveCaptureError] = Ok(
+    LoomarkDocumentArchive::capture(
+      document_id~,
+      editor~,
+      validation_agent_id="",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(
+    captured is Err(LoomarkArchiveCaptureError::InvalidValidationAgentId),
+  )
+}
+
+///|
+test "archive decode error matrix" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="archive-errors-source",
+    source="# Title\n",
+  )
+  let document_id = try! LoomarkDocumentId::from_string("doc-errors")
+  let archive = try! LoomarkDocumentArchive::capture(
+    document_id~,
+    editor~,
+    validation_agent_id="archive-errors-capture",
+  )
+  let encoded = archive.to_json_string()
+  assert_true(encoded.contains("\"schema_version\":\"1\""))
+
+  let newer : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      "{\"schema_version\":\"2\",\"document_id\":\"x\",\"portable_markdown\":42,\"history\":false,\"extensions\":{}}",
+      validation_agent_id="archive-errors-newer",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match newer {
+    Err(LoomarkArchiveDecodeError::UnsupportedNewerVersion(version~)) =>
+      assert_eq(version, "2")
+    _ => fail("expected version 2 to be unsupported")
+  }
+
+  let too_large : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      "{\"schema_version\":\"2147483648\"}",
+      validation_agent_id="archive-errors-int-overflow",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match too_large {
+    Err(LoomarkArchiveDecodeError::UnsupportedNewerVersion(version~)) =>
+      assert_eq(version, "2147483648")
+    _ => fail("expected 2147483648 to be unsupported")
+  }
+
+  let much_too_large : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      "{\"schema_version\":\"999999999999999999999999999999999999999999999999999\"}",
+      validation_agent_id="archive-errors-huge-version",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match much_too_large {
+    Err(LoomarkArchiveDecodeError::UnsupportedNewerVersion(version~)) =>
+      assert_eq(version, "999999999999999999999999999999999999999999999999999")
+    _ => fail("expected huge version to be unsupported")
+  }
+
+  let malformed_schema_versions = [
+    "{\"schema_version\":1}", "{\"schema_version\":1.0}", "{\"schema_version\":1e0}",
+    "{\"schema_version\":0}", "{\"schema_version\":-1}", "{\"schema_version\":\"\"}",
+    "{\"schema_version\":\"0\"}", "{\"schema_version\":\"00\"}", "{\"schema_version\":\"-1\"}",
+    "{\"schema_version\":\"1.0\"}", "{\"schema_version\":\"1e0\"}", "{\"schema_version\":true}",
+    "{\"schema_version\":false}", "{\"schema_version\":null}", "{\"schema_version\":{}}",
+    "{\"schema_version\":[]}",
+  ]
+  for schema_version_json in malformed_schema_versions {
+    let malformed : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+      LoomarkDocumentArchive::from_json_string(
+        schema_version_json,
+        validation_agent_id="archive-errors-malformed-schema-version",
+      ),
+    ) catch {
+      error => Err(error)
+    }
+    assert_true(
+      malformed is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)),
+    )
+  }
+
+  let malformed : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      "not-json",
+      validation_agent_id="archive-errors-malformed",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(malformed is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)))
+
+  let missing : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      "{\"schema_version\":\"1\"}",
+      validation_agent_id="archive-errors-missing",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(missing is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)))
+
+  let unknown : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded.replace(
+        old="\"extensions\":{}",
+        new="\"extensions\":{},\"unknown\":true",
+      ),
+      validation_agent_id="archive-errors-unknown",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(unknown is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)))
+
+  let corrupt : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded.replace(old="\"history\":\"", new="\"history\":\"not-history"),
+      validation_agent_id="archive-errors-corrupt",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(corrupt is Err(LoomarkArchiveDecodeError::CorruptHistory(_)))
+
+  let mismatch : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded.replace(old="# Title\\n", new="# Other\\n"),
+      validation_agent_id="archive-errors-mismatch",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(
+    mismatch is Err(LoomarkArchiveDecodeError::PortableTextHistoryMismatch),
+  )
+
+  let empty_id : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded.replace(old="doc-errors", new=""),
+      validation_agent_id="archive-errors-empty-id",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(empty_id is Err(LoomarkArchiveDecodeError::EmptyDocumentId))
+
+  let nonempty_extensions : Result[
+    LoomarkDocumentArchive,
+    LoomarkArchiveDecodeError,
+  ] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded.replace(
+        old="\"extensions\":{}",
+        new="\"extensions\":{\"future\":true}",
+      ),
+      validation_agent_id="archive-errors-extensions",
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(
+    nonempty_extensions is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)),
+  )
+}
+
+///|
+test "decoded archive continues through public edit and merge APIs" {
+  let source = "First\n\nSecond\n"
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="archive-continued-source",
+    source~,
+  )
+  let document_id = try! LoomarkDocumentId::from_string("doc-continued")
+  let archive = try! LoomarkDocumentArchive::capture(
+    document_id~,
+    editor~,
+    validation_agent_id="archive-continued-capture",
+  )
+  let decoded = try! LoomarkDocumentArchive::from_json_string(
+    archive.to_json_string(),
+    validation_agent_id="archive-continued-decode",
+  )
+  let history = decoded.history()
+  let reopened = try! @markdown.MarkdownEditor::open(
+    agent_id="archive-continued-editor",
+    history~,
+  )
+  let first = reopened.snapshot().blocks().to_array()[0]
+  assert_true(
+    reopened.commit(
+      @markdown.MarkdownEditRequest::CommitEdit(
+        node_id=first.node_id(),
+        new_text="Changed",
+      ),
+    )
+    is Ok(_),
+  )
+  let second = reopened.snapshot().blocks().to_array()[1]
+  assert_true(
+    reopened.commit(
+      @markdown.MarkdownEditRequest::MergeWithPrevious(node_id=second.node_id()),
+    )
+    is Ok(_),
+  )
+  assert_eq(reopened.portable_markdown(), "ChangedSecond\n")
+}

--- a/apps/loomark/archive/archive_wbtest.mbt
+++ b/apps/loomark/archive/archive_wbtest.mbt
@@ -14,11 +14,7 @@ test "archive capture and round-trip tracer" {
     ),
   )
   let document_id = try! LoomarkDocumentId::from_string("doc-1")
-  let archive = try! LoomarkDocumentArchive::capture(
-    document_id~,
-    editor~,
-    validation_agent_id="archive-validation-red",
-  )
+  let archive = try! LoomarkDocumentArchive::capture(document_id~, editor~)
   let encoded = archive.to_json_string()
   assert_true(encoded.contains("\"schema_version\":\"1\""))
   let decoded = try! LoomarkDocumentArchive::from_json_string(
@@ -31,40 +27,13 @@ test "archive capture and round-trip tracer" {
 }
 
 ///|
-test "archive capture rejects invalid validation agent id" {
-  let editor = try! @markdown.MarkdownEditor(
-    agent_id="archive-invalid-validation-source",
-    source="# Title\n",
-  )
-  let document_id = try! LoomarkDocumentId::from_string(
-    "doc-invalid-validation",
-  )
-  let captured : Result[LoomarkDocumentArchive, LoomarkArchiveCaptureError] = Ok(
-    LoomarkDocumentArchive::capture(
-      document_id~,
-      editor~,
-      validation_agent_id="",
-    ),
-  ) catch {
-    error => Err(error)
-  }
-  assert_true(
-    captured is Err(LoomarkArchiveCaptureError::InvalidValidationAgentId),
-  )
-}
-
-///|
 test "archive decode error matrix" {
   let editor = try! @markdown.MarkdownEditor(
     agent_id="archive-errors-source",
     source="# Title\n",
   )
   let document_id = try! LoomarkDocumentId::from_string("doc-errors")
-  let archive = try! LoomarkDocumentArchive::capture(
-    document_id~,
-    editor~,
-    validation_agent_id="archive-errors-capture",
-  )
+  let archive = try! LoomarkDocumentArchive::capture(document_id~, editor~)
   let encoded = archive.to_json_string()
   assert_true(encoded.contains("\"schema_version\":\"1\""))
 
@@ -113,10 +82,10 @@ test "archive decode error matrix" {
   let malformed_schema_versions = [
     "{\"schema_version\":1}", "{\"schema_version\":1.0}", "{\"schema_version\":1e0}",
     "{\"schema_version\":0}", "{\"schema_version\":-1}", "{\"schema_version\":\"\"}",
-    "{\"schema_version\":\"0\"}", "{\"schema_version\":\"00\"}", "{\"schema_version\":\"-1\"}",
-    "{\"schema_version\":\"1.0\"}", "{\"schema_version\":\"1e0\"}", "{\"schema_version\":true}",
-    "{\"schema_version\":false}", "{\"schema_version\":null}", "{\"schema_version\":{}}",
-    "{\"schema_version\":[]}",
+    "{\"schema_version\":\"0\"}", "{\"schema_version\":\"00\"}", "{\"schema_version\":\"01\"}",
+    "{\"schema_version\":\"0001\"}", "{\"schema_version\":\"-1\"}", "{\"schema_version\":\"1.0\"}",
+    "{\"schema_version\":\"1e0\"}", "{\"schema_version\":true}", "{\"schema_version\":false}",
+    "{\"schema_version\":null}", "{\"schema_version\":{}}", "{\"schema_version\":[]}",
   ]
   for schema_version_json in malformed_schema_versions {
     let malformed : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
@@ -224,11 +193,7 @@ test "decoded archive continues through public edit and merge APIs" {
     source~,
   )
   let document_id = try! LoomarkDocumentId::from_string("doc-continued")
-  let archive = try! LoomarkDocumentArchive::capture(
-    document_id~,
-    editor~,
-    validation_agent_id="archive-continued-capture",
-  )
+  let archive = try! LoomarkDocumentArchive::capture(document_id~, editor~)
   let decoded = try! LoomarkDocumentArchive::from_json_string(
     archive.to_json_string(),
     validation_agent_id="archive-continued-decode",

--- a/apps/loomark/archive/moon.pkg
+++ b/apps/loomark/archive/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "dowdiness/canopy/editor/markdown",
+  "moonbitlang/core/json",
+}
+
+warnings = "-7-29"
+
+options(
+  is_main: false,
+)

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -1,0 +1,53 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "dowdiness/loomark/archive"
+
+import {
+  "dowdiness/canopy/editor/markdown",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub const LOOMARK_ARCHIVE_SCHEMA_VERSION : Int = 1
+
+// Errors
+pub(all) suberror LoomarkArchiveCaptureError {
+  InvalidValidationAgentId
+  HistoryUnavailable(detail~ : String)
+  CorruptHistory(detail~ : String)
+  PortableTextHistoryMismatch
+}
+
+pub(all) suberror LoomarkArchiveDecodeError {
+  UnsupportedNewerVersion(version~ : String)
+  MalformedEnvelope(detail~ : String)
+  EmptyDocumentId
+  CorruptHistory(detail~ : String)
+  PortableTextHistoryMismatch
+  InvalidValidationAgentId
+}
+
+pub(all) suberror LoomarkDocumentIdError {
+  Empty
+}
+
+// Types and methods
+pub struct LoomarkDocumentArchive {
+  // private fields
+}
+pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor, validation_agent_id~ : String) -> Self raise LoomarkArchiveCaptureError
+pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
+pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String) -> Self raise LoomarkArchiveDecodeError
+pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
+pub fn LoomarkDocumentArchive::portable_markdown(Self) -> String
+pub fn LoomarkDocumentArchive::to_json_string(Self) -> String
+
+pub struct LoomarkDocumentId {
+  // private fields
+} derive(Eq, @debug.Debug)
+pub fn LoomarkDocumentId::from_string(String) -> Self raise LoomarkDocumentIdError
+pub fn LoomarkDocumentId::value(Self) -> String
+
+// Type aliases
+
+// Traits
+

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -11,10 +11,7 @@ pub const LOOMARK_ARCHIVE_SCHEMA_VERSION : Int = 1
 
 // Errors
 pub(all) suberror LoomarkArchiveCaptureError {
-  InvalidValidationAgentId
   HistoryUnavailable(detail~ : String)
-  CorruptHistory(detail~ : String)
-  PortableTextHistoryMismatch
 }
 
 pub(all) suberror LoomarkArchiveDecodeError {
@@ -34,7 +31,7 @@ pub(all) suberror LoomarkDocumentIdError {
 pub struct LoomarkDocumentArchive {
   // private fields
 }
-pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor, validation_agent_id~ : String) -> Self raise LoomarkArchiveCaptureError
+pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise LoomarkArchiveCaptureError
 pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
 pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String) -> Self raise LoomarkArchiveDecodeError
 pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -259,6 +259,29 @@ pub struct MarkdownDocumentHistory {
 }
 
 ///|
+/// A malformed opaque history payload at the Markdown façade boundary.
+pub(all) suberror MarkdownHistoryCodecError {
+  Malformed(detail~ : String)
+}
+
+///|
+/// Encode the opaque CRDT history without exposing its wire representation.
+pub fn MarkdownDocumentHistory::to_json_string(self : Self) -> String {
+  self.message.to_json_string()
+}
+
+///|
+/// Decode an opaque CRDT history without exposing its wire representation.
+pub fn MarkdownDocumentHistory::from_json_string(
+  json : String,
+) -> MarkdownDocumentHistory raise MarkdownHistoryCodecError {
+  let message = @text.SyncMessage::from_json_string(json) catch {
+    error => raise MarkdownHistoryCodecError::Malformed(detail=error.message())
+  }
+  { message, }
+}
+
+///|
 /// Equality is canonical-history equality: the honest check that one document
 /// continues another. Comparing source and version instead would accept a
 /// document that merely looks the same.
@@ -495,6 +518,12 @@ pub fn MarkdownEditor::admit(
 /// Read the last committed canonical source without exposing editor state.
 pub fn MarkdownEditor::snapshot(self : Self) -> MarkdownDocumentSnapshot {
   document_snapshot(self.editor)
+}
+
+///|
+/// Return portable Markdown with façade-owned empty-block sentinels removed.
+pub fn MarkdownEditor::portable_markdown(self : Self) -> String {
+  @md_companion.export_markdown_text(self.editor)
 }
 
 ///|

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -1510,3 +1510,37 @@ test "reference definition insertion preserves facade block identities" {
     _ => fail("expected reference definition insertion to apply")
   }
 }
+
+///|
+test "history codec round-trips through the Markdown façade" {
+  let editor = try! MarkdownEditor(
+    agent_id="history-codec-red",
+    source="# Title\n\nbody\n",
+  )
+  ignore(
+    editor.commit(
+      MarkdownEditRequest::ReplaceText(start=2, delete_len=0, inserted="New "),
+    ),
+  )
+  let history = try! editor.history_since()
+  let encoded = history.to_json_string()
+  let decoded = try! MarkdownDocumentHistory::from_json_string(encoded)
+  assert_true(decoded == history)
+}
+
+///|
+test "portable Markdown delegates façade sentinel export" {
+  let editor = try! MarkdownEditor(
+    agent_id="portable-markdown-facade",
+    source="Hello\n",
+  )
+  let first = editor.snapshot().blocks().to_array()[0]
+  assert_true(
+    editor.commit(
+      MarkdownEditRequest::SplitBlock(node_id=first.node_id(), offset=0),
+    )
+    is Ok(_),
+  )
+  assert_false(editor.portable_markdown().contains("\u200B"))
+  assert_eq(editor.portable_markdown(), "\n\nHello\n")
+}

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -25,6 +25,10 @@ pub(all) suberror MarkdownEditorError {
   EditFailed(detail~ : String)
 }
 
+pub(all) suberror MarkdownHistoryCodecError {
+  Malformed(detail~ : String)
+}
+
 // Types and methods
 pub(all) enum MarkdownAdmitReport {
   Complete
@@ -80,6 +84,8 @@ pub(all) enum MarkdownCommitResult {
 pub struct MarkdownDocumentHistory {
   // private fields
 }
+pub fn MarkdownDocumentHistory::from_json_string(String) -> Self raise MarkdownHistoryCodecError
+pub fn MarkdownDocumentHistory::to_json_string(Self) -> String
 pub impl Eq for MarkdownDocumentHistory
 
 pub struct MarkdownDocumentSnapshot {
@@ -114,6 +120,7 @@ pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommi
 pub fn MarkdownEditor::commit_with_receipt(Self, MarkdownEditRequest) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError
 pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -> MarkdownDocumentHistory raise MarkdownArchiveError
 pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory) -> Self raise MarkdownArchiveError
+pub fn MarkdownEditor::portable_markdown(Self) -> String
 pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
 pub fn MarkdownEditor::version(Self) -> MarkdownDocumentVersion
 pub fn MarkdownEditor::with_semantic_attachment(agent_id~ : String, source~ : String) -> (Self, @dowdiness/markdown.MarkdownSemanticAttachment) raise MarkdownEditorError


### PR DESCRIPTION
Closes #1139

## Summary

- add an opaque Markdown history JSON codec without exposing CRDT operations or wire types
- add an application-owned `dowdiness/loomark/archive` package with logical document identity and a strict versioned envelope
- trust the valid in-memory editor during capture, then validate persisted portable Markdown against reopened canonical history at decode while excluding session, storage, provider, and undo state

## UI and review evidence

N/A — no UI or visual changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `SyncMessage::to_json_string` / `from_json_string` | event-graph-walker `text` | Yes | CRDT-owned opaque history codec |
| `export_markdown_text` | Markdown companion | Yes | Existing structural sentinel removal; no duplicate normalization |
| `MarkdownEditor::history_since` / `open` | Markdown façade | Yes | Direct complete-history capture from the valid editor; consistency validation only when decoding persisted input |
| `Json`, `Map` | MoonBit core | Yes | Deterministic semantic-object encoding and strict field-set validation |
| `String`, `Result`, `Option`, `Bytes` | MoonBit core | Considered | Existing immutable values and error propagation were sufficient |

New helpers added:

- `MarkdownHistoryCodecError` and history encode/decode methods — opaque CRDT codec boundary.
- `MarkdownEditor::portable_markdown` — façade delegation to the existing companion export.
- `LoomarkDocumentId` — validated application-owned logical identity.
- `LoomarkDocumentArchive` and typed capture/decode errors — versioned application envelope and consistency boundary.
- Private archive validation helpers — exact schema and decoded source/history checks inside the owning package.

## Validation scope

Boundary matrix / first failing regression:

- opaque history round-trip and portable sentinel removal
- direct capture without a validation identity → deterministic encode → decode → canonical history equality
- capture does not reopen trusted in-memory history; decoded archives reopen and support continued editing and merge
- version is checked before payload; exact string `"1"` is accepted, canonical arbitrary-size newer versions are typed distinctly, and leading-zero forms are malformed
- malformed/missing/wrong/unknown fields, numeric/fraction/exponent/leading-zero versions, corrupt history, empty ID, nonempty extensions, decode validation ID, and source/history mismatch
- canonical writer emits unique fields; decode follows MoonBit core JSON semantic-object duplicate-member policy

Target packages:

- `modules/canopy/editor/markdown`
- `apps/loomark/archive`

Additional conditional gates:

- `moon -C apps/loomark test`: PASS
- no proof, browser, persistence, or TypeScript surface changed

## PR-ready evidence

Validated HEAD: `4ed1eefb27ff64b69ab44d387bcbd14d42a5ead9`

Validated base: `origin/main@0091e3e2f05a8d25985ad2acf1561926769f808f`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor/markdown \
  --target apps/loomark/archive
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] Both generated interfaces were reviewed; changes are additive and have no widened trait bounds.
- [x] No submodule changed.
- [x] Validation was rerun after the final commit.
- [x] Independent MoonBit review findings were resolved before final validation.
