### PR TITLE
chore(cloud): add .cursor/environment.json for reproducible Cloud Agent setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "apps/web — Waku dev (:3000)",
+      "command": "export PATH=\"$HOME/.nvm/versions/node/v22.22.2/bin:$HOME/.moon/bin:$PATH\"; export NEW_MOON_MOD=0; cd apps/web && npm run dev"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Cloud Agent Build-time setup for Canopy.
+#
+# This runs during each Cursor Cloud "Build" (formerly the update script), and
+# the resulting disk state is snapshotted into the bootable image every future
+# agent session starts from. It must be idempotent: it may run on top of an
+# already-prepared workspace, and the repo is re-cloned at its default branch
+# before it runs.
+#
+# Keep long-running processes (dev servers) OUT of this file — put those in the
+# `terminals` field of .cursor/environment.json so they start each session.
+set -euo pipefail
+
+# Canopy requires NEW_MOON_MOD=0 for every `moon` command (matches
+# .github/actions/setup-moonbit); without it the rr_moon_mod TOML migration
+# drops path fields from cross-repo deps.
+export NEW_MOON_MOD=0
+export PATH="$HOME/.moon/bin:$PATH"
+
+# MoonBit toolchain, pinned to the same pair as CI. Normally already present in
+# the base image; the guard makes a fresh base self-heal instead of failing.
+if ! command -v moon >/dev/null 2>&1; then
+  curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s 0.10.4+ade96c819
+  export PATH="$HOME/.moon/bin:$PATH"
+fi
+
+# Submodules live under deps/ and are wiped by the per-Build re-clone.
+git submodule update --init --recursive
+
+# Warm the mooncakes registry (bounded retries for transient CDN flakes).
+scripts/moon-update.sh
+
+# JS FFI artifacts consumed by the web front-ends.
+make build-js
+
+# apps/web needs node ^22.15.0; prefer nvm's pinned 22.22.2 when available so
+# npm's engines check is satisfied.
+if [ -d "$HOME/.nvm/versions/node/v22.22.2/bin" ]; then
+  export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+fi
+npm --prefix apps/web ci
+
+# Optional: Warren tool for the standalone apps/loomark Rabbita app. The repo's
+# scripts/install-local-warren.sh does the same thing but its origin-URL check
+# fails under Cloud's token rewrite, so install the pinned package directly.
+# Non-fatal: a Warren build failure must not fail the whole environment build.
+moon install "$PWD/deps/rabbita/warren" --bin "$PWD/_build/tools/bin" || \
+  echo "warn: Warren install skipped (apps/loomark dev unavailable)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a version-controlled Cursor Cloud Agent environment so every future session boots pre-configured, instead of each agent re-doing setup by hand (which does not persist).

- `.cursor/environment.json` — `install` runs `.cursor/install.sh` at **Build** time; `terminals` starts the `apps/web` Waku dev server (`:3000`) on each agent start.
- `.cursor/install.sh` — idempotent Build setup: guard-installs the pinned MoonBit toolchain, `git submodule update --init --recursive` (submodules live under `deps/`), warms the mooncakes registry, `make build-js`, `npm --prefix apps/web ci` (node `v22.22.2`), and installs the `warren` tool for `apps/loomark`.

## Why setup did not persist before

Cloud Agents boot from a Build (a snapshot). Only the base image plus whatever the `install` step writes to disk is preserved — running processes, shell exports, and interactive commands are not. Manual `git submodule update` / `npm install` / running dev servers therefore vanished in later sessions. Moving that work into `install` bakes it into the Build; putting dev servers in `terminals` brings them up every session.

## Reviewer notes / decisions

- **Base image:** this file does not set a `snapshot`/`build` base, so it uses the environment's default base. The MoonBit install in `.cursor/install.sh` is guarded (`command -v moon`), so it self-heals a bare base but is a no-op when the base already has the toolchain. If you have a dashboard snapshot with MoonBit preinstalled, add its id via a `"snapshot": "snapshot-..."` field to skip the install entirely.
- **Precedence:** a committed `.cursor/environment.json` overrides personal/team saved environments (resolution order: repo → personal → team). Merging this makes the repo the source of truth for the Cloud environment.
- **Secrets:** none required; user secrets are unavailable at Build time anyway, and this setup only needs public submodules + the mooncakes registry.
- `terminals` starts only `apps/web`; the Vite apps (`apps/ideal/web`, etc.) and `apps/loomark` (`warren dev --direct`, `:4300`) can be started on demand — add more `terminals` entries if you want them auto-started.

## Test plan

- [x] `.cursor/environment.json` parses as valid JSON
- [x] `bash .cursor/install.sh` runs end-to-end idempotently (exit 0): submodules, `scripts/moon-update.sh`, `make build-js`, `npm --prefix apps/web ci`, Warren install
- [x] Verified in this session: `apps/web` (`:3000`), `apps/ideal/web` (`:5173`), `apps/loomark` (`:4300`) all serve HTTP 200

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2406b4d7-cb38-4771-891d-e1c6031b8b18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2406b4d7-cb38-4771-891d-e1c6031b8b18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added development environment configuration for running the web app locally.
  * Streamlined setup of project dependencies and development tools.
  * Improved initialization for builds, submodules, and required development artifacts.
  * Added support for a preconfigured web development terminal on port 3000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->