### PR TITLE
refactor(loomark): extract deferred-effect decisions as pure functions

### DIFF
--- a/apps/loomark/internal/rabbita/application.mbt
+++ b/apps/loomark/internal/rabbita/application.mbt
@@ -833,25 +833,23 @@ fn update_model(
           scheduler => {
             ignore(scheduler)
             let accepted_source = next.document.source()
-            match latest_model.val {
-              Some(current) if current.state.mode() == @core.Raw &&
-                current.text_input_generation == repair_generation &&
-                current.source_revision == repair_source_revision => {
-                @dom_boundary.write_text_value_id(
-                  "loomark-input", accepted_source,
-                )
-                match raw_selection {
-                  Some(selection) =>
-                    @dom_boundary.write_text_selection_id(
-                      "loomark-input",
-                      rejected_text_selection(
-                        accepted_source, source, selection,
-                      ),
-                    )
-                  None => ()
-                }
+            if repair_eligible(
+                latest_model.val,
+                @core.Raw,
+                repair_generation,
+                repair_source_revision,
+              ) {
+              @dom_boundary.write_text_value_id(
+                "loomark-input", accepted_source,
+              )
+              match raw_selection {
+                Some(selection) =>
+                  @dom_boundary.write_text_selection_id(
+                    "loomark-input",
+                    rejected_text_selection(accepted_source, source, selection),
+                  )
+                None => ()
               }
-              _ => ()
             }
           },
           emit,
@@ -1101,22 +1099,22 @@ fn update_model(
                     after_render(
                       scheduler => {
                         ignore(scheduler)
-                        match latest_model.val {
-                          Some(current) if current.state.mode() == @core.Block &&
-                            current.text_input_generation == repair_generation &&
-                            current.source_revision == repair_source_revision => {
-                            @dom_boundary.write_text_value_id(input_id, text)
-                            @dom_boundary.focus_id(input_id)
-                            @dom_boundary.write_text_selection_id(
-                              input_id,
-                              @dom_boundary.TextSelection(
-                                offset,
-                                offset,
-                                @dom_boundary.NoDirection,
-                              ),
-                            )
-                          }
-                          _ => ()
+                        if repair_eligible(
+                            latest_model.val,
+                            @core.Block,
+                            repair_generation,
+                            repair_source_revision,
+                          ) {
+                          @dom_boundary.write_text_value_id(input_id, text)
+                          @dom_boundary.focus_id(input_id)
+                          @dom_boundary.write_text_selection_id(
+                            input_id,
+                            @dom_boundary.TextSelection(
+                              offset,
+                              offset,
+                              @dom_boundary.NoDirection,
+                            ),
+                          )
                         }
                       },
                       emit,

--- a/apps/loomark/internal/rabbita/effect_decision.mbt
+++ b/apps/loomark/internal/rabbita/effect_decision.mbt
@@ -1,0 +1,60 @@
+///|
+/// Pure decisions for deferred after-render effects. The shell reads the
+/// latest rendered model and executes the decision; the decision itself is
+/// DOM-free and wbtest-able.
+///
+/// `repair_eligible` guards the raw/block input repair: a repair scheduled
+/// for a specific mode, input generation, and source revision only writes
+/// when the rendered model still matches all three. A missing model (no
+/// render yet) is never eligible.
+fn repair_eligible(
+  current : DriverModel?,
+  expected_mode : @core.ApplicationMode,
+  expected_generation : Int,
+  expected_revision : Int,
+) -> Bool {
+  match current {
+    Some(current) =>
+      current.state.mode() == expected_mode &&
+      current.text_input_generation == expected_generation &&
+      current.source_revision == expected_revision
+    None => false
+  }
+}
+
+///|
+/// One post-render block selection outcome. `Apply(index)` is the only arm
+/// that writes the DOM; the remaining arms classify why a scheduled
+/// selection must not be applied.
+enum BlockSelectionDecision {
+  Apply(Int)
+  ModeStale
+  Superseded
+  TargetUnavailable
+  ModelUnavailable
+} derive(Eq, Debug)
+
+///|
+/// Classify a scheduled block selection restore against the latest rendered
+/// model: mode must still be Block, the revision must match the schedule,
+/// and the immutable block view must resolve the target.
+fn block_selection_effect_decision(
+  current : DriverModel?,
+  selection : BlockSelection,
+  expected_revision : Int,
+) -> BlockSelectionDecision {
+  match current {
+    None => BlockSelectionDecision::ModelUnavailable
+    Some(model) =>
+      if model.state.mode() != @core.Block {
+        BlockSelectionDecision::ModeStale
+      } else if model.source_revision != expected_revision {
+        BlockSelectionDecision::Superseded
+      } else {
+        match block_selection_target(model.document, selection) {
+          Some(index) => BlockSelectionDecision::Apply(index)
+          None => BlockSelectionDecision::TargetUnavailable
+        }
+      }
+  }
+}

--- a/apps/loomark/internal/rabbita/effect_decision_wbtest.mbt
+++ b/apps/loomark/internal/rabbita/effect_decision_wbtest.mbt
@@ -1,0 +1,107 @@
+///|
+/// Deferred-effect decision boundary matrix:
+///
+/// `repair_eligible`:
+/// | current | expected mode | expected generation | expected revision | eligible |
+/// | --- | --- | --- | --- | --- |
+/// | None | any | any | any | false |
+/// | Some | mismatch | — | — | false |
+/// | Some | match | mismatch | — | false |
+/// | Some | match | match | mismatch | false |
+/// | Some | match | match | match | true |
+///
+/// `block_selection_effect_decision`:
+/// | current | mode | revision | target | decision |
+/// | --- | --- | --- | --- | --- |
+/// | None | — | — | — | ModelUnavailable |
+/// | Some | != Block | — | — | ModeStale |
+/// | Some | Block | mismatch | — | Superseded |
+/// | Some | Block | match | found | Apply(index) |
+/// | Some | Block | match | missing | TargetUnavailable |
+
+///|
+test "repair_eligible skips before any model has rendered" {
+  assert_false(repair_eligible(None, @core.Raw, 1, 1))
+}
+
+///|
+test "repair_eligible requires mode, generation, and revision to match" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title",
+  )
+  let model = {
+    ..test_model(editor.snapshot()),
+    text_input_generation: 3,
+    source_revision: 7,
+  }
+  assert_false(repair_eligible(Some(model), @core.Block, 3, 7))
+  assert_false(repair_eligible(Some(model), @core.Raw, 4, 7))
+  assert_false(repair_eligible(Some(model), @core.Raw, 3, 8))
+  assert_true(repair_eligible(Some(model), @core.Raw, 3, 7))
+}
+
+///|
+test "block selection decision applies when mode and revision match and target resolves" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title\n\nParagraph",
+  )
+  let document = editor.snapshot()
+  let key = document.blocks()[0].key()
+  let selection = BlockSelection::{ key, index: 0, start: 0, end: 0 }
+  let model = {
+    ..test_model(document),
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+    source_revision: 7,
+  }
+  assert_eq(
+    block_selection_effect_decision(Some(model), selection, 7),
+    BlockSelectionDecision::Apply(0),
+  )
+}
+
+///|
+test "block selection decision classifies stale mode, superseded revision, missing target, and no model" {
+  let editor = try! @markdown.MarkdownEditor(
+    agent_id="agent-a",
+    source="# Title\n\nParagraph",
+  )
+  let document = editor.snapshot()
+  let key = document.blocks()[0].key()
+  let selection = BlockSelection::{ key, index: 0, start: 0, end: 0 }
+  let model = {
+    ..test_model(document),
+    state: @core.ApplicationState::ApplicationState(@core.Block),
+    source_revision: 7,
+  }
+  assert_eq(
+    block_selection_effect_decision(Some(model), selection, 6),
+    BlockSelectionDecision::Superseded,
+  )
+  assert_eq(
+    block_selection_effect_decision(
+      Some({
+        ..model,
+        state: @core.ApplicationState::ApplicationState(@core.Raw),
+      }),
+      selection,
+      7,
+    ),
+    BlockSelectionDecision::ModeStale,
+  )
+  assert_eq(
+    block_selection_effect_decision(None, selection, 7),
+    BlockSelectionDecision::ModelUnavailable,
+  )
+  let missing = BlockSelection::{
+    key: "no-such-key",
+    index: 0,
+    start: 0,
+    end: 0,
+  }
+  assert_eq(
+    block_selection_effect_decision(Some(model), missing, 7),
+    BlockSelectionDecision::TargetUnavailable,
+  )
+}

--- a/apps/loomark/internal/rabbita/focus_runtime.mbt
+++ b/apps/loomark/internal/rabbita/focus_runtime.mbt
@@ -150,50 +150,48 @@ fn block_selection_after_render(
 ) -> @cmd.Cmd {
   after_render(
     scheduler => {
-      match latest_model.val {
-        Some(model) =>
-          if model.state.mode() != @core.Block {
+      match
+        block_selection_effect_decision(
+          latest_model.val,
+          selection,
+          source_revision,
+        ) {
+        BlockSelectionDecision::Apply(index) => {
+          let id = block_input_id(index)
+          @dom_boundary.focus_id(id)
+          @dom_boundary.write_text_selection_id(
+            id,
+            @dom_boundary.TextSelection(
+              selection.start,
+              selection.end,
+              @dom_boundary.NoDirection,
+            ),
+          )
+        }
+        // Rapid input can queue several post-render selections in one frame.
+        // Rabbita runs AfterRender effects newest-first, so an older
+        // superseded selection must not emit a message that schedules a
+        // second render after the newest selection restored the caret.
+        BlockSelectionDecision::Superseded =>
+          if report_superseded {
             scheduler.add(
-              emit(
-                BlockSelectionRejected("block selection mode is stale", None),
-              ),
+              emit(BlockSelectionRejected("block selection is stale", None)),
             )
-          } else if model.source_revision != source_revision {
-            // Rapid input can queue several post-render selections in one
-            // frame. Rabbita runs AfterRender effects newest-first, so an older
-            // superseded selection must not emit a message that schedules a
-            // second render after the newest selection restored the caret.
-            if report_superseded {
-              scheduler.add(
-                emit(BlockSelectionRejected("block selection is stale", None)),
-              )
-            }
-          } else {
-            match block_selection_target(model.document, selection) {
-              Some(index) => {
-                let id = block_input_id(index)
-                @dom_boundary.focus_id(id)
-                @dom_boundary.write_text_selection_id(
-                  id,
-                  @dom_boundary.TextSelection(
-                    selection.start,
-                    selection.end,
-                    @dom_boundary.NoDirection,
-                  ),
-                )
-              }
-              None =>
-                scheduler.add(
-                  emit(
-                    BlockSelectionRejected(
-                      "block selection target is unavailable",
-                      None,
-                    ),
-                  ),
-                )
-            }
           }
-        None =>
+        BlockSelectionDecision::ModeStale =>
+          scheduler.add(
+            emit(BlockSelectionRejected("block selection mode is stale", None)),
+          )
+        BlockSelectionDecision::TargetUnavailable =>
+          scheduler.add(
+            emit(
+              BlockSelectionRejected(
+                "block selection target is unavailable",
+                None,
+              ),
+            ),
+          )
+        BlockSelectionDecision::ModelUnavailable =>
           scheduler.add(
             emit(
               BlockSelectionRejected("block selection model unavailable", None),

--- a/apps/loomark/internal/rabbita/pkg.generated.mbti
+++ b/apps/loomark/internal/rabbita/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "dowdiness/loomark/internal/rabbita"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn capture_focus() -> String
 
@@ -49,6 +53,7 @@ pub fn write_selection_failure() -> Unit
 // Errors
 
 // Types and methods
+type BlockSelectionDecision derive(Eq, @debug.Debug)
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

- The `after_render` effect bodies inlined their write-or-skip decisions: raw/block input repair guarded mode + input generation + source revision, and block selection restore classified mode staleness / superseded revision / target resolution / missing model inline
- Extract both as DOM-free decisions: `repair_eligible(current, expected mode/generation/revision) -> Bool` and `block_selection_effect_decision(current, selection, expected revision) -> BlockSelectionDecision`
- The effects now read the latest rendered model and execute the returned decision; the full classification matrix is pinned by 4 new wbtests instead of only the Playwright suite
- Focus restore was already pure (`@core.decide_focus`) — unchanged

## UI and review evidence

N/A — behavior-preserving refactor (decision arms map 1:1 to the old inline branches, including exact error message strings). Both E2E suites run green locally (dev-host 71, standalone 9) plus the full `moon test` workspace.

## Reuse check

Existing APIs considered:

| API | Location | Reused? | Reason if not |
|-----|----------|---------|---------------|
| `block_selection_target` | internal/rabbita/block_view.mbt:188 | Yes | pure block-view resolution used inside the new decision |
| `@core.decide_focus` | apps/loomark/core/application_core.mbt | Yes (unchanged) | focus restore decision was already a pure core function |
| `@core.ApplicationMode` | apps/loomark/core | Yes | repair eligibility is parameterized by expected mode |

New helpers added:

- `repair_eligible(...)` — unifies the raw and block repair guards (identical predicate, differing only in expected mode)
- `block_selection_effect_decision(...)` + `BlockSelectionDecision` enum — the DOM-free classification of a scheduled block selection restore

## Validation scope

Boundary matrix / first failing test:

- `repair_eligible`: None → false; mode mismatch → false; generation mismatch → false; revision mismatch → false; all match → true
- `block_selection_effect_decision`: None → ModelUnavailable; mode != Block → ModeStale; revision mismatch → Superseded; target found → Apply(index); target missing → TargetUnavailable

First failing test: undefined symbols in `effect_decision_wbtest.mbt` before implementation. Regression net: dev-host 71/71 and standalone 9/9 locally, `moon test` 2510 js + 70 native, `moon check` OK.

Note: `BlockSelectionDecision` is a package-visible type (MoonBit `priv` is file-scoped; the enum is defined in effect_decision.mbt and consumed in focus_runtime.mbt), so `pkg.generated.mbti` gains its `derive(Eq, @debug.Debug)` entry plus the debug import — intentional, internal package only.

Target packages: `apps/loomark/internal/rabbita`

Validation: `./scripts/validate-pr-ready.sh --target apps/loomark/internal/rabbita` passed (validated-base `dc878fbd` = current origin/main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when restoring text input values, focus, and selections after updates.
  - Prevented outdated or invalid restoration attempts from overwriting newer content or selection state.
  - Improved block selection handling when the view changes, the target is unavailable, or the underlying model is no longer current.
- **Tests**
  - Added coverage for valid restorations and scenarios involving stale updates, unavailable content, and mismatched view states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->