### PR TITLE
refactor(loomark): read the latest rendered model from the app state node

### DIFF
--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -7,10 +7,6 @@ let mounted : @ref.Ref[Bool] = { val: false }
 let detached_snapshot : @ref.Ref[String] = { val: "{}" }
 
 ///|
-/// Latest committed model for deferred browser effects in this private shell.
-let detached_model : @ref.Ref[DriverModel?] = { val: None }
-
-///|
 const HELLO_EXAMPLE_SOURCE : String = "# Hello World\n\nWelcome to the Canopy Markdown editor.\n\nThis editor has three modes: raw, block, and preview.\n"
 
 ///|
@@ -287,7 +283,6 @@ fn publish(model : DriverModel) -> Unit {
     },
   }
   detached_snapshot.val = Json::object(fields).stringify()
-  detached_model.val = Some(model)
 }
 
 ///|
@@ -724,6 +719,7 @@ fn update_model(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
+  latest_model : @ref.Ref[DriverModel?],
   event : DriverEvent,
   emit : @cmd.Emit[DriverEvent],
 ) -> (DriverModel, @cmd.Cmd) {
@@ -837,7 +833,7 @@ fn update_model(
           scheduler => {
             ignore(scheduler)
             let accepted_source = next.document.source()
-            match detached_model.val {
+            match latest_model.val {
               Some(current) if current.state.mode() == @core.Raw &&
                 current.text_input_generation == repair_generation &&
                 current.source_revision == repair_source_revision => {
@@ -921,6 +917,7 @@ fn update_model(
             let command = originating_selection
               .map(selection => {
                 block_selection_after_render(
+                  latest_model,
                   selection,
                   model.source_revision,
                   report_superseded=true,
@@ -935,6 +932,7 @@ fn update_model(
             let command = originating_selection
               .map(selection => {
                 block_selection_after_render(
+                  latest_model,
                   selection,
                   model.source_revision,
                   report_superseded=true,
@@ -952,6 +950,7 @@ fn update_model(
             editor,
             attachment,
             model,
+            latest_model,
             @markdown.MarkdownEditRequest::ChangeHeadingLevel(
               node_id=block.node_id(),
               level=target_level,
@@ -977,6 +976,7 @@ fn update_model(
             let command = originating_selection
               .map(selection => {
                 block_selection_after_render(
+                  latest_model,
                   selection,
                   model.source_revision,
                   report_superseded=true,
@@ -990,6 +990,7 @@ fn update_model(
             editor,
             attachment,
             model,
+            latest_model,
             @markdown.MarkdownEditRequest::ToggleListItem(
               node_id=block.node_id(),
             ),
@@ -1013,6 +1014,7 @@ fn update_model(
             editor,
             attachment,
             model,
+            latest_model,
             @markdown.MarkdownEditRequest::Delete(node_id=block.node_id()),
             None,
             "loomark-delete-block",
@@ -1060,6 +1062,7 @@ fn update_model(
             @cmd.batch([
               persistence_command,
               block_selection_after_render(
+                latest_model,
                 selection,
                 next.source_revision,
                 report_superseded=false,
@@ -1098,7 +1101,7 @@ fn update_model(
                     after_render(
                       scheduler => {
                         ignore(scheduler)
-                        match detached_model.val {
+                        match latest_model.val {
                           Some(current) if current.state.mode() == @core.Block &&
                             current.text_input_generation == repair_generation &&
                             current.source_revision == repair_source_revision => {
@@ -1158,6 +1161,7 @@ fn update_model(
             @cmd.batch([
               persistence_command,
               block_selection_after_render(
+                latest_model,
                 selection,
                 next.source_revision,
                 report_superseded=false,
@@ -1200,6 +1204,7 @@ fn update_model(
             @cmd.batch([
               persistence_command,
               block_selection_after_render(
+                latest_model,
                 selection,
                 next.source_revision,
                 report_superseded=false,
@@ -1213,6 +1218,7 @@ fn update_model(
             @cmd.batch([
               persistence_command,
               block_selection_after_render(
+                latest_model,
                 originating_selection,
                 next.source_revision,
                 report_superseded=true,
@@ -1238,6 +1244,7 @@ fn update_model(
           (
             next,
             block_selection_after_render(
+              latest_model,
               selection,
               next.source_revision,
               report_superseded=true,
@@ -1290,6 +1297,7 @@ fn update_model(
           @cmd.batch([
             persistence_command,
             block_selection_after_render(
+              latest_model,
               selection,
               expected_revision,
               report_superseded=true,
@@ -1422,7 +1430,7 @@ fn update_model(
             _ => model
           }
           publish(next)
-          (next, focus_latest_after_render(locator, token, emit))
+          (next, focus_latest_after_render(latest_model, locator, token, emit))
         }
         @core.Rejected(error) => reject_focus(model, error)
       }
@@ -1445,7 +1453,10 @@ fn update_model(
                 _ => model
               }
               publish(next)
-              (next, focus_latest_after_render(locator, token, emit))
+              (
+                next,
+                focus_latest_after_render(latest_model, locator, token, emit),
+              )
             }
             @core.Rejected(error) => reject_focus(model, error)
           }
@@ -1558,6 +1569,7 @@ fn update_model(
       let command = match selection {
         Some(selection) =>
           block_selection_after_render(
+            latest_model,
             selection,
             next.source_revision,
             report_superseded=true,
@@ -1811,8 +1823,9 @@ fn build_application(
   subscriptions : (DriverModel, @cmd.Emit[DriverEvent]) -> @sub.Sub,
   view : (DriverModel, @cmd.Emit[DriverEvent], @rabbita_runtime.Html) -> @rabbita_runtime.Html,
 ) -> @rabbita_runtime.App {
+  let latest_model : @ref.Ref[DriverModel?] = { val: None }
   let update = (model, event, emit) => {
-    update_model(editor, attachment, model, event, emit)
+    update_model(editor, attachment, model, latest_model, event, emit)
   }
   @rabbita_runtime.new(() => {
     let (model, emit) = @rabbita_runtime.create_state_with_init(
@@ -1831,6 +1844,7 @@ fn build_application(
     )
     let active_view = application_view(model, emit)
     model.view2(active_view, (model, active_view) => {
+      latest_model.val = Some(model)
       view(model, emit, active_view)
     })
   })
@@ -1943,7 +1957,6 @@ fn mount_application(
     replica_id,
     archive_persistence_enabled=false,
   )
-  detached_model.val = None
   detached_focus_token.val = ""
   publish(initial)
   let app = build(editor, attachment, initial, None)

--- a/apps/loomark/internal/rabbita/document_transaction.mbt
+++ b/apps/loomark/internal/rabbita/document_transaction.mbt
@@ -181,6 +181,7 @@ fn commit_block_toolbar_request(
   editor : @markdown.MarkdownEditor,
   attachment : @md_markdown.MarkdownSemanticAttachment,
   model : DriverModel,
+  latest_model : @ref.Ref[DriverModel?],
   request : @markdown.MarkdownEditRequest,
   originating_selection : BlockSelection?,
   control_id : String,
@@ -212,6 +213,7 @@ fn commit_block_toolbar_request(
         @cmd.batch([
           persistence_command,
           block_selection_after_render(
+            latest_model,
             selection,
             next.source_revision,
             report_superseded=false,
@@ -230,6 +232,7 @@ fn commit_block_toolbar_request(
               @cmd.batch([
                 persistence_command,
                 block_selection_after_render(
+                  latest_model,
                   selection,
                   next.source_revision,
                   report_superseded=true,

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -142,6 +142,7 @@ fn after_render(
 /// Routine input may follow a newer render when keystrokes overtake one frame;
 /// its superseded callback yields while structural edits report stale revisions.
 fn block_selection_after_render(
+  latest_model : @ref.Ref[DriverModel?],
   selection : BlockSelection,
   source_revision : Int,
   report_superseded~ : Bool,
@@ -149,7 +150,7 @@ fn block_selection_after_render(
 ) -> @cmd.Cmd {
   after_render(
     scheduler => {
-      match detached_model.val {
+      match latest_model.val {
         Some(model) =>
           if model.state.mode() != @core.Block {
             scheduler.add(
@@ -208,13 +209,14 @@ fn block_selection_after_render(
 /// Revalidate the latest model after rendering, then perform the final DOM
 /// write without queuing a state update after it.
 fn focus_latest_after_render(
+  latest_model : @ref.Ref[DriverModel?],
   locator : @core.FocusLocator,
   token : String,
   emit : @cmd.Emit[DriverEvent],
 ) -> @cmd.Cmd {
   after_render(
     scheduler => {
-      match detached_model.val {
+      match latest_model.val {
         Some(model) =>
           match
             @core.decide_focus(model.state, model.source_revision, locator) {

--- a/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
+++ b/apps/loomark/internal/rabbita/standalone_bootstrap.mbt
@@ -44,7 +44,6 @@ fn mount_standalone_editor(
     archive_tracker,
     local_storage_warning,
   }
-  detached_model.val = None
   detached_focus_token.val = ""
   publish(initial)
   let app = standalone_application(editor, attachment, initial, baseline)


### PR DESCRIPTION
## Summary

- Deferred `after_render` effects (raw/block input repair, block selection restore, focus restore) revalidated staleness against a hand-rolled module-global `detached_model` written by `publish()` on every transition
- The Rabbita state machine already owns the source of truth: `create_state_with_init` returns the reactive model `Val`, and the view closure receives the exact value the DOM was patched from
- Capture that value in an app-instance-local ref in `build_application`: the `view2` callback writes the model on every render, and effect constructors take the ref explicitly
- The read is now guaranteed consistent with what the view rendered (no `publish()` path can be missed), the per-transition write disappears, and the module-global plus its mount resets are deleted

## UI and review evidence

N/A — behavior-preserving refactor. Both E2E suites run green locally (dev-host 71, standalone 9) plus the full `moon test` workspace.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `@rabbita_runtime.create_state_with_init` / `Val::view2` | deps/rabbita/rabbita/incremental.mbt:588,191 | Yes | the view2 callback receives the model value the DOM was patched from |
| `@cmd.custom_cmd(kind=AfterRender)` | deps/rabbita/rabbita/cmd/commands.mbt:68 | Yes | unchanged effect primitive |
| `@duplix.Node::read` | deps/rabbita/rabbita/internal/duplix/duplix.mbt:424 | No (not used) | `internal/` package, not importable from the app; the view2-write approach needs only public API |

New helpers added: none — only explicit threading of the existing ref type.

## Validation scope

Boundary matrix / first failing test:

The deferred-effect contract is unchanged externally: effects run after the flush's DOM patch and skip when the rendered model's mode/generation/revision no longer matches the scheduled expectation. The change moves the source of that comparison from a manual `publish()`-written global to the model the view actually rendered. Regression net: dev-host 71/71 and standalone 9/9 locally, `moon test` 2506 js + 70 native, `moon check` OK, no `.mbti` drift.

Target packages: `apps/loomark/internal/rabbita`

Validation: `./scripts/validate-pr-ready.sh --target apps/loomark/internal/rabbita` passed (validated-base `70161f09` = current origin/main).