### PR TITLE
refactor(loomark): unify the two commit shells behind one transaction core

### DIFF
--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -44,94 +44,19 @@ fn archive_replacement(
 }
 
 ///|
-/// Commit one canonical source request and install state only after success.
-fn commit_source(
+/// Shared atomic-commit shell: failure injection, editor commit, receipt
+/// classification, and persistence dispatch. Mode-specific concerns
+/// (selection extraction, preview demand, application state) stay with the
+/// caller. Returns (model, result?, accepted, changed, command) — `result`
+/// is present only on a successful Ok receipt so block callers can extract
+/// the deep selection outcome without reading SyncEditor cursor state.
+fn commit_edit_request(
   editor : @markdown.MarkdownEditor,
-  model : DriverModel,
-  state : @core.ApplicationState,
-  source : String,
-  operation : String,
-  emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, Bool, Bool, @cmd.Cmd) {
-  let fail_commit = model.fail_next_editor_commit
-  let next = { ..model, fail_next_editor_commit: false }
-  let request = if fail_commit {
-    @markdown.MarkdownEditRequest::ReplaceText(
-      start=-1,
-      delete_len=0,
-      inserted="",
-    )
-  } else {
-    @markdown.MarkdownEditRequest::ReplaceSource(source)
-  }
-  let receipt = editor.commit_with_receipt(request) catch {
-    _ => {
-      let document = editor.snapshot()
-      let changed = document.source() != model.document.source()
-      let accepted = {
-        ..next,
-        state,
-        document,
-        source_revision: if changed {
-          model.source_revision + 1
-        } else {
-          model.source_revision
-        },
-        committed_change_count: if changed {
-          model.committed_change_count + 1
-        } else {
-          model.committed_change_count
-        },
-      }
-      return (
-        record_local_persistence_failure(accepted),
-        true,
-        changed,
-        @rabbita_runtime.none,
-      )
-    }
-  }
-  match receipt {
-    Err(error) => {
-      let failed = record_error(
-        next,
-        "editor-commit-failed",
-        operation,
-        "editor commit failed: " + editor_error_detail(error),
-      )
-      (failed, false, false, @rabbita_runtime.none)
-    }
-    Ok(receipt) => {
-      let (committed, changed) = classify_commit(
-        { ..next, state, },
-        receipt.result(),
-      )
-      match @repository.history_trigger(receipt) {
-        @repository.LocalArchivePersistenceDecision::Replace => {
-          let (persisted, command) = archive_replacement(
-            editor, committed, emit,
-          )
-          (persisted, true, changed, command)
-        }
-        @repository.LocalArchivePersistenceDecision::Skip =>
-          (committed, true, changed, @rabbita_runtime.none)
-      }
-    }
-  }
-}
-
-///|
-/// Commit one typed block request through the atomic façade boundary.
-/// Structural callers receive the deep selection outcome without reading
-/// SyncEditor cursor state in this shell.
-fn commit_block_request(
-  editor : @markdown.MarkdownEditor,
-  attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
   request : @markdown.MarkdownEditRequest,
   operation : String,
   emit : @cmd.Emit[DriverEvent],
-) -> (DriverModel, @markdown.MarkdownBlockSelection?, Bool, @cmd.Cmd) {
+) -> (DriverModel, @markdown.MarkdownCommitResult?, Bool, Bool, @cmd.Cmd) {
   let fail_commit = model.fail_next_editor_commit
   let next = { ..model, fail_next_editor_commit: false }
   let request = if fail_commit {
@@ -147,28 +72,27 @@ fn commit_block_request(
     _ => {
       let document = editor.snapshot()
       let changed = document.source() != model.document.source()
-      let accepted = update_preview_document(
-        attachment,
-        {
-          ..next,
-          document,
-          source_revision: if changed {
-            model.source_revision + 1
-          } else {
-            model.source_revision
-          },
-          committed_change_count: if changed {
-            model.committed_change_count + 1
-          } else {
-            model.committed_change_count
-          },
-        }
-        |> record_local_persistence_failure,
-        preview_requested(model),
-        accepted=true,
-        changed~,
+      let accepted = {
+        ..next,
+        document,
+        source_revision: if changed {
+          model.source_revision + 1
+        } else {
+          model.source_revision
+        },
+        committed_change_count: if changed {
+          model.committed_change_count + 1
+        } else {
+          model.committed_change_count
+        },
+      }
+      return (
+        record_local_persistence_failure(accepted),
+        None,
+        true,
+        changed,
+        @rabbita_runtime.none,
       )
-      return (accepted, None, true, @rabbita_runtime.none)
     }
   }
   match receipt {
@@ -179,45 +103,75 @@ fn commit_block_request(
         operation,
         "editor commit failed: " + editor_error_detail(error),
       )
-      (
-        update_preview_document(
-          attachment,
-          failed,
-          preview_requested(model),
-          accepted=false,
-          changed=false,
-        ),
-        None,
-        false,
-        @rabbita_runtime.none,
-      )
+      (failed, None, false, false, @rabbita_runtime.none)
     }
     Ok(receipt) => {
       let result = receipt.result()
       let (committed, changed) = classify_commit(next, result)
-      let selection = match result {
-        @markdown.Applied(_, selection) => selection
-        @markdown.Unchanged(_) => None
-      }
-      let committed = update_preview_document(
-        attachment,
-        committed,
-        preview_requested(model),
-        accepted=true,
-        changed~,
-      )
       match @repository.history_trigger(receipt) {
         @repository.LocalArchivePersistenceDecision::Replace => {
           let (persisted, command) = archive_replacement(
             editor, committed, emit,
           )
-          (persisted, selection, true, command)
+          (persisted, Some(result), true, changed, command)
         }
         @repository.LocalArchivePersistenceDecision::Skip =>
-          (committed, selection, true, @rabbita_runtime.none)
+          (committed, Some(result), true, changed, @rabbita_runtime.none)
       }
     }
   }
+}
+
+///|
+/// Commit one canonical source request and install state only after success.
+fn commit_source(
+  editor : @markdown.MarkdownEditor,
+  model : DriverModel,
+  state : @core.ApplicationState,
+  source : String,
+  operation : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, Bool, Bool, @cmd.Cmd) {
+  let (committed, _, accepted, changed, command) = commit_edit_request(
+    editor,
+    model,
+    @markdown.MarkdownEditRequest::ReplaceSource(source),
+    operation,
+    emit,
+  )
+  let committed = if accepted { { ..committed, state, } } else { committed }
+  (committed, accepted, changed, command)
+}
+
+///|
+/// Commit one typed block request through the atomic façade boundary.
+/// Structural callers receive the deep selection outcome without reading
+/// SyncEditor cursor state in this shell.
+fn commit_block_request(
+  editor : @markdown.MarkdownEditor,
+  attachment : @md_markdown.MarkdownSemanticAttachment,
+  model : DriverModel,
+  request : @markdown.MarkdownEditRequest,
+  operation : String,
+  emit : @cmd.Emit[DriverEvent],
+) -> (DriverModel, @markdown.MarkdownBlockSelection?, Bool, @cmd.Cmd) {
+  let (committed, result, accepted, changed, persistence_command) = commit_edit_request(
+    editor, model, request, operation, emit,
+  )
+  let selection = result.bind(result => {
+    match result {
+      @markdown.Applied(_, selection) => selection
+      @markdown.Unchanged(_) => None
+    }
+  })
+  let committed = update_preview_document(
+    attachment,
+    committed,
+    preview_requested(model),
+    accepted~,
+    changed~,
+  )
+  (committed, selection, accepted, persistence_command)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Extract the atomic-commit skeleton duplicated in `commit_source` and `commit_block_request` into `commit_edit_request`: failure injection, `editor.commit_with_receipt` with the recovery catch, `classify_commit`, and `history_trigger` → `archive_replacement` dispatch
- The shell returns `(model, result?, accepted, changed, command)`; the two entry points become thin adapters — source applies application state only on acceptance, block extracts the deep selection from `result` and applies preview demand
- Persistence scheduling and editor-failure handling now live in one place; net -46 lines

## UI and review evidence

N/A — behavior-preserving refactor. Both E2E suites run green locally (dev-host 71 tests, standalone 9 tests) plus the full `moon test` workspace.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `classify_commit` | internal/rabbita/commit_classification.mbt | Yes | the receipt classification core from #1182 |
| `@repository.history_trigger` / `archive_replacement` | repository.mbt / document_transaction.mbt | Yes | persistence dispatch stays in the shell |
| `@markdown.MarkdownCommitResult` | modules/canopy/editor/markdown | Yes | `result?` carries the Ok receipt to the block adapter for selection extraction |

New helpers added:

- `commit_edit_request(...)` — the shared transaction core; no existing API covered the commit + classify + persist skeleton (it was duplicated inline in two functions).

## Validation scope

Boundary matrix / first failing test:

The externally observable contract of both adapters is preserved (signatures unchanged, callers untouched at all 4 call sites). The regression net is the existing E2E suite, which runs red on the old expectations (none) and green on the new shell: dev-host 71/71 and standalone 9/9 locally, `moon test` 2506 js + 70 native. The classification decision matrix is pinned by the #1182 `classify_commit` wbtests.

Target packages: `apps/loomark/internal/rabbita`

Validation: `moon check` OK, `moon fmt && moon info` no `.mbti` drift, local E2E green, `./scripts/validate-pr-ready.sh --target apps/loomark/internal/rabbita` passed (validated-base `95ed7c74` = current origin/main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when committing source and block edits.
  * Ensured failed persistence is reported clearly while preserving the latest document state.
  * Unified commit handling so accepted edits consistently update application and preview state.
  * Improved block selection updates based on the committed edit result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->