### PR TITLE
feat(loomark): require explicit archive open limits

### DIFF
--- a/apps/loomark/archive/archive.mbt
+++ b/apps/loomark/archive/archive.mbt
@@ -45,6 +45,14 @@ pub(all) suberror LoomarkArchiveDecodeError {
   CorruptHistory(detail~ : String)
   PortableTextHistoryMismatch
   InvalidValidationAgentId
+  WriterUnavailable(detail~ : String)
+  CapacityExceeded(
+    kind~ : @markdown.MarkdownArchiveLimitKind,
+    limit~ : Int,
+    actual~ : Int
+  )
+  AdmissionFailed(detail~ : String)
+  IncompleteHistory
 }
 
 ///|
@@ -104,7 +112,8 @@ pub fn LoomarkDocumentArchive::to_json_string(self : Self) -> String {
 }
 
 ///|
-/// Decode and validate a v1 archive with a caller-owned fresh validation ID.
+/// Decode and validate a v1 archive with a caller-owned fresh validation ID
+/// and explicit archive admission policy.
 ///
 /// Field uniqueness follows core JSON's semantic-object `Map` behavior: a
 /// duplicate member overwrites the earlier value. Canonical Loomark encoding
@@ -113,6 +122,7 @@ pub fn LoomarkDocumentArchive::to_json_string(self : Self) -> String {
 pub fn LoomarkDocumentArchive::from_json_string(
   json : String,
   validation_agent_id~ : String,
+  admission_policy~ : @markdown.MarkdownArchiveAdmissionPolicy,
 ) -> LoomarkDocumentArchive raise LoomarkArchiveDecodeError {
   let value = @json.parse(json) catch {
     _ =>
@@ -167,7 +177,9 @@ pub fn LoomarkDocumentArchive::from_json_string(
   if validation_agent_id.is_empty() {
     raise LoomarkArchiveDecodeError::InvalidValidationAgentId
   }
-  validate_decoded(portable_markdown, history, validation_agent_id)
+  validate_decoded(
+    portable_markdown, history, validation_agent_id, admission_policy,
+  )
   { document_id, portable_markdown, history }
 }
 
@@ -223,17 +235,25 @@ fn validate_decoded(
   portable_markdown : String,
   history : @markdown.MarkdownDocumentHistory,
   validation_agent_id : String,
+  admission_policy : @markdown.MarkdownArchiveAdmissionPolicy,
 ) -> Unit raise LoomarkArchiveDecodeError {
   let reopened = @markdown.MarkdownEditor::open(
     agent_id=validation_agent_id,
     history~,
+    admission_policy~,
   ) catch {
     @markdown.MarkdownArchiveError::InvalidAgentId =>
       raise LoomarkArchiveDecodeError::InvalidValidationAgentId
-    _ =>
-      raise LoomarkArchiveDecodeError::CorruptHistory(
-        detail="history could not be reopened",
-      )
+    @markdown.MarkdownArchiveError::WriterUnavailable(detail~) =>
+      raise LoomarkArchiveDecodeError::WriterUnavailable(detail~)
+    @markdown.MarkdownArchiveError::CapacityExceeded(kind~, limit~, actual~) =>
+      raise LoomarkArchiveDecodeError::CapacityExceeded(kind~, limit~, actual~)
+    @markdown.MarkdownArchiveError::AdmitFailed(detail~) =>
+      raise LoomarkArchiveDecodeError::AdmissionFailed(detail~)
+    @markdown.MarkdownArchiveError::IncompleteArchive =>
+      raise LoomarkArchiveDecodeError::IncompleteHistory
+    @markdown.MarkdownArchiveError::ExportFailed(detail~) =>
+      raise LoomarkArchiveDecodeError::AdmissionFailed(detail~)
   }
   if reopened.portable_markdown() != portable_markdown {
     raise LoomarkArchiveDecodeError::PortableTextHistoryMismatch

--- a/apps/loomark/archive/archive.mbt
+++ b/apps/loomark/archive/archive.mbt
@@ -45,13 +45,14 @@ pub(all) suberror LoomarkArchiveDecodeError {
   CorruptHistory(detail~ : String)
   PortableTextHistoryMismatch
   InvalidValidationAgentId
-  WriterUnavailable(detail~ : String)
-  CapacityExceeded(
-    kind~ : @markdown.MarkdownArchiveLimitKind,
-    limit~ : Int,
+  WriterCreationFailed(detail~ : String)
+  LimitExceeded(
+    dimension~ : @markdown.MarkdownArchiveLimitDimension,
+    maximum~ : Int,
     actual~ : Int
   )
-  AdmissionFailed(detail~ : String)
+  HistoryAdmissionFailed(detail~ : String)
+  HistoryExportFailed(detail~ : String)
   IncompleteHistory
 }
 
@@ -113,7 +114,7 @@ pub fn LoomarkDocumentArchive::to_json_string(self : Self) -> String {
 
 ///|
 /// Decode and validate a v1 archive with a caller-owned fresh validation ID
-/// and explicit archive admission policy.
+/// and explicit archive open limits.
 ///
 /// Field uniqueness follows core JSON's semantic-object `Map` behavior: a
 /// duplicate member overwrites the earlier value. Canonical Loomark encoding
@@ -122,7 +123,7 @@ pub fn LoomarkDocumentArchive::to_json_string(self : Self) -> String {
 pub fn LoomarkDocumentArchive::from_json_string(
   json : String,
   validation_agent_id~ : String,
-  admission_policy~ : @markdown.MarkdownArchiveAdmissionPolicy,
+  open_limits~ : @markdown.MarkdownArchiveOpenLimits,
 ) -> LoomarkDocumentArchive raise LoomarkArchiveDecodeError {
   let value = @json.parse(json) catch {
     _ =>
@@ -177,9 +178,7 @@ pub fn LoomarkDocumentArchive::from_json_string(
   if validation_agent_id.is_empty() {
     raise LoomarkArchiveDecodeError::InvalidValidationAgentId
   }
-  validate_decoded(
-    portable_markdown, history, validation_agent_id, admission_policy,
-  )
+  validate_decoded(portable_markdown, history, validation_agent_id, open_limits)
   { document_id, portable_markdown, history }
 }
 
@@ -235,25 +234,29 @@ fn validate_decoded(
   portable_markdown : String,
   history : @markdown.MarkdownDocumentHistory,
   validation_agent_id : String,
-  admission_policy : @markdown.MarkdownArchiveAdmissionPolicy,
+  open_limits : @markdown.MarkdownArchiveOpenLimits,
 ) -> Unit raise LoomarkArchiveDecodeError {
   let reopened = @markdown.MarkdownEditor::open(
     agent_id=validation_agent_id,
     history~,
-    admission_policy~,
+    open_limits~,
   ) catch {
     @markdown.MarkdownArchiveError::InvalidAgentId =>
       raise LoomarkArchiveDecodeError::InvalidValidationAgentId
-    @markdown.MarkdownArchiveError::WriterUnavailable(detail~) =>
-      raise LoomarkArchiveDecodeError::WriterUnavailable(detail~)
-    @markdown.MarkdownArchiveError::CapacityExceeded(kind~, limit~, actual~) =>
-      raise LoomarkArchiveDecodeError::CapacityExceeded(kind~, limit~, actual~)
-    @markdown.MarkdownArchiveError::AdmitFailed(detail~) =>
-      raise LoomarkArchiveDecodeError::AdmissionFailed(detail~)
-    @markdown.MarkdownArchiveError::IncompleteArchive =>
+    @markdown.MarkdownArchiveError::WriterCreationFailed(detail~) =>
+      raise LoomarkArchiveDecodeError::WriterCreationFailed(detail~)
+    @markdown.MarkdownArchiveError::LimitExceeded(dimension~, maximum~, actual~) =>
+      raise LoomarkArchiveDecodeError::LimitExceeded(
+        dimension~,
+        maximum~,
+        actual~,
+      )
+    @markdown.MarkdownArchiveError::HistoryAdmissionFailed(detail~) =>
+      raise LoomarkArchiveDecodeError::HistoryAdmissionFailed(detail~)
+    @markdown.MarkdownArchiveError::IncompleteHistory =>
       raise LoomarkArchiveDecodeError::IncompleteHistory
     @markdown.MarkdownArchiveError::ExportFailed(detail~) =>
-      raise LoomarkArchiveDecodeError::AdmissionFailed(detail~)
+      raise LoomarkArchiveDecodeError::HistoryExportFailed(detail~)
   }
   if reopened.portable_markdown() != portable_markdown {
     raise LoomarkArchiveDecodeError::PortableTextHistoryMismatch

--- a/apps/loomark/archive/archive_wbtest.mbt
+++ b/apps/loomark/archive/archive_wbtest.mbt
@@ -1,11 +1,11 @@
 ///|
-fn archive_decode_test_policy(
+fn archive_decode_open_limits(
   max_encoded_bytes? : Int = 1024 * 1024,
   max_decoded_operations? : Int = 10000,
   max_pending_operations? : Int = 1000,
   max_parents_per_operation? : Int = 256,
-) -> @markdown.MarkdownArchiveAdmissionPolicy {
-  try! @markdown.MarkdownArchiveAdmissionPolicy(
+) -> @markdown.MarkdownArchiveOpenLimits {
+  try! @markdown.MarkdownArchiveOpenLimits(
     max_encoded_bytes~,
     max_decoded_operations~,
     max_pending_operations~,
@@ -35,7 +35,7 @@ test "archive capture and round-trip tracer" {
   let decoded = try! LoomarkDocumentArchive::from_json_string(
     encoded,
     validation_agent_id="archive-roundtrip-red",
-    admission_policy=archive_decode_test_policy(),
+    open_limits=archive_decode_open_limits(),
   )
   assert_true(decoded.document_id() == archive.document_id())
   assert_eq(decoded.portable_markdown(), editor.portable_markdown())
@@ -57,27 +57,27 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded,
       validation_agent_id="archive-errors-capacity",
-      admission_policy=archive_decode_test_policy(max_encoded_bytes=0),
+      open_limits=archive_decode_open_limits(max_encoded_bytes=0),
     ),
   ) catch {
     error => Err(error)
   }
   match capacity {
     Err(
-      LoomarkArchiveDecodeError::CapacityExceeded(
-        kind=@markdown.MarkdownArchiveLimitKind::EncodedBytes,
-        limit=0,
+      LoomarkArchiveDecodeError::LimitExceeded(
+        dimension=@markdown.MarkdownArchiveLimitDimension::EncodedBytes,
+        maximum=0,
         actual~
       )
     ) => assert_true(actual > 0)
-    _ => fail("expected archive capacity failure")
+    _ => fail("expected archive limit failure")
   }
 
   let newer : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"2\",\"document_id\":\"x\",\"portable_markdown\":42,\"history\":false,\"extensions\":{}}",
       validation_agent_id="archive-errors-newer",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -92,7 +92,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"2147483648\"}",
       validation_agent_id="archive-errors-int-overflow",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -107,7 +107,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"999999999999999999999999999999999999999999999999999\"}",
       validation_agent_id="archive-errors-huge-version",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -131,7 +131,7 @@ test "archive decode error matrix" {
       LoomarkDocumentArchive::from_json_string(
         schema_version_json,
         validation_agent_id="archive-errors-malformed-schema-version",
-        admission_policy=archive_decode_test_policy(),
+        open_limits=archive_decode_open_limits(),
       ),
     ) catch {
       error => Err(error)
@@ -145,7 +145,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "not-json",
       validation_agent_id="archive-errors-malformed",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -156,7 +156,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"1\"}",
       validation_agent_id="archive-errors-missing",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -170,7 +170,7 @@ test "archive decode error matrix" {
         new="\"extensions\":{},\"unknown\":true",
       ),
       validation_agent_id="archive-errors-unknown",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -181,7 +181,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="\"history\":\"", new="\"history\":\"not-history"),
       validation_agent_id="archive-errors-corrupt",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -192,7 +192,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="# Title\\n", new="# Other\\n"),
       validation_agent_id="archive-errors-mismatch",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -205,7 +205,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="doc-errors", new=""),
       validation_agent_id="archive-errors-empty-id",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -222,7 +222,7 @@ test "archive decode error matrix" {
         new="\"extensions\":{\"future\":true}",
       ),
       validation_agent_id="archive-errors-extensions",
-      admission_policy=archive_decode_test_policy(),
+      open_limits=archive_decode_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -233,7 +233,7 @@ test "archive decode error matrix" {
 }
 
 ///|
-test "archive decode distinguishes incomplete history from capacity" {
+test "archive decode distinguishes incomplete history from limit-exceeded" {
   let source = try! @markdown.MarkdownEditor(
     agent_id="archive-gap-source",
     source="x",
@@ -262,7 +262,7 @@ test "archive decode distinguishes incomplete history from capacity" {
     LoomarkDocumentArchive::from_json_string(
       encoded,
       validation_agent_id="archive-gap-incomplete",
-      admission_policy=archive_decode_test_policy(max_pending_operations=1),
+      open_limits=archive_decode_open_limits(max_pending_operations=1),
     ),
   ) catch {
     error => Err(error)
@@ -273,7 +273,7 @@ test "archive decode distinguishes incomplete history from capacity" {
     LoomarkDocumentArchive::from_json_string(
       encoded,
       validation_agent_id="archive-gap-capacity",
-      admission_policy=archive_decode_test_policy(max_pending_operations=0),
+      open_limits=archive_decode_open_limits(max_pending_operations=0),
     ),
   ) catch {
     error => Err(error)
@@ -281,9 +281,9 @@ test "archive decode distinguishes incomplete history from capacity" {
   assert_true(
     capacity
     is Err(
-      LoomarkArchiveDecodeError::CapacityExceeded(
-        kind=@markdown.MarkdownArchiveLimitKind::PendingOperations,
-        limit=0,
+      LoomarkArchiveDecodeError::LimitExceeded(
+        dimension=@markdown.MarkdownArchiveLimitDimension::PendingOperations,
+        maximum=0,
         actual=1
       )
     ),
@@ -302,13 +302,13 @@ test "decoded archive continues through public edit and merge APIs" {
   let decoded = try! LoomarkDocumentArchive::from_json_string(
     archive.to_json_string(),
     validation_agent_id="archive-continued-decode",
-    admission_policy=archive_decode_test_policy(),
+    open_limits=archive_decode_open_limits(),
   )
   let history = decoded.history()
   let reopened = try! @markdown.MarkdownEditor::open(
     agent_id="archive-continued-editor",
     history~,
-    admission_policy=archive_decode_test_policy(),
+    open_limits=archive_decode_open_limits(),
   )
   let first = reopened.snapshot().blocks().to_array()[0]
   assert_true(

--- a/apps/loomark/archive/archive_wbtest.mbt
+++ b/apps/loomark/archive/archive_wbtest.mbt
@@ -1,4 +1,19 @@
 ///|
+fn archive_decode_test_policy(
+  max_encoded_bytes? : Int = 1024 * 1024,
+  max_decoded_operations? : Int = 10000,
+  max_pending_operations? : Int = 1000,
+  max_parents_per_operation? : Int = 256,
+) -> @markdown.MarkdownArchiveAdmissionPolicy {
+  try! @markdown.MarkdownArchiveAdmissionPolicy(
+    max_encoded_bytes~,
+    max_decoded_operations~,
+    max_pending_operations~,
+    max_parents_per_operation~,
+  )
+}
+
+///|
 test "archive capture and round-trip tracer" {
   let editor = try! @markdown.MarkdownEditor(
     agent_id="archive-capture-red",
@@ -20,6 +35,7 @@ test "archive capture and round-trip tracer" {
   let decoded = try! LoomarkDocumentArchive::from_json_string(
     encoded,
     validation_agent_id="archive-roundtrip-red",
+    admission_policy=archive_decode_test_policy(),
   )
   assert_true(decoded.document_id() == archive.document_id())
   assert_eq(decoded.portable_markdown(), editor.portable_markdown())
@@ -37,10 +53,31 @@ test "archive decode error matrix" {
   let encoded = archive.to_json_string()
   assert_true(encoded.contains("\"schema_version\":\"1\""))
 
+  let capacity : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded,
+      validation_agent_id="archive-errors-capacity",
+      admission_policy=archive_decode_test_policy(max_encoded_bytes=0),
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match capacity {
+    Err(
+      LoomarkArchiveDecodeError::CapacityExceeded(
+        kind=@markdown.MarkdownArchiveLimitKind::EncodedBytes,
+        limit=0,
+        actual~
+      )
+    ) => assert_true(actual > 0)
+    _ => fail("expected archive capacity failure")
+  }
+
   let newer : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"2\",\"document_id\":\"x\",\"portable_markdown\":42,\"history\":false,\"extensions\":{}}",
       validation_agent_id="archive-errors-newer",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -55,6 +92,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"2147483648\"}",
       validation_agent_id="archive-errors-int-overflow",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -69,6 +107,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"999999999999999999999999999999999999999999999999999\"}",
       validation_agent_id="archive-errors-huge-version",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -92,6 +131,7 @@ test "archive decode error matrix" {
       LoomarkDocumentArchive::from_json_string(
         schema_version_json,
         validation_agent_id="archive-errors-malformed-schema-version",
+        admission_policy=archive_decode_test_policy(),
       ),
     ) catch {
       error => Err(error)
@@ -105,6 +145,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "not-json",
       validation_agent_id="archive-errors-malformed",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -115,6 +156,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       "{\"schema_version\":\"1\"}",
       validation_agent_id="archive-errors-missing",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -128,6 +170,7 @@ test "archive decode error matrix" {
         new="\"extensions\":{},\"unknown\":true",
       ),
       validation_agent_id="archive-errors-unknown",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -138,6 +181,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="\"history\":\"", new="\"history\":\"not-history"),
       validation_agent_id="archive-errors-corrupt",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -148,6 +192,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="# Title\\n", new="# Other\\n"),
       validation_agent_id="archive-errors-mismatch",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -160,6 +205,7 @@ test "archive decode error matrix" {
     LoomarkDocumentArchive::from_json_string(
       encoded.replace(old="doc-errors", new=""),
       validation_agent_id="archive-errors-empty-id",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
@@ -176,12 +222,71 @@ test "archive decode error matrix" {
         new="\"extensions\":{\"future\":true}",
       ),
       validation_agent_id="archive-errors-extensions",
+      admission_policy=archive_decode_test_policy(),
     ),
   ) catch {
     error => Err(error)
   }
   assert_true(
     nonempty_extensions is Err(LoomarkArchiveDecodeError::MalformedEnvelope(_)),
+  )
+}
+
+///|
+test "archive decode distinguishes incomplete history from capacity" {
+  let source = try! @markdown.MarkdownEditor(
+    agent_id="archive-gap-source",
+    source="x",
+  )
+  let cut = source.version()
+  assert_true(
+    source.commit(
+      @markdown.MarkdownEditRequest::ReplaceText(
+        start=1,
+        delete_len=0,
+        inserted="y",
+      ),
+    )
+    is Ok(_),
+  )
+  let gapped = try! source.history_since(version=cut)
+  let encoded = Json::object({
+    "schema_version": Json::string(LOOMARK_ARCHIVE_SCHEMA_VERSION.to_string()),
+    "document_id": Json::string("doc-gap"),
+    "portable_markdown": Json::string("xy"),
+    "history": Json::string(gapped.to_json_string()),
+    "extensions": Json::empty_object(),
+  }).stringify()
+
+  let incomplete : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded,
+      validation_agent_id="archive-gap-incomplete",
+      admission_policy=archive_decode_test_policy(max_pending_operations=1),
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(incomplete is Err(LoomarkArchiveDecodeError::IncompleteHistory))
+
+  let capacity : Result[LoomarkDocumentArchive, LoomarkArchiveDecodeError] = Ok(
+    LoomarkDocumentArchive::from_json_string(
+      encoded,
+      validation_agent_id="archive-gap-capacity",
+      admission_policy=archive_decode_test_policy(max_pending_operations=0),
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(
+    capacity
+    is Err(
+      LoomarkArchiveDecodeError::CapacityExceeded(
+        kind=@markdown.MarkdownArchiveLimitKind::PendingOperations,
+        limit=0,
+        actual=1
+      )
+    ),
   )
 }
 
@@ -197,11 +302,13 @@ test "decoded archive continues through public edit and merge APIs" {
   let decoded = try! LoomarkDocumentArchive::from_json_string(
     archive.to_json_string(),
     validation_agent_id="archive-continued-decode",
+    admission_policy=archive_decode_test_policy(),
   )
   let history = decoded.history()
   let reopened = try! @markdown.MarkdownEditor::open(
     agent_id="archive-continued-editor",
     history~,
+    admission_policy=archive_decode_test_policy(),
   )
   let first = reopened.snapshot().blocks().to_array()[0]
   assert_true(

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -21,9 +21,10 @@ pub(all) suberror LoomarkArchiveDecodeError {
   CorruptHistory(detail~ : String)
   PortableTextHistoryMismatch
   InvalidValidationAgentId
-  WriterUnavailable(detail~ : String)
-  CapacityExceeded(kind~ : @markdown.MarkdownArchiveLimitKind, limit~ : Int, actual~ : Int)
-  AdmissionFailed(detail~ : String)
+  WriterCreationFailed(detail~ : String)
+  LimitExceeded(dimension~ : @markdown.MarkdownArchiveLimitDimension, maximum~ : Int, actual~ : Int)
+  HistoryAdmissionFailed(detail~ : String)
+  HistoryExportFailed(detail~ : String)
   IncompleteHistory
 }
 
@@ -37,7 +38,7 @@ pub struct LoomarkDocumentArchive {
 }
 pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise LoomarkArchiveCaptureError
 pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
-pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, admission_policy~ : @markdown.MarkdownArchiveAdmissionPolicy) -> Self raise LoomarkArchiveDecodeError
+pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, open_limits~ : @markdown.MarkdownArchiveOpenLimits) -> Self raise LoomarkArchiveDecodeError
 pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
 pub fn LoomarkDocumentArchive::portable_markdown(Self) -> String
 pub fn LoomarkDocumentArchive::to_json_string(Self) -> String

--- a/apps/loomark/archive/pkg.generated.mbti
+++ b/apps/loomark/archive/pkg.generated.mbti
@@ -21,6 +21,10 @@ pub(all) suberror LoomarkArchiveDecodeError {
   CorruptHistory(detail~ : String)
   PortableTextHistoryMismatch
   InvalidValidationAgentId
+  WriterUnavailable(detail~ : String)
+  CapacityExceeded(kind~ : @markdown.MarkdownArchiveLimitKind, limit~ : Int, actual~ : Int)
+  AdmissionFailed(detail~ : String)
+  IncompleteHistory
 }
 
 pub(all) suberror LoomarkDocumentIdError {
@@ -33,7 +37,7 @@ pub struct LoomarkDocumentArchive {
 }
 pub fn LoomarkDocumentArchive::capture(document_id~ : LoomarkDocumentId, editor~ : @markdown.MarkdownEditor) -> Self raise LoomarkArchiveCaptureError
 pub fn LoomarkDocumentArchive::document_id(Self) -> LoomarkDocumentId
-pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String) -> Self raise LoomarkArchiveDecodeError
+pub fn LoomarkDocumentArchive::from_json_string(String, validation_agent_id~ : String, admission_policy~ : @markdown.MarkdownArchiveAdmissionPolicy) -> Self raise LoomarkArchiveDecodeError
 pub fn LoomarkDocumentArchive::history(Self) -> @markdown.MarkdownDocumentHistory
 pub fn LoomarkDocumentArchive::portable_markdown(Self) -> String
 pub fn LoomarkDocumentArchive::to_json_string(Self) -> String

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -127,6 +127,9 @@ ProseMirror tree positions to this API.
 | API | Location | Notes |
 |-----|----------|-------|
 | `SyncEditor[T]` | `editor/` | Collaborative editor wrapping a CRDT document. |
+| `SyncEditor::admit` | `editor/` | Peer admission using document-configured limits; causal gaps are retained and reported. |
+| `SyncEditor::admit_with_limits` | `editor/` | Call-local admission limits for owning façades; preserves the same reconciliation shell. |
+| `MarkdownArchiveAdmissionPolicy` / `MarkdownEditor::open` | `editor/markdown/` | Archive restore requires all four resource limits explicitly and refuses causal gaps. |
 | `encode_message` / `decode_message` | `editor/` | Binary sync protocol serialization. |
 | `encode_sync_request` / `encode_sync_response` | `editor/` | Handshake messages. |
 | `SyncStatus` / `SyncErrorReason` | `editor/` | Status enums for sync health. |
@@ -135,7 +138,7 @@ ProseMirror tree positions to this API.
 | `RelayRoom::on_connect` / `on_message` / `on_disconnect` | `relay/` | Lifecycle hooks. |
 | `encode_peer_joined` / `encode_peer_left` | `relay/` | Presence messages. |
 
-**Do not:** Implement custom binary framing; use `encode_message`/`decode_message`.
+**Do not:** Implement custom binary framing; use `encode_message`/`decode_message`. Do not restore an archive through peer `admit`; use the explicit archive policy and `MarkdownEditor::open`.
 
 ---
 

--- a/docs/api-map.md
+++ b/docs/api-map.md
@@ -129,7 +129,7 @@ ProseMirror tree positions to this API.
 | `SyncEditor[T]` | `editor/` | Collaborative editor wrapping a CRDT document. |
 | `SyncEditor::admit` | `editor/` | Peer admission using document-configured limits; causal gaps are retained and reported. |
 | `SyncEditor::admit_with_limits` | `editor/` | Call-local admission limits for owning façades; preserves the same reconciliation shell. |
-| `MarkdownArchiveAdmissionPolicy` / `MarkdownEditor::open` | `editor/markdown/` | Archive restore requires all four resource limits explicitly and refuses causal gaps. |
+| `MarkdownArchiveOpenLimits` / `MarkdownEditor::open` | `editor/markdown/` | Archive restore requires all four resource limits explicitly and refuses causal gaps. |
 | `encode_message` / `decode_message` | `editor/` | Binary sync protocol serialization. |
 | `encode_sync_request` / `encode_sync_response` | `editor/` | Handshake messages. |
 | `SyncStatus` / `SyncErrorReason` | `editor/` | Status enums for sync health. |
@@ -138,7 +138,7 @@ ProseMirror tree positions to this API.
 | `RelayRoom::on_connect` / `on_message` / `on_disconnect` | `relay/` | Lifecycle hooks. |
 | `encode_peer_joined` / `encode_peer_left` | `relay/` | Presence messages. |
 
-**Do not:** Implement custom binary framing; use `encode_message`/`decode_message`. Do not restore an archive through peer `admit`; use the explicit archive policy and `MarkdownEditor::open`.
+**Do not:** Implement custom binary framing; use `encode_message`/`decode_message`. Do not restore an archive through peer `admit`; use the explicit archive open limits and `MarkdownEditor::open`.
 
 ---
 

--- a/docs/design/local-first-document-ownership.md
+++ b/docs/design/local-first-document-ownership.md
@@ -237,12 +237,11 @@ tests need fixing.
 
 The remaining requirements cannot be pinned yet, because the types they
 constrain do not exist. Each should stop living here as it becomes expressible:
-document identity when the archive envelope is defined, writer identity when
-construction generates it rather than accepting it, the durability trigger when
-the archive writer takes a version rather than text, and the restore ceiling
-when it becomes a parameter with no default. **This document holding a
-constraint is a stage, not an achievement** — prose is the weakest place to
-keep a rule, and the section above should shrink as the rules move into code.
+writer identity when construction generates it rather than accepting it, and
+the durability trigger when the archive writer takes a version rather than
+text. **This document holding a constraint is a stage, not an achievement** —
+prose is the weakest place to keep a rule, and the section above should shrink
+as the rules move into code.
 
 Observations behind the claims — which were read, which were executed, which
 remain unverified — are recorded separately, dated and pinned to the commits

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -10,7 +10,7 @@
   },
   "executedProbes": {
     "command": "NEW_MOON_MOD=0 moon test -p dowdiness/canopy/editor/markdown",
-    "result": "Total tests: 17, passed: 17, failed: 0",
+    "result": "Historical result at the 2026-08-03 observed commit: Total tests: 17, passed: 17, failed: 0",
     "instrumentControl": {
       "why": "The new assertions are the whole point of the slice; a green suite proves nothing unless they ran.",
       "observed": "Falsified once per added assertion, each time restoring the suite to green afterwards. The canonical-history oracle: 13 of 14 passing, naming its line. Convergence and the withheld report: 14 of 16 passing, the second reporting 'Withheld != Complete'. Idempotence, falsified one assertion at a time because the first failure ends the test: 16 of 17 passing for the version claim, then again for the history claim. The probe's direct pending count: 41 of 42.",
@@ -140,14 +140,14 @@
       "id": "restore-inherits-receiver-policy",
       "raisedBy": "implementing the façade's admission path",
       "question": "What policy does admission state, given that the only available path applies the receiver's sync limits?",
-      "observation": "Admission goes through SyncEditor::apply_sync -> SyncSession::apply, which calls prepare_sync with the document's sync_limits and raises LimitExceeded on encoded bytes and decoded operation count. Those limits are fixed per TextState at construction (TextState::new_with_sync_limits) and cannot be varied per call, so opening an archive and admitting remote traffic cannot state different policies. The completeness half of the policy is now stated at the call -- opening refuses withheld operations, admission reports them -- but the resource half is not.",
+      "observation": "Admission now has two explicit paths over the same EGW semantics. Peer admission keeps the document-configured limits, while archive opening requires a caller-owned policy and routes through SyncSession::apply_with_limits. Opening still refuses withheld operations after admission, while peer admission reports them as ordinary causal state.",
       "sites": [
-        "event-graph-walker/text/sync.mbt:1213-1224 (SyncSession::apply passes self.doc.sync_limits)",
-        "event-graph-walker/text/sync.mbt:1099-1116 (prepare_sync limit checks)",
-        "editor/sync_editor.mbt:457-465 (apply_sync delegates to sync().apply)"
+        "event-graph-walker/text/sync.mbt:1213-1244 (per-call and document-configured admission paths)",
+        "editor/sync_editor.mbt:466-531 (shared admission shell and explicit-limit entry point)",
+        "editor/markdown/editor.mbt:125-174,553-589 (required archive policy and typed opening failures)"
       ],
-      "bearingOn": "The design's 'Scale limits are a choice restore must make deliberately' states that restore must not inherit a policy written for a different threat, and its Verification section expects the restore ceiling to become a parameter with no default. Neither is expressible without a change under event-graph-walker, and no measurement exists to choose a ceiling from. Recorded rather than resolved: no default was chosen in this slice.",
-      "status": "open"
+      "bearingOn": "The restore ceiling is now a required parameter with no default, so archive restore cannot silently inherit a policy chosen for untrusted peer traffic. No product ceiling is selected here; callers remain responsible for choosing and surfacing one.",
+      "status": "resolved 2026-08-06 by the explicit per-open archive admission policy"
     },
     {
       "id": "archive-failure-taxonomy-placement",

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -140,7 +140,7 @@
       "id": "restore-inherits-receiver-policy",
       "raisedBy": "implementing the façade's admission path",
       "question": "What policy does admission state, given that the only available path applies the receiver's sync limits?",
-      "observation": "Admission now has two explicit paths over the same EGW semantics. Peer admission keeps the document-configured limits, while archive opening requires a caller-owned policy and routes through SyncSession::apply_with_limits. Opening still refuses withheld operations after admission, while peer admission reports them as ordinary causal state.",
+      "observation": "Admission now has two explicit paths over the same EGW semantics. Peer admission keeps the document-configured limits, while archive opening requires a caller-owned policy and routes through the document sync call self.doc.sync().apply_with_limits. Opening still refuses withheld operations after admission, while peer admission reports them as ordinary causal state.",
       "sites": [
         "event-graph-walker/text/sync.mbt:1213-1244 (per-call and document-configured admission paths)",
         "editor/sync_editor.mbt:466-531 (shared admission shell and explicit-limit entry point)",

--- a/docs/evidence/2026-08-03-markdown-facade-history-transport.json
+++ b/docs/evidence/2026-08-03-markdown-facade-history-transport.json
@@ -56,7 +56,7 @@
         "question": "Can one surface treat missing prerequisites as an ordinary state for a peer exchange and as a defect for an archive?",
         "procedure": "Cut a history at a version, hand the increment to a document that never saw the operations before that cut, and observe both admitting it directly and opening a document from it.",
         "result": "confirmed",
-        "observed": "Admission returned Withheld with exact counts -- nothing applied, one operation held -- without raising. Opening the same increment raised IncompleteArchive.",
+        "observed": "Admission returned Withheld with exact counts -- nothing applied, one operation held -- without raising. Opening the same increment raised IncompleteHistory.",
         "bearingOn": "The distinction the design asks for is a judgment about one report rather than two mechanisms. The counts are asserted exactly rather than as a mere distinction, which is what shows the report is carried through rather than reconstructed from the presence of an error (F6)."
       },
       {
@@ -140,14 +140,14 @@
       "id": "restore-inherits-receiver-policy",
       "raisedBy": "implementing the façade's admission path",
       "question": "What policy does admission state, given that the only available path applies the receiver's sync limits?",
-      "observation": "Admission now has two explicit paths over the same EGW semantics. Peer admission keeps the document-configured limits, while archive opening requires a caller-owned policy and routes through the document sync call self.doc.sync().apply_with_limits. Opening still refuses withheld operations after admission, while peer admission reports them as ordinary causal state.",
+      "observation": "Admission now has two explicit paths over the same EGW semantics. Peer admission keeps the document-configured limits, while archive opening requires caller-owned open limits and routes through the document sync call self.doc.sync().apply_with_limits. Opening still refuses withheld operations after admission, while peer admission reports them as ordinary causal state.",
       "sites": [
         "event-graph-walker/text/sync.mbt:1213-1244 (per-call and document-configured admission paths)",
         "editor/sync_editor.mbt:466-531 (shared admission shell and explicit-limit entry point)",
-        "editor/markdown/editor.mbt:125-174,553-589 (required archive policy and typed opening failures)"
+        "editor/markdown/editor.mbt:125-174,553-589 (required archive open limits and typed opening failures)"
       ],
-      "bearingOn": "The restore ceiling is now a required parameter with no default, so archive restore cannot silently inherit a policy chosen for untrusted peer traffic. No product ceiling is selected here; callers remain responsible for choosing and surfacing one.",
-      "status": "resolved 2026-08-06 by the explicit per-open archive admission policy"
+      "bearingOn": "The restore ceiling is now a required parameter with no default, so archive restore cannot silently inherit limits chosen for untrusted peer traffic. No product ceiling is selected here; callers remain responsible for choosing and surfacing one.",
+      "status": "resolved 2026-08-06 by explicit archive-open limits"
     },
     {
       "id": "archive-failure-taxonomy-placement",

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -104,7 +104,7 @@ pub fn MarkdownBlockSnapshot::fence_close_range(self : Self) -> (Int, Int)? {
 
 ///|
 /// A resource dimension enforced while opening a Markdown archive.
-pub(all) enum MarkdownArchiveLimitKind {
+pub(all) enum MarkdownArchiveLimitDimension {
   EncodedBytes
   DecodedOperations
   PendingOperations
@@ -112,50 +112,50 @@ pub(all) enum MarkdownArchiveLimitKind {
 } derive(Eq, Debug)
 
 ///|
-/// Invalid caller-selected archive admission policy.
-pub(all) suberror MarkdownArchiveAdmissionPolicyError {
-  InvalidLimit(kind~ : MarkdownArchiveLimitKind, actual~ : Int)
+/// Invalid caller-selected archive open limits.
+pub(all) suberror MarkdownArchiveOpenLimitsError {
+  InvalidLimit(dimension~ : MarkdownArchiveLimitDimension, value~ : Int)
 }
 
 ///|
-/// Explicit resource policy for opening a Markdown archive.
+/// Explicit resource limits for opening a Markdown archive.
 ///
 /// All dimensions are required so archive restore cannot silently inherit the
 /// limits chosen for untrusted peer traffic.
-pub struct MarkdownArchiveAdmissionPolicy {
+pub struct MarkdownArchiveOpenLimits {
   priv limits : @sync.Limits
 }
 
 ///|
-/// Construct an archive policy from the four EGW-enforced dimensions.
-pub fn MarkdownArchiveAdmissionPolicy::MarkdownArchiveAdmissionPolicy(
+/// Construct archive open limits from the four EGW-enforced dimensions.
+pub fn MarkdownArchiveOpenLimits::MarkdownArchiveOpenLimits(
   max_encoded_bytes~ : Int,
   max_decoded_operations~ : Int,
   max_pending_operations~ : Int,
   max_parents_per_operation~ : Int,
-) -> MarkdownArchiveAdmissionPolicy raise MarkdownArchiveAdmissionPolicyError {
+) -> MarkdownArchiveOpenLimits raise MarkdownArchiveOpenLimitsError {
   if max_encoded_bytes < 0 {
-    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
-      kind=MarkdownArchiveLimitKind::EncodedBytes,
-      actual=max_encoded_bytes,
+    raise MarkdownArchiveOpenLimitsError::InvalidLimit(
+      dimension=MarkdownArchiveLimitDimension::EncodedBytes,
+      value=max_encoded_bytes,
     )
   }
   if max_decoded_operations < 0 {
-    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
-      kind=MarkdownArchiveLimitKind::DecodedOperations,
-      actual=max_decoded_operations,
+    raise MarkdownArchiveOpenLimitsError::InvalidLimit(
+      dimension=MarkdownArchiveLimitDimension::DecodedOperations,
+      value=max_decoded_operations,
     )
   }
   if max_pending_operations < 0 {
-    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
-      kind=MarkdownArchiveLimitKind::PendingOperations,
-      actual=max_pending_operations,
+    raise MarkdownArchiveOpenLimitsError::InvalidLimit(
+      dimension=MarkdownArchiveLimitDimension::PendingOperations,
+      value=max_pending_operations,
     )
   }
   if max_parents_per_operation < 0 {
-    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
-      kind=MarkdownArchiveLimitKind::ParentsPerOperation,
-      actual=max_parents_per_operation,
+    raise MarkdownArchiveOpenLimitsError::InvalidLimit(
+      dimension=MarkdownArchiveLimitDimension::ParentsPerOperation,
+      value=max_parents_per_operation,
     )
   }
   let limits = try! @sync.Limits::Limits(
@@ -168,10 +168,10 @@ pub fn MarkdownArchiveAdmissionPolicy::MarkdownArchiveAdmissionPolicy(
 }
 
 ///|
-fn MarkdownArchiveLimitKind::from_sync(
-  kind : @sync.LimitKind,
-) -> MarkdownArchiveLimitKind {
-  match kind {
+fn MarkdownArchiveLimitDimension::from_sync(
+  dimension : @sync.LimitKind,
+) -> MarkdownArchiveLimitDimension {
+  match dimension {
     EncodedBytes => EncodedBytes
     DecodedOperations => DecodedOperations
     PendingOperations => PendingOperations
@@ -189,17 +189,17 @@ fn MarkdownArchiveLimitKind::from_sync(
 pub(all) suberror MarkdownArchiveError {
   InvalidAgentId
   /// No writing instance could be created, so nothing was attempted. Distinct
-  /// from `AdmitFailed`, which means a history was taken in and the taking
-  /// failed.
-  WriterUnavailable(detail~ : String)
+  /// from `HistoryAdmissionFailed`, which means a history was taken in and the
+  /// taking failed.
+  WriterCreationFailed(detail~ : String)
   ExportFailed(detail~ : String)
-  CapacityExceeded(
-    kind~ : MarkdownArchiveLimitKind,
-    limit~ : Int,
+  LimitExceeded(
+    dimension~ : MarkdownArchiveLimitDimension,
+    maximum~ : Int,
     actual~ : Int
   )
-  AdmitFailed(detail~ : String)
-  IncompleteArchive
+  HistoryAdmissionFailed(detail~ : String)
+  IncompleteHistory
 }
 
 ///|
@@ -547,38 +547,39 @@ fn initialize_markdown_editor(
 /// reopened document is a new writing instance, and reusing the exporter's
 /// identity would make the two indistinguishable in what they go on to write.
 ///
-/// `admission_policy` is explicit because restore and peer traffic are
+/// `open_limits` is explicit because restore and peer traffic are
 /// different consumers of the same admission semantics. Opening never borrows
 /// the receiver defaults used by peer admission.
 pub fn MarkdownEditor::open(
   agent_id~ : String,
   history~ : MarkdownDocumentHistory,
-  admission_policy~ : MarkdownArchiveAdmissionPolicy,
+  open_limits~ : MarkdownArchiveOpenLimits,
 ) -> MarkdownEditor raise MarkdownArchiveError {
   let editor = @md_companion.new_markdown_editor(agent_id) catch {
     @text.TextError::EmptyReplicaId =>
       raise MarkdownArchiveError::InvalidAgentId
     error =>
-      raise MarkdownArchiveError::WriterUnavailable(detail=error.message())
+      raise MarkdownArchiveError::WriterCreationFailed(detail=error.message())
   }
   let document = { editor, }
   let report = document.editor.admit_with_limits(
     history.message,
-    admission_policy.limits,
+    open_limits.limits,
   ) catch {
     @text.TextError::SyncFailed(
       @sync.Failure::LimitExceeded(kind~, limit~, actual~)
     ) =>
-      raise MarkdownArchiveError::CapacityExceeded(
-        kind=MarkdownArchiveLimitKind::from_sync(kind),
-        limit~,
+      raise MarkdownArchiveError::LimitExceeded(
+        dimension=MarkdownArchiveLimitDimension::from_sync(kind),
+        maximum=limit,
         actual~,
       )
-    error => raise MarkdownArchiveError::AdmitFailed(detail=error.message())
+    error =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(detail=error.message())
   }
   document.editor.refresh()
   if report.pending_operations() > 0 {
-    raise MarkdownArchiveError::IncompleteArchive
+    raise MarkdownArchiveError::IncompleteHistory
   }
   document
 }
@@ -596,7 +597,8 @@ pub fn MarkdownEditor::admit(
   history : MarkdownDocumentHistory,
 ) -> MarkdownAdmitReport raise MarkdownArchiveError {
   let report = self.editor.admit(history.message) catch {
-    error => raise MarkdownArchiveError::AdmitFailed(detail=error.message())
+    error =>
+      raise MarkdownArchiveError::HistoryAdmissionFailed(detail=error.message())
   }
   // Applicable operations are committed before the withheld ones are counted,
   // so the projection is rebuilt on both paths.

--- a/modules/canopy/editor/markdown/editor.mbt
+++ b/modules/canopy/editor/markdown/editor.mbt
@@ -103,6 +103,83 @@ pub fn MarkdownBlockSnapshot::fence_close_range(self : Self) -> (Int, Int)? {
 }
 
 ///|
+/// A resource dimension enforced while opening a Markdown archive.
+pub(all) enum MarkdownArchiveLimitKind {
+  EncodedBytes
+  DecodedOperations
+  PendingOperations
+  ParentsPerOperation
+} derive(Eq, Debug)
+
+///|
+/// Invalid caller-selected archive admission policy.
+pub(all) suberror MarkdownArchiveAdmissionPolicyError {
+  InvalidLimit(kind~ : MarkdownArchiveLimitKind, actual~ : Int)
+}
+
+///|
+/// Explicit resource policy for opening a Markdown archive.
+///
+/// All dimensions are required so archive restore cannot silently inherit the
+/// limits chosen for untrusted peer traffic.
+pub struct MarkdownArchiveAdmissionPolicy {
+  priv limits : @sync.Limits
+}
+
+///|
+/// Construct an archive policy from the four EGW-enforced dimensions.
+pub fn MarkdownArchiveAdmissionPolicy::MarkdownArchiveAdmissionPolicy(
+  max_encoded_bytes~ : Int,
+  max_decoded_operations~ : Int,
+  max_pending_operations~ : Int,
+  max_parents_per_operation~ : Int,
+) -> MarkdownArchiveAdmissionPolicy raise MarkdownArchiveAdmissionPolicyError {
+  if max_encoded_bytes < 0 {
+    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
+      kind=MarkdownArchiveLimitKind::EncodedBytes,
+      actual=max_encoded_bytes,
+    )
+  }
+  if max_decoded_operations < 0 {
+    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
+      kind=MarkdownArchiveLimitKind::DecodedOperations,
+      actual=max_decoded_operations,
+    )
+  }
+  if max_pending_operations < 0 {
+    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
+      kind=MarkdownArchiveLimitKind::PendingOperations,
+      actual=max_pending_operations,
+    )
+  }
+  if max_parents_per_operation < 0 {
+    raise MarkdownArchiveAdmissionPolicyError::InvalidLimit(
+      kind=MarkdownArchiveLimitKind::ParentsPerOperation,
+      actual=max_parents_per_operation,
+    )
+  }
+  let limits = try! @sync.Limits::Limits(
+    max_encoded_bytes~,
+    max_decoded_operations~,
+    max_pending_operations~,
+    max_parents_per_operation~,
+  )
+  { limits, }
+}
+
+///|
+fn MarkdownArchiveLimitKind::from_sync(
+  kind : @sync.LimitKind,
+) -> MarkdownArchiveLimitKind {
+  match kind {
+    EncodedBytes => EncodedBytes
+    DecodedOperations => DecodedOperations
+    PendingOperations => PendingOperations
+    ParentsPerOperation => ParentsPerOperation
+  }
+}
+
+///|
 /// A categorized failure at the archive boundary.
 ///
 /// Kept separate from `MarkdownEditorError` because an archive is a different
@@ -116,6 +193,11 @@ pub(all) suberror MarkdownArchiveError {
   /// failed.
   WriterUnavailable(detail~ : String)
   ExportFailed(detail~ : String)
+  CapacityExceeded(
+    kind~ : MarkdownArchiveLimitKind,
+    limit~ : Int,
+    actual~ : Int
+  )
   AdmitFailed(detail~ : String)
   IncompleteArchive
 }
@@ -465,12 +547,13 @@ fn initialize_markdown_editor(
 /// reopened document is a new writing instance, and reusing the exporter's
 /// identity would make the two indistinguishable in what they go on to write.
 ///
-/// Not yet stated here: the admission policy. This passes through the path
-/// that admits remote traffic and inherits the resource limits written for it,
-/// which the design requires it not to. See the evidence record.
+/// `admission_policy` is explicit because restore and peer traffic are
+/// different consumers of the same admission semantics. Opening never borrows
+/// the receiver defaults used by peer admission.
 pub fn MarkdownEditor::open(
   agent_id~ : String,
   history~ : MarkdownDocumentHistory,
+  admission_policy~ : MarkdownArchiveAdmissionPolicy,
 ) -> MarkdownEditor raise MarkdownArchiveError {
   let editor = @md_companion.new_markdown_editor(agent_id) catch {
     @text.TextError::EmptyReplicaId =>
@@ -479,11 +562,25 @@ pub fn MarkdownEditor::open(
       raise MarkdownArchiveError::WriterUnavailable(detail=error.message())
   }
   let document = { editor, }
-  match document.admit(history) {
-    MarkdownAdmitReport::Complete => document
-    MarkdownAdmitReport::Withheld(..) =>
-      raise MarkdownArchiveError::IncompleteArchive
+  let report = document.editor.admit_with_limits(
+    history.message,
+    admission_policy.limits,
+  ) catch {
+    @text.TextError::SyncFailed(
+      @sync.Failure::LimitExceeded(kind~, limit~, actual~)
+    ) =>
+      raise MarkdownArchiveError::CapacityExceeded(
+        kind=MarkdownArchiveLimitKind::from_sync(kind),
+        limit~,
+        actual~,
+      )
+    error => raise MarkdownArchiveError::AdmitFailed(detail=error.message())
   }
+  document.editor.refresh()
+  if report.pending_operations() > 0 {
+    raise MarkdownArchiveError::IncompleteArchive
+  }
+  document
 }
 
 ///|

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -1,13 +1,13 @@
 ///| The first public headless Markdown façade seam.
 
 ///|
-fn archive_test_policy(
+fn archive_open_limits(
   max_encoded_bytes? : Int = 1024 * 1024,
   max_decoded_operations? : Int = 10000,
   max_pending_operations? : Int = 1000,
   max_parents_per_operation? : Int = 256,
-) -> MarkdownArchiveAdmissionPolicy {
-  try! MarkdownArchiveAdmissionPolicy(
+) -> MarkdownArchiveOpenLimits {
+  try! MarkdownArchiveOpenLimits(
     max_encoded_bytes~,
     max_decoded_operations~,
     max_pending_operations~,
@@ -1273,14 +1273,14 @@ test "empty replica identity is a categorized construction failure" {
 /// workspace/probe pinned this at the editor layer because the façade exposed
 /// neither version nor history transport. It now does, so the same claim is
 /// asserted where the application actually stands.
-test "archive open enforces the exact encoded-byte policy atomically" {
+test "archive open enforces the exact encoded-byte limit atomically" {
   let original = try! MarkdownEditor(
     agent_id="archive-policy-source",
     source="# Title\n\nbody text\n",
   )
   let history = try! original.history_since()
   let encoded_bytes = @utf8.encode(history.to_json_string()).length()
-  let exact = try! MarkdownArchiveAdmissionPolicy(
+  let exact = try! MarkdownArchiveOpenLimits(
     max_encoded_bytes=encoded_bytes,
     max_decoded_operations=100,
     max_pending_operations=10,
@@ -1289,13 +1289,13 @@ test "archive open enforces the exact encoded-byte policy atomically" {
   let reopened = try! MarkdownEditor::open(
     agent_id="archive-policy-exact",
     history~,
-    admission_policy=exact,
+    open_limits=exact,
   )
   assert_true(try! (reopened.history_since() == history))
 
   let before_source = original.snapshot().source()
   let before_version = original.version()
-  let over = try! MarkdownArchiveAdmissionPolicy(
+  let over = try! MarkdownArchiveOpenLimits(
     max_encoded_bytes=encoded_bytes - 1,
     max_decoded_operations=100,
     max_pending_operations=10,
@@ -1305,23 +1305,23 @@ test "archive open enforces the exact encoded-byte policy atomically" {
     MarkdownEditor::open(
       agent_id="archive-policy-over",
       history~,
-      admission_policy=over,
+      open_limits=over,
     ),
   ) catch {
     error => Err(error)
   }
   match refused {
     Err(
-      MarkdownArchiveError::CapacityExceeded(
-        kind=MarkdownArchiveLimitKind::EncodedBytes,
-        limit~,
+      MarkdownArchiveError::LimitExceeded(
+        dimension=MarkdownArchiveLimitDimension::EncodedBytes,
+        maximum~,
         actual~
       )
     ) => {
-      assert_eq(limit, encoded_bytes - 1)
+      assert_eq(maximum, encoded_bytes - 1)
       assert_eq(actual, encoded_bytes)
     }
-    _ => fail("expected encoded-byte capacity failure")
+    _ => fail("expected encoded-byte limit failure")
   }
   assert_eq(original.snapshot().source(), before_source)
   assert_true(original.version() == before_version)
@@ -1329,12 +1329,12 @@ test "archive open enforces the exact encoded-byte policy atomically" {
 }
 
 ///|
-test "archive policy rejects a negative resource dimension" {
+test "archive open limits reject a negative resource dimension" {
   let invalid : Result[
-    MarkdownArchiveAdmissionPolicy,
-    MarkdownArchiveAdmissionPolicyError,
+    MarkdownArchiveOpenLimits,
+    MarkdownArchiveOpenLimitsError,
   ] = Ok(
-    MarkdownArchiveAdmissionPolicy(
+    MarkdownArchiveOpenLimits(
       max_encoded_bytes=1024,
       max_decoded_operations=100,
       max_pending_operations=10,
@@ -1346,9 +1346,9 @@ test "archive policy rejects a negative resource dimension" {
   assert_true(
     invalid
     is Err(
-      MarkdownArchiveAdmissionPolicyError::InvalidLimit(
-        kind=MarkdownArchiveLimitKind::ParentsPerOperation,
-        actual=-1
+      MarkdownArchiveOpenLimitsError::InvalidLimit(
+        dimension=MarkdownArchiveLimitDimension::ParentsPerOperation,
+        value=-1
       )
     ),
   )
@@ -1371,7 +1371,7 @@ test "facade history round-trips into a reopened document" {
   let reopened = try! MarkdownEditor::open(
     agent_id="owner-2",
     history~,
-    admission_policy=archive_test_policy(),
+    open_limits=archive_open_limits(),
   )
 
   assert_eq(reopened.snapshot().source(), want_source)
@@ -1397,7 +1397,7 @@ test "reopened and original converge after divergent edits" {
   let b = try! MarkdownEditor::open(
     agent_id="peer-b",
     history=seed,
-    admission_policy=archive_test_policy(),
+    open_limits=archive_open_limits(),
   )
 
   assert_true(
@@ -1442,7 +1442,7 @@ test "open categorizes a bad writer identity as such" {
     MarkdownEditor::open(
       agent_id="",
       history~,
-      admission_policy=archive_test_policy(),
+      open_limits=archive_open_limits(),
     ),
   ) catch {
     error => Err(error)
@@ -1450,7 +1450,7 @@ test "open categorizes a bad writer identity as such" {
 
   match refused {
     Err(MarkdownArchiveError::InvalidAgentId) => ()
-    Err(MarkdownArchiveError::AdmitFailed(detail~)) =>
+    Err(MarkdownArchiveError::HistoryAdmissionFailed(detail~)) =>
       fail("blamed admission for a writer that was never created: \{detail}")
     _ => fail("expected InvalidAgentId")
   }
@@ -1515,34 +1515,34 @@ test "withheld operations are reported by admit and refused by open" {
     MarkdownEditor::open(
       agent_id="gap-open",
       history=gapped,
-      admission_policy=archive_test_policy(),
+      open_limits=archive_open_limits(),
     ),
   ) catch {
     error => Err(error)
   }
   match refused {
-    Err(MarkdownArchiveError::IncompleteArchive) => ()
-    _ => fail("expected IncompleteArchive")
+    Err(MarkdownArchiveError::IncompleteHistory) => ()
+    _ => fail("expected IncompleteHistory")
   }
 
   let capacity_refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
     MarkdownEditor::open(
       agent_id="gap-capacity-open",
       history=gapped,
-      admission_policy=archive_test_policy(max_pending_operations=0),
+      open_limits=archive_open_limits(max_pending_operations=0),
     ),
   ) catch {
     error => Err(error)
   }
   match capacity_refused {
     Err(
-      MarkdownArchiveError::CapacityExceeded(
-        kind=MarkdownArchiveLimitKind::PendingOperations,
-        limit=0,
+      MarkdownArchiveError::LimitExceeded(
+        dimension=MarkdownArchiveLimitDimension::PendingOperations,
+        maximum=0,
         actual=1
       )
     ) => ()
-    _ => fail("expected pending-operation capacity failure")
+    _ => fail("expected pending-operation limit failure")
   }
 }
 

--- a/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
+++ b/modules/canopy/editor/markdown/markdown_editor_wbtest.mbt
@@ -1,6 +1,21 @@
 ///| The first public headless Markdown façade seam.
 
 ///|
+fn archive_test_policy(
+  max_encoded_bytes? : Int = 1024 * 1024,
+  max_decoded_operations? : Int = 10000,
+  max_pending_operations? : Int = 1000,
+  max_parents_per_operation? : Int = 256,
+) -> MarkdownArchiveAdmissionPolicy {
+  try! MarkdownArchiveAdmissionPolicy(
+    max_encoded_bytes~,
+    max_decoded_operations~,
+    max_pending_operations~,
+    max_parents_per_operation~,
+  )
+}
+
+///|
 fn fresh_markdown_ir(source : String) -> @md_markdown.MarkdownIR {
   let parser = @loom.new_parser(
     @loom.SourceId("markdown-editor-semantic-fresh"),
@@ -1258,6 +1273,88 @@ test "empty replica identity is a categorized construction failure" {
 /// workspace/probe pinned this at the editor layer because the façade exposed
 /// neither version nor history transport. It now does, so the same claim is
 /// asserted where the application actually stands.
+test "archive open enforces the exact encoded-byte policy atomically" {
+  let original = try! MarkdownEditor(
+    agent_id="archive-policy-source",
+    source="# Title\n\nbody text\n",
+  )
+  let history = try! original.history_since()
+  let encoded_bytes = @utf8.encode(history.to_json_string()).length()
+  let exact = try! MarkdownArchiveAdmissionPolicy(
+    max_encoded_bytes=encoded_bytes,
+    max_decoded_operations=100,
+    max_pending_operations=10,
+    max_parents_per_operation=16,
+  )
+  let reopened = try! MarkdownEditor::open(
+    agent_id="archive-policy-exact",
+    history~,
+    admission_policy=exact,
+  )
+  assert_true(try! (reopened.history_since() == history))
+
+  let before_source = original.snapshot().source()
+  let before_version = original.version()
+  let over = try! MarkdownArchiveAdmissionPolicy(
+    max_encoded_bytes=encoded_bytes - 1,
+    max_decoded_operations=100,
+    max_pending_operations=10,
+    max_parents_per_operation=16,
+  )
+  let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+    MarkdownEditor::open(
+      agent_id="archive-policy-over",
+      history~,
+      admission_policy=over,
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match refused {
+    Err(
+      MarkdownArchiveError::CapacityExceeded(
+        kind=MarkdownArchiveLimitKind::EncodedBytes,
+        limit~,
+        actual~
+      )
+    ) => {
+      assert_eq(limit, encoded_bytes - 1)
+      assert_eq(actual, encoded_bytes)
+    }
+    _ => fail("expected encoded-byte capacity failure")
+  }
+  assert_eq(original.snapshot().source(), before_source)
+  assert_true(original.version() == before_version)
+  assert_true(try! (original.history_since() == history))
+}
+
+///|
+test "archive policy rejects a negative resource dimension" {
+  let invalid : Result[
+    MarkdownArchiveAdmissionPolicy,
+    MarkdownArchiveAdmissionPolicyError,
+  ] = Ok(
+    MarkdownArchiveAdmissionPolicy(
+      max_encoded_bytes=1024,
+      max_decoded_operations=100,
+      max_pending_operations=10,
+      max_parents_per_operation=-1,
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  assert_true(
+    invalid
+    is Err(
+      MarkdownArchiveAdmissionPolicyError::InvalidLimit(
+        kind=MarkdownArchiveLimitKind::ParentsPerOperation,
+        actual=-1
+      )
+    ),
+  )
+}
+
+///|
 test "facade history round-trips into a reopened document" {
   let original = try! MarkdownEditor(
     agent_id="owner-1",
@@ -1271,7 +1368,11 @@ test "facade history round-trips into a reopened document" {
   let want_version = original.version()
   let history = try! original.history_since()
 
-  let reopened = try! MarkdownEditor::open(agent_id="owner-2", history~)
+  let reopened = try! MarkdownEditor::open(
+    agent_id="owner-2",
+    history~,
+    admission_policy=archive_test_policy(),
+  )
 
   assert_eq(reopened.snapshot().source(), want_source)
   assert_true(reopened.version() == want_version)
@@ -1293,7 +1394,11 @@ test "facade history round-trips into a reopened document" {
 test "reopened and original converge after divergent edits" {
   let a = try! MarkdownEditor(agent_id="peer-a", source="hello world")
   let seed = try! a.history_since()
-  let b = try! MarkdownEditor::open(agent_id="peer-b", history=seed)
+  let b = try! MarkdownEditor::open(
+    agent_id="peer-b",
+    history=seed,
+    admission_policy=archive_test_policy(),
+  )
 
   assert_true(
     a.commit(
@@ -1334,7 +1439,11 @@ test "open categorizes a bad writer identity as such" {
   let history = try! document.history_since()
 
   let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
-    MarkdownEditor::open(agent_id="", history~),
+    MarkdownEditor::open(
+      agent_id="",
+      history~,
+      admission_policy=archive_test_policy(),
+    ),
   ) catch {
     error => Err(error)
   }
@@ -1403,13 +1512,37 @@ test "withheld operations are reported by admit and refused by open" {
   )
 
   let refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
-    MarkdownEditor::open(agent_id="gap-open", history=gapped),
+    MarkdownEditor::open(
+      agent_id="gap-open",
+      history=gapped,
+      admission_policy=archive_test_policy(),
+    ),
   ) catch {
     error => Err(error)
   }
   match refused {
     Err(MarkdownArchiveError::IncompleteArchive) => ()
     _ => fail("expected IncompleteArchive")
+  }
+
+  let capacity_refused : Result[MarkdownEditor, MarkdownArchiveError] = Ok(
+    MarkdownEditor::open(
+      agent_id="gap-capacity-open",
+      history=gapped,
+      admission_policy=archive_test_policy(max_pending_operations=0),
+    ),
+  ) catch {
+    error => Err(error)
+  }
+  match capacity_refused {
+    Err(
+      MarkdownArchiveError::CapacityExceeded(
+        kind=MarkdownArchiveLimitKind::PendingOperations,
+        limit=0,
+        actual=1
+      )
+    ) => ()
+    _ => fail("expected pending-operation capacity failure")
   }
 }
 

--- a/modules/canopy/editor/markdown/moon.pkg
+++ b/modules/canopy/editor/markdown/moon.pkg
@@ -7,11 +7,13 @@ import {
   "dowdiness/markdown" @md_markdown,
   "dowdiness/text_change",
   "dowdiness/event-graph-walker/text",
+  "dowdiness/event-graph-walker/sync",
   "moonbitlang/core/immut/vector",
 }
 
 import {
   "dowdiness/loom",
+  "moonbitlang/core/encoding/utf8",
 } for "wbtest"
 
 warnings = "-7-29"

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -9,17 +9,17 @@ import {
 // Values
 
 // Errors
-pub(all) suberror MarkdownArchiveAdmissionPolicyError {
-  InvalidLimit(kind~ : MarkdownArchiveLimitKind, actual~ : Int)
-}
-
 pub(all) suberror MarkdownArchiveError {
   InvalidAgentId
-  WriterUnavailable(detail~ : String)
+  WriterCreationFailed(detail~ : String)
   ExportFailed(detail~ : String)
-  CapacityExceeded(kind~ : MarkdownArchiveLimitKind, limit~ : Int, actual~ : Int)
-  AdmitFailed(detail~ : String)
-  IncompleteArchive
+  LimitExceeded(dimension~ : MarkdownArchiveLimitDimension, maximum~ : Int, actual~ : Int)
+  HistoryAdmissionFailed(detail~ : String)
+  IncompleteHistory
+}
+
+pub(all) suberror MarkdownArchiveOpenLimitsError {
+  InvalidLimit(dimension~ : MarkdownArchiveLimitDimension, value~ : Int)
 }
 
 pub(all) suberror MarkdownEditorError {
@@ -40,17 +40,17 @@ pub(all) enum MarkdownAdmitReport {
   Withheld(applied~ : Int, withheld~ : Int)
 } derive(Eq, @debug.Debug)
 
-pub struct MarkdownArchiveAdmissionPolicy {
-  // private fields
-}
-pub fn MarkdownArchiveAdmissionPolicy::MarkdownArchiveAdmissionPolicy(max_encoded_bytes~ : Int, max_decoded_operations~ : Int, max_pending_operations~ : Int, max_parents_per_operation~ : Int) -> Self raise MarkdownArchiveAdmissionPolicyError
-
-pub(all) enum MarkdownArchiveLimitKind {
+pub(all) enum MarkdownArchiveLimitDimension {
   EncodedBytes
   DecodedOperations
   PendingOperations
   ParentsPerOperation
 } derive(Eq, @debug.Debug)
+
+pub struct MarkdownArchiveOpenLimits {
+  // private fields
+}
+pub fn MarkdownArchiveOpenLimits::MarkdownArchiveOpenLimits(max_encoded_bytes~ : Int, max_decoded_operations~ : Int, max_pending_operations~ : Int, max_parents_per_operation~ : Int) -> Self raise MarkdownArchiveOpenLimitsError
 
 pub(all) enum MarkdownBlockKind {
   Paragraph
@@ -136,7 +136,7 @@ pub fn MarkdownEditor::admit(Self, MarkdownDocumentHistory) -> MarkdownAdmitRepo
 pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError]
 pub fn MarkdownEditor::commit_with_receipt(Self, MarkdownEditRequest) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError
 pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -> MarkdownDocumentHistory raise MarkdownArchiveError
-pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory, admission_policy~ : MarkdownArchiveAdmissionPolicy) -> Self raise MarkdownArchiveError
+pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory, open_limits~ : MarkdownArchiveOpenLimits) -> Self raise MarkdownArchiveError
 pub fn MarkdownEditor::portable_markdown(Self) -> String
 pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
 pub fn MarkdownEditor::version(Self) -> MarkdownDocumentVersion

--- a/modules/canopy/editor/markdown/pkg.generated.mbti
+++ b/modules/canopy/editor/markdown/pkg.generated.mbti
@@ -9,10 +9,15 @@ import {
 // Values
 
 // Errors
+pub(all) suberror MarkdownArchiveAdmissionPolicyError {
+  InvalidLimit(kind~ : MarkdownArchiveLimitKind, actual~ : Int)
+}
+
 pub(all) suberror MarkdownArchiveError {
   InvalidAgentId
   WriterUnavailable(detail~ : String)
   ExportFailed(detail~ : String)
+  CapacityExceeded(kind~ : MarkdownArchiveLimitKind, limit~ : Int, actual~ : Int)
   AdmitFailed(detail~ : String)
   IncompleteArchive
 }
@@ -33,6 +38,18 @@ pub(all) suberror MarkdownHistoryCodecError {
 pub(all) enum MarkdownAdmitReport {
   Complete
   Withheld(applied~ : Int, withheld~ : Int)
+} derive(Eq, @debug.Debug)
+
+pub struct MarkdownArchiveAdmissionPolicy {
+  // private fields
+}
+pub fn MarkdownArchiveAdmissionPolicy::MarkdownArchiveAdmissionPolicy(max_encoded_bytes~ : Int, max_decoded_operations~ : Int, max_pending_operations~ : Int, max_parents_per_operation~ : Int) -> Self raise MarkdownArchiveAdmissionPolicyError
+
+pub(all) enum MarkdownArchiveLimitKind {
+  EncodedBytes
+  DecodedOperations
+  PendingOperations
+  ParentsPerOperation
 } derive(Eq, @debug.Debug)
 
 pub(all) enum MarkdownBlockKind {
@@ -119,7 +136,7 @@ pub fn MarkdownEditor::admit(Self, MarkdownDocumentHistory) -> MarkdownAdmitRepo
 pub fn MarkdownEditor::commit(Self, MarkdownEditRequest) -> Result[MarkdownCommitResult, MarkdownEditorError]
 pub fn MarkdownEditor::commit_with_receipt(Self, MarkdownEditRequest) -> Result[MarkdownCommitReceipt, MarkdownEditorError] raise MarkdownArchiveError
 pub fn MarkdownEditor::history_since(Self, version? : MarkdownDocumentVersion) -> MarkdownDocumentHistory raise MarkdownArchiveError
-pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory) -> Self raise MarkdownArchiveError
+pub fn MarkdownEditor::open(agent_id~ : String, history~ : MarkdownDocumentHistory, admission_policy~ : MarkdownArchiveAdmissionPolicy) -> Self raise MarkdownArchiveError
 pub fn MarkdownEditor::portable_markdown(Self) -> String
 pub fn MarkdownEditor::snapshot(Self) -> MarkdownDocumentSnapshot
 pub fn MarkdownEditor::version(Self) -> MarkdownDocumentVersion

--- a/modules/canopy/editor/moon.pkg
+++ b/modules/canopy/editor/moon.pkg
@@ -6,6 +6,7 @@ import {
   "dowdiness/text_change",
   "dowdiness/moji",
   "dowdiness/event-graph-walker/text",
+  "dowdiness/event-graph-walker/sync",
   "dowdiness/event-graph-walker/undo",
   "dowdiness/event-graph-walker/history",
   "dowdiness/incr",

--- a/modules/canopy/editor/pkg.generated.mbti
+++ b/modules/canopy/editor/pkg.generated.mbti
@@ -9,6 +9,7 @@ import {
   "dowdiness/canopy/transport_ws",
   "dowdiness/diagnostic",
   "dowdiness/event-graph-walker/history",
+  "dowdiness/event-graph-walker/sync",
   "dowdiness/event-graph-walker/text",
   "dowdiness/incr/cells",
   "dowdiness/loom/incremental",
@@ -132,6 +133,7 @@ pub struct SyncEditor[T] {
   // private fields
 }
 pub fn[T : Eq] SyncEditor::admit(Self[T], @text.SyncMessage) -> @text.SyncReport raise @text.TextError
+pub fn[T : Eq] SyncEditor::admit_with_limits(Self[T], @text.SyncMessage, @sync.Limits) -> @text.SyncReport raise @text.TextError
 pub fn[T] SyncEditor::apply_ephemeral(Self[T], Bytes) -> Unit
 pub fn[T : Eq] SyncEditor::apply_span_edits(Self[T], Array[@dowdiness/canopy/core.SpanEdit], @dowdiness/canopy/core.FocusHint, Int, hint? : @dowdiness/canopy/core.IdentityTransform) -> Unit
 pub fn[T : Eq] SyncEditor::apply_sync(Self[T], @text.SyncMessage) -> Unit raise

--- a/modules/canopy/editor/sync_editor.mbt
+++ b/modules/canopy/editor/sync_editor.mbt
@@ -465,21 +465,19 @@ fn[T] SyncEditor::adjust_cursor(self : SyncEditor[T]) -> Unit {
 }
 
 ///|
-/// Take a peer's operations into this document, reporting what landed.
-///
-/// Operations whose causal prerequisites are absent are retained rather than
-/// rejected, and counted in the returned report. That is a state, not a
-/// failure. Callers that require a message to be complete apply that policy
-/// themselves — `apply_sync` is the one that does.
-pub fn[T : Eq] SyncEditor::admit(
+fn[T : Eq] SyncEditor::admit_with_policy(
   self : SyncEditor[T],
   msg : @text.SyncMessage,
+  limits : @sync.Limits?,
 ) -> @text.SyncReport raise @text.TextError {
   self.taint_pending_transforms()
   let old_source = self.doc.text()
   self.undo.set_tracking(false)
   let report_result : Result[@text.SyncReport, @text.TextError] = Ok(
-    self.doc.sync().apply(msg),
+    match limits {
+      None => self.doc.sync().apply(msg)
+      Some(limits) => self.doc.sync().apply_with_limits(msg, limits)
+    },
   ) catch {
     error => Err(error)
   }
@@ -501,6 +499,33 @@ pub fn[T : Eq] SyncEditor::admit(
     self.session.note_sync_applied()
   }
   report
+}
+
+///|
+/// Take a peer's operations into this document, reporting what landed.
+///
+/// Operations whose causal prerequisites are absent are retained rather than
+/// rejected, and counted in the returned report. That is a state, not a
+/// failure. Callers that require a message to be complete apply that policy
+/// themselves — `apply_sync` is the one that does.
+pub fn[T : Eq] SyncEditor::admit(
+  self : SyncEditor[T],
+  msg : @text.SyncMessage,
+) -> @text.SyncReport raise @text.TextError {
+  self.admit_with_policy(msg, None)
+}
+
+///|
+/// Take operations into this document using caller-selected resource limits.
+///
+/// This selects policy for one admission only; peer admission through `admit`
+/// continues to use the limits configured on the document.
+pub fn[T : Eq] SyncEditor::admit_with_limits(
+  self : SyncEditor[T],
+  msg : @text.SyncMessage,
+  limits : @sync.Limits,
+) -> @text.SyncReport raise @text.TextError {
+  self.admit_with_policy(msg, Some(limits))
 }
 
 ///|


### PR DESCRIPTION
Closes #1132

## Summary

- add Markdown-owned archive open limits with all four EGW-enforced resource dimensions required explicitly
- route archive opening through per-call limits while preserving document-configured limits for peer admission
- keep limit, writer-creation, history-admission, history-export, incomplete-history, corruption, and version failures distinct through the Loomark envelope

## UI and review evidence

N/A — no UI or visual changes.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@sync.Limits` | event-graph-walker `sync` | Yes | Private validated value behind the Markdown-owned archive open limits |
| `SyncSession::apply_with_limits` | event-graph-walker `text` | Yes | Existing call-local admission semantics; no duplicate limit enforcement |
| `SyncSession::apply` | event-graph-walker `text` | Yes, unchanged peer path | Keeps document-configured limits for ordinary peer admission |
| `SyncReport` / `@sync.Failure::LimitExceeded` | event-graph-walker `text` / `sync` | Yes | Existing completeness counts and typed capacity details |
| `MarkdownEditor::admit` / `MarkdownDocumentHistory` | Markdown façade | Yes | Existing peer-state semantics and opaque history ownership |
| `Option`, `Result` | MoonBit core | Yes | Shared shell policy selection and typed error materialization |
| `String`, `StringView`, `Bytes`, `BytesView`, `Map`, `Set`, `Array`, `Iter`, `Buffer`, `cmp` / `math` | MoonBit core | Considered | No new text, byte, collection, builder, ordering, or numeric algorithm was needed |

Existing APIs checked but not used:

- `@sync.Limits::default()` — intentionally rejected because archive restore must not acquire a hidden policy.
- Direct `SyncSession` access from the Markdown façade — rejected because it would bypass `SyncEditor` cursor/parser/session reconciliation.

New helpers and types:

- `SyncEditor::admit_with_limits` — one call-local policy seam around the existing imperative reconciliation shell.
- private `SyncEditor::admit_with_policy` — keeps peer and explicit-limit admission on one shell implementation.
- `MarkdownArchiveOpenLimits`, its construction error, and `MarkdownArchiveLimitDimension` — hide EGW types while requiring exactly the supported dimensions.
- typed limit/incomplete/admission/export mappings in the Markdown and Loomark archive errors — preserve caller recovery decisions across package seams.

No new loops or mutable collections were introduced. Remaining mutation is the pre-existing `SyncEditor` imperative shell around EGW's preflighted admission.

## Validation scope

Boundary matrix / first failing regression:

- below-limit and exact encoded-byte archives open successfully
- one-byte-over archives return typed encoded-byte capacity details and do not affect the exporting editor
- a negative open-limit dimension is rejected before an open-limits value exists
- one causally withheld operation remains valid peer state, becomes `IncompleteHistory` under archive open limits, and becomes a pending-limit failure when the pending maximum is zero
- Loomark decode preserves capacity versus incomplete-history distinctions instead of collapsing either into corruption
- existing malformed/newer/corrupt/mismatch/invalid-writer cases remain distinct
- complete archives retain canonical history equality and support continued divergent editing and merge

First RED: `archive open enforces the exact encoded-byte limit atomically` failed because the open-limits type, required `open` parameter, and typed limit error did not exist.

Target packages:

- `modules/canopy/editor`
- `modules/canopy/editor/markdown`
- `apps/loomark/archive`

Additional conditional gates:

- evidence JSON parses successfully
- no proof, browser, TypeScript, or submodule surface changed

## PR-ready evidence

Validated HEAD: `e0c7d402a358c9f795ce1924fdf652d09ffa4a30`

Validated base: `origin/main@89275635b6514704cc5f9b47aecdaa6a2a55fdcc`

```bash
git fetch origin main
./scripts/validate-pr-ready.sh \
  --target modules/canopy/editor \
  --target modules/canopy/editor/markdown \
  --target apps/loomark/archive
git fetch origin main
./scripts/validate-pr-ready.sh --verify-evidence
```

- [x] The full validator passed for the exact HEAD and base above.
- [x] The base was fetched again and `--verify-evidence` passed immediately before this PR was opened.
- [x] The committed `.mbti` diff was reviewed: additive `SyncEditor::admit_with_limits`, intentional required-open-limits signature changes, new typed errors, and no widened existing trait bounds.
- [x] No submodule changed.
- [x] Validation was rerun after the final commit and generated-interface update.
- [x] Independent MoonBit review findings were resolved before final validation.
